### PR TITLE
feat(workflow): rename Improvement to Refactor and add Refactor path

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -9,4 +9,4 @@ Follow the code review protocol exactly as defined in:
 
 `docs/ai/development-workflow/protocols/03-review-implementation-protocol.md`
 
-That document is the single source of truth for this review stage. Always read the spec and plan before reviewing code. Apply fixes by default; if invoked during a reviewer loop, continue through commit / push until the protocol reaches approval or a real human decision is required.
+That document is the single source of truth for this review stage. Always read the spec and plan before reviewing code (for Refactor items, read the plan and work item brief instead — there is no spec). Apply fixes by default; if invoked during a reviewer loop, continue through commit / push until the protocol reaches approval or a real human decision is required.

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,7 +1,7 @@
 ---
 name: developer
 model: claude-sonnet-4-6
-description: In Development stage. Handles three paths — Full Pipeline (feature with spec+plan), Fast Track (bug or simple change, no spec/plan needed), and Hotfix (critical production bug from main). Implements code, verifies build/lint/tests, opens PRs, and resolves reviewer / CI readiness.
+description: In Development stage. Handles four paths — Full Pipeline (feature with spec+plan), Refactor (code restructuring with plan only, no spec), Fast Track (bug or simple change, no spec/plan needed), and Hotfix (critical production bug from main). Implements code, verifies build/lint/tests, opens PRs, and resolves reviewer / CI readiness.
 tools: Read, Grep, Glob, Write, Edit, Bash
 ---
 
@@ -9,10 +9,11 @@ Follow the implementation protocol exactly as defined in:
 
 `docs/ai/development-workflow/protocols/03-implement-development-protocol.md`
 
-That document is the single source of truth for this stage. It covers all three paths (Full Pipeline, Fast Track, Hotfix) and their specific requirements.
+That document is the single source of truth for this stage. It covers all four paths (Full Pipeline, Refactor, Fast Track, Hotfix) and their specific requirements.
 
 Key rules:
 - For Full Pipeline: read spec + plan + runbook BEFORE writing any code
+- For Refactor: read plan + runbook BEFORE writing any code (no spec)
 - For Fast Track: stop and report if scope exceeds the brief
 - For Hotfix: branch from `main`, not `develop`
 - Never bypass build/lint/test verification

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -1,7 +1,7 @@
 ---
 name: product-manager
 model: claude-sonnet-4-6
-description: Spec Ready stage. Use when a new feature needs a spec written. Conducts a structured alignment conversation with the human, then writes the feature spec, runs its reviewer gate, and resolves PR readiness. Do NOT use for bugs or simple changes (use the developer agent with fast track instead).
+description: Spec Ready stage. Use when a new feature needs a spec written. Conducts a structured alignment conversation with the human, then writes the feature spec, runs its reviewer gate, and resolves PR readiness. Do NOT use for bugs or simple changes (use the developer agent with fast track instead) or for refactors (use the tech-lead agent to write a plan directly).
 tools: Read, Grep, Glob, Write, Edit, Bash
 ---
 

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -1,7 +1,7 @@
 ---
 name: tech-lead
 model: claude-opus-4-6
-description: Plan Ready stage. Use when a spec has been approved and an implementation plan needs to be written. Reads the codebase, resolves technical approach questions, then writes the implementation plan, runs its reviewer gate, and resolves PR readiness.
+description: Plan Ready stage. Use when an implementation plan needs to be written. For Full Pipeline items, a spec must be approved first. For Refactor items, the work item brief replaces the spec. Reads the codebase, resolves technical approach questions, then writes the implementation plan, runs its reviewer gate, and resolves PR readiness.
 tools: Read, Grep, Glob, Write, Edit, Bash
 ---
 
@@ -9,4 +9,4 @@ Follow the implementation plan generation protocol exactly as defined in:
 
 `docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md`
 
-That document is the single source of truth for this stage. Always read the approved spec and relevant codebase sections before proposing an approach. Once ambiguity is resolved, continue through reviewer gate, PR creation, and PR readiness unless the protocol requires human input.
+That document is the single source of truth for this stage. Always read the approved spec (or the work item brief for Refactor items) and relevant codebase sections before proposing an approach. Once ambiguity is resolved, continue through reviewer gate, PR creation, and PR readiness unless the protocol requires human input.

--- a/.codex/skills/workflow-code-reviewer/SKILL.md
+++ b/.codex/skills/workflow-code-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-code-reviewer
-description: Review implemented changes against the repository's code review workflow. Use when a feature, fix, or hotfix PR needs review or reviewer feedback needs to be addressed.
+description: Review implemented changes against the repository's code review workflow. Use when a feature, refactor, fix, or hotfix PR needs review or reviewer feedback needs to be addressed.
 ---
 
 # Workflow Code Reviewer

--- a/.codex/skills/workflow-implementer/SKILL.md
+++ b/.codex/skills/workflow-implementer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-implementer
-description: Implement a workflow item in code. Use for full-pipeline implementation, fast-track fixes, or hotfixes using the repository's implementation protocol.
+description: Implement a workflow item in code. Use for full-pipeline implementation, refactors (plan only, no spec), fast-track fixes, or hotfixes using the repository's implementation protocol.
 ---
 
 # Workflow Implementer
@@ -10,5 +10,5 @@ Recommended model tier: `balanced`
 1. Read `AGENTS.md` for repository-wide rules and branch overrides.
 2. Read `docs/ai/development-workflow/protocols/03-implement-development-protocol.md`.
 3. Follow that protocol exactly.
-4. For full-pipeline work, read the spec and plan first. For fast-track work, stop if scope expands. For hotfixes, branch from `main`.
+4. For full-pipeline work, read the spec and plan first. For refactors, read the plan first (no spec). For fast-track work, stop if scope expands. For hotfixes, branch from `main`.
 5. Continue through code review, PR creation, automated review, and CI readiness before returning unless the protocol surfaces a real human decision.

--- a/.codex/skills/workflow-plan-writer/SKILL.md
+++ b/.codex/skills/workflow-plan-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-plan-writer
-description: Write an implementation plan for a spec-ready feature. Use when a merged spec needs to advance into the implementation plan stage.
+description: Write an implementation plan for a feature (after spec approval) or a refactor (plan only, no spec). Use when a work item needs to advance into the implementation plan stage.
 ---
 
 # Workflow Plan Writer
@@ -10,5 +10,5 @@ Recommended model tier: `premium`
 1. Read `AGENTS.md` for repository-wide rules and branch overrides.
 2. Read `docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md`.
 3. Follow that protocol exactly.
-4. Use the plan to make technical decisions that the spec intentionally avoids.
+4. Use the plan to make technical decisions that the spec intentionally avoids. For Refactor items, use the work item brief instead of a spec.
 5. When the branch is created, continue through reviewer gate, PR creation, and PR readiness unless the protocol surfaces a real human decision.

--- a/.cursor/agents/code-reviewer.md
+++ b/.cursor/agents/code-reviewer.md
@@ -8,4 +8,4 @@ Follow the code review protocol exactly as defined in:
 
 `docs/ai/development-workflow/protocols/03-review-implementation-protocol.md`
 
