### PR TITLE
fix(config): disable CodeRabbit auto-review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,17 +3,15 @@
 # This file controls CodeRabbit's behavior for this repository.
 # Docs: https://docs.coderabbit.ai/reference/configuration
 #
-# This repository is configured for External PR reviewer mode (Path B):
-# - review.platforms includes "coderabbit" in .ai-dev-workflow.yaml
-# - review.phase_after_clean marks CodeRabbit as the post-PR-Agent-clean
-#   measurement phase
-# - auto PR reviews are enabled below
-# - draft PR reviews remain disabled, so CodeRabbit starts only after the
-#   workflow converts a PR to non-draft
+# This repository is configured for CLI-only mode (Path A):
+# - auto PR reviews are disabled (auto_review.enabled: false below)
+# - CodeRabbit is still listed in review.platforms in .ai-dev-workflow.yaml
+#   so pr-review-loop.sh can invoke it on demand via @coderabbitai review
+# - draft PR reviews remain disabled
 #
-# To switch back to CLI-only mode (Path A):
-#   1. Set reviews.auto_review.enabled to false below
-#   2. Remove "coderabbit" from review.platforms in .ai-dev-workflow.yaml
+# To re-enable External PR reviewer mode (Path B):
+#   1. Set reviews.auto_review.enabled to true below
+#   2. Ensure "coderabbit" is in review.platforms in .ai-dev-workflow.yaml
 
 reviews:
   tools:
@@ -21,7 +19,7 @@ reviews:
       enabled: true
       timeout_ms: 600000
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
     base_branches:
       - develop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CodeRabbit auto-review disabled** — `.coderabbit.yaml` `auto_review.enabled` set to `false`. CodeRabbit no longer fires automatically on new PRs; it can still be triggered on demand via `@coderabbitai review` in the reviewer loop.
+
 ### Added
 
 - **Haystack Editor git hooks (optional)** — `haystack hooks install` adds agent-aware pre-commit checks (`hooks/`), Entire session linkage (`.entire/`), and `LLM_RULES.md` aligned with the default `gh pr create` + reviewer-loop workflow. Integration guide: `docs/workflow/development-workflow/integrations/haystack.md`.


### PR DESCRIPTION
## Summary

- Sets `reviews.auto_review.enabled: false` in `.coderabbit.yaml`
- Updates config file comments to reflect CLI-only mode
- CodeRabbit remains available for manual on-demand review via `@coderabbitai review` in the reviewer loop

## Why

CodeRabbit's auto-review is being replaced by Claude Code Action in the `phase_after_clean` slot (epic #704). Disabling auto-review stops the rate-limit pressure and is the operational prerequisite for that switch.

## Test plan

- [ ] Confirm new PRs after merge do not trigger automatic CodeRabbit reviews
- [ ] Confirm `@coderabbitai review` still works on demand in `pr-review-loop.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)