### PR TITLE
docs(plan): add shared local workflow config plan

### DIFF
--- a/docs/specs/developments/20260610135749_875-shared-local-workflow-config/2_875-shared-local-workflow-config_implementation-plan.md
+++ b/docs/specs/developments/20260610135749_875-shared-local-workflow-config/2_875-shared-local-workflow-config_implementation-plan.md
@@ -1,0 +1,293 @@
+# Shared and Local Workflow Configuration - Implementation Plan
+
+**Spec**: [1_875-shared-local-workflow-config_specs.md](1_875-shared-local-workflow-config_specs.md)
+**Smoke test runbook**: [875-shared-local-workflow-config.smoke-test.md](../../../testing/workflow/875-shared-local-workflow-config.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add a single repository-context resolver for
+`.ai-dev-workflow.yaml`, `.ai-dev-workflow.local.yaml`, and the legacy
+`.tmp/template-config.json` override path. Expose that resolver through
+shell-callable helpers in `workflow-lib.sh`, add a validation command, document
+the shared/local schema, and cover the mode, product repository, local path, and
+compatibility cases with fixture-driven tests.
+
+**Estimated complexity**: M
+
+**Rationale**: The change touches shared workflow configuration, shell helper
+APIs, a new validation path, gitignore/example files, and test harnesses. The
+main implementation risk is parsing nested YAML consistently without adding an
+implicit runtime dependency.
+
+**Dependencies**: #874 must be merged into `develop-workflow-hub-mode` before
+the #875 implementation starts, because this item should extend the repository
+mode documentation introduced by #874.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `3144f30` |
+| Issue brief and comments | `gh issue view 875 --json number,title,state,body,comments,labels` | Issue #875 is part of #873, has no scope-changing comments, and carries `integration-branch:workflow-hub-mode`. |
+| Existing shared config | `sed -n '1,260p' .ai-dev-workflow.yaml` | Config currently has `schema_version`, `review`, `issue_tracker`, `vcs`, `browser_automation`, and `template`; no mode or repository-context fields. |
+| Existing config helpers | `rg -n "template-config\|ai-dev-workflow\|workflow_hub\|product_repo\|github_repo\|git_url\|yq\|python" scripts docs .github .gitignore` | Existing helpers parse simple `.ai-dev-workflow.yaml` sections with awk and use `.tmp/template-config.json` for local review overrides; no repository-context resolver exists. |
+| Python YAML dependency | `python3 - <<'PY' ... import yaml ... PY` | `pyyaml=no`; implementation must not assume PyYAML is installed. |
+| Node YAML dependency | `rg -n "js-yaml\|yaml" package-lock.json package.json` | `js-yaml` is transitive through markdown tooling only; workflow scripts must not rely on uninstalled `node_modules`. |
+| Local ignore state | `sed -n '1,160p' .gitignore` | `.tmp/` is ignored; `.ai-dev-workflow.local.yaml` is not ignored yet. |
+| Existing workflow tests | `ls scripts/development-workflow/tests` | Test harnesses exist for `workflow-lib.sh`, PR review loop, Haystack, and skill install behavior. |
+
+---
+
+## Layer-by-Layer Changes
+
+### Workflow Configuration
+
+- [ ] Keep `.ai-dev-workflow.yaml` repo-safe: document but do not require an
+      explicit mode for existing adopters.
+- [ ] Add documentation for these shared fields:
+      `mode`, `workflow_hub.product_repos[]`, and
+      `product_repo.workflow_hub`.
+- [ ] Define valid mode values as `single_repo`, `workflow_hub`, and
+      `product_repo`.
+- [ ] Enforce that a missing `mode` resolves as `single_repo`.
+- [ ] Define shared product repository identity fields:
+      `name`, `github_repo` or `git_url`, `default_branch`, optional
+      `role`, optional `scope`, optional `tracker` hints, and optional
+      non-secret app identifiers.
+- [ ] Reject shared config that requires local checkout paths, private key
+      paths, secret values, or machine-specific tool settings.
+
+### Local Configuration
+
+- [ ] Add `.ai-dev-workflow.local.yaml` to `.gitignore`.
+- [ ] Add `.ai-dev-workflow.local.example.yaml` with placeholder-only examples
+      for:
+      - checkout root defaults
+      - per-product local checkout paths
+      - private key paths or secret references
+      - local review/tool overrides
+- [ ] Document that local config is optional in `single_repo` mode and required
+      only when a workflow hub needs a local product checkout path that cannot
+      be derived safely.
+- [ ] Preserve `.tmp/template-config.json` as a compatibility fallback for
+      existing review override behavior.
+- [ ] Define override precedence explicitly:
+      1. `.tmp/template-config.json` for legacy keys it already supports.
+      2. `.ai-dev-workflow.local.yaml` for new local config keys.
+      3. `.ai-dev-workflow.yaml` shared config.
+      4. Built-in defaults such as missing mode -> `single_repo`.
+
+### Backend / Scripts
+
+- [ ] Add a dedicated repository-context resolver under
+      `scripts/development-workflow/` rather than duplicating nested YAML
+      parsing in multiple shell scripts.
+- [ ] Keep the resolver dependency-light: use `python3` stdlib only, or another
+      repository-declared dependency added and validated by CI. Do not rely on
+      undeclared PyYAML or transitive `node_modules`.
+- [ ] Make the resolver return shell-safe `KEY=value` output suitable for
+      `workflow-lib.sh` callers.
+- [ ] Add shell helper wrappers in `workflow-lib.sh` for:
+      - reading the effective mode
+      - resolving a product repository by stable name
+      - resolving the current repository context in `single_repo` and
+        `product_repo` modes
+      - returning local path, GitHub repo slug, git URL, default branch, and
+        tracker hints
+      - validating required repository context before routing, branch, PR, or
+        checkout actions
+- [ ] Add a validation command, for example
+      `scripts/development-workflow/validate-workflow-config.sh`, that prints
+      resolved mode and target repository context on success and fails clearly
+      on missing, duplicated, or ambiguous repository configuration.
+- [ ] Ensure all new failure messages include the missing field or ambiguous
+      selector and name the file the user should edit.
+
+### Tests
+
+- [ ] Add a focused repository-context test harness, for example
+      `scripts/development-workflow/tests/test-workflow-config-resolver.sh`.
+- [ ] Use temporary fixture directories and files so tests do not depend on the
+      developer's real local config.
+- [ ] Cover:
+      - missing mode -> `single_repo`
+      - explicit `single_repo`
+      - valid `workflow_hub` with multiple product repositories
+      - duplicate product repository names
+      - missing `github_repo` and `git_url`
+      - ambiguous product repository selection
+      - valid `product_repo` hub reference
+      - explicit local path override
+      - derived local path from checkout root
+      - missing local path clear error
+      - `.tmp/template-config.json` compatibility behavior
+      - local review/tool override precedence
+- [ ] Update existing workflow test entry points when needed so CI runs the new
+      harness.
+- [ ] Add static validation for any new Python script, such as
+      `python3 -m py_compile`.
+
+### Documentation
+
+- [ ] Extend the #874 repository modes note with shared/local configuration
+      guidance once #874 is merged into the integration branch.
+- [ ] Update `docs/workflow/development-workflow/README.md` to link the
+      configuration guidance from the workflow configuration section.
+- [ ] Update `.ai-dev-workflow.yaml` comments to point to the configuration
+      guidance without enabling hub mode by default.
+- [ ] Document `.tmp/template-config.json` compatibility and the preferred
+      `.ai-dev-workflow.local.yaml` replacement path.
+- [ ] Add the implementation changelog entry under `[Unreleased]` / `### Added`:
+      `- **Shared and local workflow configuration** (#875): separates versioned repository identity from local checkout and secret references, with repository-context helpers for workflow hub routing.`
+
+### Database / Data Layer
+
+- [ ] None. This feature has no database, migration, seed, or data model
+      changes.
+
+### Frontend / UI
+
+- [ ] None. This feature has no browser UI.
+
+### Infrastructure / CI
+
+- [ ] Update CI workflow paths only if a new test harness or resolver file would
+      otherwise be skipped.
+- [ ] Keep branch protection and reviewer-loop behavior unchanged.
+
+---
+
+## Testing Strategy
+
+**Test types**: Unit-style shell fixture tests, config validation smoke tests,
+markdown lint, shellcheck, and existing workflow harness regression tests.
+
+**Key scenarios to test**:
+
+1. Missing mode resolves as `single_repo` (AC1).
+2. Shared docs describe `mode`, `workflow_hub.product_repos[]`, and
+   `product_repo.workflow_hub` (AC2).
+3. Hub config supports multiple named product repositories with `github_repo`
+   or `git_url` identity (AC3, AC4).
+4. Local-only config owns checkout paths, checkout roots, secret references,
+   and tool overrides (AC5, AC6).
+5. Helpers emit shell-callable context output for mode, local path, remote
+   identity, default branch, and tracker hints (AC7).
+6. Local path resolution uses explicit override, documented default, or clear
+   error (AC8).
+7. Validation fails clearly for missing, duplicate, or ambiguous product repo
+   config (AC9).
+8. `.tmp/template-config.json` behavior remains compatible or has documented
+   migration coverage (AC10).
+9. Tests cover `single_repo`, `workflow_hub`, `product_repo`, overrides, and
+   missing path cases (AC11).
+
+**Smoke test runbook**:
+`docs/testing/workflow/875-shared-local-workflow-config.smoke-test.md`
+
+**Regression suite**:
+
+- `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`
+- `bash scripts/development-workflow/tests/test-pr-review-loop.sh`
+- `bash scripts/development-workflow/tests/test-workflow-lib-github-projects.sh`
+- `shellcheck --severity=warning scripts/development-workflow/*.sh scripts/development-workflow/tests/*.sh`
+- `python3 -m py_compile <new resolver script>` if the resolver is Python
+- `npx markdownlint-cli2 "docs/specs/developments/20260610135749_875-shared-local-workflow-config/*.md" "docs/testing/workflow/875-shared-local-workflow-config.smoke-test.md" "CHANGELOG.md"`
+- `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/875-shared-local-workflow-config.smoke-test.md CHANGELOG.md`
+- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
+
+### Parser-risk Addendum
+
+- **Edge-case enumeration**:
+  - missing `.ai-dev-workflow.yaml`
+  - config present with no `mode`
+  - quoted and unquoted scalar mode values
+  - `workflow_hub.product_repos[]` with one entry
+  - `workflow_hub.product_repos[]` with multiple entries
+  - duplicate product repository `name`
+  - entry with both `github_repo` and `git_url`
+  - entry with neither `github_repo` nor `git_url`
+  - local config path override matching by product repository `name`
+  - checkout root default plus product repo name-derived path
+  - local config file absent
+  - `.tmp/template-config.json` present with existing review override shape
+  - malformed shared YAML, malformed local YAML, and malformed legacy JSON
+- **Unit test mapping**: Add one fixture test per edge case in
+  `scripts/development-workflow/tests/test-workflow-config-resolver.sh`.
+- **Suppression semantics**: Not applicable. The resolver does not implement
+  lint suppressions.
+- **Parser constraints**: If the implementation uses a constrained parser
+  instead of a full YAML library, document supported YAML constructs in the
+  configuration guide and fail closed on unsupported structures.
+
+### Concurrent-Event-Source Addendum
+
+Not applicable. This feature adds synchronous config resolution helpers and a
+validation command. It does not add event listeners, timers, async queues, or
+shared mutable runtime state.
+
+---
+
+## Seed Data
+
+None. Tests should create temporary fixture config files.
+
+---
+
+## Documentation Updates
+
+- [ ] `.ai-dev-workflow.yaml` - comment the new shared fields and link to the
+      workflow configuration guide without enabling hub mode by default.
+- [ ] `.ai-dev-workflow.local.example.yaml` - add safe local-only examples.
+- [ ] `.gitignore` - ignore `.ai-dev-workflow.local.yaml`.
+- [ ] `docs/workflow/development-workflow/repository-modes.md` - extend with
+      shared/local configuration guidance after #874 merges.
+- [ ] `docs/workflow/development-workflow/README.md` - link to the
+      configuration guidance.
+- [ ] `CHANGELOG.md` - add the implementation entry listed above.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Nested YAML parsing becomes fragile if implemented with ad hoc awk. | High | High | Use one dedicated resolver with fixture tests and shell wrappers; avoid duplicating nested parsing across scripts. |
+| A new parser dependency is available locally but absent in CI or downstream repos. | Medium | High | Use stdlib-only code or add an explicit declared dependency and CI validation; do not rely on PyYAML or transitive packages. |
+| Local config support changes existing `.tmp/template-config.json` behavior. | Medium | High | Preserve legacy precedence for supported keys and add compatibility tests. |
+| Shared config accidentally stores local paths or secret references. | Medium | Medium | Document allowed shared fields and make validation flag local-only keys in shared product repo entries. |
+| Hub validation rejects existing single-repo adopters. | Low | High | Keep missing mode -> `single_repo` and make local config optional in that mode. |
+
+---
+
+## Code Samples
+
+Any schema examples in the implementation documentation should be illustrative
+and use placeholder repository names, paths, and secret references only. Do not
+include production-ready resolver code in documentation.
+
+---
+
+## Implementation Order
+
+1. Confirm #874 has merged into `develop-workflow-hub-mode`.
+2. Add `.ai-dev-workflow.local.yaml` to `.gitignore`.
+3. Add `.ai-dev-workflow.local.example.yaml` with placeholder local-only
+   examples.
+4. Add the repository-context resolver and validation command under
+   `scripts/development-workflow/`.
+5. Add `workflow-lib.sh` wrappers around the resolver.
+6. Add fixture-driven resolver tests.
+7. Update existing workflow test or CI entry points so the new tests run.
+8. Extend repository mode/configuration documentation and `.ai-dev-workflow.yaml`
+   comments.
+9. Add the `CHANGELOG.md` entry.
+10. Run the smoke test runbook and automated validation commands listed in
+    **Testing Strategy**.
+11. Open a draft implementation PR targeting `develop-workflow-hub-mode`, run
+    internal review, the automated reviewer loop, and CI, then mark the PR ready
+    for human review.

--- a/docs/testing/workflow/875-shared-local-workflow-config.smoke-test.md
+++ b/docs/testing/workflow/875-shared-local-workflow-config.smoke-test.md
@@ -1,0 +1,214 @@
+# Smoke Test Runbook: Shared and Local Workflow Configuration
+
+**Feature**: Shared and local workflow configuration
+**Spec**: [1_875-shared-local-workflow-config_specs.md](../../specs/developments/20260610135749_875-shared-local-workflow-config/1_875-shared-local-workflow-config_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] You are reviewing the implementation PR for #875.
+- [ ] #874 is already merged into `develop-workflow-hub-mode`.
+- [ ] The PR targets `develop-workflow-hub-mode`.
+- [ ] The implementation diff is available locally.
+
+---
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| Shared config | `.ai-dev-workflow.yaml` |
+| Local config example | `.ai-dev-workflow.local.example.yaml` |
+| Local config ignore path | `.ai-dev-workflow.local.yaml` |
+| Legacy local override | `.tmp/template-config.json` |
+| Workflow library | `scripts/development-workflow/workflow-lib.sh` |
+| Validation command | `scripts/development-workflow/validate-workflow-config.sh` |
+| Resolver tests | `scripts/development-workflow/tests/test-workflow-config-resolver.sh` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Confirm Required Files and Ignore Rules
+
+**Maps to**: AC5, AC6
+
+1. Confirm `.gitignore` includes `.ai-dev-workflow.local.yaml`.
+2. Confirm `.ai-dev-workflow.local.example.yaml` exists.
+3. Confirm the example uses placeholder paths, repository names, and secret
+   references only.
+4. Confirm the example documents checkout root defaults, per-product local
+   paths, private key paths or secret references, and local reviewer/tool
+   overrides.
+
+**Expected result**: The real local config file is ignored by git, and the
+example file is safe to commit.
+
+### Step 2: Verify Shared Configuration Documentation
+
+**Maps to**: AC1, AC2, AC3, AC4
+
+1. Locate the workflow configuration documentation.
+2. Confirm it documents these fields:
+   - `mode`
+   - `workflow_hub.product_repos[]`
+   - `product_repo.workflow_hub`
+3. Confirm it defines the valid mode values:
+   - `single_repo`
+   - `workflow_hub`
+   - `product_repo`
+4. Confirm it states that missing `mode` resolves as `single_repo`.
+5. Confirm it states that shared product repository entries may contain stable
+   non-secret identity and metadata only.
+
+**Expected result**: Readers can configure shared repository identity without
+putting local paths or secrets in version control.
+
+### Step 3: Run Repository-Context Unit Tests
+
+**Maps to**: AC1, AC3, AC7, AC8, AC9, AC10, AC11
+
+1. Run:
+
+   ```bash
+   bash scripts/development-workflow/tests/test-workflow-config-resolver.sh
+   ```
+
+2. Confirm the output includes passing cases for:
+   - missing mode -> `single_repo`
+   - valid `workflow_hub`
+   - invalid `workflow_hub`
+   - valid `product_repo`
+   - local path override
+   - derived local path
+   - missing local path
+   - legacy `.tmp/template-config.json` compatibility
+
+**Expected result**: The test harness passes and covers each mode and required
+local path behavior.
+
+### Step 4: Validate Shell-Callable Helper Output
+
+**Maps to**: AC7, AC8
+
+1. Source the workflow library from Bash.
+2. Run the new repository-context helper against a valid fixture or local test
+   config.
+3. Confirm the output uses shell-safe `KEY=value` lines.
+4. Confirm the output includes mode, repository name, local path when required,
+   remote identity, default branch, and tracker hints when configured.
+
+**Expected result**: Existing shell scripts can consume repository context
+without parsing nested YAML themselves.
+
+### Step 5: Validate Failure Messages
+
+**Maps to**: AC8, AC9
+
+1. Run the validation command against a duplicate product repository name
+   fixture.
+2. Run it against a product repository entry missing both `github_repo` and
+   `git_url`.
+3. Run it against a workflow hub target that needs a local checkout path but has
+   no override or derivable default.
+
+**Expected result**: Each failure names the missing or ambiguous value and the
+config file the user should edit.
+
+### Step 6: Verify Legacy Override Compatibility
+
+**Maps to**: AC10
+
+1. Create a temporary fixture with `.tmp/template-config.json` using the
+   existing review override shape.
+2. Create a temporary `.ai-dev-workflow.local.yaml` with a conflicting local
+   review override.
+3. Run the helper or validation path that resolves effective review overrides.
+
+**Expected result**: The documented compatibility precedence is followed, and
+existing `.tmp/template-config.json` behavior is preserved.
+
+### Step 7: Run Existing Workflow Regressions
+
+1. Run:
+
+   ```bash
+   bash scripts/development-workflow/tests/test-pr-review-loop.sh
+   bash scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+   ```
+
+2. If the implementation adds a Python resolver, run:
+
+   ```bash
+   python3 -m py_compile scripts/development-workflow/<resolver-script>.py
+   ```
+
+**Expected result**: Existing review-loop and tracker helper behavior still
+passes after the config changes.
+
+### Step 8: Run Markdown and Changelog Validation
+
+1. Run:
+
+   ```bash
+   npx markdownlint-cli2 "docs/specs/developments/20260610135749_875-shared-local-workflow-config/*.md" "docs/testing/workflow/875-shared-local-workflow-config.smoke-test.md" "CHANGELOG.md"
+   python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/875-shared-local-workflow-config.smoke-test.md CHANGELOG.md
+   bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md
+   ```
+
+**Expected result**: All commands pass with no errors.
+
+---
+
+## Assertions Checklist
+
+- [ ] AC1: A repository with no mode declaration resolves as `single_repo`.
+- [ ] AC2: Shared workflow documentation describes `mode`,
+      `workflow_hub.product_repos[]`, and `product_repo.workflow_hub`.
+- [ ] AC3: A workflow hub can declare multiple product repositories by stable
+      name plus GitHub repository slug or git URL.
+- [ ] AC4: Versioned product repository entries are limited to stable
+      non-secret identity and metadata.
+- [ ] AC5: Local paths, checkout defaults, secret references, and local
+      reviewer/tool overrides are documented as local-only configuration.
+- [ ] AC6: `.ai-dev-workflow.local.yaml` is ignored by git, and the example
+      file contains no real secrets or private paths.
+- [ ] AC7: Repository-context helpers expose shell-callable mode, path, remote,
+      branch, and tracker output.
+- [ ] AC8: Local path resolution uses explicit override, documented default, or
+      clear error.
+- [ ] AC9: Validation fails clearly for missing, duplicated, or ambiguous
+      product repository configuration.
+- [ ] AC10: Existing `.tmp/template-config.json` behavior is preserved or has
+      documented migration coverage.
+- [ ] AC11: Tests cover `single_repo`, valid and invalid `workflow_hub`,
+      `product_repo`, local path overrides, and missing local path cases.
+
+---
+
+## Seed Data Reference
+
+No committed seed data is required. Tests should create temporary fixture files.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Resolver tests pass locally but fail in CI | The implementation relies on an undeclared parser dependency | Use stdlib-only parsing or declare and install the dependency in CI. |
+| `.ai-dev-workflow.local.yaml` appears in `git status` | The gitignore entry is missing or misspelled | Add the exact path to `.gitignore`. |
+| Existing review-loop override tests fail | `.tmp/template-config.json` precedence changed | Restore documented compatibility precedence or update migration docs and tests. |
+| Validation error is generic | Failure path does not include field/file context | Update the resolver to name the missing field and relevant config file. |
+
+---
+
+## Known Limitations
+
+- This smoke test validates repository-context behavior and local config
+  boundaries. It does not validate full cross-repository orchestration.


### PR DESCRIPTION
## Summary
- Add the #875 implementation plan for shared/local workflow configuration and repository-context helpers.
- Add the #875 smoke test runbook covering shared config, local config, validation failures, helper output, and legacy override compatibility.

## Document Quality Gate
- Spec link verified: `docs/specs/developments/20260610135749_875-shared-local-workflow-config/1_875-shared-local-workflow-config_specs.md`
- Smoke runbook link verified: `docs/testing/workflow/875-shared-local-workflow-config.smoke-test.md`
- Template-fit check passed: this is template workflow tooling documentation for the framework repo.
- Parser-risk addendum included because implementation will parse nested YAML/JSON configuration.

## Validation
- `npx markdownlint-cli2 "docs/specs/developments/20260610135749_875-shared-local-workflow-config/*.md" "docs/testing/workflow/875-shared-local-workflow-config.smoke-test.md" "CHANGELOG.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/875-shared-local-workflow-config.smoke-test.md CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --cached --check`

Refs #875
