### PR TITLE
feat(workflow): route orchestration to product repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Workflow hub orchestration repository awareness** (#878): routes implementation branch, pull request, reviewer, CI, and cleanup operations to the selected product repository while keeping tracker/spec/plan state in the hub.
 - **Two-phase review config** (#868): replaces overlapping reviewer config keys with explicit draft and ready lifecycle buckets while preserving legacy aliases for one transition release.
 - **Codex review routing default**: makes `codex` the default Step 7a internal reviewer and replaces the Claude Code Action after-clean reviewer with `codex-github`.
 

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -240,6 +240,14 @@ product repository selection rule, and PR ownership model. When no mode is
 declared, repositories are interpreted as `single_repo` and keep the current
 single-repository behavior.
 
+In `workflow_hub` mode, orchestration scripts keep tracker, spec, and plan state
+in the hub while routing implementation branch/PR inspection, reviewer loops, CI
+loops, and implementation cleanup to the selected product repository. Use
+`--repo <name>` with hub-mode discovery, next-action, batch-planning, and cleanup
+commands when a product implementation action is involved. Reviewer and CI loops
+also accept `--repo <owner/repo>` or `--product-repo <name>` for implementation
+PRs outside the hub.
+
 Role-specific skeletons are inspectable under the template root:
 
 - `template/workflow-hub/` lists hub-owned protocols, scripts, agents,
@@ -435,6 +443,10 @@ template:
 Important implementation notes:
 
 - Repository mode fields are `mode`, `workflow_hub.product_repos[]`, and `product_repo.workflow_hub`. Shared product repository entries may contain stable non-secret identity and metadata such as `name`, `github_repo` or `git_url`, `default_branch`, `role`, `scope`, `tracker` hints, and non-secret app identifiers. Local checkout paths, private key paths, secret values, and machine-specific tool settings belong only in `.ai-dev-workflow.local.yaml`. See [`repository-modes.md`](repository-modes.md) for examples and validation commands.
+- Product-repository-aware orchestration scripts emit ownership fields such as
+  `WORKFLOW_MODE`, `ACTION_REPOSITORY_KIND`, `ACTION_REPOSITORY`, and
+  `ACTION_GITHUB_REPO` so orchestrators can distinguish hub-owned planning work
+  from product-owned implementation work.
 - `sync-manifest.yaml` includes informational `mode_scope` metadata:
   `shared`, `hub_only`, and `product_repo_injection`. Current sync-template
   readers still use the existing manifest categories; mode-aware sync

--- a/docs/workflow/development-workflow/repository-modes.md
+++ b/docs/workflow/development-workflow/repository-modes.md
@@ -61,6 +61,28 @@ protocols, hub docs, or hub-owned orchestration scripts opens its code PR in the
 hub. A product implementation opens its code PR in the target product
 repository.
 
+## Orchestration Ownership
+
+Workflow orchestration scripts keep planning and tracker state in the hub while
+allowing implementation actions to target a selected product repository.
+
+- `discover-workflow-state.sh`, `workflow-next-action.sh`, and
+  `workflow-batch-plan.sh` accept `--repo <name>` and report
+  `WORKFLOW_MODE`, `ACTION_REPOSITORY_KIND`, and the selected repository
+  identity for each implementation action.
+- `pr-review-loop.sh` and `pr-ci-loop.sh` can target implementation PRs outside
+  the hub by accepting `--repo <owner/repo>` or `--product-repo <name>`.
+- `post-merge-cleanup.sh --repo <name> <branch>` cleans implementation branches
+  in the selected product checkout in `workflow_hub` mode, then returns tracker
+  updates to the hub repository.
+- Spec, plan, and tracker operations remain hub-owned. Product repository
+  selection must not redirect GitHub Projects reads or status updates unless a
+  later workflow contract explicitly changes tracker ownership.
+
+When a workflow hub has more than one product repository, implementation
+inspection and mutation fail before touching product state unless the caller
+selects one product repository.
+
 ## Target Product Repository Selection
 
 A hub-managed work item must identify one visible and unambiguous target product

--- a/scripts/development-workflow/discover-workflow-state.sh
+++ b/scripts/development-workflow/discover-workflow-state.sh
@@ -41,6 +41,24 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+print_filtered_refs() {
+  local refs="$1"
+  local pattern="$2"
+  local matches=""
+  local grep_status=0
+
+  set +e
+  matches="$(printf '%s\n' "$refs" | grep -E "$pattern")"
+  grep_status=$?
+  set -e
+
+  case "$grep_status" in
+    0) printf '%s\n' "$matches" ;;
+    1) echo "(none)" ;;
+    *) return "$grep_status" ;;
+  esac
+}
+
 cd "$repo_root"
 
 mode_context="$(workflow_repository_mode "$repo_root")"
@@ -103,14 +121,18 @@ echo
 echo "== workflow branches =="
 branch_refs="$(git for-each-ref --format='%(refname:short)' refs/heads refs/remotes)"
 if [ -n "$branch_refs" ]; then
-  printf '%s\n' "$branch_refs" | grep -E '(^|/)(spec|implementation-plan|feature|refactor|fix|hotfix|release)/' || true
+  print_filtered_refs "$branch_refs" '(^|/)(spec|implementation-plan|feature|refactor|fix|hotfix|release)/'
+else
+  echo "(none)"
 fi
 if [ "$workflow_mode" = "workflow_hub" ] && [ -n "$target_local_path" ] && [ -d "$target_local_path/.git" ]; then
   echo
   echo "== product workflow branches =="
   product_branch_refs="$(git -C "$target_local_path" for-each-ref --format='%(refname:short)' refs/heads refs/remotes)"
   if [ -n "$product_branch_refs" ]; then
-    printf '%s\n' "$product_branch_refs" | grep -E '(^|/)(feature|refactor|fix|hotfix)/' || true
+    print_filtered_refs "$product_branch_refs" '(^|/)(feature|refactor|fix|hotfix)/'
+  else
+    echo "(none)"
   fi
 fi
 
@@ -135,7 +157,7 @@ echo
 echo "== open pull requests =="
 if gh_available; then
   echo "-- hub repository --"
-  gh pr list --state open --json number,title,headRefName,baseRefName,labels,statusCheckRollup \
+  gh pr list --state open --limit 100 --json number,title,headRefName,baseRefName,labels,statusCheckRollup \
     --jq '
       if length == 0 then
         "(none)"
@@ -157,7 +179,7 @@ if gh_available; then
     '
   if [ "$workflow_mode" = "workflow_hub" ] && [ -n "$target_github_repo" ]; then
     echo "-- product repository: $target_github_repo --"
-    gh pr list --repo "$target_github_repo" --state open --json number,title,headRefName,baseRefName,labels,statusCheckRollup \
+    gh pr list --repo "$target_github_repo" --state open --limit 100 --json number,title,headRefName,baseRefName,labels,statusCheckRollup \
       --jq '
         if length == 0 then
           "(none)"

--- a/scripts/development-workflow/discover-workflow-state.sh
+++ b/scripts/development-workflow/discover-workflow-state.sh
@@ -8,7 +8,84 @@ REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../.." && pwd)"
 # shellcheck source=scripts/development-workflow/workflow-lib.sh
 source "$SCRIPT_DIR/workflow-lib.sh"
 
-cd "$REPO_ROOT"
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/development-workflow/discover-workflow-state.sh [--repo <name>] [--repo-root <path>]
+
+Discovers workflow state. In workflow_hub mode, --repo selects the product
+repository used for implementation branch and PR inspection.
+EOF
+}
+
+target_repo=""
+repo_root="$REPO_ROOT"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      target_repo="${2:?--repo requires a value}"
+      shift 2
+      ;;
+    --repo-root)
+      repo_root="${2:?--repo-root requires a value}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 64
+      ;;
+  esac
+done
+
+cd "$repo_root"
+
+mode_context="$(workflow_repository_mode "$repo_root")"
+workflow_mode="$(workflow_context_value WORKFLOW_MODE "$mode_context")"
+repo_context=""
+target_github_repo=""
+target_local_path=""
+target_repo_name=""
+target_default_branch=""
+
+if [ "$workflow_mode" = "workflow_hub" ]; then
+  if repo_context="$(workflow_repository_context "$target_repo" "$repo_root" 2>/dev/null)"; then
+    target_github_repo="$(workflow_github_repo_from_context "$repo_context")"
+    target_local_path="$(workflow_context_value TARGET_LOCAL_PATH "$repo_context")"
+    target_repo_name="$(workflow_context_value TARGET_REPO_NAME "$repo_context")"
+    target_default_branch="$(workflow_context_value TARGET_DEFAULT_BRANCH "$repo_context")"
+  fi
+else
+  repo_context="$(workflow_repository_context "" "$repo_root")"
+  target_github_repo="$(workflow_github_repo_from_context "$repo_context")"
+  target_local_path="$(workflow_context_value TARGET_LOCAL_PATH "$repo_context")"
+  target_repo_name="$(workflow_context_value TARGET_REPO_NAME "$repo_context")"
+  target_default_branch="$(workflow_context_value TARGET_DEFAULT_BRANCH "$repo_context")"
+fi
+
+echo "== repository context =="
+print_kv WORKFLOW_MODE "$workflow_mode"
+if [ "$workflow_mode" = "workflow_hub" ]; then
+  if [ -n "$repo_context" ]; then
+    print_kv ACTION_REPOSITORY_KIND "product_repo_owned"
+    print_kv ACTION_REPOSITORY "$target_repo_name"
+    print_kv TARGET_GITHUB_REPO "$target_github_repo"
+    print_kv TARGET_LOCAL_PATH "$target_local_path"
+    print_kv TARGET_DEFAULT_BRANCH "$target_default_branch"
+  else
+    print_kv ACTION_REPOSITORY_KIND "selection_missing"
+    print_kv ACTION_REPOSITORY ""
+    echo "NOTE: product repository selection is required for product-owned implementation branch and PR inspection."
+  fi
+else
+  print_kv ACTION_REPOSITORY_KIND "single_repo_context"
+  print_kv ACTION_REPOSITORY "$target_repo_name"
+  print_kv TARGET_GITHUB_REPO "$target_github_repo"
+fi
+echo
 
 # Check if an issue tracker is configured and remind the caller
 tracker_provider="$(workflow_config_provider issue_tracker)"
@@ -28,10 +105,23 @@ branch_refs="$(git for-each-ref --format='%(refname:short)' refs/heads refs/remo
 if [ -n "$branch_refs" ]; then
   printf '%s\n' "$branch_refs" | grep -E '(^|/)(spec|implementation-plan|feature|refactor|fix|hotfix|release)/' || true
 fi
+if [ "$workflow_mode" = "workflow_hub" ] && [ -n "$target_local_path" ] && [ -d "$target_local_path/.git" ]; then
+  echo
+  echo "== product workflow branches =="
+  product_branch_refs="$(git -C "$target_local_path" for-each-ref --format='%(refname:short)' refs/heads refs/remotes)"
+  if [ -n "$product_branch_refs" ]; then
+    printf '%s\n' "$product_branch_refs" | grep -E '(^|/)(feature|refactor|fix|hotfix)/' || true
+  fi
+fi
 
 echo
 echo "== worktrees =="
 git worktree list
+if [ "$workflow_mode" = "workflow_hub" ] && [ -n "$target_local_path" ] && [ -d "$target_local_path/.git" ]; then
+  echo
+  echo "== product worktrees =="
+  git -C "$target_local_path" worktree list
+fi
 
 echo
 echo "== development folders =="
@@ -44,6 +134,7 @@ fi
 echo
 echo "== open pull requests =="
 if gh_available; then
+  echo "-- hub repository --"
   gh pr list --state open --json number,title,headRefName,baseRefName,labels,statusCheckRollup \
     --jq '
       if length == 0 then
@@ -64,6 +155,29 @@ if gh_available; then
         | @tsv
       end
     '
+  if [ "$workflow_mode" = "workflow_hub" ] && [ -n "$target_github_repo" ]; then
+    echo "-- product repository: $target_github_repo --"
+    gh pr list --repo "$target_github_repo" --state open --json number,title,headRefName,baseRefName,labels,statusCheckRollup \
+      --jq '
+        if length == 0 then
+          "(none)"
+        else
+          .[]
+          | [
+              ("#" + (.number | tostring)),
+              .headRefName,
+              ("base=" + .baseRefName),
+              ("labels=" + ([.labels[].name] | join(","))),
+              ("checks=" + (
+                [.statusCheckRollup[]? | (.conclusion // .state // .status // "unknown")]
+                | join(",")
+              )),
+              .title
+            ]
+          | @tsv
+        end
+      '
+  fi
 else
   echo "(gh unavailable)"
 fi

--- a/scripts/development-workflow/discover-workflow-state.sh
+++ b/scripts/development-workflow/discover-workflow-state.sh
@@ -20,14 +20,25 @@ EOF
 target_repo=""
 repo_root="$REPO_ROOT"
 
+require_option_value() {
+  local option="$1"
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ]; then
+    echo "$option requires a value." >&2
+    usage >&2
+    exit 64
+  fi
+}
+
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --repo)
-      target_repo="${2:?--repo requires a value}"
+      require_option_value "$@"
+      target_repo="$2"
       shift 2
       ;;
     --repo-root)
-      repo_root="${2:?--repo-root requires a value}"
+      require_option_value "$@"
+      repo_root="$2"
       shift 2
       ;;
     -h|--help)

