### PR TITLE
feat(workflow): support CodeRabbit as Step 7a internal reviewer (#528)

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -52,6 +52,13 @@ review:
   #                     spec/*               -> workflow-spec-reviewer
   #                     implementation-plan/* -> workflow-plan-reviewer
   #                     feature/*/refactor/*/fix/*/hotfix/* -> workflow-code-reviewer
+  #   coderabbit  — triggers CodeRabbit GitHub App auto-review on the draft PR
+  #                 (same mechanism as Step 7 but on a draft PR before non-draft
+  #                 conversion). Requires: App installed, auto_review.enabled: true
+  #                 in .coderabbit.yaml, and draft PRs not filtered out by the App.
+  #                 Reachability is determined at runtime by checking App activity
+  #                 on the repository. See docs/workflow/development-workflow/
+  #                 integrations/coderabbit.md Step 7a section for setup details.
   #
   # Runner-context constraint:
   #   'codex' as a direct CLI reviewer is NOT reliably reachable from automated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Support CodeRabbit as internal reviewer (Step 7a)** (#528): Add `coderabbit` as a supported value in `review.internal_reviewers` in `.ai-dev-workflow.yaml`, allowing CodeRabbit to run as a Step 7a draft-PR internal reviewer before non-draft conversion. Updates Protocol 91 Step 7a (supported values list, reachability classification table, reviewer dispatch map) and adds a "Step 7a — Internal Reviewer" section to `docs/workflow/development-workflow/integrations/coderabbit.md`.
+
 ### Fixed
 
 - **Add mandatory main-tree return rule to `item-orchestrator` and `developer` agents**: when dispatched without worktree isolation (`BATCH_CONTEXT=false` or absent), the agent switches the main working tree to the feature branch but did not switch back before returning, causing Protocol 90 Step 5.2 to fire a "wrong branch + clean" auto-correct on every subsequent item in a serial batch. Fixed by adding an explicit main-tree return rule (switch back to the integration branch, verify with `git rev-parse --abbrev-ref HEAD`, handle blocked switches via commit/stash) to `.claude/agents/item-orchestrator.md`, `.claude/agents/developer.md`, `.cursor/agents/item-orchestrator.md`, `.cursor/agents/developer.md`, and the Codex `workflow-item-orchestrator` and `workflow-implementer` skills.

--- a/docs/workflow/development-workflow/integrations/coderabbit.md
+++ b/docs/workflow/development-workflow/integrations/coderabbit.md
@@ -82,16 +82,7 @@ CodeRabbit auto-reviews on every push when `auto_review.enabled` is `true`. No t
 
 ### Severity Classification
 
-Findings are classified identically to Step 7:
-
-| Severity marker | Classification |
-| --- | --- |
-| `🔴 Critical` | Blocking |
-| `🟠 Major` | Blocking |
-| `🟡 Minor` | Suggestion (non-blocking) |
-| `🟢 Low` or no marker | Suggestion (non-blocking) |
-
-`Critical` and `Major` findings are blocking — the runner applies fixes and re-runs the internal review cycle. `Minor`, `Low`, and unmarked findings are non-blocking suggestions that the runner may optionally address but that do not prevent Step 7a from approving.
+Findings are classified using the same severity matrix as [Step 7](#blocking-vs-suggestion-classification). For Step 7a, only `Critical` and `Major` findings are blocking — the runner applies fixes and re-runs the internal review cycle. `Minor`, `Low`, and unmarked findings are non-blocking suggestions that the runner may optionally address but that do not prevent Step 7a from approving.
 
 ### Fix-Cycle Limit
 

--- a/docs/workflow/development-workflow/integrations/coderabbit.md
+++ b/docs/workflow/development-workflow/integrations/coderabbit.md
@@ -47,6 +47,77 @@ To enable CodeRabbit as a Step 7 automated PR reviewer platform:
 
 ---
 
+## Step 7a — Internal Reviewer (Draft PRs)
+
+CodeRabbit can act as a Step 7a internal reviewer, running on a draft PR before it is converted to non-draft. This uses the same GitHub App auto-review mechanism as Step 7, but is triggered on a draft PR during the internal review gate.
+
+### Configuration
+
+Add `coderabbit` to `review.internal_reviewers` in `.ai-dev-workflow.yaml`:
+
+```yaml
+review:
+  internal_reviewers:
+    - claude
+    - coderabbit
+```
+
+All reviewers in the list must APPROVE before `gh pr ready` is called. Reviewers run sequentially in the listed order.
+
+### Draft-PR Requirement
+
+`reviews.auto_review.enabled: true` must be set in `.coderabbit.yaml` for CodeRabbit to auto-review draft PRs. If the CodeRabbit App configuration filters out draft PRs, the runner classifies `coderabbit` as unreachable in Step 7a (BR-5).
+
+Ensure your `.coderabbit.yaml` is configured to allow draft PR reviews:
+
+```yaml
+reviews:
+  auto_review:
+    enabled: true
+```
+
+### Invocation
+
+CodeRabbit auto-reviews on every push when `auto_review.enabled` is `true`. No trigger comment is needed. The runner waits for a `coderabbitai[bot]` review posted after the HEAD commit timestamp. This is identical to the Step 7 mechanism but applied to a draft PR.
+
+### Severity Classification
+
+Findings are classified identically to Step 7:
+
+| Severity marker | Classification |
+| --- | --- |
+| `🔴 Critical` | Blocking |
+| `🟠 Major` | Blocking |
+| `🟡 Minor` | Suggestion (non-blocking) |
+| `🟢 Low` or no marker | Suggestion (non-blocking) |
+
+`Critical` and `Major` findings are blocking — the runner applies fixes and re-runs the internal review cycle. `Minor`, `Low`, and unmarked findings are non-blocking suggestions that the runner may optionally address but that do not prevent Step 7a from approving.
+
+### Fix-Cycle Limit
+
+CodeRabbit as an internal reviewer is subject to the same `max_internal_review_cycles` limit as other internal reviewers (default: 5). When the cycle count reaches the limit with unresolved blocking findings, Step 7a escalates to human rather than continuing to loop.
+
+### Availability Check
+
+Before dispatching, the runner performs a runtime availability check to classify `coderabbit` as `reachable` or `unreachable`:
+
+1. **App installation signal**: Check whether `coderabbitai[bot]` has any prior activity on the repository via `gh api repos/{owner}/{repo}/installation` or by inspecting recent PR comments for `coderabbitai[bot]` posts.
+2. **Draft-PR configuration check**: Verify that `.coderabbit.yaml` sets `reviews.auto_review.enabled: true` and does not otherwise restrict reviews to non-draft PRs.
+
+If either check fails, `coderabbit` is classified as `unreachable`. The configured `internal_reviewers_unavailable_policy` then determines whether to proceed with the remaining reachable reviewers (`warn`, the default) or hard-fail the Step 7a gate (`fail-if-any-unavailable`).
+
+### Troubleshooting
+
+| Symptom | Cause | Resolution |
+| --- | --- | --- |
+| `coderabbit` classified as `unreachable` — warning comment posted | CodeRabbit GitHub App is not installed on the repository | Install the CodeRabbit GitHub App at [coderabbit.ai](https://www.coderabbit.ai) and verify it has access to the repository |
+| `coderabbit` classified as `unreachable` — `auto_review.enabled: false` | `.coderabbit.yaml` has auto-review disabled | Set `reviews.auto_review.enabled: true` in `.coderabbit.yaml` |
+| `coderabbit` classified as `unreachable` — draft PRs not enabled | CodeRabbit App configuration or `.coderabbit.yaml` filters out draft PRs | Confirm the CodeRabbit App settings permit draft PR reviews and that `.coderabbit.yaml` does not restrict to non-draft only |
+| All Step 7a reviewers unreachable — hard-fail | No reachable internal reviewers available | Run Step 7a from a context where at least one reviewer is reachable, or temporarily override `review.internal_reviewers` via `.tmp/template-config.json` to remove unreachable reviewers |
+| CodeRabbit does not post a review after push | App installed but auto-review trigger not firing | Push a non-draft commit, confirm the App is active, and check the CodeRabbit dashboard for any rate limiting or quota issues |
+
+---
+
 ## Setup (Path B only)
 
 ### 1. Install the CodeRabbit GitHub App

--- a/docs/workflow/development-workflow/integrations/coderabbit.md
+++ b/docs/workflow/development-workflow/integrations/coderabbit.md
@@ -105,7 +105,7 @@ If either check fails, `coderabbit` is classified as `unreachable`. The configur
 | `coderabbit` classified as `unreachable` — `auto_review.enabled: false` | `.coderabbit.yaml` has auto-review disabled | Set `reviews.auto_review.enabled: true` in `.coderabbit.yaml` |
 | `coderabbit` classified as `unreachable` — draft PRs not enabled | CodeRabbit App configuration or `.coderabbit.yaml` filters out draft PRs | Confirm the CodeRabbit App settings permit draft PR reviews and that `.coderabbit.yaml` does not restrict to non-draft only |
 | All Step 7a reviewers unreachable — hard-fail | No reachable internal reviewers available | Run Step 7a from a context where at least one reviewer is reachable, or temporarily override `review.internal_reviewers` via `.tmp/template-config.json` to remove unreachable reviewers |
-| CodeRabbit does not post a review after push | App installed but auto-review trigger not firing | Push a non-draft commit, confirm the App is active, and check the CodeRabbit dashboard for any rate limiting or quota issues |
+| CodeRabbit does not post a review after push | App installed but auto-review trigger not firing | Push a new commit to the draft PR, confirm the App is active, and check the CodeRabbit dashboard for any rate limiting or quota issues |
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -754,7 +754,7 @@ No warning comment is posted for reviewers intentionally removed by the override
 
 ### Runtime-availability check
 
-Before dispatching any reviewer, classify each entry in the resolved list as `reachable` or `unreachable` based on the runner's execution context. The check is deterministic and requires no external network call — runner identity is a sufficient proxy for reviewer reachability (see [codex-reviewer-runtime-fallback spec](../../../specs/developments/20260417203329_codex-reviewer-runtime-fallback/1_codex-reviewer-runtime-fallback_specs.md) — BR-1 and BR-8).
+Before dispatching any reviewer, classify each entry in the resolved list as `reachable` or `unreachable`. For `claude` and `codex`, the check is deterministic and requires no external network call — runner identity is a sufficient proxy for reviewer reachability (see [codex-reviewer-runtime-fallback spec](../../../specs/developments/20260417203329_codex-reviewer-runtime-fallback/1_codex-reviewer-runtime-fallback_specs.md) — BR-1 and BR-8). For `coderabbit`, reachability is determined at runtime via an App installation check (see below).
 
 #### Reachability classification table
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -742,7 +742,7 @@ Example `.tmp/template-config.json` override format:
 }
 ```
 
-Supported reviewer values: `claude`, `codex`.
+Supported reviewer values: `claude`, `codex`, `coderabbit`.
 
 If neither file defines `internal_reviewers`, fall back to running the stage-appropriate reviewer once (default behavior: `claude`).
 
@@ -758,12 +758,14 @@ Before dispatching any reviewer, classify each entry in the resolved list as `re
 
 #### Reachability classification table
 
-| Runner context | `claude` reachable? | `codex` reachable? |
-|---|---|---|
-| Claude Code (direct human session) | Yes | No |
-| Claude Code subagent (dispatched by orchestrator) | Yes | No |
-| Codex runner / Codex skill | Yes | Yes |
-| Direct human (shell / CI with `gh`) | Yes | Yes |
+| Runner context | `claude` reachable? | `codex` reachable? | `coderabbit` reachable? |
+|---|---|---|---|
+| Claude Code (direct human session) | Yes | No | Determined at runtime (App check) |
+| Claude Code subagent (dispatched by orchestrator) | Yes | No | Determined at runtime (App check) |
+| Codex runner / Codex skill | Yes | Yes | Determined at runtime (App check) |
+| Direct human (shell / CI with `gh`) | Yes | Yes | Determined at runtime (App check) |
+
+To determine `coderabbit` reachability, the runner checks whether `coderabbitai[bot]` has any prior activity on the repository (App installation signal — via `gh api repos/{owner}/{repo}/installation` or by checking the PR for a prior CodeRabbit comment), **and** confirms that `.coderabbit.yaml` does not disable auto-review or restrict reviews to non-draft PRs (`reviews.auto_review.enabled: true` required). If either check fails, classify `coderabbit` as `unreachable` — the draft-PR restriction in `.coderabbit.yaml` is treated as equivalent to the App not being installed (BR-5 consequence).
 
 #### Policy resolution
 
@@ -825,6 +827,9 @@ For each reviewer in the resolved list, dispatch the stage-appropriate agent:
 | `codex` | `spec/*` | `workflow-spec-reviewer` Codex skill against `REVIEW.md` |
 | `codex` | `implementation-plan/*` | `workflow-plan-reviewer` Codex skill against `REVIEW.md` |
 | `codex` | `feature/*` / `refactor/*` / `fix/*` / `hotfix/*` | `workflow-code-reviewer` Codex skill against `REVIEW.md` |
+| `coderabbit` | `spec/*` | Trigger CodeRabbit via push (auto-review); poll for `coderabbitai[bot]` response — see `coderabbit.md` Step 7a section |
+| `coderabbit` | `implementation-plan/*` | Trigger CodeRabbit via push (auto-review); poll for `coderabbitai[bot]` response — see `coderabbit.md` Step 7a section |
+| `coderabbit` | `feature/*` / `refactor/*` / `fix/*` / `hotfix/*` | Trigger CodeRabbit via push (auto-review); poll for `coderabbitai[bot]` response — see `coderabbit.md` Step 7a section |
 
 ### Branch-type detection
 


### PR DESCRIPTION
## Summary

- Add `coderabbit` as a supported value in `review.internal_reviewers` in `.ai-dev-workflow.yaml`
- Update Protocol 91 Step 7a: supported values list, reachability classification table (new `coderabbit` column with runtime App-check annotation), and reviewer dispatch map (three new `coderabbit` rows)
- Add "Step 7a — Internal Reviewer (Draft PRs)" section to `docs/workflow/development-workflow/integrations/coderabbit.md` covering configuration, draft-PR requirement, invocation, severity classification, fix-cycle limit, availability check, and troubleshooting
- Update `.ai-dev-workflow.yaml` comment block with `coderabbit` internal reviewer description

## Closes

Closes #528

## Test plan

- [ ] Protocol 91 Step 7a "Supported reviewer values" sentence includes `coderabbit`
- [ ] Reachability classification table has a `coderabbit` column with runtime App-check annotation for all four runner contexts
- [ ] Explanatory paragraph after reachability table describes App installation check and draft-PR config check
- [ ] Reviewer dispatch map has `coderabbit` rows for all three branch-prefix groups (`spec/*`, `implementation-plan/*`, `feature/*`/`refactor/*`/`fix/*`/`hotfix/*`)
- [ ] `coderabbit.md` has a "Step 7a — Internal Reviewer (Draft PRs)" section with required subsections
- [ ] `.ai-dev-workflow.yaml` comment block lists `coderabbit` with invocation description, after `codex` entry and before "Runner-context constraint"
- [ ] No change to Step 7 (external reviewer loop) behaviour — backward compatible
- [ ] markdownlint-cli2 passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CodeRabbit added as an automated internal reviewer for draft pull requests, with runtime availability detection and configurable fallback policies.

* **Documentation**
  * Added setup and configuration guidance for enabling CodeRabbit auto-reviews.
  * Updated workflow protocol docs to include CodeRabbit routing, reachability behavior, and severity-based blocking rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/550)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->