### PR TITLE
fix(tracker): reassert merged status after close

### DIFF
--- a/.github/workflows/update-tracker-on-merge.yml
+++ b/.github/workflows/update-tracker-on-merge.yml
@@ -103,13 +103,36 @@ jobs:
             exit 0
           fi
 
-          echo "branch_type=$BRANCH_TYPE"     >> "$GITHUB_OUTPUT"
-          echo "target_status=$TARGET_STATUS" >> "$GITHUB_OUTPUT"
-          echo "issue_number=$ISSUE_NUMBER"   >> "$GITHUB_OUTPUT"
-          echo "skip=false"                   >> "$GITHUB_OUTPUT"
+          {
+            echo "branch_type=$BRANCH_TYPE"
+            echo "target_status=$TARGET_STATUS"
+            echo "issue_number=$ISSUE_NUMBER"
+            echo "skip=false"
+          } >> "$GITHUB_OUTPUT"
           echo "Detected: type=$BRANCH_TYPE, issue=$ISSUE_NUMBER, status=$TARGET_STATUS"
 
-      - name: Update GitHub Projects status
+      - name: Close issue for impl branches
+        if: >
+          steps.detect.outputs.skip == 'false' &&
+          steps.detect.outputs.branch_type == 'impl'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.detect.outputs.issue_number }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          ISSUE_STATE=$(gh issue view "$ISSUE_NUMBER" --repo "$GH_REPO" --json state --jq '.state')
+          if [ "$ISSUE_STATE" = "CLOSED" ]; then
+            echo "Issue #${ISSUE_NUMBER} is already closed; skipping close."
+            exit 0
+          fi
+
+          echo "Closing issue #${ISSUE_NUMBER} (implementation PR merged)..."
+          gh issue close "$ISSUE_NUMBER" --repo "$GH_REPO" \
+            --comment "Closed automatically: implementation PR merged to develop."
+
+      - name: Update GitHub Projects status after close
         if: steps.detect.outputs.skip == 'false'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         env:
@@ -125,6 +148,9 @@ jobs:
             const targetStatus = process.env.TARGET_STATUS;
             const issueNumber = parseInt(process.env.ISSUE_NUMBER, 10);
 
+            // This step intentionally runs after the issue-close step. For
+            // implementation branches, writing Merged after close compensates
+            // for built-in Project "item closed" workflows that set Released.
             if (!projectNumber) {
               core.warning('PROJECT_NUMBER variable is not set — skipping tracker update.');
               return;
@@ -253,20 +279,6 @@ jobs:
             });
 
             core.info(`Successfully updated issue #${issueNumber} status to "${targetStatus}".`);
-
-      - name: Close issue for impl branches
-        if: >
-          steps.detect.outputs.skip == 'false' &&
-          steps.detect.outputs.branch_type == 'impl'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ steps.detect.outputs.issue_number }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          echo "Closing issue #${ISSUE_NUMBER} (implementation PR merged)..."
-          gh issue close "$ISSUE_NUMBER" --repo "$GH_REPO" \
-            --comment "Closed automatically: implementation PR merged to develop." \
-            || echo "WARNING: gh issue close failed (issue may already be closed or not exist) — continuing."
 
       - name: Log branch-type to tracker-status mapping summary
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the built-in GitHub Projects "item closed" workflow must set Status to
   `Merged` or be disabled, rather than setting closed items to `Released`.
   This prevents implementation issues from being marked released immediately
