### PR TITLE
feat(workflow): stamp release issues with version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Release stamping** (#829): records the production release version on shipped tracker issues using provider-native release markers such as GitHub Milestones, while failing softly for unsupported providers.
+
 ### Fixed
 
 - **Claude Code Action reviewer no-op guard** (#866): passes an explicit code-review prompt to the workflow and fails closed when a successful run log shows Claude did not actually execute.

--- a/docs/testing/workflow/release-stamping.smoke-test.md
+++ b/docs/testing/workflow/release-stamping.smoke-test.md
@@ -36,9 +36,20 @@ Milestones as the GitHub Issues / GitHub Projects release primitive.
    VERSION="v999.999.999-smoke"
    ```
 
-4. Run the release-stamp helper directly, or run the release cleanup helper in a
-   controlled test repository after both release PR merge preconditions are
-   satisfied.
+4. Run the release-stamp helper directly:
+
+   ```bash
+   set -euo pipefail
+
+   source scripts/development-workflow/workflow-lib.sh
+   record_release_for_issue_best_effort "$ISSUE_NUMBER" "$VERSION"
+   ```
+
+   Expected result: output includes
+   `RELEASE_STAMPED issue=<issue> version=v999.999.999-smoke`.
+
+   Alternatively, run the release cleanup helper in a controlled test repository
+   after both release PR merge preconditions are satisfied.
 
 5. Verify the milestone exists and is assigned:
 
@@ -100,6 +111,8 @@ Milestones as the GitHub Issues / GitHub Projects release primitive.
 
 - GitHub providers create or reuse a milestone named for the release version.
 - The shipped issue is assigned to that milestone.
+- Release cleanup summary output reports `STAMPED`, `STAMP_SKIPPED`, and
+  `STAMP_FAILED` separately from tracker Status transition counts.
 - GitHub Projects can display the release version through the built-in Milestone
   field.
 - Unsupported or disabled tracker providers log a clear skip and do not fail the

--- a/docs/workflow/development-workflow/integrations/github-projects.md
+++ b/docs/workflow/development-workflow/integrations/github-projects.md
@@ -332,6 +332,27 @@ When a work item reaches **Merged** status, close the corresponding GitHub issue
 gh issue close <ISSUE_NUMBER>
 ```
 
+### Release Milestones
+
+For GitHub Issues and GitHub Projects providers, the release-stamp operation uses
+GitHub Milestones as the native "shipped in version" marker.
+
+Convention:
+
+- Milestone titles match production tags, for example `v1.2.0`.
+- `prepare-release-post-merge-cleanup.sh` creates a missing milestone when an
+  explicit released issue set is supplied.
+- The helper assigns the milestone to each shipped issue before or alongside the
+  `Merged` -> `Released` project Status transition.
+- After at least one issue is stamped, the helper closes the release milestone as
+  part of post-merge cleanup.
+- GitHub Projects can display the built-in Milestone field in board views, so no
+  custom project field is required to group or filter shipped issues by release.
+
+Release stamping is best effort. A milestone create or assignment failure is
+reported in the cleanup summary as `STAMP_FAILED`, but it does not block the
+existing tracker Status transition.
+
 ---
 
 ## Branch Naming with GitHub Issues

--- a/docs/workflow/development-workflow/integrations/issue-tracker.md
+++ b/docs/workflow/development-workflow/integrations/issue-tracker.md
@@ -45,3 +45,31 @@ If the agent does not have direct tracker access, it must ask the human to paste
 - **In Development (Full Pipeline)**: scan recent comments for post-plan scope changes. If anything conflicts with the spec or plan, stop and request an update before coding.
 - **In Development (Refactor)**: scan recent comments for post-plan scope changes. If anything conflicts with the plan, stop and request an update before coding. There is no spec for refactor items — the plan and work item brief are the authoritative sources.
 - **In Development (Fast Track)**: the work item description/comments can be the brief; confirm scope is bounded and stop if it expands beyond the brief.
+
+---
+
+## Release Stamping
+
+Release cleanup records which production version shipped each explicit issue via
+a provider-routed operation:
+
+```bash
+record_release_for_issue_best_effort <issue> <version>
+```
+
+The finalized `CHANGELOG.md` release section is the provider-independent source
+for which issues shipped. Cleanup helpers keep the issue list explicit with
+`--issue` or `--issues` so a release cannot accidentally stamp every item in a
+tracker status.
+
+| Provider | Release marker |
+| --- | --- |
+| `github_projects`, `github_issues` | GitHub Milestone named like `v1.2.0` |
+| `jira` | Fix Version/s, when a Jira integration implements the write path |
+| `linear` | Default label `release/v1.2.0`, or a configured custom field |
+| `clickup`, `notion` | Configured custom field, tag, or select property |
+| `none` | No-op |
+
+Release stamping is best effort. Unsupported or unavailable providers must log a
+clear warning/skip and continue with the rest of release cleanup. A stamp failure
+must not block the `Merged` -> `Released` status transition.

--- a/docs/workflow/development-workflow/integrations/linear.md
+++ b/docs/workflow/development-workflow/integrations/linear.md
@@ -99,11 +99,13 @@ The `[slug]` is a short kebab-case description derived from the work item title 
 
 ## Custom Fields
 
-The `issue_tracker.custom_fields` flat map in `.ai-dev-workflow.yaml` holds provider-specific fields that extend the standard `issue_tracker` configuration. For the Linear provider, the following key is recognised by workflow scripts:
+The `issue_tracker.custom_fields` flat map in `.ai-dev-workflow.yaml` holds provider-specific fields that extend the standard `issue_tracker` configuration. For the Linear provider, the following keys are recognised by workflow scripts:
 
-| Key       | Format                   | Effect                                                                                                                                                                                                            |
-| --------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `project` | Linear project ID string | When set, issue creation associates the new issue with the specified Linear project. The project ID is found in the Linear project URL (`https://linear.app/<team>/projects/<project-id>`) or via the Linear API. |
+| Key                    | Format                   | Effect                                                                                                                                                                                                            |
+| ---------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `project`              | Linear project ID string | When set, issue creation associates the new issue with the specified Linear project. The project ID is found in the Linear project URL (`https://linear.app/<team>/projects/<project-id>`) or via the Linear API. |
+| `release_field`        | Custom field key/name    | Optional future write target for recording the shipped release on a Linear issue. Shell helpers warn that MCP/API access is required.                                                                             |
+| `release_label_prefix` | Label prefix string      | Label fallback for release stamping. Defaults to `release/`, producing labels like `release/v1.2.0`. Shell helpers warn that MCP/API access is required to apply it.                                               |
 
 When `project` is absent from `custom_fields` (or `custom_fields` itself is absent), issue creation proceeds without a project association — this is the current default behaviour and is fully backward-compatible.
 
@@ -114,6 +116,7 @@ issue_tracker:
   provider: linear
   custom_fields:
     project: my-linear-project-id
+    release_label_prefix: release/
 ```
 
 Read the value in a script using the `workflow_issue_tracker_custom_field` helper:
@@ -124,6 +127,19 @@ project_id=$(workflow_issue_tracker_custom_field project)
 ```
 
 Unrecognised keys in `custom_fields` are silently ignored by all current scripts.
+
+### Release Stamping
+
+Linear has no global first-class release object. The default workflow release
+marker is a label named `release/vX.Y.Z`, using the configurable
+`release_label_prefix` above. Teams that maintain a Linear custom field for
+release tracking can set `release_field`; an MCP/API-backed implementation can
+write that field during release cleanup.
+
+Shell-only cleanup helpers cannot mutate Linear labels or custom fields directly.
+They emit release-stamp guidance and continue. The orchestrator or a Linear MCP
+runner should apply the release label/custom field and then transition shipped
+issues from `Merged` to `Released`.
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
+++ b/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
@@ -224,7 +224,13 @@ Confirm the release branch has:
 - One merged PR to `develop`
 - No remaining open PRs to either base
 
-If either merged PR is missing, or one PR is still open, stop. Do **not** delete the release branch and do **not** run tracker release transitions.
+If either merged PR is missing, or one PR is still open, stop. Do **not** delete the release branch and do **not** run release stamping or tracker release transitions.
+
+Before running cleanup, derive the explicit shipped issue set from the finalized
+`## [X.Y.Z]` section in `CHANGELOG.md`. Use only issue references that actually
+shipped in that release section. Keep the helper invocation explicit with
+`--issue` or `--issues`; do not ask the helper to infer release scope from the
+whole project board.
 
 ### 9.2 Preferred command (single entry point)
 
@@ -239,7 +245,8 @@ The script performs all required checks and actions in order:
 1. Verifies both merged PRs exist (`main` and `develop`) and no open PR remains.
 2. Deletes remote branch `release/v[X.Y.Z]` (or logs that it is already absent).
 3. Deletes local branch `release/v[X.Y.Z]` when safe.
-4. Transitions explicit in-scope tracker items from merged-to-integration to released-to-production.
+4. Records the production release version on each explicit in-scope tracker item.
+5. Transitions explicit in-scope tracker items from merged-to-integration to released-to-production.
 
 ### 9.3 Manual equivalent (when script cannot be used)
 
@@ -258,16 +265,23 @@ git branch -D "release/v[X.Y.Z]"
 
 If local deletion fails because the branch is checked out in another worktree, switch away in that worktree and retry.
 
-### 9.4 Tracker transition: `Merged` -> `Released` for in-scope items
+### 9.4 Release stamp + tracker transition for in-scope items
 
-Use the same GitHub Projects v2 update path documented in [`github-projects.md`](../integrations/github-projects.md). The helper script accepts explicit issue numbers (`--issue`/`--issues`) to keep scope safe.
+Use the provider-routed release-stamp operation documented in [`issue-tracker.md`](../integrations/issue-tracker.md) and the same GitHub Projects v2 status update path documented in [`github-projects.md`](../integrations/github-projects.md). The helper script accepts explicit issue numbers (`--issue`/`--issues`) to keep scope safe.
 
 - Default status names: `Merged` and `Released`
 - Optional env overrides:
   - `GITHUB_PROJECT_STATUS_MERGED`
   - `GITHUB_PROJECT_STATUS_RELEASED`
+- GitHub providers stamp releases with a Milestone named `vX.Y.Z`, assign it to each shipped issue, and close the milestone after cleanup succeeds.
+- Unsupported providers log a release-stamp skip/warning and continue; release stamping is best effort and must not block status transitions.
 
 Only transition work items explicitly confirmed as part of the shipped release. Do not bulk-move all project items in `Merged` unless a human explicitly asks for that scope.
+
+If release stamping needs manual repair, use the provider-native release marker
+for each shipped issue (for example, GitHub Milestone `vX.Y.Z`, Jira Fix
+Version/s, or a Linear `release/vX.Y.Z` label/custom field) and then rerun or
+manually complete the `Merged` -> `Released` status transition.
 
 ---
 

--- a/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
+++ b/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
@@ -305,36 +305,33 @@ for issue in "${ISSUE_NUMBERS[@]}"; do
   fi
 done
 
-if [ "$RELEASE_STAMPED" -gt 0 ]; then
-  finalize_release_marker_best_effort "$RELEASE_VERSION"
-fi
-
 echo "STAMPED=$RELEASE_STAMPED STAMP_SKIPPED=$RELEASE_STAMP_SKIPPED STAMP_FAILED=$RELEASE_STAMP_FAILED UPDATED=$TRACKER_UPDATED SKIPPED=$TRACKER_SKIPPED FAILED=$TRACKER_FAILED"
 
-if [ "$BEST_EFFORT" = "true" ]; then
-  echo "Release post-merge cleanup complete."
-  exit 0
+if [ "$BEST_EFFORT" != "true" ]; then
+  if [ "$TRACKER_FAILED" -gt 0 ]; then
+    echo "Error: $TRACKER_FAILED tracker transition(s) failed for release $RELEASE_BRANCH." >&2
+    echo "Pass --best-effort to suppress this error and exit 0 regardless of transition outcomes." >&2
+    exit 1
+  fi
+
+  if [ "$TRACKER_UPDATED" -eq 0 ]; then
+    case "$TRACKER_PROVIDER" in
+      github_projects|github-projects|github_issues|github-issues)
+        ;;
+      *)
+        echo "No shell-supported tracker transitions ran for provider '${TRACKER_PROVIDER:-none}'; release-stamp handling completed."
+        echo "Release post-merge cleanup complete."
+        exit 0
+        ;;
+    esac
+    echo "Error: no tracker transitions succeeded (UPDATED=0) for release $RELEASE_BRANCH." >&2
+    echo "Pass --best-effort to suppress this error and exit 0 regardless of transition outcomes." >&2
+    exit 1
+  fi
 fi
 
