### PR TITLE
fix(pr-review-loop): fetch origin before git show to avoid stale remote-tracking ref (#777)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`pr-review-loop.sh`: fetch remote-tracking ref before reading base-branch config** (#777) — `git show "origin/${_pr_base}:.ai-dev-workflow.yaml"` was reading the local remote-tracking ref as-is. In a long-lived clone or worktree behind `origin`, this could load a stale platform list or stale `phase_after_clean` values, silently breaking the intent of reading platform config from the PR's actual target branch. A `git fetch origin "$_pr_base"` call is now issued before `git show` so the remote-tracking ref is always current.
+
 ## [0.29.1] - 2026-05-28
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Formally closes issue #777: `pr-review-loop.sh` could read a stale `.ai-dev-workflow.yaml` from the base branch when the local remote-tracking ref was behind `origin`.
- The fix (`git fetch origin "$_pr_base"` before `git show "origin/${_pr_base}:.ai-dev-workflow.yaml"`) was implemented in hotfix commit `e77c015` (2026-05-27) and is already present in `develop`.
- This PR adds the missing `[Unreleased]` CHANGELOG entry and formally closes the issue.

## Changes

- `CHANGELOG.md`: adds `[Unreleased]` entry documenting the fix for #777

## Context

In a long-lived clone or worktree that is behind `origin`, `git show "origin/${_pr_base}:.ai-dev-workflow.yaml"` only reads the already-cached remote-tracking ref. If the remote has since advanced (e.g., a new `.ai-dev-workflow.yaml` was merged to the base branch), the loop silently loads stale platform config or stale `phase_after_clean` values, breaking the "read platform config from the PR's actual base branch" intent. The `git fetch origin "$_pr_base"` call before `git show` ensures the ref is always current.

This PR is paired with open PRs #784 (closes #780) and #786 (closes #776), which similarly add CHANGELOG entries for fixes already present in `develop` via the hotfix v0.29.1 authoring process.

## Test plan

- [x] The fix is already implemented and tested via the existing test suite in `scripts/development-workflow/tests/test-pr-review-loop.sh`
- [x] `./node_modules/.bin/markdownlint-cli2 CHANGELOG.md` — 0 errors
- [x] `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md` — passed

Closes #777