### PR TITLE
docs(plan): batch-merge ff-pull transient failure retry (#174)

### DIFF
--- a/docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/2_batch-merge-ff-pull-retry_implementation-plan.md
+++ b/docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/2_batch-merge-ff-pull-retry_implementation-plan.md
@@ -44,7 +44,7 @@
 4. No regression — existing call paths (clean first attempt, conflict, non-conflict non-ff failure) behave identically to before the change. *(Maps to Acceptance Criterion 4)*
 5. Change isolation — discovery mode, conflict classification, and post-merge logic are unmodified. *(Maps to Acceptance Criterion 5)*
 
-**Smoke test runbook**: [`docs/testing/workflow/batch-merge-ff-pull-retry.smoke-test.md`](../../../testing/workflow/batch-merge-ff-pull-retry.smoke-test.md)
+**Smoke test runbook**: See the canonical runbook linked in the document header above.
 
 ---
 

--- a/docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/2_batch-merge-ff-pull-retry_implementation-plan.md
+++ b/docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/2_batch-merge-ff-pull-retry_implementation-plan.md
@@ -83,7 +83,7 @@ git pull --ff-only origin "$TARGET_BASE" >/dev/null 2>&1 || \
 if ! git pull --ff-only origin "$TARGET_BASE" >/dev/null 2>&1; then
   echo "ff-pull failed on first attempt; retrying after 2s (transient stale-ref recovery)..." >&2
   sleep 2
-  git fetch origin "$TARGET_BASE" >/dev/null 2>&1 || true
+  git fetch origin "$TARGET_BASE" >/dev/null 2>&1 && \
   git pull --ff-only origin "$TARGET_BASE" >/dev/null 2>&1 || \
     merge_die "Could not fast-forward local '${TARGET_BASE}' from origin — resolve divergence manually"
 fi

--- a/docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/2_batch-merge-ff-pull-retry_implementation-plan.md
+++ b/docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/2_batch-merge-ff-pull-retry_implementation-plan.md
@@ -21,7 +21,7 @@
 
 ### Infrastructure / Configuration
 
-- [ ] `scripts/development-workflow/batch-merge.sh` — in `cmd_merge`, replace the single-attempt `git pull --ff-only` + `merge_die` call (lines 308–309) with a two-attempt sequence:
+- [ ] `scripts/development-workflow/batch-merge.sh` — in `cmd_merge`, replace the current single-attempt `git pull --ff-only` + `merge_die` block with a two-attempt sequence:
   1. Attempt `git pull --ff-only origin "$TARGET_BASE"` (suppress stdout/stderr as today).
   2. If it succeeds, continue as before.
   3. If it fails, print a diagnostic message to stderr (e.g., `"ff-pull failed; retrying after 2s..."`), sleep 2, run `git fetch origin "$TARGET_BASE"`, then retry `git pull --ff-only origin "$TARGET_BASE"`.

--- a/docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/2_batch-merge-ff-pull-retry_implementation-plan.md
+++ b/docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/2_batch-merge-ff-pull-retry_implementation-plan.md
@@ -1,0 +1,100 @@
+# batch-merge ff-pull transient failure retry — Implementation Plan
+
+**Spec**: [`1_batch-merge-ff-pull-retry_specs.md`](./1_batch-merge-ff-pull-retry_specs.md)
+**Smoke test runbook**: [`docs/testing/workflow/batch-merge-ff-pull-retry.smoke-test.md`](../../../testing/workflow/batch-merge-ff-pull-retry.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Wrap the existing `git pull --ff-only origin "$TARGET_BASE"` call in `batch-merge.sh`'s `cmd_merge` with a one-shot retry: if the first attempt fails, sleep 2 seconds, run `git fetch origin "$TARGET_BASE"`, then retry `git pull --ff-only`. Only if the retry also fails is `merge_die` called. No changes to discovery, conflict handling, or any other section.
+
+**Estimated complexity**: S
+
+**Rationale**: The change is confined to exactly three lines in one function of a single shell script. The logic is straightforward conditional branching with no new state, flags, or interfaces introduced.
+
+**Dependencies**: None
+
+---
+
+## Layer-by-Layer Changes
+
+### Infrastructure / Configuration
+
+- [ ] `scripts/development-workflow/batch-merge.sh` — in `cmd_merge`, replace the single-attempt `git pull --ff-only` + `merge_die` call (lines 308–309) with a two-attempt sequence:
+  1. Attempt `git pull --ff-only origin "$TARGET_BASE"` (suppress stdout/stderr as today).
+  2. If it succeeds, continue as before.
+  3. If it fails, print a diagnostic message to stderr (e.g., `"ff-pull failed; retrying after 2s..."`), sleep 2, run `git fetch origin "$TARGET_BASE"`, then retry `git pull --ff-only origin "$TARGET_BASE"`.
+  4. If the retry succeeds, continue.
+  5. If the retry fails, call `merge_die "Could not fast-forward local '${TARGET_BASE}' from origin — resolve divergence manually"` (same message as today).
+
+  The fetch before the retry must use `"$TARGET_BASE"` (the same variable already in scope), not a hard-coded `develop`, so the logic is correct if `TARGET_BASE` is ever changed at the top of the file.
+
+---
+
+## Testing Strategy
+
+**Test types**: Manual smoke test (bash script; no automated test suite in the repository)
+
+**Key scenarios to test**:
+
+1. Transient failure recovery — first `git pull --ff-only` fails, retry succeeds → `MERGE_RESULT=clean` emitted, no human intervention. *(Maps to Acceptance Criterion 1)*
+2. Genuine divergence — both attempts fail → `MERGE_RESULT=failed` + `ERROR_MESSAGE` emitted, same structured output as before. *(Maps to Acceptance Criterion 2)*
+3. Diagnostic message present — when a retry is attempted, stderr contains a "retrying" message. *(Maps to Acceptance Criterion 3)*
+4. No regression — existing call paths (clean first attempt, conflict, non-conflict non-ff failure) behave identically to before the change. *(Maps to Acceptance Criterion 4)*
+5. Change isolation — discovery mode, conflict classification, and post-merge logic are unmodified. *(Maps to Acceptance Criterion 5)*
+
+**Smoke test runbook**: [`docs/testing/workflow/batch-merge-ff-pull-retry.smoke-test.md`](../../../testing/workflow/batch-merge-ff-pull-retry.smoke-test.md)
+
+---
+
+## Seed Data
+
+N/A — `batch-merge.sh` is a standalone bash script that interacts with git and the GitHub API. No database or application seed data is required.
+
+---
+
+## Documentation Updates
+
+None — this change is a self-contained bug fix in a single script. It does not alter any user-facing workflow step, introduce a new option, change the output contract, or affect any pattern described in `docs/`. The script's own header comment does not describe the ff-pull internals and does not need updating.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Retry masks a genuine but intermittent divergence | Low | Med | The retry only changes the result if `git pull --ff-only` succeeds on the second attempt — a genuine divergence will fail both times and still emit `MERGE_RESULT=failed` exactly as before. |
+| 2-second sleep adds noticeable latency | Low | Low | The sleep only fires on the failure path. A clean first attempt (the common case) has zero added latency. Even in the worst case the delay is a fixed 2 seconds. |
+| Variable `TARGET_BASE` referenced incorrectly | Low | Med | Use `"$TARGET_BASE"` consistently in both the fetch and the pull; this is already the pattern in the surrounding code. |
+
+---
+
+## Code Samples
+
+```bash
+# Illustrative — adapt during implementation
+
+# Current code (lines 308–309):
+git pull --ff-only origin "$TARGET_BASE" >/dev/null 2>&1 || \
+  merge_die "Could not fast-forward local '${TARGET_BASE}' from origin — resolve divergence manually"
+
+# Replacement:
+if ! git pull --ff-only origin "$TARGET_BASE" >/dev/null 2>&1; then
+  echo "ff-pull failed on first attempt; retrying after 2s (transient stale-ref recovery)..." >&2
+  sleep 2
+  git fetch origin "$TARGET_BASE" >/dev/null 2>&1 || true
+  git pull --ff-only origin "$TARGET_BASE" >/dev/null 2>&1 || \
+    merge_die "Could not fast-forward local '${TARGET_BASE}' from origin — resolve divergence manually"
+fi
+```
+
+---
+
+## Implementation Order
+
+1. Read `scripts/development-workflow/batch-merge.sh` (specifically `cmd_merge`) to confirm the exact line numbers and surrounding context before editing.
+2. Replace the single-attempt ff-pull block with the two-attempt sequence from the Code Samples section above.
+3. Verify the script still passes `shellcheck` (run `shellcheck scripts/development-workflow/batch-merge.sh`).
+4. Run the smoke test runbook manually to validate both the retry-success and retry-failure scenarios.
+5. Update CHANGELOG.md — add an entry under `[Unreleased]` for this fix.

--- a/docs/testing/workflow/batch-merge-ff-pull-retry.smoke-test.md
+++ b/docs/testing/workflow/batch-merge-ff-pull-retry.smoke-test.md
@@ -46,6 +46,9 @@ shellcheck scripts/development-workflow/batch-merge.sh
 This step performs structural verification of the retry path by inspecting script source and setting up a controlled environment (a temporary git repository) to confirm the logic is in place. Full automated simulation is not supported without a mock git layer (see Known Limitations).
 
 ```bash
+# Save repo root so Steps 3-6 can use it after CWD changes below
+REPO_ROOT="$(pwd)"
+
 # Create a temp repo for structural verification of the retry path
 TMPDIR="$(mktemp -d)"
 cd "$TMPDIR"
@@ -69,6 +72,9 @@ git push origin develop
 
 echo "Manual verification: open batch-merge.sh and confirm lines in cmd_merge"
 echo "match the pattern: if ! git pull --ff-only ...; then sleep 2; git fetch ...; git pull --ff-only ... || merge_die; fi"
+
+# Return to repository root for Steps 3-6
+cd "$REPO_ROOT"
 ```
 
 **Expected result**: The two-attempt block is present in `cmd_merge`. The first `git pull --ff-only` is in a conditional; a `sleep 2` + `git fetch origin "$TARGET_BASE"` precede the second attempt.

--- a/docs/testing/workflow/batch-merge-ff-pull-retry.smoke-test.md
+++ b/docs/testing/workflow/batch-merge-ff-pull-retry.smoke-test.md
@@ -41,12 +41,12 @@ shellcheck scripts/development-workflow/batch-merge.sh
 
 **Expected result**: No errors or warnings are printed; shellcheck exits with code 0.
 
-### Step 2: Verify transient failure recovery (AC 1 + AC 3)
+### Step 2: Structural verification of first-attempt ff-pull retry (AC 1 + AC 3)
 
-This step simulates a first-attempt ff-pull failure that succeeds on retry. It uses a controlled environment (a temporary git repository) to exercise the retry path without affecting any real remote.
+This step performs structural verification of the retry path by inspecting script source and setting up a controlled environment (a temporary git repository) to confirm the logic is in place. Full automated simulation is not supported without a mock git layer (see Known Limitations).
 
 ```bash
-# Create a temp repo that simulates the transient failure
+# Create a temp repo for structural verification of the retry path
 TMPDIR="$(mktemp -d)"
 cd "$TMPDIR"
 
@@ -104,7 +104,8 @@ grep -A 5 "merge_die.*fast-forward" scripts/development-workflow/batch-merge.sh
 Confirm the diff of `batch-merge.sh` is confined to the ff-pull block in `cmd_merge`.
 
 ```bash
-git diff develop -- scripts/development-workflow/batch-merge.sh | grep "^[+-]" | grep -v "^[+-][+-][+-]"
+BASE="$(git merge-base HEAD origin/develop)"
+git diff "$BASE" -- scripts/development-workflow/batch-merge.sh | grep "^[+-]" | grep -v "^[+-][+-][+-]"
 ```
 
 **Expected result**: Changed lines are only within the `cmd_merge` function, touching only the `git pull --ff-only` block and the adjacent retry logic. No changes to `cmd_discover`, conflict classification, `merge_die` definition, or post-merge logic.

--- a/docs/testing/workflow/batch-merge-ff-pull-retry.smoke-test.md
+++ b/docs/testing/workflow/batch-merge-ff-pull-retry.smoke-test.md
@@ -1,0 +1,160 @@
+# Smoke Test Runbook: batch-merge ff-pull transient failure retry
+
+**Feature**: Transient ff-pull failure retry in `batch-merge.sh`
+**Spec**: [`docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/1_batch-merge-ff-pull-retry_specs.md`](../../specs/developments/20260416120000_batch-merge-ff-pull-retry/1_batch-merge-ff-pull-retry_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] Repository has a `develop` branch
+- [ ] `gh` CLI is authenticated (`gh auth status` succeeds)
+- [ ] You have push access to the repository
+- [ ] `shellcheck` is installed (for static analysis step)
+- [ ] The implementation has been applied to `scripts/development-workflow/batch-merge.sh`
+
+---
+
+## Test Data
+
+| Item | Description |
+|---|---|
+| Test repo | The `ai-dev-framework-template` repository |
+| Target branch | `develop` |
+| Script under test | `scripts/development-workflow/batch-merge.sh` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify shellcheck passes
+
+Run `shellcheck` against the modified script to confirm no static analysis errors were introduced.
+
+```bash
+shellcheck scripts/development-workflow/batch-merge.sh
+```
+
+**Expected result**: No errors or warnings are printed; shellcheck exits with code 0.
+
+### Step 2: Verify transient failure recovery (AC 1 + AC 3)
+
+This step simulates a first-attempt ff-pull failure that succeeds on retry. It uses a controlled environment (a temporary git repository) to exercise the retry path without affecting any real remote.
+
+```bash
+# Create a temp repo that simulates the transient failure
+TMPDIR="$(mktemp -d)"
+cd "$TMPDIR"
+
+# Set up a local "remote" and a working clone
+git init --bare remote.git
+git clone remote.git local
+cd local
+
+# Create develop branch with an initial commit
+git checkout -b develop
+echo "init" > file.txt
+git add file.txt
+git commit -m "initial"
+git push origin develop
+
+# Now, in the working clone, confirm the retry path by temporarily
+# wrapping git to fail once.
+# (Manual verification: inspect the modified batch-merge.sh to confirm
+#  the retry logic is present. Automated simulation below is illustrative.)
+
+echo "Manual verification: open batch-merge.sh and confirm lines in cmd_merge"
+echo "match the pattern: if ! git pull --ff-only ...; then sleep 2; git fetch ...; git pull --ff-only ... || merge_die; fi"
+```
+
+**Expected result**: The two-attempt block is present in `cmd_merge`. The first `git pull --ff-only` is in a conditional; a `sleep 2` + `git fetch origin "$TARGET_BASE"` precede the second attempt.
+
+**Maps to**: Acceptance Criterion 1, Acceptance Criterion 3
+
+### Step 3: Verify diagnostic message on stderr (AC 3)
+
+Inspect the script source to confirm a stderr diagnostic is emitted on the retry path.
+
+```bash
+grep -n "retrying\|retry\|Retrying\|Retry" scripts/development-workflow/batch-merge.sh
+```
+
+**Expected result**: At least one line containing a retry-related message that is redirected to `>&2`, located within the `cmd_merge` function, between the first and second `git pull --ff-only` calls.
+
+**Maps to**: Acceptance Criterion 3
+
+### Step 4: Verify genuine divergence is still a hard failure (AC 2)
+
+Read the script and confirm that when the retry `git pull --ff-only` fails, `merge_die` is called with the same structured output as before.
+
+```bash
+grep -A 5 "merge_die.*fast-forward" scripts/development-workflow/batch-merge.sh
+```
+
+**Expected result**: `merge_die "Could not fast-forward local '${TARGET_BASE}' from origin — resolve divergence manually"` (or equivalent wording) is called after the retry fails, ensuring `MERGE_RESULT=failed` and `ERROR_MESSAGE` are still emitted.
+
+**Maps to**: Acceptance Criterion 2
+
+### Step 5: Verify change isolation (AC 5)
+
+Confirm the diff of `batch-merge.sh` is confined to the ff-pull block in `cmd_merge`.
+
+```bash
+git diff develop -- scripts/development-workflow/batch-merge.sh | grep "^[+-]" | grep -v "^[+-][+-][+-]"
+```
+
+**Expected result**: Changed lines are only within the `cmd_merge` function, touching only the `git pull --ff-only` block and the adjacent retry logic. No changes to `cmd_discover`, conflict classification, `merge_die` definition, or post-merge logic.
+
+**Maps to**: Acceptance Criterion 5
+
+### Step 6: End-to-end batch-merge smoke test (AC 4 — no regression)
+
+Run the existing `batch-merge.sh` discovery smoke test (or a subset of it) to confirm the clean-merge path is not broken.
+
+```bash
+# Confirm the existing batch-merge.smoke-test.md still passes for Step 1 (discovery)
+# and a single-PR merge against a real ready PR (if available in the test environment).
+./scripts/development-workflow/batch-merge.sh discover
+```
+
+**Expected result**: `DISCOVERY_RESULT=found` (if ready PRs exist) or `DISCOVERY_RESULT=none` (if none), with no script errors. The output contract is unchanged.
+
+**Maps to**: Acceptance Criterion 4
+
+---
+
+## Assertions Checklist
+
+Each checkbox maps to an acceptance criterion from the spec.
+
+- [ ] AC 1: Retry path present in `cmd_merge` — when ff-pull fails, the script fetches and retries before calling `merge_die`.
+- [ ] AC 2: Genuine-divergence path preserved — `merge_die` is still called (with `MERGE_RESULT=failed` + `ERROR_MESSAGE`) when both attempts fail.
+- [ ] AC 3: Diagnostic stderr message present on the retry path.
+- [ ] AC 4: No regression — `shellcheck` is clean; existing call paths (clean first attempt, conflict, non-ff failure) are unmodified.
+- [ ] AC 5: Change scoped to the ff-pull block in `cmd_merge` only; discovery and conflict logic untouched.
+
+---
+
+## Seed Data Reference
+
+N/A — no database or application seed data required. All test scenarios exercise the shell script directly.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `shellcheck` reports `SC2064` or similar on the retry block | Quoting or expansion issue in the retry conditional | Wrap variables with double quotes; use `"$TARGET_BASE"` not `$TARGET_BASE` |
+| `grep` finds no retry message on stderr | Diagnostic was written to stdout instead | Confirm `>&2` redirect is present on the diagnostic `echo` |
+| Discovery returns unexpected output | Unintended change leaked into `cmd_discover` | Re-check the diff; revert any changes outside `cmd_merge` |
+
+---
+
+## Known Limitations
+
+- The "transient failure recovery" scenario (AC 1) cannot be fully automated without a mock git or wrapper script. The smoke test relies on code inspection to confirm the retry branch is structurally correct. A full integration test would require a controlled environment where `git pull --ff-only` can be made to fail exactly once.


### PR DESCRIPTION
## Summary

Adds the implementation plan and smoke test runbook for issue #174: the transient `git pull --ff-only` failure in `batch-merge.sh merge` that occurs between sequential merges in a batch run.

**Approach**: Wrap the existing single-attempt `git pull --ff-only` in `cmd_merge` with a one-shot retry — sleep 2s, `git fetch origin "$TARGET_BASE"`, retry `git pull --ff-only`. If the retry succeeds, the merge continues normally. If it also fails, `merge_die` is called as before.

**Estimated complexity**: S (< 1 day)

**Key risks**:
- None significant; the retry only fires on the failure path so the happy path is unchanged.
- Genuine divergence is preserved as a hard failure because both attempts must fail before `merge_die` is called.

**Dependencies**: None

**Links**:
- Spec: `docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/1_batch-merge-ff-pull-retry_specs.md`
- Plan: `docs/specs/developments/20260416120000_batch-merge-ff-pull-retry/2_batch-merge-ff-pull-retry_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/batch-merge-ff-pull-retry.smoke-test.md`

Closes #174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an implementation plan describing a one-shot retry for transient fast-forward pull failures in the batch-merge workflow.
  * Added a smoke-test runbook that verifies the retry path and diagnostic, ensures genuine divergence still hard-fails, and checks for no regressions in discovery and overall merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->