### PR TITLE
docs(plan): remove boilerplate 'Guiding principle' section from spec template

### DIFF
--- a/docs/specs/developments/20260416200000_165-remove-guiding-principle-from-spec-template/2_165-remove-guiding-principle-from-spec-template_implementation-plan.md
+++ b/docs/specs/developments/20260416200000_165-remove-guiding-principle-from-spec-template/2_165-remove-guiding-principle-from-spec-template_implementation-plan.md
@@ -26,6 +26,9 @@
 - [ ] Remove the "Guiding principle (important)" section from `docs/specs/developments/20260414184900_batch-merge/1_batch-merge_specs.md`.
 - [ ] Remove the "Guiding principle (important)" section from `docs/specs/developments/20260416120000_136-shellcheck-workflow-scripts/1_136-shellcheck-workflow-scripts_specs.md`.
 - [ ] Remove the "Guiding principle (important)" section from `docs/specs/developments/20260416120000_agent-timeout-handling/1_agent-timeout-handling_specs.md`.
+- [ ] Remove the "Guiding principle (important)" section from `docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/1_batch-merge-ff-pull-retry_specs.md`.
+- [ ] Remove the "Guiding principle (important)" section from `docs/specs/developments/20260416120000_coderabbit-success-fallback/1_coderabbit-success-fallback_specs.md`.
+- [ ] Remove the "Guiding principle (important)" section from `docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/1_173-markdown-lint-plan-spec-docs_specs.md`.
 - [ ] Confirm (read-only verification, no edit needed) that `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md` already contains equivalent product-focused authoring guidance under the "Product-first boundary (critical)" section.
 - [ ] Confirm (read-only verification, no edit needed) that `REVIEW.md` spec checklist checks implementation-detail cleanliness on substance, not on the presence of a named section.
 
@@ -43,7 +46,7 @@ _(No changes required)_
 1. Open `spec-template.md` and verify the "Guiding principle (important)" section is absent — maps to Acceptance Criterion 1.
 2. Open `01-generate-spec-protocol.md` and verify the product-focused authoring guidance is present — maps to Acceptance Criterion 2.
 3. Open `REVIEW.md` and verify the spec checklist enforces implementation-detail cleanliness, not the presence of a boilerplate section — maps to Acceptance Criterion 3.
-4. Open each of the 4 existing spec files and verify the "Guiding principle (important)" section has been removed — maps to Acceptance Criterion 4.
+4. Open each of the 7 existing spec files and verify the "Guiding principle (important)" section has been removed — maps to Acceptance Criterion 4 (and its business rule extension to all merged spec files).
 
 **Smoke test runbook**: [`docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md`](../../../../testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md)
 
