### PR TITLE
fix(workflow): label Haystack policy acknowledgements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Haystack policy acknowledgements** (#890): labels policy-only Haystack human-review signals as explicit acknowledgements in reviewer-loop summaries while keeping concrete findings blocking.
 - **Prepare-release Linear tracker completion** (#914): makes release post-merge cleanup derive shipped issue scope from the finalized changelog, fail closed when tracker scope or Linear completion is missing, and emit actionable Linear MCP/API handoff signals.
 - **Post-merge cleanup integration branch awareness** (#911): makes cleanup switch to the merged PR base branch, including workflow hub integration branches, instead of always defaulting to `develop`.
 - **Native GitHub sub-issues for epics** (#884): documents native sub-issue linking and verification for multi-item GitHub epics while preserving `integration-branch:<slug>` labels as the routing contract and fallback.

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -121,10 +121,10 @@ triage result with a policy verdict appears as:
 haystack (needs-review: policy)
 ```
 
-The same summary comment includes an explicit status handoff:
+The same summary comment includes an explicit policy acknowledgement handoff:
 
 ```text
-Review policy status:
+Policy acknowledgements:
 - haystack: bucket=needs-assignment; needsHumanReview=true; disposition=policy-human-review; verdict=needs-review; analysisStatus=ready; rating=5; hasReviewer=false;
 ```
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4655,7 +4655,7 @@ Protocol 91 Step 7b requires this label on all \`${branch_name%%/*}/*\` PRs afte
       && [ "${#platform_policy_status_notes[@]}" -gt 0 ]; then
     local _policy_status_note
     policy_status_section="
-**Review policy status:**"
+**Policy acknowledgements:**"
     for _policy_status_note in "${platform_policy_status_notes[@]}"; do
       policy_status_section="${policy_status_section}
 - ${_policy_status_note}"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1162,8 +1162,8 @@ fi
 run_test "summary_result_line_skipped" "1" "$_skipped_constant_count"
 unset _skipped_constant_count
 
-# Test 10.4: _post_review_summary source renders policy-status details.
-if grep -qF '**Review policy status:**' \
+# Test 10.4: _post_review_summary source renders policy acknowledgement details.
+if grep -qF '**Policy acknowledgements:**' \
     "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh" \
     && grep -qF 'platform_policy_status_notes' \
       "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"; then
@@ -1171,7 +1171,7 @@ if grep -qF '**Review policy status:**' \
 else
   _policy_status_summary_count=0
 fi
-run_test "summary_policy_status_section" "1" "$_policy_status_summary_count"
+run_test "summary_policy_acknowledgements_section" "1" "$_policy_status_summary_count"
 unset _policy_status_summary_count
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Rename the Haystack policy-status section in reviewer-loop summaries to `Policy acknowledgements`
- Update the matching reviewer-loop regression test and Haystack triage documentation
- Add the #890 changelog entry under Unreleased / Fixed

## Pre-Submission Self-Review
- Reviewed `git diff` for `CHANGELOG.md`, `haystack-triage.md`, `pr-review-loop.sh`, and `test-pr-review-loop.sh`
- Confirmed the change is wording-only for the PR summary handoff; no blocking/clean classification logic changed
- Confirmed issue coverage for #890: policy-only Haystack human-review signals remain non-blocking and visible, while concrete findings still block
- Confirmed sibling/caller consistency: docs and test source-string assertion now match the runtime summary heading

## Validation
- `bash scripts/development-workflow/tests/test-haystack-reviewer.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/integrations/haystack-triage.md" "CHANGELOG.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md docs/workflow/development-workflow/integrations/haystack-triage.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`

Closes #890