### PR TITLE
fix(item-orchestrator): close silent-workaround loophole when Edit/Write is denied (#228)

### DIFF
--- a/.claude/agents/item-orchestrator.md
+++ b/.claude/agents/item-orchestrator.md
@@ -23,3 +23,11 @@ That document is the single source of truth for this supporting role. Key respon
   `<worktree-path>/` is a main-repo path — correct it before calling the tool. Include
   the literal resolved `<worktree-path>` value in every stage-agent handoff so each
   dispatched agent can validate its own paths independently.
+
+**Permission-denial protocol (subagent runs only)**: If the `Edit` or `Write` tool is denied for **any path** — including `.claude/agents/**`, `.cursor/agents/**`, or any other file — the subagent MUST immediately stop all further work and return:
+
+```
+SUBAGENT_PERMISSION_DENIAL: [tool] tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.
+```
+
+Using `Bash`, Python subprocess, `gh api --method PUT`, or any other alternative mechanism to write the same file is **explicitly prohibited**. Silent workarounds bypass hook validation, break the orchestrator's fallback tracking, and violate the protocol contract. The denied path(s) must be listed so the orchestrator can resolve the permission gap before retrying. See Protocol 91 Step 3 for the complete permission-denial contract.

--- a/.claude/agents/item-orchestrator.md
+++ b/.claude/agents/item-orchestrator.md
@@ -27,7 +27,7 @@ That document is the single source of truth for this supporting role. Key respon
 **Permission-denial protocol (subagent runs only)**: If the `Edit` or `Write` tool is denied for **any path** — including `.claude/agents/**`, `.cursor/agents/**`, or any other file — the subagent MUST immediately stop all further work and return:
 
 ```
-SUBAGENT_PERMISSION_DENIAL: [tool] tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.
+SUBAGENT_PERMISSION_DENIAL: [tool] tool denied on <denied-target>. No partial work committed. Falling back to orchestrator inline execution.
 ```
 
-Using `Bash`, Python subprocess, `gh api --method PUT`, or any other alternative mechanism to write the same file is **explicitly prohibited**. Silent workarounds bypass hook validation, break the orchestrator's fallback tracking, and violate the protocol contract. The denied path(s) must be listed so the orchestrator can resolve the permission gap before retrying. See Protocol 91 Step 3 for the complete permission-denial contract.
+Using `Bash`, Python subprocess, `gh api --method PUT`, or any other alternative mechanism to write the same file is **explicitly prohibited**. Silent workarounds bypass hook validation, break the orchestrator's fallback tracking, and violate the protocol contract. The denied target (file path for Edit/Write; command pattern for Bash) must be listed in `<denied-target>` so the orchestrator can resolve the permission gap before retrying. See Protocol 91 Step 3 for the complete permission-denial contract and `<denied-target>` encoding rules.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,10 @@
       "Bash(git stash:*)",
       "Bash(git status:*)",
       "Bash(pnpm:*)",
+      "Edit(.claude/agents/**)",
+      "Write(.claude/agents/**)",
+      "Edit(.cursor/agents/**)",
+      "Write(.cursor/agents/**)",
       "WebFetch(domain:github.com)"
     ]
   }

--- a/.cursor/agents/item-orchestrator.md
+++ b/.cursor/agents/item-orchestrator.md
@@ -22,3 +22,11 @@ That document is the single source of truth for this supporting role. Key respon
   `<worktree-path>/` is a main-repo path — correct it before calling the tool. Include
   the literal resolved `<worktree-path>` value in every stage-agent handoff so each
   dispatched agent can validate its own paths independently.
+
+**Permission-denial protocol (subagent runs only)**: If the `Edit` or `Write` tool is denied for **any path** — including `.claude/agents/**`, `.cursor/agents/**`, or any other file — the subagent MUST immediately stop all further work and return:
+
+```
+SUBAGENT_PERMISSION_DENIAL: [tool] tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.
+```
+
+Using `Bash`, Python subprocess, `gh api --method PUT`, or any other alternative mechanism to write the same file is **explicitly prohibited**. Silent workarounds bypass hook validation, break the orchestrator's fallback tracking, and violate the protocol contract. The denied path(s) must be listed so the orchestrator can resolve the permission gap before retrying. See Protocol 91 Step 3 for the complete permission-denial contract.

