### PR TITLE
feat(workflow): add reviewer failure label sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Reviewer failure label** (#804): Adds a self-healing reviewer-failed PR label when automated reviewer platforms time out, escalate, or are unavailable.
 - **Pre-submission self-review pass** (#799): Adds a mandatory pre-PR diff self-review gate for implementation agents so stale markers, caller inconsistencies, and uncovered acceptance criteria are caught before draft PR creation.
 
 ### Fixed

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -218,6 +218,8 @@ COMMENT_COUNT=0
 
 In all three cases, `pr-review-loop.sh` treats the reviewer as unavailable and continues with the remaining platforms. Other platforms are not blocked.
 
+When any of these Haystack reviewer-health failures occur, `pr-review-loop.sh` applies the `reviewer-failed` label to the PR so the failure is visible from the PR list or project board. The label is self-healing: a later loop run that reaches healthy reviewer output (`clean`, `needs_fixes`, `needs_rerun`, or only `skipped/not_configured`) removes `reviewer-failed`.
+
 ---
 
 ## Exit Code Contract
@@ -274,7 +276,7 @@ RESULT=skipped
 REASON=pending_timeout
 ```
 
-**When you see `REASON=pending_timeout`**: The review loop will treat the reviewer as unavailable for this run and continue with the remaining platforms. This is distinct from `REASON=unavailable` (CLI not installed or authentication failed) and `REASON=timeout` (a single call hung).
+**When you see `REASON=pending_timeout`**: The review loop will treat the reviewer as unavailable for this run, apply `reviewer-failed`, and continue with the remaining platforms. This is distinct from `REASON=unavailable` (CLI not installed or authentication failed) and `REASON=timeout` (a single call hung). A later clean Haystack run removes `reviewer-failed`.
 
 **Recovery options**:
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3539,6 +3539,85 @@ normalize_platform_verdict() {
   esac
 }
 
+REVIEWER_FAILED_LABEL="reviewer-failed"
+REVIEWER_FAILED_LABEL_COLOR="b60205"
+REVIEWER_FAILED_LABEL_DESCRIPTION="Automated reviewer platform failed, timed out, or was unavailable"
+
+reviewer_failed_label_required_for_result() {
+  local result="$1"
+  local reason="${2:-}"
+
+  case "$result" in
+    escalate)
+      return 0
+      ;;
+    skipped)
+      case "$reason" in
+        unavailable|timeout|thread-check-failed|pending_timeout)
+          return 0
+          ;;
+      esac
+      ;;
+  esac
+
+  return 1
+}
+
+ensure_reviewer_failed_label_exists() {
+  if gh label view "$REVIEWER_FAILED_LABEL" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if ! gh label create "$REVIEWER_FAILED_LABEL" \
+      --color "$REVIEWER_FAILED_LABEL_COLOR" \
+      --description "$REVIEWER_FAILED_LABEL_DESCRIPTION" >/dev/null; then
+    echo "WARN: failed to create ${REVIEWER_FAILED_LABEL} label; proceeding with reviewer loop" >&2
+  fi
+
+  return 0
+}
+
+pr_has_reviewer_failed_label() {
+  local pr_number_arg="$1"
+  local labels
+
+  if ! labels="$(gh pr view "$pr_number_arg" --json labels --jq '.labels[].name' 2>/dev/null)"; then
+    return 2
+  fi
+
+  printf '%s\n' "$labels" | grep -Fxq "$REVIEWER_FAILED_LABEL"
+}
+
+sync_reviewer_failed_label() {
+  local pr_number_arg="$1"
+  local required="$2"
+  local label_check_status
+
+  [ -n "${pr_number_arg:-}" ] || return 0
+
+  if [ "$required" = "1" ]; then
+    ensure_reviewer_failed_label_exists
+    if ! gh pr edit "$pr_number_arg" --add-label "$REVIEWER_FAILED_LABEL" >/dev/null; then
+      echo "WARN: failed to apply ${REVIEWER_FAILED_LABEL} label to PR #${pr_number_arg}; proceeding with reviewer loop" >&2
+    fi
+  else
+    label_check_status=1
+    if pr_has_reviewer_failed_label "$pr_number_arg"; then
+      label_check_status=0
+    else
+      label_check_status=$?
+    fi
+    if [ "$label_check_status" -eq 1 ]; then
+      return 0
+    fi
+    if ! gh pr edit "$pr_number_arg" --remove-label "$REVIEWER_FAILED_LABEL" >/dev/null; then
+      echo "WARN: failed to remove ${REVIEWER_FAILED_LABEL} label from PR #${pr_number_arg}; proceeding with reviewer loop" >&2
+    fi
+  fi
+
+  return 0
+}
+
 # append_compare_metrics_row: append one structured row to the platform metrics log.
 # Called at the end of the platform loop when compare_mode=1.
 # $1 = pr_number
@@ -4017,6 +4096,7 @@ total_comment_count=0
 total_blocking_count=0
 total_suggestion_count=0
 aggregate_advisory_labels=""
+reviewer_failed_required=0
 declare -a compare_verdicts=()
 # Per-platform result tokens for the PR summary comment.
 # Each entry is "platform_name=display_token" (e.g. "haystack=unavailable").
@@ -4091,6 +4171,10 @@ for index in "${!platforms[@]}"; do
   platform_blocking_count="$(kv_value_default BLOCKING_COUNT "$platform_output" 0)"
   platform_suggestion_count="$(kv_value_default SUGGESTION_COUNT "$platform_output" 0)"
   platform_advisory_labels="$(kv_value_default ADVISORY_LABELS "$platform_output" "")"
+  platform_reason="$(kv_value_default REASON "$platform_output" "")"
+  if reviewer_failed_label_required_for_result "$platform_result" "$platform_reason"; then
+    reviewer_failed_required=1
+  fi
 
   total_comment_count=$((total_comment_count + platform_comment_count))
   total_blocking_count=$((total_blocking_count + platform_blocking_count))
@@ -4108,7 +4192,7 @@ for index in "${!platforms[@]}"; do
   print_kv "PLATFORM_${platform_index}_RESULT" "$platform_result"
   emit_prefixed_platform_output "$platform_index" "$platform_output"
   # Record a human-readable display token for the PR summary comment.
-  _prt_reason="$(kv_value_default REASON "$platform_output" "")"
+  _prt_reason="$platform_reason"
   _prt_display_override="$(kv_value_default DISPLAY_RESULT "$platform_output" "")"
   if [ -n "$_prt_display_override" ]; then
     _prt_disp="$_prt_display_override"
@@ -4478,6 +4562,7 @@ if [ -z "$last_platform" ]; then
   print_kv SUGGESTION_COUNT 0
   print_kv UNRESOLVED_THREAD_COUNT 0
   _post_review_summary "skipped" "not_configured" "none" "0" "0" "" "" "0" "" "0" "0" "" "0"
+  sync_reviewer_failed_label "$pr_number" 0
   exit 0
 fi
 
@@ -4702,6 +4787,11 @@ if [ "$compare_mode" -eq 1 ] && [ "${#compare_verdicts[@]}" -gt 0 ]; then
     echo "WARN: append_compare_metrics_row failed — metrics row not written" >&2
   set -e
 fi
+
+if reviewer_failed_label_required_for_result "$aggregate_result" "$aggregate_reason"; then
+  reviewer_failed_required=1
+fi
+sync_reviewer_failed_label "$pr_number" "$reviewer_failed_required"
 
 print_kv RESULT "$aggregate_result"
 print_kv PLATFORM "$last_platform"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -66,6 +66,18 @@ case "$*" in
     printf '%s\n' "${MOCK_GH_READY_OUTPUT:-{}}"
     exit "${MOCK_GH_READY_EXIT:-${MOCK_GH_EXIT:-0}}"
     ;;
+  *"label view"*)
+    printf '%s\n' "${MOCK_GH_LABEL_VIEW_OUTPUT:-${MOCK_GH_OUTPUT:-{}}}"
+    exit "${MOCK_GH_LABEL_VIEW_EXIT:-${MOCK_GH_EXIT:-0}}"
+    ;;
+  *"label create"*)
+    printf '%s\n' "${MOCK_GH_LABEL_CREATE_OUTPUT:-${MOCK_GH_OUTPUT:-{}}}"
+    exit "${MOCK_GH_LABEL_CREATE_EXIT:-${MOCK_GH_EXIT:-0}}"
+    ;;
+  *"pr edit"*)
+    printf '%s\n' "${MOCK_GH_PR_EDIT_OUTPUT:-${MOCK_GH_OUTPUT:-{}}}"
+    exit "${MOCK_GH_PR_EDIT_EXIT:-${MOCK_GH_EXIT:-0}}"
+    ;;
   *"--method POST"*)
     printf '%s\n' "${MOCK_GH_POST_OUTPUT:-{}}"
     exit "${MOCK_GH_POST_EXIT:-${MOCK_GH_EXIT:-0}}"
@@ -1137,6 +1149,146 @@ unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_EXIT _warn_output
 export MOCK_GH_OUTPUT='[]'
 unset MOCK_GH_EXIT MOCK_GH_COMMENTS_OUTPUT MOCK_GH_COMMENTS_EXIT
 unset _SUMMARY_COMMENT_JSON
+
+# ---------------------------------------------------------------------------
+# Area 12: reviewer-failed label sync (issue #804)
+#
+# reviewer_failed_label_required_for_result(), ensure_reviewer_failed_label_exists(),
+# and sync_reviewer_failed_label() are defined before the HARNESS_MODE return point
+# and are therefore callable directly from the test harness.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 12: reviewer-failed label sync (issue #804) ==="
+
+_reviewer_failed_required() {
+  if reviewer_failed_label_required_for_result "$1" "${2:-}"; then
+    printf 'yes'
+  else
+    printf 'no'
+  fi
+}
+
+run_test "reviewer_failed_escalate_timeout" "yes" "$(_reviewer_failed_required escalate timeout)"
+run_test "reviewer_failed_escalate_empty_reason" "yes" "$(_reviewer_failed_required escalate '')"
+run_test "reviewer_failed_escalate_pending_timeout" "yes" "$(_reviewer_failed_required escalate pending_timeout)"
+run_test "reviewer_failed_skipped_unavailable" "yes" "$(_reviewer_failed_required skipped unavailable)"
+run_test "reviewer_failed_skipped_thread_check_failed" "yes" "$(_reviewer_failed_required skipped thread-check-failed)"
+run_test "reviewer_failed_skipped_not_configured" "no" "$(_reviewer_failed_required skipped not_configured)"
+run_test "reviewer_failed_clean_no" "no" "$(_reviewer_failed_required clean timeout)"
+run_test "reviewer_failed_needs_fixes_no" "no" "$(_reviewer_failed_required needs_fixes '')"
+run_test "reviewer_failed_needs_rerun_no" "no" "$(_reviewer_failed_required needs_rerun '')"
+
+_rf_accumulated=0
+if reviewer_failed_label_required_for_result clean ""; then
+  _rf_accumulated=1
+fi
+if reviewer_failed_label_required_for_result skipped unavailable; then
+  _rf_accumulated=1
+fi
+if reviewer_failed_label_required_for_result clean ""; then
+  _rf_accumulated=1
+fi
+run_test "reviewer_failed_accumulator_or" "1" "$_rf_accumulated"
+unset _rf_accumulated
+
+unset MOCK_GH_CALL_LOG MOCK_GH_EXIT MOCK_GH_LABEL_VIEW_EXIT MOCK_GH_LABEL_CREATE_EXIT MOCK_GH_PR_EDIT_EXIT
+
+_call_log_12="$(mktemp)"
+export MOCK_GH_CALL_LOG="$_call_log_12"
+export MOCK_GH_LABEL_VIEW_EXIT=1
+sync_reviewer_failed_label "42" "1" 2>/dev/null
+_create_calls="$(grep -c -- 'label create reviewer-failed' "$_call_log_12" 2>/dev/null)" || _create_calls="0"
+_add_calls="$(grep -c -- 'pr edit 42 --add-label reviewer-failed' "$_call_log_12" 2>/dev/null)" || _add_calls="0"
+run_test "reviewer_failed_required_creates_missing_label" "1" "$_create_calls"
+run_test "reviewer_failed_required_adds_label" "1" "$_add_calls"
+rm -f "$_call_log_12"
+unset MOCK_GH_CALL_LOG MOCK_GH_LABEL_VIEW_EXIT
+
+_call_log_12="$(mktemp)"
+export MOCK_GH_CALL_LOG="$_call_log_12"
+export MOCK_GH_LABEL_VIEW_EXIT=0
+sync_reviewer_failed_label "42" "1" 2>/dev/null
+_create_calls="$(grep -c -- 'label create reviewer-failed' "$_call_log_12" 2>/dev/null)" || _create_calls="0"
+_add_calls="$(grep -c -- 'pr edit 42 --add-label reviewer-failed' "$_call_log_12" 2>/dev/null)" || _add_calls="0"
+run_test "reviewer_failed_existing_label_no_create" "0" "$_create_calls"
+run_test "reviewer_failed_existing_label_adds_label" "1" "$_add_calls"
+rm -f "$_call_log_12"
+unset MOCK_GH_CALL_LOG MOCK_GH_LABEL_VIEW_EXIT
+
+_call_log_12="$(mktemp)"
+export MOCK_GH_CALL_LOG="$_call_log_12"
+export MOCK_GH_OUTPUT='reviewer-failed'
+sync_reviewer_failed_label "42" "0" 2>/dev/null
+_remove_calls="$(grep -c -- 'pr edit 42 --remove-label reviewer-failed' "$_call_log_12" 2>/dev/null)" || _remove_calls="0"
+run_test "reviewer_failed_not_required_removes_present_label" "1" "$_remove_calls"
+rm -f "$_call_log_12"
+unset MOCK_GH_CALL_LOG MOCK_GH_OUTPUT
+
+_call_log_12="$(mktemp)"
+export MOCK_GH_CALL_LOG="$_call_log_12"
+export MOCK_GH_OUTPUT='some-other-label'
+sync_reviewer_failed_label "42" "0" 2>/dev/null
+_remove_calls="$(grep -c -- 'pr edit 42 --remove-label reviewer-failed' "$_call_log_12" 2>/dev/null)" || _remove_calls="0"
+run_test "reviewer_failed_not_required_absent_noop" "0" "$_remove_calls"
+rm -f "$_call_log_12"
+unset MOCK_GH_CALL_LOG MOCK_GH_OUTPUT
+
+_call_log_12="$(mktemp)"
+export MOCK_GH_CALL_LOG="$_call_log_12"
+export MOCK_GH_EXIT=1
+export MOCK_GH_PR_EDIT_EXIT=0
+sync_reviewer_failed_label "42" "0" 2>/dev/null
+_remove_calls="$(grep -c -- 'pr edit 42 --remove-label reviewer-failed' "$_call_log_12" 2>/dev/null)" || _remove_calls="0"
+run_test "reviewer_failed_not_required_view_failure_attempts_remove" "1" "$_remove_calls"
+rm -f "$_call_log_12"
+unset MOCK_GH_CALL_LOG MOCK_GH_EXIT MOCK_GH_PR_EDIT_EXIT
+
+_call_log_12="$(mktemp)"
+export MOCK_GH_CALL_LOG="$_call_log_12"
+export MOCK_GH_LABEL_VIEW_EXIT=1
+export MOCK_GH_LABEL_CREATE_EXIT=1
+_sync_exit=0
+_warn_output="$(sync_reviewer_failed_label "42" "1" 2>&1)" || _sync_exit=$?
+_add_calls="$(grep -c -- 'pr edit 42 --add-label reviewer-failed' "$_call_log_12" 2>/dev/null)" || _add_calls="0"
+run_test "reviewer_failed_create_failure_returns_0" "0" "$_sync_exit"
+run_test "reviewer_failed_create_failure_still_attempts_add" "1" "$_add_calls"
+if printf '%s\n' "$_warn_output" | grep -q "WARN"; then
+  _warn_emitted="yes"
+else
+  _warn_emitted="no"
+fi
+run_test "reviewer_failed_create_failure_warns" "yes" "$_warn_emitted"
+rm -f "$_call_log_12"
+unset MOCK_GH_CALL_LOG MOCK_GH_LABEL_VIEW_EXIT MOCK_GH_LABEL_CREATE_EXIT _warn_output _sync_exit
+
+_call_log_12="$(mktemp)"
+export MOCK_GH_CALL_LOG="$_call_log_12"
+sync_reviewer_failed_label "42" "1" 2>/dev/null
+_ready_label_mentions="$(grep -c -- 'ready-for-human-review' "$_call_log_12" 2>/dev/null)" || _ready_label_mentions="0"
+run_test "reviewer_failed_does_not_touch_ready_label" "0" "$_ready_label_mentions"
+rm -f "$_call_log_12"
+unset MOCK_GH_CALL_LOG
+
+_reviewer_failed_fn_line="$(grep -n 'reviewer_failed_label_required_for_result()' \
+  "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh" 2>/dev/null \
+  | head -1 | cut -d: -f1)"
+_sync_fn_line="$(grep -n 'sync_reviewer_failed_label()' \
+  "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh" 2>/dev/null \
+  | head -1 | cut -d: -f1)"
+_harness_return_line="$(grep -n '_HARNESS_MODE_EFFECTIVE.*return 0' \
+  "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh" 2>/dev/null \
+  | head -1 | cut -d: -f1)"
+if [ -n "$_reviewer_failed_fn_line" ] && [ -n "$_sync_fn_line" ] \
+    && [ -n "$_harness_return_line" ] \
+    && [ "$_reviewer_failed_fn_line" -lt "$_harness_return_line" ] \
+    && [ "$_sync_fn_line" -lt "$_harness_return_line" ]; then
+  _reviewer_failed_ordering_ok="yes"
+else
+  _reviewer_failed_ordering_ok="no"
+fi
+run_test "reviewer_failed_helpers_before_harness_return" "yes" "$_reviewer_failed_ordering_ok"
+unset _reviewer_failed_required _reviewer_failed_fn_line _sync_fn_line _harness_return_line _reviewer_failed_ordering_ok
+unset MOCK_GH_EXIT MOCK_GH_LABEL_VIEW_EXIT MOCK_GH_LABEL_CREATE_EXIT MOCK_GH_PR_EDIT_EXIT
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary

- Add self-healing `reviewer-failed` label sync to `pr-review-loop.sh` for automated reviewer failures, timeouts, unavailable platforms, and escalation results.
- Remove `reviewer-failed` on later healthy reviewer-loop outcomes without touching `ready-for-human-review`.
- Document the Haystack triage behavior and add the CHANGELOG entry for #804.

## Spec / Plan

- Spec: `docs/specs/developments/20260602154734_reviewer-failed-label/1_reviewer-failed-label_specs.md`
- Plan: `docs/specs/developments/20260602154734_reviewer-failed-label/2_reviewer-failed-label_implementation-plan.md`

## Validation

- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` — 121 passed, 0 failed
- `bash scripts/development-workflow/tests/test-haystack-reviewer.sh` — 129 passed, 0 failed
- `shellcheck --severity=warning scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-pr-review-loop.sh scripts/development-workflow/haystack-reviewer.sh scripts/development-workflow/tests/test-haystack-reviewer.sh`
- `npx markdownlint-cli2 "docs/specs/developments/20260602154734_reviewer-failed-label/2_reviewer-failed-label_implementation-plan.md" "docs/testing/workflow/804-reviewer-failed-label.smoke-test.md" "docs/workflow/development-workflow/integrations/haystack-triage.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md && bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md && git diff --check`

## Pre-submission self-review

- Checked for stale `TODO`/`FIXME`/debug markers in touched files; no new unresolved markers found.
- Verified the label name is consistently `reviewer-failed` across code, tests, docs, and CHANGELOG.
- Verified acceptance criteria coverage in Area 12: escalation, skipped failure reasons, `not_configured` negative case, idempotent removal, label creation, and no changes to `ready-for-human-review`.

Closes #804
