### PR TITLE
fix(developer-agent): add MD047 trailing-newline check to post-edit checklist

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -19,4 +19,5 @@ Key rules:
 - Never bypass build/lint/test verification
 - Always update CHANGELOG before opening the PR (except spec/plan-only PRs; for fixes to unreleased work, update the existing entry instead of adding a new one; in parallel batches, each PR adds its own CHANGELOG entry as normal; merge conflicts are resolved at merge time)
 - CHANGELOG entries must have no trailing whitespace and no trailing blank lines before commit; verify in-place after writing the entry and before staging (intentional two-space Markdown hard line breaks are exempt)
+- Every modified `.md` file must end with a trailing newline (MD047) before staging; run the pre-staging check from the protocol's MD047 section on all modified markdown files before `git add`
 - Do not stop at "PR opened"; continue through code review, automated review, and CI until the PR is ready or escalated

--- a/.cursor/agents/developer.md
+++ b/.cursor/agents/developer.md
@@ -18,4 +18,5 @@ Key rules:
 - Never bypass build/lint/test verification
 - Always update CHANGELOG before opening the PR (except spec/plan-only PRs; for fixes to unreleased work, update the existing entry instead of adding a new one; in parallel batches, each PR adds its own CHANGELOG entry as normal; merge conflicts are resolved at merge time)
 - CHANGELOG entries must have no trailing whitespace and no trailing blank lines before commit; verify in-place after writing the entry and before staging (intentional two-space Markdown hard line breaks are exempt)
