### PR TITLE
docs(github-projects): document closed-item workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **GitHub Projects closed-item workflow configuration** (#826) — documents that
+  the built-in GitHub Projects "item closed" workflow must set Status to
+  `Merged` or be disabled, rather than setting closed items to `Released`.
+  This prevents implementation issues from being marked released immediately
+  after merge, before the prepare-release workflow publishes them.
 - **PR-Agent Security Concern stuck-loop handling** (#815) — `.pr_agent.toml`
   now instructs PR-Agent to reserve `Security Concern` for high-confidence,
   actionable vulnerabilities and use `Possible Issue` for low-confidence or

--- a/docs/workflow/development-workflow/integrations/github-projects.md
+++ b/docs/workflow/development-workflow/integrations/github-projects.md
@@ -60,6 +60,28 @@ GitHub Projects v2 creates a default **Status** single-select field. Configure i
 
 To add or rename status options, use the project settings UI at `https://github.com/users/<OWNER>/projects/<NUMBER>/settings` (or the equivalent org URL).
 
+### 2.1 Configure Built-In Project Workflows
+
+GitHub Projects can run its own built-in workflow when an item is closed. Configure
+that workflow so it does not override the AI development workflow's merge state:
+
+- Preferred: set the built-in "item closed" workflow to update Status to `Merged`.
+- Also acceptable: disable the built-in "item closed" Status update entirely.
+- Do not configure the built-in workflow to set Status to `Released` when an item
+  is closed.
+
+Implementation PR merges follow this sequence:
+
+1. `update-tracker-on-merge.yml` or `post-merge-cleanup.sh` sets the issue's
+   project Status to `Merged`.
+2. The workflow closes the GitHub issue for the merged implementation branch.
+3. A later release workflow moves shipped issues from `Merged` to `Released`.
+
+If the built-in "item closed" workflow sets Status to `Released`, it races with
+and overrides the intended `Merged` status immediately after every implementation
+merge. The board then incorrectly shows unreleased work as released, and operators
+must manually correct each item before preparing a release.
+
 ### 3. Add Custom Fields
 
 Add these custom fields to the project (via project settings UI or GraphQL):


### PR DESCRIPTION
## Summary

- documents the required GitHub Projects built-in "item closed" workflow setting
- explains why closed implementation issues should remain `Merged` until release
- adds the #826 CHANGELOG entry

## Verification

- `npx markdownlint-cli2 "docs/workflow/development-workflow/integrations/github-projects.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`

## Pre-Submission Self-Review

- Reviewed `git diff develop...HEAD`; scope is limited to the GitHub Projects integration guide and `CHANGELOG.md`.
- No stale markers or renamed strings introduced.
- Sibling/caller consistency checked: the documented merge sequence matches `update-tracker-on-merge.yml` / `post-merge-cleanup.sh` behavior and the release transition model.
- Issue-body coverage: documents the durable project-settings fix requested in #826.

Closes #826
