### PR TITLE
fix(workflow): backlog creation sets Priority and Size project fields (#965)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Per-finding advisory decisions in run-epic Step 8** (#962): Protocol 95 Step 8 now requires the runner to fetch individual Haystack findings and record one `advisories[]` entry per finding — bulk-acceptance of multiple findings with a single rationale is no longer permitted. `run-epic-audit-trail.sh` emits non-fatal warnings when advisory entries are fewer than the reported count or contain generic bulk-acceptance rationale. `run-epic-delegated-gate.sh` emits a process reminder when `advisory_count > 1` but only one `advisories[]` entry is recorded.
+- **Backlog creation now sets `Priority` (default `Medium`) and `Size` project fields** when GitHub Projects is configured; fixes documentation drift where `Normal` was listed instead of `Medium` for the Priority field (`#965`).
 
 ## [0.31.0] - 2026-06-15
 

--- a/docs/workflow/development-workflow/integrations/github-projects.md
+++ b/docs/workflow/development-workflow/integrations/github-projects.md
@@ -90,7 +90,8 @@ Add these custom fields to the project (via project settings UI or GraphQL):
 
 | Field    | Type                                                         | Purpose                                                                                 |
 | -------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
-| Priority | Single select: `Urgent`, `High`, `Normal`, `Low`             | Drives orchestrator prioritization                                                      |
+| Priority | Single select: `Urgent`, `High`, `Medium`, `Low`             | Drives orchestrator prioritization                                                      |
+| Size     | Single select: `XS`, `S`, `M`, `L`, `XL`                    | Drives work sizing and sprint planning                                                  |
 | Due date | Date                                                         | Items due within 2 weeks get priority boost                                             |
 | Type     | Single select: `Feature`, `Bug`, `Refactor`, `Workflow`      | Source of truth for work-item classification and workflow path routing                  |
 

--- a/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
+++ b/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
@@ -55,11 +55,45 @@ If any of the above are missing or contradictory, ask **targeted** clarifying qu
 
 1. Create **one** item in the **confirmed** destination.
 2. For **GitHub Issues** (including when `issue_tracker.provider` is `github_projects`), prefer:
-   - `./scripts/development-workflow/add-backlog-item.sh create --title "..." --body-file -` (requires `gh` authenticated), **or**
-   - Equivalent `gh issue create` with the same title/body.
+   - `./scripts/development-workflow/add-backlog-item.sh create --title "..." --body-file - [--priority <value>] [--size <value>]` (requires `gh` authenticated), **or**
+   - Equivalent `gh issue create` with the same title/body, followed by manual project field updates.
 3. For **Linear**, use the Linear API/MCP per [`linear.md`](../integrations/linear.md). The `add-backlog-item.sh create` command exits with a non-success code for Linear when the shell helper cannot perform the operation — follow the protocol manually instead of failing silently.
 4. For **GitHub Projects** after the issue exists: if the team uses a project board, add/update the project item per `github-projects.md` (optional field updates such as Status = Backlog and Type = Feature/Bug/Refactor/Workflow) **only when** the human or repo docs supply enough context (project number, owner). If project context is missing, **ask** rather than guessing.
 5. When GitHub Projects is configured, use the project **Type** field for classification instead of repository labels. Set `Type = Workflow` for AI-development-framework/process/tooling work, `Type = Feature` for full-pipeline product work, `Type = Bug` for fast-track fixes, and `Type = Refactor` for plan-only refactors. Do not apply legacy classification labels such as `workflow`, `bug`, `enhancement`, or `type:*`; operational labels such as `integration-branch:<slug>` remain valid when the protocol requires them.
+6. When GitHub Projects is configured, set **Priority** and **Size** on the project item. Use the inference heuristics below to determine values without asking the human for every routine item.
+
+### Priority and Size inference heuristics (GitHub Projects)
+
+**Priority** — default `Medium` unless there is explicit urgency signal:
+
+| Signal | Priority |
+| ------ | -------- |
+| Human uses words like "urgent", "blocking", "ASAP", "critical", or "production issue" | `Urgent` or `High` |
+| Item blocks another in-progress item or a pending release | `High` |
+| Standard new feature, improvement, or process fix | `Medium` (default) |
+| Nice-to-have, polish, or exploratory work | `Low` |
+
+**Size** — infer from the scope of the change implied by the request:
+
+| Scope | Size |
+| ----- | ---- |
+| Tiny doc fix, single-line config tweak, one-word rename | `XS` |
+| Single narrow file: typo fix, one-protocol update, single-field doc change | `S` |
+| 2–4 files, one feature toggle, small helper addition | `M` |
+| Multiple scripts + protocol + docs touched, or new reusable function | `L` |
+| New subsystem, major refactor spanning many files, cross-cutting change | `XL` |
+
+Pass inferred values directly to the helper:
+
+```bash
+./scripts/development-workflow/add-backlog-item.sh create \
+  --title "..." \
+  --body-file - \
+  --priority Medium \
+  --size S
+```
+
+When the scope is genuinely unclear after reading the request, omit `--size` (leave it unset) rather than guessing. Do not omit `--priority` — the script defaults to `Medium` when the flag is absent.
 
 ---
 

--- a/scripts/development-workflow/add-backlog-item.sh
+++ b/scripts/development-workflow/add-backlog-item.sh
@@ -119,20 +119,36 @@ create_cmd() {
       [ -n "$label" ] || continue
       gh_args+=(--label "$label")
     done
-    # Capture the issue URL so we can extract the issue number for project field updates.
+    # Capture the issue URL. Under set -euo pipefail, a non-zero exit from
+    # gh issue create aborts the script immediately — no separate exit-code
+    # check is required. The URL is the only output on success.
     local issue_url issue_number
     issue_url="$(gh "${gh_args[@]}")"
+    # Trim leading/trailing whitespace so extraction is robust against any
+    # trailing newline or extra whitespace in the gh output.
+    issue_url="${issue_url#"${issue_url%%[! ]*}"}"  # ltrim spaces
+    issue_url="${issue_url%"${issue_url##*[! ]}"}"  # rtrim spaces
     printf '%s\n' "$issue_url"
-    # Extract issue number from the URL (last path segment).
+    # Extract and validate the issue number from the URL (last path segment).
+    # The URL is always https://github.com/<owner>/<repo>/issues/<number>.
     issue_number="${issue_url##*/}"
+    # Skip project field updates when the issue number cannot be resolved to a
+    # numeric value (e.g. gh output was unexpected or the URL was malformed).
+    case "$issue_number" in
+      ''|*[!0-9]*)
+        echo "Warning: could not extract a numeric issue number from gh output '${issue_url}'; skipping project field updates." >&2
+        return 0
+        ;;
+    esac
     # Ensure the issue is on the project board (adds it with Status=Backlog if absent).
-    # This is required before project field updates can succeed.
-    ensure_on_project_board "$issue_number" "Backlog" || true
+    # The ensure_on_project_board helper is fail-open; it always returns 0.
+    ensure_on_project_board "$issue_number" "Backlog"
     # Update project Priority (default Medium) and Size when GitHub Projects is configured.
+    # The update_tracker_*_best_effort helpers are fail-open; they always return 0.
     local effective_priority="${priority:-Medium}"
-    update_tracker_priority_best_effort "$issue_number" "$effective_priority" || true
+    update_tracker_priority_best_effort "$issue_number" "$effective_priority"
     if [ -n "$size" ]; then
-      update_tracker_size_best_effort "$issue_number" "$size" || true
+      update_tracker_size_best_effort "$issue_number" "$size"
     fi
     return 0
   fi

--- a/scripts/development-workflow/add-backlog-item.sh
+++ b/scripts/development-workflow/add-backlog-item.sh
@@ -11,7 +11,7 @@ usage() {
   cat <<'EOF'
 Usage:
   add-backlog-item.sh resolve
-  add-backlog-item.sh create --title <title> (--body <text> | --body-file <path>) [--label <name>] ...
+  add-backlog-item.sh create --title <title> (--body <text> | --body-file <path>) [--label <name>] ... [--priority <value>] [--size <value>]
 
 resolve
   Prints machine-readable lines:
@@ -22,6 +22,11 @@ resolve
 create
   When DESTINATION_KIND is github, creates one GitHub issue via gh (requires gh auth).
   For linear, other, or none, exits non-zero with guidance (agents follow 00-add-backlog-item-protocol.md).
+
+  --priority <value>  Optional. Set the project Priority field. Valid values: Urgent, High, Medium, Low.
+                      When omitted, defaults to Medium for GitHub Projects.
+  --size <value>      Optional. Set the project Size field. Valid values: XS, S, M, L, XL.
+                      When omitted, the Size field is left unset.
 EOF
 }
 
@@ -42,7 +47,7 @@ resolve_cmd() {
 
 create_cmd() {
   local caller_pwd="$PWD"
-  local title="" body="" body_file="" labels=()
+  local title="" body="" body_file="" priority="" size="" labels=()
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -64,6 +69,16 @@ create_cmd() {
       --label)
         [ $# -lt 2 ] || [ -z "${2:-}" ] && { echo "Missing value for --label" >&2; usage >&2; exit 2; }
         labels+=("$2")
+        shift 2
+        ;;
+      --priority)
+        [ $# -lt 2 ] || [ -z "${2:-}" ] && { echo "Missing value for --priority" >&2; usage >&2; exit 2; }
+        priority="$2"
+        shift 2
+        ;;
+      --size)
+        [ $# -lt 2 ] || [ -z "${2:-}" ] && { echo "Missing value for --size" >&2; usage >&2; exit 2; }
+        size="$2"
         shift 2
         ;;
       -h|--help)
@@ -104,7 +119,21 @@ create_cmd() {
       [ -n "$label" ] || continue
       gh_args+=(--label "$label")
     done
-    gh "${gh_args[@]}"
+    # Capture the issue URL so we can extract the issue number for project field updates.
+    local issue_url issue_number
+    issue_url="$(gh "${gh_args[@]}")"
+    printf '%s\n' "$issue_url"
+    # Extract issue number from the URL (last path segment).
+    issue_number="${issue_url##*/}"
+    # Ensure the issue is on the project board (adds it with Status=Backlog if absent).
+    # This is required before project field updates can succeed.
+    ensure_on_project_board "$issue_number" "Backlog" || true
+    # Update project Priority (default Medium) and Size when GitHub Projects is configured.
+    local effective_priority="${priority:-Medium}"
+    update_tracker_priority_best_effort "$issue_number" "$effective_priority" || true
+    if [ -n "$size" ]; then
+      update_tracker_size_best_effort "$issue_number" "$size" || true
+    fi
     return 0
   fi
 

--- a/scripts/development-workflow/tests/test-add-backlog-item.sh
+++ b/scripts/development-workflow/tests/test-add-backlog-item.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# test-add-backlog-item.sh — Unit tests for add-backlog-item.sh create flow.
+#
+# Exercises issue #965's Priority/Size field updates:
+#   1. Malformed gh output warns and skips project field updates
+#   2. Non-numeric issue number in URL warns and skips project field updates
+#   3. Happy path: URL parsed, board membership checked, Priority defaults to Medium
+#   4. --priority flag: uses supplied value instead of Medium default
+#   5. --size flag: triggers Size field update
+#   6. No --size: Size field update is not called
+#
+# Usage: bash scripts/development-workflow/tests/test-add-backlog-item.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+SCRIPT="$REPO_ROOT/scripts/development-workflow/add-backlog-item.sh"
+
+TMP_ROOT="$(mktemp -d)"
+MOCK_BIN="$TMP_ROOT/bin"
+CALL_LOG="$TMP_ROOT/calls.log"
+mkdir -p "$MOCK_BIN"
+: > "$CALL_LOG"
+
+cleanup() { rm -rf "$TMP_ROOT"; }
+trap cleanup EXIT
+
+cat > "$MOCK_BIN/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_GH_CALL_LOG"
+case "$*" in
+  "auth status")
+    exit 0
+    ;;
+  "repo view --json owner --jq .owner.login")
+    printf 'lhpaul\n'
+    ;;
+  "repo view --json name --jq .name")
+    printf 'test-repo\n'
+    ;;
+  issue\ create\ *)
+    case "${MOCK_GH_ISSUE_CREATE_MODE:-ok}" in
+      malformed)   printf 'not-a-url\n' ;;
+      nonnumeric)  printf 'https://github.com/lhpaul/test-repo/issues/not-a-number\n' ;;
+      *)           printf 'https://github.com/lhpaul/test-repo/issues/123\n' ;;
+    esac
+    ;;
+  "project item-add "*)
+    printf 'PVTI_added\n'
+    ;;
+  *"api graphql"*)
+    case "$*" in
+      *"projectV2(number:"*)
+        printf '{"data":{"user":{"projectV2":{"id":"PVT_project_1"}},"organization":null}}\n'
+        ;;
+      *"projectItems(first:"*)
+        printf '{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_123","project":{"id":"PVT_project_1","number":1},"status":{"name":"Backlog"},"type":{"name":"Feature"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}\n'
+        ;;
+      *"fields(first:"*)
+        printf '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_urgent","name":"Urgent"},{"id":"OPT_high","name":"High"},{"id":"OPT_medium","name":"Medium"},{"id":"OPT_low","name":"Low"}]},{"id":"PVTSSF_size","name":"Size","options":[{"id":"OPT_size_xs","name":"XS"},{"id":"OPT_size_s","name":"S"},{"id":"OPT_size_m","name":"M"},{"id":"OPT_size_l","name":"L"},{"id":"OPT_size_xl","name":"XL"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}\n'
+        ;;
+      *"updateProjectV2ItemFieldValue"*)
+        printf '{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_item_123"}}}}\n'
+        ;;
+      *)
+        printf '{}\n'
+        ;;
+    esac
+    ;;
+  *)
+    printf 'unexpected gh invocation: gh %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+MOCK_GH
+chmod +x "$MOCK_BIN/gh"
+
+export PATH="$MOCK_BIN:$PATH"
+export MOCK_GH_CALL_LOG="$CALL_LOG"
+export GITHUB_PROJECT_NUMBER="1"
+export GITHUB_PROJECT_OWNER="lhpaul"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name — expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+reset_log() { : > "$CALL_LOG"; }
+
+count_log_matches() {
+  local pattern="$1"
+  awk -v p="$pattern" '$0 ~ p { c++ } END { print c+0 }' "$CALL_LOG"
+}
+
+run_create() {
+  local mode="${1:-ok}"; shift
+  reset_log
+  local exit_code=0
+  set +e
+  MOCK_GH_ISSUE_CREATE_MODE="$mode" \
+    "$SCRIPT" create "$@" \
+    >"$TMP_ROOT/stdout.log" \
+    2>"$TMP_ROOT/stderr.log"
+  exit_code=$?
+  set -e
+  printf '%s' "$exit_code" >"$TMP_ROOT/exit.log"
+}
+
+get_stdout() { cat "$TMP_ROOT/stdout.log" 2>/dev/null || true; }
+get_stderr() { cat "$TMP_ROOT/stderr.log" 2>/dev/null || true; }
+get_exit()   { cat "$TMP_ROOT/exit.log" 2>/dev/null || true; }
+
+echo ""
+echo "=== create: URL parsing — malformed gh output ==="
+
+run_create "malformed" --title "Test" --body "body"
+run_test "malformed_url_exits_zero" "0" "$(get_exit)"
+malformed_stderr="$(get_stderr)"
+case "$malformed_stderr" in
+  *"Warning: could not extract a numeric issue number"*) malformed_warn="warned" ;;
+  *) malformed_warn="$malformed_stderr" ;;
+esac
+run_test "malformed_url_warns" "warned" "$malformed_warn"
+run_test "malformed_url_skips_board_check" "0" "$(count_log_matches 'projectItems')"
+run_test "malformed_url_skips_priority_update" "0" "$(count_log_matches 'updateProjectV2ItemFieldValue')"
+
+echo ""
+echo "=== create: URL parsing — non-numeric issue number ==="
+
+run_create "nonnumeric" --title "Test" --body "body"
+run_test "nonnumeric_exits_zero" "0" "$(get_exit)"
+nonnumeric_stderr="$(get_stderr)"
+case "$nonnumeric_stderr" in
+  *"Warning: could not extract a numeric issue number"*) nonnumeric_warn="warned" ;;
+  *) nonnumeric_warn="$nonnumeric_stderr" ;;
+esac
+run_test "nonnumeric_warns" "warned" "$nonnumeric_warn"
+run_test "nonnumeric_skips_board_check" "0" "$(count_log_matches 'projectItems')"
+run_test "nonnumeric_skips_priority_update" "0" "$(count_log_matches 'updateProjectV2ItemFieldValue')"
+
+echo ""
+echo "=== create: happy path — issue URL in output, Priority defaults to Medium ==="
+
+run_create "ok" --title "Test" --body "body"
+run_test "happy_path_exits_zero" "0" "$(get_exit)"
+happy_stdout="$(get_stdout)"
+case "$happy_stdout" in
+  *"https://github.com/lhpaul/test-repo/issues/123"*) url_in_output="yes" ;;
+  *) url_in_output="no" ;;
+esac
+run_test "happy_path_prints_issue_url" "yes" "$url_in_output"
+board_check_count="$(count_log_matches 'projectItems')"
+run_test "happy_path_checks_board_membership" "yes" "$([ "$board_check_count" -ge 1 ] && echo yes || echo no)"
+run_test "happy_path_updates_priority" "1" "$(count_log_matches 'fieldId=PVTSSF_priority')"
+run_test "happy_path_default_priority_is_medium" "1" "$(count_log_matches 'optionId=OPT_medium')"
+run_test "happy_path_skips_size_update" "0" "$(count_log_matches 'fieldId=PVTSSF_size')"
+
+echo ""
+echo "=== create: --priority flag overrides Medium default ==="
+
+run_create "ok" --title "Test" --body "body" --priority "High"
+run_test "explicit_priority_exits_zero" "0" "$(get_exit)"
+run_test "explicit_priority_high_used" "1" "$(count_log_matches 'optionId=OPT_high')"
+run_test "explicit_priority_not_medium" "0" "$(count_log_matches 'optionId=OPT_medium')"
+
+echo ""
+echo "=== create: --size flag updates Size field ==="
+
+run_create "ok" --title "Test" --body "body" --size "M"
+run_test "size_flag_exits_zero" "0" "$(get_exit)"
+run_test "size_flag_updates_size_field" "1" "$(count_log_matches 'fieldId=PVTSSF_size')"
+run_test "size_flag_uses_m_option" "1" "$(count_log_matches 'optionId=OPT_size_m')"
+run_test "size_flag_also_updates_priority" "1" "$(count_log_matches 'fieldId=PVTSSF_priority')"
+
+echo ""
+echo "Test summary: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+++ b/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
@@ -597,6 +597,141 @@ run_test "remote_repo_fallback_rejects_extra_path_segments" "" "$(resolve_repo_f
 run_test "remote_owner_fallback_rejects_invalid_owner" "" "$(resolve_owner_from_remote "git@github.com:bad_owner/ai-dev-framework-template.git")"
 run_test "remote_repo_fallback_rejects_invalid_repo" "" "$(resolve_repo_from_remote "git@github.com:lhpaul/bad!repo.git")"
 
