### PR TITLE
feat(workflow): add repository context config

### DIFF
--- a/.ai-dev-workflow.local.example.yaml
+++ b/.ai-dev-workflow.local.example.yaml
@@ -1,0 +1,33 @@
+# Example local workflow configuration.
+#
+# Copy this file to `.ai-dev-workflow.local.yaml` when a workflow hub needs
+# machine-local checkout paths, secret references, or local tool overrides.
+# The real local file is gitignored. Keep all values here as placeholders.
+
+# Optional default root used when a product repo has no explicit local_path.
+checkout_root: ../repos
+
+# Product-repo local context. Names must match
+# workflow_hub.product_repos[].name in `.ai-dev-workflow.yaml`.
+product_repos:
+  - name: mobile-app
+    local_path: ../repos/mobile-app
+    private_key_path: ~/.config/example/mobile-app-github-app.pem
+    secret_ref: op://ExampleVault/mobile-app-github-app/private-key
+  - name: admin-portal
+    # With checkout_root above, this defaults to ../repos/admin-portal.
+    secret_ref: op://ExampleVault/admin-portal-github-app/private-key
+
+# Local reviewer/tool overrides. These are developer-specific and should not be
+# committed to the shared workflow config.
+review:
+  on_draft:
+    runner:
+      - codex
+  internal_reviewers_unavailable_policy: warn
+
+tools:
+  haystack:
+    command: haystack
+  browser:
+    provider: playwright_cli

--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -5,6 +5,11 @@
 # Keep it declarative and repo-safe: select providers here, but do not store
 # secrets, tokens, hostnames, or other environment-specific credentials.
 #
+# Repository mode fields (`mode`, `workflow_hub.product_repos[]`, and
+# `product_repo.workflow_hub`) are documented in
+# docs/workflow/development-workflow/repository-modes.md. Omit `mode` to keep
+# the default `single_repo` behavior.
+#
 # See docs/workflow/development-workflow/README.md and
 # docs/workflow/development-workflow/integrations/ for integration-specific setup.
 #

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Thumbs.db
 .env
 .env.*
 !.env.example
