### PR TITLE
feat(workflow): add workflow hub product repo commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Workflow hub product repository commands** (#877): adds workflow-hub status, sync, and pull-request visibility commands for product repository checkouts.
 - **Workflow hub product repository PR authentication** (#880): adds local-only GitHub App auth guidance and helpers for opening product repository pull requests without exposing secrets.
 - **Workflow hub template skeletons** (#876): adds inspectable workflow-hub and product-repo-injection skeletons with mode-specific sync-scope metadata.
 - **Shared and local workflow configuration** (#875): separates versioned repository identity from local checkout and secret references, with repository-context helpers for workflow hub routing.

--- a/docs/workflow/development-workflow/repository-modes.md
+++ b/docs/workflow/development-workflow/repository-modes.md
@@ -300,6 +300,26 @@ Local config is optional for `single_repo` mode. It is required only when a
 workflow hub action needs a local product checkout path that cannot be derived
 safely.
 
+Workflow hub operators can inspect and prepare product repositories with:
+
+```bash
+scripts/development-workflow/hub-status.sh --repo mobile-app
+scripts/development-workflow/hub-status.sh --all
+scripts/development-workflow/hub-sync-product-repos.sh --repo mobile-app
+scripts/development-workflow/hub-list-prs.sh --all
+```
+
+These commands are workflow-hub-only surfaces:
+
+- `hub-status.sh` is read-only and reports local checkout path, current branch,
+  clean or dirty state, remote visibility, and a categorized summary.
+- `hub-sync-product-repos.sh` refuses dirty, ahead-only, or diverged checkouts;
+  it only fast-forwards clean repositories and writes local path entries to
+  `.ai-dev-workflow.local.yaml` after explicit bootstrap confirmation.
+- `hub-list-prs.sh` is read-only and targets the resolved product repository
+  with `gh pr list --repo <owner/repo>`, never the workflow hub repository as a
+  fallback.
+
 Workflow-hub product PR authentication uses the same split: shared config may
 store non-secret GitHub App IDs and installation IDs, while private key paths
 and secret-manager references stay local-only. See

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -175,6 +175,79 @@ Use this when:
 - The batch orchestrator needs a deterministic first-pass list of development-folder candidates
 - You want to separate portfolio-level batch planning from single-item orchestration
 
+### Workflow hub product repository commands
+
+These commands run only when `.ai-dev-workflow.yaml` resolves to
+`mode: workflow_hub`. They use the shared repository-context resolver, support
+`--repo <name>` for one configured product repository and `--all` for every
+configured product repository, and fail before checkout inspection when the
+current repository is not a workflow hub.
+
+#### `hub-status.sh`
+
+Inspects local product repository checkouts without modifying them.
+
+Usage:
+
+```bash
+./scripts/development-workflow/hub-status.sh --repo mobile-app
+./scripts/development-workflow/hub-status.sh --all
+```
+
+What it reports:
+
+- Product repository name and local checkout path
+- Current branch when the checkout exists
+- `clean`, `dirty`, `missing_path`, `missing_checkout`, or `failed` status
+- Origin remote visibility
+- A final categorized summary across all selected repositories
+
+Use this before routing implementation work from a workflow hub to confirm that
+the selected checkout exists and that dirty state is visible.
+
+#### `hub-sync-product-repos.sh`
+
+Safely prepares clean product repository checkouts.
+
+Usage:
+
+```bash
+./scripts/development-workflow/hub-sync-product-repos.sh --repo mobile-app
+./scripts/development-workflow/hub-sync-product-repos.sh --all
+./scripts/development-workflow/hub-sync-product-repos.sh --repo mobile-app --bootstrap-local-path --yes
+```
+
+What it does:
+
+- Refuses dirty checkouts before fetch or fast-forward work
+- Fetches the configured default branch and fast-forwards only when local state
+  is not ahead of origin
+- Blocks ahead-only or diverged checkouts instead of rebasing, stashing,
+  resetting, force-updating, or pushing
+- Reports partial success and blocked or failed repositories in the final
+  summary
+- Writes a missing local path to `.ai-dev-workflow.local.yaml` only when
+  `--bootstrap-local-path` is set and the operator confirms the prompt, or when
+  `--yes` is also supplied
+
+#### `hub-list-prs.sh`
+
+Lists open pull requests for selected product repositories without modifying
+remote state.
+
+Usage:
+
+```bash
+./scripts/development-workflow/hub-list-prs.sh --repo mobile-app
+./scripts/development-workflow/hub-list-prs.sh --all
+```
+
+The command resolves `github_repo` directly, or derives `owner/repo` from
+GitHub-form `git_url` values such as `git@github.com:owner/repo.git` and
+`https://github.com/owner/repo.git`. If no GitHub repository slug can be
+resolved, it fails for that product repository instead of falling back to the
+workflow hub repository.
+
 ### `post-merge-cleanup.sh`
 
 After a development PR is merged and the remote branch deleted, sync with origin, switch to develop, pull, and delete the local branch.

--- a/scripts/development-workflow/hub-list-prs.sh
+++ b/scripts/development-workflow/hub-list-prs.sh
@@ -54,7 +54,11 @@ hub_require_workflow_hub_mode "$REPO_ROOT"
 failed_count=0
 clean_count=0
 exit_code=0
-selected_repos="$(hub_selected_repos "$REPO_ROOT" "$REPO_NAME" "$ALL")"
+if ! selected_repos="$(hub_selected_repos "$REPO_ROOT" "$REPO_NAME" "$ALL")"; then
+  failed_count=$((failed_count + 1))
+  hub_print_summary 0 0 "$clean_count" 0 0 0 "$failed_count"
+  exit 1
+fi
 
 while IFS= read -r selected_repo; do
   [ -n "$selected_repo" ] || continue

--- a/scripts/development-workflow/hub-list-prs.sh
+++ b/scripts/development-workflow/hub-list-prs.sh
@@ -81,7 +81,7 @@ while IFS= read -r selected_repo; do
   fi
 
   printf '  GITHUB_REPO=%s\n' "$github_repo"
-  if ! pr_output="$(gh pr list --repo "$github_repo" --state open --json number,title,headRefName,baseRefName,isDraft,labels 2>&1)"; then
+  if ! pr_output="$(gh pr list --repo "$github_repo" --state open --limit 200 --json number,title,headRefName,baseRefName,isDraft,labels 2>&1)"; then
     printf '  STATUS=failed\n'
     printf '  REASON=remote_inspection_failed\n'
     printf '%s\n' "$pr_output" | sed 's/^/  gh: /'

--- a/scripts/development-workflow/hub-list-prs.sh
+++ b/scripts/development-workflow/hub-list-prs.sh
@@ -21,6 +21,7 @@ USAGE
 REPO_NAME=""
 ALL=false
 REPO_ROOT="$HUB_REPO_ROOT"
+PR_LIST_LIMIT=1000
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -81,7 +82,7 @@ while IFS= read -r selected_repo; do
   fi
 
   printf '  GITHUB_REPO=%s\n' "$github_repo"
-  if ! pr_output="$(gh pr list --repo "$github_repo" --state open --limit 200 --json number,title,headRefName,baseRefName,isDraft,labels 2>&1)"; then
+  if ! pr_output="$(gh pr list --repo "$github_repo" --state open --limit "$PR_LIST_LIMIT" --json number,title,headRefName,baseRefName,isDraft,labels 2>&1)"; then
     printf '  STATUS=failed\n'
     printf '  REASON=remote_inspection_failed\n'
     printf '%s\n' "$pr_output" | sed 's/^/  gh: /'
@@ -90,16 +91,24 @@ while IFS= read -r selected_repo; do
     continue
   fi
 
-  printf '  STATUS=clean\n'
-  clean_count=$((clean_count + 1))
-  printf '%s' "$pr_output" | jq -r '
+  if ! formatted_prs="$(printf '%s' "$pr_output" | jq -r '
     if length == 0 then
       "  PRS=none"
     else
       .[] |
       "  PR #\(.number) title=\(.title) head=\(.headRefName) base=\(.baseRefName) draft=\(.isDraft) labels=\([.labels[].name] | join(","))"
     end
-  '
+  ' 2>/dev/null)"; then
+    printf '  STATUS=failed\n'
+    printf '  REASON=pr_json_parse_failed\n'
+    failed_count=$((failed_count + 1))
+    exit_code=1
+    continue
+  fi
+
+  printf '  STATUS=clean\n'
+  clean_count=$((clean_count + 1))
+  printf '%s\n' "$formatted_prs"
 done <<< "$selected_repos"
 
 hub_print_summary 0 0 "$clean_count" 0 0 0 "$failed_count"

--- a/scripts/development-workflow/hub-list-prs.sh
+++ b/scripts/development-workflow/hub-list-prs.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# hub-list-prs.sh - list product repository pull requests from a workflow hub.
+
+set -euo pipefail
+trap 'case $? in 141) exit 0 ;; *) exit $? ;; esac' EXIT
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+# shellcheck source=scripts/development-workflow/hub-product-repo-lib.sh
+source "$SCRIPT_DIR/hub-product-repo-lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: hub-list-prs.sh (--repo <name> | --all) [--repo-root <path>]
+
+List open pull requests for workflow_hub product repositories. The command is
+read-only, requires workflow_hub mode, resolves each product repository's
+GitHub owner/repo identity, and never falls back to the hub repository.
+USAGE
+}
+
+REPO_NAME=""
+ALL=false
+REPO_ROOT="$HUB_REPO_ROOT"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      [ "$#" -ge 2 ] || hub_die "--repo requires a value"
+      REPO_NAME="$2"
+      shift 2
+      ;;
+    --all)
+      ALL=true
+      shift
+      ;;
+    --repo-root)
+      [ "$#" -ge 2 ] || hub_die "--repo-root requires a value"
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      hub_die "unknown argument '$1'"
+      ;;
+  esac
+done
+
+hub_require_workflow_hub_mode "$REPO_ROOT"
+
+failed_count=0
+clean_count=0
+exit_code=0
+selected_repos="$(hub_selected_repos "$REPO_ROOT" "$REPO_NAME" "$ALL")"
+
+while IFS= read -r selected_repo; do
+  [ -n "$selected_repo" ] || continue
+  if ! context="$(hub_resolve_context_json "$REPO_ROOT" "$selected_repo")"; then
+    printf 'REPO %s STATUS=failed\n' "$selected_repo"
+    failed_count=$((failed_count + 1))
+    exit_code=1
+    continue
+  fi
+
+  github_repo="$(hub_json_field "$context" TARGET_GITHUB_REPO)"
+  git_url="$(hub_json_field "$context" TARGET_GIT_URL)"
+  if [ -z "$github_repo" ] && [ -n "$git_url" ]; then
+    github_repo="$(hub_github_repo_from_url "$git_url")"
+  fi
+
+  printf 'REPO %s\n' "$selected_repo"
+  if [ -z "$github_repo" ]; then
+    printf '  STATUS=failed\n'
+    printf '  REASON=no_github_repo_slug\n'
+    printf '  GUIDANCE=configure github_repo or a GitHub-form git_url for this product repository\n'
+    failed_count=$((failed_count + 1))
+    exit_code=1
+    continue
+  fi
+
+  printf '  GITHUB_REPO=%s\n' "$github_repo"
+  if ! pr_output="$(gh pr list --repo "$github_repo" --state open --json number,title,headRefName,baseRefName,isDraft,labels 2>&1)"; then
+    printf '  STATUS=failed\n'
+    printf '  REASON=remote_inspection_failed\n'
+    printf '%s\n' "$pr_output" | sed 's/^/  gh: /'
+    failed_count=$((failed_count + 1))
+    exit_code=1
+    continue
+  fi
+
+  printf '  STATUS=clean\n'
+  clean_count=$((clean_count + 1))
+  printf '%s' "$pr_output" | jq -r '
+    if length == 0 then
+      "  PRS=none"
+    else
+      .[] |
+      "  PR #\(.number) title=\(.title) head=\(.headRefName) base=\(.baseRefName) draft=\(.isDraft) labels=\([.labels[].name] | join(","))"
+    end
+  '
+done <<< "$selected_repos"
+
+hub_print_summary 0 0 "$clean_count" 0 0 0 "$failed_count"
+exit "$exit_code"

--- a/scripts/development-workflow/hub-product-repo-lib.sh
+++ b/scripts/development-workflow/hub-product-repo-lib.sh
@@ -39,9 +39,16 @@ hub_list_product_repos() {
   local output
   if ! output="$(python3 "$HUB_RESOLVER" list-product-repos --repo-root "$repo_root" 2>&1)"; then
     printf '%s\n' "$output" >&2
-    exit 1
+    return 1
   fi
   printf '%s\n' "$output"
+}
+
+hub_branch_is_checked_out() {
+  local repo_path="$1"
+  local branch="$2"
+  git -C "$repo_path" worktree list --porcelain 2>/dev/null |
+    awk -v branch_ref="refs/heads/$branch" '$1 == "branch" && $2 == branch_ref { found = 1 } END { exit(found ? 0 : 1) }'
 }
 
 hub_selected_repos() {
@@ -53,7 +60,7 @@ hub_selected_repos() {
   fi
   if [ "$all" = "true" ]; then
     hub_list_product_repos "$repo_root"
-    return 0
+    return $?
   fi
   if [ -n "$repo_name" ]; then
     printf '%s\n' "$repo_name"

--- a/scripts/development-workflow/hub-product-repo-lib.sh
+++ b/scripts/development-workflow/hub-product-repo-lib.sh
@@ -103,6 +103,11 @@ hub_github_repo_from_url() {
       value=""
       ;;
   esac
+  case "$value" in
+    */*/*|/*|*/|'')
+      value=""
+      ;;
+  esac
   printf '%s\n' "$value"
 }
 

--- a/scripts/development-workflow/hub-product-repo-lib.sh
+++ b/scripts/development-workflow/hub-product-repo-lib.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Shared helpers for workflow-hub product repository commands.
+
+set -euo pipefail
+
+HUB_SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2034 # Sourcing command scripts use this default root.
+HUB_REPO_ROOT="$(CDPATH='' cd -- "$HUB_SCRIPT_DIR/../.." && pwd)"
+HUB_RESOLVER="$HUB_SCRIPT_DIR/workflow-config-resolver.py"
+
+hub_die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+hub_json_field() {
+  local json="$1"
+  local key="$2"
+  if ! printf '%s' "$json" | jq -re --arg key "$key" '.[$key] // ""' 2>/dev/null; then
+    hub_die "resolver output did not include expected field '$key'"
+  fi
+}
+
+hub_require_workflow_hub_mode() {
+  local repo_root="$1"
+  local mode_output mode
+  if ! mode_output="$(python3 "$HUB_RESOLVER" mode --repo-root "$repo_root" --json 2>&1)"; then
+    printf '%s\n' "$mode_output" >&2
+    exit 1
+  fi
+  mode="$(hub_json_field "$mode_output" WORKFLOW_MODE)"
+  if [ "$mode" != "workflow_hub" ]; then
+    hub_die "workflow_hub mode is required; current mode is '$mode'"
+  fi
+}
+
+hub_list_product_repos() {
+  local repo_root="$1"
+  local output
+  if ! output="$(python3 "$HUB_RESOLVER" list-product-repos --repo-root "$repo_root" 2>&1)"; then
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+  printf '%s\n' "$output"
+}
+
+hub_selected_repos() {
+  local repo_root="$1"
+  local repo_name="$2"
+  local all="$3"
+  if [ -n "$repo_name" ] && [ "$all" = "true" ]; then
+    hub_die "--repo and --all cannot be used together"
+  fi
+  if [ "$all" = "true" ]; then
+    hub_list_product_repos "$repo_root"
+    return 0
+  fi
+  if [ -n "$repo_name" ]; then
+    printf '%s\n' "$repo_name"
+    return 0
+  fi
+  hub_die "select one product repository with --repo <name> or all repositories with --all"
+}
+
+hub_resolve_context_json() {
+  local repo_root="$1"
+  local repo_name="$2"
+  local output
+  if ! output="$(python3 "$HUB_RESOLVER" resolve --repo-root "$repo_root" --repo "$repo_name" --json 2>&1)"; then
+    printf '%s\n' "$output" >&2
+    return 1
+  fi
+  printf '%s\n' "$output"
+}
+
+hub_github_repo_from_url() {
+  local value="$1"
+  case "$value" in
+    git@github.com:*/*.git)
+      value="${value#git@github.com:}"
+      value="${value%.git}"
+      ;;
+    git@github.com:*/*)
+      value="${value#git@github.com:}"
+      ;;
+    https://github.com/*/*.git)
+      value="${value#https://github.com/}"
+      value="${value%.git}"
+      ;;
+    https://github.com/*/*)
+      value="${value#https://github.com/}"
+      value="${value%/}"
+      ;;
+    ssh://git@github.com/*/*.git)
+      value="${value#ssh://git@github.com/}"
+      value="${value%.git}"
+      ;;
+    ssh://git@github.com/*/*)
+      value="${value#ssh://git@github.com/}"
+      value="${value%/}"
+      ;;
+    *)
+      value=""
+      ;;
+  esac
+  printf '%s\n' "$value"
+}
+
+hub_missing_path_guidance() {
+  local repo_name="$1"
+  cat <<GUIDANCE
+Add this local-only entry to .ai-dev-workflow.local.yaml:
+product_repos:
+  - name: $repo_name
+    local_path: ../$repo_name
+GUIDANCE
+}
+
+hub_default_local_path() {
+  local repo_root="$1"
+  local repo_name="$2"
+  local parent
+  parent="$(CDPATH='' cd -- "$repo_root/.." && pwd -P)"
+  printf '%s/%s\n' "$parent" "$repo_name"
+}
+
+hub_print_summary() {
+  local synced="$1"
+  local skipped="$2"
+  local clean="$3"
+  local dirty="$4"
+  local missing="$5"
+  local blocked="$6"
+  local failed="$7"
+
+  printf 'SUMMARY synced=%s skipped=%s clean=%s dirty=%s missing=%s blocked=%s failed=%s\n' \
+    "$synced" "$skipped" "$clean" "$dirty" "$missing" "$blocked" "$failed"
+}

