### PR TITLE
fix(plan-writer): add mandatory pre-commit lint step to catch broken relative links (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **CodeRabbit completion via issue comments** (`pr-review-loop.sh`): when CodeRabbit posts only an issue-thread summary (no `pulls/{id}/reviews` entry) for the current HEAD, the poll loop now proceeds to Phase 3 instead of spinning until `timeout` and returning a false `escalate`.
 
+- **Plan-writer pre-commit lint step** (#271): `02-generate-implementation-plan-protocol.md` Step 5 now includes a mandatory `markdownlint-cli2` run on the plan file and smoke test runbook before staging. This catches broken relative links (wrong `../../` depth), trailing spaces, and missing trailing newlines before the first push, preventing Devin fix cycles caused by off-by-one path errors. The lint command resolves `node_modules/` from the git repo root so it works inside isolated worktrees.
+
 - **Silent workaround loophole in item-orchestrator permission-denial contract** (#228): when `Edit`/`Write` is denied on `.claude/agents/**` or any other path, subagents were silently falling back to Bash redirects, Python subprocess writes, or `gh api --method PUT` instead of returning `SUBAGENT_PERMISSION_DENIAL`. Protocol 91 Step 3 now explicitly prohibits all alternative write mechanisms and requires the denied path(s) to be listed in the exit string; `.claude/agents/item-orchestrator.md` and `.cursor/agents/item-orchestrator.md` add a matching enforcement note; `.claude/settings.json` adds `Edit(.claude/agents/**)`, `Write(.claude/agents/**)`, `Edit(.cursor/agents/**)`, and `Write(.cursor/agents/**)` allow-list entries to close the root-cause permission gap that triggered the workarounds.
 
 ## [0.22.0] - 2026-04-20

--- a/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -164,12 +164,33 @@ If no blocking human decision remains:
 2. Create branch: `git checkout -b implementation-plan/[branch-slug]` from `develop`
 3. Write the plan file
 4. Write the smoke test runbook
-5. Commit: `docs: add implementation plan for [feature-name]`
-6. Push: `git push -u origin implementation-plan/[branch-slug]`
-7. Open a **draft** PR targeting `develop` with:
+5. **Pre-commit lint check (mandatory — do not skip)**:
+
+   Run `markdownlint-cli2` on the plan file and smoke test runbook before staging. This catches broken relative links (wrong `../../` depth), trailing spaces, and missing trailing newlines that would otherwise fail CI and require a fix commit.
+
+   ```bash
+   # Resolve the repo root (works whether running in the main tree or a worktree)
+   REPO_ROOT=$(git rev-parse --show-toplevel)
+
+   # Run markdownlint-cli2 using the repo root's node_modules
+   "$REPO_ROOT/node_modules/.bin/markdownlint-cli2" \
+     "docs/specs/developments/[timestamp]_[feature-slug]/2_[feature-slug]_implementation-plan.md" \
+     "docs/testing/[app-or-section]/[feature-slug].smoke-test.md"
+   ```
+
+   Fix any reported violations before proceeding to the commit step. Common violations to look for:
+   - **Broken relative links** (`relative-links`): verify every `[text](../../path/to/file.md)` path resolves from the file's location. Count the `../` segments carefully — off-by-one depth errors (e.g., `../../../../` where `../../../` is correct) will not be obvious by inspection alone. The lint step is the authoritative check.
+   - **Trailing spaces** (MD009): no line should end with whitespace except intentional two-space hard line breaks.
+   - **Missing trailing newline** (MD047): every file must end with a single newline.
+
+   > **Worktree note**: When running inside a git worktree (e.g., when dispatched by the Portfolio Orchestrator), `node_modules/` does not exist inside the worktree directory. Use `REPO_ROOT=$(git rev-parse --show-toplevel)` to locate the correct binary regardless of working directory.
+
+6. Commit: `docs: add implementation plan for [feature-name]`
+7. Push: `git push -u origin implementation-plan/[branch-slug]`
+8. Open a **draft** PR targeting `develop` with:
    - Title: `docs(plan): [feature-name]`
    - Body: summary of the approach, complexity estimate, key risks, link to plan and runbook
-8. Return the branch + PR details to the **Work Item Runner**
+9. Return the branch + PR details to the **Work Item Runner**
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -169,8 +169,10 @@ If no blocking human decision remains:
    Run `markdownlint-cli2` on the plan file and smoke test runbook before staging. This catches broken relative links (wrong `../../` depth), trailing spaces, and missing trailing newlines that would otherwise fail CI and require a fix commit.
 
    ```bash
-   # Resolve the repo root (works whether running in the main tree or a worktree)
-   REPO_ROOT=$(git rev-parse --show-toplevel)
+   # Resolve the repo root (works whether running in the main tree or an isolated worktree).
+   # NOTE: git rev-parse --show-toplevel returns the *worktree* directory inside a worktree,
+   # not the main repo. Use --git-common-dir instead, which always points to the shared .git/.
+   REPO_ROOT=$(git rev-parse --git-common-dir)/..
 
    # Run markdownlint-cli2 using the repo root's node_modules
    "$REPO_ROOT/node_modules/.bin/markdownlint-cli2" \
@@ -183,7 +185,7 @@ If no blocking human decision remains:
    - **Trailing spaces** (MD009): no line should end with whitespace except intentional two-space hard line breaks.
    - **Missing trailing newline** (MD047): every file must end with a single newline.
 
-   > **Worktree note**: When running inside a git worktree (e.g., when dispatched by the Portfolio Orchestrator), `node_modules/` does not exist inside the worktree directory. Use `REPO_ROOT=$(git rev-parse --show-toplevel)` to locate the correct binary regardless of working directory.
+   > **Worktree note**: When running inside a git worktree (e.g., when dispatched by the Portfolio Orchestrator), `node_modules/` does not exist inside the worktree directory. The `$(git rev-parse --git-common-dir)/..` expression resolves to the main repo root in both the main tree and any worktree.
 
 6. Commit: `docs: add implementation plan for [feature-name]`
 7. Push: `git push -u origin implementation-plan/[branch-slug]`


### PR DESCRIPTION
## Summary

Fixes #271 — regression of #173. Broken relative links in plan/spec docs have appeared in at least 3 consecutive batches because the plan-writer protocol (Step 5) had **no pre-commit lint step**. The `markdownlint-rule-relative-links` rule was configured in CI and editor tooling, but agents were never instructed to run it before pushing.

## Root Cause

The plan-writer protocol (`02-generate-implementation-plan-protocol.md`) Step 5 instructed: write files → commit → push, with no lint gate in between. Off-by-one relative path depth errors (e.g., `../../../../` where `../../../` is correct) are not detectable by inspection alone and require the lint tool to catch.

## Fix

Added a **mandatory pre-commit lint check** to Step 5 of the plan-writer protocol that runs `markdownlint-cli2` on the plan file and smoke test runbook before staging. The command:

- Uses `git rev-parse --show-toplevel` to resolve `node_modules/` from the repo root, so it works correctly inside isolated worktrees (which do not have their own `node_modules/`)
- Catches broken relative links (wrong `../../` depth via the `relative-links` custom rule), trailing spaces (MD009), and missing trailing newlines (MD047)
- Explicitly documents the off-by-one link depth error as the primary violation to look for

## Files Changed

- `docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md` — added Step 5 lint gate (steps 5-9 renumbered from 5-8)
- `CHANGELOG.md` — Fixed entry under [Unreleased]

## Test Plan

- [ ] Verify `markdownlint-cli2` with `markdownlint-rule-relative-links` catches a plan file with a wrong-depth relative link
- [ ] Verify the `git rev-parse --show-toplevel` command resolves the correct `node_modules/` path from inside a worktree
- [ ] Verify existing plan files still pass lint (no regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development workflow protocol to include pre-commit validation step.

* **Chores**
  * Added markdown linting checks on generated files to detect broken links, trailing whitespace, and missing newlines before staging changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->