### PR TITLE
fix(protocol): fetch and pull latest develop before creating release branch

### DIFF
--- a/.claude/commands/prepare-release.md
+++ b/.claude/commands/prepare-release.md
@@ -1,6 +1,6 @@
 ---
 description: Prepare a release from develop. Creates the release branch, updates CHANGELOG, bumps version, opens PRs to main and develop, then drives reviewer loop + ready-for-regression + CI on the main PR before human merge. Usage: /prepare-release [version number, e.g. 1.2.0]
-allowed-tools: Bash(git checkout:*), Bash(git pull:*), Bash(git push:*), Bash(git log:*), Bash(git status:*), Bash(git branch:*), Bash(git diff:*), Bash(gh pr create:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(gh pr edit:*), Bash(gh pr comment:*), Bash(gh api:*), Bash(date:*), Bash(./scripts/development-workflow/pr-review-loop.sh:*), Bash(./scripts/development-workflow/pr-ci-loop.sh:*)
+allowed-tools: Bash(git checkout:*), Bash(git fetch:*), Bash(git pull:*), Bash(git push:*), Bash(git log:*), Bash(git status:*), Bash(git branch:*), Bash(git diff:*), Bash(gh pr create:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(gh pr edit:*), Bash(gh pr comment:*), Bash(gh api:*), Bash(date:*), Bash(./scripts/development-workflow/pr-review-loop.sh:*), Bash(./scripts/development-workflow/pr-ci-loop.sh:*)
 ---
 
 Follow the release protocol exactly as defined in:
@@ -10,6 +10,7 @@ Follow the release protocol exactly as defined in:
 Key rules:
 
 - Verify working directory is clean and currently on `develop` before starting
+- Run `git fetch origin && git pull origin develop` before creating the release branch; if the pull fails, stop and report
 - If no version provided, inspect `[Unreleased]` entries and suggest the next version
 - Confirm the version with the human before creating the branch
 - Open **two** PRs: one to `main`, one backport to `develop`

--- a/.cursor/commands/prepare-release.md
+++ b/.cursor/commands/prepare-release.md
@@ -9,6 +9,7 @@ Follow the release protocol exactly as defined in:
 Key rules:
 
 - Verify working directory is clean and currently on `develop` before starting
+- Run `git fetch origin && git pull origin develop` before creating the release branch; if the pull fails, stop and report
 - If no version provided, inspect `[Unreleased]` entries and suggest the next version
 - Confirm the version with the human before creating the branch
 - Open **two** PRs: one to `main`, one backport to `develop`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Prepare-release pre-flight sync**: the release protocol now runs `git fetch origin && git pull origin develop` (with a code block and failure guidance) before creating the release branch, preventing stale local state from being released. The `/prepare-release` command wrappers (Claude Code and Cursor) also now explicitly list this as a key rule. `git fetch` is also added to the Claude Code command's `allowed-tools`.
+
 ## [0.21.0] - 2026-04-13
 
 ### Added

--- a/docs/ai/development-workflow/protocols/05-prepare-release-protocol.md
+++ b/docs/ai/development-workflow/protocols/05-prepare-release-protocol.md
@@ -11,7 +11,14 @@ Before doing anything, verify:
 
 1. Working directory is clean (`git status` returns no uncommitted changes). If not, stop and report.
 2. Currently on `develop`. If not, stop and report.
-3. Pull latest: `git pull origin develop`
+3. Fetch and pull latest from remote so the release branch is created from up-to-date state:
+
+   ```bash
+   git fetch origin
+   git pull origin develop
+   ```
+
+   If the pull fails (e.g., diverged history), stop and report to the human.
 
 ---
 


### PR DESCRIPTION
## What

The prepare-release protocol's Pre-flight Check #3 previously said only `Pull latest: \`git pull origin develop\``. This was a single-line bullet that didn't include `git fetch origin`, provided no code block, and gave no guidance for failure.

If the local `develop` was behind `origin/develop` and the executor skipped or misread that check, the release branch would be created from stale state — missing merged commits.

## Changes

- **`docs/ai/development-workflow/protocols/05-prepare-release-protocol.md`**: Pre-flight step 3 now runs `git fetch origin` followed by `git pull origin develop` in a fenced code block, and explicitly instructs the agent to stop and report if the pull fails.
- **`.claude/commands/prepare-release.md`**: Added `git fetch origin && git pull origin develop` as an explicit key rule; also added `Bash(git fetch:*)` to `allowed-tools` so the command has permission to run the fetch.
- **`.cursor/commands/prepare-release.md`**: Same key rule added.

## Test plan

- [ ] Read the updated protocol — Pre-flight step 3 shows a `git fetch origin` + `git pull origin develop` code block with failure guidance
- [ ] Read both command wrappers — each lists the fetch+pull as an explicit key rule
- [ ] Verify no other files were modified (scope ≤ 3 files)

Closes #92