--- a/scripts/development-workflow/discover-workflow-state.sh
+++ b/scripts/development-workflow/discover-workflow-state.sh
@@ -101,17 +101,20 @@ if [ "$workflow_mode" = "workflow_hub" ]; then
   if [ -n "$repo_context" ]; then
     print_kv ACTION_REPOSITORY_KIND "product_repo_owned"
     print_kv ACTION_REPOSITORY "$target_repo_name"
+    print_kv ACTION_GITHUB_REPO "$target_github_repo"
     print_kv TARGET_GITHUB_REPO "$target_github_repo"
     print_kv TARGET_LOCAL_PATH "$target_local_path"
     print_kv TARGET_DEFAULT_BRANCH "$target_default_branch"
   else
     print_kv ACTION_REPOSITORY_KIND "selection_missing"
     print_kv ACTION_REPOSITORY ""
+    print_kv ACTION_GITHUB_REPO ""
     echo "NOTE: product repository selection is required for product-owned implementation branch and PR inspection."
   fi
 else
   print_kv ACTION_REPOSITORY_KIND "single_repo_context"
   print_kv ACTION_REPOSITORY "$target_repo_name"
+  print_kv ACTION_GITHUB_REPO "$target_github_repo"
   print_kv TARGET_GITHUB_REPO "$target_github_repo"
 fi
 echo

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -82,6 +82,10 @@ if [ "$workflow_mode" = "workflow_hub" ] && { [ "$branch_owner_kind" = "implemen
   repo_context="$(workflow_validate_repository_context "$target_repo" "$repo_root" --require-local)"
   CLEANUP_REPO_ROOT="$(workflow_context_value TARGET_LOCAL_PATH "$repo_context")"
   DEVELOP_BRANCH="$(workflow_context_value TARGET_DEFAULT_BRANCH "$repo_context")"
+  if [ -z "$DEVELOP_BRANCH" ]; then
+    echo "ERROR: product repository default branch is required for workflow_hub cleanup." >&2
+    exit 64
+  fi
   ACTION_REPOSITORY_KIND="product_repo_owned"
   ACTION_REPOSITORY="$(workflow_context_value TARGET_REPO_NAME "$repo_context")"
   TARGET_GITHUB_REPO="$(workflow_github_repo_from_context "$repo_context")"

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -90,6 +90,11 @@ case "$(branch_prefix "$TO_DELETE")" in
     ;;
 esac
 
+if [ "$workflow_mode" = "workflow_hub" ] && [ "$branch_owner_kind" = "implementation" ] && [ -z "$target_repo" ]; then
+  echo "ERROR: product repository selection is required for implementation branch cleanup in workflow_hub mode; pass --repo <name>." >&2
+  exit 64
+fi
+
 if [ "$workflow_mode" = "workflow_hub" ] && [ -n "$target_repo" ]; then
   selected_repo_context="$(workflow_validate_repository_context "$target_repo" "$repo_root" --require-local)"
   selected_product_default_branch="$(workflow_context_value TARGET_DEFAULT_BRANCH "$selected_repo_context")"

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -302,8 +302,7 @@ if [ -n "$ISSUE_IDENTIFIER" ]; then
           echo "Reasserting issue #$ISSUE_NUMBER tracker status as Merged after close..."
           update_tracker_status_best_effort "$ISSUE_NUMBER" "Merged" "" "allow-backward"
         else
-          echo "ERROR: could not close issue #$ISSUE_NUMBER" >&2
-          exit 1
+          echo "Warning: could not close issue #$ISSUE_NUMBER; continuing cleanup." >&2
         fi
       else
         echo "No merged PR found for branch '$TO_DELETE'; leaving issue #$ISSUE_NUMBER open."

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -5,7 +5,7 @@
 # Keeps the local repo clean after merging developments.
 #
 # Usage:
-#   ./scripts/development-workflow/post-merge-cleanup.sh [BRANCH]
+#   ./scripts/development-workflow/post-merge-cleanup.sh [--repo <name>] [--repo-root <path>] [BRANCH]
 #
 # - No BRANCH: use current branch (run while still on the merged branch).
 # - BRANCH: name of the local branch to delete (e.g. feature/my-feature).
@@ -22,12 +22,41 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cd_workflow_repo_root
 
+HUB_REPO_ROOT="$(workflow_repo_root)"
 DEVELOP_BRANCH="develop"
 TO_DELETE=""
+target_repo=""
+repo_root="$HUB_REPO_ROOT"
 
-if [ $# -ge 1 ]; then
-  TO_DELETE="$1"
-else
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      target_repo="${2:?--repo requires a value}"
+      shift 2
+      ;;
+    --repo-root)
+      repo_root="${2:?--repo-root requires a value}"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,16p' "$0"
+      exit 0
+      ;;
+    *)
+      if [ -n "$TO_DELETE" ]; then
+        echo "Only one branch name may be provided." >&2
+        exit 64
+      fi
+      TO_DELETE="$1"
+      shift
+      ;;
+  esac
+done
+
+HUB_REPO_ROOT="$repo_root"
+cd "$HUB_REPO_ROOT"
+
+if [ -z "$TO_DELETE" ]; then
   TO_DELETE="$(git branch --show-current)"
   if [ -z "$TO_DELETE" ]; then
     echo "Could not determine current branch (detached HEAD?). Pass the branch name to delete." >&2
@@ -46,12 +75,44 @@ case "$TO_DELETE" in
     ;;
 esac
 
+CLEANUP_REPO_ROOT="$repo_root"
+ACTION_REPOSITORY_KIND="hub_owned"
+ACTION_REPOSITORY="$(basename "$repo_root")"
+TARGET_GITHUB_REPO=""
+
+case "$(branch_prefix "$TO_DELETE")" in
+  feature|fix|refactor|hotfix)
+    mode_context="$(workflow_repository_mode "$repo_root")"
+    workflow_mode="$(workflow_context_value WORKFLOW_MODE "$mode_context")"
+    if [ "$workflow_mode" = "workflow_hub" ]; then
+      repo_context="$(workflow_validate_repository_context "$target_repo" "$repo_root" --require-local)"
+      CLEANUP_REPO_ROOT="$(workflow_context_value TARGET_LOCAL_PATH "$repo_context")"
+      DEVELOP_BRANCH="$(workflow_context_value TARGET_DEFAULT_BRANCH "$repo_context")"
+      ACTION_REPOSITORY_KIND="product_repo_owned"
+      ACTION_REPOSITORY="$(workflow_context_value TARGET_REPO_NAME "$repo_context")"
+      TARGET_GITHUB_REPO="$(workflow_github_repo_from_context "$repo_context")"
+      if [ -z "$CLEANUP_REPO_ROOT" ]; then
+        echo "ERROR: product repository local path is required for implementation branch cleanup in workflow_hub mode." >&2
+        exit 64
+      fi
+    fi
+    ;;
+esac
+
+print_kv ACTION_REPOSITORY_KIND "$ACTION_REPOSITORY_KIND"
+print_kv ACTION_REPOSITORY "$ACTION_REPOSITORY"
+[ -n "$TARGET_GITHUB_REPO" ] && print_kv TARGET_GITHUB_REPO "$TARGET_GITHUB_REPO"
+print_kv CLEANUP_REPO_ROOT "$CLEANUP_REPO_ROOT"
+print_kv TRACKER_REPO_ROOT "$HUB_REPO_ROOT"
+
+cd "$CLEANUP_REPO_ROOT"
+
 if ! git show-ref --quiet "refs/heads/$TO_DELETE"; then
   echo "Local branch '$TO_DELETE' does not exist." >&2
   exit 2
 fi
 
-echo "Post-merge cleanup: will switch to $DEVELOP_BRANCH, update it, and delete local branch '$TO_DELETE'."
+echo "Post-merge cleanup: will switch to $DEVELOP_BRANCH in $CLEANUP_REPO_ROOT, update it, and delete local branch '$TO_DELETE'."
 echo ""
 
 echo "Fetching origin..."
@@ -162,6 +223,7 @@ elif [[ "$TO_DELETE" =~ ^(implementation-plan)/([a-zA-Z]{2,6}-([0-9]+))($|-) ]];
 fi
 
 if [ -n "$ISSUE_IDENTIFIER" ]; then
+  cd "$HUB_REPO_ROOT"
   # For team-prefixed identifiers, log the extraction result.
   # All `gh issue` and `update_tracker_status_best_effort` calls use ISSUE_NUMBER
   # (the numeric part) because:

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -54,7 +54,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 HUB_REPO_ROOT="$repo_root"
-cd "$HUB_REPO_ROOT"
+cd "$HUB_REPO_ROOT" || exit 1
 
 if [ -z "$TO_DELETE" ]; then
   TO_DELETE="$(git branch --show-current)"
@@ -62,9 +62,32 @@ if [ -z "$TO_DELETE" ]; then
     echo "Could not determine current branch (detached HEAD?). Pass the branch name to delete." >&2
     exit 2
   fi
-  if [ "$TO_DELETE" = "$DEVELOP_BRANCH" ]; then
-    echo "You are on '$DEVELOP_BRANCH'. Pass the merged branch name to delete, e.g. feature/my-feature." >&2
-    exit 2
+fi
+
+CLEANUP_REPO_ROOT="$repo_root"
+ACTION_REPOSITORY_KIND="hub_owned"
+ACTION_REPOSITORY="$(basename "$repo_root")"
+TARGET_GITHUB_REPO=""
+mode_context="$(workflow_repository_mode "$repo_root")"
+workflow_mode="$(workflow_context_value WORKFLOW_MODE "$mode_context")"
+branch_owner_kind="hub"
+
+case "$(branch_prefix "$TO_DELETE")" in
+  feature|fix|refactor|hotfix)
+    branch_owner_kind="implementation"
+    ;;
+esac
+
+if [ "$workflow_mode" = "workflow_hub" ] && { [ "$branch_owner_kind" = "implementation" ] || [ -n "$target_repo" ]; }; then
+  repo_context="$(workflow_validate_repository_context "$target_repo" "$repo_root" --require-local)"
+  CLEANUP_REPO_ROOT="$(workflow_context_value TARGET_LOCAL_PATH "$repo_context")"
+  DEVELOP_BRANCH="$(workflow_context_value TARGET_DEFAULT_BRANCH "$repo_context")"
+  ACTION_REPOSITORY_KIND="product_repo_owned"
+  ACTION_REPOSITORY="$(workflow_context_value TARGET_REPO_NAME "$repo_context")"
+  TARGET_GITHUB_REPO="$(workflow_github_repo_from_context "$repo_context")"
+  if [ -z "$CLEANUP_REPO_ROOT" ]; then
+    echo "ERROR: product repository local path is required for product repository cleanup in workflow_hub mode." >&2
+    exit 64
   fi
 fi
 
@@ -75,37 +98,13 @@ case "$TO_DELETE" in
     ;;
 esac
 
-CLEANUP_REPO_ROOT="$repo_root"
-ACTION_REPOSITORY_KIND="hub_owned"
-ACTION_REPOSITORY="$(basename "$repo_root")"
-TARGET_GITHUB_REPO=""
-
-case "$(branch_prefix "$TO_DELETE")" in
-  feature|fix|refactor|hotfix)
-    mode_context="$(workflow_repository_mode "$repo_root")"
-    workflow_mode="$(workflow_context_value WORKFLOW_MODE "$mode_context")"
-    if [ "$workflow_mode" = "workflow_hub" ]; then
-      repo_context="$(workflow_validate_repository_context "$target_repo" "$repo_root" --require-local)"
-      CLEANUP_REPO_ROOT="$(workflow_context_value TARGET_LOCAL_PATH "$repo_context")"
-      DEVELOP_BRANCH="$(workflow_context_value TARGET_DEFAULT_BRANCH "$repo_context")"
-      ACTION_REPOSITORY_KIND="product_repo_owned"
-      ACTION_REPOSITORY="$(workflow_context_value TARGET_REPO_NAME "$repo_context")"
-      TARGET_GITHUB_REPO="$(workflow_github_repo_from_context "$repo_context")"
-      if [ -z "$CLEANUP_REPO_ROOT" ]; then
-        echo "ERROR: product repository local path is required for implementation branch cleanup in workflow_hub mode." >&2
-        exit 64
-      fi
-    fi
-    ;;
-esac
-
 print_kv ACTION_REPOSITORY_KIND "$ACTION_REPOSITORY_KIND"
 print_kv ACTION_REPOSITORY "$ACTION_REPOSITORY"
 [ -n "$TARGET_GITHUB_REPO" ] && print_kv TARGET_GITHUB_REPO "$TARGET_GITHUB_REPO"
 print_kv CLEANUP_REPO_ROOT "$CLEANUP_REPO_ROOT"
 print_kv TRACKER_REPO_ROOT "$HUB_REPO_ROOT"
 
-cd "$CLEANUP_REPO_ROOT"
+cd "$CLEANUP_REPO_ROOT" || exit 1
 
 if ! git show-ref --quiet "refs/heads/$TO_DELETE"; then
   echo "Local branch '$TO_DELETE' does not exist." >&2
@@ -243,32 +242,33 @@ if [ -n "$ISSUE_IDENTIFIER" ]; then
     # whose linked issue is open; once closed the lookup silently fails).
     update_tracker_status_best_effort "$ISSUE_NUMBER" "Merged"
     # Close the issue when an implementation branch (feature/fix/hotfix/refactor) is merged.
