### PR TITLE
docs(workflow): release PR reviewer loop + regression on main (#77)

### DIFF
--- a/.claude/commands/prepare-release.md
+++ b/.claude/commands/prepare-release.md
@@ -1,6 +1,6 @@
 ---
-description: Prepare a release from develop. Creates the release branch, updates CHANGELOG, bumps version, and opens PRs targeting both main and develop. Usage: /prepare-release [version number, e.g. 1.2.0]
-allowed-tools: Bash(git checkout:*), Bash(git pull:*), Bash(git push:*), Bash(git log:*), Bash(git status:*), Bash(git branch:*), Bash(git diff:*), Bash(gh pr create:*), Bash(gh pr view:*), Bash(date:*)
+description: Prepare a release from develop. Creates the release branch, updates CHANGELOG, bumps version, opens PRs to main and develop, then drives reviewer loop + ready-for-regression + CI on the main PR before human merge. Usage: /prepare-release [version number, e.g. 1.2.0]
+allowed-tools: Bash(git checkout:*), Bash(git pull:*), Bash(git push:*), Bash(git log:*), Bash(git status:*), Bash(git branch:*), Bash(git diff:*), Bash(gh pr create:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(gh pr edit:*), Bash(gh pr comment:*), Bash(gh api:*), Bash(date:*), Bash(./scripts/development-workflow/pr-review-loop.sh:*), Bash(./scripts/development-workflow/pr-ci-loop.sh:*)
 ---
 
 Follow the release protocol exactly as defined in:
@@ -8,9 +8,11 @@ Follow the release protocol exactly as defined in:
 `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md`
 
 Key rules:
+
 - Verify working directory is clean and currently on `develop` before starting
 - If no version provided, inspect `[Unreleased]` entries and suggest the next version
 - Confirm the version with the human before creating the branch
 - Open **two** PRs: one to `main`, one backport to `develop`
+- **After both PRs exist**, run the automated reviewer loop, apply `ready-for-regression`, and run the CI loop on the **production PR targeting `main` only** — do not stop at “PR opened” (use `scripts/development-workflow/pr-review-loop.sh` and `pr-ci-loop.sh` per protocol)
 - Merge `main` PR first; the tag is created automatically by CI
 - Do not delete the release branch until both PRs are merged

--- a/.cursor/commands/prepare-release.md
+++ b/.cursor/commands/prepare-release.md
@@ -1,5 +1,5 @@
 ---
-description: Prepare a release from develop. Creates the release branch, updates CHANGELOG, bumps version, and opens PRs targeting both main and develop. Usage: /prepare-release [version number, e.g. 1.2.0]
+description: Prepare a release from develop. Creates the release branch, updates CHANGELOG, bumps version, opens PRs to main and develop, then drives reviewer loop + ready-for-regression + CI on the main PR before human merge. Usage: /prepare-release [version number, e.g. 1.2.0]
 ---
 
 Follow the release protocol exactly as defined in:
@@ -7,9 +7,11 @@ Follow the release protocol exactly as defined in:
 `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md`
 
 Key rules:
+
 - Verify working directory is clean and currently on `develop` before starting
 - If no version provided, inspect `[Unreleased]` entries and suggest the next version
 - Confirm the version with the human before creating the branch
 - Open **two** PRs: one to `main`, one backport to `develop`
+- **After both PRs exist**, run the automated reviewer loop, apply `ready-for-regression`, and run the CI loop on the **production PR targeting `main` only** — do not stop at “PR opened” (use `scripts/development-workflow/pr-review-loop.sh` and `pr-ci-loop.sh` per protocol)
 - Merge `main` PR first; the tag is created automatically by CI
 - Do not delete the release branch until both PRs are merged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,8 @@ Repository-specific workflow providers are declared in [`.ai-dev-workflow.yaml`]
 | Prepare Release | `/prepare-release` | `/prepare-release` | Follow `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md` | Follow `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md` |
 | Orchestrate Work | `orchestrator` agent | `/run-work` | `workflow-orchestrator` skill | Follow `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` |
 
+**Prepare release** does not stop after opening PRs: protocol `05` requires running the automated reviewer loop, applying `ready-for-regression` on the **production PR to `main`**, and completing the CI loop (including label-gated e2e/regression when configured) before handoff to merge.
+
 ### Codex Skills
 
 The repository ships Codex skill definitions in `.codex/skills/`. Install them into your local Codex skill directory before first use:
@@ -130,7 +132,7 @@ This repository follows the default template workflow (documented in `docs/ai/de
 - Follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 - Use [Semantic Versioning](https://semver.org/): patch for fixes/tweaks, minor for new features or meaningful improvements, major for breaking changes to the template structure.
 - **Feature and fix PRs** merged into `develop` add entries under `[Unreleased]` in `CHANGELOG.md`; do not convert to a version number on merge. Spec-only and plan-only PRs are exempt. Fixes or changes to unreleased work should update the existing entry rather than adding a new one.
-- **A new version is created only when releasing**: run the Prepare Release workflow (`/prepare-release` or `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md`). That creates a `release/v[X.Y.Z]` branch, renames `[Unreleased]` to `[X.Y.Z]` in the CHANGELOG, and opens PRs to `main` and backport to `develop`.
+- **A new version is created only when releasing**: run the Prepare Release workflow (`/prepare-release` or `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md`). That creates a `release/v[X.Y.Z]` branch, renames `[Unreleased]` to `[X.Y.Z]` in the CHANGELOG, opens PRs to `main` and backport to `develop`, then drives reviewer + regression + CI readiness on the **main** release PR before merge.
 
 ### Stack Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Prepare release protocol (`05-prepare-release-protocol.md`): after opening release PRs, drive automated reviewer loop, apply `ready-for-regression` on the PR targeting `main`, and run CI (including label-gated e2e/regression) before handoff; `/prepare-release` command docs updated accordingly.
+
 - Backlog intake: protocol `docs/ai/development-workflow/protocols/00-add-backlog-item-protocol.md`, Cursor and Claude `/add-backlog-item` commands, and `scripts/development-workflow/add-backlog-item.sh` (`resolve` / `create` for GitHub when configured). Extends `workflow-lib.sh` with issue-tracker destination helpers.
 - Label-gated e2e/regression test workflow: `.github/workflows/e2e-regression.yml` triggers on implementation PRs when `ready-for-regression` label is present; ships with a Playwright-based `e2e/` placeholder project (one always-passing baseline test) for downstream projects to customize.
 - E2e/regression integration guide: `docs/ai/development-workflow/integrations/e2e-regression.md` documents the label-gate pattern, workflow placement between Step 7 and Step 8, and downstream customization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `92-pr-readiness-signal-protocol.md` and `integrations/e2e-regression.md`: align `ready-for-regression` conditions with production release PRs (`release/*` → `main`) per protocol `05`, removing contradiction with implementation-only wording.
 - CHANGELOG policy: spec-only and plan-only PRs are now exempt from CHANGELOG updates; fixes to unreleased work should update the existing `[Unreleased]` entry instead of adding a new one. Hotfixes always require a new entry since they fix released code.
 - `03-implement-development-protocol.md` (Path 2 Refactor): spell out refactor draft PR metadata and `gh pr create` example instead of reusing Path 1 Step 8 (`feat(...)` / spec link); handoff step references the same Work Item Runner lifecycle and protocols 91/92.
 - `03-implement-development-protocol.md` (Fast Track / Hotfix): draft PR and handoff steps now reference Path 1 Step 8–9 explicitly with `fix(...)` titles and fix- or incident-focused bodies (omit spec/plan when absent); removes the incorrect “Step 8 above” pointer (that step was push, not PR).

--- a/docs/ai/development-workflow/README.md
+++ b/docs/ai/development-workflow/README.md
@@ -204,6 +204,8 @@ The sections below keep this document usable as a master reference after the nar
 | Orchestrate portfolio | `orchestrator` agent | `/run-work` | `workflow-orchestrator` skill | `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` |
 | Prepare release | `/prepare-release` | `/prepare-release` | — | `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md` |
 
+After opening release PRs, protocol `05` runs the automated reviewer loop, applies `ready-for-regression` on the **PR targeting `main`**, and runs the CI loop until checks are green (or escalation) — same persistence contract as other PR readiness work.
+
 Codex skills are stored in `.codex/skills/`. Install them into the local Codex environment with:
 
 ```bash

--- a/docs/ai/development-workflow/integrations/e2e-regression.md
+++ b/docs/ai/development-workflow/integrations/e2e-regression.md
@@ -66,6 +66,8 @@ You may also:
 
 The `ready-for-regression` label is applied only to implementation PRs (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`). Spec and plan PRs skip regression testing.
 
+Release PRs (`release/*` → `main`) also use this label on the **production** PR only, per [`05-prepare-release-protocol.md`](../protocols/05-prepare-release-protocol.md) Step 7.4, so e2e/regression runs before the release merges to `main`.
+
 ---
 
 ## Notes

--- a/docs/ai/development-workflow/integrations/e2e-regression.md
+++ b/docs/ai/development-workflow/integrations/e2e-regression.md
@@ -10,7 +10,7 @@ The workflow triggers on PRs targeting `develop` or `main` when the `ready-for-r
 
 ## How It Fits Into the Workflow
 
-The `ready-for-regression` label is applied by the orchestrator (Step 7b in `91-orchestrate-work-protocol.md`) after the automated reviewer loop (Step 7) is clean, and before the CI loop (Step 8). This means:
+The `ready-for-regression` label is applied by the orchestrator (Step 7b in `91-orchestrate-work-protocol.md`) after the automated reviewer loop (Step 7) is clean, and before the CI loop (Step 8). The prepare-release flow applies the same label on production release PRs per `05-prepare-release-protocol.md` Step 7.4. This means:
 
 1. Step 7a: Internal review gate passes
 2. Step 7: External automated reviewers are clean
@@ -64,9 +64,7 @@ You may also:
 
 ## Scope
 
-The `ready-for-regression` label is applied only to implementation PRs (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`). Spec and plan PRs skip regression testing.
-
-Release PRs (`release/*` → `main`) also use this label on the **production** PR only, per [`05-prepare-release-protocol.md`](../protocols/05-prepare-release-protocol.md) Step 7.4, so e2e/regression runs before the release merges to `main`.
+The `ready-for-regression` label is applied to implementation PRs (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`) and to **production** release PRs (`release/*` → `main`) per [`05-prepare-release-protocol.md`](../protocols/05-prepare-release-protocol.md) Step 7.4, so e2e/regression can run before merge. Spec and plan PRs (`spec/*`, `implementation-plan/*`) skip this label and regression testing.
 
 ---
 

--- a/docs/ai/development-workflow/protocols/05-prepare-release-protocol.md
+++ b/docs/ai/development-workflow/protocols/05-prepare-release-protocol.md
@@ -97,15 +97,83 @@ gh pr create --base main --title "chore(release): v[X.Y.Z]" --body-file /tmp/rel
 gh pr create --base develop --title "chore(release): v[X.Y.Z]" --body-file /tmp/release-notes.md
 ```
 
+Opening PRs is **not** a terminal condition. Continue with Step 7 for the production PR before telling the human the release is ready to merge.
+
 ---
 
-## Step 7: Inform the Human
+## Step 7: Drive Production PR Readiness (`main` Target Only)
 
-After both PRs are open:
+Apply only to the **release PR that targets `main`**. Do **not** apply the regression-label requirement to the backport PR to `develop` (that PR may still run other CI; this step scopes expensive label-gated e2e/regression to production).
 
-1. Merge the `main` PR first — the tag `v[X.Y.Z]` is created automatically by CI on merge (`.github/workflows/auto-tag-release.yml`)
+Canonical loop semantics match [`91-orchestrate-work-protocol.md`](91-orchestrate-work-protocol.md) (Steps 7, 7b, 8) and [`93-automated-reviewer-loop-protocol.md`](93-automated-reviewer-loop-protocol.md) for standalone reviewer runs. Prefer the repository helpers:
+
+```bash
+./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch release/v[X.Y.Z]
+./scripts/development-workflow/pr-ci-loop.sh <pr_number>
+```
+
+### 7.1 Resolve the production PR number
+
+Identify the open PR from `release/v[X.Y.Z]` to `main`, for example:
+
+```bash
+gh pr list --head "release/v[X.Y.Z]" --base main --state open --json number --jq '.[0].number'
+```
+
+If multiple or zero matches, stop and resolve with the human.
+
+### 7.2 Pre-flight (optional but recommended)
+
+Per `93-automated-reviewer-loop-protocol.md`, check for existing unresolved blocking review comments before re-running automation.
+
+### 7.3 Automated reviewer loop (Step 7)
+
+Run `pr-review-loop.sh` to completion **before** starting the CI loop. Do not run reviewer and CI in parallel.
+
+Interpret `RESULT` from the script output:
+
+| Result | Action |
+|---|---|
+| `clean` | Continue to Step 7.4 (regression label). |
+| `skipped` | No review platforms configured in `.ai-dev-workflow.yaml`; continue to Step 7.4 and document that external review was skipped. |
+| `needs_fixes` | Address blocking findings (commit and push to the release branch), then re-run Step 7.3 from the top. Follow fixer guidance in `91` (e.g. `code-reviewer` for code changes). Do not hand off while blocking findings remain. |
+| `escalate` | Stop and escalate to a human; do not mark the release as merge-ready. |
+
+### 7.4 Regression label (release / `main` PR only)
+
+After Step 7.3 ends with `clean` or `skipped`, apply the `ready-for-regression` label to the **production PR only** so label-gated e2e/regression runs (see [`integrations/e2e-regression.md`](../integrations/e2e-regression.md) and `.github/workflows/e2e-regression.yml`).
+
+```bash
+gh pr edit <pr_number> --add-label "ready-for-regression"
+```
+
+This mirrors Step 7b in `91` for implementation PRs, but scoped here to the release PR targeting `main`.
+
+### 7.5 CI loop (Step 8)
+
+Run `pr-ci-loop.sh` and wait until required checks settle (including the e2e/regression check when configured).
+
+| Result | Action |
+|---|---|
+| `green` | Apply `ready-for-human-review` per [`92-pr-readiness-signal-protocol.md`](92-pr-readiness-signal-protocol.md); the production PR is ready for human merge review. |
+| `red` | Apply `needs-fixes`, fix, push, then return to Step 7.3 (reviewer) and repeat through Step 7.5. |
+| `timeout` | Escalate to a human; do not apply `ready-for-human-review`. |
+
+### 7.6 Backport PR (`develop` target)
+
+Do **not** require `ready-for-regression` on the backport PR as part of this protocol. It may proceed on its own CI; merge order remains: **merge `main` first**, then backport.
+
+---
+
+## Step 8: Inform the Human
+
+When the production PR is ready (or clearly escalated):
+
+1. **Merge the `main` PR first** — the tag `v[X.Y.Z]` is created automatically by CI on merge (`.github/workflows/auto-tag-release.yml`)
 2. Then merge the `develop` backport PR
 3. Do not delete the release branch until both PRs are merged
+
+If Step 7 escalated or CI timed out, report status and blockers before merge.
 
 ---
 

--- a/docs/ai/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/ai/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -12,7 +12,7 @@ This is a **repo-wide definition**. All agents apply these labels consistently.
 | --- | --- |
 | `ready-for-human-review` | The PR is ready for a human reviewer. CI is green. The `REVIEW.md` gate is satisfied. Every configured automated reviewer is clean or skipped. |
 | `needs-fixes` | The PR still needs fixes before it is ready for human review. This may be due to human-requested changes, failing CI, or blocking automated PR feedback. |
-| `ready-for-regression` | Automated code reviews are clean (or skipped). E2e/regression tests should now run. Applied automatically by the orchestrator (Step 7b) on implementation PRs only (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`). |
+| `ready-for-regression` | Automated code reviews are clean (or skipped). E2e/regression tests should now run. Applied by the orchestrator (Step 7b) on implementation PRs (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`), and by the prepare-release flow (protocol `05`) on **production** release PRs (`release/*` → `main`) only. |
 
 ---
 
@@ -41,13 +41,22 @@ Apply this label when **any** of the following is true:
 
 Apply this label when **all** of the following are true:
 
+**Case A — implementation PR** (orchestrator Step 7b in `91-orchestrate-work-protocol.md`):
+
 - [ ] The PR is an implementation PR (branch prefix `feature/*`, `fix/*`, `hotfix/*`, or `refactor/*`)
 - [ ] Step 7a (internal review gate) previously produced `APPROVED`
 - [ ] Step 7 (automated reviewer loop) has completed with `clean` or `skipped`
 
+**Case B — production release PR** (`05-prepare-release-protocol.md` Step 7.4):
+
+- [ ] The PR targets `main` from a `release/*` branch
+- [ ] Step 7 (automated reviewer loop) on that PR has completed with `clean` or `skipped`
+
+Release PRs typically do not use the same draft → `gh pr ready` path as feature work; internal review may be minimal when the change set is changelog/version-only — still apply this label only after Step 7 is `clean` or `skipped` per protocol `05`.
+
 This label is **not removed** after e2e tests pass — it persists on the PR. The `ready-for-human-review` label is what ultimately signals human readiness after CI (including e2e) is green.
 
-This label is **not applied** to spec or plan PRs (`spec/*`, `implementation-plan/*`).
+This label is **not applied** to spec or plan PRs (`spec/*`, `implementation-plan/*`). It **is** applied to qualifying release PRs per Case B above.
 
 ---
 
@@ -65,7 +74,7 @@ This label is **not applied** to spec or plan PRs (`spec/*`, `implementation-pla
    - Once the internal review gate is clean, run `gh pr ready <pr-number>` to convert the draft to non-draft
 4. Run `./scripts/development-workflow/pr-review-loop.sh <pr-number> --branch <branch> [--platform <platform> ...]` when automated review tooling is configured
 5. If any automated reviewer reports blocking PR feedback: apply fixes, push, and repeat Step 4
-6. For implementation PRs only: apply `ready-for-regression` label to trigger e2e/regression CI checks
+6. For implementation PRs (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`), or for production release PRs per `05-prepare-release-protocol.md` Step 7.4: apply `ready-for-regression` label to trigger e2e/regression CI checks
 7. Run `./scripts/development-workflow/pr-ci-loop.sh <pr-number>`
 8. If CI passes and all reviews are clean (or not configured): apply `ready-for-human-review` (the PR is already non-draft from Step 3) and move the tracker status to the matching human-review stage (`Spec in Review`, `Plan in Review`, or `Development in Review`) when the tracker is the source of truth
 9. If CI fails: apply `needs-fixes`, fix PR feedback or failing checks, push, and return to Step 4


### PR DESCRIPTION
## Summary
Implements #77: extend the prepare-release flow so it does not stop at opening PRs. The production PR targeting `main` runs the automated reviewer loop, applies `ready-for-regression`, and completes the CI loop before human handoff.

## Changes
- `05-prepare-release-protocol.md`: new Step 7 (main PR only), Step 8 inform human
- `/prepare-release` Cursor + Claude commands; Claude `allowed-tools` for loops
- `AGENTS.md`, workflow README, `e2e-regression.md`, CHANGELOG

Closes #77 when merged.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
