### PR TITLE
feat: add sync-template mode-scope selection

### DIFF
--- a/.agents/skills/sync-template/SKILL.md
+++ b/.agents/skills/sync-template/SKILL.md
@@ -9,4 +9,6 @@ This is the Codex command-style alias for Claude Code `/sync-template`.
 
 1. Read `AGENTS.md` for repository-wide rules.
 2. Read `.codex/skills/workflow-sync-template/SKILL.md`.
-3. Follow the `workflow-sync-template` skill exactly.
+3. Follow the `workflow-sync-template` skill exactly, including role-aware
+   manifest selection for `single_repo`, `workflow_hub`, and `product_repo`
+   repositories.

--- a/.claude/commands/sync-template.md
+++ b/.claude/commands/sync-template.md
@@ -12,7 +12,7 @@ Follow this workflow exactly when invoked. Do not skip steps or reorder them.
 
 ---
 
-## Step 0 — Parse arguments and determine template source
+## Step 0 — Parse arguments, determine template source, and resolve repository role
 
 Parse the user's arguments:
 
@@ -55,6 +55,40 @@ Once the template source is resolved, read its `CHANGELOG.md` and extract the la
 
 - If found: read it and store its contents as `SYNC_MANIFEST`. The manifest is the authoritative file list (BR-1).
 - If absent: set `SYNC_MANIFEST=absent`. The graceful fallback (BR-4 / AC-4) activates in Step 2 — the embedded lists below are used and a warning is shown.
+
+**Repository role check**: Read the current project's `.ai-dev-workflow.yaml`
+top-level `mode` value. If the file or field is absent, set
+`REPOSITORY_ROLE=single_repo`. Supported roles are `single_repo`,
+`workflow_hub`, and `product_repo`; any other value is a configuration error and
+must stop the sync before file comparison.
+
+When `SYNC_MANIFEST` is loaded, build the selected manifest entry set before
+Step 0.5 using the selector helper from the resolved template source:
+
+```bash
+python3 "<template_source>/scripts/development-workflow/select-sync-manifest-entries.py" \
+  --manifest "<template_source>/sync-manifest.yaml" \
+  --role "$REPOSITORY_ROLE"
+```
+
+Store the resulting selected and skipped entries as `SYNC_SELECTED_ENTRIES` and
+`SYNC_SKIPPED_ENTRIES`. This same selected entry set must be used for dry-run
+diagnostics, file comparison, and apply steps so preview and apply cannot
+disagree.
+
+Role rules:
+
+- `single_repo`: preserve compatibility by selecting every manifest entry from
+  the existing categories.
+- `workflow_hub`: select `shared` and `hub_only`; skip
+  `product_repo_injection`.
+- `product_repo`: select `shared` and `product_repo_injection`; skip
+  `hub_only`.
+
+Unknown roles, missing `mode_scope` values, unknown `mode_scope` values, or a
+missing selector helper for a non-`single_repo` role must fail closed before any
+file changes are applied. If the manifest is absent, use fallback mode and make
+the lack of role-aware filtering explicit in the diagnostic report.
 
 **Migration notes check**: If `SYNC_MANIFEST` is loaded, read `migration_notes` from it. Read `template.last_synced_version` from the project's `.ai-dev-workflow.yaml` (if the file or field is absent, treat it as unknown — show all notes).
 
@@ -111,7 +145,7 @@ Dry-run complete. No changes were applied. Re-run without --dry-run to apply cha
 
 ### Category 1 — File-level merge conflicts (always-sync files)
 
-For each file listed in `categories.always_sync` (or the embedded fallback list when `SYNC_MANIFEST=absent`):
+For each selected file listed in `categories.always_sync` (or the embedded fallback list when `SYNC_MANIFEST=absent`):
 
 1. Enumerate all files using `find` (same method as Step 2).
 2. For files that exist in both the template and the project, run a diff:
@@ -129,7 +163,7 @@ Report all `Conflict risk` files with a one-line summary of what differs. This p
 
 Check for known CI/CD configuration mismatches between the template and the project:
 
-1. **Workflow file presence**: compare the set of `.github/workflows/` files in the template (under `categories.special_handling` if manifest is loaded, otherwise the embedded special-handling list) against the project. List any files that are in the template but absent from the project — these may be needed for full CI coverage after the sync.
+1. **Workflow file presence**: compare the selected set of `.github/workflows/` files in the template (under `categories.special_handling` if manifest is loaded, otherwise the embedded special-handling list) against the project. List any files that are in the template but absent from the project — these may be needed for full CI coverage after the sync.
 
 2. **Workflow YAML parse test** (pre-apply): for each workflow file that _would be updated_ based on the Category 1 diff, verify the _template_ version parses correctly before applying:
 
