### PR TITLE
feat(workflow): add retrospective analysis protocol

### DIFF
--- a/.claude/agents/retrospective.md
+++ b/.claude/agents/retrospective.md
@@ -1,0 +1,18 @@
+---
+name: retrospective
+model: claude-haiku-4-5-20251001
+description: Retrospective analysis agent. Analyzes completed work (a batch or individual item) to identify process improvement opportunities, presents them to the human, and executes the chosen action for each. Use after a batch or item run to surface workflow improvements, or invoke on-demand with a PR number, branch, or date as scope hint.
+tools: Read, Grep, Glob, Write, Edit, Bash
+---
+
+Follow the retrospective protocol exactly as defined in:
+
+`docs/ai/development-workflow/protocols/06-retrospective-protocol.md`
+
+That document is the single source of truth for this role. Key responsibilities:
+- Resolve scope from the user's hint (PR number, branch, batch date) or default to recent PRs in the repository
+- Gather GitHub PR metadata and git history for the relevant PRs using `gh`; also analyze conversation context when available
+- Synthesize findings into a categorized list using the fixed taxonomy (workflow-process, agent-behavior, configuration, documentation, code-quality, tooling) with severity signals (high, medium, low)
+- Present findings to the human before taking any action
+- For each opportunity, execute the human's chosen action: "Address now" (apply fix, commit, push — no new PR), "Add to backlog" (create GitHub issue directly via `gh issue create`), or "Skip"
+- Never apply fixes or create issues without the human's explicit choice

--- a/.claude/commands/retrospective.md
+++ b/.claude/commands/retrospective.md
@@ -1,0 +1,15 @@
+---
+description: Run a retrospective analysis on completed work to identify process improvement opportunities. Usage: /retrospective [PR number | branch name | batch date]
+---
+
+# Claude Code Command: Retrospective
+
+Follow the retrospective protocol exactly as defined in:
+
+`docs/ai/development-workflow/protocols/06-retrospective-protocol.md`
+
+- **Scope**: Analyze the PRs from the current session or the scope hint provided (PR number, branch name, or batch date). When no hint is given, default to recent PRs in the repository.
+- **Data sources**: GitHub PR metadata (via `gh`) and, when conversation context is available, the current session's conversation history.
+- **Output**: A categorized list of improvement opportunities — each with a category, severity signal, and recommended action. Present findings first, then act only on the human's explicit choices.
+- **Actions**: "Address now" applies a simple fix, commits, and pushes (no new PR). "Add to backlog" creates a GitHub issue directly. "Skip" moves on.
+- **Constraint**: Never apply fixes or create issues without the human's explicit choice.

--- a/.codex/skills/workflow-retrospective/SKILL.md
+++ b/.codex/skills/workflow-retrospective/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: workflow-retrospective
+description: Run a retrospective analysis on completed work to identify process improvement opportunities. Use when the user wants to review a completed batch or item run, or invoke on-demand with a PR number, branch, or date as scope hint.
+---
+
+# Workflow Retrospective
+
+Recommended model tier: `economy`
+
+1. Read `AGENTS.md` for repository-wide rules.
+2. Read `docs/ai/development-workflow/protocols/06-retrospective-protocol.md`.
+3. Resolve scope from the user's request (PR number, branch name, batch date) or default to recent PRs in the repository.
+4. Gather GitHub PR metadata (review cycles, finding types, labels, merge conflicts) and git history (commit patterns, fix-commit ratio) using `gh`. When conversation context is available, also analyze manual interventions, human corrections, and agent deviations from the current session.
+5. Synthesize findings into a categorized list using the fixed taxonomy and severity signals defined in the protocol.
+6. Present findings to the human. For each opportunity, accept the human's choice of "Address now", "Add to backlog", or "Skip" — then execute the chosen action.
+7. "Address now": apply simple fix, commit, push (no new PR or review loop). "Add to backlog": create GitHub issue directly via `gh issue create`. "Skip": move on.
+8. After all opportunities are acted on, post a confirmation summary table.

