### PR TITLE
fix(workflow): make issue tracker primary source of truth for orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- AI Workflow: orchestrator protocol now treats the issue tracker (e.g., Linear) as the primary source of truth for work item status; development folders and VCS state are supplementary detail only.
-
-### Fixed
-
-- Automated reviewer-loop now recovers stale unresolved findings from full PR history, preventing blocking issues from being dropped when Devin does not review the latest HEAD (e.g., after base-branch merges).
-- Workflow next-action detection now identifies merged feature branches via VCS (GitHub PR merged status + slug match) to avoid false `Plan Ready` classification when branches are cleaned up after merge.
-
 ### Added
 
 - GitHub Projects v2 integration doc with status mapping, custom fields, `gh` CLI/GraphQL commands, and branch naming conventions.
@@ -23,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- AI Workflow: orchestrator protocol now treats the issue tracker (e.g., Linear) as the primary source of truth for work item status; development folders and VCS state are supplementary detail only.
 - Renamed `Improvement` issue tracker label to `Refactor` (code restructuring / tech-debt cleanup).
 - Added new **Refactor** workflow path (`refactor/[slug]`): plan → implementation, skipping the spec stage entirely. Development folders can now contain only a plan file (no spec) for refactor items.
 - Greptile removed from default configured review platforms for this repository.
@@ -33,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - `Chore` type label removed from tracker integrations; chore-type work is tracked as `Refactor`.
+
+### Fixed
+
+- Automated reviewer-loop now recovers stale unresolved findings from full PR history, preventing blocking issues from being dropped when Devin does not review the latest HEAD (e.g., after base-branch merges).
+- Workflow next-action detection now identifies merged feature branches via VCS (GitHub PR merged status + slug match) to avoid false `Plan Ready` classification when branches are cleaned up after merge.
 
 ## [0.18.1] - 2026-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- AI Workflow: orchestrator protocol now treats the issue tracker (e.g., Linear) as the primary source of truth for work item status; development folders and VCS state are supplementary detail only.
+
 ### Fixed
 
 - Automated reviewer-loop now recovers stale unresolved findings from full PR history, preventing blocking issues from being dropped when Devin does not review the latest HEAD (e.g., after base-branch merges).

--- a/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -51,22 +51,30 @@ If the request is explicitly about a single development, branch, or PR, skip thi
 
 ## Step 1: Gather Portfolio State
 
-Prefer the helper scripts in `scripts/development-workflow/` for deterministic state inspection before falling back to ad hoc shell commands.
+### 1a. Query the issue tracker (primary source of truth)
 
-Read from the following sources:
+When an issue tracker is configured in `.ai-dev-workflow.yaml` (e.g., `issue_tracker.provider: linear`), it is the **primary and authoritative source** for which work items exist and their current status. **Always query the tracker first** — do not infer item status from development folders or git state alone, as those artifacts may be stale or incomplete.
 
-1. **Issue tracker** (if configured): current status, due date, priority, dependencies, and latest brief
-2. **Development folders**: `docs/specs/developments/`
-3. **Workflow branches / PRs**: local branches, remote branches, active worktrees, open PRs
+From the tracker, collect for each open item:
 
-If available, run:
+- Current status (e.g., Backlog, Writing Spec, Spec Ready, Writing Plan, Plan Ready, In Development, In Review, Done)
+- Due date, priority, dependencies, and latest brief/description
+- Linked branch or PR identifiers (if the tracker stores them)
+
+**Exclude** items whose tracker status is already `Done`, `Merged`, `Cancelled`, or equivalent — these are not candidates for advancement.
+
+**If the tracker is unavailable** (no provider configured, API unreachable, or no MCP server available), fall back to the VCS-based discovery in Step 1b below. In this fallback mode, flag to the human that status may be stale.
+
+### 1b. Enrich with VCS state (supplementary detail)
+
+Use the helper scripts in `scripts/development-workflow/` for deterministic VCS state inspection:
 
 ```bash
 ./scripts/development-workflow/discover-workflow-state.sh
 ./scripts/development-workflow/workflow-batch-plan.sh
 ```
 
