### PR TITLE
chore: backport v0.25.1 hotfix to develop (codex-github-reviewer false positives)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-05-06
+
+### Fixed
+
+- `codex-github-reviewer.sh`: verdict parsing now pre-filters negation lines (e.g. "No blocking issues found") before the blocking-marker check, eliminating false NEEDS_REVISION verdicts on clean Codex responses; also adds "no blocking issues" as an explicit approval signal
+- `codex-github-reviewer.sh`: idempotency guard now uses `contains($sha)` instead of `test($sha)` in jq for literal substring matching instead of unanchored regex matching
+
 ## [0.25.0] - 2026-05-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `codex-github-reviewer.sh`: verdict parsing now pre-filters negation lines (e.g. "No blocking issues found") before the blocking-marker check, eliminating false NEEDS_REVISION verdicts on clean Codex responses; also adds "no blocking issues" as an explicit approval signal
+- `codex-github-reviewer.sh`: verdict parsing now requires a colon after "blocking issues" (matching list form "blocking issues: …") to disambiguate from clean responses like "No blocking issues found"; also adds "no blocking issues" as an explicit approval signal, eliminating false NEEDS_REVISION verdicts on clean Codex responses
 - `codex-github-reviewer.sh`: idempotency guard now uses `contains($sha)` instead of `test($sha)` in jq for literal substring matching instead of unanchored regex matching
 
 ## [0.25.0] - 2026-05-06

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -31,13 +31,14 @@
 #
 # Verdict parsing (three-path, blocking markers checked first per safe-fail):
 #   1. Blocking markers present → NEEDS_REVISION (exit 1)
-#      Markers (case-insensitive): "changes requested", "blocking issues/finding",
-#      "blocking:", "must fix", "action required", "required:", "❌"
-#      Note: bare "blocking" is excluded to avoid false positives on
-#      "no blocking issues found" — use specific phrases instead.
+#      Markers (case-insensitive): "changes requested", "blocking issues:" (colon
+#      required), "blocking finding", "blocking:", "must fix", "action required",
+#      "required:", "❌"
+#      Note: "blocking issues:" (with colon) disambiguates the list form from
+#      "no blocking issues found"; bare "blocking" excluded (too broad).
 #   2. Approval signals present → APPROVED (exit 0)
 #      Signals (case-insensitive): "approved", "lgtm", "looks good",
-#      "didn't find any major issues" (Codex-specific clean phrase)
+#      "didn't find any major issues", "no blocking issues" (Codex clean phrases)
 #   3. Neither found (unrecognized format) → safe-fails to NEEDS_REVISION (exit 1)
 #
 # Response source detection (two sources polled each cycle):
@@ -329,18 +330,14 @@ while true; do
     # Three-path classification (per spec BR-4 and implementation plan risk table).
     # Blocking markers are checked FIRST (safe-fail: a false NEEDS_REVISION that
     # triggers an unnecessary fix cycle is safer than a false APPROVED that
-    # silently ignores blocking findings). To avoid false positives on negated
-    # phrases like "No blocking issues found", we pre-filter out lines containing
-    # a leading "no" or "not" before the blocking-marker check, then test those
-    # same phrases as explicit approval signals in the second branch.
-    # The bare word "blocking" is excluded because it is too broad; the phrases
-    # below are more targeted.
+    # silently ignores blocking findings). The bare word "blocking" is excluded
+    # because it is too broad; the phrases below are more targeted.
     #
     # 1. Blocking markers present → NEEDS_REVISION (exit 1)      [checked first]
     #    Blocking markers (case-insensitive): "changes requested",
-    #    "blocking issues", "blocking finding", "blocking:", "must fix",
-    #    "action required", "required:", "❌"
-    #    (checked on negation-filtered response to avoid "No blocking issues found")
+    #    "blocking issues:" (colon required to distinguish from "no blocking issues
+    #    found"), "blocking finding", "blocking:", "must fix", "action required",
+    #    "required:", "❌"
     #
     # 2. Explicit approval signals present → APPROVED (exit 0)   [checked second]
     #    Approval signals: "approved", "lgtm", "looks good",
@@ -350,10 +347,15 @@ while true; do
     #    Safe-fail: default to NEEDS_REVISION when the format is unrecognized to
     #    avoid incorrectly approving a response that is a rejection in an
     #    unexpected format (per spec risk mitigation for BR-4).
+    #
+    # Note on "blocking issues" disambiguation: the phrase "blocking issues" appears
+    # in both blocking context ("blocking issues: 1. foo") and clean context ("no
+    # blocking issues found"). Requiring a colon after "issues" targets the blocking
+    # list form while leaving the clean form to match the APPROVED branch via
+    # "no blocking issues". This avoids false positives without line-level filtering
+    # (which would risk missing a genuine marker on the same line as a negation).
 