@@ -220,6 +254,8 @@ Output the report in this structure before proceeding to Step 1 (or stopping, if
 ## Pre-flight Diagnostic Report
 Template version: v{TEMPLATE_VERSION}  |  Project branch: [branch]
 Manifest: [loaded / absent — fallback mode]
+Repository role: [single_repo / workflow_hub / product_repo]
+Selected manifest entries: [N selected / M skipped by mode_scope]
 
 ### Category 1 — File-level conflicts
   No conflict:    N files (will be updated cleanly)
@@ -293,13 +329,13 @@ Run these checks **before touching anything**. If any check fails, report the pr
 
 ## Step 2 — Compare files
 
-Use `SYNC_MANIFEST` to determine the file lists. If `SYNC_MANIFEST=absent`, fall back to the embedded lists in each section below and display this warning before continuing:
+Use `SYNC_MANIFEST` and `SYNC_SELECTED_ENTRIES` to determine the file lists. If `SYNC_MANIFEST=absent`, fall back to the embedded lists in each section below and display this warning before continuing:
 
 > "Warning: sync manifest not found in upstream template. Using embedded file list — results may be incomplete."
 
 ### Always sync (apply automatically after approval)
 
-**If `SYNC_MANIFEST` is loaded**: read `categories.always_sync` from the manifest and enumerate those paths from the template. Each entry may specify a `path` (single file or directory prefix) and an optional `glob` pattern for recursive enumeration.
+**If `SYNC_MANIFEST` is loaded**: read selected `categories.always_sync` entries from `SYNC_SELECTED_ENTRIES` and enumerate those paths from the template. Each entry may specify a `path` (single file or directory prefix) and an optional `glob` pattern for recursive enumeration. Do not compare or apply entries from `SYNC_SKIPPED_ENTRIES`; list them in the summary under "Skipped by repository role".
 
 **If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
@@ -334,7 +370,8 @@ For each file in these paths:
 
 **If `SYNC_MANIFEST` is loaded and contains a `rename_detections` list**: after completing the always-sync comparison above, check each entry:
 
-1. Verify that `entry.new_path` is present in `categories.always_sync`. If it is not, skip this entry.
+1. Verify that `entry.new_path` is present in selected `categories.always_sync`
+   for the resolved repository role. If it is not, skip this entry.
 2. Check whether `entry.old_path` exists as a non-empty directory in the project:
    ```bash
    [ -d "<old_path>" ] && find "<old_path>" -mindepth 1 -maxdepth 1 | wc -l
@@ -349,7 +386,7 @@ Rename cleanup candidates are displayed in Step 3 and applied in Step 4 only aft
 
 ### Special handling (show full diff, user decides per file)
 
-**If `SYNC_MANIFEST` is loaded**: read `categories.special_handling` from the manifest.
+**If `SYNC_MANIFEST` is loaded**: read selected `categories.special_handling` entries from `SYNC_SELECTED_ENTRIES`.
 
 **If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
@@ -370,7 +407,7 @@ These paths are project-specific and must **not** be overwritten by the template
 
 **Critical:** Do not remove or replace content that is specific to the project. Only suggest additions or merges that clearly originate from the template and do not conflict with project-only content. When in doubt, list the difference under "Optional additive update" and let the user decide.
 
-**If `SYNC_MANIFEST` is loaded**: read `categories.project_specific` from the manifest. For entries with `mixed_content: true`, also read the `annotation_scheme` field and apply the mixed-content extraction logic described below.
+**If `SYNC_MANIFEST` is loaded**: read selected `categories.project_specific` entries from `SYNC_SELECTED_ENTRIES`. For entries with `mixed_content: true`, also read the `annotation_scheme` field and apply the mixed-content extraction logic described below.
 
 **If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
@@ -416,6 +453,7 @@ Show a structured summary before asking for confirmation. Include file counts pe
 ## Template Sync Summary
 Template version: v0.4.0  |  Project branch: develop
 Manifest: loaded from sync-manifest.yaml  (or: "not found — using embedded fallback list")
+Repository role: workflow_hub  (selected: N entries, skipped by mode_scope: M)
 
 ### Always-sync files: N total (A to add, U to update, C up-to-date)
 
@@ -442,6 +480,12 @@ Manifest: loaded from sync-manifest.yaml  (or: "not found — using embedded fal
   AGENTS.md — template has [brief description]; project keeps its own content; suggest adding: ...
   README.md — no template additions suggested
   ...
+
+### Skipped by repository role
+  product_repo_injection:
+    AGENTS.md
+  hub_only:
+    docs/workflow/
 
 ### Rename cleanup (you decide)
   docs/ai/ — was the previous location of always-sync content now in docs/workflow/ (renamed in v0.23.0).

--- a/.claude/skills/sync-template.md
+++ b/.claude/skills/sync-template.md
@@ -12,7 +12,7 @@ Follow this workflow exactly when invoked. Do not skip steps or reorder them.
 
 ---
 
-## Step 0 — Parse arguments and determine template source
+## Step 0 — Parse arguments, determine template source, and resolve repository role
 
 Parse the user's arguments:
 
@@ -55,6 +55,40 @@ Once the template source is resolved, read its `CHANGELOG.md` and extract the la
 
 - If found: read it and store its contents as `SYNC_MANIFEST`. The manifest is the authoritative file list (BR-1).
 - If absent: set `SYNC_MANIFEST=absent`. The graceful fallback (BR-4 / AC-4) activates in Step 2 — the embedded lists below are used and a warning is shown.
+
+**Repository role check**: Read the current project's `.ai-dev-workflow.yaml`
+top-level `mode` value. If the file or field is absent, set
+`REPOSITORY_ROLE=single_repo`. Supported roles are `single_repo`,
+`workflow_hub`, and `product_repo`; any other value is a configuration error and
+must stop the sync before file comparison.
+
+When `SYNC_MANIFEST` is loaded, build the selected manifest entry set before
+Step 0.5 using the selector helper from the resolved template source:
+
+```bash
+python3 "<template_source>/scripts/development-workflow/select-sync-manifest-entries.py" \
+  --manifest "<template_source>/sync-manifest.yaml" \
+  --role "$REPOSITORY_ROLE"
+```
+
+Store the resulting selected and skipped entries as `SYNC_SELECTED_ENTRIES` and
+`SYNC_SKIPPED_ENTRIES`. This same selected entry set must be used for dry-run
+diagnostics, file comparison, and apply steps so preview and apply cannot
+disagree.
+
+Role rules:
+
+- `single_repo`: preserve compatibility by selecting every manifest entry from
+  the existing categories.
+- `workflow_hub`: select `shared` and `hub_only`; skip
+  `product_repo_injection`.
+- `product_repo`: select `shared` and `product_repo_injection`; skip
+  `hub_only`.
+
+Unknown roles, missing `mode_scope` values, unknown `mode_scope` values, or a
+missing selector helper for a non-`single_repo` role must fail closed before any
+file changes are applied. If the manifest is absent, use fallback mode and make
+the lack of role-aware filtering explicit in the diagnostic report.
 
 **Migration notes check**: If `SYNC_MANIFEST` is loaded, read `migration_notes` from it. Read `template.last_synced_version` from the project's `.ai-dev-workflow.yaml` (if the file or field is absent, treat it as unknown — show all notes).
 
@@ -111,7 +145,7 @@ Dry-run complete. No changes were applied. Re-run without --dry-run to apply cha
 
 ### Category 1 — File-level merge conflicts (always-sync files)
 
-For each file listed in `categories.always_sync` (or the embedded fallback list when `SYNC_MANIFEST=absent`):
+For each selected file listed in `categories.always_sync` (or the embedded fallback list when `SYNC_MANIFEST=absent`):
 
 1. Enumerate all files using `find` (same method as Step 2).
 2. For files that exist in both the template and the project, run a diff:
@@ -129,7 +163,7 @@ Report all `Conflict risk` files with a one-line summary of what differs. This p
 
 Check for known CI/CD configuration mismatches between the template and the project:
 
-1. **Workflow file presence**: compare the set of `.github/workflows/` files in the template (under `categories.special_handling` if manifest is loaded, otherwise the embedded special-handling list) against the project. List any files that are in the template but absent from the project — these may be needed for full CI coverage after the sync.
+1. **Workflow file presence**: compare the selected set of `.github/workflows/` files in the template (under `categories.special_handling` if manifest is loaded, otherwise the embedded special-handling list) against the project. List any files that are in the template but absent from the project — these may be needed for full CI coverage after the sync.
 
 2. **Workflow YAML parse test** (pre-apply): for each workflow file that _would be updated_ based on the Category 1 diff, verify the _template_ version parses correctly before applying:
 
@@ -220,6 +254,8 @@ Output the report in this structure before proceeding to Step 1 (or stopping, if
 ## Pre-flight Diagnostic Report
 Template version: v{TEMPLATE_VERSION}  |  Project branch: [branch]
 Manifest: [loaded / absent — fallback mode]
+Repository role: [single_repo / workflow_hub / product_repo]
+Selected manifest entries: [N selected / M skipped by mode_scope]
 
 ### Category 1 — File-level conflicts
   No conflict:    N files (will be updated cleanly)
@@ -282,10 +318,10 @@ Run these checks **before touching anything**. If any check fails, report the pr
    git branch --show-current
    ```
 
-   - If `develop` branch exists → must be on `develop`
-   - If `develop` does not exist → must be on `main`
+   - If `develop` branch exists → must be on `develop`; set `BASE_BRANCH=develop`
+   - If `develop` does not exist → must be on `main`; set `BASE_BRANCH=main`
 
-   If on the wrong branch, abort with:
+   Store `BASE_BRANCH` for use in Step 5.4. If on the wrong branch, abort with:
 
    > "You must be on the `develop` branch (or `main` if `develop` doesn't exist) before syncing. Please switch branches and try again."
 
@@ -293,29 +329,29 @@ Run these checks **before touching anything**. If any check fails, report the pr
 
 ## Step 2 — Compare files
 
-Use `SYNC_MANIFEST` to determine the file lists. If `SYNC_MANIFEST=absent`, fall back to the embedded lists in each section below and display this warning before continuing:
+Use `SYNC_MANIFEST` and `SYNC_SELECTED_ENTRIES` to determine the file lists. If `SYNC_MANIFEST=absent`, fall back to the embedded lists in each section below and display this warning before continuing:
 
 > "Warning: sync manifest not found in upstream template. Using embedded file list — results may be incomplete."
 
 ### Always sync (apply automatically after approval)
 
-**If `SYNC_MANIFEST` is loaded**: read `categories.always_sync` from the manifest and enumerate those paths from the template. Each entry may specify a `path` (single file or directory prefix) and an optional `glob` pattern for recursive enumeration.
+**If `SYNC_MANIFEST` is loaded**: read selected `categories.always_sync` entries from `SYNC_SELECTED_ENTRIES` and enumerate those paths from the template. Each entry may specify a `path` (single file or directory prefix) and an optional `glob` pattern for recursive enumeration. Do not compare or apply entries from `SYNC_SKIPPED_ENTRIES`; list them in the summary under "Skipped by repository role".
 
 **If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
 ```
-REVIEW.md                         ← canonical review contract for spec, plan, and code review gates
-docs/workflow/                          ← full tree, all files recursively
-.claude/agents/                   ← all *.md files
-.claude/commands/                 ← all *.md files
-.claude/skills/                   ← all *.md files (including this skill itself)
-.codex/skills/                    ← Codex skill trees shipped with the template (SKILL.md and assets)
-.agents/skills/                   ← Codex repo-scoped skill discovery path and command-style aliases
-.cursor/commands/                 ← all *.md files
-.cursor/agents/                   ← all *.md files
-.cursor/rules/                    ← all *.mdc files
-scripts/development-workflow/     ← workflow helper scripts (discover state, PR/CI loops, etc.)
-scripts/README.md                 ← purpose and usage of scripts in scripts/
+REVIEW.md                         <- canonical review contract for spec, plan, and code review gates
+docs/workflow/                          <- full tree, all files recursively
+.claude/agents/                   <- all *.md files
+.claude/commands/                 <- all *.md files
+.claude/skills/                   <- all *.md files (including this skill itself)
+.codex/skills/                    <- Codex skill trees shipped with the template (SKILL.md and assets)
+.agents/skills/                   <- Codex repo-scoped skill discovery path and command-style aliases
+.cursor/commands/                 <- all *.md files
+.cursor/agents/                   <- all *.md files
+.cursor/rules/                    <- all *.mdc files
+scripts/development-workflow/     <- workflow helper scripts (discover state, PR/CI loops, etc.)
+scripts/README.md                 <- purpose and usage of scripts in scripts/
 docs/best-practices/1-general.md
 docs/best-practices/2-version-control.md
 docs/best-practices/3-testing.md
@@ -325,16 +361,17 @@ docs/best-practices/3-testing.md
 
 For each file in these paths:
 
-- **Exists in template, not in project** → classify as ✅ **Add**
-- **Exists in both, content differs** → classify as 📝 **Update** (prepare a concise diff summary)
-- **Exists in both, content identical** → classify as ⏭ **No change** (list but don't highlight)
+- **Exists in template, not in project** → classify as **Add**
+- **Exists in both, content differs** → classify as **Update** (prepare a concise diff summary)
+- **Exists in both, content identical** → classify as **No change** (list but don't highlight)
 - **Exists in project, not in template** → **ignore** (never delete project-only files)
 
 ### Rename cleanup detection
 
 **If `SYNC_MANIFEST` is loaded and contains a `rename_detections` list**: after completing the always-sync comparison above, check each entry:
 
-1. Verify that `entry.new_path` is present in `categories.always_sync`. If it is not, skip this entry.
+1. Verify that `entry.new_path` is present in selected `categories.always_sync`
+   for the resolved repository role. If it is not, skip this entry.
 2. Check whether `entry.old_path` exists as a non-empty directory in the project:
    ```bash
    [ -d "<old_path>" ] && find "<old_path>" -mindepth 1 -maxdepth 1 | wc -l
@@ -349,17 +386,17 @@ Rename cleanup candidates are displayed in Step 3 and applied in Step 4 only aft
 
 ### Special handling (show full diff, user decides per file)
 
-**If `SYNC_MANIFEST` is loaded**: read `categories.special_handling` from the manifest.
+**If `SYNC_MANIFEST` is loaded**: read selected `categories.special_handling` entries from `SYNC_SELECTED_ENTRIES`.
 
 **If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
 ```
-.claude/settings.json                          ← may have project-specific permissions
+.claude/settings.json                          <- may have project-specific permissions
 .claude/settings.local.json.example
-.github/workflows/auto-tag-release.yml         ← automated release tagging; add if CI is set up
-.github/workflows/deploy.yml                   ← placeholder deployment workflow; customize with project-specific deploy logic
-.github/workflows/e2e-regression.yml           ← label-gated e2e/regression placeholder; customize with project-specific test logic
-e2e/                                              ← placeholder e2e/regression test project (Playwright); customize with project-specific tests
+.github/workflows/auto-tag-release.yml         <- automated release tagging; add if CI is set up
+.github/workflows/deploy.yml                   <- placeholder deployment workflow; customize with project-specific deploy logic
+.github/workflows/e2e-regression.yml           <- label-gated e2e/regression placeholder; customize with project-specific test logic
+e2e/                                           <- placeholder e2e/regression test project (Playwright); customize with project-specific tests
 ```
 
 For each of these: show the full diff and ask the user explicitly whether to apply it.
@@ -370,7 +407,7 @@ These paths are project-specific and must **not** be overwritten by the template
 
 **Critical:** Do not remove or replace content that is specific to the project. Only suggest additions or merges that clearly originate from the template and do not conflict with project-only content. When in doubt, list the difference under "Optional additive update" and let the user decide.
 
-**If `SYNC_MANIFEST` is loaded**: read `categories.project_specific` from the manifest. For entries with `mixed_content: true`, also read the `annotation_scheme` field and apply the mixed-content extraction logic described below.
+**If `SYNC_MANIFEST` is loaded**: read selected `categories.project_specific` entries from `SYNC_SELECTED_ENTRIES`. For entries with `mixed_content: true`, also read the `annotation_scheme` field and apply the mixed-content extraction logic described below.
 
 **If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
@@ -387,7 +424,7 @@ CLAUDE.md
 GEMINI.md
 ```
 
-For each of these: if template and project differ, show what the template has that the project might want to add; classify as ⚠️ **Optional additive update** (user decides). Do not apply changes to these paths without explicit user approval.
+For each of these: if template and project differ, show what the template has that the project might want to add; classify as **Optional additive update** (user decides). Do not apply changes to these paths without explicit user approval.
 
 Everything else not listed above (application code, project configs, etc.) is also never overwritten.
 
@@ -416,34 +453,41 @@ Show a structured summary before asking for confirmation. Include file counts pe
 ## Template Sync Summary
 Template version: v0.4.0  |  Project branch: develop
 Manifest: loaded from sync-manifest.yaml  (or: "not found — using embedded fallback list")
+Repository role: workflow_hub  (selected: N entries, skipped by mode_scope: M)
 
 ### Always-sync files: N total (A to add, U to update, C up-to-date)
 
-#### ✅ New files (will be added): A
+#### New files (will be added): A
   .claude/skills/sync-template.md
 
-#### 📝 Modified files (will be updated): U
+#### Modified files (will be updated): U
   .claude/agents/developer.md
-    Line 3: model: claude-sonnet-4-5 → model: claude-sonnet-4-6
+    Line 3: model: claude-sonnet-4-5 -> model: claude-sonnet-4-6
 
   docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
     [diff summary]
 
-#### ⏭ Already up to date (no changes): C
+#### Already up to date (no changes): C
   docs/best-practices/1-general.md
   .cursor/rules/code.mdc
   ... (N files)
 
-### ⚠️ Requires manual review (you decide)
+### Requires manual review (you decide)
   .claude/settings.json
     [full diff shown here]
 
-### ⚠️ Optional additive updates (project-specific — you decide)
-  AGENTS.md — template has [brief description]; project keeps its own content; suggest adding: …
+### Optional additive updates (project-specific — you decide)
+  AGENTS.md — template has [brief description]; project keeps its own content; suggest adding: ...
   README.md — no template additions suggested
-  …
+  ...
 
-### 🗂️ Rename cleanup (you decide)
+### Skipped by repository role
+  product_repo_injection:
+    AGENTS.md
+  hub_only:
+    docs/workflow/
+
+### Rename cleanup (you decide)
   docs/ai/ — was the previous location of always-sync content now in docs/workflow/ (renamed in v0.23.0).
   Stale directory still present. Proposed actions (each requires separate approval):
     1. Delete docs/ai/  (git rm -r docs/ai/)
@@ -467,7 +511,14 @@ Always-sync disposition:
 
 Then ask:
 
-> "Ready to apply the changes above? For the files listed under ✅ **New files** and 📝 **Modified files** in the **always-sync** section only, I can apply them in one batch when you confirm. Special-handling and optional additive-update paths always need explicit per-path approval — bulk phrases like \"apply all\" never include those categories."
+> "Ready to apply the changes above? You have two options:
+>
+> - **"apply all"** — Apply the always-sync files in one batch, then walk through each manual-review and optional-additive item inline, presenting the diff and asking you to confirm or skip before moving on.
+> - **"apply always-sync only"** — Apply only the always-sync files now; skip manual-review and optional-additive items entirely.
+>
+> Special-handling paths (`.github/workflows/deploy.yml`, `e2e-regression.yml`, `e2e/`, `.claude/settings.json`, etc.) are never included in "apply all" — those require you to name each approved path explicitly.
+>
+> Which would you like?"
 
 **Do not modify any files until you have explicit confirmation.**
 
@@ -475,9 +526,36 @@ Then ask:
 
 ## Step 4 — Apply changes (only after approval)
 
-- Copy/overwrite all ✅ (Add) and 📝 (Update) files **from the always-sync Step 3 section only** when the user confirms that batch. Phrases such as "apply all", "apply everything", or "yes to all" mean **always-sync files only** — they **never** authorize applying **special-handling** paths (`.github/workflows/deploy.yml`, `e2e-regression.yml`, `e2e/`, `.claude/settings.json`, etc.) or **optional additive updates**; those require the user to name each approved path (or `none`).
+Apply approved changes:
+
+### Always-sync files
+
+Copy/overwrite all **Add** and **Update** files from the always-sync section whenever the user confirms that batch — regardless of whether they said "apply all" or "apply always-sync only".
+
+### Manual-review and optional-additive items ("apply all" path)
+
+When the user chooses **"apply all"**, after the always-sync batch is applied, walk through **every** item in the manual-review section and every item in the optional-additive section, **one item at a time**:
+
+1. Show the item's diff (or proposed addition) inline.
+2. State a recommendation (e.g., "I recommend applying this because …" or "This is optional — your project already has equivalent content").
+3. Ask: "Apply this item? (yes / skip)"
+4. Apply immediately if the user answers "yes"; skip if "skip" (or any non-yes answer).
+5. Proceed to the next item.
+
+Continue until all manual-review and optional-additive items have been presented. This ensures "apply all" genuinely means "walk me through everything and apply what I approve."
+
+### Always-sync only path
+
+When the user chooses **"apply always-sync only"**, skip the manual-review and optional-additive walkthrough entirely. Special-handling items are also skipped unless named explicitly.
+
+### Special-handling paths
+
+Phrases such as "apply all", "apply everything", or "yes to all" **never** authorize applying **special-handling** paths (`.github/workflows/deploy.yml`, `e2e-regression.yml`, `e2e/`, `.claude/settings.json`, etc.). Those require the user to name each approved path explicitly.
+
 - **Placeholder guard for workflow YAML** (`.github/workflows/deploy.yml`, `.github/workflows/e2e-regression.yml`): Before overwriting the project copy with the template, compare line counts. If the **project** file has **more lines** than the template and the template has **fewer than 70%** of the project's line count, treat this as likely "real implementation → template placeholder" and **refuse** unless the user sends a **second** explicit confirmation naming that exact file.
-- For ⚠️ files: apply only those the user explicitly approved (including any optional additive updates to project-specific files — merge or add only, never remove project-specific content)
+
+### General rules
+
 - Do **not** delete any file from the always-sync, special-handling, or project-specific categories without explicit approval
 - Do **not** overwrite project-specific files; for those paths only additive/merge changes are allowed, and only with explicit approval
 
@@ -527,7 +605,7 @@ If any references remain, list them and ask the maintainer whether to update the
 
 **Bulk phrases do not cover rename cleanup**: "apply all", "apply everything", or "yes to all" never authorize rename cleanup actions. Each rename cleanup action (delete directory, update cross-references) requires the maintainer to name it explicitly.
 
-If the template source was a remote clone, clean it up now:
+If the template source was a remote clone, clean up the exact temp directory recorded in Step 0:
 
 ```bash
 rm -rf "$TEMPLATE_TEMP_DIR"   # use the exact path, not a wildcard
@@ -571,18 +649,22 @@ if [ "$yaml_parse_failed" -ne 0 ]; then
 fi
 ```
 
-If `yaml_parse_failed` is non-zero, **do not commit**. Report the broken file(s) and ask the maintainer to fix them before committing.
+If any file fails to parse, **do not commit**. Report the broken file(s) and ask the maintainer to fix them before committing.
 
 ### 3. Validate that `scripts/` paths referenced in workflow `run:` steps exist
 
 ```bash
-grep -hE 'scripts/[A-Za-z0-9_/.-]+' .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null \
-  | grep -oE 'scripts/[A-Za-z0-9_/.-]+' \
-  | sort -u \
-  | while read -r script_path; do
-      if [ ! -e "$script_path" ]; then
-        echo "MISSING SCRIPT: $script_path (referenced in a workflow run: step)"
-      fi
+grep -nHE 'scripts/[A-Za-z0-9_/.-]+' .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null \
+  | while IFS=: read -r workflow_file _ matched_line; do
+      printf '%s\n' "$matched_line" \
+        | grep -oE 'scripts/[A-Za-z0-9_/.-]+' \
+        | sort -u \
+        | while IFS= read -r script_path; do
+            [ -n "$script_path" ] || continue
+            if [ ! -e "$script_path" ]; then
+              echo "MISSING SCRIPT: $script_path (referenced in $workflow_file)"
+            fi
+          done
     done
 ```
 
@@ -598,61 +680,183 @@ This check is **advisory for the project-specific category** (e.g., `.github/wor
 
 ---
 
-## Step 5 — Generate git instructions
+## Step 5 — Commit, push, and open PR
 
-Before printing the git instructions, record the last-synced template version:
+### 5.1 — Record last-synced template version
 
 1. Read `.ai-dev-workflow.yaml` from the project root.
-2. Use `yq` to safely update the template section. If the `template:` key does not exist, create it with both required fields (see schema below); if it exists, update only `last_synced_version`. Insert new sections after the `browser_automation:` block.
-   - Schema for new `template:` section:
-     ```yaml
-     template:
-       repository: ""
-       last_synced_version: "v{TEMPLATE_VERSION}"
-     ```
-   - Command to update existing section: `yq eval '.template.last_synced_version = "v{TEMPLATE_VERSION}"' -i .ai-dev-workflow.yaml`
-   - Command to create new section (if missing): `yq eval '.template.repository = "" | .template.last_synced_version = "v{TEMPLATE_VERSION}"' -i .ai-dev-workflow.yaml` (yq will create the `template:` key if absent; key order in YAML is cosmetic, so exact positioning after `browser_automation:` is not critical)
-   - Error handling: If `.ai-dev-workflow.yaml` does not exist or is malformed YAML, abort with error: "Error: cannot modify .ai-dev-workflow.yaml — file does not exist or is malformed. Please fix the file manually before retrying."
-3. Print: `Recorded last-synced template version: v{TEMPLATE_VERSION}` (only after successful write)
+2. Capture the existing `template.last_synced_version` value into `PREV_LAST_VERSION` **before** writing the new value (this is used in Step 5.4 to bound the CHANGELOG extraction to changes since the previous sync):
 
-Then print ready-to-use git instructions (do not execute them — let the user run them after reviewing the changes):
+   ```bash
+   PREV_LAST_VERSION=$(grep -E 'last_synced_version:' .ai-dev-workflow.yaml | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
+   ```
+
+3. Set (or update) `template.last_synced_version` to `v{TEMPLATE_VERSION}` under the `template:` key. If the `template:` key does not exist yet, append the section after the `browser_automation:` block.
+4. Print: `Recorded last-synced template version: v{TEMPLATE_VERSION}`
+
+### 5.2 — Create sync branch
+
+Execute:
 
 ```bash
-# 1. Create a sync branch
 git checkout -b feature/sync-template-v{TEMPLATE_VERSION}
+```
 
-# 2. Review the changes
-git diff --stat
+### 5.3 — Stage and commit
 
-# 3. Stage and commit (only after you've reviewed the changes)
-git add REVIEW.md docs/workflow/ .claude/agents/ .claude/commands/ .claude/skills/ .codex/skills/ .agents/skills/ .cursor/ \
+Stage only approved paths — avoid `git add .` so unapproved files never enter the commit:
+
+```bash
+git add REVIEW.md docs/workflow/ .claude/agents/ .claude/commands/ .claude/skills/ .codex/skills/ .agents/skills/ \
+  .cursor/commands/ .cursor/agents/ .cursor/rules/ \
   scripts/development-workflow/ scripts/README.md \
   docs/best-practices/1-general.md \
   docs/best-practices/2-version-control.md \
   docs/best-practices/3-testing.md
-# If sync-manifest.yaml was updated, stage it as well:
-git add sync-manifest.yaml
-# Stage the updated last_synced_version field:
-git add .ai-dev-workflow.yaml
-git commit -m "chore(template): sync framework updates from template v{TEMPLATE_VERSION}"
+```
 
-# 4. Push and open PR
+If `sync-manifest.yaml` was updated, stage it as well:
+
+```bash
+git add sync-manifest.yaml
+```
+
+Stage the updated `last_synced_version` field:
+
+```bash
+git add .ai-dev-workflow.yaml
+```
+
+If the user explicitly approved additional paths in Step 4 (via the manual-review, optional-additive, or rename-cleanup sections), stage them now. Track approved additional paths in an `APPROVED_ADDITIONAL_PATHS` list during Step 4 as each item is approved, then apply them here:
+
+```bash
+# Stage any additional paths approved interactively in Step 4:
+if [ -n "$APPROVED_ADDITIONAL_PATHS" ]; then
+  printf '%s\n' "$APPROVED_ADDITIONAL_PATHS" \
+    | while IFS= read -r p; do
+        [ -n "$p" ] && git add -- "$p"
+      done
+fi
+```
+
+Run:
+
+```bash
+git diff --stat --cached
+git commit -m "chore(template): sync framework updates from template v{TEMPLATE_VERSION}"
+```
+
+### 5.4 — Push and open PR
+
+Execute:
+
+```bash
 git push -u origin feature/sync-template-v{TEMPLATE_VERSION}
 ```
 
-**Suggested PR description:**
+Then immediately create the PR (do not print instructions for the user to run manually — execute this step directly).
 
-```
-## Template sync: v{TEMPLATE_VERSION}
+First, extract the relevant CHANGELOG section from the template's `CHANGELOG.md` and compose the PR body. Use `TEMPLATE_DIR` (the resolved template source path from Step 0) and `TEMPLATE_VERSION`:
 
-Sync framework-level files from [ai-dev-framework-template](TEMPLATE_URL) v{TEMPLATE_VERSION}.
+```bash
+# PREV_LAST_VERSION was captured in Step 5.1 before updating .ai-dev-workflow.yaml.
+# Use it here to bound the CHANGELOG extraction to only changes since the previous sync.
+# Extract the CHANGELOG section for changes since PREV_LAST_VERSION
+if [ -n "$PREV_LAST_VERSION" ]; then
+  CHANGELOG_SECTION=$(awk -v start="${TEMPLATE_VERSION#v}" -v stop="${PREV_LAST_VERSION#v}" '
+    $0 ~ ("^## \\[" start "\\]") { in_range=1; next }
+    in_range {
+      if ($0 ~ ("^## \\[" stop "\\]")) exit
+      print
+    }
+  ' "${TEMPLATE_DIR}/CHANGELOG.md")
+else
+  # No previous version — extract content after the TEMPLATE_VERSION header up to the next versioned section
+  CHANGELOG_SECTION=$(awk -v tv="${TEMPLATE_VERSION#v}" '
+    $0 ~ ("^## \\[" tv "\\]") { in_range=1; next }
+    in_range && $0 ~ /^## \[/ { exit }
+    in_range { print }
+  ' "${TEMPLATE_DIR}/CHANGELOG.md")
+fi
+
+# Compose the PR body
+PR_BODY="## Template sync: ${TEMPLATE_VERSION}
+
+Sync framework-level files from the upstream template ${TEMPLATE_VERSION}.
 
 ### Changes included
-[Paste the relevant section from the template's CHANGELOG.md here]
+
+${CHANGELOG_SECTION}
 
 ### What was NOT overwritten
+
 Project-specific files (AGENTS.md, README.md, CHANGELOG.md, docs/project/, etc.)
-were not overwritten; optional additive updates from the template may have been applied where you approved them, with project-specific content preserved.
+were not overwritten; optional additive updates from the template may have been applied where you approved them, with project-specific content preserved."
 ```
 
-Paste the relevant section from the template's `CHANGELOG.md` into the PR description placeholder.
+Then create the PR using `BASE_BRANCH` from Step 1:
+
+```bash
+PR_URL=$(gh pr create \
+  --title "chore(template): sync framework updates from template ${TEMPLATE_VERSION}" \
+  --body "$PR_BODY" \
+  --base "$BASE_BRANCH" \
+  --draft)
+PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq '.number')
+echo "PR created: $PR_URL (#$PR_NUMBER)"
+```
+
+The `--draft` flag opens the PR as a draft so automated reviewers do not trigger prematurely; Step 6 will convert it to non-draft after the reviewer gate clears. Store `$PR_NUMBER` and `$PR_URL` for use in Step 6.
+
+---
+
+## Step 6 — Start the reviewer loop
+
+After the PR is open, run the reviewer loop immediately — do not ask the user to start it manually.
+
+### 6.1 — Run the internal review gate (Step 7a)
+
+Follow the full Step 7a procedure defined in `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` Step 7a ("Internal reviewer gate"), using the PR opened in Step 5.4 as the target.
+
+The sync-template PR is a `feature/*` branch, so the two-pass code review procedure applies. Key focus areas for the `claude` reviewer pass on a sync PR:
+
+- No project-specific content was accidentally overwritten by the sync.
+- Always-sync files match what was approved in Step 3.
+- CHANGELOG entry (if any) is correctly formatted under `[Unreleased]`.
+- `.ai-dev-workflow.yaml` was updated with `last_synced_version`.
+
+Apply any blocking fixes, commit, and push before proceeding. Continue until all configured internal reviewers have approved (or are unavailable under the configured policy).
+
+Once the Step 7a gate passes, ensure the PR is non-draft:
+
+```bash
+gh pr ready "$PR_NUMBER"
+```
+
+### 6.2 — Run the automated reviewer loop (Step 7)
+
+Run `scripts/development-workflow/pr-review-loop.sh` against the PR:
+
+```bash
+bash scripts/development-workflow/pr-review-loop.sh "$PR_NUMBER"
+```
+
+Monitor the output. If the script reports unresolved findings, apply the required fixes, push, and re-run until the loop exits clean or escalates.
+
+### 6.3 — Apply readiness labels
+
+Once the reviewer loop exits clean:
+
+```bash
+gh pr edit "$PR_NUMBER" --add-label "ready-for-regression"
+gh pr edit "$PR_NUMBER" --add-label "ready-for-human-review"
+```
+
+Update the tracker status to `Development in Review` if an issue tracker is configured.
+
+Print a final summary:
+
+```
+Sync complete. PR #$PR_NUMBER is open and ready for human review.
+URL: $PR_URL
+```

--- a/.codex/skills/workflow-sync-template/SKILL.md
+++ b/.codex/skills/workflow-sync-template/SKILL.md
@@ -13,7 +13,10 @@ Recommended model tier: `economy`
    3a. After Step 0 (template source resolved), run Step 0.5 — the comprehensive pre-flight diagnostic. This step surfaces all foreseeable conflict categories (file-level conflicts, CI configuration issues, CHANGELOG structure issues, protocol file incompatibilities) in a single pass before any files are modified. If `--dry-run` was passed, stop after printing the diagnostic report and do not proceed to Step 1. The diagnostic report format is defined in the protocol's Step 0.5 section.
 4. Apply the same manifest-driven procedure as the Claude Code and Cursor sync-template artefacts:
    - Check for `sync-manifest.yaml` at the template root after resolving the template source.
-   - If found, use `categories.always_sync`, `categories.special_handling`, and `categories.project_specific` from the manifest.
+   - Resolve the current repository role from `.ai-dev-workflow.yaml` (`single_repo` when missing).
+   - If found, run `scripts/development-workflow/select-sync-manifest-entries.py` from the template source and use only the selected `categories.always_sync`, `categories.special_handling`, and `categories.project_specific` entries for the resolved role.
+   - Report skipped entries by `mode_scope` in dry-run and apply summaries.
+   - Reuse the same selected entry set for dry-run comparison and apply; do not rebuild the file list independently.
    - If found and `rename_detections` is present, apply the rename cleanup detection defined in the protocol's "Rename cleanup detection" section (Step 2) and display the "Rename cleanup" section in Step 3 when candidates are found.
    - If absent, fall back to the embedded file list in the protocol and display the warning message.
    - For mixed-content files (`mixed_content: true`, `annotation_scheme: html_comments`), apply the extraction logic defined in the protocol's "Mixed-content extraction logic" section.

--- a/.cursor/commands/sync-template.md
+++ b/.cursor/commands/sync-template.md
@@ -11,7 +11,7 @@ Follow this workflow exactly when invoked. Do not skip steps or reorder them.
 
 ---
 
-## Step 0 — Parse arguments and determine template source
+## Step 0 — Parse arguments, determine template source, and resolve repository role
 
 Parse the user's arguments:
 
@@ -54,6 +54,40 @@ Once the template source is resolved, read its `CHANGELOG.md` and extract the la
 
 - If found: read it and store its contents as `SYNC_MANIFEST`. The manifest is the authoritative file list (BR-1).
 - If absent: set `SYNC_MANIFEST=absent`. The graceful fallback (BR-4 / AC-4) activates in Step 2 — the embedded lists below are used and a warning is shown.
+
+**Repository role check**: Read the current project's `.ai-dev-workflow.yaml`
+top-level `mode` value. If the file or field is absent, set
+`REPOSITORY_ROLE=single_repo`. Supported roles are `single_repo`,
+`workflow_hub`, and `product_repo`; any other value is a configuration error and
+must stop the sync before file comparison.
+
+When `SYNC_MANIFEST` is loaded, build the selected manifest entry set before
+Step 0.5 using the selector helper from the resolved template source:
+
+```bash
+python3 "<template_source>/scripts/development-workflow/select-sync-manifest-entries.py" \
+  --manifest "<template_source>/sync-manifest.yaml" \
+  --role "$REPOSITORY_ROLE"
+```
+
+Store the resulting selected and skipped entries as `SYNC_SELECTED_ENTRIES` and
+`SYNC_SKIPPED_ENTRIES`. This same selected entry set must be used for dry-run
+diagnostics, file comparison, and apply steps so preview and apply cannot
+disagree.
+
+Role rules:
+
+- `single_repo`: preserve compatibility by selecting every manifest entry from
+  the existing categories.
+- `workflow_hub`: select `shared` and `hub_only`; skip
+  `product_repo_injection`.
+- `product_repo`: select `shared` and `product_repo_injection`; skip
+  `hub_only`.
+
+Unknown roles, missing `mode_scope` values, unknown `mode_scope` values, or a
+missing selector helper for a non-`single_repo` role must fail closed before any
+file changes are applied. If the manifest is absent, use fallback mode and make
+the lack of role-aware filtering explicit in the diagnostic report.
 
 **Migration notes check**: If `SYNC_MANIFEST` is loaded, read `migration_notes` from it. Read `template.last_synced_version` from the project's `.ai-dev-workflow.yaml` (if the file or field is absent, treat it as unknown — show all notes).
 
@@ -110,7 +144,7 @@ Dry-run complete. No changes were applied. Re-run without --dry-run to apply cha
 
 ### Category 1 — File-level merge conflicts (always-sync files)
 
-For each file listed in `categories.always_sync` (or the embedded fallback list when `SYNC_MANIFEST=absent`):
+For each selected file listed in `categories.always_sync` (or the embedded fallback list when `SYNC_MANIFEST=absent`):
 
 1. Enumerate all files using `find` (same method as Step 2).
 2. For files that exist in both the template and the project, run a diff:
@@ -128,7 +162,7 @@ Report all `Conflict risk` files with a one-line summary of what differs. This p
 
 Check for known CI/CD configuration mismatches between the template and the project:
 
-1. **Workflow file presence**: compare the set of `.github/workflows/` files in the template (under `categories.special_handling` if manifest is loaded, otherwise the embedded special-handling list) against the project. List any files that are in the template but absent from the project — these may be needed for full CI coverage after the sync.
+1. **Workflow file presence**: compare the selected set of `.github/workflows/` files in the template (under `categories.special_handling` if manifest is loaded, otherwise the embedded special-handling list) against the project. List any files that are in the template but absent from the project — these may be needed for full CI coverage after the sync.
 
 2. **Workflow YAML parse test** (pre-apply): for each workflow file that _would be updated_ based on the Category 1 diff, verify the _template_ version parses correctly before applying:
 
@@ -219,6 +253,8 @@ Output the report in this structure before proceeding to Step 1 (or stopping, if
 ## Pre-flight Diagnostic Report
 Template version: v{TEMPLATE_VERSION}  |  Project branch: [branch]
 Manifest: [loaded / absent — fallback mode]
+Repository role: [single_repo / workflow_hub / product_repo]
+Selected manifest entries: [N selected / M skipped by mode_scope]
 
 ### Category 1 — File-level conflicts
   No conflict:    N files (will be updated cleanly)
@@ -292,29 +328,29 @@ Run these checks **before touching anything**. If any check fails, report the pr
 
 ## Step 2 — Compare files
 
-Use `SYNC_MANIFEST` to determine the file lists. If `SYNC_MANIFEST=absent`, fall back to the embedded lists in each section below and display this warning before continuing:
+Use `SYNC_MANIFEST` and `SYNC_SELECTED_ENTRIES` to determine the file lists. If `SYNC_MANIFEST=absent`, fall back to the embedded lists in each section below and display this warning before continuing:
 
 > "Warning: sync manifest not found in upstream template. Using embedded file list — results may be incomplete."
 
 ### Always sync (apply automatically after approval)
 
-**If `SYNC_MANIFEST` is loaded**: read `categories.always_sync` from the manifest and enumerate those paths from the template. Each entry may specify a `path` (single file or directory prefix) and an optional `glob` pattern for recursive enumeration.
+**If `SYNC_MANIFEST` is loaded**: read selected `categories.always_sync` entries from `SYNC_SELECTED_ENTRIES` and enumerate those paths from the template. Each entry may specify a `path` (single file or directory prefix) and an optional `glob` pattern for recursive enumeration. Do not compare or apply entries from `SYNC_SKIPPED_ENTRIES`; list them in the summary under "Skipped by repository role".
 
 **If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
 ```
-REVIEW.md                         ← canonical review contract for spec, plan, and code review gates
-docs/workflow/                          ← full tree, all files recursively
-.claude/agents/                   ← all *.md files
-.claude/commands/                 ← all *.md files
-.claude/skills/                   ← all *.md files (including this skill itself)
-.codex/skills/                    ← Codex skill trees shipped with the template (SKILL.md and assets)
-.agents/skills/                   ← Codex repo-scoped skill discovery path and command-style aliases
-.cursor/commands/                 ← all *.md files
-.cursor/agents/                   ← all *.md files
-.cursor/rules/                    ← all *.mdc files
-scripts/development-workflow/     ← workflow helper scripts (discover state, PR/CI loops, etc.)
-scripts/README.md                 ← purpose and usage of scripts in scripts/
+REVIEW.md                         <- canonical review contract for spec, plan, and code review gates
+docs/workflow/                          <- full tree, all files recursively
+.claude/agents/                   <- all *.md files
+.claude/commands/                 <- all *.md files
+.claude/skills/                   <- all *.md files (including this skill itself)
+.codex/skills/                    <- Codex skill trees shipped with the template (SKILL.md and assets)
+.agents/skills/                   <- Codex repo-scoped skill discovery path and command-style aliases
+.cursor/commands/                 <- all *.md files
+.cursor/agents/                   <- all *.md files
+.cursor/rules/                    <- all *.mdc files
+scripts/development-workflow/     <- workflow helper scripts (discover state, PR/CI loops, etc.)
+scripts/README.md                 <- purpose and usage of scripts in scripts/
 docs/best-practices/1-general.md
 docs/best-practices/2-version-control.md
 docs/best-practices/3-testing.md
@@ -324,16 +360,17 @@ docs/best-practices/3-testing.md
 
 For each file in these paths:
 
-- **Exists in template, not in project** → classify as ✅ **Add**
-- **Exists in both, content differs** → classify as 📝 **Update** (prepare a concise diff summary)
-- **Exists in both, content identical** → classify as ⏭ **No change** (list but don't highlight)
+- **Exists in template, not in project** → classify as **Add**
+- **Exists in both, content differs** → classify as **Update** (prepare a concise diff summary)
+- **Exists in both, content identical** → classify as **No change** (list but don't highlight)
 - **Exists in project, not in template** → **ignore** (never delete project-only files)
 
 ### Rename cleanup detection
 
 **If `SYNC_MANIFEST` is loaded and contains a `rename_detections` list**: after completing the always-sync comparison above, check each entry:
 
-1. Verify that `entry.new_path` is present in `categories.always_sync`. If it is not, skip this entry.
+1. Verify that `entry.new_path` is present in selected `categories.always_sync`
+   for the resolved repository role. If it is not, skip this entry.
 2. Check whether `entry.old_path` exists as a non-empty directory in the project:
    ```bash
    [ -d "<old_path>" ] && find "<old_path>" -mindepth 1 -maxdepth 1 | wc -l
@@ -348,17 +385,17 @@ Rename cleanup candidates are displayed in Step 3 and applied in Step 4 only aft
 
 ### Special handling (show full diff, user decides per file)
 
-**If `SYNC_MANIFEST` is loaded**: read `categories.special_handling` from the manifest.
+**If `SYNC_MANIFEST` is loaded**: read selected `categories.special_handling` entries from `SYNC_SELECTED_ENTRIES`.
 
 **If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
 ```
-.claude/settings.json                          ← may have project-specific permissions
+.claude/settings.json                          <- may have project-specific permissions
 .claude/settings.local.json.example
-.github/workflows/auto-tag-release.yml         ← automated release tagging; add if CI is set up
-.github/workflows/deploy.yml                   ← placeholder deployment workflow; customize with project-specific deploy logic
-.github/workflows/e2e-regression.yml           ← label-gated e2e/regression placeholder; customize with project-specific test logic
-e2e/                                              ← placeholder e2e/regression test project (Playwright); customize with project-specific tests
+.github/workflows/auto-tag-release.yml         <- automated release tagging; add if CI is set up
+.github/workflows/deploy.yml                   <- placeholder deployment workflow; customize with project-specific deploy logic
+.github/workflows/e2e-regression.yml           <- label-gated e2e/regression placeholder; customize with project-specific test logic
+e2e/                                           <- placeholder e2e/regression test project (Playwright); customize with project-specific tests
 ```
 
 For each of these: show the full diff and ask the user explicitly whether to apply it.
@@ -369,7 +406,7 @@ These paths are project-specific and must **not** be overwritten by the template
 
 **Critical:** Do not remove or replace content that is specific to the project. Only suggest additions or merges that clearly originate from the template and do not conflict with project-only content. When in doubt, list the difference under "Optional additive update" and let the user decide.
 
-**If `SYNC_MANIFEST` is loaded**: read `categories.project_specific` from the manifest. For entries with `mixed_content: true`, also read the `annotation_scheme` field and apply the mixed-content extraction logic described below.
+**If `SYNC_MANIFEST` is loaded**: read selected `categories.project_specific` entries from `SYNC_SELECTED_ENTRIES`. For entries with `mixed_content: true`, also read the `annotation_scheme` field and apply the mixed-content extraction logic described below.
 
 **If `SYNC_MANIFEST=absent`** (fallback): use the embedded list below.
 
@@ -386,7 +423,7 @@ CLAUDE.md
 GEMINI.md
 ```
 
-For each of these: if template and project differ, show what the template has that the project might want to add; classify as ⚠️ **Optional additive update** (user decides). Do not apply changes to these paths without explicit user approval.
+For each of these: if template and project differ, show what the template has that the project might want to add; classify as **Optional additive update** (user decides). Do not apply changes to these paths without explicit user approval.
 
 Everything else not listed above (application code, project configs, etc.) is also never overwritten.
 
@@ -415,34 +452,41 @@ Show a structured summary before asking for confirmation. Include file counts pe
 ## Template Sync Summary
 Template version: v0.4.0  |  Project branch: develop
 Manifest: loaded from sync-manifest.yaml  (or: "not found — using embedded fallback list")
+Repository role: workflow_hub  (selected: N entries, skipped by mode_scope: M)
 
 ### Always-sync files: N total (A to add, U to update, C up-to-date)
 
-#### ✅ New files (will be added): A
+#### New files (will be added): A
   .claude/skills/sync-template.md
 
-#### 📝 Modified files (will be updated): U
+#### Modified files (will be updated): U
   .claude/agents/developer.md
-    Line 3: model: claude-sonnet-4-5 → model: claude-sonnet-4-6
+    Line 3: model: claude-sonnet-4-5 -> model: claude-sonnet-4-6
 
   docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
     [diff summary]
 
-#### ⏭ Already up to date (no changes): C
+#### Already up to date (no changes): C
   docs/best-practices/1-general.md
   .cursor/rules/code.mdc
   ... (N files)
 
-### ⚠️ Requires manual review (you decide)
+### Requires manual review (you decide)
   .claude/settings.json
     [full diff shown here]
 
-### ⚠️ Optional additive updates (project-specific — you decide)
-  AGENTS.md — template has [brief description]; project keeps its own content; suggest adding: …
+### Optional additive updates (project-specific — you decide)
+  AGENTS.md — template has [brief description]; project keeps its own content; suggest adding: ...
   README.md — no template additions suggested
-  …
+  ...
 
-### 🗂️ Rename cleanup (you decide)
+### Skipped by repository role
+  product_repo_injection:
+    AGENTS.md
+  hub_only:
+    docs/workflow/
+
+### Rename cleanup (you decide)
   docs/ai/ — was the previous location of always-sync content now in docs/workflow/ (renamed in v0.23.0).
   Stale directory still present. Proposed actions (each requires separate approval):
     1. Delete docs/ai/  (git rm -r docs/ai/)
@@ -466,7 +510,14 @@ Always-sync disposition:
 
 Then ask:
 
-> "Ready to apply the changes above? For the files listed under ✅ **New files** and 📝 **Modified files** in the **always-sync** section only, I can apply them in one batch when you confirm. Special-handling and optional additive-update paths always need explicit per-path approval — bulk phrases like \"apply all\" never include those categories."
+> "Ready to apply the changes above? You have two options:
+>
+> - **"apply all"** — Apply the always-sync files in one batch, then walk through each manual-review and optional-additive item inline, presenting the diff and asking you to confirm or skip before moving on.
+> - **"apply always-sync only"** — Apply only the always-sync files now; skip manual-review and optional-additive items entirely.
+>
+> Special-handling paths (`.github/workflows/deploy.yml`, `e2e-regression.yml`, `e2e/`, `.claude/settings.json`, etc.) are never included in "apply all" — those require you to name each approved path explicitly.
+>
+> Which would you like?"
 
 **Do not modify any files until you have explicit confirmation.**
 
@@ -474,9 +525,36 @@ Then ask:
 
 ## Step 4 — Apply changes (only after approval)
 
-- Copy/overwrite all ✅ (Add) and 📝 (Update) files **from the always-sync Step 3 section only** when the user confirms that batch. Phrases such as "apply all", "apply everything", or "yes to all" mean **always-sync files only** — they **never** authorize applying **special-handling** paths (`.github/workflows/deploy.yml`, `e2e-regression.yml`, `e2e/`, `.claude/settings.json`, etc.) or **optional additive updates**; those require the user to name each approved path (or `none`).
+Apply approved changes:
+
+### Always-sync files
+
+Copy/overwrite all **Add** and **Update** files from the always-sync section whenever the user confirms that batch — regardless of whether they said "apply all" or "apply always-sync only".
+
+### Manual-review and optional-additive items ("apply all" path)
+
+When the user chooses **"apply all"**, after the always-sync batch is applied, walk through **every** item in the manual-review section and every item in the optional-additive section, **one item at a time**:
+
+1. Show the item's diff (or proposed addition) inline.
+2. State a recommendation (e.g., "I recommend applying this because …" or "This is optional — your project already has equivalent content").
+3. Ask: "Apply this item? (yes / skip)"
+4. Apply immediately if the user answers "yes"; skip if "skip" (or any non-yes answer).
+5. Proceed to the next item.
+
+Continue until all manual-review and optional-additive items have been presented. This ensures "apply all" genuinely means "walk me through everything and apply what I approve."
+
+### Always-sync only path
+
+When the user chooses **"apply always-sync only"**, skip the manual-review and optional-additive walkthrough entirely. Special-handling items are also skipped unless named explicitly.
+
+### Special-handling paths
+
+Phrases such as "apply all", "apply everything", or "yes to all" **never** authorize applying **special-handling** paths (`.github/workflows/deploy.yml`, `e2e-regression.yml`, `e2e/`, `.claude/settings.json`, etc.). Those require the user to name each approved path explicitly.
+
 - **Placeholder guard for workflow YAML** (`.github/workflows/deploy.yml`, `.github/workflows/e2e-regression.yml`): Before overwriting the project copy with the template, compare line counts. If the **project** file has **more lines** than the template and the template has **fewer than 70%** of the project's line count, treat this as likely "real implementation → template placeholder" and **refuse** unless the user sends a **second** explicit confirmation naming that exact file.
-- For ⚠️ files: apply only those the user explicitly approved (including any optional additive updates to project-specific files — merge or add only, never remove project-specific content)
+
+### General rules
+
 - Do **not** delete any file from the always-sync, special-handling, or project-specific categories without explicit approval
 - Do **not** overwrite project-specific files; for those paths only additive/merge changes are allowed, and only with explicit approval
 
@@ -526,7 +604,7 @@ If any references remain, list them and ask the maintainer whether to update the
 
 **Bulk phrases do not cover rename cleanup**: "apply all", "apply everything", or "yes to all" never authorize rename cleanup actions. Each rename cleanup action (delete directory, update cross-references) requires the maintainer to name it explicitly.
 
-If the template source was a remote clone, clean it up now:
+If the template source was a remote clone, clean up the exact temp directory recorded in Step 0:
 
 ```bash
 rm -rf "$TEMPLATE_TEMP_DIR"   # use the exact path, not a wildcard
@@ -565,7 +643,7 @@ for f in .github/workflows/*.yml .github/workflows/*.yaml; do
 done
 
 if [ "$yaml_parse_failed" -ne 0 ]; then
-  echo "Blocking: one or more workflow YAML files failed validation. Fix before committing."
+  echo "ERROR: One or more workflow YAML files failed validation. Fix before committing."
   exit 1
 fi
 ```
@@ -685,16 +763,16 @@ First, extract the relevant CHANGELOG section from the template's `CHANGELOG.md`
 # Extract the CHANGELOG section for changes since PREV_LAST_VERSION
 if [ -n "$PREV_LAST_VERSION" ]; then
   CHANGELOG_SECTION=$(awk -v start="${TEMPLATE_VERSION#v}" -v stop="${PREV_LAST_VERSION#v}" '
-    $0 == "## [" start "]" { in_range=1 }
+    $0 ~ ("^## \\[" start "\\]") { in_range=1; next }
     in_range {
-      if ($0 == "## [" stop "]") exit
+      if ($0 ~ ("^## \\[" stop "\\]")) exit
       print
     }
   ' "${TEMPLATE_DIR}/CHANGELOG.md")
 else
   # No previous version — extract content after the TEMPLATE_VERSION header up to the next versioned section
   CHANGELOG_SECTION=$(awk -v tv="${TEMPLATE_VERSION#v}" '
-    $0 == "## [" tv "]" { in_range=1; next }
+    $0 ~ ("^## \\[" tv "\\]") { in_range=1; next }
     in_range && $0 ~ /^## \[/ { exit }
     in_range { print }
   ' "${TEMPLATE_DIR}/CHANGELOG.md")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Sync-template workflow-hub scopes** (#881): makes template sync role-aware so workflow hubs receive hub-owned files while product repositories receive only injection-safe files.
 - **Workflow agent product repository awareness** (#879): teaches Claude, Cursor, Codex, and command-wrapper prompts to declare repository context and route implementation work to selected product repositories in workflow hub mode.
 - **Workflow hub orchestration repository awareness** (#878): routes implementation branch, pull request, reviewer, CI, and cleanup operations to the selected product repository while keeping tracker/spec/plan state in the hub.
 - **Two-phase review config** (#868): replaces overlapping reviewer config keys with explicit draft and ready lifecycle buckets while preserving legacy aliases for one transition release.

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -453,10 +453,12 @@ Important implementation notes:
   `WORKFLOW_MODE`, `ACTION_REPOSITORY_KIND`, `ACTION_REPOSITORY`, and
   `ACTION_GITHUB_REPO` so orchestrators can distinguish hub-owned planning work
   from product-owned implementation work.
-- `sync-manifest.yaml` includes informational `mode_scope` metadata:
-  `shared`, `hub_only`, and `product_repo_injection`. Current sync-template
-  readers still use the existing manifest categories; mode-aware sync
-  application belongs to later workflow-hub work.
+- `sync-manifest.yaml` includes enforced `mode_scope` metadata: `shared`,
+  `hub_only`, and `product_repo_injection`. Sync-template resolves repository
+  mode before comparison: `single_repo` keeps the compatibility file set,
+  `workflow_hub` selects shared and hub-only entries, and `product_repo`
+  selects shared and product-repo-injection entries while reporting skipped
+  scopes.
 - `review.on_draft.runner` is consumed by the Step 7a internal review gate protocol (`91-orchestrate-work-protocol.md`). If omitted, the gate falls back to running the stage-appropriate `claude` reviewer once. Developers can override the list locally via `.tmp/template-config.json` (gitignored).
 - `review.on_draft.github` and `review.on_ready.github` are consumed by `scripts/development-workflow/pr-review-loop.sh` for external automated PR review (Step 7). If the config file is absent, or both lists are omitted or empty, automated PR review is treated as not configured and the review loop reports `skipped`.
 - Legacy `review.internal_reviewers`, `review.platforms`, and `review.phase_after_clean` keys remain accepted for one transition release and map to the new lifecycle buckets.

--- a/docs/workflow/development-workflow/repository-modes.md
+++ b/docs/workflow/development-workflow/repository-modes.md
@@ -156,6 +156,21 @@ product repository should not receive hub-owned tracker artifacts, historical
 specs, implementation plans, or cross-product coordination state unless a later
 workflow explicitly documents why that copy is required.
 
+The sync-template workflow enforces this boundary through `sync-manifest.yaml`
+`mode_scope` metadata:
+
+- `single_repo` selects all manifest entries and preserves the existing
+  compatibility file set.
+- `workflow_hub` selects `shared` and `hub_only` entries, then reports
+  `product_repo_injection` entries as skipped.
+- `product_repo` selects `shared` and `product_repo_injection` entries, then
+  reports `hub_only` entries as skipped.
+
+Unknown repository roles, missing entry `mode_scope` values, and unknown
+`mode_scope` values fail closed before file changes are applied. Dry-run and
+apply paths use the same selected manifest entry set so preview output and the
+actual apply set cannot diverge.
+
 Inspectable skeletons make this boundary visible without applying it:
 
 - `template/workflow-hub/` lists hub-owned protocols, scripts, agent wrappers,
@@ -400,7 +415,7 @@ Those behaviors belong to later workflow-hub implementation items. Until those
 items land, missing mode remains `single_repo` and existing repositories keep the
 current single-repository workflow.
 
-The `sync-manifest.yaml` `mode_scope` metadata is also informational until later
-mode-aware sync work consumes it. Current sync-template readers continue to use
-the existing manifest categories and do not filter or apply files by repository
-mode.
+The `sync-manifest.yaml` `mode_scope` metadata is consumed by sync-template
+selection. Current readers still preserve single-repository compatibility, but
+workflow hubs and product repositories receive role-specific selected and
+skipped file sets.

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -225,6 +225,36 @@ Optional live GitHub App validation is separate and must be requested with
 `--live-github-app` plus operator-supplied safe-test repository environment
 variables. Do not wire the live path into default CI.
 
+### `select-sync-manifest-entries.py`
+
+Selects `sync-manifest.yaml` entries for a repository role before sync-template
+compares or applies files.
+
+Usage:
+
+```bash
+python3 scripts/development-workflow/select-sync-manifest-entries.py \
+  --manifest sync-manifest.yaml \
+  --role workflow_hub
+```
+
+What it does:
+
+- Validates declared `mode_scope` values.
+- Selects all entries for `single_repo` compatibility.
+- Selects `shared` plus `hub_only` for `workflow_hub`.
+- Selects `shared` plus `product_repo_injection` for `product_repo`.
+- Prints selected and skipped entries with stable `KEY=value` output for tests
+  and sync-template summaries.
+- Fails closed on unknown roles, missing entry scopes, and unknown scope values
+  before any file mutation path can proceed.
+
+Run focused coverage with:
+
+```bash
+bash scripts/development-workflow/tests/test-sync-template-mode-scopes.sh
+```
+
 #### `hub-sync-product-repos.sh`
 
 Safely prepares clean product repository checkouts.

--- a/scripts/development-workflow/select-sync-manifest-entries.py
+++ b/scripts/development-workflow/select-sync-manifest-entries.py
@@ -43,33 +43,64 @@ class ManifestEntry:
 def strip_inline_comment(line: str) -> str:
     in_single = False
     in_double = False
+    triple_quote: str | None = None
     escaped = False
     result: list[str] = []
-    for char in line:
+    index = 0
+    while index < len(line):
+        char = line[index]
         if escaped:
             result.append(char)
             escaped = False
+            index += 1
+            continue
+        if triple_quote is not None:
+            if line.startswith(triple_quote, index):
+                result.append(line[index : index + 3])
+                index += 3
+                triple_quote = None
+                continue
+            result.append(char)
+            index += 1
+            continue
+        if not in_single and not in_double and line.startswith('"""', index):
+            result.append('"""')
+            index += 3
+            triple_quote = '"""'
+            continue
+        if not in_single and not in_double and line.startswith("'''", index):
+            result.append("'''")
+            index += 3
+            triple_quote = "'''"
             continue
         if char == "\\" and in_double:
             result.append(char)
             escaped = True
+            index += 1
             continue
         if char == "'" and not in_double:
             in_single = not in_single
             result.append(char)
+            index += 1
             continue
         if char == '"' and not in_single:
             in_double = not in_double
             result.append(char)
+            index += 1
             continue
         if char == "#" and not in_single and not in_double:
             break
         result.append(char)
+        index += 1
     return "".join(result).rstrip()
 
 
 def parse_scalar(value: str) -> str:
     value = value.strip()
+    if (value.startswith('"""') and value.endswith('"""')) or (
+        value.startswith("'''") and value.endswith("'''")
+    ):
+        return value[3:-3]
     if (value.startswith('"') and value.endswith('"')) or (
         value.startswith("'") and value.endswith("'")
     ):

--- a/scripts/development-workflow/select-sync-manifest-entries.py
+++ b/scripts/development-workflow/select-sync-manifest-entries.py
@@ -96,6 +96,7 @@ def parse_manifest(path: Path) -> tuple[set[str], list[ManifestEntry]]:
     current_category: str | None = None
     current: dict[str, str] | None = None
     current_line = 0
+    block_scalar_indent: int | None = None
 
     def flush_current() -> None:
         nonlocal current, current_line
@@ -135,6 +136,11 @@ def parse_manifest(path: Path) -> tuple[set[str], list[ManifestEntry]]:
             continue
         indent = len(line) - len(line.lstrip(" "))
         content = line.strip()
+
+        if block_scalar_indent is not None:
+            if indent > block_scalar_indent:
+                continue
+            block_scalar_indent = None
 
         if indent == 0:
             flush_current()
@@ -180,6 +186,8 @@ def parse_manifest(path: Path) -> tuple[set[str], list[ManifestEntry]]:
             parsed = parse_key_value(content)
             if parsed is not None:
                 key, value = parsed
+                if value in {">", "|", ">-", "|-", ">+", "|+"}:
+                    block_scalar_indent = indent
                 current[key] = value
 
     flush_current()

--- a/scripts/development-workflow/select-sync-manifest-entries.py
+++ b/scripts/development-workflow/select-sync-manifest-entries.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Select sync-manifest entries for a repository mode.
+
+The sync manifest uses a deliberately small YAML shape: top-level
+`mode_scopes`, then `categories` with list entries that include `path`,
+optional `glob`, and `mode_scope`. This parser is intentionally scoped to that
+shape so the helper can run without third-party YAML dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+VALID_ROLES = {"single_repo", "workflow_hub", "product_repo"}
+VALID_MODE_SCOPES = {"shared", "hub_only", "product_repo_injection"}
+CATEGORY_NAMES = {"always_sync", "special_handling", "project_specific"}
+ROLE_SCOPE_SELECTION = {
+    "single_repo": VALID_MODE_SCOPES,
+    "workflow_hub": {"shared", "hub_only"},
+    "product_repo": {"shared", "product_repo_injection"},
+}
+
+
+class ManifestError(Exception):
+    """Manifest selection failure with a human-readable message."""
+
+
+@dataclass(frozen=True)
+class ManifestEntry:
+    category: str
+    path: str
+    glob: str
+    mode_scope: str
+    mixed_content: str
+    annotation_scheme: str
+    line_no: int
+
+
+def strip_inline_comment(line: str) -> str:
+    in_single = False
+    in_double = False
+    escaped = False
+    result: list[str] = []
+    for char in line:
+        if escaped:
+            result.append(char)
+            escaped = False
+            continue
+        if char == "\\" and in_double:
+            result.append(char)
+            escaped = True
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+            result.append(char)
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            result.append(char)
+            continue
+        if char == "#" and not in_single and not in_double:
+            break
+        result.append(char)
+    return "".join(result).rstrip()
+
+
+def parse_scalar(value: str) -> str:
+    value = value.strip()
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    return value
+
+
+def parse_key_value(content: str) -> tuple[str, str] | None:
+    if ":" not in content:
+        return None
+    key, value = content.split(":", 1)
+    return key.strip(), parse_scalar(value.strip())
+
+
+def parse_manifest(path: Path) -> tuple[set[str], list[ManifestEntry]]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise ManifestError(f"could not read manifest {path}: {exc}") from exc
+
+    mode_scopes: set[str] = set()
+    entries: list[ManifestEntry] = []
+    section: str | None = None
+    current_category: str | None = None
+    current: dict[str, str] | None = None
+    current_line = 0
+
+    def flush_current() -> None:
+        nonlocal current, current_line
+        if current is None:
+            return
+        entry_path = current.get("path", "")
+        mode_scope = current.get("mode_scope", "")
+        if not entry_path:
+            raise ManifestError(f"line {current_line}: category entry is missing path")
+        if not mode_scope:
+            raise ManifestError(f"line {current_line}: entry {entry_path} is missing mode_scope")
+        if mode_scope not in VALID_MODE_SCOPES:
+            raise ManifestError(
+                f"line {current_line}: entry {entry_path} has unknown mode_scope '{mode_scope}'"
+            )
+        if current_category is None:
+            raise ManifestError(f"line {current_line}: entry {entry_path} has no category")
+        entries.append(
+            ManifestEntry(
+                category=current_category,
+                path=entry_path,
+                glob=current.get("glob", ""),
+                mode_scope=mode_scope,
+                mixed_content=current.get("mixed_content", ""),
+                annotation_scheme=current.get("annotation_scheme", ""),
+                line_no=current_line,
+            )
+        )
+        current = None
+        current_line = 0
+
+    for line_no, raw_line in enumerate(lines, start=1):
+        if "\t" in raw_line[: len(raw_line) - len(raw_line.lstrip(" \t"))]:
+            raise ManifestError(f"line {line_no}: tabs are not supported for indentation")
+        line = strip_inline_comment(raw_line)
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        content = line.strip()
+
+        if indent == 0:
+            flush_current()
+            current_category = None
+            if content == "mode_scopes:":
+                section = "mode_scopes"
+            elif content == "categories:":
+                section = "categories"
+            else:
+                section = None
+            continue
+
+        if section == "mode_scopes":
+            if indent == 2 and content.endswith(":"):
+                mode_scopes.add(content[:-1])
+            continue
+
+        if section != "categories":
+            continue
+
+        if indent == 2 and content.endswith(":"):
+            flush_current()
+            category = content[:-1]
+            if category not in CATEGORY_NAMES:
+                raise ManifestError(f"line {line_no}: unknown category '{category}'")
+            current_category = category
+            continue
+
+        if indent == 4 and content.startswith("- "):
+            flush_current()
+            if current_category is None:
+                raise ManifestError(f"line {line_no}: category entry appears before category name")
+            current = {}
+            current_line = line_no
+            inline = content[2:].strip()
+            parsed = parse_key_value(inline)
+            if parsed is not None:
+                key, value = parsed
+                current[key] = value
+            continue
+
+        if indent >= 6 and current is not None:
+            parsed = parse_key_value(content)
+            if parsed is not None:
+                key, value = parsed
+                current[key] = value
+
+    flush_current()
+
+    if not mode_scopes:
+        raise ManifestError("manifest is missing mode_scopes")
+    unknown_declared_scopes = mode_scopes - VALID_MODE_SCOPES
+    if unknown_declared_scopes:
+        joined = ", ".join(sorted(unknown_declared_scopes))
+        raise ManifestError(f"manifest declares unknown mode_scope values: {joined}")
+    missing_declared_scopes = VALID_MODE_SCOPES - mode_scopes
+    if missing_declared_scopes:
+        joined = ", ".join(sorted(missing_declared_scopes))
+        raise ManifestError(f"manifest is missing required mode_scope declarations: {joined}")
+    if not entries:
+        raise ManifestError("manifest has no sync category entries")
+
+    return mode_scopes, entries
+
+
+def format_record(prefix: str, entry: ManifestEntry, reason: str = "") -> str:
+    parts = [
+        prefix,
+        f"category={entry.category}",
+        f"mode_scope={entry.mode_scope}",
+        f"path={entry.path}",
+        f"glob={entry.glob}",
+        f"mixed_content={entry.mixed_content}",
+        f"annotation_scheme={entry.annotation_scheme}",
+    ]
+    if reason:
+        parts.append(f"reason={reason}")
+    return " ".join(parts)
+
+
+def run(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, help="Path to sync-manifest.yaml")
+    parser.add_argument(
+        "--role",
+        required=True,
+        choices=sorted(VALID_ROLES),
+        help="Repository role to select for",
+    )
+    args = parser.parse_args(argv)
+
+    manifest = Path(args.manifest).resolve()
+    _, entries = parse_manifest(manifest)
+    selected_scopes = ROLE_SCOPE_SELECTION[args.role]
+    selected = [entry for entry in entries if entry.mode_scope in selected_scopes]
+    skipped = [entry for entry in entries if entry.mode_scope not in selected_scopes]
+
+    print(f"ROLE={args.role}")
+    print(f"MANIFEST={manifest}")
+    print(f"SELECTED_COUNT={len(selected)}")
+    print(f"SKIPPED_COUNT={len(skipped)}")
+    for entry in selected:
+        print(format_record("SELECTED", entry))
+    for entry in skipped:
+        print(format_record("SKIPPED", entry, "scope_not_applicable"))
+    return 0
+
+
+def main() -> None:
+    try:
+        raise SystemExit(run(sys.argv[1:]))
+    except ManifestError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/development-workflow/tests/test-sync-template-mode-scopes.sh
+++ b/scripts/development-workflow/tests/test-sync-template-mode-scopes.sh
@@ -104,6 +104,8 @@ categories:
   always_sync:
     - path: REVIEW.md
       mode_scope: shared
+    - path: "docs/hash#file.md"
+      mode_scope: shared
     - path: docs/workflow/
       glob: "**/*"
       mode_scope: hub_only
@@ -120,6 +122,9 @@ categories:
   project_specific:
     - path: README.md
       mode_scope: shared
+      note: |
+        This literal block also has colon-like text that must not be parsed as
+        metadata: mode_scope: hub_only.
     - path: CLAUDE.md
       mode_scope: hub_only
     - path: AGENTS.md
@@ -139,8 +144,9 @@ echo ""
 echo "=== sync_template_scopes: single_repo compatibility ==="
 
 run_contains "single_role_reported" "ROLE=single_repo" "$single_output"
-run_contains "single_selects_all_entries" "SELECTED_COUNT=9" "$single_output"
+run_contains "single_selects_all_entries" "SELECTED_COUNT=10" "$single_output"
 run_contains "single_skips_no_entries" "SKIPPED_COUNT=0" "$single_output"
+run_contains "single_preserves_quoted_hash_path" "SELECTED category=always_sync mode_scope=shared path=docs/hash#file.md glob=" "$single_output"
 run_contains "single_keeps_hub_scope" "SELECTED category=always_sync mode_scope=hub_only path=docs/workflow/ glob=**/*" "$single_output"
 run_contains "single_keeps_product_scope" "SELECTED category=project_specific mode_scope=product_repo_injection path=AGENTS.md glob=" "$single_output"
 
@@ -148,7 +154,7 @@ echo ""
 echo "=== sync_template_scopes: workflow_hub selection ==="
 
 run_contains "hub_role_reported" "ROLE=workflow_hub" "$hub_output"
-run_contains "hub_selected_count" "SELECTED_COUNT=6" "$hub_output"
+run_contains "hub_selected_count" "SELECTED_COUNT=7" "$hub_output"
 run_contains "hub_skipped_count" "SKIPPED_COUNT=3" "$hub_output"
 run_contains "hub_selects_shared" "SELECTED category=always_sync mode_scope=shared path=REVIEW.md glob=" "$hub_output"
 run_contains "hub_selects_hub_only" "SELECTED category=always_sync mode_scope=hub_only path=docs/workflow/ glob=**/*" "$hub_output"
@@ -158,7 +164,7 @@ echo ""
 echo "=== sync_template_scopes: product_repo selection ==="
 
 run_contains "product_role_reported" "ROLE=product_repo" "$product_output"
-run_contains "product_selected_count" "SELECTED_COUNT=6" "$product_output"
+run_contains "product_selected_count" "SELECTED_COUNT=7" "$product_output"
 run_contains "product_skipped_count" "SKIPPED_COUNT=3" "$product_output"
 run_contains "product_selects_shared" "SELECTED category=always_sync mode_scope=shared path=REVIEW.md glob=" "$product_output"
 run_contains "product_selects_injection" "SELECTED category=always_sync mode_scope=product_repo_injection path=template/product-repo-injection/ glob=**/*" "$product_output"
@@ -197,6 +203,13 @@ run_fails_contains \
   "unknown_role_fails_closed" \
   "invalid choice" \
   python3 "$SELECTOR" --manifest "$fixture_manifest" --role unknown_role
+
+tab_indent_manifest="$TMP_ROOT/tab-indent.yaml"
+printf 'schema_version: 1\n\nmode_scopes:\n\tshared:\n' > "$tab_indent_manifest"
+run_fails_contains \
+  "tab_indentation_fails_closed" \
+  "tabs are not supported for indentation" \
+  python3 "$SELECTOR" --manifest "$tab_indent_manifest" --role workflow_hub
 
 echo ""
 echo "sync-template mode-scope tests complete: $PASS_COUNT passed, $FAIL_COUNT failed."

--- a/scripts/development-workflow/tests/test-sync-template-mode-scopes.sh
+++ b/scripts/development-workflow/tests/test-sync-template-mode-scopes.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# test-sync-template-mode-scopes.sh - role-aware sync-manifest selection tests.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+SELECTOR="$REPO_ROOT/scripts/development-workflow/select-sync-manifest-entries.py"
+
+TMP_ROOT="$(mktemp -d)" || {
+  echo "Failed to create temporary directory." >&2
+  exit 1
+}
+
+_harness_exit() {
+  local status=$?
+  rm -rf "$TMP_ROOT"
+  case "$status" in
+    141) exit 0 ;;
+    *)   exit "$status" ;;
+  esac
+}
+trap _harness_exit EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_equals() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_contains() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if grep -Fq -- "$expected" <<< "$actual"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected output to contain '${expected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_not_contains() {
+  local name="$1"
+  local unexpected="$2"
+  local actual="$3"
+  if grep -Fq -- "$unexpected" <<< "$actual"; then
+    echo "FAIL: $name - output unexpectedly contained '${unexpected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  else
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  fi
+}
+
+run_fails_contains() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  local output=""
+  local status=0
+
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+
+  if [ "$status" -ne 0 ] && grep -Fq -- "$expected" <<< "$output"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected failure containing '${expected}'"
+    printf 'Status: %s\nOutput:\n%s\n' "$status" "$output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+fixture_manifest="$TMP_ROOT/sync-manifest.yaml"
+cat > "$fixture_manifest" <<'YAML'
+schema_version: 1
+
+mode_scopes:
+  shared:
+    label: Shared
+  hub_only:
+    label: Hub only
+  product_repo_injection:
+    label: Product repository injection
+
+categories:
+  always_sync:
+    - path: REVIEW.md
+      mode_scope: shared
+    - path: docs/workflow/
+      glob: "**/*"
+      mode_scope: hub_only
+    - path: template/product-repo-injection/
+      glob: "**/*"
+      mode_scope: product_repo_injection
+  special_handling:
+    - path: .github/workflows/e2e-regression.yml
+      mode_scope: shared
+    - path: .claude/settings.json
+      mode_scope: hub_only
+    - path: .ai-dev-workflow.local.example.yaml
+      mode_scope: product_repo_injection
+  project_specific:
+    - path: README.md
+      mode_scope: shared
+    - path: CLAUDE.md
+      mode_scope: hub_only
+    - path: AGENTS.md
+      mixed_content: true
+      annotation_scheme: html_comments
+      mode_scope: product_repo_injection
+YAML
+
+single_output="$(python3 "$SELECTOR" --manifest "$fixture_manifest" --role single_repo)"
+hub_output="$(python3 "$SELECTOR" --manifest "$fixture_manifest" --role workflow_hub)"
+product_output="$(python3 "$SELECTOR" --manifest "$fixture_manifest" --role product_repo)"
+
+echo ""
+echo "=== sync_template_scopes: single_repo compatibility ==="
+
+run_contains "single_role_reported" "ROLE=single_repo" "$single_output"
+run_contains "single_selects_all_entries" "SELECTED_COUNT=9" "$single_output"
+run_contains "single_skips_no_entries" "SKIPPED_COUNT=0" "$single_output"
+run_contains "single_keeps_hub_scope" "SELECTED category=always_sync mode_scope=hub_only path=docs/workflow/ glob=**/*" "$single_output"
+run_contains "single_keeps_product_scope" "SELECTED category=project_specific mode_scope=product_repo_injection path=AGENTS.md glob=" "$single_output"
+
+echo ""
+echo "=== sync_template_scopes: workflow_hub selection ==="
+
+run_contains "hub_role_reported" "ROLE=workflow_hub" "$hub_output"
+run_contains "hub_selected_count" "SELECTED_COUNT=6" "$hub_output"
+run_contains "hub_skipped_count" "SKIPPED_COUNT=3" "$hub_output"
+run_contains "hub_selects_shared" "SELECTED category=always_sync mode_scope=shared path=REVIEW.md glob=" "$hub_output"
+run_contains "hub_selects_hub_only" "SELECTED category=always_sync mode_scope=hub_only path=docs/workflow/ glob=**/*" "$hub_output"
+run_contains "hub_reports_product_scope_skipped" "SKIPPED category=always_sync mode_scope=product_repo_injection path=template/product-repo-injection/ glob=**/* mixed_content= annotation_scheme= reason=scope_not_applicable" "$hub_output"
+
+echo ""
+echo "=== sync_template_scopes: product_repo selection ==="
+
+run_contains "product_role_reported" "ROLE=product_repo" "$product_output"
+run_contains "product_selected_count" "SELECTED_COUNT=6" "$product_output"
+run_contains "product_skipped_count" "SKIPPED_COUNT=3" "$product_output"
+run_contains "product_selects_shared" "SELECTED category=always_sync mode_scope=shared path=REVIEW.md glob=" "$product_output"
+run_contains "product_selects_injection" "SELECTED category=always_sync mode_scope=product_repo_injection path=template/product-repo-injection/ glob=**/*" "$product_output"
+run_contains "product_reports_hub_scope_skipped" "SKIPPED category=always_sync mode_scope=hub_only path=docs/workflow/ glob=**/* mixed_content= annotation_scheme= reason=scope_not_applicable" "$product_output"
+run_not_contains "product_does_not_select_hub_protocols" "SELECTED category=always_sync mode_scope=hub_only path=docs/workflow/" "$product_output"
+
+echo ""
+echo "=== sync_template_scopes: parser-risk edge cases ==="
+
+stable_output="$(python3 "$SELECTOR" --manifest "$fixture_manifest" --role product_repo)"
+run_equals "selection_helper_output_stable_for_dry_run_apply" "$product_output" "$stable_output"
+
+unknown_scope_manifest="$TMP_ROOT/unknown-scope.yaml"
+sed 's/mode_scope: shared/mode_scope: mystery/' "$fixture_manifest" > "$unknown_scope_manifest"
+run_fails_contains \
+  "unknown_mode_scope_fails_closed" \
+  "unknown mode_scope 'mystery'" \
+  python3 "$SELECTOR" --manifest "$unknown_scope_manifest" --role workflow_hub
+
+missing_entry_scope_manifest="$TMP_ROOT/missing-entry-scope.yaml"
+sed '/mode_scope: shared/d' "$fixture_manifest" > "$missing_entry_scope_manifest"
+run_fails_contains \
+  "missing_entry_mode_scope_fails_closed" \
+  "is missing mode_scope" \
+  python3 "$SELECTOR" --manifest "$missing_entry_scope_manifest" --role workflow_hub
+
+missing_scopes_manifest="$TMP_ROOT/missing-mode-scopes.yaml"
+sed '/mode_scopes:/,/categories:/d' "$fixture_manifest" > "$missing_scopes_manifest"
+printf 'categories:\n' | cat - "$missing_scopes_manifest" > "$TMP_ROOT/missing-mode-scopes-fixed.yaml"
+run_fails_contains \
+  "missing_mode_scopes_fails_closed" \
+  "manifest is missing mode_scopes" \
+  python3 "$SELECTOR" --manifest "$TMP_ROOT/missing-mode-scopes-fixed.yaml" --role workflow_hub
+
+run_fails_contains \
+  "unknown_role_fails_closed" \
+  "invalid choice" \
+  python3 "$SELECTOR" --manifest "$fixture_manifest" --role unknown_role
+
+echo ""
+echo "sync-template mode-scope tests complete: $PASS_COUNT passed, $FAIL_COUNT failed."
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/development-workflow/tests/test-sync-template-mode-scopes.sh
+++ b/scripts/development-workflow/tests/test-sync-template-mode-scopes.sh
@@ -199,6 +199,67 @@ run_fails_contains \
   "manifest is missing mode_scopes" \
   python3 "$SELECTOR" --manifest "$TMP_ROOT/missing-mode-scopes-fixed.yaml" --role workflow_hub
 
