### PR TITLE
fix(orchestrator): add pre-dispatch stale-worktree check (Step 3.3) (#323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pre-dispatch stale-worktree and unsynced-base-branch check** (`90-batch-orchestrate-work-protocol.md`): Added Step 3.3 "Pre-Dispatch Environment Validation" to the Portfolio Orchestrator protocol. The new step runs two portfolio-wide checks before any Work Item Runner is dispatched: (1) detect orphaned/locked worktrees from prior runs whose branches are merged, closed, or no longer active — report them with suggested `git worktree remove --force` cleanup commands and block dispatch until resolved; (2) verify the integration branch is not ahead of `origin` — if it is, warn the human and block dispatch until the pending commits are pushed or the risk is explicitly acknowledged. Both checks run in parallel and are reported together to minimize human interruptions.
+
 - **Shell variable interpolation in GraphQL mutation** (`workflow-lib.sh`): `update_tracker_status_best_effort` was interpolating `${project_id}`, `${item_id}`, `${field_id}`, and `${option_id}` directly into the query string. Switched to `-f` parameterized variables with a typed mutation signature (`$projectId: ID!`, `$itemId: ID!`, `$fieldId: ID!`, `$optionId: String!`), eliminating the injection risk and aligning with the safe pattern used elsewhere in the codebase.
 
 ## [0.23.0] - 2026-04-25

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -319,9 +319,11 @@ Scan the full worktree list for orphaned entries — worktrees whose branch is e
 
 ```bash
 # List all registered worktrees and their branches
+# (This step runs from the main repo root; REPO_ROOT resolves correctly in all contexts)
+REPO_ROOT=$(git rev-parse --git-common-dir)/..
 git worktree list --porcelain \
   | awk '/^worktree / { wt=$2 } /^branch / { b=$2; sub("^refs/heads/","",b); print wt "\t" b }' \
-  | grep -v "^$(git rev-parse --show-toplevel)"
+  | grep -v "^${REPO_ROOT}"
 ```
 
 For each worktree found, check whether its branch has already been merged to the integration branch (i.e., the PR is merged and the branch is no longer active):

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -319,8 +319,8 @@ Scan the full worktree list for orphaned entries — worktrees whose branch is e
 
 ```bash
 # List all registered worktrees and their branches
-# (This step runs from the main repo root; REPO_ROOT resolves correctly in all contexts)
-REPO_ROOT=$(git rev-parse --git-common-dir)/..
+# (Resolve REPO_ROOT to an absolute path so it matches git worktree list's absolute output)
+REPO_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 git worktree list --porcelain \
   | awk '/^worktree / { wt=$2 } /^branch / { b=$2; sub("^refs/heads/","",b); print wt "\t" b }' \
   | grep -v "^${REPO_ROOT}"

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -318,12 +318,12 @@ Before building the worktree per-item pre-flight (Step 3.5), run two portfolio-w
 Scan the full worktree list for orphaned entries — worktrees whose branch is either merged, closed, or no longer needed by the current batch. These lock the `.git` index against concurrent operations and prevent clean worktree creation for items in the new batch.
 
 ```bash
-# List all registered worktrees and their branches
-# (Resolve REPO_ROOT to an absolute path so it matches git worktree list's absolute output)
+# List all registered worktrees and their branches, excluding the main worktree
+# (Resolve REPO_ROOT to an absolute path; use exact awk comparison to avoid
+# prefix-match false exclusions for nested worktrees under the repo root)
 REPO_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 git worktree list --porcelain \
-  | awk '/^worktree / { wt=$2 } /^branch / { b=$2; sub("^refs/heads/","",b); print wt "\t" b }' \
-  | grep -v "^${REPO_ROOT}"
+  | awk -v root="$REPO_ROOT" '/^worktree / { wt=$2 } /^branch / { b=$2; sub("^refs/heads/","",b); if (wt != root) print wt "\t" b }'
 ```
 
 For each worktree found, check whether its branch has already been merged to the integration branch (i.e., the PR is merged and the branch is no longer active):

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -309,6 +309,89 @@ Do **not** dispatch multiple Work Item Runners to operate in the same working di
 
 ---
 
+## Step 3.3: Pre-Dispatch Environment Validation (Parallel Batches Only)
+
+Before building the worktree per-item pre-flight (Step 3.5), run two portfolio-wide environment checks. Both checks must pass before any Work Item Runner is dispatched.
+
+### Check 1: Stale orphaned worktrees
+
+Scan the full worktree list for orphaned entries — worktrees whose branch is either merged, closed, or no longer needed by the current batch. These lock the `.git` index against concurrent operations and prevent clean worktree creation for items in the new batch.
+
+```bash
+# List all registered worktrees and their branches
+git worktree list --porcelain \
+  | awk '/^worktree / { wt=$2 } /^branch / { b=$2; sub("^refs/heads/","",b); print wt "\t" b }' \
+  | grep -v "^$(git rev-parse --show-toplevel)"
+```
+
+For each worktree found, check whether its branch has already been merged to the integration branch (i.e., the PR is merged and the branch is no longer active):
+
+```bash
+# For each candidate worktree branch <branch>:
+# A branch is "stale" if its PR was merged and no matching open PR exists any more
+gh pr list --state merged --head <branch> --json number,mergedAt --jq '.[0] | .number'
+# Non-empty output → merged; the worktree is stale and safe to remove
+```
+
+**Stale detection criteria** (a worktree is stale when **any** of the following is true):
+
+- Its branch has a merged PR (`gh pr list --state merged --head <branch>` returns a result)
+- Its branch has a closed PR with no open successor (`gh pr list --state all --head <branch>` shows only closed PRs)
+- Its branch no longer exists on the remote and is not part of the current batch (`git ls-remote --exit-code origin <branch>` returns non-zero)
+
+**Action when stale worktrees are found:**
+
+1. List every stale worktree with its path and branch name.
+2. Report them to the human with suggested cleanup commands:
+
+   ```bash
+   git worktree remove --force <worktree-path>   # use --force only when the worktree is locked
+   ```
+
+3. **Do not auto-remove** worktrees without human confirmation — a locked worktree may contain in-progress work that the human has not discarded yet.
+4. If the human confirms cleanup, remove each stale worktree and then continue.
+5. If the human cannot confirm at this time, **hold the batch dispatch** and report the blocking condition. Do not attempt to create new worktrees until the stale ones are resolved, as locked worktrees can interfere with subsequent `git worktree add` calls.
+
+**Worktrees that belong to the current batch**: Do not flag an active worktree as stale if its branch is one of the branches about to be dispatched. Those are handled by the per-item Step 3.5 check.
+
+### Check 2: Unsynced integration branch
+
+Before dispatching any Work Item Runner, verify that the local integration branch is not ahead of `origin`. New feature/fix branches are cut from the local integration branch; if the local branch has commits that are not yet on `origin`, those commits will appear in every new implementation PR's diff, causing incorrect diffs and confusing reviewers.
+
+```bash
+INTEGRATION_BRANCH="develop"   # or read from .ai-dev-workflow.yaml if a config key exists
+
+# Fetch latest remote state (idempotent, safe to run at the start of every batch)
+git fetch origin
+
+# Count commits that are local-only (ahead of origin)
+AHEAD=$(git rev-list --count "origin/${INTEGRATION_BRANCH}..${INTEGRATION_BRANCH}" 2>/dev/null || echo "0")
+echo "Integration branch '${INTEGRATION_BRANCH}' is ${AHEAD} commits ahead of origin."
+```
+
+**Action when the integration branch is ahead of origin:**
+
+1. Report to the human: the local `<integration-branch>` is `N` commits ahead of `origin/<integration-branch>`.
+2. Ask the human to push the pending commits before batch dispatch:
+
+   ```bash
+   git push origin <integration-branch>
+   ```
+
+3. **Block batch dispatch** until either:
+   - The human pushes the pending commits (re-run the check after push; `AHEAD` must be `0`)
+   - The human explicitly acknowledges the risk and instructs the orchestrator to proceed anyway (log this override in retrospective notes)
+
+**Safe condition**: `AHEAD=0` — the integration branch is in sync with `origin`. Proceed to Step 3.5.
+
+### Check ordering and gating
+
+Run Check 1 and Check 2 in parallel. Both must pass (or be explicitly acknowledged by the human) before proceeding to the per-item Step 3.5 checks and batch dispatch.
+
+If either check identifies a blocking condition, report **both** results together so the human can resolve all issues in a single interaction rather than being interrupted twice.
+
+---
+
 ## Step 3.5: Pre-Flight Worktree Check (Parallel Batches Only)
 
 Before dispatching a parallel batch, validate that each item can be isolated.


### PR DESCRIPTION
## Summary

Adds **Step 3.3: Pre-Dispatch Environment Validation** to `90-batch-orchestrate-work-protocol.md`, inserting a portfolio-wide environment validation phase before the per-item Step 3.5 (Pre-Flight Worktree Check).

### What this fixes

At the start of batch orchestration sessions, two environment conditions can silently delay or corrupt a batch:

1. **Stale orphaned worktrees** from prior runs (e.g., plan-writing) are still registered and locked. `git worktree add` for new items can fail or behave unexpectedly until these are removed. Previously the orchestrator had no protocol step to detect and clean them up.

2. **Unsynced integration branch**: if the local `develop` branch is ahead of `origin/develop` (e.g., plan PRs merged locally but not pushed), new feature branches cut from it will include those unpushed commits in their diffs, confusing reviewers and CI.

### Changes

- **`docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`**: Adds Step 3.3 between Step 3 (batch building) and Step 3.5 (per-item pre-flight). Step 3.3 defines:
  - Check 1: scan `git worktree list --porcelain` for orphaned worktrees; detect stale ones by checking if their branch has a merged/closed PR or no remote ref; report with `git worktree remove --force` commands; block dispatch until resolved.
  - Check 2: run `git fetch origin` then check `git rev-list --count origin/<branch>..<branch>` to detect local-only commits; if ahead, warn the human and block dispatch until synced or risk is acknowledged.
  - Both checks run in parallel and are reported together.

- **`CHANGELOG.md`**: Adds entry under `[Unreleased] ### Fixed`.

Closes #323.