### PR TITLE
fix(protocols): add pre-branch HEAD guard against contamination (#1004)

### DIFF
--- a/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
+++ b/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
@@ -256,7 +256,23 @@ If no blocking human decision remains:
 1. Determine the branch slug:
    - **With issue tracker**: `[issue-id]-[feature-slug]` (e.g., `ENG-123-user-auth`)
    - **Without issue tracker**: `[feature-slug]` (e.g., `user-auth`)
-2. Create branch: `git checkout -b spec/[branch-slug]` from `develop`
+2. Create branch from `develop` — but first run the **pre-branch HEAD verification** to prevent stacked-branch contamination in shared-checkout parallel execution:
+
+   ```bash
+   git fetch origin
+   git checkout develop && git pull origin develop
+   EXPECTED_SHA=$(git rev-parse "origin/develop")
+   ACTUAL_SHA=$(git rev-parse HEAD)
+   if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+     echo "ERROR: HEAD ($ACTUAL_SHA) does not match origin/develop ($EXPECTED_SHA)." >&2
+     echo "A sibling agent may have moved this checkout. Abort rather than create a stacked branch." >&2
+     exit 1
+   fi
+   echo "Pre-branch HEAD check passed: HEAD matches origin/develop"
+   git checkout -b spec/[branch-slug]
+   ```
+
+   If the check fails, do not proceed. Report the mismatch to the caller so the working tree can be reset before retrying.
 3. Create the development folder: `docs/specs/developments/[YYYYMMDDHHMMSS]_[feature-slug]/`
 4. Write the spec file: `1_[feature-slug]_specs.md`
 5. **Board membership check (when a tracker issue ID is present)**: If an issue number is available (i.e., the workflow uses a configured issue tracker and an issue ID was provided or created), call `ensure_on_project_board <issue_number> "Writing Spec"` (sourcing `scripts/development-workflow/workflow-lib.sh`). If the issue is already on the project board, this is a no-op. If it is not, the function adds it and sets initial status to "Writing Spec". On any API failure, the function logs a warning and continues — this step must never block the commit or PR creation. Skip this step entirely when no issue ID is present (no-tracker workflows).

--- a/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
+++ b/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
@@ -261,8 +261,10 @@ If no blocking human decision remains:
    ```bash
    git fetch origin
    git checkout develop && git pull origin develop
-   EXPECTED_SHA=$(git rev-parse "origin/develop")
-   ACTUAL_SHA=$(git rev-parse HEAD)
+   EXPECTED_SHA=$(git rev-parse "origin/develop") \
+     || { echo "ERROR: git rev-parse origin/develop failed — verify the remote ref exists." >&2; exit 1; }
+   ACTUAL_SHA=$(git rev-parse HEAD) \
+     || { echo "ERROR: git rev-parse HEAD failed — check repository state." >&2; exit 1; }
    if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
      echo "ERROR: HEAD ($ACTUAL_SHA) does not match origin/develop ($EXPECTED_SHA)." >&2
      echo "A sibling agent may have moved this checkout. Abort rather than create a stacked branch." >&2

--- a/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -303,7 +303,23 @@ If no blocking human decision remains:
 1. Determine the branch slug:
    - **With issue tracker**: `[issue-id]-[feature-slug]` (e.g., `ENG-123-user-auth`)
    - **Without issue tracker**: `[feature-slug]` (e.g., `user-auth`)
-2. Create branch: `git checkout -b implementation-plan/[branch-slug]` from `develop`
+2. Create branch from `develop` — but first run the **pre-branch HEAD verification** to prevent stacked-branch contamination in shared-checkout parallel execution:
+
+   ```bash
+   git fetch origin
+   git checkout develop && git pull origin develop
+   EXPECTED_SHA=$(git rev-parse "origin/develop")
+   ACTUAL_SHA=$(git rev-parse HEAD)
+   if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+     echo "ERROR: HEAD ($ACTUAL_SHA) does not match origin/develop ($EXPECTED_SHA)." >&2
+     echo "A sibling agent may have moved this checkout. Abort rather than create a stacked branch." >&2
+     exit 1
+   fi
+   echo "Pre-branch HEAD check passed: HEAD matches origin/develop"
+   git checkout -b implementation-plan/[branch-slug]
+   ```
+
+   If the check fails, do not proceed. Report the mismatch to the caller so the working tree can be reset before retrying.
 3. Write the plan file
 4. Write the smoke test runbook
 5. **Board membership check (when a tracker issue ID is present)**: If an issue number is available, call `ensure_on_project_board <issue_number> "Writing Plan"` (sourcing `scripts/development-workflow/workflow-lib.sh`). If the issue is already on the project board, this is a no-op. If it is not, the function adds it and sets initial status to "Writing Plan". On any API failure, the function logs a warning and continues — this step must never block the commit or PR creation. Skip this step entirely when no issue ID is present (no-tracker workflows).

--- a/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -308,8 +308,10 @@ If no blocking human decision remains:
    ```bash
    git fetch origin
    git checkout develop && git pull origin develop
-   EXPECTED_SHA=$(git rev-parse "origin/develop")
-   ACTUAL_SHA=$(git rev-parse HEAD)
+   EXPECTED_SHA=$(git rev-parse "origin/develop") \
+     || { echo "ERROR: git rev-parse origin/develop failed — verify the remote ref exists." >&2; exit 1; }
+   ACTUAL_SHA=$(git rev-parse HEAD) \
+     || { echo "ERROR: git rev-parse HEAD failed — check repository state." >&2; exit 1; }
    if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
      echo "ERROR: HEAD ($ACTUAL_SHA) does not match origin/develop ($EXPECTED_SHA)." >&2
      echo "A sibling agent may have moved this checkout. Abort rather than create a stacked branch." >&2

--- a/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
@@ -494,7 +494,7 @@ Determine the branch slug:
 git checkout develop && git pull origin develop
 # If integration-branch:<slug> label is present, use develop-<slug> instead:
 # git checkout develop-<slug> && git pull origin develop-<slug>
-git checkout -b feature/[branch-slug]   # or fix/[branch-slug], refactor/[branch-slug]
+# (do NOT run git checkout -b here — the branch is created below after the HEAD guard)
 ```
 
 The PR opened at the end of this path must target `develop-<slug>` when the label is present. If the integration branch does not exist yet, the orchestrator should have created it before dispatching this protocol — do not create it here; instead, stop and inform the Work Item Runner.
@@ -503,8 +503,10 @@ The PR opened at the end of this path must target `develop-<slug>` when the labe
 
 ```bash
 BASE_BRANCH="develop"  # or develop-<slug> when an integration-branch label is present
-EXPECTED_SHA=$(git rev-parse "origin/${BASE_BRANCH}")
-ACTUAL_SHA=$(git rev-parse HEAD)
+EXPECTED_SHA=$(git rev-parse "origin/${BASE_BRANCH}") \
+  || { echo "ERROR: git rev-parse origin/${BASE_BRANCH} failed — verify the remote ref exists." >&2; exit 1; }
+ACTUAL_SHA=$(git rev-parse HEAD) \
+  || { echo "ERROR: git rev-parse HEAD failed — check repository state." >&2; exit 1; }
 if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
   echo "ERROR: HEAD ($ACTUAL_SHA) does not match origin/${BASE_BRANCH} ($EXPECTED_SHA)." >&2
   echo "A sibling agent may have moved this checkout. Abort rather than create a stacked branch." >&2
@@ -856,8 +858,10 @@ git pull origin develop
 
 ```bash
 BASE_BRANCH="develop"
-EXPECTED_SHA=$(git rev-parse "origin/${BASE_BRANCH}")
-ACTUAL_SHA=$(git rev-parse HEAD)
+EXPECTED_SHA=$(git rev-parse "origin/${BASE_BRANCH}") \
+  || { echo "ERROR: git rev-parse origin/${BASE_BRANCH} failed — verify the remote ref exists." >&2; exit 1; }
+ACTUAL_SHA=$(git rev-parse HEAD) \
+  || { echo "ERROR: git rev-parse HEAD failed — check repository state." >&2; exit 1; }
 if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
   echo "ERROR: HEAD ($ACTUAL_SHA) does not match origin/${BASE_BRANCH} ($EXPECTED_SHA)." >&2
   echo "A sibling agent may have moved this checkout. Abort rather than create a stacked branch." >&2
@@ -1106,8 +1110,10 @@ git checkout develop && git pull origin develop
 
 ```bash
 BASE_BRANCH="develop"  # or develop-<slug> when an integration-branch label is present
-EXPECTED_SHA=$(git rev-parse "origin/${BASE_BRANCH}")
-ACTUAL_SHA=$(git rev-parse HEAD)
+EXPECTED_SHA=$(git rev-parse "origin/${BASE_BRANCH}") \
+  || { echo "ERROR: git rev-parse origin/${BASE_BRANCH} failed — verify the remote ref exists." >&2; exit 1; }
+ACTUAL_SHA=$(git rev-parse HEAD) \
+  || { echo "ERROR: git rev-parse HEAD failed — check repository state." >&2; exit 1; }
 if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
   echo "ERROR: HEAD ($ACTUAL_SHA) does not match origin/${BASE_BRANCH} ($EXPECTED_SHA)." >&2
   echo "A sibling agent may have moved this checkout. Abort rather than create a stacked branch." >&2
@@ -1359,8 +1365,10 @@ git pull origin main
 **Pre-branch HEAD verification (mandatory — run before `git checkout -b`)**: Before creating the hotfix branch, verify that HEAD matches `origin/main` to prevent accidental stacking on a non-main commit:
 
 ```bash
-EXPECTED_SHA=$(git rev-parse "origin/main")
-ACTUAL_SHA=$(git rev-parse HEAD)
+EXPECTED_SHA=$(git rev-parse "origin/main") \
+  || { echo "ERROR: git rev-parse origin/main failed — verify the remote ref exists." >&2; exit 1; }
+ACTUAL_SHA=$(git rev-parse HEAD) \
+  || { echo "ERROR: git rev-parse HEAD failed — check repository state." >&2; exit 1; }
 if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
   echo "ERROR: HEAD ($ACTUAL_SHA) does not match origin/main ($EXPECTED_SHA)." >&2
   echo "A sibling agent may have moved this checkout. Abort rather than create a stacked branch." >&2

--- a/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/03-implement-development-protocol.md
@@ -499,6 +499,23 @@ git checkout -b feature/[branch-slug]   # or fix/[branch-slug], refactor/[branch
 
 The PR opened at the end of this path must target `develop-<slug>` when the label is present. If the integration branch does not exist yet, the orchestrator should have created it before dispatching this protocol — do not create it here; instead, stop and inform the Work Item Runner.
 
+**Pre-branch HEAD verification (mandatory — run before `git checkout -b`)**: Before creating any branch, verify that the current HEAD matches the expected base. This guard prevents stacked-branch contamination when sibling agents share the same checkout (e.g., in parallel epic dispatch without worktree isolation):
+
+```bash
+BASE_BRANCH="develop"  # or develop-<slug> when an integration-branch label is present
+EXPECTED_SHA=$(git rev-parse "origin/${BASE_BRANCH}")
+ACTUAL_SHA=$(git rev-parse HEAD)
+if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+  echo "ERROR: HEAD ($ACTUAL_SHA) does not match origin/${BASE_BRANCH} ($EXPECTED_SHA)." >&2
+  echo "A sibling agent may have moved this checkout. Abort rather than create a stacked branch." >&2
+  exit 1
+fi
+echo "Pre-branch HEAD check passed: HEAD matches origin/${BASE_BRANCH}"
+git checkout -b feature/[branch-slug]   # or fix/[branch-slug], refactor/[branch-slug]
+```
+
+If the check fails, do not proceed. Report the mismatch to the caller so the working tree can be reset to the correct base before retrying.
+
 **Worktree context (`BATCH_CONTEXT=true`)**: If this step runs inside an isolated worktree created by the item-orchestrator (Protocol 91 Step 3), skip the `git checkout develop` / `git checkout -b` commands above — the worktree was already created on the correct branch. Run only `git fetch origin` if you need the latest remote refs. Before running any git state-changing command, confirm your working directory is inside the worktree path, not the main repo root (run `pwd` and compare). See the "Critical: Worktree Git Discipline" block in Protocol 91 Step 3 for the full pre-operation checklist.
 
 ### Step 4: Implement
@@ -833,8 +850,24 @@ Do not proceed to the Refactor Steps until this checklist is complete and all se
 git fetch origin
 git checkout develop
 git pull origin develop
+```
+
+**Pre-branch HEAD verification (mandatory — run before `git checkout -b`)**: Before creating the branch, verify that HEAD matches the expected base to prevent stacked-branch contamination in shared-checkout parallel execution:
+
+```bash
+BASE_BRANCH="develop"
+EXPECTED_SHA=$(git rev-parse "origin/${BASE_BRANCH}")
+ACTUAL_SHA=$(git rev-parse HEAD)
+if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+  echo "ERROR: HEAD ($ACTUAL_SHA) does not match origin/${BASE_BRANCH} ($EXPECTED_SHA)." >&2
+  echo "A sibling agent may have moved this checkout. Abort rather than create a stacked branch." >&2
+  exit 1
+fi
+echo "Pre-branch HEAD check passed: HEAD matches origin/${BASE_BRANCH}"
 git checkout -b refactor/[branch-slug]
 ```
+
+If the check fails, do not proceed. Report the mismatch to the caller so the working tree can be reset before retrying.
 
 **Worktree context (`BATCH_CONTEXT=true`)**: If this step runs inside an isolated worktree created by the item-orchestrator (Protocol 91 Step 3), skip the `git checkout develop` / `git checkout -b` commands above — the worktree was already created on the correct branch. Run only `git fetch origin` if you need the latest remote refs. Before running any git state-changing command, confirm your working directory is inside the worktree path, not the main repo root (run `pwd` and compare). See the "Critical: Worktree Git Discipline" block in Protocol 91 Step 3 for the full pre-operation checklist.
 
@@ -1067,8 +1100,24 @@ Branch from `develop` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without)
 git checkout develop && git pull origin develop
 # If integration-branch:<slug> label is present, use develop-<slug> instead:
 # git checkout develop-<slug> && git pull origin develop-<slug>
