### PR TITLE
feat(workflow): add guardrails config model and documentation (#979)

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -148,3 +148,82 @@ template:
   # Written automatically by sync-template after a successful sync.
   # Used by the retrospective cross-reference step to identify "already fixed upstream" findings.
   last_synced_version: ""
+
+# guardrails — declares how much authority AI agents have when advancing work through the
+# development workflow. This section is OPTIONAL. When omitted, all values resolve to the
+# documented safe defaults below, preserving today's conservative, human-reviewed behavior
+# (agents do not merge pull requests and do not start backlog work without confirmation).
+#
+# MODEL ONLY in this pass — enforcement of these settings inside delegated /run-work
+# execution is tracked by #980. Setting values here documents intent and makes the contract
+# readable but does not yet change runtime agent behavior.
+#
+# See docs/workflow/development-workflow/guardrails.md for plain-language explanations,
+# mode descriptions, worked examples, stop conditions, and audit requirements.
+#
+# guardrails:
+#   # mode — overall autonomy level for this repository.
+#   # Accepted values: manual | assisted | delegated | autonomous
+#   # Default: manual (agents draft and propose; a human performs every merge)
+#   mode: manual
+#
+#   # backlog_start — controls whether an agent may pick up a backlog item and begin
+#   # spec/plan/implementation work without a human confirming each item.
+#   backlog_start:
+#     # allow_without_confirmation — when false (default), an agent must receive an explicit
+#     # human instruction before starting a new backlog item.
+#     allow_without_confirmation: false   # default: false
+#
+#   # stages — per-stage permissions for spec, plan, and implementation.
+#   # Each stage can be configured independently.
+#   stages:
+#     spec:
+#       # may_open_pr — whether an agent may open a pull request for this stage.
+#       # Default: true (agents always draft PRs)
+#       may_open_pr: true
+#       # may_merge_pr — whether an agent may merge a clean pull request for this stage.
+#       # Default: false (a human must merge unless explicitly set to true)
+#       may_merge_pr: false
+#       # max_merge_risk — the highest risk level at which an agent may merge.
+#       # An agent must stop and defer to a human for any risk above this level.
+#       # Accepted values: low | medium | high
+#       # Default: low
+#       max_merge_risk: low
+#
+#     plan:
+#       may_open_pr: true
+#       may_merge_pr: false
+#       max_merge_risk: low
+#
+#     implementation:
+#       may_open_pr: true
+#       may_merge_pr: false
+#       max_merge_risk: low
+#       # required_evidence — named evidence items that must be present before an agent
+#       # may merge at this stage. Absence of any listed item causes the agent to stop.
+#       # Example values: regression, smoke_test, security_review
+#       required_evidence:
+#         - regression
+#
+#   # stop_conditions — situations in which an agent must stop and defer to a human,
+#   # regardless of mode and regardless of per-stage permissions.
+#   # These conditions are NEVER weaker than today's behavior; they hold in all modes.
+#   stop_conditions:
+#     - unclear_requirements          # requirement or acceptance criterion is ambiguous
+#     - architecture_decision         # choice requires human input on architecture
+#     - failing_ci                    # required CI checks are red
+#     - unresolved_blocking_review    # a blocking review thread is unresolved
+#     - high_risk_change              # classified risk exceeds the configured max_merge_risk
+#     - destructive_action            # action would delete branches, data, or releases
+#     - missing_tracker_context       # work item is missing required tracker metadata
+#     - missing_required_secret_or_permission  # a required credential or GitHub permission is absent
+#
+#   # audit — records that an agent must create after acting under delegated or autonomous mode.
+#   audit:
+#     # pr_disposition_record — a stable comment on the PR summarizing the merge decision,
+#     # the risk classification, and the evidence consulted. Required in delegated/autonomous.
+#     pr_disposition_record: required
+#     # work_item_ledger_record — a comment on the work item (issue/tracker card) recording
+#     # the stage completed, the PR merged, and the agent session that acted.
+#     # Required in delegated/autonomous.
+#     work_item_ledger_record: required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Add guardrails config model and documentation** (#979): introduce an optional, fully commented `guardrails` section in `.ai-dev-workflow.yaml` and a new `guardrails.md` reference covering the four autonomy modes, per-stage permissions, the risk scale, stop conditions, audit requirements, and safe defaults that preserve current behavior. Documentation/model only; enforcement is tracked by #980.
+
 ## [0.32.0] - 2026-06-16
 
 ### Added

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -445,6 +445,40 @@ template:
   is_template: true
   repository: ""
   last_synced_version: ""
+
+# Optional. Omit to keep today's conservative behavior (mode: manual).
+# MODEL ONLY — enforcement tracked by #980. See guardrails.md.
+guardrails:
+  mode: manual
+  backlog_start:
+    allow_without_confirmation: false
+  stages:
+    spec:
+      may_open_pr: true
+      may_merge_pr: false
+      max_merge_risk: low
+    plan:
+      may_open_pr: true
+      may_merge_pr: false
+      max_merge_risk: low
+    implementation:
+      may_open_pr: true
+      may_merge_pr: false
+      max_merge_risk: low
+      required_evidence:
+        - regression
+  stop_conditions:
+    - unclear_requirements
+    - architecture_decision
+    - failing_ci
+    - unresolved_blocking_review
+    - high_risk_change
+    - destructive_action
+    - missing_tracker_context
+    - missing_required_secret_or_permission
+  audit:
+    pr_disposition_record: required
+    work_item_ledger_record: required
 ```
 
 Important implementation notes:
@@ -470,6 +504,7 @@ Important implementation notes:
 - `template.is_template` when set to `true` marks this repository as a framework template. Protocol 02 Step 0 (Template-Fit Check) becomes mandatory: before writing any implementation plan, the tech lead must verify that the spec is sufficiently generic for all downstream consumers. Set to `true` in the template repository itself; omit or leave `false` in downstream consumer repositories.
 - `template.repository` is an optional `owner/repo` reference to the upstream template repository. When set, the retrospective protocol (Step 3b) cross-references each finding against that repository's issue tracker to classify findings as already tracked, already fixed, or a new upstream contribution candidate. Leave empty or omit to skip this step entirely. Note: this field is set by downstream consumer repos pointing back to their template origin; the template repo itself leaves this empty.
 - `template.last_synced_version` is written automatically by the sync-template skill after a successful sync (e.g., `v0.22.0`). The retrospective uses this value to identify closed template issues whose fix landed in a version newer than the downstream's last sync, surfacing "just sync" opportunities.
+- `guardrails` is an optional top-level section that declares how much authority AI agents have when advancing work through the development workflow. When the section is absent, all guardrails values resolve to safe defaults that preserve today's conservative, human-reviewed behavior (agents do not merge pull requests and do not start backlog work without confirmation). The default mode is `manual`. See [`guardrails.md`](guardrails.md) for the full reference, worked examples, and migration note. **MODEL ONLY in this pass** — enforcement is tracked by #980.
 
 Provider-specific setup still lives in the integration guides under `docs/workflow/development-workflow/integrations/`.
 
@@ -549,7 +584,8 @@ Protocol prefixes are stable family identifiers, not a promise of contiguous num
 ### Tooling And Configuration
 
 - `docs/workflow/development-workflow/agent-model-config.md`
-- `.ai-dev-workflow.yaml` - repo-level workflow integration manifest (`mode`, `workflow_hub.product_repos[]`, `product_repo.workflow_hub`, `review.on_draft.runner`, `review.on_draft.github`, `review.on_ready.github`, `template.is_template`, `template.repository`, `template.last_synced_version`, `issue_tracker.provider`, `vcs.provider`, `browser_automation.provider`)
+- `docs/workflow/development-workflow/guardrails.md` — plain-language reference for the guardrails configuration model: autonomy modes, per-stage permissions, risk scale, stop conditions, audit requirements, safe defaults, and worked examples
+- `.ai-dev-workflow.yaml` - repo-level workflow integration manifest (`mode`, `workflow_hub.product_repos[]`, `product_repo.workflow_hub`, `review.on_draft.runner`, `review.on_draft.github`, `review.on_ready.github`, `template.is_template`, `template.repository`, `template.last_synced_version`, `issue_tracker.provider`, `vcs.provider`, `browser_automation.provider`, `guardrails`)
 - `.ai-dev-workflow.local.example.yaml` - placeholder-only example for gitignored local checkout, secret-reference, review-runner, and tool overrides
 
 Repository helpers:

--- a/docs/workflow/development-workflow/guardrails.md
+++ b/docs/workflow/development-workflow/guardrails.md
@@ -1,0 +1,342 @@
+# Guardrails: Controlling Agent Autonomy
+
+Guardrails are this framework's way of answering one question up front: **how much
+should an AI agent be allowed to do on its own?**
+
+Without guardrails, the answer is buried in command flags passed at invocation
+time (`--delegate-review`, `--may-merge`, `--max-risk`), which means the policy
+changes depending on who is running the command and what flags they remember to
+pass. Guardrails move that policy into the repository's `.ai-dev-workflow.yaml`
+file so it is declared once, version-controlled, and readable by any adopter
+without looking at any protocol or script internals.
+
+A repository with guardrails configured still uses the same workflow stages (spec,
+plan, implementation, review, merge). Guardrails do not change the workflow's
+structure — they change who acts at each decision point: a human, or an agent
+acting within the repository's declared limits.
+
+> **This is model and documentation only in this pass.** The `guardrails` section
+> in `.ai-dev-workflow.yaml` is readable now but not yet enforced at runtime.
+> Wiring guardrails into delegated `/run-work` execution is tracked by issue #980.
+
+---
+
+## Autonomy Modes
+
+Every guardrails configuration declares exactly one **mode**. The mode is a
+named summary of the overall authority level. Per-stage permissions (see below)
+can refine the mode for individual stages, but the mode sets the baseline intent.
+
+| Code value   | Display label | What it means                                                                                                                                                         |
+| ------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `manual`     | Manual        | Agents draft and propose work but never merge and never start backlog work without confirmation. A human performs every merge. This is the conservative end.          |
+| `assisted`   | Assisted      | Agents prepare pull requests and gather review evidence automatically, but a human still makes every merge decision.                                                  |
+| `delegated`  | Delegated     | Agents may merge clean pull requests within configured per-stage permissions and risk limits, stopping for any documented stop condition.                             |
+| `autonomous` | Autonomous    | Agents may start eligible backlog work and merge across stages within configured permissions and risk limits, still honoring all stop conditions.                     |
+
+**Default**: When no `guardrails` section is present in `.ai-dev-workflow.yaml`,
+the mode resolves to `manual`. Existing repositories that take no action keep
+today's conservative behavior automatically.
+
+**Mode and per-stage permissions**: The mode sets a default expectation. When
+per-stage `may_merge_pr` or `max_merge_risk` values are set explicitly, those
+values take precedence over the mode's baseline for that stage, allowing
+fine-grained control (for example, `delegated` mode for spec and plan but `false`
+for implementation merges).
+
+---
+
+## Risk Scale
+
+When guardrails allow an agent to merge, a **risk level** is associated with
+each pull request. The agent compares the PR's classified risk against the stage's
+configured `max_merge_risk`. If the PR risk exceeds the limit, the agent stops
+and defers to a human.
+
+| Code value | Display label | What it means                                                            |
+| ---------- | ------------- | ------------------------------------------------------------------------ |
+| `low`      | Low           | Small, well-contained change with limited blast radius.                  |
+| `medium`   | Medium        | Moderate change touching multiple areas or with non-trivial behavior.    |
+| `high`     | High          | Large, sensitive, or wide-blast-radius change.                           |
+
+**Ordering**: `low` < `medium` < `high` by increasing risk.
+
+**Rule**: A stage's `max_merge_risk` means an agent may merge a pull request
+whose classified risk is at or below that level. Any pull request classified
+above that level triggers a stop, regardless of mode.
+
+---
+
+## Per-Stage Permissions
+
+Permissions can be configured independently for each of the three authored stages:
+`spec`, `plan`, and `implementation`. This lets a repository grant merge authority
+for documentation-heavy stages (spec and plan) while keeping implementation merges
+under human control.
+
+Each stage supports three fields:
+
+| Field              | Type    | Default | Meaning                                                                              |
+| ------------------ | ------- | ------- | ------------------------------------------------------------------------------------ |
+| `may_open_pr`      | boolean | `true`  | Whether an agent may open a pull request for this stage.                             |
+| `may_merge_pr`     | boolean | `false` | Whether an agent may merge a clean pull request for this stage.                      |
+| `max_merge_risk`   | string  | `low`   | The highest risk level (`low`, `medium`, or `high`) at which an agent may merge.    |
+| `required_evidence`| list    | `[]`    | Named evidence items that must be present before an agent may merge at this stage.   |
+
+**Example — spec and plan merges allowed, implementation merges forbidden**:
+
+```yaml
+guardrails:
+  mode: delegated
+  stages:
+    spec:
+      may_open_pr: true
+      may_merge_pr: true
+      max_merge_risk: medium
+    plan:
+      may_open_pr: true
+      may_merge_pr: true
+      max_merge_risk: medium
+    implementation:
+      may_open_pr: true
+      may_merge_pr: false   # human must merge implementation PRs
+      max_merge_risk: low
+```
+
+---
+
+## Backlog-Start Policy
+
+The `backlog_start` setting controls whether an agent may pick up a new backlog
+item and begin work without waiting for an explicit human instruction.
+
+| Field                          | Type    | Default | Meaning                                                                   |
+| ------------------------------ | ------- | ------- | ------------------------------------------------------------------------- |
+| `allow_without_confirmation`   | boolean | `false` | When `true`, agents in `autonomous` mode may start eligible items unprompted. |
+
+**Default is `false`**: Unless a repository explicitly opts in, agents wait for a
+human to confirm each new item before starting. This preserves the current
+behavior where a human invokes a workflow command to start each run.
+
+```yaml
+guardrails:
+  mode: autonomous
+  backlog_start:
+    allow_without_confirmation: true   # agents may self-start eligible backlog items
+```
+
+---
+
+## Required Evidence
+
+The `required_evidence` field on each stage lists named evidence items that must
+be present before an agent may merge a pull request for that stage. If any listed
+evidence item is absent, the agent must stop and wait for a human to provide or
+approve it.
+
+**Example — implementation stage requires regression evidence**:
+
+```yaml
+guardrails:
+  mode: delegated
+  stages:
+    implementation:
+      may_open_pr: true
+      may_merge_pr: true
+      max_merge_risk: high
+      required_evidence:
+        - regression       # a regression test run must have passed before merging
+```
+
+Recognized evidence values (additional values may be defined by future tooling):
+
+- `regression` — a regression test suite run has passed for this PR.
+- `smoke_test` — the smoke test runbook has been executed and passed.
+- `security_review` — a security review has been completed.
+
+---
+
+## Stop Conditions
+
+Stop conditions are situations in which an agent **must** stop and defer to a
+human, regardless of mode and regardless of per-stage permissions. They are not
+weaker than today's behavior in any mode.
+
+The following stop conditions are always in force:
+
+| Condition                             | When it fires                                                                          |
+| ------------------------------------- | -------------------------------------------------------------------------------------- |
+| `unclear_requirements`                | A requirement or acceptance criterion is ambiguous and cannot be safely resolved.      |
+| `architecture_decision`               | The work requires a human decision on architecture or technology.                      |
+| `failing_ci`                          | Required CI checks are red.                                                            |
+| `unresolved_blocking_review`          | A blocking review thread (from a reviewer or automated tool) is unresolved.            |
+| `high_risk_change`                    | The classified PR risk exceeds the stage's configured `max_merge_risk`.                |
+| `destructive_action`                  | The action would delete branches, data, releases, or other non-recoverable artifacts.  |
+| `missing_tracker_context`             | The work item is missing required tracker metadata (status, type, or linked spec).     |
+| `missing_required_secret_or_permission` | A required credential or GitHub permission is absent.                                |
+
+**These stops hold in all modes, including `autonomous`.** A repository cannot
+configure its way out of a stop condition. The guardrails model is about granting
+authority within safe limits, not removing the ability to stop.
+
+---
+
+## Audit Requirements
+
+When an agent acts under `delegated` or `autonomous` mode, it must leave a
+record of what it did and why. Two audit records are required:
+
+| Record                    | What it contains                                                                                                | Required in               |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `pr_disposition_record`   | A stable comment on the PR summarizing the merge decision, the risk classification, and the evidence consulted. | `delegated`, `autonomous` |
+| `work_item_ledger_record` | A comment on the work item (issue or tracker card) recording the stage completed, the PR merged, and the agent session that acted. | `delegated`, `autonomous` |
+
+These records are how a human can audit what agents did and why, without reading
+agent session logs. In `manual` and `assisted` modes, humans make every merge
+decision directly, so no disposition record is required (though agents may still
+leave informational comments).
+
+---
+
+## Safe Defaults and Migration Note
+
+**No action is required** for existing repositories. The `guardrails` section in
+`.ai-dev-workflow.yaml` is entirely optional.
+
+When no `guardrails` section is present — or when the section omits a field —
+the framework resolves that field to its documented safe default:
+
+| Field                                    | Safe default |
+| ---------------------------------------- | ------------ |
+| `mode`                                   | `manual`     |
+| `backlog_start.allow_without_confirmation` | `false`    |
+| `stages.*.may_open_pr`                   | `true`       |
+| `stages.*.may_merge_pr`                  | `false`      |
+| `stages.*.max_merge_risk`                | `low`        |
+| `stages.*.required_evidence`             | `[]` (none)  |
+
+**In `manual` mode with all defaults**, agent behavior is identical to what the
+framework has always done: agents draft pull requests and gather review evidence,
+but a human performs every merge and confirms each new backlog item before work
+starts.
+
+**Guardrails are opt-in.** Existing repositories that do nothing continue to work
+exactly as before. Adding a `guardrails` section with `mode: manual` is
+equivalent to taking no action — it documents the existing behavior explicitly
+without changing it.
+
+---
+
+## Worked Examples
+
+### Example 1: Manual (equivalent to taking no action)
+
+```yaml
+# .ai-dev-workflow.yaml
+guardrails:
+  mode: manual
+  backlog_start:
+    allow_without_confirmation: false
+```
+
+Agents draft PRs for all stages. Humans merge every PR. No agent starts a new
+backlog item unprompted.
+
+### Example 2: Assisted
+
+```yaml
+# .ai-dev-workflow.yaml
+guardrails:
+  mode: assisted
+  backlog_start:
+    allow_without_confirmation: false
+```
+
+Agents prepare pull requests and run review loops automatically. Humans still
+make every merge decision. The assisted mode is useful when you want agents to
+reduce manual setup and review-churn effort without delegating the merge click.
+
+### Example 3: Delegated (agents may merge clean spec, plan, and implementation PRs)
+
+```yaml
+# .ai-dev-workflow.yaml
+guardrails:
+  mode: delegated
+  backlog_start:
+    allow_without_confirmation: false
+  stages:
+    spec:
+      may_open_pr: true
+      may_merge_pr: true
+      max_merge_risk: medium
+    plan:
+      may_open_pr: true
+      may_merge_pr: true
+      max_merge_risk: medium
+    implementation:
+      may_open_pr: true
+      may_merge_pr: true
+      max_merge_risk: high
+      required_evidence:
+        - regression
+  stop_conditions:
+    - unclear_requirements
+    - architecture_decision
+    - failing_ci
+    - unresolved_blocking_review
+    - high_risk_change
+    - destructive_action
+    - missing_tracker_context
+    - missing_required_secret_or_permission
+  audit:
+    pr_disposition_record: required
+    work_item_ledger_record: required
+```
+
+Agents may merge clean spec, plan, and implementation pull requests within the
+configured risk limits and with regression evidence present for implementation.
+Any stop condition causes the agent to defer to a human, regardless of mode.
+Audit records are left after every agent-driven merge.
+
+### Example 4: Spec and plan delegated, implementation human-only
+
+```yaml
+# .ai-dev-workflow.yaml
+guardrails:
+  mode: delegated
+  stages:
+    spec:
+      may_open_pr: true
+      may_merge_pr: true
+      max_merge_risk: medium
+    plan:
+      may_open_pr: true
+      may_merge_pr: true
+      max_merge_risk: medium
+    implementation:
+      may_open_pr: true
+      may_merge_pr: false   # humans merge implementation PRs
+      max_merge_risk: low
+```
+
+A common setup for teams that trust agents to advance documentation-heavy stages
+(spec and plan) but want a human to review and merge every code change.
+
+---
+
+## Relationship to Existing Command Flags
+
+The `/run-epic` protocol exposes the same concepts through invocation-time flags:
+`--delegate-review`, `--may-merge`, `--max-risk <low|medium|high>`,
+`--may-start-backlog`, and the PR disposition record and epic ledger audit record
+requirements. These flags express the same authority model at the command level
+for a single epic or batch run.
+
+The `guardrails` section in `.ai-dev-workflow.yaml` gives these concepts a
+declarative, repo-level home so they do not need to be re-specified at each
+invocation. Reconciling the per-invocation flags with the repo-level guardrails
+configuration (so that the config takes effect automatically in `/run-work` runs)
+is tracked by issue #980 and is out of scope here.
+
+See `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` for
+the current `/run-epic` flag reference.


### PR DESCRIPTION
## What was implemented

This PR implements issue #979 (Add guardrails config model and documentation) — the first of three work items in the #977 guardrails epic. It is documentation and configuration only (no runtime enforcement); enforcement is tracked by #980.

**Two layers of changes:**

1. **`.ai-dev-workflow.yaml`** — adds an optional, fully commented `guardrails:` section with a leading note explaining the section is optional, values resolve to documented safe defaults, and enforcement is deferred to #980.

2. **`docs/workflow/development-workflow/guardrails.md`** (new file) — the canonical plain-language guardrails reference with 11 sections: what guardrails are, autonomy modes, risk scale, per-stage permissions, backlog-start policy, required evidence, stop conditions, audit requirements, safe defaults and migration note, worked examples, and relationship to existing `/run-epic` flags.

3. **`docs/workflow/development-workflow/README.md`** — updated "Workflow Configuration" section with `guardrails` in the schema example block, an implementation note bullet, and a "Tooling And Configuration" index entry.

## Links

- Spec: `docs/specs/developments/20260617083209_guardrails-config-model/1_guardrails-config-model_specs.md`
- Plan: `docs/specs/developments/20260617083209_guardrails-config-model/2_guardrails-config-model_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/guardrails-config-model.smoke-test.md`
- Epic: #977 | Enforcement follow-on: #980

## Test plan

1. Open `guardrails.md` and confirm a new adopter can understand the concept without reading code.
2. Confirm exactly four modes appear in both the doc and the config comments.
3. Confirm per-stage permissions are independent (Example 4: spec+plan allowed, implementation forbidden).
4. Confirm `backlog_start.allow_without_confirmation` default is `false`.
5. Confirm implementation stage `required_evidence: [regression]` in Example 3.
6. Confirm all 8 stop conditions are listed and stated to hold regardless of mode.
7. Confirm audit requirements section describes PR disposition and work-item ledger records.
8. Confirm safe-defaults table and migration note state taking no action is safe.
9. Run `scripts/development-workflow/validate-workflow-config.sh` — passes (verified locally).
10. Run `markdownlint-cli2` on changed docs — 0 errors (verified locally).

## CHANGELOG entry preview

```
### Added
- **Add guardrails config model and documentation** (#979): introduce an optional, fully commented `guardrails` section in `.ai-dev-workflow.yaml` and a new `guardrails.md` reference covering the four autonomy modes, per-stage permissions, the risk scale, stop conditions, audit requirements, and safe defaults that preserve current behavior. Documentation/model only; enforcement is tracked by #980.
```

## Pre-submission self-review

- Stale markers: none found in diff.
- Sibling/caller consistency: field names, mode code values, risk labels, and stop-condition names are identical across `.ai-dev-workflow.yaml`, `guardrails.md`, and `README.md`. Verified with targeted greps.
- Coverage: all 11 spec acceptance criteria addressed.