### PR TITLE
fix(review): prevent PR-Agent security stuck loops

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -96,6 +96,11 @@ This is a workflow framework template repository. Adjust your review accordingly
 - Do not flag intentionally redundant-looking shell guards when they are defensive
   validation around external command output, API responses, or cross-platform shell
   compatibility.
+- Apply the "Security Concern" label only for high-confidence, actionable security
+  defects. If the finding is low-confidence, theoretical, or the body describes the
+  code as technically correct, unlikely to be exploitable, low risk, or not a real
+  vulnerability, use "Possible Issue" instead so the reviewer loop treats it as
+  advisory and avoids an unresolvable fix cycle.
 - Prefer "No major issues detected" over low-confidence process, style, or
   documentation-ordering comments. Only report a focus area when it identifies a
   concrete failure mode introduced by the diff.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **PR-Agent Security Concern stuck-loop handling** (#815) — `.pr_agent.toml`
+  now instructs PR-Agent to reserve `Security Concern` for high-confidence,
+  actionable vulnerabilities and use `Possible Issue` for low-confidence or
+  self-described non-vulnerability findings. Protocol 93 now treats repeated
+  low-confidence `Security Concern` labels as a stuck-loop escalation signal when
+  other configured reviewers are clean, avoiding non-substantive fix cycles.
 - **`/run-work` proposes the largest safe Backlog start batch** (#838) — Protocol 90 now distinguishes dispatch-eligible in-flight work from proposal-eligible Backlog work. In unrestricted portfolio mode, the orchestrator must evaluate prioritized Backlog items, build the largest safe start batch by dependency and parallelization constraints, and present it for explicit human approval instead of reporting "no eligible work remains" whenever no PRs or in-flight development folders are active.
 - **GitHub Projects status helpers avoid full-board scans for single issues** (#824) — `workflow-lib.sh` now reads a single issue's project item via targeted `repository.issue(...).projectItems` GraphQL and resolves Status field metadata from the project node, replacing repeated `gh project item-list --limit 10000` calls in `get_tracker_status_for_issue`, `ensure_on_project_board`, and `update_tracker_status_best_effort`. This prevents per-item status reads and updates from paginating the whole project board and draining the GraphQL rate-limit bucket during orchestration.
 - **Protocol 93 / PR-Agent: add classifier-safe label-only fallback for blocked review-body reads** (#817) — when an agent's classifier or tool policy blocks reading PR-Agent's full structured review body, the reviewer loop now documents a non-handoff fallback: rerun `pr-review-loop.sh --platform pr-agent`, consume only key-value classification output (`RESULT`, counts, advisory labels, possible-issue evaluation), and continue or escalate from that metadata. This prevents routine PR-Agent comment reads from prematurely ending autonomous fix loops.

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -468,6 +468,17 @@ Use the **PR feedback ledger** (keyed by `(platform, path, body_snippet)`) to de
 
 3. **Maximum cycle count**: As specified in `91-orchestrate-work-protocol.md`, escalate when `cycle >= max_cycles` (default: 10). This is a hard limit independent of finding counts.
 
+4. **PR-Agent low-confidence Security Concern loop**: If PR-Agent applies
+   `Security Concern` in two or more consecutive cycles while another configured
+   reviewer is clean, inspect the PR-Agent finding text before dispatching another
+   fix pass. When the finding text itself describes the concern as theoretical,
+   unlikely, technically correct, low risk, or not a vulnerability, treat the loop
+   as stuck and escalate with that evidence instead of making non-substantive code
+   changes. PR-Agent is configured to reserve `Security Concern` for
+   high-confidence actionable defects and to use `Possible Issue` for these
+   low-confidence cases; repeated low-confidence security labels indicate reviewer
+   calibration drift, not necessarily a code defect.
+
 #### Escalation trigger
 
 Stop the loop and escalate to human when any of the above conditions are met. In the final summary comment (see "PR feedback tracking and comments" below), include:


### PR DESCRIPTION
## Summary

- tighten PR-Agent instructions so low-confidence or self-described non-vulnerability security findings use `Possible Issue` instead of `Security Concern`
- add a Protocol 93 stuck-loop heuristic for repeated low-confidence PR-Agent `Security Concern` labels when other reviewers are clean
- add the #815 CHANGELOG entry

## Verification

- `npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`

## Pre-Submission Self-Review

- Reviewed `git diff develop...HEAD`; scope is limited to `.pr_agent.toml`, Protocol 93, and `CHANGELOG.md`.
- No stale markers or renamed strings introduced.
- Sibling/caller consistency checked: PR-Agent label calibration is documented in config and the reviewer-loop escalation behavior is documented in Protocol 93.
- Issue-body coverage: implements Option B as the immediate config fix and Option C as the stuck-loop safety net from #815.

Closes #815