+```
+
+**Pre-branch HEAD verification (mandatory — run before `git checkout -b`)**: Before creating the branch, verify that HEAD matches the expected base to prevent stacked-branch contamination in shared-checkout parallel execution:
+
+```bash
+BASE_BRANCH="develop"  # or develop-<slug> when an integration-branch label is present
+EXPECTED_SHA=$(git rev-parse "origin/${BASE_BRANCH}")
+ACTUAL_SHA=$(git rev-parse HEAD)
+if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+  echo "ERROR: HEAD ($ACTUAL_SHA) does not match origin/${BASE_BRANCH} ($EXPECTED_SHA)." >&2
+  echo "A sibling agent may have moved this checkout. Abort rather than create a stacked branch." >&2
+  exit 1
+fi
+echo "Pre-branch HEAD check passed: HEAD matches origin/${BASE_BRANCH}"
 git checkout -b fix/[branch-slug]
 ```
+
+If the check fails, do not proceed. Report the mismatch to the caller so the working tree can be reset before retrying.
 
 The PR opened at the end of this path must target `develop-<slug>` when the label is present. If the integration branch does not exist yet, the orchestrator should have created it before dispatching this protocol — do not create it here; instead, stop and inform the Work Item Runner.
 
@@ -1305,8 +1354,23 @@ Branch from `main` (slug: `[issue-id]-[slug]` with tracker, `[slug]` without):
 git fetch origin
 git checkout main
 git pull origin main
+```
+
+**Pre-branch HEAD verification (mandatory — run before `git checkout -b`)**: Before creating the hotfix branch, verify that HEAD matches `origin/main` to prevent accidental stacking on a non-main commit:
+
+```bash
+EXPECTED_SHA=$(git rev-parse "origin/main")
+ACTUAL_SHA=$(git rev-parse HEAD)
+if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+  echo "ERROR: HEAD ($ACTUAL_SHA) does not match origin/main ($EXPECTED_SHA)." >&2
+  echo "A sibling agent may have moved this checkout. Abort rather than create a stacked branch." >&2
+  exit 1
+fi
+echo "Pre-branch HEAD check passed: HEAD matches origin/main"
 git checkout -b hotfix/[branch-slug]
 ```
