### PR TITLE
feat(workflow): add product repo PR auth helpers

### DIFF
--- a/.ai-dev-workflow.local.example.yaml
+++ b/.ai-dev-workflow.local.example.yaml
@@ -12,11 +12,17 @@ checkout_root: ../repos
 product_repos:
   - name: mobile-app
     local_path: ../repos/mobile-app
-    private_key_path: ~/.config/example/mobile-app-github-app.pem
-    secret_ref: op://ExampleVault/mobile-app-github-app/private-key
+    github_app:
+      private_key_path: ~/.config/example/mobile-app-github-app.pem
+      secret_ref: op://ExampleVault/mobile-app-github-app/private-key
   - name: admin-portal
     # With checkout_root above, this defaults to ../repos/admin-portal.
-    secret_ref: op://ExampleVault/admin-portal-github-app/private-key
+    github_app:
+      secret_ref: op://ExampleVault/admin-portal-github-app/private-key
+
+# Compatibility: product_repos[].private_key_path and
+# product_repos[].secret_ref remain accepted as local-only aliases. Prefer the
+# nested github_app form for new setup.
 
 # Local reviewer/tool overrides. These are developer-specific and should not be
 # committed to the shared workflow config.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Workflow hub product repository PR authentication** (#880): adds local-only GitHub App auth guidance and helpers for opening product repository pull requests without exposing secrets.
 - **Workflow hub template skeletons** (#876): adds inspectable workflow-hub and product-repo-injection skeletons with mode-specific sync-scope metadata.
 - **Shared and local workflow configuration** (#875): separates versioned repository identity from local checkout and secret references, with repository-context helpers for workflow hub routing.
 - **Workflow hub operating model** (#874): documents repository modes, artifact ownership, target repository selection, and PR ownership for workflow hub deployments.

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -248,6 +248,12 @@ commands when a product implementation action is involved. Reviewer and CI loops
 also accept `--repo <owner/repo>` or `--product-repo <name>` for implementation
 PRs outside the hub.
 
+Product repository PR creation can use GitHub App authentication without
+printing secrets. See
+[`integrations/workflow-hub-github-app.md`](integrations/workflow-hub-github-app.md)
+for required App permissions, local-only secret-reference fields, token helper
+behavior, and dry-run examples for product PR routing.
+
 Role-specific skeletons are inspectable under the template root:
 
 - `template/workflow-hub/` lists hub-owned protocols, scripts, agents,
@@ -442,7 +448,7 @@ template:
 
 Important implementation notes:
 
-- Repository mode fields are `mode`, `workflow_hub.product_repos[]`, and `product_repo.workflow_hub`. Shared product repository entries may contain stable non-secret identity and metadata such as `name`, `github_repo` or `git_url`, `default_branch`, `role`, `scope`, `tracker` hints, and non-secret app identifiers. Local checkout paths, private key paths, secret values, and machine-specific tool settings belong only in `.ai-dev-workflow.local.yaml`. See [`repository-modes.md`](repository-modes.md) for examples and validation commands.
+- Repository mode fields are `mode`, `workflow_hub.product_repos[]`, and `product_repo.workflow_hub`. Shared product repository entries may contain stable non-secret identity and metadata such as `name`, `github_repo` or `git_url`, `default_branch`, `role`, `scope`, `tracker` hints, and non-secret app identifiers. Local checkout paths, private key paths, secret values, and machine-specific tool settings belong only in `.ai-dev-workflow.local.yaml`. See [`repository-modes.md`](repository-modes.md) and [`integrations/workflow-hub-github-app.md`](integrations/workflow-hub-github-app.md) for examples and validation commands.
 - Product-repository-aware orchestration scripts emit ownership fields such as
   `WORKFLOW_MODE`, `ACTION_REPOSITORY_KIND`, `ACTION_REPOSITORY`, and
   `ACTION_GITHUB_REPO` so orchestrators can distinguish hub-owned planning work
@@ -560,6 +566,7 @@ Repository helpers:
 - `docs/workflow/development-workflow/integrations/coderabbit.md`
 - `docs/workflow/development-workflow/integrations/haystack.md`
 - `docs/workflow/development-workflow/integrations/github-projects.md`
+- `docs/workflow/development-workflow/integrations/workflow-hub-github-app.md`
 - `docs/workflow/development-workflow/integrations/ci-cd-deployment.md`
 - `docs/workflow/development-workflow/integrations/e2e-regression.md`
 

--- a/docs/workflow/development-workflow/integrations/workflow-hub-github-app.md
+++ b/docs/workflow/development-workflow/integrations/workflow-hub-github-app.md
@@ -1,0 +1,152 @@
+# Workflow Hub GitHub App Authentication
+
+Workflow hubs can coordinate product repository implementation PRs without
+using the hub repository remote or leaking local credentials. This guide covers
+the GitHub App setup and helper commands used by workflow-hub product PR
+operations.
+
+## Required GitHub App Access
+
+Install the GitHub App on every product repository that the workflow hub may
+open implementation PRs against.
+
+Minimum repository permissions:
+
+- Metadata: read.
+- Contents: read and write when the helper needs to create or update branches.
+- Pull requests: read and write.
+- Checks or commit statuses: read when later reviewer/CI helpers inspect PR
+  readiness in the product repository.
+
+The operator must record the App ID and installation ID for each product
+repository. App ID and installation ID are non-secret identifiers and may be
+stored in the shared workflow config. Private key paths, private key contents,
+secret-manager account details, token values, and machine-local secret
+locations must not be stored in the shared config.
+
+## Shared Configuration
+
+The shared `.ai-dev-workflow.yaml` records stable product repository identity
+and non-secret GitHub App identifiers:
+
+```yaml
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      default_branch: main
+      github_app:
+        app_id: "12345"
+        installation_id: "999999"
+    - name: admin-portal
+      git_url: git@github.com:example/admin-portal.git
+      default_branch: develop
+      github_app:
+        app_id: "12345"
+        installation_id: "888888"
+```
+
+The resolver rejects local-only fields such as `private_key_path`, `secret_ref`,
+`private_key`, `secret`, and `local_path` when they appear under shared
+`workflow_hub.product_repos[]` entries.
+
+## Local Configuration
+
+Local auth references belong in `.ai-dev-workflow.local.yaml`, which is
+gitignored. Prefer the nested `github_app` form for new setup:
+
+```yaml
+product_repos:
+  - name: mobile-app
+    local_path: ../repos/mobile-app
+    github_app:
+      private_key_path: ~/.config/example/mobile-app-github-app.pem
+      secret_ref: op://ExampleVault/mobile-app-github-app/private-key
+  - name: admin-portal
+    github_app:
+      secret_ref: op://ExampleVault/admin-portal-github-app/private-key
+```
+
+The legacy top-level local aliases remain accepted for compatibility:
+
+```yaml
+product_repos:
+  - name: mobile-app
+    private_key_path: ~/.config/example/mobile-app-github-app.pem
+    secret_ref: op://ExampleVault/mobile-app-github-app/private-key
+```
+
+Secret-manager references are references only; the workflow does not require a
+specific secret manager and does not store secret values in config files.
+
+## Helper Commands
+
+Check redacted auth metadata:
+
+```bash
+scripts/development-workflow/github-app-token.sh --repo mobile-app --status
+```
+
+Dry-run token metadata resolution:
+
+```bash
+scripts/development-workflow/github-app-token.sh --repo mobile-app --dry-run
+```
+
+Print an installation token for a machine caller:
+
+```bash
+scripts/development-workflow/github-app-token.sh --repo mobile-app --print-token
+```
+
+`--print-token` is the only mode that writes token material to stdout. Human
+logs and error output must not contain token values or private key contents.
+
+Dry-run a product repository PR operation before credentials are available:
+
+```bash
+scripts/development-workflow/open-product-pr.sh \
+  --repo mobile-app \
+  --base main \
+  --head feature/example \
+  --title "feat: example product change" \
+  --body-file /tmp/product-pr-body.md \
+  --dry-run
+```
+
+The dry-run output includes the target `owner/repo`, base branch, head branch,
+title, and a redacted `gh pr create --repo <owner/repo>` command shape. It does
+not require or print credentials.
+
+Run the same dry-run for a second product repository to verify routing:
+
+```bash
+scripts/development-workflow/open-product-pr.sh \
+  --repo admin-portal \
+  --base develop \
+  --head feature/example \
+  --title "feat: example admin change" \
+  --body-file /tmp/product-pr-body.md \
+  --dry-run
+```
+
+Live PR creation obtains the selected product repository token and passes it
+only to the child `gh pr create` invocation through `GH_TOKEN`.
+
+## Failure States
+
+The helpers fail before unsafe fallback when required auth is incomplete:
+
+- `missing_app_id`: no App ID is configured for the selected product repo.
+- `missing_private_key`: no readable local private key path or resolvable
+  secret reference is configured.
+- `missing_installation`: no installation ID is configured, or the token
+  exchange cannot access the installation.
+- `permission_denied`: GitHub returned a response that does not include an
+  installation token.
+
+The helpers do not silently fall back to the operator's ambient `gh` token when
+workflow-hub product repository auth is incomplete.

--- a/docs/workflow/development-workflow/repository-modes.md
+++ b/docs/workflow/development-workflow/repository-modes.md
@@ -274,9 +274,12 @@ checkout_root: ../repos
 product_repos:
   - name: mobile-app
     local_path: ../repos/mobile-app
-    secret_ref: op://ExampleVault/mobile-app-github-app/private-key
+    github_app:
+      private_key_path: ~/.config/example/mobile-app-github-app.pem
+      secret_ref: op://ExampleVault/mobile-app-github-app/private-key
   - name: admin-portal
-    secret_ref: op://ExampleVault/admin-portal-github-app/private-key
+    github_app:
+      secret_ref: op://ExampleVault/admin-portal-github-app/private-key
 
 review:
   on_draft:
@@ -296,6 +299,12 @@ For a hub target, local path resolution uses this order:
 Local config is optional for `single_repo` mode. It is required only when a
 workflow hub action needs a local product checkout path that cannot be derived
 safely.
+
+Workflow-hub product PR authentication uses the same split: shared config may
+store non-secret GitHub App IDs and installation IDs, while private key paths
+and secret-manager references stay local-only. See
+[`integrations/workflow-hub-github-app.md`](integrations/workflow-hub-github-app.md)
+for the setup guide and dry-run helper commands.
 
 ### Compatibility And Precedence
 
@@ -337,11 +346,8 @@ file-specific error.
 
 This note does not:
 
-- Route PRs across repositories.
-- Change existing agent prompts or command wrappers.
 - Migrate existing downstream repositories.
-- Define secret storage or authentication beyond local secret-reference
-  placement.
+- Define a required secret manager or store secret values.
 
 Those behaviors belong to later workflow-hub implementation items. Until those
 items land, missing mode remains `single_repo` and existing repositories keep the

--- a/scripts/development-workflow/github-app-token.sh
+++ b/scripts/development-workflow/github-app-token.sh
@@ -2,7 +2,18 @@
 # github-app-token.sh - resolve workflow-hub GitHub App auth for product repos.
 
 set -euo pipefail
-trap 'case $? in 141) exit 0 ;; *) exit $? ;; esac' EXIT
+TOKEN_TMP_DIR=""
+_github_app_token_exit() {
+  local status=$?
+  if [ -n "$TOKEN_TMP_DIR" ]; then
+    rm -rf "$TOKEN_TMP_DIR"
+  fi
+  case "$status" in
+    141) exit 0 ;;
+    *)   exit "$status" ;;
+  esac
+}
+trap _github_app_token_exit EXIT
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../.." && pwd)"
@@ -99,17 +110,13 @@ exchange_token() {
   local installation_id="$2"
   local private_key_path="$3"
   local secret_ref="$4"
-  local tmp_dir jwt response token
+  local jwt response token
 
-  tmp_dir="$(mktemp -d)"
-  _cleanup_token_tmp() {
-    rm -rf "$tmp_dir"
-  }
-  trap _cleanup_token_tmp EXIT
+  TOKEN_TMP_DIR="$(mktemp -d)"
 
   local key_file
-  key_file="$(load_private_key_file "$private_key_path" "$secret_ref" "$tmp_dir")"
-  jwt="$(create_jwt "$app_id" "$key_file" "$tmp_dir")"
+  key_file="$(load_private_key_file "$private_key_path" "$secret_ref" "$TOKEN_TMP_DIR")"
+  jwt="$(create_jwt "$app_id" "$key_file" "$TOKEN_TMP_DIR")"
 
   if [ -n "${WORKFLOW_GITHUB_APP_TOKEN_EXCHANGE_CMD:-}" ]; then
     if ! token="$("$WORKFLOW_GITHUB_APP_TOKEN_EXCHANGE_CMD" "$app_id" "$installation_id" "$jwt")"; then

--- a/scripts/development-workflow/github-app-token.sh
+++ b/scripts/development-workflow/github-app-token.sh
@@ -44,6 +44,14 @@ log() {
   printf '%s\n' "$*" >&2
 }
 
+json_field() {
+  local json="$1"
+  local key="$2"
+  if ! printf '%s' "$json" | jq -re --arg key "$key" '.[$key] // ""' 2>/dev/null; then
+    die "resolver output did not include expected field '$key'"
+  fi
+}
+
 base64url_file() {
   openssl base64 -A -in "$1" | tr '+/' '-_' | tr -d '='
 }
@@ -192,11 +200,15 @@ if [ "$MODE" = "status" ] || [ "$MODE" = "dry-run" ]; then
   exit 0
 fi
 
-if ! AUTH_OUTPUT="$(python3 "$RESOLVER" auth --repo-root "$REPO_ROOT" --repo "$REPO_NAME" --include-local-secrets 2>&1)"; then
+if ! AUTH_OUTPUT="$(python3 "$RESOLVER" auth --repo-root "$REPO_ROOT" --repo "$REPO_NAME" --include-local-secrets --json 2>&1)"; then
   printf '%s\n' "$AUTH_OUTPUT" >&2
   exit 1
 fi
-eval "$AUTH_OUTPUT"
+AUTH_STATUS="$(json_field "$AUTH_OUTPUT" AUTH_STATUS)"
+AUTH_APP_ID="$(json_field "$AUTH_OUTPUT" AUTH_APP_ID)"
+AUTH_INSTALLATION_ID="$(json_field "$AUTH_OUTPUT" AUTH_INSTALLATION_ID)"
+AUTH_PRIVATE_KEY_PATH="$(json_field "$AUTH_OUTPUT" AUTH_PRIVATE_KEY_PATH)"
+AUTH_SECRET_REF="$(json_field "$AUTH_OUTPUT" AUTH_SECRET_REF)"
 
 case "${AUTH_STATUS:-}" in
   auth_configured) ;;

--- a/scripts/development-workflow/github-app-token.sh
+++ b/scripts/development-workflow/github-app-token.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# github-app-token.sh - resolve workflow-hub GitHub App auth for product repos.
+
+set -euo pipefail
+trap 'case $? in 141) exit 0 ;; *) exit $? ;; esac' EXIT
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../.." && pwd)"
+RESOLVER="$SCRIPT_DIR/workflow-config-resolver.py"
+
+usage() {
+  cat <<'USAGE'
+Usage: github-app-token.sh --repo <product-name> [--repo-root <path>] [--status|--dry-run|--print-token]
+
+Options:
+  --repo <name>       Product repository name from workflow_hub.product_repos[].
+  --repo-root <path>  Workflow hub repository root. Defaults to this repository.
+  --status           Print redacted auth status only.
+  --dry-run          Validate auth metadata without exchanging a token.
+  --print-token      Print only the installation token to stdout.
+  -h, --help         Show this help.
+
+Secret values and token material are never printed in normal logs.
+USAGE
+}
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+base64url_file() {
+  openssl base64 -A -in "$1" | tr '+/' '-_' | tr -d '='
+}
+
+json_string() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+print(json.dumps(sys.argv[1]))
+PY
+}
+
+create_jwt() {
+  local app_id="$1"
+  local private_key_file="$2"
+  local tmp_dir="$3"
+  local now iat exp header payload signing_input signature
+
+  now="$(date +%s)"
+  iat=$((now - 60))
+  exp=$((now + 540))
+  header='{"alg":"RS256","typ":"JWT"}'
+  payload="{\"iat\":${iat},\"exp\":${exp},\"iss\":$(json_string "$app_id")}"
+
+  printf '%s' "$header" > "$tmp_dir/header.json"
+  printf '%s' "$payload" > "$tmp_dir/payload.json"
+  signing_input="$(base64url_file "$tmp_dir/header.json").$(base64url_file "$tmp_dir/payload.json")"
+  printf '%s' "$signing_input" | openssl dgst -sha256 -sign "$private_key_file" > "$tmp_dir/signature.bin"
+  signature="$(base64url_file "$tmp_dir/signature.bin")"
+  printf '%s.%s\n' "$signing_input" "$signature"
+}
+
+load_private_key_file() {
+  local private_key_path="$1"
+  local secret_ref="$2"
+  local tmp_dir="$3"
+
+  if [ -n "$private_key_path" ]; then
+    if [ ! -r "$private_key_path" ]; then
+      die "missing_private_key: configured private key path is not readable for selected product repository"
+    fi
+    printf '%s\n' "$private_key_path"
+    return 0
+  fi
+
+  if [ -z "$secret_ref" ]; then
+    die "missing_private_key: configure product_repos[].github_app.private_key_path or secret_ref in .ai-dev-workflow.local.yaml"
+  fi
+  if [ -z "${WORKFLOW_GITHUB_APP_SECRET_REF_COMMAND:-}" ]; then
+    die "missing_private_key: secret_ref is configured, but WORKFLOW_GITHUB_APP_SECRET_REF_COMMAND is not set"
+  fi
+
+  if ! "$WORKFLOW_GITHUB_APP_SECRET_REF_COMMAND" "$secret_ref" > "$tmp_dir/private-key.pem"; then
+    die "missing_private_key: secret_ref resolver command failed for selected product repository"
+  fi
+  if [ ! -s "$tmp_dir/private-key.pem" ]; then
+    die "missing_private_key: secret_ref resolver returned an empty private key"
+  fi
+  printf '%s\n' "$tmp_dir/private-key.pem"
+}
+
+exchange_token() {
+  local app_id="$1"
+  local installation_id="$2"
+  local private_key_path="$3"
+  local secret_ref="$4"
+  local tmp_dir jwt response token
+
+  tmp_dir="$(mktemp -d)"
+  _cleanup_token_tmp() {
+    rm -rf "$tmp_dir"
+  }
+  trap _cleanup_token_tmp EXIT
+
+  local key_file
+  key_file="$(load_private_key_file "$private_key_path" "$secret_ref" "$tmp_dir")"
+  jwt="$(create_jwt "$app_id" "$key_file" "$tmp_dir")"
+
+  if [ -n "${WORKFLOW_GITHUB_APP_TOKEN_EXCHANGE_CMD:-}" ]; then
+    if ! token="$("$WORKFLOW_GITHUB_APP_TOKEN_EXCHANGE_CMD" "$app_id" "$installation_id" "$jwt")"; then
+      die "missing_installation: token exchange command failed for selected product repository"
+    fi
+    [ -n "$token" ] || die "missing_installation: token exchange command returned an empty token"
+    printf '%s\n' "$token"
+    return 0
+  fi
+
+  if ! response="$(gh api -X POST "/app/installations/${installation_id}/access_tokens" \
+    -H "Authorization: Bearer ${jwt}" \
+    -H "Accept: application/vnd.github+json" 2>/dev/null)"; then
+    die "missing_installation: GitHub App installation token exchange failed"
+  fi
+  if [ -z "$response" ]; then
+    die "missing_installation: GitHub App installation token exchange returned an empty response"
+  fi
+  if ! token="$(printf '%s' "$response" | jq -re '.token' 2>/dev/null)"; then
+    die "permission_denied: token exchange response did not include an installation token"
+  fi
+  printf '%s\n' "$token"
+}
+
+REPO_NAME=""
+MODE="status"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      [ "$#" -ge 2 ] || die "--repo requires a value"
+      REPO_NAME="$2"
+      shift 2
+      ;;
+    --repo-root)
+      [ "$#" -ge 2 ] || die "--repo-root requires a value"
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --status)
+      MODE="status"
+      shift
+      ;;
+    --dry-run)
+      MODE="dry-run"
+      shift
+      ;;
+    --print-token)
+      MODE="print-token"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument '$1'"
+      ;;
+  esac
+done
+
+[ -n "$REPO_NAME" ] || die "--repo is required"
+
+if [ "$MODE" = "status" ] || [ "$MODE" = "dry-run" ]; then
+  if ! STATUS_OUTPUT="$(python3 "$RESOLVER" auth --repo-root "$REPO_ROOT" --repo "$REPO_NAME" 2>&1)"; then
+    printf '%s\n' "$STATUS_OUTPUT" >&2
+    exit 1
+  fi
+  printf '%s\n' "$STATUS_OUTPUT"
+  if [ "$MODE" = "dry-run" ]; then
+    log "DRY_RUN=true"
+  fi
+  exit 0
+fi
+
+if ! AUTH_OUTPUT="$(python3 "$RESOLVER" auth --repo-root "$REPO_ROOT" --repo "$REPO_NAME" --include-local-secrets 2>&1)"; then
+  printf '%s\n' "$AUTH_OUTPUT" >&2
+  exit 1
+fi
+eval "$AUTH_OUTPUT"
+
+case "${AUTH_STATUS:-}" in
+  auth_configured) ;;
+  missing_app_id) die "missing_app_id: configure product_repos[].github_app.app_id for selected product repository" ;;
+  missing_private_key) die "missing_private_key: configure a local private_key_path or secret_ref for selected product repository" ;;
+  missing_installation) die "missing_installation: configure product_repos[].github_app.installation_id for selected product repository" ;;
+  *) die "auth is not configured for selected product repository: ${AUTH_STATUS:-unknown}" ;;
+esac
+
+TOKEN="$(exchange_token "$AUTH_APP_ID" "$AUTH_INSTALLATION_ID" "${AUTH_PRIVATE_KEY_PATH:-}" "${AUTH_SECRET_REF:-}")"
+[ -n "$TOKEN" ] || die "missing_installation: token exchange produced an empty token"
+printf '%s\n' "$TOKEN"

