### PR TITLE
fix(workflow): harden downstream sync helpers (hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.2] - 2026-06-08
+
+### Fixed
+
+- **Downstream sync hardening** (#862, #863) (hotfix): preserves canonical Codex skill precedence during legacy alias installation and avoids dynamic regex construction in Claude Code Action run polling.
+
 ## [0.30.1] - 2026-06-08
 
 ### Fixed
@@ -883,7 +889,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.30.1...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.30.2...HEAD
+[0.30.2]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.30.1...v0.30.2
 [0.30.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.29.1...v0.30.0
 [0.29.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.29.0...v0.29.1

--- a/scripts/development-workflow/claude-code-action-reviewer.sh
+++ b/scripts/development-workflow/claude-code-action-reviewer.sh
@@ -247,8 +247,8 @@ while [ "$TOTAL_ELAPSED" -lt "$MAX_WAIT" ]; do
   #   wrong PR's run. To fix this, claude-code-review.yml sets
   #   `run-name: "Claude Code Review — PR #${{ inputs.pr_number }}"`, and GitHub
   #   populates that string into the .name field on Runs API objects. The filter
-  #   below prefers name-scoped runs (where .name contains "PR #<pr>" with a
-  #   word-boundary guard) and falls back to timestamp-only selection when the
+  #   below prefers name-scoped runs whose parsed "PR #<number>" token equals
+  #   this PR number, and falls back to timestamp-only selection when the
   #   workflow has not yet been updated to include run-name (backward compatibility
   #   during the transition period after #808 is merged to the default branch).
   #   The timestamp filter remains as a secondary guard in the fallback path to
@@ -269,9 +269,9 @@ while [ "$TOTAL_ELAPSED" -lt "$MAX_WAIT" ]; do
          # prevent selecting the wrong PR'\''s run under concurrent/parallel dispatch.
          # Fall back to all candidates when no run has the "PR #N" pattern — backward
          # compat with pre-#808 deployments where the workflow has no run-name yet.
-         ([$candidates[] | select((.name // "") | test("PR #[0-9]+\\b"))] | length > 0) as $name_scoped |
+         ([$candidates[] | select((.name // "") | capture("PR #(?<pr>[0-9]+)(?:[^0-9]|$)")?)] | length > 0) as $name_scoped |
          ($candidates | if $name_scoped then
-           [.[] | select((.name // "") | test("PR #" + $pr + "\\b"))]
+           [.[] | select(((.name // "") | capture("PR #(?<pr>[0-9]+)(?:[^0-9]|$)")? | .pr) == $pr)]
          else . end) |
          sort_by(.created_at) | reverse | first |
          {status: .status, conclusion: .conclusion, html_url: .html_url, id: .id}' \

--- a/scripts/development-workflow/install-codex-skills.sh
+++ b/scripts/development-workflow/install-codex-skills.sh
@@ -18,6 +18,7 @@ install_skill_tree() {
   local source_dir="$1"
   local dest_root="$2"
   local label="$3"
+  local skip_existing_symlink="${4:-false}"
 
   [ -d "$source_dir" ] || return 0
 
@@ -35,6 +36,10 @@ install_skill_tree() {
       echo "Skipping $skill_name: $dest_path exists and is not a symlink"
       continue
     fi
+    if [ "$skip_existing_symlink" = "true" ] && [ -L "$dest_path" ]; then
+      echo "Skipping $skill_name: $dest_path already installed; preserving existing symlink ($label)"
+      continue
+    fi
 
     ln -sfn "$skill_dir" "$dest_path"
     echo "Installed $skill_name -> $dest_path ($label)"
@@ -43,4 +48,6 @@ install_skill_tree() {
 
 install_skill_tree "$REPO_SKILL_SOURCE_DIR" "$PRIMARY_DEST_ROOT" "repo"
 install_skill_tree "$LEGACY_SOURCE_DIR" "$LEGACY_DEST_ROOT" "legacy canonical"
-install_skill_tree "$REPO_SKILL_SOURCE_DIR" "$LEGACY_DEST_ROOT" "legacy aliases"
+# Legacy canonical skill definitions take precedence over command-style aliases
+# when both trees define the same skill name.
+install_skill_tree "$REPO_SKILL_SOURCE_DIR" "$LEGACY_DEST_ROOT" "legacy aliases" "true"

--- a/scripts/development-workflow/tests/test-claude-code-action-reviewer.sh
+++ b/scripts/development-workflow/tests/test-claude-code-action-reviewer.sh
@@ -48,9 +48,9 @@ RUN_POLL_FILTER='# Candidate set: workflow-file + timestamp match
          # prevent selecting the wrong PR'\''s run under concurrent/parallel dispatch.
          # Fall back to all candidates when no run has the "PR #N" pattern — backward
          # compat with pre-#808 deployments where the workflow has no run-name yet.
-         ([$candidates[] | select((.name // "") | test("PR #[0-9]+\\b"))] | length > 0) as $name_scoped |
+         ([$candidates[] | select((.name // "") | capture("PR #(?<pr>[0-9]+)(?:[^0-9]|$)")?)] | length > 0) as $name_scoped |
          ($candidates | if $name_scoped then
-           [.[] | select((.name // "") | test("PR #" + $pr + "\\b"))]
+           [.[] | select(((.name // "") | capture("PR #(?<pr>[0-9]+)(?:[^0-9]|$)")? | .pr) == $pr)]
          else . end) |
          sort_by(.created_at) | reverse | first |
          {status: .status, conclusion: .conclusion, html_url: .html_url, id: .id}'
@@ -234,6 +234,16 @@ _json='{"workflow_runs":[
 _result=$(run_filter "$_json" "claude-code-review.yml" "2026-06-02T15:59:00Z" "808")
 _id=$(printf '%s\n' "$_result" | jq -r '.id // "null"')
 run_test "pr_number_word_boundary_no_false_match" "null" "$_id"
+unset _json _result _id
+
+# Test 5.4b: Dynamic PR input is compared as data, not interpolated as regex.
+_json='{"workflow_runs":[
+  {"path":".github/workflows/claude-code-review.yml","name":"Claude Code Review — PR #999","created_at":"2026-06-02T16:01:00Z","status":"completed","conclusion":"success","html_url":"https://a","id":999},
+  {"path":".github/workflows/claude-code-review.yml","name":"Claude Code Review — PR #808","created_at":"2026-06-02T16:00:00Z","status":"completed","conclusion":"success","html_url":"https://b","id":808}
+]}'
+_result=$(run_filter "$_json" "claude-code-review.yml" "2026-06-02T15:59:00Z" "808|999")
+_id=$(printf '%s\n' "$_result" | jq -r '.id // "null"')
+run_test "pr_input_regex_metacharacters_are_literal" "null" "$_id"
 unset _json _result _id
 
 # Test 5.5: Two runs for THIS PR in the same window — most recent selected

--- a/scripts/development-workflow/tests/test-install-codex-skills.sh
+++ b/scripts/development-workflow/tests/test-install-codex-skills.sh
@@ -3,6 +3,7 @@
 #
 # Exercises the highest-risk installer behavior:
 #   1. Three-pass ordering: repo skills -> legacy canonical -> legacy aliases
+#      with canonical legacy symlinks preserved on name collision
 #   2. Skip rules: existing non-symlink destinations are not overwritten
 #   3. Source-directory validation: missing .agents/skills fails clearly
 #
@@ -109,6 +110,12 @@ run_test "legacy_run_work_alias_symlink" "yes" "$(
 run_test "legacy_workflow_canonical_symlink" "yes" "$(
   [ -L "$codex_home/skills/workflow-orchestrator" ] && echo yes || echo no
 )"
+run_test "legacy_collision_preserves_canonical" "$fixture/.codex/skills/workflow-orchestrator" "$(
+  readlink "$codex_home/skills/workflow-orchestrator"
+)"
+run_test "legacy_alias_collision_skip_message" "yes" "$(
+  grep -q 'Skipping workflow-orchestrator: .*preserving existing symlink (legacy aliases)' "$output_file" && echo yes || echo no
+)"
 
 order_actual="$(
   awk '
@@ -178,16 +185,20 @@ AGENTS_HOME="$agents_home" CODEX_HOME="$codex_home" \
 
 while IFS= read -r alias_name; do
   [ -n "$alias_name" ] || continue
-  expected_target="$REPO_ROOT/.agents/skills/$alias_name"
+  primary_expected_target="$REPO_ROOT/.agents/skills/$alias_name"
+  legacy_expected_target="$REPO_ROOT/.agents/skills/$alias_name"
+  if [ -e "$REPO_ROOT/.codex/skills/$alias_name" ]; then
+    legacy_expected_target="$REPO_ROOT/.codex/skills/$alias_name"
+  fi
 
   assert_skill_link \
     "primary_alias_${alias_name}" \
     "$agents_home/skills/$alias_name" \
-    "$expected_target"
+    "$primary_expected_target"
   assert_skill_link \
     "legacy_alias_${alias_name}" \
     "$codex_home/skills/$alias_name" \
-    "$expected_target"
+    "$legacy_expected_target"
 done <<'ALIASES'
 add-backlog-item
 batch-merge
@@ -204,16 +215,20 @@ ALIASES
 
 while IFS= read -r workflow_name; do
   [ -n "$workflow_name" ] || continue
-  expected_target="$REPO_ROOT/.agents/skills/$workflow_name"
+  primary_expected_target="$REPO_ROOT/.agents/skills/$workflow_name"
+  legacy_expected_target="$REPO_ROOT/.agents/skills/$workflow_name"
+  if [ -e "$REPO_ROOT/.codex/skills/$workflow_name" ]; then
+    legacy_expected_target="$REPO_ROOT/.codex/skills/$workflow_name"
+  fi
 
   assert_skill_link \
     "primary_workflow_${workflow_name}" \
     "$agents_home/skills/$workflow_name" \
-    "$expected_target"
+    "$primary_expected_target"
   assert_skill_link \
     "legacy_workflow_${workflow_name}" \
     "$codex_home/skills/$workflow_name" \
-    "$expected_target"
+    "$legacy_expected_target"
 done <<'WORKFLOW_SKILLS'
 workflow-code-reviewer
 workflow-implementer


### PR DESCRIPTION
## Summary

- Preserves canonical `.codex/skills/` symlinks when installing repo aliases into the legacy Codex destination, so canonical definitions win on name collision.
- Updates Claude Code Action run polling to parse the `PR #<number>` run-name token and compare it as data instead of interpolating `$pr` into a regex.
- Adds the `0.30.2` hotfix changelog section.

Closes #862
Closes #863

## Verification

- `bash -n scripts/development-workflow/install-codex-skills.sh scripts/development-workflow/claude-code-action-reviewer.sh scripts/development-workflow/tests/test-install-codex-skills.sh scripts/development-workflow/tests/test-claude-code-action-reviewer.sh`
- `bash scripts/development-workflow/tests/test-install-codex-skills.sh` (195 passed, 0 failed)
- `bash scripts/development-workflow/tests/test-claude-code-action-reviewer.sh` (21 passed, 0 failed)
- `shellcheck --severity=warning` on changed shell scripts
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `npx markdownlint-cli2 "CHANGELOG.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `git diff --check`

## Pre-Submission Self-Review Log

- Reviewed `git diff main...HEAD`; the diff is limited to the two downstream sync findings, their focused tests, and the hotfix changelog section.
- Confirmed #862 coverage: legacy alias installation now skips an existing legacy symlink so canonical `.codex/skills/` entries keep precedence on collisions.
- Confirmed #863 coverage: jq now extracts a numeric `PR #<number>` token and compares it to `$pr`; a regression test verifies regex metacharacters in `$pr` are treated literally.
- Confirmed hotfix changelog placement: `0.30.2` appears directly below `[Unreleased]`, has one section header, and includes a link reference definition.
- No unrelated refactors or stale workflow markers were included.