--- a/scripts/development-workflow/hub-status.sh
+++ b/scripts/development-workflow/hub-status.sh
@@ -99,7 +99,15 @@ while IFS= read -r selected_repo; do
   fi
   printf '  BRANCH=%s\n' "$branch"
 
-  if [ -n "$(git -C "$local_path" status --porcelain)" ]; then
+  if ! dirty_output="$(git -C "$local_path" status --porcelain 2>/dev/null)"; then
+    printf '  STATUS=failed\n'
+    printf '  ERROR=could not inspect working tree state\n'
+    failed_count=$((failed_count + 1))
+    exit_code=1
+    continue
+  fi
+
+  if [ -n "$dirty_output" ]; then
     printf '  STATUS=dirty\n'
     dirty_count=$((dirty_count + 1))
   else

--- a/scripts/development-workflow/hub-status.sh
+++ b/scripts/development-workflow/hub-status.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# hub-status.sh - inspect workflow-hub product repository checkouts.
+
+set -euo pipefail
+trap 'case $? in 141) exit 0 ;; *) exit $? ;; esac' EXIT
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+# shellcheck source=scripts/development-workflow/hub-product-repo-lib.sh
+source "$SCRIPT_DIR/hub-product-repo-lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: hub-status.sh (--repo <name> | --all) [--repo-root <path>]
+
+Inspect workflow_hub product repository checkouts without modifying them.
+Reports local path, branch, clean/dirty state, remote visibility, and a final
+summary. Fails before checkout inspection unless the repository is in
+workflow_hub mode. Missing local paths include .ai-dev-workflow.local.yaml
+guidance.
+USAGE
+}
+
+REPO_NAME=""
+ALL=false
+REPO_ROOT="$HUB_REPO_ROOT"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      [ "$#" -ge 2 ] || hub_die "--repo requires a value"
+      REPO_NAME="$2"
+      shift 2
+      ;;
+    --all)
+      ALL=true
+      shift
+      ;;
+    --repo-root)
+      [ "$#" -ge 2 ] || hub_die "--repo-root requires a value"
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      hub_die "unknown argument '$1'"
+      ;;
+  esac
+done
+
+hub_require_workflow_hub_mode "$REPO_ROOT"
+
+clean_count=0
+dirty_count=0
+missing_count=0
+failed_count=0
+exit_code=0
+selected_repos="$(hub_selected_repos "$REPO_ROOT" "$REPO_NAME" "$ALL")"
+
+while IFS= read -r selected_repo; do
+  [ -n "$selected_repo" ] || continue
+  if ! context="$(hub_resolve_context_json "$REPO_ROOT" "$selected_repo")"; then
+    printf 'REPO %s STATUS=failed\n' "$selected_repo"
+    failed_count=$((failed_count + 1))
+    exit_code=1
+    continue
+  fi
+
+  local_path="$(hub_json_field "$context" TARGET_LOCAL_PATH)"
+  local_source="$(hub_json_field "$context" TARGET_LOCAL_PATH_SOURCE)"
+  printf 'REPO %s\n' "$selected_repo"
+  printf '  LOCAL_PATH=%s\n' "${local_path:-}"
+  printf '  LOCAL_PATH_SOURCE=%s\n' "${local_source:-}"
+
+  if [ -z "$local_path" ]; then
+    printf '  STATUS=missing_path\n'
+    hub_missing_path_guidance "$selected_repo" | sed 's/^/  /'
+    missing_count=$((missing_count + 1))
+    exit_code=1
+    continue
+  fi
+
+  if [ ! -d "$local_path/.git" ]; then
+    printf '  STATUS=missing_checkout\n'
+    printf '  GUIDANCE=create or clone the checkout at %s\n' "$local_path"
+    missing_count=$((missing_count + 1))
+    exit_code=1
+    continue
+  fi
+
+  if ! branch="$(git -C "$local_path" rev-parse --abbrev-ref HEAD 2>/dev/null)"; then
+    printf '  STATUS=failed\n'
+    printf '  ERROR=could not read current branch\n'
+    failed_count=$((failed_count + 1))
+    exit_code=1
+    continue
+  fi
+  printf '  BRANCH=%s\n' "$branch"
+
+  if [ -n "$(git -C "$local_path" status --porcelain)" ]; then
+    printf '  STATUS=dirty\n'
+    dirty_count=$((dirty_count + 1))
+  else
+    printf '  STATUS=clean\n'
+    clean_count=$((clean_count + 1))
+  fi
+
+  if remote_url="$(git -C "$local_path" remote get-url origin 2>/dev/null)"; then
+    printf '  REMOTE=available\n'
+    printf '  REMOTE_URL=%s\n' "$remote_url"
+  else
+    printf '  REMOTE=unavailable\n'
+  fi
+done <<< "$selected_repos"
+
+hub_print_summary 0 0 "$clean_count" "$dirty_count" "$missing_count" 0 "$failed_count"
+exit "$exit_code"

--- a/scripts/development-workflow/hub-status.sh
+++ b/scripts/development-workflow/hub-status.sh
@@ -57,7 +57,11 @@ dirty_count=0
 missing_count=0
 failed_count=0
 exit_code=0
