### PR TITLE
fix(workflow): handle CodeRabbit resolved findings and auto-retrigger paused reviews

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -121,6 +121,12 @@ Check:
 - CHANGELOG and workflow-specific artifacts are updated when required (spec/plan-only PRs are exempt; fixes to unreleased work update existing entries rather than adding new ones; in parallel batches, only the designated last item updates CHANGELOG per protocol 90 Step 3.6)
 - New patterns are justified and consistent with the codebase
 
+Additional checks for **shell scripts** (`*.sh`):
+- Option parsing validates that required values are present before `shift`
+- All error paths emit structured output consistent with the script's output contract
+- User-supplied input (PR numbers, branch names) is validated before interpolation into file paths or commands
+- `|| true` does not silently swallow failures from external commands (e.g., `gh`, `git`) that the caller needs to know about
+
 Typical `blocking` issues:
 - Incorrect behavior
 - Security flaw

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -950,8 +950,8 @@ run_coderabbit_review() {
       local paused_count
       paused_count="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq --arg bot "$bot_login" '
-              [.[] | select(.user.login == $bot and (.body | test("Reviews paused|review paused"; "i")))] | length
+          | jq --arg bot "$bot_login" --arg since "$since_iso" '
+              [.[] | select(.user.login == $bot and .created_at > $since and (.body | test("Reviews paused|review paused"; "i")))] | length
             '
       )"
       if [ "${paused_count:-0}" -gt 0 ]; then

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -947,14 +947,18 @@ run_coderabbit_review() {
     # the pause by checking for a "Reviews paused" issue comment and post
     # "@coderabbitai review" to trigger a fresh review. Only attempt once.
     if [ "$coderabbit_any_activity" -eq 0 ] && [ "$coderabbit_retrigger_attempted" -eq 0 ] && [ "$elapsed" -ge "$((max_wait / 2))" ]; then
-      local paused_count
-      paused_count="$(
+      # Check if the most recent CodeRabbit bot comment (if any) contains a "Reviews paused" marker.
+      # Search all comments (no since_iso filter) to catch historical paused markers, but then
+      # extract only the most recent one to avoid false positives from very old paused messages.
+      local is_paused
+      is_paused="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq --arg bot "$bot_login" --arg since "$since_iso" '
-              [.[] | select(.user.login == $bot and .created_at > $since and (.body | test("Reviews paused|review paused"; "i")))] | length
+          | jq --arg bot "$bot_login" '
+              [.[] | select(.user.login == $bot)] | sort_by(.created_at) | last // empty
+              | if (.body // "") | test("Reviews paused|review paused"; "i") then "1" else "0" end
             '
       )"
-      if [ "${paused_count:-0}" -gt 0 ]; then
+      if [ "${is_paused:-0}" -eq 1 ]; then
         echo "INFO: CodeRabbit reviews are paused — posting @coderabbitai review to trigger a fresh review" >&2
         if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
           coderabbit_retrigger_attempted=1

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -956,10 +956,14 @@ run_coderabbit_review() {
       )"
       if [ "${paused_count:-0}" -gt 0 ]; then
         echo "INFO: CodeRabbit reviews are paused — posting @coderabbitai review to trigger a fresh review" >&2
-        gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1 || true
-        coderabbit_retrigger_attempted=1
-        # Reset the elapsed timer to give the retrigger time to complete.
-        elapsed=0
+        if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
+          coderabbit_retrigger_attempted=1
+          # Reset the elapsed timer to give the retrigger time to complete.
+          elapsed=0
+        else
+          echo "WARN: failed to post retrigger comment — will not reset timer" >&2
+          coderabbit_retrigger_attempted=1
+        fi
         sleep "$poll_interval"
         elapsed=$((elapsed + poll_interval))
         continue

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -928,12 +928,17 @@ run_coderabbit_review() {
     # Also check for CodeRabbit issue comments (summary comment) as activity signal.
     # Filter by since_iso so historical comments from prior pushes do not incorrectly
     # mark this HEAD cycle as having activity (which would suppress stale-findings recovery).
+    # Exclude "Reviews paused" comments as they are not an actual review; they are a pause marker.
     if [ "$coderabbit_any_activity" -eq 0 ]; then
       local activity_count
       activity_count="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
           | jq --arg bot "$bot_login" --arg since "$since_iso" '
-              [.[] | select(.user.login == $bot and .created_at > $since)] | length
+              [.[] | select(
+                  .user.login == $bot and
+                  .created_at > $since and
+                  ((.body // "") | test("Reviews paused|review paused"; "i") | not)
+              )] | length
             '
       )"
       if [ "${activity_count:-0}" -gt 0 ]; then
@@ -947,18 +952,21 @@ run_coderabbit_review() {
     # the pause by checking for a "Reviews paused" issue comment and post
     # "@coderabbitai review" to trigger a fresh review. Only attempt once.
     if [ "$coderabbit_any_activity" -eq 0 ] && [ "$coderabbit_retrigger_attempted" -eq 0 ] && [ "$elapsed" -ge "$((max_wait / 2))" ]; then
-      # Check if the most recent CodeRabbit bot comment (if any) contains a "Reviews paused" marker.
-      # Search all comments (no since_iso filter) to catch historical paused markers, but then
-      # extract only the most recent one to avoid false positives from very old paused messages.
-      local is_paused
-      is_paused="$(
+      # Check if the most recent CodeRabbit bot comment created after since_iso contains
+      # a "Reviews paused" marker. Use since_iso filter to avoid false positives from
+      # historical pause banners from prior HEAD commits.
+      local paused_count
+      paused_count="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq -s -r --arg bot "$bot_login" '
-              [.[][] | select(.user.login == $bot)] | sort_by(.created_at) | last // empty
-              | if (.body // "") | test("Reviews paused|review paused"; "i") then "1" else "0" end
+          | jq --arg bot "$bot_login" --arg since "$since_iso" '
+              [.[] | select(
+                  .user.login == $bot and
+                  .created_at > $since and
+                  ((.body // "") | test("Reviews paused|review paused"; "i"))
+              )] | length
             '
       )"
-      if [ "${is_paused:-0}" -eq 1 ]; then
+      if [ "${paused_count:-0}" -gt 0 ]; then
         echo "INFO: CodeRabbit reviews are paused — posting @coderabbitai review to trigger a fresh review" >&2
         if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
           coderabbit_retrigger_attempted=1

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -603,6 +603,7 @@ run_devin_review() {
                     .user.login == $bot and
                     .in_reply_to_id == null and
                     ((.body // "") | test("^✅") | not) and
+                    ((.body // "") | test("✅ Addressed") | not) and
                     ((.body // "") | test("No Issues Found"; "i") | not) and
                     (.id as $comment_id | ($resolved_ids | index($comment_id) | not))
                   )
@@ -766,7 +767,11 @@ run_devin_review() {
 is_coderabbit_blocking() {
   # Returns 0 (true) if the comment body contains a blocking severity marker.
   # Critical (🔴) and Major (🟠) are blocking; Minor (🟡) and Low (🟢) are not.
+  # However, CodeRabbit appends "✅ Addressed in commit ..." at the end of the
+  # comment body when the finding has been fixed in a subsequent commit. These
+  # resolved findings are NOT blocking even if they still contain 🔴/🟠 markers.
   local body="$1"
+  if printf '%s\n' "$body" | grep -q "✅ Addressed"; then return 1; fi
   if printf '%s\n' "$body" | grep -q "🔴"; then return 0; fi
   if printf '%s\n' "$body" | grep -q "🟠"; then return 0; fi
   return 1
@@ -898,6 +903,7 @@ run_coderabbit_review() {
   #
   local coderabbit_review_count=0
   local coderabbit_any_activity=0
+  local coderabbit_retrigger_attempted=0
 
   while :; do
     # Check for any CodeRabbit review submitted after the HEAD commit
@@ -935,6 +941,31 @@ run_coderabbit_review() {
       fi
     fi
 
+    # --- Auto-retrigger: detect CodeRabbit "reviews paused" state ---
+    # CodeRabbit auto-pauses reviews after many commits. When this happens, no
+    # review is posted for the current HEAD, causing the loop to time out. Detect
+    # the pause by checking for a "Reviews paused" issue comment and post
+    # "@coderabbitai review" to trigger a fresh review. Only attempt once.
+    if [ "$coderabbit_any_activity" -eq 0 ] && [ "$coderabbit_retrigger_attempted" -eq 0 ] && [ "$elapsed" -ge "$((max_wait / 2))" ]; then
+      local paused_count
+      paused_count="$(
+        gh api "repos/$repo/issues/$pr_number/comments" --paginate \
+          | jq --arg bot "$bot_login" '
+              [.[] | select(.user.login == $bot and (.body | test("Reviews paused|review paused"; "i")))] | length
+            '
+      )"
+      if [ "${paused_count:-0}" -gt 0 ]; then
+        echo "INFO: CodeRabbit reviews are paused — posting @coderabbitai review to trigger a fresh review" >&2
+        gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1 || true
+        coderabbit_retrigger_attempted=1
+        # Reset the elapsed timer to give the retrigger time to complete.
+        elapsed=0
+        sleep "$poll_interval"
+        elapsed=$((elapsed + poll_interval))
+        continue
+      fi
+    fi
+
     if [ "$elapsed" -ge "$max_wait" ]; then
       if [ "$coderabbit_any_activity" -eq 0 ]; then
         # CodeRabbit didn't review this HEAD. Check for stale findings before skipping.
@@ -962,6 +993,7 @@ run_coderabbit_review() {
                     .user.login == $bot and
                     .in_reply_to_id == null and
                     ((.body // "") | test("^✅") | not) and
+                    ((.body // "") | test("✅ Addressed") | not) and
                     (.id as $comment_id | ($resolved_ids | index($comment_id) | not))
                   )
                 | { path, line: (.line // .original_line // 0), body: (.body // "") }

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -953,8 +953,8 @@ run_coderabbit_review() {
       local is_paused
       is_paused="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq --arg bot "$bot_login" '
-              [.[] | select(.user.login == $bot)] | sort_by(.created_at) | last // empty
+          | jq -s -r --arg bot "$bot_login" '
+              [.[][] | select(.user.login == $bot)] | sort_by(.created_at) | last // empty
               | if (.body // "") | test("Reviews paused|review paused"; "i") then "1" else "0" end
             '
       )"


### PR DESCRIPTION
## Summary

Retrospective fixes from PR #133 (batch-merge feature):

- **pr-review-loop.sh**: `is_coderabbit_blocking()` now recognizes "✅ Addressed" markers in CodeRabbit comment bodies as resolved (not blocking), even when the comment still contains 🔴/🟠 severity markers. Previously the script only checked for `^✅` (start of body), which matches Devin's pattern but not CodeRabbit's (appended at end).
- **pr-review-loop.sh**: Auto-detects CodeRabbit "reviews paused" state and posts `@coderabbitai review` to trigger a fresh review. Only attempted once per poll cycle, at the halfway point of max_wait.
- **REVIEW.md**: Added shell-script-specific code review checklist items (option parsing validation, structured error output, input validation, silent failure suppression).

## Test plan

- [ ] Verify `is_coderabbit_blocking` returns false for a comment body containing both `🟠` and `✅ Addressed`
- [ ] Verify stale-findings jq filter excludes comments with `✅ Addressed` in body
- [ ] Verify CodeRabbit pause detection triggers `@coderabbitai review` comment
- [ ] Verify retrigger is only attempted once (not on every poll cycle)
- [ ] Verify shell script checklist items appear in REVIEW.md code review section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the code review checklist with additional shell-script checks: option parsing, structured error output, input validation, and avoiding patterns that hide command failures.

* **Bug Fixes**
  * Reduced false-positive stale inline findings by treating "✅ Addressed" markers as resolved.
  * Added one-time auto-retrigger for paused automated reviews and refined activity detection to ignore "Reviews paused" comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->