### PR TITLE
fix(workflow): stale review false blockers and merged-branch detection

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -23,7 +23,6 @@ review:
   # Platforms are evaluated in order; the first blocking result stops the loop.
   # Supported today by pr-review-loop.sh: greptile, devin
   platforms:
-    - greptile
     - devin
 
 issue_tracker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Automated reviewer-loop now recovers stale unresolved findings from full PR history, preventing blocking issues from being dropped when Devin does not review the latest HEAD (e.g., after base-branch merges).
+- Workflow next-action detection now identifies merged feature branches via VCS (GitHub PR merged status + slug match) to avoid false `Plan Ready` classification when branches are cleaned up after merge.
+
+### Changed
+
+- Greptile removed from default configured review platforms for this repository.
+
 ## [0.18.1] - 2026-03-30
 
 ### Fixed

--- a/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -85,6 +85,8 @@ Build a portfolio map of:
 
 When available, use `workflow-batch-plan.sh` as the initial candidate list for development folders, then enrich it with tracker and PR data.
 
+When an issue tracker is configured and accessible, use it to pre-filter the candidate list: exclude items whose tracker status is already `Done`, `Merged`, `Cancelled`, or equivalent before calling `workflow-next-action.sh --development`. This is an optional optimization — the script performs its own VCS-level check to detect merged items, but skipping them at the tracker layer avoids unnecessary `gh` calls in large portfolios.
+
 ---
 
 ## Step 2: Determine Eligibility and Priority

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -66,8 +66,9 @@ If the request is portfolio-wide or refers to multiple items, stop using this pr
 Important for `development folder` targets:
 
 - `workflow-next-action.sh --development` is only reliable once the item is already `Spec Ready`, `Plan Ready`, or `In Development`.
