### PR TITLE
docs(plan): pre-merge setup signal for PRs requiring human configuration

### DIFF
--- a/docs/specs/developments/20260428074150_pre-merge-setup-signal/2_pre-merge-setup-signal_implementation-plan.md
+++ b/docs/specs/developments/20260428074150_pre-merge-setup-signal/2_pre-merge-setup-signal_implementation-plan.md
@@ -25,8 +25,8 @@
 | `needs-setup` in protocol 91 | `grep -n "needs-setup" docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` | No matches — label not yet defined or referenced |
 | `needs-setup` in protocol 92 | `grep -n "needs-setup" docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md` | No matches — label not yet defined or referenced |
 | `Pre-merge Setup` section referenced anywhere | `grep -rn "Pre-merge Setup" docs/workflow/` | No matches — section pattern is new |
-| Existing smoke test runbooks in `docs/testing/workflow/` | `ls docs/testing/workflow/*.smoke-test.md \| wc -l` | 27 runbooks; no `367-pre-merge-setup-signal.smoke-test.md` yet |
-| Step 8a location in protocol 91 | `grep -n "Step 8a" docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` | Line 838 — "Step 8a: Label Readiness Checklist (Hard Gate)" |
+| Existing smoke test runbooks in `docs/testing/workflow/` | `ls docs/testing/workflow/*.smoke-test.md \| wc -l` | 28 runbooks; no `367-pre-merge-setup-signal.smoke-test.md` yet |
+| Step 8a location in protocol 91 | `grep -n "^## Step 8a" docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` | Line 948 — "Step 8a: Label Readiness Checklist (Hard Gate)" |
 | Labels section in protocol 92 | `grep -n "^## Labels" docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md` | Line 9 — "## Labels" table |
 
 ---

--- a/docs/specs/developments/20260428074150_pre-merge-setup-signal/2_pre-merge-setup-signal_implementation-plan.md
+++ b/docs/specs/developments/20260428074150_pre-merge-setup-signal/2_pre-merge-setup-signal_implementation-plan.md
@@ -82,7 +82,7 @@
 1. PR diff contains a new env var entry — `needs-setup` label applied and `## Pre-merge Setup` section populated (maps to AC-1, AC-2, AC-4)
 2. PR diff contains no infrastructure signals — `needs-setup` absent, no section in body (maps to AC-3)
 3. After a fixer push removes the env var from the diff — `needs-setup` removed and section cleared (maps to AC-5)
-4. Protocol 92 explicitly lists `needs-setup` with semantics and valid combinations (maps to AC-7, AC-8)
+4. Protocol 91 Step 8a documents `needs-setup` as a valid co-label with `ready-for-human-review` and does not treat its presence as an error (maps to AC-7); Protocol 92 explicitly lists `needs-setup` with semantics and valid combinations (maps to AC-8)
 5. Smoke test runbook covers all verification assertions (maps to AC-9)
 
 **Smoke test runbook**: `docs/testing/workflow/367-pre-merge-setup-signal.smoke-test.md`
@@ -145,7 +145,8 @@ Not applicable. All changes are prose additions to existing markdown protocol fi
    - TC-1: Verify `needs-setup` label is applied and `## Pre-merge Setup` section appears in the PR body when the diff contains a new env var reference (maps to AC-1, AC-2, AC-4).
    - TC-2: Verify `needs-setup` is absent and no section appears when the diff contains no infrastructure signals (maps to AC-3).
    - TC-3: Verify after a fixer push that removes the env var: `needs-setup` is removed and the section is cleared from the PR body (maps to AC-5).
-   - TC-4: Verify protocol 92 contains the `needs-setup` label definition, semantics, and valid combinations (maps to AC-7, AC-8).
+   - TC-4a: Verify protocol 91 Step 8a documents the infrastructure dependency scan, explicitly identifies `needs-setup` as a valid co-label with `ready-for-human-review`, and does not treat its presence as an error condition (maps to AC-7).
+   - TC-4b: Verify protocol 92 contains the `needs-setup` label definition, semantics, and valid combinations (maps to AC-8).
 
 6. **Run markdownlint-cli2** on the two updated protocol files and the new smoke test runbook before committing:
 

