### PR TITLE
docs(plan): Opus 4.7 upgrade — implementation plan (#160)

### DIFF
--- a/docs/specs/developments/20260416000000_opus-4-7-upgrade/2_opus-4-7-upgrade_implementation-plan.md
+++ b/docs/specs/developments/20260416000000_opus-4-7-upgrade/2_opus-4-7-upgrade_implementation-plan.md
@@ -1,0 +1,77 @@
+# Opus 4.7 Upgrade — Implementation Plan
+
+**Spec**: N/A (Refactor — see GitHub issue #160)
+**Smoke test runbook**: [`docs/testing/workflow/opus-4-7-upgrade.smoke-test.md`](../../../testing/workflow/opus-4-7-upgrade.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Replace all `claude-opus-4-6` model ID references (and the stale `claude-opus-4-5-20251101` example) with `claude-opus-4-7` across agent configuration files and documentation. No logic changes — this is a purely mechanical find-and-replace across two files in the main repo: `.claude/agents/tech-lead.md` and `docs/ai/development-workflow/agent-model-config.md`. Sonnet and Haiku references are intentionally left untouched.
+
+**Estimated complexity**: S
+
+**Rationale**: Two files, two to three line changes. No schema, no code, no test changes required.
+
+**Dependencies**: None
+
+---
+
+## Layer-by-Layer Changes
+
+### Infrastructure / Configuration
+
+- [ ] `.claude/agents/tech-lead.md` — change `model: claude-opus-4-6` to `model: claude-opus-4-7` (front-matter field, line 3)
+- [ ] `docs/ai/development-workflow/agent-model-config.md` — update the in-session override example (currently `claude-opus-4-5-20251101`) to `claude-opus-4-7`
+- [ ] `docs/ai/development-workflow/agent-model-config.md` — update the permanent-change example (currently `claude-opus-4-6`) to `claude-opus-4-7`
+
+---
+
+## Testing Strategy
+
+**Test types**: Manual / Smoke
+
+**Key scenarios to test**:
+1. Confirm `grep -r "claude-opus-4-6" .claude/ .cursor/ .codex/ docs/ai/` returns no matches — maps to success criterion 1
+2. Confirm `grep -r "claude-opus-4-5" .claude/ .cursor/ .codex/ docs/ai/` returns no matches — maps to success criterion 1
+3. Confirm `.claude/agents/tech-lead.md` front-matter has `model: claude-opus-4-7` — maps to success criterion 1
+4. Confirm `docs/ai/development-workflow/agent-model-config.md` examples reference `claude-opus-4-7` — maps to success criterion 2
+5. Confirm CHANGELOG has an entry under `[Unreleased]` — maps to success criterion 3
+
+**Smoke test runbook**: [`docs/testing/workflow/opus-4-7-upgrade.smoke-test.md`](../../../testing/workflow/opus-4-7-upgrade.smoke-test.md)
+
+**Regression suite**: No automated regression suite exists for agent config files.
+
+---
+
+## Seed Data
+
+None — this change involves only documentation and configuration files, with no runtime data requirements.
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/ai/development-workflow/agent-model-config.md` — update the two Opus example model IDs (this is also a documentation file and is the primary change for this item)
+
+No other project docs in `docs/project/`, `AGENTS.md`, or `docs/best-practices/` require updates. The change is a version bump in the agent config documentation itself; the tier names and rationale are unchanged.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Accidentally bumping Sonnet or Haiku references | Low | Low | Targeted search before and after for `claude-opus` only; verify Sonnet/Haiku lines are unchanged |
+| Stale worktrees contain old references | Low | None | Worktrees are transient; only the tracked repo files matter |
+
+---
+
+## Implementation Order
+
+1. In the worktree's `.claude/agents/tech-lead.md`, change `model: claude-opus-4-6` to `model: claude-opus-4-7`
+2. In the worktree's `docs/ai/development-workflow/agent-model-config.md`, update the in-session override example from `claude-opus-4-5-20251101` to `claude-opus-4-7`
+3. In the worktree's `docs/ai/development-workflow/agent-model-config.md`, update the permanent-change example from `claude-opus-4-6` to `claude-opus-4-7`
+4. Run `grep -r "claude-opus-4-6\|claude-opus-4-5" .claude/agents/ .cursor/ .codex/ docs/ai/` to confirm zero remaining matches in tracked files (excluding worktree paths)
+5. Add CHANGELOG entry under `[Unreleased]`
+6. Commit: `refactor(agent-config): upgrade Opus model references from 4.6 to 4.7`

--- a/docs/specs/developments/20260416000000_opus-4-7-upgrade/2_opus-4-7-upgrade_implementation-plan.md
+++ b/docs/specs/developments/20260416000000_opus-4-7-upgrade/2_opus-4-7-upgrade_implementation-plan.md
@@ -53,8 +53,9 @@ None — this change involves only documentation and configuration files, with n
 ## Documentation Updates
 
 - [ ] `docs/ai/development-workflow/agent-model-config.md` — update the two Opus example model IDs (this is also a documentation file and is the primary change for this item)
+- [ ] `CHANGELOG.md` — add a `Changed` entry under `[Unreleased]` for the Opus 4.6 → 4.7 model reference upgrade
 
-No other project docs in `docs/project/`, `AGENTS.md`, or `docs/best-practices/` require updates. The change is a version bump in the agent config documentation itself; the tier names and rationale are unchanged.
+No other project docs in `docs/project/`, `AGENTS.md`, or `docs/best-practices/` require updates. The tier names and rationale are unchanged.
 
 ---
 
@@ -72,6 +73,6 @@ No other project docs in `docs/project/`, `AGENTS.md`, or `docs/best-practices/`
 1. In the worktree's `.claude/agents/tech-lead.md`, change `model: claude-opus-4-6` to `model: claude-opus-4-7`
 2. In the worktree's `docs/ai/development-workflow/agent-model-config.md`, update the in-session override example from `claude-opus-4-5-20251101` to `claude-opus-4-7`
 3. In the worktree's `docs/ai/development-workflow/agent-model-config.md`, update the permanent-change example from `claude-opus-4-6` to `claude-opus-4-7`
-4. Run `grep -r "claude-opus-4-6\|claude-opus-4-5" .claude/agents/ .cursor/ .codex/ docs/ai/` to confirm zero remaining matches in tracked files (excluding worktree paths)
+4. Run `grep -r "claude-opus-4-6\|claude-opus-4-5" .claude/ .cursor/ .codex/ docs/ai/` to confirm zero remaining matches in tracked files (excluding worktree paths)
 5. Add CHANGELOG entry under `[Unreleased]`
 6. Commit: `refactor(agent-config): upgrade Opus model references from 4.6 to 4.7`

--- a/docs/testing/workflow/opus-4-7-upgrade.smoke-test.md
+++ b/docs/testing/workflow/opus-4-7-upgrade.smoke-test.md
@@ -11,7 +11,7 @@
 
 Before running this smoke test:
 
-- [ ] Working tree is on the `refactor/160-opus-4-7-upgrade` branch (or reviewing the merged PR)
+- [ ] Working tree is on the `implementation-plan/160-opus-4-7-upgrade` branch (or reviewing the merged PR)
 - [ ] No worktree-local files are being checked (worktrees are transient and irrelevant)
 
 ---
@@ -33,8 +33,8 @@ Before running this smoke test:
 Run from the repo root:
 
 ```bash
-grep -r "claude-opus-4-6" .claude/agents/ .cursor/ .codex/ docs/ai/
-grep -r "claude-opus-4-5" .claude/agents/ .cursor/ .codex/ docs/ai/
+grep -r "claude-opus-4-6" .claude/ .cursor/ .codex/ docs/ai/
+grep -r "claude-opus-4-5" .claude/ .cursor/ .codex/ docs/ai/
 ```
 
 **Expected result**: Both commands return no output (zero matches).
@@ -75,8 +75,8 @@ grep -r "claude-sonnet\|claude-haiku" .claude/agents/ docs/ai/development-workfl
 
 ## Assertions Checklist
 
-- [ ] `grep -r "claude-opus-4-6" .claude/agents/ .cursor/ .codex/ docs/ai/` returns no matches
-- [ ] `grep -r "claude-opus-4-5" .claude/agents/ .cursor/ .codex/ docs/ai/` returns no matches
+- [ ] `grep -r "claude-opus-4-6" .claude/ .cursor/ .codex/ docs/ai/` returns no matches
+- [ ] `grep -r "claude-opus-4-5" .claude/ .cursor/ .codex/ docs/ai/` returns no matches
 - [ ] `.claude/agents/tech-lead.md` front-matter has `model: claude-opus-4-7`
 - [ ] `docs/ai/development-workflow/agent-model-config.md` examples use `claude-opus-4-7`
 - [ ] CHANGELOG `[Unreleased]` section has a `Changed` entry for this upgrade

--- a/docs/testing/workflow/opus-4-7-upgrade.smoke-test.md
+++ b/docs/testing/workflow/opus-4-7-upgrade.smoke-test.md
@@ -1,0 +1,104 @@
+# Smoke Test Runbook: Opus 4.7 Upgrade
+
+**Feature**: Upgrade workflow agents from Opus 4.6 to Opus 4.7 (GitHub issue #160)
+**Spec**: N/A (Refactor)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] Working tree is on the `refactor/160-opus-4-7-upgrade` branch (or reviewing the merged PR)
+- [ ] No worktree-local files are being checked (worktrees are transient and irrelevant)
+
+---
+
+## Test Data
+
+| Item | Value |
+|---|---|
+| Files to check | `.claude/agents/tech-lead.md`, `docs/ai/development-workflow/agent-model-config.md` |
+| Old Opus model IDs | `claude-opus-4-6`, `claude-opus-4-5-20251101` |
+| New Opus model ID | `claude-opus-4-7` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify no stale Opus 4.6 or 4.5 references in tracked agent files
+
+Run from the repo root:
+
+```bash
+grep -r "claude-opus-4-6" .claude/agents/ .cursor/ .codex/ docs/ai/
+grep -r "claude-opus-4-5" .claude/agents/ .cursor/ .codex/ docs/ai/
+```
+
+**Expected result**: Both commands return no output (zero matches).
+
+### Step 2: Verify tech-lead agent front-matter
+
+```bash
+head -5 .claude/agents/tech-lead.md
+```
+
+**Expected result**: Line 3 reads `model: claude-opus-4-7`.
+
+### Step 3: Verify agent-model-config examples
+
+```bash
+grep "claude-opus" docs/ai/development-workflow/agent-model-config.md
+```
+
+**Expected result**: All `claude-opus` references in the file use `claude-opus-4-7`. No `claude-opus-4-6` or `claude-opus-4-5` present.
+
+### Step 4: Verify CHANGELOG entry
+
+```bash
+grep -A 3 "\[Unreleased\]" CHANGELOG.md | head -20
+```
+
+**Expected result**: The `[Unreleased]` section contains a `Changed` entry mentioning the Opus 4.6 → 4.7 bump.
+
+### Step 5: Verify Sonnet and Haiku references are untouched
+
+```bash
+grep -r "claude-sonnet\|claude-haiku" .claude/agents/ docs/ai/development-workflow/agent-model-config.md
+```
+
+**Expected result**: Sonnet and Haiku lines are present and unchanged (no accidental version bumps).
+
+---
+
+## Assertions Checklist
+
+- [ ] `grep -r "claude-opus-4-6" .claude/agents/ .cursor/ .codex/ docs/ai/` returns no matches
+- [ ] `grep -r "claude-opus-4-5" .claude/agents/ .cursor/ .codex/ docs/ai/` returns no matches
+- [ ] `.claude/agents/tech-lead.md` front-matter has `model: claude-opus-4-7`
+- [ ] `docs/ai/development-workflow/agent-model-config.md` examples use `claude-opus-4-7`
+- [ ] CHANGELOG `[Unreleased]` section has a `Changed` entry for this upgrade
+- [ ] Sonnet and Haiku references are unchanged
+
+---
+
+## Seed Data Reference
+
+None required.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| grep still returns hits in `.claude/agents/` | Edit was not saved or committed | Re-apply the change and verify with `git diff` |
+| grep returns hits in `.claude/worktrees/` | Transient worktree directories | Exclude `.claude/worktrees/` from the search; worktrees are not tracked |
+
+---
+
+## Known Limitations
+
+- Worktrees under `.claude/worktrees/` contain copies of the old config files for other open items. These are intentionally excluded from the success criteria — only tracked repository files matter.


### PR DESCRIPTION
## Summary

Implementation plan and smoke test runbook for refactoring all Opus 4.6 model ID references to Opus 4.7.

**Approach**: Purely mechanical find-and-replace in two files:
- `.claude/agents/tech-lead.md` — bump `model: claude-opus-4-6` → `model: claude-opus-4-7`
- `docs/ai/development-workflow/agent-model-config.md` — update the two Opus example model IDs (`claude-opus-4-5-20251101` and `claude-opus-4-6` → `claude-opus-4-7`)

Sonnet 4.6 and Haiku 4.5 are intentionally untouched.

**Complexity**: S (< 1 day)

**Risks**: None — no logic changes, no schema changes.

## Artifacts

- Plan: `docs/specs/developments/20260416000000_opus-4-7-upgrade/2_opus-4-7-upgrade_implementation-plan.md`
- Smoke test: `docs/testing/workflow/opus-4-7-upgrade.smoke-test.md`

## Tracker

Closes #160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added implementation plan for Opus 4.7 upgrade process.
  * Added smoke test runbook with validation steps for the upgrade workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->