### PR TITLE
fix(protocol-06): check backlog for duplicates before presenting retrospective suggestions

### DIFF
--- a/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
+++ b/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
@@ -237,7 +237,9 @@ First, check whether a related existing item was found in Step 3a for this findi
 > - **Expand existing**: add the new observation to the existing issue's body
 > - **Create new**: create a separate issue (use when the scope is distinct enough to warrant tracking separately)
 
-If the human chooses **Expand existing**, append the new observation to the existing issue body:
+If the human chooses **Expand existing**, append the new observation to the existing issue body. Use the `issue_tracker.provider` from `.ai-dev-workflow.yaml` to determine the method:
+
+**`github_issues` or `github_projects`**:
 
 ```bash
 # Read current body, append new section via temp file to avoid shell quoting issues
@@ -258,9 +260,17 @@ gh issue edit <number> --body-file "$TEMP_FILE"
 rm -f "$TEMP_FILE"
 ```
 
+**`linear`**: Use the Linear MCP tool to read the issue description, append the new observation section, and update the issue. See [`integrations/linear.md`](../integrations/linear.md) for setup details.
+
+**`jira`**, **`clickup`**, **`notion`**: Use their respective MCP tools or APIs to read and update the issue body (see integration guides in `docs/ai/development-workflow/integrations/` if available).
+
+**`none`** or provider unavailable: Fall back to **Create new** and note that the existing item could not be expanded programmatically.
+
 Report the updated issue with its URL.
 
-**If no related existing item exists** (or the human chose **Create new**), create a new GitHub issue:
+**If no related existing item exists** (or the human chose **Create new**), create a new issue using the configured tracker.
+
+**`github_issues` or `github_projects`**:
 
 ```bash
 gh issue create \
@@ -268,6 +278,8 @@ gh issue create \
   --body "[Body — see format below]" \
   --label "workflow"
 ```
+
+**`linear`**, **`jira`**, **`clickup`**, **`notion`**: Use the respective MCP tool or API to create a new issue with an equivalent title, body, and label/tag.
 
 Issue body format:
 

--- a/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
+++ b/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
@@ -91,7 +91,35 @@ Conversation findings are often the highest-value source — weight them accordi
 
 Analyze all gathered data and produce a categorized list of improvement opportunities.
 
-### Categorization taxonomy
+### 3a. Query existing backlog for related items
+
+Before categorizing findings, query the configured issue tracker for existing open items that may overlap with what was discovered. This prevents duplicate issues and surfaces opportunities to expand existing backlog items instead.
+
+Use the `issue_tracker.provider` from `.ai-dev-workflow.yaml` to determine the query method:
+
+**`github_issues` or `github_projects`**:
+```bash
+# Fetch open issues with the workflow label
+gh issue list --label "workflow" --state open --limit 50 --json number,title,body
+
+# Also fetch recent open issues without label filter (catches unlabeled items)
+gh issue list --state open --limit 100 --json number,title,body
+```
+
+**`linear`**: Use the Linear MCP tool to list open issues in the relevant team or project.
+
+**`jira`**, **`clickup`**, **`notion`**: Use their respective MCP tools or APIs to fetch open backlog items.
+
+**`none`** or provider unavailable: Skip this substep and note in the presentation that no tracker check was performed.
+
+For each issue retrieved, extract its title and a short summary. After categorizing all findings in Step 3b below, match each finding against the retrieved items by topic similarity (keywords, file paths, affected protocol, root cause). Record:
+
+- `related_item`: issue number and title, if a match is found
+- `no_related_item`: explicitly noted when no match is found
+
+Carry this mapping into Step 4 (presentation) and Step 5 (action execution).
+
+### 3b. Categorization taxonomy
 
 Assign each opportunity exactly one category:
 
@@ -154,6 +182,7 @@ Present the categorized findings to the human in a structured format:
 **Observed**: [What happened — specific, factual description]
 **Impact**: [What it caused or could cause if unaddressed]
 **Recommended action**: Address now | Add to backlog
+**Related existing item**: #NNN — [title] | No existing backlog item found
 
 ---
 
