### PR TITLE
fix(protocols): require live tracker verify after epic merge (#1005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Document signal-safety of Bugbot polling sleep** (#1008): confirm that the `_interruptible_sleep` call in `run_bugbot_review`'s polling loop is already SIGTERM-safe (sleep runs as a background job; bash's `wait` is interrupted by signals; the TERM trap kills the subprocess immediately). Add an inline comment at the call site explaining this so future readers need not re-investigate.
 - **Add pre-branch HEAD verification guard against parallel-agent stacked-branch contamination** (#1004): Protocols 01, 02, and 03 now require a mandatory pre-branch HEAD check before any `git checkout -b` — the agent compares its current HEAD SHA against the expected base (`origin/develop` or `origin/main`) and aborts with a clear error if they differ, preventing silent stacked-branch creation when sibling agents share a checkout. Protocol 95 Step 8 documents worktree isolation as the intended long-term fix and the pre-branch guard as the current mitigation.
+- **Verify tracker status after delegated merge in run-epic** (#1005): Protocol 95 Step 11 now requires runners to re-read the live GitHub Projects status after each delegated merge, re-apply the tracker update if the live value does not match the expected post-merge status, and record the verification result (matched/reapplied/failed) in the PR disposition audit comment — preventing false-positive tracker-update claims from leaving items stuck at stale statuses.
 
 ## [0.32.0] - 2026-06-16
 

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -486,7 +486,32 @@ When all gates permit merge:
 2. Verify GitHub reports the PR state as `MERGED`.
 3. Delete or prune the merged branch as appropriate.
 4. Run post-merge cleanup for the correct base branch.
-5. Verify issue state and Project status.
+5. Verify issue state and Project status — **with live re-read and re-apply**:
+
+   a. Determine the expected post-merge tracker status from the merged branch type
+      (see Protocol 91 Step 10 table: `feature/*` / `fix/*` / `refactor/*` /
+      `hotfix/*` → `Merged`; `spec/*` → `Spec Ready`; `implementation-plan/*` →
+      `Plan Ready`).
+
+   b. Re-read the live tracker status from GitHub Projects:
+
+      ```bash
+      gh issue view <issue_number> --json projectItems \
+        --jq '.projectItems[].status.name // "unknown"'
+      ```
+
+   c. If the live status does not match the expected post-merge value, re-apply
+      the tracker update immediately before proceeding to the next item. Do not
+      rely on the agent's earlier claim that the update succeeded — the live
+      read is the authoritative source.
+
+   d. Record the verification result (expected value, live-read value, and
+      whether a re-apply was required) in the PR disposition audit comment for
+      this item. Add a `tracker_status_verified` field with value `true` when
+      the live status matched on first read, or `reapplied` when the re-apply
+      was required. Add `tracker_status_mismatch` with a brief reason when the
+      re-apply also fails.
+
 6. Update the epic ledger.
 7. Rerun scope resolution so newly unblocked items can advance.
 


### PR DESCRIPTION
## Summary

Protocol 95 Step 11 adds an explicit tracker-status verification step after each delegated merge in a `/run-epic` run.

### Problem

After a delegated merge, item agents were claiming to have updated the tracker status but the live GitHub Projects status remained stale (e.g., stuck at "Development in Review" instead of "Merged"). This was observed on epic #988 item #990 on 2026-06-17, and is a recurrence of patterns seen in Batches 38, 49, and 65.

### Fix

Protocol 95 Step 11 now requires the runner to:
1. Determine the expected post-merge tracker status from the branch type (using the Protocol 91 Step 10 table).
2. Re-read the live GitHub Projects status via `gh issue view <issue_number> --json projectItems --jq '.projectItems[].status.name'`.
3. Re-apply the tracker update if the live value does not match the expected value.
4. Record the verification result (`tracker_status_verified: true/reapplied`, or `tracker_status_mismatch` on failure) in the PR disposition audit comment.

### Files changed

- `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` — Step 11 expanded with sub-steps a–d for tracker verification
- `CHANGELOG.md` — entry added under `[Unreleased] ### Fixed`

### Test plan

- Review Step 11 sub-steps a–d for correctness of the `gh issue view` command and the audit-field names
- Confirm the branch-type → expected status mapping references Protocol 91 Step 10 (cross-reference only, no duplication)
- Confirm `run-epic-delegated-gate.sh` is unchanged (it is read-only and has no post-merge steps)

## Pre-submission self-review

- Stale markers: none
- Caller/sibling consistency: Step 11 cross-references Protocol 91 Step 10 table for the branch-type → status mapping; no duplication introduced; `run-epic-delegated-gate.sh` confirmed read-only with no post-merge tracker steps
- Coverage: issue body asks for live re-read, re-apply, and audit recording — all three are in the updated Step 11 sub-steps a–d
- No shell code changes; no `.sh` files modified; ShellCheck N/A
- No string renames; renamed-string scan N/A