-  after merge, before the prepare-release workflow publishes them.
+  after merge, before the prepare-release workflow publishes them. The merge
+  cleanup paths now also reassert `Merged` after closing implementation issues,
+  compensating for misconfigured Project close workflows in normal repo-owned
+  merge paths.
 - **Item orchestrator blocks ready labels on reviewer-loop escalation** (#827) — Protocol 91 Step 8a now requires the latest automated reviewer-loop summary to report `Result: clean` or `Result: skipped` before applying `ready-for-human-review`. `RESULT=escalate`, pending timeouts, reviewer timeouts, `needs_fixes`, and any other non-clean terminal reviewer-loop result now hard-block readiness labeling and force escalation or a return to the reviewer loop.
 - **PR-Agent Security Concern stuck-loop handling** (#815) — `.pr_agent.toml`
   now instructs PR-Agent to reserve `Security Concern` for high-confidence,

--- a/docs/workflow/development-workflow/integrations/github-projects.md
+++ b/docs/workflow/development-workflow/integrations/github-projects.md
@@ -72,15 +72,17 @@ that workflow so it does not override the AI development workflow's merge state:
 
 Implementation PR merges follow this sequence:
 
-1. `update-tracker-on-merge.yml` or `post-merge-cleanup.sh` sets the issue's
-   project Status to `Merged`.
-2. The workflow closes the GitHub issue for the merged implementation branch.
+1. The workflow closes the GitHub issue for the merged implementation branch.
+2. `update-tracker-on-merge.yml` or `post-merge-cleanup.sh` sets the issue's
+   project Status to `Merged` after the close action, so this repo-owned update
+   is the last write in the normal merge path.
 3. A later release workflow moves shipped issues from `Merged` to `Released`.
 
 If the built-in "item closed" workflow sets Status to `Released`, it races with
 and overrides the intended `Merged` status immediately after every implementation
-merge. The board then incorrectly shows unreleased work as released, and operators
-must manually correct each item before preparing a release.
+merge. The repository merge-cleanup paths now compensate by reasserting `Merged`
+after closing implementation issues, but the Project workflow should still be
+configured correctly so UI-driven closes and downstream projects do not drift.
 
 ### 3. Add Custom Fields
 
@@ -426,7 +428,9 @@ update logic. They are complementary:
   also handles local branch deletion and `develop` pull
 
 If both are active, the tracker update from `post-merge-cleanup` is idempotent (same status
-written twice is harmless).
+written twice is harmless). For implementation branches, cleanup also reasserts `Merged` after
+closing the issue so a built-in "item closed" Project workflow cannot leave the item at
+`Released`.
 
 ---
 
@@ -438,7 +442,7 @@ When a PR is merged, the `post-merge-cleanup` command will:
 2. Apply the action appropriate for the branch type:
    - `spec/*`: issue stays open; update project item Status to **Spec Ready**
    - `implementation-plan/*`: issue stays open; update project item Status to **Plan Ready**
-   - `feature/*`, `fix/*`, `refactor/*`, `hotfix/*`: close the GitHub issue (`gh issue close 42`) and update project item Status to **Merged**
+   - `feature/*`, `fix/*`, `refactor/*`, `hotfix/*`: close the GitHub issue (`gh issue close 42`) and update project item Status to **Merged** after close
 3. Each tracker update is best-effort: if `GITHUB_PROJECT_NUMBER` is unset or the API call fails, a warning is logged and the script continues without aborting
 
 ---

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -193,7 +193,12 @@ if [ -n "$ISSUE_IDENTIFIER" ]; then
         if [ -n "$MERGED_PR" ]; then
           CLOSE_COMMENT="Closed by PR #${MERGED_PR}."
           echo "Closing issue #$ISSUE_NUMBER..."
-          gh issue close "$ISSUE_NUMBER" --comment "$CLOSE_COMMENT" 2>/dev/null || echo "Warning: could not close issue #$ISSUE_NUMBER"
+          if gh issue close "$ISSUE_NUMBER" --comment "$CLOSE_COMMENT"; then
+            echo "Reasserting issue #$ISSUE_NUMBER tracker status as Merged after close..."
+            update_tracker_status_best_effort "$ISSUE_NUMBER" "Merged" "" "allow-backward"
+          else
+            echo "Warning: could not close issue #$ISSUE_NUMBER"
+          fi
         else
           echo "No merged PR found for branch '$TO_DELETE'; leaving issue #$ISSUE_NUMBER open."
         fi

--- a/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+++ b/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
@@ -68,6 +68,10 @@ JSON
 	          cat <<'JSON'
 	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1},"fieldValueByName":{"name":"Spec Ready"},"type":{"name":"Workflow"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
 JSON
+	        elif [ "${MOCK_PROJECT_ITEM_MODE:-existing}" = "released" ]; then
+	          cat <<'JSON'
+	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1},"status":{"name":"Released"},"type":{"name":"Workflow"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
 	        else
 	          cat <<'JSON'
 	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1},"status":{"name":"Spec Ready"},"type":{"name":"Workflow"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
@@ -88,7 +92,7 @@ JSON
           case "$*" in
             *"after=cursor_field_1"*)
               cat <<'JSON'
-{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_status","name":"Status","options":[{"id":"OPT_spec_ready","name":"Spec Ready"},{"id":"OPT_in_development","name":"In Development"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_workflow","name":"Workflow"},{"id":"OPT_bug","name":"Bug"},{"id":"OPT_refactor","name":"Refactor"},{"id":"OPT_feature","name":"Feature"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}
+{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_status","name":"Status","options":[{"id":"OPT_spec_ready","name":"Spec Ready"},{"id":"OPT_in_development","name":"In Development"},{"id":"OPT_merged","name":"Merged"},{"id":"OPT_released","name":"Released"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_workflow","name":"Workflow"},{"id":"OPT_bug","name":"Bug"},{"id":"OPT_refactor","name":"Refactor"},{"id":"OPT_feature","name":"Feature"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}
 JSON
               ;;
             *)
@@ -99,7 +103,7 @@ JSON
           esac
         else
           cat <<'JSON'
-{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_status","name":"Status","options":[{"id":"OPT_spec_ready","name":"Spec Ready"},{"id":"OPT_in_development","name":"In Development"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_workflow","name":"Workflow"},{"id":"OPT_bug","name":"Bug"},{"id":"OPT_refactor","name":"Refactor"},{"id":"OPT_feature","name":"Feature"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}
+{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_status","name":"Status","options":[{"id":"OPT_spec_ready","name":"Spec Ready"},{"id":"OPT_in_development","name":"In Development"},{"id":"OPT_merged","name":"Merged"},{"id":"OPT_released","name":"Released"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_workflow","name":"Workflow"},{"id":"OPT_bug","name":"Bug"},{"id":"OPT_refactor","name":"Refactor"},{"id":"OPT_feature","name":"Feature"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}
 JSON
         fi
         ;;