-Use these helpers while gathering detail:
+Use these helpers to gather detail on specific items:
 
 ```bash
 ./scripts/development-workflow/workflow-next-action.sh --development <path>
@@ -74,18 +82,18 @@ Use these helpers while gathering detail:
 ./scripts/development-workflow/workflow-next-action.sh --pr <number>
 ```
 
-Build a portfolio map of:
+These scripts read from development folders (`docs/specs/developments/`), workflow branches, worktrees, and open PRs. Use their output to **enrich** tracker data with VCS-level detail (e.g., whether a branch exists, whether a PR is open, PR labels), but **do not use VCS-derived status to override the tracker status**. Development folders contain spec and plan documents but are not reliable indicators of item status — items may be completed, cancelled, or reorganized in the tracker without corresponding changes to these folders.
+
+### 1c. Build the portfolio map
+
+Combine tracker and VCS data into a portfolio map of:
 
 - Backlog items that a human explicitly requested to start
 - Work items in **Writing Spec** / **Writing Plan** / **In Development** (PR not yet human-ready), or branches/PRs still in PR-readiness loops
 - Work items in **Spec in Review** / **Plan in Review** / **Development in Review**, or PRs labeled `ready-for-human-review` (human merge queue unless `needs-fixes`)
-- Development folders that are `Spec Ready`, `Plan Ready`, or already in development
+- Items that are **Spec Ready** or **Plan Ready** per the tracker
 - Branches that were pushed but still have no PR
 - PRs that still need readiness work or fix loops
-
-When available, use `workflow-batch-plan.sh` as the initial candidate list for development folders, then enrich it with tracker and PR data.
-
-When an issue tracker is configured and accessible, use it to pre-filter the candidate list: exclude items whose tracker status is already `Done`, `Merged`, `Cancelled`, or equivalent before calling `workflow-next-action.sh --development`. This is an optional optimization — the script performs its own VCS-level check to detect merged items, but skipping them at the tracker layer avoids unnecessary `gh` calls in large portfolios.
 
 ---
 
@@ -93,18 +101,20 @@ When an issue tracker is configured and accessible, use it to pre-filter the can
 
 ### What can advance now?
 
-| Portfolio item state | Can advance if... | Dispatch target |
+Use the **tracker status** as the canonical state for each item. VCS signals (branch existence, PR labels) provide supplementary detail but do not override the tracker. When no tracker is configured, fall back to VCS-derived status.
+
+| Portfolio item state (per tracker) | Can advance if... | Dispatch target |
 |---|---|---|
 | Backlog (Feature) | Human explicitly requested it | Work Item Runner on the tracker item / brief (starts at spec stage) |
 | Backlog (Refactor) | Human explicitly requested it as a Refactor | Work Item Runner on the tracker item / brief (starts at plan stage, skips spec) |
 | Writing Spec | Tracker **Writing Spec**; spec PR not yet human-ready | Work Item Runner on the tracker item / branch / PR |
 | Writing Plan | Tracker **Writing Plan**; plan PR not yet human-ready | Work Item Runner on the tracker item / branch / PR |
 | In Development | Tracker **In Development**; feature/fix PR not yet human-ready | Work Item Runner on the tracker item / branch / PR |
-| Spec Ready | Spec PR is merged | Work Item Runner on the development folder |
-| Plan Ready | Plan PR is merged | Work Item Runner on the development folder |
-| Pushed workflow branch, no PR yet | Branch exists on local/remote/worktree | Work Item Runner on the branch |
-| PR open, no readiness label | PR exists and latest push has not fully cleared | Work Item Runner on the PR |
-| PR labeled `needs-fixes` | Human or automated systems requested changes | Work Item Runner on the PR |
+| Spec Ready | Tracker **Spec Ready** | Work Item Runner on the development folder |
+| Plan Ready | Tracker **Plan Ready** | Work Item Runner on the development folder |
+| Pushed workflow branch, no PR yet | Branch exists on local/remote/worktree (VCS supplementary) | Work Item Runner on the branch |
+| PR open, no readiness label | PR exists and latest push has not fully cleared (VCS supplementary) | Work Item Runner on the PR |
+| PR labeled `needs-fixes` | Human or automated systems requested changes (VCS supplementary) | Work Item Runner on the PR |
 | Spec in Review / Plan in Review / Development in Review or `ready-for-human-review` | — | Wait; do not redispatch (unless human feedback requires a fix loop) |
 
 ### Priority order
