### PR TITLE
chore(release): v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.24.1] - 2026-04-30
-
-### Fixed
-
-- **GitHub Actions SHA pinning**: pin `actions/checkout` and `actions/setup-node` to commit SHAs instead of version tags in `deploy.yml`, `e2e-regression.yml`, and `shellcheck.yml` for supply chain security
-- **`add-backlog-item.sh` empty value validation**: `--body-file` and `--label` options now reject empty strings in addition to missing arguments
-- **`workflow-batch-plan.sh` issue-number skip logic**: gate the "no issue number" skip on GitHub Projects being configured — repos using Linear (no `GITHUB_PROJECT_NUMBER`) no longer incorrectly skip all folders without numeric prefixes in their slugs
-
 ## [Unreleased]
+
+## [0.25.0] - 2026-05-06
 
 ### Added
 
@@ -48,6 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`product-manager` agent upgraded to `premium` model tier** (#456): spec writing is the highest-leverage task in the pipeline — a weak spec cascades into worse plans and worse implementations. Updated `agent-model-config.md` rationale, model IDs in `.claude/agents/product-manager.md` and `.cursor/agents/product-manager.md` (to `claude-opus-4-7`), and Codex skill tier in `.codex/skills/workflow-spec-writer/SKILL.md` (to `premium`).
 
 ## [0.24.0] - 2026-04-29
+
+### Fixed
+
+- **GitHub Actions SHA pinning**: pin `actions/checkout` and `actions/setup-node` to commit SHAs instead of version tags in `deploy.yml`, `e2e-regression.yml`, and `shellcheck.yml` for supply chain security
+- **`add-backlog-item.sh` empty value validation**: `--body-file` and `--label` options now reject empty strings in addition to missing arguments
+- **`workflow-batch-plan.sh` issue-number skip logic**: gate the "no issue number" skip on GitHub Projects being configured — repos using Linear (no `GITHUB_PROJECT_NUMBER`) no longer incorrectly skip all folders without numeric prefixes in their slugs
+
+## [0.24.1] - 2026-04-30
 
 ### Added
 
@@ -616,7 +618,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.24.1...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.24.1...v0.25.0
 [0.24.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.23.2...v0.24.0
 [0.23.2]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.23.1...v0.23.2

--- a/scripts/development-workflow/batch-merge.sh
+++ b/scripts/development-workflow/batch-merge.sh
@@ -314,7 +314,7 @@ consolidate_changelog_duplicates() {
   # preserved (no reordering) — only sections with actual duplicates are
   # reconstructed; clean sections pass through verbatim.
   python3 - "$file" <<'PYEOF'
-import sys, re, os
+import sys, re, os, tempfile
 
 filepath = sys.argv[1]
 with open(filepath, "r") as fh:
@@ -414,11 +414,26 @@ while i < len(lines):
         result.append(line)
         i += 1
 
-# Write atomically via a temp file
-tmp = filepath + ".dedup.tmp"
-with open(tmp, "w") as fh:
-    fh.writelines(result)
-os.replace(tmp, filepath)
+# Write atomically via a uniquely named temp file in the same directory.
+# This avoids collisions and ensures we never replace the target with a
+# partially written file if an exception occurs mid-write.
+tmp_dir = os.path.dirname(filepath) or "."
+fd = None
+tmp = None
+try:
+    fd, tmp = tempfile.mkstemp(prefix=".dedup.", suffix=".tmp", dir=tmp_dir)
+    with os.fdopen(fd, "w") as fh:
+        fd = None
+        fh.writelines(result)
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp, filepath)
+    tmp = None
+finally:
+    if fd is not None:
+        os.close(fd)
+    if tmp is not None and os.path.exists(tmp):
+        os.unlink(tmp)
 PYEOF
 }
 

--- a/scripts/development-workflow/batch-merge.sh
+++ b/scripts/development-workflow/batch-merge.sh
@@ -550,9 +550,11 @@ cmd_merge() {
     if [ -f "CHANGELOG.md" ] && [ -f "$lint_script" ]; then
       if ! bash "$lint_script" CHANGELOG.md >/dev/null 2>&1; then
         echo "INFO: CHANGELOG duplicate section headers detected after clean merge of PR #${pr_num} — auto-consolidating..." >&2
-        # Use '|| true' so a Python3 runtime failure does not abort the merge;
-        # the re-lint check below will detect if consolidation was incomplete.
-        consolidate_changelog_duplicates CHANGELOG.md || true
+        # Do not abort merge flow if consolidation tooling is unavailable, but
+        # emit an explicit warning so this does not fail silently.
+        if ! consolidate_changelog_duplicates CHANGELOG.md; then
+          echo "WARNING: CHANGELOG deduplication helper failed (for example, missing python3); continuing without auto-fix." >&2
+        fi
         # Verify the fix resolved all duplicates before amending.
         if bash "$lint_script" CHANGELOG.md >/dev/null 2>&1; then
           git add CHANGELOG.md

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -263,13 +263,11 @@ MAX_CONSECUTIVE_FAILURES=3
 # retrigger post, scoping the next inner poll to responses after that point.
 TOTAL_ELAPSED=0
 while true; do
-  ATTEMPT_ELAPSED=0
   while [ "$TOTAL_ELAPSED" -lt "$MAX_WAIT" ]; do
   sleep "$POLL_INTERVAL"
-  ATTEMPT_ELAPSED=$((ATTEMPT_ELAPSED + POLL_INTERVAL))
   TOTAL_ELAPSED=$((TOTAL_ELAPSED + POLL_INTERVAL))
 
-  echo "INFO: polling... attempt elapsed ${ATTEMPT_ELAPSED}s, total elapsed ${TOTAL_ELAPSED}s / ${MAX_WAIT}s"
+  echo "INFO: polling... elapsed ${TOTAL_ELAPSED}s / ${MAX_WAIT}s"
 
   # Query comments authored by the bot that appeared after the trigger comment timestamp.
   # The bot login may include "[bot]" suffix — use exact string match on user.login.

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -17,7 +17,8 @@
 #                               Also overridable via CODEX_GITHUB_BOT_LOGIN env var.
 #                               Verify the actual bot login from your GitHub App settings.
 #   --poll-interval  <seconds>   Seconds between polling attempts. Default: 30
-#   --max-wait       <seconds>   Maximum wait time per attempt for bot response. Default: 600
+#   --max-wait       <seconds>   Maximum total wait time for bot response across
+#                                all attempts. Default: 600
 #   --max-retriggers <count>     How many times to re-post the trigger after a timeout
 #                                before giving up. Default: 1 (so up to 2 attempts total).
 #                                Set to 0 to disable retriggering.
@@ -173,7 +174,10 @@ fi
 echo "INFO: PR #$PR_NUMBER HEAD commit: $CURRENT_SHA"
 echo "INFO: Bot login: $BOT_LOGIN"
 echo "INFO: Trigger phrase: $TRIGGER_PHRASE"
-echo "INFO: Poll interval: ${POLL_INTERVAL}s, Max wait: ${MAX_WAIT}s"
+if [ "$POLL_INTERVAL" -gt "$MAX_WAIT" ]; then
+  POLL_INTERVAL="$MAX_WAIT"
+fi
+echo "INFO: Poll interval: ${POLL_INTERVAL}s, Max wait (total): ${MAX_WAIT}s"
 
 # Derive plain bot login (without [bot] suffix) for matching PR-comment responses.
 # Codex posts "clean" results as regular PR comments from the non-[bot] account
@@ -240,29 +244,32 @@ fi
 
 # ── Poll for bot response (with retrigger support) ───────────────────────────
 #
-# Outer loop: each iteration is one full poll attempt of up to MAX_WAIT seconds.
-# If the bot does not respond within MAX_WAIT, we re-post the trigger comment
-# (up to MAX_RETRIGGERS times) and start a fresh inner poll. This handles the
+# Outer loop: we keep polling until the shared MAX_WAIT budget is exhausted.
+# If the bot does not respond during an attempt, we re-post the trigger comment
+# (up to MAX_RETRIGGERS times) and continue polling with the remaining budget.
+# This handles the
 # case where Codex silently drops the first @codex review request — in practice
 # a re-post usually gets a response. After all attempts are exhausted, we exit
 # with TIMED_OUT (treated as unavailable by the caller).
 
 echo "INFO: polling for response from '$BOT_LOGIN' (trigger time: $TRIGGER_TIME)..."
-echo "INFO: MAX_WAIT=${MAX_WAIT}s per attempt; up to $((MAX_RETRIGGERS + 1)) attempt(s) total (MAX_RETRIGGERS=$MAX_RETRIGGERS)"
+echo "INFO: MAX_WAIT=${MAX_WAIT}s total; up to $((MAX_RETRIGGERS + 1)) attempt(s) (MAX_RETRIGGERS=$MAX_RETRIGGERS)"
 
 RETRIGGER_COUNT=0
 CONSECUTIVE_API_FAILURES=0
 MAX_CONSECUTIVE_FAILURES=3
-# Outer retrigger loop. ELAPSED is reset to 0 at the top of each iteration.
+# Outer retrigger loop. TOTAL_ELAPSED tracks the full shared wait budget.
 # TRIGGER_TIME is updated to the retrigger comment's timestamp after each
 # retrigger post, scoping the next inner poll to responses after that point.
+TOTAL_ELAPSED=0
 while true; do
-  ELAPSED=0
-  while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+  ATTEMPT_ELAPSED=0
+  while [ "$TOTAL_ELAPSED" -lt "$MAX_WAIT" ]; do
   sleep "$POLL_INTERVAL"
-  ELAPSED=$((ELAPSED + POLL_INTERVAL))
+  ATTEMPT_ELAPSED=$((ATTEMPT_ELAPSED + POLL_INTERVAL))
+  TOTAL_ELAPSED=$((TOTAL_ELAPSED + POLL_INTERVAL))
 
-  echo "INFO: polling... elapsed ${ELAPSED}s / ${MAX_WAIT}s"
+  echo "INFO: polling... attempt elapsed ${ATTEMPT_ELAPSED}s, total elapsed ${TOTAL_ELAPSED}s / ${MAX_WAIT}s"
 
   # Query comments authored by the bot that appeared after the trigger comment timestamp.
   # The bot login may include "[bot]" suffix — use exact string match on user.login.
@@ -365,11 +372,11 @@ while true; do
   done  # end inner poll loop
 
   # Inner poll loop ended without a bot response — try to re-trigger if budget remains.
-  if [ "$RETRIGGER_COUNT" -lt "$MAX_RETRIGGERS" ]; then
+  if [ "$TOTAL_ELAPSED" -lt "$MAX_WAIT" ] && [ "$RETRIGGER_COUNT" -lt "$MAX_RETRIGGERS" ]; then
     RETRIGGER_COUNT=$((RETRIGGER_COUNT + 1))
     ATTEMPT_NUM=$((RETRIGGER_COUNT + 1))
     TOTAL_ATTEMPTS=$((MAX_RETRIGGERS + 1))
-    echo "INFO: no response after ${MAX_WAIT}s; re-triggering (attempt ${ATTEMPT_NUM}/${TOTAL_ATTEMPTS})..."
+    echo "INFO: no response yet; re-triggering (attempt ${ATTEMPT_NUM}/${TOTAL_ATTEMPTS}, total elapsed ${TOTAL_ELAPSED}s/${MAX_WAIT}s)..."
     # --raw-field passes the body string as-is to the GitHub API without shell
     # re-interpretation, so special characters in TRIGGER_PHRASE are safe.
     if ! TRIGGER_TIME=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
@@ -390,7 +397,7 @@ done  # end outer retrigger loop
 # ── Timeout ───────────────────────────────────────────────────────────────────
 
 TOTAL_ATTEMPTS=$((MAX_RETRIGGERS + 1))
-echo "VERDICT: TIMED_OUT — no response from '$BOT_LOGIN' after ${TOTAL_ATTEMPTS} attempt(s) (${MAX_WAIT}s each)"
+echo "VERDICT: TIMED_OUT — no response from '$BOT_LOGIN' after ${TOTAL_ELAPSED}s (budget ${MAX_WAIT}s) across up to ${TOTAL_ATTEMPTS} attempt(s)"
 echo "INFO: remediation — verify the Codex GitHub App is installed on $OWNER/$REPO."
 echo "INFO: You can manually trigger the review by posting: $TRIGGER_PHRASE"
 exit 2

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -374,7 +374,7 @@ while true; do
     # re-interpretation, so special characters in TRIGGER_PHRASE are safe.
     if ! TRIGGER_TIME=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
       --method POST \
-      --raw-field body="$TRIGGER_PHRASE — retrigger ${RETRIGGER_COUNT}/${MAX_RETRIGGERS} after timeout" \
+      --raw-field body="$TRIGGER_PHRASE — retrigger ${RETRIGGER_COUNT}/${MAX_RETRIGGERS} after timeout (sha: $CURRENT_SHA)" \
       --jq '.created_at'); then
       echo "ERROR: failed to post retrigger comment to PR #$PR_NUMBER" >&2
       echo "VERDICT: TIMED_OUT — failed to post retrigger comment (treated as unavailable)"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -200,8 +200,8 @@ IDEM_STDERR=$(mktemp)
 IDEM_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>"$IDEM_STDERR" \
-  | jq -r --arg sha "$CURRENT_SHA" --arg trigger "$TRIGGER_PHRASE" --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" \
-    '.[] | select(.user.login != $bot and .user.login != $bot_plain) | select((.body | test($sha)) and (.body | ascii_downcase | contains($trigger | ascii_downcase))) | {id: .id, created_at: .created_at, body: .body}' \
+  | jq -r --arg sha "$CURRENT_SHA" --arg marker "review triggered by workflow runner" --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" \
+    '.[] | select(.user.login != $bot and .user.login != $bot_plain) | select((.body | test($sha)) and (.body | ascii_downcase | contains($marker))) | {id: .id, created_at: .created_at, body: .body}' \
   > "$IDEM_TMPFILE"; then
   TRIGGER_COMMENT_INFO=$(head -c 2000 "$IDEM_TMPFILE")
 else

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -482,6 +482,11 @@ run_codex_github_review() {
   local owner repo_name
   owner="$(printf '%s\n' "$repo" | cut -d/ -f1)"
   repo_name="$(printf '%s\n' "$repo" | cut -d/ -f2)"
+  local max_retriggers
+  max_retriggers="${CODEX_GITHUB_MAX_RETRIGGERS:-1}"
+  case "$max_retriggers" in
+    ''|*[!0-9]*) max_retriggers=1 ;;
+  esac
 
   # Keep polling interval bounded by the wait budget to avoid zero-poll attempts
   # when a caller provides poll_interval > max_wait.
@@ -495,7 +500,7 @@ run_codex_github_review() {
     --bot-login "$bot_login" \
     --poll-interval "$effective_poll_interval" \
     --max-wait "$max_wait" \
-    --max-retriggers 1 >/dev/null 2>&1
+    --max-retriggers "$max_retriggers" >/dev/null 2>&1
   script_exit=$?
   set -e
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -483,15 +483,18 @@ run_codex_github_review() {
   owner="$(printf '%s\n' "$repo" | cut -d/ -f1)"
   repo_name="$(printf '%s\n' "$repo" | cut -d/ -f2)"
 
-  # Split max_wait across 2 attempts (initial + 1 retrigger) so total stays
-  # within the caller's budget. floor(max_wait/2) is conservative by design:
-  # 2 * floor(max_wait/2) <= max_wait. Minor timing slack (< poll_interval
-  # per attempt) is accepted as normal polling variance.
+  # Keep polling interval bounded by the wait budget to avoid zero-poll attempts
+  # when a caller provides poll_interval > max_wait.
+  local effective_poll_interval
+  effective_poll_interval="$poll_interval"
+  if [ "$effective_poll_interval" -gt "$max_wait" ]; then
+    effective_poll_interval="$max_wait"
+  fi
   set +e
   "$reviewer_script" "$pr_number" "$owner" "$repo_name" \
     --bot-login "$bot_login" \
-    --poll-interval "$poll_interval" \
-    --max-wait "$(( max_wait / 2 ))" \
+    --poll-interval "$effective_poll_interval" \
+    --max-wait "$max_wait" \
     --max-retriggers 1 >/dev/null 2>&1
   script_exit=$?
   set -e
@@ -1029,15 +1032,12 @@ run_pr_agent_review() {
 
   _pr_agent_latest_comment() {
     gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-      | jq -rs --arg bot "$bot_login" --arg since "$since_iso" --arg sha "$head_sha" '
+      | jq -rs --arg bot "$bot_login" --arg sha "$head_sha" '
           add // []
           | [.[]
              | select(
                  .user.login == $bot and
-                 (
-                   .updated_at > $since or
-                   ((.body // "") | contains($sha))
-                 ) and
+                 ((.body // "") | contains($sha)) and
                  ((.body // "") | test("PR Reviewer Guide"; "i"))
                )
             ]

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1029,12 +1029,15 @@ run_pr_agent_review() {
 
   _pr_agent_latest_comment() {
     gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-      | jq -rs --arg bot "$bot_login" --arg since "$since_iso" '
+      | jq -rs --arg bot "$bot_login" --arg since "$since_iso" --arg sha "$head_sha" '
           add // []
           | [.[]
              | select(
                  .user.login == $bot and
-                 .updated_at > $since and
+                 (
+                   .updated_at > $since or
+                   ((.body // "") | contains($sha))
+                 ) and
                  ((.body // "") | test("PR Reviewer Guide"; "i"))
                )
             ]

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1036,13 +1036,17 @@ run_pr_agent_review() {
   fi
 
   _pr_agent_latest_comment() {
+    local match_mode="${1:-strict_sha}"
     gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-      | jq -rs --arg bot "$bot_login" --arg sha "$head_sha" '
+      | jq -rs --arg bot "$bot_login" --arg sha "$head_sha" --arg since "$since_iso" --arg mode "$match_mode" '
           add // []
           | [.[]
              | select(
                  .user.login == $bot and
-                 ((.body // "") | contains($sha)) and
+                 (
+                   ($mode == "strict_sha" and ((.body // "") | contains($sha))) or
+                   ($mode == "recent_or_sha" and (((.body // "") | contains($sha)) or .updated_at > $since))
+                 ) and
                  ((.body // "") | test("PR Reviewer Guide"; "i"))
                )
             ]
@@ -1066,7 +1070,7 @@ run_pr_agent_review() {
   }
 
   # --- Phase 1: Check for an existing PR-Agent summary comment on this HEAD ---
-  comment_body="$(_pr_agent_latest_comment)"
+  comment_body="$(_pr_agent_latest_comment strict_sha)"
   local verdict
   verdict="$(_pr_agent_classify "$comment_body")"
 
@@ -1113,7 +1117,7 @@ run_pr_agent_review() {
 
   # --- Phase 2: Poll until PR-Agent posts its summary comment ---
   while :; do
-    comment_body="$(_pr_agent_latest_comment)"
+    comment_body="$(_pr_agent_latest_comment recent_or_sha)"
     verdict="$(_pr_agent_classify "$comment_body")"
 
     if [ "$verdict" != "none" ]; then


### PR DESCRIPTION

### Added

- **External feedback pipeline: GitHub Discussions staging and triage protocol** (#459): Adds `CONTRIBUTING.md` directing external users to submit feedback via GitHub Discussions, a triage protocol (`07-feedback-triage-protocol.md`) for periodic review and promotion of high-signal community feedback to tracked issues, and the `feedback-staging` label for promoted issues.
- **PR-Agent integration**: self-hosted automated PR review via GitHub Actions using a configurable LLM backend (DeepSeek or Kimi K2.6) — no per-seat pricing; cost is LLM API token usage only. Adds `pr-agent` platform support to `pr-review-loop.sh` with a new `run_pr_agent_review()` adapter, `.github/workflows/pr-agent.yml`, `.pr_agent.toml`, and an integration guide at `docs/workflow/development-workflow/integrations/pr-agent.md`. (#499) Fixes a config race condition where PR-Agent merges TOML settings after its initial fallback check — a TOML-only configuration silently fell back to OpenAI defaults (`gpt-5.4` / `gpt-5.4-mini`) and failed with `dummy_key` auth errors. Pins `config.model`, `config.fallback_models`, `config.model_weak`, `github_action_config.pr_actions`, `auto_review`, `auto_describe`, and `auto_improve` as GHA env vars in the workflow so they take effect before the fallback fires; `model_weak` is also added to `.pr_agent.toml` as defense-in-depth.
- **Add structured retro metrics and meta-retrospective protocol** (#458): Adds a required metrics block step (Step 3d) to the retrospective protocol and a new `06b-meta-retrospective-protocol.md` for periodic verification of improvement effectiveness, along with the initial `docs/workflow/retro-metrics.md` tracking log. Updates agent, skill, and documentation files to reference the metrics block and the meta-retrospective protocol.
- **Add Playwright-based design review for frontend changes** (#450): Adds a `design-reviewer` agent (`.claude/agents/design-reviewer.md` and `.cursor/agents/design-reviewer.md`) that uses `playwright_cli` to render affected pages, capture screenshots, check browser console errors, and run axe-core accessibility checks (WCAG 2.1 Level AA). Protocol 91 Step 7a is updated to invoke the design-reviewer agent during the internal review gate for implementation PRs that include frontend file changes. Gracefully skips when no frontend changes are detected, when the browser automation provider is unavailable, or when the preview URL cannot be reached.
- **Split code review into spec-compliance and code-quality passes** (#449): Step 7a internal review gate now runs two sequential passes for implementation PRs — Pass 1 (Spec Compliance) before Pass 2 (Code Quality). Spec and plan PRs remain single-pass. REVIEW.md Code Review Checklist is split accordingly, and code-reviewer agent/skill files are updated to scope evaluation per pass.
- **Add attempt tracking to reviewer loop prompts** (#448): Fixer agents dispatched on retry (cycle ≥ 2) now receive an attempt-context prefix in their prompt summarising what prior attempts addressed and what findings remain open, enabling them to avoid repeating failing approaches and converge faster. Protocol 91 Step 7 and Protocol 93 both document the injection rule and required prompt format.
- **Add pre-merge setup signal for PRs requiring human configuration** (#367): Adds a `needs-setup` label and a standardised `## Pre-merge Setup` PR body section so agents surface infrastructure dependencies (env vars, secrets, DNS records) at PR readiness time rather than requiring the human to read the diff. Protocol 91 Step 8a now includes a diff-scan heuristic step; protocol 92 defines the label semantics and valid co-label combinations.
- **Add `custom_fields` support for issue tracker config** (#453): Adds a `custom_fields` flat map under `issue_tracker` in `.ai-dev-workflow.yaml` and a `workflow_issue_tracker_custom_field` helper function in `workflow-lib.sh` to read individual custom field values. Updates Linear and GitHub Projects integration docs to document recognised fields.

### Fixed

- **Apply mechanical reviewer findings inline before dispatching a fixer sub-agent** (#495): Protocols 91 (Step 7) and 93 now include an inline fix rule — when all blocking findings are mechanical (single file, fully described, ≤ 5 lines), the orchestrator applies them directly using Edit/Bash tools without spawning a sub-agent, eliminating the 10–20 minute startup overhead for one-line changes.
- **Automate GitHub Projects tracker status update on PR merge** (#463): adds `.github/workflows/update-tracker-on-merge.yml` — a GitHub Actions workflow triggered when a `spec/*`, `implementation-plan/*`, `feature/*`, `fix/*`, `refactor/*`, or `hotfix/*` PR is merged to `develop`. The workflow extracts the issue number from the branch name and updates the GitHub Projects v2 Status field to `Spec Ready`, `Plan Ready`, or `Merged` accordingly; implementation branches also close the linked issue. Eliminates stale statuses that persisted until the next orchestrator run. Requires `GITHUB_PROJECT_NUMBER` and `GITHUB_PROJECT_OWNER` repository variables. Updates `docs/workflow/development-workflow/integrations/github-projects.md` with setup instructions.
- **Branch-type-aware timeout in `pr-review-loop.sh`** (#462): on `spec/*` and `implementation-plan/*` branches, Devin has no trigger condition and exits immediately with `REASON=no_check_run`. The script now automatically reduces `--max-wait` from 1200 s to 60 s and `--poll-interval` from 120 s to 30 s for these branch types when the caller does not pass the respective flag explicitly, preventing 20-minute wait-budget waste on non-implementation PRs.
- **Fixer agents must fix all occurrences of flagged literal values** (#426): added mandatory all-occurrences rule to Protocol 93 fix-cycle guidance — when a reviewer flags a literal value (numeric constant, hex value, identifier, repeated string), fixer agents must `grep -n` the old value across all affected files and fix every occurrence in the same commit before pushing.
- **Mandatory "Automated Reviewer Loop Summary" comment after `pr-review-loop.sh`** (#461): Protocol 91 Step 7 now uses explicit mandatory language ("You MUST post a PR comment...") for the summary comment after every non-skipped exit result (`clean`, `needs_fixes`/escalate, `max_cycles`). The result table is updated to call out the requirement per exit path. Previously, the language was passive and agents omitted the comment when the loop exited cleanly, causing the Step 8c `hasReviewSummary` hard gate to block `ready-for-human-review`.
- **Cross-section consistency check in tech-lead plan protocol** (#427): added mandatory self-check step in `02-generate-implementation-plan-protocol.md` requiring the tech-lead to verify all function names, constants, and decision indices are defined consistently across plan sections before committing; added matching blocking checklist entry in `REVIEW.md` plan review
- **CHANGELOG duplicate section headers after clean parallel merge** (#468): `batch-merge.sh` now runs `check-changelog-duplicate-headers.sh` immediately after each clean merge; if duplicate `### Category` headers are detected within `[Unreleased]`, they are auto-consolidated (bullets merged under the first occurrence, original section order preserved) and the merge commit is amended before pushing. Protocol 94 Step 4.1 documents the new `CHANGELOG_DEDUPED` output field and deduplication behavior.
- **Async bot thread re-check in Step 8a.1** (#486): adds a mandatory 10-second wait + GraphQL re-query after the label readiness checklist passes to catch late-arriving review threads from async bots (e.g., `codex-github`). If new unresolved threads are detected, the agent removes `ready-for-human-review`, adds `needs-fixes`, and returns to Step 7a. Introduces exit code 5 (`late-arriving async bot threads detected`). Uses a shell-interpolated `JQ_FILTER` variable (instead of the unsupported `--jq --arg` flag combination) in both the pre-Check-4 gate and the Step 8a.1 re-check, injecting `CODEX_GITHUB_BOT_LOGIN` at assignment time so the correct bot login is always matched. Strips the `[bot]` suffix from `CODEX_BOT_LOGIN` before use in the JQ filter and in `run_codex_github_review()` before calling `check_unresolved_threads()` — GraphQL `author.login` values omit the `[bot]` suffix that REST API logins carry, so the default `"codex-ai[bot]"` would otherwise never match any Codex-authored thread.
- **`codex-github-reviewer.sh` response detection**: script now polls both `issues/{PR}/comments` (matching bot login with and without `[bot]` suffix) and `pulls/{PR}/reviews` (for finding-based reviews), eliminating the 5-minute timeout on clean PRs and detecting findings immediately instead of waiting for a timeout
- **`codex-github-reviewer.sh` retry-on-timeout** (#497): default `--max-wait` raised from 300 s to 600 s (10 min) per attempt, and a new `--max-retriggers` option (default `1`) automatically re-posts the trigger comment once after a timeout before exiting. Handles the recurring failure mode where Codex silently drops the first `@codex review` request — a re-post usually produces a response. Worst-case wait is `(MAX_RETRIGGERS + 1) * MAX_WAIT` (default 20 min); set `--max-retriggers 0` to keep the previous single-attempt behavior.

### Changed

- **Retrospective command dispatches agent; balanced model tier** (#457): `/retrospective` (Claude Code and Cursor) now dispatches the `retrospective` agent instead of running inline. The `retrospective` agent model is upgraded from `economy` (`claude-haiku-4-5-20251001` / `fast`) to `balanced` (`claude-sonnet-4-6` / `inherit`) — synthesis and pattern-recognition across multiple PRs requires a capable model.
- **Default internal reviewer switched from `codex` to `codex-github`**: replaced the `codex` CLI reviewer (unreachable from Claude Code and Cursor subagent runners, causing a warning on every automated PR) with `codex-github` (Codex GitHub App — universally reachable via `gh` CLI from any runner context) in the default `.ai-dev-workflow.yaml` `internal_reviewers` list. Requires the Codex GitHub App to be installed on the repository.
- **`codex-github` promoted from `internal_reviewers` (Step 7a) to `review.platforms` (Step 7)** (#486): `codex-github` now behaves like `greptile` and `devin` — handled deterministically by `pr-review-loop.sh` with idempotent pre-check, trigger, poll, and result phases. Removes the async race condition inherent in the synchronous internal-reviewer gate. Adds `run_codex_github_review()` to `pr-review-loop.sh`, updates `bot_login_for_platform()` to return the configured bot login, moves the `codex-github` entry from `internal_reviewers` to `platforms` in `.ai-dev-workflow.yaml`, and removes `codex-github` from the Step 7a reviewer dispatch table and reachability table in Protocol 91.
- **Exit code contract table in Protocol 91 Step 8a** (#433): added a prominent table documenting exit codes 0–4 at the top of the Label Readiness Checklist to prevent future exit code collisions
- **`product-manager` agent upgraded to `premium` model tier** (#456): spec writing is the highest-leverage task in the pipeline — a weak spec cascades into worse plans and worse implementations. Updated `agent-model-config.md` rationale, model IDs in `.claude/agents/product-manager.md` and `.cursor/agents/product-manager.md` (to `claude-opus-4-7`), and Codex skill tier in `.codex/skills/workflow-spec-writer/SKILL.md` (to `premium`).

