### PR TITLE
fix(workflow): prevent scope drift and parallel branch races in epics

### DIFF
--- a/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
@@ -511,6 +511,7 @@ Execute each step from the implementation plan in order.
 - Follow the implementation order in the plan
 - If you hit a spec gap (something not covered by the spec), **stop and report** — do not make unilateral decisions
 - If the scope is larger than the plan described, **stop and report**
+- Do not write, modify, or stage any file outside the plan's stated scope, even as a working-tree-only change. Discard any accidental out-of-scope modifications before committing.
 - After each logical chunk of work, verify your changes are still building
 
 **After schema/model changes** (if applicable):

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -354,6 +354,19 @@ This step applies only when the invocation policy includes `--delegate-review`.
 Without delegated review authority, any PR that reaches the normal
 `ready-for-human-review` handoff remains waiting for human review.
 
+**Pre-dispatch: create the integration branch once before dispatching parallel agents.**
+If the resolved base branch does not yet exist on the remote, create and push it
+exactly once before dispatching any in-scope item agents:
+
+```bash
+git checkout -b <base-branch> origin/develop  # or the appropriate upstream
+git push -u origin <base-branch>
+```
+
+Do this in the orchestrator context, not inside a dispatched agent. Parallel
+agents must not race to create the same branch from `develop` — this produces
+divergent starting HEADs and stacked-branch contamination across sibling items.
+
 For each in-scope item:
 
 1. Advance the item with the existing `/run-item-work` or stage protocol. Do not


### PR DESCRIPTION
## Summary

- **Protocol 95 Step 8**: orchestrator must create the integration branch once before dispatching parallel agents — prevents divergent starting HEADs and stacked-branch contamination between sibling items racing to create the same branch
- **Protocol 03 Step 4**: explicit rule prohibiting out-of-scope working-tree changes (even uncommitted) during implementation — prevents developer agents silently implementing beyond the accepted plan scope

## Background

Surfaced by the epic #988 retrospective (2026-06-17). During the parallel dispatch of #989/#990/#991, all three agents independently attempted to create `develop-cursor-bugbot-integration`, and the #991 developer agent implemented unplanned `pr-review-loop.sh` changes in the working tree (discarded before commit). Backlog items #1004 and #1005 track the deeper fixes.

## Test plan

- [ ] Review protocol 95 Step 8 pre-dispatch block for clarity
- [ ] Review protocol 03 Step 4 new rule for clarity
- [ ] Confirm no other protocol sections need the same integration-branch guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)