### PR TITLE
docs(plan): require all review threads resolved before ready-for-human-review

### DIFF
--- a/docs/specs/developments/20260417194629_review-threads-all-resolved/2_review-threads-all-resolved_implementation-plan.md
+++ b/docs/specs/developments/20260417194629_review-threads-all-resolved/2_review-threads-all-resolved_implementation-plan.md
@@ -61,7 +61,7 @@ No database seed data required. Testing relies on a real GitHub PR with controll
 
 ## Documentation Updates
 
-The protocol document changes (Step 8c in Protocol 91, Step 5.1 in Protocol 90, and the Step 7 summary template) are themselves deliverables listed in the Layer-by-Layer Changes section above and must be executed during implementation. No additional project docs in `docs/project/`, `docs/best-practices/`, or `AGENTS.md` are affected by this change.
+The protocol document changes (Step 8c in Protocol 91, Step 5.1 in Protocol 90, and the Step 7 summary template) are themselves deliverables listed in the Layer-by-Layer Changes section above and must be executed during implementation. Additionally, `CHANGELOG.md` must be updated with an entry under `[Unreleased]` as part of the implementation (Implementation Order Step 10) per standard practice for feature PRs merged into `develop`. No other project docs in `docs/project/`, `docs/best-practices/`, or `AGENTS.md` are affected by this change.
 
 ---
 
