### PR TITLE
fix: reviewer-loop and sync-template correctness fixes (hotfix v0.27.2)

### DIFF
--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -552,19 +552,24 @@ fi
 For each `.yml` / `.yaml` file in `.github/workflows/`:
 
 ```bash
+yaml_parse_failed=0
 for f in .github/workflows/*.yml .github/workflows/*.yaml; do
   [ -f "$f" ] || continue
   if command -v yamllint >/dev/null 2>&1; then
     yamllint -d "{extends: relaxed, rules: {line-length: disable}}" "$f" \
-      || echo "YAML LINT ERROR: $f"
+      || { echo "YAML LINT ERROR: $f"; yaml_parse_failed=1; }
   else
     python3 -c "import sys, yaml; yaml.safe_load(open(sys.argv[1]))" "$f" \
-      || echo "YAML PARSE ERROR: $f"
+      || { echo "YAML PARSE ERROR: $f"; yaml_parse_failed=1; }
   fi
 done
+
+if [ "$yaml_parse_failed" -ne 0 ]; then
+  echo "ERROR: One or more workflow YAML files failed validation. Fix before committing."
+fi
 ```
 
-If any file fails to parse, **do not commit**. Report the broken file(s) and ask the maintainer to fix them before committing.
+If `yaml_parse_failed` is non-zero, **do not commit**. Report the broken file(s) and ask the maintainer to fix them before committing.
 
 ### 3. Validate that `scripts/` paths referenced in workflow `run:` steps exist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.2] - 2026-05-19
+
+### Fixed
+
+- **`pr-review-loop.sh`: scope `HARNESS_MODE` bypass to sourced loads only** (hotfix): the single-instance lock guard was bypassed whenever `HARNESS_MODE=1` was set, even for direct executions against real PRs. A new `_HARNESS_MODE_EFFECTIVE` flag is only set when the script is sourced (`BASH_SOURCE[0] != $0`), so normal runs always retain the lock guard and signal traps.
+- **`pr-review-loop.sh`: re-validate REST gate after auto-reply** (hotfix): after posting auto-replies to unreplied outside-diff comments, `coderabbit_thread_gate_clean` now re-calls `check_unreplied_rest_comments` to confirm the count is zero before returning `clean`. Prevents a false-clean result when one or more auto-replies silently fail to post.
+- **`pr-review-loop.sh`: fix misleading docstring on `auto_reply_unreplied_rest_comments`** (hotfix): the function comment incorrectly described the target as "comments whose GraphQL thread is already resolved"; corrected to "outside-diff comments with no corresponding GraphQL thread".
+- **`.claude/skills/sync-template.md`: restore `yaml_parse_failed` tracking in YAML validation loop** (hotfix): the CI workflow YAML validation loop was missing the `yaml_parse_failed=0` initializer and `|| { ...; yaml_parse_failed=1; }` compound commands, so parse errors were printed but never blocked the commit. Restored to match the `.claude/commands/sync-template.md` reference implementation.
+
 ## [0.27.1] - 2026-05-19
 
 ### Fixed
