### PR TITLE
fix(claude-code-review.yml): add id-token:write and remove deprecated inputs (hotfix v0.28.4)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,10 +4,17 @@ on:
   # Triggered on demand by pr-review-loop.sh or a repository maintainer.
   # Not triggered automatically on PR open, push, or synchronize events.
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review"
+        required: true
+        type: number
 
 # Prevent duplicate simultaneous runs for the same PR.
+# Uses inputs.pr_number (not github.event.pull_request.number,
+# which is unavailable on workflow_dispatch events).
 concurrency:
-  group: claude-code-review-${{ github.run_id }}
+  group: claude-code-review-${{ inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,17 +4,10 @@ on:
   # Triggered on demand by pr-review-loop.sh or a repository maintainer.
   # Not triggered automatically on PR open, push, or synchronize events.
   workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "Pull request number to review"
-        required: true
-        type: number
 
 # Prevent duplicate simultaneous runs for the same PR.
-# Uses inputs.pr_number (not github.event.pull_request.number,
-# which is unavailable on workflow_dispatch events).
 concurrency:
-  group: claude-code-review-${{ inputs.pr_number }}
+  group: claude-code-review-${{ github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -25,9 +18,11 @@ jobs:
     # Minimum permissions required:
     #   pull-requests: write — to post review comments on the PR
     #   contents: read — to read the repository checkout during review
+    #   id-token: write — required for OIDC token auth in claude-code-action v1.0.133+
     permissions:
       pull-requests: write
       contents: read
+      id-token: write
 
     steps:
       - name: Run Claude Code Action PR review
@@ -36,16 +31,7 @@ jobs:
         # newer releases and update the SHA accordingly before merging.
         uses: anthropics/claude-code-action@db614ad5ed8c94def23ad6cc336751c8ba450ac1  # v1.0.133
         with:
-          pr_number: ${{ inputs.pr_number }}
-          # Default model: claude-sonnet-4-6
-          # Rationale: Sonnet 4.6 is Anthropic's recommended CI review model —
-          # it delivers adequate review quality at ~1/5 the token cost of Opus.
-          # Public-repo Actions minutes are free; the only cost is token
-          # consumption (~$0.30 per review pass with claude-sonnet-4-6).
-          model: claude-sonnet-4-6
-        env:
-          # Authenticate exclusively via the repository secret ANTHROPIC_API_KEY.
-          # No other Anthropic credential (OAuth, personal token) is used.
+          # Authenticate via the repository secret ANTHROPIC_API_KEY.
           # Set the secret in GitHub repo settings → Secrets → Actions before
           # triggering this workflow.
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.4] - 2026-05-27
+
+### Fixed
+
+- **`claude-code-review.yml`: add `id-token: write` and remove deprecated `pr_number`/`model` inputs** (hotfix): `claude-code-action` v1.0.133+ requires `id-token: write` for OIDC token auth; without it every `workflow_dispatch` run fails with "Could not fetch an OIDC token". Also removes the deprecated `pr_number` and `model` inputs and moves `anthropic_api_key` from `env:` to `with:` as now supported by the action. The `main` branch still carried the original v1 workflow; this hotfix brings it to parity with the fix already applied to `develop` via PR #767.
+
 ## [0.28.3] - 2026-05-26
 
 ### Fixed
@@ -794,7 +800,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.3...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.4...HEAD
+[0.28.4]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.3...v0.28.4
 [0.28.3]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.2...v0.28.3
 [0.28.2]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.1...v0.28.2
 [0.28.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.0...v0.28.1


### PR DESCRIPTION
## Summary

- Adds `id-token: write` to the `permissions` block — required for OIDC token auth in `claude-code-action` v1.0.133+; without it every `workflow_dispatch` run fails with "Could not fetch an OIDC token"
- Removes deprecated `pr_number` and `model` inputs from the `with:` block
- Moves `anthropic_api_key` from `env:` to `with:` as now supported by the action
- Bumps CHANGELOG to `[0.28.4]`

## Root cause

`main` still carried the original v1 workflow (added by hotfix v0.28.3). The `develop` branch received the fix via PR #767, but `workflow_dispatch` is only served from the default branch (`main`), so the fix had no effect there.

## Test plan

- [ ] Merge to `main` and verify `claude-code-action` completes without the OIDC error on a subsequent PR
- [ ] Confirm `anthropic_api_key` secret is set in repo Actions secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lhpaul/ai-dev-framework-template/pull/770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->