### PR TITLE
chore(release): v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-04-02
+
 ### Added
 
-- GitHub Projects v2 integration doc with status mapping, custom fields, `gh` CLI/GraphQL commands, and branch naming conventions.
-- Regression suite checklist note in implementation plan template.
+- GitHub Projects v2 integration guide (status mapping, custom fields, `gh`/GraphQL, branch naming).
+- Implementation plan template: regression suite checklist reminder.
 
 ### Changed
 
-- AI Workflow: orchestrator protocol now treats the issue tracker (e.g., Linear) as the primary source of truth for work item status; development folders and VCS state are supplementary detail only.
-- Renamed `Improvement` issue tracker label to `Refactor` (code restructuring / tech-debt cleanup).
-- Added new **Refactor** workflow path (`refactor/[slug]`): plan → implementation, skipping the spec stage entirely. Development folders can now contain only a plan file (no spec) for refactor items.
-- Greptile removed from default configured review platforms for this repository.
-- Renamed `Implementation in Review` workflow stage to `Development in Review` across all protocols and integration docs.
-- `gh pr ready` now runs after the internal review gate (Step 7a APPROVED), before external automated reviewers (Step 7) and CI (Step 8), so external reviewers see a non-draft PR while internal quality gates remain mandatory.
-- Default issue tracker provider changed from `github_issues` to `github_projects`.
+- Orchestration treats the issue tracker as the source of truth for work-item status; development folders and Git state supplement it.
+- **Refactor** path: `refactor/[slug]` (plan → implement, no spec); plan-only development folders supported. Renamed `Improvement` label to `Refactor`.
+- Default issue tracker: `github_projects` (was `github_issues`). Greptile removed from default review platforms in this repo.
+- Renamed stage `Implementation in Review` → `Development in Review` across protocols and integration docs.
+- `gh pr ready` runs after the internal review gate (Step 7a), before external reviewers and CI, so automation sees a ready PR after internal approval.
 
 ### Removed
 
-- `Chore` type label removed from tracker integrations; chore-type work is tracked as `Refactor`.
+- `Chore` tracker label; track that work as **Refactor**.
 
 ### Fixed
 
-- Automated reviewer-loop now recovers stale unresolved findings from full PR history, preventing blocking issues from being dropped when Devin does not review the latest HEAD (e.g., after base-branch merges).
-- Workflow next-action detection now identifies merged feature branches via VCS (GitHub PR merged status + slug match) to avoid false `Plan Ready` classification when branches are cleaned up after merge.
+- Automated reviewer loop recovers stale unresolved findings from full PR history so blockers are not dropped when the latest HEAD has no fresh automated review (e.g. after base-branch merges).
+- Next-action detection uses merged GitHub PRs (and slug match) so items are not misclassified as Plan Ready after the feature branch is deleted.
 
 ## [0.18.1] - 2026-03-30
 
