### PR TITLE
fix(batch-merge): guard branch deletion behind MERGED state check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Batch-merge remote branch deleted before MERGED confirmation** (`batch-merge.sh`, protocol 94): Deleting the feature branch before `git push origin develop` is reflected by GitHub causes the PR to transition to `CLOSED` instead of `MERGED`, permanently losing merge attribution even though the commits land in `develop`. Added a new `delete-branch` subcommand to `batch-merge.sh` that re-checks `gh pr view <N> --json state` immediately before deletion and emits a warning (skipping deletion) if the state is not `MERGED`. Updated protocol 94 Step 4.2 to use this guarded command and to document the failure mode.
-
 ### Added
 
 - **Sync-template migration notes** (`sync-manifest.yaml`, sync-template skill and commands): `sync-manifest.yaml` gains a `migration_notes` section for versioned manual migration steps. The sync-template skill and command variants now read this section and present a required pre-sync checklist whenever the downstream project's `last_synced_version` predates a breaking structural change. First entry: `docs/ai/ → docs/workflow/` rename (v0.23.0). Fully backwards-compatible — silently skipped when no applicable notes exist.
 
 ### Fixed
+
+- **Batch-merge remote branch deleted before MERGED confirmation** (`batch-merge.sh`, protocol 94): Deleting the feature branch before `git push origin develop` is reflected by GitHub causes the PR to transition to `CLOSED` instead of `MERGED`, permanently losing merge attribution even though the commits land in `develop`. Added a new `delete-branch` subcommand to `batch-merge.sh` that re-checks `gh pr view <N> --json state` immediately before deletion and emits a warning (skipping deletion) if the state is not `MERGED`. Updated protocol 94 Step 4.2 to use this guarded command and to document the failure mode.
 
 - **Pre-dispatch stale-worktree and unsynced-base-branch check** (`90-batch-orchestrate-work-protocol.md`): Added Step 3.3 "Pre-Dispatch Environment Validation" to the Portfolio Orchestrator protocol. The new step runs two portfolio-wide checks before any Work Item Runner is dispatched: (1) detect orphaned/locked worktrees from prior runs whose branches are merged, closed, or no longer active — report them with suggested `git worktree remove --force` cleanup commands and block dispatch until resolved; (2) verify the integration branch is not ahead of `origin` — if it is, warn the human and block dispatch until the pending commits are pushed or the risk is explicitly acknowledged. Both checks run in parallel and are reported together to minimize human interruptions.
 - **Commit SHA verification before marking reviewer findings resolved** (`91-orchestrate-work-protocol.md`, `93-automated-reviewer-loop-protocol.md`): Added a mandatory commit SHA verification step requiring agents to confirm a cited commit exists in `git log` before recording it as `resolved_commit` in the PR feedback ledger and before posting fix commit comments. If the SHA is absent, the agent must commit staged changes first and use the real SHA from `git log`. Prevents fabricated SHA references (as observed in PR #321) from propagating into the audit trail and causing PRs to be labeled `ready-for-human-review` with uncommitted fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Batch-merge remote branch deleted before MERGED confirmation** (`batch-merge.sh`, protocol 94): Deleting the feature branch before `git push origin develop` is reflected by GitHub causes the PR to transition to `CLOSED` instead of `MERGED`, permanently losing merge attribution even though the commits land in `develop`. Added a new `delete-branch` subcommand to `batch-merge.sh` that re-checks `gh pr view <N> --json state` immediately before deletion and emits a warning (skipping deletion) if the state is not `MERGED`. Updated protocol 94 Step 4.2 to use this guarded command and to document the failure mode.
+
 ### Added
 
 - **Sync-template migration notes** (`sync-manifest.yaml`, sync-template skill and commands): `sync-manifest.yaml` gains a `migration_notes` section for versioned manual migration steps. The sync-template skill and command variants now read this section and present a required pre-sync checklist whenever the downstream project's `last_synced_version` predates a breaking structural change. First entry: `docs/ai/ → docs/workflow/` rename (v0.23.0). Fully backwards-compatible — silently skipped when no applicable notes exist.

--- a/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
+++ b/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
@@ -188,13 +188,29 @@ After a clean or resolved merge, in order:
 
    - If the state is not `MERGED` after up to 30 seconds (poll every 5 s): report `failed` for this PR, do not delete the remote branch or run cleanup, and continue with the next PR.
 
-3. **Delete the remote branch** (if it still exists):
+   > **Failure mode — CLOSED instead of MERGED**: If the remote feature branch is
+   > deleted *before* the `git push origin develop` completes (or before GitHub
+   > processes the push), GitHub closes the PR instead of recording it as merged.
+   > The commits land in `develop` but `gh pr view N --json state` returns `CLOSED`,
+   > not `MERGED`, permanently losing merge attribution. This is why branch deletion
+   > (Step 3 below) is always performed *after* MERGED confirmation, and the
+   > `delete-branch` subcommand enforces this guard automatically.
+
+3. **Delete the remote branch** using the guarded helper (which re-checks MERGED
+   state immediately before deletion to prevent the CLOSED-not-MERGED failure mode):
 
    ```bash
-   gh pr view <number> --json headRefName --jq '.headRefName'
-   # If the remote branch still exists:
-   git push origin --delete <branch> 2>/dev/null || true
+   ./scripts/development-workflow/batch-merge.sh delete-branch --pr <number>
    ```
+
+   Parse the output:
+
+   - `DELETE_RESULT=deleted` → branch was deleted successfully.
+   - `DELETE_RESULT=not_found` → branch was already gone (auto-delete or prior run). No action needed.
+   - `DELETE_RESULT=skipped` → PR is not in `MERGED` state. The `ERROR_MESSAGE` field
+     contains details. Do **not** delete the branch manually. Investigate why GitHub
+     has not yet recognised the merge (e.g., push failed silently, network error)
+     before retrying.
 
 4. **Remove any worktree using the merged branch** (before running cleanup).
 

--- a/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
+++ b/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
@@ -207,10 +207,13 @@ After a clean or resolved merge, in order:
 
    - `DELETE_RESULT=deleted` → branch was deleted successfully.
    - `DELETE_RESULT=not_found` → branch was already gone (auto-delete or prior run). No action needed.
-   - `DELETE_RESULT=skipped` → PR is not in `MERGED` state. The `ERROR_MESSAGE` field
-     contains details. Do **not** delete the branch manually. Investigate why GitHub
-     has not yet recognised the merge (e.g., push failed silently, network error)
-     before retrying.
+   - `DELETE_RESULT=skipped` → branch was NOT deleted. The `ERROR_MESSAGE` field contains
+     the reason, which falls into one of two sub-cases:
+     - *PR not in MERGED state*: Do **not** delete the branch manually. Investigate why
+       GitHub has not yet recognised the merge (e.g., push failed silently, network error)
+       before retrying.
+     - *Push failure* (network/auth/permissions): Retry after resolving the underlying
+       issue. The branch still exists on the remote.
 
 4. **Remove any worktree using the merged branch** (before running cleanup).
 

--- a/scripts/development-workflow/batch-merge.sh
+++ b/scripts/development-workflow/batch-merge.sh
@@ -474,10 +474,12 @@ cmd_delete_branch() {
     # Branch was already gone — expected after auto-delete or a prior run.
     print_kv DELETE_RESULT "not_found"
   else
-    # Genuine push failure (network, auth, permissions, etc.) — report it.
+    # Genuine push failure (network, auth, permissions, etc.) — report it and
+    # exit 2 to signal a fatal error per the script's exit-code contract.
     print_kv DELETE_RESULT "skipped"
     print_kv_escaped ERROR_MESSAGE "Failed to delete remote branch '${branch}' (exit ${push_exit}): ${push_err}"
     echo "ERROR: failed to delete remote branch '${branch}': ${push_err}" >&2
+    exit 2
   fi
 }
 

--- a/scripts/development-workflow/batch-merge.sh
+++ b/scripts/development-workflow/batch-merge.sh
@@ -42,9 +42,9 @@
 # Delete-branch output:
 #   DELETE_PR_NUMBER=<n>
 #   DELETE_RESULT=deleted|skipped|not_found
-#   DELETE_BRANCH=<branch-name>
-#   DELETE_PR_STATE=<state>              (only when DELETE_RESULT=skipped)
-#   ERROR_MESSAGE=<text>                 (only when DELETE_RESULT=skipped due to non-MERGED state)
+#   DELETE_BRANCH=<branch-name>          (absent when metadata fetch fails before branch is known)
+#   DELETE_PR_STATE=<state>              (only when DELETE_RESULT=skipped due to non-MERGED state)
+#   ERROR_MESSAGE=<text>                 (when DELETE_RESULT=skipped; covers non-MERGED state and push failures)
 #
 # Exit codes:
 #   0  — operation succeeded (clean merge, discovery complete, or branch deleted/not_found)
@@ -426,10 +426,21 @@ cmd_delete_branch() {
 
   print_kv DELETE_PR_NUMBER "$pr_num"
 
+  # delete_die: emit structured failure output before exiting so the caller
+  # always receives DELETE_PR_NUMBER + DELETE_RESULT + ERROR_MESSAGE, not a
+  # partial tuple that violates the output contract.  Mirrors merge_die in
+  # cmd_merge for the same reason.
+  delete_die() {
+    print_kv DELETE_RESULT "skipped"
+    print_kv_escaped ERROR_MESSAGE "$*"
+    echo "ERROR: $*" >&2
+    exit 2
+  }
+
   # Fetch the current PR state and branch name.
   local pr_json branch state
   pr_json="$(gh pr view "$pr_num" --json headRefName,state 2>/dev/null)" || \
-    die "Could not fetch metadata for PR #${pr_num}"
+    delete_die "Could not fetch metadata for PR #${pr_num}"
 
   branch="$(printf '%s' "$pr_json" | jq -r '.headRefName')"
   state="$(printf '%s' "$pr_json" | jq -r '.state')"
@@ -448,13 +459,25 @@ cmd_delete_branch() {
     return 0
   fi
 
-  # Delete the remote branch (ignore errors if the branch is already gone —
-  # e.g., the repo has auto-delete-on-merge enabled).
-  if git push origin --delete "$branch" 2>/dev/null; then
+  # Delete the remote branch.  Distinguish "branch already gone" (expected
+  # when auto-delete-on-merge is enabled or a prior run already deleted it)
+  # from genuine errors (network failure, auth, permission denied) — the latter
+  # must be surfaced to the caller rather than silently reported as not_found.
+  local push_err push_exit
+  push_err="$(git push origin --delete "$branch" 2>&1)" && {
     print_kv DELETE_RESULT "deleted"
-  else
-    # Branch may have already been deleted (auto-delete or prior run).
+    return 0
+  }
+  push_exit=$?
+
+  if printf '%s' "$push_err" | grep -qi 'remote ref does not exist'; then
+    # Branch was already gone — expected after auto-delete or a prior run.
     print_kv DELETE_RESULT "not_found"
+  else
+    # Genuine push failure (network, auth, permissions, etc.) — report it.
+    print_kv DELETE_RESULT "skipped"
+    print_kv_escaped ERROR_MESSAGE "Failed to delete remote branch '${branch}' (exit ${push_exit}): ${push_err}"
+    echo "ERROR: failed to delete remote branch '${branch}': ${push_err}" >&2
   fi
 }
 

--- a/scripts/development-workflow/batch-merge.sh
+++ b/scripts/development-workflow/batch-merge.sh
@@ -47,7 +47,7 @@
 #   ERROR_MESSAGE=<text>                 (when DELETE_RESULT=skipped; covers non-MERGED state and push failures)
 #
 # Exit codes:
-#   0  — operation succeeded (clean merge, discovery complete, or branch deleted/not_found)
+#   0  — operation succeeded (clean merge, discovery complete, branch deleted/not_found, or branch deletion safely skipped — e.g. PR not yet MERGED)
 #   1  — conflict detected (caller must classify and resolve)
 #   2  — fatal error (invalid usage, git failure, etc.)
 #

--- a/scripts/development-workflow/batch-merge.sh
+++ b/scripts/development-workflow/batch-merge.sh
@@ -15,6 +15,9 @@
 #   # --- Per-PR merge mode ---
 #   ./scripts/development-workflow/batch-merge.sh merge --pr 101
 #
+#   # --- Safe branch deletion (MERGED-state guard) ---
+#   ./scripts/development-workflow/batch-merge.sh delete-branch --pr 101
+#
 # Discovery output (one block per candidate PR):
 #   DISCOVERY_RESULT=found|none
 #   PR_NUMBER=<n>
@@ -36,8 +39,15 @@
 #   CONFLICTED_FILES=<file1,file2,...>   (only when MERGE_RESULT=conflict)
 #   ERROR_MESSAGE=<text>                  (only when MERGE_RESULT=failed)
 #
+# Delete-branch output:
+#   DELETE_PR_NUMBER=<n>
+#   DELETE_RESULT=deleted|skipped|not_found
+#   DELETE_BRANCH=<branch-name>
+#   DELETE_PR_STATE=<state>              (only when DELETE_RESULT=skipped)
+#   ERROR_MESSAGE=<text>                 (only when DELETE_RESULT=skipped due to non-MERGED state)
+#
 # Exit codes:
-#   0  — operation succeeded (clean merge or discovery complete)
+#   0  — operation succeeded (clean merge, discovery complete, or branch deleted/not_found)
 #   1  — conflict detected (caller must classify and resolve)
 #   2  — fatal error (invalid usage, git failure, etc.)
 #
@@ -61,6 +71,7 @@ usage() {
 Usage:
   batch-merge.sh discover [--prs <num1,num2,...>]
   batch-merge.sh merge --pr <number>
+  batch-merge.sh delete-branch --pr <number>
 EOF
   exit 2
 }
@@ -380,6 +391,74 @@ cmd_merge() {
 }
 
 # ---------------------------------------------------------------------------
+# Command: delete-branch
+# ---------------------------------------------------------------------------
+#
+# Safely deletes the remote branch for a PR — but ONLY after confirming that
+# GitHub has recorded the PR as MERGED.  Deleting the branch before the merge
+# push is reflected by GitHub causes the PR to transition to CLOSED (not
+# MERGED), losing the merge attribution.  This guard prevents that failure mode.
+
+cmd_delete_branch() {
+  local pr_num=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --pr)
+        [ $# -ge 2 ] && [ -n "${2:-}" ] || die "--pr requires a PR number value"
+        pr_num="$2"
+        shift 2
+        ;;
+      *)
+        die "Unknown option: $1"
+        ;;
+    esac
+  done
+
+  [ -z "$pr_num" ] && usage
+
+  # Validate numeric.
+  case "$pr_num" in
+    ''|*[!0-9]*) die "Invalid PR number '${pr_num}' — must be a positive integer" ;;
+  esac
+
+  require_gh
+
+  print_kv DELETE_PR_NUMBER "$pr_num"
+
+  # Fetch the current PR state and branch name.
+  local pr_json branch state
+  pr_json="$(gh pr view "$pr_num" --json headRefName,state 2>/dev/null)" || \
+    die "Could not fetch metadata for PR #${pr_num}"
+
+  branch="$(printf '%s' "$pr_json" | jq -r '.headRefName')"
+  state="$(printf '%s' "$pr_json" | jq -r '.state')"
+
+  print_kv DELETE_BRANCH "$branch"
+
+  # Guard: only delete the remote branch when GitHub confirms MERGED state.
+  # If the PR is CLOSED (not MERGED) it means the merge push has not been
+  # reflected yet (or failed) — deleting now would permanently lose merge
+  # attribution on the PR.
+  if [ "$state" != "MERGED" ]; then
+    echo "WARNING: PR #${pr_num} is in state '${state}' (not MERGED) — skipping branch deletion to prevent data loss." >&2
+    print_kv DELETE_RESULT   "skipped"
+    print_kv DELETE_PR_STATE "$state"
+    print_kv_escaped ERROR_MESSAGE "PR #${pr_num} is in state '${state}' (not MERGED) — branch '${branch}' was NOT deleted. Verify the merge push completed and GitHub has updated the PR state before retrying."
+    return 0
+  fi
+
+  # Delete the remote branch (ignore errors if the branch is already gone —
+  # e.g., the repo has auto-delete-on-merge enabled).
+  if git push origin --delete "$branch" 2>/dev/null; then
+    print_kv DELETE_RESULT "deleted"
+  else
+    # Branch may have already been deleted (auto-delete or prior run).
+    print_kv DELETE_RESULT "not_found"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -391,7 +470,8 @@ COMMAND="$1"
 shift
 
 case "$COMMAND" in
-  discover) cmd_discover "$@" ;;
-  merge)    cmd_merge    "$@" ;;
+  discover)       cmd_discover       "$@" ;;
+  merge)          cmd_merge          "$@" ;;
+  delete-branch)  cmd_delete_branch  "$@" ;;
   *) die "Unknown command: ${COMMAND}" ;;
 esac


