### PR TITLE
fix(reviewer-loop): slurp paginated pages in activity/paused/rate-limit counts (hotfix v0.27.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.4] - 2026-05-20
+
+### Fixed
+
+- **`pr-review-loop.sh`: slurp paginated pages in `activity_count`, `paused_count`, and `rate_limit_comment_count`** (hotfix): three additional paginated comment-count queries in `run_coderabbit_review` used `jq` without `-s`, producing multi-line counts on multi-page PRs and breaking integer comparisons. Applied the same `jq -s` / `.[].[]` fix as `silent_no_paused_count` (v0.27.3).
+
 ## [0.27.3] - 2026-05-19
 
 ### Fixed
@@ -730,7 +736,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.3...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.4...HEAD
+[0.27.4]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.3...v0.27.4
 [0.27.3]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.2...v0.27.3
 [0.27.2]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.1...v0.27.2
 [0.27.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.0...v0.27.1

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -2208,8 +2208,8 @@ run_coderabbit_review() {
       local activity_count
       activity_count="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq --arg bot "$bot_login" --arg since "$since_iso" '
-              [.[] | select(
+          | jq -s --arg bot "$bot_login" --arg since "$since_iso" '
+              [.[].[] | select(
                   .user.login == $bot and
                   .created_at > $since and
                   ((.body // "") | test("Reviews paused|review paused"; "i") | not) and
@@ -2237,8 +2237,8 @@ run_coderabbit_review() {
       local paused_count
       paused_count="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq --arg bot "$bot_login" --arg since "$since_iso" '
-              [.[] | select(
+          | jq -s --arg bot "$bot_login" --arg since "$since_iso" '
+              [.[].[] | select(
                   .user.login == $bot and
                   .created_at > $since and
                   ((.body // "") | test("Reviews paused|review paused"; "i"))
@@ -2312,8 +2312,8 @@ run_coderabbit_review() {
       local rate_limit_comment_count
       rate_limit_comment_count="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq --arg bot "$bot_login" --arg since "$since_iso" '
-              [.[] | select(
+          | jq -s --arg bot "$bot_login" --arg since "$since_iso" '
+              [.[].[] | select(
                   .user.login == $bot and
                   .created_at > $since and
                   ((.body // "") | test("rate.?limit"; "i"))


### PR DESCRIPTION
## Summary

Completes the paginated-slurp fix from v0.27.3 (PR #677), which only fixed `silent_no_paused_count`. Three adjacent queries in `run_coderabbit_review` had the same bug and were caught by CodeRabbit during the develop backport review (PR #678).

- `activity_count` — detects any non-pause, non-rate-limit bot activity
- `paused_count` — detects "Reviews paused" banner
- `rate_limit_comment_count` — detects rate-limit comments

All three now use `jq -s` and `.[].[]` so `gh api --paginate` output is slurped into a single array before counting.

## Test plan

- [ ] All four paginated count queries (`activity_count`, `paused_count`, `silent_no_paused_count`, `rate_limit_comment_count`) use `jq -s` and `.[].[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed comment counting in CodeRabbit review polling to ensure accurate results, improving the reliability of review activity detection, pause detection, and rate limit handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->