### PR TITLE
fix(sync-template): detect stale renamed always-sync directories and offer cleanup

### DIFF
--- a/.claude/commands/sync-template.md
+++ b/.claude/commands/sync-template.md
@@ -149,6 +149,23 @@ For each file in these paths:
 - **Exists in both, content identical** → classify as **No change** (list but don't highlight)
 - **Exists in project, not in template** → **ignore** (never delete project-only files)
 
+### Rename cleanup detection
+
+**If `SYNC_MANIFEST` is loaded and contains a `rename_detections` list**: after completing the always-sync comparison above, check each entry:
+
+1. Verify that `entry.new_path` is present in `categories.always_sync`. If it is not, skip this entry.
+2. Check whether `entry.old_path` exists as a non-empty directory in the project:
+   ```bash
+   [ -d "<old_path>" ] && find "<old_path>" -maxdepth 1 | wc -l
+   ```
+3. If `old_path` exists and is non-empty: record it as a **rename cleanup candidate** with:
+   - `old_path`, `new_path`, `introduced_in`, and `description` from the manifest entry
+   - A list of project-specific files that contain references to `old_path` (scan the files in `categories.project_specific` using `grep -rl "<old_path>"`; collect matching file paths for the cross-reference update offer)
+
+Rename cleanup candidates are displayed in Step 3 and applied in Step 4 only after explicit maintainer approval. The "never delete project-only files" rule in the always-sync section does **not** apply here: `old_path` is a **former always-sync directory** whose content was superseded by `new_path`, not a project-owned directory.
+
+**If `SYNC_MANIFEST=absent`**: skip rename cleanup detection entirely (no candidates to detect without manifest data).
+
 ### Special handling (show full diff, user decides per file)
 
 **If `SYNC_MANIFEST` is loaded**: read `categories.special_handling` from the manifest.
@@ -244,7 +261,17 @@ Manifest: loaded from sync-manifest.yaml  (or: "not found — using embedded fal
   AGENTS.md — template has [brief description]; project keeps its own content; suggest adding: ...
   README.md — no template additions suggested
   ...
+
+### Rename cleanup (you decide)
+  docs/ai/ — was the previous location of always-sync content now in docs/workflow/ (renamed in v0.23.0).
+  Stale directory still present. Proposed actions (each requires separate approval):
+    1. Delete docs/ai/  (git rm -r docs/ai/)
+    2. Update cross-references in project-specific files:
+         AGENTS.md  — 3 reference(s) to docs/ai/  →  docs/workflow/
+         README.md  — 1 reference(s) to docs/ai/  →  docs/workflow/
 ```
+
+If no rename cleanup candidates were detected, omit the "Rename cleanup" section entirely from the summary.
 
 After applying changes, show a final disposition summary with separate counts (AC-5 / UX Rule 4):
 
@@ -271,8 +298,37 @@ Apply approved changes:
 - Copy/overwrite all **Add** and **Update** files **from the always-sync Step 3 section only** when the user confirms that batch. Phrases such as "apply all", "apply everything", or "yes to all" mean **always-sync files only** — they **never** authorize applying **special-handling** paths (`.github/workflows/deploy.yml`, `e2e-regression.yml`, `e2e/`, `.claude/settings.json`, etc.) or **optional additive updates**; those require the user to name each approved path (or `none`).
 - **Placeholder guard for workflow YAML** (`.github/workflows/deploy.yml`, `.github/workflows/e2e-regression.yml`): Before overwriting the project copy with the template, compare line counts. If the **project** file has **more lines** than the template and the template has **fewer than 70%** of the project's line count, treat this as likely "real implementation → template placeholder" and **refuse** unless the user sends a **second** explicit confirmation naming that exact file.
 - For files requiring manual review: apply only those the user explicitly approved (including any optional additive updates to project-specific files — merge or add only, never remove project-specific content)
-- Do **not** delete any file
+- Do **not** delete any file from the always-sync, special-handling, or project-specific categories without explicit approval
 - Do **not** overwrite project-specific files; for those paths only additive/merge changes are allowed, and only with explicit approval
+
+### Rename cleanup actions (only when maintainer approves each action individually)
+
+For each rename cleanup candidate from Step 3, apply only the actions the maintainer explicitly approved:
+
+**Action 1 — Delete the stale old directory** (only if the maintainer approved "delete `<old_path>`"):
+
+```bash
+git rm -r <old_path>
+```
+
+Do not use `rm -rf` — use `git rm -r` so the removal is tracked by git. After running the command, verify the directory no longer exists.
+
+**Action 2 — Update cross-references in project-specific files** (only if the maintainer approved "update cross-references"):
+
+For each project-specific file that contained references to `old_path` (identified during Step 2 rename detection):
+- Replace every occurrence of `old_path` with `new_path` in that file (exact string substitution, preserving surrounding context)
+- Show a brief diff of each change before writing
+- Apply only after the maintainer does not object
+
+After applying cross-reference updates, run a quick grep to confirm no remaining references exist:
+
+```bash
+grep -r "<old_path>" <project_specific_file_list>
+```
+
+If any references remain, list them and ask the maintainer whether to update them or leave them intentionally.
+
+**Bulk phrases do not cover rename cleanup**: "apply all", "apply everything", or "yes to all" never authorize rename cleanup actions. Each rename cleanup action (delete directory, update cross-references) requires the maintainer to name it explicitly.
 
 If the template source was a remote clone, clean up the exact temp directory recorded in Step 0:
 

--- a/.claude/commands/sync-template.md
+++ b/.claude/commands/sync-template.md
@@ -156,7 +156,7 @@ For each file in these paths:
 1. Verify that `entry.new_path` is present in `categories.always_sync`. If it is not, skip this entry.
 2. Check whether `entry.old_path` exists as a non-empty directory in the project:
    ```bash
-   [ -d "<old_path>" ] && find "<old_path>" -maxdepth 1 | wc -l
+   [ -d "<old_path>" ] && find "<old_path>" -mindepth 1 -maxdepth 1 | wc -l
    ```
 3. If `old_path` exists and is non-empty: record it as a **rename cleanup candidate** with:
    - `old_path`, `new_path`, `introduced_in`, and `description` from the manifest entry

--- a/.claude/commands/sync-template.md
+++ b/.claude/commands/sync-template.md
@@ -5,7 +5,7 @@ description: >
   shows a categorized diff for review, applies approved changes, and generates
   ready-to-use git instructions (branch + commit + PR). Run from the project root.
   Usage: /sync-template [--local=/path/to/template] [--ref=<branch|tag>]
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git rev-parse:*), Bash(git status:*), Bash(git branch:*), Bash(git clone:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*), Bash(git checkout:*), Bash(git push:*), Bash(cat:*), Bash(cp:*), Bash(find:*), Bash(ls:*), Bash(mkdir:*), Bash(rm:*), Bash(date:*), Bash(jq:*), Bash(diff:*), Bash(chmod:*)
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git rev-parse:*), Bash(git status:*), Bash(git branch:*), Bash(git clone:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*), Bash(git checkout:*), Bash(git push:*), Bash(git rm:*), Bash(cat:*), Bash(cp:*), Bash(find:*), Bash(ls:*), Bash(mkdir:*), Bash(rm:*), Bash(date:*), Bash(jq:*), Bash(diff:*), Bash(chmod:*), Bash(grep:*)
 ---
 
 Follow this workflow exactly when invoked. Do not skip steps or reorder them.

--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -146,6 +146,23 @@ For each file in these paths:
 - **Exists in both, content identical** → classify as ⏭ **No change** (list but don't highlight)
 - **Exists in project, not in template** → **ignore** (never delete project-only files)
 
+### Rename cleanup detection
+
+**If `SYNC_MANIFEST` is loaded and contains a `rename_detections` list**: after completing the always-sync comparison above, check each entry:
+
+1. Verify that `entry.new_path` is present in `categories.always_sync`. If it is not, skip this entry.
+2. Check whether `entry.old_path` exists as a non-empty directory in the project:
+   ```bash
+   [ -d "<old_path>" ] && find "<old_path>" -maxdepth 1 | wc -l
+   ```
+3. If `old_path` exists and is non-empty: record it as a **rename cleanup candidate** with:
+   - `old_path`, `new_path`, `introduced_in`, and `description` from the manifest entry
+   - A list of project-specific files that contain references to `old_path` (scan the files in `categories.project_specific` using `grep -rl "<old_path>"`; collect matching file paths for the cross-reference update offer)
+
+Rename cleanup candidates are displayed in Step 3 and applied in Step 4 only after explicit maintainer approval. The "never delete project-only files" rule in the always-sync section does **not** apply here: `old_path` is a **former always-sync directory** whose content was superseded by `new_path`, not a project-owned directory.
+
+**If `SYNC_MANIFEST=absent`**: skip rename cleanup detection entirely (no candidates to detect without manifest data).
+
 ### Special handling (show full diff, user decides per file)
 
 **If `SYNC_MANIFEST` is loaded**: read `categories.special_handling` from the manifest.
@@ -241,7 +258,17 @@ Manifest: loaded from sync-manifest.yaml  (or: "not found — using embedded fal
   AGENTS.md — template has [brief description]; project keeps its own content; suggest adding: …
   README.md — no template additions suggested
   …
+
+### 🗂️ Rename cleanup (you decide)
+  docs/ai/ — was the previous location of always-sync content now in docs/workflow/ (renamed in v0.23.0).
+  Stale directory still present. Proposed actions (each requires separate approval):
+    1. Delete docs/ai/  (git rm -r docs/ai/)
+    2. Update cross-references in project-specific files:
+         AGENTS.md  — 3 reference(s) to docs/ai/  →  docs/workflow/
+         README.md  — 1 reference(s) to docs/ai/  →  docs/workflow/
 ```
+
+If no rename cleanup candidates were detected, omit the "Rename cleanup" section entirely from the summary.
 
 After applying changes, show a final disposition summary with separate counts (AC-5 / UX Rule 4):
 
@@ -266,8 +293,37 @@ Then ask:
 - Copy/overwrite all ✅ (Add) and 📝 (Update) files **from the always-sync Step 3 section only** when the user confirms that batch. Phrases such as "apply all", "apply everything", or "yes to all" mean **always-sync files only** — they **never** authorize applying **special-handling** paths (`.github/workflows/deploy.yml`, `e2e-regression.yml`, `e2e/`, `.claude/settings.json`, etc.) or **optional additive updates**; those require the user to name each approved path (or `none`).
 - **Placeholder guard for workflow YAML** (`.github/workflows/deploy.yml`, `.github/workflows/e2e-regression.yml`): Before overwriting the project copy with the template, compare line counts. If the **project** file has **more lines** than the template and the template has **fewer than 70%** of the project's line count, treat this as likely "real implementation → template placeholder" and **refuse** unless the user sends a **second** explicit confirmation naming that exact file.
 - For ⚠️ files: apply only those the user explicitly approved (including any optional additive updates to project-specific files — merge or add only, never remove project-specific content)
-- Do **not** delete any file
+- Do **not** delete any file from the always-sync, special-handling, or project-specific categories without explicit approval
 - Do **not** overwrite project-specific files; for those paths only additive/merge changes are allowed, and only with explicit approval
+
+### Rename cleanup actions (only when maintainer approves each action individually)
+
+For each rename cleanup candidate from Step 3, apply only the actions the maintainer explicitly approved:
+
+**Action 1 — Delete the stale old directory** (only if the maintainer approved "delete `<old_path>`"):
+
+```bash
+git rm -r <old_path>
+```
+
+Do not use `rm -rf` — use `git rm -r` so the removal is tracked by git. After running the command, verify the directory no longer exists.
+
+**Action 2 — Update cross-references in project-specific files** (only if the maintainer approved "update cross-references"):
+
+For each project-specific file that contained references to `old_path` (identified during Step 2 rename detection):
+- Replace every occurrence of `old_path` with `new_path` in that file (exact string substitution, preserving surrounding context)
+- Show a brief diff of each change before writing
+- Apply only after the maintainer does not object
+
+After applying cross-reference updates, run a quick grep to confirm no remaining references exist:
+
+```bash
+grep -r "<old_path>" <project_specific_file_list>
+```
+
+If any references remain, list them and ask the maintainer whether to update them or leave them intentionally.
+
+**Bulk phrases do not cover rename cleanup**: "apply all", "apply everything", or "yes to all" never authorize rename cleanup actions. Each rename cleanup action (delete directory, update cross-references) requires the maintainer to name it explicitly.
 
 If the template source was a remote clone, clean it up now:
 ```bash

--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -153,7 +153,7 @@ For each file in these paths:
 1. Verify that `entry.new_path` is present in `categories.always_sync`. If it is not, skip this entry.
 2. Check whether `entry.old_path` exists as a non-empty directory in the project:
    ```bash
-   [ -d "<old_path>" ] && find "<old_path>" -maxdepth 1 | wc -l
+   [ -d "<old_path>" ] && find "<old_path>" -mindepth 1 -maxdepth 1 | wc -l
    ```
 3. If `old_path` exists and is non-empty: record it as a **rename cleanup candidate** with:
    - `old_path`, `new_path`, `introduced_in`, and `description` from the manifest entry

--- a/.codex/skills/workflow-sync-template/SKILL.md
+++ b/.codex/skills/workflow-sync-template/SKILL.md
@@ -13,6 +13,7 @@ Recommended model tier: `economy`
 4. Apply the same manifest-driven procedure as the Claude Code and Cursor sync-template artefacts:
    - Check for `sync-manifest.yaml` at the template root after resolving the template source.
    - If found, use `categories.always_sync`, `categories.special_handling`, and `categories.project_specific` from the manifest.
+   - If found and `rename_detections` is present, apply the rename cleanup detection defined in the protocol's "Rename cleanup detection" section (Step 2) and display the "Rename cleanup" section in Step 3 when candidates are found.
    - If absent, fall back to the embedded file list in the protocol and display the warning message.
    - For mixed-content files (`mixed_content: true`, `annotation_scheme: html_comments`), apply the extraction logic defined in the protocol's "Mixed-content extraction logic" section.
 5. Present the structured sync summary (always-sync counts, new/modified/up-to-date breakdown) before asking for confirmation.

--- a/.cursor/commands/sync-template.md
+++ b/.cursor/commands/sync-template.md
@@ -145,6 +145,23 @@ For each file in these paths:
 - **Exists in both, content identical** → classify as ⏭ **No change** (list but don't highlight)
 - **Exists in project, not in template** → **ignore** (never delete project-only files)
 
+### Rename cleanup detection
+
+**If `SYNC_MANIFEST` is loaded and contains a `rename_detections` list**: after completing the always-sync comparison above, check each entry:
+
+1. Verify that `entry.new_path` is present in `categories.always_sync`. If it is not, skip this entry.
+2. Check whether `entry.old_path` exists as a non-empty directory in the project:
+   ```bash
+   [ -d "<old_path>" ] && find "<old_path>" -maxdepth 1 | wc -l
+   ```
+3. If `old_path` exists and is non-empty: record it as a **rename cleanup candidate** with:
+   - `old_path`, `new_path`, `introduced_in`, and `description` from the manifest entry
+   - A list of project-specific files that contain references to `old_path` (scan the files in `categories.project_specific` using `grep -rl "<old_path>"`; collect matching file paths for the cross-reference update offer)
+
+Rename cleanup candidates are displayed in Step 3 and applied in Step 4 only after explicit maintainer approval. The "never delete project-only files" rule in the always-sync section does **not** apply here: `old_path` is a **former always-sync directory** whose content was superseded by `new_path`, not a project-owned directory.
+
+**If `SYNC_MANIFEST=absent`**: skip rename cleanup detection entirely (no candidates to detect without manifest data).
+
 ### Special handling (show full diff, user decides per file)
 
 **If `SYNC_MANIFEST` is loaded**: read `categories.special_handling` from the manifest.
@@ -240,7 +257,17 @@ Manifest: loaded from sync-manifest.yaml  (or: "not found — using embedded fal
   AGENTS.md — template has [brief description]; project keeps its own content; suggest adding: …
   README.md — no template additions suggested
   …
+
+### 🗂️ Rename cleanup (you decide)
+  docs/ai/ — was the previous location of always-sync content now in docs/workflow/ (renamed in v0.23.0).
+  Stale directory still present. Proposed actions (each requires separate approval):
+    1. Delete docs/ai/  (git rm -r docs/ai/)
+    2. Update cross-references in project-specific files:
+         AGENTS.md  — 3 reference(s) to docs/ai/  →  docs/workflow/
+         README.md  — 1 reference(s) to docs/ai/  →  docs/workflow/
 ```
+
+If no rename cleanup candidates were detected, omit the "Rename cleanup" section entirely from the summary.
 
 After applying changes, show a final disposition summary with separate counts (AC-5 / UX Rule 4):
 
@@ -265,8 +292,37 @@ Then ask:
 - Copy/overwrite all ✅ (Add) and 📝 (Update) files **from the always-sync Step 3 section only** when the user confirms that batch. Phrases such as "apply all", "apply everything", or "yes to all" mean **always-sync files only** — they **never** authorize applying **special-handling** paths (`.github/workflows/deploy.yml`, `e2e-regression.yml`, `e2e/`, `.claude/settings.json`, etc.) or **optional additive updates**; those require the user to name each approved path (or `none`).
 - **Placeholder guard for workflow YAML** (`.github/workflows/deploy.yml`, `.github/workflows/e2e-regression.yml`): Before overwriting the project copy with the template, compare line counts. If the **project** file has **more lines** than the template and the template has **fewer than 70%** of the project's line count, treat this as likely "real implementation → template placeholder" and **refuse** unless the user sends a **second** explicit confirmation naming that exact file.
 - For ⚠️ files: apply only those the user explicitly approved (including any optional additive updates to project-specific files — merge or add only, never remove project-specific content)
-- Do **not** delete any file
+- Do **not** delete any file from the always-sync, special-handling, or project-specific categories without explicit approval
 - Do **not** overwrite project-specific files; for those paths only additive/merge changes are allowed, and only with explicit approval
+
+### Rename cleanup actions (only when maintainer approves each action individually)
+
+For each rename cleanup candidate from Step 3, apply only the actions the maintainer explicitly approved:
+
+**Action 1 — Delete the stale old directory** (only if the maintainer approved "delete `<old_path>`"):
+
+```bash
+git rm -r <old_path>
+```
+
+Do not use `rm -rf` — use `git rm -r` so the removal is tracked by git. After running the command, verify the directory no longer exists.
+
+**Action 2 — Update cross-references in project-specific files** (only if the maintainer approved "update cross-references"):
+
+For each project-specific file that contained references to `old_path` (identified during Step 2 rename detection):
+- Replace every occurrence of `old_path` with `new_path` in that file (exact string substitution, preserving surrounding context)
+- Show a brief diff of each change before writing
+- Apply only after the maintainer does not object
+
+After applying cross-reference updates, run a quick grep to confirm no remaining references exist:
+
+```bash
+grep -r "<old_path>" <project_specific_file_list>
+```
+
+If any references remain, list them and ask the maintainer whether to update them or leave them intentionally.
+
+**Bulk phrases do not cover rename cleanup**: "apply all", "apply everything", or "yes to all" never authorize rename cleanup actions. Each rename cleanup action (delete directory, update cross-references) requires the maintainer to name it explicitly.
 
 If the template source was a remote clone, clean it up now:
 ```bash

--- a/.cursor/commands/sync-template.md
+++ b/.cursor/commands/sync-template.md
@@ -152,7 +152,7 @@ For each file in these paths:
 1. Verify that `entry.new_path` is present in `categories.always_sync`. If it is not, skip this entry.
 2. Check whether `entry.old_path` exists as a non-empty directory in the project:
    ```bash
-   [ -d "<old_path>" ] && find "<old_path>" -maxdepth 1 | wc -l
+   [ -d "<old_path>" ] && find "<old_path>" -mindepth 1 -maxdepth 1 | wc -l
    ```
 3. If `old_path` exists and is non-empty: record it as a **rename cleanup candidate** with:
    - `old_path`, `new_path`, `introduced_in`, and `description` from the manifest entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Sync-template leaves stale renamed directory in place** (`sync-manifest.yaml`, `.claude/commands/sync-template.md`, `.claude/skills/sync-template.md`, `.cursor/commands/sync-template.md`): When the template renames an always-sync directory (e.g., `docs/ai/` → `docs/workflow/`), the "never delete project-only files" rule previously prevented removal of the old directory, leaving both trees in place with stale cross-references. Added a `rename_detections` section to `sync-manifest.yaml` and updated all sync-template skill/command variants to detect stale old directories during Step 2 and present a "Rename cleanup" section in Step 3 — offering to delete the old directory and update cross-references in project-specific files. Each action requires separate maintainer approval; neither is applied silently. Bulk approval phrases ("apply all", "yes to all") do not cover rename cleanup actions.
+
 - **Shell variable interpolation in GraphQL mutation** (`workflow-lib.sh`): `update_tracker_status_best_effort` was interpolating `${project_id}`, `${item_id}`, `${field_id}`, and `${option_id}` directly into the query string. Switched to `-f` parameterized variables with a typed mutation signature (`$projectId: ID!`, `$itemId: ID!`, `$fieldId: ID!`, `$optionId: String!`), eliminating the injection risk and aligning with the safe pattern used elsewhere in the codebase.
 
 ## [0.23.0] - 2026-04-25

--- a/sync-manifest.yaml
+++ b/sync-manifest.yaml
@@ -147,3 +147,27 @@ migration_notes:
       - "Check whether the old directory exists: ls docs/ai/ 2>/dev/null && echo 'exists' || echo 'already renamed'"
       - "If it exists, rename it: git mv docs/ai docs/workflow"
       - "Commit the rename before applying template file updates: git add -A && git commit -m 'refactor: rename docs/ai to docs/workflow (template migration to v0.23.0)'"
+
+# rename_detections: directories previously used for always-sync content that were renamed
+# in the template. The sync-template skill checks each entry during Step 2: if old_path
+# exists in the project while new_path is in the always_sync list, the skill records a
+# rename cleanup candidate.
+#
+# In Step 3, candidates are presented under a "Rename cleanup" section so the maintainer
+# can approve: (1) deletion of the stale old_path directory, and (2) an offer to scan
+# project-specific files for cross-references to old_path and update them to new_path.
+# The skill MUST NOT delete old_path or modify any cross-references without explicit
+# maintainer approval for each action.
+#
+# Fields:
+#   old_path      - the stale directory path that should be removed after the rename
+#   new_path      - the replacement path (must be in categories.always_sync)
+#   introduced_in - template version when the rename was introduced
+#   description   - short human-readable explanation shown in the Step 3 summary
+rename_detections:
+  - old_path: docs/ai/
+    new_path: docs/workflow/
+    introduced_in: "0.23.0"
+    description: >
+      docs/ai/ was renamed to docs/workflow/ in template v0.23.0. The stale docs/ai/
+      directory still exists in the project alongside the new docs/workflow/ tree.


### PR DESCRIPTION
## Summary

Fixes #336. When the template renames an always-sync directory (e.g. `docs/ai/` → `docs/workflow/`), the sync-template skill previously applied the "never delete project-only files" rule to the old directory, leaving both trees in place with stale cross-references throughout project-specific files.

### Changes

- **`sync-manifest.yaml`**: adds a `rename_detections` section listing known always-sync directory renames (`docs/ai/` → `docs/workflow/` as the first entry). Each entry specifies `old_path`, `new_path`, `introduced_in`, and `description`.
- **`.claude/commands/sync-template.md`**, **`.claude/skills/sync-template.md`**, **`.cursor/commands/sync-template.md`**: updates Step 2 to detect rename cleanup candidates (checks each `rename_detections` entry: if `old_path` still exists in the project and `new_path` is in `always_sync`, records it as a candidate along with a list of project-specific files containing cross-references); updates Step 3 to show a "Rename cleanup" section in the summary when candidates are found; updates Step 4 to apply each approved action (directory deletion via `git rm -r`, and cross-reference updates in project-specific files).

### Key design decisions

- The offer is presented in Step 3 under "Rename cleanup", not applied silently.
- Each action (delete old directory, update cross-references) requires separate explicit maintainer approval.
- Bulk approval phrases ("apply all", "yes to all") never cover rename cleanup actions.
- The "never delete project-only files" rule is explicitly carved out for former always-sync directories detected via `rename_detections` — these are not project-owned files.
- When `SYNC_MANIFEST=absent`, rename cleanup detection is skipped entirely.

## Test plan

- [ ] Verify that `sync-manifest.yaml` schema is valid YAML with the new `rename_detections` section.
- [ ] Manually trace through the Step 2 detection logic for a project that has `docs/ai/` still present: confirm the skill would record it as a candidate.
- [ ] Manually trace through the Step 3 summary format: confirm the "Rename cleanup" section appears with correct wording and the two proposed actions.
- [ ] Verify that a project without `docs/ai/` produces no "Rename cleanup" section.
- [ ] Verify that `SYNC_MANIFEST=absent` skips rename detection entirely.
- [ ] Verify markdown lint passes on all changed files.
- [ ] Verify CHANGELOG entry is under `[Unreleased] ### Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)