### PR TITLE
feat(#453): add custom_fields support for issue tracker config

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -110,6 +110,18 @@ issue_tracker:
   # Required for tracker status updates (update_tracker_status_best_effort) and status reads
   # (get_tracker_status_for_issue) to function without setting an environment variable.
   project_number: 1
+  # custom_fields: flat key-value map of provider-specific fields.
+  # Each integration doc defines which keys are recognised and their effect.
+  # Unrecognised keys are silently ignored by scripts that do not consume them.
+  # Read individual values with: workflow_issue_tracker_custom_field <key>
+  # (defined in scripts/development-workflow/workflow-lib.sh)
+  #
+  # Example (Linear):
+  #   custom_fields:
+  #     project: my-linear-project-id
+  #
+  # custom_fields:
+  #   project: ""
 
 vcs:
   # Supported examples: github, gitlab, bitbucket, other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Add `custom_fields` support for issue tracker config** (#453): Adds a `custom_fields` flat map under `issue_tracker` in `.ai-dev-workflow.yaml` and a `workflow_issue_tracker_custom_field` helper function in `workflow-lib.sh` to read individual custom field values. Updates Linear and GitHub Projects integration docs to document recognised fields.
+
 ### Changed
 
 - **Exit code contract table in Protocol 91 Step 8a** (#433): added a prominent table documenting exit codes 0–4 at the top of the Label Readiness Checklist to prevent future exit code collisions

--- a/docs/workflow/development-workflow/integrations/github-projects.md
+++ b/docs/workflow/development-workflow/integrations/github-projects.md
@@ -305,6 +305,20 @@ Use explicit issue numbers to avoid accidental broad transitions. Items not incl
 
 ---
 
+## Custom Fields
+
+The `issue_tracker.custom_fields` flat map in `.ai-dev-workflow.yaml` is available for provider-specific configuration extensions. For the `github_projects` provider, **no `custom_fields` keys are currently recognised by workflow scripts**.
+
+Key points:
+
+- The `project_number` field is a standard top-level `issue_tracker` field — it is not a custom field and must remain under `issue_tracker` directly, not under `custom_fields`.
+- Any keys placed under `custom_fields` are silently ignored by all current GitHub Projects scripts.
+- Future provider-specific fields (e.g., additional project metadata) may be added here as the integration evolves.
+
+Read the `workflow_issue_tracker_custom_field` helper documentation in `scripts/development-workflow/workflow-lib.sh` for the parsing API available to future consumers.
+
+---
+
 ## Without GitHub Projects
 
 If you don't use GitHub Projects, the **Portfolio Orchestrator** asks the human:

--- a/docs/workflow/development-workflow/integrations/linear.md
+++ b/docs/workflow/development-workflow/integrations/linear.md
@@ -94,6 +94,36 @@ The `[slug]` is a short kebab-case description derived from the work item title 
 
 ---
 
+## Custom Fields
+
+The `issue_tracker.custom_fields` flat map in `.ai-dev-workflow.yaml` holds provider-specific fields that extend the standard `issue_tracker` configuration. For the Linear provider, the following key is recognised by workflow scripts:
+
+| Key | Format | Effect |
+|---|---|---|
+| `project` | Linear project ID string | When set, issue creation associates the new issue with the specified Linear project. The project ID is found in the Linear project URL (`https://linear.app/<team>/projects/<project-id>`) or via the Linear API. |
+
+When `project` is absent from `custom_fields` (or `custom_fields` itself is absent), issue creation proceeds without a project association — this is the current default behaviour and is fully backward-compatible.
+
+To set a project association, add the following to `.ai-dev-workflow.yaml` under `issue_tracker`:
+
+```yaml
+issue_tracker:
+  provider: linear
+  custom_fields:
+    project: my-linear-project-id
+```
+
+Read the value in a script using the `workflow_issue_tracker_custom_field` helper:
+
+```bash
+source scripts/development-workflow/workflow-lib.sh
+project_id=$(workflow_issue_tracker_custom_field project)
+```
+
+Unrecognised keys in `custom_fields` are silently ignored by all current scripts.
+
+---
+
 ## Workflow: Advancing Statuses
 
 The **Portfolio Orchestrator**, **Work Item Runner**, or stage agent updates the Linear work item status at each stage transition:

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -253,6 +253,62 @@ workflow_issue_tracker_project_number() {
   workflow_config_field issue_tracker project_number
 }
 
+# workflow_issue_tracker_custom_field <key> [config_file]
+#
+# Reads issue_tracker.custom_fields.<key> from .ai-dev-workflow.yaml.
+# Prints the value, or empty string when:
+#   - The config file is absent
+#   - The custom_fields subsection is absent
+#   - The key is absent within custom_fields
+# Returns 0 in all cases (non-blocking).
+workflow_issue_tracker_custom_field() {
+  local key="$1"
+  local config_file="${2:-$(workflow_config_file)}"
+
+  [ -f "$config_file" ] || return 0
+
+  awk -v key="$key" '
+    function trim(value) {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      gsub(/^["'"'"']|["'"'"']$/, "", value)
+      return value
+    }
+
+    /^issue_tracker:[[:space:]]*(#.*)?$/ {
+      in_section = 1
+      in_custom = 0
+      next
+    }
+
+    in_section && /^[^[:space:]#]/ {
+      in_section = 0
+      in_custom = 0
+    }
+
+    in_section && /^[[:space:]][[:space:]]custom_fields:[[:space:]]*(#.*)?$/ {
+      in_custom = 1
+      next
+    }
+
+    in_section && in_custom && /^[[:space:]][[:space:]][A-Za-z0-9_-]/ {
+      if ($0 !~ /^[[:space:]][[:space:]][[:space:]][[:space:]]/) {
+        in_custom = 0
+      }
+    }
+
+    in_section && in_custom && /^[[:space:]][[:space:]][[:space:]][[:space:]]/ {
+      pattern = "^[[:space:]][[:space:]][[:space:]][[:space:]]" key ":[[:space:]]*"
+      if ($0 ~ pattern) {
+        line = $0
+        sub(/^[[:space:]]*[^[:space:]]*:[[:space:]]*/, "", line)
+        sub(/[[:space:]]+#.*$/, "", line)
+        print trim(line)
+        exit
+      }
+    }
+  ' "$config_file"
+}
+
 workflow_issue_tracker_provider_raw() {
   workflow_config_provider issue_tracker
 }


### PR DESCRIPTION
## Summary

Closes #453.

Adds opt-in `custom_fields` support to the `issue_tracker` section of `.ai-dev-workflow.yaml`, along with a `workflow_issue_tracker_custom_field <key>` bash helper and documentation updates.

### Changes

- **`.ai-dev-workflow.yaml`**: adds a commented `custom_fields` subsection under `issue_tracker` documenting the flat map pattern with a Linear `project` example. Fully commented out — no behaviour change for existing configs.
- **`scripts/development-workflow/workflow-lib.sh`**: adds `workflow_issue_tracker_custom_field <key> [config_file]` helper that parses `issue_tracker.custom_fields.<key>` using the same `awk`-based approach as `workflow_config_field`, extended one nesting level deeper. Returns empty string (exit 0) for all missing/absent cases.
- **`docs/workflow/development-workflow/integrations/linear.md`**: adds **Custom Fields** section documenting the `project` key (Linear project ID), its format, and effect on issue creation.
- **`docs/workflow/development-workflow/integrations/github-projects.md`**: adds **Custom Fields** section stating no keys are currently recognised for this provider and that `project_number` remains a top-level field.
- **`CHANGELOG.md`**: adds `[Unreleased]` entry under `### Added`.

### Spec

`docs/specs/developments/20260430150000_453-custom-fields-issue-tracker/1_453-custom-fields-issue-tracker_specs.md`

### Plan

`docs/specs/developments/20260430150000_453-custom-fields-issue-tracker/2_453-custom-fields-issue-tracker_implementation-plan.md`

## Test plan

- [ ] Source `workflow-lib.sh` and verify `workflow_issue_tracker_custom_field project` returns empty when `custom_fields` is absent from config
- [ ] Verify it returns the correct value when `custom_fields:\n    project: my-id` is present
- [ ] Verify it returns empty for an absent key within `custom_fields`
- [ ] Verify it returns empty (exit 0) when the config file is absent entirely
- [ ] Run `markdownlint-cli2` on changed markdown files — 0 errors
- [ ] Run `check-changelog-duplicate-headers.sh` — passes
- [ ] Confirm existing scripts sourcing `workflow-lib.sh` continue to function

🤖 Generated with [Claude Code](https://claude.com/claude-code)