### PR TITLE
docs(plan): sync-template reliability (#252)

### DIFF
--- a/docs/specs/developments/20260422154017_252-sync-template-reliability/2_252-sync-template-reliability_implementation-plan.md
+++ b/docs/specs/developments/20260422154017_252-sync-template-reliability/2_252-sync-template-reliability_implementation-plan.md
@@ -26,7 +26,7 @@
 | Codex sync skill present? | `find .codex/skills -name "*sync*"` | empty — no existing Codex sync skill |
 | Inline always-sync list exists? | `grep -c "Always sync" .claude/commands/sync-template.md` | 1 (confirmed: hard-coded list in all three artefacts) |
 | docs/testing/workflow/ existing runbooks | `ls docs/testing/workflow/` | 24 files — naming pattern confirmed as `<issue-id>-<slug>.smoke-test.md` |
-| AGENTS.md sync-related mention | `grep -n "sync" AGENTS.md` | Line referencing `/sync-template` command and `workflow-sync-template` skill |
+| AGENTS.md sync-related mention | `grep -n "sync" AGENTS.md` | Line 92: `/sync-template` command in Maintenance Commands table; Codex column is `—` (skill to be added by this plan) |
 
 ---
 
@@ -171,8 +171,7 @@ This feature affects documentation-format artefacts (Markdown, YAML). There is n
 
 ## Documentation Updates
 
-- [ ] `AGENTS.md` — Add `workflow-sync-template` to the Workflow Commands table (Codex column for "Sync framework updates from template") after implementation.
-- [ ] `docs/workflow/development-workflow/README.md` — Verify the sync-template row in the Maintenance Commands table references the new Codex skill `workflow-sync-template`.
+- [ ] `AGENTS.md` — Two updates after implementation: (1) Add `workflow-sync-template` to the Codex column of the Maintenance Commands table row for "Sync framework updates from template" (currently `—`); (2) if the Workflow Commands table also has a sync-template entry for Codex, update that column as well.
 
 ---
 

--- a/docs/specs/developments/20260422154017_252-sync-template-reliability/2_252-sync-template-reliability_implementation-plan.md
+++ b/docs/specs/developments/20260422154017_252-sync-template-reliability/2_252-sync-template-reliability_implementation-plan.md
@@ -100,11 +100,11 @@
   ```
   The manifest is the single authoritative source of truth per BR-1. It must be human-readable per AC-7 and BR-5.
 
-- [ ] Define the HTML-comment annotation scheme for mixed-content files. Two marker styles:
-  - Block: `<!-- TEMPLATE-OWNED-START: <label> -->` ... `<!-- TEMPLATE-OWNED-END: <label> -->`
-  - Inline: `<!-- TEMPLATE-OWNED -->` (single-line sections)
+- [ ] Define the HTML-comment annotation scheme for mixed-content files. Canonical marker format (unlabeled — same syntax used in all references throughout this plan):
+  - Block: `<!-- TEMPLATE-OWNED-START -->` ... `<!-- TEMPLATE-OWNED-END -->`
+  - Inline: `<!-- TEMPLATE-OWNED -->` (single-line sections where a block is not needed)
 
-  These markers work in all three AI tools (Claude Code, Cursor, Codex) because they parse Markdown and YAML files as text, and HTML comments are valid in both. Human readable in editors and GitHub diff view (AC-7, BR-5).
+  These markers work in all three AI tools (Claude Code, Cursor, Codex) because they parse Markdown and YAML files as text, and HTML comments are valid in both. Human-readable in editors and GitHub diff view (AC-7, BR-5).
 
 - [ ] Add `<!-- TEMPLATE-OWNED-START -->` / `<!-- TEMPLATE-OWNED-END -->` markers to the workflow table section of `AGENTS.md`. The table between the `## Development Workflow` heading and the `### Codex Skills` heading is template-owned. Project fills in the `## Project Overview` and `## Repository Structure` sections.
 

--- a/docs/specs/developments/20260422154017_252-sync-template-reliability/2_252-sync-template-reliability_implementation-plan.md
+++ b/docs/specs/developments/20260422154017_252-sync-template-reliability/2_252-sync-template-reliability_implementation-plan.md
@@ -195,7 +195,7 @@ This feature affects documentation-format artefacts (Markdown, YAML). There is n
 5. Update `.claude/skills/sync-template.md` with the same changes as step 4 (skills mirror commands).
 6. Update `.cursor/commands/sync-template.md` with the same changes as step 4.
 7. Create `.codex/skills/workflow-sync-template/SKILL.md` thin wrapper.
-8. Update project docs per **Documentation Updates** section above (`AGENTS.md` Workflow Commands table, `docs/workflow/development-workflow/README.md` Maintenance Commands table).
+8. Update project docs per **Documentation Updates** section above: update `AGENTS.md` Maintenance Commands table — add `workflow-sync-template` to the Codex column of the "Sync framework updates from template" row.
 9. Verify smoke test runbook (`docs/testing/workflow/252-sync-template-reliability.smoke-test.md`).
 10. Update `CHANGELOG.md` under `[Unreleased]`:
     ```

--- a/docs/specs/developments/20260422154017_252-sync-template-reliability/2_252-sync-template-reliability_implementation-plan.md
+++ b/docs/specs/developments/20260422154017_252-sync-template-reliability/2_252-sync-template-reliability_implementation-plan.md
@@ -1,0 +1,204 @@
+# Sync-Template Reliability — Implementation Plan
+
+**Spec**: `docs/specs/developments/20260422154017_252-sync-template-reliability/1_252-sync-template-reliability_specs.md`
+**Smoke test runbook**: `docs/testing/workflow/252-sync-template-reliability.smoke-test.md`
+
+---
+
+## Summary
+
+**Approach**: Introduce a YAML manifest file (`sync-manifest.yaml`) at the repository root that declares every framework-managed file and its sync category (always-sync, special-handling, project-specific). Update all three sync-template artefacts (`.claude/commands/sync-template.md`, `.claude/skills/sync-template.md`, `.cursor/commands/sync-template.md`) to read and consume the manifest at runtime instead of relying on the inline hard-coded file list. For mixed-content files, define a comment-based annotation scheme (`<!-- TEMPLATE-OWNED-START -->` / `<!-- TEMPLATE-OWNED-END -->`) and document it in the manifest entry so both artefacts are kept in sync. Add a Codex skill (`workflow-sync-template`) thin-wrapper that delegates to the same manifest-driven procedure.
+
+**Estimated complexity**: M
+
+**Rationale**: The changes are confined to documentation-format files (`.md`, `.yaml`) and one new YAML manifest. No compiled code, no migrations, no service dependencies. The manifest schema and annotation markers are straightforward. Verification against all three sync artefacts and the Codex skill adds breadth but no new complexity per file. Two to three days of focused work covers manifest design, artefact updates, smoke-test authoring, and CHANGELOG.
+
+**Dependencies**: #251 (rename docs/ai to docs/workflow) — merged per spec.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+|---|---|---|
+| Repo revision | `git rev-parse --short HEAD` | `284b8b4` |
+| Sync artefact locations | `find . -path "./.claude/worktrees" -prune -o -name "sync-template.md" -print` | `./.claude/commands/sync-template.md`, `./.claude/skills/sync-template.md`, `./.cursor/commands/sync-template.md` |
+| Codex sync skill present? | `find .codex/skills -name "*sync*"` | empty — no existing Codex sync skill |
+| Inline always-sync list exists? | `grep -c "Always sync" .claude/commands/sync-template.md` | 1 (confirmed: hard-coded list in all three artefacts) |
+| docs/testing/workflow/ existing runbooks | `ls docs/testing/workflow/` | 24 files — naming pattern confirmed as `<issue-id>-<slug>.smoke-test.md` |
+| AGENTS.md sync-related mention | `grep -n "sync" AGENTS.md` | Line referencing `/sync-template` command and `workflow-sync-template` skill |
+
+---
+
+## Layer-by-Layer Changes
+
+### Infrastructure / Configuration
+
+- [ ] Create `sync-manifest.yaml` at the repository root. Schema:
+  ```yaml
+  # Illustrative — adapt during implementation
+  schema_version: 1
+  categories:
+    always_sync:
+      - path: REVIEW.md
+        note: canonical review contract
+      - path: docs/workflow/
+        glob: "**/*"
+        note: full workflow tree
+      - path: .claude/agents/
+        glob: "*.md"
+      - path: .claude/commands/
+        glob: "*.md"
+      - path: .claude/skills/
+        glob: "*.md"
+      - path: .codex/skills/
+        glob: "**/*"
+      - path: .cursor/commands/
+        glob: "*.md"
+      - path: .cursor/agents/
+        glob: "*.md"
+      - path: .cursor/rules/
+        glob: "*.mdc"
+      - path: scripts/development-workflow/
+        glob: "**/*"
+      - path: scripts/README.md
+      - path: docs/best-practices/1-general.md
+      - path: docs/best-practices/2-version-control.md
+      - path: docs/best-practices/3-testing.md
+    special_handling:
+      - path: .claude/settings.json
+        note: may have project-specific permissions
+      - path: .claude/settings.local.json.example
+      - path: .github/workflows/auto-tag-release.yml
+        note: automated release tagging
+      - path: .github/workflows/deploy.yml
+        note: placeholder deployment workflow
+      - path: .github/workflows/e2e-regression.yml
+        note: label-gated e2e/regression placeholder
+      - path: e2e/
+        glob: "**/*"
+        note: placeholder e2e test project
+    project_specific:
+      - path: AGENTS.md
+        mixed_content: true
+        annotation_scheme: html_comments
+        note: workflow table is template-owned; project fills TODO sections
+      - path: README.md
+      - path: CHANGELOG.md
+      - path: .ai-dev-workflow.yaml
+        mixed_content: true
+        annotation_scheme: html_comments
+        note: schema description is template-owned; provider selections are project-owned
+      - path: docs/project/
+        glob: "**/*"
+      - path: docs/best-practices/STACK-SPECIFIC.md
+      - path: docs/best-practices/stack/
+        glob: "**/*"
+      - path: .gitignore
+      - path: CLAUDE.md
+      - path: GEMINI.md
+  ```
+  The manifest is the single authoritative source of truth per BR-1. It must be human-readable per AC-7 and BR-5.
+
+- [ ] Define the HTML-comment annotation scheme for mixed-content files. Two marker styles:
+  - Block: `<!-- TEMPLATE-OWNED-START: <label> -->` ... `<!-- TEMPLATE-OWNED-END: <label> -->`
+  - Inline: `<!-- TEMPLATE-OWNED -->` (single-line sections)
+
+  These markers work in all three AI tools (Claude Code, Cursor, Codex) because they parse Markdown and YAML files as text, and HTML comments are valid in both. Human readable in editors and GitHub diff view (AC-7, BR-5).
+
+- [ ] Add `<!-- TEMPLATE-OWNED-START -->` / `<!-- TEMPLATE-OWNED-END -->` markers to the workflow table section of `AGENTS.md`. The table between the `## Development Workflow` heading and the `### Codex Skills` heading is template-owned. Project fills in the `## Project Overview` and `## Repository Structure` sections.
+
+- [ ] Add similar markers around the `review:` / `issue_tracker:` / `vcs:` / `browser_automation:` schema documentation block in `.ai-dev-workflow.yaml` (comment block at the top of each section heading). Note: the `platforms:` and `providers:` values under each section are project-specific.
+
+### Shared Packages / Libraries (Sync Artefacts)
+
+All three sync-template artefacts must be updated to consume `sync-manifest.yaml`. Changes are parallel across all three files.
+
+**`.claude/commands/sync-template.md`**:
+
+- [ ] **Step 0**: After resolving the template source, also check for `sync-manifest.yaml` at the template root. If found, read it and store as `SYNC_MANIFEST`. If absent, set `SYNC_MANIFEST=absent` (graceful fallback per BR-4 / AC-4).
+- [ ] **Step 2 — Always sync**: Replace the hard-coded path list with: "If `SYNC_MANIFEST` is loaded, read `categories.always_sync` from the manifest and enumerate those paths from the template. If `SYNC_MANIFEST=absent`, fall back to the embedded list below and display the warning: `Warning: sync manifest not found in upstream template. Using embedded file list — results may be incomplete.`" Keep the embedded list as the fallback.
+- [ ] **Step 2 — Special handling**: Same pattern — read `categories.special_handling` from manifest when available, fall back to embedded list.
+- [ ] **Step 2 — Project-specific**: Same pattern — read `categories.project_specific` from manifest. For entries with `mixed_content: true`, additionally read the `annotation_scheme` field and apply the mixed-content extraction logic described below.
+- [ ] **Mixed-content extraction logic** (new subsection in Step 2): When a file has `mixed_content: true` and `annotation_scheme: html_comments`, extract only the template-owned sections (delimited by `<!-- TEMPLATE-OWNED-START -->` / `<!-- TEMPLATE-OWNED-END -->`) when comparing to the upstream. Show only those sections in the diff. Label unextracted sections as "preserved — no change" (UX Rule 2). If markers are absent or malformed in the downstream copy, flag the file as "unstructured — full review required" (UX Rule 3).
+- [ ] **Step 3 — Summary format**: Update the summary to show file counts per category before asking for confirmation (UX Rule 1 / AC-5). Add a new section: "Files skipped (up-to-date): N" and "Files declined by maintainer: N" to satisfy AC-5 and UX Rule 4. The disposition of every always-sync file (updated, up-to-date, skipped by maintainer) must appear in the summary.
+- [ ] **Step 5 — Git instructions**: Update the `git add` staging instruction to reference `sync-manifest.yaml` in addition to the always-sync paths. Add a note: "If sync-manifest.yaml was updated, stage it as well."
+
+**`.claude/skills/sync-template.md`**:
+
+- [ ] Apply all the same changes as `.claude/commands/sync-template.md` above (skills and commands share the same protocol text; they must stay in sync).
+
+**`.cursor/commands/sync-template.md`**:
+
+- [ ] Apply all the same changes as `.claude/commands/sync-template.md` above.
+
+**New: `.codex/skills/workflow-sync-template/SKILL.md`**:
+
+- [ ] Create the directory `.codex/skills/workflow-sync-template/`.
+- [ ] Create `SKILL.md` as a thin wrapper that loads `.claude/commands/sync-template.md` and delegates to the same manifest-driven procedure. Follow the existing Codex skill pattern (see `.codex/skills/workflow-plan-writer/SKILL.md` for structure).
+- [ ] Register the skill in AGENTS.md under the Workflow Commands table row for `Sync framework updates`.
+
+---
+
+## Testing Strategy
+
+**Test types**: Smoke / Manual
+
+This feature affects documentation-format artefacts (Markdown, YAML). There is no executable code to unit-test. Verification is via manual smoke test against the sync command in a downstream repo or against a test project.
+
+**Key scenarios to test**:
+
+1. Full sync with manifest present — all always-sync files appear in summary with correct disposition (AC-1, AC-2, AC-5)
+2. Sync on two tools with same upstream → same always-sync file list (AC-2)
+3. Mixed-content file with annotation markers — only template-owned diff shown, project sections preserved (AC-3, Use Case 3)
+4. Manifest absent → warning shown, fallback to embedded list, command completes (AC-4, BR-4)
+5. New file added to manifest → "to be added" on next sync against downstream without that file (AC-6)
+6. Manifest file opens in editor/GitHub without special tooling (AC-7)
+
+**Smoke test runbook**: `docs/testing/workflow/252-sync-template-reliability.smoke-test.md`
+
+**Regression suite**: No automated regression suite exists in this repository. Smoke test runbook is the verification record.
+
+---
+
+## Seed Data
+
+| Entity | Values / Scenario | File |
+|---|---|---|
+| N/A | This feature has no runtime data dependencies | — |
+
+---
+
+## Documentation Updates
+
+- [ ] `AGENTS.md` — Add `workflow-sync-template` to the Workflow Commands table (Codex column for "Sync framework updates from template") after implementation.
+- [ ] `docs/workflow/development-workflow/README.md` — Verify the sync-template row in the Maintenance Commands table references the new Codex skill `workflow-sync-template`.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Manifest drift: developer adds a new template file but forgets to update `sync-manifest.yaml` | Med | Med | The spec explicitly notes this as a known limitation (Out of Scope: CI-enforced manifest completeness). Document in the manifest's header comment. |
+| HTML comment markers not preserved in some Markdown editors | Low | Low | Markers are valid HTML comments, invisible in rendered Markdown. All major editors preserve them verbatim. |
+| Three sync artefacts diverging from each other | Med | Med | Plan explicitly requires identical changes in all three files. Plan reviewer and code reviewer should cross-check. |
+| Codex skill referencing stale embedded list if manifest not present | Low | Low | The fallback logic in the skill is the same as in the command — only activates when manifest is absent. |
+
+---
+
+## Implementation Order
+
+1. Create `sync-manifest.yaml` at the repository root (full path list from the always-sync embedded lists; add mixed-content annotations for `AGENTS.md` and `.ai-dev-workflow.yaml`).
+2. Add `<!-- TEMPLATE-OWNED-START -->` / `<!-- TEMPLATE-OWNED-END -->` markers to the workflow table section in `AGENTS.md`.
+3. Add annotation markers to the schema description block in `.ai-dev-workflow.yaml` (comment blocks above `review:`, `issue_tracker:`, `vcs:`, `browser_automation:` section headings).
+4. Update `.claude/commands/sync-template.md` — Steps 0, 2, 3, and 5 as described in Layer-by-Layer Changes above.
+5. Update `.claude/skills/sync-template.md` with the same changes as step 4 (skills mirror commands).
+6. Update `.cursor/commands/sync-template.md` with the same changes as step 4.
+7. Create `.codex/skills/workflow-sync-template/SKILL.md` thin wrapper.
+8. Update project docs per **Documentation Updates** section above (`AGENTS.md` Workflow Commands table, `docs/workflow/development-workflow/README.md` Maintenance Commands table).
+9. Verify smoke test runbook (`docs/testing/workflow/252-sync-template-reliability.smoke-test.md`).
+10. Update `CHANGELOG.md` under `[Unreleased]`:
+    ```
+    - **Sync-template manifest-driven reliability** (#252): Introduce `sync-manifest.yaml` as the authoritative file list for sync-template; add HTML-comment annotation markers for mixed-content files; update all sync-template artefacts (Claude Code, Cursor, Codex) to consume the manifest; add graceful fallback when manifest is absent.
+    ```

--- a/docs/specs/developments/20260422154017_252-sync-template-reliability/2_252-sync-template-reliability_implementation-plan.md
+++ b/docs/specs/developments/20260422154017_252-sync-template-reliability/2_252-sync-template-reliability_implementation-plan.md
@@ -136,7 +136,7 @@ All three sync-template artefacts must be updated to consume `sync-manifest.yaml
 
 - [ ] Create the directory `.codex/skills/workflow-sync-template/`.
 - [ ] Create `SKILL.md` as a thin wrapper that loads `.claude/commands/sync-template.md` and delegates to the same manifest-driven procedure. Follow the existing Codex skill pattern (see `.codex/skills/workflow-plan-writer/SKILL.md` for structure).
-- [ ] Register the skill in AGENTS.md under the Workflow Commands table row for `Sync framework updates`.
+- [ ] Register the skill in AGENTS.md under the Maintenance Commands table row for `Sync framework updates from template` (update the Codex column from `—` to `workflow-sync-template`).
 
 ---
 

--- a/docs/specs/developments/20260422154017_252-sync-template-reliability/2_252-sync-template-reliability_implementation-plan.md
+++ b/docs/specs/developments/20260422154017_252-sync-template-reliability/2_252-sync-template-reliability_implementation-plan.md
@@ -100,15 +100,21 @@
   ```
   The manifest is the single authoritative source of truth per BR-1. It must be human-readable per AC-7 and BR-5.
 
-- [ ] Define the HTML-comment annotation scheme for mixed-content files. Canonical marker format (unlabeled — same syntax used in all references throughout this plan):
+- [ ] Define the annotation scheme for mixed-content files. Two canonical marker forms, chosen by file type:
+
+  **Markdown files** (e.g., `AGENTS.md`):
   - Block: `<!-- TEMPLATE-OWNED-START -->` ... `<!-- TEMPLATE-OWNED-END -->`
   - Inline: `<!-- TEMPLATE-OWNED -->` (single-line sections where a block is not needed)
 
-  These markers work in all three AI tools (Claude Code, Cursor, Codex) because they parse Markdown and YAML files as text, and HTML comments are valid in both. Human-readable in editors and GitHub diff view (AC-7, BR-5).
+  **YAML files** (e.g., `.ai-dev-workflow.yaml`): HTML comments are NOT valid YAML syntax and would cause parse errors. Markers must be wrapped in YAML comment syntax:
+  - Block: `# <!-- TEMPLATE-OWNED-START -->` ... `# <!-- TEMPLATE-OWNED-END -->`
+  - Inline: `# <!-- TEMPLATE-OWNED -->` (single-line)
+
+  Both forms are human-readable in editors and GitHub diff view (AC-7, BR-5). All three AI tools (Claude Code, Cursor, Codex) parse these files as text and will recognize either form when the extraction logic handles both.
 
 - [ ] Add `<!-- TEMPLATE-OWNED-START -->` / `<!-- TEMPLATE-OWNED-END -->` markers to the workflow table section of `AGENTS.md`. The table between the `## Development Workflow` heading and the `### Codex Skills` heading is template-owned. Project fills in the `## Project Overview` and `## Repository Structure` sections.
 
-- [ ] Add similar markers around the `review:` / `issue_tracker:` / `vcs:` / `browser_automation:` schema documentation block in `.ai-dev-workflow.yaml` (comment block at the top of each section heading). Note: the `platforms:` and `providers:` values under each section are project-specific.
+- [ ] Add YAML-comment markers (`# <!-- TEMPLATE-OWNED-START -->` / `# <!-- TEMPLATE-OWNED-END -->`) around the schema documentation block in `.ai-dev-workflow.yaml`. The comment block at the top of each section heading (`review:`, `issue_tracker:`, `vcs:`, `browser_automation:`) is template-owned. The `platforms:` and `providers:` values under each section are project-specific.
 
 ### Shared Packages / Libraries (Sync Artefacts)
 
@@ -120,7 +126,10 @@ All three sync-template artefacts must be updated to consume `sync-manifest.yaml
 - [ ] **Step 2 — Always sync**: Replace the hard-coded path list with: "If `SYNC_MANIFEST` is loaded, read `categories.always_sync` from the manifest and enumerate those paths from the template. If `SYNC_MANIFEST=absent`, fall back to the embedded list below and display the warning: `Warning: sync manifest not found in upstream template. Using embedded file list — results may be incomplete.`" Keep the embedded list as the fallback.
 - [ ] **Step 2 — Special handling**: Same pattern — read `categories.special_handling` from manifest when available, fall back to embedded list.
 - [ ] **Step 2 — Project-specific**: Same pattern — read `categories.project_specific` from manifest. For entries with `mixed_content: true`, additionally read the `annotation_scheme` field and apply the mixed-content extraction logic described below.
-- [ ] **Mixed-content extraction logic** (new subsection in Step 2): When a file has `mixed_content: true` and `annotation_scheme: html_comments`, extract only the template-owned sections (delimited by `<!-- TEMPLATE-OWNED-START -->` / `<!-- TEMPLATE-OWNED-END -->`) when comparing to the upstream. Show only those sections in the diff. Label unextracted sections as "preserved — no change" (UX Rule 2). If markers are absent or malformed in the downstream copy, flag the file as "unstructured — full review required" (UX Rule 3).
+- [ ] **Mixed-content extraction logic** (new subsection in Step 2): When a file has `mixed_content: true` and `annotation_scheme: html_comments`, extract only the template-owned sections when comparing to the upstream. Detection must handle both marker forms by file extension:
+  - For `.md` files: match bare `<!-- TEMPLATE-OWNED-START -->` / `<!-- TEMPLATE-OWNED-END -->` lines.
+  - For `.yaml` / `.yml` files: match `# <!-- TEMPLATE-OWNED-START -->` / `# <!-- TEMPLATE-OWNED-END -->` lines (YAML comment prefix required).
+  Show only the extracted sections in the diff. Label unextracted sections as "preserved — no change" (UX Rule 2). If markers are absent or malformed in the downstream copy, flag the file as "unstructured — full review required" (UX Rule 3).
 - [ ] **Step 3 — Summary format**: Update the summary to show file counts per category before asking for confirmation (UX Rule 1 / AC-5). Add a new section: "Files skipped (up-to-date): N" and "Files declined by maintainer: N" to satisfy AC-5 and UX Rule 4. The disposition of every always-sync file (updated, up-to-date, skipped by maintainer) must appear in the summary.
 - [ ] **Step 5 — Git instructions**: Update the `git add` staging instruction to reference `sync-manifest.yaml` in addition to the always-sync paths. Add a note: "If sync-manifest.yaml was updated, stage it as well."
 

--- a/docs/testing/workflow/252-sync-template-reliability.smoke-test.md
+++ b/docs/testing/workflow/252-sync-template-reliability.smoke-test.md
@@ -1,0 +1,203 @@
+# Smoke Test Runbook: Sync-Template Reliability (#252)
+
+**Feature**: Sync-Template Reliability — manifest-driven sync with mixed-content support
+**Spec**: `docs/specs/developments/20260422154017_252-sync-template-reliability/1_252-sync-template-reliability_specs.md`
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] You have a downstream test repository (can be a temporary clone of this template or a separate downstream project)
+- [ ] The upstream template has `sync-manifest.yaml` at its root (from this implementation)
+- [ ] You have at least two AI tools available to test AC-2 (e.g., Claude Code and Cursor)
+- [ ] The downstream test repo has an older version of at least one always-sync file (to verify AC-1)
+- [ ] The downstream test repo has `AGENTS.md` and `.ai-dev-workflow.yaml` with project-specific content already filled in (for Use Case 3 / AC-3 verification)
+
+---
+
+## Test Data
+
+| Item | Value |
+|---|---|
+| Upstream template path | local copy of `ai-dev-framework-template` (post-implementation) |
+| Downstream test repo | temporary clone with older always-sync files |
+| Mixed-content file | `AGENTS.md` with a filled-in `## Project Overview` section and the workflow table at the template version |
+| Mixed-content file 2 | `.ai-dev-workflow.yaml` with `provider: github` set (project-specific), schema comments from template |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify manifest exists and is human-readable (AC-7)
+
+1. Open `sync-manifest.yaml` at the root of the upstream template in a text editor (or view it on GitHub).
+2. Verify the file is valid YAML, readable without any special tooling, and lists files under `always_sync`, `special_handling`, and `project_specific` categories.
+
+**Expected result**: The manifest opens and is readable in a standard text editor. The categories and paths are clear. No binary content or encoded data.
+
+---
+
+### Step 2: Full sync with manifest present — always-sync coverage (AC-1, AC-5)
+
+**Maps to**: AC-1, AC-5, BR-1, BR-2, BR-7, Use Case 1
+
+1. In the downstream test repo (with at least one outdated always-sync file), invoke the sync-template command:
+   - Claude Code: `/sync-template --local=/path/to/upstream-template`
+   - Cursor: `/sync-template --local=/path/to/upstream-template`
+2. Before confirming any changes, read the sync summary.
+
+**Expected result**:
+- The summary shows a count of files per category (always-sync, special-handling, project-specific) before asking for confirmation.
+- Every always-sync file that differs from the upstream appears in the "will be updated" section — no always-sync file with a diff is silently absent.
+- The summary includes a disposition row for every always-sync manifest entry: "updated", "up-to-date", or "skipped by maintainer".
+
+---
+
+### Step 3: No silent skips after sync (AC-5, BR-7)
+
+**Maps to**: AC-5, BR-7
+
+1. After the sync run from Step 2 completes (whether or not changes were applied), inspect the final summary.
+
+**Expected result**:
+- The summary explicitly lists every always-sync file from the manifest and its disposition (updated, up-to-date, or skipped by maintainer).
+- The count of files in each disposition bucket is shown.
+- "Skipped because up-to-date" and "declined by maintainer" appear as separate counts (not merged into one bucket).
+
+---
+
+### Step 4: Cross-tool consistency (AC-2)
+
+**Maps to**: AC-2, BR-5
+
+1. Using the same upstream template and downstream repo state (before applying any changes), run the sync-template command in Claude Code and record the always-sync file list from the summary.
+2. Run the same command in Cursor and record the always-sync file list.
+3. Compare the two lists.
+
+**Expected result**: The always-sync file list is identical between both tools. No file appears in one tool's summary but not the other's.
+
+---
+
+### Step 5: Mixed-content file sync with annotation markers (AC-3, Use Case 3)
+
+**Maps to**: AC-3, BR-3, BR-6, UX Rule 2, Use Case 3
+
+1. In the downstream test repo, ensure `AGENTS.md` has:
+   - `## Project Overview` filled in with fake project content (project-owned)
+   - The workflow table section at an older template version (template-owned, differs from upstream)
+2. Run the sync-template command.
+3. When the `AGENTS.md` entry appears in the summary, inspect the diff shown.
+
+**Expected result**:
+- The diff shown for `AGENTS.md` is limited to the template-owned section (workflow table) only.
+- The `## Project Overview` section is labelled "preserved — no change" in the summary.
+- No project-specific content is shown in the diff or modified after applying the sync.
+
+---
+
+### Step 6: Mixed-content file with missing annotation markers (UX Rule 3)
+
+**Maps to**: BR-3, UX Rule 3
+
+1. In the downstream test repo, modify `AGENTS.md` to remove the `<!-- TEMPLATE-OWNED-START -->` and `<!-- TEMPLATE-OWNED-END -->` markers (simulating a downstream repo that hasn't added them yet).
+2. Run the sync-template command.
+3. Observe how `AGENTS.md` is handled in the summary.
+
+**Expected result**:
+- The file is flagged as "unstructured — full review required" in the summary.
+- The command does NOT attempt an automatic merge.
+- A full diff is shown instead.
+
+---
+
+### Step 7: Graceful fallback when manifest is absent (AC-4)
+
+**Maps to**: AC-4, BR-4
+
+1. Temporarily rename or remove `sync-manifest.yaml` from the upstream template source (or point `--local` to a directory without the manifest).
+2. Run the sync-template command.
+
+**Expected result**:
+- The command completes without an error (only a warning).
+- A visible warning message is shown: something indicating that the manifest was not found and the embedded file list is being used.
+- The sync still proceeds with the embedded file list.
+- The exit code is 0 (success with warning), not an error exit.
+
+---
+
+### Step 8: New file in manifest is detected (AC-6)
+
+**Maps to**: AC-6, BR-1, Use Case 2
+
+1. In the upstream template, add a new dummy file (e.g., `docs/workflow/test-new-file.md`) with the corresponding entry in `sync-manifest.yaml` under `always_sync`.
+2. In the downstream test repo (which does not have this file), run the sync-template command.
+
+**Expected result**:
+- The new file appears in the "will be added" section of the summary.
+- After approval, the file is added to the downstream repo.
+
+---
+
+### Step 9: Codex skill invocation (workflow-sync-template)
+
+**Maps to**: BR-5, AGENTS.md Workflow Commands table
+
+1. In a Codex-enabled environment, invoke the `workflow-sync-template` skill with the same `--local` argument.
+2. Verify the skill produces the same summary structure as the Claude Code command.
+
+**Expected result**:
+- The skill runs without error.
+- The sync summary structure and always-sync file list matches the Claude Code output.
+
+---
+
+### Last Step: Validate and clean up
+
+- Verify all assertions in the checklist below are met.
+- Remove any temporary files added for Step 8 testing.
+- Revert the `AGENTS.md` marker removal from Step 6.
+
+---
+
+## Assertions Checklist
+
+Each checkbox maps to an acceptance criterion from the spec.
+
+- [ ] AC-1: Every out-of-date always-sync file appears in the "will be updated" section — no silent omission.
+- [ ] AC-2: Running on Claude Code and Cursor with the same upstream produces identical always-sync file lists.
+- [ ] AC-3: Mixed-content file diff shows only the template-owned section; project-owned sections are labelled "preserved — no change".
+- [ ] AC-4: When the manifest is absent, the command completes with a warning and falls back to the embedded list.
+- [ ] AC-5: The sync summary explicitly shows the disposition of every always-sync manifest entry (updated / up-to-date / skipped by maintainer) with separate counts.
+- [ ] AC-6: A new always-sync file with a manifest entry is detected as "to be added" against a downstream that lacks it.
+- [ ] AC-7: `sync-manifest.yaml` is readable in a standard text editor or GitHub diff view without special tooling.
+
+---
+
+## Seed Data Reference
+
+| Entity | Scenario | How to load |
+|---|---|---|
+| Downstream test repo | Older always-sync files, `AGENTS.md` with project content | Manual: clone template at a prior commit and add project-specific content to `AGENTS.md` |
+| Upstream template | Post-implementation with `sync-manifest.yaml` and annotation markers | This repository after implementing #252 |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Manifest not found even though file exists | Wrong path passed to `--local` | Verify the path points to the upstream template root, not a subdirectory |
+| Mixed-content diff shows entire file | Annotation markers not added to upstream AGENTS.md | Re-run Step 2 of the implementation order to add markers |
+| Cross-tool list differs (AC-2 fails) | One sync artefact still has the old hard-coded list | Re-check that all three sync artefacts were updated in implementation step 4-6 |
+| Fallback warning not shown (AC-4) | Manifest fallback logic not implemented in the artefact under test | Verify implementation step 4 includes the graceful fallback branch |
+
+---
+
+## Known Limitations
+
+- AC-2 (cross-tool consistency) requires manual comparison of summaries from two separate tool invocations. No automated test for this.
+- Step 9 (Codex skill) requires a Codex-enabled environment; skip if unavailable and note the skip.

--- a/docs/testing/workflow/252-sync-template-reliability.smoke-test.md
+++ b/docs/testing/workflow/252-sync-template-reliability.smoke-test.md
@@ -46,8 +46,14 @@ Before running this smoke test:
 **Maps to**: AC-1, AC-5, BR-1, BR-2, BR-7, Use Case 1
 
 1. In the downstream test repo (with at least one outdated always-sync file), invoke the sync-template command:
-   - Claude Code: `/sync-template --local=/path/to/upstream-template`
-   - Cursor: `/sync-template --local=/path/to/upstream-template`
+   - Claude Code:
+     ```bash
+     /sync-template --local=/path/to/upstream-template
+     ```
+   - Cursor:
+     ```bash
+     /sync-template --local=/path/to/upstream-template
+     ```
 2. Before confirming any changes, read the sync summary.
 
 **Expected result**:
@@ -146,7 +152,10 @@ Before running this smoke test:
 
 **Maps to**: BR-5, AGENTS.md Workflow Commands table
 
-1. In a Codex-enabled environment, invoke the `workflow-sync-template` skill with the same `--local` argument.
+1. In a Codex-enabled environment, invoke the `workflow-sync-template` skill with the same `--local` argument:
+   ```bash
+   workflow-sync-template --local=/path/to/upstream-template
+   ```
 2. Verify the skill produces the same summary structure as the Claude Code command.
 
 **Expected result**:


### PR DESCRIPTION
## Summary

Implementation plan for [#252 — Review and improve sync-template reliability for downstream repos](https://github.com/lhpaul/ai-dev-framework-template/issues/252).

**Approach**: Introduce `sync-manifest.yaml` as the authoritative file list for all three sync-template artefacts (Claude Code command, Claude Code skill, Cursor command) plus a new Codex skill wrapper. Add HTML-comment annotation markers to mixed-content files (`AGENTS.md`, `.ai-dev-workflow.yaml`) so agents can extract only template-owned sections when diffing. Fall back gracefully to the embedded list when the manifest is absent.

**Estimated complexity**: M (2-3 days)

**Key risks**:
- Three sync artefacts must be kept in sync — plan review and code review should cross-check all three files.
- Manifest drift if a template author adds a file without updating `sync-manifest.yaml` — documented as a known limitation in the spec (Out of Scope: CI-enforced completeness).

## Artefacts

- Plan: `docs/specs/developments/20260422154017_252-sync-template-reliability/2_252-sync-template-reliability_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/252-sync-template-reliability.smoke-test.md`

## Dependencies

- #251 (rename docs/ai to docs/workflow) — merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an implementation plan describing a manifest-driven approach for managing sync-template file lists, template-owned annotation conventions for mixed-content files, expected sync/diff behaviors, rollout order, risks/mitigations, and a CHANGELOG entry.
  * Added a comprehensive smoke-test runbook and acceptance checklist to validate manifest handling, mixed-content cases, fallback behavior, cross-tool consistency, and detection of new manifest entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->