### PR TITLE
fix(pr-review-loop): clarify REST-vs-GraphQL bot-login normalization comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **CodeRabbit auto-review disabled** — `.coderabbit.yaml` `auto_review.enabled` set to `false`. CodeRabbit no longer fires automatically on new PRs; it can still be triggered on demand via `@coderabbitai review` in the reviewer loop.
 
+### Fixed
+
+- **`pr-review-loop.sh`: clarify REST-vs-GraphQL bot-login normalization comments** — the inline comments at the `[bot]`-suffix-stripping lines previously said only "GraphQL returns login WITHOUT [bot]", which was ambiguous and led to a Haystack triage misread. Expanded to explicitly state that REST API endpoints return logins WITH the `[bot]` suffix while GraphQL returns them WITHOUT it, and that the strip normalizes for GraphQL usage. Applies to all three stripping sites (`run_codex_github_review`, `coderabbit_thread_gate_clean`, and the `check_all_platforms_for_unresolved_threads` loop).
+
 ### Added
 
 - **Haystack Editor git hooks (optional)** — `haystack hooks install` adds agent-aware pre-commit checks (`hooks/`), Entire session linkage (`.entire/`), and `LLM_RULES.md` aligned with the default `gh pr create` + reviewer-loop workflow. Integration guide: `docs/workflow/development-workflow/integrations/haystack.md`.

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -623,8 +623,11 @@ run_codex_github_review() {
   local max_wait="$4"
   local platform="codex-github"
   local bot_login="${CODEX_GITHUB_BOT_LOGIN:-chatgpt-codex-connector[bot]}"
-  # GraphQL author.login returns the login WITHOUT the "[bot]" suffix that the
-  # REST API uses. Strip it here so check_unresolved_threads comparisons work.
+  # REST API endpoints (e.g. /pulls/{n}/reviews, /issues/{n}/comments) return
+  # bot logins WITH the "[bot]" suffix (e.g. "chatgpt-codex-connector[bot]").
+  # GraphQL API returns bot logins WITHOUT the "[bot]" suffix
+  # (e.g. "chatgpt-codex-connector"). Strip it here so check_unresolved_threads,
+  # which queries GraphQL, compares against the correct login form.
   local graphql_bot_login="${bot_login%\[bot\]}"
   local repo
   local reviewer_script
@@ -1884,8 +1887,11 @@ coderabbit_thread_gate_clean() {
   local thread_audit_max_retries
   thread_audit_max_retries="$(thread_audit_max_retries_value)"
   local thread_audit_attempt=0
-  # GraphQL author.login returns the login WITHOUT the "[bot]" suffix that the
-  # REST API uses. Strip it here so check_unresolved_threads comparisons work.
+  # REST API endpoints (e.g. /pulls/{n}/reviews, /issues/{n}/comments) return
+  # bot logins WITH the "[bot]" suffix (e.g. "coderabbit-ai[bot]").
+  # GraphQL API returns bot logins WITHOUT the "[bot]" suffix
+  # (e.g. "coderabbit-ai"). Strip it here so check_unresolved_threads,
+  # which queries GraphQL, compares against the correct login form.
   local graphql_bot_login="${bot_login%\[bot\]}"
 
   # check_unresolved_threads re-enables errexit internally; capture and restore
@@ -3540,8 +3546,9 @@ if [ "$aggregate_result" = "clean" ] || [ "$aggregate_result" = "skipped" ]; the
   # bracket characters in "[bot]" strings during iteration.
   for _platform in "${platforms[@]}"; do
     _login="$(bot_login_for_platform "$_platform")"
-    # Strip the REST-style "[bot]" suffix — check_unresolved_threads compares
-    # against GraphQL author.login which does not include the "[bot]" suffix.
+    # REST API returns bot logins WITH the "[bot]" suffix; GraphQL API returns
+    # them WITHOUT it. Strip it here so check_unresolved_threads, which queries
+    # GraphQL, compares against the correct login form.
     # (e.g. "chatgpt-codex-connector[bot]" → "chatgpt-codex-connector")
     _login="${_login%\[bot\]}"
     [ -n "$_login" ] && unresolved_bot_logins+=("$_login")


### PR DESCRIPTION
## Summary

Closes #732

Expands the inline comments at all 3 bot-login normalization sites in `scripts/development-workflow/pr-review-loop.sh` to explicitly document the REST vs. GraphQL API difference:

- REST API returns bot logins **with** the `[bot]` suffix (e.g. `github-actions[bot]`)
- GraphQL API returns bot logins **without** the `[bot]` suffix (e.g. `github-actions`)
- The `%[bot]` strip in each normalization block is explained as a GraphQL-normalization step

This is a **comment-only change** — no logic, no behavior change. Addresses the documentation gap identified in #732 where the normalization rationale was unclear to reviewers.

## Test plan

- [ ] Diff confirms only comment lines changed (no logic changes)
- [ ] `pr-review-loop.sh` executes without errors on a sample PR
- [ ] CodeRabbit/automated reviewer finds no issues