### PR TITLE
fix(workflow): harden template sync helpers (hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.1] - 2026-06-08
+
+### Fixed
+
+- **Template sync hotfixes** (#858, #859) (hotfix): hardens GitHub Projects helper diagnostics and fallback remote parsing, and syncs lint helpers referenced by workflow protocols.
+
 ## [0.30.0] - 2026-06-07
 
 ### Added
@@ -877,7 +883,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.30.0...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.30.1...HEAD
+[0.30.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.29.1...v0.30.0
 [0.29.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.29.0...v0.29.1
 [0.29.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.28.4...v0.29.0

--- a/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+++ b/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
@@ -361,15 +361,23 @@ type_field_stderr=""
 type_field_stderr="$(workflow_github_project_type_field_json "PVT_project_1" 2>&1 >/dev/null)" || true
 unset MOCK_STATUS_FIELD_MODE
 case "$type_field_stderr" in
-  *"GraphQL project Type field lookup failed"* )
-    case "$type_field_stderr" in
-      *"GraphQL failure"*) type_field_stderr_result="$type_field_stderr" ;;
-      *) type_field_stderr_result="suppressed" ;;
-    esac
-    ;;
+  *"GraphQL project Type field lookup failed"*"  gh: GraphQL failure"*) type_field_stderr_result="captured" ;;
   *) type_field_stderr_result="$type_field_stderr" ;;
 esac
-run_test "type_field_graphql_failure_suppresses_raw_gh_stderr" "suppressed" "$type_field_stderr_result"
+run_test "type_field_graphql_failure_reports_captured_gh_stderr" "captured" "$type_field_stderr_result"
+
+reset_log
+__workflow_project_status_field_cache_project_id=""
+__workflow_project_status_field_cache_json=""
+export MOCK_STATUS_FIELD_MODE=graphql_fail
+status_field_stderr=""
+status_field_stderr="$(workflow_github_project_status_field_json "PVT_project_1" 2>&1 >/dev/null)" || true
+unset MOCK_STATUS_FIELD_MODE
+case "$status_field_stderr" in
+  *"GraphQL project Status field lookup failed"*"  gh: GraphQL failure"*) status_field_stderr_result="captured" ;;
+  *) status_field_stderr_result="$status_field_stderr" ;;
+esac
+run_test "status_field_graphql_failure_reports_captured_gh_stderr" "captured" "$status_field_stderr_result"
 
 reset_log
 __workflow_project_type_field_cache_project_id=""

--- a/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+++ b/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
@@ -34,9 +34,15 @@ printf '%s\n' "$*" >> "$MOCK_GH_CALL_LOG"
 
 case "$*" in
   "repo view --json owner --jq .owner.login")
+    if [ "${MOCK_REPO_VIEW_MODE:-ok}" = "fail" ]; then
+      exit 42
+    fi
     printf 'lhpaul\n'
     ;;
   "repo view --json name --jq .name")
+    if [ "${MOCK_REPO_VIEW_MODE:-ok}" = "fail" ]; then
+      exit 42
+    fi
     printf 'ai-dev-framework-template\n'
     ;;
   *"api graphql"* )
