### PR TITLE
feat(developer-agent): apply GH Actions security defaults for new workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Scope-drift guardrails for spec and plan authoring**: protocol updates now require brief-objective coverage matrices and PR-visible deferral notes in spec writing, plus live repo verification logs for pattern-based plan scope checks; review checklists and agent/skill entrypoints were aligned, and a workflow fixture was added for stale-enumeration validation.
 
+### Changed
+
+- **GitHub Actions workflow security checklist** (`03-implement-development-protocol.md`): developer guidance now requires least-privilege `permissions`, full-SHA `uses:` pinning, scoped path filters, and `concurrency` controls whenever `.github/workflows/*.yml` files are created or materially updated.
+
 ### Fixed
 
 - **CodeRabbit completion via issue comments** (`pr-review-loop.sh`): when CodeRabbit posts only an issue-thread summary (no `pulls/{id}/reviews` entry) for the current HEAD, the poll loop now proceeds to Phase 3 instead of spinning until `timeout` and returning a false `escalate`.

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -98,6 +98,13 @@ Execute each step from the implementation plan in order.
 - If the scope is larger than the plan described, **stop and report**
 - After each logical chunk of work, verify your changes are still building
 
+**GitHub Actions workflow security checklist** (required when creating or significantly modifying `.github/workflows/*.yml` files):
+
+- Add an explicit `permissions:` block at workflow or job scope with least privilege (default to `contents: read` unless broader access is required)
+- Pin all `uses:` references to a full commit SHA, with the pinned version tag noted in an adjacent comment (for example: `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2`)
+- Add `paths:` / `paths-ignore:` filters when the workflow only needs to run for specific files or directories
+- Add a `concurrency` group when duplicate runs on the same ref should be prevented
+
 **After schema/model changes** (if applicable):
 
 - Run type generation if your project uses generated types from the schema

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -17,6 +17,17 @@
 
 ---
 
+## GitHub Actions Workflow Security Checklist
+
+When your change creates or materially modifies `.github/workflows/*.yml`, complete this checklist before opening the development PR.
+
+- Add an explicit `permissions:` block at workflow or job scope with least privilege (default to `contents: read` unless broader access is required)
+- Pin all `uses:` references to a full commit SHA, with the pinned version tag noted in an adjacent comment (for example: `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2`)
+- Add `paths:` / `paths-ignore:` filters when the workflow only needs to run for specific files or directories
+- Add a `concurrency` group when duplicate runs on the same ref should be prevented
+
+---
+
 ## Path 1: Full Pipeline
 
 ### Step 1: Non-Negotiable Prep
@@ -97,13 +108,6 @@ Execute each step from the implementation plan in order.
 - If you hit a spec gap (something not covered by the spec), **stop and report** — do not make unilateral decisions
 - If the scope is larger than the plan described, **stop and report**
 - After each logical chunk of work, verify your changes are still building
-
-**GitHub Actions workflow security checklist** (required when creating or significantly modifying `.github/workflows/*.yml` files):
-
-- Add an explicit `permissions:` block at workflow or job scope with least privilege (default to `contents: read` unless broader access is required)
-- Pin all `uses:` references to a full commit SHA, with the pinned version tag noted in an adjacent comment (for example: `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2`)
-- Add `paths:` / `paths-ignore:` filters when the workflow only needs to run for specific files or directories
-- Add a `concurrency` group when duplicate runs on the same ref should be prevented
 
 **After schema/model changes** (if applicable):
 
@@ -214,6 +218,7 @@ Read **all** of the following before writing a single line of code. Do not skip.
 4. `docs/best-practices/` — all best practice docs
 5. Relevant existing code — read actual files for the areas you will modify
 6. If an issue tracker exists for this item, follow `docs/ai/development-workflow/integrations/issue-tracker.md` for `In Development (Refactor)` expectations before coding.
+7. If your changes touch `.github/workflows/*.yml`, apply `## GitHub Actions Workflow Security Checklist` before opening the PR.
 
 Extract from your reading:
 
@@ -309,6 +314,8 @@ gh pr create --draft --base develop --title "refactor([scope]): [short descripti
 
 Read the brief. If the work item exists in an issue tracker, follow `docs/ai/development-workflow/integrations/issue-tracker.md` for `In Development (Fast Track)` expectations.
 
+If your changes touch `.github/workflows/*.yml`, apply `## GitHub Actions Workflow Security Checklist` before opening the PR.
+
 ### Step 1b: Pre-Implementation Scope Checklist
 
 Complete this checklist **before writing any code**. It takes 5–10 minutes and prevents review round-trips caused by missed files, scope drift, or inconsistencies with related files.
@@ -391,6 +398,8 @@ Hand off to the Work Item Runner per Path 1 `### Step 9: Handoff to Work Item Ru
 ### Step 1: Read Brief
 
 Read the incident brief from the human.
+
+If your changes touch `.github/workflows/*.yml`, apply `## GitHub Actions Workflow Security Checklist` before opening the PR.
 
 ### Step 2: Confirm Production
 


### PR DESCRIPTION
## Summary
- add a mandatory GitHub Actions workflow security checklist to the implementation protocol
- require least-privilege `permissions`, full-SHA action pinning, scoped path filters, and concurrency controls for `.github/workflows/*.yml` changes
- update `CHANGELOG.md` under `[Unreleased]`

## Test plan
- Verify docs clarity and markdown formatting in updated files
- Confirm checklist language matches issue #200 requirements

## Links
- Closes #200

Made with [Cursor](https://cursor.com)