### PR TITLE
feat: label-gated e2e/regression test support

### DIFF
--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -110,7 +110,7 @@ For each file in these paths:
 .github/workflows/auto-tag-release.yml         ← automated release tagging; add if CI is set up
 .github/workflows/deploy.yml                   ← placeholder deployment workflow; customize with project-specific deploy logic
 .github/workflows/e2e-regression.yml           ← label-gated e2e/regression placeholder; customize with project-specific test logic
-e2e/                                              <- placeholder e2e/regression test project (Playwright); customize with project-specific tests
+e2e/                                              ← placeholder e2e/regression test project (Playwright); customize with project-specific tests
 ```
 
 For each of these: show the full diff and ask the user explicitly whether to apply it.

--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -110,6 +110,7 @@ For each file in these paths:
 .github/workflows/auto-tag-release.yml         ← automated release tagging; add if CI is set up
 .github/workflows/deploy.yml                   ← placeholder deployment workflow; customize with project-specific deploy logic
 .github/workflows/e2e-regression.yml           ← label-gated e2e/regression placeholder; customize with project-specific test logic
+e2e/                                              <- placeholder e2e/regression test project (Playwright); customize with project-specific tests
 ```
 
 For each of these: show the full diff and ask the user explicitly whether to apply it.

--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -109,6 +109,7 @@ For each file in these paths:
 .claude/settings.local.json.example
 .github/workflows/auto-tag-release.yml         ← automated release tagging; add if CI is set up
 .github/workflows/deploy.yml                   ← placeholder deployment workflow; customize with project-specific deploy logic
+.github/workflows/e2e-regression.yml           ← label-gated e2e/regression placeholder; customize with project-specific test logic
 ```
 
 For each of these: show the full diff and ask the user explicitly whether to apply it.

--- a/.codex/skills/workflow-reviewer-loop/SKILL.md
+++ b/.codex/skills/workflow-reviewer-loop/SKILL.md
@@ -10,6 +10,6 @@ Recommended model tier: `economy`
 1. Read `AGENTS.md` for repository-wide rules.
 2. Read `docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`.
 3. Determine the target PR from the user's request (PR number, current branch, or all open workflow PRs if specified).
-4. Run Step 7 (automated review) and Step 8 (CI) using the scripts in `scripts/development-workflow/`. Run Step 7 to completion before Step 8.
+4. Run Step 7 (automated review), Step 7b (regression label for implementation PRs), and Step 8 (CI) using the scripts in `scripts/development-workflow/`. Run Step 7 to completion before Step 7b and Step 8.
 5. Dispatch the appropriate fixer agent when the loop returns `needs_fixes`; apply labels per `92-pr-readiness-signal-protocol.md` when clean or when escalating.
 6. Track all blocking findings across cycles in an issue ledger. After each fixer push, post a fix commit comment listing resolved issues. When the loop terminates, post a final summary table on the PR using `gh pr comment`.

--- a/.cursor/commands/sync-template.md
+++ b/.cursor/commands/sync-template.md
@@ -109,6 +109,7 @@ For each file in these paths:
 .github/workflows/auto-tag-release.yml         ← automated release tagging; add if CI is set up
 .github/workflows/deploy.yml                   ← placeholder deployment workflow; customize with project-specific deploy logic
 .github/workflows/e2e-regression.yml           ← label-gated e2e/regression placeholder; customize with project-specific test logic
+e2e/                                              <- placeholder e2e/regression test project (Playwright); customize with project-specific tests
 ```
 
 For each of these: show the full diff and ask the user explicitly whether to apply it.

--- a/.cursor/commands/sync-template.md
+++ b/.cursor/commands/sync-template.md
@@ -108,6 +108,7 @@ For each file in these paths:
 .claude/settings.local.json.example
 .github/workflows/auto-tag-release.yml         ← automated release tagging; add if CI is set up
 .github/workflows/deploy.yml                   ← placeholder deployment workflow; customize with project-specific deploy logic