@@ -303,7 +303,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.18.1...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.18.1...v0.19.0
 [0.18.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.16.0...v0.17.0

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ The setup agent will have a structured conversation with you to understand your 
 │           │   └── smoke-test-runbook-template.md
 │           └── integrations/             # Optional tool integrations
 │               ├── linear.md             # Issue tracker integration (Linear)
-│               └── greptile.md           # Automated PR review (Greptile)
+│               ├── greptile.md           # Automated PR review (Greptile)
+│               └── github-projects.md    # GitHub Projects board integration
 │
 ├── .codex/
 │   └── skills/                           # Codex skills that wrap the workflow protocols and ship UI metadata
@@ -238,6 +239,7 @@ Use $workflow-item-orchestrator to start and advance work for [feature or issue 
 
 - **Issue Tracker (e.g., Linear)**: See [`docs/ai/development-workflow/integrations/linear.md`](docs/ai/development-workflow/integrations/linear.md)
 - **Automated PR Review (e.g., Greptile)**: See [`docs/ai/development-workflow/integrations/greptile.md`](docs/ai/development-workflow/integrations/greptile.md)
+- **GitHub Projects board**: See [`docs/ai/development-workflow/integrations/github-projects.md`](docs/ai/development-workflow/integrations/github-projects.md)
 
 ---
 

--- a/docs/ai/development-workflow/README.md
+++ b/docs/ai/development-workflow/README.md
@@ -467,6 +467,7 @@ Repository helpers:
 - `docs/ai/development-workflow/integrations/pr-review-platform.md`
 - `docs/ai/development-workflow/integrations/greptile.md`
 - `docs/ai/development-workflow/integrations/devin.md`
+- `docs/ai/development-workflow/integrations/github-projects.md`
 
 ---
 

--- a/docs/ai/development-workflow/integrations/github-projects.md
+++ b/docs/ai/development-workflow/integrations/github-projects.md
@@ -92,7 +92,9 @@ gh label create "type:refactor" --description "Code restructuring or tech-debt c
 
 ## Status: Tracker as Source of Truth
 
-Workflow status (Spec Ready, Plan Ready, In Development) is **not** stored in the spec document. The project item's Status field is the source of truth. The helper script `workflow-next-action.sh --development <path>` derives the next action from **repo state** (presence of implementation plan file, feature branch) so it works without reading a status field from the spec. See `scripts/development-workflow/README.md` and `workflow-next-action.sh` for the logic. Orchestrators and agents with `gh` CLI access should read and update work item status in the project at stage transitions. **Do not call this script for work items in Merged or Released status;** the script cannot distinguish a not-yet-created branch from a deleted one.
+Workflow status (Spec Ready, Plan Ready, In Development) is **not** stored in the spec document. The project item's Status field is the source of truth. The helper script `workflow-next-action.sh --development <path>` derives the next action from **repo state** (presence of implementation plan file, feature branch) so it works without reading a status field from the spec. See `scripts/development-workflow/README.md` and `workflow-next-action.sh` for the logic. Orchestrators and agents with `gh` CLI access should read and update work item status in the project at stage transitions.
+
+When `gh` is available, the script detects merged PRs via `gh pr list --state merged` and returns `NEXT_ACTION=skip` for items whose branch has already been merged — so calling it on Merged or Released items is safe in that configuration. Without `gh` CLI access, the script cannot distinguish a not-yet-created branch from a deleted one; in that case, prefer filtering work items by tracker status (e.g. exclude Merged/Released) before invoking the script.
 
 ---
 


### PR DESCRIPTION
Release **v0.19.0** — see `CHANGELOG.md` for full history.

## [0.19.0] - 2026-04-02

### Added

- GitHub Projects v2 integration guide (status mapping, custom fields, `gh`/GraphQL, branch naming).
- Implementation plan template: regression suite checklist reminder.

### Changed

- Orchestration treats the issue tracker as the source of truth for work-item status; development folders and Git state supplement it.
- **Refactor** path: `refactor/[slug]` (plan → implement, no spec); plan-only development folders supported. Renamed `Improvement` label to `Refactor`.
- Default issue tracker: `github_projects` (was `github_issues`). Greptile removed from default review platforms in this repo.
- Renamed stage `Implementation in Review` → `Development in Review` across protocols and integration docs.
- `gh pr ready` runs after the internal review gate (Step 7a), before external reviewers and CI, so automation sees a ready PR after internal approval.

### Removed

- `Chore` tracker label; track that work as **Refactor**.

### Fixed

- Automated reviewer loop recovers stale unresolved findings from full PR history so blockers are not dropped when the latest HEAD has no fresh automated review (e.g. after base-branch merges).
- Next-action detection uses merged GitHub PRs (and slug match) so items are not misclassified as Plan Ready after the feature branch is deleted.

---

Merge **this PR to `main` first** (tag is created by CI). Then merge the backport PR to `develop`. Do not delete `release/v0.19.0` until both are merged.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