+echo ""
+echo "=== workflow_github_project_named_field_json ==="
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+named_field_tmpout="$(mktemp)"
+workflow_github_project_named_field_json "PVT_project_1" "Status" > "$named_field_tmpout" 2>/dev/null
+named_field_id="$(python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('field_id',''))" < "$named_field_tmpout" 2>/dev/null)"
+run_test "named_field_lookup_returns_field_id" "PVTSSF_status" "$named_field_id"
+run_test "named_field_lookup_avoids_full_board_scan" "" "$(forbidden_project_reads)"
+
+reset_log
+workflow_github_project_named_field_json "PVT_project_1" "Status" > "$named_field_tmpout" 2>/dev/null
+cached_field_id="$(python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('field_id',''))" < "$named_field_tmpout" 2>/dev/null)"
+rm -f "$named_field_tmpout"
+run_test "named_field_cache_hit_returns_correct_id" "PVTSSF_status" "$cached_field_id"
+run_test "named_field_cache_hit_makes_zero_graphql_calls" "0" "$(count_log_matches 'api graphql')"
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+named_not_found_exit=0
+named_not_found_stderr=""
+named_not_found_stderr="$(workflow_github_project_named_field_json "PVT_project_1" "Priority" 2>&1 >/dev/null)" || named_not_found_exit=$?
+run_test "named_field_not_found_returns_nonzero" "1" "$named_not_found_exit"
+case "$named_not_found_stderr" in
+  *"Priority"*"not found"*) named_not_found_result="warned" ;;
+  *) named_not_found_result="$named_not_found_stderr" ;;
+esac
+run_test "named_field_not_found_warns" "warned" "$named_not_found_result"
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+empty_name_exit=0
+workflow_github_project_named_field_json "PVT_project_1" "" > /dev/null 2>&1; empty_name_exit=$?
+run_test "named_field_empty_name_returns_nonzero" "1" "$empty_name_exit"
+run_test "named_field_empty_name_avoids_graphql" "0" "$(count_log_matches 'api graphql')"
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+export MOCK_STATUS_FIELD_MODE=graphql_fail
+named_gql_fail_exit=0
+named_gql_fail_out="$(workflow_github_project_named_field_json "PVT_project_1" "Status" 2>/dev/null)" || named_gql_fail_exit=$?
+unset MOCK_STATUS_FIELD_MODE
+run_test "named_field_graphql_failure_returns_nonzero" "1" "$named_gql_fail_exit"
+run_test "named_field_graphql_failure_empty_output" "" "$named_gql_fail_out"
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+export MOCK_STATUS_FIELD_MODE=paginated
+named_paged_json="$(workflow_github_project_named_field_json "PVT_project_1" "Priority" 2>/dev/null)"
+named_paged_id="$(printf '%s' "$named_paged_json" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('field_id',''))" 2>/dev/null)"
+calls_page_one="$(count_log_matches 'api graphql')"
+reset_log
+named_paged_status_json="$(workflow_github_project_named_field_json "PVT_project_1" "Status" 2>/dev/null)"
+named_paged_status_id="$(printf '%s' "$named_paged_status_json" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('field_id',''))" 2>/dev/null)"
+calls_page_two="$(count_log_matches 'api graphql')"
+unset MOCK_STATUS_FIELD_MODE
+run_test "named_field_found_on_first_page" "PVTSSF_other" "$named_paged_id"
+run_test "named_field_first_page_uses_one_call" "1" "$calls_page_one"
+run_test "named_field_found_on_second_page" "PVTSSF_status" "$named_paged_status_id"
+run_test "named_field_second_page_uses_two_calls" "2" "$calls_page_two"
+
+echo ""
+echo "=== update_tracker_named_field_best_effort ==="
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+named_update_output="$(update_tracker_named_field_best_effort 824 "Status" "Spec Ready" 2>&1)"
+case "$named_update_output" in
+  *"Updating tracker 'Status' for issue #824 to 'Spec Ready'"*) named_update_result="updated" ;;
+  *) named_update_result="$named_update_output" ;;
+esac
+run_test "named_field_update_happy_path" "updated" "$named_update_result"
+run_test "named_field_update_mutates_project_item" "1" "$(count_log_matches 'updateProjectV2ItemFieldValue')"
+run_test "named_field_update_avoids_full_board_scan" "" "$(forbidden_project_reads)"
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+named_miss_output="$(update_tracker_named_field_best_effort 824 "Priority" "High" 2>&1)"
+case "$named_miss_output" in
+  *"could not read project 'Priority' field metadata"*) named_miss_result="field-not-found" ;;
+  *) named_miss_result="$named_miss_output" ;;
+esac
+run_test "named_field_update_field_not_found_warns" "field-not-found" "$named_miss_result"
+run_test "named_field_update_field_not_found_no_mutation" "0" "$(count_log_matches 'updateProjectV2ItemFieldValue')"
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+named_opt_output="$(update_tracker_named_field_best_effort 824 "Status" "NonExistentOption" 2>&1)"
+case "$named_opt_output" in
+  *"could not resolve 'Status' field or option 'NonExistentOption'"*) named_opt_result="option-not-found" ;;
+  *) named_opt_result="$named_opt_output" ;;
+esac
+run_test "named_field_update_option_not_found_warns" "option-not-found" "$named_opt_result"
+run_test "named_field_update_option_not_found_no_mutation" "0" "$(count_log_matches 'updateProjectV2ItemFieldValue')"
+
+reset_log
+export MOCK_TRACKER_PROVIDER=linear
+named_linear_output="$(update_tracker_named_field_best_effort 824 "Priority" "High" 2>&1)"
+unset MOCK_TRACKER_PROVIDER
+case "$named_linear_output" in
+  *"does not support GitHub Projects"*) named_linear_result="warned" ;;
+  *) named_linear_result="$named_linear_output" ;;
+esac
+run_test "named_field_update_wrong_provider_warns" "warned" "$named_linear_result"
+run_test "named_field_update_wrong_provider_no_mutation" "0" "$(count_log_matches 'updateProjectV2ItemFieldValue')"
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+priority_output="$(update_tracker_priority_best_effort 824 "High" 2>&1)"
+case "$priority_output" in
+  *"could not read project 'Priority' field metadata"*) priority_result="routed-to-priority" ;;
+  *) priority_result="$priority_output" ;;
+esac
+run_test "priority_convenience_routes_to_named_field" "routed-to-priority" "$priority_result"
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+size_output="$(update_tracker_size_best_effort 824 "S" 2>&1)"
+case "$size_output" in
+  *"could not read project 'Size' field metadata"*) size_result="routed-to-size" ;;
+  *) size_result="$size_output" ;;
+esac
+run_test "size_convenience_routes_to_named_field" "routed-to-size" "$size_result"
+
 reset_log
 workflow_github_project_item_for_issue() {
   printf 'not json'

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -871,6 +871,10 @@ __workflow_project_status_field_cache_project_id=""
 __workflow_project_status_field_cache_json=""
 __workflow_project_type_field_cache_project_id=""
 __workflow_project_type_field_cache_json=""
+# Cache for named single-select fields (Priority, Size, etc.) — indexed by
+# "<project_id>:<field_name>" stored in parallel arrays.
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
 __workflow_last_gh_stdout=""
 __workflow_last_gh_stderr=""
 
@@ -1933,6 +1937,274 @@ print((data.get('options') or {}).get(sys.argv[1]) or '', end='')
     echo "Warning: GraphQL mutation failed for issue #${issue_number}; tracker Type not updated."
     workflow_print_captured_gh_stderr
   fi
+}
+
+# workflow_github_project_named_field_json <project_id> <field_name>
+#
+# Prints compact JSON {"field_id":"...","options":{"Name":"optionId",...}} for
+# any single-select field whose name matches <field_name> exactly (case-sensitive).
+# Uses an in-process parallel-array cache keyed by "<project_id>:<field_name>".
+# Returns non-zero when the project ID is empty, the GraphQL fetch fails, or the
+# named field is not found. Callers must treat those cases as lookup failures.
+workflow_github_project_named_field_json() {
+  local project_id="$1"
+  local field_name="$2"
+  local cache_key response cursor page_state field_json has_next end_cursor page_count line
+  local -a graphql_args
+  local _i _found_val
+
+  if [ -z "$project_id" ]; then
+    echo "Warning: project ID is empty; '${field_name}' field lookup cannot run." >&2
+    printf ''
+    return 1
+  fi
+  if [ -z "$field_name" ]; then
+    echo "Warning: field_name is empty; named field lookup cannot run." >&2
+    printf ''
+    return 1
+  fi
+
+  cache_key="${project_id}:${field_name}"
+  _found_val=""
+  for _i in "${!__workflow_project_named_field_cache_keys[@]}"; do
+    if [ "${__workflow_project_named_field_cache_keys[$_i]}" = "$cache_key" ]; then
+      _found_val="${__workflow_project_named_field_cache_vals[$_i]}"
+      break
+    fi
+  done
+  if [ -n "$_found_val" ]; then
+    printf '%s' "$_found_val"
+    return 0
+  fi
+
+  cursor=""
+  page_count=0
+  field_json=""
+  while :; do
+    graphql_args=(
+      api graphql
+      -f projectId="$project_id"
+    )
+    if [ -n "$cursor" ]; then
+      graphql_args+=(-f after="$cursor")
+    fi
+    # shellcheck disable=SC2016 # GraphQL variables are expanded by GitHub, not by Bash.
+    graphql_args+=(
+      -f query='
+        query($projectId: ID!, $after: String) {
+          node(id: $projectId) {
+            ... on ProjectV2 {
+              fields(first: 100, after: $after) {
+                nodes {
+                  ... on ProjectV2SingleSelectField {
+                    id
+                    name
+                    options { id name }
+                  }
+                }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+        }
+      '
+    )
+
+    if ! workflow_run_gh_capture_stderr "${graphql_args[@]}"; then
+      echo "Warning: GraphQL project '${field_name}' field lookup failed for project '${project_id}'." >&2
+      workflow_print_captured_gh_stderr
+      printf ''
+      return 1
+    fi
+    response="$__workflow_last_gh_stdout"
+
+    if ! page_state="$(printf '%s' "$response" | python3 -c "
+import json, sys
+try:
+    data = json.loads(sys.stdin.read(), strict=False)
+except Exception:
+    sys.exit(2)
+target = sys.argv[1]
+field_connection = (((data.get('data') or {}).get('node') or {}).get('fields') or {})
+fields = field_connection.get('nodes') or []
+field_json = ''
+for field in fields:
+    if field.get('name') == target:
+        field_json = json.dumps({
+            'field_id': field.get('id') or '',
+            'options': {option.get('name') or '': option.get('id') or '' for option in field.get('options') or []},
+        }, separators=(',', ':'))
+        break
+page_info = field_connection.get('pageInfo') or {}
+has_next = 'true' if page_info.get('hasNextPage') else 'false'
+end_cursor = page_info.get('endCursor') or ''
+print('FIELD_JSON=' + field_json)
+print('HAS_NEXT=' + has_next)
+print('END_CURSOR=' + end_cursor)
+" "$field_name" 2>/dev/null)"; then
+      echo "Warning: could not parse GraphQL '${field_name}' field response for project '${project_id}'." >&2
+      printf ''
+      return 1
+    fi
+
+    has_next="false"
+    end_cursor=""
+    while IFS= read -r line; do
+      case "$line" in
+        FIELD_JSON=*) field_json="${line#FIELD_JSON=}" ;;
+        HAS_NEXT=*)   has_next="${line#HAS_NEXT=}" ;;
+        END_CURSOR=*) end_cursor="${line#END_CURSOR=}" ;;
+      esac
+    done <<EOF
+$page_state
+EOF
+    if [ -n "$field_json" ]; then
+      break
+    fi
+    if [ "$has_next" != "true" ] || [ -z "$end_cursor" ]; then
+      break
+    fi
+    page_count=$((page_count + 1))
+    if [ "$page_count" -ge 20 ]; then
+      echo "Warning: project '${field_name}' field lookup exceeded pagination limit for project '${project_id}'." >&2
+      printf ''
+      return 1
+    fi
+    cursor="$end_cursor"
+  done
+
+  if [ -z "$field_json" ]; then
+    echo "Warning: project '${field_name}' field not found for project '${project_id}'." >&2
+    printf ''
+    return 1
+  fi
+
+  __workflow_project_named_field_cache_keys+=("$cache_key")
+  __workflow_project_named_field_cache_vals+=("$field_json")
+  printf '%s' "$field_json"
+}
+
+# update_tracker_named_field_best_effort <issue_number> <field_name> <option_value>
+#
+# Best-effort update for any single-select GitHub Projects field by name.
+# Supports github_projects provider only; emits warnings for all other providers.
+# Returns 0 in all warning/failure cases to avoid blocking caller flows.
+update_tracker_named_field_best_effort() {
+  local issue_number="$1"
+  local field_name="$2"
+  local option_value="$3"
+  local project_number project_id field_json field_id option_id item_json item_id
+
+  local _utnfbe_provider
+  _utnfbe_provider="$(workflow_normalize_issue_tracker_provider "$(workflow_issue_tracker_provider_raw)")"
+  if [ "$_utnfbe_provider" != "github_projects" ]; then
+    echo "Warning: issue tracker provider '${_utnfbe_provider:-unknown}' does not support GitHub Projects '${field_name}' updates via this helper."
+    return 0
+  fi
+
+  project_number="${GITHUB_PROJECT_NUMBER:-$(workflow_issue_tracker_project_number)}"
+  if [ -z "$project_number" ]; then
+    echo "Warning: GITHUB_PROJECT_NUMBER not set and no project_number in .ai-dev-workflow.yaml; skipping tracker '${field_name}' update."
+    return 0
+  fi
+
+  item_json="$(workflow_github_project_item_for_issue "$issue_number" "$project_number")"
+  if ! item_id=$(printf '%s' "$item_json" | python3 -c "
+import json, sys
+item = json.loads(sys.stdin.read(), strict=False)
+print(item.get('item_id') or '', end='')
+"); then
+    echo "Warning: could not parse project item ID for issue #${issue_number}; skipping tracker '${field_name}' update."
+    return 0
+  fi
+  if ! project_id=$(printf '%s' "$item_json" | python3 -c "
+import json, sys
+item = json.loads(sys.stdin.read(), strict=False)
+print(item.get('project_id') or '', end='')
+"); then
+    echo "Warning: could not parse project ID for issue #${issue_number}; skipping tracker '${field_name}' update."
+    return 0
+  fi
+  if [ -z "$item_id" ]; then
+    echo "Warning: issue #${issue_number} not found in project #${project_number}; skipping tracker '${field_name}' update."
+    return 0
+  fi
+  if [ -z "$project_id" ]; then
+    echo "Warning: could not resolve project ID for issue #${issue_number}; skipping tracker '${field_name}' update."
+    return 0
+  fi
+
+  if ! field_json="$(workflow_github_project_named_field_json "$project_id" "$field_name")"; then
+    echo "Warning: could not read project '${field_name}' field metadata; skipping tracker '${field_name}' update."
+    return 0
+  fi
+  if ! field_id=$(printf '%s' "$field_json" | python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read(), strict=False)
+print(data.get('field_id') or '', end='')
+"); then
+    echo "Warning: could not parse '${field_name}' field metadata; skipping tracker '${field_name}' update."
+    return 0
+  fi
+  if ! option_id=$(printf '%s' "$field_json" | python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read(), strict=False)
+print((data.get('options') or {}).get(sys.argv[1]) or '', end='')
+" "$option_value"); then
+    echo "Warning: could not parse '${field_name}' option '${option_value}'; skipping tracker '${field_name}' update."
+    return 0
+  fi
+  if [ -z "$field_id" ] || [ -z "$option_id" ]; then
+    echo "Warning: could not resolve '${field_name}' field or option '${option_value}'; skipping tracker '${field_name}' update."
+    return 0
+  fi
+
+  echo "Updating tracker '${field_name}' for issue #${issue_number} to '${option_value}'..."
+  # shellcheck disable=SC2016 # GraphQL variables are expanded by GitHub, not by Bash.
+  if workflow_run_gh_capture_stderr api graphql \
+    -f projectId="$project_id" \
+    -f itemId="$item_id" \
+    -f fieldId="$field_id" \
+    -f optionId="$option_id" \
+    -f query='
+      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+        updateProjectV2ItemFieldValue(input: {
+          projectId: $projectId
+          itemId: $itemId
+          fieldId: $fieldId
+          value: { singleSelectOptionId: $optionId }
+        }) {
+          projectV2Item { id }
+        }
+      }
+    '; then
+    printf '%s' "$__workflow_last_gh_stdout"
+  else
+    echo "Warning: GraphQL mutation failed for issue #${issue_number}; tracker '${field_name}' not updated."
+    workflow_print_captured_gh_stderr
+  fi
+}
+
+# update_tracker_priority_best_effort <issue_number> <priority_value>
+#
+# Best-effort update for the GitHub Projects Priority field.
+# Valid values: Urgent, High, Medium, Low
+# Returns 0 in all failure cases (fail-open).
+update_tracker_priority_best_effort() {
+  local issue_number="$1"
+  local priority_value="$2"
+  update_tracker_named_field_best_effort "$issue_number" "Priority" "$priority_value"
+}
+
+# update_tracker_size_best_effort <issue_number> <size_value>
+#
+# Best-effort update for the GitHub Projects Size field.
+# Valid values: XS, S, M, L, XL
+# Returns 0 in all failure cases (fail-open).
+update_tracker_size_best_effort() {
+  local issue_number="$1"
+  local size_value="$2"
+  update_tracker_named_field_best_effort "$issue_number" "Size" "$size_value"
 }
 
 # list_open_workflow_type_issues


### PR DESCRIPTION
## Summary

- `add-backlog-item.sh create` now accepts `--priority` and `--size` optional flags; defaults Priority to `Medium` when the flag is omitted; calls `ensure_on_project_board` before setting fields so the item is on the board before the GraphQL mutation runs.
- `workflow-lib.sh` adds `workflow_github_project_named_field_json` (generic single-select field lookup with parallel-array cache keyed by `<project_id>:<field_name>`), `update_tracker_named_field_best_effort`, and convenience wrappers `update_tracker_priority_best_effort` / `update_tracker_size_best_effort`.
- `github-projects.md`: fixes the Priority option documentation (`Normal` → `Medium`); adds Size field row (`XS`, `S`, `M`, `L`, `XL`).
- `00-add-backlog-item-protocol.md` Step 3: adds step 6 requiring agents to set Priority (default `Medium`) and Size; adds inference heuristics tables so agents can infer values for routine items without asking the human.
- CHANGELOG updated under `[Unreleased]` `### Fixed`.

## Acceptance criteria coverage

1. Protocol Step 3 requires Priority and Size — covered via new step 6 and heuristics table.
2. Safe defaults: Priority defaults to `Medium`; Size omitted when unclear — covered in protocol and script.
3. `github-projects.md` Priority options corrected (`Normal` → `Medium`) — covered.
4. `github-projects.md` Size field added (`XS`/`S`/`M`/`L`/`XL`) — covered.
5. `add-backlog-item.sh` has `--priority` and `--size` flags — covered.
6. Generic `update_tracker_named_field_best_effort` helper in `workflow-lib.sh` — covered; also exposes `update_tracker_priority_best_effort` and `update_tracker_size_best_effort`.
7. CHANGELOG updated — covered.

## Self-review log

- Removed `record_release_for_issue_best_effort` changes that were pre-existing working-tree modifications from another branch and not part of this fix.
- All shell scripts pass `shellcheck --severity=warning` and `workflow-shell-guard-lint.py --base-ref origin/develop` — no findings.
- Markdown files pass `markdownlint-cli2` and duplicate-header check.
- All modified `.md` files end with newline (MD047 verified).
- No trailing whitespace in CHANGELOG or protocol files.
- Issue is scoped to 5 files directly related to #965; no unrelated changes included.
- `jq` is not used in the new shell code; Python3 is used for JSON parsing (same pattern as existing helpers).
- All new shell functions are fail-open (return 0 on any error path).

## Test plan

- [ ] `./scripts/development-workflow/add-backlog-item.sh resolve` — still works on GitHub Projects config.
- [ ] `./scripts/development-workflow/add-backlog-item.sh create --title "Test" --body "test" --priority High --size S` — creates issue, adds to board, sets Priority=High and Size=S.
- [ ] `./scripts/development-workflow/add-backlog-item.sh create --title "Test2" --body "test"` — creates issue with default Priority=Medium; Size unset.
- [ ] Source `workflow-lib.sh` and call `update_tracker_priority_best_effort <issue> Medium` directly — updates the Priority field.
- [ ] Source `workflow-lib.sh` and call `update_tracker_size_best_effort <issue> L` directly — updates the Size field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)