### PR TITLE
fix(workflow-lib): use parameterized variables for GraphQL mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Sync-template migration notes** (`sync-manifest.yaml`, sync-template skill and commands): `sync-manifest.yaml` gains a `migration_notes` section for versioned manual migration steps. The sync-template skill and command variants now read this section and present a required pre-sync checklist whenever the downstream project's `last_synced_version` predates a breaking structural change. First entry: `docs/ai/ → docs/workflow/` rename (v0.23.0). Fully backwards-compatible — silently skipped when no applicable notes exist.
 
+### Fixed
+
+- **Shell variable interpolation in GraphQL mutation** (`workflow-lib.sh`): `update_tracker_status_best_effort` was interpolating `${project_id}`, `${item_id}`, `${field_id}`, and `${option_id}` directly into the query string. Switched to `-f` parameterized variables with a typed mutation signature (`$projectId: ID!`, `$itemId: ID!`, `$fieldId: ID!`, `$optionId: String!`), eliminating the injection risk and aligning with the safe pattern used elsewhere in the codebase.
+
 ## [0.23.0] - 2026-04-25
 
 ### Added

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -389,16 +389,21 @@ update_tracker_status_best_effort() {
   fi
 
   echo "Updating tracker status for issue #${issue_number} to '${status_label}'..."
-  gh api graphql -f query="
-    mutation {
-      updateProjectV2ItemFieldValue(input: {
-        projectId: \"${project_id}\"
-        itemId: \"${item_id}\"
-        fieldId: \"${field_id}\"
-        value: { singleSelectOptionId: \"${option_id}\" }
-      }) {
-        projectV2Item { id }
+  gh api graphql \
+    -F projectId="$project_id" \
+    -F itemId="$item_id" \
+    -F fieldId="$field_id" \
+    -F optionId="$option_id" \
+    -f query='
+      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+        updateProjectV2ItemFieldValue(input: {
+          projectId: $projectId
+          itemId: $itemId
+          fieldId: $fieldId
+          value: { singleSelectOptionId: $optionId }
+        }) {
+          projectV2Item { id }
+        }
       }
-    }
-  " 2>/dev/null || echo "Warning: GraphQL mutation failed for issue #${issue_number}; tracker status not updated."
+    ' 2>/dev/null || echo "Warning: GraphQL mutation failed for issue #${issue_number}; tracker status not updated."
 }

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -390,10 +390,10 @@ update_tracker_status_best_effort() {
 
   echo "Updating tracker status for issue #${issue_number} to '${status_label}'..."
   gh api graphql \
-    -F projectId="$project_id" \
-    -F itemId="$item_id" \
-    -F fieldId="$field_id" \
-    -F optionId="$option_id" \
+    -f projectId="$project_id" \
+    -f itemId="$item_id" \
+    -f fieldId="$field_id" \
+    -f optionId="$option_id" \
     -f query='
       mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
         updateProjectV2ItemFieldValue(input: {


### PR DESCRIPTION
## Summary

- `update_tracker_status_best_effort` in `workflow-lib.sh` was interpolating `${project_id}`, `${item_id}`, `${field_id}`, `${option_id}` directly into the GraphQL query string. Switched to `-F` parameterized variables with a typed mutation signature (`$projectId: ID!` etc.), matching the safe pattern used elsewhere in the codebase.
- Found by cross-referencing fixes in downstream sync PR lhpaul/seia#249.

## Test plan

- [ ] `bash -n scripts/development-workflow/workflow-lib.sh` passes (syntax clean)
- [ ] `post-merge-cleanup.sh` invocation that triggers a tracker status update sends a well-formed GraphQL mutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