+
+If the check fails, do not proceed. Report the mismatch to the caller so the working tree can be reset before retrying.
 
 **Worktree context (`BATCH_CONTEXT=true`)**: If this step runs inside an isolated worktree created by the item-orchestrator (Protocol 91 Step 3), skip the `git checkout main` / `git checkout -b` commands above — the worktree was already created on the correct branch. Run only `git fetch origin` if you need the latest remote refs. Before running any git state-changing command, confirm your working directory is inside the worktree path, not the main repo root (run `pwd` and compare). See the "Critical: Worktree Git Discipline" block in Protocol 91 Step 3 for the full pre-operation checklist.
 

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -373,7 +373,9 @@ step. Before running `git checkout -b`, every agent compares its current HEAD
 SHA against the expected base (`origin/develop` or the integration branch). If
 they differ — indicating that a sibling agent moved the checkout — the agent
 aborts immediately with a clear error rather than silently stacking its branch
-on top of a sibling's commits.
+on top of a sibling's commits. When the guard fires, recovery is: (1) reset the
+working tree to the expected base with `git checkout develop && git pull origin
+develop`, then (2) re-run the agent from branch creation.
 
 **Intended long-term fix — worktree isolation**: The durable solution to
 shared-checkout contamination is to dispatch each parallel agent into a

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -367,6 +367,25 @@ Do this in the orchestrator context, not inside a dispatched agent. Parallel
 agents must not race to create the same branch from `develop` — this produces
 divergent starting HEADs and stacked-branch contamination across sibling items.
 
