### PR TITLE
fix(fixer-agent): add all-occurrences rule for literal value fixes (#426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fixer agents must fix all occurrences of flagged literal values** (#426): added mandatory all-occurrences rule to Protocol 93 fix-cycle guidance — when a reviewer flags a literal value (numeric constant, hex value, identifier, repeated string), fixer agents must `grep -n` the old value across all affected files and fix every occurrence in the same commit before pushing.
+
 ### Changed
 
 - **Exit code contract table in Protocol 91 Step 8a** (#433): added a prominent table documenting exit codes 0–4 at the top of the Label Readiness Checklist to prevent future exit code collisions

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -205,6 +205,36 @@ grep -n "<old-term>" <file>  # verify no stale references remain
 
 After committing, apply the re-read verification described in [Verification: Re-read to confirm each fix](#verification-re-read-to-confirm-each-fix) above before marking the finding as resolved.
 
+### All-occurrences rule for literal value fixes (mandatory)
+
+When a reviewer flags a specific literal value — a numeric constant, hex value, identifier string, repeated phrase, or any other repeated literal — the fixer agent **must** fix every occurrence of that value across all affected files in the PR, not only the specific line flagged by the reviewer. Fixing one occurrence while leaving identical values elsewhere forces multiple unnecessary review passes and is a protocol violation.
+
+**Required sequence before committing any literal-value fix:**
+
+1. **Search the entire document** for all occurrences of the old value:
+
+   ```bash
+   grep -n "<old_value>" <file>
+   ```
+
+2. **Search all other files affected by the PR** for the same value:
+
+   ```bash
+   # For each file changed in this PR:
+   git diff --name-only HEAD~1 HEAD | xargs grep -ln "<old_value>"
+   ```
+
+3. **Fix every occurrence** in the same commit — do not leave any behind.
+
+4. **Verify with grep** on all affected files to confirm no occurrences remain before pushing:
+
+   ```bash
+   grep -rn "<old_value>" <all-affected-files>
+   # Expected: no output (zero occurrences)
+   ```
+
+This rule applies to any value type: version numbers, timeout values, port numbers, hex color codes, string constants, label names, section headers, or any other repeated literal. If a reviewer flags one instance, treat it as a signal to fix all instances — the reviewer will check all occurrences on the next cycle and finding any remaining instance resets the review loop.
+
 ### PR feedback tracking and comments
 
 Follow the "PR feedback tracking and comments" subsection of Step 7 in `91-orchestrate-work-protocol.md`:


### PR DESCRIPTION
## Summary

Closes #426

During automated review fix cycles, fixer agents corrected only the specific line flagged by a reviewer, leaving identical literal values elsewhere in the same document. This caused multiple unnecessary review passes.

### Changes

- **`docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`**: Added a mandatory "All-occurrences rule for literal value fixes" section to the fix-cycle guidance. The new rule instructs fixer agents that when fixing a literal value (numeric constant, hex value, identifier string, or any repeated literal), they must:
  1. Search the entire document for all occurrences of the old value using `grep -n`
  2. Search all other PR-affected files for the same value using `git diff --name-only | xargs grep`
  3. Fix every occurrence in the same commit — none left behind
  4. Verify with `grep -rn` on all affected files before pushing to confirm zero occurrences remain

## Test plan

- [ ] Verify the new "All-occurrences rule for literal value fixes" section appears in Protocol 93 after the existing "After fixing findings: cross-reference check" section
- [ ] Confirm the section is clearly marked as mandatory and provides actionable `grep` commands
- [ ] Verify markdownlint passes on the modified file
- [ ] Verify CHANGELOG.md has a new entry under `[Unreleased] ### Fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)