### PR TITLE
fix(coderabbit): suppress docstring-coverage false positive on shell scripts

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -39,3 +39,6 @@ reviews:
   # This prevents scope inflation where CodeRabbit flags unrelated files and
   # causes agents to make unintended edits that increase PR diff size and risk.
   changed_files_only: true
+  path_instructions:
+    - path: "**/*.sh"
+      instructions: "Do not report on docstring coverage. Bash and shell scripts have no formal docstring standard; skip any docstring-coverage warnings for these files."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`.coderabbit.yaml`: suppress docstring-coverage false positive on shell scripts** (#700): adds a `path_instructions` entry for `**/*.sh` telling CodeRabbit to skip docstring-coverage warnings. Bash and shell scripts have no formal docstring standard, so the "Docstring Coverage 0% (threshold 80%)" warning was a persistent false positive on every `.sh`-touching PR.
+
 - **`pr-review-loop.sh`: fix `timeout_incomplete_count` missing rate-limit edits to walkthrough comment** (#696): the `timeout_incomplete_count` guard filtered CodeRabbit comments using only `created_at > $since`, missing the case where CodeRabbit signals a rate limit by editing its existing persistent walkthrough comment (whose `created_at` is old). The filter now uses `(.created_at > $since or .updated_at > $since)` so recently-edited rate-limit or "Reviews paused" banners are detected and the guard correctly escalates instead of falling through to a false-clean `RESULT=skipped/REASON=no_review` exit.
 
 - **Retrospective protocol: remove `workflow` label from upstream issue filing in Step 3e** (#690): `gh issue create` in Step 3e no longer passes `--label "workflow"`, and the preceding `gh label create "workflow"` step is removed. Both caused permission errors for users without collaborator access to the template repository.


### PR DESCRIPTION
## Summary

- Adds a `path_instructions` entry in `.coderabbit.yaml` for `**/*.sh` files instructing CodeRabbit to skip docstring-coverage warnings
- Bash and shell scripts have no formal docstring standard, so the "Docstring Coverage ⚠️ 0% (threshold 80%)" warning was a persistent false positive on every `.sh`-touching PR
- CHANGELOG entry added under `[Unreleased] > Fixed`

Closes #700

## Test plan

- [ ] Verify `.coderabbit.yaml` is valid YAML
- [ ] Verify CodeRabbit no longer reports docstring-coverage on `.sh` files in this PR (no `.sh` files changed, so the instruction is not triggered here — verify on a subsequent `.sh`-touching PR)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed false positive docstring coverage warnings for shell script files in the code review process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lhpaul/ai-dev-framework-template/pull/701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->