### PR TITLE
chore(backport): hotfix v0.27.3 — pr-review-loop paginated slurp and auto-reply fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.3] - 2026-05-19
+
+### Fixed
+
+- **`pr-review-loop.sh`: slurp paginated pages in `silent_no_paused_count`** (hotfix): `gh api --paginate` emits one JSON array per page; without `-s`/`--slurp` the `jq` filter iterated over pages rather than comments, producing a multi-line count that caused integer-expression errors in the silent non-trigger retrigger path. Added `-s` and changed `.[]` to `.[].[]`.
+- **`pr-review-loop.sh`: use jq-encoded JSON body in `auto_reply_unreplied_rest_comments`** (hotfix): replaced `--raw-field body=` with a `jq -n --arg body` pipe and `--input -` so special characters in the reply body are correctly JSON-escaped before being sent to the GitHub API.
+- **`pr-review-loop.sh`: clarify auto-reply body and comment** (hotfix): the reply message now reads "Acknowledged — outside-diff comment noted…" (was "Resolved — addressed in this PR.") to make clear it is an automated gate acknowledgement, not a claim that the comment content was addressed. Added an explanatory code comment.
+
 ## [0.27.2] - 2026-05-19
 
 ### Fixed
@@ -722,7 +730,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.2...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.3...HEAD
+[0.27.3]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.2...v0.27.3
 [0.27.2]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.1...v0.27.2
 [0.27.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.26.1...v0.27.0

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1610,7 +1610,13 @@ auto_reply_unreplied_rest_comments() {
   local repo="$2"
   local bot_login="$3"
   local resolved_ids_json="${4:-[]}"
-  local reply_body="Resolved — addressed in this PR."
+  # This reply is an automated acknowledgement only — it does not assert that the
+  # specific comment content was addressed. It is posted solely to satisfy the
+  # check_unreplied_rest_comments gate for outside-diff comments that have no
+  # corresponding GraphQL review thread and therefore cannot be resolved via the
+  # normal thread-resolution mechanism. All GraphQL review threads have already
+  # been verified resolved before this function is called.
+  local reply_body="Acknowledged — outside-diff comment noted. All review threads for this PR have been resolved via the standard review process."
 
   # Fetch IDs of root CodeRabbit comments that need a reply (same filter logic
   # as check_unreplied_rest_comments, but returns IDs instead of a count).
@@ -1647,10 +1653,13 @@ auto_reply_unreplied_rest_comments() {
   local comment_id
   while IFS= read -r comment_id; do
     [ -z "$comment_id" ] && continue
-    if gh api "repos/$repo/pulls/$pr_number/comments/$comment_id/replies" \
-         --method POST \
-         --raw-field body="$reply_body" \
-         --silent > /dev/null 2>&1; then
+    local reply_json
+    reply_json="$(jq -n --arg body "$reply_body" '{"body": $body}')"
+    if printf '%s' "$reply_json" \
+         | gh api "repos/$repo/pulls/$pr_number/comments/$comment_id/replies" \
+             --method POST \
+             --input - \
+             --silent > /dev/null 2>&1; then
       reply_count=$((reply_count + 1))
       echo "INFO: auto-replied to REST comment $comment_id on PR #$pr_number" >&2
     else
@@ -2269,8 +2278,8 @@ run_coderabbit_review() {
       local silent_no_paused_count
       silent_no_paused_count="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq --arg bot "$bot_login" --arg since "$since_iso" '
-              [.[] | select(
+          | jq -s --arg bot "$bot_login" --arg since "$since_iso" '
+              [.[].[] | select(
                   .user.login == $bot and
                   .created_at > $since and
                   (

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -2208,8 +2208,8 @@ run_coderabbit_review() {
       local activity_count
       activity_count="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq --arg bot "$bot_login" --arg since "$since_iso" '
-              [.[] | select(
+          | jq -s --arg bot "$bot_login" --arg since "$since_iso" '
+              [.[].[] | select(
                   .user.login == $bot and
                   .created_at > $since and
                   ((.body // "") | test("Reviews paused|review paused"; "i") | not) and
@@ -2237,8 +2237,8 @@ run_coderabbit_review() {
       local paused_count
       paused_count="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq --arg bot "$bot_login" --arg since "$since_iso" '
-              [.[] | select(
+          | jq -s --arg bot "$bot_login" --arg since "$since_iso" '
+              [.[].[] | select(
                   .user.login == $bot and
                   .created_at > $since and
                   ((.body // "") | test("Reviews paused|review paused"; "i"))
@@ -2312,8 +2312,8 @@ run_coderabbit_review() {
       local rate_limit_comment_count
       rate_limit_comment_count="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq --arg bot "$bot_login" --arg since "$since_iso" '
-              [.[] | select(
+          | jq -s --arg bot "$bot_login" --arg since "$since_iso" '
+              [.[].[] | select(
                   .user.login == $bot and
                   .created_at > $since and
                   ((.body // "") | test("rate.?limit"; "i"))


### PR DESCRIPTION
## Summary

Backport of hotfix v0.27.3 (PR #677) to `develop`.

- `silent_no_paused_count`: add `jq -s` and `.[].[]` to slurp paginated pages before counting
- `auto_reply_unreplied_rest_comments`: jq-encoded JSON body via `--input -`
- Auto-reply message clarified to "Acknowledged — outside-diff comment noted…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with v0.27.3 hotfix entries and compare links.

* **Bug Fixes**
  * Clarified auto-reply wording for out-of-thread review comments to indicate acknowledgement-only.
  * Fixed JSON formatting for automated review replies.
  * Improved detection and counting of bot comments across paginated review activity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->