-    # Strip lines containing clear negation patterns before the blocking check.
-    BOT_RESPONSE_FOR_BLOCKING=$(echo "$BOT_RESPONSE" | grep -viE "(^|[[:space:]])no[[:space:]]+(blocking|major)")
-    if echo "$BOT_RESPONSE_FOR_BLOCKING" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+    if echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
       echo "VERDICT: NEEDS_REVISION"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -195,13 +195,15 @@ echo "INFO: Bot login (plain, for PR-comment matching): $BOT_LOGIN_PLAIN"
 # Capture the idempotency check to a temp file to avoid SIGPIPE under pipefail.
 # Use 'jq --arg' for safe variable binding — avoids jq injection if the trigger
 # phrase or SHA contain jq-special characters (double quote, backslash).
+# Use contains() not test() for SHA matching: contains() is a literal substring
+# check, while test() interprets its argument as a regex (unanchored substring).
 # Note: `]` must appear first in the bracket expression to be treated as literal.
 IDEM_STDERR=$(mktemp)
 IDEM_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>"$IDEM_STDERR" \
   | jq -r --arg sha "$CURRENT_SHA" --arg marker "review triggered by workflow runner" --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" \
-    '.[] | select(.user.login != $bot and .user.login != $bot_plain) | select((.body | test($sha)) and (.body | ascii_downcase | contains($marker))) | {id: .id, created_at: .created_at, body: .body}' \
+    '.[] | select(.user.login != $bot and .user.login != $bot_plain) | select((.body | contains($sha)) and (.body | ascii_downcase | contains($marker))) | {id: .id, created_at: .created_at, body: .body}' \
   > "$IDEM_TMPFILE"; then
   TRIGGER_COMMENT_INFO=$(head -c 2000 "$IDEM_TMPFILE")
 else
@@ -327,33 +329,37 @@ while true; do
     # Three-path classification (per spec BR-4 and implementation plan risk table).
     # Blocking markers are checked FIRST (safe-fail: a false NEEDS_REVISION that
     # triggers an unnecessary fix cycle is safer than a false APPROVED that
-    # silently ignores blocking findings). Note: even specific phrases like
-    # "blocking issues" can still match within negated context ("No blocking
-    # issues found"). This is an accepted safe-fail trade-off — the result is
-    # an unnecessary fix cycle, not a missed rejection. The bare word "blocking"
-    # is excluded because it is too broad; the phrases below are more targeted.
+    # silently ignores blocking findings). To avoid false positives on negated
+    # phrases like "No blocking issues found", we pre-filter out lines containing
+    # a leading "no" or "not" before the blocking-marker check, then test those
+    # same phrases as explicit approval signals in the second branch.
+    # The bare word "blocking" is excluded because it is too broad; the phrases
+    # below are more targeted.
     #
     # 1. Blocking markers present → NEEDS_REVISION (exit 1)      [checked first]
     #    Blocking markers (case-insensitive): "changes requested",
     #    "blocking issues", "blocking finding", "blocking:", "must fix",
     #    "action required", "required:", "❌"
+    #    (checked on negation-filtered response to avoid "No blocking issues found")
     #
     # 2. Explicit approval signals present → APPROVED (exit 0)   [checked second]
     #    Approval signals: "approved", "lgtm", "looks good",
-    #    "didn't find any major issues" (Codex-specific clean phrase)
+    #    "didn't find any major issues", "no blocking issues" (Codex clean phrases)
     #
     # 3. Neither found (unrecognized response format) → NEEDS_REVISION (exit 1)
     #    Safe-fail: default to NEEDS_REVISION when the format is unrecognized to
     #    avoid incorrectly approving a response that is a rejection in an
     #    unexpected format (per spec risk mitigation for BR-4).
 
-    if echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+    # Strip lines containing clear negation patterns before the blocking check.
+    BOT_RESPONSE_FOR_BLOCKING=$(echo "$BOT_RESPONSE" | grep -viE "(^|[[:space:]])no[[:space:]]+(blocking|major)")
+    if echo "$BOT_RESPONSE_FOR_BLOCKING" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
       echo "VERDICT: NEEDS_REVISION"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 1
-    elif echo "$BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues)"; then
+    elif echo "$BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
       echo "VERDICT: APPROVED"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"


### PR DESCRIPTION
## Summary

Backport of hotfix v0.25.1 (PR #506) to `develop`.

- Fixes false-positive `NEEDS_REVISION` in `codex-github-reviewer.sh`: colon-anchored `blocking issues?:` regex disambiguates the list form from "No blocking issues found"; adds `no blocking issues?` as an explicit `APPROVED` signal
- Fixes idempotency guard: `contains($sha)` instead of `test($sha)` for literal substring matching

## Commits cherry-picked from main

- `e9e429e` — fix(codex-github-reviewer): fix false-positive NEEDS_REVISION and unanchored SHA match
- `876c318` — fix(codex-github-reviewer): use colon-anchored blocking issues regex to avoid false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)