### PR TITLE
feat(workflow): add CodeRabbit integration

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -23,7 +23,7 @@ schema_version: 1
 review:
   # Ordered list of automated PR review platforms to run sequentially.
   # Platforms are evaluated in order; the first blocking result stops the loop.
-  # Supported today by pr-review-loop.sh: greptile, devin
+  # Supported today by pr-review-loop.sh: greptile, devin, coderabbit
   platforms:
     - devin
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,26 @@
+# CodeRabbit configuration
+#
+# This file controls CodeRabbit's behavior for this repository.
+# Docs: https://docs.coderabbit.ai/reference/configuration
+#
+# By default, auto PR reviews are DISABLED. This template uses CodeRabbit CLI
+# locally (Path A) via the Claude Code plugin (/coderabbit:review).
+#
+# To enable CodeRabbit as an external PR reviewer (Path B):
+#   1. Set reviews.auto_review.enabled to true below
+#   2. Add "coderabbit" to review.platforms in .ai-dev-workflow.yaml
+#   3. Ensure the CodeRabbit GitHub App is installed on the repository
+
+reviews:
+  auto_review:
+    enabled: false
+    drafts: false
+    base_branches:
+      - develop
+      - main
+  path_filters:
+    - "!dist/**"
+    - "!**/*.generated.*"
+    - "!**/*.lock"
+    - "!**/node_modules/**"
+  profile: "assertive"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CodeRabbit integration**: added CodeRabbit as an optional automated PR reviewer platform (`coderabbit` in `review.platforms`) and as a pre-push CLI tool via `/coderabbit:review` in Claude Code. Includes `run_coderabbit_review` adapter in `pr-review-loop.sh` with severity-based blocking classification (Critical/Major blocking, Minor/Low non-blocking), `CHANGES_REQUESTED` review handling, stale-findings recovery with resolved-comment filtering, and scoped activity detection to suppress false stale blockers. Added `.coderabbit.yaml` config (auto-review disabled by default) and `docs/ai/development-workflow/integrations/coderabbit.md` setup guide. Updated `REVIEW.md` CodeRabbit CLI guidance.
 - **`/run-work` command for Claude Code**: added `.claude/commands/run-work.md` to invoke the batch orchestrator, matching the existing Cursor `/run-work` command. Updated `AGENTS.md` workflow table and simplified `/run-item-work` to reference `/run-work` instead of the raw `orchestrator` agent.
 
 ### Changed

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -153,6 +153,13 @@ Typical `important` issues:
 - Use the repo commands `/review-spec`, `/review-implementation-plan`, and `/review-code`.
 - Those commands should manually review against this file and apply direct fixes when appropriate.
 
+### CodeRabbit CLI
+
+- Use the CodeRabbit CLI as an optional pre-push review tool for local changes.
+- In Claude Code: `/coderabbit:review`. Standalone: `cr` or `cr --agent`.
+- CodeRabbit CLI findings complement the pre-PR review gate but do not replace it.
+- See [`docs/ai/development-workflow/integrations/coderabbit.md`](docs/ai/development-workflow/integrations/coderabbit.md) for setup and usage modes.
+
 ### Automated PR Reviewers
 
 - Treat automated PR reviewers as post-push validation.

--- a/docs/ai/development-workflow/integrations/coderabbit.md
+++ b/docs/ai/development-workflow/integrations/coderabbit.md
@@ -140,6 +140,8 @@ CodeRabbit posts findings as inline comments on code lines. The adapter filters 
 
 ### Resolved comment handling
 
-When CodeRabbit detects fixes in subsequent commits, it may post a reply starting with `✅` on the original finding. During **stale-findings recovery** (where the entire PR history is scanned without a timestamp bound), the adapter collects the IDs of all bot replies starting with `✅` and excludes their parent comments from the stale blocking count — the same pattern as the Devin adapter.
+When CodeRabbit detects fixes in subsequent commits, it may post a reply starting with `✅` on the original finding.
 
-During **normal Phase 1 and Phase 3 processing**, resolved comments are implicitly excluded by the `since_iso` timestamp bound: only comments posted after the HEAD commit are considered. Because CodeRabbit posts its findings and any `✅` resolution replies in separate review cycles (triggered by different pushes), a resolved finding's original comment will have a `created_at` before `since_iso` and will not appear in Phase 1 or Phase 3 results. Reply comments (`in_reply_to_id != null`) are always excluded from direct counting regardless of phase.
+**Stale-findings recovery** (where the entire PR history is scanned without a timestamp bound) is the only path that performs explicit `✅`-reply filtering: it collects the IDs of all bot replies starting with `✅` and excludes their parent comments from the stale blocking count — the same `jq -s` pattern as the Devin adapter.
+
+**Phase 1 and Phase 3 do not perform explicit resolved-comment filtering.** They rely on the `since_iso` timestamp bound instead: only comments posted after the HEAD commit are fetched. Because CodeRabbit posts findings and `✅` resolution replies in separate review cycles (triggered by different pushes), a resolved finding's original comment will have a `created_at` before `since_iso` and will not appear in Phase 1 or Phase 3 queries. Reply comments (`in_reply_to_id != null`) are always excluded from direct counting regardless of phase.