-    if ISSUE_STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state' 2>/dev/null); then
-      if [ "$ISSUE_STATE" = "OPEN" ]; then
-        # Find the merged PR for this branch.
-        if MERGED_PR=$(gh pr list --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null); then
-          : # gh succeeded; MERGED_PR may still be empty if no matching PR exists
+    if ! ISSUE_STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state'); then
+      echo "ERROR: could not query issue #$ISSUE_NUMBER (gh command failed)." >&2
+      exit 1
+    fi
+    if [ "$ISSUE_STATE" = "OPEN" ]; then
+      # Find the merged PR for this branch.
+      if MERGED_PR=$(gh pr list --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty'); then
+        : # gh succeeded; MERGED_PR may still be empty if no matching PR exists
+      else
+        echo "ERROR: could not query merged PRs for branch '$TO_DELETE' (gh command failed)." >&2
+        exit 1
+      fi
+      if [ -n "$MERGED_PR" ]; then
+        CLOSE_COMMENT="Closed by PR #${MERGED_PR}."
+        echo "Closing issue #$ISSUE_NUMBER..."
+        if gh issue close "$ISSUE_NUMBER" --comment "$CLOSE_COMMENT"; then
+          echo "Reasserting issue #$ISSUE_NUMBER tracker status as Merged after close..."
+          update_tracker_status_best_effort "$ISSUE_NUMBER" "Merged" "" "allow-backward"
         else
-          echo "Warning: could not query merged PRs for branch '$TO_DELETE' (gh command failed). Leaving issue #$ISSUE_NUMBER open."
-          MERGED_PR=""
-        fi
-        if [ -n "$MERGED_PR" ]; then
-          CLOSE_COMMENT="Closed by PR #${MERGED_PR}."
-          echo "Closing issue #$ISSUE_NUMBER..."
-          if gh issue close "$ISSUE_NUMBER" --comment "$CLOSE_COMMENT"; then
-            echo "Reasserting issue #$ISSUE_NUMBER tracker status as Merged after close..."
-            update_tracker_status_best_effort "$ISSUE_NUMBER" "Merged" "" "allow-backward"
-          else
-            echo "Warning: could not close issue #$ISSUE_NUMBER"
-          fi
-        else
-          echo "No merged PR found for branch '$TO_DELETE'; leaving issue #$ISSUE_NUMBER open."
+          echo "ERROR: could not close issue #$ISSUE_NUMBER" >&2
+          exit 1
         fi
       else
-        echo "Issue #$ISSUE_NUMBER is already $ISSUE_STATE, skipping close."
+        echo "No merged PR found for branch '$TO_DELETE'; leaving issue #$ISSUE_NUMBER open."
       fi
     else
-      echo "Warning: could not query issue #$ISSUE_NUMBER (gh command failed). Skipping issue close."
+      echo "Issue #$ISSUE_NUMBER is already $ISSUE_STATE, skipping close."
     fi
   elif [ "$BRANCH_TYPE" = "spec" ]; then
     # spec/* branches reference the issue but must not close it — the issue stays

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -82,6 +82,7 @@ TARGET_GITHUB_REPO=""
 mode_context="$(workflow_repository_mode "$repo_root")"
 workflow_mode="$(workflow_context_value WORKFLOW_MODE "$mode_context")"
 branch_owner_kind="hub"
+selected_product_default_branch=""
 
 case "$(branch_prefix "$TO_DELETE")" in
   feature|fix|refactor|hotfix)
@@ -89,8 +90,23 @@ case "$(branch_prefix "$TO_DELETE")" in
     ;;
 esac
 
-if [ "$workflow_mode" = "workflow_hub" ] && { [ "$branch_owner_kind" = "implementation" ] || [ -n "$target_repo" ]; }; then
-  repo_context="$(workflow_validate_repository_context "$target_repo" "$repo_root" --require-local)"
+if [ "$workflow_mode" = "workflow_hub" ] && [ -n "$target_repo" ]; then
+  selected_repo_context="$(workflow_validate_repository_context "$target_repo" "$repo_root" --require-local)"
+  selected_product_default_branch="$(workflow_context_value TARGET_DEFAULT_BRANCH "$selected_repo_context")"
+  if [ -z "$selected_product_default_branch" ]; then
+    echo "ERROR: product repository default branch is required for workflow_hub cleanup." >&2
+    exit 64
+  fi
+else
+  selected_repo_context=""
+fi
+
+if [ "$workflow_mode" = "workflow_hub" ] && [ "$branch_owner_kind" = "implementation" ]; then
+  if [ -n "$selected_repo_context" ]; then
+    repo_context="$selected_repo_context"
+  else
+    repo_context="$(workflow_validate_repository_context "$target_repo" "$repo_root" --require-local)"
+  fi
   CLEANUP_REPO_ROOT="$(workflow_context_value TARGET_LOCAL_PATH "$repo_context")"
   DEVELOP_BRANCH="$(workflow_context_value TARGET_DEFAULT_BRANCH "$repo_context")"
   if [ -z "$DEVELOP_BRANCH" ]; then
@@ -107,7 +123,7 @@ if [ "$workflow_mode" = "workflow_hub" ] && { [ "$branch_owner_kind" = "implemen
 fi
 
 case "$TO_DELETE" in
-  "$DEVELOP_BRANCH"|main|master)
+  "$DEVELOP_BRANCH"|"$selected_product_default_branch"|main|master)
     echo "Refusing to delete protected branch '$TO_DELETE'." >&2
     exit 2
     ;;

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -246,7 +246,7 @@ if [ -n "$ISSUE_IDENTIFIER" ]; then
     if ISSUE_STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state' 2>/dev/null); then
       if [ "$ISSUE_STATE" = "OPEN" ]; then
         # Find the merged PR for this branch.
-        if MERGED_PR=$(gh pr list --state merged --head "$TO_DELETE" --json number --jq '.[0].number // empty' 2>/dev/null); then
+        if MERGED_PR=$(gh pr list --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null); then
           : # gh succeeded; MERGED_PR may still be empty if no matching PR exists
         else
           echo "Warning: could not query merged PRs for branch '$TO_DELETE' (gh command failed). Leaving issue #$ISSUE_NUMBER open."

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -28,14 +28,25 @@ TO_DELETE=""
 target_repo=""
 repo_root="$HUB_REPO_ROOT"
 
+require_option_value() {
+  local option="$1"
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ]; then
+    echo "$option requires a value." >&2
+    sed -n '2,16p' "$0" >&2
+    exit 64
+  fi
+}
+
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --repo)
-      target_repo="${2:?--repo requires a value}"
+      require_option_value "$@"
+      target_repo="$2"
       shift 2
       ;;
     --repo-root)
-      repo_root="${2:?--repo-root requires a value}"
+      require_option_value "$@"
+      repo_root="$2"
       shift 2
       ;;
     -h|--help)

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -284,17 +284,17 @@ if [ -n "$ISSUE_IDENTIFIER" ]; then
     fi
     if [ "$ISSUE_STATE" = "OPEN" ]; then
       # Find the merged PR for this branch.
-      if [ -n "$TARGET_GITHUB_REPO" ]; then
-        MERGED_PR="$(gh pr list --repo "$TARGET_GITHUB_REPO" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty')" || {
-          echo "ERROR: could not query merged PRs for branch '$TO_DELETE' in '$TARGET_GITHUB_REPO' (gh command failed)." >&2
+      merged_pr_repo="$TARGET_GITHUB_REPO"
+      if [ -z "$merged_pr_repo" ]; then
+        if ! merged_pr_repo="$(repo_slug)"; then
+          echo "ERROR: could not resolve GitHub repository for merged PR lookup." >&2
           exit 1
-        }
-      else
-        MERGED_PR="$(gh pr list --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty')" || {
-          echo "ERROR: could not query merged PRs for branch '$TO_DELETE' (gh command failed)." >&2
-          exit 1
-        }
+        fi
       fi
+      MERGED_PR="$(gh pr list --repo "$merged_pr_repo" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty')" || {
+        echo "ERROR: could not query merged PRs for branch '$TO_DELETE' in '$merged_pr_repo' (gh command failed)." >&2
+        exit 1
+      }
       if [ -n "$MERGED_PR" ]; then
         CLOSE_COMMENT="Closed by PR #${MERGED_PR}."
         echo "Closing issue #$ISSUE_NUMBER..."

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -279,13 +279,16 @@ if [ -n "$ISSUE_IDENTIFIER" ]; then
     fi
     if [ "$ISSUE_STATE" = "OPEN" ]; then
       # Find the merged PR for this branch.
-      merged_pr_args=()
-      [ -n "$TARGET_GITHUB_REPO" ] && merged_pr_args+=(--repo "$TARGET_GITHUB_REPO")
-      if MERGED_PR=$(gh pr list "${merged_pr_args[@]}" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty'); then
-        : # gh succeeded; MERGED_PR may still be empty if no matching PR exists
+      if [ -n "$TARGET_GITHUB_REPO" ]; then
+        MERGED_PR="$(gh pr list --repo "$TARGET_GITHUB_REPO" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty')" || {
+          echo "ERROR: could not query merged PRs for branch '$TO_DELETE' in '$TARGET_GITHUB_REPO' (gh command failed)." >&2
+          exit 1
+        }
       else
-        echo "ERROR: could not query merged PRs for branch '$TO_DELETE' (gh command failed)." >&2
-        exit 1
+        MERGED_PR="$(gh pr list --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty')" || {
+          echo "ERROR: could not query merged PRs for branch '$TO_DELETE' (gh command failed)." >&2
+          exit 1
+        }
       fi
       if [ -n "$MERGED_PR" ]; then
         CLOSE_COMMENT="Closed by PR #${MERGED_PR}."

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -248,7 +248,9 @@ if [ -n "$ISSUE_IDENTIFIER" ]; then
     fi
     if [ "$ISSUE_STATE" = "OPEN" ]; then
       # Find the merged PR for this branch.
-      if MERGED_PR=$(gh pr list --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty'); then
+      merged_pr_args=()
+      [ -n "$TARGET_GITHUB_REPO" ] && merged_pr_args+=(--repo "$TARGET_GITHUB_REPO")
+      if MERGED_PR=$(gh pr list "${merged_pr_args[@]}" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty'); then
         : # gh succeeded; MERGED_PR may still be empty if no matching PR exists
       else
         echo "ERROR: could not query merged PRs for branch '$TO_DELETE' (gh command failed)." >&2

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -79,7 +79,7 @@ require_gh
 cd "$repo_root"
 
 elapsed=0
-if [ -n "$repo_selector" ] && printf '%s\n' "$repo_selector" | grep -q '/'; then
+if [ -n "$repo_selector" ] && workflow_is_valid_github_repo_slug "$repo_selector"; then
   repo="$repo_selector"
 elif [ -n "$repo_selector" ]; then
   repo_context="$(workflow_repository_context "$repo_selector" "$repo_root")"
@@ -202,10 +202,21 @@ is_devin_status_stale() {
 }
 
 while :; do
-  checks_json="$(gh pr view "$pr_number" --repo "$repo" --json statusCheckRollup)"
+  if ! checks_json="$(gh pr view "$pr_number" --repo "$repo" --json statusCheckRollup 2>/dev/null)"; then
+    print_kv RESULT red
+    print_kv PR_NUMBER "$pr_number"
+    print_kv REPO "$repo"
+    print_kv REASON pr_status_fetch_failed
+    print_kv TOTAL_CHECK_COUNT 0
+    print_kv FAILING_CHECK_COUNT 1
+    print_kv FAILING_CHECKS pr_status_fetch_failed
+    print_kv PENDING_CHECK_COUNT 0
+    print_kv PENDING_CHECKS ""
+    exit 1
+  fi
   # statusCheckRollup can include historical duplicates for the same check.
   # Keep only the latest entry per check name to avoid stale conclusions.
-  normalized_checks_json="$(
+  if ! normalized_checks_json="$(
     printf '%s\n' "$checks_json" | jq '
       (.statusCheckRollup // [])
       | map(
@@ -228,7 +239,18 @@ while :; do
       | group_by(.__check_key)
       | map(last | del(.__check_key, .__check_ts))
     '
-  )"
+  )"; then
+    print_kv RESULT red
+    print_kv PR_NUMBER "$pr_number"
+    print_kv REPO "$repo"
+    print_kv REASON check_json_parse_failed
+    print_kv TOTAL_CHECK_COUNT 0
+    print_kv FAILING_CHECK_COUNT 1
+    print_kv FAILING_CHECKS check_json_parse_failed
+    print_kv PENDING_CHECK_COUNT 0
+    print_kv PENDING_CHECKS ""
+    exit 1
+  fi
   total_check_count="$(
     printf '%s\n' "$normalized_checks_json" | jq 'length'
   )"

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -8,7 +8,7 @@ source "$SCRIPT_DIR/workflow-lib.sh"
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/development-workflow/pr-ci-loop.sh <pr-number> [--poll-interval seconds] [--max-wait seconds]
+Usage: ./scripts/development-workflow/pr-ci-loop.sh <pr-number> [--repo owner/repo|product-name] [--product-repo name] [--repo-root path] [--poll-interval seconds] [--max-wait seconds]
 
 Polls GitHub required status checks for a PR until they are green, failing, or timed out.
 Outputs stable key=value lines and exits with:
@@ -26,6 +26,8 @@ fi
 pr_number=""
 poll_interval=60
 max_wait=1800
+repo_selector=""
+repo_root="$(workflow_repo_root)"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -35,6 +37,18 @@ while [ "$#" -gt 0 ]; do
       ;;
     --max-wait)
       max_wait="$2"
+      shift 2
+      ;;
+    --repo)
+      repo_selector="$2"
+      shift 2
+      ;;
+    --product-repo)
+      repo_selector="$2"
+      shift 2
+      ;;
+    --repo-root)
+      repo_root="$2"
       shift 2
       ;;
     -h|--help)