-That document is the single source of truth for this review stage. Always read the spec and plan before reviewing code. Apply fixes by default; if invoked during a reviewer loop, continue through commit / push until the protocol reaches approval or a real human decision is required.
+That document is the single source of truth for this review stage. Always read the spec and plan before reviewing code (for Refactor items, read the plan and work item brief instead — there is no spec). Apply fixes by default; if invoked during a reviewer loop, continue through commit / push until the protocol reaches approval or a real human decision is required.

--- a/.cursor/agents/developer.md
+++ b/.cursor/agents/developer.md
@@ -1,17 +1,18 @@
 ---
 name: developer
 model: inherit
-description: In Development stage. Handles three paths — Full Pipeline (feature with spec+plan), Fast Track (bug or simple change, no spec/plan needed), and Hotfix (critical production bug from main). Implements code, verifies build/lint/tests, opens PRs, and resolves reviewer / CI readiness.
+description: In Development stage. Handles four paths — Full Pipeline (feature with spec+plan), Refactor (code restructuring with plan only, no spec), Fast Track (bug or simple change, no spec/plan needed), and Hotfix (critical production bug from main). Implements code, verifies build/lint/tests, opens PRs, and resolves reviewer / CI readiness.
 ---
 
 Follow the implementation protocol exactly as defined in:
 
 `docs/ai/development-workflow/protocols/03-implement-development-protocol.md`
 
-That document is the single source of truth for this stage. It covers all three paths (Full Pipeline, Fast Track, Hotfix) and their specific requirements.
+That document is the single source of truth for this stage. It covers all four paths (Full Pipeline, Refactor, Fast Track, Hotfix) and their specific requirements.
 
 Key rules:
 - For Full Pipeline: read spec + plan + runbook BEFORE writing any code
+- For Refactor: read plan + runbook BEFORE writing any code (no spec)
 - For Fast Track: stop and report if scope exceeds the brief
 - For Hotfix: branch from `main`, not `develop`
 - Never bypass build/lint/test verification

--- a/.cursor/agents/product-manager.md
+++ b/.cursor/agents/product-manager.md
@@ -1,7 +1,7 @@
 ---
 name: product-manager
 model: inherit
-description: Spec Ready stage. Use when a new feature needs a spec written. Conducts a structured alignment conversation with the human, then writes the feature spec, runs its reviewer gate, and resolves PR readiness. Do NOT use for bugs or simple changes (use the developer agent with fast track instead).
+description: Spec Ready stage. Use when a new feature needs a spec written. Conducts a structured alignment conversation with the human, then writes the feature spec, runs its reviewer gate, and resolves PR readiness. Do NOT use for bugs or simple changes (use the developer agent with fast track instead) or for refactors (use the tech-lead agent to write a plan directly).
 ---
 
 Follow the spec generation protocol exactly as defined in:

--- a/.cursor/agents/tech-lead.md
+++ b/.cursor/agents/tech-lead.md
@@ -1,13 +1,13 @@
 ---
 name: tech-lead
 model: inherit
-description: Plan Ready stage. Use when a spec has been approved and an implementation plan needs to be written. Reads the codebase, resolves technical approach questions, then writes the implementation plan, runs its reviewer gate, and resolves PR readiness.
+description: Plan Ready stage. Use when an implementation plan needs to be written. For Full Pipeline items, a spec must be approved first. For Refactor items, the work item brief replaces the spec. Reads the codebase, resolves technical approach questions, then writes the implementation plan, runs its reviewer gate, and resolves PR readiness.
 ---
 
 Follow the implementation plan generation protocol exactly as defined in:
 
 `docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md`
 
-That document is the single source of truth for this stage. Always read the approved spec and relevant codebase sections before proposing an approach. Once ambiguity is resolved, continue through reviewer gate, PR creation, and PR readiness unless the protocol requires human input.
+That document is the single source of truth for this stage. Always read the approved spec (or the work item brief for Refactor items) and relevant codebase sections before proposing an approach. Once ambiguity is resolved, continue through reviewer gate, PR creation, and PR readiness unless the protocol requires human input.
 
 **Note**: This agent handles premium-tier reasoning tasks (architecture decisions). For best results, ensure your Cursor Composer is using a high-reasoning model (e.g., Claude Opus, GPT-4, or equivalent) when invoking this subagent, or edit this file to set `model:` to a specific premium model ID.

--- a/.cursor/commands/generate-implementation-plan.md
+++ b/.cursor/commands/generate-implementation-plan.md
@@ -1,9 +1,9 @@
 ---
-description: Plan Ready stage. Reads the approved spec and codebase, resolves technical approach questions, then writes the implementation plan, runs its reviewer gate, and resolves PR readiness. Usage: /generate-implementation-plan [optional feature slug or dev folder path]
+description: Plan Ready stage. Reads the approved spec (or work item brief for Refactor items) and codebase, resolves technical approach questions, then writes the implementation plan, runs its reviewer gate, and resolves PR readiness. Usage: /generate-implementation-plan [optional feature slug or dev folder path]
 ---
 
 Follow the implementation plan generation protocol exactly as defined in:
 
 `docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md`
 
-Always read the approved spec and relevant codebase sections before proposing an approach. Once ambiguity is resolved, continue through reviewer gate, PR creation, and PR readiness unless the protocol requires human input.
+Always read the approved spec (or the work item brief for Refactor items) and relevant codebase sections before proposing an approach. Once ambiguity is resolved, continue through reviewer gate, PR creation, and PR readiness unless the protocol requires human input.

--- a/.cursor/commands/implement-development.md
+++ b/.cursor/commands/implement-development.md
@@ -1,5 +1,5 @@
 ---
-description: In Development stage. Implements a feature via Full Pipeline (with spec+plan), Fast Track (bug/simple change), or Hotfix (critical production bug), then keeps the PR moving until reviewer and CI readiness are resolved. Usage: /implement-development [dev folder path | brief description of fix | "hotfix: [description]"]
+description: In Development stage. Implements a feature via Full Pipeline (with spec+plan), Refactor (plan only, no spec), Fast Track (bug/simple change), or Hotfix (critical production bug), then keeps the PR moving until reviewer and CI readiness are resolved. Usage: /implement-development [dev folder path | brief description of fix | "hotfix: [description]"]
 ---
 
 Follow the implementation protocol exactly as defined in:
@@ -9,11 +9,13 @@ Follow the implementation protocol exactly as defined in:
 ### Which path?
 
 - **Full Pipeline**: provide the dev folder path (e.g., `docs/specs/developments/20250101_my-feature/`)
+- **Refactor**: provide the dev folder path (plan-only folder, no spec)
 - **Fast Track**: provide a brief description of the bug or simple change
 - **Hotfix**: prefix with "hotfix:" (e.g., "hotfix: users can't log in after password reset")
 
 Key rules:
 - Full Pipeline: read spec + plan + runbook BEFORE writing any code
+- Refactor: read plan + runbook BEFORE writing any code (no spec)
 - Fast Track: stop and report if scope expands beyond the brief
 - Hotfix: branch from `main`, not `develop`
 - Always update CHANGELOG before opening the PR

--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -25,7 +25,7 @@ Repository-specific workflow providers live in `.ai-dev-workflow.yaml`. Today, h
 
 ### Key rules
 