--- a/scripts/development-workflow/open-product-pr.sh
+++ b/scripts/development-workflow/open-product-pr.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# open-product-pr.sh - open or dry-run product repository PRs from a workflow hub.
+
+set -euo pipefail
+trap 'case $? in 141) exit 0 ;; *) exit $? ;; esac' EXIT
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../.." && pwd)"
+RESOLVER="$SCRIPT_DIR/workflow-config-resolver.py"
+TOKEN_HELPER="$SCRIPT_DIR/github-app-token.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: open-product-pr.sh --repo <product-name> --base <branch> --head <branch> --title <title> --body-file <path> [--repo-root <path>] [--dry-run]
+
+Opens a pull request in the selected product repository. Dry-run mode prints the
+target repo and redacted command shape without requiring credentials.
+USAGE
+}
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+quote_arg() {
+  printf '%s' "$1" | sed "s/'/'\\\\''/g; s/^/'/; s/$/'/"
+}
+
+github_repo_from_url() {
+  local value="$1"
+  case "$value" in
+    git@github.com:*/*.git)
+      value="${value#git@github.com:}"
+      value="${value%.git}"
+      ;;
+    git@github.com:*/*)
+      value="${value#git@github.com:}"
+      ;;
+    https://github.com/*/*.git)
+      value="${value#https://github.com/}"
+      value="${value%.git}"
+      ;;
+    https://github.com/*/*)
+      value="${value#https://github.com/}"
+      value="${value%/}"
+      ;;
+    ssh://git@github.com/*/*.git)
+      value="${value#ssh://git@github.com/}"
+      value="${value%.git}"
+      ;;
+    ssh://git@github.com/*/*)
+      value="${value#ssh://git@github.com/}"
+      value="${value%/}"
+      ;;
+    *)
+      value=""
+      ;;
+  esac
+  printf '%s\n' "$value"
+}
+
+REPO_NAME=""
+BASE_BRANCH=""
+HEAD_BRANCH=""
+TITLE=""
+BODY_FILE=""
+DRY_RUN=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      [ "$#" -ge 2 ] || die "--repo requires a value"
+      REPO_NAME="$2"
+      shift 2
+      ;;
+    --repo-root)
+      [ "$#" -ge 2 ] || die "--repo-root requires a value"
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --base)
+      [ "$#" -ge 2 ] || die "--base requires a value"
+      BASE_BRANCH="$2"
+      shift 2
+      ;;
+    --head)
+      [ "$#" -ge 2 ] || die "--head requires a value"
+      HEAD_BRANCH="$2"
+      shift 2
+      ;;
+    --title)
+      [ "$#" -ge 2 ] || die "--title requires a value"
+      TITLE="$2"
+      shift 2
+      ;;
+    --body-file)
+      [ "$#" -ge 2 ] || die "--body-file requires a value"
+      BODY_FILE="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument '$1'"
+      ;;
+  esac
+done
+
+[ -n "$REPO_NAME" ] || die "--repo is required"
+[ -n "$BASE_BRANCH" ] || die "--base is required"
+[ -n "$HEAD_BRANCH" ] || die "--head is required"
+[ -n "$TITLE" ] || die "--title is required"
+[ -n "$BODY_FILE" ] || die "--body-file is required"
+[ -r "$BODY_FILE" ] || die "--body-file must be readable"
+
+if ! CONTEXT_OUTPUT="$(python3 "$RESOLVER" resolve --repo-root "$REPO_ROOT" --repo "$REPO_NAME" 2>&1)"; then
+  printf '%s\n' "$CONTEXT_OUTPUT" >&2
+  exit 1
+fi
+eval "$CONTEXT_OUTPUT"
+
+if [ "${WORKFLOW_MODE:-}" != "workflow_hub" ]; then
+  die "product PR operations require workflow_hub mode"
+fi
+
+TARGET_REPO="${TARGET_GITHUB_REPO:-}"
+if [ -z "$TARGET_REPO" ] && [ -n "${TARGET_GIT_URL:-}" ]; then
+  TARGET_REPO="$(github_repo_from_url "$TARGET_GIT_URL")"
+fi
+[ -n "$TARGET_REPO" ] || die "selected product repository does not resolve to a GitHub owner/repo slug"
+
+if [ "$DRY_RUN" = true ]; then
+  printf 'DRY_RUN=true\n'
+  printf 'TARGET_REPO=%s\n' "$TARGET_REPO"
+  printf 'BASE_BRANCH=%s\n' "$BASE_BRANCH"
+  printf 'HEAD_BRANCH=%s\n' "$HEAD_BRANCH"
+  printf 'TITLE=%s\n' "$TITLE"
+  printf 'COMMAND=%s\n' "GH_TOKEN=<redacted> gh pr create --repo $(quote_arg "$TARGET_REPO") --base $(quote_arg "$BASE_BRANCH") --head $(quote_arg "$HEAD_BRANCH") --title $(quote_arg "$TITLE") --body-file $(quote_arg "$BODY_FILE")"
+  exit 0
+fi
+
+TOKEN_ERR="$(mktemp)"
+if ! TOKEN="$("$TOKEN_HELPER" --repo-root "$REPO_ROOT" --repo "$REPO_NAME" --print-token 2>"$TOKEN_ERR")"; then
+  cat "$TOKEN_ERR" >&2
+  rm -f "$TOKEN_ERR"
+  exit 1
+fi
+rm -f "$TOKEN_ERR"
+[ -n "$TOKEN" ] || die "token helper returned an empty token"
+
+if ! PR_OUTPUT="$(GH_TOKEN="$TOKEN" gh pr create --repo "$TARGET_REPO" --base "$BASE_BRANCH" --head "$HEAD_BRANCH" --title "$TITLE" --body-file "$BODY_FILE" 2>&1)"; then
+  printf '%s\n' "$PR_OUTPUT" >&2
+  exit 1
+fi
+
+printf 'PR_URL=%s\n' "$PR_OUTPUT"

