### PR TITLE
fix(protocol-91): add CWD safety mandate before worktree cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Worktree isolation for parallel batch dispatch**: protocols `90-batch-orchestrate-work-protocol.md` and `91-orchestrate-work-protocol.md` now require each Work Item Runner in a parallel batch to operate in a dedicated git worktree. Includes `BATCH_CONTEXT=true` handoff signal, pre-flight worktree checks, base-branch table for all item types, and stage protocol compatibility notes.
+- **Worktree isolation for parallel batch dispatch**: protocols `90-batch-orchestrate-work-protocol.md` and `91-orchestrate-work-protocol.md` now require each Work Item Runner in a parallel batch to operate in a dedicated git worktree. Includes `BATCH_CONTEXT=true` handoff signal, pre-flight worktree checks, base-branch table for all item types, stage protocol compatibility notes, CWD safety mandate (`cd` to repo root before `git worktree remove`), and corrected Step 10 cleanup sequence (worktree removal before branch deletion).
 
 ### Fixed
 

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -195,8 +195,14 @@ Use the pre-dispatch branch check from Step 2 (`git branch --list`, `git branch 
 5. After the item reaches a terminal condition, the cleanup script will remove the worktree:
 
 ```bash
+# IMPORTANT: Change directory to the main repo root BEFORE deleting the worktree
+cd <repo-root>
 git worktree remove <worktree-path>
 ```
+
+**Critical safety rule:** You **must** `cd` to the repository root or any other valid directory **before** executing `git worktree remove`. If the shell's current working directory (CWD) is inside the worktree being deleted, the directory will cease to exist immediately after `git worktree remove` completes. All subsequent bash commands will fail with "directory not found" errors, causing the orchestration to break and requiring manual intervention or agent re-delegation.
+
+After removing the worktree, verify that the CWD is still valid by running a simple command like `pwd` before executing any further shell operations.
 
 **When not in a parallel batch**: Worktree creation is optional but recommended for large development folders or long-running work. If not using a dedicated worktree, ensure the working directory is clean before proceeding.
 

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -521,9 +521,9 @@ When a human confirms that a PR has been merged, update the issue tracker and cl
 
 ```bash
 git fetch origin
-git branch -D <merged-branch>           # force-delete local branch (squash merges need -D)
 cd <repo-root>                          # CRITICAL: change to repo root before removing worktree (see Step 3)
-git worktree remove <worktree-path>     # remove worktree if present
+git worktree remove <worktree-path>     # remove worktree first (branch is checked out there)
+git branch -D <merged-branch>           # force-delete local branch (squash merges need -D)
 ```
 
 If the item's tracker status is already in a further-advanced state (e.g., already `In Development` when a spec PR merges), do not roll it back — leave it as-is and only clean up local branches/worktrees.

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -522,6 +522,7 @@ When a human confirms that a PR has been merged, update the issue tracker and cl
 ```bash
 git fetch origin
 git branch -D <merged-branch>           # force-delete local branch (squash merges need -D)
+cd <repo-root>                          # CRITICAL: change to repo root before removing worktree (see Step 3)
 git worktree remove <worktree-path>     # remove worktree if present
 ```
 


### PR DESCRIPTION
## Summary

Protocol 91's cleanup section did not mandate changing directory to the main repo root before running `git worktree remove`. If the agent's CWD is inside the worktree being deleted, all subsequent bash commands fail because the directory no longer exists.

This was the #1 recurring friction point in real usage, affecting 5+ sessions.

## Changes

- Added explicit requirement to `cd` to the repository root before executing `git worktree remove`
- Added critical safety rule explaining the consequences of removing a worktree while CWD is inside it
- Added post-cleanup verification instruction (`pwd` before further shell operations)

## Fixes

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
