### PR TITLE
fix(agent-config): enforce capable model for item-orchestrator review fix loops

### DIFF
--- a/.claude/agents/item-orchestrator.md
+++ b/.claude/agents/item-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: item-orchestrator
-model: claude-haiku-4-5-20251001
+model: claude-sonnet-4-6
 description: Coordination agent for a single workflow item. Resumes one development, branch, or PR and keeps it moving until it is waiting on a human, blocked, or escalated. Use when you want targeted advancement without scanning the full portfolio.
 tools: Read, Grep, Glob, Write, Edit, Bash, Agent
 ---

--- a/.codex/skills/workflow-item-orchestrator/SKILL.md
+++ b/.codex/skills/workflow-item-orchestrator/SKILL.md
@@ -5,7 +5,7 @@ description: Advance a single workflow item until it reaches a real terminal con
 
 # Workflow Item Orchestrator
 
-Recommended model tier: `economy`
+Recommended model tier: `balanced`
 
 1. Read `AGENTS.md` for repository-wide rules, branch overrides, and terminal-condition expectations.
 2. Read `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`.

--- a/.cursor/agents/item-orchestrator.md
+++ b/.cursor/agents/item-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: item-orchestrator
-model: fast
+model: inherit
 description: Coordination agent for a single workflow item. Resumes one development, branch, or PR and keeps it moving until it is waiting on a human, blocked, or escalated. Use when you want targeted advancement without scanning the full portfolio.
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Item-orchestrator model upgrade to balanced tier**: upgraded `item-orchestrator` agent from economy (haiku) to balanced (sonnet) tier in `.claude/agents/item-orchestrator.md` and `.cursor/agents/item-orchestrator.md`. Economy models struggle with the multi-step reasoning required to parse review findings, determine correct fixes, and verify fixes are present during review-fix-review cycles. This upgrade ensures the Work Item Runner can reliably supervise these cycles without requiring manual takeover (issue #109).
+
 - **Implementation protocol pre-branch fetch**: all four paths (Full Pipeline, Refactor, Fast Track, Hotfix) in protocol `03-implement-development-protocol.md` now include `git fetch origin` before branching from `develop` or `main`, matching the pattern already used in the prepare-release protocol (`05`). This prevents merge conflicts caused by stale local remote-tracking refs when creating feature/refactor/fix/hotfix branches.
 - **Reviewer loop verification (Protocol 93)**: added explicit "Verification: Re-read to confirm each fix" section requiring fixer agents to re-read specific file/line references in review findings before marking them resolved. This prevents premature dismissal of findings based on memory alone and ensures substantive code changes are actually present in the PR.
 - **Stuck-loop detection for review cycles (Protocol 93)**: added protocol-level heuristics to detect stuck fix-review loops — no-progress detection across consecutive cycles, reappearing findings after resolution, and a hard maximum cycle count with mandatory escalation. Complements existing per-platform timeouts in `pr-review-loop.sh`.

--- a/docs/ai/development-workflow/agent-model-config.md
+++ b/docs/ai/development-workflow/agent-model-config.md
@@ -27,7 +27,7 @@ If you prefer different names (`small/medium/large`, `fast/standard/pro`, etc.),
 | Agent | Tier | Rationale |
 |---|---|---|
 | `orchestrator` | `economy` | **Portfolio Orchestrator**. Reads state, builds batches, and dispatches Work Item Runners; mechanical coordination that should stay fast and cheap. |
-| `item-orchestrator` | `economy` | **Work Item Runner**. Single-item control loop; mostly routing, resume logic, and readiness supervision rather than deep reasoning. |
+| `item-orchestrator` | `balanced` | **Work Item Runner**. Single-item control loop supervises review-fix-review cycles where parsing findings, determining correct fixes, and verifying them requires capable reasoning. Economy models struggle with multi-step reasoning in fix loops; balanced (sonnet minimum) is required. |
 | `automated-reviewer-loop` | `economy` | Runs review + CI loop for a PR; mechanical coordination like the orchestration agents, no deep reasoning required. |
 | `product-manager` | `balanced` | Spec writing requires creativity and structured thinking, but the spec template provides strong scaffolding. A balanced model handles this well at a reasonable cost. |
 | `spec-reviewer` | `balanced` | Review against a checklist. A balanced model is well within the capability required. |


### PR DESCRIPTION
## Summary

Upgraded item-orchestrator agent from economy tier (haiku) to balanced tier (sonnet) across all runners (.claude/agents and .cursor/agents). The Work Item Runner supervises review-fix-review cycles that require multi-step reasoning: parsing findings, determining correct fixes, and verifying fixes are present.

## Problem

Issue #96 demonstrated that economy models (haiku) lack the reasoning capacity for review loop supervision, causing loops to run without effectively fixing findings, requiring manual takeover (~20 minutes wasted and human intervention).

## Changes

- Updated `.claude/agents/item-orchestrator.md`: model changed from `claude-haiku-4-5-20251001` to `claude-sonnet-4-6`
- Updated `.cursor/agents/item-orchestrator.md`: model changed from `fast` to `inherit` (uses balanced/capable models in Cursor)
- Updated `docs/ai/development-workflow/agent-model-config.md`: changed item-orchestrator tier from `economy` to `balanced` with updated rationale explaining why review loop supervision requires capable reasoning
- Updated `CHANGELOG.md`: documented the upgrade under Fixed section

## Test plan

- [x] Branch created and pushed
- [ ] PR opens without validation errors
- [ ] Internal review (Step 7a) passes
- [ ] External automated review (Step 7) shows no blocking findings
- [ ] CI loop (Step 8) passes
- [ ] Ready for human review

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
