### PR TITLE
fix(ci-loop): handle duplicate historical statusCheckRollup entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Duplicate check-name handling in CI polling** (`pr-ci-loop.sh`): GitHub `statusCheckRollup` can contain historical entries for the same check name (for example an older `CANCELLED` run plus a newer `SKIPPED` run). The CI loop now evaluates only the latest entry per check name so stale results do not incorrectly force `RESULT=red`.
+
 - **Internal reviewers now fix `suggestion`-level findings by default** (`REVIEW.md`): `suggestion` severity was previously "report or fix at discretion", meaning internal reviewers (Step 7a) could skip them. This left low-risk improvements for external reviewers to re-raise, lengthening the review loop. The default action is now "fix by default; report only if scope-expanding or requires a product decision."
 
 - **`UNRESOLVED_THREAD_COUNT` now emits `-1` (not `"unknown"`) on page-cap escalation** (`pr-review-loop.sh`): the output contract specifies an integer field; using the string `"unknown"` violated the contract and required a defensive string-guard on the downstream consumer. Replaced with `-1` as an integer sentinel and removed the now-redundant guard.

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -70,12 +70,28 @@ min_no_checks_wait=$((poll_interval * 2))
 
 while :; do
   checks_json="$(gh pr view "$pr_number" --json statusCheckRollup)"
-  total_check_count="$(
-    printf '%s\n' "$checks_json" | jq '(.statusCheckRollup // []) | length'
-  )"
-  pending_count="$(
+  # statusCheckRollup can include historical duplicates for the same check.
+  # Keep only the latest entry per check name to avoid stale conclusions.
+  normalized_checks_json="$(
     printf '%s\n' "$checks_json" | jq '
       (.statusCheckRollup // [])
+      | map(
+          . + {
+            __check_name: (.name // .context // .workflowName // "unknown"),
+            __check_ts: (.completedAt // .startedAt // "")
+          }
+        )
+      | sort_by(.__check_name, .__check_ts)
+      | group_by(.__check_name)
+      | map(last | del(.__check_name, .__check_ts))
+    '
+  )"
+  total_check_count="$(
+    printf '%s\n' "$normalized_checks_json" | jq 'length'
+  )"
+  pending_count="$(
+    printf '%s\n' "$normalized_checks_json" | jq '
+      .
       | map(select(
           ((.status // "") != "" and (.status != "COMPLETED"))
           or (.state == "EXPECTED")
@@ -87,8 +103,8 @@ while :; do
     '
   )"
   pending_list="$(
-    printf '%s\n' "$checks_json" | jq -r '
-      (.statusCheckRollup // [])
+    printf '%s\n' "$normalized_checks_json" | jq -r '
+      .
       | map(select(
           ((.status // "") != "" and (.status != "COMPLETED"))
           or (.state == "EXPECTED")
@@ -101,8 +117,8 @@ while :; do
     '
   )"
   failing_count="$(
-    printf '%s\n' "$checks_json" | jq '
-      (.statusCheckRollup // [])
+    printf '%s\n' "$normalized_checks_json" | jq '
+      .
       | map(select(
           (.conclusion == "FAILURE")
           or (.conclusion == "CANCELLED")
@@ -116,8 +132,8 @@ while :; do
     '
   )"
   failing_list="$(
-    printf '%s\n' "$checks_json" | jq -r '
-      (.statusCheckRollup // [])
+    printf '%s\n' "$normalized_checks_json" | jq -r '
+      .
       | map(select(
           (.conclusion == "FAILURE")
           or (.conclusion == "CANCELLED")

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -78,7 +78,7 @@ while :; do
       | map(
           . + {
             __check_name: (.name // .context // .workflowName // "unknown"),
-            __check_ts: (.completedAt // .startedAt // "")
+            __check_ts: (.startedAt // .completedAt // "")
           }
         )
       | sort_by(.__check_name, .__check_ts)

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -77,13 +77,23 @@ while :; do
       (.statusCheckRollup // [])
       | map(
           . + {
-            __check_name: (.name // .context // .workflowName // "unknown"),
-            __check_ts: (.startedAt // .completedAt // "")
+            __check_key: (
+              if (.context // "") != "" then
+                "status:" + .context
+              elif (.workflowName // "") != "" and (.name // "") != "" then
+                "check:" + .workflowName + "/" + .name
+              elif (.name // "") != "" then
+                "check:" + .name
+              else
+                "unknown"
+              end
+            ),
+            __check_ts: (.startedAt // .completedAt // .createdAt // "")
           }
         )
-      | sort_by(.__check_name, .__check_ts)
-      | group_by(.__check_name)
-      | map(last | del(.__check_name, .__check_ts))
+      | sort_by(.__check_key, .__check_ts)
+      | group_by(.__check_key)
+      | map(last | del(.__check_key, .__check_ts))
     '
   )"
   total_check_count="$(


### PR DESCRIPTION
## Summary
- normalize `statusCheckRollup` to the latest entry per check name before CI evaluation
- prevent stale historical check conclusions (for example old `CANCELLED`) from forcing `RESULT=red`
- add changelog entry under `[Unreleased]` documenting the CI-loop behavior fix

## Test plan
- [x] Run `./scripts/development-workflow/pr-ci-loop.sh 257 --poll-interval 1 --max-wait 5`
- [x] Confirm output is `RESULT=green` with `FAILING_CHECK_COUNT=0`
- [x] Confirm only `scripts/development-workflow/pr-ci-loop.sh` and `CHANGELOG.md` changed

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where outdated CI check results could cause validation to fail incorrectly by deduplicating checks and considering only the latest result per check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->