### PR TITLE
feat(workflow): enforce brief/spec and spec/repo drift checks

### DIFF
--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -10,3 +10,5 @@ Follow the spec generation protocol exactly as defined in:
 `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md`
 
 That document is the single source of truth for this stage. Do not skip the alignment conversation. Once ambiguity is resolved, continue through reviewer gate, PR creation, and PR readiness unless the protocol requires human input.
+
+For tracker-backed items, follow protocol 01's Brief Objective List, Coverage Matrix, and Deferral Note requirements before opening the draft PR.

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -10,3 +10,5 @@ Follow the implementation plan generation protocol exactly as defined in:
 `docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md`
 
 That document is the single source of truth for this stage. Always read the approved spec (or the work item brief for Refactor items) and relevant codebase sections before proposing an approach. Once ambiguity is resolved, continue through reviewer gate, PR creation, and PR readiness unless the protocol requires human input.
+
+When the spec language implies pattern-based completeness, follow protocol 02's live-search vs spec-frozen enumeration rules and include a reproducible Verification Log.

--- a/.codex/skills/workflow-plan-writer/SKILL.md
+++ b/.codex/skills/workflow-plan-writer/SKILL.md
@@ -11,4 +11,5 @@ Recommended model tier: `premium`
 2. Read `docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md`.
 3. Follow that protocol exactly.
 4. Use the plan to make technical decisions that the spec intentionally avoids. For Refactor items, use the work item brief instead of a spec.
-5. When the branch is created, continue through reviewer gate, PR creation, and PR readiness unless the protocol surfaces a real human decision.
+5. When the spec implies pattern-based completeness, run a live repo query, record a Verification Log, and only use frozen enumerations when explicitly authorized in the spec.
+6. When the branch is created, continue through reviewer gate, PR creation, and PR readiness unless the protocol surfaces a real human decision.

--- a/.codex/skills/workflow-spec-writer/SKILL.md
+++ b/.codex/skills/workflow-spec-writer/SKILL.md
@@ -11,4 +11,5 @@ Recommended model tier: `balanced`
 2. Read `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md`.
 3. Follow that protocol exactly.
 4. Keep the spec product-focused; implementation details belong in the plan stage.
-5. When the branch is created, continue through reviewer gate, PR creation, and PR readiness unless the protocol surfaces a real human decision.
+5. For tracker-backed briefs, include the mandatory Brief Objective List, Coverage Matrix, and PR-visible Deferral Notes before moving to PR readiness.
+6. When the branch is created, continue through reviewer gate, PR creation, and PR readiness unless the protocol surfaces a real human decision.

--- a/.cursor/agents/product-manager.md
+++ b/.cursor/agents/product-manager.md
@@ -9,3 +9,5 @@ Follow the spec generation protocol exactly as defined in:
 `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md`
 
 That document is the single source of truth for this stage. Do not skip the alignment conversation. Once ambiguity is resolved, continue through reviewer gate, PR creation, and PR readiness unless the protocol requires human input.
+
+For tracker-backed items, follow protocol 01's Brief Objective List, Coverage Matrix, and Deferral Note requirements before opening the draft PR.

--- a/.cursor/agents/tech-lead.md
+++ b/.cursor/agents/tech-lead.md
@@ -10,4 +10,6 @@ Follow the implementation plan generation protocol exactly as defined in:
 
 That document is the single source of truth for this stage. Always read the approved spec (or the work item brief for Refactor items) and relevant codebase sections before proposing an approach. Once ambiguity is resolved, continue through reviewer gate, PR creation, and PR readiness unless the protocol requires human input.
 
+When the spec language implies pattern-based completeness, follow protocol 02's live-search vs spec-frozen enumeration rules and include a reproducible Verification Log.
+
 **Note**: This agent handles premium-tier reasoning tasks (architecture decisions). For best results, ensure your Cursor Composer is using a high-reasoning model (e.g., Claude Opus, GPT-4, or equivalent) when invoking this subagent, or edit this file to set `model:` to a specific premium model ID.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Scope-drift guardrails for spec and plan authoring**: protocol updates now require brief-objective coverage matrices and PR-visible deferral notes in spec writing, plus live repo verification logs for pattern-based plan scope checks; review checklists and agent/skill entrypoints were aligned, and a workflow fixture was added for stale-enumeration validation.
