### PR TITLE
docs(spec): retrospective protocol

### DIFF
--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -1,0 +1,207 @@
+# Retrospective Protocol — Spec
+
+**Depends on**: <!-- None -->
+
+---
+
+## Guiding principle (important)
+
+This stage is intentionally **product-focused**:
+
+- Write **user-facing behavior**, permissions, UX rules, and acceptance criteria.
+- Avoid prescribing **implementation details** (database tables/columns, specific endpoints, file paths, class names, or migration design). Those belong in the **Implementation Plan** stage.
+- If a technical constraint matters to the product (e.g., "an agent may belong to multiple broker companies"), express it as a **product requirement** without naming tables.
+
+## Overview
+
+This feature adds a retrospective analysis capability to the AI development workflow. After completing a batch or individual item, the agent analyzes the work that was done, identifies process improvement opportunities, presents them to the human, and takes the action the human chooses for each. The retrospective is always suggested at natural completion points — never forced — and works whether or not conversation context is available.
+
+---
+
+## Use Cases
+
+### Use Case 1: On-Demand Retrospective (Fresh Session)
+
+**Actor**: Developer (human) invoking `/retrospective` in a new session without prior conversation history about the completed work
+**Preconditions**: One or more PRs have been opened or merged recently in the repository
+
+**Steps**:
+1. The developer invokes `/retrospective` (optionally with a scope hint, e.g., a PR number, branch name, or batch date)
+2. The agent queries GitHub for PR metadata: review cycle count, finding types (labeling issues, wrong base branch, CHANGELOG conflicts, agent misbehavior signals visible in PR comments), labels applied/missing, and merge conflicts
+3. The agent analyzes git history for the relevant PRs: commit patterns, fix-commit ratio, and review iteration count
+4. The agent synthesizes findings into a categorized list of improvement opportunities (see Business Rules: Categorization)
+5. The agent presents the opportunities to the human with a recommended action for each
+6. For each opportunity, the human chooses: **Address now** or **Add to backlog**
+7. The agent executes the chosen action for each opportunity (see Use Case 3 and 4)
+8. The agent confirms what was done and closes the retrospective
+
+**Postconditions**: Each improvement opportunity has either been addressed in the current session or added as a backlog issue
+
+**Information shown**:
+- Categorized improvement opportunities, each with: description, category label, severity signal, and recommended action
+- After action execution: confirmation of what was done (fix applied or issue created with link)
+
+**Actions available**:
+- Choose "Address now" for a given opportunity
+- Choose "Add to backlog" for a given opportunity
+- Skip an opportunity (take no action)
+
+**Considerations**:
+- If no scope hint is provided, the agent uses recent PRs from the current repository as the default scope
+- If GitHub data is insufficient to surface meaningful findings, the agent says so and closes gracefully
+- The agent does not make any changes or create any issues without the human's explicit choice
+
+---
+
+### Use Case 2: End-of-Batch / End-of-Item Retrospective (Same Session)
+
+**Actor**: Portfolio Orchestrator (protocol 90) or Work Item Runner (protocol 91) suggesting a retrospective at the end of a run, with conversation context available
+**Preconditions**: At least one PR was processed in the current session
+
+**Steps**:
+1. After presenting the batch or item summary, the agent suggests running a retrospective: *"Would you like to run a retrospective on this session's work?"*
+2. If the human agrees, the agent runs the retrospective
+3. In addition to GitHub data (as in Use Case 1), the agent also analyzes the conversation history from the current session: manual interventions, human corrections, agent deviations from protocol, and friction points that were surfaced verbally
+4. The agent synthesizes all findings (GitHub + conversation) into a categorized list of improvement opportunities
+5. The agent presents the opportunities to the human with a recommended action for each
+6. For each opportunity, the human chooses: **Address now** or **Add to backlog**
+7. The agent executes the chosen action for each opportunity
+8. The agent confirms what was done and closes the retrospective
+
+**Postconditions**: Each improvement opportunity has either been addressed in the current session or added as a backlog issue
+
+**Information shown**:
+- Same as Use Case 1, with additional findings sourced from conversation context
+- A note indicating whether findings came from GitHub data only or from both GitHub and conversation context
+
+**Actions available**:
+- Same as Use Case 1
+
+**Considerations**:
+- The agent suggests a retrospective only once per session at the end of a batch/item run
+- In protocol 91 (Work Item Runner), the suggestion is made only when the item was run standalone (not dispatched by a batch orchestrator). When `BATCH_CONTEXT=true`, the suggestion is suppressed to avoid double-triggering (the batch orchestrator handles it)
+- In protocol 90 (Portfolio Orchestrator), the suggestion is always made after the batch summary
+- Conversation context is the richest source of findings; GitHub data alone is the fallback
+
+---
+
+### Use Case 3: Address Now
+
+**Actor**: Agent (on behalf of human who chose "Address now" for an opportunity)
+**Preconditions**: The human has chosen "Address now" for a specific improvement opportunity; the opportunity has been assessed as simple enough to not require its own review loop
+
+**Steps**:
+1. The agent applies the fix directly in the current session (e.g., corrects a configuration file, updates a protocol line, fixes a `.gitignore` entry)
+2. The agent commits and pushes the change on the current or appropriate branch
+3. The agent reports completion with a diff or summary of what changed
+
+**Postconditions**: The fix is committed and pushed; no new PR or review loop is opened
+
+**Information shown**:
+- Summary of the change made
+- Confirmation that it was committed and pushed
+
+**Actions available**:
+- None after confirmation (the opportunity is closed)
+
+**Considerations**:
+- "Address now" is only valid for changes the agent can self-assess as simple (e.g., a one-line config fix, a missing label in a YAML file). The agent uses its own judgment to determine this — no fixed criteria are enumerated
+- If the agent determines that an opportunity is too complex for "Address now", it should recommend "Add to backlog" instead and explain why
+- The agent must not open a new PR or run a review loop for "Address now" changes; those belong in backlog items
+
+---
+
+### Use Case 4: Add to Backlog
+
+**Actor**: Agent (on behalf of human who chose "Add to backlog" for an opportunity)
+**Preconditions**: The human has chosen "Add to backlog" for a specific improvement opportunity
+
+**Steps**:
+1. The agent creates a GitHub issue directly using `gh issue create` with a descriptive title, a body that describes the problem and the improvement opportunity, and the appropriate labels
+2. The agent reports the created issue with its URL
+
+**Postconditions**: A GitHub issue exists representing the improvement opportunity
+
+**Information shown**:
+- Issue title and URL
+
+**Actions available**:
+- None after confirmation (the opportunity is closed)
+
+**Considerations**:
+- The issue creation is lightweight and direct — it does not go through the full `00-add-backlog-item-protocol.md` flow (which would disrupt the retrospective with its own alignment conversation)
+- The issue body should include enough context that someone picking it up later can understand what was observed and why it matters, without needing the original conversation
+
+---
+
+## Business Rules
+
+- The retrospective is **always opt-in** — it is suggested at natural completion points but never auto-triggered without human consent
+- The retrospective operates in two modes:
+  - **With conversation context** (preferred): analyzes both GitHub data and the current session's conversation history
+  - **Without conversation context** (fallback): analyzes GitHub data only (PR metadata, git history, PR comments)
+- **Categorization taxonomy** — each improvement opportunity is assigned one of the following categories:
+
+  | Category | Description |
+  |---|---|
+  | `workflow-process` | Deviation from or friction in the defined workflow protocols (e.g., wrong base branch, skipped review step) |
+  | `agent-behavior` | Unexpected or incorrect agent action, model mischoice, or protocol misread |
+  | `configuration` | Missing or incorrect repo/workflow configuration (e.g., labels, YAML files, `.gitignore`) |
+  | `documentation` | Gap or inaccuracy in a protocol, spec, or guideline document |
+  | `code-quality` | Recurring reviewer findings that suggest a systemic pattern rather than a one-off issue |
+  | `tooling` | External tool integration issue (e.g., CodeRabbit misconfiguration, `gh` CLI usage gap) |
+
+- Each opportunity is presented with its category, a short description, a severity signal (High / Medium / Low), and a recommended action (Address now / Add to backlog)
+- Severity signals are the agent's best-effort assessment based on frequency, impact, and whether the issue caused rework or human intervention
+- **"Address now"** is reserved for changes the agent can self-assess as simple and safe to apply without a review loop; the agent uses its own judgment
+- **"Add to backlog"** issue creation uses `gh issue create` directly — not the full `00-add-backlog-item-protocol.md` flow
+- The human may skip any individual opportunity (take no action); the agent moves on
+- The retrospective scope is limited to work from the current session or the PRs specified in the scope hint — no cross-session trend analysis
+- No persistent state is required or maintained between sessions
+
+---
+
+## Delivery
+
+The retrospective capability is delivered across all three platforms following existing patterns:
+
+- **New protocol**: `docs/ai/development-workflow/protocols/06-retrospective-protocol.md`
+- **Claude Code**: a `retrospective` agent / `/retrospective` command following existing agent patterns
+- **Cursor**: a `/retrospective` subagent under `.cursor/agents/` following existing Cursor agent patterns
+- **Codex**: a `workflow-retrospective` skill under `.codex/skills/` following existing Codex skill patterns
+
+Integration points (suggestion, not auto-trigger) are added to:
+- **Protocol 90, Step 6** (after batch summary): always suggest a retrospective
+- **Protocol 91** (after item summary, before terminal handoff): suggest only when `BATCH_CONTEXT != true`
+
+---
+
+## Acceptance Criteria
+
+- [ ] A developer can invoke `/retrospective` in a fresh session and receive a categorized list of improvement opportunities derived from GitHub PR data for recent work in the repository
+- [ ] Each improvement opportunity is labeled with its category (from the taxonomy), severity signal, and recommended action
+- [ ] The developer can choose "Address now", "Add to backlog", or skip for each opportunity
+- [ ] When "Address now" is chosen for a simple fix, the agent applies the fix, commits, and pushes without opening a new PR or running a review loop
+- [ ] When "Add to backlog" is chosen, the agent creates a GitHub issue via `gh issue create` with a descriptive title and body, and returns the issue URL
+- [ ] When invoked in the same session as a completed batch/item run, the retrospective also surfaces findings from the conversation history (manual interventions, human corrections, agent deviations)
+- [ ] Protocol 90 (batch orchestrator) suggests a retrospective after the Step 6 batch summary
+- [ ] Protocol 91 (work item runner) suggests a retrospective after the item summary only when `BATCH_CONTEXT != true`
+- [ ] The `/retrospective` command/skill is available in Claude Code, Cursor, and Codex following existing platform patterns
+- [ ] The agent never applies fixes or creates issues without the human's explicit choice
+
+---
+
+## Out of Scope (MVP)
+
+- Cross-session trend analysis (no persistent state between sessions)
+- Automated retrospective triggering without human consent
+- Post-merge-cleanup integration (detecting "last item in batch" is too hard without persistent state)
+- A full backlog-item alignment conversation for "Add to backlog" (lightweight direct issue creation is used instead)
+- Custom categorization taxonomy configuration (the taxonomy is fixed at the protocol level)
+- Retrospective analytics or dashboards
+
+---
+
+## Open Questions
+
+<!-- No blocking open questions remain. -->

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -158,21 +158,8 @@ This feature adds a retrospective analysis capability to the AI development work
 - The human may skip any individual opportunity (take no action); the agent moves on
 - The retrospective scope is limited to work from the current session or the PRs specified in the scope hint — no cross-session trend analysis
 - No persistent state is required or maintained between sessions