+partial_scopes_manifest="$TMP_ROOT/partial-mode-scopes.yaml"
+cat > "$partial_scopes_manifest" <<'YAML'
+schema_version: 1
+
+mode_scopes:
+  shared:
+    label: Shared
+
+categories:
+  always_sync:
+    - path: REVIEW.md
+      mode_scope: shared
+YAML
+run_fails_contains \
+  "partial_mode_scopes_fail_closed" \
+  "manifest is missing required mode_scope declarations" \
+  python3 "$SELECTOR" --manifest "$partial_scopes_manifest" --role workflow_hub
+
+unknown_category_manifest="$TMP_ROOT/unknown-category.yaml"
+cat > "$unknown_category_manifest" <<'YAML'
+schema_version: 1
+
+mode_scopes:
+  shared:
+    label: Shared
+  hub_only:
+    label: Hub only
+  product_repo_injection:
+    label: Product repository injection
+
+categories:
+  not_a_sync_category:
+    - path: REVIEW.md
+      mode_scope: shared
+YAML
+run_fails_contains \
+  "unknown_category_fails_closed" \
+  "unknown category 'not_a_sync_category'" \
+  python3 "$SELECTOR" --manifest "$unknown_category_manifest" --role workflow_hub
+
+entry_before_category_manifest="$TMP_ROOT/entry-before-category.yaml"
+cat > "$entry_before_category_manifest" <<'YAML'
+schema_version: 1
+
+mode_scopes:
+  shared:
+    label: Shared
+  hub_only:
+    label: Hub only
+  product_repo_injection:
+    label: Product repository injection
+
+categories:
+    - path: REVIEW.md
+      mode_scope: shared
+YAML
+run_fails_contains \
+  "entry_before_category_fails_closed" \
+  "category entry appears before category name" \
+  python3 "$SELECTOR" --manifest "$entry_before_category_manifest" --role workflow_hub
+
 run_fails_contains \
   "unknown_role_fails_closed" \
   "invalid choice" \

