### PR TITLE
fix(agents): add Agent tool to orchestrator agents

### DIFF
--- a/.claude/agents/automated-reviewer-loop.md
+++ b/.claude/agents/automated-reviewer-loop.md
@@ -2,7 +2,7 @@
 name: automated-reviewer-loop
 model: claude-haiku-4-5-20251001
 description: Run the automated reviewer loop (and CI loop) for a PR. Use when the user wants to run the reviewer loop on a specific PR or the current branch's PR until it is ready for human review or escalated.
-tools: Read, Grep, Glob, Write, Edit, Bash
+tools: Read, Grep, Glob, Write, Edit, Bash, Agent
 ---
 
 Follow the standalone automated reviewer loop protocol:

--- a/.claude/agents/item-orchestrator.md
+++ b/.claude/agents/item-orchestrator.md
@@ -2,7 +2,7 @@
 name: item-orchestrator
 model: claude-haiku-4-5-20251001
 description: Coordination agent for a single workflow item. Resumes one development, branch, or PR and keeps it moving until it is waiting on a human, blocked, or escalated. Use when you want targeted advancement without scanning the full portfolio.
-tools: Read, Grep, Glob, Write, Edit, Bash
+tools: Read, Grep, Glob, Write, Edit, Bash, Agent
 ---
 
 Follow the single-item orchestration protocol exactly as defined in:

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -2,7 +2,7 @@
 name: orchestrator
 model: claude-haiku-4-5-20251001
 description: Batch orchestration agent. Discovers what developments can advance, builds safe parallel batches, dispatches one item orchestrator per item, and supervises the batch until each item is waiting on a human, blocked, or escalated.