-if [ "$TRACKER_FAILED" -gt 0 ]; then
-  echo "Error: $TRACKER_FAILED tracker transition(s) failed for release $RELEASE_BRANCH." >&2
-  echo "Pass --best-effort to suppress this error and exit 0 regardless of transition outcomes." >&2
-  exit 1
-fi
-
-if [ "$TRACKER_UPDATED" -eq 0 ]; then
-  case "$TRACKER_PROVIDER" in
-    github_projects|github-projects|github_issues|github-issues)
-      ;;
-    *)
-      echo "No shell-supported tracker transitions ran for provider '${TRACKER_PROVIDER:-none}'; release-stamp handling completed."
-      echo "Release post-merge cleanup complete."
-      exit 0
-      ;;
-  esac
-  echo "Error: no tracker transitions succeeded (UPDATED=0) for release $RELEASE_BRANCH." >&2
-  echo "Pass --best-effort to suppress this error and exit 0 regardless of transition outcomes." >&2
-  exit 1
+if [ "$RELEASE_STAMPED" -gt 0 ]; then
+  finalize_release_marker_best_effort "$RELEASE_VERSION"
 fi
 
 echo "Release post-merge cleanup complete."

--- a/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
+++ b/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
@@ -217,7 +217,10 @@ if [ "$TRACKER_PROVIDER" = "linear" ]; then
   LINEAR_STAMP_SKIPPED=0
   LINEAR_STAMP_FAILED=0
   for issue in "${ISSUE_NUMBERS[@]}"; do
