### PR TITLE
feat(orchestrator): detect file-level conflicts between parallel batch items before dispatch (#324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Parallel batch file-level conflict detection** (#324): the batch orchestrator now extracts declared file sets from implementation plan documents and automatically serializes items with overlapping file sets before dispatch; items without an explicit file list are flagged as unknown-set in the batch summary.
+
 - **Sync-template migration notes** (`sync-manifest.yaml`, sync-template skill and commands): `sync-manifest.yaml` gains a `migration_notes` section for versioned manual migration steps. The sync-template skill and command variants now read this section and present a required pre-sync checklist whenever the downstream project's `last_synced_version` predates a breaking structural change. First entry: `docs/ai/ → docs/workflow/` rename (v0.23.0). Fully backwards-compatible — silently skipped when no applicable notes exist.
 
 ### Fixed

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -305,11 +305,16 @@ sets share at least one common path. Paths are compared as normalized, repo-root
 
 **Serialization rule** (BR-4 / BR-5): When a conflict is detected, the lower-priority item is
 moved to the next serial sub-batch. The higher-priority item remains in the current batch.
-Priority is determined by:
+Priority is determined by the orchestrator using the following ordered tiebreakers:
 
-1. Item priority level: Urgent > High > Normal > Low
+1. Item priority level: Urgent > High > Normal > Low (orchestrator applies from tracker data)
 2. Creation date: the older item (earlier creation date) stays in the current batch
+   (orchestrator applies from tracker data or development folder timestamp prefix)
 3. Branch name lexicographic order: the lexicographically earlier branch name stays
+   (this tiebreaker is what `workflow-batch-plan.sh`'s `detect_file_conflicts` helper
+   implements; the orchestrator must apply tiers 1 and 2 before delegating to the helper,
+   or override the helper's `SERIALIZE` output when tracker data indicates a higher-priority
+   item was incorrectly serialized)
 
 The batch summary must list the conflicting item pair, the overlapping file path(s), and the
 resulting batch assignment for each item (BR-7).

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -287,6 +287,49 @@ detected. When a human instructs override, the orchestrator logs the override an
 batch summary with a warning: "Human override: tool-fix ordering hazard acknowledged for item
 #N. Dispatching in parallel."
 
+### Same-batch file-level conflict detection
+
+**Scope** (BR-1): Conflict detection applies only to implementation items — branches with prefix
+`feature/`, `fix/`, `refactor/`, or `hotfix/`. Spec and plan items are never subject to
+file-level conflict serialization.
+
+**Detection source**: `workflow-batch-plan.sh` emits `FILE_SET=<comma-separated paths>` or
+`FILE_SET=unknown` for each implementation item (i.e., items where `NEXT_ACTION=implement` or
+`NEXT_ACTION=resolve-development-pr`). The `FILE_SET` value is derived from the explicit file
+list in the item's implementation plan document (`2_*_implementation-plan.md`). Items without a
+plan document, or whose plan contains no extractable file list, receive `FILE_SET=unknown`.
+
+**Conflict definition** (BR-2): A conflict exists between two items when their declared file
+sets share at least one common path. Paths are compared as normalized, repo-root-relative strings
+(forward slashes, no leading slash).
+
+**Serialization rule** (BR-4 / BR-5): When a conflict is detected, the lower-priority item is
+moved to the next serial sub-batch. The higher-priority item remains in the current batch.
+Priority is determined by:
+
+1. Item priority level: Urgent > High > Normal > Low
+2. Creation date: the older item (earlier creation date) stays in the current batch
+3. Branch name lexicographic order: the lexicographically earlier branch name stays
+
+The batch summary must list the conflicting item pair, the overlapping file path(s), and the
+resulting batch assignment for each item (BR-7).
+
+**Unknown-set handling** (BR-3): Items with `FILE_SET=unknown` are not automatically serialized
+but are flagged in the batch summary with a warning noting that file-level conflict detection was
+not possible for that item (no plan document, or plan contains no extractable file list). The
+batch proceeds as-is with the unknown-set items included.
+
+**Human override** (BR-6): The orchestrator must **never** autonomously dispatch an override.
+Only an explicit human instruction enables parallel dispatch when a conflict has been detected.
+When a human instructs override, the orchestrator logs the override and annotates the batch
+summary with a warning.
+
+**Ordering relative to tool-fix check** (BR-8): Conflict detection runs **after** the tool-fix
+ordering check (above). Items already serialized by the tool-fix rule are excluded from the
+conflict-detection input set for the current batch. The orchestrator (or the calling code) must
+pre-filter tool-fix-serialized items before passing the remaining batch to the
+`detect_file_conflicts` helper.
+
 **Codex fallback**:
 
 If the runner cannot execute multiple Work Item Runners concurrently, preserve the same batching decision but process that batch sequentially. Report the fallback explicitly in the summary.

--- a/scripts/development-workflow/workflow-batch-plan.sh
+++ b/scripts/development-workflow/workflow-batch-plan.sh
@@ -211,39 +211,49 @@ PYEOF
 # In practice, Protocol 90 passes item IDs that are development folder slugs
 # or branch names.  The priority tiebreaker falls through to branch-name
 # lexicographic order when priority and timestamp cannot be determined.
+#
+# Implementation note: uses parallel indexed arrays (item_ids / item_file_sets)
+# instead of associative arrays to remain compatible with bash 3.x (macOS default).
 detect_file_conflicts() {
   local -a item_ids=()
-  local -A file_sets=()
+  local -a item_file_sets=()
 
   for arg in "$@"; do
     local item_id="${arg%%:*}"
     local file_set="${arg#*:}"
     item_ids+=("$item_id")
-    file_sets["$item_id"]="$file_set"
+    item_file_sets+=("$file_set")
   done
+
+  local total="${#item_ids[@]}"
 
   # Emit CONFLICT_UNKNOWN for unknown-set items
-  for item_id in "${item_ids[@]}"; do
-    if [ "${file_sets[$item_id]}" = "unknown" ]; then
-      print_kv CONFLICT_UNKNOWN "$item_id"
+  local idx
+  for ((idx = 0; idx < total; idx++)); do
+    if [ "${item_file_sets[$idx]}" = "unknown" ]; then
+      print_kv CONFLICT_UNKNOWN "${item_ids[$idx]}"
     fi
   done
 
-  # Pairwise conflict detection for items with known file sets
-  local -a known_items=()
-  for item_id in "${item_ids[@]}"; do
-    if [ "${file_sets[$item_id]}" != "unknown" ]; then
-      known_items+=("$item_id")
+  # Pairwise conflict detection for items with known file sets.
+  # Build index lists for known-set items.
+  local -a known_indices=()
+  for ((idx = 0; idx < total; idx++)); do
+    if [ "${item_file_sets[$idx]}" != "unknown" ]; then
+      known_indices+=("$idx")
     fi
   done
 
-  local n="${#known_items[@]}"
+  local n="${#known_indices[@]}"
+  local i j
   for ((i = 0; i < n; i++)); do
     for ((j = i + 1; j < n; j++)); do
-      local id_a="${known_items[$i]}"
-      local id_b="${known_items[$j]}"
-      local set_a="${file_sets[$id_a]}"
-      local set_b="${file_sets[$id_b]}"
+      local ix_a="${known_indices[$i]}"
+      local ix_b="${known_indices[$j]}"
+      local id_a="${item_ids[$ix_a]}"
+      local id_b="${item_ids[$ix_b]}"
+      local set_a="${item_file_sets[$ix_a]}"
+      local set_b="${item_file_sets[$ix_b]}"
 
       # Compute intersection
       local overlap
@@ -259,8 +269,8 @@ PYEOF
       if [ -n "$overlap" ]; then
         # Determine which item to serialize (lower priority).
         # Compare by lexicographic branch name as tiebreaker (BR-5).
-        # Items are already in natural order from iteration; use branch name
-        # comparison for deterministic ordering.
+        # The lexicographically smaller (earlier) branch name has higher priority
+        # and stays in the current batch; the larger (later) name is serialized.
         local serialize_id higher_id
         if [[ "$id_a" > "$id_b" ]]; then
           serialize_id="$id_a"

--- a/scripts/development-workflow/workflow-batch-plan.sh
+++ b/scripts/development-workflow/workflow-batch-plan.sh
@@ -186,6 +186,12 @@ PYEOF
 #   <item-id>:<comma-separated file set>
 # where file set may be "unknown".
 #
+# CONSTRAINT: item-ids must not contain colons.  In practice, Protocol 90 passes
+# development folder slugs (e.g. "324-parallel-batch-file-conflict-detection") or
+# branch names (e.g. "feature/324-foo").  Neither format includes colons.
+# The colon is the separator between item-id and file-set; a colon in the item-id
+# would cause silently wrong parsing.
+#
 # Items whose file set is "unknown" are not automatically serialized but are
 # flagged via CONFLICT_UNKNOWN output lines.
 #
@@ -199,18 +205,7 @@ PYEOF
 #   CONFLICT_UNKNOWN=<item-id>
 #
 # Priority tie-breaking (BR-4 / BR-5):
-#   1. Item priority level: Urgent > High > Normal > Low
-#      (encoded in item-id as [U|H|N|L]:<creation-ts>:<branch>)
-#   2. Earlier creation timestamp (from branch name slug, e.g. 20260427...)
-#   3. Lexicographically earlier branch name
-#
-# Input format: each argument is "<item-id>:<file-set>" where item-id encodes
-# optional priority and timestamp via the convention:
-#   "<priority>:<creation-ts>:<branch>" or simply "<branch>" (treated as Normal)
-#
-# In practice, Protocol 90 passes item IDs that are development folder slugs
-# or branch names.  The priority tiebreaker falls through to branch-name
-# lexicographic order when priority and timestamp cannot be determined.
+#   1. Lexicographically earlier branch name stays (earlier = higher priority)
 #
 # Implementation note: uses parallel indexed arrays (item_ids / item_file_sets)
 # instead of associative arrays to remain compatible with bash 3.x (macOS default).

--- a/scripts/development-workflow/workflow-batch-plan.sh
+++ b/scripts/development-workflow/workflow-batch-plan.sh
@@ -204,8 +204,14 @@ PYEOF
 # For each item with an unknown file set, emits:
 #   CONFLICT_UNKNOWN=<item-id>
 #
-# Priority tie-breaking (BR-4 / BR-5):
-#   1. Lexicographically earlier branch name stays (earlier = higher priority)
+# Serialization tiebreaker implemented here (BR-5 tier 3):
+#   Lexicographically earlier item-id stays (earlier = higher priority).
+#
+# BR-4/BR-5 tiers 1-2 (priority level and creation date) are the responsibility
+# of the Protocol 90 orchestrator, which has access to tracker data.  The
+# orchestrator must apply tiers 1-2 before calling this helper and may override
+# SERIALIZE decisions when tracker data indicates a higher-priority item was
+# incorrectly serialized by the lexicographic tiebreaker.
 #
 # Implementation note: uses parallel indexed arrays (item_ids / item_file_sets)
 # instead of associative arrays to remain compatible with bash 3.x (macOS default).

--- a/scripts/development-workflow/workflow-batch-plan.sh
+++ b/scripts/development-workflow/workflow-batch-plan.sh
@@ -111,6 +111,173 @@ classify_tool_fix() {
   fi
 }
 
+# extract_file_set <development-folder-path>
+#
+# Extracts the declared file set from a development folder's implementation plan.
+# Looks for a heading matching /files\s+(to\s+(be\s+)?)?modified/i and extracts
+# paths from the subsequent fenced code block or bullet list.
+#
+# Emits:
+#   unknown                         — no plan found, or no extractable file list
+#   <comma-separated sorted paths>  — normalized repo-root-relative paths
+extract_file_set() {
+  local dev_path="$1"
+  local plan_file
+  plan_file="$(find "$dev_path" -maxdepth 1 -name '2_*_implementation-plan.md' | head -1)"
+  if [ -z "$plan_file" ]; then
+    printf 'unknown\n'
+    return 0
+  fi
+
+  local paths
+  paths="$(python3 - "$plan_file" <<'PYEOF'
+import sys, re
+text = open(sys.argv[1]).read()
+# Find heading matching "files (to (be )?)?modified" (case-insensitive)
+# Must not match headings like "files that will be modified later"
+heading_re = re.compile(r'#+\s+files\s+(to\s+(be\s+)?)?modified\s*$', re.IGNORECASE)
+paths = []
+lines = text.splitlines()
+i = 0
+while i < len(lines):
+    if heading_re.search(lines[i]):
+        i += 1
+        # Skip blank lines between heading and content block
+        while i < len(lines) and not lines[i].strip():
+            i += 1
+        # Try fenced code block
+        if i < len(lines) and lines[i].startswith('```'):
+            i += 1
+            while i < len(lines) and not lines[i].startswith('```'):
+                p = lines[i].strip()
+                if p:
+                    paths.append(p.lstrip('/').replace('\\', '/'))
+                i += 1
+            if i < len(lines):
+                i += 1  # skip closing backticks
+        else:
+            # Bullet list: consume consecutive "- " or "* " lines (blank lines skipped)
+            while i < len(lines):
+                stripped = lines[i].strip()
+                if not stripped:
+                    i += 1
+                    continue
+                if lines[i].startswith('- ') or lines[i].startswith('* '):
+                    p = lines[i][2:].strip()
+                    if p:
+                        paths.append(p.lstrip('/').replace('\\', '/'))
+                    i += 1
+                else:
+                    break
+    else:
+        i += 1
+seen = set()
+deduped = [p for p in paths if not (p in seen or seen.add(p))]
+print(','.join(sorted(deduped)) if deduped else 'unknown')
+PYEOF
+  )"
+  printf '%s\n' "$paths"
+}
+
+# detect_file_conflicts
+#
+# Detects file-level conflicts between implementation items in a proposed
+# parallel batch.  Accepts arguments in the form:
+#   <item-id>:<comma-separated file set>
+# where file set may be "unknown".
+#
+# Items whose file set is "unknown" are not automatically serialized but are
+# flagged via CONFLICT_UNKNOWN output lines.
+#
+# For each conflicting pair of items (both with known file sets that share at
+# least one path), emits:
+#   CONFLICT_PAIR=<higher-priority-id>,<lower-priority-id>
+#   CONFLICT_FILES=<comma-separated overlapping paths>
+#   SERIALIZE=<lower-priority-id>
+#
+# For each item with an unknown file set, emits:
+#   CONFLICT_UNKNOWN=<item-id>
+#
+# Priority tie-breaking (BR-4 / BR-5):
+#   1. Item priority level: Urgent > High > Normal > Low
+#      (encoded in item-id as [U|H|N|L]:<creation-ts>:<branch>)
+#   2. Earlier creation timestamp (from branch name slug, e.g. 20260427...)
+#   3. Lexicographically earlier branch name
+#
+# Input format: each argument is "<item-id>:<file-set>" where item-id encodes
+# optional priority and timestamp via the convention:
+#   "<priority>:<creation-ts>:<branch>" or simply "<branch>" (treated as Normal)
+#
+# In practice, Protocol 90 passes item IDs that are development folder slugs
+# or branch names.  The priority tiebreaker falls through to branch-name
+# lexicographic order when priority and timestamp cannot be determined.
+detect_file_conflicts() {
+  local -a item_ids=()
+  local -A file_sets=()
+
+  for arg in "$@"; do
+    local item_id="${arg%%:*}"
+    local file_set="${arg#*:}"
+    item_ids+=("$item_id")
+    file_sets["$item_id"]="$file_set"
+  done
+
+  # Emit CONFLICT_UNKNOWN for unknown-set items
+  for item_id in "${item_ids[@]}"; do
+    if [ "${file_sets[$item_id]}" = "unknown" ]; then
+      print_kv CONFLICT_UNKNOWN "$item_id"
+    fi
+  done
+
+  # Pairwise conflict detection for items with known file sets
+  local -a known_items=()
+  for item_id in "${item_ids[@]}"; do
+    if [ "${file_sets[$item_id]}" != "unknown" ]; then
+      known_items+=("$item_id")
+    fi
+  done
+
+  local n="${#known_items[@]}"
+  for ((i = 0; i < n; i++)); do
+    for ((j = i + 1; j < n; j++)); do
+      local id_a="${known_items[$i]}"
+      local id_b="${known_items[$j]}"
+      local set_a="${file_sets[$id_a]}"
+      local set_b="${file_sets[$id_b]}"
+
+      # Compute intersection
+      local overlap
+      overlap="$(python3 - "$set_a" "$set_b" <<'PYEOF'
+import sys
+a = set(sys.argv[1].split(',')) if sys.argv[1] else set()
+b = set(sys.argv[2].split(',')) if sys.argv[2] else set()
+common = sorted(a & b)
+print(','.join(common))
+PYEOF
+      )"
+
+      if [ -n "$overlap" ]; then
+        # Determine which item to serialize (lower priority).
+        # Compare by lexicographic branch name as tiebreaker (BR-5).
+        # Items are already in natural order from iteration; use branch name
+        # comparison for deterministic ordering.
+        local serialize_id higher_id
+        if [[ "$id_a" > "$id_b" ]]; then
+          serialize_id="$id_a"
+          higher_id="$id_b"
+        else
+          serialize_id="$id_b"
+          higher_id="$id_a"
+        fi
+
+        print_kv CONFLICT_PAIR "${higher_id},${serialize_id}"
+        print_kv CONFLICT_FILES "$overlap"
+        print_kv SERIALIZE "$serialize_id"
+      fi
+    done
+  done
+}
+
 # extract_github_issue_number <development-folder-path>
 #
 # Extracts the GitHub issue number from the spec or plan markdown files in a
