### PR TITLE
fix(spec-protocol): add placeholder-removal self-check to prevent CodeRabbit findings on spec PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Spec template and protocol: prevent placeholder artifacts from reaching spec PRs** (#568): the spec template replaces the `**Language**: ...` instruction block with an HTML comment and converts `**Depends on**` to a clearly bracketed placeholder; Protocol 01 adds a mandatory "Template placeholder removal" self-check with a grep command that agents must run before opening every spec PR.
+
 ## [0.26.0] - 2026-05-11
 
 ### Added

--- a/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
+++ b/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
@@ -163,7 +163,7 @@ After writing the spec, verify that no template placeholder content remains in t
 Run this grep to catch the most common unfilled placeholder patterns before committing:
 
 ```bash
-grep -n "\[Step [0-9]\]\|\[Who initiates\|\[What must be\|\[Rule [0-9]\|\[UX rule\|\[Out of scope item\|\[Question [0-9]\|\[Code value\|\[Display label\|\[feature-slug-[0-9]\|<!-- Delete this section\|<!-- Replace this comment\|<!-- Depends on:\|\*\*Language\*\*:" \
+grep -n "\[Step [0-9]\]\|\[Who initiates\|\[What must be\|\[Rule [0-9]\|\[UX rule\|\[Out of scope item\|\[Question [0-9]\|\[Code value\|\[Display label\|\[Description\]\|\[feature-slug-[0-9]\|<!-- Delete this section\|<!-- Replace this comment\|<!-- Depends on:\|\*\*Language\*\*:" \
   docs/specs/developments/<timestamp>_<slug>/1_<slug>_specs.md
 ```
 

--- a/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
+++ b/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
@@ -142,6 +142,33 @@ Use the current timestamp for `YYYYMMDDHHMMSS`.
 
 Skim the spec body once more for: accidental **Open Questions** sections when forbidden, **copy/paste character corruption**, mixed terminology for the same concept, and acceptance criteria that cannot be verified without guessing environment or data setup.
 
+**Template placeholder removal (mandatory — run before every spec PR)**:
+
+After writing the spec, verify that no template placeholder content remains in the output file. These are the most common artifacts that trigger CodeRabbit findings on spec PRs:
+
+1. **`Depends on` line**: If the feature has no dependencies, the `**Depends on**:` line must be removed entirely. If dependencies exist, replace the placeholder slugs with the actual feature slugs. Never leave the line with bracketed placeholders (e.g., `[feature-slug-1, feature-slug-2]`) or the original HTML comment form.
+
+2. **`Language` instruction block**: The `**Language**: ...` block in the Overview is a template instruction, not spec content. Remove it entirely before committing. Replace it with actual spec prose (2–4 sentences describing what the feature does and why it exists).
+
+3. **Unfilled section placeholders**: Every section that remains in the spec must contain real content. Remove or fill:
+   - `<!-- Replace this comment with ... -->` comments (replace with real content)
+   - `[Step 1]`, `[Step 2]`, `[What data the user sees]`, and similar bracketed placeholder lines in use cases
+   - `[Rule 1: an invariant...]`, `[UX rule 1: ...]`, and similar bracketed placeholder items in lists
+   - `[Out of scope item 1]`, `[Out of scope item 2]` lines under Out of Scope
+   - `[Question 1]`, `[Question 2]` lines under Open Questions (fill with real questions or delete the section)
+   - `[Code value]`, `[Display label]`, `[Description]` cells in the Statuses table
+
+4. **Optional sections left with only placeholder content**: Sections such as `## UX Rules`, `## Statuses / Enum Values`, and `## Operational Visibility` include a delete instruction in the template (`<!-- Delete this section if... -->`). If a section is not applicable, delete the entire section including its heading. Never leave a section containing only the placeholder comment or example rows.
+
+Run this grep to catch the most common unfilled placeholder patterns before committing:
+
+```bash
+grep -n "\[Step [0-9]\]\|\[Who initiates\|\[What must be\|\[Rule [0-9]\|\[UX rule\|\[Out of scope item\|\[Question [0-9]\|\[Code value\|\[Display label\|\[feature-slug-[0-9]\|<!-- Delete this section\|<!-- Replace this comment\|<!-- List feature slugs\|\*\*Language\*\*:" \
+  docs/specs/developments/<timestamp>_<slug>/1_<slug>_specs.md
+```
+
+If this grep returns any output, address each match before opening the PR.
+
 ### Brief Coverage Requirements (mandatory when a tracker brief exists)
 
 When a tracker issue or work-item brief exists, add these artifacts before opening the draft PR:

--- a/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
+++ b/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
@@ -163,7 +163,7 @@ After writing the spec, verify that no template placeholder content remains in t
 Run this grep to catch the most common unfilled placeholder patterns before committing:
 
 ```bash
-grep -n "\[Step [0-9]\]\|\[Who initiates\|\[What must be\|\[Rule [0-9]\|\[UX rule\|\[Out of scope item\|\[Question [0-9]\|\[Code value\|\[Display label\|\[feature-slug-[0-9]\|<!-- Delete this section\|<!-- Replace this comment\|<!-- List feature slugs\|\*\*Language\*\*:" \
+grep -n "\[Step [0-9]\]\|\[Who initiates\|\[What must be\|\[Rule [0-9]\|\[UX rule\|\[Out of scope item\|\[Question [0-9]\|\[Code value\|\[Display label\|\[feature-slug-[0-9]\|<!-- Delete this section\|<!-- Replace this comment\|<!-- Depends on:\|\*\*Language\*\*:" \
   docs/specs/developments/<timestamp>_<slug>/1_<slug>_specs.md
 ```
 

--- a/docs/workflow/development-workflow/templates/spec-template.md
+++ b/docs/workflow/development-workflow/templates/spec-template.md
@@ -1,14 +1,16 @@
 # [Feature Name] — Spec
 
-**Depends on**: <!-- List feature slugs this depends on, or remove this line -->
+<!-- Depends on: list feature slugs this depends on (e.g. "feature-a, feature-b"), then remove this comment.
+     If there are no dependencies, remove the "Depends on" line entirely. -->
+**Depends on**: [feature-slug-1, feature-slug-2]
 
 ---
 
 ## Overview
 
-<!-- 2-4 sentences describing what this feature does and why it exists. -->
-
-**Language**: Describe outcomes in product and user terms. Do not use API field names, database column names, JSON keys, or code symbols in this document — use plain-language labels and map technical identifiers only in the implementation plan.
+<!-- Replace this comment with 2-4 sentences describing what this feature does and why it exists.
+     Use product and user language — no API field names, database column names, JSON keys, or code symbols.
+     Technical identifiers belong in the implementation plan, not the spec. -->
 
 ---
 


### PR DESCRIPTION
## What

Spec documents written by the product-manager agent have repeatedly reached CodeRabbit first-pass review with template artifacts left in place, triggering avoidable automated reviewer loop cycles on every spec batch.

The two recurring artifacts from CodeRabbit findings (PRs #474, #475 and broader batch 39 analysis):
- `**Language**: Describe outcomes in product and user terms...` — template instruction block left verbatim in the Overview
- `**Depends on**: <!-- List feature slugs this depends on, or remove this line -->` — placeholder comment left when there are no dependencies

## Changes

**`docs/workflow/development-workflow/templates/spec-template.md`**:
- Replaces the `**Language**: ...` instruction block in the Overview with an HTML comment (so it is never rendered as spec content)
- Converts the `**Depends on**:` comment form to a clearly bracketed placeholder (`[feature-slug-1, feature-slug-2]`) that is visually obvious as incomplete

**`docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md`**:
- Adds a mandatory "Template placeholder removal" self-check block inside the "Before opening the draft PR" section
- Lists 4 numbered rules covering: `Depends on` line, `Language` instruction block, unfilled section placeholders, and optional sections left with only placeholder content
- Includes a grep command that agents must run before committing to catch the most common unfilled patterns

## Fixes

Closes #568

## Test plan

- [ ] `spec-template.md` has no `**Language**:` instruction block visible as rendered Markdown content
- [ ] `spec-template.md` `**Depends on**:` placeholder is clearly a bracketed placeholder (`[feature-slug-1, ...]`)
- [ ] `01-generate-spec-protocol.md` "Before opening the draft PR" section contains the new "Template placeholder removal" block
- [ ] markdownlint passes on both files (verified locally: 0 errors)
- [ ] CHANGELOG `[Unreleased]` has exactly one `### Fixed` section with the new entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a mandatory "Template placeholder removal" self-check to prevent template artifacts in spec submissions.
  * Updated the spec template with a clearer "Depends on" section and revised Overview guidance for 2–4 sentence, plain-language descriptions.
  * Added a grep-based verification command and instructions to detect and resolve common unfilled placeholder artifacts before opening a PR.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/580)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->