### PR TITLE
feat(pr-review-loop): AI evaluation layer for PR-Agent "Possible Issue" findings (#562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Add AI evaluation layer for PR-Agent "Possible Issue" findings** (#562): When
+  PR-Agent returns clean with a "Possible Issue" advisory label, the reviewer loop
+  now dispatches the code-reviewer agent to evaluate the finding. If a real bug is
+  found the agent pushes a fix and the loop re-runs (exit code 3 / `RESULT=needs_rerun`);
+  if the finding is acceptable the agent posts a substantive acknowledgment comment and
+  the loop proceeds clean. Other advisory labels remain non-blocking and unevaluated.
+  A fallback to advisory-only behaviour is preserved when the agent is unavailable
+  (`POSSIBLE_ISSUE_EVAL_OUTCOME=unavailable`). Protocols 91 Step 7 and 93 "Procedure
+  (per PR)" are updated to document the new dispatch contract.
 - **Support CodeRabbit as internal reviewer (Step 7a)** (#528): Add `coderabbit` as a supported value in `review.internal_reviewers` in `.ai-dev-workflow.yaml`, allowing CodeRabbit to run as a Step 7a draft-PR internal reviewer before non-draft conversion. Updates Protocol 91 Step 7a (supported values list, reachability classification table, reviewer dispatch map) and adds a "Step 7a — Internal Reviewer" section to `docs/workflow/development-workflow/integrations/coderabbit.md`.
 
 ### Fixed

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1099,7 +1099,50 @@ Interpret the result as follows:
 | `skipped` | Continue to Step 7b (implementation PRs) then Step 8 (no summary comment posted — Step 8c skips the check) |
 | `needs_fixes` and `cycle < max_cycles` | Increment `cycle`, dispatch the matching fixer agent, wait for a push, then run Step 7 again |
 | `needs_fixes` and `cycle >= max_cycles` | Pass `--post-final-summary` to the final invocation — the script posts the summary automatically. Then escalate to human |
+| `needs_rerun` (exit code 3) | PR-Agent returned clean with a "Possible Issue" advisory. See "PR-Agent 'Possible Issue' evaluation" below — dispatch the code-reviewer agent, set `POSSIBLE_ISSUE_EVAL_OUTCOME`, and re-invoke the loop |
 | `escalate` | Summary comment posted automatically by the script. Escalate to human |
+
+### PR-Agent "Possible Issue" evaluation
+
+When `pr-review-loop.sh` exits with code 3 and `RESULT=needs_rerun`, PR-Agent
+classified the PR as `clean` but included a "Possible Issue" advisory label. The
+script emits two structured keys for the Work Item Runner to consume:
+
+- `PR_AGENT_POSSIBLE_ISSUE_EVAL` — format: `<pr_number>@@@<branch_name>`
+- `PR_AGENT_POSSIBLE_ISSUE_BODY` — the full PR-Agent comment body (newlines escaped)
+
+**Required sequence:**
+
+1. Read `PR_AGENT_POSSIBLE_ISSUE_BODY` from the script output and unescape it
+   (replace `\n` with real newlines).
+2. Dispatch the `code-reviewer` agent with the PR number, branch, PR-Agent comment
+   body, and the PR diff (`gh pr diff <pr_number>`). Instruct the agent: determine
+   whether the finding is a real bug or acceptable; if a real bug, push a fix commit;
+   if acceptable, post a substantive acknowledgment comment explaining the reasoning.
+3. After the agent finishes, set `POSSIBLE_ISSUE_EVAL_OUTCOME` and re-invoke the loop:
+
+   ```bash
+   # Agent pushed a fix:
+   POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed \
+     ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
+
+   # Agent acknowledged (finding is acceptable):
+   POSSIBLE_ISSUE_EVAL_OUTCOME=acknowledged \
+     ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
+
+   # Agent unavailable / timed out:
+   POSSIBLE_ISSUE_EVAL_OUTCOME=unavailable \
+     ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
+   ```
+
+4. On re-invocation, the script reads `POSSIBLE_ISSUE_EVAL_OUTCOME` from the
+   environment and exits 0 (`RESULT=clean`) for all three values. For `fix_pushed`,
+   re-run the full loop on the new HEAD as a normal re-run cycle.
+
+This evaluation step is not counted against the orchestrator's `cycle` counter. If
+the agent is unavailable (`POSSIBLE_ISSUE_EVAL_OUTCOME=unavailable` or empty), the
+script falls back to advisory-only clean and logs a warning to stderr. For full
+details see `93-automated-reviewer-loop-protocol.md`.
 
 **Step 7a summary (Internal Review Gate) is still agent-owned.** The script-posted summary covers Step 7 (external automated reviewers) only. The Step 7a summary comment (`### Step 7a Internal Review Gate Summary`) must still be posted by the orchestrator/agent after the internal review gate completes. Do not conflate the two: they serve different verification purposes and are checked by different gates.
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1104,28 +1104,32 @@ Interpret the result as follows:
 
 ### PR-Agent "Possible Issue" evaluation
 
-When `pr-review-loop.sh` exits with code 3 and `RESULT=needs_rerun`, PR-Agent
-classified the PR as `clean` but included a "Possible Issue" advisory label. The
-script emits two structured keys for the Work Item Runner to consume:
+When `pr-review-loop.sh` returns `RESULT=clean` AND the output contains
+`PR_AGENT_POSSIBLE_ISSUE_EVAL`, PR-Agent classified the PR as `clean` but included
+a "Possible Issue" advisory label. The script emits two structured keys so the
+orchestrator can dispatch a code-reviewer agent before declaring the result final:
 
 - `PR_AGENT_POSSIBLE_ISSUE_EVAL` — format: `<pr_number>@@@<branch_name>`
 - `PR_AGENT_POSSIBLE_ISSUE_BODY` — the full PR-Agent comment body (newlines escaped)
 
+Note: `RESULT=needs_rerun` (exit code 3) is only emitted on a **re-invocation** after
+the code-reviewer agent pushed a fix (i.e., when `POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed`
+is set in the environment). The first-pass result is always `RESULT=clean` with
+`PR_AGENT_POSSIBLE_ISSUE_EVAL` in the output.
+
 **Required sequence:**
 
-1. Read `PR_AGENT_POSSIBLE_ISSUE_BODY` from the script output and unescape it
+1. After any `RESULT=clean` exit, check whether `PR_AGENT_POSSIBLE_ISSUE_EVAL` is
+   present in the script output. If present, do not declare the result clean yet.
+2. Read `PR_AGENT_POSSIBLE_ISSUE_BODY` from the script output and unescape it
    (replace `\n` with real newlines).
-2. Dispatch the `code-reviewer` agent with the PR number, branch, PR-Agent comment
+3. Dispatch the `code-reviewer` agent with the PR number, branch, PR-Agent comment
    body, and the PR diff (`gh pr diff <pr_number>`). Instruct the agent: determine
    whether the finding is a real bug or acceptable; if a real bug, push a fix commit;
    if acceptable, post a substantive acknowledgment comment explaining the reasoning.
-3. After the agent finishes, set `POSSIBLE_ISSUE_EVAL_OUTCOME` and re-invoke the loop:
+4. After the agent finishes, set `POSSIBLE_ISSUE_EVAL_OUTCOME` and re-invoke the loop:
 
    ```bash
-   # Agent pushed a fix:
-   POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed \
-     ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
-
    # Agent acknowledged (finding is acceptable):
    POSSIBLE_ISSUE_EVAL_OUTCOME=acknowledged \
      ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
@@ -1133,16 +1137,22 @@ script emits two structured keys for the Work Item Runner to consume:
    # Agent unavailable / timed out:
    POSSIBLE_ISSUE_EVAL_OUTCOME=unavailable \
      ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
+
+   # Agent pushed a fix — re-invoke with fix_pushed so the script signals needs_rerun:
+   POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed \
+     ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
    ```
 
-4. On re-invocation, the script reads `POSSIBLE_ISSUE_EVAL_OUTCOME` from the
-   environment and exits 0 (`RESULT=clean`) for all three values. For `fix_pushed`,
-   re-run the full loop on the new HEAD as a normal re-run cycle.
+5. On re-invocation with `acknowledged` or `unavailable`, the script reads
+   `POSSIBLE_ISSUE_EVAL_OUTCOME` from the environment, exits 0, and emits `RESULT=clean`.
+   On re-invocation with `fix_pushed`, the script exits 3 with `RESULT=needs_rerun` —
+   the orchestrator then does a full fresh re-run (without any `POSSIBLE_ISSUE_EVAL_OUTCOME`)
+   on the new HEAD.
 
 This evaluation step is not counted against the orchestrator's `cycle` counter. If
-the agent is unavailable (`POSSIBLE_ISSUE_EVAL_OUTCOME=unavailable` or empty), the
-script falls back to advisory-only clean and logs a warning to stderr. For full
-details see `93-automated-reviewer-loop-protocol.md`.
+the agent is unavailable (`POSSIBLE_ISSUE_EVAL_OUTCOME=unavailable` or empty on first
+pass), the script falls back to advisory-only clean and logs a warning to stderr. For
+full details see `93-automated-reviewer-loop-protocol.md`.
 
 **Step 7a summary (Internal Review Gate) is still agent-owned.** The script-posted summary covers Step 7 (external automated reviewers) only. The Step 7a summary comment (`### Step 7a Internal Review Gate Summary`) must still be posted by the orchestrator/agent after the internal review gate completes. Do not conflate the two: they serve different verification purposes and are checked by different gates.
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -360,6 +360,79 @@ When a reviewer flags a specific literal value — a numeric constant, hex value
 
 This rule applies to any value type: version numbers, timeout values, port numbers, hex color codes, string constants, label names, section headers, or any other repeated literal. If a reviewer flags one instance, treat it as a signal to fix all instances — the reviewer will check all occurrences on the next cycle and finding any remaining instance resets the review loop.
 
+### PR-Agent "Possible Issue" evaluation step
+
+When `pr-review-loop.sh` returns exit code 3 with `RESULT=needs_rerun`, it means
+PR-Agent classified the PR as `clean` but the review comment contained at least one
+"Possible Issue" advisory label. The script has emitted a structured dispatch key so
+the orchestrator can evaluate the finding with a code-reviewer agent before the loop
+declares the final result.
+
+#### When this step triggers
+
+`RESULT=needs_rerun` is set only when all of the following are true:
+
+- The `pr-agent` platform is configured and ran for this PR.
+- PR-Agent's comment classified as `clean` (no hard-blocker labels).
+- The comment contained at least one `Possible Issue` advisory label (case-insensitive).
+- `POSSIBLE_ISSUE_EVAL_OUTCOME` was not already set to `acknowledged`, `fix_pushed`,
+  or `unavailable` by the caller (i.e., this is the first pass through the evaluation
+  sub-step for this HEAD commit).
+
+#### Orchestrator dispatch contract
+
+When `pr-review-loop.sh` exits with code 3 and `RESULT=needs_rerun`:
+
+1. **Read the structured keys** from the script output:
+   - `PR_AGENT_POSSIBLE_ISSUE_EVAL` — format: `<pr_number>@@@<branch_name>`
+   - `PR_AGENT_POSSIBLE_ISSUE_BODY` — the full PR-Agent comment body (newlines
+     escaped; use `kv_value` to extract, then unescape `\n` and `\t` before passing
+     to the agent)
+
+2. **Dispatch the `code-reviewer` agent** (or invoke inline if the finding is
+   mechanical) with:
+   - The PR number and branch
+   - The PR-Agent comment body (the full finding text)
+   - The PR diff (via `gh pr diff <pr_number>`) for context
+   - The following instruction:
+     > Determine whether the PR-Agent finding describes a real bug or an acceptable
+     > advisory concern. If it is a real bug, push a fix commit to the PR branch.
+     > If it is acceptable, post a substantive acknowledgment comment on the PR
+     > explaining the reasoning (do not just say "acknowledged"). Do not push a
+     > commit if the finding is not actionable.
+
+3. **After the agent finishes**, set `POSSIBLE_ISSUE_EVAL_OUTCOME` in the environment
+   and re-invoke `pr-review-loop.sh` from the top:
+   - Agent pushed a fix commit → `POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed`
+   - Agent posted an acknowledgment → `POSSIBLE_ISSUE_EVAL_OUTCOME=acknowledged`
+   - Agent is unavailable or timed out → `POSSIBLE_ISSUE_EVAL_OUTCOME=unavailable`
+
+   ```bash
+   POSSIBLE_ISSUE_EVAL_OUTCOME=acknowledged \
+     ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
+   ```
+
+4. **On the re-invocation**, the script reads `POSSIBLE_ISSUE_EVAL_OUTCOME` from the
+   environment. If `acknowledged`, it emits `RESULT=clean` and exits 0. If
+   `fix_pushed`, it also emits `RESULT=clean` and exits 0 (the caller should then
+   re-run the full loop on the new HEAD as a normal re-run cycle). If `unavailable`
+   or empty, it falls back to advisory-only (`clean`) and logs a warning to stderr.
+
+#### Retry limits
+
+The `needs_rerun` exit from `pr-review-loop.sh` is **not** counted against the
+orchestrator's `cycle` counter — it is a pre-`clean` evaluation step, not a
+`needs_fixes` fixer dispatch. However, if the agent evaluation itself finds a bug and
+pushes a fix (`fix_pushed`), that subsequent full loop re-run is counted normally.
+
+#### Fallback behavior
+
+If `POSSIBLE_ISSUE_EVAL_OUTCOME` is empty or `unavailable`, the script logs a warning
+to stderr and exits 0 with `RESULT=clean`. The advisory label is still present in the
+loop summary output. The loop does not block indefinitely on agent unavailability.
+
+---
+
 ### PR feedback tracking and comments
 
 Follow the "PR feedback tracking and comments" subsection of Step 7 in `91-orchestrate-work-protocol.md`:

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -362,22 +362,27 @@ This rule applies to any value type: version numbers, timeout values, port numbe
 
 ### PR-Agent "Possible Issue" evaluation step
 
-When `pr-review-loop.sh` returns exit code 3 with `RESULT=needs_rerun`, it means
-PR-Agent classified the PR as `clean` but the review comment contained at least one
-"Possible Issue" advisory label. The script has emitted a structured dispatch key so
-the orchestrator can evaluate the finding with a code-reviewer agent before the loop
-declares the final result.
+When `pr-review-loop.sh` returns `RESULT=clean` and the output contains
+`PR_AGENT_POSSIBLE_ISSUE_EVAL`, PR-Agent classified the PR as `clean` but the review
+comment contained at least one "Possible Issue" advisory label. The orchestrator must
+dispatch a code-reviewer agent to evaluate the finding before declaring the loop result
+final. `RESULT=needs_rerun` (exit code 3) is a separate follow-up signal emitted only
+after the code-reviewer agent pushed a fix (i.e., `POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed`
+is passed to a re-invocation).
 
 #### When this step triggers
 
-`RESULT=needs_rerun` is set only when all of the following are true:
+`PR_AGENT_POSSIBLE_ISSUE_EVAL` is emitted (with `RESULT=clean`) when all of the
+following are true on the first pass:
 
 - The `pr-agent` platform is configured and ran for this PR.
 - PR-Agent's comment classified as `clean` (no hard-blocker labels).
 - The comment contained at least one `Possible Issue` advisory label (case-insensitive).
-- `POSSIBLE_ISSUE_EVAL_OUTCOME` was not already set to `acknowledged`, `fix_pushed`,
-  or `unavailable` by the caller (i.e., this is the first pass through the evaluation
-  sub-step for this HEAD commit).
+- `POSSIBLE_ISSUE_EVAL_OUTCOME` is empty or `unavailable` (first-pass, before the
+  orchestrator sets an outcome).
+
+`RESULT=needs_rerun` (exit code 3) is emitted on a re-invocation when
+`POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed` is set in the environment.
 
 #### Orchestrator dispatch contract
 
@@ -401,22 +406,32 @@ When `pr-review-loop.sh` exits with code 3 and `RESULT=needs_rerun`:
      > explaining the reasoning (do not just say "acknowledged"). Do not push a
      > commit if the finding is not actionable.
 
-3. **After the agent finishes**, set `POSSIBLE_ISSUE_EVAL_OUTCOME` in the environment
-   and re-invoke `pr-review-loop.sh` from the top:
-   - Agent pushed a fix commit → `POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed`
-   - Agent posted an acknowledgment → `POSSIBLE_ISSUE_EVAL_OUTCOME=acknowledged`
-   - Agent is unavailable or timed out → `POSSIBLE_ISSUE_EVAL_OUTCOME=unavailable`
+3. **After the agent finishes**, set `POSSIBLE_ISSUE_EVAL_OUTCOME` and re-invoke
+   `pr-review-loop.sh`:
+   - Agent pushed a fix commit → `POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed`:
+     ```bash
+     POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed \
+       ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
+     ```
+     The script emits `RESULT=needs_rerun` and exits 3. The orchestrator then
+     does a full fresh re-run **without** `POSSIBLE_ISSUE_EVAL_OUTCOME` set, so
+     the new HEAD is checked from scratch.
+   - Agent posted an acknowledgment → `POSSIBLE_ISSUE_EVAL_OUTCOME=acknowledged`:
+     ```bash
+     POSSIBLE_ISSUE_EVAL_OUTCOME=acknowledged \
+       ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
+     ```
+   - Agent is unavailable or timed out → `POSSIBLE_ISSUE_EVAL_OUTCOME=unavailable`:
+     ```bash
+     POSSIBLE_ISSUE_EVAL_OUTCOME=unavailable \
+       ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
+     ```
 
-   ```bash
-   POSSIBLE_ISSUE_EVAL_OUTCOME=acknowledged \
-     ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
-   ```
-
-4. **On the re-invocation**, the script reads `POSSIBLE_ISSUE_EVAL_OUTCOME` from the
-   environment. If `acknowledged`, it emits `RESULT=clean` and exits 0. If
-   `fix_pushed`, it also emits `RESULT=clean` and exits 0 (the caller should then
-   re-run the full loop on the new HEAD as a normal re-run cycle). If `unavailable`
-   or empty, it falls back to advisory-only (`clean`) and logs a warning to stderr.
+4. **On the re-invocation** with `acknowledged` or `unavailable`, the script reads
+   `POSSIBLE_ISSUE_EVAL_OUTCOME` from the environment, emits `RESULT=clean`, and
+   exits 0. For `unavailable`, it also logs a warning to stderr and preserves the
+   advisory label in the loop summary. For `fix_pushed`, the script exits 3
+   (`RESULT=needs_rerun`) — the orchestrator then re-runs the loop completely fresh.
 
 #### Retry limits
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -386,7 +386,7 @@ following are true on the first pass:
 
 #### Orchestrator dispatch contract
 
-When `pr-review-loop.sh` exits with code 3 and `RESULT=needs_rerun`:
+When `pr-review-loop.sh` exits with `RESULT=clean` and includes `PR_AGENT_POSSIBLE_ISSUE_EVAL` in the output:
 
 1. **Read the structured keys** from the script output:
    - `PR_AGENT_POSSIBLE_ISSUE_EVAL` — format: `<pr_number>@@@<branch_name>`

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -102,7 +102,7 @@ Branch-type-aware default timeout:
   override either value.
 
 Outputs stable key=value lines including:
-  RESULT=clean|needs_fixes|escalate|skipped
+  RESULT=clean|needs_fixes|needs_rerun|escalate|skipped
   PLATFORM_<n>_NAME / PLATFORM_<n>_RESULT
   REASON=lock_contention (when exit code is 75)
 EOF
@@ -1139,6 +1139,80 @@ _PR_AGENT_ADVISORY_LABELS_
     printf '%s' "$advisory_labels"
   }
 
+  # Returns pipe-delimited labels that match "possible issue" (case-insensitive).
+  # Input:  pipe-delimited advisory labels string (e.g. "Possible Issue|Edge Case")
+  # Output: pipe-delimited matching labels, or empty string.
+  _extract_possible_issue_labels() {
+    local advisory="$1"
+    local result=""
+    local label label_lower
+    local _labels_normalized
+    _labels_normalized="$(printf '%s' "$advisory" | tr '|' '\n')"
+    while IFS= read -r label; do
+      [ -z "$label" ] && continue
+      label_lower="$(printf '%s' "$label" | tr '[:upper:]' '[:lower:]')"
+      if [ "$label_lower" = "possible issue" ]; then
+        if [ -n "$result" ]; then
+          result="${result}|${label}"
+        else
+          result="$label"
+        fi
+      fi
+    done <<_EXTRACT_POSSIBLE_ISSUE_LABELS_
+$_labels_normalized
+_EXTRACT_POSSIBLE_ISSUE_LABELS_
+    printf '%s' "$result"
+  }
+
+  # Evaluate "Possible Issue" advisory labels found in a PR-Agent clean result.
+  # Reads POSSIBLE_ISSUE_EVAL_OUTCOME from environment (set by orchestrator caller).
+  # Returns:
+  #   0  — no "Possible Issue" label found (short-circuit), OR
+  #         finding acknowledged, OR agent unavailable (advisory-only fallback)
+  #   3  — fix was pushed; caller must re-run the loop on the new HEAD
+  run_pr_agent_possible_issue_evaluation() {
+    local advisory_labels="$1"  # pipe-delimited, already extracted from comment
+    local comment_body="$2"     # full PR-Agent comment body (for agent context)
+    local pr_number_eval="$3"
+    local branch_name_eval="$4"
+
+    local possible_issue_labels
+    possible_issue_labels="$(_extract_possible_issue_labels "$advisory_labels")"
+
+    # Short-circuit: no "Possible Issue" advisory labels present.
+    if [ -z "$possible_issue_labels" ]; then
+      return 0
+    fi
+
+    # Emit structured key for the orchestrator caller to consume.
+    print_kv PR_AGENT_POSSIBLE_ISSUE_EVAL "${pr_number_eval}@@@${branch_name_eval}"
+    print_kv_escaped PR_AGENT_POSSIBLE_ISSUE_BODY "$comment_body"
+
+    # Read the eval outcome set by the orchestrator after code-reviewer agent finishes.
+    local eval_outcome="${POSSIBLE_ISSUE_EVAL_OUTCOME:-}"
+
+    case "$eval_outcome" in
+      fix_pushed)
+        print_kv POSSIBLE_ISSUE_EVAL_OUTCOME "fix_pushed"
+        return 3  # sentinel: re-run the loop
+        ;;
+      acknowledged)
+        print_kv POSSIBLE_ISSUE_EVAL_OUTCOME "acknowledged"
+        return 0
+        ;;
+      unavailable|"")
+        echo "WARN: code-reviewer agent unavailable or eval outcome not set for 'Possible Issue' finding — falling back to advisory-only (clean)" >&2
+        print_kv POSSIBLE_ISSUE_EVAL_OUTCOME "unavailable"
+        return 0
+        ;;
+      *)
+        echo "WARN: unknown POSSIBLE_ISSUE_EVAL_OUTCOME '${eval_outcome}' — falling back to advisory-only (clean)" >&2
+        print_kv POSSIBLE_ISSUE_EVAL_OUTCOME "unavailable"
+        return 0
+        ;;
+    esac
+  }
+
   _pr_agent_classify() {
     local body="$1"
     local label label_lower labels
@@ -1202,13 +1276,31 @@ _PR_AGENT_LABELS_
 
   case "$verdict" in
     clean)
