### PR TITLE
docs(plan): enforce ready-for-regression label and reviewer-loop handoff via CI

### DIFF
--- a/docs/specs/developments/20260515162721_613-enforce-regression-label-and-reviewer-loop-via-ci/2_613-enforce-regression-label-and-reviewer-loop-via-ci_implementation-plan.md
+++ b/docs/specs/developments/20260515162721_613-enforce-regression-label-and-reviewer-loop-via-ci/2_613-enforce-regression-label-and-reviewer-loop-via-ci_implementation-plan.md
@@ -26,7 +26,7 @@
 | Reviewer-loop summary marker (exact string) | `grep "Automated Reviewer Loop Summary" scripts/development-workflow/pr-review-loop.sh` | Present at lines 123, 3151, 3155, 3304, 3321, 3335 |
 | Secondary marker (unique to script-posted comments) | `grep "Posted automatically by" scripts/development-workflow/pr-review-loop.sh` | Present; combined with `### Automated Reviewer Loop Summary` to uniquely identify script-posted summaries |
 | Existing action pin (checkout) | `grep "actions/checkout" .github/workflows/remove-regression-label-on-push.yml` | `actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1` |
-| Existing in-scope branch prefixes in template | `grep -h "feature/\|fix/\|refactor/\|hotfix/" .github/workflows/remove-regression-label-on-push.yml` | Not listed in that file — prefixes are documented in spec; workflow defines them as a configurable variable |
+| Existing in-scope branch prefixes in template | `grep -h "feature/\|fix/\|refactor/\|hotfix/" .github/workflows/remove-regression-label-on-push.yml` | Not present (prefixes defined as env var in workflow) |
 
 ---
 
@@ -67,10 +67,6 @@ No database, backend, shared package, or frontend layers are affected.
 
 No seed data is required. The feature operates entirely on GitHub Actions events and PR metadata.
 
-| Entity | Values / Scenario | File |
-| --- | --- | --- |
-| — | — | — |
-
 ---
 
 ## Documentation Updates
@@ -101,6 +97,10 @@ name: Apply ready-for-regression label
 on:
   pull_request:
     types: [opened, reopened, ready_for_review, synchronize]
+
+concurrency:
+  group: apply-regression-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   apply-label:
@@ -150,6 +150,10 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review, synchronize]
 
+concurrency:
+  group: reviewer-loop-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   guard:
     runs-on: ubuntu-latest
@@ -163,7 +167,28 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BRANCH: ${{ github.head_ref }}
+          IN_SCOPE_PREFIXES: "feature/ fix/ refactor/ hotfix/"
         run: |
+          # Check whether the branch matches any in-scope prefix
+          in_scope=false
+          for prefix in $IN_SCOPE_PREFIXES; do
+            if [[ "$BRANCH" == "${prefix}"* ]]; then
+              in_scope=true
+              break
+            fi
+          done
+          if [ "$in_scope" = "false" ]; then
+            echo "Branch '$BRANCH' is not in scope — skipping guard check (pass)."
+            gh api \
+              --method POST \
+              "repos/$REPO/statuses/$HEAD_SHA" \
+              -f state="success" \
+              -f description="Not an implementation branch; check skipped." \
+              -f context="Reviewer-loop completion guard"
+            exit 0
+          fi
+
           MARKER1="### Automated Reviewer Loop Summary"
           MARKER2="*Posted automatically by \`pr-review-loop.sh\`.*"
 
@@ -246,11 +271,10 @@ jobs:
 
    Fix any reported issues before committing.
 
-8. **Commit and push**: stage all four new/modified files:
+8. **Commit and push**: stage the three new implementation files:
    - `.github/workflows/apply-regression-label.yml`
    - `.github/workflows/reviewer-loop-guard.yml`
    - `docs/workflow/development-workflow/integrations/ci-enforcement.md`
-   - `docs/specs/developments/20260515162721_613-enforce-regression-label-and-reviewer-loop-via-ci/2_613-enforce-regression-label-and-reviewer-loop-via-ci_implementation-plan.md` (plan — already on the plan branch; the impl branch will carry the actual workflow files)
 
 9. **Verify smoke test runbook**: execute the runbook steps against a test PR (or fixture PR in this repo) to confirm:
    - A `feature/*` PR receives the `ready-for-regression` label automatically.

--- a/docs/specs/developments/20260515162721_613-enforce-regression-label-and-reviewer-loop-via-ci/2_613-enforce-regression-label-and-reviewer-loop-via-ci_implementation-plan.md
+++ b/docs/specs/developments/20260515162721_613-enforce-regression-label-and-reviewer-loop-via-ci/2_613-enforce-regression-label-and-reviewer-loop-via-ci_implementation-plan.md
@@ -242,7 +242,7 @@ jobs:
 4. **Create `docs/workflow/development-workflow/integrations/ci-enforcement.md`**: write a new integration doc that covers:
    - What the two CI workflows do and when they run.
    - Default in-scope branch prefixes (`feature/`, `fix/`, `refactor/`, `hotfix/`).
