### PR TITLE
fix(ci): add missing claude-code-review.yml to main (hotfix v0.28.3)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,51 @@
+name: Claude Code Action PR Review
+
+on:
+  # Triggered on demand by pr-review-loop.sh or a repository maintainer.
+  # Not triggered automatically on PR open, push, or synchronize events.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review"
+        required: true
+        type: number
+
+# Prevent duplicate simultaneous runs for the same PR.
+# Uses inputs.pr_number (not github.event.pull_request.number,
+# which is unavailable on workflow_dispatch events).
+concurrency:
+  group: claude-code-review-${{ inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Claude Code Action review
+    runs-on: ubuntu-latest
+
+    # Minimum permissions required:
+    #   pull-requests: write — to post review comments on the PR
+    #   contents: read — to read the repository checkout during review
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Run Claude Code Action PR review
+        # Pinned to v1.0.133 (SHA: db614ad5ed8c94def23ad6cc336751c8ba450ac1).
+        # Check https://github.com/anthropics/claude-code-action/releases for
+        # newer releases and update the SHA accordingly before merging.
+        uses: anthropics/claude-code-action@db614ad5ed8c94def23ad6cc336751c8ba450ac1  # v1.0.133
+        with:
+          pr_number: ${{ inputs.pr_number }}
+          # Default model: claude-sonnet-4-6
+          # Rationale: Sonnet 4.6 is Anthropic's recommended CI review model —
+          # it delivers adequate review quality at ~1/5 the token cost of Opus.
+          # Public-repo Actions minutes are free; the only cost is token
+          # consumption (~$0.30 per review pass with claude-sonnet-4-6).
+          model: claude-sonnet-4-6
+        env:
+          # Authenticate exclusively via the repository secret ANTHROPIC_API_KEY.
+          # No other Anthropic credential (OAuth, personal token) is used.
+          # Set the secret in GitHub repo settings → Secrets → Actions before
+          # triggering this workflow.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.3] - 2026-05-26
+
+### Fixed
+
+- **`.github/workflows/claude-code-review.yml`: add missing workflow to `main`** (hotfix): the workflow was only present on `develop`, causing GitHub's Actions API to return 404 on every `workflow_dispatch` call from `claude-code-action-reviewer.sh`. GitHub serves `workflow_dispatch` events only for workflows registered on the default branch (`main`). Added the workflow file to `main` to restore the `claude-code-action` reviewer.
+
 ## [0.28.2] - 2026-05-23
 
 ### Fixed
@@ -788,7 +794,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.2...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.3...HEAD
+[0.28.3]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.2...v0.28.3
 [0.28.2]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.1...v0.28.2
 [0.28.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.27.4...v0.28.0


### PR DESCRIPTION
## Problem

`.github/workflows/claude-code-review.yml` exists on `develop` but not on `main`. GitHub's Actions API only serves `workflow_dispatch` events for workflows registered on the **default branch** (`main`). As a result, `claude-code-action-reviewer.sh` always receives a 404 when trying to dispatch the workflow, making the `claude-code-action` reviewer permanently unavailable.

## Fix

Adds the `claude-code-review.yml` workflow file to `main`. This is a single-file addition copied exactly from `develop` — the content is identical.

The workflow:
- Triggers on `workflow_dispatch` with a `pr_number` input (on-demand only, not on PR open/push)
- Uses `anthropics/claude-code-action@db614ad5ed8c94def23ad6cc336751c8ba450ac1` (v1.0.133), pinned to full SHA
- Runs with `claude-sonnet-4-6` and authenticates via `ANTHROPIC_API_KEY` repository secret
- Has explicit least-privilege `permissions:` block (`pull-requests: write`, `contents: read`)
- Has `concurrency` group to prevent duplicate runs for the same PR

## GitHub Actions Workflow Security Checklist

- [x] Explicit `permissions:` block at job scope with least privilege (`pull-requests: write`, `contents: read`)
- [x] All `uses:` references pinned to full commit SHA with version tag in adjacent comment
- [x] No `paths:` filter needed (workflow_dispatch only; no file-based trigger)
- [x] `concurrency` group present to prevent duplicate simultaneous runs
- [x] Fork-PR guard not required: `workflow_dispatch` events cannot be triggered by fork PRs; no `pull_request` event is used

## CHANGELOG

Adds versioned section `[0.28.3] - 2026-05-26` directly below `[Unreleased]`.

## Backport

A backport PR targeting `develop` will be opened after this merges to `main`.