+.ai-dev-workflow.local.yaml
 
 # Claude Code
 .claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Shared and local workflow configuration** (#875): separates versioned repository identity from local checkout and secret references, with repository-context helpers for workflow hub routing.
 - **Workflow hub operating model** (#874): documents repository modes, artifact ownership, target repository selection, and PR ownership for workflow hub deployments.
 - **Release stamping** (#829): records the production release version on shipped tracker issues using provider-native release markers such as GitHub Milestones, while failing softly for unsupported providers.
 - **Document PR quality gate** (#816): adds a pre-submission quality gate for spec and implementation-plan PRs so document authors check brief coverage, consistency, behavioral guarantees, and recurring reviewer categories before opening draft PRs.

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -375,9 +375,14 @@ Opening a PR is not a terminal condition. A workflow run should continue until t
 ### Workflow Configuration
 
 Repository-specific workflow integrations are declared in `.ai-dev-workflow.yaml` at the repo root.
+Machine-local overrides belong in `.ai-dev-workflow.local.yaml`, which is
+gitignored. Start from `.ai-dev-workflow.local.example.yaml` when a workflow hub
+needs checkout roots, product-repo local paths, secret references, or local tool
+overrides.
 
 The file is versioned and intentionally declarative. It is the right place to record which workflow providers this repository uses for:
 
+- Repository mode and stable product-repository identity
 - Automated PR review
 - Issue tracking
 - Git hosting / pull-request workflow
@@ -387,6 +392,9 @@ Current schema:
 
 ```yaml
 schema_version: 2
+
+# Optional. Missing mode resolves as single_repo.
+mode: single_repo
 
 review:
   on_draft:
@@ -415,6 +423,7 @@ template:
 
 Important implementation notes:
 
+- Repository mode fields are `mode`, `workflow_hub.product_repos[]`, and `product_repo.workflow_hub`. Shared product repository entries may contain stable non-secret identity and metadata such as `name`, `github_repo` or `git_url`, `default_branch`, `role`, `scope`, `tracker` hints, and non-secret app identifiers. Local checkout paths, private key paths, secret values, and machine-specific tool settings belong only in `.ai-dev-workflow.local.yaml`. See [`repository-modes.md`](repository-modes.md) for examples and validation commands.
 - `review.on_draft.runner` is consumed by the Step 7a internal review gate protocol (`91-orchestrate-work-protocol.md`). If omitted, the gate falls back to running the stage-appropriate `claude` reviewer once. Developers can override the list locally via `.tmp/template-config.json` (gitignored).
 - `review.on_draft.github` and `review.on_ready.github` are consumed by `scripts/development-workflow/pr-review-loop.sh` for external automated PR review (Step 7). If the config file is absent, or both lists are omitted or empty, automated PR review is treated as not configured and the review loop reports `skipped`.
 - Legacy `review.internal_reviewers`, `review.platforms`, and `review.phase_after_clean` keys remain accepted for one transition release and map to the new lifecycle buckets.
@@ -500,10 +509,12 @@ Protocol prefixes are stable family identifiers, not a promise of contiguous num
 ### Tooling And Configuration
 
 - `docs/workflow/development-workflow/agent-model-config.md`
-- `.ai-dev-workflow.yaml` - repo-level workflow integration manifest (`review.on_draft.runner`, `review.on_draft.github`, `review.on_ready.github`, `template.is_template`, `template.repository`, `template.last_synced_version`, `issue_tracker.provider`, `vcs.provider`, `browser_automation.provider`)
+- `.ai-dev-workflow.yaml` - repo-level workflow integration manifest (`mode`, `workflow_hub.product_repos[]`, `product_repo.workflow_hub`, `review.on_draft.runner`, `review.on_draft.github`, `review.on_ready.github`, `template.is_template`, `template.repository`, `template.last_synced_version`, `issue_tracker.provider`, `vcs.provider`, `browser_automation.provider`)
+- `.ai-dev-workflow.local.example.yaml` - placeholder-only example for gitignored local checkout, secret-reference, review-runner, and tool overrides
 
 Repository helpers:
 
+- `scripts/development-workflow/validate-workflow-config.sh`
 - `scripts/development-workflow/add-backlog-item.sh`
 - `scripts/development-workflow/discover-workflow-state.sh`
 - `scripts/development-workflow/workflow-batch-plan.sh`

--- a/docs/workflow/development-workflow/repository-modes.md
+++ b/docs/workflow/development-workflow/repository-modes.md
@@ -130,16 +130,154 @@ product repository and follows the same split. A hub-only workflow improvement,
 such as updating orchestration protocols, has no product target and opens its
 code PR in `workflow-hub`.
 
+## Shared And Local Workflow Configuration
+
+Repository mode configuration is split across one versioned shared file and one
+optional local file:
+
+- `.ai-dev-workflow.yaml` is committed and may contain only repository-safe
+  workflow identity, provider selection, and non-secret metadata.
+- `.ai-dev-workflow.local.yaml` is gitignored and contains machine-local paths,
+  checkout defaults, secret references, and local tool or reviewer overrides.
+- `.ai-dev-workflow.local.example.yaml` is committed as a placeholder-only
+  starting point for local setup.
+
+Omitting `mode` in `.ai-dev-workflow.yaml` resolves as `single_repo`.
+
+Valid `mode` values are:
+
+- `single_repo`
+- `workflow_hub`
+- `product_repo`
+
+### Shared Hub Configuration
+
+A `workflow_hub` repository declares stable product repository identity under
+`workflow_hub.product_repos[]`:
+
+```yaml
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      default_branch: main
+      role: mobile
+      scope: customer-facing app
+      tracker:
+        component: mobile
+    - name: admin-portal
+      git_url: git@github.com:example/admin-portal.git
+      default_branch: develop
+```
+
+Each product entry needs a stable `name` and either `github_repo` or `git_url`.
+Optional shared fields may include `default_branch`, `role`, `scope`, `tracker`
+hints, and non-secret app identifiers. Shared product entries must not contain
+local checkout paths, private key paths, secret values, or machine-specific tool
+settings.
+
+When a hub has more than one product repository, callers must pass the target
+product name explicitly. Ambiguous target selection fails before branch, PR,
+checkout, or routing actions run.
+
+### Product Repository Configuration
+
+A `product_repo` declares the hub that owns portfolio workflow state:
+
+```yaml
+schema_version: 2
+mode: product_repo
+
+product_repo:
+  default_branch: main
+  workflow_hub:
+    github_repo: example/workflow-hub
+```
+
+The hub reference must include `github_repo` or `git_url`.
+
+### Local Configuration
+
+Local checkout and secret-reference data belongs in
+`.ai-dev-workflow.local.yaml`:
+
+```yaml
+checkout_root: ../repos
+
+product_repos:
+  - name: mobile-app
+    local_path: ../repos/mobile-app
+    secret_ref: op://ExampleVault/mobile-app-github-app/private-key
+  - name: admin-portal
+    secret_ref: op://ExampleVault/admin-portal-github-app/private-key
+
+review:
+  on_draft:
+    runner:
+      - codex
+  internal_reviewers_unavailable_policy: warn
+```
+
+For a hub target, local path resolution uses this order:
+
+1. `product_repos[].local_path` or `product_repos[].checkout_path` in
+   `.ai-dev-workflow.local.yaml`.
+2. `checkout_root` plus the product repository `name`.
+3. A clear validation error when the caller requires a local checkout and no
+   path can be resolved.
+
+Local config is optional for `single_repo` mode. It is required only when a
+workflow hub action needs a local product checkout path that cannot be derived
+safely.
+
+### Compatibility And Precedence
+
+Existing `.tmp/template-config.json` review overrides remain supported for the
+legacy keys they already handled. New local workflow configuration should use
+`.ai-dev-workflow.local.yaml`.
+
+Effective precedence is:
+
+1. `.tmp/template-config.json` for legacy review override keys.
+2. `.ai-dev-workflow.local.yaml` for new local config keys.
+3. `.ai-dev-workflow.yaml` shared config.
+4. Built-in defaults, including missing `mode` resolving as `single_repo`.
+
+### Validation And Shell Helpers
+
+Validate repository-context configuration with:
+
+```bash
+scripts/development-workflow/validate-workflow-config.sh
+scripts/development-workflow/validate-workflow-config.sh --repo mobile-app --require-local
+```
+
+The underlying resolver is
+`scripts/development-workflow/workflow-config-resolver.py`. It uses only the
+Python standard library and supports the constrained YAML subset used by the
+workflow config files: nested mappings, lists, scalar values, comments, and
+two-space indentation. Unsupported or malformed config fails closed with a
+file-specific error.
+
+`workflow-lib.sh` exposes shell-callable helpers that print `KEY=value` output:
+
+- `workflow_repository_mode`
+- `workflow_repository_context`
+- `workflow_validate_repository_context`
+- `workflow_review_override_context`
+
 ## Non-Goals
 
 This note does not:
 
-- Add a mode field to `.ai-dev-workflow.yaml`.
-- Change existing script behavior.
+- Route PRs across repositories.
 - Change existing agent prompts or command wrappers.
 - Migrate existing downstream repositories.
-- Route PRs across repositories.
-- Define secret storage, authentication, or product-repo checkout discovery.
+- Define secret storage or authentication beyond local secret-reference
+  placement.
 
 Those behaviors belong to later workflow-hub implementation items. Until those
 items land, missing mode remains `single_repo` and existing repositories keep the

--- a/scripts/development-workflow/tests/test-workflow-config-resolver.sh
+++ b/scripts/development-workflow/tests/test-workflow-config-resolver.sh
@@ -108,11 +108,13 @@ single_repo_output="$(workflow_repository_context "" "$single_repo_dir")"
 run_contains "single_repo_context_mode" "WORKFLOW_MODE=single_repo" "$single_repo_output"
 run_contains "single_repo_context_github_repo" "TARGET_GITHUB_REPO=example/mobile-app.extra" "$single_repo_output"
 run_contains "single_repo_context_local_path" "TARGET_LOCAL_PATH=$single_repo_dir" "$single_repo_output"
-run_contains "single_repo_context_default_branch" "TARGET_DEFAULT_BRANCH=develop" "$single_repo_output"
+run_contains "single_repo_context_default_branch" "TARGET_DEFAULT_BRANCH=main" "$single_repo_output"
 validator_output="$(bash "$VALIDATOR" --repo-root "$single_repo_dir")"
 run_contains "validate_wrapper_repo_root_arg" "TARGET_REPO_NAME=single-repo" "$validator_output"
 validator_help_output="$(bash "$VALIDATOR" --help)"
 run_contains "validate_wrapper_help" "Usage:" "$validator_help_output"
+validator_short_help_output="$(bash "$VALIDATOR" -h)"
+run_contains "validate_wrapper_short_help" "Usage:" "$validator_short_help_output"
 run_fails_contains \
   "validate_wrapper_unknown_arg" \
   "unknown argument '--unknown'" \
@@ -121,6 +123,10 @@ run_fails_contains \
   "validate_wrapper_missing_arg_value" \
   "--repo requires a value" \
   bash "$VALIDATOR" --repo
+run_fails_contains \
+  "validate_wrapper_missing_repo_root_value" \
+  "--repo-root requires a value" \
+  bash "$VALIDATOR" --repo-root
 
 hub_dir="$(fixture_dir workflow-hub)"
 cat > "$hub_dir/.ai-dev-workflow.yaml" <<'YAML'

--- a/scripts/development-workflow/tests/test-workflow-config-resolver.sh
+++ b/scripts/development-workflow/tests/test-workflow-config-resolver.sh
@@ -110,21 +110,24 @@ run_contains "single_repo_context_github_repo" "TARGET_GITHUB_REPO=example/mobil
 run_contains "single_repo_context_local_path" "TARGET_LOCAL_PATH=$single_repo_dir" "$single_repo_output"
 run_contains "single_repo_context_default_branch" "TARGET_DEFAULT_BRANCH=main" "$single_repo_output"
 validator_output="$(bash "$VALIDATOR" --repo-root "$single_repo_dir")"
-run_contains "validate_wrapper_repo_root_arg" "TARGET_REPO_NAME=single-repo" "$validator_output"
+run_contains "validate_workflow_config_sh_repo_root_arg" "TARGET_REPO_NAME=single-repo" "$validator_output"
+
+# validate-workflow-config.sh argument parsing coverage: help flags, unknown
+# flags, and missing values for both value-taking options.
 validator_help_output="$(bash "$VALIDATOR" --help)"
-run_contains "validate_wrapper_help" "Usage:" "$validator_help_output"
+run_contains "validate_workflow_config_sh_help" "Usage:" "$validator_help_output"
 validator_short_help_output="$(bash "$VALIDATOR" -h)"
-run_contains "validate_wrapper_short_help" "Usage:" "$validator_short_help_output"
+run_contains "validate_workflow_config_sh_short_help" "Usage:" "$validator_short_help_output"
 run_fails_contains \
-  "validate_wrapper_unknown_arg" \
+  "validate_workflow_config_sh_unknown_arg" \
   "unknown argument '--unknown'" \
   bash "$VALIDATOR" --unknown
 run_fails_contains \
-  "validate_wrapper_missing_arg_value" \
+  "validate_workflow_config_sh_missing_repo_value" \
   "--repo requires a value" \
   bash "$VALIDATOR" --repo
 run_fails_contains \
-  "validate_wrapper_missing_repo_root_value" \
+  "validate_workflow_config_sh_missing_repo_root_value" \
   "--repo-root requires a value" \
   bash "$VALIDATOR" --repo-root
 

--- a/scripts/development-workflow/tests/test-workflow-config-resolver.sh
+++ b/scripts/development-workflow/tests/test-workflow-config-resolver.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# test-workflow-config-resolver.sh - repository-context config resolver tests.
+#
+# Usage: bash scripts/development-workflow/tests/test-workflow-config-resolver.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+RESOLVER="$REPO_ROOT/scripts/development-workflow/workflow-config-resolver.py"
+
+TMP_ROOT="$(mktemp -d)"
+TMP_ROOT="$(CDPATH='' cd -- "$TMP_ROOT" && pwd -P)"
+
+_harness_exit() {
+  local status=$?
+  rm -rf "$TMP_ROOT"
+  case "$status" in
+    141) exit 0 ;;
+    *)   exit "$status" ;;
+  esac
+}
+trap _harness_exit EXIT
+
+# shellcheck source=scripts/development-workflow/workflow-lib.sh
+source "$REPO_ROOT/scripts/development-workflow/workflow-lib.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_contains() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if grep -Fq "$expected" <<< "$actual"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected output to contain '${expected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_fails_contains() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  local output=""
+  local status=0
+
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+
+  if [ "$status" -ne 0 ] && grep -Fq "$expected" <<< "$output"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected failure containing '${expected}'"
+    printf 'Status: %s\nOutput:\n%s\n' "$status" "$output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+fixture_dir() {
+  local name="$1"
+  local path="$TMP_ROOT/$name"
+  mkdir -p "$path"
+  printf '%s\n' "$path"
+}
+
+echo ""
+echo "=== Workflow config resolver ==="
+
+missing_mode_dir="$(fixture_dir missing-mode)"
+missing_mode_output="$(python3 "$RESOLVER" mode --repo-root "$missing_mode_dir")"
+run_test "missing_mode_defaults_single_repo" "WORKFLOW_MODE=single_repo" "$missing_mode_output"
+
+single_repo_dir="$(fixture_dir single-repo)"
+cat > "$single_repo_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: single_repo
+YAML
+single_repo_output="$(workflow_repository_context "" "$single_repo_dir")"
+run_contains "single_repo_context_mode" "WORKFLOW_MODE=single_repo" "$single_repo_output"
+run_contains "single_repo_context_local_path" "TARGET_LOCAL_PATH=$single_repo_dir" "$single_repo_output"
+run_contains "single_repo_context_default_branch" "TARGET_DEFAULT_BRANCH=develop" "$single_repo_output"
+
+hub_dir="$(fixture_dir workflow-hub)"
+cat > "$hub_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      default_branch: main
+      role: mobile
+      scope: app
+      tracker:
+        component: mobile
+    - name: admin-portal
+      git_url: git@github.com:example/admin-portal.git
+      default_branch: develop
+YAML
+cat > "$hub_dir/.ai-dev-workflow.local.yaml" <<'YAML'
+checkout_root: ../checkouts
+
+product_repos:
+  - name: mobile-app
+    local_path: ../local/mobile-app
+YAML
+hub_output="$(workflow_repository_context mobile-app "$hub_dir")"
+run_contains "workflow_hub_context_mode" "WORKFLOW_MODE=workflow_hub" "$hub_output"
+run_contains "workflow_hub_context_name" "TARGET_REPO_NAME=mobile-app" "$hub_output"
+run_contains "workflow_hub_context_github_repo" "TARGET_GITHUB_REPO=example/mobile-app" "$hub_output"
+run_contains "workflow_hub_context_default_branch" "TARGET_DEFAULT_BRANCH=main" "$hub_output"
+run_contains "workflow_hub_context_tracker_hints" "TARGET_TRACKER_HINTS=component:mobile" "$hub_output"
+run_contains "workflow_hub_local_path_override" "TARGET_LOCAL_PATH=$TMP_ROOT/local/mobile-app" "$hub_output"
+run_contains "workflow_hub_local_path_source" "TARGET_LOCAL_PATH_SOURCE=local_override" "$hub_output"
+
+admin_output="$(workflow_repository_context admin-portal "$hub_dir")"
+run_contains "workflow_hub_checkout_root_path" "TARGET_LOCAL_PATH=$TMP_ROOT/checkouts/admin-portal" "$admin_output"
+run_contains "workflow_hub_checkout_root_source" "TARGET_LOCAL_PATH_SOURCE=checkout_root" "$admin_output"
+
+run_fails_contains \
+  "workflow_hub_ambiguous_without_repo" \
+  "product repository selection is ambiguous" \
+  python3 "$RESOLVER" resolve --repo-root "$hub_dir"
+
+run_fails_contains \
+  "workflow_hub_unknown_repo" \
+  "no workflow_hub.product_repos entry named 'unknown-app'" \
+  python3 "$RESOLVER" resolve --repo-root "$hub_dir" --repo unknown-app
+
+no_local_dir="$(fixture_dir no-local)"
+cat > "$no_local_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+YAML
+run_fails_contains \
+  "workflow_hub_require_local_path" \
+  "local path for product repo 'mobile-app' is required" \
+  python3 "$RESOLVER" validate --repo-root "$no_local_dir" --repo mobile-app --require-local
+
+duplicate_dir="$(fixture_dir duplicate)"
+cat > "$duplicate_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+    - name: mobile-app
+      github_repo: example/mobile-app-2
+YAML
+run_fails_contains \
+  "workflow_hub_duplicate_names" \
+  "duplicate workflow_hub.product_repos name 'mobile-app'" \
+  python3 "$RESOLVER" resolve --repo-root "$duplicate_dir" --repo mobile-app
+
+missing_identity_dir="$(fixture_dir missing-identity)"
+cat > "$missing_identity_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+YAML
+run_fails_contains \
+  "workflow_hub_missing_identity" \
+  "must define github_repo or git_url" \
+  python3 "$RESOLVER" resolve --repo-root "$missing_identity_dir" --repo mobile-app
+
+local_only_dir="$(fixture_dir local-only-field)"
+cat > "$local_only_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      local_path: ../mobile-app
+YAML
+run_fails_contains \
+  "workflow_hub_rejects_local_only_fields" \
+  "contains local-only field(s): local_path" \
+  python3 "$RESOLVER" resolve --repo-root "$local_only_dir" --repo mobile-app
+
+product_repo_dir="$(fixture_dir product-repo)"
+cat > "$product_repo_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: product_repo
+
+product_repo:
+  default_branch: release
+  workflow_hub:
+    github_repo: example/workflow-hub
+YAML
+product_repo_output="$(workflow_repository_context "" "$product_repo_dir")"
+run_contains "product_repo_context_mode" "WORKFLOW_MODE=product_repo" "$product_repo_output"
+run_contains "product_repo_context_hub" "WORKFLOW_HUB_GITHUB_REPO=example/workflow-hub" "$product_repo_output"
+run_contains "product_repo_context_branch" "TARGET_DEFAULT_BRANCH=release" "$product_repo_output"
+
+bad_product_repo_dir="$(fixture_dir bad-product-repo)"
+cat > "$bad_product_repo_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: product_repo
+
+product_repo:
+  workflow_hub: {}
+YAML
+run_fails_contains \
+  "product_repo_requires_hub_reference" \
+  "product_repo.workflow_hub must define github_repo or git_url" \
+  python3 "$RESOLVER" resolve --repo-root "$bad_product_repo_dir"
+
+review_dir="$(fixture_dir review-overrides)"
+mkdir -p "$review_dir/.tmp"
+cat > "$review_dir/.tmp/template-config.json" <<'JSON'
+{
+  "overrides": {
+    "review": {
+      "on_draft": {
+        "runner": ["claude"]
+      },
+      "internal_reviewers_unavailable_policy": "fail-if-any-unavailable"
+    }
+  }
+}
+JSON
+cat > "$review_dir/.ai-dev-workflow.local.yaml" <<'YAML'
+review:
+  on_draft:
+    runner: [codex]
+  internal_reviewers_unavailable_policy: warn
+YAML
+review_output="$(workflow_review_override_context "$review_dir")"
+run_contains "legacy_review_override_precedence_runner" "REVIEW_ON_DRAFT_RUNNER=claude" "$review_output"
+run_contains "legacy_review_override_precedence_policy" "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY=fail-if-any-unavailable" "$review_output"
+run_contains "legacy_review_override_source" "LOCAL_OVERRIDE_SOURCE=.tmp/template-config.json" "$review_output"
+
+local_review_dir="$(fixture_dir local-review-overrides)"
+cat > "$local_review_dir/.ai-dev-workflow.local.yaml" <<'YAML'
+review:
+  on_draft:
+    runner: [claude, codex]
+  internal_reviewers_unavailable_policy: warn
+YAML
+local_review_output="$(workflow_review_override_context "$local_review_dir")"
+run_contains "local_review_override_runner" "REVIEW_ON_DRAFT_RUNNER=claude,codex" "$local_review_output"
+run_contains "local_review_override_source" "LOCAL_OVERRIDE_SOURCE=.ai-dev-workflow.local.yaml" "$local_review_output"
+
+malformed_dir="$(fixture_dir malformed)"
+cat > "$malformed_dir/.ai-dev-workflow.yaml" <<'YAML'
+ schema_version: 2
+YAML
+run_fails_contains \
+  "malformed_yaml_fails_closed" \
+  "indentation must use multiples of two spaces" \
+  python3 "$RESOLVER" mode --repo-root "$malformed_dir"
+
+wrapper_output="$(workflow_validate_repository_context mobile-app "$hub_dir" require-local)"
+run_contains "workflow_lib_validate_wrapper" "TARGET_REPO_NAME=mobile-app" "$wrapper_output"
+
+echo ""
+echo "Passed: $PASS_COUNT"
+echo "Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi

--- a/scripts/development-workflow/tests/test-workflow-config-resolver.sh
+++ b/scripts/development-workflow/tests/test-workflow-config-resolver.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
 RESOLVER="$REPO_ROOT/scripts/development-workflow/workflow-config-resolver.py"
+VALIDATOR="$REPO_ROOT/scripts/development-workflow/validate-workflow-config.sh"
 
 TMP_ROOT="$(mktemp -d)"
 TMP_ROOT="$(CDPATH='' cd -- "$TMP_ROOT" && pwd -P)"
@@ -45,7 +46,7 @@ run_contains() {
   local name="$1"
   local expected="$2"
   local actual="$3"
-  if grep -Fq "$expected" <<< "$actual"; then
+  if grep -Fq -- "$expected" <<< "$actual"; then
     echo "PASS: $name"
     PASS_COUNT=$((PASS_COUNT + 1))
   else
@@ -67,7 +68,7 @@ run_fails_contains() {
   status=$?
   set -e
 
-  if [ "$status" -ne 0 ] && grep -Fq "$expected" <<< "$output"; then
+  if [ "$status" -ne 0 ] && grep -Fq -- "$expected" <<< "$output"; then
     echo "PASS: $name"
     PASS_COUNT=$((PASS_COUNT + 1))
   else
@@ -106,6 +107,18 @@ run_contains "single_repo_context_mode" "WORKFLOW_MODE=single_repo" "$single_rep
 run_contains "single_repo_context_github_repo" "TARGET_GITHUB_REPO=example/mobile-app.extra" "$single_repo_output"
 run_contains "single_repo_context_local_path" "TARGET_LOCAL_PATH=$single_repo_dir" "$single_repo_output"
 run_contains "single_repo_context_default_branch" "TARGET_DEFAULT_BRANCH=develop" "$single_repo_output"
+validator_output="$(bash "$VALIDATOR" --repo-root "$single_repo_dir")"
+run_contains "validate_wrapper_repo_root_arg" "TARGET_REPO_NAME=single-repo" "$validator_output"
+validator_help_output="$(bash "$VALIDATOR" --help)"
+run_contains "validate_wrapper_help" "Usage:" "$validator_help_output"
+run_fails_contains \
+  "validate_wrapper_unknown_arg" \
+  "unknown argument '--unknown'" \
+  bash "$VALIDATOR" --unknown
+run_fails_contains \
+  "validate_wrapper_missing_arg_value" \
+  "--repo requires a value" \
+  bash "$VALIDATOR" --repo
 
 hub_dir="$(fixture_dir workflow-hub)"
 cat > "$hub_dir/.ai-dev-workflow.yaml" <<'YAML'
@@ -235,6 +248,34 @@ run_fails_contains \
   "contains local-only field(s): github_app.private_key_path" \
   python3 "$RESOLVER" resolve --repo-root "$nested_local_only_dir" --repo mobile-app
 
+nested_list_local_only_dir="$(fixture_dir nested-list-local-only-field)"
+cat > "$nested_list_local_only_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      app_identifiers:
+        - github_app:
+            app_id: "123"
+            private_key_path: ~/.config/example/private-key.pem
+YAML
+run_fails_contains \
+  "workflow_hub_preserves_nested_list_mapping" \
+  "contains local-only field(s): app_identifiers[1].github_app.private_key_path" \
+  python3 "$RESOLVER" resolve --repo-root "$nested_list_local_only_dir" --repo mobile-app
+
+ssh_remote_dir="$(fixture_dir ssh-remote)"
+mkdir -p "$ssh_remote_dir/.git"
+cat > "$ssh_remote_dir/.git/config" <<'GITCONFIG'
+[remote "origin"]
+  url = ssh://git@github.com/example/ssh-product.git
+GITCONFIG
+ssh_remote_output="$(python3 "$RESOLVER" resolve --repo-root "$ssh_remote_dir")"
+run_contains "single_repo_ssh_remote_slug" "TARGET_GITHUB_REPO=example/ssh-product" "$ssh_remote_output"
+
 product_repo_dir="$(fixture_dir product-repo)"
 cat > "$product_repo_dir/.ai-dev-workflow.yaml" <<'YAML'
 schema_version: 2
@@ -285,7 +326,9 @@ review:
 YAML
 review_output="$(workflow_review_override_context "$review_dir")"
 run_contains "legacy_review_override_precedence_runner" "REVIEW_ON_DRAFT_RUNNER=claude" "$review_output"
+run_contains "legacy_review_override_precedence_runner_source" "REVIEW_ON_DRAFT_RUNNER_SOURCE=.tmp/template-config.json" "$review_output"
 run_contains "legacy_review_override_precedence_policy" "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY=fail-if-any-unavailable" "$review_output"
+run_contains "legacy_review_override_precedence_policy_source" "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY_SOURCE=.tmp/template-config.json" "$review_output"
 run_contains "legacy_review_override_source" "LOCAL_OVERRIDE_SOURCE=.tmp/template-config.json" "$review_output"
 
 local_review_dir="$(fixture_dir local-review-overrides)"
@@ -298,6 +341,27 @@ YAML
 local_review_output="$(workflow_review_override_context "$local_review_dir")"
 run_contains "local_review_override_runner" "REVIEW_ON_DRAFT_RUNNER=claude,codex" "$local_review_output"
 run_contains "local_review_override_source" "LOCAL_OVERRIDE_SOURCE=.ai-dev-workflow.local.yaml" "$local_review_output"
+
+mixed_review_dir="$(fixture_dir mixed-review-overrides)"
+mkdir -p "$mixed_review_dir/.tmp"
+cat > "$mixed_review_dir/.tmp/template-config.json" <<'JSON'
+{
+  "overrides": {
+    "review": {
+      "internal_reviewers_unavailable_policy": "fail-if-any-unavailable"
+    }
+  }
+}
+JSON
+cat > "$mixed_review_dir/.ai-dev-workflow.local.yaml" <<'YAML'
+review:
+  on_draft:
+    runner: [codex]
+YAML
+mixed_review_output="$(workflow_review_override_context "$mixed_review_dir")"
+run_contains "mixed_review_override_runner_source" "REVIEW_ON_DRAFT_RUNNER_SOURCE=.ai-dev-workflow.local.yaml" "$mixed_review_output"
+run_contains "mixed_review_override_policy_source" "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY_SOURCE=.tmp/template-config.json" "$mixed_review_output"
+run_contains "mixed_review_override_combined_source" "LOCAL_OVERRIDE_SOURCE=.ai-dev-workflow.local.yaml,.tmp/template-config.json" "$mixed_review_output"
 
 malformed_dir="$(fixture_dir malformed)"
 cat > "$malformed_dir/.ai-dev-workflow.yaml" <<'YAML'

--- a/scripts/development-workflow/tests/test-workflow-config-resolver.sh
+++ b/scripts/development-workflow/tests/test-workflow-config-resolver.sh
@@ -92,12 +92,18 @@ missing_mode_output="$(python3 "$RESOLVER" mode --repo-root "$missing_mode_dir")
 run_test "missing_mode_defaults_single_repo" "WORKFLOW_MODE=single_repo" "$missing_mode_output"
 
 single_repo_dir="$(fixture_dir single-repo)"
+mkdir -p "$single_repo_dir/.git"
 cat > "$single_repo_dir/.ai-dev-workflow.yaml" <<'YAML'
 schema_version: 2
 mode: single_repo
 YAML
+cat > "$single_repo_dir/.git/config" <<'GITCONFIG'
+[remote "origin"]
+  url = https://github.com/example/mobile-app.extra.git
+GITCONFIG
 single_repo_output="$(workflow_repository_context "" "$single_repo_dir")"
 run_contains "single_repo_context_mode" "WORKFLOW_MODE=single_repo" "$single_repo_output"
+run_contains "single_repo_context_github_repo" "TARGET_GITHUB_REPO=example/mobile-app.extra" "$single_repo_output"
 run_contains "single_repo_context_local_path" "TARGET_LOCAL_PATH=$single_repo_dir" "$single_repo_output"
 run_contains "single_repo_context_default_branch" "TARGET_DEFAULT_BRANCH=develop" "$single_repo_output"
 

--- a/scripts/development-workflow/tests/test-workflow-config-resolver.sh
+++ b/scripts/development-workflow/tests/test-workflow-config-resolver.sh
@@ -91,6 +91,8 @@ echo "=== Workflow config resolver ==="
 missing_mode_dir="$(fixture_dir missing-mode)"
 missing_mode_output="$(python3 "$RESOLVER" mode --repo-root "$missing_mode_dir")"
 run_test "missing_mode_defaults_single_repo" "WORKFLOW_MODE=single_repo" "$missing_mode_output"
+missing_mode_wrapper_output="$(workflow_repository_mode "$missing_mode_dir")"
+run_test "workflow_repository_mode_wrapper" "WORKFLOW_MODE=single_repo" "$missing_mode_wrapper_output"
 
 single_repo_dir="$(fixture_dir single-repo)"
 mkdir -p "$single_repo_dir/.git"
@@ -329,18 +331,32 @@ run_contains "legacy_review_override_precedence_runner" "REVIEW_ON_DRAFT_RUNNER=
 run_contains "legacy_review_override_precedence_runner_source" "REVIEW_ON_DRAFT_RUNNER_SOURCE=.tmp/template-config.json" "$review_output"
 run_contains "legacy_review_override_precedence_policy" "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY=fail-if-any-unavailable" "$review_output"
 run_contains "legacy_review_override_precedence_policy_source" "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY_SOURCE=.tmp/template-config.json" "$review_output"
-run_contains "legacy_review_override_source" "LOCAL_OVERRIDE_SOURCE=.tmp/template-config.json" "$review_output"
+run_contains "legacy_review_override_source" "LOCAL_OVERRIDE_SOURCE=runner:.tmp/template-config.json,policy:.tmp/template-config.json" "$review_output"
 
 local_review_dir="$(fixture_dir local-review-overrides)"
 cat > "$local_review_dir/.ai-dev-workflow.local.yaml" <<'YAML'
 review:
   on_draft:
-    runner: [claude, codex]
+    runner: ["claude,with-comma", codex]
   internal_reviewers_unavailable_policy: warn
 YAML
+inline_list_parse_output="$(
+  python3 - "$RESOLVER" "$local_review_dir/.ai-dev-workflow.local.yaml" <<'PY'
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("workflow_config_resolver", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+runner = module.parse_yaml_subset(Path(sys.argv[2]))["review"]["on_draft"]["runner"]
+print(f"{len(runner)}:{runner[0]}:{runner[1]}")
+PY
+)"
+run_test "inline_list_parser_respects_quotes" "2:claude,with-comma:codex" "$inline_list_parse_output"
 local_review_output="$(workflow_review_override_context "$local_review_dir")"
-run_contains "local_review_override_runner" "REVIEW_ON_DRAFT_RUNNER=claude,codex" "$local_review_output"
-run_contains "local_review_override_source" "LOCAL_OVERRIDE_SOURCE=.ai-dev-workflow.local.yaml" "$local_review_output"
+run_contains "local_review_override_runner" "REVIEW_ON_DRAFT_RUNNER=claude,with-comma,codex" "$local_review_output"
+run_contains "local_review_override_source" "LOCAL_OVERRIDE_SOURCE=runner:.ai-dev-workflow.local.yaml,policy:.ai-dev-workflow.local.yaml" "$local_review_output"
 
 mixed_review_dir="$(fixture_dir mixed-review-overrides)"
 mkdir -p "$mixed_review_dir/.tmp"
@@ -361,7 +377,7 @@ YAML
 mixed_review_output="$(workflow_review_override_context "$mixed_review_dir")"
 run_contains "mixed_review_override_runner_source" "REVIEW_ON_DRAFT_RUNNER_SOURCE=.ai-dev-workflow.local.yaml" "$mixed_review_output"
 run_contains "mixed_review_override_policy_source" "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY_SOURCE=.tmp/template-config.json" "$mixed_review_output"
-run_contains "mixed_review_override_combined_source" "LOCAL_OVERRIDE_SOURCE=.ai-dev-workflow.local.yaml,.tmp/template-config.json" "$mixed_review_output"
+run_contains "mixed_review_override_combined_source" "LOCAL_OVERRIDE_SOURCE=runner:.ai-dev-workflow.local.yaml,policy:.tmp/template-config.json" "$mixed_review_output"
 
 malformed_dir="$(fixture_dir malformed)"
 cat > "$malformed_dir/.ai-dev-workflow.yaml" <<'YAML'

--- a/scripts/development-workflow/tests/test-workflow-config-resolver.sh
+++ b/scripts/development-workflow/tests/test-workflow-config-resolver.sh
@@ -211,6 +211,24 @@ run_fails_contains \
   "contains local-only field(s): local_path" \
   python3 "$RESOLVER" resolve --repo-root "$local_only_dir" --repo mobile-app
 
+nested_local_only_dir="$(fixture_dir nested-local-only-field)"
+cat > "$nested_local_only_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      github_app:
+        app_id: "123"
+        private_key_path: ~/.config/example/private-key.pem
+YAML
+run_fails_contains \
+  "workflow_hub_rejects_nested_local_only_fields" \
+  "contains local-only field(s): github_app.private_key_path" \
+  python3 "$RESOLVER" resolve --repo-root "$nested_local_only_dir" --repo mobile-app
+
 product_repo_dir="$(fixture_dir product-repo)"
 cat > "$product_repo_dir/.ai-dev-workflow.yaml" <<'YAML'
 schema_version: 2

--- a/scripts/development-workflow/validate-workflow-config.sh
+++ b/scripts/development-workflow/validate-workflow-config.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Validate shared/local workflow repository-context configuration.
+#
+# Usage:
+#   scripts/development-workflow/validate-workflow-config.sh [--repo <name>] [--require-local] [--repo-root <path>]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+ARGS=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo|--repo-root)
+      [ "$#" -ge 2 ] || { echo "ERROR: $1 requires a value" >&2; exit 2; }
+      ARGS+=("$1" "$2")
+      shift 2
+      ;;
+    --require-local)
+      ARGS+=("$1")
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,8p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument '$1'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "${#ARGS[@]}" -gt 0 ]; then
+  python3 "$SCRIPT_DIR/workflow-config-resolver.py" validate "${ARGS[@]}"
+else
+  python3 "$SCRIPT_DIR/workflow-config-resolver.py" validate
+fi

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""Resolve shared and local workflow repository context.
+
+This script intentionally uses only the Python standard library. It supports the
+small YAML subset used by `.ai-dev-workflow.yaml` and
+`.ai-dev-workflow.local.yaml`: nested mappings, lists, and scalar values.
+Unsupported or malformed structures fail closed with a file-specific error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+
+VALID_MODES = {"single_repo", "workflow_hub", "product_repo"}
+LOCAL_ONLY_KEYS = {
+    "local_path",
+    "checkout_path",
+    "checkout_root",
+    "private_key_path",
+    "private_key",
+    "secret",
+    "secrets",
+    "secret_ref",
+    "tool_overrides",
+    "local_overrides",
+}
+
+
+class ConfigError(Exception):
+    """Configuration problem with a human-readable message."""
+
+
+def strip_inline_comment(line: str) -> str:
+    in_single = False
+    in_double = False
+    escaped = False
+    result: list[str] = []
+    for char in line:
+        if escaped:
+            result.append(char)
+            escaped = False
+            continue
+        if char == "\\" and in_double:
+            result.append(char)
+            escaped = True
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+            result.append(char)
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            result.append(char)
+            continue
+        if char == "#" and not in_single and not in_double:
+            break
+        result.append(char)
+    return "".join(result).rstrip()
+
+
+def preprocess_yaml(path: Path) -> list[tuple[int, str, int]]:
+    try:
+        raw_lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise ConfigError(f"{path}: could not read config: {exc}") from exc
+
+    lines: list[tuple[int, str, int]] = []
+    for line_no, raw in enumerate(raw_lines, start=1):
+        if "\t" in raw[: len(raw) - len(raw.lstrip(" \t"))]:
+            raise ConfigError(f"{path}:{line_no}: tabs are not supported for indentation")
+        stripped_comment = strip_inline_comment(raw)
+        if not stripped_comment.strip():
+            continue
+        indent = len(stripped_comment) - len(stripped_comment.lstrip(" "))
+        if indent % 2 != 0:
+            raise ConfigError(f"{path}:{line_no}: indentation must use multiples of two spaces")
+        lines.append((indent, stripped_comment.strip(), line_no))
+    return lines
+
+
+def split_key_value(content: str, path: Path, line_no: int) -> tuple[str, str | None]:
+    if ":" not in content:
+        raise ConfigError(f"{path}:{line_no}: expected '<key>: <value>'")
+    key, value = content.split(":", 1)
+    key = key.strip()
+    if not re.match(r"^[A-Za-z0-9_.-]+$", key):
+        raise ConfigError(f"{path}:{line_no}: unsupported key '{key}'")
+    value = value.strip()
+    return key, value if value != "" else None
+
+
+def parse_scalar(value: str) -> Any:
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        if not inner:
+            return []
+        return [parse_scalar(item.strip()) for item in inner.split(",") if item.strip()]
+    if value in {"''", '""'}:
+        return ""
+    if (value.startswith("'") and value.endswith("'")) or (
+        value.startswith('"') and value.endswith('"')
+    ):
+        return value[1:-1]
+    if value == "[]":
+        return []
+    if value == "{}":
+        return {}
+    if value.lower() == "true":
+        return True
+    if value.lower() == "false":
+        return False
+    if value.lower() in {"null", "~"}:
+        return None
+    return value
+
+
+def parse_mapping(
+    lines: list[tuple[int, str, int]], index: int, indent: int, path: Path
+) -> tuple[dict[str, Any], int]:
+    result: dict[str, Any] = {}
+    while index < len(lines):
+        line_indent, content, line_no = lines[index]
+        if line_indent < indent:
+            break
+        if line_indent > indent:
+            raise ConfigError(f"{path}:{line_no}: unexpected indentation")
+        if content.startswith("- "):
+            raise ConfigError(f"{path}:{line_no}: list item is not valid in this mapping")
+        key, value = split_key_value(content, path, line_no)
+        index += 1
+        if value is not None:
+            result[key] = parse_scalar(value)
+            continue
+        if index >= len(lines) or lines[index][0] <= indent:
+            result[key] = {}
+            continue
+        child_indent, child_content, _ = lines[index]
+        if child_indent != indent + 2:
+            raise ConfigError(f"{path}:{lines[index][2]}: expected child indentation of {indent + 2}")
+        if child_content.startswith("- "):
+            child, index = parse_list(lines, index, child_indent, path)
+        else:
+            child, index = parse_mapping(lines, index, child_indent, path)
+        result[key] = child
+    return result, index
+
+
+def parse_list(
+    lines: list[tuple[int, str, int]], index: int, indent: int, path: Path
+) -> tuple[list[Any], int]:
+    result: list[Any] = []
+    while index < len(lines):
+        line_indent, content, line_no = lines[index]
+        if line_indent < indent:
+            break
+        if line_indent > indent:
+            raise ConfigError(f"{path}:{line_no}: unexpected indentation")
+        if not content.startswith("- "):
+            break
+        item = content[2:].strip()
+        index += 1
+        if not item:
+            if index >= len(lines) or lines[index][0] <= indent:
+                result.append({})
+                continue
+            child_indent, child_content, _ = lines[index]
+            if child_indent != indent + 2:
+                raise ConfigError(f"{path}:{lines[index][2]}: expected child indentation of {indent + 2}")
+            if child_content.startswith("- "):
+                child, index = parse_list(lines, index, child_indent, path)
+            else:
+                child, index = parse_mapping(lines, index, child_indent, path)
+            result.append(child)
+            continue
+        if ":" in item:
+            key, value = split_key_value(item, path, line_no)
+            item_map: dict[str, Any] = {key: parse_scalar(value) if value is not None else {}}
+            if index < len(lines) and lines[index][0] == indent + 2:
+                continuation, index = parse_mapping(lines, index, indent + 2, path)
+                item_map.update(continuation)
+            result.append(item_map)
+        else:
+            result.append(parse_scalar(item))
+    return result, index
+
+
+def parse_yaml_subset(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    lines = preprocess_yaml(path)
+    if not lines:
+        return {}
+    if lines[0][0] != 0:
+        raise ConfigError(f"{path}:{lines[0][2]}: top-level keys must not be indented")
+    data, index = parse_mapping(lines, 0, lines[0][0], path)
+    if index != len(lines):
+        _, _, line_no = lines[index]
+        raise ConfigError(f"{path}:{line_no}: could not parse remaining YAML")
+    return data
+
+
+def repo_root_from_args(value: str | None) -> Path:
+    if value:
+        return Path(value).resolve()
+    return Path.cwd().resolve()
+
+
+def as_mapping(value: Any, path: Path, field: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ConfigError(f"{path}: field '{field}' must be a mapping")
+    return value
+
+
+def as_list(value: Any, path: Path, field: str) -> list[Any]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ConfigError(f"{path}: field '{field}' must be a list")
+    return value
+
+
+def load_configs(repo_root: Path) -> tuple[dict[str, Any], dict[str, Any], Path, Path]:
+    shared_path = repo_root / ".ai-dev-workflow.yaml"
+    local_path = repo_root / ".ai-dev-workflow.local.yaml"
+    shared = parse_yaml_subset(shared_path)
+    local = parse_yaml_subset(local_path)
+    return shared, local, shared_path, local_path
+
+
+def mode_from_shared(shared: dict[str, Any], shared_path: Path) -> str:
+    raw_mode = shared.get("mode", "single_repo")
+    if raw_mode in {None, ""}:
+        raw_mode = "single_repo"
+    if not isinstance(raw_mode, str):
+        raise ConfigError(f"{shared_path}: field 'mode' must be a string")
+    if raw_mode not in VALID_MODES:
+        raise ConfigError(
+            f"{shared_path}: field 'mode' must be one of {', '.join(sorted(VALID_MODES))}"
+        )
+    return raw_mode
+
+
+def product_repos(shared: dict[str, Any], shared_path: Path) -> list[dict[str, Any]]:
+    workflow_hub = as_mapping(shared.get("workflow_hub"), shared_path, "workflow_hub")
+    repos = as_list(workflow_hub.get("product_repos"), shared_path, "workflow_hub.product_repos")
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, raw in enumerate(repos, start=1):
+        if not isinstance(raw, dict):
+            raise ConfigError(f"{shared_path}: workflow_hub.product_repos[{index}] must be a mapping")
+        forbidden = sorted(key for key in raw if key in LOCAL_ONLY_KEYS)
+        if forbidden:
+            raise ConfigError(
+                f"{shared_path}: workflow_hub.product_repos[{index}] contains local-only field(s): {', '.join(forbidden)}"
+            )
+        name = raw.get("name")
+        if not isinstance(name, str) or not name:
+            raise ConfigError(f"{shared_path}: workflow_hub.product_repos[{index}].name is required")
+        if name in seen:
+            raise ConfigError(
+                f"{shared_path}: duplicate workflow_hub.product_repos name '{name}'"
+            )
+        seen.add(name)
+        github_repo = raw.get("github_repo") or ""
+        git_url = raw.get("git_url") or ""
+        if not github_repo and not git_url:
+            raise ConfigError(
+                f"{shared_path}: workflow_hub.product_repos[{index}] '{name}' must define github_repo or git_url"
+            )
+        repo = dict(raw)
+        repo["default_branch"] = repo.get("default_branch") or "main"
+        normalized.append(repo)
+    return normalized
+
+
+def select_product_repo(repos: list[dict[str, Any]], target: str | None, shared_path: Path) -> dict[str, Any]:
+    if target:
+        for repo in repos:
+            if repo.get("name") == target:
+                return repo
+        raise ConfigError(f"{shared_path}: no workflow_hub.product_repos entry named '{target}'")
+    if not repos:
+        raise ConfigError(f"{shared_path}: workflow_hub.product_repos is required for workflow_hub mode")
+    if len(repos) > 1:
+        names = ", ".join(str(repo.get("name")) for repo in repos)
+        raise ConfigError(
+            f"{shared_path}: product repository selection is ambiguous; pass --repo. Available: {names}"
+        )
+    return repos[0]
+
+
+def local_product_repo(local: dict[str, Any], local_path: Path, name: str) -> dict[str, Any]:
+    repos = as_list(local.get("product_repos"), local_path, "product_repos")
+    for index, raw in enumerate(repos, start=1):
+        if not isinstance(raw, dict):
+            raise ConfigError(f"{local_path}: product_repos[{index}] must be a mapping")
+        if raw.get("name") == name:
+            return raw
+    return {}
+
+
+def resolve_local_path(
+    repo_root: Path,
+    local: dict[str, Any],
+    local_path: Path,
+    name: str,
+    require_local: bool,
+) -> tuple[str, str]:
+    local_entry = local_product_repo(local, local_path, name)
+    explicit = local_entry.get("local_path") or local_entry.get("checkout_path")
+    if explicit:
+        return str((repo_root / str(explicit)).resolve()) if not os.path.isabs(str(explicit)) else str(explicit), "local_override"
+    checkout_root = local.get("checkout_root")
+    if checkout_root:
+        base = Path(str(checkout_root))
+        if not base.is_absolute():
+            base = (repo_root / base).resolve()
+        return str(base / name), "checkout_root"
+    if require_local:
+        raise ConfigError(
+            f"{local_path}: local path for product repo '{name}' is required; set product_repos[].local_path or checkout_root"
+        )
+    return "", ""
+
+
+def flatten_tracker_hints(repo: dict[str, Any]) -> str:
+    tracker = repo.get("tracker")
+    if not isinstance(tracker, dict):
+        return ""
+    parts = []
+    for key in sorted(tracker):
+        value = tracker[key]
+        if value not in {None, ""}:
+            parts.append(f"{key}:{value}")
+    return ",".join(parts)
+
+
+def parse_remote_slug(repo_root: Path) -> str:
+    git_config = repo_root / ".git" / "config"
+    if not git_config.exists():
+        return ""
+    try:
+        text = git_config.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+    match = re.search(r"url = (?:git@github\.com:|https://github\.com/)([^/\s]+/[^/\s]+?)(?:\.git)?\s*$", text, re.M)
+    return match.group(1) if match else ""
+
+
+def resolve_context(args: argparse.Namespace) -> dict[str, str]:
+    repo_root = repo_root_from_args(args.repo_root)
+    shared, local, shared_path, local_path = load_configs(repo_root)
+    mode = mode_from_shared(shared, shared_path)
+    context: dict[str, str] = {
+        "WORKFLOW_MODE": mode,
+        "TARGET_REPO_NAME": "",
+        "TARGET_GITHUB_REPO": "",
+        "TARGET_GIT_URL": "",
+        "TARGET_DEFAULT_BRANCH": "",
+        "TARGET_LOCAL_PATH": "",
+        "TARGET_LOCAL_PATH_SOURCE": "",
+        "TARGET_TRACKER_HINTS": "",
+        "WORKFLOW_HUB_GITHUB_REPO": "",
+        "WORKFLOW_HUB_GIT_URL": "",
+    }
+
+    if mode == "single_repo":
+        context["TARGET_REPO_NAME"] = repo_root.name
+        context["TARGET_GITHUB_REPO"] = parse_remote_slug(repo_root)
+        context["TARGET_DEFAULT_BRANCH"] = "develop"
+        context["TARGET_LOCAL_PATH"] = str(repo_root)
+        context["TARGET_LOCAL_PATH_SOURCE"] = "current_repo"
+        return context
+
+    if mode == "workflow_hub":
+        repo = select_product_repo(product_repos(shared, shared_path), args.repo, shared_path)
+        local_value, local_source = resolve_local_path(
+            repo_root, local, local_path, str(repo["name"]), bool(args.require_local)
+        )
+        context.update(
+            {
+                "TARGET_REPO_NAME": str(repo.get("name") or ""),
+                "TARGET_GITHUB_REPO": str(repo.get("github_repo") or ""),
+                "TARGET_GIT_URL": str(repo.get("git_url") or ""),
+                "TARGET_DEFAULT_BRANCH": str(repo.get("default_branch") or "main"),
+                "TARGET_LOCAL_PATH": local_value,
+                "TARGET_LOCAL_PATH_SOURCE": local_source,
+                "TARGET_TRACKER_HINTS": flatten_tracker_hints(repo),
+            }
+        )
+        return context
+
+    product_repo = as_mapping(shared.get("product_repo"), shared_path, "product_repo")
+    hub = as_mapping(product_repo.get("workflow_hub"), shared_path, "product_repo.workflow_hub")
+    context.update(
+        {
+            "TARGET_REPO_NAME": repo_root.name,
+            "TARGET_GITHUB_REPO": parse_remote_slug(repo_root),
+            "TARGET_DEFAULT_BRANCH": str(product_repo.get("default_branch") or "main"),
+            "TARGET_LOCAL_PATH": str(repo_root),
+            "TARGET_LOCAL_PATH_SOURCE": "current_repo",
+            "WORKFLOW_HUB_GITHUB_REPO": str(hub.get("github_repo") or ""),
+            "WORKFLOW_HUB_GIT_URL": str(hub.get("git_url") or ""),
+        }
+    )
+    if not context["WORKFLOW_HUB_GITHUB_REPO"] and not context["WORKFLOW_HUB_GIT_URL"]:
+        raise ConfigError(
+            f"{shared_path}: product_repo.workflow_hub must define github_repo or git_url in product_repo mode"
+        )
+    return context
+
+
+def load_legacy_template_config(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / ".tmp" / "template-config.json"
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"{path}: could not parse legacy override JSON: {exc}") from exc
+
+
+def list_from_path(data: dict[str, Any], path: list[str]) -> list[str]:
+    value: Any = data
+    for key in path:
+        if not isinstance(value, dict):
+            return []
+        value = value.get(key)
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    return []
+
+
+def scalar_from_path(data: dict[str, Any], path: list[str]) -> str:
+    value: Any = data
+    for key in path:
+        if not isinstance(value, dict):
+            return ""
+        value = value.get(key)
+    return str(value) if value not in {None, ""} else ""
+
+
+def resolve_review_overrides(args: argparse.Namespace) -> dict[str, str]:
+    repo_root = repo_root_from_args(args.repo_root)
+    _, local, _, _ = load_configs(repo_root)
+    legacy = load_legacy_template_config(repo_root)
+
+    legacy_runner = list_from_path(legacy, ["overrides", "review", "on_draft", "runner"])
+    if not legacy_runner:
+        legacy_runner = list_from_path(legacy, ["overrides", "review", "internal_reviewers"])
+    local_runner = list_from_path(local, ["review", "on_draft", "runner"])
+    runner = legacy_runner or local_runner
+
+    legacy_policy = scalar_from_path(
+        legacy, ["overrides", "review", "internal_reviewers_unavailable_policy"]
+    )
+    local_policy = scalar_from_path(local, ["review", "internal_reviewers_unavailable_policy"])
+    policy = legacy_policy or local_policy
+
+    return {
+        "REVIEW_ON_DRAFT_RUNNER": ",".join(runner),
+        "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY": policy,
+        "LOCAL_OVERRIDE_SOURCE": ".tmp/template-config.json"
+        if legacy_runner or legacy_policy
+        else (".ai-dev-workflow.local.yaml" if local_runner or local_policy else ""),
+    }
+
+
+def print_shell_context(values: dict[str, str]) -> None:
+    for key in sorted(values):
+        value = values[key]
+        if value == "":
+            print(f"{key}=")
+        else:
+            print(f"{key}={shlex.quote(str(value))}")
+
+
+def cmd_mode(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from_args(args.repo_root)
+    shared, _, shared_path, _ = load_configs(repo_root)
+    print_shell_context({"WORKFLOW_MODE": mode_from_shared(shared, shared_path)})
+    return 0
+
+
+def cmd_resolve(args: argparse.Namespace) -> int:
+    print_shell_context(resolve_context(args))
+    return 0
+
+
+def cmd_review_overrides(args: argparse.Namespace) -> int:
+    print_shell_context(resolve_review_overrides(args))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Resolve AI workflow repository context")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    mode = subcommands.add_parser("mode", help="print the effective workflow mode")
+    mode.add_argument("--repo-root")
+    mode.set_defaults(func=cmd_mode)
+
+    for name in ("resolve", "validate"):
+        command = subcommands.add_parser(name, help=f"{name} repository context")
+        command.add_argument("--repo-root")
+        command.add_argument("--repo", help="stable product repository name")
+        command.add_argument(
+            "--require-local",
+            action="store_true",
+            help="require a resolved local product checkout path",
+        )
+        command.set_defaults(func=cmd_resolve)
+
+    overrides = subcommands.add_parser(
+        "review-overrides", help="print local review override compatibility values"
+    )
+    overrides.add_argument("--repo-root")
+    overrides.set_defaults(func=cmd_review_overrides)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except ConfigError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -445,7 +445,7 @@ def resolve_context(args: argparse.Namespace) -> dict[str, str]:
     if mode == "single_repo":
         context["TARGET_REPO_NAME"] = repo_root.name
         context["TARGET_GITHUB_REPO"] = parse_remote_slug(repo_root)
-        context["TARGET_DEFAULT_BRANCH"] = "develop"
+        context["TARGET_DEFAULT_BRANCH"] = str(shared.get("default_branch") or "main")
         context["TARGET_LOCAL_PATH"] = str(repo_root)
         context["TARGET_LOCAL_PATH_SOURCE"] = "current_repo"
         return context

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -217,6 +217,8 @@ def parse_list(
         if ":" in item:
             key, value = split_key_value(item, path, line_no)
             if value is None and index < len(lines) and lines[index][0] > indent:
+                # For `- key:` items, the following indented block is the value
+                # of `key`; it must not be merged into the list-item root.
                 child_indent = lines[index][0]
                 child_content = lines[index][1]
                 if child_content.startswith("- "):
@@ -228,7 +230,8 @@ def parse_list(
                 item_map = {key: parse_scalar(value) if value is not None else {}}
             if value is not None and index < len(lines) and lines[index][0] == indent + 2:
                 continuation, index = parse_mapping(lines, index, indent + 2, path)
-                item_map.update(continuation)
+                for continuation_key, continuation_value in continuation.items():
+                    item_map[continuation_key] = continuation_value
             result.append(item_map)
         else:
             result.append(parse_scalar(item))

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -371,8 +371,15 @@ def parse_remote_slug(repo_root: Path) -> str:
         text = git_config.read_text(encoding="utf-8", errors="ignore")
     except OSError:
         return ""
-    match = re.search(r"url = (?:git@github\.com:|https://github\.com/)([^/\s]+/[^/\s]+?)(?:\.git)?\s*$", text, re.M)
-    return match.group(1) if match else ""
+    match = re.search(
+        r"^\s*url = (?:git@github\.com:|https://github\.com/)([^/\s]+/[^/\s]+)\s*$",
+        text,
+        re.M,
+    )
+    if not match:
+        return ""
+    slug = match.group(1)
+    return slug[:-4] if slug.endswith(".git") else slug
 
 
 def resolve_context(args: argparse.Namespace) -> dict[str, str]:

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -258,7 +258,7 @@ def product_repos(shared: dict[str, Any], shared_path: Path) -> list[dict[str, A
     for index, raw in enumerate(repos, start=1):
         if not isinstance(raw, dict):
             raise ConfigError(f"{shared_path}: workflow_hub.product_repos[{index}] must be a mapping")
-        forbidden = sorted(key for key in raw if key in LOCAL_ONLY_KEYS)
+        forbidden = sorted(find_local_only_keys(raw))
         if forbidden:
             raise ConfigError(
                 f"{shared_path}: workflow_hub.product_repos[{index}] contains local-only field(s): {', '.join(forbidden)}"
@@ -281,6 +281,24 @@ def product_repos(shared: dict[str, Any], shared_path: Path) -> list[dict[str, A
         repo["default_branch"] = repo.get("default_branch") or "main"
         normalized.append(repo)
     return normalized
+
+
+def find_local_only_keys(value: Any, prefix: str = "") -> set[str]:
+    if isinstance(value, dict):
+        found: set[str] = set()
+        for key, child in value.items():
+            key_path = f"{prefix}.{key}" if prefix else str(key)
+            if key in LOCAL_ONLY_KEYS:
+                found.add(key_path)
+            found.update(find_local_only_keys(child, key_path))
+        return found
+    if isinstance(value, list):
+        found = set()
+        for index, child in enumerate(value, start=1):
+            item_path = f"{prefix}[{index}]" if prefix else f"[{index}]"
+            found.update(find_local_only_keys(child, item_path))
+        return found
+    return set()
 
 
 def select_product_repo(repos: list[dict[str, Any]], target: str | None, shared_path: Path) -> dict[str, Any]:

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -182,8 +182,17 @@ def parse_list(
             continue
         if ":" in item:
             key, value = split_key_value(item, path, line_no)
-            item_map: dict[str, Any] = {key: parse_scalar(value) if value is not None else {}}
-            if index < len(lines) and lines[index][0] == indent + 2:
+            if value is None and index < len(lines) and lines[index][0] > indent:
+                child_indent = lines[index][0]
+                child_content = lines[index][1]
+                if child_content.startswith("- "):
+                    child, index = parse_list(lines, index, child_indent, path)
+                else:
+                    child, index = parse_mapping(lines, index, child_indent, path)
+                item_map = {key: child}
+            else:
+                item_map = {key: parse_scalar(value) if value is not None else {}}
+            if value is not None and index < len(lines) and lines[index][0] == indent + 2:
                 continuation, index = parse_mapping(lines, index, indent + 2, path)
                 item_map.update(continuation)
             result.append(item_map)
@@ -372,7 +381,7 @@ def parse_remote_slug(repo_root: Path) -> str:
     except OSError:
         return ""
     match = re.search(
-        r"^\s*url = (?:git@github\.com:|https://github\.com/)([^/\s]+/[^/\s]+)\s*$",
+        r"^\s*url = (?:git@github\.com:|https://github\.com/|ssh://git@github\.com/)([^/\s]+/[^/\s]+)\s*$",
         text,
         re.M,
     )
@@ -485,19 +494,34 @@ def resolve_review_overrides(args: argparse.Namespace) -> dict[str, str]:
         legacy_runner = list_from_path(legacy, ["overrides", "review", "internal_reviewers"])
     local_runner = list_from_path(local, ["review", "on_draft", "runner"])
     runner = legacy_runner or local_runner
+    runner_source = (
+        ".tmp/template-config.json"
+        if legacy_runner
+        else (".ai-dev-workflow.local.yaml" if local_runner else "")
+    )
 
     legacy_policy = scalar_from_path(
         legacy, ["overrides", "review", "internal_reviewers_unavailable_policy"]
     )
     local_policy = scalar_from_path(local, ["review", "internal_reviewers_unavailable_policy"])
     policy = legacy_policy or local_policy
+    policy_source = (
+        ".tmp/template-config.json"
+        if legacy_policy
+        else (".ai-dev-workflow.local.yaml" if local_policy else "")
+    )
+
+    sources = []
+    for source in (runner_source, policy_source):
+        if source and source not in sources:
+            sources.append(source)
 
     return {
         "REVIEW_ON_DRAFT_RUNNER": ",".join(runner),
+        "REVIEW_ON_DRAFT_RUNNER_SOURCE": runner_source,
         "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY": policy,
-        "LOCAL_OVERRIDE_SOURCE": ".tmp/template-config.json"
-        if legacy_runner or legacy_policy
-        else (".ai-dev-workflow.local.yaml" if local_runner or local_policy else ""),
+        "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY_SOURCE": policy_source,
+        "LOCAL_OVERRIDE_SOURCE": ",".join(sources),
     }
 
 

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -102,7 +102,7 @@ def parse_scalar(value: str) -> Any:
         inner = value[1:-1].strip()
         if not inner:
             return []
-        return [parse_scalar(item.strip()) for item in inner.split(",") if item.strip()]
+        return [parse_scalar(item.strip()) for item in split_inline_list(inner) if item.strip()]
     if value in {"''", '""'}:
         return ""
     if (value.startswith("'") and value.endswith("'")) or (
@@ -120,6 +120,40 @@ def parse_scalar(value: str) -> Any:
     if value.lower() in {"null", "~"}:
         return None
     return value
+
+
+def split_inline_list(value: str) -> list[str]:
+    items: list[str] = []
+    current: list[str] = []
+    in_single = False
+    in_double = False
+    escaped = False
+
+    for char in value:
+        if escaped:
+            current.append(char)
+            escaped = False
+            continue
+        if char == "\\" and in_double:
+            current.append(char)
+            escaped = True
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+            current.append(char)
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            current.append(char)
+            continue
+        if char == "," and not in_single and not in_double:
+            items.append("".join(current))
+            current = []
+            continue
+        current.append(char)
+
+    items.append("".join(current))
+    return items
 
 
 def parse_mapping(
@@ -512,9 +546,10 @@ def resolve_review_overrides(args: argparse.Namespace) -> dict[str, str]:
     )
 
     sources = []
-    for source in (runner_source, policy_source):
-        if source and source not in sources:
-            sources.append(source)
+    if runner_source:
+        sources.append(f"runner:{runner_source}")
+    if policy_source:
+        sources.append(f"policy:{policy_source}")
 
     return {
         "REVIEW_ON_DRAFT_RUNNER": ",".join(runner),

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -18,6 +18,10 @@ workflow_config_file() {
   printf '%s/.ai-dev-workflow.yaml\n' "$(workflow_repo_root)"
 }
 
+workflow_config_resolver_script() {
+  printf '%s/workflow-config-resolver.py\n' "$(workflow_script_dir)"
+}
+
 workflow_config_exists() {
   [ -f "$(workflow_config_file)" ]
 }
@@ -349,6 +353,46 @@ workflow_config_review_phase_after_clean_platforms() {
   [ -f "$config_file" ] || return 0
 
   workflow_config_review_on_ready_github "$config_file"
+}
+
+workflow_repository_mode() {
+  local repo_root="${1:-$(workflow_repo_root)}"
+
+  python3 "$(workflow_config_resolver_script)" mode --repo-root "$repo_root"
+}
+
+workflow_repository_context() {
+  local target_repo="${1:-}"
+  local repo_root="${2:-$(workflow_repo_root)}"
+  local args=(resolve --repo-root "$repo_root")
+
+  if [ -n "$target_repo" ]; then
+    args+=(--repo "$target_repo")
+  fi
+
+  python3 "$(workflow_config_resolver_script)" "${args[@]}"
+}
+
+workflow_validate_repository_context() {
+  local target_repo="${1:-}"
+  local repo_root="${2:-$(workflow_repo_root)}"
+  local require_local="${3:-}"
+  local args=(validate --repo-root "$repo_root")
+
+  if [ -n "$target_repo" ]; then
+    args+=(--repo "$target_repo")
+  fi
+  if [ "$require_local" = "--require-local" ] || [ "$require_local" = "require-local" ]; then
+    args+=(--require-local)
+  fi
+
+  python3 "$(workflow_config_resolver_script)" "${args[@]}"
+}
+
+workflow_review_override_context() {
+  local repo_root="${1:-$(workflow_repo_root)}"
+
+  python3 "$(workflow_config_resolver_script)" review-overrides --repo-root "$repo_root"
 }
 
 workflow_config_provider() {


### PR DESCRIPTION
## Summary

- Adds a stdlib-only workflow config resolver for shared `.ai-dev-workflow.yaml`, local `.ai-dev-workflow.local.yaml`, and legacy `.tmp/template-config.json` review overrides.
- Adds shell wrappers and a validation command for repository mode, target repository context, local path resolution, and review override compatibility.
- Documents shared/local config boundaries, adds the local example file and gitignore rule, and records the changelog entry.

## Validation

- `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh` (47 passed, 0 failed)
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` (159 passed, 0 failed)
- `bash scripts/development-workflow/tests/test-workflow-lib-github-projects.sh` (85 passed, 0 failed)
- `shellcheck --severity=warning scripts/development-workflow/*.sh scripts/development-workflow/tests/*.sh`
- `python3 -m py_compile scripts/development-workflow/workflow-config-resolver.py`
- `npx markdownlint-cli2 "docs/specs/developments/20260610135749_875-shared-local-workflow-config/*.md" "docs/testing/workflow/875-shared-local-workflow-config.smoke-test.md" "CHANGELOG.md" "docs/workflow/development-workflow/repository-modes.md" "docs/workflow/development-workflow/README.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/875-shared-local-workflow-config.smoke-test.md CHANGELOG.md docs/workflow/development-workflow/repository-modes.md docs/workflow/development-workflow/README.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `bash scripts/development-workflow/validate-workflow-config.sh`

Closes #875