### PR TITLE
feat(workflow): multi-reviewer gate, post-merge transitions, /run-work command

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -25,6 +25,29 @@ review:
   platforms:
     - devin
 
+  # Ordered list of internal AI reviewers to run sequentially on draft PRs
+  # (Step 7a in 91-orchestrate-work-protocol.md) before converting to non-draft.
+  # All listed reviewers must APPROVE before `gh pr ready` is called.
+  #
+  # Supported values:
+  #   claude  — dispatches the stage-appropriate reviewer agent:
+  #               spec/*               -> spec-reviewer
+  #               implementation-plan/* -> implementation-plan-reviewer
+  #               feature/*/refactor/*/fix/*/hotfix/* -> code-reviewer
+  #   codex   — runs `workflow-reviewer-loop` Codex skill (or equivalent)
+  #             against REVIEW.md for the stage-appropriate review protocol
+  #
+  # Local override: developers who do not have access to all tools listed here
+  # can override this list locally by creating .tmp/template-config.json in the
+  # repository root (this path is gitignored). Format:
+  #   { "overrides": { "review": { "internal_reviewers": ["claude"] } } }
+  # The overrides key takes precedence over this file for the local environment.
+  # See docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+  # Step 7a for the full multi-reviewer gate procedure.
+  internal_reviewers:
+    - claude
+    - codex
+
 issue_tracker:
   # Supported examples: linear, github_projects, github_issues, jira, clickup, notion, none
   provider: github_projects

--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -8,8 +8,10 @@
 # docs/ai/development-workflow/integrations/ for integration-specific setup.
 #
 # Important:
-# - scripts/development-workflow/pr-review-loop.sh currently consumes only
-#   review.platforms.
+# - review.platforms is consumed by scripts/development-workflow/pr-review-loop.sh
+#   for external automated PR review (Step 7).
+# - review.internal_reviewers is consumed by the Step 7a internal review gate
+#   protocol (91-orchestrate-work-protocol.md).
 # - Other sections are advisory until additional scripts or agents adopt them.
 #
 # Behavior for automated PR review:

--- a/.claude/commands/post-merge-cleanup.md
+++ b/.claude/commands/post-merge-cleanup.md
@@ -21,4 +21,14 @@ The script will: fetch origin, checkout `develop`, pull, then delete the local b
 Do not skip steps or change the order. If the script fails, show the error and stop.
 
 **After the script succeeds — update the issue tracker (if configured):**
-The merged branch name often contains an issue identifier (e.g. `feature/ENG-123-user-auth` → `ENG-123`, or `feature/42-user-auth` → `#42`). If so, update that issue in the project's issue tracker to the merged/done state. For **Linear**, use the Linear MCP to set the issue status to **Merged** (see `docs/ai/development-workflow/integrations/linear.md`). For **GitHub Projects**, close the issue with `gh issue close <number>` and update the project item Status field to **Merged** via the `gh` CLI / GraphQL (see `docs/ai/development-workflow/integrations/github-projects.md`). For other trackers, set the equivalent "PR merged" status (e.g. Done, Closed, Merged); see `docs/ai/development-workflow/integrations/issue-tracker.md` and the tracker-specific doc under `docs/ai/development-workflow/integrations/`. If the branch has no issue ID or no tracker is in use, skip this step.
+The merged branch name often contains an issue identifier (e.g. `feature/ENG-123-user-auth` → `ENG-123`, or `feature/42-user-auth` → `#42`). If so, update that issue in the project's issue tracker using the branch-type-based status table from Step 10 of `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`:
+
+| Merged branch type | Set tracker status to |
+|---|---|
+| `spec/*` | Spec Ready |
+| `implementation-plan/*` | Plan Ready |
+| `feature/*` / `fix/*` / `refactor/*` / `hotfix/*` | Merged |
+
+If the item's tracker status is already in a further-advanced state (e.g., already `In Development` when a spec branch merges), do not roll it back — leave it as-is.
+
+For **Linear**, use the Linear MCP to set the issue status (see `docs/ai/development-workflow/integrations/linear.md`). For **GitHub Projects**, update the project item Status field via the `gh` CLI / GraphQL (see `docs/ai/development-workflow/integrations/github-projects.md`); only close the issue with `gh issue close` for implementation branches (feature/fix/refactor/hotfix), not for spec or plan branches. For other trackers, set the equivalent status; see `docs/ai/development-workflow/integrations/issue-tracker.md`. If the branch has no issue ID or no tracker is in use, skip this step.

