### PR TITLE
fix(review): prevent Claude no-op approvals

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,3 +53,6 @@ jobs:
           # Set the secret in GitHub repo settings → Secrets → Actions before
           # triggering this workflow.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ inputs.pr_number }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Claude Code Action reviewer no-op guard** (#866): passes an explicit code-review prompt to the workflow and fails closed when a successful run log shows Claude did not actually execute.
+
 ## [0.30.2] - 2026-06-08
 
 ### Fixed

--- a/scripts/development-workflow/claude-code-action-reviewer.sh
+++ b/scripts/development-workflow/claude-code-action-reviewer.sh
@@ -36,6 +36,88 @@
 
 set -euo pipefail
 
+# Defaults (overridable by flags or env vars)
+WORKFLOW_FILE="${CLAUDE_CODE_ACTION_WORKFLOW_FILE:-claude-code-review.yml}"
+BOT_LOGIN="${CLAUDE_CODE_ACTION_BOT_LOGIN:-claude[bot]}"
+POLL_INTERVAL=30
+MAX_WAIT=600
+
+classify_claude_code_action_log() {
+  local log_file="$1"
+
+  if grep -Eqi 'Context prompt: NO PROMPT|Trigger result: false|No trigger found, skipping remaining steps|"prompt": ""' "$log_file"; then
+    printf '%s\n' noop
+    return 1
+  fi
+
+  if grep -Eqi 'Trigger result: true|Context prompt: .+' "$log_file" \
+    && ! grep -Eqi 'Context prompt: NO PROMPT' "$log_file"; then
+    printf '%s\n' ran
+    return 0
+  fi
+
+  printf '%s\n' unknown
+  return 2
+}
+
+verify_claude_code_action_run_log() {
+  local run_id="$1"
+  local owner="$2"
+  local repo="$3"
+  local run_log_stderr run_log_tmpfile run_log_status run_log_err
+  local log_classification log_classification_status
+
+  if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+    echo "VERDICT: UNAVAILABLE — run succeeded but no run id was available for log verification"
+    return 3
+  fi
+
+  run_log_stderr="$(mktemp)" || {
+    echo "VERDICT: UNAVAILABLE — could not create temp file for Actions log stderr" >&2
+    return 3
+  }
+  run_log_tmpfile="$(mktemp)" || {
+    rm -f "$run_log_stderr"
+    echo "VERDICT: UNAVAILABLE — could not create temp file for Actions run log" >&2
+    return 3
+  }
+  run_log_status=0
+  gh run view "$run_id" --repo "$owner/$repo" --log \
+    >"$run_log_tmpfile" 2>"$run_log_stderr" || run_log_status=$?
+
+  if [ "$run_log_status" -ne 0 ]; then
+    run_log_err=$(cat "$run_log_stderr")
+    rm -f "$run_log_stderr" "$run_log_tmpfile"
+    echo "WARNING: could not fetch Actions run log (exit $run_log_status): $run_log_err" >&2
+    echo "VERDICT: UNAVAILABLE — run succeeded but log verification failed"
+    return 3
+  fi
+  rm -f "$run_log_stderr"
+
+  log_classification_status=0
+  log_classification="$(classify_claude_code_action_log "$run_log_tmpfile")" || log_classification_status=$?
+  rm -f "$run_log_tmpfile"
+
+  case "$log_classification_status" in
+    0)
+      echo "INFO: Claude Code Action log verification passed ($log_classification)"
+      return 0
+      ;;
+    1)
+      echo "VERDICT: UNAVAILABLE — Claude Code Action run completed without executing a review ($log_classification)"
+      return 3
+      ;;
+    *)
+      echo "VERDICT: UNAVAILABLE — Claude Code Action run log did not contain a positive execution marker ($log_classification)"
+      return 3
+      ;;
+  esac
+}
+
+if [ "${CLAUDE_CODE_ACTION_REVIEWER_LIBRARY_MODE:-0}" = "1" ]; then
+  return 0 2>/dev/null || exit 0
+fi
+
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 if [ $# -lt 3 ]; then
@@ -71,30 +153,6 @@ case "$REPO" in
     exit 2
     ;;
 esac
-
-# Defaults (overridable by flags or env vars)
-WORKFLOW_FILE="${CLAUDE_CODE_ACTION_WORKFLOW_FILE:-claude-code-review.yml}"
-BOT_LOGIN="${CLAUDE_CODE_ACTION_BOT_LOGIN:-claude[bot]}"
-POLL_INTERVAL=30
-MAX_WAIT=600
-
-classify_claude_code_action_log() {
-  local log_file="$1"
-
-  if grep -Eqi 'Context prompt: NO PROMPT|Trigger result: false|No trigger found, skipping remaining steps|"prompt": ""' "$log_file"; then
-    printf '%s\n' noop
-    return 1
-  fi
-
-  if grep -Eqi 'Trigger result: true|Context prompt: .+' "$log_file" \
-    && ! grep -Eqi 'Context prompt: NO PROMPT' "$log_file"; then
-    printf '%s\n' ran
-    return 0
-  fi
-
-  printf '%s\n' unknown
-  return 2
-}
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -356,43 +414,7 @@ echo "INFO: Actions run completed with conclusion=success: $RUN_URL"
 # claude-code-action exits successfully when no prompt/trigger is present, logging
 # "No trigger found" and posting no review. Treat that as unavailable rather than
 # clean so the reviewer loop does not bless no-op runs.
-if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
-  echo "VERDICT: UNAVAILABLE — run succeeded but no run id was available for log verification"
-  exit 3
-fi
-
-RUN_LOG_STDERR=$(mktemp)
-RUN_LOG_TMPFILE=$(mktemp)
-RUN_LOG_STATUS=0
-gh run view "$RUN_ID" --repo "$OWNER/$REPO" --log \
-  >"$RUN_LOG_TMPFILE" 2>"$RUN_LOG_STDERR" || RUN_LOG_STATUS=$?
-
-if [ "$RUN_LOG_STATUS" -ne 0 ]; then
-  RUN_LOG_ERR=$(cat "$RUN_LOG_STDERR")
-  rm -f "$RUN_LOG_STDERR" "$RUN_LOG_TMPFILE"
-  echo "WARNING: could not fetch Actions run log (exit $RUN_LOG_STATUS): $RUN_LOG_ERR" >&2
-  echo "VERDICT: UNAVAILABLE — run succeeded but log verification failed"
-  exit 3
-fi
-rm -f "$RUN_LOG_STDERR"
-
-LOG_CLASSIFICATION_STATUS=0
-LOG_CLASSIFICATION="$(classify_claude_code_action_log "$RUN_LOG_TMPFILE")" || LOG_CLASSIFICATION_STATUS=$?
-rm -f "$RUN_LOG_TMPFILE"
-
-case "$LOG_CLASSIFICATION_STATUS" in
-  0)
-    echo "INFO: Claude Code Action log verification passed ($LOG_CLASSIFICATION)"
-    ;;
-  1)
-    echo "VERDICT: UNAVAILABLE — Claude Code Action run completed without executing a review ($LOG_CLASSIFICATION)"
-    exit 3
-    ;;
-  *)
-    echo "VERDICT: UNAVAILABLE — Claude Code Action run log did not contain a positive execution marker ($LOG_CLASSIFICATION)"
-    exit 3
-    ;;
-esac
+verify_claude_code_action_run_log "$RUN_ID" "$OWNER" "$REPO" || exit $?
 
 # ── Phase 3 (continued): Check PR review threads ──────────────────────────────
 # After a successful run, inspect PR reviews posted by the bot after dispatch_time.