@@ -67,6 +73,10 @@ JSON
 	        elif [ "${MOCK_PROJECT_ITEM_MODE:-existing}" = "legacy_field_value" ]; then
 	          cat <<'JSON'
 	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1},"fieldValueByName":{"name":"Spec Ready"},"type":{"name":"Workflow"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
+	        elif [ "${MOCK_PROJECT_ITEM_MODE:-existing}" = "missing_fields" ]; then
+	          cat <<'JSON'
+	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
 JSON
 	        elif [ "${MOCK_PROJECT_ITEM_MODE:-existing}" = "released" ]; then
 	          cat <<'JSON'
@@ -214,6 +224,16 @@ run_test "legacy_field_value_type_alias_read" "Workflow" "$tracker_type"
 run_test "legacy_field_value_avoids_full_board_scan" "" "$(forbidden_project_reads)"
 
 reset_log
+export MOCK_PROJECT_ITEM_MODE=missing_fields
+missing_fields_stderr="$(workflow_github_project_item_for_issue 824 1 2>&1 >/dev/null || true)"
+unset MOCK_PROJECT_ITEM_MODE
+case "$missing_fields_stderr" in
+  *"named exactly 'Status'"*"named exactly 'Type'"*) missing_fields_result="warned" ;;
+  *) missing_fields_result="$missing_fields_stderr" ;;
+esac
+run_test "project_item_missing_named_fields_warns" "warned" "$missing_fields_result"
+
+reset_log
 invalid_item="$(workflow_github_project_item_for_issue "not-a-number" "1" 2>/dev/null)"
 run_test "invalid_issue_number_returns_empty" "" "$invalid_item"
 run_test "invalid_issue_number_avoids_graphql" "0" "$(count_log_matches 'api graphql')"
@@ -336,6 +356,24 @@ run_test "type_field_graphql_failure_no_cache" "" "$__workflow_project_type_fiel
 reset_log
 __workflow_project_type_field_cache_project_id=""
 __workflow_project_type_field_cache_json=""
+export MOCK_STATUS_FIELD_MODE=graphql_fail
+type_field_stderr=""
+type_field_stderr="$(workflow_github_project_type_field_json "PVT_project_1" 2>&1 >/dev/null)" || true
+unset MOCK_STATUS_FIELD_MODE
+case "$type_field_stderr" in
+  *"GraphQL project Type field lookup failed"* )
+    case "$type_field_stderr" in
+      *"GraphQL failure"*) type_field_stderr_result="$type_field_stderr" ;;
+      *) type_field_stderr_result="suppressed" ;;
+    esac
+    ;;
+  *) type_field_stderr_result="$type_field_stderr" ;;
+esac
+run_test "type_field_graphql_failure_suppresses_raw_gh_stderr" "suppressed" "$type_field_stderr_result"
+
+reset_log
+__workflow_project_type_field_cache_project_id=""
+__workflow_project_type_field_cache_json=""
 export MOCK_STATUS_FIELD_MODE=invalid_json
 type_update_output="$(update_tracker_type_best_effort 824 "Workflow" 2>&1)"
 unset MOCK_STATUS_FIELD_MODE
@@ -394,6 +432,44 @@ esac
 run_test "type_helpers_invalid_project_warns" "warned" "$invalid_project_guard_result"
 run_test "type_helpers_invalid_project_empty_list" "[]" "$(printf '%s' "$invalid_workflow_issues" | jq -c '.')"
 run_test "type_helpers_missing_invalid_project_avoids_api" "0" "$(count_log_matches 'api graphql|issue list|project item-list')"
