### PR TITLE
docs(plan): add cross-repo pr auth plan

### DIFF
--- a/docs/specs/developments/20260610165914_880-cross-repo-pr-auth-support/2_880-cross-repo-pr-auth-support_implementation-plan.md
+++ b/docs/specs/developments/20260610165914_880-cross-repo-pr-auth-support/2_880-cross-repo-pr-auth-support_implementation-plan.md
@@ -1,0 +1,279 @@
+# Cross-Repository Pull Request Authentication and Operation Support - Implementation Plan
+
+**Spec**: [1_880-cross-repo-pr-auth-support_specs.md](1_880-cross-repo-pr-auth-support_specs.md)
+**Smoke test runbook**: [880-cross-repo-pr-auth-support.smoke-test.md](../../../testing/workflow/880-cross-repo-pr-auth-support.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add a small workflow-hub authentication layer for selected product
+repositories, then route product pull-request creation through a helper that
+uses the selected product repository slug and an explicit non-logging token
+path. Keep shared repository configuration secret-free, keep local secret
+references in `.ai-dev-workflow.local.yaml`, and use dry-run fixture coverage to
+prove command construction without real credentials.
+
+**Estimated complexity**: M
+
+**Rationale**: The change is security-sensitive but intentionally narrow. It
+adds command contracts around token acquisition and PR creation without changing
+tracker ownership, reviewer behavior, or product code. The highest risks are
+secret disclosure in stdout/stderr, accidentally opening PRs in the workflow hub,
+and silently falling back to a human `gh` token when product-repo GitHub App auth
+is incomplete.
+
+**Dependencies**: #875 must be merged into `develop-workflow-hub-mode` because
+this work depends on shared/local workflow config resolution. #878 should be
+available before implementation PR routing is wired into orchestrator-owned
+flows; this feature can still land as standalone helpers and docs first.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `8b30a37` |
+| Approved spec | `sed -n '1,360p' docs/specs/developments/20260610165914_880-cross-repo-pr-auth-support/1_880-cross-repo-pr-auth-support_specs.md` | Spec requires GitHub App setup docs, local-only secret refs, token helper behavior, product-repo PR targeting, dry-run validation, and clear auth failures. |
+| Local config example | `sed -n '1,220p' .ai-dev-workflow.local.example.yaml` | Placeholder-only local config already includes product repo entries with `private_key_path` and `secret_ref`. |
+| Local ignore rule | `sed -n '1,80p' .gitignore` | `.ai-dev-workflow.local.yaml` is already gitignored; no token cache exists today. |
+| Repository mode docs | `sed -n '1,260p' docs/workflow/development-workflow/repository-modes.md` | Shared config is versioned and local config is gitignored; product repository identity is selected by name. |
+| Config resolver | `rg -n "private_key_path|secret_ref|TARGET_GITHUB_REPO|TARGET_GIT_URL|workflow_hub" scripts/development-workflow/workflow-config-resolver.py scripts/development-workflow/tests/test-workflow-config-resolver.sh` | Resolver rejects local-only keys in shared product repo config and returns product repo context for selected hub targets. |
+| Existing GitHub tracker docs | `sed -n '1,180p' docs/workflow/development-workflow/integrations/github-projects.md` | Tracker docs are separate from product-repo PR auth and should remain hub-owned. |
+
+---
+
+## Layer-by-Layer Changes
+
+### Backend / Scripts
+
+- [ ] Extend `workflow-config-resolver.py` to expose auth metadata for a
+      selected product repository.
+      - Add an auth-focused subcommand or output mode that resolves only field
+        presence and local references, not secret values.
+      - Support non-secret `github_app.app_id` and
+        `github_app.installation_id` under shared
+        `workflow_hub.product_repos[]`, with local overrides allowed when an
+        operator needs machine-specific values.
+      - Support local-only `product_repos[].github_app.private_key_path` and
+        `product_repos[].github_app.secret_ref` in
+        `.ai-dev-workflow.local.yaml`.
+      - Preserve the existing `private_key_path` and `secret_ref` aliases in
+        the local example for compatibility, but document the nested
+        `github_app` form as preferred for new setup.
+      - Keep `LOCAL_ONLY_KEYS` enforcement for shared
+        `.ai-dev-workflow.yaml`; add coverage proving secret-bearing auth keys
+        cannot be committed under `workflow_hub.product_repos[]`.
+      - Do not print private key paths in normal command output unless the user
+        explicitly requests local config validation details.
+- [ ] Add `scripts/development-workflow/github-app-token.sh`.
+      - Accept `--repo <product-name>`, `--repo-root <path>`, `--dry-run`,
+        `--status`, and a machine-readable token mode such as `--print-token`.
+      - Resolve the selected product repo through the shared/local workflow
+        config helpers.
+      - Validate required local auth fields before attempting any GitHub call.
+      - Generate a GitHub App JWT from the local private key source, exchange it
+        for an installation token, and write the token only to stdout in
+        explicit machine mode.
+      - Send all human logs to stderr and redact token-like and key-like
+        material.
+      - Fail with distinct messages for missing app id, missing private key or
+        secret reference, missing installation access, and permission denied
+        where GitHub returns enough detail.
+      - Do not fall back to ambient `gh auth token` when the selected GitHub App
+        auth source is incomplete.
+- [ ] Add `scripts/development-workflow/open-product-pr.sh`.
+      - Accept `--repo <product-name>`, `--repo-root <path>`, `--base <branch>`,
+        `--head <branch>`, `--title <title>`, `--body-file <path>`, and
+        `--dry-run`.
+      - Resolve `TARGET_GITHUB_REPO` from `github_repo`, or derive it from
+        recognized GitHub `git_url` forms; fail clearly for non-GitHub URLs.
+      - In dry-run mode, print target repository, base, head, title, and the
+        redacted `gh pr create --repo <owner/repo>` command shape without
+        requiring credentials.
+      - In live mode, call the token helper, pass the token to `gh` through
+        `GH_TOKEN` for that invocation, and never echo the token.
+      - Fail before PR creation when product repo selection is missing,
+        ambiguous, non-GitHub, or missing local auth configuration.
+      - Return a success URL and stable key/value output on successful PR
+        creation.
+- [ ] Decide explicitly whether a token cache is needed.
+      - Default MVP: no persistent token cache.
+      - If implementation adds caching, use a local path such as
+        `.ai-dev-workflow.auth-cache/`, add it to `.gitignore`, document its
+        lifecycle, and test that it is not emitted in shared config examples.
+- [ ] Keep tracker and single-repository behavior unchanged.
+      - Do not route GitHub Projects reads or updates through the product repo
+        token helper.
+      - Keep `single_repo` mode on existing `gh` auth behavior.
+      - Require explicit workflow-hub product selection for product PR
+        operations when multiple product repos exist.
+
+### Tests
+
+- [ ] Add
+      `scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh`.
+- [ ] Use temporary fixture directories and stubbed `gh`, token exchange, and
+      private-key reader commands. Tests must not need live GitHub credentials.
+- [ ] Cover:
+      - shared `.ai-dev-workflow.yaml` rejects local-only secret-bearing auth
+        fields
+      - shared `.ai-dev-workflow.yaml` may contain non-secret app id and
+        installation id values
+      - local `.ai-dev-workflow.local.yaml` accepts placeholder auth refs
+      - missing app id reports `missing_app_id`
+      - missing private key path or secret ref reports `missing_private_key`
+      - missing installation reports `missing_installation`
+      - permission failure reports `permission_denied`
+      - token helper normal logs do not contain token-like output
+      - token helper explicit machine mode prints only the token on stdout
+      - product PR dry-run works before real credentials are configured
+      - product PR dry-run produces distinct `--repo` values for two product
+        repositories
+      - live PR helper passes `GH_TOKEN` only to the child `gh pr create`
+        command
+      - non-GitHub `git_url` fails clearly before auth
+      - ambiguous workflow-hub product selection fails before auth or PR
+        creation
+      - `single_repo` mode behavior is unchanged
+- [ ] Add a redaction assertion that scans captured stdout/stderr for fixture
+      tokens, private key text, and secret-ref placeholder values.
+
+### Documentation
+
+- [ ] Add
+      `docs/workflow/development-workflow/integrations/workflow-hub-github-app.md`.
+      - List required GitHub App permissions for product PR creation:
+        repository contents read/write as needed for branches, pull requests
+        read/write, metadata read, and checks/status read if the helper later
+        validates readiness.
+      - Document product repository installation steps and where to find app id
+        and installation id.
+      - Document local-only config fields and safe placeholder examples.
+      - Explain that secret manager references are supported as references, not
+        secret values, and that the workflow does not require one specific
+        secret manager.
+      - Explain that no token values, private key contents, or machine-local
+        secret locations belong in `.ai-dev-workflow.yaml`.
+      - Include dry-run examples for two product repositories.
+- [ ] Update
+      `docs/workflow/development-workflow/repository-modes.md`.
+      - Add a short cross-reference from local workflow configuration to the
+        GitHub App auth integration doc.
+      - Clarify that product PR helpers target the selected product repository,
+        not the hub remote.
+- [ ] Update `.ai-dev-workflow.local.example.yaml`.
+      - Keep placeholder-only values.
+      - Prefer nested `github_app` fields while retaining a compatibility note
+        for top-level `private_key_path` / `secret_ref`.
+- [ ] Update `docs/workflow/development-workflow/README.md` if the helper
+      command becomes part of the normal workflow-hub implementation path.
+- [ ] Add the implementation changelog entry under `[Unreleased]` / `### Added`:
+      `- **Workflow hub product repository PR authentication** (#880): adds local-only GitHub App auth guidance and helpers for opening product repository pull requests without exposing secrets.`
+
+### Database / Frontend / Infrastructure
+
+- [ ] None. This feature changes local workflow scripts, fixture tests, docs,
+      and examples only. CI must not require live GitHub App secrets.
+
+---
+
+## Testing Strategy
+
+**Test types**: Shell fixture tests, resolver regression tests, command-contract
+tests, redaction tests, dry-run tests, markdown lint, and shellcheck.
+
+**Key scenarios to test**:
+
+1. Shared config rejects private key paths, secret refs, token values, and local
+   auth cache paths (AC2, AC3, AC4).
+2. Shared config can hold non-secret app ids and installation ids, while local
+   config accepts private key paths and secret refs without printing secret
+   values (AC2, AC3).
+3. Token helper reports missing app id, missing private key or secret ref,
+   missing installation, and permission denied as distinct actionable failures
+   (AC8).
+4. Token helper never prints token values in normal logs or failure output
+   (AC5, AC10).
+5. Explicit machine token mode has a narrow stdout contract and keeps human logs
+   on stderr (AC5, AC10).
+6. PR helper dry-run works without credentials and reports target repository,
+   base branch, head branch, title, and redacted command shape (AC6, AC7, AC9).
+7. Two product-repo fixtures produce two different `gh pr create --repo`
+   targets (AC6, AC7).
+8. Live PR helper uses the selected product token only for the child `gh`
+   invocation and does not expose it in parent logs (AC10).
+9. Missing or ambiguous product repository selection fails before auth or PR
+   creation (AC6, AC8).
+10. `single_repo` mode remains compatible with existing behavior (AC9).
+
+**Smoke test runbook**:
+`docs/testing/workflow/880-cross-repo-pr-auth-support.smoke-test.md`
+
+**Regression suite**:
+
+- `bash scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh`
+- `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`
+- `python3 -m py_compile scripts/development-workflow/workflow-config-resolver.py`
+- `shellcheck --severity=warning scripts/development-workflow/*.sh scripts/development-workflow/tests/*.sh`
+- `npx markdownlint-cli2 "docs/specs/developments/20260610165914_880-cross-repo-pr-auth-support/*.md" "docs/testing/workflow/880-cross-repo-pr-auth-support.smoke-test.md" "CHANGELOG.md"`
+- `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/880-cross-repo-pr-auth-support.smoke-test.md CHANGELOG.md`
+- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
+
+### Parser-risk Addendum
+
+- **Edge-case enumeration**:
+  - no mode declaration
+  - explicit `single_repo`
+  - `workflow_hub` with one product repo
+  - `workflow_hub` with two product repos and no selection
+  - unknown product repo selection
+  - product repo with `github_repo`
+  - product repo with GitHub HTTPS `git_url`
+  - product repo with GitHub SSH `git_url`
+  - product repo with non-GitHub `git_url`
+  - local secret-bearing auth fields missing entirely
+  - missing app id
+  - missing installation id
+  - private key path configured but unreadable
+  - secret ref configured but resolver command unavailable
+  - both private key path and secret ref configured
+  - token exchange returns not found
+  - token exchange returns permission denied
+  - token exchange returns malformed JSON
+  - `gh pr create` fails after token acquisition
+  - `--dry-run` with no credentials
+  - `--body-file` missing
+  - title, base, or head containing shell-sensitive characters
+  - fixture token present in child environment but absent from logs
+  - future auth cache path configured
+- **Unit test mapping**: Add one named assertion for each edge case in
+  `scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh`.
+- **Suppression semantics**: No new suppression directive format is introduced.
+  Any ShellCheck suppression must follow the existing line-level directive with
+  inline rationale required by `docs/best-practices/1-general.md`.
+
+---
+
+## Seed Data
+
+No persistent seed data is required. Tests should create temporary workflow hub
+fixtures with two product repositories, local config placeholders, stubbed token
+exchange responses, and a stubbed `gh` executable that records command
+arguments and environment without contacting GitHub.
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/workflow/development-workflow/integrations/workflow-hub-github-app.md`
+      - new GitHub App setup and local auth guidance.
+- [ ] `docs/workflow/development-workflow/repository-modes.md` - link local
+      auth setup to product repository PR ownership.
+- [ ] `.ai-dev-workflow.local.example.yaml` - placeholder-only local GitHub App
+      auth fields.
+- [ ] `docs/workflow/development-workflow/README.md` - only if the PR helper is
+      part of the operator-facing workflow command list.
+- [ ] `CHANGELOG.md` - add the implementation entry listed in the Documentation
+      layer above.

--- a/docs/testing/workflow/880-cross-repo-pr-auth-support.smoke-test.md
+++ b/docs/testing/workflow/880-cross-repo-pr-auth-support.smoke-test.md
@@ -1,0 +1,189 @@
+# Smoke Test Runbook: Cross-Repository Pull Request Authentication and Operation Support
+
+**Feature**: Cross-repository pull request authentication and operation support
+**Spec**: [1_880-cross-repo-pr-auth-support_specs.md](../../specs/developments/20260610165914_880-cross-repo-pr-auth-support/1_880-cross-repo-pr-auth-support_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] You are reviewing the implementation PR for #880.
+- [ ] #875 is merged into `develop-workflow-hub-mode`.
+- [ ] The PR targets `develop-workflow-hub-mode`.
+- [ ] The implementation diff is available locally.
+- [ ] No live GitHub App credentials are required for the automated fixture
+      tests.
+
+---
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| Token helper | `scripts/development-workflow/github-app-token.sh` |
+| Product PR helper | `scripts/development-workflow/open-product-pr.sh` |
+| Config resolver | `scripts/development-workflow/workflow-config-resolver.py` |
+| Local config example | `.ai-dev-workflow.local.example.yaml` |
+| GitHub App docs | `docs/workflow/development-workflow/integrations/workflow-hub-github-app.md` |
+| Auth fixture tests | `scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify Setup Documentation
+
+**Maps to**: AC1, AC2, AC3, AC4
+
+1. Open the GitHub App integration doc.
+2. Confirm it lists required product repository permissions and installation
+   steps.
+3. Confirm it distinguishes committed shared config from local-only config.
+4. Confirm the local example uses placeholders only.
+5. If a token cache was introduced, confirm its path is listed in `.gitignore`.
+
+**Expected result**: Operators can configure product repository access without
+putting private key paths, secret-manager locations, tokens, or cache paths in
+versioned shared config.
+
+### Step 2: Verify Local Config Validation
+
+**Maps to**: AC2, AC3, AC8
+
+1. Run the auth fixture test harness.
+2. Inspect the cases where shared config contains local-only secret-bearing
+   auth fields.
+3. Inspect the cases where shared config contains non-secret app id and
+   installation id values.
+4. Inspect the cases where local config contains placeholder auth refs.
+5. Confirm shared config fails closed only for secret-bearing fields and local
+   config is accepted.
+
+**Expected result**: Auth references are local-only and versioned config remains
+secret-free.
+
+### Step 3: Verify Token Helper Redaction
+
+**Maps to**: AC5, AC8, AC10
+
+1. Run token helper fixture cases for missing app id, missing private key or
+   secret ref, missing installation, and permission denied.
+2. Confirm each failure reports the selected product repository and the missing
+   setup step.
+3. Confirm captured stdout/stderr do not contain fixture tokens, private key
+   text, or secret-ref values.
+4. Run explicit machine token mode with a fixture token.
+5. Confirm stdout contains only the token and human logs are on stderr.
+
+**Expected result**: Normal logs and failure output never disclose token or key
+material, while machine mode has a narrow token-output contract.
+
+### Step 4: Verify Product PR Dry Run
+
+**Maps to**: AC6, AC7, AC9
+
+1. Use a workflow hub fixture with two product repositories.
+2. Run the product PR helper in dry-run mode for `mobile-app`.
+3. Run the same helper in dry-run mode for `admin-portal`.
+4. Confirm the output shows distinct target repositories, base branches, head
+   branches, titles, and redacted command shapes.
+5. Confirm dry-run mode does not require credentials.
+
+**Expected result**: Dry-run output proves PR command construction for two
+product repositories without exposing secrets.
+
+### Step 5: Verify Product PR Live Command Contract
+
+**Maps to**: AC6, AC10
+
+1. Run the live-mode fixture with a stubbed token helper and stubbed `gh`.
+2. Confirm `gh pr create` receives `--repo <owner/repo>` for the selected
+   product repository.
+3. Confirm `GH_TOKEN` is set only for the child command.
+4. Confirm the token value is absent from captured logs and summary output.
+
+**Expected result**: Live PR creation targets the product repository and passes
+credentials through a non-logging environment path.
+
+### Step 6: Verify Failure Boundaries
+
+**Maps to**: AC6, AC8, AC9
+
+1. Run fixture cases for no product repo selection in a multi-product hub.
+2. Run fixture cases for an unknown product repo name.
+3. Run fixture cases for a non-GitHub product repo `git_url`.
+4. Run fixture cases for missing title, base, head, or body file values.
+5. Confirm every case fails before auth or PR creation.
+
+**Expected result**: The helpers fail closed before unsafe fallback or hub-repo
+PR creation.
+
+### Step 7: Run Automated Validation
+
+**Maps to**: AC1 through AC10
+
+1. Run:
+
+   ```bash
+   bash scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh
+   bash scripts/development-workflow/tests/test-workflow-config-resolver.sh
+   ```
+
+2. Run shell, Python, markdown, and changelog validation from the implementation
+   plan.
+
+**Expected result**: Auth, dry-run, command routing, redaction, and config
+regression checks pass.
+
+---
+
+## Assertions Checklist
+
+- [ ] AC1: Setup docs list GitHub App permissions and product repo installation
+      steps.
+- [ ] AC2: Versioned config excludes private key paths, machine-local secret
+      locations, token values, and cache paths.
+- [ ] AC3: Secret refs and private key paths are documented as local-only.
+- [ ] AC4: Any introduced auth cache path is gitignored.
+- [ ] AC5: Token helper logs do not print token values.
+- [ ] AC6: Product PR helper targets the selected product repository.
+- [ ] AC7: Dry-run or fixture validation covers two product repositories.
+- [ ] AC8: Missing app id, private key or secret ref, installation access, and
+      permission failures are actionable.
+- [ ] AC9: Help and dry-run output work before real credentials are available.
+- [ ] AC10: Scripts use the selected product token and repo context without
+      exposing secrets.
+
+---
+
+## Seed Data Reference
+
+No persistent seed data is required. Automated tests should create temporary
+workflow hub fixtures, two product repo definitions, placeholder local auth
+refs, stub token responses, and a stubbed `gh` command.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Dry-run targets the hub repository | Product repo slug resolution fell back to the current remote | Resolve `TARGET_GITHUB_REPO` or GitHub-form `TARGET_GIT_URL` before constructing `gh pr create`. |
+| Token appears in logs | Helper mixed machine output with human logs | Keep token stdout behind explicit machine mode and send redacted status logs to stderr. |
+| Shared config accepts `private_key_path` | Local-only key validation missed nested auth keys | Extend resolver validation and tests for nested `github_app` fields. |
+| Missing auth uses a human `gh` token | Helper fell back to ambient auth | Fail closed when selected product repo GitHub App config is incomplete. |
+| Non-GitHub target reaches auth | PR helper did not validate repo slug first | Fail before token helper invocation for unsupported `git_url` values. |
+
+---
+
+## Known Limitations
+
+- The smoke test uses fixtures and command stubs. It does not prove live GitHub
+  App installation permissions in a real product repository.
+- The MVP should avoid persistent token caching. If implementation introduces a
+  cache, reviewers must verify the additional cache-specific checks in this
+  runbook.


### PR DESCRIPTION
## Summary

- Adds the implementation plan for #880 cross-repository product PR authentication.
- Adds the smoke-test runbook for GitHub App auth, product PR dry-run routing, redaction, and failure boundaries.

## Document Quality Gate

- Spec coverage: checked against `1_880-cross-repo-pr-auth-support_specs.md`; all AC1-AC10 are mapped through plan tasks, tests, and the smoke-test checklist.
- Implementation specificity: script names, config fields, command contracts, redaction rules, and failure cases are explicitly enumerated.
- Parser-risk coverage: included concrete edge-case enumeration and mapped the automated fixture file `scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh`.
- Documentation coverage: lists GitHub App setup docs, repository-mode docs, local example, README if needed, and CHANGELOG update for the future implementation PR.
- Validation run: markdownlint, heuristic lint, and whitespace checks passed locally.

## Validation

- `npx markdownlint-cli2 "docs/specs/developments/20260610165914_880-cross-repo-pr-auth-support/*.md" "docs/testing/workflow/880-cross-repo-pr-auth-support.smoke-test.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/880-cross-repo-pr-auth-support.smoke-test.md`
- `git diff --check`

Closes #880
