### PR TITLE
fix(workflow): route review defaults through Codex

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -41,7 +41,7 @@ review:
   # repository.
   phase_after_clean:
     - haystack
-    - codex-github
+    - codex-github # Uses CODEX_GITHUB_BOT_LOGIN default documented below.
   #
   # Configurable codex-github options (set via env vars or script flags to codex-github-reviewer.sh):
   #   CODEX_GITHUB_TRIGGER_PHRASE  — trigger phrase sent to the bot (default: "@codex review")

--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -80,23 +80,23 @@ review:
   #                 integrations/coderabbit.md Step 7a section for setup details.
   #
   # Runner-context constraint:
-  #   'codex' as a direct CLI reviewer is NOT reliably reachable from automated
-  #   subagent runners (Claude Code subagents, Cursor subagents, or any headless
+  #   This template defaults to 'codex' for Codex-first workflow runs. 'codex' as
+  #   a direct CLI reviewer is NOT reliably reachable from automated subagent
+  #   runners (Claude Code subagents, Cursor subagents, or any headless
   #   environment). It is typically only reachable when Codex is the top-level
   #   runner itself. Protocol 91 Step 7a will classify 'codex' as unreachable in
-  #   these contexts and emit a warning comment on the PR, then proceed with only
-  #   'claude' under the default 'warn' policy. This is expected behaviour — not
-  #   a misconfiguration.
+  #   these contexts and emit a warning comment on the PR. This is expected
+  #   behaviour — not a misconfiguration.
   #
-  # Local override: developers who do not have access to all tools listed here
-  # can override this list locally by creating .tmp/template-config.json in the
-  # repository root (this path is gitignored). Format:
+  # Local override: developers who need a different top-level review runner can
+  # override this list locally by creating .tmp/template-config.json in the
+  # repository root (this path is gitignored). Example for Claude Code:
   #   { "overrides": { "review": { "internal_reviewers": ["claude"] } } }
   # The overrides key takes precedence over this file for the local environment.
   # See docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
   # Step 7a for the full multi-reviewer gate procedure.
   internal_reviewers:
-    - claude
+    - codex
 
   # Optional: policy when a listed internal reviewer is unreachable from the current runner.
   # Protocol 91 Step 7a enforces this policy at runtime.

--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -46,7 +46,7 @@ review:
   # Configurable codex-github options (set via env vars or script flags to codex-github-reviewer.sh):
   #   CODEX_GITHUB_TRIGGER_PHRASE  — trigger phrase sent to the bot (default: "@codex review")
   #   CODEX_GITHUB_BOT_LOGIN       — GitHub login of the Codex bot account
-  #                                  (default: "codex-ai[bot]"; verify from GitHub App settings)
+  #                                  (default: "chatgpt-codex-connector[bot]"; verify from GitHub App settings)
   #
   # Additional options available as script flags to codex-github-reviewer.sh (passed via pr-review-loop.sh):
   #   --poll-interval <seconds>    — polling interval while waiting for bot response (default: 30)

--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -29,18 +29,19 @@ review:
   platforms:
     - pr-agent
     - haystack
-    - claude-code-action
+    - codex-github
   #
   # Platforms listed here are treated as "after-clean" reviewers by
   # pr-review-loop.sh: earlier platforms must reach clean before these platforms
   # are considered the value-measurement phase. The protocol keeps PRs as drafts
   # while PR-Agent clears, then converts to non-draft so Haystack and
-  # claude-code-action can run after the clean gate. Haystack triage is placed
+  # codex-github can run after the clean gate. Haystack triage is placed
   # here because it does not reliably complete analysis for draft PRs.
-  # claude-code-action requires ANTHROPIC_API_KEY in GitHub Actions secrets.
+  # codex-github requires the Codex GitHub App/connector to be available on the
+  # repository.
   phase_after_clean:
     - haystack
-    - claude-code-action
+    - codex-github
   #
   # Configurable codex-github options (set via env vars or script flags to codex-github-reviewer.sh):
   #   CODEX_GITHUB_TRIGGER_PHRASE  — trigger phrase sent to the bot (default: "@codex review")

--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -86,8 +86,10 @@ review:
   #   runners (Claude Code subagents, Cursor subagents, or any headless
   #   environment). It is typically only reachable when Codex is the top-level
   #   runner itself. Protocol 91 Step 7a will classify 'codex' as unreachable in
-  #   these contexts and emit a warning comment on the PR. This is expected
-  #   behaviour — not a misconfiguration.
+  #   these contexts. Because 'codex' is the only default internal reviewer, that
+  #   means zero reviewers are reachable and the gate hard-fails until the run is
+  #   retried from Codex or a local override selects a reachable reviewer. This is
+  #   expected behaviour — not a misconfiguration.
   #
   # Local override: developers who need a different top-level review runner can
   # override this list locally by creating .tmp/template-config.json in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Codex internal reviewer default**: makes `codex` the default Step 7a internal reviewer for Codex-first workflow runs.
