### PR TITLE
fix(workflow): cover reviewer loop follow-up paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Reviewer-loop follow-up test coverage** (#802, #803) — adds regression
+  coverage for `pr-review-loop.sh` lock-unlock failure handling, Codex thread
+  audit escalation, reviewer-summary temp-file cleanup, and
+  `claude-code-action-reviewer.sh` timestamp fallback plus paginated Actions run
+  selection.
 - **Haystack doc-branch reviewer timeout** (#851) — raises the reviewer-loop
   default wait budget for `spec/*` and `implementation-plan/*` branches to 180s,
   exposes `PR_REVIEW_LOOP_DOC_MAX_WAIT` for operators, and preserves explicit

--- a/docs/workflow/development-workflow/integrations/claude-code-action.md
+++ b/docs/workflow/development-workflow/integrations/claude-code-action.md
@@ -164,8 +164,9 @@ dispatches. The companion script polls the Actions API for the run triggered
 after the workflow was dispatched:
 
 ```bash
-run_status=$(gh api "repos/$OWNER/$REPO/actions/runs" \
-  --jq ".workflow_runs | map(select(.event == \"workflow_dispatch\")) | .[0].status")
+run_status=$(gh api --paginate \
+  "repos/$OWNER/$REPO/actions/runs?event=workflow_dispatch&per_page=100" \
+  | jq -sr '[.[] | .workflow_runs[]?] | sort_by(.created_at) | reverse | .[0].status')
 ```
 
 | Result                                           | Action                                                                |

--- a/scripts/development-workflow/claude-code-action-reviewer.sh
+++ b/scripts/development-workflow/claude-code-action-reviewer.sh
@@ -179,11 +179,11 @@ echo "INFO: Bot login (plain, for review matching): $BOT_LOGIN_PLAIN"
 _DISPATCH_EPOCH=$(date -u +%s)
 DISPATCH_TIME=$(date -u -r "$_DISPATCH_EPOCH" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
   date -u -d "@$_DISPATCH_EPOCH" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
-  python3 -c "import datetime,sys; print(datetime.datetime.utcfromtimestamp(int(sys.argv[1])).strftime('%Y-%m-%dT%H:%M:%SZ'))" "$_DISPATCH_EPOCH")
+  python3 -c "import datetime,sys; print(datetime.datetime.fromtimestamp(int(sys.argv[1]), datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))" "$_DISPATCH_EPOCH")
 _POLL_EPOCH=$((_DISPATCH_EPOCH - 10))
 POLL_AFTER_TIME=$(date -u -r "$_POLL_EPOCH" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
   date -u -d "@$_POLL_EPOCH" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
-  python3 -c "import datetime,sys; print(datetime.datetime.utcfromtimestamp(int(sys.argv[1])).strftime('%Y-%m-%dT%H:%M:%SZ'))" "$_POLL_EPOCH")
+  python3 -c "import datetime,sys; print(datetime.datetime.fromtimestamp(int(sys.argv[1]), datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))" "$_POLL_EPOCH")
 unset _DISPATCH_EPOCH _POLL_EPOCH
 echo "INFO: dispatch time (pre-dispatch): $DISPATCH_TIME"
 echo "INFO: poll filter time (with 10s clock-skew buffer): $POLL_AFTER_TIME"
@@ -257,12 +257,12 @@ while [ "$TOTAL_ELAPSED" -lt "$MAX_WAIT" ]; do
   RUN_POLL_STDERR=$(mktemp)
   RUN_POLL_TMPFILE=$(mktemp)
   POLL_STATUS=0
-  gh api "repos/$OWNER/$REPO/actions/runs?event=workflow_dispatch&per_page=20" \
+  gh api --paginate "repos/$OWNER/$REPO/actions/runs?event=workflow_dispatch&per_page=100" \
     2>"$RUN_POLL_STDERR" \
-    | jq -r --arg wf "$WORKFLOW_FILE" --arg poll_after "$POLL_AFTER_TIME" \
+    | jq -sr --arg wf "$WORKFLOW_FILE" --arg poll_after "$POLL_AFTER_TIME" \
         --arg pr "$PR_NUMBER" \
         '# Candidate set: workflow-file + timestamp match
