### PR TITLE
chore(release): v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Automated reviewer-loop protocol pre-flight now explicitly defines unresolved findings and blocking Devin outcomes, and documents ledger bootstrap from full PR history before fix cycles.
+- Workflow protocols were renumbered and normalized (`04-*` -> `03-*`, `05-*` -> `04-*`, `06-*` -> `05-*`, `89-*` -> `90-*`, `90-*` -> `91-*`, `91-*` -> `92-*`, `92-*` -> `93-*`) and several protocol filenames were standardized (`generate-specs` -> `generate-spec`, `review-specs` -> `review-spec`, `review-implemented-development` -> `review-implementation`).
+- PR readiness labels were renamed to simpler defaults: `agent:ready-for-review` -> `ready-for-human-review` and `agent:needs-fixes` -> `needs-fixes`.
+- `.ai-dev-workflow.yaml` now uses a versioned nested schema (`review.platforms`) and includes declarative sections for `issue_tracker`, `vcs`, and `browser_automation`.
+- Stage protocols now open draft PRs first, then mark them ready with `gh pr ready` only after internal review, automated review, and CI all pass.
+- Orchestration now includes an explicit Step 7a internal review gate before external automated reviewers.
+- Workflow docs were refreshed, including a full rewrite of `docs/ai/development-workflow/README.md` and terminology updates to "Portfolio Orchestrator" and "Work Item Runner".
+
+### Removed
+
+- `docs/ai/development-workflow/tooling-assumptions.md`; capability assumptions and fallback guidance now live in the workflow README.
 
 ## [0.18.0] - 2026-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-03-30
+
 ### Fixed
 
-- `pr-review-loop.sh`: Devin adapter now recovers stale unresolved findings when Devin does not review the current HEAD (e.g. after merging the base branch). Before reporting `skipped (no_check_run)`, the script scans the full PR history for unresolved Devin inline comments and reports `needs_fixes` with reason `stale_findings` if any exist. This prevents blocking code bugs from being silently dropped after a merge.
-- `pr-review-loop.sh`: Devin `✅ **Resolved**` confirmation comments are now excluded from the blocking count in Phase 1 (existing findings) and Phase 3 (new results), preventing resolved confirmations from being misclassified as new blocking findings.
-- `pr-review-loop.sh`: Devin adapter now counts GitHub Status Contexts (in addition to Check Runs) when detecting Devin review activity and completion, preventing false `no_check_run` skips when Devin signals via a commit status instead of a check run. Status counts are deduplicated by context (latest entry per context) to avoid inflated counts when the same context transitions through multiple states.
+- Automated Devin review loops now recover stale unresolved findings from PR history when the latest HEAD has no fresh Devin review, preventing blocking issues from being dropped after base-branch merges.
+- Devin resolved-confirmation comments (`✅ **Resolved**`) are excluded from blocking issue counts so previously fixed findings are not reclassified as new blockers.
+- Devin review detection now considers both GitHub Check Runs and Status Contexts (deduplicated by context), avoiding false `no_check_run` skips when Devin reports via statuses.
 
 ### Changed
 
-- `93-automated-reviewer-loop-protocol.md`: Pre-flight section now defines **unresolved finding** (full PR history, merge/rebase trap, matching ✅ to the same finding), states Devin `COMMENTED` + `**Devin Review**` as blocking, and documents **ledger bootstrap** (seed the ledger from full PR history before Step 7).
+- Automated reviewer-loop protocol pre-flight now explicitly defines unresolved findings and blocking Devin outcomes, and documents ledger bootstrap from full PR history before fix cycles.
 
 ## [0.18.0] - 2026-03-18
 
