### PR TITLE
docs(plan): attempt tracking for reviewer loop prompts

### DIFF
--- a/docs/specs/developments/20260504142615_448-attempt-tracking-reviewer-loop/2_448-attempt-tracking-reviewer-loop_implementation-plan.md
+++ b/docs/specs/developments/20260504142615_448-attempt-tracking-reviewer-loop/2_448-attempt-tracking-reviewer-loop_implementation-plan.md
@@ -1,0 +1,206 @@
+# Attempt Tracking for Reviewer Loop Prompts — Implementation Plan
+
+**Spec**: [`1_448-attempt-tracking-reviewer-loop_specs.md`](./1_448-attempt-tracking-reviewer-loop_specs.md)
+**Smoke test runbook**: [`../../testing/workflow/448-attempt-tracking-reviewer-loop.smoke-test.md`](../../../testing/workflow/448-attempt-tracking-reviewer-loop.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add an attempt-context injection rule to the fixer agent dispatch section of Protocol 91 (Step 7) and Protocol 93. On the first fixer dispatch (cycle = 1) the prompt is unchanged. On each retry (cycle ≥ 2) the orchestrator prepends a structured header — "Attempt N/M:" followed by one-to-two-sentence summaries of what prior attempts addressed and what findings remain open — before the standard blocking-findings list. The attempt summaries are derived from the orchestrator's existing PR feedback ledger and fixer response, live in in-session state only, and are discarded when the orchestration session ends.
+
+**Estimated complexity**: S
+
+**Rationale**: The change is documentation-only — two markdown protocol files. No scripts, no code, no database changes. The fixer dispatch section in both Protocol 91 Step 7 and Protocol 93 needs a new subsection describing the injection rule and the required prompt format. The existing cycle counter and PR feedback ledger (already tracked in the protocol) are the only data sources required; no new state structures are needed.
+
+**Dependencies**: None
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+|---|---|---|
+| Repo revision | `git rev-parse --short HEAD` | `1ab1488` |
+| Files that define fixer dispatch in Protocol 91 | `grep -n "Fixer agent batching rule\|dispatch.*fixer\|needs_fixes.*cycle" docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` | Lines 766, 895, 933–944 (fixer batching rule block, `needs_fixes` dispatch table, loop parameters) |
+| Files that define fixer dispatch in Protocol 93 | `grep -n "Fixer agent batching rule\|dispatch.*fixer" docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` | Lines 117–129 (fixer batching rule block) |
+| Protocol 91 line count | `wc -l docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` | 1385 |
+| Protocol 93 line count | `wc -l docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` | 286 |
+| Other agents/skills referencing these protocols | `grep -rl "91-orchestrate-work-protocol\|93-automated-reviewer-loop" .claude/agents/ .cursor/agents/ .codex/skills/ 2>/dev/null` | Results include `.claude/agents/automated-reviewer-loop.md`, `.cursor/agents/automated-reviewer-loop.md`, `.claude/agents/item-orchestrator.md`, `.cursor/agents/item-orchestrator.md` — these reference the protocols by pointer only; the injection rule lives in the protocols themselves, so the agent files do not need updating |
+
+---
+
+## Layer-by-Layer Changes
+
+### Protocol / Documentation Layer
+
+- [ ] **`docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` — Step 7 fixer dispatch**: Add a new subsection `### Attempt-context injection rule (Step 7 fixer dispatch)` immediately after the existing `### Fixer agent batching rule (mandatory)` block. The subsection must document:
+  - When to inject (cycle ≥ 2 only; cycle = 1 is unchanged)
+  - How to derive per-attempt summaries from the PR feedback ledger and fixer response
+  - The required prompt format for cycle ≥ 2
+  - The fallback format when no prior-attempt summary is available
+  - How to accumulate summaries across multiple retries
+  - The rule that the attempt-context prefix is prepended and does not replace the standard blocking-findings list
+- [ ] **`docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` — fixer dispatch section**: Add the same `### Attempt-context injection rule` subsection in the matching location (after `### Fixer agent batching rule (mandatory)`) with identical content, so the standalone reviewer loop path is covered (AC-8, AC-9 both require documentation in both protocols)
+
+---
+
+## Testing Strategy
+
+**Test types**: Manual / smoke (protocol review is the verification mechanism — no automated test for documentation changes)
+
+**Key scenarios to test**:
+
+1. First dispatch (cycle = 1) — prompt has no attempt-context prefix (maps to AC-1)
+2. First retry (cycle = 2) — prompt begins with "Attempt 2/M:" plus prior-attempt summary and remaining findings (maps to AC-2, AC-3, AC-4, AC-5)
+3. Multi-retry (cycle ≥ 3) — prompt accumulates all prior-attempt summaries, not only the most recent (maps to Use Case 3, AC-5)
+4. Fallback path — when no prior-attempt summary is available, minimal "Attempt N/M: prior attempt did not fully resolve all findings" message is used (maps to Use Case 1 Considerations, AC-5)
+5. Reappearance — when a finding reappeared after a prior fix, the summary notes the reappearance explicitly (maps to AC-6)
+6. Prefix additive — the attempt-context prefix is in addition to, not a replacement of, the blocking-findings list (maps to AC-7)
+
+**Smoke test runbook**: `docs/testing/workflow/448-attempt-tracking-reviewer-loop.smoke-test.md`
+
+---
+
+## Seed Data
+
+None — this is a documentation-only change with no application data requirements.
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` — Updated as the primary implementation file (see Layer-by-Layer Changes)
+- [ ] `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` — Updated as a secondary implementation file (see Layer-by-Layer Changes)
+
+No other project docs in `docs/project/`, `docs/best-practices/`, or `AGENTS.md` are affected. The change is scoped to the reviewer loop protocols.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Attempt-context prompt grows too long for large max_cycles values | Low | Med | Spec mandates one-to-two sentences per attempt summary; plan enforces this in the documented format |
+| Fixer agent ignores the attempt-context prefix | Low | Med | The prefix is informational context only; the standard blocking-findings list is unchanged and the agent still has all findings to work from |
+| Protocol 93 diverges from Protocol 91 over time | Low | Med | Both are updated in the same PR so they are in sync at merge; future editors are advised by the subsection header that this rule mirrors Protocol 91 Step 7 |
+
+---
+
+## Code Samples
+
+> All samples below are illustrative — adapt during implementation.
+
+### Attempt-context injection rule (illustrative format for the protocol text)
+
+The following shows the content to add to the `### Attempt-context injection rule` subsection in both Protocol 91 and Protocol 93. It is marked illustrative; the developer must adapt prose, headings, and formatting to match the surrounding document style.
+
+```markdown
+<!-- Illustrative — adapt during implementation -->
+### Attempt-context injection rule (Step 7 fixer dispatch)
+
+This rule governs what the orchestrator prepends to the fixer agent's prompt on each
+dispatch. It applies to fixer agents dispatched from this step only (Step 7 external
+automated reviewers); Step 7a (internal review gate) fixer cycles are unaffected.
+
+**First dispatch (cycle = 1)**
+
+No attempt-context prefix is added. The fixer receives only the standard
+blocking-findings list and the batching rule above.
+
+**Retry dispatches (cycle ≥ 2)**
+
+Before dispatching the fixer, the orchestrator prepends an attempt-context header
+to the fixer's prompt using the following format:
+
+> Attempt N/M: prior attempt(s) tried [per-attempt summaries]. The following findings
+> remain open: [standard blocking-findings list]. Try a different approach for each
+> remaining finding.
+
+Where:
+- `N` = the current `cycle` value (matches the loop's `cycle` counter exactly)
+- `M` = `max_cycles` (the loop escalation limit — default: 10)
+- `[per-attempt summaries]` = one entry per prior dispatch, each one-to-two plain-language
+  sentences describing what that attempt changed and which findings it addressed or left
+  open. Derive each entry from the PR feedback ledger and the fixer's commit message /
+  response for that cycle.
+- `[standard blocking-findings list]` = the same findings list passed in any dispatch —
+  the attempt-context prefix does not replace it
+
+**Accumulating summaries across retries**
+
+For cycle N, include summaries for all N-1 prior attempts, not only the most recent.
+Each entry should be keyed to its cycle number for clarity:
+
+> Attempt 1: rewrote the `foo()` function signature in `bar.sh`; MD009 trailing-space
+> finding on line 42 remained open.
+> Attempt 2: removed trailing space on line 42; `relative-links` finding on `baz.md`
+> remained open.
+
+**Fallback when no prior-attempt summary is available**
+
+If no summary was recorded for a prior attempt (e.g., the fixer did not respond or
+the attempt had no ledger entries), use the minimal fallback:
+
+> Attempt N/M: prior attempt did not fully resolve all findings. Try a different approach.
+
+**Reappearance notation**
+
+When a finding that was marked `resolved` in a prior cycle reappears in the current
+ledger (same `(platform, path, body_snippet)` key, status reverted to `open`), the
+per-attempt summary for the cycle in which it was "resolved" must note the reappearance:
+
+> Attempt 2: removed trailing space on line 42 (fix did not hold — finding reappeared
+> in cycle 3).
+
+**In-session state only**
+
+Attempt summaries live in the orchestrator's in-session state for the duration of the
+PR's review loop. They are not persisted to disk or to any external tracker. They are
+discarded when the orchestration session ends.
+```
+
+---
+
+## Implementation Order
+
+1. **Read both target files** — read the complete text of `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` and `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` before making any edits. Confirm the exact line after the `### Fixer agent batching rule (mandatory)` block in each file where the new subsection will be inserted.
+
+2. **Add `### Attempt-context injection rule` subsection to Protocol 91** — insert the new subsection immediately after the closing lines of the `### Fixer agent batching rule (mandatory)` block (i.e., after the closing `>` blockquote and before `### Loop parameters`). The subsection must cover all items listed in the Layer-by-Layer Changes section and must match the illustrative format in the Code Samples section. Verify after editing that the section appears between the fixer batching rule and the loop parameters table.
+
+3. **Add `### Attempt-context injection rule` subsection to Protocol 93** — insert the identical subsection in the matching location in Protocol 93: immediately after the closing lines of the `### Fixer agent batching rule (mandatory)` block. The subsection header should note that this rule mirrors Protocol 91 Step 7 to aid future maintenance. Verify after editing that the section appears in the correct position.
+
+4. **Cross-section consistency self-check** — confirm that:
+   - The cycle counter variable name (`cycle`) is consistent across both files and matches the existing usage in the loop parameters sections
+   - The `max_cycles` constant name is consistent with existing usage
+   - The prompt format uses the same `N/M` notation in both files
+   - The fallback phrase is identical in both files
+
+5. **Pre-commit markdown lint** — run `markdownlint-cli2` on both modified files:
+
+   ```bash
+   REPO_ROOT=$(git rev-parse --git-common-dir)/..
+   "$REPO_ROOT/node_modules/.bin/markdownlint-cli2" \
+     "docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md" \
+     "docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md"
+   ```
+
+   Fix any reported violations (trailing spaces, missing trailing newline, broken relative links) before committing.
+
+6. **Pre-commit smoke test runbook lint** — run `markdownlint-cli2` on the smoke test runbook:
+
+   ```bash
+   REPO_ROOT=$(git rev-parse --git-common-dir)/..
+   "$REPO_ROOT/node_modules/.bin/markdownlint-cli2" \
+     "docs/testing/workflow/448-attempt-tracking-reviewer-loop.smoke-test.md"
+   ```
+
+7. **Commit** — `docs: add attempt-context injection rule to reviewer loop fixer dispatch (#448)`
+
+8. **Verify smoke test runbook scenarios** — confirm each scenario in the runbook can be traced to a specific acceptance criterion in the spec and a specific line in the updated protocol text.
+
+9. **Update `CHANGELOG.md`** under `[Unreleased]` — add:
+
+   ```
+   - **Add attempt tracking to reviewer loop prompts** (#448): Fixer agents dispatched on retry (cycle ≥ 2) now receive an attempt-context prefix in their prompt summarising what prior attempts addressed and what findings remain open, enabling them to avoid repeating failing approaches and converge faster.
+   ```

--- a/docs/testing/workflow/448-attempt-tracking-reviewer-loop.smoke-test.md
+++ b/docs/testing/workflow/448-attempt-tracking-reviewer-loop.smoke-test.md
@@ -1,0 +1,173 @@
+# Smoke Test Runbook: Attempt Tracking for Reviewer Loop Prompts
+
+**Feature**: Add attempt tracking to reviewer loop prompts
+**Spec**: [`docs/specs/developments/20260504142615_448-attempt-tracking-reviewer-loop/1_448-attempt-tracking-reviewer-loop_specs.md`](../../specs/developments/20260504142615_448-attempt-tracking-reviewer-loop/1_448-attempt-tracking-reviewer-loop_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] Protocol 91 Step 7 has been updated to include the `### Attempt-context injection rule` subsection
+- [ ] Protocol 93 has been updated with the matching `### Attempt-context injection rule` subsection
+- [ ] You have access to the updated protocol files and can read them
+
+---
+
+## Test Data
+
+| Item | Value |
+|---|---|
+| Protocol 91 | `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` |
+| Protocol 93 | `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` |
+| Target section in 91 | Between `### Fixer agent batching rule (mandatory)` and `### Loop parameters` |
+| Target section in 93 | After `### Fixer agent batching rule (mandatory)` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify Protocol 91 — First dispatch has no attempt-context prefix
+
+**Maps to**: Acceptance Criterion 1
+
+1. Open `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`
+2. Locate the `### Attempt-context injection rule` subsection in Step 7
+3. Confirm there is an explicit rule stating that when `cycle = 1` (first fixer dispatch), no attempt-context prefix is added to the fixer prompt
+
+**Expected result**: A clear statement that cycle = 1 dispatches use the standard prompt with no attempt-context prefix
+
+---
+
+### Step 2: Verify Protocol 91 — Retry dispatch prompt format
+
+**Maps to**: Acceptance Criteria 2, 3, 4
+
+1. In the same `### Attempt-context injection rule` subsection, locate the retry dispatch rules (cycle ≥ 2)
+2. Confirm the documented prompt format begins with `"Attempt N/M:"` where N is the current cycle value
+3. Confirm the format specifies that N matches the loop's `cycle` counter
+4. Confirm the format specifies that M is the `max_cycles` parameter
+
+**Expected result**: The subsection explicitly states N = current `cycle` value and M = `max_cycles` (default: 10)
+
+---
+
+### Step 3: Verify Protocol 91 — Per-attempt summary content and accumulation
+
+**Maps to**: Acceptance Criteria 5, Use Case 3
+
+1. In the `### Attempt-context injection rule` subsection, locate the per-attempt summary rules
+2. Confirm the rule specifies one-to-two plain-language sentences per prior attempt
+3. Confirm the rule requires summaries for ALL prior attempts (not only the most recent) when cycle ≥ 3
+4. Confirm the rule states that summaries are derived from the PR feedback ledger and fixer response/commit
+
+**Expected result**: Accumulation rule is explicit — cycle N includes summaries for attempts 1 through N-1
+
+---
+
+### Step 4: Verify Protocol 91 — Reappearance notation
+
+**Maps to**: Acceptance Criterion 6
+
+1. In the `### Attempt-context injection rule` subsection, locate the reappearance handling rule
+2. Confirm the rule states that when a finding reappears (was marked resolved, then opened again), the per-attempt summary for the cycle where it was "resolved" must note the reappearance explicitly
+
+**Expected result**: A specific rule about reappearance notation with example wording similar to "fix did not hold — finding reappeared in cycle N"
+
+---
+
+### Step 5: Verify Protocol 91 — Attempt-context prefix is additive
+
+**Maps to**: Acceptance Criterion 7
+
+1. In the `### Attempt-context injection rule` subsection, confirm the rule states that the attempt-context prefix is prepended in addition to the standard blocking-findings list
+2. Confirm there is no statement that the prefix replaces the findings list
+
+**Expected result**: An explicit statement that the prefix does not replace the standard blocking-findings list
+
+---
+
+### Step 6: Verify Protocol 91 — Fallback when no prior-attempt summary is available
+
+**Maps to**: Use Case 1 Considerations, Acceptance Criterion 5
+
+1. In the `### Attempt-context injection rule` subsection, locate the fallback rule
+2. Confirm the fallback phrase is similar to: "Attempt N/M: prior attempt did not fully resolve all findings. Try a different approach."
+
+**Expected result**: A clearly documented fallback message for cases where no per-attempt summary was recorded
+
+---
+
+### Step 7: Verify Protocol 93 — Same rule is documented
+
+**Maps to**: Acceptance Criterion 9
+
+1. Open `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
+2. Locate the `### Attempt-context injection rule` subsection after the `### Fixer agent batching rule (mandatory)` block
+3. Confirm it contains the same rule as Protocol 91 (first dispatch unchanged, retry format, accumulation, reappearance, additive prefix, fallback)
+
+**Expected result**: Protocol 93 contains an equivalent `### Attempt-context injection rule` subsection covering all the same rules as Protocol 91 Step 7
+
+---
+
+### Step 8: Verify Protocol 91 — Step 7 cycle counter documentation
+
+**Maps to**: Acceptance Criterion 3
+
+1. In Protocol 91 Step 7, find where `cycle` is initialized (`Initialize cycle = 0`)
+2. Confirm the `### Attempt-context injection rule` subsection references the same `cycle` variable
+3. Confirm the subsection states that N shown in the prompt matches the `cycle` counter exactly
+
+**Expected result**: N in the prompt is explicitly defined as the current `cycle` counter value, with no offset or separate counter
+
+---
+
+### Last Step: Validate & Shut Down
+
+- Confirm all assertions in the checklist below are met
+- No application to shut down (documentation-only change)
+
+---
+
+## Assertions Checklist
+
+Each checkbox maps to an acceptance criterion from the spec.
+
+- [ ] AC-1: First dispatch (cycle = 1) prompt has no attempt-context prefix
+- [ ] AC-2: Retry dispatch (cycle ≥ 2) prompt begins with "Attempt N/M:" followed by prior-attempt summary and remaining findings
+- [ ] AC-3: N in the prompt matches the loop's `cycle` counter value
+- [ ] AC-4: M in the prompt matches the `max_cycles` parameter
+- [ ] AC-5: Per-attempt summary is one-to-two plain-language sentences; all prior attempts are included for cycle ≥ 3
+- [ ] AC-6: When a finding reappeared after a prior fix, the summary notes the reappearance explicitly
+- [ ] AC-7: Attempt-context prefix is prepended to (not a replacement of) the standard blocking-findings list
+- [ ] AC-8: Protocol 91 Step 7 documents the attempt-context injection rule and required prompt format
+- [ ] AC-9: Protocol 93 documents the same rule for the standalone reviewer loop path
+
+---
+
+## Seed Data Reference
+
+None — this is a documentation-only feature with no application data requirements.
+
+| Entity | Scenario | How to load |
+|---|---|---|
+| N/A | N/A | N/A |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `### Attempt-context injection rule` subsection missing from Protocol 91 | Implementation step 2 was not completed | Re-run the implementation and add the subsection after `### Fixer agent batching rule (mandatory)` |
+| `### Attempt-context injection rule` subsection missing from Protocol 93 | Implementation step 3 was not completed | Add the subsection in the matching position in Protocol 93 |
+| N or M in the prompt format definition does not match cycle / max_cycles | Cross-section inconsistency during authoring | Re-read both subsections and align variable names with the existing loop parameters table |
+
+---
+
+## Known Limitations
+
+- This smoke test verifies protocol documentation correctness only. It does not test runtime orchestrator behaviour — live validation requires observing an actual multi-cycle reviewer loop dispatch with a PR that has persistent findings.


### PR DESCRIPTION
## Summary

Implementation plan for issue #448: add attempt-context injection to fixer agent prompts in the automated reviewer loop.

**Approach**: Documentation-only change to two markdown protocol files:
- `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` (Step 7 fixer dispatch)
- `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`

A new `### Attempt-context injection rule` subsection is added after the existing `### Fixer agent batching rule (mandatory)` block in both files. On the first fixer dispatch (cycle = 1) the prompt is unchanged. On each retry (cycle ≥ 2) the orchestrator prepends "Attempt N/M:" followed by per-attempt summaries and the remaining findings list.

**Estimated complexity**: S (documentation only)

**Key risks**: None significant — no code or script changes, no new state structures.

## Links

- Spec: `docs/specs/developments/20260504142615_448-attempt-tracking-reviewer-loop/1_448-attempt-tracking-reviewer-loop_specs.md`
- Plan: `docs/specs/developments/20260504142615_448-attempt-tracking-reviewer-loop/2_448-attempt-tracking-reviewer-loop_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/448-attempt-tracking-reviewer-loop.smoke-test.md`