### PR TITLE
chore(release): v0.6.1

### DIFF
--- a/.claude/agents/smoke-tester.md
+++ b/.claude/agents/smoke-tester.md
@@ -1,0 +1,18 @@
+---
+name: smoke-tester
+model: claude-sonnet-4-6
+description: Smoke test stage. Use when a code review has been approved and the implementation needs manual smoke testing before merge. Executes the smoke test runbook using browser automation.
+tools: Read, Grep, Glob, Bash, Write
+---
+
+Follow the smoke test protocol exactly as defined in:
+
+**`docs/ai/development-workflow/protocols/05-smoke-test-protocol.md`**
+
+That document is the single source of truth for this stage. The protocol is project-agnostic and directs you to the project's testing README for repo-specific details.
+
+For project-specific execution instructions, read:
+
+**`docs/testing/README.md`**
+
+Always read the smoke test runbook and the testing README before beginning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-02-26
+
+### Added
+
+- `.claude/agents/smoke-tester.md` — missing Claude Code sub-agent for the smoke test stage; delegates execution to `docs/ai/development-workflow/protocols/05-smoke-test-protocol.md` and `docs/testing/README.md`.
+
 ## [0.6.0] - 2026-02-25
 
 ### Added


### PR DESCRIPTION
Add missing smoke-tester sub-agent (.claude/agents/smoke-tester.md).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Completes the smoke test feature introduced in v0.6.0 by adding the missing `smoke-tester` Claude Code agent. The agent properly delegates to the smoke test protocol and follows the established agent configuration pattern (YAML frontmatter with model, tools, and delegation to protocol docs). CHANGELOG entry correctly documents the addition as a patch release.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are straightforward documentation additions that complete a feature from v0.6.0. The new agent file follows the established pattern used by all other agents, references existing and validated protocol files, and uses appropriate tool and model assignments. The CHANGELOG entry follows project conventions. No code logic, dependencies, or runtime behavior is affected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .claude/agents/smoke-tester.md | New Claude Code agent for smoke test execution; properly formatted with correct model and tool assignments, references existing protocol |
| CHANGELOG.md | Properly formatted changelog entry for v0.6.1 following Keep a Changelog format and project versioning conventions |

</details>



<sub>Last reviewed commit: ea9ba6d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->