### PR TITLE
docs(checkpoints): document human checkpoint lifecycle

### DIFF
--- a/.agents/skills/run-epic/SKILL.md
+++ b/.agents/skills/run-epic/SKILL.md
@@ -26,12 +26,11 @@ This is the Codex command-style alias for Claude Code `/run-epic`.
    `./scripts/development-workflow/run-epic-policy-recommender.sh --scope <resolver-json> --original-command "<requested command>"`
    with any supplied policy flags, including `--no-delegate-review` or
    `--no-may-merge` for explicit negative selections. Present the recommended
-   policy, risk
-   rationale, base branch, scoped items, and copy-paste equivalent command
-   before mutation. Continue in the same run when the human accepts the
-   recommendation or supplies custom values. Exact fully specified invocations
-   may skip the prompt but still record original, recommended, selected, and
-   effective policy in later audit evidence.
+   policy, checkpoint policy, risk rationale, base branch, scoped items, and
+   copy-paste equivalent command before mutation. Continue in the same run when
+   the human accepts the recommendation or supplies custom values. Exact fully
+   specified invocations may skip the prompt but still record original,
+   recommended, selected, and effective policy in later audit evidence.
 6. When a later delegated run reaches a candidate PR merge decision, run
    `./scripts/development-workflow/run-epic-risk-classifier.sh --pr <pr-number>`
    with the invocation's `--max-risk` before merge. The classifier is also

--- a/.agents/skills/run-epic/SKILL.md
+++ b/.agents/skills/run-epic/SKILL.md
@@ -38,7 +38,7 @@ This is the Codex command-style alias for Claude Code `/run-epic`.
    readiness-label, or repository merge-protocol checks.
 7. After delegated review, fix, merge, block, or escalation decisions, use
    `./scripts/development-workflow/run-epic-audit-trail.sh` to create or update
-   stable PR disposition and epic ledger comments:
+   stable PR disposition and epic ledger comments, including checkpoint state:
    - `render-pr-disposition --input <file>`
    - `apply-pr-disposition --input <file> --pr <pr-number>`
    - `render-epic-ledger --input <file>`

--- a/.claude/commands/run-epic.md
+++ b/.claude/commands/run-epic.md
@@ -26,13 +26,13 @@ Key responsibilities:
 - Keep the command read-only: no tracker updates, branches, PRs, merges, issue
   closure, or cleanup.
 - When autonomy policy is missing or ambiguous, run the read-only policy
-  recommender, present the recommended config in-place, and continue the same
-  run when the human accepts or customizes it.
+  recommender, present the recommended config and checkpoint policy in-place,
+  and continue the same run when the human accepts or customizes it.
 - Before any later delegated merge decision, run the PR risk classifier and
   respect its `--max-risk` gate.
 - After delegated review, fix, merge, block, or escalation decisions, update
   stable PR disposition and epic ledger audit comments, including original,
-  recommended, selected, and effective policy.
+  recommended, selected, and effective policy plus checkpoint state.
 - Before merge, run the delegated gate with current scope, policy, reviewer,
   CI, risk, and audit evidence. Merge only when it reports `merge_allowed`.
 

--- a/.cursor/commands/run-epic.md
+++ b/.cursor/commands/run-epic.md
@@ -26,13 +26,13 @@ Key responsibilities:
 - Keep the command read-only: no tracker updates, branches, PRs, merges, issue
   closure, or cleanup.
 - When autonomy policy is missing or ambiguous, run the read-only policy
-  recommender, present the recommended config in-place, and continue the same
-  run when the human accepts or customizes it.
+  recommender, present the recommended config and checkpoint policy in-place,
+  and continue the same run when the human accepts or customizes it.
 - Before any later delegated merge decision, run the PR risk classifier and
   respect its `--max-risk` gate.
 - After delegated review, fix, merge, block, or escalation decisions, update
   stable PR disposition and epic ledger audit comments, including original,
