### PR TITLE
fix(config): replace codex CLI reviewer with codex-github for universal runner coverage

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -75,10 +75,10 @@ review:
   # Step 7a for the full multi-reviewer gate procedure.
   internal_reviewers:
     - claude
-    - codex  # not reachable from automated subagent runners (Claude Code or Cursor); skipped with a warning
-  # To enable the Codex GitHub App reviewer path (universally reachable from all
-  # runner contexts), add 'codex-github' to the list above. Requires the Codex
-  # GitHub App to be installed on the repository.
+    - codex-github  # Codex GitHub App — universally reachable from all runner contexts (Claude Code, Cursor, Codex, headless CI); requires the Codex GitHub App to be installed on this repository
+  # To use the Codex CLI reviewer path instead (only reachable when Codex is the
+  # top-level runner, not from Claude Code or Cursor subagents), replace 'codex-github'
+  # with 'codex'. See runner-context constraint above for details.
   #
   # Configurable codex-github options (set via env vars or script flags; these are
   # advisory comments — the helper script is the enforcement point):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Default internal reviewer switched from `codex` to `codex-github`**: replaced the `codex` CLI reviewer (unreachable from Claude Code and Cursor subagent runners, causing a warning on every automated PR) with `codex-github` (Codex GitHub App — universally reachable via `gh` CLI from any runner context) in the default `.ai-dev-workflow.yaml` `internal_reviewers` list. Requires the Codex GitHub App to be installed on the repository.
 - **Exit code contract table in Protocol 91 Step 8a** (#433): added a prominent table documenting exit codes 0–4 at the top of the Label Readiness Checklist to prevent future exit code collisions
 
 ## [0.24.0] - 2026-04-29


### PR DESCRIPTION
## Summary

- Replaces `codex` with `codex-github` in `internal_reviewers` in `.ai-dev-workflow.yaml`
- `codex` (CLI path) is unreachable from Claude Code and Cursor subagent runners, generating a warning comment on every automated PR and silently reducing Step 7a reviewer coverage from 2 to 1
- `codex-github` (GitHub App path) is universally reachable from all runner contexts because it only requires `gh` CLI access

## Prerequisite

The Codex GitHub App must be installed on this repository and configured to respond to the default trigger phrase (`@codex review`). See `scripts/development-workflow/codex-github-reviewer.sh` for implementation details.

## Test plan

- [ ] Verify the Codex GitHub App is installed on this repository
- [ ] Open a draft PR, confirm `codex-github-reviewer.sh` posts `@codex review` and polls for a response
- [ ] Confirm no `codex unreachable` warning appears in Step 7a summary

## Source

Retrospective finding from Batch 26 (PRs #464–#467, 2026-05-03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)