### PR TITLE
fix(protocol-91,03): derive required labels from branch prefix, not content type

### DIFF
--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -172,6 +172,8 @@ After the draft PR exists, the **Work Item Runner** owns the rest of the lifecyc
 - Apply `ready-for-human-review` and move the tracker to **Development in Review** when the PR is human-ready
 - Stop only when the PR is waiting on human review / merge or the run has escalated
 
+**Label derivation rule**: The `ready-for-regression` label requirement is determined by the **branch prefix**, not by the content of the PR. `feature/*` branches always require `ready-for-regression` regardless of whether the changes are code, documentation, or configuration. See `91-orchestrate-work-protocol.md` Step 8a for the full branch-prefix-to-label table.
+
 If this protocol is invoked **standalone** rather than through the Work Item Runner, hand off manually by following `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` from the newly opened draft PR.
 
 See `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` and `docs/ai/development-workflow/protocols/92-pr-readiness-signal-protocol.md`.
@@ -251,7 +253,7 @@ gh pr create --draft --base develop --title "refactor([scope]): [short descripti
 
 **Important**: Always use `--base develop` to explicitly target the `develop` branch.
 
-10. Hand off to the Work Item Runner with the same lifecycle expectations as Path 1 Step 9 (internal review gate, automated reviewer loop, CI, labels). See `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` and `docs/ai/development-workflow/protocols/92-pr-readiness-signal-protocol.md`.
+10. Hand off to the Work Item Runner with the same lifecycle expectations as Path 1 Step 9 (internal review gate, automated reviewer loop, CI, labels). **Label derivation rule**: `refactor/*` branches always require `ready-for-regression` based on branch prefix, not content type. See `91-orchestrate-work-protocol.md` Step 8a for the full branch-prefix-to-label table. See `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` and `docs/ai/development-workflow/protocols/92-pr-readiness-signal-protocol.md`.
 
 ---
 
@@ -331,7 +333,7 @@ gh pr create --draft --base develop --title "fix([scope]): [description]" --body
 
 ### Step 9: Handoff to Work Item Runner
 
-Hand off to the Work Item Runner per Path 1 `### Step 9: Handoff to Work Item Runner`.
+Hand off to the Work Item Runner per Path 1 `### Step 9: Handoff to Work Item Runner`. **Label derivation rule**: `fix/*` branches always require `ready-for-regression` based on branch prefix, not content type. See `91-orchestrate-work-protocol.md` Step 8a for the full branch-prefix-to-label table.
 
 ---
 
@@ -403,7 +405,7 @@ gh pr create --draft --base main --title "fix([scope]): [description] (hotfix)" 
 
 ### Step 9: Handoff to Work Item Runner
 
-Hand off to the Work Item Runner per Path 1 `### Step 9: Handoff to Work Item Runner`.
+Hand off to the Work Item Runner per Path 1 `### Step 9: Handoff to Work Item Runner`. **Label derivation rule**: `hotfix/*` branches always require `ready-for-regression` based on branch prefix, not content type. See `91-orchestrate-work-protocol.md` Step 8a for the full branch-prefix-to-label table.
 
 **After merge**: notify the human that a backport PR (main → develop) must be opened to prevent branch drift.
 

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -584,6 +584,7 @@ case "$BRANCH" in
     ;;
   *)
     IS_IMPLEMENTATION_PR=false
+    echo "WARNING: Branch '$BRANCH' does not match a recognized prefix (feature/*, fix/*, refactor/*, hotfix/*, spec/*, implementation-plan/*). Treating as non-implementation PR. Report this anomaly to the human."
     ;;
 esac
 

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -553,6 +553,21 @@ Interpret the result as follows:
 
 **Before applying `ready-for-human-review`**, verify all required readiness conditions are met. This is a hard gate — do not skip or defer.
 
+### Label derivation rule
+
+Required labels are determined by the **branch prefix**, not by the content of the PR (e.g., whether it changes code vs. documentation). An agent must never infer labels from what was changed inside the PR.
+
+| Branch prefix | Requires `ready-for-regression` |
+|---|---|
+| `feature/*` | Yes |
+| `fix/*` | Yes |
+| `refactor/*` | Yes |
+| `hotfix/*` | Yes |
+| `spec/*` | No |
+| `implementation-plan/*` | No |
+
+Any branch that does not match a recognized prefix is treated as non-implementation (i.e., `ready-for-regression` is NOT required), but this should be treated as a configuration anomaly and reported to the human.
+
 Run this checklist for **every PR**:
 
 ```bash


### PR DESCRIPTION
## What was changed

- `91-orchestrate-work-protocol.md` Step 8a: added a **Label derivation rule** section with an explicit table mapping branch prefixes to `ready-for-regression` requirement. `feature/*`, `fix/*`, `refactor/*`, `hotfix/*` always require the label; `spec/*` and `implementation-plan/*` do not. Unknown prefixes are treated as non-implementation with an anomaly warning.

- `03-implement-development-protocol.md` Step 9 / Step 10 (all four paths): added inline label derivation reminders so agents see the rule at the point of PR handoff, not just in Protocol 91.

## Why

PRs #146 and #147 were missing `ready-for-regression` labels because agents inferred the label requirement from PR content type (docs-only change) instead of from the branch prefix (`fix/*`, `refactor/*`). The protocol must be explicit that branch prefix is the sole source of truth for this decision.

## Test plan

- Read `91-orchestrate-work-protocol.md` Step 8a and verify the new table is present and matches the existing `case` block and Step 7b.
- Read `03-implement-development-protocol.md` and verify each path's handoff step includes the label derivation reminder.
- Confirm no other files were modified.

## CHANGELOG

See `[Unreleased]` section: "Label derivation from branch prefix (Protocol 91 and Protocol 03)".