@@ -62,10 +76,23 @@ if [ -z "$pr_number" ]; then
 fi
 
 require_gh
-cd_workflow_repo_root
+cd "$repo_root"
 
 elapsed=0
-repo="$(repo_slug)"
+if [ -n "$repo_selector" ] && printf '%s\n' "$repo_selector" | grep -q '/'; then
+  repo="$repo_selector"
+elif [ -n "$repo_selector" ]; then
+  repo_context="$(workflow_repository_context "$repo_selector" "$repo_root")"
+  repo="$(workflow_github_repo_from_context "$repo_context")"
+else
+  repo="$(repo_slug)"
+fi
+if [ -z "$repo" ]; then
+  echo "ERROR: could not resolve GitHub repository for PR CI loop; pass --repo owner/repo or --product-repo <name>." >&2
+  exit 64
+fi
+export WORKFLOW_TARGET_GITHUB_REPO="$repo"
+export GH_REPO="$repo"
 min_no_checks_wait=$((poll_interval * 2))
 
 # is_devin_status_stale <pr_number> <repo>
@@ -175,7 +202,7 @@ is_devin_status_stale() {
 }
 
 while :; do
-  checks_json="$(gh pr view "$pr_number" --json statusCheckRollup)"
+  checks_json="$(gh pr view "$pr_number" --repo "$repo" --json statusCheckRollup)"
   # statusCheckRollup can include historical duplicates for the same check.
   # Keep only the latest entry per check name to avoid stale conclusions.
   normalized_checks_json="$(

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -29,25 +29,39 @@ max_wait=1800
 repo_selector=""
 repo_root="$(workflow_repo_root)"
 
+require_option_value() {
+  local option="$1"
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ]; then
+    echo "$option requires a value." >&2
+    usage >&2
+    exit 64
+  fi
+}
+
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --poll-interval)
+      require_option_value "$@"
       poll_interval="$2"
       shift 2
       ;;
     --max-wait)
+      require_option_value "$@"
       max_wait="$2"
       shift 2
       ;;
     --repo)
+      require_option_value "$@"
       repo_selector="$2"
       shift 2
       ;;
     --product-repo)
+      require_option_value "$@"
       repo_selector="$2"
       shift 2
       ;;
     --repo-root)
+      require_option_value "$@"
       repo_root="$2"
       shift 2
       ;;

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -81,7 +81,7 @@ _skip_next=0
 for _arg in "$@"; do
   if [ "$_skip_next" -eq 1 ]; then _skip_next=0; continue; fi
   case "$_arg" in
-    --branch|--platform|--poll-interval|--max-wait) _skip_next=1 ;;
+    --branch|--platform|--poll-interval|--max-wait|--repo|--product-repo|--repo-root) _skip_next=1 ;;
     [0-9]*) _PR_ARG="$_arg"; break ;;
   esac
 done
@@ -172,7 +172,7 @@ _interruptible_sleep() {
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--platform greptile] [--platform greptile,devin,pr-agent,coderabbit,codex-github,claude-code-action,copilot,haystack] [--ready-phase haystack] [--phase-after-clean haystack] [--draft-github-only] [--pre-after-clean-only] [--poll-interval seconds] [--max-wait seconds] [--post-final-summary] [--compare]
+Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--repo owner/repo|product-name] [--product-repo name] [--repo-root path] [--platform greptile] [--platform greptile,devin,pr-agent,coderabbit,codex-github,claude-code-action,copilot,haystack] [--ready-phase haystack] [--phase-after-clean haystack] [--draft-github-only] [--pre-after-clean-only] [--poll-interval seconds] [--max-wait seconds] [--post-final-summary] [--compare]
        ./scripts/development-workflow/pr-review-loop.sh unlock <pr-number>
 
 Runs the automated PR review loop for one or more platforms in sequence. Before
@@ -3946,6 +3946,8 @@ fi
 
 pr_number=""
 branch_name=""
+repo_selector=""
+repo_root="$(workflow_repo_root)"
 poll_interval=120
 poll_interval_explicit=0
 max_wait=1200
@@ -3962,6 +3964,18 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --branch)
       branch_name="$2"
+      shift 2
+      ;;
+    --repo)
+      repo_selector="$2"
+      shift 2
+      ;;
+    --product-repo)
+      repo_selector="$2"
+      shift 2
+      ;;
+    --repo-root)
+      repo_root="$2"
       shift 2
       ;;
     --platform)
@@ -4024,6 +4038,22 @@ done
 if [ -z "$pr_number" ]; then
   usage >&2
   exit 64
+fi
+
+if [ -n "$repo_selector" ]; then
+  if printf '%s\n' "$repo_selector" | grep -q '/'; then
+    target_github_repo="$repo_selector"
+  else
+    repo_context="$(workflow_repository_context "$repo_selector" "$repo_root")"
+    target_github_repo="$(workflow_github_repo_from_context "$repo_context")"
+  fi
+  if [ -z "$target_github_repo" ]; then
+    echo "ERROR: could not resolve GitHub repository for PR review loop; pass --repo owner/repo or --product-repo <name>." >&2
+    exit 64
+  fi
+  export WORKFLOW_TARGET_GITHUB_REPO="$target_github_repo"
+  export GH_REPO="$target_github_repo"
+  print_kv REPO "$target_github_repo"
 fi
 
 if [ "${#platforms[@]}" -eq 0 ]; then
@@ -4093,7 +4123,7 @@ fi
 
 if [ "${#platforms[@]}" -gt 0 ]; then
   require_gh
-  cd_workflow_repo_root
+  cd "$repo_root"
 
   if [ -z "$branch_name" ]; then
     branch_name="$(gh pr view "$pr_number" --json headRefName --jq '.headRefName')"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3960,33 +3960,49 @@ declare -a platforms=()
 declare -a phase_after_clean_platforms=()
 phase_after_clean_filtered_out=""
 
+require_option_value() {
+  local option="$1"
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ]; then
+    echo "$option requires a value." >&2
+    usage >&2
+    exit 64
+  fi
+}
+
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --branch)
+      require_option_value "$@"
       branch_name="$2"
       shift 2
       ;;
     --repo)
+      require_option_value "$@"
       repo_selector="$2"
       shift 2
       ;;
     --product-repo)
+      require_option_value "$@"
       repo_selector="$2"
       shift 2
       ;;
     --repo-root)
+      require_option_value "$@"
       repo_root="$2"
       shift 2
       ;;
     --platform)
+      require_option_value "$@"
       append_platforms "$2"
       shift 2
       ;;
     --phase-after-clean)
+      require_option_value "$@"
       append_phase_after_clean_platforms "$2"
       shift 2
       ;;
     --ready-phase)
+      require_option_value "$@"
       append_ready_phase_platforms "$2"
       shift 2
       ;;
@@ -3999,11 +4015,13 @@ while [ "$#" -gt 0 ]; do
       shift
       ;;
     --poll-interval)
+      require_option_value "$@"
       poll_interval="$2"
       poll_interval_explicit=1
       shift 2
       ;;
     --max-wait)
+      require_option_value "$@"
       max_wait="$2"
       max_wait_explicit=1
       shift 2

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4123,10 +4123,13 @@ fi
 
 if [ "${#platforms[@]}" -gt 0 ]; then
   require_gh
-  cd "$repo_root"
+  cd "$repo_root" || exit 1
 
   if [ -z "$branch_name" ]; then
-    branch_name="$(gh pr view "$pr_number" --json headRefName --jq '.headRefName')"
+    if ! branch_name="$(gh pr view "$pr_number" --json headRefName --jq '.headRefName')"; then
+      echo "ERROR: could not resolve PR #$pr_number head branch." >&2
+      exit 1
+    fi
   fi
 fi
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4041,7 +4041,7 @@ if [ -z "$pr_number" ]; then
 fi
 
 if [ -n "$repo_selector" ]; then
-  if printf '%s\n' "$repo_selector" | grep -q '/'; then
+  if workflow_is_valid_github_repo_slug "$repo_selector"; then
     target_github_repo="$repo_selector"
   else
     repo_context="$(workflow_repository_context "$repo_selector" "$repo_root")"

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -169,6 +169,14 @@ branch_resolution_output="$(
 run_contains "workflow_branch_unresolved_repo_action" "NEXT_ACTION=resolve-repository-selection" "$branch_resolution_output"
 run_contains "workflow_branch_unresolved_repo_context" "ACTION_REPOSITORY_KIND=repository_resolution_failed" "$branch_resolution_output"
 
+pr_selection_output="$(
+  WORKFLOW_SKIP_FETCH=1 "$REPO_ROOT/scripts/development-workflow/workflow-next-action.sh" \
+    --repo-root "$hub_dir" \
+    --pr 123
+)"
+run_contains "workflow_pr_requires_repo_selection" "NEXT_ACTION=resolve-repository-selection" "$pr_selection_output"
+run_contains "workflow_pr_selection_required_context" "ACTION_REPOSITORY_KIND=repository_selection_required" "$pr_selection_output"
+
 run_fails_contains \
   "workflow_next_action_repo_requires_value" \
   "--repo requires a value." \

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -100,10 +100,16 @@ workflow_hub:
     - name: admin-portal
       git_url: git@github.com:example/admin-portal.git
       default_branch: develop
+    - name: trunk-app
+      github_repo: example/trunk-app
+      default_branch: trunk
 YAML
 cat > "$hub_dir/.ai-dev-workflow.local.yaml" <<'YAML'
 checkout_root: ../products
 YAML
+trunk_product_dir="$TMP_ROOT/products/trunk-app"
+mkdir -p "$trunk_product_dir"
+git -C "$trunk_product_dir" init -q -b trunk
 
 echo ""
 echo "=== Workflow orchestration product repository awareness ==="
@@ -231,6 +237,14 @@ run_fails_contains \
     --repo example/mobile-app \
     --poll-interval 1 \
     --max-wait 2
+
+run_fails_contains \
+  "post_merge_cleanup_refuses_product_default_branch" \
+  "Refusing to delete protected branch 'trunk'." \
+  "$REPO_ROOT/scripts/development-workflow/post-merge-cleanup.sh" \
+    --repo-root "$hub_dir" \
+    --repo trunk-app \
+    trunk
 
 echo ""
 echo "Passed: $PASS_COUNT"

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -87,6 +87,7 @@ single_dev="$(make_development "$single_dir")"
 
 hub_dir="$TMP_ROOT/hub"
 mkdir -p "$hub_dir"
+git -C "$hub_dir" init -q -b main
 hub_dev="$(make_development "$hub_dir")"
 cat > "$hub_dir/.ai-dev-workflow.yaml" <<'YAML'
 schema_version: 2
@@ -222,6 +223,10 @@ case "$1" in
       printf '{"statusCheckRollup":[]}\n'
       exit 0
     fi
+    if [ "$2" = "list" ]; then
+      printf '[]\n'
+      exit 0
+    fi
     ;;
   repo)
     if [ "$2" = "view" ]; then
@@ -235,6 +240,13 @@ echo "unexpected gh invocation: $*" >&2
 exit 1
 SH
 chmod +x "$stub_bin/gh"
