### PR TITLE
fix(workflow): allow skipped run-epic regression checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Run-epic skipped regression checks** (#955): allows delegated `/run-epic` merge gates to accept completed skipped or neutral label-gated regression checks while still blocking real failures, pending checks, and implementation PRs missing `ready-for-regression`.
 - **Haystack policy acknowledgements** (#890): labels policy-only Haystack human-review signals as explicit acknowledgements in reviewer-loop summaries while keeping concrete findings blocking.
 - **Reviewer-loop Haystack summaries** (#909): updates automated reviewer summaries on `needs_fixes` exits so active Haystack findings cannot be hidden behind stale clean summaries.
 - **Prepare-release Linear tracker completion** (#914): makes release post-merge cleanup derive shipped issue scope from the finalized changelog, fail closed when tracker scope or Linear completion is missing, and emit actionable Linear MCP/API handoff signals.

--- a/scripts/development-workflow/run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/run-epic-delegated-gate.sh
@@ -38,13 +38,18 @@ require_value() {
 
 load_input_json() {
   local file="$1"
+  local raw
   if [ ! -f "$file" ]; then
     error_exit "input file not found: $file"
   fi
   if [ ! -s "$file" ]; then
     error_exit "input file is empty: $file"
   fi
-  jq -c '.' "$file" 2>/dev/null || error_exit "input file is not valid JSON: $file"
+  raw="$(jq -c '.' "$file" 2>/dev/null)" || error_exit "input file is not valid JSON: $file"
+  if [ -z "$raw" ]; then
+    error_exit "input file is not valid JSON: $file"
+  fi
+  printf '%s\n' "$raw"
 }
 
 while [ "$#" -gt 0 ]; do
@@ -96,7 +101,8 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
       ((.state // "") | ascii_downcase) == "success"
     else
       (((.status // "") | ascii_downcase) == "completed" and
-       ((.conclusion // "") | ascii_downcase) == "success")
+       (((.conclusion // "") | ascii_downcase) as $conclusion |
+        $conclusion == "success" or $conclusion == "skipped" or $conclusion == "neutral"))
     end;
   def implementation_branch:
     (.pr.headRefName // "") | test("^(feature|fix|refactor|hotfix|backport/hotfix)/");

--- a/scripts/development-workflow/run-epic-risk-classifier.sh
+++ b/scripts/development-workflow/run-epic-risk-classifier.sh
@@ -98,6 +98,9 @@ normalize_fixture() {
   if ! raw="$(jq -c '.' "$file" 2>/dev/null)"; then
     error_exit "input file is not valid JSON: $file"
   fi
+  if [ -z "$raw" ]; then
+    error_exit "input file is not valid JSON: $file"
+  fi
 
   printf '%s\n' "$raw"
 }
@@ -161,10 +164,17 @@ check_status_is_success() {
   local status="$1"
   local conclusion="$2"
 
-  case "${status}:${conclusion}" in
-    COMPLETED:SUCCESS|completed:success) return 0 ;;
-    *) return 1 ;;
-  esac
+  status="$(printf '%s\n' "$status" | tr '[:upper:]' '[:lower:]')"
+  conclusion="$(printf '%s\n' "$conclusion" | tr '[:upper:]' '[:lower:]')"
+
+  if [ "$status" = "completed" ]; then
+    case "$conclusion" in
+      success|skipped|neutral) return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+
+  [ -z "$status" ] && [ "$conclusion" = "success" ]
 }
 
 collect_check_blockers() {

--- a/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
@@ -148,6 +148,8 @@ empty_file="$TMP_ROOT/empty.json"
 : > "$empty_file"
 malformed_file="$TMP_ROOT/malformed.json"
 printf '{"oops"\n' > "$malformed_file"
+whitespace_file="$TMP_ROOT/whitespace.json"
+printf ' \n\t\n' > "$whitespace_file"
 
 echo ""
 echo "=== Run epic delegated gate ==="
@@ -157,6 +159,7 @@ run_fails_contains "rejects_pr_mode" "Unknown option: --pr" "$GATE" --pr 42
 run_fails_contains "rejects_missing_fixture" "input file not found" "$GATE" --input "$missing_file"
 run_fails_contains "rejects_empty_fixture" "input file is empty" "$GATE" --input "$empty_file"
 run_fails_contains "rejects_malformed_fixture" "input file is not valid JSON" "$GATE" --input "$malformed_file"
+run_fails_contains "rejects_whitespace_fixture" "input file is not valid JSON" "$GATE" --input "$whitespace_file"
 
 clean_fixture="$(write_fixture clean)"
 run_test "merge_allowed_when_all_gates_clean" "merge_allowed" "$(decision_for "$clean_fixture")"
@@ -197,6 +200,18 @@ run_test "feature_pr_requires_regression_label" "blocked" "$(decision_for "$miss
 spec_without_regression_fixture="$(write_fixture spec-no-regression '.pr.headRefName = "spec/918-delegated-review-merge-loop" | .pr.labels = ["ready-for-human-review"]')"
 run_test "spec_pr_skips_regression_label" "merge_allowed" "$(decision_for "$spec_without_regression_fixture")"
 
+implementation_plan_skipped_fixture="$(write_fixture implementation-plan-skipped '.pr.headRefName = "implementation-plan/918-delegated-review-merge-loop" | .pr.labels = ["ready-for-human-review"] | .statusChecks += [{"name": "E2E regression (placeholder)", "status": "COMPLETED", "conclusion": "SKIPPED"}]')"
+run_test "implementation_plan_pr_allows_skipped_regression_check" "merge_allowed" "$(decision_for "$implementation_plan_skipped_fixture")"
+
+spec_neutral_fixture="$(write_fixture spec-neutral '.pr.headRefName = "spec/918-delegated-review-merge-loop" | .pr.labels = ["ready-for-human-review"] | .statusChecks += [{"name": "E2E regression (placeholder)", "status": "COMPLETED", "conclusion": "NEUTRAL"}]')"
+run_test "spec_pr_allows_neutral_regression_check" "merge_allowed" "$(decision_for "$spec_neutral_fixture")"
+
+implementation_skipped_missing_label_fixture="$(write_fixture implementation-skipped-missing-label '.pr.labels = ["ready-for-human-review"] | .statusChecks += [{"name": "E2E regression (placeholder)", "status": "COMPLETED", "conclusion": "SKIPPED"}]')"
+run_test "implementation_pr_still_requires_regression_label" "blocked" "$(decision_for "$implementation_skipped_missing_label_fixture")"
+
+implementation_skipped_with_label_fixture="$(write_fixture implementation-skipped-with-label '.statusChecks += [{"name": "E2E regression (placeholder)", "status": "COMPLETED", "conclusion": "SKIPPED"}]')"
+run_test "implementation_pr_with_regression_label_allows_skipped_check" "merge_allowed" "$(decision_for "$implementation_skipped_with_label_fixture")"
+
 setup_fixture="$(write_fixture setup '.pr.labels += ["needs-setup"]')"
 run_test "needs_setup_requires_human" "human_required" "$(decision_for "$setup_fixture")"
 
@@ -205,6 +220,17 @@ run_test "ci_failure_requires_fix" "fix_required" "$(decision_for "$ci_failure_f
 
 ci_in_progress_fixture="$(write_fixture ci-in-progress '.statusChecks[0].status = "IN_PROGRESS" | .statusChecks[0].conclusion = "SUCCESS"')"
 run_test "ci_in_progress_success_conclusion_requires_fix" "fix_required" "$(decision_for "$ci_in_progress_fixture")"
+
+for terminal_conclusion in FAILURE CANCELLED TIMED_OUT ACTION_REQUIRED STARTUP_FAILURE ""; do
+  fixture_suffix="${terminal_conclusion:-missing}"
+  terminal_fixture="$(write_fixture "terminal-${fixture_suffix}" ".statusChecks = [{\"name\": \"guard\", \"status\": \"COMPLETED\", \"conclusion\": \"${terminal_conclusion}\"}]")"
+  run_test "completed_${fixture_suffix}_check_requires_fix" "fix_required" "$(decision_for "$terminal_fixture")"
+done
+
+for pending_state in IN_PROGRESS QUEUED PENDING EXPECTED; do
+  pending_fixture="$(write_fixture "pending-${pending_state}" ".statusChecks = [{\"name\": \"guard\", \"status\": \"${pending_state}\", \"conclusion\": \"SUCCESS\"}]")"
+  run_test "${pending_state}_check_requires_fix" "fix_required" "$(decision_for "$pending_fixture")"
+done
 
 status_context_fixture="$(write_fixture status-context '.statusChecks = [{"name": "legacy", "state": "SUCCESS", "conclusion": "SUCCESS"}]')"
 run_test "status_context_success_is_terminal" "merge_allowed" "$(decision_for "$status_context_fixture")"

--- a/scripts/development-workflow/tests/test-run-epic-risk-classifier.sh
+++ b/scripts/development-workflow/tests/test-run-epic-risk-classifier.sh
@@ -325,6 +325,18 @@ spec_neutral_output="$(classify_fixture "$spec_neutral_fixture" low)"
 run_test "spec_neutral_regression_check_allowed" "low" "$(printf '%s\n' "$spec_neutral_output" | jq -r '.risk')"
 run_test "spec_neutral_regression_merge_permitted" "true" "$(printf '%s\n' "$spec_neutral_output" | jq -r '.merge_permitted')"
 
+state_only_success_fixture="$(write_fixture state-only-success '{
+  "pr_number": 7,
+  "merge_state": "CLEAN",
+  "labels": ["ready-for-human-review"],
+  "status_checks": [{"name": "legacy", "conclusion": "SUCCESS"}],
+  "changed_files": ["docs/README.md"],
+  "reviewer": {"status": "clean", "blocking_count": 0, "unresolved_blocking_threads": 0}
+}')"
+state_only_success_output="$(classify_fixture "$state_only_success_fixture" low)"
+run_test "empty_status_success_conclusion_allowed" "low" "$(printf '%s\n' "$state_only_success_output" | jq -r '.risk')"
+run_test "empty_status_success_conclusion_merge_permitted" "true" "$(printf '%s\n' "$state_only_success_output" | jq -r '.merge_permitted')"
+
 for terminal_conclusion in FAILURE CANCELLED TIMED_OUT ACTION_REQUIRED STARTUP_FAILURE ""; do
   fixture_suffix="${terminal_conclusion:-missing}"
   terminal_fixture="$(write_fixture "terminal-${fixture_suffix}" "{

--- a/scripts/development-workflow/tests/test-run-epic-risk-classifier.sh
+++ b/scripts/development-workflow/tests/test-run-epic-risk-classifier.sh
@@ -149,6 +149,8 @@ printf '{not-json\n' > "$TMP_ROOT/malformed.json"
 run_fails_contains "rejects_malformed_fixture" "not valid JSON" "$CLASSIFIER" --input "$TMP_ROOT/malformed.json"
 : > "$TMP_ROOT/empty.json"
 run_fails_contains "rejects_empty_fixture" "input file is empty" "$CLASSIFIER" --input "$TMP_ROOT/empty.json"
+printf ' \n\t\n' > "$TMP_ROOT/whitespace.json"
+run_fails_contains "rejects_whitespace_fixture" "not valid JSON" "$CLASSIFIER" --input "$TMP_ROOT/whitespace.json"
 
 low_fixture="$(write_fixture low '{
   "pr_number": 1,
@@ -290,6 +292,65 @@ incomplete_success_fixture="$(write_fixture incomplete-success '{
 }')"
 incomplete_success_output="$(classify_fixture "$incomplete_success_fixture" high)"
 run_test "incomplete_success_check_blocks" "blocked" "$(printf '%s\n' "$incomplete_success_output" | jq -r '.risk')"
+
+implementation_plan_skipped_fixture="$(write_fixture implementation-plan-skipped '{
+  "pr_number": 7,
+  "head": "implementation-plan/955-run-epic-skipped-regression-checks",
+  "merge_state": "CLEAN",
+  "labels": ["ready-for-human-review"],
+  "status_checks": [
+    {"name": "guard", "status": "COMPLETED", "conclusion": "SUCCESS"},
+    {"name": "E2E regression (placeholder)", "status": "COMPLETED", "conclusion": "SKIPPED"}
+  ],
+  "changed_files": ["docs/specs/developments/2026-06-15_run-epic-skipped-regression-checks/2_run-epic-skipped-regression-checks_implementation-plan.md"],
+  "reviewer": {"status": "clean", "blocking_count": 0, "unresolved_blocking_threads": 0}
+}')"
+implementation_plan_skipped_output="$(classify_fixture "$implementation_plan_skipped_fixture" low)"
+run_test "implementation_plan_skipped_regression_check_allowed" "low" "$(printf '%s\n' "$implementation_plan_skipped_output" | jq -r '.risk')"
+run_test "implementation_plan_skipped_regression_merge_permitted" "true" "$(printf '%s\n' "$implementation_plan_skipped_output" | jq -r '.merge_permitted')"
+
+spec_neutral_fixture="$(write_fixture spec-neutral '{
+  "pr_number": 7,
+  "head": "spec/955-run-epic-skipped-regression-checks",
+  "merge_state": "CLEAN",
+  "labels": ["ready-for-human-review"],
+  "status_checks": [
+    {"name": "guard", "status": "COMPLETED", "conclusion": "SUCCESS"},
+    {"name": "E2E regression (placeholder)", "status": "COMPLETED", "conclusion": "NEUTRAL"}
+  ],
+  "changed_files": ["docs/specs/developments/2026-06-15_run-epic-skipped-regression-checks/1_run-epic-skipped-regression-checks_specs.md"],
+  "reviewer": {"status": "clean", "blocking_count": 0, "unresolved_blocking_threads": 0}
+}')"
+spec_neutral_output="$(classify_fixture "$spec_neutral_fixture" low)"
+run_test "spec_neutral_regression_check_allowed" "low" "$(printf '%s\n' "$spec_neutral_output" | jq -r '.risk')"
+run_test "spec_neutral_regression_merge_permitted" "true" "$(printf '%s\n' "$spec_neutral_output" | jq -r '.merge_permitted')"
+
+for terminal_conclusion in FAILURE CANCELLED TIMED_OUT ACTION_REQUIRED STARTUP_FAILURE ""; do
+  fixture_suffix="${terminal_conclusion:-missing}"
+  terminal_fixture="$(write_fixture "terminal-${fixture_suffix}" "{
+    \"pr_number\": 7,
+    \"merge_state\": \"CLEAN\",
+    \"labels\": [\"ready-for-human-review\"],
+    \"status_checks\": [{\"name\": \"guard\", \"status\": \"COMPLETED\", \"conclusion\": \"${terminal_conclusion}\"}],
+    \"changed_files\": [\"docs/README.md\"],
+    \"reviewer\": {\"status\": \"clean\", \"blocking_count\": 0, \"unresolved_blocking_threads\": 0}
+  }")"
+  terminal_output="$(classify_fixture "$terminal_fixture" high)"
+  run_test "completed_${fixture_suffix}_check_blocks" "blocked" "$(printf '%s\n' "$terminal_output" | jq -r '.risk')"
+done
+
+for pending_state in IN_PROGRESS QUEUED PENDING EXPECTED; do
+  pending_fixture="$(write_fixture "pending-${pending_state}" "{
+    \"pr_number\": 7,
+    \"merge_state\": \"CLEAN\",
+    \"labels\": [\"ready-for-human-review\"],
+    \"status_checks\": [{\"name\": \"guard\", \"status\": \"${pending_state}\", \"conclusion\": \"SUCCESS\"}],
+    \"changed_files\": [\"docs/README.md\"],
+    \"reviewer\": {\"status\": \"clean\", \"blocking_count\": 0, \"unresolved_blocking_threads\": 0}
+  }")"
+  pending_output="$(classify_fixture "$pending_fixture" high)"
+  run_test "${pending_state}_check_blocks" "blocked" "$(printf '%s\n' "$pending_output" | jq -r '.risk')"
+done
 
 dedupe_checks_fixture="$(write_fixture dedupe-checks '{
   "pr_number": 8,


### PR DESCRIPTION
## Summary
- Align delegated run-epic CI success predicates with the normal PR readiness policy by accepting completed `success`, `skipped`, and `neutral` checks.
- Keep incomplete, failed, cancelled, timed-out, action-required, startup-failed, missing, and ambiguous checks blocking.
- Add fixtures for implementation-plan/spec PRs with skipped or neutral label-gated regression checks, implementation PR regression-label enforcement, whitespace-only input rejection, and negative CI states.

## Test Plan
- `bash scripts/development-workflow/tests/test-run-epic-risk-classifier.sh`
- `bash scripts/development-workflow/tests/test-run-epic-delegated-gate.sh`
- `for f in scripts/development-workflow/tests/test-run-epic-*.sh; do bash "$f"; done`
- `shellcheck --severity=warning scripts/development-workflow/run-epic-risk-classifier.sh scripts/development-workflow/run-epic-delegated-gate.sh scripts/development-workflow/tests/test-run-epic-risk-classifier.sh scripts/development-workflow/tests/test-run-epic-delegated-gate.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`

## CHANGELOG Preview
- Fixed: Run-epic skipped regression checks (#955) allows delegated `/run-epic` merge gates to accept completed skipped or neutral label-gated regression checks while still blocking real failures, pending checks, and implementation PRs missing `ready-for-regression`.

## Test Harness Coverage Checklist
- Empty / zero-length input: covered by existing empty fixture tests in both harnesses.
- Whitespace-only input: added whitespace-only JSON fixture rejection tests in both harnesses.
- Boundary values: covered by completed success/skipped/neutral allowed cases and completed failure/cancelled/timed-out/action-required/startup-failed/missing plus pending state blockers.
- Missing / absent environment variables: not applicable; modified harness paths use local fixtures and mock `gh` with explicit temp state, not required env inputs.
- Concurrent / parallel execution: not applicable; each harness uses an isolated `mktemp -d` fixture root and local mock binaries.
- Negative assertions: added and retained explicit blocking assertions for failed terminal conclusions, pending states, missing regression label, malformed/empty/whitespace input, and no mutating gh commands.
- Single EXIT trap: verified each modified harness has a single cleanup trap.
- Variable-length quoting safety: temp-root paths and fixture paths are consistently quoted in modified paths.
- BASH_SOURCE / HARNESS_MODE guard placement: not applicable; these harnesses execute directly and do not expose sourced-mode functions.
- Sourced-function ordering: not applicable; modified harnesses invoke scripts rather than sourcing changed script functions.

## Pre-submission self-review
Pre-submission self-review: stale markers — none; caller consistency — verified between risk classifier and delegated gate predicates; coverage — issue #955 acceptance criteria addressed, including non-implementation skipped checks, implementation regression-label enforcement, negative CI states, and existing run-epic regression tests.