### PR TITLE
docs: add issue tracker branch naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-02-24
+
+### Added
+
+- Issue tracker branch naming convention: when an issue tracker is in use, branch slugs are prefixed with the issue identifier (e.g., `feature/ENG-123-user-auth`); without a tracker the existing slug convention applies. Documented in `docs/best-practices/2-version-control.md`, `docs/ai/development-workflow/README.md`, all three development protocols, and `docs/ai/development-workflow/integrations/linear.md`
+
 ### Changed
 
 - `AGENTS.md` — Git & Branching and CHANGELOG sections updated with project-specific overrides: no `develop` branch (all PRs target `main`), and every merged PR releases a new version

--- a/docs/ai/development-workflow/README.md
+++ b/docs/ai/development-workflow/README.md
@@ -72,12 +72,18 @@ This document is the **canonical master reference** for how development is struc
 
 | Branch type | Pattern | Base branch |
 |---|---|---|
-| Spec | `spec/[feature-slug]` | `develop` |
-| Implementation plan | `implementation-plan/[feature-slug]` | `develop` |
-| Feature | `feature/[feature-slug]` | `develop` |
+| Spec | `spec/[slug]` | `develop` |
+| Implementation plan | `implementation-plan/[slug]` | `develop` |
+| Feature | `feature/[slug]` | `develop` |
 | Bug / simple fix | `fix/[slug]` | `develop` |
 | Hotfix | `hotfix/[slug]` | `main` |
 | Release | `release/v[X.Y.Z]` | `develop` |
+
+**Slug format:**
+- **With issue tracker** → `[issue-id]-[short-description]` (e.g., `feature/ENG-123-user-auth`)
+- **Without issue tracker** → `[short-description]` (e.g., `feature/user-auth`)
+
+See `docs/best-practices/2-version-control.md` for the full slug convention.
 
 ---
 

--- a/docs/ai/development-workflow/integrations/linear.md
+++ b/docs/ai/development-workflow/integrations/linear.md
@@ -66,6 +66,22 @@ When the orchestrator has Linear access, it should:
 
 ---
 
+## Branch Naming with Linear
+
+When a Linear issue exists, use the Linear issue identifier as the branch slug prefix:
+
+| Branch type | Pattern | Example |
+|---|---|---|
+| Spec | `spec/[TEAM-ID]-[slug]` | `spec/ENG-123-user-auth` |
+| Implementation plan | `implementation-plan/[TEAM-ID]-[slug]` | `implementation-plan/ENG-123-user-auth` |
+| Feature | `feature/[TEAM-ID]-[slug]` | `feature/ENG-123-user-auth` |
+| Bug fix | `fix/[TEAM-ID]-[slug]` | `fix/ENG-456-login-redirect` |
+| Hotfix | `hotfix/[TEAM-ID]-[slug]` | `hotfix/ENG-789-payment-crash` |
+
+The `[slug]` is a short kebab-case description derived from the issue title (omit common words like "add", "fix", "update" to keep it short). Linear also auto-suggests a branch name on each issue — use it directly if preferred.
+
+---
+
 ## Workflow: Advancing Statuses
 
 The orchestrator or developer agent updates the Linear issue status at each stage transition:

--- a/docs/ai/development-workflow/protocols/01-generate-specs-protocol.md
+++ b/docs/ai/development-workflow/protocols/01-generate-specs-protocol.md
@@ -110,12 +110,15 @@ If the human requests changes, make them and re-present. Repeat until approved.
 
 Once the human approves the spec:
 