-
----
-
-## Delivery
-
-The retrospective capability is delivered across all three platforms following existing patterns:
-
-- **New protocol**: `docs/ai/development-workflow/protocols/06-retrospective-protocol.md`
-- **Claude Code**: a `retrospective` agent / `/retrospective` command following existing agent patterns
-- **Cursor**: a `/retrospective` subagent under `.cursor/agents/` following existing Cursor agent patterns
-- **Codex**: a `workflow-retrospective` skill under `.codex/skills/` following existing Codex skill patterns
-
-Integration points (suggestion, not auto-trigger) are added to:
-- **Protocol 90, Step 6** (after batch summary): always suggest a retrospective
-- **Protocol 91** (after item summary, before terminal handoff): suggest only when `BATCH_CONTEXT != true`
+- The `/retrospective` capability must be available as an invocable command across all three supported workflow platforms: Claude Code, Cursor, and Codex
+- The retrospective suggestion must be added to the batch orchestration summary (end of a batch run) and to the individual item summary (end of a standalone item run, not part of a batch)
 
 ---
 

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -31,11 +31,11 @@ This feature adds a retrospective analysis capability to the AI development work
 3. The agent analyzes git history for the relevant PRs: commit patterns, fix-commit ratio, and review iteration count
 4. The agent synthesizes findings into a categorized list of improvement opportunities (see Business Rules: Categorization)
 5. The agent presents the opportunities to the human with a recommended action for each