-         (.workflow_runs // []) as $all |
+         [.[] | .workflow_runs[]?] as $all |
          [$all[] | select((.path | endswith($wf)) and .created_at >= $poll_after)] as $candidates |
          # PR-scoping via run-name (#808): if any candidate has a "PR #N"-style name
          # (indicating the workflow uses run-name), require name match for THIS PR to

--- a/scripts/development-workflow/tests/test-claude-code-action-reviewer.sh
+++ b/scripts/development-workflow/tests/test-claude-code-action-reviewer.sh
@@ -41,7 +41,7 @@ run_test() {
 #            $pr (PR number string for run-name scoping)
 # ---------------------------------------------------------------------------
 RUN_POLL_FILTER='# Candidate set: workflow-file + timestamp match
-         (.workflow_runs // []) as $all |
+         [.[] | .workflow_runs[]?] as $all |
          [$all[] | select((.path | endswith($wf)) and .created_at >= $poll_after)] as $candidates |
          # PR-scoping via run-name (#808): if any candidate has a "PR #N"-style name
          # (indicating the workflow uses run-name), require name match for THIS PR to
@@ -58,6 +58,7 @@ RUN_POLL_FILTER='# Candidate set: workflow-file + timestamp match
 run_filter() {
   local json="$1" wf="$2" poll_after="$3" pr="${4:-808}"
   printf '%s\n' "$json" | jq -r \
+    --slurp \
     --arg wf "$wf" \
     --arg poll_after "$poll_after" \
     --arg pr "$pr" \
@@ -246,7 +247,34 @@ _id=$(printf '%s\n' "$_result" | jq -r '.id')
 run_test "two_runs_same_pr_most_recent_selected" "830" "$_id"
 unset _json _result _id
 
-# Test 5.6: Backward compat — old workflow (no run-name, generic names) falls back
+# Test 5.6: Runs can arrive out of timestamp order — newest created_at wins
+# This fails without `sort_by(.created_at) | reverse | first` because the first
+# input item is intentionally older than the later candidate for the same PR.
+_json='{"workflow_runs":[
+  {"path":".github/workflows/claude-code-review.yml","name":"Claude Code Review — PR #808","created_at":"2026-06-02T16:00:00Z","status":"completed","conclusion":"success","html_url":"https://a","id":840},
+  {"path":".github/workflows/claude-code-review.yml","name":"Claude Code Review — PR #808","created_at":"2026-06-02T16:03:00Z","status":"completed","conclusion":"success","html_url":"https://b","id":843},
+  {"path":".github/workflows/claude-code-review.yml","name":"Claude Code Review — PR #808","created_at":"2026-06-02T16:01:00Z","status":"completed","conclusion":"success","html_url":"https://c","id":841}
+]}'
+_result=$(run_filter "$_json" "claude-code-review.yml" "2026-06-02T15:59:00Z" "808")
+_id=$(printf '%s\n' "$_result" | jq -r '.id')
+run_test "out_of_order_runs_newest_created_at_selected" "843" "$_id"
+unset _json _result _id
+
+# Test 5.7: Paginated workflow-run responses are flattened before selection
+# The production poller uses `gh api --paginate` and slurps all page objects
+# before applying the same filter. This guards against selecting only page 1.
+_json='{"workflow_runs":[
+  {"path":".github/workflows/claude-code-review.yml","name":"Claude Code Review — PR #808","created_at":"2026-06-02T16:00:00Z","status":"completed","conclusion":"failure","html_url":"https://page1","id":850}
+]}
+{"workflow_runs":[
+  {"path":".github/workflows/claude-code-review.yml","name":"Claude Code Review — PR #808","created_at":"2026-06-02T16:04:00Z","status":"completed","conclusion":"success","html_url":"https://page2","id":854}
+]}'
+_result=$(run_filter "$_json" "claude-code-review.yml" "2026-06-02T15:59:00Z" "808")
+_id=$(printf '%s\n' "$_result" | jq -r '.id')
+run_test "paginated_runs_flattened_newest_selected" "854" "$_id"
+unset _json _result _id
+
+# Test 5.8: Backward compat — old workflow (no run-name, generic names) falls back
 # to timestamp-only selection. When no candidate has a "PR #N"-style name, the
 # filter uses all candidates. The most recent one is selected regardless of name.
 # This covers the transition period before the new workflow is deployed to main.