@@ -267,7 +269,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.18.1...HEAD
+[0.18.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.15.0...v0.16.0

--- a/README.md
+++ b/README.md
@@ -81,9 +81,12 @@ The setup agent will have a structured conversation with you to understand your 
 │           │   ├── 02-review-implementation-plan-protocol.md
 │           │   ├── 03-implement-development-protocol.md
 │           │   ├── 03-review-implementation-protocol.md
+│           │   ├── 04-smoke-test-protocol.md
+│           │   ├── 05-prepare-release-protocol.md
 │           │   ├── 90-batch-orchestrate-work-protocol.md
 │           │   ├── 91-orchestrate-work-protocol.md
-│           │   └── 92-pr-readiness-signal-protocol.md
+│           │   ├── 92-pr-readiness-signal-protocol.md
+│           │   └── 93-automated-reviewer-loop-protocol.md
 │           ├── templates/                 # Spec, plan, and test templates
 │           │   ├── spec-template.md
 │           │   ├── implementation-plan-template.md

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -584,10 +584,10 @@ run_devin_review() {
         local stale_reviews
         stale_comments="$(
           gh api "repos/$repo/pulls/$pr_number/comments" --paginate \
-            | jq -r --arg bot "$bot_login" '
+            | jq -s -r --arg bot "$bot_login" '
                 (
                   [
-                    .[]
+                    .[][]
                     | select(
                         .user.login == $bot and
                         .in_reply_to_id != null and
@@ -596,7 +596,7 @@ run_devin_review() {
                     | .in_reply_to_id
                   ]
                 ) as $resolved_ids
-                | .[]
+                | .[][]
                 | select(
                     .user.login == $bot and
                     .in_reply_to_id == null and

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -518,16 +518,20 @@ run_devin_review() {
       break
     fi
 
-    devin_any_check_count="$(
+    read -r devin_any_check_count check_completed < <(
       gh api "repos/$repo/commits/$head_sha/check-runs" --paginate \
-        | jq -s '
+        | jq -s -r '
             [.[].check_runs[] | select(
               (.app.slug == "devin-ai-integration") or
               (.name | test("devin"; "i"))
-            )] | length
-          '
-    )"
+            )] as $runs
+            | ($runs | length),
+              ($runs | map(select(.status == "completed")) | length)
+            | tostring
+          ' | tr '\n' ' '; echo
+    )
     devin_any_check_count="${devin_any_check_count:-0}"
+    check_completed="${check_completed:-0}"
 
     # Also count Devin status contexts (Devin sometimes signals via a GitHub Status
     # Context on the commit rather than a Check Run — both mean Devin has completed).
@@ -547,24 +551,13 @@ run_devin_review() {
               | map(select(.state == "success" or .state == "failure" or .state == "error"))
               | length )
             | tostring
-          ' | tr '\n' ' '
+          ' | tr '\n' ' '; echo
     )
     devin_status_count="${devin_status_count:-0}"
     devin_completed_status_count="${devin_completed_status_count:-0}"
     if [ "$devin_status_count" -gt 0 ]; then
       devin_any_check_count=$(( devin_any_check_count + devin_status_count ))
     fi
-
-    check_completed="$(
-      gh api "repos/$repo/commits/$head_sha/check-runs" --paginate \
-        | jq -s '
-            [.[].check_runs[] | select(
-              (.app.slug == "devin-ai-integration") or
-              (.name | test("devin"; "i"))
-            )] | map(select(.status == "completed")) | length
-          '
-    )"
-    check_completed="${check_completed:-0}"
 
     # Only count status contexts in terminal states toward check_completed.
     if [ "$devin_completed_status_count" -gt 0 ]; then
@@ -588,6 +581,7 @@ run_devin_review() {
         # full PR history for unresolved Devin findings from prior reviews.
         local stale_count=0
         local stale_comments
+        local stale_reviews
         stale_comments="$(
           gh api "repos/$repo/pulls/$pr_number/comments" --paginate \
             | jq -r --arg bot "$bot_login" '
@@ -614,12 +608,37 @@ run_devin_review() {
                 | @json
               '
         )"
+        stale_reviews="$(
+          gh api "repos/$repo/pulls/$pr_number/reviews" --paginate \
+            | jq -r --arg bot "$bot_login" '
+                .[]
+                | select(
+                    .user.login == $bot and
+                    (
+                      .state == "CHANGES_REQUESTED" or
+                      (
+                        .state == "COMMENTED" and
+                        (.body // "" | test("^\\*\\*Devin Review\\*\\*"; "i"))
+                      )
+                    ) and
+                    ((.body // "") | test("No Issues Found"; "i") | not) and
+                    ((.body // "") | test("^✅") | not)
+                  )
+                | { path: "", line: 0, body: (.body // "review without body") }
+                | @json
+              '
+        )"
         stale_file="$(mktemp)"
         while IFS= read -r comment_json; do
           [ -z "${comment_json:-}" ] && continue
           stale_count=$((stale_count + 1))
           printf '%s\n' "$comment_json" >> "$stale_file"
         done <<< "$stale_comments"
+        while IFS= read -r review_json; do
+          [ -z "${review_json:-}" ] && continue
+          stale_count=$((stale_count + 1))
+          printf '%s\n' "$review_json" >> "$stale_file"
+        done <<< "$stale_reviews"
 
         if [ "$stale_count" -gt 0 ]; then
           print_kv RESULT needs_fixes

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -145,7 +145,7 @@ workflow_config_review_platforms() {
       return value
     }
 
-    /^review:[[:space:]]*$/ {
+    /^review:[[:space:]]*(#.*)?$/ {
       in_review = 1
       in_platforms = 0
       next
@@ -156,7 +156,7 @@ workflow_config_review_platforms() {
       in_platforms = 0
     }
 
-    in_review && /^[[:space:]][[:space:]]platforms:[[:space:]]*$/ {
+    in_review && /^[[:space:]][[:space:]]platforms:[[:space:]]*(#.*)?$/ {
       in_platforms = 1
       next
     }
@@ -172,7 +172,7 @@ workflow_config_review_platforms() {
       next
     }
 
-    in_review && in_platforms && !/^[[:space:]][[:space:]][[:space:]][[:space:]]-[[:space:]]*/ {
+    in_review && in_platforms && !/^[[:space:]][[:space:]][[:space:]][[:space:]]-[[:space:]]*/ && !/^[[:space:]]*#/ && !/^[[:space:]]*$/ {
       in_platforms = 0
     }
   ' "$config_file"

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -168,6 +168,7 @@ workflow_config_review_platforms() {
     in_review && in_platforms && /^[[:space:]][[:space:]][[:space:]][[:space:]]-[[:space:]]*/ {
       line = $0
       sub(/^[[:space:]]*-[[:space:]]*/, "", line)
+      sub(/[[:space:]]+#.*$/, "", line)
       print trim(line)
       next
     }

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -172,19 +172,7 @@ workflow_config_review_platforms() {
       next
     }
 
-    in_review && in_platforms && /^[^[:space:]#]/ {
-      in_platforms = 0
-    }
-
-    in_review && in_platforms && /^[[:space:]][^[:space:]#]/ {
-      in_platforms = 0
-    }
-
-    in_review && in_platforms && /^[[:space:]][[:space:]][^[:space:]#]/ {
-      in_platforms = 0
-    }
-
-    in_review && in_platforms && /^[[:space:]][[:space:]][[:space:]][^[:space:]#]/ {
+    in_review && in_platforms && !/^[[:space:]][[:space:]][[:space:]][[:space:]]-[[:space:]]*/ {
       in_platforms = 0
     }
   ' "$config_file"


### PR DESCRIPTION
## Summary

- Automated Devin review loops now recover stale unresolved findings from PR history when the latest HEAD has no fresh Devin review.
- Resolved-confirmation comments are excluded from blocking counts to avoid false blockers.
- Devin activity detection now counts both check runs and status contexts, and protocol pre-flight clarifies unresolved/blocking semantics with ledger bootstrap.

## Changelog (0.18.1)

### Fixed
- Automated Devin review loops now recover stale unresolved findings from PR history when the latest HEAD has no fresh Devin review, preventing blocking issues from being dropped after base-branch merges.
- Devin resolved-confirmation comments (`✅ **Resolved**`) are excluded from blocking issue counts so previously fixed findings are not reclassified as new blockers.
- Devin review detection now considers both GitHub Check Runs and Status Contexts (deduplicated by context), avoiding false `no_check_run` skips when Devin reports via statuses.

### Changed
- Automated reviewer-loop protocol pre-flight now explicitly defines unresolved findings and blocking Devin outcomes, and documents ledger bootstrap from full PR history before fix cycles.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a changelog-only release PR promoting the `[Unreleased]` entries to `[0.18.1] - 2026-03-30`. The changes correctly follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions: the versioned section is inserted immediately after `[Unreleased]`, the comparison link for `[0.18.1]` is added to the reference block, and the `[Unreleased]` reference is updated to point from `v0.18.1...HEAD`.

Notable: the entry descriptions were rewritten to be more general (removing the `` `pr-review-loop.sh` `` and `` `93-automated-reviewer-loop-protocol.md` `` prefixes that were present in the unreleased entries). This is a deliberate style choice visible in the PR description, though it diverges slightly from the prior release entries (e.g. `0.18.0`) which retain explicit file paths for traceability.

- `CHANGELOG.md`: `[0.18.1]` section added with correct date, `Fixed` and `Changed` entries match PR description, all link definitions updated correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changelog-only change with correct structure and no code modifications.

The PR touches only CHANGELOG.md, the structure follows Keep a Changelog conventions, link definitions are consistent, and no code is modified. No P0/P1 issues were found. The only observation is the intentional style shift toward less file-specific descriptions, which is P2 at most and clearly deliberate.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Promotes [Unreleased] entries to [0.18.1] - 2026-03-30, updates comparison link definitions, and rewrites entries with more general (less file-specific) descriptions — no structural or logical issues found. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pr-review-loop.sh runs] --> B{Fresh Devin review\nfor current HEAD?}
    B -- Yes --> C[Parse inline findings\nfrom check run]
    B -- No --> D[Scan full PR history\nfor stale unresolved findings]
    D --> E{Stale unresolved\nfindings exist?}
    E -- Yes --> F[Report needs_fixes\nreason: stale_findings]
    E -- No --> G[Report skipped\nno_check_run]
    C --> H[Filter findings:\nexclude ✅ Resolved confirmations]
    F --> H
    H --> I{Blocking\nissues remain?}
    I -- Yes --> J[Return CHANGES_REQUESTED /\nCOMMENTED blocking]
    I -- No --> K[Return approved / no blockers]
```

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.18.1"](https://github.com/lhpaul/ai-dev-framework-template/commit/21db57a22466b1e4a80fb449fbb34d925278de32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26756893)</sub>

**Context used:**

- Context used - Documentation conventions. Apply when creating or ... ([source](https://app.greptile.com/review/custom-context?memory=39fb40c5-7a08-44b3-bd0f-8bdaa28ce647))

<!-- /greptile_comment -->