-6. For each opportunity, the human chooses: **Address now** or **Add to backlog**
+6. For each opportunity, the human chooses: **Address now**, **Add to backlog**, or **Skip**
 7. The agent executes the chosen action for each opportunity (see Use Case 3 and 4)
 8. The agent confirms what was done and closes the retrospective
 
-**Postconditions**: Each improvement opportunity has either been addressed in the current session or added as a backlog issue
+**Postconditions**: Each improvement opportunity has either been addressed in the current session, added as a backlog issue, or explicitly skipped by the human
 
 **Information shown**:
 - Categorized improvement opportunities, each with: description, category label, severity signal, and recommended action
@@ -64,11 +64,11 @@ This feature adds a retrospective analysis capability to the AI development work
 3. In addition to GitHub data (as in Use Case 1), the agent also analyzes the conversation history from the current session: manual interventions, human corrections, agent deviations from protocol, and friction points that were surfaced verbally
 4. The agent synthesizes all findings (GitHub + conversation) into a categorized list of improvement opportunities
 5. The agent presents the opportunities to the human with a recommended action for each
-6. For each opportunity, the human chooses: **Address now** or **Add to backlog**
+6. For each opportunity, the human chooses: **Address now**, **Add to backlog**, or **Skip**
 7. The agent executes the chosen action for each opportunity
 8. The agent confirms what was done and closes the retrospective
 