+
+discover_output="$(
+  PATH="$stub_bin:$PATH" "$REPO_ROOT/scripts/development-workflow/discover-workflow-state.sh" \
+    --repo-root "$hub_dir" \
+    --repo mobile-app
+)"
+run_contains "discover_state_emits_action_github_repo" "ACTION_GITHUB_REPO=example/mobile-app" "$discover_output"
 
 ci_output="$(
   PATH="$stub_bin:$PATH" "$REPO_ROOT/scripts/development-workflow/pr-ci-loop.sh" \

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# test-workflow-orchestration-product-repo-aware.sh - workflow hub routing tests.
+#
+# Usage: bash scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+
+TMP_ROOT="$(mktemp -d)"
+TMP_ROOT="$(CDPATH='' cd -- "$TMP_ROOT" && pwd -P)"
+
+_harness_exit() {
+  local status=$?
+  rm -rf "$TMP_ROOT"
+  case "$status" in
+    141) exit 0 ;;
+    *)   exit "$status" ;;
+  esac
+}
+trap _harness_exit EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_contains() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if grep -Fq -- "$expected" <<< "$actual"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected output to contain '${expected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_fails_contains() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  local output=""
+  local status=0
+
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+
+  if [ "$status" -ne 0 ] && grep -Fq -- "$expected" <<< "$output"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected failure containing '${expected}'"
+    printf 'Status: %s\nOutput:\n%s\n' "$status" "$output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+make_development() {
+  local root="$1"
+  local path="$root/docs/specs/developments/20260611120000_900-product-routing"
+  mkdir -p "$path"
+  cat > "$path/1_900-product-routing_specs.md" <<'MD'
+# Product Routing Spec
+
+## Acceptance Criteria
+
+- [ ] Implementation work targets a selected product repository.
+MD
+  cat > "$path/2_900-product-routing_implementation-plan.md" <<'MD'
+# Product Routing Implementation Plan
+
+## Summary
+
+Route implementation work to a product repository.
+MD
+  printf '%s\n' "$path"
+}
+
+single_dir="$TMP_ROOT/single"
+mkdir -p "$single_dir"
+single_dev="$(make_development "$single_dir")"
+
+hub_dir="$TMP_ROOT/hub"
+mkdir -p "$hub_dir"
+hub_dev="$(make_development "$hub_dir")"
+cat > "$hub_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      default_branch: main
+    - name: admin-portal
+      git_url: git@github.com:example/admin-portal.git
+      default_branch: develop
+YAML
+cat > "$hub_dir/.ai-dev-workflow.local.yaml" <<'YAML'
+checkout_root: ../products
+YAML
+
+echo ""
+echo "=== Workflow orchestration product repository awareness ==="
+
+single_output="$(
+  WORKFLOW_SKIP_FETCH=1 "$REPO_ROOT/scripts/development-workflow/workflow-next-action.sh" \
+    --repo-root "$single_dir" \
+    --development "$single_dev"
+)"
+run_contains "single_repo_next_action_context" "WORKFLOW_MODE=single_repo" "$single_output"
+run_contains "single_repo_action_kind" "ACTION_REPOSITORY_KIND=single_repo_context" "$single_output"
+
+selected_output="$(
+  WORKFLOW_SKIP_FETCH=1 "$REPO_ROOT/scripts/development-workflow/workflow-next-action.sh" \
+    --repo-root "$hub_dir" \
+    --repo mobile-app \
+    --development "$hub_dev"
+)"
+run_contains "workflow_hub_next_action_context" "WORKFLOW_MODE=workflow_hub" "$selected_output"
+run_contains "workflow_hub_product_owner" "ACTION_REPOSITORY_KIND=product_repo_owned" "$selected_output"
+run_contains "workflow_hub_product_repo_name" "ACTION_REPOSITORY=mobile-app" "$selected_output"
+run_contains "workflow_hub_product_github_repo" "ACTION_GITHUB_REPO=example/mobile-app" "$selected_output"
+
+run_fails_contains \
+  "workflow_hub_implementation_requires_repo_selection" \
+  "product repository selection is ambiguous" \
+  env WORKFLOW_SKIP_FETCH=1 "$REPO_ROOT/scripts/development-workflow/workflow-next-action.sh" \
+    --repo-root "$hub_dir" \
+    --development "$hub_dev"
+
+batch_output="$(
+  WORKFLOW_SKIP_FETCH=1 "$REPO_ROOT/scripts/development-workflow/workflow-batch-plan.sh" \
+    --repo-root "$hub_dir" \
+    --repo admin-portal \
+    "$hub_dev"
+)"
+run_contains "batch_plan_preserves_action_kind" "ACTION_REPOSITORY_KIND=product_repo_owned" "$batch_output"
+run_contains "batch_plan_derives_github_repo_from_git_url" "ACTION_GITHUB_REPO=example/admin-portal" "$batch_output"
+
+stub_bin="$TMP_ROOT/bin"
+mkdir -p "$stub_bin"
+cat > "$stub_bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$1" in
+  auth)
+    exit 0
+    ;;
+  pr)
+    if [ "$2" = "view" ]; then
+      printf '{"statusCheckRollup":[]}\n'
+      exit 0
+    fi
+    ;;
+  repo)
+    if [ "$2" = "view" ]; then
+      printf '{"nameWithOwner":"example/hub"}\n'
+      exit 0
+    fi
+    ;;
+esac
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+SH
+chmod +x "$stub_bin/gh"
+
+ci_output="$(
+  PATH="$stub_bin:$PATH" "$REPO_ROOT/scripts/development-workflow/pr-ci-loop.sh" \
+    7 \
+    --repo example/mobile-app \
+    --poll-interval 1 \
+    --max-wait 2
+)"
+run_contains "ci_loop_targets_explicit_repo" "REPO=example/mobile-app" "$ci_output"
+run_contains "ci_loop_reports_green" "RESULT=green" "$ci_output"
+
+echo ""
+echo "Passed: $PASS_COUNT"
+echo "Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -287,6 +287,13 @@ run_fails_contains \
     --repo trunk-app \
     trunk
 
+run_fails_contains \
+  "post_merge_cleanup_implementation_requires_repo_selection" \
+  "pass --repo <name>" \
+  "$REPO_ROOT/scripts/development-workflow/post-merge-cleanup.sh" \
+    --repo-root "$hub_dir" \
+    feature/900-product-routing
+
 echo ""
 echo "Passed: $PASS_COUNT"
 echo "Failed: $FAIL_COUNT"

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -199,6 +199,22 @@ batch_output="$(
 run_contains "batch_plan_preserves_action_kind" "ACTION_REPOSITORY_KIND=product_repo_owned" "$batch_output"
 run_contains "batch_plan_derives_github_repo_from_git_url" "ACTION_GITHUB_REPO=example/admin-portal" "$batch_output"
 
+run_fails_contains \
+  "batch_plan_repo_rejects_next_flag_as_value" \
+  "--repo requires a value." \
+  env WORKFLOW_SKIP_FETCH=1 "$REPO_ROOT/scripts/development-workflow/workflow-batch-plan.sh" \
+    --repo \
+    --repo-root "$hub_dir" \
+    "$hub_dev"
+
+run_fails_contains \
+  "batch_plan_repo_root_rejects_next_flag_as_value" \
+  "--repo-root requires a value." \
+  env WORKFLOW_SKIP_FETCH=1 "$REPO_ROOT/scripts/development-workflow/workflow-batch-plan.sh" \
+    --repo-root \
+    --repo admin-portal \
+    "$hub_dev"
+
 stub_bin="$TMP_ROOT/bin"
 mkdir -p "$stub_bin"
 cat > "$stub_bin/gh" <<'SH'

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -160,6 +160,15 @@ run_fails_contains \
     --repo-root "$hub_dir" \
     --development "$hub_dev"
 
+branch_resolution_output="$(
+  WORKFLOW_SKIP_FETCH=1 "$REPO_ROOT/scripts/development-workflow/workflow-next-action.sh" \
+    --repo-root "$hub_dir" \
+    --repo missing-app \
+    --branch feature/900-product-routing
+)"
+run_contains "workflow_branch_unresolved_repo_action" "NEXT_ACTION=resolve-repository-selection" "$branch_resolution_output"
+run_contains "workflow_branch_unresolved_repo_context" "ACTION_REPOSITORY_KIND=repository_resolution_failed" "$branch_resolution_output"
+
 run_fails_contains \
   "workflow_next_action_repo_requires_value" \
   "--repo requires a value." \

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -160,6 +160,18 @@ run_fails_contains \
     --repo-root "$hub_dir" \
     --development "$hub_dev"
 
+run_fails_contains \
+  "workflow_next_action_repo_requires_value" \
+  "--repo requires a value." \
+  "$REPO_ROOT/scripts/development-workflow/workflow-next-action.sh" \
+    --repo
+
+run_fails_contains \
+  "workflow_next_action_repo_root_requires_value" \
+  "--repo-root requires a value." \
+  "$REPO_ROOT/scripts/development-workflow/workflow-next-action.sh" \
+    --repo-root
+
 batch_output="$(
   WORKFLOW_SKIP_FETCH=1 "$REPO_ROOT/scripts/development-workflow/workflow-batch-plan.sh" \
     --repo-root "$hub_dir" \

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -112,6 +112,20 @@ trunk_product_dir="$TMP_ROOT/products/trunk-app"
 mkdir -p "$trunk_product_dir"
 git -C "$trunk_product_dir" init -q -b trunk
 
+solo_hub_dir="$TMP_ROOT/solo-hub"
+mkdir -p "$solo_hub_dir"
+git -C "$solo_hub_dir" init -q -b main
+cat > "$solo_hub_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      default_branch: main
+YAML
+
 echo ""
 echo "=== Workflow orchestration product repository awareness ==="
 
@@ -236,7 +250,7 @@ case "$1" in
     ;;
   pr)
     if [ "$2" = "view" ]; then
-      printf '{"statusCheckRollup":[]}\n'
+      printf '{"headRefName":"feature/900-product-routing","labels":[],"isDraft":false,"comments":[],"statusCheckRollup":[]}\n'
       exit 0
     fi
     if [ "$2" = "list" ]; then
@@ -263,6 +277,16 @@ discover_output="$(
     --repo mobile-app
 )"
 run_contains "discover_state_emits_action_github_repo" "ACTION_GITHUB_REPO=example/mobile-app" "$discover_output"
+
+pr_inferred_repo_log="$TMP_ROOT/pr-inferred-repo-gh-args.log"
+touch "$pr_inferred_repo_log"
+pr_inferred_output="$(
+  env GH_ARGS_LOG="$pr_inferred_repo_log" PATH="$stub_bin:$PATH" "$REPO_ROOT/scripts/development-workflow/workflow-next-action.sh" \
+    --repo-root "$solo_hub_dir" \
+    --pr 42
+)"
+run_contains "workflow_pr_infers_single_product_repo" "ACTION_GITHUB_REPO=example/mobile-app" "$pr_inferred_output"
+run_contains "workflow_pr_passes_inferred_repo_to_gh" "--repo example/mobile-app" "$(tr '\n' ' ' < "$pr_inferred_repo_log")"
 
 ci_output="$(
   PATH="$stub_bin:$PATH" "$REPO_ROOT/scripts/development-workflow/pr-ci-loop.sh" \

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -108,6 +108,26 @@ YAML
 echo ""
 echo "=== Workflow orchestration product repository awareness ==="
 
+lib_script="$REPO_ROOT/scripts/development-workflow/workflow-lib.sh"
+
+git_url_repo="$(
+  bash -c 'source "$1"; workflow_github_repo_from_git_url "$2"' \
+    bash "$lib_script" "ssh://git@github.com/example/admin-portal.git"
+)"
+run_contains "workflow_lib_derives_repo_from_ssh_url" "example/admin-portal" "$git_url_repo"
+
+env_repo="$(
+  bash -c 'source "$1"; WORKFLOW_TARGET_GITHUB_REPO=example/mobile-app repo_slug' \
+    bash "$lib_script"
+)"
+run_contains "workflow_lib_uses_valid_repo_override" "example/mobile-app" "$env_repo"
+
+run_fails_contains \
+  "workflow_lib_rejects_invalid_repo_override" \
+  "WORKFLOW_TARGET_GITHUB_REPO must be an owner/repo" \
+  bash -c 'source "$1"; WORKFLOW_TARGET_GITHUB_REPO=example/mobile/app repo_slug' \
+    bash "$lib_script"
+
 single_output="$(
   WORKFLOW_SKIP_FETCH=1 "$REPO_ROOT/scripts/development-workflow/workflow-next-action.sh" \
     --repo-root "$single_dir" \
@@ -149,6 +169,15 @@ cat > "$stub_bin/gh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [ "${GH_FAIL_PR_VIEW:-}" = "1" ] && [ "$1" = "pr" ] && [ "${2:-}" = "view" ]; then
+  echo "simulated pr view failure" >&2
+  exit 1
+fi
+
+if [ -n "${GH_ARGS_LOG:-}" ]; then
+  printf '%s\n' "$*" >> "$GH_ARGS_LOG"
+fi
+
 case "$1" in
   auth)
     exit 0
@@ -181,6 +210,27 @@ ci_output="$(
 )"
 run_contains "ci_loop_targets_explicit_repo" "REPO=example/mobile-app" "$ci_output"
 run_contains "ci_loop_reports_green" "RESULT=green" "$ci_output"
+
+ci_product_log="$TMP_ROOT/ci-product-gh-args.log"
+ci_product_output="$(
+  GH_ARGS_LOG="$ci_product_log" PATH="$stub_bin:$PATH" "$REPO_ROOT/scripts/development-workflow/pr-ci-loop.sh" \
+    8 \
+    --repo-root "$hub_dir" \
+    --product-repo mobile-app \
+    --poll-interval 1 \
+    --max-wait 2
+)"
+run_contains "ci_loop_resolves_product_repo" "REPO=example/mobile-app" "$ci_product_output"
+run_contains "ci_loop_passes_resolved_repo_to_gh" "--repo example/mobile-app" "$(tr '\n' ' ' < "$ci_product_log")"
+
+run_fails_contains \
+  "ci_loop_fails_closed_when_pr_status_unreadable" \
+  "REASON=pr_status_fetch_failed" \
+  env GH_FAIL_PR_VIEW=1 PATH="$stub_bin:$PATH" "$REPO_ROOT/scripts/development-workflow/pr-ci-loop.sh" \
+    9 \
+    --repo example/mobile-app \
+    --poll-interval 1 \
+    --max-wait 2
 
 echo ""
 echo "Passed: $PASS_COUNT"

--- a/scripts/development-workflow/workflow-batch-plan.sh
+++ b/scripts/development-workflow/workflow-batch-plan.sh
@@ -354,7 +354,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-cd "$repo_root"
+cd "$repo_root" || exit 1
 
 if [ "${#development_paths[@]}" -eq 0 ]; then
   if [ -d "docs/specs/developments" ]; then