+
+resolve_owner_from_remote() {
+  local remote_url="$1"
+  local tmp_repo owner
+  tmp_repo="$(mktemp -d)"
+  (
+    export MOCK_REPO_VIEW_MODE=fail
+    cd "$tmp_repo"
+    git init -q
+    git remote add origin "$remote_url"
+    owner="$(workflow_resolve_github_repo_owner 2>/dev/null)"
+    printf '%s' "$owner"
+  )
+  rm -rf "$tmp_repo"
+}
+
+resolve_repo_from_remote() {
+  local remote_url="$1"
+  local tmp_repo repo_name
+  tmp_repo="$(mktemp -d)"
+  (
+    export MOCK_REPO_VIEW_MODE=fail
+    cd "$tmp_repo"
+    git init -q
+    git remote add origin "$remote_url"
+    repo_name="$(workflow_resolve_github_repo_name 2>/dev/null)"
+    printf '%s' "$repo_name"
+  )
+  rm -rf "$tmp_repo"
+}
+
+reset_log
+run_test "remote_owner_https_fallback_validates_github_host" "lhpaul" "$(resolve_owner_from_remote "https://github.com/lhpaul/ai-dev-framework-template.git")"
+run_test "remote_repo_https_fallback_validates_github_host" "ai-dev-framework-template" "$(resolve_repo_from_remote "https://github.com/lhpaul/ai-dev-framework-template.git")"
+run_test "remote_owner_fallback_rejects_non_github_host" "" "$(resolve_owner_from_remote "https://github.com.evil/lhpaul/ai-dev-framework-template.git")"
+run_test "remote_repo_fallback_rejects_extra_path_segments" "" "$(resolve_repo_from_remote "https://github.com/lhpaul/ai-dev-framework-template/extra.git")"
+run_test "remote_owner_fallback_rejects_invalid_owner" "" "$(resolve_owner_from_remote "git@github.com:bad_owner/ai-dev-framework-template.git")"
+run_test "remote_repo_fallback_rejects_invalid_repo" "" "$(resolve_repo_from_remote "git@github.com:lhpaul/bad!repo.git")"
 
 reset_log
 workflow_github_project_item_for_issue() {

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -638,6 +638,36 @@ __workflow_project_status_field_cache_project_id=""
 __workflow_project_status_field_cache_json=""
 __workflow_project_type_field_cache_project_id=""
 __workflow_project_type_field_cache_json=""
+__workflow_last_gh_stdout=""
+__workflow_last_gh_stderr=""
+
+workflow_run_gh_capture_stderr() {
+  local stderr_file
+  __workflow_last_gh_stdout=""
+  __workflow_last_gh_stderr=""
+
+  if ! stderr_file="$(mktemp "${TMPDIR:-/tmp}/workflow-gh-stderr.XXXXXX")"; then
+    if __workflow_last_gh_stdout="$(gh "$@")"; then
+      return 0
+    fi
+    return 1
+  fi
+
+  if __workflow_last_gh_stdout="$(gh "$@" 2>"$stderr_file")"; then
+    rm -f "$stderr_file"
+    return 0
+  fi
+
+  __workflow_last_gh_stderr="$(cat "$stderr_file" 2>/dev/null || true)"
+  rm -f "$stderr_file"
+  return 1
+}
+
+workflow_print_captured_gh_stderr() {
+  if [ -n "$__workflow_last_gh_stderr" ]; then
+    printf '%s\n' "$__workflow_last_gh_stderr" | sed 's/^/  gh: /' >&2
+  fi
+}
 
 workflow_github_project_id() {
   local project_owner="$1"
@@ -778,11 +808,13 @@ workflow_github_project_item_for_issue() {
       '
     )
 
-    if ! response=$(gh "${graphql_args[@]}" 2>/dev/null); then
+    if ! workflow_run_gh_capture_stderr "${graphql_args[@]}"; then
       echo "Warning: GraphQL project item lookup failed for issue #${issue_number}; tracker status not read." >&2
+      workflow_print_captured_gh_stderr
       printf ''
       return 0
     fi
+    response="$__workflow_last_gh_stdout"
 
     if ! page_state="$(printf '%s' "$response" | python3 -c "
 import json, sys
@@ -913,11 +945,13 @@ workflow_github_project_status_field_json() {
         '
       )
 
-      if ! response=$(gh "${graphql_args[@]}" 2>/dev/null); then
+      if ! workflow_run_gh_capture_stderr "${graphql_args[@]}"; then
         echo "Warning: GraphQL project Status field lookup failed for project '${project_id}'." >&2
+        workflow_print_captured_gh_stderr
         printf ''
         return 0
       fi
+      response="$__workflow_last_gh_stdout"
 
       if ! page_state="$(printf '%s' "$response" | python3 -c "
 import json, sys
@@ -1031,11 +1065,13 @@ workflow_github_project_type_field_json() {
         '
       )
 
-      if ! response=$(gh "${graphql_args[@]}" 2>/dev/null); then
+      if ! workflow_run_gh_capture_stderr "${graphql_args[@]}"; then
         echo "Warning: GraphQL project Type field lookup failed for project '${project_id}'." >&2
+        workflow_print_captured_gh_stderr
         printf ''
         return 1
       fi
+      response="$__workflow_last_gh_stdout"
 
       if ! page_state="$(printf '%s' "$response" | python3 -c "
 import json, sys

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -390,23 +390,24 @@ workflow_resolve_github_repo_owner() {
     remote_url=""
   fi
   if [ -n "$remote_url" ]; then
+    local remote_path
+    remote_path=""
     case "$remote_url" in
-      https://*github.com/*)
-        owner="${remote_url#https://}"
-        owner="${owner#*@}"
-        owner="${owner#github.com/}"
-        owner="${owner%%/*}"
+      https://github.com/*)
+        remote_path="${remote_url#https://github.com/}"
+        ;;
+      https://*@github.com/*)
+        remote_path="${remote_url#https://*@github.com/}"
         ;;
       git@github.com:*)
-        owner="${remote_url#git@github.com:}"
-        owner="${owner%%/*}"
+        remote_path="${remote_url#git@github.com:}"
         ;;
       ssh://git@github.com/*)
-        owner="${remote_url#ssh://git@github.com/}"
-        owner="${owner%%/*}"
+        remote_path="${remote_url#ssh://git@github.com/}"
         ;;
     esac
-    if [ -n "$owner" ]; then
+    owner="${remote_path%%/*}"
+    if workflow_is_valid_github_owner "$owner" && workflow_remote_path_has_single_repo "$remote_path"; then
       printf '%s' "$owner"
       return 0
     fi
@@ -432,9 +433,25 @@ workflow_resolve_github_repo_name() {
     remote_url=""
   fi
   if [ -n "$remote_url" ]; then
-    repo_name="${remote_url##*/}"
-    repo_name="${repo_name%.git}"
-    if [ -n "$repo_name" ]; then
+    local remote_path path_remainder
+    remote_path=""
+    case "$remote_url" in
+      https://github.com/*)
+        remote_path="${remote_url#https://github.com/}"
+        ;;
+      https://*@github.com/*)
+        remote_path="${remote_url#https://*@github.com/}"
+        ;;
+      git@github.com:*)
+        remote_path="${remote_url#git@github.com:}"
+        ;;
+      ssh://git@github.com/*)
+        remote_path="${remote_url#ssh://git@github.com/}"
+        ;;
+    esac
+    path_remainder="${remote_path#*/}"
+    repo_name="${path_remainder%.git}"
+    if workflow_remote_path_has_single_repo "$remote_path" && workflow_is_valid_github_repo_name "$repo_name"; then
       printf '%s' "$repo_name"
       return 0
     fi
@@ -442,6 +459,53 @@ workflow_resolve_github_repo_name() {
 
   echo "Warning: could not resolve GitHub repository name from 'gh repo view' or git remote URL." >&2
   printf ''
+  return 0
+}
+
+workflow_remote_path_has_single_repo() {
+  local remote_path="$1"
+  local path_remainder
+
+  case "$remote_path" in
+    ''|*'?'*|*'#'*)
+      return 1
+      ;;
+  esac
+  case "$remote_path" in
+    */*)
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  path_remainder="${remote_path#*/}"
+  case "$path_remainder" in
+    ''|*/*)
+      return 1
+      ;;
+  esac
+
+  return 0
+}
+
+workflow_is_valid_github_owner() {
+  local owner="$1"
+  case "$owner" in
+    ''|-*|*-|*[!A-Za-z0-9-]*)
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+workflow_is_valid_github_repo_name() {
+  local repo_name="$1"
+  case "$repo_name" in
+    ''|'.'|'..'|*[!A-Za-z0-9._-]*)
+      return 1
+      ;;
+  esac
   return 0
 }
 
@@ -650,7 +714,7 @@ workflow_github_project_item_for_issue() {
   local issue_number="$1"
   local project_number="$2"
   local project_owner project_id repo_owner repo_name response
-  local cursor page_state item_json has_next end_cursor page_count line
+  local cursor page_state item_json has_next end_cursor page_count line missing_fields
   local -a graphql_args
 
   case "$issue_number" in
@@ -730,11 +794,18 @@ except Exception:
 issue = (((data.get('data') or {}).get('repository') or {}).get('issue') or {})
 project_items = issue.get('projectItems') or {}
 match = ''
+missing_fields = ''
 for item in project_items.get('nodes') or []:
     project = item.get('project') or {}
     if project.get('id') == project_id:
         status_value = item.get('status') or item.get('fieldValueByName') or {}
         type_value = item.get('type') or {}
+        missing = []
+        if not status_value.get('name'):
+            missing.append('Status')
+        if not type_value.get('name'):
+            missing.append('Type')
+        missing_fields = ','.join(missing)
         match = json.dumps({
             'item_id': item.get('id') or '',
             'project_id': project.get('id') or '',
@@ -746,6 +817,7 @@ page_info = project_items.get('pageInfo') or {}
 has_next = 'true' if page_info.get('hasNextPage') else 'false'
 end_cursor = page_info.get('endCursor') or ''
 print('ITEM=' + match)
+print('MISSING_FIELDS=' + missing_fields)
 print('HAS_NEXT=' + has_next)
 print('END_CURSOR=' + end_cursor)
 " "$project_id" 2>/dev/null)"; then
@@ -757,9 +829,11 @@ print('END_CURSOR=' + end_cursor)
     item_json=""
     has_next="false"
     end_cursor=""
+    missing_fields=""
     while IFS= read -r line; do
       case "$line" in
         ITEM=*) item_json="${line#ITEM=}" ;;
+        MISSING_FIELDS=*) missing_fields="${line#MISSING_FIELDS=}" ;;
         HAS_NEXT=*) has_next="${line#HAS_NEXT=}" ;;
         END_CURSOR=*) end_cursor="${line#END_CURSOR=}" ;;
       esac
@@ -767,6 +841,16 @@ print('END_CURSOR=' + end_cursor)
 $page_state
 EOF
     if [ -n "$item_json" ]; then
+      case ",$missing_fields," in
+        *",Status,"*)
+          echo "Warning: project item for issue #${issue_number} has no Status value. The workflow expects a single-select field named exactly 'Status'." >&2
+          ;;
+      esac
+      case ",$missing_fields," in
+        *",Type,"*)
+          echo "Warning: project item for issue #${issue_number} has no Type value. The workflow expects a single-select field named exactly 'Type'." >&2
+          ;;
+      esac
       printf '%s' "$item_json"
       return 0
     fi
@@ -947,7 +1031,7 @@ workflow_github_project_type_field_json() {
         '
       )
 
-      if ! response=$(gh "${graphql_args[@]}"); then
+      if ! response=$(gh "${graphql_args[@]}" 2>/dev/null); then
         echo "Warning: GraphQL project Type field lookup failed for project '${project_id}'." >&2
         printf ''
         return 1
@@ -975,7 +1059,7 @@ end_cursor = page_info.get('endCursor') or ''
 print('FIELD_JSON=' + field_json)
 print('HAS_NEXT=' + has_next)
 print('END_CURSOR=' + end_cursor)
-")"; then
+" 2>/dev/null)"; then
         echo "Warning: could not parse GraphQL project Type field response for project '${project_id}'." >&2
         printf ''
         return 1

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -672,7 +672,7 @@ workflow_print_captured_gh_stderr() {
 workflow_github_project_id() {
   local project_owner="$1"
   local project_number="$2"
-  local response project_id
+  local response project_id user_lookup_stderr org_lookup_stderr
 
   if [ -z "$project_owner" ] || [ -z "$project_number" ]; then
     printf ''
@@ -683,14 +683,19 @@ workflow_github_project_id() {
      [ "$__workflow_github_project_id_cache_number" != "$project_number" ] || \
      [ -z "$__workflow_github_project_id_cache_id" ]; then
     # shellcheck disable=SC2016 # GraphQL variables are expanded by GitHub, not by Bash.
-    response=$(gh api graphql \
+    if workflow_run_gh_capture_stderr api graphql \
       -f owner="$project_owner" \
       -F projectNumber="$project_number" \
       -f query='
         query($owner: String!, $projectNumber: Int!) {
           user(login: $owner) { projectV2(number: $projectNumber) { id } }
         }
-      ' 2>/dev/null || true)
+      '; then
+      response="$__workflow_last_gh_stdout"
+    else
+      user_lookup_stderr="$__workflow_last_gh_stderr"
+      response=""
+    fi
 
     project_id="$(printf '%s' "$response" | python3 -c "
 import json, sys
@@ -704,14 +709,19 @@ print(project.get('id') or '', end='')
 
     if [ -z "$project_id" ]; then
       # shellcheck disable=SC2016 # GraphQL variables are expanded by GitHub, not by Bash.
-      response=$(gh api graphql \
+      if workflow_run_gh_capture_stderr api graphql \
         -f owner="$project_owner" \
         -F projectNumber="$project_number" \
         -f query='
           query($owner: String!, $projectNumber: Int!) {
             organization(login: $owner) { projectV2(number: $projectNumber) { id } }
           }
-        ' 2>/dev/null || true)
+        '; then
+        response="$__workflow_last_gh_stdout"
+      else
+        org_lookup_stderr="$__workflow_last_gh_stderr"
+        response=""
+      fi
 
       project_id="$(printf '%s' "$response" | python3 -c "
 import json, sys
@@ -722,6 +732,16 @@ except Exception:
 project = ((data.get('data') or {}).get('organization') or {}).get('projectV2') or {}
 print(project.get('id') or '', end='')
 " 2>/dev/null || true)"
+    fi
+
+    if [ -z "$project_id" ] && { [ -n "${user_lookup_stderr:-}" ] || [ -n "${org_lookup_stderr:-}" ]; }; then
+      echo "Warning: GraphQL project ID lookup failed for project owner '${project_owner}' and project #${project_number}." >&2
+      if [ -n "${user_lookup_stderr:-}" ]; then
+        printf '%s\n' "$user_lookup_stderr" | sed 's/^/  gh user: /' >&2
+      fi
+      if [ -n "${org_lookup_stderr:-}" ]; then
+        printf '%s\n' "$org_lookup_stderr" | sed 's/^/  gh org: /' >&2
+      fi
     fi
 
     __workflow_github_project_id_cache_owner="$project_owner"
@@ -1368,7 +1388,7 @@ print(item.get('status') or '', end='')
 
   echo "Updating tracker status for issue #${issue_number} to '${status_label}'..."
   # shellcheck disable=SC2016 # GraphQL variables are expanded by GitHub, not by Bash.
-  if ! gh api graphql \
+  if workflow_run_gh_capture_stderr api graphql \
     -f projectId="$project_id" \
     -f itemId="$item_id" \
     -f fieldId="$field_id" \
@@ -1384,8 +1404,11 @@ print(item.get('status') or '', end='')
           projectV2Item { id }
         }
       }
-    ' 2>/dev/null; then
+    '; then
+    printf '%s' "$__workflow_last_gh_stdout"
+  else
     echo "Warning: GraphQL mutation failed for issue #${issue_number}; tracker status not updated."
+    workflow_print_captured_gh_stderr
   fi
 }
 
@@ -1464,7 +1487,7 @@ print((data.get('options') or {}).get(sys.argv[1]) or '', end='')
 
   echo "Updating tracker Type for issue #${issue_number} to '${type_label}'..."
   # shellcheck disable=SC2016 # GraphQL variables are expanded by GitHub, not by Bash.
-  if ! gh api graphql \
+  if workflow_run_gh_capture_stderr api graphql \
     -f projectId="$project_id" \
     -f itemId="$item_id" \
     -f fieldId="$field_id" \
@@ -1480,8 +1503,11 @@ print((data.get('options') or {}).get(sys.argv[1]) or '', end='')
           projectV2Item { id }
         }
       }
-    ' 2>/dev/null; then
+    '; then
+    printf '%s' "$__workflow_last_gh_stdout"
+  else
     echo "Warning: GraphQL mutation failed for issue #${issue_number}; tracker Type not updated."
+    workflow_print_captured_gh_stderr
   fi
 }
 

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -658,7 +658,13 @@ workflow_run_gh_capture_stderr() {
     return 0
   fi
 
-  __workflow_last_gh_stderr="$(cat "$stderr_file" 2>/dev/null || true)"
+  if [ -f "$stderr_file" ]; then
+    if ! __workflow_last_gh_stderr="$(cat "$stderr_file")"; then
+      __workflow_last_gh_stderr="could not read captured gh stderr file '${stderr_file}'"
+    fi
+  else
+    __workflow_last_gh_stderr="captured gh stderr file '${stderr_file}' is missing"
+  fi
   rm -f "$stderr_file"
   return 1
 }

--- a/sync-manifest.yaml
+++ b/sync-manifest.yaml
@@ -63,6 +63,9 @@ categories:
     - path: scripts/development-workflow/
       glob: "**/*"
       note: workflow helper scripts (state inspection, PR/CI loops, etc.)
+    - path: scripts/lint/
+      glob: "**/*"
+      note: lint helpers referenced by workflow protocols and best-practice docs
     - path: scripts/README.md
       note: purpose and usage of scripts in scripts/
     - path: docs/best-practices/1-general.md


### PR DESCRIPTION
## Summary

- Hardens GitHub Projects helper diagnostics for downstream template-sync usage:
  - suppresses raw `gh api graphql` stderr for Type field lookup failures, matching Status lookup behavior
  - warns explicitly when Project item lookups return no exact `Status` or `Type` single-select field value
  - validates fallback GitHub remote URL parsing before deriving owner/repo
- Adds `scripts/lint/` to `sync-manifest.yaml` always-sync coverage so workflow protocols do not sync references to absent lint helpers.
- Adds the `0.30.1` hotfix changelog section.

Closes #858
Closes #859

## Verification

- `bash -n scripts/development-workflow/workflow-lib.sh scripts/development-workflow/tests/test-workflow-lib-github-projects.sh scripts/lint/check-changelog-duplicate-headers.sh`
- `bash scripts/development-workflow/tests/test-workflow-lib-github-projects.sh` (67 passed, 0 failed)
- `shellcheck --severity=warning` on changed shell scripts
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `npx markdownlint-cli2 "CHANGELOG.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file("sync-manifest.yaml")'`

## Pre-Submission Self-Review Log

- Reviewed `git diff main...HEAD`; the diff is limited to `workflow-lib.sh`, its GitHub Projects test harness, `sync-manifest.yaml`, and `CHANGELOG.md`.
- Confirmed #858 coverage: Type lookup stderr is suppressed, missing exact Project field values now warn loudly, and fallback owner/repo parsing rejects non-GitHub hosts, invalid owners/repos, and extra path segments.
- Confirmed #859 coverage: `scripts/lint/` is now listed under `categories.always_sync`, matching protocol and best-practice references to lint helper scripts.
- Confirmed hotfix changelog placement: `0.30.1` appears directly below `[Unreleased]`, has one section header, and includes a link reference definition.
- No stale markers, unrelated files, or broad refactors were included.