### PR TITLE
fix(prepare-release-post-merge-cleanup): treat already-Released issues as success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`prepare-release-post-merge-cleanup.sh`: treat "already in Released status" as success** (#671): when GitHub project automation advances issues to `Released` before the cleanup script runs, `UPDATED=0` was incorrectly treated as a failure. Issues whose project status is already `Released` are now counted as a no-op success, so `UPDATED=0` only signals a real API failure.
 - **`pr-review-loop.sh`: pagination guard for `check_unresolved_threads` on empty endCursor** (#667): adds the same `hasNextPage=true + empty endCursor` break guard to `check_unresolved_threads` that was already present in `get_resolved_thread_comment_ids`, preventing an infinite pagination loop when the GitHub GraphQL API returns a malformed page-info object.
 
 ## [0.27.4] - 2026-05-20

--- a/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
+++ b/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
@@ -16,7 +16,8 @@
 #   ./scripts/development-workflow/prepare-release-post-merge-cleanup.sh release/v1.2.3 --issues 232,240 --best-effort
 #
 # Exit codes when --issues is supplied (unless --best-effort is passed):
-#   0  At least one issue was updated and no hard failures occurred (or no issues supplied)
+#   0  At least one issue was updated (or already in Released status) and no hard failures
+#      occurred (or no issues supplied). Issues already in Released status count as success.
 #   1  updated==0 after processing all issues, or at least one hard failure occurred
 #
 # Output (when --issues is supplied):
@@ -234,6 +235,10 @@ for issue in "${ISSUE_NUMBERS[@]}"; do
   #   "Updating tracker status..."  (followed by successful GraphQL JSON) -> updated
   #   "Warning: ... skipping ..."                                          -> skipped
   #   "Warning: GraphQL mutation failed ..."                               -> failed
+  # When the issue is already in the target status (set by GitHub project automation
+  # before this script runs), the helper emits a "does not match required source
+  # status" message because the current status is already 'Released' (not 'Merged').
+  # Treat that as a no-op success so that UPDATED=0 only signals a real failure.
   TRACKER_OUT=$(update_tracker_status_best_effort "$issue" "$RELEASED_LABEL" "$MERGED_LABEL" 2>&1)
   echo "$TRACKER_OUT"
   if echo "$TRACKER_OUT" | grep -q "^Updating tracker status"; then
@@ -242,6 +247,11 @@ for issue in "${ISSUE_NUMBERS[@]}"; do
     else
       TRACKER_UPDATED=$((TRACKER_UPDATED + 1))
     fi
+  elif echo "$TRACKER_OUT" | grep -q "current status '${RELEASED_LABEL}'"; then
+    # Issue is already in the target Released status (set by GitHub project automation).
+    # This is a no-op success — not a failure or a skip that warrants an error exit.
+    echo "Issue #$issue is already in '$RELEASED_LABEL' status; counting as success."
+    TRACKER_UPDATED=$((TRACKER_UPDATED + 1))
   elif echo "$TRACKER_OUT" | grep -q "Warning:"; then
     TRACKER_SKIPPED=$((TRACKER_SKIPPED + 1))
   else


### PR DESCRIPTION
## Summary

- Fixes `prepare-release-post-merge-cleanup.sh` exiting non-zero with `UPDATED=0` when all in-scope issues were already in the `Released` state set by GitHub project automation before the script runs.
- Root cause: `update_tracker_status_best_effort` emits `"Issue #N current status 'Released' does not match required source status 'Merged'; skipping update."` — which is not prefixed with `Warning:` nor `Updating tracker status`, so the classifier fell through to the skip bucket. With all issues skipped, `TRACKER_UPDATED=0` triggered the failure exit.
- Fix: adds an explicit classifier branch that matches `"current status '${RELEASED_LABEL}'"` in the helper output and increments `TRACKER_UPDATED`, treating already-released issues as a no-op success. `UPDATED=0` now only signals a real API failure.

## Test plan

- [ ] Manually verify: run the script against a release where all scoped issues are already in `Released` status — should exit 0 and print `UPDATED=N SKIPPED=0 FAILED=0`.
- [ ] Manually verify: run the script against a release where some issues are in `Merged` and some already in `Released` — should exit 0 and report combined UPDATED count.
- [ ] Manually verify: run with no `--issues` flag — unaffected path, still exits 0.
- [ ] Verify `--best-effort` flag still exits 0 regardless (no regression).
- [ ] Verify that a real API failure (no project access) still exits 1 via FAILED>0 path.

Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release automation to treat issues already in Released status as successful transitions, preventing false failure reports during cleanup operations when no transitions are required.
  * Improved error reporting to distinguish between actual API failures and expected no-op scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->