@@ -258,6 +286,31 @@ _result=$(run_filter "$_json" "claude-code-review.yml" "2026-06-02T15:59:00Z" "8
 _id=$(printf '%s\n' "$_result" | jq -r '.id')
 run_test "backward_compat_generic_name_falls_back_to_newest" "901" "$_id"
 unset _json _result _id
+
+# ---------------------------------------------------------------------------
+# Area 6: epoch→ISO8601 conversion fallback
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 6: epoch→ISO8601 conversion fallback ==="
+
+_date_mock_dir="$(mktemp -d)"
+cat > "$_date_mock_dir/date" <<'MOCK_DATE'
+#!/usr/bin/env bash
+exit 1
+MOCK_DATE
+chmod +x "$_date_mock_dir/date"
+
+_epoch_to_iso_with_python_fallback() {
+  local epoch="$1"
+  PATH="$_date_mock_dir:$PATH" date -u -r "$epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+    PATH="$_date_mock_dir:$PATH" date -u -d "@$epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+    python3 -c "import datetime,sys; print(datetime.datetime.fromtimestamp(int(sys.argv[1]), datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))" "$epoch"
+}
+
+_iso="$(_epoch_to_iso_with_python_fallback 1700000000)"
+run_test "python_fallback_epoch_to_iso" "2023-11-14T22:13:20Z" "$_iso"
+rm -rf "$_date_mock_dir"
+unset _date_mock_dir _iso
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1360,6 +1360,123 @@ unset _reviewer_failed_required _reviewer_failed_fn_line _sync_fn_line _harness_
 unset MOCK_GH_EXIT MOCK_GH_LABEL_VIEW_EXIT MOCK_GH_LABEL_CREATE_EXIT MOCK_GH_PR_EDIT_EXIT
 
 # ---------------------------------------------------------------------------
+# Area 13: PR #801 follow-up coverage for reviewer-loop failure paths
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 13: PR #801 reviewer-loop failure paths ==="
+
+_unlock_pr="80213"
+_unlock_lock_dir="/tmp/pr-review-loop-${_unlock_pr}.lockdir"
+rm -rf "$_unlock_lock_dir"
+mkdir -p "$_unlock_lock_dir/pid"
+printf '%s\n' "pr-review-loop.sh" > "$_unlock_lock_dir/cmd"
+_unlock_exit=0
+_unlock_output="$("$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh" unlock "$_unlock_pr" 2>&1)" || _unlock_exit=$?
+run_test "unlock_unreadable_pid_exits_1" "1" "$_unlock_exit"
+if printf '%s\n' "$_unlock_output" | grep -q "could not read lock PID"; then
+  _unlock_error_seen="yes"
+else
+  _unlock_error_seen="no"
+fi
+run_test "unlock_unreadable_pid_error" "yes" "$_unlock_error_seen"
+rm -rf "$_unlock_lock_dir"
+unset _unlock_output _unlock_exit _unlock_error_seen
+
+_unlock_pr="80313"
+_unlock_lock_dir="/tmp/pr-review-loop-${_unlock_pr}.lockdir"
+rm -rf "$_unlock_lock_dir"
+mkdir -p "$_unlock_lock_dir/cmd"
+printf '%s\n' "999999" > "$_unlock_lock_dir/pid"
+_unlock_exit=0
+_unlock_output="$("$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh" unlock "$_unlock_pr" 2>&1)" || _unlock_exit=$?
+run_test "unlock_unreadable_cmd_exits_1" "1" "$_unlock_exit"
+if printf '%s\n' "$_unlock_output" | grep -q "could not read lock cmd"; then
+  _unlock_error_seen="yes"
+else
+  _unlock_error_seen="no"
+fi
+run_test "unlock_unreadable_cmd_error" "yes" "$_unlock_error_seen"
+rm -rf "$_unlock_lock_dir"
+unset _unlock_pr _unlock_lock_dir _unlock_output _unlock_exit _unlock_error_seen
+
+_codex_overrides='
+  cd_workflow_repo_root() { :; }
+  repo_slug() { printf "owner/repo\n"; }
+  require_gh() { :; }
+  check_unresolved_threads() { return 3; }
+'
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_codex_overrides"
+  _ec=0
+  run_codex_github_review "42" "fix/42-test" "1" "5" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "codex_thread_check_failure_result" "RESULT=escalate" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "codex_thread_check_failure_reason" "REASON=thread-check-failed" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+run_test "codex_thread_check_failure_exit_code" "2" "$actual_exit"
+unset _codex_overrides actual_output actual_exit
+
+_post_summary_source="$(awk '/^_post_review_summary\(\)/,/^}$/' \
+  "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"
+eval "$_post_summary_source"
+# shellcheck disable=SC2329 # Invoked indirectly by the eval-loaded function.
+repo_slug() { printf "owner/repo\n"; }
+# shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
+compare_mode=0
+# shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
+compare_verdicts=()
+# shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
+platform_policy_status_notes=()
+# shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
+pr_number=42
+# shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
+branch_name="fix/42-summary"
+MOCK_GH_COMMENTS_OUTPUT='[]'
+export MOCK_GH_COMMENTS_OUTPUT
+
+_summary_call_log="$(mktemp)"
+export MOCK_GH_CALL_LOG="$_summary_call_log"
+MOCK_GH_EXIT=0
+export MOCK_GH_EXIT
+_post_review_summary "escalate" "thread-check-failed" "codex-github" "0" "0"
+_body_file="$(awk '/pr comment 42 --body-file / {print $NF}' "$_summary_call_log" | tail -n 1)"
+if [ -n "$_body_file" ]; then
+  _body_file_used="yes"
+else
+  _body_file_used="no"
+fi
+run_test "post_summary_uses_body_file" "yes" "$_body_file_used"
+if [ -n "$_body_file" ] && [ ! -e "$_body_file" ]; then
+  _body_file_removed="yes"
+else
+  _body_file_removed="no"
+fi
+run_test "post_summary_removes_body_file_on_success" "yes" "$_body_file_removed"
+rm -f "$_summary_call_log"
+
+_summary_call_log="$(mktemp)"
+export MOCK_GH_CALL_LOG="$_summary_call_log"
+MOCK_GH_EXIT=1
+export MOCK_GH_EXIT
+_post_review_summary "escalate" "thread-check-failed" "codex-github" "0" "0" 2>/dev/null
+_body_file="$(awk '/pr comment 42 --body-file / {print $NF}' "$_summary_call_log" | tail -n 1)"
+if [ -n "$_body_file" ] && [ ! -e "$_body_file" ]; then
+  _body_file_removed="yes"
+else
+  _body_file_removed="no"
+fi
+run_test "post_summary_removes_body_file_on_failure" "yes" "$_body_file_removed"
+rm -f "$_summary_call_log"
+unset MOCK_GH_CALL_LOG MOCK_GH_EXIT MOCK_GH_COMMENTS_OUTPUT
+unset _post_summary_source _summary_call_log _body_file _body_file_used _body_file_removed
+unset -f _post_review_summary repo_slug
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1365,7 +1365,7 @@ unset MOCK_GH_EXIT MOCK_GH_LABEL_VIEW_EXIT MOCK_GH_LABEL_CREATE_EXIT MOCK_GH_PR_
 echo ""
 echo "=== Area 13: PR #801 reviewer-loop failure paths ==="
 
-_unlock_pr="80213"
+_unlock_pr="80213$$"
 _unlock_lock_dir="/tmp/pr-review-loop-${_unlock_pr}.lockdir"
 rm -rf "$_unlock_lock_dir"
 mkdir -p "$_unlock_lock_dir/pid"
@@ -1382,7 +1382,7 @@ run_test "unlock_unreadable_pid_error" "yes" "$_unlock_error_seen"
 rm -rf "$_unlock_lock_dir"
 unset _unlock_output _unlock_exit _unlock_error_seen
 
-_unlock_pr="80313"
+_unlock_pr="80313$$"
 _unlock_lock_dir="/tmp/pr-review-loop-${_unlock_pr}.lockdir"
 rm -rf "$_unlock_lock_dir"
 mkdir -p "$_unlock_lock_dir/cmd"


### PR DESCRIPTION
## Summary

- Add regression coverage for `pr-review-loop.sh` unlock metadata read failures, Codex GitHub thread-check escalation, and reviewer-loop summary temp-file cleanup.
- Harden `claude-code-action-reviewer.sh` run polling to read paginated Actions run results, and cover out-of-order, paginated, and Python timestamp-fallback paths.
- Update the Claude Code Action integration docs and CHANGELOG entry for the new behavior.

## Pre-Submission Self-Review

- Reviewed `git diff origin/develop` for all changed files.
- Scope is limited to issues #802 and #803 plus direct documentation/changelog alignment.
- Issue-body coverage confirmed: #802 requested lock-read failure, Codex thread-check escalation, and summary temp-file cleanup coverage; #803 requested timestamp fallback, run-selection ordering, concurrent dispatch, and first-page-only run hardening/coverage.
- Sibling/caller consistency checked: the production poller and extracted test filter both use paginated/slurped workflow-run input; docs now show the paginated polling shape.
- Renamed-string scan checked for stale `utcfromtimestamp` and `per_page=20` references in the touched script/test path.

## Verification

- `bash scripts/development-workflow/tests/test-claude-code-action-reviewer.sh` — 20 passed, 0 failed
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` — 139 passed, 0 failed
- `bash -n scripts/development-workflow/claude-code-action-reviewer.sh scripts/development-workflow/tests/test-claude-code-action-reviewer.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `shellcheck --severity=warning scripts/development-workflow/claude-code-action-reviewer.sh scripts/development-workflow/tests/test-claude-code-action-reviewer.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `npx markdownlint-cli2 CHANGELOG.md docs/workflow/development-workflow/integrations/claude-code-action.md`
- `python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md docs/workflow/development-workflow/integrations/claude-code-action.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `git diff --check`

Closes #802
Closes #803