-selected_repos="$(hub_selected_repos "$REPO_ROOT" "$REPO_NAME" "$ALL")"
+if ! selected_repos="$(hub_selected_repos "$REPO_ROOT" "$REPO_NAME" "$ALL")"; then
+  failed_count=$((failed_count + 1))
+  hub_print_summary 0 0 "$clean_count" "$dirty_count" "$missing_count" 0 "$failed_count"
+  exit 1
+fi
 
 while IFS= read -r selected_repo; do
   [ -n "$selected_repo" ] || continue

--- a/scripts/development-workflow/hub-sync-product-repos.sh
+++ b/scripts/development-workflow/hub-sync-product-repos.sh
@@ -36,7 +36,7 @@ confirm_bootstrap() {
 
 sync_one_repo() {
   local selected_repo="$1"
-  local context local_path default_branch current_branch remote_ref ahead behind counts
+  local context local_path default_branch current_branch remote_ref ahead behind counts dirty_output
 
   if ! context="$(hub_resolve_context_json "$REPO_ROOT" "$selected_repo")"; then
     printf 'REPO %s STATUS=failed\n' "$selected_repo"
@@ -77,7 +77,14 @@ sync_one_repo() {
     return 1
   fi
 
-  if [ -n "$(git -C "$local_path" status --porcelain)" ]; then
+  if ! dirty_output="$(git -C "$local_path" status --porcelain 2>/dev/null)"; then
+    printf '  STATUS=failed\n'
+    printf '  REASON=working_tree_inspection_failed\n'
+    failed_count=$((failed_count + 1))
+    return 1
+  fi
+
+  if [ -n "$dirty_output" ]; then
     printf '  STATUS=blocked\n'
     printf '  REASON=dirty_checkout\n'
     printf '  PATH=%s\n' "$local_path"

--- a/scripts/development-workflow/hub-sync-product-repos.sh
+++ b/scripts/development-workflow/hub-sync-product-repos.sh
@@ -34,33 +34,10 @@ confirm_bootstrap() {
   esac
 }
 
-restore_original_branch() {
-  local local_path="$1"
-  local original_branch="$2"
-  if ! git -C "$local_path" checkout "$original_branch" >/dev/null 2>&1; then
-    printf '  RESTORE_ORIGINAL_BRANCH=failed\n'
-    printf '  ORIGINAL_BRANCH=%s\n' "$original_branch"
-    return 1
-  fi
-  printf '  RESTORE_ORIGINAL_BRANCH=ok\n'
-  printf '  ORIGINAL_BRANCH=%s\n' "$original_branch"
-  return 0
-}
-
-return_after_sync_failure() {
-  local local_path="$1"
-  local original_branch="$2"
-  local switched_branch="$3"
-  if [ "$switched_branch" = "true" ]; then
-    restore_original_branch "$local_path" "$original_branch" || return 1
-  fi
-  return 1
-}
-
 sync_one_repo() {
   local selected_repo="$1"
   local context local_path default_branch current_branch remote_ref ahead behind counts dirty_output branch_after
-  local switched_branch=false
+  local local_ref
 
   if ! context="$(hub_resolve_context_json "$REPO_ROOT" "$selected_repo")"; then
     printf 'REPO %s STATUS=failed\n' "$selected_repo"
@@ -131,21 +108,10 @@ sync_one_repo() {
   fi
   printf '  BRANCH_BEFORE=%s\n' "$current_branch"
 
-  if [ "$current_branch" != "$default_branch" ]; then
-    if ! git -C "$local_path" checkout "$default_branch" >/dev/null 2>&1; then
-      printf '  STATUS=failed\n'
-      printf '  REASON=default_branch_checkout_failed\n'
-      failed_count=$((failed_count + 1))
-      return 1
-    fi
-    switched_branch=true
-  fi
-
   if ! git -C "$local_path" fetch origin "$default_branch" >/dev/null 2>&1; then
     printf '  STATUS=failed\n'
     printf '  REASON=fetch_failed\n'
     failed_count=$((failed_count + 1))
-    return_after_sync_failure "$local_path" "$current_branch" "$switched_branch"
     return 1
   fi
 
@@ -154,15 +120,24 @@ sync_one_repo() {
     printf '  STATUS=failed\n'
     printf '  REASON=remote_branch_missing\n'
     failed_count=$((failed_count + 1))
-    return_after_sync_failure "$local_path" "$current_branch" "$switched_branch"
     return 1
   fi
 
-  if ! counts="$(git -C "$local_path" rev-list --left-right --count "HEAD...$remote_ref" 2>/dev/null)"; then
+  local_ref="HEAD"
+  if [ "$current_branch" != "$default_branch" ]; then
+    local_ref="$default_branch"
+    if ! git -C "$local_path" rev-parse --verify "$local_ref" >/dev/null 2>&1; then
+      printf '  STATUS=failed\n'
+      printf '  REASON=local_default_branch_missing\n'
+      failed_count=$((failed_count + 1))
+      return 1
+    fi
+  fi
+
+  if ! counts="$(git -C "$local_path" rev-list --left-right --count "$local_ref...$remote_ref" 2>/dev/null)"; then
     printf '  STATUS=failed\n'
     printf '  REASON=ahead_behind_check_failed\n'
     failed_count=$((failed_count + 1))
-    return_after_sync_failure "$local_path" "$current_branch" "$switched_branch"
     return 1
   fi
   ahead="${counts%%[[:space:]]*}"
@@ -174,16 +149,21 @@ sync_one_repo() {
     printf '  AHEAD=%s\n' "$ahead"
     printf '  BEHIND=%s\n' "$behind"
     blocked_count=$((blocked_count + 1))
-    return_after_sync_failure "$local_path" "$current_branch" "$switched_branch"
     return 1
   fi
 
   if [ "$behind" -gt 0 ]; then
-    if ! git -C "$local_path" merge --ff-only "$remote_ref" >/dev/null 2>&1; then
+    if [ "$current_branch" = "$default_branch" ]; then
+      if ! git -C "$local_path" merge --ff-only "$remote_ref" >/dev/null 2>&1; then
+        printf '  STATUS=failed\n'
+        printf '  REASON=fast_forward_failed\n'
+        failed_count=$((failed_count + 1))
+        return 1
+      fi
+    elif ! git -C "$local_path" fetch origin "$default_branch:$default_branch" >/dev/null 2>&1; then
       printf '  STATUS=failed\n'
       printf '  REASON=fast_forward_failed\n'
       failed_count=$((failed_count + 1))
-      return_after_sync_failure "$local_path" "$current_branch" "$switched_branch"
       return 1
     fi
     printf '  STATUS=synced\n'

--- a/scripts/development-workflow/hub-sync-product-repos.sh
+++ b/scripts/development-workflow/hub-sync-product-repos.sh
@@ -160,6 +160,11 @@ sync_one_repo() {
         failed_count=$((failed_count + 1))
         return 1
       fi
+    elif hub_branch_is_checked_out "$local_path" "$default_branch"; then
+      printf '  STATUS=blocked\n'
+      printf '  REASON=default_branch_checked_out_elsewhere\n'
+      blocked_count=$((blocked_count + 1))
+      return 1
     elif ! git -C "$local_path" fetch origin "$default_branch:$default_branch" >/dev/null 2>&1; then
       printf '  STATUS=failed\n'
       printf '  REASON=fast_forward_failed\n'
@@ -230,7 +235,11 @@ missing_count=0
 blocked_count=0
 failed_count=0
 exit_code=0
-selected_repos="$(hub_selected_repos "$REPO_ROOT" "$REPO_NAME" "$ALL")"
+if ! selected_repos="$(hub_selected_repos "$REPO_ROOT" "$REPO_NAME" "$ALL")"; then
+  failed_count=$((failed_count + 1))
+  hub_print_summary "$synced_count" "$skipped_count" 0 0 "$missing_count" "$blocked_count" "$failed_count"
+  exit 1
+fi
 
 while IFS= read -r selected_repo; do
   [ -n "$selected_repo" ] || continue

--- a/scripts/development-workflow/hub-sync-product-repos.sh
+++ b/scripts/development-workflow/hub-sync-product-repos.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# hub-sync-product-repos.sh - safely sync workflow-hub product checkouts.
+
+set -euo pipefail
+trap 'case $? in 141) exit 0 ;; *) exit $? ;; esac' EXIT
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+# shellcheck source=scripts/development-workflow/hub-product-repo-lib.sh
+source "$SCRIPT_DIR/hub-product-repo-lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: hub-sync-product-repos.sh (--repo <name> | --all) [--repo-root <path>] [--bootstrap-local-path] [--yes]
+
+Prepare workflow_hub product repository checkouts. The command refuses dirty,
+ahead-only, or diverged checkouts and only fast-forwards clean repositories.
+It fails before checkout inspection unless the repository is in workflow_hub
+mode. Missing local paths can be written to .ai-dev-workflow.local.yaml only
+with --bootstrap-local-path and explicit confirmation; --yes confirms.
+USAGE
+}
+
+confirm_bootstrap() {
+  local repo_name="$1"
+  local local_path="$2"
+  if [ "$YES" = "true" ]; then
+    return 0
+  fi
+  printf "Write local_path '%s' for product repo '%s' to .ai-dev-workflow.local.yaml? [y/N] " "$local_path" "$repo_name" >&2
+  IFS= read -r answer || return 1
+  case "$answer" in
+    y|Y|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+sync_one_repo() {
+  local selected_repo="$1"
+  local context local_path default_branch current_branch remote_ref ahead behind counts
+
+  if ! context="$(hub_resolve_context_json "$REPO_ROOT" "$selected_repo")"; then
+    printf 'REPO %s STATUS=failed\n' "$selected_repo"
+    failed_count=$((failed_count + 1))
+    return 1
+  fi
+
+  local_path="$(hub_json_field "$context" TARGET_LOCAL_PATH)"
+  default_branch="$(hub_json_field "$context" TARGET_DEFAULT_BRANCH)"
+  [ -n "$default_branch" ] || default_branch="main"
+
+  printf 'REPO %s\n' "$selected_repo"
+  printf '  DEFAULT_BRANCH=%s\n' "$default_branch"
+
+  if [ -z "$local_path" ]; then
+    local_path="$(hub_default_local_path "$REPO_ROOT" "$selected_repo")"
+    printf '  STATUS=missing_path\n'
+    printf '  SUGGESTED_LOCAL_PATH=%s\n' "$local_path"
+    hub_missing_path_guidance "$selected_repo" | sed 's/^/  /'
+    if [ "$BOOTSTRAP_LOCAL_PATH" = "true" ]; then
+      if confirm_bootstrap "$selected_repo" "$local_path"; then
+        python3 "$HUB_RESOLVER" set-local-path --repo-root "$REPO_ROOT" --repo "$selected_repo" --local-path "$local_path" >/dev/null
+        printf '  BOOTSTRAP=written\n'
+        skipped_count=$((skipped_count + 1))
+        return 0
+      fi
+      printf '  BOOTSTRAP=declined\n'
+    fi
+    missing_count=$((missing_count + 1))
+    return 1
+  fi
+
+  printf '  LOCAL_PATH=%s\n' "$local_path"
+  if [ ! -d "$local_path/.git" ]; then
+    printf '  STATUS=missing_checkout\n'
+    printf '  GUIDANCE=create or clone the checkout at %s\n' "$local_path"
+    missing_count=$((missing_count + 1))
+    return 1
+  fi
+
+  if [ -n "$(git -C "$local_path" status --porcelain)" ]; then
+    printf '  STATUS=blocked\n'
+    printf '  REASON=dirty_checkout\n'
+    printf '  PATH=%s\n' "$local_path"
+    blocked_count=$((blocked_count + 1))
+    return 1
+  fi
+
+  if ! git -C "$local_path" remote get-url origin >/dev/null 2>&1; then
+    printf '  STATUS=failed\n'
+    printf '  REASON=missing_origin_remote\n'
+    failed_count=$((failed_count + 1))
+    return 1
+  fi
+
+  if ! git -C "$local_path" fetch origin "$default_branch" >/dev/null 2>&1; then
+    printf '  STATUS=failed\n'
+    printf '  REASON=fetch_failed\n'
+    failed_count=$((failed_count + 1))
+    return 1
+  fi
+
+  if ! current_branch="$(git -C "$local_path" rev-parse --abbrev-ref HEAD 2>/dev/null)"; then
+    printf '  STATUS=failed\n'
+    printf '  REASON=current_branch_unreadable\n'
+    failed_count=$((failed_count + 1))
+    return 1
+  fi
+  printf '  BRANCH_BEFORE=%s\n' "$current_branch"
+
+  if [ "$current_branch" != "$default_branch" ]; then
+    if ! git -C "$local_path" checkout "$default_branch" >/dev/null 2>&1; then
+      printf '  STATUS=failed\n'
+      printf '  REASON=default_branch_checkout_failed\n'
+      failed_count=$((failed_count + 1))
+      return 1
+    fi
+  fi
+
+  remote_ref="origin/$default_branch"
+  if ! git -C "$local_path" rev-parse --verify "$remote_ref" >/dev/null 2>&1; then
+    printf '  STATUS=failed\n'
+    printf '  REASON=remote_branch_missing\n'
+    failed_count=$((failed_count + 1))
+    return 1
+  fi
+
+  counts="$(git -C "$local_path" rev-list --left-right --count "HEAD...$remote_ref")"
+  ahead="${counts%%[[:space:]]*}"
+  behind="${counts##*[[:space:]]}"
+
+  if [ "$ahead" -gt 0 ]; then
+    printf '  STATUS=blocked\n'
+    printf '  REASON=local_ahead_or_diverged\n'
+    printf '  AHEAD=%s\n' "$ahead"
+    printf '  BEHIND=%s\n' "$behind"
+    blocked_count=$((blocked_count + 1))
+    return 1
+  fi
+
+  if [ "$behind" -gt 0 ]; then
+    if ! git -C "$local_path" merge --ff-only "$remote_ref" >/dev/null 2>&1; then
+      printf '  STATUS=failed\n'
+      printf '  REASON=fast_forward_failed\n'
+      failed_count=$((failed_count + 1))
+      return 1
+    fi
+    printf '  STATUS=synced\n'
+    synced_count=$((synced_count + 1))
+  else
+    printf '  STATUS=skipped\n'
+    printf '  REASON=already_current\n'
+    skipped_count=$((skipped_count + 1))
+  fi
+
+  printf '  BRANCH_AFTER=%s\n' "$(git -C "$local_path" rev-parse --abbrev-ref HEAD)"
+  return 0
+}
+
+REPO_NAME=""
+ALL=false
+REPO_ROOT="$HUB_REPO_ROOT"
+BOOTSTRAP_LOCAL_PATH=false
+YES=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      [ "$#" -ge 2 ] || hub_die "--repo requires a value"
+      REPO_NAME="$2"
+      shift 2
+      ;;
+    --all)
+      ALL=true
+      shift
+      ;;
+    --repo-root)
+      [ "$#" -ge 2 ] || hub_die "--repo-root requires a value"
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --bootstrap-local-path)
+      BOOTSTRAP_LOCAL_PATH=true
+      shift
+      ;;
+    --yes)
+      YES=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      hub_die "unknown argument '$1'"
+      ;;
+  esac
+done
+
+hub_require_workflow_hub_mode "$REPO_ROOT"
+
+synced_count=0
+skipped_count=0
+missing_count=0
+blocked_count=0
+failed_count=0
+exit_code=0
+selected_repos="$(hub_selected_repos "$REPO_ROOT" "$REPO_NAME" "$ALL")"
+
+while IFS= read -r selected_repo; do
+  [ -n "$selected_repo" ] || continue
+  sync_one_repo "$selected_repo" || exit_code=1
+done <<< "$selected_repos"
+
+hub_print_summary "$synced_count" "$skipped_count" 0 0 "$missing_count" "$blocked_count" "$failed_count"
+exit "$exit_code"

--- a/scripts/development-workflow/hub-sync-product-repos.sh
+++ b/scripts/development-workflow/hub-sync-product-repos.sh
@@ -34,9 +34,23 @@ confirm_bootstrap() {
   esac
 }
 
+restore_original_branch() {
+  local local_path="$1"
+  local original_branch="$2"
+  if ! git -C "$local_path" checkout "$original_branch" >/dev/null 2>&1; then
+    printf '  RESTORE_ORIGINAL_BRANCH=failed\n'
+    printf '  ORIGINAL_BRANCH=%s\n' "$original_branch"
+    return 1
+  fi
+  printf '  RESTORE_ORIGINAL_BRANCH=ok\n'
+  printf '  ORIGINAL_BRANCH=%s\n' "$original_branch"
+  return 0
+}
+
 sync_one_repo() {
   local selected_repo="$1"
-  local context local_path default_branch current_branch remote_ref ahead behind counts dirty_output
+  local context local_path default_branch current_branch remote_ref ahead behind counts dirty_output branch_after
+  local switched_branch=false
 
   if ! context="$(hub_resolve_context_json "$REPO_ROOT" "$selected_repo")"; then
     printf 'REPO %s STATUS=failed\n' "$selected_repo"
@@ -121,6 +135,7 @@ sync_one_repo() {
       failed_count=$((failed_count + 1))
       return 1
     fi
+    switched_branch=true
   fi
 
   remote_ref="origin/$default_branch"
@@ -128,10 +143,21 @@ sync_one_repo() {
     printf '  STATUS=failed\n'
     printf '  REASON=remote_branch_missing\n'
     failed_count=$((failed_count + 1))
+    if [ "$switched_branch" = "true" ]; then
+      restore_original_branch "$local_path" "$current_branch" || return 1
+    fi
     return 1
   fi
 
-  counts="$(git -C "$local_path" rev-list --left-right --count "HEAD...$remote_ref")"
+  if ! counts="$(git -C "$local_path" rev-list --left-right --count "HEAD...$remote_ref" 2>/dev/null)"; then
+    printf '  STATUS=failed\n'
+    printf '  REASON=ahead_behind_check_failed\n'
+    failed_count=$((failed_count + 1))
+    if [ "$switched_branch" = "true" ]; then
+      restore_original_branch "$local_path" "$current_branch" || return 1
+    fi
+    return 1
+  fi
   ahead="${counts%%[[:space:]]*}"
   behind="${counts##*[[:space:]]}"
 
@@ -141,6 +167,9 @@ sync_one_repo() {
     printf '  AHEAD=%s\n' "$ahead"
     printf '  BEHIND=%s\n' "$behind"
     blocked_count=$((blocked_count + 1))
+    if [ "$switched_branch" = "true" ]; then
+      restore_original_branch "$local_path" "$current_branch" || return 1
+    fi
     return 1
   fi
 
@@ -149,6 +178,9 @@ sync_one_repo() {
       printf '  STATUS=failed\n'
       printf '  REASON=fast_forward_failed\n'
       failed_count=$((failed_count + 1))
+      if [ "$switched_branch" = "true" ]; then
+        restore_original_branch "$local_path" "$current_branch" || return 1
+      fi
       return 1
     fi
     printf '  STATUS=synced\n'
@@ -159,7 +191,11 @@ sync_one_repo() {
     skipped_count=$((skipped_count + 1))
   fi
 
-  printf '  BRANCH_AFTER=%s\n' "$(git -C "$local_path" rev-parse --abbrev-ref HEAD)"
+  if ! branch_after="$(git -C "$local_path" rev-parse --abbrev-ref HEAD 2>/dev/null)"; then
+    printf '  BRANCH_AFTER=unknown\n'
+  else
+    printf '  BRANCH_AFTER=%s\n' "$branch_after"
+  fi
   return 0
 }
 

--- a/scripts/development-workflow/hub-sync-product-repos.sh
+++ b/scripts/development-workflow/hub-sync-product-repos.sh
@@ -47,6 +47,16 @@ restore_original_branch() {
   return 0
 }
 
+return_after_sync_failure() {
+  local local_path="$1"
+  local original_branch="$2"
+  local switched_branch="$3"
+  if [ "$switched_branch" = "true" ]; then
+    restore_original_branch "$local_path" "$original_branch" || return 1
+  fi
+  return 1
+}
+
 sync_one_repo() {
   local selected_repo="$1"
   local context local_path default_branch current_branch remote_ref ahead behind counts dirty_output branch_after
@@ -113,13 +123,6 @@ sync_one_repo() {
     return 1
   fi
 
-  if ! git -C "$local_path" fetch origin "$default_branch" >/dev/null 2>&1; then
-    printf '  STATUS=failed\n'
-    printf '  REASON=fetch_failed\n'
-    failed_count=$((failed_count + 1))
-    return 1
-  fi
-
   if ! current_branch="$(git -C "$local_path" rev-parse --abbrev-ref HEAD 2>/dev/null)"; then
     printf '  STATUS=failed\n'
     printf '  REASON=current_branch_unreadable\n'
@@ -138,14 +141,20 @@ sync_one_repo() {
     switched_branch=true
   fi
 
+  if ! git -C "$local_path" fetch origin "$default_branch" >/dev/null 2>&1; then
+    printf '  STATUS=failed\n'
+    printf '  REASON=fetch_failed\n'
+    failed_count=$((failed_count + 1))
+    return_after_sync_failure "$local_path" "$current_branch" "$switched_branch"
+    return 1
+  fi
+
   remote_ref="origin/$default_branch"
   if ! git -C "$local_path" rev-parse --verify "$remote_ref" >/dev/null 2>&1; then
     printf '  STATUS=failed\n'
     printf '  REASON=remote_branch_missing\n'
     failed_count=$((failed_count + 1))
-    if [ "$switched_branch" = "true" ]; then
-      restore_original_branch "$local_path" "$current_branch" || return 1
-    fi
+    return_after_sync_failure "$local_path" "$current_branch" "$switched_branch"
     return 1
   fi
 
@@ -153,9 +162,7 @@ sync_one_repo() {
     printf '  STATUS=failed\n'
     printf '  REASON=ahead_behind_check_failed\n'
     failed_count=$((failed_count + 1))
-    if [ "$switched_branch" = "true" ]; then
-      restore_original_branch "$local_path" "$current_branch" || return 1
-    fi
+    return_after_sync_failure "$local_path" "$current_branch" "$switched_branch"
     return 1
   fi
   ahead="${counts%%[[:space:]]*}"
@@ -167,9 +174,7 @@ sync_one_repo() {
     printf '  AHEAD=%s\n' "$ahead"
     printf '  BEHIND=%s\n' "$behind"
     blocked_count=$((blocked_count + 1))
-    if [ "$switched_branch" = "true" ]; then
-      restore_original_branch "$local_path" "$current_branch" || return 1
-    fi
+    return_after_sync_failure "$local_path" "$current_branch" "$switched_branch"
     return 1
   fi
 
@@ -178,9 +183,7 @@ sync_one_repo() {
       printf '  STATUS=failed\n'
       printf '  REASON=fast_forward_failed\n'
       failed_count=$((failed_count + 1))
-      if [ "$switched_branch" = "true" ]; then
-        restore_original_branch "$local_path" "$current_branch" || return 1
-      fi
+      return_after_sync_failure "$local_path" "$current_branch" "$switched_branch"
       return 1
     fi
     printf '  STATUS=synced\n'

--- a/scripts/development-workflow/tests/test-workflow-config-resolver.sh
+++ b/scripts/development-workflow/tests/test-workflow-config-resolver.sh
@@ -182,6 +182,28 @@ newline_path=$'line1\nline2'
 python3 "$RESOLVER" set-local-path --repo-root "$hub_dir" --repo mobile-app --local-path "$newline_path" >/dev/null
 run_contains "workflow_hub_set_local_path_escapes_newline" 'local_path: "line1\nline2"' "$(cat "$hub_dir/.ai-dev-workflow.local.yaml")"
 
+duplicate_local_dir="$(fixture_dir duplicate-local)"
+cat > "$duplicate_local_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+YAML
+cat > "$duplicate_local_dir/.ai-dev-workflow.local.yaml" <<'YAML'
+product_repos:
+  - name: mobile-app
+    local_path: ../one
+  - name: mobile-app
+    local_path: ../two
+YAML
+run_fails_contains \
+  "workflow_hub_set_local_path_duplicate_local_fails" \
+  "duplicate product_repos entries named 'mobile-app'" \
+  python3 "$RESOLVER" set-local-path --repo-root "$duplicate_local_dir" --repo mobile-app --local-path ../three
+
 run_fails_contains \
   "workflow_hub_ambiguous_without_repo" \
   "product repository selection is ambiguous" \

--- a/scripts/development-workflow/tests/test-workflow-config-resolver.sh
+++ b/scripts/development-workflow/tests/test-workflow-config-resolver.sh
@@ -176,6 +176,11 @@ set_local_path_output="$(python3 "$RESOLVER" set-local-path --repo-root "$hub_di
 run_contains "workflow_hub_set_local_path_output" "LOCAL_CONFIG_PATH=$hub_dir/.ai-dev-workflow.local.yaml" "$set_local_path_output"
 admin_local_output="$(workflow_repository_context admin-portal "$hub_dir")"
 run_contains "workflow_hub_set_local_path_resolves" "TARGET_LOCAL_PATH=$TMP_ROOT/local/admin-portal" "$admin_local_output"
+python3 "$RESOLVER" set-local-path --repo-root "$hub_dir" --repo mobile-app --local-path "true" >/dev/null
+run_contains "workflow_hub_set_local_path_quotes_yaml_token" 'local_path: "true"' "$(cat "$hub_dir/.ai-dev-workflow.local.yaml")"
+newline_path=$'line1\nline2'
+python3 "$RESOLVER" set-local-path --repo-root "$hub_dir" --repo mobile-app --local-path "$newline_path" >/dev/null
+run_contains "workflow_hub_set_local_path_escapes_newline" 'local_path: "line1\nline2"' "$(cat "$hub_dir/.ai-dev-workflow.local.yaml")"
 
 run_fails_contains \
   "workflow_hub_ambiguous_without_repo" \

--- a/scripts/development-workflow/tests/test-workflow-config-resolver.sh
+++ b/scripts/development-workflow/tests/test-workflow-config-resolver.sh
@@ -168,6 +168,14 @@ run_contains "workflow_hub_local_path_source" "TARGET_LOCAL_PATH_SOURCE=local_ov
 admin_output="$(workflow_repository_context admin-portal "$hub_dir")"
 run_contains "workflow_hub_checkout_root_path" "TARGET_LOCAL_PATH=$TMP_ROOT/checkouts/admin-portal" "$admin_output"
 run_contains "workflow_hub_checkout_root_source" "TARGET_LOCAL_PATH_SOURCE=checkout_root" "$admin_output"
+repo_list_output="$(python3 "$RESOLVER" list-product-repos --repo-root "$hub_dir")"
+run_contains "workflow_hub_list_product_repos_mobile" "mobile-app" "$repo_list_output"
+run_contains "workflow_hub_list_product_repos_admin" "admin-portal" "$repo_list_output"
+
+set_local_path_output="$(python3 "$RESOLVER" set-local-path --repo-root "$hub_dir" --repo admin-portal --local-path "$TMP_ROOT/local/admin-portal")"
+run_contains "workflow_hub_set_local_path_output" "LOCAL_CONFIG_PATH=$hub_dir/.ai-dev-workflow.local.yaml" "$set_local_path_output"
+admin_local_output="$(workflow_repository_context admin-portal "$hub_dir")"
+run_contains "workflow_hub_set_local_path_resolves" "TARGET_LOCAL_PATH=$TMP_ROOT/local/admin-portal" "$admin_local_output"
 
 run_fails_contains \
   "workflow_hub_ambiguous_without_repo" \

--- a/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
@@ -120,10 +120,12 @@ run_fails_contains "status_unknown_option" "unknown argument '--bogus'" bash "$S
 hub_dir="$(fixture_dir hub)"
 clean_repo="$(fixture_dir clean-product)"
 dirty_repo="$(fixture_dir dirty-product)"
+branch_restore_repo="$(fixture_dir branch-restore-product)"
 missing_checkout="$TMP_ROOT/missing-checkout"
 mkdir -p "$missing_checkout"
 init_repo "$clean_repo" main
 init_repo "$dirty_repo" main
+init_repo "$branch_restore_repo" main
 clean_remote="$(fixture_dir clean-remote.git)"
 updater_repo="$(fixture_dir clean-updater)"
 git init --bare -q -b main "$clean_remote"
@@ -136,6 +138,16 @@ printf 'remote update\n' > "$updater_repo/remote.txt"
 git -C "$updater_repo" add remote.txt
 git -C "$updater_repo" commit -q -m "remote update"
 git -C "$updater_repo" push -q origin main
+restore_remote="$(fixture_dir restore-remote.git)"
+git init --bare -q -b main "$restore_remote"
+git -C "$branch_restore_repo" remote add origin "$restore_remote"
+git -C "$branch_restore_repo" push -q -u origin main
+git -C "$branch_restore_repo" switch -q -c feature/start
+git -C "$branch_restore_repo" switch -q main
+printf 'local ahead\n' > "$branch_restore_repo/local-ahead.txt"
+git -C "$branch_restore_repo" add local-ahead.txt
+git -C "$branch_restore_repo" commit -q -m "local ahead"
+git -C "$branch_restore_repo" switch -q feature/start
 printf 'dirty\n' > "$dirty_repo/dirty.txt"
 
 cat > "$hub_dir/.ai-dev-workflow.yaml" <<'YAML'
@@ -149,6 +161,9 @@ workflow_hub:
       default_branch: main
     - name: dirty-app
       github_repo: example/dirty-app
+      default_branch: main
+    - name: branch-restore-app
+      github_repo: example/branch-restore-app
       default_branch: main
     - name: missing-path-app
       github_repo: example/missing-path-app
@@ -169,6 +184,8 @@ product_repos:
     local_path: "$clean_repo"
   - name: dirty-app
     local_path: "$dirty_repo"
+  - name: branch-restore-app
+    local_path: "$branch_restore_repo"
   - name: missing-checkout-app
     local_path: "$missing_checkout"
 YAML
@@ -201,6 +218,21 @@ run_contains "status_all_summary" "SUMMARY" "$all_status"
 
 run_fails_contains "sync_dirty_refusal" "REASON=dirty_checkout" bash "$SYNC_CMD" --repo-root "$hub_dir" --repo dirty-app
 run_fails_contains "sync_repo_all_conflict" "--repo and --all cannot be used together" bash "$SYNC_CMD" --repo-root "$hub_dir" --repo clean-app --all
+set +e
+branch_restore_output="$(bash "$SYNC_CMD" --repo-root "$hub_dir" --repo branch-restore-app 2>&1)"
+branch_restore_code=$?
+set -e
+if [ "$branch_restore_code" -ne 0 ]; then
+  echo "PASS: sync_branch_restore_exit"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: sync_branch_restore_exit - expected blocked local-ahead branch"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+run_contains "sync_branch_restore_reason" "REASON=local_ahead_or_diverged" "$branch_restore_output"
+run_contains "sync_branch_restore_marker" "RESTORE_ORIGINAL_BRANCH=ok" "$branch_restore_output"
+branch_after_restore="$(git -C "$branch_restore_repo" rev-parse --abbrev-ref HEAD)"
+run_contains "sync_branch_restore_current_branch" "feature/start" "$branch_after_restore"
 
 set +e
 all_sync="$(bash "$SYNC_CMD" --repo-root "$hub_dir" --all 2>&1)"

--- a/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# test-workflow-hub-product-repo-commands.sh - workflow-hub product command tests.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+STATUS_CMD="$REPO_ROOT/scripts/development-workflow/hub-status.sh"
+SYNC_CMD="$REPO_ROOT/scripts/development-workflow/hub-sync-product-repos.sh"
+PRS_CMD="$REPO_ROOT/scripts/development-workflow/hub-list-prs.sh"
+RESOLVER="$REPO_ROOT/scripts/development-workflow/workflow-config-resolver.py"
+
+TMP_ROOT="$(mktemp -d)"
+TMP_ROOT="$(CDPATH='' cd -- "$TMP_ROOT" && pwd -P)"
+
+_harness_exit() {
+  local status=$?
+  rm -rf "$TMP_ROOT"
+  case "$status" in
+    141) exit 0 ;;
+    *)   exit "$status" ;;
+  esac
+}
+trap _harness_exit EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_contains() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if grep -Fq -- "$expected" <<< "$actual"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected output to contain '${expected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_not_contains() {
+  local name="$1"
+  local unexpected="$2"
+  local actual="$3"
+  if grep -Fq -- "$unexpected" <<< "$actual"; then
+    echo "FAIL: $name - output unexpectedly contained '${unexpected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  else
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  fi
+}
+
+run_fails_contains() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  local output=""
+  local status=0
+
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+
+  if [ "$status" -ne 0 ] && grep -Fq -- "$expected" <<< "$output"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected failure containing '${expected}'"
+    printf 'Status: %s\nOutput:\n%s\n' "$status" "$output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+fixture_dir() {
+  local name="$1"
+  local path="$TMP_ROOT/$name"
+  mkdir -p "$path"
+  printf '%s\n' "$path"
+}
+
+init_repo() {
+  local path="$1"
+  local branch="$2"
+  mkdir -p "$path"
+  git -C "$path" init -q -b "$branch"
+  git -C "$path" config user.email "test@example.com"
+  git -C "$path" config user.name "Test User"
+  printf 'initial\n' > "$path/README.md"
+  git -C "$path" add README.md
+  git -C "$path" commit -q -m "initial commit"
+}
+
+echo ""
+echo "=== Workflow hub product repository commands ==="
+
+for command in "$STATUS_CMD" "$SYNC_CMD" "$PRS_CMD"; do
+  help_output="$(bash "$command" --help)"
+  run_contains "help_${command##*/}_usage" "Usage:" "$help_output"
+  run_contains "help_${command##*/}_mode" "workflow_hub" "$help_output"
+done
+
+single_repo_dir="$(fixture_dir single-repo)"
+cat > "$single_repo_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: single_repo
+YAML
+run_fails_contains "status_wrong_mode" "workflow_hub mode is required" bash "$STATUS_CMD" --repo-root "$single_repo_dir" --repo mobile-app
+run_fails_contains "sync_wrong_mode" "workflow_hub mode is required" bash "$SYNC_CMD" --repo-root "$single_repo_dir" --repo mobile-app
+run_fails_contains "prs_wrong_mode" "workflow_hub mode is required" bash "$PRS_CMD" --repo-root "$single_repo_dir" --repo mobile-app
+run_fails_contains "status_missing_repo_value" "--repo requires a value" bash "$STATUS_CMD" --repo
+run_fails_contains "sync_missing_repo_value" "--repo requires a value" bash "$SYNC_CMD" --repo
+run_fails_contains "prs_missing_repo_value" "--repo requires a value" bash "$PRS_CMD" --repo
+run_fails_contains "status_unknown_option" "unknown argument '--bogus'" bash "$STATUS_CMD" --bogus
+
+hub_dir="$(fixture_dir hub)"
+clean_repo="$(fixture_dir clean-product)"
+dirty_repo="$(fixture_dir dirty-product)"
+missing_checkout="$TMP_ROOT/missing-checkout"
+mkdir -p "$missing_checkout"
+init_repo "$clean_repo" main
+init_repo "$dirty_repo" main
+clean_remote="$(fixture_dir clean-remote.git)"
+updater_repo="$(fixture_dir clean-updater)"
+git init --bare -q -b main "$clean_remote"
+git -C "$clean_repo" remote add origin "$clean_remote"
+git -C "$clean_repo" push -q -u origin main
+git clone -q "$clean_remote" "$updater_repo"
+git -C "$updater_repo" config user.email "test@example.com"
+git -C "$updater_repo" config user.name "Test User"
+printf 'remote update\n' > "$updater_repo/remote.txt"
+git -C "$updater_repo" add remote.txt
+git -C "$updater_repo" commit -q -m "remote update"
+git -C "$updater_repo" push -q origin main
+printf 'dirty\n' > "$dirty_repo/dirty.txt"
+
+cat > "$hub_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: clean-app
+      github_repo: example/clean-app
+      default_branch: main
+    - name: dirty-app
+      github_repo: example/dirty-app
+      default_branch: main
+    - name: missing-path-app
+      github_repo: example/missing-path-app
+      default_branch: main
+    - name: missing-checkout-app
+      github_repo: example/missing-checkout-app
+      default_branch: main
+    - name: git-url-app
+      git_url: git@github.com:example/git-url-app.git
+      default_branch: main
+    - name: internal-app
+      git_url: ssh://git@example.com/internal-app.git
+      default_branch: main
+YAML
+cat > "$hub_dir/.ai-dev-workflow.local.yaml" <<YAML
+product_repos:
+  - name: clean-app
+    local_path: "$clean_repo"
+  - name: dirty-app
+    local_path: "$dirty_repo"
+  - name: missing-checkout-app
+    local_path: "$missing_checkout"
+YAML
+
+repo_names="$(python3 "$RESOLVER" list-product-repos --repo-root "$hub_dir")"
+run_contains "resolver_lists_clean" "clean-app" "$repo_names"
+run_contains "resolver_lists_internal" "internal-app" "$repo_names"
+
+clean_status="$(bash "$STATUS_CMD" --repo-root "$hub_dir" --repo clean-app)"
+run_contains "status_clean_repo_name" "REPO clean-app" "$clean_status"
+run_contains "status_clean_path" "LOCAL_PATH=$clean_repo" "$clean_status"
+run_contains "status_clean_branch" "BRANCH=main" "$clean_status"
+run_contains "status_clean_outcome" "STATUS=clean" "$clean_status"
+
+set +e
+all_status="$(bash "$STATUS_CMD" --repo-root "$hub_dir" --all 2>&1)"
+all_status_code=$?
+set -e
+if [ "$all_status_code" -ne 0 ]; then
+  echo "PASS: status_all_mixed_exit"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: status_all_mixed_exit - expected non-zero for missing repositories"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+run_contains "status_all_dirty" "STATUS=dirty" "$all_status"
+run_contains "status_all_missing_path" "STATUS=missing_path" "$all_status"
+run_contains "status_all_missing_checkout" "STATUS=missing_checkout" "$all_status"
+run_contains "status_all_summary" "SUMMARY" "$all_status"
+
+run_fails_contains "sync_dirty_refusal" "REASON=dirty_checkout" bash "$SYNC_CMD" --repo-root "$hub_dir" --repo dirty-app
+run_fails_contains "sync_repo_all_conflict" "--repo and --all cannot be used together" bash "$SYNC_CMD" --repo-root "$hub_dir" --repo clean-app --all
+
+set +e
+all_sync="$(bash "$SYNC_CMD" --repo-root "$hub_dir" --all 2>&1)"
+all_sync_code=$?
+set -e
+if [ "$all_sync_code" -ne 0 ]; then
+  echo "PASS: sync_all_mixed_exit"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: sync_all_mixed_exit - expected non-zero for blocked or failed repositories"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+run_contains "sync_all_synced_repo" "STATUS=synced" "$all_sync"
+run_contains "sync_all_blocked" "blocked=" "$all_sync"
+run_contains "sync_all_failed_or_missing" "missing=" "$all_sync"
+run_contains "sync_all_summary" "SUMMARY" "$all_sync"
+
+run_fails_contains "missing_path_guidance" ".ai-dev-workflow.local.yaml" bash "$SYNC_CMD" --repo-root "$hub_dir" --repo missing-path-app
+
+bootstrap_declined_before="$(cat "$hub_dir/.ai-dev-workflow.local.yaml")"
+set +e
+bootstrap_declined="$(printf 'n\n' | bash "$SYNC_CMD" --repo-root "$hub_dir" --repo missing-path-app --bootstrap-local-path 2>&1)"
+bootstrap_declined_code=$?
+set -e
+if [ "$bootstrap_declined_code" -ne 0 ]; then
+  echo "PASS: bootstrap_declined_exit"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: bootstrap_declined_exit - expected non-zero when declined"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+run_contains "bootstrap_declined_output" "BOOTSTRAP=declined" "$bootstrap_declined"
+bootstrap_declined_after="$(cat "$hub_dir/.ai-dev-workflow.local.yaml")"
+if [ "$bootstrap_declined_before" = "$bootstrap_declined_after" ]; then
+  echo "PASS: bootstrap_declined_no_write"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: bootstrap_declined_no_write - local config changed"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+bootstrap_yes="$(bash "$SYNC_CMD" --repo-root "$hub_dir" --repo missing-path-app --bootstrap-local-path --yes)"
+run_contains "bootstrap_yes_written" "BOOTSTRAP=written" "$bootstrap_yes"
+local_after_bootstrap="$(cat "$hub_dir/.ai-dev-workflow.local.yaml")"
+run_contains "bootstrap_wrote_repo_name" "name: missing-path-app" "$local_after_bootstrap"
+run_contains "bootstrap_wrote_local_path" "local_path:" "$local_after_bootstrap"
+run_not_contains "bootstrap_no_secret" "secret" "$local_after_bootstrap"
+
+mock_bin="$(fixture_dir mock-bin)"
+cat > "$mock_bin/gh" <<'MOCKGH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  repo=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --repo)
+        repo="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  case "$repo" in
+    example/clean-app|example/git-url-app)
+      printf '[{"number":7,"title":"Ready PR","headRefName":"feature/test","baseRefName":"main","isDraft":false,"labels":[{"name":"ready-for-human-review"}]}]\n'
+      ;;
+    *)
+      printf 'mock remote failure for %s\n' "$repo" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+printf 'unexpected gh invocation\n' >&2
+exit 1
+MOCKGH
+chmod +x "$mock_bin/gh"
+
+prs_output="$(PATH="$mock_bin:$PATH" bash "$PRS_CMD" --repo-root "$hub_dir" --repo clean-app)"
+run_contains "prs_lists_number" "PR #7" "$prs_output"
+run_contains "prs_uses_github_repo" "GITHUB_REPO=example/clean-app" "$prs_output"
+
+git_url_prs="$(PATH="$mock_bin:$PATH" bash "$PRS_CMD" --repo-root "$hub_dir" --repo git-url-app)"
+run_contains "prs_git_url_slug" "GITHUB_REPO=example/git-url-app" "$git_url_prs"
+run_fails_contains "prs_non_github_url_fails" "REASON=no_github_repo_slug" env PATH="$mock_bin:$PATH" bash "$PRS_CMD" --repo-root "$hub_dir" --repo internal-app
+
+printf '\nPassed: %s\nFailed: %s\n' "$PASS_COUNT" "$FAIL_COUNT"
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
@@ -255,7 +255,6 @@ else
   FAIL_COUNT=$((FAIL_COUNT + 1))
 fi
 run_contains "sync_branch_restore_reason" "REASON=local_ahead_or_diverged" "$branch_restore_output"
-run_contains "sync_branch_restore_marker" "RESTORE_ORIGINAL_BRANCH=ok" "$branch_restore_output"
 branch_after_restore="$(git -C "$branch_restore_repo" rev-parse --abbrev-ref HEAD)"
 run_contains "sync_branch_restore_current_branch" "feature/start" "$branch_after_restore"
 set +e
@@ -270,7 +269,6 @@ else
   FAIL_COUNT=$((FAIL_COUNT + 1))
 fi
 run_contains "sync_fetch_failure_reason" "REASON=fetch_failed" "$fetch_fail_output"
-run_contains "sync_fetch_failure_restore_marker" "RESTORE_ORIGINAL_BRANCH=ok" "$fetch_fail_output"
 branch_after_fetch_failure="$(git -C "$fetch_fail_repo" rev-parse --abbrev-ref HEAD)"
 run_contains "sync_fetch_failure_current_branch" "feature/start" "$branch_after_fetch_failure"
 

--- a/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
@@ -174,6 +174,18 @@ workflow_hub:
     - name: git-url-app
       git_url: git@github.com:example/git-url-app.git
       default_branch: main
+    - name: ssh-url-app
+      git_url: ssh://git@github.com/example/ssh-url-app.git
+      default_branch: main
+    - name: https-url-app
+      git_url: https://github.com/example/https-url-app.git
+      default_branch: main
+    - name: extra-path-url-app
+      git_url: https://github.com/example/extra-path-url-app/extra
+      default_branch: main
+    - name: port-url-app
+      git_url: ssh://git@github.com:22/example/port-url-app.git
+      default_branch: main
     - name: malformed-pr-app
       github_repo: example/malformed-pr-app
       default_branch: main
@@ -311,7 +323,7 @@ if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
     exit 1
   fi
   case "$repo" in
-    example/clean-app|example/git-url-app)
+    example/clean-app|example/git-url-app|example/ssh-url-app|example/https-url-app)
       printf '[{"number":7,"title":"Ready PR","headRefName":"feature/test","baseRefName":"main","isDraft":false,"labels":[{"name":"ready-for-human-review"}]}]\n'
       ;;
     example/malformed-pr-app)
@@ -335,6 +347,12 @@ run_contains "prs_uses_github_repo" "GITHUB_REPO=example/clean-app" "$prs_output
 
 git_url_prs="$(PATH="$mock_bin:$PATH" bash "$PRS_CMD" --repo-root "$hub_dir" --repo git-url-app)"
 run_contains "prs_git_url_slug" "GITHUB_REPO=example/git-url-app" "$git_url_prs"
+ssh_url_prs="$(PATH="$mock_bin:$PATH" bash "$PRS_CMD" --repo-root "$hub_dir" --repo ssh-url-app)"
+run_contains "prs_ssh_url_slug" "GITHUB_REPO=example/ssh-url-app" "$ssh_url_prs"
+https_url_prs="$(PATH="$mock_bin:$PATH" bash "$PRS_CMD" --repo-root "$hub_dir" --repo https-url-app)"
+run_contains "prs_https_url_slug" "GITHUB_REPO=example/https-url-app" "$https_url_prs"
+run_fails_contains "prs_extra_path_url_fails" "REASON=no_github_repo_slug" env PATH="$mock_bin:$PATH" bash "$PRS_CMD" --repo-root "$hub_dir" --repo extra-path-url-app
+run_fails_contains "prs_port_url_fails" "REASON=no_github_repo_slug" env PATH="$mock_bin:$PATH" bash "$PRS_CMD" --repo-root "$hub_dir" --repo port-url-app
 set +e
 malformed_prs="$(PATH="$mock_bin:$PATH" bash "$PRS_CMD" --repo-root "$hub_dir" --repo malformed-pr-app 2>&1)"
 malformed_prs_code=$?

--- a/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
@@ -116,6 +116,7 @@ run_fails_contains "status_missing_repo_value" "--repo requires a value" bash "$
 run_fails_contains "sync_missing_repo_value" "--repo requires a value" bash "$SYNC_CMD" --repo
 run_fails_contains "prs_missing_repo_value" "--repo requires a value" bash "$PRS_CMD" --repo
 run_fails_contains "status_unknown_option" "unknown argument '--bogus'" bash "$STATUS_CMD" --bogus
+run_fails_contains "prs_unknown_option" "unknown argument '--bogus'" bash "$PRS_CMD" --bogus
 
 hub_dir="$(fixture_dir hub)"
 clean_repo="$(fixture_dir clean-product)"
@@ -290,6 +291,7 @@ run_contains "sync_all_failed_or_missing" "missing=" "$all_sync"
 run_contains "sync_all_summary" "SUMMARY" "$all_sync"
 
 run_fails_contains "missing_path_guidance" ".ai-dev-workflow.local.yaml" bash "$SYNC_CMD" --repo-root "$hub_dir" --repo missing-path-app
+run_fails_contains "prs_repo_all_conflict" "--repo and --all cannot be used together" bash "$PRS_CMD" --repo-root "$hub_dir" --repo clean-app --all
 
 bootstrap_declined_before="$(cat "$hub_dir/.ai-dev-workflow.local.yaml")"
 set +e

--- a/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
@@ -174,6 +174,9 @@ workflow_hub:
     - name: git-url-app
       git_url: git@github.com:example/git-url-app.git
       default_branch: main
+    - name: malformed-pr-app
+      github_repo: example/malformed-pr-app
+      default_branch: main
     - name: internal-app
       git_url: ssh://git@example.com/internal-app.git
       default_branch: main
@@ -287,10 +290,15 @@ cat > "$mock_bin/gh" <<'MOCKGH'
 set -euo pipefail
 if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
   repo=""
+  has_limit=false
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --repo)
         repo="$2"
+        shift 2
+        ;;
+      --limit)
+        has_limit=true
         shift 2
         ;;
       *)
@@ -298,9 +306,16 @@ if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
         ;;
     esac
   done
+  if [ "$has_limit" != "true" ]; then
+    printf 'missing --limit\n' >&2
+    exit 1
+  fi
   case "$repo" in
     example/clean-app|example/git-url-app)
       printf '[{"number":7,"title":"Ready PR","headRefName":"feature/test","baseRefName":"main","isDraft":false,"labels":[{"name":"ready-for-human-review"}]}]\n'
+      ;;
+    example/malformed-pr-app)
+      printf '{not-json\n'
       ;;
     *)
       printf 'mock remote failure for %s\n' "$repo" >&2