-      local _advisory_labels _comment_url _advisory_entry
+      local _advisory_labels _comment_url _advisory_entry _eval_status
       _advisory_labels="$(_pr_agent_extract_advisory_labels "$comment_body")"
       if [ -n "$_advisory_labels" ]; then
         _comment_url="$(_pr_agent_latest_comment_url strict_sha)"
         _advisory_entry="${_advisory_labels}@@@${_comment_url}"
       else
         _advisory_entry=""
+      fi
+      # Evaluate any "Possible Issue" advisory labels before emitting clean.
+      _eval_status=0
+      run_pr_agent_possible_issue_evaluation \
+        "$_advisory_labels" "$comment_body" "$pr_number" "$branch_name" || _eval_status=$?
+      if [ "$_eval_status" -eq 3 ]; then
+        # Fix was pushed — signal to caller to re-run the loop on the new HEAD.
+        print_kv RESULT needs_rerun
+        print_kv PLATFORM "$platform"
+        print_kv PR_NUMBER "$pr_number"
+        print_kv BRANCH "$branch_name"
+        print_kv REVIEW_COMMENT_ID ""
+        print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+        print_kv COMMENT_COUNT 0
+        print_kv BLOCKING_COUNT 0
+        print_kv SUGGESTION_COUNT 0
+        [ -n "$_advisory_entry" ] && print_kv ADVISORY_LABELS "$_advisory_entry"
+        return 3
       fi
       print_kv RESULT clean
       print_kv PLATFORM "$platform"
