### PR TITLE
fix(pr-agent): disable ticket compliance check to prevent false positives (#569)

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -58,3 +58,14 @@ num_code_suggestions = 0
 # Context-specific workarounds (e.g. ShellCheck SC2188 false-positives, intentional
 # pipefail suppressions) are typically emitted under "Possible Issue" and are therefore
 # non-blocking. The reviewer loop will classify them as clean and will not loop.
+#
+# Ticket compliance check disabled: PR-Agent's ticket compliance analysis is disabled
+# because it generates false positives. When a PR description or branch name contains
+# issue numbers from cross-repository references (e.g. "ported from other-repo#145"),
+# PR-Agent incorrectly treats those numbers as the PR's own linked tickets and checks
+# requirements from the wrong issue. The check does not affect the automated reviewer
+# loop's clean/needs_fixes classification (which relies on "No major issues detected"
+# vs "Recommended focus areas for review" markers), but it creates confusing noise in
+# the review comment and can mislead agents into treating the false positive as a
+# finding that needs to be fixed. See issue #569.
+require_ticket_analysis_review = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR-Agent ticket compliance check disabled** (#569): `require_ticket_analysis_review = false` added to `.pr_agent.toml` to prevent false-positive compliance findings. PR-Agent was extracting issue numbers from cross-repository links in PR descriptions (e.g. "ported from other-repo#145") and checking ticket requirements from the wrong issue, creating confusing noise that required manual triage to dismiss.
+
 ## [0.26.0] - 2026-05-11
 
 ### Added


### PR DESCRIPTION
## Summary

- Set `require_ticket_analysis_review = false` in `.pr_agent.toml` to disable PR-Agent's ticket compliance check

## Root Cause

PR-Agent's ticket compliance analysis determines which issue to check by extracting issue numbers from:
1. The branch name (e.g., `fix/497-slug` → issue #497) — usually correct
2. The PR description body — where it picks up **any** `#N` reference, including cross-repository links

When a PR description contains phrases like "Ported from [other-repo PR #145](https://github.com/owner/other-repo/pull/145)", PR-Agent extracts `#145` and checks whether this PR's code addresses the requirements of issue #145 in the **current** repository. Since issue #145 is from a different context, every requirement check fails, producing a false "Partially compliant" finding.

## Impact

The ticket compliance check does **not** affect the automated reviewer loop's `clean`/`needs_fixes` classification (which relies solely on `No major issues detected` vs `Recommended focus areas for review` body markers). However:
- It creates confusing noise in the review comment that human reviewers must triage
- Agents evaluating PR-Agent output may incorrectly treat "Partially compliant" as a finding requiring fixes, adding unnecessary rework cycles

## Fix

Disable `require_ticket_analysis_review` in `[pr_reviewer]` section of `.pr_agent.toml`. The check produces unreliable results in this workflow because PRs frequently reference cross-repository issue numbers in their descriptions (batch notes, ported-from references, etc.).

## Test Plan

- [ ] Open a PR with a description referencing a cross-repository issue number — verify the PR-Agent review comment no longer contains a "Ticket compliance analysis" section
- [ ] Verify the review loop continues to correctly classify clean PRs as `RESULT=clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PR review accuracy by reducing false positives in automated compliance checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/581)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->