### PR TITLE
docs(plan): protocol-90 tracker status update before dispatch

### DIFF
--- a/docs/specs/developments/20260416154733_protocol-90-tracker-status-update/2_protocol-90-tracker-status-update_implementation-plan.md
+++ b/docs/specs/developments/20260416154733_protocol-90-tracker-status-update/2_protocol-90-tracker-status-update_implementation-plan.md
@@ -1,0 +1,91 @@
+# Protocol-90 Tracker Status Update Before Dispatch — Implementation Plan
+
+**Spec**: N/A (Refactor — see [GitHub issue #159](https://github.com/lhpaul/ai-dev-framework-template/issues/159))
+**Smoke test runbook**: [`docs/testing/workflow/protocol-90-tracker-status-update.smoke-test.md`](../../../../testing/workflow/protocol-90-tracker-status-update.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Insert a new "Pre-Dispatch Tracker Status Update" step into Protocol 90 (between the current Step 2 "Determine Eligibility" and Step 3 "Build Parallel Batches") that explicitly requires the Portfolio Orchestrator to (a) add each eligible item to the configured project board if it is not already present and (b) update each item's tracker status to the appropriate in-flight stage before dispatching Work Item Runners. Additionally, add a matching note to Protocol 91 clarifying that the Work Item Runner owns status transitions for single-item dispatch when the item is still in a stale pre-dispatch state.
+
+**Estimated complexity**: S
+
+**Rationale**: The change is documentation-only (two Markdown protocol files). No code, scripts, templates, or other files are modified. The scope is narrow and the desired behavior is already well-understood from the Batch 3 retro analysis.
+
+**Dependencies**: None
+
+---
+
+## Layer-by-Layer Changes
+
+### Infrastructure / Configuration
+
+Not applicable — this is a doc-only change.
+
+### Workflow Protocol Documentation
+
+- [ ] `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` — Add new **Step 2.5: Pre-Dispatch Tracker Status Update** section between existing Step 2 and Step 3. This step must:
+  - Enumerate every item that passed the Step 2 eligibility check
+  - For each item, check whether it already exists in the configured project board; add it if missing
+  - For each item, update its tracker status to the appropriate in-flight value based on the next action that will be dispatched:
+    | Next action | Status to set |
+    |---|---|
+    | Write Spec | `Writing Spec` |
+    | Write Plan | `Writing Plan` |
+    | Implement | `In Development` |
+    | Resume in-progress stage (Writing Spec, Writing Plan, In Development already set) | No change needed — skip |
+  - Log each update (added to board / status changed / already correct) for transparency
+  - Only after all updates complete, proceed to Step 3
+
+- [ ] `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` — Add a short note in **Step 2: Determine the Next Deterministic Action** (under "What can advance now?") to clarify that when the Work Item Runner is invoked directly (not via Protocol 90) and the item's tracker status is stale (e.g., still `Backlog` when the Refactor type dictates `Writing Plan`), the runner must update the status before dispatching the creator agent — mirroring Protocol 90's new Step 2.5. Reference the same status-transition table. This covers the single-item dispatch path (issue #159 explicitly calls for Protocol 91 to be updated as well).
+
+---
+
+## Testing Strategy
+
+**Test types**: Manual / Smoke
+
+**Key scenarios to test**:
+1. Portfolio Orchestrator runs against items in Backlog with no project board entry — items are added to the board and set to the correct in-flight status before any Work Item Runner is dispatched
+2. Portfolio Orchestrator runs against items already in the correct in-flight status — no spurious status changes occur (idempotent)
+3. Work Item Runner invoked directly for a single Refactor item that is still `Backlog` — runner sets status to `Writing Plan` before proceeding
+
+**Smoke test runbook**: [`docs/testing/workflow/protocol-90-tracker-status-update.smoke-test.md`](../../../../testing/workflow/protocol-90-tracker-status-update.smoke-test.md)
+
+**Regression suite**: Not applicable — no automated regression suite configured in this repository.
+
+---
+
+## Seed Data
+
+Not applicable — this is a protocol documentation change; no seed data is required.
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` — Primary change: add Step 2.5 as described above
+- [ ] `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` — Secondary change: add pre-dispatch status note to Step 2
+
+No other project docs require updating. The change does not affect architecture, best practices, repo structure, AGENTS.md, or other files.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Step numbering conflict with existing protocol cross-references | Low | Low | Introduce the new step as "Step 2.5" (a sub-step after Step 2) to avoid renumbering existing Step 3 through Step 6 which are referenced in Protocol 91 and elsewhere |
+| New step adds overhead to orchestrator runs when the tracker is unavailable | Low | Low | Step 2.5 should follow the same "warn and fall back" pattern established in Steps 1a–1c: if the tracker API is unreachable, log a warning and proceed without blocking the batch |
+| Duplicate status updates from Protocol 91 when Protocol 90 already ran | Low | Low | Both protocols use idempotent `gh` GraphQL mutations; updating an already-correct status is a no-op |
+
+---
+
+## Implementation Order
+
+1. Edit `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`: insert new Step 2.5 section after the existing Step 2 content, before the Step 3 heading
+2. Edit `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`: add pre-dispatch tracker status note to Step 2 ("What can advance now?" table or its prose)
+3. Update `CHANGELOG.md` with an entry under `[Unreleased]` for this protocol improvement
+4. Verify smoke test runbook scenarios manually against the updated protocol text
+5. Update project docs per **Documentation Updates** section above (both files are the target, so this step is already covered by steps 1–2)

--- a/docs/testing/workflow/protocol-90-tracker-status-update.smoke-test.md
+++ b/docs/testing/workflow/protocol-90-tracker-status-update.smoke-test.md
@@ -1,0 +1,121 @@
+# Smoke Test Runbook: Protocol-90 Tracker Status Update Before Dispatch
+
+**Feature**: Protocol 90 — Pre-dispatch tracker status update (issue #159)
+**Spec**: N/A (Refactor — see [GitHub issue #159](https://github.com/lhpaul/ai-dev-framework-template/issues/159))
+**Implementation plan**: [`docs/specs/developments/20260416154733_protocol-90-tracker-status-update/2_protocol-90-tracker-status-update_implementation-plan.md`](../../specs/developments/20260416154733_protocol-90-tracker-status-update/2_protocol-90-tracker-status-update_implementation-plan.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] `gh` CLI is authenticated with `project` and `repo` scopes
+- [ ] The repository's GitHub Projects board is accessible
+- [ ] The updated protocol files (`90-batch-orchestrate-work-protocol.md` and `91-orchestrate-work-protocol.md`) are merged and in the branch under test
+- [ ] At least one GitHub issue exists in `Backlog` status with no project board entry (for Scenario 1)
+- [ ] At least one GitHub issue exists already in `Writing Spec` or `Writing Plan` status on the board (for Scenario 2)
+
+---
+
+## Test Data
+
+| Item | Value |
+|---|---|
+| Test Backlog issue (not on board) | A fresh GitHub issue with Status = Backlog, not added to the project board |
+| Test in-progress issue | A GitHub issue already on the board with Status = Writing Spec or Writing Plan |
+| Project number | Obtain via `gh project list --owner <OWNER>` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify new Step 2.5 exists in Protocol 90
+
+- Open `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
+- Confirm a **Step 2.5: Pre-Dispatch Tracker Status Update** (or equivalent heading) appears between Step 2 and Step 3
+- Confirm it documents:
+  - Adding missing items to the project board
+  - Setting the appropriate in-flight status before dispatch
+  - A status-transition table covering `Writing Spec`, `Writing Plan`, and `In Development`
+  - Idempotent behavior for items already in the correct status
+  - Fallback warning when the tracker is unavailable
+
+**Expected result**: The section is present with all required content; existing step numbering (Steps 3–6) is unchanged.
+
+### Step 2: Verify Protocol 91 pre-dispatch note
+
+- Open `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`
+- Navigate to **Step 2: Determine the Next Deterministic Action**
+- Confirm a note or row exists instructing the Work Item Runner to update tracker status before dispatching a creator agent when the item's current status is stale (e.g., still `Backlog` for a Refactor item)
+
+**Expected result**: The note is present and references the same status-transition logic as Protocol 90 Step 2.5.
+
+### Step 3: Scenario 1 — Backlog item not on board
+
+**Maps to**: Acceptance Criterion: items added to board and status updated before dispatch
+
+1. Simulate a Portfolio Orchestrator run against the test Backlog issue (read the updated protocol and verify the Step 2.5 instructions would cause the item to be added to the board and set to `Writing Spec` or `Writing Plan` before Work Item Runner dispatch)
+2. If the orchestrator supports dry-run or step-by-step: confirm Step 2.5 fires before Step 3 (batch building)
+3. Alternatively, trace the protocol by hand: confirm the new step explicitly mentions adding missing items and setting status
+
+**Expected result**: Protocol text unambiguously requires the board addition and status update to complete before Work Item Runners are dispatched.
+
+### Step 4: Scenario 2 — Item already in correct in-flight status
+
+**Maps to**: Acceptance Criterion: idempotent behavior for already-updated items
+
+1. Review the Step 2.5 text for an explicit "skip if already correct" condition
+2. Confirm the step does not reset or change a status that is already `Writing Spec`, `Writing Plan`, or `In Development`
+
+**Expected result**: The protocol includes an idempotency guard — no redundant status update when the item is already in the correct in-flight state.
+
+### Step 5: Scenario 3 — Single-item dispatch via Protocol 91
+
+**Maps to**: Acceptance Criterion: Protocol 91 mirrors the pre-dispatch status update for single-item runs
+
+1. Review the updated Protocol 91 Step 2 note
+2. Confirm that a Work Item Runner started for a Refactor item in `Backlog` status would set `Writing Plan` before calling the plan-writing stage
+
+**Expected result**: The Protocol 91 update is present and consistent with the Protocol 90 Step 2.5 table.
+
+### Last Step: Assertions Checklist
+
+- Verify all assertions below are met before closing
+
+---
+
+## Assertions Checklist
+
+- [ ] Protocol 90 contains a new pre-dispatch tracker status update step between Step 2 and Step 3
+- [ ] The new step requires adding missing items to the project board
+- [ ] The new step requires setting the appropriate in-flight status (Writing Spec / Writing Plan / In Development) before dispatch
+- [ ] The new step is idempotent — no change when status is already correct
+- [ ] The new step follows the tracker-unavailable fallback pattern (warn and proceed)
+- [ ] Protocol 91 Step 2 contains a matching note for single-item dispatch
+- [ ] No existing step numbers (3–6) in Protocol 90 were changed
+- [ ] CHANGELOG.md has an `[Unreleased]` entry for this change
+
+---
+
+## Seed Data Reference
+
+Not applicable — this smoke test validates protocol documentation only; no seed data is required.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Step 2.5 heading not found in Protocol 90 | Implementation not yet merged | Confirm the `refactor/159-protocol-90-tracker-status-update` branch is merged into the branch under test |
+| Protocol 91 note missing | Step 2 of Protocol 91 not updated during implementation | Re-read issue #159 scope and apply the missing edit |
+| Step numbering in Protocol 90 changed | Editor renumbered steps | Restore original step numbers (3–6) and use "2.5" for the new step |
+
+---
+
+## Known Limitations
+
+- This runbook validates protocol text only — it does not execute an actual orchestrator run against a live GitHub project. Full behavioral validation requires a live orchestrator run with a real GitHub project board.


### PR DESCRIPTION
## Summary

Implementation plan for [issue #159](https://github.com/lhpaul/ai-dev-framework-template/issues/159): add an explicit pre-dispatch tracker status update step to Protocol 90 (and a matching note to Protocol 91).

**Approach**: Insert a new Step 2.5 in Protocol 90 between eligibility determination (Step 2) and batch building (Step 3) that requires the Portfolio Orchestrator to add missing items to the project board and set each item's tracker status to the appropriate in-flight stage before dispatching Work Item Runners. Add a corresponding note to Protocol 91 Step 2 for single-item dispatch.

**Complexity**: S (doc-only change, two protocol Markdown files)

**Key risks**: None material — inserting Step 2.5 avoids renumbering existing steps and is consistent with the tracker-unavailable fallback pattern already in the protocol.

## Files

- `docs/specs/developments/20260416154733_protocol-90-tracker-status-update/2_protocol-90-tracker-status-update_implementation-plan.md`
- `docs/testing/workflow/protocol-90-tracker-status-update.smoke-test.md`

## Source

Retrospective analysis of Batch 3 orchestration (2026-04-16) — items #112, #126, #149–#152 were dispatched without updating tracker status from Backlog.