+
 ### Fixed
 
 - **CodeRabbit completion via issue comments** (`pr-review-loop.sh`): when CodeRabbit posts only an issue-thread summary (no `pulls/{id}/reviews` entry) for the current HEAD, the poll loop now proceeds to Phase 3 instead of spinning until `timeout` and returning a false `escalate`.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -57,6 +57,7 @@ Check:
 - Required spec template sections are present and no placeholders are unintentionally left behind
 - Use cases are explicit: actor, trigger, steps, outcome
 - Acceptance criteria are specific and testable
+- When a tracker issue is linked, brief objectives are fully covered via a visible matrix: each objective maps to AC(s) or explicit out-of-scope deferral with rationale
 - Business rules are unambiguous and non-contradictory
 - Scope boundaries and out-of-scope items are explicit
 - Status or enum changes include display labels and transitions
@@ -87,6 +88,7 @@ Check:
 - Every use case and acceptance criterion from the spec (or from the work item brief for Refactor items) is addressed
 - Steps are specific enough to execute without guessing
 - Ordering is feasible and dependencies are explicit
+- When pattern-based completeness applies, enumerated counts/paths are validated against the plan's Verification Log commands and outputs
 - Documentation updates are listed or intentionally declared unnecessary
 - Seed data, generated artifacts, and follow-up tasks are called out when applicable
 - The proposed approach matches existing architecture and repo patterns

--- a/docs/ai/development-workflow/protocols/01-generate-spec-protocol.md
+++ b/docs/ai/development-workflow/protocols/01-generate-spec-protocol.md
@@ -186,8 +186,7 @@ If no blocking human decision remains:
 7. Open a **draft** PR targeting `develop` with:
    - Title: `docs(spec): [feature-name]`
    - Body: summary of the feature, link to the spec file, list of open questions (if any)
-   - Coverage Matrix summary: each brief objective mapped to AC reference(s) or Out-of-Scope entry
-   - Deferral Notes for each objective intentionally moved to Out of Scope
+   - When a tracker brief exists: Coverage Matrix summary (each brief objective mapped to AC reference(s) or Out-of-Scope entry) and Deferral Notes for each objective intentionally moved to Out of Scope
 8. Return the branch + PR details to the **Work Item Runner**
 
 ---

--- a/docs/ai/development-workflow/protocols/01-generate-spec-protocol.md
+++ b/docs/ai/development-workflow/protocols/01-generate-spec-protocol.md
@@ -135,6 +135,21 @@ Use the current timestamp for `YYYYMMDDHHMMSS`.
 - Explicitly list what is **out of scope** for this feature (MVP boundary)
 - Keep spec decisions **product-facing**; defer technical design to the implementation plan
 