+- Every modified `.md` file must end with a trailing newline (MD047) before staging; run the pre-staging check from the protocol's MD047 section on all modified markdown files before `git add`
 - Do not stop at "PR opened"; continue through code review, automated review, and CI until the PR is ready or escalated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **MD047 trailing-newline pre-staging check** (#227): `03-implement-development-protocol.md` (all four paths) now includes an explicit MD047 check that scans every modified `.md` file for a missing trailing newline before `git add`; `.claude/agents/developer.md` and `.cursor/agents/developer.md` key-rules sections were updated with the matching rule (parity with the #178 trailing-whitespace step).
+
 - **Tech-lead CHANGELOG literal format** (#226): plan protocol, plan template, and `REVIEW.md` plan-review checklist now require and enforce the project's `**Bold Title** (#N):` CHANGELOG entry format; conventional-commit-style literals (`fix(scope): message`) in Implementation Order steps are now a blocking plan-review finding.
 
 - **CodeRabbit review pass vs unresolved threads** (GitHub #242, `pr-review-loop.sh`): Phase 3 clean and SUCCESS commit-status fallback now honor the GraphQL review-thread audit so old unresolved CodeRabbit threads cannot coexist with a "clean" platform result. Follow-up: emit `UNRESOLVED_THREAD_COUNT` from the per-platform gate and restore shell `errexit` after `check_unresolved_threads` so aggregate output stays contract-correct.

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -159,6 +159,18 @@ git diff CHANGELOG.md | grep '^+' | grep -E '[[:space:]]+$'
 
 If this returns output, inspect each flagged line: leave intentional two-space Markdown hard line breaks (exactly two trailing spaces followed by a newline) intact, and fix any other trailing whitespace (e.g., a single trailing space, a tab, or three or more trailing spaces) before committing.
 
+**MD047 trailing-newline check (before staging)**: After editing any markdown file, verify that every modified `.md` file ends with a newline (MD047). Run this check on each markdown file you are about to stage:
+
+```bash
+# Check each modified .md file for a missing trailing newline (run before git add)
+git diff --name-only | grep '\.md$' | while read f; do
+  python3 -c "import sys; d=open(sys.argv[1],'rb').read(); sys.exit(0 if d.endswith(b'\n') else 1)" "$f" \
+    || echo "MISSING trailing newline: $f"
+done
+```
+
+If any file is flagged, append a newline to it (e.g., `echo "" >> <file>` or reopen and save in your editor) before staging.
+
 ### Step 7: Commit & Push
 
 ```bash
@@ -275,6 +287,18 @@ git checkout -b refactor/[branch-slug]
 
    If this returns output, inspect each flagged line: leave intentional two-space Markdown hard line breaks (exactly two trailing spaces followed by a newline) intact, and fix any other trailing whitespace (e.g., a single trailing space, a tab, or three or more trailing spaces) before committing.
 
+   **MD047 trailing-newline check (before staging)**: After editing any markdown file, verify that every modified `.md` file ends with a newline (MD047). Run this check on each markdown file you are about to stage:
+
+   ```bash
+   # Check each modified .md file for a missing trailing newline (run before git add)
+   git diff --name-only | grep '\.md$' | while read f; do
+     python3 -c "import sys; d=open(sys.argv[1],'rb').read(); sys.exit(0 if d.endswith(b'\n') else 1)" "$f" \
+       || echo "MISSING trailing newline: $f"
+   done
+   ```
+
+   If any file is flagged, append a newline to it (e.g., `echo "" >> <file>` or reopen and save in your editor) before staging.
+
 7. Commit: `refactor([scope]): [description]`
 8. Push branch to remote
 9. Open a **draft** PR targeting `develop` with refactor-appropriate metadata (do **not** reuse Path 1 Step 8 verbatim — that path uses `feat(...)` and a spec link):
@@ -369,6 +393,18 @@ git diff CHANGELOG.md | grep '^+' | grep -E '[[:space:]]+$'
 
 If this returns output, inspect each flagged line: leave intentional two-space Markdown hard line breaks (exactly two trailing spaces followed by a newline) intact, and fix any other trailing whitespace (e.g., a single trailing space, a tab, or three or more trailing spaces) before committing.
 
+**MD047 trailing-newline check (before staging)**: After editing any markdown file, verify that every modified `.md` file ends with a newline (MD047). Run this check on each markdown file you are about to stage:
+
+```bash
+# Check each modified .md file for a missing trailing newline (run before git add)
+git diff --name-only | grep '\.md$' | while read f; do
+  python3 -c "import sys; d=open(sys.argv[1],'rb').read(); sys.exit(0 if d.endswith(b'\n') else 1)" "$f" \
+    || echo "MISSING trailing newline: $f"
+done
+```
+
+If any file is flagged, append a newline to it (e.g., `echo "" >> <file>` or reopen and save in your editor) before staging.
+
 ### Step 7: Commit & Push
 
 ```bash
@@ -453,6 +489,18 @@ git diff CHANGELOG.md | grep '^+' | grep -E '[[:space:]]+$'
 ```
 
 If this returns output, inspect each flagged line: leave intentional two-space Markdown hard line breaks (exactly two trailing spaces followed by a newline) intact, and fix any other trailing whitespace (e.g., a single trailing space, a tab, or three or more trailing spaces) before committing.
+
+**MD047 trailing-newline check (before staging)**: After editing any markdown file, verify that every modified `.md` file ends with a newline (MD047). Run this check on each markdown file you are about to stage:
+
+```bash
+# Check each modified .md file for a missing trailing newline (run before git add)
+git diff --name-only | grep '\.md$' | while read f; do
+  python3 -c "import sys; d=open(sys.argv[1],'rb').read(); sys.exit(0 if d.endswith(b'\n') else 1)" "$f" \
+    || echo "MISSING trailing newline: $f"
+done
+```
+
+If any file is flagged, append a newline to it (e.g., `echo "" >> <file>` or reopen and save in your editor) before staging.
 
 ### Step 7: Commit & Push
 

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -162,8 +162,8 @@ If this returns output, inspect each flagged line: leave intentional two-space M
 **MD047 trailing-newline check (before staging)**: After editing any markdown file, verify that every modified `.md` file ends with a newline (MD047). Run this check on each markdown file you are about to stage:
 
 ```bash
-# Check each modified or newly created .md file for a missing trailing newline (run before git add)
-{ git diff --name-only; git ls-files --others --exclude-standard; } | grep '\.md$' | sort -u | while read -r f; do
+# Check each modified (non-deleted) or newly created .md file for a missing trailing newline (run before git add)
+{ git diff --name-only --diff-filter=d; git ls-files --others --exclude-standard; } | grep '\.md$' | sort -u | while read -r f; do
   python3 -c "import sys; d=open(sys.argv[1],'rb').read(); sys.exit(0 if d.endswith(b'\n') else 1)" "$f" \
     || echo "MISSING trailing newline: $f"
 done
@@ -290,8 +290,8 @@ git checkout -b refactor/[branch-slug]
    **MD047 trailing-newline check (before staging)**: After editing any markdown file, verify that every modified `.md` file ends with a newline (MD047). Run this check on each markdown file you are about to stage:
 
    ```bash
-   # Check each modified or newly created .md file for a missing trailing newline (run before git add)
-   { git diff --name-only; git ls-files --others --exclude-standard; } | grep '\.md$' | sort -u | while read -r f; do
+   # Check each modified (non-deleted) or newly created .md file for a missing trailing newline (run before git add)
+   { git diff --name-only --diff-filter=d; git ls-files --others --exclude-standard; } | grep '\.md$' | sort -u | while read -r f; do
      python3 -c "import sys; d=open(sys.argv[1],'rb').read(); sys.exit(0 if d.endswith(b'\n') else 1)" "$f" \
        || echo "MISSING trailing newline: $f"
    done
@@ -396,8 +396,8 @@ If this returns output, inspect each flagged line: leave intentional two-space M
 **MD047 trailing-newline check (before staging)**: After editing any markdown file, verify that every modified `.md` file ends with a newline (MD047). Run this check on each markdown file you are about to stage:
 
 ```bash
-# Check each modified or newly created .md file for a missing trailing newline (run before git add)
-{ git diff --name-only; git ls-files --others --exclude-standard; } | grep '\.md$' | sort -u | while read -r f; do
+# Check each modified (non-deleted) or newly created .md file for a missing trailing newline (run before git add)
+{ git diff --name-only --diff-filter=d; git ls-files --others --exclude-standard; } | grep '\.md$' | sort -u | while read -r f; do
   python3 -c "import sys; d=open(sys.argv[1],'rb').read(); sys.exit(0 if d.endswith(b'\n') else 1)" "$f" \
     || echo "MISSING trailing newline: $f"
 done
@@ -493,8 +493,8 @@ If this returns output, inspect each flagged line: leave intentional two-space M
 **MD047 trailing-newline check (before staging)**: After editing any markdown file, verify that every modified `.md` file ends with a newline (MD047). Run this check on each markdown file you are about to stage:
 
 ```bash
-# Check each modified or newly created .md file for a missing trailing newline (run before git add)
-{ git diff --name-only; git ls-files --others --exclude-standard; } | grep '\.md$' | sort -u | while read -r f; do
+# Check each modified (non-deleted) or newly created .md file for a missing trailing newline (run before git add)
+{ git diff --name-only --diff-filter=d; git ls-files --others --exclude-standard; } | grep '\.md$' | sort -u | while read -r f; do
   python3 -c "import sys; d=open(sys.argv[1],'rb').read(); sys.exit(0 if d.endswith(b'\n') else 1)" "$f" \
     || echo "MISSING trailing newline: $f"
 done

--- a/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/ai/development-workflow/protocols/03-implement-development-protocol.md
@@ -162,8 +162,8 @@ If this returns output, inspect each flagged line: leave intentional two-space M
 **MD047 trailing-newline check (before staging)**: After editing any markdown file, verify that every modified `.md` file ends with a newline (MD047). Run this check on each markdown file you are about to stage:
 
 ```bash
-# Check each modified .md file for a missing trailing newline (run before git add)
-git diff --name-only | grep '\.md$' | while read f; do
+# Check each modified or newly created .md file for a missing trailing newline (run before git add)
+{ git diff --name-only; git ls-files --others --exclude-standard; } | grep '\.md$' | sort -u | while read -r f; do
   python3 -c "import sys; d=open(sys.argv[1],'rb').read(); sys.exit(0 if d.endswith(b'\n') else 1)" "$f" \
     || echo "MISSING trailing newline: $f"
 done
@@ -290,8 +290,8 @@ git checkout -b refactor/[branch-slug]
    **MD047 trailing-newline check (before staging)**: After editing any markdown file, verify that every modified `.md` file ends with a newline (MD047). Run this check on each markdown file you are about to stage:
 
    ```bash
-   # Check each modified .md file for a missing trailing newline (run before git add)
-   git diff --name-only | grep '\.md$' | while read f; do
+   # Check each modified or newly created .md file for a missing trailing newline (run before git add)
+   { git diff --name-only; git ls-files --others --exclude-standard; } | grep '\.md$' | sort -u | while read -r f; do
      python3 -c "import sys; d=open(sys.argv[1],'rb').read(); sys.exit(0 if d.endswith(b'\n') else 1)" "$f" \
        || echo "MISSING trailing newline: $f"
    done
@@ -396,8 +396,8 @@ If this returns output, inspect each flagged line: leave intentional two-space M
 **MD047 trailing-newline check (before staging)**: After editing any markdown file, verify that every modified `.md` file ends with a newline (MD047). Run this check on each markdown file you are about to stage:
 
 ```bash
-# Check each modified .md file for a missing trailing newline (run before git add)
-git diff --name-only | grep '\.md$' | while read f; do
+# Check each modified or newly created .md file for a missing trailing newline (run before git add)
+{ git diff --name-only; git ls-files --others --exclude-standard; } | grep '\.md$' | sort -u | while read -r f; do
   python3 -c "import sys; d=open(sys.argv[1],'rb').read(); sys.exit(0 if d.endswith(b'\n') else 1)" "$f" \
     || echo "MISSING trailing newline: $f"
 done
@@ -493,8 +493,8 @@ If this returns output, inspect each flagged line: leave intentional two-space M
 **MD047 trailing-newline check (before staging)**: After editing any markdown file, verify that every modified `.md` file ends with a newline (MD047). Run this check on each markdown file you are about to stage:
 
 ```bash
-# Check each modified .md file for a missing trailing newline (run before git add)
-git diff --name-only | grep '\.md$' | while read f; do
+# Check each modified or newly created .md file for a missing trailing newline (run before git add)
+{ git diff --name-only; git ls-files --others --exclude-standard; } | grep '\.md$' | sort -u | while read -r f; do
   python3 -c "import sys; d=open(sys.argv[1],'rb').read(); sys.exit(0 if d.endswith(b'\n') else 1)" "$f" \
     || echo "MISSING trailing newline: $f"
 done


### PR DESCRIPTION
## What

Adds an MD047 trailing-newline pre-staging check to the developer agent post-edit checklist, mirroring the #178 trailing-whitespace step.

## Why

On PR #225, `.claude/agents/item-orchestrator.md` lost its trailing newline after the `Edit` tool appended a bullet at EOF. Devin flagged it as MD047 blocking on reviewer cycle 2 (fixed in commit `d35dd82`). The existing CHANGELOG trailing-whitespace verification step covers whitespace but not missing trailing newlines. The `Edit` and `Write` tools do not reliably preserve a trailing newline when the insertion point is at the end of a file.

## Changes

- `docs/ai/development-workflow/protocols/03-implement-development-protocol.md`: Added a **MD047 trailing-newline check** section to Step 6 (CHANGELOG update) in all four implementation paths (Full Pipeline, Refactor, Fast Track, Hotfix). The check runs `git diff --name-only | grep '\.md$'` and uses `python3` to verify each modified markdown file ends with `\n` before staging.
- `.claude/agents/developer.md`: Added key-rule bullet — every modified `.md` file must end with a trailing newline (MD047) before staging.
- `.cursor/agents/developer.md`: Same key-rule bullet (parity with `.claude` variant).
- `CHANGELOG.md`: Added `Fixed` entry under `[Unreleased]`.

## Test Plan

- Confirm `03-implement-development-protocol.md` includes the MD047 check block in all four paths (Full Pipeline Step 6, Refactor step 6, Fast Track Step 6, Hotfix Step 6).
- Confirm `.claude/agents/developer.md` and `.cursor/agents/developer.md` both have the new key-rule bullet with identical wording.
- Confirm the check command can detect a file missing a trailing newline: `printf 'test' > /tmp/test.md && python3 -c "import sys; d=open(sys.argv[1],'rb').read(); sys.exit(0 if d.endswith(b'\n') else 1)" /tmp/test.md || echo "MISSING trailing newline: /tmp/test.md"` should print the MISSING message.

## CHANGELOG entry preview

```
- **MD047 trailing-newline pre-staging check** (#227): `03-implement-development-protocol.md` (all four paths) now includes an explicit MD047 check that scans every modified `.md` file for a missing trailing newline before `git add`; `.claude/agents/developer.md` and `.cursor/agents/developer.md` key-rules sections were updated with the matching rule (parity with the #178 trailing-whitespace step).
```

Closes #227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a new Markdown formatting requirement enforcing trailing newlines (MD047 compliance) in all modified `.md` files before staging
  * Updated development protocol documentation across all workflow paths to enforce this formatting standard
  * Added automatic validation that checks all modified Markdown files for proper trailing newlines prior to Git staging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->