--- a/.claude/commands/run-item-work.md
+++ b/.claude/commands/run-item-work.md
@@ -13,4 +13,4 @@ Key responsibilities:
 - Resolve the request to exactly one workflow item
 - Use the helper scripts in `scripts/development-workflow/` to classify the next deterministic action
 - Continue through creator, reviewer, PR, automated review, and CI work until the item reaches a real terminal condition
-- If the request is portfolio-wide or requires batch selection, use the Agent tool to invoke the `orchestrator` agent (there is no `/run-work` slash command in Claude Code; the `orchestrator` agent is the equivalent dispatch target)
+- If the request is portfolio-wide or requires batch selection, switch to `/run-work`

--- a/.claude/commands/run-work.md
+++ b/.claude/commands/run-work.md
@@ -1,0 +1,20 @@
+---
+description: Batch-orchestrate and supervise multiple developments. Reads current state from the issue tracker and/or dev folders, builds safe parallel batches, and keeps each selected item moving until it is waiting on a human, blocked, or escalated. Usage: /run-work [optional filter, e.g. "only spec stage" or "feature-slug"]
+---
+
+# Claude Code Command: Run Work
+
+Follow the batch orchestration protocol exactly as defined in:
+
+`docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
+
+Key responsibilities:
+
+- Read current state from the issue tracker (if configured) and `docs/specs/developments/`
+- When using an issue tracker, read the current brief per `docs/ai/development-workflow/integrations/issue-tracker.md`
+- Respect dependencies declared in specs
+- Prioritize: due within 2 weeks → priority level → creation date
+- Flag conflicts to the human rather than choosing silently
+- Use the helper scripts in `scripts/development-workflow/` to inspect state, plan batches, resume partial work, poll automated review, and poll CI
+- Use the Agent tool to dispatch the `item-orchestrator` agent for each selected item when possible
+- Report a summary of what was started, what is ready for review, what was serialized, and what is blocked

--- a/.claude/skills/post-merge-cleanup.md
+++ b/.claude/skills/post-merge-cleanup.md
@@ -20,4 +20,14 @@ The script will: fetch origin, checkout `develop`, pull, then delete the local b
 Do not skip steps or change the order. If the script fails, show the error and stop.
 
 **After the script succeeds — update the issue tracker (if configured):**
-The merged branch name often contains an issue identifier (e.g. `feature/ENG-123-user-auth` → `ENG-123`, or `feature/42-user-auth` → `#42`). If so, update that issue in the project’s issue tracker to the merged/done state. For **Linear**, use the Linear MCP to set the issue status to **Merged** (see `docs/ai/development-workflow/integrations/linear.md`). For **GitHub Projects**, close the issue with `gh issue close <number>` and update the project item Status field to **Merged** via the `gh` CLI / GraphQL (see `docs/ai/development-workflow/integrations/github-projects.md`). For other trackers, set the equivalent "PR merged" status (e.g. Done, Closed, Merged); see `docs/ai/development-workflow/integrations/issue-tracker.md` and the tracker-specific doc under `docs/ai/development-workflow/integrations/`. If the branch has no issue ID or no tracker is in use, skip this step.
+The merged branch name often contains an issue identifier (e.g. `feature/ENG-123-user-auth` → `ENG-123`, or `feature/42-user-auth` → `#42`). If so, update that issue in the project’s issue tracker using the branch-type-based status table from Step 10 of `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`:
+
+| Merged branch type | Set tracker status to |
+|---|---|
+| `spec/*` | Spec Ready |
+| `implementation-plan/*` | Plan Ready |
+| `feature/*` / `fix/*` / `refactor/*` / `hotfix/*` | Merged |
+
+If the item’s tracker status is already in a further-advanced state (e.g., already `In Development` when a spec branch merges), do not roll it back — leave it as-is.
+
+For **Linear**, use the Linear MCP to set the issue status (see `docs/ai/development-workflow/integrations/linear.md`). For **GitHub Projects**, update the project item Status field via the `gh` CLI / GraphQL (see `docs/ai/development-workflow/integrations/github-projects.md`); only close the issue with `gh issue close` for implementation branches (feature/fix/refactor/hotfix), not for spec or plan branches. For other trackers, set the equivalent status; see `docs/ai/development-workflow/integrations/issue-tracker.md`. If the branch has no issue ID or no tracker is in use, skip this step.

