### PR TITLE
feat(workflow): add backlog item command and protocol (#74)

### DIFF
--- a/.claude/commands/add-backlog-item.md
+++ b/.claude/commands/add-backlog-item.md
@@ -1,0 +1,20 @@
+---
+description: Backlog stage. Creates one backlog work item from natural-language input with tracker destination detection and clarifying questions when needed. Usage: /add-backlog-item [optional brief description]
+---
+
+# Claude Code Command: Add Backlog Item
+
+Follow the backlog-item protocol exactly as defined in:
+
+`docs/ai/development-workflow/protocols/00-add-backlog-item-protocol.md`
+
+Key responsibilities:
+
+- Read `issue_tracker.provider` from `.ai-dev-workflow.yaml` (or run `./scripts/development-workflow/add-backlog-item.sh resolve` for machine-readable destination hints).
+- If destination is unclear, contradictory, or unsupported without MCP/API access, ask clarifying questions **before** creating anything.
+- If the user request is missing title, problem/outcome, or other essential context, ask **targeted** clarifying questions before creating anything.
+- Create **exactly one** backlog item in the confirmed destination.
+- For GitHub Issues (including when the provider is `github_projects`), prefer `./scripts/development-workflow/add-backlog-item.sh create --title "..." --body-file -` when `gh` is authenticated; otherwise follow the protocol manually.
+- For Linear, use Linear MCP/API per `docs/ai/development-workflow/integrations/linear.md` when the shell helper cannot create the item.
+- Do not silently assume a tracker or duplicate items across clarification turns.
+- Return the created item identifier, URL, and a short recap to the user.

--- a/.cursor/commands/add-backlog-item.md
+++ b/.cursor/commands/add-backlog-item.md
@@ -1,0 +1,18 @@
+---
+description: Backlog stage. Creates one backlog work item from natural-language input with tracker destination detection and clarifying questions when needed. Usage: /add-backlog-item [optional brief description]
+---
+
+Follow the backlog-item protocol exactly as defined in:
+
+`docs/ai/development-workflow/protocols/00-add-backlog-item-protocol.md`
+
+Key responsibilities:
+
+- Read `issue_tracker.provider` from `.ai-dev-workflow.yaml` (or run `./scripts/development-workflow/add-backlog-item.sh resolve` for machine-readable destination hints).
+- If destination is unclear, contradictory, or unsupported without MCP/API access, ask clarifying questions **before** creating anything.
+- If the user request is missing title, problem/outcome, or other essential context, ask **targeted** clarifying questions before creating anything.
+- Create **exactly one** backlog item in the confirmed destination.
+- For GitHub Issues (including when the provider is `github_projects`), prefer `./scripts/development-workflow/add-backlog-item.sh create --title "..." --body-file -` when `gh` is authenticated; otherwise follow the protocol manually.
+- For Linear, use Linear MCP/API per `docs/ai/development-workflow/integrations/linear.md` when the shell helper cannot create the item.
+- Do not silently assume a tracker or duplicate items across clarification turns.
+- Return the created item identifier, URL, and a short recap to the user.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Always refer to these docs for authoritative guidance:
 | [`docs/best-practices/STACK-SPECIFIC.md`](docs/best-practices/STACK-SPECIFIC.md) | Stack-specific conventions |
 | [`REVIEW.md`](REVIEW.md) | Canonical review contract for spec, plan, and code review gates |
 | [`docs/ai/development-workflow/README.md`](docs/ai/development-workflow/README.md) | AI development workflow (master doc) |
+| [`docs/ai/development-workflow/protocols/00-add-backlog-item-protocol.md`](docs/ai/development-workflow/protocols/00-add-backlog-item-protocol.md) | Create backlog work items in a configured tracker (before spec/plan work) |
 | [`docs/ai/development-workflow/agent-model-config.md`](docs/ai/development-workflow/agent-model-config.md) | Model assignments, tool restrictions, and override guide for all agents |
 | [`.ai-dev-workflow.yaml`](.ai-dev-workflow.yaml) | Repo-level workflow integration manifest (review tools, issue tracker, VCS, browser automation) |
 
@@ -56,6 +57,7 @@ Repository-specific workflow providers are declared in [`.ai-dev-workflow.yaml`]
 | Stage | Claude Code | Cursor | Codex | Any other tool |
 |---|---|---|---|---|
 | Project Setup | `project-setup` agent | `/setup-project` | `workflow-project-setup` skill | Follow `docs/ai/setup/protocol.md` |
+| Add backlog item | `/add-backlog-item` | `/add-backlog-item` | — | Follow `docs/ai/development-workflow/protocols/00-add-backlog-item-protocol.md` |
 | Write Spec | `product-manager` agent | `/generate-new-feature` | `workflow-spec-writer` skill | Follow `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md` |
 | Write Plan | `tech-lead` agent | `/generate-implementation-plan` | `workflow-plan-writer` skill | Follow `docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md` |
 | Implement | `developer` agent | `/implement-development` | `workflow-implementer` skill | Follow `docs/ai/development-workflow/protocols/03-implement-development-protocol.md` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Backlog intake: protocol `docs/ai/development-workflow/protocols/00-add-backlog-item-protocol.md`, Cursor and Claude `/add-backlog-item` commands, and `scripts/development-workflow/add-backlog-item.sh` (`resolve` / `create` for GitHub when configured). Extends `workflow-lib.sh` with issue-tracker destination helpers.
 - Label-gated e2e/regression test workflow: `.github/workflows/e2e-regression.yml` triggers on implementation PRs when `ready-for-regression` label is present; ships with a Playwright-based `e2e/` placeholder project (one always-passing baseline test) for downstream projects to customize.
 - E2e/regression integration guide: `docs/ai/development-workflow/integrations/e2e-regression.md` documents the label-gate pattern, workflow placement between Step 7 and Step 8, and downstream customization.
 - `ready-for-regression` label and Step 7b: applied automatically by the orchestrator on implementation PRs after automated review is clean, gating expensive e2e tests until the PR is reviewer-ready. Documented in protocol 92 (PR readiness signal) and protocol 91 (orchestrate work).

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The setup agent will have a structured conversation with you to understand your 
 │
 ├── scripts/
 │   ├── development-workflow/            # AI workflow helpers (orchestrator, PR/CI loops, state discovery)
+│   │   ├── add-backlog-item.sh          # Resolves tracker destination; creates GitHub issues when configured
 │   │   ├── discover-workflow-state.sh   # Summarizes branches, worktrees, development folders, and open PRs
 │   │   ├── check-workflow-branch.sh     # Checks whether a workflow branch already exists
 │   │   ├── pr-review-loop.sh      # Polls Greptile PR review until clean / fix / escalate
@@ -295,6 +296,7 @@ Framework-level paths to propagate:
 - `.cursor/agents/`
 - `.cursor/commands/`
 - `scripts/development-workflow/install-codex-skills.sh`
+- `scripts/development-workflow/add-backlog-item.sh`
 - `scripts/development-workflow/discover-workflow-state.sh`
 - `scripts/development-workflow/check-workflow-branch.sh`
 - `docs/best-practices/1-general.md`

--- a/docs/ai/development-workflow/README.md
+++ b/docs/ai/development-workflow/README.md
@@ -193,6 +193,7 @@ The sections below keep this document usable as a master reference after the nar
 
 | Stage | Claude Code | Cursor | Codex | Any AI tool |
 | --- | --- | --- | --- | --- |
+| Add backlog item | `/add-backlog-item` | `/add-backlog-item` | — | `docs/ai/development-workflow/protocols/00-add-backlog-item-protocol.md` |
 | Write spec | `product-manager` agent | `/generate-new-feature` | `workflow-spec-writer` skill | `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md` |
 | Write plan | `tech-lead` agent | `/generate-implementation-plan` | `workflow-plan-writer` skill | `docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md` |
 | Implement | `developer` agent | `/implement-development` | `workflow-implementer` skill | `docs/ai/development-workflow/protocols/03-implement-development-protocol.md` |
@@ -424,12 +425,14 @@ Use these documents when you need the detailed rules behind a part of the workfl
 Protocol prefixes are stable family identifiers, not a promise of contiguous numbering.
 
 - `01`-`05` are the current primary stage families in workflow order.
+- `00` is reserved for pre-stage backlog intake (creating tracker work items before spec work).
 - Generate and review protocols for the same stage share the same family number.
 - `90`-`99` are orchestration, readiness, and other cross-cutting operational protocols.
 - The numbering was normalized after an older stage was removed, so the current primary stages are contiguous again.
 
 ### Core Protocols
 
+- `docs/ai/development-workflow/protocols/00-add-backlog-item-protocol.md`
 - `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md`
 - `docs/ai/development-workflow/protocols/01-review-spec-protocol.md`
 - `docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md`
@@ -454,6 +457,7 @@ Protocol prefixes are stable family identifiers, not a promise of contiguous num
 
 Repository helpers:
 
+- `scripts/development-workflow/add-backlog-item.sh`
 - `scripts/development-workflow/discover-workflow-state.sh`
 - `scripts/development-workflow/workflow-batch-plan.sh`
 - `scripts/development-workflow/workflow-next-action.sh`

--- a/docs/ai/development-workflow/protocols/00-add-backlog-item-protocol.md
+++ b/docs/ai/development-workflow/protocols/00-add-backlog-item-protocol.md
@@ -1,0 +1,86 @@
+# Protocol: Add Backlog Item
+
+**Agent role**: Any launcher or orchestrator entrypoint (often invoked via `/add-backlog-item` in Cursor or the matching Claude command)
+
+**Purpose**: Create exactly one backlog work item from natural-language input, choose the correct tracker destination when possible, and ask clarifying questions when destination or intent is ambiguous.
+
+This protocol runs **before** spec/plan/implementation stages. It does not write repository development artifacts under `docs/specs/developments/`.
+
+---
+
+## Prerequisites
+
+Before creating anything, read:
+
+- [`docs/ai/development-workflow/integrations/issue-tracker.md`](../integrations/issue-tracker.md) — tracker-agnostic rules (do not guess; ask when unclear).
+- [`.ai-dev-workflow.yaml`](../../../../.ai-dev-workflow.yaml) — `issue_tracker.provider` declares the configured tracker integration.
+- Tracker-specific guides as needed:
+  - [`docs/ai/development-workflow/integrations/linear.md`](../integrations/linear.md)
+  - [`docs/ai/development-workflow/integrations/github-projects.md`](../integrations/github-projects.md)
+
+Optional deterministic helper (destination resolution and GitHub issue creation):
+
+```bash
+./scripts/development-workflow/add-backlog-item.sh resolve
+./scripts/development-workflow/add-backlog-item.sh create --title "..." --body-file -
+```
+
+---
+
+## Step 1: Resolve destination (no silent assumptions)
+
+1. Read `issue_tracker.provider` from `.ai-dev-workflow.yaml` (or run `add-backlog-item.sh resolve` for machine-readable output).
+2. Map provider to destination **kind**:
+   - `github_issues` or `github_projects` → GitHub Issues (issues are the work items; GitHub Projects layers fields on top of issues — see `github-projects.md`).
+   - `linear` → Linear work items.
+   - `jira`, `clickup`, `notion`, or other values → use the matching integration guide if present; if none exists, **stop and ask** the human where to create the item.
+3. If the provider is missing, empty, `none`, or **ambiguous** (multiple plausible destinations, or config contradicts what the user asked for), **ask clarifying questions** and do **not** create an item until the human confirms the destination.
+4. If tracker APIs/MCP are unavailable (e.g. Linear MCP not configured), **warn explicitly** (same spirit as protocols `90` / `91`: do not silently assume). Offer: paste tracker details, fix MCP/`gh` auth, or confirm a one-off destination.
+
+---
+
+## Step 2: Clarify the request (intent)
+
+Before creating the work item, ensure you have enough signal. Minimum:
+
+- **Title** (or a clear one-line summary you can turn into a title).
+- **Problem / outcome** — what should change and why it matters.
+- **Type / path hint** (when relevant): Full Pipeline (feature), Refactor, Fast Track, or bug — only if the team uses these distinctions in the tracker.
+
+If any of the above are missing or contradictory, ask **targeted** clarifying questions. Do **not** create duplicate items across clarification turns: one creation per successful completion of this protocol.
+
+---
+
+## Step 3: Create exactly one backlog item
+
+1. Create **one** item in the **confirmed** destination.
+2. For **GitHub Issues** (including when `issue_tracker.provider` is `github_projects`), prefer:
+   - `./scripts/development-workflow/add-backlog-item.sh create --title "..." --body-file -` (requires `gh` authenticated), **or**
+   - Equivalent `gh issue create` with the same title/body.
+3. For **Linear**, use the Linear API/MCP per [`linear.md`](../integrations/linear.md). The `add-backlog-item.sh create` command exits with a non-success code for Linear when the shell helper cannot perform the operation — follow the protocol manually instead of failing silently.
+4. For **GitHub Projects** after the issue exists: if the team uses a project board, add/update the project item per `github-projects.md` (optional field updates such as Status = Backlog) **only when** the human or repo docs supply enough context (project number, owner). If project context is missing, **ask** rather than guessing.
+
+---
+
+## Step 4: Confirm to the user
+
+Return a short confirmation including:
+
+- **Destination** (e.g. GitHub issue vs Linear issue).
+- **Identifier** (e.g. issue number, Linear key).
+- **URL** to the item.
+- **Title** and one-line recap of scope.
+
+---
+
+## Non-goals
+
+- Do not silently pick a tracker when uncertain.
+- Do not create multiple items for one user request.
+- Do not start spec/plan/implementation work unless the user explicitly asks to advance stages afterward.
+
+---
+
+## Relationship to other protocols
+
+- Advancing from **Backlog** into **Writing Spec** / **Writing Plan** is owned by orchestration protocols [`90-batch-orchestrate-work-protocol.md`](90-batch-orchestrate-work-protocol.md) and [`91-orchestrate-work-protocol.md`](91-orchestrate-work-protocol.md) once a work item exists and is selected.

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -16,6 +16,29 @@ Use this when:
 - You want to make the template's bundled Codex skills available in your local Codex environment
 - You are testing the workflow skills in a downstream repository created from this template
 
+### `add-backlog-item.sh`
+
+Resolves the configured issue tracker destination for backlog creation and can create a GitHub issue when `issue_tracker.provider` maps to GitHub Issues / GitHub Projects.
+
+Usage:
+
+```bash
+./scripts/development-workflow/add-backlog-item.sh resolve
+./scripts/development-workflow/add-backlog-item.sh create --title "Title" --body "Body"
+./scripts/development-workflow/add-backlog-item.sh create --title "Title" --body-file path/to/body.md
+```
+
+What it does:
+
+- `resolve` prints `ISSUE_TRACKER_PROVIDER`, `DESTINATION_KIND` (`github`, `linear`, `other`, `none`), and a `CREATE_VIA` hint for agents.
+- `create` runs `gh issue create` when the destination kind is `github` (requires authenticated `gh`).
+- For Linear or unsupported providers, exits non-zero with guidance so agents follow `docs/ai/development-workflow/protocols/00-add-backlog-item-protocol.md` instead of guessing.
+
+Use this when:
+
+- An agent needs a deterministic destination check before creating a backlog item.
+- You want to create a GitHub issue from a shell environment without manual `gh` typing.
+
 ### `discover-workflow-state.sh`
 
 Prints a compact snapshot of the repository's workflow-related state.

--- a/scripts/development-workflow/add-backlog-item.sh
+++ b/scripts/development-workflow/add-backlog-item.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
+# shellcheck source=scripts/development-workflow/workflow-lib.sh
+source "$SCRIPT_DIR/workflow-lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  add-backlog-item.sh resolve
+  add-backlog-item.sh create --title <title> (--body <text> | --body-file <path>) [--label <name>] ...
+
+resolve
+  Prints machine-readable lines:
+    ISSUE_TRACKER_PROVIDER=<raw or empty>
+    DESTINATION_KIND=github|linear|other|none
+    CREATE_VIA=<hint for agents>
+
+create
+  When DESTINATION_KIND is github, creates one GitHub issue via gh (requires gh auth).
+  For linear, other, or none, exits non-zero with guidance (agents follow 00-add-backlog-item-protocol.md).
+EOF
+}
+
+resolve_cmd() {
+  cd_workflow_repo_root
+  local raw kind
+  raw="$(workflow_issue_tracker_provider_raw)"
+  kind="$(workflow_backlog_destination_kind)"
+  print_kv ISSUE_TRACKER_PROVIDER "${raw:-}"
+  print_kv DESTINATION_KIND "$kind"
+  case "$kind" in
+    github) print_kv CREATE_VIA "gh_issue_create" ;;
+    linear) print_kv CREATE_VIA "linear_mcp_or_api" ;;
+    other) print_kv CREATE_VIA "manual_or_tracker_specific_mcp" ;;
+    none) print_kv CREATE_VIA "configure_issue_tracker_or_ask_human" ;;
+  esac
+}
+
+create_cmd() {
+  cd_workflow_repo_root
+  local title="" body="" body_file="" labels=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --title)
+        title="${2:-}"
+        shift 2
+        ;;
+      --body)
+        body="${2:-}"
+        shift 2
+        ;;
+      --body-file)
+        body_file="${2:-}"
+        shift 2
+        ;;
+      --label)
+        labels+=("${2:-}")
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "Unknown argument: $1" >&2
+        usage >&2
+        exit 2
+        ;;
+    esac
+  done
+
+  local kind
+  kind="$(workflow_backlog_destination_kind)"
+
+  if [ "$kind" = "github" ]; then
+    require_gh
+    if [ -z "$title" ]; then
+      echo "create: --title is required" >&2
+      exit 2
+    fi
+    if [ -n "$body_file" ]; then
+      body="$(cat -- "$body_file")"
+    fi
+    local -a gh_args=(issue create --title "$title")
+    if [ -n "$body" ]; then
+      gh_args+=(--body "$body")
+    fi
+    local label
+    for label in "${labels[@]}"; do
+      [ -n "$label" ] || continue
+      gh_args+=(--label "$label")
+    done
+    gh "${gh_args[@]}"
+    return 0
+  fi
+
+  if [ "$kind" = "linear" ]; then
+    echo "add-backlog-item: Linear backlog creation is not performed by this script. Use Linear MCP/API per docs/ai/development-workflow/integrations/linear.md" >&2
+    exit 2
+  fi
+
+  if [ "$kind" = "none" ]; then
+    echo "add-backlog-item: issue_tracker.provider is unset or none. Configure .ai-dev-workflow.yaml or ask the human where to create the item (see docs/ai/development-workflow/protocols/00-add-backlog-item-protocol.md)" >&2
+    exit 3
+  fi
+
+  echo "add-backlog-item: issue_tracker.provider is not supported for automatic creation by this script. Create the item in the configured tracker manually or via MCP." >&2
+  exit 4
+}
+
+main() {
+  case "${1:-}" in
+    resolve)
+      resolve_cmd
+      ;;
+    create)
+      shift
+      create_cmd "$@"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -210,3 +210,38 @@ workflow_config_provider() {
     }
   ' "$config_file"
 }
