### PR TITLE
backport: v0.23.1 hotfix CHANGELOG to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.1] - 2026-04-26
+
+### Fixed
+
+- **Bot login format mismatch in GraphQL thread audit** (`pr-review-loop.sh`):
+  `bot_login_for_platform()` passed `[bot]`-suffixed bot logins to `check_unresolved_threads`,
+  but the GitHub GraphQL API returns `author.login` without the suffix for bot-authored comments.
+  The string comparison always failed, causing the unresolved thread gate to report zero unresolved
+  threads even when unresolved bot threads existed. Fixed by removing the `[bot]` suffix from
+  `bot_login_for_platform()` return values to match the GraphQL API contract. Updated documentation
+  and smoke test to reflect that GraphQL returns bare bot login strings.
+
 ## [Unreleased]
 
 ### Added
@@ -484,7 +496,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.23.0...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.23.1...HEAD
+[0.23.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.20.0...v0.21.0


### PR DESCRIPTION
## Backport v0.23.1 CHANGELOG to develop

Adds the `[0.23.1]` hotfix section to `develop`'s CHANGELOG and updates the `[Unreleased]` link reference to compare from `v0.23.1...HEAD`.

All code changes from the hotfix (`pr-review-loop.sh` bot login fix, sync-template yq improvements) were already present on `develop` — this PR carries only the CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed unresolved thread detection in GraphQL thread audit incorrectly reporting zero results when bot accounts were involved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->