--- a/scripts/development-workflow/claude-code-action-reviewer.sh
+++ b/scripts/development-workflow/claude-code-action-reviewer.sh
@@ -78,6 +78,24 @@ BOT_LOGIN="${CLAUDE_CODE_ACTION_BOT_LOGIN:-claude[bot]}"
 POLL_INTERVAL=30
 MAX_WAIT=600
 
+classify_claude_code_action_log() {
+  local log_file="$1"
+
+  if grep -Eqi 'Context prompt: NO PROMPT|Trigger result: false|No trigger found, skipping remaining steps|"prompt": ""' "$log_file"; then
+    printf '%s\n' noop
+    return 1
+  fi
+
+  if grep -Eqi 'Trigger result: true|Context prompt: .+' "$log_file" \
+    && ! grep -Eqi 'Context prompt: NO PROMPT' "$log_file"; then
+    printf '%s\n' ran
+    return 0
+  fi
+
+  printf '%s\n' unknown
+  return 2
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --workflow-file)
@@ -333,6 +351,48 @@ if [ "$RUN_CONCLUSION" != "success" ]; then
 fi
 
 echo "INFO: Actions run completed with conclusion=success: $RUN_URL"
+
+# A successful Actions run is not proof that Claude actually reviewed the PR.
+# claude-code-action exits successfully when no prompt/trigger is present, logging
+# "No trigger found" and posting no review. Treat that as unavailable rather than
+# clean so the reviewer loop does not bless no-op runs.
+if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+  echo "VERDICT: UNAVAILABLE — run succeeded but no run id was available for log verification"
+  exit 3
+fi
+
+RUN_LOG_STDERR=$(mktemp)
+RUN_LOG_TMPFILE=$(mktemp)
+RUN_LOG_STATUS=0
+gh run view "$RUN_ID" --repo "$OWNER/$REPO" --log \
+  >"$RUN_LOG_TMPFILE" 2>"$RUN_LOG_STDERR" || RUN_LOG_STATUS=$?
+
+if [ "$RUN_LOG_STATUS" -ne 0 ]; then
+  RUN_LOG_ERR=$(cat "$RUN_LOG_STDERR")
+  rm -f "$RUN_LOG_STDERR" "$RUN_LOG_TMPFILE"
+  echo "WARNING: could not fetch Actions run log (exit $RUN_LOG_STATUS): $RUN_LOG_ERR" >&2
+  echo "VERDICT: UNAVAILABLE — run succeeded but log verification failed"
+  exit 3
+fi
+rm -f "$RUN_LOG_STDERR"
+
+LOG_CLASSIFICATION_STATUS=0
+LOG_CLASSIFICATION="$(classify_claude_code_action_log "$RUN_LOG_TMPFILE")" || LOG_CLASSIFICATION_STATUS=$?
+rm -f "$RUN_LOG_TMPFILE"
+
+case "$LOG_CLASSIFICATION_STATUS" in
+  0)
+    echo "INFO: Claude Code Action log verification passed ($LOG_CLASSIFICATION)"
+    ;;
+  1)
+    echo "VERDICT: UNAVAILABLE — Claude Code Action run completed without executing a review ($LOG_CLASSIFICATION)"
+    exit 3
+    ;;
+  *)
+    echo "VERDICT: UNAVAILABLE — Claude Code Action run log did not contain a positive execution marker ($LOG_CLASSIFICATION)"
+    exit 3
+    ;;
+esac
 
 # ── Phase 3 (continued): Check PR review threads ──────────────────────────────
 # After a successful run, inspect PR reviews posted by the bot after dispatch_time.

