### PR TITLE
feat(ci): add Claude Code Action PR-review GHA workflow (#706)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,51 @@
+name: Claude Code Action PR Review
+
+on:
+  # Triggered on demand by pr-review-loop.sh or a repository maintainer.
+  # Not triggered automatically on PR open, push, or synchronize events.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review"
+        required: true
+        type: number
+
+# Prevent duplicate simultaneous runs for the same PR.
+# Uses inputs.pr_number (not github.event.pull_request.number,
+# which is unavailable on workflow_dispatch events).
+concurrency:
+  group: claude-code-review-${{ inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Claude Code Action review
+    runs-on: ubuntu-latest
+
+    # Minimum permissions required:
+    #   pull-requests: write — to post review comments on the PR
+    #   contents: read — to read the repository checkout during review
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Run Claude Code Action PR review
+        # Pinned to v1.0.133 (SHA: db614ad5ed8c94def23ad6cc336751c8ba450ac1).
+        # Check https://github.com/anthropics/claude-code-action/releases for
+        # newer releases and update the SHA accordingly before merging.
+        uses: anthropics/claude-code-action@db614ad5ed8c94def23ad6cc336751c8ba450ac1  # v1.0.133
+        with:
+          pr_number: ${{ inputs.pr_number }}
+          # Default model: claude-sonnet-4-6
+          # Rationale: Sonnet 4.6 is Anthropic's recommended CI review model —
+          # it delivers adequate review quality at ~1/5 the token cost of Opus.
+          # Public-repo Actions minutes are free; the only cost is token
+          # consumption (~$0.30 per review pass with claude-sonnet-4-6).
+          model: claude-sonnet-4-6
+        env:
+          # Authenticate exclusively via the repository secret ANTHROPIC_API_KEY.
+          # No other Anthropic credential (OAuth, personal token) is used.
+          # Set the secret in GitHub repo settings → Secrets → Actions before
+          # triggering this workflow.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Ship Claude Code Action PR-review GHA workflow** (#706): add `.github/workflows/claude-code-review.yml` that invokes `anthropics/claude-code-action@v1` as an on-demand PR reviewer triggered by `workflow_dispatch` with a `pr_number` input; uses `claude-sonnet-4-6` by default and authenticates via `ANTHROPIC_API_KEY`.
 - **`claude-code-action` review platform** — `pr-review-loop.sh` now recognizes `claude-code-action` as a review platform. Add it to `review.platforms` in `.ai-dev-workflow.yaml` to integrate a GitHub Actions-based Claude Code review into the automated reviewer loop. Companion script `scripts/development-workflow/claude-code-action-reviewer.sh` dispatches a `workflow_dispatch` event, polls for the resulting Actions run to complete, and exits with codes 0 = APPROVED, 1 = NEEDS_REVISION, 2 = TIMED_OUT, 3 = UNAVAILABLE.
 - **Haystack Editor git hooks (optional)** — `haystack hooks install` adds agent-aware pre-commit checks (`hooks/`), Entire session linkage (`.entire/`), and `LLM_RULES.md` aligned with the default `gh pr create` + reviewer-loop workflow. Integration guide: `docs/workflow/development-workflow/integrations/haystack.md`.
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/claude-code-review.yml` — a GitHub Actions workflow that invokes `anthropics/claude-code-action@v1.0.133` as an on-demand PR reviewer.

- Triggered exclusively via `workflow_dispatch` with a required `pr_number` input (no automatic triggers on PR open/push/sync)
- Pinned action ref: `anthropics/claude-code-action@db614ad5ed8c94def23ad6cc336751c8ba450ac1` (v1.0.133)
- Model: `claude-sonnet-4-6` (cost-quality balance; ~$0.30/review pass; public-repo Actions minutes are free)
- Auth: `ANTHROPIC_API_KEY` secret only
- `concurrency` group keyed on `inputs.pr_number` to prevent duplicate simultaneous runs
- `permissions` block: `pull-requests: write`, `contents: read` (minimum required)

## Changes

- New file: `.github/workflows/claude-code-review.yml`
- `CHANGELOG.md` entry under `[Unreleased]`

## Test plan

Smoke test runbook: `docs/testing/workflow/706-claude-code-action-gha-workflow.smoke-test.md`

- [ ] Workflow appears in `gh workflow list` as `Claude Code Action PR Review` (active)
- [ ] `on:` section contains only `workflow_dispatch`
- [ ] `pr_number` input has `required: true`
- [ ] `concurrency.group` keyed on `inputs.pr_number`
- [ ] `permissions` block: `pull-requests: write`, `contents: read` only
- [ ] Action ref is pinned to SHA `db614ad5ed8c94def23ad6cc336751c8ba450ac1` (v1.0.133)
- [ ] `ANTHROPIC_API_KEY` set via `${{ secrets.ANTHROPIC_API_KEY }}` only
- [ ] Inline comments present explaining model rationale and free compute minutes

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)