+
 ### Fixed
 
 - **Claude Code Action reviewer no-op guard** (#866): passes an explicit code-review prompt to the workflow and fails closed when a successful run log shows Claude did not actually execute.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Codex GitHub reviewer loop**: aligns the documented Codex bot default with the reviewer scripts, ignores outdated Codex review threads, and treats Codex's no-inline-comments review boilerplate as a clean response while preserving the aggregate thread audit.
+- **Codex GitHub reviewer loop**: aligns the documented Codex bot default with the reviewer scripts, ignores outdated Codex review threads, and waits for Codex's definitive thumbs-up or inline-comment signal instead of treating review boilerplate as approval.
 - **Claude Code Action reviewer no-op guard** (#866): passes an explicit code-review prompt to the workflow and fails closed when a successful run log shows Claude did not actually execute.
 
 ## [0.30.2] - 2026-06-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Codex GitHub reviewer loop**: ignores outdated Codex review threads and treats Codex's no-inline-comments review boilerplate as a clean response while preserving the aggregate thread audit.
 - **Claude Code Action reviewer no-op guard** (#866): passes an explicit code-review prompt to the workflow and fails closed when a successful run log shows Claude did not actually execute.
 
 ## [0.30.2] - 2026-06-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Codex internal reviewer default**: makes `codex` the default Step 7a internal reviewer for Codex-first workflow runs.
+- **Codex review routing default**: makes `codex` the default Step 7a internal reviewer and replaces the Claude Code Action after-clean reviewer with `codex-github`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Codex GitHub reviewer loop**: ignores outdated Codex review threads and treats Codex's no-inline-comments review boilerplate as a clean response while preserving the aggregate thread audit.
+- **Codex GitHub reviewer loop**: aligns the documented Codex bot default with the reviewer scripts, ignores outdated Codex review threads, and treats Codex's no-inline-comments review boilerplate as a clean response while preserving the aggregate thread audit.
 - **Claude Code Action reviewer no-op guard** (#866): passes an explicit code-review prompt to the workflow and fails closed when a successful run log shows Claude did not actually execute.
 
 ## [0.30.2] - 2026-06-08

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1741,11 +1741,12 @@ fi
 #
 # NOTE: Skip this check ONLY when Step 7 was 'skipped' because no review platforms are configured.
 echo "⛔ STOP: Verifying all review threads are resolved via GraphQL before applying ready-for-human-review..."
-CODEX_BOT_LOGIN="${CODEX_GITHUB_BOT_LOGIN:-codex-ai[bot]}"
+CODEX_BOT_LOGIN="${CODEX_GITHUB_BOT_LOGIN:-chatgpt-codex-connector[bot]}"
 # GraphQL author.login omits the "[bot]" suffix present in REST API logins; strip it.
 CODEX_BOT_LOGIN="${CODEX_BOT_LOGIN%\[bot\]}"
 JQ_FILTER="[.data.repository.pullRequest.reviewThreads.nodes[]
         | select(.isResolved == false)
+        | select((.isOutdated // false) == false)
         | select(.comments.nodes[0].author.login as \$a | [\"coderabbitai\",\"devin-ai-integration\",\"greptile-apps\",\"$CODEX_BOT_LOGIN\"] | index(\$a) != null)
         | select((.comments.nodes[0].body // \"\") | test(\"✅ Addressed\") | not)] | length"
 UNRESOLVED_COUNT=$(gh api graphql -f query='
@@ -1753,7 +1754,7 @@ UNRESOLVED_COUNT=$(gh api graphql -f query='
     repository(owner:$owner, name:$repo) {
       pullRequest(number:$number) {
         reviewThreads(first: 100) {
-          nodes { isResolved comments(first: 1) { nodes { author { login } body } } }
+          nodes { isResolved isOutdated comments(first: 1) { nodes { author { login } body } } }
         }
       }
     }
@@ -1804,10 +1805,10 @@ Review bots like the Codex GitHub App (`codex-github`) post `reviewThreads` asyn
 
 2. **Re-query review threads**:
 
-   Before running the query, resolve the Codex bot login. Use the value of `CODEX_GITHUB_BOT_LOGIN` if set; otherwise default to `"codex-ai[bot]"` (the default used by `codex-github-reviewer.sh`). Strip the `[bot]` suffix because GraphQL `author.login` values omit it:
+   Before running the query, resolve the Codex bot login. Use the value of `CODEX_GITHUB_BOT_LOGIN` if set; otherwise default to `"chatgpt-codex-connector[bot]"` (the default used by `codex-github-reviewer.sh`). Strip the `[bot]` suffix because GraphQL `author.login` values omit it:
 
    ```bash
-   CODEX_BOT_LOGIN="${CODEX_GITHUB_BOT_LOGIN:-codex-ai[bot]}"
+   CODEX_BOT_LOGIN="${CODEX_GITHUB_BOT_LOGIN:-chatgpt-codex-connector[bot]}"
    # GraphQL author.login omits the "[bot]" suffix present in REST API logins; strip it.
    CODEX_BOT_LOGIN="${CODEX_BOT_LOGIN%\[bot\]}"
    ```
@@ -1815,6 +1816,7 @@ Review bots like the Codex GitHub App (`codex-github`) post `reviewThreads` asyn
    ```bash
    JQ_FILTER="[.data.repository.pullRequest.reviewThreads.nodes[]
          | select(.isResolved == false)
+         | select((.isOutdated // false) == false)
          | select(.comments.nodes[0].author.login as \$a | [\"coderabbitai\",\"devin-ai-integration\",\"greptile-apps\",\"$CODEX_BOT_LOGIN\"] | index(\$a) != null)
          | select((.comments.nodes[0].body // \"\") | test(\"✅ Addressed\") | not)] | length"
    UNRESOLVED_RECHECK=$(gh api graphql -f query='
@@ -1822,7 +1824,7 @@ Review bots like the Codex GitHub App (`codex-github`) post `reviewThreads` asyn
        repository(owner:$owner, name:$repo) {
          pullRequest(number:$number) {
            reviewThreads(first: 100) {
-             nodes { isResolved comments(first: 1) { nodes { author { login } body } } }
+           nodes { isResolved isOutdated comments(first: 1) { nodes { author { login } body } } }
            }
          }
        }

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1824,7 +1824,7 @@ Review bots like the Codex GitHub App (`codex-github`) post `reviewThreads` asyn
        repository(owner:$owner, name:$repo) {
          pullRequest(number:$number) {
            reviewThreads(first: 100) {
-           nodes { isResolved isOutdated comments(first: 1) { nodes { author { login } body } } }
+             nodes { isResolved isOutdated comments(first: 1) { nodes { author { login } body } } }
            }
          }
        }

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -502,11 +502,20 @@ echo "INFO: poll budget exhausted; waiting ${POLL_INTERVAL}s for late async resp
 
 if [ "$MAX_RETRIGGERS" -gt 0 ]; then
   echo "INFO: posting async-arrival trigger comment..."
-  if ! gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
+  if ! TRIGGER_RESPONSE=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
     --method POST \
-    --raw-field body="$TRIGGER_PHRASE — async-arrival check after poll-window expiry (sha: $CURRENT_SHA)" \
-    --jq '.created_at' >/dev/null; then
+    --raw-field body="$TRIGGER_PHRASE — async-arrival check after poll-window expiry (sha: $CURRENT_SHA)"); then
     echo "WARNING: failed to post async-arrival trigger comment; continuing with grace poll from existing trigger time" >&2
+  else
+    if ! TRIGGER_TIME=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -re '.created_at'); then
+      echo "VERDICT: TIMED_OUT — malformed async trigger comment response (treated as unavailable)"
+      exit 2
+    fi
+    if ! TRIGGER_COMMENT_ID=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -re '.id | tostring'); then
+      echo "VERDICT: TIMED_OUT — malformed async trigger comment response (treated as unavailable)"
+      exit 2
+    fi
+    echo "INFO: async-arrival trigger comment posted at $TRIGGER_TIME"
   fi
 else
   echo "INFO: MAX_RETRIGGERS=0 — skipping async-arrival trigger comment; grace poll will use existing trigger time"
@@ -517,6 +526,26 @@ sleep "$POLL_INTERVAL"
 
 # Single grace poll: check both PR comments and PR reviews
 ASYNC_BOT_RESPONSE=""
+
+if ! ASYNC_INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME"); then
+  echo "VERDICT: TIMED_OUT — failed to fetch Codex inline review comments during async grace period (treated as unavailable)"
+  exit 2
+fi
+if [ "$ASYNC_INLINE_REVIEW_COMMENT_COUNT" -gt 0 ]; then
+  echo "VERDICT: NEEDS_REVISION"
+  echo "INFO: detected $ASYNC_INLINE_REVIEW_COMMENT_COUNT Codex inline review comment(s) during async grace period"
+  exit 1
+fi
+
+if ! ASYNC_APPROVAL_REACTION_COUNT=$(codex_trigger_approval_reaction_count "$TRIGGER_COMMENT_ID"); then
+  echo "VERDICT: TIMED_OUT — failed to fetch Codex trigger reactions during async grace period (treated as unavailable)"
+  exit 2
+fi
+if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
+  echo "VERDICT: APPROVED"
+  echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID during async grace period"
+  exit 0
+fi
 
 ASYNC_POLL_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -196,14 +196,15 @@ codex_trigger_approval_reaction_count() {
 
   local reaction_tmpfile
   reaction_tmpfile=$(mktemp)
-  if gh api "repos/$OWNER/$REPO/issues/comments/$comment_id/reactions" \
-    2>/dev/null \
-    | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" \
-      '[.[] | select(.content == "+1" and (.user.login == $bot or .user.login == $bot_plain))] | length' \
+  if gh api "repos/$OWNER/$REPO/issues/comments/$comment_id/reactions" --paginate \
+    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" \
+      '(add // []) | [.[] | select(.content == "+1" and (.user.login == $bot or .user.login == $bot_plain))] | length' \
     > "$reaction_tmpfile"; then
     cat "$reaction_tmpfile"
   else
-    printf '0\n'
+    rm -f "$reaction_tmpfile"
+    echo "ERROR: failed to fetch or parse Codex trigger reactions" >&2
+    return 3
   fi
   rm -f "$reaction_tmpfile"
 }
@@ -215,13 +216,14 @@ codex_inline_review_comment_count_since() {
   local review_comment_tmpfile
   review_comment_tmpfile=$(mktemp)
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments" --paginate \
-    2>/dev/null \
-    | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$trigger_time" \
-      '[.[] | select((.user.login == $bot or .user.login == $bot_plain) and .created_at > $trigger_time)] | length' \
+    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$trigger_time" \
+      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .created_at > $trigger_time)] | length' \
     > "$review_comment_tmpfile"; then
     cat "$review_comment_tmpfile"
   else
-    printf '0\n'
+    rm -f "$review_comment_tmpfile"
+    echo "ERROR: failed to fetch or parse Codex inline review comments" >&2
+    return 3
   fi
   rm -f "$review_comment_tmpfile"
 }
@@ -255,10 +257,16 @@ rm -f "$IDEM_STDERR" "$IDEM_TMPFILE"
 
 TRIGGER_TIME=""
 if [ -n "$TRIGGER_COMMENT_INFO" ]; then
-  # jq outputs pretty-printed JSON with a space after the colon: "created_at": "..."
-  # Use ' *' to match zero or more spaces to handle both compact and pretty-print output.
-  TRIGGER_COMMENT_ID=$(echo "$TRIGGER_COMMENT_INFO" | grep -o '"id": *[0-9]*' | head -1 | sed 's/"id": *//')
-  TRIGGER_TIME=$(echo "$TRIGGER_COMMENT_INFO" | grep -o '"created_at": *"[^"]*"' | head -1 | sed 's/"created_at": *"//;s/"//')
+  if ! TRIGGER_COMMENT_ID=$(printf '%s\n' "$TRIGGER_COMMENT_INFO" | jq -re '.id | tostring'); then
+    echo "ERROR: existing trigger comment payload missing id" >&2
+    echo "VERDICT: TIMED_OUT — malformed trigger comment payload (treated as unavailable)"
+    exit 2
+  fi
+  if ! TRIGGER_TIME=$(printf '%s\n' "$TRIGGER_COMMENT_INFO" | jq -re '.created_at'); then
+    echo "ERROR: existing trigger comment payload missing created_at" >&2
+    echo "VERDICT: TIMED_OUT — malformed trigger comment payload (treated as unavailable)"
+    exit 2
+  fi
   if [ -n "$TRIGGER_TIME" ]; then
     echo "INFO: trigger comment already posted for commit $CURRENT_SHA (at $TRIGGER_TIME) — skipping duplicate post"
   fi
@@ -281,9 +289,12 @@ if [ -z "$TRIGGER_TIME" ]; then
     echo "VERDICT: TIMED_OUT — failed to post trigger comment (treated as unavailable)"
     exit 2
   fi
-  TRIGGER_TIME=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -r '.created_at // empty')
-  TRIGGER_COMMENT_ID=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -r '.id // empty')
-  if [ -z "$TRIGGER_TIME" ] || [ -z "$TRIGGER_COMMENT_ID" ]; then
+  if ! TRIGGER_TIME=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -re '.created_at'); then
+    echo "ERROR: trigger comment response missing created_at" >&2
+    echo "VERDICT: TIMED_OUT — malformed trigger comment response (treated as unavailable)"
+    exit 2
+  fi
+  if ! TRIGGER_COMMENT_ID=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -re '.id | tostring'); then
     echo "ERROR: trigger comment response missing id or created_at" >&2
     echo "VERDICT: TIMED_OUT — malformed trigger comment response (treated as unavailable)"
     exit 2
@@ -369,14 +380,20 @@ while true; do
     rm -f "$REVIEW_TMPFILE"
   fi
 
-  INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME")
+  if ! INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME"); then
+    echo "VERDICT: TIMED_OUT — failed to fetch Codex inline review comments (treated as unavailable)"
+    exit 2
+  fi
   if [ "$INLINE_REVIEW_COMMENT_COUNT" -gt 0 ]; then
     echo "VERDICT: NEEDS_REVISION"
     echo "INFO: detected $INLINE_REVIEW_COMMENT_COUNT Codex inline review comment(s) after trigger"
     exit 1
   fi
 
-  APPROVAL_REACTION_COUNT=$(codex_trigger_approval_reaction_count "$TRIGGER_COMMENT_ID")
+  if ! APPROVAL_REACTION_COUNT=$(codex_trigger_approval_reaction_count "$TRIGGER_COMMENT_ID"); then
+    echo "VERDICT: TIMED_OUT — failed to fetch Codex trigger reactions (treated as unavailable)"
+    exit 2
+  fi
   if [ "$APPROVAL_REACTION_COUNT" -gt 0 ]; then
     echo "VERDICT: APPROVED"
     echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID"
@@ -456,9 +473,12 @@ while true; do
       echo "VERDICT: TIMED_OUT — failed to post retrigger comment (treated as unavailable)"
       exit 2
     fi
-    TRIGGER_TIME=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -r '.created_at // empty')
-    TRIGGER_COMMENT_ID=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -r '.id // empty')
-    if [ -z "$TRIGGER_TIME" ] || [ -z "$TRIGGER_COMMENT_ID" ]; then
+    if ! TRIGGER_TIME=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -re '.created_at'); then
+      echo "ERROR: retrigger comment response missing created_at" >&2
+      echo "VERDICT: TIMED_OUT — malformed retrigger comment response (treated as unavailable)"
+      exit 2
+    fi
+    if ! TRIGGER_COMMENT_ID=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -re '.id | tostring'); then
       echo "ERROR: retrigger comment response missing id or created_at" >&2
       echo "VERDICT: TIMED_OUT — malformed retrigger comment response (treated as unavailable)"
       exit 2

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -591,6 +591,26 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     exit 0
   elif echo "$ASYNC_BOT_RESPONSE" | grep -qi "If Codex has suggestions, it will comment; otherwise it will react with"; then
     echo "INFO: async-arrival Codex acknowledgement detected without approval reaction or inline comments"
+    echo "INFO: waiting ${POLL_INTERVAL}s for final Codex async signal..."
+    sleep "$POLL_INTERVAL"
+    if ! ASYNC_INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME"); then
+      echo "VERDICT: TIMED_OUT — failed to fetch Codex inline review comments after async acknowledgement (treated as unavailable)"
+      exit 2
+    fi
+    if [ "$ASYNC_INLINE_REVIEW_COMMENT_COUNT" -gt 0 ]; then
+      echo "VERDICT: NEEDS_REVISION"
+      echo "INFO: detected $ASYNC_INLINE_REVIEW_COMMENT_COUNT Codex inline review comment(s) after async acknowledgement"
+      exit 1
+    fi
+    if ! ASYNC_APPROVAL_REACTION_COUNT=$(codex_trigger_approval_reaction_count "$TRIGGER_COMMENT_ID"); then
+      echo "VERDICT: TIMED_OUT — failed to fetch Codex trigger reactions after async acknowledgement (treated as unavailable)"
+      exit 2
+    fi
+    if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
+      echo "VERDICT: APPROVED"
+      echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID after async acknowledgement"
+      exit 0
+    fi
   else
     echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
     echo "---BEGIN BOT RESPONSE---"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -38,8 +38,8 @@
 #      "no blocking issues found"; bare "blocking" excluded (too broad).
 #   2. Approval signals present → APPROVED (exit 0)
 #      Signals (case-insensitive): "approved", "lgtm", "looks good",
-#      "didn't find any major issues", "no blocking issues", or Codex's
-#      no-inline-comments review boilerplate (thread audit catches real inline findings)
+#      "didn't find any major issues", "no blocking issues", or a Codex
+#      thumbs-up reaction on the trigger comment
 #   3. Neither found (unrecognized format) → safe-fails to NEEDS_REVISION (exit 1)
 #
 # Response source detection (two sources polled each cycle):
@@ -188,6 +188,44 @@ echo "INFO: Poll interval: ${POLL_INTERVAL}s, Max wait (total): ${MAX_WAIT}s"
 BOT_LOGIN_PLAIN="${BOT_LOGIN%\[bot\]}"
 echo "INFO: Bot login (plain, for PR-comment matching): $BOT_LOGIN_PLAIN"
 
+TRIGGER_COMMENT_ID=""
+
+codex_trigger_approval_reaction_count() {
+  local comment_id="$1"
+  [ -z "$comment_id" ] && { printf '0\n'; return 0; }
+
+  local reaction_tmpfile
+  reaction_tmpfile=$(mktemp)
+  if gh api "repos/$OWNER/$REPO/issues/comments/$comment_id/reactions" \
+    2>/dev/null \
+    | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" \
+      '[.[] | select(.content == "+1" and (.user.login == $bot or .user.login == $bot_plain))] | length' \
+    > "$reaction_tmpfile"; then
+    cat "$reaction_tmpfile"
+  else
+    printf '0\n'
+  fi
+  rm -f "$reaction_tmpfile"
+}
+
+codex_inline_review_comment_count_since() {
+  local trigger_time="$1"
+  [ -z "$trigger_time" ] && { printf '0\n'; return 0; }
+
+  local review_comment_tmpfile
+  review_comment_tmpfile=$(mktemp)
+  if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments" --paginate \
+    2>/dev/null \
+    | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$trigger_time" \
+      '[.[] | select((.user.login == $bot or .user.login == $bot_plain) and .created_at > $trigger_time)] | length' \
+    > "$review_comment_tmpfile"; then
+    cat "$review_comment_tmpfile"
+  else
+    printf '0\n'
+  fi
+  rm -f "$review_comment_tmpfile"
+}
+
 # ── Idempotency guard (BR-10) ─────────────────────────────────────────────────
 # Check whether a trigger comment for the current commit SHA already exists.
 # We look for a comment body containing BOTH the trigger phrase AND the SHA to
@@ -219,6 +257,7 @@ TRIGGER_TIME=""
 if [ -n "$TRIGGER_COMMENT_INFO" ]; then
   # jq outputs pretty-printed JSON with a space after the colon: "created_at": "..."
   # Use ' *' to match zero or more spaces to handle both compact and pretty-print output.
+  TRIGGER_COMMENT_ID=$(echo "$TRIGGER_COMMENT_INFO" | grep -o '"id": *[0-9]*' | head -1 | sed 's/"id": *//')
   TRIGGER_TIME=$(echo "$TRIGGER_COMMENT_INFO" | grep -o '"created_at": *"[^"]*"' | head -1 | sed 's/"created_at": *"//;s/"//')
   if [ -n "$TRIGGER_TIME" ]; then
     echo "INFO: trigger comment already posted for commit $CURRENT_SHA (at $TRIGGER_TIME) — skipping duplicate post"
@@ -235,12 +274,18 @@ if [ -z "$TRIGGER_TIME" ]; then
   # filtered out during polling (created_at > TRIGGER_TIME would be false).
   # Guard with 'if !' to emit TIMED_OUT (exit 2) on failure instead of letting
   # set -e exit with code 1 (NEEDS_REVISION) without a VERDICT line.
-  if ! TRIGGER_TIME=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
+  if ! TRIGGER_RESPONSE=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
     --method POST \
-    --raw-field body="$TRIGGER_PHRASE (review triggered by workflow runner, commit: $CURRENT_SHA)" \
-    --jq '.created_at'); then
+    --raw-field body="$TRIGGER_PHRASE (review triggered by workflow runner, commit: $CURRENT_SHA)"); then
     echo "ERROR: failed to post trigger comment to PR #$PR_NUMBER" >&2
     echo "VERDICT: TIMED_OUT — failed to post trigger comment (treated as unavailable)"
+    exit 2
+  fi
+  TRIGGER_TIME=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -r '.created_at // empty')
+  TRIGGER_COMMENT_ID=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -r '.id // empty')
+  if [ -z "$TRIGGER_TIME" ] || [ -z "$TRIGGER_COMMENT_ID" ]; then
+    echo "ERROR: trigger comment response missing id or created_at" >&2
+    echo "VERDICT: TIMED_OUT — malformed trigger comment response (treated as unavailable)"
     exit 2
   fi
   echo "INFO: trigger comment posted at $TRIGGER_TIME (server-assigned timestamp)"
@@ -324,6 +369,20 @@ while true; do
     rm -f "$REVIEW_TMPFILE"
   fi
 
+  INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME")
+  if [ "$INLINE_REVIEW_COMMENT_COUNT" -gt 0 ]; then
+    echo "VERDICT: NEEDS_REVISION"
+    echo "INFO: detected $INLINE_REVIEW_COMMENT_COUNT Codex inline review comment(s) after trigger"
+    exit 1
+  fi
+
+  APPROVAL_REACTION_COUNT=$(codex_trigger_approval_reaction_count "$TRIGGER_COMMENT_ID")
+  if [ "$APPROVAL_REACTION_COUNT" -gt 0 ]; then
+    echo "VERDICT: APPROVED"
+    echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID"
+    exit 0
+  fi
+
   if [ -n "$BOT_RESPONSE" ]; then
     echo "INFO: bot response detected"
 
@@ -342,9 +401,8 @@ while true; do
     #
     # 2. Explicit approval signals present → APPROVED (exit 0)   [checked second]
     #    Approval signals: "approved", "lgtm", "looks good",
-    #    "didn't find any major issues", "no blocking issues", or Codex's
-    #    no-inline-comments review boilerplate. A later review-thread audit still
-    #    catches real inline findings when Codex posts them alongside the boilerplate.
+    #    "didn't find any major issues", "no blocking issues", or a Codex
+    #    thumbs-up reaction on the trigger comment (checked above).
     #
     # 3. Neither found (unrecognized response format) → NEEDS_REVISION (exit 1)
     #    Safe-fail: default to NEEDS_REVISION when the format is unrecognized to
@@ -364,12 +422,15 @@ while true; do
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 1
-    elif echo "$BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?|If Codex has suggestions, it will comment; otherwise it will react with)"; then
+    elif echo "$BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
       echo "VERDICT: APPROVED"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 0
+    elif echo "$BOT_RESPONSE" | grep -qi "If Codex has suggestions, it will comment; otherwise it will react with"; then
+      echo "INFO: Codex acknowledgement detected; waiting for thumbs-up reaction or inline review comments"
+      continue
     else
       echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
       echo "---BEGIN BOT RESPONSE---"
@@ -388,12 +449,18 @@ while true; do
     echo "INFO: no response yet; re-triggering (attempt ${ATTEMPT_NUM}/${TOTAL_ATTEMPTS}, total elapsed ${TOTAL_ELAPSED}s/${MAX_WAIT}s)..."
     # --raw-field passes the body string as-is to the GitHub API without shell
     # re-interpretation, so special characters in TRIGGER_PHRASE are safe.
-    if ! TRIGGER_TIME=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
+    if ! TRIGGER_RESPONSE=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
       --method POST \
-      --raw-field body="$TRIGGER_PHRASE — retrigger ${RETRIGGER_COUNT}/${MAX_RETRIGGERS} after timeout (sha: $CURRENT_SHA)" \
-      --jq '.created_at'); then
+      --raw-field body="$TRIGGER_PHRASE — retrigger ${RETRIGGER_COUNT}/${MAX_RETRIGGERS} after timeout (sha: $CURRENT_SHA)"); then
       echo "ERROR: failed to post retrigger comment to PR #$PR_NUMBER" >&2
       echo "VERDICT: TIMED_OUT — failed to post retrigger comment (treated as unavailable)"
+      exit 2
+    fi
+    TRIGGER_TIME=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -r '.created_at // empty')
+    TRIGGER_COMMENT_ID=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -r '.id // empty')
+    if [ -z "$TRIGGER_TIME" ] || [ -z "$TRIGGER_COMMENT_ID" ]; then
+      echo "ERROR: retrigger comment response missing id or created_at" >&2
+      echo "VERDICT: TIMED_OUT — malformed retrigger comment response (treated as unavailable)"
       exit 2
     fi
     echo "INFO: retrigger comment posted at $TRIGGER_TIME (TRIGGER_TIME updated)"
@@ -467,12 +534,14 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     echo "$ASYNC_BOT_RESPONSE"
     echo "---END BOT RESPONSE---"
     exit 1
-  elif echo "$ASYNC_BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?|If Codex has suggestions, it will comment; otherwise it will react with)"; then
+  elif echo "$ASYNC_BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
     echo "VERDICT: APPROVED"
     echo "---BEGIN BOT RESPONSE---"
     echo "$ASYNC_BOT_RESPONSE"
     echo "---END BOT RESPONSE---"
     exit 0
+  elif echo "$ASYNC_BOT_RESPONSE" | grep -qi "If Codex has suggestions, it will comment; otherwise it will react with"; then
+    echo "INFO: async-arrival Codex acknowledgement detected without approval reaction or inline comments"
   else
     echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
     echo "---BEGIN BOT RESPONSE---"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -500,6 +500,7 @@ done  # end outer retrigger loop
 
 echo "INFO: poll budget exhausted; waiting ${POLL_INTERVAL}s for late async response..."
 
+ASYNC_TRIGGER_COMMENT_ID=""
 if [ "$MAX_RETRIGGERS" -gt 0 ]; then
   echo "INFO: posting async-arrival trigger comment..."
   if ! TRIGGER_RESPONSE=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
@@ -507,15 +508,15 @@ if [ "$MAX_RETRIGGERS" -gt 0 ]; then
     --raw-field body="$TRIGGER_PHRASE — async-arrival check after poll-window expiry (sha: $CURRENT_SHA)"); then
     echo "WARNING: failed to post async-arrival trigger comment; continuing with grace poll from existing trigger time" >&2
   else
-    if ! TRIGGER_TIME=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -re '.created_at'); then
+    if ! ASYNC_TRIGGER_TIME=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -re '.created_at'); then
       echo "VERDICT: TIMED_OUT — malformed async trigger comment response (treated as unavailable)"
       exit 2
     fi
-    if ! TRIGGER_COMMENT_ID=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -re '.id | tostring'); then
+    if ! ASYNC_TRIGGER_COMMENT_ID=$(printf '%s\n' "$TRIGGER_RESPONSE" | jq -re '.id | tostring'); then
       echo "VERDICT: TIMED_OUT — malformed async trigger comment response (treated as unavailable)"
       exit 2
     fi
-    echo "INFO: async-arrival trigger comment posted at $TRIGGER_TIME"
+    echo "INFO: async-arrival trigger comment posted at $ASYNC_TRIGGER_TIME"
   fi
 else
   echo "INFO: MAX_RETRIGGERS=0 — skipping async-arrival trigger comment; grace poll will use existing trigger time"
@@ -540,6 +541,13 @@ fi
 if ! ASYNC_APPROVAL_REACTION_COUNT=$(codex_trigger_approval_reaction_count "$TRIGGER_COMMENT_ID"); then
   echo "VERDICT: TIMED_OUT — failed to fetch Codex trigger reactions during async grace period (treated as unavailable)"
   exit 2
+fi
+if [ -n "$ASYNC_TRIGGER_COMMENT_ID" ]; then
+  if ! ASYNC_EXTRA_APPROVAL_REACTION_COUNT=$(codex_trigger_approval_reaction_count "$ASYNC_TRIGGER_COMMENT_ID"); then
+    echo "VERDICT: TIMED_OUT — failed to fetch Codex async trigger reactions during async grace period (treated as unavailable)"
+    exit 2
+  fi
+  ASYNC_APPROVAL_REACTION_COUNT=$((ASYNC_APPROVAL_REACTION_COUNT + ASYNC_EXTRA_APPROVAL_REACTION_COUNT))
 fi
 if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
   echo "VERDICT: APPROVED"
@@ -605,6 +613,13 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     if ! ASYNC_APPROVAL_REACTION_COUNT=$(codex_trigger_approval_reaction_count "$TRIGGER_COMMENT_ID"); then
       echo "VERDICT: TIMED_OUT — failed to fetch Codex trigger reactions after async acknowledgement (treated as unavailable)"
       exit 2
+    fi
+    if [ -n "$ASYNC_TRIGGER_COMMENT_ID" ]; then
+      if ! ASYNC_EXTRA_APPROVAL_REACTION_COUNT=$(codex_trigger_approval_reaction_count "$ASYNC_TRIGGER_COMMENT_ID"); then
+        echo "VERDICT: TIMED_OUT — failed to fetch Codex async trigger reactions after async acknowledgement (treated as unavailable)"
+        exit 2
+      fi
+      ASYNC_APPROVAL_REACTION_COUNT=$((ASYNC_APPROVAL_REACTION_COUNT + ASYNC_EXTRA_APPROVAL_REACTION_COUNT))
     fi
     if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
       echo "VERDICT: APPROVED"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -38,7 +38,8 @@
 #      "no blocking issues found"; bare "blocking" excluded (too broad).
 #   2. Approval signals present → APPROVED (exit 0)
 #      Signals (case-insensitive): "approved", "lgtm", "looks good",
-#      "didn't find any major issues", "no blocking issues" (Codex clean phrases)
+#      "didn't find any major issues", "no blocking issues", or Codex's
+#      no-inline-comments review boilerplate (thread audit catches real inline findings)
 #   3. Neither found (unrecognized format) → safe-fails to NEEDS_REVISION (exit 1)
 #
 # Response source detection (two sources polled each cycle):
@@ -341,7 +342,9 @@ while true; do
     #
     # 2. Explicit approval signals present → APPROVED (exit 0)   [checked second]
     #    Approval signals: "approved", "lgtm", "looks good",
-    #    "didn't find any major issues", "no blocking issues" (Codex clean phrases)
+    #    "didn't find any major issues", "no blocking issues", or Codex's
+    #    no-inline-comments review boilerplate. A later review-thread audit still
+    #    catches real inline findings when Codex posts them alongside the boilerplate.
     #
     # 3. Neither found (unrecognized response format) → NEEDS_REVISION (exit 1)
     #    Safe-fail: default to NEEDS_REVISION when the format is unrecognized to
@@ -361,7 +364,7 @@ while true; do
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 1
-    elif echo "$BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
+    elif echo "$BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?|If Codex has suggestions, it will comment; otherwise it will react with)"; then
       echo "VERDICT: APPROVED"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
@@ -464,7 +467,7 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     echo "$ASYNC_BOT_RESPONSE"
     echo "---END BOT RESPONSE---"
     exit 1
-  elif echo "$ASYNC_BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
+  elif echo "$ASYNC_BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?|If Codex has suggestions, it will comment; otherwise it will react with)"; then
     echo "VERDICT: APPROVED"
     echo "---BEGIN BOT RESPONSE---"
     echo "$ASYNC_BOT_RESPONSE"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3323,6 +3323,7 @@ check_unresolved_threads() {
   #
   # A thread is considered resolved when:
   #   - isResolved=true (GitHub resolved it via the Resolve button / mutation), OR
+  #   - isOutdated=true (GitHub marked it stale after a newer commit), OR
   #   - the first comment body contains "✅ Addressed" (bot self-marked it resolved)
   #
   # Only threads whose first comment was authored by a configured bot login are counted.
@@ -3361,7 +3362,7 @@ check_unresolved_threads() {
   # GraphQL query: paginate reviewThreads 100 at a time, fetch first comment per thread.
   # Using inline query string to avoid heredoc quoting issues in subshells.
   local graphql_query
-  graphql_query='query($owner:String!,$repo:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100,after:$cursor){pageInfo{hasNextPage endCursor}nodes{id isResolved comments(first:1){nodes{author{login}body}}}}}}}'
+  graphql_query='query($owner:String!,$repo:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100,after:$cursor){pageInfo{hasNextPage endCursor}nodes{id isResolved isOutdated comments(first:1){nodes{author{login}body}}}}}}}'
 
   while [ "$has_next_page" = "true" ]; do
     page=$((page + 1))
@@ -3402,8 +3403,9 @@ check_unresolved_threads() {
     while IFS= read -r thread_json; do
       [ -z "${thread_json:-}" ] && continue
 
-      local is_resolved author body
+      local is_resolved is_outdated author body
       is_resolved="$(printf '%s\n' "$thread_json" | jq -r '.isResolved')"
+      is_outdated="$(printf '%s\n' "$thread_json" | jq -r '.isOutdated // false')"
       author="$(printf '%s\n' "$thread_json" | jq -r '.comments.nodes[0].author.login // ""')"
       body="$(printf '%s\n' "$thread_json" | jq -r '.comments.nodes[0].body // ""')"
 
@@ -3416,8 +3418,9 @@ check_unresolved_threads() {
       done
       [ "$is_bot" -eq 0 ] && continue
 
-      # Thread is resolved if isResolved=true (GitHub resolved) or body contains "✅ Addressed"
+      # Thread is resolved if isResolved=true, isOutdated=true, or body contains "✅ Addressed"
       if [ "$is_resolved" = "true" ]; then continue; fi
+      if [ "$is_outdated" = "true" ]; then continue; fi
       if printf '%s\n' "$body" | grep -q "✅ Addressed"; then continue; fi
 
       unresolved_count=$((unresolved_count + 1))

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1419,14 +1419,14 @@ export MOCK_GH_OUTPUT='{
 run_test "codex_thread_audit_all_outdated_clean" "0" \
   "$(check_unresolved_threads "42" "owner/repo" "chatgpt-codex-connector")"
 unset MOCK_GH_OUTPUT
-if grep -q "If Codex has suggestions, it will comment; otherwise it will react with" \
+if grep -q "Codex acknowledgement detected; waiting for thumbs-up reaction or inline review comments" \
     "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh"; then
-  _codex_clean_boilerplate_signal="yes"
+  _codex_ack_wait_signal="yes"
 else
-  _codex_clean_boilerplate_signal="no"
+  _codex_ack_wait_signal="no"
 fi
-run_test "codex_reviewer_clean_boilerplate_signal" "yes" "$_codex_clean_boilerplate_signal"
-unset _codex_clean_boilerplate_signal
+run_test "codex_reviewer_ack_wait_signal" "yes" "$_codex_ack_wait_signal"
+unset _codex_ack_wait_signal
 
 _unlock_pr="80213$$"
 _unlock_lock_dir="/tmp/pr-review-loop-${_unlock_pr}.lockdir"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1365,6 +1365,69 @@ unset MOCK_GH_EXIT MOCK_GH_LABEL_VIEW_EXIT MOCK_GH_LABEL_CREATE_EXIT MOCK_GH_PR_
 echo ""
 echo "=== Area 13: PR #801 reviewer-loop failure paths ==="
 
+export MOCK_GH_OUTPUT='{
+  "pageInfo": {"hasNextPage": false, "endCursor": null},
+  "nodes": [
+    {
+      "id": "thread-outdated",
+      "isResolved": false,
+      "isOutdated": true,
+      "comments": {
+        "nodes": [
+          {
+            "author": {"login": "chatgpt-codex-connector"},
+            "body": "stale Codex finding"
+          }
+        ]
+      }
+    },
+    {
+      "id": "thread-active",
+      "isResolved": false,
+      "isOutdated": false,
+      "comments": {
+        "nodes": [
+          {
+            "author": {"login": "chatgpt-codex-connector"},
+            "body": "active Codex finding"
+          }
+        ]
+      }
+    }
+  ]
+}'
+run_test "codex_thread_audit_ignores_outdated" "1" \
+  "$(check_unresolved_threads "42" "owner/repo" "chatgpt-codex-connector")"
+export MOCK_GH_OUTPUT='{
+  "pageInfo": {"hasNextPage": false, "endCursor": null},
+  "nodes": [
+    {
+      "id": "thread-outdated",
+      "isResolved": false,
+      "isOutdated": true,
+      "comments": {
+        "nodes": [
+          {
+            "author": {"login": "chatgpt-codex-connector"},
+            "body": "stale Codex finding"
+          }
+        ]
+      }
+    }
+  ]
+}'
+run_test "codex_thread_audit_all_outdated_clean" "0" \
+  "$(check_unresolved_threads "42" "owner/repo" "chatgpt-codex-connector")"
+unset MOCK_GH_OUTPUT
+if grep -q "If Codex has suggestions, it will comment; otherwise it will react with" \
+    "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh"; then
+  _codex_clean_boilerplate_signal="yes"
+else
+  _codex_clean_boilerplate_signal="no"
+fi
+run_test "codex_reviewer_clean_boilerplate_signal" "yes" "$_codex_clean_boilerplate_signal"
+unset _codex_clean_boilerplate_signal
+
 _unlock_pr="80213$$"
 _unlock_lock_dir="/tmp/pr-review-loop-${_unlock_pr}.lockdir"
 rm -rf "$_unlock_lock_dir"


### PR DESCRIPTION
## Summary

- Default Step 7a `review.internal_reviewers` to `codex` in `.ai-dev-workflow.yaml`.
- Replace the Claude Code Action after-clean review platform with `codex-github`.
- Clarify the local override comment for Claude Code or other non-Codex top-level runners.
- Fix Codex GitHub reviewer handling so stale/outdated Codex threads do not block reruns.
- Make the Codex GitHub reviewer wait for definitive final signals: inline comments mean needs-fixes, a Codex thumbs-up reaction on the trigger means clean, and review boilerplate is treated as an acknowledgement.
- Align Protocol 91 Codex bot-login defaults and late-thread checks with the reviewer scripts.
- Add `[Unreleased]` changelog entries for the template behavior change and reviewer-loop fix.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".ai-dev-workflow.yaml"); puts "yaml ok"'`
- `npx markdownlint-cli2 CHANGELOG.md docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`
- `python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`
- `bash -n scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/codex-github-reviewer.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` — 142 passed, 0 failed
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `rg -n "codex-ai\[bot\]" .ai-dev-workflow.yaml docs/workflow/development-workflow scripts -g '!node_modules'` — no matches
- `git diff --check`

## Pre-Submission Self-Review

- Reviewed `git diff` against `origin/develop`; scope is limited to shared workflow config, Protocol 91 reviewer guidance, Codex reviewer-loop support, tests, and changelog.
- Confirmed the config now consistently routes default internal and after-clean review through Codex.
- Confirmed the config states the zero-reviewer hard-fail behavior for non-Codex runners and documents the local override path.
- Confirmed stale Codex threads are ignored via `isOutdated`, while active unresolved Codex threads still block.
- Confirmed the Codex GitHub reviewer no longer treats acknowledgement boilerplate as approval.
- Confirmed the Protocol 91 Codex bot default matches the reviewer script default.
- Confirmed no stale markers, generated artifacts, or unrelated workflow files were changed.