--- a/scripts/development-workflow/tests/test-claude-code-action-reviewer.sh
+++ b/scripts/development-workflow/tests/test-claude-code-action-reviewer.sh
@@ -65,6 +65,24 @@ run_filter() {
     "$RUN_POLL_FILTER"
 }
 
+classify_log_fixture() {
+  local log_file="$1"
+
+  if grep -Eqi 'Context prompt: NO PROMPT|Trigger result: false|No trigger found, skipping remaining steps|"prompt": ""' "$log_file"; then
+    printf '%s\n' noop
+    return 1
+  fi
+
+  if grep -Eqi 'Trigger result: true|Context prompt: .+' "$log_file" \
+    && ! grep -Eqi 'Context prompt: NO PROMPT' "$log_file"; then
+    printf '%s\n' ran
+    return 0
+  fi
+
+  printf '%s\n' unknown
+  return 2
+}
+
 # ---------------------------------------------------------------------------
 # Area 1: Basic timestamp filtering
 # Run objects include "name" matching the dispatched PR (808) so they pass the
@@ -321,6 +339,72 @@ _iso="$(_epoch_to_iso_with_python_fallback 1700000000)"
 run_test "python_fallback_epoch_to_iso" "2023-11-14T22:13:20Z" "$_iso"
 rm -rf "$_date_mock_dir"
 unset _date_mock_dir _iso