--- a/scripts/development-workflow/workflow-batch-plan.sh
+++ b/scripts/development-workflow/workflow-batch-plan.sh
@@ -333,7 +333,7 @@ target_repo=""
 repo_root="$(workflow_repo_root)"
 development_paths=()
 
-require_option_value() {
+option_value_or_exit() {
   local option="$1"
   local value="${2:-}"
   if [ -z "$value" ] || [[ "$value" == --* ]]; then
@@ -341,18 +341,17 @@ require_option_value() {
     usage >&2
     exit 64
   fi
+  printf '%s\n' "$value"
 }
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --repo)
-      require_option_value "$1" "${2:-}"
-      target_repo="$2"
+      target_repo="$(option_value_or_exit "$1" "${2:-}")"
       shift 2
       ;;
     --repo-root)
-      require_option_value "$1" "${2:-}"
-      repo_root="$2"
+      repo_root="$(option_value_or_exit "$1" "${2:-}")"
       shift 2
       ;;
     -h|--help)

--- a/scripts/development-workflow/workflow-batch-plan.sh
+++ b/scripts/development-workflow/workflow-batch-plan.sh
@@ -9,7 +9,7 @@ source "$SCRIPT_DIR/workflow-lib.sh"
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/development-workflow/workflow-batch-plan.sh [development-path ...]
+  ./scripts/development-workflow/workflow-batch-plan.sh [--repo <name>] [--repo-root <path>] [development-path ...]
 
 Classifies development folders into batch-planning candidates for the batch
 orchestrator. If no paths are given, scans docs/specs/developments/*.
@@ -329,23 +329,38 @@ extract_github_issue_number() {
   printf '%s' "${issue_number:-}"
 }
 
-cd_workflow_repo_root
+target_repo=""
+repo_root="$(workflow_repo_root)"
+development_paths=()
 
-if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
-  usage
-  exit 0
-fi
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      target_repo="${2:?--repo requires a value}"
+      shift 2
+      ;;
+    --repo-root)
+      repo_root="${2:?--repo-root requires a value}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      development_paths+=("$1")
+      shift
+      ;;
+  esac
+done
 
-if [ "$#" -gt 0 ]; then
-  development_paths=("$@")
-else
+cd "$repo_root"
+
+if [ "${#development_paths[@]}" -eq 0 ]; then
   if [ -d "docs/specs/developments" ]; then
-    development_paths=()
     while IFS= read -r path; do
       development_paths+=("$path")
     done < <(find "docs/specs/developments" -mindepth 1 -maxdepth 1 -type d | sort)
-  else
-    development_paths=()
   fi
 fi
 
@@ -419,7 +434,9 @@ for development_path in "${development_paths[@]}"; do
     tool_fix_files="$(printf '%s\n' "$tool_fix_output" | sed -n '2p')"
   fi
 
-  if ! next_action_output="$("$SCRIPT_DIR/workflow-next-action.sh" --development "$development_path" 2>&1)"; then
+  next_action_args=(--development "$development_path" --repo-root "$repo_root")
+  [ -n "$target_repo" ] && next_action_args+=(--repo "$target_repo")
+  if ! next_action_output="$("$SCRIPT_DIR/workflow-next-action.sh" "${next_action_args[@]}" 2>&1)"; then
     # next-action failed (e.g., no merged spec/plan PR yet).  Emit an abbreviated
     # block so the orchestrator still sees TOOL_FIX for this folder.
     echo "Skipping $development_path: $next_action_output" >&2
@@ -435,11 +452,21 @@ for development_path in "${development_paths[@]}"; do
   status=""
   next_action=""
   linear_issue=""
+  workflow_mode=""
+  action_repository_kind=""
+  action_repository=""
+  action_github_repo=""
+  action_local_path=""
   while IFS='=' read -r key value; do
     case "$key" in
       STATUS) status="$value" ;;
       NEXT_ACTION) next_action="$value" ;;
       LINEAR_ISSUE) linear_issue="$value" ;;
+      WORKFLOW_MODE) workflow_mode="$value" ;;
+      ACTION_REPOSITORY_KIND) action_repository_kind="$value" ;;
+      ACTION_REPOSITORY) action_repository="$value" ;;
+      ACTION_GITHUB_REPO) action_github_repo="$value" ;;
+      ACTION_LOCAL_PATH) action_local_path="$value" ;;
     esac
   done <<< "$next_action_output"
 
@@ -470,6 +497,11 @@ for development_path in "${development_paths[@]}"; do
   [ -n "$linear_issue" ] && print_kv LINEAR_ISSUE "$linear_issue"
   print_kv STATUS "$status"
   print_kv NEXT_ACTION "$next_action"
+  [ -n "$workflow_mode" ] && print_kv WORKFLOW_MODE "$workflow_mode"
+  [ -n "$action_repository_kind" ] && print_kv ACTION_REPOSITORY_KIND "$action_repository_kind"
+  [ -n "$action_repository" ] && print_kv ACTION_REPOSITORY "$action_repository"
+  [ -n "$action_github_repo" ] && print_kv ACTION_GITHUB_REPO "$action_github_repo"
+  [ -n "$action_local_path" ] && print_kv ACTION_LOCAL_PATH "$action_local_path"
   print_kv BATCH_HINT "$(batch_hint_for_action "$next_action")"
   print_kv PARALLEL_SAFE "$(parallel_safe_for_action "$next_action")"
   print_kv TOOL_FIX "$tool_fix"

--- a/scripts/development-workflow/workflow-batch-plan.sh
+++ b/scripts/development-workflow/workflow-batch-plan.sh
@@ -347,12 +347,16 @@ option_value_or_exit() {
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --repo)
-      target_repo="$(option_value_or_exit "$1" "${2:-}")"
-      shift 2
+      option="$1"
+      shift
+      target_repo="$(option_value_or_exit "$option" "${1:-}")"
+      shift
       ;;
     --repo-root)
-      repo_root="$(option_value_or_exit "$1" "${2:-}")"
-      shift 2
+      option="$1"
+      shift
+      repo_root="$(option_value_or_exit "$option" "${1:-}")"
+      shift
       ;;
     -h|--help)
       usage

--- a/scripts/development-workflow/workflow-batch-plan.sh
+++ b/scripts/development-workflow/workflow-batch-plan.sh
@@ -335,7 +335,8 @@ development_paths=()
 
 require_option_value() {
   local option="$1"
-  if [ "$#" -lt 2 ] || [ -z "${2:-}" ] || [[ "${2:-}" == -* ]]; then
+  local value="${2:-}"
+  if [ -z "$value" ] || [[ "$value" == --* ]]; then
     echo "$option requires a value." >&2
     usage >&2
     exit 64
@@ -345,12 +346,12 @@ require_option_value() {
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --repo)
-      require_option_value "$@"
+      require_option_value "$1" "${2:-}"
       target_repo="$2"
       shift 2
       ;;
     --repo-root)
-      require_option_value "$@"
+      require_option_value "$1" "${2:-}"
       repo_root="$2"
       shift 2
       ;;

--- a/scripts/development-workflow/workflow-batch-plan.sh
+++ b/scripts/development-workflow/workflow-batch-plan.sh
@@ -333,14 +333,25 @@ target_repo=""
 repo_root="$(workflow_repo_root)"
 development_paths=()
 
+require_option_value() {
+  local option="$1"
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ]; then
+    echo "$option requires a value." >&2
+    usage >&2
+    exit 64
+  fi
+}
+
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --repo)
-      target_repo="${2:?--repo requires a value}"
+      require_option_value "$@"
+      target_repo="$2"
       shift 2
       ;;
     --repo-root)
-      repo_root="${2:?--repo-root requires a value}"
+      require_option_value "$@"
+      repo_root="$2"
       shift 2
       ;;
     -h|--help)

--- a/scripts/development-workflow/workflow-batch-plan.sh
+++ b/scripts/development-workflow/workflow-batch-plan.sh
@@ -335,7 +335,7 @@ development_paths=()
 
 require_option_value() {
   local option="$1"
-  if [ "$#" -lt 2 ] || [ -z "${2:-}" ]; then
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ] || [[ "${2:-}" == -* ]]; then
     echo "$option requires a value." >&2
     usage >&2
     exit 64

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -47,6 +47,10 @@ require_gh() {
 
 repo_slug() {
   if [ -n "${WORKFLOW_TARGET_GITHUB_REPO:-}" ]; then
+    if ! workflow_is_valid_github_repo_slug "$WORKFLOW_TARGET_GITHUB_REPO"; then
+      echo "ERROR: WORKFLOW_TARGET_GITHUB_REPO must be an owner/repo GitHub repository slug." >&2
+      return 1
+    fi
     printf '%s\n' "$WORKFLOW_TARGET_GITHUB_REPO"
     return 0
   fi
@@ -192,7 +196,7 @@ is_soft_suggestion() {
 
 open_pr_number_for_branch() {
   require_gh
-  gh pr list --head "$1" --state open --json number --jq '.[0].number // empty'
+  gh pr list --head "$1" --state open --limit 100 --json number --jq '.[0].number // empty'
 }
 
 workflow_config_review_nested_list() {
@@ -724,6 +728,17 @@ workflow_is_valid_github_repo_name() {
       return 1
       ;;
   esac
+  return 0
+}
+
+workflow_is_valid_github_repo_slug() {
+  local repo_slug="$1"
+  local owner="${repo_slug%%/*}"
+  local repo_name="${repo_slug#*/}"
+
+  [ "$owner/$repo_name" = "$repo_slug" ] || return 1
+  workflow_is_valid_github_owner "$owner" || return 1
+  workflow_is_valid_github_repo_name "$repo_name" || return 1
   return 0
 }
 

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -46,7 +46,60 @@ require_gh() {
 }
 
 repo_slug() {
+  if [ -n "${WORKFLOW_TARGET_GITHUB_REPO:-}" ]; then
+    printf '%s\n' "$WORKFLOW_TARGET_GITHUB_REPO"
+    return 0
+  fi
   gh repo view --json nameWithOwner --jq '.nameWithOwner'
+}
+
+workflow_context_value() {
+  local key="$1"
+  local context="${2:-}"
+
+  printf '%s\n' "$context" | awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }'
+}
+
+workflow_github_repo_from_git_url() {
+  local git_url="$1"
+  local remote_path=""
+
+  case "$git_url" in
+    https://github.com/*)
+      remote_path="${git_url#https://github.com/}"
+      ;;
+    https://*@github.com/*)
+      remote_path="${git_url#https://*@github.com/}"
+      ;;
+    git@github.com:*)
+      remote_path="${git_url#git@github.com:}"
+      ;;
+    ssh://git@github.com/*)
+      remote_path="${git_url#ssh://git@github.com/}"
+      ;;
+  esac
+
+  remote_path="${remote_path%.git}"
+  if [ -n "$remote_path" ] && workflow_remote_path_has_single_repo "$remote_path"; then
+    printf '%s\n' "$remote_path"
+  fi
+}
+
+workflow_github_repo_from_context() {
+  local context="$1"
+  local github_repo
+  local git_url
+
+  github_repo="$(workflow_context_value TARGET_GITHUB_REPO "$context")"
+  if [ -n "$github_repo" ]; then
+    printf '%s\n' "$github_repo"
+    return 0
+  fi
+
+  git_url="$(workflow_context_value TARGET_GIT_URL "$context")"
+  if [ -n "$git_url" ]; then
+    workflow_github_repo_from_git_url "$git_url"
+  fi
 }
 
 branch_prefix() {

--- a/scripts/development-workflow/workflow-next-action.sh
+++ b/scripts/development-workflow/workflow-next-action.sh
@@ -130,6 +130,7 @@ repository_context_for_action() {
   print_kv ACTION_REPOSITORY "$action_repository"
   [ -n "$action_github_repo" ] && print_kv ACTION_GITHUB_REPO "$action_github_repo"
   [ -n "$action_local_path" ] && print_kv ACTION_LOCAL_PATH "$action_local_path"
+  return 0
 }
 
 github_repo_args_for_action() {
@@ -144,23 +145,26 @@ github_repo_args_for_action() {
       printf '%s\n%s\n' "--repo" "$action_github_repo"
     fi
   fi
+  return 0
 }
 
 if [ -n "$pr_number" ]; then
   if [ "$workflow_mode" = "workflow_hub" ] && [ -z "$target_repo" ]; then
-    print_kv WORKFLOW_MODE "$workflow_mode"
-    print_kv ACTION_REPOSITORY_KIND "repository_selection_required"
-    print_kv ACTION_REPOSITORY ""
-    print_kv TARGET "pr:$pr_number"
-    print_kv PR_NUMBER "$pr_number"
-    print_kv REVIEW_AGENT "none"
-    print_kv NEXT_ACTION "resolve-repository-selection"
-    print_kv ERROR "workflow_hub PR lookup requires --repo because PR numbers are repository-scoped."
-    exit 0
+    if ! pr_action_context="$(repository_context_for_action implementation 2>&1)"; then
+      print_kv WORKFLOW_MODE "$workflow_mode"
+      print_kv ACTION_REPOSITORY_KIND "repository_selection_required"
+      print_kv ACTION_REPOSITORY ""
+      print_kv TARGET "pr:$pr_number"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv REVIEW_AGENT "none"
+      print_kv NEXT_ACTION "resolve-repository-selection"
+      print_kv_escaped ERROR "$pr_action_context"
+      exit 0
+    fi
   fi
   require_gh
   pr_view_args=()
-  if [ "$workflow_mode" = "workflow_hub" ] && [ -n "$target_repo" ]; then
+  if [ "$workflow_mode" = "workflow_hub" ]; then
     while IFS= read -r arg; do
       [ -n "$arg" ] && pr_view_args+=("$arg")
     done < <(github_repo_args_for_action implementation)

--- a/scripts/development-workflow/workflow-next-action.sh
+++ b/scripts/development-workflow/workflow-next-action.sh
@@ -9,9 +9,9 @@ source "$SCRIPT_DIR/workflow-lib.sh"
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/development-workflow/workflow-next-action.sh --branch <branch>
-  ./scripts/development-workflow/workflow-next-action.sh --pr <number>
-  ./scripts/development-workflow/workflow-next-action.sh --development <path>
+  ./scripts/development-workflow/workflow-next-action.sh --branch <branch> [--repo <name>] [--repo-root <path>]
+  ./scripts/development-workflow/workflow-next-action.sh --pr <number> [--repo <name>] [--repo-root <path>]
+  ./scripts/development-workflow/workflow-next-action.sh --development <path> [--repo <name>] [--repo-root <path>]
 
 Classifies the next deterministic workflow action and prints stable key=value lines.
 
@@ -29,6 +29,8 @@ ere_escape() {
 branch_name=""
 pr_number=""
 development_path=""
+target_repo=""
+repo_root="$(workflow_repo_root)"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -42,6 +44,14 @@ while [ "$#" -gt 0 ]; do
       ;;
     --development)
       development_path="$2"
+      shift 2
+      ;;
+    --repo)
+      target_repo="$2"
+      shift 2
+      ;;
+    --repo-root)
+      repo_root="$2"
       shift 2
       ;;
     -h|--help)
