### PR TITLE
feat(workflow): add pre-merge setup signal for PRs requiring human configuration (#367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Add pre-merge setup signal for PRs requiring human configuration** (#367): Adds a `needs-setup` label and a standardised `## Pre-merge Setup` PR body section so agents surface infrastructure dependencies (env vars, secrets, DNS records) at PR readiness time rather than requiring the human to read the diff. Protocol 91 Step 8a now includes a diff-scan heuristic step; protocol 92 defines the label semantics and valid co-label combinations.
 - **Add `custom_fields` support for issue tracker config** (#453): Adds a `custom_fields` flat map under `issue_tracker` in `.ai-dev-workflow.yaml` and a `workflow_issue_tracker_custom_field` helper function in `workflow-lib.sh` to read individual custom field values. Updates Linear and GitHub Projects integration docs to document recognised fields.
 
 ### Fixed

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1062,25 +1062,33 @@ Before running the readiness checklist below, perform a best-effort scan of the 
 
 3. **If one or more signals are found**:
 
-   a. Read the current PR body:
-
-   ```bash
-   CURRENT_BODY=$(gh pr view <pr_number> --json body --jq '.body')
-   ```
-
-   b. Construct a `## Pre-merge Setup` section listing each detected requirement with (BR-8):
+   a. Construct a `## Pre-merge Setup` section listing each detected requirement with (BR-8):
       - Requirement name
       - Type (e.g., environment variable, GitHub Actions secret, DNS record, service account token)
       - Plain-language description of the expected value
       - Where to set it (e.g., GitHub Actions secrets, Railway environment, DNS provider)
 
-   c. Append the section to the existing PR body and update:
+   b. Replace any existing `## Pre-merge Setup` section in the PR body with the newly constructed one, then update the PR body. This step runs on every pass through Step 8a (including after fixer pushes), so the section must always reflect the current diff — never accumulate stale or duplicate sections:
 
    ```bash
-   gh pr edit <pr_number> --body "<updated-body-with-pre-merge-setup-section>"
+   # Remove any existing ## Pre-merge Setup block (from header to next ## heading or EOF),
+   # then append the updated block at the end of the cleaned body.
+   CURRENT_BODY=$(gh pr view <pr_number> --json body --jq '.body')
+   CLEANED_BODY=$(echo "$CURRENT_BODY" | python3 -c "
+   import sys, re
+   body = sys.stdin.read()
+   # Remove existing ## Pre-merge Setup section (from the heading to next ## heading or end of string)
+   body = re.sub(r'\n## Pre-merge Setup\n.*?(?=\n## |\Z)', '', body, flags=re.DOTALL)
+   print(body.rstrip())
+   ")
+   UPDATED_BODY="${CLEANED_BODY}
+
+   ## Pre-merge Setup
+   <requirements list>"
+   gh pr edit <pr_number> --body "$UPDATED_BODY"
    ```
 
-   d. Apply the `needs-setup` label (BR-1 — the label must always accompany the section):
+   c. Apply the `needs-setup` label (BR-1 — the label must always accompany the section):
 
    ```bash
    gh pr edit <pr_number> --add-label "needs-setup"
@@ -1093,11 +1101,22 @@ Before running the readiness checklist below, perform a best-effort scan of the 
    Ensure `needs-setup` is not present and no `## Pre-merge Setup` section exists in the PR body. If either is present from a prior scan (e.g., a previous commit introduced an env var that has since been removed), remove them:
 
    ```bash
-   # Remove label if present (idempotent — no error if already absent)
-   gh pr edit <pr_number> --remove-label "needs-setup" 2>/dev/null || true
+   # Remove label only if it is currently present (avoids silencing real API/auth errors)
+   HAS_SETUP_LABEL=$(gh pr view <pr_number> --json labels --jq '.labels[].name' | grep -c "^needs-setup$" || true)
+   if [ "$HAS_SETUP_LABEL" -gt 0 ]; then
+     gh pr edit <pr_number> --remove-label "needs-setup"
+   fi
 
    # Remove the ## Pre-merge Setup section from the PR body if present
    # (Read body, strip the section and all content until the next ## heading or EOF, write back)
+   CURRENT_BODY=$(gh pr view <pr_number> --json body --jq '.body')
+   CLEANED_BODY=$(echo "$CURRENT_BODY" | python3 -c "
+   import sys, re
+   body = sys.stdin.read()
+   body = re.sub(r'\n## Pre-merge Setup\n.*?(?=\n## |\Z)', '', body, flags=re.DOTALL)
+   print(body.rstrip())
+   ")
+   gh pr edit <pr_number> --body "$CLEANED_BODY"
    ```
 
 5. After the scan: proceed to the readiness checklist below. The presence of `needs-setup` is a valid co-label with `ready-for-human-review` and does **not** block this checklist or prevent `ready-for-human-review` from being applied (BR-3). The checklist script does not check for or remove `needs-setup` — it is a deliberate signal, not a stale label.

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1039,6 +1039,69 @@ Required labels are determined by the **branch prefix**, not by the content of t
 
 Any branch that does not match a recognized prefix is treated as non-implementation (i.e., `ready-for-regression` is NOT required), but this should be treated as a configuration anomaly and reported to the human.
 
+### Infrastructure Dependency Scan (pre-readiness)
+
+Before running the readiness checklist below, perform a best-effort scan of the PR diff to detect infrastructure dependencies that require human setup before the feature can be safely enabled. This scan runs on **every pass through Step 8a** — including after fixer pushes — so the label and PR body section always reflect the current diff (BR-6).
+
+**Timing**: Run after CI is green and all automated reviewer loops are clean (Step 7 complete), but before applying `ready-for-human-review`. The scan result does **not** block readiness — `needs-setup` co-exists with `ready-for-human-review` (BR-3, BR-4).
+
+**Scan procedure**:
+
+1. Read the PR diff:
+
+   ```bash
+   gh pr diff <pr_number>
+   ```
+
+2. Scan the diff for infrastructure dependency signals on **added lines** (lines starting with `+`). The following heuristics are best-effort and intentionally incomplete (BR-9 — false negatives are acceptable):
+
+   - **New environment variable references**: added lines matching patterns like `process.env.NEW_VAR`, `os.environ["NEW_VAR"]`, `$NEW_VAR` in shell scripts, or new entries added to `.env.example`, `.env.template`, or similar env-template files.
+   - **New GitHub Actions secret references**: added lines in `.github/workflows/**` files that reference `${{ secrets.NEW_SECRET }}`.
+   - **New config key additions to environment-specific config files**: added keys in files named `*.env`, `.env.*`, `config/production.*`, or similar deployment-configuration files.
+   - **Explicit setup TODO comments added in the diff**: added comments containing phrases like `# TODO: set`, `# Set this to`, `# Required: configure`, or similar that indicate a value must be externally provided.
+
+3. **If one or more signals are found**:
+
+   a. Read the current PR body:
+
+   ```bash
+   CURRENT_BODY=$(gh pr view <pr_number> --json body --jq '.body')
+   ```
+
+   b. Construct a `## Pre-merge Setup` section listing each detected requirement with (BR-8):
+      - Requirement name
+      - Type (e.g., environment variable, GitHub Actions secret, DNS record, service account token)
+      - Plain-language description of the expected value
+      - Where to set it (e.g., GitHub Actions secrets, Railway environment, DNS provider)
+
+   c. Append the section to the existing PR body and update:
+
+   ```bash
+   gh pr edit <pr_number> --body "<updated-body-with-pre-merge-setup-section>"
+   ```
+
+   d. Apply the `needs-setup` label (BR-1 — the label must always accompany the section):
+
+   ```bash
+   gh pr edit <pr_number> --add-label "needs-setup"
+   ```
+
+   **Note**: The `needs-setup` GitHub label must exist in the repository's label settings before this step can succeed. Suggested color: `#fbca04` (yellow). If the label does not exist, create it in the repository's **Issues → Labels** settings first.
+
+4. **If no signals are found**:
+
+   Ensure `needs-setup` is not present and no `## Pre-merge Setup` section exists in the PR body. If either is present from a prior scan (e.g., a previous commit introduced an env var that has since been removed), remove them:
+
+   ```bash
+   # Remove label if present (idempotent — no error if already absent)
+   gh pr edit <pr_number> --remove-label "needs-setup" 2>/dev/null || true
+
+   # Remove the ## Pre-merge Setup section from the PR body if present
+   # (Read body, strip the section and all content until the next ## heading or EOF, write back)
+   ```
+
+5. After the scan: proceed to the readiness checklist below. The presence of `needs-setup` is a valid co-label with `ready-for-human-review` and does **not** block this checklist or prevent `ready-for-human-review` from being applied (BR-3). The checklist script does not check for or remove `needs-setup` — it is a deliberate signal, not a stale label.
+
 Run this checklist for **every PR**:
 
 ```bash
@@ -1240,6 +1303,7 @@ Verify all of the following. If any check fails, **do not report ready** — tre
 | `ready-for-human-review` label | Present in `labels[].name` |
 | `ready-for-regression` label | Present in `labels[].name` for `feature/*`, `fix/*`, `refactor/*`, `hotfix/*`; absent/ignored for `spec/*`, `implementation-plan/*` |
 | No `needs-fixes` label | `needs-fixes` absent from `labels[].name` |
+| `needs-setup` label (if present) | **Valid co-label** — `needs-setup` may be present alongside `ready-for-human-review` when the diff contains infrastructure dependency signals. Its presence does **not** constitute a verification failure and does not block this check. Do not remove it. |
 | All automated-reviewer `reviewThreads` resolved | GraphQL query above returns empty output — `isResolved: true` (or first comment body contains `✅ Addressed`) for every thread authored by a configured bot login (skip this check only when Step 7 was `skipped` because no review platforms are configured) |
 | Automated reviewer loop summary | At least one comment whose body contains `"Automated Reviewer Loop Summary"`, `"Reviewer Loop Summary"`, or `"No blocking PR feedback"` (skip this check only when Step 7 was `skipped` because no review platforms are configured). **This is a hard requirement. Agents applying fixes MUST NOT remove or skip this check — the presence of the comment is the only reliable signal that Step 7 ran to completion. A PR that has `ready-for-human-review` but lacks this comment is in an incomplete state and must re-run Step 7.** (Note: the Step 7a summary comment posted by the internal review gate is a distinct comment from a distinct step — it does not satisfy this check. This check targets the external automated reviewer loop summary from Step 7 only.) |
 | CI checks | All required status checks have `state: SUCCESS` or `conclusion: success` in `statusCheckRollup` (no check in `PENDING`, `FAILURE`, or `ERROR` state) |

--- a/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -13,6 +13,7 @@ This is a **repo-wide definition**. All agents apply these labels consistently.
 | `ready-for-human-review` | The PR is ready for a human reviewer. CI is green. The `REVIEW.md` gate is satisfied. Every configured automated reviewer is clean or skipped. |
 | `needs-fixes` | The PR still needs fixes before it is ready for human review. This may be due to human-requested changes, failing CI, or blocking automated PR feedback. |
 | `ready-for-regression` | Automated code reviews are clean (or skipped). E2e/regression tests should now run. Applied by the orchestrator (Step 7b) on implementation PRs (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`), and by the prepare-release flow (protocol `05`) on **production** release PRs (`release/*` → `main`) only. |
+| `needs-setup` | PR introduces one or more infrastructure dependencies (env vars, secrets, DNS records, service account tokens, etc.) that require human setup steps before the feature can be safely enabled. Co-exists with `ready-for-human-review`; the human removes this label after completing (or intentionally deferring) setup. |
 
 ---
 
@@ -57,6 +58,32 @@ Release PRs typically do not use the same draft → `gh pr ready` path as featur
 This label is **not removed** after e2e tests pass — it persists on the PR. The `ready-for-human-review` label is what ultimately signals human readiness after CI (including e2e) is green.
 
 This label is **not applied** to spec or plan PRs (`spec/*`, `implementation-plan/*`). It **is** applied to qualifying release PRs per Case B above.
+
+---
+
+## Conditions for `needs-setup`
+
+Apply this label when the agent's infrastructure dependency scan (Protocol 91 Step 8a) detects one or more infrastructure dependency signals in the PR diff. The agent applies it; the human removes it.
+
+**Who applies it**: The agent, as part of Protocol 91 Step 8a, after all automated reviewer loops and CI checks pass but before applying `ready-for-human-review`. The scan runs on every pass through Step 8a (including after fixer pushes) so the label always reflects the current diff.
+
+**Who removes it**: The human reviewer, after completing the listed setup steps (or intentionally deferring them).
+
+**Valid label combinations**:
+
+| Combination | Meaning |
+|---|---|
+| `ready-for-human-review` only | No setup requirements detected — standard ready state |
+| `ready-for-human-review` + `needs-setup` | PR is technically ready but has unmet setup requirements; human must perform setup and then remove `needs-setup` before or after merge |
+| `needs-fixes` + `needs-setup` | Transitional state — PR has both code changes requested by reviewers and setup requirements; `needs-fixes` must be addressed first, at which point `needs-setup` persists alongside `ready-for-human-review` |
+
+**Invariants**:
+
+- **BR-1**: `needs-setup` must always be accompanied by a `## Pre-merge Setup` section in the PR body. Applying the label without the section is an incomplete signal.
+- **BR-2**: The `## Pre-merge Setup` section must not appear in the PR body without `needs-setup` being applied at that time. After the human removes `needs-setup`, the section may remain as a historical record — this is an intentional audit trail, not an orphaned section.
+- **BR-3**: `needs-setup` does not prevent `ready-for-human-review` from being applied, does not block CI from passing, and does not block automated review tools from completing. It co-exists with `ready-for-human-review`.
+- **BR-7**: When the human removes `needs-setup` (Use Case 3 — setup acknowledged), the `## Pre-merge Setup` section remains in the PR body as a historical record. When the agent rescans and finds no infrastructure dependencies (Use Case 4 — dependency removed from diff), the agent removes both the label and the section.
+- **BR-10**: `needs-setup` is distinct from `needs-fixes`. They have different semantics, different lifecycles, and may co-exist. `needs-fixes` signals reviewer-requested code changes; `needs-setup` signals out-of-band human configuration steps.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements issue #367 — adds a lightweight `needs-setup` label and a standardised `## Pre-merge Setup` PR body section so agents surface infrastructure dependencies (env vars, secrets, DNS records, service account tokens) at PR readiness time, rather than requiring the human to read the full diff.

### Changes

- **`docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md`**: Added `needs-setup` row to the Labels table; added new `## Conditions for needs-setup` section defining who applies it (agent at Step 8a), who removes it (human after setup), valid co-label combinations, and the BR-1/BR-2/BR-3/BR-7/BR-10 invariants.
- **`docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`**: Added "Infrastructure Dependency Scan (pre-readiness)" sub-step to Step 8a with detection heuristics and scan procedure; added note to Step 8c verification table that `needs-setup` is a valid co-label that does not constitute a verification failure.
- **`CHANGELOG.md`**: Added `[Unreleased]` entry for #367.

### Smoke test

`docs/testing/workflow/367-pre-merge-setup-signal.smoke-test.md` was created during the plan stage and covers TC-1 through TC-4b (AC-1 through AC-9).

## Test plan

- [ ] TC-4a: Verify protocol 91 Step 8a contains the "Infrastructure Dependency Scan" sub-step and explicitly documents `needs-setup` as a valid co-label
- [ ] TC-4b: Verify protocol 92 contains the `needs-setup` label definition, semantics, valid combinations, and BR invariants
- [ ] Markdownlint: all three changed files pass `markdownlint-cli2` (verified in implementation — 0 errors)
- [ ] CHANGELOG duplicate-header check passes (verified)