+
+# ---------------------------------------------------------------------------
+# Area 7: Claude Code Action log execution verification
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 7: action log execution verification ==="
+
+_log_tmp="$(mktemp)"
+cat > "$_log_tmp" <<'LOG'
+Claude Code Action review	UNKNOWN STEP	Context prompt: NO PROMPT
+Claude Code Action review	UNKNOWN STEP	Trigger result: false
+Claude Code Action review	UNKNOWN STEP	No trigger found, skipping remaining steps
+LOG
+_status=0
+_classification="$(classify_log_fixture "$_log_tmp")" || _status=$?
+run_test "noop_log_is_not_clean_status" "1" "$_status"
+run_test "noop_log_is_classified_noop" "noop" "$_classification"
+rm -f "$_log_tmp"
+unset _log_tmp _status _classification
+
+_log_tmp="$(mktemp)"
+cat > "$_log_tmp" <<'LOG'
+Claude Code Action review	UNKNOWN STEP	Context prompt: /code-review:code-review lhpaul/ai-dev-framework-template/pull/866
+Claude Code Action review	UNKNOWN STEP	Trigger result: true
+LOG
+_status=0
+_classification="$(classify_log_fixture "$_log_tmp")" || _status=$?
+run_test "executed_log_is_clean_status" "0" "$_status"
+run_test "executed_log_is_classified_ran" "ran" "$_classification"
+rm -f "$_log_tmp"
+unset _log_tmp _status _classification
+
+_log_tmp="$(mktemp)"
+cat > "$_log_tmp" <<'LOG'
+Claude Code Action review	UNKNOWN STEP	Mode: agent
+Claude Code Action review	UNKNOWN STEP	App token successfully obtained
+LOG
+_status=0
+_classification="$(classify_log_fixture "$_log_tmp")" || _status=$?
+run_test "unknown_log_is_not_clean_status" "2" "$_status"
+run_test "unknown_log_is_classified_unknown" "unknown" "$_classification"
+rm -f "$_log_tmp"
+unset _log_tmp _status _classification
+
+# ---------------------------------------------------------------------------
+# Area 8: workflow automation prompt configuration
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 8: workflow prompt configuration ==="
+
+_workflow_file=".github/workflows/claude-code-review.yml"
+# shellcheck disable=SC2016 # Literal GitHub expression expected in workflow YAML.
+if grep -q 'prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ inputs.pr_number }}"' "$_workflow_file"; then
+  _has_prompt=1
+else
+  _has_prompt=0
+fi
+run_test "workflow_has_explicit_code_review_prompt" "1" "$_has_prompt"
+
+if grep -q 'plugins: "code-review@claude-code-plugins"' "$_workflow_file"; then
+  _has_plugin=1
+else
+  _has_plugin=0
+fi
+run_test "workflow_has_code_review_plugin" "1" "$_has_plugin"
+unset _workflow_file _has_prompt _has_plugin
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/development-workflow/tests/test-claude-code-action-reviewer.sh
+++ b/scripts/development-workflow/tests/test-claude-code-action-reviewer.sh
@@ -35,6 +35,12 @@ run_test() {
   fi
 }
 
+REVIEWER_SCRIPT="scripts/development-workflow/claude-code-action-reviewer.sh"
+CLAUDE_CODE_ACTION_REVIEWER_LIBRARY_MODE=1
+# shellcheck source=scripts/development-workflow/claude-code-action-reviewer.sh
+source "$REVIEWER_SCRIPT"
+unset CLAUDE_CODE_ACTION_REVIEWER_LIBRARY_MODE
+
 # ---------------------------------------------------------------------------
 # The run-poll jq filter (extracted verbatim from claude-code-action-reviewer.sh)
 # Arguments: $wf (workflow filename suffix), $poll_after (ISO8601 timestamp),
@@ -63,24 +69,6 @@ run_filter() {
     --arg poll_after "$poll_after" \
     --arg pr "$pr" \
     "$RUN_POLL_FILTER"
-}
-
-classify_log_fixture() {
-  local log_file="$1"
-
-  if grep -Eqi 'Context prompt: NO PROMPT|Trigger result: false|No trigger found, skipping remaining steps|"prompt": ""' "$log_file"; then
-    printf '%s\n' noop
-    return 1
-  fi
-
-  if grep -Eqi 'Trigger result: true|Context prompt: .+' "$log_file" \
-    && ! grep -Eqi 'Context prompt: NO PROMPT' "$log_file"; then
-    printf '%s\n' ran
-    return 0
-  fi
-
-  printf '%s\n' unknown
-  return 2
 }
 
 # ---------------------------------------------------------------------------
@@ -346,42 +334,73 @@ unset _date_mock_dir _iso
 echo ""
 echo "=== Area 7: action log execution verification ==="
 
-_log_tmp="$(mktemp)"
+_log_tmp="$(mktemp)" || { echo "ERROR: mktemp failed" >&2; exit 1; }
 cat > "$_log_tmp" <<'LOG'
 Claude Code Action review	UNKNOWN STEP	Context prompt: NO PROMPT
 Claude Code Action review	UNKNOWN STEP	Trigger result: false
 Claude Code Action review	UNKNOWN STEP	No trigger found, skipping remaining steps
 LOG
 _status=0