-1. Create branch: `git checkout -b spec/[feature-slug]` from `develop`
-2. Create the development folder: `docs/specs/developments/[YYYYMMDDHHMMSS]_[feature-slug]/`
-3. Write the spec file: `1_[feature-slug]_specs.md`
-4. Commit: `docs: add spec for [feature-name]`
-5. Push: `git push -u origin spec/[feature-slug]`
-6. Open PR targeting `develop` with:
+1. Determine the branch slug:
+   - **With issue tracker**: `[issue-id]-[feature-slug]` (e.g., `ENG-123-user-auth`)
+   - **Without issue tracker**: `[feature-slug]` (e.g., `user-auth`)
+2. Create branch: `git checkout -b spec/[branch-slug]` from `develop`
+3. Create the development folder: `docs/specs/developments/[YYYYMMDDHHMMSS]_[feature-slug]/`
+4. Write the spec file: `1_[feature-slug]_specs.md`
+5. Commit: `docs: add spec for [feature-name]`
+6. Push: `git push -u origin spec/[branch-slug]`
+7. Open PR targeting `develop` with:
    - Title: `docs(spec): [feature-name]`
    - Body: summary of the feature, link to the spec file, list of open questions (if any)
 

--- a/docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -108,12 +108,15 @@ Present the plan and runbook to the human:
 
 Once approved:
 
-1. Create branch: `git checkout -b implementation-plan/[feature-slug]` from `develop`
-2. Write the plan file
-3. Write the smoke test runbook
-4. Update the spec status from `Spec Ready` to `Plan Ready` (in the spec file's status field)
-5. Commit: `docs: add implementation plan for [feature-name]`
-6. Push and open PR targeting `develop` with:
+1. Determine the branch slug:
+   - **With issue tracker**: `[issue-id]-[feature-slug]` (e.g., `ENG-123-user-auth`)
+   - **Without issue tracker**: `[feature-slug]` (e.g., `user-auth`)
+2. Create branch: `git checkout -b implementation-plan/[branch-slug]` from `develop`
+3. Write the plan file
+4. Write the smoke test runbook
+5. Update the spec status from `Spec Ready` to `Plan Ready` (in the spec file's status field)
+6. Commit: `docs: add implementation plan for [feature-name]`
+7. Push and open PR targeting `develop` with:
    - Title: `docs(plan): [feature-name]`
    - Body: summary of the approach, complexity estimate, key risks, link to plan and runbook
 

--- a/docs/ai/development-workflow/protocols/04-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/04-implement-development-protocol.md
@@ -47,10 +47,14 @@ Wait for explicit confirmation.
 
 ### Step 3: Branch
 
+Determine the branch slug:
+- **With issue tracker**: `[issue-id]-[slug]` (e.g., `ENG-123-user-auth`)
+- **Without issue tracker**: `[slug]` (e.g., `user-auth`)
+
 ```bash
 git checkout develop
 git pull
-git checkout -b feature/[slug]
+git checkout -b feature/[branch-slug]
 ```
 
 ### Step 4: Mark Status
@@ -158,7 +162,7 @@ See `docs/ai/development-workflow/protocols/91-pr-readiness-signal-protocol.md`.
 
 1. Read the brief provided by the human
 2. Present a brief execution plan and get approval
-3. Branch: `git checkout -b fix/[slug]` from `develop`
+3. Branch: `git checkout -b fix/[branch-slug]` from `develop` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without)
 4. Implement the fix
 5. Verify: build, lint, tests pass
 6. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry
@@ -177,7 +181,7 @@ See `docs/ai/development-workflow/protocols/91-pr-readiness-signal-protocol.md`.
 
 1. Read the incident brief from the human
 2. Confirm it's a production-only issue (not a dev/staging issue)
-3. Branch: `git checkout -b hotfix/[slug]` from `main`
+3. Branch: `git checkout -b hotfix/[branch-slug]` from `main` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without)
 4. Implement the minimal fix (do not bundle unrelated changes)
 5. Verify: build, lint, tests pass
 6. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry

--- a/docs/best-practices/2-version-control.md
+++ b/docs/best-practices/2-version-control.md
@@ -55,6 +55,28 @@ chore(deps): upgrade eslint to v9
 | Implementation plan | `implementation-plan/[slug]` | `develop` | `develop` |
 | Release | `release/v[X.Y.Z]` | `develop` | `main` + `develop` |
 