@@ -257,6 +261,26 @@ esac
 run_test "status_update_field_lookup_paginates" "updated" "$update_result"
 run_test "status_update_field_lookup_uses_two_field_queries" "2" "$(count_log_matches 'fields')"
 run_test "status_update_field_lookup_avoids_full_board_scan" "" "$(forbidden_project_reads)"
+
+reset_log
+export MOCK_PROJECT_ITEM_MODE=released
+update_output="$(update_tracker_status_best_effort 824 "Merged")"
+case "$update_output" in
+  *"already at status 'Released' (more advanced than 'Merged'); skipping rollback"*) update_result="rollback-skipped" ;;
+  *) update_result="$update_output" ;;
+esac
+run_test "status_update_blocks_backward_move_by_default" "rollback-skipped" "$update_result"
+run_test "status_update_default_backward_no_mutation" "0" "$(count_log_matches 'updateProjectV2ItemFieldValue')"
+
+reset_log
+update_output="$(update_tracker_status_best_effort 824 "Merged" "" "allow-backward")"
+unset MOCK_PROJECT_ITEM_MODE
+case "$update_output" in
+  *"Updating tracker status for issue #824 to 'Merged'"*) update_result="updated" ;;
+  *) update_result="$update_output" ;;
+esac
+run_test "status_update_allows_explicit_backward_move" "updated" "$update_result"
+run_test "status_update_explicit_backward_mutates_project_item" "1" "$(count_log_matches 'updateProjectV2ItemFieldValue')"
 
 reset_log
 type_update_output="$(update_tracker_type_best_effort 824 "Workflow")"

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -1155,7 +1155,7 @@ ensure_on_project_board() {
   update_tracker_status_best_effort "$issue_number" "$initial_status"
 }
 
-# update_tracker_status_best_effort <issue_number> <status_label> [required_current_status]
+# update_tracker_status_best_effort <issue_number> <status_label> [required_current_status] [allow-backward]
 #
 # Best-effort update for the configured issue tracker's Status field.
 # Supports GitHub Projects (provider: github_projects) and emits actionable
@@ -1170,6 +1170,7 @@ update_tracker_status_best_effort() {
   local issue_number="$1"
   local status_label="$2"
   local required_current_status="${3:-}"
+  local allow_backward="${4:-false}"
   local project_number project_id field_json field_id option_id item_json item_id current_status
   local target_order current_order
 
@@ -1240,7 +1241,7 @@ print(item.get('status') or '', end='')
     echo "Warning: Issue #${issue_number} current status '${current_status}' is unrecognized; skipping update to '${status_label}' to avoid silent state corruption. Provide required_current_status to proceed anyway."
     return 0
   fi
-  if [ "$target_order" -ge 0 ] && [ "$current_order" -gt "$target_order" ]; then
+  if [ "$target_order" -ge 0 ] && [ "$current_order" -gt "$target_order" ] && [ "$allow_backward" != "allow-backward" ]; then
     echo "Issue #${issue_number} is already at status '${current_status}' (more advanced than '${status_label}'); skipping rollback."
     return 0
   fi


### PR DESCRIPTION
## Summary

- Reorder the merge tracker workflow so implementation issues are closed before the Project status is written to `Merged`.
- Add an explicit `allow-backward` mode to `update_tracker_status_best_effort` and use it only after local implementation issue close.
- Update GitHub Projects integration docs, CHANGELOG, and helper tests for the `Released` to `Merged` compensation path.

## Verification

- `bash scripts/development-workflow/tests/test-workflow-lib-github-projects.sh`
- `bash scripts/development-workflow/check-tracker-merge-mapping.sh`
- `npx markdownlint-cli2 docs/workflow/development-workflow/integrations/github-projects.md CHANGELOG.md`
- `actionlint .github/workflows/update-tracker-on-merge.yml`
- `bash -n scripts/development-workflow/workflow-lib.sh scripts/development-workflow/post-merge-cleanup.sh`
- `shellcheck -x -P scripts/development-workflow scripts/development-workflow/workflow-lib.sh scripts/development-workflow/post-merge-cleanup.sh scripts/development-workflow/tests/test-workflow-lib-github-projects.sh`

## Pre-Submission Self-Review

- Reviewed `git diff origin/develop...HEAD` for scope: changes are limited to #826 merge-status compensation, tests, docs, and CHANGELOG.
- Verified sibling/caller consistency: local `post-merge-cleanup.sh` and `.github/workflows/update-tracker-on-merge.yml` now both make `Merged` the last repo-owned write for implementation merges.
- Verified rollback protection remains default: helper tests cover default skip from `Released` to `Merged` and explicit `allow-backward` compensation.
- Checked for stale markers: no TODO/FIXME markers introduced.

Closes #826