--- a/docs/specs/developments/20260428074150_pre-merge-setup-signal/2_pre-merge-setup-signal_implementation-plan.md
+++ b/docs/specs/developments/20260428074150_pre-merge-setup-signal/2_pre-merge-setup-signal_implementation-plan.md
@@ -1,0 +1,166 @@
+# Pre-merge Setup Signal — Implementation Plan
+
+**Spec**: [`1_pre-merge-setup-signal_specs.md`](1_pre-merge-setup-signal_specs.md)
+**Smoke test runbook**: [`../../../testing/workflow/367-pre-merge-setup-signal.smoke-test.md`](../../../testing/workflow/367-pre-merge-setup-signal.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add a lightweight `needs-setup` label and a standardised `## Pre-merge Setup` PR body section as a co-signal alongside `ready-for-human-review`. The implementation touches three areas: (1) the PR readiness signal protocol (`92-pr-readiness-signal-protocol.md`) to define the `needs-setup` label, its semantics, valid co-label combinations, and who removes it; (2) the orchestration protocol (`91-orchestrate-work-protocol.md`) at Step 8a to add a diff-scan step that detects infrastructure dependency signals and conditionally applies the label and section before `ready-for-human-review`; and (3) the smoke test runbook to cover detection on a setup PR and absence on a clean PR. No database, backend API, or frontend layer is involved — this is a pure workflow-protocol and documentation change.
+
+**Estimated complexity**: S
+
+**Rationale**: All changes are confined to two markdown protocol files and a new smoke test runbook. No code, scripts, or external services are modified. The detection heuristics are prose-level guidance for the agent performing the diff scan (not a compiled rule engine), so there is no parser-risk classification. The entire change is read, write, and label operations via `gh` CLI — well within the existing orchestration toolchain.
+
+**Dependencies**: None
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+|---|---|---|
+| Repo revision | `git rev-parse --short HEAD` | `b5b3937` |
+| `needs-setup` in protocol 91 | `grep -n "needs-setup" docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` | No matches — label not yet defined or referenced |
+| `needs-setup` in protocol 92 | `grep -n "needs-setup" docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md` | No matches — label not yet defined or referenced |
+| `Pre-merge Setup` section referenced anywhere | `grep -rn "Pre-merge Setup" docs/workflow/` | No matches — section pattern is new |
+| Existing smoke test runbooks in `docs/testing/workflow/` | `ls docs/testing/workflow/*.smoke-test.md \| wc -l` | 27 runbooks; no `367-pre-merge-setup-signal.smoke-test.md` yet |
+| Step 8a location in protocol 91 | `grep -n "Step 8a" docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` | Line 838 — "Step 8a: Label Readiness Checklist (Hard Gate)" |
+| Labels section in protocol 92 | `grep -n "^## Labels" docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md` | Line 9 — "## Labels" table |
+
+---
+
+## Layer-by-Layer Changes
+
+### Protocol / Documentation Layer
+
+- [ ] **`docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md` — Labels table**: Add a `needs-setup` row to the Labels table:
+  - Label: `needs-setup`
+  - Meaning: PR introduces one or more infrastructure dependencies (env vars, secrets, DNS records, service account tokens, etc.) that require human setup steps before the feature can be safely enabled. Co-exists with `ready-for-human-review`; the human removes this label after completing setup.
+
+- [ ] **`docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md` — `needs-setup` semantics section**: Add a dedicated section after the Labels table defining:
+  - The valid label combinations (see spec Statuses section): `ready-for-human-review` only; `ready-for-human-review` + `needs-setup`; `needs-fixes` + `needs-setup` (transitional state).
+  - Who applies `needs-setup`: the agent, as part of Step 8a, after a diff scan detects infrastructure dependency signals.
+  - Who removes `needs-setup`: the human, after completing the listed setup steps (or intentionally deferring).
+  - Invariant (BR-1): `needs-setup` must always be accompanied by a `## Pre-merge Setup` section in the PR body. The label without the section is an incomplete signal.
+  - Invariant (BR-2): The `## Pre-merge Setup` section must not appear in the PR body without the `needs-setup` label present at that time. After the human removes the label, the section remains as a historical record (BR-7).
+  - Invariant (BR-3): `needs-setup` does not prevent `ready-for-human-review` from being applied, does not block CI, and does not block automated review tools from completing.
+  - Invariant (BR-10): `needs-setup` is distinct from `needs-fixes` — different semantics, different lifecycle, may co-exist.
+
+- [ ] **`docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` — Step 8a diff-scan step**: Insert a new sub-step into Step 8a (Label Readiness Checklist) to run the infrastructure dependency scan **after** CI is green and reviews are clean but **before** applying `ready-for-human-review`. The sub-step must:
+  1. Read the PR diff via `gh pr diff <pr_number>`.
+  2. Scan the diff for infrastructure dependency signals using the detection heuristics defined below (see Infrastructure Dependency Detection Heuristics subsection).
+  3. If one or more signals are found:
+     a. Construct a `## Pre-merge Setup` section in the PR body listing each detected requirement with: requirement name, type (env var / GitHub Actions secret / DNS record / etc.), plain-language description of the expected value, and where to set it (BR-8).
+     b. Edit the PR body to include this section: `gh pr edit <pr_number> --body "<updated-body>"`. The section is appended to the existing PR body.
+     c. Apply the `needs-setup` label: `gh pr edit <pr_number> --add-label "needs-setup"`.
+  4. If no signals are found: ensure no `needs-setup` label is present and no `## Pre-merge Setup` section exists in the PR body.
+  5. This scan runs on every pass through Step 8a (including after fixer pushes), so the label and section always reflect the current diff (AC-5, AC-6, BR-6).
+  6. After the scan: proceed to apply `ready-for-human-review` as normal. The presence of `needs-setup` does not block this step (BR-3, BR-4).
+
+- [ ] **`docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` — Step 8a: infrastructure dependency detection heuristics subsection**: Add a prose subsection named "Infrastructure Dependency Detection Heuristics" inside Step 8a. The heuristics are best-effort and intentionally incomplete (BR-9). The developer agent must look for the following patterns in the PR diff (added lines, i.e., lines starting with `+` in the diff output):
+  - **New environment variable references**: lines matching patterns like `process.env.NEW_VAR`, `os.environ["NEW_VAR"]`, `$NEW_VAR` (in shell), or entries added to `.env.example`, `.env.template`, or similar env template files.
+  - **New GitHub Actions secret references**: added lines in `.github/workflows/**` files that reference `${{ secrets.NEW_SECRET }}`.
+  - **New config key additions to environment-specific config files**: added keys in files named `*.env`, `.env.*`, `config/production.*`, or similar deployment-configuration files.
+  - **Explicit "TODO: set secret/env" comments added in the diff**: comments in the diff containing phrases like `# TODO: set`, `# Set this to`, `# Required: configure`, or similar that indicate a value must be externally provided.
+  - The heuristics are advisory. False negatives (missed dependencies) are acceptable (BR-9). False positives should be handled gracefully: the section informs the human, who decides whether setup is actually required.
+  - Each detected signal produces one row in the `## Pre-merge Setup` section.
+
+- [ ] **`docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` — Step 8a checklist update**: Add a note to the Step 8a checklist that `needs-setup` is a valid co-label with `ready-for-human-review` and must not be treated as an error condition that blocks readiness. The checklist script does not need to check for or remove `needs-setup` — it is not stale at this point; it is a deliberate signal.
+
+- [ ] **`docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` — Step 8c independent verification table**: Add a row to the verification table noting that the presence of `needs-setup` is valid and expected when infrastructure dependencies are detected, and that its presence does not constitute a verification failure.
+
+---
+
+## Testing Strategy
+
+**Test types**: Manual / Smoke
+
+**Key scenarios to test**:
+
+1. PR diff contains a new env var entry — `needs-setup` label applied and `## Pre-merge Setup` section populated (maps to AC-1, AC-2, AC-4)
+2. PR diff contains no infrastructure signals — `needs-setup` absent, no section in body (maps to AC-3)
+3. After a fixer push removes the env var from the diff — `needs-setup` removed and section cleared (maps to AC-5)
+4. Protocol 92 explicitly lists `needs-setup` with semantics and valid combinations (maps to AC-7, AC-8)
+5. Smoke test runbook covers all verification assertions (maps to AC-9)
+
+**Smoke test runbook**: `docs/testing/workflow/367-pre-merge-setup-signal.smoke-test.md`
+
+**Regression suite**: None in this repository.
+
+---
+
+## Seed Data
+
+Not applicable — this feature has no database or application-level seed data requirements. The smoke test exercises the feature by inspecting PR labels and body text on a GitHub pull request.
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` — updated as part of this implementation (Step 8a diff-scan step, heuristics subsection, Step 8c table row). This is an in-scope change, not a follow-up.
+- [ ] `docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md` — updated as part of this implementation (Labels table, `needs-setup` semantics section). This is an in-scope change, not a follow-up.
+
+No other project docs in `docs/project/`, `docs/best-practices/`, or `AGENTS.md` require updates. This feature adds a workflow-level signal mechanism; it does not change domain entities, repo architecture, software architecture, the database model, general coding standards, version control conventions, or testing standards.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Diff-scan heuristics produce false positives on spec/plan PRs (which touch markdown, not code) | Low | Low | Detection heuristics target code-level patterns (env references in source files, secrets in workflow YAML). Markdown-only diffs will not match these patterns. No mitigation required beyond heuristic design. |
+| PR body edit (`gh pr edit --body`) overwrites an existing custom body | Low | Low | Read the existing PR body first, append the section, then write the full updated body. Implementation note in Step 8a makes this explicit. |
+| `needs-setup` label does not exist in the GitHub repo's label set | Low | Medium | Document in the smoke test that the label must be created in the repo's label settings before first use. The developer implementing this step should also add a note in the heuristics subsection. |
+| Human forgets to remove `needs-setup` before merge | Low | Low | The label is a signal only (BR-3); it does not block merge. The human's responsibility is documented in the spec (Use Case 3) and in protocol 92. |
+
+---
+
+## Code Samples
+
+Not applicable. All changes are prose additions to existing markdown protocol files. No scripts, code, or structured data files are introduced.
+
+---
+
+## Implementation Order
+
+1. **Create the `needs-setup` GitHub label** in the repository's label settings (if it does not already exist). Suggested color: `#fbca04` (yellow, to indicate a prerequisite action without implying a blocking failure). This step is a one-time repo setup action, not a code change.
+
+2. **Update `docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md`**:
+   - Add `needs-setup` row to the Labels table (after the existing `ready-for-regression` row).
+   - Add a new `## Conditions for needs-setup` section (parallel to the existing `## Conditions for ready-for-human-review` and `## Conditions for needs-fixes` sections) defining: who applies it (agent at Step 8a after diff scan), who removes it (human after setup), valid co-label combinations, and the BR-1/BR-2/BR-3/BR-10 invariants.
+   - Verify the section placement is logical and consistent with the surrounding content.
+
+3. **Update `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` — Step 8a**:
+   - Locate the Step 8a section (Label Readiness Checklist).
+   - Before the existing checklist script block (Check 1–4), insert a new prose block titled "**Infrastructure Dependency Scan (pre-readiness)**" that describes the diff-scan process and heuristics (as defined in Layer-by-Layer Changes above).
+   - After the scan prose, update the existing checklist commentary to note that `needs-setup` is a valid co-label with `ready-for-human-review` and is not removed by the checklist script.
+
+4. **Update `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` — Step 8c**:
+   - Locate the verification table in Step 8c.
+   - Add a note (either as a new row or as a footnote to the existing `No needs-fixes label` row) clarifying that `needs-setup` may be present alongside `ready-for-human-review` and does not constitute a verification failure.
+
+5. **Write the smoke test runbook** at `docs/testing/workflow/367-pre-merge-setup-signal.smoke-test.md` covering:
+   - TC-1: Verify `needs-setup` label is applied and `## Pre-merge Setup` section appears in the PR body when the diff contains a new env var reference (maps to AC-1, AC-2, AC-4).
+   - TC-2: Verify `needs-setup` is absent and no section appears when the diff contains no infrastructure signals (maps to AC-3).
+   - TC-3: Verify after a fixer push that removes the env var: `needs-setup` is removed and the section is cleared from the PR body (maps to AC-5).
+   - TC-4: Verify protocol 92 contains the `needs-setup` label definition, semantics, and valid combinations (maps to AC-7, AC-8).
+
+6. **Run markdownlint-cli2** on the two updated protocol files and the new smoke test runbook before committing:
+
+   ```bash
+   REPO_ROOT=$(git rev-parse --git-common-dir)/..
+   "$REPO_ROOT/node_modules/.bin/markdownlint-cli2" \
+     "docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md" \
+     "docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md" \
+     "docs/testing/workflow/367-pre-merge-setup-signal.smoke-test.md"
+   ```
+
+   Fix any trailing-whitespace, broken-link, or missing-trailing-newline violations before proceeding.
+
+7. **Update `CHANGELOG.md`** under `[Unreleased]` with:
+
+   ```
+   - **Add pre-merge setup signal for PRs requiring human configuration** (#367): Adds a `needs-setup` label and a standardised `## Pre-merge Setup` PR body section so agents surface infrastructure dependencies (env vars, secrets, DNS records) at PR readiness time rather than requiring the human to read the diff. Protocol 91 Step 8a now includes a diff-scan heuristic step; protocol 92 defines the label semantics and valid co-label combinations.
+   ```

--- a/docs/testing/workflow/367-pre-merge-setup-signal.smoke-test.md
+++ b/docs/testing/workflow/367-pre-merge-setup-signal.smoke-test.md
@@ -129,9 +129,24 @@ Using the same PR from TC-1 (or a similar setup), push a fix commit that removes
 
 ---
 
-### Step 5 (TC-4): Protocol 92 documents `needs-setup` with correct semantics
+### Step 5a (TC-4a): Protocol 91 Step 8a documents `needs-setup` as a valid co-label
 
-**Maps to**: AC-7, AC-8
+**Maps to**: AC-7
+
+1. Open `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`.
+2. Locate the Step 8a section (Label Readiness Checklist).
+3. Confirm there is an "Infrastructure Dependency Scan (pre-readiness)" sub-step or equivalent prose block within Step 8a that describes the diff-scan process.
+4. Confirm the Step 8a section explicitly states that `needs-setup` is a valid co-label with `ready-for-human-review` and must not be treated as an error condition that blocks readiness.
+5. Confirm the checklist script (Check 1–4 or equivalent) does not attempt to remove the `needs-setup` label — the plan notes it is a deliberate signal, not a stale label.
+6. Confirm the Step 8c verification table contains a note that `needs-setup` may co-exist with `ready-for-human-review` without constituting a verification failure.
+
+**Expected result**: Protocol 91 Step 8a clearly documents the infrastructure dependency scan step and explicitly identifies `needs-setup` as a valid co-label that does not block `ready-for-human-review`.
+
+---
+
+### Step 5b (TC-4b): Protocol 92 documents `needs-setup` with correct semantics
+
+**Maps to**: AC-8
 
 1. Open `docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md`.
 2. Confirm the Labels table contains a `needs-setup` row with a clear description of the label's meaning.

--- a/docs/testing/workflow/367-pre-merge-setup-signal.smoke-test.md
+++ b/docs/testing/workflow/367-pre-merge-setup-signal.smoke-test.md
@@ -1,0 +1,189 @@
+# Smoke Test Runbook: Pre-merge Setup Signal
+
+**Feature**: Pre-merge Setup Signal (#367)
+**Spec**: [`docs/specs/developments/20260428074150_pre-merge-setup-signal/1_pre-merge-setup-signal_specs.md`](../../specs/developments/20260428074150_pre-merge-setup-signal/1_pre-merge-setup-signal_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] The `needs-setup` GitHub label exists in the repository's label settings (created as part of Step 1 of the implementation)
+- [ ] You have `gh` CLI authenticated against the repository
+- [ ] You have a test PR available (or can create a minimal one) that includes a diff with a new environment variable reference (e.g., a change that adds a line like `process.env.MY_NEW_API_KEY` to a source file, or a new entry in `.env.example`)
+- [ ] You have a second test PR (or the same PR after a fixer push) that has a diff with no infrastructure dependency signals
+
+---
+
+## Test Data
+
+| Item | Value |
+|---|---|
+| Test repo | The current repository (`ai-dev-framework-template` or the downstream project under test) |
+| PR with env var in diff | A PR whose diff adds a new environment variable reference (see Prerequisites) |
+| PR without infrastructure signals | A PR whose diff contains only documentation or logic changes |
+| `needs-setup` label | Must exist in repo label settings before running TC-1 |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify `needs-setup` label exists in the repository
+
+1. Open the repository on GitHub.
+2. Navigate to **Issues** → **Labels**.
+3. Confirm that a label named `needs-setup` is present.
+
+**Expected result**: The `needs-setup` label exists with an appropriate description (e.g., "PR introduces setup steps required before the feature can be enabled").
+
+---
+
+### Step 2 (TC-1): Agent applies `needs-setup` when diff contains infrastructure signals
+
+**Maps to**: AC-1, AC-2, AC-4
+
+Simulate or observe the agent running Step 8a on a PR whose diff contains a new environment variable reference:
+
+1. Identify or create a PR whose diff includes an added line that matches a detection heuristic (e.g., `+MY_NEW_SECRET=` in `.env.example`, or `+process.env.NEW_API_KEY` in source code, or `+${{ secrets.NEW_SECRET }}` in a GitHub Actions workflow file).
+2. Manually trigger (or observe the agent trigger) the infrastructure dependency scan step at Step 8a of protocol 91.
+3. After the scan completes, run:
+
+   ```bash
+   gh pr view <pr_number> --json labels --jq '.labels[].name'
+   ```
+
+4. Confirm `needs-setup` is present in the output.
+5. Run:
+
+   ```bash
+   gh pr view <pr_number> --json body --jq '.body'
+   ```
+
+6. Confirm the PR body contains a `## Pre-merge Setup` section.
+7. Confirm the section lists the detected requirement with: requirement name, type, plain-language description of the expected value, and where to set it.
+8. Confirm `ready-for-human-review` is also present (the two labels co-exist):
+
+   ```bash
+   gh pr view <pr_number> --json labels --jq '.labels[].name'
+   ```
+
+**Expected result**: Both `needs-setup` and `ready-for-human-review` labels are present. The PR body contains a `## Pre-merge Setup` section with at least one row for the detected requirement. CI and automated reviews are not blocked by the presence of `needs-setup`.
+
+---
+
+### Step 3 (TC-2): Agent does not apply `needs-setup` when diff has no infrastructure signals
+
+**Maps to**: AC-3
+
+Observe or simulate the agent running Step 8a on a PR whose diff contains only documentation or logic changes (no new env var references, no new secret references, no new config keys):
+
+1. Identify a PR whose diff adds only markdown prose, comments, or application logic with no infrastructure dependency patterns.
+2. Trigger (or observe) the Step 8a scan.
+3. Run:
+
+   ```bash
+   gh pr view <pr_number> --json labels --jq '.labels[].name'
+   ```
+
+4. Confirm `needs-setup` is **absent** from the output.
+5. Run:
+
+   ```bash
+   gh pr view <pr_number> --json body --jq '.body'
+   ```
+
+6. Confirm the PR body does **not** contain a `## Pre-merge Setup` section.
+
+**Expected result**: `needs-setup` is absent. No `## Pre-merge Setup` section appears in the PR body. `ready-for-human-review` is applied as normal.
+
+---
+
+### Step 4 (TC-3): Agent removes `needs-setup` when a fixer push removes the infrastructure signal
+
+**Maps to**: AC-5
+
+Using the same PR from TC-1 (or a similar setup), push a fix commit that removes the infrastructure dependency signal from the diff:
+
+1. Starting from a PR that has `needs-setup` applied (from TC-1).
+2. Push a commit that removes the env var reference from the diff (e.g., replace `process.env.NEW_API_KEY` with a hardcoded default or remove it entirely).
+3. The agent re-runs automated review and CI loops, then re-runs Step 8a (including the diff scan).
+4. After the re-scan, run:
+
+   ```bash
+   gh pr view <pr_number> --json labels --jq '.labels[].name'
+   ```
+
+5. Confirm `needs-setup` is now **absent**.
+6. Run:
+
+   ```bash
+   gh pr view <pr_number> --json body --jq '.body'
+   ```
+
+7. Confirm the `## Pre-merge Setup` section has been **removed** from the PR body.
+
+**Expected result**: After the fixer push that eliminates the infrastructure signal, both the `needs-setup` label and the `## Pre-merge Setup` section are removed. The PR body and labels reflect the current diff, not the prior state.
+
+---
+
+### Step 5 (TC-4): Protocol 92 documents `needs-setup` with correct semantics
+
+**Maps to**: AC-7, AC-8
+
+1. Open `docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md`.
+2. Confirm the Labels table contains a `needs-setup` row with a clear description of the label's meaning.
+3. Confirm there is a section defining the conditions under which `needs-setup` is applied.
+4. Confirm the section lists the valid label combinations:
+   - `ready-for-human-review` only (clean path)
+   - `ready-for-human-review` + `needs-setup` (setup required)
+   - `needs-fixes` + `needs-setup` (transitional — both conditions apply)
+5. Confirm the section documents who applies `needs-setup` (the agent at Step 8a) and who removes it (the human after setup).
+6. Confirm the BR-3 invariant is documented: `needs-setup` does not prevent `ready-for-human-review` from being applied and does not block CI.
+
+**Expected result**: Protocol 92 clearly defines the `needs-setup` label, its valid combinations, the actor responsible for each transition, and the invariant that it co-exists with `ready-for-human-review`.
+
+---
+
+### Last Step: Validate all assertions
+
+- [ ] All checkboxes in the Assertions Checklist below are satisfied
+- [ ] No CI or automated review was blocked by the presence of `needs-setup`
+
+---
+
+## Assertions Checklist
+
+- [ ] AC-1: `needs-setup` label is applied when the diff contains one or more infrastructure dependency signals (env var, secret, config key)
+- [ ] AC-2: The `## Pre-merge Setup` section in the PR body lists each detected requirement with: name, type, description of the expected value, and where to set it
+- [ ] AC-3: `needs-setup` is absent and no `## Pre-merge Setup` section appears when the diff has no infrastructure signals
+- [ ] AC-4: `needs-setup` is applied alongside `ready-for-human-review` — not instead of it
+- [ ] AC-5: After a fixer push removes the infrastructure signal from the diff, both `needs-setup` and the `## Pre-merge Setup` section are removed
+- [ ] AC-7: Protocol 91 Step 8a documents `needs-setup` as a valid co-label with `ready-for-human-review` and does not treat its presence as an error
+- [ ] AC-8: Protocol 92 defines `needs-setup` with: semantics, valid combinations, and who removes it
+
+---
+
+## Seed Data Reference
+
+Not applicable — this feature has no database seed data requirements. The smoke test operates on GitHub PRs and protocol documentation files only.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `needs-setup` label cannot be applied (error from `gh pr edit`) | Label does not exist in the repository's label settings | Create the `needs-setup` label in **Issues → Labels** in the GitHub repository UI, then retry |
+| `## Pre-merge Setup` section not appearing in PR body | The diff-scan heuristic did not match the pattern used in the test PR | Verify the diff contains a pattern explicitly listed in the detection heuristics (e.g., `+NEW_VAR=` in `.env.example`, or `+${{ secrets.SECRET_NAME }}` in a workflow file). Check the protocol 91 heuristics subsection for the exact patterns. |
+| `needs-setup` not removed after fixer push | The fixer commit did not remove all lines matching the detection heuristics | Inspect the PR diff after the fixer push (`gh pr diff <pr_number>`) and confirm no added lines match any heuristic pattern |
+| Both `needs-setup` and `needs-fixes` are on the PR simultaneously | Expected transitional state — both conditions apply | No fix needed; the spec explicitly allows this combination. Address `needs-fixes` first (code changes), then the `needs-setup` scan will re-run during the next Step 8a pass |
+
+---
+
+## Known Limitations
+
+- The detection heuristics are best-effort (BR-9). False negatives (missed dependencies) are accepted by design — the agent may not detect all infrastructure requirements, especially when they are introduced indirectly (e.g., a new npm dependency that internally requires an env var). Human judgment is the final authority on whether all setup is complete.
+- AC-6 (new signals introduced by a fixer push are added to the section) is not explicitly covered by a TC step in this runbook because it requires an artificial scenario where a fixer push introduces a new infrastructure signal. This scenario is considered a variant of TC-1 and is assumed to work correctly given the same code path is exercised.


### PR DESCRIPTION
## Summary

Implementation plan and smoke test runbook for #367: Add pre-merge setup signal for PRs that require human configuration.

**Approach**: Pure workflow-protocol and documentation change. No database, backend, frontend, or script layers are modified.

- `docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md` — add `needs-setup` label definition, semantics, valid co-label combinations, and lifecycle (who applies, who removes)
- `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` — add an infrastructure dependency diff-scan sub-step at Step 8a and a note in Step 8c that `needs-setup` is a valid co-label

**Complexity**: S (small) — all changes are prose additions to two existing markdown protocol files plus a new smoke test runbook.

**Key risks**: Minimal. No executable code is introduced; detection heuristics are prose-level guidance. The `needs-setup` label must be created in the repo's GitHub label settings before first use (documented in implementation Step 1).

**Links**:
- Spec: `docs/specs/developments/20260428074150_pre-merge-setup-signal/1_pre-merge-setup-signal_specs.md`
- Plan: `docs/specs/developments/20260428074150_pre-merge-setup-signal/2_pre-merge-setup-signal_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/367-pre-merge-setup-signal.smoke-test.md`