### PR TITLE
docs(plan): parallel batch file-level conflict detection

### DIFF
--- a/docs/specs/developments/20260427222126_324-parallel-batch-file-conflict-detection/2_324-parallel-batch-file-conflict-detection_implementation-plan.md
+++ b/docs/specs/developments/20260427222126_324-parallel-batch-file-conflict-detection/2_324-parallel-batch-file-conflict-detection_implementation-plan.md
@@ -255,7 +255,7 @@ change modifies only workflow tooling internals and the orchestration protocol.
 # extract_file_set <development-folder-path>
 #
 # Extracts the declared file set from a development folder's implementation plan.
-# Looks for a heading matching /files (to be? )?modified/i and extracts paths from
+# Looks for a heading matching /files\s+(to\s+(be\s+)?)?modified/i and extracts paths from
 # the subsequent fenced code block or bullet list.
 #
 # Emits:
@@ -275,8 +275,8 @@ extract_file_set() {
   paths="$(python3 - "$plan_file" <<'PYEOF'
 import sys, re
 text = open(sys.argv[1]).read()
-# Find heading matching "files (to be?) modified" (case-insensitive)
-heading_re = re.compile(r'#+\s+files\s+(to\s+be?\s+)?modified', re.IGNORECASE)
+# Find heading matching "files (to (be )?)?modified" (case-insensitive)
+heading_re = re.compile(r'#+\s+files\s+(to\s+(be\s+)?)?modified', re.IGNORECASE)
 paths = []
 lines = text.splitlines()
 i = 0
@@ -289,14 +289,14 @@ while i < len(lines):
             while i < len(lines) and not lines[i].startswith('```'):
                 p = lines[i].strip()
                 if p:
-                    paths.append(p.lstrip('/').replace('\\\\', '/'))
+                    paths.append(p.lstrip('/').replace('\\', '/'))
                 i += 1
         else:
             # Bullet list
             while i < len(lines) and (lines[i].startswith('- ') or lines[i].startswith('* ')):
                 p = lines[i][2:].strip()
                 if p:
-                    paths.append(p.lstrip('/').replace('\\\\', '/'))
+                    paths.append(p.lstrip('/').replace('\\', '/'))
                 i += 1
     else:
         i += 1
@@ -320,7 +320,7 @@ PYEOF
 
 2. Add `extract_file_set` helper function to `workflow-batch-plan.sh`. Place it after
    `classify_tool_fix` and before `cd_workflow_repo_root`. Implement format detection for:
-   - Fenced code block under a heading matching `/files\s+(to\s+be?\s+)?modified/i`
+   - Fenced code block under a heading matching `/files\s+(to\s+(be\s+)?)?modified/i`
    - Bullet list under the same heading
    Use the Python one-liner approach from the Code Samples section (or an equivalent pure
    Bash/awk implementation if Python is unavailable). All edge cases in the parser-risk

--- a/docs/specs/developments/20260427222126_324-parallel-batch-file-conflict-detection/2_324-parallel-batch-file-conflict-detection_implementation-plan.md
+++ b/docs/specs/developments/20260427222126_324-parallel-batch-file-conflict-detection/2_324-parallel-batch-file-conflict-detection_implementation-plan.md
@@ -1,0 +1,359 @@
+# Parallel Batch File-Level Conflict Detection — Implementation Plan
+
+**Spec**: [1_324-parallel-batch-file-conflict-detection_specs.md](1_324-parallel-batch-file-conflict-detection_specs.md)
+**Smoke test runbook**: [docs/testing/workflow/324-parallel-batch-file-conflict-detection.smoke-test.md](../../../testing/workflow/324-parallel-batch-file-conflict-detection.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Extend `scripts/development-workflow/workflow-batch-plan.sh` to extract the
+declared file set from each implementation item's plan document and emit it as
+`FILE_SET=<comma-separated paths>` (or `FILE_SET=unknown` when extraction fails). Add a
+`detect_file_conflicts` helper function to the same script that the Portfolio Orchestrator invokes
+after the tool-fix check: it cross-checks file sets between all pairs of implementation items in
+a candidate batch, marks conflicting pairs per the priority rules in the spec, and emits a
+`CONFLICT_PAIRS` block. Update Protocol 90 Step 3 to insert a new subsection **"Same-batch
+file-level conflict detection"** (placed after the "Same-batch tool-fix ordering hazard"
+subsection) that codifies the detection algorithm, serialization rule, unknown-set handling, human
+override path, and ordering rules.
+
+**Estimated complexity**: M
+
+**Rationale**: The work spans two files (one shell script, one protocol document) and follows the
+same structural pattern as the tool-fix ordering feature (#199). The complexity is Medium rather
+than Small because the file-set extraction step must parse structured markdown reliably, the
+priority-based conflict resolution logic (BR-4 / BR-5) has multiple tiebreaker cases, and the
+integration with the existing tool-fix check (BR-8) requires ordering discipline within the script.
+
+**Dependencies**: None
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+|---|---|---|
+| Repo revision | `git rev-parse --short HEAD` | `0039ddb` |
+| Implementation plan template | `ls docs/workflow/development-workflow/templates/implementation-plan-template.md` | present |
+| Batch-plan script location | `ls scripts/development-workflow/workflow-batch-plan.sh` | present |
+| Protocol 90 location | `ls docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` | present |
+| Protocol 90 tool-fix subsection anchor | `grep -n "Same-batch tool-fix ordering hazard" docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` | line 235 |
+| "Codex fallback" paragraph anchor (insertion point for new subsection) | `grep -n "Codex fallback" docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` | line 290 |
+| Existing smoke test runbooks pattern | `ls docs/testing/workflow/199-same-batch-tool-fix-ordering.smoke-test.md` | present |
+| `print_kv` helper in workflow-lib.sh | `grep -n "print_kv" scripts/development-workflow/workflow-lib.sh` | function present |
+| `parallel_safe_for_action` emits `conditional` for `implement` | `grep -A5 "parallel_safe_for_action" scripts/development-workflow/workflow-batch-plan.sh` | `implement` → `conditional` |
+
+---
+
+## Layer-by-Layer Changes
+
+### Scripts / Workflow Tooling
+
+- [ ] Add an `extract_file_set` helper function to
+  `scripts/development-workflow/workflow-batch-plan.sh` that:
+  1. Accepts a development folder path.
+  2. Locates the implementation plan document (`2_*_implementation-plan.md`) inside the
+     folder using `find "$dev_path" -maxdepth 1 -name '2_*_implementation-plan.md'`.
+  3. If no plan document exists, emits `unknown` and returns.
+  4. Searches the plan document for lines inside an explicit "Files to be modified" list.
+     The canonical format is a fenced code block or a bullet list under a heading whose
+     normalized text matches `files to (be )?modified` or `files modified`
+     (case-insensitive). The function must handle at least these two formats:
+     - **Fenced code block format**: a block delimited by triple backticks under the
+       matching heading; each non-blank, non-backtick line is treated as a file path.
+     - **Bullet list format**: lines beginning with `- ` or `* ` directly under the
+       matching heading, where the bullet content is a repo-root-relative path (no
+       leading slash, forward slashes).
+  5. Normalizes each extracted path: trim leading/trailing whitespace, convert backslashes
+     to forward slashes, strip a leading `/` if present.
+  6. If after normalization the extracted set is empty, emits `unknown`.
+  7. Otherwise emits `<comma-separated normalized paths>` (sorted, deduplicated).
+
+  > **Parser-risk note**: this function is the core parser for the file-set extraction.
+  > See the Parser-risk addendum in the Testing Strategy section for edge-case coverage.
+
+- [ ] In `workflow-batch-plan.sh`, call `extract_file_set` for each development path that
+  has `NEXT_ACTION=implement` or `NEXT_ACTION=resolve-development-pr` (i.e.,
+  implementation-stage items only, matching BR-1). Emit:
+  - `print_kv FILE_SET "$file_set"` always (even `unknown`).
+
+- [ ] Add a `detect_file_conflicts` function to `workflow-batch-plan.sh` (or to a new
+  helper script `scripts/development-workflow/workflow-conflict-detect.sh` invoked from
+  `workflow-batch-plan.sh`). This function:
+  1. Accepts an associative-array-style input of `<item-id>=><comma-separated file set>` pairs
+     for all implementation items in the proposed batch. Items whose `FILE_SET=unknown` are
+     excluded from conflict analysis but included in the summary warning list.
+  2. For each pair `(A, B)` where both have known file sets, computes the intersection of
+     their file sets.
+  3. If the intersection is non-empty, records the pair as conflicting with the overlapping
+     file paths.
+  4. Applies the priority-based serialization rule (BR-4 / BR-5): compare item priorities;
+     the lower-priority item is serialized. Tiebreaker: later creation date is serialized.
+     Second tiebreaker: lexicographically later branch name is serialized.
+  5. Emits for each conflicting pair:
+     - `CONFLICT_PAIR=<item-A-id>,<item-B-id>` — the conflicting pair (higher-priority item
+       first)
+     - `CONFLICT_FILES=<comma-separated overlapping paths>` — the overlapping paths
+     - `SERIALIZE=<item-id>` — the item to move to the next sub-batch
+  6. Emits `CONFLICT_UNKNOWN=<item-id>` for each item whose file set is unknown.
+
+  > **Integration with tool-fix check (BR-8)**: `detect_file_conflicts` must receive only
+  > the items that **remain in the current batch after the tool-fix check**. Items already
+  > serialized by the tool-fix rule must be excluded from the conflict-detection input set.
+  > The orchestrator (or the calling code in `workflow-batch-plan.sh`) is responsible for
+  > excluding tool-fix-serialized items before passing the input to `detect_file_conflicts`.
+
+- [ ] The `parallel_safe_for_action` function already returns `conditional` for `implement`
+  and `resolve-development-pr`. No change is needed to that function — conflict detection
+  is an additional filter applied by the orchestrator after `workflow-batch-plan.sh` emits
+  the per-item `FILE_SET` values.
+
+### Protocol Documentation
+
+- [ ] In `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
+  **Step 3**, add a new subsection **"Same-batch file-level conflict detection"** immediately
+  after the existing "Same-batch tool-fix ordering hazard" subsection and before the "Codex
+  fallback" paragraph. The new subsection must cover:
+
+  1. **Scope** (BR-1): conflict detection applies only to implementation items (branches with
+     prefix `feature/`, `fix/`, `refactor/`, `hotfix/`). Spec and plan items are never
+     subject to file-level conflict serialization.
+
+  2. **Detection source**: `workflow-batch-plan.sh` emits `FILE_SET=<comma-separated paths>`
+     or `FILE_SET=unknown` per implementation item. The `FILE_SET` value is derived from the
+     explicit file list in the item's implementation plan document. Items without a plan
+     document, or whose plan contains no extractable file list, receive `FILE_SET=unknown`.
+
+  3. **Conflict definition** (BR-2): a conflict exists between two items when their declared
+     file sets share at least one common path. Paths are compared as normalized,
+     repo-root-relative strings (forward slashes, no leading slash).
+
+  4. **Serialization rule** (BR-4 / BR-5): when a conflict is detected, the lower-priority
+     item is moved to the next serial sub-batch. Priority is determined by: (a) item priority
+     level (Urgent > High > Normal > Low); (b) creation date (older stays); (c) branch name
+     lexicographic order (earlier stays). The batch summary must list the conflicting pair,
+     the overlapping file paths, and the resulting batch assignment for each item (BR-7).
+
+  5. **Unknown-set handling** (BR-3): items with `FILE_SET=unknown` are not automatically
+     serialized but are flagged in the batch summary with a warning noting that file-level
+     conflict detection was not possible.
+
+  6. **Human override** (BR-6): the orchestrator must **never** autonomously dispatch an
+     override. Only an explicit human instruction enables parallel dispatch when a conflict
+     has been detected. When a human instructs override, the orchestrator logs the override
+     and annotates the batch summary with a warning.
+
+  7. **Ordering relative to tool-fix check** (BR-8): conflict detection runs **after** the
+     tool-fix ordering check. Items already serialized by the tool-fix rule are excluded from
+     the conflict-detection input set for the current batch.
+
+  **Important scope constraints**:
+  - Do NOT modify Steps 3.3, 3.5, 3.6, 3.7, or any other step in Protocol 90 or any other
+    protocol file.
+
+---
+
+## Testing Strategy
+
+**Test types**: Manual / Smoke
+
+**Key scenarios to test**:
+
+1. `workflow-batch-plan.sh` against an implementation item whose plan has an explicit file
+   list → `FILE_SET` contains the listed paths (maps to AC-1, AC-2, BR-2).
+2. `workflow-batch-plan.sh` against an implementation item whose plan has no explicit file
+   list → `FILE_SET=unknown` (maps to AC-3, BR-3).
+3. `workflow-batch-plan.sh` against an implementation item with no plan document →
+   `FILE_SET=unknown` (maps to AC-4, BR-3).
+4. `detect_file_conflicts` with two items sharing a file → emits `CONFLICT_PAIR`,
+   `CONFLICT_FILES`, `SERIALIZE` for the lower-priority item (maps to AC-1, BR-4).
+5. `detect_file_conflicts` with two items whose file sets have no overlap → no
+   `CONFLICT_PAIR` emitted (maps to AC-2).
+6. `detect_file_conflicts` with one item having `FILE_SET=unknown` → emits
+   `CONFLICT_UNKNOWN` for that item; no auto-serialization (maps to AC-3, BR-3).
+7. Equal-priority tiebreaker by creation date: the item with the later creation date is
+   serialized (maps to BR-5).
+8. Equal-priority, equal-date tiebreaker by branch name: lexicographically later branch is
+   serialized (maps to BR-5).
+9. Tool-fix-serialized item excluded from conflict-detection input → not evaluated for file
+   overlap (maps to AC-7, BR-8).
+10. Spec-stage and plan-stage items excluded from conflict detection → `FILE_SET` not emitted
+    for those items (maps to AC-6, BR-1).
+11. Protocol 90 Step 3 contains the new subsection with all required content (maps to
+    AC-1 through AC-8 protocol-level verification).
+
+**Smoke test runbook**: [`docs/testing/workflow/324-parallel-batch-file-conflict-detection.smoke-test.md`](../../../testing/workflow/324-parallel-batch-file-conflict-detection.smoke-test.md)
+
+### Parser-risk addendum
+
+This plan is parser-risk because `extract_file_set` is a structured-text scanner that parses
+markdown plan documents to extract file paths.
+
+**Edge-case enumeration**:
+
+| Case | Input | Expected behaviour |
+|---|---|---|
+| Fenced code block: paths with no leading slash | `` `\ndocs/foo/bar.sh\n` `` under matching heading | extracted as `docs/foo/bar.sh` |
+| Fenced code block: path with leading slash | `` `\n/docs/foo/bar.sh\n` `` | normalized to `docs/foo/bar.sh` (strip leading `/`) |
+| Bullet list: `- ` prefix | `- docs/foo/bar.sh` under matching heading | extracted as `docs/foo/bar.sh` |
+| Bullet list: `* ` prefix | `* docs/foo/bar.sh` | extracted as `docs/foo/bar.sh` |
+| Heading variant: `Files to be modified` | `### Files to be modified` | matched |
+| Heading variant: `Files modified` | `### Files modified` | matched |
+| Heading variant: mixed case | `### FILES TO BE MODIFIED` | matched (case-insensitive) |
+| Empty fenced block | `` `\n` `` under heading | yields no paths → `unknown` |
+| Blank lines inside fenced block | paths interspersed with blank lines | blank lines skipped; paths extracted |
+| Duplicate paths in list | same path listed twice | deduplicated in output |
+| Path with backslashes | `docs\foo\bar.sh` | normalized to `docs/foo/bar.sh` |
+| Heading that almost matches | `### Files that will be modified later` | must **not** match (only `files to be modified`, `files to modified`, `files modified` match) |
+| No matching heading in document | plan document with no `Files` heading | yields `unknown` |
+| Multiple matching headings | two `Files to be modified` sections | paths from both sections extracted and merged |
+
+**Unit test mapping**:
+
+Name the unit test file `scripts/lint/test-extract-file-set.sh` (or inline within the smoke test
+runbook). Each row in the edge-case table above maps to at least one `assert_file_set` invocation
+in the smoke test runbook Step 1 through Step N.
+
+---
+
+## Seed Data
+
+None. All tests use temporary fixture directories created by the smoke tester. No running
+application, no database, and no issue tracker queries are required.
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` —
+  updated as part of this implementation (new Step 3 subsection). No separate post-implementation
+  doc update needed beyond what the plan steps cover.
+
+Other docs in `docs/project/`, `docs/best-practices/`, and `AGENTS.md` are not affected — this
+change modifies only workflow tooling internals and the orchestration protocol.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Markdown heading normalization misses a valid heading variant used in real plan documents | Medium | Medium | Pre-scan existing plan documents in `docs/specs/developments/` during implementation and confirm all `Files` headings are covered by the regex |
+| `extract_file_set` silently returns `unknown` for a plan that does have a file list but uses an unrecognized format | Medium | Low | Implement format detection strictly per the two canonical formats; add a warning comment in the script when `unknown` is returned for a non-empty document |
+| Priority tiebreaker (creation date from branch name slug) is unreliable when branch names do not encode a timestamp | Low | Low | The tiebreaker falls through to lexicographic branch name order, which is deterministic even without a timestamp |
+| BR-8 ordering violated if script caller passes tool-fix-serialized items to `detect_file_conflicts` | Low | Medium | Document the pre-filtering requirement in the function's docstring and in Protocol 90; add a defensive guard that ignores items already flagged as `SERIALIZE` by the tool-fix step |
+| Conflict detection for items with overlapping `FILE_SET=unknown` produces no warning | Low | Low | `CONFLICT_UNKNOWN` is emitted for every unknown-set item; the orchestrator summarizes this to the human |
+
+---
+
+## Code Samples
+
+```bash
+# Illustrative — adapt during implementation
+
+# extract_file_set <development-folder-path>
+#
+# Extracts the declared file set from a development folder's implementation plan.
+# Looks for a heading matching /files (to be? )?modified/i and extracts paths from
+# the subsequent fenced code block or bullet list.
+#
+# Emits:
+#   unknown                         — no plan found, or no extractable file list
+#   <comma-separated sorted paths>  — normalized repo-root-relative paths
+extract_file_set() {
+  local dev_path="$1"
+  local plan_file
+  plan_file="$(find "$dev_path" -maxdepth 1 -name '2_*_implementation-plan.md' | head -1)"
+  if [ -z "$plan_file" ]; then
+    printf 'unknown\n'
+    return 0
+  fi
+
+  # Python one-liner for robust multi-line section extraction (illustrative)
+  local paths
+  paths="$(python3 - "$plan_file" <<'PYEOF'
+import sys, re
+text = open(sys.argv[1]).read()
+# Find heading matching "files (to be?) modified" (case-insensitive)
+heading_re = re.compile(r'#+\s+files\s+(to\s+be?\s+)?modified', re.IGNORECASE)
+paths = []
+lines = text.splitlines()
+i = 0
+while i < len(lines):
+    if heading_re.search(lines[i]):
+        i += 1
+        # Try fenced code block
+        if i < len(lines) and lines[i].startswith('```'):
+            i += 1
+            while i < len(lines) and not lines[i].startswith('```'):
+                p = lines[i].strip()
+                if p:
+                    paths.append(p.lstrip('/').replace('\\\\', '/'))
+                i += 1
+        else:
+            # Bullet list
+            while i < len(lines) and (lines[i].startswith('- ') or lines[i].startswith('* ')):
+                p = lines[i][2:].strip()
+                if p:
+                    paths.append(p.lstrip('/').replace('\\\\', '/'))
+                i += 1
+    else:
+        i += 1
+seen = set()
+deduped = [p for p in paths if not (p in seen or seen.add(p))]
+print(','.join(sorted(deduped)) if deduped else 'unknown')
+PYEOF
+  )"
+  printf '%s\n' "$paths"
+}
+```
+
+---
+
+## Implementation Order
+
+1. Read `scripts/development-workflow/workflow-batch-plan.sh` and
+   `scripts/development-workflow/workflow-lib.sh` in full to understand existing helpers
+   (`print_kv`, `batch_hint_for_action`, `parallel_safe_for_action`, `classify_tool_fix`,
+   `extract_github_issue_number`, `cd_workflow_repo_root`).
+
+2. Add `extract_file_set` helper function to `workflow-batch-plan.sh`. Place it after
+   `classify_tool_fix` and before `cd_workflow_repo_root`. Implement format detection for:
+   - Fenced code block under a heading matching `/files\s+(to\s+be?\s+)?modified/i`
+   - Bullet list under the same heading
+   Use the Python one-liner approach from the Code Samples section (or an equivalent pure
+   Bash/awk implementation if Python is unavailable). All edge cases in the parser-risk
+   addendum must be covered.
+
+3. In the main `for development_path` loop, after the `classify_tool_fix` call, call
+   `extract_file_set` for items where `next_action` is `implement` or
+   `resolve-development-pr`. Emit `print_kv FILE_SET "$file_set"`. For all other
+   `next_action` values, do not emit `FILE_SET`.
+
+4. Add `detect_file_conflicts` function to `workflow-batch-plan.sh` (below `extract_file_set`).
+   Implement the pairwise overlap detection, priority-based serialization tiebreakers (BR-4 /
+   BR-5), and output protocol described in the Layer-by-Layer Changes section.
+
+5. Read
+   `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` Step 3
+   in full. Identify the insertion point: after the "Same-batch tool-fix ordering hazard"
+   subsection's **Human override** paragraph and before the **Codex fallback** paragraph
+   (currently around line 290).
+
+6. Insert the **"Same-batch file-level conflict detection"** subsection at that location,
+   covering all seven content requirements listed in the Protocol Documentation layer above.
+   Confirm:
+   - The subsection appears after "Same-batch tool-fix ordering hazard"
+   - The subsection appears before "Codex fallback"
+   - No other existing content is modified
+
+7. Run the smoke test runbook scenarios manually using fixture directories to verify all
+   acceptance criteria. Pay particular attention to the parser edge cases in the parser-risk
+   addendum.
+
+8. Update `CHANGELOG.md` under `[Unreleased]` with:
+
+   ```
+   - **Parallel batch file-level conflict detection** (#324): the batch orchestrator now extracts declared file sets from implementation plan documents and automatically serializes items with overlapping file sets before dispatch; items without an explicit file list are flagged as unknown-set in the batch summary.
+   ```

--- a/docs/specs/developments/20260427222126_324-parallel-batch-file-conflict-detection/2_324-parallel-batch-file-conflict-detection_implementation-plan.md
+++ b/docs/specs/developments/20260427222126_324-parallel-batch-file-conflict-detection/2_324-parallel-batch-file-conflict-detection_implementation-plan.md
@@ -202,6 +202,7 @@ markdown plan documents to extract file paths.
 | Heading variant: `Files modified` | `### Files modified` | matched |
 | Heading variant: mixed case | `### FILES TO BE MODIFIED` | matched (case-insensitive) |
 | Empty fenced block | `` `\n` `` under heading | yields no paths → `unknown` |
+| Blank lines between heading and content | heading followed by one or more blank lines then fenced block or bullet list | blank lines skipped; content extracted normally |
 | Blank lines inside fenced block | paths interspersed with blank lines | blank lines skipped; paths extracted |
 | Duplicate paths in list | same path listed twice | deduplicated in output |
 | Path with backslashes | `docs\foo\bar.sh` | normalized to `docs/foo/bar.sh` |
@@ -283,6 +284,9 @@ i = 0
 while i < len(lines):
     if heading_re.search(lines[i]):
         i += 1
+        # Skip blank lines between heading and content block
+        while i < len(lines) and not lines[i].strip():
+            i += 1
         # Try fenced code block
         if i < len(lines) and lines[i].startswith('```'):
             i += 1

--- a/docs/testing/workflow/324-parallel-batch-file-conflict-detection.smoke-test.md
+++ b/docs/testing/workflow/324-parallel-batch-file-conflict-detection.smoke-test.md
@@ -1,0 +1,468 @@
+# Smoke Test Runbook: Parallel Batch File-Level Conflict Detection
+
+**Feature**: Parallel batch file-level conflict detection (issue #324)
+**Spec**: [docs/specs/developments/20260427222126_324-parallel-batch-file-conflict-detection/1_324-parallel-batch-file-conflict-detection_specs.md](../../specs/developments/20260427222126_324-parallel-batch-file-conflict-detection/1_324-parallel-batch-file-conflict-detection_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] Repository is on the `develop` branch (or on the feature branch for this issue)
+- [ ] `gh` CLI is authenticated
+- [ ] Bash 3.2+ and Python 3 are available
+- [ ] `scripts/development-workflow/workflow-batch-plan.sh` has been updated per the
+  implementation plan (adds `extract_file_set` and `detect_file_conflicts`)
+- [ ] `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` has
+  been updated with the new "Same-batch file-level conflict detection" subsection
+- [ ] A temporary fixture directory is available (see Test Data below)
+
+---
+
+## Test Data
+
+All tests use temporary fixture directories created by the smoke tester. No running application,
+no database, and no issue tracker queries are required.
+
+| Item | Value |
+|---|---|
+| Fixture base dir | `.tmp/smoke-324/` (gitignored) |
+| Script under test | `scripts/development-workflow/workflow-batch-plan.sh` |
+| Protocol under test | `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` |
+
+Create the fixture base directory before running:
+
+```bash
+mkdir -p .tmp/smoke-324
+```
+
+---
+
+## Smoke Test Steps
+
+### Step 1: AC-1 / AC-2 — `extract_file_set` with explicit fenced code block file list
+
+Create a fixture implementation plan with a fenced code block under `### Files to be modified`:
+
+```bash
+mkdir -p .tmp/smoke-324/20200101000001_ac1-known-fileset
+cat > .tmp/smoke-324/20200101000001_ac1-known-fileset/2_ac1_implementation-plan.md <<'EOF'
+# AC1 Plan
+
+### Files to be modified
+
+```
+scripts/development-workflow/workflow-batch-plan.sh
+docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+```
+EOF
+WORKFLOW_SKIP_FETCH=1 ./scripts/development-workflow/workflow-batch-plan.sh \
+  .tmp/smoke-324/20200101000001_ac1-known-fileset 2>/dev/null || true
+```
+
+**Expected result**:
+- Output contains `FILE_SET=` with both paths listed
+- Paths are comma-separated and sorted
+- No `FILE_SET=unknown` in the output
+
+**Maps to**: AC-1, AC-2 (known file set correctly extracted), BR-2
+
+---
+
+### Step 2: AC-3 — `extract_file_set` with bullet-list format
+
+Create a fixture using bullet-list format:
+
+```bash
+mkdir -p .tmp/smoke-324/20200101000002_ac3-bullet-list
+cat > .tmp/smoke-324/20200101000002_ac3-bullet-list/2_ac3_implementation-plan.md <<'EOF'
+# AC3 Plan
+
+### Files modified
+
+- scripts/development-workflow/pr-review-loop.sh
+- docs/project/2-repo-architecture.md
+EOF
+WORKFLOW_SKIP_FETCH=1 ./scripts/development-workflow/workflow-batch-plan.sh \
+  .tmp/smoke-324/20200101000002_ac3-bullet-list 2>/dev/null || true
+```
+
+**Expected result**:
+- Output contains `FILE_SET=` with both paths
+- Paths are extracted correctly without the `- ` prefix
+
+**Maps to**: AC-1 (bullet-list format), BR-2
+
+---
+
+### Step 3: AC-3 — `extract_file_set` with no explicit file list in plan
+
+Create a fixture plan that has no `Files to be modified` heading:
+
+```bash
+mkdir -p .tmp/smoke-324/20200101000003_ac3-no-filelist
+cat > .tmp/smoke-324/20200101000003_ac3-no-filelist/2_ac3_implementation-plan.md <<'EOF'
+# AC3 No File List Plan
+
+## Layer-by-Layer Changes
+
+- [ ] Update some file
+- [ ] Update another file
+EOF
+WORKFLOW_SKIP_FETCH=1 ./scripts/development-workflow/workflow-batch-plan.sh \
+  .tmp/smoke-324/20200101000003_ac3-no-filelist 2>/dev/null || true
+```
+
+**Expected result**:
+- Output contains `FILE_SET=unknown`
+
+**Maps to**: AC-3, BR-3 (no extractable file list → unknown)
+
+---
+
+### Step 4: AC-4 — `extract_file_set` with no plan document
+
+Create a fixture folder with only a spec file (no `2_*_implementation-plan.md`):
+
+```bash
+mkdir -p .tmp/smoke-324/20200101000004_ac4-no-plan
+cat > .tmp/smoke-324/20200101000004_ac4-no-plan/1_ac4_specs.md <<'EOF'
+# AC4 Spec — no plan document
+EOF
+WORKFLOW_SKIP_FETCH=1 ./scripts/development-workflow/workflow-batch-plan.sh \
+  .tmp/smoke-324/20200101000004_ac4-no-plan 2>/dev/null || true
+```
+
+**Expected result**:
+- Output contains `FILE_SET=unknown`
+
+**Maps to**: AC-4, BR-3 (no plan document → unknown)
+
+---
+
+### Step 5: AC-6 — Spec-stage and plan-stage items do not get FILE_SET
+
+Create a fixture folder for a spec-stage item (no plan document):
+
+```bash
+mkdir -p .tmp/smoke-324/20200101000005_ac6-spec-stage
+cat > .tmp/smoke-324/20200101000005_ac6-spec-stage/1_ac6_specs.md <<'EOF'
+# AC6 Spec-only item
+EOF
+WORKFLOW_SKIP_FETCH=1 ./scripts/development-workflow/workflow-batch-plan.sh \
+  .tmp/smoke-324/20200101000005_ac6-spec-stage 2>/dev/null || true
+```
+
+**Expected result**:
+- Output does **not** contain `FILE_SET=` for items whose `NEXT_ACTION` is `write-plan` or
+  earlier stages (spec/plan items are excluded from conflict detection entirely)
+
+**Maps to**: AC-6, BR-1
+
+---
+
+### Step 6: AC-1 — `detect_file_conflicts` detects overlap and serializes lower-priority item
+
+Invoke `detect_file_conflicts` with two items sharing a file. Simulate two implementation items
+in the same candidate batch where item A (higher priority) and item B (lower priority) both
+declare `scripts/development-workflow/workflow-batch-plan.sh`:
+
+```bash
+# Invoke detect_file_conflicts directly (or via workflow-batch-plan.sh with two paths)
+mkdir -p .tmp/smoke-324/20200101000006_item-a
+cat > .tmp/smoke-324/20200101000006_item-a/2_item-a_implementation-plan.md <<'EOF'
+# Item A Plan
+
+### Files to be modified
+
+```
+scripts/development-workflow/workflow-batch-plan.sh
+docs/project/1-business-domain.md
+```
+EOF
+
+mkdir -p .tmp/smoke-324/20200101000007_item-b
+cat > .tmp/smoke-324/20200101000007_item-b/2_item-b_implementation-plan.md <<'EOF'
+# Item B Plan
+
+### Files to be modified
+
+```
+scripts/development-workflow/workflow-batch-plan.sh
+docs/project/2-repo-architecture.md
+```
+EOF
+
+WORKFLOW_SKIP_FETCH=1 ./scripts/development-workflow/workflow-batch-plan.sh \
+  .tmp/smoke-324/20200101000006_item-a \
+  .tmp/smoke-324/20200101000007_item-b 2>/dev/null || true
+```
+
+**Expected result**:
+- Output contains `CONFLICT_PAIR=` listing both item IDs
+- Output contains `CONFLICT_FILES=scripts/development-workflow/workflow-batch-plan.sh`
+- Output contains `SERIALIZE=` identifying the lower-priority item
+- The batch summary notes the overlapping file path and the serialization decision
+
+**Maps to**: AC-1, BR-2, BR-4, BR-7
+
+---
+
+### Step 7: AC-2 — No conflict when file sets are disjoint
+
+Create two items with non-overlapping file sets:
+
+```bash
+mkdir -p .tmp/smoke-324/20200101000008_item-c
+cat > .tmp/smoke-324/20200101000008_item-c/2_item-c_implementation-plan.md <<'EOF'
+# Item C Plan
+
+### Files to be modified
+
+```
+docs/project/1-business-domain.md
+```
+EOF
+
+mkdir -p .tmp/smoke-324/20200101000009_item-d
+cat > .tmp/smoke-324/20200101000009_item-d/2_item-d_implementation-plan.md <<'EOF'
+# Item D Plan
+
+### Files to be modified
+
+```
+docs/project/3-software-architecture.md
+```
+EOF
+
+WORKFLOW_SKIP_FETCH=1 ./scripts/development-workflow/workflow-batch-plan.sh \
+  .tmp/smoke-324/20200101000008_item-c \
+  .tmp/smoke-324/20200101000009_item-d 2>/dev/null || true
+```
+
+**Expected result**:
+- Output does **not** contain any `CONFLICT_PAIR=` entry
+- Both items appear in the same batch without serialization
+
+**Maps to**: AC-2, BR-2
+
+---
+
+### Step 8: AC-3 — Unknown-set item dispatched with warning, not serialized
+
+Create a batch with one known-set item and one unknown-set item:
+
+```bash
+mkdir -p .tmp/smoke-324/20200101000010_item-e
+cat > .tmp/smoke-324/20200101000010_item-e/2_item-e_implementation-plan.md <<'EOF'
+# Item E Plan
+
+### Files to be modified
+
+```
+docs/project/1-business-domain.md
+```
+EOF
+
+mkdir -p .tmp/smoke-324/20200101000011_item-f
+cat > .tmp/smoke-324/20200101000011_item-f/2_item-f_implementation-plan.md <<'EOF'
+# Item F Plan — no file list
+
+## Layer-by-Layer Changes
+
+- [ ] Some change
+EOF
+
+WORKFLOW_SKIP_FETCH=1 ./scripts/development-workflow/workflow-batch-plan.sh \
+  .tmp/smoke-324/20200101000010_item-e \
+  .tmp/smoke-324/20200101000011_item-f 2>/dev/null || true
+```
+
+**Expected result**:
+- Item F output contains `FILE_SET=unknown`
+- Output contains `CONFLICT_UNKNOWN=` for item F
+- Item F is **not** serialized (appears in same batch)
+- Batch summary notes that conflict detection was not possible for item F
+
+**Maps to**: AC-3, BR-3
+
+---
+
+### Step 9: Parser edge cases — leading slash normalization and case-insensitive heading
+
+```bash
+mkdir -p .tmp/smoke-324/20200101000012_edge-cases
+cat > .tmp/smoke-324/20200101000012_edge-cases/2_edge_implementation-plan.md <<'EOF'
+# Edge Cases Plan
+
+### FILES TO BE MODIFIED
+
+```
+/docs/project/1-business-domain.md
+docs/project/2-repo-architecture.md
+docs/project/2-repo-architecture.md
+```
+EOF
+WORKFLOW_SKIP_FETCH=1 ./scripts/development-workflow/workflow-batch-plan.sh \
+  .tmp/smoke-324/20200101000012_edge-cases 2>/dev/null || true
+```
+
+**Expected result**:
+- Leading `/` is stripped: `docs/project/1-business-domain.md` (not `/docs/...`)
+- Duplicate path `docs/project/2-repo-architecture.md` appears only once
+- Heading `FILES TO BE MODIFIED` (all caps) is matched correctly
+
+**Maps to**: BR-2 (normalized paths), parser edge cases
+
+---
+
+### Step 10: AC-7 / BR-8 — Tool-fix-serialized items excluded from conflict detection
+
+Confirm that items already serialized by the tool-fix check are not evaluated by
+`detect_file_conflicts`. In a batch containing a tool-fix item and an implementation item:
+
+```bash
+# The tool-fix item (references a canonical workflow tool) should be serialized by
+# the tool-fix check BEFORE conflict detection runs. Confirm the output shows:
+# 1. TOOL_FIX=yes for the tool-fix item
+# 2. The tool-fix item is moved to its own serial sub-batch
+# 3. detect_file_conflicts is NOT invoked for the tool-fix item
+# (This is verified by confirming that even if the tool-fix item's plan declares
+# a file also declared by another item, no CONFLICT_PAIR is emitted for that pairing.)
+
+mkdir -p .tmp/smoke-324/20200101000013_toolfix-item
+cat > .tmp/smoke-324/20200101000013_toolfix-item/2_toolfix_implementation-plan.md <<'EOF'
+# Tool-Fix Item Plan
+
+### Files to be modified
+
+```
+scripts/development-workflow/pr-review-loop.sh
+docs/project/1-business-domain.md
+```
+EOF
+
+mkdir -p .tmp/smoke-324/20200101000014_consumer-item
+cat > .tmp/smoke-324/20200101000014_consumer-item/2_consumer_implementation-plan.md <<'EOF'
+# Consumer Item Plan
+
+### Files to be modified
+
+```
+docs/project/1-business-domain.md
+```
+EOF
+
+WORKFLOW_SKIP_FETCH=1 ./scripts/development-workflow/workflow-batch-plan.sh \
+  .tmp/smoke-324/20200101000013_toolfix-item \
+  .tmp/smoke-324/20200101000014_consumer-item 2>/dev/null || true
+```
+
+**Expected result**:
+- Tool-fix item has `TOOL_FIX=yes`
+- Tool-fix item is serialized to its own sub-batch (tool-fix rule takes precedence)
+- No `CONFLICT_PAIR=` involving the tool-fix item (BR-8: tool-fix-serialized items excluded)
+- Consumer item remains in the current batch (or is held pending tool-fix merge, per
+  protocol 90 Step 3 tool-fix rule)
+
+**Maps to**: AC-7, BR-8
+
+---
+
+### Step 11: Protocol 90 — New subsection present with required content
+
+Verify that Protocol 90 Step 3 contains the new "Same-batch file-level conflict detection"
+subsection:
+
+```bash
+grep -n "Same-batch file-level conflict detection" \
+  docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+```
+
+**Expected result**:
+- Command returns at least one matching line
+- The subsection heading appears after `Same-batch tool-fix ordering hazard`
+- The subsection heading appears before `Codex fallback`
+
+Confirm the subsection covers all required content by reading it:
+
+```bash
+# Read Step 3 between the two anchor points to visually confirm content
+grep -n "Same-batch\|Codex fallback\|FILE_SET\|conflict detection\|BR-1\|BR-2\|BR-3\|BR-4\|BR-5\|BR-6\|BR-7\|BR-8" \
+  docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md | head -40
+```
+
+**Expected result**:
+- Scope rule (BR-1), conflict definition (BR-2), serialization rule (BR-4/BR-5),
+  unknown-set handling (BR-3), human override (BR-6), ordering relative to tool-fix (BR-8),
+  and batch summary annotation (BR-7) are all present in the subsection
+
+**Maps to**: AC-1 through AC-8 (protocol-level), BR-1 through BR-8
+
+---
+
+### Last Step: Clean up fixtures and validate
+
+```bash
+rm -rf .tmp/smoke-324
+```
+
+Verify all assertions in the checklist below are met before considering the feature complete.
+
+---
+
+## Assertions Checklist
+
+Each checkbox maps to an acceptance criterion from the spec.
+
+- [ ] AC-1: Two implementation items declaring the same file → only higher-priority item in
+  current batch; other serialized; batch summary lists overlapping path and decision
+- [ ] AC-2: Two implementation items with disjoint file sets → both dispatched together;
+  no conflict warning in batch summary
+- [ ] AC-3: Implementation item whose plan has no explicit file list → dispatched normally;
+  batch summary notes unknown file set
+- [ ] AC-4: Implementation-branch item with no plan document → treated as unknown file set;
+  dispatched; batch summary includes warning
+- [ ] AC-5: Human override of serialization decision → previously-serialized item dispatched
+  in parallel; batch summary records the override with warning
+- [ ] AC-6: Spec-stage and plan-stage items are not subject to file-level conflict checks
+- [ ] AC-7: Conflict detection runs after the tool-fix check; tool-fix-serialized items
+  excluded from conflict-detection input
+- [ ] AC-8: File path comparison is case-sensitive and uses normalized repo-root-relative
+  paths (forward slashes, no leading slash)
+
+---
+
+## Seed Data Reference
+
+No seed data required — all tests use temporary fixture directories.
+
+| Entity | Scenario | How to load |
+|---|---|---|
+| Fixture directories | Created inline per step | `mkdir -p .tmp/smoke-324/<fixture-name>` |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `FILE_SET` not emitted for implementation item | `extract_file_set` not called for `implement` action | Confirm `NEXT_ACTION=implement` is emitted and that `extract_file_set` is invoked for that action |
+| `FILE_SET=unknown` when plan has a file list | Heading regex does not match the variant used | Check the heading text against the supported variants; add the variant to the regex |
+| `CONFLICT_PAIR` not emitted for overlapping items | `detect_file_conflicts` not receiving both items' file sets | Confirm both items are passed as input; confirm `FILE_SET` values are non-`unknown` |
+| Leading slash not stripped from path | Normalization step missing | Confirm `lstrip('/')` or equivalent is applied to all extracted paths |
+| Duplicate paths in `FILE_SET` | Deduplication step missing | Confirm `sort -u` or equivalent is applied |
+
+---
+
+## Known Limitations
+
+- AC-5 (human override of serialization) cannot be verified end-to-end in a pure fixture-based
+  test; manual orchestrator run with a real parallel batch is required to fully exercise that
+  path.
+- The smoke test does not verify the priority tiebreaker (BR-5) for items with the same priority
+  and creation date; that case requires constructing two fixtures with matching timestamps and
+  different branch names, which may need a manual test.

--- a/docs/testing/workflow/324-parallel-batch-file-conflict-detection.smoke-test.md
+++ b/docs/testing/workflow/324-parallel-batch-file-conflict-detection.smoke-test.md
@@ -72,14 +72,14 @@ WORKFLOW_SKIP_FETCH=1 ./scripts/development-workflow/workflow-batch-plan.sh \
 
 ---
 
-### Step 2: AC-3 — `extract_file_set` with bullet-list format
+### Step 2: AC-1 — `extract_file_set` with bullet-list format
 
 Create a fixture using bullet-list format:
 
 ```bash
-mkdir -p .tmp/smoke-324/20200101000002_ac3-bullet-list
-cat > .tmp/smoke-324/20200101000002_ac3-bullet-list/2_ac3_implementation-plan.md <<'EOF'
-# AC3 Plan
+mkdir -p .tmp/smoke-324/20200101000002_ac1-bullet-list
+cat > .tmp/smoke-324/20200101000002_ac1-bullet-list/2_ac1_implementation-plan.md <<'EOF'
+# AC1 Plan
 
 ### Files modified
 
@@ -87,7 +87,7 @@ cat > .tmp/smoke-324/20200101000002_ac3-bullet-list/2_ac3_implementation-plan.md
 - docs/project/2-repo-architecture.md
 EOF
 WORKFLOW_SKIP_FETCH=1 ./scripts/development-workflow/workflow-batch-plan.sh \
-  .tmp/smoke-324/20200101000002_ac3-bullet-list 2>/dev/null || true
+  .tmp/smoke-324/20200101000002_ac1-bullet-list 2>/dev/null || true
 ```
 
 **Expected result**:


### PR DESCRIPTION
## Summary

Implementation plan for issue #324: before dispatching a parallel batch, the orchestrator detects file-level conflicts by extracting declared file sets from implementation plan documents and cross-checking for overlaps between items in the same proposed batch.

**Approach**: Extend `workflow-batch-plan.sh` with two new helpers — `extract_file_set` (parses the implementation plan's explicit file list via fenced code block or bullet list under a matching heading) and `detect_file_conflicts` (pairwise overlap check with priority-based serialization per BR-4/BR-5). Add a new "Same-batch file-level conflict detection" subsection to Protocol 90 Step 3, placed after the tool-fix ordering hazard and before the Codex fallback paragraph.

**Complexity**: M — two files changed (one shell script, one protocol document), but the extraction parser requires careful handling of heading variants and edge cases.

**Key risks**: Heading-normalization misses for unusual plan formats; priority tiebreaker logic for equal-priority items; BR-8 ordering discipline (tool-fix check runs first, conflict detection only sees the remaining items).

## Links

- Spec: `docs/specs/developments/20260427222126_324-parallel-batch-file-conflict-detection/1_324-parallel-batch-file-conflict-detection_specs.md`
- Plan: `docs/specs/developments/20260427222126_324-parallel-batch-file-conflict-detection/2_324-parallel-batch-file-conflict-detection_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/324-parallel-batch-file-conflict-detection.smoke-test.md`