### PR TITLE
fix(workflow-lib): GITHUB_PROJECT_NUMBER fallback from .ai-dev-workflow.yaml (#374)

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -85,6 +85,11 @@ review:
 issue_tracker:
   # Supported examples: linear, github_projects, github_issues, jira, clickup, notion, none
   provider: github_projects
+  # GitHub Projects project number (the integer in the project URL, e.g. /users/<owner>/projects/1).
+  # Used by workflow-lib.sh as a fallback when GITHUB_PROJECT_NUMBER env var is not set.
+  # Required for tracker status updates (update_tracker_status_best_effort) and status reads
+  # (get_tracker_status_for_issue) to function without setting an environment variable.
+  project_number: 1
 
 vcs:
   # Supported examples: github, gitlab, bitbucket, other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **`GITHUB_PROJECT_NUMBER` missing fallback causes silent tracker skips** (`workflow-lib.sh`, `.ai-dev-workflow.yaml`): `update_tracker_status_best_effort` and `get_tracker_status_for_issue` set `project_number` from `GITHUB_PROJECT_NUMBER` with no fallback, so tracker updates silently skipped on every run in normal shell sessions where the env var is not set. Fixed by reading `project_number` from the `issue_tracker.project_number` field in `.ai-dev-workflow.yaml` when the env var is absent (using `grep -A10` against the absolute path from `workflow_config_file()` to safely clear the comment lines before the field and avoid a CWD dependency). Added a `project_number: 1` field to `.ai-dev-workflow.yaml` with documentation comment.
-
 ### Added
 
 - **Sync-template migration notes** (`sync-manifest.yaml`, sync-template skill and commands): `sync-manifest.yaml` gains a `migration_notes` section for versioned manual migration steps. The sync-template skill and command variants now read this section and present a required pre-sync checklist whenever the downstream project's `last_synced_version` predates a breaking structural change. First entry: `docs/ai/ → docs/workflow/` rename (v0.23.0). Fully backwards-compatible — silently skipped when no applicable notes exist.
 
 ### Fixed
+
+- **`GITHUB_PROJECT_NUMBER` missing fallback causes silent tracker skips** (`workflow-lib.sh`, `.ai-dev-workflow.yaml`): `update_tracker_status_best_effort` and `get_tracker_status_for_issue` set `project_number` from `GITHUB_PROJECT_NUMBER` with no fallback, so tracker updates silently skipped on every run in normal shell sessions where the env var is not set. Fixed by reading `project_number` from the `issue_tracker.project_number` field in `.ai-dev-workflow.yaml` when the env var is absent (via a new `workflow_config_field` awk-based YAML section/field parser and `workflow_issue_tracker_project_number` named wrapper in `workflow-lib.sh`). Also removed the now-redundant `GITHUB_PROJECT_NUMBER` guard in `workflow-batch-plan.sh` that prevented the terminal-status skip from activating when project number was configured only via YAML. Added a `project_number: 1` field to `.ai-dev-workflow.yaml` with documentation comment.
 
 - **Project board status update skipped after issue close in `post-merge-cleanup.sh`** (#361): `gh project item-list` only returns items whose linked issue is still open, so the "Merged" tracker status update was silently skipped whenever the issue was closed first. Fixed by moving `update_tracker_status_best_effort` to run before `gh issue close`, ensuring the project item is still visible during the lookup.
 - **Batch-merge remote branch deleted before MERGED confirmation** (`batch-merge.sh`, protocol 94): Deleting the feature branch before `git push origin develop` is reflected by GitHub causes the PR to transition to `CLOSED` instead of `MERGED`, permanently losing merge attribution even though the commits land in `develop`. Added a new `delete-branch` subcommand to `batch-merge.sh` that re-checks `gh pr view <N> --json state` immediately before deletion and emits a warning (skipping deletion) if the state is not `MERGED`. Updated protocol 94 Step 4.2 to use this guarded command and to document the failure mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`GITHUB_PROJECT_NUMBER` missing fallback causes silent tracker skips** (`workflow-lib.sh`, `.ai-dev-workflow.yaml`): `update_tracker_status_best_effort` and `get_tracker_status_for_issue` set `project_number` from `GITHUB_PROJECT_NUMBER` with no fallback, so tracker updates silently skipped on every run in normal shell sessions where the env var is not set. Fixed by reading `project_number` from the `issue_tracker.project_number` field in `.ai-dev-workflow.yaml` when the env var is absent. Added a `project_number: 1` field to `.ai-dev-workflow.yaml` with documentation comment.
+- **`GITHUB_PROJECT_NUMBER` missing fallback causes silent tracker skips** (`workflow-lib.sh`, `.ai-dev-workflow.yaml`): `update_tracker_status_best_effort` and `get_tracker_status_for_issue` set `project_number` from `GITHUB_PROJECT_NUMBER` with no fallback, so tracker updates silently skipped on every run in normal shell sessions where the env var is not set. Fixed by reading `project_number` from the `issue_tracker.project_number` field in `.ai-dev-workflow.yaml` when the env var is absent (using `grep -A10` to safely clear the comment lines before the field). Added a `project_number: 1` field to `.ai-dev-workflow.yaml` with documentation comment.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`GITHUB_PROJECT_NUMBER` missing fallback causes silent tracker skips** (`workflow-lib.sh`, `.ai-dev-workflow.yaml`): `update_tracker_status_best_effort` and `get_tracker_status_for_issue` set `project_number` from `GITHUB_PROJECT_NUMBER` with no fallback, so tracker updates silently skipped on every run in normal shell sessions where the env var is not set. Fixed by reading `project_number` from the `issue_tracker.project_number` field in `.ai-dev-workflow.yaml` when the env var is absent. Added a `project_number: 1` field to `.ai-dev-workflow.yaml` with documentation comment.
+
 ### Added
 
 - **Sync-template migration notes** (`sync-manifest.yaml`, sync-template skill and commands): `sync-manifest.yaml` gains a `migration_notes` section for versioned manual migration steps. The sync-template skill and command variants now read this section and present a required pre-sync checklist whenever the downstream project's `last_synced_version` predates a breaking structural change. First entry: `docs/ai/ → docs/workflow/` rename (v0.23.0). Fully backwards-compatible — silently skipped when no applicable notes exist.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`GITHUB_PROJECT_NUMBER` missing fallback causes silent tracker skips** (`workflow-lib.sh`, `.ai-dev-workflow.yaml`): `update_tracker_status_best_effort` and `get_tracker_status_for_issue` set `project_number` from `GITHUB_PROJECT_NUMBER` with no fallback, so tracker updates silently skipped on every run in normal shell sessions where the env var is not set. Fixed by reading `project_number` from the `issue_tracker.project_number` field in `.ai-dev-workflow.yaml` when the env var is absent (using `grep -A10` to safely clear the comment lines before the field). Added a `project_number: 1` field to `.ai-dev-workflow.yaml` with documentation comment.
+- **`GITHUB_PROJECT_NUMBER` missing fallback causes silent tracker skips** (`workflow-lib.sh`, `.ai-dev-workflow.yaml`): `update_tracker_status_best_effort` and `get_tracker_status_for_issue` set `project_number` from `GITHUB_PROJECT_NUMBER` with no fallback, so tracker updates silently skipped on every run in normal shell sessions where the env var is not set. Fixed by reading `project_number` from the `issue_tracker.project_number` field in `.ai-dev-workflow.yaml` when the env var is absent (using `grep -A10` against the absolute path from `workflow_config_file()` to safely clear the comment lines before the field and avoid a CWD dependency). Added a `project_number: 1` field to `.ai-dev-workflow.yaml` with documentation comment.
 
 ### Added
 

--- a/scripts/development-workflow/workflow-batch-plan.sh
+++ b/scripts/development-workflow/workflow-batch-plan.sh
@@ -193,17 +193,18 @@ for development_path in "${development_paths[@]}"; do
   slug="$(basename "$development_path" | sed 's/^[0-9]\{14\}_//')"
 
   # Skip development folders whose tracker status is terminal (Released, Merged,
-  # Cancelled).  When GitHub Projects is configured (GITHUB_PROJECT_NUMBER set),
-  # query the tracker for each candidate and skip stale folders early — before
-  # running the more expensive workflow-next-action.sh call.
-  if [ -n "${GITHUB_PROJECT_NUMBER:-}" ]; then
-    issue_number="$(extract_github_issue_number "$development_path")"
-    if [ -n "$issue_number" ]; then
-      tracker_status="$(get_tracker_status_for_issue "$issue_number")"
-      if is_terminal_tracker_status "$tracker_status"; then
-        echo "Skipping $development_path: tracker status is terminal ('$tracker_status') for issue #$issue_number" >&2
-        continue
-      fi
+  # Cancelled).  When GitHub Projects is configured (GITHUB_PROJECT_NUMBER env var
+  # or issue_tracker.project_number in .ai-dev-workflow.yaml), query the tracker
+  # for each candidate and skip stale folders early — before running the more
+  # expensive workflow-next-action.sh call.
+  # get_tracker_status_for_issue returns empty string gracefully when no project
+  # is configured, so we can call it unconditionally.
+  issue_number="$(extract_github_issue_number "$development_path")"
+  if [ -n "$issue_number" ]; then
+    tracker_status="$(get_tracker_status_for_issue "$issue_number")"
+    if is_terminal_tracker_status "$tracker_status"; then
+      echo "Skipping $development_path: tracker status is terminal ('$tracker_status') for issue #$issue_number" >&2
+      continue
     fi
   fi
 

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -303,7 +303,7 @@ get_tracker_status_for_issue() {
   local owner project_number item_json current_status
 
   owner="${GITHUB_PROJECT_OWNER:-$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || true)}"
-  project_number="${GITHUB_PROJECT_NUMBER:-$(grep -A5 'issue_tracker:' .ai-dev-workflow.yaml 2>/dev/null | awk '/project_number:/ {print $2; exit}')}"
+  project_number="${GITHUB_PROJECT_NUMBER:-$(grep -A10 'issue_tracker:' .ai-dev-workflow.yaml 2>/dev/null | awk '/project_number:/ {print $2; exit}')}"
   if [ -z "$owner" ] || [ -z "$project_number" ]; then
     printf ''
     return 0
@@ -344,7 +344,7 @@ update_tracker_status_best_effort() {
   local target_order current_order
 
   owner="${GITHUB_PROJECT_OWNER:-$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || true)}"
-  project_number="${GITHUB_PROJECT_NUMBER:-$(grep -A5 'issue_tracker:' .ai-dev-workflow.yaml 2>/dev/null | awk '/project_number:/ {print $2; exit}')}"
+  project_number="${GITHUB_PROJECT_NUMBER:-$(grep -A10 'issue_tracker:' .ai-dev-workflow.yaml 2>/dev/null | awk '/project_number:/ {print $2; exit}')}"
   if [ -z "$owner" ] || [ -z "$project_number" ]; then
     echo "Warning: GITHUB_PROJECT_OWNER or GITHUB_PROJECT_NUMBER not set and no project_number in .ai-dev-workflow.yaml; skipping tracker status update."
     return 0

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -212,6 +212,47 @@ workflow_config_provider() {
   ' "$config_file"
 }
 
+workflow_config_field() {
+  local section="$1"
+  local field="$2"
+  local config_file="${3:-$(workflow_config_file)}"
+
+  [ -f "$config_file" ] || return 0
+
+  awk -v section="$section" -v field="$field" '
+    function trim(value) {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      gsub(/^["'"'"']|["'"'"']$/, "", value)
+      return value
+    }
+
+    $0 ~ ("^" section ":[[:space:]]*$") {
+      in_section = 1
+      next
+    }
+
+    in_section && /^[^[:space:]#].*:[[:space:]]*/ {
+      exit
+    }
+
+    in_section {
+      # Match "  <field>: <value>" — two-space indent, exact field name, optional comment
+      pattern = "^[[:space:]][[:space:]]" field ":[[:space:]]*"
+      if ($0 ~ pattern) {
+        line = $0
+        sub(/^[[:space:]]*[^[:space:]]*:[[:space:]]*/, "", line)
+        sub(/[[:space:]]+#.*$/, "", line)
+        print trim(line)
+        exit
+      }
+    }
+  ' "$config_file"
+}
+
+workflow_issue_tracker_project_number() {
+  workflow_config_field issue_tracker project_number
+}
+
 workflow_issue_tracker_provider_raw() {
   workflow_config_provider issue_tracker
 }
@@ -289,12 +330,13 @@ __workflow_tracker_cache_json=""
 # Queries GitHub Projects for the current Status of the given issue.
 # Prints the status string (e.g. "Merged", "Released", "In Development").
 # Prints an empty string when:
-#   - GITHUB_PROJECT_NUMBER is unset (GitHub Projects not configured)
+#   - project_number is unset in both GITHUB_PROJECT_NUMBER and .ai-dev-workflow.yaml
 #   - The issue is not found in the project
 #   - Any API call fails
 # Returns 0 in all cases (non-blocking).
 # Uses GITHUB_PROJECT_OWNER/GITHUB_PROJECT_NUMBER when set; owner falls back
-# to the repository owner if omitted.
+# to the repository owner if omitted; project_number falls back to the
+# issue_tracker.project_number field in .ai-dev-workflow.yaml if omitted.
 #
 # The full project item list is fetched once per owner+project pair and cached
 # in script-level variables to avoid a full-board scan on every call.
@@ -303,7 +345,7 @@ get_tracker_status_for_issue() {
   local owner project_number item_json current_status
 
   owner="${GITHUB_PROJECT_OWNER:-$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || true)}"
-  project_number="${GITHUB_PROJECT_NUMBER:-$(grep -A10 'issue_tracker:' "$(workflow_config_file)" 2>/dev/null | awk '/project_number:/ {print $2; exit}')}"
+  project_number="${GITHUB_PROJECT_NUMBER:-$(workflow_issue_tracker_project_number)}"
   if [ -z "$owner" ] || [ -z "$project_number" ]; then
     printf ''
     return 0
@@ -335,7 +377,8 @@ get_tracker_status_for_issue() {
 # - Returns 0 in all warning/failure cases to avoid blocking caller flows.
 # - Respects status progression ordering and never rolls status backward.
 # - Uses GITHUB_PROJECT_OWNER/GITHUB_PROJECT_NUMBER when set; owner falls back
-#   to the repository owner if omitted.
+#   to the repository owner if omitted; project_number falls back to the
+#   issue_tracker.project_number field in .ai-dev-workflow.yaml if omitted.
 update_tracker_status_best_effort() {
   local issue_number="$1"
   local status_label="$2"
@@ -344,7 +387,7 @@ update_tracker_status_best_effort() {
   local target_order current_order
 
   owner="${GITHUB_PROJECT_OWNER:-$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || true)}"
-  project_number="${GITHUB_PROJECT_NUMBER:-$(grep -A10 'issue_tracker:' "$(workflow_config_file)" 2>/dev/null | awk '/project_number:/ {print $2; exit}')}"
+  project_number="${GITHUB_PROJECT_NUMBER:-$(workflow_issue_tracker_project_number)}"
   if [ -z "$owner" ] || [ -z "$project_number" ]; then
     echo "Warning: GITHUB_PROJECT_OWNER or GITHUB_PROJECT_NUMBER not set and no project_number in .ai-dev-workflow.yaml; skipping tracker status update."
     return 0

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -303,7 +303,7 @@ get_tracker_status_for_issue() {
   local owner project_number item_json current_status
 
   owner="${GITHUB_PROJECT_OWNER:-$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || true)}"
-  project_number="${GITHUB_PROJECT_NUMBER:-}"
+  project_number="${GITHUB_PROJECT_NUMBER:-$(grep -A5 'issue_tracker:' .ai-dev-workflow.yaml 2>/dev/null | awk '/project_number:/ {print $2; exit}')}"
   if [ -z "$owner" ] || [ -z "$project_number" ]; then
     printf ''
     return 0
@@ -344,9 +344,9 @@ update_tracker_status_best_effort() {
   local target_order current_order
 
   owner="${GITHUB_PROJECT_OWNER:-$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || true)}"
-  project_number="${GITHUB_PROJECT_NUMBER:-}"
+  project_number="${GITHUB_PROJECT_NUMBER:-$(grep -A5 'issue_tracker:' .ai-dev-workflow.yaml 2>/dev/null | awk '/project_number:/ {print $2; exit}')}"
   if [ -z "$owner" ] || [ -z "$project_number" ]; then
-    echo "Warning: GITHUB_PROJECT_OWNER or GITHUB_PROJECT_NUMBER not set; skipping tracker status update."
+    echo "Warning: GITHUB_PROJECT_OWNER or GITHUB_PROJECT_NUMBER not set and no project_number in .ai-dev-workflow.yaml; skipping tracker status update."
     return 0
   fi
 

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -303,7 +303,7 @@ get_tracker_status_for_issue() {
   local owner project_number item_json current_status
 
   owner="${GITHUB_PROJECT_OWNER:-$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || true)}"
-  project_number="${GITHUB_PROJECT_NUMBER:-$(grep -A10 'issue_tracker:' .ai-dev-workflow.yaml 2>/dev/null | awk '/project_number:/ {print $2; exit}')}"
+  project_number="${GITHUB_PROJECT_NUMBER:-$(grep -A10 'issue_tracker:' "$(workflow_config_file)" 2>/dev/null | awk '/project_number:/ {print $2; exit}')}"
   if [ -z "$owner" ] || [ -z "$project_number" ]; then
     printf ''
     return 0
@@ -344,7 +344,7 @@ update_tracker_status_best_effort() {
   local target_order current_order
 
   owner="${GITHUB_PROJECT_OWNER:-$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || true)}"
-  project_number="${GITHUB_PROJECT_NUMBER:-$(grep -A10 'issue_tracker:' .ai-dev-workflow.yaml 2>/dev/null | awk '/project_number:/ {print $2; exit}')}"
+  project_number="${GITHUB_PROJECT_NUMBER:-$(grep -A10 'issue_tracker:' "$(workflow_config_file)" 2>/dev/null | awk '/project_number:/ {print $2; exit}')}"
   if [ -z "$owner" ] || [ -z "$project_number" ]; then
     echo "Warning: GITHUB_PROJECT_OWNER or GITHUB_PROJECT_NUMBER not set and no project_number in .ai-dev-workflow.yaml; skipping tracker status update."
     return 0


### PR DESCRIPTION
## Summary

- `update_tracker_status_best_effort` and `get_tracker_status_for_issue` in `workflow-lib.sh` set `project_number` from `GITHUB_PROJECT_NUMBER` with no fallback, causing all tracker status updates to be silently skipped on every run in normal shell sessions
- Adds a `grep`/`awk` fallback that reads `project_number` from the `issue_tracker` section of `.ai-dev-workflow.yaml` when the env var is absent
- Adds a `project_number: 1` field (with documentation comment) to `.ai-dev-workflow.yaml`

## Changes

- `scripts/development-workflow/workflow-lib.sh`: both `get_tracker_status_for_issue` (line 306) and `update_tracker_status_best_effort` (line 347) now use `${GITHUB_PROJECT_NUMBER:-$(grep -A5 'issue_tracker:' .ai-dev-workflow.yaml 2>/dev/null | awk '/project_number:/ {print $2; exit}')}`
- `.ai-dev-workflow.yaml`: added `project_number: 1` with a descriptive comment under `issue_tracker`
- `CHANGELOG.md`: entry added under `[Unreleased] ### Fixed`

## Test plan

- [ ] Verify `post-merge-cleanup` runs tracker update without `GITHUB_PROJECT_NUMBER` set and successfully moves issue status
- [ ] Verify the fallback silently skips when `.ai-dev-workflow.yaml` has no `project_number` field (backwards-compatible)
- [ ] Verify `GITHUB_PROJECT_NUMBER` env var still takes precedence when set

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