@@ -129,7 +129,7 @@ check_unresolved_threads() {
     local result
     result="$(gh api graphql \
       -f query='query($owner:String!,$repo:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100,after:$cursor){pageInfo{hasNextPage endCursor}nodes{id isResolved comments(first:1){nodes{author{login}body}}}}}}}' \
-      -f owner="$owner" -f repo="$repo_name" -F pr="$pr_number" \
+      -f owner="$owner" -f repo="$repo_name" -F pr="$pr_number" ${cursor:+-f cursor="$cursor"} \
       --jq '.data.repository.pullRequest.reviewThreads')"
 
     has_next_page="$(printf '%s\n' "$result" | jq -r '.pageInfo.hasNextPage')"

--- a/docs/specs/developments/20260417194629_review-threads-all-resolved/2_review-threads-all-resolved_implementation-plan.md
+++ b/docs/specs/developments/20260417194629_review-threads-all-resolved/2_review-threads-all-resolved_implementation-plan.md
@@ -1,0 +1,233 @@
+# Require All Review Threads Resolved Before Ready-For-Human-Review — Implementation Plan
+
+**Spec**: [`1_review-threads-all-resolved_specs.md`](./1_review-threads-all-resolved_specs.md)
+**Smoke test runbook**: [`docs/testing/workflow/review-threads-all-resolved.smoke-test.md`](../../../../testing/workflow/review-threads-all-resolved.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add a `check_unresolved_threads` function to `pr-review-loop.sh` that uses the GitHub GraphQL API to enumerate all `reviewThreads` on a PR, filters them to threads authored by configured bot logins, and exits `needs_fixes` with `UNRESOLVED_THREAD_COUNT=N` when any remain unresolved. This function runs as the final check inside each platform handler's "clean" exit path and also at the aggregate level before the script exits with `RESULT=clean`. Protocol 91 Step 8c is updated to add an explicit `reviewThreads` GraphQL check to its independent verification checklist.
+
+**Estimated complexity**: M
+
+**Rationale**: The change is entirely contained in one shell script (`pr-review-loop.sh`) and one protocol document (`91-orchestrate-work-protocol.md`). The GraphQL query, bot-login filtering, and `UNRESOLVED_THREAD_COUNT` output are straightforward to add. Pagination handling (cursor-based) and the `✅ Addressed` equivalence rule require careful implementation, pushing this from S to M.
+
+**Dependencies**: None — no other in-progress issues block this work.
+
+---
+
+## Layer-by-Layer Changes
+
+### Scripts / Automation
+
+- [ ] **`scripts/development-workflow/pr-review-loop.sh`** — Add `check_unresolved_threads` function (see implementation steps below) and wire it into the final clean-exit path of each platform handler and the aggregate exit.
+
+### Protocol Documentation
+
+- [ ] **`docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`** — Update Step 8c's independent-verification checklist to include an explicit `reviewThreads` GraphQL check as a hard gate, aligned with AC3 and AC7.
+
+---
+
+## Testing Strategy
+
+**Test types**: Smoke (manual, against a real PR with known thread states)
+
+**Key scenarios to test**:
+
+1. PR has one Nitpick/Minor thread that is `isResolved: false` — loop must exit `needs_fixes` with `UNRESOLVED_THREAD_COUNT=1` (maps to AC1)
+2. PR has all threads resolved (`isResolved: true` or `✅ Addressed` in body) — loop must exit `clean` (maps to AC2)
+3. Fixer resolves thread via `resolveReviewThread` mutation; loop re-runs and sees `isResolved: true`; PR reaches `ready-for-human-review` (maps to AC4)
+4. Step 8c catches a PR where thread check was bypassed (maps to AC3)
+5. Human-authored threads are not counted by the gate (maps to AC6)
+
+**Smoke test runbook**: [`docs/testing/workflow/review-threads-all-resolved.smoke-test.md`](../../../../testing/workflow/review-threads-all-resolved.smoke-test.md)
+
+**Regression suite**: No automated regression suite exists in this repository.
+
+---
+
+## Seed Data
+
+No database seed data required. Testing relies on a real GitHub PR with controlled thread states.
+
+| Entity | Values / Scenario | File |
+|---|---|---|
+| Test PR | PR with at least one open Nitpick-severity CodeRabbit thread | Created manually during smoke test |
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` — Add the `reviewThreads` unresolved-thread check to the Step 8c hard-gate table (listed under Layer changes above and is itself a deliverable of this item, not a follow-up doc update). No other project docs are affected by this change.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| GitHub GraphQL `reviewThreads` paginates beyond 100 nodes | Low | High (silent miss) | Use cursor-based pagination in the query loop; emit a warning if cursor is non-null after 10 pages |
+| Bot login list in `.ai-dev-workflow.yaml` diverges from actual bot accounts | Low | Med | Read bot logins from `review.platforms` mapping at runtime; document the mapping in the plan |
+| `✅ Addressed` text appears in a human comment, causing false positive "resolved" | Very Low | Low | Scope the `✅ Addressed` equivalence check to comments authored by bot logins only |
+| `resolveReviewThread` mutation requires the `id` (node ID), not the REST `comment_id` | Med | Med | GraphQL query already returns `id` (node ID) per thread; document this in code comment |
+| Spec/plan branches where CodeRabbit skips review have zero bot threads — gate must not block | Low | Med | Guard: if `UNRESOLVED_THREAD_COUNT=0`, always pass; only fail when count > 0 |
+
+---
+
+## Code Samples
+
+> All samples below are **illustrative — adapt during implementation**.
+
+### GraphQL query to enumerate review threads (paginated)
+
+```graphql
+# Illustrative — adapt during implementation
+query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes {
+              author { login }
+              body
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Bash helper to call the query (illustrative)
+
+```bash
+# Illustrative — adapt during implementation
+check_unresolved_threads() {
+  local pr_number="$1"
+  local branch_name="$2"
+  # bot_logins: space-separated list derived from review.platforms config
+  local bot_logins="$3"
+  local repo="$4"
+
+  local unresolved_count=0
+  local cursor=""
+  local has_next_page="true"
+  local owner repo_name
+
+  owner="$(printf '%s\n' "$repo" | cut -d/ -f1)"
+  repo_name="$(printf '%s\n' "$repo" | cut -d/ -f2)"
+
+  while [ "$has_next_page" = "true" ]; do
+    local result
+    result="$(gh api graphql \
+      -f query='query($owner:String!,$repo:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100,after:$cursor){pageInfo{hasNextPage endCursor}nodes{id isResolved comments(first:1){nodes{author{login}body}}}}}}}' \
+      -f owner="$owner" -f repo="$repo_name" -F pr="$pr_number" \
+      --jq '.data.repository.pullRequest.reviewThreads')"
+
+    has_next_page="$(printf '%s\n' "$result" | jq -r '.pageInfo.hasNextPage')"
+    cursor="$(printf '%s\n' "$result" | jq -r '.pageInfo.endCursor // empty')"
+
+    while IFS= read -r thread_json; do
+      [ -z "${thread_json:-}" ] && continue
+      local is_resolved author body
+
+      is_resolved="$(printf '%s\n' "$thread_json" | jq -r '.isResolved')"
+      author="$(printf '%s\n' "$thread_json" | jq -r '.comments.nodes[0].author.login // ""')"
+      body="$(printf '%s\n' "$thread_json" | jq -r '.comments.nodes[0].body // ""')"
+
+      # Check if author is a configured bot login
+      local is_bot=0
+      local bot_login
+      for bot_login in $bot_logins; do
+        if [ "$author" = "$bot_login" ]; then is_bot=1; break; fi
+      done
+      [ "$is_bot" -eq 0 ] && continue
+
+      # A thread is resolved if isResolved=true OR body contains "✅ Addressed"
+      if [ "$is_resolved" = "true" ]; then continue; fi
+      if printf '%s\n' "$body" | grep -q "✅ Addressed"; then continue; fi
+
+      unresolved_count=$((unresolved_count + 1))
+    done < <(printf '%s\n' "$result" | jq -c '.nodes[]')
+  done
+
+  printf '%d\n' "$unresolved_count"
+}
+```
+
+### Bot login mapping from `.ai-dev-workflow.yaml`
+
+```bash
+# Illustrative — adapt during implementation
+# Derive bot logins from the platforms list in .ai-dev-workflow.yaml
+bot_login_for_platform() {
+  case "$1" in
+    coderabbit) printf 'coderabbitai[bot]\n' ;;
+    devin)      printf 'devin-ai-integration[bot]\n' ;;
+    greptile)   printf 'greptile-apps[bot]\n' ;;
+    *)          printf '\n' ;;
+  esac
+}
+```
+
+### Wiring into the aggregate clean-exit path (illustrative)
+
+```bash
+# Illustrative — adapt during implementation
+# In the aggregate loop, after all platforms return clean/skipped:
+if [ "$aggregate_result" = "clean" ] || [ "$aggregate_result" = "skipped" ]; then
+  # Derive bot logins from configured platforms
+  bot_logins=""
+  for p in "${platforms[@]}"; do
+    login="$(bot_login_for_platform "$p")"
+    [ -n "$login" ] && bot_logins="$bot_logins $login"
+  done
+  bot_logins="$(printf '%s\n' "$bot_logins" | xargs)"  # trim
+
+  unresolved_count=0
+  if [ -n "$bot_logins" ]; then
+    unresolved_count="$(check_unresolved_threads "$pr_number" "$branch_name" "$bot_logins" "$repo")"
+  fi
+  print_kv UNRESOLVED_THREAD_COUNT "$unresolved_count"
+
+  if [ "$unresolved_count" -gt 0 ]; then
+    print_kv RESULT needs_fixes
+    print_kv REASON unresolved_review_threads
+    exit 1
+  fi
+fi
+```
+
+---
+
+## Implementation Order
+
+1. **Read and understand `pr-review-loop.sh` and `workflow-lib.sh`** — identify the exact exit points that currently emit `RESULT=clean` and the aggregate exit block at the bottom of the script.
+
+2. **Add `bot_login_for_platform` helper function** to `pr-review-loop.sh` — maps platform name (from `.ai-dev-workflow.yaml`) to its bot login string. Add immediately after the existing platform-specific `run_*` functions and before `run_platform_review`.
+
+3. **Add `check_unresolved_threads` function** to `pr-review-loop.sh` — implements the paginated GraphQL query, bot-login filter, `isResolved` + `✅ Addressed` equivalence, and returns the unresolved count as a plain integer on stdout. Add after `bot_login_for_platform`.
+
+4. **Wire `check_unresolved_threads` into the aggregate exit block** — in the section starting at `if [ -z "$last_platform" ]; then`, add the unresolved-thread check after the platform loop completes and the aggregate result is `clean` or `skipped` (before the `case "$aggregate_result"` exit switch). Emit `UNRESOLVED_THREAD_COUNT` in all exit paths (0 when clean, N when needs_fixes). When `unresolved_count > 0`, override `aggregate_result` to `needs_fixes`, set `aggregate_reason` to `unresolved_review_threads`, and exit 1.
+
+5. **Update `91-orchestrate-work-protocol.md` Step 8c** — add a new row to the verification checklist table:
+
+   | Check | Pass condition |
+   |---|---|
+   | All automated-reviewer `reviewThreads` resolved | GraphQL `reviewThreads.nodes[].isResolved=true` (or `✅ Addressed` in parent comment body) for every thread authored by a configured bot login |
+
+   Add a code block showing the `gh api graphql` command that evaluates this check, consistent with the illustrative sample in this plan. Place this row after the "No `needs-fixes` label" row and before the "Automated reviewer loop summary" row in the existing table.
+
+6. **Verify `shellcheck` passes** — run `shellcheck scripts/development-workflow/pr-review-loop.sh` in the worktree and fix any warnings before committing.
+
+7. **Verify markdown lint passes** — run `npx markdownlint-cli2 "docs/specs/developments/**/*.md"` and `npx markdownlint-cli2 "docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md"` in the worktree.
+
+8. **Update CHANGELOG** — add an entry under `[Unreleased]` describing this change.
+
+9. **Verify smoke test runbook scenarios** — manually confirm the runbook steps map to each acceptance criterion.

--- a/docs/specs/developments/20260417194629_review-threads-all-resolved/2_review-threads-all-resolved_implementation-plan.md
+++ b/docs/specs/developments/20260417194629_review-threads-all-resolved/2_review-threads-all-resolved_implementation-plan.md
@@ -1,7 +1,7 @@
 # Require All Review Threads Resolved Before Ready-For-Human-Review — Implementation Plan
 
 **Spec**: [`1_review-threads-all-resolved_specs.md`](./1_review-threads-all-resolved_specs.md)
-**Smoke test runbook**: [`docs/testing/workflow/review-threads-all-resolved.smoke-test.md`](../../../../testing/workflow/review-threads-all-resolved.smoke-test.md)
+**Smoke test runbook**: [`docs/testing/workflow/review-threads-all-resolved.smoke-test.md`](../../../testing/workflow/review-threads-all-resolved.smoke-test.md)
 
 ---
 
@@ -25,7 +25,9 @@
 
 ### Protocol Documentation
 
-- [ ] **`docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`** — Update Step 8c's independent-verification checklist to include an explicit `reviewThreads` GraphQL check as a hard gate, aligned with AC3 and AC7.
+- [ ] **`docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`** — Update Step 8c's independent-verification checklist to include an explicit `reviewThreads` GraphQL check as a hard gate, aligned with AC3. Also update the Automated Reviewer Loop Summary template in Step 7 to include a "Reply-only resolutions" section that lists threads resolved via reply + mutation (no code fix) with a short rationale, aligned with AC5.
+
+- [ ] **`docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`** — Update Step 5.1's post-dispatch PR verification checklist to include the same `reviewThreads` unresolved-thread check, aligned with AC7.
 
 ---
 
@@ -41,7 +43,7 @@
 4. Step 8c catches a PR where thread check was bypassed (maps to AC3)
 5. Human-authored threads are not counted by the gate (maps to AC6)
 
-**Smoke test runbook**: [`docs/testing/workflow/review-threads-all-resolved.smoke-test.md`](../../../../testing/workflow/review-threads-all-resolved.smoke-test.md)
+**Smoke test runbook**: [`docs/testing/workflow/review-threads-all-resolved.smoke-test.md`](../../../testing/workflow/review-threads-all-resolved.smoke-test.md)
 
 **Regression suite**: No automated regression suite exists in this repository.
 
@@ -59,7 +61,7 @@ No database seed data required. Testing relies on a real GitHub PR with controll
 
 ## Documentation Updates
 
-- [ ] `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` — Add the `reviewThreads` unresolved-thread check to the Step 8c hard-gate table (listed under Layer changes above and is itself a deliverable of this item, not a follow-up doc update). No other project docs are affected by this change.
+The protocol document changes (Step 8c in Protocol 91, Step 5.1 in Protocol 90, and the Step 7 summary template) are themselves deliverables listed in the Layer-by-Layer Changes section above and must be executed during implementation. No additional project docs in `docs/project/`, `docs/best-practices/`, or `AGENTS.md` are affected by this change.
 
 ---
 
@@ -224,10 +226,30 @@ fi
 
    Add a code block showing the `gh api graphql` command that evaluates this check, consistent with the illustrative sample in this plan. Place this row after the "No `needs-fixes` label" row and before the "Automated reviewer loop summary" row in the existing table.
 
-6. **Verify `shellcheck` passes** — run `shellcheck scripts/development-workflow/pr-review-loop.sh` in the worktree and fix any warnings before committing.
+6. **Update `91-orchestrate-work-protocol.md` Step 7 Automated Reviewer Loop Summary template** — add a "Reply-only resolutions" subsection to the Final Summary Comment template (the `### Automated Reviewer Loop Summary` block). The new section lists each thread resolved via reply + `resolveReviewThread` mutation (no code fix) with the thread author, a short description of the concern, and the rationale given in the reply. This enables human reviewers to audit non-code-fix resolutions (AC5).
 
-7. **Verify markdown lint passes** — run `npx markdownlint-cli2 "docs/specs/developments/**/*.md"` and `npx markdownlint-cli2 "docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md"` in the worktree.
+   The subsection should be added after the findings table in the summary template, similar to:
 
-8. **Update CHANGELOG** — add an entry under `[Unreleased]` describing this change.
+   ```markdown
+   **Reply-only resolutions (no code fix):** M thread(s) resolved via reply + resolveReviewThread mutation.
 
-9. **Verify smoke test runbook scenarios** — manually confirm the runbook steps map to each acceptance criterion.
+   | Thread | Author | Concern summary | Rationale |
+   |--------|--------|-----------------|-----------|
+   | #1 | coderabbitai[bot] | First 60 chars of concern... | First 80 chars of reply rationale... |
+   ```
+
+   When M=0 (all resolutions were code fixes), omit this subsection.
+
+7. **Update `90-batch-orchestrate-work-protocol.md` Step 5.1** — add the same `reviewThreads` unresolved-thread check to the post-dispatch PR verification checklist table (AC7). Add a row after "No `needs-fixes` label":
+
+   | Check | Pass condition |
+   |---|---|
+   | All automated-reviewer `reviewThreads` resolved | GraphQL `reviewThreads.nodes[].isResolved=true` (or `✅ Addressed` in body) for every thread authored by a configured bot login |
+
+8. **Verify `shellcheck` passes** — run `shellcheck scripts/development-workflow/pr-review-loop.sh` in the worktree and fix any warnings before committing.
+
+9. **Verify markdown lint passes** — run `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md" "docs/ai/development-workflow/protocols/90-batch-orchestrate-work-protocol.md"` in the worktree.
+
+10. **Update CHANGELOG** — add an entry under `[Unreleased]` describing this change.
+
+11. **Verify smoke test runbook scenarios** — manually confirm the runbook steps map to each acceptance criterion.

--- a/docs/testing/workflow/review-threads-all-resolved.smoke-test.md
+++ b/docs/testing/workflow/review-threads-all-resolved.smoke-test.md
@@ -38,10 +38,15 @@ Before running this smoke test:
 
    ```bash
    gh api graphql \
-     -f query='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100){nodes{isResolved comments(first:1){nodes{author{login}body}}}}}}}' \
+     -f query='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100){nodes{id isResolved comments(first:1){nodes{author{login}body}}}}}}}' \
      -f owner="<owner>" -f repo="<repo>" -F pr=<pr_number> \
-     --jq '.data.repository.pullRequest.reviewThreads.nodes[] | {isResolved, author: .comments.nodes[0].author.login}'
+     --jq '.data.repository.pullRequest.reviewThreads.nodes[] | {id, isResolved, author: .comments.nodes[0].author.login}'
    ```
+
+   > **Note**: This query returns only the first 100 review threads; for smoke
+   > testing this is sufficient. For PRs with >100 threads, use the paginated
+   > implementation in `pr-review-loop.sh` or repeat the query with cursor-based
+   > pagination.
 
 3. Confirm at least one thread is `isResolved: false` and authored by `coderabbitai[bot]`.
 
@@ -134,6 +139,11 @@ Before running this smoke test:
      -f owner="<owner>" -f repo="<repo>" -F pr=<pr_number> \
      --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login | IN("coderabbitai[bot]","devin-ai-integration[bot]","greptile-apps[bot]")) | select(.comments.nodes[0].body | contains("✅ Addressed") | not)] | length'
    ```
+
+   > **Note**: This query returns only the first 100 review threads; it is a
+   > simplified smoke-test check. For PRs with >100 threads, use the paginated
+   > implementation in `pr-review-loop.sh` or repeat the query with cursor-based
+   > pagination.
 
 3. Confirm the output is > 0 (at least one unresolved bot thread).
 4. Confirm the protocol's Step 8c logic would reject `ready-for-human-review` for this PR.

--- a/docs/testing/workflow/review-threads-all-resolved.smoke-test.md
+++ b/docs/testing/workflow/review-threads-all-resolved.smoke-test.md
@@ -1,0 +1,196 @@
+# Smoke Test Runbook: Require All Review Threads Resolved Before Ready-For-Human-Review
+
+**Feature**: Require all automated-reviewer review threads resolved before `ready-for-human-review`
+**Spec**: [`docs/specs/developments/20260417194629_review-threads-all-resolved/1_review-threads-all-resolved_specs.md`](../../specs/developments/20260417194629_review-threads-all-resolved/1_review-threads-all-resolved_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] `gh` CLI is authenticated (`gh auth status`)
+- [ ] `jq` is installed
+- [ ] You have a GitHub repository with at least one open PR that has received CodeRabbit inline review comments
+- [ ] The `pr-review-loop.sh` changes from this feature are deployed (i.e., the feature branch is checked out or merged)
+
+---
+
+## Test Data
+
+| Item | Value |
+|---|---|
+| Test PR | A PR where CodeRabbit has posted at least one inline thread of any severity |
+| Bot login (CodeRabbit) | `coderabbitai[bot]` |
+| Bot login (Devin) | `devin-ai-integration[bot]` |
+| `.ai-dev-workflow.yaml` platforms | `devin` and `coderabbit` (repo default) |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Confirm a PR has unresolved automated-reviewer threads
+
+1. Find or create a PR where CodeRabbit has posted an inline comment that is **not** resolved (`isResolved: false`) and does **not** contain `✅ Addressed` in its body.
+2. Verify using the GitHub GraphQL API:
+
+   ```bash
+   gh api graphql \
+     -f query='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100){nodes{isResolved comments(first:1){nodes{author{login}body}}}}}}}' \
+     -f owner="<owner>" -f repo="<repo>" -F pr=<pr_number> \
+     --jq '.data.repository.pullRequest.reviewThreads.nodes[] | {isResolved, author: .comments.nodes[0].author.login}'
+   ```
+
+3. Confirm at least one thread is `isResolved: false` and authored by `coderabbitai[bot]`.
+
+### Step 2: Run `pr-review-loop.sh` with an existing unresolved thread (AC1)
+
+**Maps to**: Acceptance Criterion 1
+
+1. Run the review loop against the test PR:
+
+   ```bash
+   ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch_name>
+   ```
+
+2. Wait for the script to complete.
+
+**Expected result**:
+- Script exits with non-zero status (1)
+- Output contains `RESULT=needs_fixes`
+- Output contains `UNRESOLVED_THREAD_COUNT=N` where N >= 1
+- Output contains `REASON=unresolved_review_threads`
+
+### Step 3: Resolve the thread via `resolveReviewThread` mutation and re-run (AC2, AC4)
+
+**Maps to**: Acceptance Criteria 2 and 4
+
+1. Obtain the thread node ID from the GraphQL query run in Step 1 (the `id` field on the thread node).
+2. Resolve the thread via the mutation:
+
+   ```bash
+   gh api graphql \
+     -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{isResolved}}}' \
+     -f threadId="<thread_node_id>"
+   ```
+
+3. Confirm the mutation response shows `isResolved: true`.
+4. Re-run the review loop:
+
+   ```bash
+   ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch_name>
+   ```
+
+**Expected result**:
+- Script exits with status 0
+- Output contains `RESULT=clean`
+- Output contains `UNRESOLVED_THREAD_COUNT=0`
+
+### Step 4: Verify `✅ Addressed` text is treated as resolved (AC2)
+
+**Maps to**: Acceptance Criterion 2
+
+1. Find or create a PR where a CodeRabbit comment body contains the text `✅ Addressed` (CodeRabbit appends this after a fix commit).
+2. Even if `isResolved` is still `false` on the thread, run the loop:
+
+   ```bash
+   ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch_name>
+   ```
+
+**Expected result**:
+- The thread with `✅ Addressed` in the first comment body does **not** contribute to `UNRESOLVED_THREAD_COUNT`.
+- If that was the only unresolved thread, `RESULT=clean`.
+
+### Step 5: Verify human-authored threads are not counted (AC6)
+
+**Maps to**: Acceptance Criterion 6
+
+1. Find or create a PR where a **human** user (not a bot) has posted an unresolved inline review thread.
+2. Ensure no bot-authored threads are unresolved on the same PR.
+3. Run the review loop:
+
+   ```bash
+   ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch_name>
+   ```
+
+**Expected result**:
+- Script exits with status 0
+- Output contains `RESULT=clean`
+- Output contains `UNRESOLVED_THREAD_COUNT=0`
+- The human-authored unresolved thread did not trigger `needs_fixes`
+
+### Step 6: Verify Step 8c independent verification catches unresolved threads (AC3)
+
+**Maps to**: Acceptance Criterion 3
+
+1. Find a PR where the loop would have exited `clean` before this feature (zero blocking findings from platform classifiers) but has an unresolved bot-authored thread.
+2. Manually run the GraphQL check that Step 8c now performs:
+
+   ```bash
+   gh api graphql \
+     -f query='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100){nodes{isResolved comments(first:1){nodes{author{login}body}}}}}}}' \
+     -f owner="<owner>" -f repo="<repo>" -F pr=<pr_number> \
+     --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login | IN("coderabbitai[bot]","devin-ai-integration[bot]","greptile-apps[bot]")) | select(.comments.nodes[0].body | contains("✅ Addressed") | not)] | length'
+   ```
+
+3. Confirm the output is > 0 (at least one unresolved bot thread).
+4. Confirm the protocol's Step 8c logic would reject `ready-for-human-review` for this PR.
+
+**Expected result**:
+- GraphQL query returns N > 0
+- Step 8c would remove `ready-for-human-review` and apply `needs-fixes` for this PR
+
+### Step 7: Verify Automated Reviewer Loop Summary lists reply-only resolutions (AC5)
+
+**Maps to**: Acceptance Criterion 5
+
+1. After a fixer resolves a thread via reply + `resolveReviewThread` mutation (no code fix), run the loop to completion.
+2. Check the Automated Reviewer Loop Summary comment posted on the PR.
+
+**Expected result**:
+- The summary comment includes a section (or note) indicating which threads were resolved via reply-only with a short rationale
+- The `Resolved` count in the summary reflects the reply-only resolution
+
+---
+
+## Assertions Checklist
+
+- [ ] AC1: `pr-review-loop.sh` exits `needs_fixes` with `UNRESOLVED_THREAD_COUNT=N` when bot-authored threads are unresolved
+- [ ] AC2: `pr-review-loop.sh` exits `clean` when all bot-authored threads are `isResolved: true` or contain `✅ Addressed`
+- [ ] AC3: Step 8c independent verification rejects the PR when any bot-authored thread is unresolved
+- [ ] AC4: After fixer resolves threads via `resolveReviewThread` mutation and loop re-runs, PR reaches `ready-for-human-review`
+- [ ] AC5: Automated Reviewer Loop Summary includes a note on threads resolved via reply-only
+- [ ] AC6: Human-authored unresolved threads do not trigger the gate (`UNRESOLVED_THREAD_COUNT` counts only bot-authored threads)
+- [ ] AC7: The portfolio orchestrator's pre-readiness verification includes the unresolved-thread check
+
+---
+
+## Seed Data Reference
+
+No persistent seed data required. All test scenarios use live GitHub PRs.
+
+| Entity | Scenario | How to load |
+|---|---|---|
+| Test PR with unresolved CodeRabbit thread | AC1, AC2, AC4 | Create a PR; wait for CodeRabbit to post a Nitpick/Minor comment; do not resolve it |
+| Test PR with `✅ Addressed` comment | AC2 | Push a fix commit to a PR where CodeRabbit has a finding; CodeRabbit auto-appends the marker |
+| Test PR with human-authored thread | AC6 | Open a PR; human reviewer posts an inline comment without resolving it |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `UNRESOLVED_THREAD_COUNT` not in output | Running old version of `pr-review-loop.sh` | Check out feature branch; confirm `check_unresolved_threads` function exists in script |
+| GraphQL query returns 0 threads even though comments exist | Comments are REST inline comments, not review threads | Verify the comment was posted as part of a review (pull request review thread), not a standalone PR comment |
+| `resolveReviewThread` mutation fails with "Not Found" | Using REST `comment_id` instead of GraphQL node `id` | Re-run GraphQL query from Step 1; use the `id` field (node ID starting with `PRT_`) |
+| CodeRabbit thread still shows `isResolved: false` after `✅ Addressed` appears | Normal — `✅ Addressed` in body is the equivalence path | Script should still treat it as resolved; if not, check the `✅ Addressed` grep pattern in `check_unresolved_threads` |
+
+---
+
+## Known Limitations
+
+- This smoke test requires a live GitHub PR with real CodeRabbit/Devin activity. It cannot be run in a fully offline or mocked environment.
+- The `resolveReviewThread` mutation requires the authenticated user to have write access to the repository.


### PR DESCRIPTION
## Summary

Implementation plan for issue #167: extends the `pr-review-loop.sh` readiness gate to block `ready-for-human-review` until every unresolved review thread authored by a configured automated-reviewer bot is resolved (via `resolveReviewThread` mutation or code fix on current HEAD). Also updates Protocol 91 Step 8c independent verification to include the same check as a hard gate.

## Approach

- Add `bot_login_for_platform` and `check_unresolved_threads` functions to `scripts/development-workflow/pr-review-loop.sh`
- Wire the unresolved-thread check into the aggregate exit path (runs after all platforms are clean/skipped)
- Emit `UNRESOLVED_THREAD_COUNT=N` in all exit paths
- Update `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` Step 8c checklist with the GraphQL thread gate

## Complexity

**Medium** — contained entirely in one script and one protocol document; pagination handling and `✅ Addressed` equivalence require care.

## Key Risks

- GraphQL `reviewThreads` pagination (cursor-based) must be handled to avoid silent misses on PRs with many threads
- Bot login list must be derived at runtime from `.ai-dev-workflow.yaml` platforms, not hardcoded

## Links

- Spec: `docs/specs/developments/20260417194629_review-threads-all-resolved/1_review-threads-all-resolved_specs.md`
- Plan: `docs/specs/developments/20260417194629_review-threads-all-resolved/2_review-threads-all-resolved_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/review-threads-all-resolved.smoke-test.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added implementation plan for enforcing review thread resolution before PR ready-for-human-review status
  * Includes updated protocol verification steps and workflow automation specifications

* **Tests**
  * New smoke test runbook with step-by-step scenarios validating review thread resolution gating and GraphQL verification workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->