### PR TITLE
feat(reviewer-loop): phase CodeRabbit after PR-Agent clean

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -30,6 +30,14 @@ review:
     - pr-agent
     - coderabbit
   #
+  # Platforms listed here are treated as "after-clean" reviewers by
+  # pr-review-loop.sh: earlier platforms must reach clean before these platforms
+  # are considered the value-measurement phase. The protocol keeps PRs as drafts
+  # while PR-Agent clears, then converts to non-draft so CodeRabbit can run after
+  # the PR-Agent-clean gate. This makes CodeRabbit's net-new findings measurable.
+  phase_after_clean:
+    - coderabbit
+  #
   # Configurable codex-github options (set via env vars or script flags to codex-github-reviewer.sh):
   #   CODEX_GITHUB_TRIGGER_PHRASE  — trigger phrase sent to the bot (default: "@codex review")
   #   CODEX_GITHUB_BOT_LOGIN       — GitHub login of the Codex bot account
@@ -78,7 +86,6 @@ review:
   # Step 7a for the full multi-reviewer gate procedure.
   internal_reviewers:
     - claude
-    - coderabbit
 
   # Optional: policy when a listed internal reviewer is unreachable from the current runner.
   # Protocol 91 Step 7a enforces this policy at runtime.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,7 +5,11 @@
 #
 # This repository is configured for External PR reviewer mode (Path B):
 # - review.platforms includes "coderabbit" in .ai-dev-workflow.yaml
+# - review.phase_after_clean marks CodeRabbit as the post-PR-Agent-clean
+#   measurement phase
 # - auto PR reviews are enabled below
+# - draft PR reviews remain disabled, so CodeRabbit starts only after the
+#   workflow converts a PR to non-draft
 #
 # To switch back to CLI-only mode (Path A):
 #   1. Set reviews.auto_review.enabled to false below

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -20,19 +20,19 @@ jobs:
     name: PR-Agent review
     steps:
       - name: PR-Agent
-        uses: the-pr-agent/pr-agent@009ba5a116c4d3273368a6dc53a4efdb7904d519 # v0.34.3
+        uses: the-pr-agent/pr-agent@0bd56c0508504c718cc03d504cd4ceb6725ba3c7 # v0.35.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # --- Model: DeepSeek (via LiteLLM) ---
           # Pinned as env vars in addition to .pr_agent.toml: PR-Agent can fall back
-          # to its Qodo-hosted GPT-5.4 default before TOML settings are fully merged,
+          # to its Qodo-hosted GPT-5.x default before TOML settings are fully merged,
           # causing AuthenticationError on every run when only DEEPSEEK_API_KEY is set.
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           config.model: "deepseek/deepseek-chat"
           config.fallback_models: '["deepseek/deepseek-chat"]'
           # config.model_weak controls ancillary tasks (PR description generation,
           # classification, file summaries). PR-Agent's built-in default is OpenAI's
-          # gpt-5.4 / gpt-5.4-mini, which fails with `dummy_key` 401 errors when only
+          # GPT-5.x family, which fails with `dummy_key` 401 errors when only
           # DEEPSEEK_API_KEY is configured. Pin it to DeepSeek too so all calls go
           # through one provider.
           config.model_weak: "deepseek/deepseek-chat"

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -9,7 +9,7 @@
 model = "deepseek/deepseek-chat"
 fallback_models = ["deepseek/deepseek-chat"]
 # model_weak is used for ancillary tasks (PR description generation, classification,
-# file summaries). PR-Agent's built-in default is OpenAI's gpt-5.4 / gpt-5.4-mini,
+# file summaries). PR-Agent's built-in default is OpenAI's GPT-5.x family,
 # which causes auth failures on every PR when only DEEPSEEK_API_KEY is configured.
 # Must match the active provider. Also pinned as `config.model_weak` in
 # .github/workflows/pr-agent.yml because TOML settings are merged after PR-Agent's
@@ -69,3 +69,34 @@ num_code_suggestions = 0
 # the review comment and can mislead agents into treating the false positive as a
 # finding that needs to be fixed. See issue #569.
 require_ticket_analysis_review = false
