### PR TITLE
feat(run-epic): recommend human checkpoints in policy (#1021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Run-epic checkpoint policy recommendations** (#1021): `run-epic-policy-recommender.sh`
+  now emits per-item human checkpoint recommendations from read-only scope metadata,
+  supports explicit selection/waiver via `--checkpoints-file`, and records
+  recommended/selected/effective checkpoint policy for audit evidence.
 - **Cursor pilot configuration**: adds Cursor as a Step 7a runner reviewer value,
   supports overriding ready-phase review to Cursor Bugbot from local config,
   exposes `bugbot` in reviewer-loop usage help, and ships project-level Bugbot

--- a/docs/workflow/development-workflow/guardrails-enforcement.md
+++ b/docs/workflow/development-workflow/guardrails-enforcement.md
@@ -66,6 +66,14 @@ model — there is **one** policy path, not two.
 | `audit.pr_disposition_record` | PR disposition audit required | `run-epic-audit-trail.sh apply-pr-disposition` (stable marker `<!-- run-epic:pr-disposition -->`) |
 | `audit.work_item_ledger_record` | Item-level ledger required | `run-epic-audit-trail.sh apply-epic-ledger` (stable marker `<!-- run-epic:epic-ledger -->`) when a parent/epic exists; otherwise "not applicable" |
 | `stop_conditions[]` | Named human-stops | Stop-and-name behavior (see section 4); these add to but never weaken the baseline stops |
+| Epic checkpoint policy (`checkpoints[]` on effective policy) | Stage-scoped, item-specific human stops declared before mutation | `run-epic-policy-recommender.sh` output (`recommendedPolicy.checkpoints`, `selectedPolicy.checkpoints`, `effectivePolicy.checkpoints`, `checkpointPolicy`); consumed by delegated gate (#1023) and audit trail (#1022); **not** a `.ai-dev-workflow.yaml` schema field |
+
+Epic human checkpoints extend the same run-epic policy object — they are not
+separate guardrails config fields. The recommender proposes them from read-only
+item metadata; the human selects or waives them before mutation. Audit evidence
+records original, recommended, selected, and effective checkpoint policy via
+`checkpointPolicy` on the recommender JSON output and later PR/epic ledger
+comments.
 
 ### Per-Stage Authority Resolution
 

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -86,7 +86,7 @@ When autonomy policy is missing or ambiguous, derive a recommended policy from
 the resolver output before any mutating stage begins:
 
 ```bash
-./scripts/development-workflow/run-epic-policy-recommender.sh --scope <resolver-json> --original-command "<requested command>" [--base <branch>] [--delegate-review|--no-delegate-review] [--may-merge|--no-may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--json]
+./scripts/development-workflow/run-epic-policy-recommender.sh --scope <resolver-json> --original-command "<requested command>" [--base <branch>] [--delegate-review|--no-delegate-review] [--may-merge|--no-may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--checkpoints-file <json-array>] [--json]
 ```
 
 The recommender is also read-only. It must not update tracker status, create
@@ -95,6 +95,37 @@ comments. It produces recommended, selected, and effective policy values plus a
 copy-paste equivalent command for audit evidence. Use `--no-delegate-review` or
 `--no-may-merge` when the selected policy explicitly disables a recommended
 positive default.
+
+### Human-checkpoint recommendations
+
+Before mutation, the recommender classifies per-item human checkpoints from
+read-only scope metadata (title, type, labels, tracker status). High-leverage
+signals default to checkpoints:
+
+- **Plan + technical**: database schema, migration, or persistent data-model
+  wording.
+- **Spec + product**: unresolved product or acceptance-criteria ambiguity when
+  the item is still in Backlog or spec stage.
+- **Plan or implementation + both**: ambiguous product/technical tradeoffs.
+- **Implementation + technical**: security, auth, permission, or other
+  sensitive-change wording.
+
+The JSON output includes `recommendedPolicy.checkpoints`,
+`selectedPolicy.checkpoints`, `effectivePolicy.checkpoints`, and
+`checkpointPolicy` (`recommended`, `selected`, `effective`) for audit evidence.
+Each checkpoint record carries `item_number`, `stage`, `domain`, `reason`,
+`required_human_action`, and `satisfaction_state` (`pending` by default).
+
+Humans may accept recommendations as-is, customize them, or waive defaults with
+documented rationale before mutation begins. Pass an explicit selected checkpoint
+array with `--checkpoints-file <json-array>`; waived entries must include
+`waiver_rationale`. When recommendations exist and no `--checkpoints-file` is
+supplied, confirmation is required before mutation — silent auto-waiver is not
+permitted.
+
+Enforcement of checkpoints at PR readiness labels and delegated merge gates is
+implemented in follow-up items #1022 and #1023; this step only recommends and
+records policy.
 
 When a later delegated run reaches a candidate PR merge decision, classify that
 PR with:
@@ -286,14 +317,18 @@ Recommended defaults should favor the most automatic safe configuration:
 - `--max-risk medium` for workflow scripts, orchestration behavior, merge or
   cleanup automation, or shared workflow tooling when later
   `why_safe_to_merge` evidence can be produced.
+- Human-checkpoint recommendations per eligible item when metadata signals
+  schema/migration, product ambiguity, tradeoff ambiguity, or sensitive
+  implementation work (see **Human-checkpoint recommendations** above).
 - Never recommend `high` by default. High-risk work requires explicit human
   selection.
 
 Present a preflight summary before mutation: scoped issues, grouped states,
-base branch, recommended policy, risk rationale, and the copy-paste equivalent
-command. If confirmation is required, ask in-place and continue in the same run
-when the human accepts. Do not ask repeatedly for the same policy choice within
-the same invocation once selected/effective policy has been recorded.
+base branch, recommended policy, recommended checkpoints (if any), risk
+rationale, and the copy-paste equivalent command. If confirmation is required,
+ask in-place and continue in the same run when the human accepts. Do not ask
+repeatedly for the same policy choice within the same invocation once
+selected/effective policy has been recorded.
 
 Exact invocations with all effective policy values already supplied may skip the
 confirmation prompt, but they still record the original command, recommended

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -272,7 +272,7 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
         else . end
     );
   def recommended_checkpoints:
-    [.items[]? | recommend_checkpoints_for_item(.)[]]
+    [.items[]? | select((.group // "eligible") == "eligible") | recommend_checkpoints_for_item(.)[]]
     | unique_by(checkpoint_key(.));
   def checkpoint_matches($a; $b):
     ($a.item_number == $b.item_number) and ($a.stage == $b.stage) and ($a.domain == $b.domain);

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -9,7 +9,7 @@ source "$SCRIPT_DIR/workflow-lib.sh"
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/development-workflow/run-epic-policy-recommender.sh --scope <resolver-json> --original-command <text> [--base <branch>] [--delegate-review|--no-delegate-review] [--may-merge|--no-may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--json]
+  ./scripts/development-workflow/run-epic-policy-recommender.sh --scope <resolver-json> --original-command <text> [--base <branch>] [--delegate-review|--no-delegate-review] [--may-merge|--no-may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--checkpoints-file <json-array>] [--json]
 
 Derives a read-only recommended /run-epic autonomy policy from resolver output.
 The helper does not update trackers, create branches, open PRs, edit labels,
@@ -24,6 +24,7 @@ delegate_review_override=""
 may_merge_override=""
 may_start_backlog_override=""
 max_risk_override=""
+checkpoints_file=""
 json_output=0
 
 error_exit() {
@@ -125,6 +126,11 @@ while [ "$#" -gt 0 ]; do
       max_risk_override="$2"
       shift 2
       ;;
+    --checkpoints-file)
+      require_value "$@"
+      checkpoints_file="$2"
+      shift 2
+      ;;
     --json)
       json_output=1
       shift
@@ -155,6 +161,19 @@ fi
 
 scope_json="$(load_scope_json "$scope_file")"
 
+checkpoints_override_json="null"
+if [ -n "$checkpoints_file" ]; then
+  if [ ! -f "$checkpoints_file" ]; then
+    error_exit "checkpoints file not found: $checkpoints_file"
+  fi
+  if ! checkpoints_override_json="$(jq -c '.' "$checkpoints_file" 2>/dev/null)"; then
+    error_exit "checkpoints file is not valid JSON: $checkpoints_file"
+  fi
+  if ! printf '%s\n' "$checkpoints_override_json" | jq -e 'type == "array"' >/dev/null; then
+    error_exit "checkpoints file must contain a JSON array"
+  fi
+fi
+
 if ! printf '%s\n' "$scope_json" | jq -e '
   (.groups | type) == "object" and
   (.items | type) == "array" and
@@ -176,7 +195,8 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
   --arg mayMergeOverride "$may_merge_override" \
   --arg mayStartBacklogOverride "$may_start_backlog_override" \
   --arg maxRiskOverride "$max_risk_override" \
-  --argjson reviewerCount "$reviewer_count" '
+  --argjson reviewerCount "$reviewer_count" \
+  --argjson checkpointsOverride "$checkpoints_override_json" '
   def bool_override($v): if $v == "" then null elif $v == "true" then true else false end;
   def risk_rank($risk): {"low": 1, "medium": 2, "high": 3}[$risk] // 0;
   def max_risk($a; $b): if risk_rank($a) >= risk_rank($b) then $a else $b end;
@@ -184,6 +204,84 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
     [.items[]? | ((.title // "") + " " + (.type // "") + " " + ((.labels // []) | join(" ")) + " " + (.integrationBranchLabel // ""))]
     | join(" ")
     | ascii_downcase;
+  def item_signal_text($item):
+    (($item.title // "") + " " + ($item.body // "") + " " + ($item.type // "") + " " + (($item.labels // []) | join(" ")) + " " + ($item.integrationBranchLabel // ""))
+    | ascii_downcase;
+  def infer_workflow_stage($item):
+    ($item.status // "" | ascii_downcase) as $s |
+    if $s == "backlog" or ($s | test("writing spec|spec in review|spec")) then "spec"
+    elif $s | test("writing plan|plan in review|plan") then "plan"
+    elif $s | test("development|implement") then "implementation"
+    else "implementation"
+    end;
+  def checkpoint_key($cp): "\($cp.item_number):\($cp.stage):\($cp.domain)";
+  def normalize_checkpoint($cp):
+    $cp
+    | .item_number |= (if type == "number" then . else tonumber? // . end)
+    | .satisfaction_state |= (. // "pending")
+    | if .satisfaction_state == "waived" and ((.waiver_rationale // "") | length) == 0 then
+        error("waived checkpoints require waiver_rationale")
+      else .
+      end;
+  def recommend_checkpoints_for_item($item):
+    item_signal_text($item) as $text |
+    infer_workflow_stage($item) as $stage |
+    ($item.number) as $num |
+    (
+      []
+      | if ($stage == "spec" or ($item.status // "" | ascii_downcase) == "backlog")
+          and ($text | test("ambiguous|unclear|\\btbd\\b|open question|acceptance criteria|unresolved product")) then
+          . + [{
+            item_number: $num,
+            stage: "spec",
+            domain: "product",
+            reason: "issue signals unresolved product requirements or acceptance-criteria ambiguity",
+            required_human_action: "confirm product requirements and acceptance criteria before spec work proceeds",
+            satisfaction_state: "pending"
+          }]
+        else . end
+      | if $text | test("schema|migration|database|data[ -]?model|\\bsql\\b|persistent data") then
+          . + [{
+            item_number: $num,
+            stage: "plan",
+            domain: "technical",
+            reason: "issue signals database schema, migration, or persistent data-model changes",
+            required_human_action: "review and approve proposed data model in the plan before implementation proceeds",
+            satisfaction_state: "pending"
+          }]
+        else . end
+      | if $text | test("trade[- ]?off|architecture.{0,30}product|product.{0,30}technical|ambiguous.{0,40}(architecture|product|technical)") then
+          . + [{
+            item_number: $num,
+            stage: (if $stage == "spec" then "plan" else $stage end),
+            domain: "both",
+            reason: "issue signals ambiguous product and technical tradeoffs",
+            required_human_action: "confirm product and technical direction before proceeding",
+            satisfaction_state: "pending"
+          }]
+        else . end
+      | if ($stage == "implementation" or ($text | test("auth|security|secret|permission|credential|sensitive")))
+          and ($text | test("auth|security|secret|permission|credential|sensitive")) then
+          . + [{
+            item_number: $num,
+            stage: "implementation",
+            domain: "technical",
+            reason: "issue signals security, auth, or other sensitive implementation changes",
+            required_human_action: "review security-sensitive implementation approach before delegated merge",
+            satisfaction_state: "pending"
+          }]
+        else . end
+    );
+  def recommended_checkpoints:
+    [.items[]? | recommend_checkpoints_for_item(.)[]]
+    | unique_by(checkpoint_key(.));
+  def selected_checkpoints($recommended):
+    if $checkpointsOverride == null then $recommended
+    else [$checkpointsOverride[] | normalize_checkpoint(.)]
+    end;
+  def effective_checkpoints($selected): $selected;
+  def checkpoint_field_source: if $checkpointsOverride == null then "recommended" else "explicit" end;
+  def has_recommended_checkpoints: (recommended_checkpoints | length) > 0;
   def has_backlog: [.items[]? | select((.status // "") == "Backlog")] | length > 0;
   def has_dependency_blocker: [.items[]? | select((.dependencies.state // "") == "blocked")] | length > 0;
   def has_ambiguous: ((.groups.ambiguous // []) | length) > 0 or (.baseAmbiguous // false) == true;
@@ -226,6 +324,9 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
   (recommended_merge) as $recMerge |
   (recommended_risk) as $recRisk |
   (recommended_base) as $recBase |
+  (recommended_checkpoints) as $recCheckpoints |
+  (selected_checkpoints($recCheckpoints)) as $selCheckpoints |
+  (effective_checkpoints($selCheckpoints)) as $effCheckpoints |
   {
     originalCommand: $originalCommand,
     scope: {
@@ -247,35 +348,46 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
       delegateReview: $recReview,
       mayMerge: $recMerge,
       maxRisk: $recRisk,
-      base: $recBase
+      base: $recBase,
+      checkpoints: $recCheckpoints
     },
     selectedPolicy: {
       mayStartBacklog: value_bool($mayStartBacklogOverride; $recStart),
       delegateReview: value_bool($delegateReviewOverride; $recReview),
       mayMerge: value_bool($mayMergeOverride; $recMerge),
       maxRisk: value_string($maxRiskOverride; $recRisk),
-      base: value_string($baseOverride; $recBase)
+      base: value_string($baseOverride; $recBase),
+      checkpoints: $selCheckpoints
     },
     effectivePolicy: {
       mayStartBacklog: value_bool($mayStartBacklogOverride; $recStart),
       delegateReview: value_bool($delegateReviewOverride; $recReview),
       mayMerge: value_bool($mayMergeOverride; $recMerge),
       maxRisk: value_string($maxRiskOverride; $recRisk),
-      base: value_string($baseOverride; $recBase)
+      base: value_string($baseOverride; $recBase),
+      checkpoints: $effCheckpoints
+    },
+    checkpointPolicy: {
+      recommended: $recCheckpoints,
+      selected: $selCheckpoints,
+      effective: $effCheckpoints
     },
     fieldSources: {
       mayStartBacklog: source_for($mayStartBacklogOverride),
       delegateReview: source_for($delegateReviewOverride),
       mayMerge: source_for($mayMergeOverride),
       maxRisk: source_for($maxRiskOverride),
-      base: source_for($baseOverride)
+      base: source_for($baseOverride),
+      checkpoints: checkpoint_field_source
     },
     requiresConfirmation: ((
       [$mayStartBacklogOverride, $delegateReviewOverride, $mayMergeOverride, $maxRiskOverride, $baseOverride]
       | any(. == "")
-    ) or has_ambiguous),
+    ) or has_ambiguous or (has_recommended_checkpoints and ($checkpointsOverride == null))),
     confirmationReason: (
       if has_ambiguous then "scope or base is ambiguous; confirm before mutation"
+      elif has_recommended_checkpoints and ($checkpointsOverride == null) then
+        "human checkpoints were recommended; confirm, customize, or waive before mutation"
       elif ([$mayStartBacklogOverride, $delegateReviewOverride, $mayMergeOverride, $maxRiskOverride, $baseOverride] | any(. == "")) then
         "one or more autonomy policy values were inferred from resolved scope"
       else "all autonomy policy values were explicit"
@@ -306,6 +418,11 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
       base: (
         if $recBase == null then "base branch could not be inferred unambiguously"
         else "base branch inferred by resolver: " + ($recBase | tostring)
+        end
+      ),
+      checkpoints: (
+        if ($recCheckpoints | length) == 0 then "no human checkpoints recommended for resolved scope"
+        else ($recCheckpoints | length | tostring) + " checkpoint(s) recommended from item metadata signals"
         end
       )
     },
@@ -343,7 +460,16 @@ printf '%s\n' "$recommendation_json" | jq -r '
   "- Review: " + .rationale.delegateReview,
   "- Merge: " + .rationale.mayMerge,
   "- Risk: " + .rationale.maxRisk,
-  "- Base: " + .rationale.base
+  "- Base: " + .rationale.base,
+  "- Checkpoints: " + .rationale.checkpoints
 '
+checkpoint_count="$(printf '%s\n' "$recommendation_json" | jq -r '.effectivePolicy.checkpoints | length')"
+if [ "$checkpoint_count" -gt 0 ]; then
+  printf 'Human checkpoints (%s):\n' "$(printf '%s\n' "$recommendation_json" | jq -r '.fieldSources.checkpoints')"
+  printf '%s\n' "$recommendation_json" | jq -r '
+    .effectivePolicy.checkpoints[]
+    | "- #" + (.item_number | tostring) + " " + .stage + "/" + .domain + " [" + .satisfaction_state + "]: " + .reason
+  '
+fi
 printf 'Copy-paste equivalent: %s\n' "$(printf '%s\n' "$recommendation_json" | jq -r '.copyPasteCommand')"
 printf 'Read-only: %s\n' "$(printf '%s\n' "$recommendation_json" | jq -r '.readOnlyGuarantee')"

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -271,8 +271,10 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
           }]
         else . end
     );
+  def item_eligible_for_checkpoints($item):
+    (($item.group // "eligible") | IN("eligible", "in_review"));
   def recommended_checkpoints:
-    [.items[]? | select((.group // "eligible") == "eligible") | recommend_checkpoints_for_item(.)[]]
+    [.items[]? | select(item_eligible_for_checkpoints(.)) | recommend_checkpoints_for_item(.)[]]
     | unique_by(checkpoint_key(.));
   def checkpoint_matches($a; $b):
     ($a.item_number == $b.item_number) and ($a.stage == $b.stage) and ($a.domain == $b.domain);
@@ -450,8 +452,26 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
       (if value_bool($mayMergeOverride; $recMerge) then " --may-merge" else "" end) +
       " --may-start-backlog " + (value_bool($mayStartBacklogOverride; $recStart) | tostring) +
       " --max-risk " + (value_string($maxRiskOverride; $recRisk) | tostring) +
-      (if value_string($baseOverride; $recBase) == null then "" else " --base " + (value_string($baseOverride; $recBase) | tostring) end)
+      (if value_string($baseOverride; $recBase) == null then "" else " --base " + (value_string($baseOverride; $recBase) | tostring) end) +
+      (if ($effCheckpoints | length) > 0 then
+        " --checkpoints-file checkpoint-policy.json"
+      else "" end)
     ),
+    copyPasteCheckpointCommand: (
+      if ($effCheckpoints | length) == 0 then null
+      else
+        "./scripts/development-workflow/run-epic-policy-recommender.sh --scope <resolver-json> --original-command \""
+        + $originalCommand + "\""
+        + (if value_bool($delegateReviewOverride; $recReview) then " --delegate-review" else "" end)
+        + (if value_bool($mayMergeOverride; $recMerge) then " --may-merge" else "" end)
+        + " --may-start-backlog " + (value_bool($mayStartBacklogOverride; $recStart) | tostring)
+        + " --max-risk " + (value_string($maxRiskOverride; $recRisk) | tostring)
+        + (if value_string($baseOverride; $recBase) == null then "" else " --base " + (value_string($baseOverride; $recBase) | tostring) end)
+        + " --checkpoints-file checkpoint-policy.json"
+      end
+    ),
+    checkpointPolicyExport: $effCheckpoints,
+    checkpointPolicyFile: (if ($effCheckpoints | length) > 0 then "checkpoint-policy.json" else null end),
     readOnlyGuarantee: "No tracker updates, branch creation, PR edits, labels, comments, merges, issue closure, or branch deletion were performed."
   }
 ')"
@@ -490,4 +510,8 @@ if [ "$checkpoint_count" -gt 0 ]; then
   '
 fi
 printf 'Copy-paste equivalent: %s\n' "$(printf '%s\n' "$recommendation_json" | jq -r '.copyPasteCommand')"
+if printf '%s\n' "$recommendation_json" | jq -e '.checkpointPolicyFile != null' >/dev/null; then
+  printf 'Checkpoint policy file: %s (save checkpointPolicyExport JSON before re-run)\n' "$(printf '%s\n' "$recommendation_json" | jq -r '.checkpointPolicyFile')"
+  printf 'Recommender copy-paste: %s\n' "$(printf '%s\n' "$recommendation_json" | jq -r '.copyPasteCheckpointCommand')"
+fi
 printf 'Read-only: %s\n' "$(printf '%s\n' "$recommendation_json" | jq -r '.readOnlyGuarantee')"

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -260,8 +260,7 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
             satisfaction_state: "pending"
           }]
         else . end
-      | if ($stage == "implementation" or ($text | test("auth|security|secret|permission|credential|sensitive")))
-          and ($text | test("auth|security|secret|permission|credential|sensitive")) then
+      | if ($stage == "implementation") and ($text | test("auth|security|secret|permission|credential|sensitive")) then
           . + [{
             item_number: $num,
             stage: "implementation",
@@ -275,13 +274,32 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
   def recommended_checkpoints:
     [.items[]? | recommend_checkpoints_for_item(.)[]]
     | unique_by(checkpoint_key(.));
+  def checkpoint_matches($a; $b):
+    ($a.item_number == $b.item_number) and ($a.stage == $b.stage) and ($a.domain == $b.domain);
   def selected_checkpoints($recommended):
     if $checkpointsOverride == null then $recommended
-    else [$checkpointsOverride[] | normalize_checkpoint(.)]
+    else
+      ($checkpointsOverride | map(normalize_checkpoint(.))) as $override |
+      (
+        $recommended
+        | map(
+            . as $rec
+            | ($override | map(select(checkpoint_matches($rec; .))) | first) // $rec
+          )
+      ) as $merged
+      | $merged + (
+          $override
+          | map(
+              . as $ov
+              | if ($recommended | any(checkpoint_matches(.; $ov))) then empty else $ov end
+            )
+        )
     end;
   def effective_checkpoints($selected): $selected;
   def checkpoint_field_source: if $checkpointsOverride == null then "recommended" else "explicit" end;
   def has_recommended_checkpoints: (recommended_checkpoints | length) > 0;
+  def has_pending_checkpoints($checkpoints):
+    ($checkpoints | map(select(.satisfaction_state == "pending")) | length) > 0;
   def has_backlog: [.items[]? | select((.status // "") == "Backlog")] | length > 0;
   def has_dependency_blocker: [.items[]? | select((.dependencies.state // "") == "blocked")] | length > 0;
   def has_ambiguous: ((.groups.ambiguous // []) | length) > 0 or (.baseAmbiguous // false) == true;
@@ -383,11 +401,11 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
     requiresConfirmation: ((
       [$mayStartBacklogOverride, $delegateReviewOverride, $mayMergeOverride, $maxRiskOverride, $baseOverride]
       | any(. == "")
-    ) or has_ambiguous or (has_recommended_checkpoints and ($checkpointsOverride == null))),
+    ) or has_ambiguous or has_pending_checkpoints($effCheckpoints)),
     confirmationReason: (
       if has_ambiguous then "scope or base is ambiguous; confirm before mutation"
-      elif has_recommended_checkpoints and ($checkpointsOverride == null) then
-        "human checkpoints were recommended; confirm, customize, or waive before mutation"
+      elif has_pending_checkpoints($effCheckpoints) then
+        "pending human checkpoints remain; confirm, customize, or waive before mutation"
       elif ([$mayStartBacklogOverride, $delegateReviewOverride, $mayMergeOverride, $maxRiskOverride, $baseOverride] | any(. == "")) then
         "one or more autonomy policy values were inferred from resolved scope"
       else "all autonomy policy values were explicit"

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -242,6 +242,7 @@ schema_output="$(recommend_json "$schema_fixture" "\$run-epic --items 200")"
 run_test "schema_scope_recommends_plan_checkpoint" "plan:technical" "$(printf '%s\n' "$schema_output" | jq -r '.recommendedPolicy.checkpoints[0] | .stage + ":" + .domain')"
 run_test "schema_checkpoint_pending" "pending" "$(printf '%s\n' "$schema_output" | jq -r '.recommendedPolicy.checkpoints[0].satisfaction_state')"
 run_test "schema_checkpoint_requires_confirmation" "true" "$(printf '%s\n' "$schema_output" | jq -r '.requiresConfirmation')"
+run_test "schema_copy_paste_includes_checkpoint_file" "yes" "$(printf '%s\n' "$schema_output" | jq -r '.copyPasteCommand' | grep -Fq -- '--checkpoints-file checkpoint-policy.json' && echo yes || echo no)"
 
 sensitive_fixture="$(write_fixture sensitive '{
   "scopeSource": "items",
@@ -259,7 +260,7 @@ sensitive_fixture="$(write_fixture sensitive '{
     "ambiguous": []
   },
   "items": [
-    {"number": 300, "title": "Harden auth permission checks", "status": "Development in Review", "type": "Feature", "labels": []}
+    {"number": 300, "title": "Harden auth permission checks", "status": "Development in Review", "type": "Feature", "labels": [], "group": "in_review"}
   ]
 }')"
 sensitive_output="$(recommend_json "$sensitive_fixture" "\$run-epic --items 300")"

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -295,6 +295,15 @@ run_test "empty_checkpoint_override_still_requires_confirmation" "true" "$(print
 checkpoint_text_output="$("$HELPER" --scope "$schema_fixture" --original-command "\$run-epic --items 200")"
 run_test "text_output_lists_checkpoints" "yes" "$(grep -q 'Human checkpoints' <<< "$checkpoint_text_output" && echo yes || echo no)"
 
+blocked_schema_fixture="$(write_fixture blocked-schema "$(jq '
+  .groups.eligible = []
+  | .groups.blocked = [.items[0] | .group = "blocked" | .dependencies.state = "blocked"]
+  | .items[0].group = "blocked"
+  | .items[0].dependencies.state = "blocked"
+' "$schema_fixture")")"
+blocked_schema_output="$(recommend_json "$blocked_schema_fixture" "\$run-epic --items 200")"
+run_test "blocked_item_skips_checkpoint_recommendation" "0" "$(printf '%s\n' "$blocked_schema_output" | jq -r '.recommendedPolicy.checkpoints | length')"
+
 echo ""
 echo "=== Summary ==="
 echo "Passed: $PASS_COUNT"

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -219,6 +219,76 @@ run_test "text_output_names_effective_policy" "yes" "$(grep -q 'Effective policy
 PATH="$MOCK_BIN:$PATH" "$HELPER" --scope "$backlog_fixture" --original-command "\$run-epic issues 949" --json >/dev/null
 run_test "does_not_call_gh_or_git" "0" "$(wc -l < "$CALL_LOG" | tr -d ' ')"
 
+schema_fixture="$(write_fixture schema '{
+  "scopeSource": "items",
+  "epicNumber": null,
+  "itemInput": "200",
+  "baseBranch": "develop",
+  "baseAmbiguous": false,
+  "baseReason": "no integration branch label",
+  "policy": {"delegateReview": false, "mayMerge": false, "mayStartBacklog": false, "maxRisk": "low"},
+  "groups": {
+    "eligible": [{"number": 200, "title": "Add users table database migration", "status": "Backlog", "type": "Feature", "labels": ["database"], "dependencies": {"state": "none"}}],
+    "blocked": [],
+    "already_merged": [],
+    "in_review": [],
+    "ambiguous": []
+  },
+  "items": [
+    {"number": 200, "title": "Add users table database migration", "status": "Backlog", "type": "Feature", "labels": ["database"], "dependencies": {"state": "none"}}
+  ]
+}')"
+schema_output="$(recommend_json "$schema_fixture" "\$run-epic --items 200")"
+run_test "schema_scope_recommends_plan_checkpoint" "plan:technical" "$(printf '%s\n' "$schema_output" | jq -r '.recommendedPolicy.checkpoints[0] | .stage + ":" + .domain')"
+run_test "schema_checkpoint_pending" "pending" "$(printf '%s\n' "$schema_output" | jq -r '.recommendedPolicy.checkpoints[0].satisfaction_state')"
+run_test "schema_checkpoint_requires_confirmation" "true" "$(printf '%s\n' "$schema_output" | jq -r '.requiresConfirmation')"
+
+sensitive_fixture="$(write_fixture sensitive '{
+  "scopeSource": "items",
+  "epicNumber": null,
+  "itemInput": "300",
+  "baseBranch": "develop",
+  "baseAmbiguous": false,
+  "baseReason": "no integration branch label",
+  "policy": {"delegateReview": false, "mayMerge": false, "mayStartBacklog": false, "maxRisk": "low"},
+  "groups": {
+    "eligible": [],
+    "blocked": [],
+    "already_merged": [],
+    "in_review": [{"number": 300, "title": "Harden auth permission checks", "status": "Development in Review", "type": "Feature", "labels": []}],
+    "ambiguous": []
+  },
+  "items": [
+    {"number": 300, "title": "Harden auth permission checks", "status": "Development in Review", "type": "Feature", "labels": []}
+  ]
+}')"
+sensitive_output="$(recommend_json "$sensitive_fixture" "\$run-epic --items 300")"
+run_test "sensitive_scope_recommends_implementation_checkpoint" "implementation:technical" "$(printf '%s\n' "$sensitive_output" | jq -r '.recommendedPolicy.checkpoints[0] | .stage + ":" + .domain')"
+
+run_test "docs_scope_has_no_checkpoints" "0" "$(printf '%s\n' "$docs_output" | jq -r '.recommendedPolicy.checkpoints | length')"
+
+waived_file="$TMP_ROOT/waived-checkpoints.json"
+printf '%s\n' '[{
+  "item_number": 200,
+  "stage": "plan",
+  "domain": "technical",
+  "reason": "issue signals database schema, migration, or persistent data-model changes",
+  "required_human_action": "review and approve proposed data model in the plan before implementation proceeds",
+  "satisfaction_state": "waived",
+  "waiver_rationale": "schema change is additive only and pre-approved in epic brief"
+}]' > "$waived_file"
+waived_output="$("$HELPER" --scope "$schema_fixture" --original-command "\$run-epic --items 200" --checkpoints-file "$waived_file" --json)"
+run_test "explicit_checkpoint_override_source" "explicit" "$(printf '%s\n' "$waived_output" | jq -r '.fieldSources.checkpoints')"
+run_test "waived_checkpoint_preserved" "waived" "$(printf '%s\n' "$waived_output" | jq -r '.effectivePolicy.checkpoints[0].satisfaction_state')"
+run_test "checkpoint_policy_audit_fields_present" "yes" "$(printf '%s\n' "$waived_output" | jq -e '.checkpointPolicy.recommended and .checkpointPolicy.selected and .checkpointPolicy.effective' >/dev/null && echo yes || echo no)"
+
+invalid_waived_file="$TMP_ROOT/invalid-waived.json"
+printf '%s\n' '[{"item_number": 200, "stage": "plan", "domain": "technical", "satisfaction_state": "waived"}]' > "$invalid_waived_file"
+run_fails_contains "rejects_waived_without_rationale" "waived checkpoints require waiver_rationale" "$HELPER" --scope "$schema_fixture" --original-command x --checkpoints-file "$invalid_waived_file" --json
+
+checkpoint_text_output="$("$HELPER" --scope "$schema_fixture" --original-command "\$run-epic --items 200")"
+run_test "text_output_lists_checkpoints" "yes" "$(grep -q 'Human checkpoints' <<< "$checkpoint_text_output" && echo yes || echo no)"
+
 echo ""
 echo "=== Summary ==="
 echo "Passed: $PASS_COUNT"

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -286,6 +286,12 @@ invalid_waived_file="$TMP_ROOT/invalid-waived.json"
 printf '%s\n' '[{"item_number": 200, "stage": "plan", "domain": "technical", "satisfaction_state": "waived"}]' > "$invalid_waived_file"
 run_fails_contains "rejects_waived_without_rationale" "waived checkpoints require waiver_rationale" "$HELPER" --scope "$schema_fixture" --original-command x --checkpoints-file "$invalid_waived_file" --json
 
+empty_checkpoints_file="$TMP_ROOT/empty-checkpoints.json"
+printf '%s\n' '[]' > "$empty_checkpoints_file"
+empty_override_output="$("$HELPER" --scope "$schema_fixture" --original-command "\$run-epic --items 200" --checkpoints-file "$empty_checkpoints_file" --json)"
+run_test "empty_checkpoint_override_keeps_recommended" "1" "$(printf '%s\n' "$empty_override_output" | jq -r '.effectivePolicy.checkpoints | length')"
+run_test "empty_checkpoint_override_still_requires_confirmation" "true" "$(printf '%s\n' "$empty_override_output" | jq -r '.requiresConfirmation')"
+
 checkpoint_text_output="$("$HELPER" --scope "$schema_fixture" --original-command "\$run-epic --items 200")"
 run_test "text_output_lists_checkpoints" "yes" "$(grep -q 'Human checkpoints' <<< "$checkpoint_text_output" && echo yes || echo no)"
 


### PR DESCRIPTION
## Summary

- Extends `run-epic-policy-recommender.sh` to classify per-item human checkpoints from read-only scope metadata (title, type, labels, tracker status).
- Adds `--checkpoints-file` for explicit selection/waiver with required `waiver_rationale` on waived defaults.
- Emits `recommendedPolicy.checkpoints`, `selectedPolicy.checkpoints`, `effectivePolicy.checkpoints`, and `checkpointPolicy` audit fields in JSON and human-readable output.
- Documents checkpoint recommendation behavior in protocol 95 Step 6a and the guardrails enforcement mapping table.

Implements #1021 per the merged spec/plan from #1020. Enforcement at PR labels and delegated gates is deferred to #1022/#1023.

## Self-review

- Reviewed `git diff develop-run-epic-human-checkpoints...HEAD` for scope alignment with issue #1021 and plan section for #1021.
- Verified existing recommender behavior unchanged for delegation, merge, base, and risk fields.
- Added unit fixtures for no-checkpoint, plan-stage schema, implementation-stage sensitive change, and explicit waiver override.

## Test plan

- [x] `bash scripts/development-workflow/tests/test-run-epic-policy-recommender.sh` (44 passed)


Made with [Cursor](https://cursor.com)