### PR TITLE
fix(sync-template): add post-apply path verification for cross-reference integrity (#335)

### DIFF
--- a/.claude/commands/sync-template.md
+++ b/.claude/commands/sync-template.md
@@ -274,6 +274,22 @@ Apply approved changes:
 - Do **not** delete any file
 - Do **not** overwrite project-specific files; for those paths only additive/merge changes are allowed, and only with explicit approval
 
+### Post-apply path verification (cross-reference integrity check)
+
+After applying any file that contains cross-references to workflow doc paths (e.g., `.claude/commands/*.md`, `.cursor/commands/*.md`, `.claude/skills/*.md`, `.cursor/agents/*.md`, `.claude/agents/*.md`), verify that every resulting path resolves to an actual file in the project. This catches cases where a path-prefix rename (e.g., `docs/ai/` → `docs/workflow/`) is applied correctly but protocol numbers that shifted between the old and new directory trees are not.
+
+For each file that was added or updated in this step:
+
+1. Extract all relative file paths referenced in the file (look for patterns like `docs/workflow/...`, `docs/specs/...`, or any `*.md` path under `docs/`).
+2. For each extracted path, verify the file exists:
+   ```bash
+   ls <path>   # or: test -f <path> && echo "OK" || echo "MISSING: <path>"
+   ```
+3. If any path does not resolve, **do not commit**. Instead, surface it as a manual review item:
+   > "⚠️  Cross-reference path not found after sync: `<path>` (in `<file>`). The path prefix was updated but the filename may have changed. Please verify the correct path and update the reference manually before committing."
+
+Collect all broken paths and report them together before asking the user to confirm or fix them. Only proceed to Step 5 once either (a) all paths resolve, or (b) the user has explicitly acknowledged each broken path and confirmed they will fix it manually after the commit.
+
 If the template source was a remote clone, clean up the exact temp directory recorded in Step 0:
 
 ```bash

--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -269,6 +269,22 @@ Then ask:
 - Do **not** delete any file
 - Do **not** overwrite project-specific files; for those paths only additive/merge changes are allowed, and only with explicit approval
 
+### Post-apply path verification (cross-reference integrity check)
+
+After applying any file that contains cross-references to workflow doc paths (e.g., `.claude/commands/*.md`, `.cursor/commands/*.md`, `.claude/skills/*.md`, `.cursor/agents/*.md`, `.claude/agents/*.md`), verify that every resulting path resolves to an actual file in the project. This catches cases where a path-prefix rename (e.g., `docs/ai/` → `docs/workflow/`) is applied correctly but protocol numbers that shifted between the old and new directory trees are not.
+
+For each file that was added or updated in this step:
+
+1. Extract all relative file paths referenced in the file (look for patterns like `docs/workflow/...`, `docs/specs/...`, or any `*.md` path under `docs/`).
+2. For each extracted path, verify the file exists:
+   ```bash
+   ls <path>   # or: test -f <path> && echo "OK" || echo "MISSING: <path>"
+   ```
+3. If any path does not resolve, **do not commit**. Instead, surface it as a manual review item:
+   > "⚠️  Cross-reference path not found after sync: `<path>` (in `<file>`). The path prefix was updated but the filename may have changed. Please verify the correct path and update the reference manually before committing."
+
+Collect all broken paths and report them together before asking the user to confirm or fix them. Only proceed to Step 5 once either (a) all paths resolve, or (b) the user has explicitly acknowledged each broken path and confirmed they will fix it manually after the commit.
+
 If the template source was a remote clone, clean it up now:
 ```bash
 rm -rf /tmp/template-sync-*

--- a/.cursor/commands/sync-template.md
+++ b/.cursor/commands/sync-template.md
@@ -268,6 +268,22 @@ Then ask:
 - Do **not** delete any file
 - Do **not** overwrite project-specific files; for those paths only additive/merge changes are allowed, and only with explicit approval
 
+### Post-apply path verification (cross-reference integrity check)
+
+After applying any file that contains cross-references to workflow doc paths (e.g., `.claude/commands/*.md`, `.cursor/commands/*.md`, `.claude/skills/*.md`, `.cursor/agents/*.md`, `.claude/agents/*.md`), verify that every resulting path resolves to an actual file in the project. This catches cases where a path-prefix rename (e.g., `docs/ai/` → `docs/workflow/`) is applied correctly but protocol numbers that shifted between the old and new directory trees are not.
+
+For each file that was added or updated in this step:
+
+1. Extract all relative file paths referenced in the file (look for patterns like `docs/workflow/...`, `docs/specs/...`, or any `*.md` path under `docs/`).
+2. For each extracted path, verify the file exists:
+   ```bash
+   ls <path>   # or: test -f <path> && echo "OK" || echo "MISSING: <path>"
+   ```
+3. If any path does not resolve, **do not commit**. Instead, surface it as a manual review item:
+   > "⚠️  Cross-reference path not found after sync: `<path>` (in `<file>`). The path prefix was updated but the filename may have changed. Please verify the correct path and update the reference manually before committing."
+
+Collect all broken paths and report them together before asking the user to confirm or fix them. Only proceed to Step 5 once either (a) all paths resolve, or (b) the user has explicitly acknowledged each broken path and confirmed they will fix it manually after the commit.
+
 If the template source was a remote clone, clean it up now:
 ```bash
 rm -rf /tmp/template-sync-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Sync-template: post-apply path verification** (`.claude/skills/sync-template.md`, `.claude/commands/sync-template.md`, `.cursor/commands/sync-template.md`): After applying any file that contains cross-references to workflow doc paths, the sync-template skill now instructs the agent to verify that every resulting path resolves to an actual file in the project. This catches cases where a path-prefix rename (e.g., `docs/ai/` → `docs/workflow/`) is applied correctly but protocol numbers that shifted between the old and new directory trees are not — the root cause of the broken references in PR #188.
+
 - **Shell variable interpolation in GraphQL mutation** (`workflow-lib.sh`): `update_tracker_status_best_effort` was interpolating `${project_id}`, `${item_id}`, `${field_id}`, and `${option_id}` directly into the query string. Switched to `-f` parameterized variables with a typed mutation signature (`$projectId: ID!`, `$itemId: ID!`, `$fieldId: ID!`, `$optionId: String!`), eliminating the injection risk and aligning with the safe pattern used elsewhere in the codebase.
 
 ## [0.23.0] - 2026-04-25


### PR DESCRIPTION
## Summary

Adds a **post-apply path verification** checklist item to Step 4 of all three sync-template artefacts:

- `.claude/skills/sync-template.md`
- `.claude/commands/sync-template.md`
- `.cursor/commands/sync-template.md`

After applying any file that contains cross-references to workflow doc paths, the skill now instructs the agent to:

1. Extract all relative `docs/` paths referenced in the updated files
2. Verify each path resolves to an actual file (`ls <path>` or `test -f <path>`)
3. Surface any missing paths as a manual review item **before committing** — do not proceed to Step 5 until the user acknowledges

This catches the class of bug described in #335: a path-prefix rename (e.g., `docs/ai/` → `docs/workflow/`) updates the prefix correctly but leaves stale protocol numbers from the old directory tree intact. Both broken references in the retrospective analysis of PR #188 would have been caught by this check.

## Test plan

- [ ] Read the updated Step 4 in `.claude/skills/sync-template.md` and verify the verification block is present, clearly scoped to cross-reference files, and explains the detection rationale
- [ ] Verify the same block is present and consistent in `.claude/commands/sync-template.md` and `.cursor/commands/sync-template.md`
- [ ] Verify `CHANGELOG.md` has a `### Fixed` entry under `[Unreleased]` referencing #335 / PR #188
- [ ] Confirm no existing path references in any of the three files are broken

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)