### PR TITLE
fix(plan-writer): add verification step simplicity guidance (#280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Scope-drift guardrails for spec and plan authoring**: protocol updates now require brief-objective coverage matrices and PR-visible deferral notes in spec writing, plus live repo verification logs for pattern-based plan scope checks; review checklists and agent/skill entrypoints were aligned, and a workflow fixture was added for stale-enumeration validation.
 - **Release post-merge cleanup command** (`prepare-release-post-merge-cleanup.sh`): verifies both release PRs are merged before deleting `release/vX.Y.Z`, removes remote/local release branches safely, and transitions explicitly scoped tracker items from `Merged` to `Released`.
 
+### Fixed
+
+- **Plan verification step simplicity** (#280): added guidance to `02-generate-implementation-plan-protocol.md` requiring verification commands in Implementation Order steps to be simple and human-readable (prefer prose assertions over exact counts, avoid complex multi-flag grep one-liners); added a corresponding `important`-severity reviewer note to `REVIEW.md` Plan Review Checklist instructing plan reviewers to flag complex shell verification commands and suggest simpler "run and confirm output" assertions.
+
 ### Changed
 
 - **Rename docs/ai/ to docs/workflow/** (#251): renamed the `docs/ai/` directory to `docs/workflow/` to clarify framework ownership. Updated all cross-references across agent definitions, Cursor/Codex wrappers, scripts, protocol files, and root documentation. No content changes — pure structural refactor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Scope-drift guardrails for spec and plan authoring**: protocol updates now require brief-objective coverage matrices and PR-visible deferral notes in spec writing, plus live repo verification logs for pattern-based plan scope checks; review checklists and agent/skill entrypoints were aligned, and a workflow fixture was added for stale-enumeration validation.
 - **Release post-merge cleanup command** (`prepare-release-post-merge-cleanup.sh`): verifies both release PRs are merged before deleting `release/vX.Y.Z`, removes remote/local release branches safely, and transitions explicitly scoped tracker items from `Merged` to `Released`.
 
-### Fixed
-
-- **Plan verification step simplicity** (#280): added guidance to `02-generate-implementation-plan-protocol.md` requiring verification commands in Implementation Order steps to be simple and human-readable (prefer prose assertions over exact counts, avoid complex multi-flag grep one-liners); added a corresponding `important`-severity reviewer note to `REVIEW.md` Plan Review Checklist instructing plan reviewers to flag complex shell verification commands and suggest simpler "run and confirm output" assertions.
-
 ### Changed
 
 - **Rename docs/ai/ to docs/workflow/** (#251): renamed the `docs/ai/` directory to `docs/workflow/` to clarify framework ownership. Updated all cross-references across agent definitions, Cursor/Codex wrappers, scripts, protocol files, and root documentation. No content changes — pure structural refactor.
@@ -37,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Prepare-release protocol and command wrappers** now include a required post-merge Step 9 that runs branch cleanup plus tracker transition guidance after both release PRs merge.
 
 ### Fixed
+
+- **Plan verification step simplicity** (#280): added guidance to `02-generate-implementation-plan-protocol.md` requiring verification commands in Implementation Order steps to be simple and human-readable (prefer prose assertions over exact counts, avoid complex multi-flag grep one-liners); added a corresponding `important`-severity reviewer note to `REVIEW.md` Plan Review Checklist instructing plan reviewers to flag complex shell verification commands and suggest simpler "run and confirm output" assertions.
 
 - **Post-agent main working tree sanity check** (#229): Protocol 90 Step 5.2 now runs immediately after each Work Item Runner returns — before PR verification, before the next dispatch, and before any action that assumes the integration branch context; the Case 1 postcondition table now documents the root-cause implication of a wrong-branch + clean result (agent ran in main tree instead of worktree). Protocol 91 post-terminal check upgraded from a single error branch to the same four-case handling (auto-correct Case 1, halt-and-escalate Cases 2 and 4, proceed Case 3) with explicit cross-reference to Protocol 90 Step 5.2.
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -111,6 +111,7 @@ Typical `important` issues:
 - Vague wording like "update as needed"
 - Missing documentation/test updates
 - Incomplete dependency or rollout notes
+- Verification steps in Implementation Order steps use complex shell commands that are hard to verify by reading: flag any multi-flag grep one-liner with exclusion scopes or self-referencing globs, hardcoded file counts that go stale, or broad exclusion patterns that may silently under-count. Suggest replacing with a human-readable "run and confirm output" assertion instead.
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -100,6 +100,11 @@ docs/specs/developments/[timestamp]_[feature-slug]/2_[feature-slug]_implementati
 - **Explicit freeze exception**: You may copy a fixed enumeration only when the spec explicitly freezes scope to a named subset; quote that spec section in the plan.
 - **Verification Log required**: Every plan must include a reproducible Verification Log (command/query, repo SHA, and resulting counts/paths that drive scope statements).
 - **CHANGELOG literal format**: When the Implementation Order includes a literal CHANGELOG entry for the developer to copy, it must follow the project's `**Bold Title** (#N):` format (e.g., `- **Fix tech-lead CHANGELOG format** (#226): ...`). Never use conventional-commit format (`fix(scope): message`) in a CHANGELOG literal — that format is for git commit messages, not CHANGELOG entries. The impl agent will copy the literal verbatim; a wrong format wastes a reviewer cycle.
+- **Verification command simplicity**: Verification steps in Implementation Order steps must be simple and human-readable. Follow these rules:
+  - Prefer prose assertions ("confirm the output lists only the renamed files") over exact file counts or byte counts.
+  - Avoid multi-flag grep one-liners that are difficult to verify by reading (e.g., complex exclusion scopes, self-referencing exclusion globs, chained pipes with hard-coded counts).
+  - For mass-rename or substitution operations: include an explicit "run the command and confirm the output matches expectations" sanity check rather than prescribing the exact expected count — counts go stale as the repo evolves and breed fix commits when reviewers find mismatches.
+  - A verification step is correct if a developer can execute it, read the output, and confidently determine pass/fail without consulting an external reference.
 
 ### Parser-risk plans: custom parsers, regex, and structured-text scanning
 


### PR DESCRIPTION
## Summary

Fixes #280.

Plans with complex shell verification commands in their Implementation Order steps accumulate excessive fix commits during review — reviewers (Devin, CodeRabbit) flag incorrect grep exclusion scopes, wrong file counts, self-referencing exclusion logic, and stale counts that looked correct at plan-write time but drifted.

### Changes

**`docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md`**  
Added a `Verification command simplicity` bullet to the Quality guardrails section of Step 3. Guidance:
- Prefer prose assertions over exact counts
- Avoid multi-flag grep one-liners with complex exclusion scopes
- For mass-rename/substitution operations: use "run and confirm output" sanity checks, not hard-coded expected counts
- A verification step passes if a developer can execute it and confidently determine pass/fail without consulting an external reference

**`REVIEW.md`** (Plan Review Checklist)  
Added a `Typical important issues` bullet instructing plan reviewers to flag complex shell verification commands (multi-flag greps, hardcoded counts, broad exclusion globs) and suggest simpler human-readable assertions.

**`CHANGELOG.md`**  
Added entry under `[Unreleased] > Fixed`.

### Complexity

Small (S) — documentation-only change to two protocol/review files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added changelog entry noting documentation updates.
  * Require simple, human-readable verification assertions in implementation plans (avoid brittle exact-count or complex shell one-liners).
  * Updated reviewer checklist to flag overly complex verification steps and recommend “run and confirm output” style checks.
  * Emphasized explicit sanity checks for bulk rename/substitution operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->