### PR TITLE
fix(workflow): backlog batch — sync-template, CodeRabbit threads, spec/review hygiene (#239–#243, #241–#242, #248, #250, #260–#262)

### DIFF
--- a/.claude/commands/sync-template.md
+++ b/.claude/commands/sync-template.md
@@ -89,6 +89,7 @@ docs/ai/                          <- full tree, all files recursively
 .claude/agents/                   <- all *.md files
 .claude/commands/                 <- all *.md files
 .claude/skills/                   <- all *.md files (including this skill itself)
+.codex/skills/                    <- Codex skill trees shipped with the template (SKILL.md and assets)
 .cursor/commands/                 <- all *.md files
 .cursor/agents/                   <- all *.md files
 .cursor/rules/                    <- all *.mdc files
@@ -98,6 +99,8 @@ docs/best-practices/1-general.md
 docs/best-practices/2-version-control.md
 docs/best-practices/3-testing.md
 ```
+
+**Comparison method:** For each directory in the list above, enumerate files with `find` (or equivalent) and compare each path to the template using `cmp` or `diff -q`. Do not rely on ad-hoc agent inspection alone for the always-sync trees — a missed directory is a silent sync gap.
 
 For each file in these paths:
 - **Exists in template, not in project** → classify as **Add**
@@ -177,7 +180,7 @@ Template version: v0.4.0  |  Project branch: develop
 ```
 
 Then ask:
-> "Ready to apply the changes above? For the files marked as new or modified, I'll apply them automatically. For files requiring manual review (including optional additive updates for project-specific files), please tell me which ones to apply."
+> "Ready to apply the changes above? For paths listed under **New files** and **Modified files** in the **always-sync** section only, I can apply them in one batch when you confirm. Special-handling and optional additive-update sections always need explicit per-path approval — bulk phrases like \"apply all\" never include those categories."
 
 **Do not modify any files until you have explicit confirmation.**
 
@@ -187,7 +190,8 @@ Then ask:
 
 Apply approved changes:
 
-- Copy/overwrite all Add and Update files from the template source into the project
+- Copy/overwrite all **Add** and **Update** files **from the always-sync Step 3 section only** when the user confirms that batch. Phrases such as "apply all", "apply everything", or "yes to all" mean **always-sync files only** — they **never** authorize applying **special-handling** paths (`.github/workflows/deploy.yml`, `e2e-regression.yml`, `e2e/`, `.claude/settings.json`, etc.) or **optional additive updates**; those require the user to name each approved path (or `none`).
+- **Placeholder guard for workflow YAML** (`.github/workflows/deploy.yml`, `.github/workflows/e2e-regression.yml`): Before overwriting the project copy with the template, compare line counts. If the **project** file has **more lines** than the template and the template has **fewer than 70%** of the project's line count, treat this as likely "real implementation → template placeholder" and **refuse** unless the user sends a **second** explicit confirmation naming that exact file.
 - For files requiring manual review: apply only those the user explicitly approved (including any optional additive updates to project-specific files — merge or add only, never remove project-specific content)
 - Do **not** delete any file
 - Do **not** overwrite project-specific files; for those paths only additive/merge changes are allowed, and only with explicit approval
@@ -212,9 +216,13 @@ git checkout -b feature/sync-template-v{TEMPLATE_VERSION}
 git diff --stat
 
 # 3. Stage and commit (only after you've reviewed the changes)
-# Note: 'git add .' stages all approved changes including any special-handling or
-# project-specific files that were approved in Step 3.
-git add .
+# Stage only approved paths — avoid 'git add .' so unapproved files never enter the commit.
+git add REVIEW.md docs/ai/ .claude/agents/ .claude/commands/ .claude/skills/ .codex/skills/ .cursor/ \
+  scripts/development-workflow/ scripts/README.md \
+  docs/best-practices/1-general.md \
+  docs/best-practices/2-version-control.md \
+  docs/best-practices/3-testing.md
+# If the user explicitly approved additional paths in Step 4, 'git add' those paths too.
 git commit -m "chore(template): sync framework updates from template v{TEMPLATE_VERSION}"
 
 # 4. Push and open PR

--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -86,6 +86,7 @@ docs/ai/                          ← full tree, all files recursively
 .claude/agents/                   ← all *.md files
 .claude/commands/                 ← all *.md files
 .claude/skills/                   ← all *.md files (including this skill itself)
+.codex/skills/                    ← Codex skill trees shipped with the template (SKILL.md and assets)
 .cursor/commands/                 ← all *.md files
 .cursor/agents/                   ← all *.md files
 .cursor/rules/                    ← all *.mdc files
@@ -95,6 +96,8 @@ docs/best-practices/1-general.md
 docs/best-practices/2-version-control.md
 docs/best-practices/3-testing.md
 ```
+
+**Comparison method:** For each directory in the list above, enumerate files with `find` (or equivalent) and compare each path to the template using `cmp` or `diff -q`. Do not rely on ad-hoc agent inspection alone for the always-sync trees — a missed directory is a silent sync gap.
 
 For each file in these paths:
 - **Exists in template, not in project** → classify as ✅ **Add**
@@ -174,7 +177,7 @@ Template version: v0.4.0  |  Project branch: develop
 ```
 
 Then ask:
-> "Ready to apply the changes above? For the files marked ✅ and 📝, I'll apply them automatically. For ⚠️ files (including optional additive updates for project-specific files), please tell me which ones to apply."
+> "Ready to apply the changes above? For the files listed under ✅ **New files** and 📝 **Modified files** in the **always-sync** section only, I can apply them in one batch when you confirm. Special-handling and optional additive-update paths always need explicit per-path approval — bulk phrases like \"apply all\" never include those categories."
 
 **Do not modify any files until you have explicit confirmation.**
 
@@ -182,7 +185,8 @@ Then ask:
 
 ## Step 4 — Apply changes (only after approval)
 
-- Copy/overwrite all ✅ (Add) and 📝 (Update) files from the template source into the project
+- Copy/overwrite all ✅ (Add) and 📝 (Update) files **from the always-sync Step 3 section only** when the user confirms that batch. Phrases such as "apply all", "apply everything", or "yes to all" mean **always-sync files only** — they **never** authorize applying **special-handling** paths (`.github/workflows/deploy.yml`, `e2e-regression.yml`, `e2e/`, `.claude/settings.json`, etc.) or **optional additive updates**; those require the user to name each approved path (or `none`).
+- **Placeholder guard for workflow YAML** (`.github/workflows/deploy.yml`, `.github/workflows/e2e-regression.yml`): Before overwriting the project copy with the template, compare line counts. If the **project** file has **more lines** than the template and the template has **fewer than 70%** of the project's line count, treat this as likely "real implementation → template placeholder" and **refuse** unless the user sends a **second** explicit confirmation naming that exact file.
 - For ⚠️ files: apply only those the user explicitly approved (including any optional additive updates to project-specific files — merge or add only, never remove project-specific content)
 - Do **not** delete any file
 - Do **not** overwrite project-specific files; for those paths only additive/merge changes are allowed, and only with explicit approval
@@ -206,7 +210,7 @@ git checkout -b feature/sync-template-v{TEMPLATE_VERSION}
 git diff --stat
 
 # 3. Stage and commit (only after you've reviewed the changes)
-git add REVIEW.md docs/ai/ .claude/agents/ .claude/commands/ .claude/skills/ .cursor/ \
+git add REVIEW.md docs/ai/ .claude/agents/ .claude/commands/ .claude/skills/ .codex/skills/ .cursor/ \
   scripts/development-workflow/ scripts/README.md \
   docs/best-practices/1-general.md \
   docs/best-practices/2-version-control.md \

--- a/.cursor/commands/sync-template.md
+++ b/.cursor/commands/sync-template.md
@@ -85,6 +85,7 @@ docs/ai/                          ← full tree, all files recursively
 .claude/agents/                   ← all *.md files
 .claude/commands/                 ← all *.md files
 .claude/skills/                   ← all *.md files (including this skill itself)
+.codex/skills/                    ← Codex skill trees shipped with the template (SKILL.md and assets)
 .cursor/commands/                 ← all *.md files
 .cursor/agents/                   ← all *.md files
 .cursor/rules/                    ← all *.mdc files
@@ -94,6 +95,8 @@ docs/best-practices/1-general.md
 docs/best-practices/2-version-control.md
 docs/best-practices/3-testing.md
 ```
+
+**Comparison method:** For each directory in the list above, enumerate files with `find` (or equivalent) and compare each path to the template using `cmp` or `diff -q`. Do not rely on ad-hoc agent inspection alone for the always-sync trees — a missed directory is a silent sync gap.
 
 For each file in these paths:
 - **Exists in template, not in project** → classify as ✅ **Add**
@@ -173,7 +176,7 @@ Template version: v0.4.0  |  Project branch: develop
 ```
 
 Then ask:
-> "Ready to apply the changes above? For the files marked ✅ and 📝, I'll apply them automatically. For ⚠️ files (including optional additive updates for project-specific files), please tell me which ones to apply."
+> "Ready to apply the changes above? For the files listed under ✅ **New files** and 📝 **Modified files** in the **always-sync** section only, I can apply them in one batch when you confirm. Special-handling and optional additive-update paths always need explicit per-path approval — bulk phrases like \"apply all\" never include those categories."
 
 **Do not modify any files until you have explicit confirmation.**
 
@@ -181,7 +184,8 @@ Then ask:
 
 ## Step 4 — Apply changes (only after approval)
 
-- Copy/overwrite all ✅ (Add) and 📝 (Update) files from the template source into the project
+- Copy/overwrite all ✅ (Add) and 📝 (Update) files **from the always-sync Step 3 section only** when the user confirms that batch. Phrases such as "apply all", "apply everything", or "yes to all" mean **always-sync files only** — they **never** authorize applying **special-handling** paths (`.github/workflows/deploy.yml`, `e2e-regression.yml`, `e2e/`, `.claude/settings.json`, etc.) or **optional additive updates**; those require the user to name each approved path (or `none`).
+- **Placeholder guard for workflow YAML** (`.github/workflows/deploy.yml`, `.github/workflows/e2e-regression.yml`): Before overwriting the project copy with the template, compare line counts. If the **project** file has **more lines** than the template and the template has **fewer than 70%** of the project's line count, treat this as likely "real implementation → template placeholder" and **refuse** unless the user sends a **second** explicit confirmation naming that exact file.
 - For ⚠️ files: apply only those the user explicitly approved (including any optional additive updates to project-specific files — merge or add only, never remove project-specific content)
 - Do **not** delete any file
 - Do **not** overwrite project-specific files; for those paths only additive/merge changes are allowed, and only with explicit approval
@@ -205,7 +209,7 @@ git checkout -b feature/sync-template-v{TEMPLATE_VERSION}
 git diff --stat
 
 # 3. Stage and commit (only after you've reviewed the changes)
-git add REVIEW.md docs/ai/ .claude/agents/ .claude/commands/ .claude/skills/ .cursor/ \
+git add REVIEW.md docs/ai/ .claude/agents/ .claude/commands/ .claude/skills/ .codex/skills/ .cursor/ \
   scripts/development-workflow/ scripts/README.md \
   docs/best-practices/1-general.md \
   docs/best-practices/2-version-control.md \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **CodeRabbit review pass vs unresolved threads** (GitHub #242, `pr-review-loop.sh`): Phase 3 clean and SUCCESS commit-status fallback now honor the GraphQL review-thread audit so old unresolved CodeRabbit threads cannot coexist with a "clean" platform result.
+- **CodeRabbit review pass vs unresolved threads** (GitHub #242, `pr-review-loop.sh`): Phase 3 clean and SUCCESS commit-status fallback now honor the GraphQL review-thread audit so old unresolved CodeRabbit threads cannot coexist with a "clean" platform result. Follow-up: emit `UNRESOLVED_THREAD_COUNT` from the per-platform gate and restore shell `errexit` after `check_unresolved_threads` so aggregate output stays contract-correct.
 
 - **`workflow-next-action.sh`**: `--development` path always exits zero after emitting key=value lines (empty `LINEAR_ISSUE` no longer yields exit status 1), restoring `workflow-batch-plan.sh` parsing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Database migration review checklist** (`REVIEW.md`): trigger/backfill arithmetic parity when both exist in the same migration.
+
 - **Scope-drift guardrails for spec and plan authoring**: protocol updates now require brief-objective coverage matrices and PR-visible deferral notes in spec writing, plus live repo verification logs for pattern-based plan scope checks; review checklists and agent/skill entrypoints were aligned, and a workflow fixture was added for stale-enumeration validation.
 - **Release post-merge cleanup command** (`prepare-release-post-merge-cleanup.sh`): verifies both release PRs are merged before deleting `release/vX.Y.Z`, removes remote/local release branches safely, and transitions explicitly scoped tracker items from `Merged` to `Released`.
 
 ### Changed
+
+- **Sync-template skill and commands** (GitHub #239, #240, #243): include `.codex/skills/` in always-sync paths; require deterministic directory enumeration and `diff`/`cmp` comparison; treat "apply all" as always-sync only (never bulk-applies special-handling files); add placeholder guard for `deploy.yml` / `e2e-regression.yml`; scope `git add` paths in the Claude command variant instead of `git add .`.
+
+- **Retrospective protocol** (GitHub #248): optional **Contribute upstream** action for workflow-only insights via labeled issues on the template repository.
+
+- **Spec authoring guardrails** (GitHub #260, #261): `spec-template.md` and `01-generate-spec-protocol.md` reinforce product language, consistency, testable acceptance criteria, and a pre-PR self-check pass.
+
+- **Automated reviewer loop protocol** (GitHub #241): shell workflow fixes require `bash -n` and a narrow behavioral verification before push.
 
 - **GitHub Actions workflow security checklist** (`03-implement-development-protocol.md`): developer guidance now requires least-privilege `permissions`, full-SHA `uses:` pinning, scoped path filters, and `concurrency` controls whenever `.github/workflows/*.yml` files are created or materially updated.
 - **Parser-risk implementation-plan requirements** (`02-generate-implementation-plan-protocol.md`, `implementation-plan-template.md`, `REVIEW.md`, `tech-lead` agents): plans that touch parser/regex/structured-text scanning now require deterministic classification plus mandatory edge-case enumeration, unit-test mapping, and conditional suppression semantics.
 - **Prepare-release protocol and command wrappers** now include a required post-merge Step 9 that runs branch cleanup plus tracker transition guidance after both release PRs merge.
 
 ### Fixed
+
+- **CodeRabbit review pass vs unresolved threads** (GitHub #242, `pr-review-loop.sh`): Phase 3 clean and SUCCESS commit-status fallback now honor the GraphQL review-thread audit so old unresolved CodeRabbit threads cannot coexist with a "clean" platform result.
+
+- **`workflow-next-action.sh`**: `--development` path always exits zero after emitting key=value lines (empty `LINEAR_ISSUE` no longer yields exit status 1), restoring `workflow-batch-plan.sh` parsing.
+
+- **`post-merge-cleanup.sh` worktrees** (GitHub #250): run `git worktree unlock` before remove to clear common agent lock files without manual intervention.
 
 - **Duplicate check-name handling in CI polling** (`pr-ci-loop.sh`): GitHub `statusCheckRollup` can contain historical entries for the same check name (for example an older `CANCELLED` run plus a newer `SKIPPED` run). The CI loop now evaluates only the latest entry per check name so stale results do not incorrectly force `RESULT=red`.
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -136,6 +136,9 @@ Additional checks for **shell scripts** (`*.sh`):
 - User-supplied input (PR numbers, branch names) is validated before interpolation into file paths or commands
 - `|| true` does not silently swallow failures from external commands (e.g., `gh`, `git`) that the caller needs to know about
 
+Additional checks for **database migrations** (when a migration adds or changes triggers, functions, or backfills):
+- **Trigger/backfill arithmetic parity**: If both a trigger and a backfill compute the same derived value, they must use the **same formula**, including guards such as `GREATEST`, `LEAST`, `COALESCE`, and null handling. A trigger that differs from its backfill is a latent production bug.
+
 Typical `blocking` issues:
 - Incorrect behavior
 - Security flaw

--- a/docs/ai/development-workflow/protocols/01-generate-spec-protocol.md
+++ b/docs/ai/development-workflow/protocols/01-generate-spec-protocol.md
@@ -134,6 +134,12 @@ Use the current timestamp for `YYYYMMDDHHMMSS`.
 - If the feature has multiple actors, each actor gets its own use case section
 - Explicitly list what is **out of scope** for this feature (MVP boundary)
 - Keep spec decisions **product-facing**; defer technical design to the implementation plan
+- Use **domain and user language** in use cases, business rules, and UX sections — do not embed API field names, JSON keys, method names, or other code identifiers (they belong in the implementation plan, not the product spec)
+- For multi-entity or high-edge-case briefs: keep **terminology consistent** across sections, keep acceptance criteria **verifiable in a test environment**, and use **Open Questions** (when present in the template) only for genuine product ambiguities — not as a dump for implementation unknowns (those belong in the plan or out-of-scope deferrals)
+
+### Before opening the draft PR (self-check)
+
+Skim the spec body once more for: accidental **Open Questions** sections when forbidden, **copy/paste character corruption**, mixed terminology for the same concept, and acceptance criteria that cannot be verified without guessing environment or data setup.
 
 ### Brief Coverage Requirements (mandatory when a tracker brief exists)
 

--- a/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
+++ b/docs/ai/development-workflow/protocols/06-retrospective-protocol.md
@@ -168,6 +168,7 @@ For each opportunity, recommend one of:
 
 - **Address now** — suitable for changes the agent can self-assess as simple and safe to apply without a review loop (e.g., one-line config fix, missing label in a YAML file, a `.gitignore` entry)
 - **Add to backlog** — suitable for anything requiring implementation planning, cross-file changes, or a review loop
+- **Contribute upstream** — suitable only for **workflow, tooling, or template-process** insights that would benefit every downstream consumer of this template (not product/domain/business retrospectives)
 
 The recommended action is a suggestion. The human makes the final choice.
 
@@ -210,7 +211,7 @@ Present the categorized findings to the human in a structured format:
 
 Then ask the human to choose an action for each opportunity:
 
-> For each finding above, please choose: **Address now**, **Add to backlog**, or **Skip**.
+> For each finding above, please choose: **Address now**, **Add to backlog**, **Contribute upstream** (workflow-only insights to the template repository), or **Skip**.
 
 Wait for the human's choices before executing any action.
 
@@ -314,6 +315,18 @@ Report the created issue with its URL.
 **Constraints**:
 - Do **not** run the full `00-add-backlog-item-protocol.md` flow — that would disrupt the retrospective with its own alignment conversation
 - The issue body must contain enough context that someone picking it up later can understand what was observed without needing the original conversation
+
+### Contribute upstream
+
+Only when the human explicitly chose **Contribute upstream** for a finding that qualifies as **workflow/tooling/template-process** (per the scope rules above). This path is **opt-in** and must never run without an explicit per-finding choice.
+
+1. Confirm the default upstream repository and issue tracker with the human when ambiguous (typically the public template repository this project was derived from).
+2. Create a new issue on the **template** repository using `gh issue create` (or the tracker’s equivalent), with label **`template-feedback`** (create the label first if it does not exist), and a body that includes:
+   - The retrospective insight (Observed / Impact / Proposed improvement), anonymized if needed
+   - A link or name of the downstream repository that produced the insight (only with human consent)
+   - Reference to the original retrospective scope (PR numbers, batch id, or date)
+
+3. Do **not** close the downstream retrospective item automatically — the upstream issue is additive visibility, not a replacement for local backlog tracking.
 
 ### Skip
 

--- a/docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/ai/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -70,6 +70,15 @@ Also handle the case where a platform posted blocking findings after a previous 
 
 If unresolved findings exist: dispatch a fixer agent, wait for the push, then proceed to the scripts. Do not re-trigger the reviewer loop against stale findings — fix first.
 
+### Shell script fix verification (fixer agents)
+
+When findings target `*.sh` workflow scripts (especially under `scripts/development-workflow/`), the fixer must **verify locally before pushing**:
+
+1. Run `bash -n <path>` on every edited script for syntax errors.
+2. Run at least one **narrow behavioral check** appropriate to the change — for example exercising the edited code path with a small controlled input, running the script’s `--help`, or running the smallest documented smoke command for that script.
+
+If verification fails, iterate without pushing. When a prior attempt introduced regressions (e.g., misunderstood `IFS`, `read`, or `git worktree list --porcelain` ordering), prefer the **orchestrating agent** applying the fix inline with full conversation context rather than re-dispatching a blind fixer on the same subtle finding.
+
 ### Run the loops
 
 Execute **Step 7a: Internal Review Gate**, **Step 7: Automated Reviewer Loop**, **Step 8: CI Loop**, **Step 8a: Label Readiness Checklist**, **Step 8b: Update Tracker Status**, and **Step 8c: Post-Label Independent Verification** exactly as defined in `91-orchestrate-work-protocol.md` (scripts, result interpretation, sequential platform policy, fixer mapping, parameters, and labels). Do not duplicate that logic here — follow 91.

--- a/docs/ai/development-workflow/templates/spec-template.md
+++ b/docs/ai/development-workflow/templates/spec-template.md
@@ -8,6 +8,8 @@
 
 <!-- 2-4 sentences describing what this feature does and why it exists. -->
 
+**Language**: Describe outcomes in product and user terms. Do not use API field names, database column names, JSON keys, or code symbols in this document — use plain-language labels and map technical identifiers only in the implementation plan.
+
 ---
 
 ## Use Cases

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -73,6 +73,8 @@ echo "Deleting local branch '$TO_DELETE'..."
 WORKTREE_PATH=$(git worktree list --porcelain | grep -B2 "branch refs/heads/$TO_DELETE$" | grep "^worktree " | sed 's/^worktree //' || true)
 if [ -n "$WORKTREE_PATH" ]; then
   echo "Worktree '$WORKTREE_PATH' is still using branch '$TO_DELETE'. Removing worktree first..."
+  # Proactive unlock: agent processes often leave worktrees locked; unlock is idempotent when not locked.
+  git worktree unlock "$WORKTREE_PATH" 2>/dev/null || true
   # Capture stderr so we can detect the locked-worktree condition.
   REMOVE_ERR=$(git worktree remove "$WORKTREE_PATH" --force 2>&1) && REMOVE_RC=0 || REMOVE_RC=$?
   if [ "$REMOVE_RC" -ne 0 ] && echo "$REMOVE_ERR" | grep -q "locked working tree"; then

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -777,6 +777,53 @@ is_coderabbit_blocking() {
   return 1
 }
 
+# Returns 0 when CodeRabbit may treat the PR as thread-clean for this pass.
+# Returns 1 after emitting RESULT=needs_fixes (unresolved GraphQL threads).
+# Returns 2 after emitting RESULT=escalate (thread page cap exceeded).
+# On transient GraphQL failure (exit 3 from check_unresolved_threads), returns 0
+# to match the aggregate thread gate degrade behavior at script EOF.
+coderabbit_thread_gate_clean() {
+  local pr_number="$1" repo="$2" bot_login="$3" branch_name="$4"
+  local platform="coderabbit"
+  local out st
+  set +e
+  out="$(check_unresolved_threads "$pr_number" "$repo" "$bot_login")"
+  st=$?
+  set -e
+  if [ "$st" -eq 2 ]; then
+    echo "WARN: check_unresolved_threads exceeded page cap for PR #$pr_number (CodeRabbit pass)" >&2
+    print_kv RESULT escalate
+    print_kv REASON unresolved_thread_check_incomplete
+    print_kv PLATFORM "$platform"
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv REVIEW_COMMENT_ID ""
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv COMMENT_COUNT 0
+    print_kv BLOCKING_COUNT 0
+    print_kv SUGGESTION_COUNT 0
+    return 2
+  fi
+  if [ "$st" -ne 0 ]; then
+    echo "WARN: check_unresolved_threads failed in CodeRabbit pass (exit $st) — not blocking on threads" >&2
+    return 0
+  fi
+  if [ "${out:-0}" -gt 0 ]; then
+    print_kv RESULT needs_fixes
+    print_kv REASON coderabbit_unresolved_review_threads
+    print_kv PLATFORM "$platform"
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv REVIEW_COMMENT_ID ""
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv COMMENT_COUNT "$out"
+    print_kv BLOCKING_COUNT "$out"
+    print_kv SUGGESTION_COUNT 0
+    return 1
+  fi
+  return 0
+}
+
 run_coderabbit_review() {
   local pr_number="$1"
   local branch_name="$2"
@@ -1055,18 +1102,27 @@ run_coderabbit_review() {
                   | length'
         )"
         if [ "${coderabbit_success_status_count:-0}" -gt 0 ]; then
-          echo "INFO: CodeRabbit SUCCESS commit-status found for HEAD $head_sha — treating PR as clean (coderabbit_status_success_fallback)" >&2
-          print_kv RESULT clean
-          print_kv REASON coderabbit_status_success_fallback
-          print_kv PLATFORM "$platform"
-          print_kv PR_NUMBER "$pr_number"
-          print_kv BRANCH "$branch_name"
-          print_kv REVIEW_COMMENT_ID ""
-          print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
-          print_kv COMMENT_COUNT 0
-          print_kv BLOCKING_COUNT 0
-          print_kv SUGGESTION_COUNT 0
-          return 0
+          # SUCCESS status can appear while older CodeRabbit review threads stay unresolved
+          # on the PR. Do not short-circuit to clean until GraphQL thread audit passes.
+          coderabbit_thread_gate_clean "$pr_number" "$repo" "$bot_login" "$branch_name"
+          cr_success_gate_rc=$?
+          if [ "$cr_success_gate_rc" -eq 0 ]; then
+            echo "INFO: CodeRabbit SUCCESS commit-status found for HEAD $head_sha — treating PR as clean (coderabbit_status_success_fallback)" >&2
+            print_kv RESULT clean
+            print_kv REASON coderabbit_status_success_fallback
+            print_kv PLATFORM "$platform"
+            print_kv PR_NUMBER "$pr_number"
+            print_kv BRANCH "$branch_name"
+            print_kv REVIEW_COMMENT_ID ""
+            print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+            print_kv COMMENT_COUNT 0
+            print_kv BLOCKING_COUNT 0
+            print_kv SUGGESTION_COUNT 0
+            return 0
+          fi
+          if [ "$cr_success_gate_rc" -eq 1 ] || [ "$cr_success_gate_rc" -eq 2 ]; then
+            return "$cr_success_gate_rc"
+          fi
         fi
 
         # CodeRabbit didn't review this HEAD. Check for stale findings before skipping.
@@ -1241,6 +1297,11 @@ run_coderabbit_review() {
   fi
 
   rm -f "$blocking_lines_file"
+  coderabbit_thread_gate_clean "$pr_number" "$repo" "$bot_login" "$branch_name"
+  cr_phase3_gate_rc=$?
+  if [ "$cr_phase3_gate_rc" -ne 0 ]; then
+    return "$cr_phase3_gate_rc"
+  fi
   print_kv RESULT clean
   print_kv PLATFORM "$platform"
   print_kv PR_NUMBER "$pr_number"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -786,10 +786,14 @@ coderabbit_thread_gate_clean() {
   local pr_number="$1" repo="$2" bot_login="$3" branch_name="$4"
   local platform="coderabbit"
   local out st
+  # check_unresolved_threads re-enables errexit internally; capture and restore
+  # shellopts so set -e does not leak into run_coderabbit_review (dead rc capture).
+  local prev_errexit
+  prev_errexit="$(set +o | grep errexit)"
   set +e
   out="$(check_unresolved_threads "$pr_number" "$repo" "$bot_login")"
   st=$?
-  set -e
+  eval "$prev_errexit"
   if [ "$st" -eq 2 ]; then
     echo "WARN: check_unresolved_threads exceeded page cap for PR #$pr_number (CodeRabbit pass)" >&2
     print_kv RESULT escalate
@@ -819,6 +823,7 @@ coderabbit_thread_gate_clean() {
     print_kv COMMENT_COUNT "$out"
     print_kv BLOCKING_COUNT "$out"
     print_kv SUGGESTION_COUNT 0
+    print_kv UNRESOLVED_THREAD_COUNT "$out"
     return 1
   fi
   return 0

--- a/scripts/development-workflow/workflow-next-action.sh
+++ b/scripts/development-workflow/workflow-next-action.sh
@@ -267,4 +267,7 @@ linear_issue=""
 if [ -n "$spec_file" ] && linear_line="$(grep -m 1 '^\*\*Linear Issue\*\*: ' "$spec_file" 2>/dev/null)"; then
   linear_issue="$(printf '%s\n' "$linear_line" | sed 's/^\*\*Linear Issue\*\*: //' | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
 fi
-[ -n "$linear_issue" ] && print_kv LINEAR_ISSUE "$linear_issue"
+if [ -n "$linear_issue" ]; then
+  print_kv LINEAR_ISSUE "$linear_issue"
+fi
+exit 0


### PR DESCRIPTION
## Summary

Single integration PR addressing the following **Backlog** items (GitHub Projects) in one pass:

- **#239 / #243 / #240** — Sync-template: `.codex/skills/` in always-sync manifest, deterministic `find`+`diff` comparison guidance, “apply all” = always-sync only, placeholder guard for `deploy.yml` / `e2e-regression.yml`, path-scoped `git add` in Claude command; mirrored in Cursor skill/command and `.claude/skills/sync-template.md`.
- **#242** — `pr-review-loop.sh`: CodeRabbit SUCCESS fallback and Phase 3 “clean” now run the GraphQL unresolved-thread audit first (`coderabbit_thread_gate_clean`).
- **#241** — Protocol **93**: shell fixers must run `bash -n` and a narrow behavioral check before push.
- **#248** — Protocol **06**: optional **Contribute upstream** (`template-feedback` on template repo).
- **#250** — `post-merge-cleanup.sh`: proactive `git worktree unlock` before remove.
- **#260 / #261** — Spec template + protocol **01** product-language and first-draft quality guardrails.
- **#262** — `REVIEW.md`: trigger/backfill arithmetic parity for migrations.

Also fixes **`workflow-next-action.sh`** exiting `1` when no Linear issue line is printed (restores `workflow-batch-plan.sh`).

## Deferred (not in this PR)

- **#251** — `docs/ai/` → `docs/workflow/` rename: large cross-repo migration; needs dedicated plan/PR.
- **#252** — Sync-template manifest / mixed-content strategy: broader design work; partially overlapped by #240 path list + comparison rules but not a full manifest system.

## Testing

- `bash -n` on modified shell scripts.
- Manual: `workflow-next-action.sh --development …` now exits `0`.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