--- a/.codex/skills/post-merge-cleanup/SKILL.md
+++ b/.codex/skills/post-merge-cleanup/SKILL.md
@@ -11,12 +11,19 @@ description: After a development PR is merged and the remote branch deleted, syn
    ```
 2. **No argument**: the current branch is the one to delete (user runs while still on the merged branch).
 3. **With `branch-name`**: delete that local branch (e.g. `feature/my-feature`).
-4. **Update the issue tracker (if configured)**  
-   The merged branch name often contains an issue identifier (e.g. `feature/ENG-123-user-auth` → `ENG-123`, `fix/PROJ-456-login` → `PROJ-456`, `feature/42-user-auth` → `#42`). After the script succeeds:
-   - If the branch name contains such an identifier, update the corresponding issue in the project’s issue tracker to the “merged” / “done” state (or equivalent).
-   - **Linear**: Use the Linear MCP/skill to get the issue by ID and set its status to **Merged** (per `docs/ai/development-workflow/integrations/linear.md`).
-   - **GitHub Projects**: Close the issue with `gh issue close <number>` and update the project item Status field to **Merged** via the `gh` CLI / GraphQL (per `docs/ai/development-workflow/integrations/github-projects.md`).
-   - **Other trackers**: Follow the same idea — set the issue to the status that means “PR merged to develop” (e.g. Done, Closed, Merged). See `docs/ai/development-workflow/integrations/issue-tracker.md` and the tracker-specific doc under `docs/ai/development-workflow/integrations/`.
+4. **Update the issue tracker (if configured)**
+   The merged branch name often contains an issue identifier (e.g. `feature/ENG-123-user-auth` → `ENG-123`, `fix/PROJ-456-login` → `PROJ-456`, `feature/42-user-auth` → `#42`). After the script succeeds, update the corresponding issue using the branch-type-based status table from Step 10 of `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`:
+
+   | Merged branch type | Set tracker status to |
+   |---|---|
+   | `spec/*` | Spec Ready |
+   | `implementation-plan/*` | Plan Ready |
+   | `feature/*` / `fix/*` / `refactor/*` / `hotfix/*` | Merged |
+
+   If the item’s tracker status is already in a further-advanced state (e.g., already `In Development` when a spec branch merges), do not roll it back — leave it as-is.
+   - **Linear**: Use the Linear MCP/skill to get the issue by ID and set its status (per `docs/ai/development-workflow/integrations/linear.md`).
+   - **GitHub Projects**: Update the project item Status field via the `gh` CLI / GraphQL (per `docs/ai/development-workflow/integrations/github-projects.md`); only close the issue with `gh issue close` for implementation branches (feature/fix/refactor/hotfix), not for spec or plan branches.
+   - **Other trackers**: Follow the same idea — set the issue to the appropriate status per the table above. See `docs/ai/development-workflow/integrations/issue-tracker.md` and the tracker-specific doc under `docs/ai/development-workflow/integrations/`.
    - If no issue identifier is present in the branch name or no tracker is in use, skip this step.
 
 The script (step 1) fetches origin, checks out `develop`, pulls, and deletes the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote). Do not change the order or skip steps.

--- a/.cursor/commands/post-merge-cleanup.md
+++ b/.cursor/commands/post-merge-cleanup.md
@@ -19,4 +19,14 @@ The script will: fetch origin, checkout `develop`, pull, then delete the local b
 Do not skip steps or change the order. If the script fails, show the error and stop.
 
 **After the script succeeds — update the issue tracker (if configured):**
-The merged branch name often contains an issue identifier (e.g. `feature/ENG-123-user-auth` → `ENG-123`, or `feature/42-user-auth` → `#42`). If so, update that issue in the project’s issue tracker to the merged/done state. For **Linear**, use the Linear MCP to set the issue status to **Merged** (see `docs/ai/development-workflow/integrations/linear.md`). For **GitHub Projects**, close the issue with `gh issue close <number>` and update the project item Status field to **Merged** via the `gh` CLI / GraphQL (see `docs/ai/development-workflow/integrations/github-projects.md`). For other trackers, set the equivalent "PR merged" status (e.g. Done, Closed, Merged); see `docs/ai/development-workflow/integrations/issue-tracker.md` and the tracker-specific doc under `docs/ai/development-workflow/integrations/`. If the branch has no issue ID or no tracker is in use, skip this step.
+The merged branch name often contains an issue identifier (e.g. `feature/ENG-123-user-auth` → `ENG-123`, or `feature/42-user-auth` → `#42`). If so, update that issue in the project’s issue tracker using the branch-type-based status table from Step 10 of `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`:
+
+| Merged branch type | Set tracker status to |
+|---|---|
+| `spec/*` | Spec Ready |
+| `implementation-plan/*` | Plan Ready |
+| `feature/*` / `fix/*` / `refactor/*` / `hotfix/*` | Merged |
+
+If the item’s tracker status is already in a further-advanced state (e.g., already `In Development` when a spec branch merges), do not roll it back — leave it as-is.
+
+For **Linear**, use the Linear MCP to set the issue status (see `docs/ai/development-workflow/integrations/linear.md`). For **GitHub Projects**, update the project item Status field via the `gh` CLI / GraphQL (see `docs/ai/development-workflow/integrations/github-projects.md`); only close the issue with `gh issue close` for implementation branches (feature/fix/refactor/hotfix), not for spec or plan branches. For other trackers, set the equivalent status; see `docs/ai/development-workflow/integrations/issue-tracker.md`. If the branch has no issue ID or no tracker is in use, skip this step.