@@ -1280,13 +1372,31 @@ _PR_AGENT_LABELS_
   # --- Phase 3: Classify the comment body ---
   case "$verdict" in
     clean)
-      local _advisory_labels _comment_url _advisory_entry
+      local _advisory_labels _comment_url _advisory_entry _eval_status
       _advisory_labels="$(_pr_agent_extract_advisory_labels "$comment_body")"
       if [ -n "$_advisory_labels" ]; then
         _comment_url="$(_pr_agent_latest_comment_url recent_or_sha)"
         _advisory_entry="${_advisory_labels}@@@${_comment_url}"
       else
         _advisory_entry=""
+      fi
+      # Evaluate any "Possible Issue" advisory labels before emitting clean.
+      _eval_status=0
+      run_pr_agent_possible_issue_evaluation \
+        "$_advisory_labels" "$comment_body" "$pr_number" "$branch_name" || _eval_status=$?
+      if [ "$_eval_status" -eq 3 ]; then
+        # Fix was pushed — signal to caller to re-run the loop on the new HEAD.
+        print_kv RESULT needs_rerun
+        print_kv PLATFORM "$platform"
+        print_kv PR_NUMBER "$pr_number"
+        print_kv BRANCH "$branch_name"
+        print_kv REVIEW_COMMENT_ID ""
+        print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+        print_kv COMMENT_COUNT 0
+        print_kv BLOCKING_COUNT 0
+        print_kv SUGGESTION_COUNT 0
+        [ -n "$_advisory_entry" ] && print_kv ADVISORY_LABELS "$_advisory_entry"
+        return 3
       fi
       print_kv RESULT clean
       print_kv PLATFORM "$platform"