-**Postconditions**: Each improvement opportunity has either been addressed in the current session or added as a backlog issue
+**Postconditions**: Each improvement opportunity has either been addressed in the current session, added as a backlog issue, or explicitly skipped by the human
 
 **Information shown**:
 - Same as Use Case 1, with additional findings sourced from conversation context

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -142,14 +142,14 @@ This feature adds a retrospective analysis capability to the AI development work
   - **Without conversation context** (fallback): analyzes GitHub data only (PR metadata, git history, PR comments)
 - **Categorization taxonomy** — each improvement opportunity is assigned one of the following categories:
 
-  | Category | Description |
-  |---|---|
-  | `workflow-process` | Deviation from or friction in the defined workflow protocols (e.g., wrong base branch, skipped review step) |
-  | `agent-behavior` | Unexpected or incorrect agent action, model mischoice, or protocol misread |
-  | `configuration` | Missing or incorrect repo/workflow configuration (e.g., labels, YAML files, `.gitignore`) |
-  | `documentation` | Gap or inaccuracy in a protocol, spec, or guideline document |
-  | `code-quality` | Recurring reviewer findings that suggest a systemic pattern rather than a one-off issue |
-  | `tooling` | External tool integration issue (e.g., CodeRabbit misconfiguration, `gh` CLI usage gap) |
+  | Category | Display label | Description |
+  |---|---|---|
+  | `workflow-process` | Workflow & Process | Deviation from or friction in the defined workflow protocols (e.g., wrong base branch, skipped review step) |
+  | `agent-behavior` | Agent Behavior | Unexpected or incorrect agent action, model mischoice, or protocol misread |
+  | `configuration` | Configuration | Missing or incorrect repo/workflow configuration (e.g., labels, YAML files, `.gitignore`) |
+  | `documentation` | Documentation | Gap or inaccuracy in a protocol, spec, or guideline document |
+  | `code-quality` | Code Quality | Recurring reviewer findings that suggest a systemic pattern rather than a one-off issue |
+  | `tooling` | Tooling | External tool integration issue (e.g., CodeRabbit misconfiguration, `gh` CLI usage gap) |
 
 - Each opportunity is presented with its category, a short description, a severity signal (High / Medium / Low), and a recommended action (Address now / Add to backlog)
 - Severity signals are the agent's best-effort assessment based on frequency, impact, and whether the issue caused rework or human intervention

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -166,9 +166,11 @@ This feature adds a retrospective analysis capability to the AI development work
 ## Acceptance Criteria
 
 - [ ] A developer can invoke `/retrospective` in a fresh session and receive a categorized list of improvement opportunities derived from GitHub PR data for recent work in the repository
