### PR TITLE
docs(plan): developer agent CHANGELOG trailing-whitespace prevention

### DIFF
--- a/docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/2_178-changelog-trailing-whitespace_implementation-plan.md
+++ b/docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/2_178-changelog-trailing-whitespace_implementation-plan.md
@@ -103,7 +103,7 @@ No other project docs (`docs/project/`, `docs/best-practices/`, `AGENTS.md`, etc
    ```bash
    npx markdownlint-cli2 "docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/*.md" "docs/testing/workflow/178-changelog-trailing-whitespace.smoke-test.md"
    ```
-7. Commit with message: `fix(developer-agent): add CHANGELOG trailing-whitespace verification step`
-8. Push branch and open a draft PR targeting `develop`.
-9. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry.
+7. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry.
+8. Commit with message: `fix(developer-agent): add CHANGELOG trailing-whitespace verification step`
+9. Push branch and open a draft PR targeting `develop`.
 10. Verify smoke test runbook assertions manually.

--- a/docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/2_178-changelog-trailing-whitespace_implementation-plan.md
+++ b/docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/2_178-changelog-trailing-whitespace_implementation-plan.md
@@ -28,7 +28,7 @@
   - **Hotfix Path 4, Step 6** (`### Step 6: Update CHANGELOG`): add the same verification instruction.
   - The instruction must cover both defect patterns (trailing whitespace on any line, two or more consecutive blank lines at the end of the entry), state that intentional two-space Markdown hard line breaks must not be treated as violations, and clarify that the check runs after writing the entry and before staging.
 
-- [ ] `.claude/agents/developer.md` — Add a key rule that states the CHANGELOG entry must have no trailing whitespace or trailing blank lines before commit, alongside the existing CHANGELOG update reminder.
+- [ ] `.claude/agents/developer.md` and `.cursor/agents/developer.md` — Add the same key rule to the `Key rules:` bullet list of **both** files (they share an identical key-rules section and must stay in sync): the CHANGELOG entry must have no trailing whitespace or trailing blank lines before commit, alongside the existing CHANGELOG update reminder.
 
 ---
 
@@ -39,7 +39,7 @@
 **Key scenarios to test**:
 
 1. Verify that `03-implement-development-protocol.md` contains the CHANGELOG verification instruction in all four implementation paths (Full Pipeline Step 6, Refactor Step 6, Fast Track Step 6, Hotfix Step 6) — maps to AC1, AC3, AC4.
-2. Verify that `.claude/agents/developer.md` key rules section mentions no trailing whitespace or trailing blank lines — maps to AC2.
+2. Verify that **both** `.claude/agents/developer.md` **and** `.cursor/agents/developer.md` key rules sections mention no trailing whitespace or trailing blank lines, and that both bullets are worded identically — maps to AC2.
 3. Verify the changes do not remove or conflict with any existing CHANGELOG update instructions — maps to AC5.
 
 **Smoke test runbook**: [`docs/testing/workflow/178-changelog-trailing-whitespace.smoke-test.md`](../../../testing/workflow/178-changelog-trailing-whitespace.smoke-test.md)
@@ -55,7 +55,7 @@ None — this feature is documentation/protocol-only. No runtime seed data is re
 ## Documentation Updates
 
 - [ ] `docs/ai/development-workflow/protocols/03-implement-development-protocol.md` — Updated as the primary deliverable (all four CHANGELOG update steps). No further documentation updates are needed beyond what is listed under Layer-by-Layer Changes.
-- [ ] `.claude/agents/developer.md` — Updated as the secondary deliverable (key rules section).
+- [ ] `.claude/agents/developer.md` and `.cursor/agents/developer.md` — Both updated as the secondary deliverable (the shared key rules section must receive the same new bullet in each file).
 
 No other project docs (`docs/project/`, `docs/best-practices/`, `AGENTS.md`, etc.) are affected by this change.
 
@@ -74,7 +74,7 @@ No other project docs (`docs/project/`, `docs/best-practices/`, `AGENTS.md`, etc
 ## Implementation Order
 
 1. Read the current text of `03-implement-development-protocol.md` in full, noting the exact location of Step 6 / the CHANGELOG update step in each of the four paths (Full Pipeline, Refactor, Fast Track, Hotfix).
-2. Read the current text of `.claude/agents/developer.md` in full, noting the key rules section.
+2. Read the current text of `.claude/agents/developer.md` and `.cursor/agents/developer.md` in full, noting the key rules section in each (they are currently identical and must stay so).
 3. **Cross-reference consistency check**: grep for `CHANGELOG` and `trailing` across `docs/`, `.claude/`, `.cursor/`, `.codex/`, `AGENTS.md`, `REVIEW.md` to ensure no other location mentions a contradictory rule or would also need updating.
 4. Edit `03-implement-development-protocol.md`:
    - In **Full Pipeline Path 1, Step 6**: append the verification sub-step immediately after the existing bullet list.
@@ -95,13 +95,19 @@ No other project docs (`docs/project/`, `docs/best-practices/`, `AGENTS.md`, etc
    > ```
    > If this returns output, fix the flagged lines before committing.
 
-5. Edit `.claude/agents/developer.md`:
+5. Edit **both** `.claude/agents/developer.md` **and** `.cursor/agents/developer.md` (both
+   files contain an identical `Key rules:` bullet list that must stay in sync per the
+   protocol's Quality Rule on cross-reference consistency):
    - In the key rules section (the bullet list after `Key rules:`), add the following bullet:
      > - CHANGELOG entries must have no trailing whitespace and no trailing blank lines before commit; verify in-place after writing the entry and before staging (intentional two-space Markdown hard line breaks are exempt)
 
-6. Run the markdown lint check on modified files to confirm no lint violations are introduced:
+6. Run the markdown lint check on the files actually modified in steps 4–5 to confirm no
+   lint violations are introduced:
    ```bash
-   npx markdownlint-cli2 "docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/*.md" "docs/testing/workflow/178-changelog-trailing-whitespace.smoke-test.md"
+   npx markdownlint-cli2 \
+     "docs/ai/development-workflow/protocols/03-implement-development-protocol.md" \
+     ".claude/agents/developer.md" \
+     ".cursor/agents/developer.md"
    ```
 7. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry.
 8. Commit with message: `fix(developer-agent): add CHANGELOG trailing-whitespace verification step`

--- a/docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/2_178-changelog-trailing-whitespace_implementation-plan.md
+++ b/docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/2_178-changelog-trailing-whitespace_implementation-plan.md
@@ -89,9 +89,9 @@ No other project docs (`docs/project/`, `docs/best-practices/`, `AGENTS.md`, etc
    > 1. **Trailing whitespace**: No line in the written entry should end with one or more whitespace characters. Note: intentional two-space Markdown hard line breaks (`<text>  ` with exactly two trailing spaces followed by a newline) are not trailing whitespace and must not be removed.
    > 2. **Trailing blank lines**: The entry must not end with two or more consecutive blank lines.
    >
-   > A quick shell check for trailing whitespace on staged CHANGELOG lines:
+   > A quick shell check for trailing whitespace on pending CHANGELOG changes (run **before** `git add`, per the "before staging" timing requirement):
    > ```bash
-   > git diff --cached CHANGELOG.md | grep '^+' | grep -P '\s+$'
+   > git diff CHANGELOG.md | grep '^+' | grep -P '\s+$'
    > ```
    > If this returns output, inspect each flagged line: leave intentional two-space Markdown hard line breaks (exactly two trailing spaces followed by a newline) intact, and fix any other trailing whitespace (e.g., a single trailing space, a tab, or three or more trailing spaces) before committing.
 

--- a/docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/2_178-changelog-trailing-whitespace_implementation-plan.md
+++ b/docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/2_178-changelog-trailing-whitespace_implementation-plan.md
@@ -7,11 +7,11 @@
 
 ## Summary
 
-**Approach**: Add an explicit, actionable CHANGELOG format verification instruction to every implementation path in `03-implement-development-protocol.md` (Full Pipeline Step 6, and equivalent CHANGELOG update steps in the Refactor, Fast Track, and Hotfix paths). Concurrently, add a matching rule to the developer agent's key rules section in `.claude/agents/developer.md` so the check is surfaced at agent initialization. Both changes are pure documentation and protocol text edits — no scripts, hooks, or CI changes are needed.
+**Approach**: Add an explicit, actionable CHANGELOG format verification instruction to every implementation path in `03-implement-development-protocol.md` (Full Pipeline Step 6, and equivalent CHANGELOG update steps in the Refactor, Fast Track, and Hotfix paths). Concurrently, add a matching rule to the developer agent's key rules section in **both** `.claude/agents/developer.md` **and** `.cursor/agents/developer.md` (the two agent files share an identical `Key rules:` section and must stay in sync) so the check is surfaced at agent initialization for both runners. All changes are pure documentation and protocol text edits — no scripts, hooks, or CI changes are needed.
 
 **Estimated complexity**: S
 
-**Rationale**: Only two files need targeted text additions. No code, schema, or CI configuration changes are required. The change is well-bounded and each insertion point is clearly identified by the spec.
+**Rationale**: Three files need targeted text additions — the protocol file plus the two parallel agent definitions that share an identical key-rules section. No code, schema, or CI configuration changes are required. The change is well-bounded and each insertion point is clearly identified by the spec.
 
 **Dependencies**: 173-markdown-lint-plan-spec-docs (merged — provides the durable CI enforcement gate that coexists with the agent-level check introduced here)
 
@@ -93,7 +93,7 @@ No other project docs (`docs/project/`, `docs/best-practices/`, `AGENTS.md`, etc
    > ```bash
    > git diff --cached CHANGELOG.md | grep '^+' | grep -P '\s+$'
    > ```
-   > If this returns output, fix the flagged lines before committing.
+   > If this returns output, inspect each flagged line: leave intentional two-space Markdown hard line breaks (exactly two trailing spaces followed by a newline) intact, and fix any other trailing whitespace (e.g., a single trailing space, a tab, or three or more trailing spaces) before committing.
 
 5. Edit **both** `.claude/agents/developer.md` **and** `.cursor/agents/developer.md` (both
    files contain an identical `Key rules:` bullet list that must stay in sync per the

--- a/docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/2_178-changelog-trailing-whitespace_implementation-plan.md
+++ b/docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/2_178-changelog-trailing-whitespace_implementation-plan.md
@@ -1,0 +1,109 @@
+# Developer Agent CHANGELOG Trailing-Whitespace Prevention — Implementation Plan
+
+**Spec**: [`docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/1_178-changelog-trailing-whitespace_specs.md`](1_178-changelog-trailing-whitespace_specs.md)
+**Smoke test runbook**: [`docs/testing/workflow/178-changelog-trailing-whitespace.smoke-test.md`](../../../testing/workflow/178-changelog-trailing-whitespace.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add an explicit, actionable CHANGELOG format verification instruction to every implementation path in `03-implement-development-protocol.md` (Full Pipeline Step 6, and equivalent CHANGELOG update steps in the Refactor, Fast Track, and Hotfix paths). Concurrently, add a matching rule to the developer agent's key rules section in `.claude/agents/developer.md` so the check is surfaced at agent initialization. Both changes are pure documentation and protocol text edits — no scripts, hooks, or CI changes are needed.
+
+**Estimated complexity**: S
+
+**Rationale**: Only two files need targeted text additions. No code, schema, or CI configuration changes are required. The change is well-bounded and each insertion point is clearly identified by the spec.
+
+**Dependencies**: 173-markdown-lint-plan-spec-docs (merged — provides the durable CI enforcement gate that coexists with the agent-level check introduced here)
+
+---
+
+## Layer-by-Layer Changes
+
+### Infrastructure / Configuration
+
+- [ ] `docs/ai/development-workflow/protocols/03-implement-development-protocol.md` — Insert a CHANGELOG format verification sub-step into the CHANGELOG update step for every implementation path:
+  - **Full Pipeline Path 1, Step 6** (`### Step 6: Update CHANGELOG`): add verification instruction after the entry-writing guidance.
+  - **Refactor Path 2, Step 6** (the `Update CHANGELOG` bullet inside Refactor Steps): add the same verification instruction.
+  - **Fast Track Path 3, Step 6** (`### Step 6: Update CHANGELOG`): add the same verification instruction.
+  - **Hotfix Path 4, Step 6** (`### Step 6: Update CHANGELOG`): add the same verification instruction.
+  - The instruction must cover both defect patterns (trailing whitespace on any line, two or more consecutive blank lines at the end of the entry), state that intentional two-space Markdown hard line breaks must not be treated as violations, and clarify that the check runs after writing the entry and before staging.
+
+- [ ] `.claude/agents/developer.md` — Add a key rule that states the CHANGELOG entry must have no trailing whitespace or trailing blank lines before commit, alongside the existing CHANGELOG update reminder.
+
+---
+
+## Testing Strategy
+
+**Test types**: Manual / Smoke
+
+**Key scenarios to test**:
+
+1. Verify that `03-implement-development-protocol.md` contains the CHANGELOG verification instruction in all four implementation paths (Full Pipeline Step 6, Refactor Step 6, Fast Track Step 6, Hotfix Step 6) — maps to AC1, AC3, AC4.
+2. Verify that `.claude/agents/developer.md` key rules section mentions no trailing whitespace or trailing blank lines — maps to AC2.
+3. Verify the changes do not remove or conflict with any existing CHANGELOG update instructions — maps to AC5.
+
+**Smoke test runbook**: [`docs/testing/workflow/178-changelog-trailing-whitespace.smoke-test.md`](../../../testing/workflow/178-changelog-trailing-whitespace.smoke-test.md)
+
+---
+
+## Seed Data
+
+None — this feature is documentation/protocol-only. No runtime seed data is required.
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/ai/development-workflow/protocols/03-implement-development-protocol.md` — Updated as the primary deliverable (all four CHANGELOG update steps). No further documentation updates are needed beyond what is listed under Layer-by-Layer Changes.
+- [ ] `.claude/agents/developer.md` — Updated as the secondary deliverable (key rules section).
+
+No other project docs (`docs/project/`, `docs/best-practices/`, `AGENTS.md`, etc.) are affected by this change.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Instruction is too vague and an LLM agent skips it | Low | Med | Spec AC3 requires concrete, unambiguous language; use a shell-checkable example pattern in the instruction |
+| Instruction inadvertently strips intentional two-space hard line breaks | Low | Low | Spec AC4 requires an explicit exclusion clause; include it verbatim in every insertion point |
+| One of the four paths is missed | Low | Med | Pre-implementation scope checklist: grep for the CHANGELOG step heading in each path before opening PR |
+
+---
+
+## Implementation Order
+
+1. Read the current text of `03-implement-development-protocol.md` in full, noting the exact location of Step 6 / the CHANGELOG update step in each of the four paths (Full Pipeline, Refactor, Fast Track, Hotfix).
+2. Read the current text of `.claude/agents/developer.md` in full, noting the key rules section.
+3. **Cross-reference consistency check**: grep for `CHANGELOG` and `trailing` across `docs/`, `.claude/`, `.cursor/`, `.codex/`, `AGENTS.md`, `REVIEW.md` to ensure no other location mentions a contradictory rule or would also need updating.
+4. Edit `03-implement-development-protocol.md`:
+   - In **Full Pipeline Path 1, Step 6**: append the verification sub-step immediately after the existing bullet list.
+   - In **Refactor Path 2** Refactor Steps, the Update CHANGELOG bullet: append the same verification sub-step inline.
+   - In **Fast Track Path 3, Step 6**: append the same verification sub-step.
+   - In **Hotfix Path 4, Step 6**: append the same verification sub-step.
+
+   The verification sub-step text (use consistently in all four paths):
+
+   > **CHANGELOG format verification (before staging)**: After writing the CHANGELOG entry, verify the entry for the following defects and fix them in-place before staging:
+   >
+   > 1. **Trailing whitespace**: No line in the written entry should end with one or more whitespace characters. Note: intentional two-space Markdown hard line breaks (`<text>  ` with exactly two trailing spaces followed by a newline) are not trailing whitespace and must not be removed.
+   > 2. **Trailing blank lines**: The entry must not end with two or more consecutive blank lines.
+   >
+   > A quick shell check for trailing whitespace on staged CHANGELOG lines:
+   > ```bash
+   > git diff --cached CHANGELOG.md | grep '^+' | grep -P '\s+$'
+   > ```
+   > If this returns output, fix the flagged lines before committing.
+
+5. Edit `.claude/agents/developer.md`:
+   - In the key rules section (the bullet list after `Key rules:`), add the following bullet:
+     > - CHANGELOG entries must have no trailing whitespace and no trailing blank lines before commit; verify in-place after writing the entry and before staging (intentional two-space Markdown hard line breaks are exempt)
+
+6. Run the markdown lint check on modified files to confirm no lint violations are introduced:
+   ```bash
+   npx markdownlint-cli2 "docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/*.md" "docs/testing/workflow/178-changelog-trailing-whitespace.smoke-test.md"
+   ```
+7. Commit with message: `fix(developer-agent): add CHANGELOG trailing-whitespace verification step`
+8. Push branch and open a draft PR targeting `develop`.
+9. Update CHANGELOG under `[Unreleased]` with a `Fixed` entry.
+10. Verify smoke test runbook assertions manually.

--- a/docs/testing/workflow/178-changelog-trailing-whitespace.smoke-test.md
+++ b/docs/testing/workflow/178-changelog-trailing-whitespace.smoke-test.md
@@ -1,0 +1,156 @@
+# Smoke Test Runbook: Developer Agent CHANGELOG Trailing-Whitespace Prevention
+
+**Feature**: Developer Agent CHANGELOG Trailing-Whitespace Prevention (issue #178)
+**Spec**: [`docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/1_178-changelog-trailing-whitespace_specs.md`](../../specs/developments/20260417154805_178-changelog-trailing-whitespace/1_178-changelog-trailing-whitespace_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] The feature branch has been merged to `develop`
+- [ ] You have a local clone of the repository at the latest `develop` HEAD
+- [ ] `grep`, `git`, and a text editor are available in your shell
+
+---
+
+## Test Data
+
+| Item | Value |
+|---|---|
+| Protocol file | `docs/ai/development-workflow/protocols/03-implement-development-protocol.md` |
+| Agent definition | `.claude/agents/developer.md` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify Full Pipeline Path (AC1, AC3, AC4)
+
+1. Open `docs/ai/development-workflow/protocols/03-implement-development-protocol.md`.
+2. Navigate to **Path 1: Full Pipeline**, **Step 6: Update CHANGELOG**.
+3. Confirm that immediately after the existing entry-writing guidance there is a **CHANGELOG format verification** sub-step.
+4. Confirm the sub-step names both defect patterns:
+   - Trailing whitespace on any line of the entry
+   - Two or more consecutive blank lines at the end of the entry
+5. Confirm the sub-step explicitly states that intentional two-space Markdown hard line breaks are **not** trailing whitespace.
+6. Confirm the sub-step instructs the agent to fix in-place **before staging**.
+
+**Expected result**: All six confirmations pass.
+
+---
+
+### Step 2: Verify Refactor Path (AC1, AC3, AC4)
+
+1. In the same file, navigate to **Path 2: Refactor**, **Refactor Steps**, step 6 (Update CHANGELOG bullet).
+2. Confirm the same CHANGELOG format verification sub-step is present (same content as Step 1 above).
+
+**Expected result**: Verification sub-step is present and covers both defect patterns with the hard-line-break exclusion.
+
+---
+
+### Step 3: Verify Fast Track Path (AC1, AC3, AC4)
+
+1. In the same file, navigate to **Path 3: Fast Track**, **Step 6: Update CHANGELOG**.
+2. Confirm the same CHANGELOG format verification sub-step is present.
+
+**Expected result**: Verification sub-step is present and covers both defect patterns with the hard-line-break exclusion.
+
+---
+
+### Step 4: Verify Hotfix Path (AC1, AC3, AC4)
+
+1. In the same file, navigate to **Path 4: Hotfix**, **Step 6: Update CHANGELOG**.
+2. Confirm the same CHANGELOG format verification sub-step is present.
+
+**Expected result**: Verification sub-step is present and covers both defect patterns with the hard-line-break exclusion.
+
+---
+
+### Step 5: Verify Developer Agent Key Rules (AC2)
+
+1. Open `.claude/agents/developer.md`.
+2. Navigate to the **Key rules** bullet list.
+3. Confirm there is a bullet stating that CHANGELOG entries must have no trailing whitespace and no trailing blank lines before commit.
+4. Confirm the bullet mentions that intentional two-space Markdown hard line breaks are exempt.
+
+**Expected result**: Both confirmations pass.
+
+---
+
+### Step 6: Verify No Existing Instructions Removed (AC5)
+
+1. In `03-implement-development-protocol.md`, confirm that all pre-existing CHANGELOG update instructions (e.g., "Add an entry under `[Unreleased]`", category guidance, unreleased-entry update rule) are still present in each path.
+2. In `.claude/agents/developer.md`, confirm that all pre-existing key rules (e.g., "Always update CHANGELOG before opening the PR") are still present and unchanged.
+
+**Expected result**: No pre-existing instruction has been removed or overwritten.
+
+---
+
+### Step 7: Shell Grep Verification (AC1)
+
+Run the following commands and verify the output:
+
+```bash
+# Confirm verification instruction appears in all four paths
+grep -n "CHANGELOG format verification" \
+  docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+```
+
+**Expected result**: Exactly 4 matches (one per path).
+
+```bash
+# Confirm the hard-line-break exclusion is present in each occurrence
+grep -n "two-space" \
+  docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+```
+
+**Expected result**: At least 4 matches (one per path).
+
+```bash
+# Confirm the developer agent key rule
+grep -n "trailing whitespace" .claude/agents/developer.md
+```
+
+**Expected result**: At least 1 match in the key rules section.
+
+---
+
+## Assertions Checklist
+
+Each checkbox maps to an acceptance criterion from the spec.
+
+- [ ] AC1: `03-implement-development-protocol.md` includes an explicit, actionable CHANGELOG format verification instruction in every implementation path (Full Pipeline Step 6, Refactor Step 6, Fast Track Step 6, Hotfix Step 6), directing the agent to verify for trailing whitespace and trailing blank lines before staging.
+- [ ] AC2: `.claude/agents/developer.md` key rules section includes a note that the CHANGELOG entry must have no trailing whitespace or trailing blank lines before commit.
+- [ ] AC3: The instruction in the protocol specifies both defect patterns (trailing whitespace, trailing blank lines at end of entry) and the timing (after writing the CHANGELOG entry, before staging for commit).
+- [ ] AC4: The instruction explicitly states that intentional two-space Markdown hard line breaks must not be treated as trailing whitespace violations.
+- [ ] AC5: The changes do not remove or conflict with any existing CHANGELOG update instructions in the protocol or agent definition.
+
+---
+
+## Seed Data Reference
+
+None — this feature is documentation and protocol text only. No runtime seed data is required.
+
+| Entity | Scenario | How to load |
+|---|---|---|
+| N/A | N/A | N/A |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `grep` returns fewer than 4 matches for "CHANGELOG format verification" | One or more paths were missed during implementation | Re-read each path's Step 6 and add the missing sub-step |
+| Developer agent key rule is missing | `.claude/agents/developer.md` was not updated | Add the trailing-whitespace key rule to the key rules bullet list |
+| Existing CHANGELOG instructions are missing after the change | Incorrect edit replaced rather than appended | Restore from git history and re-apply the change as an append |
+
+---
+
+## Known Limitations
+
+- This runbook verifies the presence and content of protocol text. It does not execute the developer agent end-to-end to confirm it follows the instruction — that requires a live agent run with a CHANGELOG-modifying PR. Manual spot-check of a future developer agent run is recommended as a follow-up validation.

--- a/docs/testing/workflow/178-changelog-trailing-whitespace.smoke-test.md
+++ b/docs/testing/workflow/178-changelog-trailing-whitespace.smoke-test.md
@@ -22,7 +22,8 @@ Before running this smoke test:
 | Item | Value |
 |---|---|
 | Protocol file | `docs/ai/development-workflow/protocols/03-implement-development-protocol.md` |
-| Agent definition | `.claude/agents/developer.md` |
+| Agent definition (Claude) | `.claude/agents/developer.md` |
+| Agent definition (Cursor) | `.cursor/agents/developer.md` |
 
 ---
 
@@ -76,15 +77,17 @@ Before running this smoke test:
 2. Navigate to the **Key rules** bullet list.
 3. Confirm there is a bullet stating that CHANGELOG entries must have no trailing whitespace and no trailing blank lines before commit.
 4. Confirm the bullet mentions that intentional two-space Markdown hard line breaks are exempt.
+5. Open `.cursor/agents/developer.md`.
+6. Navigate to its **Key rules** bullet list and confirm the same bullet is present with identical wording to the bullet in `.claude/agents/developer.md` (both agent files must stay in sync).
 
-**Expected result**: Both confirmations pass.
+**Expected result**: All six confirmations pass — both files contain the new key rule with identical wording.
 
 ---
 
 ### Step 6: Verify No Existing Instructions Removed (AC5)
 
 1. In `03-implement-development-protocol.md`, confirm that all pre-existing CHANGELOG update instructions (e.g., "Add an entry under `[Unreleased]`", category guidance, unreleased-entry update rule) are still present in each path.
-2. In `.claude/agents/developer.md`, confirm that all pre-existing key rules (e.g., "Always update CHANGELOG before opening the PR") are still present and unchanged.
+2. In **both** `.claude/agents/developer.md` and `.cursor/agents/developer.md`, confirm that all pre-existing key rules (e.g., "Always update CHANGELOG before opening the PR") are still present and unchanged.
 
 **Expected result**: No pre-existing instruction has been removed or overwritten.
 
@@ -111,11 +114,18 @@ grep -n "two-space" \
 **Expected result**: At least 4 matches (one per path).
 
 ```bash
-# Confirm the developer agent key rule
+# Confirm the developer agent key rule in the Claude agent definition
 grep -n "trailing whitespace" .claude/agents/developer.md
 ```
 
 **Expected result**: At least 1 match in the key rules section.
+
+```bash
+# Confirm the same key rule in the Cursor agent definition
+grep -n "trailing whitespace" .cursor/agents/developer.md
+```
+
+**Expected result**: At least 1 match in the key rules section, with wording identical to the `.claude/agents/developer.md` bullet.
 
 ---
 
@@ -124,7 +134,7 @@ grep -n "trailing whitespace" .claude/agents/developer.md
 Each checkbox maps to an acceptance criterion from the spec.
 
 - [ ] AC1: `03-implement-development-protocol.md` includes an explicit, actionable CHANGELOG format verification instruction in every implementation path (Full Pipeline Step 6, Refactor Step 6, Fast Track Step 6, Hotfix Step 6), directing the agent to verify for trailing whitespace and trailing blank lines before staging.
-- [ ] AC2: `.claude/agents/developer.md` key rules section includes a note that the CHANGELOG entry must have no trailing whitespace or trailing blank lines before commit.
+- [ ] AC2: **Both** `.claude/agents/developer.md` **and** `.cursor/agents/developer.md` key rules sections include a note (worded identically across the two files) that the CHANGELOG entry must have no trailing whitespace or trailing blank lines before commit.
 - [ ] AC3: The instruction in the protocol specifies both defect patterns (trailing whitespace, trailing blank lines at end of entry) and the timing (after writing the CHANGELOG entry, before staging for commit).
 - [ ] AC4: The instruction explicitly states that intentional two-space Markdown hard line breaks must not be treated as trailing whitespace violations.
 - [ ] AC5: The changes do not remove or conflict with any existing CHANGELOG update instructions in the protocol or agent definition.

--- a/docs/testing/workflow/178-changelog-trailing-whitespace.smoke-test.md
+++ b/docs/testing/workflow/178-changelog-trailing-whitespace.smoke-test.md
@@ -145,10 +145,6 @@ Each checkbox maps to an acceptance criterion from the spec.
 
 None — this feature is documentation and protocol text only. No runtime seed data is required.
 
-| Entity | Scenario | How to load |
-|---|---|---|
-| N/A | N/A | N/A |
-
 ---
 
 ## Troubleshooting
@@ -156,7 +152,7 @@ None — this feature is documentation and protocol text only. No runtime seed d
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `grep` returns fewer than 4 matches for "CHANGELOG format verification" | One or more paths were missed during implementation | Re-read each path's Step 6 and add the missing sub-step |
-| Developer agent key rule is missing | `.claude/agents/developer.md` was not updated | Add the trailing-whitespace key rule to the key rules bullet list |
+| Developer agent key rule is missing or mismatched between agent files | `.claude/agents/developer.md` and/or `.cursor/agents/developer.md` was not updated, or wording diverged between the two | Add/fix the trailing-whitespace key rule in both files and ensure the bullet text is identical |
 | Existing CHANGELOG instructions are missing after the change | Incorrect edit replaced rather than appended | Restore from git history and re-apply the change as an append |
 
 ---


### PR DESCRIPTION
## Summary

Adds the implementation plan and smoke test runbook for issue #178: preventing CHANGELOG trailing-whitespace and trailing-blank-line findings in developer agent output.

**Approach**: Add an explicit, actionable CHANGELOG format verification sub-step to every CHANGELOG update step in `03-implement-development-protocol.md` (Full Pipeline Step 6, Refactor Step 6, Fast Track Step 6, Hotfix Step 6). Add a matching key rule to `.claude/agents/developer.md`. Both changes are pure documentation/protocol edits — no scripts, hooks, or CI changes.

**Complexity**: S (small — two file changes, targeted text additions only)

**Key risks**: Low. The only risk is a missed path or overly vague wording; the plan calls for a grep-based pre-implementation scope check and concrete instruction language.

## Links

- Spec: `docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/1_178-changelog-trailing-whitespace_specs.md`
- Plan: `docs/specs/developments/20260417154805_178-changelog-trailing-whitespace/2_178-changelog-trailing-whitespace_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/178-changelog-trailing-whitespace.smoke-test.md`

## Closes

Part of #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a specification and smoke-test runbook for a protocol to prevent trailing-whitespace in CHANGELOG entries, including a required "CHANGELOG format verification" step that checks for trailing spaces and excessive trailing blank lines.
  * Clarified that two-space Markdown hard line breaks are exempt, added matching agent guidance, and included a checklist and verification commands for maintainers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->