-  recommended, selected, and effective policy.
+  recommended, selected, and effective policy plus checkpoint state.
 - Before merge, run the delegated gate with current scope, policy, reviewer,
   CI, risk, and audit evidence. Merge only when it reports `merge_allowed`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Human checkpoint lifecycle documentation** (#1024): adds an end-to-end
+  smoke-test runbook for checkpoint recommendation, readiness labels,
+  satisfaction detection, delegated gate blocking, batch merge handling, audit
+  evidence, and command-surface guidance.
 - **Human checkpoint merge gates** (#1023): delegated `/run-epic` merge gates and
   batch merge discovery now block unsatisfied `human-checkpoint-required` PRs
   until checkpoint satisfaction or waiver evidence is recorded and labels are synced.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -19,6 +19,11 @@ Before running anything:
 1. **Read the smoke test runbook** — provided by the human or located under `docs/testing/` (e.g. `docs/testing/[app]/[feature].smoke-test.md`).
 2. **Read the application source** for the pages under test — selectors, form structure, component patterns.
 
+Workflow-framework smoke tests live under `docs/testing/workflow/`. For
+delegated `/run-epic` human-checkpoint behavior, use
+[`workflow/1024-human-checkpoint-lifecycle.smoke-test.md`](workflow/1024-human-checkpoint-lifecycle.smoke-test.md)
+as the end-to-end lifecycle runbook.
+
 ---
 
 ## 2. Choose Execution Approach

--- a/docs/testing/workflow/1024-human-checkpoint-lifecycle.smoke-test.md
+++ b/docs/testing/workflow/1024-human-checkpoint-lifecycle.smoke-test.md
@@ -1,0 +1,211 @@
+# Smoke Test Runbook: Human Checkpoint Lifecycle
+
+**Feature**: Human Checkpoint Lifecycle
+**Spec**:
+[1_1020-human-checkpoint-policy-model_specs.md](../../specs/developments/20260622164905_1020-human-checkpoint-policy-model/1_1020-human-checkpoint-policy-model_specs.md)
+**Created in**: In Development stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+- [ ] You are reviewing the implementation PR for #1024.
+- [ ] The PR targets `develop-run-epic-human-checkpoints`.
+- [ ] The implementation branch includes the merged work for #1021, #1022, and
+      #1023.
+- [ ] Fixture tests are available and do not require live GitHub mutation.
+
+---
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| Policy recommender | `scripts/development-workflow/run-epic-policy-recommender.sh` |
+| Checkpoint lifecycle helper | `scripts/development-workflow/run-epic-checkpoint-lifecycle.sh` |
+| Delegated gate | `scripts/development-workflow/run-epic-delegated-gate.sh` |
+| Batch merge helper | `scripts/development-workflow/batch-merge.sh` |
+| Audit helper | `scripts/development-workflow/run-epic-audit-trail.sh` |
+| Run-epic protocol | `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` |
+| Readiness signal protocol | `docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md` |
+| Batch merge protocol | `docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify Policy Recommendation and Initial Summary
+
+**Maps to**: issue requirements 1, 2, and 3.
+
+1. Run the policy recommender fixture tests.
+2. Confirm eligible items with schema, migration, data-model, product ambiguity,
+   product/technical tradeoff, auth, permission, security, or sensitive-change
+   wording produce `effectivePolicy.checkpoints`.
+3. Confirm the run-epic protocol and command wrappers tell agents to present
+   checkpoint policy in the initial preflight summary alongside autonomy policy,
+   base branch, risk rationale, scoped items, and copy-paste command.
+
+**Expected result**: A `/run-epic` preflight makes checkpoint policy visible
+before any branch, tracker, PR, label, comment, or merge mutation.
+
+### Step 2: Verify Plan-Stage Database or Schema Checkpoint
+
+**Maps to**: issue requirement 2.
+
+1. Inspect the run-epic protocol examples.
+2. Confirm database schema, migration, or persistent data-model wording maps to
+   a `plan` / `technical` checkpoint.
+3. Confirm the required human action names plan approval, such as approving the
+   migration and rollback plan.
+4. Confirm an implementation-stage PR for the same item remains blocked while
+   the earlier plan-stage checkpoint is still `pending`.
+
+**Expected result**: Schema and migration work asks for human plan review before
+implementation can be delegated through merge.
+
+### Step 3: Verify Implementation-Stage Sensitive-Change Checkpoint
+
+**Maps to**: issue requirements 2 and 4.
+
+1. Inspect the run-epic protocol examples and policy recommender fixtures.
+2. Confirm auth, permission, security-sensitive automation, or merge behavior
+   wording maps to an `implementation` / `technical` checkpoint.
+3. Confirm the required human action names approval of the sensitive
+   implementation before delegated merge.
+
+**Expected result**: Sensitive implementation work cannot pass delegated review
+or merge solely because CI and automated reviewers are clean.
+
+### Step 4: Verify PR Readiness Label Lifecycle
+
+**Maps to**: issue requirements 1 and 4.
+
+1. Run the checkpoint lifecycle helper fixture tests.
+2. Confirm an applicable pending checkpoint applies `human-checkpoint-required`
+   and records a stable `<!-- run-epic:checkpoint-status -->` PR comment.
+3. Confirm `ready-for-human-review` may coexist with
+   `human-checkpoint-required` when automation is clean but a checkpoint remains
+   open.
+4. Confirm satisfaction via human approval/comment, or waiver with rationale,
+   removes `human-checkpoint-required` only after checkpoint state becomes
+   `satisfied` or `waived`.
+
+**Expected result**: Readiness labels distinguish automation-clean from
+checkpoint-satisfied state.
+
+### Step 5: Verify Delegated Gate Blocking
+
+**Maps to**: issue requirements 1 and 4.
+
+1. Run the delegated gate fixture tests.
+2. Confirm a pending checkpoint for the PR's item and current or earlier stage
+   returns `human_required`.
+3. Confirm the stop reason includes `human_checkpoint_required`, the affected
+   issue number, stage, domain, and required human action.
+4. Confirm satisfied checkpoints, future-stage checkpoints, and checkpoints for
+   other items do not block an otherwise clean PR.
+
+**Expected result**: Delegated merge cannot bypass an unsatisfied declared
+checkpoint.
+
+### Step 6: Verify Batch Merge Handling
+
+**Maps to**: issue requirements 1 and 4.
+
+1. Run the batch merge checkpoint fixture tests.
+2. Confirm discovery warns and skips PRs labeled `human-checkpoint-required` by
+   default, even when `ready-for-human-review` is present.
+3. Confirm explicit discovery can surface checkpointed PRs for protocol handling
+   with `--include-checkpointed`.
+4. Confirm merge mode refuses a stale `human-checkpoint-required` label.
+
+**Expected result**: Batch merge does not silently merge checkpointed PRs.
+
+### Step 7: Verify Audit Evidence
+
+**Maps to**: issue requirements 1 and 4.
+
+1. Run the audit trail fixture tests.
+2. Confirm PR disposition output includes invocation policy, checkpoint policy,
+   satisfaction states, pending applicable checkpoint count, reviewer outcome,
+   CI outcome, risk classification, and final decision.
+3. Confirm epic ledger output scopes checkpoints by item and updates marker
+   comments in place.
+
+**Expected result**: Delegated checkpoint decisions leave reproducible audit
+evidence without duplicate comments.
+
+### Step 8: Run Automated Validation
+
+**Maps to**: all issue requirements and acceptance criteria.
+
+1. Run:
+
+   ```bash
+   bash scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+   bash scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+   bash scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
+   bash scripts/development-workflow/tests/test-batch-merge-checkpoints.sh
+   bash scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+   python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop-run-epic-human-checkpoints
+   npx markdownlint-cli2 "docs/testing/workflow/1024-human-checkpoint-lifecycle.smoke-test.md" "docs/workflow/development-workflow/protocols/95-run-epic-protocol.md" "docs/testing/README.md" ".agents/skills/run-epic/SKILL.md" ".claude/commands/run-epic.md" ".cursor/commands/run-epic.md" "CHANGELOG.md"
+   find docs/testing/workflow -name "1024-human-checkpoint-lifecycle.smoke-test.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md
+   ```
+
+2. Confirm all commands pass.
+
+**Expected result**: Policy recommendation, readiness labels, satisfaction
+detection, delegated gate blocking, batch merge handling, audit output, shell
+quality, and documentation formatting are validated together.
+
+---
+
+## Assertions Checklist
+
+- [ ] Policy recommendation exposes checkpoints before mutation.
+- [ ] Plan-stage database/schema checkpoints are documented with a technical
+      approval action.
+- [ ] Implementation-stage sensitive-change checkpoints are documented with a
+      technical approval action.
+- [ ] Pending checkpoints apply `human-checkpoint-required` without replacing
+      `ready-for-human-review`.
+- [ ] Satisfied or waived checkpoints remove `human-checkpoint-required` only
+      with audit evidence.
+- [ ] Delegated gate returns `human_required` for applicable pending
+      checkpoints.
+- [ ] Batch merge discovery warns and skips checkpointed PRs by default.
+- [ ] Batch merge refuses stale checkpoint labels at merge time.
+- [ ] PR disposition and epic ledger audit output include checkpoint policy and
+      satisfaction state.
+- [ ] Command wrappers mention checkpoint policy in the initial run summary.
+
+---
+
+## Seed Data Reference
+
+No persistent seed data is required. Fixture tests create temporary checkpoint
+policy, PR label, reviewer, CI, delegated gate, batch merge, and audit inputs.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| No checkpoints appear in preflight output | Item metadata lacks a high-leverage signal or the checkpoint policy was not carried from recommender output | Add explicit checkpoint policy with `--checkpoints-file` or update metadata signals when appropriate. |
+| `human-checkpoint-required` disappears after a fix cycle | Label sync treated `needs-fixes` removal as satisfaction | Rerun lifecycle tests and require `satisfied` or `waived` checkpoint state before removing the label. |
+| Delegated gate blocks with no concrete action | Stop reason omitted checkpoint metadata | Include `human_checkpoint_required`, item number, stage, domain, and `required_human_action`. |
+| Batch merge includes checkpointed PRs silently | Discovery skipped the checkpoint-label filter | Verify `PR_HAS_HUMAN_CHECKPOINT` output and default skip behavior. |
+| Audit comments duplicate | Stable marker lookup failed | Reuse `<!-- run-epic:pr-disposition -->`, `<!-- run-epic:epic-ledger -->`, and `<!-- run-epic:checkpoint-status -->`. |
+
+---
+
+## Known Limitations
+
+- The smoke test uses fixture-backed shell tests for mutation-sensitive paths.
+  Live GitHub runs should use disposable PRs and should not bypass checkpoint
+  satisfaction by manually deleting labels.
+- Checkpoints are scoped to delegated epic policy. Non-epic single-item runs do
+  not receive checkpoint policy unless an orchestrator supplies it explicitly.

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -123,9 +123,23 @@ array with `--checkpoints-file <json-array>`; waived entries must include
 supplied, confirmation is required before mutation — silent auto-waiver is not
 permitted.
 
-Enforcement of checkpoints at PR readiness labels and delegated merge gates is
-implemented in follow-up items #1022 and #1023; this step only recommends and
-records policy.
+The preflight summary must show checkpoint policy alongside autonomy policy so
+the human can accept, customize, or waive checkpoints before mutation. Two common
+examples:
+
+- **Plan-stage database/schema checkpoint**: an item titled "Add tenant billing
+  migrations" should recommend a `plan` / `technical` checkpoint with a required
+  action such as "approve the migration and rollback plan". A later
+  implementation PR remains blocked until that plan-stage checkpoint is
+  `satisfied` or `waived`.
+- **Implementation-stage sensitive-change checkpoint**: an item touching auth,
+  permissions, security-sensitive automation, or merge behavior should recommend
+  an `implementation` / `technical` checkpoint with a required action such as
+  "approve the sensitive implementation before delegated merge".
+
+Checkpoint enforcement now spans PR readiness labels, delegated gates, batch
+merge, and audit comments. The lifecycle validation path is documented in
+[`docs/testing/workflow/1024-human-checkpoint-lifecycle.smoke-test.md`](../../../testing/workflow/1024-human-checkpoint-lifecycle.smoke-test.md).
 
 When a later delegated run reaches a candidate PR merge decision, classify that
 PR with:


### PR DESCRIPTION
## Summary
- add an end-to-end human checkpoint lifecycle smoke-test runbook for #1024
- update /run-epic command guidance across Codex, Claude, and Cursor surfaces to include checkpoint policy in preflight summaries
- add concrete plan-stage schema and implementation-stage sensitive-change checkpoint examples to protocol 95

## Validation
- TMPDIR="$PWD/.tmp/test-tmp" bash scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
- TMPDIR="$PWD/.tmp/test-tmp" bash scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
- TMPDIR="$PWD/.tmp/test-tmp" bash scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
- TMPDIR="$PWD/.tmp/test-tmp" bash scripts/development-workflow/tests/test-batch-merge-checkpoints.sh
- TMPDIR="$PWD/.tmp/test-tmp" bash scripts/development-workflow/tests/test-run-epic-audit-trail.sh
- python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop-run-epic-human-checkpoints
- npx markdownlint-cli2 "docs/testing/workflow/1024-human-checkpoint-lifecycle.smoke-test.md" "docs/workflow/development-workflow/protocols/95-run-epic-protocol.md" "docs/testing/README.md" ".agents/skills/run-epic/SKILL.md" ".claude/commands/run-epic.md" ".cursor/commands/run-epic.md" "CHANGELOG.md"
- find docs/testing/workflow -name "1024-human-checkpoint-lifecycle.smoke-test.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md
- bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md

Closes #1024

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no workflow script or merge-gate logic modified in this diff.
> 
> **Overview**
> Documents the delegated `/run-epic` **human checkpoint lifecycle** (#1024) so operators and agents can validate behavior without inferring it from prior issues alone.
> 
> A new **`docs/testing/workflow/1024-human-checkpoint-lifecycle.smoke-test.md`** runbook walks through policy recommendation, plan vs implementation checkpoints, `human-checkpoint-required` label behavior, delegated gate blocking, batch merge skips, audit evidence, and a bundled fixture/lint command list. **`docs/testing/README.md`** now points workflow testers at that runbook.
> 
> **Protocol 95** no longer defers checkpoint enforcement to follow-ups; it requires **checkpoint policy in the preflight summary**, adds **plan-stage schema/migration** and **implementation-stage sensitive-change** examples, and links enforcement across readiness labels, delegated gates, batch merge, and audit comments to the smoke test.
> 
> **`.agents/skills/run-epic/SKILL.md`**, **`.claude/commands/run-epic.md`**, and **`.cursor/commands/run-epic.md`** are updated so agents present **checkpoint policy** with autonomy policy before mutation and record **checkpoint state** in audit trail steps. **`CHANGELOG.md`** records the documentation addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf4f51d3bcb85d1ce6b02e05d1654e338733325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->