### PR TITLE
fix(script): fix unbound variable error in add-backlog-item.sh create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Unbound variable in `add-backlog-item.sh create`**: fixed `labels[@]: unbound variable` error (bash `set -u`) that occurred when no `--label` flags were passed. The array iteration now uses the `${var[@]+"${var[@]}"}` guard so an empty `labels` array expands safely to nothing rather than triggering an error.
+
 - **Cross-reference consistency check in developer protocol**: `03-implement-development-protocol.md` now requires a cross-reference consistency check in the pre-implementation scope checklist (item 6, all four paths) and the Quality Rules section. When a change modifies policy or rule text that appears in multiple files, developers must grep for key phrases, list every matched location, and confirm all locations are updated consistently before opening a PR. This addresses the root cause of multi-cycle review loops on cross-cutting documentation changes (e.g., PR #120 required 8 cycles due to inconsistencies across 10+ files).
 - **Worktree agent main-branch safety rule (Protocol 91)**: added an explicit safety rule to the worktree isolation section of `91-orchestrate-work-protocol.md` prohibiting agents running inside a worktree from running `git checkout`, `git switch`, or any other branch-switching command that targets the main working tree. Violations leave the main repo checked out on a `worktree-agent-*` branch, breaking all subsequent agent and human operations. The rule requires agents to use `git -C <main-repo-root>` for read-only main-repo queries and to verify that the main working tree is still on `develop` before worktree cleanup — stopping with an error and escalating to the human if the branch has changed (issue #111).
 

--- a/scripts/development-workflow/add-backlog-item.sh
+++ b/scripts/development-workflow/add-backlog-item.sh
@@ -91,7 +91,7 @@ create_cmd() {
       gh_args+=(--body "$body")
     fi
     local label
-    for label in "${labels[@]}"; do
+    for label in "${labels[@]+"${labels[@]}"}"; do
       [ -n "$label" ] || continue
       gh_args+=(--label "$label")
     done


### PR DESCRIPTION
## Summary

- Fixes `labels[@]: unbound variable` error in `add-backlog-item.sh create` when no `--label` flags are passed
- Bash `set -u` (nounset) treats an empty array expansion `${labels[@]}` as unbound in some bash versions (notably bash 3.x on macOS)
- Changed the loop from `"${labels[@]}"` to `"${labels[@]+"${labels[@]}"}"` so an empty array expands safely to nothing

Closes #112.

## Test plan

- [ ] Run `add-backlog-item.sh create --title "Test" --body "body"` (no --label) — should not error with `unbound variable`
- [ ] Run `add-backlog-item.sh create --title "Test" --body "body" --label "bug"` — should still pass the label correctly to `gh issue create`
- [ ] Verify syntax is valid: `bash -n scripts/development-workflow/add-backlog-item.sh`

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a bash script error in the backlog item creation workflow that would fail when items were created without labels. The command now properly handles cases where no labels are specified, allowing successful execution in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->