### PR TITLE
fix(workflow): honor local review platform overrides

### DIFF
--- a/.ai-dev-workflow.local.example.yaml
+++ b/.ai-dev-workflow.local.example.yaml
@@ -31,12 +31,19 @@ product_repos:
 # - copy this file to `.ai-dev-workflow.local.yaml`
 # - set `review.on_draft.runner` to `cursor` while running `/run-work` from
 #   Cursor so Step 7a dispatches the Cursor review agents instead of Codex
+# - override GitHub/App reviewer lists to match the tools available on this
+#   machine, for example PR Agent during draft and Cursor Bugbot after ready
 # - keep `internal_reviewers_unavailable_policy: warn` unless you explicitly
 #   want unavailable local reviewers to hard-fail the gate
 review:
   on_draft:
     runner:
       - cursor
+    github:
+      - pr-agent
+  on_ready:
+    github:
+      - bugbot
   internal_reviewers_unavailable_policy: warn
 
 tools:

--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -51,7 +51,6 @@ review:
     # Ordered list of GitHub/App/CLI reviewers that run only after draft gates
     # are clean and the PR has been converted with `gh pr ready`.
     github:
-      - haystack
       - bugbot
   #
   # Configurable codex-github options (set via env vars or script flags to codex-github-reviewer.sh):

--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -52,7 +52,6 @@ review:
     # are clean and the PR has been converted with `gh pr ready`.
     github:
       - haystack
-      - bugbot
   #
   # Configurable codex-github options (set via env vars or script flags to codex-github-reviewer.sh):
   #   CODEX_GITHUB_TRIGGER_PHRASE  — trigger phrase sent to the bot (default: "@codex review")

--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -51,6 +51,7 @@ review:
     # Ordered list of GitHub/App/CLI reviewers that run only after draft gates
     # are clean and the PR has been converted with `gh pr ready`.
     github:
+      - haystack
       - bugbot
   #
   # Configurable codex-github options (set via env vars or script flags to codex-github-reviewer.sh):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Cursor pilot configuration**: adds Cursor as a Step 7a runner reviewer value,
-  enables Cursor Bugbot in the ready-phase reviewer loop for this repository,
+  supports overriding ready-phase review to Cursor Bugbot from local config,
   exposes `bugbot` in reviewer-loop usage help, and ships project-level Bugbot
   rules plus a local Cursor-runner override example for testing the workflow
   from Cursor.

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -402,9 +402,11 @@ Opening a PR is not a terminal condition. A workflow run should continue until t
 
 Repository-specific workflow integrations are declared in `.ai-dev-workflow.yaml` at the repo root.
 Machine-local overrides belong in `.ai-dev-workflow.local.yaml`, which is
-gitignored. Start from `.ai-dev-workflow.local.example.yaml` when a workflow hub
-needs checkout roots, product-repo local paths, secret references, or local tool
-overrides.
+gitignored. Local review overrides replace the matching shared reviewer list
+for this checkout, including `review.on_draft.runner`,
+`review.on_draft.github`, and `review.on_ready.github`. Start from
+`.ai-dev-workflow.local.example.yaml` when a workflow hub needs checkout roots,
+product-repo local paths, secret references, or local tool overrides.
 
 The file is versioned and intentionally declarative. It is the right place to record which workflow providers this repository uses for:
 
@@ -520,8 +522,9 @@ The expected sequence is:
 4. Mark the PR ready for human review only after both loops are clean.
 
 GitHub review platforms are declared in `.ai-dev-workflow.yaml` under
-`review.on_draft.github` and `review.on_ready.github`. The repository helpers
-that support this loop are:
+`review.on_draft.github` and `review.on_ready.github`, with matching
+`.ai-dev-workflow.local.yaml` lists taking precedence for local tool/subscription
+differences. The repository helpers that support this loop are:
 
 - `scripts/development-workflow/pr-review-loop.sh`
 - `scripts/development-workflow/pr-ci-loop.sh`

