### PR TITLE
fix(workflow): exempt spec/plan PRs and unreleased fixes from changelog requirements

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -17,5 +17,5 @@ Key rules:
 - For Fast Track: stop and report if scope exceeds the brief
 - For Hotfix: branch from `main`, not `develop`
 - Never bypass build/lint/test verification
-- Always update CHANGELOG before opening the PR
+- Always update CHANGELOG before opening the PR (except spec/plan-only PRs; for fixes to unreleased work, update the existing entry instead of adding a new one)
 - Do not stop at "PR opened"; continue through code review, automated review, and CI until the PR is ready or escalated

--- a/.cursor/agents/developer.md
+++ b/.cursor/agents/developer.md
@@ -16,5 +16,5 @@ Key rules:
 - For Fast Track: stop and report if scope exceeds the brief
 - For Hotfix: branch from `main`, not `develop`
 - Never bypass build/lint/test verification
-- Always update CHANGELOG before opening the PR
+- Always update CHANGELOG before opening the PR (except spec/plan-only PRs; for fixes to unreleased work, update the existing entry instead of adding a new one)
 - Do not stop at "PR opened"; continue through code review, automated review, and CI until the PR is ready or escalated

--- a/.cursor/commands/implement-development.md
+++ b/.cursor/commands/implement-development.md
@@ -18,5 +18,5 @@ Key rules:
 - Refactor: read plan + runbook BEFORE writing any code (no spec)
 - Fast Track: stop and report if scope expands beyond the brief
 - Hotfix: branch from `main`, not `develop`
-- Always update CHANGELOG before opening the PR
+- Always update CHANGELOG before opening the PR (except spec/plan-only PRs; for fixes to unreleased work, update the existing entry instead of adding a new one)
 - Do not stop at "PR opened"; continue through code review, automated review, and CI until the PR is ready or escalated

--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -27,7 +27,7 @@ Repository-specific workflow providers live in `.ai-dev-workflow.yaml`. Today, h
 
 - Always read the spec and plan before implementing (Refactor items have no spec — read the plan and work item brief instead)
 - Continue through the review gate, PR readiness, and CI unless the protocol surfaces a real human decision