--- a/scripts/development-workflow/open-product-pr.sh
+++ b/scripts/development-workflow/open-product-pr.sh
@@ -23,6 +23,14 @@ die() {
   exit 1
 }
 
+json_field() {
+  local json="$1"
+  local key="$2"
+  if ! printf '%s' "$json" | jq -re --arg key "$key" '.[$key] // ""' 2>/dev/null; then
+    die "resolver output did not include expected field '$key'"
+  fi
+}
+
 quote_arg() {
   printf '%s' "$1" | sed "s/'/'\\\\''/g; s/^/'/; s/$/'/"
 }
@@ -120,11 +128,13 @@ done
 [ -n "$BODY_FILE" ] || die "--body-file is required"
 [ -r "$BODY_FILE" ] || die "--body-file must be readable"
 
-if ! CONTEXT_OUTPUT="$(python3 "$RESOLVER" resolve --repo-root "$REPO_ROOT" --repo "$REPO_NAME" 2>&1)"; then
+if ! CONTEXT_OUTPUT="$(python3 "$RESOLVER" resolve --repo-root "$REPO_ROOT" --repo "$REPO_NAME" --json 2>&1)"; then
   printf '%s\n' "$CONTEXT_OUTPUT" >&2
   exit 1
 fi
-eval "$CONTEXT_OUTPUT"
+WORKFLOW_MODE="$(json_field "$CONTEXT_OUTPUT" WORKFLOW_MODE)"
+TARGET_GITHUB_REPO="$(json_field "$CONTEXT_OUTPUT" TARGET_GITHUB_REPO)"
+TARGET_GIT_URL="$(json_field "$CONTEXT_OUTPUT" TARGET_GIT_URL)"
 
 if [ "${WORKFLOW_MODE:-}" != "workflow_hub" ]; then
   die "product PR operations require workflow_hub mode"