-    STAMP_OUT="$(record_release_for_issue_best_effort "$issue" "$RELEASE_VERSION" 2>&1)"
+    if ! STAMP_OUT="$(record_release_for_issue_best_effort "$issue" "$RELEASE_VERSION")"; then
+      echo "Warning: release-stamp helper failed for issue #$issue; counting as stamp failure."
+      STAMP_OUT="RELEASE_STAMP_FAILED issue=${issue} version=${RELEASE_VERSION} provider=${TRACKER_PROVIDER:-unknown} reason=helper_failed"
+    fi
     echo "$STAMP_OUT"
     if echo "$STAMP_OUT" | grep -q "^RELEASE_STAMPED "; then
       LINEAR_STAMPED=$((LINEAR_STAMPED + 1))
@@ -250,7 +253,10 @@ TRACKER_SKIPPED=0
 TRACKER_FAILED=0
 
 for issue in "${ISSUE_NUMBERS[@]}"; do
-  STAMP_OUT="$(record_release_for_issue_best_effort "$issue" "$RELEASE_VERSION" 2>&1)"
+  if ! STAMP_OUT="$(record_release_for_issue_best_effort "$issue" "$RELEASE_VERSION")"; then
+    echo "Warning: release-stamp helper failed for issue #$issue; counting as stamp failure."
+    STAMP_OUT="RELEASE_STAMP_FAILED issue=${issue} version=${RELEASE_VERSION} provider=${TRACKER_PROVIDER:-unknown} reason=helper_failed"
+  fi
   echo "$STAMP_OUT"
   if echo "$STAMP_OUT" | grep -q "^RELEASE_STAMPED "; then
     RELEASE_STAMPED=$((RELEASE_STAMPED + 1))

--- a/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
+++ b/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
@@ -335,7 +335,10 @@ if [ "$BEST_EFFORT" != "true" ]; then
 fi
 
 if [ "$RELEASE_STAMPED" -gt 0 ]; then
-  finalize_release_marker_best_effort "$RELEASE_VERSION"
+  if ! finalize_release_marker_best_effort "$RELEASE_VERSION"; then
+    echo "Error: release marker finalization failed for $RELEASE_VERSION." >&2
+    exit 1
+  fi
 fi
 
 echo "Release post-merge cleanup complete."

--- a/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
+++ b/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
@@ -324,9 +324,13 @@ if [ "$BEST_EFFORT" != "true" ]; then
         exit 0
         ;;
     esac
-    echo "Error: no tracker transitions succeeded (UPDATED=0) for release $RELEASE_BRANCH." >&2
-    echo "Pass --best-effort to suppress this error and exit 0 regardless of transition outcomes." >&2
-    exit 1
+    if [ "$RELEASE_STAMPED" -gt 0 ] && [ "$TRACKER_SKIPPED" -gt 0 ] && [ "$TRACKER_FAILED" -eq 0 ]; then
+      echo "Release stamping succeeded, but tracker status transitions were skipped; treating cleanup as successful because no transition failed."
+    else
+      echo "Error: no tracker transitions succeeded (UPDATED=0) for release $RELEASE_BRANCH." >&2
+      echo "Pass --best-effort to suppress this error and exit 0 regardless of transition outcomes." >&2
+      exit 1
+    fi
   fi
 fi
 

--- a/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
+++ b/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
@@ -336,8 +336,12 @@ fi
 
 if [ "$RELEASE_STAMPED" -gt 0 ]; then
   if ! finalize_release_marker_best_effort "$RELEASE_VERSION"; then
-    echo "Error: release marker finalization failed for $RELEASE_VERSION." >&2
-    exit 1
+    if [ "$BEST_EFFORT" != "true" ]; then
+      echo "Error: release marker finalization failed for $RELEASE_VERSION." >&2
+      echo "Pass --best-effort to suppress this error and exit 0 regardless of finalization outcomes." >&2
+      exit 1
+    fi
+    echo "Warning: release marker finalization failed for $RELEASE_VERSION; continuing because --best-effort was passed." >&2
   fi
 fi
 

--- a/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
+++ b/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
@@ -213,11 +213,22 @@ fi
 # exit cleanly rather than silently skipping or failing with UPDATED=0.
 if [ "$TRACKER_PROVIDER" = "linear" ]; then
   echo "Recording release stamp guidance for Linear issue(s)..."
