### PR TITLE
docs(plan): add tool-fix merge ordering plan

### DIFF
--- a/docs/specs/developments/20260606100937_tool-fix-merge-ordering/2_tool-fix-merge-ordering_implementation-plan.md
+++ b/docs/specs/developments/20260606100937_tool-fix-merge-ordering/2_tool-fix-merge-ordering_implementation-plan.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-**Approach**: Extend Protocol 90's existing tool-fix ordering hazard section with merge-ordering guidance for foundational reviewer-tool fixes. The implementation is documentation-only: define detection signals, hold behavior, resume behavior after foundational merge, and required batch-summary output.
+**Approach**: Extend the batch orchestration protocol's existing tool-fix ordering hazard section with merge-ordering guidance for foundational reviewer-tool fixes. The implementation is documentation-only: define detection signals, hold behavior, resume behavior after foundational merge, and required batch-summary output.
 
 **Estimated complexity**: S
 
@@ -22,7 +22,7 @@
 | Check | Command / query | Result |
 | --- | --- | --- |
 | Repo revision | `git rev-parse --short HEAD` | `0b52d0d` |
-| Existing tool-fix ordering text | `rg -n "tool-fix|Serialize-first|foundational|dependent|reviewer tooling|rebase" docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md docs/testing/workflow` | Protocol 90 already owns the same-batch tool-fix serialize-first rule; no existing foundational-merge guidance is present. |
+| Existing tool-fix ordering text | `rg -n "tool-fix|Serialize-first|foundational|dependent|reviewer tooling|rebase" docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md docs/testing/workflow` | The batch orchestration protocol already owns the same-batch tool-fix serialize-first rule; no existing foundational-merge guidance is present. |
 | Script change scope check | `rg -n "TOOL_FIX|TOOL_FIX_FILES|detect_file_conflicts|workflow-batch-plan" scripts/development-workflow docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` | `workflow-batch-plan.sh` already emits tool-fix classification; the requested behavior can be expressed as orchestrator protocol guidance without changing helper output. |
 
 ---
@@ -44,7 +44,7 @@
 
 ### Tests and Smoke Runbooks
 
-- [ ] `docs/testing/workflow/tool-fix-merge-ordering.smoke-test.md` — add a manual smoke runbook that verifies Protocol 90 includes detection, hold, merge-first, update/reloop, stale-escalation, summary, and human-merge-approval guidance.
+- [ ] `docs/testing/workflow/tool-fix-merge-ordering.smoke-test.md` — add a manual smoke runbook that verifies the batch orchestration protocol includes detection, hold, merge-first, update/reloop, stale-escalation, summary, and human-merge-approval guidance.
 
 ---
 
@@ -54,8 +54,8 @@
 
 **Key scenarios to test**:
 
-1. Protocol 90 explains why dispatch serialization alone is insufficient for dependent reviewer-tool fixes — maps to AC1.
-2. Protocol 90 instructs the orchestrator to identify foundational reviewer-tool fixes — maps to AC2.
+1. The batch orchestration protocol explains why dispatch serialization alone is insufficient for dependent reviewer-tool fixes — maps to AC1.
+2. The batch orchestration protocol instructs the orchestrator to identify foundational reviewer-tool fixes — maps to AC2.
 3. Dependent tool-fix items are held until the foundational PR is merged — maps to AC3.
 4. Dependent branches are updated from target base and rerun through reviewer loop/CI after foundational merge — maps to AC4.
 5. Pre-foundational-merge escalations are treated as stale until post-update review runs — maps to AC5.
@@ -100,7 +100,7 @@ No production code samples are required.
 
 ## Implementation Order
 
-1. Update Protocol 90's same-batch tool-fix ordering section with the foundational reviewer-tool merge-ordering subsection.
+1. Update the batch orchestration protocol's same-batch tool-fix ordering section with the foundational reviewer-tool merge-ordering subsection.
 2. Add summary-output requirements for foundational item, held dependents, merge-ordering reason, stale escalation treatment, and resume condition.
 3. Add `docs/testing/workflow/tool-fix-merge-ordering.smoke-test.md` with the seven Testing Strategy scenarios.
 4. Update `CHANGELOG.md` with the entry listed in **Documentation Updates**.

