### PR TITLE
fix(reviewer-loop): re-query reviewThreads after each push before Step 8c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Re-query `reviewThreads` after each push before Step 8c** (`91-orchestrate-work-protocol.md`, `93-automated-reviewer-loop-protocol.md`): Agents were checking reviewer thread state once (before the final push) and then labeling PRs `ready-for-human-review` without re-querying. New bot-created threads from the push were missed, causing PRs to be labeled with unresolved comments. Added a mandatory "Re-query reviewThreads after each push" section to both Protocol 91 Step 7 and Protocol 93, requiring a fresh GraphQL `reviewThreads` query after every fixer push before proceeding to Step 7b/Step 8 or reporting readiness. Closes #330.
+
+- **Shell variable interpolation in GraphQL mutation** (`workflow-lib.sh`): `update_tracker_status_best_effort` was interpolating `${project_id}`, `${item_id}`, `${field_id}`, and `${option_id}` directly into the query string. Switched to `-f` parameterized variables with a typed mutation signature (`$projectId: ID!`, `$itemId: ID!`, `$fieldId: ID!`, `$optionId: String!`), eliminating the injection risk and aligning with the safe pattern used elsewhere in the codebase.
+
 ### Added
 
 - **Sync-template migration notes** (`sync-manifest.yaml`, sync-template skill and commands): `sync-manifest.yaml` gains a `migration_notes` section for versioned manual migration steps. The sync-template skill and command variants now read this section and present a required pre-sync checklist whenever the downstream project's `last_synced_version` predates a breaking structural change. First entry: `docs/ai/ → docs/workflow/` rename (v0.23.0). Fully backwards-compatible — silently skipped when no applicable notes exist.
-
-### Fixed
-
-- **Shell variable interpolation in GraphQL mutation** (`workflow-lib.sh`): `update_tracker_status_best_effort` was interpolating `${project_id}`, `${item_id}`, `${field_id}`, and `${option_id}` directly into the query string. Switched to `-f` parameterized variables with a typed mutation signature (`$projectId: ID!`, `$itemId: ID!`, `$fieldId: ID!`, `$optionId: String!`), eliminating the injection risk and aligning with the safe pattern used elsewhere in the codebase.
 
 ## [0.23.0] - 2026-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Sync-template migration notes** (`sync-manifest.yaml`, sync-template skill and commands): `sync-manifest.yaml` gains a `migration_notes` section for versioned manual migration steps. The sync-template skill and command variants now read this section and present a required pre-sync checklist whenever the downstream project's `last_synced_version` predates a breaking structural change. First entry: `docs/ai/ → docs/workflow/` rename (v0.23.0). Fully backwards-compatible — silently skipped when no applicable notes exist.
+
 ### Fixed
 
 - **Re-query `reviewThreads` after each push before Step 8c** (`91-orchestrate-work-protocol.md`, `93-automated-reviewer-loop-protocol.md`): Agents were checking reviewer thread state once (before the final push) and then labeling PRs `ready-for-human-review` without re-querying. New bot-created threads from the push were missed, causing PRs to be labeled with unresolved comments. Added a mandatory "Re-query reviewThreads after each push" section to both Protocol 91 Step 7 and Protocol 93, requiring a fresh GraphQL `reviewThreads` query after every fixer push before proceeding to Step 7b/Step 8 or reporting readiness. Closes #330.
 
 - **Shell variable interpolation in GraphQL mutation** (`workflow-lib.sh`): `update_tracker_status_best_effort` was interpolating `${project_id}`, `${item_id}`, `${field_id}`, and `${option_id}` directly into the query string. Switched to `-f` parameterized variables with a typed mutation signature (`$projectId: ID!`, `$itemId: ID!`, `$fieldId: ID!`, `$optionId: String!`), eliminating the injection risk and aligning with the safe pattern used elsewhere in the codebase.
