### PR TITLE
fix(protocol-90): orchestrator must route parallel impl batch merges through batch-merge.sh, not gh pr merge directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Orchestrator parallel impl batch merges must use batch-merge.sh** (#273): Protocol 90 Step 5.5 now includes an explicit batch-merge routing rule clarifying that parallel implementation batches must always be merged via `batch-merge.sh discover --prs <list>` + Protocol 94 (which provides CHANGELOG auto-resolution and active-worktree awareness); direct `gh pr merge` calls are only acceptable for single-PR or non-implementation (spec/plan) merges. A summary table and reference to the Batch 4 incident are included.
+
 - **Post-agent main working tree sanity check** (#229): Protocol 90 Step 5.2 now runs immediately after each Work Item Runner returns — before PR verification, before the next dispatch, and before any action that assumes the integration branch context; the Case 1 postcondition table now documents the root-cause implication of a wrong-branch + clean result (agent ran in main tree instead of worktree). Protocol 91 post-terminal check upgraded from a single error branch to the same four-case handling (auto-correct Case 1, halt-and-escalate Cases 2 and 4, proceed Case 3) with explicit cross-reference to Protocol 90 Step 5.2.
 
 - **MD047 trailing-newline pre-staging check** (#227): `03-implement-development-protocol.md` (all four paths) now includes an explicit MD047 check that scans every modified `.md` file for a missing trailing newline before `git add`; `.claude/agents/developer.md` and `.cursor/agents/developer.md` key-rules sections were updated with the matching rule (parity with the #178 trailing-whitespace step).

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -616,6 +616,18 @@ If any PR is still in progress or labeled `needs-fixes`, continue supervising (S
 
 5. **Include the batch-merge summary** (Step 5 of Protocol 94) in the orchestrator's Step 6 summary output.
 
+### Batch-merge routing rule (mandatory)
+
+When merging a parallel implementation batch, **always** invoke `batch-merge.sh discover --prs <list>` followed by execution of `94-batch-merge-protocol.md`. Direct `gh pr merge` calls are only acceptable for single-PR merges or non-implementation PRs (spec, plan). **Never** use `gh pr merge` individually for parallel implementation batches — it bypasses CHANGELOG auto-resolution (Protocol 94 Step 4.3) and active-worktree awareness.
+
+| Merge scenario | Required tool |
+|---|---|
+| Parallel implementation batch (2+ PRs) | `batch-merge.sh` + Protocol 94 |
+| Single implementation PR | `gh pr merge` is acceptable |
+| Spec or plan PR (any count) | `gh pr merge` is acceptable |
+
+Violating this rule causes CHANGELOG merge conflicts that must be resolved manually, as observed in the Batch 4 incident (2026-04-22).
+
 ### Governance note
 
 The orchestrator prepares and validates the batch but **does not merge autonomously**. The human's explicit approval at Step 5.5 (above) is the required merge gate. This aligns with the policy in `2_batch-merge_implementation-plan.md`: "The agent executes `git merge` locally, but only after the human explicitly confirms the merge plan."


### PR DESCRIPTION
## Summary

- Adds an explicit **batch-merge routing rule** to Protocol 90 Step 5.5 (Batch-Merge Handoff).
- Parallel implementation batches (2+ PRs) **must** be merged via `batch-merge.sh discover --prs <list>` + Protocol 94, which provides CHANGELOG auto-resolution (Step 4.3) and active-worktree awareness.
- Direct `gh pr merge` remains acceptable for single-PR merges and non-implementation (spec/plan) PRs.
- A summary table and reference to the Batch 4 incident (2026-04-22) are included for clarity.

Closes #273

## Test plan

- [ ] Read Step 5.5 in the updated `90-batch-orchestrate-work-protocol.md` — confirm the "Batch-merge routing rule (mandatory)" sub-section is present above the "Governance note".
- [ ] Verify the routing table lists: parallel impl batch → `batch-merge.sh` + Protocol 94; single impl PR → `gh pr merge`; spec/plan → `gh pr merge`.
- [ ] Confirm CHANGELOG entry under `[Unreleased] > Fixed` references #273.
- [ ] Markdown lint passes with zero errors (standard + heuristic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Protocol 90 documentation to clarify merge requirements for batch orchestration processes.
  * Added guidance on merge routing procedures to prevent conflicts during parallel implementation work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->