### PR TITLE
docs(plan): add workflow hub product repo command plan

### DIFF
--- a/docs/specs/developments/20260610164114_877-workflow-hub-product-repo-sync-status-scripts/2_877-workflow-hub-product-repo-sync-status-scripts_implementation-plan.md
+++ b/docs/specs/developments/20260610164114_877-workflow-hub-product-repo-sync-status-scripts/2_877-workflow-hub-product-repo-sync-status-scripts_implementation-plan.md
@@ -1,0 +1,281 @@
+# Workflow Hub Product Repository Sync and Status Scripts - Implementation Plan
+
+**Spec**: [1_877-workflow-hub-product-repo-sync-status-scripts_specs.md](1_877-workflow-hub-product-repo-sync-status-scripts_specs.md)
+**Smoke test runbook**: [877-workflow-hub-product-repo-sync-status-scripts.smoke-test.md](../../../testing/workflow/877-workflow-hub-product-repo-sync-status-scripts.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add workflow-hub-only command wrappers for status, sync, and pull
+request visibility that consume the repository-context helpers from #875. Keep
+the commands conservative: status and PR listing are read-only, sync refuses
+dirty checkouts, and any local-path bootstrap path requires an explicit
+confirmation flag before writing `.ai-dev-workflow.local.yaml`.
+
+**Estimated complexity**: M
+
+**Rationale**: The work is script-heavy and safety-sensitive, but it can stay
+bounded by reusing the existing repository-context resolver instead of adding
+new config parsing. The main risk is command behavior around missing paths,
+dirty checkouts, and partial multi-repository results.
+
+**Dependencies**: #875 must be merged into `develop-workflow-hub-mode` before
+implementation starts because this feature depends on
+`workflow-config-resolver.py` and the `workflow-lib.sh` repository-context
+wrappers.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `8b30a37` |
+| Approved spec | `sed -n '1,340p' docs/specs/developments/20260610164114_877-workflow-hub-product-repo-sync-status-scripts/1_877-workflow-hub-product-repo-sync-status-scripts_specs.md` | Spec defines status, sync, optional PR listing, wrong-mode refusal, dirty-checkout refusal, missing-path guidance, explicit bootstrap confirmation, and shell validation coverage. |
+| Dependency implementation | `find scripts/development-workflow -maxdepth 1 -type f \| sort` | #875 has introduced `workflow-config-resolver.py` and `validate-workflow-config.sh`. |
+| Repository-context wrappers | `rg -n "workflow_repository_context\|workflow_repository_mode\|workflow_validate_repository_context" scripts/development-workflow/workflow-lib.sh` | `workflow-lib.sh` exposes shell-callable helpers for mode and repository context resolution. |
+| Resolver behavior tests | `rg -n "checkout_root\|TARGET_LOCAL_PATH\|require-local" scripts/development-workflow/tests/test-workflow-config-resolver.sh` | Existing resolver tests cover local overrides, checkout-root defaults, and require-local missing-path failures. |
+| Existing workflow tests | `find scripts/development-workflow/tests -maxdepth 1 -type f \| sort` | Shell harness convention is `scripts/development-workflow/tests/test-*.sh`. |
+| Existing smoke runbooks | `find docs/testing/workflow -maxdepth 1 -type f \| sort` | Workflow smoke runbooks live in `docs/testing/workflow/`. |
+
+---
+
+## Layer-by-Layer Changes
+
+### Backend / Scripts
+
+- [ ] Add `scripts/development-workflow/hub-status.sh`.
+      - Support `--repo <name>`, `--all`, `--repo-root <path>`, and `--help`.
+      - Require `workflow_hub` mode before inspecting product checkouts.
+      - Use `workflow_repository_context` from `workflow-lib.sh`.
+      - For each selected product repository, report local path, branch, clean
+        or dirty working tree, remote visibility, and one of the spec status
+        codes: `clean`, `dirty`, `missing_path`, `missing_checkout`, or
+        `failed`.
+      - Keep the command read-only.
+- [ ] Add `scripts/development-workflow/hub-sync-product-repos.sh`.
+      - Support `--repo <name>`, `--all`, `--repo-root <path>`, optional
+        `--bootstrap-local-path`, optional `--yes`, and `--help`.
+      - Require `workflow_hub` mode before inspecting or syncing product
+        checkouts.
+      - Refuse to sync a checkout when `git -C <path> status --porcelain`
+        returns any content.
+      - For clean checkouts, fetch the remote and fast-forward the configured
+        default branch only when the local branch is not ahead of origin.
+      - Fail closed on true divergence or local-ahead-only state; report the
+        branch/path and do not push, rebase, reset, stash, or force update.
+      - Return a final summary that separates `synced`, `skipped`, `blocked`,
+        and `failed` repositories.
+- [ ] Add `scripts/development-workflow/hub-list-prs.sh`.
+      - Support `--repo <name>`, `--all`, `--repo-root <path>`, and `--help`.
+      - Resolve each selected repository's GitHub identity from
+        repository-context output.
+      - Prefer `TARGET_GITHUB_REPO` when present. When only `TARGET_GIT_URL`
+        is present, derive a GitHub `owner/repo` slug only for recognized
+        GitHub URL forms such as `git@github.com:owner/repo.git`,
+        `https://github.com/owner/repo.git`, or
+        `ssh://git@github.com/owner/repo.git`.
+      - Fail clearly when no GitHub repository slug can be resolved; do not
+        silently fall back to the workflow hub repository.
+      - Use `gh pr list --repo <owner/repo>` and print PR number, title, head,
+        base, draft state, and readiness labels.
+      - Keep the command read-only and report remote-inspection errors per
+        repository.
+- [ ] Extend the #875 resolver or `workflow-lib.sh` with a shell-callable way
+      to list configured product repository names for `--all`.
+      - Prefer a resolver subcommand such as `list-product-repos` that emits one
+        repository name per line after validating `workflow_hub` mode.
+      - Use the same list helper in all three commands so `--all` cannot drift
+        across status, sync, and PR listing behavior.
+      - Reject `--repo` and `--all` together before calling the resolver.
+- [ ] Add local-path bootstrap support only behind explicit confirmation.
+      - Without `--bootstrap-local-path`, print the exact
+        `.ai-dev-workflow.local.yaml` entry the operator can add.
+      - With `--bootstrap-local-path` but without `--yes`, prompt on stdin and
+        require an affirmative response.
+      - With both flags, append or update only the selected product repository
+        local-path entry in `.ai-dev-workflow.local.yaml`.
+      - Never write token values, private key values, or secret references from
+        this command.
+
+### Tests
+
+- [ ] Add
+      `scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh`.
+- [ ] Build tests with temporary fixture repos created under `mktemp -d` so no
+      developer checkout is mutated.
+- [ ] Cover:
+      - help output for all three commands
+      - wrong-mode failure before checkout inspection
+      - status for one clean product repo
+      - status for `--all` with mixed clean, dirty, missing path, and missing
+        checkout outcomes
+      - sync refusal for a dirty checkout
+      - sync partial success and failure summary for `--all`
+      - missing local path guidance naming `.ai-dev-workflow.local.yaml`
+      - bootstrap declined, confirmed interactively, and confirmed with `--yes`
+      - PR listing dry fixture with `gh` unavailable or remote inspection
+        failure producing a per-repository `failed` result
+      - PR listing for a repository declared only with a GitHub `git_url`
+      - PR listing for a repository whose `git_url` is not a GitHub URL,
+        proving the command fails clearly instead of targeting the hub
+- [ ] Add any new test harness to the same execution path used by existing
+      workflow script tests.
+
+### Documentation
+
+- [ ] Update `scripts/development-workflow/README.md` with command purpose,
+      mode requirement, target-selection options, and safe-failure behavior.
+- [ ] Update `docs/workflow/development-workflow/repository-modes.md` to point
+      workflow hub operators to the new status, sync, and PR visibility
+      commands.
+- [ ] Add the implementation changelog entry under `[Unreleased]` / `### Added`:
+      `- **Workflow hub product repository commands** (#877): adds workflow-hub status, sync, and pull-request visibility commands for product repository checkouts.`
+
+### Infrastructure / Configuration
+
+- [ ] No new versioned secrets or machine-local paths.
+- [ ] No CI secret requirement. Tests must run with local fixture repositories.
+- [ ] No database, frontend, or deployment changes.
+
+---
+
+## Testing Strategy
+
+**Test types**: Shell fixture tests, command help tests, config-mode failure
+tests, smoke runbook validation, shellcheck, and markdown lint.
+
+**Key scenarios to test**:
+
+1. Help output names purpose, required mode, target selection, and safe failure
+   behavior for each command (AC1).
+2. All commands fail clearly outside `workflow_hub` mode before product checkout
+   inspection or mutation (AC2).
+3. `hub-status.sh --repo <name>` reports local path, branch, cleanliness, and
+   remote visibility for one repository (AC3).
+4. `hub-status.sh --all` reports per-repository outcomes plus a final summary
+   (AC4).
+5. `hub-sync-product-repos.sh --repo <name>` refuses a dirty checkout (AC5).
+6. `hub-sync-product-repos.sh --all` reports partial success and blocked
+   repositories without hiding either result (AC6).
+7. Missing local paths report a default or the exact local config entry to add
+   (AC7).
+8. Bootstrap writes only after explicit confirmation (AC8).
+9. `hub-list-prs.sh` is read-only and supports one repository or all
+   repositories (AC9).
+10. Shell validation covers the command matrix above (AC10).
+
+**Smoke test runbook**:
+`docs/testing/workflow/877-workflow-hub-product-repo-sync-status-scripts.smoke-test.md`
+
+**Regression suite**:
+
+- `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`
+- `bash scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh`
+- `bash scripts/development-workflow/tests/test-workflow-lib-github-projects.sh`
+- `shellcheck --severity=warning scripts/development-workflow/*.sh scripts/development-workflow/tests/*.sh`
+- `npx markdownlint-cli2 "docs/specs/developments/20260610164114_877-workflow-hub-product-repo-sync-status-scripts/*.md" "docs/testing/workflow/877-workflow-hub-product-repo-sync-status-scripts.smoke-test.md" "CHANGELOG.md"`
+- `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/877-workflow-hub-product-repo-sync-status-scripts.smoke-test.md CHANGELOG.md`
+- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
+
+### Parser-risk Addendum
+
+- **Edge-case enumeration**:
+  - `--repo` with a missing value.
+  - `--repo` and `--all` passed together.
+  - unknown option.
+  - help requested with invalid or absent workflow configuration.
+  - missing mode and explicit `single_repo`.
+  - explicit `product_repo` mode.
+  - `workflow_hub` with one product repo.
+  - `workflow_hub` with multiple product repos and no selection.
+  - missing local path with and without `--bootstrap-local-path`.
+  - bootstrap confirmation declined, accepted through stdin, and accepted with
+    `--yes`.
+  - local path exists but is not a git checkout.
+  - checkout on default branch and clean.
+  - checkout on non-default branch and clean.
+  - checkout dirty through unstaged, staged, and untracked changes.
+  - remote inspection succeeds, fails due to missing remote, and fails due to
+    `gh` or network error.
+  - PR listing with `TARGET_GITHUB_REPO`.
+  - PR listing with a GitHub-form `TARGET_GIT_URL`.
+  - PR listing with a non-GitHub `TARGET_GIT_URL`.
+  - sync local behind only, local ahead only, true divergence, and remote branch
+    missing.
+  - multi-repository status with mixed outcome categories.
+- **Unit test mapping**: Map each edge case to a named assertion in
+  `scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh`.
+- **Suppression semantics**: ShellCheck suppressions may be used only with a
+  line-level `# shellcheck disable=...` directive and inline rationale, following
+  `docs/best-practices/1-general.md`.
+
+---
+
+## Seed Data
+
+No persistent seed data is required. Tests should create temporary workflow hub
+configs, local config files, and throwaway product repository fixtures under
+`mktemp -d`.
+
+---
+
+## Documentation Updates
+
+- [ ] `scripts/development-workflow/README.md` - add status, sync, and PR
+      listing command usage.
+- [ ] `docs/workflow/development-workflow/repository-modes.md` - add workflow
+      hub operator guidance for inspecting and preparing product repositories.
+- [ ] `CHANGELOG.md` - add the implementation entry listed in the Documentation
+      layer above.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Sync mutates a dirty checkout | Medium | High | Check `git status --porcelain` before fetch or pull and block on any output. |
+| A command acts outside workflow hub mode | Medium | High | Resolve mode first and fail before checkout inspection or mutation. |
+| Partial `--all` results hide blocked repositories | Medium | Medium | Track per-repository outcomes and always print a categorized final summary. |
+| Bootstrap corrupts local config | Low | Medium | Keep bootstrap opt-in, fixture-test append/update behavior, and write only local path fields. |
+| PR listing accidentally targets the hub repo | Medium | Medium | Always pass `--repo <owner/repo>` from resolved product context to `gh pr list`. |
+
+---
+
+## Code Samples
+
+No production code samples are required in this plan. Implementation should
+prefer small shell functions with explicit argument validation and structured
+status output.
+
+---
+
+## Implementation Order
+
+1. Add the command argument parser and workflow-hub mode guard for
+   `hub-status.sh`; verify `--help` works without valid config and wrong mode
+   fails before checkout inspection.
+2. Extend the repository-context layer with a shell-callable product repository
+   list helper for `--all`, then implement product repository selection for one
+   repository and all repositories using #875 helpers. Verify missing,
+   ambiguous, and mutually exclusive selection states produce clear errors.
+3. Implement read-only status inspection and categorized summary output.
+4. Add `hub-sync-product-repos.sh` with the same selection contract and dirty
+   checkout guard; verify dirty checkouts are blocked before any sync command.
+5. Implement conservative clean-checkout sync: fetch, detect ahead/behind, fast
+   forward only when safe, and fail closed on divergence or local-ahead state.
+6. Add missing-path guidance and explicit local-path bootstrap behavior.
+7. Add `hub-list-prs.sh` as a read-only visibility command that uses resolved
+   product repository identity with `gh pr list --repo`, including GitHub
+   `git_url` slug derivation and clear failure when no GitHub slug is
+   available.
+8. Add
+   `scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh`
+   with fixture coverage for all acceptance criteria and parser-risk edge
+   cases.
+9. Update project docs per **Documentation Updates**.
+10. Add the CHANGELOG entry:
+    `- **Workflow hub product repository commands** (#877): adds workflow-hub status, sync, and pull-request visibility commands for product repository checkouts.`
+11. Run the regression suite from **Testing Strategy** and fix any failures.

--- a/docs/testing/workflow/877-workflow-hub-product-repo-sync-status-scripts.smoke-test.md
+++ b/docs/testing/workflow/877-workflow-hub-product-repo-sync-status-scripts.smoke-test.md
@@ -1,0 +1,214 @@
+# Smoke Test Runbook: Workflow Hub Product Repository Commands
+
+**Feature**: Workflow hub product repository sync and status scripts
+**Spec**: [1_877-workflow-hub-product-repo-sync-status-scripts_specs.md](../../specs/developments/20260610164114_877-workflow-hub-product-repo-sync-status-scripts/1_877-workflow-hub-product-repo-sync-status-scripts_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] You are reviewing the implementation PR for #877.
+- [ ] #875 is already merged into `develop-workflow-hub-mode`.
+- [ ] The PR targets `develop-workflow-hub-mode`.
+- [ ] The implementation diff is available locally.
+
+---
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| Status command | `scripts/development-workflow/hub-status.sh` |
+| Sync command | `scripts/development-workflow/hub-sync-product-repos.sh` |
+| PR listing command | `scripts/development-workflow/hub-list-prs.sh` |
+| Repository-context resolver | `scripts/development-workflow/workflow-config-resolver.py` |
+| Workflow library | `scripts/development-workflow/workflow-lib.sh` |
+| Command tests | `scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh` |
+| Local config | `.ai-dev-workflow.local.yaml` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Confirm Command Surfaces
+
+**Maps to**: AC1
+
+1. Run each command with `--help`.
+2. Confirm help output explains purpose, required `workflow_hub` mode, target
+   selection, and safe-failure behavior.
+3. Confirm help output works even from a fixture without valid workflow hub
+   configuration.
+
+**Expected result**: Help output is available and complete for all commands.
+
+### Step 2: Verify Wrong-Mode Failure
+
+**Maps to**: AC2
+
+1. Run each command from a missing-mode or explicit `single_repo` fixture.
+2. Confirm each command fails before inspecting or mutating any product checkout.
+3. Confirm the failure says `workflow_hub` mode is required.
+
+**Expected result**: Commands do not act outside workflow hub mode.
+
+### Step 3: Inspect One Product Repository
+
+**Maps to**: AC3
+
+1. Create or use a fixture workflow hub with one clean product repository.
+2. Run:
+
+   ```bash
+   scripts/development-workflow/hub-status.sh --repo <name> --repo-root <fixture>
+   ```
+
+3. Confirm output includes local path, current branch, clean state, and remote
+   inspection status.
+
+**Expected result**: One-repository status output is readable and complete.
+
+### Step 4: Inspect All Product Repositories
+
+**Maps to**: AC4
+
+1. Use a fixture with at least one clean checkout, one dirty checkout, one
+   missing path, and one missing checkout.
+2. Run:
+
+   ```bash
+   scripts/development-workflow/hub-status.sh --all --repo-root <fixture>
+   ```
+
+3. Confirm output reports each repository separately and ends with a final
+   categorized summary.
+
+**Expected result**: Multi-repository status does not hide mixed outcomes.
+
+### Step 5: Verify Dirty-Checkout Refusal
+
+**Maps to**: AC5
+
+1. Add staged, unstaged, or untracked changes to a fixture product checkout.
+2. Run sync for that repository.
+3. Confirm the command refuses to overwrite the checkout and names the path.
+
+**Expected result**: Dirty product checkouts remain untouched.
+
+### Step 6: Verify Multi-Repository Sync Summary
+
+**Maps to**: AC6
+
+1. Use a fixture with one safe clean checkout and one blocked dirty checkout.
+2. Run sync with `--all`.
+3. Confirm the final summary separates synced repositories from blocked or
+   failed repositories.
+
+**Expected result**: Partial success and partial failure are both visible.
+
+### Step 7: Verify Missing-Path Guidance
+
+**Maps to**: AC7
+
+1. Use a workflow hub fixture whose selected product repository has no local
+   checkout path and no derivable default.
+2. Run status or sync for that repository.
+3. Confirm the output names `.ai-dev-workflow.local.yaml` and the exact entry
+   the operator should add.
+
+**Expected result**: Missing-path output gives an actionable local config fix.
+
+### Step 8: Verify Bootstrap Confirmation
+
+**Maps to**: AC8
+
+1. Run the bootstrap path without confirmation and decline the prompt.
+2. Confirm local config remains unchanged.
+3. Run the bootstrap path with explicit confirmation.
+4. Confirm only the selected repository local path entry is written.
+5. Confirm no token, private key, or secret value is written.
+
+**Expected result**: Local config writes require explicit confirmation and stay
+limited to local path data.
+
+### Step 9: Verify Pull-Request Listing
+
+**Maps to**: AC9
+
+1. Run PR listing for one fixture product repository.
+2. Run PR listing with `--all`.
+3. Confirm the command is read-only and reports PR number, title, branch, base,
+   draft state, and readiness labels when remote inspection succeeds.
+4. Confirm a repository declared with only a GitHub-form `git_url` is converted
+   to the intended `owner/repo` slug.
+5. Confirm a repository with a non-GitHub `git_url` fails clearly instead of
+   targeting the workflow hub.
+6. Confirm remote-inspection errors are reported per repository.
+
+**Expected result**: PR visibility targets product repositories, not the hub.
+
+### Step 10: Run Automated Validation
+
+**Maps to**: AC10
+
+1. Run:
+
+   ```bash
+   bash scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
+   bash scripts/development-workflow/tests/test-workflow-config-resolver.sh
+   ```
+
+2. Run shell and markdown validation from the implementation plan.
+
+**Expected result**: The command test harness passes and covers the required
+success and failure paths.
+
+---
+
+## Assertions Checklist
+
+- [ ] AC1: Command help explains purpose, required mode, target selection, and
+      safe-failure behavior.
+- [ ] AC2: Commands fail clearly outside `workflow_hub` mode before checkout
+      inspection or mutation.
+- [ ] AC3: One-repository status reports path, branch, cleanliness, and remote
+      inspection availability.
+- [ ] AC4: All-repository status reports per-repository outcomes and a final
+      summary.
+- [ ] AC5: One-repository sync refuses dirty checkouts.
+- [ ] AC6: All-repository sync reports partial success and partial failure.
+- [ ] AC7: Missing paths report the default or exact local config entry.
+- [ ] AC8: Bootstrap writes require explicit confirmation.
+- [ ] AC9: PR listing is read-only and supports one repository or all
+      repositories.
+- [ ] AC10: Shell validation covers help, wrong mode, clean status, dirty
+      refusal, missing path guidance, and multi-repository summaries.
+
+---
+
+## Seed Data Reference
+
+No persistent seed data is required. The automated command test should create
+temporary workflow hub and product repository fixtures.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Commands inspect the hub instead of the product repo | Missing `--repo <owner/repo>` or missing `git -C <path>` use | Route every product command through resolved repository context. |
+| Sync changes a dirty checkout | Dirty check happened after mutation or used the wrong path | Run `git -C <path> status --porcelain` before fetch or pull. |
+| Missing-path output is generic | Resolver errors are not converted into operator guidance | Include `.ai-dev-workflow.local.yaml` and the product repo name in the message. |
+| `--all` hides a blocked repo | Summary only reports final exit status | Accumulate and print per-repository outcome categories. |
+
+---
+
+## Known Limitations
+
+- The default smoke path does not open, merge, or mutate product repository pull
+  requests. It validates visibility and command routing only.


### PR DESCRIPTION
## Summary

Adds the implementation plan and smoke test runbook for #877, covering workflow-hub product repository status, sync, and pull-request visibility commands.

## Plan

- Plan: docs/specs/developments/20260610164114_877-workflow-hub-product-repo-sync-status-scripts/2_877-workflow-hub-product-repo-sync-status-scripts_implementation-plan.md
- Smoke test: docs/testing/workflow/877-workflow-hub-product-repo-sync-status-scripts.smoke-test.md

## Document Quality Gate

- Spec/brief coverage: Checked - all ACs map to implementation steps and smoke coverage.
- Implementation-order consistency: Checked - command names, file paths, and status names are consistent across plan sections.
- Verification support: Checked - broad scope claims cite the plan Verification Log.
- Behavioral guarantees: Checked - wrong-mode refusal, dirty-checkout refusal, explicit bootstrap confirmation, and read-only PR listing name their enforcing mechanisms.
- Parser/API/concurrency checklist: Checked - parser-risk applies because shell command parsing and structured status classification are introduced; edge cases and unit-test mapping are included. API and concurrency checks are not applicable because no API surface or concurrent event source is planned.
- CHANGELOG literal format: Checked - implementation changelog entry uses the project bold-title format.
- Not-applicable rationale: Checked - database, frontend, and CI-secret changes are explicitly not applicable.

## Validation

- `npx markdownlint-cli2 "docs/specs/developments/20260610164114_877-workflow-hub-product-repo-sync-status-scripts/*.md" "docs/testing/workflow/877-workflow-hub-product-repo-sync-status-scripts.smoke-test.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/877-workflow-hub-product-repo-sync-status-scripts.smoke-test.md`
- `git diff --check`

Closes #877
