### PR TITLE
docs(plan): Write/Edit path guardrail for isolated worktrees (#193)

### DIFF
--- a/docs/specs/developments/20260418003426_193-worktree-write-paths-guardrail/2_193-worktree-write-paths-guardrail_implementation-plan.md
+++ b/docs/specs/developments/20260418003426_193-worktree-write-paths-guardrail/2_193-worktree-write-paths-guardrail_implementation-plan.md
@@ -1,0 +1,159 @@
+# fix(item-orchestrator): Write/Edit path guardrail for isolated worktrees — Implementation Plan
+
+**Spec**: [`1_193-worktree-write-paths-guardrail_specs.md`](./1_193-worktree-write-paths-guardrail_specs.md)
+**Smoke test runbook**: [`docs/testing/workflow/193-worktree-write-paths-guardrail.smoke-test.md`](../../../testing/workflow/193-worktree-write-paths-guardrail.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add an explicit `Write`/`Edit` path guardrail reminder to the worktree isolation section of Protocol 91 Step 3, instructing agents that all `Write` and `Edit` tool calls must target paths under the resolved `<worktree-path>` value — not the main repo root. Mirror identical reminder language into both `.claude/agents/item-orchestrator.md` and `.cursor/agents/item-orchestrator.md` (dual-agent sync). Optionally document the pre-tool-use hook design for `WORKTREE_ROOT`-based path validation. No scripts are modified.
+
+**Estimated complexity**: S
+
+**Rationale**: All changes are documentation-only (one protocol file + two agent prompt files). No code, scripts, or infrastructure changes are required. The guardrail is a targeted prose addition to an existing section.
+
+**Dependencies**: None — no other in-progress issues block this work. Note: issue #192 touches the same worktree-discipline section of Protocol 91 for the `git switch`/`git checkout` rule; at the plan stage there is no overlap. At implementation the two changes must be applied to separate lines or paragraphs; a merge conflict is expected and resolved by the developer.
+
+---
+
+## Layer-by-Layer Changes
+
+### Protocol Documentation
+
+- [ ] **`docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`** — In the Step 3 worktree isolation block (after the existing `git switch`/`git reset` safety rule), add an explicit `Write`/`Edit` path guardrail subsection (see Implementation Order Step 1 for the exact prose placement and required content).
+
+### Agent Prompt Files
+
+- [ ] **`.claude/agents/item-orchestrator.md`** — Append a short worktree path reminder instruction after the existing key responsibilities list: when `BATCH_CONTEXT=true`, all `Write` and `Edit` calls must target paths under the resolved worktree path, and any main-repo-absolute path is a red flag to correct before calling the tool (see Implementation Order Step 2).
+- [ ] **`.cursor/agents/item-orchestrator.md`** — Apply the identical change as `.claude/agents/item-orchestrator.md` in the same relative position (dual-agent consistency). The two files must remain in sync (see Implementation Order Step 3).
+
+---
+
+## Testing Strategy
+
+**Test types**: Smoke (manual, doc-review walkthrough)
+
+**Key scenarios to test**:
+
+1. Protocol 91 Step 3 worktree section contains the Write/Edit path guardrail reminder with the `<worktree-path>` runtime-value requirement — maps to AC1
+2. The reminder specifies that `<worktree-path>` must be resolved to its runtime value before injection into handoffs — maps to AC2
+3. The reminder specifies it must appear in every stage-agent handoff (not just the first) — maps to AC3
+4. The protocol language makes clear the guardrail applies only when `BATCH_CONTEXT=true` — maps to AC4
+5. (Optional) A pre-tool-use hook design is described — maps to AC5
+6. (Optional) The hook spec states `WORKTREE_ROOT` unset is a no-op — maps to AC6
+7. Non-batch behavior is unchanged; no spurious changes to Protocol 90, `post-merge-cleanup.sh`, `pr-review-loop.sh`, or issue #192's scope — maps to AC7
+8. `.claude/agents/item-orchestrator.md` and `.cursor/agents/item-orchestrator.md` have identical reminder language — confirms dual-agent sync
+
+**Smoke test runbook**: [`docs/testing/workflow/193-worktree-write-paths-guardrail.smoke-test.md`](../../../testing/workflow/193-worktree-write-paths-guardrail.smoke-test.md)
+
+**Regression suite**: No automated regression suite exists in this repository.
+
+---
+
+## Seed Data
+
+No seed data required. All changes are documentation-only.
+
+| Entity | Values / Scenario | File |
+|---|---|---|
+| N/A | — | — |
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` — Primary change target (Step 3 worktree isolation section). Already listed under Layer-by-Layer Changes.
+- [ ] `.claude/agents/item-orchestrator.md` — Primary change target (agent prompt). Already listed under Layer-by-Layer Changes.
+- [ ] `.cursor/agents/item-orchestrator.md` — Primary change target (agent prompt, dual-sync). Already listed under Layer-by-Layer Changes.
+
+No additional `docs/project/` files or `AGENTS.md` need updating; this change does not alter the public-facing project overview, architecture docs, or best-practice guides.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Merge conflict with #192 in Protocol 91 Step 3 | Med | Low | Resolve at impl time: #192 adds `git switch` prose, this PR adds `Write`/`Edit` prose — apply to adjacent lines or paragraphs with clear labels |
+| `.claude` and `.cursor` agent files diverge | Low | Med | Implementation Order enforces applying both files in the same commit before pushing |
+| Guardrail reminder is too generic and agents ignore it | Low | Med | Include the literal resolved `<worktree-path>` value instruction (not a static placeholder) so agents can compare at runtime |
+
+---
+
+## Code Samples
+
+> All samples below are **illustrative — adapt during implementation**.
+
+### Protocol 91 Step 3 — Write/Edit Path Guardrail addition
+
+The following prose block should be inserted in the Step 3 worktree isolation section, immediately after the existing critical safety rule for `git switch`/`git checkout`/`git reset`:
+
+```markdown
+**Critical safety rule — Write and Edit paths inside a worktree**: Every `Write` and
+`Edit` tool call issued within an active worktree session **must** target a path under
+`<worktree-path>/...`. Any path that does NOT begin with the resolved `<worktree-path>`
+value is a main-repo path — treat it as a red flag and correct it before calling the tool.
+
+- Before calling `Write` or `Edit`, mentally verify: "Does this absolute path start with
+  `<worktree-path>/`?" If not, prepend `<worktree-path>/` to the relative portion of the
+  path.
+- The item-orchestrator must include the resolved literal value of `<worktree-path>` in
+  every stage-agent handoff (not just the first), so each agent can validate paths against
+  it independently.
+- Paths under `<worktree-path>/.tmp/` are within the worktree boundary and are permitted.
+- This rule applies only when `BATCH_CONTEXT=true` and a dedicated worktree exists; for
+  non-batch runs, no reminder is injected.
+```
+
+### Optional pre-tool-use hook design (Use Case 2)
+
+Add a short reference block to the same Step 3 section, after the Write/Edit path guardrail, to document the optional hook:
+
+```markdown
+**Optional: pre-tool-use hook for WORKTREE_ROOT validation**
+
+A pre-tool-use hook can enforce the Write/Edit path rule automatically:
+
+1. Set the `WORKTREE_ROOT` environment variable to the resolved worktree path when
+   launching the agent session.
+2. In the hook, intercept `Write` and `Edit` tool calls only.
+3. If `WORKTREE_ROOT` is unset, skip the check (non-worktree session — no-op).
+4. If the target path does not start with `$WORKTREE_ROOT`, emit:
+   `"GUARDRAIL: Write/Edit target '<path>' is outside the designated worktree
+   '<WORKTREE_ROOT>'. Correct the path before proceeding."`
+5. The hook must NOT intercept read-only tools (`Read`, `Glob`, `Grep`).
+```
+
+### `.claude/agents/item-orchestrator.md` reminder addition
+
+Append after the existing key responsibilities list:
+
+```markdown
+Notes:
+- Agent threads always have their cwd reset between bash calls, as a result please only use absolute file paths.
+- In your final response, share file paths (always absolute, never relative) that are relevant to the task. Include code snippets only when the exact text is load-bearing (e.g., a bug you found, a function signature the caller asked for) — do not recap code you merely read.
+- For clear communication with the user the assistant MUST avoid using emojis.
+- Do not use a colon before tool calls. Text like "Let me read the file:" followed by a read tool call should just be "Let me read the file." with a period.
+- Do NOT Write report/summary/findings/analysis .md files. Return findings directly as your final assistant message — the parent agent reads your text output, not files you create.
+- **Worktree Write/Edit path discipline (BATCH_CONTEXT=true only)**: When running inside an isolated worktree, all `Write` and `Edit` tool calls must target paths under the resolved `<worktree-path>/...`. Any absolute path that does NOT begin with `<worktree-path>/` is a main-repo path — correct it before calling the tool. Include the literal resolved `<worktree-path>` value in every stage-agent handoff so each agent can validate its own paths independently.
+```
+
+---
+
+## Implementation Order
+
+1. **Update Protocol 91 Step 3** — In `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`, locate the "Critical safety rule — never modify the main working tree's branch" bullet block inside the Step 3 worktree isolation section. Immediately after that block (before the "4. Suggested worktree path" item), insert the "Write and Edit paths inside a worktree" critical safety rule prose and the optional pre-tool-use hook design block (see Code Samples above).
+
+2. **Update `.claude/agents/item-orchestrator.md`** — Append the "Notes" block (including the worktree Write/Edit path discipline bullet) after the existing key responsibilities list in the agent file (see Code Samples above). Keep the `---` frontmatter and `tools:` line unchanged.
+
+3. **Update `.cursor/agents/item-orchestrator.md`** — Apply the identical Notes block addition in the same relative position as step 2. The two agent files must be updated in the same commit to ensure they stay in sync.
+
+4. **Commit** — Single commit with all three files: `fix(item-orchestrator): add Write/Edit path guardrail for isolated worktrees`
+
+5. **Update CHANGELOG** — Add an entry under `[Unreleased]`:
+   - Under `Fixed`: `fix(item-orchestrator): item-orchestrator agents running in isolated git worktrees now receive an explicit reminder that all Write/Edit tool calls must target paths under the resolved worktree path, not the main repo root; same guardrail added to both Claude Code and Cursor agent prompts (#193)`
+
+6. **Push and open draft PR** targeting `develop`
+
+7. **Verify smoke test runbook** — Confirm all AC checkboxes map to testable steps in `docs/testing/workflow/193-worktree-write-paths-guardrail.smoke-test.md`

--- a/docs/specs/developments/20260418003426_193-worktree-write-paths-guardrail/2_193-worktree-write-paths-guardrail_implementation-plan.md
+++ b/docs/specs/developments/20260418003426_193-worktree-write-paths-guardrail/2_193-worktree-write-paths-guardrail_implementation-plan.md
@@ -148,10 +148,10 @@ Append after the existing key responsibilities list (after the last bullet point
 
 3. **Update `.cursor/agents/item-orchestrator.md`** — Apply the identical worktree Write/Edit path discipline bullet in the same relative position as step 2. The two agent files must be updated in the same commit to ensure they stay in sync.
 
-4. **Commit** — Single commit with all three files: `fix(item-orchestrator): add Write/Edit path guardrail for isolated worktrees`
-
-5. **Update CHANGELOG** — Add an entry under `[Unreleased]`:
+4. **Update CHANGELOG** — Add an entry under `[Unreleased]` in `CHANGELOG.md`:
    - Under `Fixed`: `fix(item-orchestrator): item-orchestrator agents running in isolated git worktrees now receive an explicit reminder that all Write/Edit tool calls must target paths under the resolved worktree path, not the main repo root; same guardrail added to both Claude Code and Cursor agent prompts (#193)`
+
+5. **Commit** — Single commit with all four files (Protocol 91, `.claude/agents/item-orchestrator.md`, `.cursor/agents/item-orchestrator.md`, `CHANGELOG.md`): `fix(item-orchestrator): add Write/Edit path guardrail for isolated worktrees`
 
 6. **Push and open draft PR** targeting `develop`
 

--- a/docs/specs/developments/20260418003426_193-worktree-write-paths-guardrail/2_193-worktree-write-paths-guardrail_implementation-plan.md
+++ b/docs/specs/developments/20260418003426_193-worktree-write-paths-guardrail/2_193-worktree-write-paths-guardrail_implementation-plan.md
@@ -127,16 +127,15 @@ A pre-tool-use hook can enforce the Write/Edit path rule automatically:
 
 ### `.claude/agents/item-orchestrator.md` reminder addition
 
-Append after the existing key responsibilities list:
+Append after the existing key responsibilities list (after the last bullet point, before the end of the file):
 
 ```markdown
-Notes:
-- Agent threads always have their cwd reset between bash calls, as a result please only use absolute file paths.
-- In your final response, share file paths (always absolute, never relative) that are relevant to the task. Include code snippets only when the exact text is load-bearing (e.g., a bug you found, a function signature the caller asked for) — do not recap code you merely read.
-- For clear communication with the user the assistant MUST avoid using emojis.
-- Do not use a colon before tool calls. Text like "Let me read the file:" followed by a read tool call should just be "Let me read the file." with a period.
-- Do NOT Write report/summary/findings/analysis .md files. Return findings directly as your final assistant message — the parent agent reads your text output, not files you create.
-- **Worktree Write/Edit path discipline (BATCH_CONTEXT=true only)**: When running inside an isolated worktree, all `Write` and `Edit` tool calls must target paths under the resolved `<worktree-path>/...`. Any absolute path that does NOT begin with `<worktree-path>/` is a main-repo path — correct it before calling the tool. Include the literal resolved `<worktree-path>` value in every stage-agent handoff so each agent can validate its own paths independently.
+- **Worktree Write/Edit path discipline (BATCH_CONTEXT=true only)**: When running inside
+  an isolated worktree, all `Write` and `Edit` tool calls must target paths under the
+  resolved `<worktree-path>/...`. Any absolute path that does NOT begin with
+  `<worktree-path>/` is a main-repo path — correct it before calling the tool. Include
+  the literal resolved `<worktree-path>` value in every stage-agent handoff so each
+  dispatched agent can validate its own paths independently.
 ```
 
 ---
@@ -145,9 +144,9 @@ Notes:
 
 1. **Update Protocol 91 Step 3** — In `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`, locate the "Critical safety rule — never modify the main working tree's branch" bullet block inside the Step 3 worktree isolation section. Immediately after that block (before the "4. Suggested worktree path" item), insert the "Write and Edit paths inside a worktree" critical safety rule prose and the optional pre-tool-use hook design block (see Code Samples above).
 
-2. **Update `.claude/agents/item-orchestrator.md`** — Append the "Notes" block (including the worktree Write/Edit path discipline bullet) after the existing key responsibilities list in the agent file (see Code Samples above). Keep the `---` frontmatter and `tools:` line unchanged.
+2. **Update `.claude/agents/item-orchestrator.md`** — Append the worktree Write/Edit path discipline bullet to the existing key responsibilities list (after the last existing bullet, before the end of the file). See Code Samples above for the exact bullet text. Keep the `---` frontmatter and `tools:` line unchanged.
 
-3. **Update `.cursor/agents/item-orchestrator.md`** — Apply the identical Notes block addition in the same relative position as step 2. The two agent files must be updated in the same commit to ensure they stay in sync.
+3. **Update `.cursor/agents/item-orchestrator.md`** — Apply the identical worktree Write/Edit path discipline bullet in the same relative position as step 2. The two agent files must be updated in the same commit to ensure they stay in sync.
 
 4. **Commit** — Single commit with all three files: `fix(item-orchestrator): add Write/Edit path guardrail for isolated worktrees`
 

--- a/docs/testing/workflow/193-worktree-write-paths-guardrail.smoke-test.md
+++ b/docs/testing/workflow/193-worktree-write-paths-guardrail.smoke-test.md
@@ -98,7 +98,7 @@ Before running this smoke test:
 2. Locate the worktree Write/Edit path discipline reminder after the key responsibilities list.
 3. Open `.cursor/agents/item-orchestrator.md`.
 4. Confirm the identical reminder language is present in the same relative position.
-5. Confirm no other content differs between the two files beyond the `model:` and `tools:` frontmatter fields (which legitimately differ).
+5. Confirm no other content differs between the two files beyond legitimate frontmatter differences: `.claude/agents/item-orchestrator.md` has `model: claude-sonnet-4-6` and a `tools:` line, while `.cursor/agents/item-orchestrator.md` has `model: inherit` and omits the `tools:` field.
 
 **Expected result**: Worktree path reminder is identical in both agent files.
 

--- a/docs/testing/workflow/193-worktree-write-paths-guardrail.smoke-test.md
+++ b/docs/testing/workflow/193-worktree-write-paths-guardrail.smoke-test.md
@@ -86,7 +86,7 @@ Before running this smoke test:
 3. Verify Protocol 90 (`90-batch-orchestrate-work-protocol.md`) was not changed by this PR.
 4. Verify `scripts/development-workflow/post-merge-cleanup.sh` and `scripts/development-workflow/pr-review-loop.sh` were not changed by this PR.
 
-**Expected result**: Zero diffs outside the three targeted files (Protocol 91 Step 3, `.claude/agents/item-orchestrator.md`, `.cursor/agents/item-orchestrator.md`).
+**Expected result**: Zero diffs outside the targeted files (Protocol 91 Step 3, `.claude/agents/item-orchestrator.md`, `.cursor/agents/item-orchestrator.md`, and `CHANGELOG.md`).
 
 ---
 
@@ -95,7 +95,7 @@ Before running this smoke test:
 **Maps to**: Acceptance Criterion for dual-agent consistency
 
 1. Open `.claude/agents/item-orchestrator.md`.
-2. Locate the worktree Write/Edit path discipline reminder in the Notes block.
+2. Locate the worktree Write/Edit path discipline reminder after the key responsibilities list.
 3. Open `.cursor/agents/item-orchestrator.md`.
 4. Confirm the identical reminder language is present in the same relative position.
 5. Confirm no other content differs between the two files beyond the `model:` and `tools:` frontmatter fields (which legitimately differ).

--- a/docs/testing/workflow/193-worktree-write-paths-guardrail.smoke-test.md
+++ b/docs/testing/workflow/193-worktree-write-paths-guardrail.smoke-test.md
@@ -1,0 +1,150 @@
+# Smoke Test Runbook: Write/Edit Path Guardrail for Isolated Worktrees
+
+**Feature**: fix(item-orchestrator): Write/Edit path guardrail for isolated worktrees (#193)
+**Spec**: [`docs/specs/developments/20260418003426_193-worktree-write-paths-guardrail/1_193-worktree-write-paths-guardrail_specs.md`](../../specs/developments/20260418003426_193-worktree-write-paths-guardrail/1_193-worktree-write-paths-guardrail_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] Working copy is on `develop` (or the feature branch after merge)
+- [ ] No worktrees with leaked files are present in the main repo root
+- [ ] You have `gh` CLI configured and authenticated
+
+---
+
+## Test Data
+
+| Item | Value |
+|---|---|
+| Protocol file | `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` |
+| Claude agent file | `.claude/agents/item-orchestrator.md` |
+| Cursor agent file | `.cursor/agents/item-orchestrator.md` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify Protocol 91 Step 3 contains the Write/Edit guardrail
+
+**Maps to**: Acceptance Criterion 1 and 2
+
+1. Open `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`.
+2. Navigate to Step 3 (Dispatch Strategy) → worktree isolation subsection.
+3. Locate the critical safety rule block for `Write` and `Edit` paths.
+4. Confirm the block explicitly states that all `Write` and `Edit` tool calls must target paths under `<worktree-path>/...`.
+5. Confirm the block states that `<worktree-path>` must be resolved to its **runtime value** (not left as a static placeholder) before injection into stage-agent handoffs.
+
+**Expected result**: The guardrail prose is present in Step 3 and references the runtime-resolved `<worktree-path>`.
+
+---
+
+### Step 2: Verify the reminder covers every stage-agent handoff
+
+**Maps to**: Acceptance Criterion 3
+
+1. In the same guardrail block, look for the instruction that the item-orchestrator must include the reminder in **every** stage-agent handoff, not only the first.
+2. Confirm the block explicitly says "every stage-agent handoff" or equivalent language.
+
+**Expected result**: The text clearly mandates repeated inclusion across all handoffs in a batch run.
+
+---
+
+### Step 3: Verify the guardrail is scoped to BATCH_CONTEXT=true
+
+**Maps to**: Acceptance Criterion 4
+
+1. Confirm the guardrail prose states the rule applies only when `BATCH_CONTEXT=true` (a dedicated worktree exists).
+2. Confirm non-batch runs (no worktree) are explicitly excluded or the block notes this is a no-op when `BATCH_CONTEXT=false`.
+
+**Expected result**: The scoping condition is unambiguous.
+
+---
+
+### Step 4: Verify optional pre-tool-use hook design (if implemented)
+
+**Maps to**: Acceptance Criterion 5 and 6
+
+1. Look for an "Optional: pre-tool-use hook" or similarly titled subsection in Protocol 91 Step 3.
+2. Confirm it describes: intercept `Write`/`Edit` calls only, check path against `WORKTREE_ROOT`, emit a blocking warning on mismatch, skip read-only tools.
+3. Confirm the hook spec states that when `WORKTREE_ROOT` is unset the hook is a no-op.
+
+**Expected result**: Hook design is documented (or step is skipped if the optional section was not implemented).
+
+---
+
+### Step 5: Verify non-batch behavior is unchanged
+
+**Maps to**: Acceptance Criterion 7
+
+1. Search `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` for any change outside the Step 3 worktree isolation block (e.g., Step 7a, Step 8, Protocol 90 references, `post-merge-cleanup.sh`, `pr-review-loop.sh`).
+2. Confirm no lines outside the targeted subsection were modified.
+3. Verify Protocol 90 (`90-batch-orchestrate-work-protocol.md`) was not changed by this PR.
+4. Verify `scripts/development-workflow/post-merge-cleanup.sh` and `scripts/development-workflow/pr-review-loop.sh` were not changed by this PR.
+
+**Expected result**: Zero diffs outside the three targeted files (Protocol 91 Step 3, `.claude/agents/item-orchestrator.md`, `.cursor/agents/item-orchestrator.md`).
+
+---
+
+### Step 6: Verify dual-agent sync
+
+**Maps to**: Acceptance Criterion for dual-agent consistency
+
+1. Open `.claude/agents/item-orchestrator.md`.
+2. Locate the worktree Write/Edit path discipline reminder in the Notes block.
+3. Open `.cursor/agents/item-orchestrator.md`.
+4. Confirm the identical reminder language is present in the same relative position.
+5. Confirm no other content differs between the two files beyond the `model:` and `tools:` frontmatter fields (which legitimately differ).
+
+**Expected result**: Worktree path reminder is identical in both agent files.
+
+---
+
+### Last Step: Assertions checklist
+
+- [ ] All assertions below are confirmed.
+- [ ] No unexpected file changes are present in the PR diff.
+
+---
+
+## Assertions Checklist
+
+- [ ] AC1: Protocol 91 Step 3 worktree section contains an explicit, human-readable reminder that all `Write` and `Edit` tool calls must target paths under `<worktree-path>/...` and that any main-repo-absolute path is a red flag to correct before calling the tool.
+- [ ] AC2: The reminder specifies that `<worktree-path>` must be resolved to its runtime value before being included in stage-agent handoffs (not left as a placeholder).
+- [ ] AC3: The reminder specifies that it must appear in every stage-agent handoff (not just the first) issued for the item.
+- [ ] AC4: The protocol language makes clear the guardrail applies only when `BATCH_CONTEXT=true`.
+- [ ] AC5 (Optional): A pre-tool-use hook design is described that intercepts `Write`/`Edit` calls, checks the target path against `WORKTREE_ROOT`, and emits a blocking warning if the path is outside the worktree.
+- [ ] AC6 (Optional): The hook spec states that when `WORKTREE_ROOT` is unset the hook is a no-op.
+- [ ] AC7: The changes do not alter Protocol 91 behavior for non-batch runs, Protocol 90, `post-merge-cleanup.sh`, `pr-review-loop.sh`, or any scope covered by issue #192.
+- [ ] Dual-agent sync: `.claude/agents/item-orchestrator.md` and `.cursor/agents/item-orchestrator.md` contain identical worktree path reminder language.
+
+---
+
+## Seed Data Reference
+
+No seed data required. All changes are documentation-only.
+
+| Entity | Scenario | How to load |
+|---|---|---|
+| N/A | — | — |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Reminder not found in Protocol 91 Step 3 | Implementation PR not yet merged, or wrong section searched | Confirm you are in the Step 3 worktree isolation block, after the `git switch`/`git reset` safety rule |
+| `.claude` and `.cursor` agent files differ | Developer forgot to update one file | Re-open the implementation PR and apply the missing change to the out-of-sync file |
+| Non-targeted files modified in PR diff | Scope leak during implementation | Revert unexpected changes and reopen the PR |
+
+---
+
+## Known Limitations
+
+- This smoke test is entirely manual (document review). There is no automated way to verify that an agent honors the reminder at runtime without running a live parallel batch.
+- The optional pre-tool-use hook (Use Case 2) is not implemented as runnable code in this PR; its design is documented only.


### PR DESCRIPTION
## Summary

Adds the implementation plan and smoke test runbook for issue #193: **fix(item-orchestrator): Write tool calls use main-repo absolute paths inside isolated worktrees**.

**Approach**: Documentation-only changes to three files:
1. `docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md` — add Write/Edit path guardrail reminder in Step 3 worktree isolation section
2. `.claude/agents/item-orchestrator.md` — add worktree path reminder in Notes block
3. `.cursor/agents/item-orchestrator.md` — identical change (dual-agent sync)

**Complexity**: S (documentation only, no scripts or infrastructure changes)

**Key risks**: Potential merge conflict with #192 in Protocol 91 Step 3; resolved at implementation time since #192 targets the `git switch` rule and this PR targets `Write`/`Edit` rule (adjacent prose).

## Links

- Spec: `docs/specs/developments/20260418003426_193-worktree-write-paths-guardrail/1_193-worktree-write-paths-guardrail_specs.md`
- Plan: `docs/specs/developments/20260418003426_193-worktree-write-paths-guardrail/2_193-worktree-write-paths-guardrail_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/193-worktree-write-paths-guardrail.smoke-test.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added implementation plan for enforcing write-path safety guardrails within isolated worktrees
  * Added manual smoke test documentation with detailed verification steps for validating guardrail functionality and agent consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->