### PR TITLE
chore(config): swap CodeRabbit for claude-code-action in reviewer config

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -29,15 +29,15 @@ review:
   platforms:
     - pr-agent
     - haystack
-    - coderabbit
   #
   # Platforms listed here are treated as "after-clean" reviewers by
   # pr-review-loop.sh: earlier platforms must reach clean before these platforms
   # are considered the value-measurement phase. The protocol keeps PRs as drafts
-  # while PR-Agent clears, then converts to non-draft so CodeRabbit can run after
-  # the PR-Agent-clean gate. This makes CodeRabbit's net-new findings measurable.
+  # while PR-Agent and Haystack clear, then converts to non-draft so
+  # claude-code-action can run after the clean gate. This makes claude-code-action's
+  # net-new findings measurable. Requires ANTHROPIC_API_KEY in GitHub Actions secrets.
   phase_after_clean:
-    - coderabbit
+    - claude-code-action
   # Recommended: swap coderabbit for claude-code-action in phase_after_clean to
   # remove the CodeRabbit per-hour rate-limit bottleneck. claude-code-action has
   # no review cap and uses your own Anthropic API key. Requires the

--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -29,6 +29,7 @@ review:
   platforms:
     - pr-agent
     - haystack
+    - claude-code-action
   #
   # Platforms listed here are treated as "after-clean" reviewers by
   # pr-review-loop.sh: earlier platforms must reach clean before these platforms
@@ -38,12 +39,6 @@ review:
   # net-new findings measurable. Requires ANTHROPIC_API_KEY in GitHub Actions secrets.
   phase_after_clean:
     - claude-code-action
-  # Recommended: swap coderabbit for claude-code-action in phase_after_clean to
-  # remove the CodeRabbit per-hour rate-limit bottleneck. claude-code-action has
-  # no review cap and uses your own Anthropic API key. Requires the
-  # ANTHROPIC_API_KEY secret and the CI workflow added by sibling item #706.
-  # See docs/workflow/development-workflow/integrations/claude-code-action.md
-  # for setup instructions.
   #
   # Configurable codex-github options (set via env vars or script flags to codex-github-reviewer.sh):
   #   CODEX_GITHUB_TRIGGER_PHRASE  — trigger phrase sent to the bot (default: "@codex review")


### PR DESCRIPTION
## Summary

- Removes `coderabbit` from `review.platforms` and `review.phase_after_clean`
- Adds `claude-code-action` to `review.phase_after_clean` as the post-clean deep reviewer

## New reviewer flow

1. `pr-agent` — fast blocking review (main loop)
2. `haystack` — logic-error focused blocking review (main loop)
3. `claude-code-action` — deep uncapped review via Anthropic API (phase_after_clean, runs after main loop is clean)

## Prerequisites

`ANTHROPIC_API_KEY` must be set as a GitHub Actions secret. The `claude-code-review.yml` workflow is already in the repo (added in #706 / PR #730).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->