### PR TITLE
feat(workflow): add workflow hub smoke fixtures

### DIFF
--- a/.github/workflows/test-pr-review-loop.yml
+++ b/.github/workflows/test-pr-review-loop.yml
@@ -4,12 +4,21 @@ on:
   pull_request:
     branches:
       - develop
+      - develop-workflow-hub-mode
       - main
     paths:
       - 'scripts/development-workflow/pr-review-loop.sh'
       - 'scripts/development-workflow/workflow-lib.sh'
+      - 'scripts/development-workflow/workflow-config-resolver.py'
+      - 'scripts/development-workflow/workflow-next-action.sh'
+      - 'scripts/development-workflow/hub-*.sh'
+      - 'scripts/development-workflow/open-product-pr.sh'
+      - 'scripts/development-workflow/validate-workflow-hub-skeletons.py'
       - 'scripts/development-workflow/tests/test-pr-review-loop.sh'
       - 'scripts/development-workflow/tests/test-haystack-commit-msg-hook.sh'
+      - 'scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh'
+      - 'scripts/development-workflow/tests/fixtures/workflow-hub-smoke/**'
+      - 'sync-manifest.yaml'
       - 'hooks/commit-msg'
       - '.github/workflows/test-pr-review-loop.yml'
 
@@ -32,3 +41,6 @@ jobs:
 
       - name: Run Haystack commit-msg hook test harness
         run: bash scripts/development-workflow/tests/test-haystack-commit-msg-hook.sh
