### PR TITLE
fix(batch-merge): remove interactive approval prompt (#689)

### DIFF
--- a/.claude/commands/batch-merge.md
+++ b/.claude/commands/batch-merge.md
@@ -1,8 +1,9 @@
 ---
 description: >
   Merge all ready PRs in a parallel batch into develop sequentially, auto-resolving trivial
-  CHANGELOG and documentation conflicts, pausing for human input on non-trivial ones, and
-  running post-merge-cleanup for each successfully merged PR.
+  CHANGELOG and documentation conflicts, pausing for human input only on non-trivial conflicts,
+  and running post-merge-cleanup for each successfully merged PR. Prints the merge plan for
+  visibility but proceeds immediately without requiring confirmation.
   Usage: /batch-merge [#PR1 #PR2 ...] or /batch-merge --prs 101,102,103
 allowed-tools: Bash(./scripts/development-workflow/batch-merge.sh:*), Bash(./scripts/development-workflow/post-merge-cleanup.sh:*), Bash(git:*), Bash(gh:*), mcp__claude_ai_Linear__get_issue, mcp__claude_ai_Linear__save_issue, mcp__claude_ai_Linear__list_issue_statuses
 # If using a different issue tracker, add its MCP tool names here (e.g. mcp__jira__update_issue).
@@ -16,7 +17,7 @@ Follow `docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md`
 
 Key rules:
 
-- Do not start any merge until the human explicitly confirms the merge plan (Step 3 of the protocol).
+- Print the merge plan (Step 3 of the protocol) for visibility, then proceed immediately without waiting for user confirmation.
 - For each PR, run `./scripts/development-workflow/batch-merge.sh merge --pr <number>`.
 - Auto-resolve CHANGELOG conflicts and documentation file conflicts where changes are non-overlapping (different line ranges); pause and escalate all other conflicts.
 - After each successful merge: push `develop`, verify GitHub shows the PR as `MERGED`, delete the remote branch, run `./scripts/development-workflow/post-merge-cleanup.sh <branch>`.

--- a/.codex/skills/batch-merge/SKILL.md
+++ b/.codex/skills/batch-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: batch-merge
-description: Merge all ready PRs in a parallel batch into develop sequentially, auto-resolving trivial CHANGELOG and documentation conflicts, pausing for human input on non-trivial ones, and running post-merge-cleanup for each successfully merged PR. Use when a parallel batch of PRs is ready for merge.
+description: Merge all ready PRs in a parallel batch into develop sequentially, auto-resolving trivial CHANGELOG and documentation conflicts, pausing for human input only on non-trivial conflicts, and running post-merge-cleanup for each successfully merged PR. Prints the merge plan for visibility but proceeds immediately without requiring confirmation. Use when a parallel batch of PRs is ready for merge.
 ---
 
 # Batch Merge
@@ -25,9 +25,9 @@ Follow `docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md`
 
 4. **Readiness gate**: for each PR missing `ready-for-human-review`, warn the human and require an explicit include-or-skip decision. Never silently include or skip.
 
-5. **Human confirmation**: present the final ordered merge plan and require explicit approval before any merge.
+5. **Merge plan display**: present the final ordered merge plan, then proceed immediately without waiting for user confirmation.
 
-6. **Sequential merge loop (human-confirmed, agent-executed)**: after the human approves the merge plan in Step 5, for each PR in order:
+6. **Sequential merge loop**: for each PR in order:
    - Run `./scripts/development-workflow/batch-merge.sh merge --pr <number>`
    - On `MERGE_RESULT=clean`: proceed to post-merge steps.
    - On `MERGE_RESULT=conflict`: classify each conflicted file:

--- a/.cursor/commands/batch-merge.md
+++ b/.cursor/commands/batch-merge.md
@@ -1,8 +1,9 @@
 ---
 description: >
   Merge all ready PRs in a parallel batch into develop sequentially, auto-resolving trivial
-  CHANGELOG and documentation conflicts, pausing for human input on non-trivial ones, and
-  running post-merge-cleanup for each successfully merged PR.
+  CHANGELOG and documentation conflicts, pausing for human input only on non-trivial conflicts,
+  and running post-merge-cleanup for each successfully merged PR. Prints the merge plan for
+  visibility but proceeds immediately without requiring confirmation.
   Usage: /batch-merge [#PR1 #PR2 ...] or /batch-merge --prs 101,102,103
 ---
 
@@ -14,7 +15,7 @@ Follow `docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md`
 
 Key rules:
 
-- Do not start any merge until the human explicitly confirms the merge plan (Step 3 of the protocol).
+- Print the merge plan (Step 3 of the protocol) for visibility, then proceed immediately without waiting for user confirmation.
 - For each PR, run `./scripts/development-workflow/batch-merge.sh merge --pr <number>`.
 - Auto-resolve CHANGELOG and non-overlapping documentation conflicts; pause and escalate non-trivial conflicts.
 - After each successful merge: push `develop`, verify GitHub shows the PR as `MERGED`, delete the remote branch, run `./scripts/development-workflow/post-merge-cleanup.sh <branch>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`/batch-merge`: remove interactive approval prompt** (#689): the batch-merge command no longer pauses to ask for user confirmation after displaying the merge plan. The plan is still printed for visibility, but execution proceeds immediately. Protocol 94, the Claude Code command, Cursor command, and Codex skill are all updated to reflect the new non-interactive behavior.
 - **PR-Agent review noise controls** (#691): tightens `.pr_agent.toml` repository instructions to suppress speculative environment-variable, redundant shell-guard, and low-confidence process/style findings; upgrades the pinned PR-Agent GitHub Action from `v0.34.3` to `v0.35.0`; and removes CodeRabbit from the default Step 7a internal reviewer list so it runs only in the measured after-clean phase.
 - **Developer protocol: mandatory fork-PR guard check for GitHub Actions workflow files** (#670): the "GitHub Actions Workflow Security Checklist" in `03-implement-development-protocol.md` gains a new mandatory bullet requiring every step that writes to the repository (adds/removes labels, posts comments, creates deployments or releases, writes status checks or check runs) in a `pull_request`-triggered workflow to include `if: github.event.pull_request.head.repo.full_name == github.repository` or an equivalent fork-origin check. Steps on `push` events or protected branches are exempt.
 

--- a/docs/testing/workflow/batch-merge.smoke-test.md
+++ b/docs/testing/workflow/batch-merge.smoke-test.md
@@ -56,8 +56,7 @@ Create the following test PRs before running the smoke test. Each PR should be a
 **Expected result**:
 
 - The command discovers PRs A, B, C, E, and F and displays a candidate summary table showing PR number, title, branch, labels, and readiness status.
-- The command asks for confirmation before proceeding. No merge has occurred yet.
-- Cancel/decline the confirmation to avoid merging (we will test merging in later steps).
+- The command prints the merge plan and proceeds immediately without prompting for confirmation.
 
 ---
 
@@ -70,8 +69,7 @@ Create the following test PRs before running the smoke test. Each PR should be a
 **Expected result**:
 
 - The command shows only PRs A and B in the candidate list (not C, D, or E).
-- The command asks for confirmation before proceeding.
-- Cancel the confirmation.
+- The command prints the merge plan and proceeds immediately.
 
 ---
 
@@ -101,12 +99,11 @@ Create the following test PRs before running the smoke test. Each PR should be a
 **Maps to**: AC 4
 
 1. Run `/batch-merge` with PRs A (no CHANGELOG), B (with CHANGELOG), C (with CHANGELOG), ensuring A has the lowest PR number.
-2. Confirm the merge plan.
 
 **Expected result**:
 
-- The merge order displayed is: PR A first (no CHANGELOG, lowest number), then PR B (CHANGELOG, lower number), then PR C (CHANGELOG, higher number).
-- Verify this order in the confirmation prompt before any merge occurs.
+- The merge order displayed in the plan is: PR A first (no CHANGELOG, lowest number), then PR B (CHANGELOG, lower number), then PR C (CHANGELOG, higher number).
+- Execution proceeds immediately after the plan is printed.
 
 ---
 
@@ -257,7 +254,7 @@ Create the following test PRs before running the smoke test. Each PR should be a
 Each checkbox maps to an acceptance criterion from the spec.
 
 - [ ] AC 1: Auto-discovery finds all `ready-for-human-review` PRs and displays candidate list before merging
-- [ ] AC 2: Human sees confirmation prompt; no merge occurs until confirmed
+- [ ] AC 2: Merge plan is printed for visibility; execution proceeds immediately without confirmation
 - [ ] AC 3: Missing `ready-for-human-review` label causes warning and requires explicit human decision
 - [ ] AC 4: PRs merge in correct order (non-CHANGELOG first by PR number, then CHANGELOG by PR number)
 - [ ] AC 5: Merge preserves individual PR history, PR threads intact, no force-push

--- a/docs/testing/workflow/batch-merge.smoke-test.md
+++ b/docs/testing/workflow/batch-merge.smoke-test.md
@@ -207,7 +207,7 @@ Create the following test PRs before running the smoke test. Each PR should be a
 
 1. Create 3 PRs (G, H, I) targeting `develop` with `ready-for-human-review`.
 2. Run `/batch-merge` with all three.
-3. After PR G merges successfully, abort the entire batch when prompted for PR H.
+3. After PR G merges successfully, type `abort` before PR H is processed to signal a batch abort.
 
 **Expected result**:
 

--- a/docs/testing/workflow/batch-merge.smoke-test.md
+++ b/docs/testing/workflow/batch-merge.smoke-test.md
@@ -112,7 +112,6 @@ Create the following test PRs before running the smoke test. Each PR should be a
 **Maps to**: AC 5, AC 11, AC 12
 
 1. Continue from Step 5 (or start a fresh batch with only PR A).
-2. Confirm the merge plan.
 
 **Expected result**:
 
@@ -153,7 +152,6 @@ Create the following test PRs before running the smoke test. Each PR should be a
 
 1. Set up PR F so it modifies a documentation file (e.g., `docs/some-doc.md`) in non-overlapping line ranges compared to changes already in `develop` (from a previously merged PR that also touched the same file in different sections).
 2. Run `/batch-merge` with PR F.
-3. Confirm the merge plan.
 
 **Expected result**:
 
@@ -170,7 +168,6 @@ Create the following test PRs before running the smoke test. Each PR should be a
 
 1. Set up PR E so it conflicts with a file already in `develop` (a non-doc, non-CHANGELOG file).
 2. Run `/batch-merge` with PR E.
-3. Confirm the merge plan.
 
 **Expected result**:
 
@@ -194,8 +191,7 @@ Create the following test PRs before running the smoke test. Each PR should be a
 
 1. Create a new PR (PR F2) that will conflict with `develop` on a non-doc file.
 2. Run `/batch-merge` with PR F2.
-3. Confirm the merge plan.
-4. When the conflict is detected and the command pauses, choose to abort the merge for this PR.
+3. When the conflict is detected and the command pauses, choose to abort the merge for this PR.
 
 **Expected result**:
 
@@ -211,8 +207,7 @@ Create the following test PRs before running the smoke test. Each PR should be a
 
 1. Create 3 PRs (G, H, I) targeting `develop` with `ready-for-human-review`.
 2. Run `/batch-merge` with all three.
-3. Confirm the merge plan.
-4. After PR G merges successfully, abort the entire batch when prompted for PR H.
+3. After PR G merges successfully, abort the entire batch when prompted for PR H.
 
 **Expected result**:
 

--- a/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
+++ b/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
@@ -5,7 +5,7 @@
 
 **Shell helper**: `scripts/development-workflow/batch-merge.sh`
 
-**Governance**: The agent assists with merge execution but does **not** merge autonomously. Every merge in this protocol requires explicit human confirmation of the merge plan (Step 3) before any `git merge` runs. This satisfies the repository's human-gate policy.
+**Governance**: The agent assists with merge execution. The merge plan is printed for visibility before execution, but no interactive approval is required — merges proceed immediately after the plan is displayed.
 
 ---
 
@@ -14,7 +14,7 @@
 - A human invokes `/batch-merge` directly (Use Case 1 — human-invoked).
 - The Portfolio Orchestrator detects that all PRs in a parallel batch have reached `ready-for-human-review` and routes to this protocol (Use Case 2 — orchestrator-invoked).
 
-In both cases, **no merge occurs until the human explicitly confirms the merge plan** (Step 3).
+In both cases, the merge plan is displayed before any `git merge` runs, but execution proceeds immediately without waiting for user input.
 
 ---
 
@@ -90,9 +90,9 @@ After Step 2, update the candidate list: remove any PRs the human chose to skip 
 
 ---
 
-## Step 3: Human Confirmation — Merge Plan
+## Step 3: Merge Plan Display
 
-Display the final merge plan (only PRs approved so far):
+Display the final merge plan (only PRs approved so far) and proceed immediately:
 
 ```text
 Merge plan (will be executed in this order)
@@ -102,11 +102,9 @@ Merge plan (will be executed in this order)
   3. PR #103  fix/103-docs-update    (may cause CHANGELOG conflict — will auto-resolve)
 
 Skipped (not ready): #104
-
-Proceed with the merge? [yes / no / abort]
 ```
 
-**No merge occurs until the human types `yes`.** If the human types `no` or `abort`, exit immediately with no side effects.
+After printing the plan, proceed directly to Step 3.5 without waiting for user input.
 
 ---
 
@@ -410,7 +408,7 @@ Include details of any auto-resolved conflicts in the summary (which files, what
 When called from the Portfolio Orchestrator (Protocol 90), the same flow applies:
 
 - The orchestrator passes the PR list discovered from the batch.
-- This protocol still requires explicit human confirmation at Step 3 before any merge occurs.
+- The merge plan is printed for visibility at Step 3, then execution proceeds immediately.
 - The orchestrator must NOT skip or auto-approve the readiness gate (Step 2) for any unready PR.
 - Non-trivial conflicts still require human resolution at Step 4.3.
 


### PR DESCRIPTION
## Summary

Closes #689.

The `/batch-merge` command previously paused at Step 3 to ask for user confirmation before executing the merge plan. In practice the plan is always accepted as-is, making the prompt pure friction.

Changes:
- **Protocol 94** (`94-batch-merge-protocol.md`): Step 3 renamed from "Human Confirmation — Merge Plan" to "Merge Plan Display". The prompt block and `[yes / no / abort]` interaction are removed; the plan is still printed but execution proceeds immediately. The Governance preamble and Orchestrator-Invoked Mode section are updated to match.
- **Claude Code command** (`.claude/commands/batch-merge.md`): description and key rules updated to reflect non-interactive behavior.
- **Cursor command** (`.cursor/commands/batch-merge.md`): same.
- **Codex skill** (`.codex/skills/batch-merge/SKILL.md`): description and step 5 updated.
- **Smoke test** (`batch-merge.smoke-test.md`): Steps 2, 3, 5 and AC 2 updated to reflect no confirmation prompt.
- **CHANGELOG.md**: entry added under `[Unreleased] > Changed`.

## Test plan

- [ ] Markdown lint passes on all changed files (`markdownlint-cli2`)
- [ ] CHANGELOG duplicate-header check passes
- [ ] Protocol 94 Step 3 no longer contains a `[yes / no / abort]` prompt
- [ ] All other smoke test steps (readiness gate, merge ordering, conflict resolution, summary) are unaffected
- [ ] Existing batch-merge CI/tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Batch-merge now prints the final merge plan and proceeds automatically without requiring user confirmation; it still pauses/escalates on non-trivial conflicts and preserves readiness gating for unready PRs.
  * Protocols and runbooks updated to reflect the new non-interactive flow and an added pre-merge clean-state check.
* **Tests**
  * Smoke-test runbook updated to expect immediate execution after the merge plan is printed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->