### PR TITLE
docs: add parser-risk plan requirements

### DIFF
--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -11,4 +11,6 @@ Follow the implementation plan generation protocol exactly as defined in:
 
 That document is the single source of truth for this stage. Always read the approved spec (or the work item brief for Refactor items) and relevant codebase sections before proposing an approach. Once ambiguity is resolved, continue through reviewer gate, PR creation, and PR readiness unless the protocol requires human input.
 
+Before finalizing Step 3, classify parser-risk using the deterministic signals in protocol 02 (tooling-path parser/lint changes, parser/scanner-oriented module naming, or explicit regex/structured-text scanning behavior). When parser-risk applies, include the mandatory edge-case enumeration and unit-test mapping subsections before deep Layer-by-Layer walkthroughs. If suppressions are part of the feature, include suppression semantics (recognized directives, placement, and multi-suppression behavior).
+
 When the spec language implies pattern-based completeness, follow protocol 02's live-search vs spec-frozen enumeration rules and include a reproducible Verification Log.

--- a/.codex/skills/workflow-plan-writer/SKILL.md
+++ b/.codex/skills/workflow-plan-writer/SKILL.md
@@ -12,4 +12,5 @@ Recommended model tier: `premium`
 3. Follow that protocol exactly.
 4. Use the plan to make technical decisions that the spec intentionally avoids. For Refactor items, use the work item brief instead of a spec.
 5. When the spec implies pattern-based completeness, run a live repo query, record a Verification Log, and only use frozen enumerations when explicitly authorized in the spec.
-6. When the branch is created, continue through reviewer gate, PR creation, and PR readiness unless the protocol surfaces a real human decision.
+6. Before finalizing Step 3, classify parser-risk using the deterministic signals in protocol 02 (tooling-path parser/lint changes, parser/scanner-oriented module naming, or explicit regex/structured-text scanning behavior). When parser-risk applies, include the mandatory edge-case enumeration and unit-test mapping subsections before deep Layer-by-Layer walkthroughs. If suppressions are part of the feature, include suppression semantics (recognized directives, placement, and multi-suppression behavior).
+7. When the branch is created, continue through reviewer gate, PR creation, and PR readiness unless the protocol surfaces a real human decision.

--- a/.cursor/agents/tech-lead.md
+++ b/.cursor/agents/tech-lead.md
@@ -10,6 +10,8 @@ Follow the implementation plan generation protocol exactly as defined in:
 
 That document is the single source of truth for this stage. Always read the approved spec (or the work item brief for Refactor items) and relevant codebase sections before proposing an approach. Once ambiguity is resolved, continue through reviewer gate, PR creation, and PR readiness unless the protocol requires human input.
 
+Before finalizing Step 3, classify parser-risk using the deterministic signals in protocol 02 (tooling-path parser/lint changes, parser/scanner-oriented module naming, or explicit regex/structured-text scanning behavior). When parser-risk applies, include the mandatory edge-case enumeration and unit-test mapping subsections before deep Layer-by-Layer walkthroughs. If suppressions are part of the feature, include suppression semantics (recognized directives, placement, and multi-suppression behavior).
+
 When the spec language implies pattern-based completeness, follow protocol 02's live-search vs spec-frozen enumeration rules and include a reproducible Verification Log.
 
 **Note**: This agent handles premium-tier reasoning tasks (architecture decisions). For best results, ensure your Cursor Composer is using a high-reasoning model (e.g., Claude Opus, GPT-4, or equivalent) when invoking this subagent, or edit this file to set `model:` to a specific premium model ID.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **GitHub Actions workflow security checklist** (`03-implement-development-protocol.md`): developer guidance now requires least-privilege `permissions`, full-SHA `uses:` pinning, scoped path filters, and `concurrency` controls whenever `.github/workflows/*.yml` files are created or materially updated.
+- **Parser-risk implementation-plan requirements** (`02-generate-implementation-plan-protocol.md`, `implementation-plan-template.md`, `REVIEW.md`, `tech-lead` agents): plans that touch parser/regex/structured-text scanning now require deterministic classification plus mandatory edge-case enumeration, unit-test mapping, and conditional suppression semantics.
 
 ### Fixed
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -89,6 +89,10 @@ Check:
 - Steps are specific enough to execute without guessing
 - Ordering is feasible and dependencies are explicit
 - When pattern-based completeness applies, enumerated counts/paths are validated against the plan's Verification Log commands and outputs
+- Parser-risk completeness (when protocol `02-generate-implementation-plan-protocol.md` Step 3 parser-risk signals apply):
+  - Edge-case enumeration is present and concrete
+  - A unit test file is named with at least one automated test mapped per enumerated case
+  - Suppression semantics subsection is present when suppressions are part of the proposed feature
 - Documentation updates are listed or intentionally declared unnecessary
 - Seed data, generated artifacts, and follow-up tasks are called out when applicable
 - The proposed approach matches existing architecture and repo patterns

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -92,7 +92,10 @@ Check:
 - Parser-risk completeness (when protocol `02-generate-implementation-plan-protocol.md` Step 3 parser-risk signals apply):
   - Edge-case enumeration is present and concrete
   - A unit test file is named with at least one automated test mapped per enumerated case