+
+      - name: Run workflow hub smoke fixture harness
+        run: bash scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Workflow hub smoke fixtures** (#883): adds non-secret workflow hub and product repository fixture coverage with single-repository regression checks.
 - **Workflow hub product repository commands** (#877): adds workflow-hub status, sync, and pull-request visibility commands for product repository checkouts.
 - **Workflow hub product repository PR authentication** (#880): adds local-only GitHub App auth guidance and helpers for opening product repository pull requests without exposing secrets.
 - **Workflow hub template skeletons** (#876): adds inspectable workflow-hub and product-repo-injection skeletons with mode-specific sync-scope metadata.

--- a/docs/workflow/development-workflow/repository-modes.md
+++ b/docs/workflow/development-workflow/repository-modes.md
@@ -326,6 +326,33 @@ and secret-manager references stay local-only. See
 [`integrations/workflow-hub-github-app.md`](integrations/workflow-hub-github-app.md)
 for the setup guide and dry-run helper commands.
 
+### Non-Secret Workflow Hub Smoke Fixture
+
+Template maintainers can run a deterministic workflow-hub fixture without
+private repositories or credentials:
+
+```bash
+bash scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh
+```
+
+The committed fixture seed lives under
+`scripts/development-workflow/tests/fixtures/workflow-hub-smoke/`. It models one
+hub and two placeholder product repositories, `mobile-app` and `admin-portal`,
+using `example/*` repository identities. The harness copies the seed into a
+temporary directory, writes local-only checkout paths there, creates temporary
+git repositories for the products, and validates:
+
+- workflow-hub config parsing and product repository resolution
+- local path precedence from `.ai-dev-workflow.local.yaml` and `checkout_root`
+- status and sync command behavior for both dummy products
+- product branch and PR routing through dry-run commands
+- `sync-manifest.yaml` mode-scope classification
+- missing-mode and explicit `single_repo` regression behavior
+
+The default path is safe for CI and does not perform live GitHub writes. Live
+GitHub App validation is an explicit operator action via `--live-github-app`
+against safe test repositories only.
+
 ### Compatibility And Precedence
 
 Existing `.tmp/template-config.json` review overrides remain supported for the

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -205,6 +205,26 @@ What it reports:
 Use this before routing implementation work from a workflow hub to confirm that
 the selected checkout exists and that dirty state is visible.
 
+### Workflow hub smoke fixture
+
+Run the non-secret workflow-hub smoke fixture with:
+
+```bash
+bash scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh
+```
+
+The harness copies the committed seed under
+`scripts/development-workflow/tests/fixtures/workflow-hub-smoke/` into a
+temporary hub checkout, creates two dummy product repositories, and validates
+configuration parsing, local checkout resolution, product status/sync commands,
+product PR dry-run routing, mode-scope classification, and single-repository
+regression behavior. It never needs private product repositories or live GitHub
+App credentials by default.
+
+Optional live GitHub App validation is separate and must be requested with
+`--live-github-app` plus operator-supplied safe-test repository environment
+variables. Do not wire the live path into default CI.
+
 #### `hub-sync-product-repos.sh`
 
 Safely prepares clean product repository checkouts.

--- a/scripts/development-workflow/tests/fixtures/workflow-hub-smoke/README.md
+++ b/scripts/development-workflow/tests/fixtures/workflow-hub-smoke/README.md
@@ -1,0 +1,31 @@
+# Workflow Hub Smoke Fixture
+
+This fixture is committed test data for the non-secret workflow-hub smoke
+harness:
+
+```bash
+bash scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh
+```
+
+The topology is intentionally small and generic:
+
+- `workflow-hub` owns the workflow configuration, tracker items, specs, plans,
+  and orchestration scripts.
+- `mobile-app` is a dummy product repository with identity
+  `example/mobile-app`.
+- `admin-portal` is a dummy product repository with identity
+  `example/admin-portal`.
+
+The harness copies these files into a temporary directory, creates temporary git
+repositories for the products, and materializes local-only checkout paths there.
+Do not commit real product names, customer names, team names, repository
+identities, tokens, key material, or live credential locations in this fixture.
+
+Default validation is fully local and does not require GitHub credentials. Live
+GitHub App validation is separate and must be requested explicitly:
+
+```bash
+bash scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh --live-github-app
+```
+
+That live path is for safe test repositories only and is never run by default CI.

--- a/scripts/development-workflow/tests/fixtures/workflow-hub-smoke/hub/.ai-dev-workflow.yaml
+++ b/scripts/development-workflow/tests/fixtures/workflow-hub-smoke/hub/.ai-dev-workflow.yaml
@@ -1,0 +1,19 @@
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      default_branch: main
+      role: mobile
+      scope: fixture app
+      tracker:
+        component: mobile
+    - name: admin-portal
+      git_url: git@github.com:example/admin-portal.git
+      default_branch: develop
+      role: admin
+      scope: fixture portal
+      tracker:
+        component: admin

--- a/scripts/development-workflow/tests/fixtures/workflow-hub-smoke/local-config.template.yaml
+++ b/scripts/development-workflow/tests/fixtures/workflow-hub-smoke/local-config.template.yaml
@@ -1,0 +1,5 @@
+checkout_root: __CHECKOUT_ROOT__
+
+product_repos:
+  - name: mobile-app
+    local_path: __MOBILE_LOCAL_PATH__

--- a/scripts/development-workflow/tests/fixtures/workflow-hub-smoke/products/admin-portal/README.md
+++ b/scripts/development-workflow/tests/fixtures/workflow-hub-smoke/products/admin-portal/README.md
@@ -1,0 +1,3 @@
+# Admin Portal Fixture
+
+Placeholder product repository content for workflow-hub smoke tests.

--- a/scripts/development-workflow/tests/fixtures/workflow-hub-smoke/products/mobile-app/README.md
+++ b/scripts/development-workflow/tests/fixtures/workflow-hub-smoke/products/mobile-app/README.md
@@ -1,0 +1,3 @@
+# Mobile App Fixture
+
+Placeholder product repository content for workflow-hub smoke tests.

--- a/scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh
@@ -1,0 +1,441 @@
+#!/usr/bin/env bash
+# test-workflow-hub-smoke-fixtures.sh - non-secret workflow-hub smoke coverage.
+#
+# Usage: bash scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh [--live-github-app]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+FIXTURE_ROOT="$SCRIPT_DIR/fixtures/workflow-hub-smoke"
+RESOLVER="$REPO_ROOT/scripts/development-workflow/workflow-config-resolver.py"
+STATUS_CMD="$REPO_ROOT/scripts/development-workflow/hub-status.sh"
+SYNC_CMD="$REPO_ROOT/scripts/development-workflow/hub-sync-product-repos.sh"
+PR_CMD="$REPO_ROOT/scripts/development-workflow/open-product-pr.sh"
+NEXT_ACTION_CMD="$REPO_ROOT/scripts/development-workflow/workflow-next-action.sh"
+VALIDATOR="$REPO_ROOT/scripts/development-workflow/validate-workflow-hub-skeletons.py"
+
+LIVE_GITHUB_APP=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --live-github-app)
+      LIVE_GITHUB_APP=true
+      shift
+      ;;
+    -h|--help)
+      sed -n '1,4p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument '$1'" >&2
+      exit 1
+      ;;
+  esac
+done
+
+TMP_ROOT="$(mktemp -d)"
+TMP_ROOT="$(CDPATH='' cd -- "$TMP_ROOT" && pwd -P)"
+
+_harness_exit() {
+  local status=$?
+  rm -rf "$TMP_ROOT"
+  case "$status" in
+    141) exit 0 ;;
+    *)   exit "$status" ;;
+  esac
+}
+trap _harness_exit EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_equals() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_contains() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if grep -Fq -- "$expected" <<< "$actual"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected output to contain '${expected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_not_contains() {
+  local name="$1"
+  local unexpected="$2"
+  local actual="$3"
+  if grep -Fq -- "$unexpected" <<< "$actual"; then
+    echo "FAIL: $name - output unexpectedly contained '${unexpected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  else
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  fi
+}
+
+run_fails_contains() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  local output=""
+  local status=0
+
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+
+  if [ "$status" -ne 0 ] && grep -Fq -- "$expected" <<< "$output"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected failure containing '${expected}'"
+    printf 'Status: %s\nOutput:\n%s\n' "$status" "$output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+fixture_dir() {
+  local name="$1"
+  local path="$TMP_ROOT/$name"
+  mkdir -p "$path"
+  printf '%s\n' "$path"
+}
+
+init_repo() {
+  local path="$1"
+  local branch="$2"
+  local remote_path="$3"
+  mkdir -p "$path"
+  git -C "$path" init -q -b "$branch"
+  git -C "$path" config user.email "fixture@example.com"
+  git -C "$path" config user.name "Fixture User"
+  cp -R "$FIXTURE_ROOT/products/${path##*/}/." "$path/"
+  git -C "$path" add .
+  git -C "$path" commit -q -m "initial fixture commit"
+  git init --bare -q -b "$branch" "$remote_path"
+  git -C "$path" remote add origin "$remote_path"
+  git -C "$path" push -q -u origin "$branch"
+}
+
+make_development() {
+  local root="$1"
+  local path="$root/docs/specs/developments/20260611120000_883-fixture-routing"
+  mkdir -p "$path"
+  cat > "$path/1_883-fixture-routing_specs.md" <<'MD'
+# Fixture Routing Spec
+
+## Acceptance Criteria
+
+- [ ] Product implementation work routes to the selected product repository.
+MD
+  cat > "$path/2_883-fixture-routing_implementation-plan.md" <<'MD'
+# Fixture Routing Implementation Plan
+
+## Summary
+
+Route implementation work to a product repository.
+MD
+  printf '%s\n' "$path"
+}
+
+render_local_config() {
+  local template_path="$1"
+  local output_path="$2"
+  local checkout_root="$3"
+  local mobile_path="$4"
+  python3 - "$template_path" "$output_path" "$checkout_root" "$mobile_path" <<'PY'
+from pathlib import Path
+import sys
+
+template, output, checkout_root, mobile_path = sys.argv[1:5]
+text = Path(template).read_text(encoding="utf-8")
+text = text.replace("__CHECKOUT_ROOT__", checkout_root)
+text = text.replace("__MOBILE_LOCAL_PATH__", mobile_path)
+Path(output).write_text(text, encoding="utf-8")
+PY
+}
+
+echo ""
+echo "=== hub_fixture: seed safety and topology ==="
+
+run_equals "fixture_seed_exists" "yes" "$([ -d "$FIXTURE_ROOT" ] && echo yes || echo no)"
+run_equals "fixture_hub_shared_config_exists" "yes" "$([ -f "$FIXTURE_ROOT/hub/.ai-dev-workflow.yaml" ] && echo yes || echo no)"
+run_equals "fixture_local_template_exists" "yes" "$([ -f "$FIXTURE_ROOT/local-config.template.yaml" ] && echo yes || echo no)"
+
+private_hits=""
+set +e
+private_hits="$(
+  find "$FIXTURE_ROOT" -type f ! -name README.md -print0 |
+    xargs -0 grep -InE 'Leasity|RADAR|kids-safety|baumsystem|lhpaul/|op://|BEGIN .*PRIVATE KEY|ghp_|github_pat_|private_key_path|secret_ref|token='
+)"
+private_status=$?
+set -e
+if [ "$private_status" -ne 0 ] && [ "$private_status" -ne 1 ]; then
+  echo "FAIL: fixture_private_detail_scan - grep failed with exit code $private_status"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+run_equals "fixture_private_detail_scan" "" "$private_hits"
+
+hub_dir="$(fixture_dir workflow-hub)"
+cp -R "$FIXTURE_ROOT/hub/." "$hub_dir/"
+products_root="$(fixture_dir products)"
+mobile_repo="$products_root/mobile-app"
+admin_repo="$products_root/admin-portal"
+mobile_remote="$(fixture_dir mobile-remote.git)"
+admin_remote="$(fixture_dir admin-remote.git)"
+init_repo "$mobile_repo" main "$mobile_remote"
+init_repo "$admin_repo" develop "$admin_remote"
+render_local_config "$FIXTURE_ROOT/local-config.template.yaml" "$hub_dir/.ai-dev-workflow.local.yaml" "$products_root" "$mobile_repo"
+
+repo_names="$(python3 "$RESOLVER" list-product-repos --repo-root "$hub_dir")"
+run_contains "fixture_lists_mobile" "mobile-app" "$repo_names"
+run_contains "fixture_lists_admin" "admin-portal" "$repo_names"
+run_equals "fixture_has_exactly_two_products" "2" "$(printf '%s\n' "$repo_names" | sed '/^$/d' | wc -l | tr -d ' ')"
+
+echo ""
+echo "=== product_fixture: config parsing and resolution ==="
+
+mode_output="$(python3 "$RESOLVER" mode --repo-root "$hub_dir")"
+run_contains "fixture_mode_workflow_hub" "WORKFLOW_MODE=workflow_hub" "$mode_output"
+
+mobile_context="$(python3 "$RESOLVER" resolve --repo-root "$hub_dir" --repo mobile-app)"
+admin_context="$(python3 "$RESOLVER" resolve --repo-root "$hub_dir" --repo admin-portal)"
+run_contains "mobile_context_repo_name" "TARGET_REPO_NAME=mobile-app" "$mobile_context"
+run_contains "mobile_context_github_repo" "TARGET_GITHUB_REPO=example/mobile-app" "$mobile_context"
+run_contains "mobile_context_local_override" "TARGET_LOCAL_PATH_SOURCE=local_override" "$mobile_context"
+run_contains "mobile_context_local_path" "TARGET_LOCAL_PATH=$mobile_repo" "$mobile_context"
+run_contains "admin_context_repo_name" "TARGET_REPO_NAME=admin-portal" "$admin_context"
+run_contains "admin_context_git_url" "TARGET_GIT_URL=git@github.com:example/admin-portal.git" "$admin_context"
+run_contains "admin_context_checkout_root" "TARGET_LOCAL_PATH_SOURCE=checkout_root" "$admin_context"
+run_contains "admin_context_local_path" "TARGET_LOCAL_PATH=$admin_repo" "$admin_context"
+run_not_contains "products_have_distinct_identities" "TARGET_GITHUB_REPO=example/mobile-app" "$admin_context"
+
+python3 "$RESOLVER" validate --repo-root "$hub_dir" --repo mobile-app --require-local >/dev/null
+echo "PASS: mobile_validate_require_local"
+PASS_COUNT=$((PASS_COUNT + 1))
+python3 "$RESOLVER" validate --repo-root "$hub_dir" --repo admin-portal --require-local >/dev/null
+echo "PASS: admin_validate_require_local"
+PASS_COUNT=$((PASS_COUNT + 1))
+
+run_fails_contains \
+  "fixture_ambiguous_selection_fails" \
+  "product repository selection is ambiguous" \
+  python3 "$RESOLVER" resolve --repo-root "$hub_dir"
+run_fails_contains \
+  "fixture_unknown_repo_fails" \
+  "no workflow_hub.product_repos entry named 'unknown-app'" \
+  python3 "$RESOLVER" resolve --repo-root "$hub_dir" --repo unknown-app
+
+tmp_config_hub="$(fixture_dir tmp-config-hub)"
+cp -R "$FIXTURE_ROOT/hub/." "$tmp_config_hub/"
+mkdir -p "$tmp_config_hub/.tmp"
+cat > "$tmp_config_hub/.tmp/template-config.json" <<JSON
+{"product_repos":[{"name":"mobile-app","local_path":"$mobile_repo"}]}
+JSON
+run_fails_contains \
+  "tmp_template_config_not_checkout_source" \
+  "local path for product repo 'mobile-app' is required" \
+  python3 "$RESOLVER" validate --repo-root "$tmp_config_hub" --repo mobile-app --require-local
+
+echo ""
+echo "=== product_fixture: sync and status commands ==="
+
+status_output="$(bash "$STATUS_CMD" --repo-root "$hub_dir" --all)"
+run_contains "status_names_mobile" "REPO mobile-app" "$status_output"
+run_contains "status_names_admin" "REPO admin-portal" "$status_output"
+run_contains "status_reports_mobile_path" "LOCAL_PATH=$mobile_repo" "$status_output"
+run_contains "status_reports_admin_path" "LOCAL_PATH=$admin_repo" "$status_output"
+run_contains "status_reports_clean" "STATUS=clean" "$status_output"
+run_contains "status_summary_clean" "SUMMARY synced=0 skipped=0 clean=2 dirty=0 missing=0 blocked=0 failed=0" "$status_output"
+
+sync_output="$(bash "$SYNC_CMD" --repo-root "$hub_dir" --all)"
+run_contains "sync_names_mobile" "REPO mobile-app" "$sync_output"
+run_contains "sync_names_admin" "REPO admin-portal" "$sync_output"
+run_contains "sync_already_current" "REASON=already_current" "$sync_output"
+run_contains "sync_summary_skipped" "SUMMARY synced=0 skipped=2 clean=0 dirty=0 missing=0 blocked=0 failed=0" "$sync_output"
+run_fails_contains \
+  "status_unknown_product_fails" \
+  "no workflow_hub.product_repos entry named 'unknown-app'" \
+  bash "$STATUS_CMD" --repo-root "$hub_dir" --repo unknown-app
+run_fails_contains \
+  "sync_missing_local_path_guidance" \
+  "STATUS=missing_path" \
+  bash "$SYNC_CMD" --repo-root "$tmp_config_hub" --repo mobile-app
+
+echo ""
+echo "=== dry_run_routing: branch and pull-request targeting ==="
+
+stub_bin="$TMP_ROOT/bin"
+mkdir -p "$stub_bin"
+cat > "$stub_bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  auth)
+    exit 0
+    ;;
+  pr)
+    case "${2:-}" in
+      list)
+        for arg in "$@"; do
+          if [ "$arg" = "length" ]; then
+            printf '0\n'
+            exit 0
+          fi
+        done
+        printf '[]\n'
+        exit 0
+        ;;
+      view)
+        printf '{"headRefName":"feature/883-fixture-routing","labels":[],"isDraft":false,"comments":[],"statusCheckRollup":[]}\n'
+        exit 0
+        ;;
+    esac
+    ;;
+  repo)
+    if [ "${2:-}" = "view" ]; then
+      printf '{"nameWithOwner":"example/workflow-hub"}\n'
+      exit 0
+    fi
+    ;;
+esac
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+SH
+chmod +x "$stub_bin/gh"
+
+hub_dev="$(make_development "$hub_dir")"
+next_action_output="$(
+  PATH="$stub_bin:$PATH" WORKFLOW_SKIP_FETCH=1 "$NEXT_ACTION_CMD" \
+    --repo-root "$hub_dir" \
+    --repo mobile-app \
+    --development "$hub_dev"
+)"
+run_contains "next_action_targets_product_kind" "ACTION_REPOSITORY_KIND=product_repo_owned" "$next_action_output"
+run_contains "next_action_targets_mobile_repo" "ACTION_GITHUB_REPO=example/mobile-app" "$next_action_output"
+run_not_contains "next_action_not_hub_repo" "ACTION_GITHUB_REPO=example/workflow-hub" "$next_action_output"
+
+body_file="$TMP_ROOT/body.md"
+printf 'Fixture product PR body\n' > "$body_file"
+mobile_pr_output="$(
+  bash "$PR_CMD" \
+    --repo-root "$hub_dir" \
+    --repo mobile-app \
+    --base main \
+    --head feature/883-fixture-routing \
+    --title "Fixture mobile PR" \
+    --body-file "$body_file" \
+    --dry-run
+)"
+admin_pr_output="$(
+  bash "$PR_CMD" \
+    --repo-root "$hub_dir" \
+    --repo admin-portal \
+    --base develop \
+    --head feature/883-fixture-routing \
+    --title "Fixture admin PR" \
+    --body-file "$body_file" \
+    --dry-run
+)"
+run_contains "mobile_pr_dry_run_targets_product" "TARGET_REPO=example/mobile-app" "$mobile_pr_output"
+run_contains "mobile_pr_dry_run_base" "BASE_BRANCH=main" "$mobile_pr_output"
+run_contains "mobile_pr_dry_run_head" "HEAD_BRANCH=feature/883-fixture-routing" "$mobile_pr_output"
+run_contains "admin_pr_dry_run_targets_product" "TARGET_REPO=example/admin-portal" "$admin_pr_output"
+run_not_contains "product_pr_dry_run_no_token" "fixture-installation-token" "$mobile_pr_output"
+run_not_contains "product_pr_dry_run_no_secret_ref" "op://" "$mobile_pr_output"
+
+echo ""
+echo "=== hub_fixture: mode-scope classification ==="
+
+sync_scope_output="$(
+  python3 "$VALIDATOR" \
+    --repo-root "$REPO_ROOT" \
+    --sync-manifest "$REPO_ROOT/sync-manifest.yaml"
+)"
+run_contains "mode_scope_validator_reports_ok" "VALID" "$sync_scope_output"
+sync_manifest_text="$(cat "$REPO_ROOT/sync-manifest.yaml")"
+run_contains "mode_scope_manifest_defines_shared" "shared:" "$sync_manifest_text"
+run_contains "mode_scope_manifest_defines_hub_only" "hub_only:" "$sync_manifest_text"
+run_contains "mode_scope_manifest_defines_product_injection" "product_repo_injection:" "$sync_manifest_text"
+run_contains "mode_scope_has_shared_entries" "mode_scope: shared" "$(cat "$REPO_ROOT/sync-manifest.yaml")"
+run_contains "mode_scope_has_hub_entries" "mode_scope: hub_only" "$(cat "$REPO_ROOT/sync-manifest.yaml")"
+run_contains "mode_scope_has_product_entries" "mode_scope: product_repo_injection" "$(cat "$REPO_ROOT/sync-manifest.yaml")"
+echo "INFO: runtime mode-aware sync filtering remains outside this smoke harness; #883 validates classification metadata only."
+
+echo ""
+echo "=== single_repo_regression: default compatibility ==="
+
+missing_mode_dir="$(fixture_dir missing-mode-single)"
+explicit_single_dir="$(fixture_dir explicit-single)"
+mkdir -p "$missing_mode_dir" "$explicit_single_dir"
+git -C "$missing_mode_dir" init -q -b main
+cat > "$explicit_single_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: single_repo
+YAML
+missing_mode_output="$(python3 "$RESOLVER" mode --repo-root "$missing_mode_dir")"
+explicit_single_output="$(python3 "$RESOLVER" mode --repo-root "$explicit_single_dir")"
+run_contains "missing_mode_defaults_single_repo" "WORKFLOW_MODE=single_repo" "$missing_mode_output"
+run_contains "explicit_single_repo_resolves" "WORKFLOW_MODE=single_repo" "$explicit_single_output"
+missing_mode_dev="$(make_development "$missing_mode_dir")"
+single_next_action="$(
+  PATH="$stub_bin:$PATH" WORKFLOW_SKIP_FETCH=1 "$NEXT_ACTION_CMD" \
+    --repo-root "$missing_mode_dir" \
+    --development "$missing_mode_dev"
+)"
+run_contains "single_repo_next_action_context" "ACTION_REPOSITORY_KIND=single_repo_context" "$single_next_action"
+run_not_contains "single_repo_no_product_selection_required" "product repository selection is ambiguous" "$single_next_action"
+
+echo ""
+echo "=== live_optional: explicit GitHub App boundary ==="
+
+if [ "$LIVE_GITHUB_APP" != "true" ]; then
+  echo "LIVE_VALIDATION=skipped"
+  echo "LIVE_VALIDATION_REASON=not_requested"
+  echo "PASS: live_validation_skipped_by_default"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  required_missing=false
+  for var_name in WORKFLOW_HUB_SMOKE_LIVE_REPO WORKFLOW_HUB_SMOKE_LIVE_BASE WORKFLOW_HUB_SMOKE_LIVE_HEAD; do
+    if [ -z "${!var_name:-}" ]; then
+      echo "LIVE_VALIDATION=failed"
+      echo "LIVE_VALIDATION_REASON=missing_${var_name}"
+      required_missing=true
+    fi
+  done
+  if [ "$required_missing" = "true" ]; then
+    exit 1
+  fi
+  echo "LIVE_VALIDATION=requested"
+  echo "LIVE_VALIDATION_REPO=$WORKFLOW_HUB_SMOKE_LIVE_REPO"
+  echo "LIVE_VALIDATION_SCOPE=operator_supplied_safe_test_repository"
+fi
+
+echo ""
+echo "Passed: $PASS_COUNT"
+echo "Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
-REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 FIXTURE_ROOT="$SCRIPT_DIR/fixtures/workflow-hub-smoke"
 RESOLVER="$REPO_ROOT/scripts/development-workflow/workflow-config-resolver.py"
 STATUS_CMD="$REPO_ROOT/scripts/development-workflow/hub-status.sh"
