### PR TITLE
fix(workflow): backport downstream sync corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Downstream template-sync corrections**: `run_bugbot_review` now fails closed on Bugbot fetch/parse errors before trigger and while collecting comments/reviews, and workflow shell tests use portable `cp` syntax.
+
 ## [0.33.0] - 2026-06-17
 
 ### Added

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1237,6 +1237,8 @@ run_bugbot_review() {
   # If blocking findings already exist (e.g. from a previous trigger in the same
   # review cycle) return needs_fixes immediately without re-triggering.
   set +e
+  local _existing_comments_rc=0
+  local _existing_reviews_rc=0
   existing_comments="$(
     gh api "repos/$repo/pulls/$pr_number/comments" --paginate 2>/dev/null \
       | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
@@ -1246,6 +1248,7 @@ run_bugbot_review() {
           | @json
         ' 2>/dev/null
   )"
+  _existing_comments_rc=$?
   existing_reviews="$(
     gh api "repos/$repo/pulls/$pr_number/reviews" --paginate 2>/dev/null \
       | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
@@ -1262,7 +1265,21 @@ run_bugbot_review() {
           | @json
         ' 2>/dev/null
   )"
+  _existing_reviews_rc=$?
   set -e
+  if [ "$_existing_comments_rc" -ne 0 ] || [ "$_existing_reviews_rc" -ne 0 ]; then
+    echo "WARN: run_bugbot_review: existing finding fetch/parse failed for PR #$pr_number — returning unavailable" >&2
+    print_kv RESULT escalate
+    print_kv REASON fetch-failed
+    print_kv PLATFORM "$platform"
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv COMMENT_COUNT 0
+    print_kv BLOCKING_COUNT 0
+    print_kv SUGGESTION_COUNT 0
+    return 2
+  fi
 
   existing_blocking_file="$(mktemp)"
 
@@ -1319,6 +1336,7 @@ run_bugbot_review() {
   # the current head. If none exists, post the trigger comment (idempotent).
   set +e
   local _bb_run_count
+  local _bb_run_count_rc=0
   _bb_run_count="$(
     gh api "repos/$repo/commits/$head_sha/check-runs" --paginate 2>/dev/null \
       | jq -se --arg name "$check_name" '
@@ -1330,7 +1348,21 @@ run_bugbot_review() {
           ] | length
         ' 2>/dev/null
   )"
+  _bb_run_count_rc=$?
   set -e
+  if [ "$_bb_run_count_rc" -ne 0 ] || [ -z "$_bb_run_count" ]; then
+    echo "WARN: run_bugbot_review: check-run fetch/parse failed for PR #$pr_number (SHA=$head_sha) — returning unavailable" >&2
+    print_kv RESULT escalate
+    print_kv REASON fetch-failed
+    print_kv PLATFORM "$platform"
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv COMMENT_COUNT 0
+    print_kv BLOCKING_COUNT 0
+    print_kv SUGGESTION_COUNT 0
+    return 2
+  fi
   _bb_run_count="${_bb_run_count:-0}"
 
   if [ "$_bb_run_count" -eq 0 ]; then
@@ -1413,6 +1445,7 @@ run_bugbot_review() {
           blocking_lines_file="$(mktemp)"
           set +e
           local _clean_comments
+          local _clean_comments_rc=0
           _clean_comments="$(
             gh api "repos/$repo/pulls/$pr_number/comments" --paginate 2>/dev/null \
               | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
@@ -1422,7 +1455,22 @@ run_bugbot_review() {
                   | @json
                 ' 2>/dev/null
           )"
+          _clean_comments_rc=$?
           set -e
+          if [ "$_clean_comments_rc" -ne 0 ]; then
+            echo "WARN: run_bugbot_review: success-path comment fetch/parse failed for PR #$pr_number — returning unavailable" >&2
+            print_kv RESULT escalate
+            print_kv REASON fetch-failed
+            print_kv PLATFORM "$platform"
+            print_kv PR_NUMBER "$pr_number"
+            print_kv BRANCH "$branch_name"
+            print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+            print_kv COMMENT_COUNT 0
+            print_kv BLOCKING_COUNT 0
+            print_kv SUGGESTION_COUNT 0
+            rm -f "$blocking_lines_file"
+            return 2
+          fi
           while IFS= read -r comment_json; do
             [ -z "${comment_json:-}" ] && continue
             body="$(printf '%s\n' "$comment_json" | jq -r '.body')"
@@ -1475,6 +1523,8 @@ run_bugbot_review() {
           blocking_lines_file="$(mktemp)"
           set +e
           local _blocking_comments _blocking_reviews
+          local _blocking_comments_rc=0
+          local _blocking_reviews_rc=0
           _blocking_comments="$(
             gh api "repos/$repo/pulls/$pr_number/comments" --paginate 2>/dev/null \
               | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
@@ -1484,6 +1534,7 @@ run_bugbot_review() {
                   | @json
                 ' 2>/dev/null
           )"
+          _blocking_comments_rc=$?
           _blocking_reviews="$(
             gh api "repos/$repo/pulls/$pr_number/reviews" --paginate 2>/dev/null \
               | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
@@ -1500,7 +1551,22 @@ run_bugbot_review() {
                   | @json
                 ' 2>/dev/null
           )"
+          _blocking_reviews_rc=$?
           set -e
+          if [ "$_blocking_comments_rc" -ne 0 ] || [ "$_blocking_reviews_rc" -ne 0 ]; then
+            echo "WARN: run_bugbot_review: blocking finding fetch/parse failed for PR #$pr_number — returning unavailable" >&2
+            print_kv RESULT escalate
+            print_kv REASON fetch-failed
+            print_kv PLATFORM "$platform"
+            print_kv PR_NUMBER "$pr_number"
+            print_kv BRANCH "$branch_name"
+            print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+            print_kv COMMENT_COUNT 0
+            print_kv BLOCKING_COUNT 0
+            print_kv SUGGESTION_COUNT 0
+            rm -f "$blocking_lines_file"
+            return 2
+          fi
 
           local inline_count=0
           while IFS= read -r comment_json; do

--- a/scripts/development-workflow/tests/test-add-backlog-item.sh
+++ b/scripts/development-workflow/tests/test-add-backlog-item.sh
@@ -34,7 +34,7 @@ cleanup() {
   # backup was successfully created; do not suppress errors — a restore failure
   # means the workspace is clobbered and the test runner must know.
   if [ -n "$_config_backup" ] && [ -f "$_config_backup" ]; then
-    cp -- "$_config_backup" "$_config_file"
+    cp "$_config_backup" "$_config_file"
   fi
   rm -rf "$TMP_ROOT"
 }
@@ -215,7 +215,7 @@ if [ ! -f "$_config_file" ]; then
   exit "$( [ "$FAIL_COUNT" -ne 0 ] && echo 1 || echo 0 )"
 fi
 
-cp -- "$_config_file" "$_config_backup"
+cp "$_config_file" "$_config_backup"
 
 # Write a minimal linear config for the duration of these tests.
 cat > "$_config_file" <<'LINEAR_CONFIG'
@@ -229,7 +229,7 @@ _linear_stdout="$(get_stdout)"
 _linear_stderr="$(get_stderr)"
 
 # Restore the real config immediately (cleanup() also does this on any exit).
-cp -- "$_config_backup" "$_config_file"
+cp "$_config_backup" "$_config_file"
 
 # The create_item action emits TRACKER_ACTION_REQUIRED=create_item title='<title>'
 # to stdout and exits 0. Multi-word titles are single-quoted so parsers can

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2013,6 +2013,10 @@ unset _integ_out _integ_exit INTEG_MOCK_HEAD_JSON
 #         → RESULT=escalate REASON=trigger-failed, exit 2
 #   16.8  fetch-failed path: check-run API call fails during Phase 3 poll
 #         → RESULT=escalate REASON=fetch-failed, exit 2
+#   16.8b fetch-failed path: check-run API call fails during Phase 2 trigger guard
+#         → RESULT=escalate REASON=fetch-failed, exit 2
+#   16.8c fetch-failed path: check-run JSON parse fails during Phase 2 trigger guard
+#         → RESULT=escalate REASON=fetch-failed, exit 2
 #   16.9  neutral conclusion path: check run concludes neutral
 #         → RESULT=clean BLOCKING_COUNT=0 SUGGESTION_COUNT=0, exit 0
 #   16.10 run_platform_review routes "bugbot" to run_bugbot_review
@@ -2453,6 +2457,98 @@ run_test "bugbot_fetch_failed_exit_code" "2" "$actual_exit"
 rm -rf "$_bugbot_mock_dir_168"
 rm -f "$_bugbot_cr_counter_168"
 unset _bugbot_mock_dir_168 _bugbot_cr_counter_168 actual_output actual_exit
+
+# ---------------------------------------------------------------------------
+# Test 16.8b: fetch-failed path — Phase 2 check-run API call fails before trigger
+#
+# A failed check-run read must not be treated as "zero check runs" and must not
+# trigger a Bugbot comment. It escalates as fetch-failed immediately.
+# ---------------------------------------------------------------------------
+_bugbot_mock_dir_168b="$(mktemp -d)"
+cat > "$_bugbot_mock_dir_168b/gh" <<'BUGBOT_GH_168B'
+#!/usr/bin/env bash
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc168bsha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"check-runs"*)
+    exit 1 ;;
+  *"--method POST"*)
+    printf 'ERROR: trigger POST reached unexpectedly\n' >&2; exit 1 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+BUGBOT_GH_168B
+chmod +x "$_bugbot_mock_dir_168b/gh"
+
+unset BUGBOT_BOT_LOGIN BUGBOT_CHECK_NAME BUGBOT_TRIGGER_COMMENT
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_bugbot_overrides"
+  _ec=0
+  PATH="$_bugbot_mock_dir_168b:$PATH" run_bugbot_review "42" "feature/42-test" "1" "5" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "bugbot_phase2_fetch_failed_result" "RESULT=escalate" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "bugbot_phase2_fetch_failed_reason" "REASON=fetch-failed" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+run_test "bugbot_phase2_fetch_failed_exit_code" "2" "$actual_exit"
+rm -rf "$_bugbot_mock_dir_168b"
+unset _bugbot_mock_dir_168b actual_output actual_exit
+
+# ---------------------------------------------------------------------------
+# Test 16.8c: fetch-failed path — Phase 2 check-run JSON parse fails
+#
+# Malformed check-run JSON must also escalate as fetch-failed instead of being
+# coerced to an empty run list.
+# ---------------------------------------------------------------------------
+_bugbot_mock_dir_168c="$(mktemp -d)"
+cat > "$_bugbot_mock_dir_168c/gh" <<'BUGBOT_GH_168C'
+#!/usr/bin/env bash
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc168csha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"check-runs"*)
+    printf '{not-json\n'; exit 0 ;;
+  *"--method POST"*)
+    printf 'ERROR: trigger POST reached unexpectedly\n' >&2; exit 1 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+BUGBOT_GH_168C
+chmod +x "$_bugbot_mock_dir_168c/gh"
+
+unset BUGBOT_BOT_LOGIN BUGBOT_CHECK_NAME BUGBOT_TRIGGER_COMMENT
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_bugbot_overrides"
+  _ec=0
+  PATH="$_bugbot_mock_dir_168c:$PATH" run_bugbot_review "42" "feature/42-test" "1" "5" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "bugbot_phase2_parse_failed_result" "RESULT=escalate" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "bugbot_phase2_parse_failed_reason" "REASON=fetch-failed" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+run_test "bugbot_phase2_parse_failed_exit_code" "2" "$actual_exit"
+rm -rf "$_bugbot_mock_dir_168c"
+unset _bugbot_mock_dir_168c actual_output actual_exit
 
 # ---------------------------------------------------------------------------
 # Test 16.9: neutral conclusion path — check run concludes neutral

