### PR TITLE
fix(developer-agent): mass-rename refactors miss display-text and directory-tree reference types (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Mass-rename reference-type coverage** (#281): `03-implement-development-protocol.md` Refactor path now includes a mandatory mass-rename sub-step requiring post-substitution verification of three reference categories — link targets (both href and display text when text mirrors the old path), display text in already-updated links, and non-link occurrences (prose, code blocks, directory trees, YAML values) — plus a residual-occurrence grep command to confirm no old-string instances remain before staging.
+
 - **Post-agent main working tree sanity check** (#229): Protocol 90 Step 5.2 now runs immediately after each Work Item Runner returns — before PR verification, before the next dispatch, and before any action that assumes the integration branch context; the Case 1 postcondition table now documents the root-cause implication of a wrong-branch + clean result (agent ran in main tree instead of worktree). Protocol 91 post-terminal check upgraded from a single error branch to the same four-case handling (auto-correct Case 1, halt-and-escalate Cases 2 and 4, proceed Case 3) with explicit cross-reference to Protocol 90 Step 5.2.
 
 - **MD047 trailing-newline pre-staging check** (#227): `03-implement-development-protocol.md` (all four paths) now includes an explicit MD047 check that scans every modified `.md` file for a missing trailing newline before `git add`; `.claude/agents/developer.md` and `.cursor/agents/developer.md` key-rules sections were updated with the matching rule (parity with the #178 trailing-whitespace step).

--- a/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
@@ -270,6 +270,33 @@ git checkout -b refactor/[branch-slug]
 ```
 
 3. Implement following the plan order. Follow `docs/best-practices/` for all code written.
+
+   **Mass-rename sub-step (applies when the refactor renames a path, identifier, or string across multiple files):**
+
+   After performing any global substitution (find-and-replace, `sed`, `git mv`, or IDE rename), verify all three reference categories before committing:
+
+   | Category | What to check | Example pattern |
+   |---|---|---|
+   | **Link targets** | `[text](old-path)` — both the link target and `text` when text mirrors the old path | `[docs/ai/old](docs/workflow/old)` |
+   | **Display text in links** | `[old-path-text](new-path)` — link target already updated but display text still shows the old string | `[docs/ai/old](docs/workflow/new)` |
+   | **Non-link occurrences** | Bare old-string in prose, code blocks, directory trees, YAML values, and shell scripts | `docs/ai/old` inside a code fence |
+
+   Run a residual-occurrence check immediately after the substitution and before staging:
+
+   ```bash
+   # Replace "old-string" with the actual old path / identifier being renamed
+   grep -r "old-string" . --include="*.md" --include="*.yaml" --include="*.sh" \
+     --exclude-dir=".git" --exclude-dir="worktrees" -l
+   # Output should be empty, or contain only files where the old string
+   # appears intentionally as subject-matter text (e.g., a CHANGELOG entry
+   # describing the rename, or a comment explaining the old name).
+   ```
+
+   For each file listed in the output:
+   1. Open it and confirm whether the occurrence is intentional (e.g., historical CHANGELOG entry, explanatory comment) or a missed substitution.
+   2. Fix every missed substitution before staging.
+   3. Re-run the check until the output contains only intentional occurrences.
+
 4. If scope is larger than the plan described, **stop and report**
 5. Verify: build, lint, tests pass; run e2e suite if a spec exists for the affected area
 6. Update CHANGELOG under `[Unreleased]` with a `Changed` entry (skip if this refactor adjusts unreleased work that already has an entry — update the existing entry instead, or leave it unchanged if it already describes the correct behavior).

--- a/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
@@ -285,7 +285,7 @@ git checkout -b refactor/[branch-slug]
 
    ```bash
    # Replace "old-string" with the actual old path / identifier being renamed
-   grep -r "old-string" . --include="*.md" --include="*.yaml" --include="*.yml" --include="*.sh" \
+   grep -r "old-string" . --include="*.md" --include="*.mdc" --include="*.yaml" --include="*.yml" --include="*.sh" \
      --exclude-dir=".git" --exclude-dir="worktrees" -l
    # Output should be empty, or contain only files where the old string
    # appears intentionally as subject-matter text (e.g., a CHANGELOG entry

--- a/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
@@ -277,7 +277,7 @@ git checkout -b refactor/[branch-slug]
 
    | Category | What to check | Example pattern |
    |---|---|---|
-   | **Link targets** | `[text](old-path)` — both the link target and `text` when text mirrors the old path | `[docs/ai/old](docs/workflow/old)` |
+   | **Link targets** | `[text](old-path)` — both the link target and `text` when text mirrors the old path | `[docs/ai/old](docs/ai/old)` |
    | **Display text in links** | `[old-path-text](new-path)` — link target already updated but display text still shows the old string | `[docs/ai/old](docs/workflow/new)` |
    | **Non-link occurrences** | Bare old-string in prose, code blocks, directory trees, YAML values, and shell scripts | `docs/ai/old` inside a code fence |
 

--- a/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
@@ -285,7 +285,7 @@ git checkout -b refactor/[branch-slug]
 
    ```bash
    # Replace "old-string" with the actual old path / identifier being renamed
-   grep -r "old-string" . --include="*.md" --include="*.yaml" --include="*.sh" \
+   grep -r "old-string" . --include="*.md" --include="*.yaml" --include="*.yml" --include="*.sh" \
      --exclude-dir=".git" --exclude-dir="worktrees" -l
    # Output should be empty, or contain only files where the old string
    # appears intentionally as subject-matter text (e.g., a CHANGELOG entry


### PR DESCRIPTION
## What

Adds a mandatory mass-rename verification sub-step to **Path 2: Refactor** in `03-implement-development-protocol.md`.

## Why

PR #275 (a directory rename refactor) required 4 fix commits because the initial substitution missed:
1. Display text in markdown links where the text mirrors the old path
2. Directory tree strings inside code blocks
3. Bare path strings in prose sentences

## Changes

- **`docs/workflow/development-workflow/protocols/03-implement-development-protocol.md`**: Added a "Mass-rename sub-step" within the Refactor Steps implementation step. The sub-step:
  - Lists three reference categories to verify: link targets (both href + display text), display text in already-updated links, and non-link occurrences (prose, code blocks, directory trees, YAML)
  - Provides a residual-occurrence grep command to run after substitution
  - Requires re-running until only intentional occurrences remain

- **`CHANGELOG.md`**: Added `Fixed` entry under `[Unreleased]` for #281

## Test Plan

- Verify the new mass-rename sub-step appears in Path 2 (Refactor) of `03-implement-development-protocol.md`
- Verify the three reference categories and the grep command are present and accurate
- Verify CHANGELOG entry is present under `[Unreleased] > Fixed`
- No functional behavior changed — documentation only

## Related

Closes #281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a verification sub-step for mass-rename/refactor workflows to validate link targets, mirrored display text, and residual occurrences across prose, code blocks, directory listings, and configuration files.
* **Changelog**
  * Added a "Fixed" entry documenting the new verification step and the requirement to run a targeted residual-occurrence check until only intentional matches remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->