### PR TITLE
fix(review): extend doc branch Haystack timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Haystack doc-branch reviewer timeout** (#851) — raises the reviewer-loop
+  default wait budget for `spec/*` and `implementation-plan/*` branches to 180s,
+  exposes `PR_REVIEW_LOOP_DOC_MAX_WAIT` for operators, and preserves explicit
+  `--max-wait` overrides so transient Haystack `pending_timeout` states are less
+  likely to produce false `reviewer-failed` labels on small documentation PRs.
 - **GitHub Projects closed-item workflow configuration** (#826) — documents that
   the built-in GitHub Projects "item closed" workflow must set Status to
   `Merged` or be disabled, rather than setting closed items to `Released`.

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -232,13 +232,14 @@ Platform selection (in priority order):
 Branch-type-aware default timeout:
   On spec/* and implementation-plan/* branches, Devin has no trigger condition and
   exits immediately with REASON=no_check_run. To avoid wasting the full 20-minute
-  default wait budget on these branches, the script automatically reduces --max-wait
-  to 60 s and --poll-interval to 30 s when the branch matches spec/* or
-  implementation-plan/* and the caller did not pass the respective flag explicitly.
-  poll_interval is also reduced so it stays below max_wait — the per-loop timeout
-  check requires elapsed >= max_wait, which can only fire after at least one
-  poll_interval has elapsed. Pass --max-wait and/or --poll-interval explicitly to
-  override either value.
+  default wait budget on these branches, the script automatically reduces
+  --max-wait to PR_REVIEW_LOOP_DOC_MAX_WAIT seconds (default: 180) and
+  --poll-interval to 30 s when the branch matches spec/* or
+  implementation-plan/* and the caller did not pass the respective flag
+  explicitly. poll_interval is also reduced when needed so it stays below
+  max_wait — the per-loop timeout check requires elapsed >= max_wait, which can
+  only fire after at least one poll_interval has elapsed. Pass --max-wait and/or
+  --poll-interval explicitly to override either value.
 
 Large-diff poll-window extension:
   CodeRabbit takes significantly longer to post its review on PRs with a large
@@ -3862,6 +3863,25 @@ restore_regression_label_if_missing() {
   return 0
 }
 
+doc_branch_default_max_wait() {
+  local configured="${PR_REVIEW_LOOP_DOC_MAX_WAIT:-180}"
+  if ! [[ "$configured" =~ ^[1-9][0-9]*$ ]]; then
+    echo "WARN: PR_REVIEW_LOOP_DOC_MAX_WAIT must be a positive integer; defaulting to 180" >&2
+    configured=180
+  fi
+  printf '%s\n' "$configured"
+}
+
+doc_branch_default_poll_interval() {
+  local max_wait="$1"
+  local interval=30
+  if [ "$interval" -ge "$max_wait" ]; then
+    interval=$((max_wait / 2))
+    [ "$interval" -lt 1 ] && interval=1
+  fi
+  printf '%s\n' "$interval"
+}
+
 # Skip the main execution block when sourced in test-harness mode.
 # All function definitions above (including normalize_platform_verdict,
 # append_compare_metrics_row, and restore_regression_label_if_missing) are
@@ -4015,15 +4035,15 @@ fi
 # Branch-type-aware timeout: spec/* and implementation-plan/* branches produce
 # REASON=no_check_run immediately when Devin has no trigger condition (non-implementation
 # branches). Waiting the full 1200-second default wastes orchestrator budget.
-# Apply a short max_wait=60 / poll_interval=30 default when the caller did not pass
-# --max-wait / --poll-interval explicitly. poll_interval must be less than max_wait
-# so the per-loop timeout check can fire within the budget.
+# Apply a bounded doc-branch max_wait / poll_interval=30 default when the caller
+# did not pass --max-wait / --poll-interval explicitly. poll_interval must be
+# less than max_wait so the per-loop timeout check can fire within the budget.
 if [ "$max_wait_explicit" -eq 0 ]; then
   case "$branch_name" in
     spec/*|implementation-plan/*)
-      max_wait=60
+      max_wait="$(doc_branch_default_max_wait)"
       if [ "$poll_interval_explicit" -eq 0 ]; then
-        poll_interval=30
+        poll_interval="$(doc_branch_default_poll_interval "$max_wait")"
       fi
       ;;
   esac
@@ -4040,7 +4060,7 @@ fi
 # count and extend max_wait to LARGE_DIFF_MAX_WAIT (default 2400 s) when the count
 # exceeds LARGE_DIFF_THRESHOLD (default 50 files). A case guard excludes spec/* and
 # implementation-plan/* branches — those are already handled by the branch-type-aware
-# timeout block above and must not have their 60-second budget overridden.
+# timeout block above and must not have their bounded doc-branch budget overridden.
 large_diff_threshold="${LARGE_DIFF_THRESHOLD:-50}"
 large_diff_max_wait="${LARGE_DIFF_MAX_WAIT:-2400}"
 if ! [[ "$large_diff_threshold" =~ ^[1-9][0-9]*$ ]]; then

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -219,6 +219,30 @@ run_test "pre_after_clean_only_filters_phase_platform" "pr-agent" "${platforms[0
 run_test "pre_after_clean_only_platform_count" "1" "${#platforms[@]}"
 
 # ---------------------------------------------------------------------------
+# Area 0b: doc branch timeout defaults
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 0b: doc branch timeout defaults ==="
+
+unset PR_REVIEW_LOOP_DOC_MAX_WAIT
+run_test "doc_branch_default_max_wait" "180" "$(doc_branch_default_max_wait)"
+
+PR_REVIEW_LOOP_DOC_MAX_WAIT=240
+export PR_REVIEW_LOOP_DOC_MAX_WAIT
+run_test "doc_branch_env_override_max_wait" "240" "$(doc_branch_default_max_wait)"
+
+PR_REVIEW_LOOP_DOC_MAX_WAIT=abc
+export PR_REVIEW_LOOP_DOC_MAX_WAIT
+_doc_timeout_output="$(doc_branch_default_max_wait 2>/dev/null)"
+run_test "doc_branch_invalid_env_falls_back" "180" "$_doc_timeout_output"
+
+run_test "doc_branch_poll_interval_default" "30" "$(doc_branch_default_poll_interval 180)"
+run_test "doc_branch_poll_interval_equal_clamps" "15" "$(doc_branch_default_poll_interval 30)"
+run_test "doc_branch_poll_interval_greater_clamps" "10" "$(doc_branch_default_poll_interval 20)"
+
+unset PR_REVIEW_LOOP_DOC_MAX_WAIT _doc_timeout_output
+
+# ---------------------------------------------------------------------------
 # Area 1: normalize_platform_verdict
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

- raise the default reviewer-loop wait budget for `spec/*` and `implementation-plan/*` branches from 60s to 180s
- add `PR_REVIEW_LOOP_DOC_MAX_WAIT` so operators can tune the doc-branch budget without editing the script
- keep explicit `--max-wait` overrides intact and add unit tests for default, override, and invalid env fallback

Closes #851

## Verification

- bash scripts/development-workflow/tests/test-pr-review-loop.sh
- bash -n scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-pr-review-loop.sh
- git diff --check
- npx markdownlint-cli2 CHANGELOG.md
- bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md
- find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md
- shellcheck -S warning scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-pr-review-loop.sh

## Pre-Submission Self-Review

- Diff scope: limited to `pr-review-loop.sh`, its test harness, and `CHANGELOG.md`.
- Coverage: confirms the fast-track issue body requirements: configurable doc-branch timeout, higher default, explicit override preservation, and invalid-env fallback.
- Sibling consistency: live branch-timeout documentation and the execution block now both reference `PR_REVIEW_LOOP_DOC_MAX_WAIT`; remaining 60s reference is historical changelog text only.
- Stale markers: no new TODO/FIXME/debug markers introduced.