### PR TITLE
fix(protocol-93): require re-reading diff to verify review findings are resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Reviewer loop verification (Protocol 93)**: added explicit "Verification: Re-read to confirm each fix" section requiring fixer agents to re-read specific file/line references in review findings before marking them resolved. This prevents premature dismissal of findings based on memory alone and ensures substantive code changes are actually present in the PR.
 - **Prepare-release pre-flight sync**: the release protocol now runs `git fetch origin && git pull origin develop` (with a code block and failure guidance) before creating the release branch, preventing stale local state from being released. The `/prepare-release` command wrappers (Claude Code and Cursor) also now explicitly list this as a key rule. `git fetch` is also added to the Claude Code command's `allowed-tools`.
 
 ## [0.21.0] - 2026-04-13

--- a/docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -53,6 +53,17 @@ A **blocking** inline comment or review from a configured platform (see `.ai-dev
 
 Do not assume the latest bot comment is the only active issue. A fixer may address a doc-only or secondary item while leaving an earlier code bug untouched. After each fixer push, verify the change fixes the **substantive problem** described in each open finding (e.g. the referenced file and behavior), not only a stale reference or a single resolved thread.
 
+#### Verification: Re-read to confirm each fix
+
+**Critical:** When a fixer agent addresses a review finding and commits changes:
+
+1. **Before marking a finding resolved**: The fixer agent must re-read the specific file and line referenced in the finding to confirm the fix is actually present in the current code.
+2. **Do not rely on memory alone**: Just because the agent planned or implemented a fix does not mean it is present. Dismissing findings as "already handled" without verification can mask unaddressed issues.
+3. **Per-finding re-read**: For each blocking finding, explicitly read the file/line after changes are committed, then confirm in the PR comment that the verification was performed. Example: _"Confirmed: re-read `/src/foo.ts:42` and verified the fix is present."_
+4. **Document verification in fix comments**: In the "Automated Fix" commit comment posted to the PR, state which findings were verified as resolved vs. which remain open.
+
+This prevents premature dismissal of findings and ensures the PR feedback tracking ledger accurately reflects substantive code changes.
+
 #### Stale review after timeout
 
 Also handle the case where a platform posted blocking findings after a previous run timed out and the agent moved on: if those findings are still unresolved per the rules above, dispatch a fixer, wait for the push, then run the scripts.


### PR DESCRIPTION
Fixes issue #97

Add explicit verification step requiring agents to re-read specific file/line references in review findings before marking them resolved. This prevents premature dismissal of findings based on memory alone and ensures substantive code changes are actually present in the PR.