--- a/scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh
@@ -154,6 +154,31 @@ run_contains "admin_dry_run_targets_admin" "TARGET_REPO=example/admin-portal" "$
 run_not_contains "dry_run_redacts_token" "fixture-installation-token" "$mobile_dry_run"
 run_contains "dry_run_command_shape" "GH_TOKEN=<redacted> gh pr create --repo 'example/mobile-app'" "$mobile_dry_run"
 
+non_github_dir="$(fixture_dir non-github)"
+cat > "$non_github_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: internal-app
+      git_url: ssh://git@example.com/internal-app.git
+YAML
+run_fails_contains \
+  "product_pr_non_github_url_fails" \
+  "does not resolve to a GitHub owner/repo slug" \
+  bash "$PR_HELPER" --repo-root "$non_github_dir" --repo internal-app --base main --head feature/test --title "Internal PR" --body-file "$body_file" --dry-run
+
+single_repo_dir="$(fixture_dir single-repo)"
+cat > "$single_repo_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: single_repo
+YAML
+run_fails_contains \
+  "product_pr_single_repo_mode_fails" \
+  "product PR operations require workflow_hub mode" \
+  bash "$PR_HELPER" --repo-root "$single_repo_dir" --repo mobile-app --base main --head feature/test --title "Mobile PR" --body-file "$body_file" --dry-run
+
 missing_app_dir="$(fixture_dir missing-app)"
 cat > "$missing_app_dir/.ai-dev-workflow.yaml" <<'YAML'
 schema_version: 2
