### PR TITLE
fix(tech-lead): plan CHANGELOG literals must use project bold-title format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Tech-lead CHANGELOG literal format** (#226): plan protocol, plan template, and `REVIEW.md` plan-review checklist now require and enforce the project's `**Bold Title** (#N):` CHANGELOG entry format; conventional-commit-style literals (`fix(scope): message`) in Implementation Order steps are now a blocking plan-review finding.
+
 - **CodeRabbit review pass vs unresolved threads** (GitHub #242, `pr-review-loop.sh`): Phase 3 clean and SUCCESS commit-status fallback now honor the GraphQL review-thread audit so old unresolved CodeRabbit threads cannot coexist with a "clean" platform result. Follow-up: emit `UNRESOLVED_THREAD_COUNT` from the per-platform gate and restore shell `errexit` after `check_unresolved_threads` so aggregate output stays contract-correct.
 
 - **`workflow-next-action.sh`**: `--development` path always exits zero after emitting key=value lines (empty `LINEAR_ISSUE` no longer yields exit status 1), restoring `workflow-batch-plan.sh` parsing.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -105,6 +105,7 @@ Typical `blocking` issues:
 - Plan steps do not cover required acceptance criteria
 - The plan requires guessing at implementation details
 - The plan introduces unsafe or contradictory architecture decisions
+- A CHANGELOG literal in the Implementation Order uses conventional-commit format (`fix(scope): message`) instead of the project's `**Bold Title** (#N):` format
 
 Typical `important` issues:
 - Vague wording like "update as needed"

--- a/docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/ai/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -99,6 +99,7 @@ docs/specs/developments/[timestamp]_[feature-slug]/2_[feature-slug]_implementati
 - **Pattern completeness checks**: When the spec intent implies "all files/items matching pattern X", do not trust stale enumerations. Re-run a live repo query at plan-write time and use those results in the plan's file list and counts.
 - **Explicit freeze exception**: You may copy a fixed enumeration only when the spec explicitly freezes scope to a named subset; quote that spec section in the plan.
 - **Verification Log required**: Every plan must include a reproducible Verification Log (command/query, repo SHA, and resulting counts/paths that drive scope statements).
+- **CHANGELOG literal format**: When the Implementation Order includes a literal CHANGELOG entry for the developer to copy, it must follow the project's `**Bold Title** (#N):` format (e.g., `- **Fix tech-lead CHANGELOG format** (#226): ...`). Never use conventional-commit format (`fix(scope): message`) in a CHANGELOG literal — that format is for git commit messages, not CHANGELOG entries. The impl agent will copy the literal verbatim; a wrong format wastes a reviewer cycle.
 
 ### Parser-risk plans: custom parsers, regex, and structured-text scanning
 

--- a/docs/ai/development-workflow/templates/implementation-plan-template.md
+++ b/docs/ai/development-workflow/templates/implementation-plan-template.md
@@ -126,4 +126,4 @@
 6. [Step 6: e.g., update seed data]
 7. [Step 7: e.g., verify smoke test runbook]
 8. [Step 8: Update project docs per **Documentation Updates** section above (if any)]
-9. [Step 9: e.g., update CHANGELOG]
+9. [Step 9: update `CHANGELOG.md` under `[Unreleased]` — use the project's `**Bold Title** (#N):` format (e.g., `- **Bold Title** (#226): description`). Do NOT use conventional-commit format (`fix(scope): message`) in the CHANGELOG entry.]


### PR DESCRIPTION
## Summary

Closes #226.

On PR #225, the plan's Implementation Order supplied the CHANGELOG entry literal in conventional-commit format (`fix(item-orchestrator): ...`). The impl agent copied it verbatim, Devin flagged it as blocking on reviewer cycle 1, and a rewrite commit was required. Every plan that quotes a literal CHANGELOG entry inherits this footgun.

### Changes

- **`02-generate-implementation-plan-protocol.md`** (Step 3 quality guardrails): added explicit rule requiring CHANGELOG literals to use the project's `**Bold Title** (#N):` format and prohibiting conventional-commit format in plan-quoted CHANGELOG entries.
- **`implementation-plan-template.md`** (Implementation Order Step 9): clarified the CHANGELOG update step with the correct format and an explicit "do NOT use conventional-commit format" note.
- **`REVIEW.md`** (Plan Review Checklist, Typical `blocking` issues): added a blocking finding for CHANGELOG literals that use conventional-commit format instead of the project format.

### Scope

Fast Track fix — no spec or plan required. Changes are confined to workflow protocol docs and the REVIEW contract.

## Test plan

- [ ] `markdownlint-cli2` passes on all four changed files
- [ ] Heuristic lint passes (no GLOB001/COUNT001 findings)
- [ ] Plan Review Checklist in REVIEW.md includes the new blocking finding
- [ ] Protocol 02 Step 3 quality guardrails include the CHANGELOG literal format rule
- [ ] Template Implementation Order Step 9 includes format guidance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development workflow protocols to enforce standardized CHANGELOG entry format
  * Updated implementation plan template with refined CHANGELOG entry instructions
  
* **Chores**
  * Added plan review checklist item for CHANGELOG format validation
  * Updated changelog documenting format enforcement requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->