-  - Suppression semantics subsection is present when suppressions are part of the proposed feature
+  - When suppressions are part of the proposed feature, suppression semantics explicitly define:
+    - Recognized directives
+    - Allowed placement
+    - Interpretation of multiple suppressions on one line
 - Documentation updates are listed or intentionally declared unnecessary
 - Seed data, generated artifacts, and follow-up tasks are called out when applicable
 - The proposed approach matches existing architecture and repo patterns

--- a/docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -100,6 +100,36 @@ docs/specs/developments/[timestamp]_[feature-slug]/2_[feature-slug]_implementati
 - **Explicit freeze exception**: You may copy a fixed enumeration only when the spec explicitly freezes scope to a named subset; quote that spec section in the plan.
 - **Verification Log required**: Every plan must include a reproducible Verification Log (command/query, repo SHA, and resulting counts/paths that drive scope statements).
 
+### Parser-risk plans: custom parsers, regex, and structured-text scanning
+
+Treat this block as conditional guidance. Apply it only when the plan is parser-risk.
+
+**Classification (parser-risk):** classify a plan as parser-risk when Layer-by-Layer changes introduce or materially change any of the following:
+
+- Files under conventional tooling paths such as `scripts/lint/`, `scripts/parse/`, or similar parse/lint scanner directories
+- New or renamed modules whose names imply lint/parser/scanner/tokenizer/regex-engine responsibilities (for example `*lint*.py`, `*parser*.mjs`, `*scanner*.ts`)
+- Explicit behavior described as regex-heavy scanning, structured-text parsing, or rule engines over markdown, code, config, or logs
+
+If none of these signals apply, skip this entire block.
+
+**Mandatory when parser-risk — Edge-case enumeration:** include a dedicated subsection with concrete inputs (not vague statements like "handle edge cases"). Cover at minimum:
+
+- Boundary-character variants
+- Negative cases (strings that resemble matches but must not match)
+- Multiple occurrences on one line
+- Nested or overlapping constructs where relevant
+- Normative-spec flexibility when applicable (for example CommonMark closing fence length >= opening fence length)
+
+**Mandatory when parser-risk — Unit tests:** in the Testing Strategy, name a concrete unit test file and map at least one automated unit test per enumerated edge case. Smoke-only or manual-only plans are insufficient for parser-risk work.
+
+**Conditional — Suppression semantics:** when the feature supports inline/directive suppressions, add a subsection naming:
+
+- Which directives are recognized
+- Where directives can appear
+- How multiple suppressions on one line are interpreted
+
+For acceptance intent and terminology, reference `docs/specs/developments/20260420120000_201-tech-lead-parser-regex-plan-requirements/1_201-tech-lead-parser-regex-plan-requirements_specs.md`.
+
 ### Examples
 
 ```markdown

--- a/docs/ai/development-workflow/templates/implementation-plan-template.md
+++ b/docs/ai/development-workflow/templates/implementation-plan-template.md
@@ -70,6 +70,12 @@
 
 **Regression suite**: If the repository has an automated regression test suite, include a checklist item in the relevant layer for a new regression spec that covers the smoke test runbook scenarios above. Omit this if no regression suite exists in the repository.
 
+### Parser-risk addendum (include only when Step 3 classifier applies)
+
+- **Edge-case enumeration**: List concrete parser/scanner inputs that cover boundary variants, negative lookalikes, multi-match lines, and nested/overlapping patterns when relevant.
+- **Unit test mapping**: Name a unit test file and map at least one automated unit test per enumerated edge case.
+- **Suppression semantics (if applicable)**: Name recognized suppression directives, allowed placement, and behavior when multiple suppressions appear on one line.
+
 ---
 
 ## Seed Data

--- a/docs/ai/development-workflow/templates/implementation-plan-template.md
+++ b/docs/ai/development-workflow/templates/implementation-plan-template.md
@@ -72,7 +72,7 @@
 
 ### Parser-risk addendum (include only when Step 3 classifier applies)
 
-- **Edge-case enumeration**: List concrete parser/scanner inputs that cover boundary variants, negative lookalikes, multi-match lines, and nested/overlapping patterns when relevant.
+- **Edge-case enumeration**: List concrete parser/scanner inputs that cover boundary variants, negative lookalikes, multi-match lines, nested/overlapping patterns when relevant, and normative-spec flexibility when applicable (for example, CommonMark closing fence length >= opening fence length).
 - **Unit test mapping**: Name a unit test file and map at least one automated unit test per enumerated edge case.
 - **Suppression semantics (if applicable)**: Name recognized suppression directives, allowed placement, and behavior when multiple suppressions appear on one line.
 


### PR DESCRIPTION
## Summary
- add a parser-risk conditional block to plan protocol Step 3 with deterministic classification signals
- add template and review-contract checks for edge-case enumeration, unit-test mapping, and suppression semantics
- align tech-lead agent guidance and add an Unreleased changelog entry for issue #201

## Testing
- npx markdownlint-cli2 \"docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md\" \"docs/ai/development-workflow/templates/implementation-plan-template.md\" \"REVIEW.md\" \"CHANGELOG.md\"

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced implementation plan requirements for features involving parser/regex/structured-text scanning with deterministic risk classification
  * Added mandatory subsections for edge-case enumeration and unit test mapping when parser-risk applies
  * New requirements for documenting suppression semantics (directives, placement, multi-suppression behavior) when supported
  * Updated plan review validation rules to enforce parser-risk quality standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->