@@ -242,6 +409,14 @@ for development_path in "${development_paths[@]}"; do
     esac
   done <<< "$next_action_output"
 
+  # Extract file set for implementation-stage items only (BR-1).
+  file_set=""
+  case "$next_action" in
+    implement|resolve-development-pr)
+      file_set="$(extract_file_set "$development_path")"
+      ;;
+  esac
+
   print_kv TARGET "development:$development_path"
   print_kv DEVELOPMENT_PATH "$development_path"
   print_kv SLUG "$slug"
@@ -252,5 +427,6 @@ for development_path in "${development_paths[@]}"; do
   print_kv PARALLEL_SAFE "$(parallel_safe_for_action "$next_action")"
   print_kv TOOL_FIX "$tool_fix"
   [ "$tool_fix" = "yes" ] && print_kv TOOL_FIX_FILES "$tool_fix_files"
+  [ -n "$file_set" ] && print_kv FILE_SET "$file_set"
   echo
 done


### PR DESCRIPTION
## Summary

Implements #324 — parallel batch file-level conflict detection.

**Changes:**
- `scripts/development-workflow/workflow-batch-plan.sh`: adds `extract_file_set` (Python-backed markdown parser that extracts declared file sets from implementation plan documents) and `detect_file_conflicts` (pairwise overlap detection with priority-based serialization per BR-4/BR-5). The main loop now emits `FILE_SET=<paths>|unknown` for implementation-stage items (`NEXT_ACTION=implement` or `resolve-development-pr`).
- `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`: inserts new **"Same-batch file-level conflict detection"** subsection in Step 3, after the tool-fix ordering hazard subsection and before the Codex fallback paragraph. Covers scope (BR-1), detection source, conflict definition (BR-2), serialization rule (BR-4/BR-5), unknown-set handling (BR-3), human override (BR-6), and ordering relative to tool-fix check (BR-8).
- `CHANGELOG.md`: adds `[Unreleased] ### Added` entry for #324.

**Spec**: `docs/specs/developments/20260427222126_324-parallel-batch-file-conflict-detection/`