--- a/scripts/development-workflow/tests/test-sync-template-mode-scopes.sh
+++ b/scripts/development-workflow/tests/test-sync-template-mode-scopes.sh
@@ -126,6 +126,9 @@ categories:
       mixed_content: true
       annotation_scheme: html_comments
       mode_scope: product_repo_injection
+      note: >
+        This folded block has colon-like text that must not be parsed as entry
+        metadata: mode_scope: hub_only.
 YAML
 
 single_output="$(python3 "$SELECTOR" --manifest "$fixture_manifest" --role single_repo)"

--- a/scripts/development-workflow/tests/test-sync-template-mode-scopes.sh
+++ b/scripts/development-workflow/tests/test-sync-template-mode-scopes.sh
@@ -272,6 +272,29 @@ run_fails_contains \
   "tabs are not supported for indentation" \
   python3 "$SELECTOR" --manifest "$tab_indent_manifest" --role workflow_hub
 
+triple_quote_manifest="$TMP_ROOT/triple-quote.yaml"
+cat > "$triple_quote_manifest" <<'YAML'
+schema_version: 1
+
+mode_scopes:
+  shared:
+    label: Shared
+  hub_only:
+    label: Hub only
+  product_repo_injection:
+    label: Product repository injection
+
+categories:
+  always_sync:
+    - path: """docs/triple#hash.md"""
+      mode_scope: shared
+YAML
+triple_quote_output="$(python3 "$SELECTOR" --manifest "$triple_quote_manifest" --role single_repo)"
+run_contains \
+  "triple_quoted_hash_path_preserved" \
+  "SELECTED category=always_sync mode_scope=shared path=docs/triple#hash.md glob=" \
+  "$triple_quote_output"
+
 echo ""
 echo "sync-template mode-scope tests complete: $PASS_COUNT passed, $FAIL_COUNT failed."
 