+- [ ] When GitHub data is insufficient to surface meaningful findings, the agent communicates that no actionable opportunities were found and closes the retrospective gracefully
 - [ ] Each improvement opportunity is labeled with its category (from the taxonomy), severity signal, and recommended action
 - [ ] The developer can choose "Address now", "Add to backlog", or skip for each opportunity
 - [ ] When "Address now" is chosen for a simple fix, the agent applies the fix, commits, and pushes without opening a new PR or running a review loop
+- [ ] When "Address now" is chosen but the agent assesses the opportunity as too complex to apply without a review loop, the agent recommends "Add to backlog" instead and explains why
 - [ ] When "Add to backlog" is chosen, the agent creates a GitHub issue via `gh issue create` with a descriptive title and body, and returns the issue URL
 - [ ] When invoked in the same session as a completed batch/item run, the retrospective also surfaces findings from the conversation history (manual interventions, human corrections, agent deviations)
 - [ ] Protocol 90 (batch orchestrator) suggests a retrospective after the Step 6 batch summary

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -79,7 +79,7 @@ This feature adds a retrospective analysis capability to the AI development work
 
 **Considerations**:
 - The agent suggests a retrospective only once per session at the end of a batch/item run
-- In protocol 91 (Work Item Runner), the suggestion is made only when the item was run standalone (not dispatched by a batch orchestrator). When `BATCH_CONTEXT=true`, the suggestion is suppressed to avoid double-triggering (the batch orchestrator handles it)
+- In protocol 91 (Work Item Runner), the suggestion is made only when the item was run standalone (not dispatched by a batch orchestrator). When dispatched by a batch orchestrator, the suggestion is suppressed to avoid double-triggering — the batch orchestrator handles it
 - In protocol 90 (Portfolio Orchestrator), the suggestion is always made after the batch summary
 - Conversation context is the richest source of findings; GitHub data alone is the fallback
 

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -174,7 +174,7 @@ This feature adds a retrospective analysis capability to the AI development work
 - [ ] When "Add to backlog" is chosen, the agent creates a GitHub issue via `gh issue create` with a descriptive title and body, and returns the issue URL
 - [ ] When invoked in the same session as a completed batch/item run, the retrospective also surfaces findings from the conversation history (manual interventions, human corrections, agent deviations)
 - [ ] Protocol 90 (batch orchestrator) suggests a retrospective after the Step 6 batch summary
-- [ ] Protocol 91 (work item runner) suggests a retrospective after the item summary only when `BATCH_CONTEXT != true`
+- [ ] Protocol 91 (work item runner) suggests a retrospective after the item summary only when the item was run standalone (not dispatched by a batch orchestrator)
 - [ ] The `/retrospective` command/skill is available in Claude Code, Cursor, and Codex following existing platform patterns
 - [ ] The agent never applies fixes or creates issues without the human's explicit choice
 

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -117,7 +117,7 @@ This feature adds a retrospective analysis capability to the AI development work
 **Preconditions**: The human has chosen "Add to backlog" for a specific improvement opportunity
 
 **Steps**:
-1. The agent creates a GitHub issue directly using `gh issue create` with a descriptive title, a body that describes the problem and the improvement opportunity, and the appropriate labels
+1. The agent creates a GitHub issue directly with a descriptive title, a body that describes the problem and the improvement opportunity, and the appropriate labels
 2. The agent reports the created issue with its URL
 
 **Postconditions**: A GitHub issue exists representing the improvement opportunity
@@ -154,7 +154,7 @@ This feature adds a retrospective analysis capability to the AI development work
 - Each opportunity is presented with its category, a short description, a severity signal (High / Medium / Low), and a recommended action (Address now / Add to backlog)
 - Severity signals are the agent's best-effort assessment based on frequency, impact, and whether the issue caused rework or human intervention
 - **"Address now"** is reserved for changes the agent can self-assess as simple and safe to apply without a review loop; the agent uses its own judgment
-- **"Add to backlog"** issue creation uses `gh issue create` directly — not the full `00-add-backlog-item-protocol.md` flow
+- **"Add to backlog"** creates a GitHub issue directly — not through the full `00-add-backlog-item-protocol.md` flow
 - The human may skip any individual opportunity (take no action); the agent moves on
 - The retrospective scope is limited to work from the current session or the PRs specified in the scope hint — no cross-session trend analysis
 - No persistent state is required or maintained between sessions