@@ -320,6 +335,19 @@ run_contains "prs_uses_github_repo" "GITHUB_REPO=example/clean-app" "$prs_output
 
 git_url_prs="$(PATH="$mock_bin:$PATH" bash "$PRS_CMD" --repo-root "$hub_dir" --repo git-url-app)"
 run_contains "prs_git_url_slug" "GITHUB_REPO=example/git-url-app" "$git_url_prs"
+set +e
+malformed_prs="$(PATH="$mock_bin:$PATH" bash "$PRS_CMD" --repo-root "$hub_dir" --repo malformed-pr-app 2>&1)"
+malformed_prs_code=$?
+set -e
+if [ "$malformed_prs_code" -ne 0 ]; then
+  echo "PASS: prs_malformed_json_exit"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: prs_malformed_json_exit - expected non-zero for malformed JSON"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+run_contains "prs_malformed_json_reason" "REASON=pr_json_parse_failed" "$malformed_prs"
+run_contains "prs_malformed_json_summary" "SUMMARY" "$malformed_prs"
 run_fails_contains "prs_non_github_url_fails" "REASON=no_github_repo_slug" env PATH="$mock_bin:$PATH" bash "$PRS_CMD" --repo-root "$hub_dir" --repo internal-app
 
 printf '\nPassed: %s\nFailed: %s\n' "$PASS_COUNT" "$FAIL_COUNT"

