### PR TITLE
fix(tech-lead): add cross-section consistency self-check to plan protocol (#427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cross-section consistency check in tech-lead plan protocol** (#427): added mandatory self-check step in `02-generate-implementation-plan-protocol.md` requiring the tech-lead to verify all function names, constants, and decision indices are defined consistently across plan sections before committing; added matching blocking checklist entry in `REVIEW.md` plan review
+
 ### Changed
 
 - **Exit code contract table in Protocol 91 Step 8a** (#433): added a prominent table documenting exit codes 0–4 at the top of the Label Readiness Checklist to prevent future exit code collisions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Cross-section consistency check in tech-lead plan protocol** (#427): added mandatory self-check step in `02-generate-implementation-plan-protocol.md` requiring the tech-lead to verify all function names, constants, and decision indices are defined consistently across plan sections before committing; added matching blocking checklist entry in `REVIEW.md` plan review
-
 ### Changed
 
 - **Exit code contract table in Protocol 91 Step 8a** (#433): added a prominent table documenting exit codes 0–4 at the top of the Label Readiness Checklist to prevent future exit code collisions
+
+### Fixed
+
+- **Cross-section consistency check in tech-lead plan protocol** (#427): added mandatory self-check step in `02-generate-implementation-plan-protocol.md` requiring the tech-lead to verify all function names, constants, and decision indices are defined consistently across plan sections before committing; added matching blocking checklist entry in `REVIEW.md` plan review
 
 ## [0.24.0] - 2026-04-29
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -112,6 +112,7 @@ Check:
   - Verify each such claim against the real source files — not just against other parts of the plan document
   - Flag any claim that cannot be verified from the codebase as "unverified — implementer must confirm before proceeding"
   - Cross-reference consistency: line numbers, counts, and symbolic references (e.g., smoke test counts, Verification Log output counts, log line references) must be consistent across the plan document; flag any number or reference that cannot be confirmed against the codebase or a prior plan step
+- Cross-section consistency: all references to the same function, constant, or architecture decision are consistent across all sections of the plan (e.g., a function described in the Architecture section must have the same signature in the Implementation Order steps; a constant must carry the same value everywhere it appears; a decision index must map to the same decision in every reference)
 
 Typical `blocking` issues:
 - Plan steps do not cover required acceptance criteria
@@ -120,6 +121,7 @@ Typical `blocking` issues:
 - A CHANGELOG literal in the Implementation Order uses conventional-commit format (`fix(scope): message`) instead of the project's `**Bold Title** (#N):` format
 - `CHANGELOG.md` is modified in this PR — `implementation-plan/*` branches are exempt from CHANGELOG entries; remove any CHANGELOG modification before merging
 - A behavioral claim about framework/runtime behavior (guard logic, config inheritance, scope, API contract) cannot be verified against the codebase and is not flagged as "unverified"
+- Cross-section inconsistency: the same function, constant, or architecture decision is defined or described differently in two or more sections of the plan (e.g., incompatible function signatures, conflicting constant values, contradictory decision rationales)
 
 Typical `important` issues:
 - Vague wording like "update as needed"

--- a/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -296,7 +296,23 @@ If no blocking human decision remains:
 2. Create branch: `git checkout -b implementation-plan/[branch-slug]` from `develop`
 3. Write the plan file
 4. Write the smoke test runbook
-5. **Pre-commit lint check (mandatory — do not skip)**:
+5. **Cross-section consistency self-check (mandatory — do not skip)**:
+
+   Before committing, verify that every function name, constant, and architecture decision index (ADR/decision number) that appears more than once in the plan has a consistent definition across all occurrences. Contradictory definitions of the same symbol in different sections lead to multiple unnecessary implementation review passes.
+
+   Procedure:
+   1. Collect all identifiers that appear more than once: function/method names, constant names, and decision index labels (e.g., "Decision 1", "ADR-3").
+   2. For each repeated identifier, compare every occurrence across all sections of the plan document.
+   3. If any two occurrences define or describe the identifier differently (e.g., incompatible signatures, conflicting return types, different constant values, or contradictory descriptions), fix the inconsistency before proceeding.
+
+   Common sources of inconsistency to check:
+   - A function described with different signatures or parameters in the "Architecture" section vs. the "Implementation Order" steps.
+   - A constant defined with one value in the overview and a different value in the verification step.
+   - A decision (e.g., "Decision 1: use X") referenced as "Decision 2" or with a different rationale in another section.
+
+   Fix all inconsistencies found before moving to the lint check. Do not proceed to commit with known cross-section contradictions.
+
+6. **Pre-commit lint check (mandatory — do not skip)**:
 
    Run `markdownlint-cli2` on the plan file and smoke test runbook before staging. This catches broken relative links (wrong `../../` depth), trailing spaces, and missing trailing newlines that would otherwise fail CI and require a fix commit.
 
@@ -319,13 +335,13 @@ If no blocking human decision remains:
 
    > **Worktree note**: When running inside a git worktree (e.g., when dispatched by the Portfolio Orchestrator), `node_modules/` does not exist inside the worktree directory. The `$(git rev-parse --git-common-dir)/..` expression resolves to the main repo root in both the main tree and any worktree.
 
-6. **Do NOT update CHANGELOG**: `implementation-plan/*` branches are exempt from CHANGELOG entries. The changelog policy only applies to `feature/*`, `fix/*`, `refactor/*`, and `hotfix/*` branches. Do not create or modify `CHANGELOG.md` in this PR.
-7. Commit: `docs: add implementation plan for [feature-name]`
-8. Push: `git push -u origin implementation-plan/[branch-slug]`
-9. Open a **draft** PR targeting `develop` with:
-   - Title: `docs(plan): [feature-name]`
-   - Body: summary of the approach, complexity estimate, key risks, link to plan and runbook
-10. Return the branch + PR details to the **Work Item Runner**
+7. **Do NOT update CHANGELOG**: `implementation-plan/*` branches are exempt from CHANGELOG entries. The changelog policy only applies to `feature/*`, `fix/*`, `refactor/*`, and `hotfix/*` branches. Do not create or modify `CHANGELOG.md` in this PR.
+8. Commit: `docs: add implementation plan for [feature-name]`
+9. Push: `git push -u origin implementation-plan/[branch-slug]`
+10. Open a **draft** PR targeting `develop` with:
+    - Title: `docs(plan): [feature-name]`
+    - Body: summary of the approach, complexity estimate, key risks, link to plan and runbook
+11. Return the branch + PR details to the **Work Item Runner**
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #427. The tech-lead agent was producing implementation plans containing architectural contradictions across sections (e.g., the same function described with incompatible signatures in different sections), and the internal review gate was approving such plans — leading to multiple unnecessary Devin review passes during implementation.

## Changes

### `docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md`

Added a new mandatory **Step 5 sub-step 5** ("Cross-section consistency self-check") in the Git Execution section. Before committing, the tech-lead must:
1. Collect all identifiers (function/method names, constants, decision indices) that appear more than once in the plan.
2. Compare every occurrence across all sections and verify they are consistent.
3. Fix any inconsistencies before proceeding to the lint check.

Renumbered downstream steps (old 5–9 → new 6–11) to accommodate the new sub-step.

### `REVIEW.md`

Added two entries to the Plan Review Checklist:
- A new check item: "Cross-section consistency: all references to the same function, constant, or architecture decision are consistent across all sections of the plan."
- A new typical `blocking` issue: "Cross-section inconsistency: the same function, constant, or architecture decision is defined or described differently in two or more sections of the plan."

### `CHANGELOG.md`

Added a `### Fixed` entry under `[Unreleased]` for this change.

## Test plan

- [ ] Read the updated protocol and verify the self-check step is clear, actionable, and positioned correctly before the lint check
- [ ] Read the updated REVIEW.md and verify the checklist entry and blocking issue are clear and consistent with the new protocol step
- [ ] Verify markdown lint passes on all modified files
- [ ] Verify CHANGELOG entry follows the project's `**Bold Title** (#N):` format