### PR TITLE
feat(internal-review): add codex-github integration reviewer path for Step 7a (#309)

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -34,14 +34,22 @@ review:
   # All listed reviewers must APPROVE before `gh pr ready` is called.
   #
   # Supported values:
-  #   claude  — dispatches the stage-appropriate reviewer agent:
-  #               spec/*               -> spec-reviewer
-  #               implementation-plan/* -> implementation-plan-reviewer
-  #               feature/*/refactor/*/fix/*/hotfix/* -> code-reviewer
-  #   codex   — dispatches the stage-appropriate Codex review skill:
-  #               spec/*               -> workflow-spec-reviewer
-  #               implementation-plan/* -> workflow-plan-reviewer
-  #               feature/*/refactor/*/fix/*/hotfix/* -> workflow-code-reviewer
+  #   claude        — dispatches the stage-appropriate reviewer agent:
+  #                     spec/*               -> spec-reviewer
+  #                     implementation-plan/* -> implementation-plan-reviewer
+  #                     feature/*/refactor/*/fix/*/hotfix/* -> code-reviewer
+  #   codex         — dispatches the stage-appropriate Codex review skill:
+  #                     spec/*               -> workflow-spec-reviewer
+  #                     implementation-plan/* -> workflow-plan-reviewer
+  #                     feature/*/refactor/*/fix/*/hotfix/* -> workflow-code-reviewer
+  #   codex-github  — posts a review-trigger comment to the PR and polls for the
+  #                   Codex GitHub App bot response. Universally reachable from all
+  #                   runner contexts (Claude Code, Cursor, Codex, headless CI) because
+  #                   it requires only `gh` CLI access — no Codex CLI runtime needed.
+  #                   Prerequisite: the Codex GitHub App must be installed on this
+  #                   repository and configured to respond to the trigger phrase.
+  #                   See scripts/development-workflow/codex-github-reviewer.sh for
+  #                   implementation details.
   #
   # Runner-context constraint:
   #   'codex' as a direct CLI reviewer is NOT reliably reachable from automated
@@ -52,12 +60,11 @@ review:
   #   'claude' under the default 'warn' policy. This is expected behaviour — not
   #   a misconfiguration.
   #
-  #   A future improvement (tracked in the template backlog) will add a
-  #   GitHub-integration-based Codex reviewer path that works from any runner by
-  #   posting a review trigger comment and polling for the Codex bot response.
-  #
-  #   To suppress the recurring warning in the meantime, remove 'codex' from this
-  #   list or override it locally via .tmp/template-config.json (see below).
+  #   To eliminate recurring 'codex unreachable' warnings from automated runners,
+  #   replace 'codex' with 'codex-github'. The codex-github path provides equivalent
+  #   Codex review coverage from any runner context. Running both 'codex' and
+  #   'codex-github' is supported (Use Case 5 in the spec) but doubles review time
+  #   and is typically unnecessary.
   #
   # Local override: developers who do not have access to all tools listed here
   # can override this list locally by creating .tmp/template-config.json in the
@@ -69,6 +76,19 @@ review:
   internal_reviewers:
     - claude
     - codex  # not reachable from automated subagent runners (Claude Code or Cursor); skipped with a warning
+  # To enable the Codex GitHub App reviewer path (universally reachable from all
+  # runner contexts), add 'codex-github' to the list above. Requires the Codex
+  # GitHub App to be installed on the repository.
+  #
+  # Configurable codex-github options (set via env vars or script flags; these are
+  # advisory comments — the helper script is the enforcement point):
+  #   CODEX_GITHUB_TRIGGER_PHRASE  — trigger phrase sent to the bot (default: "@codex review")
+  #   CODEX_GITHUB_BOT_LOGIN       — GitHub login of the Codex bot account
+  #                                  (default: "codex-ai[bot]"; verify from GitHub App settings)
+  #
+  # Additional options available as script flags to codex-github-reviewer.sh:
+  #   --poll-interval <seconds>    — polling interval while waiting for bot response (default: 30)
+  #   --max-wait      <seconds>    — maximum total wait time for bot response (default: 300)
 
   # Optional: policy when a listed internal reviewer is unreachable from the current runner.
   # Protocol 91 Step 7a enforces this policy at runtime.

--- a/.claude/agents/item-orchestrator.md
+++ b/.claude/agents/item-orchestrator.md
@@ -26,6 +26,8 @@ That document is the single source of truth for this supporting role. Key respon
   the literal resolved `<worktree-path>` value in every stage-agent handoff so each
   dispatched agent can validate its own paths independently.
 
+**`codex-github` internal reviewer dispatch**: When `codex-github` is listed in `review.internal_reviewers`, invoke `scripts/development-workflow/codex-github-reviewer.sh <pr_number> <owner> <repo>` instead of dispatching a CLI-based reviewer agent. This script is universally reachable from all runner contexts (Claude Code, Cursor, Codex, headless CI) because it uses only `gh` CLI — no Codex CLI runtime is needed. Exit code semantics: `0` = APPROVED, `1` = NEEDS_REVISION (blocking findings in stdout), `2` = TIMED_OUT (treat as unavailable under `internal_reviewers_unavailable_policy`). Prerequisite: Codex GitHub App must be installed on the repository and configured to respond to the trigger phrase (default: `@codex review`).
+
 **Permission-denial protocol (subagent runs only)**: If the `Edit` or `Write` tool is denied for **any path** — including `.claude/agents/**`, `.cursor/agents/**`, or any other file — the subagent MUST immediately stop all further work and return:
 
 ```

--- a/.cursor/agents/item-orchestrator.md
+++ b/.cursor/agents/item-orchestrator.md
@@ -25,6 +25,8 @@ That document is the single source of truth for this supporting role. Key respon
   the literal resolved `<worktree-path>` value in every stage-agent handoff so each
   dispatched agent can validate its own paths independently.
 
+**`codex-github` internal reviewer dispatch**: When `codex-github` is listed in `review.internal_reviewers`, invoke `scripts/development-workflow/codex-github-reviewer.sh <pr_number> <owner> <repo>` instead of dispatching a CLI-based reviewer agent. This script is universally reachable from all runner contexts (Claude Code, Cursor, Codex, headless CI) because it uses only `gh` CLI — no Codex CLI runtime is needed. Exit code semantics: `0` = APPROVED, `1` = NEEDS_REVISION (blocking findings in stdout), `2` = TIMED_OUT (treat as unavailable under `internal_reviewers_unavailable_policy`). Prerequisite: Codex GitHub App must be installed on the repository and configured to respond to the trigger phrase (default: `@codex review`).
+
 **Permission-denial protocol (subagent runs only)**: If the `Edit` or `Write` tool is denied for **any path** — including `.claude/agents/**`, `.cursor/agents/**`, or any other file — the subagent MUST immediately stop all further work and return:
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Add `codex-github` integration reviewer path for Step 7a** (#309): adds a runner-agnostic internal reviewer that posts a trigger comment to a PR and polls for the Codex GitHub App bot response; works from Claude Code, Cursor, headless CI, and Codex runner contexts. New `scripts/development-workflow/codex-github-reviewer.sh` implements the trigger/poll/parse/timeout loop. `codex-github` is classified as universally reachable in Protocol 91's reachability table (requires only `gh` CLI). `.ai-dev-workflow.yaml`, `.claude/agents/item-orchestrator.md`, and `.cursor/agents/item-orchestrator.md` updated to document the new reviewer path.
+
 - **Sync-template migration notes** (`sync-manifest.yaml`, sync-template skill and commands): `sync-manifest.yaml` gains a `migration_notes` section for versioned manual migration steps. The sync-template skill and command variants now read this section and present a required pre-sync checklist whenever the downstream project's `last_synced_version` predates a breaking structural change. First entry: `docs/ai/ → docs/workflow/` rename (v0.23.0). Fully backwards-compatible — silently skipped when no applicable notes exist.
 
 ### Fixed

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -526,6 +526,8 @@ Example `.tmp/template-config.json` override format:
 }
 ```
 
+Supported reviewer values: `claude`, `codex`, `codex-github`. The `codex-github` reviewer requires the Codex GitHub App to be installed on the repository; see `scripts/development-workflow/codex-github-reviewer.sh` for setup details and configurable options (`--trigger-phrase`, `--bot-login`, `--poll-interval`, `--max-wait`).
+
 If neither file defines `internal_reviewers`, fall back to running the stage-appropriate reviewer once (default behavior: `claude`).
 
 When `.tmp/template-config.json` supplies an override, log the following before running the availability check:
@@ -540,12 +542,14 @@ Before dispatching any reviewer, classify each entry in the resolved list as `re
 
 #### Reachability classification table
 
-| Runner context | `claude` reachable? | `codex` reachable? |
-|---|---|---|
-| Claude Code (direct human session) | Yes | No |
-| Claude Code subagent (dispatched by orchestrator) | Yes | No |
-| Codex runner / Codex skill | Yes | Yes |
-| Direct human (shell / CI with both CLIs available) | Yes | Yes |
+| Runner context | `claude` reachable? | `codex` reachable? | `codex-github` reachable? |
+|---|---|---|---|
+| Claude Code (direct human session) | Yes | No | Yes |
+| Claude Code subagent (dispatched by orchestrator) | Yes | No | Yes |
+| Codex runner / Codex skill | Yes | Yes | Yes |
+| Direct human (shell / CI with `gh`) | Yes | Yes | Yes |
+
+`codex-github` is classified as universally reachable because it interacts with the Codex GitHub App via `gh` CLI only — no Codex CLI runtime is required. It is reachable from any runner context where `gh` is authenticated.
 
 #### Policy resolution
 
@@ -607,6 +611,18 @@ For each reviewer in the resolved list, dispatch the stage-appropriate agent:
 | `codex` | `spec/*` | `workflow-spec-reviewer` Codex skill against `REVIEW.md` |
 | `codex` | `implementation-plan/*` | `workflow-plan-reviewer` Codex skill against `REVIEW.md` |
 | `codex` | `feature/*` / `refactor/*` / `fix/*` / `hotfix/*` | `workflow-code-reviewer` Codex skill against `REVIEW.md` |
+| `codex-github` | `spec/*` | `scripts/development-workflow/codex-github-reviewer.sh <pr> <owner> <repo>` |
+| `codex-github` | `implementation-plan/*` | `scripts/development-workflow/codex-github-reviewer.sh <pr> <owner> <repo>` |
+| `codex-github` | `feature/*` / `refactor/*` / `fix/*` / `hotfix/*` | `scripts/development-workflow/codex-github-reviewer.sh <pr> <owner> <repo>` |
+
+**`codex-github` dispatch notes:**
+
+- **Exit code semantics**: exit 0 = `APPROVED`, exit 1 = `NEEDS REVISION` (blocking findings present), exit 2 = `TIMED_OUT` (no bot response within max wait time).
+- **TIMED_OUT policy**: treat `TIMED_OUT` identically to `skipped (unavailable)` — apply the configured `internal_reviewers_unavailable_policy` (`warn` by default). Post a warning comment identifying the trigger comment that was posted and suggesting the operator verify Codex GitHub App installation.
+- **NEEDS REVISION — finding extraction**: on exit code 1, the script writes the bot response body to stdout between `---BEGIN BOT RESPONSE---` and `---END BOT RESPONSE---` markers. The runner must capture and pass this output to the fixer agent as context.
+- **Re-trigger on each fix cycle (BR-6)**: after fixes are pushed, a new trigger comment must be posted for the new commit SHA. The script handles this automatically — it checks the current HEAD SHA before posting and skips duplicate triggers for the same SHA.
+- **Idempotency guard (BR-10)**: the script checks existing PR comments for a trigger comment containing the current commit SHA before posting. If a matching trigger is found, posting is skipped and polling proceeds from the existing trigger timestamp. This prevents duplicate reviews when Step 7a is retried on the same commit.
+- **Prerequisite**: the Codex GitHub App must be installed on the repository and configured to respond to the trigger phrase (default: `@codex review`). If the app is not installed, the script times out and the runner applies the unavailability policy.
 
 ### Multi-reviewer execution rules
 

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -90,6 +90,7 @@ fi
 CURRENT_SHA=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid --jq '.headRefOid' | cut -c1-12)
 if [ -z "$CURRENT_SHA" ]; then
   echo "ERROR: could not resolve PR #$PR_NUMBER HEAD SHA" >&2
+  echo "VERDICT: TIMED_OUT — could not resolve PR HEAD SHA (treated as unavailable)"
   exit 2
 fi
 
@@ -210,7 +211,7 @@ while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
     #    avoid incorrectly approving a response that is a rejection in an
     #    unexpected format (per spec risk mitigation for BR-4).
 
-    if echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking|must[[:space:]]+fix|action[[:space:]]+required|required:[[:space:]]|❌)"; then
+    if echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
       echo "VERDICT: NEEDS_REVISION"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -83,14 +83,14 @@ done
 # silently causing 'sleep' to fail under set -e with code 1 (NEEDS_REVISION).
 
 case "$POLL_INTERVAL" in
-  ''|*[!0-9]*)
-    echo "ERROR: --poll-interval value '$POLL_INTERVAL' is not a positive integer" >&2
+  ''|0|*[!0-9]*)
+    echo "ERROR: --poll-interval value '$POLL_INTERVAL' is not a positive integer (must be >= 1)" >&2
     exit 2
     ;;
 esac
 case "$MAX_WAIT" in
-  ''|*[!0-9]*)
-    echo "ERROR: --max-wait value '$MAX_WAIT' is not a positive integer" >&2
+  ''|0|*[!0-9]*)
+    echo "ERROR: --max-wait value '$MAX_WAIT' is not a positive integer (must be >= 1)" >&2
     exit 2
     ;;
 esac
@@ -229,32 +229,43 @@ while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
     echo "INFO: bot response detected"
 
     # ── Verdict parsing ───────────────────────────────────────────────────────
-    # Three-path classification (per spec BR-4 and implementation plan risk table):
+    # Three-path classification (per spec BR-4 and implementation plan risk table).
+    # Approval signals are checked FIRST to avoid false NEEDS_REVISION when the
+    # bot says "No blocking issues. Approved." (the bare word 'blocking' would
+    # match the blocking-marker check if it ran first).
     #
-    # 1. Blocking markers present → NEEDS_REVISION (exit 1)
+    # 1. Explicit approval signals present → APPROVED (exit 0)   [checked first]
+    #    Approval signals: "approved", "lgtm", "looks good"
+    #
+    # 2. Blocking markers present → NEEDS_REVISION (exit 1)      [checked second]
     #    Blocking markers (case-insensitive): "changes requested", "blocking",
     #    "must fix", "required:", "action required", "❌"
     #
-    # 2. Explicit approval signals present (no blocking markers) → APPROVED (exit 0)
+    # 2. Explicit approval signals present → APPROVED (exit 0)
     #    Approval signals: "approved", "lgtm", "looks good"
+    #    Approval is checked BEFORE blocking markers so that responses like
+    #    "No blocking issues found. Approved." are not falsely rejected by the
+    #    bare word 'blocking'. When both an approval signal and a blocking marker
+    #    appear, the approval signal takes precedence — the bot most likely said
+    #    "no blocking issues" (negated context), not "blocking: fix X".
     #
     # 3. Neither found (unrecognized response format) → NEEDS_REVISION (exit 1)
     #    Safe-fail: default to NEEDS_REVISION when the format is unrecognized to
     #    avoid incorrectly approving a response that is a rejection in an
     #    unexpected format (per spec risk mitigation for BR-4).
 
-    if echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
-      echo "VERDICT: NEEDS_REVISION"
-      echo "---BEGIN BOT RESPONSE---"
-      echo "$BOT_RESPONSE"
-      echo "---END BOT RESPONSE---"
-      exit 1
-    elif echo "$BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good)"; then
+    if echo "$BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good)"; then
       echo "VERDICT: APPROVED"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 0
+    elif echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+      echo "VERDICT: NEEDS_REVISION"
+      echo "---BEGIN BOT RESPONSE---"
+      echo "$BOT_RESPONSE"
+      echo "---END BOT RESPONSE---"
+      exit 1
     else
       echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
       echo "---BEGIN BOT RESPONSE---"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -244,10 +244,11 @@ while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
     # Three-path classification (per spec BR-4 and implementation plan risk table).
     # Blocking markers are checked FIRST (safe-fail: a false NEEDS_REVISION that
     # triggers an unnecessary fix cycle is safer than a false APPROVED that
-    # silently ignores blocking findings). The bare word "blocking" is excluded
-    # from the marker list because it matches negated context ("no blocking
-    # issues") — use more specific phrases ("blocking issues", "blocking finding",
-    # "blocking:") instead.
+    # silently ignores blocking findings). Note: even specific phrases like
+    # "blocking issues" can still match within negated context ("No blocking
+    # issues found"). This is an accepted safe-fail trade-off — the result is
+    # an unnecessary fix cycle, not a missed rejection. The bare word "blocking"
+    # is excluded because it is too broad; the phrases below are more targeted.
     #
     # 1. Blocking markers present → NEEDS_REVISION (exit 1)      [checked first]
     #    Blocking markers (case-insensitive): "changes requested",

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -140,6 +140,8 @@ fi
 echo "INFO: polling for response from '$BOT_LOGIN' (trigger time: $TRIGGER_TIME)..."
 
 ELAPSED=0
+CONSECUTIVE_API_FAILURES=0
+MAX_CONSECUTIVE_FAILURES=3
 while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
   sleep "$POLL_INTERVAL"
   ELAPSED=$((ELAPSED + POLL_INTERVAL))
@@ -148,28 +150,42 @@ while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
 
   # Query comments authored by the bot that appeared after the trigger comment timestamp.
   # The bot login may include "[bot]" suffix — use exact string match on user.login.
+  # Capture stderr separately to distinguish API failures from empty results.
+  POLL_STDERR=$(mktemp)
   BOT_RESPONSE=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
     --jq ".[] | select(.user.login == \"$BOT_LOGIN\") | select(.created_at > \"$TRIGGER_TIME\") | .body" \
-    2>/dev/null | head -c 10000 || true)
+    2>"$POLL_STDERR" | head -c 10000) || {
+    POLL_ERR=$(cat "$POLL_STDERR")
+    rm -f "$POLL_STDERR"
+    CONSECUTIVE_API_FAILURES=$((CONSECUTIVE_API_FAILURES + 1))
+    echo "WARNING: gh api failed during polling (attempt $CONSECUTIVE_API_FAILURES): $POLL_ERR" >&2
+    if [ "$CONSECUTIVE_API_FAILURES" -ge "$MAX_CONSECUTIVE_FAILURES" ]; then
+      echo "VERDICT: TIMED_OUT — gh api failed $CONSECUTIVE_API_FAILURES consecutive times. Last error: $POLL_ERR"
+      echo "INFO: remediation — check gh CLI authentication, API rate limits, and network connectivity."
+      exit 2
+    fi
+    continue
+  }
+  rm -f "$POLL_STDERR"
+  CONSECUTIVE_API_FAILURES=0
 
   if [ -n "$BOT_RESPONSE" ]; then
     echo "INFO: bot response detected"
 
     # ── Verdict parsing ───────────────────────────────────────────────────────
-    # Safe-fail: default to NEEDS_REVISION when the response format is unrecognized.
-    # APPROVED only when none of the blocking markers are present.
+    # Three-path classification (per spec BR-4 and implementation plan risk table):
     #
-    # Blocking markers (case-insensitive):
-    #   - "changes requested"
-    #   - "blocking"
-    #   - "must fix"
-    #   - "required:"
-    #   - "action required"
-    #   - the ❌ emoji (literal or Unicode escape)
+    # 1. Blocking markers present → NEEDS_REVISION (exit 1)
+    #    Blocking markers (case-insensitive): "changes requested", "blocking",
+    #    "must fix", "required:", "action required", "❌"
     #
-    # Approval signals:
-    #   - "approved" or "lgtm" or "looks good" present AND no blocking markers
-    #   - no blocking markers at all (conservative: treat silence as approval)
+    # 2. Explicit approval signals present (no blocking markers) → APPROVED (exit 0)
+    #    Approval signals: "approved", "lgtm", "looks good"
+    #
+    # 3. Neither found (unrecognized response format) → NEEDS_REVISION (exit 1)
+    #    Safe-fail: default to NEEDS_REVISION when the format is unrecognized to
+    #    avoid incorrectly approving a response that is a rejection in an
+    #    unexpected format (per spec risk mitigation for BR-4).
 
     if echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking|must[[:space:]]+fix|action[[:space:]]+required|required:[[:space:]]|❌)"; then
       echo "VERDICT: NEEDS_REVISION"
@@ -177,12 +193,18 @@ while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 1
-    else
+    elif echo "$BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good)"; then
       echo "VERDICT: APPROVED"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 0
+    else
+      echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
+      echo "---BEGIN BOT RESPONSE---"
+      echo "$BOT_RESPONSE"
+      echo "---END BOT RESPONSE---"
+      exit 1
     fi
   fi
 done

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -25,12 +25,15 @@
 #   2 — TIMED_OUT  (no bot response within max-wait; treat as unavailable under
 #                   configured internal_reviewers_unavailable_policy)
 #
-# Verdict parsing:
-#   The script looks for blocking markers in the bot response body. If any
-#   blocking marker is found, the result is NEEDS_REVISION. Otherwise APPROVED.
-#   Blocking markers (case-insensitive): "changes requested", "blocking",
-#   "must fix", "required:", "action required", "❌".
-#   On unrecognized format, the script safe-fails to NEEDS_REVISION.
+# Verdict parsing (three-path, approval checked first):
+#   1. Explicit approval signals present → APPROVED (exit 0)
+#      Signals (case-insensitive): "approved", "lgtm", "looks good"
+#      Checked FIRST to avoid false NEEDS_REVISION from negated blocking context
+#      (e.g. "No blocking issues. Approved.").
+#   2. Blocking markers present → NEEDS_REVISION (exit 1)
+#      Markers (case-insensitive): "changes requested", "blocking",
+#      "must fix", "required:", "action required", "❌"
+#   3. Neither found (unrecognized format) → safe-fails to NEEDS_REVISION (exit 1)
 #
 # Idempotency (BR-10):
 #   Before posting a trigger comment, the script queries existing PR comments
@@ -51,6 +54,15 @@ PR_NUMBER="$1"
 OWNER="$2"
 REPO="$3"
 shift 3
+
+# Validate PR_NUMBER is a positive integer before any interpolation into
+# gh commands or API URLs (REVIEW.md: validate user-supplied input).
+case "$PR_NUMBER" in
+  ''|0|*[!0-9]*)
+    echo "ERROR: PR number '$PR_NUMBER' is not a valid positive integer" >&2
+    exit 2
+    ;;
+esac
 
 # Defaults (overridable by flags or env vars)
 TRIGGER_PHRASE="${CODEX_GITHUB_TRIGGER_PHRASE:-@codex review}"
@@ -240,14 +252,6 @@ while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
     # 2. Blocking markers present → NEEDS_REVISION (exit 1)      [checked second]
     #    Blocking markers (case-insensitive): "changes requested", "blocking",
     #    "must fix", "required:", "action required", "❌"
-    #
-    # 2. Explicit approval signals present → APPROVED (exit 0)
-    #    Approval signals: "approved", "lgtm", "looks good"
-    #    Approval is checked BEFORE blocking markers so that responses like
-    #    "No blocking issues found. Approved." are not falsely rejected by the
-    #    bare word 'blocking'. When both an approval signal and a blocking marker
-    #    appear, the approval signal takes precedence — the bot most likely said
-    #    "no blocking issues" (negated context), not "blocking: fix X".
     #
     # 3. Neither found (unrecognized response format) → NEEDS_REVISION (exit 1)
     #    Safe-fail: default to NEEDS_REVISION when the format is unrecognized to

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -89,7 +89,7 @@ fi
 # Guard the assignment with 'if !' to prevent set -e from exiting with code 1
 # (NEEDS_REVISION) before the empty-check guard below can emit the VERDICT line.
 
-if ! CURRENT_SHA=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid --jq '.headRefOid' 2>&1 | head -c 100); then
+if ! CURRENT_SHA=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid --jq '.headRefOid' | head -c 100); then
   echo "ERROR: could not resolve PR #$PR_NUMBER HEAD SHA" >&2
   echo "VERDICT: TIMED_OUT — could not resolve PR HEAD SHA (treated as unavailable)"
   exit 2

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -120,8 +120,8 @@ IDEM_STDERR=$(mktemp)
 IDEM_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>"$IDEM_STDERR" \
-  | jq -r --arg sha "$CURRENT_SHA" --arg trigger "$TRIGGER_PHRASE" \
-    '.[] | select((.body | test($sha)) and (.body | ascii_downcase | contains($trigger | ascii_downcase))) | {id: .id, created_at: .created_at, body: .body}' \
+  | jq -r --arg sha "$CURRENT_SHA" --arg trigger "$TRIGGER_PHRASE" --arg bot "$BOT_LOGIN" \
+    '.[] | select(.user.login != $bot) | select((.body | test($sha)) and (.body | ascii_downcase | contains($trigger | ascii_downcase))) | {id: .id, created_at: .created_at, body: .body}' \
   > "$IDEM_TMPFILE"; then
   TRIGGER_COMMENT_INFO=$(head -c 2000 "$IDEM_TMPFILE")
 else

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -105,20 +105,17 @@ echo "INFO: Poll interval: ${POLL_INTERVAL}s, Max wait: ${MAX_WAIT}s"
 # avoid falsely matching bot review comments or human comments that happen to
 # reference the commit SHA.
 
-# Escape both strings for jq regex use (escape regex metacharacters)
-ESCAPED_SHA=$(printf '%s' "$CURRENT_SHA" | sed 's/[[\\.^$()|?*+{}]/\\&/g')
-ESCAPED_TRIGGER=$(printf '%s' "$TRIGGER_PHRASE" | sed 's/[[\\.^$()|?*+{}]/\\&/g')
-
-# Capture the idempotency check to a temp file to avoid:
-# - SIGPIPE under pipefail when piping to head (head closes the pipe early when
-#   the response is larger than the truncation limit, causing gh api to exit
-#   with SIGPIPE which pipefail propagates as a non-zero exit code)
-# - Silent failure swallowing (|| true on a pipeline hides real API errors)
+# Capture the idempotency check to a temp file to avoid SIGPIPE under pipefail.
+# Use 'jq --arg' for safe variable binding — avoids jq injection if the trigger
+# phrase or SHA contain jq-special characters (double quote, backslash).
+# Note: `]` must appear first in the bracket expression to be treated as literal.
 IDEM_STDERR=$(mktemp)
 IDEM_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
-  --jq ".[] | select((.body | test(\"$ESCAPED_SHA\")) and (.body | test(\"$ESCAPED_TRIGGER\"))) | {id: .id, created_at: .created_at, body: .body}" \
-  2>"$IDEM_STDERR" > "$IDEM_TMPFILE"; then
+  2>"$IDEM_STDERR" \
+  | jq -r --arg sha "$CURRENT_SHA" --arg trigger "$TRIGGER_PHRASE" \
+    '.[] | select((.body | test($sha)) and (.body | test($trigger; "i"))) | {id: .id, created_at: .created_at, body: .body}' \
+  > "$IDEM_TMPFILE"; then
   TRIGGER_COMMENT_INFO=$(head -c 2000 "$IDEM_TMPFILE")
 else
   IDEM_ERR=$(cat "$IDEM_STDERR")
@@ -171,11 +168,15 @@ while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
   # piping directly to 'head -c N' causes gh api to receive SIGPIPE when head
   # closes its stdin early (when response > N bytes), which pipefail propagates
   # as a non-zero exit code — falsely triggering the API failure counter.
+  # Use 'jq --arg' for safe variable binding — avoids jq injection if BOT_LOGIN
+  # contains jq-special characters (e.g., double quote, backslash).
   POLL_STDERR=$(mktemp)
   POLL_TMPFILE=$(mktemp)
   if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
-    --jq ".[] | select(.user.login == \"$BOT_LOGIN\") | select(.created_at > \"$TRIGGER_TIME\") | .body" \
-    2>"$POLL_STDERR" > "$POLL_TMPFILE"; then
+    2>"$POLL_STDERR" \
+    | jq -r --arg bot "$BOT_LOGIN" --arg trigger_time "$TRIGGER_TIME" \
+        '.[] | select(.user.login == $bot) | select(.created_at > $trigger_time) | .body' \
+    > "$POLL_TMPFILE"; then
     # Truncate after successful API call — no SIGPIPE risk here
     BOT_RESPONSE=$(head -c 10000 "$POLL_TMPFILE")
     rm -f "$POLL_STDERR" "$POLL_TMPFILE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -108,13 +108,29 @@ echo "INFO: Poll interval: ${POLL_INTERVAL}s, Max wait: ${MAX_WAIT}s"
 ESCAPED_SHA=$(printf '%s' "$CURRENT_SHA" | sed 's/[[\\.^$()|?*+{}]/\\&/g')
 ESCAPED_TRIGGER=$(printf '%s' "$TRIGGER_PHRASE" | sed 's/[[\\.^$()|?*+{}]/\\&/g')
 
-TRIGGER_COMMENT_INFO=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
+# Capture the idempotency check to a temp file to avoid:
+# - SIGPIPE under pipefail when piping to head (head closes the pipe early when
+#   the response is larger than the truncation limit, causing gh api to exit
+#   with SIGPIPE which pipefail propagates as a non-zero exit code)
+# - Silent failure swallowing (|| true on a pipeline hides real API errors)
+IDEM_STDERR=$(mktemp)
+IDEM_TMPFILE=$(mktemp)
+if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   --jq ".[] | select((.body | test(\"$ESCAPED_SHA\")) and (.body | test(\"$ESCAPED_TRIGGER\"))) | {id: .id, created_at: .created_at, body: .body}" \
-  2>/dev/null | head -c 2000 || true)
+  2>"$IDEM_STDERR" > "$IDEM_TMPFILE"; then
+  TRIGGER_COMMENT_INFO=$(head -c 2000 "$IDEM_TMPFILE")
+else
+  IDEM_ERR=$(cat "$IDEM_STDERR")
+  echo "WARNING: gh api failed in idempotency check (will proceed with trigger post as fallback): $IDEM_ERR" >&2
+  TRIGGER_COMMENT_INFO=""
+fi
+rm -f "$IDEM_STDERR" "$IDEM_TMPFILE"
 
 TRIGGER_TIME=""
 if [ -n "$TRIGGER_COMMENT_INFO" ]; then
-  TRIGGER_TIME=$(echo "$TRIGGER_COMMENT_INFO" | grep -o '"created_at":"[^"]*"' | head -1 | sed 's/"created_at":"//;s/"//')
+  # jq outputs pretty-printed JSON with a space after the colon: "created_at": "..."
+  # Use ' *' to match zero or more spaces to handle both compact and pretty-print output.
+  TRIGGER_TIME=$(echo "$TRIGGER_COMMENT_INFO" | grep -o '"created_at": *"[^"]*"' | head -1 | sed 's/"created_at": *"//;s/"//')
   if [ -n "$TRIGGER_TIME" ]; then
     echo "INFO: trigger comment already posted for commit $CURRENT_SHA (at $TRIGGER_TIME) — skipping duplicate post"
   fi
@@ -150,13 +166,22 @@ while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
 
   # Query comments authored by the bot that appeared after the trigger comment timestamp.
   # The bot login may include "[bot]" suffix — use exact string match on user.login.
-  # Capture stderr separately to distinguish API failures from empty results.
+  # Write the full output to a temp file first to avoid SIGPIPE under pipefail:
+  # piping directly to 'head -c N' causes gh api to receive SIGPIPE when head
+  # closes its stdin early (when response > N bytes), which pipefail propagates
+  # as a non-zero exit code — falsely triggering the API failure counter.
   POLL_STDERR=$(mktemp)
-  BOT_RESPONSE=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
+  POLL_TMPFILE=$(mktemp)
+  if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
     --jq ".[] | select(.user.login == \"$BOT_LOGIN\") | select(.created_at > \"$TRIGGER_TIME\") | .body" \
-    2>"$POLL_STDERR" | head -c 10000) || {
+    2>"$POLL_STDERR" > "$POLL_TMPFILE"; then
+    # Truncate after successful API call — no SIGPIPE risk here
+    BOT_RESPONSE=$(head -c 10000 "$POLL_TMPFILE")
+    rm -f "$POLL_STDERR" "$POLL_TMPFILE"
+    CONSECUTIVE_API_FAILURES=0
+  else
     POLL_ERR=$(cat "$POLL_STDERR")
-    rm -f "$POLL_STDERR"
+    rm -f "$POLL_STDERR" "$POLL_TMPFILE"
     CONSECUTIVE_API_FAILURES=$((CONSECUTIVE_API_FAILURES + 1))
     echo "WARNING: gh api failed during polling (attempt $CONSECUTIVE_API_FAILURES): $POLL_ERR" >&2
     if [ "$CONSECUTIVE_API_FAILURES" -ge "$MAX_CONSECUTIVE_FAILURES" ]; then
@@ -165,9 +190,7 @@ while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
       exit 2
     fi
     continue
-  }
-  rm -f "$POLL_STDERR"
-  CONSECUTIVE_API_FAILURES=0
+  fi
 
   if [ -n "$BOT_RESPONSE" ]; then
     echo "INFO: bot response detected"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -100,10 +100,16 @@ echo "INFO: Poll interval: ${POLL_INTERVAL}s, Max wait: ${MAX_WAIT}s"
 
 # ── Idempotency guard (BR-10) ─────────────────────────────────────────────────
 # Check whether a trigger comment for the current commit SHA already exists.
-# We look for a comment body containing both the trigger phrase prefix and the SHA.
+# We look for a comment body containing BOTH the trigger phrase AND the SHA to
+# avoid falsely matching bot review comments or human comments that happen to
+# reference the commit SHA.
+
+# Escape both strings for jq regex use (escape regex metacharacters)
+ESCAPED_SHA=$(printf '%s' "$CURRENT_SHA" | sed 's/[[\\.^$()|?*+{}]/\\&/g')
+ESCAPED_TRIGGER=$(printf '%s' "$TRIGGER_PHRASE" | sed 's/[[\\.^$()|?*+{}]/\\&/g')
 
 TRIGGER_COMMENT_INFO=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
-  --jq ".[] | select(.body | test(\"$(echo "$CURRENT_SHA" | sed 's/[[\\.^$()|?*+{}]/\\\\&/g')\")) | {id: .id, created_at: .created_at, body: .body}" \
+  --jq ".[] | select((.body | test(\"$ESCAPED_SHA\")) and (.body | test(\"$ESCAPED_TRIGGER\"))) | {id: .id, created_at: .created_at, body: .body}" \
   2>/dev/null | head -c 2000 || true)
 
 TRIGGER_TIME=""
@@ -118,11 +124,15 @@ fi
 
 if [ -z "$TRIGGER_TIME" ]; then
   echo "INFO: posting trigger comment to PR #$PR_NUMBER..."
-  gh pr comment "$PR_NUMBER" --repo "$OWNER/$REPO" \
-    --body "$TRIGGER_PHRASE (review triggered by workflow runner, commit: $CURRENT_SHA)"
-  # Capture the timestamp of the trigger comment we just posted
-  TRIGGER_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  echo "INFO: trigger comment posted at $TRIGGER_TIME"
+  # Use gh api --method POST to capture the GitHub-server-assigned created_at
+  # timestamp. Using 'date -u' here would risk clock skew between the local
+  # machine and GitHub's API server, causing bot responses to be silently
+  # filtered out during polling (created_at > TRIGGER_TIME would be false).
+  TRIGGER_TIME=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
+    --method POST \
+    --raw-field body="$TRIGGER_PHRASE (review triggered by workflow runner, commit: $CURRENT_SHA)" \
+    --jq '.created_at')
+  echo "INFO: trigger comment posted at $TRIGGER_TIME (server-assigned timestamp)"
 fi
 
 # ── Poll for bot response ─────────────────────────────────────────────────────

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# codex-github-reviewer.sh — Codex GitHub App reviewer path for Step 7a
+#
+# Implements the trigger/poll/parse loop for the Codex GitHub bot reviewer.
+# Classifies as universally reachable: requires only gh CLI access (no Codex
+# CLI runtime), so it works from Claude Code, Cursor, headless CI, and any
+# context where `gh` is authenticated.
+#
+# Usage:
+#   codex-github-reviewer.sh <pr_number> <owner> <repo> [options]
+#
+# Options:
+#   --trigger-phrase <phrase>   Trigger phrase to post. Default: "@codex review"
+#                               Also overridable via CODEX_GITHUB_TRIGGER_PHRASE env var.
+#   --bot-login     <login>     GitHub login of the Codex bot account.
+#                               Default: "codex-ai[bot]"
+#                               Also overridable via CODEX_GITHUB_BOT_LOGIN env var.
+#                               Verify the actual bot login from your GitHub App settings.
+#   --poll-interval <seconds>   Seconds between polling attempts. Default: 30
+#   --max-wait      <seconds>   Maximum total wait time for bot response. Default: 300
+#
+# Exit codes:
+#   0 — APPROVED   (bot responded with no blocking findings)
+#   1 — NEEDS_REVISION (bot responded with blocking findings)
+#   2 — TIMED_OUT  (no bot response within max-wait; treat as unavailable under
+#                   configured internal_reviewers_unavailable_policy)
+#
+# Verdict parsing:
+#   The script looks for blocking markers in the bot response body. If any
+#   blocking marker is found, the result is NEEDS_REVISION. Otherwise APPROVED.
+#   Blocking markers (case-insensitive): "changes requested", "blocking",
+#   "must fix", "required:", "action required", "❌".
+#   On unrecognized format, the script safe-fails to NEEDS_REVISION.
+#
+# Idempotency (BR-10):
+#   Before posting a trigger comment, the script queries existing PR comments
+#   for a trigger comment authored by a human/runner user (not the bot) that
+#   contains the current commit SHA. If found, the trigger post is skipped and
+#   polling proceeds from the existing trigger timestamp.
+
+set -euo pipefail
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+if [ $# -lt 3 ]; then
+  echo "Usage: $0 <pr_number> <owner> <repo> [--trigger-phrase <phrase>] [--bot-login <login>] [--poll-interval <seconds>] [--max-wait <seconds>]" >&2
+  exit 2
+fi
+
+PR_NUMBER="$1"
+OWNER="$2"
+REPO="$3"
+shift 3
+
+# Defaults (overridable by flags or env vars)
+TRIGGER_PHRASE="${CODEX_GITHUB_TRIGGER_PHRASE:-@codex review}"
+BOT_LOGIN="${CODEX_GITHUB_BOT_LOGIN:-codex-ai[bot]}"
+POLL_INTERVAL=30
+MAX_WAIT=300
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --trigger-phrase)
+      if [ $# -lt 2 ]; then echo "ERROR: --trigger-phrase requires a value" >&2; exit 2; fi
+      TRIGGER_PHRASE="$2"; shift 2;;
+    --bot-login)
+      if [ $# -lt 2 ]; then echo "ERROR: --bot-login requires a value" >&2; exit 2; fi
+      BOT_LOGIN="$2"; shift 2;;
+    --poll-interval)
+      if [ $# -lt 2 ]; then echo "ERROR: --poll-interval requires a value" >&2; exit 2; fi
+      POLL_INTERVAL="$2"; shift 2;;
+    --max-wait)
+      if [ $# -lt 2 ]; then echo "ERROR: --max-wait requires a value" >&2; exit 2; fi
+      MAX_WAIT="$2"; shift 2;;
+    *)
+      echo "ERROR: unknown option '$1'" >&2; exit 2;;
+  esac
+done
+
+# ── Pre-flight: verify gh CLI authentication ──────────────────────────────────
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: gh CLI not authenticated. Run 'gh auth login' before using codex-github-reviewer.sh" >&2
+  echo "VERDICT: TIMED_OUT — gh CLI authentication failed (treated as unavailable)"
+  exit 2
+fi
+
+# ── Resolve current HEAD commit SHA ──────────────────────────────────────────
+
+CURRENT_SHA=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid --jq '.headRefOid' | cut -c1-12)
+if [ -z "$CURRENT_SHA" ]; then
+  echo "ERROR: could not resolve PR #$PR_NUMBER HEAD SHA" >&2
+  exit 2
+fi
+
+echo "INFO: PR #$PR_NUMBER HEAD commit: $CURRENT_SHA"
+echo "INFO: Bot login: $BOT_LOGIN"
+echo "INFO: Trigger phrase: $TRIGGER_PHRASE"
+echo "INFO: Poll interval: ${POLL_INTERVAL}s, Max wait: ${MAX_WAIT}s"
+
+# ── Idempotency guard (BR-10) ─────────────────────────────────────────────────
+# Check whether a trigger comment for the current commit SHA already exists.
+# We look for a comment body containing both the trigger phrase prefix and the SHA.
+
+TRIGGER_COMMENT_INFO=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
+  --jq ".[] | select(.body | test(\"$(echo "$CURRENT_SHA" | sed 's/[[\\.^$()|?*+{}]/\\\\&/g')\")) | {id: .id, created_at: .created_at, body: .body}" \
+  2>/dev/null | head -c 2000 || true)
+
+TRIGGER_TIME=""
+if [ -n "$TRIGGER_COMMENT_INFO" ]; then
+  TRIGGER_TIME=$(echo "$TRIGGER_COMMENT_INFO" | grep -o '"created_at":"[^"]*"' | head -1 | sed 's/"created_at":"//;s/"//')
+  if [ -n "$TRIGGER_TIME" ]; then
+    echo "INFO: trigger comment already posted for commit $CURRENT_SHA (at $TRIGGER_TIME) — skipping duplicate post"
+  fi
+fi
+
+# ── Post trigger comment (if no duplicate found) ──────────────────────────────
+
+if [ -z "$TRIGGER_TIME" ]; then
+  echo "INFO: posting trigger comment to PR #$PR_NUMBER..."
+  gh pr comment "$PR_NUMBER" --repo "$OWNER/$REPO" \
+    --body "$TRIGGER_PHRASE (review triggered by workflow runner, commit: $CURRENT_SHA)"
+  # Capture the timestamp of the trigger comment we just posted
+  TRIGGER_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  echo "INFO: trigger comment posted at $TRIGGER_TIME"
+fi
+
+# ── Poll for bot response ─────────────────────────────────────────────────────
+
+echo "INFO: polling for response from '$BOT_LOGIN' (trigger time: $TRIGGER_TIME)..."
+
+ELAPSED=0
+while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+  sleep "$POLL_INTERVAL"
+  ELAPSED=$((ELAPSED + POLL_INTERVAL))
+
+  echo "INFO: polling... elapsed ${ELAPSED}s / ${MAX_WAIT}s"
+
+  # Query comments authored by the bot that appeared after the trigger comment timestamp.
+  # The bot login may include "[bot]" suffix — use exact string match on user.login.
+  BOT_RESPONSE=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
+    --jq ".[] | select(.user.login == \"$BOT_LOGIN\") | select(.created_at > \"$TRIGGER_TIME\") | .body" \
+    2>/dev/null | head -c 10000 || true)
+
+  if [ -n "$BOT_RESPONSE" ]; then
+    echo "INFO: bot response detected"
+
+    # ── Verdict parsing ───────────────────────────────────────────────────────
+    # Safe-fail: default to NEEDS_REVISION when the response format is unrecognized.
+    # APPROVED only when none of the blocking markers are present.
+    #
+    # Blocking markers (case-insensitive):
+    #   - "changes requested"
+    #   - "blocking"
+    #   - "must fix"
+    #   - "required:"
+    #   - "action required"
+    #   - the ❌ emoji (literal or Unicode escape)
+    #
+    # Approval signals:
+    #   - "approved" or "lgtm" or "looks good" present AND no blocking markers
+    #   - no blocking markers at all (conservative: treat silence as approval)
+
+    if echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|must[[:space:]]+fix|action[[:space:]]+required|required:[[:space:]]|❌)"; then
+      echo "VERDICT: NEEDS_REVISION"
+      echo "---BEGIN BOT RESPONSE---"
+      echo "$BOT_RESPONSE"
+      echo "---END BOT RESPONSE---"
+      exit 1
+    else
+      echo "VERDICT: APPROVED"
+      echo "---BEGIN BOT RESPONSE---"
+      echo "$BOT_RESPONSE"
+      echo "---END BOT RESPONSE---"
+      exit 0
+    fi
+  fi
+done
+
+# ── Timeout ───────────────────────────────────────────────────────────────────
+
+echo "VERDICT: TIMED_OUT — no response from '$BOT_LOGIN' within ${MAX_WAIT}s after trigger"
+echo "INFO: remediation — verify the Codex GitHub App is installed on $OWNER/$REPO."
+echo "INFO: You can manually trigger the review by posting: $TRIGGER_PHRASE"
+exit 2

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -161,7 +161,7 @@ while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
     #   - "approved" or "lgtm" or "looks good" present AND no blocking markers
     #   - no blocking markers at all (conservative: treat silence as approval)
 
-    if echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|must[[:space:]]+fix|action[[:space:]]+required|required:[[:space:]]|❌)"; then
+    if echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking|must[[:space:]]+fix|action[[:space:]]+required|required:[[:space:]]|❌)"; then
       echo "VERDICT: NEEDS_REVISION"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -25,14 +25,14 @@
 #   2 — TIMED_OUT  (no bot response within max-wait; treat as unavailable under
 #                   configured internal_reviewers_unavailable_policy)
 #
-# Verdict parsing (three-path, approval checked first):
-#   1. Explicit approval signals present → APPROVED (exit 0)
+# Verdict parsing (three-path, blocking markers checked first per safe-fail):
+#   1. Blocking markers present → NEEDS_REVISION (exit 1)
+#      Markers (case-insensitive): "changes requested", "blocking issues/finding",
+#      "blocking:", "must fix", "action required", "required:", "❌"
+#      Note: bare "blocking" is excluded to avoid false positives on
+#      "no blocking issues found" — use specific phrases instead.
+#   2. Approval signals present → APPROVED (exit 0)
 #      Signals (case-insensitive): "approved", "lgtm", "looks good"
-#      Checked FIRST to avoid false NEEDS_REVISION from negated blocking context
-#      (e.g. "No blocking issues. Approved.").
-#   2. Blocking markers present → NEEDS_REVISION (exit 1)
-#      Markers (case-insensitive): "changes requested", "blocking",
-#      "must fix", "required:", "action required", "❌"
 #   3. Neither found (unrecognized format) → safe-fails to NEEDS_REVISION (exit 1)
 #
 # Idempotency (BR-10):
@@ -242,34 +242,38 @@ while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
 
     # ── Verdict parsing ───────────────────────────────────────────────────────
     # Three-path classification (per spec BR-4 and implementation plan risk table).
-    # Approval signals are checked FIRST to avoid false NEEDS_REVISION when the
-    # bot says "No blocking issues. Approved." (the bare word 'blocking' would
-    # match the blocking-marker check if it ran first).
+    # Blocking markers are checked FIRST (safe-fail: a false NEEDS_REVISION that
+    # triggers an unnecessary fix cycle is safer than a false APPROVED that
+    # silently ignores blocking findings). The bare word "blocking" is excluded
+    # from the marker list because it matches negated context ("no blocking
+    # issues") — use more specific phrases ("blocking issues", "blocking finding",
+    # "blocking:") instead.
     #
-    # 1. Explicit approval signals present → APPROVED (exit 0)   [checked first]
+    # 1. Blocking markers present → NEEDS_REVISION (exit 1)      [checked first]
+    #    Blocking markers (case-insensitive): "changes requested",
+    #    "blocking issues", "blocking finding", "blocking:", "must fix",
+    #    "action required", "required:", "❌"
+    #
+    # 2. Explicit approval signals present → APPROVED (exit 0)   [checked second]
     #    Approval signals: "approved", "lgtm", "looks good"
-    #
-    # 2. Blocking markers present → NEEDS_REVISION (exit 1)      [checked second]
-    #    Blocking markers (case-insensitive): "changes requested", "blocking",
-    #    "must fix", "required:", "action required", "❌"
     #
     # 3. Neither found (unrecognized response format) → NEEDS_REVISION (exit 1)
     #    Safe-fail: default to NEEDS_REVISION when the format is unrecognized to
     #    avoid incorrectly approving a response that is a rejection in an
     #    unexpected format (per spec risk mitigation for BR-4).
 
-    if echo "$BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good)"; then
-      echo "VERDICT: APPROVED"
-      echo "---BEGIN BOT RESPONSE---"
-      echo "$BOT_RESPONSE"
-      echo "---END BOT RESPONSE---"
-      exit 0
-    elif echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+    if echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
       echo "VERDICT: NEEDS_REVISION"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 1
+    elif echo "$BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good)"; then
+      echo "VERDICT: APPROVED"
+      echo "---BEGIN BOT RESPONSE---"
+      echo "$BOT_RESPONSE"
+      echo "---END BOT RESPONSE---"
+      exit 0
     else
       echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
       echo "---BEGIN BOT RESPONSE---"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -86,10 +86,17 @@ if ! gh auth status >/dev/null 2>&1; then
 fi
 
 # ── Resolve current HEAD commit SHA ──────────────────────────────────────────
+# Guard the assignment with 'if !' to prevent set -e from exiting with code 1
+# (NEEDS_REVISION) before the empty-check guard below can emit the VERDICT line.
 
-CURRENT_SHA=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid --jq '.headRefOid' | cut -c1-12)
-if [ -z "$CURRENT_SHA" ]; then
+if ! CURRENT_SHA=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid --jq '.headRefOid' 2>&1 | head -c 100); then
   echo "ERROR: could not resolve PR #$PR_NUMBER HEAD SHA" >&2
+  echo "VERDICT: TIMED_OUT — could not resolve PR HEAD SHA (treated as unavailable)"
+  exit 2
+fi
+CURRENT_SHA=$(printf '%s' "$CURRENT_SHA" | cut -c1-12)
+if [ -z "$CURRENT_SHA" ]; then
+  echo "ERROR: could not resolve PR #$PR_NUMBER HEAD SHA (empty result)" >&2
   echo "VERDICT: TIMED_OUT — could not resolve PR HEAD SHA (treated as unavailable)"
   exit 2
 fi
@@ -114,7 +121,7 @@ IDEM_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>"$IDEM_STDERR" \
   | jq -r --arg sha "$CURRENT_SHA" --arg trigger "$TRIGGER_PHRASE" \
-    '.[] | select((.body | test($sha)) and (.body | test($trigger; "i"))) | {id: .id, created_at: .created_at, body: .body}' \
+    '.[] | select((.body | test($sha)) and (.body | ascii_downcase | contains($trigger | ascii_downcase))) | {id: .id, created_at: .created_at, body: .body}' \
   > "$IDEM_TMPFILE"; then
   TRIGGER_COMMENT_INFO=$(head -c 2000 "$IDEM_TMPFILE")
 else
@@ -142,10 +149,16 @@ if [ -z "$TRIGGER_TIME" ]; then
   # timestamp. Using 'date -u' here would risk clock skew between the local
   # machine and GitHub's API server, causing bot responses to be silently
   # filtered out during polling (created_at > TRIGGER_TIME would be false).
-  TRIGGER_TIME=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
+  # Guard with 'if !' to emit TIMED_OUT (exit 2) on failure instead of letting
+  # set -e exit with code 1 (NEEDS_REVISION) without a VERDICT line.
+  if ! TRIGGER_TIME=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
     --method POST \
     --raw-field body="$TRIGGER_PHRASE (review triggered by workflow runner, commit: $CURRENT_SHA)" \
-    --jq '.created_at')
+    --jq '.created_at'); then
+    echo "ERROR: failed to post trigger comment to PR #$PR_NUMBER" >&2
+    echo "VERDICT: TIMED_OUT — failed to post trigger comment (treated as unavailable)"
+    exit 2
+  fi
   echo "INFO: trigger comment posted at $TRIGGER_TIME (server-assigned timestamp)"
 fi
 

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -55,11 +55,26 @@ OWNER="$2"
 REPO="$3"
 shift 3
 
-# Validate PR_NUMBER is a positive integer before any interpolation into
-# gh commands or API URLs (REVIEW.md: validate user-supplied input).
+# Validate positional arguments before interpolation into gh commands and API
+# URLs (REVIEW.md: validate user-supplied input before interpolation).
 case "$PR_NUMBER" in
   ''|0|*[!0-9]*)
     echo "ERROR: PR number '$PR_NUMBER' is not a valid positive integer" >&2
+    exit 2
+    ;;
+esac
+# GitHub owner and repo names consist of alphanumerics, hyphens, underscores,
+# and dots. Reject empty values or values with other characters (including '/'
+# which could redirect API paths).
+case "$OWNER" in
+  ''|*[!A-Za-z0-9._-]*)
+    echo "ERROR: owner '$OWNER' contains invalid characters (expected alphanumerics, hyphens, underscores, dots)" >&2
+    exit 2
+    ;;
+esac
+case "$REPO" in
+  ''|*[!A-Za-z0-9._-]*)
+    echo "ERROR: repo '$REPO' contains invalid characters (expected alphanumerics, hyphens, underscores, dots)" >&2
     exit 2
     ;;
 esac

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -77,6 +77,24 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# ── Validate numeric options ──────────────────────────────────────────────────
+# POLL_INTERVAL and MAX_WAIT are used in 'sleep' and arithmetic. Validate them
+# here so a non-numeric value exits with code 2 (TIMED_OUT) instead of
+# silently causing 'sleep' to fail under set -e with code 1 (NEEDS_REVISION).
+
+case "$POLL_INTERVAL" in
+  ''|*[!0-9]*)
+    echo "ERROR: --poll-interval value '$POLL_INTERVAL' is not a positive integer" >&2
+    exit 2
+    ;;
+esac
+case "$MAX_WAIT" in
+  ''|*[!0-9]*)
+    echo "ERROR: --max-wait value '$MAX_WAIT' is not a positive integer" >&2
+    exit 2
+    ;;
+esac
+
 # ── Pre-flight: verify gh CLI authentication ──────────────────────────────────
 
 if ! gh auth status >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Closes #309.

Adds a `codex-github` reviewer entry to the Step 7a internal review gate. This reviewer posts a review-trigger comment to the PR via `gh pr comment` and polls for the Codex GitHub App bot response. Because it uses only `gh` CLI (already available in every runner context), `codex-github` is classified as universally reachable — unlike the `codex` (CLI) reviewer which is restricted to Codex-native runners.

**Files changed:**

- `scripts/development-workflow/codex-github-reviewer.sh` (new): trigger/poll/parse/timeout loop; exit codes 0=APPROVED, 1=NEEDS_REVISION, 2=TIMED_OUT; idempotency guard prevents duplicate trigger comments for the same commit SHA (BR-10)
- `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`: expanded reachability table with `codex-github` column, new dispatch map rows, exit-code semantics, timeout policy mapping, NEEDS_REVISION finding extraction, and re-trigger-on-fix-cycle notes
- `.ai-dev-workflow.yaml`: documented `codex-github` as a supported `internal_reviewers` value with configuration keys (`CODEX_GITHUB_TRIGGER_PHRASE`, `CODEX_GITHUB_BOT_LOGIN`, `--poll-interval`, `--max-wait`)
- `.claude/agents/item-orchestrator.md` + `.cursor/agents/item-orchestrator.md`: added `codex-github` dispatch path bullet

## Test plan

- [ ] `codex-github` appears in Protocol 91 Step 7a reachability classification table with `Yes` for all runner contexts
- [ ] `codex-github` rows present in Step 7a reviewer dispatch map (pointing to `codex-github-reviewer.sh`)
- [ ] `scripts/development-workflow/codex-github-reviewer.sh` is executable and passes `bash -n` syntax check
- [ ] CHANGELOG `[Unreleased]` section has new `### Added` entry for #309
- [ ] `.ai-dev-workflow.yaml` documents `codex-github` as supported value with configuration key comments
- [ ] Agent guidance files updated in both `.claude/agents/` and `.cursor/agents/`
- [ ] Smoke test runbook exists at `docs/testing/workflow/309-codex-github-integration-reviewer.smoke-test.md`

See smoke test runbook for manual verification scenarios.