@@ -2413,6 +2523,15 @@ for index in "${!platforms[@]}"; do
       aggregate_status=$platform_status
       break
       ;;
+    needs_rerun)
+      # PR-Agent "Possible Issue" evaluation: a fix was pushed; re-run the loop.
+      # Propagate as needs_rerun (exit 3) so orchestrator callers distinguish
+      # this from needs_fixes (fixer dispatch) and re-invoke on the new HEAD.
+      aggregate_result="needs_rerun"
+      aggregate_output="$platform_output"
+      aggregate_status=$platform_status
+      break
+      ;;
     *)
       aggregate_result="escalate"
       aggregate_reason="unknown-platform-result"
@@ -2538,6 +2657,7 @@ _post_review_summary() {
   local blocking="$4"
   local suggestions="$5"
   local advisory_labels="${6:-}"
+  local possible_issue_eval_outcome="${7:-}"
 
   if [ -z "$pr_number" ]; then
     return 0
@@ -2599,6 +2719,26 @@ _ADVISORY_LABEL_LINES_
     done <<_ADVISORY_ENTRY_LINES_
 $_entries_normalized
 _ADVISORY_ENTRY_LINES_
+    # Append "Possible Issue" evaluation outcome when available.
+    if [ -n "$possible_issue_eval_outcome" ]; then
+      local _eval_note
+      case "$possible_issue_eval_outcome" in
+        acknowledged)
+          _eval_note="Evaluated by code-reviewer: acknowledged (finding is acceptable — loop proceeded clean)"
+          ;;
+        fix_pushed)
+          _eval_note="Evaluated by code-reviewer: fix pushed — loop re-ran on new HEAD"
+          ;;
+        unavailable)
+          _eval_note="Evaluated by code-reviewer: unavailable — fell back to advisory-only (clean)"
+          ;;
+        *)
+          _eval_note="Evaluated by code-reviewer: outcome=${possible_issue_eval_outcome}"
+          ;;
+      esac
+      advisory_section="${advisory_section}
+  _Possible Issue evaluation_: ${_eval_note}"
+    fi
   fi
 
   # Step 7b regression-label assertion (clean path, implementation PRs only).