+  LINEAR_STAMPED=0
   LINEAR_STAMP_SKIPPED=0
+  LINEAR_STAMP_FAILED=0
   for issue in "${ISSUE_NUMBERS[@]}"; do
     STAMP_OUT="$(record_release_for_issue_best_effort "$issue" "$RELEASE_VERSION" 2>&1)"
     echo "$STAMP_OUT"
-    LINEAR_STAMP_SKIPPED=$((LINEAR_STAMP_SKIPPED + 1))
+    if echo "$STAMP_OUT" | grep -q "^RELEASE_STAMPED "; then
+      LINEAR_STAMPED=$((LINEAR_STAMPED + 1))
+    elif echo "$STAMP_OUT" | grep -q "^RELEASE_STAMP_FAILED "; then
+      LINEAR_STAMP_FAILED=$((LINEAR_STAMP_FAILED + 1))
+    elif echo "$STAMP_OUT" | grep -q "^RELEASE_STAMP_SKIPPED "; then
+      LINEAR_STAMP_SKIPPED=$((LINEAR_STAMP_SKIPPED + 1))
+    else
+      echo "Warning: unrecognized release-stamp output for issue #$issue; counting as stamp failure."
+      LINEAR_STAMP_FAILED=$((LINEAR_STAMP_FAILED + 1))
+    fi
   done
   echo "Linear tracker detected: automatic '$MERGED_LABEL' -> '$RELEASED_LABEL' transitions are not supported by this script."
   echo "Manually transition the following issue(s) to '$RELEASED_LABEL' in Linear (via MCP server or API):"
@@ -225,7 +236,7 @@ if [ "$TRACKER_PROVIDER" = "linear" ]; then
     echo "  - Issue $issue: set status to '$RELEASED_LABEL'"
   done
   echo "See docs/workflow/development-workflow/integrations/linear.md for guidance."
-  echo "STAMPED=0 STAMP_SKIPPED=$LINEAR_STAMP_SKIPPED STAMP_FAILED=0 UPDATED=0 SKIPPED=0 FAILED=0"
+  echo "STAMPED=$LINEAR_STAMPED STAMP_SKIPPED=$LINEAR_STAMP_SKIPPED STAMP_FAILED=$LINEAR_STAMP_FAILED UPDATED=0 SKIPPED=0 FAILED=0"
   echo "Release post-merge cleanup complete."
   exit 0
 fi
@@ -248,7 +259,8 @@ for issue in "${ISSUE_NUMBERS[@]}"; do
   elif echo "$STAMP_OUT" | grep -q "^RELEASE_STAMP_SKIPPED "; then
     RELEASE_STAMP_SKIPPED=$((RELEASE_STAMP_SKIPPED + 1))
   else
-    RELEASE_STAMP_SKIPPED=$((RELEASE_STAMP_SKIPPED + 1))
+    echo "Warning: unrecognized release-stamp output for issue #$issue; counting as stamp failure."
+    RELEASE_STAMP_FAILED=$((RELEASE_STAMP_FAILED + 1))
   fi
 
   ISSUE_STATE=$(gh issue view "$issue" --json state --jq '.state' 2>/dev/null || true)

--- a/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
+++ b/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
@@ -323,6 +323,15 @@ if [ "$TRACKER_FAILED" -gt 0 ]; then
 fi
 
 if [ "$TRACKER_UPDATED" -eq 0 ]; then
+  case "$TRACKER_PROVIDER" in
+    github_projects|github-projects|github_issues|github-issues)
+      ;;
+    *)
+      echo "No shell-supported tracker transitions ran for provider '${TRACKER_PROVIDER:-none}'; release-stamp handling completed."
+      echo "Release post-merge cleanup complete."
+      exit 0
+      ;;
+  esac
   echo "Error: no tracker transitions succeeded (UPDATED=0) for release $RELEASE_BRANCH." >&2
   echo "Pass --best-effort to suppress this error and exit 0 regardless of transition outcomes." >&2
   exit 1

--- a/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
+++ b/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
@@ -4,6 +4,7 @@
 # - verifies release PRs to main and develop are both merged
 # - deletes remote release branch (if present)
 # - deletes local release branch (switching away first if needed)
+# - optionally stamps explicit issue numbers with the release version
 # - optionally transitions explicit issue numbers from merged -> released
 #
 # Usage:
@@ -21,7 +22,8 @@
 #   1  updated==0 after processing all issues, or at least one hard failure occurred
 #
 # Output (when --issues is supplied):
-#   Emits structured key/value summary line:  UPDATED=N SKIPPED=N FAILED=N
+#   Emits structured key/value summary line:
+#   STAMPED=N STAMP_SKIPPED=N STAMP_FAILED=N UPDATED=N SKIPPED=N FAILED=N
 #
 # Env overrides:
 #   GITHUB_PROJECT_STATUS_MERGED   (default: Merged)
@@ -148,7 +150,9 @@ if [ -z "$RELEASE_INPUT" ]; then
 fi
 
 RELEASE_BRANCH="$(normalize_release_branch "$RELEASE_INPUT")"
+RELEASE_VERSION="${RELEASE_BRANCH#release/}"
 echo "Release branch: $RELEASE_BRANCH"
+echo "Release version: $RELEASE_VERSION"
 
 echo "Verifying merged PRs for release branch..."
 MAIN_PR=$(gh pr list --state merged --head "$RELEASE_BRANCH" --base main --json number --jq '.[0].number // empty')
@@ -208,22 +212,45 @@ fi
 # (they require MCP/API access). Emit per-issue manual action guidance and
 # exit cleanly rather than silently skipping or failing with UPDATED=0.
 if [ "$TRACKER_PROVIDER" = "linear" ]; then
