### PR TITLE
fix(protocol-90): enforce worktree isolation for parallel batched items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Thumbs.db
 
 # Claude Code
 .claude/settings.local.json
+.claude/worktrees/
 
 # Temp files
 .tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Worktree isolation for parallel batch dispatch**: protocols `90-batch-orchestrate-work-protocol.md` and `91-orchestrate-work-protocol.md` now require each Work Item Runner in a parallel batch to operate in a dedicated git worktree. Includes `BATCH_CONTEXT=true` handoff signal, pre-flight worktree checks, base-branch table for all item types, and stage protocol compatibility notes.
+
 ### Fixed
 
 - **Implementation protocol pre-branch fetch**: all four paths (Full Pipeline, Refactor, Fast Track, Hotfix) in protocol `03-implement-development-protocol.md` now include `git fetch origin` before branching from `develop` or `main`, matching the pattern already used in the prepare-release protocol (`05`). This prevents merge conflicts caused by stale local remote-tracking refs when creating feature/refactor/fix/hotfix branches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Implementation protocol pre-branch fetch**: all four paths (Full Pipeline, Refactor, Fast Track, Hotfix) in protocol `03-implement-development-protocol.md` now include `git fetch origin` before branching from `develop` or `main`, matching the pattern already used in the prepare-release protocol (`05`). This prevents merge conflicts caused by stale local remote-tracking refs when creating feature/refactor/fix/hotfix branches.
 - **Prepare-release pre-flight sync**: the release protocol now runs `git fetch origin && git pull origin develop` (with a code block and failure guidance) before creating the release branch, preventing stale local state from being released. The `/prepare-release` command wrappers (Claude Code and Cursor) also now explicitly list this as a key rule. `git fetch` is also added to the Claude Code command's `allowed-tools`.
 
 ## [0.21.0] - 2026-04-13

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -179,7 +179,15 @@ Extract from your reading:
 ### Refactor Steps
 
 1. If no blocking ambiguity remains, proceed without an extra approval pause; otherwise stop and ask the human
-2. Branch: `git checkout -b refactor/[branch-slug]` from `develop` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without)
+2. Branch from `develop` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without):
+
+```bash
+git fetch origin
+git checkout develop
+git pull origin develop
+git checkout -b refactor/[branch-slug]
+```
+
 3. Implement following the plan order. Follow `docs/best-practices/` for all code written.
 4. If scope is larger than the plan described, **stop and report**
 5. Verify: build, lint, tests pass; run e2e suite if a spec exists for the affected area
@@ -221,7 +229,15 @@ gh pr create --draft --title "refactor([scope]): [short description]" --body "..
 
 1. Read the brief. If the work item exists in an issue tracker, follow `docs/ai/development-workflow/integrations/issue-tracker.md` for `In Development (Fast Track)` expectations.
 2. If no blocking ambiguity remains, proceed without an extra approval pause; otherwise stop and ask the human
-3. Branch: `git checkout -b fix/[branch-slug]` from `develop` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without)
+3. Branch from `develop` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without):
+
+```bash
+git fetch origin
+git checkout develop
+git pull origin develop
+git checkout -b fix/[branch-slug]
+```
+
 4. Implement the fix
 5. Verify: build, lint, tests pass; run e2e suite if a spec exists for the affected area
 6. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry (skip if this fixes unreleased work that already has an entry — update the existing entry instead, or leave it unchanged if it already describes the correct behavior)
@@ -240,7 +256,15 @@ gh pr create --draft --title "refactor([scope]): [short description]" --body "..
 
 1. Read the incident brief from the human
 2. Confirm it's a production-only issue (not a dev/staging issue)