-tools: Read, Grep, Glob, Write, Edit, Bash
+tools: Read, Grep, Glob, Write, Edit, Bash, Agent
 ---
 
 Follow the batch orchestration protocol exactly as defined in:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ This project uses a staged AI-assisted development workflow. See [`docs/ai/devel
 | Write Plan | `tech-lead` agent | `/generate-implementation-plan` | `workflow-plan-writer` skill | Follow `docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md` |
 | Implement | `developer` agent | `/implement-development` | `workflow-implementer` skill | Follow `docs/ai/development-workflow/protocols/04-implement-development-protocol.md` |
 | Review Gate (Spec / Plan / Code) | Native review against `REVIEW.md` | `/review-spec`, `/review-implementation-plan`, `/review-code` | Native review against `REVIEW.md` | Follow `REVIEW.md` and the compatibility wrapper protocols under `docs/ai/development-workflow/protocols/` when needed |
+| Smoke Test | `smoke-tester` agent | `/smoke-tester` | — | Follow `docs/ai/development-workflow/protocols/05-smoke-test-protocol.md` |
 | Run reviewer loop (PR) | `automated-reviewer-loop` agent | `/run-reviewer-loop` | `workflow-reviewer-loop` skill | Follow `docs/ai/development-workflow/protocols/92-automated-reviewer-loop-protocol.md` |
 | Advance One Item | `item-orchestrator` agent | `/run-item-work` | `workflow-item-orchestrator` skill | Follow `docs/ai/development-workflow/protocols/90-orchestrate-work-protocol.md` |
 | Prepare Commit | — | `/prepare-commit` | Follow `docs/best-practices/2-version-control.md` | Follow `docs/best-practices/2-version-control.md` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Claude Code orchestrator agents: added the `Agent` tool to `orchestrator` and `item-orchestrator` so they can dispatch sub-agents (developer, code-reviewer, etc.) instead of running all stages inline in a single session.
 - pr-review-loop.sh: existing-findings path now correctly counts and reports existing soft-suggestion comments; COMMENT_COUNT and SUGGESTION_COUNT were previously undercounting.
 - pr-review-loop.sh: fallback date when neither BSD nor GNU date is available now uses epoch (1970-01-01T00:00:00Z) instead of current time, so all comments are considered rather than none.
 - sync-template: include `.cursor/agents/` in the Always sync list so `/sync-template` detects and propagates Cursor agent files; aligns with README framework-level propagation paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Smoke tester agent: added `smoke-tester` to the AGENTS.md workflow commands table and `agent-model-config.md` (tier assignment, per-agent model recommendations, and tool restrictions) to complete documentation coverage for the smoke test stage.
 - Cursor subagents: workflow agents (orchestrator, developer, tech-lead, etc.) are now defined in `.cursor/agents/` with per-agent model selection (`fast`, `inherit`, or specific model ID). Orchestration protocol and `agent-model-config.md` document how to execute with Cursor subagents and override models.
 
 ## [0.15.0] - 2026-03-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Claude Code orchestrator agents: added the `Agent` tool to `orchestrator` and `item-orchestrator` so they can dispatch sub-agents (developer, code-reviewer, etc.) instead of running all stages inline in a single session.
+- Claude Code orchestrator agents: added the `Agent` tool to `orchestrator`, `item-orchestrator`, and `automated-reviewer-loop` so they can dispatch sub-agents (developer, code-reviewer, etc.) instead of running all stages inline in a single session.
 - pr-review-loop.sh: existing-findings path now correctly counts and reports existing soft-suggestion comments; COMMENT_COUNT and SUGGESTION_COUNT were previously undercounting.
 - pr-review-loop.sh: fallback date when neither BSD nor GNU date is available now uses epoch (1970-01-01T00:00:00Z) instead of current time, so all comments are considered rather than none.
 - sync-template: include `.cursor/agents/` in the Always sync list so `/sync-template` detects and propagates Cursor agent files; aligns with README framework-level propagation paths.

--- a/docs/ai/development-workflow/agent-model-config.md
+++ b/docs/ai/development-workflow/agent-model-config.md
@@ -173,6 +173,15 @@ These examples are **current as of 2026-02-24** (model names/IDs change often). 
 - Baidu (ERNIE): `ernie-4.5-turbo-128k-preview`
 - Tencent (Hunyuan): Hunyuan Standard (latest)
 
+### `smoke-tester` (`balanced`)
+
+- OpenAI: `gpt-5-mini`, `gpt-5.2` (low/medium reasoning)
+- Anthropic: Claude Sonnet (latest)
+- Google: Gemini Flash (latest)
+- Alibaba (Qwen): `qwen-plus`
+- Baidu (ERNIE): `ernie-4.5-turbo-128k-preview`
+- Tencent (Hunyuan): Hunyuan Standard (latest)
+
 ---
 
 ## Tool Restrictions

--- a/docs/ai/development-workflow/agent-model-config.md
+++ b/docs/ai/development-workflow/agent-model-config.md
@@ -36,6 +36,7 @@ If you prefer different names (`small/medium/large`, `fast/standard/pro`, etc.),
 | `developer` | `balanced` | Code generation at scale. A balanced model is typically the cost/quality sweet spot for coding tasks, especially with a strong spec + plan. |
 | `code-reviewer` | `balanced` | Code review against known standards and a completed spec. A balanced model is capable here. |
 | `project-setup` | `balanced` | Structured onboarding conversation with clear protocol guidance. A balanced model is sufficient. |
+| `smoke-tester` | `balanced` | Executes the smoke test runbook using browser automation. A balanced model is sufficient for following step-by-step testing instructions. |
 
 ### Example Mapping (Optional)
 
@@ -190,6 +191,7 @@ Agents only get `Bash` when they need it to carry a stage through branch creatio
 | `developer` | ✅ | ❌ | Runs build, lint, and test commands as part of implementation |
 | `code-reviewer` | ✅ | ❌ | May run lint or tests to verify applied fixes |
 | `project-setup` | ✅ | ❌ | May need to initialize git, run project commands during setup |
+| `smoke-tester` | ✅ | ❌ | Runs browser automation and test scripts; needs Bash for execution |
 
 ---
 

--- a/docs/ai/development-workflow/agent-model-config.md
+++ b/docs/ai/development-workflow/agent-model-config.md
@@ -176,20 +176,20 @@ These examples are **current as of 2026-02-24** (model names/IDs change often). 
 
 ## Tool Restrictions
 
-Agents only get `Bash` when they need it to carry a stage through branch creation, commits, pushes, PR creation, or readiness loops.
+Agents only get `Bash` when they need it to carry a stage through branch creation, commits, pushes, PR creation, or readiness loops. Agents only get `Agent` when they need to dispatch sub-agents to handle stage-specific work.
 
-| Agent | Has Bash? | Reason |
-|---|---|---|
-| `orchestrator` | ✅ | Needs `git branch`, `git status`, helper scripts, and issue / PR inspection to build and supervise batches |
-| `item-orchestrator` | ✅ | Needs helper scripts, git / PR inspection, and readiness loops to keep one item moving end to end |
-| `automated-reviewer-loop` | ✅ | Runs pr-review-loop.sh, pr-ci-loop.sh, git; needs Bash for scripts and labels |
-| `product-manager` | ✅ | Creates spec branches / PRs and may run readiness helpers |
-| `spec-reviewer` | ✅ | May commit, push, and re-run fixes during spec review loops |
-| `tech-lead` | ✅ | May need to run commands to understand the codebase before planning |
-| `implementation-plan-reviewer` | ✅ | May commit, push, and re-run fixes during plan review loops |
-| `developer` | ✅ | Runs build, lint, and test commands as part of implementation |
-| `code-reviewer` | ✅ | May run lint or tests to verify applied fixes |
-| `project-setup` | ✅ | May need to initialize git, run project commands during setup |
+| Agent | Has Bash? | Has Agent? | Reason |
+|---|---|---|---|
+| `orchestrator` | ✅ | ✅ | Needs `git branch`, `git status`, helper scripts, and issue / PR inspection to build and supervise batches; dispatches `item-orchestrator` sub-agents |
+| `item-orchestrator` | ✅ | ✅ | Needs helper scripts, git / PR inspection, and readiness loops to keep one item moving end to end; dispatches stage agents (developer, code-reviewer, etc.) |
+| `automated-reviewer-loop` | ✅ | ✅ | Runs pr-review-loop.sh, pr-ci-loop.sh, git; dispatches fixer agents (spec-reviewer, implementation-plan-reviewer, code-reviewer) when needs_fixes |
+| `product-manager` | ✅ | ❌ | Creates spec branches / PRs and may run readiness helpers |
+| `spec-reviewer` | ✅ | ❌ | May commit, push, and re-run fixes during spec review loops |
+| `tech-lead` | ✅ | ❌ | May need to run commands to understand the codebase before planning |
+| `implementation-plan-reviewer` | ✅ | ❌ | May commit, push, and re-run fixes during plan review loops |
+| `developer` | ✅ | ❌ | Runs build, lint, and test commands as part of implementation |
+| `code-reviewer` | ✅ | ❌ | May run lint or tests to verify applied fixes |
+| `project-setup` | ✅ | ❌ | May need to initialize git, run project commands during setup |
 
 ---
 


### PR DESCRIPTION
## Summary
- Added `Agent` tool to `orchestrator` and `item-orchestrator` Claude Code agent configurations
- Without this tool, these agents could not dispatch sub-agents (developer, code-reviewer, automated-reviewer-loop, etc.), causing the entire orchestration to run inline in a single session instead of properly chaining stage-specific agents
- This was already working in Cursor because its subagent system inherits tools from the parent Composer; Claude Code requires explicit tool declarations

## Test plan
- [ ] Run `item-orchestrator` agent on a development item in the implementation stage and verify it dispatches the `developer` agent followed by `code-reviewer` and the automated reviewer loop
- [ ] Run `orchestrator` agent and verify it dispatches `item-orchestrator` sub-agents for each batch item

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Claude Code–specific gap where `orchestrator`, `item-orchestrator`, and `automated-reviewer-loop` agents were missing the `Agent` tool declaration, preventing them from dispatching sub-agents and causing all orchestration stages to run inline in a single session. The fix is minimal and targeted: one tool name appended to each agent's `tools:` frontmatter line.

**Key changes:**
- `.claude/agents/orchestrator.md`, `item-orchestrator.md`, `automated-reviewer-loop.md`: `Agent` appended to the `tools:` list so Claude Code permits sub-agent dispatch at runtime.
- `docs/ai/development-workflow/agent-model-config.md`: Tool Restrictions table expanded with a "Has Agent?" column documenting which agents can dispatch sub-agents; `smoke-tester` agent added to the Assignments and Tool Restrictions tables.
- `CHANGELOG.md`: Fix entry correctly documents all three agent files under `[Unreleased] ### Fixed`.

The Cursor counterpart files (`.cursor/agents/`) correctly do not need this change — Cursor's subagent system inherits tools from the parent Composer implicitly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; changes are minimal one-line additions to agent frontmatter with no runtime logic affected.
- The core fix is a single-token addition (`Agent`) to three tool lists. The doc update is accurate and consistent with the existing agent files. The only gap is a missing per-agent recommendations subsection for `smoke-tester`, which is a documentation completeness issue rather than a functional regression.
- No files require special attention beyond the optional `smoke-tester` recommendations subsection noted in `docs/ai/development-workflow/agent-model-config.md`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .claude/agents/orchestrator.md | Added `Agent` to the tools list — correct and necessary for Claude Code to allow sub-agent dispatch to `item-orchestrator`. |
| .claude/agents/item-orchestrator.md | Added `Agent` to the tools list — correct and necessary for dispatching stage agents (developer, code-reviewer, etc.). |
| .claude/agents/automated-reviewer-loop.md | Added `Agent` to the tools list — correct, enables dispatching fixer agents (spec-reviewer, implementation-plan-reviewer, code-reviewer) on `needs_fixes`. |
| docs/ai/development-workflow/agent-model-config.md | Tool Restrictions table correctly expanded with "Has Agent?" column; `smoke-tester` added to assignments and restrictions tables, but the per-agent model recommendations section is missing a `smoke-tester (balanced)` subsection. |
| CHANGELOG.md | Fix entry correctly documents all three modified agent files under `[Unreleased] ### Fixed`. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant O as orchestrator
    participant IO as item-orchestrator
    participant ARL as automated-reviewer-loop
    participant SA as Stage Agents<br/>(developer / code-reviewer / etc.)

    U->>O: invoke orchestrator
    O->>O: discover & batch items
    O->>IO: dispatch item-orchestrator [Agent tool ✅]
    IO->>IO: determine next action
    IO->>SA: dispatch stage agent [Agent tool ✅]
    SA-->>IO: stage complete
    IO->>ARL: dispatch automated-reviewer-loop [Agent tool ✅]
    ARL->>SA: dispatch fixer agent on needs_fixes [Agent tool ✅]
    SA-->>ARL: fixes applied
    ARL-->>IO: ready-for-review / escalated
    IO-->>O: item done / blocked / escalated
    O-->>U: batch complete
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `.claude/agents/automated-reviewer-loop.md`, line 5 ([link](https://github.com/lhpaul/ai-dev-framework-template/blob/d607cf8e95441baec3fa4edea31d40f3352979a9/.claude/agents/automated-reviewer-loop.md#L5)) 

   **Missing `Agent` tool for fixer-agent dispatch**

   This agent explicitly dispatches sub-agents (`spec-reviewer`, `implementation-plan-reviewer`, or `code-reviewer`) when the automated review platform returns `needs_fixes` — as stated in its own description ("Dispatch the matching fixer agent…when the platform reports needs_fixes") and as required by Step 7 of `90-orchestrate-work-protocol.md` / `92-automated-reviewer-loop-protocol.md`. Without the `Agent` tool, Claude Code cannot hand off to those fixer agents and will either run the fix inline or silently fail to dispatch, which is exactly the same bug this PR fixes for `orchestrator.md`.

2. `docs/ai/development-workflow/agent-model-config.md`, line 39 ([link](https://github.com/lhpaul/ai-dev-framework-template/blob/c4ff2af42aa64df832e5fa9d44b6c97360c2dc28/docs/ai/development-workflow/agent-model-config.md#L39)) 

   **Missing per-agent recommendations section for `smoke-tester`**

   Every other agent listed in the Agent Assignments table (lines 28–39) has a corresponding `### <agent> (<tier>)` subsection in the **Per-Agent Model Recommendations** section (lines 67–175) with cross-provider model examples. The new `smoke-tester` (`balanced`) entry was added to both the assignments table and the tool restrictions table, but no `### smoke-tester (balanced)` subsection was added to the recommendations section.

   This means users who consult the doc to pick a model for `smoke-tester` on a non-Anthropic provider have no guidance. Consider adding a section analogous to the existing ones, e.g.:

   ```markdown
   ### `smoke-tester` (`balanced`)

   - OpenAI: `gpt-5-mini`, `gpt-5.2` (low/medium reasoning)
   - Anthropic: Claude Sonnet (latest)
   - Google: Gemini Flash (latest)
   - Alibaba (Qwen): `qwen-plus`
   - ...
   ```

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: c4ff2af</sub>

<!-- /greptile_comment -->