### PR TITLE
fix: sync-template yaml-exit hard-stop and phase_after_clean doc fix (hotfix v0.28.1)

### DIFF
--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -566,6 +566,7 @@ done
 
 if [ "$yaml_parse_failed" -ne 0 ]; then
   echo "ERROR: One or more workflow YAML files failed validation. Fix before committing."
+  exit 1
 fi
 ```
 

--- a/.cursor/commands/sync-template.md
+++ b/.cursor/commands/sync-template.md
@@ -565,6 +565,7 @@ done
 
 if [ "$yaml_parse_failed" -ne 0 ]; then
   echo "Blocking: one or more workflow YAML files failed validation. Fix before committing."
+  exit 1
 fi
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.1] - 2026-05-22
+
+### Fixed
+
+- **`/sync-template` skill and Cursor command: hard-stop on YAML validation failure** (hotfix): the `yaml_parse_failed` check in both `.claude/skills/sync-template.md` and `.cursor/commands/sync-template.md` only echoed an error but did not exit, allowing the sync to proceed past a broken workflow YAML file. Added `exit 1` to match the reference implementation in `.claude/commands/sync-template.md`.
+- **`pr-review-platform.md`: fix `phase_after_clean` config example** (hotfix): the YAML example listed `coderabbit` only under `review.phase_after_clean` but not under `review.platforms`, contradicting the requirement that phase platforms must also appear in the platforms list. Added `- coderabbit` to the `platforms` array in the example.
+
 ## [0.28.0] - 2026-05-22
 
 ### Added
@@ -769,7 +776,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.0...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.1...HEAD
+[0.28.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.4...v0.28.0
 [0.27.4]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.3...v0.27.4
 [0.27.3]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.2...v0.27.3

--- a/docs/workflow/development-workflow/integrations/pr-review-platform.md
+++ b/docs/workflow/development-workflow/integrations/pr-review-platform.md
@@ -69,6 +69,7 @@ review:
   platforms:
     - greptile
     - devin
+    - coderabbit
   phase_after_clean:
     - coderabbit
 ```


### PR DESCRIPTION
## Summary

- **`/sync-template` skill + Cursor command**: `yaml_parse_failed` check was missing `exit 1` — YAML validation errors were logged but the sync continued anyway. Matches the reference implementation in `.claude/commands/sync-template.md`.
- **`pr-review-platform.md`**: `phase_after_clean` config example listed `coderabbit` only under `phase_after_clean`, omitting it from `review.platforms` — contradicting the requirement that phase platforms must also appear in the main platforms list.

Both findings were caught during a downstream sync review (leasity-exchanges-prototype PR #263).

## Test plan

- [ ] Verify `.claude/skills/sync-template.md` YAML validation block now includes `exit 1`
- [ ] Verify `.cursor/commands/sync-template.md` YAML validation block now includes `exit 1`
- [ ] Verify `pr-review-platform.md` YAML example shows `coderabbit` under both `platforms` and `phase_after_clean`
- [ ] CHANGELOG `[0.28.1]` section present with correct compare link

🤖 Generated with [Claude Code](https://claude.com/claude-code)