--- a/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
@@ -25,7 +25,7 @@ _harness_exit() {
   local status=$?
   # Restore .ai-dev-workflow.yaml if it was swapped out during provider tests.
   if [ -n "$_config_backup" ] && [ -f "$_config_backup" ]; then
-    cp -- "$_config_backup" "$_config_file"
+    cp "$_config_backup" "$_config_file"
   fi
   rm -rf "$TMP_ROOT"
   case "$status" in
@@ -300,7 +300,7 @@ echo "=== Provider normalization and deferred-read signals (#966) ==="
 # Temporarily swap .ai-dev-workflow.yaml to test non-default providers.
 # _harness_exit() restores the real config on any exit.
 _config_backup="$TMP_ROOT/ai-dev-workflow.yaml.bak"
-cp -- "$_config_file" "$_config_backup"
+cp "$_config_file" "$_config_backup"
 
 # --- github_projects provider ---
 # The real config already has github_projects; run text-mode and verify PROVIDER=.
@@ -328,7 +328,7 @@ LINEAR_CONFIG
 linear_text_output="$("$RESOLVER" --items 101 2>/dev/null)"
 
 # Restore immediately; _harness_exit is the safety net.
-cp -- "$_config_backup" "$_config_file"
+cp "$_config_backup" "$_config_file"
 
 case "$linear_text_output" in
   *"PROVIDER=linear"*) linear_provider_result="emitted" ;;


### PR DESCRIPTION
## Summary
- backport the upstream-reusable corrections found while reviewing Leasity template-sync PR #387
- make `run_bugbot_review` fail closed when Bugbot comment/review/check-run fetches or JSON parsing fail before trigger or during result collection
- replace `cp --` in workflow shell tests with portable `cp`

## Not Backported
- Leasity's Supabase doc link rewrite to `4-database-model.doc.md`; this template uses `docs/project/4-database-model.md`, so the existing upstream link is correct

## Validation
- `bash scripts/development-workflow/tests/test-add-backlog-item.sh`
- `bash scripts/development-workflow/tests/test-run-epic-scope-resolver.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh`
- `git diff --check`
- `bash -n scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-add-backlog-item.sh scripts/development-workflow/tests/test-run-epic-scope-resolver.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `npx markdownlint-cli2 CHANGELOG.md`
- `python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