+**Current mitigation — pre-branch HEAD guard (short-term)**: Each agent protocol
+(Protocols 01, 02, and 03) now includes a mandatory pre-branch HEAD verification
+step. Before running `git checkout -b`, every agent compares its current HEAD
+SHA against the expected base (`origin/develop` or the integration branch). If
+they differ — indicating that a sibling agent moved the checkout — the agent
+aborts immediately with a clear error rather than silently stacking its branch
+on top of a sibling's commits.
+
+**Intended long-term fix — worktree isolation**: The durable solution to
+shared-checkout contamination is to dispatch each parallel agent into a
+separate `git worktree` (one worktree per item). With worktree isolation, each
+agent has its own working tree backed by the shared `.git` directory, so no
+agent can disturb another's HEAD or uncommitted changes. Protocol 91 Step 3
+already supports this model via the `BATCH_CONTEXT=true` / worktree path
+contract. Future `/run-epic` parallel dispatch should set `isolation: worktree`
+(or equivalent) so item-orchestrators create a dedicated worktree before
+handing off to each agent, making the pre-branch guard redundant for parallel
+runs while keeping it as a backstop for single-checkout fallback.
+
 For each in-scope item:
 
 1. Advance the item with the existing `/run-item-work` or stage protocol. Do not


### PR DESCRIPTION
## Summary