-_classification="$(classify_log_fixture "$_log_tmp")" || _status=$?
+_classification="$(classify_claude_code_action_log "$_log_tmp")" || _status=$?
 run_test "noop_log_is_not_clean_status" "1" "$_status"
 run_test "noop_log_is_classified_noop" "noop" "$_classification"
 rm -f "$_log_tmp"
 unset _log_tmp _status _classification
 
-_log_tmp="$(mktemp)"
+_log_tmp="$(mktemp)" || { echo "ERROR: mktemp failed" >&2; exit 1; }
 cat > "$_log_tmp" <<'LOG'
 Claude Code Action review	UNKNOWN STEP	Context prompt: /code-review:code-review lhpaul/ai-dev-framework-template/pull/866
 Claude Code Action review	UNKNOWN STEP	Trigger result: true
 LOG
 _status=0
-_classification="$(classify_log_fixture "$_log_tmp")" || _status=$?
+_classification="$(classify_claude_code_action_log "$_log_tmp")" || _status=$?
 run_test "executed_log_is_clean_status" "0" "$_status"
 run_test "executed_log_is_classified_ran" "ran" "$_classification"
 rm -f "$_log_tmp"
 unset _log_tmp _status _classification
 
-_log_tmp="$(mktemp)"
+_log_tmp="$(mktemp)" || { echo "ERROR: mktemp failed" >&2; exit 1; }
 cat > "$_log_tmp" <<'LOG'
 Claude Code Action review	UNKNOWN STEP	Mode: agent
 Claude Code Action review	UNKNOWN STEP	App token successfully obtained
 LOG
 _status=0
-_classification="$(classify_log_fixture "$_log_tmp")" || _status=$?
+_classification="$(classify_claude_code_action_log "$_log_tmp")" || _status=$?
 run_test "unknown_log_is_not_clean_status" "2" "$_status"
 run_test "unknown_log_is_classified_unknown" "unknown" "$_classification"
 rm -f "$_log_tmp"
 unset _log_tmp _status _classification
+
+_status=0
+_output="$(verify_claude_code_action_run_log "" "owner" "repo" 2>&1)" || _status=$?
+run_test "missing_run_id_returns_unavailable" "3" "$_status"
+case "$_output" in
+  *"no run id was available"*) _message_found=1 ;;
+  *) _message_found=0 ;;
+esac
+run_test "missing_run_id_message" "1" "$_message_found"
+unset _status _output _message_found
+
+_gh_mock_dir="$(mktemp -d)" || { echo "ERROR: mktemp -d failed" >&2; exit 1; }
+cat > "$_gh_mock_dir/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+echo "mock gh failure" >&2
+exit 1
+MOCK_GH
+chmod +x "$_gh_mock_dir/gh"
+_old_path="$PATH"
+PATH="$_gh_mock_dir:$PATH"
+_status=0
+_output="$(verify_claude_code_action_run_log "123" "owner" "repo" 2>&1)" || _status=$?
+PATH="$_old_path"
+run_test "gh_run_view_failure_returns_unavailable" "3" "$_status"
+case "$_output" in
+  *"log verification failed"*) _message_found=1 ;;
+  *) _message_found=0 ;;
+esac
+run_test "gh_run_view_failure_message" "1" "$_message_found"
+rm -rf "$_gh_mock_dir"
+unset _gh_mock_dir _old_path _status _output _message_found
 
 # ---------------------------------------------------------------------------
 # Area 8: workflow automation prompt configuration

--- a/scripts/development-workflow/tests/test-claude-code-action-reviewer.sh
+++ b/scripts/development-workflow/tests/test-claude-code-action-reviewer.sh
@@ -402,6 +402,85 @@ run_test "gh_run_view_failure_message" "1" "$_message_found"
 rm -rf "$_gh_mock_dir"
 unset _gh_mock_dir _old_path _status _output _message_found
 
