### PR TITLE
feat(pr-review-loop): enhance Devin status tracking by counting statu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `pr-review-loop.sh`: Devin adapter now counts GitHub Status Contexts (in addition to Check Runs) when detecting Devin review activity and completion, preventing false `no_check_run` skips when Devin signals via a commit status instead of a check run. Status counts are deduplicated by context (latest entry per context) to avoid inflated counts when the same context transitions through multiple states.
+
 ## [0.18.0] - 2026-03-18
 
 ### Added

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -501,6 +501,8 @@ run_devin_review() {
   local devin_post_check_grace=120  # seconds to wait after check completes
   local devin_summary_count=0
   local since_check_completed=0
+  local devin_status_count=0
+  local devin_completed_status_count=0
 
   while :; do
     # Check for any Devin completion review every iteration (so "No Issues Found" is detected)
@@ -539,17 +541,21 @@ run_devin_review() {
     #   devin_any_check_count so we know Devin is configured and active.
     # devin_completed_status_count: only terminal states (success/failure/error) — used
     #   for check_completed so a pending status never starts the grace timer prematurely.
-    local devin_status_count=0
-    local devin_completed_status_count=0
-    devin_status_count="$(
+    # Deduplicate by context (keep latest entry per context) to avoid double-counting
+    # when the same context transitions through multiple states (e.g. pending → success).
+    read -r devin_status_count devin_completed_status_count < <(
       gh api "repos/$repo/commits/$head_sha/statuses" --paginate \
-        | jq -s '[.[].[] | select(.context | test("devin"; "i"))] | length'
-    )"
+        | jq -s -r '
+            ( [.[].[] | select(.context | test("devin"; "i"))]
+              | group_by(.context) | map(max_by(.updated_at)) | length ),
+            ( [.[].[] | select(.context | test("devin"; "i"))]
+              | group_by(.context) | map(max_by(.updated_at))
+              | map(select(.state == "success" or .state == "failure" or .state == "error"))
+              | length )
+            | tostring
+          ' | tr '\n' ' '
+    )
     devin_status_count="${devin_status_count:-0}"
-    devin_completed_status_count="$(
-      gh api "repos/$repo/commits/$head_sha/statuses" --paginate \
-        | jq -s '[.[].[] | select((.context | test("devin"; "i")) and (.state == "success" or .state == "failure" or .state == "error"))] | length'
-    )"
     devin_completed_status_count="${devin_completed_status_count:-0}"
     if [ "$devin_status_count" -gt 0 ]; then
       devin_any_check_count=$(( devin_any_check_count + devin_status_count ))

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -533,6 +533,28 @@ run_devin_review() {
     )"
     devin_any_check_count="${devin_any_check_count:-0}"
 
+    # Also count Devin status contexts (Devin sometimes signals via a GitHub Status
+    # Context on the commit rather than a Check Run — both mean Devin has completed).
+    # devin_status_count: any Devin status context (including pending) — used for
+    #   devin_any_check_count so we know Devin is configured and active.
+    # devin_completed_status_count: only terminal states (success/failure/error) — used
+    #   for check_completed so a pending status never starts the grace timer prematurely.
+    local devin_status_count=0
+    local devin_completed_status_count=0
+    devin_status_count="$(
+      gh api "repos/$repo/commits/$head_sha/statuses" --paginate \
+        | jq -s '[.[].[] | select(.context | test("devin"; "i"))] | length'
+    )"
+    devin_status_count="${devin_status_count:-0}"
+    devin_completed_status_count="$(
+      gh api "repos/$repo/commits/$head_sha/statuses" --paginate \
+        | jq -s '[.[].[] | select((.context | test("devin"; "i")) and (.state == "success" or .state == "failure" or .state == "error"))] | length'
+    )"
+    devin_completed_status_count="${devin_completed_status_count:-0}"
+    if [ "$devin_status_count" -gt 0 ]; then
+      devin_any_check_count=$(( devin_any_check_count + devin_status_count ))
+    fi
+
     check_completed="$(
       gh api "repos/$repo/commits/$head_sha/check-runs" --paginate \
         | jq -s '
@@ -543,6 +565,11 @@ run_devin_review() {
           '
     )"
     check_completed="${check_completed:-0}"
+
+    # Only count status contexts in terminal states toward check_completed.
+    if [ "$devin_completed_status_count" -gt 0 ]; then
+      check_completed=$(( check_completed + devin_completed_status_count ))
+    fi
 
     if [ "$check_completed" -gt 0 ]; then
       if [ "$check_completed_at" -eq -1 ]; then


### PR DESCRIPTION
…s contexts and completed states
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes false `no_check_run` skips in `pr-review-loop.sh` for cases where Devin signals via a GitHub **Commit Status** rather than a **Check Run**. The fix extends the existing check-run polling logic with a parallel status-context query that:

- uses a single `gh api … --paginate` call to `/statuses`, with `jq` computing both counts in one pass,
- deduplicates per-context using `group_by(.context) | map(max_by(.updated_at))` (preventing inflation from pending→success transitions),
- adds only *terminal*-state statuses (`success`/`failure`/`error`) to `check_completed`, so a `pending` context never prematurely starts the post-check grace timer,
- declares the new locals (`devin_status_count`, `devin_completed_status_count`) before the loop, consistent with the surrounding convention.

All three previously raised concerns (local-inside-loop, double API call, inflated counts from historical entries) have been resolved by this revision. The CHANGELOG entry accurately reflects the change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all previously raised concerns are resolved and no new issues were found.

The implementation is correct: single API call, proper deduplication, terminal-state guard, and locals declared before the loop. No P0/P1 findings remain.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/development-workflow/pr-review-loop.sh | Adds GitHub Status Context counting alongside existing Check Run counting for Devin detection; uses a single paginated API call with jq deduplication (group_by + max_by(.updated_at)), local variables declared before the loop, and terminal-state guard for the grace timer. |
| CHANGELOG.md | Adds an accurate Fixed entry under [Unreleased] describing the new Status Context counting and deduplication behaviour. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Poll iteration start] --> B[gh api /reviews\nDevin summary check]
    B --> C{devin_summary_count > 0?}
    C -- yes --> DONE[break — Devin done]
    C -- no --> D[gh api /check-runs\ncount all Devin check runs\ndevin_any_check_count]
    D --> E[gh api /statuses --paginate\njq: group_by context, max_by updated_at\n→ devin_status_count\n→ devin_completed_status_count]
    E --> F{devin_status_count > 0?}
    F -- yes --> G[devin_any_check_count += devin_status_count]
    F -- no --> H
    G --> H[gh api /check-runs\ncount completed Devin check runs\ncheck_completed]
    H --> I{devin_completed_status_count > 0?}
    I -- yes --> J[check_completed += devin_completed_status_count]
    I -- no --> K
    J --> K{check_completed > 0?}
    K -- yes --> L[record check_completed_at\ncompute since_check_completed]
    L --> M{since_check_completed >= grace 120s?}
    M -- yes --> DONE
    M -- no --> N
    K -- no --> N{elapsed >= max_wait?}
    N -- yes, no checks --> O[RESULT: skipped / no_check_run]
    N -- yes, checks seen --> P[RESULT: escalate / timeout]
    N -- no --> Q[sleep poll_interval]
    Q --> A
```

<sub>Reviews (2): Last reviewed commit: ["fix(pr-review-loop): address Greptile an..."](https://github.com/lhpaul/ai-dev-framework-template/commit/2da48fca233809fd59564e74968f7601a0f7df92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26601362)</sub>

<!-- /greptile_comment -->