### PR TITLE
fix(workflow): document tool-fix merge ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Claude Code Action reviewer no-op guard** (#866): passes an explicit code-review prompt to the workflow and fails closed when a successful run log shows Claude did not actually execute.
+- **Tool-fix merge ordering** (#825): documents that foundational reviewer-tool fixes must merge before dependent tool-fixes are trusted, and that dependents must update from the fixed base before rerunning reviewer loops.
 
 ## [0.30.2] - 2026-06-08
 

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -527,6 +527,40 @@ item is dispatched. The ordering among multiple tool-fix items follows the stand
 order — due date within 2 weeks (earliest first), then priority (Urgent → High → Normal → Low),
 then creation date (earliest first) — mirroring the Step 2 priority rules.
 
+#### Foundational reviewer-tool merge ordering
+
+Dispatch serialization alone is not enough when one tool-fix repairs reviewer-loop or
+reviewer-action behavior that another same-batch tool-fix needs in order to trust its own
+reviewer loop.
+
+A **foundational reviewer-tool fix** is a tool-fix item that repairs behavior in a reviewer
+loop, reviewer adapter, review-action workflow, reviewer summary guard, reviewer status check,
+or related protocol that another same-batch tool-fix will invoke while proving readiness.
+
+A **dependent reviewer-tool fix** is a tool-fix item whose own reviewer loop, CI/review
+readiness proof, or prior escalation depends on the foundational fix being present on the
+target base branch.
+
+When a foundational/dependent relationship is detected:
+
+1. Dispatch the foundational item first and hold dependent tool-fix items.
+2. Do not trust a dependent item's reviewer-loop result until the foundational PR has merged
+   to the dependent item's target base branch.
+3. After the foundational PR merges, update each dependent branch or PR from the target base
+   before rerunning reviewer loop and CI.
+4. Treat any dependent reviewer-loop escalation that happened before the foundational merge as
+   stale until a fresh post-update reviewer loop runs.
+5. Only mark the dependent item ready after the post-update reviewer loop and CI are clean, or
+   escalate if fresh post-update findings remain.
+
+The batch summary must list the foundational item, each held dependent item, the merge-ordering
+reason, any stale pre-merge escalation being re-evaluated, and the exact resume condition
+(for example, `held — merge PR #N, update from develop, rerun reviewer loop and CI`).
+
+This guidance changes sequencing only. The orchestrator must not merge any foundational or
+dependent PR autonomously; every PR merge still requires human approval under the repository's
+normal merge rules.
+
 **Already-waiting tool-fix**: If the tool-fix item is already `ready-for-human-review`, `Spec in
 Review`, or `Plan in Review` (already waiting for merge) before batch dispatch, the orchestrator
 reports it as a "pending tool-fix" blocker for the consumer items and holds those items without


### PR DESCRIPTION
## Summary

Implements the approved docs-only guidance for tool-fix merge ordering.

- Adds a `Foundational reviewer-tool merge ordering` subsection to Protocol 90.
- Defines foundational and dependent reviewer-tool fixes.
- Requires held dependents to update from the fixed base and rerun reviewer loop and CI before readiness is trusted.
- Preserves the repository rule that every PR merge still requires human approval.

## Protocol 03 Pre-Submission Self-Review Pass

- Diff reviewed against the approved spec and implementation plan for #825.
- Plan surface coverage verified:
  - Protocol 90 explains why dispatch serialization alone is insufficient for dependent reviewer-tool fixes.
  - The text defines foundational fixes, dependent fixes, hold behavior, post-merge update/reloop behavior, stale escalation treatment, summary output, and human merge-approval preservation.
  - Existing smoke runbook assertions already cover the new Protocol 90 section.
- Stale-marker scan run for changed files; only older changelog text matched the broad placeholder pattern.

## Validation

- `npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md" "docs/testing/workflow/tool-fix-merge-ordering.smoke-test.md" "CHANGELOG.md"`
- `find docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `git diff --check`

## Tracker

Closes #825
