### PR TITLE
fix(tooling): handle CodeRabbit rate limiting in parallel batch dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **CodeRabbit rate-limit handling in `pr-review-loop.sh`**: when CodeRabbit posts a rate-limit comment instead of a review (common in parallel batches with 3+ PRs), the script now detects the comment, waits 3 minutes, and retries with `@coderabbitai review` (up to 2 retries, configurable via `CODERABBIT_RATE_LIMIT_MAX_RETRIES` and `CODERABBIT_RATE_LIMIT_WAIT`). Also added Step 3.7 to `90-batch-orchestrate-work-protocol.md` documenting this behavior and fallback guidance for human reviewers.
-
 ### Added
 
 - **Batch merge command** (`/batch-merge`): a new command and shell script that merge all ready PRs in a parallel batch into `develop` sequentially. Discovers PRs labeled `ready-for-human-review` automatically or accepts an explicit PR list; presents a merge plan for human confirmation before any merge; auto-resolves CHANGELOG `[Unreleased]` conflicts (entries combined, none dropped) and non-overlapping documentation file conflicts; pauses for human input on non-trivial conflicts; runs `post-merge-cleanup` after each successful merge; and produces a structured outcome summary (`merged_clean`, `merged_auto`, `merged_human`, `skipped_not_ready`, `skipped_conflict`, `failed`, `not_attempted`). Available as `/batch-merge` in Claude Code, `/batch-merge` in Cursor, and the `batch-merge` Codex skill. Protocol 90 (batch orchestrator) now includes a Step 5.5 handoff path for merge-ready parallel batches.
