### PR TITLE
fix(protocol-03): add cross-reference consistency check for multi-file policy changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Cross-reference consistency check in developer protocol**: `03-implement-development-protocol.md` now requires a cross-reference consistency check in the pre-implementation scope checklist (item 6, all four paths) and the Quality Rules section. When a change modifies policy or rule text that appears in multiple files, developers must grep for key phrases, list every matched location, and confirm all locations are updated consistently before opening a PR. This addresses the root cause of multi-cycle review loops on cross-cutting documentation changes (e.g., PR #120 required 8 cycles due to inconsistencies across 10+ files).
-
 ### Added
 
 - **Batch merge command** (`/batch-merge`): a new command and shell script that merge all ready PRs in a parallel batch into `develop` sequentially. Discovers PRs labeled `ready-for-human-review` automatically or accepts an explicit PR list; presents a merge plan for human confirmation before any merge; auto-resolves CHANGELOG `[Unreleased]` conflicts (entries combined, none dropped) and non-overlapping documentation file conflicts; pauses for human input on non-trivial conflicts; runs `post-merge-cleanup` after each successful merge; and produces a structured outcome summary (`merged_clean`, `merged_auto`, `merged_human`, `skipped_not_ready`, `skipped_conflict`, `failed`, `not_attempted`). Available as `/batch-merge` in Claude Code, `/batch-merge` in Cursor, and the `batch-merge` Codex skill. Protocol 90 (batch orchestrator) now includes a Step 5.5 handoff path for merge-ready parallel batches.
@@ -27,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AI Workflow: `implementation-plan-template.md` — added a "Code Samples" section with guidance to mark code samples as illustrative and to ensure all cross-section references are consistent before marking the plan ready.
 
 ### Fixed
+
+- **Cross-reference consistency check in developer protocol**: `03-implement-development-protocol.md` now requires a cross-reference consistency check in the pre-implementation scope checklist (item 6, all four paths) and the Quality Rules section. When a change modifies policy or rule text that appears in multiple files, developers must grep for key phrases, list every matched location, and confirm all locations are updated consistently before opening a PR. This addresses the root cause of multi-cycle review loops on cross-cutting documentation changes (e.g., PR #120 required 8 cycles due to inconsistencies across 10+ files).
 
 - **Pre-implementation scope checklist in Protocol 03**: all four implementation paths (Full Pipeline, Refactor, Fast Track, Hotfix) in `03-implement-development-protocol.md` now require a scope checklist before writing any code. The checklist asks the agent to enumerate all files to be changed, describe the specific change needed per file, verify all changes are within the issue's scope, consider edge cases (existing branch, worktree context, failure modes), and cross-reference related protocols for consistency. This prevents implementation gaps that lead to multi-round review cycles.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cross-reference consistency check in developer protocol**: `03-implement-development-protocol.md` now requires a cross-reference consistency check in the pre-implementation scope checklist (item 6, all four paths) and the Quality Rules section. When a change modifies policy or rule text that appears in multiple files, developers must grep for key phrases, list every matched location, and confirm all locations are updated consistently before opening a PR. This addresses the root cause of multi-cycle review loops on cross-cutting documentation changes (e.g., PR #120 required 8 cycles due to inconsistencies across 10+ files).
+
 ### Added
 
 - **Batch merge command** (`/batch-merge`): a new command and shell script that merge all ready PRs in a parallel batch into `develop` sequentially. Discovers PRs labeled `ready-for-human-review` automatically or accepts an explicit PR list; presents a merge plan for human confirmation before any merge; auto-resolves CHANGELOG `[Unreleased]` conflicts (entries combined, none dropped) and non-overlapping documentation file conflicts; pauses for human input on non-trivial conflicts; runs `post-merge-cleanup` after each successful merge; and produces a structured outcome summary (`merged_clean`, `merged_auto`, `merged_human`, `skipped_not_ready`, `skipped_conflict`, `failed`, `not_attempted`). Available as `/batch-merge` in Claude Code, `/batch-merge` in Cursor, and the `batch-merge` Codex skill. Protocol 90 (batch orchestrator) now includes a Step 5.5 handoff path for merge-ready parallel batches.

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -425,7 +425,7 @@ When you encounter something the spec or plan doesn't cover:
 ## Quality Rules
 
 - **Cross-reference consistency**: When a change modifies policy or rule text that appears in multiple files (protocols, agent instructions, best-practice docs, Cursor agents, Codex skills, etc.), every location must be updated in the same PR. Before opening the PR:
-  1. Grep for key phrases and signal names from the changed rule across the entire docs tree
+  1. Grep for key phrases and signal names from the changed rule across all relevant locations (`docs/`, `AGENTS.md`, `README.md`, `.cursor/`, `.claude/`, `.codex/`)
   2. Confirm every matched location is updated consistently
   3. Verify headings, signal names, and language do not contradict each other across files
 

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -53,8 +53,14 @@ Complete this checklist **before writing any code**. It takes 5–10 minutes and
    - What are the failure modes or missing inputs?
    - Are there related files that must stay consistent with the changed files?
 5. **Cross-reference related protocols**: if any changed file references or is referenced by other protocol documents, read those documents and confirm your changes are consistent with them.
+6. **Cross-reference consistency check** (required when the change modifies policy or rule text): if the rule or policy you are changing is documented in more than one location, grep for key phrases before writing any code, list every location, and confirm each location will be updated consistently. Verify that headings, signal names, and language do not contradict each other across files.
 
-Do not proceed to Step 2 until this checklist is complete and all five points are answered.
+   ```bash
+   # Example: grep for the key phrase or signal name across all docs
+   grep -r "key phrase" docs/ .cursor/ .claude/ .codex/ --include="*.md" -l
+   ```
+
+Do not proceed to Step 2 until this checklist is complete and all six points are answered.
 
 ### Step 2: Human Review Shortcut (Optional)
 
@@ -208,8 +214,9 @@ Complete this checklist **before writing any code**. It takes 5–10 minutes and
    - Are there callers or dependents of the refactored code that must be updated in sync?
    - What behavior is preserved vs. changed?
 5. **Cross-reference related protocols**: if any changed file references or is referenced by other protocol documents, read those documents and confirm your changes are consistent with them.
+6. **Cross-reference consistency check** (required when the change modifies policy or rule text): if the rule or policy you are changing is documented in more than one location, grep for key phrases before writing any code, list every location, and confirm each location will be updated consistently. Verify that headings, signal names, and language do not contradict each other across files.
 
-Do not proceed to the Refactor Steps until this checklist is complete and all five points are answered.
+Do not proceed to the Refactor Steps until this checklist is complete and all six points are answered.
 
 ### Refactor Steps
 
@@ -275,8 +282,9 @@ Complete this checklist **before writing any code**. It takes 5–10 minutes and
 3. **Verify scope**: confirm all listed changes are within the issue's stated scope. Remove anything that is not.
 4. **Consider edge cases**: what if the branch already exists locally or remotely? What if this runs in a worktree? What are the failure modes?
 5. **Cross-reference related protocols**: if any changed file references or is referenced by other protocol documents, read those documents and confirm your changes are consistent with them.
+6. **Cross-reference consistency check** (required when the change modifies policy or rule text): if the rule or policy you are changing is documented in more than one location, grep for key phrases before writing any code, list every location, and confirm each location will be updated consistently. Verify that headings, signal names, and language do not contradict each other across files.
 
-Do not proceed to Step 2 until this checklist is complete and all five points are answered.
+Do not proceed to Step 2 until this checklist is complete and all six points are answered.
 
 ### Step 2: Ambiguity Check
 
@@ -348,8 +356,9 @@ Complete this checklist **before writing any code**. It takes 5–10 minutes and
 3. **Verify scope**: confirm all listed changes address the production incident directly. Remove anything that is not strictly necessary.
 4. **Consider edge cases**: what if the branch already exists locally or remotely? What is the minimal safe change? Are there related files that must stay consistent?
 5. **Cross-reference related protocols**: if the fix touches shared utilities or configuration files used by other flows, confirm consistency.
+6. **Cross-reference consistency check** (required when the fix modifies policy or rule text): if the rule or policy you are changing is documented in more than one location, grep for key phrases before writing any code, list every location, and confirm each location will be updated consistently.
 
-Do not proceed to Step 3 until this checklist is complete and all five points are answered.
+Do not proceed to Step 3 until this checklist is complete and all six points are answered.
 
 ### Step 3: Branch
 
@@ -414,6 +423,13 @@ When you encounter something the spec or plan doesn't cover:
 ---
 
 ## Quality Rules
+
+- **Cross-reference consistency**: When a change modifies policy or rule text that appears in multiple files (protocols, agent instructions, best-practice docs, Cursor agents, Codex skills, etc.), every location must be updated in the same PR. Before opening the PR:
+  1. Grep for key phrases and signal names from the changed rule across the entire docs tree
+  2. Confirm every matched location is updated consistently
+  3. Verify headings, signal names, and language do not contradict each other across files
+
+  Skipping this check is the primary cause of multi-cycle review loops on cross-cutting documentation changes.
 
 - **Scope boundary**: Modify **only** files directly related to the assigned issue. If a code review or linter finding requires changes outside the issue's scope (e.g., fixing issues in adjacent modules, refactoring unrelated utilities, or addressing tech debt in other areas):
   1. **Do not fix it** in the current PR

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -56,8 +56,8 @@ Complete this checklist **before writing any code**. It takes 5–10 minutes and
 6. **Cross-reference consistency check** (required when the change modifies policy or rule text): if the rule or policy you are changing is documented in more than one location, grep for key phrases before writing any code, list every location, and confirm each location will be updated consistently. Verify that headings, signal names, and language do not contradict each other across files.
 
    ```bash
-   # Example: grep for the key phrase or signal name across all docs
-   grep -r "key phrase" docs/ .cursor/ .claude/ .codex/ --include="*.md" -l
+   # Example: grep for the key phrase or signal name across all relevant locations
+   grep -r "key phrase" docs/ .cursor/ .claude/ .codex/ AGENTS.md README.md REVIEW.md --include="*.md" -l
    ```
 
 Do not proceed to Step 2 until this checklist is complete and all six points are answered.

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -356,7 +356,7 @@ Complete this checklist **before writing any code**. It takes 5–10 minutes and
 3. **Verify scope**: confirm all listed changes address the production incident directly. Remove anything that is not strictly necessary.
 4. **Consider edge cases**: what if the branch already exists locally or remotely? What is the minimal safe change? Are there related files that must stay consistent?
 5. **Cross-reference related protocols**: if the fix touches shared utilities or configuration files used by other flows, confirm consistency.
-6. **Cross-reference consistency check** (required when the fix modifies policy or rule text): if the rule or policy you are changing is documented in more than one location, grep for key phrases before writing any code, list every location, and confirm each location will be updated consistently.
+6. **Cross-reference consistency check** (required when the fix modifies policy or rule text): if the rule or policy you are changing is documented in more than one location, grep for key phrases before writing any code, list every location, and confirm each location will be updated consistently. Verify that headings, signal names, and language do not contradict each other across files.
 
 Do not proceed to Step 3 until this checklist is complete and all six points are answered.
 

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -425,7 +425,7 @@ When you encounter something the spec or plan doesn't cover:
 ## Quality Rules
 
 - **Cross-reference consistency**: When a change modifies policy or rule text that appears in multiple files (protocols, agent instructions, best-practice docs, Cursor agents, Codex skills, etc.), every location must be updated in the same PR. Before opening the PR:
-  1. Grep for key phrases and signal names from the changed rule across all relevant locations (`docs/`, `AGENTS.md`, `README.md`, `.cursor/`, `.claude/`, `.codex/`)
+  1. Grep for key phrases and signal names from the changed rule across all relevant locations (`docs/`, `AGENTS.md`, `README.md`, `REVIEW.md`, `.cursor/`, `.claude/`, `.codex/`)
   2. Confirm every matched location is updated consistently
   3. Verify headings, signal names, and language do not contradict each other across files
 


### PR DESCRIPTION
## What

Adds a cross-reference consistency check to `03-implement-development-protocol.md` — the root cause of PR #120 requiring 8 Devin review cycles.

## Changes

- **Pre-implementation scope checklist (all 4 paths)**: New item 6 requires developers to grep for key phrases before writing code, list every location where the changed rule/policy appears, and confirm all locations will be updated consistently. Updated "five points" → "six points" in all completion gates.
- **Quality Rules section**: New "Cross-reference consistency" rule explains the full check (grep, list, verify headings/signal names/language) and calls out that skipping it is the primary cause of multi-cycle review loops.

## Why

PR #120 (CHANGELOG conflict mitigation) required 8 review cycles because the developer agent had no guidance to proactively find all locations where a rule is documented. Inconsistencies were discovered one-by-one per review cycle: missing Cursor agent update, inconsistent signal naming, contradictory "always" language, etc.

## Test plan

- [ ] Read the updated checklist items in all 4 paths and verify the wording is clear and actionable
- [ ] Confirm the Quality Rules entry concisely describes the check without duplicating the checklist
- [ ] Confirm CHANGELOG entry is accurate

Closes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a required cross-reference consistency check to pre-implementation scope checklists for all implementation paths (adds a sixth checklist item).
  * Updated gating instructions to require completion of the new checklist step before opening a PR.
  * Expanded Quality Rules with a “Cross-reference consistency” rule detailing a three-part pre-PR process: search for key phrases, enumerate matches, and confirm consistent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->