### PR TITLE
fix: make cleanup use merged PR base

### DIFF
--- a/.claude/commands/batch-merge.md
+++ b/.claude/commands/batch-merge.md
@@ -1,6 +1,6 @@
 ---
 description: >
-  Merge all ready PRs in a parallel batch into develop sequentially, auto-resolving trivial
+  Merge all ready PRs in a parallel batch into the target base branch sequentially, auto-resolving trivial
   CHANGELOG and documentation conflicts, pausing for human input only on non-trivial conflicts,
   and running post-merge-cleanup for each successfully merged PR. Prints the merge plan for
   visibility but proceeds immediately without requiring confirmation.
@@ -11,7 +11,7 @@ allowed-tools: Bash(./scripts/development-workflow/batch-merge.sh:*), Bash(./scr
 
 Follow `docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md` exactly.
 
-**Auto-discovery** (no arguments): discovers all PRs labeled `ready-for-human-review` targeting `develop`.
+**Auto-discovery** (no arguments): discovers all PRs labeled `ready-for-human-review` targeting the configured base branch.
 
 **Explicit PR list**: pass PR numbers as arguments, e.g. `/batch-merge #101 #102 #103` or `/batch-merge --prs 101,102,103`. The command proceeds to per-PR readiness checks regardless of label status.
 
@@ -20,6 +20,6 @@ Key rules:
 - Print the merge plan (Step 3 of the protocol) for visibility, then proceed immediately without waiting for user confirmation.
 - For each PR, run `./scripts/development-workflow/batch-merge.sh merge --pr <number>`.
 - Auto-resolve CHANGELOG conflicts and documentation file conflicts where changes are non-overlapping (different line ranges); pause and escalate all other conflicts.
-- After each successful merge: push `develop`, verify GitHub shows the PR as `MERGED`, delete the remote branch, run `./scripts/development-workflow/post-merge-cleanup.sh <branch>`.
-- Never leave `develop` in a conflicted state.
+- After each successful merge: push the target base branch, verify GitHub shows the PR as `MERGED`, delete the remote branch, run `./scripts/development-workflow/post-merge-cleanup.sh --base <target-base> <branch>`.
+- Never leave the target base branch in a conflicted state.
 - Always print the final summary table (Step 5) regardless of outcome.

--- a/.claude/commands/post-merge-cleanup.md
+++ b/.claude/commands/post-merge-cleanup.md
@@ -1,8 +1,8 @@
 ---
 description: >
   After a development PR is merged and the remote branch deleted, sync with origin,
-  switch to develop, pull, delete the local branch, and update the related issue in the issue tracker.
-  Usage: /post-merge-cleanup [branch-name]
+  switch to the merged PR's base branch, pull, delete the local branch, and update the related issue in the issue tracker.
+  Usage: /post-merge-cleanup [--base base-branch] [branch-name]
 allowed-tools: Bash(./scripts/development-workflow/post-merge-cleanup.sh:*), Bash(git branch:*), Bash(gh issue:*), Bash(gh api:*), Bash(gh project:*), mcp__claude_ai_Linear__get_issue, mcp__claude_ai_Linear__save_issue, mcp__claude_ai_Linear__list_issue_statuses
 # If using a different issue tracker, add its MCP tool names here (e.g. mcp__jira__update_issue).
 ---
@@ -11,12 +11,13 @@ Run the post-merge cleanup script from the repository root.
 
 - **From repo root**, run:
   ```bash
-  ./scripts/development-workflow/post-merge-cleanup.sh [branch-name]
+  ./scripts/development-workflow/post-merge-cleanup.sh [--base base-branch] [branch-name]
   ```
 - **No argument**: use the current branch (user should run while still on the merged branch).
 - **With `branch-name`**: delete that local branch (e.g. `feature/my-feature`).
+- **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and falls back to `develop` only if that lookup is unavailable.
 
-The script will: fetch origin, checkout `develop`, pull, delete the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote), and for implementation branches (`fix/*`, `feature/*`, `hotfix/*`, `refactor/*`) automatically close the associated GitHub issue if a merged PR is found for the branch. If the user is not in the repo root, `cd` to the repo root first (e.g. use the workspace root or ask which directory is the repo).
+The script will: fetch origin, checkout the merged PR's base branch, pull, delete the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote), and for implementation branches (`fix/*`, `feature/*`, `hotfix/*`, `refactor/*`) automatically close the associated GitHub issue if a merged PR is found for the branch. If the user is not in the repo root, `cd` to the repo root first (e.g. use the workspace root or ask which directory is the repo).
 
 Do not skip steps or change the order. If the script fails, show the error and stop.
 

