### PR TITLE
fix(claude-code-action): dispatch workflow against default branch, not PR base branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`pr-review-loop.sh`: stale-lock detection and recovery** (#734) — when `lock_contention` is reported, the error message now includes the lock file path and a recovery one-liner (`./scripts/development-workflow/pr-review-loop.sh unlock <pr>`). A new `unlock <pr-number>` subcommand lets agents remove a stale lock autonomously without human intervention; it refuses to remove a lock whose recorded PID is still alive, preventing accidental removal of a live lock.
 - **`batch-merge.sh`: support non-`develop` base branches in `merge` and `discover` subcommands** (#736): `merge` hardcoded `TARGET_BASE="develop"` and did not honour a `--base` flag or `TARGET_BASE` env var, making batch-merge unusable for integration branches (e.g. `develop-<slug>`). Added: (1) `TARGET_BASE` env var support (`TARGET_BASE="${TARGET_BASE:-develop}"`); (2) per-subcommand `--base <branch>` flag to both `merge` and `discover` (highest priority override); (3) a global pre-dispatch `--base` flag already present is preserved. Protocol 94 Step 4.1 updated to document the `--base` flag and equivalent env var form for integration-branch contexts.
 - **`pr-review-loop.sh`: clarify REST-vs-GraphQL bot-login normalization comments** — the inline comments at the `[bot]`-suffix-stripping lines previously said only "GraphQL returns login WITHOUT [bot]", which was ambiguous and led to a Haystack triage misread. Expanded to explicitly state that REST API endpoints return logins WITH the `[bot]` suffix while GraphQL returns them WITHOUT it, and that the strip normalizes for GraphQL usage. Applies to all three stripping sites (`run_codex_github_review`, `coderabbit_thread_gate_clean`, and the `check_all_platforms_for_unresolved_threads` loop).
+- **`claude-code-action-reviewer.sh`: dispatch workflow against default branch, not PR base branch** — `workflow_dispatch` only works for workflows registered on the repository's default branch; dispatching against `BASE_REF` (e.g. `develop`) caused a permanent 404 when the workflow file was not yet on the default branch. The script now resolves the default branch via `gh repo view` and uses it as the dispatch ref, falling back to `main` if resolution fails.
 
 ### Added
 
@@ -27,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Integrate Haystack triage CLI as native PR review platform** (#720): add `haystack-reviewer.sh` companion script and wire `haystack` as a native platform in `pr-review-loop.sh`; add `haystack-triage.md` integration guide. Declare `haystack` in `review.platforms` or `review.phase_after_clean` in `.ai-dev-workflow.yaml` to include Haystack triage in the Step 7 automated reviewer loop.
 - **Script-Accuracy Self-Check Checklist in protocol 03** (#735): `03-implement-development-protocol.md` now includes a conditional Script-Accuracy Self-Check Checklist that applies to documentation PRs describing script behavior. Before opening such PRs, agents must enumerate each claim about input/output format, exit codes, option flags, and API calls; verify each claim against the actual script source with targeted greps; resolve discrepancies by updating the documentation; and append a self-check log to the PR description. The checklist is cross-referenced in the pre-commit verification step of all four implementation paths (Full Pipeline, Refactor, Fast Track, Hotfix). Developer agent files (`.claude/agents/developer.md`, `.cursor/agents/developer.md`) updated with a corresponding key rule.
 - **`copilot` review platform** (#709): `pr-review-loop.sh` now recognizes `copilot` as a review platform. Add it to `review.platforms` in `.ai-dev-workflow.yaml` to use GitHub Copilot code review as an automated PR reviewer. `run_copilot_review()` requests Copilot as a reviewer via the GitHub Pulls API, polls until Copilot posts its verdict, and maps the review state to the standard exit-code contract (APPROVED → clean, CHANGES\_REQUESTED → needs\_fixes, COMMENTED → clean, timeout → escalate). Falls back gracefully when Copilot code review is not enabled on the repository (`RESULT=escalate REASON=unavailable`). Bot login overridable via `COPILOT_BOT_LOGIN` env var. Integration guide: `docs/workflow/development-workflow/integrations/copilot.md`.
+
+## [0.28.3] - 2026-05-26
+
+### Fixed
+
+- **`.github/workflows/claude-code-review.yml`: add missing workflow to `main`** (hotfix): the workflow was only present on `develop`, causing GitHub's Actions API to return 404 on every `workflow_dispatch` call from `claude-code-action-reviewer.sh`. GitHub serves `workflow_dispatch` events only for workflows registered on the default branch (`main`). Added the workflow file to `main` to restore the `claude-code-action` reviewer.
 
 ## [0.28.2] - 2026-05-23
 
@@ -809,7 +816,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.2...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.3...HEAD
+[0.28.3]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.2...v0.28.3
 [0.28.2]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.1...v0.28.2
 [0.28.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.4...v0.28.0

--- a/scripts/development-workflow/claude-code-action-reviewer.sh
+++ b/scripts/development-workflow/claude-code-action-reviewer.sh
@@ -131,7 +131,12 @@ if ! gh auth status >/dev/null 2>&1; then
   exit 2
 fi
 
-# ── Resolve PR base branch for workflow dispatch ref ─────────────────────────
+# ── Resolve base branch and dispatch ref ─────────────────────────────────────
+# BASE_REF is the PR's target branch (used for logging and context).
+# DISPATCH_REF is always the repo's default branch: GitHub's workflow_dispatch
+# API only serves workflows registered on the default branch. Dispatching
+# against BASE_REF (e.g. 'develop') causes a permanent 404 when the workflow
+# file is not yet on the default branch.
 
 echo "INFO: resolving PR #$PR_NUMBER base branch..."
 if ! BASE_REF=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json baseRefName --jq '.baseRefName' 2>/dev/null); then
@@ -145,7 +150,13 @@ if [ -z "$BASE_REF" ]; then
   exit 2
 fi
 
-echo "INFO: PR #$PR_NUMBER base branch: $BASE_REF"
+DEFAULT_BRANCH=$(gh repo view "$OWNER/$REPO" --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null) || true
+if [ -z "$DEFAULT_BRANCH" ]; then
+  DEFAULT_BRANCH="main"
+fi
+DISPATCH_REF="$DEFAULT_BRANCH"
+echo "INFO: PR #$PR_NUMBER base branch: $BASE_REF (dispatch ref: $DISPATCH_REF)"
+echo "INFO: dispatch ref: $DISPATCH_REF (GitHub workflow_dispatch requires the workflow on the default branch)"
 echo "INFO: Workflow file: $WORKFLOW_FILE"
 echo "INFO: Bot login: $BOT_LOGIN"
 if [ "$POLL_INTERVAL" -gt "$MAX_WAIT" ]; then
@@ -176,17 +187,18 @@ echo "INFO: dispatch time (pre-dispatch): $DISPATCH_TIME"
 echo "INFO: poll filter time (with 10s clock-skew buffer): $POLL_AFTER_TIME"
 
 # ── Phase 1: Dispatch workflow ────────────────────────────────────────────────
-# Call workflow_dispatch with ref=BASE_REF and pr_number input. On failure:
+# Call workflow_dispatch with ref=DISPATCH_REF (default branch) and pr_number
+# input. On failure:
 #   - 404 / "workflow was not found" → exit 3 (UNAVAILABLE: file absent)
 #   - other errors → exit 3 (UNAVAILABLE: dispatch failure)
 
-echo "INFO: dispatching workflow '$WORKFLOW_FILE' on ref '$BASE_REF' for PR #$PR_NUMBER..."
+echo "INFO: dispatching workflow '$WORKFLOW_FILE' on ref '$DISPATCH_REF' for PR #$PR_NUMBER..."
 
 DISPATCH_STDERR=$(mktemp)
 DISPATCH_STATUS=0
 gh api "repos/$OWNER/$REPO/actions/workflows/$WORKFLOW_FILE/dispatches" \
   --method POST \
-  --raw-field "ref=$BASE_REF" \
+  --raw-field "ref=$DISPATCH_REF" \
   --raw-field "inputs[pr_number]=$PR_NUMBER" \
   2>"$DISPATCH_STDERR" || DISPATCH_STATUS=$?
 
@@ -196,7 +208,7 @@ if [ "$DISPATCH_STATUS" -ne 0 ]; then
   echo "ERROR: workflow dispatch failed (exit $DISPATCH_STATUS): $DISPATCH_ERR" >&2
   # Distinguish 404 (workflow file absent / not found) from other errors
   if echo "$DISPATCH_ERR" | grep -qi "not found\|404\|workflow was not found"; then
-    echo "VERDICT: UNAVAILABLE — workflow file '$WORKFLOW_FILE' not found on ref '$BASE_REF'"
+    echo "VERDICT: UNAVAILABLE — workflow file '$WORKFLOW_FILE' not found on ref '$DISPATCH_REF'"
   else
     echo "VERDICT: UNAVAILABLE — workflow dispatch failed: $DISPATCH_ERR"
   fi


### PR DESCRIPTION
## Problem

`claude-code-action-reviewer.sh` dispatches the `claude-code-review.yml` workflow using `ref=$BASE_REF` (the PR's base branch, e.g. `develop`). However, GitHub's `workflow_dispatch` API only serves workflows registered on the **default branch** of the repository (typically `main`). When the workflow file exists on `develop` but not on `main`, the API returns 404.

## Fix

1. After resolving `BASE_REF`, the script now resolves the repo's default branch via `gh repo view ... --json defaultBranchRef` and uses it as `DISPATCH_REF`. Falls back to `main` if resolution fails.
2. The `workflow_dispatch` API call now uses `ref=$DISPATCH_REF` instead of `ref=$BASE_REF`.
3. The UNAVAILABLE verdict message and the dispatch info log are updated to reference `$DISPATCH_REF`.
4. The comment block is renamed from "Resolve PR base branch for workflow dispatch ref" to "Resolve base branch and dispatch ref" with a note explaining why `DISPATCH_REF` must be the default branch.
5. `BASE_REF` is kept for all other uses (logging, context).

## Testing

- `shellcheck --severity=warning` passes with no warnings.
- No behavioral change when the workflow exists on both `develop` and `main`.
- When the workflow only exists on `main` (common during development), dispatches now succeed instead of returning 404.

## CHANGELOG

Added `### Fixed` entry under `[Unreleased]`.

## Script-Accuracy Self-Check

| Claim | Verified |
|---|---|
| `gh repo view ... --json defaultBranchRef --jq '.defaultBranchRef.name'` resolves the default branch | Matches `gh` CLI JSON field name |
| Falls back to `main` if resolution fails | `|| true` + `if [ -z "$DEFAULT_BRANCH" ]` guard present |
| `DISPATCH_REF` used in `--raw-field "ref=..."` | Line 201: `--raw-field "ref=$DISPATCH_REF"` |
| VERDICT UNAVAILABLE message uses `$DISPATCH_REF` | Line 211 updated |
| `BASE_REF` still used for all other logging | Lines 158, no other dispatch uses |

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>