### PR TITLE
feat(protocol): require advisory finding dispositions in reviewer loop summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Reviewer loop: mandatory advisory finding dispositions in summary comment**: Protocol 93 gains a new "Advisory finding dispositions" step — when the loop exits clean with non-empty `ADVISORY_LABELS`, the runner must evaluate each advisory finding, assign a disposition (Addressed / Accepted / Deferred / Rejected) with a one-line rationale, and update the Automated Reviewer Loop Summary comment with a "Advisory dispositions" subsection. Protocol 91 Step 7 result table is updated to reference this step on `clean` exits.
+
 ### Fixed
 
 - **Spec template and protocol: prevent placeholder artifacts from reaching spec PRs** (#568): the spec template replaces the `**Language**: ...` instruction block with an HTML comment and converts `**Depends on**` to a clearly bracketed placeholder; Protocol 01 adds a mandatory "Template placeholder removal" self-check with a grep command that agents must run before opening every spec PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Reviewer loop: mandatory advisory finding dispositions in summary comment**: Protocol 93 gains a new "Advisory finding dispositions" step — when the loop exits clean with non-empty `ADVISORY_LABELS`, the runner must evaluate each advisory finding, assign a disposition (Addressed / Accepted / Deferred / Rejected) with a one-line rationale, and update the Automated Reviewer Loop Summary comment with a "Advisory dispositions" subsection. Protocol 91 Step 7 result table is updated to reference this step on `clean` exits.
+- **Reviewer loop: mandatory advisory finding dispositions in summary comment**: Protocol 93 gains a new "Advisory finding dispositions" step — when the loop exits clean with non-empty `ADVISORY_LABELS`, the runner must evaluate each advisory finding, assign a disposition (Addressed / Accepted / Deferred / Rejected) with a one-line rationale, and update the Automated Reviewer Loop Summary comment with an "Advisory dispositions" subsection. Protocol 91 Step 7 result table is updated to reference this step on `clean` exits.
 
 ### Fixed
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1095,7 +1095,7 @@ Interpret the result as follows:
 
 | Result | Action |
 |---|---|
-| `clean` | Summary comment posted automatically by the script. Re-issue the GraphQL `reviewThreads` query (Step 8c) before proceeding — see "Re-query reviewThreads after each push" below |
+| `clean` | Summary comment posted automatically by the script. If `ADVISORY_LABELS` is non-empty, document a disposition for each advisory finding and update the summary comment before proceeding — see "Advisory finding dispositions" in `93-automated-reviewer-loop-protocol.md`. Then re-issue the GraphQL `reviewThreads` query (Step 8c) — see "Re-query reviewThreads after each push" below |
 | `skipped` | Continue to Step 7b (implementation PRs) then Step 8 (no summary comment posted — Step 8c skips the check) |
 | `needs_fixes` and `cycle < max_cycles` | Increment `cycle`, dispatch the matching fixer agent, wait for a push, then run Step 7 again |
 | `needs_fixes` and `cycle >= max_cycles` | Pass `--post-final-summary` to the final invocation — the script posts the summary automatically. Then escalate to human |

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -476,9 +476,10 @@ Any clean exit where the script output includes one or more advisory label entri
 4. **Edit the comment in place** using `gh api PATCH`:
 
    ```bash
-   # Find the summary comment ID (last match in case of multiple)
+   # Find the summary comment ID (last match in case of multiple).
+   # Use the same multi-marker pattern as Step 8c to cover all accepted summary forms.
    comment_id=$(gh api repos/{owner}/{repo}/issues/{pr_number}/comments \
-     --jq '[.[] | select(.body | test("Automated Reviewer Loop Summary"))] | last | .id')
+     --jq '[.[] | select(.body | test("Automated Reviewer Loop Summary|Reviewer Loop Summary|No blocking PR feedback"))] | last | .id')
 
    # Patch with the updated body (include dispositions section at the end, before the script footer)
    gh api repos/{owner}/{repo}/issues/comments/$comment_id \

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -448,6 +448,47 @@ loop summary output. The loop does not block indefinitely on agent unavailabilit
 
 ---
 
+### Advisory finding dispositions (post-clean)
+
+When `pr-review-loop.sh` exits `clean` and the output contains a non-empty `ADVISORY_LABELS` value (advisory findings from any configured platform), the runner must document the disposition of each advisory finding and update the summary comment before marking the PR ready. This closes the gap between "we saw this finding" and "here is why it was or was not addressed."
+
+#### When this step triggers
+
+Any clean exit where the script output includes one or more advisory label entries in the `ADVISORY_LABELS` key (comma-separated names, e.g. `Possible Issue,Logic Issue`).
+
+#### Procedure
+
+1. **For each advisory finding** listed in the "Advisory findings" section of the Automated Reviewer Loop Summary comment, read the full finding text from the linked PR comment.
+
+2. **Determine the disposition** — choose one per finding:
+   - **Addressed** — the finding describes a real issue that was fixed in this PR. Cite the commit SHA.
+   - **Accepted** — the finding is technically valid but intentionally not fixed. Provide a one-line rationale (e.g., "edge case that cannot occur in practice because platform names are always set programmatically").
+   - **Deferred** — the finding will be tracked separately. Note the issue or backlog reference.
+   - **Rejected** — the finding is a false positive. Explain why (e.g., "regex verified correct via manual test — pattern correctly excludes `[bot]`-suffixed logins").
+
+3. **Update the Automated Reviewer Loop Summary comment** to append an "Advisory dispositions" subsection immediately after the advisory findings list:
+
+   ```
+   **Advisory dispositions:**
+   - *Finding Name*: [Addressed in `<sha>` | Accepted | Deferred | Rejected] — one-line reason.
+   ```
+
+4. **Edit the comment in place** using `gh api PATCH`:
+
+   ```bash
+   # Find the summary comment ID (last match in case of multiple)
+   comment_id=$(gh api repos/{owner}/{repo}/issues/{pr_number}/comments \
+     --jq '[.[] | select(.body | test("Automated Reviewer Loop Summary"))] | last | .id')
+
+   # Patch with the updated body (include dispositions section at the end, before the script footer)
+   gh api repos/{owner}/{repo}/issues/comments/$comment_id \
+     -X PATCH -f body="<updated body>"
+   ```
+
+This step is mandatory when advisory findings are present. A summary comment that only lists finding names and links without dispositions leaves human reviewers and future retrospectives without visibility into whether findings were considered and why.
+
+---
+
 ### PR feedback tracking and comments
 
 Follow the "PR feedback tracking and comments" subsection of Step 7 in `91-orchestrate-work-protocol.md`:


### PR DESCRIPTION
## Summary

- Protocol 93 gains a new **"Advisory finding dispositions (post-clean)"** step: when `pr-review-loop.sh` exits `clean` with a non-empty `ADVISORY_LABELS`, the runner must evaluate each advisory finding, assign a disposition (Addressed / Accepted / Deferred / Rejected) with a one-line rationale, and patch the Automated Reviewer Loop Summary comment with an "Advisory dispositions" subsection.
- Protocol 91 Step 7 result table updated: the `clean` row now references the advisory dispositions step.

**Motivation**: the summary comment currently lists advisory finding names and links but provides no explanation of whether each finding was considered or why it was not addressed. This leaves human reviewers and retrospective analyses without visibility into the decision-making process.

## Test plan

- [ ] Run the reviewer loop on a PR where PR-Agent returns `clean` with a "Possible Issue" advisory label
- [ ] Verify the summary comment is updated to include an "Advisory dispositions" section with at least one disposition entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Mandatory post-clean step: when advisory findings are present, reviewers must record a disposition per finding (Addressed, Accepted, Deferred, Rejected) with a one-line rationale.
  * "Addressed" dispositions must include the commit SHA.
  * Workflow docs updated to require updating the reviewer summary comment with an "Advisory dispositions" subsection before proceeding; prior protocol now references this step.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/592)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->