### PR TITLE
fix(reviewer-loop): verify claimed commits exist in git log before reporting a finding as resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Commit SHA verification before marking reviewer findings resolved** (`91-orchestrate-work-protocol.md`, `93-automated-reviewer-loop-protocol.md`): Added a mandatory commit SHA verification step requiring agents to confirm a cited commit exists in `git log` before recording it as `resolved_commit` in the PR feedback ledger and before posting fix commit comments. If the SHA is absent, the agent must commit staged changes first and use the real SHA from `git log`. Prevents fabricated SHA references (as observed in PR #321) from propagating into the audit trail and causing PRs to be labeled `ready-for-human-review` with uncommitted fixes.
+
 - **Shell variable interpolation in GraphQL mutation** (`workflow-lib.sh`): `update_tracker_status_best_effort` was interpolating `${project_id}`, `${item_id}`, `${field_id}`, and `${option_id}` directly into the query string. Switched to `-f` parameterized variables with a typed mutation signature (`$projectId: ID!`, `$itemId: ID!`, `$fieldId: ID!`, `$optionId: String!`), eliminating the injection risk and aligning with the safe pattern used elsewhere in the codebase.
 
 ## [0.23.0] - 2026-04-25

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -684,6 +684,29 @@ Maintain a **PR feedback ledger** alongside the cycle counter. Each entry tracks
 - After each fixer push + re-review: any open entry whose key no longer appears in the new output is marked `resolved` with the fixer's commit SHA.
 - When the loop terminates: any still-open entry is marked `unresolved`.
 
+#### Commit SHA verification (mandatory before marking resolved)
+
+Before recording a `resolved_commit` SHA in any ledger entry and before posting the fix commit comment, the agent **must** verify that the cited commit actually exists in the repository:
+
+```bash
+git log --oneline | grep "^<short_sha>"
+# or equivalently:
+git rev-parse --verify <short_sha>^ 2>/dev/null && echo "exists" || echo "not found"
+```
+
+If the SHA is not found in `git log`, the agent must **not** record it as the `resolved_commit` and must **not** claim the finding is resolved. Instead, the agent must commit any staged or unstaged changes first, obtain the real commit SHA from `git log`, and then record that SHA:
+
+```bash
+# If changes exist but were never committed:
+git add <changed-files>
+git commit -m "<commit message>"
+REAL_SHA=$(git log --oneline -1 | awk '{print $1}')
+```
+
+**Rationale**: An agent may edit files in a worktree and mentally track a planned commit SHA without ever running `git commit`. Recording a non-existent SHA in the ledger produces an audit trail that cannot be verified, misleads human reviewers who inspect the commit history, and can cause the PR to be labeled `ready-for-human-review` with uncommitted fixes. The verification step is the only reliable guard against this class of error.
+
+**Escalation if commit fails**: If `git commit` fails (e.g., due to a pre-commit hook or empty diff), the agent must investigate and resolve the failure before marking any finding resolved. Do not silently skip the commit and record a fabricated SHA.
+
 #### Fix commit comment
 
 Post via `gh pr comment` immediately after updating the ledger following a fixer push:

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -691,7 +691,7 @@ Before recording a `resolved_commit` SHA in any ledger entry and before posting 
 ```bash
 git log --oneline | grep "^<short_sha>"
 # or equivalently:
-git rev-parse --verify <short_sha>^ 2>/dev/null && echo "exists" || echo "not found"
+git rev-parse --verify <short_sha> 2>/dev/null && echo "exists" || echo "not found"
 ```
 
 If the SHA is not found in `git log`, the agent must **not** record it as the `resolved_commit` and must **not** claim the finding is resolved. Instead, the agent must commit any staged or unstaged changes first, obtain the real commit SHA from `git log`, and then record that SHA:

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -73,6 +73,31 @@ Do not assume the latest bot comment is the only active issue. A fixer may addre
 
 This prevents premature dismissal of findings and ensures the PR feedback tracking ledger accurately reflects substantive code changes.
 
+#### Commit SHA verification (mandatory before marking resolved)
+
+Before citing any commit SHA in a fix comment or marking a finding resolved in the PR feedback ledger, the agent **must** verify the commit actually exists in the repository:
+
+```bash
+git log --oneline | grep "^<short_sha>"
+# or equivalently:
+git rev-parse --verify <short_sha>^ 2>/dev/null && echo "exists" || echo "not found"
+```
+
+If the SHA is **not found**, the agent must **not** record it as the resolved commit and must **not** claim the finding is resolved. Instead:
+
+1. Run `git status` to check for uncommitted changes.
+2. If changes are present but not committed, commit them:
+   ```bash
+   git add <changed-files>
+   git commit -m "<commit message>"
+   REAL_SHA=$(git log --oneline -1 | awk '{print $1}')
+   ```
+3. Use the real SHA returned by `git log` — never a remembered or planned SHA.
+
+**Rationale**: An agent may edit files and internally track a planned commit SHA without ever running `git commit`. Citing a SHA that does not exist in `git log` produces a false audit trail, misleads human reviewers, and can result in the PR being labeled `ready-for-human-review` with uncommitted fixes that will be silently lost on branch cleanup.
+
+**Escalation**: If `git commit` fails (e.g., pre-commit hook rejection or empty diff), investigate and resolve the failure before marking any finding resolved. Do not fabricate a SHA or skip the commit step.
+
 #### Stale review after timeout
 
 Also handle the case where a platform posted blocking findings after a previous run timed out and the agent moved on: if those findings are still unresolved per the rules above, dispatch a fixer, wait for the push, then run the scripts.

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -80,7 +80,7 @@ Before citing any commit SHA in a fix comment or marking a finding resolved in t
 ```bash
 git log --oneline | grep "^<short_sha>"
 # or equivalently:
-git rev-parse --verify <short_sha>^ 2>/dev/null && echo "exists" || echo "not found"
+git rev-parse --verify <short_sha> 2>/dev/null && echo "exists" || echo "not found"
 ```
 
 If the SHA is **not found**, the agent must **not** record it as the resolved commit and must **not** claim the finding is resolved. Instead:


### PR DESCRIPTION
## Summary

Closes #329.

When an automated-reviewer-loop agent reports fixing a finding and cites a commit SHA, the protocol now requires the agent to verify the SHA actually exists in `git log` before marking the thread as resolved. If the SHA does not exist, the agent must commit the staged changes first and use the real SHA obtained from `git log`.

### Changes

- **`91-orchestrate-work-protocol.md`**: Added "Commit SHA verification (mandatory before marking resolved)" subsection under the PR feedback ledger "Ledger updates" block in Step 7. Requires `git log | grep <sha>` (or `git rev-parse --verify`) before recording any `resolved_commit`. Specifies the recovery path (commit staged changes, get real SHA) and escalation rules for commit failures.

- **`93-automated-reviewer-loop-protocol.md`**: Added matching "Commit SHA verification (mandatory before marking resolved)" subsection in the "Verification: Re-read to confirm each fix" section of the pre-flight block. Same verification command and recovery steps.

- **`CHANGELOG.md`**: Added `[Unreleased] Fixed` entry.

### Motivation

PR #321 (batch 17): the automated-reviewer-loop agent edited a file in the worktree but never ran `git commit`. It cited commit `a314508` as proof of resolution — a SHA that did not exist. The fix was later applied manually. Without a git log verification gate, a fabricated SHA can propagate into the PR audit trail and cause the PR to be labeled `ready-for-human-review` with an uncommitted (invisible to reviewers and lost on cleanup) fix.