### PR TITLE
docs: clarify Linear branch naming placeholder

### DIFF
--- a/docs/ai/development-workflow/integrations/linear.md
+++ b/docs/ai/development-workflow/integrations/linear.md
@@ -72,11 +72,11 @@ When a Linear issue exists, use the Linear issue identifier as the branch slug p
 
 | Branch type | Pattern | Example |
 |---|---|---|
-| Spec | `spec/[TEAM-ID]-[slug]` | `spec/ENG-123-user-auth` |
-| Implementation plan | `implementation-plan/[TEAM-ID]-[slug]` | `implementation-plan/ENG-123-user-auth` |
-| Feature | `feature/[TEAM-ID]-[slug]` | `feature/ENG-123-user-auth` |
-| Bug fix | `fix/[TEAM-ID]-[slug]` | `fix/ENG-456-login-redirect` |
-| Hotfix | `hotfix/[TEAM-ID]-[slug]` | `hotfix/ENG-789-payment-crash` |
+| Spec | `spec/[issue-id]-[slug]` | `spec/ENG-123-user-auth` |
+| Implementation plan | `implementation-plan/[issue-id]-[slug]` | `implementation-plan/ENG-123-user-auth` |
+| Feature | `feature/[issue-id]-[slug]` | `feature/ENG-123-user-auth` |
+| Bug fix | `fix/[issue-id]-[slug]` | `fix/ENG-456-login-redirect` |
+| Hotfix | `hotfix/[issue-id]-[slug]` | `hotfix/ENG-789-payment-crash` |
 
 The `[slug]` is a short kebab-case description derived from the issue title (omit common words like "add", "fix", "update" to keep it short). Linear also auto-suggests a branch name on each issue — use it directly if preferred.
 


### PR DESCRIPTION
Replaces the confusing TEAM-ID placeholder with issue-id in docs/ai/development-workflow/integrations/linear.md so it aligns with the branch slug convention used elsewhere (e.g., ENG-123).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the branch naming convention placeholders in the Linear integration documentation from `[TEAM-ID]` to `[issue-id]`, ensuring consistency with the terminology used throughout the rest of the workflow documentation.

- The change aligns with how issue identifiers are referenced in other docs (e.g., `docs/ai/development-workflow/README.md`, protocol documents)
- All 5 branch type patterns in the table are updated consistently
- The examples remain unchanged (already using `ENG-123` format)
- No functional impact, purely a documentation clarity improvement

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only change that improves clarity and consistency by replacing a confusing placeholder with terminology already established in other workflow documents. No code changes, no functional impact.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/ai/development-workflow/integrations/linear.md | Changed placeholder from `[TEAM-ID]` to `[issue-id]` for consistency with rest of documentation |

</details>



<sub>Last reviewed commit: 058d3d7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->