### PR TITLE
feat(checkpoints): enforce human checkpoint merge gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Human checkpoint merge gates** (#1023): delegated `/run-epic` merge gates and
+  batch merge discovery now block unsatisfied `human-checkpoint-required` PRs
+  until checkpoint satisfaction or waiver evidence is recorded and labels are synced.
 - **Human checkpoint PR lifecycle** (#1022): adds `human-checkpoint-required` readiness
   signal (protocol 92), Step 8a/8c checkpoint label sync in protocol 91,
   `run-epic-checkpoint-lifecycle.sh` for satisfaction detection and label/comment

--- a/docs/workflow/development-workflow/guardrails-enforcement.md
+++ b/docs/workflow/development-workflow/guardrails-enforcement.md
@@ -222,6 +222,7 @@ table is required for consistent stop reporting.
 | `unresolved_blocking_review` | A blocking review thread from a configured automated reviewer or a human reviewer remains unresolved. |
 | `high_risk_change` | The PR is classified above the configured `max_merge_risk` for the stage. |
 | `destructive_action` | The next action would delete branches, data, releases, or other non-recoverable artifacts. |
+| `human_checkpoint_required` | A declared stage-scoped human checkpoint for the PR's work item is still pending, or the PR still carries `human-checkpoint-required`. |
 | `missing_tracker_context` | A required tracker field (status, type, assignee, dependency link) is absent or unresolvable. |
 | `missing_required_secret_or_permission` | A required credential, GitHub permission, or access token is absent. |
 | `guardrails_config_unreadable` | The `guardrails` block in `.ai-dev-workflow.yaml` is missing required fields, uses invalid values, or is internally contradictory. |

--- a/docs/workflow/development-workflow/guardrails.md
+++ b/docs/workflow/development-workflow/guardrails.md
@@ -174,6 +174,7 @@ The following stop conditions are always in force:
 | `unresolved_blocking_review`          | A blocking review thread (from a reviewer or automated tool) is unresolved.            |
 | `high_risk_change`                    | The classified PR risk exceeds the stage's configured `max_merge_risk`.                |
 | `destructive_action`                  | The action would delete branches, data, releases, or other non-recoverable artifacts.  |
+| `human_checkpoint_required`           | A declared stage-scoped human checkpoint is still pending for the PR's work item.      |
 | `missing_tracker_context`             | The work item is missing required tracker metadata (status, type, or linked spec).     |
 | `missing_required_secret_or_permission` | A required credential or GitHub permission is absent.                                |
 

--- a/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
+++ b/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
@@ -54,6 +54,14 @@ Parse the output. Each PR candidate is a block of `KEY=VALUE` lines terminated b
 
   When the user supplied an explicit PR list the script proceeds to per-PR readiness checks regardless of label status (some may not have the `ready-for-human-review` label — those are handled in Step 2).
 
+  If discovery warns that a PR is labeled `human-checkpoint-required`, treat it
+  as skipped until the named checkpoint is satisfied or waived. Do not add it
+  back to the candidate list just because `ready-for-human-review` is present.
+  To inspect an explicitly supplied checkpointed PR in the candidate table after
+  human confirmation, rerun discovery with `--include-checkpointed`; merge mode
+  will still refuse the stale label, so the checkpoint lifecycle helper must
+  record `satisfied` or `waived` evidence and sync labels before the merge step.
+
 ### 1c. Display the candidate summary table
 
 Print a summary table so the human can see what was discovered before any gate or merge:
@@ -91,6 +99,23 @@ For each candidate PR:
    Record the human's decision. If the human does not respond or exits, treat as **skip**.
 
 3. Do not silently skip or silently include an unready PR. The human must explicitly decide.
+
+4. If `PR_HAS_HUMAN_CHECKPOINT=true`, display a warning:
+
+   > **Warning**: PR #N — _title_ — still requires a human checkpoint.
+   > The required action must be completed and recorded before this batch can
+   > merge it.
+   >
+   > - Type **satisfied** only after the checkpoint lifecycle evidence records
+   >   `satisfied` or `waived` and the `human-checkpoint-required` label has
+   >   been synced away.
+   > - Type **skip** to exclude it from this run (outcome:
+   >   `skipped_human_checkpoint`).
+
+   Do not proceed on a verbal "include" alone. The merge helper refuses a stale
+   `human-checkpoint-required` label, so the concrete action is to satisfy or
+   waive the checkpoint, rerun label sync, rerun discovery, and continue only
+   after `PR_HAS_HUMAN_CHECKPOINT=false`.
 
 After Step 2, update the candidate list: remove any PRs the human chose to skip and mark them `skipped_not_ready` in the tracking state.
 

--- a/scripts/development-workflow/batch-merge.sh
+++ b/scripts/development-workflow/batch-merge.sh
@@ -11,6 +11,7 @@
 #   # --- Discovery mode ---
 #   ./scripts/development-workflow/batch-merge.sh [--base <branch>] discover
 #   ./scripts/development-workflow/batch-merge.sh [--base <branch>] discover --prs 101,102,103
+#   ./scripts/development-workflow/batch-merge.sh [--base <branch>] discover --include-checkpointed --prs 101,102,103
 #
 #   # --- Per-PR merge mode ---
 #   ./scripts/development-workflow/batch-merge.sh [--base <branch>] merge --pr 101
@@ -30,6 +31,7 @@
 #   PR_READY_LABEL=true|false
 #   PR_IS_DRAFT=true|false
 #   PR_HAS_NEEDS_FIXES=true|false
+#   PR_HAS_HUMAN_CHECKPOINT=true|false
 #   PR_HAS_CHANGELOG=true|false
 #   PR_CREATED_AT=<ISO-8601>
 #   PR_ORDER=<1-based index in merge order>
@@ -84,12 +86,17 @@ TARGET_BASE="${TARGET_BASE:-develop}"
 usage() {
   cat >&2 <<'EOF'
 Usage:
-  batch-merge.sh [--base <branch>] discover [--prs <num1,num2,...>]
+  batch-merge.sh [--base <branch>] discover [--include-checkpointed] [--prs <num1,num2,...>]
   batch-merge.sh [--base <branch>] merge --pr <number>
   batch-merge.sh [--base <branch>] delete-branch --pr <number>
 
   --base  Target integration branch (default: develop).
           Override when merging PRs into an epic integration branch.
+
+  --include-checkpointed
+          Discovery only. Include PRs labeled human-checkpoint-required in the
+          candidate output after protocol-level confirmation. Merge mode still
+          refuses that label until checkpoint satisfaction evidence removes it.
 EOF
   exit 2
 }
@@ -112,7 +119,7 @@ fetch_pr_meta() {
     return 1
   }
 
-  local number title branch base created_at labels_csv ready_label is_draft has_needs_fixes
+  local number title branch base created_at labels_csv ready_label is_draft has_needs_fixes has_human_checkpoint
 
   number="$(printf '%s' "$json" | jq -r '.number')"
   title="$(printf '%s' "$json" | jq -r '.title')"
@@ -131,6 +138,11 @@ fetch_pr_meta() {
   else
     has_needs_fixes="false"
   fi
+  if printf '%s' "$json" | jq -r '.labels[].name' | grep -q '^human-checkpoint-required$'; then
+    has_human_checkpoint="true"
+  else
+    has_human_checkpoint="false"
+  fi
 
   # Check whether the PR diff touches CHANGELOG.md
   local has_changelog="false"
@@ -146,6 +158,7 @@ fetch_pr_meta() {
   print_kv PR_READY_LABEL    "$ready_label"
   print_kv PR_IS_DRAFT       "$is_draft"
   print_kv PR_HAS_NEEDS_FIXES "$has_needs_fixes"
+  print_kv PR_HAS_HUMAN_CHECKPOINT "$has_human_checkpoint"
   print_kv PR_HAS_CHANGELOG  "$has_changelog"
   print_kv PR_CREATED_AT     "$created_at"
 }
@@ -156,9 +169,14 @@ fetch_pr_meta() {
 
 cmd_discover() {
   local explicit_prs=""
+  local include_checkpointed="false"
 
   while [ $# -gt 0 ]; do
     case "$1" in
+      --include-checkpointed)
+        include_checkpointed="true"
+        shift
+        ;;
       --prs)
         [ $# -ge 2 ] && [ -n "${2:-}" ] || die "--prs requires a comma-separated value (e.g. --prs 101,102)"
         explicit_prs="$2"
@@ -239,11 +257,12 @@ cmd_discover() {
       continue
     fi
 
-    local base has_changelog is_draft has_needs_fixes
+    local base has_changelog is_draft has_needs_fixes has_human_checkpoint
     base="$(printf '%s\n' "$meta" | awk -F'=' '$1=="PR_BASE"{print $2}')"
     has_changelog="$(printf '%s\n' "$meta" | awk -F'=' '$1=="PR_HAS_CHANGELOG"{print $2}')"
     is_draft="$(printf '%s\n' "$meta" | awk -F'=' '$1=="PR_IS_DRAFT"{print $2}')"
     has_needs_fixes="$(printf '%s\n' "$meta" | awk -F'=' '$1=="PR_HAS_NEEDS_FIXES"{print $2}')"
+    has_human_checkpoint="$(printf '%s\n' "$meta" | awk -F'=' '$1=="PR_HAS_HUMAN_CHECKPOINT"{print $2}')"
 
     # Filter: only target develop (explicit mode may include any PR numbers)
     if [ "$base" != "$TARGET_BASE" ]; then
@@ -260,6 +279,14 @@ cmd_discover() {
     # Filter: skip PRs labeled needs-fixes (review cycle not complete)
     if [ "$has_needs_fixes" = "true" ]; then
       echo "WARNING: PR #${pr_num} is labeled needs-fixes — skipping" >&2
+      continue
+    fi
+
+    # Filter: skip unsatisfied human checkpoints unless the caller has already
+    # completed the protocol-level checkpoint confirmation path. Merge mode has
+    # a second hard guard and will still refuse a stale checkpoint label.
+    if [ "$has_human_checkpoint" = "true" ] && [ "$include_checkpointed" != "true" ]; then
+      echo "WARNING: PR #${pr_num} is labeled human-checkpoint-required — skipping until the named checkpoint is satisfied or waived and labels are synced" >&2
       continue
     fi
 
@@ -520,6 +547,10 @@ cmd_merge() {
 
   if printf '%s' "$pr_json" | jq -e '.labels[].name | select(. == "needs-fixes")' >/dev/null 2>&1; then
     merge_die "PR #${pr_num} is labeled needs-fixes"
+  fi
+
+  if printf '%s' "$pr_json" | jq -e '.labels[].name | select(. == "human-checkpoint-required")' >/dev/null 2>&1; then
+    merge_die "PR #${pr_num} is labeled human-checkpoint-required — satisfy or waive the checkpoint, record audit evidence, and sync labels before merging"
   fi
 
   # Guard: refuse to proceed if the working tree has unresolved conflict markers.

--- a/scripts/development-workflow/run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/run-epic-delegated-gate.sh
@@ -109,6 +109,39 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     end;
   def implementation_branch:
     (.pr.headRefName // "") | test("^(feature|fix|refactor|hotfix|backport/hotfix)/");
+  def stage_rank($stage):
+    if $stage == "spec" then 1
+    elif $stage == "plan" then 2
+    elif $stage == "implementation" then 3
+    else 0 end;
+  def stage_from_branch($branch):
+    if ($branch | test("^spec/")) then "spec"
+    elif ($branch | test("^implementation-plan/")) then "plan"
+    elif ($branch | test("^(feature|fix|refactor|hotfix|backport/hotfix)/")) then "implementation"
+    else "implementation" end;
+  def checkpoint_list:
+    if ((.checkpoint_policy.effective // null) | type) == "array" then .checkpoint_policy.effective
+    elif ((.checkpointPolicy.effective // null) | type) == "array" then .checkpointPolicy.effective
+    elif ((policy.effectivePolicy.checkpoints // null) | type) == "array" then policy.effectivePolicy.checkpoints
+    elif ((policy.checkpoints // null) | type) == "array" then policy.checkpoints
+    else [] end;
+  def item_number:
+    (.item.number // .item.issue_number // .item.issueNumber // null);
+  def checkpoint_applies($cp; $item; $prStage):
+    ($item != null)
+    and (($cp.item_number | tonumber) == ($item | tonumber))
+    and (($cp.satisfaction_state // "pending") == "pending")
+    and (stage_rank($cp.stage) > 0)
+    and (stage_rank($cp.stage) <= stage_rank($prStage));
+  def pending_checkpoints:
+    (stage_from_branch(.pr.headRefName // "")) as $prStage |
+    (item_number) as $item |
+    checkpoint_list
+    | map(select(checkpoint_applies(.; $item; $prStage)));
+  def checkpoint_reason($cp):
+    "human checkpoint pending for issue #" + (($cp.item_number // item_number) | tostring) +
+    " " + (($cp.stage // "unknown") | tostring) + "/" + (($cp.domain // "unknown") | tostring) +
+    ": " + (($cp.required_human_action // $cp.reason // "human confirmation required") | tostring);
   def risk_merge_permitted:
     if (.risk // {}) | has("mergePermitted") then .risk.mergePermitted
     elif (.risk // {}) | has("merge_permitted") then .risk.merge_permitted
@@ -143,6 +176,13 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
   (if has_label("needs-setup")
    then add_reason($reasons; "needs-setup label is present")
    else $reasons end) as $reasons |
+  (pending_checkpoints) as $pendingCheckpoints |
+  (if ($pendingCheckpoints | length) > 0
+   then $reasons + ($pendingCheckpoints | map(checkpoint_reason(.)))
+   else $reasons end) as $reasons |
+  (if has_label("human-checkpoint-required") and (($pendingCheckpoints | length) == 0)
+   then add_reason($reasons; "human-checkpoint-required label is present; record satisfied or waived checkpoint evidence and remove the label before delegated merge")
+   else $reasons end) as $reasons |
   (if ((.statusChecks // []) | length) == 0
    then add_reason($reasons; "required CI state is missing")
    else $reasons end) as $reasons |
@@ -172,7 +212,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     decision: (
       if $count == 0 then "merge_allowed"
       elif ($reasons | any(test("reviewer blocking|CI checks|unresolved blocking|advisories"))) then "fix_required"
-      elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog"))) then "human_required"
+      elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog|human checkpoint|human-checkpoint"))) then "human_required"
       else "blocked"
       end
     ),
@@ -181,6 +221,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     nextAction: (
       if $count == 0 then "record merge evidence and use the repository merge protocol"
       elif ($reasons | any(test("reviewer blocking|CI checks|unresolved blocking|advisories"))) then "remove readiness labels, fix, rerun validation, reviewer loop, CI loop, and this gate"
+      elif ($reasons | any(test("human checkpoint|human-checkpoint"))) then "stop for the named human checkpoint action, record satisfied or waived evidence, sync labels, and rerun this gate"
       elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog"))) then "stop for human authority or setup before mutating"
       else "block until required state is available"
       end

--- a/scripts/development-workflow/run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/run-epic-delegated-gate.sh
@@ -139,7 +139,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     checkpoint_list
     | map(select(checkpoint_applies(.; $item; $prStage)));
   def checkpoint_reason($cp):
-    "human checkpoint pending for issue #" + (($cp.item_number // item_number) | tostring) +
+    "human_checkpoint_required: issue #" + (($cp.item_number // item_number) | tostring) +
     " " + (($cp.stage // "unknown") | tostring) + "/" + (($cp.domain // "unknown") | tostring) +
     ": " + (($cp.required_human_action // $cp.reason // "human confirmation required") | tostring);
   def risk_merge_permitted:
@@ -181,7 +181,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
    then $reasons + ($pendingCheckpoints | map(checkpoint_reason(.)))
    else $reasons end) as $reasons |
   (if has_label("human-checkpoint-required") and (($pendingCheckpoints | length) == 0)
-   then add_reason($reasons; "human-checkpoint-required label is present; record satisfied or waived checkpoint evidence and remove the label before delegated merge")
+   then add_reason($reasons; "human_checkpoint_required: human-checkpoint-required label is present; record satisfied or waived checkpoint evidence and remove the label before delegated merge")
    else $reasons end) as $reasons |
   (if ((.statusChecks // []) | length) == 0
    then add_reason($reasons; "required CI state is missing")
@@ -212,7 +212,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     decision: (
       if $count == 0 then "merge_allowed"
       elif ($reasons | any(test("reviewer blocking|CI checks|unresolved blocking|advisories"))) then "fix_required"
-      elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog|human checkpoint|human-checkpoint"))) then "human_required"
+      elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog|human_checkpoint_required|human-checkpoint"))) then "human_required"
       else "blocked"
       end
     ),
@@ -221,7 +221,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     nextAction: (
       if $count == 0 then "record merge evidence and use the repository merge protocol"
       elif ($reasons | any(test("reviewer blocking|CI checks|unresolved blocking|advisories"))) then "remove readiness labels, fix, rerun validation, reviewer loop, CI loop, and this gate"
-      elif ($reasons | any(test("human checkpoint|human-checkpoint"))) then "stop for the named human checkpoint action, record satisfied or waived evidence, sync labels, and rerun this gate"
+      elif ($reasons | any(test("human_checkpoint_required|human-checkpoint"))) then "stop for the named human checkpoint action, record satisfied or waived evidence, sync labels, and rerun this gate"
       elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog"))) then "stop for human authority or setup before mutating"
       else "block until required state is available"
       end

--- a/scripts/development-workflow/tests/test-batch-merge-checkpoints.sh
+++ b/scripts/development-workflow/tests/test-batch-merge-checkpoints.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# test-batch-merge-checkpoints.sh - Unit tests for batch merge checkpoint guards.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+HELPER="$REPO_ROOT/scripts/development-workflow/batch-merge.sh"
+
+TMP_ROOT="$(mktemp -d)"
+MOCK_BIN="$TMP_ROOT/bin"
+CALL_LOG="$TMP_ROOT/gh-calls.log"
+mkdir -p "$MOCK_BIN"
+: > "$CALL_LOG"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+cat > "$MOCK_BIN/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_GH_CALL_LOG"
+case "$*" in
+  auth\ status)
+    exit 0
+    ;;
+  pr\ list\ --base\ develop\ --label\ ready-for-human-review\ --state\ open\ --json\ number\ --jq\ .[].number)
+    printf '42\n43\n'
+    ;;
+  pr\ view\ 42\ --json\ number,title,headRefName,baseRefName,labels,createdAt,isDraft)
+    cat <<'JSON'
+{"number":42,"title":"checkpointed PR","headRefName":"feature/42-checkpointed","baseRefName":"develop","labels":[{"name":"ready-for-human-review"},{"name":"ready-for-regression"},{"name":"human-checkpoint-required"}],"createdAt":"2026-06-22T12:00:00Z","isDraft":false}
+JSON
+    ;;
+  pr\ view\ 43\ --json\ number,title,headRefName,baseRefName,labels,createdAt,isDraft)
+    cat <<'JSON'
+{"number":43,"title":"clean PR","headRefName":"feature/43-clean","baseRefName":"develop","labels":[{"name":"ready-for-human-review"},{"name":"ready-for-regression"}],"createdAt":"2026-06-22T12:01:00Z","isDraft":false}
+JSON
+    ;;
+  pr\ view\ 42\ --json\ headRefName,baseRefName,state,labels,isDraft)
+    cat <<'JSON'
+{"headRefName":"feature/42-checkpointed","baseRefName":"develop","state":"OPEN","labels":[{"name":"ready-for-human-review"},{"name":"ready-for-regression"},{"name":"human-checkpoint-required"}],"isDraft":false}
+JSON
+    ;;
+  pr\ diff\ 42\ --name-only|pr\ diff\ 43\ --name-only)
+    printf 'scripts/example.sh\n'
+    ;;
+  *)
+    printf 'unexpected gh invocation: gh %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+MOCK_GH
+chmod +x "$MOCK_BIN/gh"
+export PATH="$MOCK_BIN:$PATH"
+export MOCK_GH_CALL_LOG="$CALL_LOG"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+echo ""
+echo "=== Batch merge checkpoint guards ==="
+
+discover_stderr="$TMP_ROOT/discover.err"
+discover_output="$("$HELPER" discover 2>"$discover_stderr")"
+run_test "discovery_warns_about_checkpoint" "yes" "$(grep -q 'human-checkpoint-required' "$discover_stderr" && echo yes || echo no)"
+run_test "discovery_skips_checkpointed_pr" "no" "$(grep -q '^PR_NUMBER=42$' <<< "$discover_output" && echo yes || echo no)"
+run_test "discovery_keeps_clean_pr" "yes" "$(grep -q '^PR_NUMBER=43$' <<< "$discover_output" && echo yes || echo no)"
+
+include_output="$("$HELPER" discover --include-checkpointed --prs 42)"
+run_test "explicit_checkpoint_include_emits_candidate" "yes" "$(grep -q '^PR_NUMBER=42$' <<< "$include_output" && echo yes || echo no)"
+run_test "explicit_checkpoint_candidate_marks_flag" "true" "$(awk -F= '$1=="PR_HAS_HUMAN_CHECKPOINT"{print $2; exit}' <<< "$include_output")"
+
+set +e
+merge_output="$("$HELPER" merge --pr 42 2>&1)"
+merge_status=$?
+set -e
+run_test "merge_refuses_checkpoint_label_status" "2" "$merge_status"
+run_test "merge_refuses_checkpoint_label_message" "yes" "$(grep -q 'human-checkpoint-required' <<< "$merge_output" && echo yes || echo no)"
+
+echo ""
+echo "=== Summary ==="
+echo "Passed: $PASS_COUNT"
+echo "Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
@@ -259,6 +259,22 @@ run_test "risk_gate_accepts_classifier_shape" "merge_allowed" "$(decision_for "$
 missing_risk_fixture="$(write_fixture missing-risk 'del(.risk)')"
 run_test "missing_risk_gate_requires_human" "human_required" "$(decision_for "$missing_risk_fixture")"
 
+pending_checkpoint_fixture="$(write_fixture pending-checkpoint '.item.number = 1023 | .pr.headRefName = "feature/1023-human-checkpoint-gates" | .policy.checkpoints = [{"item_number":1023,"stage":"implementation","domain":"technical","reason":"sensitive merge gate behavior","required_human_action":"approve delegated gate checkpoint handling","satisfaction_state":"pending"}]')"
+run_test "pending_checkpoint_requires_human" "human_required" "$(decision_for "$pending_checkpoint_fixture")"
+run_test "pending_checkpoint_reason_names_action" "true" "$(reason_match_for "$pending_checkpoint_fixture" "approve delegated gate checkpoint handling")"
+
+satisfied_checkpoint_fixture="$(write_fixture satisfied-checkpoint '.item.number = 1023 | .pr.headRefName = "feature/1023-human-checkpoint-gates" | .policy.checkpoints = [{"item_number":1023,"stage":"implementation","domain":"technical","reason":"sensitive merge gate behavior","required_human_action":"approve delegated gate checkpoint handling","satisfaction_state":"satisfied","satisfied_by":"lhpaul"}]')"
+run_test "satisfied_checkpoint_allows_merge" "merge_allowed" "$(decision_for "$satisfied_checkpoint_fixture")"
+
+other_item_checkpoint_fixture="$(write_fixture other-item-checkpoint '.item.number = 1023 | .pr.headRefName = "feature/1023-human-checkpoint-gates" | .policy.checkpoints = [{"item_number":9999,"stage":"implementation","domain":"technical","reason":"other item","required_human_action":"ignore","satisfaction_state":"pending"}]')"
+run_test "other_item_checkpoint_does_not_block" "merge_allowed" "$(decision_for "$other_item_checkpoint_fixture")"
+
+future_stage_checkpoint_fixture="$(write_fixture future-stage-checkpoint '.item.number = 1023 | .pr.headRefName = "implementation-plan/1023-human-checkpoint-gates" | .policy.checkpoints = [{"item_number":1023,"stage":"implementation","domain":"technical","reason":"future implementation review","required_human_action":"approve implementation","satisfaction_state":"pending"}]')"
+run_test "future_stage_checkpoint_does_not_block" "merge_allowed" "$(decision_for "$future_stage_checkpoint_fixture")"
+
+stale_checkpoint_label_fixture="$(write_fixture stale-checkpoint-label '.pr.labels += ["human-checkpoint-required"]')"
+run_test "stale_checkpoint_label_requires_human" "human_required" "$(decision_for "$stale_checkpoint_label_fixture")"
+
 audit_fixture="$(write_fixture audit-missing '.pr.auditDispositionPresent = false')"
 run_test "audit_required_before_merge" "blocked" "$(decision_for "$audit_fixture")"
 


### PR DESCRIPTION
## Summary
- block delegated run-epic merges when pending checkpoint evidence applies or the checkpoint label is still present
- make batch merge discovery skip checkpointed PRs by default and hard-refuse stale checkpoint labels at merge time
- document protocol 94 and guardrails stop-condition handling, with focused shell coverage for batch merge checkpoint guards

## Internal Review
- Codex review against REVIEW.md found one named-stop consistency gap; fixed in `fix(checkpoints): name human checkpoint stop condition`.
- Remaining verdict: APPROVED.

## Validation
- TMPDIR="$PWD/.tmp/test-tmp" bash scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
- TMPDIR="$PWD/.tmp/test-tmp" bash scripts/development-workflow/tests/test-batch-merge-checkpoints.sh
- TMPDIR="$PWD/.tmp/test-tmp" bash scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
- TMPDIR="$PWD/.tmp/test-tmp" bash scripts/development-workflow/tests/test-run-epic-audit-trail.sh
- python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop-run-epic-human-checkpoints
- npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md" "docs/workflow/development-workflow/guardrails.md" "docs/workflow/development-workflow/guardrails-enforcement.md" "CHANGELOG.md"
- bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md
- find docs/workflow/development-workflow/protocols -name "94-batch-merge-protocol.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md

Closes #1023

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge and delegated-gate behavior on the critical path to production; mistakes could block legitimate merges or allow stale labels, but scope is workflow scripts/docs with focused tests and fail-closed checks.
> 
> **Overview**
> Adds **`human_checkpoint_required`** as a baseline stop and wires it through delegated `/run-epic` merge gates and **batch merge** so PRs cannot merge while checkpoint policy is pending or the **`human-checkpoint-required`** label is still present.
> 
> **`run-epic-delegated-gate.sh`** now evaluates effective checkpoint policy (pending checkpoints scoped by item, stage, and branch), surfaces named `human_checkpoint_required` reasons, routes those cases to **`human_required`**, and blocks merge when the label remains without matching pending policy.
> 
> **`batch-merge.sh`** emits **`PR_HAS_HUMAN_CHECKPOINT`**, skips checkpointed PRs in discovery by default (with **`--include-checkpointed`** for explicit inspection), and **hard-refuses** merge if the checkpoint label is still on the PR.
> 
> **Protocol 94** and **guardrails** docs describe discovery warnings, readiness prompts (`skipped_human_checkpoint`), and the new stop condition. **CHANGELOG** and shell tests cover batch-merge checkpoint guards and delegated-gate checkpoint scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5b58dbee78f76fc3eafb67ce527191af31f6168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->