+.github/workflows/e2e-regression.yml           ← label-gated e2e/regression placeholder; customize with project-specific test logic
 ```
 
 For each of these: show the full diff and ask the user explicitly whether to apply it.

--- a/.cursor/commands/sync-template.md
+++ b/.cursor/commands/sync-template.md
@@ -109,7 +109,7 @@ For each file in these paths:
 .github/workflows/auto-tag-release.yml         ← automated release tagging; add if CI is set up
 .github/workflows/deploy.yml                   ← placeholder deployment workflow; customize with project-specific deploy logic
 .github/workflows/e2e-regression.yml           ← label-gated e2e/regression placeholder; customize with project-specific test logic
-e2e/                                              <- placeholder e2e/regression test project (Playwright); customize with project-specific tests
+e2e/                                              ← placeholder e2e/regression test project (Playwright); customize with project-specific tests
 ```
 
 For each of these: show the full diff and ask the user explicitly whether to apply it.

--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -1,0 +1,44 @@
+name: E2E / Regression Tests (Template Placeholder)
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+    branches:
+      - develop
+      - main
+
+concurrency:
+  group: e2e-regression-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: E2E regression (placeholder)
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'ready-for-regression') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ready-for-regression'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: e2e
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: e2e
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        working-directory: e2e
+        run: npx playwright test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Label-gated e2e/regression test workflow: `.github/workflows/e2e-regression.yml` triggers on implementation PRs when `ready-for-regression` label is present; ships with a Playwright-based `e2e/` placeholder project (one always-passing baseline test) for downstream projects to customize.
+- E2e/regression integration guide: `docs/ai/development-workflow/integrations/e2e-regression.md` documents the label-gate pattern, workflow placement between Step 7 and Step 8, and downstream customization.
+- `ready-for-regression` label and Step 7b: applied automatically by the orchestrator on implementation PRs after automated review is clean, gating expensive e2e tests until the PR is reviewer-ready. Documented in protocol 92 (PR readiness signal) and protocol 91 (orchestrate work).
 - Template deployment workflow scaffold: `.github/workflows/deploy.yml` triggers on `develop` and `main`, maps to `develop`/`production` environments, and keeps deploy steps as explicit no-op placeholders for downstream repository customization.
 - CI/CD deployment integration guide: `docs/ai/development-workflow/integrations/ci-cd-deployment.md` documents placeholder behavior and how downstream projects should replace it with provider-specific deploy logic and environment configuration.
 - Setup and architecture docs now explicitly capture CI/CD onboarding details: deployment integration prompts in `docs/ai/setup/protocol.md` and branch-to-environment mapping guidance in `docs/project/3-software-architecture.md`.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The setup agent will have a structured conversation with you to understand your 
 │               ├── greptile.md           # Automated PR review (Greptile)
 │               ├── github-projects.md    # GitHub Projects board integration
 │               ├── ci-cd-deployment.md   # CI/CD deployment placeholders and customization
-│               └── e2e-regression.md    # E2E/regression test integration
+│               └── e2e-regression.md     # E2E/regression test integration
 │
 ├── .codex/
 │   └── skills/                           # Codex skills that wrap the workflow protocols and ship UI metadata

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The setup agent will have a structured conversation with you to understand your 
 │   └── workflows/
 │       ├── auto-tag-release.yml           # Tags release branches after merge to main
 │       ├── deploy.yml                     # Placeholder branch-based deployment workflow
-│       └── e2e-regression.yml            # Label-gated e2e/regression placeholder
+│       └── e2e-regression.yml             # Label-gated e2e/regression placeholder
 │
 ├── docs/
 │   ├── README.md                          # Documentation index

--- a/README.md
+++ b/README.md
@@ -51,10 +51,16 @@ The setup agent will have a structured conversation with you to understand your 
 ├── AGENTS.md                              # Universal AI guidance (all tools read this)
 ├── CLAUDE.md -> AGENTS.md                 # Symlink for Claude Code
 ├── CHANGELOG.md
+├── e2e/                                   # Placeholder e2e/regression test project (Playwright)
+│   ├── playwright.config.ts               # Minimal Playwright config
+│   ├── tests/
+│   │   └── baseline.spec.ts               # Always-passing placeholder test
+│   └── package.json
 ├── .github/
 │   └── workflows/
 │       ├── auto-tag-release.yml           # Tags release branches after merge to main
