### PR TITLE
fix(batch-merge): support non-develop base branches in merge and discover subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`batch-merge.sh`: support non-`develop` base branches in `merge` and `discover` subcommands** (#736): `merge` hardcoded `TARGET_BASE="develop"` and did not honour a `--base` flag or `TARGET_BASE` env var, making batch-merge unusable for integration branches (e.g. `develop-<slug>`). Added: (1) `TARGET_BASE` env var support (`TARGET_BASE="${TARGET_BASE:-develop}"`); (2) per-subcommand `--base <branch>` flag to both `merge` and `discover` (highest priority override); (3) a global pre-dispatch `--base` flag already present is preserved. Protocol 94 Step 4.1 updated to document the `--base` flag and equivalent env var form for integration-branch contexts.
 - **`pr-review-loop.sh`: clarify REST-vs-GraphQL bot-login normalization comments** — the inline comments at the `[bot]`-suffix-stripping lines previously said only "GraphQL returns login WITHOUT [bot]", which was ambiguous and led to a Haystack triage misread. Expanded to explicitly state that REST API endpoints return logins WITH the `[bot]` suffix while GraphQL returns them WITHOUT it, and that the strip normalizes for GraphQL usage. Applies to all three stripping sites (`run_codex_github_review`, `coderabbit_thread_gate_clean`, and the `check_all_platforms_for_unresolved_threads` loop).
 
 ### Added

--- a/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
+++ b/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
@@ -154,7 +154,7 @@ Process PRs one at a time in the approved order.
 > resolution, or abort) **before** advancing to the next PR. Never wrap multiple merge
 > calls in a single non-interactive shell loop (e.g., `for pr in …; do … merge --pr $pr; done`)
 > — if one PR leaves the working tree in a conflicted state, subsequent calls will fail with
-> "Could not check out 'develop' — working tree is not clean" and all remaining PRs will be
+> "Could not check out '<base>' — working tree is not clean" and all remaining PRs will be
 > lost. The sequential discipline is mandatory even when all PRs are expected to be conflict-free.
 
 For each PR in the approved order:
@@ -166,7 +166,13 @@ For each PR in the approved order:
 **b. Run the merge script:**
 
 ```bash
+# Standard (merging into develop):
 ./scripts/development-workflow/batch-merge.sh merge --pr <number>
+
+# Integration-branch override (merging into develop-<slug> or other base):
+./scripts/development-workflow/batch-merge.sh merge --pr <number> --base develop-<slug>
+# Equivalent using the env var form:
+# TARGET_BASE=develop-<slug> ./scripts/development-workflow/batch-merge.sh merge --pr <number>
 ```
 
 Parse the output:

--- a/scripts/development-workflow/batch-merge.sh
+++ b/scripts/development-workflow/batch-merge.sh
@@ -70,7 +70,12 @@ SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 cd_workflow_repo_root
 
-TARGET_BASE="develop"
+# TARGET_BASE: base integration branch for merge and discover subcommands.
+# Resolution order (highest priority first):
+#   1. --base flag (parsed at entry point before subcommand dispatch)
+#   2. TARGET_BASE environment variable
+#   3. Default: "develop"
+TARGET_BASE="${TARGET_BASE:-develop}"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -157,6 +162,12 @@ cmd_discover() {
       --prs)
         [ $# -ge 2 ] && [ -n "${2:-}" ] || die "--prs requires a comma-separated value (e.g. --prs 101,102)"
         explicit_prs="$2"
+        shift 2
+        ;;
+      --base)
+        # Per-subcommand --base overrides the global TARGET_BASE (and env var).
+        [ $# -ge 2 ] && [ -n "${2:-}" ] || die "--base requires a branch name"
+        TARGET_BASE="$2"
         shift 2
         ;;
       *)
@@ -454,6 +465,12 @@ cmd_merge() {
       --pr)
         [ $# -ge 2 ] && [ -n "${2:-}" ] || die "--pr requires a PR number value"
         pr_num="$2"
+        shift 2
+        ;;
+      --base)
+        # Per-subcommand --base overrides the global TARGET_BASE (and env var).
+        [ $# -ge 2 ] && [ -n "${2:-}" ] || die "--base requires a branch name"
+        TARGET_BASE="$2"
         shift 2
         ;;
       *)


### PR DESCRIPTION
## Summary

- batch-merge.sh merge hardcoded TARGET_BASE=develop and ignored --base flag and TARGET_BASE env var, making the merge subcommand unusable for integration branches (e.g. develop-<slug>)
- Added TARGET_BASE env var support via ${TARGET_BASE:-develop} at the declaration site
- Added per-subcommand --base <branch> flag to both cmd_merge and cmd_discover (highest priority, overrides env var and global pre-dispatch flag)
- Protocol 94 Step 4.1 updated to document the per-subcommand --base flag and TARGET_BASE env var form

## Acceptance criteria (from #736)

- [x] batch-merge.sh merge --pr <N> --base develop-<slug> targets the override branch
- [x] TARGET_BASE=develop-<slug> batch-merge.sh merge --pr <N> works equivalently
- [x] delete-branch continues to honour TARGET_BASE as before (unchanged)
- [x] Protocol 94 documents the flag

## Test plan

- [ ] Verify merge --pr N --base develop-test targets develop-test
- [ ] Verify TARGET_BASE=develop-test merge --pr N targets develop-test
- [ ] Verify discover --base develop-test filters to that base
- [ ] Verify merge --base (no value) exits with error
- [ ] ShellCheck passes (pre-existing SC1091 info warning only)
- [ ] CHANGELOG lint passes

Fixes #736

Generated with Claude Code