### PR TITLE
fix(protocol-03): enforce review summary comment exists before applying readiness labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pre-label ordering gate in developer protocol** (#270): `03-implement-development-protocol.md` Step 9 now documents an explicit hard sequential gate that agents must pass before applying any readiness label — reviewer loop summary comment must be present, all CI checks must be in a terminal state, and all automated-reviewer threads must be resolved before `ready-for-regression` and then `ready-for-human-review` are applied in order.
+
 - **Post-agent main working tree sanity check** (#229): Protocol 90 Step 5.2 now runs immediately after each Work Item Runner returns — before PR verification, before the next dispatch, and before any action that assumes the integration branch context; the Case 1 postcondition table now documents the root-cause implication of a wrong-branch + clean result (agent ran in main tree instead of worktree). Protocol 91 post-terminal check upgraded from a single error branch to the same four-case handling (auto-correct Case 1, halt-and-escalate Cases 2 and 4, proceed Case 3) with explicit cross-reference to Protocol 90 Step 5.2.
 
 - **MD047 trailing-newline pre-staging check** (#227): `03-implement-development-protocol.md` (all four paths) now includes an explicit MD047 check that scans every modified `.md` file for a missing trailing newline before `git add`; `.claude/agents/developer.md` and `.cursor/agents/developer.md` key-rules sections were updated with the matching rule (parity with the #178 trailing-whitespace step).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Pre-label ordering gate in developer protocol** (#270): `03-implement-development-protocol.md` Step 9 now documents an explicit hard sequential gate that agents must pass before applying any readiness label — reviewer loop summary comment must be present, all CI checks must be in a terminal state, and all automated-reviewer threads must be resolved before `ready-for-regression` and then `ready-for-human-review` are applied in order.
+- **Pre-label ordering gate in developer protocol** (#270): `03-implement-development-protocol.md` Step 9 now documents an explicit hard sequential two-phase gate that agents must pass before applying readiness labels — Phase 1 requires the reviewer loop summary comment to be present and all automated-reviewer threads to be resolved before applying `ready-for-regression`; Phase 2 requires all CI checks to reach a terminal state with no failures before applying `ready-for-human-review`.
 
 - **Post-agent main working tree sanity check** (#229): Protocol 90 Step 5.2 now runs immediately after each Work Item Runner returns — before PR verification, before the next dispatch, and before any action that assumes the integration branch context; the Case 1 postcondition table now documents the root-cause implication of a wrong-branch + clean result (agent ran in main tree instead of worktree). Protocol 91 post-terminal check upgraded from a single error branch to the same four-case handling (auto-correct Case 1, halt-and-escalate Cases 2 and 4, proceed Case 3) with explicit cross-reference to Protocol 90 Step 5.2.
 

--- a/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
@@ -222,10 +222,10 @@ Before applying any readiness label, the Work Item Runner (or this protocol when
 
 **Phase 2 — before applying `ready-for-human-review` (Step 8a), after CI settles**:
 
-4. **All CI checks are in a terminal state with no failures**: Every required status check in `statusCheckRollup` must have `state: SUCCESS` or `conclusion: success` / `conclusion: skipped` — no check may be in `PENDING`, `null`, `IN_PROGRESS`, `FAILURE`, or `ERROR` state. Do not apply `ready-for-human-review` while any check is still pending or failed.
+4. **All CI checks are green**: Every required status check in `statusCheckRollup` must have passed or been skipped — no check may be in `PENDING`, `null`, `IN_PROGRESS`, `FAILURE`, or `ERROR` state. Do not apply `ready-for-human-review` while any check is still pending or failed. (See `91-orchestrate-work-protocol.md` Step 8 and `pr-ci-loop.sh` for the authoritative CI polling logic.)
 5. **Apply `ready-for-human-review`** (Step 8a).
 
-This two-phase sequence matches `91-orchestrate-work-protocol.md` Steps 7b → 8 → 8a → 8c. When invoked through the Work Item Runner, those steps enforce this gate automatically. When invoked standalone, run this gate explicitly before calling `gh pr edit --add-label`.
+This two-phase sequence aligns with `91-orchestrate-work-protocol.md` Steps 7b → 8 → 8a → 8c. When invoked through the Work Item Runner, those steps enforce this gate automatically. When invoked standalone, run this gate explicitly before calling `gh pr edit --add-label`.
 
 If this protocol is invoked **standalone** rather than through the Work Item Runner, hand off manually by following `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` from the newly opened draft PR.
 

--- a/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
@@ -212,14 +212,20 @@ After the draft PR exists, the **Work Item Runner** owns the rest of the lifecyc
 
 **Pre-label ordering gate (hard sequential gate — do not skip)**:
 
-Before applying `ready-for-regression` or `ready-for-human-review`, the Work Item Runner (or this protocol when invoked standalone) **must** verify all of the following conditions **in order**. Block on each step until it passes; do not proceed to the next step while the current step is still unmet:
+Before applying any readiness label, the Work Item Runner (or this protocol when invoked standalone) **must** satisfy the following two-phase sequence. Each phase must be fully satisfied before proceeding to the next. Do not collapse both phases or apply both labels simultaneously.
 
-1. **Reviewer loop summary comment is present**: At least one PR comment containing `"Automated Reviewer Loop Summary"` or `"No blocking PR feedback"` must exist on the PR. This is the only reliable signal that Step 7 ran to completion. Do not apply any readiness label before this comment exists. (Skip this check only when no review platforms are configured and Step 7 result was `skipped`.)
-2. **All CI checks are in a terminal state**: Every required status check in `statusCheckRollup` must have `state: SUCCESS`, `state: FAILURE`, `conclusion: success`, or `conclusion: skipped` — no check may be in `PENDING`, `null`, or `IN_PROGRESS` state. Do not apply any readiness label while any check is still pending.
-3. **All automated-reviewer threads are resolved**: Every review thread authored by a configured bot (e.g., `coderabbitai[bot]`, `devin[bot]`) must have `isResolved: true`. Unresolved bot threads block labeling.
-4. **Only then apply labels in sequence**: `ready-for-regression` first (Step 7b), then `ready-for-human-review` (Step 8a). Never reverse this order or apply both simultaneously.
+**Phase 1 — before applying `ready-for-regression` (Step 7b)**:
 
-This gate mirrors `91-orchestrate-work-protocol.md` Steps 8a and 8c. When invoked through the Work Item Runner, those steps enforce this gate automatically. When invoked standalone, run this gate explicitly before calling `gh pr edit --add-label`.
+1. **Reviewer loop summary comment is present**: At least one PR comment containing `"Automated Reviewer Loop Summary"` or `"No blocking PR feedback"` must exist on the PR. This is the only reliable signal that Step 7 ran to completion. Do not apply `ready-for-regression` before this comment exists. (Skip this check only when no review platforms are configured and Step 7 result was `skipped`.)
+2. **All automated-reviewer threads are resolved**: Every review thread authored by a configured bot (e.g., `coderabbitai[bot]`, `devin[bot]`) must have `isResolved: true`. Unresolved bot threads block labeling.
+3. **Apply `ready-for-regression`** (Step 7b). This label triggers label-gated e2e/regression CI checks.
+
+**Phase 2 — before applying `ready-for-human-review` (Step 8a), after CI settles**:
+
+4. **All CI checks are in a terminal state with no failures**: Every required status check in `statusCheckRollup` must have `state: SUCCESS` or `conclusion: success` / `conclusion: skipped` — no check may be in `PENDING`, `null`, `IN_PROGRESS`, `FAILURE`, or `ERROR` state. Do not apply `ready-for-human-review` while any check is still pending or failed.
+5. **Apply `ready-for-human-review`** (Step 8a).
+
+This two-phase sequence matches `91-orchestrate-work-protocol.md` Steps 7b → 8 → 8a → 8c. When invoked through the Work Item Runner, those steps enforce this gate automatically. When invoked standalone, run this gate explicitly before calling `gh pr edit --add-label`.
 
 If this protocol is invoked **standalone** rather than through the Work Item Runner, hand off manually by following `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` from the newly opened draft PR.
 

--- a/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
@@ -210,6 +210,17 @@ After the draft PR exists, the **Work Item Runner** owns the rest of the lifecyc
 
 **Label derivation rule**: The `ready-for-regression` label requirement is determined by the **branch prefix**, not by the content of the PR. `feature/*` branches always require `ready-for-regression` regardless of whether the changes are code, documentation, or configuration. See `91-orchestrate-work-protocol.md` Step 8a for the full branch-prefix-to-label table.
 
+**Pre-label ordering gate (hard sequential gate — do not skip)**:
+
+Before applying `ready-for-regression` or `ready-for-human-review`, the Work Item Runner (or this protocol when invoked standalone) **must** verify all of the following conditions **in order**. Block on each step until it passes; do not proceed to the next step while the current step is still unmet:
+
+1. **Reviewer loop summary comment is present**: At least one PR comment containing `"Automated Reviewer Loop Summary"` or `"No blocking PR feedback"` must exist on the PR. This is the only reliable signal that Step 7 ran to completion. Do not apply any readiness label before this comment exists. (Skip this check only when no review platforms are configured and Step 7 result was `skipped`.)
+2. **All CI checks are in a terminal state**: Every required status check in `statusCheckRollup` must have `state: SUCCESS`, `state: FAILURE`, `conclusion: success`, or `conclusion: skipped` — no check may be in `PENDING`, `null`, or `IN_PROGRESS` state. Do not apply any readiness label while any check is still pending.
+3. **All automated-reviewer threads are resolved**: Every review thread authored by a configured bot (e.g., `coderabbitai[bot]`, `devin[bot]`) must have `isResolved: true`. Unresolved bot threads block labeling.
+4. **Only then apply labels in sequence**: `ready-for-regression` first (Step 7b), then `ready-for-human-review` (Step 8a). Never reverse this order or apply both simultaneously.
+
+This gate mirrors `91-orchestrate-work-protocol.md` Steps 8a and 8c. When invoked through the Work Item Runner, those steps enforce this gate automatically. When invoked standalone, run this gate explicitly before calling `gh pr edit --add-label`.
+
 If this protocol is invoked **standalone** rather than through the Work Item Runner, hand off manually by following `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` from the newly opened draft PR.
 
 See `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` and `docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md`.


### PR DESCRIPTION
## What

Adds an explicit hard sequential pre-label ordering gate to `03-implement-development-protocol.md` Path 1 Step 9 (Handoff to Work Item Runner).

## Why

During Batch 4 (2026-04-22), an implementation agent (PR #157) applied `ready-for-human-review` and `ready-for-regression` labels while:
1. The E2E regression CI check was still in `null` (pending) state
2. The reviewer loop summary comment had not yet been posted

The orchestrator's Step 5.1 verification caught this. This is a regression from prior fixes — agents still violate the ordering constraint because the current wording implies the order but does not make it a hard sequential gate with explicit blocking steps.

## Changes

- `docs/workflow/development-workflow/protocols/03-implement-development-protocol.md`: added **Pre-label ordering gate** block to Path 1 Step 9. The gate documents four sequential blocking conditions an agent must verify before applying any readiness label:
  1. Reviewer loop summary comment is present on the PR
  2. All CI checks are in a terminal state (no `PENDING`/`null`)
  3. All automated-reviewer threads are resolved
  4. Apply labels in sequence: `ready-for-regression` then `ready-for-human-review`
- `CHANGELOG.md`: added `Fixed` entry under `[Unreleased]`

## Test Plan

- Read the updated Step 9 — the gate is now explicit and sequential
- Confirm the gate is consistent with `91-orchestrate-work-protocol.md` Steps 8a/8c (it mirrors those steps; this gate documents the same requirements in the developer protocol for standalone use)

Closes #270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified development workflow protocol requirements for pull request readiness status, including mandatory checks for reviewer completion, CI terminal states, and thread resolution before label application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->