@@ -65,13 +75,82 @@ if [ "$targets" -ne 1 ]; then
   exit 64
 fi
 
-cd_workflow_repo_root
+cd "$repo_root"
+
+mode_context="$(workflow_repository_mode "$repo_root")"
+workflow_mode="$(workflow_context_value WORKFLOW_MODE "$mode_context")"
+
+repository_context_for_action() {
+  local action_kind="$1"
+  local context=""
+  local action_repository_kind="single_repo_context"
+  local action_repository=""
+  local action_github_repo=""
+  local action_local_path=""
+
+  if [ "$workflow_mode" = "workflow_hub" ]; then
+    case "$action_kind" in
+      implementation)
+        if ! context="$(workflow_repository_context "$target_repo" "$repo_root")"; then
+          return 1
+        fi
+        action_repository_kind="product_repo_owned"
+        action_repository="$(workflow_context_value TARGET_REPO_NAME "$context")"
+        action_github_repo="$(workflow_github_repo_from_context "$context")"
+        action_local_path="$(workflow_context_value TARGET_LOCAL_PATH "$context")"
+        ;;
+      *)
+        action_repository_kind="hub_owned"
+        action_repository="$(basename "$repo_root")"
+        ;;
+    esac
+  else
+    context="$(workflow_repository_context "" "$repo_root")"
+    action_repository="$(workflow_context_value TARGET_REPO_NAME "$context")"
+    action_github_repo="$(workflow_github_repo_from_context "$context")"
+    action_local_path="$(workflow_context_value TARGET_LOCAL_PATH "$context")"
+  fi
+
+  print_kv WORKFLOW_MODE "$workflow_mode"
+  print_kv ACTION_REPOSITORY_KIND "$action_repository_kind"
+  print_kv ACTION_REPOSITORY "$action_repository"
+  [ -n "$action_github_repo" ] && print_kv ACTION_GITHUB_REPO "$action_github_repo"
+  [ -n "$action_local_path" ] && print_kv ACTION_LOCAL_PATH "$action_local_path"
+}
+
+github_repo_args_for_action() {
+  local action_kind="$1"
+  local context=""
+  local action_github_repo=""
+
+  if [ "$workflow_mode" = "workflow_hub" ] && [ "$action_kind" = "implementation" ]; then
+    context="$(workflow_repository_context "$target_repo" "$repo_root")"
+    action_github_repo="$(workflow_github_repo_from_context "$context")"
+    if [ -n "$action_github_repo" ]; then
+      printf '%s\n%s\n' "--repo" "$action_github_repo"
+    fi
+  fi
+}
 
 if [ -n "$pr_number" ]; then
   require_gh
-  pr_json="$(gh pr view "$pr_number" --json headRefName,labels,isDraft,comments)"
+  pr_view_args=()
+  if [ "$workflow_mode" = "workflow_hub" ] && [ -n "$target_repo" ]; then
+    while IFS= read -r arg; do
+      [ -n "$arg" ] && pr_view_args+=("$arg")
+    done < <(github_repo_args_for_action implementation)
+  fi
+  if [ "${#pr_view_args[@]}" -gt 0 ]; then
+    pr_json="$(gh pr view "$pr_number" "${pr_view_args[@]}" --json headRefName,labels,isDraft,comments)"
+  else
+    pr_json="$(gh pr view "$pr_number" --json headRefName,labels,isDraft,comments)"
+  fi
   branch_name="$(printf '%s\n' "$pr_json" | jq -r '.headRefName')"
   labels="$(printf '%s\n' "$pr_json" | jq -r '[.labels[].name] | join(",")')"
+  case "$(branch_prefix "$branch_name")" in
+    feature|refactor|fix|hotfix) repository_context_for_action implementation ;;
+    *) repository_context_for_action hub ;;
+  esac
 
   print_kv TARGET "pr:$pr_number"
   print_kv PR_NUMBER "$pr_number"
@@ -108,8 +187,25 @@ if [ -n "$pr_number" ]; then
 fi
 
 if [ -n "$branch_name" ]; then
+  case "$(branch_prefix "$branch_name")" in
+    feature|refactor|fix|hotfix) action_kind="implementation" ;;
+    *) action_kind="hub" ;;
+  esac
+  repository_context_for_action "$action_kind"
+  pr_list_args=()
+  pr_view_args=()
+  if [ "$action_kind" = "implementation" ]; then
+    while IFS= read -r arg; do
+      [ -n "$arg" ] && pr_list_args+=("$arg")
+      [ -n "$arg" ] && pr_view_args+=("$arg")
+    done < <(github_repo_args_for_action implementation)
+  fi
   if gh_available; then
-    pr_number="$(open_pr_number_for_branch "$branch_name")"
+    if [ "${#pr_list_args[@]}" -gt 0 ]; then
+      pr_number="$(gh pr list "${pr_list_args[@]}" --head "$branch_name" --state open --json number --jq '.[0].number // empty')"
+    else
+      pr_number="$(open_pr_number_for_branch "$branch_name")"
+    fi
   else
     pr_number=""
   fi
@@ -119,7 +215,11 @@ if [ -n "$branch_name" ]; then
   print_kv REVIEW_AGENT "$(reviewer_for_branch "$branch_name")"
 
   if [ -n "$pr_number" ]; then
-    pr_json="$(gh pr view "$pr_number" --json labels,isDraft,comments)"
+    if [ "${#pr_view_args[@]}" -gt 0 ]; then
+      pr_json="$(gh pr view "$pr_number" "${pr_view_args[@]}" --json labels,isDraft,comments)"
+    else
+      pr_json="$(gh pr view "$pr_number" --json labels,isDraft,comments)"
+    fi
     labels="$(printf '%s\n' "$pr_json" | jq -r '[.labels[].name] | join(",")')"
     print_kv PR_NUMBER "$pr_number"
     case ",$labels," in
@@ -238,13 +338,27 @@ feature_branch_merged=0
 if [ "$feature_branch_exists" -eq 0 ] && [ -n "$plan_file" ] && gh_available; then
   # Use the same scoped dev_prefix determined above (feature or refactor).
   # Try exact branch name first: [prefix]/<slug>
-  merged_count="$(gh pr list --state merged --head "${dev_prefix}/$slug" --json number --jq 'length' 2>/dev/null || echo 0)"
+  merged_pr_args=()
+  if [ "$dev_prefix" != "spec" ] && [ "$workflow_mode" = "workflow_hub" ]; then
+    while IFS= read -r arg; do
+      [ -n "$arg" ] && merged_pr_args+=("$arg")
+    done < <(github_repo_args_for_action implementation)
+  fi
+  if [ "${#merged_pr_args[@]}" -gt 0 ]; then
+    merged_count="$(gh pr list "${merged_pr_args[@]}" --state merged --head "${dev_prefix}/$slug" --json number --jq 'length' 2>/dev/null || echo 0)"
+  else
+    merged_count="$(gh pr list --state merged --head "${dev_prefix}/$slug" --json number --jq 'length' 2>/dev/null || echo 0)"
+  fi
   if [ "${merged_count:-0}" -gt 0 ]; then
     feature_branch_merged=1
   else
     # Try issue-tracker-prefixed pattern: [prefix]/<ISSUE-ID>-<slug>
     # Matches Linear (ENG-123), Jira (PROJ-456), and GitHub Issues (42) prefixes.
-    if gh pr list --state merged --limit 500 --json headRefName 2>/dev/null \
+    if { if [ "${#merged_pr_args[@]}" -gt 0 ]; then
+           gh pr list "${merged_pr_args[@]}" --state merged --limit 500 --json headRefName 2>/dev/null
+         else
+           gh pr list --state merged --limit 500 --json headRefName 2>/dev/null
+         fi; } \
         | jq -r '.[].headRefName' 2>/dev/null \
         | sed -n "s|^${dev_prefix}/||p" \
         | grep -qE "^([A-Z]+-)?[0-9]+-${slug_ere}$"; then
@@ -287,6 +401,10 @@ print_kv TARGET "development:$development_path"
 [ -n "$spec_file" ] && print_kv SPEC_FILE "$spec_file"
 print_kv STATUS "$status_line"
 print_kv NEXT_ACTION "$next_action"
+case "$next_action" in
+  implement|resolve-development-pr) repository_context_for_action implementation ;;
+  *) repository_context_for_action hub ;;
+esac
 
 # Optional: read Linear issue ID from spec for orchestrator (tracker is source of truth for status)
 linear_issue=""

--- a/scripts/development-workflow/workflow-next-action.sh
+++ b/scripts/development-workflow/workflow-next-action.sh
@@ -32,25 +32,39 @@ development_path=""
 target_repo=""
 repo_root="$(workflow_repo_root)"
 
+require_option_value() {
+  local option="$1"
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ]; then
+    echo "$option requires a value." >&2
+    usage >&2
+    exit 64
+  fi
+}
+
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --branch)
+      require_option_value "$@"
       branch_name="$2"
       shift 2
       ;;
     --pr)
+      require_option_value "$@"
       pr_number="$2"
       shift 2
       ;;
     --development)
+      require_option_value "$@"
       development_path="$2"
       shift 2
       ;;
     --repo)
+      require_option_value "$@"
       target_repo="$2"
       shift 2
       ;;
     --repo-root)
+      require_option_value "$@"
       repo_root="$2"
       shift 2
       ;;

--- a/scripts/development-workflow/workflow-next-action.sh
+++ b/scripts/development-workflow/workflow-next-action.sh
@@ -393,12 +393,12 @@ if [ "$feature_branch_exists" -eq 0 ] && [ -n "$plan_file" ] && gh_available; th
     done < <(github_repo_args_for_action implementation)
   fi
   if [ "${#merged_pr_args[@]}" -gt 0 ]; then
-    if ! merged_count="$(gh pr list "${merged_pr_args[@]}" --state merged --head "${dev_prefix}/$slug" --limit 100 --json number --jq 'length' 2>/dev/null)"; then
+    if ! merged_count="$(gh pr list "${merged_pr_args[@]}" --state merged --head "${dev_prefix}/$slug" --limit 100 --json number --jq 'length')"; then
       echo "workflow-next-action.sh: warning: could not query merged PRs for ${dev_prefix}/$slug; treating as not merged" >&2
       merged_count=0
     fi
   else
-    if ! merged_count="$(gh pr list --state merged --head "${dev_prefix}/$slug" --limit 100 --json number --jq 'length' 2>/dev/null)"; then
+    if ! merged_count="$(gh pr list --state merged --head "${dev_prefix}/$slug" --limit 100 --json number --jq 'length')"; then
       echo "workflow-next-action.sh: warning: could not query merged PRs for ${dev_prefix}/$slug; treating as not merged" >&2
       merged_count=0
     fi
@@ -410,10 +410,10 @@ if [ "$feature_branch_exists" -eq 0 ] && [ -n "$plan_file" ] && gh_available; th
     # Matches Linear (ENG-123), Jira (PROJ-456), and GitHub Issues (42) prefixes.
     merged_heads_json=""
     if [ "${#merged_pr_args[@]}" -gt 0 ]; then
-      if ! merged_heads_json="$(gh pr list "${merged_pr_args[@]}" --state merged --limit 500 --json headRefName 2>/dev/null)"; then
+      if ! merged_heads_json="$(gh pr list "${merged_pr_args[@]}" --state merged --limit 500 --json headRefName)"; then
         echo "workflow-next-action.sh: warning: could not scan merged PR heads; treating as not merged" >&2
       fi