+# Repo context for the reviewer model — reduces false positives from DeepSeek on
+# this repository's common content types.
+extra_instructions = """
+This is a workflow framework template repository. Adjust your review accordingly:
+
+- Shell scripts in scripts/ use intentional patterns: pipefail/errexit/nounset, complex
+  awk/sed pipelines, heredocs, and mktemp. Variables like ISSUE_NUMBER are validated
+  upstream; treat shell expansion/injection concerns as low-risk unless the variable
+  clearly comes from untrusted external input with no prior validation.
+- Files in docs/ are protocol/workflow documentation written in Markdown — not
+  application code. Do not flag missing tests, missing error handling, or code-quality
+  issues in Markdown files.
+- CHANGELOG.md and versioned docs follow Keep a Changelog format intentionally;
+  formatting and ordering choices are deliberate.
+- Issue numbers appearing in PR descriptions, branch names, or commit messages
+  (e.g. #123, "issue #456", "ported from other-repo#145") may reference
+  cross-repository or upstream template issues — do not infer linked ticket
+  requirements from them when performing ticket compliance analysis.
+- GitHub Actions workflows in .github/workflows/ use standard GitHub Actions expression
+  syntax. Flag only genuine script-injection risks (untrusted user input interpolated
+  directly into run: steps), not normal ${{ }} expression usage.
+- Do not flag theoretical misconfiguration risks for environment variables or workflow
+  tuning knobs unless the PR introduces an unbounded value that can be reached through
+  normal automated execution.
+- Do not flag intentionally redundant-looking shell guards when they are defensive
+  validation around external command output, API responses, or cross-platform shell
+  compatibility.
+- Prefer "No major issues detected" over low-confidence process, style, or
+  documentation-ordering comments. Only report a focus area when it identifies a
+  concrete failure mode introduced by the diff.
+"""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Reviewer loop: phased PR-Agent clean gate before CodeRabbit** (#691): adds `review.phase_after_clean` support to `.ai-dev-workflow.yaml` and `pr-review-loop.sh`, emitting `PHASE_AFTER_CLEAN_*` telemetry and summary text that records whether CodeRabbit found a net-new blocker after PR-Agent was already clean. Protocols 91 and 93 now document the draft-PR PR-Agent gate before converting to non-draft for CodeRabbit, making CodeRabbit's ongoing value measurable.
 - **Database best practices: RLS migration safety checklist** (#680): adds `docs/best-practices/4-database.md` with a dedicated RLS section. The "Enabling RLS on an existing table" checklist requires revoking broad grants (`REVOKE ALL ON public.<table> FROM public, anon, authenticated`) before running `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`, preventing legacy grants from silently bypassing policies on pre-existing tables. Includes guidance on enabling RLS on new tables, re-granting narrowly scoped permissions after policies are in place, and a smoke-test verification step.
 - **Supabase best-practices doc: TypeScript type narrowing for CHECK-constrained columns** (#681): adds `docs/best-practices/stack/supabase.md` with guidance on narrowing Supabase-generated `string` types to union literals for `text` columns with `CHECK (...) IN (...)` constraints. Documents Option A (post-generation override file) and Option B (Zod schema as source of truth), with a migration review checklist. `STACK-SPECIFIC.md` gains a Quick Reference entry and a table row linking to the new file.
 
 ### Changed
 
+- **PR-Agent review noise controls** (#691): tightens `.pr_agent.toml` repository instructions to suppress speculative environment-variable, redundant shell-guard, and low-confidence process/style findings; upgrades the pinned PR-Agent GitHub Action from `v0.34.3` to `v0.35.0`; and removes CodeRabbit from the default Step 7a internal reviewer list so it runs only in the measured after-clean phase.
 - **Developer protocol: mandatory fork-PR guard check for GitHub Actions workflow files** (#670): the "GitHub Actions Workflow Security Checklist" in `03-implement-development-protocol.md` gains a new mandatory bullet requiring every step that writes to the repository (adds/removes labels, posts comments, creates deployments or releases, writes status checks or check runs) in a `pull_request`-triggered workflow to include `if: github.event.pull_request.head.repo.full_name == github.repository` or an equivalent fork-origin check. Steps on `push` events or protected branches are exempt.
 
 ### Fixed

--- a/docs/workflow/development-workflow/integrations/pr-review-platform.md
+++ b/docs/workflow/development-workflow/integrations/pr-review-platform.md
@@ -69,9 +69,16 @@ review:
   platforms:
     - greptile
     - devin
+  phase_after_clean:
+    - coderabbit
 ```
 
 The helper script reads this file automatically when no `--platform` flag is passed. If the file is absent, or if `review.platforms` is omitted or the platform list is empty, no reviewer tool runs and the result is skipped. Explicit `--platform` flags always override the config file.
+
+`review.phase_after_clean` is optional. Platforms listed there remain normal
+review platforms, but `pr-review-loop.sh` emits extra telemetry showing whether
+those platforms found net-new blockers after earlier platforms were already
+clean. This is intended for measuring whether a second reviewer still adds value.
 
 Use the nested `review.platforms` form so `.ai-dev-workflow.yaml` can also declare other workflow integrations such as `issue_tracker`, `vcs`, and `browser_automation`.
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -703,7 +703,7 @@ Run the next deterministic action for the selected item, then immediately re-eva
 
 Expected chain:
 
-`creator -> draft PR opened -> internal review gate with all internal reviewers (Step 7a) -> gh pr ready -> automated reviewer loop (Step 7) -> regression label (Step 7b, implementation PRs only) -> CI loop (Step 8) -> label readiness checklist (Step 8a) -> tracker status update (Step 8b) -> independent PR verification (Step 8c) -> wait or escalation`
+`creator -> draft PR opened -> internal review gate with all internal reviewers (Step 7a) -> PR-Agent draft clean gate when CodeRabbit is configured in review.phase_after_clean -> gh pr ready -> after-clean automated reviewer phase (Step 7) -> regression label (Step 7b, implementation PRs only) -> CI loop (Step 8) -> label readiness checklist (Step 8a) -> tracker status update (Step 8b) -> independent PR verification (Step 8c) -> wait or escalation`
 
 After any subagent finishes, determine whether the item still has a deterministic next action:
 
@@ -769,7 +769,17 @@ Before dispatching any reviewer, check whether the PR is currently in draft stat
 gh pr view <pr_number> --json isDraft --jq '.isDraft'
 ```
 
-If the result is `true` (PR is a draft), inspect the resolved `internal_reviewers` list from `.ai-dev-workflow.yaml` (after any `.tmp/template-config.json` override). If **any** listed reviewer is known to skip draft PRs, convert the PR to non-draft **before** triggering any reviewer:
+If the result is `true` (PR is a draft), inspect the resolved `internal_reviewers`
+list from `.ai-dev-workflow.yaml` (after any `.tmp/template-config.json`
+override) and the `review.phase_after_clean` list.
+
+If `coderabbit` is **only** listed under `review.phase_after_clean`, keep the PR
+as a draft during Step 7a. This is intentional: `.coderabbit.yaml` has
+`reviews.auto_review.drafts: false`, so draft state prevents CodeRabbit from
+starting before the PR-Agent-clean gate.
+
+If `coderabbit` is listed as an **internal reviewer** and is therefore required
+inside Step 7a itself, convert the PR to non-draft before triggering reviewers:
 
 ```bash
 gh pr ready <pr_number>
@@ -779,7 +789,12 @@ Post a comment on the PR explaining the action:
 
 > `INFO: PR converted from draft to non-draft before Step 7a internal review. Reason: CodeRabbit is configured as an internal reviewer and '.coderabbit.yaml' sets 'auto_review.drafts: false' — CodeRabbit silently skips draft PRs. Converting now to ensure full reviewer coverage.`
 
-**Why this matters**: CodeRabbit (and similar tools) configured with `auto_review.drafts: false` do not post any skip notice when they bypass a draft PR — the absence is silent. If the PR remains in draft state when the reviewer loop fires, CodeRabbit's review is simply missing, the internal review gate passes with reduced coverage, and no warning reaches the agent or the human.
+**Why this matters**: CodeRabbit (and similar tools) configured with
+`auto_review.drafts: false` do not post any skip notice when they bypass a draft
+PR. That behavior is useful when CodeRabbit is intentionally configured as an
+after-clean reviewer, because it lets PR-Agent clear first. It is unsafe when
+CodeRabbit is configured as a Step 7a internal reviewer, because the internal
+review gate would silently pass with reduced coverage.
 
 **Reviewer-to-draft-restriction mapping**:
 
@@ -797,7 +812,10 @@ grep -E '^\s*drafts:\s*false' .coderabbit.yaml
 
 If the file is absent or the key is not present, CodeRabbit defaults to `drafts: false` — treat it as draft-restricting.
 
-**Important**: The pre-check converts the PR to non-draft solely to enable reviewer coverage. This does not change the Step 7a → Step 7 flow: the PR still goes through the full internal review gate before external reviewers run. The `gh pr ready` calls in the outcome tables at the end of Step 7a (after all reviewers approve) are idempotent — if the pre-check has already converted the PR, those calls are safe no-ops.
+**Important**: Do not convert a draft PR to non-draft merely because CodeRabbit
+appears in `review.platforms` or `review.phase_after_clean`. Convert early only
+when CodeRabbit is part of `internal_reviewers`. Otherwise, keep the draft state
+until the PR-Agent-clean gate below has passed.
 
 If the PR is **not** in draft state, skip this pre-check entirely and proceed to the Design Review Gate.
 
@@ -1221,9 +1239,43 @@ The script-posted comment format:
 **Result:** clean — no blocking findings | escalated (reason) | max cycles reached — N blocking finding(s) unresolved
 **Platforms:** greptile, devin
 **Findings:** N blocking, N suggestions
+**After-clean reviewer phase:** No net-new blocker was found after the PR-Agent-clean gate.
+**After-clean platforms:** coderabbit
 
 _Posted automatically by `pr-review-loop.sh`._
 ```
+
+### PR-Agent-clean gate before CodeRabbit
+
+When `.ai-dev-workflow.yaml` contains `review.phase_after_clean` with
+`coderabbit`, run the external reviewer loop in two PR lifecycle phases:
+
+1. **Draft phase** — keep the PR as draft and run only the pre-CodeRabbit
+   platforms, normally `pr-agent`:
+
+   ```bash
+   ./scripts/development-workflow/pr-review-loop.sh <pr_number> \
+     --branch <branch_name> \
+     --platform pr-agent
+   ```
+
+2. If the PR-Agent phase returns `needs_fixes`, fix and re-run the draft phase.
+   Do not convert the PR to non-draft and do not trigger CodeRabbit yet.
+3. When the PR-Agent phase returns `clean`, convert the PR to non-draft:
+
+   ```bash
+   gh pr ready <pr_number>
+   ```
+
+4. Run the configured full reviewer loop. Because CodeRabbit is listed in
+   `review.phase_after_clean`, `pr-review-loop.sh` emits
+   `PHASE_AFTER_CLEAN_*` keys and annotates the summary with whether CodeRabbit
+   found a net-new blocker after PR-Agent was already clean.
+
+This sequence is the canonical way to evaluate whether CodeRabbit still adds
+review value. If CodeRabbit repeatedly returns clean after the PR-Agent-clean
+gate across enough implementation PRs, the team can remove it from the normal
+path with evidence rather than intuition.
 
 After running the helper script (it reads `.ai-dev-workflow.yaml` for the platform list automatically):
 
@@ -1239,60 +1291,16 @@ Interpret the result as follows:
 | `skipped`                               | Continue to Step 7b (implementation PRs) then Step 8 (no summary comment posted — Step 8c skips the check)                                                                                                                                                                                                                                                                                 |
 | `needs_fixes` and `cycle < max_cycles`  | Increment `cycle`, dispatch the matching fixer agent, wait for a push, then run Step 7 again                                                                                                                                                                                                                                                                                               |
 | `needs_fixes` and `cycle >= max_cycles` | Pass `--post-final-summary` to the final invocation — the script posts the summary automatically. Then escalate to human                                                                                                                                                                                                                                                                   |
-| `needs_rerun` (exit code 3)             | PR-Agent returned clean with a "Possible Issue" advisory. See "PR-Agent 'Possible Issue' evaluation" below — dispatch the code-reviewer agent, set `POSSIBLE_ISSUE_EVAL_OUTCOME`, and re-invoke the loop                                                                                                                                                                                   |
+| `needs_rerun` (exit code 3)             | (Reserved — not currently emitted.) Treat as `escalate` if encountered unexpectedly.                                                                                                                                                                                                                                                                                                      |
 | `escalate`                              | Summary comment posted automatically by the script. Escalate to human                                                                                                                                                                                                                                                                                                                      |
 
-### PR-Agent "Possible Issue" evaluation
+### PR-Agent "Possible Issue" advisory labels
 
-When `pr-review-loop.sh` returns `RESULT=clean` AND the output contains
-`PR_AGENT_POSSIBLE_ISSUE_EVAL`, PR-Agent classified the PR as `clean` but included
-a "Possible Issue" advisory label. The script emits two structured keys so the
-orchestrator can dispatch a code-reviewer agent before declaring the result final:
-
-- `PR_AGENT_POSSIBLE_ISSUE_EVAL` — format: `<pr_number>@@@<branch_name>`
-- `PR_AGENT_POSSIBLE_ISSUE_BODY` — the full PR-Agent comment body (newlines escaped)
-
-Note: `RESULT=needs_rerun` (exit code 3) is only emitted on a **re-invocation** after
-the code-reviewer agent pushed a fix (i.e., when `POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed`
-is set in the environment). The first-pass result is always `RESULT=clean` with
-`PR_AGENT_POSSIBLE_ISSUE_EVAL` in the output.
-
-**Required sequence:**
-
-1. After any `RESULT=clean` exit, check whether `PR_AGENT_POSSIBLE_ISSUE_EVAL` is
-   present in the script output. If present, do not declare the result clean yet.
-2. Read `PR_AGENT_POSSIBLE_ISSUE_BODY` from the script output and unescape it
-   (replace `\n` with real newlines).
-3. Dispatch the `code-reviewer` agent with the PR number, branch, PR-Agent comment
-   body, and the PR diff (`gh pr diff <pr_number>`). Instruct the agent: determine
-   whether the finding is a real bug or acceptable; if a real bug, push a fix commit;
-   if acceptable, post a substantive acknowledgment comment explaining the reasoning.
-4. After the agent finishes, set `POSSIBLE_ISSUE_EVAL_OUTCOME` and re-invoke the loop:
-
-   ```bash
-   # Agent acknowledged (finding is acceptable):
-   POSSIBLE_ISSUE_EVAL_OUTCOME=acknowledged \
-     ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
-
-   # Agent unavailable / timed out:
-   POSSIBLE_ISSUE_EVAL_OUTCOME=unavailable \
-     ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
-
-   # Agent pushed a fix — re-invoke with fix_pushed so the script signals needs_rerun:
-   POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed \
-     ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
-   ```
-
-5. On re-invocation with `acknowledged` or `unavailable`, the script reads
-   `POSSIBLE_ISSUE_EVAL_OUTCOME` from the environment, exits 0, and emits `RESULT=clean`.
-   On re-invocation with `fix_pushed`, the script exits 3 with `RESULT=needs_rerun` —
-   the orchestrator then does a full fresh re-run (without any `POSSIBLE_ISSUE_EVAL_OUTCOME`)
-   on the new HEAD.
-
-This evaluation step is not counted against the orchestrator's `cycle` counter. If
-the agent is unavailable (`POSSIBLE_ISSUE_EVAL_OUTCOME=unavailable` or empty on first
-pass), the script falls back to advisory-only clean and logs a warning to stderr. For
-full details see `93-automated-reviewer-loop-protocol.md`.
+When `pr-review-loop.sh` returns `RESULT=clean` with `ADVISORY_LABELS` containing
+`Possible Issue` entries, PR-Agent flagged advisory concerns but no hard-blockers.
+**No orchestrator action is required.** The script auto-acknowledges these findings
+and exits clean. See `93-automated-reviewer-loop-protocol.md` for the full advisory
+label disposition rules.
 
 **Step 7a summary (Internal Review Gate) is still agent-owned.** The script-posted summary covers Step 7 (external automated reviewers) only. The Step 7a summary comment (`### Step 7a Internal Review Gate Summary`) must still be posted by the orchestrator/agent after the internal review gate completes. Do not conflate the two: they serve different verification purposes and are checked by different gates.
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1250,13 +1250,13 @@ _Posted automatically by `pr-review-loop.sh`._
 When `.ai-dev-workflow.yaml` contains `review.phase_after_clean` with
 `coderabbit`, run the external reviewer loop in two PR lifecycle phases:
 
-1. **Draft phase** — keep the PR as draft and run only the pre-CodeRabbit
-   platforms, normally `pr-agent`:
+1. **Draft phase** — keep the PR as draft and run all configured
+   pre-after-clean platforms (`review.platforms` minus `review.phase_after_clean`):
 
    ```bash
    ./scripts/development-workflow/pr-review-loop.sh <pr_number> \
      --branch <branch_name> \
-     --platform pr-agent
+     --pre-after-clean-only
    ```
 
 2. If the PR-Agent phase returns `needs_fixes`, fix and re-run the draft phase.

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1270,7 +1270,9 @@ When `.ai-dev-workflow.yaml` contains `review.phase_after_clean` with
 4. Run the configured full reviewer loop. Because CodeRabbit is listed in
    `review.phase_after_clean`, `pr-review-loop.sh` emits
    `PHASE_AFTER_CLEAN_*` keys and annotates the summary with whether CodeRabbit
-   found a net-new blocker after PR-Agent was already clean.
+   found a net-new blocker after PR-Agent was already clean. If the after-clean
+   phase is not reached, the script emits `PHASE_AFTER_CLEAN_SKIP_REASON` rather
+   than a gate result.
 
 This sequence is the canonical way to evaluate whether CodeRabbit still adds
 review value. If CodeRabbit repeatedly returns clean after the PR-Agent-clean

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -539,6 +539,8 @@ Repositories may list one or more platforms under `review.phase_after_clean` in
 
 - `PHASE_AFTER_CLEAN_ENABLED=1`
 - `PHASE_AFTER_CLEAN_PLATFORM_LIST=<platforms>`
+- `PHASE_AFTER_CLEAN_FILTERED_OUT=<platforms>` when phase platforms are configured
+  but absent from the active invocation
 - `PHASE_AFTER_CLEAN_STARTED=0|1`
 - `PHASE_AFTER_CLEAN_GATE_RESULT=<result>` when the after-clean phase starts
 - `PHASE_AFTER_CLEAN_SKIP_REASON=<result>` when the after-clean phase never starts

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -571,10 +571,9 @@ When `pr-review-loop.sh` returns `RESULT=clean` and the output contains an
 concerns but no hard-blocker labels. **No orchestrator action is required.**
 
 `Possible Issue` findings are automatically acknowledged by the script and the loop
-exits clean. The advisory label is recorded in `ADVISORY_LABELS` for informational
-purposes only. Do not dispatch a code-reviewer agent or re-invoke the loop on account
-of these labels — in practice they have never surfaced real bugs for this repository
-type and the dispatch loop caused more fix-round churn than it prevented.
+exits clean. The advisory label is recorded in `ADVISORY_LABELS`. Do not dispatch a
+code-reviewer agent or re-invoke the loop because of these labels. Continue to record
+advisory dispositions in the post-clean summary flow defined below.
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -531,91 +531,47 @@ When a reviewer flags a specific literal value — a numeric constant, hex value
 
 This rule applies to any value type: version numbers, timeout values, port numbers, hex color codes, string constants, label names, section headers, or any other repeated literal. If a reviewer flags one instance, treat it as a signal to fix all instances — the reviewer will check all occurrences on the next cycle and finding any remaining instance resets the review loop.
 
-### PR-Agent "Possible Issue" evaluation step
+### After-clean reviewer phase
 
-When `pr-review-loop.sh` returns `RESULT=clean` and the output contains
-`PR_AGENT_POSSIBLE_ISSUE_EVAL`, PR-Agent classified the PR as `clean` but the review
-comment contained at least one "Possible Issue" advisory label. The orchestrator must
-dispatch a code-reviewer agent to evaluate the finding before declaring the loop result
-final. `RESULT=needs_rerun` (exit code 3) is a separate follow-up signal emitted only
-after the code-reviewer agent pushed a fix (i.e., `POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed`
-is passed to a re-invocation).
+Repositories may list one or more platforms under `review.phase_after_clean` in
+`.ai-dev-workflow.yaml`. These platforms remain in `review.platforms`, but
+`pr-review-loop.sh` treats them as a measured second phase and emits:
 
-#### When this step triggers
+- `PHASE_AFTER_CLEAN_ENABLED=1`
+- `PHASE_AFTER_CLEAN_PLATFORM_LIST=<platforms>`
+- `PHASE_AFTER_CLEAN_STARTED=0|1`
+- `PHASE_AFTER_CLEAN_GATE_RESULT=<result>`
+- `PHASE_AFTER_CLEAN_NET_NEW_BLOCKER=0|1`
+- `PHASE_AFTER_CLEAN_BLOCKING_PLATFORM=<platform>` when applicable
 
-`PR_AGENT_POSSIBLE_ISSUE_EVAL` is emitted (with `RESULT=clean`) when all of the
-following are true on the first pass:
+For this template, `coderabbit` is the after-clean platform. Keep implementation
+PRs as drafts while the PR-Agent-only gate runs, then convert the PR to non-draft
+and run the full configured loop. Because `.coderabbit.yaml` sets
+`reviews.auto_review.drafts: false`, this prevents CodeRabbit from starting
+before PR-Agent has reached `clean`.
 
-- The `pr-agent` platform is configured and ran for this PR.
-- PR-Agent's comment classified as `clean` (no hard-blocker labels).
-- The comment contained at least one `Possible Issue` advisory label (case-insensitive).
-- `POSSIBLE_ISSUE_EVAL_OUTCOME` is empty or `unavailable` (first-pass, before the
-  orchestrator sets an outcome).
+Use `PHASE_AFTER_CLEAN_NET_NEW_BLOCKER` as the primary value signal:
 
-`RESULT=needs_rerun` (exit code 3) is emitted on a re-invocation when
-`POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed` is set in the environment.
+- `0` means the after-clean reviewer did not find a blocker after PR-Agent was
+  already clean.
+- `1` means the after-clean reviewer found net-new blocking feedback that the
+  pre-clean phase missed.
 
-#### Orchestrator dispatch contract
+This signal is for tool-evaluation and graduation decisions. It does not weaken
+the normal merge gates: any net-new blocker still follows the standard
+`needs_fixes` loop.
 
-When `pr-review-loop.sh` exits with `RESULT=clean` and includes `PR_AGENT_POSSIBLE_ISSUE_EVAL` in the output:
+### PR-Agent "Possible Issue" advisory labels
 
-1. **Read the structured keys** from the script output:
-   - `PR_AGENT_POSSIBLE_ISSUE_EVAL` — format: `<pr_number>@@@<branch_name>`
-   - `PR_AGENT_POSSIBLE_ISSUE_BODY` — the full PR-Agent comment body (newlines
-     escaped; use `kv_value` to extract, then unescape `\n` and `\t` before passing
-     to the agent)
+When `pr-review-loop.sh` returns `RESULT=clean` and the output contains an
+`ADVISORY_LABELS` key with `Possible Issue` entries, PR-Agent flagged advisory
+concerns but no hard-blocker labels. **No orchestrator action is required.**
 
-2. **Dispatch the `code-reviewer` agent** (or invoke inline if the finding is
-   mechanical) with:
-   - The PR number and branch
-   - The PR-Agent comment body (the full finding text)
-   - The PR diff (via `gh pr diff <pr_number>`) for context
-   - The following instruction:
-     > Determine whether the PR-Agent finding describes a real bug or an acceptable
-     > advisory concern. If it is a real bug, push a fix commit to the PR branch.
-     > If it is acceptable, post a substantive acknowledgment comment on the PR
-     > explaining the reasoning (do not just say "acknowledged"). Do not push a
-     > commit if the finding is not actionable.
-
-3. **After the agent finishes**, set `POSSIBLE_ISSUE_EVAL_OUTCOME` and re-invoke
-   `pr-review-loop.sh`:
-   - Agent pushed a fix commit → `POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed`:
-     ```bash
-     POSSIBLE_ISSUE_EVAL_OUTCOME=fix_pushed \
-       ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
-     ```
-     The script emits `RESULT=needs_rerun` and exits 3. The orchestrator then
-     does a full fresh re-run **without** `POSSIBLE_ISSUE_EVAL_OUTCOME` set, so
-     the new HEAD is checked from scratch.
-   - Agent posted an acknowledgment → `POSSIBLE_ISSUE_EVAL_OUTCOME=acknowledged`:
-     ```bash
-     POSSIBLE_ISSUE_EVAL_OUTCOME=acknowledged \
-       ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
-     ```
-   - Agent is unavailable or timed out → `POSSIBLE_ISSUE_EVAL_OUTCOME=unavailable`:
-     ```bash
-     POSSIBLE_ISSUE_EVAL_OUTCOME=unavailable \
-       ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch>
-     ```
-
-4. **On the re-invocation** with `acknowledged` or `unavailable`, the script reads
-   `POSSIBLE_ISSUE_EVAL_OUTCOME` from the environment, emits `RESULT=clean`, and
-   exits 0. For `unavailable`, it also logs a warning to stderr and preserves the
-   advisory label in the loop summary. For `fix_pushed`, the script exits 3
-   (`RESULT=needs_rerun`) — the orchestrator then re-runs the loop completely fresh.
-
-#### Retry limits
-
-The `needs_rerun` exit from `pr-review-loop.sh` is **not** counted against the
-orchestrator's `cycle` counter — it is a pre-`clean` evaluation step, not a
-`needs_fixes` fixer dispatch. However, if the agent evaluation itself finds a bug and
-pushes a fix (`fix_pushed`), that subsequent full loop re-run is counted normally.
-
-#### Fallback behavior
-
-If `POSSIBLE_ISSUE_EVAL_OUTCOME` is empty or `unavailable`, the script logs a warning
-to stderr and exits 0 with `RESULT=clean`. The advisory label is still present in the
-loop summary output. The loop does not block indefinitely on agent unavailability.
+`Possible Issue` findings are automatically acknowledged by the script and the loop
+exits clean. The advisory label is recorded in `ADVISORY_LABELS` for informational
+purposes only. Do not dispatch a code-reviewer agent or re-invoke the loop on account
+of these labels — in practice they have never surfaced real bugs for this repository
+type and the dispatch loop caused more fix-round churn than it prevented.
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -540,7 +540,8 @@ Repositories may list one or more platforms under `review.phase_after_clean` in
 - `PHASE_AFTER_CLEAN_ENABLED=1`
 - `PHASE_AFTER_CLEAN_PLATFORM_LIST=<platforms>`
 - `PHASE_AFTER_CLEAN_STARTED=0|1`
-- `PHASE_AFTER_CLEAN_GATE_RESULT=<result>`
+- `PHASE_AFTER_CLEAN_GATE_RESULT=<result>` when the after-clean phase starts
+- `PHASE_AFTER_CLEAN_SKIP_REASON=<result>` when the after-clean phase never starts
 - `PHASE_AFTER_CLEAN_NET_NEW_BLOCKER=0|1`
 - `PHASE_AFTER_CLEAN_BLOCKING_PLATFORM=<platform>` when applicable
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -118,7 +118,7 @@ _interruptible_sleep() {
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--platform greptile] [--platform greptile,devin,pr-agent,coderabbit,codex-github] [--phase-after-clean coderabbit] [--poll-interval seconds] [--max-wait seconds] [--post-final-summary] [--compare]
+Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--platform greptile] [--platform greptile,devin,pr-agent,coderabbit,codex-github] [--phase-after-clean coderabbit] [--pre-after-clean-only] [--poll-interval seconds] [--max-wait seconds] [--post-final-summary] [--compare]
 
 Runs the automated PR review loop for one or more platforms in sequence. Before
 triggering a new review, each platform checks for existing blocking findings. If
@@ -151,6 +151,11 @@ REASON=lock_contention and exits 75 (EX_TEMPFAIL).
   emits PHASE_AFTER_CLEAN_* key=value telemetry and annotates the summary so the
   value of the second-phase reviewer can be measured. When omitted, the script
   reads review.phase_after_clean from .ai-dev-workflow.yaml when present.
+
+--pre-after-clean-only:
+  Run only the configured platforms that are not listed in phase-after-clean.
+  Use this for draft PR gates that must clear all pre-after-clean reviewers before
+  converting the PR to non-draft and allowing after-clean reviewers to run.
 
 Platform selection (in priority order):
   1. --platform flag(s) passed on the command line
@@ -194,6 +199,7 @@ Outputs stable key=value lines including:
   PHASE_AFTER_CLEAN_ENABLED=0|1
   PHASE_AFTER_CLEAN_STARTED=0|1
   PHASE_AFTER_CLEAN_PLATFORM_LIST=<comma-separated platforms>
+  PHASE_AFTER_CLEAN_FILTERED_OUT=<comma-separated platforms> (when configured phase platforms are absent from this invocation)
   PHASE_AFTER_CLEAN_GATE_RESULT=<result> (emitted only after the phase starts)
   PHASE_AFTER_CLEAN_SKIP_REASON=<result> (emitted when the phase never starts)
   PHASE_AFTER_CLEAN_NET_NEW_BLOCKER=0|1 (1 when a second-phase platform blocks)
@@ -234,30 +240,60 @@ append_phase_after_clean_platforms() {
   done
 }
 
-is_phase_after_clean_platform() {
-  local candidate="$1"
-  local configured
-  for configured in "${phase_after_clean_platforms[@]:-}"; do
-    [ "$candidate" = "$configured" ] && return 0
+array_contains_value() {
+  local needle="$1"
+  shift
+  local value
+  for value in "$@"; do
+    [ "$needle" = "$value" ] && return 0
   done
   return 1
 }
 
-filter_phase_after_clean_platforms() {
-  local phase_platform configured_platform
+is_phase_after_clean_platform() {
+  local candidate="$1"
+  array_contains_value "$candidate" "${phase_after_clean_platforms[@]:-}"
+}
+
+filter_pre_after_clean_platforms() {
+  local configured_platform
   declare -a filtered=()
+  for configured_platform in "${platforms[@]:-}"; do
+    if ! is_phase_after_clean_platform "$configured_platform"; then
+      filtered+=("$configured_platform")
+    fi
+  done
+  if [ "${#filtered[@]}" -gt 0 ]; then
+    platforms=("${filtered[@]}")
+  else
+    platforms=()
+  fi
+}
+
+filter_phase_after_clean_platforms() {
+  local phase_platform configured_platform matched
+  declare -a filtered=()
+  declare -a filtered_out=()
   for phase_platform in "${phase_after_clean_platforms[@]:-}"; do
+    matched=0
     for configured_platform in "${platforms[@]:-}"; do
       if [ "$phase_platform" = "$configured_platform" ]; then
         filtered+=("$phase_platform")
+        matched=1
         break
       fi
     done
+    [ "$matched" -eq 0 ] && filtered_out+=("$phase_platform")
   done
   if [ "${#filtered[@]}" -gt 0 ]; then
     phase_after_clean_platforms=("${filtered[@]}")
   else
     phase_after_clean_platforms=()
+  fi
+  if [ "${#filtered_out[@]}" -gt 0 ]; then
+    phase_after_clean_filtered_out="$(IFS=,; printf '%s' "${filtered_out[*]}")"
+  else
+    phase_after_clean_filtered_out=""
   fi
 }
 
@@ -3030,8 +3066,10 @@ max_wait=1200
 max_wait_explicit=0
 post_final_summary=0
 compare_mode=0
+pre_after_clean_only=0
 declare -a platforms=()
 declare -a phase_after_clean_platforms=()
+phase_after_clean_filtered_out=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -3046,6 +3084,10 @@ while [ "$#" -gt 0 ]; do
     --phase-after-clean)
       append_phase_after_clean_platforms "$2"
       shift 2
+      ;;
+    --pre-after-clean-only)
+      pre_after_clean_only=1
+      shift
       ;;
     --poll-interval)
       poll_interval="$2"
@@ -3109,6 +3151,9 @@ if [ "${#phase_after_clean_platforms[@]}" -eq 0 ]; then
   fi
 fi
 
+if [ "$pre_after_clean_only" -eq 1 ]; then
+  filter_pre_after_clean_platforms
+fi
 filter_phase_after_clean_platforms
 
 if [ "${#platforms[@]}" -gt 0 ]; then
@@ -3220,7 +3265,10 @@ print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
 print_kv PLATFORM_COUNT "${#platforms[@]}"
 # So callers can verify config was respected (e.g. no greptile when only devin is in .ai-dev-workflow.yaml)
 print_kv PLATFORM_LIST "$(IFS=,; printf '%s' "${platforms[*]}")"
+print_kv PRE_AFTER_CLEAN_ONLY "$pre_after_clean_only"
 print_kv PHASE_AFTER_CLEAN_ENABLED "$phase_after_clean_enabled"
+[ -n "$phase_after_clean_filtered_out" ] && \
+  print_kv PHASE_AFTER_CLEAN_FILTERED_OUT "$phase_after_clean_filtered_out"
 [ "$phase_after_clean_enabled" -eq 1 ] && \
   print_kv PHASE_AFTER_CLEAN_PLATFORM_LIST "$(IFS=,; printf '%s' "${phase_after_clean_platforms[*]}")"
 print_kv CHANGED_FILES_COUNT "${changed_files_count:--1}"
@@ -3233,8 +3281,10 @@ for index in "${!platforms[@]}"; do
   if [ "$phase_after_clean_enabled" -eq 1 ] \
       && [ "$phase_after_clean_started" -eq 0 ] \
       && is_phase_after_clean_platform "$platform_name"; then
-    phase_after_clean_started=1
-    phase_after_clean_gate_result="clean"
+    if [ "$compare_mode" -eq 0 ] || [ -z "$compare_first_blocking_result" ]; then
+      phase_after_clean_started=1
+      phase_after_clean_gate_result="clean"
+    fi
   fi
 
   set +e

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -194,6 +194,8 @@ Outputs stable key=value lines including:
   PHASE_AFTER_CLEAN_ENABLED=0|1
   PHASE_AFTER_CLEAN_STARTED=0|1
   PHASE_AFTER_CLEAN_PLATFORM_LIST=<comma-separated platforms>
+  PHASE_AFTER_CLEAN_GATE_RESULT=<result> (emitted only after the phase starts)
+  PHASE_AFTER_CLEAN_SKIP_REASON=<result> (emitted when the phase never starts)
   PHASE_AFTER_CLEAN_NET_NEW_BLOCKER=0|1 (1 when a second-phase platform blocks)
   POST_CLEAN_RECHECK=0|1 (1 when the post-clean wait-and-recheck ran)
   LATE_THREADS_FOUND=<N> (count of newly-found unresolved threads; -1 on audit failure; 0 when POST_CLEAN_RECHECK=0)
@@ -3187,6 +3189,7 @@ phase_after_clean_started=0
 phase_after_clean_net_new_blocker=0
 phase_after_clean_blocking_platform=""
 phase_after_clean_gate_result="not_started"
+phase_after_clean_skip_reason=""
 if [ "${#phase_after_clean_platforms[@]}" -gt 0 ]; then
   phase_after_clean_enabled=1
 fi
@@ -3536,11 +3539,15 @@ else
 fi
 
 if [ "$phase_after_clean_enabled" -eq 1 ] && [ "$phase_after_clean_started" -eq 0 ]; then
-  phase_after_clean_gate_result="$aggregate_result"
+  phase_after_clean_skip_reason="$aggregate_result"
 fi
 print_kv PHASE_AFTER_CLEAN_STARTED "$phase_after_clean_started"
 if [ "$phase_after_clean_enabled" -eq 1 ]; then
-  print_kv PHASE_AFTER_CLEAN_GATE_RESULT "$phase_after_clean_gate_result"
+  if [ "$phase_after_clean_started" -eq 1 ]; then
+    print_kv PHASE_AFTER_CLEAN_GATE_RESULT "$phase_after_clean_gate_result"
+  else
+    print_kv PHASE_AFTER_CLEAN_SKIP_REASON "$phase_after_clean_skip_reason"
+  fi
   print_kv PHASE_AFTER_CLEAN_NET_NEW_BLOCKER "$phase_after_clean_net_new_blocker"
   [ -n "$phase_after_clean_blocking_platform" ] && \
     print_kv PHASE_AFTER_CLEAN_BLOCKING_PLATFORM "$phase_after_clean_blocking_platform"
@@ -3735,9 +3742,10 @@ Protocol 91 Step 7b requires this label on all \`${branch_name%%/*}/*\` PRs afte
   local phase_section=""
   if [ "$phase_enabled" -eq 1 ]; then
     local _phase_value_line
+    local _phase_subject="${phase_platform_list:-after-clean reviewer}"
     if [ "$phase_started" -eq 1 ]; then
       if [ "$phase_net_new_blocker" -eq 1 ]; then
-        _phase_value_line="CodeRabbit-after-PR-Agent-clean found a net-new blocker (${phase_blocking_platform:-unknown})."
+        _phase_value_line="${_phase_subject} found a net-new blocker after the clean gate (${phase_blocking_platform:-unknown})."
       else
         _phase_value_line="No net-new blocker was found after the PR-Agent-clean gate."
       fi

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -243,6 +243,24 @@ is_phase_after_clean_platform() {
   return 1
 }
 
+filter_phase_after_clean_platforms() {
+  local phase_platform configured_platform
+  declare -a filtered=()
+  for phase_platform in "${phase_after_clean_platforms[@]:-}"; do
+    for configured_platform in "${platforms[@]:-}"; do
+      if [ "$phase_platform" = "$configured_platform" ]; then
+        filtered+=("$phase_platform")
+        break
+      fi
+    done
+  done
+  if [ "${#filtered[@]}" -gt 0 ]; then
+    phase_after_clean_platforms=("${filtered[@]}")
+  else
+    phase_after_clean_platforms=()
+  fi
+}
+
 kv_value() {
   local key="$1"
   local kv_output="$2"
@@ -3090,6 +3108,8 @@ if [ "${#phase_after_clean_platforms[@]}" -eq 0 ]; then
     done < <(workflow_config_review_phase_after_clean_platforms "$config_file")
   fi
 fi
+
+filter_phase_after_clean_platforms
 
 if [ "${#platforms[@]}" -gt 0 ]; then
   require_gh

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3837,7 +3837,11 @@ EOF
 }
 
 aggregate_possible_issue_eval_outcome="$(kv_value_default POSSIBLE_ISSUE_EVAL_OUTCOME "$aggregate_output" "")"
-phase_after_clean_platform_list="$(IFS=,; printf '%s' "${phase_after_clean_platforms[*]}")"
+if [ "${#phase_after_clean_platforms[@]}" -gt 0 ]; then
+  phase_after_clean_platform_list="$(IFS=,; printf '%s' "${phase_after_clean_platforms[*]}")"
+else
+  phase_after_clean_platform_list=""
+fi
 
 case "$aggregate_result" in
   clean)

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -118,7 +118,7 @@ _interruptible_sleep() {
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--platform greptile] [--platform greptile,devin,pr-agent,coderabbit,codex-github] [--poll-interval seconds] [--max-wait seconds] [--post-final-summary] [--compare]
+Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--platform greptile] [--platform greptile,devin,pr-agent,coderabbit,codex-github] [--phase-after-clean coderabbit] [--poll-interval seconds] [--max-wait seconds] [--post-final-summary] [--compare]
 
 Runs the automated PR review loop for one or more platforms in sequence. Before
 triggering a new review, each platform checks for existing blocking findings. If
@@ -144,6 +144,13 @@ REASON=lock_contention and exits 75 (EX_TEMPFAIL).
   COMPARE_VERDICT_<n>_RESULT key=value lines, and one row is appended to
   docs/workflow/retro-metrics-platforms.md. Intended for platform evaluation only —
   not for normal orchestration where early exit is desired.
+
+--phase-after-clean:
+  Mark one or more platforms as second-phase reviewers that should run only after
+  earlier platforms are clean. This does not override normal platform order; it
+  emits PHASE_AFTER_CLEAN_* key=value telemetry and annotates the summary so the
+  value of the second-phase reviewer can be measured. When omitted, the script
+  reads review.phase_after_clean from .ai-dev-workflow.yaml when present.
 
 Platform selection (in priority order):
   1. --platform flag(s) passed on the command line
@@ -184,6 +191,10 @@ Outputs stable key=value lines including:
   REASON=late_review_threads (when post-clean recheck finds new unresolved threads)
   COMPARE_MODE=1 (when --compare is active)
   COMPARE_VERDICT_<n>_PLATFORM / COMPARE_VERDICT_<n>_RESULT (when --compare is active)
+  PHASE_AFTER_CLEAN_ENABLED=0|1
+  PHASE_AFTER_CLEAN_STARTED=0|1
+  PHASE_AFTER_CLEAN_PLATFORM_LIST=<comma-separated platforms>
+  PHASE_AFTER_CLEAN_NET_NEW_BLOCKER=0|1 (1 when a second-phase platform blocks)
   POST_CLEAN_RECHECK=0|1 (1 when the post-clean wait-and-recheck ran)
   LATE_THREADS_FOUND=<N> (count of newly-found unresolved threads; -1 on audit failure; 0 when POST_CLEAN_RECHECK=0)
 
@@ -209,6 +220,25 @@ append_platforms() {
     entry="$(trim "$entry")"
     [ -n "$entry" ] && platforms+=("$entry")
   done
+}
+
+append_phase_after_clean_platforms() {
+  local raw="$1"
+  local entry
+  IFS=',' read -r -a entries <<< "$raw"
+  for entry in "${entries[@]}"; do
+    entry="$(trim "$entry")"
+    [ -n "$entry" ] && phase_after_clean_platforms+=("$entry")
+  done
+}
+
+is_phase_after_clean_platform() {
+  local candidate="$1"
+  local configured
+  for configured in "${phase_after_clean_platforms[@]:-}"; do
+    [ "$candidate" = "$configured" ] && return 0
+  done
+  return 1
 }
 
 kv_value() {
@@ -1257,57 +1287,27 @@ _EXTRACT_POSSIBLE_ISSUE_LABELS_
   }
 
   # Evaluate "Possible Issue" advisory labels found in a PR-Agent clean result.
-  # Reads POSSIBLE_ISSUE_EVAL_OUTCOME from environment (set by orchestrator caller).
+  # "Possible Issue" findings are always treated as acknowledged without dispatching
+  # a code-reviewer agent. In practice these findings have never been real blockers
+  # for this repo type; the dispatch loop caused fix-round spirals (issue #511 pattern).
   # Returns:
-  #   0  — no "Possible Issue" label found (short-circuit), OR
-  #         finding acknowledged, OR agent unavailable (advisory-only fallback)
-  #   3  — fix was pushed; caller must re-run the loop on the new HEAD
+  #   0  — always (no "Possible Issue" label found, or finding acknowledged immediately)
   run_pr_agent_possible_issue_evaluation() {
     local advisory_labels="$1"  # pipe-delimited, already extracted from comment
-    local comment_body="$2"     # full PR-Agent comment body (for agent context)
-    local pr_number_eval="$3"
-    local branch_name_eval="$4"
+    # comment_body ($2), pr_number_eval ($3), branch_name_eval ($4) unused — kept for
+    # signature compatibility with the call site.
 
     local possible_issue_labels
     possible_issue_labels="$(_extract_possible_issue_labels "$advisory_labels")"
 
-    # Short-circuit: no "Possible Issue" advisory labels present.
+    # Short-circuit: no "Possible Issue" label present.
     if [ -z "$possible_issue_labels" ]; then
       return 0
     fi
 
-    # Read the eval outcome set by the orchestrator after code-reviewer agent finishes.
-    local eval_outcome="${POSSIBLE_ISSUE_EVAL_OUTCOME:-}"
-
-    case "$eval_outcome" in
-      fix_pushed)
-        # A fix was pushed; the orchestrator must re-run the loop on the new HEAD
-        # to confirm the finding is resolved. Exit 3 signals this to the caller.
-        print_kv POSSIBLE_ISSUE_EVAL_OUTCOME "fix_pushed"
-        return 3  # sentinel: orchestrator must re-run the loop from the top
-        ;;
-      acknowledged)
-        print_kv POSSIBLE_ISSUE_EVAL_OUTCOME "acknowledged"
-        return 0
-        ;;
-      unavailable|"")
-        # No outcome set (first pass, before orchestrator dispatches code-reviewer)
-        # or agent is unavailable. Emit structured keys ONLY here so the orchestrator
-        # can read them and dispatch; fall back to advisory-only (clean) here.
-        # Keys are NOT emitted for fix_pushed/acknowledged re-invocations, which
-        # avoids ambiguous re-dispatch signals to the orchestrator.
-        print_kv PR_AGENT_POSSIBLE_ISSUE_EVAL "${pr_number_eval}@@@${branch_name_eval}"
-        print_kv_escaped PR_AGENT_POSSIBLE_ISSUE_BODY "$comment_body"
-        echo "WARN: code-reviewer agent unavailable or eval outcome not set for 'Possible Issue' finding — falling back to advisory-only (clean)" >&2
-        print_kv POSSIBLE_ISSUE_EVAL_OUTCOME "unavailable"
-        return 0
-        ;;
-      *)
-        echo "WARN: unknown POSSIBLE_ISSUE_EVAL_OUTCOME '${eval_outcome}' — falling back to advisory-only (clean)" >&2
-        print_kv POSSIBLE_ISSUE_EVAL_OUTCOME "unavailable"
-        return 0
-        ;;
-    esac
+    # Always acknowledge immediately — do not dispatch a code-reviewer agent.
+    print_kv POSSIBLE_ISSUE_EVAL_OUTCOME "acknowledged"
+    return 0
   }
 
   _pr_agent_classify() {
@@ -3011,6 +3011,7 @@ max_wait_explicit=0
 post_final_summary=0
 compare_mode=0
 declare -a platforms=()
+declare -a phase_after_clean_platforms=()
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -3020,6 +3021,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --platform)
       append_platforms "$2"
+      shift 2
+      ;;
+    --phase-after-clean)
+      append_phase_after_clean_platforms "$2"
       shift 2
       ;;
     --poll-interval)
@@ -3071,6 +3076,16 @@ if [ "${#platforms[@]}" -eq 0 ]; then
       line="$(trim "$line")"
       [ -n "$line" ] && platforms+=("$line")
     done < <(workflow_config_review_platforms "$config_file")
+  fi
+fi
+
+if [ "${#phase_after_clean_platforms[@]}" -eq 0 ]; then
+  config_file="${config_file:-$(workflow_config_file)}"
+  if workflow_config_exists; then
+    while IFS= read -r line; do
+      line="$(trim "$line")"
+      [ -n "$line" ] && phase_after_clean_platforms+=("$line")
+    done < <(workflow_config_review_phase_after_clean_platforms "$config_file")
   fi
 fi
 
@@ -3167,6 +3182,14 @@ compare_first_blocking_result=""
 compare_first_blocking_reason=""
 compare_first_blocking_output=""
 compare_first_blocking_status=0
+phase_after_clean_enabled=0
+phase_after_clean_started=0
+phase_after_clean_net_new_blocker=0
+phase_after_clean_blocking_platform=""
+phase_after_clean_gate_result="not_started"
+if [ "${#phase_after_clean_platforms[@]}" -gt 0 ]; then
+  phase_after_clean_enabled=1
+fi
 
 print_kv PR_NUMBER "$pr_number"
 print_kv BRANCH "$branch_name"
@@ -3174,12 +3197,22 @@ print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
 print_kv PLATFORM_COUNT "${#platforms[@]}"
 # So callers can verify config was respected (e.g. no greptile when only devin is in .ai-dev-workflow.yaml)
 print_kv PLATFORM_LIST "$(IFS=,; printf '%s' "${platforms[*]}")"
+print_kv PHASE_AFTER_CLEAN_ENABLED "$phase_after_clean_enabled"
+[ "$phase_after_clean_enabled" -eq 1 ] && \
+  print_kv PHASE_AFTER_CLEAN_PLATFORM_LIST "$(IFS=,; printf '%s' "${phase_after_clean_platforms[*]}")"
 print_kv CHANGED_FILES_COUNT "${changed_files_count:--1}"
 [ "$large_diff_extended" -eq 1 ] && print_kv LARGE_DIFF_EXTENDED 1
 
 for index in "${!platforms[@]}"; do
   platform_index=$((index + 1))
   platform_name="${platforms[$index]}"
+
+  if [ "$phase_after_clean_enabled" -eq 1 ] \
+      && [ "$phase_after_clean_started" -eq 0 ] \
+      && is_phase_after_clean_platform "$platform_name"; then
+    phase_after_clean_started=1
+    phase_after_clean_gate_result="clean"
+  fi
 
   set +e
   platform_output="$(run_platform_review "$platform_name" "$pr_number" "$branch_name" "$poll_interval" "$max_wait")"
@@ -3231,6 +3264,12 @@ for index in "${!platforms[@]}"; do
       aggregate_result="clean"
       ;;
     needs_fixes|escalate)
+      if [ "$phase_after_clean_enabled" -eq 1 ] \
+          && [ "$phase_after_clean_started" -eq 1 ] \
+          && is_phase_after_clean_platform "$platform_name"; then
+        phase_after_clean_net_new_blocker=1
+        phase_after_clean_blocking_platform="$platform_name"
+      fi
       aggregate_result="$platform_result"
       aggregate_reason="$(kv_value_default REASON "$platform_output" "")"
       aggregate_output="$platform_output"
@@ -3249,6 +3288,12 @@ for index in "${!platforms[@]}"; do
       fi
       ;;
     needs_rerun)
+      if [ "$phase_after_clean_enabled" -eq 1 ] \
+          && [ "$phase_after_clean_started" -eq 1 ] \
+          && is_phase_after_clean_platform "$platform_name"; then
+        phase_after_clean_net_new_blocker=1
+        phase_after_clean_blocking_platform="$platform_name"
+      fi
       # PR-Agent "Possible Issue" evaluation: a fix was pushed; re-run the loop.
       # Propagate as needs_rerun (exit 3) so orchestrator callers distinguish
       # this from needs_fixes (fixer dispatch) and re-invoke on the new HEAD.
@@ -3267,6 +3312,12 @@ for index in "${!platforms[@]}"; do
       fi
       ;;
     *)
+      if [ "$phase_after_clean_enabled" -eq 1 ] \
+          && [ "$phase_after_clean_started" -eq 1 ] \
+          && is_phase_after_clean_platform "$platform_name"; then
+        phase_after_clean_net_new_blocker=1
+        phase_after_clean_blocking_platform="$platform_name"
+      fi
       aggregate_result="escalate"
       aggregate_reason="unknown-platform-result"
       aggregate_output="$platform_output"
@@ -3399,6 +3450,10 @@ if [ "$aggregate_result" = "clean" ] || [ "$aggregate_result" = "skipped" ]; the
   if [ "$unresolved_thread_count" -gt 0 ]; then
     aggregate_result="needs_fixes"
     aggregate_reason="unresolved_review_threads"
+    if [ "$phase_after_clean_enabled" -eq 1 ] && [ "$phase_after_clean_started" -eq 1 ]; then
+      phase_after_clean_net_new_blocker=1
+      phase_after_clean_blocking_platform="${phase_after_clean_blocking_platform:-review_threads}"
+    fi
     # Increment total_blocking_count so BLOCKING_COUNT reflects the unresolved threads.
     # No BLOCKING_N_* entries are emitted for thread findings — callers must use
     # REASON=unresolved_review_threads and UNRESOLVED_THREAD_COUNT to handle this case.
@@ -3463,6 +3518,10 @@ if [ "$aggregate_result" = "clean" ] \
       echo "INFO: post-clean recheck — found $late_thread_count late unresolved thread(s); switching to needs_fixes" >&2
       aggregate_result="needs_fixes"
       aggregate_reason="late_review_threads"
+      if [ "$phase_after_clean_enabled" -eq 1 ] && [ "$phase_after_clean_started" -eq 1 ]; then
+        phase_after_clean_net_new_blocker=1
+        phase_after_clean_blocking_platform="${phase_after_clean_blocking_platform:-late_review_threads}"
+      fi
       total_blocking_count=$((total_blocking_count + late_thread_count))
     else
       echo "INFO: post-clean recheck — no late threads found; result remains clean" >&2
@@ -3474,6 +3533,17 @@ else
   # Emit LATE_THREADS_FOUND=0 on skipped paths so consumers can always rely on
   # the field being present, regardless of whether the recheck ran.
   print_kv LATE_THREADS_FOUND 0
+fi
+
+if [ "$phase_after_clean_enabled" -eq 1 ] && [ "$phase_after_clean_started" -eq 0 ]; then
+  phase_after_clean_gate_result="$aggregate_result"
+fi
+print_kv PHASE_AFTER_CLEAN_STARTED "$phase_after_clean_started"
+if [ "$phase_after_clean_enabled" -eq 1 ]; then
+  print_kv PHASE_AFTER_CLEAN_GATE_RESULT "$phase_after_clean_gate_result"
+  print_kv PHASE_AFTER_CLEAN_NET_NEW_BLOCKER "$phase_after_clean_net_new_blocker"
+  [ -n "$phase_after_clean_blocking_platform" ] && \
+    print_kv PHASE_AFTER_CLEAN_BLOCKING_PLATFORM "$phase_after_clean_blocking_platform"
 fi
 
 # Append compare-mode metrics row after the thread gate so the recorded
@@ -3525,6 +3595,11 @@ _post_review_summary() {
   local suggestions="$5"
   local advisory_labels="${6:-}"
   local possible_issue_eval_outcome="${7:-}"
+  local phase_enabled="${8:-0}"
+  local phase_platform_list="${9:-}"
+  local phase_started="${10:-0}"
+  local phase_net_new_blocker="${11:-0}"
+  local phase_blocking_platform="${12:-}"
 
   if [ -z "$pr_number" ]; then
     return 0
@@ -3591,7 +3666,7 @@ _ADVISORY_ENTRY_LINES_
       local _eval_note
       case "$possible_issue_eval_outcome" in
         acknowledged)
-          _eval_note="Evaluated by code-reviewer: acknowledged (finding is acceptable — loop proceeded clean)"
+          _eval_note="Auto-acknowledged: Possible Issue is advisory-only — loop proceeded clean"
           ;;
         fix_pushed)
           _eval_note="Evaluated by code-reviewer: fix pushed — loop re-ran on new HEAD"
@@ -3657,13 +3732,31 @@ Protocol 91 Step 7b requires this label on all \`${branch_name%%/*}/*\` PRs afte
     fi
   fi
 
+  local phase_section=""
+  if [ "$phase_enabled" -eq 1 ]; then
+    local _phase_value_line
+    if [ "$phase_started" -eq 1 ]; then
+      if [ "$phase_net_new_blocker" -eq 1 ]; then
+        _phase_value_line="CodeRabbit-after-PR-Agent-clean found a net-new blocker (${phase_blocking_platform:-unknown})."
+      else
+        _phase_value_line="No net-new blocker was found after the PR-Agent-clean gate."
+      fi
+    else
+      _phase_value_line="After-clean phase was not reached because an earlier platform did not exit clean."
+    fi
+    phase_section="
+
+**After-clean reviewer phase:** ${_phase_value_line}
+**After-clean platforms:** ${phase_platform_list:-none}"
+  fi
+
   local comment_body
   comment_body="$(cat <<EOF
 ### Automated Reviewer Loop Summary
 
 **Result:** ${result_line}
 **Platforms:** ${platform_list:-none}
-**Findings:** ${blocking} blocking, ${suggestions} suggestions${compare_section}${advisory_section}${regression_label_section}
+**Findings:** ${blocking} blocking, ${suggestions} suggestions${phase_section}${compare_section}${advisory_section}${regression_label_section}
 
 *Posted automatically by \`pr-review-loop.sh\`.*
 EOF
@@ -3716,6 +3809,7 @@ EOF
 }
 
 aggregate_possible_issue_eval_outcome="$(kv_value_default POSSIBLE_ISSUE_EVAL_OUTCOME "$aggregate_output" "")"
+phase_after_clean_platform_list="$(IFS=,; printf '%s' "${phase_after_clean_platforms[*]}")"
 
 case "$aggregate_result" in
   clean)
@@ -3723,7 +3817,10 @@ case "$aggregate_result" in
       "$(IFS=,; printf '%s' "${platforms[*]}")" \
       "$total_blocking_count" "$total_suggestion_count" \
       "$aggregate_advisory_labels" \
-      "$aggregate_possible_issue_eval_outcome"
+      "$aggregate_possible_issue_eval_outcome" \
+      "$phase_after_clean_enabled" "$phase_after_clean_platform_list" \
+      "$phase_after_clean_started" "$phase_after_clean_net_new_blocker" \
+      "$phase_after_clean_blocking_platform"
     exit 0
     ;;
   skipped)
@@ -3735,7 +3832,10 @@ case "$aggregate_result" in
         "$(IFS=,; printf '%s' "${platforms[*]}")" \
         "$total_blocking_count" "$total_suggestion_count" \
         "$aggregate_advisory_labels" \
-        "$aggregate_possible_issue_eval_outcome"
+        "$aggregate_possible_issue_eval_outcome" \
+        "$phase_after_clean_enabled" "$phase_after_clean_platform_list" \
+        "$phase_after_clean_started" "$phase_after_clean_net_new_blocker" \
+        "$phase_after_clean_blocking_platform"
     fi
     exit 1
     ;;
@@ -3751,7 +3851,10 @@ case "$aggregate_result" in
       "$(IFS=,; printf '%s' "${platforms[*]}")" \
       "$total_blocking_count" "$total_suggestion_count" \
       "$aggregate_advisory_labels" \
-      "$aggregate_possible_issue_eval_outcome"
+      "$aggregate_possible_issue_eval_outcome" \
+      "$phase_after_clean_enabled" "$phase_after_clean_platform_list" \
+      "$phase_after_clean_started" "$phase_after_clean_net_new_blocker" \
+      "$phase_after_clean_blocking_platform"
     exit 2
     ;;
   *)

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3361,12 +3361,6 @@ for index in "${!platforms[@]}"; do
       fi
       ;;
     needs_rerun)
-      if [ "$phase_after_clean_enabled" -eq 1 ] \
-          && [ "$phase_after_clean_started" -eq 1 ] \
-          && is_phase_after_clean_platform "$platform_name"; then
-        phase_after_clean_net_new_blocker=1
-        phase_after_clean_blocking_platform="$platform_name"
-      fi
       # PR-Agent "Possible Issue" evaluation: a fix was pushed; re-run the loop.
       # Propagate as needs_rerun (exit 3) so orchestrator callers distinguish
       # this from needs_fixes (fixer dispatch) and re-invoke on the new HEAD.
@@ -3385,12 +3379,6 @@ for index in "${!platforms[@]}"; do
       fi
       ;;
     *)
-      if [ "$phase_after_clean_enabled" -eq 1 ] \
-          && [ "$phase_after_clean_started" -eq 1 ] \
-          && is_phase_after_clean_platform "$platform_name"; then
-        phase_after_clean_net_new_blocker=1
-        phase_after_clean_blocking_platform="$platform_name"
-      fi
       aggregate_result="escalate"
       aggregate_reason="unknown-platform-result"
       aggregate_output="$platform_output"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # test-pr-review-loop.sh — Self-contained test harness for pr-review-loop.sh.
 #
-# Exercises four highest-risk logic areas:
+# Exercises five highest-risk logic areas:
 #   1. normalize_platform_verdict (verdict normalization / mapping)
 #   2. check_unreplied_rest_comments (bot-account exclusion, reply detection)
 #   3. append_compare_metrics_row (compare-mode platform config change detection)
 #   4. Lock cleanup on SIGTERM (signal trap removes lockdir before exit)
+#   5. phase_after_clean config parsing and membership detection
 #
 # Usage: bash scripts/development-workflow/tests/test-pr-review-loop.sh
 # No external tooling required beyond bash and git (git is used only to locate
@@ -31,6 +32,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)"
 MOCK_BIN="$(mktemp -d)"
 _METRICS_TMP=""
 _METRICS_DIR=""
+_CONFIG_DIR=""
 
 # Single EXIT trap: normalise SIGPIPE exit code (141 -> 0) and clean up temp
 # directories. A second trap would override this one, losing the 141 guard.
@@ -38,6 +40,7 @@ _harness_exit() {
   local status=$?
   rm -rf "$MOCK_BIN"
   [ -n "${_METRICS_DIR:-}" ] && rm -rf "$_METRICS_DIR"
+  [ -n "${_CONFIG_DIR:-}" ] && rm -rf "$_CONFIG_DIR"
   case "$status" in
     141) exit 0 ;;
     *)   exit "$status" ;;
@@ -139,6 +142,36 @@ run_test() {
     FAIL_COUNT=$(( FAIL_COUNT + 1 ))
   fi
 }
+
+# ---------------------------------------------------------------------------
+# Area 0: phase_after_clean config parsing
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 0: phase_after_clean config parsing ==="
+
+_CONFIG_DIR="$(mktemp -d)"
+cat > "$_CONFIG_DIR/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 1
+
+review:
+  platforms:
+    - pr-agent
+    - coderabbit
+  phase_after_clean:
+    - coderabbit
+YAML
+
+phase_after_clean_parsed="$(workflow_config_review_phase_after_clean_platforms "$_CONFIG_DIR/.ai-dev-workflow.yaml" | paste -sd ',' -)"
+run_test "phase_after_clean_parser" "coderabbit" "$phase_after_clean_parsed"
+
+declare -a phase_after_clean_platforms=()
+append_phase_after_clean_platforms "coderabbit, pr-agent"
+if is_phase_after_clean_platform "coderabbit" && is_phase_after_clean_platform "pr-agent"; then
+  phase_membership="yes"
+else
+  phase_membership="no"
+fi
+run_test "phase_after_clean_membership" "yes" "$phase_membership"
 
 # ---------------------------------------------------------------------------
 # Area 1: normalize_platform_verdict

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -173,6 +173,11 @@ else
 fi
 run_test "phase_after_clean_membership" "yes" "$phase_membership"
 
+declare -a phase_after_clean_platforms=("coderabbit")
+declare -a platforms=("pr-agent")
+filter_phase_after_clean_platforms
+run_test "phase_after_clean_filters_absent_platform" "0" "${#phase_after_clean_platforms[@]}"
+
 # ---------------------------------------------------------------------------
 # Area 1: normalize_platform_verdict
 # ---------------------------------------------------------------------------

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -175,8 +175,16 @@ run_test "phase_after_clean_membership" "yes" "$phase_membership"
 
 declare -a phase_after_clean_platforms=("coderabbit")
 declare -a platforms=("pr-agent")
+phase_after_clean_filtered_out=""
 filter_phase_after_clean_platforms
 run_test "phase_after_clean_filters_absent_platform" "0" "${#phase_after_clean_platforms[@]}"
+run_test "phase_after_clean_filtered_out_records_absent_platform" "coderabbit" "$phase_after_clean_filtered_out"
+
+declare -a phase_after_clean_platforms=("coderabbit")
+declare -a platforms=("pr-agent" "coderabbit")
+filter_pre_after_clean_platforms
+run_test "pre_after_clean_only_filters_phase_platform" "pr-agent" "${platforms[0]}"
+run_test "pre_after_clean_only_platform_count" "1" "${#platforms[@]}"
 
 # ---------------------------------------------------------------------------
 # Area 1: normalize_platform_verdict

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -180,6 +180,52 @@ workflow_config_review_platforms() {
   ' "$config_file"
 }
 
+workflow_config_review_phase_after_clean_platforms() {
+  local config_file="${1:-$(workflow_config_file)}"
+
+  [ -f "$config_file" ] || return 0
+
+  awk '
+    function trim(value) {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      gsub(/^["'"'"']|["'"'"']$/, "", value)
+      return value
+    }
+
+    /^review:[[:space:]]*(#.*)?$/ {
+      in_review = 1
+      in_phase = 0
+      next
+    }
+
+    in_review && /^[^[:space:]#].*:[[:space:]]*$/ {
+      in_review = 0
+      in_phase = 0
+    }
+
+    in_review && /^[[:space:]][[:space:]]phase_after_clean:[[:space:]]*(#.*)?$/ {
+      in_phase = 1
+      next
+    }
+
+    in_review && in_phase && /^[[:space:]][[:space:]][A-Za-z0-9_-]+:[[:space:]]*/ {
+      in_phase = 0
+    }
+
+    in_review && in_phase && /^[[:space:]][[:space:]][[:space:]][[:space:]]-[[:space:]]*/ {
+      line = $0
+      sub(/^[[:space:]]*-[[:space:]]*/, "", line)
+      sub(/[[:space:]]+#.*$/, "", line)
+      print trim(line)
+      next
+    }
+
+    in_review && in_phase && !/^[[:space:]][[:space:]][[:space:]][[:space:]]-[[:space:]]*/ && !/^[[:space:]]*#/ && !/^[[:space:]]*$/ {
+      in_phase = 0
+    }
+  ' "$config_file"
+}
+
 workflow_config_provider() {
   local section="$1"
   local config_file="${2:-$(workflow_config_file)}"


### PR DESCRIPTION
## Summary

- add `review.phase_after_clean` support and telemetry to `pr-review-loop.sh`
- configure CodeRabbit as the after-PR-Agent-clean reviewer and remove it from the default Step 7a internal gate
- document the draft PR-Agent gate before converting to non-draft for CodeRabbit, and tighten PR-Agent false-positive guidance
- upgrade the pinned PR-Agent GitHub Action to v0.35.0

## Verification

- `bash -n scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/workflow-lib.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md" "docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md" "docs/workflow/development-workflow/integrations/pr-review-platform.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 2>/dev/null | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `shellcheck --severity=warning scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/workflow-lib.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `git diff --check`

Closes #691


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable "phase after clean" review so selected reviewers run only after earlier reviews report clean, with new after-clean telemetry and summary output.

* **Documentation**
  * Updated orchestration and review docs to describe staged after-clean phases, telemetry signals, and refined draft-to-non-draft conversion rules.

* **Changed**
  * PR-Agent action pinned to v0.35.0, CodeRabbit moved to after-clean role, PR-Agent possible-issue handling simplified, and repo-specific reviewer guidance field added.

* **Tests**
  * Extended tests to cover phase-after-clean parsing and membership/filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->