@@ -75,11 +78,14 @@ None — all file changes in this plan (the spec template and the 4 existing spe
 ## Implementation Order
 
 1. Read `docs/ai/development-workflow/templates/spec-template.md` — locate and delete the "Guiding principle (important)" section (the `## Guiding principle (important)` heading and its 4-line body, including the surrounding blank lines).
-2. Repeat the same deletion for the 4 existing spec files:
+2. Repeat the same deletion for all 7 existing spec files that contain the section (run `grep -rn "Guiding principle" docs/specs/developments/ --include="*.md"` first to confirm the complete list):
    a. `docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md`
    b. `docs/specs/developments/20260414184900_batch-merge/1_batch-merge_specs.md`
    c. `docs/specs/developments/20260416120000_136-shellcheck-workflow-scripts/1_136-shellcheck-workflow-scripts_specs.md`
    d. `docs/specs/developments/20260416120000_agent-timeout-handling/1_agent-timeout-handling_specs.md`
+   e. `docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/1_batch-merge-ff-pull-retry_specs.md`
+   f. `docs/specs/developments/20260416120000_coderabbit-success-fallback/1_coderabbit-success-fallback_specs.md`
+   g. `docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/1_173-markdown-lint-plan-spec-docs_specs.md`
 3. Verify `01-generate-spec-protocol.md` already has the product-focused boundary guidance (read-only check; no edits expected).
 4. Verify `REVIEW.md` spec checklist does not require the "Guiding principle" section (read-only check; no edits expected).
 5. Run the smoke test runbook manually to confirm all acceptance criteria pass.

--- a/docs/specs/developments/20260416200000_165-remove-guiding-principle-from-spec-template/2_165-remove-guiding-principle-from-spec-template_implementation-plan.md
+++ b/docs/specs/developments/20260416200000_165-remove-guiding-principle-from-spec-template/2_165-remove-guiding-principle-from-spec-template_implementation-plan.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-**Approach**: Remove the "Guiding principle (important)" section from the spec template and all 4 existing merged spec files that still contain it. Verify that the product-focused authoring guidance is already present (in equivalent form) in `01-generate-spec-protocol.md` — it is (the "Product-first boundary" section), so no additions are needed there. Confirm `REVIEW.md`'s spec checklist already checks implementation-detail cleanliness rather than the presence of a named boilerplate section — it does, so no changes are needed there.
+**Approach**: Remove the "Guiding principle (important)" section from the spec template and all 7 existing merged spec files that still contain it. Verify that the product-focused authoring guidance is already present (in equivalent form) in `01-generate-spec-protocol.md` — it is (the "Product-first boundary" section), so no additions are needed there. Confirm `REVIEW.md`'s spec checklist already checks implementation-detail cleanliness rather than the presence of a named boilerplate section — it does, so no changes are needed there.
 
 **Estimated complexity**: S
 <!-- S: < 1 day | M: 1-3 days | L: 3+ days -->
@@ -62,7 +62,7 @@ None — this feature affects documentation files only.
 
 ## Documentation Updates
 
-None — all file changes in this plan (the spec template and the 4 existing spec files) are the primary deliverable, not secondary documentation updates triggered by a code or config change. No additional project docs in `docs/project/`, `docs/best-practices/`, or `AGENTS.md` need updating as a result of this work.
+None — all file changes in this plan (the spec template and the 7 existing spec files) are the primary deliverable, not secondary documentation updates triggered by a code or config change. No additional project docs in `docs/project/`, `docs/best-practices/`, or `AGENTS.md` need updating as a result of this work.
 
 ---
 

--- a/docs/specs/developments/20260416200000_165-remove-guiding-principle-from-spec-template/2_165-remove-guiding-principle-from-spec-template_implementation-plan.md
+++ b/docs/specs/developments/20260416200000_165-remove-guiding-principle-from-spec-template/2_165-remove-guiding-principle-from-spec-template_implementation-plan.md
@@ -1,7 +1,7 @@
 # Remove Boilerplate 'Guiding Principle' Section from Spec Template — Implementation Plan
 
 **Spec**: [`1_165-remove-guiding-principle-from-spec-template_specs.md`](1_165-remove-guiding-principle-from-spec-template_specs.md)
-**Smoke test runbook**: [`docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md`](../../../../testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md)
+**Smoke test runbook**: [`docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md`](../../../testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md)
 
 ---
 
@@ -48,7 +48,7 @@ _(No changes required)_
 3. Open `REVIEW.md` and verify the spec checklist enforces implementation-detail cleanliness, not the presence of a boilerplate section — maps to Acceptance Criterion 3.
 4. Open each of the 7 existing spec files and verify the "Guiding principle (important)" section has been removed — maps to Acceptance Criterion 4 (and its business rule extension to all merged spec files).
 
-**Smoke test runbook**: [`docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md`](../../../../testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md)
+**Smoke test runbook**: [`docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md`](../../../testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md)
 
 **Regression suite**: No automated regression suite exists in this repository for documentation changes.
 

--- a/docs/specs/developments/20260416200000_165-remove-guiding-principle-from-spec-template/2_165-remove-guiding-principle-from-spec-template_implementation-plan.md
+++ b/docs/specs/developments/20260416200000_165-remove-guiding-principle-from-spec-template/2_165-remove-guiding-principle-from-spec-template_implementation-plan.md
@@ -59,9 +59,7 @@ None — this feature affects documentation files only.
 
 ## Documentation Updates
 
-- [ ] `docs/ai/development-workflow/templates/spec-template.md` — remove the "Guiding principle (important)" section (this is the primary deliverable, not a secondary doc update).
-
-All other doc changes in this plan are the primary deliverable (removing the boilerplate from existing spec files). No separate documentation updates are required beyond what is listed in the Layer-by-Layer Changes section above.
+None — all file changes in this plan (the spec template and the 4 existing spec files) are the primary deliverable, not secondary documentation updates triggered by a code or config change. No additional project docs in `docs/project/`, `docs/best-practices/`, or `AGENTS.md` need updating as a result of this work.
 
 ---
 
@@ -85,4 +83,4 @@ All other doc changes in this plan are the primary deliverable (removing the boi
 3. Verify `01-generate-spec-protocol.md` already has the product-focused boundary guidance (read-only check; no edits expected).
 4. Verify `REVIEW.md` spec checklist does not require the "Guiding principle" section (read-only check; no edits expected).
 5. Run the smoke test runbook manually to confirm all acceptance criteria pass.
-6. Update CHANGELOG under `[Unreleased]`.
+6. Update CHANGELOG under `[Unreleased]` in the implementation PR (plan-only PRs are exempt).

--- a/docs/specs/developments/20260416200000_165-remove-guiding-principle-from-spec-template/2_165-remove-guiding-principle-from-spec-template_implementation-plan.md
+++ b/docs/specs/developments/20260416200000_165-remove-guiding-principle-from-spec-template/2_165-remove-guiding-principle-from-spec-template_implementation-plan.md
@@ -1,0 +1,88 @@
+# Remove Boilerplate 'Guiding Principle' Section from Spec Template — Implementation Plan
+
+**Spec**: [`1_165-remove-guiding-principle-from-spec-template_specs.md`](1_165-remove-guiding-principle-from-spec-template_specs.md)
+**Smoke test runbook**: [`docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md`](../../../../testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Remove the "Guiding principle (important)" section from the spec template and all 4 existing merged spec files that still contain it. Verify that the product-focused authoring guidance is already present (in equivalent form) in `01-generate-spec-protocol.md` — it is (the "Product-first boundary" section), so no additions are needed there. Confirm `REVIEW.md`'s spec checklist already checks implementation-detail cleanliness rather than the presence of a named boilerplate section — it does, so no changes are needed there.
+
+**Estimated complexity**: S
+<!-- S: < 1 day | M: 1-3 days | L: 3+ days -->
+**Rationale**: All changes are mechanical find-and-delete operations on Markdown files. No code, no configuration, no tests, no schema changes. The guidance is already present in `01-generate-spec-protocol.md` and `REVIEW.md` requires no update.
+
+**Dependencies**: None
+
+---
+
+## Layer-by-Layer Changes
+
+### Documentation / Template Files
+
+- [ ] Remove the "Guiding principle (important)" section (lines 7–14 in the current template) from `docs/ai/development-workflow/templates/spec-template.md`.
+- [ ] Remove the "Guiding principle (important)" section from `docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md`.
+- [ ] Remove the "Guiding principle (important)" section from `docs/specs/developments/20260414184900_batch-merge/1_batch-merge_specs.md`.
+- [ ] Remove the "Guiding principle (important)" section from `docs/specs/developments/20260416120000_136-shellcheck-workflow-scripts/1_136-shellcheck-workflow-scripts_specs.md`.
+- [ ] Remove the "Guiding principle (important)" section from `docs/specs/developments/20260416120000_agent-timeout-handling/1_agent-timeout-handling_specs.md`.
+- [ ] Confirm (read-only verification, no edit needed) that `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md` already contains equivalent product-focused authoring guidance under the "Product-first boundary (critical)" section.
+- [ ] Confirm (read-only verification, no edit needed) that `REVIEW.md` spec checklist checks implementation-detail cleanliness on substance, not on the presence of a named section.
+
+### Infrastructure / Configuration
+
+_(No changes required)_
+
+---
+
+## Testing Strategy
+
+**Test types**: Manual / Smoke
+
+**Key scenarios to test**:
+1. Open `spec-template.md` and verify the "Guiding principle (important)" section is absent — maps to Acceptance Criterion 1.
+2. Open `01-generate-spec-protocol.md` and verify the product-focused authoring guidance is present — maps to Acceptance Criterion 2.
+3. Open `REVIEW.md` and verify the spec checklist enforces implementation-detail cleanliness, not the presence of a boilerplate section — maps to Acceptance Criterion 3.
+4. Open each of the 4 existing spec files and verify the "Guiding principle (important)" section has been removed — maps to Acceptance Criterion 4.
+
+**Smoke test runbook**: [`docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md`](../../../../testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md)
+
+**Regression suite**: No automated regression suite exists in this repository for documentation changes.
+
+---
+
+## Seed Data
+
+None — this feature affects documentation files only.
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/ai/development-workflow/templates/spec-template.md` — remove the "Guiding principle (important)" section (this is the primary deliverable, not a secondary doc update).
+
+All other doc changes in this plan are the primary deliverable (removing the boilerplate from existing spec files). No separate documentation updates are required beyond what is listed in the Layer-by-Layer Changes section above.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| A spec file lists content immediately after the "Guiding principle" section with no blank line separator, causing the wrong lines to be deleted | Low | Low | Read each file before editing; remove only the section header and its body bullets, verify surrounding content is intact |
+| A future spec author or agent re-adds the "Guiding principle" section because they are copying from a cached/stale template | Low | Low | The spec review gate in `REVIEW.md` does not require the section; automated reviewers will not flag its absence — adding it back would be neutral noise, not a broken workflow |
+
+---
+
+## Implementation Order
+
+1. Read `docs/ai/development-workflow/templates/spec-template.md` — locate and delete the "Guiding principle (important)" section (the `## Guiding principle (important)` heading and its 4-line body, including the surrounding blank lines).
+2. Repeat the same deletion for the 4 existing spec files:
+   a. `docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md`
+   b. `docs/specs/developments/20260414184900_batch-merge/1_batch-merge_specs.md`
+   c. `docs/specs/developments/20260416120000_136-shellcheck-workflow-scripts/1_136-shellcheck-workflow-scripts_specs.md`
+   d. `docs/specs/developments/20260416120000_agent-timeout-handling/1_agent-timeout-handling_specs.md`
+3. Verify `01-generate-spec-protocol.md` already has the product-focused boundary guidance (read-only check; no edits expected).
+4. Verify `REVIEW.md` spec checklist does not require the "Guiding principle" section (read-only check; no edits expected).
+5. Run the smoke test runbook manually to confirm all acceptance criteria pass.
+6. Update CHANGELOG under `[Unreleased]`.

--- a/docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md
+++ b/docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md
@@ -27,6 +27,9 @@ Before running this smoke test:
 | Batch merge spec | `docs/specs/developments/20260414184900_batch-merge/1_batch-merge_specs.md` |
 | Shellcheck spec | `docs/specs/developments/20260416120000_136-shellcheck-workflow-scripts/1_136-shellcheck-workflow-scripts_specs.md` |
 | Agent timeout spec | `docs/specs/developments/20260416120000_agent-timeout-handling/1_agent-timeout-handling_specs.md` |
+| Batch merge FF pull retry spec | `docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/1_batch-merge-ff-pull-retry_specs.md` |
+| CodeRabbit success fallback spec | `docs/specs/developments/20260416120000_coderabbit-success-fallback/1_coderabbit-success-fallback_specs.md` |
+| Markdown lint plan spec docs spec | `docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/1_173-markdown-lint-plan-spec-docs_specs.md` |
 
 ---
 
@@ -67,15 +70,18 @@ Before running this smoke test:
 
 ---
 
-### Step 4: Verify all 4 existing spec files no longer contain "Guiding principle" section
+### Step 4: Verify all existing spec files no longer contain "Guiding principle" section
 
-**Maps to**: Acceptance Criterion 4
+**Maps to**: Acceptance Criterion 4 and spec Business Rule (all merged spec files must be updated)
 
 For each of the following files:
 - `docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md`
 - `docs/specs/developments/20260414184900_batch-merge/1_batch-merge_specs.md`
 - `docs/specs/developments/20260416120000_136-shellcheck-workflow-scripts/1_136-shellcheck-workflow-scripts_specs.md`
 - `docs/specs/developments/20260416120000_agent-timeout-handling/1_agent-timeout-handling_specs.md`
+- `docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/1_batch-merge-ff-pull-retry_specs.md`
+- `docs/specs/developments/20260416120000_coderabbit-success-fallback/1_coderabbit-success-fallback_specs.md`
+- `docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/1_173-markdown-lint-plan-spec-docs_specs.md`
 
 1. Open the file.
 2. Search for the text `Guiding principle`.
@@ -102,6 +108,9 @@ Each checkbox maps to an acceptance criterion from the spec.
 - [ ] `docs/specs/developments/20260414184900_batch-merge/1_batch-merge_specs.md` does not contain the "Guiding principle (important)" section.
 - [ ] `docs/specs/developments/20260416120000_136-shellcheck-workflow-scripts/1_136-shellcheck-workflow-scripts_specs.md` does not contain the "Guiding principle (important)" section.
 - [ ] `docs/specs/developments/20260416120000_agent-timeout-handling/1_agent-timeout-handling_specs.md` does not contain the "Guiding principle (important)" section.
+- [ ] `docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/1_batch-merge-ff-pull-retry_specs.md` does not contain the "Guiding principle (important)" section.
+- [ ] `docs/specs/developments/20260416120000_coderabbit-success-fallback/1_coderabbit-success-fallback_specs.md` does not contain the "Guiding principle (important)" section.
+- [ ] `docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/1_173-markdown-lint-plan-spec-docs_specs.md` does not contain the "Guiding principle (important)" section.
 
 ---
 

--- a/docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md
+++ b/docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md
@@ -1,0 +1,125 @@
+# Smoke Test Runbook: Remove 'Guiding Principle' Section from Spec Template
+
+**Feature**: Remove boilerplate 'Guiding principle' section from spec template
+**Spec**: [`docs/specs/developments/20260416200000_165-remove-guiding-principle-from-spec-template/1_165-remove-guiding-principle-from-spec-template_specs.md`](../../specs/developments/20260416200000_165-remove-guiding-principle-from-spec-template/1_165-remove-guiding-principle-from-spec-template_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] The feature branch has been merged into `develop` (or is checked out locally)
+- [ ] You have file read access to the repository
+
+---
+
+## Test Data
+
+| Item | Value |
+|---|---|
+| Spec template | `docs/ai/development-workflow/templates/spec-template.md` |
+| Spec generation protocol | `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md` |
+| Review contract | `REVIEW.md` |
+| Retrospective spec | `docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md` |
+| Batch merge spec | `docs/specs/developments/20260414184900_batch-merge/1_batch-merge_specs.md` |
+| Shellcheck spec | `docs/specs/developments/20260416120000_136-shellcheck-workflow-scripts/1_136-shellcheck-workflow-scripts_specs.md` |
+| Agent timeout spec | `docs/specs/developments/20260416120000_agent-timeout-handling/1_agent-timeout-handling_specs.md` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify spec template no longer contains "Guiding principle" section
+
+**Maps to**: Acceptance Criterion 1
+
+1. Open `docs/ai/development-workflow/templates/spec-template.md`.
+2. Search for the text `Guiding principle`.
+3. Search for the text `product-focused`.
+
+**Expected result**: The string `Guiding principle` is not present. The template begins with the `## Overview` section (or `## Depends on`) immediately after the title line.
+
+---
+
+### Step 2: Verify authoring guidance is present in the spec generation protocol
+
+**Maps to**: Acceptance Criterion 2
+
+1. Open `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md`.
+2. Search for guidance that instructs spec authors to write product-focused content and avoid implementation details.
+
+**Expected result**: The file contains a section (e.g., "Product-first boundary (critical)") that instructs authors to write user-facing behavior and avoid implementation details such as database tables, endpoints, file paths, or class names.
+
+---
+
+### Step 3: Verify REVIEW.md spec checklist does not require the "Guiding principle" section
+
+**Maps to**: Acceptance Criterion 3
+
+1. Open `REVIEW.md`.
+2. Search for the text `Guiding principle`.
+3. Read the "Spec Review Checklist" section.
+
+**Expected result**: The string `Guiding principle` is not present in `REVIEW.md`. The spec checklist checks that the spec does not contain implementation details (table names, endpoints, file paths, class names, migration design) — it does not require the presence of a named boilerplate section.
+
+---
+
+### Step 4: Verify all 4 existing spec files no longer contain "Guiding principle" section
+
+**Maps to**: Acceptance Criterion 4
+
+For each of the following files:
+- `docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md`
+- `docs/specs/developments/20260414184900_batch-merge/1_batch-merge_specs.md`
+- `docs/specs/developments/20260416120000_136-shellcheck-workflow-scripts/1_136-shellcheck-workflow-scripts_specs.md`
+- `docs/specs/developments/20260416120000_agent-timeout-handling/1_agent-timeout-handling_specs.md`
+
+1. Open the file.
+2. Search for the text `Guiding principle`.
+3. Verify the remaining content (Overview, Use Cases, Business Rules, Acceptance Criteria, etc.) is intact.
+
+**Expected result**: The string `Guiding principle` is not present in any of the 4 files. All other spec content is unmodified.
+
+---
+
+### Last Step: Validate all assertions
+
+- Verify all checkboxes in the Assertions Checklist below are met.
+
+---
+
+## Assertions Checklist
+
+Each checkbox maps to an acceptance criterion from the spec.
+
+- [ ] `docs/ai/development-workflow/templates/spec-template.md` does not contain the "Guiding principle (important)" section.
+- [ ] `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md` contains product-focused authoring guidance (verbatim or equivalent).
+- [ ] `REVIEW.md` spec checklist does not require the "Guiding principle" section; instead it checks that specs avoid implementation details.
+- [ ] `docs/specs/developments/20260413201328_retrospective-protocol/1_retrospective-protocol_specs.md` does not contain the "Guiding principle (important)" section.
+- [ ] `docs/specs/developments/20260414184900_batch-merge/1_batch-merge_specs.md` does not contain the "Guiding principle (important)" section.
+- [ ] `docs/specs/developments/20260416120000_136-shellcheck-workflow-scripts/1_136-shellcheck-workflow-scripts_specs.md` does not contain the "Guiding principle (important)" section.
+- [ ] `docs/specs/developments/20260416120000_agent-timeout-handling/1_agent-timeout-handling_specs.md` does not contain the "Guiding principle (important)" section.
+
+---
+
+## Seed Data Reference
+
+None — this feature affects documentation files only.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Guiding principle` still appears in a spec file | The file was not updated during implementation | Edit the file and remove the section |
+| Remaining spec content appears truncated or garbled | Incorrect deletion during implementation removed too many lines | Restore from git history and redo the removal carefully |
+
+---
+
+## Known Limitations
+
+- This smoke test is entirely manual (file inspection). No automated test runner is available for Markdown content structure verification.

--- a/docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md
+++ b/docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md
@@ -87,7 +87,7 @@ For each of the following files:
 2. Search for the text `Guiding principle`.
 3. Verify the remaining content (Overview, Use Cases, Business Rules, Acceptance Criteria, etc.) is intact.
 
-**Expected result**: The string `Guiding principle` is not present in any of the 4 files. All other spec content is unmodified.
+**Expected result**: The string `Guiding principle` is not present in any of the 7 files. All other spec content is unmodified.
 
 ---
 


### PR DESCRIPTION
## Summary

This plan covers removing the boilerplate "Guiding principle (important)" section from the spec template and all 4 existing merged spec files that still contain it.

**Approach**: Mechanical find-and-delete of the `## Guiding principle (important)` section from 5 Markdown files. No changes to `01-generate-spec-protocol.md` (already has equivalent guidance under "Product-first boundary (critical)") or `REVIEW.md` (already checks implementation-detail cleanliness, not the presence of a named section).

**Estimated complexity**: S (< 1 day)

**Key risks**: None significant — all changes are additive deletions on documentation files with no code impact.

**Dependencies**: None

## Files Changed

- Plan: [`docs/specs/developments/20260416200000_165-remove-guiding-principle-from-spec-template/2_165-remove-guiding-principle-from-spec-template_implementation-plan.md`](docs/specs/developments/20260416200000_165-remove-guiding-principle-from-spec-template/2_165-remove-guiding-principle-from-spec-template_implementation-plan.md)
- Smoke test runbook: [`docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md`](docs/testing/workflow/165-remove-guiding-principle-from-spec-template.smoke-test.md)

## Related

Closes part of #165
Spec merged via PR #179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed implementation plan with step-by-step guidance for streamlining specification templates by removing redundant boilerplate sections.
  * Added comprehensive smoke test procedures to validate template simplification and ensure consistency across specification documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->