### PR DESCRIPTION
## Summary

- Adds a `delete-branch` subcommand to `batch-merge.sh` that verifies `gh pr view <N> --json state` returns `MERGED` before deleting the remote branch. If not `MERGED`, it emits `WARNING: PR #N is in state '<STATE>' (not MERGED) — skipping branch deletion to prevent data loss.` and exits cleanly.
- Updates protocol 94 Step 4.2.3 to use the new `delete-branch` subcommand instead of a raw `git push origin --delete` call.
- Documents the CLOSED-not-MERGED failure mode inline in protocol 94 Step 4.2 so future operators understand the root cause.

## Root cause

Deleting the remote feature branch before `git push origin develop` is fully reflected by GitHub causes GitHub to close the PR (branch gone = PR closed) rather than record it as merged. The commits land in `develop` but PR attribution is permanently lost.

## Fix

The new `delete-branch` subcommand is the single choke point for all remote branch deletions in the batch-merge flow. It fetches fresh state from GitHub immediately before every deletion and hard-blocks if `state != MERGED`. This makes the guard structural (not advisory).

## Test plan

- [ ] Verify `batch-merge.sh delete-branch --pr <N>` returns `DELETE_RESULT=deleted` for a merged PR
- [ ] Verify `batch-merge.sh delete-branch --pr <N>` returns `DELETE_RESULT=skipped` and warns for an open or closed PR
- [ ] Verify `batch-merge.sh delete-branch --pr <N>` returns `DELETE_RESULT=not_found` when branch is already gone
- [ ] Confirm protocol 94 Step 4.2 instructions reference the new subcommand
- [ ] Confirm CHANGELOG entry under `[Unreleased] ### Fixed`

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
