### PR TITLE
docs(database): add RLS migration safety checklist — REVOKE before enabling RLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Database best practices: RLS migration safety checklist** (#680): adds `docs/best-practices/4-database.md` with a dedicated RLS section. The "Enabling RLS on an existing table" checklist requires revoking broad grants (`REVOKE ALL ON public.<table> FROM public, anon, authenticated`) before running `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`, preventing legacy grants from silently bypassing policies on pre-existing tables. Includes guidance on enabling RLS on new tables, re-granting narrowly scoped permissions after policies are in place, and a smoke-test verification step.
+
 ### Changed
 
 - **Developer protocol: mandatory fork-PR guard check for GitHub Actions workflow files** (#670): the "GitHub Actions Workflow Security Checklist" in `03-implement-development-protocol.md` gains a new mandatory bullet requiring every step that writes to the repository (adds/removes labels, posts comments, creates deployments or releases, writes status checks or check runs) in a `pull_request`-triggered workflow to include `if: github.event.pull_request.head.repo.full_name == github.repository` or an equivalent fork-origin check. Steps on `push` events or protected branches are exempt.

--- a/docs/best-practices/4-database.md
+++ b/docs/best-practices/4-database.md
@@ -44,12 +44,15 @@ CREATE POLICY "users can read their own rows"
 
 When retrofitting RLS onto a table that already exists in production, follow these steps
 in order. Skipping Step 1 is a common security mistake: legacy `GRANT` statements survive
-the `ALTER TABLE` and can silently bypass every policy you create.
+the `ALTER TABLE` and can expose more rows than intended if policies are incomplete or
+overly permissive during rollout.
 
 1. **Revoke broad grants before enabling RLS.**
-   Pre-existing grants (e.g. `GRANT SELECT ON public.my_table TO public`) let any
-   authenticated — or even anonymous — caller read all rows, regardless of the policies
-   defined below. Revoke them first:
+   Pre-existing grants (e.g. `GRANT SELECT ON public.my_table TO public`) increase the
+   blast radius: if any RLS policy is incomplete or missing during rollout, more rows
+   than intended are exposed. Both table privileges and RLS policies are required to
+   restrict access — neither control bypasses the other. Revoke broad grants first to
+   limit that blast radius:
 
    ```sql
    -- Revoke from every role that should no longer have unrestricted access.
@@ -84,10 +87,15 @@ the `ALTER TABLE` and can silently bypass every policy you create.
    by user A is not visible to user B, and that service-role access still works if
    required.
 
-> **Why this order matters**: PostgreSQL evaluates grants before policies. A `GRANT SELECT
-> TO public` permits the `public` role to read rows unconditionally — the presence of an
-> RLS policy does not override a grant. The only safe order is REVOKE → ENABLE → CREATE
-> POLICY → re-GRANT.
+> **Why this order matters**: PostgreSQL access control combines table privileges (GRANT)
+> and RLS policies as layered, complementary controls — both must permit access for a
+> user to see rows. A `GRANT SELECT TO public` grants table-level access, but RLS
+> policies further restrict which rows are visible. The risk is not that grants override
+> policies; it is that a broad grant **expands the blast radius** if any policy is
+> incomplete or missing during a migration. The safe order is REVOKE → ENABLE → CREATE
+> POLICY → re-GRANT, so the blast radius is minimised throughout the transition.
+> See the [PostgreSQL Row Security Policies documentation](https://www.postgresql.org/docs/current/ddl-rowsecurity.html)
+> for the authoritative reference.
 
 ---
 

--- a/docs/best-practices/4-database.md
+++ b/docs/best-practices/4-database.md
@@ -1,0 +1,100 @@
+# Database Best Practices
+
+> **STATUS: TEMPLATE SEED**
+>
+> This file ships with the framework template and contains general database best practices
+> that apply regardless of which database engine or ORM your project uses.
+>
+> After running the project setup agent (`docs/workflow/setup/protocol.md`), add your
+> project-specific conventions in [`stack/`](stack/) files and link them from
+> [`STACK-SPECIFIC.md`](STACK-SPECIFIC.md).
+
+---
+
+## Migrations
+
+- Keep migrations small and reversible whenever possible.
+- Never edit a migration file that has already been applied in any environment; create a
+  new one instead.
+- Test every migration against a production-representative dataset before applying to
+  staging or production.
+- Run `EXPLAIN ANALYZE` on queries that touch columns affected by a new index or schema
+  change before shipping.
+
+---
+
+## Row Level Security (RLS)
+
+### Enabling RLS on a new table
+
+When creating a new table, enable RLS immediately after the `CREATE TABLE` statement and
+define all policies in the same migration:
+
+```sql
+CREATE TABLE public.my_table ( ... );
+
+ALTER TABLE public.my_table ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users can read their own rows"
+  ON public.my_table FOR SELECT
+  USING (auth.uid() = user_id);
+```
+
+### Enabling RLS on an existing table — safety checklist
+
+When retrofitting RLS onto a table that already exists in production, follow these steps
+in order. Skipping Step 1 is a common security mistake: legacy `GRANT` statements survive
+the `ALTER TABLE` and can silently bypass every policy you create.
+
+1. **Revoke broad grants before enabling RLS.**
+   Pre-existing grants (e.g. `GRANT SELECT ON public.my_table TO public`) let any
+   authenticated — or even anonymous — caller read all rows, regardless of the policies
+   defined below. Revoke them first:
+
+   ```sql
+   -- Revoke from every role that should no longer have unrestricted access.
+   -- Adjust the role list to match your auth setup (e.g. anon, authenticated, service_role).
+   REVOKE ALL ON public.my_table FROM public, anon, authenticated;
+   ```
+
+2. **Enable RLS.**
+
+   ```sql
+   ALTER TABLE public.my_table ENABLE ROW LEVEL SECURITY;
+   ```
+
+3. **Define your policies.**
+
+   ```sql
+   CREATE POLICY "users can read their own rows"
+     ON public.my_table FOR SELECT
+     USING (auth.uid() = user_id);
+   ```
+
+4. **Re-grant only what each role needs** (if anything).
+   If a role requires read access but must still go through policies, grant `SELECT` back
+   after policies are in place:
+
+   ```sql
+   -- Only if the role needs access that a policy will filter:
+   GRANT SELECT ON public.my_table TO authenticated;
+   ```
+
+5. **Verify with a smoke test** against a staging environment: confirm that a row owned
+   by user A is not visible to user B, and that service-role access still works if
+   required.
+
+> **Why this order matters**: PostgreSQL evaluates grants before policies. A `GRANT SELECT
+> TO public` permits the `public` role to read rows unconditionally — the presence of an
+> RLS policy does not override a grant. The only safe order is REVOKE → ENABLE → CREATE
+> POLICY → re-GRANT.
+
+---
+
+## General Access Control
+
+- Apply the principle of least privilege: grant only the permissions a role or user
+  actually needs.
+- Prefer explicit, narrow grants over broad ones (e.g. `SELECT` on specific tables rather
+  than `ALL PRIVILEGES ON SCHEMA public`).
+- Audit existing grants whenever a security-sensitive migration is applied.


### PR DESCRIPTION
## Summary

Closes #680.

Adds `docs/best-practices/4-database.md` — a new template-seed database best-practices file — with a concrete RLS section covering:

- **New tables**: enable RLS immediately after `CREATE TABLE` in the same migration.
- **Existing tables** (safety checklist): revoke broad grants → enable RLS → define policies → re-grant narrowly → smoke-test. This is the primary fix for the issue: legacy `GRANT ... TO public` statements survive `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` and silently bypass every policy, so the revoke step must come first.
- **General access control**: least-privilege grant guidance.

The file is marked `STATUS: TEMPLATE SEED` so downstream projects know it ships populated content rather than requiring a setup step.

## Files changed

- `docs/best-practices/4-database.md` — new file
- `CHANGELOG.md` — `[Unreleased] ### Added` entry

## Test plan

- [x] Markdownlint passes (`node_modules/.bin/markdownlint-cli2` reports 0 errors on the new file and CHANGELOG)
- [x] The five-step checklist covers: REVOKE → ENABLE RLS → CREATE POLICY → re-GRANT → smoke-test
- [x] The explanatory note clarifies why order matters (PostgreSQL evaluates grants before policies)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a database best-practices guide with a migrations checklist, Row Level Security rollout safety steps (revoke broad grants → enable RLS → create policies → re-grant), verification smoke-test guidance, and access-control advice emphasizing least-privilege and grant auditing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->