### PR TITLE
chore(haystack-hooks): finalize Option B adoption — remove Entire tracking (#722)

### DIFF
--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,4 +1,0 @@
-tmp/
-settings.local.json
-metadata/
-logs/

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,4 +1,0 @@
-{
-  "enabled": true,
-  "telemetry": false
-}

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,3 @@ node_modules/
 # Temp files
 .tmp/
 
-# Entire CLI local session data
-.entire/metadata/

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ node_modules/
 
 # Temp files
 .tmp/
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ This repository follows the default template workflow (documented in `docs/workf
 
 ### Agent commit hooks (optional — Haystack)
 
-When `haystack hooks install` has been run, git uses `hooks/` for pre-commit enforcement on **AI agent** commits: truncation checks, `LLM_RULES.md` review, and Entire session tracking. Human commits are unaffected. See [`docs/workflow/development-workflow/integrations/haystack.md`](docs/workflow/development-workflow/integrations/haystack.md). Customize `LLM_RULES.md` for your project; the template keeps `gh pr create` + protocol 93 as the default PR path.
+When `haystack hooks install` has been run, git uses `hooks/` for pre-commit enforcement on **AI agent** commits: truncation checks and `LLM_RULES.md` review (Option B — Entire session tracking not adopted; see integration doc for rationale). Human commits are unaffected. See [`docs/workflow/development-workflow/integrations/haystack.md`](docs/workflow/development-workflow/integrations/haystack.md). Customize `LLM_RULES.md` for your project; the template keeps `gh pr create` + protocol 93 as the default PR path.
 
 ### Stack Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Haystack Editor git hooks (optional)** — `haystack hooks install` adds agent-aware pre-commit checks (`hooks/`), Entire session linkage (`.entire/`), and `LLM_RULES.md` aligned with the default `gh pr create` + reviewer-loop workflow. Integration guide: `docs/workflow/development-workflow/integrations/haystack.md`.
+- **Haystack Editor git hooks (optional, Option B)** (#722) — `haystack hooks install` adds agent-aware pre-commit checks (`hooks/`) and `LLM_RULES.md` aligned with the default `gh pr create` + reviewer-loop workflow. Entire session tracking is not adopted (Option B scope decision): `prepare-commit-msg`, `commit-msg`, `post-commit`, and `pre-push` hooks are retained as no-ops; `.entire/settings.json` and its `.gitignore` entry are removed. Integration guide: `docs/workflow/development-workflow/integrations/haystack.md`.
 
 ## [0.28.2] - 2026-05-23
 

--- a/docs/workflow/development-workflow/integrations/haystack.md
+++ b/docs/workflow/development-workflow/integrations/haystack.md
@@ -1,6 +1,22 @@
-# Integration: Haystack Editor (Git Hooks & Optional PR Workflow)
+# Integration: Haystack Editor (Git Hooks)
 
-This document describes [Haystack Editor](https://haystackeditor.com/) (`@haystackeditor/cli`) as an **optional** complement to this framework's default PR and review workflow.
+This document describes [Haystack Editor](https://haystackeditor.com/) (`@haystackeditor/cli`) local git hooks as an **adopted optional complement** to this framework's default PR and review workflow.
+
+## Adoption Decision (Option B — Recommended)
+
+After evaluating the hooks in production use (2026-05-23/24), this template ships **Option B**:
+
+| Component | Adopted? | Notes |
+| --------- | -------- | ----- |
+| **Truncation checker** (`hooks/truncation-checker/`) | Yes | Silent gate on staged AI-agent code; no external binary dependency |
+| **LLM_RULES.md gate** (`hooks/pre-commit`) | Yes | Two-step commit with bypass token; shows rules and staged stat on first blocked attempt |
+| Entire session tracking | No | Removed — adds `~/.haystack/bin/entire` binary dependency that downstream consumers may not want |
+
+The hooks retained for Entire (`prepare-commit-msg`, `commit-msg`, `post-commit`, `pre-push`) are kept as no-op entry points so downstream teams that want to extend them have the scaffolding.
+
+**What this means for downstream consumers**: Run `haystack hooks install` once per clone to activate the two high-value gates. The Entire binary is not required — this template does not ship or reference it.
+
+---
 
 Haystack is **not** the same product as deepset's [Hayhooks](https://github.com/deepset-ai/hayhooks) (Haystack pipeline deployment). Haystack Editor focuses on AI-assisted development: PR triage, agent-session attribution, and local guardrails on agent commits.
 
@@ -17,16 +33,12 @@ Installed via `haystack hooks install`:
 | Hook | Purpose |
 | ---- | ------- |
 | `pre-commit` | Detects active AI agent sessions (Claude Code, Codex, Gemini CLI, OpenCode); runs truncation checks on staged agent/prompt code; enforces review of `LLM_RULES.md` on agent commits (two-step commit with bypass token) |
-| `prepare-commit-msg` | Entire session tracking / commit message preparation |
-| `commit-msg` | Entire trailer handling |
-| `post-commit` | Condenses session data when an Entire checkpoint exists |
-| `pre-push` | Pushes session logs; reminds agents about `haystack submit` when applicable |
+| `prepare-commit-msg` | No-op entry point (Entire session tracking not adopted — Option B) |
+| `commit-msg` | No-op entry point (Entire session tracking not adopted — Option B) |
+| `post-commit` | No-op entry point (Entire session tracking not adopted — Option B) |
+| `pre-push` | No-op entry point (Entire session tracking not adopted — Option B) |
 
 Human commits skip the enforcement path in `pre-commit` and pass through immediately.
-
-### Entire session linkage
-
-Hooks delegate to Entire (`~/.haystack/bin/entire`) to attach agent conversation context to commits. Local session metadata lives under `.entire/metadata/` (gitignored). Shared settings are in `.entire/settings.json`.
 
 ### Optional PR triage and review (Haystack cloud)
 
@@ -61,11 +73,13 @@ This:
 
 1. Copies hook scripts into `hooks/` and installs `hooks/package.json` dependencies (tree-sitter for truncation AST checks)
 2. Sets `core.hooksPath` to `hooks/` (local git config)
-3. Creates `.entire/settings.json`, `LLM_RULES.md`, and updates `.gitignore` for `.entire/metadata/`
+3. Creates `LLM_RULES.md` (if not already present)
 
-**Teammates** must run `haystack hooks install` on each clone so `core.hooksPath` points at `hooks/`. Commit `hooks/`, `LLM_RULES.md`, and `.entire/settings.json`; do not commit `hooks/node_modules/` (covered by root `node_modules/` ignore).
+**Teammates** must run `haystack hooks install` on each clone so `core.hooksPath` points at `hooks/`. Commit `hooks/` and `LLM_RULES.md`; do not commit `hooks/node_modules/` (covered by root `node_modules/` ignore).
 
 After install, run `npm install` in `hooks/` only if the installer did not already install dependencies.
+
+> **Note**: This template does not ship `.entire/settings.json` or the `.entire/` directory (Option B — Entire session tracking not adopted). If you later adopt full Entire integration, run `haystack hooks install` again and commit the generated `.entire/settings.json` and the corresponding `.gitignore` entry for `.entire/metadata/`.
 
 ---
 
@@ -103,7 +117,6 @@ To disable Haystack's mandatory PR wording entirely, edit the PR section in `LLM
 3. Truncation checker runs on relevant staged paths
 4. First attempt: commit blocked; full `LLM_RULES.md` + staged stat shown
 5. Second attempt (same staged tree): bypass token consumed; commit proceeds
-6. Entire hooks run on `prepare-commit-msg`, `commit-msg`, `post-commit`, `pre-push`
 
 Agents using Cursor are not detected by the stock agent-context parsers today; those commits behave like human commits unless detection is extended.
 
@@ -113,7 +126,7 @@ Agents using Cursor are not detected by the stock agent-context parsers today; t
 
 - **Temporarily skip hooks**: `git commit --no-verify` (human decision; do not use routinely for agent work)
 - **Uninstall hooks path**: `git config --unset core.hooksPath` and remove or stop using `hooks/`
-- **Remove from repo**: delete `hooks/`, `LLM_RULES.md`, `.entire/`, and revert `.gitignore` Entire entries; document the change in `CHANGELOG.md`
+- **Remove from repo**: delete `hooks/` and `LLM_RULES.md`; document the change in `CHANGELOG.md`
 
 ---
 
@@ -125,7 +138,6 @@ Agents using Cursor are not detected by the stock agent-context parsers today; t
 | `hooks/truncation-checker/` | Pattern and AST-based truncation detection |
 | `hooks/agent-context/` | Parsers for Claude, Codex, Gemini, OpenCode sessions |
 | `LLM_RULES.md` | Project rules injected on agent commits |
-| `.entire/settings.json` | Entire enabled/telemetry flags |
 | `docs/best-practices/2-version-control.md` | Default PR conventions (`gh`) |
 
 ---

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
-# Haystack hooks (powered by Entire)
-# Commit-msg hook: strip trailer if no user content (allows aborting empty commits)
-"$HOME/.haystack/bin/entire" hooks git commit-msg "$1" || exit 1
+# Haystack hooks: commit-msg
+# Entire session tracking removed (Option B scope decision — see integrations/haystack.md).
+# Hook retained as a no-op so downstream teams that extend it have the entry point.

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
-# Haystack hooks (powered by Entire)
-# Post-commit hook: condense session data if commit has Entire-Checkpoint trailer
-"$HOME/.haystack/bin/entire" hooks git post-commit 2>/dev/null || true
+# Haystack hooks: post-commit
+# Entire session tracking removed (Option B scope decision — see integrations/haystack.md).
+# Hook retained as a no-op so downstream teams that extend it have the entry point.

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,25 +1,4 @@
 #!/bin/sh
-# Haystack hooks (powered by Entire)
-# Pre-push hook: push session logs alongside user's push
-# $1 is the remote name (e.g., "origin")
-
-# Check if pushing a non-haystack branch and remind about haystack submit
-current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-if [ -n "$current_branch" ] && [ "$current_branch" != "main" ] && [ "$current_branch" != "master" ]; then
-  case "$current_branch" in
-    haystack/*)
-      # Already a haystack branch, no reminder needed
-      ;;
-    *)
-      # Check if this is an AI agent session (set by agent-context detector)
-      if [ -n "$HAYSTACK_AGENT_SESSION" ] || [ -n "$CLAUDE_CODE" ] || [ -n "$CODEX_CLI" ] || [ -n "$CODEX_SHELL" ] || [ -n "$CODEX_THREAD_ID" ] || [ -n "$CODEX_CI" ]; then
-        echo ""
-        echo "💡 Tip: Use 'haystack submit' to create PRs through Haystack's submit workflow."
-        echo "   This enables automatic analysis and merge when approved."
-        echo ""
-      fi
-      ;;
-  esac
-fi
-
-"$HOME/.haystack/bin/entire" hooks git pre-push "$1" || true
+# Haystack hooks: pre-push
+# Entire session tracking removed (Option B scope decision — see integrations/haystack.md).
+# Hook retained as a no-op so downstream teams that extend it have the entry point.

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -1,3 +1,4 @@
 #!/bin/sh
-# Haystack hooks (powered by Entire)
-"$HOME/.haystack/bin/entire" hooks git prepare-commit-msg "$1" "$2" 2>/dev/null || true
+# Haystack hooks: prepare-commit-msg
+# Entire session tracking removed (Option B scope decision — see integrations/haystack.md).
+# Hook retained as a no-op so downstream teams that extend it have the entry point.


### PR DESCRIPTION
## Summary

Finalizes the Haystack Editor git hooks adoption decision (issue #722):

- **Option B adopted**: keep truncation checker + LLM_RULES.md gate; remove Entire session tracking (requires `~/.haystack/bin/entire` binary, unwanted overhead for downstream consumers)
- Remove `.entire/settings.json` and its `.gitignore` entry from the repo
- Convert `prepare-commit-msg`, `commit-msg`, `post-commit`, `pre-push` hooks to no-ops (preserved as extension scaffolding)
- Update `docs/workflow/development-workflow/integrations/haystack.md` with adoption decision table and downstream consumer note
- Update `AGENTS.md` section to reflect Option B (drop Entire mention)
- Update CHANGELOG `[Unreleased]` Haystack entry to reflect Option B scope

## Files Changed

- `.entire/.gitignore` — deleted (Entire tracking removed)
- `.entire/settings.json` — deleted (Entire tracking removed)
- `.gitignore` — remove `.entire/metadata/` ignore entry
- `AGENTS.md` — update Haystack hooks section
- `CHANGELOG.md` — update existing Haystack entry with Option B scope
- `docs/workflow/development-workflow/integrations/haystack.md` — add adoption decision section, update hook table and installation note
- `hooks/commit-msg` — no-op (Entire removed)
- `hooks/post-commit` — no-op (Entire removed)
- `hooks/pre-push` — no-op (Entire removed)
- `hooks/prepare-commit-msg` — no-op (Entire removed)

## Test Plan

- [ ] Verify markdownlint passes on changed markdown files
- [ ] Verify `hooks/pre-commit` still runs agent detection + truncation check + LLM_RULES gate normally
- [ ] Verify no `.entire/` directory or settings are referenced in updated docs
- [ ] Human review of adoption decision rationale in `integrations/haystack.md`

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)