--- a/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
@@ -118,17 +118,45 @@ run_fails_contains "prs_missing_repo_value" "--repo requires a value" bash "$PRS
 run_fails_contains "status_unknown_option" "unknown argument '--bogus'" bash "$STATUS_CMD" --bogus
 run_fails_contains "prs_unknown_option" "unknown argument '--bogus'" bash "$PRS_CMD" --bogus
 
+broken_list_hub="$(fixture_dir broken-list-hub)"
+cat > "$broken_list_hub/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: duplicate-app
+      github_repo: example/duplicate-app
+    - name: duplicate-app
+      github_repo: example/duplicate-app-two
+YAML
+set +e
+broken_list_status="$(bash "$STATUS_CMD" --repo-root "$broken_list_hub" --all 2>&1)"
+broken_list_status_code=$?
+set -e
+if [ "$broken_list_status_code" -ne 0 ]; then
+  echo "PASS: status_all_bad_repo_list_exit"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: status_all_bad_repo_list_exit - expected bad repo list failure"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+run_contains "status_all_bad_repo_list_reason" "duplicate workflow_hub.product_repos name 'duplicate-app'" "$broken_list_status"
+run_contains "status_all_bad_repo_list_summary" "SUMMARY" "$broken_list_status"
+
 hub_dir="$(fixture_dir hub)"
 clean_repo="$(fixture_dir clean-product)"
 dirty_repo="$(fixture_dir dirty-product)"
 branch_restore_repo="$(fixture_dir branch-restore-product)"
 fetch_fail_repo="$(fixture_dir fetch-fail-product)"