--- a/docs/workflow/development-workflow/integrations/pr-review-platform.md
+++ b/docs/workflow/development-workflow/integrations/pr-review-platform.md
@@ -85,9 +85,11 @@ review:
 ```
 
 The helper script reads this file automatically when no `--platform` flag is
-passed. If the file is absent, or if both `review.on_draft.github` and
-`review.on_ready.github` are omitted or empty, no reviewer tool runs and the
-result is skipped. Explicit `--platform` flags always override the config file.
+passed. Matching lists in `.ai-dev-workflow.local.yaml` replace the shared
+`review.on_draft.github` and `review.on_ready.github` lists for local
+tool/subscription differences. If the effective config is absent, or if both
+effective lists are omitted or empty, no reviewer tool runs and the result is
+skipped. Explicit `--platform` flags always override the config file.
 
 `review.on_ready.github` is optional. Platforms listed there run only after
 draft GitHub reviewers are clean and the PR has been converted with

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -297,6 +297,47 @@ run_test "mixed_new_legacy_draft_prefers_new" "pr-agent" "$mixed_draft_github"
 run_test "mixed_new_legacy_ready_prefers_new" "haystack" "$mixed_ready_github"
 run_test "mixed_new_legacy_combined_prefers_new" "pr-agent,haystack" "$mixed_all_github"
 
+_LOCAL_OVERRIDE_DIR="$(mktemp -d)"
+cat > "$_LOCAL_OVERRIDE_DIR/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+
+review:
+  on_draft:
+    runner: [codex]
+    github: [pr-agent]
+  on_ready:
+    github: [haystack]
+YAML
+cat > "$_LOCAL_OVERRIDE_DIR/.ai-dev-workflow.local.yaml" <<'YAML'
+review:
+  on_draft:
+    runner: [cursor]
+    github: [pr-agent]
+  on_ready:
+    github: [bugbot]
+YAML
+local_override_parsed="$(
+  workflow_repo_root() { printf '%s\n' "$_LOCAL_OVERRIDE_DIR"; }
+  printf 'runner=%s\n' "$(workflow_config_review_on_draft_runner "$(workflow_config_file)" | paste -sd ',' -)"
+  printf 'draft=%s\n' "$(workflow_config_review_on_draft_github "$(workflow_config_file)" | paste -sd ',' -)"
+  printf 'ready=%s\n' "$(workflow_config_review_on_ready_github "$(workflow_config_file)" | paste -sd ',' -)"
+  printf 'all=%s\n' "$(workflow_config_review_platforms "$(workflow_config_file)" | paste -sd ',' -)"
+)"
+run_test "local_review_override_applied" $'runner=cursor\ndraft=pr-agent\nready=bugbot\nall=pr-agent,bugbot' "$local_override_parsed"
+
+cat > "$_LOCAL_OVERRIDE_DIR/.ai-dev-workflow.local.yaml" <<'YAML'
+review:
+  on_ready:
+    github: []
+YAML
+local_empty_ready_parsed="$(
+  workflow_repo_root() { printf '%s\n' "$_LOCAL_OVERRIDE_DIR"; }
+  workflow_config_review_on_ready_github "$(workflow_config_file)" | paste -sd ',' -
+)"
+run_test "local_review_override_empty_ready_github_applied" "" "$local_empty_ready_parsed"
+rm -rf "$_LOCAL_OVERRIDE_DIR"
+unset _LOCAL_OVERRIDE_DIR local_override_parsed local_empty_ready_parsed
+
 cat > "$_CONFIG_DIR/.ai-dev-workflow-duplicates.yaml" <<'YAML'
 schema_version: 2
 

--- a/scripts/development-workflow/tests/test-workflow-config-resolver.sh
+++ b/scripts/development-workflow/tests/test-workflow-config-resolver.sh
@@ -355,14 +355,38 @@ cat > "$review_dir/.ai-dev-workflow.local.yaml" <<'YAML'
 review:
   on_draft:
     runner: [codex]
+    github: [pr-agent]
+  on_ready:
+    github: [bugbot]
   internal_reviewers_unavailable_policy: warn
 YAML
 review_output="$(workflow_review_override_context "$review_dir")"
 run_contains "local_review_override_runner_value" "REVIEW_ON_DRAFT_RUNNER=codex" "$review_output"
 run_contains "local_review_override_runner_source" "REVIEW_ON_DRAFT_RUNNER_SOURCE=.ai-dev-workflow.local.yaml" "$review_output"
+run_contains "local_review_override_draft_github_value" "REVIEW_ON_DRAFT_GITHUB=pr-agent" "$review_output"
+run_contains "local_review_override_draft_github_source" "REVIEW_ON_DRAFT_GITHUB_SOURCE=.ai-dev-workflow.local.yaml" "$review_output"
+run_contains "local_review_override_ready_github_value" "REVIEW_ON_READY_GITHUB=bugbot" "$review_output"
+run_contains "local_review_override_ready_github_source" "REVIEW_ON_READY_GITHUB_SOURCE=.ai-dev-workflow.local.yaml" "$review_output"
 run_contains "local_review_override_policy_value" "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY=warn" "$review_output"
 run_contains "local_review_override_policy_source" "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY_SOURCE=.ai-dev-workflow.local.yaml" "$review_output"
-run_contains "local_review_override_combined_source" "LOCAL_OVERRIDE_SOURCE=runner:.ai-dev-workflow.local.yaml,policy:.ai-dev-workflow.local.yaml" "$review_output"
+run_contains "local_review_override_combined_source" "LOCAL_OVERRIDE_SOURCE=runner:.ai-dev-workflow.local.yaml,draft-github:.ai-dev-workflow.local.yaml,ready-github:.ai-dev-workflow.local.yaml,policy:.ai-dev-workflow.local.yaml" "$review_output"
+
+empty_review_dir="$(fixture_dir empty-review-overrides)"
+cat > "$empty_review_dir/.ai-dev-workflow.local.yaml" <<'YAML'
+review:
+  on_draft:
+    runner: []
+    github: []
+  on_ready:
+    github: []
+YAML
+empty_review_output="$(workflow_review_override_context "$empty_review_dir")"
+run_contains "empty_local_review_override_runner_value" "REVIEW_ON_DRAFT_RUNNER=" "$empty_review_output"
+run_contains "empty_local_review_override_runner_source" "REVIEW_ON_DRAFT_RUNNER_SOURCE=.ai-dev-workflow.local.yaml" "$empty_review_output"
+run_contains "empty_local_review_override_draft_github_value" "REVIEW_ON_DRAFT_GITHUB=" "$empty_review_output"
+run_contains "empty_local_review_override_draft_github_source" "REVIEW_ON_DRAFT_GITHUB_SOURCE=.ai-dev-workflow.local.yaml" "$empty_review_output"
+run_contains "empty_local_review_override_ready_github_value" "REVIEW_ON_READY_GITHUB=" "$empty_review_output"
+run_contains "empty_local_review_override_ready_github_source" "REVIEW_ON_READY_GITHUB_SOURCE=.ai-dev-workflow.local.yaml" "$empty_review_output"
 
 local_review_dir="$(fixture_dir local-review-overrides)"
 cat > "$local_review_dir/.ai-dev-workflow.local.yaml" <<'YAML'
@@ -406,6 +430,10 @@ JSON
 stale_review_output="$(workflow_review_override_context "$stale_review_dir")"
 run_contains "stale_review_override_runner_empty" "REVIEW_ON_DRAFT_RUNNER=" "$stale_review_output"
 run_contains "stale_review_override_runner_source_empty" "REVIEW_ON_DRAFT_RUNNER_SOURCE=" "$stale_review_output"
+run_contains "stale_review_override_draft_github_empty" "REVIEW_ON_DRAFT_GITHUB=" "$stale_review_output"
+run_contains "stale_review_override_draft_github_source_empty" "REVIEW_ON_DRAFT_GITHUB_SOURCE=" "$stale_review_output"
+run_contains "stale_review_override_ready_github_empty" "REVIEW_ON_READY_GITHUB=" "$stale_review_output"
+run_contains "stale_review_override_ready_github_source_empty" "REVIEW_ON_READY_GITHUB_SOURCE=" "$stale_review_output"
 run_contains "stale_review_override_policy_empty" "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY=" "$stale_review_output"
 run_contains "stale_review_override_policy_source_empty" "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY_SOURCE=" "$stale_review_output"
 run_contains "stale_review_override_source_empty" "LOCAL_OVERRIDE_SOURCE=" "$stale_review_output"

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -677,15 +677,15 @@ def resolve_context(args: argparse.Namespace) -> dict[str, str]:
     return context
 
 
-def list_from_path(data: dict[str, Any], path: list[str]) -> list[str]:
+def list_override_from_path(data: dict[str, Any], path: list[str]) -> tuple[list[str], bool]:
     value: Any = data
     for key in path:
-        if not isinstance(value, dict):
-            return []
+        if not isinstance(value, dict) or key not in value:
+            return [], False
         value = value.get(key)
     if isinstance(value, list):
-        return [str(item) for item in value]
-    return []
+        return [str(item) for item in value], True
+    return [], False
 
 
 def scalar_from_path(data: dict[str, Any], path: list[str]) -> str:
@@ -701,9 +701,21 @@ def resolve_review_overrides(args: argparse.Namespace) -> dict[str, str]:
     repo_root = repo_root_from_args(args.repo_root)
     _, local, _, _ = load_configs(repo_root)
 
-    local_runner = list_from_path(local, ["review", "on_draft", "runner"])
+    local_runner, has_local_runner = list_override_from_path(local, ["review", "on_draft", "runner"])
     runner = local_runner
-    runner_source = ".ai-dev-workflow.local.yaml" if local_runner else ""
+    runner_source = ".ai-dev-workflow.local.yaml" if has_local_runner else ""
+
+    local_draft_github, has_local_draft_github = list_override_from_path(
+        local, ["review", "on_draft", "github"]
+    )
+    draft_github = local_draft_github
+    draft_github_source = ".ai-dev-workflow.local.yaml" if has_local_draft_github else ""
+
+    local_ready_github, has_local_ready_github = list_override_from_path(
+        local, ["review", "on_ready", "github"]
+    )
+    ready_github = local_ready_github
+    ready_github_source = ".ai-dev-workflow.local.yaml" if has_local_ready_github else ""
 
     local_policy = scalar_from_path(local, ["review", "internal_reviewers_unavailable_policy"])
     policy = local_policy
@@ -712,12 +724,20 @@ def resolve_review_overrides(args: argparse.Namespace) -> dict[str, str]:
     sources = []
     if runner_source:
         sources.append(f"runner:{runner_source}")
+    if draft_github_source:
+        sources.append(f"draft-github:{draft_github_source}")
+    if ready_github_source:
+        sources.append(f"ready-github:{ready_github_source}")
     if policy_source:
         sources.append(f"policy:{policy_source}")
 
     return {
         "REVIEW_ON_DRAFT_RUNNER": ",".join(runner),
         "REVIEW_ON_DRAFT_RUNNER_SOURCE": runner_source,
+        "REVIEW_ON_DRAFT_GITHUB": ",".join(draft_github),
+        "REVIEW_ON_DRAFT_GITHUB_SOURCE": draft_github_source,
+        "REVIEW_ON_READY_GITHUB": ",".join(ready_github),
+        "REVIEW_ON_READY_GITHUB_SOURCE": ready_github_source,
         "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY": policy,
         "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY_SOURCE": policy_source,
         "LOCAL_OVERRIDE_SOURCE": ",".join(sources),

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -18,6 +18,15 @@ workflow_config_file() {
   printf '%s/.ai-dev-workflow.yaml\n' "$(workflow_repo_root)"
 }
 
+workflow_local_config_file() {
+  printf '%s/.ai-dev-workflow.local.yaml\n' "$(workflow_repo_root)"
+}
+
+workflow_is_default_config_file() {
+  local config_file="$1"
+  [ "$config_file" = "$(workflow_config_file)" ]
+}
+
 workflow_config_resolver_script() {
   printf '%s/workflow-config-resolver.py\n' "$(workflow_script_dir)"
 }
@@ -345,10 +354,83 @@ workflow_config_review_legacy_list() {
   ' "$config_file"
 }
 
+workflow_config_review_nested_list_declared() {
+  local config_file="$1"
+  local phase="$2"
+  local key="$3"
+
+  [ -f "$config_file" ] || return 1
+
+  awk -v phase="$phase" -v key="$key" '
+    BEGIN { found = 0 }
+
+    /^review:[[:space:]]*(#.*)?$/ {
+      in_review = 1
+      in_phase = 0
+      in_list = 0
+      next
+    }
+
+    in_review && /^[^[:space:]#].*:[[:space:]]*/ {
+      in_review = 0
+      in_phase = 0
+      in_list = 0
+    }
+
+    in_review && $0 ~ ("^[[:space:]][[:space:]]" phase ":[[:space:]]*(#.*)?$") {
+      in_phase = 1
+      in_list = 0
+      next
+    }
+
+    in_phase && /^[[:space:]][[:space:]][A-Za-z0-9_-]+:[[:space:]]*/ && $0 !~ ("^[[:space:]][[:space:]]" phase ":[[:space:]]*") {
+      in_phase = 0
+      in_list = 0
+    }
+
+    in_phase && $0 ~ ("^[[:space:]][[:space:]][[:space:]][[:space:]]" key ":[[:space:]]*\\[") {
+      found = 1
+      exit
+    }
+
+    in_phase && $0 ~ ("^[[:space:]][[:space:]][[:space:]][[:space:]]" key ":[[:space:]]*(#.*)?$") {
+      in_list = 1
+      next
+    }
+
+    in_list && /^[[:space:]][[:space:]][[:space:]][[:space:]][A-Za-z0-9_-]+:[[:space:]]*/ {
+      in_list = 0
+    }
+
+    in_list && /^[[:space:]][[:space:]][[:space:]][[:space:]][[:space:]][[:space:]]-[[:space:]]*/ {
+      found = 1
+      exit
+    }
+
+    END { exit found ? 0 : 1 }
+  ' "$config_file"
+}
+
+workflow_config_review_local_list_if_declared() {
+  local config_file="$1"
+  local phase="$2"
+  local key="$3"
+  local local_file
+
+  workflow_is_default_config_file "$config_file" || return 1
+  local_file="$(workflow_local_config_file)"
+  workflow_config_review_nested_list_declared "$local_file" "$phase" "$key" || return 1
+  workflow_config_review_nested_list "$local_file" "$phase" "$key"
+}
+
 workflow_config_review_on_draft_runner() {
   local config_file="${1:-$(workflow_config_file)}"
 
   [ -f "$config_file" ] || return 0
+
+  if workflow_config_review_local_list_if_declared "$config_file" on_draft runner; then
+    return 0
+  fi
 
   if workflow_config_review_nested_list "$config_file" on_draft runner | grep -q .; then
     workflow_config_review_nested_list "$config_file" on_draft runner
@@ -361,6 +443,10 @@ workflow_config_review_on_draft_github() {
   local config_file="${1:-$(workflow_config_file)}"
 
   [ -f "$config_file" ] || return 0
+
+  if workflow_config_review_local_list_if_declared "$config_file" on_draft github; then
+    return 0
+  fi
 
   if workflow_config_review_nested_list "$config_file" on_draft github | grep -q .; then
     workflow_config_review_nested_list "$config_file" on_draft github
@@ -385,6 +471,10 @@ workflow_config_review_on_ready_github() {
   local config_file="${1:-$(workflow_config_file)}"
 
   [ -f "$config_file" ] || return 0
+
+  if workflow_config_review_local_list_if_declared "$config_file" on_ready github; then
+    return 0
+  fi
 
   if workflow_config_review_nested_list "$config_file" on_ready github | grep -q .; then
     workflow_config_review_nested_list "$config_file" on_ready github


### PR DESCRIPTION
## Summary
- make `.ai-dev-workflow.local.yaml` replace `review.on_draft.runner`, `review.on_draft.github`, and `review.on_ready.github` when workflow helpers read the default repo config
- expose local GitHub reviewer overrides in `workflow-config-resolver.py review-overrides`, including explicit empty-list overrides
- update the local config example and docs so Cursor-only runs can use Cursor + PR Agent + Bugbot without changing the shared repo config

## Validation
- `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh`
- `python3 scripts/development-workflow/workflow-config-resolver.py validate --repo-root .`
- `python3 -m py_compile scripts/development-workflow/workflow-config-resolver.py`
- `shellcheck --severity=warning scripts/development-workflow/workflow-lib.sh scripts/development-workflow/tests/test-pr-review-loop.sh scripts/development-workflow/tests/test-workflow-config-resolver.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/README.md" "docs/workflow/development-workflow/integrations/pr-review-platform.md" "CHANGELOG.md"`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`

## Local Verification
With this checkout's ignored `.ai-dev-workflow.local.yaml`, the effective review config resolves to:

```text
effective_runner:
cursor
effective_draft_github:
pr-agent
effective_ready_github:
bugbot
```

## Pre-submission Self-review
Stale markers: none. Caller/config consistency: verified across resolver, shell helpers, PR review loop tests, local example, and docs. Coverage: focused tests cover replacement of runner/draft/ready lists and explicit empty-list overrides.
