### PR TITLE
docs: add workflow hub repository modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Workflow hub operating model** (#874): documents repository modes, artifact ownership, target repository selection, and PR ownership for workflow hub deployments.
 - **Release stamping** (#829): records the production release version on shipped tracker issues using provider-native release markers such as GitHub Milestones, while failing softly for unsupported providers.
 - **Document PR quality gate** (#816): adds a pre-submission quality gate for spec and implementation-plan PRs so document authors check brief coverage, consistency, behavioral guarantees, and recurring reviewer categories before opening draft PRs.
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ Released
 
 See [`docs/workflow/development-workflow/README.md`](docs/workflow/development-workflow/README.md) for the full workflow specification.
 
+For teams coordinating work across more than one repository, see
+[`docs/workflow/development-workflow/repository-modes.md`](docs/workflow/development-workflow/repository-modes.md)
+for the supported repository modes, artifact ownership rules, and PR ownership
+model. Repositories with no mode declaration continue to behave as
+single-repository adopters.
+
 ---
 
 ## Using With Different AI Tools

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -230,6 +230,16 @@ This workflow depends on a few capabilities more than on any specific vendor or 
 - An issue tracker is optional. Without one, portfolio-wide prioritization and "current brief" lookup require more direct human guidance.
 - Browser automation is optional. Without it, smoke tests should be run manually from the committed smoke test runbook.
 
+### Repository Modes
+
+The workflow supports a documented repository-mode model for future
+multi-repository coordination. See
+[`repository-modes.md`](repository-modes.md) for the `single_repo`,
+`workflow_hub`, and `product_repo` definitions, artifact ownership table, target
+product repository selection rule, and PR ownership model. When no mode is
+declared, repositories are interpreted as `single_repo` and keep the current
+single-repository behavior.
+
 ### Branch Naming
 
 | Branch type         | Pattern                      | Base branch |

--- a/docs/workflow/development-workflow/repository-modes.md
+++ b/docs/workflow/development-workflow/repository-modes.md
@@ -1,0 +1,146 @@
+# Repository Modes
+
+This note defines the repository ownership model for the AI development workflow.
+It is the source of truth for later workflow-hub implementation work, but this
+document by itself does not change runtime behavior, scripts, PR routing, or
+configuration requirements.
+
+## Supported Modes
+
+| Code value | Display label | Description |
+| --- | --- | --- |
+| `single_repo` | Single repository | One repository owns tracker work, specs, plans, implementation branches, PRs, CI, reviewer-loop checks, and releases. |
+| `workflow_hub` | Workflow hub | A coordination repository owns portfolio planning and workflow artifacts for one or more product repositories. |
+| `product_repo` | Product repository | A product repository receives routed implementation work from a workflow hub and owns product code validation. |
+
+When a repository has no mode declaration, the workflow interprets it as
+`single_repo`. Existing adopters keep the current behavior until they explicitly
+choose a different mode and install later workflow-hub automation.
+
+## Artifact Ownership
+
+| Artifact | `single_repo` owner | `workflow_hub` owner | `product_repo` owner |
+| --- | --- | --- | --- |
+| Backlog or tracker items | Current repository tracker | Hub tracker | Hub tracker references product work; product repo does not own portfolio tracking |
+| Specs | Current repository | Hub | Hub, unless a later product-specific convention explicitly copies read-only context |
+| Plans | Current repository | Hub | Hub, unless a later product-specific convention explicitly copies read-only context |
+| Hub-owned smoke runbooks | Current repository | Hub | Not owned by product repo |
+| Product-owned smoke runbooks | Current repository | Hub may reference or coordinate them | Product repo owns product validation runbooks |
+| Implementation branches | Current repository | Not owned by hub for product code | Product repo |
+| Spec PRs | Current repository | Hub | Hub |
+| Plan PRs | Current repository | Hub | Hub |
+| Code PRs | Current repository | Product repo selected by the work item | Product repo |
+| CI checks | Current repository | Hub for hub-doc/tool PRs; product repo for product code PRs | Product repo |
+| Reviewer-loop checks | Current repository | Hub for hub-doc/tool PRs; product repo for product code PRs | Product repo |
+
+In `single_repo` mode, all artifact ownership stays exactly as it works today:
+the tracker item, spec, plan, implementation branch, PR, CI, reviewer loop, smoke
+runbook, and release evidence are all handled in the same repository.
+
+In `workflow_hub` mode, the hub centralizes coordination artifacts. It owns the
+tracker item, spec, implementation plan, cross-repository workflow
+documentation, and any smoke runbook that validates hub-owned workflow behavior.
+The selected product repository owns implementation branches, code PRs, product
+CI checks, product reviewer-loop checks, and product smoke runbooks.
+
+In `product_repo` mode, the repository is a target for product implementation
+work routed from a hub. It owns the code change and validation artifacts for that
+product, while the hub remains the source of truth for portfolio state, specs,
+plans, and cross-product coordination.
+
+## PR Ownership
+
+| PR type | `single_repo` target | `workflow_hub` target | `product_repo` target |
+| --- | --- | --- | --- |
+| Spec PR | Current repository | Hub repository | Hub repository |
+| Plan PR | Current repository | Hub repository | Hub repository |
+| Code PR | Current repository | Selected product repository for product work; hub repository for hub-only workflow work | Product repository |
+
+A hub-managed item can still be hub-only. For example, a change to hub
+protocols, hub docs, or hub-owned orchestration scripts opens its code PR in the
+hub. A product implementation opens its code PR in the target product
+repository.
+
+## Target Product Repository Selection
+
+A hub-managed work item must identify one visible and unambiguous target product
+repository before implementation work is routed to a product repository. The
+target value must be reviewable from the work item context, stable enough for
+automation to resolve, and clear to humans reading the spec, plan, and PRs.
+
+This note does not prescribe the storage format for the target repository value.
+Later implementation items may choose a tracker field, issue-body field, local
+configuration mapping, command flag, or another explicit mechanism. Whatever
+format is chosen must preserve these rules:
+
+- A missing target is flagged before product implementation routing starts.
+- An ambiguous target is flagged before product implementation routing starts.
+- Multi-repository implementation work must make every target explicit instead
+  of relying on an implicit default.
+- Hub-only workflow changes must be distinguishable from product-code changes.
+
+## Hub-Owned And Product-Injected Content
+
+The workflow hub owns content that defines or coordinates the development
+process:
+
+- Tracker coordination and portfolio status.
+- Specs and implementation plans for hub-managed work.
+- Cross-repository workflow documentation and operating runbooks.
+- Hub-owned workflow protocols, agent wrappers, and orchestration scripts.
+- Hub smoke runbooks that validate workflow behavior rather than product
+  behavior.
+
+Product repositories own or receive content that must run next to product code:
+
+- Product implementation branches and product code PRs.
+- Product CI and reviewer-loop execution for product code changes.
+- Product smoke runbooks and regression fixtures.
+- Local agent wrappers or thin integration files when later workflow-hub
+  injection support provides them.
+- Minimal workflow helper files required for local product-repo operation.
+
+Product-injected framework content should be the smallest useful subset. A
+product repository should not receive hub-owned tracker artifacts, historical
+specs, implementation plans, or cross-product coordination state unless a later
+workflow explicitly documents why that copy is required.
+
+## Generic Multi-Product Example
+
+A team can run one hub and multiple product repositories:
+
+```text
+workflow-hub
+  owns: tracker items, specs, plans, workflow docs, hub orchestration scripts
+
+mobile-app
+  owns: mobile product code, mobile implementation PRs, mobile CI, mobile smoke runbooks
+
+admin-portal
+  owns: admin product code, admin implementation PRs, admin CI, admin smoke runbooks
+```
+
+In this topology, a hub work item for a mobile feature records `mobile-app` as
+its target product repository. The spec and plan PRs are opened in
+`workflow-hub`; the implementation branch, code PR, CI, reviewer-loop checks,
+and product smoke runbook execution happen in `mobile-app`.
+
+A different work item for an admin workflow records `admin-portal` as its target
+product repository and follows the same split. A hub-only workflow improvement,
+such as updating orchestration protocols, has no product target and opens its
+code PR in `workflow-hub`.
+
+## Non-Goals
+
+This note does not:
+
+- Add a mode field to `.ai-dev-workflow.yaml`.
+- Change existing script behavior.
+- Change existing agent prompts or command wrappers.
+- Migrate existing downstream repositories.
+- Route PRs across repositories.
+- Define secret storage, authentication, or product-repo checkout discovery.
+
+Those behaviors belong to later workflow-hub implementation items. Until those
+items land, missing mode remains `single_repo` and existing repositories keep the
+current single-repository workflow.


### PR DESCRIPTION
## Summary

- Add `docs/workflow/development-workflow/repository-modes.md` as the canonical repository-mode architecture note.
- Document `single_repo`, `workflow_hub`, and `product_repo`, including artifact ownership, PR ownership, target product repository selection, and a generic multi-product hub example.
- Link the note from the root README and development workflow README.
- Add the #874 CHANGELOG entry under `[Unreleased]` / `Added`.

## Spec and Plan

- Spec: `docs/specs/developments/20260610135131_874-workflow-hub-operating-model/1_874-workflow-hub-operating-model_specs.md`
- Plan: `docs/specs/developments/20260610135131_874-workflow-hub-operating-model/2_874-workflow-hub-operating-model_implementation-plan.md`
- Smoke test: `docs/testing/workflow/874-workflow-hub-operating-model.smoke-test.md`

## Test Plan

- `npx markdownlint-cli2 "README.md" "docs/workflow/development-workflow/**/*.md" "docs/testing/workflow/874-workflow-hub-operating-model.smoke-test.md" "CHANGELOG.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/874-workflow-hub-operating-model.smoke-test.md CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- Smoke assertions checked with targeted `rg` queries for required mode values, ownership rows, PR ownership, target repository rules, generic example names, and documentation-only scope language.
- `git diff --name-only origin/develop-workflow-hub-mode...HEAD` confirms the implementation diff is documentation-only plus `CHANGELOG.md`.

## Deviations

None. This PR intentionally introduces no runtime behavior changes, config keys, scripts, or migration requirements.

## CHANGELOG Entry Preview

- **Workflow hub operating model** (#874): documents repository modes, artifact ownership, target repository selection, and PR ownership for workflow hub deployments.

## Pre-submission Self-review

Pre-submission self-review: stale markers — none; caller/link consistency — verified for `README.md` and `docs/workflow/development-workflow/README.md`; coverage — AC1 through AC10 addressed by the architecture note, entry-point links, generic example, documentation-only diff, and CHANGELOG entry.

Closes #874
