### PR TITLE
docs(plan): register claude-code-action config and reslot phase_after_clean — Implementation Plan (#708)

### DIFF
--- a/docs/specs/developments/20260523170145_708-claude-code-action-config/2_708-claude-code-action-config_implementation-plan.md
+++ b/docs/specs/developments/20260523170145_708-claude-code-action-config/2_708-claude-code-action-config_implementation-plan.md
@@ -1,0 +1,149 @@
+# Register Claude Code Action and Reslot phase_after_clean — Implementation Plan
+
+**Spec**: [`docs/specs/developments/20260523170145_708-claude-code-action-config/1_708-claude-code-action-config_specs.md`](1_708-claude-code-action-config_specs.md)
+**Smoke test runbook**: [`docs/testing/workflow/708-claude-code-action-config.smoke-test.md`](../../../../testing/workflow/708-claude-code-action-config.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Update the inline YAML comments in `.ai-dev-workflow.yaml` to list `claude-code-action` as a supported platform and recommend it as the `phase_after_clean` value. Update `README.md` to mention `claude-code-action` in the Optional Integrations section. Add a CHANGELOG entry under `[Unreleased]`.
+
+**Estimated complexity**: S
+
+**Rationale**: All changes are comment/documentation edits in two files plus a CHANGELOG entry. No script logic, no binary changes, no schema changes. Dependencies #705, #706, and #707 must be merged before the *implementation* PR for this item; the plan stage has no such constraint.
+
+**Dependencies**: Implementation depends on #705 (script), #706 (CI workflow), and #707 (integration docs) being merged into `develop-claude-review-platform` before the implementation PR is merged. Plan writing has no such dependency.
+
+---
+
+## Verification Log
+
+> Reproducible plan-time verification commands used to confirm scope.
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` (worktree) | `0e984a7` |
+| Current `phase_after_clean` value in `.ai-dev-workflow.yaml` | `grep -n "phase_after_clean\|coderabbit" .ai-dev-workflow.yaml` | `phase_after_clean: [coderabbit]`; `coderabbit` appears in `platforms` list and `phase_after_clean` list |
+| `claude-code-action` already present in `.ai-dev-workflow.yaml` | `grep "claude-code-action" .ai-dev-workflow.yaml` | No matches (not yet added) |
+| `review.platforms` comment line | `grep "Supported today" .ai-dev-workflow.yaml` | `# Supported today by pr-review-loop.sh: greptile, devin, coderabbit, pr-agent, codex-github` |
+| README Optional Integrations section | `grep -n "Automated PR Review" README.md` | Line 261: `Automated PR Review (e.g., Greptile)` |
+| README mentions of `claude-code-action` | `grep "claude-code-action" README.md` | No matches (not yet added) |
+
+---
+
+## Layer-by-Layer Changes
+
+### Infrastructure / Configuration
+
+- [ ] In `.ai-dev-workflow.yaml`, update the `# Supported today by pr-review-loop.sh:` comment to append `claude-code-action` to the platform list.
+- [ ] In `.ai-dev-workflow.yaml`, add a comment block below the existing `phase_after_clean` comment that recommends `claude-code-action` as the value to use in place of `coderabbit` to remove the rate-limit bottleneck.
+- [ ] Do **not** change the active `review.platforms` list values or the active `review.phase_after_clean` value — only comments are modified by this item (the active config change is out of scope per the spec's Business Rules and Out of Scope section).
+
+### Frontend / UI
+
+_Not applicable._
+
+### Backend / API
+
+_Not applicable._
+
+### Shared Packages / Libraries
+
+_Not applicable._
+
+### Database / Data Layer
+
+_Not applicable._
+
+---
+
+## Testing Strategy
+
+**Test types**: Manual (smoke test)
+
+**Key scenarios to test**:
+
+1. Open `.ai-dev-workflow.yaml` and confirm `claude-code-action` appears in the `Supported today` comment line — maps to AC1.
+2. Open `.ai-dev-workflow.yaml` and confirm the `phase_after_clean` comment block explicitly names `claude-code-action` as the recommended value — maps to AC2.
+3. Open `README.md` and confirm `claude-code-action` is mentioned as the recommended `phase_after_clean` platform — maps to AC3.
+4. Open `CHANGELOG.md` and confirm a new entry exists under `[Unreleased]` describing this update — maps to AC4.
+5. Verify that the active `review.platforms` list and `review.phase_after_clean` value in `.ai-dev-workflow.yaml` are unchanged (still contain `coderabbit`) — maps to AC5.
+
+**Smoke test runbook**: `docs/testing/workflow/708-claude-code-action-config.smoke-test.md`
+
+---
+
+## Seed Data
+
+_Not applicable — no application runtime or database is involved._
+
+---
+
+## Documentation Updates
+
+- [ ] `README.md` — update the "Optional Integrations" section: expand the "Automated PR Review" bullet to mention `claude-code-action` as the recommended `phase_after_clean` platform and link to the integration guide added by sibling item #707.
+
+> Note: `AGENTS.md` (aliased as `CLAUDE.md`/`GEMINI.md`) does not currently describe review platform configuration in detail; the reference to `.ai-dev-workflow.yaml` as the source of truth is sufficient. No update to `AGENTS.md` is required.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Developer misreads the comment update as a change to the active config and enables `claude-code-action` prematurely (before sibling items are merged) | Low | Low | Comments are clearly worded as guidance ("recommended value"), not as active configuration. The active list values are not modified. |
+| sibling item #707 integration guide path referenced in `README.md` does not exist yet at plan time | Medium | Low | Plan step references the integration guide path as established by #707; developer confirms the path exists before linking when implementing. If #707 is not yet merged, use a placeholder link or defer the README link until after #707 merges. |
+
+---
+
+## Implementation Order
+
+1. **Update `.ai-dev-workflow.yaml` comment: `Supported today` line** — append `claude-code-action` to the platform list in the comment: change `# Supported today by pr-review-loop.sh: greptile, devin, coderabbit, pr-agent, codex-github` to `# Supported today by pr-review-loop.sh: greptile, devin, coderabbit, pr-agent, codex-github, claude-code-action`.
+
+   Verification: open `.ai-dev-workflow.yaml` and confirm the comment line now includes `claude-code-action`.
+
+2. **Update `.ai-dev-workflow.yaml` comment: `phase_after_clean` guidance** — add a comment below the existing `phase_after_clean` block that explicitly recommends `claude-code-action` as the value to swap in for `coderabbit` to remove the per-hour rate-limit constraint. The comment should mention that `claude-code-action` requires the `ANTHROPIC_API_KEY` secret and the CI workflow from sibling item #706, and that the integration guide (sibling item #707) covers setup. Example wording (illustrative — adapt during implementation):
+
+   ```yaml
+   # Recommended: swap coderabbit for claude-code-action in phase_after_clean to
+   # remove the CodeRabbit per-hour rate-limit bottleneck. claude-code-action has
+   # no review cap and uses your own Anthropic API key. Requires the
+   # ANTHROPIC_API_KEY secret and the CI workflow from sibling item #706.
+   # See docs/workflow/development-workflow/integrations/claude-code-action.md
+   # for setup instructions.
+   ```
+
+   Verification: open `.ai-dev-workflow.yaml` and confirm the new comment is present near the `phase_after_clean` stanza and names `claude-code-action` explicitly.
+
+3. **Update `README.md` Optional Integrations section** — expand the `Automated PR Review` bullet to mention `claude-code-action` as the recommended `phase_after_clean` option. Example (illustrative — adapt during implementation):
+
+   ```markdown
+   - **Automated PR Review (e.g., CodeRabbit, claude-code-action)**: See [`docs/workflow/development-workflow/integrations/coderabbit.md`](docs/workflow/development-workflow/integrations/coderabbit.md) or [`docs/workflow/development-workflow/integrations/claude-code-action.md`](docs/workflow/development-workflow/integrations/claude-code-action.md) (recommended `phase_after_clean` value; no rate-limit cap)
+   ```
+
+   Verify that sibling item #707's integration guide file (`docs/workflow/development-workflow/integrations/claude-code-action.md`) exists before adding the link. If it does not exist (i.e., #707 is not yet merged), link to the existing `greptile.md` as a placeholder or omit the direct link and add a note instead; do not create a dead link.
+
+   Verification: open `README.md` and confirm `claude-code-action` is mentioned in the Optional Integrations section.
+
+4. **Add CHANGELOG entry** — add a new bullet under `[Unreleased]` → `### Changed` (create the `### Changed` header if it does not yet exist under `[Unreleased]`):
+
+   ```markdown
+   - **Register claude-code-action as recommended phase_after_clean reviewer** (#708): Updated `.ai-dev-workflow.yaml` inline comments to list `claude-code-action` as a supported platform and recommend it as the `phase_after_clean` value in place of CodeRabbit for projects that want to avoid per-hour rate-limit stalls. Updated `README.md` Optional Integrations section to surface `claude-code-action` alongside existing options.
+   ```
+
+   Verification: open `CHANGELOG.md` and confirm the entry appears under `[Unreleased]`.
+
+5. **Verify AC5 (no active config change)** — confirm that the `review.platforms` list and `review.phase_after_clean` value in `.ai-dev-workflow.yaml` remain unchanged (both still contain `coderabbit`; `claude-code-action` does not appear in the active YAML values, only in comments).
+
+6. **Update project docs per Documentation Updates section** — already covered in steps 1–3 above. No additional `docs/project/` files require updating for this item.
+
+7. **Run markdown lint** to confirm no trailing whitespace or link errors were introduced:
+
+   ```bash
+   npx markdownlint-cli2 "docs/specs/developments/20260523170145_708-claude-code-action-config/2_708-claude-code-action-config_implementation-plan.md" "CHANGELOG.md"
+   ```
+
+   Confirm no lint errors are reported.
+
+8. **Verify smoke test runbook** — run through `docs/testing/workflow/708-claude-code-action-config.smoke-test.md` steps 1–5 to confirm all acceptance criteria are met before opening the PR.

--- a/docs/testing/workflow/708-claude-code-action-config.smoke-test.md
+++ b/docs/testing/workflow/708-claude-code-action-config.smoke-test.md
@@ -1,0 +1,102 @@
+# Smoke Test Runbook: Register Claude Code Action and Reslot phase_after_clean
+
+**Feature**: #708 — chore(config): register claude-code-action and reslot phase_after_clean
+**Spec**: [`docs/specs/developments/20260523170145_708-claude-code-action-config/1_708-claude-code-action-config_specs.md`](../../specs/developments/20260523170145_708-claude-code-action-config/1_708-claude-code-action-config_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] The implementation branch has been merged or is checked out locally
+- [ ] You have access to the repository's `.ai-dev-workflow.yaml`, `README.md`, and `CHANGELOG.md` files
+
+---
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| Target file 1 | `.ai-dev-workflow.yaml` |
+| Target file 2 | `README.md` |
+| Target file 3 | `CHANGELOG.md` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify `.ai-dev-workflow.yaml` — `claude-code-action` in supported-platforms comment
+
+**Maps to**: Acceptance Criterion 1
+
+1. Open `.ai-dev-workflow.yaml` in the repository root.
+2. Find the comment line that lists supported platforms (look for the line starting with `# Supported today by pr-review-loop.sh:`).
+3. Confirm that `claude-code-action` appears in that comment line alongside other platforms such as `coderabbit`, `pr-agent`, and `codex-github`.
+
+**Expected result**: The comment line reads something like `# Supported today by pr-review-loop.sh: greptile, devin, coderabbit, pr-agent, codex-github, claude-code-action` (exact order may vary).
+
+---
+
+### Step 2: Verify `.ai-dev-workflow.yaml` — `phase_after_clean` recommendation comment
+
+**Maps to**: Acceptance Criterion 2
+
+1. In `.ai-dev-workflow.yaml`, locate the `phase_after_clean` key and its surrounding comment block.
+2. Read the comment block near or below `phase_after_clean`.
+3. Confirm that the comment explicitly states that `claude-code-action` is the recommended value to use in place of `coderabbit` to remove the CodeRabbit per-hour rate-limit bottleneck.
+
+**Expected result**: A comment near the `phase_after_clean` stanza mentions `claude-code-action` as the recommended replacement for `coderabbit` and explains that it removes the rate-limit constraint.
+
+---
+
+### Step 3: Verify `README.md` — `claude-code-action` in Optional Integrations
+
+**Maps to**: Acceptance Criterion 3
+
+1. Open `README.md` in the repository root.
+2. Navigate to the "Optional Integrations" section.
+3. Find the bullet that describes automated PR review platforms.
+4. Confirm that `claude-code-action` is mentioned as the recommended `phase_after_clean` option, or that the bullet links to the `claude-code-action` integration guide.
+
+**Expected result**: The `README.md` Optional Integrations section mentions `claude-code-action` as an available and recommended automated review platform, with a reference or link to the integration guide.
+
+---
+
+### Step 4: Verify `CHANGELOG.md` — entry under `[Unreleased]`
+
+**Maps to**: Acceptance Criterion 4
+
+1. Open `CHANGELOG.md` in the repository root.
+2. Navigate to the `## [Unreleased]` section.
+3. Confirm that a new bullet entry describes this configuration and documentation update (e.g., registers `claude-code-action` as a supported platform and recommends it for `phase_after_clean`).
+4. Confirm the entry uses the project's `**Bold Title** (#N):` format.
+
+**Expected result**: `CHANGELOG.md` contains an entry referencing issue #708 under `[Unreleased]`.
+
+---
+
+### Step 5: Verify no active config change — `coderabbit` still in active YAML values
+
+**Maps to**: Acceptance Criterion 5
+
+1. In `.ai-dev-workflow.yaml`, inspect the `review.platforms` list (the YAML array, not the comment).
+2. Confirm that `coderabbit` is still present in the list and `claude-code-action` is **not** present in the active list values.
+3. Inspect the `review.phase_after_clean` list (the YAML array, not the comment).
+4. Confirm that `coderabbit` is still listed as the active value and `claude-code-action` is **not** in the active array.
+
+**Expected result**: The active YAML values for `review.platforms` and `review.phase_after_clean` are unchanged. `claude-code-action` appears only in YAML comments, not in the active configuration arrays.
+
+---
+
+## Pass / Fail Summary
+
+| Step | Criterion | Result |
+| --- | --- | --- |
+| Step 1 | `claude-code-action` in `# Supported today` comment | Pass / Fail |
+| Step 2 | `phase_after_clean` comment recommends `claude-code-action` | Pass / Fail |
+| Step 3 | `README.md` mentions `claude-code-action` as recommended option | Pass / Fail |
+| Step 4 | `CHANGELOG.md` entry present under `[Unreleased]` | Pass / Fail |
+| Step 5 | Active YAML values unchanged (`coderabbit` still active) | Pass / Fail |


### PR DESCRIPTION
## Summary

Implementation plan for issue #708 — part of epic #704 (Add Claude Code Action as an uncapped, own-key PR review platform).

This plan covers the documentation and configuration-comment changes to surface `claude-code-action` as the recommended `phase_after_clean` reviewer in the template.

**Plan file**: `docs/specs/developments/20260523170145_708-claude-code-action-config/2_708-claude-code-action-config_implementation-plan.md`

**Smoke test runbook**: `docs/testing/workflow/708-claude-code-action-config.smoke-test.md`

## Plan Coverage

| Acceptance Criterion | Covered by |
|---|---|
| AC1: `claude-code-action` in `Supported today` comment | Implementation Order Step 1 |
| AC2: `phase_after_clean` comment recommends `claude-code-action` | Implementation Order Step 2 |
| AC3: README/docs mention `claude-code-action` as recommended option | Implementation Order Step 3 |
| AC4: CHANGELOG entry under `[Unreleased]` | Implementation Order Step 4 |
| AC5: Existing `coderabbit` config not removed | Implementation Order Step 5 |

## Integration Branch

All PRs for this epic target `develop-claude-review-platform` (not `develop`).

## Implementation Dependencies

The implementation stage depends on #705 (script), #706 (CI workflow), and #707 (integration docs) being merged before the implementation PR is opened. The plan itself has no such dependency.