+worktree_guard_repo="$(fixture_dir worktree-guard-product)"
 missing_checkout="$TMP_ROOT/missing-checkout"
 mkdir -p "$missing_checkout"
 init_repo "$clean_repo" main
 init_repo "$dirty_repo" main
 init_repo "$branch_restore_repo" main
 init_repo "$fetch_fail_repo" main
+init_repo "$worktree_guard_repo" main
 clean_remote="$(fixture_dir clean-remote.git)"
 updater_repo="$(fixture_dir clean-updater)"
 git init --bare -q -b main "$clean_remote"
@@ -153,6 +181,21 @@ git -C "$branch_restore_repo" commit -q -m "local ahead"
 git -C "$branch_restore_repo" switch -q feature/start
 git -C "$fetch_fail_repo" switch -q -c feature/start
 git -C "$fetch_fail_repo" remote add origin "$TMP_ROOT/does-not-exist.git"
+worktree_guard_remote="$(fixture_dir worktree-guard-remote.git)"
+worktree_guard_updater="$(fixture_dir worktree-guard-updater)"
+worktree_guard_default_worktree="$TMP_ROOT/worktree-guard-default-worktree"
+git init --bare -q -b main "$worktree_guard_remote"
+git -C "$worktree_guard_repo" remote add origin "$worktree_guard_remote"
+git -C "$worktree_guard_repo" push -q -u origin main
+git -C "$worktree_guard_repo" switch -q -c feature/start
+git -C "$worktree_guard_repo" worktree add -q "$worktree_guard_default_worktree" main
+git clone -q "$worktree_guard_remote" "$worktree_guard_updater"
+git -C "$worktree_guard_updater" config user.email "test@example.com"
+git -C "$worktree_guard_updater" config user.name "Test User"
+printf 'remote update\n' > "$worktree_guard_updater/remote.txt"
+git -C "$worktree_guard_updater" add remote.txt
+git -C "$worktree_guard_updater" commit -q -m "remote update"
+git -C "$worktree_guard_updater" push -q origin main
 printf 'dirty\n' > "$dirty_repo/dirty.txt"
 
 cat > "$hub_dir/.ai-dev-workflow.yaml" <<'YAML'
