### PR TITLE
fix(pr-review-loop): check SUCCESS status before rate-limit retry and add single-instance guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **CodeRabbit retry loop skips SUCCESS status** (`pr-review-loop.sh`): script now checks for an existing CodeRabbit SUCCESS commit status on the current HEAD before entering the rate-limit retry sleep; if SUCCESS is already present, the loop exits immediately via `coderabbit_status_success_fallback` rather than waiting indefinitely.
-- **Single-instance guard** (`pr-review-loop.sh`): added PID lock file (`/tmp/pr-review-loop-<pr>.lock`) at script startup so a second invocation for the same PR exits immediately with a clear error message rather than running in parallel.
-
 ### Added
 
 - **Sync-template manifest-driven reliability** (#252): Introduce `sync-manifest.yaml` as the authoritative file list for sync-template; add `<!-- TEMPLATE-OWNED-START -->` / `<!-- TEMPLATE-OWNED-END -->` HTML-comment annotation markers to mixed-content files (`AGENTS.md`, `.ai-dev-workflow.yaml`); update all sync-template artefacts (`.claude/commands/sync-template.md`, `.claude/skills/sync-template.md`, `.cursor/commands/sync-template.md`) to consume the manifest with graceful fallback when absent; add new Codex skill `workflow-sync-template`; update `AGENTS.md` Maintenance Commands table to include `workflow-sync-template` in the Codex column.
@@ -38,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Prepare-release protocol and command wrappers** now include a required post-merge Step 9 that runs branch cleanup plus tracker transition guidance after both release PRs merge.
 
 ### Fixed
+
+- **CodeRabbit retry loop skips SUCCESS status before retry wait** (`pr-review-loop.sh`): script now checks for an existing CodeRabbit SUCCESS commit status on the current HEAD before entering the rate-limit retry sleep; if SUCCESS is already present (and thread gate passes), the loop exits immediately via `coderabbit_status_success_fallback` rather than waiting indefinitely.
+- **Single-instance guard** (`pr-review-loop.sh`): added PID lock file (`/tmp/pr-review-loop-<pr>.lock`) at script startup so a second invocation for the same PR exits immediately with exit code 75 (EX_TEMPFAIL) and a clear error message rather than running in parallel.
 
 - **Post-agent main working tree sanity check** (#229): Protocol 90 Step 5.2 now runs immediately after each Work Item Runner returns — before PR verification, before the next dispatch, and before any action that assumes the integration branch context; the Case 1 postcondition table now documents the root-cause implication of a wrong-branch + clean result (agent ran in main tree instead of worktree). Protocol 91 post-terminal check upgraded from a single error branch to the same four-case handling (auto-correct Case 1, halt-and-escalate Cases 2 and 4, proceed Case 3) with explicit cross-reference to Protocol 90 Step 5.2.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **CodeRabbit retry loop skips SUCCESS status before retry wait** (`pr-review-loop.sh`): script now checks for an existing CodeRabbit SUCCESS commit status on the current HEAD before entering the rate-limit retry sleep; if SUCCESS is already present (and thread gate passes), the loop exits immediately via `coderabbit_status_success_fallback` rather than waiting indefinitely.
-- **Single-instance guard** (`pr-review-loop.sh`): added PID lock file (`/tmp/pr-review-loop-<pr>.lock`) at script startup so a second invocation for the same PR exits immediately with exit code 75 (EX_TEMPFAIL) and a clear error message rather than running in parallel.
+- **Single-instance guard** (`pr-review-loop.sh`): added atomic mkdir lock directory (`/tmp/pr-review-loop-<pr>.lockdir`) at script startup so a second invocation for the same PR exits immediately with `RESULT=escalate` / `REASON=lock_contention` (exit code 75) rather than running in parallel.
 
 - **Post-agent main working tree sanity check** (#229): Protocol 90 Step 5.2 now runs immediately after each Work Item Runner returns — before PR verification, before the next dispatch, and before any action that assumes the integration branch context; the Case 1 postcondition table now documents the root-cause implication of a wrong-branch + clean result (agent ran in main tree instead of worktree). Protocol 91 post-terminal check upgraded from a single error branch to the same four-case handling (auto-correct Case 1, halt-and-escalate Cases 2 and 4, proceed Case 3) with explicit cross-reference to Protocol 90 Step 5.2.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CodeRabbit retry loop skips SUCCESS status** (`pr-review-loop.sh`): script now checks for an existing CodeRabbit SUCCESS commit status on the current HEAD before entering the rate-limit retry sleep; if SUCCESS is already present, the loop exits immediately via `coderabbit_status_success_fallback` rather than waiting indefinitely.
+- **Single-instance guard** (`pr-review-loop.sh`): added PID lock file (`/tmp/pr-review-loop-<pr>.lock`) at script startup so a second invocation for the same PR exits immediately with a clear error message rather than running in parallel.
+
 ### Added
 
 - **Sync-template manifest-driven reliability** (#252): Introduce `sync-manifest.yaml` as the authoritative file list for sync-template; add `<!-- TEMPLATE-OWNED-START -->` / `<!-- TEMPLATE-OWNED-END -->` HTML-comment annotation markers to mixed-content files (`AGENTS.md`, `.ai-dev-workflow.yaml`); update all sync-template artefacts (`.claude/commands/sync-template.md`, `.claude/skills/sync-template.md`, `.cursor/commands/sync-template.md`) to consume the manifest with graceful fallback when absent; add new Codex skill `workflow-sync-template`; update `AGENTS.md` Maintenance Commands table to include `workflow-sync-template` in the Codex column.

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -12,11 +12,15 @@ source "$SCRIPT_DIR/workflow-lib.sh"
 # The guard uses PID tracking: if the PID recorded in the lock file is still alive
 # and belongs to an invocation of this script, exit immediately.
 _PR_ARG=""
+_skip_next=0
 for _arg in "$@"; do
+  if [ "$_skip_next" -eq 1 ]; then _skip_next=0; continue; fi
   case "$_arg" in
+    --branch|--platform|--poll-interval|--max-wait) _skip_next=1 ;;
     [0-9]*) _PR_ARG="$_arg"; break ;;
   esac
 done
+unset _skip_next
 _LOCK_FILE="/tmp/pr-review-loop-${_PR_ARG:-unknown}.lock"
 _OWN_LOCK=0
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -6,6 +6,31 @@ SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 # shellcheck source=scripts/development-workflow/workflow-lib.sh
 source "$SCRIPT_DIR/workflow-lib.sh"
 
+# --- Single-instance guard ---
+# Prevent two simultaneous invocations for the same PR. The lock file is stored
+# in /tmp and includes the PR number so parallel runs on different PRs are allowed.
+# The guard uses PID tracking: if the PID recorded in the lock file is still alive
+# and belongs to an invocation of this script, exit immediately.
+_PR_ARG=""
+for _arg in "$@"; do
+  case "$_arg" in
+    [0-9]*) _PR_ARG="$_arg"; break ;;
+  esac
+done
+_LOCK_FILE="/tmp/pr-review-loop-${_PR_ARG:-unknown}.lock"
+_OWN_LOCK=0
+
+if [ -f "$_LOCK_FILE" ]; then
+  _LOCK_PID="$(cat "$_LOCK_FILE" 2>/dev/null || true)"
+  if [ -n "$_LOCK_PID" ] && kill -0 "$_LOCK_PID" 2>/dev/null; then
+    echo "ERROR: pr-review-loop.sh is already running for PR #${_PR_ARG:-unknown} (PID $_LOCK_PID). Exiting to prevent parallel execution." >&2
+    exit 1
+  fi
+fi
+printf '%d\n' "$$" > "$_LOCK_FILE"
+_OWN_LOCK=1
+trap '[ "$_OWN_LOCK" -eq 1 ] && rm -f "$_LOCK_FILE"' EXIT
+
 usage() {
   cat <<'EOF'
 Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--platform greptile] [--platform greptile,devin,coderabbit] [--poll-interval seconds] [--max-wait seconds]
@@ -1067,7 +1092,37 @@ run_coderabbit_review() {
       )"
       if [ "${rate_limit_comment_count:-0}" -gt 0 ]; then
         coderabbit_rate_limit_retries=$((coderabbit_rate_limit_retries + 1))
-        echo "INFO: CodeRabbit rate limit detected (retry $coderabbit_rate_limit_retries/$coderabbit_rate_limit_max_retries) — waiting ${coderabbit_rate_limit_wait}s before re-triggering" >&2
+        echo "INFO: CodeRabbit rate limit detected (retry $coderabbit_rate_limit_retries/$coderabbit_rate_limit_max_retries) — checking for SUCCESS commit status before waiting" >&2
+        # --- Early SUCCESS check before retry wait ---
+        # Check whether CodeRabbit already posted a SUCCESS commit status for the current
+        # HEAD SHA. This happens when CodeRabbit signals the result via a commit status
+        # during a rate-limit window on a parallel batch. If found, skip the retry wait
+        # entirely and treat the PR as clean via coderabbit_status_success_fallback.
+        local coderabbit_early_success_count
+        coderabbit_early_success_count="$(
+          gh api "repos/$repo/commits/$head_sha/statuses" --paginate \
+            | jq -s '[.[].[] | select(
+                    (.context // "" | ascii_downcase | test("coderabbit"))
+                  )]
+                  | group_by(.context) | map(max_by(.updated_at))
+                  | map(select(.state == "success"))
+                  | length'
+        )"
+        if [ "${coderabbit_early_success_count:-0}" -gt 0 ]; then
+          echo "INFO: CodeRabbit SUCCESS commit-status found for HEAD $head_sha before retry wait — treating PR as clean (coderabbit_status_success_fallback)" >&2
+          print_kv RESULT clean
+          print_kv REASON coderabbit_status_success_fallback
+          print_kv PLATFORM "$platform"
+          print_kv PR_NUMBER "$pr_number"
+          print_kv BRANCH "$branch_name"
+          print_kv REVIEW_COMMENT_ID ""
+          print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+          print_kv COMMENT_COUNT 0
+          print_kv BLOCKING_COUNT 0
+          print_kv SUGGESTION_COUNT 0
+          return 0
+        fi
+        echo "INFO: no SUCCESS commit status found — waiting ${coderabbit_rate_limit_wait}s before re-triggering" >&2
         sleep "$coderabbit_rate_limit_wait"
         # Do NOT reset since_iso — keep the original HEAD-commit timestamp so any review
         # posted by CodeRabbit during or after the wait is still within the detection window.

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -7,10 +7,15 @@ SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 source "$SCRIPT_DIR/workflow-lib.sh"
 
 # --- Single-instance guard ---
