### PR TITLE
docs(plan): CodeRabbit SUCCESS commit-status fallback (#166)

### DIFF
--- a/docs/specs/developments/20260416120000_coderabbit-success-fallback/2_coderabbit-success-fallback_implementation-plan.md
+++ b/docs/specs/developments/20260416120000_coderabbit-success-fallback/2_coderabbit-success-fallback_implementation-plan.md
@@ -22,12 +22,12 @@
 ### Scripts / Shell
 
 - [ ] In `scripts/development-workflow/pr-review-loop.sh`, within `run_coderabbit_review()`:
-  - Add a new local variable `coderabbit_success_status_found=0` in the local declarations block at the top of the function.
+  - Add a new local variable `local coderabbit_success_status_count` in the local declarations block at the top of the function.
   - After the rate-limit retry block (the `if [ "$coderabbit_any_activity" -eq 0 ] && [ "$coderabbit_rate_limit_retries" -lt "$coderabbit_rate_limit_max_retries" ]` guard) and once `elapsed >= max_wait`, insert a new fallback check block immediately before the existing `stale_count` / stale-findings block:
     1. Query `GET /repos/{repo}/commits/{head_sha}/statuses` (paginated) via `gh api`.
     2. Filter for entries where `.context` contains `coderabbit` (case-insensitive) and `.state == "success"`.
-    3. If at least one such entry is found, set `coderabbit_success_status_found=1`.
-  - If `coderabbit_success_status_found=1`, skip the stale-findings block entirely and emit:
+    3. Count the matching entries into `coderabbit_success_status_count`.
+  - If `coderabbit_success_status_count > 0`, skip the stale-findings block entirely and emit:
     ```
     RESULT=clean
     REASON=coderabbit_status_success_fallback
@@ -41,8 +41,8 @@
     SUGGESTION_COUNT=0
     ```
     Then `return 0`.
-  - The stale-findings block and the existing `skipped (no_review)` / `escalate (timeout)` paths are only reached when `coderabbit_success_status_found=0`.
-  - The `coderabbit_success_status_found` check must only apply when `coderabbit_any_activity -eq 0`. When `coderabbit_any_activity -eq 1` (a real review was posted), the existing Phase 3 result collection path runs as-is.
+  - The stale-findings block and the existing `skipped (no_review)` / `escalate (timeout)` paths are only reached when `coderabbit_success_status_count` is 0 or empty.
+  - This check must only apply when `coderabbit_any_activity -eq 0`. When `coderabbit_any_activity -eq 1` (a real review was posted), the existing Phase 3 result collection path runs as-is.
 
 ### Documentation
 
@@ -139,7 +139,7 @@ fi
 ## Implementation Order
 
 1. Read the full `run_coderabbit_review()` function in `scripts/development-workflow/pr-review-loop.sh` and identify the exact insertion point: the `if [ "$elapsed" -ge "$max_wait" ]` block, inside the `if [ "$coderabbit_any_activity" -eq 0 ]` guard, before the stale-findings query.
-2. Add `local coderabbit_success_status_found=0` to the local declarations block at the top of `run_coderabbit_review()`.
+2. Add `local coderabbit_success_status_count` to the local declarations block at the top of `run_coderabbit_review()`.
 3. Insert the SUCCESS commit-status fallback block (API query + conditional `return 0`) at the identified location.
 4. Update `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` Step 3.7 to document the new fallback.
 5. Verify the smoke test runbook scenarios manually or with a dry-run review of the script diff.

--- a/docs/specs/developments/20260416120000_coderabbit-success-fallback/2_coderabbit-success-fallback_implementation-plan.md
+++ b/docs/specs/developments/20260416120000_coderabbit-success-fallback/2_coderabbit-success-fallback_implementation-plan.md
@@ -1,0 +1,146 @@
+# CodeRabbit SUCCESS Commit-Status Fallback — Implementation Plan
+
+**Spec**: [1_coderabbit-success-fallback_specs.md](./1_coderabbit-success-fallback_specs.md)
+**Smoke test runbook**: [docs/testing/workflow/coderabbit-success-fallback.smoke-test.md](../../../testing/workflow/coderabbit-success-fallback.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Modify `run_coderabbit_review()` in `scripts/development-workflow/pr-review-loop.sh` to check the GitHub commit-status contexts for the current HEAD SHA after the retry budget is exhausted but before the stale-findings recovery path runs. If a CodeRabbit commit-status context with `state: SUCCESS` is found and no blocking inline comments exist for the current HEAD, the function returns `clean` with `REASON=coderabbit_status_success_fallback` instead of falling through to stale-findings or escalation. Also update `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` Step 3.7 to document this fallback.
+
+**Estimated complexity**: S
+
+**Rationale**: The change is limited to a single insertion point in `run_coderabbit_review()` — a new code block inserted between the rate-limit retry exhaustion check and the existing stale-findings recovery. It requires one new GitHub API call (`/commits/{sha}/statuses`) and two output key-value pairs. No new files are created; no other platform handlers are touched.
+
+**Dependencies**: None
+
+---
+
+## Layer-by-Layer Changes
+
+### Scripts / Shell
+
+- [ ] In `scripts/development-workflow/pr-review-loop.sh`, within `run_coderabbit_review()`:
+  - Add a new local variable `coderabbit_success_status_found=0` in the local declarations block at the top of the function.
+  - After the rate-limit retry block (the `if [ "$coderabbit_any_activity" -eq 0 ] && [ "$coderabbit_rate_limit_retries" -lt "$coderabbit_rate_limit_max_retries" ]` guard) and once `elapsed >= max_wait`, insert a new fallback check block immediately before the existing `stale_count` / stale-findings block:
+    1. Query `GET /repos/{repo}/commits/{head_sha}/statuses` (paginated) via `gh api`.
+    2. Filter for entries where `.context` contains `coderabbit` (case-insensitive) and `.state == "success"`.
+    3. If at least one such entry is found, set `coderabbit_success_status_found=1`.
+  - If `coderabbit_success_status_found=1`, skip the stale-findings block entirely and emit:
+    ```
+    RESULT=clean
+    REASON=coderabbit_status_success_fallback
+    PLATFORM=coderabbit
+    PR_NUMBER=<pr_number>
+    BRANCH=<branch_name>
+    REVIEW_COMMENT_ID=
+    FIX_AGENT=<reviewer_for_branch>
+    COMMENT_COUNT=0
+    BLOCKING_COUNT=0
+    SUGGESTION_COUNT=0
+    ```
+    Then `return 0`.
+  - The stale-findings block and the existing `skipped (no_review)` / `escalate (timeout)` paths are only reached when `coderabbit_success_status_found=0`.
+  - The `coderabbit_success_status_found` check must only apply when `coderabbit_any_activity -eq 0`. When `coderabbit_any_activity -eq 1` (a real review was posted), the existing Phase 3 result collection path runs as-is.
+
+### Documentation
+
+- [ ] In `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`, update Step 3.7 to document the new fallback:
+  - Describe the new behavior: when all retry budget is exhausted and no CodeRabbit review comment was posted, the script checks for a CodeRabbit commit-status context with `state: SUCCESS`. If found, the result is `clean` with `REASON=coderabbit_status_success_fallback`.
+  - Remove the statement "The PR can still advance to `ready-for-human-review`" that currently applies only to the stale/skipped path — that statement remains valid but the new fallback path should be described first.
+  - Keep the note about manually posting `@coderabbitai review` as an optional step for human reviewers.
+
+---
+
+## Testing Strategy
+
+**Test types**: Manual / Smoke
+
+**Key scenarios to test**:
+
+1. SUCCESS commit-status present, retry budget exhausted, no blocking inline comments → `RESULT=clean, REASON=coderabbit_status_success_fallback` (maps to Acceptance Criterion 1)
+2. No SUCCESS commit-status, retry budget exhausted → fallthrough to existing stale/skipped/escalate paths, behavior unchanged (maps to Acceptance Criterion 2)
+3. Blocking CodeRabbit inline comments present even when SUCCESS status exists → `RESULT=needs_fixes` (maps to Acceptance Criterion 3)
+4. `REASON=coderabbit_status_success_fallback` appears in script output when fallback is triggered (maps to Acceptance Criterion 4)
+5. Greptile and Devin handlers are unaffected (maps to Acceptance Criterion 5)
+
+**Smoke test runbook**: [`docs/testing/workflow/coderabbit-success-fallback.smoke-test.md`](../../../testing/workflow/coderabbit-success-fallback.smoke-test.md)
+
+---
+
+## Seed Data
+
+| Entity | Values / Scenario | File |
+|---|---|---|
+| N/A — shell script change; no application seed data required | — | — |
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` — Update Step 3.7 as described in the Layer-by-Layer Changes section above. This is included in-scope per Acceptance Criterion 6.
+
+No other project docs (`docs/project/`, `AGENTS.md`, `docs/best-practices/`) are affected by this fix — it is entirely internal to the `pr-review-loop.sh` script and its corresponding orchestration protocol note.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| GitHub commit-statuses API returns paginated results and the CodeRabbit entry is on a later page | Low | Medium | Use `--paginate` flag on `gh api` to fetch all pages before filtering |
+| Context name for CodeRabbit commit-status changes over time | Low | Medium | Filter with case-insensitive substring match (`coderabbit`) rather than exact context name; document the assumption in an inline comment |
+| `state: success` is returned for a stale status from a prior HEAD (not the current HEAD) | Low | High | The API call is scoped to `head_sha` — GitHub statuses endpoint is keyed by commit SHA, so only statuses for that exact SHA are returned; no additional time filter is needed |
+| New fallback bypasses stale-findings detection | Low | High | The fallback only activates when `coderabbit_any_activity -eq 0`; when activity was detected (Phase 2 loop exited normally), Phase 3 runs as-is. The stale-findings block is only skipped when the SUCCESS status fallback fires. |
+
+---
+
+## Code Samples
+
+> Illustrative — adapt during implementation.
+
+```bash
+# Inside run_coderabbit_review(), after the rate-limit retry block,
+# at the start of the `if [ "$elapsed" -ge "$max_wait" ]` block,
+# before the stale-findings check:
+
+if [ "$coderabbit_any_activity" -eq 0 ]; then
+  # Check for a CodeRabbit SUCCESS commit-status on the current HEAD SHA
+  # before falling through to stale-findings recovery or escalation.
+  local coderabbit_success_status_count
+  coderabbit_success_status_count="$(
+    gh api "repos/$repo/commits/$head_sha/statuses" --paginate \
+      | jq '[.[] | select(
+            (.context // "" | ascii_downcase | test("coderabbit")) and
+            .state == "success"
+          )] | length'
+  )"
+  if [ "${coderabbit_success_status_count:-0}" -gt 0 ]; then
+    # SUCCESS commit-status found — treat as clean (Illustrative — adapt during implementation)
+    print_kv RESULT clean
+    print_kv REASON coderabbit_status_success_fallback
+    print_kv PLATFORM "$platform"
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv REVIEW_COMMENT_ID ""
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv COMMENT_COUNT 0
+    print_kv BLOCKING_COUNT 0
+    print_kv SUGGESTION_COUNT 0
+    return 0
+  fi
+  # ... existing stale-findings block follows here ...
+fi
+```
+
+---
+
+## Implementation Order
+
+1. Read the full `run_coderabbit_review()` function in `scripts/development-workflow/pr-review-loop.sh` and identify the exact insertion point: the `if [ "$elapsed" -ge "$max_wait" ]` block, inside the `if [ "$coderabbit_any_activity" -eq 0 ]` guard, before the stale-findings query.
+2. Add `local coderabbit_success_status_found=0` to the local declarations block at the top of `run_coderabbit_review()`.
+3. Insert the SUCCESS commit-status fallback block (API query + conditional `return 0`) at the identified location.
+4. Update `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` Step 3.7 to document the new fallback.
+5. Verify the smoke test runbook scenarios manually or with a dry-run review of the script diff.
+6. Update CHANGELOG.md under `[Unreleased]` with the fix entry.

--- a/docs/testing/workflow/coderabbit-success-fallback.smoke-test.md
+++ b/docs/testing/workflow/coderabbit-success-fallback.smoke-test.md
@@ -1,0 +1,211 @@
+# Smoke Test Runbook: CodeRabbit SUCCESS Commit-Status Fallback
+
+**Feature**: fix(pr-review-loop): treat existing CodeRabbit SUCCESS status as clean during rate-limit wait
+**Spec**: [docs/specs/developments/20260416120000_coderabbit-success-fallback/1_coderabbit-success-fallback_specs.md](../../specs/developments/20260416120000_coderabbit-success-fallback/1_coderabbit-success-fallback_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] `gh` CLI is authenticated with a token that has `repo` scope
+- [ ] `jq` is installed and on `$PATH`
+- [ ] The repository has CodeRabbit configured (the `coderabbitai[bot]` has previously posted reviews on PRs)
+- [ ] You have access to a test PR or can create one on a feature branch
+
+---
+
+## Test Data
+
+| Item | Value |
+|---|---|
+| Script under test | `scripts/development-workflow/pr-review-loop.sh` |
+| Function under test | `run_coderabbit_review()` |
+| Environment variable (poll interval) | `POLL_INTERVAL` (default 120s) |
+| Environment variable (max wait) | `MAX_WAIT` (default 1200s) |
+| Environment variable (rate-limit retries) | `CODERABBIT_RATE_LIMIT_MAX_RETRIES` (default 2) |
+
+> **Note**: These smoke tests require shell-level inspection of the script logic and controlled API conditions. Full end-to-end testing requires an actual PR with a CodeRabbit SUCCESS commit-status. Steps below describe both a live test path (preferred) and a code-inspection verification path (fallback).
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify the fallback code path exists in the script
+
+**Maps to**: All acceptance criteria (structural prerequisite)
+
+1. Open `scripts/development-workflow/pr-review-loop.sh`.
+2. Locate the `run_coderabbit_review()` function.
+3. Inside the `if [ "$elapsed" -ge "$max_wait" ]` block, within the `if [ "$coderabbit_any_activity" -eq 0 ]` guard, verify a block that:
+   - Calls `gh api "repos/$repo/commits/$head_sha/statuses"` (paginated).
+   - Filters with `jq` for entries where `.context` matches `coderabbit` (case-insensitive) and `.state == "success"`.
+   - On a positive match: emits `RESULT=clean` and `REASON=coderabbit_status_success_fallback`, then returns 0.
+4. Verify this block appears **before** the stale-findings query (`stale_comments`).
+
+**Expected result**: The fallback block is present at the correct location, before stale-findings recovery.
+
+---
+
+### Step 2: Verify REASON output key-value format
+
+**Maps to**: Acceptance Criterion 4 — `REASON=coderabbit_status_success_fallback` key-value is in script output.
+
+1. Search the fallback block for the `print_kv REASON coderabbit_status_success_fallback` call.
+2. Confirm `print_kv` is called with both `RESULT clean` and `REASON coderabbit_status_success_fallback` in the same early-return path.
+
+**Expected result**: Both key-value calls are present and use the exact values `clean` and `coderabbit_status_success_fallback`.
+
+---
+
+### Step 3: Verify Greptile and Devin handlers are untouched
+
+**Maps to**: Acceptance Criterion 5 — Greptile and Devin platform handlers are unaffected.
+
+1. Search `run_greptile_review()` for any reference to `commit-status`, `statuses`, or `coderabbit_success_status_fallback`.
+2. Search `run_devin_review()` for the same.
+
+**Expected result**: Neither `run_greptile_review()` nor `run_devin_review()` contain any reference to the new fallback logic.
+
+---
+
+### Step 4: Live test — SUCCESS commit-status present, retry budget exhausted, no blocking comments (Use Case 1)
+
+**Maps to**: Acceptance Criterion 1
+
+> This step requires a real PR where CodeRabbit has posted a `SUCCESS` commit-status but no inline review comment for the current HEAD. This scenario naturally occurs when CodeRabbit completes review via a status check rather than an inline comment (e.g., after a rate-limit window resets and re-review is triggered via API rather than comment).
+
+1. Identify or create a PR where:
+   - The current HEAD SHA has a CodeRabbit commit-status with `state: success`. Verify with:
+     ```bash
+     HEAD_SHA=$(gh pr view <PR_NUMBER> --json headRefOid --jq '.headRefOid')
+     gh api "repos/{owner}/{repo}/commits/$HEAD_SHA/statuses" \
+       | jq '[.[] | select((.context | ascii_downcase | test("coderabbit")) and .state == "success")] | length'
+     ```
+     The output should be `> 0`.
+   - No blocking CodeRabbit inline comments exist on the current HEAD.
+2. Run the script with a very short `max_wait` to simulate budget exhaustion and no polling activity (set `CODERABBIT_RATE_LIMIT_MAX_RETRIES=0` to skip rate-limit retries):
+   ```bash
+   CODERABBIT_RATE_LIMIT_MAX_RETRIES=0 \
+     ./scripts/development-workflow/pr-review-loop.sh <PR_NUMBER> \
+       --branch <branch-name> \
+       --platform coderabbit \
+       --poll-interval 1 \
+       --max-wait 2
+   ```
+3. Capture the output.
+
+**Expected result**:
+- `RESULT=clean`
+- `REASON=coderabbit_status_success_fallback`
+- Script exits with code `0`
+
+---
+
+### Step 5: Live test — No SUCCESS commit-status, retry budget exhausted (Use Case 2)
+
+**Maps to**: Acceptance Criterion 2
+
+1. Identify or create a PR where the current HEAD SHA has NO CodeRabbit commit-status with `state: success`. Verify with:
+   ```bash
+   HEAD_SHA=$(gh pr view <PR_NUMBER> --json headRefOid --jq '.headRefOid')
+   gh api "repos/{owner}/{repo}/commits/$HEAD_SHA/statuses" \
+     | jq '[.[] | select((.context | ascii_downcase | test("coderabbit")) and .state == "success")] | length'
+   ```
+   The output should be `0`.
+2. Run the script with a very short `max_wait`:
+   ```bash
+   CODERABBIT_RATE_LIMIT_MAX_RETRIES=0 \
+     ./scripts/development-workflow/pr-review-loop.sh <PR_NUMBER> \
+       --branch <branch-name> \
+       --platform coderabbit \
+       --poll-interval 1 \
+       --max-wait 2
+   ```
+3. Capture the output.
+
+**Expected result**:
+- Script does NOT output `REASON=coderabbit_status_success_fallback`
+- Behavior falls through to existing stale-findings recovery: `RESULT=skipped` with `REASON=no_review` (if no stale blocking comments) or `RESULT=needs_fixes` with `REASON=stale_findings` (if stale blocking comments exist)
+- Script exits with code `0` (skipped) or `1` (needs_fixes)
+
+---
+
+### Step 6: Live test — Blocking inline comments present even with SUCCESS commit-status (Acceptance Criterion 3)
+
+**Maps to**: Acceptance Criterion 3
+
+1. On the same PR from Step 4 (SUCCESS commit-status present), verify that there IS at least one unresolved blocking CodeRabbit inline comment (severity 🔴 Critical or 🟠 Major) on the current HEAD.
+2. Run the script with a very short `max_wait`:
+   ```bash
+   CODERABBIT_RATE_LIMIT_MAX_RETRIES=0 \
+     ./scripts/development-workflow/pr-review-loop.sh <PR_NUMBER> \
+       --branch <branch-name> \
+       --platform coderabbit \
+       --poll-interval 1 \
+       --max-wait 2
+   ```
+3. Capture the output.
+
+**Expected result**:
+- `RESULT=needs_fixes`
+- `REASON=stale_findings`
+- `BLOCKING_COUNT` is greater than 0
+- Script does NOT output `REASON=coderabbit_status_success_fallback`
+- Script exits with code `1`
+
+> Note: The Phase 1 (existing-blocking-findings) check runs before the polling loop. If the blocking comments are found in Phase 1 (before the loop), the script returns `needs_fixes` from Phase 1 — the fallback is never reached. Either Phase 1 or the stale-findings path will catch blocking comments; the fallback does not apply in either case.
+
+---
+
+### Step 7: Verify protocol 90 Step 3.7 is updated
+
+**Maps to**: Acceptance Criterion 6
+
+1. Open `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`.
+2. Locate Step 3.7.
+3. Verify the section now describes the SUCCESS commit-status fallback behavior: when retry budget is exhausted and no inline review was posted, the script checks for a CodeRabbit `SUCCESS` commit-status. If found (and no blocking inline comments), it returns `clean` with `REASON=coderabbit_status_success_fallback`.
+
+**Expected result**: Step 3.7 accurately describes both the existing rate-limit retry behavior and the new SUCCESS status fallback path. The note about manually posting `@coderabbitai review` is retained as an optional human action.
+
+---
+
+## Assertions Checklist
+
+Each checkbox maps to an acceptance criterion from the spec.
+
+- [ ] AC1: When retry budget exhausted and HEAD SHA has CodeRabbit `SUCCESS` commit-status and no blocking inline comments → `RESULT=clean`, `REASON=coderabbit_status_success_fallback`, exit 0
+- [ ] AC2: When retry budget exhausted and NO CodeRabbit `SUCCESS` commit-status → behavior unchanged; falls through to stale-findings/skipped/escalate paths
+- [ ] AC3: When blocking CodeRabbit inline comments (Critical or Major) are present → fallback does not apply; `RESULT=needs_fixes` regardless of commit-status
+- [ ] AC4: `REASON=coderabbit_status_success_fallback` key-value is present in script output when fallback triggers
+- [ ] AC5: Greptile and Devin platform handlers contain no references to the new fallback logic
+- [ ] AC6: `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` Step 3.7 documents the new fallback behavior
+
+---
+
+## Seed Data Reference
+
+| Entity | Scenario | How to load |
+|---|---|---|
+| N/A | Shell script test — no application seed data required | — |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Script still returns `skipped (no_review)` even with SUCCESS commit-status | Fallback not inserted before stale-findings block | Verify insertion point is before the stale-findings `stale_comments` query |
+| `jq` filter returns 0 even when status exists | Context name mismatch | Check the actual `.context` value in the API response and update the `test("coderabbit")` filter if needed |
+| `gh api` returns paginated results that miss the status | Missing `--paginate` flag | Confirm `--paginate` is included in the API call |
+| Phase 1 returns `needs_fixes` before fallback runs | Blocking comments exist from a prior commit and are being picked up | Verify `since_iso` is correctly set to the HEAD commit timestamp |
+
+---
+
+## Known Limitations
+
+- Live testing of the full fallback path requires a PR in a CodeRabbit rate-limited state, which is difficult to reproduce on demand. Code-inspection verification (Steps 1-3 and 7) provides deterministic coverage for the structural requirements.
+- The `--max-wait 2` / `--poll-interval 1` workaround in Steps 4-6 approximates retry budget exhaustion but skips the actual polling loop. In production, the fallback is only reached after the full `max_wait` (default 20 minutes).

--- a/docs/testing/workflow/coderabbit-success-fallback.smoke-test.md
+++ b/docs/testing/workflow/coderabbit-success-fallback.smoke-test.md
@@ -65,7 +65,7 @@ Before running this smoke test:
 
 **Maps to**: Acceptance Criterion 5 — Greptile and Devin platform handlers are unaffected.
 
-1. Search `run_greptile_review()` for any reference to `commit-status`, `statuses`, or `coderabbit_success_status_fallback`.
+1. Search `run_greptile_review()` for any reference to `commit-status`, `statuses`, or `coderabbit_status_success_fallback`.
 2. Search `run_devin_review()` for the same.
 
 **Expected result**: Neither `run_greptile_review()` nor `run_devin_review()` contain any reference to the new fallback logic.
@@ -134,11 +134,13 @@ Before running this smoke test:
 
 ---
 
-### Step 6: Live test — Blocking inline comments present even with SUCCESS commit-status (Acceptance Criterion 3)
+### Step 6: Live test — Blocking inline comments present on current HEAD even with SUCCESS commit-status (Acceptance Criterion 3)
 
 **Maps to**: Acceptance Criterion 3
 
-1. On the same PR from Step 4 (SUCCESS commit-status present), verify that there IS at least one unresolved blocking CodeRabbit inline comment (severity 🔴 Critical or 🟠 Major) on the current HEAD.
+> The most practical way to test this scenario is with blocking inline comments posted **after** the HEAD commit timestamp (i.e., truly "on the current HEAD" from the script's perspective). In this case, Phase 1 of `run_coderabbit_review()` (`pr-review-loop.sh` lines 831–895) intercepts them before the polling loop starts, and the fallback is never reached.
+
+1. On the same PR from Step 4 (SUCCESS commit-status present), verify that there IS at least one unresolved blocking CodeRabbit inline comment (severity 🔴 Critical or 🟠 Major) whose `created_at` timestamp is **after** the HEAD commit's committer timestamp (`since_iso`).
 2. Run the script with a very short `max_wait`:
    ```bash
    CODERABBIT_RATE_LIMIT_MAX_RETRIES=0 \