+  echo "Recording release stamp guidance for Linear issue(s)..."
+  LINEAR_STAMP_SKIPPED=0
+  for issue in "${ISSUE_NUMBERS[@]}"; do
+    STAMP_OUT="$(record_release_for_issue_best_effort "$issue" "$RELEASE_VERSION" 2>&1)"
+    echo "$STAMP_OUT"
+    LINEAR_STAMP_SKIPPED=$((LINEAR_STAMP_SKIPPED + 1))
+  done
   echo "Linear tracker detected: automatic '$MERGED_LABEL' -> '$RELEASED_LABEL' transitions are not supported by this script."
   echo "Manually transition the following issue(s) to '$RELEASED_LABEL' in Linear (via MCP server or API):"
   for issue in "${ISSUE_NUMBERS[@]}"; do
     echo "  - Issue $issue: set status to '$RELEASED_LABEL'"
   done
   echo "See docs/workflow/development-workflow/integrations/linear.md for guidance."
+  echo "STAMPED=0 STAMP_SKIPPED=$LINEAR_STAMP_SKIPPED STAMP_FAILED=0 UPDATED=0 SKIPPED=0 FAILED=0"
   echo "Release post-merge cleanup complete."
   exit 0
 fi
 
 echo "Transitioning scoped issues from '$MERGED_LABEL' to '$RELEASED_LABEL'..."
+RELEASE_STAMPED=0
+RELEASE_STAMP_SKIPPED=0
+RELEASE_STAMP_FAILED=0
 TRACKER_UPDATED=0
 TRACKER_SKIPPED=0
 TRACKER_FAILED=0
 
 for issue in "${ISSUE_NUMBERS[@]}"; do
+  STAMP_OUT="$(record_release_for_issue_best_effort "$issue" "$RELEASE_VERSION" 2>&1)"
+  echo "$STAMP_OUT"
+  if echo "$STAMP_OUT" | grep -q "^RELEASE_STAMPED "; then
+    RELEASE_STAMPED=$((RELEASE_STAMPED + 1))
+  elif echo "$STAMP_OUT" | grep -q "^RELEASE_STAMP_FAILED "; then
+    RELEASE_STAMP_FAILED=$((RELEASE_STAMP_FAILED + 1))
+  elif echo "$STAMP_OUT" | grep -q "^RELEASE_STAMP_SKIPPED "; then
+    RELEASE_STAMP_SKIPPED=$((RELEASE_STAMP_SKIPPED + 1))
+  else
+    RELEASE_STAMP_SKIPPED=$((RELEASE_STAMP_SKIPPED + 1))
+  fi
+
   ISSUE_STATE=$(gh issue view "$issue" --json state --jq '.state' 2>/dev/null || true)
   if [ -z "$ISSUE_STATE" ]; then
     echo "Warning: could not read issue #$issue; skipping tracker update."
@@ -260,7 +287,11 @@ for issue in "${ISSUE_NUMBERS[@]}"; do
   fi
 done
 
-echo "UPDATED=$TRACKER_UPDATED SKIPPED=$TRACKER_SKIPPED FAILED=$TRACKER_FAILED"
+if [ "$RELEASE_STAMPED" -gt 0 ]; then
+  finalize_release_marker_best_effort "$RELEASE_VERSION"
+fi
+
+echo "STAMPED=$RELEASE_STAMPED STAMP_SKIPPED=$RELEASE_STAMP_SKIPPED STAMP_FAILED=$RELEASE_STAMP_FAILED UPDATED=$TRACKER_UPDATED SKIPPED=$TRACKER_SKIPPED FAILED=$TRACKER_FAILED"
 
 if [ "$BEST_EFFORT" = "true" ]; then
   echo "Release post-merge cleanup complete."

--- a/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+++ b/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
@@ -45,6 +45,43 @@ case "$*" in
     fi
     printf 'ai-dev-framework-template\n'
     ;;
+  "api --paginate --slurp repos/lhpaul/ai-dev-framework-template/milestones?state=all&per_page=100")
+    if [ "${MOCK_MILESTONE_MODE:-existing}" = "fail" ]; then
+      printf 'milestone list failed\n' >&2
+      exit 42
+    elif [ "${MOCK_MILESTONE_MODE:-existing}" = "missing" ]; then
+      printf '[[]]\n'
+    else
+      cat <<'JSON'
+[[{"number":7,"title":"v1.2.3","state":"open"},{"number":8,"title":"v0.1.0","state":"closed"}]]
+JSON
+    fi
+    ;;
+  "api -X POST repos/lhpaul/ai-dev-framework-template/milestones -f title=v1.2.3 -f description=Release v1.2.3")
+    if [ "${MOCK_MILESTONE_CREATE_MODE:-ok}" = "fail" ]; then
+      printf 'milestone create failed\n' >&2
+      exit 42
+    fi
+    cat <<'JSON'
+{"number":9,"title":"v1.2.3","state":"open"}
+JSON
+    ;;
+  "api -X PATCH repos/lhpaul/ai-dev-framework-template/milestones/7 -f state=closed"|"api -X PATCH repos/lhpaul/ai-dev-framework-template/milestones/9 -f state=closed")
+    if [ "${MOCK_MILESTONE_CLOSE_MODE:-ok}" = "fail" ]; then
+      printf 'milestone close failed\n' >&2
+      exit 42
+    fi
+    cat <<'JSON'
+{"number":7,"title":"v1.2.3","state":"closed"}
+JSON
+    ;;
+  "issue edit 824 --milestone v1.2.3")
+    if [ "${MOCK_ISSUE_EDIT_MODE:-ok}" = "fail" ]; then
+      printf 'issue edit failed\n' >&2
+      exit 42
+    fi
+    printf 'https://github.com/lhpaul/ai-dev-framework-template/issues/824\n'
+    ;;
   *"api graphql"* )
     case "$*" in
       *"projectV2(number:"*)
@@ -413,6 +450,73 @@ esac
 run_test "type_helpers_wrong_provider_warns" "warned" "$provider_guard_result"
 run_test "type_helpers_wrong_provider_empty_list" "[]" "$(printf '%s' "$workflow_issues" | jq -c '.')"
 run_test "type_helpers_wrong_provider_avoids_api" "0" "$(count_log_matches 'api graphql|issue list|project item-list')"