-# Prevent two simultaneous invocations for the same PR. The lock file is stored
-# in /tmp and includes the PR number so parallel runs on different PRs are allowed.
-# The guard uses PID tracking: if the PID recorded in the lock file is still alive
-# and belongs to an invocation of this script, exit immediately.
+# Prevent two simultaneous invocations for the same PR. Uses an atomic mkdir
+# lock directory (POSIX-guaranteed atomic) so two concurrent callers cannot
+# both acquire the lock. The lock dir name includes the PR number so parallel
+# runs for different PRs do not interfere with each other.
+#
+# Layout:
+#   /tmp/pr-review-loop-<pr>.lockdir/   — lock directory (atomic creation)
+#   /tmp/pr-review-loop-<pr>.lockdir/pid — PID of the owner process
+#   /tmp/pr-review-loop-<pr>.lockdir/cmd — basename of script ($0) for verification
 _PR_ARG=""
 _skip_next=0
 for _arg in "$@"; do
@@ -21,19 +26,37 @@ for _arg in "$@"; do
   esac
 done
 unset _skip_next
-_LOCK_FILE="/tmp/pr-review-loop-${_PR_ARG:-unknown}.lock"
+_LOCK_DIR="/tmp/pr-review-loop-${_PR_ARG:-unknown}.lockdir"
 _OWN_LOCK=0
 
