### PR TITLE
chore(config): register claude-code-action and reslot phase_after_clean (#708)

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -37,6 +37,12 @@ review:
   # the PR-Agent-clean gate. This makes CodeRabbit's net-new findings measurable.
   phase_after_clean:
     - coderabbit
+  # Recommended: swap coderabbit for claude-code-action in phase_after_clean to
+  # remove the CodeRabbit per-hour rate-limit bottleneck. claude-code-action has
+  # no review cap and uses your own Anthropic API key. Requires the
+  # ANTHROPIC_API_KEY secret and the CI workflow added by sibling item #706.
+  # See docs/workflow/development-workflow/integrations/claude-code-action.md
+  # for setup instructions.
   #
   # Configurable codex-github options (set via env vars or script flags to codex-github-reviewer.sh):
   #   CODEX_GITHUB_TRIGGER_PHRASE  — trigger phrase sent to the bot (default: "@codex review")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Haystack Editor git hooks (optional)** — `haystack hooks install` adds agent-aware pre-commit checks (`hooks/`), Entire session linkage (`.entire/`), and `LLM_RULES.md` aligned with the default `gh pr create` + reviewer-loop workflow. Integration guide: `docs/workflow/development-workflow/integrations/haystack.md`.
 
+### Changed
+
+- **Register claude-code-action as recommended phase_after_clean reviewer** (#708): Updated `.ai-dev-workflow.yaml` inline comments to recommend `claude-code-action` as the `phase_after_clean` value in place of CodeRabbit for projects that want to avoid per-hour rate-limit stalls. Updated `README.md` Optional Integrations section to surface `claude-code-action` alongside existing options.
+
 ## [0.28.2] - 2026-05-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Use $workflow-item-orchestrator to start and advance work for [feature or issue 
 ## Optional Integrations
 
 - **Issue Tracker (e.g., Linear)**: See [`docs/workflow/development-workflow/integrations/linear.md`](docs/workflow/development-workflow/integrations/linear.md)
-- **Automated PR Review (e.g., Greptile)**: See [`docs/workflow/development-workflow/integrations/greptile.md`](docs/workflow/development-workflow/integrations/greptile.md)
+- **Automated PR Review (e.g., CodeRabbit, claude-code-action)**: See [`docs/workflow/development-workflow/integrations/coderabbit.md`](docs/workflow/development-workflow/integrations/coderabbit.md) or [`docs/workflow/development-workflow/integrations/greptile.md`](docs/workflow/development-workflow/integrations/greptile.md). For projects that want to avoid per-hour rate-limit stalls, `claude-code-action` is the recommended `phase_after_clean` value (no review cap; uses your own Anthropic API key). See `docs/workflow/development-workflow/integrations/claude-code-action.md` for setup instructions (added by sibling item #707).
 - **GitHub Projects board**: See [`docs/workflow/development-workflow/integrations/github-projects.md`](docs/workflow/development-workflow/integrations/github-projects.md)
 - **CI/CD deployment placeholders**: See [`docs/workflow/development-workflow/integrations/ci-cd-deployment.md`](docs/workflow/development-workflow/integrations/ci-cd-deployment.md)
 


### PR DESCRIPTION
## Summary

Updates `.ai-dev-workflow.yaml` and `README.md` to surface `claude-code-action` as the recommended `phase_after_clean` reviewer option for projects wanting to avoid CodeRabbit per-hour rate-limit stalls.

### Changes

- **`.ai-dev-workflow.yaml`**: added a comment block below the `phase_after_clean` stanza recommending `claude-code-action` as the value to swap in for `coderabbit`. The active `review.platforms` list and active `review.phase_after_clean` value are unchanged — only comments are modified.
- **`README.md`**: expanded the Optional Integrations "Automated PR Review" bullet to mention `claude-code-action` as the recommended `phase_after_clean` platform alongside existing options.
- **`CHANGELOG.md`**: added `[Unreleased]` `### Changed` entry.

### Scope note

The `# Supported today by pr-review-loop.sh:` comment update was already handled by sibling item #705 (PR #728). This PR covers only the two changes not yet done:

1. `phase_after_clean` guidance comment in `.ai-dev-workflow.yaml`
2. `README.md` Optional Integrations mention of `claude-code-action`

### Related items

- Closes #708
- Part of `develop-claude-review-platform` sub-batch B (sibling: #705 PR #728)
- Dependencies: #706 (CI workflow), #707 (integration guide) must merge before this PR merges

## Test plan

- [x] `.ai-dev-workflow.yaml`: `phase_after_clean` comment block present, names `claude-code-action` explicitly
- [x] `.ai-dev-workflow.yaml`: active `review.platforms` and `review.phase_after_clean` unchanged (still `coderabbit` only)
- [x] `README.md`: `claude-code-action` mentioned in Optional Integrations section
- [x] `CHANGELOG.md`: entry under `[Unreleased]` `### Changed`
- [x] `markdownlint-cli2 CHANGELOG.md` — 0 errors
- [x] `check-changelog-duplicate-headers.sh CHANGELOG.md` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)