--- a/.codex/skills/workflow-retrospective/agents/openai.yaml
+++ b/.codex/skills/workflow-retrospective/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Workflow Retrospective"
+  short_description: "Run a retrospective analysis on completed work to identify and act on process improvement opportunities."
+  default_prompt: "Use $workflow-retrospective to run a retrospective on the most recently completed batch or item run (or the PR number / branch I give you)."
+
+policy:
+  allow_implicit_invocation: false

--- a/.cursor/agents/retrospective.md
+++ b/.cursor/agents/retrospective.md
@@ -1,0 +1,17 @@
+---
+name: retrospective
+model: fast
+description: Retrospective analysis agent. Analyzes completed work (a batch or individual item) to identify process improvement opportunities, presents them to the human, and executes the chosen action for each.
+---
+
+Follow the retrospective protocol exactly as defined in:
+
+`docs/ai/development-workflow/protocols/06-retrospective-protocol.md`
+
+That document is the single source of truth for this role. Key responsibilities:
+- Resolve scope from the user's hint (PR number, branch, batch date) or default to recent PRs in the repository
+- Gather GitHub PR metadata and git history for the relevant PRs; also analyze conversation context when available
+- Synthesize findings into a categorized list using the fixed taxonomy (workflow-process, agent-behavior, configuration, documentation, code-quality, tooling) with severity signals (high, medium, low)
+- Present findings to the human before taking any action
+- For each opportunity, execute the human's chosen action: "Address now" (apply fix, commit, push — no new PR), "Add to backlog" (create GitHub issue directly), or "Skip"
+- Never apply fixes or create issues without the human's explicit choice

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ Repository-specific workflow providers are declared in [`.ai-dev-workflow.yaml`]
 | Prepare Commit | — | `/prepare-commit` | Follow `docs/best-practices/2-version-control.md` | Follow `docs/best-practices/2-version-control.md` |
 | Prepare Release | `/prepare-release` | `/prepare-release` | Follow `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md` | Follow `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md` |
 | Orchestrate Work | `/run-work` command (or `orchestrator` agent) | `/run-work` | `workflow-orchestrator` skill | Follow `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` |
+| Retrospective | `/retrospective` | `/retrospective` | `workflow-retrospective` skill | Follow `docs/ai/development-workflow/protocols/06-retrospective-protocol.md` |
 
 **Prepare release** does not stop after opening PRs: protocol `05` requires running the automated reviewer loop, applying `ready-for-regression` on the **production PR to `main`**, and completing the CI loop (including label-gated e2e/regression when configured) before handoff to merge.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Retrospective analysis protocol**: a new `/retrospective` command and `06-retrospective-protocol.md` allow developers (or agents) to analyze completed work — a batch or individual item — and identify process improvement opportunities. Each finding is categorized (Workflow & Process, Agent Behavior, Configuration, Documentation, Code Quality, Tooling) and assigned a severity signal (High, Medium, Low). The human chooses an action for each: "Address now" (agent applies a simple fix, commits, and pushes — no new PR), "Add to backlog" (agent creates a GitHub issue directly), or "Skip". Works in two modes: with conversation context (preferred, richer findings) or with GitHub data only (on-demand fallback). Protocol 90 (batch orchestrator) now suggests a retrospective after its Step 6 summary; Protocol 91 (work item runner) does the same for standalone item runs only (suppressed when `BATCH_CONTEXT=true`). Available as `/retrospective` in Claude Code, `/retrospective` in Cursor, and the `workflow-retrospective` Codex skill.
+
 - **Worktree isolation for parallel batch dispatch**: protocols `90-batch-orchestrate-work-protocol.md` and `91-orchestrate-work-protocol.md` now require each Work Item Runner in a parallel batch to operate in a dedicated git worktree. Includes `BATCH_CONTEXT=true` handoff signal, pre-flight worktree checks, base-branch table for all item types, stage protocol compatibility notes, CWD safety mandate (`cd` to repo root before `git worktree remove`), and corrected Step 10 cleanup sequence (worktree removal before branch deletion).
 
 ### Fixed

--- a/docs/ai/development-workflow/README.md
+++ b/docs/ai/development-workflow/README.md
@@ -203,6 +203,7 @@ The sections below keep this document usable as a master reference after the nar
 | Advance one item | `/run-item-work` command (or `item-orchestrator` agent) | `/run-item-work` | `workflow-item-orchestrator` skill | `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` |
 | Orchestrate portfolio | `/run-work` command (or `orchestrator` agent) | `/run-work` | `workflow-orchestrator` skill | `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` |
 | Prepare release | `/prepare-release` | `/prepare-release` | — | `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md` |