Adds a mandatory pre-branch HEAD verification step to Protocols 01 (Spec), 02 (Plan), and 03 (Implementation) — all four implementation paths (Full Pipeline, Refactor, Fast Track, Hotfix). Protocol 95 (Run Epic) Step 8 is updated to document worktree isolation as the intended long-term fix.

## Problem

Issue #1004: When `/run-epic` dispatches multiple agents in parallel against a shared git checkout, two contamination patterns can occur:

**A — Working-tree cross-contamination**: Agent for one item leaks uncommitted changes to a sibling.

**B — Stacked-branch contamination**: `git checkout -b spec/990` silently landed on top of `spec/989`'s HEAD when sibling local branches existed, because `git checkout -b` creates from wherever HEAD currently is. Recovery required `git reset` + cherry-pick.

## Fix

**Short-term (implemented in this PR)**: Before any `git checkout -b`, each protocol now requires the agent to run:

```bash
EXPECTED_SHA=$(git rev-parse "origin/${BASE_BRANCH}")
ACTUAL_SHA=$(git rev-parse HEAD)
if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
  echo "ERROR: HEAD does not match origin/${BASE_BRANCH}. Abort." >&2
  exit 1
fi
```

If the SHAs differ — indicating a sibling agent has moved the checkout — the agent aborts with a clear error rather than silently creating a stacked branch.

**Long-term (documented in Protocol 95 Step 8)**: Use `git worktree` isolation per item so each parallel agent has its own working tree.

## Files Changed

- `docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md` — Step 5 branch creation
- `docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md` — Step 5 branch creation
- `docs/workflow/development-workflow/protocols/03-implement-development-protocol.md` — Path 1 Step 3, Path 2 Refactor Steps, Path 3 Step 3, Path 4 Step 3
- `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` — Step 8 pre-dispatch block
- `CHANGELOG.md` — `### Fixed` under `[Unreleased]`

## Test Plan

- Review each protocol's branch-creation step and confirm the guard runs before `git checkout -b`
- Confirm the guard uses `git rev-parse "origin/${BASE_BRANCH}"` (remote SHA) not the local branch SHA
- Confirm Protocol 95 Step 8 explains both the short-term guard and the long-term worktree isolation intent
- Confirm no existing text was removed or changed beyond what the fix requires

## Pre-Submission Self-Review

Pre-submission self-review: stale markers — none, caller consistency — all 5 protocol locations updated consistently with the same guard pattern, coverage — issue body's stated problem (stacked-branch contamination) and proposed fix (pre-branch HEAD check + Protocol 95 worktree note) both addressed.

Checklist applicability:
- Test Harness Coverage Checklist: not applicable — no test harness added
- Filter-Schema Canary Test Checklist: not applicable — no filter parameters
- Script-Accuracy Self-Check Checklist: not applicable — no script behavior described (guard is embedded protocol text, not a script)
- Shell Script Quality Checklist item 8 (shell blocks in .md files): applied — multi-step blocks include exit code checks; no state mutation beyond the `git checkout -b` they guard