@@ -171,7 +171,7 @@ This feature adds a retrospective analysis capability to the AI development work
 - [ ] The developer can choose "Address now", "Add to backlog", or skip for each opportunity
 - [ ] When "Address now" is chosen for a simple fix, the agent applies the fix, commits, and pushes without opening a new PR or running a review loop
 - [ ] When "Address now" is chosen but the agent assesses the opportunity as too complex to apply without a review loop, the agent recommends "Add to backlog" instead and explains why
-- [ ] When "Add to backlog" is chosen, the agent creates a GitHub issue via `gh issue create` with a descriptive title and body, and returns the issue URL
+- [ ] When "Add to backlog" is chosen, the agent creates a GitHub issue directly with a descriptive title and body, and returns the issue URL
 - [ ] When invoked in the same session as a completed batch/item run, the retrospective also surfaces findings from the conversation history (manual interventions, human corrections, agent deviations)
 - [ ] Protocol 90 (batch orchestrator) suggests a retrospective after the Step 6 batch summary
 - [ ] Protocol 91 (work item runner) suggests a retrospective after the item summary only when the item was run standalone (not dispatched by a batch orchestrator)

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -151,8 +151,16 @@ This feature adds a retrospective analysis capability to the AI development work
   | `code-quality` | Code Quality | Recurring reviewer findings that suggest a systemic pattern rather than a one-off issue |
   | `tooling` | Tooling | External tool integration issue (e.g., CodeRabbit misconfiguration, `gh` CLI usage gap) |
 
-- Each opportunity is presented with its category, a short description, a severity signal (High / Medium / Low), and a recommended action (Address now / Add to backlog)
-- Severity signals are the agent's best-effort assessment based on frequency, impact, and whether the issue caused rework or human intervention
+- Each opportunity is presented with its category, a short description, a severity signal, and a recommended action (Address now / Add to backlog)
+- **Severity signal** — each opportunity is assigned one of the following severity levels:
+
+  | Code value | Display label | Description |
+  |---|---|---|
+  | `high` | High | The issue caused rework, required human intervention, or has high likelihood of recurring and significantly disrupting future runs |
+  | `medium` | Medium | The issue caused friction or delay but did not require human intervention; likely to recur without a fix |
+  | `low` | Low | The issue is a minor deviation or a one-off occurrence with low likelihood of recurring or causing meaningful disruption |
+
+- Severity signals are the agent's best-effort assessment; the agent should bias toward `high` when an issue required direct human correction
 - **"Address now"** is reserved for changes the agent can self-assess as simple and safe to apply without a review loop; the agent uses its own judgment
 - **"Add to backlog"** creates a GitHub issue directly — not through the full `00-add-backlog-item-protocol.md` flow
 - The human may skip any individual opportunity (take no action); the agent moves on

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -187,8 +187,3 @@ This feature adds a retrospective analysis capability to the AI development work
 - Custom categorization taxonomy configuration (the taxonomy is fixed at the protocol level)
 - Retrospective analytics or dashboards
 
----
-
-## Open Questions
-
-<!-- No blocking open questions remain. -->


### PR DESCRIPTION
## Summary

This draft PR adds the feature spec for issue #113: **Retrospective Analysis Protocol**.

The spec defines a new `/retrospective` capability that analyzes completed workflow work (batches or individual items), surfaces categorized improvement opportunities, and lets the developer choose to address each one immediately or add it to the backlog.

## Spec file

[`docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md`](docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md)

## Key design decisions captured in the spec

- **Two operating modes**: with conversation context (preferred, richer findings) and without (GitHub data only, fallback for fresh sessions)
- **Six-category taxonomy**: `workflow-process`, `agent-behavior`, `configuration`, `documentation`, `code-quality`, `tooling`
- **"Address now"** is reserved for simple self-contained fixes the agent can apply without a review loop; the agent uses runtime judgment
- **"Add to backlog"** uses lightweight direct `gh issue create` — no alignment conversation (per human decision)
- **Integration points**: protocol 90 always suggests a retrospective after the batch summary; protocol 91 suggests only when `BATCH_CONTEXT != true`
- **Post-merge-cleanup integration**: out of scope (detecting "last item in batch" requires persistent state)
- **Platform delivery**: Claude Code, Cursor, and Codex following existing patterns

## Open questions

None — all alignment questions were resolved before writing.

Closes #113