### PR TITLE
fix(reviewer-loop): paginated slurp, jq-encoded reply body, clarify auto-reply (hotfix v0.27.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.3] - 2026-05-19
+
+### Fixed
+
+- **`pr-review-loop.sh`: slurp paginated pages in `silent_no_paused_count`** (hotfix): `gh api --paginate` emits one JSON array per page; without `-s`/`--slurp` the `jq` filter iterated over pages rather than comments, producing a multi-line count that caused integer-expression errors in the silent non-trigger retrigger path. Added `-s` and changed `.[]` to `.[].[]`.
+- **`pr-review-loop.sh`: use jq-encoded JSON body in `auto_reply_unreplied_rest_comments`** (hotfix): replaced `--raw-field body=` with a `jq -n --arg body` pipe and `--input -` so special characters in the reply body are correctly JSON-escaped before being sent to the GitHub API.
+- **`pr-review-loop.sh`: clarify auto-reply body and comment** (hotfix): the reply message now reads "Acknowledged — outside-diff comment noted…" (was "Resolved — addressed in this PR.") to make clear it is an automated gate acknowledgement, not a claim that the comment content was addressed. Added an explanatory code comment.
+
 ## [0.27.2] - 2026-05-19
 
 ### Fixed
@@ -722,7 +730,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.2...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.3...HEAD
+[0.27.3]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.2...v0.27.3
 [0.27.2]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.1...v0.27.2
 [0.27.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.26.1...v0.27.0

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1610,7 +1610,13 @@ auto_reply_unreplied_rest_comments() {
   local repo="$2"
   local bot_login="$3"
   local resolved_ids_json="${4:-[]}"
-  local reply_body="Resolved — addressed in this PR."
+  # This reply is an automated acknowledgement only — it does not assert that the
+  # specific comment content was addressed. It is posted solely to satisfy the
+  # check_unreplied_rest_comments gate for outside-diff comments that have no
+  # corresponding GraphQL review thread and therefore cannot be resolved via the
+  # normal thread-resolution mechanism. All GraphQL review threads have already
+  # been verified resolved before this function is called.
+  local reply_body="Acknowledged — outside-diff comment noted. All review threads for this PR have been resolved via the standard review process."
 
   # Fetch IDs of root CodeRabbit comments that need a reply (same filter logic
   # as check_unreplied_rest_comments, but returns IDs instead of a count).
@@ -1647,10 +1653,13 @@ auto_reply_unreplied_rest_comments() {
   local comment_id
   while IFS= read -r comment_id; do
     [ -z "$comment_id" ] && continue
-    if gh api "repos/$repo/pulls/$pr_number/comments/$comment_id/replies" \
-         --method POST \
-         --raw-field body="$reply_body" \
-         --silent > /dev/null 2>&1; then
+    local reply_json
+    reply_json="$(jq -n --arg body "$reply_body" '{"body": $body}')"
+    if printf '%s' "$reply_json" \
+         | gh api "repos/$repo/pulls/$pr_number/comments/$comment_id/replies" \
+             --method POST \
+             --input - \
+             --silent > /dev/null 2>&1; then
       reply_count=$((reply_count + 1))
       echo "INFO: auto-replied to REST comment $comment_id on PR #$pr_number" >&2
     else
@@ -2269,8 +2278,8 @@ run_coderabbit_review() {
       local silent_no_paused_count
       silent_no_paused_count="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq --arg bot "$bot_login" --arg since "$since_iso" '
-              [.[] | select(
+          | jq -s --arg bot "$bot_login" --arg since "$since_iso" '
+              [.[].[] | select(
                   .user.login == $bot and
                   .created_at > $since and
                   (


### PR DESCRIPTION
## Summary

Three bugs found via downstream template sync review (lhpaul/seia PR #357).

- **`silent_no_paused_count`: slurp paginated pages** — `gh api --paginate` emits one JSON array per page; without `-s` the `jq` filter counted pages instead of comments, producing a multi-line value that caused integer-expression errors in the silent non-trigger retrigger path.
- **`auto_reply_unreplied_rest_comments`: jq-encoded JSON body** — replaced `--raw-field body=` with `jq -n --arg body` pipe and `--input -` so special characters in the reply string are correctly JSON-encoded before reaching the GitHub API.
- **Auto-reply message and comment clarified** — reply now reads "Acknowledged — outside-diff comment noted…" (was "Resolved — addressed in this PR.") with an explanatory comment making clear this is a gate acknowledgement, not a claim the comment was addressed.

## Test plan

- [ ] `silent_no_paused_count` jq filter uses `-s` and `.[].[]`
- [ ] `auto_reply_unreplied_rest_comments` pipes `jq`-encoded JSON via `--input -`
- [ ] Reply body starts with "Acknowledged"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination issue with comment counting in non-paused mode.
  * Fixed handling of JSON-escaped request bodies in auto-reply messages.
  * Improved clarity of acknowledgement messaging for outside-diff review comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->