+| Retrospective | `/retrospective` command | `/retrospective` | `workflow-retrospective` skill | `docs/ai/development-workflow/protocols/06-retrospective-protocol.md` |
 
 After opening release PRs, protocol `05` runs the automated reviewer loop, applies `ready-for-regression` on the **PR targeting `main`**, and runs the CI loop until checks are green (or escalation) — same persistence contract as other PR readiness work.
 
@@ -446,6 +447,7 @@ Protocol prefixes are stable family identifiers, not a promise of contiguous num
 - `docs/ai/development-workflow/protocols/03-review-implementation-protocol.md`
 - `docs/ai/development-workflow/protocols/04-smoke-test-protocol.md`
 - `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md`
+- `docs/ai/development-workflow/protocols/06-retrospective-protocol.md`
 - `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
 - `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`
 - `docs/ai/development-workflow/protocols/92-pr-readiness-signal-protocol.md`

--- a/docs/ai/development-workflow/README.md
+++ b/docs/ai/development-workflow/README.md
@@ -430,7 +430,7 @@ Use these documents when you need the detailed rules behind a part of the workfl
 
 Protocol prefixes are stable family identifiers, not a promise of contiguous numbering.
 
-- `01`-`05` are the current primary stage families in workflow order.
+- `01`-`06` are the current primary stage families in workflow order.
 - `00` is reserved for pre-stage backlog intake (creating tracker work items before spec work).
 - Generate and review protocols for the same stage share the same family number.
 - `90`-`99` are orchestration, readiness, and other cross-cutting operational protocols.

--- a/docs/ai/development-workflow/agent-model-config.md
+++ b/docs/ai/development-workflow/agent-model-config.md
@@ -37,6 +37,7 @@ If you prefer different names (`small/medium/large`, `fast/standard/pro`, etc.),
 | `code-reviewer` | `balanced` | Code review against known standards and a completed spec. A balanced model is capable here. |
 | `project-setup` | `balanced` | Structured onboarding conversation with clear protocol guidance. A balanced model is sufficient. |
 | `smoke-tester` | `balanced` | Executes the smoke test runbook using browser automation. A balanced model is sufficient for following step-by-step testing instructions. |
+| `retrospective` | `economy` | **Retrospective Analyst**. Reads PR metadata and git history, synthesizes findings into a categorized list; mechanical analysis that should stay fast and cheap. |
 
 ### Runner Notes
 
@@ -65,6 +66,7 @@ Agents only get `Bash` when they need it to carry a stage through branch creatio
 | `code-reviewer` | ✅ | ❌ | May run lint or tests to verify applied fixes |
 | `project-setup` | ✅ | ❌ | May need to initialize git, run project commands during setup |
 | `smoke-tester` | ✅ | ❌ | Runs browser automation and test scripts; needs Bash for execution |
+| `retrospective` | ✅ | ❌ | Needs `gh` CLI for PR metadata queries, `git` for history analysis, and `gh issue create` for backlog items; does not dispatch sub-agents |
 
 ---
 

--- a/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
+++ b/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
@@ -1,0 +1,247 @@
+# Protocol: Run Retrospective
+
+**Agent role**: Retrospective Analyst
+**Purpose**: Analyze completed work (a batch or individual item) to identify process improvement opportunities, present them to the human, and execute the chosen action for each
+
+This protocol may be entered in two ways:
+
+- A human invokes `/retrospective` in a fresh session (on-demand mode — no conversation history)
+- Protocol 90 or Protocol 91 suggests a retrospective at the end of a run and the human agrees (same-session mode — conversation history available)
+
+---
+
+## Step 1: Resolve Scope
+
+Determine which PRs to analyze.
+
+**With a scope hint** (e.g., PR number, branch name, or batch date provided by the human):
+- Use the hint directly. Query the specified PR(s) via `gh pr view` and `gh pr list`.
+
+**Without a scope hint, same-session mode** (triggered from Protocol 90 or 91):
+- Use the PRs processed during the current session. These are already known from the conversation context.
+
+**Without a scope hint, on-demand mode** (fresh session, `/retrospective` with no argument):
+- Default to recent PRs in the current repository:
+  ```bash
+  gh pr list --state all --limit 10 --json number,title,headRefName,baseRefName,mergedAt,createdAt,labels,reviews
+  ```
+- Focus on PRs merged or opened in the last 7 days. If no PRs meet this threshold, widen to 14 days or the last 5 closed PRs, whichever is smaller.
+
+If no PRs can be found at all, report this clearly and close the retrospective gracefully — do not proceed.
+
+---
+
+## Step 2: Gather Data
+
+### 2a. GitHub PR metadata
+
+For each PR in scope, collect:
+
+```bash
+# PR metadata
+gh pr view <number> --json number,title,headRefName,baseRefName,mergedAt,state,labels,reviews,comments,reviewDecision
+
+# PR review comments (inline findings)
+gh api repos/{owner}/{repo}/pulls/<number>/comments
+
+# PR timeline events (label changes, base branch edits, re-requests)
+gh api repos/{owner}/{repo}/issues/<number>/events
+```
+
+From this data, extract:
+
+- **Review cycle count**: how many times a reviewer (automated or human) requested changes
+- **Finding types**: labeling issues, wrong base branch, CHANGELOG conflicts, agent misbehavior signals visible in PR comments
+- **Labels applied / missing**: were expected labels (`ready-for-human-review`, `needs-fixes`, `ready-for-regression`) applied correctly?
+- **Merge conflicts**: did the PR require conflict resolution?
+- **Automated reviewer findings**: CodeRabbit, Greptile, or other configured platforms (if visible in PR comments or reviews)
+
+### 2b. Git history analysis
+
+For each PR branch in scope:
+
+```bash
+# Commit history for the PR branch
+gh api repos/{owner}/{repo}/pulls/<number>/commits
+
+# Or using git directly if the branch is available locally
+git log origin/<base-branch>..origin/<pr-branch> --oneline
+```
+
+From this data, extract:
+
+- **Total commit count**
+- **Fix-commit ratio**: commits with messages starting with `fix:`, `fixup!`, or similar correction indicators as a proportion of all commits
+- **Review iteration count**: number of distinct pushes that followed a review comment or `needs-fixes` label
+
+### 2c. Conversation context (same-session mode only)
+
+When the retrospective is triggered in the same session as a completed batch or item run, analyze the conversation history for:
+
+- **Manual interventions**: moments where the human had to correct the agent's direction mid-run
+- **Human corrections**: instances where the agent made an error the human caught and fixed
+- **Agent deviations from protocol**: explicit statements in the conversation that the agent did something unexpected or against protocol
+- **Friction points surfaced verbally**: anything the human flagged as annoying, slow, or incorrect during the run
+
+Conversation findings are often the highest-value source — weight them accordingly.
+
+---
+
+## Step 3: Synthesize Findings
+
+Analyze all gathered data and produce a categorized list of improvement opportunities.
+
+### Categorization taxonomy
+
+Assign each opportunity exactly one category:
+
+| Category | Display label | Description |
+|---|---|---|
+| `workflow-process` | Workflow & Process | Deviation from or friction in the defined workflow protocols (e.g., wrong base branch, skipped review step) |
+| `agent-behavior` | Agent Behavior | Unexpected or incorrect agent action, model mischoice, or protocol misread |
+| `configuration` | Configuration | Missing or incorrect repo/workflow configuration (e.g., labels, YAML files, `.gitignore`) |
+| `documentation` | Documentation | Gap or inaccuracy in a protocol, spec, or guideline document |
+| `code-quality` | Code Quality | Recurring reviewer findings that suggest a systemic pattern rather than a one-off issue |
+| `tooling` | Tooling | External tool integration issue (e.g., CodeRabbit misconfiguration, `gh` CLI usage gap) |
+
+### Severity signals
+
+Assign each opportunity a severity level:
+
+| Code | Display label | Description |
+|---|---|---|
+| `high` | High | The issue caused rework, required human intervention, or has high likelihood of recurring and significantly disrupting future runs |
+| `medium` | Medium | The issue caused friction or delay but did not require human intervention; likely to recur without a fix |
+| `low` | Low | The issue is a minor deviation or a one-off occurrence with low likelihood of recurring or causing meaningful disruption |
+
+**Bias toward `high`** when an issue required direct human correction.
+
+### Recommended action per opportunity
+
+For each opportunity, recommend one of:
+
+- **Address now** — suitable for changes the agent can self-assess as simple and safe to apply without a review loop (e.g., one-line config fix, missing label in a YAML file, a `.gitignore` entry)
+- **Add to backlog** — suitable for anything requiring implementation planning, cross-file changes, or a review loop
+
+The recommended action is a suggestion. The human makes the final choice.
+
+### Graceful exit
+
+If the gathered data does not surface any actionable improvement opportunities (e.g., the PR was clean on first attempt, no human corrections were needed, all labels applied correctly), report this clearly:
+
+> No actionable improvement opportunities were found for the analyzed work. The run appears to have proceeded cleanly.
+
+Then close the retrospective.
+
+---
+
+## Step 4: Present Findings
+
+Present the categorized findings to the human in a structured format:
+
+```markdown
+## Retrospective Analysis
+
+**Scope**: [PR number(s) or batch identifier]
+**Data sources**: GitHub data + conversation context | GitHub data only
+
+---
+
+### Improvement Opportunities
+
+#### 1. [Short title] — [Display label] | [Severity display label]
+
+**Observed**: [What happened — specific, factual description]
+**Impact**: [What it caused or could cause if unaddressed]
+**Recommended action**: Address now | Add to backlog
+
+---
+
+#### 2. [Short title] — [Display label] | [Severity display label]
+...
+```
+
+Then ask the human to choose an action for each opportunity:
+
+> For each finding above, please choose: **Address now**, **Add to backlog**, or **Skip**.
+
+Wait for the human's choices before executing any action.
+
+---
+
+## Step 5: Execute Actions
+
+Execute each chosen action in the order the human specified (or in the order they were presented if no specific order was given).
+
+### Address now
+
+1. Assess whether the opportunity is truly simple enough to apply without a review loop.
+   - If **yes**: apply the fix directly, commit, and push on the current or appropriate branch.
+   - If **no**: inform the human that the fix is more complex than it appears and recommend "Add to backlog" instead. Explain why (e.g., "This change touches 4 files and would benefit from a proper review loop").
+2. After applying a fix:
+   - Commit with a descriptive message: `fix([scope]): [description]`
+   - Push to the appropriate branch
+   - Report what changed with a short diff or summary
+
+**Constraints**:
+- Do **not** open a new PR for "Address now" changes
+- Do **not** run a review loop for "Address now" changes
+- If the fix requires changes to multiple files, a schema migration, or introduces a new pattern, stop and recommend "Add to backlog" instead
+
+### Add to backlog
+
+Create a GitHub issue directly using `gh issue create`:
+
+```bash
+gh issue create \
+  --title "[Descriptive title of the improvement opportunity]" \
+  --body "[Body — see format below]" \
+  --label "enhancement"
+```
+
+Issue body format:
+
+```markdown
+## Observed
+
+[What was observed during the retrospective — specific, factual]
+
+## Impact
+
+[What it caused or could cause if unaddressed]
+
+## Category
+
+[Category display label] — [Severity display label]
+
+## Source
+
+Retrospective analysis of [PR number(s) or batch/session identifier] on [date]
+```
+
+Report the created issue with its URL.
+
+**Constraints**:
+- Do **not** run the full `00-add-backlog-item-protocol.md` flow — that would disrupt the retrospective with its own alignment conversation
+- The issue body must contain enough context that someone picking it up later can understand what was observed without needing the original conversation
+
+### Skip
+
+Acknowledge and move on.
+
+---
+
+## Step 6: Close
+
+After all opportunities have been acted on (or skipped), provide a confirmation summary:
+
+```markdown
+## Retrospective Complete
+
+| # | Title | Category | Severity | Action taken |
+|---|-------|----------|----------|--------------|
+| 1 | [title] | [label] | [severity] | Fixed in commit `abc1234` / Issue #42 / Skipped |
+| 2 | ... | ... | ... | ... |
+```
+
+The retrospective is now closed.

--- a/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -265,3 +265,9 @@ After all currently eligible items have reached a terminal condition, provide a 
 ```
 
 Call out any sequential fallback caused by runner limitations so humans can distinguish a workflow constraint from a product dependency.