@@ -2687,12 +2827,15 @@ EOF
   set -e
 }
 
+aggregate_possible_issue_eval_outcome="$(kv_value_default POSSIBLE_ISSUE_EVAL_OUTCOME "$aggregate_output" "")"
+
 case "$aggregate_result" in
   clean)
     _post_review_summary "$aggregate_result" "$aggregate_reason" \
       "$(IFS=,; printf '%s' "${platforms[*]}")" \
       "$total_blocking_count" "$total_suggestion_count" \
-      "$aggregate_advisory_labels"
+      "$aggregate_advisory_labels" \
+      "$aggregate_possible_issue_eval_outcome"
     exit 0
     ;;
   skipped)
@@ -2703,15 +2846,24 @@ case "$aggregate_result" in
       _post_review_summary "$aggregate_result" "$aggregate_reason" \
         "$(IFS=,; printf '%s' "${platforms[*]}")" \
         "$total_blocking_count" "$total_suggestion_count" \
-        "$aggregate_advisory_labels"
+        "$aggregate_advisory_labels" \
+        "$aggregate_possible_issue_eval_outcome"
     fi
     exit 1
+    ;;
+  needs_rerun)
+    # PR-Agent "Possible Issue" evaluation pushed a fix; orchestrator must
+    # re-invoke the loop on the new HEAD. No summary comment is posted here —
+    # the loop re-runs from the top and posts the summary on its terminal exit.
+    print_kv RESULT needs_rerun
+    exit 3
     ;;
   escalate)
     _post_review_summary "$aggregate_result" "$aggregate_reason" \
       "$(IFS=,; printf '%s' "${platforms[*]}")" \
       "$total_blocking_count" "$total_suggestion_count" \
