### PR TITLE
docs(plan): prepare-release post-merge cleanup (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Implementation plan** (#232): prepare-release post-merge cleanup — release branch deletion and `Merged` → `Released` tracker transitions (plan PR only; implementation follows).
+
 ### Fixed
 
 - **CodeRabbit completion via issue comments** (`pr-review-loop.sh`): when CodeRabbit posts only an issue-thread summary (no `pulls/{id}/reviews` entry) for the current HEAD, the poll loop now proceeds to Phase 3 instead of spinning until `timeout` and returning a false `escalate`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **Implementation plan** (#232): prepare-release post-merge cleanup — release branch deletion and `Merged` → `Released` tracker transitions (plan PR only; implementation follows).
-
 ### Fixed
 
 - **CodeRabbit completion via issue comments** (`pr-review-loop.sh`): when CodeRabbit posts only an issue-thread summary (no `pulls/{id}/reviews` entry) for the current HEAD, the poll loop now proceeds to Phase 3 instead of spinning until `timeout` and returning a false `escalate`.

--- a/docs/specs/developments/20260420182725_prepare-release-post-merge-cleanup/2_prepare-release-post-merge-cleanup_implementation-plan.md
+++ b/docs/specs/developments/20260420182725_prepare-release-post-merge-cleanup/2_prepare-release-post-merge-cleanup_implementation-plan.md
@@ -1,0 +1,125 @@
+# Prepare release post-merge cleanup — Implementation Plan
+
+**Spec**: [`1_prepare-release-post-merge-cleanup_specs.md`](./1_prepare-release-post-merge-cleanup_specs.md)  
+**Smoke test runbook**: [`docs/testing/workflow/232-prepare-release-post-merge-cleanup.smoke-test.md`](../../../testing/workflow/232-prepare-release-post-merge-cleanup.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Extend `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md` with an explicit post-merge sequence (after both the `main` release PR and the `develop` backport PR are merged): verify merge state with `gh`, delete `release/vX.Y.Z` on `origin`, delete the local release branch when safe, then transition scoped tracker items from the integration-merged status to the shipped terminal status using the same GitHub Projects v2 GraphQL patterns as `scripts/development-workflow/post-merge-cleanup.sh` (`gh project field-list`, `gh project item-list`, `gh api graphql` mutation). Implement a dedicated helper script (e.g. `scripts/development-workflow/prepare-release-post-merge-cleanup.sh`) so operators and agents run one audited entry point instead of ad hoc commands; the script sources shared helpers from `workflow-lib.sh` where practical and logs skip reasons when project env vars are missing.
+
+**Estimated complexity**: **M**  
+**Rationale**: Touches protocol docs, a new script with git and GitHub edge cases, configuration surface for status labels, and must stay aligned with existing `update_tracker_status` ordering / rollback rules — more than a single-file tweak, but no application runtime.
+
+**Dependencies**: None (spec **Depends on**: none).
+
+---
+
+## Layer-by-Layer Changes
+
+### Database / Data Layer
+
+- [ ] Not applicable.
+
+### Backend / API
+
+- [ ] Not applicable.
+
+### Shared Packages / Libraries
+
+- [ ] Not applicable.
+
+### Frontend / UI
+
+- [ ] Not applicable.
+
+### Infrastructure / Configuration
+
+- [ ] Optional: document advisory keys under `.ai-dev-workflow.yaml` (e.g. `issue_tracker.status_labels.released`) **or** environment variables only (`GITHUB_PROJECT_STATUS_MERGED`, `GITHUB_PROJECT_STATUS_RELEASED`) — pick one primary mechanism in implementation and reference the other as override; must not require secrets in repo files.
+- [ ] Reuse existing `GITHUB_PROJECT_OWNER` / `GITHUB_PROJECT_NUMBER` contract from `post-merge-cleanup.sh` / `docs/ai/development-workflow/integrations/github-projects.md`.
+
+### Documentation / Workflow
+
+- [ ] **`docs/ai/development-workflow/protocols/05-prepare-release-protocol.md`**: Replace or extend current Step 8 (“Inform the Human”) so it clearly separates (a) pre-merge handoff from (b) post-merge cleanup. Add numbered substeps: confirm both PRs merged via `gh pr view` or `gh pr list` queries; **do not** delete the branch if either PR is open or only one merged (**AC**: one-PR-merged edge case). Document `git push origin --delete release/vX.Y.Z` and local `git branch -d` / `switch` away if branch checked out (**UC1**, **AC**).
+- [ ] Same protocol: document tracker transition (**UC2**, **AC**): only items explicitly in scope for this release (default per spec open question: not a blind “all Merged in project” bulk unless human opts in); reference the new script’s flags (e.g. explicit issue numbers, or allowlisted query) in prose.
+- [ ] **`docs/ai/development-workflow/integrations/github-projects.md`**: Add configuration for shipped status display name / option resolution (parallel to how `Merged` is discovered today).
+- [ ] **Command wrappers** (`.cursor/commands/prepare-release.md`, `.claude/commands/prepare-release.md`): One-line note that post-merge cleanup is defined in protocol Step 9 (or whatever final numbering is) so humans do not assume the command ends at PR merge.
+
+### Scripts
+
+- [ ] **`scripts/development-workflow/prepare-release-post-merge-cleanup.sh`** (name illustrative — adapt during implementation):  
+  - Arguments: release version `X.Y.Z` or `vX.Y.Z` normalized to `release/vX.Y.Z`.  
+  - Preconditions: both PRs from that head merged (`main` and `develop` targets) — exit non-zero with clear message if not (**BR**: branch deletion only after both merged).  
+  - Remote delete: `git push origin --delete release/vX.Y.Z` with error handling if already absent (log and success exit 0 or distinct code — document choice).  
+  - Local delete: `git branch -d release/vX.Y.Z` when ref exists; if “checked out” error, print remediation from spec (**UC1** considerations).  
+  - Tracker: for each issue in scope, call shared logic equivalent to `update_tracker_status` in `post-merge-cleanup.sh` but targeting the **Released** option (or configured name). Respect rollback-prevention (do not move from a status more advanced than target).  
+  - Logging: each major action emits one clear line (**Operational visibility**).
+- [ ] **Refactor consideration**: extract `update_tracker_status` from `post-merge-cleanup.sh` into `workflow-lib.sh` if duplication would otherwise copy the GraphQL mutation; keep `post-merge-cleanup.sh` behavior unchanged for existing callers (**AC** same class of mechanism).
+
+---
+
+## Testing Strategy
+
+**Test types**: ShellCheck on new/changed scripts, manual smoke per runbook, optional lightweight `bats` or script self-test only if the repo already uses them for workflow scripts (do not introduce a new framework unless already present).
+
+**Key scenarios to test**:
+
+1. Both PRs merged → remote branch deleted; script exits 0 (**AC** / **UC1**).
+2. Only production PR merged → script refuses branch delete (**AC** edge case).
+3. Tracker configured → in-scope issue moves `Merged` → `Released`; out-of-scope issue unchanged (**UC2**).
+4. Missing `GITHUB_PROJECT_NUMBER` → script completes git cleanup and warns on tracker skip (**Operational visibility**).
+
+**Smoke test runbook**: [`docs/testing/workflow/232-prepare-release-post-merge-cleanup.smoke-test.md`](../../../testing/workflow/232-prepare-release-post-merge-cleanup.smoke-test.md)
+
+**Regression suite**: If a CI job runs ShellCheck on `scripts/development-workflow/`, ensure new script is included by existing glob; no separate e2e unless already standard for workflow scripts.
+
+---
+
+## Seed Data
+
+| Entity | Values / Scenario | File |
+|---|---|---|
+| Not applicable | No database seed; use real or sandbox GitHub project for optional tracker steps | — |
+
+---
+
+## Documentation Updates
+
+Post-implementation edits (not done in this plan PR):
+
+- [ ] `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md` — add post-merge branch + tracker sequence; renumber steps if needed.
+- [ ] `docs/ai/development-workflow/integrations/github-projects.md` — document `Released` / configurable status and any new env vars.
+- [ ] `.cursor/commands/prepare-release.md` and `.claude/commands/prepare-release.md` — pointer to post-merge section after merge.
+- [ ] `docs/ai/development-workflow/README.md` — only if the master workflow table needs a one-line note that release completes with post-merge cleanup (optional if protocol cross-link is enough).
+- [ ] `CHANGELOG.md` — under `[Unreleased]` when the **implementation** PR merges (not this plan PR), per repo changelog rules.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Bulk transition moves wrong issues | Med | High | Default to explicit issue list or human-confirmed input; document dangerous vs safe modes; never auto-select “all Merged” without opt-in flag. |
+| Branch delete while backport pending | Low | High | Hard gate in script + protocol: query both PR merge state before any `git push --delete`. |
+| Divergence from `post-merge-cleanup.sh` mutation | Med | Med | Share one helper for GraphQL update; add ShellCheck and a short comment block pointing to protocol. |
+| Local branch checked out | Med | Low | Document `git switch develop` then retry; script prints exact commands. |
+
+---
+
+## Code Samples
+
+> No executable code samples in this plan — behavior is described at shell command level in protocol steps; any snippet in the implementation PR must be marked **Illustrative** per `REVIEW.md`.
+
+---
+
+## Implementation Order
+
+1. Read `post-merge-cleanup.sh` and `workflow-lib.sh`; decide extract-vs-duplicate for `update_tracker_status`.
+2. Implement `prepare-release-post-merge-cleanup.sh` with merge verification, branch deletion, and scoped tracker transitions.
+3. Run ShellCheck locally / fix warnings.
+4. Update `05-prepare-release-protocol.md` with post-merge section aligned to script capabilities.
+5. Update `github-projects.md` and thin command wrappers.
+6. Execute smoke test runbook (dry protocol review before script lands; full run after).
+7. Add `[Unreleased]` CHANGELOG entry in the **implementation** PR.
+8. Open implementation PR from `feature/232-…` or `fix/232-…` per repo conventions (follow implementation protocol when plan is merged).

--- a/docs/testing/workflow/232-prepare-release-post-merge-cleanup.smoke-test.md
+++ b/docs/testing/workflow/232-prepare-release-post-merge-cleanup.smoke-test.md
@@ -1,0 +1,129 @@
+# Smoke Test Runbook: prepare-release post-merge cleanup (#232)
+
+**Feature**: Post-merge release branch deletion and `Merged` → `Released` tracker transitions after both release PRs merge  
+**Spec**: [`1_prepare-release-post-merge-cleanup_specs.md`](../../specs/developments/20260420182725_prepare-release-post-merge-cleanup/1_prepare-release-post-merge-cleanup_specs.md)  
+**Created in**: Plan Ready stage  
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] Repository root: `cd` to your clone of this template
+- [ ] `gh` CLI authenticated (`gh auth status`)
+- [ ] **Implementation landed**: protocol `05-prepare-release-protocol.md` documents post-merge steps; `prepare-release-post-merge-cleanup.sh` (or equivalent from the implementation plan) exists and is executable
+- [ ] For tracker steps (optional): `GITHUB_PROJECT_OWNER`, `GITHUB_PROJECT_NUMBER` set; project has Status options including **Merged** and **Released** (or configured equivalents)
+
+> **Note**: Steps 1–3 validate documentation and refusal paths without mutating `origin`. Steps 4–5 perform destructive git remote operations — use a fork or test repo unless you intentionally want to delete a real `release/v*` branch.
+
+---
+
+## Test Data
+
+| Item | Value |
+|---|---|
+| Example version | `0.99.0` (replace with a non-production test version when using a fork) |
+| Release branch | `release/v0.99.0` |
+| Script path | `./scripts/development-workflow/prepare-release-post-merge-cleanup.sh` (adjust if final name differs) |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Protocol documents branch-delete precondition
+
+**Maps to**: Acceptance Criterion — “no step tells them to delete the release branch before both PRs are merged”
+
+1. Open `docs/ai/development-workflow/protocols/05-prepare-release-protocol.md`.
+2. Search for the post-merge / cleanup section added for this feature.
+3. Confirm the text states branch deletion is allowed **only after** both the production (`main`) and backport (`develop`) PRs for that release branch are merged.
+
+**Expected result**: Precondition is explicit and appears **before** the `git push origin --delete` instruction.
+
+---
+
+### Step 2: Protocol documents tracker transition and configuration
+
+**Maps to**: Acceptance Criterion — tracker transition uses GitHub Projects / GraphQL class of mechanism; configurable terminal status
+
+1. In the same protocol section (or linked integration doc), confirm documented steps reference `gh project` / GraphQL-style updates consistent with `post-merge-cleanup.sh`.
+2. Confirm documentation explains how to configure the terminal shipped status when it is not literally named **Released** (env var or config key as implemented).
+
+**Expected result**: Operator can find configuration instructions without reading source-only comments.
+
+---
+
+### Step 3: Script / protocol — only one PR merged
+
+**Maps to**: Acceptance Criterion — edge case “only one PR merged”
+
+1. With **no** fully merged pair (or using a stub version where the backport is still open), run the cleanup script for that version (exact CLI from implementation).
+2. Observe exit code and stderr/stdout.
+
+**Expected result**: Non-success exit or explicit “blocked” message; **no** `git push origin --delete` is executed (verify with `git log` / shell trace if script supports `--dry-run`, or read script behavior).
+
+---
+
+### Step 4: Happy path — branch cleanup (fork / disposable branch only)
+
+**Maps to**: Use Case 1 (release branch cleanup)
+
+1. Ensure both PRs for `release/vX.Y.Z` are merged on your test remote.
+2. Run the cleanup script for `X.Y.Z`.
+3. Run `git ls-remote --heads origin "refs/heads/release/vX.Y.Z"` — expect empty after remote delete.
+4. If a local `release/vX.Y.Z` existed: confirm it is removed or instructions printed for manual delete when checked out.
+
+**Expected result**: Remote branch absent; local cleanup succeeded or documented retry path.
+
+---
+
+### Step 5: Tracker transition (GitHub Projects)
+
+**Maps to**: Use Case 2; Operational visibility
+
+1. Pick a test issue on the board in **Merged** that is in scope for the fake release (per implementation’s scoping rules).
+2. Run the script’s tracker mode per implementation (flags as documented).
+3. In GitHub Projects UI, confirm the issue Status is now **Released** (or configured equivalent).
+4. Confirm another **Merged** issue *not* in scope remains **Merged**.
+
+**Expected result**: Scoped transition only; console logs show success or skip with reason.
+
+---
+
+### Last Step: Validate & Shut Down
+
+- Verify every checkbox in **Assertions Checklist** below
+- No lingering test branches on shared `origin` unless intentional
+
+---
+
+## Assertions Checklist
+
+- [ ] Protocol lists remote and local release branch cleanup after both PRs merge (**AC**).
+- [ ] Protocol documents `Merged` → shipped terminal status transition using same integration approach as `post-merge-cleanup.sh` (**AC**).
+- [ ] “Only one PR merged” is explicitly called out; automation refuses early branch delete (**AC**).
+- [ ] Smoke test runbook paths remain valid relative links after any file renames.
+
+---
+
+## Seed Data Reference
+
+Not applicable (no DB seeds). GitHub test issues and project board state are the live “fixtures.”
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Warning: GITHUB_PROJECT_NUMBER not set` | Env not exported | Export vars or skip tracker steps |
+| `cannot delete branch` checked out | Current branch is release branch | `git switch develop` then rerun |
+| Script says PR not merged | Query mismatch / wrong version | Re-check `gh pr list --head release/vX.Y.Z` |
+
+---
+
+## Known Limitations
+
+- Full remote-delete validation requires a repository where you are allowed to delete `release/*` branches.


### PR DESCRIPTION
## Summary

Adds the implementation plan and smoke test runbook for **#232**: after both release PRs merge, delete `release/vX.Y.Z` (remote + local when safe) and transition scoped tracker items from **Merged** to **Released** (or configured equivalent), using the same GitHub Projects patterns as `post-merge-cleanup.sh`.

## Approach
- Extend protocol `05-prepare-release-protocol.md` with explicit post-merge steps and preconditions.
- New script entry point (name TBD in implementation) with merge verification, branch deletion, and scoped status updates.
- Optional extract of `update_tracker_status` to `workflow-lib.sh` to avoid duplication.

## Complexity
**M** — protocol + script + integration docs + careful scoping for bulk tracker updates.

## Links
- Plan: `docs/specs/developments/20260420182725_prepare-release-post-merge-cleanup/2_prepare-release-post-merge-cleanup_implementation-plan.md`
- Runbook: `docs/testing/workflow/232-prepare-release-post-merge-cleanup.smoke-test.md`
- Spec: #232 / merged spec in same development folder

## Risks
Bulk `Merged` → `Released` must default to explicit in-scope issues (see plan); branch delete gated on **both** PRs merged.


Made with [Cursor](https://cursor.com)