### PR TITLE
fix(copilot): escalate instead of falling back to unscoped query when head SHA lookup fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`pr-review-loop.sh`: escalate instead of falling back to unscoped Copilot query when head SHA lookup fails** (#776) — when `gh pr view --json headRefOid` returns empty (transient API failure), `run_copilot_review()` now returns `RESULT=escalate REASON=head-sha-unavailable` instead of querying the reviews endpoint without a commit filter. The unscoped fallback could reuse a stale `APPROVED` or `CHANGES_REQUESTED` verdict from a previous review cycle, producing a false-clean or false-block result.
+
 ## [0.29.1] - 2026-05-28
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Formally closes issue #776: `run_copilot_review()` in `pr-review-loop.sh` already escalates when `headRefOid` returns empty (returns `RESULT=escalate REASON=head-sha-unavailable`), rather than falling back to an unscoped review query that could match a stale verdict from a previous cycle.
- The fix was implemented in hotfix commits `e77c015` (2026-05-27) and `520ec1f` (2026-05-28). This PR adds the missing CHANGELOG entry under `[Unreleased]` and formally closes the issue.
- Unit test coverage already exists: `copilot_head_sha_unavailable_result`, `copilot_head_sha_unavailable_reason`, and `copilot_head_sha_unavailable_exit_code` in `scripts/development-workflow/tests/test-pr-review-loop.sh` all pass.

## Changes

- `CHANGELOG.md`: adds `[Unreleased]` entry documenting the fix for #776

## Note on [0.29.0] CHANGELOG entry

The `[0.29.0]` CHANGELOG entry for #759 (`fix run_copilot_review() returning stale verdict`) still says "Falls back to unfiltered if head SHA cannot be resolved" — that was accurate when #759 was first merged but became stale after `e77c015` changed the behavior to escalate. That entry is in a released version section and left unchanged here. Human reviewers may choose to correct it in a follow-up.

## Test plan

- [x] `bash scripts/development-workflow/tests/test-pr-review-loop.sh` — all 80 tests pass, including the 3 `copilot_head_sha_unavailable_*` tests that cover this fix
- [x] `./node_modules/.bin/markdownlint-cli2 CHANGELOG.md` — 0 errors
- [x] `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md` — passed

Closes #776