@@ -172,6 +215,9 @@ workflow_hub:
       default_branch: main
     - name: fetch-fail-app
       github_repo: example/fetch-fail-app
+      default_branch: main
+    - name: worktree-guard-app
+      github_repo: example/worktree-guard-app
       default_branch: main
     - name: missing-path-app
       github_repo: example/missing-path-app
@@ -211,6 +257,8 @@ product_repos:
     local_path: "$branch_restore_repo"
   - name: fetch-fail-app
     local_path: "$fetch_fail_repo"
+  - name: worktree-guard-app
+    local_path: "$worktree_guard_repo"
   - name: missing-checkout-app
     local_path: "$missing_checkout"
 YAML
@@ -271,6 +319,20 @@ fi
 run_contains "sync_fetch_failure_reason" "REASON=fetch_failed" "$fetch_fail_output"
 branch_after_fetch_failure="$(git -C "$fetch_fail_repo" rev-parse --abbrev-ref HEAD)"
 run_contains "sync_fetch_failure_current_branch" "feature/start" "$branch_after_fetch_failure"
+set +e
+worktree_guard_output="$(bash "$SYNC_CMD" --repo-root "$hub_dir" --repo worktree-guard-app 2>&1)"
+worktree_guard_code=$?
+set -e
+if [ "$worktree_guard_code" -ne 0 ]; then
+  echo "PASS: sync_worktree_guard_exit"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: sync_worktree_guard_exit - expected checked-out default branch block"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+run_contains "sync_worktree_guard_reason" "REASON=default_branch_checked_out_elsewhere" "$worktree_guard_output"
+branch_after_worktree_guard="$(git -C "$worktree_guard_repo" rev-parse --abbrev-ref HEAD)"
+run_contains "sync_worktree_guard_current_branch" "feature/start" "$branch_after_worktree_guard"
 
 set +e
 all_sync="$(bash "$SYNC_CMD" --repo-root "$hub_dir" --all 2>&1)"

--- a/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
@@ -121,11 +121,13 @@ hub_dir="$(fixture_dir hub)"
 clean_repo="$(fixture_dir clean-product)"
 dirty_repo="$(fixture_dir dirty-product)"
 branch_restore_repo="$(fixture_dir branch-restore-product)"
+fetch_fail_repo="$(fixture_dir fetch-fail-product)"
 missing_checkout="$TMP_ROOT/missing-checkout"
 mkdir -p "$missing_checkout"
 init_repo "$clean_repo" main
 init_repo "$dirty_repo" main
 init_repo "$branch_restore_repo" main
+init_repo "$fetch_fail_repo" main
 clean_remote="$(fixture_dir clean-remote.git)"
 updater_repo="$(fixture_dir clean-updater)"
 git init --bare -q -b main "$clean_remote"
@@ -148,6 +150,8 @@ printf 'local ahead\n' > "$branch_restore_repo/local-ahead.txt"
 git -C "$branch_restore_repo" add local-ahead.txt
 git -C "$branch_restore_repo" commit -q -m "local ahead"
 git -C "$branch_restore_repo" switch -q feature/start
+git -C "$fetch_fail_repo" switch -q -c feature/start
+git -C "$fetch_fail_repo" remote add origin "$TMP_ROOT/does-not-exist.git"
 printf 'dirty\n' > "$dirty_repo/dirty.txt"
 
 cat > "$hub_dir/.ai-dev-workflow.yaml" <<'YAML'
@@ -164,6 +168,9 @@ workflow_hub:
       default_branch: main
     - name: branch-restore-app
       github_repo: example/branch-restore-app
+      default_branch: main
+    - name: fetch-fail-app
+      github_repo: example/fetch-fail-app
       default_branch: main
     - name: missing-path-app
       github_repo: example/missing-path-app
@@ -201,6 +208,8 @@ product_repos:
     local_path: "$dirty_repo"
   - name: branch-restore-app
     local_path: "$branch_restore_repo"
+  - name: fetch-fail-app
+    local_path: "$fetch_fail_repo"
   - name: missing-checkout-app
     local_path: "$missing_checkout"
 YAML
@@ -248,6 +257,21 @@ run_contains "sync_branch_restore_reason" "REASON=local_ahead_or_diverged" "$bra
 run_contains "sync_branch_restore_marker" "RESTORE_ORIGINAL_BRANCH=ok" "$branch_restore_output"
 branch_after_restore="$(git -C "$branch_restore_repo" rev-parse --abbrev-ref HEAD)"
 run_contains "sync_branch_restore_current_branch" "feature/start" "$branch_after_restore"