--- a/scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh
@@ -14,6 +14,7 @@ SYNC_CMD="$REPO_ROOT/scripts/development-workflow/hub-sync-product-repos.sh"
 PR_CMD="$REPO_ROOT/scripts/development-workflow/open-product-pr.sh"
 NEXT_ACTION_CMD="$REPO_ROOT/scripts/development-workflow/workflow-next-action.sh"
 VALIDATOR="$REPO_ROOT/scripts/development-workflow/validate-workflow-hub-skeletons.py"
+SYNC_SELECTOR="$REPO_ROOT/scripts/development-workflow/select-sync-manifest-entries.py"
 
 LIVE_GITHUB_APP=false
 
@@ -393,7 +394,13 @@ run_contains "mode_scope_manifest_defines_product_injection" "product_repo_injec
 run_contains "mode_scope_has_shared_entries" "mode_scope: shared" "$(cat "$REPO_ROOT/sync-manifest.yaml")"
 run_contains "mode_scope_has_hub_entries" "mode_scope: hub_only" "$(cat "$REPO_ROOT/sync-manifest.yaml")"
 run_contains "mode_scope_has_product_entries" "mode_scope: product_repo_injection" "$(cat "$REPO_ROOT/sync-manifest.yaml")"
-echo "INFO: runtime mode-aware sync filtering remains outside this smoke harness; #883 validates classification metadata only."
+hub_sync_scope_output="$(python3 "$SYNC_SELECTOR" --manifest "$REPO_ROOT/sync-manifest.yaml" --role workflow_hub)"
+product_sync_scope_output="$(python3 "$SYNC_SELECTOR" --manifest "$REPO_ROOT/sync-manifest.yaml" --role product_repo)"
+run_contains "mode_scope_hub_selects_hub_docs" "SELECTED category=always_sync mode_scope=hub_only path=docs/workflow/ glob=**/*" "$hub_sync_scope_output"
+run_contains "mode_scope_hub_skips_product_injection" "SKIPPED category=project_specific mode_scope=product_repo_injection path=AGENTS.md glob= mixed_content=true annotation_scheme=html_comments reason=scope_not_applicable" "$hub_sync_scope_output"
+run_contains "mode_scope_product_selects_injection" "SELECTED category=project_specific mode_scope=product_repo_injection path=AGENTS.md glob=" "$product_sync_scope_output"
+run_contains "mode_scope_product_skips_hub_docs" "SKIPPED category=always_sync mode_scope=hub_only path=docs/workflow/ glob=**/* mixed_content= annotation_scheme= reason=scope_not_applicable" "$product_sync_scope_output"
+run_not_contains "mode_scope_product_does_not_select_hub_docs" "SELECTED category=always_sync mode_scope=hub_only path=docs/workflow/" "$product_sync_scope_output"
 
 echo ""
 echo "=== single_repo_regression: default compatibility ==="