+### Branch Slug Convention
+
+The `[slug]` is a short kebab-case identifier for the change.
+
+**If using an issue tracker**, prefix the slug with the issue identifier:
+
+```
+feature/ENG-123-user-authentication
+fix/ENG-456-login-redirect
+spec/ENG-123-user-authentication
+implementation-plan/ENG-123-user-authentication
+```
+
+**If not using an issue tracker**, use the slug alone:
+
+```
+feature/user-authentication
+fix/login-redirect
+```
+
+The issue ID prefix is the canonical identifier when a tracker is in use. The slug portion (derived from the issue title in kebab-case) is recommended for readability but may be omitted for brevity.
+
 ## Staging and Committing
 
 - Stage only files that belong to the logical change being committed


### PR DESCRIPTION
## Summary

- Introduces a conditional branch slug rule: when an issue tracker is in use, slugs are prefixed with the issue identifier (`feature/ENG-123-user-auth`); without a tracker the existing slug-only convention applies unchanged
- Adds a dedicated **Branch Slug Convention** section to `docs/best-practices/2-version-control.md` as the authoritative reference
- Updates `docs/ai/development-workflow/README.md` branch naming table with the new format and a pointer to the full convention
- Updates protocols 01, 02, and 04 to include an explicit "determine the branch slug" step before every `git checkout -b` command
- Adds a **Branch Naming with Linear** section to `integrations/linear.md` with a concrete example table

## Test plan

- [ ] Review `docs/best-practices/2-version-control.md` — Branch Slug Convention section is clear and covers both cases with examples
- [ ] Review `docs/ai/development-workflow/README.md` — slug format note is accurate and links to the full doc
- [ ] Review protocols 01, 02, 04 — each has a slug determination step with correct conditional logic before the branch creation command
- [ ] Review `integrations/linear.md` — Branch Naming with Linear table shows correct patterns and examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds conditional branch slug convention: when an issue tracker is in use, branch names are prefixed with the issue identifier (e.g., `feature/ENG-123-user-auth`); without a tracker, the existing slug-only convention continues to apply. The convention is documented in a new dedicated section in `docs/best-practices/2-version-control.md` (the authoritative reference), with cross-references added to the workflow README and Linear integration doc, and explicit slug determination steps added to all three development protocols before every `git checkout -b` command.

**Changes:**
- New **Branch Slug Convention** section added to `docs/best-practices/2-version-control.md` with clear conditional logic and examples
- Workflow README updated with slug format note and pointer to full convention
- Linear integration doc enhanced with Branch Naming with Linear section showing concrete TEAM-ID patterns
- Protocols 01, 02, and 04 updated to include explicit "determine the branch slug" step before branch creation
- CHANGELOG updated with v0.2.0 release entry

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only PR that adds clear, well-structured guidance. All changes are internally consistent, follow the project's documentation conventions (single source of truth with cross-references), and properly update the CHANGELOG per project requirements. The conditional logic is clear and unambiguous.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Added v0.2.0 release entry documenting the new issue tracker branch naming convention |
| docs/best-practices/2-version-control.md | Added authoritative Branch Slug Convention section with clear conditional logic for issue tracker vs non-issue-tracker scenarios |
| docs/ai/development-workflow/README.md | Updated branch naming table with slug format note and cross-reference to full convention in version control doc |
| docs/ai/development-workflow/integrations/linear.md | Added Branch Naming with Linear section showing concrete examples with TEAM-ID prefix pattern |
| docs/ai/development-workflow/protocols/01-generate-specs-protocol.md | Added explicit slug determination step before branch creation with conditional logic |
| docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md | Added explicit slug determination step before branch creation with conditional logic |
| docs/ai/development-workflow/protocols/04-implement-development-protocol.md | Added slug determination logic to feature, fix, and hotfix branch creation sections |

</details>



<sub>Last reviewed commit: 2b3785d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->