### PR TITLE
fix(retrospective): dispatch subagent and upgrade to balanced model tier

### DIFF
--- a/.claude/agents/retrospective.md
+++ b/.claude/agents/retrospective.md
@@ -1,6 +1,6 @@
 ---
 name: retrospective
-model: claude-haiku-4-5-20251001
+model: claude-sonnet-4-6
 description: Retrospective analysis agent. Analyzes completed work (a batch or individual item) to identify process improvement opportunities, presents them to the human, and executes the chosen action for each. Use after a batch or item run to surface workflow improvements, or invoke on-demand with a PR number, branch, or date as scope hint.
 tools: Read, Grep, Glob, Write, Edit, Bash
 ---

--- a/.claude/commands/retrospective.md
+++ b/.claude/commands/retrospective.md
@@ -4,12 +4,6 @@ description: Run a retrospective analysis on completed work to identify process 
 
 # Claude Code Command: Retrospective
 
-Follow the retrospective protocol exactly as defined in:
+Dispatch the `retrospective` agent to run the retrospective analysis.
 
-`docs/workflow/development-workflow/protocols/06-retrospective-protocol.md`
-
-- **Scope**: Analyze the PRs from the current session or the scope hint provided (PR number, branch name, or batch date). When no hint is given, default to recent PRs in the repository.
-- **Data sources**: GitHub PR metadata (via `gh`) and, when conversation context is available, the current session's conversation history.
-- **Output**: A categorized list of improvement opportunities — each with a category, severity signal, and recommended action. Present findings first, then act only on the human's explicit choices.
-- **Actions**: "Address now" applies a simple fix, commits, and pushes (no new PR). "Add to backlog" creates a GitHub issue directly. "Skip" moves on.
-- **Constraint**: Never apply fixes or create issues without the human's explicit choice.
+Pass any scope hint provided by the user (PR number, branch name, or batch date) directly to the agent. When no hint is given, the agent defaults to recent PRs in the repository.

--- a/.claude/commands/retrospective.md
+++ b/.claude/commands/retrospective.md
@@ -7,3 +7,5 @@ description: Run a retrospective analysis on completed work to identify process 
 Dispatch the `retrospective` agent to run the retrospective analysis.
 
 Pass any scope hint provided by the user (PR number, branch name, or batch date) directly to the agent. When no hint is given, the agent defaults to recent PRs in the repository.
+
+**Context bridging**: The retrospective agent runs as a subagent and cannot read the parent conversation. Batch notes saved to memory (e.g. `project_batchN_retro_notes.md`) are the primary context bridge — the orchestrator saves these proactively during supervision. If any key corrections or anomalies were NOT saved to memory, include a brief summary in the scope hint before dispatching.

--- a/.cursor/agents/retrospective.md
+++ b/.cursor/agents/retrospective.md
@@ -1,6 +1,6 @@
 ---
 name: retrospective
-model: fast
+model: inherit
 description: Retrospective analysis agent. Analyzes completed work (a batch or individual item) to identify process improvement opportunities, presents them to the human, and executes the chosen action for each.
 ---
 

--- a/.cursor/commands/retrospective.md
+++ b/.cursor/commands/retrospective.md
@@ -4,14 +4,6 @@ description: Run a retrospective analysis on completed work to identify process 
 
 # Cursor Command: Retrospective
 
-Follow the retrospective protocol exactly as defined in:
+Invoke the `retrospective` agent to run the retrospective analysis.
 
