### PR TITLE
feat(sync-template): introduce manifest-driven reliability (#252)

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -1,3 +1,4 @@
+# <!-- TEMPLATE-OWNED-START -->
 # AI Development Workflow Configuration
 #
 # This file declares which workflow integrations this repository uses.
@@ -17,6 +18,7 @@
 # Behavior for automated PR review:
 # - If this file is absent, or review.platforms is omitted or empty, the review
 #   loop reports skipped (not configured).
+# <!-- TEMPLATE-OWNED-END -->
 
 schema_version: 1
 

--- a/.claude/commands/sync-template.md
+++ b/.claude/commands/sync-template.md
@@ -46,6 +46,11 @@ If `--ref` is not specified for a remote source, use the default branch (`main`)
 
 Once the template source is resolved, read its `CHANGELOG.md` and extract the latest version number (first `[X.Y.Z]` entry after `[Unreleased]` if present, otherwise the first versioned entry). Store it as `TEMPLATE_VERSION`.
 
+**Manifest check**: After resolving the template source, check for `sync-manifest.yaml` at the template root.
+
+- If found: read it and store its contents as `SYNC_MANIFEST`. The manifest is the authoritative file list (BR-1).
+- If absent: set `SYNC_MANIFEST=absent`. The graceful fallback (BR-4 / AC-4) activates in Step 2 — the embedded lists below are used and a warning is shown.
+
 ---
 
 ## Step 1 — Pre-flight checks on the current project
@@ -79,9 +84,15 @@ Run these checks **before touching anything**. If any check fails, report the pr
 
 ## Step 2 — Compare files
 
-Compare the following **framework-level paths** from the template against the current project.
+Use `SYNC_MANIFEST` to determine the file lists. If `SYNC_MANIFEST=absent`, fall back to the embedded lists in each section below and display this warning before continuing:
+
+> "Warning: sync manifest not found in upstream template. Using embedded file list — results may be incomplete."
 
 ### Always sync (apply automatically after approval)
+
+**If `SYNC_MANIFEST` is loaded**: read `categories.always_sync` from the manifest and enumerate those paths from the template. Each entry may specify a `path` (single file or directory prefix) and an optional `glob` pattern for recursive enumeration.
+
+**If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
 ```
 REVIEW.md                         <- canonical review contract for spec, plan, and code review gates
@@ -100,7 +111,7 @@ docs/best-practices/2-version-control.md
 docs/best-practices/3-testing.md
 ```
 
-**Comparison method:** For each directory in the list above, enumerate files with `find` (or equivalent) and compare each path to the template using `cmp` or `diff -q`. Do not rely on ad-hoc agent inspection alone for the always-sync trees — a missed directory is a silent sync gap.
+**Comparison method:** For each path in the always-sync list, enumerate files with `find` (or equivalent) and compare each path to the template using `cmp` or `diff -q`. Do not rely on ad-hoc agent inspection alone — a missed directory is a silent sync gap.
 
 For each file in these paths:
 - **Exists in template, not in project** → classify as **Add**
@@ -109,6 +120,10 @@ For each file in these paths:
 - **Exists in project, not in template** → **ignore** (never delete project-only files)
 
 ### Special handling (show full diff, user decides per file)
+
+**If `SYNC_MANIFEST` is loaded**: read `categories.special_handling` from the manifest.
+
+**If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
 ```
 .claude/settings.json                          <- may have project-specific permissions
@@ -127,6 +142,10 @@ These paths are project-specific and must **not** be overwritten by the template
 
 **Critical:** Do not remove or replace content that is specific to the project. Only suggest additions or merges that clearly originate from the template and do not conflict with project-only content. When in doubt, list the difference under "Optional additive update" and let the user decide.
 
+**If `SYNC_MANIFEST` is loaded**: read `categories.project_specific` from the manifest. For entries with `mixed_content: true`, also read the `annotation_scheme` field and apply the mixed-content extraction logic described below.
+
+**If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
+
 ```
 AGENTS.md
 README.md
@@ -144,27 +163,45 @@ For each of these: if template and project differ, show what the template has th
 
 Everything else not listed above (application code, project configs, etc.) is also never overwritten.
 
+### Mixed-content extraction logic
+
+When a file has `mixed_content: true` and `annotation_scheme: html_comments` in the manifest, use the following extraction logic when comparing to the upstream template:
+
+**Detection by file extension:**
+
+- For `.md` files: match lines that are exactly `<!-- TEMPLATE-OWNED-START -->` and `<!-- TEMPLATE-OWNED-END -->`.
+- For `.yaml` / `.yml` files: match lines that are exactly `# <!-- TEMPLATE-OWNED-START -->` and `# <!-- TEMPLATE-OWNED-END -->` (YAML comment prefix required).
+
+**Extraction behaviour:**
+
+- Extract only the content between `TEMPLATE-OWNED-START` and `TEMPLATE-OWNED-END` marker pairs for comparison and diffing.
+- Show only the extracted template-owned sections in the diff. Label all other sections as "preserved — no change" in the summary (UX Rule 2).
+- If markers are absent or malformed in the downstream copy of the file, flag the file as "unstructured — full review required" and show a full diff instead. Do NOT attempt an automatic merge in this case (UX Rule 3).
+
 ---
 
 ## Step 3 — Present the change summary
 
-Show a structured summary before asking for confirmation. Example format:
+Show a structured summary before asking for confirmation. Include file counts per category before the file lists so the maintainer can quickly detect an unexpectedly small always-sync list (UX Rule 1 / AC-5). Example format:
 
 ```
 ## Template Sync Summary
 Template version: v0.4.0  |  Project branch: develop
+Manifest: loaded from sync-manifest.yaml  (or: "not found — using embedded fallback list")
 
-### New files (will be added)
+### Always-sync files: N total (A to add, U to update, C up-to-date)
+
+#### New files (will be added): A
   .claude/skills/sync-template.md
 
-### Modified files (will be updated)
+#### Modified files (will be updated): U
   .claude/agents/developer.md
     Line 3: model: claude-sonnet-4-5 -> model: claude-sonnet-4-6
 
   docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
     [diff summary]
 
-### Already up to date (no changes)
+#### Already up to date (no changes): C
   docs/best-practices/1-general.md
   .cursor/rules/code.mdc
   ... (N files)
@@ -177,6 +214,17 @@ Template version: v0.4.0  |  Project branch: develop
   AGENTS.md — template has [brief description]; project keeps its own content; suggest adding: ...
   README.md — no template additions suggested
   ...
+```
+
+After applying changes, show a final disposition summary with separate counts (AC-5 / UX Rule 4):
+
+```
+### Sync complete
+
+Always-sync disposition:
+  Updated:              N files
+  Up-to-date (skipped): N files
+  Declined by maintainer: N files
 ```
 
 Then ask:
@@ -222,6 +270,8 @@ git add REVIEW.md docs/workflow/ .claude/agents/ .claude/commands/ .claude/skill
   docs/best-practices/1-general.md \
   docs/best-practices/2-version-control.md \
   docs/best-practices/3-testing.md
+# If sync-manifest.yaml was updated, stage it as well:
+git add sync-manifest.yaml
 # If the user explicitly approved additional paths in Step 4, 'git add' those paths too.
 git commit -m "chore(template): sync framework updates from template v{TEMPLATE_VERSION}"
 

--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -43,6 +43,11 @@ If `--ref` is not specified for a remote source, use the default branch (`main`)
 
 Once the template source is resolved, read its `CHANGELOG.md` and extract the latest version number (first `[X.Y.Z]` entry after `[Unreleased]` if present, otherwise the first versioned entry). Store it as `TEMPLATE_VERSION`.
 
+**Manifest check**: After resolving the template source, check for `sync-manifest.yaml` at the template root.
+
+- If found: read it and store its contents as `SYNC_MANIFEST`. The manifest is the authoritative file list (BR-1).
+- If absent: set `SYNC_MANIFEST=absent`. The graceful fallback (BR-4 / AC-4) activates in Step 2 — the embedded lists below are used and a warning is shown.
+
 ---
 
 ## Step 1 — Pre-flight checks on the current project
@@ -59,7 +64,7 @@ Run these checks **before touching anything**. If any check fails, report the pr
    git status --porcelain
    ```
    Must return empty output. If there are staged, unstaged, or untracked changes, abort with:
-   > "⚠️ Your working directory has uncommitted changes. Please commit or stash them before syncing."
+   > "Your working directory has uncommitted changes. Please commit or stash them before syncing."
 
 3. **Is the project on the correct base branch?**
    ```bash
@@ -70,15 +75,21 @@ Run these checks **before touching anything**. If any check fails, report the pr
    - If `develop` does not exist → must be on `main`
 
    If on the wrong branch, abort with:
-   > "⚠️ You must be on the `develop` branch (or `main` if `develop` doesn't exist) before syncing. Please switch branches and try again."
+   > "You must be on the `develop` branch (or `main` if `develop` doesn't exist) before syncing. Please switch branches and try again."
 
 ---
 
 ## Step 2 — Compare files
 
-Compare the following **framework-level paths** from the template against the current project.
+Use `SYNC_MANIFEST` to determine the file lists. If `SYNC_MANIFEST=absent`, fall back to the embedded lists in each section below and display this warning before continuing:
+
+> "Warning: sync manifest not found in upstream template. Using embedded file list — results may be incomplete."
 
 ### Always sync (apply automatically after approval)
+
+**If `SYNC_MANIFEST` is loaded**: read `categories.always_sync` from the manifest and enumerate those paths from the template. Each entry may specify a `path` (single file or directory prefix) and an optional `glob` pattern for recursive enumeration.
+
+**If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
 ```
 REVIEW.md                         ← canonical review contract for spec, plan, and code review gates
@@ -97,7 +108,7 @@ docs/best-practices/2-version-control.md
 docs/best-practices/3-testing.md
 ```
 
-**Comparison method:** For each directory in the list above, enumerate files with `find` (or equivalent) and compare each path to the template using `cmp` or `diff -q`. Do not rely on ad-hoc agent inspection alone for the always-sync trees — a missed directory is a silent sync gap.
+**Comparison method:** For each path in the always-sync list, enumerate files with `find` (or equivalent) and compare each path to the template using `cmp` or `diff -q`. Do not rely on ad-hoc agent inspection alone — a missed directory is a silent sync gap.
 
 For each file in these paths:
 - **Exists in template, not in project** → classify as ✅ **Add**
@@ -106,6 +117,10 @@ For each file in these paths:
 - **Exists in project, not in template** → **ignore** (never delete project-only files)
 
 ### Special handling (show full diff, user decides per file)
+
+**If `SYNC_MANIFEST` is loaded**: read `categories.special_handling` from the manifest.
+
+**If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
 ```
 .claude/settings.json                          ← may have project-specific permissions
@@ -124,6 +139,10 @@ These paths are project-specific and must **not** be overwritten by the template
 
 **Critical:** Do not remove or replace content that is specific to the project. Only suggest additions or merges that clearly originate from the template and do not conflict with project-only content. When in doubt, list the difference under "Optional additive update" and let the user decide.
 
+**If `SYNC_MANIFEST` is loaded**: read `categories.project_specific` from the manifest. For entries with `mixed_content: true`, also read the `annotation_scheme` field and apply the mixed-content extraction logic described below.
+
+**If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
+
 ```
 AGENTS.md
 README.md
@@ -141,27 +160,45 @@ For each of these: if template and project differ, show what the template has th
 
 Everything else not listed above (application code, project configs, etc.) is also never overwritten.
 
+### Mixed-content extraction logic
+
+When a file has `mixed_content: true` and `annotation_scheme: html_comments` in the manifest, use the following extraction logic when comparing to the upstream template:
+
+**Detection by file extension:**
+
+- For `.md` files: match lines that are exactly `<!-- TEMPLATE-OWNED-START -->` and `<!-- TEMPLATE-OWNED-END -->`.
+- For `.yaml` / `.yml` files: match lines that are exactly `# <!-- TEMPLATE-OWNED-START -->` and `# <!-- TEMPLATE-OWNED-END -->` (YAML comment prefix required).
+
+**Extraction behaviour:**
+
+- Extract only the content between `TEMPLATE-OWNED-START` and `TEMPLATE-OWNED-END` marker pairs for comparison and diffing.
+- Show only the extracted template-owned sections in the diff. Label all other sections as "preserved — no change" in the summary (UX Rule 2).
+- If markers are absent or malformed in the downstream copy of the file, flag the file as "unstructured — full review required" and show a full diff instead. Do NOT attempt an automatic merge in this case (UX Rule 3).
+
 ---
 
 ## Step 3 — Present the change summary
 
-Show a structured summary before asking for confirmation. Example format:
+Show a structured summary before asking for confirmation. Include file counts per category before the file lists so the maintainer can quickly detect an unexpectedly small always-sync list (UX Rule 1 / AC-5). Example format:
 
 ```
 ## Template Sync Summary
 Template version: v0.4.0  |  Project branch: develop
+Manifest: loaded from sync-manifest.yaml  (or: "not found — using embedded fallback list")
 
-### ✅ New files (will be added)
+### Always-sync files: N total (A to add, U to update, C up-to-date)
+
+#### ✅ New files (will be added): A
   .claude/skills/sync-template.md
 
-### 📝 Modified files (will be updated)
+#### 📝 Modified files (will be updated): U
   .claude/agents/developer.md
     Line 3: model: claude-sonnet-4-5 → model: claude-sonnet-4-6
 
   docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
     [diff summary]
 
-### ⏭ Already up to date (no changes)
+#### ⏭ Already up to date (no changes): C
   docs/best-practices/1-general.md
   .cursor/rules/code.mdc
   ... (N files)
@@ -174,6 +211,17 @@ Template version: v0.4.0  |  Project branch: develop
   AGENTS.md — template has [brief description]; project keeps its own content; suggest adding: …
   README.md — no template additions suggested
   …
+```
+
+After applying changes, show a final disposition summary with separate counts (AC-5 / UX Rule 4):
+
+```
+### Sync complete
+
+Always-sync disposition:
+  Updated:              N files
+  Up-to-date (skipped): N files
+  Declined by maintainer: N files
 ```
 
 Then ask:
@@ -215,6 +263,8 @@ git add REVIEW.md docs/workflow/ .claude/agents/ .claude/commands/ .claude/skill
   docs/best-practices/1-general.md \
   docs/best-practices/2-version-control.md \
   docs/best-practices/3-testing.md
+# If sync-manifest.yaml was updated, stage it as well:
+git add sync-manifest.yaml
 git commit -m "chore(template): sync framework updates from template v{TEMPLATE_VERSION}"
 
 # 4. Push and open PR

--- a/.codex/skills/workflow-sync-template/SKILL.md
+++ b/.codex/skills/workflow-sync-template/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: workflow-sync-template
+description: Sync framework updates from the upstream template into this downstream project. Reads sync-manifest.yaml from the upstream template for the authoritative file list; falls back to the embedded list when the manifest is absent. Use when a downstream project needs to pull in the latest framework files from the template.
+---
+
+# Workflow Sync Template
+
+Recommended model tier: `economy`
+
+1. Read `AGENTS.md` for repository-wide rules.
+2. Read `.claude/commands/sync-template.md` (the canonical sync-template protocol).
+3. Follow that protocol exactly, starting from Step 0.
+4. Apply the same manifest-driven procedure as the Claude Code and Cursor sync-template artefacts:
+   - Check for `sync-manifest.yaml` at the template root after resolving the template source.
+   - If found, use `categories.always_sync`, `categories.special_handling`, and `categories.project_specific` from the manifest.
+   - If absent, fall back to the embedded file list in the protocol and display the warning message.
+   - For mixed-content files (`mixed_content: true`, `annotation_scheme: html_comments`), apply the extraction logic defined in the protocol's "Mixed-content extraction logic" section.
+5. Present the structured sync summary (always-sync counts, new/modified/up-to-date breakdown) before asking for confirmation.
+6. Do not apply any changes until the user explicitly confirms.

--- a/.cursor/commands/sync-template.md
+++ b/.cursor/commands/sync-template.md
@@ -42,6 +42,11 @@ If `--ref` is not specified for a remote source, use the default branch (`main`)
 
 Once the template source is resolved, read its `CHANGELOG.md` and extract the latest version number (first `[X.Y.Z]` entry after `[Unreleased]` if present, otherwise the first versioned entry). Store it as `TEMPLATE_VERSION`.
 
+**Manifest check**: After resolving the template source, check for `sync-manifest.yaml` at the template root.
+
+- If found: read it and store its contents as `SYNC_MANIFEST`. The manifest is the authoritative file list (BR-1).
+- If absent: set `SYNC_MANIFEST=absent`. The graceful fallback (BR-4 / AC-4) activates in Step 2 — the embedded lists below are used and a warning is shown.
+
 ---
 
 ## Step 1 — Pre-flight checks on the current project
@@ -58,7 +63,7 @@ Run these checks **before touching anything**. If any check fails, report the pr
    git status --porcelain
    ```
    Must return empty output. If there are staged, unstaged, or untracked changes, abort with:
-   > "⚠️ Your working directory has uncommitted changes. Please commit or stash them before syncing."
+   > "Your working directory has uncommitted changes. Please commit or stash them before syncing."
 
 3. **Is the project on the correct base branch?**
    ```bash
@@ -69,15 +74,21 @@ Run these checks **before touching anything**. If any check fails, report the pr
    - If `develop` does not exist → must be on `main`
 
    If on the wrong branch, abort with:
-   > "⚠️ You must be on the `develop` branch (or `main` if `develop` doesn't exist) before syncing. Please switch branches and try again."
+   > "You must be on the `develop` branch (or `main` if `develop` doesn't exist) before syncing. Please switch branches and try again."
 
 ---
 
 ## Step 2 — Compare files
 
-Compare the following **framework-level paths** from the template against the current project.
+Use `SYNC_MANIFEST` to determine the file lists. If `SYNC_MANIFEST=absent`, fall back to the embedded lists in each section below and display this warning before continuing:
+
+> "Warning: sync manifest not found in upstream template. Using embedded file list — results may be incomplete."
 
 ### Always sync (apply automatically after approval)
+
+**If `SYNC_MANIFEST` is loaded**: read `categories.always_sync` from the manifest and enumerate those paths from the template. Each entry may specify a `path` (single file or directory prefix) and an optional `glob` pattern for recursive enumeration.
+
+**If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
 ```
 REVIEW.md                         ← canonical review contract for spec, plan, and code review gates
@@ -96,7 +107,7 @@ docs/best-practices/2-version-control.md
 docs/best-practices/3-testing.md
 ```
 
-**Comparison method:** For each directory in the list above, enumerate files with `find` (or equivalent) and compare each path to the template using `cmp` or `diff -q`. Do not rely on ad-hoc agent inspection alone for the always-sync trees — a missed directory is a silent sync gap.
+**Comparison method:** For each path in the always-sync list, enumerate files with `find` (or equivalent) and compare each path to the template using `cmp` or `diff -q`. Do not rely on ad-hoc agent inspection alone — a missed directory is a silent sync gap.
 
 For each file in these paths:
 - **Exists in template, not in project** → classify as ✅ **Add**
@@ -105,6 +116,10 @@ For each file in these paths:
 - **Exists in project, not in template** → **ignore** (never delete project-only files)
 
 ### Special handling (show full diff, user decides per file)
+
+**If `SYNC_MANIFEST` is loaded**: read `categories.special_handling` from the manifest.
+
+**If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
 ```
 .claude/settings.json                          ← may have project-specific permissions
@@ -123,6 +138,10 @@ These paths are project-specific and must **not** be overwritten by the template
 
 **Critical:** Do not remove or replace content that is specific to the project. Only suggest additions or merges that clearly originate from the template and do not conflict with project-only content. When in doubt, list the difference under "Optional additive update" and let the user decide.
 
+**If `SYNC_MANIFEST` is loaded**: read `categories.project_specific` from the manifest. For entries with `mixed_content: true`, also read the `annotation_scheme` field and apply the mixed-content extraction logic described below.
+
+**If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
+
 ```
 AGENTS.md
 README.md
@@ -140,27 +159,45 @@ For each of these: if template and project differ, show what the template has th
 
 Everything else not listed above (application code, project configs, etc.) is also never overwritten.
 
+### Mixed-content extraction logic
+
+When a file has `mixed_content: true` and `annotation_scheme: html_comments` in the manifest, use the following extraction logic when comparing to the upstream template:
+
+**Detection by file extension:**
+
+- For `.md` files: match lines that are exactly `<!-- TEMPLATE-OWNED-START -->` and `<!-- TEMPLATE-OWNED-END -->`.
+- For `.yaml` / `.yml` files: match lines that are exactly `# <!-- TEMPLATE-OWNED-START -->` and `# <!-- TEMPLATE-OWNED-END -->` (YAML comment prefix required).
+
+**Extraction behaviour:**
+
+- Extract only the content between `TEMPLATE-OWNED-START` and `TEMPLATE-OWNED-END` marker pairs for comparison and diffing.
+- Show only the extracted template-owned sections in the diff. Label all other sections as "preserved — no change" in the summary (UX Rule 2).
+- If markers are absent or malformed in the downstream copy of the file, flag the file as "unstructured — full review required" and show a full diff instead. Do NOT attempt an automatic merge in this case (UX Rule 3).
+
 ---
 
 ## Step 3 — Present the change summary
 
-Show a structured summary before asking for confirmation. Example format:
+Show a structured summary before asking for confirmation. Include file counts per category before the file lists so the maintainer can quickly detect an unexpectedly small always-sync list (UX Rule 1 / AC-5). Example format:
 
 ```
 ## Template Sync Summary
 Template version: v0.4.0  |  Project branch: develop
+Manifest: loaded from sync-manifest.yaml  (or: "not found — using embedded fallback list")
 
-### ✅ New files (will be added)
+### Always-sync files: N total (A to add, U to update, C up-to-date)
+
+#### ✅ New files (will be added): A
   .claude/skills/sync-template.md
 
-### 📝 Modified files (will be updated)
+#### 📝 Modified files (will be updated): U
   .claude/agents/developer.md
     Line 3: model: claude-sonnet-4-5 → model: claude-sonnet-4-6
 
   docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
     [diff summary]
 
-### ⏭ Already up to date (no changes)
+#### ⏭ Already up to date (no changes): C
   docs/best-practices/1-general.md
   .cursor/rules/code.mdc
   ... (N files)
@@ -173,6 +210,17 @@ Template version: v0.4.0  |  Project branch: develop
   AGENTS.md — template has [brief description]; project keeps its own content; suggest adding: …
   README.md — no template additions suggested
   …
+```
+
+After applying changes, show a final disposition summary with separate counts (AC-5 / UX Rule 4):
+
+```
+### Sync complete
+
+Always-sync disposition:
+  Updated:              N files
+  Up-to-date (skipped): N files
+  Declined by maintainer: N files
 ```
 
 Then ask:
@@ -214,6 +262,8 @@ git add REVIEW.md docs/workflow/ .claude/agents/ .claude/commands/ .claude/skill
   docs/best-practices/1-general.md \
   docs/best-practices/2-version-control.md \
   docs/best-practices/3-testing.md
+# If sync-manifest.yaml was updated, stage it as well:
+git add sync-manifest.yaml
 git commit -m "chore(template): sync framework updates from template v{TEMPLATE_VERSION}"
 
 # 4. Push and open PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Always refer to these docs for authoritative guidance:
 
 ---
 
+<!-- TEMPLATE-OWNED-START -->
 ## Development Workflow
 
 This project uses a staged AI-assisted development workflow. See [`docs/workflow/development-workflow/README.md`](docs/workflow/development-workflow/README.md) for the full specification.
@@ -89,8 +90,10 @@ For normal Codex usage, start with `workflow-orchestrator`. It is the primary po
 
 | Task | Claude Code | Cursor | Codex |
 |---|---|---|---|
-| Sync framework updates from template | `/sync-template` | `/sync-template` | — |
+| Sync framework updates from template | `/sync-template` | `/sync-template` | `workflow-sync-template` skill |
 | Post-merge cleanup (fetch, develop, pull, delete local branch; update issue tracker) | `/post-merge-cleanup` | `/post-merge-cleanup` | `post-merge-cleanup` skill |
+
+<!-- TEMPLATE-OWNED-END -->
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Sync-template manifest-driven reliability** (#252): Introduce `sync-manifest.yaml` as the authoritative file list for sync-template; add `<!-- TEMPLATE-OWNED-START -->` / `<!-- TEMPLATE-OWNED-END -->` HTML-comment annotation markers to mixed-content files (`AGENTS.md`, `.ai-dev-workflow.yaml`); update all sync-template artefacts (`.claude/commands/sync-template.md`, `.claude/skills/sync-template.md`, `.cursor/commands/sync-template.md`) to consume the manifest with graceful fallback when absent; add new Codex skill `workflow-sync-template`; update `AGENTS.md` Maintenance Commands table to include `workflow-sync-template` in the Codex column.
+
 - **Database migration review checklist** (`REVIEW.md`): trigger/backfill arithmetic parity when both exist in the same migration.
 
 - **Scope-drift guardrails for spec and plan authoring**: protocol updates now require brief-objective coverage matrices and PR-visible deferral notes in spec writing, plus live repo verification logs for pattern-based plan scope checks; review checklists and agent/skill entrypoints were aligned, and a workflow fixture was added for stale-enumeration validation.

--- a/sync-manifest.yaml
+++ b/sync-manifest.yaml
@@ -1,0 +1,117 @@
+# sync-manifest.yaml
+# Authoritative list of all framework-managed files and their sync category.
+# Consumed by sync-template artefacts (Claude Code, Cursor, Codex) at runtime.
+#
+# Schema version: 1
+#
+# Categories:
+#   always_sync       - Framework-owned files. Must be kept in sync with the upstream template.
+#                       The agent presents all out-of-date entries to the maintainer before
+#                       applying; the maintainer may decline individual files but no always-sync
+#                       file with a diff may be silently omitted from the summary (BR-2, BR-7).
+#   special_handling  - Files that may have project-specific customisations.
+#                       Always show the full diff; the maintainer decides per file.
+#   project_specific  - Files owned by the downstream project. Never overwrite.
+#                       The agent may propose additive updates but must preserve all
+#                       project-specific content. Files with mixed_content: true contain
+#                       both template-owned and project-owned sections separated by
+#                       annotation markers (see annotation_scheme below).
+#
+# Annotation schemes (used in mixed_content files):
+#   html_comments     - Markers in Markdown files:
+#                         <!-- TEMPLATE-OWNED-START --> ... <!-- TEMPLATE-OWNED-END -->
+#                       Markers in YAML files (must be wrapped in YAML comment syntax):
+#                         # <!-- TEMPLATE-OWNED-START --> ... # <!-- TEMPLATE-OWNED-END -->
+#
+# NOTE: If a new framework file is added to the template, add a corresponding entry here.
+# Files absent from this manifest will not be included in always-sync batches.
+# (CI-enforced manifest completeness is out of scope for this iteration — see issue #252.)
+
+schema_version: 1
+
+categories:
+  always_sync:
+    - path: REVIEW.md
+      note: canonical review contract for spec, plan, and code review gates
+    - path: docs/workflow/
+      glob: "**/*"
+      note: full workflow documentation tree (all files recursively)
+    - path: .claude/agents/
+      glob: "*.md"
+      note: Claude Code agent definitions
+    - path: .claude/commands/
+      glob: "*.md"
+      note: Claude Code slash commands
+    - path: .claude/skills/
+      glob: "*.md"
+      note: Claude Code skills
+    - path: .codex/skills/
+      glob: "**/*"
+      note: Codex skill trees shipped with the template (SKILL.md and assets)
+    - path: .cursor/commands/
+      glob: "*.md"
+      note: Cursor slash commands
+    - path: .cursor/agents/
+      glob: "*.md"
+      note: Cursor subagent definitions
+    - path: .cursor/rules/
+      glob: "*.mdc"
+      note: Cursor rules files
+    - path: scripts/development-workflow/
+      glob: "**/*"
+      note: workflow helper scripts (state inspection, PR/CI loops, etc.)
+    - path: scripts/README.md
+      note: purpose and usage of scripts in scripts/
+    - path: docs/best-practices/1-general.md
+      note: general coding standards
+    - path: docs/best-practices/2-version-control.md
+      note: git and branching conventions
+    - path: docs/best-practices/3-testing.md
+      note: testing standards
+
+  special_handling:
+    - path: .claude/settings.json
+      note: may have project-specific tool permissions
+    - path: .claude/settings.local.json.example
+      note: local settings example file
+    - path: .github/workflows/auto-tag-release.yml
+      note: automated release tagging; add if CI is set up
+    - path: .github/workflows/deploy.yml
+      note: placeholder deployment workflow; customize with project-specific deploy logic
+    - path: .github/workflows/e2e-regression.yml
+      note: label-gated e2e/regression placeholder; customize with project-specific test logic
+    - path: e2e/
+      glob: "**/*"
+      note: placeholder e2e/regression test project (Playwright); customize with project-specific tests
+
+  project_specific:
+    - path: AGENTS.md
+      mixed_content: true
+      annotation_scheme: html_comments
+      note: >
+        workflow table (## Development Workflow section) is template-owned;
+        project fills in ## Project Overview and ## Repository Structure sections
+    - path: README.md
+      note: project-specific README; template version is a starting point only
+    - path: CHANGELOG.md
+      note: project maintains its own changelog; never overwrite
+    - path: .ai-dev-workflow.yaml
+      mixed_content: true
+      annotation_scheme: html_comments
+      note: >
+        schema description comments are template-owned;
+        provider selections (platforms, internal_reviewers, etc.) are project-specific
+    - path: docs/project/
+      glob: "**/*"
+      note: project domain docs; entirely project-specific
+    - path: docs/best-practices/STACK-SPECIFIC.md
+      note: stack summary; project fills in its own technology choices
+    - path: docs/best-practices/stack/
+      glob: "**/*"
+      note: per-technology convention files; project-specific
+    - path: .gitignore
+      note: project-specific ignore rules
+    - path: CLAUDE.md
+      note: symlink to AGENTS.md; project-specific
+    - path: GEMINI.md
+      note: symlink to AGENTS.md; project-specific

--- a/sync-manifest.yaml
+++ b/sync-manifest.yaml
@@ -68,6 +68,8 @@ categories:
       note: git and branching conventions
     - path: docs/best-practices/3-testing.md
       note: testing standards
+    - path: sync-manifest.yaml
+      note: this manifest file itself; must be synced so downstream projects receive manifest updates
 
   special_handling:
     - path: .claude/settings.json


### PR DESCRIPTION
## Summary

Implements [#252](https://github.com/lhpaul/ai-dev-framework-template/issues/252) — Sync-Template Reliability.

- Introduces `sync-manifest.yaml` at the repository root as the authoritative list of always-sync, special-handling, and project-specific files (BR-1, AC-7).
- Adds `<!-- TEMPLATE-OWNED-START -->` / `<!-- TEMPLATE-OWNED-END -->` HTML-comment annotation markers to the workflow table in `AGENTS.md` and YAML-comment equivalents to the schema description block in `.ai-dev-workflow.yaml` (BR-3, BR-6, AC-3).
- Updates all three sync-template artefacts (`.claude/commands/sync-template.md`, `.claude/skills/sync-template.md`, `.cursor/commands/sync-template.md`) to: read the manifest in Step 0; enumerate always-sync/special-handling/project-specific paths from it; apply mixed-content extraction logic for annotated files; show file counts per category before confirmation; produce a final disposition summary with separate "updated / up-to-date / declined" counts (BR-2, BR-4, BR-7, AC-1, AC-4, AC-5, UX Rules 1-4).
- Creates new Codex skill `workflow-sync-template` as a thin wrapper delegating to the same protocol (BR-5, AC-2).
- Updates `AGENTS.md` Maintenance Commands table to include `workflow-sync-template` in the Codex column.

## Spec / Plan

- Spec: `docs/specs/developments/20260422154017_252-sync-template-reliability/1_252-sync-template-reliability_specs.md`
- Plan: `docs/specs/developments/20260422154017_252-sync-template-reliability/2_252-sync-template-reliability_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/252-sync-template-reliability.smoke-test.md`

## Test plan

- [ ] `sync-manifest.yaml` opens in a text editor and is valid YAML (AC-7)
- [ ] Markdown lint passes: `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
- [ ] All three sync-template artefacts contain the manifest-check section in Step 0 and the mixed-content extraction section in Step 2
- [ ] `AGENTS.md` workflow table is wrapped with `<!-- TEMPLATE-OWNED-START -->` / `<!-- TEMPLATE-OWNED-END -->`
- [ ] `.ai-dev-workflow.yaml` schema description block is wrapped with `# <!-- TEMPLATE-OWNED-START -->` / `# <!-- TEMPLATE-OWNED-END -->`
- [ ] `.codex/skills/workflow-sync-template/SKILL.md` exists and follows the Codex skill pattern
- [ ] `AGENTS.md` Maintenance Commands table lists `workflow-sync-template` in the Codex column for the sync row
- [ ] CHANGELOG entry added under `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manifest-driven template synchronization with graceful fallback and per-category sync counts.
  * Improved mixed-content handling with HTML-comment boundary markers to isolate template-owned regions and require full review when markers are absent.

* **Documentation**
  * New workflow sync guidance and updated sync command docs across platforms.
  * Maintenance reference and changelog updated to reflect the new sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->