@@ -190,13 +219,39 @@ Execute each chosen action in the order the human specified (or in the order the
 
 ### Add to backlog
 
-Create a GitHub issue directly using `gh issue create`:
+First, check whether a related existing item was found in Step 3a for this finding.
+
+**If a related existing item exists**: offer the human a choice before creating a new issue:
+
+> Finding #N has a related existing item: **#NNN — [title]**.
+> Would you like to:
+> - **Expand existing**: add the new observation to the existing issue's body
+> - **Create new**: create a separate issue (use when the scope is distinct enough to warrant tracking separately)
+
+If the human chooses **Expand existing**, append the new observation to the existing issue body:
+
+```bash
+# Read current body, append new section, then edit
+gh issue edit <number> --body "$(gh issue view <number> --json body -q '.body')
+
+---
+
+## Additional observation from retrospective on [date]
+
+[What was observed — specific, factual]
+
+[Impact if unaddressed]"
+```
+
+Report the updated issue with its URL.
+
+**If no related existing item exists** (or the human chose **Create new**), create a new GitHub issue:
 
 ```bash
 gh issue create \
   --title "[Descriptive title of the improvement opportunity]" \
   --body "[Body — see format below]" \
-  --label "enhancement"
+  --label "workflow"
 ```
 
 Issue body format:

--- a/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
+++ b/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
@@ -119,7 +119,7 @@ For each issue retrieved, extract its title and a short description. After categ
 2. **Strong keyword overlap**: Three or more significant keywords (excluding stopwords like "the", "a", "is") appear in both the finding and the existing item title/body
 3. **Root-cause category match**: The finding and existing item share the same categorization taxonomy label (e.g., both are `workflow-process`) and describe overlapping symptoms
 
-When multiple existing items could match, prefer the most recently updated item. When no item meets at least criterion 2 or 3, record `no_related_item`. When match confidence is ambiguous (one weak criterion only), present both the potential match and "No strong existing item found" and let the human decide in Step 5.
+When multiple existing items could match, prefer the most recently updated item. When no item meets at least one criterion, record `no_related_item`. When match confidence is ambiguous (one weak criterion only), present both the potential match and "No strong existing item found" and let the human decide in Step 5.
 
 Record:
 

--- a/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
+++ b/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
@@ -231,8 +231,9 @@ First, check whether a related existing item was found in Step 3a for this findi
 If the human chooses **Expand existing**, append the new observation to the existing issue body:
 
 ```bash
-# Read current body, append new section, then edit
-gh issue edit <number> --body "$(gh issue view <number> --json body -q '.body')
+# Read current body, append new section via temp file to avoid shell quoting issues
+gh issue view <number> --json body -q '.body' > /tmp/retro-issue-body.md
+cat >> /tmp/retro-issue-body.md <<'EOF'
 
 ---
 
@@ -240,7 +241,10 @@ gh issue edit <number> --body "$(gh issue view <number> --json body -q '.body')
 
 [What was observed — specific, factual]
 
-[Impact if unaddressed]"
+[Impact if unaddressed]
+EOF
+
+gh issue edit <number> --body-file /tmp/retro-issue-body.md
 ```
 
 Report the updated issue with its URL.

--- a/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
+++ b/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
@@ -97,7 +97,7 @@ Before categorizing findings, query the configured issue tracker for existing op
 
 Use the `issue_tracker.provider` from `.ai-dev-workflow.yaml` to determine the query method:
 
-**`github_issues` or `github_projects`**:
+**`github_issues`**:
 
 ```bash
 # Fetch open issues with the workflow label
@@ -106,6 +106,15 @@ gh issue list --label "workflow" --state open --limit 50 --json number,title,bod
 # Also fetch recent open issues without label filter (catches unlabeled items)
 gh issue list --state open --limit 100 --json number,title,body
 ```
+
+**`github_projects`**:
+
+```bash
+# Fetch items from GitHub Project v2
+gh project item-list <number> --owner @me --limit 50 --json number,title,body
+```
+
+Where `<number>` is the project number (find it via `gh project list`). This includes issues, PRs, and draft issues tracked in the project.
 
 **`linear`**: Use the Linear MCP tool to list open issues in the relevant team or project. See [`integrations/linear.md`](../integrations/linear.md) for setup details.
 

--- a/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
+++ b/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
@@ -98,6 +98,7 @@ Before categorizing findings, query the configured issue tracker for existing op
 Use the `issue_tracker.provider` from `.ai-dev-workflow.yaml` to determine the query method:
 
 **`github_issues` or `github_projects`**:
+
 ```bash
 # Fetch open issues with the workflow label
 gh issue list --label "workflow" --state open --limit 50 --json number,title,body
@@ -106,13 +107,21 @@ gh issue list --label "workflow" --state open --limit 50 --json number,title,bod
 gh issue list --state open --limit 100 --json number,title,body
 ```
 
-**`linear`**: Use the Linear MCP tool to list open issues in the relevant team or project.
+**`linear`**: Use the Linear MCP tool to list open issues in the relevant team or project. See [`integrations/linear.md`](../integrations/linear.md) for setup details.
 
-**`jira`**, **`clickup`**, **`notion`**: Use their respective MCP tools or APIs to fetch open backlog items.
+**`jira`**, **`clickup`**, **`notion`**: Use their respective MCP tools or APIs to fetch open backlog items (see integration guides in `docs/ai/development-workflow/integrations/` if available).
 
 **`none`** or provider unavailable: Skip this substep and note in the presentation that no tracker check was performed.
 
-For each issue retrieved, extract its title and a short summary. After categorizing all findings in Step 3b below, match each finding against the retrieved items by topic similarity (keywords, file paths, affected protocol, root cause). Record:
+For each issue retrieved, extract its title and a short description. After categorizing all findings in Step 3b below, match each finding against the retrieved items using these criteria (in priority order):
+
+1. **Exact match**: The finding's affected file path or protocol name appears in the existing item's title or body
+2. **Strong keyword overlap**: Three or more significant keywords (excluding stopwords like "the", "a", "is") appear in both the finding and the existing item title/body
+3. **Root-cause category match**: The finding and existing item share the same categorization taxonomy label (e.g., both are `workflow-process`) and describe overlapping symptoms
+
+When multiple existing items could match, prefer the most recently updated item. When no item meets at least criterion 2 or 3, record `no_related_item`. When match confidence is ambiguous (one weak criterion only), present both the potential match and "No strong existing item found" and let the human decide in Step 5.
+
+Record:
 
 - `related_item`: issue number and title, if a match is found
 - `no_related_item`: explicitly noted when no match is found
@@ -232,8 +241,9 @@ If the human chooses **Expand existing**, append the new observation to the exis
 
 ```bash
 # Read current body, append new section via temp file to avoid shell quoting issues
-gh issue view <number> --json body -q '.body' > /tmp/retro-issue-body.md
-cat >> /tmp/retro-issue-body.md <<'EOF'
+TEMP_FILE=$(mktemp)
+gh issue view <number> --json body -q '.body' > "$TEMP_FILE"
+cat >> "$TEMP_FILE" <<'EOF'
 
 ---
 
@@ -244,7 +254,8 @@ cat >> /tmp/retro-issue-body.md <<'EOF'
 [Impact if unaddressed]
 EOF
 
-gh issue edit <number> --body-file /tmp/retro-issue-body.md
+gh issue edit <number> --body-file "$TEMP_FILE"
+rm -f "$TEMP_FILE"
 ```
 
 Report the updated issue with its URL.

--- a/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
+++ b/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
@@ -111,10 +111,10 @@ gh issue list --state open --limit 100 --json number,title,body
 
 ```bash
 # Fetch items from GitHub Project v2
-gh project item-list <number> --owner @me --limit 50 --json number,title,body
+gh project item-list <PROJECT_NUMBER> --owner <OWNER> --format json --limit 50
 ```
 
-Where `<number>` is the project number (find it via `gh project list`). This includes issues, PRs, and draft issues tracked in the project.
+Where `<PROJECT_NUMBER>` is the project number (find it via `gh project list`) and `<OWNER>` is the user or organization owning the project. This includes issues, PRs, and draft issues tracked in the project.
 
 **`linear`**: Use the Linear MCP tool to list open issues in the relevant team or project. See [`integrations/linear.md`](../integrations/linear.md) for setup details.
 

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -114,7 +114,7 @@ This feature adds a retrospective analysis capability to the AI development work
 ### Use Case 4: Add to Backlog
 
 **Actor**: Agent (on behalf of human who chose "Add to backlog" for an opportunity)
-**Preconditions**: The human has chosen "Add to backlog" for a specific improvement opportunity; the agent has already queried the issue tracker for related existing items during synthesis (Use Case 3 / Step 3a)
+**Preconditions**: The human has chosen "Add to backlog" for a specific improvement opportunity; the agent has already queried the issue tracker for related existing items during synthesis (Protocol Step 3 / Step 3a)
 
 **Steps**:
 1. The agent checks whether a related existing backlog item was identified for this finding during the synthesis phase

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -168,7 +168,7 @@ This feature adds a retrospective analysis capability to the AI development work
 
 - Severity signals are the agent's best-effort assessment; the agent should bias toward `high` when an issue required direct human correction
 - **"Address now"** is reserved for changes the agent can self-assess as simple and safe to apply without a review loop; the agent uses its own judgment
-- **"Add to backlog"** creates a GitHub issue directly — not through the full `00-add-backlog-item-protocol.md` flow
+- **"Add to backlog"** creates a new GitHub issue or expands an existing one directly — not through the full `00-add-backlog-item-protocol.md` flow
 - The human may skip any individual opportunity (take no action); the agent moves on
 - The retrospective scope is limited to work from the current session or the PRs specified in the scope hint — no cross-session trend analysis
 - No persistent state is required or maintained between sessions

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -38,7 +38,7 @@ This feature adds a retrospective analysis capability to the AI development work
 **Postconditions**: Each improvement opportunity has either been addressed in the current session, added as a backlog issue, or explicitly skipped by the human
 
 **Information shown**:
-- Categorized improvement opportunities, each with: description, category label, severity signal, and recommended action
+- Categorized improvement opportunities, each with: description, category label, severity signal, recommended action, and a related existing item reference (issue number and title) or "No existing backlog item found"
 - After action execution: confirmation of what was done (fix applied or issue created with link)
 
 **Actions available**:

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -114,23 +114,29 @@ This feature adds a retrospective analysis capability to the AI development work
 ### Use Case 4: Add to Backlog
 
 **Actor**: Agent (on behalf of human who chose "Add to backlog" for an opportunity)
-**Preconditions**: The human has chosen "Add to backlog" for a specific improvement opportunity
+**Preconditions**: The human has chosen "Add to backlog" for a specific improvement opportunity; the agent has already queried the issue tracker for related existing items during synthesis (Use Case 3 / Step 3a)
 
 **Steps**:
-1. The agent creates a GitHub issue directly with a descriptive title, a body that describes the problem and the improvement opportunity, and the appropriate labels
-2. The agent reports the created issue with its URL
+1. The agent checks whether a related existing backlog item was identified for this finding during the synthesis phase
+2. **If a related item exists**: the agent offers the human a choice:
+   - **Expand existing**: append the new observation to the existing issue's body
+   - **Create new**: create a separate issue (appropriate when the scope is distinct enough to warrant separate tracking)
+3. If the human chooses **Expand existing**: the agent appends the new observation to the existing issue body and reports the updated issue URL
+4. If the human chooses **Create new**, or if no related item was found: the agent creates a new GitHub issue with a descriptive title, a body describing the problem and improvement opportunity, and the `workflow` label; the agent reports the created issue URL
 
-**Postconditions**: A GitHub issue exists representing the improvement opportunity
+**Postconditions**: Either a new GitHub issue exists, or an existing issue has been updated with the new observation
 
 **Information shown**:
-- Issue title and URL
+- Related existing item number and title (if found during synthesis)
+- Updated or created issue URL
 
 **Actions available**:
 - None after confirmation (the opportunity is closed)
 
 **Considerations**:
-- The issue creation is lightweight and direct — it does not go through the full `00-add-backlog-item-protocol.md` flow (which would disrupt the retrospective with its own alignment conversation)
+- The issue creation or update is lightweight and direct — it does not go through the full `00-add-backlog-item-protocol.md` flow (which would disrupt the retrospective with its own alignment conversation)
 - The issue body should include enough context that someone picking it up later can understand what was observed and why it matters, without needing the original conversation
+- The expand-existing path avoids creating duplicate backlog items for the same systemic issue seen across multiple sessions
 
 ---
 

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -185,6 +185,7 @@ This feature adds a retrospective analysis capability to the AI development work
 - [ ] Protocol 91 (work item runner) suggests a retrospective after the item summary only when the item was run standalone (not dispatched by a batch orchestrator)
 - [ ] The `/retrospective` command/skill is available in Claude Code, Cursor, and Codex following existing platform patterns
 - [ ] The agent never applies fixes or creates issues without the human's explicit choice
+- [ ] Before presenting findings, the agent queries the configured issue tracker for existing open items and annotates each finding with a related existing item reference (number and title) or "No existing backlog item found"; when "Add to backlog" is chosen and a related item exists, the agent offers to expand the existing item instead of creating a duplicate
 
 ---
 

--- a/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md
@@ -157,7 +157,7 @@ This feature adds a retrospective analysis capability to the AI development work
   | `code-quality` | Code Quality | Recurring reviewer findings that suggest a systemic pattern rather than a one-off issue |
   | `tooling` | Tooling | External tool integration issue (e.g., CodeRabbit misconfiguration, `gh` CLI usage gap) |
 
-- Each opportunity is presented with its category, a short description, a severity signal, and a recommended action (Address now / Add to backlog)
+- Each opportunity is presented with its category, a short description, a severity signal, a recommended action (Address now / Add to backlog), and a related existing item reference (issue number and title, or "No existing backlog item found")
 - **Severity signal** — each opportunity is assigned one of the following severity levels:
 
   | Code value | Display label | Description |

--- a/docs/specs/developments/20260413201328_retrospective-protocol/2_retrospective-protocol_implementation-plan.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/2_retrospective-protocol_implementation-plan.md
@@ -25,13 +25,13 @@
   - Protocol metadata (agent role, purpose)
   - Step 1: Resolve scope — determine which PRs to analyze (from scope hint, current session, or recent repo PRs)
   - Step 2: Gather data — query GitHub PR metadata (review cycles, finding types, labels, merge conflicts) and git history (commit patterns, fix-commit ratio); when conversation context is available, also analyze manual interventions, human corrections, agent deviations
-  - Step 3: Synthesize findings — categorize improvement opportunities using the fixed taxonomy (`workflow-process`, `agent-behavior`, `configuration`, `documentation`, `code-quality`, `tooling`), assign severity signals (`high`, `medium`, `low`), and recommend an action for each
-  - Step 4: Present and act — show categorized findings to the human; for each, accept the human's choice of "Address now", "Add to backlog", or "Skip"; execute the chosen action
-  - Step 5: Execute actions — "Address now": apply simple fix, commit, push (no new PR or review loop); "Add to backlog": create GitHub issue directly via `gh issue create` (not through `00-add-backlog-item-protocol.md`); "Skip": move on
+  - Step 3: Synthesize findings — Step 3a queries the configured issue tracker for existing open items that may overlap with findings (tracker-agnostic via `issue_tracker.provider` in `.ai-dev-workflow.yaml`); Step 3b categorizes improvement opportunities using the fixed taxonomy (`workflow-process`, `agent-behavior`, `configuration`, `documentation`, `code-quality`, `tooling`), assigns severity signals (`high`, `medium`, `low`), recommends an action for each, and records a related existing item reference (or "none") per finding
+  - Step 4: Present and act — show categorized findings to the human; each finding includes a "Related existing item" field; for each, accept the human's choice of "Address now", "Add to backlog", or "Skip"; execute the chosen action
+  - Step 5: Execute actions — "Address now": apply simple fix, commit, push (no new PR or review loop); "Add to backlog": when a related item exists, offer "Expand existing" (append to the existing issue body) or "Create new" (create a new GitHub issue with the `workflow` label); when no related item exists, create a new issue directly; "Skip": move on
   - Step 6: Close — confirm what was done and end the retrospective
   - Graceful exit when no actionable findings are surfaced
   - Constraint: the agent never applies fixes or creates issues without the human's explicit choice
-  - Maps to: AC 1, 2, 3, 4, 5, 6, 7, 8, 12
+  - Maps to: AC 1, 2, 3, 4, 5, 6, 7, 8, 12, 13
 
 ### Integration into Existing Protocols
 
@@ -56,7 +56,8 @@
 2. Invoke `/retrospective` with a specific PR number as scope hint — verify findings are scoped to that PR (AC 1)
 3. Choose "Address now" for a simple finding — verify fix is applied, committed, and pushed without a new PR (AC 5)
 4. Choose "Address now" for a complex finding — verify agent recommends "Add to backlog" instead and explains why (AC 6)
-5. Choose "Add to backlog" for a finding — verify a GitHub issue is created with descriptive title/body and the URL is returned (AC 7)
+5. Choose "Add to backlog" for a finding with no related existing item — verify a new GitHub issue is created with the `workflow` label, descriptive title/body, and the URL is returned (AC 7)
+5a. Choose "Add to backlog" for a finding with a related existing item — verify the agent offers "Expand existing" vs "Create new"; choosing "Expand existing" appends the observation to the existing issue body and returns the updated URL (AC 13)
 6. Complete a batch run via Protocol 90 and verify retrospective is suggested after the batch summary (AC 9)
 7. Complete a standalone item run via Protocol 91 and verify retrospective is suggested after the item summary (AC 10)
 8. Complete a dispatched (non-standalone) item run via Protocol 91 and verify retrospective is NOT suggested (AC 10)

--- a/docs/specs/developments/20260413201328_retrospective-protocol/2_retrospective-protocol_implementation-plan.md
+++ b/docs/specs/developments/20260413201328_retrospective-protocol/2_retrospective-protocol_implementation-plan.md
@@ -57,7 +57,7 @@
 3. Choose "Address now" for a simple finding — verify fix is applied, committed, and pushed without a new PR (AC 5)
 4. Choose "Address now" for a complex finding — verify agent recommends "Add to backlog" instead and explains why (AC 6)
 5. Choose "Add to backlog" for a finding with no related existing item — verify a new GitHub issue is created with the `workflow` label, descriptive title/body, and the URL is returned (AC 7)
-5a. Choose "Add to backlog" for a finding with a related existing item — verify the agent offers "Expand existing" vs "Create new"; choosing "Expand existing" appends the observation to the existing issue body and returns the updated URL (AC 13)
+5b. Choose "Add to backlog" for a finding with a related existing item — verify the agent offers "Expand existing" vs "Create new"; choosing "Expand existing" appends the observation to the existing issue body and returns the updated URL (AC 13)
 6. Complete a batch run via Protocol 90 and verify retrospective is suggested after the batch summary (AC 9)
 7. Complete a standalone item run via Protocol 91 and verify retrospective is suggested after the item summary (AC 10)
 8. Complete a dispatched (non-standalone) item run via Protocol 91 and verify retrospective is NOT suggested (AC 10)

--- a/docs/testing/workflow/retrospective-protocol.smoke-test.md
+++ b/docs/testing/workflow/retrospective-protocol.smoke-test.md
@@ -79,17 +79,31 @@ Before running this smoke test:
 
 **Expected result**: Agent redirects to "Add to backlog" with explanation. (Note: this scenario depends on the findings surfaced; if no complex findings exist, note this step as N/A.)
 
-### Step 5: Add to Backlog
+### Step 5: Add to Backlog — New Issue
 
-**Maps to**: Acceptance Criteria 7, 12
+**Maps to**: Acceptance Criteria 7, 12, 13
 
-1. From the findings, choose "Add to backlog" for one finding
-2. Verify a GitHub issue is created (via `gh issue create`)
-3. Verify the issue has a descriptive title and body
-4. Verify the agent returns the issue URL
-5. Inspect the created issue: confirm the body includes enough context to understand the problem without the original conversation
+1. Verify the Step 4 presentation includes a **"Related existing item"** field for each finding (`#NNN — [title]` or "No existing backlog item found")
+2. From the findings, choose "Add to backlog" for one finding that has **no related existing item**
+3. Verify a new GitHub issue is created (via `gh issue create` with the `workflow` label)
+4. Verify the issue has a descriptive title and body
+5. Verify the agent returns the issue URL
+6. Inspect the created issue: confirm the body includes enough context to understand the problem without the original conversation
 
-**Expected result**: GitHub issue created with descriptive content; URL returned.
+**Expected result**: GitHub issue created with descriptive content and `workflow` label; URL returned.
+
+### Step 5b: Add to Backlog — Expand Existing Issue
+
+**Maps to**: Acceptance Criteria 7, 12, 13
+
+1. From the findings, choose "Add to backlog" for one finding that has a **related existing item**
+2. Verify the agent offers a choice: **Expand existing** or **Create new**
+3. Choose "Expand existing"
+4. Verify the agent appends the new observation to the existing issue body (via `gh issue edit --body-file`)
+5. Verify the agent returns the updated issue URL
+6. Inspect the updated issue on GitHub: confirm the new observation appears as an additional section
+
+**Expected result**: Existing issue updated with new observation appended; URL returned. No duplicate issue created. (Note: this step requires a finding that matched an existing item; mark N/A if none are detected.)
 
 ### Step 6: Protocol 90 Integration — Batch Summary Suggestion
 
@@ -149,6 +163,7 @@ Each checkbox maps to an acceptance criterion from the spec.
 - [ ] AC 5: "Address now" for a simple fix: agent applies, commits, pushes without new PR
 - [ ] AC 6: "Address now" for a complex fix: agent recommends "Add to backlog" instead with explanation
 - [ ] AC 7: "Add to backlog": agent creates GitHub issue directly and returns URL
+- [ ] AC 13: Before presenting findings, agent queries the configured issue tracker for existing open items and annotates each finding with a related item reference or "No existing backlog item found"; when a related item exists and the human chooses "Expand existing", the agent appends the new observation to the existing issue rather than creating a duplicate
 - [ ] AC 8: Same-session retrospective surfaces conversation-context findings alongside GitHub findings
 - [ ] AC 9: Protocol 90 suggests retrospective after Step 6 batch summary
 - [ ] AC 10: Protocol 91 suggests retrospective after item summary only for standalone runs (not batched)
@@ -160,5 +175,6 @@ Each checkbox maps to an acceptance criterion from the spec.
 ## Known Limitations
 
 - Step 4 (complex finding) depends on the retrospective surfacing a finding that is too complex; if all findings are simple, this step cannot be validated and should be marked N/A
+- Step 5b (expand existing) depends on the retrospective surfacing a finding that matches an existing open backlog item; if no match is detected, this step cannot be validated and should be marked N/A
 - Steps 6-8 require running full orchestration sessions, which may take significant time; these can be tested opportunistically during normal workflow usage rather than in a dedicated smoke test session
 - Conversation-context analysis quality depends on the richness of the conversation history in the current session

--- a/docs/testing/workflow/retrospective-protocol.smoke-test.md
+++ b/docs/testing/workflow/retrospective-protocol.smoke-test.md
@@ -94,7 +94,7 @@ Before running this smoke test:
 
 ### Step 5b: Add to Backlog — Expand Existing Issue
 
-**Maps to**: Acceptance Criteria 7, 12, 13
+**Maps to**: Acceptance Criteria 12, 13
 
 1. From the findings, choose "Add to backlog" for one finding that has a **related existing item**
 2. Verify the agent offers a choice: **Expand existing** or **Create new**

--- a/docs/testing/workflow/retrospective-protocol.smoke-test.md
+++ b/docs/testing/workflow/retrospective-protocol.smoke-test.md
@@ -83,7 +83,7 @@ Before running this smoke test:
 
 **Maps to**: Acceptance Criteria 7, 12, 13
 
-1. Verify the Step 4 presentation includes a **"Related existing item"** field for each finding (`#NNN — [title]` or "No existing backlog item found")
+1. Verify the findings presentation (protocol Step 4) includes a **"Related existing item"** field for each finding (`#NNN — [title]` or "No existing backlog item found")
 2. From the findings, choose "Add to backlog" for one finding that has **no related existing item**
 3. Verify a new GitHub issue is created (via `gh issue create` with the `workflow` label)
 4. Verify the issue has a descriptive title and body


### PR DESCRIPTION
## Summary

- Adds **Step 3a** to protocol-06: queries the configured issue tracker for existing open items before categorizing retrospective findings (tracker-agnostic via `issue_tracker.provider` in `.ai-dev-workflow.yaml`)
- Each finding in the Step 4 presentation now includes a **"Related existing item"** field (`#NNN — title` or "No existing backlog item found")
- **Step 5 (Add to backlog)** now offers to expand an existing item instead of creating a duplicate when a related item is detected

## Test plan

- [ ] Read through protocol-06 Step 3a, Step 4, and Step 5 for coherence and completeness
- [ ] Verify the tracker query commands are correct for `github_issues` / `github_projects`
- [ ] Verify the "Expand existing" edit command is syntactically correct (`gh issue edit` with appended body)
- [ ] Confirm the graceful fallback when provider is `none` or unavailable

Closes #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent now checks the configured issue tracker and shows a "Related existing item" for each finding.
  * Backlog flow branches: Expand existing (append observation and report updated URL; falls back to Create new if expansion unavailable) or Create new; newly created issues default to a "workflow" label.

* **Documentation**
  * Updated retrospective protocol, specs, implementation plan, and smoke tests to reflect issue-tracker-aware flows and new acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->