### PR TITLE
feat(checkpoints): carry human checkpoints through PR readiness lifecycle (#1022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Human checkpoint PR lifecycle** (#1022): adds `human-checkpoint-required` readiness
+  signal (protocol 92), Step 8a/8c checkpoint label sync in protocol 91,
+  `run-epic-checkpoint-lifecycle.sh` for satisfaction detection and label/comment
+  persistence, and checkpoint policy fields in `run-epic-audit-trail.sh`.
 - **Run-epic checkpoint policy recommendations** (#1021): `run-epic-policy-recommender.sh`
   now emits per-item human checkpoint recommendations from read-only scope metadata,
   supports explicit selection/waiver via `--checkpoints-file`, and records

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1788,6 +1788,49 @@ Before running the readiness checklist below, perform a best-effort scan of the 
 
 5. After the scan: proceed to the readiness checklist below. The presence of `needs-setup` is a valid co-label with `ready-for-human-review` and does **not** block this checklist or prevent `ready-for-human-review` from being applied (BR-3). The checklist script does not check for or remove `needs-setup` — it is a deliberate signal, not a stale label.
 
+### Human Checkpoint Label Sync (pre-readiness)
+
+When the run carries an effective checkpoint policy (`checkpoints[]` on the epic
+invocation policy or a `checkpoint-policy.json` file saved at policy selection
+time), synchronize the `human-checkpoint-required` label and stable PR comment
+**after** CI and automated review are clean and **before** applying
+`ready-for-human-review`. This runs on every pass through Step 8a — including
+after fixer pushes — so label state always reflects current checkpoint
+satisfaction.
+
+**Timing**: Run after the infrastructure dependency scan above and before Check
+4 (`ready-for-human-review` application) in the readiness checklist.
+
+**Procedure**:
+
+1. Resolve the linked work item number (`ITEM_NUMBER`) and branch name
+   (`BRANCH`) for the PR.
+2. Locate the effective checkpoint policy JSON array (from epic handoff metadata,
+   `checkpoint-policy.json` in the run working directory, or
+   `invocation_policy.effective_policy.checkpoints`).
+3. Detect satisfaction from human signals and sync labels:
+
+   ```bash
+   ./scripts/development-workflow/run-epic-checkpoint-lifecycle.sh sync-pr-labels \
+     --pr "$PR_NUMBER" \
+     --item "$ITEM_NUMBER" \
+     --branch "$BRANCH" \
+     --checkpoints-file checkpoint-policy.json \
+     --write-checkpoints-file checkpoint-policy.json
+   ```
+
+4. When `BLOCKING_COUNT` is greater than zero, apply `ready-for-human-review`
+   **and** keep `human-checkpoint-required` (both labels may coexist per
+   protocol 92 BR-11/BR-3). Record checkpoint reason and required human action
+   in the `<!-- run-epic:checkpoint-status -->` comment posted by the script.
+5. When all applicable checkpoints are `satisfied` or `waived`, the script
+   removes `human-checkpoint-required` automatically.
+6. During fix cycles (Step 9): when applying `needs-fixes`, do **not** remove
+   `human-checkpoint-required` while checkpoints remain `pending`.
+
+**Skip condition**: When no checkpoint policy is in scope for this run (no
+`checkpoints[]` and no `checkpoint-policy.json`), skip this subsection.
+
 Run this checklist for **every PR**:
 
 ```bash
@@ -2120,6 +2163,8 @@ Verify all of the following. If any check fails, **do not report ready** — tre
 | `ready-for-regression` label                    | Present in `labels[].name` for `feature/*`, `fix/*`, `refactor/*`, `hotfix/*`, `backport/hotfix/*`; absent/ignored for `spec/*`, `implementation-plan/*`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | No `needs-fixes` label                          | `needs-fixes` absent from `labels[].name`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `needs-setup` label (if present)                | **Valid co-label** — `needs-setup` may be present alongside `ready-for-human-review` when the diff contains infrastructure dependency signals. Its presence does **not** constitute a verification failure and does not block this check. Do not remove it.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `human-checkpoint-required` label (when checkpoints in scope) | When the run carries checkpoint policy for this item: present if and only if applicable checkpoints remain `pending`; absent when all applicable checkpoints are `satisfied` or `waived`. Valid co-label with `ready-for-human-review`. When no checkpoint policy is in scope, ignore this check. |
+| Checkpoint status comment (when checkpoints in scope) | At least one PR comment containing `<!-- run-epic:checkpoint-status -->` whose blocking section matches the current label state. Skip when no checkpoint policy is in scope. |
 | All automated-reviewer `reviewThreads` resolved | GraphQL query above returns empty output — `isResolved: true` (or first comment body contains `✅ Addressed`) for every thread authored by a configured bot login (skip this check only when Step 7 was `skipped` because no review platforms are configured)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | Automated reviewer loop summary                 | At least one comment whose body contains `"Automated Reviewer Loop Summary"`, `"Reviewer Loop Summary"`, or `"No blocking PR feedback"` (skip this check only when Step 7 was `skipped` because no review platforms are configured), and the latest summary's `Result:` line is `clean` or `skipped`. **This is a hard requirement. Agents applying fixes MUST NOT remove or skip this check — the presence of the comment plus a clean/skipped result is the only reliable signal that Step 7 ran to completion successfully. A PR that has `ready-for-human-review` but lacks this comment or has `RESULT=escalate`, `pending_timeout`, `timeout`, `needs_fixes`, or any other non-clean terminal result is in an incomplete state and must re-run Step 7 or escalate.** (Note: the Step 7a summary comment posted by the internal review gate is a distinct comment from a distinct step — it does not satisfy this check. This check targets the external automated reviewer loop summary from Step 7 only.) |
 | CI checks                                       | All required status checks have `state: SUCCESS` or `conclusion: success` in `statusCheckRollup` (no check in `PENDING`, `FAILURE`, or `ERROR` state)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |

--- a/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -14,6 +14,7 @@ This is a **repo-wide definition**. All agents apply these labels consistently.
 | `needs-fixes`            | The PR still needs fixes before it is ready for human review. This may be due to human-requested changes, failing CI, or blocking automated PR feedback.                                                                                                                                                                 |
 | `ready-for-regression`   | Automated code reviews are clean (or skipped). E2e/regression tests should now run. Applied by the orchestrator (Step 7b) on implementation PRs (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`, `backport/hotfix/*`), and by the prepare-release flow (protocol `05`) on **production** release PRs (`release/*` → `main`) only. |
 | `needs-setup`            | PR introduces one or more infrastructure dependencies (env vars, secrets, DNS records, service account tokens, etc.) that require human setup steps before the feature can be safely enabled. Co-exists with `ready-for-human-review`; the human removes this label after completing (or intentionally deferring) setup. |
+| `human-checkpoint-required` | The PR's linked work item has at least one `pending` human checkpoint that applies to this PR: same `item_number` and either matching the PR's current workflow stage or an earlier stage not yet `satisfied`/`waived`. Human feedback or approval named in `required_human_action` is still required. Co-exists with `ready-for-human-review` when automation is clean but a checkpoint remains open. Does **not** satisfy when only `needs-setup` is removed. |
 
 ---
 
@@ -85,6 +86,55 @@ Apply this label when the agent's infrastructure dependency scan (Protocol 91 St
 - **BR-3**: `needs-setup` does not prevent `ready-for-human-review` from being applied, does not block CI from passing, and does not block automated review tools from completing. It co-exists with `ready-for-human-review`.
 - **BR-7**: When the human removes `needs-setup` (Use Case 3 — setup acknowledged), the `## Pre-merge Setup` section remains in the PR body as a historical record. When the agent rescans and finds no infrastructure dependencies (Use Case 4 — dependency removed from diff), the agent removes both the label and the section.
 - **BR-10**: `needs-setup` is distinct from `needs-fixes`. They have different semantics, different lifecycles, and may co-exist. `needs-fixes` signals reviewer-requested code changes; `needs-setup` signals out-of-band human configuration steps.
+
+---
+
+## Conditions for `human-checkpoint-required`
+
+Apply this label when the PR's linked work item has at least one checkpoint in
+`pending` state that applies to this PR's workflow stage or an earlier stage in
+the ordered sequence `spec` → `plan` → `implementation` (see
+`1020-human-checkpoint-policy-model` spec BR-2 and BR-4).
+
+**Who applies it**: The Work Item Runner (Protocol 91 Step 8a) via
+`run-epic-checkpoint-lifecycle.sh sync-pr-labels` after CI and automated review
+are clean and before or alongside applying `ready-for-human-review`.
+
+**Who removes it**: The script removes the label when every applicable
+checkpoint transitions to `satisfied` or `waived` with audit evidence. Removing
+`needs-fixes` or `needs-setup` does **not** remove this label.
+
+**Valid label combinations**:
+
+| Combination                                                         | Meaning                                                                                                                                                       |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ready-for-human-review` only                                       | Automation clean and no open checkpoints apply to this PR                                                                                                       |
+| `ready-for-human-review` + `human-checkpoint-required`              | Automation clean but explicit human checkpoint feedback is still required before delegated review/merge may proceed                                           |
+| `ready-for-human-review` + `needs-setup` + `human-checkpoint-required` | Automation clean, setup steps may still be required, and a checkpoint remains open                                                                         |
+| `needs-fixes` + `human-checkpoint-required`                         | Transitional — automation/reviewer fixes needed; checkpoint state persists independently                                                                    |
+
+**Invariants**:
+
+- **BR-11**: `ready-for-human-review` means automation-clean only; it does not
+  imply checkpoint satisfaction.
+- **BR-12**: `human-checkpoint-required` persists through ordinary fix cycles
+  while the checkpoint remains `pending`.
+- **BR-13**: Removing `human-checkpoint-required` requires `satisfaction_state`
+  of `satisfied` or `waived` with audit evidence recorded in the stable
+  `<!-- run-epic:checkpoint-status -->` PR comment.
+- **BR-14**: `needs-fixes` removal does not imply checkpoint satisfaction.
+
+**Satisfaction signals** (detected on reruns):
+
+- Explicit PR comment:
+  `<!-- run-epic:checkpoint-satisfied:<item>:<stage>:<domain> -->`
+- Explicit waiver comment:
+  `<!-- run-epic:checkpoint-waived:<item>:<stage>:<domain> --> <rationale>`
+- Human PR review approval (`APPROVED`) on a PR whose workflow stage matches
+  the checkpoint's `stage`.
+
+The `human-checkpoint-required` GitHub label must exist in the repository's label
+settings before Step 8a can apply it. Suggested color: `#d93f0b` (orange-red).
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -131,7 +131,8 @@ checkpoint transitions to `satisfied` or `waived` with audit evidence. Removing
 - Explicit waiver comment:
   `<!-- run-epic:checkpoint-waived:<item>:<stage>:<domain> --> <rationale>`
 - Human PR review approval (`APPROVED`) on a PR whose workflow stage matches
-  the checkpoint's `stage`.
+  the checkpoint's `stage` satisfies **all** pending checkpoints at that stage
+  for the linked item in one action.
 
 The `human-checkpoint-required` GitHub label must exist in the repository's label
 settings before Step 8a can apply it. Suggested color: `#d93f0b` (orange-red).

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1299,7 +1299,13 @@ run_bugbot_review() {
   while IFS= read -r review_json; do
     [ -z "${review_json:-}" ] && continue
     body="$(printf '%s\n' "$review_json" | jq -r '.body')"
+    _rv_state="$(printf '%s\n' "$review_json" | jq -r '.state // ""')"
     [ -z "$body" ] && continue
+    if [ "$_rv_state" = "CHANGES_REQUESTED" ]; then
+      existing_blocking_count=$((existing_blocking_count + 1))
+      printf '%s\n' "$review_json" >> "$existing_blocking_file"
+      continue
+    fi
     if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
       existing_suggestion_count=$((existing_suggestion_count + 1))
       continue
@@ -1589,7 +1595,9 @@ run_bugbot_review() {
             local _rv_state
             _rv_state="$(printf '%s\n' "$review_json" | jq -r '.state // ""')"
             [ -z "$body" ] && continue
-            if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
+            if [ "$_rv_state" = "CHANGES_REQUESTED" ]; then
+              : # requested changes are always blocking regardless of body text
+            elif is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
               suggestion_count=$((suggestion_count + 1))
               comment_count=$((comment_count + 1))
               continue

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1288,7 +1288,7 @@ run_bugbot_review() {
     body="$(printf '%s\n' "$comment_json" | jq -r '.body')"
     [ -z "$body" ] && continue
     # Bugbot informational notes are counted as suggestions, not blockers (AC-4).
-    if is_soft_suggestion "$body"; then
+    if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
       existing_suggestion_count=$((existing_suggestion_count + 1))
       continue
     fi
@@ -1300,7 +1300,7 @@ run_bugbot_review() {
     [ -z "${review_json:-}" ] && continue
     body="$(printf '%s\n' "$review_json" | jq -r '.body')"
     [ -z "$body" ] && continue
-    if is_soft_suggestion "$body"; then
+    if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
       existing_suggestion_count=$((existing_suggestion_count + 1))
       continue
     fi
@@ -1476,7 +1476,7 @@ run_bugbot_review() {
             body="$(printf '%s\n' "$comment_json" | jq -r '.body')"
             [ -z "$body" ] && continue
             comment_count=$((comment_count + 1))
-            if is_soft_suggestion "$body"; then
+            if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
               suggestion_count=$((suggestion_count + 1))
             else
               blocking_count=$((blocking_count + 1))
@@ -1574,7 +1574,7 @@ run_bugbot_review() {
             body="$(printf '%s\n' "$comment_json" | jq -r '.body')"
             [ -z "$body" ] && continue
             comment_count=$((comment_count + 1))
-            if is_soft_suggestion "$body"; then
+            if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
               suggestion_count=$((suggestion_count + 1))
             else
               blocking_count=$((blocking_count + 1))
@@ -1589,7 +1589,7 @@ run_bugbot_review() {
             local _rv_state
             _rv_state="$(printf '%s\n' "$review_json" | jq -r '.state // ""')"
             [ -z "$body" ] && continue
-            if is_soft_suggestion "$body"; then
+            if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
               suggestion_count=$((suggestion_count + 1))
               comment_count=$((comment_count + 1))
               continue

--- a/scripts/development-workflow/run-epic-audit-trail.sh
+++ b/scripts/development-workflow/run-epic-audit-trail.sh
@@ -150,14 +150,17 @@ render_pr_disposition() {
     else
       printf '%s\n' "$json" | jq -r '
         (.checkpoint_policy // .checkpointPolicy // {}) as $cp |
+        (.item.number) as $itemNum |
         "- Field source: " + (($cp.field_source // $cp.fieldSource // "unknown") | tostring),
-        "- Pending applicable checkpoints: " + (([($cp.effective // $cp.effectivePolicy // [])[] | select(.satisfaction_state == "pending")] | length) | tostring)
+        "- Pending applicable checkpoints: " + (([($cp.effective // $cp.effectivePolicy // [])[] | select(.satisfaction_state == "pending" and ((.item_number | tonumber) == ($itemNum | tonumber)))] | length) | tostring)
       '
       printf '\n| Item | Stage | Domain | State | Reason | Required action |\n'
       printf '| --- | --- | --- | --- | --- | --- |\n'
       printf '%s\n' "$json" | jq -r "$table_cell_filter"'
         (.checkpoint_policy // .checkpointPolicy // {}) as $cp |
-        ($cp.effective // $cp.effectivePolicy // [])[]? |
+        (.item.number) as $itemNum |
+        ($cp.effective // $cp.effectivePolicy // [])[]
+        | select((.item_number | tonumber) == ($itemNum | tonumber)) |
         "| #" + (.item_number | tostring) +
         " | " + ((.stage // "") | cell) +
         " | " + ((.domain // "") | cell) +

--- a/scripts/development-workflow/run-epic-audit-trail.sh
+++ b/scripts/development-workflow/run-epic-audit-trail.sh
@@ -80,6 +80,24 @@ table_cell_filter='
     | gsub("\\t"; " ");
 '
 
+checkpoint_stage_filter='
+  def stage_rank($stage):
+    if $stage == "spec" then 1
+    elif $stage == "plan" then 2
+    elif $stage == "implementation" then 3
+    else 0 end;
+  def stage_from_branch($branch):
+    if ($branch | test("^spec/")) then "spec"
+    elif ($branch | test("^implementation-plan/")) then "plan"
+    elif ($branch | test("^(feature|fix|refactor|hotfix|backport/hotfix)/")) then "implementation"
+    else "implementation" end;
+  def checkpoint_applies($cp; $item; $prStage):
+    (($cp.item_number | tonumber) == ($item | tonumber))
+    and ($cp.satisfaction_state // "pending") == "pending"
+    and (stage_rank($cp.stage) > 0)
+    and (stage_rank($cp.stage) <= stage_rank($prStage));
+'
+
 render_pr_disposition() {
   local json="$1"
   local missing
@@ -148,19 +166,43 @@ render_pr_disposition() {
     if [ "$(printf '%s\n' "$json" | jq 'if (.checkpoint_policy // .checkpointPolicy // null) == null then 0 else 1 end')" -eq 0 ]; then
       printf 'Not recorded.\n'
     else
-      printf '%s\n' "$json" | jq -r '
+      printf '%s\n' "$json" | jq -r "$checkpoint_stage_filter"'
         (.checkpoint_policy // .checkpointPolicy // {}) as $cp |
         (.item.number) as $itemNum |
+        (.pr.branch // "") as $branch |
+        ((.pr.stage // "") as $stage |
+          if ($branch | length) > 0 then stage_from_branch($branch)
+          elif ($stage | length) > 0 then $stage
+          else null end) as $prStage |
         "- Field source: " + (($cp.field_source // $cp.fieldSource // "unknown") | tostring),
-        "- Pending applicable checkpoints: " + (([($cp.effective // $cp.effectivePolicy // [])[] | select(.satisfaction_state == "pending" and ((.item_number | tonumber) == ($itemNum | tonumber)))] | length) | tostring)
+        "- Pending applicable checkpoints: " + (
+          [($cp.effective // $cp.effectivePolicy // [])[]
+            | select(
+                if $prStage == null then
+                  (.satisfaction_state == "pending" and ((.item_number | tonumber) == ($itemNum | tonumber)))
+                else
+                  checkpoint_applies(.; ($itemNum | tostring); $prStage)
+                end
+              )] | length | tostring
+        )
       '
       printf '\n| Item | Stage | Domain | State | Reason | Required action |\n'
       printf '| --- | --- | --- | --- | --- | --- |\n'
-      printf '%s\n' "$json" | jq -r "$table_cell_filter"'
+      printf '%s\n' "$json" | jq -r "$table_cell_filter $checkpoint_stage_filter"'
         (.checkpoint_policy // .checkpointPolicy // {}) as $cp |
         (.item.number) as $itemNum |
+        (.pr.branch // "") as $branch |
+        ((.pr.stage // "") as $stage |
+          if ($branch | length) > 0 then stage_from_branch($branch)
+          elif ($stage | length) > 0 then $stage
+          else null end) as $prStage |
         ($cp.effective // $cp.effectivePolicy // [])[]
-        | select((.item_number | tonumber) == ($itemNum | tonumber)) |
+        | select((.item_number | tonumber) == ($itemNum | tonumber))
+        | select(
+            if $prStage == null then true
+            else checkpoint_applies(.; ($itemNum | tostring); $prStage) or (.satisfaction_state // "pending") != "pending"
+            end
+          ) |
         "| #" + (.item_number | tostring) +
         " | " + ((.stage // "") | cell) +
         " | " + ((.domain // "") | cell) +

--- a/scripts/development-workflow/run-epic-audit-trail.sh
+++ b/scripts/development-workflow/run-epic-audit-trail.sh
@@ -151,7 +151,7 @@ render_pr_disposition() {
       printf '%s\n' "$json" | jq -r '
         (.checkpoint_policy // .checkpointPolicy // {}) as $cp |
         "- Field source: " + (($cp.field_source // $cp.fieldSource // "unknown") | tostring),
-        "- Pending applicable checkpoints: " + (([$cp.effective // $cp.effectivePolicy // [] | .[] | select(.satisfaction_state == "pending")] | length) | tostring)
+        "- Pending applicable checkpoints: " + (([($cp.effective // $cp.effectivePolicy // [])[] | select(.satisfaction_state == "pending")] | length) | tostring)
       '
       printf '\n| Item | Stage | Domain | State | Reason | Required action |\n'
       printf '| --- | --- | --- | --- | --- | --- |\n'

--- a/scripts/development-workflow/run-epic-audit-trail.sh
+++ b/scripts/development-workflow/run-epic-audit-trail.sh
@@ -305,9 +305,15 @@ render_epic_ledger() {
         ]
         | map(select((. | tostring | length) > 0))
         | join("\n");
+      def item_checkpoints($item; $rootPolicy):
+        if (($item.checkpoints // $item.effective_checkpoints // null) != null) then
+          ($item.checkpoints // $item.effective_checkpoints // [])
+        else
+          ($rootPolicy.checkpoints // [] | map(select((.item_number | tonumber) == ($item.issue_number | tonumber))))
+        end;
       .items[] |
       (.effective_policy // .effectivePolicy // $rootEffectivePolicy) as $effectivePolicy |
-      (.checkpoints // .effective_checkpoints // $rootEffectivePolicy.checkpoints // []) as $itemCheckpoints |
+      item_checkpoints(.; $rootEffectivePolicy) as $itemCheckpoints |
       (.stop_gate // .stopGate // .final_stop_gate // .finalStopGate // "") as $stopGate |
       "| #" + (.issue_number | tostring) + " " + ((.title // "") | cell) +
       " | " + (if .pr_number then "#" + (.pr_number | tostring) else "-" end) +

--- a/scripts/development-workflow/run-epic-audit-trail.sh
+++ b/scripts/development-workflow/run-epic-audit-trail.sh
@@ -144,6 +144,28 @@ render_pr_disposition() {
         " | " + (($e[$field] // "") | cell) + " |"
       '
     fi
+    printf '\n### Checkpoint Policy\n\n'
+    if [ "$(printf '%s\n' "$json" | jq 'if (.checkpoint_policy // .checkpointPolicy // null) == null then 0 else 1 end')" -eq 0 ]; then
+      printf 'Not recorded.\n'
+    else
+      printf '%s\n' "$json" | jq -r '
+        (.checkpoint_policy // .checkpointPolicy // {}) as $cp |
+        "- Field source: " + (($cp.field_source // $cp.fieldSource // "unknown") | tostring),
+        "- Pending applicable checkpoints: " + (([$cp.effective // $cp.effectivePolicy // [] | .[] | select(.satisfaction_state == "pending")] | length) | tostring)
+      '
+      printf '\n| Item | Stage | Domain | State | Reason | Required action |\n'
+      printf '| --- | --- | --- | --- | --- | --- |\n'
+      printf '%s\n' "$json" | jq -r "$table_cell_filter"'
+        (.checkpoint_policy // .checkpointPolicy // {}) as $cp |
+        ($cp.effective // $cp.effectivePolicy // [])[]? |
+        "| #" + (.item_number | tostring) +
+        " | " + ((.stage // "") | cell) +
+        " | " + ((.domain // "") | cell) +
+        " | " + ((.satisfaction_state // "pending") | cell) +
+        " | " + ((.reason // "") | cell) +
+        " | " + ((.required_human_action // "") | cell) + " |"
+      '
+    fi
     printf '\n### Advisory Decisions\n\n'
     if [ "$(printf '%s\n' "$json" | jq '(.advisories // []) | length')" -eq 0 ]; then
       printf 'None.\n'
@@ -266,16 +288,26 @@ render_epic_ledger() {
           ", maxRisk=" + (($policy.maxRisk // "") | tostring) +
           ", base=" + (($policy.base // "") | tostring)
         else "" end;
-      def notes_with_policy($base; $policy; $gate):
+      def checkpoint_note($checkpoints):
+        if (($checkpoints | type) == "array") and (($checkpoints | length) > 0) then
+          "Checkpoints: " + (
+            $checkpoints
+            | map("#" + (.item_number|tostring) + " " + (.stage // "") + "/" + (.domain // "") + "=" + (.satisfaction_state // "pending"))
+            | join(", ")
+          )
+        else "" end;
+      def notes_with_policy($base; $policy; $gate; $checkpoints):
         [
           ($base // ""),
           policy_note($policy),
+          checkpoint_note($checkpoints),
           (if (($gate // "") | tostring | length) > 0 then "Stop gate: " + ($gate | tostring) else "" end)
         ]
         | map(select((. | tostring | length) > 0))
         | join("\n");
       .items[] |
       (.effective_policy // .effectivePolicy // $rootEffectivePolicy) as $effectivePolicy |
+      (.checkpoints // .effective_checkpoints // $rootEffectivePolicy.checkpoints // []) as $itemCheckpoints |
       (.stop_gate // .stopGate // .final_stop_gate // .finalStopGate // "") as $stopGate |
       "| #" + (.issue_number | tostring) + " " + ((.title // "") | cell) +
       " | " + (if .pr_number then "#" + (.pr_number | tostring) else "-" end) +
@@ -284,7 +316,7 @@ render_epic_ledger() {
       " | " + ((.review_result // "") | cell) +
       " | " + ((.decision // "") | cell) +
       " | " + ((.merge_cleanup // "") | cell) +
-      " | " + (notes_with_policy(.notes; $effectivePolicy; $stopGate) | cell) + " |"
+      " | " + (notes_with_policy(.notes; $effectivePolicy; $stopGate; $itemCheckpoints) | cell) + " |"
     '
   } | redact_text
 }

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -1,0 +1,426 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+# shellcheck source=scripts/development-workflow/workflow-lib.sh
+source "$SCRIPT_DIR/workflow-lib.sh"
+
+CHECKPOINT_MARKER="<!-- run-epic:checkpoint-status -->"
+SATISFIED_MARKER_PREFIX="<!-- run-epic:checkpoint-satisfied:"
+WAIVED_MARKER_PREFIX="<!-- run-epic:checkpoint-waived:"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/development-workflow/run-epic-checkpoint-lifecycle.sh stage-from-branch --branch <name>
+  ./scripts/development-workflow/run-epic-checkpoint-lifecycle.sh evaluate-blocking --item <number> --branch <name> --checkpoints-file <json-array>
+  ./scripts/development-workflow/run-epic-checkpoint-lifecycle.sh detect-satisfaction --item <number> --branch <name> --checkpoints-file <json-array> [--pr <number>]
+  ./scripts/development-workflow/run-epic-checkpoint-lifecycle.sh render-pr-checkpoint-comment --input <file>
+  ./scripts/development-workflow/run-epic-checkpoint-lifecycle.sh sync-pr-labels --pr <number> --item <number> --branch <name> --checkpoints-file <json-array> [--write-checkpoints-file <path>]
+
+Evaluates human-checkpoint policy for a PR, detects satisfaction from human
+review/comment signals, applies or removes human-checkpoint-required, and
+records checkpoint state in a stable PR comment.
+EOF
+}
+
+command="${1:-}"
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+pr_number=""
+item_number=""
+branch_name=""
+checkpoints_file=""
+write_checkpoints_file=""
+input_file=""
+
+error_exit() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_value() {
+  local option="$1"
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ] || [ "${2#--}" != "$2" ]; then
+    echo "$option requires a value." >&2
+    usage >&2
+    exit 64
+  fi
+}
+
+is_positive_int() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    0*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+load_checkpoints_json() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    error_exit "checkpoints file not found: $file"
+  fi
+  jq -c '.' "$file" 2>/dev/null || error_exit "checkpoints file is not valid JSON: $file"
+}
+
+checkpoint_jq_filter='
+  def stage_rank($stage):
+    if $stage == "spec" then 1
+    elif $stage == "plan" then 2
+    elif $stage == "implementation" then 3
+    else 0 end;
+  def stage_from_branch($branch):
+    if ($branch | test("^spec/")) then "spec"
+    elif ($branch | test("^implementation-plan/")) then "plan"
+    elif ($branch | test("^(feature|fix|refactor|hotfix|backport/hotfix)/")) then "implementation"
+    else "implementation" end;
+  def checkpoint_key($cp): "\($cp.item_number):\($cp.stage):\($cp.domain)";
+  def checkpoint_applies($cp; $item; $prStage):
+    ($cp.item_number | tonumber) == ($item | tonumber)
+    and ($cp.satisfaction_state // "pending") == "pending"
+    and (stage_rank($cp.stage) > 0)
+    and (stage_rank($cp.stage) <= stage_rank($prStage));
+'
+
+stage_from_branch() {
+  local branch="$1"
+  jq -r --arg branch "$branch" -n "$checkpoint_jq_filter"'stage_from_branch($branch)'
+}
+
+evaluate_blocking_json() {
+  local item="$1"
+  local branch="$2"
+  local checkpoints_json="$3"
+  printf '%s\n' "$checkpoints_json" | jq -c --arg item "$item" --arg branch "$branch" "$checkpoint_jq_filter"'
+    stage_from_branch($branch) as $prStage |
+    [.[] | select(checkpoint_applies(.; $item; $prStage))]
+  '
+}
+
+detect_satisfaction_json() {
+  local item="$1"
+  local branch="$2"
+  local checkpoints_json="$3"
+  local pr="${4:-}"
+
+  local reviews_json comments_json
+  reviews_json='[]'
+  comments_json='[]'
+
+  if [ -n "$pr" ] && is_positive_int "$pr"; then
+    require_gh
+    reviews_json="$(gh pr view "$pr" --json reviews --jq '.reviews // []' 2>/dev/null || printf '[]\n')"
+    local repo
+    repo="$(repo_slug)"
+    if ! comments_json="$(gh api --paginate --slurp "repos/${repo}/issues/${pr}/comments?per_page=100" 2>/dev/null | jq -c '[.[].[]? | {author: (.user.login // ""), body: (.body // ""), createdAt: (.created_at // "")}]' 2>/dev/null)"; then
+      comments_json='[]'
+    fi
+  fi
+
+  printf '%s\n' "$checkpoints_json" | jq -c \
+    --arg item "$item" \
+    --arg branch "$branch" \
+    --argjson reviews "$reviews_json" \
+    --argjson comments "$comments_json" \
+    "$checkpoint_jq_filter"'
+    def bot_login($login):
+      ($login // "") as $l |
+      ($l | test("^(coderabbitai|cursor\\[bot\\]|devin-ai-integration|greptile-apps|github-actions|dependabot|renovate|copilot|bot)$"; "i"))
+      or ($l | endswith("[bot]"));
+    def marker_match($body; $prefix; $item; $stage; $domain):
+      ($body // "") | contains($prefix + ($item|tostring) + ":" + $stage + ":" + $domain + " -->");
+    def parse_waiver_rationale($body; $prefix; $item; $stage; $domain):
+      ($body // "")
+      | capture($prefix + ($item|tostring) + ":" + $stage + ":" + $domain + " -->\\s*(?<rationale>.*)$"; "s")
+      | (.rationale // "") | gsub("\\s+$"; "");
+    def review_satisfies($cp):
+      ($reviews // [])
+      | map(select((.state // "") == "APPROVED" and (bot_login(.author.login) | not)))
+      | length > 0;
+    stage_from_branch($branch) as $prStage |
+    map(
+      . as $cp |
+      if ($cp.item_number | tonumber) != ($item | tonumber) then .
+      elif ($cp.satisfaction_state // "pending") != "pending" then .
+      elif (stage_rank($cp.stage) > stage_rank($prStage)) then .
+      else
+        ($comments // []) as $commentList |
+        (
+          ($commentList
+            | map(select(
+                marker_match(.body; "'"$WAIVED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain)
+              ))
+            | first) as $waivedComment
+          | if $waivedComment then
+              .satisfaction_state = "waived"
+              | .satisfied_by = ($waivedComment.author // "")
+              | .satisfied_at = ($waivedComment.createdAt // "")
+              | .waiver_rationale = (parse_waiver_rationale($waivedComment.body; "'"$WAIVED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain))
+            elif
+              ($commentList
+                | map(select(
+                    marker_match(.body; "'"$SATISFIED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain)
+                  ))
+                | length) > 0
+            then
+              .satisfaction_state = "satisfied"
+              | .satisfied_by = (
+                  $commentList
+                  | map(select(marker_match(.body; "'"$SATISFIED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain)))
+                  | first
+                  | .author // ""
+                )
+              | .satisfied_at = (
+                  $commentList
+                  | map(select(marker_match(.body; "'"$SATISFIED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain)))
+                  | first
+                  | .createdAt // ""
+                )
+            elif ($cp.stage == $prStage) and review_satisfies($cp) then
+              .satisfaction_state = "satisfied"
+              | .satisfied_by = (
+                  ($reviews // [])
+                  | map(select((.state // "") == "APPROVED" and (bot_login(.author.login) | not)))
+                  | first
+                  | .author.login // "pr_review_approved"
+                )
+              | .satisfied_at = (
+                  ($reviews // [])
+                  | map(select((.state // "") == "APPROVED" and (bot_login(.author.login) | not)))
+                  | first
+                  | .submittedAt // ""
+                )
+            else .
+            end
+        )
+      end
+    )
+  '
+}
+
+render_pr_checkpoint_comment() {
+  local json="$1"
+  {
+    printf '%s\n' "$CHECKPOINT_MARKER"
+    printf '## Human Checkpoint Status\n\n'
+    printf '%s\n' "$json" | jq -r '
+      "- Item: #" + (.item.number | tostring),
+      "- PR: #" + (.pr.number | tostring),
+      "- Branch: `" + (.pr.branch | tostring) + "`",
+      "- PR workflow stage: " + (.pr.stage | tostring),
+      "- Label required: " + ((.label_required // false) | tostring)
+    '
+    printf '\n### Checkpoints\n\n'
+    if [ "$(printf '%s\n' "$json" | jq '(.checkpoints // []) | length')" -eq 0 ]; then
+      printf 'No checkpoints recorded for this PR.\n'
+    else
+      printf '| Item | Stage | Domain | State | Reason | Required human action | Satisfied by |\n'
+      printf '| --- | --- | --- | --- | --- | --- | --- |\n'
+      printf '%s\n' "$json" | jq -r '
+        def cell:
+          tostring
+          | gsub("\\|"; "\\\\|")
+          | gsub("\\r?\\n"; "<br>")
+          | gsub("\\t"; " ");
+        (.checkpoints // [])[] |
+        "| #" + (.item_number | tostring) +
+        " | " + ((.stage // "") | cell) +
+        " | " + ((.domain // "") | cell) +
+        " | " + ((.satisfaction_state // "pending") | cell) +
+        " | " + ((.reason // "") | cell) +
+        " | " + ((.required_human_action // "") | cell) +
+        " | " + ((.satisfied_by // "-") | cell) + " |"
+      '
+    fi
+    printf '\n### Blocking checkpoints\n\n'
+    if [ "$(printf '%s\n' "$json" | jq '(.blocking // []) | length')" -eq 0 ]; then
+      printf 'None — delegated review/merge may proceed when other gates pass.\n'
+    else
+      printf '%s\n' "$json" | jq -r '(.blocking // [])[] | "- #" + (.item_number|tostring) + " " + .stage + "/" + .domain + ": " + (.required_human_action // "")'
+    fi
+    printf '\n### Satisfaction signals\n\n'
+    printf '%s\n' "$json" | jq -r '
+      "- Explicit comment: `" + (.satisfaction_signals.comment_marker | tostring) + "`",
+      "- Explicit waiver: `" + (.satisfaction_signals.waiver_marker | tostring) + "`",
+      "- PR review approval on matching stage also satisfies the checkpoint."
+    '
+  }
+}
+
+find_marker_comment_id() {
+  local target="$1"
+  local marker="$2"
+  local repo comments
+
+  repo="$(repo_slug)"
+  if ! comments="$(gh api --paginate --slurp "repos/${repo}/issues/${target}/comments?per_page=100" 2>/dev/null)"; then
+    error_exit "failed to read comments for issue/PR #$target"
+  fi
+  printf '%s\n' "$comments" |
+    jq -r --arg marker "$marker" '[.[][]? | select((.body // "") | contains($marker))][0].id // empty'
+}
+
+apply_checkpoint_comment() {
+  local pr="$1"
+  local body="$2"
+  local repo comment_id
+
+  require_gh
+  repo="$(repo_slug)"
+  comment_id="$(find_marker_comment_id "$pr" "$CHECKPOINT_MARKER")"
+  if [ -n "$comment_id" ]; then
+    jq -n --arg body "$body" '{body: $body}' |
+      gh api -X PATCH "repos/${repo}/issues/comments/${comment_id}" --input - >/dev/null
+    printf 'UPDATED_COMMENT_ID=%s\n' "$comment_id"
+  else
+    jq -n --arg body "$body" '{body: $body}' |
+      gh api -X POST "repos/${repo}/issues/${pr}/comments" --input - >/dev/null
+    printf 'CREATED_COMMENT=1\n'
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --pr)
+      require_value "$@"
+      pr_number="$2"
+      shift 2
+      ;;
+    --item)
+      require_value "$@"
+      item_number="$2"
+      shift 2
+      ;;
+    --branch)
+      require_value "$@"
+      branch_name="$2"
+      shift 2
+      ;;
+    --checkpoints-file)
+      require_value "$@"
+      checkpoints_file="$2"
+      shift 2
+      ;;
+    --write-checkpoints-file)
+      require_value "$@"
+      write_checkpoints_file="$2"
+      shift 2
+      ;;
+    --input)
+      require_value "$@"
+      input_file="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+case "$command" in
+  stage-from-branch|evaluate-blocking|detect-satisfaction|render-pr-checkpoint-comment|sync-pr-labels)
+    ;;
+  *)
+    echo "ERROR: unknown or missing subcommand." >&2
+    usage >&2
+    exit 64
+    ;;
+esac
+
+case "$command" in
+  stage-from-branch)
+    [ -n "$branch_name" ] || error_exit "--branch is required"
+    stage_from_branch "$branch_name"
+    ;;
+  evaluate-blocking)
+    [ -n "$item_number" ] && is_positive_int "$item_number" || error_exit "--item must be a positive integer"
+    [ -n "$branch_name" ] || error_exit "--branch is required"
+    [ -n "$checkpoints_file" ] || error_exit "--checkpoints-file is required"
+    checkpoints_json="$(load_checkpoints_json "$checkpoints_file")"
+    evaluate_blocking_json "$item_number" "$branch_name" "$checkpoints_json"
+    ;;
+  detect-satisfaction)
+    [ -n "$item_number" ] && is_positive_int "$item_number" || error_exit "--item must be a positive integer"
+    [ -n "$branch_name" ] || error_exit "--branch is required"
+    [ -n "$checkpoints_file" ] || error_exit "--checkpoints-file is required"
+    checkpoints_json="$(load_checkpoints_json "$checkpoints_file")"
+    updated_json="$(detect_satisfaction_json "$item_number" "$branch_name" "$checkpoints_json" "$pr_number")"
+    if [ -n "$write_checkpoints_file" ]; then
+      printf '%s\n' "$updated_json" | jq '.' > "$write_checkpoints_file"
+    fi
+    printf '%s\n' "$updated_json"
+    ;;
+  render-pr-checkpoint-comment)
+    [ -n "$input_file" ] || error_exit "--input is required"
+    if [ ! -f "$input_file" ]; then
+      error_exit "input file not found: $input_file"
+    fi
+    render_pr_checkpoint_comment "$(jq -c '.' "$input_file")"
+    ;;
+  sync-pr-labels)
+    [ -n "$pr_number" ] && is_positive_int "$pr_number" || error_exit "--pr must be a positive integer"
+    [ -n "$item_number" ] && is_positive_int "$item_number" || error_exit "--item must be a positive integer"
+    [ -n "$branch_name" ] || error_exit "--branch is required"
+    [ -n "$checkpoints_file" ] || error_exit "--checkpoints-file is required"
+    require_gh
+    checkpoints_json="$(load_checkpoints_json "$checkpoints_file")"
+    updated_checkpoints="$(detect_satisfaction_json "$item_number" "$branch_name" "$checkpoints_json" "$pr_number")"
+    if [ -n "$write_checkpoints_file" ]; then
+      printf '%s\n' "$updated_checkpoints" | jq '.' > "$write_checkpoints_file"
+    fi
+    blocking_json="$(evaluate_blocking_json "$item_number" "$branch_name" "$updated_checkpoints")"
+    pr_stage="$(stage_from_branch "$branch_name")"
+    label_required="false"
+    if [ "$(printf '%s\n' "$blocking_json" | jq 'length')" -gt 0 ]; then
+      label_required="true"
+    fi
+    has_label="$(gh pr view "$pr_number" --json labels --jq '[.labels[].name | select(. == "human-checkpoint-required")] | length' 2>/dev/null || printf '0\n')"
+    if [ "$label_required" = "true" ]; then
+      if [ "$has_label" -eq 0 ]; then
+        gh pr edit "$pr_number" --add-label "human-checkpoint-required"
+        printf 'LABEL_APPLIED=human-checkpoint-required\n'
+      else
+        printf 'LABEL_PRESENT=human-checkpoint-required\n'
+      fi
+    else
+      if [ "$has_label" -gt 0 ]; then
+        gh pr edit "$pr_number" --remove-label "human-checkpoint-required"
+        printf 'LABEL_REMOVED=human-checkpoint-required\n'
+      else
+        printf 'LABEL_ABSENT=human-checkpoint-required\n'
+      fi
+    fi
+    comment_payload="$(jq -n \
+      --argjson item "$(jq -n --argjson n "$item_number" '{number: ($n|tonumber)}')" \
+      --argjson pr "$(jq -n --argjson n "$pr_number" --arg branch "$branch_name" --arg stage "$pr_stage" '{number: ($n|tonumber), branch: $branch, stage: $stage}')" \
+      --argjson checkpoints "$updated_checkpoints" \
+      --argjson blocking "$blocking_json" \
+      --argjson label_required "$label_required" \
+      --arg satisfied_marker "${SATISFIED_MARKER_PREFIX}${item_number}:<stage>:<domain> -->" \
+      --arg waiver_marker "${WAIVED_MARKER_PREFIX}${item_number}:<stage>:<domain> --> <rationale>" \
+      '{
+        item: $item,
+        pr: $pr,
+        checkpoints: $checkpoints,
+        blocking: $blocking,
+        label_required: $label_required,
+        satisfaction_signals: {
+          comment_marker: $satisfied_marker,
+          waiver_marker: $waiver_marker
+        }
+      }')"
+    comment_body="$(render_pr_checkpoint_comment "$comment_payload")"
+    apply_checkpoint_comment "$pr_number" "$comment_body"
+    printf 'BLOCKING_COUNT=%s\n' "$(printf '%s\n' "$blocking_json" | jq 'length')"
+    ;;
+esac

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -223,7 +223,8 @@ render_pr_checkpoint_comment() {
       "- PR: #" + (.pr.number | tostring),
       "- Branch: `" + (.pr.branch | tostring) + "`",
       "- PR workflow stage: " + (.pr.stage | tostring),
-      "- Label required: " + ((.label_required // false) | tostring)
+      "- Label required: " + ((.label_required // false) | tostring),
+      "- Label present: " + ((.label_present // false) | tostring)
     '
     printf '\n### Checkpoints\n\n'
     if [ "$(printf '%s\n' "$json" | jq '(.checkpoints // []) | length')" -eq 0 ]; then
@@ -396,12 +397,38 @@ case "$command" in
       label_required="true"
     fi
     item_checkpoints_json="$(printf '%s\n' "$updated_checkpoints" | jq -c --arg item "$item_number" '[.[] | select((.item_number | tonumber) == ($item | tonumber))]')"
+    if [ "$label_required" = "true" ]; then
+      if ! gh pr edit "$pr_number" --add-label "human-checkpoint-required" >/dev/null 2>&1; then
+        error_exit "failed to apply human-checkpoint-required label on PR #$pr_number"
+      fi
+      printf 'LABEL_APPLIED=human-checkpoint-required\n'
+    else
+      if ! has_label="$(gh pr view "$pr_number" --json labels --jq '[.labels[].name | select(. == "human-checkpoint-required")] | length' 2>/dev/null)"; then
+        error_exit "failed to read labels for PR #$pr_number"
+      fi
+      if [ "$has_label" -gt 0 ]; then
+        if ! gh pr edit "$pr_number" --remove-label "human-checkpoint-required" >/dev/null 2>&1; then
+          error_exit "failed to remove human-checkpoint-required label on PR #$pr_number"
+        fi
+        printf 'LABEL_REMOVED=human-checkpoint-required\n'
+      else
+        printf 'LABEL_ABSENT=human-checkpoint-required\n'
+      fi
+    fi
+    if ! has_label_after="$(gh pr view "$pr_number" --json labels --jq '[.labels[].name | select(. == "human-checkpoint-required")] | length' 2>/dev/null)"; then
+      error_exit "failed to read labels for PR #$pr_number after label sync"
+    fi
+    label_present="false"
+    if [ "$has_label_after" -gt 0 ]; then
+      label_present="true"
+    fi
     comment_payload="$(jq -n \
       --argjson item "$(jq -n --argjson n "$item_number" '{number: ($n|tonumber)}')" \
       --argjson pr "$(jq -n --argjson n "$pr_number" --arg branch "$branch_name" --arg stage "$pr_stage" '{number: ($n|tonumber), branch: $branch, stage: $stage}')" \
       --argjson checkpoints "$item_checkpoints_json" \
       --argjson blocking "$blocking_json" \
       --argjson label_required "$label_required" \
+      --argjson label_present "$label_present" \
       --arg satisfied_marker "${SATISFIED_MARKER_PREFIX}${item_number}:<stage>:<domain> -->" \
       --arg waiver_marker "${WAIVED_MARKER_PREFIX}${item_number}:<stage>:<domain> --> <rationale>" \
       '{
@@ -410,6 +437,7 @@ case "$command" in
         checkpoints: $checkpoints,
         blocking: $blocking,
         label_required: $label_required,
+        label_present: $label_present,
         satisfaction_signals: {
           comment_marker: $satisfied_marker,
           waiver_marker: $waiver_marker
@@ -417,24 +445,6 @@ case "$command" in
       }')"
     comment_body="$(render_pr_checkpoint_comment "$comment_payload")"
     apply_checkpoint_comment "$pr_number" "$comment_body"
-    if ! has_label="$(gh pr view "$pr_number" --json labels --jq '[.labels[].name | select(. == "human-checkpoint-required")] | length' 2>/dev/null)"; then
-      error_exit "failed to read labels for PR #$pr_number"
-    fi
-    if [ "$label_required" = "true" ]; then
-      if [ "$has_label" -eq 0 ]; then
-        gh pr edit "$pr_number" --add-label "human-checkpoint-required"
-        printf 'LABEL_APPLIED=human-checkpoint-required\n'
-      else
-        printf 'LABEL_PRESENT=human-checkpoint-required\n'
-      fi
-    else
-      if [ "$has_label" -gt 0 ]; then
-        gh pr edit "$pr_number" --remove-label "human-checkpoint-required"
-        printf 'LABEL_REMOVED=human-checkpoint-required\n'
-      else
-        printf 'LABEL_ABSENT=human-checkpoint-required\n'
-      fi
-    fi
     printf 'BLOCKING_COUNT=%s\n' "$(printf '%s\n' "$blocking_json" | jq 'length')"
     ;;
 esac

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -151,9 +151,7 @@ detect_satisfaction_json() {
     def waiver_rationale_valid($body; $item; $stage; $domain):
       (parse_waiver_rationale($body; "'"$WAIVED_MARKER_PREFIX"'"; ($item|tostring); $stage; $domain) | gsub("\\s"; "") | length) > 0;
     stage_from_branch($branch) as $prStage |
-    ( . as $all |
-      ($all | [.[] | select((.item_number | tonumber) == ($item | tonumber) and .stage == $prStage and (.satisfaction_state // "pending") == "pending")]) as $pendingAtStage |
-      $all | map(
+    map(
       . as $cp |
       if ($cp.item_number | tonumber) != ($item | tonumber) then .
       elif ($cp.satisfaction_state // "pending") != "pending" then .
@@ -192,7 +190,7 @@ detect_satisfaction_json() {
                   | first
                   | .createdAt // ""
                 )
-            elif ($cp.stage == $prStage) and (($pendingAtStage | length) == 1) and (checkpoint_key($cp) == checkpoint_key($pendingAtStage[0])) and review_satisfies($cp) then
+            elif ($cp.stage == $prStage) and review_satisfies($cp) then
               .satisfaction_state = "satisfied"
               | .satisfied_by = (latest_human_review | .author.login // "pr_review_approved")
               | .satisfied_at = (latest_human_review | .submittedAt // "")
@@ -200,7 +198,7 @@ detect_satisfaction_json() {
             end
         )
       end
-    ))
+    )
   '
 }
 

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -383,25 +383,11 @@ case "$command" in
     if ! has_label="$(gh pr view "$pr_number" --json labels --jq '[.labels[].name | select(. == "human-checkpoint-required")] | length' 2>/dev/null)"; then
       error_exit "failed to read labels for PR #$pr_number"
     fi
-    if [ "$label_required" = "true" ]; then
-      if [ "$has_label" -eq 0 ]; then
-        gh pr edit "$pr_number" --add-label "human-checkpoint-required"
-        printf 'LABEL_APPLIED=human-checkpoint-required\n'
-      else
-        printf 'LABEL_PRESENT=human-checkpoint-required\n'
-      fi
-    else
-      if [ "$has_label" -gt 0 ]; then
-        gh pr edit "$pr_number" --remove-label "human-checkpoint-required"
-        printf 'LABEL_REMOVED=human-checkpoint-required\n'
-      else
-        printf 'LABEL_ABSENT=human-checkpoint-required\n'
-      fi
-    fi
+    item_checkpoints_json="$(printf '%s\n' "$updated_checkpoints" | jq -c --arg item "$item_number" '[.[] | select((.item_number | tonumber) == ($item | tonumber))]')"
     comment_payload="$(jq -n \
       --argjson item "$(jq -n --argjson n "$item_number" '{number: ($n|tonumber)}')" \
       --argjson pr "$(jq -n --argjson n "$pr_number" --arg branch "$branch_name" --arg stage "$pr_stage" '{number: ($n|tonumber), branch: $branch, stage: $stage}')" \
-      --argjson checkpoints "$updated_checkpoints" \
+      --argjson checkpoints "$item_checkpoints_json" \
       --argjson blocking "$blocking_json" \
       --argjson label_required "$label_required" \
       --arg satisfied_marker "${SATISFIED_MARKER_PREFIX}${item_number}:<stage>:<domain> -->" \
@@ -419,6 +405,21 @@ case "$command" in
       }')"
     comment_body="$(render_pr_checkpoint_comment "$comment_payload")"
     apply_checkpoint_comment "$pr_number" "$comment_body"
+    if [ "$label_required" = "true" ]; then
+      if [ "$has_label" -eq 0 ]; then
+        gh pr edit "$pr_number" --add-label "human-checkpoint-required"
+        printf 'LABEL_APPLIED=human-checkpoint-required\n'
+      else
+        printf 'LABEL_PRESENT=human-checkpoint-required\n'
+      fi
+    else
+      if [ "$has_label" -gt 0 ]; then
+        gh pr edit "$pr_number" --remove-label "human-checkpoint-required"
+        printf 'LABEL_REMOVED=human-checkpoint-required\n'
+      else
+        printf 'LABEL_ABSENT=human-checkpoint-required\n'
+      fi
+    fi
     printf 'BLOCKING_COUNT=%s\n' "$(printf '%s\n' "$blocking_json" | jq 'length')"
     ;;
 esac

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -147,19 +147,25 @@ detect_satisfaction_json() {
     def review_satisfies($cp):
       (latest_human_review) as $latest |
       ($latest != null) and (($latest.state // "") == "APPROVED");
+    def human_comments: ($comments // []) | map(select(bot_login(.author) | not));
+    def waiver_rationale_valid($body; $item; $stage; $domain):
+      (parse_waiver_rationale($body; "'"$WAIVED_MARKER_PREFIX"'"; ($item|tostring); $stage; $domain) | gsub("\\s"; "") | length) > 0;
     stage_from_branch($branch) as $prStage |
-    map(
+    ( . as $all |
+      ($all | [.[] | select((.item_number | tonumber) == ($item | tonumber) and .stage == $prStage and (.satisfaction_state // "pending") == "pending")]) as $pendingAtStage |
+      $all | map(
       . as $cp |
       if ($cp.item_number | tonumber) != ($item | tonumber) then .
       elif ($cp.satisfaction_state // "pending") != "pending" then .
       elif (stage_rank($cp.stage) > stage_rank($prStage)) then .
       else
-        ($comments // []) as $commentList |
+        human_comments as $commentList |
         (
           ($commentList
             | map(select(
                 marker_match(.body; "'"$WAIVED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain)
               ))
+            | map(select(waiver_rationale_valid(.body; ($cp.item_number|tostring); $cp.stage; $cp.domain)))
             | first) as $waivedComment
           | if $waivedComment then
               .satisfaction_state = "waived"
@@ -186,7 +192,7 @@ detect_satisfaction_json() {
                   | first
                   | .createdAt // ""
                 )
-            elif ($cp.stage == $prStage) and review_satisfies($cp) then
+            elif ($cp.stage == $prStage) and (($pendingAtStage | length) == 1) and (checkpoint_key($cp) == checkpoint_key($pendingAtStage[0])) and review_satisfies($cp) then
               .satisfaction_state = "satisfied"
               | .satisfied_by = (latest_human_review | .author.login // "pr_review_approved")
               | .satisfied_at = (latest_human_review | .submittedAt // "")
@@ -194,7 +200,7 @@ detect_satisfaction_json() {
             end
         )
       end
-    )
+    ))
   '
 }
 
@@ -257,7 +263,7 @@ find_marker_comment_id() {
     error_exit "failed to read comments for issue/PR #$target"
   fi
   printf '%s\n' "$comments" |
-    jq -r --arg marker "$marker" '[.[][]? | select((.body // "") | contains($marker))][0].id // empty'
+    jq -r --arg marker "$marker" '[.[][]? | select((.body // "") | contains($marker))] | last | .id // empty'
 }
 
 apply_checkpoint_comment() {

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -61,10 +61,17 @@ is_positive_int() {
 
 load_checkpoints_json() {
   local file="$1"
+  local json
   if [ ! -f "$file" ]; then
     error_exit "checkpoints file not found: $file"
   fi
-  jq -c '.' "$file" 2>/dev/null || error_exit "checkpoints file is not valid JSON: $file"
+  if ! json="$(jq -c '.' "$file" 2>/dev/null)"; then
+    error_exit "checkpoints file is not valid JSON: $file"
+  fi
+  if ! printf '%s\n' "$json" | jq -e 'type == "array"' >/dev/null; then
+    error_exit "checkpoints file must contain a JSON array"
+  fi
+  printf '%s\n' "$json"
 }
 
 checkpoint_jq_filter='
@@ -107,14 +114,18 @@ detect_satisfaction_json() {
   local checkpoints_json="$3"
   local pr="${4:-}"
 
-  local reviews_json comments_json
+  local reviews_json comments_json head_sha
   reviews_json='[]'
   comments_json='[]'
+  head_sha=""
 
   if [ -n "$pr" ] && is_positive_int "$pr"; then
     require_gh
     if ! reviews_json="$(gh pr view "$pr" --json reviews --jq '.reviews // []' 2>/dev/null)"; then
       error_exit "failed to read reviews for PR #$pr"
+    fi
+    if ! head_sha="$(gh pr view "$pr" --json headRefOid --jq '.headRefOid // ""' 2>/dev/null)"; then
+      error_exit "failed to read head SHA for PR #$pr"
     fi
     local repo
     repo="$(repo_slug)"
@@ -126,6 +137,7 @@ detect_satisfaction_json() {
   printf '%s\n' "$checkpoints_json" | jq -c \
     --arg item "$item" \
     --arg branch "$branch" \
+    --arg head_sha "$head_sha" \
     --argjson reviews "$reviews_json" \
     --argjson comments "$comments_json" \
     "$checkpoint_jq_filter"'
@@ -142,6 +154,11 @@ detect_satisfaction_json() {
     def latest_human_review:
       ($reviews // [])
       | map(select(bot_login(.author.login) | not))
+      | map(select(
+          ($head_sha | length) == 0
+          or ((.commit.oid // "") == $head_sha)
+          or ((.commit // {}).oid? // "" | length) == 0
+        ))
       | sort_by(.submittedAt // "")
       | last // null;
     def review_satisfies($cp):
@@ -154,9 +171,10 @@ detect_satisfaction_json() {
     map(
       . as $cp |
       if ($cp.item_number | tonumber) != ($item | tonumber) then .
-      elif ($cp.satisfaction_state // "pending") != "pending" then .
       elif (stage_rank($cp.stage) > stage_rank($prStage)) then .
       else
+        ($cp | del(.satisfaction_state, .satisfied_by, .satisfied_at, .waiver_rationale) | .satisfaction_state = "pending") as $base |
+        $base |
         human_comments as $commentList |
         (
           ($commentList
@@ -164,7 +182,7 @@ detect_satisfaction_json() {
                 marker_match(.body; "'"$WAIVED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain)
               ))
             | map(select(waiver_rationale_valid(.body; ($cp.item_number|tostring); $cp.stage; $cp.domain)))
-            | first) as $waivedComment
+            | last) as $waivedComment
           | if $waivedComment then
               .satisfaction_state = "waived"
               | .satisfied_by = ($waivedComment.author // "")
@@ -177,19 +195,12 @@ detect_satisfaction_json() {
                   ))
                 | length) > 0
             then
-              .satisfaction_state = "satisfied"
-              | .satisfied_by = (
-                  $commentList
-                  | map(select(marker_match(.body; "'"$SATISFIED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain)))
-                  | first
-                  | .author // ""
-                )
-              | .satisfied_at = (
-                  $commentList
-                  | map(select(marker_match(.body; "'"$SATISFIED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain)))
-                  | first
-                  | .createdAt // ""
-                )
+              ($commentList
+                | map(select(marker_match(.body; "'"$SATISFIED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain)))
+                | last) as $satisfiedComment
+              | .satisfaction_state = "satisfied"
+              | .satisfied_by = ($satisfiedComment.author // "")
+              | .satisfied_at = ($satisfiedComment.createdAt // "")
             elif ($cp.stage == $prStage) and review_satisfies($cp) then
               .satisfaction_state = "satisfied"
               | .satisfied_by = (latest_human_review | .author.login // "pr_review_approved")
@@ -384,9 +395,6 @@ case "$command" in
     if [ "$(printf '%s\n' "$blocking_json" | jq 'length')" -gt 0 ]; then
       label_required="true"
     fi
-    if ! has_label="$(gh pr view "$pr_number" --json labels --jq '[.labels[].name | select(. == "human-checkpoint-required")] | length' 2>/dev/null)"; then
-      error_exit "failed to read labels for PR #$pr_number"
-    fi
     item_checkpoints_json="$(printf '%s\n' "$updated_checkpoints" | jq -c --arg item "$item_number" '[.[] | select((.item_number | tonumber) == ($item | tonumber))]')"
     comment_payload="$(jq -n \
       --argjson item "$(jq -n --argjson n "$item_number" '{number: ($n|tonumber)}')" \
@@ -409,6 +417,9 @@ case "$command" in
       }')"
     comment_body="$(render_pr_checkpoint_comment "$comment_payload")"
     apply_checkpoint_comment "$pr_number" "$comment_body"
+    if ! has_label="$(gh pr view "$pr_number" --json labels --jq '[.labels[].name | select(. == "human-checkpoint-required")] | length' 2>/dev/null)"; then
+      error_exit "failed to read labels for PR #$pr_number"
+    fi
     if [ "$label_required" = "true" ]; then
       if [ "$has_label" -eq 0 ]; then
         gh pr edit "$pr_number" --add-label "human-checkpoint-required"

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -171,8 +171,8 @@ detect_satisfaction_json() {
     map(
       . as $cp |
       if ($cp.item_number | tonumber) != ($item | tonumber) then .
+      elif (($cp.satisfaction_state // "pending") != "pending") then .
       elif (stage_rank($cp.stage) > stage_rank($prStage)) then .
-      elif (stage_rank($cp.stage) < stage_rank($prStage)) and (($cp.satisfaction_state // "pending") != "pending") then .
       else
         ($cp | del(.satisfaction_state, .satisfied_by, .satisfied_at, .waiver_rationale) | .satisfaction_state = "pending") as $base |
         $base |

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -137,10 +137,14 @@ detect_satisfaction_json() {
       ($body // "")
       | capture($prefix + ($item|tostring) + ":" + $stage + ":" + $domain + " -->\\s*(?<rationale>.*)$"; "s")
       | (.rationale // "") | gsub("\\s+$"; "");
-    def review_satisfies($cp):
+    def latest_human_review:
       ($reviews // [])
-      | map(select((.state // "") == "APPROVED" and (bot_login(.author.login) | not)))
-      | length > 0;
+      | map(select(bot_login(.author.login) | not))
+      | sort_by(.submittedAt // "")
+      | last // null;
+    def review_satisfies($cp):
+      (latest_human_review) as $latest |
+      ($latest != null) and (($latest.state // "") == "APPROVED");
     stage_from_branch($branch) as $prStage |
     map(
       . as $cp |
@@ -182,18 +186,8 @@ detect_satisfaction_json() {
                 )
             elif ($cp.stage == $prStage) and review_satisfies($cp) then
               .satisfaction_state = "satisfied"
-              | .satisfied_by = (
-                  ($reviews // [])
-                  | map(select((.state // "") == "APPROVED" and (bot_login(.author.login) | not)))
-                  | first
-                  | .author.login // "pr_review_approved"
-                )
-              | .satisfied_at = (
-                  ($reviews // [])
-                  | map(select((.state // "") == "APPROVED" and (bot_login(.author.login) | not)))
-                  | first
-                  | .submittedAt // ""
-                )
+              | .satisfied_by = (latest_human_review | .author.login // "pr_review_approved")
+              | .satisfied_at = (latest_human_review | .submittedAt // "")
             else .
             end
         )

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -172,6 +172,7 @@ detect_satisfaction_json() {
       . as $cp |
       if ($cp.item_number | tonumber) != ($item | tonumber) then .
       elif (stage_rank($cp.stage) > stage_rank($prStage)) then .
+      elif (stage_rank($cp.stage) < stage_rank($prStage)) and (($cp.satisfaction_state // "pending") != "pending") then .
       else
         ($cp | del(.satisfaction_state, .satisfied_by, .satisfied_at, .waiver_rationale) | .satisfaction_state = "pending") as $base |
         $base |

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -113,11 +113,13 @@ detect_satisfaction_json() {
 
   if [ -n "$pr" ] && is_positive_int "$pr"; then
     require_gh
-    reviews_json="$(gh pr view "$pr" --json reviews --jq '.reviews // []' 2>/dev/null || printf '[]\n')"
+    if ! reviews_json="$(gh pr view "$pr" --json reviews --jq '.reviews // []' 2>/dev/null)"; then
+      error_exit "failed to read reviews for PR #$pr"
+    fi
     local repo
     repo="$(repo_slug)"
     if ! comments_json="$(gh api --paginate --slurp "repos/${repo}/issues/${pr}/comments?per_page=100" 2>/dev/null | jq -c '[.[].[]? | {author: (.user.login // ""), body: (.body // ""), createdAt: (.created_at // "")}]' 2>/dev/null)"; then
-      comments_json='[]'
+      error_exit "failed to read comments for PR #$pr"
     fi
   fi
 
@@ -378,7 +380,9 @@ case "$command" in
     if [ "$(printf '%s\n' "$blocking_json" | jq 'length')" -gt 0 ]; then
       label_required="true"
     fi
-    has_label="$(gh pr view "$pr_number" --json labels --jq '[.labels[].name | select(. == "human-checkpoint-required")] | length' 2>/dev/null || printf '0\n')"
+    if ! has_label="$(gh pr view "$pr_number" --json labels --jq '[.labels[].name | select(. == "human-checkpoint-required")] | length' 2>/dev/null)"; then
+      error_exit "failed to read labels for PR #$pr_number"
+    fi
     if [ "$label_required" = "true" ]; then
       if [ "$has_label" -eq 0 ]; then
         gh pr edit "$pr_number" --add-label "human-checkpoint-required"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2169,7 +2169,15 @@ else
   actual="blocking"
 fi
 run_test "bugbot_clean_phrase_in_multiline_body_is_blocking" "blocking" "$actual"
-unset bugbot_clean_body bugbot_mixed_body bugbot_multiline_body actual
+
+bugbot_same_line_severity_body="Cursor Bugbot found no issues in this pull request. **High Severity**: still broken"
+if is_bugbot_clean_review "$bugbot_same_line_severity_body"; then
+  actual="clean"
+else
+  actual="blocking"
+fi
+run_test "bugbot_same_line_severity_is_blocking" "blocking" "$actual"
+unset bugbot_clean_body bugbot_mixed_body bugbot_multiline_body bugbot_same_line_severity_body actual
 
 # ---------------------------------------------------------------------------
 # Test 16.1: clean path — check run conclusion=success, no blocking comments
@@ -2275,6 +2283,50 @@ run_test "bugbot_needs_fixes_blocking_count_nonzero" "1" \
 run_test "bugbot_needs_fixes_exit_code" "1" "$actual_exit"
 rm -rf "$_bugbot_mock_dir_162"
 unset _bugbot_mock_dir_162 actual_output actual_exit
+
+# ---------------------------------------------------------------------------
+# Test 16.2b: CHANGES_REQUESTED review blocks even with clean body text
+# ---------------------------------------------------------------------------
+_bugbot_mock_dir_162b="$(mktemp -d)"
+cat > "$_bugbot_mock_dir_162b/gh" <<'BUGBOT_GH_162B'
+#!/usr/bin/env bash
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc162bsha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"user":{"login":"cursor[bot]"},"submitted_at":"2020-01-02T00:00:00Z","state":"CHANGES_REQUESTED","body":"Cursor Bugbot found no issues in this pull request."}]\n'
+    exit 0 ;;
+  *"check-runs"*)
+    printf '{"check_runs":[{"name":"Cursor Bugbot","app":{"slug":"cursor"},"status":"completed","conclusion":"success","started_at":"2020-01-01T00:00:00Z"}]}\n'
+    exit 0 ;;
+  *"headRefOid"*)
+    printf 'abc162bsha\n'; exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+BUGBOT_GH_162B
+chmod +x "$_bugbot_mock_dir_162b/gh"
+
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_bugbot_overrides"
+  _ec=0
+  PATH="$_bugbot_mock_dir_162b:$PATH" run_bugbot_review "42" "feature/42-test" "1" "5" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "bugbot_changes_requested_clean_body_blocks_result" "RESULT=needs_fixes" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "bugbot_changes_requested_clean_body_blocks_count" "1" \
+  "$(printf '%s\n' "$actual_output" | grep "^BLOCKING_COUNT=" | cut -d= -f2)"
+run_test "bugbot_changes_requested_clean_body_blocks_exit_code" "1" "$actual_exit"
+rm -rf "$_bugbot_mock_dir_162b"
+unset _bugbot_mock_dir_162b actual_output actual_exit
 
 # ---------------------------------------------------------------------------
 # Test 16.3: escalate (timeout) — run appeared but never completed

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2144,6 +2144,26 @@ run_test "bugbot_bot_login_env_override" "my-custom-bugbot[bot]" "$actual"
 unset BUGBOT_BOT_LOGIN
 
 # ---------------------------------------------------------------------------
+# Test 16.0c-d: Bugbot clean summary detection must not hide finding markers
+# ---------------------------------------------------------------------------
+bugbot_clean_body="Cursor Bugbot found no new issues in this pull request."
+if is_bugbot_clean_review "$bugbot_clean_body"; then
+  actual="clean"
+else
+  actual="blocking"
+fi
+run_test "bugbot_clean_phrase_is_non_blocking" "clean" "$actual"
+
+bugbot_mixed_body=$'Cursor Bugbot found no issues in this pull request.\n\n**High Severity**\n\n<!-- BUGBOT_BUG_ID: abc123 -->'
+if is_bugbot_clean_review "$bugbot_mixed_body"; then
+  actual="clean"
+else
+  actual="blocking"
+fi
+run_test "bugbot_finding_markers_override_clean_phrase" "blocking" "$actual"
+unset bugbot_clean_body bugbot_mixed_body actual
+
+# ---------------------------------------------------------------------------
 # Test 16.1: clean path — check run conclusion=success, no blocking comments
 # ---------------------------------------------------------------------------
 _bugbot_mock_dir_161="$(mktemp -d)"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2161,7 +2161,15 @@ else
   actual="blocking"
 fi
 run_test "bugbot_finding_markers_override_clean_phrase" "blocking" "$actual"
-unset bugbot_clean_body bugbot_mixed_body actual
+
+bugbot_multiline_body=$'Cursor Bugbot found no issues in this pull request.\n\nThis review still describes a blocking workflow problem.'
+if is_bugbot_clean_review "$bugbot_multiline_body"; then
+  actual="clean"
+else
+  actual="blocking"
+fi
+run_test "bugbot_clean_phrase_in_multiline_body_is_blocking" "blocking" "$actual"
+unset bugbot_clean_body bugbot_mixed_body bugbot_multiline_body actual
 
 # ---------------------------------------------------------------------------
 # Test 16.1: clean path — check run conclusion=success, no blocking comments

--- a/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+++ b/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
@@ -4,11 +4,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
-GIT_COMMON_DIR="$(cd "$SCRIPT_DIR" && git rev-parse --git-common-dir)"
-case "$GIT_COMMON_DIR" in
-  /*) REPO_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd -P)" ;;
-  *) REPO_ROOT="$(cd "$SCRIPT_DIR/$GIT_COMMON_DIR/.." && pwd -P)" ;;
-esac
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 HELPER="$REPO_ROOT/scripts/development-workflow/run-epic-audit-trail.sh"
 
 TMP_ROOT="$(mktemp -d)"

--- a/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+++ b/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
@@ -172,6 +172,40 @@ cat > "$pr_fixture" <<'JSON'
   "protocol_deviations": [
     {"action": "accepted advisory", "impact": "none | expected", "mitigation": "documented\nrationale\twith ghp_FAKE_PLACEHOLDER /tmp/fake-placeholder/local"}
   ],
+  "checkpoint_policy": {
+    "field_source": "recommended",
+    "recommended": [
+      {
+        "item_number": 920,
+        "stage": "plan",
+        "domain": "technical",
+        "reason": "schema signals",
+        "required_human_action": "approve data model",
+        "satisfaction_state": "pending"
+      }
+    ],
+    "selected": [
+      {
+        "item_number": 920,
+        "stage": "plan",
+        "domain": "technical",
+        "reason": "schema signals",
+        "required_human_action": "approve data model",
+        "satisfaction_state": "pending"
+      }
+    ],
+    "effective": [
+      {
+        "item_number": 920,
+        "stage": "plan",
+        "domain": "technical",
+        "reason": "schema signals",
+        "required_human_action": "approve data model",
+        "satisfaction_state": "satisfied",
+        "satisfied_by": "human-reviewer"
+      }
+    ]
+  },
   "notes": "token ghp_FAKE_PLACEHOLDER /tmp/fake-placeholder/local"
 }
 JSON
@@ -190,7 +224,7 @@ cat > "$ledger_fixture" <<'JSON'
     }
   },
   "items": [
-    {"issue_number": 920, "title": "Add autonomous | epic audit trail", "pr_number": 10, "tracker_status": "In Development", "risk_level": "medium", "review_result": "clean", "decision": "merge_approved", "merge_cleanup": "verified", "notes": "ready\nBearer token.value"},
+    {"issue_number": 920, "title": "Add autonomous | epic audit trail", "pr_number": 10, "tracker_status": "In Development", "risk_level": "medium", "review_result": "clean", "decision": "merge_approved", "merge_cleanup": "verified", "notes": "ready\nBearer token.value", "checkpoints": [{"item_number": 920, "stage": "plan", "domain": "technical", "satisfaction_state": "satisfied"}]},
     {"issue_number": 918, "title": "Add delegated review and merge loop", "tracker_status": "Backlog", "risk_level": "-", "review_result": "-", "decision": "blocked", "merge_cleanup": "-", "notes": "depends on #920", "stop_gate": "blocked dependency"}
   ]
 }
@@ -236,6 +270,7 @@ run_test "renders_advisory_decision" "yes" "$(grep -q 'accepted' <<< "$pr_output
 run_test "renders_protocol_deviation" "yes" "$(grep -q 'documented<br>rationale' <<< "$pr_output" && echo yes || echo no)"
 run_test "renders_invocation_policy" "yes" "$(grep -q '### Invocation Policy' <<< "$pr_output" && grep -q 'accepted recommended policy' <<< "$pr_output" && echo yes || echo no)"
 run_test "renders_policy_table" "yes" "$(grep -q '| mayStartBacklog | true | true | true |' <<< "$pr_output" && grep -q '| maxRisk | medium | medium | medium |' <<< "$pr_output" && echo yes || echo no)"
+run_test "renders_checkpoint_policy" "yes" "$(grep -q '### Checkpoint Policy' <<< "$pr_output" && grep -q 'approve data model' <<< "$pr_output" && echo yes || echo no)"
 run_test "escapes_pr_table_pipes" "yes" "$(grep -Fq 'haystack\\|triage' <<< "$pr_output" && grep -Fq 'none \\| expected' <<< "$pr_output" && echo yes || echo no)"
 run_test "normalizes_pr_table_newlines_tabs" "yes" "$(grep -Fq 'docs<br>sync' <<< "$pr_output" && grep -Fq 'documented<br>rationale with' <<< "$pr_output" && echo yes || echo no)"
 run_test "redacts_sensitive_values" "yes" "$(! grep -Eq 'ghp_FAKE_PLACEHOLDER|Authorization: dummy|Bearer dummy\\.value|/tmp/fake-placeholder' <<< "$pr_output" && grep -Fq 'Authorization: [REDACTED]' <<< "$pr_output" && grep -Fq 'Bearer [REDACTED]' <<< "$pr_output" && echo yes || echo no)"
@@ -250,6 +285,7 @@ run_test "escapes_ledger_table_pipes" "yes" "$(grep -Fq 'Add autonomous \\| epic
 run_test "normalizes_ledger_newlines" "yes" "$(grep -Fq 'ready<br>Bearer [REDACTED]' <<< "$ledger_output" && echo yes || echo no)"
 run_test "ledger_notes_include_effective_policy" "yes" "$(grep -Fq 'Effective policy: mayStartBacklog=true, delegateReview=true, mayMerge=true, maxRisk=medium, base=develop-delegated-epic-orchestration' <<< "$ledger_output" && echo yes || echo no)"
 run_test "ledger_notes_include_stop_gate" "yes" "$(grep -Fq 'Stop gate: blocked dependency' <<< "$ledger_output" && echo yes || echo no)"
+run_test "ledger_notes_include_checkpoints" "yes" "$(grep -Fq 'Checkpoints: #920 plan/technical=satisfied' <<< "$ledger_output" && echo yes || echo no)"
 
 explicit_output="$("$HELPER" render-epic-ledger --input "$explicit_fixture")"
 run_test "explicit_items_skip_epic_ledger" "yes" "$(grep -q 'Not applicable' <<< "$explicit_output" && echo yes || echo no)"

--- a/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+++ b/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
@@ -125,7 +125,7 @@ cat > "$pr_fixture" <<'JSON'
 {
   "scope_source": "epic #916",
   "item": {"number": 920, "title": "Add autonomous epic audit trail"},
-  "pr": {"number": 10, "head_sha": "abc123"},
+  "pr": {"number": 10, "head_sha": "abc123", "branch": "implementation-plan/audit-trail"},
   "reviewer": {"result": "clean", "blocking_count": 0, "advisory_count": 2},
   "advisories": [
     {"source": "haystack|triage", "category": "docs\nsync", "decision": "accepted", "rationale": "stale after rg verification with Authorization: dummy Bearer dummy.value"},
@@ -272,6 +272,14 @@ run_test "renders_invocation_policy" "yes" "$(grep -q '### Invocation Policy' <<
 run_test "renders_policy_table" "yes" "$(grep -q '| mayStartBacklog | true | true | true |' <<< "$pr_output" && grep -q '| maxRisk | medium | medium | medium |' <<< "$pr_output" && echo yes || echo no)"
 run_test "renders_checkpoint_policy" "yes" "$(grep -q '### Checkpoint Policy' <<< "$pr_output" && grep -q 'approve data model' <<< "$pr_output" && echo yes || echo no)"
 run_test "pending_checkpoint_count_excludes_satisfied" "0" "$(printf '%s\n' "$pr_output" | grep 'Pending applicable checkpoints:' | sed 's/.*: //')"
+
+stage_scoped_fixture="$TMP_ROOT/stage-scoped-checkpoints.json"
+jq '.checkpoint_policy.effective = [
+  {"item_number": 920, "stage": "plan", "domain": "technical", "reason": "plan pending", "required_human_action": "approve plan", "satisfaction_state": "pending"},
+  {"item_number": 920, "stage": "implementation", "domain": "technical", "reason": "impl pending", "required_human_action": "approve impl", "satisfaction_state": "pending"}
+] | .pr.branch = "implementation-plan/audit-trail"' "$pr_fixture" > "$stage_scoped_fixture"
+stage_scoped_output="$("$HELPER" render-pr-disposition --input "$stage_scoped_fixture")"
+run_test "pending_count_scoped_to_pr_stage" "1" "$(printf '%s\n' "$stage_scoped_output" | grep 'Pending applicable checkpoints:' | sed 's/.*: //')"
 run_test "escapes_pr_table_pipes" "yes" "$(grep -Fq 'haystack\\|triage' <<< "$pr_output" && grep -Fq 'none \\| expected' <<< "$pr_output" && echo yes || echo no)"
 run_test "normalizes_pr_table_newlines_tabs" "yes" "$(grep -Fq 'docs<br>sync' <<< "$pr_output" && grep -Fq 'documented<br>rationale with' <<< "$pr_output" && echo yes || echo no)"
 run_test "redacts_sensitive_values" "yes" "$(! grep -Eq 'ghp_FAKE_PLACEHOLDER|Authorization: dummy|Bearer dummy\\.value|/tmp/fake-placeholder' <<< "$pr_output" && grep -Fq 'Authorization: [REDACTED]' <<< "$pr_output" && grep -Fq 'Bearer [REDACTED]' <<< "$pr_output" && echo yes || echo no)"

--- a/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+++ b/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
@@ -302,6 +302,32 @@ run_fails_contains "comment_patch_failure_errors" "patch failed" env MOCK_COMMEN
 
 ledger_create_output="$("$HELPER" apply-epic-ledger --input "$ledger_fixture" --epic 900)"
 run_test "creates_epic_ledger_when_missing" "CREATED_COMMENT=1" "$ledger_create_output"
+
+ledger_root_checkpoint_fixture="$TMP_ROOT/ledger-root-checkpoints.json"
+cat > "$ledger_root_checkpoint_fixture" <<'JSON'
+{
+  "epic": {"number": 916, "title": "Delegated epic orchestration"},
+  "invocation_policy": {
+    "effective_policy": {
+      "mayStartBacklog": true,
+      "delegateReview": true,
+      "mayMerge": true,
+      "maxRisk": "medium",
+      "base": "develop-delegated-epic-orchestration",
+      "checkpoints": [
+        {"item_number": 920, "stage": "plan", "domain": "technical", "satisfaction_state": "pending"},
+        {"item_number": 918, "stage": "plan", "domain": "technical", "satisfaction_state": "pending"}
+      ]
+    }
+  },
+  "items": [
+    {"issue_number": 920, "title": "Item A", "tracker_status": "In Development", "decision": "merge_approved"},
+    {"issue_number": 918, "title": "Item B", "tracker_status": "Backlog", "decision": "blocked"}
+  ]
+}
+JSON
+root_checkpoint_ledger_output="$("$HELPER" render-epic-ledger --input "$ledger_root_checkpoint_fixture")"
+run_test "ledger_root_checkpoints_scoped_by_item" "yes" "$(grep -Fq 'Checkpoints: #920 plan/technical=pending' <<< "$root_checkpoint_ledger_output" && ! grep '#918' <<< "$(grep 'Item A' <<< "$root_checkpoint_ledger_output")" && echo yes || echo no)"
 ledger_update_output="$(MOCK_COMMENT_MODE=existing "$HELPER" apply-epic-ledger --input "$ledger_fixture" --epic 900)"
 run_test "updates_existing_epic_ledger_comment" "UPDATED_COMMENT_ID=456" "$ledger_update_output"
 

--- a/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+++ b/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
@@ -271,6 +271,7 @@ run_test "renders_protocol_deviation" "yes" "$(grep -q 'documented<br>rationale'
 run_test "renders_invocation_policy" "yes" "$(grep -q '### Invocation Policy' <<< "$pr_output" && grep -q 'accepted recommended policy' <<< "$pr_output" && echo yes || echo no)"
 run_test "renders_policy_table" "yes" "$(grep -q '| mayStartBacklog | true | true | true |' <<< "$pr_output" && grep -q '| maxRisk | medium | medium | medium |' <<< "$pr_output" && echo yes || echo no)"
 run_test "renders_checkpoint_policy" "yes" "$(grep -q '### Checkpoint Policy' <<< "$pr_output" && grep -q 'approve data model' <<< "$pr_output" && echo yes || echo no)"
+run_test "pending_checkpoint_count_excludes_satisfied" "0" "$(printf '%s\n' "$pr_output" | grep 'Pending applicable checkpoints:' | sed 's/.*: //')"
 run_test "escapes_pr_table_pipes" "yes" "$(grep -Fq 'haystack\\|triage' <<< "$pr_output" && grep -Fq 'none \\| expected' <<< "$pr_output" && echo yes || echo no)"
 run_test "normalizes_pr_table_newlines_tabs" "yes" "$(grep -Fq 'docs<br>sync' <<< "$pr_output" && grep -Fq 'documented<br>rationale with' <<< "$pr_output" && echo yes || echo no)"
 run_test "redacts_sensitive_values" "yes" "$(! grep -Eq 'ghp_FAKE_PLACEHOLDER|Authorization: dummy|Bearer dummy\\.value|/tmp/fake-placeholder' <<< "$pr_output" && grep -Fq 'Authorization: [REDACTED]' <<< "$pr_output" && grep -Fq 'Bearer [REDACTED]' <<< "$pr_output" && echo yes || echo no)"

--- a/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
@@ -182,7 +182,7 @@ cat > "$multi_domain_file" <<'JSON'
   {"item_number": 1022, "stage": "plan", "domain": "product", "required_human_action": "b", "satisfaction_state": "pending"}
 ]
 JSON
-run_test "single_approval_does_not_satisfy_multi_domain" "2" "$(MOCK_REVIEW_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$multi_domain_file" --pr 42 | jq '[.[] | select(.satisfaction_state == "pending")] | length')"
+run_test "single_approval_satisfies_all_at_stage" "0" "$(MOCK_REVIEW_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$multi_domain_file" --pr 42 | jq '[.[] | select(.satisfaction_state == "pending")] | length')"
 
 no_block_after="$("$HELPER" evaluate-blocking --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$satisfied_file")"
 run_test "satisfied_checkpoint_not_blocking" "0" "$(printf '%s\n' "$no_block_after" | jq 'length')"

--- a/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
@@ -44,6 +44,10 @@ case "$*" in
       cat <<'JSON'
 [{"state":"APPROVED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T12:00:00Z"}]
 JSON
+    elif [ "${MOCK_REVIEW_STALE_APPROVED:-0}" = "1" ]; then
+      cat <<'JSON'
+[{"state":"APPROVED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T11:00:00Z"},{"state":"CHANGES_REQUESTED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T12:00:00Z"}]
+JSON
     else
       printf '[]\n'
     fi
@@ -154,6 +158,10 @@ run_test "earlier_plan_checkpoint_blocks_implementation_pr" "1" "$(printf '%s\n'
 satisfied_file="$TMP_ROOT/satisfied-checkpoints.json"
 MOCK_COMMENT_MODE=satisfied "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 --write-checkpoints-file "$satisfied_file" >/dev/null
 run_test "detect_satisfaction_via_comment" "satisfied" "$(jq -r '.[0].satisfaction_state' "$satisfied_file")"
+
+run_test "stale_approval_does_not_satisfy" "pending" "$(MOCK_REVIEW_STALE_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
+
+run_test "latest_approval_satisfies" "satisfied" "$(MOCK_REVIEW_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
 
 no_block_after="$("$HELPER" evaluate-blocking --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$satisfied_file")"
 run_test "satisfied_checkpoint_not_blocking" "0" "$(printf '%s\n' "$no_block_after" | jq 'length')"

--- a/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
@@ -4,11 +4,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
-GIT_COMMON_DIR="$(cd "$SCRIPT_DIR" && git rev-parse --git-common-dir)"
-case "$GIT_COMMON_DIR" in
-  /*) REPO_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd -P)" ;;
-  *) REPO_ROOT="$(cd "$SCRIPT_DIR/$GIT_COMMON_DIR/.." && pwd -P)" ;;
-esac
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 HELPER="$REPO_ROOT/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh"
 
 TMP_ROOT="$(mktemp -d)"

--- a/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# test-run-epic-checkpoint-lifecycle.sh - Unit tests for checkpoint PR lifecycle.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+GIT_COMMON_DIR="$(cd "$SCRIPT_DIR" && git rev-parse --git-common-dir)"
+case "$GIT_COMMON_DIR" in
+  /*) REPO_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd -P)" ;;
+  *) REPO_ROOT="$(cd "$SCRIPT_DIR/$GIT_COMMON_DIR/.." && pwd -P)" ;;
+esac
+HELPER="$REPO_ROOT/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh"
+
+TMP_ROOT="$(mktemp -d)"
+MOCK_BIN="$TMP_ROOT/bin"
+CALL_LOG="$TMP_ROOT/gh-calls.log"
+mkdir -p "$MOCK_BIN"
+: > "$CALL_LOG"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+cat > "$MOCK_BIN/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_GH_CALL_LOG"
+case "$*" in
+  auth\ status)
+    exit 0
+    ;;
+  repo\ view\ --json\ nameWithOwner\ --jq\ .nameWithOwner)
+    printf 'lhpaul/ai-dev-framework-template\n'
+    ;;
+  pr\ view\ 42\ --json\ labels\ --jq\ *)
+    if [ "${MOCK_HAS_CHECKPOINT_LABEL:-0}" = "1" ]; then
+      printf '1\n'
+    else
+      printf '0\n'
+    fi
+    ;;
+  pr\ view\ 42\ --json\ reviews\ --jq\ *)
+    if [ "${MOCK_REVIEW_APPROVED:-0}" = "1" ]; then
+      cat <<'JSON'
+[{"state":"APPROVED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T12:00:00Z"}]
+JSON
+    else
+      printf '[]\n'
+    fi
+    ;;
+  pr\ edit\ 42\ --add-label\ human-checkpoint-required)
+    printf 'added\n'
+    ;;
+  pr\ edit\ 42\ --remove-label\ human-checkpoint-required)
+    printf 'removed\n'
+    ;;
+  api\ --paginate\ --slurp\ repos/lhpaul/ai-dev-framework-template/issues/42/comments\?per_page=100)
+    if [ "${MOCK_COMMENT_MODE:-empty}" = "satisfied" ]; then
+      cat <<'JSON'
+[[{"user":{"login":"human-reviewer"},"body":"<!-- run-epic:checkpoint-satisfied:1022:plan:technical -->","created_at":"2026-06-22T12:00:00Z"}]]
+JSON
+    elif [ "${MOCK_COMMENT_MODE:-empty}" = "existing-marker" ]; then
+      cat <<'JSON'
+[[{"id":999,"user":{"login":"bot"},"body":"<!-- run-epic:checkpoint-status -->\nold"}]]
+JSON
+    else
+      printf '[]\n'
+    fi
+    ;;
+  api\ -X\ PATCH\ repos/lhpaul/ai-dev-framework-template/issues/comments/999\ --input\ -)
+    printf '{"id":999}\n'
+    ;;
+  api\ -X\ POST\ repos/lhpaul/ai-dev-framework-template/issues/42/comments\ --input\ -)
+    printf '{"id":1000}\n'
+    ;;
+  *)
+    printf 'unexpected gh invocation: gh %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+MOCK_GH
+chmod +x "$MOCK_BIN/gh"
+export PATH="$MOCK_BIN:$PATH"
+export MOCK_GH_CALL_LOG="$CALL_LOG"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_fails_contains() {
+  local name="$1" expected="$2"
+  shift 2
+  local output status
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ] && grep -Fq -- "$expected" <<< "$output"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected failure containing '${expected}'"
+    printf 'Status: %s\nOutput:\n%s\n' "$status" "$output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+checkpoints_file="$TMP_ROOT/checkpoints.json"
+cat > "$checkpoints_file" <<'JSON'
+[
+  {
+    "item_number": 1022,
+    "stage": "plan",
+    "domain": "technical",
+    "reason": "schema changes",
+    "required_human_action": "approve data model",
+    "satisfaction_state": "pending"
+  },
+  {
+    "item_number": 9999,
+    "stage": "plan",
+    "domain": "technical",
+    "reason": "other item",
+    "required_human_action": "ignore",
+    "satisfaction_state": "pending"
+  }
+]
+JSON
+
+echo ""
+echo "=== Run epic checkpoint lifecycle ==="
+
+run_fails_contains "requires_known_subcommand" "unknown or missing subcommand" "$HELPER"
+run_test "stage_from_spec_branch" "spec" "$("$HELPER" stage-from-branch --branch spec/human-checkpoints)"
+run_test "stage_from_plan_branch" "plan" "$("$HELPER" stage-from-branch --branch implementation-plan/human-checkpoints)"
+
+blocking_output="$("$HELPER" evaluate-blocking --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file")"
+run_test "evaluate_blocking_plan_stage" "1" "$(printf '%s\n' "$blocking_output" | jq 'length')"
+run_test "evaluate_blocking_same_item_only" "1022" "$(printf '%s\n' "$blocking_output" | jq -r '.[0].item_number')"
+
+impl_blocking="$("$HELPER" evaluate-blocking --item 1022 --branch feature/human-checkpoints --checkpoints-file "$checkpoints_file")"
+run_test "earlier_plan_checkpoint_blocks_implementation_pr" "1" "$(printf '%s\n' "$impl_blocking" | jq 'length')"
+
+satisfied_file="$TMP_ROOT/satisfied-checkpoints.json"
+MOCK_COMMENT_MODE=satisfied "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 --write-checkpoints-file "$satisfied_file" >/dev/null
+run_test "detect_satisfaction_via_comment" "satisfied" "$(jq -r '.[0].satisfaction_state' "$satisfied_file")"
+
+no_block_after="$("$HELPER" evaluate-blocking --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$satisfied_file")"
+run_test "satisfied_checkpoint_not_blocking" "0" "$(printf '%s\n' "$no_block_after" | jq 'length')"
+
+comment_input="$TMP_ROOT/comment-input.json"
+jq -n \
+  --argjson item '{"number":1022}' \
+  --argjson pr '{"number":42,"branch":"implementation-plan/human-checkpoints","stage":"plan"}' \
+  --argjson checkpoints "$(cat "$checkpoints_file")" \
+  --argjson blocking "$(printf '%s\n' "$blocking_output")" \
+  '{
+    item: $item,
+    pr: $pr,
+    checkpoints: $checkpoints,
+    blocking: $blocking,
+    label_required: true,
+    satisfaction_signals: {
+      comment_marker: "<!-- run-epic:checkpoint-satisfied:1022:plan:technical -->",
+      waiver_marker: "<!-- run-epic:checkpoint-waived:1022:plan:technical --> rationale"
+    }
+  }' > "$comment_input"
+comment_output="$("$HELPER" render-pr-checkpoint-comment --input "$comment_input")"
+run_test "renders_checkpoint_marker" "yes" "$(grep -q '<!-- run-epic:checkpoint-status -->' <<< "$comment_output" && echo yes || echo no)"
+run_test "renders_blocking_section" "yes" "$(grep -q 'approve data model' <<< "$comment_output" && echo yes || echo no)"
+
+sync_output="$("$HELPER" sync-pr-labels --pr 42 --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file")"
+run_test "sync_applies_label_when_blocking" "LABEL_APPLIED=human-checkpoint-required" "$(grep '^LABEL_APPLIED=' <<< "$sync_output" || true)"
+run_test "sync_reports_blocking_count" "BLOCKING_COUNT=1" "$(grep '^BLOCKING_COUNT=' <<< "$sync_output" || true)"
+
+sync_remove_output="$(MOCK_HAS_CHECKPOINT_LABEL=1 MOCK_COMMENT_MODE=satisfied "$HELPER" sync-pr-labels --pr 42 --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file")"
+run_test "sync_removes_label_when_satisfied" "LABEL_REMOVED=human-checkpoint-required" "$(grep '^LABEL_REMOVED=' <<< "$sync_remove_output" || true)"
+
+echo ""
+echo "=== Summary ==="
+echo "Passed: $PASS_COUNT"
+echo "Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
@@ -39,18 +39,24 @@ case "$*" in
       printf '0\n'
     fi
     ;;
-  pr\ view\ 42\ --json\ reviews\ --jq\ *)
+  pr\ view\ 42\ --json\ headRefOid*)
+    printf 'abc123\n'
+    ;;
+  pr\ view\ 42\ --json\ reviews*)
     if [ "${MOCK_REVIEW_APPROVED:-0}" = "1" ]; then
       cat <<'JSON'
-[{"state":"APPROVED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T12:00:00Z"}]
+[{"state":"APPROVED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T12:00:00Z","commit":{"oid":"abc123"}}]
 JSON
     elif [ "${MOCK_REVIEW_STALE_APPROVED:-0}" = "1" ]; then
       cat <<'JSON'
-[{"state":"APPROVED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T11:00:00Z"},{"state":"CHANGES_REQUESTED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T12:00:00Z"}]
+[{"state":"APPROVED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T11:00:00Z","commit":{"oid":"oldsha"}},{"state":"CHANGES_REQUESTED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T12:00:00Z","commit":{"oid":"abc123"}}]
 JSON
     else
       printf '[]\n'
     fi
+    ;;
+  pr\ view\ 42\ --json\ headRefOid\ --jq\ .headRefOid)
+    printf 'abc123\n'
     ;;
   pr\ edit\ 42\ --add-label\ human-checkpoint-required)
     printf 'added\n'

--- a/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
@@ -190,6 +190,7 @@ run_test "renders_blocking_section" "yes" "$(grep -q 'approve data model' <<< "$
 sync_output="$("$HELPER" sync-pr-labels --pr 42 --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file")"
 run_test "sync_applies_label_when_blocking" "LABEL_APPLIED=human-checkpoint-required" "$(grep '^LABEL_APPLIED=' <<< "$sync_output" || true)"
 run_test "sync_reports_blocking_count" "BLOCKING_COUNT=1" "$(grep '^BLOCKING_COUNT=' <<< "$sync_output" || true)"
+run_test "sync_comment_scoped_to_item" "yes" "$(grep -Fq 'POST repos/lhpaul/ai-dev-framework-template/issues/42/comments' "$CALL_LOG" && ! grep -Fq '#9999' "$CALL_LOG" && echo yes || echo no)"
 
 sync_remove_output="$(MOCK_HAS_CHECKPOINT_LABEL=1 MOCK_COMMENT_MODE=satisfied "$HELPER" sync-pr-labels --pr 42 --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file")"
 run_test "sync_removes_label_when_satisfied" "LABEL_REMOVED=human-checkpoint-required" "$(grep '^LABEL_REMOVED=' <<< "$sync_remove_output" || true)"

--- a/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
@@ -63,6 +63,14 @@ JSON
       cat <<'JSON'
 [[{"user":{"login":"human-reviewer"},"body":"<!-- run-epic:checkpoint-satisfied:1022:plan:technical -->","created_at":"2026-06-22T12:00:00Z"}]]
 JSON
+    elif [ "${MOCK_COMMENT_MODE:-empty}" = "bot-satisfied" ]; then
+      cat <<'JSON'
+[[{"user":{"login":"cursor[bot]"},"body":"<!-- run-epic:checkpoint-satisfied:1022:plan:technical -->","created_at":"2026-06-22T12:00:00Z"}]]
+JSON
+    elif [ "${MOCK_COMMENT_MODE:-empty}" = "waived-no-rationale" ]; then
+      cat <<'JSON'
+[[{"user":{"login":"human-reviewer"},"body":"<!-- run-epic:checkpoint-waived:1022:plan:technical -->","created_at":"2026-06-22T12:00:00Z"}]]
+JSON
     elif [ "${MOCK_COMMENT_MODE:-empty}" = "existing-marker" ]; then
       cat <<'JSON'
 [[{"id":999,"user":{"login":"bot"},"body":"<!-- run-epic:checkpoint-status -->\nold"}]]
@@ -162,6 +170,19 @@ run_test "detect_satisfaction_via_comment" "satisfied" "$(jq -r '.[0].satisfacti
 run_test "stale_approval_does_not_satisfy" "pending" "$(MOCK_REVIEW_STALE_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
 
 run_test "latest_approval_satisfies" "satisfied" "$(MOCK_REVIEW_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
+
+run_test "bot_satisfaction_marker_ignored" "pending" "$(MOCK_COMMENT_MODE=bot-satisfied "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
+
+run_test "waived_without_rationale_ignored" "pending" "$(MOCK_COMMENT_MODE=waived-no-rationale "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
+
+multi_domain_file="$TMP_ROOT/multi-domain-checkpoints.json"
+cat > "$multi_domain_file" <<'JSON'
+[
+  {"item_number": 1022, "stage": "plan", "domain": "technical", "required_human_action": "a", "satisfaction_state": "pending"},
+  {"item_number": 1022, "stage": "plan", "domain": "product", "required_human_action": "b", "satisfaction_state": "pending"}
+]
+JSON
+run_test "single_approval_does_not_satisfy_multi_domain" "2" "$(MOCK_REVIEW_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$multi_domain_file" --pr 42 | jq '[.[] | select(.satisfaction_state == "pending")] | length')"
 
 no_block_after="$("$HELPER" evaluate-blocking --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$satisfied_file")"
 run_test "satisfied_checkpoint_not_blocking" "0" "$(printf '%s\n' "$no_block_after" | jq 'length')"

--- a/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
@@ -195,6 +195,15 @@ cat > "$multi_domain_file" <<'JSON'
 JSON
 run_test "single_approval_satisfies_all_at_stage" "0" "$(MOCK_REVIEW_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$multi_domain_file" --pr 42 | jq '[.[] | select(.satisfaction_state == "pending")] | length')"
 
+satisfied_plan_file="$TMP_ROOT/satisfied-plan-checkpoints.json"
+cat > "$satisfied_plan_file" <<'JSON'
+[
+  {"item_number": 1022, "stage": "plan", "domain": "technical", "required_human_action": "a", "satisfaction_state": "satisfied", "satisfied_by": "human"},
+  {"item_number": 1022, "stage": "implementation", "domain": "technical", "required_human_action": "b", "satisfaction_state": "pending"}
+]
+JSON
+run_test "preserves_satisfied_checkpoint_on_later_stage_pr" "satisfied" "$( "$HELPER" detect-satisfaction --item 1022 --branch feature/human-checkpoints --checkpoints-file "$satisfied_plan_file" --pr 42 | jq -r '.[0].satisfaction_state')"
+
 no_block_after="$("$HELPER" evaluate-blocking --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$satisfied_file")"
 run_test "satisfied_checkpoint_not_blocking" "0" "$(printf '%s\n' "$no_block_after" | jq 'length')"
 

--- a/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
@@ -169,6 +169,11 @@ run_test "evaluate_blocking_same_item_only" "1022" "$(printf '%s\n' "$blocking_o
 impl_blocking="$("$HELPER" evaluate-blocking --item 1022 --branch feature/human-checkpoints --checkpoints-file "$checkpoints_file")"
 run_test "earlier_plan_checkpoint_blocks_implementation_pr" "1" "$(printf '%s\n' "$impl_blocking" | jq 'length')"
 
+satisfied_plan_file="$TMP_ROOT/satisfied-plan-checkpoint.json"
+printf '%s\n' '[{"item_number":1022,"stage":"plan","domain":"technical","reason":"schema","required_human_action":"approve","satisfaction_state":"satisfied","satisfied_by":"human"}]' > "$satisfied_plan_file"
+impl_blocking_after_plan="$("$HELPER" evaluate-blocking --item 1022 --branch feature/human-checkpoints --checkpoints-file "$satisfied_plan_file")"
+run_test "satisfied_earlier_stage_not_reblocked" "0" "$(printf '%s\n' "$impl_blocking_after_plan" | jq 'length')"
+
 satisfied_file="$TMP_ROOT/satisfied-checkpoints.json"
 MOCK_COMMENT_MODE=satisfied "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 --write-checkpoints-file "$satisfied_file" >/dev/null
 run_test "detect_satisfaction_via_comment" "satisfied" "$(jq -r '.[0].satisfaction_state' "$satisfied_file")"

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -210,7 +210,7 @@ is_bugbot_clean_review() {
   local non_empty_count=0
 
   case "$body" in
-    *BUGBOT_BUG_ID*|*"BUGBOT_REVIEW"*|*"LOCATIONS START"*|*"DESCRIPTION START"*|*"Triggered by project rule"*|*"**High Severity"*|*"**Medium Severity"*|*"**Low Severity"*)
+    *BUGBOT_BUG_ID*|*BUGBOT_REVIEW*|*"LOCATIONS START"*|*"DESCRIPTION START"*|*"Triggered by project rule"*|*'**High Severity**'*|*'**Medium Severity**'*|*'**Low Severity**'*)
       return 1
       ;;
   esac

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -205,8 +205,12 @@ is_soft_suggestion() {
 
 is_bugbot_clean_review() {
   local body="$1"
+  local line
+  local normalized_line
+  local non_empty_count=0
+
   case "$body" in
-    *BUGBOT_BUG_ID*|*"BUGBOT_REVIEW"*|*"LOCATIONS START"*|*"**High Severity"*|*"**Medium Severity"*|*"**Low Severity"*)
+    *BUGBOT_BUG_ID*|*"BUGBOT_REVIEW"*|*"LOCATIONS START"*|*"DESCRIPTION START"*|*"Triggered by project rule"*|*"**High Severity"*|*"**Medium Severity"*|*"**Low Severity"*)
       return 1
       ;;
   esac
@@ -215,6 +219,16 @@ is_bugbot_clean_review() {
       return 1
       ;;
   esac
+  while IFS= read -r line; do
+    normalized_line="${line%$'\r'}"
+    normalized_line="${normalized_line#"${normalized_line%%[![:space:]]*}"}"
+    normalized_line="${normalized_line%"${normalized_line##*[![:space:]]}"}"
+    [ -z "$normalized_line" ] && continue
+    non_empty_count=$((non_empty_count + 1))
+    if [ "$non_empty_count" -gt 1 ]; then
+      return 1
+    fi
+  done <<< "$body"
   case "$body" in
     *"found no new issues"*|*"found no potential issues"*|*"found no issues"*)
       return 0

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -203,6 +203,16 @@ is_soft_suggestion() {
   [ "$saw_content" -eq 1 ]
 }
 
+is_bugbot_clean_review() {
+  local body="$1"
+  case "$body" in
+    *"found no new issues"*|*"found no issues"*|*"found no potential issues"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 open_pr_number_for_branch() {
   require_gh
   gh pr list --head "$1" --state open --limit 100 --json number --jq '.[0].number // empty'

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -206,6 +206,11 @@ is_soft_suggestion() {
 is_bugbot_clean_review() {
   local body="$1"
   case "$body" in
+    *BUGBOT_BUG_ID*|*"potential issue"*|*"blocking finding"*|*"**High Severity"*|*"**Medium Severity"*|*"**Low Severity"*)
+      return 1
+      ;;
+  esac
+  case "$body" in
     *"found no new issues"*|*"found no issues"*|*"found no potential issues"*)
       return 0
       ;;

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -206,16 +206,18 @@ is_soft_suggestion() {
 is_bugbot_clean_review() {
   local body="$1"
   case "$body" in
-    *"found no new issues"*|*"found no potential issues"*|*"found no issues"*)
-      return 0
+    *BUGBOT_BUG_ID*|*"BUGBOT_REVIEW"*|*"LOCATIONS START"*|*"**High Severity"*|*"**Medium Severity"*|*"**Low Severity"*)
+      return 1
       ;;
   esac
   case "$body" in
-    *BUGBOT_BUG_ID*|*"**High Severity"*|*"**Medium Severity"*|*"**Low Severity"*)
-      return 1
-      ;;
     *"found 1 potential issue"*|*"found 2 potential issue"*|*"found 3 potential issue"*|*"found 4 potential issue"*|*"found 5 potential issue"*)
       return 1
+      ;;
+  esac
+  case "$body" in
+    *"found no new issues"*|*"found no potential issues"*|*"found no issues"*)
+      return 0
       ;;
   esac
   return 1

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -206,13 +206,16 @@ is_soft_suggestion() {
 is_bugbot_clean_review() {
   local body="$1"
   case "$body" in
-    *BUGBOT_BUG_ID*|*"potential issue"*|*"blocking finding"*|*"**High Severity"*|*"**Medium Severity"*|*"**Low Severity"*)
-      return 1
+    *"found no new issues"*|*"found no potential issues"*|*"found no issues"*)
+      return 0
       ;;
   esac
   case "$body" in
-    *"found no new issues"*|*"found no issues"*|*"found no potential issues"*)
-      return 0
+    *BUGBOT_BUG_ID*|*"**High Severity"*|*"**Medium Severity"*|*"**Low Severity"*)
+      return 1
+      ;;
+    *"found 1 potential issue"*|*"found 2 potential issue"*|*"found 3 potential issue"*|*"found 4 potential issue"*|*"found 5 potential issue"*)
+      return 1
       ;;
   esac
   return 1


### PR DESCRIPTION
## Summary

Implements #1022 from epic #1019: PR lifecycle support for human checkpoints.

- Defines `human-checkpoint-required` in protocol 92 with valid label combinations and satisfaction signals
- Adds Step 8a checkpoint label sync and Step 8c verification in protocol 91
- Ships `run-epic-checkpoint-lifecycle.sh` for blocking evaluation, satisfaction detection, label apply/remove, and stable PR comments
- Extends `run-epic-audit-trail.sh` with checkpoint policy sections for PR disposition and epic ledger

## Test plan

- [x] `bash scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh`
- [x] `bash scripts/development-workflow/tests/test-run-epic-audit-trail.sh`

Closes #1022


Made with [Cursor](https://cursor.com)