### PR TITLE
docs: add workflow hub setup guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Workflow hub setup and operations docs** (#882): documents workflow-hub setup, product-repo injection, cross-repo PR flow, and troubleshooting with non-secret example repositories.
 - **Workflow hub smoke fixtures** (#883): adds non-secret workflow hub and product repository fixture coverage with single-repository regression checks.
 - **Workflow hub product repository commands** (#877): adds workflow-hub status, sync, and pull-request visibility commands for product repository checkouts.
 - **Workflow hub product repository PR authentication** (#880): adds local-only GitHub App auth guidance and helpers for opening product repository pull requests without exposing secrets.

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -459,6 +459,10 @@ Important implementation notes:
   `workflow_hub` selects shared and hub-only entries, and `product_repo`
   selects shared and product-repo-injection entries while reporting skipped
   scopes.
+- Workflow-hub adopters can follow the setup and operations guides:
+  [`workflow-hub-setup.md`](workflow-hub-setup.md),
+  [`product-repo-injection.md`](product-repo-injection.md), and
+  [`cross-repo-pr-flow.md`](cross-repo-pr-flow.md).
 - `review.on_draft.runner` is consumed by the Step 7a internal review gate protocol (`91-orchestrate-work-protocol.md`). If omitted, the gate falls back to running the stage-appropriate `claude` reviewer once. Developers can override the list locally via `.tmp/template-config.json` (gitignored).
 - `review.on_draft.github` and `review.on_ready.github` are consumed by `scripts/development-workflow/pr-review-loop.sh` for external automated PR review (Step 7). If the config file is absent, or both lists are omitted or empty, automated PR review is treated as not configured and the review loop reports `skipped`.
 - Legacy `review.internal_reviewers`, `review.platforms`, and `review.phase_after_clean` keys remain accepted for one transition release and map to the new lifecycle buckets.

--- a/docs/workflow/development-workflow/cross-repo-pr-flow.md
+++ b/docs/workflow/development-workflow/cross-repo-pr-flow.md
@@ -1,0 +1,206 @@
+# Cross-Repository PR Flow
+
+Use this guide from the workflow hub checkout when a hub-managed item routes
+implementation work to a selected product repository.
+
+Related references:
+
+- [Workflow hub setup](workflow-hub-setup.md)
+- [Product repository injection](product-repo-injection.md)
+- [Repository modes](repository-modes.md)
+- [Workflow Hub GitHub App Authentication](integrations/workflow-hub-github-app.md)
+- [Batch Orchestration Protocol](protocols/90-batch-orchestrate-work-protocol.md)
+- [Work Item Orchestration Protocol](protocols/91-orchestrate-work-protocol.md)
+- [Automated Reviewer Loop Protocol](protocols/93-automated-reviewer-loop-protocol.md)
+- [Batch Merge Protocol](protocols/94-batch-merge-protocol.md)
+
+## Ownership Model
+
+| Artifact | Owner in workflow-hub product work |
+| --- | --- |
+| Tracker item | Workflow hub |
+| Spec | Workflow hub |
+| Implementation plan | Workflow hub |
+| Product implementation branch | Selected product repository |
+| Product PR | Selected product repository |
+| Product CI | Selected product repository |
+| Product reviewer loop | Selected product repository |
+| Merge cleanup tracker update | Workflow hub |
+
+Hub-only workflow improvements, such as updates to orchestration scripts or
+workflow docs, still open implementation PRs in the hub repository.
+
+## Route The Work Item
+
+Run location: hub checkout.
+
+Confirm the next action and selected product repository:
+
+```bash
+scripts/development-workflow/workflow-next-action.sh \
+  --repo faind-mobile-app \
+  --development docs/specs/developments/20260611204735_882-workflow-hub-docs
+```
+
+The output should name the workflow mode, action repository kind, action
+repository, and GitHub repository. Stop if product repository selection is
+missing or ambiguous.
+
+## Prepare The Product Checkout
+
+Run location: hub checkout.
+
+Inspect the product checkout:
+
+```bash
+scripts/development-workflow/hub-status.sh --repo faind-mobile-app
+```
+
+Fast-forward a clean checkout:
+
+```bash
+scripts/development-workflow/hub-sync-product-repos.sh --repo faind-mobile-app
+```
+
+If the checkout is dirty, resolve product-local changes in the product checkout
+before continuing.
+
+## Open Or Preview The Product PR
+
+Run location: hub checkout.
+
+Dry-run product PR creation before credentials or live writes:
+
+```bash
+scripts/development-workflow/open-product-pr.sh \
+  --repo faind-mobile-app \
+  --base main \
+  --head feature/faind-example \
+  --title "feat: add faind example" \
+  --body-file /tmp/faind-product-pr-body.md \
+  --dry-run
+```
+
+Live PR creation uses the selected product repository GitHub App credentials and
+passes the installation token only to the child `gh pr create` invocation.
+
+## Run Reviewers And CI
+
+Run location: hub checkout.
+
+Run the reviewer loop against the product repository PR:
+
+```bash
+scripts/development-workflow/pr-review-loop.sh 123 \
+  --repo example/faind-mobile-app \
+  --branch feature/faind-example
+```
+
+Run the CI loop against the product repository PR:
+
+```bash
+scripts/development-workflow/pr-ci-loop.sh 123 \
+  --repo example/faind-mobile-app
+```
+
+Do not apply readiness labels until reviewer loop and CI are clean or only
+acceptable advisory findings remain.
+
+## Merge And Cleanup
+
+Run location: hub checkout.
+
+Use the repository merge protocol for the PR owner. For product PRs, the target
+repository is the selected product repository. After merge, run cleanup from
+the hub so tracker state remains hub-owned:
+
+```bash
+scripts/development-workflow/post-merge-cleanup.sh \
+  --repo faind-mobile-app \
+  feature/faind-example
+```
+
+Verify:
+
+- Product PR state is `MERGED`.
+- Product branch cleanup completed.
+- Hub tracker status moved to `Merged` when the implementation closes the item.
+- The hub checkout returns to the integration branch for the topic.
+
+## Troubleshooting
+
+### Failed CI
+
+Symptom: `pr-ci-loop.sh` reports `RESULT=red`.
+
+Confirm from the hub checkout:
+
+```bash
+scripts/development-workflow/pr-ci-loop.sh 123 --repo example/faind-mobile-app
+```
+
+Safe repair:
+
+- Inspect the failing product repository check logs.
+- Fix the product branch in the selected product checkout.
+- Push the fix and rerun reviewer loop and CI.
+
+### Reviewer-Loop Failures
+
+Symptom: `pr-review-loop.sh` reports `needs_fixes`, `escalate`, or
+`reviewer-failed`.
+
+Confirm from the hub checkout:
+
+```bash
+scripts/development-workflow/pr-review-loop.sh 123 \
+  --repo example/faind-mobile-app \
+  --branch feature/faind-example
+```
+
+Safe repair:
+
+- Address blocking findings in the selected product checkout.
+- Treat low-value advisory findings as acceptable only when they do not
+  materially improve correctness, security, maintainability, or test coverage.
+- Rerun reviewer loop before applying readiness labels.
+
+### Missing Product Checkout
+
+Symptom: routing or cleanup cannot resolve `faind-mobile-app`.
+
+Confirm from the hub checkout:
+
+```bash
+scripts/development-workflow/hub-status.sh --repo faind-mobile-app
+```
+
+Safe repair:
+
+- Add or correct the local checkout path in `.ai-dev-workflow.local.yaml`.
+- Re-run status and sync before mutating product files.
+
+### Dirty Product Repo
+
+Symptom: sync or cleanup refuses to operate on the product checkout.
+
+Safe repair:
+
+- Inspect product-local changes directly.
+- Commit, stash, or intentionally remove those changes using the product
+  repository's normal workflow.
+- Re-run `hub-status.sh --repo faind-mobile-app`.
+
+### Missing App Credentials
+
+Symptom: `open-product-pr.sh` reports missing app metadata or private key
+access.
+
+Safe repair:
+
+- Verify non-secret App ID and installation ID in `.ai-dev-workflow.yaml`.
+- Verify local credential references in `.ai-dev-workflow.local.yaml`.
+- Use `github-app-token.sh --repo faind-mobile-app --dry-run` before live PR
+  creation.
+- Stop if the credential source is unavailable; do not use unrelated ambient
+  credentials.

--- a/docs/workflow/development-workflow/product-repo-injection.md
+++ b/docs/workflow/development-workflow/product-repo-injection.md
@@ -1,0 +1,129 @@
+# Product Repository Injection
+
+Use this guide from a product repository checkout when the repository should
+receive the minimal workflow integration surface for hub-routed work.
+
+Related references:
+
+- [Repository modes](repository-modes.md)
+- [Workflow hub setup](workflow-hub-setup.md)
+- [Sync-template command](../../../.claude/commands/sync-template.md)
+- [Sync manifest](../../../sync-manifest.yaml)
+- [Product repository injection skeleton](../../../template/product-repo-injection/README.md)
+
+## Product Repo Mode
+
+Run location: product repository checkout.
+
+The versioned `.ai-dev-workflow.yaml` identifies the product repository and its
+hub. Keep it free of machine-local paths and secret material.
+
+```yaml
+schema_version: 2
+mode: product_repo
+
+product_repo:
+  workflow_hub:
+    github_repo: example/faind-workflow-hub
+```
+
+Local checkout paths and credential references belong in the hub operator's
+`.ai-dev-workflow.local.yaml`, not in product repository versioned config.
+
+## Role-Aware Sync Selection
+
+Run location: product repository checkout.
+
+When sync-template reads `sync-manifest.yaml`, product repositories select:
+
+- `shared`
+- `product_repo_injection`
+
+Product repositories skip:
+
+- `hub_only`
+
+Preview the manifest selection before applying a template sync:
+
+```bash
+python3 scripts/development-workflow/select-sync-manifest-entries.py \
+  --manifest sync-manifest.yaml \
+  --role product_repo
+```
+
+Then run sync-template in dry-run mode:
+
+```text
+/sync-template --local=../ai-dev-framework-template --dry-run
+```
+
+The dry-run summary should show selected and skipped entries before any file is
+applied.
+
+## What Product Repos Must Not Receive
+
+Product repositories must not receive hub-owned workflow state unless a future
+workflow contract explicitly marks a specific file as product-repo injection:
+
+- Hub tracker state.
+- Historical specs.
+- Implementation plans.
+- Workflow protocols.
+- Hub orchestration scripts.
+- Hub-only runbooks.
+
+Product repositories may receive shared docs, local integration wrappers, config
+schema comments, and injection-safe files declared with
+`product_repo_injection`.
+
+## Apply Injection Safely
+
+Run location: product repository checkout.
+
+1. Confirm the product repository is on the intended base branch.
+2. Run sync-template dry-run and inspect selected/skipped scopes.
+3. Apply approved changes only after reviewing divergent local files.
+4. Commit the injected files through the product repository's normal PR flow.
+5. Keep `.ai-dev-workflow.local.yaml` and any credential material untracked.
+
+## Troubleshooting
+
+### Unexpected Hub Files In Product Repo Output
+
+Symptom: dry-run output includes `docs/workflow/development-workflow/protocols/`
+or `scripts/development-workflow/` as selected entries.
+
+Confirm from the product repository checkout:
+
+```bash
+python3 scripts/development-workflow/select-sync-manifest-entries.py \
+  --manifest sync-manifest.yaml \
+  --role product_repo
+```
+
+Safe repair:
+
+- Verify the repository declares `mode: product_repo`.
+- Verify the manifest entry is not incorrectly marked
+  `product_repo_injection`.
+- Stop before applying if hub-owned files are selected unexpectedly.
+
+### Divergent Local Files
+
+Symptom: sync-template dry-run reports local differences for selected files.
+
+Safe repair:
+
+- Review the diff before applying.
+- Preserve product-specific content.
+- Apply only the template-owned sections for mixed-content files.
+
+### Missing Local Config
+
+Symptom: validation cannot resolve the hub or local product checkout.
+
+Safe repair:
+
+- Keep product identity in `.ai-dev-workflow.yaml`.
+- Put machine-local paths only in `.ai-dev-workflow.local.yaml` in the hub
+  operator environment.

--- a/docs/workflow/development-workflow/repository-modes.md
+++ b/docs/workflow/development-workflow/repository-modes.md
@@ -209,6 +209,14 @@ product repository and follows the same split. A hub-only workflow improvement,
 such as updating orchestration protocols, has no product target and opens its
 code PR in `workflow-hub`.
 
+## Adoption Guides
+
+Use these guides when moving from the operating model to a concrete setup:
+
+- [Workflow Hub Setup](workflow-hub-setup.md)
+- [Product Repository Injection](product-repo-injection.md)
+- [Cross-Repository PR Flow](cross-repo-pr-flow.md)
+
 ## Shared And Local Workflow Configuration
 
 Repository mode configuration is split across one versioned shared file and one

--- a/docs/workflow/development-workflow/workflow-hub-setup.md
+++ b/docs/workflow/development-workflow/workflow-hub-setup.md
@@ -169,3 +169,35 @@ Safe repair:
 
 Do not fall back to an unrelated user token when GitHub App configuration is
 missing.
+
+### Failed CI
+
+Symptom: product PR validation reports a failing CI result.
+
+Start from the hub checkout and follow the recovery path in
+[Cross-Repository PR Flow](cross-repo-pr-flow.md#failed-ci). The first check is:
+
+```bash
+scripts/development-workflow/pr-ci-loop.sh 123 --repo example/faind-mobile-app
+```
+
+Fix the selected product branch in the product checkout, push the repair, and
+rerun reviewer and CI loops before applying readiness labels.
+
+### Reviewer-Loop Failures
+
+Symptom: product PR review reports `needs_fixes`, `escalate`, or a reviewer
+failure label.
+
+Start from the hub checkout and follow the recovery path in
+[Cross-Repository PR Flow](cross-repo-pr-flow.md#reviewer-loop-failures). The
+first check is:
+
+```bash
+scripts/development-workflow/pr-review-loop.sh 123 \
+  --repo example/faind-mobile-app \
+  --branch feature/faind-example
+```
+
+Fix blocking findings in the selected product checkout and rerun the reviewer
+loop before applying readiness labels.

--- a/docs/workflow/development-workflow/workflow-hub-setup.md
+++ b/docs/workflow/development-workflow/workflow-hub-setup.md
@@ -1,0 +1,171 @@
+# Workflow Hub Setup
+
+Use this guide from the workflow hub checkout when a repository will coordinate
+workflow items for one or more product repositories.
+
+Related references:
+
+- [Repository modes](repository-modes.md)
+- [Workflow Hub GitHub App Authentication](integrations/workflow-hub-github-app.md)
+- [Orchestrate Work Protocol](protocols/90-batch-orchestrate-work-protocol.md)
+- [Work Item Orchestration Protocol](protocols/91-orchestrate-work-protocol.md)
+
+## Example Topology
+
+This guide uses a non-secret Faind-like example:
+
+| Role | Local name | GitHub repository |
+| --- | --- | --- |
+| Workflow hub | `faind-workflow-hub` | `example/faind-workflow-hub` |
+| Mobile product | `faind-mobile-app` | `example/faind-mobile-app` |
+| Admin product | `faind-admin-portal` | `example/faind-admin-portal` |
+
+All IDs, paths, and secret references below are placeholders.
+
+## Versioned Hub Config
+
+Run location: hub checkout.
+
+Create or update `.ai-dev-workflow.yaml` with repository-safe identity and
+non-secret product repository metadata:
+
+```yaml
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: faind-mobile-app
+      github_repo: example/faind-mobile-app
+      default_branch: main
+      github_app:
+        app_id: "12345"
+        installation_id: "999999"
+    - name: faind-admin-portal
+      github_repo: example/faind-admin-portal
+      default_branch: develop
+      github_app:
+        app_id: "12345"
+        installation_id: "888888"
+```
+
+Keep this file free of local paths, private key paths, token values, and secret
+material.
+
+## Local Hub Config
+
+Run location: hub checkout.
+
+Create `.ai-dev-workflow.local.yaml` for machine-local checkout paths and
+credential references. This file is gitignored.
+
+```yaml
+product_repos:
+  - name: faind-mobile-app
+    local_path: ../repos/faind-mobile-app
+    github_app:
+      secret_ref: example-secret-ref-faind-mobile-app-github-app
+  - name: faind-admin-portal
+    local_path: ../repos/faind-admin-portal
+    github_app:
+      secret_ref: example-secret-ref-faind-admin-portal-github-app
+```
+
+Use a real secret manager only in your local environment. Do not commit secret
+manager account names, private key paths, private keys, tokens, or generated
+installation tokens.
+
+## Validate Setup
+
+Run location: hub checkout.
+
+Validate shared and local config:
+
+```bash
+scripts/development-workflow/validate-workflow-config.sh
+scripts/development-workflow/validate-workflow-config.sh --repo faind-mobile-app --require-local
+scripts/development-workflow/validate-workflow-config.sh --repo faind-admin-portal --require-local
+```
+
+Inspect product checkouts without modifying them:
+
+```bash
+scripts/development-workflow/hub-status.sh --all
+scripts/development-workflow/hub-status.sh --repo faind-mobile-app
+```
+
+Prepare clean product checkouts with fast-forward-only behavior:
+
+```bash
+scripts/development-workflow/hub-sync-product-repos.sh --all
+scripts/development-workflow/hub-sync-product-repos.sh --repo faind-mobile-app
+```
+
+Run the non-secret workflow-hub smoke fixture:
+
+```bash
+bash scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh
+```
+
+## Troubleshooting
+
+### Missing Product Checkout
+
+Symptom: `hub-status.sh` reports `missing_path` or `missing_checkout`.
+
+Confirm from the hub checkout:
+
+```bash
+scripts/development-workflow/hub-status.sh --repo faind-mobile-app
+scripts/development-workflow/validate-workflow-config.sh --repo faind-mobile-app --require-local
+```
+
+Safe repair:
+
+- Add the product checkout path to `.ai-dev-workflow.local.yaml`.
+- Create or clone the product checkout outside the hub repository.
+- Re-run validation before starting implementation work.
+
+Escalate when the intended product repository or local checkout location is
+ambiguous.
+
+### Dirty Product Repo
+
+Symptom: `hub-status.sh` reports `dirty`, or `hub-sync-product-repos.sh` blocks
+before fetching.
+
+Confirm from the hub checkout:
+
+```bash
+scripts/development-workflow/hub-status.sh --repo faind-mobile-app
+```
+
+Safe repair:
+
+- Inspect the product checkout directly.
+- Commit, stash, or otherwise resolve the product-local changes intentionally.
+- Re-run `hub-sync-product-repos.sh --repo faind-mobile-app`.
+
+Do not use destructive reset commands or force-update product branches to make
+the workflow proceed.
+
+### Missing App Credentials
+
+Symptom: product PR creation reports `missing_app_id`, `missing_private_key`, or
+`missing_installation`.
+
+Confirm from the hub checkout:
+
+```bash
+scripts/development-workflow/github-app-token.sh --repo faind-mobile-app --status
+scripts/development-workflow/github-app-token.sh --repo faind-mobile-app --dry-run
+```
+
+Safe repair:
+
+- Put non-secret App ID and installation ID in `.ai-dev-workflow.yaml`.
+- Put only local credential references in `.ai-dev-workflow.local.yaml`.
+- Re-run dry-run checks before live PR creation.
+
+Do not fall back to an unrelated user token when GitHub App configuration is
+missing.

--- a/scripts/development-workflow/tests/test-workflow-hub-docs.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-docs.sh
@@ -56,11 +56,15 @@ run_not_contains_any() {
   status=$?
   set -e
 
-  if [ "$status" -eq 1 ]; then
+  if [ "$status" -eq 0 ]; then
+    echo "FAIL: $name - unexpected match for pattern '$pattern'"
+    printf '%s\n' "$output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  elif [ "$status" -eq 1 ]; then
     echo "PASS: $name"
     PASS_COUNT=$((PASS_COUNT + 1))
   else
-    echo "FAIL: $name - unexpected match for pattern '$pattern'"
+    echo "FAIL: $name - grep failed with status $status"
     printf '%s\n' "$output"
     FAIL_COUNT=$((FAIL_COUNT + 1))
   fi

--- a/scripts/development-workflow/tests/test-workflow-hub-docs.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-docs.sh
@@ -4,7 +4,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
-REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)" || {
+  echo "Error: could not resolve repository root." >&2
+  exit 1
+}
 
 SETUP_DOC="$REPO_ROOT/docs/workflow/development-workflow/workflow-hub-setup.md"
 INJECTION_DOC="$REPO_ROOT/docs/workflow/development-workflow/product-repo-injection.md"

--- a/scripts/development-workflow/tests/test-workflow-hub-docs.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-docs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# test-workflow-hub-docs.sh - smoke checks for workflow-hub adoption docs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+SETUP_DOC="$REPO_ROOT/docs/workflow/development-workflow/workflow-hub-setup.md"
+INJECTION_DOC="$REPO_ROOT/docs/workflow/development-workflow/product-repo-injection.md"
+FLOW_DOC="$REPO_ROOT/docs/workflow/development-workflow/cross-repo-pr-flow.md"
+README_DOC="$REPO_ROOT/docs/workflow/development-workflow/README.md"
+MODES_DOC="$REPO_ROOT/docs/workflow/development-workflow/repository-modes.md"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_equals() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_contains() {
+  local name="$1"
+  local expected="$2"
+  local file="$3"
+  if grep -Fq -- "$expected" "$file"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '$file' to contain '${expected}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_not_contains_any() {
+  local name="$1"
+  local pattern="$2"
+  shift 2
+  local output=""
+  local status=0
+
+  set +e
+  output="$(grep -RInE "$pattern" "$@" 2>&1)"
+  status=$?
+  set -e
+
+  if [ "$status" -eq 1 ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - unexpected match for pattern '$pattern'"
+    printf '%s\n' "$output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+echo ""
+echo "=== workflow_hub_docs: required files ==="
+
+run_equals "setup_doc_exists" "yes" "$([ -f "$SETUP_DOC" ] && echo yes || echo no)"
+run_equals "injection_doc_exists" "yes" "$([ -f "$INJECTION_DOC" ] && echo yes || echo no)"
+run_equals "flow_doc_exists" "yes" "$([ -f "$FLOW_DOC" ] && echo yes || echo no)"
+
+echo ""
+echo "=== workflow_hub_docs: setup guide ==="
+
+run_contains "setup_has_versioned_config" ".ai-dev-workflow.yaml" "$SETUP_DOC"
+run_contains "setup_has_local_config" ".ai-dev-workflow.local.yaml" "$SETUP_DOC"
+run_contains "setup_has_validate_command" "validate-workflow-config.sh" "$SETUP_DOC"
+run_contains "setup_has_status_command" "hub-status.sh --all" "$SETUP_DOC"
+run_contains "setup_has_sync_command" "hub-sync-product-repos.sh --all" "$SETUP_DOC"
+run_contains "setup_has_smoke_fixture" "test-workflow-hub-smoke-fixtures.sh" "$SETUP_DOC"
+run_contains "setup_has_run_location" "Run location: hub checkout." "$SETUP_DOC"
+run_contains "setup_links_auth_guide" "integrations/workflow-hub-github-app.md" "$SETUP_DOC"
+
+echo ""
+echo "=== workflow_hub_docs: product injection guide ==="
+
+run_contains "injection_has_product_mode" "mode: product_repo" "$INJECTION_DOC"
+run_contains "injection_has_selector_command" "select-sync-manifest-entries.py" "$INJECTION_DOC"
+run_contains "injection_has_dry_run" "/sync-template --local=../ai-dev-framework-template --dry-run" "$INJECTION_DOC"
+run_contains "injection_selects_shared" "shared" "$INJECTION_DOC"
+run_contains "injection_selects_product_scope" "product_repo_injection" "$INJECTION_DOC"
+run_contains "injection_skips_hub_only" "hub_only" "$INJECTION_DOC"
+run_contains "injection_excludes_protocols" "Workflow protocols." "$INJECTION_DOC"
+
+echo ""
+echo "=== workflow_hub_docs: cross-repo PR flow ==="
+
+run_contains "flow_has_next_action" "workflow-next-action.sh" "$FLOW_DOC"
+run_contains "flow_has_open_product_pr" "open-product-pr.sh" "$FLOW_DOC"
+run_contains "flow_has_reviewer_loop" "pr-review-loop.sh" "$FLOW_DOC"
+run_contains "flow_has_ci_loop" "pr-ci-loop.sh" "$FLOW_DOC"
+run_contains "flow_has_cleanup" "post-merge-cleanup.sh" "$FLOW_DOC"
+run_contains "flow_has_ready_labels" "readiness labels" "$FLOW_DOC"
+run_contains "flow_links_protocol_90" "90-batch-orchestrate-work-protocol.md" "$FLOW_DOC"
+run_contains "flow_links_protocol_91" "91-orchestrate-work-protocol.md" "$FLOW_DOC"
+run_contains "flow_links_protocol_93" "93-automated-reviewer-loop-protocol.md" "$FLOW_DOC"
+run_contains "flow_links_protocol_94" "94-batch-merge-protocol.md" "$FLOW_DOC"
+
+echo ""
+echo "=== workflow_hub_docs: troubleshooting and examples ==="
+
+combined_docs=("$SETUP_DOC" "$INJECTION_DOC" "$FLOW_DOC")
+run_contains "example_hub_present" "faind-workflow-hub" "$SETUP_DOC"
+run_contains "example_mobile_present" "faind-mobile-app" "$SETUP_DOC"
+run_contains "example_admin_present" "faind-admin-portal" "$SETUP_DOC"
+run_contains "troubleshoot_missing_checkout" "Missing Product Checkout" "$FLOW_DOC"
+run_contains "troubleshoot_dirty_repo" "Dirty Product Repo" "$FLOW_DOC"
+run_contains "troubleshoot_missing_credentials" "Missing App Credentials" "$FLOW_DOC"
+run_contains "troubleshoot_failed_ci" "Failed CI" "$FLOW_DOC"
+run_contains "troubleshoot_reviewer_loop" "Reviewer-Loop Failures" "$FLOW_DOC"
+run_contains "readme_links_setup" "workflow-hub-setup.md" "$README_DOC"
+run_contains "readme_links_injection" "product-repo-injection.md" "$README_DOC"
+run_contains "readme_links_flow" "cross-repo-pr-flow.md" "$README_DOC"
+run_contains "modes_links_setup" "workflow-hub-setup.md" "$MODES_DOC"
+
+run_not_contains_any \
+  "docs_avoid_unsafe_commands" \
+  'git reset --hard|push --force|--force-with-lease|ambient token fallback|unrelated ambient token' \
+  "${combined_docs[@]}"
+
+run_not_contains_any \
+  "docs_avoid_private_details" \
+  'Leasity|RADAR|kids-safety|baumsystem|lhpaul/|op://|BEGIN .*PRIVATE KEY|ghp_|github_pat_|token=' \
+  "${combined_docs[@]}"
+
+echo ""
+echo "workflow-hub docs smoke tests complete: $PASS_COUNT passed, $FAIL_COUNT failed."
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- adds workflow-hub setup, product-repo injection, and cross-repository PR flow guides
- links the guides from the development workflow README and repository modes doc
- adds a focused workflow-hub docs smoke test for required commands, links, troubleshooting, placeholders, and unsafe/private-detail absence

## Acceptance Criteria
- AC1/AC2: setup guide includes concrete commands, run locations, and versioned vs local-only config.
- AC3: product-repo injection guide documents role-aware sync-template selection.
- AC4/AC5: cross-repo PR flow covers routing, reviewer loop, CI, readiness, merge, cleanup, and ownership boundaries.
- AC6: troubleshooting covers missing checkout, dirty repo, missing app credentials, failed CI, and reviewer-loop failures.
- AC7/AC10: guides link to protocols/integrations and are discoverable from existing docs.
- AC8/AC9: examples use non-secret Faind-like placeholders and smoke tests reject unsafe/private-detail patterns.

## Validation
- `bash scripts/development-workflow/tests/test-workflow-hub-docs.sh`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/*.md" "docs/workflow/development-workflow/integrations/*.md" "docs/specs/developments/20260611204735_882-workflow-hub-docs/*.md" "docs/testing/workflow/882-workflow-hub-docs.smoke-test.md" "CHANGELOG.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py docs/testing/workflow/882-workflow-hub-docs.smoke-test.md CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `shellcheck --severity=warning scripts/development-workflow/tests/test-workflow-hub-docs.sh`
- `git diff --check`

Closes #882