--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -10,7 +10,7 @@ This project follows a staged AI-assisted development workflow. The canonical re
 
 `docs/ai/development-workflow/README.md`
 
-Repository-specific workflow providers live in `.ai-dev-workflow.yaml`. Today, helper scripts consume `review.platforms` directly; other sections are advisory until more tooling adopts them.
+Repository-specific workflow providers live in `.ai-dev-workflow.yaml`. Today, `review.platforms` is consumed by `pr-review-loop.sh` (Step 7) and `review.internal_reviewers` is consumed by the Step 7a internal review gate protocol; other sections are advisory until more tooling adopts them.
 
 ### Stages and protocols
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Repository-specific workflow providers are declared in [`.ai-dev-workflow.yaml`]
 | Advance One Item | `/run-item-work` command (or `item-orchestrator` agent) | `/run-item-work` | `workflow-item-orchestrator` skill | Follow `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` |
 | Prepare Commit | — | `/prepare-commit` | Follow `docs/best-practices/2-version-control.md` | Follow `docs/best-practices/2-version-control.md` |
 | Prepare Release | `/prepare-release` | `/prepare-release` | Follow `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md` | Follow `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md` |
-| Orchestrate Work | `orchestrator` agent | `/run-work` | `workflow-orchestrator` skill | Follow `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` |
+| Orchestrate Work | `/run-work` command (or `orchestrator` agent) | `/run-work` | `workflow-orchestrator` skill | Follow `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` |
 
 **Prepare release** does not stop after opening PRs: protocol `05` requires running the automated reviewer loop, applying `ready-for-regression` on the **production PR to `main`**, and completing the CI loop (including label-gated e2e/regression when configured) before handoff to merge.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Always refer to these docs for authoritative guidance:
 
 This project uses a staged AI-assisted development workflow. See [`docs/ai/development-workflow/README.md`](docs/ai/development-workflow/README.md) for the full specification.
 
-Repository-specific workflow providers are declared in [`.ai-dev-workflow.yaml`](.ai-dev-workflow.yaml). Today, only `review.platforms` is consumed directly by repository helper scripts; other sections are advisory until additional tooling adopts them.
+Repository-specific workflow providers are declared in [`.ai-dev-workflow.yaml`](.ai-dev-workflow.yaml). Today, `review.platforms` is consumed by `pr-review-loop.sh` (Step 7) and `review.internal_reviewers` is consumed by the Step 7a internal review gate protocol; other sections are advisory until additional tooling adopts them.
 
 ### Workflow Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`/run-work` command for Claude Code**: added `.claude/commands/run-work.md` to invoke the batch orchestrator, matching the existing Cursor `/run-work` command. Updated `AGENTS.md` workflow table and simplified `/run-item-work` to reference `/run-work` instead of the raw `orchestrator` agent.
+
+### Changed
+
+- **Multi-reviewer internal review gate (Step 7a)**: expanded Step 7a in `91-orchestrate-work-protocol.md` to run all configured internal reviewers (`review.internal_reviewers` in `.ai-dev-workflow.yaml`) sequentially on draft PRs before converting to non-draft. Added `max_internal_review_cycles` parameter (default: 5) to prevent infinite loops. Added local override support via `.tmp/template-config.json` for developers without access to all review tools. Updated `93-automated-reviewer-loop-protocol.md` to reference the multi-reviewer gate.
+- **Post-merge status transitions (Step 10)**: added Step 10 to `91-orchestrate-work-protocol.md` with a branch-type-to-tracker-status table (`spec/*` -> Spec Ready, `implementation-plan/*` -> Plan Ready, implementation branches -> Merged). Updated `90-batch-orchestrate-work-protocol.md` Step 5 and all post-merge-cleanup command/skill files (Claude Code, Cursor, Codex) to follow this table instead of always setting status to Merged.
+
 ### Fixed
 
 - **Missing `/sync-template` command for Claude Code**: `CLAUDE.md` advertised `/sync-template` as available in Claude Code, but the command file did not exist. Added `.claude/commands/sync-template.md` as a port of the existing Cursor command (`.cursor/commands/sync-template.md`), covering the full workflow: template source resolution (local path, remote ref, or `.tmp/template-config.json`), categorized diff and approval gate, file application, and git/PR instructions.

