### PR TITLE
fix(haystack): classify Rules violation as advisory to prevent false positive on hotfix backport PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`haystack-reviewer.sh`: classify `Rules violation` as advisory, not blocking** (#782) — Haystack uses this category for custom rule findings such as CHANGELOG structure checks. On hotfix backport PRs the diff against `develop` shows an empty `[Unreleased]` section from `main`, which Haystack misidentifies as a structural violation; the 3-way merge produces a correct result. Mapping `Rules violation` to advisory prevents this false positive from blocking the reviewer loop. Updated `haystack-triage.md` with a dedicated section and troubleshooting entry, and added a Haystack false-positive note to the backport section of `03-implement-development-protocol.md`.
+
 ## [0.29.1] - 2026-05-28
 
 ### Fixed

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -82,7 +82,7 @@ The `haystack triage --json` output schema uses a `.findings[].category` field a
 | `Nitpick` | Advisory | Non-blocking; reported in SUGGESTION_COUNT |
 | `Trivial` | Advisory | Non-blocking; reported in SUGGESTION_COUNT |
 | `Weak test coverage` | Advisory | Non-blocking; reported in SUGGESTION_COUNT |
-| `Rules violation` | Advisory | Non-blocking; used for custom rule findings (e.g. CHANGELOG structure) that can produce false positives on hotfix backport PRs — see note below |
+| `Rules violation` | Advisory | Non-blocking; used for custom rule findings (e.g. CHANGELOG structure) that can produce false positives on hotfix backport PRs — see the ["Rules violation" section](#rules-violation--changelog-false-positive-on-hotfix-backport-prs) below |
 | Any unrecognised value | Blocking | Conservative safe-fail per spec BR-2 |
 
 The `COMMENT_COUNT` output equals `BLOCKING_COUNT + SUGGESTION_COUNT`.

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -82,6 +82,7 @@ The `haystack triage --json` output schema uses a `.findings[].category` field a
 | `Nitpick` | Advisory | Non-blocking; reported in SUGGESTION_COUNT |
 | `Trivial` | Advisory | Non-blocking; reported in SUGGESTION_COUNT |
 | `Weak test coverage` | Advisory | Non-blocking; reported in SUGGESTION_COUNT |
+| `Rules violation` | Advisory | Non-blocking; used for custom rule findings (e.g. CHANGELOG structure) that can produce false positives on hotfix backport PRs — see note below |
 | Any unrecognised value | Blocking | Conservative safe-fail per spec BR-2 |
 
 The `COMMENT_COUNT` output equals `BLOCKING_COUNT + SUGGESTION_COUNT`.
@@ -93,6 +94,19 @@ By default, `Major` findings are treated as advisory (non-blocking). If your tea
 ```bash
 HAYSTACK_MAJOR_IS_BLOCKING=1 ./scripts/development-workflow/pr-review-loop.sh <pr_number>
 ```
+
+### "Rules violation" — CHANGELOG false positive on hotfix backport PRs
+
+Haystack uses the `Rules violation` category for custom rule findings, including CHANGELOG structure checks. On hotfix backport PRs, this can produce a false positive:
+
+**Root cause**: Hotfix branches are cut from `main`. The diff of a backport branch against `develop` shows an empty `[Unreleased]` section (from `main`'s version of the CHANGELOG). Haystack interprets the diff as "removing `[Unreleased]` content" and flags it as a structure violation. In reality, the 3-way merge on the `develop` side preserves its own `[Unreleased]` content; the CHANGELOG structure in the merged result is correct.
+
+**Resolution**: `Rules violation` is classified as advisory (non-blocking) in `haystack-reviewer.sh`. If you see this finding on a backport PR, verify:
+
+1. The `develop` branch also has an empty `[Unreleased]` section (or the same content that was on `main`).
+2. The merged CHANGELOG on `develop` will have the correct Keep-a-Changelog structure: `[Unreleased]` at the top, followed by the new versioned section from the hotfix, followed by prior versioned sections.
+
+If both conditions hold, the finding is a false positive and can be dismissed. Genuine CHANGELOG structure problems are caught by the `check-changelog-duplicate-headers.sh` CI check and `markdownlint-cli2` lint, which are not subject to the same diff-interpretation issue.
 
 ---
 
@@ -166,6 +180,17 @@ REASON=timeout
 ```
 
 **Remediation**: Increase `HAYSTACK_REVIEWER_TIMEOUT` or check network connectivity to the Haystack service.
+
+### "Rules violation" finding on a hotfix backport PR
+
+```text
+INFO: findings parsed — blocking: 0, advisory: 1, total: 1
+RESULT=clean
+```
+
+**Cause**: Haystack flagged a `Rules violation` finding for CHANGELOG structure on the backport PR. This is a known false positive (see the "Rules violation" section above). The finding is advisory and does not block the reviewer loop.
+
+**Remediation**: Verify that the merged CHANGELOG on `develop` will have correct Keep-a-Changelog structure. No code change is required; the finding can be dismissed.
 
 ### Unrecognised finding category
 

--- a/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
@@ -1411,6 +1411,8 @@ echo "Post-create assertion passed: backport PR base is '$ACTUAL_BASE'"
 
 **Automated reviewer loop exemption for identical cherry-pick backports**: For identical cherry-pick backport PRs (no changes beyond what was reviewed on the main hotfix PR), running the full automated reviewer loop is optional. If the automated reviewers (PR-Agent, Codex) post a clean result or no result, proceeding directly to merge is acceptable. If any reviewer posts a blocking finding on the backport PR, it must be addressed before merge.
 
+**Haystack "Rules violation" false positive on backport PRs**: When Haystack is configured in `review.platforms`, it may flag a `Rules violation` finding on the backport PR related to CHANGELOG structure. This is a known false positive: the diff of the backport branch against `develop` shows an empty `[Unreleased]` section (from `main`'s CHANGELOG), which Haystack misidentifies as a structure violation. As of v0.29.2, `haystack-reviewer.sh` classifies `Rules violation` as advisory (non-blocking), so this finding will not block the reviewer loop. If you see it reported as a suggestion, verify that `develop`'s `[Unreleased]` section is also empty or equivalent, confirming the merged result will be structurally correct. See [`haystack-triage.md`](../integrations/haystack-triage.md) for details.
+
 If the backport PR introduces any changes beyond a plain cherry-pick (e.g., conflict resolution changes, develop-only fixups), treat it as a normal implementation PR and run the full internal review gate, automated reviewer loop, and CI loop.
 
 Apply `ready-for-regression` and `ready-for-human-review` labels when the PR is clean. The backport PR can be merged by the human alongside or after the main hotfix review.

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -47,7 +47,7 @@
 # Severity mapping (based on confirmed schema — .findings[].category):
 #   Blocking:  "Logic error", "Critical", any unrecognised value (safe-fail)
 #   Advisory:  "Major" (conservative — see note), "Minor", "Advisory",
-#              "Nitpick", "Trivial", "Weak test coverage"
+#              "Nitpick", "Trivial", "Weak test coverage", "Rules violation"
 #
 # NOTE on "Major": The spec marks "Major" as blocking (conservative safe-fail).
 # However, Haystack uses "Major" for findings like "Weak test coverage" that are
@@ -55,6 +55,13 @@
 # spec, only "Logic error" and "Critical" are formally blocking; "Major" is treated
 # as advisory here to avoid false-positive blocks on style/coverage findings.
 # If your team wants "Major" to be blocking, set HAYSTACK_MAJOR_IS_BLOCKING=1.
+#
+# NOTE on "Rules violation": Haystack uses this category for custom rule findings
+# such as CHANGELOG structure checks. These can produce false positives on hotfix
+# backport PRs (where the diff against develop shows an empty [Unreleased] section
+# from main, which Haystack misidentifies as a structural violation). "Rules violation"
+# is treated as advisory here because it is not a code logic error or security issue;
+# genuine CHANGELOG structure problems are already caught by the markdownlint CI check.
 #
 # Unrecognised categories are treated as blocking (conservative safe-fail per spec).
 
@@ -300,7 +307,7 @@ if [ -n "$CATEGORIES" ]; then
           SUGGESTION_COUNT=$((SUGGESTION_COUNT + 1))
         fi
         ;;
-      "Minor"|"Advisory"|"Nitpick"|"Trivial"|"Weak test coverage")
+      "Minor"|"Advisory"|"Nitpick"|"Trivial"|"Weak test coverage"|"Rules violation")
         SUGGESTION_COUNT=$((SUGGESTION_COUNT + 1))
         ;;
       "__UNKNOWN__"|*)


### PR DESCRIPTION
## Summary

Haystack uses the `Rules violation` category for custom rule findings such as CHANGELOG structure checks. On hotfix backport PRs, the diff of the backport branch against `develop` shows an empty `[Unreleased]` section (from `main`'s CHANGELOG), which Haystack misidentifies as a structural violation. The actual 3-way merge produces a correct Keep-a-Changelog result.

This PR maps `Rules violation` to advisory (non-blocking) in `haystack-reviewer.sh`, alongside existing advisory categories (`Minor`, `Advisory`, `Nitpick`, etc.). Previously it was treated as an unrecognised category and safe-failed to blocking, which blocked the reviewer loop on the v0.29.1 backport PR #779.

## Changes

- **`scripts/development-workflow/haystack-reviewer.sh`**: add `Rules violation` to the advisory category set; add explanatory comment about the hotfix backport false-positive scenario
- **`docs/workflow/development-workflow/integrations/haystack-triage.md`**: add `Rules violation` row to severity mapping table; add dedicated "Rules violation — CHANGELOG false positive on hotfix backport PRs" section and troubleshooting entry
- **`docs/workflow/development-workflow/protocols/03-implement-development-protocol.md`**: add Haystack false-positive note to the backport section of Path 4 (Hotfix)
- **`CHANGELOG.md`**: add entry under `[Unreleased]`

## Test plan

- [ ] `haystack-reviewer.sh` category switch now includes `"Rules violation"` in the advisory arm — verify by inspection
- [ ] `haystack-triage.md` severity mapping table includes the new row
- [ ] Markdownlint passes on all modified `.md` files
- [ ] CHANGELOG duplicate-header check passes

Closes #782