+
+workflow_issue_tracker_provider_raw() {
+  workflow_config_provider issue_tracker
+}
+
+workflow_normalize_issue_tracker_provider() {
+  local raw="$1"
+  printf '%s' "$raw" | tr '[:upper:]' '[:lower:]'
+}
+
+# Prints a coarse destination bucket for backlog creation: github | linear | other | none
+# none: missing provider, none, or empty string
+workflow_backlog_destination_kind() {
+  local raw normalized
+  raw="$(workflow_issue_tracker_provider_raw)"
+  normalized="$(workflow_normalize_issue_tracker_provider "$raw")"
+  if [ -z "$normalized" ] && [ -z "$raw" ]; then
+    printf 'none\n'
+    return 0
+  fi
+  case "$normalized" in
+    ''|'none')
+      printf 'none\n'
+      ;;
+    linear)
+      printf 'linear\n'
+      ;;
+    github_issues|github-issues|github_projects|github-projects)
+      printf 'github\n'
+      ;;
+    *)
+      printf 'other\n'
+      ;;
+  esac
+}


### PR DESCRIPTION
## Summary
Implements #74: backlog intake via `/add-backlog-item` (Cursor + Claude), protocol `00-add-backlog-item-protocol.md`, and `add-backlog-item.sh` for destination resolution and GitHub issue creation when configured.

## Changes
- Protocol and command wrappers aligned with `.ai-dev-workflow.yaml` `issue_tracker.provider`
- `workflow-lib.sh`: destination helpers; `add-backlog-item.sh resolve|create`
- Docs: AGENTS, workflow README, scripts README, root README, CHANGELOG

## How to test
- `./scripts/development-workflow/add-backlog-item.sh resolve`
- With authenticated `gh` and GitHub tracker: `add-backlog-item.sh create --title "..." --body "..."`

Closes #74 when merged.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
