### PR TITLE
chore(agent-config): upgrade workflow agents from Opus 4.6 to Opus 4.7

### DIFF
--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -1,6 +1,6 @@
 ---
 name: tech-lead
-model: claude-opus-4-6
+model: claude-opus-4-7
 description: Plan Ready stage. Use when an implementation plan needs to be written. For Full Pipeline items, a spec must be approved first. For Refactor items, the work item brief replaces the spec. Reads the codebase, resolves technical approach questions, then writes the implementation plan, runs its reviewer gate, and resolves PR readiness.
 tools: Read, Grep, Glob, Write, Edit, Bash
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AI Workflow: `93-automated-reviewer-loop-protocol.md` — added mandatory cross-reference check requiring agents to grep edited files for stale references before committing fixes; links to the existing re-read verification section for post-commit confirmation.
 - AI Workflow: `implementation-plan-template.md` — added a "Code Samples" section with guidance to mark code samples as illustrative and to ensure all cross-section references are consistent before marking the plan ready.
+- **Workflow agent model bump to Opus 4.7**: updated `.claude/agents/tech-lead.md` (`model: claude-opus-4-6` → `model: claude-opus-4-7`) and refreshed the two Opus model-ID examples in `docs/ai/development-workflow/agent-model-config.md` (in-session override example `claude-opus-4-5-20251101` → `claude-opus-4-7`; Cursor permanent-change example `claude-opus-4-6` → `claude-opus-4-7`). Sonnet 4.6 and Haiku 4.5 remain unchanged — only Opus had a newer latest model to pick up. No tier reassignments, no tool restriction changes (issue #160).
 
 ### Fixed
 

--- a/docs/ai/development-workflow/agent-model-config.md
+++ b/docs/ai/development-workflow/agent-model-config.md
@@ -80,7 +80,7 @@ Use your runner’s “one-off model override” mechanism.
 Claude Code example (if applicable):
 
 ```bash
-claude --agent developer --model claude-opus-4-5-20251101
+claude --agent developer --model claude-opus-4-7
 ```
 
 **Cursor:**
@@ -101,7 +101,7 @@ This affects all future invocations until changed back.
 
 - `fast`: Uses Cursor's fast model (recommended for economy-tier agents)
 - `inherit`: Uses the current Composer model (recommended for balanced/premium-tier agents)
-- Specific model ID: Uses that exact model (e.g., `claude-opus-4-6`, `gpt-4-turbo`)
+- Specific model ID: Uses that exact model (e.g., `claude-opus-4-7`, `gpt-4-turbo`)
 
 **Precedence**: When multiple agent locations exist (`.cursor/agents/`, `.claude/agents/`, `.codex/agents/`), Cursor uses `.cursor/agents/` first, then `.claude/agents/`, then `.codex/agents/`.
 


### PR DESCRIPTION
## Summary

- Bumps the Opus references used by workflow agents from `claude-opus-4-6` to `claude-opus-4-7` so the current latest Opus is used.
- Refreshes the two Opus model-ID examples in `docs/ai/development-workflow/agent-model-config.md` (in-session override example and Cursor permanent-change example).
- Sonnet 4.6 and Haiku 4.5 intentionally left unchanged; only Opus had a newer latest model ID to pick up. No tier reassignments, no tool restriction changes.

## Files changed

- `.claude/agents/tech-lead.md` — `model: claude-opus-4-6` → `model: claude-opus-4-7`
- `docs/ai/development-workflow/agent-model-config.md`
  - in-session override example: `claude-opus-4-5-20251101` → `claude-opus-4-7`
  - Cursor permanent-change example: `claude-opus-4-6` → `claude-opus-4-7`
- `CHANGELOG.md` — `[Unreleased]` Changed entry

## Test plan

- [ ] `grep -r "claude-opus-4-6" .claude/ .cursor/ .codex/ docs/ai/` returns no matches in scope
- [ ] `grep -r "claude-opus-4-5" .claude/ .cursor/ .codex/ docs/ai/` returns no matches in scope
- [ ] Workflow agents invoked after merge run on Opus 4.7

Closes #160