### PR TITLE
feat(haystack): calibrate mirror guidance

### DIFF
--- a/.haystack/pr-rules.yml
+++ b/.haystack/pr-rules.yml
@@ -68,9 +68,9 @@ rules:
     type: llm
     severity: warning
     category: "patterns"
-    message: "When shared agent guidance changes, update matching files under .claude and .cursor together."
+    message: "When shared agent guidance changes, update the real mirrored surfaces in .claude and .cursor together; compare workflow semantics, not tool-specific front matter, and do not require absent .cursor/skills surfaces."
     llm:
-      prompt: "When shared agent guidance changes, update matching files under .claude and .cursor together."
+      prompt: "When shared agent guidance changes, update the real mirrored surfaces in .claude and .cursor together. Compare the workflow body semantically, not byte-for-byte, so tool-specific front matter differences stay advisory. Do not require absent .cursor/skills surfaces as mirrors."
   - id: "sync-integration-docs-with-script-behavior"
     name: "Sync integration docs and scripts"
     type: llm

--- a/.haystack/review-policy.md
+++ b/.haystack/review-policy.md
@@ -34,3 +34,4 @@
 - If reviewer availability drops or warn-only behavior is used, a human must decide whether reduced coverage is acceptable for that pull request.
 - If automation cannot post review summary output and manual recovery is used, a human must confirm the evidence is sufficient to proceed.
 - If a pull request expands beyond approved scope or defers advisory findings, a human must decide whether the remaining risk is acceptable.
+- If Haystack mirror guidance changes, verify the live agent-doc surface map first. Treat tool-specific front matter differences and absent `.cursor/skills` surfaces as advisory-only unless a real mirrored workflow body mismatch remains.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -21,6 +21,10 @@ Use it for every pre-PR review gate and as the normalization layer for PR review
 | `important`  | Edge-case gap, maintainability issue, unclear design choice, incomplete workflow update                                 | Fix by default unless a human decision is required                       |
 | `suggestion` | Improvement that is optional and low-risk                                                                               | Fix by default; report if scope-expanding or requires a product decision |
 
+### Haystack mirror findings
+
+When a review references mirrored agent docs, compare the live repository surface map before treating the finding as blocking. A `Rules violation` that only points at tool-specific front matter differences or an absent `.cursor/skills` tree is advisory only; a real mismatch between mirrored workflow bodies is actionable.
+
 ### Fix vs. Report
 
 Fix directly when:

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -156,6 +156,15 @@ Haystack uses the `Rules violation` category for custom rule findings, including
 
 If both conditions hold, the finding is a confirmed false positive and can be dismissed.
 