-if [ -f "$_LOCK_FILE" ]; then
-  _LOCK_PID="$(cat "$_LOCK_FILE" 2>/dev/null || true)"
-  if [ -n "$_LOCK_PID" ] && kill -0 "$_LOCK_PID" 2>/dev/null; then
+if mkdir "$_LOCK_DIR" 2>/dev/null; then
+  # We created the lock dir atomically — we own the lock.
+  printf '%d\n' "$$"           > "$_LOCK_DIR/pid"
+  printf '%s\n' "$(basename "$0")" > "$_LOCK_DIR/cmd"
+  _OWN_LOCK=1
+else
+  # Lock dir already exists — check whether the recorded owner is still alive
+  # and actually belongs to this script (guards against stale locks from crashes).
+  _LOCK_PID="$(cat "$_LOCK_DIR/pid" 2>/dev/null || true)"
+  _LOCK_CMD="$(cat "$_LOCK_DIR/cmd" 2>/dev/null || true)"
+  if [ -n "$_LOCK_PID" ] && kill -0 "$_LOCK_PID" 2>/dev/null && [ "$_LOCK_CMD" = "$(basename "$0")" ]; then
     echo "ERROR: pr-review-loop.sh is already running for PR #${_PR_ARG:-unknown} (PID $_LOCK_PID). Exiting to prevent parallel execution." >&2
     exit 75  # EX_TEMPFAIL — lock contention; not a review result (not 0/1/2)
   fi