@@ -188,6 +213,30 @@ run_fails_contains \
   "token_helper_missing_private_key" \
   "missing_private_key" \
   bash "$TOKEN_HELPER" --repo-root "$missing_key_dir" --repo mobile-app --print-token
+
+secret_ref_dir="$(fixture_dir secret-ref)"
+cat > "$secret_ref_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      github_app:
+        app_id: "12345"
+        installation_id: "999"
+YAML
+cat > "$secret_ref_dir/.ai-dev-workflow.local.yaml" <<'YAML'
+product_repos:
+  - name: mobile-app
+    github_app:
+      secret_ref: op://ExampleVault/mobile-app-github-app/private-key
+YAML
+run_fails_contains \
+  "token_helper_secret_ref_without_resolver_command" \
+  "WORKFLOW_GITHUB_APP_SECRET_REF_COMMAND is not set" \
+  bash "$TOKEN_HELPER" --repo-root "$secret_ref_dir" --repo mobile-app --print-token
 
 missing_installation_dir="$(fixture_dir missing-installation)"
 cat > "$missing_installation_dir/.ai-dev-workflow.yaml" <<'YAML'

--- a/scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh
@@ -214,6 +214,34 @@ run_fails_contains \
   "missing_private_key" \
   bash "$TOKEN_HELPER" --repo-root "$missing_key_dir" --repo mobile-app --print-token
 
+unreadable_key_dir="$(fixture_dir unreadable-key)"
+unreadable_key="$unreadable_key_dir/mobile-app.pem"
+make_private_key "$unreadable_key"
+chmod 000 "$unreadable_key"
+cat > "$unreadable_key_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      github_app:
+        app_id: "12345"
+        installation_id: "999"
+YAML
+cat > "$unreadable_key_dir/.ai-dev-workflow.local.yaml" <<YAML
+product_repos:
+  - name: mobile-app
+    github_app:
+      private_key_path: "$unreadable_key"
+YAML
+run_fails_contains \
+  "token_helper_unreadable_private_key" \
+  "configured private key path is not readable" \
+  bash "$TOKEN_HELPER" --repo-root "$unreadable_key_dir" --repo mobile-app --print-token
+chmod 600 "$unreadable_key"
+
 secret_ref_dir="$(fixture_dir secret-ref)"
 cat > "$secret_ref_dir/.ai-dev-workflow.yaml" <<'YAML'
 schema_version: 2
@@ -237,6 +265,30 @@ run_fails_contains \
   "token_helper_secret_ref_without_resolver_command" \
   "WORKFLOW_GITHUB_APP_SECRET_REF_COMMAND is not set" \
   bash "$TOKEN_HELPER" --repo-root "$secret_ref_dir" --repo mobile-app --print-token
+
+secret_ref_fail_stub="$TMP_ROOT/secret-ref-fail.sh"
+cat > "$secret_ref_fail_stub" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 42
+SH
+chmod +x "$secret_ref_fail_stub"
+run_fails_contains \
+  "token_helper_secret_ref_resolver_failure" \
+  "secret_ref resolver command failed" \
+  env WORKFLOW_GITHUB_APP_SECRET_REF_COMMAND="$secret_ref_fail_stub" bash "$TOKEN_HELPER" --repo-root "$secret_ref_dir" --repo mobile-app --print-token
+
+secret_ref_empty_stub="$TMP_ROOT/secret-ref-empty.sh"
+cat > "$secret_ref_empty_stub" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf ''
+SH
+chmod +x "$secret_ref_empty_stub"
+run_fails_contains \
+  "token_helper_secret_ref_empty_result" \
+  "secret_ref resolver returned an empty private key" \
+  env WORKFLOW_GITHUB_APP_SECRET_REF_COMMAND="$secret_ref_empty_stub" bash "$TOKEN_HELPER" --repo-root "$secret_ref_dir" --repo mobile-app --print-token
 
 missing_installation_dir="$(fixture_dir missing-installation)"
 cat > "$missing_installation_dir/.ai-dev-workflow.yaml" <<'YAML'
@@ -292,6 +344,11 @@ token_stdout="$(
 )"
 run_equals "token_helper_prints_only_token" "fixture-installation-token" "$token_stdout"
 run_not_contains "token_helper_stderr_no_token" "fixture-installation-token" "$(cat "$TMP_ROOT/token.stderr")"
+token_tmp_root="$TMP_ROOT/token-tmp"
+mkdir -p "$token_tmp_root"
+TMPDIR="$token_tmp_root" WORKFLOW_GITHUB_APP_TOKEN_EXCHANGE_CMD="$token_exchange_stub" \
+  bash "$TOKEN_HELPER" --repo-root "$hub_dir" --repo mobile-app --print-token > "$TMP_ROOT/token-cleanup.stdout"
+run_equals "token_helper_cleans_temp_dir" "0" "$(find "$token_tmp_root" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')"
 
 stub_bin="$TMP_ROOT/bin"
 mkdir -p "$stub_bin"