-3. Branch: `git checkout -b hotfix/[branch-slug]` from `main` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without)
+3. Branch from `main` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without):
+
+```bash
+git fetch origin
+git checkout main
+git pull origin main
+git checkout -b hotfix/[branch-slug]
+```
+
 4. Implement the minimal fix (do not bundle unrelated changes)
 5. Verify: build, lint, tests pass
 6. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry (hotfixes always fix released code, so a new entry is always required)

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -58,6 +58,7 @@ Determine the branch slug:
 - **Without issue tracker**: `[slug]` (e.g., `user-auth`)
 
 ```bash
+git fetch origin
 git checkout develop
 git pull origin develop
 git checkout -b feature/[branch-slug]

--- a/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -165,6 +165,7 @@ For each item in the batch, prepare a short handoff:
 - Current next action
 - Priority context
 - Parallelization notes or serialization reason
+- `BATCH_CONTEXT=true` — required for parallel batches so the Work Item Runner (protocol 91) activates worktree isolation
 
 ### Worktree isolation requirement
 

--- a/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -166,6 +166,44 @@ For each item in the batch, prepare a short handoff:
 - Priority context
 - Parallelization notes or serialization reason
 
+### Worktree isolation requirement
+
+**When batching items for parallel dispatch**: Each item in a parallel batch **must** run in its own isolated worktree (or checked-out copy) to prevent branch contamination, PR cross-pollution, and shared-state conflicts between concurrent agents.
+
+Do **not** dispatch multiple Work Item Runners to operate in the same working directory.
+
+---
+
+## Step 3.5: Pre-Flight Worktree Check (Parallel Batches Only)
+
+Before dispatching a parallel batch, validate that each item can be isolated.
+
+For each item in the batch:
+
+```bash
+# Check if the item's branch already has a worktree
+git worktree list | grep -F "<branch-name>"
+
+# If no match, the pre-flight check passes for this item.
+# The Work Item Runner (Step 4, protocol 91) will create the worktree.
+
+# If a match is found and points to an active worktree:
+# - If the worktree is on the same branch and clean, it is safe to reuse
+# - If the worktree is on a different branch or dirty, the pre-flight fails
+```
+
+**Failure handling**:
+
+If the pre-flight check finds an active worktree on a conflicting branch or in a dirty state:
+
+1. Stop the batch dispatch
+2. Report to the human which item(s) have conflicting worktrees
+3. Ask the human to either:
+   - Remove the conflicting worktree (`git worktree remove <path>`)
+   - Or manually run the item serially after the batch completes
+
+Proceed with batch dispatch only when all pre-flight checks pass.
+
 ---
 
 ## Step 4: Dispatch Work Item Runners

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -168,18 +168,25 @@ Use the matching workflow agent / skill for the next stage when your runner supp
 
 **Note:** Use `origin/<base>` (remote tracking) rather than local `<base>` to avoid git worktree conflicts if the local base branch is already checked out elsewhere.
 
-3. Create the worktree with the item's branch directly (preferred):
+3. Create the worktree. The command depends on whether the item's branch already exists:
 
 ```bash
 # Fetch latest remote refs first
 git fetch origin
 
-# Create worktree and immediately check out a new branch from origin/<base>
+# Case A: New item — branch does not exist yet
 git worktree add <worktree-path> -b <branch-prefix>/<slug> origin/<base-branch>
+
+# Case B: Resuming item — branch exists locally
+git worktree add <worktree-path> <branch-prefix>/<slug>
+
+# Case C: Resuming item — branch exists only on remote
+git worktree add <worktree-path> -b <branch-prefix>/<slug> origin/<branch-prefix>/<slug>
+
 cd <worktree-path>
 ```
 
-This is preferred over detached-HEAD mode because it creates the branch in one step and avoids conflicts with stage protocols (e.g., protocol 03) that assume a branch is already checked out.
+Use the pre-dispatch branch check from Step 2 (`git branch --list`, `git branch -r --list`) to determine which case applies. Case B and C are common when resuming "In Development" items, PRs with `needs-fixes`, or any item with prior work.
 
 **Important — stage protocol compatibility**: When working inside a worktree created with this method, the stage protocol's initial branching steps (`git fetch origin`, `git checkout develop`, `git pull origin develop`, `git checkout -b ...`) are **already satisfied** by the worktree creation above. The stage agent should skip those steps and proceed directly to the implementation work. If the stage agent runs `git checkout develop` inside the worktree, it will fail because `develop` is already checked out in the main working tree and git prevents the same branch from being checked out in multiple worktrees simultaneously.
 

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -155,20 +155,42 @@ Use the matching workflow agent / skill for the next stage when your runner supp
 
 1. **Create a dedicated worktree** for this item before executing any stage work. This ensures complete isolation from other concurrent Work Item Runners in the batch.
 
-2. Execute this checkout sequence:
+2. Determine the appropriate base branch for the worktree:
+
+| Item type | Base branch |
+|-----------|------------|
+| Feature (`feature/`) | `origin/develop` |
+| Refactor (`refactor/`) | `origin/develop` |
+| Fast Track fix (`fix/`) | `origin/develop` |
+| Hotfix (`hotfix/`) | `origin/main` |
+| Spec (`spec/`) | `origin/develop` |
+| Plan (`implementation-plan/`) | `origin/develop` |
+
+**Note:** Use `origin/<base>` (remote tracking) rather than local `<base>` to avoid git worktree conflicts if the local base branch is already checked out elsewhere.
+
+3. Create the worktree using detached HEAD mode (safest):
 
 ```bash