+### Brief Coverage Requirements (mandatory when a tracker brief exists)
+
+When a tracker issue or work-item brief exists, add these artifacts before opening the draft PR:
+
+1. Build a **Brief Objective List** from discrete requirement bullets/checklists in the brief.
+2. Create a **Coverage Matrix** that maps every brief objective to either:
+   - one or more acceptance criteria, or
+   - an explicit entry under `## Out of Scope (MVP)`.
+3. For each objective deferred to out of scope, include a **Deferral Note** with:
+   - the objective wording (or stable paraphrase),
+   - rationale for deferral, and
+   - whether human confirmation is requested.
+
+No objective may be silently dropped. If an objective is not mapped in the matrix, the spec is incomplete and must not proceed to PR-ready steps.
+
 ### Spec Snippet Example
 
 ```markdown
@@ -171,6 +186,8 @@ If no blocking human decision remains:
 7. Open a **draft** PR targeting `develop` with:
    - Title: `docs(spec): [feature-name]`
    - Body: summary of the feature, link to the spec file, list of open questions (if any)
+   - Coverage Matrix summary: each brief objective mapped to AC reference(s) or Out-of-Scope entry
+   - Deferral Notes for each objective intentionally moved to Out of Scope
 8. Return the branch + PR details to the **Work Item Runner**
 
 ---

--- a/docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -96,6 +96,9 @@ docs/specs/developments/[timestamp]_[feature-slug]/2_[feature-slug]_implementati
 - Every change must reference an acceptance criterion from the spec (for Refactor items, reference the work item brief or stated restructuring goals instead)
 - Seed data requirements must be explicit — what data, in which files, for which test scenarios
 - **Documentation**: Explicitly consider project documentation in `docs/`. The plan must list every doc in `docs/` (including `AGENTS.md` if relevant) that the developer must update after implementation, or state "None" only when the feature truly affects no project docs. Do not plan the doc edits — only list them for the developer to execute.
+- **Pattern completeness checks**: When the spec intent implies "all files/items matching pattern X", do not trust stale enumerations. Re-run a live repo query at plan-write time and use those results in the plan's file list and counts.
+- **Explicit freeze exception**: You may copy a fixed enumeration only when the spec explicitly freezes scope to a named subset; quote that spec section in the plan.
+- **Verification Log required**: Every plan must include a reproducible Verification Log (command/query, repo SHA, and resulting counts/paths that drive scope statements).
 
 ### Examples
 

--- a/docs/ai/development-workflow/templates/implementation-plan-template.md
+++ b/docs/ai/development-workflow/templates/implementation-plan-template.md
@@ -17,6 +17,17 @@
 
 ---
 
+## Verification Log
+
+> Record reproducible plan-time verification commands that influenced scope, counts, or file lists. Include repo revision and concrete results.
+
+| Check | Command / query | Result |
+|---|---|---|
+| Repo revision | `git rev-parse --short HEAD` | [short SHA] |
+| [Pattern/search validation] | `[exact command]` | [count and key paths] |
+
+---
+
 ## Layer-by-Layer Changes
 
 > Delete any layers that don't apply to this feature.
@@ -55,7 +66,7 @@
 1. [Scenario 1 — maps to Acceptance Criterion N]
 2. [Scenario 2]
 
-**Smoke test runbook**: [`docs/testing/[section]/[slug].smoke-test.md`](../../testing/[section]/[slug].smoke-test.md)
+**Smoke test runbook**: `docs/testing/[section]/[slug].smoke-test.md`
 
 **Regression suite**: If the repository has an automated regression test suite, include a checklist item in the relevant layer for a new regression spec that covers the smoke test runbook scenarios above. Omit this if no regression suite exists in the repository.
 

--- a/docs/testing/workflow/fixtures/186-scope-drift-pattern-enumeration-mismatch.md
+++ b/docs/testing/workflow/fixtures/186-scope-drift-pattern-enumeration-mismatch.md
@@ -1,0 +1,19 @@
+# Fixture: Pattern Enumeration Mismatch
+
+This fixture simulates a stale spec excerpt where intent is "all matching files" but the explicit list is incomplete.
+
+## Stale Spec Excerpt
+
+Guidance must be added to all files matching pattern:
+
+`docs/ai/development-workflow/protocols/*-protocol.md`
+
+Current (stale) enumeration in spec text:
+
+- `docs/ai/development-workflow/protocols/01-generate-spec-protocol.md`
+- `docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md`
+- `docs/ai/development-workflow/protocols/03-implement-development-protocol.md`
+
+## Verification Intent
+
+A plan writer should run a live query (for example `rg --files docs/ai/development-workflow/protocols`) and use current repository results for counts/paths rather than copying the stale list above.


### PR DESCRIPTION
## Summary
- add mandatory brief objective coverage + deferral visibility rules to spec-writing protocol
- add plan-writing rules for live repo verification vs spec-frozen enumerations, including Verification Log expectations
- align review rubric, workflow agent/skill entrypoints, changelog, and add fixture for stale-enumeration testing

## Testing
- [x] npx markdownlint-cli2 on touched markdown files

## Links
- Closes #186
- Spec: docs/specs/developments/20260420153000_scope-drift-brief-coverage/1_scope-drift-brief-coverage_specs.md
- Plan: docs/specs/developments/20260420153000_scope-drift-brief-coverage/2_scope-drift-brief-coverage_implementation-plan.md

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added mandatory brief-coverage requirements: Brief Objective Lists, Coverage Matrices, and PR-visible Deferral Notes for tracker-backed items.
  * Introduced plan verification requirements: live repo verification for pattern-based scope, rules for frozen enumerations, and a reproducible Verification Log.
  * Updated review checklists and templates to enforce these guardrails.

* **Tests**
  * Added a fixture scenario validating pattern-enumeration mismatch and verification practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->