+_gh_mock_dir="$(mktemp -d)" || { echo "ERROR: mktemp -d failed" >&2; exit 1; }
+cat > "$_gh_mock_dir/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+case "$3" in
+  200)
+    echo 'Claude Code Action review	UNKNOWN STEP	Context prompt: /code-review:code-review owner/repo/pull/1'
+    echo 'Claude Code Action review	UNKNOWN STEP	Trigger result: true'
+    ;;
+  201)
+    echo 'Claude Code Action review	UNKNOWN STEP	Context prompt: NO PROMPT'
+    echo 'Claude Code Action review	UNKNOWN STEP	Trigger result: false'
+    ;;
+  202)
+    echo 'Claude Code Action review	UNKNOWN STEP	Mode: agent'
+    echo 'Claude Code Action review	UNKNOWN STEP	App token successfully obtained'
+    ;;
+  *)
+    echo "unexpected run id: $3" >&2
+    exit 1
+    ;;
+esac
+MOCK_GH
+chmod +x "$_gh_mock_dir/gh"
+_old_path="$PATH"
+PATH="$_gh_mock_dir:$PATH"
+
+_status=0
+_output="$(verify_claude_code_action_run_log "200" "owner" "repo" 2>&1)" || _status=$?
+run_test "verify_run_log_executed_returns_clean" "0" "$_status"
+case "$_output" in
+  *"log verification passed (ran)"*) _message_found=1 ;;
+  *) _message_found=0 ;;
+esac
+run_test "verify_run_log_executed_message" "1" "$_message_found"
+unset _status _output _message_found
+
+_status=0
+_output="$(verify_claude_code_action_run_log "201" "owner" "repo" 2>&1)" || _status=$?
+run_test "verify_run_log_noop_returns_unavailable" "3" "$_status"
+case "$_output" in
+  *"without executing a review (noop)"*) _message_found=1 ;;
+  *) _message_found=0 ;;
+esac
+run_test "verify_run_log_noop_message" "1" "$_message_found"
+unset _status _output _message_found
+
+_status=0
+_output="$(verify_claude_code_action_run_log "202" "owner" "repo" 2>&1)" || _status=$?
+PATH="$_old_path"
+run_test "verify_run_log_unknown_returns_unavailable" "3" "$_status"
+case "$_output" in
+  *"did not contain a positive execution marker (unknown)"*) _message_found=1 ;;
+  *) _message_found=0 ;;
+esac
+run_test "verify_run_log_unknown_message" "1" "$_message_found"
+rm -rf "$_gh_mock_dir"
+unset _gh_mock_dir _old_path _status _output _message_found
+
+_mktemp_mock_dir="$(mktemp -d)" || { echo "ERROR: mktemp -d failed" >&2; exit 1; }
+cat > "$_mktemp_mock_dir/mktemp" <<'MOCK_MKTEMP'
+#!/usr/bin/env bash
+echo "mktemp unavailable" >&2
+exit 1
+MOCK_MKTEMP
+chmod +x "$_mktemp_mock_dir/mktemp"
+_old_path="$PATH"
+PATH="$_mktemp_mock_dir:$PATH"
+_status=0
+_output="$(verify_claude_code_action_run_log "203" "owner" "repo" 2>&1)" || _status=$?
+PATH="$_old_path"
+run_test "verify_run_log_mktemp_failure_returns_unavailable" "3" "$_status"
+case "$_output" in
+  *"could not create temp file"*) _message_found=1 ;;
+  *) _message_found=0 ;;
+esac
+run_test "verify_run_log_mktemp_failure_message" "1" "$_message_found"
+rm -rf "$_mktemp_mock_dir"
+unset _mktemp_mock_dir _old_path _status _output _message_found
+
 # ---------------------------------------------------------------------------
 # Area 8: workflow automation prompt configuration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- configure the Claude Code Action workflow with the official code-review plugin and an explicit PR review prompt
- verify completed Claude Action logs before accepting a successful run as clean
- add regression coverage for no-op logs, positive execution markers, missing run ids, log-fetch failures, and verifier wrapper outcomes

## Validation

- `bash scripts/development-workflow/tests/test-claude-code-action-reviewer.sh` — 41 passed, 0 failed
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` — 139 passed, 0 failed
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md` — passed
- `npx markdownlint-cli2 "CHANGELOG.md"` — 0 errors
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop` — passed
- `shellcheck --severity=warning scripts/development-workflow/claude-code-action-reviewer.sh scripts/development-workflow/tests/test-claude-code-action-reviewer.sh` — passed
- `git diff --check` — passed

## Pre-Submission Self-Review

- Reviewed the working-tree diff before commit; changes are limited to the Claude Action workflow, its reviewer wrapper, the targeted test harness, and CHANGELOG.
- Confirmed the workflow has an explicit permissions block, pinned action SHA, and existing per-PR concurrency; this change only adds action inputs.
- Confirmed the wrapper no longer treats a successful no-op action run as approval; no-op and unknown logs return unavailable/non-clean.
- Confirmed the issue body acceptance criteria are covered by implementation and tests.

Closes #866