+  # Stale lock (process gone or belongs to a different script) — reclaim atomically.
+  # Remove the stale dir and retry mkdir. If two callers reach this point
+  # simultaneously, only one mkdir will succeed; the other exits via the else branch.
+  rm -rf "$_LOCK_DIR"
+  if mkdir "$_LOCK_DIR" 2>/dev/null; then
+    printf '%d\n' "$$"           > "$_LOCK_DIR/pid"
+    printf '%s\n' "$(basename "$0")" > "$_LOCK_DIR/cmd"
+    _OWN_LOCK=1
+  else
+    echo "ERROR: pr-review-loop.sh is already running for PR #${_PR_ARG:-unknown} (concurrent startup race). Exiting to prevent parallel execution." >&2
+    exit 75
+  fi
 fi
-printf '%d\n' "$$" > "$_LOCK_FILE"
-_OWN_LOCK=1
-trap '[ "$_OWN_LOCK" -eq 1 ] && rm -f "$_LOCK_FILE"' EXIT
+trap '[ "$_OWN_LOCK" -eq 1 ] && rm -rf "$_LOCK_DIR"' EXIT
 
 usage() {
   cat <<'EOF'

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -41,7 +41,10 @@ else
   _LOCK_CMD="$(cat "$_LOCK_DIR/cmd" 2>/dev/null || true)"
   if [ -n "$_LOCK_PID" ] && kill -0 "$_LOCK_PID" 2>/dev/null && [ "$_LOCK_CMD" = "$(basename "$0")" ]; then
     echo "ERROR: pr-review-loop.sh is already running for PR #${_PR_ARG:-unknown} (PID $_LOCK_PID). Exiting to prevent parallel execution." >&2
-    exit 75  # EX_TEMPFAIL — lock contention; not a review result (not 0/1/2)
+    print_kv RESULT escalate
+    print_kv REASON lock_contention
+    print_kv PR_NUMBER "${_PR_ARG:-}"
+    exit 75  # EX_TEMPFAIL — lock contention; not a normal review result (0/1/2)
   fi
   # Stale lock (process gone or belongs to a different script) — reclaim atomically.
   # Use mv (atomic rename) to move the stale dir out of the way, then mkdir.
@@ -56,6 +59,9 @@ else
     _OWN_LOCK=1
   else
     echo "ERROR: pr-review-loop.sh is already running for PR #${_PR_ARG:-unknown} (concurrent startup race). Exiting to prevent parallel execution." >&2
+    print_kv RESULT escalate
+    print_kv REASON lock_contention
+    print_kv PR_NUMBER "${_PR_ARG:-}"
     exit 75
   fi
 fi
@@ -69,7 +75,9 @@ Runs the automated PR review loop for one or more platforms in sequence. Before
 triggering a new review, each platform checks for existing blocking findings. If
 any platform reports blocking findings, the script stops immediately and exits 1.
 If a platform times out or escalates, the script exits 2. If all configured
-platforms are clean or skipped, the script exits 0.
+platforms are clean or skipped, the script exits 0. If a second instance is
+detected for the same PR number, the script emits RESULT=escalate with
+REASON=lock_contention and exits 75 (EX_TEMPFAIL).
 
 Platform selection (in priority order):
   1. --platform flag(s) passed on the command line
@@ -78,6 +86,7 @@ Platform selection (in priority order):
 Outputs stable key=value lines including:
   RESULT=clean|needs_fixes|escalate|skipped
   PLATFORM_<n>_NAME / PLATFORM_<n>_RESULT
+  REASON=lock_contention (when exit code is 75)
 EOF
 }
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -44,9 +44,12 @@ else
     exit 75  # EX_TEMPFAIL — lock contention; not a review result (not 0/1/2)
   fi
   # Stale lock (process gone or belongs to a different script) — reclaim atomically.