-- A development folder by itself cannot distinguish `Spec in Review` / `Plan in Review` from the corresponding merged state.
-- If the target may still be waiting on a spec or plan PR merge, confirm the state via the issue tracker or by inspecting the workflow branch / PR directly before advancing.
+- The script uses a VCS-level merged-PR check to distinguish `Plan Ready` (not yet started) from `Done` (branch merged and cleaned up). This is tracker-agnostic and requires only `gh`.
+- The script **cannot** distinguish `Spec in Review` / `Plan in Review` from the corresponding merged state. If the target may still be waiting on a spec or plan PR merge, confirm the state via the issue tracker or by inspecting the workflow branch / PR directly before advancing.
+- If `NEXT_ACTION=skip` is returned, the item is already done — do not redispatch.
 
 When dispatching a subagent for this item, include a short “Tracker Work Item Summary” in the handoff:
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -581,7 +581,9 @@ run_devin_review() {
         # full PR history for unresolved Devin findings from prior reviews.
         local stale_count=0
         local stale_comments
-        local stale_reviews
+        # Only consider unresolved inline comments here. Historical review-level
+        # summaries (e.g., CHANGES_REQUESTED/COMMENTED) may have been superseded
+        # by later clean runs and can cause false stale blockers.
         stale_comments="$(
           gh api "repos/$repo/pulls/$pr_number/comments" --paginate \
             | jq -s -r --arg bot "$bot_login" '
@@ -608,37 +610,12 @@ run_devin_review() {
                 | @json
               '
         )"
-        stale_reviews="$(
-          gh api "repos/$repo/pulls/$pr_number/reviews" --paginate \
-            | jq -r --arg bot "$bot_login" '
-                .[]
-                | select(
-                    .user.login == $bot and
-                    (
-                      .state == "CHANGES_REQUESTED" or
-                      (
-                        .state == "COMMENTED" and
-                        (.body // "" | test("^\\*\\*Devin Review\\*\\*"; "i"))
-                      )
-                    ) and
-                    ((.body // "") | test("No Issues Found"; "i") | not) and
-                    ((.body // "") | test("^✅") | not)
-                  )
-                | { path: "", line: 0, body: (.body // "review without body") }
-                | @json
-              '
-        )"
         stale_file="$(mktemp)"
         while IFS= read -r comment_json; do
           [ -z "${comment_json:-}" ] && continue
           stale_count=$((stale_count + 1))
           printf '%s\n' "$comment_json" >> "$stale_file"
         done <<< "$stale_comments"
-        while IFS= read -r review_json; do
-          [ -z "${review_json:-}" ] && continue
-          stale_count=$((stale_count + 1))
-          printf '%s\n' "$review_json" >> "$stale_file"
-        done <<< "$stale_reviews"
 
         if [ "$stale_count" -gt 0 ]; then
           print_kv RESULT needs_fixes

--- a/scripts/development-workflow/workflow-next-action.sh
+++ b/scripts/development-workflow/workflow-next-action.sh
@@ -187,16 +187,40 @@ if [ -n "$slug" ]; then
   fi
 fi
 
-# NOTE: This logic cannot distinguish "branch not yet created" from "branch merged and cleaned up".
-# When the issue tracker is the source of truth (e.g. Linear), the orchestrator should only call
-# this script for items whose tracker status is Spec Ready, Plan Ready, or In Development.
-# For items already Merged or Released, skip this script entirely.
+# When no live feature branch exists and a plan is present, the item could be either
+# "Plan Ready (not yet started)" or "Done (branch merged and cleaned up)".
+# Disambiguate with a VCS-level merged-PR check — no issue tracker required.
+# Falls back gracefully to "Plan Ready" when gh is unavailable (non-GitHub VCS).
+feature_branch_merged=0
+if [ "$feature_branch_exists" -eq 0 ] && [ -n "$plan_file" ] && gh_available; then
+  # Try exact branch name first: feature/<slug>
+  merged_count="$(gh pr list --state merged --head "feature/$slug" --json number --jq 'length' 2>/dev/null || echo 0)"
+  if [ "${merged_count:-0}" -gt 0 ]; then
+    feature_branch_merged=1
+  else
+    # Try issue-tracker-prefixed pattern: feature/<ISSUE-ID>-<slug>
+    # Matches Linear (ENG-123), Jira (PROJ-456), and similar [A-Z]+-[0-9]+ prefixes.
+    if gh pr list --state merged --limit 500 --json headRefName 2>/dev/null \
+        | jq -r '.[].headRefName' 2>/dev/null \
+        | sed -n 's|^feature/||p' \
+        | grep -qE "^[A-Z]+-[0-9]+-${slug_ere}$"; then
+      feature_branch_merged=1
+    fi
+  fi
+fi
+
+# NOTE: This logic still cannot distinguish "spec/plan PR not yet merged" from "spec/plan PR merged".
+# When the issue tracker is configured, the orchestrator should pre-filter items whose tracker
+# status is already Done/Merged/Cancelled and skip this script for them entirely.
 if [ -z "$plan_file" ]; then
   status_line="Spec Ready"
   next_action="write-plan"
 elif [ "$feature_branch_exists" -eq 1 ]; then
   status_line="In Development"
   next_action="resolve-development-pr"
+elif [ "$feature_branch_merged" -eq 1 ]; then
+  status_line="Done"
+  next_action="skip"
 else
   status_line="Plan Ready"
   next_action="implement"


### PR DESCRIPTION
## Summary

- **Stale review recovery**: Limit stale Devin recovery to unresolved inline comments only. Historical review-level summaries (`CHANGES_REQUESTED`/`COMMENTED`) can be superseded by later clean runs and were triggering false `needs_fixes` outcomes.
- **Remove greptile**: Drop greptile from `review.platforms` in `.ai-dev-workflow.yaml`.
- **Merged-branch detection**: Add a VCS-level merged-PR check in `workflow-next-action.sh --development` mode to distinguish "Plan Ready (not yet started)" from "Done (branch merged and cleaned up)". This is tracker-agnostic (uses `gh`, no issue tracker required) and prevents agents from re-implementing already-merged items. Update orchestrator protocol docs accordingly.

## Test plan

- [ ] Run `workflow-next-action.sh --development <path>` on a development folder whose feature branch was already merged — should return `NEXT_ACTION=skip`
- [ ] Run `workflow-next-action.sh --development <path>` on a development folder that is genuinely Plan Ready — should return `NEXT_ACTION=implement`
- [ ] Run `pr-review-loop.sh` on a PR with stale Devin review summaries but no unresolved inline comments — should not false-positive as `needs_fixes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)