### PR TITLE
fix(sync-template): use $TEMPLATE_TEMP_DIR instead of wildcard in cleanup step

### DIFF
--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -269,9 +269,10 @@ Then ask:
 - Do **not** delete any file
 - Do **not** overwrite project-specific files; for those paths only additive/merge changes are allowed, and only with explicit approval
 
-If the template source was a remote clone, clean it up now:
+If the template source was a remote clone, clean up the exact temp directory recorded in Step 0:
+
 ```bash
-rm -rf /tmp/template-sync-*
+rm -rf "$TEMPLATE_TEMP_DIR"   # use the exact path, not a wildcard
 ```
 
 ---

--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -35,10 +35,13 @@ or
 Save the user's answer to `.tmp/template-config.json` before continuing (create the `.tmp` directory if needed; it is gitignored).
 
 **Remote fetch** (when a URL source is used):
+
 ```bash
-git clone --depth=1 --branch=<ref> <url> /tmp/template-sync-$(date +%s)
+TEMPLATE_TEMP_DIR="/tmp/template-sync-$(date +%s)"
+git clone --depth=1 --branch=<ref> <url> "$TEMPLATE_TEMP_DIR"
 ```
-Remember the temp path — you must clean it up at the end of this skill.
+
+Store the exact path in `TEMPLATE_TEMP_DIR` — you must clean up this specific directory at the end (never use a wildcard).
 If `--ref` is not specified for a remote source, use the default branch (`main`).
 
 Once the template source is resolved, read its `CHANGELOG.md` and extract the latest version number (first `[X.Y.Z]` entry after `[Unreleased]` if present, otherwise the first versioned entry). Store it as `TEMPLATE_VERSION`.

--- a/.cursor/commands/sync-template.md
+++ b/.cursor/commands/sync-template.md
@@ -268,9 +268,10 @@ Then ask:
 - Do **not** delete any file
 - Do **not** overwrite project-specific files; for those paths only additive/merge changes are allowed, and only with explicit approval
 
-If the template source was a remote clone, clean it up now:
+If the template source was a remote clone, clean up the exact temp directory recorded in Step 0:
+
 ```bash
-rm -rf /tmp/template-sync-*
+rm -rf "$TEMPLATE_TEMP_DIR"   # use the exact path, not a wildcard
 ```
 
 ---

--- a/.cursor/commands/sync-template.md
+++ b/.cursor/commands/sync-template.md
@@ -34,10 +34,13 @@ or
 Save the user's answer to `.tmp/template-config.json` before continuing (create the `.tmp` directory if needed; it is gitignored).
 
 **Remote fetch** (when a URL source is used):
+
 ```bash
-git clone --depth=1 --branch=<ref> <url> /tmp/template-sync-$(date +%s)
+TEMPLATE_TEMP_DIR="/tmp/template-sync-$(date +%s)"
+git clone --depth=1 --branch=<ref> <url> "$TEMPLATE_TEMP_DIR"
 ```
-Remember the temp path — you must clean it up at the end.
+
+Store the exact path in `TEMPLATE_TEMP_DIR` — you must clean up this specific directory at the end (never use a wildcard).
 If `--ref` is not specified for a remote source, use the default branch (`main`).
 
 Once the template source is resolved, read its `CHANGELOG.md` and extract the latest version number (first `[X.Y.Z]` entry after `[Unreleased]` if present, otherwise the first versioned entry). Store it as `TEMPLATE_VERSION`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Wildcard `rm -rf` in sync-template cleanup** (`.claude/skills/sync-template.md`, `.cursor/commands/sync-template.md`): The cleanup step used `rm -rf /tmp/template-sync-*`, which could delete temp directories from other concurrent sync runs or leftover artifacts. Updated both files to use `rm -rf "$TEMPLATE_TEMP_DIR"` (the exact path recorded in Step 0), consistent with the already-fixed `.claude/commands/sync-template.md`.
+- **Wildcard `rm -rf` in sync-template cleanup** (`.claude/skills/sync-template.md`, `.cursor/commands/sync-template.md`): The Step 0 clone block did not assign the temp directory to `TEMPLATE_TEMP_DIR`, and the cleanup step used `rm -rf /tmp/template-sync-*` (a wildcard that could delete dirs from concurrent or prior runs). Updated both files to assign `TEMPLATE_TEMP_DIR="/tmp/template-sync-$(date +%s)"` in Step 0 and use `rm -rf "$TEMPLATE_TEMP_DIR"` in the cleanup step, consistent with the already-fixed `.claude/commands/sync-template.md`.
 
 - **Shell variable interpolation in GraphQL mutation** (`workflow-lib.sh`): `update_tracker_status_best_effort` was interpolating `${project_id}`, `${item_id}`, `${field_id}`, and `${option_id}` directly into the query string. Switched to `-f` parameterized variables with a typed mutation signature (`$projectId: ID!`, `$itemId: ID!`, `$fieldId: ID!`, `$optionId: String!`), eliminating the injection risk and aligning with the safe pattern used elsewhere in the codebase.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Wildcard `rm -rf` in sync-template cleanup** (`.claude/skills/sync-template.md`, `.cursor/commands/sync-template.md`): The cleanup step used `rm -rf /tmp/template-sync-*`, which could delete temp directories from other concurrent sync runs or leftover artifacts. Updated both files to use `rm -rf "$TEMPLATE_TEMP_DIR"` (the exact path recorded in Step 0), consistent with the already-fixed `.claude/commands/sync-template.md`.
+
 - **Shell variable interpolation in GraphQL mutation** (`workflow-lib.sh`): `update_tracker_status_best_effort` was interpolating `${project_id}`, `${item_id}`, `${field_id}`, and `${option_id}` directly into the query string. Switched to `-f` parameterized variables with a typed mutation signature (`$projectId: ID!`, `$itemId: ID!`, `$fieldId: ID!`, `$optionId: String!`), eliminating the injection risk and aligning with the safe pattern used elsewhere in the codebase.
 
 ## [0.23.0] - 2026-04-25


### PR DESCRIPTION
## Summary

Fixes #337.

The cleanup step in `.claude/skills/sync-template.md` and `.cursor/commands/sync-template.md` used `rm -rf /tmp/template-sync-*`, a wildcard glob that could silently delete temp directories from other concurrent sync runs or leftover artifacts from previous unfinished runs.

Updated both files to use `rm -rf "$TEMPLATE_TEMP_DIR"` (the exact path recorded in Step 0), consistent with the already-fixed `.claude/commands/sync-template.md`.

## Files changed

- `.claude/skills/sync-template.md` — cleanup step uses `$TEMPLATE_TEMP_DIR`
- `.cursor/commands/sync-template.md` — cleanup step uses `$TEMPLATE_TEMP_DIR`
- `CHANGELOG.md` — added Fixed entry under [Unreleased]

## Test plan

- [ ] Verify `.claude/skills/sync-template.md` cleanup step references `"$TEMPLATE_TEMP_DIR"` not the wildcard
- [ ] Verify `.cursor/commands/sync-template.md` cleanup step references `"$TEMPLATE_TEMP_DIR"` not the wildcard
- [ ] Verify `.codex/skills/workflow-sync-template/SKILL.md` does not contain the wildcard (it delegates to the skill file, no inline cleanup)
- [ ] CHANGELOG entry present under [Unreleased] Fixed section