### PR TITLE
fix(workflow): skip reviewer loop on release/hotfix PRs (#960)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Release PR reviewer loop skip** (#960): `pr-review-loop.sh` now exits immediately with `RESULT=skipped` for release and hotfix PRs targeting `main`, eliminating the ~40-minute poll timeout that added no review value. Release readiness uses a dedicated artifact-validation and CI path instead of external reviewer tools.
+
 ## [0.31.0] - 2026-06-15
 
 ### Added

--- a/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
+++ b/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
@@ -112,12 +112,9 @@ Opening PRs is **not** a terminal condition. Continue with Step 7 for the produc
 
 Apply only to the **release PR that targets `main`**. Do **not** apply the regression-label requirement to the backport PR to `develop` (that PR may still run other CI; this step scopes expensive label-gated e2e/regression to production).
 
-Canonical loop semantics match [`91-orchestrate-work-protocol.md`](91-orchestrate-work-protocol.md) (Steps 7, 7b, 8) and [`93-automated-reviewer-loop-protocol.md`](93-automated-reviewer-loop-protocol.md) for standalone reviewer runs. Note: release PRs use a simplified readiness flow (Step 7.5 applies `ready-for-human-review` directly) and do not run Protocol 91's Step 8a/8b label checklist. Prefer the repository helpers:
+**No external reviewer tools for release PRs.** External automated reviewers (Haystack, CodeRabbit, PR-Agent, Claude Code Action, etc.) are not required for release PRs and must not be waited on. Every change in a release PR was already reviewed when its feature/fix PR merged into `develop`. Running `pr-review-loop.sh` on a release PR automatically exits with `RESULT=skipped` (release PR guard fires) — treat that as a clean non-blocking result and proceed directly to release artifact validation and CI.
 
-```bash
-./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch release/v[X.Y.Z]
-./scripts/development-workflow/pr-ci-loop.sh <pr_number>
-```
+Note: release PRs use a simplified readiness flow (Step 7.5 applies `ready-for-human-review` directly) and do not run Protocol 91's Step 8a/8b label checklist.
 
 ### 7.1 Resolve the production PR number
 
@@ -129,19 +126,15 @@ gh pr list --head "release/v[X.Y.Z]" --base main --state open --json number --jq
 
 If multiple or zero matches, stop and resolve with the human.
 
-### 7.2 Pre-flight (optional but recommended)
+### 7.2 Validate release artifacts
 
-Per `93-automated-reviewer-loop-protocol.md`, check for existing unresolved blocking review comments before re-running automation.
+Before applying any labels or starting CI, confirm the release artifacts are correct:
 
-### 7.3 Automated reviewer loop (Step 7)
+1. **CHANGELOG version header**: verify `## [X.Y.Z] - YYYY-MM-DD` is present and the version matches the release target.
+2. **Link definitions**: confirm the `[Unreleased]` and `[X.Y.Z]` reference-style link definitions at the bottom of `CHANGELOG.md` have been updated.
+3. **Version bump**: if a manifest file (`package.json`, `pyproject.toml`, etc.) is versioned, verify the bump is present.
 
-Run `pr-review-loop.sh` to completion **before** starting the CI loop. Do not run reviewer and CI in parallel.
-
-**Script-coverage requirement**: Before running the reviewer loop, confirm that
-CodeRabbit (when available) is configured to review all files in
-`scripts/development-workflow/` that were modified since the last release. If
-CodeRabbit is not installed, manually review changed workflow scripts for logic
-bugs before labeling the production PR `ready-for-human-review`.
+If any artifact is missing or incorrect, fix it on the release branch, push, and verify again before continuing.
 
 **Downstream script-bug review**: Before labeling the production PR
 `ready-for-human-review`, search for open workflow-framework GitHub issues that
@@ -163,18 +156,9 @@ gh issue list --label workflow --state open --limit 200
 If any known script bugs remain open and affect code in this release, address them
 in the release branch or document the decision to defer with a comment on the issue.
 
-Interpret `RESULT` from the script output:
+### 7.3 Regression label (release / `main` PR only)
 
-| Result        | Action                                                                                                                                                                                                                       |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `clean`       | Continue to Step 7.4 (regression label).                                                                                                                                                                                     |
-| `skipped`     | No review platforms configured in `.ai-dev-workflow.yaml`; continue to Step 7.4 and document that external review was skipped.                                                                                               |
-| `needs_fixes` | Address blocking findings (commit and push to the release branch), then re-run Step 7.3 from the top. Follow fixer guidance in `91` (e.g. `code-reviewer` for code changes). Do not hand off while blocking findings remain. |
-| `escalate`    | Stop and escalate to a human; do not mark the release as merge-ready.                                                                                                                                                        |
-
-### 7.4 Regression label (release / `main` PR only)
-
-After Step 7.3 ends with `clean` or `skipped`, apply the `ready-for-regression` label to the **production PR only** so label-gated e2e/regression runs (see [`integrations/e2e-regression.md`](../integrations/e2e-regression.md) and `.github/workflows/e2e-regression.yml`).
+Apply the `ready-for-regression` label to the **production PR only** so label-gated e2e/regression runs (see [`integrations/e2e-regression.md`](../integrations/e2e-regression.md) and `.github/workflows/e2e-regression.yml`).
 
 ```bash
 gh pr edit <pr_number> --add-label "ready-for-regression"
@@ -182,17 +166,21 @@ gh pr edit <pr_number> --add-label "ready-for-regression"
 
 This mirrors Step 7b in `91` for implementation PRs, but scoped here to the release PR targeting `main`.
 
-### 7.5 CI loop (Step 8)
+### 7.4 CI loop
 
-Run `pr-ci-loop.sh` and wait until required checks settle (including the e2e/regression check when configured).
+Run `pr-ci-loop.sh` and wait until required checks settle (including the e2e/regression check when configured):
+
+```bash
+./scripts/development-workflow/pr-ci-loop.sh <pr_number>
+```
 
 | Result    | Action                                                                                                                                                            |
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `green`   | Apply `ready-for-human-review` per [`92-pr-readiness-signal-protocol.md`](92-pr-readiness-signal-protocol.md); the production PR is ready for human merge review. |
-| `red`     | Apply `needs-fixes`, fix, push, then return to Step 7.3 (reviewer) and repeat through Step 7.5.                                                                   |
+| `red`     | Apply `needs-fixes`, fix, push, then return to Step 7.2 (artifact validation) and repeat through Step 7.4.                                                        |
 | `timeout` | Escalate to a human; do not apply `ready-for-human-review`.                                                                                                       |
 
-### 7.6 Backport PR (`develop` target)
+### 7.5 Backport PR (`develop` target)
 
 Do **not** require `ready-for-regression` on the backport PR as part of this protocol. It may proceed on its own CI; merge order remains: **merge `main` first**, then backport.
 

--- a/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
+++ b/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
@@ -114,7 +114,7 @@ Apply only to the **release PR that targets `main`**. Do **not** apply the regre
 
 **No external reviewer tools for release PRs.** External automated reviewers (Haystack, CodeRabbit, PR-Agent, Claude Code Action, etc.) are not required for release PRs and must not be waited on. Every change in a release PR was already reviewed when its feature/fix PR merged into `develop`. Running `pr-review-loop.sh` on a release PR automatically exits with `RESULT=skipped` (release PR guard fires) — treat that as a clean non-blocking result and proceed directly to release artifact validation and CI.
 
-Note: release PRs use a simplified readiness flow (Step 7.5 applies `ready-for-human-review` directly) and do not run Protocol 91's Step 8a/8b label checklist.
+Note: release PRs use a simplified readiness flow (Step 7.4 applies `ready-for-human-review` directly after CI is green) and do not run Protocol 91's Step 8a/8b label checklist.
 
 ### 7.1 Resolve the production PR number
 

--- a/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
+++ b/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
@@ -114,7 +114,7 @@ Apply only to the **release PR that targets `main`**. Do **not** apply the regre
 
 **No external reviewer tools for release PRs.** External automated reviewers (Haystack, CodeRabbit, PR-Agent, Claude Code Action, etc.) are not required for release PRs and must not be waited on. Every change in a release PR was already reviewed when its feature/fix PR merged into `develop`. Running `pr-review-loop.sh` on a release PR automatically exits with `RESULT=skipped` (release PR guard fires) — treat that as a clean non-blocking result and proceed directly to release artifact validation and CI.
 
-Note: release PRs use a simplified readiness flow (Step 7.4 applies `ready-for-human-review` directly after CI is green) and do not run Protocol 91's Step 8a/8b label checklist.
+Note: release PRs use a simplified readiness flow (the CI loop step applies `ready-for-human-review` directly after CI is green) and do not run Protocol 91's Step 8a/8b label checklist.
 
 ### 7.1 Resolve the production PR number
 
@@ -177,7 +177,7 @@ Run `pr-ci-loop.sh` and wait until required checks settle (including the e2e/reg
 | Result    | Action                                                                                                                                                            |
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `green`   | Apply `ready-for-human-review` per [`92-pr-readiness-signal-protocol.md`](92-pr-readiness-signal-protocol.md); the production PR is ready for human merge review. |
-| `red`     | Apply `needs-fixes`, fix, push, then return to Step 7.2 (artifact validation) and repeat through Step 7.4.                                                        |
+| `red`     | Apply `needs-fixes`, fix, push, then return to the artifact validation step (§7.2) and repeat through the CI loop step (§7.4).                                                        |
 | `timeout` | Escalate to a human; do not apply `ready-for-human-review`.                                                                                                       |
 
 ### 7.5 Backport PR (`develop` target)

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -13,6 +13,8 @@ This protocol is **standalone**: it can be invoked for any open PR (or set of PR
 - You want to advance one or more open PRs through automated review and CI without running full workflow discovery
 - After pushing fixes to a PR, to re-run the loop until clean or escalate
 
+> **Release PR exemption**: The automated reviewer loop applies only to PRs that target `develop` (feature, fix, refactor, hotfix backport). Release PRs (`release/*` or `hotfix/*` branches targeting `main`) are **exempt** — `pr-review-loop.sh` automatically exits with `RESULT=skipped` and `REASON=release_pr` for these PRs. All changes in a release PR were already reviewed when their individual feature/fix PRs merged into `develop`. For release PR readiness, follow [`05-prepare-release-protocol.md`](05-prepare-release-protocol.md) Step 7 instead.
+
 ---
 
 ## Scope: which PR(s)

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -13,7 +13,7 @@ This protocol is **standalone**: it can be invoked for any open PR (or set of PR
 - You want to advance one or more open PRs through automated review and CI without running full workflow discovery
 - After pushing fixes to a PR, to re-run the loop until clean or escalate
 
-> **Release PR exemption**: The automated reviewer loop applies only to PRs that target `develop` (feature, fix, refactor, hotfix backport). Release PRs (`release/*` or `hotfix/*` branches targeting `main`) are **exempt** — `pr-review-loop.sh` automatically exits with `RESULT=skipped` and `REASON=release_pr` for these PRs. All changes in a release PR were already reviewed when their individual feature/fix PRs merged into `develop`. For release PR readiness, follow [`05-prepare-release-protocol.md`](05-prepare-release-protocol.md) Step 7 instead.
+> **Release PR exemption**: The automated reviewer loop applies only to develop-targeting PRs (feature, fix, refactor, hotfix backport). PRs whose head branch matches `release/*` or `hotfix/*` are **exempt** — `pr-review-loop.sh` automatically exits with `RESULT=skipped` and `REASON=release_pr` for these PRs. All changes in a release PR were already reviewed when their individual feature/fix PRs merged into `develop`. For release PR readiness, follow [`05-prepare-release-protocol.md`](05-prepare-release-protocol.md) Step 7 instead.
 
 ---
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4072,6 +4072,65 @@ if [ -n "$repo_selector" ]; then
   print_kv REPO "$target_github_repo"
 fi
 
+# --- Release PR early-exit guard ---
+# Release PRs (release/* -> main) and hotfix PRs (hotfix/* -> main) carry
+# large diffs that were already reviewed when each feature/fix PR merged into
+# develop. Running external reviewer tools (Haystack, CodeRabbit, PR-Agent,
+# etc.) on these PRs produces no review value and wastes the poll timeout
+# (historically ~40 min for large-diff Haystack waits). Skip the reviewer
+# loop entirely for these PR types and return RESULT=skipped so callers treat
+# the result as a clean non-blocking outcome.
+#
+# Detection criteria (OR logic — either condition triggers the skip):
+#   1. Head branch matches release/* or hotfix/*
+#   2. Base branch is main (any PR targeting main skips the reviewer loop)
+#
+# When --branch was passed on the command line, use it for criterion 1 without
+# an additional API call. When --branch was not passed, fetch both head and
+# base from the PR in a single gh pr view call.
+_release_guard_head="${branch_name:-}"
+_release_guard_base=""
+if [ -z "$_release_guard_head" ]; then
+  set +e
+  _release_guard_pr_json="$(gh pr view "$pr_number" --json headRefName,baseRefName 2>/dev/null)"
+  _release_guard_pr_exit=$?
+  set -e
+  if [ "$_release_guard_pr_exit" -eq 0 ] && [ -n "$_release_guard_pr_json" ]; then
+    _release_guard_head="$(printf '%s\n' "$_release_guard_pr_json" | jq -r '.headRefName // ""')"
+    _release_guard_base="$(printf '%s\n' "$_release_guard_pr_json" | jq -r '.baseRefName // ""')"
+    # Populate branch_name from the fetched value so later blocks do not need
+    # to re-fetch it (mirrors the existing pattern in the platforms block).
+    if [ -z "$branch_name" ] && [ -n "$_release_guard_head" ]; then
+      branch_name="$_release_guard_head"
+    fi
+  fi
+else
+  # --branch was provided; fetch only the base branch for criterion 2.
+  set +e
+  _release_guard_base="$(gh pr view "$pr_number" --json baseRefName --jq '.baseRefName // ""' 2>/dev/null)" || _release_guard_base=""
+  set -e
+fi
+
+_is_release_pr=0
+case "$_release_guard_head" in
+  release/*|hotfix/*) _is_release_pr=1 ;;
+esac
+if [ "$_release_guard_base" = "main" ]; then
+  _is_release_pr=1
+fi
+
+if [ "$_is_release_pr" -eq 1 ]; then
+  echo "Release PR detected — reviewer loop skipped." >&2
+  echo "Review happens on develop-targeting feature/fix PRs, not on release/* or hotfix/* branches or PRs targeting main." >&2
+  echo "Release readiness path: validate release artifacts → run pr-ci-loop.sh → apply ready-for-human-review when CI is green." >&2
+  print_kv RESULT skipped
+  print_kv REASON release_pr
+  print_kv PR_NUMBER "$pr_number"
+  [ -n "$branch_name" ] && print_kv BRANCH "$branch_name"
+  exit 0
+fi
+# --- End release PR early-exit guard ---
+
 if [ "${#platforms[@]}" -eq 0 ]; then
   # Resolve config from the PR's target branch so platform coverage is
   # consistent regardless of the operator's local checkout state (#756).

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3963,11 +3963,29 @@ _check_release_pr_guard() {
   guard_head="$given_branch"
 
   if [ -z "$guard_head" ]; then
+    # Fetch the head branch from GitHub. Steps are separated so that gh failures
+    # and jq parse failures are each caught explicitly.
+    #
+    # Fail-safe design: if the branch cannot be determined (gh failure, empty
+    # JSON, or jq error), guard_head stays empty. An empty guard_head does NOT
+    # match release/* or hotfix/*, so the guard does not fire and the reviewer
+    # loop runs normally. For this SKIP guard (not a BLOCK guard), failing open
+    # means running the reviewer loop — the safe default, not a dangerous one.
+    local _gh_json=""
+    local _gh_exit=0
     set +e
-    guard_head="$(gh pr view "$pr_num" --json headRefName --jq '.headRefName // ""' 2>/dev/null)" || guard_head=""
+    _gh_json="$(gh pr view "$pr_num" --json headRefName 2>/dev/null)"
+    _gh_exit=$?
     set -e
-    # On fetch failure, guard_head stays empty — no branch match, guard does
-    # not fire (fail-safe: run the reviewer loop rather than silently skipping).
+    if [ "$_gh_exit" -eq 0 ] && [ -n "$_gh_json" ]; then
+      local _jq_exit=0
+      set +e
+      guard_head="$(printf '%s\n' "$_gh_json" | jq -r '.headRefName // ""' 2>/dev/null)"
+      _jq_exit=$?
+      set -e
+      [ "$_jq_exit" -ne 0 ] && guard_head=""
+    fi
+    # guard_head remains empty on any failure — guard does not fire.
   fi
 
   case "$guard_head" in

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3938,50 +3938,43 @@ doc_branch_default_poll_interval() {
 # the automated reviewer loop. Returns 0 (guard fires → skip) or 1 (guard
 # does not fire → continue normally).
 #
+# Detection is based exclusively on the head branch name:
+#   release/* — release PR (release/vX.Y.Z → main or develop backport)
+#   hotfix/*  — hotfix PR (hotfix/vX.Y.Z → main)
+#
+# Relying on the head branch name (not base branch) avoids false-positive
+# matches for non-release PRs that might target main outside the standard
+# gitflow workflow. In this workflow, all release and hotfix PRs use the
+# release/* or hotfix/* prefix by convention.
+#
 # Output (stdout, key=value lines):
 #   RELEASE_GUARD_HEAD=<head branch or empty>
-#   RELEASE_GUARD_BASE=<base branch or empty>
 #   RELEASE_GUARD_FIRED=0|1
 #
 # When <branch_name> is provided, it is used directly for head-branch matching
-# without a network call. When omitted, both head and base are fetched from the
-# PR in a single gh pr view call.
+# without a network call. When omitted, the head branch is fetched from the PR.
 # ---------------------------------------------------------------------------
 _check_release_pr_guard() {
   local pr_num="$1"
   local given_branch="${2:-}"
   local guard_head=""
-  local guard_base=""
   local is_release=0
-  local pr_json=""
-  local pr_exit=0
 
   guard_head="$given_branch"
 
   if [ -z "$guard_head" ]; then
     set +e
-    pr_json="$(gh pr view "$pr_num" --json headRefName,baseRefName 2>/dev/null)"
-    pr_exit=$?
+    guard_head="$(gh pr view "$pr_num" --json headRefName --jq '.headRefName // ""' 2>/dev/null)" || guard_head=""
     set -e
-    if [ "$pr_exit" -eq 0 ] && [ -n "$pr_json" ]; then
-      guard_head="$(printf '%s\n' "$pr_json" | jq -re '.headRefName // ""' 2>/dev/null)" || guard_head=""
-      guard_base="$(printf '%s\n' "$pr_json" | jq -re '.baseRefName // ""' 2>/dev/null)" || guard_base=""
-    fi
-  else
-    set +e
-    guard_base="$(gh pr view "$pr_num" --json baseRefName --jq '.baseRefName // ""' 2>/dev/null)" || guard_base=""
-    set -e
+    # On fetch failure, guard_head stays empty — no branch match, guard does
+    # not fire (fail-safe: run the reviewer loop rather than silently skipping).
   fi
 
   case "$guard_head" in
     release/*|hotfix/*) is_release=1 ;;
   esac
-  if [ "$guard_base" = "main" ]; then
-    is_release=1
-  fi
 
   printf 'RELEASE_GUARD_HEAD=%s\n' "$guard_head"
-  printf 'RELEASE_GUARD_BASE=%s\n' "$guard_base"
   printf 'RELEASE_GUARD_FIRED=%s\n' "$is_release"
 
   if [ "$is_release" -eq 1 ]; then
@@ -4140,9 +4133,7 @@ fi
 # loop entirely for these PR types and return RESULT=skipped so callers treat
 # the result as a clean non-blocking outcome.
 #
-# Detection criteria (OR logic — either condition triggers the skip):
-#   1. Head branch matches release/* or hotfix/*
-#   2. Base branch is main (any PR targeting main skips the reviewer loop)
+# Detection: head branch matches release/* or hotfix/*
 _release_guard_output=""
 set +e
 _release_guard_output="$(_check_release_pr_guard "$pr_number" "${branch_name:-}")"
@@ -4150,7 +4141,6 @@ _release_guard_fired=$?
 set -e
 
 _release_guard_head="$(printf '%s\n' "$_release_guard_output" | awk -F= '/^RELEASE_GUARD_HEAD=/{sub(/^[^=]*=/,""); print; exit}')"
-_release_guard_base="$(printf '%s\n' "$_release_guard_output" | awk -F= '/^RELEASE_GUARD_BASE=/{sub(/^[^=]*=/,""); print; exit}')"
 
 # Propagate the fetched head branch to branch_name so later blocks do not
 # need to re-fetch it (mirrors the existing pattern in the platforms block).
@@ -4160,7 +4150,7 @@ fi
 
 if [ "$_release_guard_fired" -eq 0 ]; then
   echo "Release PR detected — reviewer loop skipped." >&2
-  echo "Review happens on develop-targeting feature/fix PRs, not on release/* or hotfix/* branches or PRs targeting main." >&2
+  echo "Review happens on develop-targeting feature/fix PRs, not on release/* or hotfix/* branches." >&2
   echo "Release readiness path: validate release artifacts → run pr-ci-loop.sh → apply ready-for-human-review when CI is green." >&2
   print_kv RESULT skipped
   print_kv REASON release_pr

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3931,6 +3931,65 @@ doc_branch_default_poll_interval() {
   printf '%s\n' "$interval"
 }
 
+# ---------------------------------------------------------------------------
+# _check_release_pr_guard <pr_number> [<branch_name>]
+#
+# Determines whether the given PR is a release or hotfix PR that should skip
+# the automated reviewer loop. Returns 0 (guard fires → skip) or 1 (guard
+# does not fire → continue normally).
+#
+# Output (stdout, key=value lines):
+#   RELEASE_GUARD_HEAD=<head branch or empty>
+#   RELEASE_GUARD_BASE=<base branch or empty>
+#   RELEASE_GUARD_FIRED=0|1
+#
+# When <branch_name> is provided, it is used directly for head-branch matching
+# without a network call. When omitted, both head and base are fetched from the
+# PR in a single gh pr view call.
+# ---------------------------------------------------------------------------
+_check_release_pr_guard() {
+  local pr_num="$1"
+  local given_branch="${2:-}"
+  local guard_head=""
+  local guard_base=""
+  local is_release=0
+  local pr_json=""
+  local pr_exit=0
+
+  guard_head="$given_branch"
+
+  if [ -z "$guard_head" ]; then
+    set +e
+    pr_json="$(gh pr view "$pr_num" --json headRefName,baseRefName 2>/dev/null)"
+    pr_exit=$?
+    set -e
+    if [ "$pr_exit" -eq 0 ] && [ -n "$pr_json" ]; then
+      guard_head="$(printf '%s\n' "$pr_json" | jq -re '.headRefName // ""' 2>/dev/null)" || guard_head=""
+      guard_base="$(printf '%s\n' "$pr_json" | jq -re '.baseRefName // ""' 2>/dev/null)" || guard_base=""
+    fi
+  else
+    set +e
+    guard_base="$(gh pr view "$pr_num" --json baseRefName --jq '.baseRefName // ""' 2>/dev/null)" || guard_base=""
+    set -e
+  fi
+
+  case "$guard_head" in
+    release/*|hotfix/*) is_release=1 ;;
+  esac
+  if [ "$guard_base" = "main" ]; then
+    is_release=1
+  fi
+
+  printf 'RELEASE_GUARD_HEAD=%s\n' "$guard_head"
+  printf 'RELEASE_GUARD_BASE=%s\n' "$guard_base"
+  printf 'RELEASE_GUARD_FIRED=%s\n' "$is_release"
+
+  if [ "$is_release" -eq 1 ]; then
+    return 0
+  fi
+  return 1
+}
+
 # Skip the main execution block when sourced in test-harness mode.
 # All function definitions above (including normalize_platform_verdict,
 # append_compare_metrics_row, and restore_regression_label_if_missing) are
@@ -4084,49 +4143,29 @@ fi
 # Detection criteria (OR logic — either condition triggers the skip):
 #   1. Head branch matches release/* or hotfix/*
 #   2. Base branch is main (any PR targeting main skips the reviewer loop)
-#
-# When --branch was passed on the command line, use it for criterion 1 without
-# an additional API call. When --branch was not passed, fetch both head and
-# base from the PR in a single gh pr view call.
-_release_guard_head="${branch_name:-}"
-_release_guard_base=""
-if [ -z "$_release_guard_head" ]; then
-  set +e
-  _release_guard_pr_json="$(gh pr view "$pr_number" --json headRefName,baseRefName 2>/dev/null)"
-  _release_guard_pr_exit=$?
-  set -e
-  if [ "$_release_guard_pr_exit" -eq 0 ] && [ -n "$_release_guard_pr_json" ]; then
-    _release_guard_head="$(printf '%s\n' "$_release_guard_pr_json" | jq -r '.headRefName // ""')"
-    _release_guard_base="$(printf '%s\n' "$_release_guard_pr_json" | jq -r '.baseRefName // ""')"
-    # Populate branch_name from the fetched value so later blocks do not need
-    # to re-fetch it (mirrors the existing pattern in the platforms block).
-    if [ -z "$branch_name" ] && [ -n "$_release_guard_head" ]; then
-      branch_name="$_release_guard_head"
-    fi
-  fi
-else
-  # --branch was provided; fetch only the base branch for criterion 2.
-  set +e
-  _release_guard_base="$(gh pr view "$pr_number" --json baseRefName --jq '.baseRefName // ""' 2>/dev/null)" || _release_guard_base=""
-  set -e
+_release_guard_output=""
+set +e
+_release_guard_output="$(_check_release_pr_guard "$pr_number" "${branch_name:-}")"
+_release_guard_fired=$?
+set -e
+
+_release_guard_head="$(printf '%s\n' "$_release_guard_output" | awk -F= '/^RELEASE_GUARD_HEAD=/{sub(/^[^=]*=/,""); print; exit}')"
+_release_guard_base="$(printf '%s\n' "$_release_guard_output" | awk -F= '/^RELEASE_GUARD_BASE=/{sub(/^[^=]*=/,""); print; exit}')"
+
+# Propagate the fetched head branch to branch_name so later blocks do not
+# need to re-fetch it (mirrors the existing pattern in the platforms block).
+if [ -z "$branch_name" ] && [ -n "$_release_guard_head" ]; then
+  branch_name="$_release_guard_head"
 fi
 
-_is_release_pr=0
-case "$_release_guard_head" in
-  release/*|hotfix/*) _is_release_pr=1 ;;
-esac
-if [ "$_release_guard_base" = "main" ]; then
-  _is_release_pr=1
-fi
-
-if [ "$_is_release_pr" -eq 1 ]; then
+if [ "$_release_guard_fired" -eq 0 ]; then
   echo "Release PR detected — reviewer loop skipped." >&2
   echo "Review happens on develop-targeting feature/fix PRs, not on release/* or hotfix/* branches or PRs targeting main." >&2
   echo "Release readiness path: validate release artifacts → run pr-ci-loop.sh → apply ready-for-human-review when CI is green." >&2
   print_kv RESULT skipped
   print_kv REASON release_pr
   print_kv PR_NUMBER "$pr_number"
-  [ -n "$branch_name" ] && print_kv BRANCH "$branch_name"
+  print_kv BRANCH "${branch_name:-}"
   exit 0
 fi
 # --- End release PR early-exit guard ---

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4156,6 +4156,9 @@ if [ "$_release_guard_fired" -eq 0 ]; then
   print_kv REASON release_pr
   print_kv PR_NUMBER "$pr_number"
   print_kv BRANCH "${branch_name:-}"
+  # Remove any stale reviewer-failed label left from a prior failed run so the
+  # PR is not misleadingly labeled after a clean release-guard skip exit.
+  sync_reviewer_failed_label "$pr_number" 0
   exit 0
 fi
 # --- End release PR early-exit guard ---

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1850,12 +1850,11 @@ _guard_out="$(_check_release_pr_guard "104" "fix/some-fix")" || _guard_exit=$?
 run_test "release_guard_fix_no_fire" "RELEASE_GUARD_FIRED=0" \
   "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
 
-# Test 14.5: no --branch provided; head branch fetched from PR via jq
-# The mock returns MOCK_GH_OUTPUT for the default case. The function calls
-# gh pr view with --json headRefName --jq '.headRefName // ""' which the mock
-# does not apply jq to — it returns MOCK_GH_OUTPUT verbatim. Set it to the
-# expected jq-filtered value: the plain branch name string.
-export MOCK_GH_OUTPUT='release/v2.0.0'
+# Test 14.5: no --branch provided; head branch fetched from PR, parsed via jq.
+# The mock returns MOCK_GH_OUTPUT for the default gh pr view call. The function
+# now calls gh pr view WITHOUT --jq and then pipes to jq itself, so the mock
+# must return valid JSON rather than a pre-filtered plain branch name.
+export MOCK_GH_OUTPUT='{"headRefName":"release/v2.0.0"}'
 _guard_out=""
 _guard_exit=0
 _guard_out="$(_check_release_pr_guard "105")" || _guard_exit=$?
@@ -1865,8 +1864,9 @@ run_test "release_guard_fetched_head_value" "RELEASE_GUARD_HEAD=release/v2.0.0" 
   "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_HEAD=")"
 export MOCK_GH_OUTPUT='[]'
 
-# Test 14.6: no --branch provided; gh pr view failure — guard does not fire
-# (fail-safe: run the reviewer loop rather than silently skipping)
+# Test 14.6: no --branch provided; gh pr view failure — guard does not fire.
+# Fail-safe design: a SKIP guard that can't determine the branch defaults to
+# NOT firing, so the reviewer loop runs normally (fail-open is safe here).
 export MOCK_GH_EXIT=1
 export MOCK_GH_OUTPUT=''
 _guard_out=""
@@ -1878,7 +1878,118 @@ run_test "release_guard_fetch_failure_exit1" "1" "$_guard_exit"
 unset MOCK_GH_EXIT
 export MOCK_GH_OUTPUT='[]'
 
+# Test 14.7: no --branch provided; gh succeeds but jq parse fails (malformed
+# JSON) — guard does not fire (fail-safe).
+export MOCK_GH_OUTPUT='not-valid-json'
+_guard_out=""
+_guard_exit=1
+_guard_out="$(_check_release_pr_guard "107")" || _guard_exit=$?
+run_test "release_guard_jq_parse_fail_no_fire" "RELEASE_GUARD_FIRED=0" \
+  "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
+run_test "release_guard_jq_parse_fail_exit1" "1" "$_guard_exit"
+export MOCK_GH_OUTPUT='[]'
+
+# Test 14.8: no --branch provided; gh succeeds with null headRefName field —
+# guard does not fire (null collapses to empty string via jq // "").
+export MOCK_GH_OUTPUT='{"headRefName":null}'
+_guard_out=""
+_guard_exit=1
+_guard_out="$(_check_release_pr_guard "108")" || _guard_exit=$?
+run_test "release_guard_null_head_no_fire" "RELEASE_GUARD_FIRED=0" \
+  "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
+run_test "release_guard_null_head_exit1" "1" "$_guard_exit"
+export MOCK_GH_OUTPUT='[]'
+
 unset _guard_out _guard_exit
+
+# ---------------------------------------------------------------------------
+# Area 15: main-loop integration — release guard in full-script execution
+# ---------------------------------------------------------------------------
+# The harness-mode early-return prevents the Area 14 function tests from
+# exercising the main-loop code that calls _check_release_pr_guard (lines
+# 4127–4163 in pr-review-loop.sh). These integration tests run the full
+# script as a subprocess with a mocked gh so the main-loop path is covered.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 15: main-loop integration — release guard ==="
+
+_integration_mock_bin="$(mktemp -d)"
+_integration_cleanup() { rm -rf "${_integration_mock_bin:-}"; }
+trap '_integration_cleanup' EXIT
+
+# Minimal mock gh for the integration tests:
+#  - headRefName queries: return INTEG_MOCK_HEAD_JSON
+#  - pr edit (sync_reviewer_failed_label): succeed silently
+#  - everything else: succeed silently
+cat > "$_integration_mock_bin/gh" <<'INTEG_GH_MOCK'
+#!/usr/bin/env bash
+case "$*" in
+  *"headRefName"*)
+    # Use a variable for the default to avoid the bash brace-balance issue:
+    # ${VAR:-{"key":""}} closes ${...} at the inner }, producing a stray }
+    # in the output and therefore invalid JSON.
+    _hdr_default='{"headRefName":""}'
+    printf '%s\n' "${INTEG_MOCK_HEAD_JSON:-$_hdr_default}"
+    exit 0
+    ;;
+  *"pr edit"*|*"api"*|*"pr view"*)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+INTEG_GH_MOCK
+chmod +x "$_integration_mock_bin/gh"
+
+_run_loop_integration() {
+  # Run pr-review-loop.sh as a subprocess with the integration mock in PATH.
+  # Captures combined stdout; ignores stderr (diagnostic messages).
+  PATH="$_integration_mock_bin:$PATH" \
+    bash "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh" "$@" 2>/dev/null
+}
+
+# Test 15.1: release/* head branch → main loop emits RESULT=skipped, REASON=release_pr, exits 0
+export INTEG_MOCK_HEAD_JSON='{"headRefName":"release/v9.9.9"}'
+_integ_out=""
+_integ_exit=0
+set +e
+_integ_out="$(_run_loop_integration 999)"
+_integ_exit=$?
+set -e
+run_test "mainloop_release_guard_result_skipped" "RESULT=skipped" \
+  "$(printf '%s\n' "$_integ_out" | grep '^RESULT=')"
+run_test "mainloop_release_guard_reason_release_pr" "REASON=release_pr" \
+  "$(printf '%s\n' "$_integ_out" | grep '^REASON=')"
+run_test "mainloop_release_guard_exit0" "0" "$_integ_exit"
+unset INTEG_MOCK_HEAD_JSON
+
+# Test 15.2: hotfix/* head branch → main loop also emits RESULT=skipped, exits 0
+export INTEG_MOCK_HEAD_JSON='{"headRefName":"hotfix/v9.9.1"}'
+_integ_out=""
+_integ_exit=0
+set +e
+_integ_out="$(_run_loop_integration 998)"
+_integ_exit=$?
+set -e
+run_test "mainloop_hotfix_guard_result_skipped" "RESULT=skipped" \
+  "$(printf '%s\n' "$_integ_out" | grep '^RESULT=')"
+run_test "mainloop_hotfix_guard_exit0" "0" "$_integ_exit"
+unset INTEG_MOCK_HEAD_JSON
+
+# Test 15.3: --branch release/v9.9.9 flag → guard fires without a gh call, exits 0
+_integ_out=""
+_integ_exit=0
+set +e
+_integ_out="$(_run_loop_integration 997 --branch release/v9.9.9)"
+_integ_exit=$?
+set -e
+run_test "mainloop_branch_flag_release_result_skipped" "RESULT=skipped" \
+  "$(printf '%s\n' "$_integ_out" | grep '^RESULT=')"
+run_test "mainloop_branch_flag_release_exit0" "0" "$_integ_exit"
+
+_integration_cleanup
+unset _integ_out _integ_exit INTEG_MOCK_HEAD_JSON
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1818,8 +1818,8 @@ echo "=== Area 14: _check_release_pr_guard ==="
 # For tests that pass --branch, the head is known; only the base is fetched.
 
 # Test 14.1: release/* head branch detected as release PR (branch provided)
-# MOCK_GH_OUTPUT returns the jq-filtered base ref string (mock does not run jq)
-export MOCK_GH_OUTPUT='main'
+# When branch is provided, no gh call is made; mock output is irrelevant.
+export MOCK_GH_OUTPUT='[]'
 _guard_out=""
 _guard_exit=0
 _guard_out="$(_check_release_pr_guard "100" "release/v1.0.0")" || _guard_exit=$?
@@ -1828,7 +1828,6 @@ run_test "release_guard_release_head_fires" "RELEASE_GUARD_FIRED=1" \
 run_test "release_guard_release_head_exit0" "0" "$_guard_exit"
 
 # Test 14.2: hotfix/* head branch detected as release PR (branch provided)
-export MOCK_GH_OUTPUT='develop'
 _guard_out=""
 _guard_exit=0
 _guard_out="$(_check_release_pr_guard "101" "hotfix/v1.0.1")" || _guard_exit=$?
@@ -1836,21 +1835,7 @@ run_test "release_guard_hotfix_head_fires" "RELEASE_GUARD_FIRED=1" \
   "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
 run_test "release_guard_hotfix_head_exit0" "0" "$_guard_exit"
 
-# Test 14.3: base branch is main — fires regardless of head branch
-# When --branch is provided, the function calls gh pr view with --jq to get
-# just the base ref name. The mock returns MOCK_GH_OUTPUT verbatim (no jq
-# processing), so set it to the expected jq-filtered result: the plain string.
-export MOCK_GH_OUTPUT='main'
-_guard_out=""
-_guard_exit=0
-_guard_out="$(_check_release_pr_guard "102" "feature/some-feature")" || _guard_exit=$?
-run_test "release_guard_main_base_fires" "RELEASE_GUARD_FIRED=1" \
-  "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
-run_test "release_guard_main_base_exit0" "0" "$_guard_exit"
-
-# Test 14.4: develop-targeting feature branch — guard does NOT fire
-# MOCK_GH_OUTPUT="develop" simulates jq-filtered base branch = develop
-export MOCK_GH_OUTPUT='develop'
+# Test 14.3: develop-targeting feature branch — guard does NOT fire
 _guard_out=""
 _guard_exit=1
 _guard_out="$(_check_release_pr_guard "103" "feature/some-feature")" || _guard_exit=$?
@@ -1858,17 +1843,19 @@ run_test "release_guard_feature_no_fire" "RELEASE_GUARD_FIRED=0" \
   "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
 run_test "release_guard_feature_exit1" "1" "$_guard_exit"
 
-# Test 14.5: fix/* branch targeting develop — guard does NOT fire
-export MOCK_GH_OUTPUT='develop'
+# Test 14.4: fix/* branch — guard does NOT fire
 _guard_out=""
 _guard_exit=1
 _guard_out="$(_check_release_pr_guard "104" "fix/some-fix")" || _guard_exit=$?
 run_test "release_guard_fix_no_fire" "RELEASE_GUARD_FIRED=0" \
   "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
 
-# Test 14.6: no --branch provided; head and base fetched from PR JSON
-# Mock gh returns the full JSON object for the default case (headRefName + baseRefName)
-export MOCK_GH_OUTPUT='{"headRefName":"release/v2.0.0","baseRefName":"main"}'
+# Test 14.5: no --branch provided; head branch fetched from PR via jq
+# The mock returns MOCK_GH_OUTPUT for the default case. The function calls
+# gh pr view with --json headRefName --jq '.headRefName // ""' which the mock
+# does not apply jq to — it returns MOCK_GH_OUTPUT verbatim. Set it to the
+# expected jq-filtered value: the plain branch name string.
+export MOCK_GH_OUTPUT='release/v2.0.0'
 _guard_out=""
 _guard_exit=0
 _guard_out="$(_check_release_pr_guard "105")" || _guard_exit=$?
@@ -1876,10 +1863,10 @@ run_test "release_guard_fetched_head_fires" "RELEASE_GUARD_FIRED=1" \
   "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
 run_test "release_guard_fetched_head_value" "RELEASE_GUARD_HEAD=release/v2.0.0" \
   "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_HEAD=")"
-run_test "release_guard_fetched_base_value" "RELEASE_GUARD_BASE=main" \
-  "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_BASE=")"
+export MOCK_GH_OUTPUT='[]'
 
-# Test 14.7: gh pr view failure — guard does not fire (fail-safe: run the loop)
+# Test 14.6: no --branch provided; gh pr view failure — guard does not fire
+# (fail-safe: run the reviewer loop rather than silently skipping)
 export MOCK_GH_EXIT=1
 export MOCK_GH_OUTPUT=''
 _guard_out=""

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1807,6 +1807,93 @@ unset _needs_fixes_create_calls _needs_fixes_patch_calls
 unset -f _post_review_summary repo_slug
 
 # ---------------------------------------------------------------------------
+# Area 14: _check_release_pr_guard — release PR early-exit guard (#960)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 14: _check_release_pr_guard ==="
+
+# Helper: set MOCK_GH_OUTPUT to simulate a gh pr view JSON response.
+# MOCK_GH_OUTPUT is the default gh mock output used when no specific case
+# applies (the default case in the mock gh script).
+# For tests that pass --branch, the head is known; only the base is fetched.
+
+# Test 14.1: release/* head branch detected as release PR (branch provided)
+# MOCK_GH_OUTPUT returns the jq-filtered base ref string (mock does not run jq)
+export MOCK_GH_OUTPUT='main'
+_guard_out=""
+_guard_exit=0
+_guard_out="$(_check_release_pr_guard "100" "release/v1.0.0")" || _guard_exit=$?
+run_test "release_guard_release_head_fires" "RELEASE_GUARD_FIRED=1" \
+  "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
+run_test "release_guard_release_head_exit0" "0" "$_guard_exit"
+
+# Test 14.2: hotfix/* head branch detected as release PR (branch provided)
+export MOCK_GH_OUTPUT='develop'
+_guard_out=""
+_guard_exit=0
+_guard_out="$(_check_release_pr_guard "101" "hotfix/v1.0.1")" || _guard_exit=$?
+run_test "release_guard_hotfix_head_fires" "RELEASE_GUARD_FIRED=1" \
+  "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
+run_test "release_guard_hotfix_head_exit0" "0" "$_guard_exit"
+
+# Test 14.3: base branch is main — fires regardless of head branch
+# When --branch is provided, the function calls gh pr view with --jq to get
+# just the base ref name. The mock returns MOCK_GH_OUTPUT verbatim (no jq
+# processing), so set it to the expected jq-filtered result: the plain string.
+export MOCK_GH_OUTPUT='main'
+_guard_out=""
+_guard_exit=0
+_guard_out="$(_check_release_pr_guard "102" "feature/some-feature")" || _guard_exit=$?
+run_test "release_guard_main_base_fires" "RELEASE_GUARD_FIRED=1" \
+  "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
+run_test "release_guard_main_base_exit0" "0" "$_guard_exit"
+
+# Test 14.4: develop-targeting feature branch — guard does NOT fire
+# MOCK_GH_OUTPUT="develop" simulates jq-filtered base branch = develop
+export MOCK_GH_OUTPUT='develop'
+_guard_out=""
+_guard_exit=1
+_guard_out="$(_check_release_pr_guard "103" "feature/some-feature")" || _guard_exit=$?
+run_test "release_guard_feature_no_fire" "RELEASE_GUARD_FIRED=0" \
+  "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
+run_test "release_guard_feature_exit1" "1" "$_guard_exit"
+
+# Test 14.5: fix/* branch targeting develop — guard does NOT fire
+export MOCK_GH_OUTPUT='develop'
+_guard_out=""
+_guard_exit=1
+_guard_out="$(_check_release_pr_guard "104" "fix/some-fix")" || _guard_exit=$?
+run_test "release_guard_fix_no_fire" "RELEASE_GUARD_FIRED=0" \
+  "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
+
+# Test 14.6: no --branch provided; head and base fetched from PR JSON
+# Mock gh returns the full JSON object for the default case (headRefName + baseRefName)
+export MOCK_GH_OUTPUT='{"headRefName":"release/v2.0.0","baseRefName":"main"}'
+_guard_out=""
+_guard_exit=0
+_guard_out="$(_check_release_pr_guard "105")" || _guard_exit=$?
+run_test "release_guard_fetched_head_fires" "RELEASE_GUARD_FIRED=1" \
+  "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
+run_test "release_guard_fetched_head_value" "RELEASE_GUARD_HEAD=release/v2.0.0" \
+  "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_HEAD=")"
+run_test "release_guard_fetched_base_value" "RELEASE_GUARD_BASE=main" \
+  "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_BASE=")"
+
+# Test 14.7: gh pr view failure — guard does not fire (fail-safe: run the loop)
+export MOCK_GH_EXIT=1
+export MOCK_GH_OUTPUT=''
+_guard_out=""
+_guard_exit=1
+_guard_out="$(_check_release_pr_guard "106")" || _guard_exit=$?
+run_test "release_guard_fetch_failure_no_fire" "RELEASE_GUARD_FIRED=0" \
+  "$(printf '%s\n' "$_guard_out" | grep "^RELEASE_GUARD_FIRED=")"
+run_test "release_guard_fetch_failure_exit1" "1" "$_guard_exit"
+unset MOCK_GH_EXIT
+export MOCK_GH_OUTPUT='[]'
+
+unset _guard_out _guard_exit
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

- Adds an early-exit guard in `pr-review-loop.sh` that detects release and hotfix PRs (head branch matches `release/*` or `hotfix/*`) and exits immediately with `RESULT=skipped` / `REASON=release_pr`.
- Eliminates the ~40-minute Haystack poll timeout observed during v0.31.0 preparation (PR #958), where the reviewer loop waited on a 100+ file diff that added no review value — every change was already reviewed when its feature/fix PR merged into `develop`.
- Updates `05-prepare-release-protocol.md` Step 7 to remove the `pr-review-loop.sh` invocation and add an explicit release artifact validation step before CI.
- Adds a release PR exemption note to `93-automated-reviewer-loop-protocol.md`.

## Changes

- `scripts/development-workflow/pr-review-loop.sh`: `_check_release_pr_guard()` function (testable in harness) + main execution block integration; `sync_reviewer_failed_label` called on release guard exit.
- `scripts/development-workflow/tests/test-pr-review-loop.sh`: Area 14 — 11 tests for the release guard function.
- `docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md`: Step 7 rewritten — no external reviewers, explicit artifact validation, CI loop only.
- `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`: note that the loop applies only to develop-targeting PRs; release PRs are exempt.
- `CHANGELOG.md`: `### Changed` entry under `[Unreleased]`.

## Test plan

- [x] `shellcheck --severity=warning scripts/development-workflow/pr-review-loop.sh` — clean
- [x] `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop` — clean
- [x] `bash scripts/development-workflow/tests/test-pr-review-loop.sh` — 177/177 passed
- [x] `markdownlint-cli2` on all three modified markdown files — 0 errors
- [x] CHANGELOG duplicate-section check — passed
- [x] No trailing whitespace in modified files
- [x] Reviewer loop (PR-Agent + Haystack) — RESULT=clean
- [x] CI checks — all green

## Pre-submission self-review

- Stale markers: none
- Caller consistency: `05-prepare-release-protocol.md` Step 7 updated to match new script behavior; `93` note added; no other callers reference `pr-review-loop.sh` for release PRs
- Coverage: issue body requests guard in script + protocol 05 Step 7 update + protocol 93 note + CHANGELOG — all addressed

Closes #960