### PR TITLE
backport: v0.23.0 CHANGELOG to develop

### DIFF
--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -251,8 +251,17 @@ rm -rf /tmp/template-sync-*
 Before printing the git instructions, record the last-synced template version:
 
 1. Read `.ai-dev-workflow.yaml` from the project root.
-2. Set (or update) `template.last_synced_version` to `v{TEMPLATE_VERSION}` under the `template:` key. If the `template:` key does not exist yet, append the section after the `browser_automation:` block.
-3. Print: `Recorded last-synced template version: v{TEMPLATE_VERSION}`
+2. Use `yq` to safely update the template section. If the `template:` key does not exist, create it with both required fields (see schema below); if it exists, update only `last_synced_version`. Insert new sections after the `browser_automation:` block.
+   - Schema for new `template:` section:
+     ```yaml
+     template:
+       repository: ""
+       last_synced_version: "v{TEMPLATE_VERSION}"
+     ```
+   - Command to update existing section: `yq eval '.template.last_synced_version = "v{TEMPLATE_VERSION}"' -i .ai-dev-workflow.yaml`
+   - Command to create new section (if missing): Use a YAML library or insert the schema block above after verifying the file is valid YAML and not malformed.
+   - Error handling: If `.ai-dev-workflow.yaml` does not exist or is malformed YAML, abort with error: "Error: cannot modify .ai-dev-workflow.yaml — file does not exist or is malformed. Please fix the file manually before retrying."
+3. Print: `Recorded last-synced template version: v{TEMPLATE_VERSION}` (only after successful write)
 
 Then print ready-to-use git instructions (do not execute them — let the user run them after reviewing the changes):
 

--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -265,6 +265,8 @@ git add REVIEW.md docs/workflow/ .claude/agents/ .claude/commands/ .claude/skill
   docs/best-practices/3-testing.md
 # If sync-manifest.yaml was updated, stage it as well:
 git add sync-manifest.yaml
+# Stage the updated last_synced_version field:
+git add .ai-dev-workflow.yaml
 git commit -m "chore(template): sync framework updates from template v{TEMPLATE_VERSION}"
 
 # 4. Push and open PR

--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -259,7 +259,7 @@ Before printing the git instructions, record the last-synced template version:
        last_synced_version: "v{TEMPLATE_VERSION}"
      ```
    - Command to update existing section: `yq eval '.template.last_synced_version = "v{TEMPLATE_VERSION}"' -i .ai-dev-workflow.yaml`
-   - Command to create new section (if missing): Use a YAML library or insert the schema block above after verifying the file is valid YAML and not malformed.
+   - Command to create new section (if missing): `yq eval '.template.repository = "" | .template.last_synced_version = "v{TEMPLATE_VERSION}"' -i .ai-dev-workflow.yaml` (yq will create the `template:` key if absent; key order in YAML is cosmetic, so exact positioning after `browser_automation:` is not critical)
    - Error handling: If `.ai-dev-workflow.yaml` does not exist or is malformed YAML, abort with error: "Error: cannot modify .ai-dev-workflow.yaml — file does not exist or is malformed. Please fix the file manually before retrying."
 3. Print: `Recorded last-synced template version: v{TEMPLATE_VERSION}` (only after successful write)
 

--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -248,7 +248,13 @@ rm -rf /tmp/template-sync-*
 
 ## Step 5 — Generate git instructions
 
-Print ready-to-use git instructions (do not execute them — let the user run them after reviewing the changes):
+Before printing the git instructions, record the last-synced template version:
+
+1. Read `.ai-dev-workflow.yaml` from the project root.
+2. Set (or update) `template.last_synced_version` to `v{TEMPLATE_VERSION}` under the `template:` key. If the `template:` key does not exist yet, append the section after the `browser_automation:` block.
+3. Print: `Recorded last-synced template version: v{TEMPLATE_VERSION}`
+
+Then print ready-to-use git instructions (do not execute them — let the user run them after reviewing the changes):
 
 ```bash
 # 1. Create a sync branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.23.0] - 2026-04-25
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.23.0] - 2026-04-25
 
 ### Added
@@ -478,7 +480,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.22.0...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.23.0...HEAD
+[0.23.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.19.0...v0.20.0


### PR DESCRIPTION
## Backport v0.23.0 CHANGELOG to develop

Backports the `[Unreleased]` → `[0.23.0] - 2026-04-25` rename from `release/v0.23.0` into `develop`.

**Merge this after PR #332 (release → main) is merged.**

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Version 0.23.0 released (2026-04-25); changelog updated with a new 0.23.0 entry and adjusted compare links so Unreleased now compares from 0.23.0 → HEAD and a dedicated range exists for 0.22.0 → 0.23.0

* **Chores**
  * Template sync flow updated so generated git steps record and stage the template sync version, with clearer abort/error messaging and a confirmation only after successful write
<!-- end of auto-generated comment: release notes by coderabbit.ai -->