-- Always read the spec and plan before implementing
+- Always read the spec and plan before implementing (Refactor items have no spec — read the plan and work item brief instead)
 - Continue through the review gate, PR readiness, and CI unless the protocol surfaces a real human decision
 - Always update CHANGELOG under `[Unreleased]` before opening a PR
 - No `git push --force`, `reset --hard`, or rebase on shared branches without explicit human approval
@@ -35,7 +35,7 @@ Repository-specific workflow providers live in `.ai-dev-workflow.yaml`. Today, h
 
 ```
 docs/specs/developments/[YYYYMMDDHHMMSS]_[slug]/
-  1_[slug]_specs.md
+  1_[slug]_specs.md          # Full Pipeline only; Refactor items have no spec file
   2_[slug]_implementation-plan.md
 
 docs/testing/[section]/[slug].smoke-test.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ This repository follows the default template workflow (documented in `docs/ai/de
 - Release branch: `main` (release PR targets `main`, plus a mandatory backport PR to `develop`)
 - Branch naming:
   - Features / improvements: `feature/[feature-slug]` (from `develop`)
+  - Refactors: `refactor/[slug]` (from `develop`)
   - Bug fixes (fast track): `fix/[slug]` (from `develop`)
   - Hotfixes: `hotfix/[slug]` (from `main`, then backport to `develop`)
   - Releases: `release/v[X.Y.Z]` (from `develop`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renamed `Improvement` issue tracker label to `Refactor` (code restructuring / tech-debt cleanup).
+- Added new **Refactor** workflow path (`refactor/[slug]`): plan → implementation, skipping the spec stage entirely. Development folders can now contain only a plan file (no spec) for refactor items.
 - Greptile removed from default configured review platforms for this repository.
 
 ## [0.18.1] - 2026-03-30

--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ Released
 ```
 
 **Special paths:**
-- **Fast Track** (`fix/[slug]` from default branch): bugs and simple changes that don't need a spec or plan
+- **Refactor** (`refactor/[slug]` from develop): code restructuring or tech-debt cleanup with a plan but no spec
+- **Fast Track** (`fix/[slug]` from develop): bugs and simple changes that don't need a spec or plan
 - **Hotfix** (`hotfix/[slug]` from main): critical production bugs that need immediate deployment
 
 See [`docs/ai/development-workflow/README.md`](docs/ai/development-workflow/README.md) for the full workflow specification.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -78,13 +78,13 @@ Typical `important` issues:
 ## Plan Review Checklist
 
 Read before reviewing:
-- The corresponding spec
+- The corresponding spec (Full Pipeline only — Refactor items have no spec; use the work item brief instead)
 - The implementation plan
 - Relevant code and architecture docs
 - The smoke test runbook when one exists
 
 Check:
-- Every use case and acceptance criterion from the spec is addressed
+- Every use case and acceptance criterion from the spec (or from the work item brief for Refactor items) is addressed
 - Steps are specific enough to execute without guessing
 - Ordering is feasible and dependencies are explicit
 - Documentation updates are listed or intentionally declared unnecessary
@@ -107,13 +107,13 @@ Typical `important` issues:
 ## Code Review Checklist
 
 Read before reviewing:
-- The corresponding spec
+- The corresponding spec (Full Pipeline only — Refactor items have no spec; use the work item brief instead)
 - The implementation plan
 - Relevant best-practice docs
 - The changed code
 
 Check:
-- Implementation matches the approved spec and plan, or any deviations are documented
+- Implementation matches the approved spec and plan (or the plan and work item brief for Refactor items), or any deviations are documented
 - Project and stack conventions are followed
 - Logic and edge cases are correct
 - Security boundaries and validation are respected

--- a/docs/ai/development-workflow/README.md
+++ b/docs/ai/development-workflow/README.md
@@ -229,6 +229,7 @@ This workflow depends on a few capabilities more than on any specific vendor or 
 | Spec | `spec/[slug]` | `develop` |
 | Implementation plan | `implementation-plan/[slug]` | `develop` |
 | Feature | `feature/[slug]` | `develop` |
+| Refactor | `refactor/[slug]` | `develop` |
 | Bug or simple fix | `fix/[slug]` | `develop` |
 | Hotfix | `hotfix/[slug]` | `main` |
 | Release | `release/v[X.Y.Z]` | `develop` |
@@ -261,6 +262,8 @@ If an issue tracker is configured, the work item status usually maps to the work
 
 `Backlog -> Writing Spec -> Spec in Review -> Spec Ready -> Writing Plan -> Plan in Review -> Plan Ready -> In Development -> Implementation in Review -> Merged -> Released`
 
+Refactor items skip the spec stages: `Backlog -> Writing Plan -> Plan in Review -> Plan Ready -> In Development -> Implementation in Review -> Merged -> Released`
+
 Typical tracker fields worth keeping current:
 
 - Status
@@ -289,6 +292,20 @@ Parallel work is encouraged when it is safe:
 - Parallel database schema work should usually be serialized to avoid migration conflicts.
 
 ### Special Paths
+
+#### Refactor
+
+Refactor is the path for code restructuring or tech-debt cleanup that does not need a product spec but benefits from a planned approach.
+
+Use it when all of the following are true:
+
+- The change is code restructuring, tech-debt cleanup, or internal reorganization — not a new user-facing feature.
+- The scope is understood well enough to write an implementation plan without a product spec.
+- The work item brief (from a tracker or human) is sufficient context for the tech lead to plan the work.
+
+Path: `refactor/[slug]` from `develop` -> write plan -> plan review gate -> implement -> code review gate -> smoke test as needed -> merge.
+
+The development folder contains only a plan file (no spec). The tech lead uses the work item brief as input instead of an approved spec.
 
 #### Fast Track
 

--- a/docs/ai/development-workflow/integrations/issue-tracker.md
+++ b/docs/ai/development-workflow/integrations/issue-tracker.md
@@ -38,7 +38,8 @@ If the agent does not have direct tracker access, it must ask the human to paste
 - **Writing Plan**: same as **Writing Spec**, but for the implementation-plan branch/PR after the spec is merged.
 - **Implementation in Review**: treat the work item as waiting on a human merge decision for the feature/fix PR; address `needs-fixes` promptly if the human requests changes.
 - **Spec Ready**: use the work item description/comments as the starting point for the alignment checklist; any decision captured in comments must be reflected in the spec (or surfaced as an Open Question if still unresolved).
-- **Plan Ready**: if comments contain new constraints after the spec was merged, flag the discrepancy and request a spec update before proceeding.
+- **Plan Ready (Full Pipeline)**: if comments contain new constraints after the spec was merged, flag the discrepancy and request a spec update before proceeding.
+- **Plan Ready (Refactor)**: if comments contain new constraints after the plan was written, flag the discrepancy and request a plan update before proceeding. There is no spec — the plan and work item brief are the authoritative sources.
 - **In Development (Full Pipeline)**: scan recent comments for post-plan scope changes. If anything conflicts with the spec or plan, stop and request an update before coding.
 - **In Development (Refactor)**: scan recent comments for post-plan scope changes. If anything conflicts with the plan, stop and request an update before coding. There is no spec for refactor items — the plan and work item brief are the authoritative sources.
 - **In Development (Fast Track)**: the work item description/comments can be the brief; confirm scope is bounded and stop if it expands beyond the brief.

--- a/docs/ai/development-workflow/integrations/issue-tracker.md
+++ b/docs/ai/development-workflow/integrations/issue-tracker.md
@@ -35,7 +35,8 @@ If the agent does not have direct tracker access, it must ask the human to paste
 ## Stage-Specific Rules
 
 - **Writing Spec**: treat the work item as “in flight” until the spec PR is human-ready; keep the brief and any new comments in sync with the spec branch/PR.
-- **Writing Plan**: same as **Writing Spec**, but for the implementation-plan branch/PR after the spec is merged.
+- **Writing Plan (Full Pipeline)**: same as **Writing Spec**, but for the implementation-plan branch/PR after the spec is merged.
+- **Writing Plan (Refactor)**: treat the work item as "in flight" until the plan PR is human-ready; keep the brief and any new comments in sync with the plan branch/PR. There is no spec — the work item brief is the starting input.
 - **Implementation in Review**: treat the work item as waiting on a human merge decision for the feature/fix PR; address `needs-fixes` promptly if the human requests changes.
 - **Spec Ready**: use the work item description/comments as the starting point for the alignment checklist; any decision captured in comments must be reflected in the spec (or surfaced as an Open Question if still unresolved).
 - **Plan Ready (Full Pipeline)**: if comments contain new constraints after the spec was merged, flag the discrepancy and request a spec update before proceeding.

--- a/docs/ai/development-workflow/integrations/issue-tracker.md
+++ b/docs/ai/development-workflow/integrations/issue-tracker.md
@@ -40,4 +40,5 @@ If the agent does not have direct tracker access, it must ask the human to paste
 - **Spec Ready**: use the work item description/comments as the starting point for the alignment checklist; any decision captured in comments must be reflected in the spec (or surfaced as an Open Question if still unresolved).
 - **Plan Ready**: if comments contain new constraints after the spec was merged, flag the discrepancy and request a spec update before proceeding.
 - **In Development (Full Pipeline)**: scan recent comments for post-plan scope changes. If anything conflicts with the spec or plan, stop and request an update before coding.
+- **In Development (Refactor)**: scan recent comments for post-plan scope changes. If anything conflicts with the plan, stop and request an update before coding. There is no spec for refactor items — the plan and work item brief are the authoritative sources.
 - **In Development (Fast Track)**: the work item description/comments can be the brief; confirm scope is bounded and stop if it expands beyond the brief.

--- a/docs/ai/development-workflow/integrations/linear.md
+++ b/docs/ai/development-workflow/integrations/linear.md
@@ -41,7 +41,7 @@ Configure the following statuses in your Linear team settings:
 **Type labels** (one per work item):
 - `Feature` — new capability
 - `Bug` — something broken
-- `Improvement` — enhancement to existing capability
+- `Refactor` — code restructuring or tech-debt cleanup
 - `Chore` — non-functional work (deps, tooling, docs)
 
 **Scope labels** (one or more per work item):
@@ -87,6 +87,7 @@ When a Linear work item exists, use the Linear identifier as the branch slug pre
 | Spec | `spec/[work-item-id]-[slug]` | `spec/ENG-123-user-auth` |
 | Implementation plan | `implementation-plan/[work-item-id]-[slug]` | `implementation-plan/ENG-123-user-auth` |
 | Feature | `feature/[work-item-id]-[slug]` | `feature/ENG-123-user-auth` |
+| Refactor | `refactor/[work-item-id]-[slug]` | `refactor/ENG-321-extract-auth-service` |
 | Bug fix | `fix/[work-item-id]-[slug]` | `fix/ENG-456-login-redirect` |
 | Hotfix | `hotfix/[work-item-id]-[slug]` | `hotfix/ENG-789-payment-crash` |
 
@@ -103,7 +104,7 @@ The **Portfolio Orchestrator**, **Work Item Runner**, or stage agent updates the
 | Human or Portfolio Orchestrator selects the item; Work Item Runner dispatches `product-manager` | → Writing Spec |
 | Spec PR is human-ready (automation clean; ready for humans) | → Spec in Review |
 | Spec PR merged | → Spec Ready |
-| Human or Portfolio Orchestrator selects the item; Work Item Runner dispatches `tech-lead` | → Writing Plan |
+| Human or Portfolio Orchestrator selects the item; Work Item Runner dispatches `tech-lead` | → Writing Plan (Refactor items skip directly here from Backlog) |
 | Plan PR is human-ready (automation clean) | → Plan in Review |
 | Plan PR merged | → Plan Ready |
 | Human or Portfolio Orchestrator selects the item; Work Item Runner dispatches `developer` | → In Development |
@@ -142,7 +143,7 @@ If you don't use Linear, the **Portfolio Orchestrator** asks the human:
 
 > "What should I work on next? Please provide:
 > - Feature name and slug
-> - Path: Full Pipeline / Fast Track / Hotfix
+> - Path: Full Pipeline / Refactor / Fast Track / Hotfix
 > - Priority context (if any)
 > - Dependencies (if any)"
 

--- a/docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -10,7 +10,7 @@
 
 Before starting, read:
 
-- The approved spec: `docs/specs/developments/[timestamp]_[feature-slug]/1_[feature-slug]_specs.md`
+- The approved spec: `docs/specs/developments/[timestamp]_[feature-slug]/1_[feature-slug]_specs.md` (Full Pipeline only — Refactor items have no spec; use the work item brief from the tracker or human instead)
 - `docs/project/2-repo-architecture.md` — repository structure
 - `docs/project/3-software-architecture.md` — tech stack and design patterns
 - `docs/project/4-database-model.md` — data model (if applicable)
@@ -93,7 +93,7 @@ docs/specs/developments/[timestamp]_[feature-slug]/2_[feature-slug]_implementati
 
 - All layers that will change must be covered
 - The implementation order must be logical and executable (no steps that require a later step to be done first)
-- Every change must reference an acceptance criterion from the spec
+- Every change must reference an acceptance criterion from the spec (for Refactor items, reference the work item brief or stated restructuring goals instead)
 - Seed data requirements must be explicit — what data, in which files, for which test scenarios
 - **Documentation**: Explicitly consider project documentation in `docs/`. The plan must list every doc in `docs/` (including `AGENTS.md` if relevant) that the developer must update after implementation, or state "None" only when the feature truly affects no project docs. Do not plan the doc edits — only list them for the developer to execute.
 
@@ -116,7 +116,7 @@ Create the smoke test runbook using the template at `docs/ai/development-workflo
 docs/testing/[app-or-section]/[feature-slug].smoke-test.md
 ```
 
-The runbook must cover all acceptance criteria from the spec. Each criterion must have at least one testable step.
+The runbook must cover all acceptance criteria from the spec (or from the work item brief for Refactor items). Each criterion must have at least one testable step.
 
 ---
 

--- a/docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -17,7 +17,7 @@ Before starting, read:
 - `docs/best-practices/` — all best practice docs
 - Relevant existing code — read actual files, don't assume structure
 - **Project documentation**: Scan `docs/` (e.g. `docs/project/`, `docs/best-practices/`, `AGENTS.md`, and any feature- or domain-specific docs) so the plan can explicitly list which of these need updates after implementation.
-- If an issue tracker exists for this item, follow `docs/ai/development-workflow/integrations/issue-tracker.md` for expectations while the work item is **Spec Ready** (spec merged) and you are entering **Writing Plan**.
+- If an issue tracker exists for this item, follow `docs/ai/development-workflow/integrations/issue-tracker.md` for expectations while the work item is entering **Writing Plan** (Full Pipeline: after spec is merged; Refactor: directly from Backlog).
 
 **Tracker workflow status**: The **Work Item Runner** owns workflow-status transitions for this stage. When this protocol is run under normal orchestration, expect the runner to set **Writing Plan** before dispatch, **Plan in Review** when the PR is human-ready, and **Plan Ready** only after merge. If you invoke this protocol standalone, mirror the same status progression manually.
 
@@ -69,7 +69,7 @@ For each layer affected, confirm what changes are needed:
 
 ## Step 2: Human Review Shortcut (Optional)
 
-Default behavior is **max autonomy**: once you have read the approved spec, inspected the codebase, and there is no unresolved architectural ambiguity, continue through plan writing, commit, push, and draft-PR creation without an extra pause.
+Default behavior is **max autonomy**: once you have read the approved spec (or the work item brief for Refactor items), inspected the codebase, and there is no unresolved architectural ambiguity, continue through plan writing, commit, push, and draft-PR creation without an extra pause.
 
 Pause only if:
 

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -165,7 +165,7 @@ Read **all** of the following before writing a single line of code. Do not skip.
 3. `docs/project/3-software-architecture.md` — architecture patterns
 4. `docs/best-practices/` — all best practice docs
 5. Relevant existing code — read actual files for the areas you will modify
-6. If an issue tracker exists for this item, follow `docs/ai/development-workflow/integrations/issue-tracker.md` for `In Development` expectations before coding.
+6. If an issue tracker exists for this item, follow `docs/ai/development-workflow/integrations/issue-tracker.md` for `In Development (Refactor)` expectations before coding.
 
 Extract from your reading:
 

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -2,7 +2,7 @@
 
 **Agent role**: Developer
 **Stage**: In Development
-**Paths**: Full Pipeline | Fast Track | Hotfix
+**Paths**: Full Pipeline | Refactor | Fast Track | Hotfix
 
 ---
 
@@ -11,6 +11,7 @@
 | Path | Branch | Use when |
 |---|---|---|
 | **Full Pipeline** | `feature/[slug]` from `develop` | Feature with approved spec + plan |
+| **Refactor** | `refactor/[slug]` from `develop` | Code restructuring with approved plan (no spec) |
 | **Fast Track** | `fix/[slug]` from `develop` | Bug or simple change — clear scope, ≤3 files, no schema changes, no new patterns |
 | **Hotfix** | `hotfix/[slug]` from `main` | Critical production bug requiring immediate deployment |
 
@@ -197,6 +198,44 @@ See `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` and
 9. Open draft PR targeting `main` (Step 8 above)
 10. Hand off to the Work Item Runner (Step 9 above)
 11. **After merge**: notify the human that a backport PR (main → develop) must be opened to prevent branch drift
+
+---
+
+## Path 4: Refactor (Code Restructuring / Tech Debt)
+
+**Criteria**: Code restructuring, tech-debt cleanup, or internal reorganization that has an approved implementation plan but no product spec.
+
+### Step 1: Non-Negotiable Prep
+
+Read **all** of the following before writing a single line of code. Do not skip.
+
+1. `docs/specs/developments/[timestamp]_[slug]/2_[slug]_implementation-plan.md` — plan (what to restructure, in what order)
+2. `docs/testing/[section]/[slug].smoke-test.md` — smoke test runbook (what "done" looks like)
+3. `docs/project/3-software-architecture.md` — architecture patterns
+4. `docs/best-practices/` — all best practice docs
+5. Relevant existing code — read actual files for the areas you will modify
+6. If an issue tracker exists for this item, follow `docs/ai/development-workflow/integrations/issue-tracker.md` for `In Development` expectations before coding.
+
+Extract from your reading:
+
+- Every file or area you will touch
+- The implementation order from the plan
+- The acceptance criteria from the plan
+
+**Dependency check**: Read the `Depends on` field in the plan. If any dependency is not yet Merged or Released, stop and report to the human.
+
+### Refactor Steps
+
+1. If no blocking ambiguity remains, proceed without an extra approval pause; otherwise stop and ask the human
+2. Branch: `git checkout -b refactor/[branch-slug]` from `develop` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without)
+3. Implement following the plan order. Follow `docs/best-practices/` for all code written.
+4. If scope is larger than the plan described, **stop and report**
+5. Verify: build, lint, tests pass; run e2e suite if a spec exists for the affected area
+6. Update CHANGELOG under `[Unreleased]` with a `Changed` entry
+7. Commit: `refactor([scope]): [description]`
+8. Push branch to remote
+9. Open draft PR targeting `develop` (Step 8 from Path 1)
+10. Hand off to the Work Item Runner (Step 9 from Path 1)
 
 ---
 

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -152,56 +152,7 @@ See `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` and
 
 ---
 
-## Path 2: Fast Track (Bug / Simple Change)
-
-**Criteria check — all must be true**:
-
-- [ ] The scope is clear and bounded from the start
-- [ ] ≤ 3 files will be modified (estimate before starting)
-- [ ] No new database schema migrations
-- [ ] No new architectural patterns
-- [ ] Human provided a clear, self-contained brief
-
-**If any criterion fails**: Use the Full Pipeline instead.
-
-**If scope expands during implementation**: Stop immediately. Report to the human. Do not silently expand scope.
-
-### Fast Track Steps
-
-1. Read the brief. If the work item exists in an issue tracker, follow `docs/ai/development-workflow/integrations/issue-tracker.md` for `In Development (Fast Track)` expectations.
-2. If no blocking ambiguity remains, proceed without an extra approval pause; otherwise stop and ask the human
-3. Branch: `git checkout -b fix/[branch-slug]` from `develop` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without)
-4. Implement the fix
-5. Verify: build, lint, tests pass; run e2e suite if a spec exists for the affected area
-6. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry
-7. Commit: `fix([scope]): [description]`
-8. Push branch to remote
-9. Open draft PR targeting `develop` (Step 8 above)
-10. Hand off to the Work Item Runner (Step 9 above)
-
----
-
-## Path 3: Hotfix (Critical Production Bug)
-
-**Criteria**: Active production incident or critical security issue.
-
-### Hotfix Steps
-
-1. Read the incident brief from the human
-2. Confirm it's a production-only issue (not a dev/staging issue)
-3. Branch: `git checkout -b hotfix/[branch-slug]` from `main` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without)
-4. Implement the minimal fix (do not bundle unrelated changes)
-5. Verify: build, lint, tests pass
-6. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry
-7. Commit: `fix([scope]): [description] (hotfix)`
-8. Push branch to remote
-9. Open draft PR targeting `main` (Step 8 above)
-10. Hand off to the Work Item Runner (Step 9 above)
-11. **After merge**: notify the human that a backport PR (main → develop) must be opened to prevent branch drift
-
----
-
-## Path 4: Refactor (Code Restructuring / Tech Debt)
+## Path 2: Refactor (Code Restructuring / Tech Debt)
 
 **Criteria**: Code restructuring, tech-debt cleanup, or internal reorganization that has an approved implementation plan but no product spec.
 
@@ -236,6 +187,55 @@ Extract from your reading:
 8. Push branch to remote
 9. Open draft PR targeting `develop` (Step 8 from Path 1)
 10. Hand off to the Work Item Runner (Step 9 from Path 1)
+
+---
+
+## Path 3: Fast Track (Bug / Simple Change)
+
+**Criteria check — all must be true**:
+
+- [ ] The scope is clear and bounded from the start
+- [ ] ≤ 3 files will be modified (estimate before starting)
+- [ ] No new database schema migrations
+- [ ] No new architectural patterns
+- [ ] Human provided a clear, self-contained brief
+
+**If any criterion fails**: Use the Full Pipeline instead.
+
+**If scope expands during implementation**: Stop immediately. Report to the human. Do not silently expand scope.
+
+### Fast Track Steps
+
+1. Read the brief. If the work item exists in an issue tracker, follow `docs/ai/development-workflow/integrations/issue-tracker.md` for `In Development (Fast Track)` expectations.
+2. If no blocking ambiguity remains, proceed without an extra approval pause; otherwise stop and ask the human
+3. Branch: `git checkout -b fix/[branch-slug]` from `develop` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without)
+4. Implement the fix
+5. Verify: build, lint, tests pass; run e2e suite if a spec exists for the affected area
+6. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry
+7. Commit: `fix([scope]): [description]`
+8. Push branch to remote
+9. Open draft PR targeting `develop` (Step 8 above)
+10. Hand off to the Work Item Runner (Step 9 above)
+
+---
+
+## Path 4: Hotfix (Critical Production Bug)
+
+**Criteria**: Active production incident or critical security issue.
+
+### Hotfix Steps
+
+1. Read the incident brief from the human
+2. Confirm it's a production-only issue (not a dev/staging issue)
+3. Branch: `git checkout -b hotfix/[branch-slug]` from `main` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without)
+4. Implement the minimal fix (do not bundle unrelated changes)
+5. Verify: build, lint, tests pass
+6. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry
+7. Commit: `fix([scope]): [description] (hotfix)`
+8. Push branch to remote
+9. Open draft PR targeting `main` (Step 8 above)
+10. Hand off to the Work Item Runner (Step 9 above)
+11. **After merge**: notify the human that a backport PR (main → develop) must be opened to prevent branch drift
 
 ---
 

--- a/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -95,7 +95,8 @@ When an issue tracker is configured and accessible, use it to pre-filter the can
 
 | Portfolio item state | Can advance if... | Dispatch target |
 |---|---|---|
-| Backlog | Human explicitly requested it | Work Item Runner on the tracker item / brief |
+| Backlog (Feature) | Human explicitly requested it | Work Item Runner on the tracker item / brief (starts at spec stage) |
+| Backlog (Refactor) | Human explicitly requested it as a Refactor | Work Item Runner on the tracker item / brief (starts at plan stage, skips spec) |
 | Writing Spec | Tracker **Writing Spec**; spec PR not yet human-ready | Work Item Runner on the tracker item / branch / PR |
 | Writing Plan | Tracker **Writing Plan**; plan PR not yet human-ready | Work Item Runner on the tracker item / branch / PR |
 | In Development | Tracker **In Development**; feature/fix PR not yet human-ready | Work Item Runner on the tracker item / branch / PR |

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -84,7 +84,8 @@ When dispatching a subagent for this item, include a short “Tracker Work Item 
 
 | Current state / detection | Can advance if... | Next action |
 |---|---|---|
-| Backlog | Human has requested this specific item | Set tracker status to **Writing Spec**, then run `01-generate-spec-protocol.md` |
+| Backlog (Feature) | Human has requested this specific item | Set tracker status to **Writing Spec**, then run `01-generate-spec-protocol.md` |
+| Backlog (Refactor) | Human has requested this specific item as a Refactor | Set tracker status to **Writing Plan**, then run `02-generate-implementation-plan-protocol.md` (skip spec) |
 | Writing Spec | Tracker **Writing Spec** — spec PR not yet human-ready | Continue spec branch/PR work (generate, internal review, reviewer tools, CI) until tracker moves to **Spec in Review** |
 | Spec in Review | Tracker **Spec in Review** — spec PR ready for humans | Wait — human review / merge (unless addressing `needs-fixes`) |
 | Spec branch pushed, no PR yet | Branch exists on local / remote / worktree | Run the spec review gate via `REVIEW.md` / `01-review-spec-protocol.md`, open the PR, then finish PR readiness |
@@ -116,7 +117,8 @@ git worktree list | grep "<branch-prefix>/<slug>"
 |---|---|
 | Write spec | `spec/[slug]` |
 | Write plan | `implementation-plan/[slug]` |
-| Implement | `feature/[slug]` |
+| Implement (Feature) | `feature/[slug]` |
+| Implement (Refactor) | `refactor/[slug]` |
 
 If any check returns a match: **do not re-dispatch**. Resume from the existing branch or PR with `workflow-next-action.sh`.
 
@@ -203,7 +205,7 @@ Dispatch the stage-appropriate internal reviewer for the draft PR:
 |---|---|
 | `spec/*` | `spec-reviewer` or `01-review-spec-protocol.md` |
 | `implementation-plan/*` | `implementation-plan-reviewer` or `02-review-implementation-plan-protocol.md` |
-| `feature/*` / `fix/*` / `hotfix/*` | `code-reviewer` or `03-review-implementation-protocol.md` |
+| `feature/*` / `refactor/*` / `fix/*` / `hotfix/*` | `code-reviewer` or `03-review-implementation-protocol.md` |
 
 The reviewer runs against `REVIEW.md`, applies deterministic fixes directly, and commits + pushes if needed.
 
@@ -330,7 +332,7 @@ Soft suggestions may be reported in summaries, but they do not change the loop r
 |---|---|
 | `spec/*` | `spec-reviewer` |
 | `implementation-plan/*` | `implementation-plan-reviewer` |
-| `feature/*` / `fix/*` / `hotfix/*` | `code-reviewer` |
+| `feature/*` / `refactor/*` / `fix/*` / `hotfix/*` | `code-reviewer` |
 
 ### Loop parameters
 

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -50,7 +50,7 @@ Resolve the request to exactly one of the following:
 
 1. **Backlog / tracker work item** — use when a human explicitly requests a not-yet-started item
 2. **Development folder** — `docs/specs/developments/<timestamp>_<slug>`
-3. **Workflow branch** — `spec/*`, `implementation-plan/*`, `feature/*`, `fix/*`, `hotfix/*`
+3. **Workflow branch** — `spec/*`, `implementation-plan/*`, `feature/*`, `refactor/*`, `fix/*`, `hotfix/*`
 4. **Open PR**
 
 Use these helpers while resolving and resuming work:

--- a/docs/ai/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/ai/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -45,7 +45,7 @@ Apply this label when **any** of the following is true:
 3. Run the relevant internal review gate from `REVIEW.md` on the draft PR (spec/plan/code review):
    - `spec/*` → `spec-reviewer` / `01-review-spec-protocol.md`
    - `implementation-plan/*` → `implementation-plan-reviewer` / `02-review-implementation-plan-protocol.md`
-   - `feature/*` / `fix/*` / `hotfix/*` → `code-reviewer` / `03-review-implementation-protocol.md`
+   - `feature/*` / `refactor/*` / `fix/*` / `hotfix/*` → `code-reviewer` / `03-review-implementation-protocol.md`
    - Apply fixes, commit, push; repeat until clean
 4. Run `./scripts/development-workflow/pr-review-loop.sh <pr-number> --branch <branch> [--platform <platform> ...]` when automated review tooling is configured
 5. If any automated reviewer reports blocking PR feedback: apply fixes, push, and repeat Step 4

--- a/docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -21,7 +21,7 @@ Determine the target PR(s) in this order:
 
 1. **Explicit PR number** — from the command or user message (e.g. "run reviewer loop on PR 42")
 2. **Current branch** — if the user said "current" or "this PR" or did not specify: resolve the PR for the current branch, e.g. `gh pr view --json number --jq '.number'` from the repo root (or equivalent)
-3. **Multiple PRs** — only if the user explicitly asked for "all open workflow PRs" or similar; then discover open PRs (e.g. branches `spec/*`, `implementation-plan/*`, `feature/*`, `fix/*`, `hotfix/*`) and run the loop for each, one at a time unless the tool supports parallel runs
+3. **Multiple PRs** — only if the user explicitly asked for "all open workflow PRs" or similar; then discover open PRs (e.g. branches `spec/*`, `implementation-plan/*`, `feature/*`, `refactor/*`, `fix/*`, `hotfix/*`) and run the loop for each, one at a time unless the tool supports parallel runs
 
 If no PR can be determined, ask the user to specify a PR number or to run from a branch that has an open PR.
 

--- a/docs/best-practices/2-version-control.md
+++ b/docs/best-practices/2-version-control.md
@@ -49,6 +49,7 @@ chore(deps): upgrade eslint to v9
 | Branch type | Naming | Branch from | Merges into |
 |---|---|---|---|
 | Feature (full pipeline) | `feature/[slug]` | `develop` | `develop` |
+| Refactor | `refactor/[slug]` | `develop` | `develop` |
 | Bug / simple fix | `fix/[slug]` | `develop` | `develop` |
 | Hotfix (critical prod) | `hotfix/[slug]` | `main` | `main` + `develop` |
 | Spec | `spec/[slug]` | `develop` | `develop` |

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -22,7 +22,7 @@ Prints a compact snapshot of the repository's workflow-related state.
 
 What it does:
 - Shows `git status --short --branch`
-- Lists workflow branches (`spec/`, `implementation-plan/`, `feature/`, `fix/`, `hotfix/`, `release/`)
+- Lists workflow branches (`spec/`, `implementation-plan/`, `feature/`, `refactor/`, `fix/`, `hotfix/`, `release/`)
 - Lists active git worktrees
 - Lists directories under `docs/specs/developments/` if they exist
 - Lists open pull requests, labels, and check summaries when `gh` is available

--- a/scripts/development-workflow/discover-workflow-state.sh
+++ b/scripts/development-workflow/discover-workflow-state.sh
@@ -17,7 +17,7 @@ echo
 echo "== workflow branches =="
 branch_refs="$(git for-each-ref --format='%(refname:short)' refs/heads refs/remotes)"
 if [ -n "$branch_refs" ]; then
-  printf '%s\n' "$branch_refs" | grep -E '(^|/)(spec|implementation-plan|feature|fix|hotfix|release)/' || true
+  printf '%s\n' "$branch_refs" | grep -E '(^|/)(spec|implementation-plan|feature|refactor|fix|hotfix|release)/' || true
 fi
 
 echo

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -46,6 +46,7 @@ branch_prefix() {
     spec/*) printf 'spec\n' ;;
     implementation-plan/*) printf 'implementation-plan\n' ;;
     feature/*) printf 'feature\n' ;;
+    refactor/*) printf 'refactor\n' ;;
     fix/*) printf 'fix\n' ;;
     hotfix/*) printf 'hotfix\n' ;;
     release/*) printf 'release\n' ;;
@@ -57,7 +58,7 @@ reviewer_for_branch() {
   case "$(branch_prefix "$1")" in
     spec) printf 'spec-reviewer\n' ;;
     implementation-plan) printf 'implementation-plan-reviewer\n' ;;
-    feature|fix|hotfix) printf 'code-reviewer\n' ;;
+    feature|refactor|fix|hotfix) printf 'code-reviewer\n' ;;
     *) printf 'none\n' ;;
   esac
 }

--- a/scripts/development-workflow/workflow-next-action.sh
+++ b/scripts/development-workflow/workflow-next-action.sh
@@ -132,7 +132,7 @@ if [ -n "$branch_name" ]; then
     implementation-plan)
       print_kv NEXT_ACTION run-plan-review-and-open-pr
       ;;
-    feature|fix|hotfix)
+    feature|refactor|fix|hotfix)
       print_kv NEXT_ACTION run-code-review-and-open-pr
       ;;
     *)
@@ -151,10 +151,6 @@ spec_file=""
 for f in "$development_path"/1_*_specs.md "$development_path"/1_*_specs.doc.md; do
   [ -f "$f" ] && spec_file="$f" && break
 done
-if [ -z "$spec_file" ] || [ ! -f "$spec_file" ]; then
-  echo "No spec file found in $development_path" >&2
-  exit 66
-fi
 
 # Derive workflow status from repo state so issue tracker remains source of truth (no Status line in spec required)
 slug="$(basename "$development_path" | sed 's/^[0-9]\{14\}_//')"
@@ -162,6 +158,14 @@ plan_file=""
 for f in "$development_path"/2_*_implementation-plan.md "$development_path"/2_*_implementation-plan.doc.md; do
   [ -f "$f" ] && plan_file="$f" && break
 done
+
+# A development folder must contain at least a spec or a plan file.
+# Spec-only (Full Pipeline not yet at plan stage) and plan-only (Refactor path) are both valid.
+if [ -z "$spec_file" ] && [ -z "$plan_file" ]; then
+  echo "No spec or plan file found in $development_path" >&2
+  exit 66
+fi
+
 feature_branch_exists=0
 # Refresh remote refs so feature branch check is accurate. Skip if caller set WORKFLOW_SKIP_FETCH (e.g. one fetch before a loop).
 if [ -z "${WORKFLOW_SKIP_FETCH:-}" ]; then
@@ -169,58 +173,72 @@ if [ -z "${WORKFLOW_SKIP_FETCH:-}" ]; then
     echo "workflow-next-action.sh: warning: git fetch --prune origin failed; refs may be stale" >&2
   fi
 fi
-# Only feature/ is checked; development folders are Full Pipeline only (fix/ and hotfix/ don't use this path).
+# Check for feature/ or refactor/ branches (fix/ and hotfix/ don't use development folders).
 if [ -n "$slug" ]; then
-  if git show-ref --verify -q "refs/remotes/origin/feature/$slug" 2>/dev/null; then
-    feature_branch_exists=1
-  else
-    # Linear: feature/[issue-id]-[slug] (e.g. feature/ENG-123-user-auth); folder may be [timestamp]_[slug] only
+  slug_ere="$(ere_escape "$slug")"
+  for dev_prefix in feature refactor; do
+    if git show-ref --verify -q "refs/remotes/origin/${dev_prefix}/$slug" 2>/dev/null; then
+      feature_branch_exists=1
+      break
+    fi
+    # Linear: [prefix]/[issue-id]-[slug] (e.g. feature/ENG-123-user-auth); folder may be [timestamp]_[slug] only
     # Anchor to end: branch must end with the slug (no extra suffixes like -v2 or -phase-2).
-    slug_ere="$(ere_escape "$slug")"
     while IFS= read -r ref; do
       [ -z "$ref" ] && continue
       if [ "$ref" = "$slug" ] || echo "$ref" | grep -qE "^[A-Z]+-[0-9]+-${slug_ere}$"; then
         feature_branch_exists=1
-        break
+        break 2
       fi
-    done < <(git show-ref 2>/dev/null | sed -n 's|.*refs/remotes/origin/feature/||p')
-  fi
+    done < <(git show-ref 2>/dev/null | sed -n "s|.*refs/remotes/origin/${dev_prefix}/||p")
+  done
 fi
 
-# When no live feature branch exists and a plan is present, the item could be either
+# When no live dev branch exists and a plan is present, the item could be either
 # "Plan Ready (not yet started)" or "Done (branch merged and cleaned up)".
 # Disambiguate with a VCS-level merged-PR check — no issue tracker required.
 # Falls back gracefully to "Plan Ready" when gh is unavailable (non-GitHub VCS).
 feature_branch_merged=0
 if [ "$feature_branch_exists" -eq 0 ] && [ -n "$plan_file" ] && gh_available; then
-  # Try exact branch name first: feature/<slug>
-  merged_count="$(gh pr list --state merged --head "feature/$slug" --json number --jq 'length' 2>/dev/null || echo 0)"
-  if [ "${merged_count:-0}" -gt 0 ]; then
-    feature_branch_merged=1
-  else
-    # Try issue-tracker-prefixed pattern: feature/<ISSUE-ID>-<slug>
+  for dev_prefix in feature refactor; do
+    # Try exact branch name first: [prefix]/<slug>
+    merged_count="$(gh pr list --state merged --head "${dev_prefix}/$slug" --json number --jq 'length' 2>/dev/null || echo 0)"
+    if [ "${merged_count:-0}" -gt 0 ]; then
+      feature_branch_merged=1
+      break
+    fi
+    # Try issue-tracker-prefixed pattern: [prefix]/<ISSUE-ID>-<slug>
     # Matches Linear (ENG-123), Jira (PROJ-456), and similar [A-Z]+-[0-9]+ prefixes.
     if gh pr list --state merged --limit 500 --json headRefName 2>/dev/null \
         | jq -r '.[].headRefName' 2>/dev/null \
-        | sed -n 's|^feature/||p' \
+        | sed -n "s|^${dev_prefix}/||p" \
         | grep -qE "^[A-Z]+-[0-9]+-${slug_ere}$"; then
       feature_branch_merged=1
+      break
     fi
-  fi
+  done
 fi
 
 # NOTE: This logic still cannot distinguish "spec/plan PR not yet merged" from "spec/plan PR merged".
 # When the issue tracker is configured, the orchestrator should pre-filter items whose tracker
 # status is already Done/Merged/Cancelled and skip this script for them entirely.
-if [ -z "$plan_file" ]; then
+if [ -z "$plan_file" ] && [ -n "$spec_file" ]; then
+  # Full Pipeline: spec exists but no plan yet
   status_line="Spec Ready"
   next_action="write-plan"
+elif [ -z "$plan_file" ] && [ -z "$spec_file" ]; then
+  # Should not reach here (guarded above), but be defensive
+  status_line="Unknown"
+  next_action="unknown"
 elif [ "$feature_branch_exists" -eq 1 ]; then
   status_line="In Development"
   next_action="resolve-development-pr"
 elif [ "$feature_branch_merged" -eq 1 ]; then
   status_line="Done"
   next_action="skip"
+elif [ -z "$spec_file" ] && [ -n "$plan_file" ]; then
+  # Refactor path: plan-only folder, no spec — already at Plan Ready
+  status_line="Plan Ready"
+  next_action="implement"
 else
   status_line="Plan Ready"
   next_action="implement"
@@ -229,13 +247,13 @@ fi
 # PLAN_FILE is intentionally not emitted; callers that need the path should scan
 # "$development_path"/2_*_implementation-plan.md directly.
 print_kv TARGET "development:$development_path"
-print_kv SPEC_FILE "$spec_file"
+[ -n "$spec_file" ] && print_kv SPEC_FILE "$spec_file"
 print_kv STATUS "$status_line"
 print_kv NEXT_ACTION "$next_action"
 
 # Optional: read Linear issue ID from spec for orchestrator (tracker is source of truth for status)
 linear_issue=""
-if linear_line="$(grep -m 1 '^\*\*Linear Issue\*\*: ' "$spec_file" 2>/dev/null)"; then
+if [ -n "$spec_file" ] && linear_line="$(grep -m 1 '^\*\*Linear Issue\*\*: ' "$spec_file" 2>/dev/null)"; then
   linear_issue="$(printf '%s\n' "$linear_line" | sed 's/^\*\*Linear Issue\*\*: //' | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
 fi
 [ -n "$linear_issue" ] && print_kv LINEAR_ISSUE "$linear_issue"

--- a/scripts/development-workflow/workflow-next-action.sh
+++ b/scripts/development-workflow/workflow-next-action.sh
@@ -235,11 +235,9 @@ elif [ "$feature_branch_exists" -eq 1 ]; then
 elif [ "$feature_branch_merged" -eq 1 ]; then
   status_line="Done"
   next_action="skip"
-elif [ -z "$spec_file" ] && [ -n "$plan_file" ]; then
-  # Refactor path: plan-only folder, no spec — already at Plan Ready
-  status_line="Plan Ready"
-  next_action="implement"
 else
+  # Plan exists, no live or merged dev branch — ready to implement.
+  # Covers both Full Pipeline (spec + plan) and Refactor (plan only).
   status_line="Plan Ready"
   next_action="implement"
 fi


### PR DESCRIPTION
## Summary

- Renames the `Improvement` issue tracker label to `Refactor` (code restructuring / tech-debt cleanup)
- Adds a new **Refactor** workflow path: plan → implementation (skips spec stage entirely)
- Introduces `refactor/[slug]` branch prefix with full routing support in scripts, protocols, and agent definitions
- Makes spec files optional in development folders — plan-only folders are now valid for the Refactor path

## Changes across 21 files

**Shell scripts**: `workflow-lib.sh`, `workflow-next-action.sh`, `discover-workflow-state.sh` — added `refactor/` branch prefix support, made spec file optional in `--development` mode

**Protocols**: `02`, `03`, `90`, `91`, `92`, `93` — added Refactor path routing, branch lists, reviewer dispatch

**Agent/command definitions**: `.claude/agents/`, `.cursor/agents/`, `.cursor/commands/`, `.codex/skills/` — updated to describe four paths

**Docs**: workflow README, version-control best practices, AGENTS.md, README.md, Linear integration, issue-tracker integration

## Test plan

- [ ] Verify `workflow-next-action.sh --development` works with a plan-only folder (no spec file)
- [ ] Verify `workflow-next-action.sh --branch refactor/test-slug` returns `run-code-review-and-open-pr`
- [ ] Verify `discover-workflow-state.sh` lists `refactor/` branches
- [ ] Review all protocol docs for consistency of the Refactor path description

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
