### PR TITLE
chore(hotfix): backport reviewer-loop-script-fixes to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.1] - 2026-05-11
+
+### Fixed
+
+- **`pr-review-loop.sh`: remove duplicate `RESULT=needs_rerun` output** (hotfix): `print_kv RESULT needs_rerun` was emitted twice — once by the general emit block and again inside the final `case` switch. The redundant emission in the `needs_rerun)` branch is removed; only the general block emits the value.
+- **`pr-review-loop.sh`: `normalize_platform_verdict` now handles `advisory` result** (hotfix): compare-mode runs where a platform returned `advisory` fell through to the `*)` catch-all and were logged as `unavailable` in the metrics file. An explicit `advisory) printf 'advisory' ;;` case is added.
+- **`codex-github-reviewer.sh`: async grace trigger comment respects `--max-retriggers=0`** (hotfix): the async grace period unconditionally posted a trigger comment even when callers passed `--max-retriggers=0`. The `gh api POST` call is now guarded by `[ "$MAX_RETRIGGERS" -gt 0 ]`; when retriggers are disabled the grace poll still runs but no comment is posted.
+
 ## [0.26.0] - 2026-05-11
 
 ### Added
@@ -655,7 +663,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.26.1...HEAD
+[0.26.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.25.1...v0.26.0
 [0.25.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.24.1...v0.25.0

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -408,13 +408,18 @@ done  # end outer retrigger loop
 # This is a lightweight one-shot check: it does not extend the full MAX_WAIT
 # budget and does not add another iteration of the outer retrigger loop.
 
-echo "INFO: poll budget exhausted; posting async-arrival trigger and waiting ${POLL_INTERVAL}s for late response..."
+echo "INFO: poll budget exhausted; waiting ${POLL_INTERVAL}s for late async response..."
 
-if ! gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
-  --method POST \
-  --raw-field body="$TRIGGER_PHRASE — async-arrival check after poll-window expiry (sha: $CURRENT_SHA)" \
-  --jq '.created_at' >/dev/null; then
-  echo "WARNING: failed to post async-arrival trigger comment; continuing with grace poll from existing trigger time" >&2
+if [ "$MAX_RETRIGGERS" -gt 0 ]; then
+  echo "INFO: posting async-arrival trigger comment..."
+  if ! gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
+    --method POST \
+    --raw-field body="$TRIGGER_PHRASE — async-arrival check after poll-window expiry (sha: $CURRENT_SHA)" \
+    --jq '.created_at' >/dev/null; then
+    echo "WARNING: failed to post async-arrival trigger comment; continuing with grace poll from existing trigger time" >&2
+  fi
+else
+  echo "INFO: MAX_RETRIGGERS=0 — skipping async-arrival trigger comment; grace poll will use existing trigger time"
 fi
 
 echo "INFO: sleeping ${POLL_INTERVAL}s before async grace poll..."

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -2495,6 +2495,7 @@ normalize_platform_verdict() {
   case "$result" in
     clean)       printf 'clean' ;;
     needs_fixes) printf 'blocking' ;;
+    advisory)    printf 'advisory' ;;
     skipped)     printf 'clean' ;;
     needs_rerun) printf 'blocking' ;;
     escalate)
@@ -3154,7 +3155,7 @@ case "$aggregate_result" in
     # PR-Agent "Possible Issue" evaluation pushed a fix; orchestrator must
     # re-invoke the loop on the new HEAD. No summary comment is posted here —
     # the loop re-runs from the top and posts the summary on its terminal exit.
-    print_kv RESULT needs_rerun
+    # RESULT=needs_rerun is already emitted by the general print_kv block above.
     exit 3
     ;;
   escalate)


### PR DESCRIPTION
## Summary

Backports hotfix `reviewer-loop-script-fixes` (PR #582, targeting `main`) to keep `develop` in sync.

**Do not merge before PR #582 is merged to `main`.**

### Changes included

- `pr-review-loop.sh`: remove duplicate `print_kv RESULT needs_rerun` from case switch
- `pr-review-loop.sh`: add `advisory) printf 'advisory' ;;` to `normalize_platform_verdict`
- `codex-github-reviewer.sh`: guard async grace trigger comment with `[ "$MAX_RETRIGGERS" -gt 0 ]`
- `CHANGELOG.md`: versioned `[0.26.1]` section with three `### Fixed` entries

## Closes backport requirement for hotfix/reviewer-loop-script-fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added v0.26.1 release notes documenting recent hotfixes.

* **Bug Fixes**
  * Eliminated duplicate result emissions in review workflow.
  * Enhanced verdict classification with explicit advisory handling.
  * Fixed async trigger comment posting when retriggers are disabled.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/583)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->