### PR TITLE
fix(reviewer-loop): apply mechanical findings inline before dispatching fixer sub-agent (#495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-
-- **Apply mechanical reviewer findings inline before dispatching a fixer sub-agent** (#495): Protocols 91 (Step 7) and 93 now include an inline fix rule — when all blocking findings are mechanical (single file, fully described, ≤ 5 lines), the orchestrator applies them directly using Edit/Bash tools without spawning a sub-agent, eliminating the 10–20 minute startup overhead for one-line changes.
-
 ## [0.24.1] - 2026-04-30
 
 ### Fixed
@@ -32,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Apply mechanical reviewer findings inline before dispatching a fixer sub-agent** (#495): Protocols 91 (Step 7) and 93 now include an inline fix rule — when all blocking findings are mechanical (single file, fully described, ≤ 5 lines), the orchestrator applies them directly using Edit/Bash tools without spawning a sub-agent, eliminating the 10–20 minute startup overhead for one-line changes.
 - **Automate GitHub Projects tracker status update on PR merge** (#463): adds `.github/workflows/update-tracker-on-merge.yml` — a GitHub Actions workflow triggered when a `spec/*`, `implementation-plan/*`, `feature/*`, `fix/*`, `refactor/*`, or `hotfix/*` PR is merged to `develop`. The workflow extracts the issue number from the branch name and updates the GitHub Projects v2 Status field to `Spec Ready`, `Plan Ready`, or `Merged` accordingly; implementation branches also close the linked issue. Eliminates stale statuses that persisted until the next orchestrator run. Requires `GITHUB_PROJECT_NUMBER` and `GITHUB_PROJECT_OWNER` repository variables. Updates `docs/workflow/development-workflow/integrations/github-projects.md` with setup instructions.
 - **Branch-type-aware timeout in `pr-review-loop.sh`** (#462): on `spec/*` and `implementation-plan/*` branches, Devin has no trigger condition and exits immediately with `REASON=no_check_run`. The script now automatically reduces `--max-wait` from 1200 s to 60 s and `--poll-interval` from 120 s to 30 s for these branch types when the caller does not pass the respective flag explicitly, preventing 20-minute wait-budget waste on non-implementation PRs.
 - **Fixer agents must fix all occurrences of flagged literal values** (#426): added mandatory all-occurrences rule to Protocol 93 fix-cycle guidance — when a reviewer flags a literal value (numeric constant, hex value, identifier, repeated string), fixer agents must `grep -n` the old value across all affected files and fix every occurrence in the same commit before pushing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Apply mechanical reviewer findings inline before dispatching a fixer sub-agent** (#495): Protocols 91 (Step 7) and 93 now include an inline fix rule — when all blocking findings are mechanical (single file, fully described, ≤ 5 lines), the orchestrator applies them directly using Edit/Bash tools without spawning a sub-agent, eliminating the 10–20 minute startup overhead for one-line changes.
+
 ## [0.24.1] - 2026-04-30
 
 ### Fixed

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1030,8 +1030,8 @@ Soft suggestions may be reported in summaries, but they do not change the loop r
 
 Before dispatching a fixer sub-agent, check whether ALL blocking findings are **mechanical** — meeting every one of these criteria:
 
-1. **Single file**: the finding body identifies exactly one file path.
-2. **Fully described**: the change is completely and unambiguously specified in the finding (e.g., "replace `grep '^\s*'` with `grep '^[[:space:]]*'`", "add `--limit 100` to the `gh issue list` call", "remove the `states:OPEN` argument").
+1. **Single file across the batch**: all blocking findings reference the **same single file** (one file total across the batch — not one file per finding). If two findings name two different files, the inline path does not apply; dispatch a sub-agent.
+2. **Fully described**: each finding's body completely and unambiguously specifies the change (e.g., "replace `grep '^\s*'` with `grep '^[[:space:]]*'`", "add `--limit 100` to the `gh issue list` call", "remove the `states:OPEN` argument").
 3. **Small scope**: the total estimated change across all blocking findings is ≤ 5 lines.
 
 **When ALL criteria are met — apply the fixes directly** in the current session using Edit/Bash tools:

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1037,9 +1037,9 @@ Before dispatching a fixer sub-agent, check whether ALL blocking findings are **
 **When ALL criteria are met — apply the fixes directly** in the current session using Edit/Bash tools:
 
 1. Apply every blocking finding in one pass (follow the batching rule: all in one commit).
-2. Reply to each finding's review thread with the fix description and commit SHA.
-3. Resolve each addressed thread via the GraphQL `resolveReviewThread` mutation.
-4. Commit with a descriptive message (e.g., `fix: address [platform] findings inline ([brief description])`).
+2. Commit with a descriptive message (e.g., `fix: address [platform] findings inline ([brief description])`).
+3. Reply to each finding's review thread with the fix description and commit SHA.
+4. Resolve each addressed thread via the GraphQL `resolveReviewThread` mutation.
 5. Push the commit.
 6. Run `pr-review-loop.sh` again from the top of Step 7.
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1038,9 +1038,9 @@ Before dispatching a fixer sub-agent, check whether ALL blocking findings are **
 
 1. Apply every blocking finding in one pass (follow the batching rule: all in one commit).
 2. Commit with a descriptive message (e.g., `fix: address [platform] findings inline ([brief description])`).
-3. Reply to each finding's review thread with the fix description and commit SHA.
-4. Resolve each addressed thread via the GraphQL `resolveReviewThread` mutation.
-5. Push the commit.
+3. Push the commit. *(Push before resolving threads — if push fails, threads must not be falsely marked resolved.)*
+4. Reply to each finding's review thread with the fix description and commit SHA.
+5. Resolve each addressed thread via the GraphQL `resolveReviewThread` mutation.
 6. Run `pr-review-loop.sh` again from the top of Step 7.
 
 **Do not dispatch a sub-agent for mechanical findings.** Sub-agent startup overhead (context loading, planning) typically costs 10–20 minutes for changes that take 30 seconds to apply directly.

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1026,6 +1026,27 @@ When an automated review platform returns inline comments, classify them before 
 
 Soft suggestions may be reported in summaries, but they do not change the loop result to `needs_fixes`. Any blocking finding does.
 
+### Inline fix rule (attempt before sub-agent dispatch)
+
+Before dispatching a fixer sub-agent, check whether ALL blocking findings are **mechanical** — meeting every one of these criteria:
+
+1. **Single file**: the finding body identifies exactly one file path.
+2. **Fully described**: the change is completely and unambiguously specified in the finding (e.g., "replace `grep '^\s*'` with `grep '^[[:space:]]*'`", "add `--limit 100` to the `gh issue list` call", "remove the `states:OPEN` argument").
+3. **Small scope**: the total estimated change across all blocking findings is ≤ 5 lines.
+
+**When ALL criteria are met — apply the fixes directly** in the current session using Edit/Bash tools:
+
+1. Apply every blocking finding in one pass (follow the batching rule: all in one commit).
+2. Reply to each finding's review thread with the fix description and commit SHA.
+3. Resolve each addressed thread via the GraphQL `resolveReviewThread` mutation.
+4. Commit with a descriptive message (e.g., `fix: address [platform] findings inline ([brief description])`).
+5. Push the commit.
+6. Run `pr-review-loop.sh` again from the top of Step 7.
+
+**Do not dispatch a sub-agent for mechanical findings.** Sub-agent startup overhead (context loading, planning) typically costs 10–20 minutes for changes that take 30 seconds to apply directly.
+
+**When ANY criterion fails** — fall through to the sub-agent dispatch path below. The inline path is a fast lane, not a mandatory gate. When in doubt about whether a finding is fully described or single-file, dispatch the sub-agent.
+
 **Fixing agent by PR branch type:**
 
 | PR branch prefix | Compatibility fixer to dispatch when direct fixes are needed |

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1041,8 +1041,8 @@ Before dispatching a fixer sub-agent, check whether ALL blocking findings are **
 3. Push the commit. *(Push before resolving threads — if push fails, threads must not be falsely marked resolved.)*
 4. Reply to each finding's review thread with the fix description and commit SHA.
 5. Resolve each addressed thread via the GraphQL `resolveReviewThread` mutation.
-6. **Increment `cycle`** (the same counter used in the sub-agent loop) before re-running. Inline fix retries are bounded by `max_cycles` exactly like sub-agent retries — the inline path is a faster lane, not an unbounded one. If `cycle >= max_cycles`, escalate to human instead of re-running.
-7. Run `pr-review-loop.sh` again from the top of Step 7.
+6. **Increment `cycle`** (the same counter used in the sub-agent loop). Inline fix retries are bounded by `max_cycles` exactly like sub-agent retries — the inline path is a faster lane, not an unbounded one.
+7. Run `pr-review-loop.sh` again from the top of Step 7. If it returns `clean`, proceed normally. If the loop still reports unresolved blocking findings **and** `cycle >= max_cycles`, escalate to human (the just-pushed fix is always given a chance to be verified before escalating).
 
 **Do not dispatch a sub-agent for mechanical findings.** Sub-agent startup overhead (context loading, planning) typically costs 10–20 minutes for changes that take 30 seconds to apply directly.
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1041,7 +1041,8 @@ Before dispatching a fixer sub-agent, check whether ALL blocking findings are **
 3. Push the commit. *(Push before resolving threads — if push fails, threads must not be falsely marked resolved.)*
 4. Reply to each finding's review thread with the fix description and commit SHA.
 5. Resolve each addressed thread via the GraphQL `resolveReviewThread` mutation.
-6. Run `pr-review-loop.sh` again from the top of Step 7.
+6. **Increment `cycle`** (the same counter used in the sub-agent loop) before re-running. Inline fix retries are bounded by `max_cycles` exactly like sub-agent retries — the inline path is a faster lane, not an unbounded one. If `cycle >= max_cycles`, escalate to human instead of re-running.
+7. Run `pr-review-loop.sh` again from the top of Step 7.
 
 **Do not dispatch a sub-agent for mechanical findings.** Sub-agent startup overhead (context loading, planning) typically costs 10–20 minutes for changes that take 30 seconds to apply directly.
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -106,8 +106,8 @@ Also handle the case where a platform posted blocking findings after a previous 
 
 Before dispatching a fixer sub-agent, check whether ALL blocking findings are **mechanical** — meeting every one of these criteria:
 
-1. **Single file**: the finding body identifies exactly one file path.
-2. **Fully described**: the change is completely and unambiguously specified in the finding (e.g., "replace `grep '^\s*'` with `grep '^[[:space:]]*'`", "add `--limit 100` to the `gh issue list` call", "remove the `states:OPEN` argument").
+1. **Single file across the batch**: all blocking findings reference the **same single file** (one file total across the batch — not one file per finding). If two findings name two different files, the inline path does not apply; dispatch a sub-agent.
+2. **Fully described**: each finding's body completely and unambiguously specifies the change (e.g., "replace `grep '^\s*'` with `grep '^[[:space:]]*'`", "add `--limit 100` to the `gh issue list` call", "remove the `states:OPEN` argument").
 3. **Small scope**: the total estimated change across all blocking findings is ≤ 5 lines.
 
 **When ALL criteria are met — apply the fixes directly** in the current session using Edit/Bash tools:

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -102,7 +102,28 @@ If the SHA is **not found**, the agent must **not** record it as the resolved co
 
 Also handle the case where a platform posted blocking findings after a previous run timed out and the agent moved on: if those findings are still unresolved per the rules above, dispatch a fixer, wait for the push, then run the scripts.
 
-If unresolved findings exist: dispatch a fixer agent, wait for the push, then proceed to the scripts. Do not re-trigger the reviewer loop against stale findings — fix first.
+If unresolved findings exist: apply the inline fix rule below first; fall back to dispatching a fixer agent only when the rule does not apply. Then proceed to the scripts.
+
+### Inline fix rule (attempt before sub-agent dispatch)
+
+Before dispatching a fixer sub-agent, check whether ALL blocking findings are **mechanical** — meeting every one of these criteria:
+
+1. **Single file**: the finding body identifies exactly one file path.
+2. **Fully described**: the change is completely and unambiguously specified in the finding (e.g., "replace `grep '^\s*'` with `grep '^[[:space:]]*'`", "add `--limit 100` to the `gh issue list` call", "remove the `states:OPEN` argument").
+3. **Small scope**: the total estimated change across all blocking findings is ≤ 5 lines.
+
+**When ALL criteria are met — apply the fixes directly** in the current session using Edit/Bash tools:
+
+1. Apply every blocking finding in one pass (follow the batching rule: all in one commit).
+2. Reply to each finding's review thread with the fix description and commit SHA.
+3. Resolve each addressed thread via the GraphQL `resolveReviewThread` mutation.
+4. Commit with a descriptive message (e.g., `fix: address [platform] findings inline ([brief description])`).
+5. Push the commit.
+6. Re-run the reviewer loop script from the top.
+
+**Do not dispatch a sub-agent for mechanical findings.** Sub-agent startup overhead (context loading, planning) typically costs 10–20 minutes for changes that take 30 seconds to apply directly.
+
+**When ANY criterion fails** — fall through to the sub-agent dispatch path. The inline path is a fast lane, not a mandatory gate. When in doubt about whether a finding is fully described or single-file, dispatch the sub-agent.
 
 ### Worktree discipline for fixer agents (`BATCH_CONTEXT=true`)
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -100,9 +100,7 @@ If the SHA is **not found**, the agent must **not** record it as the resolved co
 
 #### Stale review after timeout
 
-Also handle the case where a platform posted blocking findings after a previous run timed out and the agent moved on: if those findings are still unresolved per the rules above, dispatch a fixer, wait for the push, then run the scripts.
-
-If unresolved findings exist: apply the inline fix rule below first; fall back to dispatching a fixer agent only when the rule does not apply. Then proceed to the scripts.
+Also handle the case where a platform posted blocking findings after a previous run timed out and the agent moved on: if those findings are still unresolved per the rules above, address them before re-running the scripts. Apply the **Inline fix rule below first** when all findings are mechanical (single file, fully described, ≤ 5 lines); fall back to dispatching a fixer sub-agent only when the inline rule does not apply. In either case, wait for the push to land before running the scripts again — do not re-trigger the reviewer loop against stale findings.
 
 ### Inline fix rule (attempt before sub-agent dispatch)
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -119,8 +119,8 @@ Before dispatching a fixer sub-agent, check whether ALL blocking findings are **
 3. Push the commit. *(Push before resolving threads — if push fails, threads must not be falsely marked resolved.)*
 4. Reply to each finding's review thread with the fix description and commit SHA.
 5. Resolve each addressed thread via the GraphQL `resolveReviewThread` mutation.
-6. **Increment `cycle`** (the same counter used in the sub-agent loop) before re-running. Inline fix retries are bounded by `max_cycles` exactly like sub-agent retries — the inline path is a faster lane, not an unbounded one. If `cycle >= max_cycles`, escalate to human instead of re-running.
-7. Re-run the reviewer loop script from the top.
+6. **Increment `cycle`** (the same counter used in the sub-agent loop). Inline fix retries are bounded by `max_cycles` exactly like sub-agent retries — the inline path is a faster lane, not an unbounded one.
+7. Re-run the reviewer loop script from the top. If it returns `clean`, proceed normally. If the loop still reports unresolved blocking findings **and** `cycle >= max_cycles`, escalate to human (the just-pushed fix is always given a chance to be verified before escalating).
 
 **Do not dispatch a sub-agent for mechanical findings.** Sub-agent startup overhead (context loading, planning) typically costs 10–20 minutes for changes that take 30 seconds to apply directly.
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -116,9 +116,9 @@ Before dispatching a fixer sub-agent, check whether ALL blocking findings are **
 
 1. Apply every blocking finding in one pass (follow the batching rule: all in one commit).
 2. Commit with a descriptive message (e.g., `fix: address [platform] findings inline ([brief description])`).
-3. Reply to each finding's review thread with the fix description and commit SHA.
-4. Resolve each addressed thread via the GraphQL `resolveReviewThread` mutation.
-5. Push the commit.
+3. Push the commit. *(Push before resolving threads — if push fails, threads must not be falsely marked resolved.)*
+4. Reply to each finding's review thread with the fix description and commit SHA.
+5. Resolve each addressed thread via the GraphQL `resolveReviewThread` mutation.
 6. Re-run the reviewer loop script from the top.
 
 **Do not dispatch a sub-agent for mechanical findings.** Sub-agent startup overhead (context loading, planning) typically costs 10–20 minutes for changes that take 30 seconds to apply directly.

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -115,9 +115,9 @@ Before dispatching a fixer sub-agent, check whether ALL blocking findings are **
 **When ALL criteria are met — apply the fixes directly** in the current session using Edit/Bash tools:
 
 1. Apply every blocking finding in one pass (follow the batching rule: all in one commit).
-2. Reply to each finding's review thread with the fix description and commit SHA.
-3. Resolve each addressed thread via the GraphQL `resolveReviewThread` mutation.
-4. Commit with a descriptive message (e.g., `fix: address [platform] findings inline ([brief description])`).
+2. Commit with a descriptive message (e.g., `fix: address [platform] findings inline ([brief description])`).
+3. Reply to each finding's review thread with the fix description and commit SHA.
+4. Resolve each addressed thread via the GraphQL `resolveReviewThread` mutation.
 5. Push the commit.
 6. Re-run the reviewer loop script from the top.
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -119,7 +119,8 @@ Before dispatching a fixer sub-agent, check whether ALL blocking findings are **
 3. Push the commit. *(Push before resolving threads — if push fails, threads must not be falsely marked resolved.)*
 4. Reply to each finding's review thread with the fix description and commit SHA.
 5. Resolve each addressed thread via the GraphQL `resolveReviewThread` mutation.
-6. Re-run the reviewer loop script from the top.
+6. **Increment `cycle`** (the same counter used in the sub-agent loop) before re-running. Inline fix retries are bounded by `max_cycles` exactly like sub-agent retries — the inline path is a faster lane, not an unbounded one. If `cycle >= max_cycles`, escalate to human instead of re-running.
+7. Re-run the reviewer loop script from the top.
 
 **Do not dispatch a sub-agent for mechanical findings.** Sub-agent startup overhead (context loading, planning) typically costs 10–20 minutes for changes that take 30 seconds to apply directly.
 


### PR DESCRIPTION
## Summary

- Adds an **inline fix rule** to Protocol 91 Step 7 and Protocol 93
- When all blocking findings are mechanical (single file, fully described, ≤5 lines), the runner applies them directly using Edit/Bash tools — no sub-agent
- Eliminates 10–20 minutes of sub-agent startup overhead for one-line changes (add a flag, fix a shell pattern, remove an argument)
- Falls back to sub-agent dispatch for complex or multi-file findings

## Test plan

- [ ] Review the inline fix rule text in both protocol files for clarity and correctness
- [ ] Verify the criteria (single file, fully described, ≤5 lines) are well-defined enough to apply consistently
- [ ] Verify the fallback path ("when any criterion fails, dispatch sub-agent") is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)