+
+reset_log
+milestone_number="$(workflow_github_milestone_number "v1.2.3")"
+run_test "release_stamp_finds_existing_milestone" "7" "$milestone_number"
+stamp_output="$(record_release_for_issue_best_effort 824 "v1.2.3" 2>&1)"
+case "$stamp_output" in
+  *"RELEASE_STAMPED issue=824 version=v1.2.3 provider=github_projects"*) stamp_result="stamped" ;;
+  *) stamp_result="$stamp_output" ;;
+esac
+run_test "release_stamp_assigns_existing_milestone" "stamped" "$stamp_result"
+run_test "release_stamp_existing_does_not_create_milestone" "0" "$(count_log_matches 'api -X POST repos/.*/milestones')"
+run_test "release_stamp_assigns_issue_milestone" "1" "$(count_log_matches 'issue edit 824 --milestone v1.2.3')"
+
+reset_log
+export MOCK_MILESTONE_MODE=missing
+stamp_output="$(record_release_for_issue_best_effort 824 "v1.2.3" 2>&1)"
+unset MOCK_MILESTONE_MODE
+case "$stamp_output" in
+  *"RELEASE_STAMPED issue=824 version=v1.2.3 provider=github_projects"*) stamp_result="stamped" ;;
+  *) stamp_result="$stamp_output" ;;
+esac
+run_test "release_stamp_creates_missing_milestone" "stamped" "$stamp_result"
+run_test "release_stamp_missing_creates_once" "1" "$(count_log_matches 'api -X POST repos/.*/milestones')"
+
+reset_log
+export MOCK_ISSUE_EDIT_MODE=fail
+stamp_output="$(record_release_for_issue_best_effort 824 "v1.2.3" 2>&1)"
+unset MOCK_ISSUE_EDIT_MODE
+case "$stamp_output" in
+  *"RELEASE_STAMP_FAILED issue=824 version=v1.2.3 provider=github_projects reason=assignment_failed"*) stamp_result="failed" ;;
+  *) stamp_result="$stamp_output" ;;
+esac
+run_test "release_stamp_assignment_failure_warns" "failed" "$stamp_result"
+
+reset_log
+export MOCK_TRACKER_PROVIDER=none
+stamp_output="$(record_release_for_issue_best_effort 824 "v1.2.3")"
+unset MOCK_TRACKER_PROVIDER
+run_test "release_stamp_provider_none_skips" "RELEASE_STAMP_SKIPPED issue=824 version=v1.2.3 provider=none reason=provider_none" "$stamp_output"
+run_test "release_stamp_provider_none_avoids_api" "0" "$(count_log_matches 'api |issue edit')"
+
+reset_log
+export MOCK_TRACKER_PROVIDER=linear
+stamp_output="$(record_release_for_issue_best_effort 824 "v1.2.3")"
+unset MOCK_TRACKER_PROVIDER
+case "$stamp_output" in
+  *"RELEASE_STAMP_SKIPPED issue=824 version=v1.2.3 provider=linear reason=mcp_required release_label=release/v1.2.3"*) stamp_result="linear-skip" ;;
+  *) stamp_result="$stamp_output" ;;
+esac
+run_test "release_stamp_linear_requires_mcp" "linear-skip" "$stamp_result"
+run_test "release_stamp_linear_avoids_api" "0" "$(count_log_matches 'api |issue edit')"
+
+reset_log
+export MOCK_TRACKER_PROVIDER=jira
+stamp_output="$(record_release_for_issue_best_effort 824 "v1.2.3")"
+unset MOCK_TRACKER_PROVIDER
+run_test "release_stamp_unsupported_provider_skips" "RELEASE_STAMP_SKIPPED issue=824 version=v1.2.3 provider=jira reason=unsupported_provider" "$stamp_output"
+run_test "release_stamp_unsupported_provider_avoids_api" "0" "$(count_log_matches 'api |issue edit')"
+
+reset_log
+finalize_output="$(finalize_release_marker_best_effort "v1.2.3" 2>&1)"
+case "$finalize_output" in
+  *"Release marker finalized: v1.2.3"*) finalize_result="finalized" ;;
+  *) finalize_result="$finalize_output" ;;
+esac
+run_test "release_marker_finalize_closes_milestone" "finalized" "$finalize_result"
+run_test "release_marker_finalize_calls_patch" "1" "$(count_log_matches 'api -X PATCH repos/.*/milestones/7 -f state=closed')"
 
 reset_log
 old_project_number="${GITHUB_PROJECT_NUMBER:-}"

--- a/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+++ b/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
@@ -519,6 +519,20 @@ run_test "release_marker_finalize_closes_milestone" "finalized" "$finalize_resul
 run_test "release_marker_finalize_calls_patch" "1" "$(count_log_matches 'api -X PATCH repos/.*/milestones/7 -f state=closed')"
 
 reset_log
+export MOCK_MILESTONE_CLOSE_MODE=fail
+if finalize_output="$(finalize_release_marker_best_effort "v1.2.3" 2>&1)"; then
+  finalize_failure_result="unexpected-success"
+else
+  case "$finalize_output" in
+    *"Warning: could not close GitHub release milestone 'v1.2.3'."*) finalize_failure_result="failed" ;;
+    *) finalize_failure_result="$finalize_output" ;;
+  esac
+fi
+unset MOCK_MILESTONE_CLOSE_MODE
+run_test "release_marker_finalize_close_failure_returns_nonzero" "failed" "$finalize_failure_result"
+run_test "release_marker_finalize_close_failure_calls_patch" "1" "$(count_log_matches 'api -X PATCH repos/.*/milestones/7 -f state=closed')"
+
+reset_log
 old_project_number="${GITHUB_PROJECT_NUMBER:-}"
 unset GITHUB_PROJECT_NUMBER
 MOCK_TRACKER_PROJECT_NUMBER=""

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -1418,6 +1418,185 @@ print(item.get('status') or '', end='')
   fi
 }
 