-      "$aggregate_advisory_labels"
+      "$aggregate_advisory_labels" \
+      "$aggregate_possible_issue_eval_outcome"
     exit 2
     ;;
   *)

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1193,14 +1193,19 @@ _EXTRACT_POSSIBLE_ISSUE_LABELS_
 
     case "$eval_outcome" in
       fix_pushed)
+        # A fix was pushed; the orchestrator must re-run the loop on the new HEAD
+        # to confirm the finding is resolved. Exit 3 signals this to the caller.
         print_kv POSSIBLE_ISSUE_EVAL_OUTCOME "fix_pushed"
-        return 3  # sentinel: re-run the loop
+        return 3  # sentinel: orchestrator must re-run the loop from the top
         ;;
       acknowledged)
         print_kv POSSIBLE_ISSUE_EVAL_OUTCOME "acknowledged"
         return 0
         ;;
       unavailable|"")
+        # No outcome set (first pass, before orchestrator dispatches code-reviewer)
+        # or agent is unavailable. Emit the evaluation keys so the orchestrator can
+        # read them and dispatch; fall back to advisory-only (clean) here.
         echo "WARN: code-reviewer agent unavailable or eval outcome not set for 'Possible Issue' finding — falling back to advisory-only (clean)" >&2
         print_kv POSSIBLE_ISSUE_EVAL_OUTCOME "unavailable"
         return 0

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1150,6 +1150,12 @@ _PR_AGENT_ADVISORY_LABELS_
     _labels_normalized="$(printf '%s' "$advisory" | tr '|' '\n')"
     while IFS= read -r label; do
       [ -z "$label" ] && continue