-`docs/workflow/development-workflow/protocols/06-retrospective-protocol.md`
-
-Key responsibilities:
-
-- **Scope**: Analyze the PRs from the current session or the scope hint provided (PR number, branch name, or batch date). When no hint is given, default to recent PRs in the repository.
-- **Data sources**: GitHub PR metadata (via `gh`) and, when conversation context is available, the current session's conversation history.
-- **Output**: A categorized list of improvement opportunities — each with a category, severity signal, and recommended action. Present findings first, then act only on the human's explicit choices.
-- **Actions**: "Address now" applies a simple fix, commits, and pushes (no new PR). "Add to backlog" creates a GitHub issue directly. "Skip" moves on.
-- **Constraint**: Never apply fixes or create issues without the human's explicit choice.
+Pass any scope hint provided by the user (PR number, branch name, or batch date) directly to the agent. When no hint is given, the agent defaults to recent PRs in the repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Retrospective command dispatches agent; balanced model tier** (#457): `/retrospective` (Claude Code and Cursor) now dispatches the `retrospective` agent instead of running inline. The `retrospective` agent model is upgraded from `economy` (`claude-haiku-4-5-20251001` / `fast`) to `balanced` (`claude-sonnet-4-6` / `inherit`) — synthesis and pattern-recognition across multiple PRs requires a capable model.
 - **Default internal reviewer switched from `codex` to `codex-github`**: replaced the `codex` CLI reviewer (unreachable from Claude Code and Cursor subagent runners, causing a warning on every automated PR) with `codex-github` (Codex GitHub App — universally reachable via `gh` CLI from any runner context) in the default `.ai-dev-workflow.yaml` `internal_reviewers` list. Requires the Codex GitHub App to be installed on the repository.
 - **Exit code contract table in Protocol 91 Step 8a** (#433): added a prominent table documenting exit codes 0–4 at the top of the Label Readiness Checklist to prevent future exit code collisions
 

--- a/docs/workflow/development-workflow/agent-model-config.md
+++ b/docs/workflow/development-workflow/agent-model-config.md
@@ -37,7 +37,7 @@ If you prefer different names (`small/medium/large`, `fast/standard/pro`, etc.),
 | `code-reviewer` | `balanced` | Code review against known standards and a completed spec. A balanced model is capable here. |
 | `project-setup` | `balanced` | Structured onboarding conversation with clear protocol guidance. A balanced model is sufficient. |
 | `smoke-tester` | `balanced` | Executes the smoke test runbook using browser automation. A balanced model is sufficient for following step-by-step testing instructions. |
-| `retrospective` | `economy` | **Retrospective Analyst**. Reads PR metadata and git history, synthesizes findings into a categorized list; mechanical analysis that should stay fast and cheap. |
+| `retrospective` | `balanced` | **Retrospective Analyst**. Reads PR metadata and git history, synthesizes findings across multiple PRs, and identifies workflow patterns; the synthesis and pattern-recognition work requires a capable model — economy tier produces shallow, low-signal retrospectives. |
 
 ### Runner Notes
 


### PR DESCRIPTION
## Summary

- **`/retrospective` command now dispatches the `retrospective` agent** instead of running inline (both Claude Code and Cursor commands updated)
- **Retrospective agent model upgraded** from `economy` (`claude-haiku-4-5-20251001` / `fast`) to `balanced` (`claude-sonnet-4-6` / `inherit`) — synthesis and pattern-recognition across multiple PRs requires a capable model
- **`agent-model-config.md`** updated: `retrospective` tier changed from `economy` to `balanced` with updated rationale

## Files changed

- `.claude/commands/retrospective.md` — dispatch agent instead of inline execution
- `.claude/agents/retrospective.md` — model: `claude-haiku-4-5-20251001` → `claude-sonnet-4-6`
- `.cursor/commands/retrospective.md` — dispatch agent instead of inline execution
- `.cursor/agents/retrospective.md` — model: `fast` → `inherit`
- `docs/workflow/development-workflow/agent-model-config.md` — tier: `economy` → `balanced` with updated rationale
- `CHANGELOG.md` — added entry under `[Unreleased] ### Changed`

Closes #457

## Test plan

- [ ] Verify `/retrospective` command file dispatches the agent (not inline protocol)
- [ ] Verify `.claude/agents/retrospective.md` model is `claude-sonnet-4-6`
- [ ] Verify `.cursor/agents/retrospective.md` model is `inherit`
- [ ] Verify `agent-model-config.md` shows `retrospective` → `balanced` with updated rationale
- [ ] Verify no other agent tier assignments changed
- [ ] Verify CHANGELOG entry is under `[Unreleased]` / `### Changed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)