@@ -152,12 +154,12 @@ Before running this smoke test:
 
 **Expected result**:
 - `RESULT=needs_fixes`
-- `REASON=stale_findings`
+- `REASON=existing_findings` (Phase 1 intercepts the blocking comment before the polling loop starts)
 - `BLOCKING_COUNT` is greater than 0
-- Script does NOT output `REASON=coderabbit_status_success_fallback`
+- Script does NOT output `REASON=coderabbit_status_success_fallback` (the fallback is never reached when Phase 1 finds blocking comments)
 - Script exits with code `1`
 
-> Note: The Phase 1 (existing-blocking-findings) check runs before the polling loop. If the blocking comments are found in Phase 1 (before the loop), the script returns `needs_fixes` from Phase 1 — the fallback is never reached. Either Phase 1 or the stale-findings path will catch blocking comments; the fallback does not apply in either case.
+> Note: Phase 1 (`existing-blocking-findings` check) runs before the polling loop and before the SUCCESS-status fallback. When blocking inline comments are present on the current HEAD, Phase 1 returns `REASON=existing_findings` immediately. The SUCCESS commit-status fallback is only reachable when `coderabbit_any_activity -eq 0` after the full polling loop completes — a condition that cannot occur when Phase 1 already found blocking findings and returned early.
 
 ---
 


