### PR TITLE
fix(gitignore): add .worktrees/ to .gitignore alongside .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ Thumbs.db
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 
+# Agent worktrees (parallel batch isolation)
+.worktrees/
+
 # Node
 node_modules/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Shell variable interpolation in GraphQL mutation** (`workflow-lib.sh`): `update_tracker_status_best_effort` was interpolating `${project_id}`, `${item_id}`, `${field_id}`, and `${option_id}` directly into the query string. Switched to `-f` parameterized variables with a typed mutation signature (`$projectId: ID!`, `$itemId: ID!`, `$fieldId: ID!`, `$optionId: String!`), eliminating the injection risk and aligning with the safe pattern used elsewhere in the codebase.
 
+- **`.worktrees/` not gitignored** (`.gitignore`): Some item-orchestrator agents choose `.worktrees/<slug>/` as the worktree base path instead of `.claude/worktrees/<slug>/`. Both are valid isolation paths, but only the `.claude/worktrees/` prefix was gitignored, causing `.worktrees/` directories to appear as untracked noise in `git status` after parallel batch runs. Added `.worktrees/` to `.gitignore` alongside the existing `.claude/worktrees/` entry.
+
 ## [0.23.0] - 2026-04-25
 
 ### Added


### PR DESCRIPTION
## Summary

Fixes #339.

Some item-orchestrator agents choose `.worktrees/<slug>/` as the worktree base path instead of `.claude/worktrees/<slug>/`. Both are valid isolation paths, but only the `.claude/worktrees/` prefix was gitignored. This causes persistent untracked-directory noise in `git status` after parallel batch runs and triggers false positives in the Step 5.2 dirty-tree check.

### Changes

- **`.gitignore`**: Added `.worktrees/` entry alongside the existing `.claude/worktrees/` entry under a new `# Agent worktrees (parallel batch isolation)` comment block.
- **`CHANGELOG.md`**: Added entry under `[Unreleased] ### Fixed`.

### Test plan

- [ ] Confirm `.gitignore` now contains `.worktrees/`
- [ ] Confirm creating a `.worktrees/` directory at repo root does not appear in `git status`
- [ ] Confirm `.claude/worktrees/` is still ignored