-
-### Added
-
-- **Sync-template migration notes** (`sync-manifest.yaml`, sync-template skill and commands): `sync-manifest.yaml` gains a `migration_notes` section for versioned manual migration steps. The sync-template skill and command variants now read this section and present a required pre-sync checklist whenever the downstream project's `last_synced_version` predates a breaking structural change. First entry: `docs/ai/ → docs/workflow/` rename (v0.23.0). Fully backwards-compatible — silently skipped when no applicable notes exist.
 
 ## [0.23.0] - 2026-04-25
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -759,11 +759,27 @@ Interpret the result as follows:
 
 | Result | Action |
 |---|---|
-| `clean` | Continue to Step 7b (implementation PRs) then Step 8 |
+| `clean` | Re-issue the GraphQL `reviewThreads` query (Step 8c) **before** proceeding — see "Re-query reviewThreads after each push" below |
 | `skipped` | Continue to Step 7b (implementation PRs) then Step 8 |
 | `needs_fixes` and `cycle < max_cycles` | Increment `cycle`, dispatch the matching fixer agent, wait for a push, then run Step 7 again |
 | `needs_fixes` and `cycle >= max_cycles` | Escalate to human |
 | `escalate` | Escalate to human |
+
+### Re-query reviewThreads after each push (mandatory)
+
+**After every push that addresses reviewer feedback — including the push that causes `pr-review-loop.sh` to return `clean` — you MUST re-issue the GraphQL `reviewThreads` query (Step 8c) before proceeding to Step 7b or Step 8.**
+
+Do not rely on thread state observed before the push. Bot reviewers (CodeRabbit, Devin, or any configured platform) may open new review threads within seconds of a push landing. Thread state cached from before the push will not include these new threads.
+
+The required sequence after each fixer push is:
+
+1. Push the fix commit.
+2. Run `pr-review-loop.sh` (wait for bot response and poll for `clean` / `needs_fixes`).
+3. **Re-issue the GraphQL `reviewThreads` query** (as defined in Step 8c) to get the current thread state for the latest push.
+4. If new unresolved threads are found: treat this as `needs_fixes` — handle them (dispatch a fixer or resolve via reply), then repeat from step 1.
+5. Only when the re-issued query returns no unresolved bot-authored threads: proceed to Step 7b (implementation PRs) then Step 8.
+
+**This check is not optional and cannot be skipped, even when the review loop script reported `clean`.** The script checks review state (blocking inline comments and `CHANGES_REQUESTED` reviews), not the resolved/unresolved state of `reviewThreads`. New threads created by a push may appear after the script's poll window closes. The GraphQL query is the only authoritative source for thread resolution state.
 
 ### Blocking vs. suggestion classification
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -94,6 +94,22 @@ Execute **Step 7a: Internal Review Gate**, **Step 7: Automated Reviewer Loop**, 
 
 For each PR: run Step 7a first. Step 7a runs **all** configured internal reviewers sequentially (per the `review.internal_reviewers` list in `.ai-dev-workflow.yaml`, with `.tmp/template-config.json` local overrides taking precedence). All internal reviewers must APPROVE before proceeding. Once Step 7a produces `APPROVED` from all internal reviewers, run `gh pr ready <pr_number>` to convert the draft PR to non-draft, then run Step 7 to completion, then Step 7b (regression label, implementation PRs only), then Step 8. Dispatch fixers and re-run as specified in 91 until the PR is clean and ready for human review or escalated. After Step 8 returns `green`, run Step 8a (label readiness checklist — this is a **hard gate** that verifies non-draft status, `ready-for-regression` label on implementation PRs, and applies `ready-for-human-review`). Once Step 8a passes, run Step 8b to update tracker status, then run Step 8c (post-label independent verification — this is a **hard gate** that independently verifies actual PR state via `gh pr view` before reporting ready). Only after Step 8c passes should the PR be reported as ready for human review.
 