@@ -178,9 +188,10 @@ The Portfolio Orchestrator remains responsible for the batch after dispatch.
 
 After a Work Item Runner returns:
 
-1. Re-check the item with `workflow-next-action.sh` when a branch, PR, or development folder exists
-2. If the next action is still deterministic because the Work Item Runner returned early or was interrupted, redispatch / resume that same item
-3. Stop supervising that item only when it is waiting on a human, blocked, or escalated
+1. **Re-check tracker status first** when an issue tracker is configured — query the tracker for the item's current status before consulting VCS state. Do not rely solely on `workflow-next-action.sh` to determine whether an item should advance, as VCS-derived status cannot reliably distinguish certain states (e.g., a spec PR awaiting review vs. one already merged). Use `workflow-next-action.sh` only for VCS-level enrichment (branch existence, PR labels) after the tracker status is known.
+2. If the tracker is unavailable, fall back to `workflow-next-action.sh` but flag to the human that status may be stale.
+3. If the next action is still deterministic because the Work Item Runner returned early or was interrupted, redispatch / resume that same item.
+4. Stop supervising that item only when it is waiting on a human, blocked, or escalated.
 
 Do not consider the batch complete until every dispatched item has reached a real terminal condition.
 

--- a/scripts/development-workflow/discover-workflow-state.sh
+++ b/scripts/development-workflow/discover-workflow-state.sh
@@ -10,6 +10,15 @@ source "$SCRIPT_DIR/workflow-lib.sh"
 
 cd "$REPO_ROOT"
 
+# Check if an issue tracker is configured and remind the caller
+tracker_provider="$(workflow_config_provider issue_tracker)"
+if [ -n "$tracker_provider" ] && [ "$tracker_provider" != "none" ]; then
+  echo "== issue tracker =="
+  echo "Provider: $tracker_provider (query the tracker for authoritative item status)"
+  echo "NOTE: Development folders and VCS state below are supplementary — the tracker is the primary source of truth."
+  echo
+fi
+
 echo "== git status =="
 git status --short --branch
 

--- a/scripts/development-workflow/workflow-next-action.sh
+++ b/scripts/development-workflow/workflow-next-action.sh
@@ -220,9 +220,13 @@ if [ "$feature_branch_exists" -eq 0 ] && [ -n "$plan_file" ] && gh_available; th
   done
 fi
 
-# NOTE: This logic still cannot distinguish "spec/plan PR not yet merged" from "spec/plan PR merged".
-# When the issue tracker is configured, the orchestrator should pre-filter items whose tracker
-# status is already Done/Merged/Cancelled and skip this script for them entirely.
+# IMPORTANT: The VCS-derived status below is a best-effort heuristic. It cannot reliably
+# distinguish "spec/plan PR not yet merged" from "spec/plan PR merged", and development
+# folders may be stale (items completed or cancelled in the tracker without folder updates).
+# When an issue tracker is configured (e.g., Linear), the orchestrator MUST use the tracker
+# as the primary source of truth for item status and should only call this script to enrich
+# tracker data with VCS-level detail (branch existence, PR state). Do not use the STATUS
+# output from this script to override the tracker status.
 if [ -z "$plan_file" ] && [ -n "$spec_file" ]; then
   # Full Pipeline: spec exists but no plan yet
   status_line="Spec Ready"


### PR DESCRIPTION
## Summary

- The orchestrator agent was inferring work item status from development folders and git state, which can be stale (e.g., items completed in the tracker but folders still present)
- Updated protocol to make the issue tracker the **primary and authoritative source** for item status, with VCS signals as supplementary detail only
- Added a reminder in `discover-workflow-state.sh` output when a tracker is configured

Ported from lhpaul/leasity-exchanges-prototype#92.

## Test plan

- [ ] Verify `discover-workflow-state.sh` prints the tracker provider reminder when `.ai-dev-workflow.yaml` has a provider configured
- [ ] Run the orchestrator agent and confirm it queries the tracker first rather than relying on development folder scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
