### PR TITLE
docs(plan): fix(post-merge-cleanup) contradictory log and missing tracker status update

### DIFF
--- a/docs/specs/developments/20260417203259_post-merge-cleanup-log-and-tracker/2_post-merge-cleanup-log-and-tracker_implementation-plan.md
+++ b/docs/specs/developments/20260417203259_post-merge-cleanup-log-and-tracker/2_post-merge-cleanup-log-and-tracker_implementation-plan.md
@@ -124,16 +124,21 @@ update_tracker_status() {
     return 0
   fi
 
-  project_id=$(gh project view "$project_number" --owner "$owner" --format json 2>/dev/null | jq -r '.id // empty')
+  # Note: each `gh`/`jq` pipeline below is wrapped with `|| true` so that, under the
+  # script's `set -euo pipefail`, a failed API call (auth missing, rate-limit, project not
+  # found, etc.) produces an empty string the `[ -z ... ]` guard can detect and handle —
+  # rather than aborting the entire `post-merge-cleanup.sh` script before reaching the
+  # warn-and-continue fallback.
+  project_id=$(gh project view "$project_number" --owner "$owner" --format json 2>/dev/null | jq -r '.id // empty' || true)
   if [ -z "$project_id" ]; then
     echo "Warning: could not resolve project ID for project #${project_number}; skipping tracker status update."
     return 0
   fi
 
   # Resolve Status field ID and option ID for the requested label
-  field_json=$(gh project field-list "$project_number" --owner "$owner" --format json 2>/dev/null)
-  field_id=$(echo "$field_json" | jq -r '.fields[] | select(.name == "Status") | .id // empty')
-  option_id=$(echo "$field_json" | jq -r --arg label "$status_label" '.fields[] | select(.name == "Status") | .options[] | select(.name == $label) | .id // empty')
+  field_json=$(gh project field-list "$project_number" --owner "$owner" --format json 2>/dev/null || true)
+  field_id=$(printf '%s' "$field_json" | jq -r '.fields[] | select(.name == "Status") | .id // empty' || true)
+  option_id=$(printf '%s' "$field_json" | jq -r --arg label "$status_label" '.fields[] | select(.name == "Status") | .options[] | select(.name == $label) | .id // empty' || true)
   if [ -z "$field_id" ] || [ -z "$option_id" ]; then
     echo "Warning: could not resolve Status field or option '${status_label}'; skipping tracker status update."
     return 0
@@ -141,7 +146,7 @@ update_tracker_status() {
 
   # Resolve project item ID for the issue
   item_id=$(gh project item-list "$project_number" --owner "$owner" --format json 2>/dev/null \
-    | jq -r --argjson num "$issue_number" '.items[] | select(.content.number == $num) | .id // empty')
+    | jq -r --argjson num "$issue_number" '.items[] | select(.content.number == $num) | .id // empty' || true)
   if [ -z "$item_id" ]; then
     echo "Warning: issue #${issue_number} not found in project #${project_number}; skipping tracker status update."
     return 0

--- a/docs/specs/developments/20260417203259_post-merge-cleanup-log-and-tracker/2_post-merge-cleanup-log-and-tracker_implementation-plan.md
+++ b/docs/specs/developments/20260417203259_post-merge-cleanup-log-and-tracker/2_post-merge-cleanup-log-and-tracker_implementation-plan.md
@@ -1,7 +1,7 @@
 # fix(post-merge-cleanup): Contradictory Log Output and Missing Tracker Status Update — Implementation Plan
 
 **Spec**: [1_post-merge-cleanup-log-and-tracker_specs.md](1_post-merge-cleanup-log-and-tracker_specs.md)
-**Smoke test runbook**: [../../testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md](../../../testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md)
+**Smoke test runbook**: [../../../testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md](../../../testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md)
 
 ---
 

--- a/docs/specs/developments/20260417203259_post-merge-cleanup-log-and-tracker/2_post-merge-cleanup-log-and-tracker_implementation-plan.md
+++ b/docs/specs/developments/20260417203259_post-merge-cleanup-log-and-tracker/2_post-merge-cleanup-log-and-tracker_implementation-plan.md
@@ -116,8 +116,11 @@ update_tracker_status() {
   local status_label="$2"
   local owner project_number project_id field_id option_id item_id
 
-  # Resolve owner and project number
-  owner="${GITHUB_PROJECT_OWNER:-$(gh repo view --json owner --jq '.owner.login' 2>/dev/null)}"
+  # Resolve owner and project number. The `|| true` guard on the `gh repo view` fallback
+  # is mandatory: under `set -euo pipefail`, a failed command substitution in a parameter
+  # expansion default would propagate non-zero and abort the script before the
+  # `[ -z "$owner" ]` guard below can emit the warning and return 0.
+  owner="${GITHUB_PROJECT_OWNER:-$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || true)}"
   project_number="${GITHUB_PROJECT_NUMBER:-}"
   if [ -z "$owner" ] || [ -z "$project_number" ]; then
     echo "Warning: GITHUB_PROJECT_OWNER or GITHUB_PROJECT_NUMBER not set; skipping tracker status update."

--- a/docs/specs/developments/20260417203259_post-merge-cleanup-log-and-tracker/2_post-merge-cleanup-log-and-tracker_implementation-plan.md
+++ b/docs/specs/developments/20260417203259_post-merge-cleanup-log-and-tracker/2_post-merge-cleanup-log-and-tracker_implementation-plan.md
@@ -1,0 +1,182 @@
+# fix(post-merge-cleanup): Contradictory Log Output and Missing Tracker Status Update — Implementation Plan
+
+**Spec**: [1_post-merge-cleanup-log-and-tracker_specs.md](1_post-merge-cleanup-log-and-tracker_specs.md)
+**Smoke test runbook**: [../../testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md](../../../testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Unify the two separate issue-number extraction regexes in `post-merge-cleanup.sh` into a single code path that covers all branch prefixes (`fix`, `feature`, `hotfix`, `refactor`, `spec`, `implementation-plan`), then add a `update_tracker_status` helper that calls the `updateProjectV2ItemFieldValue` GraphQL mutation using the already-available `gh` CLI to set the project board Status after each merge.
+
+**Estimated complexity**: S
+
+**Rationale**: Both changes are confined to a single shell script with no dependencies on other files. The GraphQL pattern is already documented in `docs/ai/development-workflow/integrations/github-projects.md` and similar patterns exist elsewhere in the workflow. No schema changes, no frontend, no new packages.
+
+**Dependencies**: None. (The #177 plan adds `git worktree unlock` + force-remove near the `git worktree remove` call — a disjoint line range from the issue-number detection block and the new tracker update block. The two changes will apply cleanly on top of each other.)
+
+---
+
+## Layer-by-Layer Changes
+
+### Scripts / Shell (`scripts/development-workflow/post-merge-cleanup.sh`)
+
+- [ ] **Unify issue-number extraction** (Bug Fix 1 — contradictory log output):
+  Replace the two separate `if/elif` regex blocks for `(fix|feature|hotfix|refactor)` and `(spec|implementation-plan)` with a single block that captures the issue number from any matching prefix and sets a `BRANCH_TYPE` variable (`implementation`, `spec`, or `plan`). The `STAGE_ISSUE` variable and the separate `ISSUE_NUMBER` variable are merged into a single `ISSUE_NUMBER` extraction followed by a `BRANCH_TYPE` classification. This eliminates the code path that sets `STAGE_ISSUE` without setting `ISSUE_NUMBER`, which is the root cause of the spurious "No issue number detected" fallthrough for spec/plan branches.
+
+- [ ] **Add `update_tracker_status` helper function**: Implement a bash function `update_tracker_status <issue_number> <status_label>` that:
+  1. Reads `GITHUB_PROJECT_NUMBER` and `GITHUB_PROJECT_OWNER` from environment (with fallback to querying the repo owner via `gh repo view --json owner`).
+  2. Fetches the project node ID: `gh project view <NUMBER> --owner <OWNER> --format json | jq -r '.id'`.
+  3. Fetches the Status field ID and the option ID for `<status_label>` via `gh project field-list`.
+  4. Fetches the project item ID for the issue via `gh project item-list`.
+  5. Runs the `updateProjectV2ItemFieldValue` GraphQL mutation via `gh api graphql`.
+  6. On any step failure, logs a `Warning:` line and returns 0 (best-effort, non-fatal).
+
+- [ ] **Call `update_tracker_status` from the unified issue-number block**:
+  - If `BRANCH_TYPE=spec`: call `update_tracker_status "$ISSUE_NUMBER" "Spec Ready"`.
+  - If `BRANCH_TYPE=plan`: call `update_tracker_status "$ISSUE_NUMBER" "Plan Ready"`.
+  - If `BRANCH_TYPE=implementation`: after the existing issue-close logic, call `update_tracker_status "$ISSUE_NUMBER" "Merged"`.
+
+- [ ] **Emit exactly one log line per branch** for the issue-number outcome:
+  - Issue detected + stays open (spec/plan): one line, e.g. `Plan/spec branch for issue #N merged; issue stays open for the next workflow stage. Updating tracker status to <Status>...`
+  - Issue detected + closed (implementation): the existing close log lines are preserved; add one line for tracker update.
+  - No issue number detected: one line (existing), no tracker update.
+
+### Documentation (`docs/ai/development-workflow/integrations/github-projects.md`)
+
+- [ ] **Align "Post-Merge Cleanup" section (Step 3)**: Update the step list under "Post-Merge Cleanup" (currently only mentions closing the issue and setting status to `Merged`) to reflect that all branch types now update tracker status:
+  - `spec/*` → `Spec Ready`
+  - `implementation-plan/*` → `Plan Ready`
+  - `feature/*`, `fix/*`, `refactor/*`, `hotfix/*` → `Merged` (and closes issue)
+
+---
+
+## Testing Strategy
+
+**Test types**: Manual smoke test (shell script — no automated unit test suite in this repo for scripts)
+
+**Key scenarios to test**:
+1. Run `post-merge-cleanup.sh spec/184-…` (simulated/dry-run path) — single log line, no "No issue number detected", tracker update attempted for `Spec Ready` — maps to AC 1 and AC 4
+2. Run `post-merge-cleanup.sh implementation-plan/184-…` — single log line, tracker update attempted for `Plan Ready` — maps to AC 2 and AC 5
+3. Run `post-merge-cleanup.sh feature/184-…` — issue close preserved, tracker update attempted for `Merged` — maps to AC 3
+4. Run with a branch that has no numeric prefix — single "No issue number detected" line, no tracker update — maps to AC 6
+5. Run with GitHub Projects env vars absent or pointing to non-existent project — script exits 0 with warning — maps to AC 7
+
+**Smoke test runbook**: [`docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md`](../../../testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md)
+
+---
+
+## Seed Data
+
+Not applicable. This feature modifies a shell script with no database or seed data requirements. Smoke test scenarios are exercised against live GitHub API or simulated by patching environment variables (see runbook).
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/ai/development-workflow/integrations/github-projects.md` — update the "Post-Merge Cleanup" section to list all three status transitions (Spec Ready, Plan Ready, Merged) rather than only Merged. *(This update is planned in the Layer-by-Layer Changes above and executed during implementation.)*
+
+No other project docs require changes. `AGENTS.md`/`CLAUDE.md` reference the `post-merge-cleanup` command but do not describe its internal tracker behavior. `docs/best-practices/2-version-control.md` and Protocol 91 Step 10 already list the correct status transitions without prescribing how the script implements them.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| GitHub Projects API fields not discoverable (project not configured) | Low | Low | Helper is best-effort: logs warning, exits 0. Git cleanup always runs first. |
+| Regex unification accidentally breaks feature/fix/refactor/hotfix issue extraction | Low | Med | New unified regex covers the same patterns; add explicit test cases in smoke runbook for each prefix type |
+| `gh project item-list` returns empty for issues not added to any project | Low | Low | Helper detects empty item ID and logs warning, exits 0 |
+| Collision with #177 impl edits to `post-merge-cleanup.sh` | Low | Low | Edits are in non-overlapping line ranges (worktree unlock near `git worktree remove`; unified regex near `gh issue close`; new tracker block after close block). Batch-merge auto-resolution handles CHANGELOG conflicts. |
+
+---
+
+## Code Samples
+
+```bash
+# Illustrative — adapt during implementation
+
+# Unified issue-number extraction (replaces the two separate if/elif blocks)
+ISSUE_NUMBER=""
+BRANCH_TYPE=""
+if [[ "$TO_DELETE" =~ ^(fix|feature|hotfix|refactor)/([0-9]+)($|-) ]]; then
+  ISSUE_NUMBER="${BASH_REMATCH[2]}"
+  BRANCH_TYPE="implementation"
+elif [[ "$TO_DELETE" =~ ^(spec)/([0-9]+)($|-) ]]; then
+  ISSUE_NUMBER="${BASH_REMATCH[2]}"
+  BRANCH_TYPE="spec"
+elif [[ "$TO_DELETE" =~ ^(implementation-plan)/([0-9]+)($|-) ]]; then
+  ISSUE_NUMBER="${BASH_REMATCH[2]}"
+  BRANCH_TYPE="plan"
+fi
+
+# update_tracker_status helper (illustrative — adapt during implementation)
+update_tracker_status() {
+  local issue_number="$1"
+  local status_label="$2"
+  local owner project_number project_id field_id option_id item_id
+
+  # Resolve owner and project number
+  owner="${GITHUB_PROJECT_OWNER:-$(gh repo view --json owner --jq '.owner.login' 2>/dev/null)}"
+  project_number="${GITHUB_PROJECT_NUMBER:-}"
+  if [ -z "$owner" ] || [ -z "$project_number" ]; then
+    echo "Warning: GITHUB_PROJECT_OWNER or GITHUB_PROJECT_NUMBER not set; skipping tracker status update."
+    return 0
+  fi
+
+  project_id=$(gh project view "$project_number" --owner "$owner" --format json 2>/dev/null | jq -r '.id // empty')
+  if [ -z "$project_id" ]; then
+    echo "Warning: could not resolve project ID for project #${project_number}; skipping tracker status update."
+    return 0
+  fi
+
+  # Resolve Status field ID and option ID for the requested label
+  field_json=$(gh project field-list "$project_number" --owner "$owner" --format json 2>/dev/null)
+  field_id=$(echo "$field_json" | jq -r '.fields[] | select(.name == "Status") | .id // empty')
+  option_id=$(echo "$field_json" | jq -r --arg label "$status_label" '.fields[] | select(.name == "Status") | .options[] | select(.name == $label) | .id // empty')
+  if [ -z "$field_id" ] || [ -z "$option_id" ]; then
+    echo "Warning: could not resolve Status field or option '${status_label}'; skipping tracker status update."
+    return 0
+  fi
+
+  # Resolve project item ID for the issue
+  item_id=$(gh project item-list "$project_number" --owner "$owner" --format json 2>/dev/null \
+    | jq -r --argjson num "$issue_number" '.items[] | select(.content.number == $num) | .id // empty')
+  if [ -z "$item_id" ]; then
+    echo "Warning: issue #${issue_number} not found in project #${project_number}; skipping tracker status update."
+    return 0
+  fi
+
+  echo "Updating tracker status for issue #${issue_number} to '${status_label}'..."
+  gh api graphql -f query="
+    mutation {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: \"${project_id}\"
+        itemId: \"${item_id}\"
+        fieldId: \"${field_id}\"
+        value: { singleSelectOptionId: \"${option_id}\" }
+      }) {
+        projectV2Item { id }
+      }
+    }
+  " 2>/dev/null || echo "Warning: GraphQL mutation failed for issue #${issue_number}; tracker status not updated."
+}
+```
+
+---
+
+## Implementation Order
+
+1. Read the current `scripts/development-workflow/post-merge-cleanup.sh` in full.
+2. Replace the two-block `if/elif` issue-number detection (lines 85–92 in current file) with the unified three-branch block (`implementation` / `spec` / `plan`) that sets both `ISSUE_NUMBER` and `BRANCH_TYPE`.
+3. Implement the `update_tracker_status` function (placed before the issue-number extraction block, after the `cd_workflow_repo_root` call and local variable declarations).
+4. Update the issue-number action block below the extraction:
+   - For `BRANCH_TYPE=spec` and `BRANCH_TYPE=plan`: emit one log line (issue stays open) and call `update_tracker_status`.
+   - For `BRANCH_TYPE=implementation`: preserve the existing issue-close logic; after the close block, call `update_tracker_status "$ISSUE_NUMBER" "Merged"`.
+   - For no issue number: emit the existing single log line (unchanged).
+5. Update `docs/ai/development-workflow/integrations/github-projects.md` — "Post-Merge Cleanup" section.
+6. Write the smoke test runbook at `docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md`.
+7. Run `shellcheck scripts/development-workflow/post-merge-cleanup.sh` and fix any warnings.
+8. Run markdown lint on changed `.md` files: `npx markdownlint-cli2 "docs/specs/developments/20260417203259_post-merge-cleanup-log-and-tracker/*.md" "docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md" "docs/ai/development-workflow/integrations/github-projects.md"`.
+9. Update `CHANGELOG.md` under `[Unreleased]` with an entry for this fix.
+10. Verify the main working tree is clean and all changes are committed to the implementation branch.

--- a/docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md
+++ b/docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md
@@ -11,7 +11,7 @@
 
 Before running this smoke test:
 
-- [ ] You are in the repository root: `cd /path/to/ai-dev-framework-template`
+- [ ] You are in the repository root (replace the path with your local clone location): `cd <your-local-clone-of-ai-dev-framework-template>`
 - [ ] `gh` CLI is authenticated: `gh auth status`
 - [ ] `shellcheck` is available (optional but recommended): `shellcheck --version`
 - [ ] The implementation branch has been built and `scripts/development-workflow/post-merge-cleanup.sh` reflects the changes from this PR
@@ -25,7 +25,7 @@ Before running this smoke test:
 
 | Item | Value |
 |---|---|
-| Repo root | `/path/to/ai-dev-framework-template` |
+| Repo root | Repository root directory |
 | Test branch (spec) | `spec/184-smoke-test-dummy` (create locally, do not push) |
 | Test branch (plan) | `implementation-plan/184-smoke-test-dummy` (create locally, do not push) |
 | Test branch (feature) | `feature/184-smoke-test-dummy` (create locally, do not push) |

--- a/docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md
+++ b/docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md
@@ -149,8 +149,9 @@ echo "$output"
 git branch feature/184-smoke-test-dummy 2>/dev/null || true
 output=$(GITHUB_PROJECT_NUMBER="" GITHUB_PROJECT_OWNER="" \
   ./scripts/development-workflow/post-merge-cleanup.sh feature/184-smoke-test-dummy 2>&1)
+exit_code=$?
 echo "$output"
-echo "Exit code: $?"
+echo "Exit code: $exit_code"
 ```
 
 **Expected result**:

--- a/docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md
+++ b/docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md
@@ -83,7 +83,10 @@ echo "$output"
 **Maps to**: Acceptance Criteria 2 and 5
 
 ```bash
-# Re-create the branch (it was NOT deleted in Step 1 since we passed spec/ above)
+# Re-create the implementation-plan branch only if it does not already exist
+# (Step 1 deleted the spec/* branch, so the implementation-plan/* one should
+# already be present from its creation above — the command is a no-op in that
+# case; if a previous run removed it, this recreates it).
 git branch implementation-plan/184-smoke-test-dummy 2>/dev/null || true
 output=$(./scripts/development-workflow/post-merge-cleanup.sh implementation-plan/184-smoke-test-dummy 2>&1)
 echo "$output"
@@ -169,7 +172,7 @@ git status --porcelain
 git branch --show-current
 ```
 
-**Expected result**: Output is empty (no uncommitted changes). Current branch is `develop`.
+**Expected result**: `git status --porcelain` outputs nothing (no uncommitted changes), and `git branch --show-current` outputs `develop`.
 
 ---
 

--- a/docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md
+++ b/docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md
@@ -1,0 +1,211 @@
+# Smoke Test Runbook: fix(post-merge-cleanup) — Contradictory Log Output and Missing Tracker Status Update
+
+**Feature**: Unified issue-number detection and automatic tracker status update in `post-merge-cleanup.sh`
+**Spec**: [1_post-merge-cleanup-log-and-tracker_specs.md](../../specs/developments/20260417203259_post-merge-cleanup-log-and-tracker/1_post-merge-cleanup-log-and-tracker_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] You are in the repository root: `cd /path/to/ai-dev-framework-template`
+- [ ] `gh` CLI is authenticated: `gh auth status`
+- [ ] `shellcheck` is available (optional but recommended): `shellcheck --version`
+- [ ] The implementation branch has been built and `scripts/development-workflow/post-merge-cleanup.sh` reflects the changes from this PR
+- [ ] For Step 5 (tracker update), you have access to a GitHub Projects v2 project with Status options: `Spec Ready`, `Plan Ready`, `Merged`
+
+> **Important**: Steps 1–4 can be run without a real GitHub Projects setup by checking only the log output and return code. Step 5 requires a live project. Use `GITHUB_PROJECT_NUMBER` and `GITHUB_PROJECT_OWNER` environment variables to point at a test project if needed.
+
+---
+
+## Test Data
+
+| Item | Value |
+|---|---|
+| Repo root | `/path/to/ai-dev-framework-template` |
+| Test branch (spec) | `spec/184-smoke-test-dummy` (create locally, do not push) |
+| Test branch (plan) | `implementation-plan/184-smoke-test-dummy` (create locally, do not push) |
+| Test branch (feature) | `feature/184-smoke-test-dummy` (create locally, do not push) |
+| Test branch (no issue) | `feature/my-legacy-feature` (create locally, do not push) |
+| GitHub issue | `#184` (must exist in the repo) |
+| Project number | `$GITHUB_PROJECT_NUMBER` (set in environment) |
+| Project owner | `$GITHUB_PROJECT_OWNER` (set in environment) |
+
+---
+
+## Smoke Test Steps
+
+### Step 0: Prepare test branches
+
+Create four dummy local branches to use as inputs. These do not need to be pushed to origin or have any commits beyond the current `develop` HEAD.
+
+```bash
+git checkout develop
+git branch spec/184-smoke-test-dummy
+git branch implementation-plan/184-smoke-test-dummy
+git branch feature/184-smoke-test-dummy
+git branch feature/my-legacy-feature
+```
+
+**Expected result**: All four branches created locally. You are still on `develop`.
+
+---
+
+### Step 1: Spec branch — single log line, no "No issue number detected"
+
+**Maps to**: Acceptance Criteria 1 and 4
+
+```bash
+# Capture output; the script will try to delete the branch and switch to develop.
+# We need to be on develop already and not on the test branch.
+# The script exits 0 even if tracker update warns.
+output=$(./scripts/development-workflow/post-merge-cleanup.sh spec/184-smoke-test-dummy 2>&1)
+echo "$output"
+```
+
+**Expected result**:
+
+1. Output contains exactly **one** line that mentions issue `#184` (e.g., contains "184" and "stays open" or "Spec Ready").
+2. Output does **not** contain the phrase `No issue number detected`.
+3. Output **does not** contain two separate messages about the issue — only one.
+4. Script exits 0.
+5. Local branch `spec/184-smoke-test-dummy` is deleted.
+6. If GitHub Projects is configured: output contains a line about "Updating tracker status" or "Spec Ready"; project board for issue #184 shows `Spec Ready`.
+7. If GitHub Projects is not configured (env vars absent): output contains a `Warning:` line mentioning missing project config; script still exits 0.
+
+---
+
+### Step 2: Implementation-plan branch — single log line, tracker update for Plan Ready
+
+**Maps to**: Acceptance Criteria 2 and 5
+
+```bash
+# Re-create the branch (it was NOT deleted in Step 1 since we passed spec/ above)
+git branch implementation-plan/184-smoke-test-dummy 2>/dev/null || true
+output=$(./scripts/development-workflow/post-merge-cleanup.sh implementation-plan/184-smoke-test-dummy 2>&1)
+echo "$output"
+```
+
+**Expected result**:
+
+1. Output contains exactly **one** line mentioning issue `#184`.
+2. Output does **not** contain `No issue number detected`.
+3. Script exits 0.
+4. Local branch `implementation-plan/184-smoke-test-dummy` is deleted.
+5. If GitHub Projects is configured: output mentions `Plan Ready`; project board for issue #184 shows `Plan Ready`.
+6. If GitHub Projects is not configured: `Warning:` line present; script exits 0.
+
+---
+
+### Step 3: Feature branch — issue close preserved, tracker update for Merged
+
+**Maps to**: Acceptance Criterion 3
+
+```bash
+git branch feature/184-smoke-test-dummy 2>/dev/null || true
+output=$(./scripts/development-workflow/post-merge-cleanup.sh feature/184-smoke-test-dummy 2>&1)
+echo "$output"
+```
+
+**Expected result**:
+
+1. Output does **not** contain `No issue number detected`.
+2. Script attempts to close issue #184 (may log "Issue #184 is already CLOSED" or attempt `gh issue close` — both are acceptable).
+3. Script exits 0.
+4. Local branch `feature/184-smoke-test-dummy` is deleted.
+5. If GitHub Projects is configured: output mentions `Merged`; project board for issue #184 shows `Merged`.
+6. If GitHub Projects is not configured: `Warning:` line present; script exits 0.
+
+---
+
+### Step 4: Branch with no issue number — single skip message, no tracker update
+
+**Maps to**: Acceptance Criteria 6
+
+```bash
+git branch feature/my-legacy-feature 2>/dev/null || true
+output=$(./scripts/development-workflow/post-merge-cleanup.sh feature/my-legacy-feature 2>&1)
+echo "$output"
+```
+
+**Expected result**:
+
+1. Output contains exactly **one** line matching `No issue number detected in branch name`.
+2. Output does **not** contain any mention of a tracker update.
+3. Script exits 0.
+4. Local branch `feature/my-legacy-feature` is deleted.
+
+---
+
+### Step 5: GitHub Projects misconfigured — warning, clean exit
+
+**Maps to**: Acceptance Criterion 7
+
+```bash
+# Temporarily unset project env vars to simulate missing config
+git branch feature/184-smoke-test-dummy 2>/dev/null || true
+output=$(GITHUB_PROJECT_NUMBER="" GITHUB_PROJECT_OWNER="" \
+  ./scripts/development-workflow/post-merge-cleanup.sh feature/184-smoke-test-dummy 2>&1)
+echo "$output"
+echo "Exit code: $?"
+```
+
+**Expected result**:
+
+1. Script outputs a `Warning:` line mentioning missing `GITHUB_PROJECT_NUMBER` or `GITHUB_PROJECT_OWNER`.
+2. Script exits 0 (git cleanup completed successfully).
+3. If the branch was not already deleted, it is deleted now. (If deleted in Step 3, re-create it first with `git branch feature/184-smoke-test-dummy`.)
+
+---
+
+### Last Step: Verify main working tree is clean
+
+```bash
+git status --porcelain
+git branch --show-current
+```
+
+**Expected result**: Output is empty (no uncommitted changes). Current branch is `develop`.
+
+---
+
+## Assertions Checklist
+
+Each checkbox maps to an acceptance criterion from the spec.
+
+- [ ] **AC 1**: `post-merge-cleanup.sh spec/<N>-...` → exactly one log line about issue; no "No issue number detected" message (Step 1)
+- [ ] **AC 2**: `post-merge-cleanup.sh implementation-plan/<N>-...` → exactly one log line about issue; no "No issue number detected" message (Step 2)
+- [ ] **AC 3**: `post-merge-cleanup.sh feature/<N>-...` → GitHub Projects v2 Status set to `Merged`; existing issue-close behavior preserved (Step 3)
+- [ ] **AC 4**: `post-merge-cleanup.sh spec/<N>-...` → GitHub Projects v2 Status set to `Spec Ready` (Step 1, with live project)
+- [ ] **AC 5**: `post-merge-cleanup.sh implementation-plan/<N>-...` → GitHub Projects v2 Status set to `Plan Ready` (Step 2, with live project)
+- [ ] **AC 6**: Branch with no numeric issue number → single "No issue number detected" line; no tracker update (Step 4)
+- [ ] **AC 7**: GitHub Projects misconfigured → `Warning:` line; script exits 0; git cleanup completes (Step 5)
+
+---
+
+## Seed Data Reference
+
+Not applicable. No seed data is required. Test branches are created locally during the test and deleted by the script under test.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Local branch 'spec/184-smoke-test-dummy' does not exist` | Branch was not created in Step 0 | Run `git branch spec/184-smoke-test-dummy` from `develop` |
+| `You are on 'develop'. Pass the merged branch name…` | Passed wrong argument or no arg | Pass the branch name explicitly as the first argument |
+| `Warning: GITHUB_PROJECT_OWNER or GITHUB_PROJECT_NUMBER not set` | Env vars not exported | Export `GITHUB_PROJECT_NUMBER` and `GITHUB_PROJECT_OWNER` before running |
+| `Warning: could not resolve project ID` | Wrong project number or owner | Verify with `gh project list --owner <OWNER>` |
+| `Warning: issue #184 not found in project` | Issue not added to the project | Add issue #184 to the project via GitHub UI or `gh project item-add` |
+| Two log lines appear for spec/plan branch | Bug not fully fixed | Review the unified extraction block; ensure `STAGE_ISSUE` variable path is removed |
+
+---
+
+## Known Limitations
+
+- Steps 1–4 validate log output structure but cannot assert tracker field values without a live GitHub Projects setup. Use Step 5 env-var override to test the failure path without real credentials.
+- The script runs real `git checkout develop` and `git branch -D` operations; ensure test branches are truly throwaway before running.

--- a/docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md
+++ b/docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md
@@ -14,7 +14,7 @@ Before running this smoke test:
 - [ ] You are in the repository root (replace the path with your local clone location): `cd <your-local-clone-of-ai-dev-framework-template>`
 - [ ] `gh` CLI is authenticated: `gh auth status`
 - [ ] `shellcheck` is available (optional but recommended): `shellcheck --version`
-- [ ] The implementation branch has been built and `scripts/development-workflow/post-merge-cleanup.sh` reflects the changes from this PR
+- [ ] **The implementation from this plan must already be landed before running this smoke test.** `scripts/development-workflow/post-merge-cleanup.sh` must contain the unified `BRANCH_TYPE`/`ISSUE_NUMBER` extraction, the `update_tracker_status` helper, and the `Spec Ready` / `Plan Ready` / `Merged` status transitions described in the plan. This runbook validates post-implementation behavior; running it against the current `develop` state (where the script is unchanged) will fail Steps 1–5 because the expected output does not yet exist
 - [ ] For Step 5 (tracker update), you have access to a GitHub Projects v2 project with Status options: `Spec Ready`, `Plan Ready`, `Merged`
 
 > **Important**: Steps 1–4 can be run without a real GitHub Projects setup by checking only the log output and return code. Step 5 requires a live project. Use `GITHUB_PROJECT_NUMBER` and `GITHUB_PROJECT_OWNER` environment variables to point at a test project if needed.
@@ -63,7 +63,9 @@ git branch feature/my-legacy-feature
 # We need to be on develop already and not on the test branch.
 # The script exits 0 even if tracker update warns.
 output=$(./scripts/development-workflow/post-merge-cleanup.sh spec/184-smoke-test-dummy 2>&1)
+exit_code=$?
 echo "$output"
+echo "Exit code: $exit_code"
 ```
 
 **Expected result**:
@@ -89,7 +91,9 @@ echo "$output"
 # case; if a previous run removed it, this recreates it).
 git branch implementation-plan/184-smoke-test-dummy 2>/dev/null || true
 output=$(./scripts/development-workflow/post-merge-cleanup.sh implementation-plan/184-smoke-test-dummy 2>&1)
+exit_code=$?
 echo "$output"
+echo "Exit code: $exit_code"
 ```
 
 **Expected result**:
@@ -110,7 +114,9 @@ echo "$output"
 ```bash
 git branch feature/184-smoke-test-dummy 2>/dev/null || true
 output=$(./scripts/development-workflow/post-merge-cleanup.sh feature/184-smoke-test-dummy 2>&1)
+exit_code=$?
 echo "$output"
+echo "Exit code: $exit_code"
 ```
 
 **Expected result**:
@@ -131,7 +137,9 @@ echo "$output"
 ```bash
 git branch feature/my-legacy-feature 2>/dev/null || true
 output=$(./scripts/development-workflow/post-merge-cleanup.sh feature/my-legacy-feature 2>&1)
+exit_code=$?
 echo "$output"
+echo "Exit code: $exit_code"
 ```
 
 **Expected result**:


### PR DESCRIPTION
## Summary

This plan covers two bugs in `scripts/development-workflow/post-merge-cleanup.sh` that recur on every spec/plan/implementation branch merge:

- **Bug 1 (contradictory log output)**: For `spec/*` and `implementation-plan/*` branches, the script emits two conflicting log lines — one correct "issue stays open" message and one spurious "No issue number detected" message — because issue extraction was split into two separate code paths.
- **Bug 2 (missing tracker status update)**: The script never updates the GitHub Projects v2 Status field after any merge. Implementation branches close the issue but leave the project board stale; spec/plan branches do neither.

## Approach

- Unify the two separate `if/elif` issue-number regex blocks into a single three-branch block that sets both `ISSUE_NUMBER` and a `BRANCH_TYPE` variable (`implementation` / `spec` / `plan`).
- Add a `update_tracker_status` helper function that calls `updateProjectV2ItemFieldValue` GraphQL mutation via `gh api graphql`. Best-effort: logs a warning and exits 0 on any failure (missing env vars, project not configured, item not found).
- Call `update_tracker_status` for all branch types: `Spec Ready` for `spec/*`, `Plan Ready` for `implementation-plan/*`, `Merged` for `feature/fix/refactor/hotfix/*`.
- Update `docs/ai/development-workflow/integrations/github-projects.md` "Post-Merge Cleanup" section to reflect all three transitions.

**Estimated complexity**: S (single shell script, no schema or frontend changes)

**Dependencies**: None (#177 plan edits disjoint line ranges; batch-merge resolves CHANGELOG conflicts)

## Files

- Plan: [`docs/specs/developments/20260417203259_post-merge-cleanup-log-and-tracker/2_post-merge-cleanup-log-and-tracker_implementation-plan.md`](docs/specs/developments/20260417203259_post-merge-cleanup-log-and-tracker/2_post-merge-cleanup-log-and-tracker_implementation-plan.md)
- Smoke test runbook: [`docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md`](docs/testing/workflow/184-post-merge-cleanup-log-and-tracker.smoke-test.md)

## Key Risks

- Regex unification might accidentally break existing feature/fix extraction (mitigated by explicit smoke test coverage for each prefix type)
- Collision with #177 plan is low-risk (disjoint line ranges)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an implementation plan for the post-merge cleanup workflow: unified issue-number detection across branch types, defined tracker-status points (Spec Ready / Plan Ready / Merged), and a best-effort tracker-update that logs non-fatal warnings on failure.
  * Added a smoke test runbook covering branch scenarios, step-by-step checks and acceptance criteria, misconfiguration handling, troubleshooting, and final cleanup verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->