--- a/docs/ai/development-workflow/integrations/coderabbit.md
+++ b/docs/ai/development-workflow/integrations/coderabbit.md
@@ -141,4 +141,6 @@ CodeRabbit posts findings as inline comments on code lines. The adapter filters 
 
 ### Resolved comment handling
 
-When CodeRabbit detects fixes in subsequent commits, it may post a reply starting with `✅` on the original finding. The adapter uses these resolved confirmations to exclude their parent comments from blocking counts — both during normal Phase 1/3 processing and during stale-findings recovery (same pattern as the Devin adapter). Reply comments (`in_reply_to_id != null`) are always excluded from direct counting.
+When CodeRabbit detects fixes in subsequent commits, it may post a reply starting with `✅` on the original finding. During **stale-findings recovery** (where the entire PR history is scanned without a timestamp bound), the adapter collects the IDs of all bot replies starting with `✅` and excludes their parent comments from the stale blocking count — the same pattern as the Devin adapter.
+
+During **normal Phase 1 and Phase 3 processing**, resolved comments are implicitly excluded by the `since_iso` timestamp bound: only comments posted after the HEAD commit are considered. Because CodeRabbit posts its findings and any `✅` resolution replies in separate review cycles (triggered by different pushes), a resolved finding's original comment will have a `created_at` before `since_iso` and will not appear in Phase 1 or Phase 3 results. Reply comments (`in_reply_to_id != null`) are always excluded from direct counting regardless of phase.

--- a/docs/ai/development-workflow/integrations/coderabbit.md
+++ b/docs/ai/development-workflow/integrations/coderabbit.md
@@ -113,16 +113,18 @@ The helper script checks for a CodeRabbit review on each poll iteration. If a re
 | `elapsed >= max_wait` and no CodeRabbit activity detected | Stale findings recovery, then skip as `no_review` if none found |
 | `elapsed >= max_wait` and CodeRabbit activity was detected | Timeout — escalate to human |
 
-### Step 7.3 — Fetch inline comments
+### Step 7.3 — Fetch inline comments and reviews
 
 ```bash
 gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
   --jq "[.[] | select(.user.login == \"coderabbitai[bot]\" and .created_at > \"$since_iso\" and .in_reply_to_id == null) | {path, line, body}]"
 ```
 
+Additionally, `CHANGES_REQUESTED` reviews posted by `coderabbitai[bot]` after the HEAD commit are also fetched from the reviews endpoint and counted as blocking, regardless of the emoji severity marker in their body. This matches the behavior of the other platform adapters.
+
 ### Blocking vs. suggestion classification
 
-Unlike Devin (where all findings are blocking), CodeRabbit findings include severity markers that determine blocking status:
+Unlike Devin (where all findings are blocking), CodeRabbit inline comments include severity markers that determine blocking status:
 
 | Severity marker | Classification |
 | --- | --- |