--- a/docs/ai/development-workflow/README.md
+++ b/docs/ai/development-workflow/README.md
@@ -201,7 +201,7 @@ The sections below keep this document usable as a master reference after the nar
 | Smoke test | `smoke-tester` agent | `/smoke-tester` | — | `docs/ai/development-workflow/protocols/04-smoke-test-protocol.md` |
 | Run reviewer loop | `automated-reviewer-loop` agent | `/run-reviewer-loop` | `workflow-reviewer-loop` skill | `docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` |
 | Advance one item | `item-orchestrator` agent | `/run-item-work` | `workflow-item-orchestrator` skill | `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` |
-| Orchestrate portfolio | `orchestrator` agent | `/run-work` | `workflow-orchestrator` skill | `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` |
+| Orchestrate portfolio | `/run-work` command (or `orchestrator` agent) | `/run-work` | `workflow-orchestrator` skill | `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` |
 | Prepare release | `/prepare-release` | `/prepare-release` | — | `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md` |
 
 After opening release PRs, protocol `05` runs the automated reviewer loop, applies `ready-for-regression` on the **PR targeting `main`**, and runs the CI loop until checks are green (or escalation) — same persistence contract as other PR readiness work.
@@ -365,6 +365,9 @@ review:
   platforms:
     - greptile
     - devin
+  internal_reviewers:
+    - claude
+    - codex
 
 issue_tracker:
   provider: linear