+# workflow_github_milestone_number <version>
+#
+# Prints the GitHub milestone number whose title exactly matches <version>, or
+# empty when absent/unreadable.
+workflow_github_milestone_number() {
+  local version="$1"
+  local repo_owner repo_name milestones
+
+  repo_owner="$(workflow_resolve_github_repo_owner)"
+  repo_name="$(workflow_resolve_github_repo_name)"
+  if [ -z "$repo_owner" ] || [ -z "$repo_name" ]; then
+    return 0
+  fi
+
+  if ! workflow_run_gh_capture_stderr api --paginate --slurp "repos/${repo_owner}/${repo_name}/milestones?state=all&per_page=100"; then
+    echo "Warning: could not list GitHub milestones for release '${version}'." >&2
+    workflow_print_captured_gh_stderr
+    return 0
+  fi
+  milestones="$__workflow_last_gh_stdout"
+
+  printf '%s' "$milestones" | python3 -c '
+import json
+import sys
+
+version = sys.argv[1]
+raw = sys.stdin.read()
+try:
+    pages = json.loads(raw)
+except Exception:
+    pages = []
+
+if isinstance(pages, dict):
+    pages = [pages]
+if pages and all(isinstance(item, dict) for item in pages):
+    items = pages
+else:
+    items = []
+    for page in pages if isinstance(pages, list) else []:
+        if isinstance(page, list):
+            items.extend(item for item in page if isinstance(item, dict))
+
+for item in items:
+    if item.get("title") == version:
+        print(item.get("number") or "", end="")
+        break
+' "$version"
+}
+
+# workflow_ensure_github_release_milestone <version>
+#
+# Creates the release milestone when absent and prints its number when known.
+workflow_ensure_github_release_milestone() {
+  local version="$1"
+  local repo_owner repo_name milestone_number created_number
+
+  milestone_number="$(workflow_github_milestone_number "$version")"
+  if [ -n "$milestone_number" ]; then
+    printf '%s' "$milestone_number"
+    return 0
+  fi
+
+  repo_owner="$(workflow_resolve_github_repo_owner)"
+  repo_name="$(workflow_resolve_github_repo_name)"
+  if [ -z "$repo_owner" ] || [ -z "$repo_name" ]; then
+    echo "Warning: could not resolve GitHub repository for release milestone '${version}'." >&2
+    return 1
+  fi
+
+  if ! workflow_run_gh_capture_stderr api -X POST "repos/${repo_owner}/${repo_name}/milestones" \
+    -f title="$version" \
+    -f description="Release ${version}"; then
+    echo "Warning: could not create GitHub release milestone '${version}'." >&2
+    workflow_print_captured_gh_stderr
+    return 1
+  fi
+
+  created_number=$(printf '%s' "$__workflow_last_gh_stdout" | python3 -c '
+import json
+import sys
+
+try:
+    data = json.loads(sys.stdin.read())
+except Exception:
+    data = {}
+print(data.get("number") or "", end="")
+'
+)
+  if [ -z "$created_number" ]; then
+    echo "Warning: GitHub milestone create response did not include a milestone number for '${version}'." >&2
+    return 1
+  fi
+  printf '%s' "$created_number"
+}
+
+# record_release_for_issue_best_effort <issue> <version>
+#
+# Provider-routed, fail-soft release stamp. Emits exactly one stable result line:
+#   RELEASE_STAMPED issue=<issue> version=<version> provider=<provider>
+#   RELEASE_STAMP_SKIPPED issue=<issue> version=<version> provider=<provider> reason=<reason>
+#   RELEASE_STAMP_FAILED issue=<issue> version=<version> provider=<provider> reason=<reason>
+record_release_for_issue_best_effort() {
+  local issue="$1"
+  local version="$2"
+  local provider milestone_number
+
+  provider="$(workflow_normalize_issue_tracker_provider "$(workflow_issue_tracker_provider_raw)")"
+  case "$provider" in
+    github_projects|github-projects|github_issues|github-issues)
+      milestone_number="$(workflow_ensure_github_release_milestone "$version")"
+      if [ -z "$milestone_number" ]; then
+        echo "RELEASE_STAMP_FAILED issue=${issue} version=${version} provider=${provider} reason=milestone_unavailable"
+        return 0
+      fi
+      if workflow_run_gh_capture_stderr issue edit "$issue" --milestone "$version"; then
+        echo "RELEASE_STAMPED issue=${issue} version=${version} provider=${provider}"
+      else
+        echo "Warning: could not assign GitHub milestone '${version}' to issue '${issue}'." >&2
+        workflow_print_captured_gh_stderr
+        echo "RELEASE_STAMP_FAILED issue=${issue} version=${version} provider=${provider} reason=assignment_failed"
+      fi
+      ;;
+    ''|none)
+      echo "RELEASE_STAMP_SKIPPED issue=${issue} version=${version} provider=${provider:-none} reason=provider_none"
+      ;;
+    linear)
+      local release_field release_label_prefix
+      release_field="$(workflow_issue_tracker_custom_field release_field)"
+      release_label_prefix="$(workflow_issue_tracker_custom_field release_label_prefix)"
+      release_label_prefix="${release_label_prefix:-release/}"
+      if [ -n "$release_field" ]; then
+        echo "RELEASE_STAMP_SKIPPED issue=${issue} version=${version} provider=linear reason=mcp_required release_field=${release_field}"
+      else
+        echo "RELEASE_STAMP_SKIPPED issue=${issue} version=${version} provider=linear reason=mcp_required release_label=${release_label_prefix}${version}"
+      fi
+      ;;
+    *)
+      echo "RELEASE_STAMP_SKIPPED issue=${issue} version=${version} provider=${provider} reason=unsupported_provider"
+      ;;
+  esac
+  return 0
+}
+
+# finalize_release_marker_best_effort <version>
+#
+# Best-effort lifecycle finalizer. GitHub providers close the release milestone;
+# other providers currently no-op.
+finalize_release_marker_best_effort() {
+  local version="$1"
+  local provider repo_owner repo_name milestone_number
+
+  provider="$(workflow_normalize_issue_tracker_provider "$(workflow_issue_tracker_provider_raw)")"
+  case "$provider" in
+    github_projects|github-projects|github_issues|github-issues)
+      milestone_number="$(workflow_github_milestone_number "$version")"
+      if [ -z "$milestone_number" ]; then
+        echo "Warning: release milestone '${version}' not found; skipping finalization."
+        return 0
+      fi
+      repo_owner="$(workflow_resolve_github_repo_owner)"
+      repo_name="$(workflow_resolve_github_repo_name)"
+      if [ -z "$repo_owner" ] || [ -z "$repo_name" ]; then
+        echo "Warning: could not resolve GitHub repository for release marker finalization."
+        return 0
+      fi
+      if workflow_run_gh_capture_stderr api -X PATCH "repos/${repo_owner}/${repo_name}/milestones/${milestone_number}" -f state=closed; then
+        echo "Release marker finalized: ${version}"
+      else
+        echo "Warning: could not close GitHub release milestone '${version}'."
+        workflow_print_captured_gh_stderr
+      fi
+      ;;
+    *)
+      echo "Release marker finalization skipped for provider '${provider:-none}'."
+      ;;
+  esac
+  return 0
+}
+
 # update_tracker_type_best_effort <issue_number> <type_label>
 #
 # Best-effort update for the GitHub Projects Type field. This intentionally

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -1429,13 +1429,13 @@ workflow_github_milestone_number() {
   repo_owner="$(workflow_resolve_github_repo_owner)"
   repo_name="$(workflow_resolve_github_repo_name)"
   if [ -z "$repo_owner" ] || [ -z "$repo_name" ]; then
-    return 0
+    return 1
   fi
 
   if ! workflow_run_gh_capture_stderr api --paginate --slurp "repos/${repo_owner}/${repo_name}/milestones?state=all&per_page=100"; then
     echo "Warning: could not list GitHub milestones for release '${version}'." >&2
     workflow_print_captured_gh_stderr
-    return 0
+    return 1
   fi
   milestones="$__workflow_last_gh_stdout"
 
@@ -1474,7 +1474,9 @@ workflow_ensure_github_release_milestone() {
   local version="$1"
   local repo_owner repo_name milestone_number created_number
 
-  milestone_number="$(workflow_github_milestone_number "$version")"
+  if ! milestone_number="$(workflow_github_milestone_number "$version")"; then
+    return 1
+  fi
   if [ -n "$milestone_number" ]; then
     printf '%s' "$milestone_number"
     return 0
@@ -1572,7 +1574,10 @@ finalize_release_marker_best_effort() {
   provider="$(workflow_normalize_issue_tracker_provider "$(workflow_issue_tracker_provider_raw)")"
   case "$provider" in
     github_projects|github-projects|github_issues|github-issues)
-      milestone_number="$(workflow_github_milestone_number "$version")"
+      if ! milestone_number="$(workflow_github_milestone_number "$version")"; then
+        echo "Warning: could not read release milestone '${version}'; skipping finalization."
+        return 0
+      fi
       if [ -z "$milestone_number" ]; then
         echo "Warning: release milestone '${version}' not found; skipping finalization."
         return 0

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -1565,8 +1565,8 @@ record_release_for_issue_best_effort() {
 
 # finalize_release_marker_best_effort <version>
 #
-# Best-effort lifecycle finalizer. GitHub providers close the release milestone;
-# other providers currently no-op.
+# Lifecycle finalizer. GitHub providers must close the release milestone
+# successfully; other providers currently no-op.
 finalize_release_marker_best_effort() {
   local version="$1"
   local provider repo_owner repo_name milestone_number
@@ -1576,23 +1576,24 @@ finalize_release_marker_best_effort() {
     github_projects|github-projects|github_issues|github-issues)
       if ! milestone_number="$(workflow_github_milestone_number "$version")"; then
         echo "Warning: could not read release milestone '${version}'; skipping finalization."
-        return 0
+        return 1
       fi
       if [ -z "$milestone_number" ]; then
         echo "Warning: release milestone '${version}' not found; skipping finalization."
-        return 0
+        return 1
       fi
       repo_owner="$(workflow_resolve_github_repo_owner)"
       repo_name="$(workflow_resolve_github_repo_name)"
       if [ -z "$repo_owner" ] || [ -z "$repo_name" ]; then
         echo "Warning: could not resolve GitHub repository for release marker finalization."
-        return 0
+        return 1
       fi
       if workflow_run_gh_capture_stderr api -X PATCH "repos/${repo_owner}/${repo_name}/milestones/${milestone_number}" -f state=closed; then
         echo "Release marker finalized: ${version}"
       else
         echo "Warning: could not close GitHub release milestone '${version}'."
         workflow_print_captured_gh_stderr
+        return 1
       fi
       ;;
     *)


### PR DESCRIPTION
## Summary

Implements provider-routed release stamping for release post-merge cleanup.

- Adds `record_release_for_issue_best_effort` and release-marker finalization helpers.
- Uses GitHub Milestones for `github_projects` / `github_issues`, with create/reuse, issue assignment, and close-after-cleanup behavior.
- Wires `prepare-release-post-merge-cleanup.sh` to stamp explicit issues before `Merged` -> `Released` transitions and report `STAMPED`, `STAMP_SKIPPED`, and `STAMP_FAILED` separately from tracker Status counts.
- Documents the release-stamp contract in Protocol 05 and tracker integration guides.
- Extends the GitHub Projects helper test harness with release-stamp paths.

## Protocol 03 Pre-Submission Self-Review Pass

- Diff reviewed against the approved spec and implementation plan for #829.
- Plan surface coverage verified:
  - Cleanup helper keeps explicit `--issue` / `--issues` scope.
  - GitHub providers use Milestones named like `vX.Y.Z`.
  - Linear and unsupported providers warn/skip without blocking cleanup.
  - Stamp failures are counted separately and do not block status transitions.
  - Docs and smoke runbook describe provider behavior and manual repair.
- Stale-marker scan run for changed files; only existing guarded script patterns and older changelog text matched broad marker patterns.

## Validation

- `bash -n scripts/development-workflow/workflow-lib.sh scripts/development-workflow/prepare-release-post-merge-cleanup.sh scripts/development-workflow/tests/test-workflow-lib-github-projects.sh`
- `bash scripts/development-workflow/tests/test-workflow-lib-github-projects.sh` (`83 passed, 0 failed`)
- `npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md" "docs/workflow/development-workflow/integrations/github-projects.md" "docs/workflow/development-workflow/integrations/issue-tracker.md" "docs/workflow/development-workflow/integrations/linear.md" "docs/testing/workflow/release-stamping.smoke-test.md" "CHANGELOG.md"`
- `find docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `git diff --check`

## Tracker

Closes #829