-- Always update CHANGELOG under `[Unreleased]` before opening a PR
+- Always update CHANGELOG under `[Unreleased]` before opening a PR (except spec/plan-only PRs; for fixes to unreleased work, update the existing entry instead of adding a new one)
 - No `git push --force`, `reset --hard`, or rebase on shared branches without explicit human approval
 - Humans merge PRs — agents open them
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ This repository follows the default template workflow (documented in `docs/ai/de
 
 - Follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 - Use [Semantic Versioning](https://semver.org/): patch for fixes/tweaks, minor for new features or meaningful improvements, major for breaking changes to the template structure.
-- **Feature and fix PRs** merged into `develop` add entries under `[Unreleased]` in `CHANGELOG.md`; do not convert to a version number on merge.
+- **Feature and fix PRs** merged into `develop` add entries under `[Unreleased]` in `CHANGELOG.md`; do not convert to a version number on merge. Spec-only and plan-only PRs are exempt. Fixes or changes to unreleased work should update the existing entry rather than adding a new one.
 - **A new version is created only when releasing**: run the Prepare Release workflow (`/prepare-release` or `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md`). That creates a `release/v[X.Y.Z]` branch, renames `[Unreleased]` to `[X.Y.Z]` in the CHANGELOG, and opens PRs to `main` and backport to `develop`.
 
 ### Stack Conventions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CHANGELOG policy: spec-only and plan-only PRs are now exempt from CHANGELOG updates; fixes to unreleased work should update the existing `[Unreleased]` entry instead of adding a new one. Hotfixes always require a new entry since they fix released code.
 - `03-implement-development-protocol.md` (Path 2 Refactor): spell out refactor draft PR metadata and `gh pr create` example instead of reusing Path 1 Step 8 (`feat(...)` / spec link); handoff step references the same Work Item Runner lifecycle and protocols 91/92.
 - `03-implement-development-protocol.md` (Fast Track / Hotfix): draft PR and handoff steps now reference Path 1 Step 8–9 explicitly with `fix(...)` titles and fix- or incident-focused bodies (omit spec/plan when absent); removes the incorrect “Step 8 above” pointer (that step was push, not PR).
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Use $workflow-item-orchestrator to start and advance work for [feature or issue 
 
 ## Mandatory Conventions
 
-- **CHANGELOG.md is required**: every feature/fix/hotfix PR must add an entry under `[Unreleased]` before merge. Never defer CHANGELOG entries to release time.
+- **CHANGELOG.md is required**: every feature/fix/hotfix PR must add an entry under `[Unreleased]` before merge, with exceptions for spec/plan-only PRs (no entry needed) and fixes to unreleased work (update the existing entry instead of adding a new one). Never defer CHANGELOG entries to release time.
 - **Human merge gates**: PRs for spec, plan, and implementation are opened by agents and kept moving until they are actually review-ready; humans still review and merge them.
 - **No destructive Git operations** without explicit human approval (no `--force`, `reset --hard`, `rebase` on shared branches).
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -118,7 +118,7 @@ Check:
 - Logic and edge cases are correct
 - Security boundaries and validation are respected
 - Tests cover the changed business behavior
-- CHANGELOG and workflow-specific artifacts are updated when required
+- CHANGELOG and workflow-specific artifacts are updated when required (spec/plan-only PRs are exempt; fixes to unreleased work update existing entries rather than adding new ones)
 - New patterns are justified and consistent with the codebase
 
 Typical `blocking` issues:

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -110,7 +110,6 @@ Add an entry under `[Unreleased]` in `CHANGELOG.md`:
 
 - Use the appropriate category: `Added`, `Changed`, `Fixed`, `Security`, `Deprecated`, `Removed`
 - Write from the user's perspective: what can they now do / what is now fixed?
-- **Skip this step** if the PR only adds spec or plan documentation
 - If this PR fixes or adjusts an unreleased development that already has an `[Unreleased]` entry, update the existing entry instead of adding a new one; if the entry already describes the corrected behavior, no change is needed
 
 ### Step 7: Commit & Push
@@ -244,7 +243,7 @@ gh pr create --draft --title "refactor([scope]): [short description]" --body "..
 3. Branch: `git checkout -b hotfix/[branch-slug]` from `main` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without)
 4. Implement the minimal fix (do not bundle unrelated changes)
 5. Verify: build, lint, tests pass
-6. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry (skip if this fixes unreleased work that already has an entry — update the existing entry instead, or leave it unchanged if it already describes the correct behavior)
+6. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry (hotfixes always fix released code, so a new entry is always required)
 7. Commit: `fix([scope]): [description] (hotfix)`
 8. Push branch to remote
 9. Open a **draft** PR targeting `main` by adapting Path 1 `### Step 8: Open PR (Draft)` for hotfix (`fix(...)` title with `(hotfix)` as needed, incident-focused body, target branch `main`).

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -110,6 +110,8 @@ Add an entry under `[Unreleased]` in `CHANGELOG.md`:
 
 - Use the appropriate category: `Added`, `Changed`, `Fixed`, `Security`, `Deprecated`, `Removed`
 - Write from the user's perspective: what can they now do / what is now fixed?
+- **Skip this step** if the PR only adds spec or plan documentation
+- If this PR fixes or adjusts an unreleased development that already has an `[Unreleased]` entry, update the existing entry instead of adding a new one; if the entry already describes the corrected behavior, no change is needed
 
 ### Step 7: Commit & Push
 
@@ -182,7 +184,7 @@ Extract from your reading:
 3. Implement following the plan order. Follow `docs/best-practices/` for all code written.
 4. If scope is larger than the plan described, **stop and report**
 5. Verify: build, lint, tests pass; run e2e suite if a spec exists for the affected area
-6. Update CHANGELOG under `[Unreleased]` with a `Changed` entry
+6. Update CHANGELOG under `[Unreleased]` with a `Changed` entry (skip if this refactor adjusts unreleased work that already has an entry — update the existing entry instead, or leave it unchanged if it already describes the correct behavior)
 7. Commit: `refactor([scope]): [description]`
 8. Push branch to remote
 9. Open a **draft** PR targeting `develop` with refactor-appropriate metadata (do **not** reuse Path 1 Step 8 verbatim — that path uses `feat(...)` and a spec link):
@@ -223,7 +225,7 @@ gh pr create --draft --title "refactor([scope]): [short description]" --body "..
 3. Branch: `git checkout -b fix/[branch-slug]` from `develop` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without)
 4. Implement the fix
 5. Verify: build, lint, tests pass; run e2e suite if a spec exists for the affected area
