### PR TITLE
docs(plan): add workflow hub operating model plan

### DIFF
--- a/docs/specs/developments/20260610135131_874-workflow-hub-operating-model/2_874-workflow-hub-operating-model_implementation-plan.md
+++ b/docs/specs/developments/20260610135131_874-workflow-hub-operating-model/2_874-workflow-hub-operating-model_implementation-plan.md
@@ -1,0 +1,195 @@
+# Workflow Hub Operating Model and Artifact Ownership - Implementation Plan
+
+**Spec**: [1_874-workflow-hub-operating-model_specs.md](1_874-workflow-hub-operating-model_specs.md)
+**Smoke test runbook**: [874-workflow-hub-operating-model.smoke-test.md](../../../testing/workflow/874-workflow-hub-operating-model.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add a documentation-only architecture note at
+`docs/workflow/development-workflow/repository-modes.md` that defines the three
+supported repository modes, artifact ownership, PR routing, target repository
+selection, and a generic multi-product hub example. Link the note from the root
+`README.md` and `docs/workflow/development-workflow/README.md`.
+
+**Estimated complexity**: S
+
+**Rationale**: The implementation changes documentation only and does not alter
+scripts, config parsing, CI workflows, reviewer integrations, or runtime
+behavior. The main risk is incomplete or ambiguous ownership language, not code
+complexity.
+
+**Dependencies**: None. This is the first workflow-hub sub-item and establishes
+terminology for later implementation work under #873.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `3144f30` |
+| Existing workflow-hub references | `rg -n "workflow hub\|workflow_hub\|product_repo\|single_repo\|target product\|target repository" README.md docs/README.md docs/workflow/development-workflow/README.md docs/workflow/development-workflow docs/project AGENTS.md .ai-dev-workflow.yaml` | No existing repository-mode architecture note or mode definitions found. |
+| Documentation location options | `find docs/workflow/development-workflow -maxdepth 2 -type d -print \| sort` | Existing workflow docs are organized under `integrations/`, `protocols/`, and `templates/`; a top-level workflow architecture note is appropriate. |
+| README link targets | `rg -n "Repository Structure\|AI Development Workflow" README.md docs/workflow/development-workflow/README.md docs/README.md` | Root README has workflow overview sections; workflow README is the canonical workflow index. |
+| Tracker brief and comments | `gh issue view 874 --json title,body,comments,labels,url` | Issue #874 is part of #873, has no scope-changing comments, and carries `integration-branch:workflow-hub-mode`. |
+
+---
+
+## Layer-by-Layer Changes
+
+### Documentation Architecture
+
+- [ ] Add `docs/workflow/development-workflow/repository-modes.md` as the
+      canonical architecture note for repository modes.
+- [ ] Define exactly these code values with display labels and user-facing
+      descriptions: `single_repo`, `workflow_hub`, and `product_repo`.
+- [ ] State that a missing mode declaration is interpreted as `single_repo`.
+- [ ] Add an artifact ownership table covering:
+      backlog/tracker items, specs, plans, hub-owned smoke runbooks,
+      product-owned smoke runbooks, implementation branches, spec PRs, plan PRs,
+      code PRs, CI checks, and reviewer-loop checks.
+- [ ] State where spec, plan, and code PRs are opened in each mode.
+- [ ] Define target product repository selection for hub-managed work items,
+      including the rule that missing or ambiguous targets are flagged before
+      product implementation routing.
+- [ ] Distinguish content that lives in the workflow hub from framework-owned
+      content that may be injected into product repositories.
+- [ ] Include a generic multi-product hub example without private project,
+      repository, or team names.
+- [ ] Explicitly state that this item introduces no runtime behavior changes or
+      migration requirement for existing adopters.
+
+### Root Documentation Links
+
+- [ ] Update `README.md` to link to the repository modes architecture note from
+      the development workflow section or nearby workflow overview.
+- [ ] Update `docs/workflow/development-workflow/README.md` to link to the
+      repository modes architecture note from the workflow documentation index
+      or architecture/configuration section.
+
+### Database / Data Layer
+
+- [ ] None. No schema, migration, seed, or data model changes.
+
+### Backend / API
+
+- [ ] None. No scripts, services, APIs, or workflow automation behavior changes.
+
+### Shared Packages / Libraries
+
+- [ ] None.
+
+### Frontend / UI
+
+- [ ] None.
+
+### Infrastructure / Configuration
+
+- [ ] None. Do not add mode declarations to `.ai-dev-workflow.yaml` in this
+      item; later implementation items can introduce config keys once behavior
+      exists.
+
+---
+
+## Testing Strategy
+
+**Test types**: Markdown lint, documentation smoke/manual verification.
+
+**Key scenarios to test**:
+
+1. Repository modes are defined with display labels and descriptions (AC1).
+2. The architecture note is linked from both required entry points (AC2).
+3. Missing mode defaults to `single_repo` and preserves current behavior (AC3,
+   AC9).
+4. Artifact ownership and PR routing tables cover every artifact named in the
+   spec (AC4, AC5).
+5. Target repository selection is visible and missing or ambiguous targets are
+   flagged before implementation routing (AC6).
+6. Hub-owned content and product-injected content are distinct (AC7).
+7. The example is generic and contains no private project details (AC8).
+8. The diff is documentation-only (AC10).
+
+**Smoke test runbook**:
+`docs/testing/workflow/874-workflow-hub-operating-model.smoke-test.md`
+
+**Regression suite**: No automated product regression suite applies because the
+implementation is documentation-only. Use markdown lint and the smoke runbook.
+
+### Parser-risk Addendum
+
+Not applicable. The implementation does not add parser, scanner, regex, lint, or
+structured-text processing behavior.
+
+### Concurrent-Event-Source Addendum
+
+Not applicable. The implementation does not introduce event listeners, timers,
+async queues, or shared mutable runtime state.
+
+---
+
+## Seed Data
+
+None.
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/workflow/development-workflow/repository-modes.md` - new canonical
+      architecture note for repository modes and artifact ownership.
+- [ ] `README.md` - link to the repository modes note.
+- [ ] `docs/workflow/development-workflow/README.md` - link to the repository
+      modes note.
+- [ ] `CHANGELOG.md` - add an `[Unreleased]` / `### Added` entry:
+      `- **Workflow hub operating model** (#874): documents repository modes, artifact ownership, target repository selection, and PR ownership for workflow hub deployments.`
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| The ownership table omits an artifact type from the spec. | Medium | Medium | Use the smoke runbook to check every named artifact: backlog/tracker items, specs, plans, smoke runbooks, implementation branches, PRs, CI checks, and reviewer-loop checks. |
+| The note appears to introduce behavior that later scripts must already support. | Medium | Medium | Include explicit "documentation-only, no runtime behavior change" language and avoid adding config keys in this item. |
+| The target repository rule over-specifies the future storage format. | Medium | Medium | Define required properties of the value, not the concrete storage mechanism; leave storage details to later implementation items. |
+| The example leaks private project details. | Low | Medium | Use generic names such as `workflow-hub`, `mobile-app`, and `admin-portal`. |
+
+---
+
+## Code Samples
+
+No code samples. The only structured examples should be documentation tables and
+generic repository-mode examples.
+
+---
+
+## Implementation Order
+
+1. Create `docs/workflow/development-workflow/repository-modes.md`.
+2. In the note, add sections for:
+   - Supported repository modes.
+   - Missing-mode default.
+   - Artifact ownership by mode.
+   - PR ownership by mode.
+   - Target product repository selection.
+   - Hub-owned versus product-injected framework content.
+   - Generic multi-product hub example.
+   - Non-goals and current behavior preservation.
+3. Update `README.md` to link to the note from the development workflow
+   overview.
+4. Update `docs/workflow/development-workflow/README.md` to link to the note
+   from the workflow documentation/configuration area.
+5. Add the CHANGELOG entry under `[Unreleased]` / `### Added` using the literal
+   from **Documentation Updates**.
+6. Run the smoke test runbook and confirm all assertions pass.
+7. Run markdown validation:
+   - `npx markdownlint-cli2 "README.md" "docs/workflow/development-workflow/**/*.md" "docs/testing/workflow/874-workflow-hub-operating-model.smoke-test.md" "CHANGELOG.md"`
+   - `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/874-workflow-hub-operating-model.smoke-test.md CHANGELOG.md`
+   - `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
+8. Run `git diff --name-only` and confirm the implementation diff is
+   documentation-only.
+9. Open a draft implementation PR targeting `develop-workflow-hub-mode` and run
+   the standard plan review, automated reviewer, and CI loops before marking it
+   ready for human review.

--- a/docs/testing/workflow/874-workflow-hub-operating-model.smoke-test.md
+++ b/docs/testing/workflow/874-workflow-hub-operating-model.smoke-test.md
@@ -1,0 +1,195 @@
+# Smoke Test Runbook: Workflow Hub Operating Model
+
+**Feature**: Workflow hub operating model and artifact ownership
+**Spec**: [1_874-workflow-hub-operating-model_specs.md](../../specs/developments/20260610135131_874-workflow-hub-operating-model/1_874-workflow-hub-operating-model_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] You are reviewing the implementation PR for #874.
+- [ ] The PR targets `develop-workflow-hub-mode`.
+- [ ] The implementation diff is available locally.
+
+---
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| Architecture note | `docs/workflow/development-workflow/repository-modes.md` |
+| Root README | `README.md` |
+| Workflow README | `docs/workflow/development-workflow/README.md` |
+| Spec | `docs/specs/developments/20260610135131_874-workflow-hub-operating-model/1_874-workflow-hub-operating-model_specs.md` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Confirm Required Files Exist
+
+**Maps to**: AC1, AC2
+
+1. Confirm `docs/workflow/development-workflow/repository-modes.md` exists.
+2. Confirm `README.md` links to the architecture note.
+3. Confirm `docs/workflow/development-workflow/README.md` links to the
+   architecture note.
+
+**Expected result**: The architecture note exists and both required entry points
+link to it with relative links that render from their file locations.
+
+### Step 2: Verify Repository Modes and Default Behavior
+
+**Maps to**: AC1, AC3, AC9
+
+1. Open the architecture note.
+2. Confirm it defines exactly these mode code values:
+   - `single_repo`
+   - `workflow_hub`
+   - `product_repo`
+3. Confirm each mode has a display label and user-facing description.
+4. Confirm the note states that a missing mode declaration is interpreted as
+   `single_repo`.
+5. Confirm the `single_repo` section says existing adopters keep current
+   behavior when no mode is declared.
+
+**Expected result**: A reader can identify all supported modes and understand
+that missing mode means no migration or new configuration is required.
+
+### Step 3: Verify Artifact Ownership Coverage
+
+**Maps to**: AC4, AC5
+
+1. Locate the artifact ownership table.
+2. Confirm it covers:
+   - backlog or tracker items
+   - specs
+   - plans
+   - hub-owned smoke runbooks
+   - product-owned smoke runbooks
+   - implementation branches
+   - spec PRs
+   - plan PRs
+   - code PRs
+   - CI checks
+   - reviewer-loop checks
+3. Confirm the note states where spec PRs, plan PRs, and code PRs are opened in
+   every supported mode.
+
+**Expected result**: Every artifact named in the spec has an owner in each mode,
+and PR ownership is explicit.
+
+### Step 4: Verify Target Repository Selection
+
+**Maps to**: AC6
+
+1. Locate the target product repository selection section.
+2. Confirm the note says hub-managed implementation work must identify one
+   visible, unambiguous target product repository.
+3. Confirm the note says missing or ambiguous targets are flagged before product
+   implementation routing.
+4. Confirm the note avoids prescribing a storage format for the target
+   repository value.
+
+**Expected result**: The rule is clear enough for later script and agent work,
+but storage details remain open for later implementation items.
+
+### Step 5: Verify Hub-Owned and Product-Injected Content
+
+**Maps to**: AC7
+
+1. Locate the section that distinguishes hub-owned content from product-injected
+   content.
+2. Confirm the note lists workflow-hub content such as tracker coordination,
+   specs, plans, and cross-repository workflow documentation.
+3. Confirm the note lists product-repo content such as local agent wrappers,
+   workflow helper injection, CI/reviewer-loop hooks, and product smoke
+   runbooks when later implementation items provide them.
+
+**Expected result**: Readers can tell what remains centralized and what may be
+copied or injected into product repositories.
+
+### Step 6: Verify Generic Multi-Product Example
+
+**Maps to**: AC8
+
+1. Locate the multi-product hub example.
+2. Confirm it uses generic repository names.
+3. Confirm it shows one hub coordinating more than one product repository.
+4. Confirm it contains no private project, repository, team, customer, or domain
+   details.
+
+**Expected result**: The example explains the intended topology without
+hardcoding private project information.
+
+### Step 7: Verify Documentation-Only Scope
+
+**Maps to**: AC10
+
+1. Run:
+
+   ```bash
+   git diff --name-only origin/develop-workflow-hub-mode...HEAD
+   ```
+
+2. Confirm the diff contains only documentation files and `CHANGELOG.md`.
+3. Confirm no shell scripts, workflow automation, CI files, or runtime config
+   files changed.
+
+**Expected result**: The implementation introduces no runtime behavior changes.
+
+### Step 8: Run Markdown Validation
+
+1. Run:
+
+   ```bash
+   npx markdownlint-cli2 "README.md" "docs/workflow/development-workflow/**/*.md" "docs/testing/workflow/874-workflow-hub-operating-model.smoke-test.md" "CHANGELOG.md"
+   python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/874-workflow-hub-operating-model.smoke-test.md CHANGELOG.md
+   bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md
+   ```
+
+**Expected result**: All commands pass with no errors.
+
+---
+
+## Assertions Checklist
+
+- [ ] AC1: The architecture note defines `single_repo`, `workflow_hub`, and
+      `product_repo` with display labels and descriptions.
+- [ ] AC2: The architecture note is linked from `README.md` and
+      `docs/workflow/development-workflow/README.md`.
+- [ ] AC3: Missing mode declaration is interpreted as `single_repo`.
+- [ ] AC4: Artifact ownership covers all artifacts named in the spec.
+- [ ] AC5: Spec PR, plan PR, and code PR ownership is explicit in every mode.
+- [ ] AC6: Target product repository selection is visible and missing or
+      ambiguous targets are flagged before implementation routing.
+- [ ] AC7: Hub-owned content and product-injected content are distinguished.
+- [ ] AC8: The multi-product example is generic and private-detail-free.
+- [ ] AC9: Existing single-repository behavior is preserved by default.
+- [ ] AC10: The implementation is documentation-only.
+
+---
+
+## Seed Data Reference
+
+No seed data is required.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| README link fails markdown lint | Relative path is wrong for the source file | Adjust the link relative to the file that contains it. |
+| Artifact ownership table omits smoke runbook split | Hub-owned and product-owned runbooks were merged into one row | Split the row or make ownership explicit for both runbook types. |
+| Diff includes scripts or config | Scope expanded beyond #874 | Remove runtime/config changes or move them to later workflow-hub implementation items. |
+
+---
+
+## Known Limitations
+
+- This smoke test validates documentation content, not runtime behavior.


### PR DESCRIPTION
## Summary

Adds the implementation plan and smoke test runbook for #874, the documentation-only workflow hub operating model and artifact ownership item.

## Scope

- Plan: `docs/specs/developments/20260610135131_874-workflow-hub-operating-model/2_874-workflow-hub-operating-model_implementation-plan.md`
- Smoke runbook: `docs/testing/workflow/874-workflow-hub-operating-model.smoke-test.md`
- Base branch: `develop-workflow-hub-mode`

## Document Quality Gate

- Spec read: `1_874-workflow-hub-operating-model_specs.md`
- Tracker brief read: #874 body and comments; no scope-changing comments found
- Template-fit check: passed; the item is generic workflow documentation for the template
- Acceptance coverage: AC1-AC10 mapped in the plan and smoke runbook
- Parser-risk: not applicable
- Concurrent-event-source: not applicable
- Cross-cutting checklist: not applicable
- Cross-section consistency: checked for paths, AC references, and documentation-only scope

## Validation

- `npx markdownlint-cli2 "docs/specs/developments/20260610135131_874-workflow-hub-operating-model/*.md" "docs/testing/workflow/874-workflow-hub-operating-model.smoke-test.md" "CHANGELOG.md"` -> 0 errors
- `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/874-workflow-hub-operating-model.smoke-test.md CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --cached --check`

## Review

- Internal plan review against `REVIEW.md`: APPROVED; no direct fixes required.

Refs #874
