### PR TITLE
fix(orchestrator): add worktree pre-op checklist to prevent main-tree branch leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Worktree isolation: agents still switching branches in main working tree** (`03-implement-development-protocol.md`, `91-orchestrate-work-protocol.md`, `93-automated-reviewer-loop-protocol.md`): Protocol 91's "Critical: Worktree Git Discipline" block now includes an explicit pre-operation checklist — agents must confirm they are inside the worktree path (not the main repo root) and must skip base-branch checkout steps before any state-changing git command. All four branching steps in Protocol 03 (Full Pipeline, Refactor, Fast Track, Hotfix) gain a "Worktree context" note instructing agents to skip `git checkout <base> && git checkout -b` when the worktree was already created on the correct branch. Protocol 93 adds a "Worktree discipline for fixer agents" section that carries the same pre-operation checklist to reviewer-loop fixer dispatch in batch contexts.
+
 - **Shell variable interpolation in GraphQL mutation** (`workflow-lib.sh`): `update_tracker_status_best_effort` was interpolating `${project_id}`, `${item_id}`, `${field_id}`, and `${option_id}` directly into the query string. Switched to `-f` parameterized variables with a typed mutation signature (`$projectId: ID!`, `$itemId: ID!`, `$fieldId: ID!`, `$optionId: String!`), eliminating the injection risk and aligning with the safe pattern used elsewhere in the codebase.
 
 ## [0.23.0] - 2026-04-25

--- a/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
@@ -104,6 +104,8 @@ git pull origin develop
 git checkout -b feature/[branch-slug]
 ```
 
+**Worktree context (`BATCH_CONTEXT=true`)**: If this step runs inside an isolated worktree created by the item-orchestrator (Protocol 91 Step 3), skip the `git checkout develop` / `git checkout -b` commands above — the worktree was already created on the correct branch. Run only `git fetch origin` if you need the latest remote refs. Before running any git state-changing command, confirm your working directory is inside the worktree path, not the main repo root (run `pwd` and compare). See the "Critical: Worktree Git Discipline" block in Protocol 91 Step 3 for the full pre-operation checklist.
+
 ### Step 4: Implement
 
 Execute each step from the implementation plan in order.
@@ -334,6 +336,8 @@ git pull origin develop
 git checkout -b refactor/[branch-slug]
 ```
 
+**Worktree context (`BATCH_CONTEXT=true`)**: If this step runs inside an isolated worktree created by the item-orchestrator (Protocol 91 Step 3), skip the `git checkout develop` / `git checkout -b` commands above — the worktree was already created on the correct branch. Run only `git fetch origin` if you need the latest remote refs. Before running any git state-changing command, confirm your working directory is inside the worktree path, not the main repo root (run `pwd` and compare). See the "Critical: Worktree Git Discipline" block in Protocol 91 Step 3 for the full pre-operation checklist.
+
 3. Implement following the plan order. Follow `docs/best-practices/` for all code written.
 
    **Mass-rename sub-step (applies when the refactor renames a path, identifier, or string across multiple files):**
@@ -486,6 +490,8 @@ git pull origin develop
 git checkout -b fix/[branch-slug]
 ```
 
+**Worktree context (`BATCH_CONTEXT=true`)**: If this step runs inside an isolated worktree created by the item-orchestrator (Protocol 91 Step 3), skip the `git checkout develop` / `git checkout -b` commands above — the worktree was already created on the correct branch. Run only `git fetch origin` if you need the latest remote refs. Before running any git state-changing command, confirm your working directory is inside the worktree path, not the main repo root (run `pwd` and compare). See the "Critical: Worktree Git Discipline" block in Protocol 91 Step 3 for the full pre-operation checklist.
+
 ### Step 4: Implement
 
 Implement the fix.
@@ -609,6 +615,8 @@ git checkout main
 git pull origin main
 git checkout -b hotfix/[branch-slug]
 ```
