### PR TITLE
fix(batch-merge): document and enforce per-PR sequential merge discipline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Batch-merge orchestrator must not wrap merge calls in a single shell loop** (`94-batch-merge-protocol.md`, `batch-merge.sh`): Added an explicit sequencing rule to protocol Step 4.1 requiring that `batch-merge.sh merge --pr N` be called for exactly one PR at a time with `MERGE_RESULT` fully resolved before advancing to the next PR. Batching multiple calls in a non-interactive loop left the working tree in a conflicted state when any PR produced `MERGE_RESULT=conflict`, causing all subsequent merge attempts to fail. Added a pre-merge guard to `batch-merge.sh` that checks for unresolved conflict markers via `git status --porcelain` and exits non-zero with a clear diagnostic message before attempting `git checkout develop`.
+
 ### Added
 
 - **Sync-template migration notes** (`sync-manifest.yaml`, sync-template skill and commands): `sync-manifest.yaml` gains a `migration_notes` section for versioned manual migration steps. The sync-template skill and command variants now read this section and present a required pre-sync checklist whenever the downstream project's `last_synced_version` predates a breaking structural change. First entry: `docs/ai/ → docs/workflow/` rename (v0.23.0). Fully backwards-compatible — silently skipped when no applicable notes exist.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Batch-merge orchestrator must not wrap merge calls in a single shell loop** (`94-batch-merge-protocol.md`, `batch-merge.sh`): Added an explicit sequencing rule to protocol Step 4.1 requiring that `batch-merge.sh merge --pr N` be called for exactly one PR at a time with `MERGE_RESULT` fully resolved before advancing to the next PR. Batching multiple calls in a non-interactive loop left the working tree in a conflicted state when any PR produced `MERGE_RESULT=conflict`, causing all subsequent merge attempts to fail. Added a pre-merge guard to `batch-merge.sh` that checks for unresolved conflict markers via `git status --porcelain` and exits non-zero with a clear diagnostic message before attempting `git checkout develop`.
-
 ### Added
 
 - **Sync-template migration notes** (`sync-manifest.yaml`, sync-template skill and commands): `sync-manifest.yaml` gains a `migration_notes` section for versioned manual migration steps. The sync-template skill and command variants now read this section and present a required pre-sync checklist whenever the downstream project's `last_synced_version` predates a breaking structural change. First entry: `docs/ai/ → docs/workflow/` rename (v0.23.0). Fully backwards-compatible — silently skipped when no applicable notes exist.
+
+### Fixed
+
+- **Batch-merge orchestrator must not wrap merge calls in a single shell loop** (`94-batch-merge-protocol.md`, `batch-merge.sh`): Added an explicit sequencing rule to protocol Step 4.1 requiring that `batch-merge.sh merge --pr N` be called for exactly one PR at a time with `MERGE_RESULT` fully resolved before advancing to the next PR. Batching multiple calls in a non-interactive loop left the working tree in a conflicted state when any PR produced `MERGE_RESULT=conflict`, causing all subsequent merge attempts to fail. Added a pre-merge guard to `batch-merge.sh` that checks for unresolved conflict markers via `git status --porcelain` and exits non-zero with a clear diagnostic message before attempting `git checkout develop`.
 
 ## [0.23.0] - 2026-04-25
 

--- a/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
+++ b/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
@@ -144,6 +144,14 @@ Process PRs one at a time in the approved order.
 
 ### 4.1 Per-PR merge attempt
 
+> **Critical sequencing rule**: Call `batch-merge.sh merge --pr N` for **exactly one PR at a
+> time**, inspect `MERGE_RESULT`, and fully resolve the outcome (merge success, conflict
+> resolution, or abort) **before** advancing to the next PR. Never wrap multiple merge
+> calls in a single non-interactive shell loop (e.g., `for pr in …; do … merge --pr $pr; done`)
+> — if one PR leaves the working tree in a conflicted state, subsequent calls will fail with
+> "Could not check out 'develop' — working tree is not clean" and all remaining PRs will be
+> lost. The sequential discipline is mandatory even when all PRs are expected to be conflict-free.
+
 For each PR in the approved order:
 
 **a. Announce the merge attempt:**

--- a/scripts/development-workflow/batch-merge.sh
+++ b/scripts/development-workflow/batch-merge.sh
@@ -330,6 +330,16 @@ cmd_merge() {
     merge_die "PR #${pr_num} is labeled needs-fixes"
   fi
 
+  # Guard: refuse to proceed if the working tree has unresolved conflict markers.
+  # This prevents a previous merge's conflict state from contaminating this PR's
+  # merge (e.g., when the caller accidentally batches multiple merge calls in a
+  # single shell loop instead of handling each MERGE_RESULT individually).
+  local conflict_state
+  conflict_state="$(git status --porcelain 2>/dev/null | grep -E '^(UU|AA|DD|AU|UA|DU|UD)' || true)"
+  if [ -n "$conflict_state" ]; then
+    merge_die "Working tree has unresolved conflicts from a previous merge — resolve or abort the in-progress merge before calling merge --pr again. Conflicting paths: $(printf '%s' "$conflict_state" | awk '{print $2}' | tr '\n' ' ')"
+  fi
+
   # Ensure local develop is current
   git checkout "$TARGET_BASE" >/dev/null 2>&1 || \
     merge_die "Could not check out '${TARGET_BASE}' — ensure the working tree is clean and the branch exists locally"


### PR DESCRIPTION
## Summary

- **Protocol 94 Step 4.1**: Added an explicit sequencing rule that `batch-merge.sh merge --pr N` must be called for exactly one PR at a time, with `MERGE_RESULT` fully resolved before advancing to the next PR. The note explains the failure mode from batch 2026-04-27: a single loop over PRs #351–#360 left the working tree in a conflicted state after PR #351 produced `MERGE_RESULT=conflict`, causing PRs #352–#360 to all fail with "Could not check out 'develop'".
- **`batch-merge.sh` merge subcommand**: Added a pre-merge conflict-state guard that checks `git status --porcelain` for unresolved conflict markers (`UU`, `AA`, `DD`, `AU`, `UA`, `DU`, `UD`) and exits non-zero with a diagnostic listing the conflicting paths before attempting `git checkout develop`.

## Test plan

- [ ] Verify `bash -n scripts/development-workflow/batch-merge.sh` succeeds
- [ ] Verify `markdownlint-cli2` reports 0 errors on the updated protocol file and CHANGELOG
- [ ] Review new Step 4.1 warning block in `94-batch-merge-protocol.md` for clarity
- [ ] Review the conflict-state guard in `cmd_merge()` — confirm it fires before `git checkout develop` and that the error message names the conflicting paths
- [ ] Confirm CHANGELOG entry is under `[Unreleased] ### Fixed`

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