--- a/.cursor/agents/item-orchestrator.md
+++ b/.cursor/agents/item-orchestrator.md
@@ -26,7 +26,7 @@ That document is the single source of truth for this supporting role. Key respon
 **Permission-denial protocol (subagent runs only)**: If the `Edit` or `Write` tool is denied for **any path** — including `.claude/agents/**`, `.cursor/agents/**`, or any other file — the subagent MUST immediately stop all further work and return:
 
 ```
-SUBAGENT_PERMISSION_DENIAL: [tool] tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.
+SUBAGENT_PERMISSION_DENIAL: [tool] tool denied on <denied-target>. No partial work committed. Falling back to orchestrator inline execution.
 ```
 
-Using `Bash`, Python subprocess, `gh api --method PUT`, or any other alternative mechanism to write the same file is **explicitly prohibited**. Silent workarounds bypass hook validation, break the orchestrator's fallback tracking, and violate the protocol contract. The denied path(s) must be listed so the orchestrator can resolve the permission gap before retrying. See Protocol 91 Step 3 for the complete permission-denial contract.
+Using `Bash`, Python subprocess, `gh api --method PUT`, or any other alternative mechanism to write the same file is **explicitly prohibited**. Silent workarounds bypass hook validation, break the orchestrator's fallback tracking, and violate the protocol contract. The denied target (file path for Edit/Write; command pattern for Bash) must be listed in `<denied-target>` so the orchestrator can resolve the permission gap before retrying. See Protocol 91 Step 3 for the complete permission-denial contract and `<denied-target>` encoding rules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **CodeRabbit completion via issue comments** (`pr-review-loop.sh`): when CodeRabbit posts only an issue-thread summary (no `pulls/{id}/reviews` entry) for the current HEAD, the poll loop now proceeds to Phase 3 instead of spinning until `timeout` and returning a false `escalate`.
 