--- a/sync-manifest.yaml
+++ b/sync-manifest.yaml
@@ -22,11 +22,12 @@
 #   hub_only                - File belongs only in a workflow hub repository.
 #   product_repo_injection  - File may be injected into a product repository.
 #
-# The mode_scope metadata below is informational for this schema version. Current
-# sync-template readers continue to consume categories.always_sync,
-# categories.special_handling, and categories.project_specific exactly as before.
-# Later mode-aware sync tooling may use these values to filter role-specific
-# skeletons or injection sets.
+# Sync-template uses mode_scope to filter the manifest by repository role before
+# comparing or applying files. Missing mode resolves to single_repo and keeps the
+# compatibility file set. workflow_hub selects shared and hub_only entries.
+# product_repo selects shared and product_repo_injection entries. Unknown roles,
+# missing mode_scope values, and unknown mode_scope values fail closed before
+# file changes are applied.
 #
 # Annotation schemes (used in mixed_content files):
 #   html_comments     - Markers in Markdown files:


### PR DESCRIPTION
## Summary
- adds a role-aware sync-manifest selector for `single_repo`, `workflow_hub`, and `product_repo`
- updates the canonical sync-template protocol and Codex wrappers to use one selected entry set for dry-run, compare, and apply
- adds focused mode-scope tests and extends the workflow-hub smoke fixture to prove hub/product-repo selection differences

