### PR TITLE
fix(protocol-05): add merge strategy guidance for release PRs

### DIFF
--- a/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
+++ b/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
@@ -180,6 +180,8 @@ When the production PR is ready (or clearly escalated):
 2. Then merge the `develop` backport PR
 3. Run Step 9 post-merge cleanup only after both PRs are merged
 
+> **Use regular merge commits — not squash or rebase.** Squash-merging release PRs breaks the gitflow history chain: `main` won't share commit ancestors with `develop`, causing future comparisons to show accumulated historical divergence instead of just new changes. Regular merge commits preserve the relationship so `git log main..develop` accurately reflects pending work.
+
 If Step 7 escalated or CI timed out, report status and blockers before merge.
 
 ---


### PR DESCRIPTION
## Summary

Adds explicit guidance to Step 8 of the prepare-release protocol requiring **regular merge commits** (not squash or rebase) for release PRs.

**Why:** Squash-merging release PRs breaks the gitflow history chain — `main` won't share commit ancestors with `develop`, causing future `develop → main` comparisons to show accumulated historical divergence instead of just new changes.

## Test plan

- [ ] Guidance is clear and visible in Step 8
- [ ] Explains the consequence of squash-merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