+- **Silent workaround loophole in item-orchestrator permission-denial contract** (#228): when `Edit`/`Write` is denied on `.claude/agents/**` or any other path, subagents were silently falling back to Bash redirects, Python subprocess writes, or `gh api --method PUT` instead of returning `SUBAGENT_PERMISSION_DENIAL`. Protocol 91 Step 3 now explicitly prohibits all alternative write mechanisms and requires the denied path(s) to be listed in the exit string; `.claude/agents/item-orchestrator.md` and `.cursor/agents/item-orchestrator.md` add a matching enforcement note; `.claude/settings.json` adds `Edit(.claude/agents/**)`, `Write(.claude/agents/**)`, `Edit(.cursor/agents/**)`, and `Write(.cursor/agents/**)` allow-list entries to close the root-cause permission gap that triggered the workarounds.
+
 ## [0.22.0] - 2026-04-20
 
 ### Added

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -322,7 +322,7 @@ After removing the worktree, verify that the CWD is still valid by running a sim
 
 **When not in a parallel batch**: Worktree creation is optional but recommended for large development folders or long-running work. If not using a dedicated worktree, ensure the working directory is clean before proceeding.
 
-**Permission-denial early exit (subagent runs only)**: If at any point during the run the harness responds with the known harness failure pattern — a message containing the phrase `"Permission to use"` AND a denied tool name (`Edit` or `Bash`) — the subagent must **immediately stop all further work** and return the following structured string to the Portfolio Orchestrator:
+**Permission-denial early exit (subagent runs only)**: If at any point during the run the harness responds with the known harness failure pattern — a message containing the phrase `"Permission to use"` AND a denied tool name (`Edit`, `Write`, or `Bash`) — the subagent must **immediately stop all further work** and return the following structured string to the Portfolio Orchestrator:
 
 ```
 SUBAGENT_PERMISSION_DENIAL: [tool] tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.
@@ -383,7 +383,7 @@ Before calling any creator-stage agent or making any file edits, perform a light
 If either tool call is denied (harness responds with a permission-denied message), exit immediately before any creator-stage work:
 
 ```
-SUBAGENT_PERMISSION_DENIAL: [DENIED_TOOL] tool denied by harness. No partial work committed. Falling back to orchestrator inline execution.
+SUBAGENT_PERMISSION_DENIAL: [DENIED_TOOL] tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.
 ```
 
 **Self-check rules**:

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -325,10 +325,15 @@ After removing the worktree, verify that the CWD is still valid by running a sim
 **Permission-denial early exit (subagent runs only)**: If at any point during the run the harness responds with the known harness failure pattern — a message containing the phrase `"Permission to use"` AND a denied tool name (`Edit`, `Write`, or `Bash`) — the subagent must **immediately stop all further work** and return the following structured string to the Portfolio Orchestrator:
 
 ```
-SUBAGENT_PERMISSION_DENIAL: [tool] tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.
+SUBAGENT_PERMISSION_DENIAL: [tool] tool denied on <denied-target>. No partial work committed. Falling back to orchestrator inline execution.
 ```
 
-The `<denied-path>` field must list every path for which permission was denied. This is mandatory so the orchestrator can identify and resolve the permission gap before retrying. Use a comma-separated list of absolute, normalized paths, sorted lexicographically, with no duplicates and no surrounding spaces (e.g., `.claude/agents/developer.md,.cursor/agents/developer.md`). When only one path was denied, write it without a trailing comma.
+The `<denied-target>` field identifies what was denied and must be populated as follows:
+
+- **`Edit` or `Write` denial**: list every denied file path as a comma-separated list of repo-relative, normalized paths, sorted lexicographically, with no duplicates and no surrounding spaces (e.g., `.claude/agents/developer.md,.cursor/agents/developer.md`). When only one path was denied, write it without a trailing comma.
+- **`Bash` denial**: use the denied command pattern as reported by the harness (e.g., `Bash(gh api:*)`). There is no file path to report for a Bash denial.
+
+This field is mandatory in all cases so the orchestrator can identify and resolve the permission gap before retrying.
 
 **No silent workarounds — this is an absolute rule**: When `Edit` or `Write` is denied for any path (including `.claude/agents/**`, `.cursor/agents/**`, or any other file), the subagent MUST NOT use any alternative mechanism to write the same content. The following substitutions are all explicitly prohibited:
 
@@ -383,7 +388,7 @@ Before calling any creator-stage agent or making any file edits, perform a light
 If either tool call is denied (harness responds with a permission-denied message), exit immediately before any creator-stage work:
 
 ```
-SUBAGENT_PERMISSION_DENIAL: [DENIED_TOOL] tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.
+SUBAGENT_PERMISSION_DENIAL: [DENIED_TOOL] tool denied on <denied-target>. No partial work committed. Falling back to orchestrator inline execution.
 ```
 
 **Self-check rules**:

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -328,7 +328,7 @@ After removing the worktree, verify that the CWD is still valid by running a sim
 SUBAGENT_PERMISSION_DENIAL: [tool] tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.
 ```
 
-The `<denied-path>` field must list every path for which permission was denied. This is mandatory so the orchestrator can identify and resolve the permission gap before retrying.
+The `<denied-path>` field must list every path for which permission was denied. This is mandatory so the orchestrator can identify and resolve the permission gap before retrying. Use a comma-separated list of absolute, normalized paths, sorted lexicographically, with no duplicates and no surrounding spaces (e.g., `.claude/agents/developer.md,.cursor/agents/developer.md`). When only one path was denied, write it without a trailing comma.
 
 **No silent workarounds — this is an absolute rule**: When `Edit` or `Write` is denied for any path (including `.claude/agents/**`, `.cursor/agents/**`, or any other file), the subagent MUST NOT use any alternative mechanism to write the same content. The following substitutions are all explicitly prohibited:
 

--- a/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -325,8 +325,19 @@ After removing the worktree, verify that the CWD is still valid by running a sim
 **Permission-denial early exit (subagent runs only)**: If at any point during the run the harness responds with the known harness failure pattern — a message containing the phrase `"Permission to use"` AND a denied tool name (`Edit` or `Bash`) — the subagent must **immediately stop all further work** and return the following structured string to the Portfolio Orchestrator:
 
 ```
-SUBAGENT_PERMISSION_DENIAL: [tool] tool denied by harness. No partial work committed. Falling back to orchestrator inline execution.
+SUBAGENT_PERMISSION_DENIAL: [tool] tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.
 ```
+
+The `<denied-path>` field must list every path for which permission was denied. This is mandatory so the orchestrator can identify and resolve the permission gap before retrying.
+
+**No silent workarounds — this is an absolute rule**: When `Edit` or `Write` is denied for any path (including `.claude/agents/**`, `.cursor/agents/**`, or any other file), the subagent MUST NOT use any alternative mechanism to write the same content. The following substitutions are all explicitly prohibited:
+
+- `Bash` with `echo`, `cat`, `tee`, `printf`, `>`, or any shell redirection
+- Python subprocess (`python3 -c "open(...).write(...)"` or equivalent)
+- `gh api --method PUT /repos/.../contents/...` (GitHub Contents API)
+- Any other indirect write path
+
+**Rationale**: These side-channel writes bypass the canonical `Edit`/`Write` tool pipeline, which means any pre-tool-use hooks (e.g., path validation, write tracking) do not fire. They also make it impossible for the Portfolio Orchestrator to detect that a permission gap exists and perform the correct inline fallback. Silent degradation to a workaround tool is a protocol violation that erodes the orchestrator's ability to track item state reliably.
 
 Before exiting:
 - Do **not** apply any PR labels.

--- a/docs/testing/workflow/subagent-permission-denial.smoke-test.md
+++ b/docs/testing/workflow/subagent-permission-denial.smoke-test.md
@@ -23,7 +23,7 @@ Before running this smoke test:
 | Item | Value |
 |---|---|
 | Simulated denied tools | `Edit`, `Write`, `Bash` |
-| Structured exit string | `SUBAGENT_PERMISSION_DENIAL: Edit tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.` |
+| Structured exit string | `SUBAGENT_PERMISSION_DENIAL: Edit tool denied on <denied-target>. No partial work committed. Falling back to orchestrator inline execution.` |
 | Test item | Any single Spec Ready or Plan Ready item in the tracker |
 
 ---
@@ -48,7 +48,7 @@ Before running this smoke test:
 
 1. Configure a test subagent to return the following output and exit:
    ```
-   SUBAGENT_PERMISSION_DENIAL: Edit tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.
+   SUBAGENT_PERMISSION_DENIAL: Edit tool denied on <denied-target>. No partial work committed. Falling back to orchestrator inline execution.
    ```
 2. Run a batch orchestration session with one eligible item and the mock subagent.
 3. Observe the Portfolio Orchestrator's response after the subagent returns.
@@ -66,7 +66,7 @@ Before running this smoke test:
 
 **Maps to**: AC6
 
-1. Configure a test subagent to return `SUBAGENT_PERMISSION_DENIAL: Edit tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.`.
+1. Configure a test subagent to return `SUBAGENT_PERMISSION_DENIAL: Edit tool denied on <denied-target>. No partial work committed. Falling back to orchestrator inline execution.`.
 2. Configure the main-session inline execution to also encounter an `Edit` permission denial.
 3. Run the batch.
 
@@ -87,7 +87,7 @@ Before running this smoke test:
 3. Allow the pre-flight self-check to run.
 
 **Expected results**:
-- The subagent exits immediately with: `SUBAGENT_PERMISSION_DENIAL: Edit tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.`
+- The subagent exits immediately with: `SUBAGENT_PERMISSION_DENIAL: Edit tool denied on <denied-target>. No partial work committed. Falling back to orchestrator inline execution.`
 - No creator-stage file (spec, plan, feature code) has been written or committed.
 - No tracked files are modified (verify with `git status --porcelain` — clean).
 - The `.tmp/` self-check file (if created) is cleaned up.

--- a/docs/testing/workflow/subagent-permission-denial.smoke-test.md
+++ b/docs/testing/workflow/subagent-permission-denial.smoke-test.md
@@ -22,8 +22,8 @@ Before running this smoke test:
 
 | Item | Value |
 |---|---|
-| Simulated denied tools | `Edit`, `Bash` |
-| Structured exit string | `SUBAGENT_PERMISSION_DENIAL: Edit tool denied by harness. No partial work committed. Falling back to orchestrator inline execution.` |
+| Simulated denied tools | `Edit`, `Write`, `Bash` |
+| Structured exit string | `SUBAGENT_PERMISSION_DENIAL: Edit tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.` |
 | Test item | Any single Spec Ready or Plan Ready item in the tracker |
 
 ---
@@ -48,7 +48,7 @@ Before running this smoke test:
 
 1. Configure a test subagent to return the following output and exit:
    ```
-   SUBAGENT_PERMISSION_DENIAL: Edit tool denied by harness. No partial work committed. Falling back to orchestrator inline execution.
+   SUBAGENT_PERMISSION_DENIAL: Edit tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.
    ```
 2. Run a batch orchestration session with one eligible item and the mock subagent.
 3. Observe the Portfolio Orchestrator's response after the subagent returns.
@@ -87,7 +87,7 @@ Before running this smoke test:
 3. Allow the pre-flight self-check to run.
 
 **Expected results**:
-- The subagent exits immediately with: `SUBAGENT_PERMISSION_DENIAL: Edit tool denied by harness. No partial work committed. Falling back to orchestrator inline execution.`
+- The subagent exits immediately with: `SUBAGENT_PERMISSION_DENIAL: Edit tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.`
 - No creator-stage file (spec, plan, feature code) has been written or committed.
 - No tracked files are modified (verify with `git status --porcelain` — clean).
 - The `.tmp/` self-check file (if created) is cleaned up.

--- a/docs/testing/workflow/subagent-permission-denial.smoke-test.md
+++ b/docs/testing/workflow/subagent-permission-denial.smoke-test.md
@@ -66,7 +66,7 @@ Before running this smoke test:
 
 **Maps to**: AC6
 
-1. Configure a test subagent to return `SUBAGENT_PERMISSION_DENIAL: Edit tool denied`.
+1. Configure a test subagent to return `SUBAGENT_PERMISSION_DENIAL: Edit tool denied on path <denied-path>. No partial work committed. Falling back to orchestrator inline execution.`.
 2. Configure the main-session inline execution to also encounter an `Edit` permission denial.
 3. Run the batch.
 


### PR DESCRIPTION
## Summary

Closes #228.

Three batch-13 incidents showed subagents silently falling back to Bash shell redirects, Python subprocess writes, or `gh api --method PUT` when `Edit`/`Write` was denied on `.claude/agents/**`. These side-channel writes bypass hook validation and break the Portfolio Orchestrator's fallback tracking because the orchestrator never learns a permission gap existed.

**Changes:**

- **Protocol 91 Step 3** (`docs/ai/development-workflow/protocols/91-orchestrate-work-protocol.md`): the permission-denial early-exit block now explicitly prohibits Bash, Python subprocess, `gh api --method PUT`, and any other alternative write mechanism on a denied path. The exit string format now requires the denied path(s) to be listed.
- **`.claude/agents/item-orchestrator.md`** and **`.cursor/agents/item-orchestrator.md`**: add an enforcement note repeating the no-workaround rule directly in the agent instructions, so the rule is visible to any runner loading the agent file.
- **`.claude/settings.json`**: add `Edit(.claude/agents/**)`, `Write(.claude/agents/**)`, `Edit(.cursor/agents/**)`, and `Write(.cursor/agents/**)` allow-list entries to close the root-cause permission gap that drove the workarounds in #178 and #192.

## Test plan

- [ ] Verify `.claude/settings.json` allow-list now includes Write/Edit entries for `.claude/agents/**` and `.cursor/agents/**`
- [ ] Verify Protocol 91 Step 3 contains explicit prohibition of Bash/Python/gh-api as alternative write tools, with required denied-path listing
- [ ] Verify both `item-orchestrator.md` files contain the enforcement note
- [ ] Verify CHANGELOG entry under `[Unreleased] ### Fixed` is present and follows the `**Bold Title** (#N):` format
- [ ] Verify no trailing whitespace or missing trailing newline in any modified file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended agent permissions to allow managed agent configuration directories to be edited and written by orchestration flows.

* **Documentation**
  * Clarified permission-denial contract: subagents must immediately stop and return a structured denial message listing denied paths; alternative write workarounds are explicitly prohibited and orchestrator retry handling requires the denied paths to be reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->