+      # Trim leading and trailing whitespace before comparing (defensive — labels
+      # from _pr_agent_extract_advisory_labels are already trimmed by sed, but
+      # callers may pass labels with surrounding spaces).
+      label="${label#"${label%%[![:space:]]*}"}"
+      label="${label%"${label##*[![:space:]]}"}"
+      [ -z "$label" ] && continue
       label_lower="$(printf '%s' "$label" | tr '[:upper:]' '[:lower:]')"
       if [ "$label_lower" = "possible issue" ]; then
         if [ -n "$result" ]; then

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1190,10 +1190,6 @@ _EXTRACT_POSSIBLE_ISSUE_LABELS_
       return 0
     fi
 
-    # Emit structured key for the orchestrator caller to consume.
-    print_kv PR_AGENT_POSSIBLE_ISSUE_EVAL "${pr_number_eval}@@@${branch_name_eval}"
-    print_kv_escaped PR_AGENT_POSSIBLE_ISSUE_BODY "$comment_body"
-
     # Read the eval outcome set by the orchestrator after code-reviewer agent finishes.
     local eval_outcome="${POSSIBLE_ISSUE_EVAL_OUTCOME:-}"
 
@@ -1210,8 +1206,12 @@ _EXTRACT_POSSIBLE_ISSUE_LABELS_
         ;;
       unavailable|"")
         # No outcome set (first pass, before orchestrator dispatches code-reviewer)