### PR DESCRIPTION
## Summary

Implementation plan for issue #166: fix `pr-review-loop.sh` to treat an existing CodeRabbit `SUCCESS` commit-status as a clean result when the retry budget is exhausted during rate-limit windows.

**Spec**: [1_coderabbit-success-fallback_specs.md](docs/specs/developments/20260416120000_coderabbit-success-fallback/1_coderabbit-success-fallback_specs.md)
**Plan**: [2_coderabbit-success-fallback_implementation-plan.md](docs/specs/developments/20260416120000_coderabbit-success-fallback/2_coderabbit-success-fallback_implementation-plan.md)
**Smoke test runbook**: [coderabbit-success-fallback.smoke-test.md](docs/testing/workflow/coderabbit-success-fallback.smoke-test.md)

## Approach

- **Complexity**: S (small — single insertion point in `run_coderabbit_review()`)
- **Strategy**: Insert a GitHub commit-status API check after rate-limit retry budget is exhausted, before stale-findings recovery. If a CodeRabbit `SUCCESS` status exists on the current HEAD SHA and no blocking inline comments are present, return `clean` with `REASON=coderabbit_status_success_fallback`.
- **Scope**: `scripts/development-workflow/pr-review-loop.sh` (one new code block) + `docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` Step 3.7 (documentation update).

## Key Risks

- GitHub statuses API paginates: plan uses `--paginate` to fetch all pages.
- CodeRabbit context name stability: filter uses case-insensitive substring match on `coderabbit`.
- Stale status from prior HEAD: not possible — statuses endpoint is scoped to `head_sha`.

## Dependencies

None