-   - How downstream repos override the prefix list (override the `IN_SCOPE_PREFIXES` environment variable in the workflow file, or fork and edit the `push` filter).
+   - How downstream repos override the prefix list (override the `IN_SCOPE_PREFIXES` environment variable in the workflow file, or fork and edit the `pull_request` trigger/scope logic).
    - How to add `"Reviewer-loop completion guard"` to branch protection as a required status check (Settings → Branches → Branch protection rules → Require status checks to pass → search for the check name).
    - A note that `ready-for-regression` label auto-creation is idempotent; no manual label setup is required.
 

--- a/docs/specs/developments/20260515162721_613-enforce-regression-label-and-reviewer-loop-via-ci/2_613-enforce-regression-label-and-reviewer-loop-via-ci_implementation-plan.md
+++ b/docs/specs/developments/20260515162721_613-enforce-regression-label-and-reviewer-loop-via-ci/2_613-enforce-regression-label-and-reviewer-loop-via-ci_implementation-plan.md
@@ -1,0 +1,266 @@
+# Enforce Ready-for-Regression Label and Reviewer-Loop Handoff via CI — Implementation Plan
+
+**Spec**: [1\_613-enforce-regression-label-and-reviewer-loop-via-ci\_specs.md](./1_613-enforce-regression-label-and-reviewer-loop-via-ci_specs.md)
+**Smoke test runbook**: [docs/testing/workflow/613-enforce-regression-label-and-reviewer-loop-via-ci.smoke-test.md](../../../../docs/testing/workflow/613-enforce-regression-label-and-reviewer-loop-via-ci.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add two new GitHub Actions workflow files to `.github/workflows/`. The first (`apply-regression-label.yml`) triggers on `pull_request` events (opened, reopened, ready_for_review, synchronize) and applies the `ready-for-regression` label when the head branch matches any configured in-scope implementation prefix. The second (`reviewer-loop-guard.yml`) triggers on the same PR events and posts a failing commit status check when the PR's comment timeline does not contain a canonical "Automated Reviewer Loop Summary" comment posted by `pr-review-loop.sh`. Both workflows are idempotent, require only `GITHUB_TOKEN`, and carry the minimum permissions needed for their job.
+
+**Estimated complexity**: S
+
+**Rationale**: The work is fully scoped to two self-contained GitHub Actions YAML files and minimal documentation. No existing code is modified; no new secrets or external services are introduced; the canonical summary marker is already defined and stable. The label workflow pattern mirrors the existing `remove-regression-label-on-push.yml` file, reducing net authoring risk.
+
+**Dependencies**: None
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `50b337d` |
+| Existing regression-label workflow count | `ls .github/workflows/ \| grep regression` | 1 (`remove-regression-label-on-push.yml`) |
+| Reviewer-loop summary marker (exact string) | `grep "Automated Reviewer Loop Summary" scripts/development-workflow/pr-review-loop.sh` | Present at lines 123, 3151, 3155, 3304, 3321, 3335 |
+| Secondary marker (unique to script-posted comments) | `grep "Posted automatically by" scripts/development-workflow/pr-review-loop.sh` | Present; combined with `### Automated Reviewer Loop Summary` to uniquely identify script-posted summaries |
+| Existing action pin (checkout) | `grep "actions/checkout" .github/workflows/remove-regression-label-on-push.yml` | `actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1` |
+| Existing in-scope branch prefixes in template | `grep -h "feature/\|fix/\|refactor/\|hotfix/" .github/workflows/remove-regression-label-on-push.yml` | Not listed in that file — prefixes are documented in spec; workflow defines them as a configurable variable |
+
+---
+
+## Layer-by-Layer Changes
+
+### Infrastructure / Configuration
+
+- [ ] Add `.github/workflows/apply-regression-label.yml` — new GitHub Actions workflow that auto-applies `ready-for-regression` to implementation PRs based on branch prefix.
+- [ ] Add `.github/workflows/reviewer-loop-guard.yml` — new GitHub Actions workflow that posts a failing commit status when the PR lacks a canonical reviewer-loop summary comment.
+- [ ] Add documentation section to `docs/workflow/development-workflow/integrations/ci-enforcement.md` (new file) explaining: (a) which branch prefixes are in scope by default, (b) how downstream repos override the prefix list, (c) how to configure the reviewer-loop guard as a required status check in branch protection.
+
+No database, backend, shared package, or frontend layers are affected.
+
+---
+
+## Testing Strategy
+
+**Test types**: Smoke / Manual (GitHub Actions run in CI; no unit test framework exists for workflow YAML in this repository).
+
+**Key scenarios to test**:
+
+1. Opening a PR from `feature/`, `fix/`, `refactor/`, or `hotfix/` branch applies `ready-for-regression` automatically — maps to Acceptance Criteria #1 and #3.
+2. Opening a PR from `spec/`, `implementation-plan/`, `docs/`, or `chore/` branch does not apply the label — maps to Acceptance Criterion #2.
+3. Re-running the label workflow when the label is already present completes without error and without duplicating the label — maps to Acceptance Criterion #4.
+4. An implementation PR with no reviewer-loop summary comment shows a failing check — maps to Acceptance Criterion #5.
+5. After `pr-review-loop.sh` posts its summary, the guard check transitions to passing — maps to Acceptance Criterion #6.
+6. A new push to the PR branch (synchronize) causes the guard to re-evaluate — maps to Acceptance Criterion #7.
+7. Both workflow YAML files pass `actionlint` with no warnings — maps to Acceptance Criterion #9.
+8. Permissions declared in each workflow are the minimum required — maps to Acceptance Criterion #10.
+
+**Smoke test runbook**: `docs/testing/workflow/613-enforce-regression-label-and-reviewer-loop-via-ci.smoke-test.md`
+
+**Regression suite**: No automated regression suite exists for GitHub Actions workflow files in this repository. Smoke test covers the acceptance criteria via manual or fixture-PR verification.
+
+---
+
+## Seed Data
+
+No seed data is required. The feature operates entirely on GitHub Actions events and PR metadata.
+
+| Entity | Values / Scenario | File |
+| --- | --- | --- |
+| — | — | — |
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/workflow/development-workflow/integrations/ci-enforcement.md` (new file, created as part of this implementation) — explains default branch prefix list, downstream override, and branch protection wiring. This file IS part of implementation; it is not a post-implementation update.
+- [ ] `CLAUDE.md` / `AGENTS.md` — No update required; this feature adds CI enforcement and does not change agent protocols or project overview conventions.
+- [ ] `docs/project/` docs — No update required; these are placeholder docs and the feature does not affect architecture, business domain, or data model.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| `ready-for-regression` label does not exist in the repo, causing `gh pr edit --add-label` to fail | Low | Med | Create the label in the workflow with `gh label create --force` before applying; `--force` is a no-op when the label already exists |
+| Guard workflow uses a commit status API that requires a SHA, which is unavailable in certain PR event contexts | Low | High | Use `gh pr comment`-based approach or the GitHub Checks API with `github.event.pull_request.head.sha` — always available in `pull_request` events |
+| Downstream repos have customised the reviewer-loop script's summary format | Low | Med | Guard matches on the same two-marker combination already used by `pr-review-loop.sh` itself (lines 3335–3337); downstream repos that fork the script must keep the markers |
+| `actionlint` is not available in the CI runner or locally, blocking the acceptance criterion | Low | Low | `actionlint` is available as a standalone binary via `brew install actionlint` locally, and via `docker run rhysd/actionlint:latest` in CI; the implementation step documents the invocation |
+
+---
+
+## Code Samples
+
+```yaml
+# apply-regression-label.yml — Illustrative — adapt during implementation
+name: Apply ready-for-regression label
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Apply ready-for-regression label for implementation branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          # Override IN_SCOPE_PREFIXES in your repository to customise which branches
+          # receive the label. Default covers the four standard implementation prefixes.
+          IN_SCOPE_PREFIXES: "feature/ fix/ refactor/ hotfix/"
+        run: |
+          # Check whether the branch matches any in-scope prefix
+          in_scope=false
+          for prefix in $IN_SCOPE_PREFIXES; do
+            if [[ "$BRANCH" == "${prefix}"* ]]; then
+              in_scope=true
+              break
+            fi
+          done
+          if [ "$in_scope" = "false" ]; then
+            echo "Branch '$BRANCH' is not in scope — skipping label."
+            exit 0
+          fi
+          # Ensure the label exists (idempotent)
+          gh label create "ready-for-regression" \
+            --repo "$REPO" --color "e4e669" \
+            --description "PR is ready for regression testing" \
+            --force || true
+          # Apply the label (idempotent via --add-label)
+          gh pr edit "$PR_NUMBER" \
+            --repo "$REPO" \
+            --add-label "ready-for-regression"
+          echo "Label 'ready-for-regression' applied to PR #${PR_NUMBER}."
+```
+
+```yaml
+# reviewer-loop-guard.yml — Illustrative — adapt during implementation
+name: Reviewer-loop completion guard
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Check for Automated Reviewer Loop Summary comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          MARKER1="### Automated Reviewer Loop Summary"
+          MARKER2="*Posted automatically by \`pr-review-loop.sh\`.*"
+
+          FOUND=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq '[.[] | select(
+              (.body // "" | contains("### Automated Reviewer Loop Summary")) and
+              (.body // "" | contains("*Posted automatically by `pr-review-loop.sh`.*"))
+            )] | length')
+
+          if [ "${FOUND:-0}" -gt 0 ]; then
+            STATE="success"
+            DESCRIPTION="Reviewer-loop summary present."
+          else
+            STATE="failure"
+            DESCRIPTION="No reviewer-loop summary found. Run the automated reviewer loop before merging."
+          fi
+
+          gh api \
+            --method POST \
+            "repos/$REPO/statuses/$HEAD_SHA" \
+            -f state="$STATE" \
+            -f description="$DESCRIPTION" \
+            -f context="Reviewer-loop completion guard"
+```
+
+---
+
+## Implementation Order
+
+1. **Confirm the `ready-for-regression` label exists in the repository** (or let the workflow create it): verify with `gh label list --repo <repo> | grep ready-for-regression`. Note the current label color/description for the idempotent `gh label create --force` call.
+
+2. **Create `.github/workflows/apply-regression-label.yml`**: implement the workflow based on the code sample above. Key requirements:
+   - Trigger on `pull_request` types: `opened`, `reopened`, `ready_for_review`, `synchronize`.
+   - Read `IN_SCOPE_PREFIXES` from an env var (defaulting to `feature/ fix/ refactor/ hotfix/`) to allow downstream override.
+   - Call `gh label create --force` before `gh pr edit --add-label` so the label always exists.
+   - Use `pull-requests: write` permission (minimum required).
+   - Pin `actions/checkout` to the same SHA used in other workflows (`93cb6efe18208431cddfb8368fd83d5badbf9bfd`) if a checkout step is needed (the label workflow does not need checkout — the `gh` CLI uses the repo slug from `${{ github.repository }}`).
+   - Add a `concurrency` group keyed on the PR number (`apply-regression-label-${{ github.event.pull_request.number }}`) with `cancel-in-progress: true` to avoid race conditions when multiple events fire in quick succession.
+
+3. **Create `.github/workflows/reviewer-loop-guard.yml`**: implement the workflow based on the code sample above. Key requirements:
+   - Trigger on `pull_request` types: `opened`, `reopened`, `ready_for_review`, `synchronize`.
+   - Scope to in-scope implementation branch prefixes only (same `IN_SCOPE_PREFIXES` check as the label workflow — branches outside scope always pass).
+   - Fetch all PR comments via `gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate`.
+   - Match comments that contain **both** `### Automated Reviewer Loop Summary` and `*Posted automatically by \`pr-review-loop.sh\`.*` (same two-marker combination used in `pr-review-loop.sh` line 3335).
+   - Post a GitHub commit status on `HEAD_SHA` (`${{ github.event.pull_request.head.sha }}`): `success` when found, `failure` when absent.
+   - Use context string `"Reviewer-loop completion guard"` so downstream repos can add it to branch protection as a required check by name.
+   - Use `pull-requests: read` and `statuses: write` permissions (minimum required).
+   - Add a `concurrency` group keyed on the PR number (`reviewer-loop-guard-${{ github.event.pull_request.number }}`) with `cancel-in-progress: true`.
+
+4. **Create `docs/workflow/development-workflow/integrations/ci-enforcement.md`**: write a new integration doc that covers:
+   - What the two CI workflows do and when they run.
+   - Default in-scope branch prefixes (`feature/`, `fix/`, `refactor/`, `hotfix/`).
+   - How downstream repos override the prefix list (override the `IN_SCOPE_PREFIXES` environment variable in the workflow file, or fork and edit the `push` filter).
+   - How to add `"Reviewer-loop completion guard"` to branch protection as a required status check (Settings → Branches → Branch protection rules → Require status checks to pass → search for the check name).
+   - A note that `ready-for-regression` label auto-creation is idempotent; no manual label setup is required.
+
+5. **Cross-section consistency self-check**: confirm that the `IN_SCOPE_PREFIXES` default value, the context string `"Reviewer-loop completion guard"`, and the two-marker combination are consistent between the workflow files, the code samples in this plan, and the integration doc.
+
+6. **Pre-commit lint check**: run `markdownlint-cli2` on the plan file and the smoke test runbook before staging:
+
+   ```bash
+   REPO_ROOT=$(git rev-parse --git-common-dir)/..
+   "$REPO_ROOT/node_modules/.bin/markdownlint-cli2" \
+     "docs/specs/developments/20260515162721_613-enforce-regression-label-and-reviewer-loop-via-ci/2_613-enforce-regression-label-and-reviewer-loop-via-ci_implementation-plan.md" \
+     "docs/testing/workflow/613-enforce-regression-label-and-reviewer-loop-via-ci.smoke-test.md"
+   ```
+
+7. **Validate workflow YAML syntax**: run `actionlint` on both new workflow files:
+
+   ```bash
+   # If actionlint is installed locally:
+   actionlint .github/workflows/apply-regression-label.yml .github/workflows/reviewer-loop-guard.yml
+
+   # Fallback via Docker if actionlint is not installed:
+   docker run --rm -v "$(pwd):/repo" rhysd/actionlint:latest \
+     /repo/.github/workflows/apply-regression-label.yml \
+     /repo/.github/workflows/reviewer-loop-guard.yml
+   ```
+
+   Fix any reported issues before committing.
+
+8. **Commit and push**: stage all four new/modified files:
+   - `.github/workflows/apply-regression-label.yml`
+   - `.github/workflows/reviewer-loop-guard.yml`
+   - `docs/workflow/development-workflow/integrations/ci-enforcement.md`
+   - `docs/specs/developments/20260515162721_613-enforce-regression-label-and-reviewer-loop-via-ci/2_613-enforce-regression-label-and-reviewer-loop-via-ci_implementation-plan.md` (plan — already on the plan branch; the impl branch will carry the actual workflow files)
+
+9. **Verify smoke test runbook**: execute the runbook steps against a test PR (or fixture PR in this repo) to confirm:
+   - A `feature/*` PR receives the `ready-for-regression` label automatically.
+   - The guard check fails on a PR with no reviewer-loop summary.
+   - The guard check passes after `pr-review-loop.sh` posts its summary comment.
+
+10. **Update project docs per Documentation Updates section**: as noted above, no post-implementation project doc updates are required beyond the `ci-enforcement.md` file created in Step 4.
+
+11. **Update `CHANGELOG.md`** under `[Unreleased]`:
+
+    ```markdown
+    - **Enforce ready-for-regression label and reviewer-loop handoff via CI** (#613): add two GitHub Actions workflows — one that auto-applies the `ready-for-regression` label to implementation PRs based on branch prefix, and one that asserts the automated reviewer-loop summary comment is present before a PR can be treated as merge-eligible.
+    ```

--- a/docs/testing/workflow/613-enforce-regression-label-and-reviewer-loop-via-ci.smoke-test.md
+++ b/docs/testing/workflow/613-enforce-regression-label-and-reviewer-loop-via-ci.smoke-test.md
@@ -53,7 +53,11 @@ Before running this smoke test:
      --draft
    ```
 
-3. Note the PR number: `PR_NUM=$(gh pr view --json number --jq '.number')`.
+3. Note the PR number:
+
+   ```bash
+   PR_NUM=$(gh pr view --json number --jq '.number')
+   ```
 
 **Expected result after CI runs**:
 
@@ -140,16 +144,16 @@ Before running this smoke test:
 
 ---
 
-### Step 5: Verify a push resets the guard to failing
+### Step 5: Verify the guard re-evaluates on every push
 
-1. Push another empty commit (the `remove-regression-label-on-push.yml` workflow removes the label, and the guard re-evaluates):
+1. Push another empty commit to trigger `synchronize` and force guard re-evaluation:
 
    ```bash
-   git commit --allow-empty -m "chore: second push to verify guard reset"
+   git commit --allow-empty -m "chore: second push to verify guard re-evaluation"
    git push
    ```
 
-2. Wait for both the `remove-regression-label-on-push` and `reviewer-loop-guard` workflows to complete.
+2. Wait for the `reviewer-loop-guard` workflow to complete.
 
 3. Check the guard status on the new SHA:
 
@@ -161,7 +165,8 @@ Before running this smoke test:
 
 **Expected result**:
 
-- `state` is `"failure"` (guard re-evaluated after the push and the new SHA has no summary comment yet).
+- A new status is posted for the new `HEAD_SHA` under context `Reviewer-loop completion guard`.
+- `state` reflects whether the canonical summary comment is present on the PR at evaluation time.
 - **Maps to**: Acceptance Criterion #7 (guard re-evaluates on every push).
 
 ---
@@ -187,7 +192,11 @@ Before running this smoke test:
      --draft
    ```
 
-3. Note this PR number as `PR_NUM_2`.
+3. Note this PR number:
+
+   ```bash
+   PR_NUM_2=$(gh pr view --json number --jq '.number')
+   ```
 
 4. After CI runs:
 
@@ -263,7 +272,7 @@ Each checkbox maps to an acceptance criterion from the spec.
 - [ ] **AC #4**: Re-running the label workflow when the label was already present completed without failure and without duplicating the label.
 - [ ] **AC #5**: The implementation PR with no reviewer-loop summary comment showed a failing `Reviewer-loop completion guard` check.
 - [ ] **AC #6**: After posting the canonical summary comment, the guard check transitioned to passing.
-- [ ] **AC #7**: A subsequent push caused the guard to re-evaluate and fail again (no summary on the new SHA).
+- [ ] **AC #7**: A subsequent push caused the guard to re-evaluate and post a fresh status on the new SHA.
 - [ ] **AC #9** (defer to CI): Both workflow files pass `actionlint` with no new warnings (verified in the implementation PR's CI run).
 - [ ] **AC #10** (defer to CI): Each workflow declares only the minimum permissions required (`pull-requests: write` for the label workflow; `pull-requests: read` + `statuses: write` for the guard).
 
@@ -272,10 +281,6 @@ Each checkbox maps to an acceptance criterion from the spec.
 ## Seed Data Reference
 
 No seed data is required. The smoke test uses fixture branches and PRs created inline.
-
-| Entity | Scenario | How to load |
-| --- | --- | --- |
-| — | — | — |
 
 ---
 

--- a/docs/testing/workflow/613-enforce-regression-label-and-reviewer-loop-via-ci.smoke-test.md
+++ b/docs/testing/workflow/613-enforce-regression-label-and-reviewer-loop-via-ci.smoke-test.md
@@ -1,0 +1,297 @@
+# Smoke Test Runbook: Enforce Ready-for-Regression Label and Reviewer-Loop Handoff via CI
+
+**Feature**: Enforce ready-for-regression label and reviewer-loop handoff via CI/GitHub Actions
+**Spec**: [1\_613-enforce-regression-label-and-reviewer-loop-via-ci\_specs.md](../../specs/developments/20260515162721_613-enforce-regression-label-and-reviewer-loop-via-ci/1_613-enforce-regression-label-and-reviewer-loop-via-ci_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] The two new GitHub Actions workflows are merged to `develop` (or to the branch under test).
+- [ ] You have a GitHub repository with the workflows active (can be this repository or a downstream fork).
+- [ ] You have a local checkout of the repository with `gh` CLI authenticated.
+- [ ] No pre-existing open PRs from the fixture branches listed below are open on the repo.
+
+---
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| In-scope fixture branch | `fix/613-smoke-test-fixture` |
+| Out-of-scope fixture branch | `spec/613-smoke-test-fixture` |
+| Target branch for fixture PRs | `develop` |
+| Label to verify | `ready-for-regression` |
+| Guard check name | `Reviewer-loop completion guard` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Create an in-scope fixture PR (implementation branch)
+
+1. From `develop`, create a temporary fixture branch:
+
+   ```bash
+   git checkout -b fix/613-smoke-test-fixture develop
+   git commit --allow-empty -m "chore: smoke test fixture for #613"
+   git push -u origin fix/613-smoke-test-fixture
+   ```
+
+2. Open a draft PR targeting `develop`:
+
+   ```bash
+   gh pr create \
+     --base develop \
+     --head fix/613-smoke-test-fixture \
+     --title "chore: smoke test fixture for #613 CI enforcement" \
+     --body "Smoke test fixture PR — delete after verification." \
+     --draft
+   ```
+
+3. Note the PR number: `PR_NUM=$(gh pr view --json number --jq '.number')`.
+
+**Expected result after CI runs**:
+
+- The `apply-regression-label` workflow completes successfully.
+- `gh pr view "$PR_NUM" --json labels --jq '.labels[].name'` includes `ready-for-regression`.
+- **Maps to**: Acceptance Criterion #1 (opening an implementation PR applies the label).
+
+---
+
+### Step 2: Verify the reviewer-loop guard fails on the new PR
+
+1. Wait for the `reviewer-loop-guard` workflow run to complete on the fixture PR (typically < 60 s).
+2. Check the commit status:
+
+   ```bash
+   HEAD_SHA=$(gh pr view "$PR_NUM" --json headRefOid --jq '.headRefOid')
+   gh api "repos/$(gh repo view --json nameWithOwner --jq '.nameWithOwner')/commits/$HEAD_SHA/statuses" \
+     --jq '[.[] | select(.context == "Reviewer-loop completion guard")] | last | {state, description}'
+   ```
+
+**Expected result**:
+
+- `state` is `"failure"`.
+- `description` mentions that no reviewer-loop summary was found.
+- **Maps to**: Acceptance Criterion #5 (guard fails when no summary comment is present).
+
+---
+
+### Step 3: Verify a draft-to-non-draft conversion still carries the label
+
+1. Convert the fixture PR to non-draft:
+
+   ```bash
+   gh pr ready "$PR_NUM"
+   ```
+
+2. Check labels after CI runs:
+
+   ```bash
+   gh pr view "$PR_NUM" --json labels --jq '.labels[].name'
+   ```
+
+**Expected result**:
+
+- `ready-for-regression` is still present (or reapplied by the `ready_for_review` trigger).
+- **Maps to**: Acceptance Criterion #3 (converting a draft PR results in the label being present).
+
+---
+
+### Step 4: Simulate the reviewer-loop summary comment
+
+1. Post a synthetic summary comment that matches the canonical marker:
+
+   ```bash
+   gh pr comment "$PR_NUM" --body "### Automated Reviewer Loop Summary
+
+**Result:** CLEAN
+**Platforms:** pr-agent, coderabbit
+**Findings:** 0 blocking, 0 suggestions
+
+*Posted automatically by \`pr-review-loop.sh\`.*"
+   ```
+
+2. Push a no-op commit to trigger the `synchronize` event:
+
+   ```bash
+   git commit --allow-empty -m "chore: trigger synchronize event for guard re-evaluation"
+   git push
+   ```
+
+3. Wait for the guard workflow to complete, then re-check the commit status:
+
+   ```bash
+   HEAD_SHA=$(gh pr view "$PR_NUM" --json headRefOid --jq '.headRefOid')
+   gh api "repos/$(gh repo view --json nameWithOwner --jq '.nameWithOwner')/commits/$HEAD_SHA/statuses" \
+     --jq '[.[] | select(.context == "Reviewer-loop completion guard")] | last | {state, description}'
+   ```
+
+**Expected result**:
+
+- `state` is `"success"`.
+- `description` indicates the reviewer-loop summary is present.
+- **Maps to**: Acceptance Criterion #6 (guard passes once the summary comment is present).
+
+---
+
+### Step 5: Verify a push resets the guard to failing
+
+1. Push another empty commit (the `remove-regression-label-on-push.yml` workflow removes the label, and the guard re-evaluates):
+
+   ```bash
+   git commit --allow-empty -m "chore: second push to verify guard reset"
+   git push
+   ```
+
+2. Wait for both the `remove-regression-label-on-push` and `reviewer-loop-guard` workflows to complete.
+
+3. Check the guard status on the new SHA:
+
+   ```bash
+   HEAD_SHA=$(gh pr view "$PR_NUM" --json headRefOid --jq '.headRefOid')
+   gh api "repos/$(gh repo view --json nameWithOwner --jq '.nameWithOwner')/commits/$HEAD_SHA/statuses" \
+     --jq '[.[] | select(.context == "Reviewer-loop completion guard")] | last | {state, description}'
+   ```
+
+**Expected result**:
+
+- `state` is `"failure"` (guard re-evaluated after the push and the new SHA has no summary comment yet).
+- **Maps to**: Acceptance Criterion #7 (guard re-evaluates on every push).
+
+---
+
+### Step 6: Verify an out-of-scope branch does NOT receive the label
+
+1. Create a second fixture branch with an out-of-scope prefix:
+
+   ```bash
+   git checkout -b spec/613-smoke-test-fixture develop
+   git commit --allow-empty -m "chore: out-of-scope smoke test fixture for #613"
+   git push -u origin spec/613-smoke-test-fixture
+   ```
+
+2. Open a draft PR:
+
+   ```bash
+   gh pr create \
+     --base develop \
+     --head spec/613-smoke-test-fixture \
+     --title "chore: out-of-scope fixture for #613 CI enforcement" \
+     --body "Smoke test fixture PR — delete after verification." \
+     --draft
+   ```
+
+3. Note this PR number as `PR_NUM_2`.
+
+4. After CI runs:
+
+   ```bash
+   gh pr view "$PR_NUM_2" --json labels --jq '.labels[].name'
+   ```
+
+**Expected result**:
+
+- `ready-for-regression` is NOT in the label list.
+- The `apply-regression-label` workflow run completed successfully (not a workflow error).
+- **Maps to**: Acceptance Criterion #2 (out-of-scope branches do not receive the label).
+
+---
+
+### Step 7: Verify idempotency (label already present)
+
+1. Manually add the `ready-for-regression` label to the fixture PR (`$PR_NUM`):
+
+   ```bash
+   gh pr edit "$PR_NUM" --add-label "ready-for-regression"
+   ```
+
+2. Push another empty commit to trigger the `apply-regression-label` workflow:
+
+   ```bash
+   git checkout fix/613-smoke-test-fixture
+   git commit --allow-empty -m "chore: idempotency test"
+   git push
+   ```
+
+3. After CI runs, check labels and the workflow run result:
+
+   ```bash
+   gh pr view "$PR_NUM" --json labels --jq '.labels[].name'
+   # Also check the workflow run for "Label 'ready-for-regression' already present" log message
+   ```
+
+**Expected result**:
+
+- The label is still present (not duplicated, not removed by the apply workflow).
+- The workflow run exit code is 0 (no failure on duplicate label).
+- **Maps to**: Acceptance Criterion #4 (workflow is idempotent when label is already present).
+
+---
+
+### Last Step: Clean up fixture PRs and branches
+
+1. Close and delete the fixture PRs:
+
+   ```bash
+   gh pr close "$PR_NUM" --delete-branch
+   gh pr close "$PR_NUM_2" --delete-branch
+   ```
+
+2. If branches were not deleted automatically:
+
+   ```bash
+   git push origin --delete fix/613-smoke-test-fixture
+   git push origin --delete spec/613-smoke-test-fixture
+   git branch -d fix/613-smoke-test-fixture spec/613-smoke-test-fixture
+   ```
+
+---
+
+## Assertions Checklist
+
+Each checkbox maps to an acceptance criterion from the spec.
+
+- [ ] **AC #1**: Opening a PR from `fix/613-smoke-test-fixture` caused `ready-for-regression` to be applied automatically without any agent or human action.
+- [ ] **AC #2**: Opening a PR from `spec/613-smoke-test-fixture` did not result in `ready-for-regression` being applied.
+- [ ] **AC #3**: Converting the draft implementation PR to non-draft resulted in the label being present.
+- [ ] **AC #4**: Re-running the label workflow when the label was already present completed without failure and without duplicating the label.
+- [ ] **AC #5**: The implementation PR with no reviewer-loop summary comment showed a failing `Reviewer-loop completion guard` check.
+- [ ] **AC #6**: After posting the canonical summary comment, the guard check transitioned to passing.
+- [ ] **AC #7**: A subsequent push caused the guard to re-evaluate and fail again (no summary on the new SHA).
+- [ ] **AC #9** (defer to CI): Both workflow files pass `actionlint` with no new warnings (verified in the implementation PR's CI run).
+- [ ] **AC #10** (defer to CI): Each workflow declares only the minimum permissions required (`pull-requests: write` for the label workflow; `pull-requests: read` + `statuses: write` for the guard).
+
+---
+
+## Seed Data Reference
+
+No seed data is required. The smoke test uses fixture branches and PRs created inline.
+
+| Entity | Scenario | How to load |
+| --- | --- | --- |
+| — | — | — |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `apply-regression-label` workflow fails with "Label not found" | The `ready-for-regression` label does not exist in the repo and `gh label create --force` was not included | Verify the workflow includes the `gh label create --force` step before `gh pr edit --add-label` |
+| Guard workflow fails with a GitHub API error instead of a status check | `statuses: write` permission missing from the workflow | Add `statuses: write` under `permissions` in `reviewer-loop-guard.yml` |
+| Guard reports "failure" even after posting the summary comment | Comment body does not contain both required markers | Confirm the comment contains exactly `### Automated Reviewer Loop Summary` and `*Posted automatically by \`pr-review-loop.sh\`.*` |
+| Out-of-scope branch (`spec/*`) receives the label | `IN_SCOPE_PREFIXES` env var contains an unexpected value | Check the env var default in `apply-regression-label.yml`; ensure `spec/` is not included |
+| `actionlint` reports warnings on the new workflow files | YAML syntax issue or unsupported action reference | Fix the reported lines; re-run `actionlint` |
+
+---
+
+## Known Limitations
+
+- The guard check uses the GitHub Commit Statuses API (not Checks API). Some branch protection UIs surface statuses and checks in separate sections. Downstream maintainers must search for `Reviewer-loop completion guard` in the "Statuses" section, not only under "GitHub Actions checks", when configuring branch protection.
+- The smoke test steps require a repository where the workflows are active. This runbook cannot be executed entirely offline.

--- a/docs/testing/workflow/613-enforce-regression-label-and-reviewer-loop-via-ci.smoke-test.md
+++ b/docs/testing/workflow/613-enforce-regression-label-and-reviewer-loop-via-ci.smoke-test.md
@@ -75,7 +75,7 @@ Before running this smoke test:
    ```bash
    HEAD_SHA=$(gh pr view "$PR_NUM" --json headRefOid --jq '.headRefOid')
    gh api "repos/$(gh repo view --json nameWithOwner --jq '.nameWithOwner')/commits/$HEAD_SHA/statuses" \
-     --jq '[.[] | select(.context == "Reviewer-loop completion guard")] | last | {state, description}'
+     --jq '[.[] | select(.context == "Reviewer-loop completion guard")] | first | {state, description}'
    ```
 
 **Expected result**:
@@ -133,7 +133,7 @@ Before running this smoke test:
    ```bash
    HEAD_SHA=$(gh pr view "$PR_NUM" --json headRefOid --jq '.headRefOid')
    gh api "repos/$(gh repo view --json nameWithOwner --jq '.nameWithOwner')/commits/$HEAD_SHA/statuses" \
-     --jq '[.[] | select(.context == "Reviewer-loop completion guard")] | last | {state, description}'
+     --jq '[.[] | select(.context == "Reviewer-loop completion guard")] | first | {state, description}'
    ```
 
 **Expected result**:
@@ -160,7 +160,7 @@ Before running this smoke test:
    ```bash
    HEAD_SHA=$(gh pr view "$PR_NUM" --json headRefOid --jq '.headRefOid')
    gh api "repos/$(gh repo view --json nameWithOwner --jq '.nameWithOwner')/commits/$HEAD_SHA/statuses" \
-     --jq '[.[] | select(.context == "Reviewer-loop completion guard")] | last | {state, description}'
+     --jq '[.[] | select(.context == "Reviewer-loop completion guard")] | first | {state, description}'
    ```
 
 **Expected result**:


### PR DESCRIPTION
## Summary

Implementation plan for issue #613 — structural CI enforcement of two recurring workflow gaps:
1. `ready-for-regression` label missing when agents declare PRs ready for human review.
2. PRs treated as ready without the automated reviewer-loop running to completion.

## Approach

**Two new GitHub Actions workflow files**:
- `.github/workflows/apply-regression-label.yml` — triggers on `pull_request` events (opened, reopened, ready_for_review, synchronize); auto-applies `ready-for-regression` to implementation branches (`feature/`, `fix/`, `refactor/`, `hotfix/`); skips all other branch prefixes; idempotent.
- `.github/workflows/reviewer-loop-guard.yml` — triggers on the same events; asserts the canonical `### Automated Reviewer Loop Summary` comment is present on the PR; posts a GitHub commit status (`Reviewer-loop completion guard`) that downstream repos can add to branch protection as a required check.

**One new integration doc**: `docs/workflow/development-workflow/integrations/ci-enforcement.md` explaining default branch prefix list, downstream override, and branch protection wiring.

**Estimated complexity**: S — two self-contained YAML files and a doc page. No existing code is modified; no secrets or external services required beyond `GITHUB_TOKEN`.

**Key risks**:
- `ready-for-regression` label might not exist in target repos → mitigated by `gh label create --force` in the workflow.
- Guard uses Commit Statuses API (not Checks API) → documented in smoke test troubleshooting.

## Links

- Spec: `docs/specs/developments/20260515162721_613-enforce-regression-label-and-reviewer-loop-via-ci/1_613-enforce-regression-label-and-reviewer-loop-via-ci_specs.md`
- Implementation plan: `docs/specs/developments/20260515162721_613-enforce-regression-label-and-reviewer-loop-via-ci/2_613-enforce-regression-label-and-reviewer-loop-via-ci_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/613-enforce-regression-label-and-reviewer-loop-via-ci.smoke-test.md`

Closes #613 (plan stage only — issue remains open until implementation PR is merged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an implementation plan for CI-driven automation that applies a regression-readiness label to in-scope branches and gates merge readiness on a reviewer-loop completion check.
  * Added a smoke-test runbook with step-by-step validation, acceptance criteria, verification checklist, idempotency/edge-case handling, troubleshooting guidance, and cleanup instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->