### PR TITLE
docs(plan): scope drift brief coverage (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Implementation plan (issue #186)**: scope drift detection between issue brief and generated spec, plus plan-time verification against live repo search — see `docs/specs/developments/20260420153000_scope-drift-brief-coverage/2_scope-drift-brief-coverage_implementation-plan.md` and `docs/testing/workflow/186-scope-drift-brief-coverage.smoke-test.md`.
+
 ### Fixed
 
 - **CodeRabbit completion via issue comments** (`pr-review-loop.sh`): when CodeRabbit posts only an issue-thread summary (no `pulls/{id}/reviews` entry) for the current HEAD, the poll loop now proceeds to Phase 3 instead of spinning until `timeout` and returning a false `escalate`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **Implementation plan (issue #186)**: scope drift detection between issue brief and generated spec, plus plan-time verification against live repo search — see `docs/specs/developments/20260420153000_scope-drift-brief-coverage/2_scope-drift-brief-coverage_implementation-plan.md` and `docs/testing/workflow/186-scope-drift-brief-coverage.smoke-test.md`.
-
 ### Fixed
 
 - **CodeRabbit completion via issue comments** (`pr-review-loop.sh`): when CodeRabbit posts only an issue-thread summary (no `pulls/{id}/reviews` entry) for the current HEAD, the poll loop now proceeds to Phase 3 instead of spinning until `timeout` and returning a false `escalate`.

--- a/docs/specs/developments/20260420153000_scope-drift-brief-coverage/2_scope-drift-brief-coverage_implementation-plan.md
+++ b/docs/specs/developments/20260420153000_scope-drift-brief-coverage/2_scope-drift-brief-coverage_implementation-plan.md
@@ -99,6 +99,8 @@ Files the developer edits during implementation (this plan already targets them;
 
 **None** for `AGENTS.md` / `docs/project/*` unless the implementation PR discovers a broken link after renames.
 
+- [ ] `docs/ai/development-workflow/integrations/issue-tracker.md` — only if protocol edits assume GitHub-only fields; add a short tracker-agnostic note per spec **Out of Scope (MVP)** (non-GitHub trackers)
+
 ---
 
 ## Risks & Mitigations

--- a/docs/specs/developments/20260420153000_scope-drift-brief-coverage/2_scope-drift-brief-coverage_implementation-plan.md
+++ b/docs/specs/developments/20260420153000_scope-drift-brief-coverage/2_scope-drift-brief-coverage_implementation-plan.md
@@ -65,7 +65,7 @@
 
 **Key scenarios to test**:
 
-1. Protocol 01 documents matrix + deferral PR requirements — maps to **AC3**, **AC1** (synthetic brief scenario described in smoke runbook)
+1. Protocol 01 documents matrix + deferral PR requirements — maps to **AC3**, **AC2**, **AC1** (synthetic brief scenario described in smoke runbook)
 2. Protocol 02 documents Verification Log + pattern-vs-freeze — maps to **AC4**
 3. Fixture + live `rg` proves plan text cannot copy stale counts — maps to **AC5**
 4. `REVIEW.md` lists new blocking bullets — maps to **AC6**, **AC7**
@@ -127,6 +127,7 @@ None (documentation-only work).
 4. Update `REVIEW.md` spec and plan checklists — **AC6**, **AC7**
 5. Optional: agent entrypoint files and Codex skill one-liners — supports discoverability for **AC3**, **AC4**
 6. Run markdownlint on touched Markdown paths per `AGENTS.md`; fix violations
-7. Execute smoke runbook steps on the implementation PR branch before marking development done
+7. Update `CHANGELOG.md` under `[Unreleased]` with an entry for the **feature implementation** PR (protocol / `REVIEW.md` / fixture changes), following `AGENTS.md` conventions
+8. Execute smoke runbook steps on the implementation PR branch before marking development done
 
 Each step should leave the repo internally consistent (no dangling references to headings that do not exist).

--- a/docs/specs/developments/20260420153000_scope-drift-brief-coverage/2_scope-drift-brief-coverage_implementation-plan.md
+++ b/docs/specs/developments/20260420153000_scope-drift-brief-coverage/2_scope-drift-brief-coverage_implementation-plan.md
@@ -1,0 +1,130 @@
+# Scope Drift Brief Coverage — Implementation Plan
+
+**Spec**: [`1_scope-drift-brief-coverage_specs.md`](./1_scope-drift-brief-coverage_specs.md)  
+**Smoke test runbook**: [`docs/testing/workflow/186-scope-drift-brief-coverage.smoke-test.md`](../../../testing/workflow/186-scope-drift-brief-coverage.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Update workflow documentation and review rubrics so spec-writers and plan-writers cannot silently drop brief objectives or copy stale enumerations when pattern-based completeness is intended. Changes are confined to Markdown: `01-generate-spec-protocol.md` (Brief Objective List, Coverage Matrix, PR-body requirements, deferral notes), `02-generate-implementation-plan-protocol.md` (mandatory live search vs spec-frozen enumeration, **Verification Log** block in every plan), `REVIEW.md` (blocking checklist bullets for spec and plan per AC6–AC7), and optional one-line cross-links in `product-manager` / `tech-lead` agent entrypoints so dispatched agents open the right protocol sections. Add a small **committed fixture** under `docs/testing/workflow/fixtures/` for AC5 manual verification: the fixture text claims pattern-wide coverage while listing too few concrete paths. The developer proves the updated plan-writer rules by recording a live `rg` in the Verification Log and aligning Summary counts with that output, not with the stale list.
+
+**Estimated complexity**: M  
+**Rationale**: Several files must stay mutually consistent (protocols ↔ `REVIEW.md` ↔ smoke runbook ↔ optional agent stubs). AC5 needs a reproducible grep command and a stable fixture path so reviewers are not asked to invent repo state.
+
+**Dependencies**: None (`Depends on: none` in spec).
+
+---
+
+## Verification Log (plan-write time)
+
+| Check | Command / note | Result |
+|---|---|---|
+| Repo revision | `git rev-parse --short HEAD` (run at authoring time in worktree) | `f74c5cd` |
+| Spec file presence | `test -f docs/specs/developments/20260420153000_scope-drift-brief-coverage/1_scope-drift-brief-coverage_specs.md` | present |
+
+---
+
+## Layer-by-Layer Changes
+
+### Database / Data Layer
+
+- [ ] None
+
+### Backend / API
+
+- [ ] None
+
+### Shared Packages / Libraries
+
+- [ ] None
+
+### Frontend / UI
+
+- [ ] None
+
+### Infrastructure / Configuration
+
+- [ ] None
+
+### Documentation / Workflow (primary surface)
+
+- [ ] `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md` — insert a dedicated subsection after alignment (or within Step 3 quality guardrails) documenting Brief Objective List, Coverage Matrix, PR description summary, and Deferral Notes per UC1–UC3, BR-1–BR-3; wire Step 5 PR body bullet to require the matrix summary — **AC3**
+- [ ] `docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md` — add plan-writer rules for pattern vs frozen enumeration, mandatory Verification Log (command, repo SHA, outputs affecting counts/paths), and cross-links to UC4–UC5 — **AC4**
+- [ ] `REVIEW.md` — extend **Spec Review Checklist** with a blocking bullet: when a tracker issue is linked, verify brief-to-spec coverage (matrix or equivalent trace) — **AC6**; extend **Plan Review Checklist** with a blocking bullet: when pattern-based completeness applies, verify counts/paths against the plan’s Verification Log — **AC7**
+- [ ] `.claude/agents/product-manager.md` and `.cursor/agents/product-manager.md` — add a single sentence pointing to the new brief-coverage subsection in protocol 01 (optional but recommended for discoverability) — supports **AC3**
+- [ ] `.claude/agents/tech-lead.md` and `.cursor/agents/tech-lead.md` — add a single sentence pointing to enumeration vs live-search rules in protocol 02 — supports **AC4**
+- [ ] `docs/testing/workflow/fixtures/186-scope-drift-pattern-enumeration-mismatch.md` — new synthetic excerpt: states “all files matching pattern P” while listing fewer concrete paths than a live search returns in today’s repo — **AC5** input
+- [ ] `.codex/skills/workflow-spec-writer/SKILL.md` and `.codex/skills/workflow-plan-writer/SKILL.md` — if either duplicates protocol steps inline, add one line each referencing the new mandatory checks (skills remain thin wrappers) — **AC3**, **AC4**
+
+---
+
+## Testing Strategy
+
+**Test types**: Manual / documentation smoke (no automated unit tests).
+
+**Key scenarios to test**:
+
+1. Protocol 01 documents matrix + deferral PR requirements — maps to **AC3**, **AC1** (synthetic brief scenario described in smoke runbook)
+2. Protocol 02 documents Verification Log + pattern-vs-freeze — maps to **AC4**
+3. Fixture + live `rg` proves plan text cannot copy stale counts — maps to **AC5**
+4. `REVIEW.md` lists new blocking bullets — maps to **AC6**, **AC7**
+
+**Smoke test runbook**: [`docs/testing/workflow/186-scope-drift-brief-coverage.smoke-test.md`](../../../testing/workflow/186-scope-drift-brief-coverage.smoke-test.md)
+
+**Regression suite**: None beyond existing markdownlint / CI on touched paths.
+
+---
+
+## Seed Data
+
+| Entity | Values / Scenario | File |
+|---|---|---|
+| Synthetic stale enumeration | Fixture markdown for AC5 | `docs/testing/workflow/fixtures/186-scope-drift-pattern-enumeration-mismatch.md` (new) |
+
+---
+
+## Documentation Updates
+
+Files the developer edits during implementation (this plan already targets them; no separate `docs/project/*` churn unless review finds a glossary gap):
+
+- [ ] `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md`
+- [ ] `docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md`
+- [ ] `REVIEW.md`
+- [ ] `docs/testing/workflow/186-scope-drift-brief-coverage.smoke-test.md` (created in Plan Ready stage alongside this file)
+- [ ] `docs/testing/workflow/fixtures/186-scope-drift-pattern-enumeration-mismatch.md` (new in Development)
+- [ ] `.claude/agents/product-manager.md`, `.cursor/agents/product-manager.md` (optional cross-link)
+- [ ] `.claude/agents/tech-lead.md`, `.cursor/agents/tech-lead.md` (optional cross-link)
+- [ ] `.codex/skills/workflow-spec-writer/SKILL.md`, `.codex/skills/workflow-plan-writer/SKILL.md` (optional one-liners)
+
+**None** for `AGENTS.md` / `docs/project/*` unless the implementation PR discovers a broken link after renames.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Protocol text becomes too long; agents skip it | Med | Med | Use scannable headings + a short checklist table at the top of each new subsection |
+| AC5 fixture drifts as repo grows | Low | Med | Fixture uses a **stable path subset** (e.g. only `docs/ai/development-workflow/protocols/*.md`) and documents the exact `rg` pattern so counts remain meaningful |
+| Parallel wording between 01/02 protocols and `REVIEW.md` diverges | Med | Med | Single source of truth in protocols; `REVIEW.md` bullets only point to behaviors already spelled out there |
+
+---
+
+## Code Samples
+
+None (documentation-only work).
+
+---
+
+## Implementation Order
+
+1. Add fixture `docs/testing/workflow/fixtures/186-scope-drift-pattern-enumeration-mismatch.md` so AC5 verification is reproducible — **AC5**
+2. Update `01-generate-spec-protocol.md` with Brief Objective List, Coverage Matrix, PR description requirements, deferral visibility — **AC1**, **AC2**, **AC3**
+3. Update `02-generate-implementation-plan-protocol.md` with live-search vs freeze rules and Verification Log template — **AC4**
+4. Update `REVIEW.md` spec and plan checklists — **AC6**, **AC7**
+5. Optional: agent entrypoint files and Codex skill one-liners — supports discoverability for **AC3**, **AC4**
+6. Run markdownlint on touched Markdown paths per `AGENTS.md`; fix violations
+7. Execute smoke runbook steps on the implementation PR branch before marking development done
+
+Each step should leave the repo internally consistent (no dangling references to headings that do not exist).

--- a/docs/testing/workflow/186-scope-drift-brief-coverage.smoke-test.md
+++ b/docs/testing/workflow/186-scope-drift-brief-coverage.smoke-test.md
@@ -1,0 +1,128 @@
+# Smoke Test Runbook: Scope Drift Brief Coverage (Issue #186)
+
+**Feature**: Detect and surface scope drift (brief ↔ spec, spec ↔ repo at plan time)  
+**Spec**: [`docs/specs/developments/20260420153000_scope-drift-brief-coverage/1_scope-drift-brief-coverage_specs.md`](../../specs/developments/20260420153000_scope-drift-brief-coverage/1_scope-drift-brief-coverage_specs.md)  
+**Created in**: Plan Ready stage  
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] Implementation PR for issue **#186** is merged or available on a branch
+- [ ] You can run `rg` (ripgrep) from the repository root
+- [ ] You have read the issue brief ([GitHub #186](https://github.com/lhpaul/ai-dev-framework-template/issues/186)) for context
+
+---
+
+## Test Data
+
+| Item | Value |
+|---|---|
+| Spec protocol | `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md` |
+| Plan protocol | `docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md` |
+| Review contract | `REVIEW.md` |
+| AC5 fixture | `docs/testing/workflow/fixtures/186-scope-drift-pattern-enumeration-mismatch.md` (created during implementation) |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Spec protocol — brief coverage mechanics
+
+**Maps to**: **AC3**, **AC1** (synthetic three-objective scenario)
+
+1. Open `01-generate-spec-protocol.md`.
+2. Verify the document defines all of: **Brief Objective List**, **Coverage Matrix** (mapping each objective to AC ids or `## Out of Scope (MVP)`), and a requirement that the **draft PR body** includes a Coverage Matrix summary before human-ready automation.
+3. Verify **Deferral Note** behavior is documented for objectives placed under Out of Scope (visible in spec and PR description / alignment stand-in).
+
+**Expected result**: A new agent session could follow the protocol without reading the full narrative spec.
+
+### Step 2: Spec protocol — synthetic three-objective mental walkthrough
+
+**Maps to**: **AC1**
+
+1. Imagine a GitHub issue brief with three numbered required objectives.
+2. Trace the protocol: confirm it requires each objective to appear in the matrix as mapped ACs or explicit out-of-scope rows before the draft spec PR is opened.
+
+**Expected result**: No step allows a brief objective to be omitted without an explicit row.
+
+### Step 3: Plan protocol — live search vs frozen enumeration
+
+**Maps to**: **AC4**
+
+1. Open `02-generate-implementation-plan-protocol.md`.
+2. Verify it states when **live repository search at plan-write time** is mandatory vs when a **spec-frozen** subset is allowed (with quoting the authorizing spec section).
+3. Verify it requires a **Verification Log** in implementation plans (command, repo revision, and how outputs drive Summary / Documentation Updates counts).
+
+**Expected result**: Plan writers cannot treat stale AC enumerations as authoritative when the spec implies pattern completeness.
+
+### Step 4: Fixture + live count (stale enumeration vs pattern)
+
+**Maps to**: **AC5**
+
+1. Open `docs/testing/workflow/fixtures/186-scope-drift-pattern-enumeration-mismatch.md`.
+2. Run the exact search command documented in that fixture (or in the implementation PR description) from the repo root.
+3. Compare the **live result count** to the **stale list length** embedded in the fixture.
+
+**Expected result**: Live count is strictly greater than the stale enumerated list (proving the mismatch the plan-writer rules must catch).
+
+### Step 5: `REVIEW.md` — internal gates
+
+**Maps to**: **AC6**, **AC7**
+
+1. Under **Spec Review Checklist**, verify at least one bullet instructs reviewers to verify **brief-to-spec coverage** when a tracker issue is linked.
+2. Under **Plan Review Checklist**, verify at least one bullet instructs reviewers to verify **enumerated counts/paths against the plan’s Verification Log** when pattern-based completeness applies.
+
+**Expected result**: Both bullets are present and read as **blocking**-class checks (same severity class as contradictory acceptance criteria per spec BR-6).
+
+### Step 6: Optional agent / skill discoverability
+
+**Maps to**: Supporting traceability for **AC3**, **AC4**
+
+1. If agent files were updated, open `.cursor/agents/product-manager.md` and `.cursor/agents/tech-lead.md` (and `.claude/agents/*` mirrors) and confirm they reference the new protocol sections.
+2. If Codex skills were updated, confirm `workflow-spec-writer` / `workflow-plan-writer` skills mention the new mandatory checks.
+
+**Expected result**: No broken relative links; references point to real headings or sections.
+
+### Last Step: Validate & Shut Down
+
+- Confirm every assertion in the checklist below is satisfied
+- No local-only files were required for the smoke test beyond the repository
+
+---
+
+## Assertions Checklist
+
+- [ ] **AC1**: Protocol 01 documents Coverage Matrix behavior for multi-objective briefs before draft PR open
+- [ ] **AC2**: Protocol 01 documents Deferral Notes for out-of-scope brief objectives in human-visible surfaces
+- [ ] **AC3**: Protocol 01 alone is sufficient for a cold-start agent to perform brief coverage without reading the feature spec narrative
+- [ ] **AC4**: Protocol 02 documents live search vs freeze + Verification Log
+- [ ] **AC5**: Fixture exists; live search count contradicts stale enumeration as documented
+- [ ] **AC6**: `REVIEW.md` spec checklist includes brief-to-spec coverage bullet
+- [ ] **AC7**: `REVIEW.md` plan checklist includes Verification Log vs enumeration bullet
+
+---
+
+## Seed Data Reference
+
+| Entity | Scenario | How to load |
+|---|---|---|
+| Fixture markdown | Stale list vs pattern | Read `docs/testing/workflow/fixtures/186-scope-drift-pattern-enumeration-mismatch.md` |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `rg` count matches stale list | Fixture path or pattern too narrow | Widen pattern in fixture to a stable directory as defined in implementation PR |
+| Cannot find new headings | Implementation on different branch | Check out the feature branch that merged #186 |
+
+---
+
+## Known Limitations
+
+- This smoke test does not execute the full spec-writer or plan-writer agents; it validates **documentation and fixture correctness** only.

--- a/docs/testing/workflow/186-scope-drift-brief-coverage.smoke-test.md
+++ b/docs/testing/workflow/186-scope-drift-brief-coverage.smoke-test.md
@@ -32,7 +32,7 @@ Before running this smoke test:
 
 ### Step 1: Spec protocol — brief coverage mechanics
 
-**Maps to**: **AC3**, **AC1** (synthetic three-objective scenario)
+**Maps to**: **AC3**, **AC2**, **AC1** (synthetic three-objective scenario)
 
 1. Open `01-generate-spec-protocol.md`.
 2. Verify the document defines all of: **Brief Objective List**, **Coverage Matrix** (mapping each objective to AC ids or `## Out of Scope (MVP)`), and a requirement that the **draft PR body** includes a Coverage Matrix summary before human-ready automation.


### PR DESCRIPTION
## Summary

Implements the **Plan Ready** stage for issue [#186](https://github.com/lhpaul/ai-dev-framework-template/issues/186): protocol and review-contract updates so spec-writers surface brief-to-spec coverage (matrix + deferrals) and plan-writers re-verify pattern-based completeness with a **Verification Log** instead of copying stale enumerations.

## Artifacts

- Implementation plan: `docs/specs/developments/20260420153000_scope-drift-brief-coverage/2_scope-drift-brief-coverage_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/186-scope-drift-brief-coverage.smoke-test.md`

## Approach / complexity

Documentation-only (**M**): coordinated edits to `01-generate-spec-protocol.md`, `02-generate-implementation-plan-protocol.md`, `REVIEW.md`, optional agent/skill cross-links, and a small AC5 fixture under `docs/testing/workflow/fixtures/`.

## Risks

- Protocol verbosity vs agent compliance — mitigated with scannable checklists per plan.

## Coverage matrix (brief → plan)

| Brief theme | Plan trace |
|-------------|------------|
| Spec-writer brief coverage + matrix + deferrals | Implementation order steps 2, Documentation protocol 01 |
| Plan-writer live search vs stale enumeration | Implementation order steps 1, 3; protocol 02 + Verification Log |
| Internal spec/plan reviewer reinforcement | `REVIEW.md` checklist steps; implementation order 4 |
| AC5 fixture | Fixture file + smoke Step 4 |

Refs: #186

Made with [Cursor](https://cursor.com)