### PR TITLE
docs(plan): add tracker Type classification plan

### DIFF
--- a/docs/specs/developments/20260606100326_tracker-type-field-classification/2_tracker-type-field-classification_implementation-plan.md
+++ b/docs/specs/developments/20260606100326_tracker-type-field-classification/2_tracker-type-field-classification_implementation-plan.md
@@ -1,0 +1,199 @@
+# Tracker Type Field Classification — Implementation Plan
+
+**Spec**: Refactor work item #828 brief
+**Smoke test runbook**: [tracker-type-field-classification.smoke-test.md](../../../testing/workflow/tracker-type-field-classification.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Make the GitHub Projects `Type` field the classification source of
+truth for workflow items, add a `Workflow` Type option, and stop relying on
+repository labels for Bug/Feature/Workflow classification. Keep operational labels
+unchanged because they trigger automation and review gates. Replace cheap
+`workflow` label filters with targeted project-field queries or open-issue plus
+project cross-reference flows so the implementation does not reintroduce the
+GraphQL budget drain addressed by #824.
+
+**Estimated complexity**: L
+
+**Rationale**: The change spans tracker integration guidance, release and
+retrospective protocols, backlog creation/classification conventions, smoke tests,
+and helper behavior. It also includes a migration and project-board configuration
+step that cannot be represented by repository file edits alone.
+
+**Dependencies**: #824 must remain merged because this refactor depends on
+targeted GitHub Projects lookups rather than repeated full-board scans.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse HEAD` | `a8eb835e4fcab978f0aae16f974333b70590d648` |
+| Workflow-label filters | `rg -n "gh issue list --label workflow|--label \"workflow\"|--label workflow" docs scripts .claude .cursor .codex AGENTS.md --glob '!docs/specs/developments/**'` | In-scope current references: `docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md`, `docs/workflow/development-workflow/protocols/06-retrospective-protocol.md`, and `docs/testing/workflow/656-agents-add-to-project-board.smoke-test.md`. |
+| Type-label setup guidance | `rg -n "type:feature|type:bug|type:refactor|Type labels" docs/workflow/development-workflow/integrations docs/workflow/development-workflow/protocols --glob '!docs/specs/developments/**'` | Current type-label guidance is concentrated in `docs/workflow/development-workflow/integrations/github-projects.md`; `linear.md` separately documents Linear type labels. |
+| Type-field guidance | `rg -n "Type.*Single select|project.*Type|Type field|Workflow" docs/workflow/development-workflow scripts AGENTS.md --glob '!docs/specs/developments/**'` | GitHub Projects docs define `Type` as `Feature`, `Bug`, `Refactor`; Protocol 90 already references tracker Type for Backlog routing; no reusable helper exists yet for querying Workflow-typed open issues. |
+
+## Layer-by-Layer Changes
+
+### Tracker / GitHub Projects Integration
+
+- [ ] Update `docs/workflow/development-workflow/integrations/github-projects.md`
+      to define the project `Type` field as the classification source of truth.
+- [ ] Add `Workflow` as a required `Type` option for framework workflow items.
+- [ ] State that repository labels `bug`, `enhancement`, `type:feature`,
+      `type:bug`, `type:refactor`, and `workflow` are legacy classification
+      labels and should not be applied by new workflow automation.
+- [ ] Preserve operational labels such as `ready-for-human-review`,
+      `needs-fixes`, `ready-for-regression`, `reviewer-failed`,
+      `feedback-staging`, and `integration-branch:<slug>`.
+- [ ] Document the board migration: backfill Type values from current labels and
+      issue context, then remove retired classification labels from open workflow
+      issues after the Type field is populated.
+
+### Workflow Scripts / Helpers
+
+- [ ] Add or extend GitHub Projects helpers in
+      `scripts/development-workflow/workflow-lib.sh` for targeted Type-field
+      access:
+      - read an issue's Type value through the targeted project item query;
+      - set an issue's Type value best-effort;
+      - list open issues whose project Type is `Workflow` without per-item
+        full-board scans.
+- [ ] Ensure the list helper uses the #824-safe discovery shape: fetch open
+      issues first, then cross-reference a single project item-list result, or
+      use a targeted GraphQL query that does not paginate all closed items.
+- [ ] Add tests in
+      `scripts/development-workflow/tests/test-workflow-lib-github-projects.sh`
+      for Type field metadata lookup, Type update mutation construction, and
+      open Workflow issue filtering.
+
+### Protocols
+
+- [ ] Update
+      `docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md`
+      so GitHub Projects backlog creation sets the project Type field when the
+      type/path is known, rather than instructing agents to use classification
+      labels.
+- [ ] Update
+      `docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md`
+      to replace `gh issue list --label workflow` with the new Workflow Type
+      discovery helper or equivalent Type-field query.
+- [ ] Update
+      `docs/workflow/development-workflow/protocols/06-retrospective-protocol.md`
+      so retrospective backlog checks and issue creation use project Type
+      `Workflow` instead of the `workflow` label.
+- [ ] Update
+      `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
+      to clarify that tracker Type, not labels, determines Backlog route for
+      GitHub Projects items.
+- [ ] Update
+      `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`
+      where single-item routing discusses Backlog Feature/Bug/Refactor
+      classification, making tracker Type authoritative for GitHub Projects.
+
+### Agent / Skill Guidance
+
+- [ ] Update `AGENTS.md` GitHub/tracker conventions to mention the `Workflow`
+      Type option and retired classification labels.
+- [ ] Do not update `.codex/skills/workflow-orchestrator/SKILL.md`; it delegates
+      to Protocol 90 and contains no direct classification-label instruction.
+- [ ] Do not update `.codex/skills/workflow-item-orchestrator/SKILL.md`; it
+      delegates to Protocol 91 and contains no direct classification-label
+      instruction.
+- [ ] Do not update Claude/Cursor agent docs; the plan-time search found no
+      direct `workflow` classification label application in `.claude/agents/` or
+      `.cursor/agents/`.
+
+### Tests and Smoke Runbooks
+
+- [ ] Update `docs/testing/workflow/656-agents-add-to-project-board.smoke-test.md`
+      so its temporary issue setup no longer applies the `workflow` label.
+- [ ] Add or update a smoke runbook for this refactor:
+      `docs/testing/workflow/tracker-type-field-classification.smoke-test.md`.
+- [ ] Run the workflow-lib GitHub Projects test harness after helper changes.
+- [ ] Run markdown lint over the changed protocol, integration, and smoke-test
+      docs.
+
+## Testing Strategy
+
+**Test types**: shell unit tests, markdown lint, smoke/manual tracker verification.
+
+**Key scenarios to test**:
+
+1. A GitHub Projects item with Type `Workflow` is discovered as workflow backlog
+   without relying on a `workflow` label.
+2. A GitHub Projects item with Type `Bug` routes to the fast-track/fix path even
+   when it has no `bug` label.
+3. A GitHub Projects item with Type `Refactor` routes to the plan-only refactor
+   path even when it has no `type:refactor` label.
+4. Operational labels still drive PR readiness and CI behavior.
+5. Release and retrospective protocols can find workflow items through Type-based
+   discovery.
+
+**Smoke test runbook**: `docs/testing/workflow/tracker-type-field-classification.smoke-test.md`
+
+**Regression suite**: Add workflow-lib shell tests for Type-field helper behavior.
+
+## Seed Data
+
+No permanent seed data is required. Smoke testing uses temporary GitHub issues on
+the configured project board and deletes or closes them at the end of the run.
+
+## Documentation Updates
+
+- [ ] `docs/workflow/development-workflow/integrations/github-projects.md` —
+      document the Type taxonomy, `Workflow` option, retired classification
+      labels, and migration steps.
+- [ ] `docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md`
+      — route backlog creation/classification through project Type.
+- [ ] `docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md`
+      — replace `workflow` label discovery with Workflow Type discovery.
+- [ ] `docs/workflow/development-workflow/protocols/06-retrospective-protocol.md`
+      — replace `workflow` label issue creation/filtering with Workflow Type.
+- [ ] `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
+      — clarify Type-based Backlog routing and proposal eligibility.
+- [ ] `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`
+      — clarify Type-based single-item Backlog routing.
+- [ ] `AGENTS.md` — document the project Type convention and retired labels.
+- [ ] `docs/testing/workflow/656-agents-add-to-project-board.smoke-test.md` —
+      remove the `workflow` label from temporary issue setup.
+- [ ] `docs/testing/workflow/tracker-type-field-classification.smoke-test.md` —
+      add the manual smoke runbook for this refactor.
+- [ ] `CHANGELOG.md` — add a `### Changed` entry for #828 using the format below.
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Type-field discovery reintroduces GraphQL budget drain. | Medium | High | Reuse the #824 targeted-query pattern and add tests that fail if helpers call per-item full-board scans. |
+| Removing label-based filters misses workflow items whose Type is unset. | Medium | High | Include an explicit migration step and fail-soft warnings for open workflow-labeled items with missing Type. |
+| Operational labels are accidentally retired with classification labels. | Low | High | Document the allow-list of operational labels and keep PR readiness protocols unchanged. |
+| Downstream projects have not created a `Workflow` Type option yet. | Medium | Medium | Document setup/migration steps and make helpers warn clearly when the option is absent. |
+
+## Code Samples
+
+No production code samples are required in the plan. The implementation should
+prefer small Bash helper functions in `workflow-lib.sh` that mirror the existing
+targeted Status helpers.
+
+## Implementation Order
+
+1. Add `Workflow` Type setup and retired-label guidance to the GitHub Projects
+   integration document.
+2. Add Type field read/update/discovery helpers to `workflow-lib.sh`, reusing the
+   existing targeted project item lookup and Status field metadata patterns.
+3. Add workflow-lib tests for Type helper success, missing-option warnings, and
+   Workflow Type discovery.
+4. Update Protocol 00 so backlog creation sets Type instead of classification
+   labels when GitHub Projects is configured.
+5. Update Protocol 05 and Protocol 06 to replace `workflow` label filters with
+   Workflow Type discovery.
+6. Update Protocol 90 and Protocol 91 to make tracker Type authoritative for
+   Backlog route classification under GitHub Projects.
+7. Update `AGENTS.md` and the affected smoke-test docs listed above.
+8. Run markdown lint for changed docs and the workflow-lib test harness.
+9. Add this CHANGELOG entry under `[Unreleased]` → `### Changed`:
+   `- **Tracker Type field classification** (#828): makes GitHub Projects Type the source of truth for workflow item classification, adds the Workflow Type convention, and retires repository labels for bug/enhancement/workflow classification while preserving operational PR labels.`

--- a/docs/testing/workflow/tracker-type-field-classification.smoke-test.md
+++ b/docs/testing/workflow/tracker-type-field-classification.smoke-test.md
@@ -1,0 +1,108 @@
+# Smoke Test Runbook: Tracker Type Field Classification
+
+**Feature**: Tracker Type field classification
+**Spec**: Refactor work item #828 brief
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] `gh` is authenticated for the repository and project owner.
+- [ ] `.ai-dev-workflow.yaml` uses `issue_tracker.provider: github_projects`.
+- [ ] The configured GitHub Project has a `Type` single-select field with
+      `Feature`, `Bug`, `Refactor`, and `Workflow` options.
+- [ ] The local branch includes the implementation for #828.
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| Temporary workflow issue | Created during the smoke test, then closed |
+| Temporary bug issue | Created during the smoke test, then closed |
+| Project number | Value from `.ai-dev-workflow.yaml` or `GITHUB_PROJECT_NUMBER` |
+
+## Smoke Test Steps
+
+### Step 1: Create temporary issues without classification labels
+
+1. Create one temporary issue whose project Type will be set to `Workflow`.
+2. Create one temporary issue whose project Type will be set to `Bug`.
+3. Add both issues to the configured project board.
+4. Confirm neither issue has `workflow`, `bug`, `enhancement`, or `type:*`
+   classification labels.
+
+**Expected result**: Both temporary issues exist on the board without retired
+classification labels.
+
+### Step 2: Set project Type values
+
+1. Set the first temporary issue's project Type to `Workflow`.
+2. Set the second temporary issue's project Type to `Bug`.
+3. Read each issue back through the workflow helper or documented GraphQL query.
+
+**Expected result**: The first issue reports Type `Workflow`; the second reports
+Type `Bug`.
+
+### Step 3: Verify Workflow Type discovery
+
+1. Run the Workflow Type discovery helper or the documented equivalent command.
+2. Confirm the output includes the temporary Workflow issue.
+3. Confirm the output does not include the temporary Bug issue.
+
+**Expected result**: Workflow discovery is based on project Type, not labels.
+
+### Step 4: Verify Backlog route classification
+
+1. Run the orchestrator or next-action classification path against the temporary
+   Bug issue.
+2. Confirm the issue is treated as a fast-track bug/fix candidate based on Type.
+3. Run the workflow discovery path against the temporary Workflow issue.
+4. Confirm it remains discoverable as workflow-framework work without the
+   `workflow` label.
+
+**Expected result**: Type values drive classification and routing.
+
+### Step 5: Verify operational labels are unchanged
+
+1. Inspect an implementation PR or test PR using `ready-for-human-review`,
+   `ready-for-regression`, and `needs-fixes`.
+2. Confirm the implementation did not remove or replace these operational labels.
+
+**Expected result**: Operational PR labels still exist and continue to drive
+review/CI behavior.
+
+### Last Step: Cleanup
+
+- Close the temporary issues.
+- Remove them from the project board if desired.
+- Verify no temporary classification labels were created.
+
+## Assertions Checklist
+
+- [ ] Workflow issue discovery works through project Type `Workflow`.
+- [ ] Bug/fix routing works through project Type `Bug`.
+- [ ] Retired classification labels are not required for the tested flows.
+- [ ] Operational labels remain unchanged.
+- [ ] Temporary issues are closed or cleaned up after the test.
+
+## Seed Data Reference
+
+No persistent seed data is required. The smoke test creates temporary GitHub
+issues and closes them before completion.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Type option cannot be set | Project Type field is missing the option | Add `Workflow`, `Bug`, `Feature`, and `Refactor` options in project settings |
+| Discovery returns no Workflow issues | Helper is still filtering by label or the issue is not on the board | Confirm the issue is on the board and inspect the helper query |
+| Temporary issue still has `workflow` label | Test setup copied an older command | Remove the label and rerun setup using Type-only classification |
+
+## Known Limitations
+
+- This smoke test requires write access to the configured GitHub Project.
+- The cleanup step may leave closed test issues visible in GitHub history.


### PR DESCRIPTION
## Summary

- Adds the implementation plan for #828, the tracker Type field classification refactor.
- Adds the smoke test runbook for Type-based workflow discovery and routing.
- Records live verification for the current workflow-label and Type-field references.

## Plan and Runbook

- `docs/specs/developments/20260606100326_tracker-type-field-classification/2_tracker-type-field-classification_implementation-plan.md`
- `docs/testing/workflow/tracker-type-field-classification.smoke-test.md`

## Verification

- `npx markdownlint-cli2 "docs/specs/developments/20260606100326_tracker-type-field-classification/2_tracker-type-field-classification_implementation-plan.md" "docs/testing/workflow/tracker-type-field-classification.smoke-test.md"`

## Plan Review Notes

- Template-fit check passed: this refactor changes the workflow template itself and is generic for downstream consumers.
- Parser-risk classifier: not applicable; implementation plans Type-field GraphQL helpers, not text parsers/scanners.
- Concurrent-event-source classifier: not applicable; no concurrent event sources are introduced.
- Cross-section consistency self-check completed for Type taxonomy, helper responsibilities, file paths, and implementation order.

Closes #828