--- a/.claude/commands/post-merge-cleanup.md
+++ b/.claude/commands/post-merge-cleanup.md
@@ -15,7 +15,7 @@ Run the post-merge cleanup script from the repository root.
   ```
 - **No argument**: use the current branch (user should run while still on the merged branch).
 - **With `branch-name`**: delete that local branch (e.g. `feature/my-feature`).
-- **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and falls back to `develop` only if that lookup is unavailable.
+- **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and fails closed if that lookup is unavailable.
 
 The script will: fetch origin, checkout the merged PR's base branch, pull, delete the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote), and for implementation branches (`fix/*`, `feature/*`, `hotfix/*`, `refactor/*`) automatically close the associated GitHub issue if a merged PR is found for the branch. If the user is not in the repo root, `cd` to the repo root first (e.g. use the workspace root or ask which directory is the repo).
 

--- a/.claude/skills/post-merge-cleanup.md
+++ b/.claude/skills/post-merge-cleanup.md
@@ -14,7 +14,7 @@ Run the post-merge cleanup script from the repository root.
   ```
 - **No argument**: use the current branch (user should run while still on the merged branch).
 - **With `branch-name`**: delete that local branch (e.g. `feature/my-feature`).
-- **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and falls back to `develop` only if that lookup is unavailable.
+- **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and fails closed if that lookup is unavailable.
 
 The script will: fetch origin, checkout the merged PR's base branch, pull, then delete the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote). If the user is not in the repo root, change to the repo root first.
 

--- a/.claude/skills/post-merge-cleanup.md
+++ b/.claude/skills/post-merge-cleanup.md
@@ -2,20 +2,21 @@
 name: post-merge-cleanup
 description: >
   After a development PR is merged and the remote branch deleted, sync with origin,
-  switch to develop, pull, delete the local branch, and update the related issue in the issue tracker.
-  Usage: /post-merge-cleanup [branch-name]
+  switch to the merged PR's base branch, pull, delete the local branch, and update the related issue in the issue tracker.
+  Usage: /post-merge-cleanup [--base base-branch] [branch-name]
 ---
 
 Run the post-merge cleanup script from the repository root.
 
 - **From repo root**, run:
   ```bash
-  ./scripts/development-workflow/post-merge-cleanup.sh [branch-name]
+  ./scripts/development-workflow/post-merge-cleanup.sh [--base base-branch] [branch-name]
   ```
 - **No argument**: use the current branch (user should run while still on the merged branch).
 - **With `branch-name`**: delete that local branch (e.g. `feature/my-feature`).
+- **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and falls back to `develop` only if that lookup is unavailable.
 
-The script will: fetch origin, checkout `develop`, pull, then delete the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote). If the user is not in the repo root, change to the repo root first.
+The script will: fetch origin, checkout the merged PR's base branch, pull, then delete the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote). If the user is not in the repo root, change to the repo root first.
 
 Do not skip steps or change the order. If the script fails, show the error and stop.
 

--- a/.codex/skills/batch-merge/SKILL.md
+++ b/.codex/skills/batch-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: batch-merge
-description: Merge all ready PRs in a parallel batch into develop sequentially, auto-resolving trivial CHANGELOG and documentation conflicts, pausing for human input only on non-trivial conflicts, and running post-merge-cleanup for each successfully merged PR. Prints the merge plan for visibility but proceeds immediately without requiring confirmation. Use when a parallel batch of PRs is ready for merge.
+description: Merge all ready PRs in a parallel batch into the target base branch sequentially, auto-resolving trivial CHANGELOG and documentation conflicts, pausing for human input only on non-trivial conflicts, and running post-merge-cleanup for each successfully merged PR. Prints the merge plan for visibility but proceeds immediately without requiring confirmation. Use when a parallel batch of PRs is ready for merge.
 ---
 
 # Batch Merge
@@ -35,13 +35,13 @@ Follow `docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md`
      - Documentation files (`docs/`, `.claude/`, `.cursor/`, `.codex/`): auto-resolve if non-overlapping; escalate if overlapping.
      - All other files (or overlapping doc changes): pause, show conflict markers, wait for human to resolve or abort.
    - On `MERGE_RESULT=failed`: report the error, mark `failed`, continue.
-   - After each successful merge: complete the post-merge sequence from Protocol 94 Step 4.2 (`git push origin develop`, verify GitHub shows `MERGED`, delete the remote branch if it still exists, create a temporary local branch if needed, then run `./scripts/development-workflow/post-merge-cleanup.sh <branch>`).
+   - After each successful merge: complete the post-merge sequence from Protocol 94 Step 4.2 (push the target base branch, verify GitHub shows `MERGED`, delete the remote branch if it still exists, create a temporary local branch if needed, then run `./scripts/development-workflow/post-merge-cleanup.sh --base <target-base> <branch>`).
 
 7. **Final summary**: always print a table listing every candidate PR with its outcome code (`merged_clean`, `merged_auto`, `merged_human`, `skipped_not_ready`, `skipped_conflict`, `failed`, `not_attempted`).
 
 Key rules:
 
-- Never leave `develop` in a conflicted state — always run `git merge --abort` if a conflict cannot be resolved.
+- Never leave the target base branch in a conflicted state — always run `git merge --abort` if a conflict cannot be resolved.
 - Do not force-push or rebase PR branches.
 - Do not use `gh pr close` — the merge must be recognized by GitHub as `MERGED`.
 - Already-merged PRs stay merged even if the human aborts mid-batch.

--- a/.codex/skills/post-merge-cleanup/SKILL.md
+++ b/.codex/skills/post-merge-cleanup/SKILL.md
@@ -11,7 +11,7 @@ description: After a development PR is merged and the remote branch deleted, syn
    ```
 2. **No argument**: the current branch is the one to delete (user runs while still on the merged branch).
 3. **With `branch-name`**: delete that local branch (e.g. `feature/my-feature`).
-4. **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and falls back to `develop` only if that lookup is unavailable.
+4. **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and fails closed if that lookup is unavailable.
 5. In `workflow_hub`, preserve the selected product repository context for product-owned implementation cleanup and pass it through to shared cleanup helpers; hub-owned spec, plan, and workflow PR cleanup remains in the hub. Missing mode or `single_repo` keeps current cleanup behavior.
 6. **Update the issue tracker (if configured)**
    The merged branch name often contains an issue identifier (e.g. `feature/ENG-123-user-auth` → `ENG-123`, `fix/PROJ-456-login` → `PROJ-456`, `feature/42-user-auth` → `#42`). After the script succeeds, update the corresponding issue using the branch-type-based status table from Step 10 of `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`:

--- a/.codex/skills/post-merge-cleanup/SKILL.md
+++ b/.codex/skills/post-merge-cleanup/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: post-merge-cleanup
-description: After a development PR is merged and the remote branch deleted, sync with origin, switch to develop, pull, delete the local branch, and update the related issue in the issue tracker. Use when you want to clean up the local repo post-merge.
+description: After a development PR is merged and the remote branch deleted, sync with origin, switch to the merged PR's base branch, pull, delete the local branch, and update the related issue in the issue tracker. Use when you want to clean up the local repo post-merge.
 ---
 
 # Post-merge cleanup
 
 1. From the repository root, run:
    ```bash
-   ./scripts/development-workflow/post-merge-cleanup.sh [branch-name]
+   ./scripts/development-workflow/post-merge-cleanup.sh [--base base-branch] [branch-name]
    ```
 2. **No argument**: the current branch is the one to delete (user runs while still on the merged branch).
 3. **With `branch-name`**: delete that local branch (e.g. `feature/my-feature`).
-4. In `workflow_hub`, preserve the selected product repository context for product-owned implementation cleanup and pass it through to shared cleanup helpers; hub-owned spec, plan, and workflow PR cleanup remains in the hub. Missing mode or `single_repo` keeps current cleanup behavior.
-5. **Update the issue tracker (if configured)**
+4. **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and falls back to `develop` only if that lookup is unavailable.
+5. In `workflow_hub`, preserve the selected product repository context for product-owned implementation cleanup and pass it through to shared cleanup helpers; hub-owned spec, plan, and workflow PR cleanup remains in the hub. Missing mode or `single_repo` keeps current cleanup behavior.
+6. **Update the issue tracker (if configured)**
    The merged branch name often contains an issue identifier (e.g. `feature/ENG-123-user-auth` → `ENG-123`, `fix/PROJ-456-login` → `PROJ-456`, `feature/42-user-auth` → `#42`). After the script succeeds, update the corresponding issue using the branch-type-based status table from Step 10 of `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`:
 
    | Merged branch type                                | Set tracker status to |
@@ -34,4 +35,4 @@ If this post-merge cleanup is the final action for a work item that was advanced
 
 Only suggest this when the cleanup is for a standalone item run (not when called as part of a batch merge or orchestrator flow, which handle retrospectives at their own level). See `docs/workflow/development-workflow/protocols/06-retrospective-protocol.md`.
 
-The script (step 1) fetches origin, checks out `develop`, pulls, deletes the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote), and for implementation branches (`fix/*`, `feature/*`, `hotfix/*`, `refactor/*`) automatically closes the associated GitHub issue if a merged PR is found. Do not change the order or skip steps.
+The script (step 1) fetches origin, checks out the merged PR's base branch, pulls, deletes the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote), and for implementation branches (`fix/*`, `feature/*`, `hotfix/*`, `refactor/*`) automatically closes the associated GitHub issue if a merged PR is found. Do not change the order or skip steps.

--- a/.cursor/commands/batch-merge.md
+++ b/.cursor/commands/batch-merge.md
@@ -1,6 +1,6 @@
 ---
 description: >
-  Merge all ready PRs in a parallel batch into develop sequentially, auto-resolving trivial
+  Merge all ready PRs in a parallel batch into the target base branch sequentially, auto-resolving trivial
   CHANGELOG and documentation conflicts, pausing for human input only on non-trivial conflicts,
   and running post-merge-cleanup for each successfully merged PR. Prints the merge plan for
   visibility but proceeds immediately without requiring confirmation.
@@ -9,7 +9,7 @@ description: >
 
 Follow `docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md` exactly.
 
-**Auto-discovery** (no arguments): discovers all PRs labeled `ready-for-human-review` targeting `develop`.
+**Auto-discovery** (no arguments): discovers all PRs labeled `ready-for-human-review` targeting the configured base branch.
 
 **Explicit PR list**: pass PR numbers as arguments, e.g. `/batch-merge #101 #102 #103` or `/batch-merge --prs 101,102,103`. The command proceeds to per-PR readiness checks regardless of label status.
 
@@ -18,6 +18,6 @@ Key rules:
 - Print the merge plan (Step 3 of the protocol) for visibility, then proceed immediately without waiting for user confirmation.
 - For each PR, run `./scripts/development-workflow/batch-merge.sh merge --pr <number>`.
 - Auto-resolve CHANGELOG and non-overlapping documentation conflicts; pause and escalate non-trivial conflicts.
-- After each successful merge: push `develop`, verify GitHub shows the PR as `MERGED`, delete the remote branch, run `./scripts/development-workflow/post-merge-cleanup.sh <branch>`.
-- Never leave `develop` in a conflicted state.
+- After each successful merge: push the target base branch, verify GitHub shows the PR as `MERGED`, delete the remote branch, run `./scripts/development-workflow/post-merge-cleanup.sh --base <target-base> <branch>`.
+- Never leave the target base branch in a conflicted state.
 - Always print the final summary table (Step 5) regardless of outcome.

--- a/.cursor/commands/post-merge-cleanup.md
+++ b/.cursor/commands/post-merge-cleanup.md
@@ -13,7 +13,7 @@ Run the post-merge cleanup script from the repository root.
   ```
 - **No argument**: use the current branch (user should run while still on the merged branch).
 - **With `branch-name`**: delete that local branch (e.g. `feature/my-feature`).
-- **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and falls back to `develop` only if that lookup is unavailable.
+- **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and fails closed if that lookup is unavailable.
 
 The script will: fetch origin, checkout the merged PR's base branch, pull, delete the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote), and for implementation branches (`fix/*`, `feature/*`, `hotfix/*`, `refactor/*`) automatically close the associated GitHub issue if a merged PR is found for the branch. If the user is not in the repo root, `cd` to the repo root first (e.g. use the workspace root or ask which directory is the repo).
 

--- a/.cursor/commands/post-merge-cleanup.md
+++ b/.cursor/commands/post-merge-cleanup.md
@@ -1,20 +1,21 @@
 ---
 description: >
   After a development PR is merged and the remote branch deleted, sync with origin,
-  switch to develop, pull, delete the local branch, and update the related issue in the issue tracker.
-  Usage: /post-merge-cleanup [branch-name]
+  switch to the merged PR's base branch, pull, delete the local branch, and update the related issue in the issue tracker.
+  Usage: /post-merge-cleanup [--base base-branch] [branch-name]
 ---
 
 Run the post-merge cleanup script from the repository root.
 
 - **From repo root**, run:
   ```bash
-  ./scripts/development-workflow/post-merge-cleanup.sh [branch-name]
+  ./scripts/development-workflow/post-merge-cleanup.sh [--base base-branch] [branch-name]
   ```
 - **No argument**: use the current branch (user should run while still on the merged branch).
 - **With `branch-name`**: delete that local branch (e.g. `feature/my-feature`).
+- **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and falls back to `develop` only if that lookup is unavailable.
 
-The script will: fetch origin, checkout `develop`, pull, delete the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote), and for implementation branches (`fix/*`, `feature/*`, `hotfix/*`, `refactor/*`) automatically close the associated GitHub issue if a merged PR is found for the branch. If the user is not in the repo root, `cd` to the repo root first (e.g. use the workspace root or ask which directory is the repo).
+The script will: fetch origin, checkout the merged PR's base branch, pull, delete the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote), and for implementation branches (`fix/*`, `feature/*`, `hotfix/*`, `refactor/*`) automatically close the associated GitHub issue if a merged PR is found for the branch. If the user is not in the repo root, `cd` to the repo root first (e.g. use the workspace root or ask which directory is the repo).
 
 Do not skip steps or change the order. If the script fails, show the error and stop.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Post-merge cleanup integration branch awareness** (#911): makes cleanup switch to the merged PR base branch, including workflow hub integration branches, instead of always defaulting to `develop`.
 - **Native GitHub sub-issues for epics** (#884): documents native sub-issue linking and verification for multi-item GitHub epics while preserving `integration-branch:<slug>` labels as the routing contract and fallback.
 - **Codex GitHub reviewer loop**: aligns the documented Codex bot default with the reviewer scripts, ignores outdated Codex review threads, and waits for Codex's definitive thumbs-up or inline-comment signal instead of treating review boilerplate as approval.
 - **Claude Code Action reviewer no-op guard** (#866): passes an explicit code-review prompt to the workflow and fails closed when a successful run log shows Claude did not actually execute.

--- a/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
+++ b/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
@@ -256,12 +256,13 @@ After a clean or resolved merge, in order:
 
    ```bash
    BRANCH="$(gh pr view <number> --json headRefName --jq '.headRefName')"
+   BASE_BRANCH="${TARGET_BASE:-develop}"
    # Try origin/<branch> first; fall back to HEAD~1 if the remote branch was
    # already deleted (e.g., repo has auto-delete enabled). HEAD~1 points to the
    # pre-merge develop commit, not the PR's tip, but post-merge-cleanup.sh only
    # needs the branch *name* to delete it — the commit it points to is irrelevant.
    git branch "$BRANCH" "origin/$BRANCH" 2>/dev/null || git branch "$BRANCH" HEAD~1 2>/dev/null || true
-   ./scripts/development-workflow/post-merge-cleanup.sh "$BRANCH"
+   ./scripts/development-workflow/post-merge-cleanup.sh --base "$BASE_BRANCH" "$BRANCH"
    ```
 
    If cleanup fails: report the failure but **do not halt remaining merges**. The human can re-run cleanup manually.

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -313,8 +313,8 @@ Usage:
 - No argument: use the current branch (run while still on the merged branch).
 - With `BRANCH`: branch name to delete (e.g. `feature/my-feature`).
 - With `--base`: explicitly choose the cleanup base branch. When omitted for
-  hub-owned branches, the script queries the merged PR base and falls back to
-  `develop` only if that lookup is unavailable.
+  hub-owned branches, the script queries the merged PR base and fails closed if
+  that lookup is unavailable.
 
 Use this when:
 

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -300,20 +300,26 @@ workflow hub repository.
 
 ### `post-merge-cleanup.sh`
 
-After a development PR is merged and the remote branch deleted, sync with origin, switch to develop, pull, and delete the local branch.
+After a development PR is merged and the remote branch deleted, sync with
+origin, switch to the merged PR's base branch, pull, and delete the local
+branch.
 
 Usage:
 
 ```bash
-./scripts/development-workflow/post-merge-cleanup.sh [BRANCH]
+./scripts/development-workflow/post-merge-cleanup.sh [--base develop-workflow-hub-mode] [BRANCH]
 ```
 
 - No argument: use the current branch (run while still on the merged branch).
 - With `BRANCH`: branch name to delete (e.g. `feature/my-feature`).
+- With `--base`: explicitly choose the cleanup base branch. When omitted for
+  hub-owned branches, the script queries the merged PR base and falls back to
+  `develop` only if that lookup is unavailable.
 
 Use this when:
 
-- You have merged a feature/plan/spec PR and deleted the remote branch, and want to clean up the local branch and update develop.
+- You have merged a feature/plan/spec PR and deleted the remote branch, and want
+  to clean up the local branch and update the correct base branch.
 
 ### `prepare-release-post-merge-cleanup.sh`
 

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
-# Post-merge cleanup: fetch origin, checkout develop, pull, and delete the
+# Post-merge cleanup: fetch origin, checkout the merge base, pull, and delete the
 # local branch that was just merged (remote branch already deleted).
 # Keeps the local repo clean after merging developments.
 #
 # Usage:
-#   ./scripts/development-workflow/post-merge-cleanup.sh [--repo <name>] [--repo-root <path>] [BRANCH]
+#   ./scripts/development-workflow/post-merge-cleanup.sh [--repo <name>] [--repo-root <path>] [--base <branch>] [BRANCH]
 #
 # - No BRANCH: use current branch (run while still on the merged branch).
 # - BRANCH: name of the local branch to delete (e.g. feature/my-feature).
@@ -27,6 +27,7 @@ DEVELOP_BRANCH="develop"
 TO_DELETE=""
 target_repo=""
 repo_root="$HUB_REPO_ROOT"
+base_branch_override=""
 
 require_option_value() {
   local option="$1"
@@ -47,6 +48,11 @@ while [ "$#" -gt 0 ]; do
     --repo-root)
       require_option_value "$@"
       repo_root="$2"
+      shift 2
+      ;;
+    --base)
+      require_option_value "$@"
+      base_branch_override="$2"
       shift 2
       ;;
     -h|--help)
@@ -124,6 +130,31 @@ if [ "$workflow_mode" = "workflow_hub" ] && [ "$branch_owner_kind" = "implementa
   if [ -z "$CLEANUP_REPO_ROOT" ]; then
     echo "ERROR: product repository local path is required for product repository cleanup in workflow_hub mode." >&2
     exit 64
+  fi
+fi
+
+if [ -n "$base_branch_override" ]; then
+  DEVELOP_BRANCH="$base_branch_override"
+elif [ "$ACTION_REPOSITORY_KIND" = "hub_owned" ]; then
+  cleanup_repo_slug=""
+  if cleanup_repo_slug="$(repo_slug 2>/dev/null)"; then
+    merged_base="$(
+      gh pr list \
+        --repo "$cleanup_repo_slug" \
+        --state merged \
+        --head "$TO_DELETE" \
+        --limit 1 \
+        --json baseRefName \
+        --jq '.[0].baseRefName // empty'
+    )" || {
+      echo "Warning: could not query merged PR base for branch '$TO_DELETE'; using '$DEVELOP_BRANCH'." >&2
+      merged_base=""
+    }
+    if [ -n "$merged_base" ]; then
+      DEVELOP_BRANCH="$merged_base"
+    fi
+  else
+    echo "Warning: could not resolve GitHub repository; using '$DEVELOP_BRANCH' for cleanup base." >&2
   fi
 fi
 

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -133,33 +133,42 @@ if [ "$workflow_mode" = "workflow_hub" ] && [ "$branch_owner_kind" = "implementa
   fi
 fi
 
+case "$TO_DELETE" in
+  "$DEVELOP_BRANCH"|"$selected_product_default_branch"|main|master)
+    echo "Refusing to delete protected branch '$TO_DELETE'." >&2
+    exit 2
+    ;;
+esac
+
 if [ -n "$base_branch_override" ]; then
   DEVELOP_BRANCH="$base_branch_override"
 elif [ "$ACTION_REPOSITORY_KIND" = "hub_owned" ]; then
   cleanup_repo_slug=""
-  if cleanup_repo_slug="$(repo_slug 2>/dev/null)"; then
-    merged_base="$(
-      gh pr list \
-        --repo "$cleanup_repo_slug" \
-        --state merged \
-        --head "$TO_DELETE" \
-        --limit 1 \
-        --json baseRefName \
-        --jq '.[0].baseRefName // empty'
-    )" || {
-      echo "Warning: could not query merged PR base for branch '$TO_DELETE'; using '$DEVELOP_BRANCH'." >&2
-      merged_base=""
-    }
-    if [ -n "$merged_base" ]; then
-      DEVELOP_BRANCH="$merged_base"
-    fi
-  else
-    echo "Warning: could not resolve GitHub repository; using '$DEVELOP_BRANCH' for cleanup base." >&2
+  if ! cleanup_repo_slug="$(repo_slug 2>/dev/null)"; then
+    echo "ERROR: could not resolve GitHub repository for merged PR base lookup; pass --base <branch> to override." >&2
+    exit 1
   fi
+  if ! merged_base="$(
+    gh pr list \
+      --repo "$cleanup_repo_slug" \
+      --state merged \
+      --head "$TO_DELETE" \
+      --limit 1 \
+      --json baseRefName \
+      --jq '.[0].baseRefName // empty'
+  )"; then
+    echo "ERROR: could not query merged PR base for branch '$TO_DELETE'; pass --base <branch> to override." >&2
+    exit 1
+  fi
+  if [ -z "$merged_base" ]; then
+    echo "ERROR: could not determine merged PR base for branch '$TO_DELETE'; pass --base <branch> to override." >&2
+    exit 1
+  fi
+  DEVELOP_BRANCH="$merged_base"
 fi
 
 case "$TO_DELETE" in
-  "$DEVELOP_BRANCH"|"$selected_product_default_branch"|main|master)
+  "$DEVELOP_BRANCH")
     echo "Refusing to delete protected branch '$TO_DELETE'." >&2
     exit 2
     ;;

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -338,6 +338,13 @@ run_fails_contains \
     feature/900-product-routing
 
 run_fails_contains \
+  "post_merge_cleanup_refuses_main_branch" \
+  "Refusing to delete protected branch 'main'." \
+  "$REPO_ROOT/scripts/development-workflow/post-merge-cleanup.sh" \
+    --repo-root "$hub_dir" \
+    main
+
+run_fails_contains \
   "post_merge_cleanup_fails_when_merged_base_unknown" \
   "could not determine merged PR base" \
   env WORKFLOW_TARGET_GITHUB_REPO=example/workflow-hub \
@@ -362,6 +369,29 @@ printf 'branch\n' > "$cleanup_repo/spec.txt"
 git -C "$cleanup_repo" add spec.txt
 git -C "$cleanup_repo" commit -q -m "spec branch fixture"
 git -C "$cleanup_repo" checkout -q develop-workflow-hub-mode
+git -C "$cleanup_repo" checkout -q -b spec/base-override
+printf 'override\n' > "$cleanup_repo/override.txt"
+git -C "$cleanup_repo" add override.txt
+git -C "$cleanup_repo" commit -q -m "base override fixture"
+git -C "$cleanup_repo" checkout -q develop-workflow-hub-mode
+
+base_override_output="$(
+  GH_PR_LIST_BASE=wrong-base \
+  WORKFLOW_TARGET_GITHUB_REPO=example/workflow-hub \
+  PATH="$stub_bin:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/post-merge-cleanup.sh" \
+    --repo-root "$cleanup_repo" \
+    --base develop-workflow-hub-mode \
+    spec/base-override
+)"
+run_contains \
+  "post_merge_cleanup_base_override_precedes_lookup" \
+  "will switch to develop-workflow-hub-mode" \
+  "$base_override_output"
+run_contains \
+  "post_merge_cleanup_base_override_deletes_branch" \
+  "Deleted branch spec/base-override" \
+  "$base_override_output"
 
 cleanup_output="$(
   GH_PR_LIST_BASE=develop-workflow-hub-mode \

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -254,6 +254,10 @@ case "$1" in
       exit 0
     fi
     if [ "$2" = "list" ]; then
+      if [ -n "${GH_PR_LIST_BASE:-}" ]; then
+        printf '%s\n' "$GH_PR_LIST_BASE"
+        exit 0
+      fi
       printf '[]\n'
       exit 0
     fi
@@ -333,6 +337,40 @@ run_fails_contains \
   "$REPO_ROOT/scripts/development-workflow/post-merge-cleanup.sh" \
     --repo-root "$hub_dir" \
     feature/900-product-routing
+
+cleanup_remote="$TMP_ROOT/integration-cleanup.git"
+cleanup_repo="$TMP_ROOT/integration-cleanup"
+git init --bare -q -b develop-workflow-hub-mode "$cleanup_remote"
+git init -q -b develop-workflow-hub-mode "$cleanup_repo"
+git -C "$cleanup_repo" config user.email "fixture@example.com"
+git -C "$cleanup_repo" config user.name "Fixture User"
+printf 'base\n' > "$cleanup_repo/README.md"
+git -C "$cleanup_repo" add README.md
+git -C "$cleanup_repo" commit -q -m "initial integration base"
+git -C "$cleanup_repo" remote add origin "$cleanup_remote"
+git -C "$cleanup_repo" push -q -u origin develop-workflow-hub-mode
+git -C "$cleanup_repo" checkout -q -b spec/integration-cleanup
+printf 'branch\n' > "$cleanup_repo/spec.txt"
+git -C "$cleanup_repo" add spec.txt
+git -C "$cleanup_repo" commit -q -m "spec branch fixture"
+git -C "$cleanup_repo" checkout -q develop-workflow-hub-mode
+
+cleanup_output="$(
+  GH_PR_LIST_BASE=develop-workflow-hub-mode \
+  WORKFLOW_TARGET_GITHUB_REPO=example/workflow-hub \
+  PATH="$stub_bin:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/post-merge-cleanup.sh" \
+    --repo-root "$cleanup_repo" \
+    spec/integration-cleanup
+)"
+run_contains \
+  "post_merge_cleanup_uses_merged_pr_base" \
+  "will switch to develop-workflow-hub-mode" \
+  "$cleanup_output"
+run_contains \
+  "post_merge_cleanup_deletes_integration_branch" \
+  "Deleted branch spec/integration-cleanup" \
+  "$cleanup_output"
 
 echo ""
 echo "Passed: $PASS_COUNT"

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -254,10 +254,20 @@ case "$1" in
       exit 0
     fi
     if [ "$2" = "list" ]; then
-      if [ -n "${GH_PR_LIST_BASE:-}" ]; then
-        printf '%s\n' "$GH_PR_LIST_BASE"
-        exit 0
+      if [ "${GH_FAIL_PR_LIST:-}" = "1" ]; then
+        echo "simulated pr list failure" >&2
+        exit 1
       fi
+      case " $* " in
+        *" --json baseRefName "*)
+          [ -n "${GH_PR_LIST_BASE:-}" ] && printf '%s\n' "$GH_PR_LIST_BASE"
+          exit 0
+          ;;
+        *" --json number "*)
+          [ -n "${GH_PR_LIST_NUMBER:-}" ] && printf '%s\n' "$GH_PR_LIST_NUMBER"
+          exit 0
+          ;;
+      esac
       exit 0
     fi
     ;;
@@ -353,6 +363,16 @@ run_fails_contains \
     --repo-root "$hub_dir" \
     spec/integration-cleanup
 
+run_fails_contains \
+  "post_merge_cleanup_fails_when_merged_base_query_fails" \
+  "could not query merged PR base" \
+  env GH_FAIL_PR_LIST=1 \
+    WORKFLOW_TARGET_GITHUB_REPO=example/workflow-hub \
+    PATH="$stub_bin:$PATH" \
+    "$REPO_ROOT/scripts/development-workflow/post-merge-cleanup.sh" \
+    --repo-root "$hub_dir" \
+    spec/integration-cleanup
+
 cleanup_remote="$TMP_ROOT/integration-cleanup.git"
 cleanup_repo="$TMP_ROOT/integration-cleanup"
 git init --bare -q -b develop-workflow-hub-mode "$cleanup_remote"
@@ -374,6 +394,16 @@ printf 'override\n' > "$cleanup_repo/override.txt"
 git -C "$cleanup_repo" add override.txt
 git -C "$cleanup_repo" commit -q -m "base override fixture"
 git -C "$cleanup_repo" checkout -q develop-workflow-hub-mode
+
+run_fails_contains \
+  "post_merge_cleanup_refuses_resolved_base_branch" \
+  "Refusing to delete protected branch 'develop-workflow-hub-mode'." \
+  env GH_PR_LIST_BASE=develop-workflow-hub-mode \
+    WORKFLOW_TARGET_GITHUB_REPO=example/workflow-hub \
+    PATH="$stub_bin:$PATH" \
+    "$REPO_ROOT/scripts/development-workflow/post-merge-cleanup.sh" \
+    --repo-root "$cleanup_repo" \
+    develop-workflow-hub-mode
 
 base_override_output="$(
   GH_PR_LIST_BASE=wrong-base \

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -258,7 +258,6 @@ case "$1" in
         printf '%s\n' "$GH_PR_LIST_BASE"
         exit 0
       fi
-      printf '[]\n'
       exit 0
     fi
     ;;
@@ -337,6 +336,15 @@ run_fails_contains \
   "$REPO_ROOT/scripts/development-workflow/post-merge-cleanup.sh" \
     --repo-root "$hub_dir" \
     feature/900-product-routing
+
+run_fails_contains \
+  "post_merge_cleanup_fails_when_merged_base_unknown" \
+  "could not determine merged PR base" \
+  env WORKFLOW_TARGET_GITHUB_REPO=example/workflow-hub \
+    PATH="$stub_bin:$PATH" \
+    "$REPO_ROOT/scripts/development-workflow/post-merge-cleanup.sh" \
+    --repo-root "$hub_dir" \
+    spec/integration-cleanup
 
 cleanup_remote="$TMP_ROOT/integration-cleanup.git"
 cleanup_repo="$TMP_ROOT/integration-cleanup"


### PR DESCRIPTION
## Summary
- add a --base override to post-merge-cleanup.sh and infer hub-owned cleanup base branches from the merged PR
- update batch-merge protocol/skill wrappers to pass the target base during cleanup
- cover workflow hub integration branch cleanup with a product-repo-aware workflow regression test

Closes #911

## Validation
- bash scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
- shellcheck --severity=warning scripts/development-workflow/post-merge-cleanup.sh scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
- npx markdownlint-cli2 "CHANGELOG.md" "scripts/development-workflow/README.md" "docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md" ".codex/skills/post-merge-cleanup/SKILL.md" ".claude/skills/post-merge-cleanup.md" ".claude/commands/post-merge-cleanup.md" ".cursor/commands/post-merge-cleanup.md" ".claude/commands/batch-merge.md" ".cursor/commands/batch-merge.md" ".codex/skills/batch-merge/SKILL.md"
- bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md
- git diff --check