+
+**Worktree context (`BATCH_CONTEXT=true`)**: If this step runs inside an isolated worktree created by the item-orchestrator (Protocol 91 Step 3), skip the `git checkout main` / `git checkout -b` commands above — the worktree was already created on the correct branch. Run only `git fetch origin` if you need the latest remote refs. Before running any git state-changing command, confirm your working directory is inside the worktree path, not the main repo root (run `pwd` and compare). See the "Critical: Worktree Git Discipline" block in Protocol 91 Step 3 for the full pre-operation checklist.
 
 ### Step 4: Implement
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -207,6 +207,16 @@ Use the pre-dispatch branch check from Step 2 (`git branch --list`, `git branch 
 
 **Critical: Worktree Git Discipline** (`BATCH_CONTEXT=true` only)
 
+**Pre-operation checklist — verify before every git state-changing command**
+
+Before issuing any `git switch`, `git checkout`, `git checkout -b`, `git reset`, or `git restore` command, confirm both conditions below. If either check fails, do not run the command — correct the path or use the `-C` flag instead.
+
+1. **Confirm you are operating inside the worktree, not the main repository root.**
+   Run `pwd` and compare the output against `<worktree-path>`. If they differ, you are in the wrong directory. `cd <worktree-path>` or use `git -C <worktree-path>` before continuing.
+
+2. **Confirm the command targets the current worktree branch, not a base branch.**
+   Running `git checkout develop` (or any other base branch) inside the worktree will fail because `develop` is already checked out in the main working tree — git prevents the same branch from being checked out in two locations simultaneously. If a stage protocol's branching step says `git checkout develop && git checkout -b <branch>`, skip it entirely: the worktree was already created on the correct branch.
+
 When operating inside a worktree, **never** run the following commands against the main repo root:
 
 - `git switch <branch>`

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -79,6 +79,16 @@ Also handle the case where a platform posted blocking findings after a previous 
 
 If unresolved findings exist: dispatch a fixer agent, wait for the push, then proceed to the scripts. Do not re-trigger the reviewer loop against stale findings — fix first.
 
+### Worktree discipline for fixer agents (`BATCH_CONTEXT=true`)
+
+When this protocol runs inside a worktree (the item was dispatched as part of a parallel batch, `BATCH_CONTEXT=true`), all fixer agents dispatched during the reviewer loop **must** stay inside the worktree. The same rules from Protocol 91 Step 3 "Critical: Worktree Git Discipline" apply here:
+
+- **Before any git state-changing command** (`git switch`, `git checkout`, `git commit`, `git push`, `git reset`, `git restore`): confirm the working directory is inside the worktree path, not the main repo root. Run `pwd` and compare against `<worktree-path>`.
+- **Never run `git checkout develop` or any base-branch switch** from inside the worktree — the base branch is already checked out in the main working tree and cannot be checked out in the worktree simultaneously.
+- When delegating a fixer subagent, pass the resolved `<worktree-path>` in the handoff and instruct the fixer to validate all `Write`/`Edit` tool call paths start with `<worktree-path>/`.
+
+Violations leave the main repo on a feature branch, breaking all subsequent agents and the human operator. The Portfolio Orchestrator's Step 5.2 check catches leaks after the fact, but prevention here avoids the need for correction.
+
 ### Shell script fix verification (fixer agents)
 
 When findings target `*.sh` workflow scripts (especially under `scripts/development-workflow/`), the fixer must **verify locally before pushing**:


### PR DESCRIPTION
## Summary

Addresses #345 — agents dispatched with `isolation: "worktree"` were performing branch switches inside the main working tree instead of staying inside their isolated worktree. Protocol 90 Step 5.2 only corrects after the fact; this PR adds prevention at the agent level.

### Changes

- **Protocol 91 Step 3** (`91-orchestrate-work-protocol.md`): The "Critical: Worktree Git Discipline" block now includes an explicit **pre-operation checklist** with two numbered checks agents must verify before any git state-changing command:
  1. Confirm CWD is inside the worktree path, not the main repo root (`pwd` + compare)
  2. Confirm the command does not target a base branch (skip `git checkout develop && git checkout -b` entirely when the worktree already satisfies the setup)

- **Protocol 03 Step 3 (all 4 paths)** (`03-implement-development-protocol.md`): Each branching step (Full Pipeline, Refactor, Fast Track, Hotfix) gains a "Worktree context (`BATCH_CONTEXT=true`)" note instructing agents to skip the base-branch checkout/switch sequence when dispatched inside an isolated worktree.

- **Protocol 93** (`93-automated-reviewer-loop-protocol.md`): New "Worktree discipline for fixer agents" section before "Shell script fix verification" carries the same pre-operation checklist to fixer agents dispatched during the reviewer loop in batch contexts.

- **CHANGELOG.md**: Fixed entry under `[Unreleased]`.

## Test plan

- [ ] Review Protocol 91 Step 3 Critical block for clarity and completeness of the pre-operation checklist
- [ ] Verify Protocol 03 worktree notes are consistent across all 4 paths
- [ ] Verify Protocol 93 new section references Protocol 91 Step 3 correctly
- [ ] Confirm no trailing whitespace or lint errors in changed files
- [ ] Confirm main working tree remains on `develop` throughout this PR