### PR TITLE
feat(release): add prepare-release post-merge cleanup

### DIFF
--- a/.claude/commands/prepare-release.md
+++ b/.claude/commands/prepare-release.md
@@ -16,4 +16,4 @@ Key rules:
 - Open **two** PRs: one to `main`, one backport to `develop`
 - **After both PRs exist**, run the automated reviewer loop, apply `ready-for-regression`, and run the CI loop on the **production PR targeting `main` only** — do not stop at “PR opened” (use `scripts/development-workflow/pr-review-loop.sh` and `pr-ci-loop.sh` per protocol)
 - Merge `main` PR first; the tag is created automatically by CI
-- Do not delete the release branch until both PRs are merged
+- After both PRs merge, run Step 9 post-merge cleanup (`scripts/development-workflow/prepare-release-post-merge-cleanup.sh`) before considering the release flow complete

--- a/.cursor/commands/prepare-release.md
+++ b/.cursor/commands/prepare-release.md
@@ -15,4 +15,4 @@ Key rules:
 - Open **two** PRs: one to `main`, one backport to `develop`
 - **After both PRs exist**, run the automated reviewer loop, apply `ready-for-regression`, and run the CI loop on the **production PR targeting `main` only** — do not stop at “PR opened” (use `scripts/development-workflow/pr-review-loop.sh` and `pr-ci-loop.sh` per protocol)
 - Merge `main` PR first; the tag is created automatically by CI
-- Do not delete the release branch until both PRs are merged
+- After both PRs merge, run Step 9 post-merge cleanup (`scripts/development-workflow/prepare-release-post-merge-cleanup.sh`) before considering the release flow complete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Scope-drift guardrails for spec and plan authoring**: protocol updates now require brief-objective coverage matrices and PR-visible deferral notes in spec writing, plus live repo verification logs for pattern-based plan scope checks; review checklists and agent/skill entrypoints were aligned, and a workflow fixture was added for stale-enumeration validation.
+- **Release post-merge cleanup command** (`prepare-release-post-merge-cleanup.sh`): verifies both release PRs are merged before deleting `release/vX.Y.Z`, removes remote/local release branches safely, and transitions explicitly scoped tracker items from `Merged` to `Released`.
 
 ### Changed
 
 - **GitHub Actions workflow security checklist** (`03-implement-development-protocol.md`): developer guidance now requires least-privilege `permissions`, full-SHA `uses:` pinning, scoped path filters, and `concurrency` controls whenever `.github/workflows/*.yml` files are created or materially updated.
 - **Parser-risk implementation-plan requirements** (`02-generate-implementation-plan-protocol.md`, `implementation-plan-template.md`, `REVIEW.md`, `tech-lead` agents): plans that touch parser/regex/structured-text scanning now require deterministic classification plus mandatory edge-case enumeration, unit-test mapping, and conditional suppression semantics.
+- **Prepare-release protocol and command wrappers** now include a required post-merge Step 9 that runs branch cleanup plus tracker transition guidance after both release PRs merge.
 
 ### Fixed
 

--- a/docs/ai/development-workflow/integrations/github-projects.md
+++ b/docs/ai/development-workflow/integrations/github-projects.md
@@ -205,6 +205,29 @@ When a PR is merged, the `post-merge-cleanup` command will:
 
 ---
 
+## Release Post-Merge Cleanup
+
+After a release branch has merged to both `main` and `develop`, use:
+
+```bash
+./scripts/development-workflow/prepare-release-post-merge-cleanup.sh vX.Y.Z --issues 101,102
+```
+
+This script:
+
+1. Verifies both release PRs are merged before any branch deletion
+2. Deletes `release/vX.Y.Z` on `origin` and locally (when safe)
+3. Transitions explicit scoped issues from merged-to-integration to released-to-production
+
+Status label defaults and overrides:
+
+- `GITHUB_PROJECT_STATUS_MERGED` (default: `Merged`)
+- `GITHUB_PROJECT_STATUS_RELEASED` (default: `Released`)
+
+Use explicit issue numbers to avoid accidental broad transitions. Items not included in the shipped release should remain unchanged.
+
+---
+
 ## Prerequisites
 
 - **`gh` CLI** authenticated with a token that has `project` and `repo` scopes:

--- a/docs/ai/development-workflow/protocols/05-prepare-release-protocol.md
+++ b/docs/ai/development-workflow/protocols/05-prepare-release-protocol.md
@@ -225,7 +225,7 @@ git push origin --delete "release/v[X.Y.Z]"
 
 # delete local branch (switch away first if currently checked out)
 git switch develop
-git branch -d "release/v[X.Y.Z]"
+git branch -D "release/v[X.Y.Z]"
 ```
 
 If local deletion fails because the branch is checked out in another worktree, switch away in that worktree and retry.

--- a/docs/ai/development-workflow/protocols/05-prepare-release-protocol.md
+++ b/docs/ai/development-workflow/protocols/05-prepare-release-protocol.md
@@ -178,9 +178,68 @@ When the production PR is ready (or clearly escalated):
 
 1. **Merge the `main` PR first** — the tag `v[X.Y.Z]` is created automatically by CI on merge (`.github/workflows/auto-tag-release.yml`)
 2. Then merge the `develop` backport PR
-3. Do not delete the release branch until both PRs are merged
+3. Run Step 9 post-merge cleanup only after both PRs are merged
 
 If Step 7 escalated or CI timed out, report status and blockers before merge.
+
+---
+
+## Step 9: Post-Merge Cleanup (Branch + Tracker)
+
+Run this step only after both release PRs from `release/v[X.Y.Z]` are merged.
+
+### 9.1 Verify merged state before deletion
+
+Confirm the release branch has:
+
+- One merged PR to `main`
+- One merged PR to `develop`
+- No remaining open PRs to either base
+
+If either merged PR is missing, or one PR is still open, stop. Do **not** delete the release branch and do **not** run tracker release transitions.
+
+### 9.2 Preferred command (single entry point)
+
+Use the helper script:
+
+```bash
+./scripts/development-workflow/prepare-release-post-merge-cleanup.sh v[X.Y.Z] --issues <issue1,issue2,...>
+```
+
+The script performs all required checks and actions in order:
+
+1. Verifies both merged PRs exist (`main` and `develop`) and no open PR remains.
+2. Deletes remote branch `release/v[X.Y.Z]` (or logs that it is already absent).
+3. Deletes local branch `release/v[X.Y.Z]` when safe.
+4. Transitions explicit in-scope tracker items from merged-to-integration to released-to-production.
+
+### 9.3 Manual equivalent (when script cannot be used)
+
+```bash
+# verify merged PRs first (examples)
+gh pr list --head "release/v[X.Y.Z]" --base main --state merged --json number
+gh pr list --head "release/v[X.Y.Z]" --base develop --state merged --json number
+
+# delete remote branch (only after both merges)
+git push origin --delete "release/v[X.Y.Z]"
+
+# delete local branch (switch away first if currently checked out)
+git switch develop
+git branch -d "release/v[X.Y.Z]"
+```
+
+If local deletion fails because the branch is checked out in another worktree, switch away in that worktree and retry.
+
+### 9.4 Tracker transition: `Merged` -> `Released` for in-scope items
+
+Use the same GitHub Projects v2 update path documented in [`github-projects.md`](../integrations/github-projects.md). The helper script accepts explicit issue numbers (`--issue`/`--issues`) to keep scope safe.
+
+- Default status names: `Merged` and `Released`
+- Optional env overrides:
+  - `GITHUB_PROJECT_STATUS_MERGED`
+  - `GITHUB_PROJECT_STATUS_RELEASED`
+
+Only transition work items explicitly confirmed as part of the shipped release. Do not bulk-move all project items in `Merged` unless a human explicitly asks for that scope.
 
 ---
 

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -176,6 +176,27 @@ Usage:
 Use this when:
 - You have merged a feature/plan/spec PR and deleted the remote branch, and want to clean up the local branch and update develop.
 
+### `prepare-release-post-merge-cleanup.sh`
+
+After both release PRs (`release/*` -> `main` and `release/*` -> `develop`) are merged, verify merge state, remove the release branch remotely and locally, and optionally transition scoped tracker items from `Merged` to `Released`.
+
+Usage:
+
+```bash
+./scripts/development-workflow/prepare-release-post-merge-cleanup.sh <version|release-branch> [--issue N]... [--issues N,N,...]
+```
+
+Examples:
+
+```bash
+./scripts/development-workflow/prepare-release-post-merge-cleanup.sh v1.2.3 --issues 232,240
+./scripts/development-workflow/prepare-release-post-merge-cleanup.sh release/v1.2.3 --issue 232
+```
+
+Use this when:
+- Both release PRs are already merged and you need deterministic release-branch cleanup.
+- You want explicit, scoped tracker transitions to the terminal shipped status.
+
 ### `batch-merge.sh`
 
 Deterministic merge pipeline for parallel batch PRs. Handles PR discovery (auto or explicit), metadata collection, merge ordering (non-CHANGELOG PRs first by ascending PR number, then CHANGELOG PRs by ascending PR number), and single-PR merge execution with structured key-value output.

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -75,7 +75,7 @@ if [ -n "$WORKTREE_PATH" ]; then
   echo "Worktree '$WORKTREE_PATH' is still using branch '$TO_DELETE'. Removing worktree first..."
   # Capture stderr so we can detect the locked-worktree condition.
   REMOVE_ERR=$(git worktree remove "$WORKTREE_PATH" --force 2>&1) && REMOVE_RC=0 || REMOVE_RC=$?
-  if [ $REMOVE_RC -ne 0 ] && echo "$REMOVE_ERR" | grep -q "locked working tree"; then
+  if [ "$REMOVE_RC" -ne 0 ] && echo "$REMOVE_ERR" | grep -q "locked working tree"; then
     # Detect lock reason from git worktree list --porcelain (the "locked" field).
     LOCK_REASON=$(git worktree list --porcelain | grep -A5 "^worktree $WORKTREE_PATH$" | grep "^locked" | sed 's/^locked //' || echo "unknown")
     echo "WARNING: Worktree '$WORKTREE_PATH' is locked (reason: $LOCK_REASON). Force-overriding — if this worktree belongs to an active agent, data may be lost."
@@ -96,7 +96,7 @@ if [ -n "$WORKTREE_PATH" ]; then
         exit 1
       fi
     fi
-  elif [ $REMOVE_RC -ne 0 ]; then
+  elif [ "$REMOVE_RC" -ne 0 ]; then
     echo "Error removing worktree '$WORKTREE_PATH': $REMOVE_ERR" >&2
     exit 1
   fi
@@ -106,129 +106,6 @@ fi
 git branch -D "$TO_DELETE"
 
 # --- Update tracker status and close associated GitHub issue (if any) ---
-# update_tracker_status <issue_number> <status_label>
-#
-# Best-effort: logs a warning and returns 0 on any failure so that git cleanup
-# always completes regardless of GitHub Projects API availability.
-#
-# Requires GITHUB_PROJECT_NUMBER (and optionally GITHUB_PROJECT_OWNER) to be set
-# in the environment. Falls back to querying the repo owner via 'gh repo view'.
-#
-# Every `gh`/`jq` pipeline is wrapped with `|| true` so that, under
-# `set -euo pipefail`, a failed API call (auth missing, rate-limit, project not
-# found, etc.) produces an empty string the `[ -z ... ]` guard can detect and
-# handle — rather than aborting the entire script.
-update_tracker_status() {
-  local issue_number="$1"
-  local status_label="$2"
-  local owner project_number project_id field_json field_id option_id item_id
-
-  # Resolve owner and project number. The `|| true` guard on the `gh repo view`
-  # fallback is mandatory: under `set -euo pipefail`, a failed command
-  # substitution in a parameter expansion default would propagate non-zero and
-  # abort the script before the `[ -z "$owner" ]` guard below can emit the
-  # warning and return 0.
-  owner="${GITHUB_PROJECT_OWNER:-$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || true)}"
-  project_number="${GITHUB_PROJECT_NUMBER:-}"
-  if [ -z "$owner" ] || [ -z "$project_number" ]; then
-    echo "Warning: GITHUB_PROJECT_OWNER or GITHUB_PROJECT_NUMBER not set; skipping tracker status update."
-    return 0
-  fi
-
-  project_id=$(gh project view "$project_number" --owner "$owner" --format json 2>/dev/null | jq -r '.id // empty' || true)
-  if [ -z "$project_id" ]; then
-    echo "Warning: could not resolve project ID for project #${project_number}; skipping tracker status update."
-    return 0
-  fi
-
-  # Resolve Status field ID and option ID for the requested label.
-  field_json=$(gh project field-list "$project_number" --owner "$owner" --format json 2>/dev/null || true)
-  field_id=$(printf '%s' "$field_json" | jq -r '.fields[] | select(.name == "Status") | .id // empty' || true)
-  option_id=$(printf '%s' "$field_json" | jq -r --arg label "$status_label" '.fields[] | select(.name == "Status") | .options[] | select(.name == $label) | .id // empty' || true)
-  if [ -z "$field_id" ] || [ -z "$option_id" ]; then
-    echo "Warning: could not resolve Status field or option '${status_label}'; skipping tracker status update."
-    return 0
-  fi
-
-  # Resolve project item ID and current status for the issue.
-  # The item-list output is stored so we can read both id and current Status without a second API call.
-  local item_json current_status target_order
-  item_json=$(gh project item-list "$project_number" --owner "$owner" --limit 10000 --format json 2>/dev/null \
-    | jq -c --argjson num "$issue_number" '.items[] | select(.content.number == $num)' || true)
-  item_id=$(printf '%s' "$item_json" | jq -r '.id // empty' || true)
-  if [ -z "$item_id" ]; then
-    echo "Warning: issue #${issue_number} not found in project #${project_number}; skipping tracker status update."
-    return 0
-  fi
-
-  # Rollback prevention: do not set the status to a less-advanced state than the current one.
-  # Protocol 91 Step 10: "If the item's tracker status is already in a further-advanced state,
-  # do not roll it back — leave it as-is."
-  # Status ordering (lower index = earlier stage):
-  #   0:Backlog 1:Writing Spec 2:Spec in Review 3:Spec Ready
-  #   4:Writing Plan 5:Plan in Review 6:Plan Ready
-  #   7:In Development 8:Development in Review 9:Merged 10:Released
-  current_status=$(printf '%s' "$item_json" | jq -r '.status // empty' || true)
-  target_order=0
-  local i=0
-  local s
-  while IFS= read -r s; do
-    if [ "$s" = "$status_label" ]; then
-      target_order=$i
-    fi
-    i=$((i + 1))
-  done <<EOF
-Backlog
-Writing Spec
-Spec in Review
-Spec Ready
-Writing Plan
-Plan in Review
-Plan Ready
-In Development
-Development in Review
-Merged
-Released
-EOF
-  local current_order=0
-  i=0
-  while IFS= read -r s; do
-    if [ "$s" = "$current_status" ]; then
-      current_order=$i
-    fi
-    i=$((i + 1))
-  done <<EOF
-Backlog
-Writing Spec
-Spec in Review
-Spec Ready
-Writing Plan
-Plan in Review
-Plan Ready
-In Development
-Development in Review
-Merged
-Released
-EOF
-  if [ -n "$current_status" ] && [ "$current_order" -gt "$target_order" ]; then
-    echo "Issue #${issue_number} is already at status '${current_status}' (more advanced than '${status_label}'); skipping rollback."
-    return 0
-  fi
-
-  echo "Updating tracker status for issue #${issue_number} to '${status_label}'..."
-  gh api graphql -f query="
-    mutation {
-      updateProjectV2ItemFieldValue(input: {
-        projectId: \"${project_id}\"
-        itemId: \"${item_id}\"
-        fieldId: \"${field_id}\"
-        value: { singleSelectOptionId: \"${option_id}\" }
-      }) {
-        projectV2Item { id }
-      }
-    }
-  " 2>/dev/null || echo "Warning: GraphQL mutation failed for issue #${issue_number}; tracker status not updated."
-}
 
 # Unified issue-number extraction: covers all branch prefixes in a single pass.
 # Sets ISSUE_NUMBER and BRANCH_TYPE; both remain empty if the branch name does
@@ -271,17 +148,17 @@ if [ -n "$ISSUE_NUMBER" ]; then
     else
       echo "Warning: could not query issue #$ISSUE_NUMBER (gh command failed). Skipping issue close."
     fi
-    update_tracker_status "$ISSUE_NUMBER" "Merged"
+    update_tracker_status_best_effort "$ISSUE_NUMBER" "Merged"
   elif [ "$BRANCH_TYPE" = "spec" ]; then
     # spec/* branches reference the issue but must not close it — the issue stays
     # open for the next workflow stage (writing the implementation plan).
     echo "Spec branch for issue #$ISSUE_NUMBER merged; issue stays open for the next workflow stage. Updating tracker status to Spec Ready..."
-    update_tracker_status "$ISSUE_NUMBER" "Spec Ready"
+    update_tracker_status_best_effort "$ISSUE_NUMBER" "Spec Ready"
   elif [ "$BRANCH_TYPE" = "plan" ]; then
     # implementation-plan/* branches reference the issue but must not close it —
     # the issue stays open for the next workflow stage (implementation).
     echo "Implementation plan branch for issue #$ISSUE_NUMBER merged; issue stays open for the next workflow stage. Updating tracker status to Plan Ready..."
-    update_tracker_status "$ISSUE_NUMBER" "Plan Ready"
+    update_tracker_status_best_effort "$ISSUE_NUMBER" "Plan Ready"
   fi
 else
   echo "No issue number detected in branch name '$TO_DELETE', skipping issue close and tracker update."

--- a/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
+++ b/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
@@ -41,6 +41,7 @@ normalize_release_branch() {
   value="${value#refs/heads/}"
   case "$value" in
     release/v*) printf '%s\n' "$value" ;;
+    release/*) printf 'release/v%s\n' "${value#release/}" ;;
     v*) printf 'release/%s\n' "$value" ;;
     *) printf 'release/v%s\n' "$value" ;;
   esac
@@ -174,7 +175,7 @@ for issue in "${ISSUE_NUMBERS[@]}"; do
     echo "Warning: could not read issue #$issue; skipping tracker update."
     continue
   fi
-  update_tracker_status_best_effort "$issue" "$RELEASED_LABEL"
+  update_tracker_status_best_effort "$issue" "$RELEASED_LABEL" "$MERGED_LABEL"
 done
 
 echo "Release post-merge cleanup complete."

--- a/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
+++ b/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
@@ -154,7 +154,8 @@ if git show-ref --quiet "refs/heads/$RELEASE_BRANCH"; then
   fi
 
   echo "Deleting local branch '$RELEASE_BRANCH'..."
-  if ! git branch -d "$RELEASE_BRANCH"; then
+  # -D is intentional: squash/rebase merges often make -d fail despite merged PRs.
+  if ! git branch -D "$RELEASE_BRANCH"; then
     echo "Could not delete local branch '$RELEASE_BRANCH' cleanly." >&2
     echo "If it is checked out elsewhere, switch away in that worktree and retry." >&2
     exit 1

--- a/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
+++ b/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# Post-merge cleanup for a release branch:
+# - verifies release PRs to main and develop are both merged
+# - deletes remote release branch (if present)
+# - deletes local release branch (switching away first if needed)
+# - optionally transitions explicit issue numbers from merged -> released
+#
+# Usage:
+#   ./scripts/development-workflow/prepare-release-post-merge-cleanup.sh <version|release-branch> [--issue N]... [--issues N,N,...]
+#
+# Examples:
+#   ./scripts/development-workflow/prepare-release-post-merge-cleanup.sh 1.2.3
+#   ./scripts/development-workflow/prepare-release-post-merge-cleanup.sh v1.2.3 --issue 232 --issue 240
+#   ./scripts/development-workflow/prepare-release-post-merge-cleanup.sh release/v1.2.3 --issues 232,240
+#
+# Env overrides:
+#   GITHUB_PROJECT_STATUS_MERGED   (default: Merged)
+#   GITHUB_PROJECT_STATUS_RELEASED (default: Released)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./workflow-lib.sh
+. "$SCRIPT_DIR/workflow-lib.sh"
+
+cd_workflow_repo_root
+require_gh
+
+MERGED_LABEL="${GITHUB_PROJECT_STATUS_MERGED:-Merged}"
+RELEASED_LABEL="${GITHUB_PROJECT_STATUS_RELEASED:-Released}"
+RELEASE_INPUT=""
+declare -a ISSUE_NUMBERS=()
+
+usage() {
+  echo "Usage: $0 <version|release-branch> [--issue N]... [--issues N,N,...]" >&2
+}
+
+normalize_release_branch() {
+  local value="$1"
+  value="${value#refs/heads/}"
+  case "$value" in
+    release/v*) printf '%s\n' "$value" ;;
+    v*) printf 'release/%s\n' "$value" ;;
+    *) printf 'release/v%s\n' "$value" ;;
+  esac
+}
+
+parse_issue_csv() {
+  local csv="$1"
+  local old_ifs="$IFS"
+  local part
+  IFS=','
+  # shellcheck disable=SC2086
+  for part in $csv; do
+    part="${part//[[:space:]]/}"
+    [ -z "$part" ] && continue
+    if [[ ! "$part" =~ ^[0-9]+$ ]]; then
+      echo "Invalid issue number '$part' in --issues list." >&2
+      exit 2
+    fi
+    ISSUE_NUMBERS+=("$part")
+  done
+  IFS="$old_ifs"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --issue)
+      if [ $# -lt 2 ]; then
+        usage
+        exit 2
+      fi
+      if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+        echo "Invalid issue number for --issue: $2" >&2
+        exit 2
+      fi
+      ISSUE_NUMBERS+=("$2")
+      shift 2
+      ;;
+    --issues)
+      if [ $# -lt 2 ]; then
+        usage
+        exit 2
+      fi
+      parse_issue_csv "$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      if [ -n "$RELEASE_INPUT" ]; then
+        echo "Unexpected extra positional argument: $1" >&2
+        usage
+        exit 2
+      fi
+      RELEASE_INPUT="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$RELEASE_INPUT" ]; then
+  usage
+  exit 2
+fi
+
+RELEASE_BRANCH="$(normalize_release_branch "$RELEASE_INPUT")"
+echo "Release branch: $RELEASE_BRANCH"
+
+echo "Verifying merged PRs for release branch..."
+MAIN_PR=$(gh pr list --state merged --head "$RELEASE_BRANCH" --base main --json number --jq '.[0].number // empty')
+DEVELOP_PR=$(gh pr list --state merged --head "$RELEASE_BRANCH" --base develop --json number --jq '.[0].number // empty')
+OPEN_MAIN_PR=$(gh pr list --state open --head "$RELEASE_BRANCH" --base main --json number --jq '.[0].number // empty')
+OPEN_DEVELOP_PR=$(gh pr list --state open --head "$RELEASE_BRANCH" --base develop --json number --jq '.[0].number // empty')
+
+if [ -n "$OPEN_MAIN_PR" ] || [ -n "$OPEN_DEVELOP_PR" ]; then
+  echo "Release PRs are still open (main: ${OPEN_MAIN_PR:-none}, develop: ${OPEN_DEVELOP_PR:-none})."
+  echo "Do not run post-merge cleanup until both PRs are merged." >&2
+  exit 1
+fi
+
+if [ -z "$MAIN_PR" ] || [ -z "$DEVELOP_PR" ]; then
+  echo "Both merged PRs are required before cleanup." >&2
+  echo "Detected merged PRs - main: ${MAIN_PR:-none}, develop: ${DEVELOP_PR:-none}" >&2
+  exit 1
+fi
+
+echo "Merged PRs verified (main #$MAIN_PR, develop #$DEVELOP_PR)."
+
+echo "Fetching origin refs..."
+git fetch origin --prune
+
+if git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" >/dev/null 2>&1; then
+  echo "Deleting remote branch '$RELEASE_BRANCH'..."
+  git push origin --delete "$RELEASE_BRANCH"
+else
+  echo "Remote branch '$RELEASE_BRANCH' is already absent; skipping remote delete."
+fi
+
+if git show-ref --quiet "refs/heads/$RELEASE_BRANCH"; then
+  CURRENT_BRANCH="$(git branch --show-current)"
+  if [ "$CURRENT_BRANCH" = "$RELEASE_BRANCH" ]; then
+    echo "Local branch '$RELEASE_BRANCH' is currently checked out; switching to develop first..."
+    git switch develop
+  fi
+
+  echo "Deleting local branch '$RELEASE_BRANCH'..."
+  if ! git branch -d "$RELEASE_BRANCH"; then
+    echo "Could not delete local branch '$RELEASE_BRANCH' cleanly." >&2
+    echo "If it is checked out elsewhere, switch away in that worktree and retry." >&2
+    exit 1
+  fi
+else
+  echo "Local branch '$RELEASE_BRANCH' is already absent; skipping local delete."
+fi
+
+if [ "${#ISSUE_NUMBERS[@]}" -eq 0 ]; then
+  echo "No issues supplied; skipping tracker release transitions."
+  exit 0
+fi
+
+echo "Transitioning scoped issues from '$MERGED_LABEL' to '$RELEASED_LABEL'..."
+for issue in "${ISSUE_NUMBERS[@]}"; do
+  ISSUE_STATE=$(gh issue view "$issue" --json state --jq '.state' 2>/dev/null || true)
+  if [ -z "$ISSUE_STATE" ]; then
+    echo "Warning: could not read issue #$issue; skipping tracker update."
+    continue
+  fi
+  update_tracker_status_best_effort "$issue" "$RELEASED_LABEL"
+done
+
+echo "Release post-merge cleanup complete."

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -264,7 +264,7 @@ workflow_status_order() {
   esac
 }
 
-# update_tracker_status_best_effort <issue_number> <status_label>
+# update_tracker_status_best_effort <issue_number> <status_label> [required_current_status]
 #
 # Best-effort update for GitHub Projects Status field.
 # - Returns 0 in all warning/failure cases to avoid blocking caller flows.
@@ -274,6 +274,7 @@ workflow_status_order() {
 update_tracker_status_best_effort() {
   local issue_number="$1"
   local status_label="$2"
+  local required_current_status="${3:-}"
   local owner project_number project_id field_json field_id option_id item_json item_id current_status
   local target_order current_order
 
@@ -307,6 +308,10 @@ update_tracker_status_best_effort() {
   fi
 
   current_status=$(printf '%s' "$item_json" | jq -r '.status // empty' || true)
+  if [ -n "$required_current_status" ] && [ "$current_status" != "$required_current_status" ]; then
+    echo "Issue #${issue_number} current status '${current_status:-unknown}' does not match required source status '${required_current_status}'; skipping update."
+    return 0
+  fi
   target_order="$(workflow_status_order "$status_label")"
   current_order="$(workflow_status_order "$current_status")"
   if [ "$target_order" -ge 0 ] && [ "$current_order" -gt "$target_order" ]; then

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -246,3 +246,85 @@ workflow_backlog_destination_kind() {
       ;;
   esac
 }
+
+workflow_status_order() {
+  case "$1" in
+    Backlog) printf '0\n' ;;
+    "Writing Spec") printf '1\n' ;;
+    "Spec in Review") printf '2\n' ;;
+    "Spec Ready") printf '3\n' ;;
+    "Writing Plan") printf '4\n' ;;
+    "Plan in Review") printf '5\n' ;;
+    "Plan Ready") printf '6\n' ;;
+    "In Development") printf '7\n' ;;
+    "Development in Review") printf '8\n' ;;
+    Merged) printf '9\n' ;;
+    Released) printf '10\n' ;;
+    *) printf -- '-1\n' ;;
+  esac
+}
+
+# update_tracker_status_best_effort <issue_number> <status_label>
+#
+# Best-effort update for GitHub Projects Status field.
+# - Returns 0 in all warning/failure cases to avoid blocking caller flows.
+# - Respects status progression ordering and never rolls status backward.
+# - Uses GITHUB_PROJECT_OWNER/GITHUB_PROJECT_NUMBER when set; owner falls back
+#   to the repository owner if omitted.
+update_tracker_status_best_effort() {
+  local issue_number="$1"
+  local status_label="$2"
+  local owner project_number project_id field_json field_id option_id item_json item_id current_status
+  local target_order current_order
+
+  owner="${GITHUB_PROJECT_OWNER:-$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || true)}"
+  project_number="${GITHUB_PROJECT_NUMBER:-}"
+  if [ -z "$owner" ] || [ -z "$project_number" ]; then
+    echo "Warning: GITHUB_PROJECT_OWNER or GITHUB_PROJECT_NUMBER not set; skipping tracker status update."
+    return 0
+  fi
+
+  project_id=$(gh project view "$project_number" --owner "$owner" --format json 2>/dev/null | jq -r '.id // empty' || true)
+  if [ -z "$project_id" ]; then
+    echo "Warning: could not resolve project ID for project #${project_number}; skipping tracker status update."
+    return 0
+  fi
+
+  field_json=$(gh project field-list "$project_number" --owner "$owner" --format json 2>/dev/null || true)
+  field_id=$(printf '%s' "$field_json" | jq -r '.fields[] | select(.name == "Status") | .id // empty' || true)
+  option_id=$(printf '%s' "$field_json" | jq -r --arg label "$status_label" '.fields[] | select(.name == "Status") | .options[] | select(.name == $label) | .id // empty' || true)
+  if [ -z "$field_id" ] || [ -z "$option_id" ]; then
+    echo "Warning: could not resolve Status field or option '${status_label}'; skipping tracker status update."
+    return 0
+  fi
+
+  item_json=$(gh project item-list "$project_number" --owner "$owner" --limit 10000 --format json 2>/dev/null \
+    | jq -c --argjson num "$issue_number" '.items[] | select(.content.number == $num)' || true)
+  item_id=$(printf '%s' "$item_json" | jq -r '.id // empty' || true)
+  if [ -z "$item_id" ]; then
+    echo "Warning: issue #${issue_number} not found in project #${project_number}; skipping tracker status update."
+    return 0
+  fi
+
+  current_status=$(printf '%s' "$item_json" | jq -r '.status // empty' || true)
+  target_order="$(workflow_status_order "$status_label")"
+  current_order="$(workflow_status_order "$current_status")"
+  if [ "$target_order" -ge 0 ] && [ "$current_order" -gt "$target_order" ]; then
+    echo "Issue #${issue_number} is already at status '${current_status}' (more advanced than '${status_label}'); skipping rollback."
+    return 0
+  fi
+
+  echo "Updating tracker status for issue #${issue_number} to '${status_label}'..."
+  gh api graphql -f query="
+    mutation {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: \"${project_id}\"
+        itemId: \"${item_id}\"
+        fieldId: \"${field_id}\"
+        value: { singleSelectOptionId: \"${option_id}\" }
+      }) {
+        projectV2Item { id }
+      }
+    }
+  " 2>/dev/null || echo "Warning: GraphQL mutation failed for issue #${issue_number}; tracker status not updated."
+}


### PR DESCRIPTION
## Summary
- add `prepare-release-post-merge-cleanup.sh` to verify both release PRs are merged before branch deletion
- delete remote/local `release/vX.Y.Z` safely and support scoped `Merged -> Released` tracker transitions
- document the new Step 9 post-merge flow in prepare-release protocol, integration docs, command wrappers, and changelog

## Test plan
- [x] `shellcheck -x scripts/development-workflow/workflow-lib.sh scripts/development-workflow/post-merge-cleanup.sh scripts/development-workflow/prepare-release-post-merge-cleanup.sh`
- [x] `npx --yes markdownlint-cli2 \"CHANGELOG.md\" \"docs/ai/development-workflow/protocols/05-prepare-release-protocol.md\" \"docs/ai/development-workflow/integrations/github-projects.md\" \".cursor/commands/prepare-release.md\" \".claude/commands/prepare-release.md\" \"scripts/development-workflow/README.md\"`

Closes #232

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated post-merge cleanup for releases that deletes release branches after both required PRs merge and transitions tracker items from merged to released status.

* **Documentation**
  * Updated release workflow protocol documentation with new Step 9 post-merge cleanup requirements and procedures.
  * Added comprehensive documentation for release branch cleanup and tracker status transition workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->