@@ -45,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Post-dispatch PR verification step for orchestrator (issue #123)**: protocol `90-batch-orchestrate-work-protocol.md` Step 5.1 and protocol `91-orchestrate-work-protocol.md` Step 8c now require the orchestrator to independently verify actual PR state via `gh pr view` before reporting any PR as ready for human review. Verification covers base branch correctness, non-draft state, required labels (`ready-for-regression`, `ready-for-human-review`, absence of `needs-fixes`), presence of the automated reviewer loop summary comment, and green CI checks. Trusting Work Item Runner self-reports without verification caused 50% of batch 1 PRs to have at least one issue requiring human correction.
 - **Pre-dispatch merged-PR cross-check (issue #142)**: protocol `90-batch-orchestrate-work-protocol.md` Step 1a now cross-checks each candidate item against `gh pr list --state merged` before building the portfolio map. If a merged PR already exists for an item whose tracker status is stale, the orchestrator updates the tracker to Merged, closes the issue, and excludes it — preventing duplicate agent runs on already-completed work.
 - **Post-merge cleanup now closes GitHub issues (issue #144)**: `post-merge-cleanup.sh` now detects the issue number from the branch name (e.g., `fix/123-slug` → issue #123) and closes the GitHub issue with a comment linking the merged PR. This prevents issues from remaining open after their PRs are merged.
+- **CodeRabbit rate-limit handling in `pr-review-loop.sh`**: when CodeRabbit posts a rate-limit comment instead of a review (common in parallel batches with 3+ PRs), the script now detects the comment, waits 3 minutes, and retries with `@coderabbitai review` (up to 2 retries, configurable via `CODERABBIT_RATE_LIMIT_MAX_RETRIES` and `CODERABBIT_RATE_LIMIT_WAIT`). Also added Step 3.7 to `90-batch-orchestrate-work-protocol.md` documenting this behavior and fallback guidance for human reviewers.
 
 ## [0.21.0] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CodeRabbit rate-limit handling in `pr-review-loop.sh`**: when CodeRabbit posts a rate-limit comment instead of a review (common in parallel batches with 3+ PRs), the script now detects the comment, waits 3 minutes, and retries with `@coderabbitai review` (up to 2 retries, configurable via `CODERABBIT_RATE_LIMIT_MAX_RETRIES` and `CODERABBIT_RATE_LIMIT_WAIT`). Also added Step 3.7 to `90-batch-orchestrate-work-protocol.md` documenting this behavior and fallback guidance for human reviewers.
+
 ### Added
 
 - **Batch merge command** (`/batch-merge`): a new command and shell script that merge all ready PRs in a parallel batch into `develop` sequentially. Discovers PRs labeled `ready-for-human-review` automatically or accepts an explicit PR list; presents a merge plan for human confirmation before any merge; auto-resolves CHANGELOG `[Unreleased]` conflicts (entries combined, none dropped) and non-overlapping documentation file conflicts; pauses for human input on non-trivial conflicts; runs `post-merge-cleanup` after each successful merge; and produces a structured outcome summary (`merged_clean`, `merged_auto`, `merged_human`, `skipped_not_ready`, `skipped_conflict`, `failed`, `not_attempted`). Available as `/batch-merge` in Claude Code, `/batch-merge` in Cursor, and the `batch-merge` Codex skill. Protocol 90 (batch orchestrator) now includes a Step 5.5 handoff path for merge-ready parallel batches.

--- a/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -250,6 +250,16 @@ Each PR in a parallel batch adds its own CHANGELOG entry as normal during implem
 
 ---
 
+## Step 3.7: CodeRabbit Rate Limits in Parallel Batches
+
+CodeRabbit enforces a per-hour rate limit on automated reviews. When multiple PRs are created within a short window (e.g., 3+ PRs within seconds of each other in a parallel batch), CodeRabbit may rate-limit reviews on some PRs and post a "rate limit" comment instead of a full review.
+
+`pr-review-loop.sh` detects this automatically: when a rate-limit comment is found, it waits 3 minutes and retries with `@coderabbitai review` (up to 2 retries, configurable via `CODERABBIT_RATE_LIMIT_MAX_RETRIES` and `CODERABBIT_RATE_LIMIT_WAIT`). No manual intervention is needed in most cases.
+
+If a PR still shows no CodeRabbit review after all retries (e.g., the rate-limit window extends beyond the retry budget), the script falls through to stale-findings recovery and eventually marks the result as `skipped (no_review)`. The PR can still advance to `ready-for-human-review`. A human reviewer can manually post `@coderabbitai review` on the PR to trigger a fresh review after the rate-limit window resets.
+
+---
+
 ## Step 4: Dispatch Work Item Runners
 
 Dispatch exactly one Work Item Runner per item in the current batch.

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1006,8 +1006,8 @@ run_coderabbit_review() {
         coderabbit_rate_limit_retries=$((coderabbit_rate_limit_retries + 1))
         echo "INFO: CodeRabbit rate limit detected (retry $coderabbit_rate_limit_retries/$coderabbit_rate_limit_max_retries) — waiting ${coderabbit_rate_limit_wait}s before re-triggering" >&2
         sleep "$coderabbit_rate_limit_wait"
-        # Reset since_iso to after the wait so activity detection picks up the new review.
-        since_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
+        # Do NOT reset since_iso — keep the original HEAD-commit timestamp so any review
+        # posted by CodeRabbit during or after the wait is still within the detection window.
         elapsed=0
         if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
           echo "INFO: posted @coderabbitai review trigger after rate-limit wait" >&2

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -904,6 +904,9 @@ run_coderabbit_review() {
   local coderabbit_review_count=0
   local coderabbit_any_activity=0
   local coderabbit_retrigger_attempted=0
+  local coderabbit_rate_limit_retries=0
+  local coderabbit_rate_limit_max_retries="${CODERABBIT_RATE_LIMIT_MAX_RETRIES:-2}"
+  local coderabbit_rate_limit_wait="${CODERABBIT_RATE_LIMIT_WAIT:-180}"
 
   while :; do
     # Check for any CodeRabbit review submitted after the HEAD commit
@@ -975,6 +978,39 @@ run_coderabbit_review() {
         else
           echo "WARN: failed to post retrigger comment — will not reset timer" >&2
           coderabbit_retrigger_attempted=1
+        fi
+        sleep "$poll_interval"
+        elapsed=$((elapsed + poll_interval))
+        continue
+      fi
+    fi
+
+    # --- Rate-limit detection: CodeRabbit posts a comment when it cannot review yet ---
+    # When CodeRabbit is rate-limited it posts an issue comment containing "rate limit"
+    # text. Detect this, wait, and retry up to coderabbit_rate_limit_max_retries times.
+    if [ "$coderabbit_any_activity" -eq 0 ] && [ "$coderabbit_rate_limit_retries" -lt "$coderabbit_rate_limit_max_retries" ]; then
+      local rate_limit_comment_count
+      rate_limit_comment_count="$(
+        gh api "repos/$repo/issues/$pr_number/comments" --paginate \
+          | jq --arg bot "$bot_login" --arg since "$since_iso" '
+              [.[] | select(
+                  .user.login == $bot and
+                  .created_at > $since and
+                  ((.body // "") | test("rate.?limit"; "i"))
+              )] | length
+            '
+      )"
+      if [ "${rate_limit_comment_count:-0}" -gt 0 ]; then
+        coderabbit_rate_limit_retries=$((coderabbit_rate_limit_retries + 1))
+        echo "INFO: CodeRabbit rate limit detected (retry $coderabbit_rate_limit_retries/$coderabbit_rate_limit_max_retries) — waiting ${coderabbit_rate_limit_wait}s before re-triggering" >&2
+        sleep "$coderabbit_rate_limit_wait"
+        # Reset since_iso to after the wait so activity detection picks up the new review.
+        since_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
+        elapsed=0
+        if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
+          echo "INFO: posted @coderabbitai review trigger after rate-limit wait" >&2
+        else
+          echo "WARN: failed to post @coderabbitai review trigger after rate-limit wait" >&2
         fi
         sleep "$poll_interval"
         elapsed=$((elapsed + poll_interval))

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -907,6 +907,14 @@ run_coderabbit_review() {
   local coderabbit_rate_limit_retries=0
   local coderabbit_rate_limit_max_retries="${CODERABBIT_RATE_LIMIT_MAX_RETRIES:-2}"
   local coderabbit_rate_limit_wait="${CODERABBIT_RATE_LIMIT_WAIT:-180}"
+  if ! [[ "$coderabbit_rate_limit_max_retries" =~ ^[0-9]+$ ]]; then
+    echo "WARN: CODERABBIT_RATE_LIMIT_MAX_RETRIES must be a non-negative integer; defaulting to 2" >&2
+    coderabbit_rate_limit_max_retries=2
+  fi
+  if ! [[ "$coderabbit_rate_limit_wait" =~ ^[0-9]+$ ]] || [ "$coderabbit_rate_limit_wait" -le 0 ]; then
+    echo "WARN: CODERABBIT_RATE_LIMIT_WAIT must be a positive integer; defaulting to 180" >&2
+    coderabbit_rate_limit_wait=180
+  fi
 
   while :; do
     # Check for any CodeRabbit review submitted after the HEAD commit

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -931,7 +931,8 @@ run_coderabbit_review() {
     # Also check for CodeRabbit issue comments (summary comment) as activity signal.
     # Filter by since_iso so historical comments from prior pushes do not incorrectly
     # mark this HEAD cycle as having activity (which would suppress stale-findings recovery).
-    # Exclude "Reviews paused" comments as they are not an actual review; they are a pause marker.
+    # Exclude "Reviews paused" comments (pause marker) and "rate limit" comments (rate-limit
+    # marker) — neither represents a completed review and must not suppress rate-limit handling.
     if [ "$coderabbit_any_activity" -eq 0 ]; then
       local activity_count
       activity_count="$(
@@ -940,7 +941,8 @@ run_coderabbit_review() {
               [.[] | select(
                   .user.login == $bot and
                   .created_at > $since and
-                  ((.body // "") | test("Reviews paused|review paused"; "i") | not)
+                  ((.body // "") | test("Reviews paused|review paused"; "i") | not) and
+                  ((.body // "") | test("rate.?limit"; "i") | not)
               )] | length
             '
       )"


### PR DESCRIPTION
## Summary

- Adds rate-limit detection in `pr-review-loop.sh` `run_coderabbit_review`: when CodeRabbit posts a comment containing "rate limit" text (common when 3+ PRs are created within seconds in a parallel batch), the script waits 3 minutes and retries with `@coderabbitai review` (up to 2 retries)
- Retry count and wait time are configurable via `CODERABBIT_RATE_LIMIT_MAX_RETRIES` (default: 2) and `CODERABBIT_RATE_LIMIT_WAIT` (default: 180 seconds)
- After each retry, `since_iso` and `elapsed` are reset so the polling loop correctly picks up the fresh review
- Adds Step 3.7 to `90-batch-orchestrate-work-protocol.md` documenting CodeRabbit rate-limit behavior in parallel batches and fallback guidance for human reviewers

Fixes #151

## Test plan

- [ ] Verify `pr-review-loop.sh` syntax is valid (`bash -n scripts/development-workflow/pr-review-loop.sh`)
- [ ] Confirm rate-limit detection block appears after the "Reviews paused" block and before the timeout check in `run_coderabbit_review`
- [ ] Confirm Step 3.7 in protocol 90 is logically placed and describes the auto-retry and human fallback correctly
- [ ] Confirm CHANGELOG entry is present under `[Unreleased] > Fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic detection and retry mechanism for rate-limited review requests, with configurable wait times and maximum retry attempts.
  * Reviews automatically marked as skipped when retries are exhausted, with clear guidance for manual review triggering.

* **Documentation**
  * Enhanced documentation on rate-limit handling during parallel batch operations, including fallback recovery procedures and human reviewer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->