+### Re-query reviewThreads after each push (mandatory)
+
+**After every push that addresses reviewer feedback — including the final push before Step 8c — you MUST re-issue the GraphQL `reviewThreads` query (as defined in Protocol 91 Step 8c) before proceeding to check readiness.**
+
+Do not rely on thread state observed before the push. A bot reviewer (CodeRabbit, Devin, or any configured platform) may open new review threads within seconds of a push landing. These new threads will not be visible in any cached or pre-push snapshot.
+
+The sequence after each fixer push is:
+
+1. Push the fix commit.
+2. Wait for configured bot reviewers to process the push (as part of the `pr-review-loop.sh` poll cycle).
+3. **Re-issue the GraphQL `reviewThreads` query** (Protocol 91 Step 8c) to get the current thread state.
+4. If new unresolved threads are found: handle them before proceeding (dispatch a fixer or resolve via reply, then repeat from step 1).
+5. Only when the re-issued query returns no unresolved threads from configured bot reviewers: proceed to Step 8c.
+
+**This check is not optional and cannot be skipped, even when the review loop script reported `clean`.** The script checks review state (blocking inline comments and `CHANGES_REQUESTED` reviews), not the resolved/unresolved state of `reviewThreads`. New threads created by a push may appear after the script's poll window closes. The GraphQL query is the only authoritative source for thread resolution state.
+
 ### Stuck-loop detection and escalation
 
 The automated reviewer loop can become stuck if findings are not being resolved or if the same issues keep reappearing. Complement the per-platform timeouts in `pr-review-loop.sh` (20 min) with these higher-level heuristics to detect when a fix-review cycle is not making progress:

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -106,7 +106,7 @@ The sequence after each fixer push is:
 2. Wait for configured bot reviewers to process the push (as part of the `pr-review-loop.sh` poll cycle).
 3. **Re-issue the GraphQL `reviewThreads` query** (Protocol 91 Step 8c) to get the current thread state.
 4. If new unresolved threads are found: handle them before proceeding (dispatch a fixer or resolve via reply, then repeat from step 1).
-5. Only when the re-issued query returns no unresolved threads from configured bot reviewers: proceed to Step 8c.
+5. Only when the re-issued query returns no unresolved threads from configured bot reviewers: proceed to Step 7b (implementation PRs) then Step 8, then Step 8c.
 
 **This check is not optional and cannot be skipped, even when the review loop script reported `clean`.** The script checks review state (blocking inline comments and `CHANGES_REQUESTED` reviews), not the resolved/unresolved state of `reviewThreads`. New threads created by a push may appear after the script's poll window closes. The GraphQL query is the only authoritative source for thread resolution state.
 


### PR DESCRIPTION
## Summary

Fixes #330. Agents were caching reviewer thread state from before a fixer push and labeling PRs `ready-for-human-review` without re-querying. New bot-created threads (CodeRabbit, Devin) from the push were missed, causing PRs with unresolved comments to be labeled prematurely. This recurred 4 times in batch 17 (PRs #321 and #328).

### Changes

- **`docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`**: Added a "Re-query reviewThreads after each push (mandatory)" subsection to Step 7. The `clean` result row in the result-interpretation table now explicitly points to this subsection. Makes clear that `pr-review-loop.sh` returning `clean` is not sufficient — the GraphQL `reviewThreads` query must be re-issued after every fixer push before proceeding to Step 7b/Step 8.

- **`docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`**: Added the same "Re-query reviewThreads after each push (mandatory)" subsection to Protocol 93's "Run the loops" section, restating the requirement from the standalone reviewer-loop protocol's perspective with a concrete 5-step sequence.

- **`CHANGELOG.md`**: Added entry under `[Unreleased] ### Fixed`.

## Test plan

- [ ] Read Protocol 91 Step 7: verify the `clean` row in the result table now points to the re-query requirement, and the "Re-query reviewThreads after each push" section is present and unambiguous
- [ ] Read Protocol 93 "Run the loops": verify the new mandatory section is present with the 5-step sequence
- [ ] Verify no markdown lint errors (`markdownlint-cli2 CHANGELOG.md`)
- [ ] Verify no duplicate CHANGELOG headers (`check-changelog-duplicate-headers.sh CHANGELOG.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)