### PR TITLE
fix(reviewer-loop): batch all Devin fixes into one commit per cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Devin review cycles outracing fix commits** (#372): fixer agents were addressing findings one-by-one and pushing after each individual fix, causing reviewer bots (e.g. Devin) to start re-reviewing stale state mid-fix and triggering unnecessary extra review cycles. Protocols `91-orchestrate-work-protocol.md` (Step 7) and `93-automated-reviewer-loop-protocol.md` now include an explicit mandatory batching rule: fixer agents must read all blocking findings first, apply all addressable fixes, and push exactly once per dispatch cycle rather than once per finding.
+
 ### Added
 
 - **Sync-template migration notes** (`sync-manifest.yaml`, sync-template skill and commands): `sync-manifest.yaml` gains a `migration_notes` section for versioned manual migration steps. The sync-template skill and command variants now read this section and present a required pre-sync checklist whenever the downstream project's `last_synced_version` predates a breaking structural change. First entry: `docs/ai/ → docs/workflow/` rename (v0.23.0). Fully backwards-compatible — silently skipped when no applicable notes exist.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Devin review cycles outracing fix commits** (#372): fixer agents were addressing findings one-by-one and pushing after each individual fix, causing reviewer bots (e.g. Devin) to start re-reviewing stale state mid-fix and triggering unnecessary extra review cycles. Protocols `91-orchestrate-work-protocol.md` (Step 7) and `93-automated-reviewer-loop-protocol.md` now include an explicit mandatory batching rule: fixer agents must read all blocking findings first, apply all addressable fixes, and push exactly once per dispatch cycle rather than once per finding.
-
 ### Added
 
 - **Sync-template migration notes** (`sync-manifest.yaml`, sync-template skill and commands): `sync-manifest.yaml` gains a `migration_notes` section for versioned manual migration steps. The sync-template skill and command variants now read this section and present a required pre-sync checklist whenever the downstream project's `last_synced_version` predates a breaking structural change. First entry: `docs/ai/ → docs/workflow/` rename (v0.23.0). Fully backwards-compatible — silently skipped when no applicable notes exist.
+
+### Fixed
+
+- **Devin review cycles outracing fix commits** (#372): fixer agents were addressing findings one-by-one and pushing after each individual fix, causing reviewer bots (e.g. Devin) to start re-reviewing stale state mid-fix and triggering unnecessary extra review cycles. Protocols `91-orchestrate-work-protocol.md` (Step 7) and `93-automated-reviewer-loop-protocol.md` now include an explicit mandatory batching rule: fixer agents must read all blocking findings first, apply all addressable fixes, and push exactly once per dispatch cycle rather than once per finding.
 
 ## [0.23.0] - 2026-04-25
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -783,6 +783,19 @@ Soft suggestions may be reported in summaries, but they do not change the loop r
 | `implementation-plan/*` | `implementation-plan-reviewer` |
 | `feature/*` / `refactor/*` / `fix/*` / `hotfix/*` | `code-reviewer` |
 
+**Fixer agent batching rule (mandatory):**
+
+When dispatching a fixer agent, include the following explicit instruction:
+
+> **Critical batching rule**: Do NOT address findings one-by-one with a separate push after each fix. Reviewer bots (e.g. Devin) start a new review cycle within 5–8 minutes of each push. If you push before all addressable fixes are done, the reviewer will start re-reviewing stale state while you are still working — creating a "one cycle behind" loop that can spin for dozens of cycles.
+>
+> Required sequence for every fixer dispatch:
+> 1. **Read ALL blocking findings first** — before touching any file, collect the complete list of open blocking findings from the current review cycle.
+> 2. **Apply ALL addressable fixes** — implement every fix you can address in this dispatch, across all files.
+> 3. **One commit, then push** — bundle every fix into a single commit and push once. Do not push after each individual fix.
+>
+> Findings that cannot be addressed in this dispatch (e.g. require a human decision, are out of scope, or are genuinely contradictory) should be noted and left for human review. Do not skip a push just because one finding is unresolvable — push the rest.
+
 ### Loop parameters
 
 | Parameter | Value | Description |

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -79,6 +79,20 @@ Also handle the case where a platform posted blocking findings after a previous 
 
 If unresolved findings exist: dispatch a fixer agent, wait for the push, then proceed to the scripts. Do not re-trigger the reviewer loop against stale findings — fix first.
 
+### Fixer agent batching rule (mandatory)
+
+Reviewer bots (e.g. Devin) start a new review cycle within 5–8 minutes of each push. Pushing after each individual fix means the reviewer starts re-reviewing stale state before all fixes are done, creating a "one cycle behind" pattern that can spin for 12+ review cycles on a single PR.
+
+**Required sequence for every fixer dispatch:**
+
+1. **Read ALL blocking findings first** — before editing any file, collect the complete list of open blocking findings from the current review cycle. Do not start fixing until you have the full picture.
+2. **Apply ALL addressable fixes** — implement every fix you can address in this dispatch, across all files and findings.
+3. **One commit, then push** — bundle every fix into a single commit and push exactly once per dispatch. Do not push after each individual fix.
+
+Findings that cannot be addressed in this dispatch (e.g. require a human decision, are out of scope, or are genuinely contradictory) should be noted. Do not withhold the push for unresolvable findings — push all the fixes you can, then document what remains.
+
+**When delegating to a fixer subagent**, include this rule explicitly in the subagent instruction so it knows not to push incrementally.
+
 ### Shell script fix verification (fixer agents)
 
 When findings target `*.sh` workflow scripts (especially under `scripts/development-workflow/`), the fixer must **verify locally before pushing**:


### PR DESCRIPTION
## Summary

- Fixer agents were addressing reviewer findings one-by-one and pushing after each individual fix, causing Devin (and other reviewer bots) to start a new 5–8 minute review cycle against stale state mid-fix
- This "one cycle behind" pattern was observed generating 12+ Devin review cycles on a single PR in a downstream project
- Adds an explicit mandatory batching rule to both protocol 91 (Step 7) and protocol 93: read ALL blocking findings first, apply ALL addressable fixes, then push exactly once per fixer dispatch

## Changes

- `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`: Added "Fixer agent batching rule (mandatory)" block after the "Fixing agent by PR branch type" table in Step 7
- `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`: Added new "Fixer agent batching rule (mandatory)" subsection before "Shell script fix verification (fixer agents)"
- `CHANGELOG.md`: Added entry under `[Unreleased] > Fixed`

## Test plan

- [ ] Read the updated Step 7 section in protocol 91 and verify the batching rule is clearly stated before the loop parameters
- [ ] Read the new section in protocol 93 and verify it precedes "Shell script fix verification"
- [ ] Verify the rule covers: (a) read all findings first, (b) apply all addressable fixes, (c) one push per dispatch
- [ ] Verify the rule includes delegation guidance (subagents must receive the instruction explicitly)
- [ ] Confirm CHANGELOG entry is under `[Unreleased] > Fixed` with no trailing whitespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
