### PR TITLE
fix(release): correct CHANGELOG section ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,28 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.23.2] - 2026-04-27
-
-### Fixed
-
-- **`shift 2` without guarding `$2` in `add-backlog-item.sh`**: Option parsing for `--title`, `--body`, `--body-file`, and `--label` called `shift 2` even when no value argument followed, which aborts the script under `set -e`. Fixed by validating `$# -lt 2` before each shift and emitting a clear error message.
-
-- **`local IFS=','` leaking across function scope in `batch-merge.sh`**: Setting `local IFS=','` inside the explicit-PR parsing block left IFS altered for all subsequent code in the same function. Replaced with `IFS=',' read -r -a _pr_tokens <<< "$explicit_prs"` (IFS scoped to the read command only) and declared the array with `local -a` to prevent it from escaping the function.
-
-- **Branch name used as unescaped grep regex in `post-merge-cleanup.sh`**: The worktree lookup used `grep -B2 "branch refs/heads/$TO_DELETE$"`, interpreting the branch name as a regex pattern. Branch names containing `.`, `+`, or other metacharacters could produce false matches, and `grep -F` without a line-boundary check would additionally match branch names that are a prefix of another checked-out branch. Replaced the grep pipeline with an `awk` exact-string comparison (`$0 == branch`) against the structured porcelain output, eliminating both the regex-injection risk and the prefix-match false positive.
-
-## [0.23.1] - 2026-04-26
-
-### Fixed
-
-- **Bot login format mismatch in GraphQL thread audit** (`pr-review-loop.sh`):
-  `bot_login_for_platform()` passed `[bot]`-suffixed bot logins to `check_unresolved_threads`,
-  but the GitHub GraphQL API returns `author.login` without the suffix for bot-authored comments.
-  The string comparison always failed, causing the unresolved thread gate to report zero unresolved
-  threads even when unresolved bot threads existed. Fixed by removing the `[bot]` suffix from
-  `bot_login_for_platform()` return values to match the GraphQL API contract. Updated documentation
-  and smoke test to reflect that GraphQL returns bare bot login strings.
-
 ## [Unreleased]
 
 ## [0.24.0] - 2026-04-29
@@ -102,6 +80,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cross-cutting checklist file enumeration** (#389): plans must list all affected agent/skill files.
 - **Fixer batching rule** (#372): all fixes applied and pushed once per dispatch cycle.
 - **`.worktrees/` gitignored**: both worktree path conventions now excluded.
+
+## [0.23.2] - 2026-04-27
+
+### Fixed
+
+- **`shift 2` without guarding `$2` in `add-backlog-item.sh`**: Option parsing for `--title`, `--body`, `--body-file`, and `--label` called `shift 2` even when no value argument followed, which aborts the script under `set -e`. Fixed by validating `$# -lt 2` before each shift and emitting a clear error message.
+
+- **`local IFS=','` leaking across function scope in `batch-merge.sh`**: Setting `local IFS=','` inside the explicit-PR parsing block left IFS altered for all subsequent code in the same function. Replaced with `IFS=',' read -r -a _pr_tokens <<< "$explicit_prs"` (IFS scoped to the read command only) and declared the array with `local -a` to prevent it from escaping the function.
+
+- **Branch name used as unescaped grep regex in `post-merge-cleanup.sh`**: The worktree lookup used `grep -B2 "branch refs/heads/$TO_DELETE$"`, interpreting the branch name as a regex pattern. Branch names containing `.`, `+`, or other metacharacters could produce false matches, and `grep -F` without a line-boundary check would additionally match branch names that are a prefix of another checked-out branch. Replaced the grep pipeline with an `awk` exact-string comparison (`$0 == branch`) against the structured porcelain output, eliminating both the regex-injection risk and the prefix-match false positive.
+
+## [0.23.1] - 2026-04-26
+
+### Fixed
+
+- **Bot login format mismatch in GraphQL thread audit** (`pr-review-loop.sh`):
+  `bot_login_for_platform()` passed `[bot]`-suffixed bot logins to `check_unresolved_threads`,
+  but the GitHub GraphQL API returns `author.login` without the suffix for bot-authored comments.
+  The string comparison always failed, causing the unresolved thread gate to report zero unresolved
+  threads even when unresolved bot threads existed. Fixed by removing the `[bot]` suffix from
+  `bot_login_for_platform()` return values to match the GraphQL API contract. Updated documentation
+  and smoke test to reflect that GraphQL returns bare bot login strings.
 
 ## [0.23.0] - 2026-04-25
 


### PR DESCRIPTION
## Summary

- Moves `[Unreleased]` and `[0.24.0]` sections to the top of CHANGELOG.md
- Restores correct reverse-chronological ordering per Keep a Changelog convention
- The hotfix versions `[0.23.2]` and `[0.23.1]` now appear after `[0.24.0]` as expected

**Before:** `[0.23.2]` → `[0.23.1]` → `[Unreleased]` → `[0.24.0]` → `[0.23.0]`
**After:** `[Unreleased]` → `[0.24.0]` → `[0.23.2]` → `[0.23.1]` → `[0.23.0]`

## Test plan

- [ ] Verify section ordering is correct
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized changelog entries for improved readability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->