### PR TITLE
fix(hotfix-v0.29.1): address sync-review findings from kids-safety-platform PR #208

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.1] - 2026-05-28
+
+### Fixed
+
+- **`pr-review-loop.sh`: move `unlock` before the single-instance lock guard** — when a stale lock exists, the guard was re-acquiring it before `unlock` could run, causing `unlock` to see a live PID and refuse to remove the lock, breaking manual stale-lock recovery.
+- **`claude-code-action-reviewer.sh`: emit `UNAVAILABLE`/exit 3 for preflight failures** — auth failure and unresolvable PR base branch were returning `TIMED_OUT`/exit 2, causing callers to apply the timeout policy instead of the unavailable policy.
+- **`pr-review-loop.sh`: add `claude-code-action` and `copilot` to usage string** — both platforms were omitted from the help text, making CLI discoverability inconsistent with the actual dispatcher.
+- **`claude-code-action.md`: fix dispatch-ref troubleshooting row** — the table incorrectly said the dispatch `ref` must match the PR base branch; the correct value is the repository default branch.
+- **`pr-review-loop.sh`: re-fetch Copilot review SHA each poll iteration** — if a new commit is pushed while the Copilot review is in-flight, the initial SHA becomes stale and the SHA-filtered poll would never match the submitted review, causing a spurious timeout.
+- **`pr-review-loop.sh`: guard `since_iso` against future-dated commit timestamps** — a committer date ahead of wall-clock time (clock skew or rebase) caused all existing bot comments to be excluded, producing false-clean results or duplicate review requests in the Devin, PR-Agent, and codex-github platforms.
+- **`pr-review-loop.sh`: keep `comment_count` consistent with forced `blocking_count`** — when the Haystack companion script exits 1 with unparseable stdout, `blocking_count` was forced to 1 but `comment_count` stayed at 0, producing inconsistent output for downstream consumers.
+- **`haystack-triage.md`: add language specifiers to fenced code blocks** — unlabeled fences triggered MD040 markdownlint warnings.
+
 ## [0.29.0] - 2026-05-27
 
 ### Added