## Acceptance Criteria
- AC1/AC2/AC5/AC8: selector reports selected and skipped entries for workflow hubs and product repositories.
- AC3: product repositories skip hub-only workflow docs/protocol paths.
- AC4: `single_repo` selects all manifest entries for compatibility.
- AC6: sync-template diagnostics compare selected entries before apply; skipped entries are not overwrite candidates.
- AC7: missing or unknown `mode_scope` values fail closed.
- AC9: tests use local fixtures only and require no private repositories or live GitHub credentials.

## Validation
- `bash scripts/development-workflow/tests/test-sync-template-mode-scopes.sh`
- `bash scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh`
- `bash scripts/development-workflow/tests/test-workflow-hub-skeletons.sh`
- `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`
- `python3 -m py_compile scripts/development-workflow/workflow-config-resolver.py scripts/development-workflow/validate-workflow-hub-skeletons.py scripts/development-workflow/select-sync-manifest-entries.py`
- `shellcheck --severity=warning scripts/development-workflow/*.sh scripts/development-workflow/tests/*.sh`
- `npx markdownlint-cli2 "docs/specs/developments/20260611200820_881-sync-template-workflow-hub-scopes/*.md" "docs/testing/workflow/881-sync-template-workflow-hub-scopes.smoke-test.md" "docs/workflow/development-workflow/README.md" "docs/workflow/development-workflow/repository-modes.md" "scripts/development-workflow/README.md" "CHANGELOG.md" ".claude/commands/sync-template.md" ".codex/skills/workflow-sync-template/SKILL.md" ".agents/skills/sync-template/SKILL.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/881-sync-template-workflow-hub-scopes.smoke-test.md CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`

Closes #881