-# Create and enter an isolated worktree for this item
-git worktree add <worktree-path> develop
+# Create an isolated worktree in detached HEAD state from origin/<base-branch>
+git worktree add <worktree-path> --detach origin/<base-branch>
 cd <worktree-path>
 
-# All subsequent work (creator stage, PR operations, etc.) happens in this worktree
-# The worktree automatically manages its own branch state and index
+# All subsequent work (creator stage, branch creation, PR operations, etc.)
+# happens in this worktree. The item orchestrator will create the feature/fix/etc.
+# branch as needed.
 ```
 
-3. **Suggested worktree path**: `<repo-root>/.claude/worktrees/<item-id>/<branch-prefix>-<slug>` where `<item-id>` is the issue number, tracker ID, or slug.
+Alternatively, if you prefer to avoid detached HEAD:
 
-4. After the item reaches a terminal condition, the cleanup script will remove the worktree:
+```bash
+# Create worktree and immediately check out a new branch
+git worktree add <worktree-path> -b <branch-prefix>/<slug> origin/<base-branch>
+cd <worktree-path>
+```
+
+4. **Suggested worktree path**: `<repo-root>/.claude/worktrees/<item-id>/<branch-prefix>-<slug>` where `<item-id>` is the issue number, tracker ID, or slug.
+
+5. After the item reaches a terminal condition, the cleanup script will remove the worktree:
 
 ```bash
 git worktree remove <worktree-path>

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -48,6 +48,10 @@ When an issue tracker is configured in `.ai-dev-workflow.yaml`, **always query t
 
 Prefer the helper scripts in `scripts/development-workflow/` for deterministic state inspection before falling back to ad hoc shell commands.
 
+### Parallel batch indicator
+
+**Check for a parallel batch context**: If this Work Item Runner was dispatched as part of a parallel batch by the Portfolio Orchestrator (`90-batch-orchestrate-work-protocol.md`), the handoff metadata will indicate `BATCH_CONTEXT=true`. Note this indicator; you will use it in Step 3 (Dispatch Strategy) to decide whether worktree isolation is required.
+
 Resolve the request to exactly one of the following:
 
 1. **Backlog / tracker work item** — use when a human explicitly requests a not-yet-started item
@@ -144,6 +148,33 @@ Use the matching workflow agent / skill for the next stage when your runner supp
 | Review plan | Native review against `REVIEW.md` or the compatibility wrapper `02-review-implementation-plan-protocol.md` |
 | Implement feature | `developer` |
 | Review code (post-draft-PR) | `code-reviewer` agent (Claude Code: `/code-review`); for other runners use compatibility wrapper `03-review-implementation-protocol.md` |
+
+### Worktree isolation for parallel batches
+
+**When dispatched as part of a parallel batch** (`BATCH_CONTEXT=true` in the handoff metadata):
+
+1. **Create a dedicated worktree** for this item before executing any stage work. This ensures complete isolation from other concurrent Work Item Runners in the batch.
+
+2. Execute this checkout sequence:
+
+```bash
+# Create and enter an isolated worktree for this item
+git worktree add <worktree-path> develop
+cd <worktree-path>
+
+# All subsequent work (creator stage, PR operations, etc.) happens in this worktree
+# The worktree automatically manages its own branch state and index
+```
+
+3. **Suggested worktree path**: `<repo-root>/.claude/worktrees/<item-id>/<branch-prefix>-<slug>` where `<item-id>` is the issue number, tracker ID, or slug.
+
+4. After the item reaches a terminal condition, the cleanup script will remove the worktree:
+
+```bash
+git worktree remove <worktree-path>
+```
+
+**When not in a parallel batch**: Worktree creation is optional but recommended for large development folders or long-running work. If not using a dedicated worktree, ensure the working directory is clean before proceeding.
 
 This protocol stays scoped to one item. It may call different stage agents over time, but it must not start scanning or dispatching unrelated items.
 

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -181,7 +181,7 @@ cd <worktree-path>
 
 This is preferred over detached-HEAD mode because it creates the branch in one step and avoids conflicts with stage protocols (e.g., protocol 03) that assume a branch is already checked out.
 
