### PR TITLE
docs(plan): markdown lint for plan and spec docs (#173)

### DIFF
--- a/docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/2_173-markdown-lint-plan-spec-docs_implementation-plan.md
+++ b/docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/2_173-markdown-lint-plan-spec-docs_implementation-plan.md
@@ -30,7 +30,7 @@
   - Accepts one or more file paths as positional arguments; exits 0 if no violations, exits 1 if any violations found.
   - The cue list for GLOB001 is declared as a top-level constant in the script so contributors can extend it without changing the detection logic.
 - [ ] Add `scripts/lint/` directory with a `README.md` briefly describing the scripts it contains and their invocation.
-- [ ] Create a new `package.json` at the repository root (no root-level `package.json` exists yet; the `e2e/package.json` is scoped to the Playwright suite and must not be modified for this feature) declaring `markdownlint-cli2` and `markdownlint-rule-relative-links` as `devDependencies`; pin to specific versions. Run `npm install` to generate the accompanying `package-lock.json`.
+- [ ] Create a new `package.json` at the repository root (no root-level `package.json` exists yet; the `e2e/package.json` is scoped to the Playwright suite and must not be modified for this feature) declaring `markdownlint-cli2` and `markdownlint-rule-relative-links` as `devDependencies`. Pin each dependency to the latest stable version available at implementation time using an exact version specifier (no `^` or `~`) so CI does not silently pick up upstream changes. Run `npm install` to generate the accompanying `package-lock.json`.
 - [ ] Baseline cleanup: scan all files under `docs/specs/developments/`, `docs/testing/workflow/`, and `CHANGELOG.md` with both the markdownlint-cli2 rules and the heuristic script; fix any violations directly (remove trailing whitespace, fix broken relative links, correct count phrases or list lengths, correct glob patterns) or add an inline suppression with a reviewer-visible rationale where a fix is not appropriate.
 
 ---

--- a/docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/2_173-markdown-lint-plan-spec-docs_implementation-plan.md
+++ b/docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/2_173-markdown-lint-plan-spec-docs_implementation-plan.md
@@ -74,7 +74,7 @@ None — this feature has no database layer or application state. The "data" is 
 |---|---|---|---|
 | `markdownlint-rule-relative-links` produces false positives on intentional placeholder links or in-document anchors | Med | Med | Inline suppression is available; out-of-scope link types (anchors, external URLs) are explicitly excluded from the rule configuration |
 | Heuristic count-disagreement check fires on numeric content unrelated to lists (version numbers, durations) | Med | Low | The regex is scoped to count-of-items phrasing keywords ("acceptance criteria", "use cases", "steps", "items"); inline suppression is available |
-| Baseline cleanup surfaces many violations, delaying the PR | Med | Med | Scan the baseline before writing other plan artefacts (Step 1 of implementation order); block the PR only after cleanup is included in the same commit |
+| Baseline cleanup surfaces many violations, delaying the PR | Med | Med | Scan the baseline before writing other plan artefacts (Step 5 of implementation order); block the PR only after cleanup is included in the same commit |
 | `markdownlint-cli2` npm install time slows CI | Low | Low | Cache `node_modules` with `actions/cache` keyed on `package-lock.json` |
 | Python 3 unavailable on the GitHub-hosted runner image | Low | High | GitHub-hosted `ubuntu-latest` includes Python 3 by default; verify in the first CI run |
 

--- a/docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/2_173-markdown-lint-plan-spec-docs_implementation-plan.md
+++ b/docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/2_173-markdown-lint-plan-spec-docs_implementation-plan.md
@@ -1,0 +1,94 @@
+# Markdown Lint for Plan and Spec Docs — Implementation Plan
+
+**Spec**: [1_173-markdown-lint-plan-spec-docs_specs.md](./1_173-markdown-lint-plan-spec-docs_specs.md)
+**Smoke test runbook**: [docs/testing/workflow/173-markdown-lint-plan-spec-docs.smoke-test.md](../../../testing/workflow/173-markdown-lint-plan-spec-docs.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add a new GitHub Actions workflow (`markdown-lint.yml`) that runs on every pull request touching `docs/specs/developments/`, `docs/testing/workflow/`, or `CHANGELOG.md`. The workflow uses `markdownlint-cli2` (npm) for standard rules (trailing whitespace, relative-link validation) together with a custom Python script for the two heuristic rules (suspicious glob patterns and within-document count disagreements). Existing baseline violations in all target files are resolved or suppressed in the same implementation PR so the check is green from day one.
+
+**Estimated complexity**: M
+
+**Rationale**: The standard rules (trailing whitespace, broken relative links) are well-served by `markdownlint-cli2` and the `markdownlint-rule-relative-links` plugin; these are battle-tested npm packages with inline-suppression support. The two heuristic rules (glob pattern mismatch, count disagreement) require custom logic that no off-the-shelf markdownlint rule provides — a small Python script handles these cleanly without additional runtime dependencies beyond the standard GitHub-hosted runner. The baseline cleanup effort is bounded (the target file set is small) but requires careful scanning.
+
+**Dependencies**: None
+
+---
+
+## Layer-by-Layer Changes
+
+### Infrastructure / Configuration
+
+- [ ] Create `.github/workflows/markdown-lint.yml` — new GitHub Actions workflow triggered on `pull_request` for paths `docs/specs/developments/**`, `docs/testing/workflow/**`, and `CHANGELOG.md`; runs `markdownlint-cli2` and the custom heuristic script.
+- [ ] Create `.markdownlint.jsonc` at the repository root — markdownlint-cli2 configuration enabling rules MD009 (trailing whitespace, hard-break exception), MD047 (files end with newline), and the `markdownlint-rule-relative-links` plugin for relative-link checking; disabling all other default rules that are not in scope.
+- [ ] Create `scripts/lint/markdown-heuristic-lint.py` — custom Python 3 script implementing the two heuristic checks:
+  - **Suspicious glob**: scans each input file for code blocks containing non-recursive globs (e.g., `*.sh`, `*.md`) while the surrounding document prose within a configurable window uses any phrase from a declared cue list (e.g., "subdirectories", "recursively", "under the tree", "all files in", "in all subdirectories"); emits `file:line: GLOB001 Suspicious non-recursive glob '<pattern>' — surrounding prose suggests recursion ('<cue>'); use '**/<pattern>' or suppress inline`.
+  - **Count disagreement**: scans each input file for narrative count phrases (e.g., "4 acceptance criteria", "three use cases", "N steps") in digits or written-out numerals (0–20), then counts items in the list or section that immediately follows (within 30 lines); emits `file:line: COUNT001 Count disagreement — stated '<N> <label>' but found <actual> items; update the narrative or the list, or suppress inline`.
+  - Supports inline suppression via `<!-- markdown-heuristic-disable GLOB001 -->` and `<!-- markdown-heuristic-disable COUNT001 -->` on the same or preceding line.
+  - Accepts one or more file paths as positional arguments; exits 0 if no violations, exits 1 if any violations found.
+  - The cue list for GLOB001 is declared as a top-level constant in the script so contributors can extend it without changing the detection logic.
+- [ ] Add `scripts/lint/` directory with a `README.md` briefly describing the scripts it contains and their invocation.
+- [ ] Create `package.json` (or extend an existing one at the root) declaring `markdownlint-cli2` and `markdownlint-rule-relative-links` as `devDependencies`; pin to specific versions. If a root `package.json` already exists, add to `devDependencies` only.
+- [ ] Baseline cleanup: scan all files under `docs/specs/developments/`, `docs/testing/workflow/`, and `CHANGELOG.md` with both the markdownlint-cli2 rules and the heuristic script; fix any violations directly (remove trailing whitespace, fix broken relative links, correct count phrases or list lengths, correct glob patterns) or add an inline suppression with a reviewer-visible rationale where a fix is not appropriate.
+
+---
+
+## Testing Strategy
+
+**Test types**: Smoke (manual CI trigger via PR; verifying green/red states)
+
+**Key scenarios to test**:
+
+1. PR touching only non-target markdown files — lint check passes or is skipped (AC5)
+2. PR introducing a trailing-whitespace violation in a spec file — lint check fails with file/line detail (AC3, AC1)
+3. PR introducing a broken relative link in a plan file — lint check fails with broken-link detail (AC2, AC1)
+4. PR with no violations — lint check passes green (AC4)
+5. PR with an inline suppression directive covering a violation — lint check passes (AC6)
+6. CHANGELOG.md trailing whitespace — lint check fails (AC8)
+7. Suspicious glob pattern with recursive prose — heuristic check fails (AC9)
+8. Within-document count disagreement — heuristic check fails (AC10)
+9. Implementation PR itself is green with no suppressions or with only documented suppressions (AC7)
+
+**Smoke test runbook**: [`docs/testing/workflow/173-markdown-lint-plan-spec-docs.smoke-test.md`](../../../testing/workflow/173-markdown-lint-plan-spec-docs.smoke-test.md)
+
+---
+
+## Seed Data
+
+None — this feature has no database layer or application state. The "data" is the markdown files in the repository, which are already present.
+
+---
+
+## Documentation Updates
+
+- [ ] `AGENTS.md` (via `CLAUDE.md` symlink) — add a note in the **Common Commands** or **Troubleshooting** section describing how to run the markdown lint check locally: `npx markdownlint-cli2 <files>` and `python3 scripts/lint/markdown-heuristic-lint.py <files>`.
+- [ ] `docs/best-practices/1-general.md` — add a bullet under **Formatting** pointing contributors to the markdown lint rules for spec/plan/CHANGELOG files, referencing `.markdownlint.jsonc`.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `markdownlint-rule-relative-links` produces false positives on intentional placeholder links or in-document anchors | Med | Med | Inline suppression is available; out-of-scope link types (anchors, external URLs) are explicitly excluded from the rule configuration |
+| Heuristic count-disagreement check fires on numeric content unrelated to lists (version numbers, durations) | Med | Low | The regex is scoped to count-of-items phrasing keywords ("acceptance criteria", "use cases", "steps", "items"); inline suppression is available |
+| Baseline cleanup surfaces many violations, delaying the PR | Med | Med | Scan the baseline before writing other plan artefacts (Step 1 of implementation order); block the PR only after cleanup is included in the same commit |
+| `markdownlint-cli2` npm install time slows CI | Low | Low | Cache `node_modules` with `actions/cache` keyed on `package-lock.json` |
+| Python 3 unavailable on the GitHub-hosted runner image | Low | High | GitHub-hosted `ubuntu-latest` includes Python 3 by default; verify in the first CI run |
+
+---
+
+## Implementation Order
+
+1. Create the `scripts/lint/` directory and write `markdown-heuristic-lint.py` with both heuristic checks (GLOB001, COUNT001), inline suppression support, and the declared cue list constant.
+2. Add `scripts/lint/README.md` briefly describing the script and its invocation.
+3. Create or update `package.json` at the repository root to add `markdownlint-cli2` and `markdownlint-rule-relative-links` as `devDependencies`; run `npm install` to generate / update `package-lock.json`.
+4. Create `.markdownlint.jsonc` at the repository root with the scoped rule set (MD009 with hard-break exception, relative-link plugin enabled, all out-of-scope default rules disabled).
+5. Scan all baseline files (`docs/specs/developments/**/*.md`, `docs/testing/workflow/**/*.md`, `CHANGELOG.md`) with `markdownlint-cli2` and `python3 scripts/lint/markdown-heuristic-lint.py`; fix all violations directly or add inline suppressions with reviewer-visible rationale.
+6. Create `.github/workflows/markdown-lint.yml` with path-filtered `pull_request` trigger, `npm ci`, `markdownlint-cli2` step, and heuristic script step.
+7. Run the full lint check locally against the implementation branch's files to confirm the check exits green.
+8. Update `AGENTS.md` with the local-run commands and update `docs/best-practices/1-general.md` with the formatting note.
+9. Update `CHANGELOG.md` under `[Unreleased]` with a new entry for this feature.
+10. Verify smoke test runbook scenarios manually or via a draft PR CI run.

--- a/docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/2_173-markdown-lint-plan-spec-docs_implementation-plan.md
+++ b/docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/2_173-markdown-lint-plan-spec-docs_implementation-plan.md
@@ -30,7 +30,7 @@
   - Accepts one or more file paths as positional arguments; exits 0 if no violations, exits 1 if any violations found.
   - The cue list for GLOB001 is declared as a top-level constant in the script so contributors can extend it without changing the detection logic.
 - [ ] Add `scripts/lint/` directory with a `README.md` briefly describing the scripts it contains and their invocation.
-- [ ] Create `package.json` (or extend an existing one at the root) declaring `markdownlint-cli2` and `markdownlint-rule-relative-links` as `devDependencies`; pin to specific versions. If a root `package.json` already exists, add to `devDependencies` only.
+- [ ] Create a new `package.json` at the repository root (no root-level `package.json` exists yet; the `e2e/package.json` is scoped to the Playwright suite and must not be modified for this feature) declaring `markdownlint-cli2` and `markdownlint-rule-relative-links` as `devDependencies`; pin to specific versions. Run `npm install` to generate the accompanying `package-lock.json`.
 - [ ] Baseline cleanup: scan all files under `docs/specs/developments/`, `docs/testing/workflow/`, and `CHANGELOG.md` with both the markdownlint-cli2 rules and the heuristic script; fix any violations directly (remove trailing whitespace, fix broken relative links, correct count phrases or list lengths, correct glob patterns) or add an inline suppression with a reviewer-visible rationale where a fix is not appropriate.
 
 ---

--- a/docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/2_173-markdown-lint-plan-spec-docs_implementation-plan.md
+++ b/docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/2_173-markdown-lint-plan-spec-docs_implementation-plan.md
@@ -30,7 +30,7 @@
   - Accepts one or more file paths as positional arguments; exits 0 if no violations, exits 1 if any violations found.
   - The cue list for GLOB001 is declared as a top-level constant in the script so contributors can extend it without changing the detection logic.
 - [ ] Add `scripts/lint/` directory with a `README.md` briefly describing the scripts it contains and their invocation.
-- [ ] Create a new `package.json` at the repository root (no root-level `package.json` exists yet; the `e2e/package.json` is scoped to the Playwright suite and must not be modified for this feature) declaring `markdownlint-cli2` and `markdownlint-rule-relative-links` as `devDependencies`. Pin each dependency to the latest stable version available at implementation time using an exact version specifier (no `^` or `~`) so CI does not silently pick up upstream changes. Run `npm install` to generate the accompanying `package-lock.json`.
+- [ ] Create a new `package.json` at the repository root (no root-level `package.json` exists yet; the `e2e/package.json` is scoped to the Playwright suite and must not be modified for this feature) declaring `markdownlint-cli2` and `markdownlint-rule-relative-links` as `devDependencies`. Pin each dependency to the latest stable version available at implementation time using an exact version specifier (no `^` or `~`) so CI does not silently pick up upstream changes. Run `npm install` to generate the accompanying `package-lock.json`. Add `node_modules/` to the root `.gitignore` (the current root `.gitignore` does not exclude it; only `e2e/.gitignore` covers its own scope) to prevent accidentally committing generated npm packages.
 - [ ] Baseline cleanup: scan all files under `docs/specs/developments/`, `docs/testing/workflow/`, and `CHANGELOG.md` with both the markdownlint-cli2 rules and the heuristic script; fix any violations directly (remove trailing whitespace, fix broken relative links, correct count phrases or list lengths, correct glob patterns) or add an inline suppression with a reviewer-visible rationale where a fix is not appropriate.
 
 ---
@@ -84,7 +84,7 @@ None — this feature has no database layer or application state. The "data" is 
 
 1. Create the `scripts/lint/` directory and write `markdown-heuristic-lint.py` with both heuristic checks (GLOB001, COUNT001), inline suppression support, and the declared cue list constant.
 2. Add `scripts/lint/README.md` briefly describing the script and its invocation.
-3. Create or update `package.json` at the repository root to add `markdownlint-cli2` and `markdownlint-rule-relative-links` as `devDependencies`; run `npm install` to generate / update `package-lock.json`.
+3. Create the root `package.json` with `markdownlint-cli2` and `markdownlint-rule-relative-links` as exact-version `devDependencies`; run `npm install` to generate `package-lock.json`; add `node_modules/` to the root `.gitignore` (currently absent from root `.gitignore`).
 4. Create `.markdownlint.jsonc` at the repository root with the scoped rule set (MD009 with hard-break exception, relative-link plugin enabled, all out-of-scope default rules disabled).
 5. Scan all baseline files (`docs/specs/developments/**/*.md`, `docs/testing/workflow/**/*.md`, `CHANGELOG.md`) with `markdownlint-cli2` and `python3 scripts/lint/markdown-heuristic-lint.py`; fix all violations directly or add inline suppressions with reviewer-visible rationale.
 6. Create `.github/workflows/markdown-lint.yml` with path-filtered `pull_request` trigger, `npm ci`, `markdownlint-cli2` step, and heuristic script step.

--- a/docs/testing/workflow/173-markdown-lint-plan-spec-docs.smoke-test.md
+++ b/docs/testing/workflow/173-markdown-lint-plan-spec-docs.smoke-test.md
@@ -170,8 +170,8 @@ Before running this smoke test:
    ```bash
    git checkout -b smoke-test/173-glob-heuristic develop
    ```
-2. Add the following content to a file under `docs/specs/developments/` (e.g., append to the spec file). The prose should contain "subdirectories" (or another recursive-language cue) while the code block contains a non-recursive glob such as `*.sh` — for example, a paragraph reading "Run the script on all files in subdirectories:" followed by a bash code block containing `find . -name "*.sh"`.
-   (Note: the prose says "subdirectories" but the find pattern is non-recursive.)
+2. Add the following content to a file under `docs/specs/developments/` (e.g., append to the spec file). The prose should contain "subdirectories" (or another recursive-language cue) while the code block contains a non-recursive glob such as `*.sh` — for example, a paragraph reading "Run the linter on all shell scripts in subdirectories:" followed by a bash code block containing `lint *.sh`.
+   (Note: the prose says "subdirectories" but `lint *.sh` only matches files in the current directory, not subdirectories — making this a genuine non-recursive pattern.)
 3. Commit and push, then open a draft PR targeting `develop`.
 4. Wait for the `Markdown Lint` CI check to complete.
 

--- a/docs/testing/workflow/173-markdown-lint-plan-spec-docs.smoke-test.md
+++ b/docs/testing/workflow/173-markdown-lint-plan-spec-docs.smoke-test.md
@@ -170,14 +170,7 @@ Before running this smoke test:
    ```bash
    git checkout -b smoke-test/173-glob-heuristic develop
    ```
-2. Add the following content to a file under `docs/specs/developments/` (e.g., append to the spec file):
-   ```markdown
-   Run the script on all files in subdirectories:
-
-   ```bash
-   find . -name "*.sh"
-   ```
-   ```
+2. Add the following content to a file under `docs/specs/developments/` (e.g., append to the spec file). The prose should contain "subdirectories" (or another recursive-language cue) while the code block contains a non-recursive glob such as `*.sh` — for example, a paragraph reading "Run the script on all files in subdirectories:" followed by a bash code block containing `find . -name "*.sh"`.
    (Note: the prose says "subdirectories" but the find pattern is non-recursive.)
 3. Commit and push, then open a draft PR targeting `develop`.
 4. Wait for the `Markdown Lint` CI check to complete.

--- a/docs/testing/workflow/173-markdown-lint-plan-spec-docs.smoke-test.md
+++ b/docs/testing/workflow/173-markdown-lint-plan-spec-docs.smoke-test.md
@@ -1,0 +1,274 @@
+# Smoke Test Runbook: Markdown Lint for Plan and Spec Docs
+
+**Feature**: Markdown Lint for Plan and Spec Docs (#173)
+**Spec**: [docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/1_173-markdown-lint-plan-spec-docs_specs.md](../../specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/1_173-markdown-lint-plan-spec-docs_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] The implementation PR has been merged into `develop`
+- [ ] You have a local checkout of `develop` (or a fresh branch from `develop`)
+- [ ] Node.js 20+ is available locally (for running `markdownlint-cli2`)
+- [ ] Python 3.8+ is available locally (for running `markdown-heuristic-lint.py`)
+- [ ] GitHub repository access to open pull requests and read CI check results
+
+---
+
+## Test Data
+
+| Item | Value |
+|---|---|
+| Target paths | `docs/specs/developments/`, `docs/testing/workflow/`, `CHANGELOG.md` |
+| Lint config | `.markdownlint.jsonc` at repo root |
+| Heuristic script | `scripts/lint/markdown-heuristic-lint.py` |
+| Workflow file | `.github/workflows/markdown-lint.yml` |
+| Inline suppression (markdownlint) | `<!-- markdownlint-disable MD009 -->` (or the relevant rule code) |
+| Inline suppression (heuristic) | `<!-- markdown-heuristic-disable GLOB001 -->` or `<!-- markdown-heuristic-disable COUNT001 -->` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify the markdown lint CI check exists on a spec/plan PR
+
+**Maps to**: AC1
+
+1. Open (or find) any open pull request that modifies a file under `docs/specs/developments/` or `docs/testing/workflow/`.
+2. Navigate to the PR's **Checks** tab on GitHub.
+3. Confirm a check named `Markdown Lint` (or similar) appears in the list.
+
+**Expected result**: The `Markdown Lint` CI check is present on the PR checks list.
+
+---
+
+### Step 2: PR with trailing whitespace — check fails
+
+**Maps to**: AC1, AC3
+
+1. Create a test branch from `develop`:
+   ```bash
+   git checkout -b smoke-test/173-trailing-ws develop
+   ```
+2. Add a trailing space to any line in a file under `docs/specs/developments/` (e.g., append a space to a line in the spec file).
+3. Commit and push, then open a draft PR targeting `develop`.
+4. Wait for the `Markdown Lint` CI check to complete.
+
+**Expected result**: The `Markdown Lint` CI check exits red. The check output shows the file path, line number, and rule description (`MD009` or equivalent) for the trailing-whitespace violation.
+
+---
+
+### Step 3: Hard line break is not flagged as trailing whitespace
+
+**Maps to**: AC3
+
+1. In the same test branch (or a new one), add a line ending with exactly two spaces (intentional Markdown hard line break) to a spec or plan file.
+2. Commit and push.
+3. Wait for the `Markdown Lint` CI check to complete.
+
+**Expected result**: The `Markdown Lint` CI check does not flag the two-space hard line break as a trailing-whitespace violation (the check exits green if no other violations are present).
+
+---
+
+### Step 4: PR with a broken relative link — check fails
+
+**Maps to**: AC1, AC2
+
+1. Create a test branch from `develop`:
+   ```bash
+   git checkout -b smoke-test/173-broken-link develop
+   ```
+2. Add a relative link pointing to a nonexistent file to any spec or plan document:
+   ```markdown
+   See [nonexistent file](../../nonexistent-doc.md) for details.
+   ```
+3. Commit and push, then open a draft PR targeting `develop`.
+4. Wait for the `Markdown Lint` CI check to complete.
+
+**Expected result**: The `Markdown Lint` CI check exits red. The output shows the file path, line number, and the broken relative link target.
+
+---
+
+### Step 5: PR with no violations — check passes
+
+**Maps to**: AC4
+
+1. Create a test branch from `develop`:
+   ```bash
+   git checkout -b smoke-test/173-clean develop
+   ```
+2. Make a trivial, lint-clean change to a file under `docs/specs/developments/` (e.g., add a line with no trailing whitespace, no broken links).
+3. Commit and push, then open a draft PR targeting `develop`.
+4. Wait for the `Markdown Lint` CI check to complete.
+
+**Expected result**: The `Markdown Lint` CI check exits green.
+
+---
+
+### Step 6: PR touching only non-target files — check passes or is skipped
+
+**Maps to**: AC5
+
+1. Create a test branch from `develop`:
+   ```bash
+   git checkout -b smoke-test/173-non-target develop
+   ```
+2. Modify only a file outside the three target paths (e.g., `docs/project/1-business-domain.md` or a shell script).
+3. Commit and push, then open a draft PR targeting `develop`.
+4. Wait for the CI checks to complete.
+
+**Expected result**: The `Markdown Lint` CI check either does not appear (path-filtered out) or appears and exits green with a "no target files changed" message. The PR is not blocked by the lint check.
+
+---
+
+### Step 7: Inline suppression silences a violation
+
+**Maps to**: AC6
+
+1. Create a test branch from `develop`:
+   ```bash
+   git checkout -b smoke-test/173-suppression develop
+   ```
+2. Add a trailing-whitespace line to a spec file.
+3. On the same line or the line above the violation, add the markdownlint inline suppression:
+   ```markdown
+   <!-- markdownlint-disable-next-line MD009 -->
+   This line has a trailing space intentionally.   
+   ```
+4. Commit and push, then open a draft PR targeting `develop`.
+5. Wait for the `Markdown Lint` CI check to complete.
+
+**Expected result**: The `Markdown Lint` CI check exits green for the suppressed finding. The suppression directive is visible in the diff.
+
+---
+
+### Step 8: CHANGELOG.md trailing whitespace is caught
+
+**Maps to**: AC8
+
+1. Create a test branch from `develop`:
+   ```bash
+   git checkout -b smoke-test/173-changelog-ws develop
+   ```
+2. Add a trailing space to a line in `CHANGELOG.md`.
+3. Commit and push, then open a draft PR targeting `develop`.
+4. Wait for the `Markdown Lint` CI check to complete.
+
+**Expected result**: The `Markdown Lint` CI check exits red and reports the trailing-whitespace violation in `CHANGELOG.md`.
+
+---
+
+### Step 9: Suspicious glob pattern heuristic fires
+
+**Maps to**: AC9
+
+1. Create a test branch from `develop`:
+   ```bash
+   git checkout -b smoke-test/173-glob-heuristic develop
+   ```
+2. Add the following content to a file under `docs/specs/developments/` (e.g., append to the spec file):
+   ```markdown
+   Run the script on all files in subdirectories:
+
+   ```bash
+   find . -name "*.sh"
+   ```
+   ```
+   (Note: the prose says "subdirectories" but the find pattern is non-recursive.)
+3. Commit and push, then open a draft PR targeting `develop`.
+4. Wait for the `Markdown Lint` CI check to complete.
+
+**Expected result**: The `Markdown Lint` CI check exits red. The output shows the file path, the line of the glob pattern, the triggering prose excerpt (containing "subdirectories"), and rule code `GLOB001`.
+
+---
+
+### Step 10: Within-document count disagreement heuristic fires
+
+**Maps to**: AC10
+
+1. Create a test branch from `develop`:
+   ```bash
+   git checkout -b smoke-test/173-count-heuristic develop
+   ```
+2. Add the following content to a file under `docs/specs/developments/`:
+   ```markdown
+   There are 4 acceptance criteria:
+
+   - AC1: First criterion
+   - AC2: Second criterion
+   - AC3: Third criterion
+   ```
+   (The prose says "4" but only 3 items follow.)
+3. Commit and push, then open a draft PR targeting `develop`.
+4. Wait for the `Markdown Lint` CI check to complete.
+
+**Expected result**: The `Markdown Lint` CI check exits red. The output shows the file path, the line of the count phrase, the stated count (4), and the actual count (3), with rule code `COUNT001`.
+
+---
+
+### Step 11: Verify the implementation PR itself is green (baseline check)
+
+**Maps to**: AC7
+
+1. Navigate to the closed implementation PR for issue #173 on GitHub.
+2. Check the `Markdown Lint` CI check result on that PR.
+
+**Expected result**: The `Markdown Lint` CI check was green on the implementation PR, confirming no unresolved baseline violations exist in the merged files.
+
+---
+
+### Last Step: Clean up smoke test branches
+
+1. Delete all `smoke-test/173-*` branches created during this runbook (locally and remotely).
+2. Confirm no open smoke-test PRs remain.
+
+---
+
+## Assertions Checklist
+
+Each checkbox maps to an acceptance criterion from the spec.
+
+- [ ] AC1: A CI check runs on PRs touching target markdown paths and exits red when a configured rule is violated.
+- [ ] AC2: Broken relative links are detected and reported with file path, line number, and broken link target.
+- [ ] AC3: Trailing whitespace is detected and reported; intentional two-space hard line breaks are not flagged.
+- [ ] AC4: The check exits green when no violations are present.
+- [ ] AC5: PRs touching only non-target files are not blocked by the markdown lint check.
+- [ ] AC6: An inline suppression directive causes the check to exit green for that specific finding.
+- [ ] AC7: The check was green on the implementation PR itself (no unresolved baseline violations).
+- [ ] AC8: Trailing whitespace in `CHANGELOG.md` is caught by the same check.
+- [ ] AC9: Suspicious glob patterns (non-recursive glob with recursive prose) are detected and reported with file path, glob line, and triggering prose excerpt (GLOB001).
+- [ ] AC10: Within-document count disagreements are detected and reported with file path, count-phrase line, stated count, and actual count (COUNT001).
+
+---
+
+## Seed Data Reference
+
+None — this feature operates on repository files; no database seed data is required.
+
+| Entity | Scenario | How to load |
+|---|---|---|
+| Spec/plan files | Files under `docs/specs/developments/` already present in the repository | Already in repository; no additional loading needed |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Markdown Lint` check does not appear on a PR | PR does not touch any path in the workflow's path filter | Confirm the PR modifies at least one file under `docs/specs/developments/`, `docs/testing/workflow/`, or `CHANGELOG.md` |
+| `markdownlint-cli2` not found in CI | `npm ci` step failed or `package.json` is missing the dependency | Check the workflow logs for the `npm ci` step; verify `package.json` lists `markdownlint-cli2` in `devDependencies` |
+| Heuristic script exits with `python3: command not found` | Runner image lacks Python 3 | Add a `setup-python` step in the workflow before the heuristic script step |
+| False positive on a relative link that intentionally does not resolve | The lint tool resolves the link relative to the file and the target is absent | Add an inline `<!-- markdownlint-disable-next-line relative-links -->` suppression with a rationale comment |
+| Count heuristic fires on a version number or duration phrase | Regex too broad | Check whether the phrase matches count-of-items keywords ("acceptance criteria", "use cases", "steps", "items"); if it is a genuine false positive, add `<!-- markdown-heuristic-disable COUNT001 -->` on the triggering line |
+
+---
+
+## Known Limitations
+
+- The suspicious-glob heuristic is correlation-based: it matches recursive-language cues and non-recursive globs within the same document, not necessarily in the same paragraph. Inline suppression is always available for confirmed false positives.
+- The count-disagreement heuristic looks ahead at most 30 lines from the count phrase to find the corresponding list. Lists separated from their count phrase by large blocks of text may not be correlated correctly.
+- External URLs (http/https) are not checked for liveness (by design — network-free lint only).


### PR DESCRIPTION
## Summary

Adds the implementation plan and smoke test runbook for issue #173 — automated markdown lint CI check for spec, plan, and CHANGELOG documents.

**Approach**: New GitHub Actions workflow (`markdown-lint.yml`) with path-filtered trigger on `docs/specs/developments/`, `docs/testing/workflow/`, and `CHANGELOG.md`. Uses `markdownlint-cli2` + `markdownlint-rule-relative-links` for standard rules, plus a custom Python heuristic script for the two advanced checks (suspicious glob patterns and within-document count disagreements).

**Complexity**: M — standard CI workflow plus a small custom Python script; bounded baseline cleanup effort.

**Key risks**: Heuristic rules may produce false positives on legitimate content (mitigated by inline suppression support); baseline cleanup scope is unknown until the scanner runs.

**Artefacts**:
- Plan: `docs/specs/developments/20260416180000_173-markdown-lint-plan-spec-docs/2_173-markdown-lint-plan-spec-docs_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/173-markdown-lint-plan-spec-docs.smoke-test.md`

**Dependencies**: None

Closes #173 (plan stage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an implementation plan detailing CI check, config, local run/format guidance, baseline cleanup, and rollout steps for a Markdown Lint system targeting plan/spec docs
  * Added a comprehensive smoke test runbook with step-by-step validation scenarios, acceptance criteria, and troubleshooting notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->