@@ -376,10 +379,10 @@ browser_automation:
   provider: playwright_mcp
 ```
 
-Important implementation note:
+Important implementation notes:
 
-- Today, the repository helpers only consume `review.platforms`, and only `scripts/development-workflow/pr-review-loop.sh` reads the file directly.
-- If the config file is absent, or `review.platforms` is omitted or empty, automated PR review is treated as not configured and the review loop reports `skipped`.
+- `review.platforms` is consumed by `scripts/development-workflow/pr-review-loop.sh` for external automated PR review (Step 7). If the config file is absent, or `review.platforms` is omitted or empty, automated PR review is treated as not configured and the review loop reports `skipped`.
+- `review.internal_reviewers` is consumed by the Step 7a internal review gate protocol (`91-orchestrate-work-protocol.md`). If omitted, the gate falls back to running the stage-appropriate `claude` reviewer once. Developers can override the list locally via `.tmp/template-config.json` (gitignored).
 
 Provider-specific setup still lives in the integration guides under `docs/ai/development-workflow/integrations/`.
 
@@ -455,7 +458,7 @@ Protocol prefixes are stable family identifiers, not a promise of contiguous num
 ### Tooling And Configuration
 
 - `docs/ai/development-workflow/agent-model-config.md`
-- `.ai-dev-workflow.yaml` - repo-level workflow integration manifest (`review.platforms`, `issue_tracker.provider`, `vcs.provider`, `browser_automation.provider`)
+- `.ai-dev-workflow.yaml` - repo-level workflow integration manifest (`review.platforms`, `review.internal_reviewers`, `issue_tracker.provider`, `vcs.provider`, `browser_automation.provider`)
 
 Repository helpers:
 

--- a/docs/ai/development-workflow/README.md
+++ b/docs/ai/development-workflow/README.md
@@ -199,8 +199,8 @@ The sections below keep this document usable as a master reference after the nar
 | Implement | `developer` agent | `/implement-development` | `workflow-implementer` skill | `docs/ai/development-workflow/protocols/03-implement-development-protocol.md` |
 | Review gate (spec / plan / code) | Native review against `REVIEW.md` | `/review-spec`, `/review-implementation-plan`, `/review-code` | Native review against `REVIEW.md` | `REVIEW.md` plus compatibility wrappers in `docs/ai/development-workflow/protocols/` |
 | Smoke test | `smoke-tester` agent | `/smoke-tester` | — | `docs/ai/development-workflow/protocols/04-smoke-test-protocol.md` |
-| Run reviewer loop | `automated-reviewer-loop` agent | `/run-reviewer-loop` | `workflow-reviewer-loop` skill | `docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` |
-| Advance one item | `item-orchestrator` agent | `/run-item-work` | `workflow-item-orchestrator` skill | `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` |
+| Run reviewer loop | `/run-reviewer-loop` command (or `automated-reviewer-loop` agent) | `/run-reviewer-loop` | `workflow-reviewer-loop` skill | `docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` |
+| Advance one item | `/run-item-work` command (or `item-orchestrator` agent) | `/run-item-work` | `workflow-item-orchestrator` skill | `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` |
 | Orchestrate portfolio | `/run-work` command (or `orchestrator` agent) | `/run-work` | `workflow-orchestrator` skill | `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` |
 | Prepare release | `/prepare-release` | `/prepare-release` | — | `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md` |
 

--- a/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -196,6 +196,7 @@ After a Work Item Runner returns:
 2. If the tracker is unavailable, fall back to `workflow-next-action.sh` but flag to the human that status may be stale.
 3. If the next action is still deterministic because the Work Item Runner returned early or was interrupted, redispatch / resume that same item.
 4. Stop supervising that item only when it is waiting on a human, blocked, or escalated.
+5. **When a human confirms PRs have been merged**: run post-merge status transitions per the table in Step 10 of `91-orchestrate-work-protocol.md` — set tracker status to `Spec Ready`, `Plan Ready`, or `Merged` depending on the branch type of the merged PR — and clean up local branches and worktrees associated with the merged PRs.
 
 Do not consider the batch complete until every dispatched item has reached a real terminal condition.
 

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -155,7 +155,7 @@ Run the next deterministic action for the selected item, then immediately re-eva
 
 Expected chain:
 
-`creator -> draft PR opened -> internal review gate (Step 7a) -> gh pr ready -> automated reviewer loop (Step 7) -> regression label (Step 7b, implementation PRs only) -> CI loop (Step 8) -> readiness label / tracker status -> wait or escalation`
+`creator -> draft PR opened -> internal review gate with all internal reviewers (Step 7a) -> gh pr ready -> automated reviewer loop (Step 7) -> regression label (Step 7b, implementation PRs only) -> CI loop (Step 8) -> readiness label / tracker status -> wait or escalation`
 
 After any subagent finishes, determine whether the item still has a deterministic next action:
 
@@ -201,23 +201,57 @@ After the selected item reaches a terminal condition, provide a concise summary:
 
 Run this step immediately after opening a draft PR, and again after any push that addresses internal-review findings.
 
-Dispatch the stage-appropriate internal reviewer for the draft PR:
+### Determining which reviewers to run
 
-| PR branch prefix | Internal reviewer to dispatch |
-|---|---|
-| `spec/*` | `spec-reviewer` or `01-review-spec-protocol.md` |
-| `implementation-plan/*` | `implementation-plan-reviewer` or `02-review-implementation-plan-protocol.md` |
-| `feature/*` / `refactor/*` / `fix/*` / `hotfix/*` | `code-reviewer` or `03-review-implementation-protocol.md` |
+Read the `review.internal_reviewers` list from `.ai-dev-workflow.yaml`. If a `.tmp/template-config.json` file exists in the repository root (this path is gitignored and used for local developer overrides), read its `overrides.review.internal_reviewers` list — that value takes precedence over `.ai-dev-workflow.yaml` for the local environment. This allows developers without access to all configured review tools to run a subset (e.g., only `claude`) without changing the shared config.
 
-The reviewer runs against `REVIEW.md`, applies deterministic fixes directly, and commits + pushes if needed.
+Example `.tmp/template-config.json` override format:
+
+```json
+{
+  "overrides": {
+    "review": {
+      "internal_reviewers": ["claude"]
+    }
+  }
+}
+```
+
+If neither file defines `internal_reviewers`, fall back to running the stage-appropriate reviewer once (default behavior: `claude`).
+
+### Reviewer dispatch map
+
+For each reviewer in the resolved list, dispatch the stage-appropriate agent:
+
+| Reviewer | PR branch prefix | Agent / protocol to dispatch |
+|---|---|---|
+| `claude` | `spec/*` | `spec-reviewer` or `01-review-spec-protocol.md` |
+| `claude` | `implementation-plan/*` | `implementation-plan-reviewer` or `02-review-implementation-plan-protocol.md` |
+| `claude` | `feature/*` / `refactor/*` / `fix/*` / `hotfix/*` | `code-reviewer` or `03-review-implementation-protocol.md` |
+| `codex` | any | `workflow-reviewer-loop` Codex skill (or equivalent) against `REVIEW.md` for the stage-appropriate review protocol |
+
+### Multi-reviewer execution rules
+
+Run all configured internal reviewers **sequentially** in the order listed. Each reviewer runs against `REVIEW.md`, applies deterministic fixes directly, and commits + pushes if needed.
+
+Initialize `internal_review_cycle = 0` at the start of Step 7a. Increment each time the full reviewer list is restarted. Escalate to human when `internal_review_cycle` reaches `max_internal_review_cycles` (default: 5).
 
 | Outcome | Action |
 |---|---|
-| `APPROVED` | Run `gh pr ready <pr_number>` to convert the draft PR to non-draft, then continue to Step 7 (external automated reviewers) |
-| `NEEDS REVISION` (fixable) | Fixes already applied by the agent; re-run Step 7a |
-| `NEEDS REVISION` (product/design decision) | Stop and escalate to human before proceeding |
+| All reviewers `APPROVED` | Run `gh pr ready <pr_number>` to convert the draft PR to non-draft, then continue to Step 7 (external automated reviewers) |
+| Any reviewer returns `NEEDS REVISION` (fixable) and `internal_review_cycle < max_internal_review_cycles` | Fixes already applied by the agent; increment `internal_review_cycle`; re-run **all** internal reviewers from the beginning of the list |
+| Any reviewer returns `NEEDS REVISION` (fixable) and `internal_review_cycle >= max_internal_review_cycles` | Escalate to human — internal review is not converging |
+| Any reviewer returns `NEEDS REVISION` (product/design decision) | Stop and escalate to human before proceeding |
 
-Step 7a runs **before** Step 7 (external reviewers). Only proceed to Step 7 once Step 7a produces `APPROVED`. After any fixer push triggered by Step 7 (external reviewers), re-run Step 7a to ensure the stage-specific internal review gate is still clean.
+All internal reviewers must APPROVE before `gh pr ready` is called. If any reviewer finds issues, fix them and re-run ALL internal reviewers.
+
+### Step 7a loop parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `max_internal_review_cycles` | 5 | Max times the full internal reviewer list is restarted before escalating |
+
+Step 7a runs **before** Step 7 (external reviewers). Only proceed to Step 7 once all internal reviewers in Step 7a produce `APPROVED`. After any fixer push triggered by Step 7 (external reviewers), re-run Step 7a (all internal reviewers) to ensure the stage-specific internal review gate is still clean.
 
 ---
 
@@ -402,3 +436,29 @@ When a human requests changes on a PR:
 8. Reapply `ready-for-human-review` only when both loops are clean again
 
 See `92-pr-readiness-signal-protocol.md` for label definitions.
+
+---
+
+## Step 10: Post-Merge Status Transitions
+
+When a human confirms that a PR has been merged, update the issue tracker and clean up local state according to this table:
+
+| Merged PR branch type | Set tracker status to |
+|---|---|
+| `spec/*` | Spec Ready |
+| `implementation-plan/*` | Plan Ready |
+| `feature/*` / `fix/*` / `refactor/*` / `hotfix/*` | Merged |
+
+**Key rules:**
+
+- When a spec or plan PR is merged, set the tracker status to the corresponding **Ready** status (`Spec Ready` or `Plan Ready`) — **not** `Merged`. Only implementation PRs (feature, fix, refactor, hotfix) go to `Merged`.
+- The `/post-merge-cleanup` skill and `post-merge-cleanup` command follow this same table when updating tracker status.
+- After updating the tracker, clean up local branches and worktrees associated with the merged PR:
+
+```bash
+git fetch origin
+git branch -D <merged-branch>           # force-delete local branch (squash merges need -D)
+git worktree remove <worktree-path>     # remove worktree if present
+```
+
+If the item's tracker status is already in a further-advanced state (e.g., already `In Development` when a spec PR merges), do not roll it back — leave it as-is and only clean up local branches/worktrees.

--- a/docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -63,7 +63,7 @@ If unresolved findings exist: dispatch a fixer agent, wait for the push, then pr
 
 Execute **Step 7a: Internal Review Gate**, **Step 7: Automated Reviewer Loop**, and **Step 8: CI Loop** exactly as defined in `91-orchestrate-work-protocol.md` (scripts, result interpretation, sequential platform policy, fixer mapping, parameters, and labels). Do not duplicate that logic here — follow 91.
 
-For each PR: run Step 7a first (the stage-appropriate internal review gate). Once Step 7a produces `APPROVED`, run `gh pr ready <pr_number>` to convert the draft PR to non-draft, then run Step 7 to completion, then Step 7b (regression label, implementation PRs only), then Step 8. Dispatch fixers and re-run as specified in 91 until the PR is clean and ready for human review or escalated. After Step 8 returns `green`, apply `ready-for-human-review` (the PR is already non-draft from the step after 7a).
+For each PR: run Step 7a first. Step 7a runs **all** configured internal reviewers sequentially (per the `review.internal_reviewers` list in `.ai-dev-workflow.yaml`, with `.tmp/template-config.json` local overrides taking precedence). All internal reviewers must APPROVE before proceeding. Once Step 7a produces `APPROVED` from all internal reviewers, run `gh pr ready <pr_number>` to convert the draft PR to non-draft, then run Step 7 to completion, then Step 7b (regression label, implementation PRs only), then Step 8. Dispatch fixers and re-run as specified in 91 until the PR is clean and ready for human review or escalated. After Step 8 returns `green`, apply `ready-for-human-review` (the PR is already non-draft from the step after 7a).
 
 ### PR feedback tracking and comments
 

--- a/docs/ai/setup/protocol.md
+++ b/docs/ai/setup/protocol.md
@@ -144,6 +144,7 @@ Ask:
 - What Git hosting / pull-request platform do you use? (GitHub, GitLab, Bitbucket, other)
 - What browser automation tool, if any, should the workflow assume for smoke tests? (Cursor browser MCP, Playwright MCP, Playwright CLI, other, none)
 - Do you want to use automated PR review? (Greptile, Devin, both, other, none)
+- Which internal AI reviewers should run on draft PRs before external review? (Claude, Codex, both, other, none — default: Claude only)
 - Do you want branch-based CI/CD deployments? (yes/no)
   - If yes: what is the deploy branch strategy (`develop` -> non-production, `main` -> production, or custom)?
   - What deployment provider/tool should downstream repos wire in? (or `TBD`)
@@ -163,6 +164,9 @@ schema_version: 1
 review:
   platforms:
     - greptile
+  internal_reviewers:
+    - claude
+    - codex
 
 issue_tracker:
   provider: linear
@@ -177,7 +181,7 @@ browser_automation:
 Rules:
 - Include only the sections the user actually chose.
 - Keep the file declarative; do not store secrets or tokens in it.
-- `pr-review-loop.sh` currently consumes only `review.platforms`.
+- `review.platforms` is consumed by `pr-review-loop.sh` for external automated PR review (Step 7). `review.internal_reviewers` is consumed by the Step 7a internal review gate protocol.
 - If the file is absent, or `review.platforms` is omitted or empty, automated PR review is treated as not configured and the review loop reports `skipped`.
 
 ---


### PR DESCRIPTION
## Summary

- Expanded Step 7a in `91-orchestrate-work-protocol.md` to run all configured internal reviewers (`review.internal_reviewers` in `.ai-dev-workflow.yaml`) sequentially on draft PRs before converting to non-draft; added `max_internal_review_cycles` (default: 5) to prevent infinite loops.
- Added `.tmp/template-config.json` local override support so developers without access to all tools can run a subset of reviewers without modifying the shared config.
- Added Step 10 (Post-Merge Status Transitions) to protocol 91 with a table mapping merged branch types to correct tracker statuses: `spec/*` → Spec Ready, `implementation-plan/*` → Plan Ready, `feature/*/fix/*/refactor/*/hotfix/*` → Merged.
- Updated all post-merge-cleanup command/skill files (Claude Code, Cursor, Codex) to follow Step 10's branch-type-aware status table instead of always setting "Merged".
- Updated protocol 90 Step 5 to run post-merge transitions when a human confirms PRs have been merged.
- Updated protocol 93 to reference the multi-reviewer Step 7a from protocol 91.
- Added `/run-work` command for Claude Code batch orchestration (`.claude/commands/run-work.md`), matching the existing Cursor `/run-work` command. Updated AGENTS.md workflow table and simplified `/run-item-work` to reference `/run-work`.

## Test plan

- [ ] Read `.ai-dev-workflow.yaml` and confirm `review.internal_reviewers` is present under `review:` with concrete dispatch definitions
- [ ] Read Step 7a in protocol 91 and confirm: reviewer dispatch table covers both `claude` and `codex`; multi-reviewer execution rules table present; `max_internal_review_cycles` parameter documented; override mechanism documented with example JSON
- [ ] Read Step 10 in protocol 91 and confirm the branch-type → tracker-status table is present, uses `git branch -D` (not `-d`), and includes guidance on not rolling back further-advanced status
- [ ] Read protocol 90 Step 5 and confirm post-merge clause references Step 10 of protocol 91
- [ ] Read protocol 93 "Run the loops" and confirm it references the multi-reviewer Step 7a without duplicating logic
- [ ] Read all post-merge-cleanup files (`.claude/commands/`, `.claude/skills/`, `.cursor/commands/`, `.codex/skills/`) and confirm they use branch-type-aware status table
- [ ] Confirm `.claude/commands/run-work.md` exists and dispatches via Agent tool to `item-orchestrator`
- [ ] Confirm AGENTS.md workflow table shows `/run-work` command for Claude Code
- [ ] Confirm `.claude/commands/run-item-work.md` references `/run-work` instead of raw orchestrator agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)