@@ -713,7 +722,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.1...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.2...HEAD
+[0.27.2]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.1...v0.27.2
 [0.27.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.26.1...v0.27.0
 [0.26.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.26.0...v0.26.1

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -9,10 +9,19 @@ SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/development-workflow/workflow-lib.sh
 source "$SCRIPT_DIR/workflow-lib.sh"
 
-# In HARNESS_MODE, skip the single-instance lock guard entirely.
+# Effective harness mode: only active when HARNESS_MODE=1 AND the script is
+# sourced (BASH_SOURCE[0] != $0). When executed directly with HARNESS_MODE=1
+# set in the environment, treat it as a normal run so the lock guard and all
+# signal traps remain active and protect the real PR.
+_HARNESS_MODE_EFFECTIVE=0
+if [ "${HARNESS_MODE:-0}" -eq 1 ] && [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  _HARNESS_MODE_EFFECTIVE=1
+fi
+
+# In harness mode (sourced), skip the single-instance lock guard entirely.
 # The guard is irrelevant when the script is sourced by the test harness
 # (no real PR is being processed and no lock directory should be created).
-if [ "${HARNESS_MODE:-0}" -ne 1 ]; then
+if [ "$_HARNESS_MODE_EFFECTIVE" -ne 1 ]; then
 
 # --- Single-instance guard ---
 # Prevent two simultaneous invocations for the same PR. Uses an atomic mkdir
@@ -1581,11 +1590,12 @@ check_unreplied_rest_comments() {
 
 auto_reply_unreplied_rest_comments() {
   # Post a brief acknowledgement reply to each unreplied CodeRabbit REST review
-  # comment whose GraphQL thread is already resolved.  Called by
+  # comment that has no corresponding resolved GraphQL thread (i.e., outside-diff
+  # comments with no GraphQL thread representation).  Called by
   # coderabbit_thread_gate_clean after the GraphQL thread audit passes but the
-  # REST supplement still reports unreplied comments.  Replying satisfies the
-  # check_unreplied_rest_comments gate so the loop can advance to RESULT=clean
-  # without requiring manual intervention.
+  # REST supplement still reports unreplied outside-diff comments.  Replying
+  # satisfies the check_unreplied_rest_comments gate so the loop can advance to
+  # RESULT=clean without requiring manual intervention.
   #
   # Arguments:
   #   $1  pr_number              - PR number (integer)
@@ -1917,7 +1927,30 @@ coderabbit_thread_gate_clean() {
       print_kv UNRESOLVED_THREAD_COUNT "${rest_unreplied_raw:-0}"
       return 1
     fi
-    # Replies posted successfully — fall through to return 0 (RESULT=clean).
+    # Re-validate the gate after auto-replies to confirm the count is now zero.
+    # A partial success from auto_reply_unreplied_rest_comments (exit 0 but some
+    # replies silently dropped) would otherwise cause a false clean return.
+    local recheck_raw recheck_st
+    set +e
+    recheck_raw="$(check_unreplied_rest_comments "$pr_number" "$repo" "$bot_login" "$resolved_ids_json")"
+    recheck_st=$?
+    eval "$prev_errexit"
+    if [ "$recheck_st" -eq 0 ] && [ "${recheck_raw:-0}" -gt 0 ]; then
+      echo "WARN: ${recheck_raw} unreplied REST comment(s) remain after auto-reply on PR #$pr_number — returning needs_fixes" >&2
+      print_kv RESULT needs_fixes
+      print_kv REASON coderabbit_unreplied_rest_comments
+      print_kv PLATFORM "$platform"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv BRANCH "$branch_name"
+      print_kv REVIEW_COMMENT_ID ""
+      print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv COMMENT_COUNT "${recheck_raw:-0}"
+      print_kv BLOCKING_COUNT "${recheck_raw:-0}"
+      print_kv SUGGESTION_COUNT 0
+      print_kv UNRESOLVED_THREAD_COUNT "${recheck_raw:-0}"
+      return 1
+    fi
+    # Gate confirmed clean after auto-replies — fall through to return 0.
   fi
   if [ "$rest_check_st" -ne 0 ]; then
     # REST failure is non-fatal: the GraphQL thread check already passed.
@@ -2906,7 +2939,7 @@ METRICS_HEADER
 # All function definitions above (including normalize_platform_verdict and
 # append_compare_metrics_row) are loaded; only the argument-parsing and
 # execution sections below are skipped.
-[ "${HARNESS_MODE:-0}" -eq 1 ] && return 0 2>/dev/null || true
+[ "$_HARNESS_MODE_EFFECTIVE" -eq 1 ] && return 0 2>/dev/null || true
 
 if [ "$#" -lt 1 ]; then
   usage >&2

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1935,7 +1935,24 @@ coderabbit_thread_gate_clean() {
     recheck_raw="$(check_unreplied_rest_comments "$pr_number" "$repo" "$bot_login" "$resolved_ids_json")"
     recheck_st=$?
     eval "$prev_errexit"
-    if [ "$recheck_st" -eq 0 ] && [ "${recheck_raw:-0}" -gt 0 ]; then
+    if [ "$recheck_st" -ne 0 ]; then
+      # Re-check REST query failed — cannot confirm gate is clean; treat as
+      # needs_fixes so the agent re-inspects rather than claiming false clean.
+      echo "WARN: REST re-check failed (exit $recheck_st) after auto-reply on PR #$pr_number — returning needs_fixes" >&2
+      print_kv RESULT needs_fixes
+      print_kv REASON coderabbit_unreplied_rest_comments
+      print_kv PLATFORM "$platform"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv BRANCH "$branch_name"
+      print_kv REVIEW_COMMENT_ID ""
+      print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv COMMENT_COUNT 0
+      print_kv BLOCKING_COUNT 0
+      print_kv SUGGESTION_COUNT 0
+      print_kv UNRESOLVED_THREAD_COUNT 0
+      return 1
+    fi
+    if [ "${recheck_raw:-0}" -gt 0 ]; then
       echo "WARN: ${recheck_raw} unreplied REST comment(s) remain after auto-reply on PR #$pr_number — returning needs_fixes" >&2
       print_kv RESULT needs_fixes
       print_kv REASON coderabbit_unreplied_rest_comments


### PR DESCRIPTION
## Summary

Four bugs found via downstream template sync review (lhpaul/kids-safety-platform PR #181).

- **`pr-review-loop.sh`: `HARNESS_MODE` bypass scoped to sourced loads only** — introduces `_HARNESS_MODE_EFFECTIVE` flag; only set when `BASH_SOURCE[0] != $0`. Direct executions always retain lock guard and signal traps.
- **`pr-review-loop.sh`: re-validate REST gate after auto-reply** — adds a second `check_unreplied_rest_comments` call after auto-replies to confirm count is zero; prevents false-clean when replies silently fail.
- **`pr-review-loop.sh`: fix misleading docstring** — corrected description of `auto_reply_unreplied_rest_comments` to accurately describe outside-diff comments with no GraphQL thread.
- **`.claude/skills/sync-template.md`: restore `yaml_parse_failed` tracking** — missing `yaml_parse_failed=0` init and `|| { ...; yaml_parse_failed=1; }` branches meant YAML parse errors printed but never blocked the commit.

## Test plan

- [ ] `_HARNESS_MODE_EFFECTIVE` is `0` when `HARNESS_MODE=1` but script is executed directly
- [ ] `_HARNESS_MODE_EFFECTIVE` is `1` when `HARNESS_MODE=1` and script is sourced
- [ ] After auto-reply, REST gate is re-checked before returning clean
- [ ] `.claude/skills/sync-template.md` YAML loop sets `yaml_parse_failed=1` on error and prints the ERROR line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CI validation now detects YAML parse/lint failures, aggregates errors, and blocks when parsing fails.
  * PR review flow improves harness-mode detection to avoid skipping guards when not sourced.
  * Auto-reply logic now rechecks external comment threads and marks reviews as needing fixes if replies remain unresolved.

* **Documentation**
  * Added release notes entry for version 0.27.2 with hotfix details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->