-│       └── deploy.yml                     # Placeholder branch-based deployment workflow
+│       ├── deploy.yml                     # Placeholder branch-based deployment workflow
+│       └── e2e-regression.yml            # Label-gated e2e/regression placeholder
 │
 ├── docs/
 │   ├── README.md                          # Documentation index
@@ -96,7 +102,8 @@ The setup agent will have a structured conversation with you to understand your 
 │               ├── linear.md             # Issue tracker integration (Linear)
 │               ├── greptile.md           # Automated PR review (Greptile)
 │               ├── github-projects.md    # GitHub Projects board integration
-│               └── ci-cd-deployment.md   # CI/CD deployment placeholders and customization
+│               ├── ci-cd-deployment.md   # CI/CD deployment placeholders and customization
+│               └── e2e-regression.md    # E2E/regression test integration
 │
 ├── .codex/
 │   └── skills/                           # Codex skills that wrap the workflow protocols and ship UI metadata

--- a/docs/ai/development-workflow/README.md
+++ b/docs/ai/development-workflow/README.md
@@ -469,6 +469,7 @@ Repository helpers:
 - `docs/ai/development-workflow/integrations/devin.md`
 - `docs/ai/development-workflow/integrations/github-projects.md`
 - `docs/ai/development-workflow/integrations/ci-cd-deployment.md`
+- `docs/ai/development-workflow/integrations/e2e-regression.md`
 
 ---
 