-**Important — stage protocol compatibility**: When working inside a worktree created with this method, the stage protocol's initial branching steps (`git fetch origin`, `git checkout develop`, `git pull origin develop`, `git checkout -b ...`) are **already satisfied** by the worktree creation above. The stage agent should skip those steps and proceed directly to the implementation work. If the stage agent runs `git checkout develop` inside the worktree, it will fail because the worktree is already on the correct branch.
+**Important — stage protocol compatibility**: When working inside a worktree created with this method, the stage protocol's initial branching steps (`git fetch origin`, `git checkout develop`, `git pull origin develop`, `git checkout -b ...`) are **already satisfied** by the worktree creation above. The stage agent should skip those steps and proceed directly to the implementation work. If the stage agent runs `git checkout develop` inside the worktree, it will fail because `develop` is already checked out in the main working tree and git prevents the same branch from being checked out in multiple worktrees simultaneously.
 
 4. **Suggested worktree path**: `<repo-root>/.claude/worktrees/<item-id>/<branch-prefix>-<slug>` where `<item-id>` is the issue number, tracker ID, or slug.
 

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -168,25 +168,20 @@ Use the matching workflow agent / skill for the next stage when your runner supp
 
 **Note:** Use `origin/<base>` (remote tracking) rather than local `<base>` to avoid git worktree conflicts if the local base branch is already checked out elsewhere.
 
-3. Create the worktree using detached HEAD mode (safest):
+3. Create the worktree with the item's branch directly (preferred):
 
 ```bash
-# Create an isolated worktree in detached HEAD state from origin/<base-branch>
-git worktree add <worktree-path> --detach origin/<base-branch>
-cd <worktree-path>
+# Fetch latest remote refs first
+git fetch origin
 
-# All subsequent work (creator stage, branch creation, PR operations, etc.)
-# happens in this worktree. The item orchestrator will create the feature/fix/etc.
-# branch as needed.
-```
-
-Alternatively, if you prefer to avoid detached HEAD:
-
-```bash
-# Create worktree and immediately check out a new branch
+# Create worktree and immediately check out a new branch from origin/<base>
 git worktree add <worktree-path> -b <branch-prefix>/<slug> origin/<base-branch>
 cd <worktree-path>
 ```
+
+This is preferred over detached-HEAD mode because it creates the branch in one step and avoids conflicts with stage protocols (e.g., protocol 03) that assume a branch is already checked out.
+
+**Important — stage protocol compatibility**: When working inside a worktree created with this method, the stage protocol's initial branching steps (`git fetch origin`, `git checkout develop`, `git pull origin develop`, `git checkout -b ...`) are **already satisfied** by the worktree creation above. The stage agent should skip those steps and proceed directly to the implementation work. If the stage agent runs `git checkout develop` inside the worktree, it will fail because the worktree is already on the correct branch.
 
 4. **Suggested worktree path**: `<repo-root>/.claude/worktrees/<item-id>/<branch-prefix>-<slug>` where `<item-id>` is the issue number, tracker ID, or slug.
 

--- a/docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -53,6 +53,17 @@ A **blocking** inline comment or review from a configured platform (see `.ai-dev
 
 Do not assume the latest bot comment is the only active issue. A fixer may address a doc-only or secondary item while leaving an earlier code bug untouched. After each fixer push, verify the change fixes the **substantive problem** described in each open finding (e.g. the referenced file and behavior), not only a stale reference or a single resolved thread.
 
+#### Verification: Re-read to confirm each fix
+
+**Critical:** When a fixer agent addresses a review finding and commits changes:
+
+1. **Before marking a finding resolved**: The fixer agent must re-read the specific file and line referenced in the finding to confirm the fix is actually present in the current code.
+2. **Do not rely on memory alone**: Just because the agent planned or implemented a fix does not mean it is present. Dismissing findings as "already handled" without verification can mask unaddressed issues.
+3. **Per-finding re-read**: For each blocking finding, explicitly read the file/line after changes are committed, then confirm in the PR comment that the verification was performed. Example: _"Confirmed: re-read `/src/foo.ts:42` and verified the fix is present."_
+4. **Document verification in fix comments**: In the "Automated Fix" commit comment posted to the PR, state which findings were verified as resolved vs. which remain open.
+
+This prevents premature dismissal of findings and ensures the PR feedback tracking ledger accurately reflects substantive code changes.
+
 #### Stale review after timeout
 
 Also handle the case where a platform posted blocking findings after a previous run timed out and the agent moved on: if those findings are still unresolved per the rules above, dispatch a fixer, wait for the push, then run the scripts.


### PR DESCRIPTION
Adds worktree isolation requirement to batch orchestration protocol (90) and mandates worktree creation in item orchestrator (91) when dispatched as part of parallel batch.

Changes:
- Protocol 90: Added worktree isolation requirement in Step 3 and new Step 3.5 with pre-flight worktree check for parallel batches
- Protocol 91: Added parallel batch indicator check in Step 1 and worktree isolation mandate in Step 3

This prevents branch contamination and PR cross-pollution when multiple agents run in parallel.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