--- a/docs/specs/developments/20260606100937_tool-fix-merge-ordering/2_tool-fix-merge-ordering_implementation-plan.md
+++ b/docs/specs/developments/20260606100937_tool-fix-merge-ordering/2_tool-fix-merge-ordering_implementation-plan.md
@@ -1,0 +1,111 @@
+# Tool-Fix Merge Ordering — Implementation Plan
+
+**Spec**: [1_tool-fix-merge-ordering_specs.md](1_tool-fix-merge-ordering_specs.md)
+**Smoke test runbook**: [tool-fix-merge-ordering.smoke-test.md](../../../testing/workflow/tool-fix-merge-ordering.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Extend Protocol 90's existing tool-fix ordering hazard section with merge-ordering guidance for foundational reviewer-tool fixes. The implementation is documentation-only: define detection signals, hold behavior, resume behavior after foundational merge, and required batch-summary output.
+
+**Estimated complexity**: S
+
+**Rationale**: The approved spec scopes the change to protocol guidance and smoke documentation. No script behavior, tracker schema, or reviewer platform integration changes are required.
+
+**Dependencies**: None.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `0b52d0d` |
+| Existing tool-fix ordering text | `rg -n "tool-fix|Serialize-first|foundational|dependent|reviewer tooling|rebase" docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md docs/testing/workflow` | Protocol 90 already owns the same-batch tool-fix serialize-first rule; no existing foundational-merge guidance is present. |
+| Script change scope check | `rg -n "TOOL_FIX|TOOL_FIX_FILES|detect_file_conflicts|workflow-batch-plan" scripts/development-workflow docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` | `workflow-batch-plan.sh` already emits tool-fix classification; the requested behavior can be expressed as orchestrator protocol guidance without changing helper output. |
+
+---
+
+## Layer-by-Layer Changes
+
+### Workflow Protocols
+
+- [ ] `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` — update the "Same-batch tool-fix ordering hazard" section with a new "Foundational reviewer-tool merge ordering" subsection.
+- [ ] Define a foundational reviewer-tool fix as a tool-fix that repairs reviewer-loop or reviewer-action behavior another same-batch tool-fix needs to trust its own reviewer loop.
+- [ ] Require dependent tool-fix items to be held until the foundational PR is merged.
+- [ ] Require dependent branches or PRs to be updated from the target base after the foundational merge, then rerun reviewer loop and CI before readiness is trusted.
+- [ ] State that a dependent pre-foundational-merge escalation is stale until a post-update reviewer loop runs.
+- [ ] Require the batch summary to list foundational item, held dependent items, merge-ordering reason, and resume condition.
+
+### Scripts / Helpers
+
+- [ ] No script changes. `workflow-batch-plan.sh` already emits `TOOL_FIX` and `TOOL_FIX_FILES`; this feature only adds orchestration guidance for a case discovered after classification.
+
+### Tests and Smoke Runbooks
+
+- [ ] `docs/testing/workflow/tool-fix-merge-ordering.smoke-test.md` — add a manual smoke runbook that verifies Protocol 90 includes detection, hold, merge-first, update/reloop, stale-escalation, summary, and human-merge-approval guidance.
+
+---
+
+## Testing Strategy
+
+**Test types**: Markdown lint and manual smoke verification.
+
+**Key scenarios to test**:
+
+1. Protocol 90 explains why dispatch serialization alone is insufficient for dependent reviewer-tool fixes — maps to AC1.
+2. Protocol 90 instructs the orchestrator to identify foundational reviewer-tool fixes — maps to AC2.
+3. Dependent tool-fix items are held until the foundational PR is merged — maps to AC3.
+4. Dependent branches are updated from target base and rerun through reviewer loop/CI after foundational merge — maps to AC4.
+5. Pre-foundational-merge escalations are treated as stale until post-update review runs — maps to AC5.
+6. Batch summaries list held dependents and merge-ordering reason — maps to AC6.
+7. Human approval remains required before every merge — maps to AC7.
+
+**Smoke test runbook**: `docs/testing/workflow/tool-fix-merge-ordering.smoke-test.md`
+
+**Regression suite**: No automated shell regression is required because this plan does not change scripts.
+
+---
+
+## Seed Data
+
+No seed data is required.
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` — add foundational reviewer-tool merge-ordering guidance.
+- [ ] `docs/testing/workflow/tool-fix-merge-ordering.smoke-test.md` — add manual smoke coverage.
+- [ ] `CHANGELOG.md` — add under `[Unreleased]` → `### Fixed`: `- **Tool-fix merge ordering** (#825): documents that foundational reviewer-tool fixes must merge before dependent tool-fixes are trusted, and that dependents must update from the fixed base before rerunning reviewer loops.`
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Orchestrators over-serialize unrelated tool-fixes. | Medium | Medium | Limit the rule to reviewer-tool fixes that a dependent item's own reviewer loop needs to trust. |
+| Agents infer auto-merge authority. | Low | High | State explicitly that human approval remains required for every PR merge. |
+| Dependent PRs are marked ready using stale pre-merge reviewer outcomes. | Medium | High | Require update-from-base and a fresh reviewer loop/CI run after the foundational merge. |
+
+---
+
+## Code Samples
+
+No production code samples are required.
+
+---
+
+## Implementation Order
+
+1. Update Protocol 90's same-batch tool-fix ordering section with the foundational reviewer-tool merge-ordering subsection.
+2. Add summary-output requirements for foundational item, held dependents, merge-ordering reason, stale escalation treatment, and resume condition.
+3. Add `docs/testing/workflow/tool-fix-merge-ordering.smoke-test.md` with the seven Testing Strategy scenarios.
+4. Update `CHANGELOG.md` with the entry listed in **Documentation Updates**.
+5. Run markdown lint:
+
+   ```bash
+   npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md" "docs/testing/workflow/tool-fix-merge-ordering.smoke-test.md" "CHANGELOG.md"
+   ```

--- a/docs/testing/workflow/tool-fix-merge-ordering.smoke-test.md
+++ b/docs/testing/workflow/tool-fix-merge-ordering.smoke-test.md
@@ -1,0 +1,72 @@
+# Smoke Test Runbook: Tool-Fix Merge Ordering
+
+**Feature**: Tool-fix merge ordering
+**Spec**: [1_tool-fix-merge-ordering_specs.md](../../specs/developments/20260606100937_tool-fix-merge-ordering/1_tool-fix-merge-ordering_specs.md)
+**Created in**: Plan Ready stage
+
+---
+
+## Prerequisites
+
+- [ ] The implementation branch for #825 is checked out.
+- [ ] The changed documentation has been linted with `markdownlint-cli2`.
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify foundational hazard explanation
+
+1. Open `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`.
+2. Find the same-batch tool-fix ordering section.
+3. Confirm it explains that dispatch serialization is insufficient when one tool-fix repairs reviewer tooling that another same-batch tool-fix needs.
+
+**Expected result**: Protocol 90 names the merge-ordering hazard, not only dispatch ordering.
+
+### Step 2: Verify foundational detection and hold behavior
+
+1. In the same section, confirm the orchestrator is instructed to identify foundational reviewer-tool fixes.
+2. Confirm dependent tool-fix items are held until the foundational PR is merged.
+3. Confirm the hold reason must be visible in the batch summary.
+
+**Expected result**: Dependent tool-fixes are not trusted while they still depend on broken reviewer tooling.
+
+### Step 3: Verify post-merge resume behavior
+
+1. Confirm dependent branches or PRs must be updated from the target base after the foundational PR merges.
+2. Confirm the dependent reviewer loop and CI must be rerun after that update.
+3. Confirm readiness is trusted only after the fresh post-update loop is clean.
+
+**Expected result**: Dependent readiness cannot rely on stale pre-foundational-merge reviewer results.
+
+### Step 4: Verify stale escalation treatment
+
+1. Confirm a dependent escalation that happened before the foundational merge is treated as stale.
+2. Confirm it must be re-evaluated after updating from the fixed base.
+
+**Expected result**: The orchestrator distinguishes stale tool-caused escalations from substantive post-update findings.
+
+### Step 5: Verify human merge approval remains required
+
+1. Confirm Protocol 90 does not authorize autonomous merge of the foundational PR.
+2. Confirm the text explicitly preserves human approval for every PR merge.
+
+**Expected result**: Merge-ordering guidance changes sequencing, not merge authority.
+
+---
+
+## Assertions Checklist
+
+- [ ] Foundational reviewer-tool fixes are defined.
+- [ ] Dependent tool-fixes are held until foundational merge.
+- [ ] Dependent branches update from target base before rerun.
+- [ ] Fresh reviewer loop and CI are required before readiness.
+- [ ] Stale pre-merge escalations are explicitly re-evaluated.
+- [ ] Batch summaries list held items and reasons.
+- [ ] Human merge approval remains required.
+
+---
+
+## Seed Data Reference
+
+No seed data is required.


### PR DESCRIPTION
## Summary

- Adds the implementation plan for #825's foundational tool-fix merge-ordering guidance.
- Adds the smoke test runbook covering foundational detection, dependent holds, post-merge update/rerun, stale escalations, summaries, and human merge approval.

## Verification

- `npx markdownlint-cli2 "docs/specs/developments/20260606100937_tool-fix-merge-ordering/2_tool-fix-merge-ordering_implementation-plan.md" "docs/testing/workflow/tool-fix-merge-ordering.smoke-test.md"` — 0 errors
- `git diff --check`
- `ensure_on_project_board 825 "Writing Plan"` — already on project board

Closes #825