-6. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry
+6. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry (skip if this fixes unreleased work that already has an entry — update the existing entry instead, or leave it unchanged if it already describes the correct behavior)
 7. Commit: `fix([scope]): [description]`
 8. Push branch to remote
 9. Open a **draft** PR targeting `develop` using the same structure as Path 1 `### Step 8: Open PR (Draft)`, but with a **`fix(...)`** title and a fix-focused description (omit spec/plan links when none exist).
@@ -242,7 +244,7 @@ gh pr create --draft --title "refactor([scope]): [short description]" --body "..
 3. Branch: `git checkout -b hotfix/[branch-slug]` from `main` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without)
 4. Implement the minimal fix (do not bundle unrelated changes)
 5. Verify: build, lint, tests pass
-6. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry
+6. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry (skip if this fixes unreleased work that already has an entry — update the existing entry instead, or leave it unchanged if it already describes the correct behavior)
 7. Commit: `fix([scope]): [description] (hotfix)`
 8. Push branch to remote
 9. Open a **draft** PR targeting `main` by adapting Path 1 `### Step 8: Open PR (Draft)` for hotfix (`fix(...)` title with `(hotfix)` as needed, incident-focused body, target branch `main`).

--- a/docs/best-practices/2-version-control.md
+++ b/docs/best-practices/2-version-control.md
@@ -91,7 +91,7 @@ The issue ID prefix is the canonical identifier when a tracker is in use. The sl
 - Write a clear title following the commit message convention
 - Include context in the PR description: what, why, how to test
 - Link the relevant issue if one exists
-- Every PR must update `CHANGELOG.md` under `[Unreleased]` before merge
+- Every PR must update `CHANGELOG.md` under `[Unreleased]` before merge (except spec/plan-only PRs and fixes to unreleased work — see the CHANGELOG section below)
 
 ## Safety Rules
 
@@ -112,3 +112,6 @@ This project uses [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) forma
 - Never defer CHANGELOG entries to release time
 - Use the appropriate category: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`
 - Release PRs move `[Unreleased]` entries to a versioned section: `[X.Y.Z] - YYYY-MM-DD`
+- **Exempt from CHANGELOG updates**:
+  - Spec-only or plan-only PRs (documentation artifacts for upcoming work)
+  - Fixes or changes to developments that have not been released yet — update the existing `[Unreleased]` entry instead of adding a new one; if the original entry already describes the corrected behavior, no change is needed

--- a/docs/best-practices/2-version-control.md
+++ b/docs/best-practices/2-version-control.md
@@ -91,7 +91,7 @@ The issue ID prefix is the canonical identifier when a tracker is in use. The sl
 - Write a clear title following the commit message convention
 - Include context in the PR description: what, why, how to test
 - Link the relevant issue if one exists
-- Every PR must update `CHANGELOG.md` under `[Unreleased]` before merge (except spec/plan-only PRs and fixes to unreleased work — see the CHANGELOG section below)
+- Every PR must update `CHANGELOG.md` under `[Unreleased]` before merge (see the CHANGELOG section below for exceptions)
 
 ## Safety Rules
 
@@ -108,10 +108,9 @@ When in doubt, stop and ask. The cost of confirming is low; the cost of lost wor
 
 This project uses [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 
-- Every feature/fix/hotfix PR adds an entry under `[Unreleased]` **before merge**
+- Every feature/fix/hotfix PR adds an entry under `[Unreleased]` **before merge**, with these exceptions:
+  - Spec-only or plan-only PRs (documentation artifacts for upcoming work) — no entry needed
+  - Fixes or changes to developments that have not been released yet — update the existing `[Unreleased]` entry instead of adding a new one; if the original entry already describes the corrected behavior, no change is needed
 - Never defer CHANGELOG entries to release time
 - Use the appropriate category: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`
 - Release PRs move `[Unreleased]` entries to a versioned section: `[X.Y.Z] - YYYY-MM-DD`
-- **Exempt from CHANGELOG updates**:
-  - Spec-only or plan-only PRs (documentation artifacts for upcoming work)
-  - Fixes or changes to developments that have not been released yet — update the existing `[Unreleased]` entry instead of adding a new one; if the original entry already describes the corrected behavior, no change is needed


### PR DESCRIPTION
## Summary
- Spec-only and plan-only PRs are now exempt from CHANGELOG update requirements
- Fixes or changes to unreleased developments should update the existing `[Unreleased]` entry instead of adding a new one
- Updated all 7 files that contain changelog instructions to reflect these two rules

## Test plan
- [ ] Verify all modified files consistently describe the two new exemptions
- [ ] Confirm no changelog instruction was missed across the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