--- a/scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# test-workflow-hub-pr-auth.sh - workflow-hub product PR auth helper tests.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+RESOLVER="$REPO_ROOT/scripts/development-workflow/workflow-config-resolver.py"
+TOKEN_HELPER="$REPO_ROOT/scripts/development-workflow/github-app-token.sh"
+PR_HELPER="$REPO_ROOT/scripts/development-workflow/open-product-pr.sh"
+
+TMP_ROOT="$(mktemp -d)"
+TMP_ROOT="$(CDPATH='' cd -- "$TMP_ROOT" && pwd -P)"
+
+_harness_exit() {
+  local status=$?
+  rm -rf "$TMP_ROOT"
+  case "$status" in
+    141) exit 0 ;;
+    *)   exit "$status" ;;
+  esac
+}
+trap _harness_exit EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_contains() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if grep -Fq -- "$expected" <<< "$actual"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected output to contain '${expected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_not_contains() {
+  local name="$1"
+  local unexpected="$2"
+  local actual="$3"
+  if grep -Fq -- "$unexpected" <<< "$actual"; then
+    echo "FAIL: $name - output unexpectedly contained '${unexpected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  else
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  fi
+}
+
+run_equals() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_fails_contains() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  local output=""
+  local status=0
+
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+
+  if [ "$status" -ne 0 ] && grep -Fq -- "$expected" <<< "$output"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected failure containing '${expected}'"
+    printf 'Status: %s\nOutput:\n%s\n' "$status" "$output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+fixture_dir() {
+  local name="$1"
+  local path="$TMP_ROOT/$name"
+  mkdir -p "$path"
+  printf '%s\n' "$path"
+}
+
+make_private_key() {
+  local path="$1"
+  openssl genrsa 2048 > "$path" 2>/dev/null
+}
+
+echo ""
+echo "=== Workflow hub product PR auth ==="
+
+hub_dir="$(fixture_dir hub)"
+mobile_key="$hub_dir/mobile-app.pem"
+admin_key="$hub_dir/admin-portal.pem"
+make_private_key "$mobile_key"
+make_private_key "$admin_key"
+
+cat > "$hub_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      default_branch: main
+      github_app:
+        app_id: "12345"
+        installation_id: "999"
+    - name: admin-portal
+      git_url: git@github.com:example/admin-portal.git
+      default_branch: develop
+      github_app:
+        app_id: "23456"
+        installation_id: "888"
+YAML
+cat > "$hub_dir/.ai-dev-workflow.local.yaml" <<YAML
+product_repos:
+  - name: mobile-app
+    github_app:
+      private_key_path: "$mobile_key"
+  - name: admin-portal
+    private_key_path: "$admin_key"
+YAML
+
+auth_status="$(python3 "$RESOLVER" auth --repo-root "$hub_dir" --repo mobile-app)"
+run_contains "auth_status_configured" "AUTH_STATUS=auth_configured" "$auth_status"
+run_contains "auth_status_redacted_source" "AUTH_SECRET_SOURCE=private_key_path" "$auth_status"
+run_not_contains "auth_status_hides_private_key_path" "$mobile_key" "$auth_status"
+
+auth_machine="$(python3 "$RESOLVER" auth --repo-root "$hub_dir" --repo mobile-app --include-local-secrets)"
+run_contains "auth_machine_includes_private_key_path" "AUTH_PRIVATE_KEY_PATH=$mobile_key" "$auth_machine"
+
+body_file="$hub_dir/body.md"
+printf 'PR body\n' > "$body_file"
+mobile_dry_run="$(bash "$PR_HELPER" --repo-root "$hub_dir" --repo mobile-app --base main --head feature/test --title "Mobile PR" --body-file "$body_file" --dry-run)"
+admin_dry_run="$(bash "$PR_HELPER" --repo-root "$hub_dir" --repo admin-portal --base develop --head feature/test --title "Admin PR" --body-file "$body_file" --dry-run)"
+run_contains "mobile_dry_run_targets_mobile" "TARGET_REPO=example/mobile-app" "$mobile_dry_run"
+run_contains "admin_dry_run_targets_admin" "TARGET_REPO=example/admin-portal" "$admin_dry_run"
+run_not_contains "dry_run_redacts_token" "fixture-installation-token" "$mobile_dry_run"
+run_contains "dry_run_command_shape" "GH_TOKEN=<redacted> gh pr create --repo 'example/mobile-app'" "$mobile_dry_run"
+
+missing_app_dir="$(fixture_dir missing-app)"
+cat > "$missing_app_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      github_app:
+        installation_id: "999"
+YAML
+run_fails_contains \
+  "token_helper_missing_app_id" \
+  "missing_app_id" \
+  bash "$TOKEN_HELPER" --repo-root "$missing_app_dir" --repo mobile-app --print-token
+
+missing_key_dir="$(fixture_dir missing-key)"
+cat > "$missing_key_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      github_app:
+        app_id: "12345"
+        installation_id: "999"
+YAML
+run_fails_contains \
+  "token_helper_missing_private_key" \
+  "missing_private_key" \
+  bash "$TOKEN_HELPER" --repo-root "$missing_key_dir" --repo mobile-app --print-token
+
+missing_installation_dir="$(fixture_dir missing-installation)"
+cat > "$missing_installation_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      github_app:
+        app_id: "12345"
+YAML
+cat > "$missing_installation_dir/.ai-dev-workflow.local.yaml" <<YAML
+product_repos:
+  - name: mobile-app
+    private_key_path: "$mobile_key"
+YAML
+run_fails_contains \
+  "token_helper_missing_installation" \
+  "missing_installation" \
+  bash "$TOKEN_HELPER" --repo-root "$missing_installation_dir" --repo mobile-app --print-token
+
+shared_secret_dir="$(fixture_dir shared-secret)"
+cat > "$shared_secret_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      github_app:
+        app_id: "12345"
+        private_key_path: /private/key.pem
+YAML
+run_fails_contains \
+  "shared_config_rejects_private_key_path" \
+  "contains local-only field(s): github_app.private_key_path" \
+  python3 "$RESOLVER" auth --repo-root "$shared_secret_dir" --repo mobile-app
+
+token_exchange_stub="$TMP_ROOT/token-exchange-stub.sh"
+cat > "$token_exchange_stub" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'fixture-installation-token\n'
+SH
+chmod +x "$token_exchange_stub"
+
+token_stdout="$(
+  WORKFLOW_GITHUB_APP_TOKEN_EXCHANGE_CMD="$token_exchange_stub" \
+    bash "$TOKEN_HELPER" --repo-root "$hub_dir" --repo mobile-app --print-token 2>"$TMP_ROOT/token.stderr"
+)"
+run_equals "token_helper_prints_only_token" "fixture-installation-token" "$token_stdout"
+run_not_contains "token_helper_stderr_no_token" "fixture-installation-token" "$(cat "$TMP_ROOT/token.stderr")"
+
+stub_bin="$TMP_ROOT/bin"
+mkdir -p "$stub_bin"
+cat > "$stub_bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$GH_TOKEN" > "$GH_TOKEN_CAPTURE"
+printf '%s\n' "$*" > "$GH_ARGS_CAPTURE"
+printf 'https://github.com/example/mobile-app/pull/123\n'
+SH
+chmod +x "$stub_bin/gh"
+
+live_output="$(
+  PATH="$stub_bin:$PATH" \
+  GH_TOKEN_CAPTURE="$TMP_ROOT/gh-token.txt" \
+  GH_ARGS_CAPTURE="$TMP_ROOT/gh-args.txt" \
+  WORKFLOW_GITHUB_APP_TOKEN_EXCHANGE_CMD="$token_exchange_stub" \
+    bash "$PR_HELPER" --repo-root "$hub_dir" --repo mobile-app --base main --head feature/test --title "Mobile PR" --body-file "$body_file"
+)"
+run_contains "live_pr_returns_url" "PR_URL=https://github.com/example/mobile-app/pull/123" "$live_output"
+run_equals "live_pr_child_receives_token" "fixture-installation-token" "$(cat "$TMP_ROOT/gh-token.txt")"
+run_contains "live_pr_targets_repo" "pr create --repo example/mobile-app" "$(cat "$TMP_ROOT/gh-args.txt")"
+run_not_contains "live_pr_output_no_token" "fixture-installation-token" "$live_output"
+
+echo ""
+echo "Passed: $PASS_COUNT"
+echo "Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi

--- a/scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh
@@ -144,6 +144,9 @@ run_not_contains "auth_status_hides_private_key_path" "$mobile_key" "$auth_statu
 
 auth_machine="$(python3 "$RESOLVER" auth --repo-root "$hub_dir" --repo mobile-app --include-local-secrets)"
 run_contains "auth_machine_includes_private_key_path" "AUTH_PRIVATE_KEY_PATH=$mobile_key" "$auth_machine"