+### Mirror guidance — actionable drift vs. stale advisories
+
+Haystack also uses `Rules violation` for mirror guidance around the agent-doc surface map. Treat those findings as follows:
+
+- **Actionable mirror drift**: a real mismatch exists between matching `.claude/agents/*` and `.cursor/agents/*` workflow docs, or between another documented mirror pair that actually exists in the repository.
+- **Non-actionable advisory**: the finding is based only on tool-specific front matter, a missing `.cursor/skills` tree, or another surface that the repository does not actually contain.
+
+The reviewer loop keeps these findings non-blocking. Use the repository surface map and the mirrored file content to decide whether a `Rules violation` needs a fix or just a note in the summary comment.
+
 #### Hotfix backport PRs
 
 An additional false positive occurs specifically on hotfix backport PRs. Hotfix branches are cut from `main`. The diff of a backport branch against `develop` shows an empty `[Unreleased]` section (from `main`'s version of the CHANGELOG). Haystack interprets the diff as "removing `[Unreleased]` content" and flags it as a structure violation. In reality, the 3-way merge on the `develop` side preserves its own `[Unreleased]` content; the CHANGELOG structure in the merged result is correct.

--- a/docs/workflow/development-workflow/integrations/haystack.md
+++ b/docs/workflow/development-workflow/integrations/haystack.md
@@ -65,6 +65,8 @@ Use Haystack in three layers, each with a different failure mode:
 
 Prefer deterministic checks for rules that can be expressed mechanically. Keep `.haystack/pr-rules.yml` focused on judgement calls: shell control-flow risk, review-state freshness, unsafe API payload construction, and workflow-contract drift. When Haystack reports a non-blocking finding, record the disposition in the reviewer-loop summary instead of silently ignoring it.
 
+Mirror guidance is calibrated against the live repository surface map. For this template, the mirrored agent-doc surfaces are the files under `.claude/agents/` and `.cursor/agents/`, while `.cursor/skills/` is intentionally absent and must not be treated as a required mirror. Tool-specific front matter differences are advisory unless the shared workflow body really diverges.
+
 For repositories that open implementation PRs as drafts, configure Haystack in
 `review.on_ready.github` instead of the draft phase. The reviewer loop will
 mark the PR ready before running ready-phase platforms; Haystack triage may stay
@@ -78,6 +80,7 @@ Use small PRs when expanding this integration:
 2. Extend local hooks only for repo-wide contracts with low false-positive risk.
 3. Keep `haystack triage` visible in reviewer-loop summaries, especially `unavailable`, `pending_timeout`, and advisory-only outcomes.
 4. Add agent detection only for tools that the team actively uses. Cursor is not detected by the stock parsers today; those commits behave like human commits unless detection is extended.
+5. When refining mirror guidance, prefer semantic workflow-body checks over byte-for-byte matching and treat absent surfaces as out of scope unless the repo actually contains them.
 
 ---
 

--- a/scripts/development-workflow/tests/test-haystack-reviewer.sh
+++ b/scripts/development-workflow/tests/test-haystack-reviewer.sh
@@ -440,6 +440,17 @@ run_test "advisory_only_result" "RESULT=clean" "$(echo "$output" | grep '^RESULT
 run_test "advisory_only_suggestion_count" "SUGGESTION_COUNT=1" "$(echo "$output" | grep '^SUGGESTION_COUNT=')"
 run_test "advisory_only_blocking_zero" "BLOCKING_COUNT=0" "$(echo "$output" | grep '^BLOCKING_COUNT=')"
 
+# Test 5.3: Rules violation mirror finding stays advisory-only.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Rules violation","summary":"Mirror drift needs review","detail":"Claude/Cursor workflow bodies differ; front matter differs only"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+
+run_test "rules_violation_result" "RESULT=clean" "$(echo "$output" | grep '^RESULT=')"
+run_test "rules_violation_suggestion_count" "SUGGESTION_COUNT=1" "$(echo "$output" | grep '^SUGGESTION_COUNT=')"
+run_test "rules_violation_blocking_zero" "BLOCKING_COUNT=0" "$(echo "$output" | grep '^BLOCKING_COUNT=')"
+
 # ---------------------------------------------------------------------------
 # Area 6: HAYSTACK_POLL_INTERVAL controls retry cadence (env var)
 # ---------------------------------------------------------------------------

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1250,8 +1250,22 @@ platform_policy_status_notes=()
 pr_number=42
 # shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
 branch_name="fix/42-summary"
-_summary_call_log="$(mktemp)"
-_summary_body_capture="$(mktemp)"
+if ! _summary_call_log="$(mktemp)"; then
+  echo "ERROR: failed to allocate summary call log temp file" >&2
+  exit 1
+fi
+if [ -z "$_summary_call_log" ]; then
+  echo "ERROR: mktemp returned an empty summary call log path" >&2
+  exit 1
+fi
+if ! _summary_body_capture="$(mktemp)"; then
+  echo "ERROR: failed to allocate summary body capture temp file" >&2
+  exit 1
+fi
+if [ -z "$_summary_body_capture" ]; then
+  echo "ERROR: mktemp returned an empty summary body capture path" >&2
+  exit 1
+fi
 export MOCK_GH_CALL_LOG="$_summary_call_log"
 export MOCK_GH_BODY_CAPTURE="$_summary_body_capture"
 MOCK_GH_EXIT=0
@@ -1311,7 +1325,10 @@ _SUMMARY_COMMENT_JSON='[{"id":1,"body":"### Automated Reviewer Loop Summary\nAll
 # Test 11.1: label absent + summary comment PRESENT on an implementation branch
 # → gh pr edit IS called (the #805 scenario: loop ran before, label was dropped
 # by a push, restore is correct).
-_call_log_11="$(mktemp)"
+if ! _call_log_11="$(mktemp)"; then
+  echo "ERROR: failed to allocate regression-label test temp file" >&2
+  exit 1
+fi
 export MOCK_GH_OUTPUT="false"
 export MOCK_GH_COMMENTS_OUTPUT="$_SUMMARY_COMMENT_JSON"
 export MOCK_GH_CALL_LOG="$_call_log_11"
@@ -1323,7 +1340,10 @@ unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_OUTPUT
 
 # Test 11.2: label already present on an implementation branch → NO gh pr edit.
 # MOCK_GH_OUTPUT is "true" (label present); summary-comment gate is not reached.
-_call_log_11="$(mktemp)"
+if ! _call_log_11="$(mktemp)"; then
+  echo "ERROR: failed to allocate regression-label test temp file" >&2
+  exit 1
+fi
 export MOCK_GH_OUTPUT="true"
 export MOCK_GH_CALL_LOG="$_call_log_11"
 restore_regression_label_if_missing "42" "feature/42-my-feature" 2>/dev/null
@@ -1334,7 +1354,10 @@ unset MOCK_GH_CALL_LOG
 
 # Test 11.3: non-implementation branch (spec/) → NO gh pr edit regardless of
 # label state or summary-comment presence.
-_call_log_11="$(mktemp)"
+if ! _call_log_11="$(mktemp)"; then
+  echo "ERROR: failed to allocate regression-label test temp file" >&2
+  exit 1
+fi
 export MOCK_GH_OUTPUT="false"
 export MOCK_GH_COMMENTS_OUTPUT="$_SUMMARY_COMMENT_JSON"
 export MOCK_GH_CALL_LOG="$_call_log_11"
@@ -1348,7 +1371,10 @@ unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_OUTPUT
 # gh pr edit is NOT called (no false re-apply on unknown label state).
 # Note: MOCK_GH_EXIT=1 affects the label-check `gh pr view` call; the function
 # returns early before reaching the summary-comment gate.
-_call_log_11="$(mktemp)"
+if ! _call_log_11="$(mktemp)"; then
+  echo "ERROR: failed to allocate regression-label test temp file" >&2
+  exit 1
+fi
 export MOCK_GH_EXIT=1
 export MOCK_GH_CALL_LOG="$_call_log_11"
 _restore_exit=0
@@ -1361,7 +1387,10 @@ unset MOCK_GH_CALL_LOG MOCK_GH_EXIT
 
 # Test 11.5: hotfix/* branch + label absent + summary comment PRESENT
 # → gh pr edit called (hotfix is an implementation branch; must be in scope).
-_call_log_11="$(mktemp)"
+if ! _call_log_11="$(mktemp)"; then
+  echo "ERROR: failed to allocate regression-label test temp file" >&2
+  exit 1
+fi
 export MOCK_GH_OUTPUT="false"
 export MOCK_GH_COMMENTS_OUTPUT="$_SUMMARY_COMMENT_JSON"
 export MOCK_GH_CALL_LOG="$_call_log_11"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -60,6 +60,22 @@ cat > "$MOCK_BIN/gh" <<'MOCK_GH'
 if [ -n "${MOCK_GH_CALL_LOG:-}" ]; then
   printf '%s\n' "$*" >> "$MOCK_GH_CALL_LOG"
 fi
+# Capture comment body files when requested so tests can inspect the rendered
+# summary after pr-review-loop.sh removes the temporary file.
+if [ -n "${MOCK_GH_BODY_CAPTURE:-}" ]; then
+  _gh_body_file=""
+  _prev_arg=""
+  for _gh_arg in "$@"; do
+    if [ "$_prev_arg" = "--body-file" ]; then
+      _gh_body_file="$_gh_arg"
+      break
+    fi
+    _prev_arg="$_gh_arg"
+  done
+  if [ -n "$_gh_body_file" ] && [ -f "$_gh_body_file" ]; then
+    cat "$_gh_body_file" > "$MOCK_GH_BODY_CAPTURE"
+  fi
+fi
 # Differentiate call types.
 case "$*" in
   *"pr ready"*)