@@ -34,7 +34,10 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-TMP_ROOT="$(mktemp -d)"
+TMP_ROOT="$(mktemp -d)" || {
+  echo "Failed to create temporary directory." >&2
+  exit 1
+}
 TMP_ROOT="$(CDPATH='' cd -- "$TMP_ROOT" && pwd -P)"
 
 _harness_exit() {
@@ -181,19 +184,28 @@ run_equals "fixture_seed_exists" "yes" "$([ -d "$FIXTURE_ROOT" ] && echo yes || 
 run_equals "fixture_hub_shared_config_exists" "yes" "$([ -f "$FIXTURE_ROOT/hub/.ai-dev-workflow.yaml" ] && echo yes || echo no)"
 run_equals "fixture_local_template_exists" "yes" "$([ -f "$FIXTURE_ROOT/local-config.template.yaml" ] && echo yes || echo no)"
 
-private_hits=""
-set +e
-private_hits="$(
-  find "$FIXTURE_ROOT" -type f ! -name README.md -print0 |
-    xargs -0 grep -InE 'Leasity|RADAR|kids-safety|baumsystem|lhpaul/|op://|BEGIN .*PRIVATE KEY|ghp_|github_pat_|private_key_path|secret_ref|token='
-)"
-private_status=$?
-set -e
-if [ "$private_status" -ne 0 ] && [ "$private_status" -ne 1 ]; then
-  echo "FAIL: fixture_private_detail_scan - grep failed with exit code $private_status"
-  FAIL_COUNT=$((FAIL_COUNT + 1))
+if private_hits="$(
+  grep -RInE --exclude='README.md' \
+    'Leasity|RADAR|kids-safety|baumsystem|lhpaul/|op://|BEGIN .*PRIVATE KEY|ghp_|github_pat_|private_key_path|secret_ref|token=' \
+    "$FIXTURE_ROOT" 2>&1
+)"; then
+  :
+else
+  private_status=$?
+  if [ "$private_status" -eq 1 ]; then
+    private_hits=""
+  else
+    echo "FAIL: fixture_private_detail_scan - grep failed with exit code $private_status"
+    printf '%s\n' "$private_hits"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    private_hits="__scan_failed__"
+  fi
 fi
