### PR TITLE
fix(plan-writer): add explicit CHANGELOG exemption to spec and plan protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Shell variable interpolation in GraphQL mutation** (`workflow-lib.sh`): `update_tracker_status_best_effort` was interpolating `${project_id}`, `${item_id}`, `${field_id}`, and `${option_id}` directly into the query string. Switched to `-f` parameterized variables with a typed mutation signature (`$projectId: ID!`, `$itemId: ID!`, `$fieldId: ID!`, `$optionId: String!`), eliminating the injection risk and aligning with the safe pattern used elsewhere in the codebase.
 
+- **Plan-writing and spec-writing agents adding CHANGELOG entries to exempt PRs** (#340): `implementation-plan/*` and `spec/*` branches are exempt from CHANGELOG updates per the project changelog policy, but agents occasionally added entries anyway, triggering an unnecessary internal-review fix cycle. Added explicit `Do NOT update CHANGELOG` steps to `02-generate-implementation-plan-protocol.md` and `01-generate-spec-protocol.md`, and added a blocking finding to the Spec and Plan Review checklists in `REVIEW.md` so the exemption is caught at review time if missed at authoring time.
+
 ## [0.23.0] - 2026-04-25
 
 ### Added

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -68,6 +68,7 @@ Typical `blocking` issues:
 - Missing or ambiguous acceptance criteria
 - Contradictory business rules
 - Spec drift that would force engineering to guess
+- `CHANGELOG.md` is modified in this PR — `spec/*` branches are exempt from CHANGELOG entries; remove any CHANGELOG modification before merging
 
 Typical `important` issues:
 - Missing edge cases
@@ -106,6 +107,7 @@ Typical `blocking` issues:
 - The plan requires guessing at implementation details
 - The plan introduces unsafe or contradictory architecture decisions
 - A CHANGELOG literal in the Implementation Order uses conventional-commit format (`fix(scope): message`) instead of the project's `**Bold Title** (#N):` format
+- `CHANGELOG.md` is modified in this PR — `implementation-plan/*` branches are exempt from CHANGELOG entries; remove any CHANGELOG modification before merging
 
 Typical `important` issues:
 - Vague wording like "update as needed"

--- a/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
+++ b/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
@@ -188,13 +188,14 @@ If no blocking human decision remains:
 2. Create branch: `git checkout -b spec/[branch-slug]` from `develop`
 3. Create the development folder: `docs/specs/developments/[YYYYMMDDHHMMSS]_[feature-slug]/`
 4. Write the spec file: `1_[feature-slug]_specs.md`
-5. Commit: `docs: add spec for [feature-name]`
-6. Push: `git push -u origin spec/[branch-slug]`
-7. Open a **draft** PR targeting `develop` with:
+5. **Do NOT update CHANGELOG**: `spec/*` branches are exempt from CHANGELOG entries. The changelog policy only applies to `feature/*`, `fix/*`, `refactor/*`, and `hotfix/*` branches. Do not create or modify `CHANGELOG.md` in this PR.
+6. Commit: `docs: add spec for [feature-name]`
+7. Push: `git push -u origin spec/[branch-slug]`
+8. Open a **draft** PR targeting `develop` with:
    - Title: `docs(spec): [feature-name]`
    - Body: summary of the feature, link to the spec file, list of open questions (if any)
    - When a tracker brief exists: Coverage Matrix summary (each brief objective mapped to AC reference(s) or Out-of-Scope entry) and Deferral Notes for each objective intentionally moved to Out of Scope
-8. Return the branch + PR details to the **Work Item Runner**
+9. Return the branch + PR details to the **Work Item Runner**
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -192,12 +192,13 @@ If no blocking human decision remains:
 
    > **Worktree note**: When running inside a git worktree (e.g., when dispatched by the Portfolio Orchestrator), `node_modules/` does not exist inside the worktree directory. The `$(git rev-parse --git-common-dir)/..` expression resolves to the main repo root in both the main tree and any worktree.
 
-6. Commit: `docs: add implementation plan for [feature-name]`
-7. Push: `git push -u origin implementation-plan/[branch-slug]`
-8. Open a **draft** PR targeting `develop` with:
+6. **Do NOT update CHANGELOG**: `implementation-plan/*` branches are exempt from CHANGELOG entries. The changelog policy only applies to `feature/*`, `fix/*`, `refactor/*`, and `hotfix/*` branches. Do not create or modify `CHANGELOG.md` in this PR.
+7. Commit: `docs: add implementation plan for [feature-name]`
+8. Push: `git push -u origin implementation-plan/[branch-slug]`
+9. Open a **draft** PR targeting `develop` with:
    - Title: `docs(plan): [feature-name]`
    - Body: summary of the approach, complexity estimate, key risks, link to plan and runbook
-9. Return the branch + PR details to the **Work Item Runner**
+10. Return the branch + PR details to the **Work Item Runner**
 
 ---
 


### PR DESCRIPTION
## Summary

`implementation-plan/*` and `spec/*` branches are exempt from CHANGELOG updates per the project changelog policy, but agents occasionally added entries anyway — triggering an unnecessary internal-review fix cycle.

This PR adds an explicit guardrail at two enforcement points:

1. **Authoring time**: new `Do NOT update CHANGELOG` steps in `01-generate-spec-protocol.md` (Step 5) and `02-generate-implementation-plan-protocol.md` (Step 5) make the exemption explicit so agents skip the CHANGELOG step by default.
2. **Review time**: new blocking findings in the Spec and Plan Review checklists in `REVIEW.md` catch any CHANGELOG modification that slips through.

## Files changed

- `docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md` — new step 5 (CHANGELOG exemption); existing steps 5–8 renumbered 6–9
- `docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md` — new step 6 (CHANGELOG exemption); existing steps 6–9 renumbered 7–10
- `REVIEW.md` — blocking finding added to Spec Review Checklist and Plan Review Checklist
- `CHANGELOG.md` — `[Unreleased] Fixed` entry for this change

## Test plan

- [ ] Read updated `02-generate-implementation-plan-protocol.md` Step 5 — confirm the CHANGELOG exemption step is present and clearly worded
- [ ] Read updated `01-generate-spec-protocol.md` Step 5 — confirm the same exemption is present
- [ ] Read updated `REVIEW.md` Plan Review Checklist → Typical blocking issues — confirm the new CHANGELOG-modification finding is listed
- [ ] Read updated `REVIEW.md` Spec Review Checklist → Typical blocking issues — confirm the same finding is listed
- [ ] Confirm `CHANGELOG.md` has the new `[Unreleased] Fixed` entry and no trailing whitespace

Closes #340