-    elif ! merged_heads_json="$(gh pr list --state merged --limit 500 --json headRefName 2>/dev/null)"; then
+    elif ! merged_heads_json="$(gh pr list --state merged --limit 500 --json headRefName)"; then
       echo "workflow-next-action.sh: warning: could not scan merged PR heads; treating as not merged" >&2
     fi
     if [ -n "$merged_heads_json" ]; then

--- a/scripts/development-workflow/workflow-next-action.sh
+++ b/scripts/development-workflow/workflow-next-action.sh
@@ -141,9 +141,15 @@ if [ -n "$pr_number" ]; then
     done < <(github_repo_args_for_action implementation)
   fi
   if [ "${#pr_view_args[@]}" -gt 0 ]; then
-    pr_json="$(gh pr view "$pr_number" "${pr_view_args[@]}" --json headRefName,labels,isDraft,comments)"
+    if ! pr_json="$(gh pr view "$pr_number" "${pr_view_args[@]}" --json headRefName,labels,isDraft,comments)"; then
+      echo "ERROR: could not read PR #$pr_number from the selected GitHub repository." >&2
+      exit 1
+    fi
   else
-    pr_json="$(gh pr view "$pr_number" --json headRefName,labels,isDraft,comments)"
+    if ! pr_json="$(gh pr view "$pr_number" --json headRefName,labels,isDraft,comments)"; then
+      echo "ERROR: could not read PR #$pr_number." >&2
+      exit 1
+    fi
   fi
   branch_name="$(printf '%s\n' "$pr_json" | jq -r '.headRefName')"
   labels="$(printf '%s\n' "$pr_json" | jq -r '[.labels[].name] | join(",")')"
@@ -202,7 +208,7 @@ if [ -n "$branch_name" ]; then
   fi
   if gh_available; then
     if [ "${#pr_list_args[@]}" -gt 0 ]; then
-      pr_number="$(gh pr list "${pr_list_args[@]}" --head "$branch_name" --state open --json number --jq '.[0].number // empty')"
+      pr_number="$(gh pr list "${pr_list_args[@]}" --head "$branch_name" --state open --limit 100 --json number --jq '.[0].number // empty')"
     else
       pr_number="$(open_pr_number_for_branch "$branch_name")"
     fi
@@ -216,9 +222,15 @@ if [ -n "$branch_name" ]; then
 
   if [ -n "$pr_number" ]; then
     if [ "${#pr_view_args[@]}" -gt 0 ]; then
-      pr_json="$(gh pr view "$pr_number" "${pr_view_args[@]}" --json labels,isDraft,comments)"
+      if ! pr_json="$(gh pr view "$pr_number" "${pr_view_args[@]}" --json labels,isDraft,comments)"; then
+        echo "ERROR: could not read PR #$pr_number from the selected GitHub repository." >&2
+        exit 1
+      fi
     else
-      pr_json="$(gh pr view "$pr_number" --json labels,isDraft,comments)"
+      if ! pr_json="$(gh pr view "$pr_number" --json labels,isDraft,comments)"; then
+        echo "ERROR: could not read PR #$pr_number." >&2
+        exit 1
+      fi
     fi
     labels="$(printf '%s\n' "$pr_json" | jq -r '[.labels[].name] | join(",")')"
     print_kv PR_NUMBER "$pr_number"
@@ -345,24 +357,36 @@ if [ "$feature_branch_exists" -eq 0 ] && [ -n "$plan_file" ] && gh_available; th
     done < <(github_repo_args_for_action implementation)
   fi
   if [ "${#merged_pr_args[@]}" -gt 0 ]; then
-    merged_count="$(gh pr list "${merged_pr_args[@]}" --state merged --head "${dev_prefix}/$slug" --json number --jq 'length' 2>/dev/null || echo 0)"
+    if ! merged_count="$(gh pr list "${merged_pr_args[@]}" --state merged --head "${dev_prefix}/$slug" --limit 100 --json number --jq 'length' 2>/dev/null)"; then
+      echo "workflow-next-action.sh: warning: could not query merged PRs for ${dev_prefix}/$slug; treating as not merged" >&2
+      merged_count=0
+    fi
   else
-    merged_count="$(gh pr list --state merged --head "${dev_prefix}/$slug" --json number --jq 'length' 2>/dev/null || echo 0)"
+    if ! merged_count="$(gh pr list --state merged --head "${dev_prefix}/$slug" --limit 100 --json number --jq 'length' 2>/dev/null)"; then
+      echo "workflow-next-action.sh: warning: could not query merged PRs for ${dev_prefix}/$slug; treating as not merged" >&2
+      merged_count=0
+    fi
   fi
   if [ "${merged_count:-0}" -gt 0 ]; then
     feature_branch_merged=1
   else
     # Try issue-tracker-prefixed pattern: [prefix]/<ISSUE-ID>-<slug>
     # Matches Linear (ENG-123), Jira (PROJ-456), and GitHub Issues (42) prefixes.
-    if { if [ "${#merged_pr_args[@]}" -gt 0 ]; then
-           gh pr list "${merged_pr_args[@]}" --state merged --limit 500 --json headRefName 2>/dev/null
-         else
-           gh pr list --state merged --limit 500 --json headRefName 2>/dev/null
-         fi; } \
-        | jq -r '.[].headRefName' 2>/dev/null \
-        | sed -n "s|^${dev_prefix}/||p" \
-        | grep -qE "^([A-Z]+-)?[0-9]+-${slug_ere}$"; then
-      feature_branch_merged=1
+    merged_heads_json=""
+    if [ "${#merged_pr_args[@]}" -gt 0 ]; then
+      if ! merged_heads_json="$(gh pr list "${merged_pr_args[@]}" --state merged --limit 500 --json headRefName 2>/dev/null)"; then
+        echo "workflow-next-action.sh: warning: could not scan merged PR heads; treating as not merged" >&2
+      fi
+    elif ! merged_heads_json="$(gh pr list --state merged --limit 500 --json headRefName 2>/dev/null)"; then
+      echo "workflow-next-action.sh: warning: could not scan merged PR heads; treating as not merged" >&2
+    fi
+    if [ -n "$merged_heads_json" ]; then
+      if printf '%s\n' "$merged_heads_json" \
+          | jq -r '.[].headRefName' 2>/dev/null \
+          | sed -n "s|^${dev_prefix}/||p" \
+          | grep -qE "^([A-Z]+-)?[0-9]+-${slug_ere}$"; then
+        feature_branch_merged=1
+      fi
     fi
   fi
 fi

--- a/scripts/development-workflow/workflow-next-action.sh
+++ b/scripts/development-workflow/workflow-next-action.sh
@@ -458,8 +458,18 @@ fi
 # PLAN_FILE is intentionally not emitted; callers that need the path should scan
 # "$development_path"/2_*_implementation-plan.md directly.
 case "$next_action" in
-  implement|resolve-development-pr) action_context_output="$(repository_context_for_action implementation)" ;;
-  *) action_context_output="$(repository_context_for_action hub)" ;;
+  implement|resolve-development-pr)
+    if ! action_context_output="$(repository_context_for_action implementation 2>&1)"; then
+      echo "ERROR: $action_context_output" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    if ! action_context_output="$(repository_context_for_action hub 2>&1)"; then
+      echo "ERROR: $action_context_output" >&2
+      exit 1
+    fi
+    ;;
 esac
 print_kv TARGET "development:$development_path"
 [ -n "$spec_file" ] && print_kv SPEC_FILE "$spec_file"

--- a/scripts/development-workflow/workflow-next-action.sh
+++ b/scripts/development-workflow/workflow-next-action.sh
@@ -147,6 +147,17 @@ github_repo_args_for_action() {
 }
 
 if [ -n "$pr_number" ]; then
+  if [ "$workflow_mode" = "workflow_hub" ] && [ -z "$target_repo" ]; then
+    print_kv WORKFLOW_MODE "$workflow_mode"
+    print_kv ACTION_REPOSITORY_KIND "repository_selection_required"
+    print_kv ACTION_REPOSITORY ""
+    print_kv TARGET "pr:$pr_number"
+    print_kv PR_NUMBER "$pr_number"
+    print_kv REVIEW_AGENT "none"
+    print_kv NEXT_ACTION "resolve-repository-selection"
+    print_kv ERROR "workflow_hub PR lookup requires --repo because PR numbers are repository-scoped."
+    exit 0
+  fi
   require_gh
   pr_view_args=()
   if [ "$workflow_mode" = "workflow_hub" ] && [ -n "$target_repo" ]; then

--- a/scripts/development-workflow/workflow-next-action.sh
+++ b/scripts/development-workflow/workflow-next-action.sh
@@ -211,7 +211,17 @@ if [ -n "$branch_name" ]; then
     feature|refactor|fix|hotfix) action_kind="implementation" ;;
     *) action_kind="hub" ;;
   esac
-  repository_context_for_action "$action_kind"
+  if ! action_context_output="$(repository_context_for_action "$action_kind" 2>&1)"; then
+    print_kv WORKFLOW_MODE "$workflow_mode"
+    print_kv ACTION_REPOSITORY_KIND "repository_resolution_failed"
+    print_kv ACTION_REPOSITORY ""
+    print_kv TARGET "branch:$branch_name"
+    print_kv BRANCH "$branch_name"
+    print_kv REVIEW_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv NEXT_ACTION "resolve-repository-selection"
+    print_kv_escaped ERROR "$action_context_output"
+    exit 0
+  fi
   pr_list_args=()
   pr_view_args=()
   if [ "$action_kind" = "implementation" ]; then
@@ -230,6 +240,7 @@ if [ -n "$branch_name" ]; then
     pr_number=""
   fi
 
+  printf '%s\n' "$action_context_output"
   print_kv TARGET "branch:$branch_name"
   print_kv BRANCH "$branch_name"
   print_kv REVIEW_AGENT "$(reviewer_for_branch "$branch_name")"
@@ -435,14 +446,15 @@ fi
 
 # PLAN_FILE is intentionally not emitted; callers that need the path should scan
 # "$development_path"/2_*_implementation-plan.md directly.
+case "$next_action" in
+  implement|resolve-development-pr) action_context_output="$(repository_context_for_action implementation)" ;;
+  *) action_context_output="$(repository_context_for_action hub)" ;;
+esac
 print_kv TARGET "development:$development_path"
 [ -n "$spec_file" ] && print_kv SPEC_FILE "$spec_file"
 print_kv STATUS "$status_line"
 print_kv NEXT_ACTION "$next_action"
-case "$next_action" in
-  implement|resolve-development-pr) repository_context_for_action implementation ;;
-  *) repository_context_for_action hub ;;
-esac
+printf '%s\n' "$action_context_output"
 
 # Optional: read Linear issue ID from spec for orchestrator (tracker is source of truth for status)
 linear_issue=""


### PR DESCRIPTION
## Summary

Implements #878 by making workflow orchestration scripts product-repository aware for workflow hub mode while preserving current single-repository behavior.

- Adds repository-context output to discovery, next-action, and batch planning.
- Routes implementation PR review and CI loops to an explicit product `owner/repo` or configured product repo name.
- Lets post-merge cleanup delete implementation branches in the selected product checkout while keeping tracker updates in the hub.
- Documents orchestration ownership and adds fixture coverage for single-repo and multi-product workflow-hub paths.

## Spec and plan

- Spec: `docs/specs/developments/20260610164605_878-workflow-orchestration-product-repo-aware/1_878-workflow-orchestration-product-repo-aware_specs.md`
- Plan: `docs/specs/developments/20260610164605_878-workflow-orchestration-product-repo-aware/2_878-workflow-orchestration-product-repo-aware_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/878-workflow-orchestration-product-repo-aware.smoke-test.md`

## Test plan

- `bash scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh`
- `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh`
- `python3 -m py_compile scripts/development-workflow/workflow-config-resolver.py`
- `bash -n scripts/development-workflow/discover-workflow-state.sh scripts/development-workflow/workflow-next-action.sh scripts/development-workflow/workflow-batch-plan.sh scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/pr-ci-loop.sh scripts/development-workflow/post-merge-cleanup.sh scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh`
- `shellcheck --severity=warning scripts/development-workflow/discover-workflow-state.sh scripts/development-workflow/workflow-next-action.sh scripts/development-workflow/workflow-batch-plan.sh scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/pr-ci-loop.sh scripts/development-workflow/post-merge-cleanup.sh scripts/development-workflow/workflow-lib.sh scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh`
- `npx markdownlint-cli2 "docs/specs/developments/20260610164605_878-workflow-orchestration-product-repo-aware/*.md" "docs/testing/workflow/878-workflow-orchestration-product-repo-aware.smoke-test.md" "docs/workflow/development-workflow/README.md" "docs/workflow/development-workflow/repository-modes.md" "CHANGELOG.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/878-workflow-orchestration-product-repo-aware.smoke-test.md CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `./scripts/development-workflow/discover-workflow-state.sh | sed -n '1,40p'`

## Pre-submission self-review

Stale markers: none found by diff grep. Caller consistency: workflow-hub repository context is threaded through discovery, next-action, batch planning, reviewer loop, CI loop, and cleanup; tracker updates remain hub-owned in cleanup. Coverage: AC1 through AC10 are addressed by the new fixture test plus existing config resolver and reviewer-loop regression suites.

## CHANGELOG

- **Workflow hub orchestration repository awareness** (#878): routes implementation branch, pull request, reviewer, CI, and cleanup operations to the selected product repository while keeping tracker/spec/plan state in the hub.