-  # Remove the stale dir and retry mkdir. If two callers reach this point
-  # simultaneously, only one mkdir will succeed; the other exits via the else branch.
-  rm -rf "$_LOCK_DIR"
+  # Use mv (atomic rename) to move the stale dir out of the way, then mkdir.
+  # If two callers reach this point simultaneously, only one mv succeeds (rename
+  # is atomic on POSIX); the loser's mv fails because the source is gone. Then
+  # both try mkdir; only one succeeds and the other exits via the else branch.
+  mv "$_LOCK_DIR" "${_LOCK_DIR}.stale.$$" 2>/dev/null || true
+  rm -rf "${_LOCK_DIR}.stale.$$" 2>/dev/null || true
   if mkdir "$_LOCK_DIR" 2>/dev/null; then
     printf '%d\n' "$$"           > "$_LOCK_DIR/pid"
     printf '%s\n' "$(basename "$0")" > "$_LOCK_DIR/cmd"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -24,7 +24,7 @@ if [ -f "$_LOCK_FILE" ]; then
   _LOCK_PID="$(cat "$_LOCK_FILE" 2>/dev/null || true)"
   if [ -n "$_LOCK_PID" ] && kill -0 "$_LOCK_PID" 2>/dev/null; then
     echo "ERROR: pr-review-loop.sh is already running for PR #${_PR_ARG:-unknown} (PID $_LOCK_PID). Exiting to prevent parallel execution." >&2
-    exit 1
+    exit 75  # EX_TEMPFAIL — lock contention; not a review result (not 0/1/2)
   fi
 fi
 printf '%d\n' "$$" > "$_LOCK_FILE"
@@ -1109,18 +1109,29 @@ run_coderabbit_review() {
                   | length'
         )"
         if [ "${coderabbit_early_success_count:-0}" -gt 0 ]; then
