### PR TITLE
chore(backport): hotfix v0.27.1 — disable relative-links rule in CI

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,13 +1,16 @@
 // markdownlint-cli2 configuration for spec, plan, and CHANGELOG documents.
 //
-// This file registers the markdownlint-rule-relative-links custom rule plugin
-// and configures the rule set. The rule settings are also mirrored in
-// .markdownlint.jsonc for editor integrations that read that file directly.
+// The rule settings are also mirrored in .markdownlint.jsonc for editor
+// integrations that read that file directly.
 //
 // Rules enabled:
 //   MD009 — Trailing spaces (hard-break exception: two trailing spaces allowed)
 //   MD047 — Files should end with a single newline
-//   relative-links — Relative links must resolve to existing files (custom plugin)
+//
+// Rules disabled:
+//   relative-links — Disabled because implementation plans intentionally
+//                    reference smoke test runbooks that are created later in the
+//                    workflow (forward references are the expected pattern here).
 //
 // All other default rules are disabled so future markdownlint upgrades do not
 // silently break existing documents.
@@ -16,8 +19,6 @@
 //   <!-- markdownlint-disable MD009 -->
 //   <!-- markdownlint-disable-next-line MD009 -->
 {
-  "customRules": ["markdownlint-rule-relative-links"],
-
   "config": {
     "default": false,
 
@@ -27,8 +28,6 @@
       "strict": false
     },
 
-    "MD047": true,
-
-    "relative-links": true
+    "MD047": true
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.1] - 2026-05-19
+
+### Fixed
+
+- **`markdown-lint.yml`: disable `relative-links` rule in CI** (hotfix): implementation plans intentionally reference smoke test runbooks that are created later in the workflow — those forward references caused CI failures for any downstream project with plans. `markdownlint-rule-relative-links` is removed from `.markdownlint-cli2.jsonc` (the CI/runner config); `.markdownlint.jsonc` retains the rule for editor integrations.
+
 ## [0.27.0] - 2026-05-19
 
 ### Added
@@ -17,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI enforcement: auto-apply `ready-for-regression` and assert reviewer-loop summary** (#613): two new GitHub Actions workflows — `apply-regression-label.yml` (auto-labels implementation PRs by branch prefix) and `reviewer-loop-guard.yml` (blocks merge-eligibility when the reviewer-loop summary comment is absent).
 - **Auto-remove `ready-for-regression` label on push** (#612): `remove-regression-label-on-push.yml` removes the label when new commits are pushed, preventing stale regression-readiness signals.
 - **Canary test requirement for filter-schema additions** (#606): developer and code-reviewer protocols now require a two-invocation canary test for every new filter parameter; absence is a blocking review finding.
-- **Mandatory advisory finding dispositions in reviewer loop summary**: Protocol 93 requires runners to evaluate each non-blocking advisory finding and record a disposition (Addressed / Accepted / Deferred / Rejected) in the summary comment on clean exits.
+- **Mandatory advisory finding dispositions in reviewer loop summary**: Protocol 93 requires runners to evaluate each non-breaking advisory finding and record a disposition (Addressed / Accepted / Deferred / Rejected) in the summary comment on clean exits.
 - **Script quality gates and test harness for `pr-review-loop.sh`** (#585): adds `scripts/development-workflow/tests/test-pr-review-loop.sh` and a path-triggered CI workflow; prepare-release and retrospective protocols gain script-coverage and downstream bug-review checklist items.
 - **Prettier for markdown formatting** (#584): adds `prettier` v3.8.3 and formats all `.md` files so downstream `/sync-template` runs see no spurious diffs.
 
@@ -707,7 +713,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.0...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.1...HEAD
+[0.27.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.26.1...v0.27.0
 [0.26.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.25.1...v0.26.0


### PR DESCRIPTION
## Summary

Backport of hotfix v0.27.1 (PR #673) to `develop`.

- Disables `markdownlint-rule-relative-links` in `.markdownlint-cli2.jsonc` (CI runner config) — implementation plans forward-reference smoke test runbooks that don't exist yet, causing CI failures downstream
- Adds `[0.27.1]` versioned section to CHANGELOG with correct compare-link refs

## Test plan

- [ ] `.markdownlint-cli2.jsonc` has no `customRules` or `"relative-links": true`
- [ ] CHANGELOG has `[0.27.1]` above `[0.27.0]` with correct compare links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI environment markdown linting configuration.

* **Documentation**
  * Updated release notes for versions 0.27.1 and 0.27.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->