@@ -829,7 +842,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.29.1...HEAD
+[0.29.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.29.0...v0.29.1
 [0.29.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.4...v0.29.0
 [0.28.4]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.3...v0.28.4
 [0.28.3]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.2...v0.28.3

--- a/docs/workflow/development-workflow/integrations/claude-code-action.md
+++ b/docs/workflow/development-workflow/integrations/claude-code-action.md
@@ -41,7 +41,7 @@ tier for private repositories) are the only other resource consumed.
 In your repository settings, navigate to **Settings → Secrets and variables →
 Actions** and create a new repository secret named exactly:
 
-```
+```text
 ANTHROPIC_API_KEY
 ```
 
@@ -53,7 +53,7 @@ reviewer script expect this name by default.
 
 The framework template ships a ready-to-use GitHub Actions workflow at:
 
-```
+```text
 .github/workflows/claude-code-review.yml
 ```
 
@@ -84,7 +84,7 @@ automatically. You do not need to dispatch the workflow manually when using
 When Claude Code Action posts review threads on a PR, the comments appear under
 the GitHub App bot login:
 
-```
+```text
 claude[bot]
 ```
 
@@ -287,7 +287,7 @@ Step 7a gate maps to outcomes:
 | `RESULT=escalate REASON=timeout`                               | Actions run did not complete within `max_wait` (default 600 s) | Check the Actions tab for the run status; increase `--max-wait` if the review consistently takes longer than 10 minutes         |
 | Review threads not detected after Actions run succeeds         | Bot login mismatch                                             | Confirm the bot posting threads is `claude[bot]`; if using a custom App, set `CLAUDE_CODE_ACTION_BOT_LOGIN` to the correct login |
 | `pr-review-loop.sh` reports `skipped` for `claude-code-action` | Platform not listed in `review.platforms`                      | Add `claude-code-action` to `review.platforms` in `.ai-dev-workflow.yaml`                                                       |
-| Workflow dispatched but no Actions run appears                 | Dispatch accepted but workflow file not found or wrong ref     | Confirm `.github/workflows/claude-code-review.yml` exists on the base branch and the dispatch `ref` matches the PR base branch |
+| Workflow dispatched but no Actions run appears                 | Dispatch accepted but workflow file not found or wrong ref     | Confirm `.github/workflows/claude-code-review.yml` exists on the default branch and the dispatch `ref` matches the repository default branch |
 
 ---
 

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -112,7 +112,7 @@ If `haystack triage` does not return within the timeout, `haystack-reviewer.sh` 
 
 When the `haystack` CLI is absent from `$PATH` or returns a non-zero exit code (authentication failure, network error, etc.), `haystack-reviewer.sh` exits `3` (UNAVAILABLE) and emits:
 
-```
+```text
 RESULT=skipped
 REASON=unavailable
 BLOCKING_COUNT=0
@@ -139,7 +139,7 @@ COMMENT_COUNT=0
 
 ### `haystack` CLI not found
 
-```
+```text
 INFO: haystack CLI not found in PATH — skipping (UNAVAILABLE)
 RESULT=skipped
 REASON=unavailable
@@ -149,7 +149,7 @@ REASON=unavailable
 
 ### Triage returns `status=none`
 
-```
+```text
 INFO: haystack triage returned status=none (no analysis available for this PR yet) — treating as UNAVAILABLE
 ```
 
@@ -159,7 +159,7 @@ INFO: haystack triage returned status=none (no analysis available for this PR ye
 
 ### Triage times out
 
-```
+```text
 INFO: haystack triage timed out after 120s
 RESULT=escalate
 REASON=timeout
@@ -169,7 +169,7 @@ REASON=timeout
 
 ### Unrecognised finding category
 
-```
+```text
 INFO: unrecognised finding category 'SomeNewCategory' — treating as blocking (safe-fail)
 ```
 

--- a/scripts/development-workflow/claude-code-action-reviewer.sh
+++ b/scripts/development-workflow/claude-code-action-reviewer.sh
@@ -127,8 +127,8 @@ fi
 
 if ! gh auth status >/dev/null 2>&1; then
   echo "ERROR: gh CLI not authenticated. Run 'gh auth login' before using claude-code-action-reviewer.sh" >&2
-  echo "VERDICT: TIMED_OUT — gh CLI authentication failed (treated as unavailable)"
-  exit 2
+  echo "VERDICT: UNAVAILABLE — gh CLI authentication failed"
+  exit 3
 fi
 
 # ── Resolve base branch and dispatch ref ─────────────────────────────────────
@@ -141,13 +141,13 @@ fi
 echo "INFO: resolving PR #$PR_NUMBER base branch..."
 if ! BASE_REF=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json baseRefName --jq '.baseRefName' 2>/dev/null); then
   echo "ERROR: could not resolve PR #$PR_NUMBER base branch" >&2
-  echo "VERDICT: TIMED_OUT — could not resolve PR base branch (treated as unavailable)"
-  exit 2
+  echo "VERDICT: UNAVAILABLE — could not resolve PR base branch"
+  exit 3
 fi
 if [ -z "$BASE_REF" ]; then
   echo "ERROR: could not resolve PR #$PR_NUMBER base branch (empty result)" >&2
-  echo "VERDICT: TIMED_OUT — could not resolve PR base branch (treated as unavailable)"
-  exit 2
+  echo "VERDICT: UNAVAILABLE — could not resolve PR base branch (empty result)"
+  exit 3
 fi
 
 DEFAULT_BRANCH=$(gh repo view "$OWNER/$REPO" --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null) || true

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -18,6 +18,35 @@ if [ "${HARNESS_MODE:-0}" -eq 1 ] && [ "${BASH_SOURCE[0]}" != "$0" ]; then
   _HARNESS_MODE_EFFECTIVE=1
 fi
 
+# --- unlock subcommand ---
+# Must run before the single-instance lock guard so stale-lock recovery always
+# works: if a previous invocation crashed, the lock guard would re-acquire the
+# lock for this process before `unlock` could check it, causing `unlock` to see
+# a live PID and refuse to remove the (now re-owned) lock dir.
+if [ "${1:-}" = "unlock" ]; then
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ]; then
+    echo "Usage: $0 unlock <pr-number>" >&2
+    exit 64
+  fi
+  _UNLOCK_PR="$2"
+  _UNLOCK_LOCK_DIR="/tmp/pr-review-loop-${_UNLOCK_PR}.lockdir"
+  _UNLOCK_PID="$(cat "$_UNLOCK_LOCK_DIR/pid" 2>/dev/null || true)"
+  _UNLOCK_CMD="$(cat "$_UNLOCK_LOCK_DIR/cmd" 2>/dev/null || true)"
+  if [ -n "$_UNLOCK_PID" ] && kill -0 "$_UNLOCK_PID" 2>/dev/null && [ "$_UNLOCK_CMD" = "$(basename "$0")" ]; then
+    echo "ERROR: A live pr-review-loop.sh process (PID $_UNLOCK_PID) currently holds the lock for PR #${_UNLOCK_PR}. Not removing a live lock." >&2
+    echo "  Wait for the process to finish, or send it SIGTERM to stop it gracefully." >&2
+    exit 1
+  fi
+  if [ -d "$_UNLOCK_LOCK_DIR" ]; then
+    rm -rf "$_UNLOCK_LOCK_DIR"
+    echo "OK: stale lock removed for PR #${_UNLOCK_PR} ($_UNLOCK_LOCK_DIR)."
+    exit 0
+  else
+    echo "OK: no lock found for PR #${_UNLOCK_PR} ($_UNLOCK_LOCK_DIR). Nothing to remove."
+    exit 0
+  fi
+fi
+
 # In harness mode (sourced), skip the single-instance lock guard entirely.
 # The guard is irrelevant when the script is sourced by the test harness
 # (no real PR is being processed and no lock directory should be created).
@@ -129,7 +158,7 @@ _interruptible_sleep() {
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--platform greptile] [--platform greptile,devin,pr-agent,coderabbit,codex-github,haystack] [--phase-after-clean coderabbit] [--pre-after-clean-only] [--poll-interval seconds] [--max-wait seconds] [--post-final-summary] [--compare]
+Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--platform greptile] [--platform greptile,devin,pr-agent,coderabbit,codex-github,claude-code-action,copilot,haystack] [--phase-after-clean coderabbit] [--pre-after-clean-only] [--poll-interval seconds] [--max-wait seconds] [--post-final-summary] [--compare]
        ./scripts/development-workflow/pr-review-loop.sh unlock <pr-number>
 
 Runs the automated PR review loop for one or more platforms in sequence. Before
@@ -954,9 +983,13 @@ run_copilot_review() {
   [ "$effective_poll_interval" -le 0 ] && effective_poll_interval=1
 
   while [ "$elapsed" -lt "$max_wait" ]; do
+    # Re-fetch the HEAD SHA on each iteration so that if a new commit is pushed
+    # while Copilot's review is still in-flight, the filter matches the review
+    # against the current commit rather than timing out on a stale SHA.
     set +e
+    current_sha="$(gh pr view "$pr_number" --repo "$owner/$repo_name" --json headRefOid --jq '.headRefOid' 2>/dev/null || echo "$head_sha")"
     review_state="$(gh api --paginate "repos/$owner/$repo_name/pulls/$pr_number/reviews" 2>/dev/null \
-      | jq -rs --arg login "$bot_login" --arg sha "$head_sha" \
+      | jq -rs --arg login "$bot_login" --arg sha "$current_sha" \
         '[ .[] | .[] | select(.user.login == $login and .commit_id == $sha) ] | last | .state // empty')"
     set -e
 
@@ -1082,8 +1115,11 @@ run_haystack_review() {
       return 0
       ;;
     1)
-      # Ensure blocking_count >= 1 even if stdout parsing failed.
+      # Ensure blocking_count >= 1 even if stdout parsing failed, and keep
+      # comment_count consistent so downstream consumers don't see blocking
+      # findings with zero comments.
       [ "$blocking_count" -eq 0 ] && blocking_count=1
+      [ "$comment_count" -eq 0 ] && comment_count=1
       print_kv RESULT needs_fixes
       print_kv PLATFORM "$platform"
       print_kv PR_NUMBER "$pr_number"
@@ -1172,6 +1208,11 @@ run_devin_review() {
   if [ -z "$since_iso" ]; then
     since_iso="$(date -u -v-24H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '24 hours ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
   fi
+  # Cap to now: a future committer.date (clock skew or rebase) would exclude all
+  # existing bot comments, causing false-clean results or duplicate review requests.
+  _now_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  [ "$since_iso" \> "$_now_iso" ] && since_iso="$_now_iso"
+  unset _now_iso
 
   # --- Phase 1: Check for existing blocking findings on the current HEAD ---
   existing_comments="$(
@@ -1615,6 +1656,11 @@ run_pr_agent_review() {
   if [ -z "$since_iso" ]; then
     since_iso="$(date -u -v-24H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '24 hours ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
   fi
+  # Cap to now: a future committer.date (clock skew or rebase) would exclude all
+  # existing bot comments, causing false-clean results or duplicate review requests.
+  _now_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  [ "$since_iso" \> "$_now_iso" ] && since_iso="$_now_iso"
+  unset _now_iso
 
   # Common helper: fetch the matching PR-Agent comment and return one of its fields.
   # Parameters: field (e.g. "body" or "html_url"), match_mode (optional, default "strict_sha").
@@ -2512,6 +2558,11 @@ run_coderabbit_review() {
   if [ -z "$since_iso" ]; then
     since_iso="$(date -u -v-24H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '24 hours ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
   fi
+  # Cap to now: a future committer.date (clock skew or rebase) would exclude all
+  # existing bot comments, causing false-clean results or duplicate review requests.
+  _now_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  [ "$since_iso" \> "$_now_iso" ] && since_iso="$_now_iso"
+  unset _now_iso
 
   # --- Phase 1: Check for existing blocking findings on the current HEAD ---
   existing_comments="$(
@@ -3538,33 +3589,6 @@ METRICS_HEADER
 if [ "$#" -lt 1 ]; then
   usage >&2
   exit 64
-fi
-
-# --- unlock subcommand ---
-# Handle before the lock guard so a crashed-process recovery can always proceed.
-if [ "$1" = "unlock" ]; then
-  if [ "$#" -lt 2 ] || [ -z "$2" ]; then
-    echo "Usage: $0 unlock <pr-number>" >&2
-    exit 64
-  fi
-  _UNLOCK_PR="$2"
-  _UNLOCK_LOCK_DIR="/tmp/pr-review-loop-${_UNLOCK_PR}.lockdir"
-  # Verify no live owner holds the lock before removing it.
-  _UNLOCK_PID="$(cat "$_UNLOCK_LOCK_DIR/pid" 2>/dev/null || true)"
-  _UNLOCK_CMD="$(cat "$_UNLOCK_LOCK_DIR/cmd" 2>/dev/null || true)"
-  if [ -n "$_UNLOCK_PID" ] && kill -0 "$_UNLOCK_PID" 2>/dev/null && [ "$_UNLOCK_CMD" = "$(basename "$0")" ]; then
-    echo "ERROR: A live pr-review-loop.sh process (PID $_UNLOCK_PID) currently holds the lock for PR #${_UNLOCK_PR}. Not removing a live lock." >&2
-    echo "  Wait for the process to finish, or send it SIGTERM to stop it gracefully." >&2
-    exit 1
-  fi
-  if [ -d "$_UNLOCK_LOCK_DIR" ]; then
-    rm -rf "$_UNLOCK_LOCK_DIR"
-    echo "OK: stale lock removed for PR #${_UNLOCK_PR} ($_UNLOCK_LOCK_DIR)."
-    exit 0
-  else
-    echo "OK: no lock found for PR #${_UNLOCK_PR} ($_UNLOCK_LOCK_DIR). Nothing to remove."
-    exit 0
-  fi
 fi
 
 pr_number=""

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -987,7 +987,15 @@ run_copilot_review() {
     # while Copilot's review is still in-flight, the filter matches the review
     # against the current commit rather than timing out on a stale SHA.
     set +e
-    current_sha="$(gh pr view "$pr_number" --repo "$owner/$repo_name" --json headRefOid --jq '.headRefOid' 2>/dev/null || echo "$head_sha")"
+    current_sha="$(gh pr view "$pr_number" --repo "$owner/$repo_name" --json headRefOid --jq '.headRefOid' 2>/dev/null)"
+    _sha_rc=$?
+    set -e
+    if [ "$_sha_rc" -ne 0 ] || [ -z "$current_sha" ]; then
+      echo "WARN: could not refresh HEAD SHA for PR $pr_number (exit $_sha_rc) — falling back to initial SHA $head_sha" >&2
+      current_sha="$head_sha"
+    fi
+    unset _sha_rc
+    set +e
     review_state="$(gh api --paginate "repos/$owner/$repo_name/pulls/$pr_number/reviews" 2>/dev/null \
       | jq -rs --arg login "$bot_login" --arg sha "$current_sha" \
         '[ .[] | .[] | select(.user.login == $login and .commit_id == $sha) ] | last | .state // empty')"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -30,8 +30,18 @@ if [ "${1:-}" = "unlock" ]; then
   fi
   _UNLOCK_PR="$2"
   _UNLOCK_LOCK_DIR="/tmp/pr-review-loop-${_UNLOCK_PR}.lockdir"
-  _UNLOCK_PID="$(cat "$_UNLOCK_LOCK_DIR/pid" 2>/dev/null || true)"
-  _UNLOCK_CMD="$(cat "$_UNLOCK_LOCK_DIR/cmd" 2>/dev/null || true)"
+  # Read lock metadata only when the dir exists; surface failures explicitly so
+  # filesystem or permission errors are not silently swallowed.
+  _UNLOCK_PID=""
+  _UNLOCK_CMD=""
+  if [ -d "$_UNLOCK_LOCK_DIR" ]; then
+    if ! _UNLOCK_PID="$(cat "$_UNLOCK_LOCK_DIR/pid" 2>/dev/null)"; then
+      echo "WARN: could not read lock PID from $_UNLOCK_LOCK_DIR/pid" >&2
+    fi
+    if ! _UNLOCK_CMD="$(cat "$_UNLOCK_LOCK_DIR/cmd" 2>/dev/null)"; then
+      echo "WARN: could not read lock cmd from $_UNLOCK_LOCK_DIR/cmd" >&2
+    fi
+  fi
   if [ -n "$_UNLOCK_PID" ] && kill -0 "$_UNLOCK_PID" 2>/dev/null && [ "$_UNLOCK_CMD" = "$(basename "$0")" ]; then
     echo "ERROR: A live pr-review-loop.sh process (PID $_UNLOCK_PID) currently holds the lock for PR #${_UNLOCK_PR}. Not removing a live lock." >&2
     echo "  Wait for the process to finish, or send it SIGTERM to stop it gracefully." >&2


### PR DESCRIPTION
## Summary

- **`unlock` ordering bug** — moved the `unlock` subcommand before the single-instance lock guard in `pr-review-loop.sh`; the guard was re-acquiring the lock before `unlock` could run, causing it to see a live PID and refuse to remove a stale lock
- **Wrong exit codes** — `claude-code-action-reviewer.sh` preflight failures (auth, unresolvable base branch) now emit `UNAVAILABLE`/exit 3 instead of `TIMED_OUT`/exit 2
- **Usage string** — `pr-review-loop.sh` help text now includes `claude-code-action` and `copilot`
- **Doc inaccuracy** — `claude-code-action.md` troubleshooting row now correctly says "default branch" instead of "PR base branch" for the dispatch ref
- **Copilot SHA race** — SHA re-fetched each poll iteration so a mid-review commit push no longer causes a spurious timeout
- **Devin `since_iso` clock-skew guard** — future-dated commit timestamps are capped to wall-clock now to prevent false-clean results across Devin, PR-Agent, and codex-github platforms
- **Haystack `comment_count` consistency** — `comment_count` forced to ≥ 1 when `blocking_count` is forced in the fail-safe path
- **MD040** — language specifiers added to fenced code blocks in `claude-code-action.md` and `haystack-triage.md`

All findings sourced from CodeRabbit + PR-Agent review of `lhpaul/kids-safety-platform#208` (v0.29.0 sync PR).

## Test plan

- [ ] Run `pr-review-loop.sh unlock <pr>` against a PR with a stale lock; confirm it removes the lock and exits 0
- [ ] Run `claude-code-action-reviewer.sh` without `gh auth`; confirm `VERDICT: UNAVAILABLE` and exit 3
- [ ] Run `pr-review-loop.sh --help`; confirm `claude-code-action` and `copilot` appear in the platform list
- [ ] Confirm `markdownlint-cli2` reports 0 errors on the changed docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)