-          echo "INFO: CodeRabbit SUCCESS commit-status found for HEAD $head_sha before retry wait — treating PR as clean (coderabbit_status_success_fallback)" >&2
-          print_kv RESULT clean
-          print_kv REASON coderabbit_status_success_fallback
-          print_kv PLATFORM "$platform"
-          print_kv PR_NUMBER "$pr_number"
-          print_kv BRANCH "$branch_name"
-          print_kv REVIEW_COMMENT_ID ""
-          print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
-          print_kv COMMENT_COUNT 0
-          print_kv BLOCKING_COUNT 0
-          print_kv SUGGESTION_COUNT 0
-          return 0
+          # SUCCESS status can appear while older CodeRabbit review threads stay unresolved
+          # on the PR. Do not short-circuit to clean until GraphQL thread audit passes —
+          # same pattern as the timeout SUCCESS fallback below.
+          local cr_early_gate_rc
+          coderabbit_thread_gate_clean "$pr_number" "$repo" "$bot_login" "$branch_name"
+          cr_early_gate_rc=$?
+          if [ "$cr_early_gate_rc" -eq 0 ]; then
+            echo "INFO: CodeRabbit SUCCESS commit-status found for HEAD $head_sha before retry wait — treating PR as clean (coderabbit_status_success_fallback)" >&2
+            print_kv RESULT clean
+            print_kv REASON coderabbit_status_success_fallback
+            print_kv PLATFORM "$platform"
+            print_kv PR_NUMBER "$pr_number"
+            print_kv BRANCH "$branch_name"
+            print_kv REVIEW_COMMENT_ID ""
+            print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+            print_kv COMMENT_COUNT 0
+            print_kv BLOCKING_COUNT 0
+            print_kv SUGGESTION_COUNT 0
+            return 0
+          fi
+          if [ "$cr_early_gate_rc" -eq 1 ] || [ "$cr_early_gate_rc" -eq 2 ]; then
+            return "$cr_early_gate_rc"
+          fi
         fi
         echo "INFO: no SUCCESS commit status found — waiting ${coderabbit_rate_limit_wait}s before re-triggering" >&2
         sleep "$coderabbit_rate_limit_wait"


### PR DESCRIPTION
## What

Fixes two related issues observed in batch 14 (PR #277):

### Fix 1: SUCCESS commit-status check before rate-limit retry wait

When CodeRabbit detects a rate limit and enters the retry loop, `pr-review-loop.sh` now checks whether a CodeRabbit SUCCESS commit status already exists for the current HEAD SHA **before** sleeping and re-triggering. If SUCCESS is already present, the script exits immediately via `coderabbit_status_success_fallback` rather than waiting indefinitely.

Previously the script detected the rate-limit comment, incremented the retry counter, slept for `CODERABBIT_RATE_LIMIT_WAIT` seconds (default 3 min), then re-triggered — even when the SUCCESS status was already available. This caused PR #277 to hang until manually killed.

### Fix 2: Single-instance PID lock guard

Added a PID-based lock file at `/tmp/pr-review-loop-<pr>.lock`. On startup the script checks whether the recorded PID is still alive. If so, it exits immediately with a clear error message. This prevents the race condition where a background task runner spawns a second shell while the first is in the retry wait loop.

## Why

Observed in batch 14: CodeRabbit hit a rate limit on PR #277. The script entered the retry wait loop but never checked whether a SUCCESS commit status already existed. Two instances were found running simultaneously, both requiring manual killing.

## Test plan

- Verify ShellCheck passes (no new warnings)
- Confirm the lock file is created on startup and cleaned up on exit
- Confirm a second invocation for the same PR exits with exit code 1 and an error message
- Confirm the SUCCESS status check path returns `RESULT=clean` and `REASON=coderabbit_status_success_fallback` when a SUCCESS status exists at rate-limit detection time

## Changes

- `scripts/development-workflow/pr-review-loop.sh`: two additions
- `CHANGELOG.md`: two `Fixed` entries under `[Unreleased]`

Closes #279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detects when CodeRabbit review has already completed for the current PR and short-circuits retry waiting (subject to gating), reducing unnecessary delays.
  * Prevents multiple simultaneous review processes for the same PR by enforcing a single active run, so duplicate invocations terminate immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->