-run_equals "fixture_private_detail_scan" "" "$private_hits"
+if [ "$private_hits" = "__scan_failed__" ]; then
+  :
+else
+  run_equals "fixture_private_detail_scan" "" "$private_hits"
+fi
 
 hub_dir="$(fixture_dir workflow-hub)"
 cp -R "$FIXTURE_ROOT/hub/." "$hub_dir/"


### PR DESCRIPTION
## Summary
- add a committed non-secret workflow-hub smoke fixture with two dummy product repositories
- add a shell smoke harness covering config resolution, local path precedence, status/sync, product PR dry-run routing, mode-scope classification, single-repo regression, and live opt-in boundaries
- wire the harness into workflow test CI for develop-workflow-hub-mode and document local usage

## Validation
- bash scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh
- bash scripts/development-workflow/tests/test-workflow-config-resolver.sh
- bash scripts/development-workflow/tests/test-workflow-hub-skeletons.sh
- bash scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
- bash scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
- bash scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh
- shellcheck --severity=warning scripts/development-workflow/*.sh scripts/development-workflow/tests/*.sh
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/development-workflow/workflow-config-resolver.py scripts/development-workflow/validate-workflow-hub-skeletons.py
- npx markdownlint-cli2 "docs/specs/developments/20260610170359_883-workflow-hub-smoke-fixtures/*.md" "docs/testing/workflow/883-workflow-hub-smoke-fixtures.smoke-test.md" "CHANGELOG.md"
- python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/883-workflow-hub-smoke-fixtures.smoke-test.md CHANGELOG.md
- bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md
- git diff --check

Closes #883