@@ -1217,6 +1233,47 @@ else
 fi
 run_test "summary_policy_acknowledgements_section" "1" "$_policy_status_summary_count"
 unset _policy_status_summary_count
+
+# Test 10.7: blocking findings and advisory findings both remain visible in the summary.
+_post_summary_source="$(awk '/^_post_review_summary\(\)/,/^}$/' \
+  "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"
+eval "$_post_summary_source"
+# shellcheck disable=SC2329 # Invoked indirectly by the eval-loaded function.
+repo_slug() { printf "owner/repo\n"; }
+# shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
+compare_mode=0
+# shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
+compare_verdicts=()
+# shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
+platform_policy_status_notes=()
+# shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
+pr_number=42
+# shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
+branch_name="fix/42-summary"
+_summary_call_log="$(mktemp)"
+_summary_body_capture="$(mktemp)"
+export MOCK_GH_CALL_LOG="$_summary_call_log"
+export MOCK_GH_BODY_CAPTURE="$_summary_body_capture"
+MOCK_GH_EXIT=0
+export MOCK_GH_EXIT
+MOCK_GH_COMMENTS_OUTPUT='[]'
+export MOCK_GH_COMMENTS_OUTPUT
+_post_review_summary "needs_fixes" "haystack_blocking_findings" "haystack (needs_fixes)" "1" "1" \
+  "Rules violation@@@https://github.com/lhpaul/ai-dev-framework-template/pull/952#issuecomment-1"
+if [ -n "${_summary_body_capture:-}" ] && grep -q "1 blocking finding(s) require fixes" "$_summary_body_capture" \
+    && grep -q "Advisory findings (non-blocking):" "$_summary_body_capture" \
+    && grep -q "Rules violation" "$_summary_body_capture"; then
+  _summary_advisory_split="yes"
+else
+  _summary_advisory_split="no"
+fi
+run_test "summary_advisory_split_visible" "yes" "$_summary_advisory_split"
+rm -f "$_summary_call_log"
+rm -f "$_summary_body_capture"
+unset MOCK_GH_CALL_LOG MOCK_GH_BODY_CAPTURE MOCK_GH_EXIT MOCK_GH_COMMENTS_OUTPUT
+unset _summary_advisory_split _post_summary_source
+unset -f _post_review_summary
+unset compare_mode compare_verdicts platform_policy_status_notes pr_number branch_name
 
 # ---------------------------------------------------------------------------
 # Area 11: Step 7b regression-label auto-restore (Option C, issue #805)


### PR DESCRIPTION
## Summary
- Calibrate Haystack mirror guidance against the live agent-doc surface map.
- Treat front-matter-only differences and absent `.cursor/skills` surfaces as advisory, not blocking.
- Preserve the advisory split in reviewer-loop summary output and add regression coverage.

## Self-review
- Reviewed `git diff develop...HEAD` for scope drift and stale markers.
- Confirmed the change stays within the approved #929 plan and smoke-test runbook.
- Verified the shared Haystack docs now describe the same mirror contract as the rule file.
- Validation: `bash scripts/development-workflow/tests/test-haystack-reviewer.sh`, `bash scripts/development-workflow/tests/test-pr-review-loop.sh`, `git diff --check`.

Closes #929