-        # or agent is unavailable. Emit the evaluation keys so the orchestrator can
-        # read them and dispatch; fall back to advisory-only (clean) here.
+        # or agent is unavailable. Emit structured keys ONLY here so the orchestrator
+        # can read them and dispatch; fall back to advisory-only (clean) here.
+        # Keys are NOT emitted for fix_pushed/acknowledged re-invocations, which
+        # avoids ambiguous re-dispatch signals to the orchestrator.
+        print_kv PR_AGENT_POSSIBLE_ISSUE_EVAL "${pr_number_eval}@@@${branch_name_eval}"
+        print_kv_escaped PR_AGENT_POSSIBLE_ISSUE_BODY "$comment_body"
         echo "WARN: code-reviewer agent unavailable or eval outcome not set for 'Possible Issue' finding — falling back to advisory-only (clean)" >&2
         print_kv POSSIBLE_ISSUE_EVAL_OUTCOME "unavailable"
         return 0


### PR DESCRIPTION
## Summary

Inserts an AI evaluation sub-step into `pr-review-loop.sh` whenever PR-Agent returns `clean` with one or more "Possible Issue" advisory labels. A code-reviewer agent evaluates each finding and either pushes a fix (real bug found) or posts an acknowledgment comment (acceptable finding).

### Changes

- **`scripts/development-workflow/pr-review-loop.sh`**: add `_extract_possible_issue_labels` helper and `run_pr_agent_possible_issue_evaluation` function; wire both Phase 1 and Phase 3 `clean` blocks; propagate `needs_rerun` (exit 3) through outer loop; update `_post_review_summary` to render eval outcome in advisory section.
- **`docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`**: add `needs_rerun` row to Step 7 result table and a "PR-Agent 'Possible Issue' evaluation" subsection.
- **`docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`**: add full `### PR-Agent "Possible Issue" evaluation step` subsection with orchestrator dispatch contract.
- **`CHANGELOG.md`**: add entry under `[Unreleased] → Added`.

### Design decisions

- New `RESULT=needs_rerun` / exit-3 sentinel distinguishes "re-run for evaluation fix" from `needs_fixes` (fixer dispatch).
- Orchestrator sets `POSSIBLE_ISSUE_EVAL_OUTCOME` before re-invoking the loop.
- `unavailable`/empty triggers advisory-only fallback with a WARN to stderr.
- No PR type exemptions — spec/chore PRs are also evaluated.

## Test plan

- [ ] `bash -n scripts/development-workflow/pr-review-loop.sh` passes
- [ ] Markdown lint (`markdownlint-cli2`, heuristic, duplicate-header) passes
- [ ] Smoke test runbook at `docs/testing/workflow/562-pr-agent-ai-evaluation-layer.smoke-test.md`
- [ ] Step 7a internal review gate
- [ ] CI green

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated evaluation layer for PR-Agent "Possible Issue" advisories that dispatches a reviewer agent to assess findings and can acknowledge, request a rerun after a fix, or fallback to advisory-only behavior.

* **Documentation**
  * Updated development workflow and orchestrator protocols to describe the new evaluation step, its outcomes, and how summaries are reported.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/576)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->