--- a/docs/ai/development-workflow/integrations/e2e-regression.md
+++ b/docs/ai/development-workflow/integrations/e2e-regression.md
@@ -1,0 +1,75 @@
+# Integration: E2E / Regression Tests
+
+This template includes a label-gated GitHub Actions workflow for e2e/regression testing:
+
+- `.github/workflows/e2e-regression.yml`
+
+The workflow triggers on PRs targeting `develop` or `main` when the `ready-for-regression` label is present. It is intentionally generic so downstream repositories can implement their own test suites.
+
+---
+
+## How It Fits Into the Workflow
+
+The `ready-for-regression` label is applied by the orchestrator (Step 7b in `91-orchestrate-work-protocol.md`) after the automated reviewer loop (Step 7) is clean, and before the CI loop (Step 8). This means:
+
+1. Step 7a: Internal review gate passes
+2. Step 7: External automated reviewers are clean
+3. **Step 7b: `ready-for-regression` label is applied** (triggers this workflow)
+4. Step 8: CI loop polls `statusCheckRollup` — the e2e job appears as a check
+
+Regression tests are expensive in time and compute, so they only run after all reviewer gates confirm the code is clean.
+
+The CI loop (`pr-ci-loop.sh`) naturally picks up the e2e check result as part of its green/red polling. No script changes are needed.
+
+---
+
+## Label Gate Pattern
+
+The workflow uses a two-part `if` condition:
+
+```yaml
+if: >-
+  (github.event.action == 'labeled' && github.event.label.name == 'ready-for-regression') ||
+  (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ready-for-regression'))
+```
+
+- First clause: fires when the label is just applied
+- Second clause: fires on `synchronize` (new push) or `reopened` if the label is already present
+
+This means e2e tests re-run automatically after fixer pushes — the label stays on the PR, and `synchronize` triggers the second clause.
+
+---
+
+## Default Behavior
+
+The template ships with a minimal Playwright project at `e2e/` that has one always-passing baseline test. This keeps the template pipeline green without external dependencies.
+
+---
+
+## What Downstream Repositories Should Customize
+
+Replace the placeholder e2e project with project-specific tests:
+
+1. Update `e2e/package.json` with your dependencies (Playwright, Cypress, etc.).
+2. Configure `e2e/playwright.config.ts` (or equivalent) with your base URL, projects, web server, and auth setup.
+3. Replace `e2e/tests/baseline.spec.ts` with real regression specs.
+4. Update the workflow steps in `.github/workflows/e2e-regression.yml` if your test runner differs (e.g. different install commands, environment variables, artifact uploads).
+
+You may also:
+- Add the `E2E regression (placeholder)` check as a required status check in branch protection rules.
+- Split into multiple workflow files for different test suites (each gated on `ready-for-regression`).
+- Add environment variables or secrets for test infrastructure.
+
+---
+
+## Scope
+
+The `ready-for-regression` label is applied only to implementation PRs (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`). Spec and plan PRs skip regression testing.
+
+---
+
+## Notes
+
+- The label persists on the PR after e2e tests pass. It is not removed.
+- This workflow does not store test credentials or environment URLs in the template.
+- For projects without e2e tests, the baseline test keeps the check green. Alternatively, remove the workflow file and do not configure the check as required — the orchestrator will still apply the label but the CI loop will not block on a missing check.

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -397,8 +397,8 @@ When a human requests changes on a PR:
 3. Address the feedback
 4. Push fixes
 5. Run Step 7
-5b. Run Step 7b (implementation PRs only)
-6. Run Step 8
-7. Reapply `ready-for-human-review` only when both loops are clean again
+6. Run Step 7b (implementation PRs only)
+7. Run Step 8
+8. Reapply `ready-for-human-review` only when both loops are clean again
 
 See `92-pr-readiness-signal-protocol.md` for label definitions.

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -360,7 +360,7 @@ gh pr edit <pr_number> --add-label "ready-for-regression"
 
 This label triggers the `e2e-regression.yml` workflow (or project-specific equivalents). Step 8's CI loop (`pr-ci-loop.sh`) will then naturally pick up the e2e check as part of its green/red polling via `statusCheckRollup`.
 
-If the PR already has the `ready-for-regression` label (e.g. from a previous cycle where Step 7 was re-run after fixes), skip the label application — the `synchronize` event from the latest push will have already re-triggered the workflow.
+The `gh pr edit --add-label` command is idempotent — applying a label that already exists is a no-op. When the label is already present from a previous cycle, the `synchronize` event from the latest push will have already re-triggered the workflow.
 
 Skip this step entirely for spec and plan PRs.
 

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -155,7 +155,7 @@ Run the next deterministic action for the selected item, then immediately re-eva
 
 Expected chain:
 
-`creator -> draft PR opened -> internal review gate (Step 7a) -> gh pr ready -> automated reviewer loop (Step 7) -> CI loop (Step 8) -> readiness label / tracker status -> wait or escalation`
+`creator -> draft PR opened -> internal review gate (Step 7a) -> gh pr ready -> automated reviewer loop (Step 7) -> regression label (Step 7b, implementation PRs only) -> CI loop (Step 8) -> readiness label / tracker status -> wait or escalation`
 
 After any subagent finishes, determine whether the item still has a deterministic next action:
 
@@ -346,9 +346,31 @@ Soft suggestions may be reported in summaries, but they do not change the loop r
 
 ---
 
+## Step 7b: Regression Label (Implementation PRs Only)
+
+After Step 7 completes with result `clean` or `skipped`, and **before** entering Step 8, apply the `ready-for-regression` label on implementation PRs to trigger label-gated e2e/regression CI checks.
+
+**Applies to**: PRs on branches `feature/*`, `fix/*`, `hotfix/*`, `refactor/*`
+**Does not apply to**: PRs on branches `spec/*`, `implementation-plan/*`
+
+```bash
+# Only for implementation PRs:
+gh pr edit <pr_number> --add-label "ready-for-regression"
+```
+
+This label triggers the `e2e-regression.yml` workflow (or project-specific equivalents). Step 8's CI loop (`pr-ci-loop.sh`) will then naturally pick up the e2e check as part of its green/red polling via `statusCheckRollup`.
+
+If the PR already has the `ready-for-regression` label (e.g. from a previous cycle where Step 7 was re-run after fixes), skip the label application — the `synchronize` event from the latest push will have already re-triggered the workflow.
+
+Skip this step entirely for spec and plan PRs.
+
+See [`integrations/e2e-regression.md`](../integrations/e2e-regression.md) for the full integration guide, including downstream customization.
+
+---
+
 ## Step 8: CI Loop
 
-**Only after Step 7 has completed** with result `clean` or `skipped`, wait for required checks to settle.
+**Only after Step 7 (and Step 7b for implementation PRs) has completed**, wait for required checks to settle.
 
 Prefer the helper script:
 

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -312,8 +312,8 @@ Interpret the result as follows:
 
 | Result | Action |
 |---|---|
-| `clean` | Continue immediately to Step 8 |
-| `skipped` | Continue immediately to Step 8 |
+| `clean` | Continue to Step 7b (implementation PRs) then Step 8 |
+| `skipped` | Continue to Step 7b (implementation PRs) then Step 8 |
 | `needs_fixes` and `cycle < max_cycles` | Increment `cycle`, dispatch the matching fixer agent, wait for a push, then run Step 7 again |
 | `needs_fixes` and `cycle >= max_cycles` | Escalate to human |
 | `escalate` | Escalate to human |
@@ -397,6 +397,7 @@ When a human requests changes on a PR:
 3. Address the feedback
 4. Push fixes
 5. Run Step 7
+5b. Run Step 7b (implementation PRs only)
 6. Run Step 8
 7. Reapply `ready-for-human-review` only when both loops are clean again
 

--- a/docs/ai/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/ai/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -12,6 +12,7 @@ This is a **repo-wide definition**. All agents apply these labels consistently.
 | --- | --- |
 | `ready-for-human-review` | The PR is ready for a human reviewer. CI is green. The `REVIEW.md` gate is satisfied. Every configured automated reviewer is clean or skipped. |
 | `needs-fixes` | The PR still needs fixes before it is ready for human review. This may be due to human-requested changes, failing CI, or blocking automated PR feedback. |
+| `ready-for-regression` | Automated code reviews are clean (or skipped). E2e/regression tests should now run. Applied automatically by the orchestrator (Step 7b) on implementation PRs only (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`). |
 
 ---
 
@@ -36,6 +37,20 @@ Apply this label when **any** of the following is true:
 
 ---
 
+## Conditions for `ready-for-regression`
+
+Apply this label when **all** of the following are true:
+
+- [ ] The PR is an implementation PR (branch prefix `feature/*`, `fix/*`, `hotfix/*`, or `refactor/*`)
+- [ ] Step 7a (internal review gate) previously produced `APPROVED`
+- [ ] Step 7 (automated reviewer loop) has completed with `clean` or `skipped`
+
+This label is **not removed** after e2e tests pass — it persists on the PR. The `ready-for-human-review` label is what ultimately signals human readiness after CI (including e2e) is green.
+
+This label is **not applied** to spec or plan PRs (`spec/*`, `implementation-plan/*`).
+
+---
+
 ## Workflow
 
 ### Work Item Runner advances a draft PR
@@ -50,6 +65,7 @@ Apply this label when **any** of the following is true:
    - Once the internal review gate is clean, run `gh pr ready <pr-number>` to convert the draft to non-draft
 4. Run `./scripts/development-workflow/pr-review-loop.sh <pr-number> --branch <branch> [--platform <platform> ...]` when automated review tooling is configured
 5. If any automated reviewer reports blocking PR feedback: apply fixes, push, and repeat Step 4
+5b. For implementation PRs only: apply `ready-for-regression` label to trigger e2e/regression CI checks
 6. Run `./scripts/development-workflow/pr-ci-loop.sh <pr-number>`
 7. If CI passes and all reviews are clean (or not configured): apply `ready-for-human-review` (the PR is already non-draft from Step 3) and move the tracker status to the matching human-review stage (`Spec in Review`, `Plan in Review`, or `Development in Review`) when the tracker is the source of truth
 8. If CI fails: apply `needs-fixes`, fix PR feedback or failing checks, push, and return to Step 4

--- a/docs/ai/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/ai/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -65,10 +65,10 @@ This label is **not applied** to spec or plan PRs (`spec/*`, `implementation-pla
    - Once the internal review gate is clean, run `gh pr ready <pr-number>` to convert the draft to non-draft
 4. Run `./scripts/development-workflow/pr-review-loop.sh <pr-number> --branch <branch> [--platform <platform> ...]` when automated review tooling is configured
 5. If any automated reviewer reports blocking PR feedback: apply fixes, push, and repeat Step 4
-5b. For implementation PRs only: apply `ready-for-regression` label to trigger e2e/regression CI checks
-6. Run `./scripts/development-workflow/pr-ci-loop.sh <pr-number>`
-7. If CI passes and all reviews are clean (or not configured): apply `ready-for-human-review` (the PR is already non-draft from Step 3) and move the tracker status to the matching human-review stage (`Spec in Review`, `Plan in Review`, or `Development in Review`) when the tracker is the source of truth
-8. If CI fails: apply `needs-fixes`, fix PR feedback or failing checks, push, and return to Step 4
+6. For implementation PRs only: apply `ready-for-regression` label to trigger e2e/regression CI checks
+7. Run `./scripts/development-workflow/pr-ci-loop.sh <pr-number>`
+8. If CI passes and all reviews are clean (or not configured): apply `ready-for-human-review` (the PR is already non-draft from Step 3) and move the tracker status to the matching human-review stage (`Spec in Review`, `Plan in Review`, or `Development in Review`) when the tracker is the source of truth
+9. If CI fails: apply `needs-fixes`, fix PR feedback or failing checks, push, and return to Step 4
 
 ### Human requests changes
 

--- a/docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -63,7 +63,7 @@ If unresolved findings exist: dispatch a fixer agent, wait for the push, then pr
 
 Execute **Step 7a: Internal Review Gate**, **Step 7: Automated Reviewer Loop**, and **Step 8: CI Loop** exactly as defined in `91-orchestrate-work-protocol.md` (scripts, result interpretation, sequential platform policy, fixer mapping, parameters, and labels). Do not duplicate that logic here — follow 91.
 
-For each PR: run Step 7a first (the stage-appropriate internal review gate). Once Step 7a produces `APPROVED`, run `gh pr ready <pr_number>` to convert the draft PR to non-draft, then run Step 7 to completion, then Step 8. Dispatch fixers and re-run as specified in 91 until the PR is clean and ready for human review or escalated. After Step 8 returns `green`, apply `ready-for-human-review` (the PR is already non-draft from the step after 7a).
+For each PR: run Step 7a first (the stage-appropriate internal review gate). Once Step 7a produces `APPROVED`, run `gh pr ready <pr_number>` to convert the draft PR to non-draft, then run Step 7 to completion, then Step 7b (regression label, implementation PRs only), then Step 8. Dispatch fixers and re-run as specified in 91 until the PR is clean and ready for human review or escalated. After Step 8 returns `green`, apply `ready-for-human-review` (the PR is already non-draft from the step after 7a).
 
 ### PR feedback tracking and comments
 

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+test-results/
+playwright-report/
+blob-report/

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.50.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "e2e",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0"
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,5 +1,6 @@
 {
   "name": "e2e",
+  "description": "",
   "private": true,
   "scripts": {
     "test": "playwright test"

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  retries: 0,
+  reporter: 'list',
+  use: {
+    trace: 'on-first-retry',
+  },
+});

--- a/e2e/tests/baseline.spec.ts
+++ b/e2e/tests/baseline.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+// Template placeholder: this test ensures the e2e pipeline stays green.
+// Downstream projects should replace this file with real e2e/regression specs.
+
+test('baseline placeholder', () => {
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
## Summary

- Adds a `ready-for-regression` label gate (Step 7b) between automated review (Step 7) and CI (Step 8) so expensive e2e tests only run after all reviewer gates are clean
- Ships a Playwright-based placeholder project in `e2e/` with one always-passing baseline test
- Label-gated GitHub Actions workflow (`.github/workflows/e2e-regression.yml`) triggers only when `ready-for-regression` is present on implementation PRs

## Test plan

- [ ] Verify `e2e-regression.yml` workflow does NOT run without the label
- [ ] Apply `ready-for-regression` label manually — confirm workflow triggers and baseline test passes
- [ ] Push a new commit with label present — confirm workflow re-triggers on `synchronize`
- [ ] Validate protocol docs (91, 92, 93) correctly describe Step 7b flow

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