--- a/docs/ai/development-workflow/integrations/coderabbit.md
+++ b/docs/ai/development-workflow/integrations/coderabbit.md
@@ -1,0 +1,142 @@
+# Integration: CodeRabbit (Automated PR Review)
+
+This document describes how to use [CodeRabbit](https://www.coderabbit.ai) as one automated PR reviewer tool in the workflow.
+
+CodeRabbit is **optional**. The workflow functions without it. See [`integrations/pr-review-platform.md`](pr-review-platform.md) for the multi-platform loop and aggregation rules.
+
+---
+
+## What CodeRabbit Adds
+
+- AST-based code analysis that catches race conditions, memory leaks, security vulnerabilities, and logic errors
+- Severity-classified findings (Critical, Major, Minor) with inline suggestions
+- Complements other reviewers by providing static analysis from a different angle
+
+---
+
+## Usage Modes
+
+CodeRabbit supports two independent usage modes in this framework:
+
+### CLI-only (Path A — default)
+
+Use the CodeRabbit CLI locally before pushing. No GitHub App needed.
+
+```bash
+# Install
+brew install coderabbit
+# or: curl -fsSL https://cli.coderabbit.ai/install.sh | sh
+
+# Authenticate
+coderabbit auth login
+
+# In Claude Code
+/plugin install coderabbit
+/coderabbit:review
+```
+
+The `.coderabbit.yaml` at the repo root ships with `auto_review.enabled: false` so the GitHub App (if installed) does not auto-review PRs.
+
+### External PR reviewer (Path B)
+
+To enable CodeRabbit as a Step 7 automated PR reviewer platform:
+
+1. Set `reviews.auto_review.enabled: true` in `.coderabbit.yaml`
+2. Add `coderabbit` to `review.platforms` in `.ai-dev-workflow.yaml`
+3. Install the CodeRabbit GitHub App on the repository
+
+---
+
+## Setup (Path B only)
+
+### 1. Install the CodeRabbit GitHub App
+
+Go to [coderabbit.ai](https://www.coderabbit.ai) and install the GitHub App on your repository. Enable auto-review so CodeRabbit automatically reviews PRs when code is pushed.
+
+### 2. Enable auto-review in `.coderabbit.yaml`
+
+```yaml
+reviews:
+  auto_review:
+    enabled: true
+```
+
+### 3. Add to `.ai-dev-workflow.yaml`
+
+```yaml
+review:
+  platforms:
+    - coderabbit
+```
+
+### 4. Verify Auto-Review Is Active
+
+Push a commit to an open PR and confirm that CodeRabbit posts review comments. The bot posts as `coderabbitai[bot]`.
+
+---
+
+## Step 7 — CodeRabbit-Specific Implementation
+
+The **Work Item Runner's** Step 7 (Automated Reviewer Loop) requires platform-specific commands. Below are the CodeRabbit adapter details used by the shared helper.
+
+### Preferred helper
+
+When possible, call the repository helper instead of re-implementing the loop inline:
+
+```bash
+./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch_name> --platform coderabbit
+```
+
+It encapsulates the polling, comment classification, and stable aggregate `RESULT=` output used by the **Work Item Runner** (and by the **Portfolio Orchestrator** when it supervises item-level runs).
+
+### Bot identity
+
+CodeRabbit posts as `coderabbitai[bot]`. Use this login to filter its comments and reviews from human activity.
+
+### Step 7.1 — Trigger a re-review
+
+**No trigger needed.** CodeRabbit auto-reviews on every push when `auto_review.enabled` is `true` in `.coderabbit.yaml`. There is no trigger comment and therefore no `REVIEW_COMMENT_ID`.
+
+### Step 7.2 — Detect review completion
+
+CodeRabbit signals completion in one of these ways:
+
+1. **Review submission** — a `COMMENTED` review posted by `coderabbitai[bot]` after the HEAD commit timestamp
+2. **Summary comment update** — the PR issue comment containing `<!-- This is an auto-generated comment: summarize by coderabbit.ai -->` no longer contains "Currently processing"
+
+The helper script checks for a CodeRabbit review on each poll iteration. If a review is found submitted after the HEAD commit, the review is considered complete.
+
+| Result | Action |
+| --- | --- |
+| CodeRabbit review found after HEAD commit | Review complete — proceed to Step 7.3 |
+| No review yet and `elapsed < max_wait` | Not finished yet — wait another `poll_interval` and poll again |
+| `elapsed >= max_wait` and no CodeRabbit activity detected | Stale findings recovery, then skip as `no_review` if none found |
+| `elapsed >= max_wait` and CodeRabbit activity was detected | Timeout — escalate to human |
+
+### Step 7.3 — Fetch inline comments
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
+  --jq "[.[] | select(.user.login == \"coderabbitai[bot]\" and .created_at > \"$since_iso\" and .in_reply_to_id == null) | {path, line, body}]"
+```
+
+### Blocking vs. suggestion classification
+
+Unlike Devin (where all findings are blocking), CodeRabbit findings include severity markers that determine blocking status:
+
+| Severity marker | Classification |
+| --- | --- |
+| `🔴 Critical` | Blocking |
+| `🟠 Major` | Blocking |
+| `🟡 Minor` | Suggestion (non-blocking) |
+| `🟢 Low` or no marker | Suggestion (non-blocking) |
+
+The adapter parses the comment body for these emoji+label patterns. Comments without a recognized severity marker default to suggestion.
+
+### Reply thread handling
+
+CodeRabbit posts findings as inline comments on code lines. The adapter filters out reply comments (`in_reply_to_id != null`) to avoid double-counting a finding and its reply as separate items. Only top-level inline comments are counted.
+
+### Resolved comment handling
+
+When CodeRabbit detects fixes in subsequent commits, it may update or resolve prior findings. The adapter excludes comments that are replies or resolved confirmations from the blocking count.

--- a/docs/ai/development-workflow/integrations/coderabbit.md
+++ b/docs/ai/development-workflow/integrations/coderabbit.md
@@ -99,12 +99,11 @@ CodeRabbit posts as `coderabbitai[bot]`. Use this login to filter its comments a
 
 ### Step 7.2 — Detect review completion
 
-CodeRabbit signals completion in one of these ways:
+CodeRabbit signals completion by posting a review (typically `COMMENTED` or `CHANGES_REQUESTED`) on the PR after analyzing the pushed commit.
 
-1. **Review submission** — a `COMMENTED` review posted by `coderabbitai[bot]` after the HEAD commit timestamp
-2. **Summary comment update** — the PR issue comment containing `<!-- This is an auto-generated comment: summarize by coderabbit.ai -->` no longer contains "Currently processing"
+The helper script checks for a CodeRabbit review on each poll iteration. If a review from `coderabbitai[bot]` is found submitted after the HEAD commit timestamp, the review is considered complete and the script proceeds to Phase 3.
 
-The helper script checks for a CodeRabbit review on each poll iteration. If a review is found submitted after the HEAD commit, the review is considered complete.
+As a secondary signal, the script also checks for CodeRabbit issue comments (e.g., the PR summary comment) as an **activity indicator** — this is used only to distinguish "CodeRabbit is active but hasn't finished" from "CodeRabbit didn't review this HEAD at all" when the timeout is reached.
 
 | Result | Action |
 | --- | --- |

--- a/docs/ai/development-workflow/integrations/coderabbit.md
+++ b/docs/ai/development-workflow/integrations/coderabbit.md
@@ -141,4 +141,4 @@ CodeRabbit posts findings as inline comments on code lines. The adapter filters 
 
 ### Resolved comment handling
 
-When CodeRabbit detects fixes in subsequent commits, it may update or resolve prior findings. The adapter excludes comments that are replies or resolved confirmations from the blocking count.
+When CodeRabbit detects fixes in subsequent commits, it may post a reply starting with `✅` on the original finding. The adapter uses these resolved confirmations to exclude their parent comments from blocking counts — both during normal Phase 1/3 processing and during stale-findings recovery (same pattern as the Devin adapter). Reply comments (`in_reply_to_id != null`) are always excluded from direct counting.

--- a/docs/ai/development-workflow/integrations/pr-review-platform.md
+++ b/docs/ai/development-workflow/integrations/pr-review-platform.md
@@ -3,6 +3,7 @@
 This document defines **platform-agnostic** expectations for how agents use one or more automated PR review tools in this workflow.
 
 Platform-specific setup lives in each platform's own integration doc. See:
+- [`integrations/coderabbit.md`](coderabbit.md)
 - [`integrations/greptile.md`](greptile.md)
 - [`integrations/devin.md`](devin.md)
 

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -101,7 +101,7 @@ Runs one or more automated PR review platforms in order, then classifies finding
 Usage:
 
 ```bash
-./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch feature/my-branch] [--platform greptile] [--platform devin]
+./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch feature/my-branch] [--platform greptile] [--platform devin] [--platform coderabbit]
 ```
 
 What it does:

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -783,14 +783,17 @@ run_coderabbit_review() {
   local head_sha=""
   local since_iso=""
   local existing_comments=""
+  local existing_reviews=""
   local existing_blocking_file=""
   local existing_blocking_count=0
   local existing_suggestion_count=0
   local comment_json=""
+  local review_json=""
   local body=""
   local blocking_lines_file=""
   local elapsed=0
   local comments=""
+  local blocking_reviews=""
   local blocking_count=0
   local suggestion_count=0
   local comment_count=0
@@ -830,6 +833,19 @@ run_coderabbit_review() {
           | @json
         '
   )"
+  existing_reviews="$(
+    gh api "repos/$repo/pulls/$pr_number/reviews" --paginate \
+      | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
+          .[]
+          | select(
+              .user.login == $bot and
+              .submitted_at > $since and
+              .state == "CHANGES_REQUESTED"
+            )
+          | { path: "", line: 0, body: (.body // "CHANGES_REQUESTED review without body") }
+          | @json
+        '
+  )"
 
   existing_blocking_file="$(mktemp)"
   while IFS= read -r comment_json; do
@@ -843,6 +859,14 @@ run_coderabbit_review() {
       existing_suggestion_count=$((existing_suggestion_count + 1))
     fi
   done <<< "$existing_comments"
+
+  while IFS= read -r review_json; do
+    [ -z "${review_json:-}" ] && continue
+    body="$(printf '%s\n' "$review_json" | jq -r '.body')"
+    [ -z "$body" ] && continue
+    existing_blocking_count=$((existing_blocking_count + 1))
+    printf '%s\n' "$review_json" >> "$existing_blocking_file"
+  done <<< "$existing_reviews"
 
   if [ "$existing_blocking_count" -gt 0 ]; then
     print_kv RESULT needs_fixes
@@ -895,13 +919,15 @@ run_coderabbit_review() {
       break
     fi
 
-    # Also check for CodeRabbit issue comments (summary comment) as activity signal
+    # Also check for CodeRabbit issue comments (summary comment) as activity signal.
+    # Filter by since_iso so historical comments from prior pushes do not incorrectly
+    # mark this HEAD cycle as having activity (which would suppress stale-findings recovery).
     if [ "$coderabbit_any_activity" -eq 0 ]; then
       local activity_count
       activity_count="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq --arg bot "$bot_login" '
-              [.[] | select(.user.login == $bot)] | length
+          | jq --arg bot "$bot_login" --arg since "$since_iso" '
+              [.[] | select(.user.login == $bot and .created_at > $since)] | length
             '
       )"
       if [ "${activity_count:-0}" -gt 0 ]; then
@@ -1005,6 +1031,24 @@ run_coderabbit_review() {
       '
   )"
 
+  blocking_reviews="$(
+    gh api "repos/$repo/pulls/$pr_number/reviews" --paginate \
+      | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
+        .[]
+        | select(
+            .user.login == $bot and
+            .submitted_at > $since and
+            .state == "CHANGES_REQUESTED"
+          )
+        | {
+            path: "",
+            line: 0,
+            body: (.body // "CHANGES_REQUESTED review without body")
+          }
+        | @json
+      '
+  )"
+
   while IFS= read -r comment_json; do
     [ -z "${comment_json:-}" ] && continue
     body="$(printf '%s\n' "$comment_json" | jq -r '.body')"
@@ -1017,6 +1061,15 @@ run_coderabbit_review() {
       suggestion_count=$((suggestion_count + 1))
     fi
   done <<< "$comments"
+
+  while IFS= read -r review_json; do
+    [ -z "${review_json:-}" ] && continue
+    body="$(printf '%s\n' "$review_json" | jq -r '.body')"
+    [ -z "$body" ] && continue
+    comment_count=$((comment_count + 1))
+    blocking_count=$((blocking_count + 1))
+    printf '%s\n' "$review_json" >> "$blocking_lines_file"
+  done <<< "$blocking_reviews"
 
   if [ "$blocking_count" -gt 0 ]; then
     print_kv RESULT needs_fixes

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -938,16 +938,31 @@ run_coderabbit_review() {
     if [ "$elapsed" -ge "$max_wait" ]; then
       if [ "$coderabbit_any_activity" -eq 0 ]; then
         # CodeRabbit didn't review this HEAD. Check for stale findings before skipping.
+        # Only consider unresolved inline comments here. Exclude resolved findings
+        # (replies starting with ✅ resolve their parent comment) — same pattern as Devin.
         local stale_count=0
         local stale_blocking_count=0
         local stale_comments
         stale_comments="$(
           gh api "repos/$repo/pulls/$pr_number/comments" --paginate \
-            | jq -r --arg bot "$bot_login" '
-                .[]
+            | jq -s -r --arg bot "$bot_login" '
+                (
+                  [
+                    .[][]
+                    | select(
+                        .user.login == $bot and
+                        .in_reply_to_id != null and
+                        ((.body // "") | test("^✅"))
+                      )
+                    | .in_reply_to_id
+                  ]
+                ) as $resolved_ids
+                | .[][]
                 | select(
                     .user.login == $bot and
-                    .in_reply_to_id == null
+                    .in_reply_to_id == null and
+                    ((.body // "") | test("^✅") | not) and
+                    (.id as $comment_id | ($resolved_ids | index($comment_id) | not))
                   )
                 | { path, line: (.line // .original_line // 0), body: (.body // "") }
                 | @json

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -8,7 +8,7 @@ source "$SCRIPT_DIR/workflow-lib.sh"
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--platform greptile] [--platform greptile,devin] [--poll-interval seconds] [--max-wait seconds]
+Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--platform greptile] [--platform greptile,devin,coderabbit] [--poll-interval seconds] [--max-wait seconds]
 
 Runs the automated PR review loop for one or more platforms in sequence. Before
 triggering a new review, each platform checks for existing blocking findings. If
@@ -763,6 +763,295 @@ run_devin_review() {
   return 0
 }
 
+is_coderabbit_blocking() {
+  # Returns 0 (true) if the comment body contains a blocking severity marker.
+  # Critical (🔴) and Major (🟠) are blocking; Minor (🟡) and Low (🟢) are not.
+  local body="$1"
+  if printf '%s\n' "$body" | grep -q "🔴"; then return 0; fi
+  if printf '%s\n' "$body" | grep -q "🟠"; then return 0; fi
+  return 1
+}
+
+run_coderabbit_review() {
+  local pr_number="$1"
+  local branch_name="$2"
+  local poll_interval="$3"
+  local max_wait="$4"
+  local platform="coderabbit"
+  local bot_login="coderabbitai[bot]"
+  local repo
+  local head_sha=""
+  local since_iso=""
+  local existing_comments=""
+  local existing_blocking_file=""
+  local existing_blocking_count=0
+  local existing_suggestion_count=0
+  local comment_json=""
+  local body=""
+  local blocking_lines_file=""
+  local elapsed=0
+  local comments=""
+  local blocking_count=0
+  local suggestion_count=0
+  local comment_count=0
+  local index=1
+  local blocking_json=""
+  local stale_file=""
+
+  trap 'rm -f "${existing_blocking_file:-}" "${blocking_lines_file:-}" "${stale_file:-}"' RETURN
+
+  require_gh
+  cd_workflow_repo_root
+  repo="$(repo_slug)"
+
+  head_sha="$(gh api "repos/$repo/pulls/$pr_number" --jq '.head.sha')"
+  if [ -z "$head_sha" ]; then
+    print_kv RESULT escalate
+    print_kv REASON "head-sha-unavailable"
+    print_kv PLATFORM "$platform"
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv REVIEW_COMMENT_ID ""
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    return 2
+  fi
+  since_iso="$(gh api "repos/$repo/commits/$head_sha" --jq '.commit.committer.date // empty')"
+  if [ -z "$since_iso" ]; then
+    since_iso="$(date -u -v-24H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '24 hours ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
+  fi
+
+  # --- Phase 1: Check for existing blocking findings on the current HEAD ---
+  existing_comments="$(
+    gh api "repos/$repo/pulls/$pr_number/comments" --paginate \
+      | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
+          .[]
+          | select(.user.login == $bot and .created_at > $since and .in_reply_to_id == null)
+          | { path, line: (.line // .original_line // 0), body: (.body // "") }
+          | @json
+        '
+  )"
+
+  existing_blocking_file="$(mktemp)"
+  while IFS= read -r comment_json; do
+    [ -z "${comment_json:-}" ] && continue
+    body="$(printf '%s\n' "$comment_json" | jq -r '.body')"
+    [ -z "$body" ] && continue
+    if is_coderabbit_blocking "$body"; then
+      existing_blocking_count=$((existing_blocking_count + 1))
+      printf '%s\n' "$comment_json" >> "$existing_blocking_file"
+    else
+      existing_suggestion_count=$((existing_suggestion_count + 1))
+    fi
+  done <<< "$existing_comments"
+
+  if [ "$existing_blocking_count" -gt 0 ]; then
+    print_kv RESULT needs_fixes
+    print_kv PLATFORM "$platform"
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv REVIEW_COMMENT_ID ""
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv REASON existing_findings
+    print_kv COMMENT_COUNT "$((existing_blocking_count + existing_suggestion_count))"
+    print_kv BLOCKING_COUNT "$existing_blocking_count"
+    print_kv SUGGESTION_COUNT "$existing_suggestion_count"
+    while IFS= read -r blocking_json; do
+      [ -z "${blocking_json:-}" ] && continue
+      print_kv "BLOCKING_${index}_PATH" "$(printf '%s\n' "$blocking_json" | jq -r '.path')"
+      print_kv "BLOCKING_${index}_LINE" "$(printf '%s\n' "$blocking_json" | jq -r '.line')"
+      print_kv_escaped "BLOCKING_${index}_BODY" "$(printf '%s\n' "$blocking_json" | jq -r '.body')"
+      index=$((index + 1))
+    done < "$existing_blocking_file"
+    rm -f "$existing_blocking_file"
+    return 1
+  fi
+
+  rm -f "$existing_blocking_file"
+
+  # --- Phase 2: Poll for CodeRabbit review completion ---
+  # CodeRabbit signals completion by posting a COMMENTED review after the HEAD commit.
+  # Unlike Devin, there are no check runs to monitor — we rely solely on the review.
+  #
+  local coderabbit_review_count=0
+  local coderabbit_any_activity=0
+
+  while :; do
+    # Check for any CodeRabbit review submitted after the HEAD commit
+    coderabbit_review_count="$(
+      gh api "repos/$repo/pulls/$pr_number/reviews" --paginate \
+        | jq --arg bot "$bot_login" --arg since "$since_iso" '
+            [.[]
+             | select(
+                 .user.login == $bot and
+                 .submitted_at > $since
+               )
+            ] | length
+          '
+    )"
+    coderabbit_review_count="${coderabbit_review_count:-0}"
+
+    if [ "$coderabbit_review_count" -gt 0 ]; then
+      coderabbit_any_activity=1
+      break
+    fi
+
+    # Also check for CodeRabbit issue comments (summary comment) as activity signal
+    if [ "$coderabbit_any_activity" -eq 0 ]; then
+      local activity_count
+      activity_count="$(
+        gh api "repos/$repo/issues/$pr_number/comments" --paginate \
+          | jq --arg bot "$bot_login" '
+              [.[] | select(.user.login == $bot)] | length
+            '
+      )"
+      if [ "${activity_count:-0}" -gt 0 ]; then
+        coderabbit_any_activity=1
+      fi
+    fi
+
+    if [ "$elapsed" -ge "$max_wait" ]; then
+      if [ "$coderabbit_any_activity" -eq 0 ]; then
+        # CodeRabbit didn't review this HEAD. Check for stale findings before skipping.
+        local stale_count=0
+        local stale_blocking_count=0
+        local stale_comments
+        stale_comments="$(
+          gh api "repos/$repo/pulls/$pr_number/comments" --paginate \
+            | jq -r --arg bot "$bot_login" '
+                .[]
+                | select(
+                    .user.login == $bot and
+                    .in_reply_to_id == null
+                  )
+                | { path, line: (.line // .original_line // 0), body: (.body // "") }
+                | @json
+              '
+        )"
+        stale_file="$(mktemp)"
+        while IFS= read -r comment_json; do
+          [ -z "${comment_json:-}" ] && continue
+          body="$(printf '%s\n' "$comment_json" | jq -r '.body')"
+          [ -z "$body" ] && continue
+          if is_coderabbit_blocking "$body"; then
+            stale_blocking_count=$((stale_blocking_count + 1))
+            printf '%s\n' "$comment_json" >> "$stale_file"
+          fi
+          stale_count=$((stale_count + 1))
+        done <<< "$stale_comments"
+
+        if [ "$stale_blocking_count" -gt 0 ]; then
+          print_kv RESULT needs_fixes
+          print_kv PLATFORM "$platform"
+          print_kv PR_NUMBER "$pr_number"
+          print_kv BRANCH "$branch_name"
+          print_kv REVIEW_COMMENT_ID ""
+          print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+          print_kv REASON stale_findings
+          print_kv COMMENT_COUNT "$stale_count"
+          print_kv BLOCKING_COUNT "$stale_blocking_count"
+          print_kv SUGGESTION_COUNT "$((stale_count - stale_blocking_count))"
+          while IFS= read -r blocking_json; do
+            [ -z "${blocking_json:-}" ] && continue
+            print_kv "BLOCKING_${index}_PATH" "$(printf '%s\n' "$blocking_json" | jq -r '.path')"
+            print_kv "BLOCKING_${index}_LINE" "$(printf '%s\n' "$blocking_json" | jq -r '.line')"
+            print_kv_escaped "BLOCKING_${index}_BODY" "$(printf '%s\n' "$blocking_json" | jq -r '.body')"
+            index=$((index + 1))
+          done < "$stale_file"
+          rm -f "$stale_file"
+          return 1
+        fi
+        rm -f "$stale_file"
+
+        print_kv RESULT skipped
+        print_kv REASON no_review
+        print_kv PLATFORM "$platform"
+        print_kv PR_NUMBER "$pr_number"
+        print_kv BRANCH "$branch_name"
+        print_kv REVIEW_COMMENT_ID ""
+        print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+        print_kv COMMENT_COUNT 0
+        print_kv BLOCKING_COUNT 0
+        print_kv SUGGESTION_COUNT 0
+        return 0
+      fi
+      print_kv RESULT escalate
+      print_kv REASON timeout
+      print_kv PLATFORM "$platform"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv BRANCH "$branch_name"
+      print_kv REVIEW_COMMENT_ID ""
+      print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      return 2
+    fi
+
+    sleep "$poll_interval"
+    elapsed=$((elapsed + poll_interval))
+  done
+
+  # --- Phase 3: Collect results after completion ---
+  blocking_lines_file="$(mktemp)"
+
+  comments="$(
+    gh api "repos/$repo/pulls/$pr_number/comments" --paginate \
+      | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
+        .[]
+        | select(.user.login == $bot and .created_at > $since and .in_reply_to_id == null)
+        | {
+            path,
+            line: (.line // .original_line // 0),
+            body: (.body // "")
+          }
+        | @json
+      '
+  )"
+
+  while IFS= read -r comment_json; do
+    [ -z "${comment_json:-}" ] && continue
+    body="$(printf '%s\n' "$comment_json" | jq -r '.body')"
+    [ -z "$body" ] && continue
+    comment_count=$((comment_count + 1))
+    if is_coderabbit_blocking "$body"; then
+      blocking_count=$((blocking_count + 1))
+      printf '%s\n' "$comment_json" >> "$blocking_lines_file"
+    else
+      suggestion_count=$((suggestion_count + 1))
+    fi
+  done <<< "$comments"
+
+  if [ "$blocking_count" -gt 0 ]; then
+    print_kv RESULT needs_fixes
+    print_kv PLATFORM "$platform"
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv REVIEW_COMMENT_ID ""
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv COMMENT_COUNT "$comment_count"
+    print_kv BLOCKING_COUNT "$blocking_count"
+    print_kv SUGGESTION_COUNT "$suggestion_count"
+    while IFS= read -r blocking_json; do
+      [ -z "${blocking_json:-}" ] && continue
+      print_kv "BLOCKING_${index}_PATH" "$(printf '%s\n' "$blocking_json" | jq -r '.path')"
+      print_kv "BLOCKING_${index}_LINE" "$(printf '%s\n' "$blocking_json" | jq -r '.line')"
+      print_kv_escaped "BLOCKING_${index}_BODY" "$(printf '%s\n' "$blocking_json" | jq -r '.body')"
+      index=$((index + 1))
+    done < "$blocking_lines_file"
+    rm -f "$blocking_lines_file"
+    return 1
+  fi
+
+  rm -f "$blocking_lines_file"
+  print_kv RESULT clean
+  print_kv PLATFORM "$platform"
+  print_kv PR_NUMBER "$pr_number"
+  print_kv BRANCH "$branch_name"
+  print_kv REVIEW_COMMENT_ID ""
+  print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+  print_kv COMMENT_COUNT "$comment_count"
+  print_kv BLOCKING_COUNT 0
+  print_kv SUGGESTION_COUNT "$suggestion_count"
+  return 0
+}
+
 run_platform_review() {
   local platform="$1"
   local pr_number="$2"
@@ -776,6 +1065,9 @@ run_platform_review() {
       ;;
     devin)
       run_devin_review "$pr_number" "$branch_name" "$poll_interval" "$max_wait"
+      ;;
+    coderabbit)
+      run_coderabbit_review "$pr_number" "$branch_name" "$poll_interval" "$max_wait"
       ;;
     *)
       print_kv RESULT skipped


### PR DESCRIPTION
## Summary

- Add CodeRabbit support at two levels: **CLI plugin** for pre-push reviews (Path A) and **GitHub App** as an external PR reviewer platform in `pr-review-loop.sh` (Path B)
- Ship `.coderabbit.yaml` with auto-review **disabled by default** — projects opt in per-repo
- CodeRabbit severity classification: Critical/Major are blocking, Minor/Low are suggestions (unlike Devin where all findings block)

## Changes

- **`.coderabbit.yaml`** — default config with auto PR review off, path filters, assertive profile
- **`docs/ai/development-workflow/integrations/coderabbit.md`** — integration doc covering both usage modes
- **`scripts/development-workflow/pr-review-loop.sh`** — `run_coderabbit_review()` adapter with completion polling, severity-based blocking classification, and stale findings recovery
- **`.ai-dev-workflow.yaml`** — updated supported platforms comment
- **`REVIEW.md`** — added CodeRabbit CLI to tool guidance
- **`pr-review-platform.md`** — added CodeRabbit to platform list

## How to enable per-project

1. Set `reviews.auto_review.enabled: true` in `.coderabbit.yaml`
2. Add `coderabbit` to `review.platforms` in `.ai-dev-workflow.yaml`
3. Install the CodeRabbit GitHub App on the repository

## Test plan

- [ ] Verify `.coderabbit.yaml` prevents auto-reviews when `enabled: false`
- [ ] Enable Path B on a test repo and confirm `pr-review-loop.sh --platform coderabbit` polls and classifies findings correctly
- [ ] Verify Critical/Major findings are classified as blocking, Minor/Low as suggestions
- [ ] Verify stale findings recovery works when CodeRabbit doesn't review current HEAD
- [ ] Confirm `/coderabbit:review` works in Claude Code for Path A usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/88" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