+auth_json="$(python3 "$RESOLVER" auth --repo-root "$hub_dir" --repo mobile-app --include-local-secrets --json)"
+run_contains "auth_json_status" '"AUTH_STATUS": "auth_configured"' "$auth_json"
+run_contains "auth_json_private_key_path" "\"AUTH_PRIVATE_KEY_PATH\": \"$mobile_key\"" "$auth_json"
 
 body_file="$hub_dir/body.md"
 printf 'PR body\n' > "$body_file"
@@ -153,6 +156,19 @@ run_contains "mobile_dry_run_targets_mobile" "TARGET_REPO=example/mobile-app" "$
 run_contains "admin_dry_run_targets_admin" "TARGET_REPO=example/admin-portal" "$admin_dry_run"
 run_not_contains "dry_run_redacts_token" "fixture-installation-token" "$mobile_dry_run"
 run_contains "dry_run_command_shape" "GH_TOKEN=<redacted> gh pr create --repo 'example/mobile-app'" "$mobile_dry_run"
+
+https_dir="$(fixture_dir https-url)"
+cat > "$https_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: web-app
+      git_url: https://github.com/example/web-app.git
+YAML
+https_dry_run="$(bash "$PR_HELPER" --repo-root "$https_dir" --repo web-app --base main --head feature/test --title "Web PR" --body-file "$body_file" --dry-run)"
+run_contains "https_git_url_targets_repo" "TARGET_REPO=example/web-app" "$https_dry_run"
 
 non_github_dir="$(fixture_dir non-github)"
 cat > "$non_github_dir/.ai-dev-workflow.yaml" <<'YAML'
@@ -174,10 +190,20 @@ cat > "$single_repo_dir/.ai-dev-workflow.yaml" <<'YAML'
 schema_version: 2
 mode: single_repo
 YAML
+single_auth_json="$(python3 "$RESOLVER" auth --repo-root "$single_repo_dir" --json)"
+run_contains "auth_not_required_json" '"AUTH_STATUS": "not_required"' "$single_auth_json"
 run_fails_contains \
   "product_pr_single_repo_mode_fails" \
   "product PR operations require workflow_hub mode" \
   bash "$PR_HELPER" --repo-root "$single_repo_dir" --repo mobile-app --base main --head feature/test --title "Mobile PR" --body-file "$body_file" --dry-run
+run_fails_contains \
+  "product_pr_missing_repo_value" \
+  "--repo requires a value" \
+  bash "$PR_HELPER" --repo
+run_fails_contains \
+  "token_helper_missing_repo_value" \
+  "--repo requires a value" \
+  bash "$TOKEN_HELPER" --repo
 
 missing_app_dir="$(fixture_dir missing-app)"
 cat > "$missing_app_dir/.ai-dev-workflow.yaml" <<'YAML'
@@ -289,6 +315,33 @@ run_fails_contains \
   "token_helper_secret_ref_empty_result" \
   "secret_ref resolver returned an empty private key" \
   env WORKFLOW_GITHUB_APP_SECRET_REF_COMMAND="$secret_ref_empty_stub" bash "$TOKEN_HELPER" --repo-root "$secret_ref_dir" --repo mobile-app --print-token
+
+precedence_dir="$(fixture_dir precedence)"
+precedence_key="$precedence_dir/mobile-app.pem"
+make_private_key "$precedence_key"
+cat > "$precedence_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      github_app:
+        app_id: "shared-app"
+        installation_id: "shared-installation"
+YAML
+cat > "$precedence_dir/.ai-dev-workflow.local.yaml" <<YAML
+product_repos:
+  - name: mobile-app
+    github_app:
+      app_id: "local-app"
+      installation_id: "local-installation"
+      private_key_path: "$precedence_key"
+YAML
+precedence_auth="$(python3 "$RESOLVER" auth --repo-root "$precedence_dir" --repo mobile-app --include-local-secrets)"
+run_contains "auth_precedence_local_app_id" "AUTH_APP_ID=local-app" "$precedence_auth"
+run_contains "auth_precedence_local_installation" "AUTH_INSTALLATION_ID=local-installation" "$precedence_auth"
 
 missing_installation_dir="$(fixture_dir missing-installation)"
 cat > "$missing_installation_dir/.ai-dev-workflow.yaml" <<'YAML'

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -660,25 +660,32 @@ def print_shell_context(values: dict[str, str]) -> None:
             print(f"{key}={shlex.quote(str(value))}")
 
 
+def print_context(args: argparse.Namespace, values: dict[str, str]) -> None:
+    if getattr(args, "json", False):
+        print(json.dumps(values, sort_keys=True))
+    else:
+        print_shell_context(values)
+
+
 def cmd_mode(args: argparse.Namespace) -> int:
     repo_root = repo_root_from_args(args.repo_root)
     shared, _, shared_path, _ = load_configs(repo_root)
-    print_shell_context({"WORKFLOW_MODE": mode_from_shared(shared, shared_path)})
+    print_context(args, {"WORKFLOW_MODE": mode_from_shared(shared, shared_path)})
     return 0
 
 
 def cmd_resolve(args: argparse.Namespace) -> int:
-    print_shell_context(resolve_context(args))
+    print_context(args, resolve_context(args))
     return 0
 
 
 def cmd_auth(args: argparse.Namespace) -> int:
-    print_shell_context(resolve_auth_context(args))
+    print_context(args, resolve_auth_context(args))
     return 0
 
 
 def cmd_review_overrides(args: argparse.Namespace) -> int:
-    print_shell_context(resolve_review_overrides(args))
+    print_context(args, resolve_review_overrides(args))
     return 0
 
 
@@ -688,6 +695,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     mode = subcommands.add_parser("mode", help="print the effective workflow mode")
     mode.add_argument("--repo-root")
+    mode.add_argument("--json", action="store_true", help="print JSON instead of shell KEY=value")
     mode.set_defaults(func=cmd_mode)
 
     for name in ("resolve", "validate"):
@@ -699,6 +707,7 @@ def build_parser() -> argparse.ArgumentParser:
             action="store_true",
             help="require a resolved local product checkout path",
         )
+        command.add_argument("--json", action="store_true", help="print JSON instead of shell KEY=value")
         command.set_defaults(func=cmd_resolve)
 
     auth = subcommands.add_parser("auth", help="print product repository auth metadata")
@@ -709,12 +718,14 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="include local secret references for machine callers; do not use for normal logs",
     )
+    auth.add_argument("--json", action="store_true", help="print JSON instead of shell KEY=value")
     auth.set_defaults(func=cmd_auth)
 
     overrides = subcommands.add_parser(
         "review-overrides", help="print local review override compatibility values"
     )
     overrides.add_argument("--repo-root")
+    overrides.add_argument("--json", action="store_true", help="print JSON instead of shell KEY=value")
     overrides.set_defaults(func=cmd_review_overrides)
     return parser
 

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -409,6 +409,16 @@ def flatten_tracker_hints(repo: dict[str, Any]) -> str:
     return ",".join(parts)
 
 
+def github_repo_from_url(value: str) -> str:
+    match = re.match(
+        r"^(?:git@github\.com:|https://github\.com/|ssh://git@github\.com/)([^/\s]+/[^/\s]+?)(?:\.git)?/?$",
+        value,
+    )
+    if not match:
+        return ""
+    return match.group(1)
+
+
 def parse_remote_slug(repo_root: Path) -> str:
     git_config = repo_root / ".git" / "config"
     if not git_config.exists():
@@ -426,6 +436,84 @@ def parse_remote_slug(repo_root: Path) -> str:
         return ""
     slug = match.group(1)
     return slug[:-4] if slug.endswith(".git") else slug