+set +e
+fetch_fail_output="$(bash "$SYNC_CMD" --repo-root "$hub_dir" --repo fetch-fail-app 2>&1)"
+fetch_fail_code=$?
+set -e
+if [ "$fetch_fail_code" -ne 0 ]; then
+  echo "PASS: sync_fetch_failure_exit"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: sync_fetch_failure_exit - expected fetch failure"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+run_contains "sync_fetch_failure_reason" "REASON=fetch_failed" "$fetch_fail_output"
+run_contains "sync_fetch_failure_restore_marker" "RESTORE_ORIGINAL_BRANCH=ok" "$fetch_fail_output"
+branch_after_fetch_failure="$(git -C "$fetch_fail_repo" rev-parse --abbrev-ref HEAD)"
+run_contains "sync_fetch_failure_current_branch" "feature/start" "$branch_after_fetch_failure"
 
 set +e
 all_sync="$(bash "$SYNC_CMD" --repo-root "$hub_dir" --all 2>&1)"

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -468,6 +468,7 @@ def set_local_product_repo_path(repo_root: Path, repo_name: str, local_path_valu
     _, local, _, local_path = load_configs(repo_root)
     repos = as_list(local.get("product_repos"), local_path, "product_repos")
     updated = False
+    match_count = 0
     normalized_path = relative_or_absolute_path(repo_root, local_path_value)
 
     new_repos: list[dict[str, Any]] = []
@@ -476,9 +477,15 @@ def set_local_product_repo_path(repo_root: Path, repo_name: str, local_path_valu
             raise ConfigError(f"{local_path}: product_repos[{index}] must be a mapping")
         repo = dict(raw)
         if repo.get("name") == repo_name:
+            match_count += 1
             repo["local_path"] = normalized_path
             updated = True
         new_repos.append(repo)
+
+    if match_count > 1:
+        raise ConfigError(
+            f"{local_path}: duplicate product_repos entries named '{repo_name}' cannot be updated safely"
+        )
 
     if not updated:
         new_repos.append({"name": repo_name, "local_path": normalized_path})

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -411,9 +411,18 @@ def quote_yaml_scalar(value: Any) -> str:
     text = str(value)
     if text == "":
         return '""'
-    if re.match(r"^[A-Za-z0-9_./:@~+-]+$", text):
+    yaml_token = text.lower()
+    if (
+        yaml_token in {"true", "false", "yes", "no", "on", "off", "null", "~"}
+        or re.match(r"^[+-]?[0-9]+(?:\.[0-9]+)?$", text)
+    ):
+        must_quote = True
+    else:
+        must_quote = not re.match(r"^[A-Za-z0-9_./:@~+-]+$", text)
+    if not must_quote:
         return text
-    return '"' + text.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    escaped = text.replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+    return '"' + escaped + '"'
 
 
 def dump_yaml_subset(value: Any, indent: int = 0) -> list[str]:

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -397,6 +397,88 @@ def resolve_local_path(
     return "", ""
 
 
+def relative_or_absolute_path(repo_root: Path, value: str) -> str:
+    path = Path(value)
+    if path.is_absolute():
+        try:
+            return os.path.relpath(path, repo_root)
+        except ValueError:
+            return str(path)
+    return value
+
+
+def quote_yaml_scalar(value: Any) -> str:
+    text = str(value)
+    if text == "":
+        return '""'
+    if re.match(r"^[A-Za-z0-9_./:@~+-]+$", text):
+        return text
+    return '"' + text.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def dump_yaml_subset(value: Any, indent: int = 0) -> list[str]:
+    prefix = " " * indent
+    lines: list[str] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if isinstance(child, (dict, list)):
+                lines.append(f"{prefix}{key}:")
+                lines.extend(dump_yaml_subset(child, indent + 2))
+            else:
+                lines.append(f"{prefix}{key}: {quote_yaml_scalar(child)}")
+        return lines
+    if isinstance(value, list):
+        for item in value:
+            if isinstance(item, dict):
+                if not item:
+                    lines.append(f"{prefix}- {{}}")
+                    continue
+                first = True
+                for key, child in item.items():
+                    if first:
+                        if isinstance(child, (dict, list)):
+                            lines.append(f"{prefix}- {key}:")
+                            lines.extend(dump_yaml_subset(child, indent + 4))
+                        else:
+                            lines.append(f"{prefix}- {key}: {quote_yaml_scalar(child)}")
+                        first = False
+                    else:
+                        if isinstance(child, (dict, list)):
+                            lines.append(f"{prefix}  {key}:")
+                            lines.extend(dump_yaml_subset(child, indent + 4))
+                        else:
+                            lines.append(f"{prefix}  {key}: {quote_yaml_scalar(child)}")
+            else:
+                lines.append(f"{prefix}- {quote_yaml_scalar(item)}")
+        return lines
+    lines.append(f"{prefix}{quote_yaml_scalar(value)}")
+    return lines
+
+
+def set_local_product_repo_path(repo_root: Path, repo_name: str, local_path_value: str) -> Path:
+    _, local, _, local_path = load_configs(repo_root)
+    repos = as_list(local.get("product_repos"), local_path, "product_repos")
+    updated = False
+    normalized_path = relative_or_absolute_path(repo_root, local_path_value)
+
+    new_repos: list[dict[str, Any]] = []
+    for index, raw in enumerate(repos, start=1):
+        if not isinstance(raw, dict):
+            raise ConfigError(f"{local_path}: product_repos[{index}] must be a mapping")
+        repo = dict(raw)
+        if repo.get("name") == repo_name:
+            repo["local_path"] = normalized_path
+            updated = True
+        new_repos.append(repo)
+
+    if not updated:
+        new_repos.append({"name": repo_name, "local_path": normalized_path})
+    local["product_repos"] = new_repos
+
+    local_path.write_text("\n".join(dump_yaml_subset(local)) + "\n", encoding="utf-8")
+    return local_path
+
+
 def flatten_tracker_hints(repo: dict[str, Any]) -> str:
     tracker = repo.get("tracker")
     if not isinstance(tracker, dict):
@@ -679,6 +761,33 @@ def cmd_resolve(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_list_product_repos(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from_args(args.repo_root)
+    shared, _, shared_path, _ = load_configs(repo_root)
+    mode = mode_from_shared(shared, shared_path)
+    if mode != "workflow_hub":
+        raise ConfigError(f"{shared_path}: workflow_hub mode is required to list product repositories")
+    names = [str(repo.get("name")) for repo in product_repos(shared, shared_path)]
+    if args.json:
+        print(json.dumps(names))
+    else:
+        for name in names:
+            print(name)
+    return 0
+
+
+def cmd_set_local_path(args: argparse.Namespace) -> int:
+    repo_root = repo_root_from_args(args.repo_root)
+    shared, _, shared_path, _ = load_configs(repo_root)
+    mode = mode_from_shared(shared, shared_path)
+    if mode != "workflow_hub":
+        raise ConfigError(f"{shared_path}: workflow_hub mode is required to write product repository local paths")
+    select_product_repo(product_repos(shared, shared_path), args.repo, shared_path)
+    written = set_local_product_repo_path(repo_root, args.repo, args.local_path)
+    print_context(args, {"LOCAL_CONFIG_PATH": str(written)})
+    return 0
+
+
 def cmd_auth(args: argparse.Namespace) -> int:
     print_context(args, resolve_auth_context(args))
     return 0
@@ -709,6 +818,22 @@ def build_parser() -> argparse.ArgumentParser:
         )
         command.add_argument("--json", action="store_true", help="print JSON instead of shell KEY=value")
         command.set_defaults(func=cmd_resolve)
+
+    list_product_repos = subcommands.add_parser(
+        "list-product-repos", help="list configured workflow_hub product repository names"
+    )
+    list_product_repos.add_argument("--repo-root")
+    list_product_repos.add_argument("--json", action="store_true", help="print JSON instead of one name per line")
+    list_product_repos.set_defaults(func=cmd_list_product_repos)
+
+    set_local_path = subcommands.add_parser(
+        "set-local-path", help="write one product repository local path to local config"
+    )
+    set_local_path.add_argument("--repo-root")
+    set_local_path.add_argument("--repo", required=True, help="stable product repository name")
+    set_local_path.add_argument("--local-path", required=True, help="local checkout path to write")
+    set_local_path.add_argument("--json", action="store_true", help="print JSON instead of shell KEY=value")
+    set_local_path.set_defaults(func=cmd_set_local_path)
 
     auth = subcommands.add_parser("auth", help="print product repository auth metadata")
     auth.add_argument("--repo-root")


### PR DESCRIPTION
## What changed

Implements #877 by adding workflow-hub product repository command surfaces:

- `hub-status.sh` for read-only local checkout status across one product repo or all configured repos.
- `hub-sync-product-repos.sh` for conservative clean-checkout sync with dirty/ahead/diverged checkout refusal and explicit local-path bootstrap.
- `hub-list-prs.sh` for read-only product repository PR visibility without falling back to the hub repo.
- Resolver support for listing configured product repositories and writing confirmed local path entries.
- Fixture coverage, script README guidance, repository-mode docs, and CHANGELOG entry.

## Links

- Spec: `docs/specs/developments/20260610164114_877-workflow-hub-product-repo-sync-status-scripts/1_877-workflow-hub-product-repo-sync-status-scripts_specs.md`
- Plan: `docs/specs/developments/20260610164114_877-workflow-hub-product-repo-sync-status-scripts/2_877-workflow-hub-product-repo-sync-status-scripts_implementation-plan.md`
- Smoke runbook: `docs/testing/workflow/877-workflow-hub-product-repo-sync-status-scripts.smoke-test.md`

## Validation

- `bash scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh` — 43 passed, 0 failed
- `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh` — 51 passed, 0 failed
- `bash scripts/development-workflow/tests/test-workflow-lib-github-projects.sh` — 85 passed, 0 failed
- `shellcheck --severity=warning scripts/development-workflow/*.sh scripts/development-workflow/tests/*.sh`
- `npx markdownlint-cli2 "docs/specs/developments/20260610164114_877-workflow-hub-product-repo-sync-status-scripts/*.md" "docs/testing/workflow/877-workflow-hub-product-repo-sync-status-scripts.smoke-test.md" "CHANGELOG.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/877-workflow-hub-product-repo-sync-status-scripts.smoke-test.md CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/development-workflow/workflow-config-resolver.py`

## Test Harness Coverage Checklist

- Empty / zero-length input: not applicable; commands do not accept structured stdin as primary input.
- Whitespace-only input: not applicable; command arguments are parsed as shell argv values and repository fixtures use explicit names/paths.
- Boundary values: covered by single repo vs `--all`, missing values, missing checkout, missing path, and mixed result summaries.
- Missing / absent environment variables: no required environment variables; `gh` behavior is mocked for PR listing failure paths.
- Concurrent / parallel execution: fixture writes are isolated under `mktemp -d`; local config bootstrap is limited to the selected fixture repo.
- Negative assertions: covered by wrong mode, missing `--repo` values, unknown option, `--repo` plus `--all`, dirty checkout refusal, missing path, bootstrap decline, and non-GitHub PR listing failure.
- Single EXIT trap: verified; the new harness has one cleanup trap.
- Variable-length quoting safety: fixture paths are quoted consistently and shellcheck is clean.
- `BASH_SOURCE` / guard placement: not applicable; the harness is executed directly and the sourced helper has no main side effects.
- Sourced-function ordering: command scripts source the shared helper before using helper functions.

## Pre-submission self-review

Stale markers: none found. Caller/script consistency: verified against existing resolver and workflow shell conventions. Coverage: AC1-AC10 addressed by implementation and fixture tests. Deviation: PR listing is included as the optional command from the spec because the plan called for product PR visibility.

## CHANGELOG preview

- **Workflow hub product repository commands** (#877): adds workflow-hub status, sync, and pull-request visibility commands for product repository checkouts.