+
+After presenting the summary, suggest running a retrospective:
+
+> Would you like to run a retrospective on this session's work?
+
+If the human agrees, follow `docs/ai/development-workflow/protocols/06-retrospective-protocol.md`. The retrospective will analyze the PRs from this batch using both GitHub data and the conversation context from this session.

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -256,6 +256,16 @@ After the selected item reaches a terminal condition, provide a concise summary:
 - Next human action: merge PR / answer architecture question / unblock dependency
 ```
 
+**Retrospective suggestion (standalone runs only)**:
+
+If this Work Item Runner was invoked **directly by a human** (i.e., `BATCH_CONTEXT` is not set or is `false`), after presenting the summary, suggest running a retrospective:
+
+> Would you like to run a retrospective on this session's work?
+
+If the human agrees, follow `docs/ai/development-workflow/protocols/06-retrospective-protocol.md`. The retrospective will analyze the PRs from this item run using both GitHub data and the conversation context from this session.
+
+**When `BATCH_CONTEXT=true`** (dispatched by the Portfolio Orchestrator): suppress the retrospective suggestion. The Portfolio Orchestrator will suggest the retrospective at the end of its own Step 6 summary instead, covering the entire batch at once.
+
 ---
 
 ## Step 7a: Internal Review Gate (Draft PR)


### PR DESCRIPTION
## What was implemented

Adds a retrospective analysis capability to the AI development workflow per spec and plan in `docs/specs/developments/20260413201328_retrospective-protocol/`.

### New files

- `docs/ai/development-workflow/protocols/06-retrospective-protocol.md` — core protocol: scope resolution, GitHub data gathering, conversation-context analysis (same-session mode), finding categorization + severity, human-choice action execution (address now / add to backlog / skip), graceful close
- `.claude/commands/retrospective.md` — Claude Code `/retrospective` command
- `.cursor/agents/retrospective.md` — Cursor `/retrospective` agent
- `.codex/skills/workflow-retrospective/SKILL.md` — Codex skill
- `.codex/skills/workflow-retrospective/agents/openai.yaml` — Codex agent metadata

### Modified files

- `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` — retrospective suggestion added after Step 6 batch summary
- `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` — retrospective suggestion added after Step 6 item summary (suppressed when `BATCH_CONTEXT=true`)
- `docs/ai/development-workflow/README.md` — `06-retrospective-protocol.md` added to Core Protocols list; `/retrospective` row added to Commands By Stage table
- `AGENTS.md` — `/retrospective` row added to Workflow Commands table
- `CHANGELOG.md` — entry added under `[Unreleased]`

## Links

- Spec: `docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md`
- Plan: `docs/specs/developments/20260413201328_retrospective-protocol/2_retrospective-protocol_implementation-plan.md`
- Issue: #113

## Test plan

1. Invoke `/retrospective` in a fresh session with no scope hint — agent should query recent PRs and present categorized findings (or close gracefully if none found)
2. Invoke `/retrospective <PR number>` — findings should be scoped to that PR only
3. Choose "Address now" for a simple finding — agent applies fix, commits, pushes; no new PR opened
4. Choose "Address now" for a complex finding — agent recommends "Add to backlog" and explains why
5. Choose "Add to backlog" — agent creates a GitHub issue via `gh issue create` and returns URL
6. Run a batch via Protocol 90 — verify retrospective is suggested after the Step 6 summary
7. Run a standalone item via Protocol 91 — verify retrospective is suggested after the Step 6 summary
8. Run a dispatched item via Protocol 91 (`BATCH_CONTEXT=true`) — verify retrospective is NOT suggested
9. Run retrospective in same session as a batch/item run — verify conversation-context findings are surfaced alongside GitHub findings

See smoke test runbook: `docs/testing/workflow/retrospective-protocol.smoke-test.md`

## Deviations from plan

None. All 10 implementation steps completed as specified.

## CHANGELOG entry preview

**Added**: Retrospective analysis protocol — `/retrospective` command, `06-retrospective-protocol.md`, integration into Protocols 90 and 91, available in Claude Code, Cursor, and Codex.