+
+
+def nested_mapping(value: dict[str, Any], key: str) -> dict[str, Any]:
+    raw = value.get(key)
+    return raw if isinstance(raw, dict) else {}
+
+
+def first_present(*values: Any) -> str:
+    for value in values:
+        if value is not None and value != "":
+            return str(value)
+    return ""
+
+
+def resolve_auth_context(args: argparse.Namespace) -> dict[str, str]:
+    repo_root = repo_root_from_args(args.repo_root)
+    shared, local, shared_path, local_path = load_configs(repo_root)
+    mode = mode_from_shared(shared, shared_path)
+    if mode != "workflow_hub":
+        return {
+            "WORKFLOW_MODE": mode,
+            "AUTH_STATUS": "not_required",
+            "AUTH_REQUIRES_PRODUCT_REPO": "false",
+            "AUTH_MESSAGE": "GitHub App product-repo auth is only required in workflow_hub mode",
+        }
+
+    repo = select_product_repo(product_repos(shared, shared_path), args.repo, shared_path)
+    local_repo = local_product_repo(local, local_path, str(repo["name"]))
+    shared_app = nested_mapping(repo, "github_app")
+    local_app = nested_mapping(local_repo, "github_app")
+
+    github_repo = str(repo.get("github_repo") or "")
+    if not github_repo and repo.get("git_url"):
+        github_repo = github_repo_from_url(str(repo.get("git_url")))
+
+    app_id = first_present(local_app.get("app_id"), local_repo.get("app_id"), shared_app.get("app_id"))
+    installation_id = first_present(
+        local_app.get("installation_id"),
+        local_repo.get("installation_id"),
+        shared_app.get("installation_id"),
+    )
+    private_key_path = first_present(
+        local_app.get("private_key_path"), local_repo.get("private_key_path")
+    )
+    secret_ref = first_present(local_app.get("secret_ref"), local_repo.get("secret_ref"))
+
+    status = "auth_configured"
+    if not app_id:
+        status = "missing_app_id"
+    elif not private_key_path and not secret_ref:
+        status = "missing_private_key"
+    elif not installation_id:
+        status = "missing_installation"
+
+    context = {
+        "WORKFLOW_MODE": mode,
+        "TARGET_REPO_NAME": str(repo.get("name") or ""),
+        "TARGET_GITHUB_REPO": github_repo,
+        "TARGET_GIT_URL": str(repo.get("git_url") or ""),
+        "AUTH_STATUS": status,
+        "AUTH_REQUIRES_PRODUCT_REPO": "true",
+        "AUTH_APP_ID_PRESENT": "true" if app_id else "false",
+        "AUTH_INSTALLATION_ID_PRESENT": "true" if installation_id else "false",
+        "AUTH_PRIVATE_KEY_REF_PRESENT": "true" if (private_key_path or secret_ref) else "false",
+        "AUTH_SECRET_SOURCE": (
+            "private_key_path" if private_key_path else ("secret_ref" if secret_ref else "")
+        ),
+    }
+    if args.include_local_secrets:
+        context.update(
+            {
+                "AUTH_APP_ID": app_id,
+                "AUTH_INSTALLATION_ID": installation_id,
+                "AUTH_PRIVATE_KEY_PATH": private_key_path,
+                "AUTH_SECRET_REF": secret_ref,
+            }
+        )
+    return context
 
 
 def resolve_context(args: argparse.Namespace) -> dict[str, str]:
@@ -584,6 +672,11 @@ def cmd_resolve(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_auth(args: argparse.Namespace) -> int:
+    print_shell_context(resolve_auth_context(args))
+    return 0
+
+
 def cmd_review_overrides(args: argparse.Namespace) -> int:
     print_shell_context(resolve_review_overrides(args))
     return 0
@@ -607,6 +700,16 @@ def build_parser() -> argparse.ArgumentParser:
             help="require a resolved local product checkout path",
         )
         command.set_defaults(func=cmd_resolve)
+
+    auth = subcommands.add_parser("auth", help="print product repository auth metadata")
+    auth.add_argument("--repo-root")
+    auth.add_argument("--repo", help="stable product repository name")
+    auth.add_argument(
+        "--include-local-secrets",
+        action="store_true",
+        help="include local secret references for machine callers; do not use for normal logs",
+    )
+    auth.set_defaults(func=cmd_auth)
 
     overrides = subcommands.add_parser(
         "review-overrides", help="print local review override compatibility values"


### PR DESCRIPTION
## Summary

- add a redacted workflow-hub auth metadata resolver path for selected product repositories
- add GitHub App token and product PR helpers with dry-run output and child-process-only `GH_TOKEN` use
- document workflow-hub GitHub App setup, local-only secret references, and dry-run PR routing
- add fixture coverage for redaction, auth failure states, distinct product PR targets, and live helper token scoping

## Pre-Submission Self-Review

- Reviewed `git diff origin/develop-workflow-hub-mode...HEAD` for stale markers, fixed an unused helper, removed an outdated non-goal that contradicted the new PR helper, and added missing edge-case tests before finalizing.
- Checked secret handling: default resolver/token status output omits private key paths; token values only appear in `--print-token`; PR helper dry-run emits `GH_TOKEN=<redacted>`; live PR helper scopes `GH_TOKEN` to the child `gh pr create` invocation.
- Checked shell safety: required arguments are validated up front, temp files use `mktemp`, `gh`/`jq`/token-exchange calls are guarded, and the new fixture harness covers missing app ID, missing private key, secret-ref resolver absence, missing installation, non-GitHub URL failure, shared-config secret rejection, and token redaction.
- Confirmed scope remains hub-owned: this adds helper contracts/docs/tests and does not change tracker ownership or single-repo behavior.

## Script-Accuracy Self-Check

Script: `scripts/development-workflow/github-app-token.sh`
- `--repo`, `--repo-root`, `--status`, `--dry-run`, and `--print-token` flags: verified against option parser.
- `missing_app_id`, `missing_private_key`, `missing_installation`, and `permission_denied` failure outputs: verified against script branches and fixture tests.
- Token output contract: verified `--print-token` prints only the token to stdout in fixture test; normal status/dry-run output is redacted.

Script: `scripts/development-workflow/open-product-pr.sh`
- `--repo`, `--repo-root`, `--base`, `--head`, `--title`, `--body-file`, and `--dry-run` flags: verified against option parser.
- Dry-run output fields `DRY_RUN`, `TARGET_REPO`, `BASE_BRANCH`, `HEAD_BRANCH`, `TITLE`, and redacted `COMMAND`: verified against script output and fixture tests for two repositories.
- Live PR token scoping: verified fixture `gh` receives `GH_TOKEN` only for the child `gh pr create` command and the PR helper output omits token material.

## Validation

- `python3 -m py_compile scripts/development-workflow/workflow-config-resolver.py`
- `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh` (`47 passed, 0 failed`)
- `bash scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh` (`33 passed, 0 failed`)
- `shellcheck --severity=warning scripts/development-workflow/*.sh scripts/development-workflow/tests/*.sh`
- `npx markdownlint-cli2 "docs/specs/developments/20260610165914_880-cross-repo-pr-auth-support/*.md" "docs/testing/workflow/880-cross-repo-pr-auth-support.smoke-test.md" "docs/workflow/development-workflow/integrations/workflow-hub-github-app.md" "docs/workflow/development-workflow/repository-modes.md" "docs/workflow/development-workflow/README.md" "CHANGELOG.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/880-cross-repo-pr-auth-support.smoke-test.md CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`

Closes #880
