### PR TITLE
Graduate run-epic-human-checkpoints integration branch to develop

### DIFF
--- a/.agents/skills/run-epic/SKILL.md
+++ b/.agents/skills/run-epic/SKILL.md
@@ -26,12 +26,11 @@ This is the Codex command-style alias for Claude Code `/run-epic`.
    `./scripts/development-workflow/run-epic-policy-recommender.sh --scope <resolver-json> --original-command "<requested command>"`
    with any supplied policy flags, including `--no-delegate-review` or
    `--no-may-merge` for explicit negative selections. Present the recommended
-   policy, risk
-   rationale, base branch, scoped items, and copy-paste equivalent command
-   before mutation. Continue in the same run when the human accepts the
-   recommendation or supplies custom values. Exact fully specified invocations
-   may skip the prompt but still record original, recommended, selected, and
-   effective policy in later audit evidence.
+   policy, checkpoint policy, risk rationale, base branch, scoped items, and
+   copy-paste equivalent command before mutation. Continue in the same run when
+   the human accepts the recommendation or supplies custom values. Exact fully
+   specified invocations may skip the prompt but still record original,
+   recommended, selected, and effective policy in later audit evidence.
 6. When a later delegated run reaches a candidate PR merge decision, run
    `./scripts/development-workflow/run-epic-risk-classifier.sh --pr <pr-number>`
    with the invocation's `--max-risk` before merge. The classifier is also

--- a/.agents/skills/run-epic/SKILL.md
+++ b/.agents/skills/run-epic/SKILL.md
@@ -38,7 +38,7 @@ This is the Codex command-style alias for Claude Code `/run-epic`.
    readiness-label, or repository merge-protocol checks.
 7. After delegated review, fix, merge, block, or escalation decisions, use
    `./scripts/development-workflow/run-epic-audit-trail.sh` to create or update
-   stable PR disposition and epic ledger comments:
+   stable PR disposition and epic ledger comments, including checkpoint state:
    - `render-pr-disposition --input <file>`
    - `apply-pr-disposition --input <file> --pr <pr-number>`
    - `render-epic-ledger --input <file>`

--- a/.claude/commands/run-epic.md
+++ b/.claude/commands/run-epic.md
@@ -26,13 +26,13 @@ Key responsibilities:
 - Keep the command read-only: no tracker updates, branches, PRs, merges, issue
   closure, or cleanup.
 - When autonomy policy is missing or ambiguous, run the read-only policy
-  recommender, present the recommended config in-place, and continue the same
-  run when the human accepts or customizes it.
+  recommender, present the recommended config and checkpoint policy in-place,
+  and continue the same run when the human accepts or customizes it.
 - Before any later delegated merge decision, run the PR risk classifier and
   respect its `--max-risk` gate.
 - After delegated review, fix, merge, block, or escalation decisions, update
   stable PR disposition and epic ledger audit comments, including original,
-  recommended, selected, and effective policy.
+  recommended, selected, and effective policy plus checkpoint state.
 - Before merge, run the delegated gate with current scope, policy, reviewer,
   CI, risk, and audit evidence. Merge only when it reports `merge_allowed`.
 

--- a/.cursor/commands/run-epic.md
+++ b/.cursor/commands/run-epic.md
@@ -26,13 +26,13 @@ Key responsibilities:
 - Keep the command read-only: no tracker updates, branches, PRs, merges, issue
   closure, or cleanup.
 - When autonomy policy is missing or ambiguous, run the read-only policy
-  recommender, present the recommended config in-place, and continue the same
-  run when the human accepts or customizes it.
+  recommender, present the recommended config and checkpoint policy in-place,
+  and continue the same run when the human accepts or customizes it.
 - Before any later delegated merge decision, run the PR risk classifier and
   respect its `--max-risk` gate.
 - After delegated review, fix, merge, block, or escalation decisions, update
   stable PR disposition and epic ledger audit comments, including original,
-  recommended, selected, and effective policy.
+  recommended, selected, and effective policy plus checkpoint state.
 - Before merge, run the delegated gate with current scope, policy, reviewer,
   CI, risk, and audit evidence. Merge only when it reports `merge_allowed`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Human checkpoint PR lifecycle** (#1022): adds `human-checkpoint-required` readiness
+  signal (protocol 92), Step 8a/8c checkpoint label sync in protocol 91,
+  `run-epic-checkpoint-lifecycle.sh` for satisfaction detection and label/comment
+  persistence, and checkpoint policy fields in `run-epic-audit-trail.sh`.
 - **Run-epic checkpoint policy recommendations** (#1021): `run-epic-policy-recommender.sh`
   now emits per-item human checkpoint recommendations from read-only scope metadata,
   supports explicit selection/waiver via `--checkpoints-file`, and records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Human checkpoint merge gates** (#1023): delegated `/run-epic` merge gates and
+  batch merge discovery now block unsatisfied `human-checkpoint-required` PRs
+  until checkpoint satisfaction or waiver evidence is recorded and labels are synced.
 - **Human checkpoint PR lifecycle** (#1022): adds `human-checkpoint-required` readiness
   signal (protocol 92), Step 8a/8c checkpoint label sync in protocol 91,
   `run-epic-checkpoint-lifecycle.sh` for satisfaction detection and label/comment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Run-epic checkpoint policy recommendations** (#1021): `run-epic-policy-recommender.sh`
+  now emits per-item human checkpoint recommendations from read-only scope metadata,
+  supports explicit selection/waiver via `--checkpoints-file`, and records
+  recommended/selected/effective checkpoint policy for audit evidence.
 - **Cursor pilot configuration**: adds Cursor as a Step 7a runner reviewer value,
   supports overriding ready-phase review to Cursor Bugbot from local config,
   exposes `bugbot` in reviewer-loop usage help, and ships project-level Bugbot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Human checkpoint lifecycle documentation** (#1024): adds an end-to-end
+  smoke-test runbook for checkpoint recommendation, readiness labels,
+  satisfaction detection, delegated gate blocking, batch merge handling, audit
+  evidence, and command-surface guidance.
 - **Human checkpoint merge gates** (#1023): delegated `/run-epic` merge gates and
   batch merge discovery now block unsatisfied `human-checkpoint-required` PRs
   until checkpoint satisfaction or waiver evidence is recorded and labels are synced.

--- a/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/1_1020-human-checkpoint-policy-model_specs.md
+++ b/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/1_1020-human-checkpoint-policy-model_specs.md
@@ -171,7 +171,9 @@ or explicit human declaration).
 
 **Postconditions**: Schema- or migration-touching work cannot flow into
 implementation under delegated merge without an explicit plan-stage human
-checkpoint unless the human waived it up front.
+checkpoint unless the human waived it up front. An implementation-stage PR for
+the same item remains blocked by a `pending` plan-stage checkpoint even when
+that PR's automation gates are clean.
 
 **Information shown**:
 
@@ -291,11 +293,12 @@ PRs for the same item.
 **Invariants**:
 
 - **BR-1**: `ready-for-human-review` means automation-clean only.
-- **BR-2**: `human-checkpoint-required` means a stage-applicable checkpoint is
-  still open (`pending`) for the PR's current workflow stage.
+- **BR-2**: `human-checkpoint-required` means a checkpoint on the PR's linked
+  work item is still open (`pending`) at the PR's current workflow stage **or**
+  at an earlier stage in `spec` → `plan` → `implementation`.
 - **BR-3**: A PR may carry both `ready-for-human-review` and
-  `human-checkpoint-required` simultaneously when a stage-applicable checkpoint
-  is `pending`.
+  `human-checkpoint-required` simultaneously when such a checkpoint is
+  `pending`.
 - **BR-4**: Delegated review, delegated merge, and batch merge must treat
   `pending` checkpoints on the PR's linked work item as blocking when the
   checkpoint's `stage` is the PR's current workflow stage **or an earlier stage**

--- a/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/1_1020-human-checkpoint-policy-model_specs.md
+++ b/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/1_1020-human-checkpoint-policy-model_specs.md
@@ -1,0 +1,431 @@
+# Human-Checkpoint Policy Model for Delegated `/run-epic` — Spec
+
+**Epic**: #1019 Add human checkpoints to delegated run-epic work  
+**Depends on**: guardrails configuration model (#977), run-epic policy recommender (#949), PR risk classification (#919)
+
+---
+
+## Overview
+
+Delegated `/run-epic` runs can decide review and merge authority up front through
+guardrails and invocation policy, but they lack a first-class way to declare
+that a specific item must pause for human product or technical feedback when its
+pull request becomes automation-clean. Today, complex or ambiguous work relies
+on ad hoc judgment late in the run — after reviewer loops, CI, and readiness
+labels are already green — which makes it easy for an agent to treat
+`ready-for-human-review` as permission to continue delegated review or merge.
+
+This feature defines a **human-checkpoint policy model** that sits on the
+existing run-epic/guardrails policy path. It does not introduce a parallel
+autonomy system. Instead, it adds checkpoint metadata and a distinct readiness
+signal so orchestration can distinguish:
+
+- **Automation clean** — CI green, internal review gate satisfied, automated
+  reviewers clean or skipped (`ready-for-human-review` semantics).
+- **Human checkpoint still required** — automation is clean, but the epic run
+  must stop and wait for explicit human feedback or approval before delegated
+  review, delegated merge, or batch merge may continue.
+
+The model is classified **before mutation** (during epic scope resolution and
+policy recommendation), carried through PR readiness, and enforced at delegated
+gates. Follow-up work items (#1021–#1024) implement the recommender, lifecycle
+carriers, enforcement gates, and documentation/tests; this spec defines the
+policy shape those items must implement.
+
+---
+
+## Brief Objective List
+
+1. Define checkpoint record fields: stage, domain, reason, required human action,
+   and satisfaction state.
+2. Define how checkpoint intent is selected before mutation from item complexity,
+   ambiguity, and known high-leverage signals.
+3. Document database/schema/migration changes as a default plan-stage checkpoint
+   signal.
+4. Specify how checkpoints interact with `ready-for-human-review`,
+   `needs-fixes`, `needs-setup`, delegated review, delegated merge, and audit
+   comments.
+5. Keep the model on the existing run-epic/guardrails policy path — one policy
+   surface, not two.
+6. Identify the documentation and implementation surfaces for follow-up
+   sub-items.
+
+---
+
+## Use Cases
+
+### Use Case 1: Epic runner classifies checkpoint intent before mutation
+
+**Actor**: Portfolio Orchestrator or Work Item Runner operating under a
+delegated `/run-epic` session  
+**Preconditions**: Epic scope is resolved. Guardrails and invocation policy are
+known or recommended. No artifact-mutating work has started for the item.
+
+**Steps**:
+
+1. The actor evaluates each eligible item using read-only signals: tracker
+   type, title/body keywords, dependency references, ambiguity markers, and
+   known high-leverage categories (schema, migration, architecture, product
+   ambiguity).
+2. For each item that needs a human checkpoint, the actor records one or more
+   checkpoint records with stage, domain, reason, and required human action.
+3. The recommended policy output includes checkpoint metadata alongside existing
+   fields (`delegate-review`, `may-merge`, `may-start-backlog`, `max-risk`).
+4. The human accepts, customizes, or rejects checkpoint recommendations before
+   mutation begins.
+
+**Postconditions**: Every in-scope item has zero or more declared checkpoints
+with a deterministic satisfaction state of `pending`. The epic ledger can record
+original, recommended, selected, and effective checkpoint policy.
+
+**Information shown**:
+
+- Per-item checkpoint list (may be empty).
+- Why each checkpoint was recommended.
+- Which stage and domain each checkpoint applies to.
+- What the human must do to satisfy each checkpoint.
+
+**Actions available**:
+
+- Accept the recommended checkpoints.
+- Add, remove, or edit checkpoints before work starts.
+- Proceed without checkpoints when none are recommended and none are required.
+
+**Considerations**:
+
+- Checkpoint classification is read-only until the human confirms policy.
+- Absence of a checkpoint does not remove baseline stop conditions from
+  guardrails.
+
+---
+
+### Use Case 2: Automation-clean PR still blocks delegated merge
+
+**Actor**: Work Item Runner advancing an item under delegated `/run-epic`  
+**Preconditions**: The item has a `pending` checkpoint for the current stage
+(e.g., `plan`). The PR has passed internal review, automated review, and CI.
+
+**Steps**:
+
+1. The runner applies `ready-for-human-review` because automation gates are
+   clean.
+2. The runner also applies `human-checkpoint-required` (or equivalent distinct
+   signal) because a declared checkpoint for this stage is still `pending`.
+3. Delegated review and delegated merge gates treat the checkpoint as blocking
+   even though the PR is automation-clean.
+4. The human provides the required feedback or approval documented in the
+   checkpoint record.
+5. The runner records checkpoint satisfaction (`satisfied`) with who satisfied
+   it and when.
+6. The runner removes `human-checkpoint-required` and may continue delegated
+   review or merge if all other gates permit.
+
+**Postconditions**: Delegated automation cannot bypass a declared checkpoint
+merely because readiness labels are green.
+
+**Information shown**:
+
+- `ready-for-human-review` — automation is clean.
+- `human-checkpoint-required` — explicit human feedback still required.
+- Checkpoint reason, domain, and required human action on the PR and/or epic
+  ledger.
+- Satisfaction state transitions (`pending` → `satisfied` or `waived`).
+
+**Actions available**:
+
+- Human satisfies the checkpoint with review comments or explicit approval.
+- Human waives the checkpoint with documented rationale (when policy permits).
+- Agent fixes issues if human feedback converts the PR to `needs-fixes`.
+
+**Considerations**:
+
+- `ready-for-human-review` and `human-checkpoint-required` are orthogonal.
+  Both may be present simultaneously.
+- Satisfying a checkpoint does not by itself authorize merge; risk, audit, and
+  other gates still apply.
+
+---
+
+### Use Case 3: Plan-stage checkpoint for schema or migration work
+
+**Actor**: Policy recommender during epic scope resolution  
+**Preconditions**: An eligible item's plan scope will include database schema,
+migration, or persistent data-model changes (detected from issue body, labels,
+or explicit human declaration).
+
+**Steps**:
+
+1. The recommender assigns a default **plan-stage** checkpoint with domain
+   `technical` (or `both` when product impact is unclear).
+2. The reason cites schema/migration/data-model impact.
+3. The required human action asks for technical review of the proposed data
+   model before implementation proceeds.
+4. The checkpoint remains `pending` until the plan PR is reviewed and the human
+   satisfies the checkpoint.
+
+**Postconditions**: Schema- or migration-touching work cannot flow into
+implementation under delegated merge without an explicit plan-stage human
+checkpoint unless the human waived it up front.
+
+**Information shown**:
+
+- Default signal: plan stage, technical domain.
+- Reason template referencing schema/migration/data model.
+- Required action: human review/approval of plan before implementation branch
+  work.
+
+**Actions available**:
+
+- Accept the default plan-stage checkpoint.
+- Narrow domain to `product` when only product semantics are in question.
+- Waive before mutation if the human explicitly accepts risk.
+
+**Considerations**:
+
+- This is a **default signal**, not an absolute rule — humans may waive at
+  policy selection time.
+- Implementation-stage checkpoints may still be added separately for the same
+  item.
+
+---
+
+### Use Case 4: Checkpoint interaction with `needs-fixes` and `needs-setup`
+
+**Actor**: Work Item Runner managing PR labels through a review cycle  
+**Preconditions**: A PR carries `human-checkpoint-required` and one or more
+other readiness labels.
+
+**Steps**:
+
+1. When CI fails or reviewers block, the runner applies `needs-fixes` and
+   removes `ready-for-human-review` per existing protocol.
+2. `human-checkpoint-required` persists while the checkpoint remains `pending`
+   and the declared stage still applies.
+3. When automation is clean again, the runner reapplies
+   `ready-for-human-review`.
+4. If infrastructure dependencies are detected, `needs-setup` may coexist with
+   `ready-for-human-review` and `human-checkpoint-required`.
+5. Delegated merge remains blocked until the checkpoint is `satisfied` or
+   `waived`, regardless of `needs-setup` removal.
+
+**Postconditions**: Checkpoint state survives ordinary fix cycles and coexists
+correctly with existing label semantics.
+
+**Information shown**:
+
+- Valid label combinations and their meanings (see Business Rules).
+- Which label changes do and do not affect checkpoint satisfaction.
+
+**Actions available**:
+
+- Fix code and rerun automation without satisfying the checkpoint.
+- Satisfy checkpoint only after automation is clean unless policy defines an
+  earlier satisfaction point.
+
+**Considerations**:
+
+- `needs-fixes` addresses automation/reviewer failures; checkpoints address
+  human judgment requirements beyond automation cleanliness.
+
+---
+
+## Business Rules
+
+### Checkpoint record shape
+
+Each checkpoint is a structured record with these fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `stage` | `spec` \| `plan` \| `implementation` | Workflow stage the checkpoint applies to. |
+| `domain` | `product` \| `technical` \| `both` | Whether product judgment, technical judgment, or both are required. |
+| `reason` | string | Human-readable explanation of why the checkpoint exists. |
+| `required_human_action` | string | What the human must do (e.g., "approve plan data model", "confirm UX copy", "acknowledge architecture decision"). |
+| `satisfaction_state` | `pending` \| `satisfied` \| `waived` | Whether the checkpoint is open, completed, or explicitly waived. |
+| `satisfied_by` | string (optional) | Actor who satisfied or waived the checkpoint. |
+| `satisfied_at` | timestamp (optional) | When satisfaction or waiver occurred. |
+| `waiver_rationale` | string (optional) | Required when `satisfaction_state` is `waived`. |
+
+An item may have zero or more checkpoints. An epic run carries the union of
+per-item checkpoints in its effective policy.
+
+### Checkpoint selection before mutation
+
+- Checkpoint intent is selected **before any artifact-mutating action** for the
+  item (branch creation, tracker transition beyond read-only, PR open, doc
+  edit on feature branch).
+- Selection inputs include: item type, title/body ambiguity, open questions,
+  dependency on architecture or data-model decisions, explicit `Depends on`
+  references, human-supplied policy overrides, and known high-leverage signals.
+- Known high-leverage signals **default** to checkpoints:
+  - **Plan stage + technical domain**: database schema, migration, or
+    persistent data-model changes.
+  - **Plan or implementation stage + both domains**: ambiguous product and
+    technical tradeoffs called out in the issue.
+  - **Spec stage + product domain**: unresolved product requirements or
+    acceptance-criteria ambiguity when starting from Backlog.
+- The policy recommender proposes checkpoints; the human selects effective
+  checkpoints before mutation. Silent auto-waiver is not permitted for defaulted
+  high-leverage signals unless the human explicitly waives with rationale at
+  policy selection time.
+
+### Readiness labels vs checkpoint signal
+
+| Label / signal | Meaning |
+| --- | --- |
+| `ready-for-human-review` | Automation is clean: CI green, internal review gate satisfied, automated reviewers clean or skipped. Does **not** mean delegated review or merge may proceed when a checkpoint is pending. |
+| `human-checkpoint-required` | A declared checkpoint for the PR's stage is `pending`. Human feedback or approval named in `required_human_action` is still required. |
+| `needs-fixes` | Automation or reviewer feedback requires code/doc fixes. Independent of checkpoint satisfaction except that fixes may be how a human responds. |
+| `needs-setup` | Infrastructure setup is required. May coexist with `ready-for-human-review` and `human-checkpoint-required`. Does not satisfy a checkpoint. |
+
+**Invariants**:
+
+- **BR-1**: `ready-for-human-review` means automation-clean only.
+- **BR-2**: `human-checkpoint-required` means human checkpoint still open.
+- **BR-3**: A PR may carry both `ready-for-human-review` and
+  `human-checkpoint-required` simultaneously.
+- **BR-4**: Delegated review, delegated merge, and batch merge must treat
+  `pending` checkpoints as blocking even when `ready-for-human-review` is
+  present.
+- **BR-5**: Removing `human-checkpoint-required` requires
+  `satisfaction_state` of `satisfied` or `waived` with audit evidence.
+- **BR-6**: `needs-fixes` removal does not imply checkpoint satisfaction.
+- **BR-7**: Checkpoint metadata must appear in epic audit output (PR
+  disposition and epic ledger) alongside existing policy fields.
+
+### Policy path integration
+
+- Checkpoints extend the **existing** run-epic policy object consumed by
+  `run-epic-policy-recommender.sh`, `run-epic-delegated-gate.sh`, and
+  `run-epic-audit-trail.sh`. They do not replace guardrails `mode`,
+  `stages.*`, `stop_conditions`, or risk classification.
+- Guardrails `stop_conditions` (e.g., `architecture_decision`,
+  `unclear_requirements`) remain baseline human-stops. Checkpoints add
+  **stage-scoped, item-specific** human stops declared up front for delegated
+  epic runs.
+- Mapping placement (for follow-up implementation):
+  - Recommender output → `checkpoints[]` on effective policy.
+  - Delegated gate → block when any applicable checkpoint is `pending`.
+  - Audit trail → record original, recommended, selected, effective checkpoints
+    and per-PR satisfaction transitions.
+
+### Satisfaction and waiver
+
+- Only a human (or an explicitly delegated human approval channel documented in
+  the run) may set `satisfied` or `waived`.
+- `waived` requires `waiver_rationale` in audit evidence.
+- Satisfying a checkpoint for stage X does not satisfy checkpoints for other
+  stages on the same item.
+
+---
+
+## Statuses / Enum Values
+
+### `satisfaction_state`
+
+| Code value | Display label | Description |
+| --- | --- | --- |
+| `pending` | Pending | Checkpoint declared; required human action not yet completed. |
+| `satisfied` | Satisfied | Human completed the required action; delegated gates may proceed if all other gates pass. |
+| `waived` | Waived | Human explicitly waived the checkpoint with documented rationale at or before satisfaction time. |
+
+**Valid transitions**:
+
+- `pending` → `satisfied` when the human completes the required action.
+- `pending` → `waived` when the human explicitly waives with rationale.
+- `satisfied` and `waived` are terminal for that checkpoint instance on that
+  PR/stage cycle. A new PR cycle for a later stage may introduce new
+  checkpoints.
+
+### `domain`
+
+| Code value | Display label | Description |
+| --- | --- | --- |
+| `product` | Product | Product judgment, UX, requirements, or acceptance criteria. |
+| `technical` | Technical | Architecture, data model, migrations, security, or implementation approach. |
+| `both` | Product and technical | Both domains must weigh in. |
+
+---
+
+## Operational Visibility
+
+- **Policy recommendation summary**: Before mutation, show recommended
+  checkpoints per item with reasons and required actions.
+- **PR label pair**: When automation-clean but checkpoint pending, show both
+  `ready-for-human-review` and `human-checkpoint-required`.
+- **PR disposition audit**: Include checkpoint list, satisfaction states, and
+  waiver rationales in `<!-- run-epic:pr-disposition -->` comments.
+- **Epic ledger audit**: Include original, recommended, selected, and effective
+  checkpoint policy in `<!-- run-epic:epic-ledger -->` comments.
+- **Stop messages**: Delegated gate stop output must name the blocking checkpoint
+  (`stage`, `domain`, `reason`, `required_human_action`).
+
+---
+
+## Acceptance Criteria
+
+- [ ] AC1: The spec defines checkpoint fields (`stage`, `domain`, `reason`,
+      `required_human_action`, `satisfaction_state`) and optional satisfaction
+      metadata.
+- [ ] AC2: The spec defines pre-mutation checkpoint selection from complexity,
+      ambiguity, and high-leverage signals including schema/migration defaults at
+      plan stage.
+- [ ] AC3: The spec distinguishes `ready-for-human-review` (automation clean)
+      from `human-checkpoint-required` (human feedback still required).
+- [ ] AC4: The spec documents interaction with `needs-fixes`, `needs-setup`,
+      delegated review, delegated merge, batch merge, and audit comments.
+- [ ] AC5: The spec requires checkpoints on the existing run-epic/guardrails
+      policy path without a parallel autonomy model.
+- [ ] AC6: Follow-up implementation plan (#1020 plan stage) identifies files and
+      tests for items #1021–#1024.
+
+---
+
+## Documentation Deliverables (for follow-up items)
+
+The following authoritative docs must describe the checkpoint lifecycle after
+the epic is implemented. This spec is the source requirement; item #1024 owns
+final comprehensive documentation and tests. Intermediate items update targeted
+sections:
+
+| Document | Required content |
+| --- | --- |
+| `95-run-epic-protocol.md` | When checkpoints are recommended, how policy carries them, and gate behavior before delegated review/merge. |
+| `guardrails.md` / `guardrails-enforcement.md` | How checkpoints relate to `stop_conditions`, delegated authority, and audit — without duplicating the policy schema. |
+| `92-pr-readiness-signal-protocol.md` | `human-checkpoint-required` label definition, valid combinations with existing labels, application/removal rules. |
+
+---
+
+## Out of Scope (this spec / #1020)
+
+- Implementing the policy recommender logic (#1021).
+- Applying or removing PR labels in automation (#1022).
+- Enforcing checkpoints in delegated gate or batch merge scripts (#1023).
+- Comprehensive documentation edits and test fixtures (#1024).
+- Non-epic single-item runs (`/run-item-work` without epic policy) unless later
+  extended explicitly.
+- Replacing guardrails `stop_conditions` or PR risk classification.
+
+---
+
+## Follow-Up Item Mapping
+
+| Issue | Scope | Primary surfaces |
+| --- | --- | --- |
+| #1021 | Recommend upfront human checkpoints in run-epic policy | `run-epic-policy-recommender.sh`, recommender tests, protocol 95 policy section |
+| #1022 | Carry checkpoints through PR readiness lifecycle | Protocol 91 Step 8a/8c, protocol 92, item-orchestrator labeling steps |
+| #1023 | Enforce checkpoints in delegated and batch merge gates | `run-epic-delegated-gate.sh`, batch-merge gate, risk classifier interaction |
+| #1024 | Document and test the human-checkpoint lifecycle | Workflow docs, smoke tests, fixture coverage |
+
+---
+
+## Brief Coverage Matrix
+
+| Brief objective | Coverage |
+| --- | --- |
+| Define checkpoint fields | Checkpoint record shape, Statuses / Enum Values, AC1 |
+| Pre-mutation selection from complexity and signals | Use Case 1, Business Rules (selection), AC2 |
+| Schema/migration default plan-stage signal | Use Case 3, AC2 |
+| Interaction with labels, delegated gates, audit | Use Case 2, Use Case 4, Business Rules (labels), AC3, AC4 |
+| Existing policy path only | Business Rules (policy path), AC5 |
+| Implementation identification for follow-up | Follow-Up Item Mapping, Documentation Deliverables, AC6 |

--- a/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/1_1020-human-checkpoint-policy-model_specs.md
+++ b/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/1_1020-human-checkpoint-policy-model_specs.md
@@ -74,8 +74,10 @@ known or recommended. No artifact-mutating work has started for the item.
 4. The human accepts, customizes, or rejects checkpoint recommendations before
    mutation begins.
 
-**Postconditions**: Every in-scope item has zero or more declared checkpoints
-with a deterministic satisfaction state of `pending`. The epic ledger can record
+**Postconditions**: Every in-scope item has zero or more declared checkpoints.
+Recommended checkpoints start as `pending` until policy selection completes; the
+human may waive any checkpoint up front (recording `waived` with rationale) or
+leave them `pending` for later satisfaction. The epic ledger can record
 original, recommended, selected, and effective checkpoint policy.
 
 **Information shown**:

--- a/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/1_1020-human-checkpoint-policy-model_specs.md
+++ b/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/1_1020-human-checkpoint-policy-model_specs.md
@@ -90,11 +90,15 @@ original, recommended, selected, and effective checkpoint policy.
 **Actions available**:
 
 - Accept the recommended checkpoints.
-- Add, remove, or edit checkpoints before work starts.
+- Add or edit checkpoints before work starts.
+- Waive a recommended default checkpoint with documented `waiver_rationale`
+  (recorded as `waived`, not removed).
 - Proceed without checkpoints when none are recommended and none are required.
 
 **Considerations**:
 
+- Removing a defaulted high-leverage checkpoint without recording `waived` and
+  `waiver_rationale` is not permitted.
 - Checkpoint classification is read-only until the human confirms policy.
 - Absence of a checkpoint does not remove baseline stop conditions from
   guardrails.
@@ -239,6 +243,7 @@ Each checkpoint is a structured record with these fields:
 
 | Field | Type | Description |
 | --- | --- | --- |
+| `item_number` | positive integer | Tracker issue number of the work item this checkpoint belongs to. |
 | `stage` | `spec` \| `plan` \| `implementation` | Workflow stage the checkpoint applies to. |
 | `domain` | `product` \| `technical` \| `both` | Whether product judgment, technical judgment, or both are required. |
 | `reason` | string | Human-readable explanation of why the checkpoint exists. |
@@ -249,7 +254,9 @@ Each checkpoint is a structured record with these fields:
 | `waiver_rationale` | string (optional) | Required when `satisfaction_state` is `waived`. |
 
 An item may have zero or more checkpoints. An epic run carries the union of
-per-item checkpoints in its effective policy.
+per-item checkpoints in its effective policy. Gates and labels must scope
+checkpoint evaluation to the PR's linked work item (`item_number`) in addition
+to stage applicability.
 
 ### Checkpoint selection before mutation
 
@@ -276,7 +283,7 @@ per-item checkpoints in its effective policy.
 | Label / signal | Meaning |
 | --- | --- |
 | `ready-for-human-review` | Automation is clean: CI green, internal review gate satisfied, automated reviewers clean or skipped. Does **not** mean delegated review or merge may proceed when a **stage-applicable** checkpoint is `pending`. |
-| `human-checkpoint-required` | A declared checkpoint whose `stage` matches the PR's current workflow stage is `pending`. Human feedback or approval named in `required_human_action` is still required. Checkpoints for future stages do not block the current PR. |
+| `human-checkpoint-required` | A declared checkpoint whose `item_number` matches the PR's linked work item and whose `stage` matches the PR's current workflow stage is `pending`. Human feedback or approval named in `required_human_action` is still required. Checkpoints for other items or future stages do not block the current PR. |
 | `needs-fixes` | Automation or reviewer feedback requires code/doc fixes. Independent of checkpoint satisfaction except that fixes may be how a human responds. |
 | `needs-setup` | Infrastructure setup is required. May coexist with `ready-for-human-review` and `human-checkpoint-required`. Does not satisfy a checkpoint. |
 
@@ -289,9 +296,10 @@ per-item checkpoints in its effective policy.
   `human-checkpoint-required` simultaneously when a stage-applicable checkpoint
   is `pending`.
 - **BR-4**: Delegated review, delegated merge, and batch merge must treat
-  `pending` checkpoints whose `stage` matches the PR's current workflow stage
-  as blocking even when `ready-for-human-review` is present. Future-stage
-  checkpoints declared up front do not block earlier-stage PRs.
+  `pending` checkpoints whose `item_number` matches the PR's linked work item
+  and whose `stage` matches the PR's current workflow stage as blocking even
+  when `ready-for-human-review` is present. Checkpoints for other items or
+  future stages do not block the current PR.
 - **BR-5**: Removing `human-checkpoint-required` requires
   `satisfaction_state` of `satisfied` or `waived` with audit evidence.
 - **BR-6**: `needs-fixes` removal does not imply checkpoint satisfaction.
@@ -310,8 +318,9 @@ per-item checkpoints in its effective policy.
   epic runs.
 - Mapping placement (for follow-up implementation):
   - Recommender output → `checkpoints[]` on effective policy.
-  - Delegated gate → block when any stage-applicable checkpoint (matching the
-    PR's current workflow stage) is `pending`.
+  - Delegated gate → block when any item- and stage-applicable checkpoint
+    (matching the PR's linked work item and current workflow stage) is
+    `pending`.
   - Audit trail → record original, recommended, selected, effective checkpoints
     and per-PR satisfaction transitions.
 
@@ -370,9 +379,9 @@ per-item checkpoints in its effective policy.
 
 ## Acceptance Criteria
 
-- [ ] AC1: The spec defines checkpoint fields (`stage`, `domain`, `reason`,
-      `required_human_action`, `satisfaction_state`) and optional satisfaction
-      metadata.
+- [ ] AC1: The spec defines checkpoint fields (`item_number`, `stage`, `domain`,
+      `reason`, `required_human_action`, `satisfaction_state`) and optional
+      satisfaction metadata.
 - [ ] AC2: The spec defines pre-mutation checkpoint selection from complexity,
       ambiguity, and high-leverage signals including schema/migration defaults at
       plan stage.

--- a/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/1_1020-human-checkpoint-policy-model_specs.md
+++ b/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/1_1020-human-checkpoint-policy-model_specs.md
@@ -255,8 +255,9 @@ Each checkpoint is a structured record with these fields:
 
 An item may have zero or more checkpoints. An epic run carries the union of
 per-item checkpoints in its effective policy. Gates and labels must scope
-checkpoint evaluation to the PR's linked work item (`item_number`) in addition
-to stage applicability.
+checkpoint evaluation to the PR's linked work item (`item_number`) and apply
+stage-order rules: a `pending` checkpoint at an earlier stage blocks later-stage
+PRs for the same item.
 
 ### Checkpoint selection before mutation
 
@@ -283,7 +284,7 @@ to stage applicability.
 | Label / signal | Meaning |
 | --- | --- |
 | `ready-for-human-review` | Automation is clean: CI green, internal review gate satisfied, automated reviewers clean or skipped. Does **not** mean delegated review or merge may proceed when a **stage-applicable** checkpoint is `pending`. |
-| `human-checkpoint-required` | A declared checkpoint whose `item_number` matches the PR's linked work item and whose `stage` matches the PR's current workflow stage is `pending`. Human feedback or approval named in `required_human_action` is still required. Checkpoints for other items or future stages do not block the current PR. |
+| `human-checkpoint-required` | The PR's linked work item has at least one `pending` checkpoint that applies to this PR: same `item_number` and either matching the PR's current workflow stage or an earlier stage not yet `satisfied`/`waived`. Human feedback or approval named in `required_human_action` is still required. |
 | `needs-fixes` | Automation or reviewer feedback requires code/doc fixes. Independent of checkpoint satisfaction except that fixes may be how a human responds. |
 | `needs-setup` | Infrastructure setup is required. May coexist with `ready-for-human-review` and `human-checkpoint-required`. Does not satisfy a checkpoint. |
 
@@ -296,10 +297,11 @@ to stage applicability.
   `human-checkpoint-required` simultaneously when a stage-applicable checkpoint
   is `pending`.
 - **BR-4**: Delegated review, delegated merge, and batch merge must treat
-  `pending` checkpoints whose `item_number` matches the PR's linked work item
-  and whose `stage` matches the PR's current workflow stage as blocking even
-  when `ready-for-human-review` is present. Checkpoints for other items or
-  future stages do not block the current PR.
+  `pending` checkpoints on the PR's linked work item as blocking when the
+  checkpoint's `stage` is the PR's current workflow stage **or an earlier stage**
+  in the ordered sequence `spec` → `plan` → `implementation`. This prevents a
+  later-stage PR from proceeding while an earlier-stage checkpoint remains open.
+  Checkpoints for other items or future stages do not block the current PR.
 - **BR-5**: Removing `human-checkpoint-required` requires
   `satisfaction_state` of `satisfied` or `waived` with audit evidence.
 - **BR-6**: `needs-fixes` removal does not imply checkpoint satisfaction.
@@ -318,9 +320,9 @@ to stage applicability.
   epic runs.
 - Mapping placement (for follow-up implementation):
   - Recommender output → `checkpoints[]` on effective policy.
-  - Delegated gate → block when any item- and stage-applicable checkpoint
-    (matching the PR's linked work item and current workflow stage) is
-    `pending`.
+  - Delegated gate → block when any item-applicable `pending` checkpoint matches
+    the PR's linked work item and is at the PR's current stage or an earlier
+    stage in `spec` → `plan` → `implementation`.
   - Audit trail → record original, recommended, selected, effective checkpoints
     and per-PR satisfaction transitions.
 

--- a/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/1_1020-human-checkpoint-policy-model_specs.md
+++ b/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/1_1020-human-checkpoint-policy-model_specs.md
@@ -273,20 +273,23 @@ per-item checkpoints in its effective policy.
 
 | Label / signal | Meaning |
 | --- | --- |
-| `ready-for-human-review` | Automation is clean: CI green, internal review gate satisfied, automated reviewers clean or skipped. Does **not** mean delegated review or merge may proceed when a checkpoint is pending. |
-| `human-checkpoint-required` | A declared checkpoint for the PR's stage is `pending`. Human feedback or approval named in `required_human_action` is still required. |
+| `ready-for-human-review` | Automation is clean: CI green, internal review gate satisfied, automated reviewers clean or skipped. Does **not** mean delegated review or merge may proceed when a **stage-applicable** checkpoint is `pending`. |
+| `human-checkpoint-required` | A declared checkpoint whose `stage` matches the PR's current workflow stage is `pending`. Human feedback or approval named in `required_human_action` is still required. Checkpoints for future stages do not block the current PR. |
 | `needs-fixes` | Automation or reviewer feedback requires code/doc fixes. Independent of checkpoint satisfaction except that fixes may be how a human responds. |
 | `needs-setup` | Infrastructure setup is required. May coexist with `ready-for-human-review` and `human-checkpoint-required`. Does not satisfy a checkpoint. |
 
 **Invariants**:
 
 - **BR-1**: `ready-for-human-review` means automation-clean only.
-- **BR-2**: `human-checkpoint-required` means human checkpoint still open.
+- **BR-2**: `human-checkpoint-required` means a stage-applicable checkpoint is
+  still open (`pending`) for the PR's current workflow stage.
 - **BR-3**: A PR may carry both `ready-for-human-review` and
-  `human-checkpoint-required` simultaneously.
+  `human-checkpoint-required` simultaneously when a stage-applicable checkpoint
+  is `pending`.
 - **BR-4**: Delegated review, delegated merge, and batch merge must treat
-  `pending` checkpoints as blocking even when `ready-for-human-review` is
-  present.
+  `pending` checkpoints whose `stage` matches the PR's current workflow stage
+  as blocking even when `ready-for-human-review` is present. Future-stage
+  checkpoints declared up front do not block earlier-stage PRs.
 - **BR-5**: Removing `human-checkpoint-required` requires
   `satisfaction_state` of `satisfied` or `waived` with audit evidence.
 - **BR-6**: `needs-fixes` removal does not imply checkpoint satisfaction.
@@ -305,7 +308,8 @@ per-item checkpoints in its effective policy.
   epic runs.
 - Mapping placement (for follow-up implementation):
   - Recommender output → `checkpoints[]` on effective policy.
-  - Delegated gate → block when any applicable checkpoint is `pending`.
+  - Delegated gate → block when any stage-applicable checkpoint (matching the
+    PR's current workflow stage) is `pending`.
   - Audit trail → record original, recommended, selected, effective checkpoints
     and per-PR satisfaction transitions.
 

--- a/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/2_1020-human-checkpoint-policy-model_implementation-plan.md
+++ b/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/2_1020-human-checkpoint-policy-model_implementation-plan.md
@@ -131,10 +131,9 @@ This item (#1020) is **complete** after:
 1. Spec PR merged (PR #1029).
 2. Plan PR merged (this document).
 
-No `feature/*` implementation PR is required for #1020. Tracker should move to
-**Plan Ready** after plan merge, then **Done** or remain open until epic
-completion — per tracker conventions, mark **Plan Ready** and let the epic
-runner advance #1021 next.
+No `feature/*` implementation PR is required for #1020. After plan merge, the Work
+Item Runner sets tracker status to **Done** (plan-only workflow item; no
+implementation stage). The epic runner then advances #1021.
 
 ---
 

--- a/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/2_1020-human-checkpoint-policy-model_implementation-plan.md
+++ b/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/2_1020-human-checkpoint-policy-model_implementation-plan.md
@@ -1,0 +1,169 @@
+# Human-Checkpoint Policy Model for Delegated `/run-epic` — Implementation Plan
+
+**Spec**: [`1_1020-human-checkpoint-policy-model_specs.md`](./1_1020-human-checkpoint-policy-model_specs.md)
+
+---
+
+## Summary
+
+**Approach**: Item #1020 delivers the policy **model** in spec form only. No
+runtime scripts change in this item. This plan maps the spec to four follow-up
+implementation items (#1021–#1024) that extend the existing run-epic/guardrails
+policy path: recommender output, PR readiness labels, delegated/batch merge
+enforcement, and comprehensive docs/tests. Each sub-item owns a narrow slice so
+the epic can land incrementally on
+`develop-run-epic-human-checkpoints`.
+
+**Estimated complexity**: S (plan-only for #1020; aggregate M across #1021–#1024)
+
+**Rationale**: The spec already defines checkpoint fields, stage-order blocking
+rules (`spec` → `plan` → `implementation`), label semantics, and audit
+handoff. Implementation is deliberately split so policy recommendation (#1021),
+lifecycle carriers (#1022), gate enforcement (#1023), and documentation/tests
+(#1024) can merge independently without a monolithic PR.
+
+**Dependencies**: guardrails config model (#977), run-epic policy recommender
+(#949), PR risk classification (#919), guardrails enforcement (#980).
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | on `develop-run-epic-human-checkpoints` after spec PR #1029 merge |
+| Existing policy helpers | `ls scripts/development-workflow/run-epic-*.sh` | `run-epic-policy-recommender.sh`, `run-epic-delegated-gate.sh`, `run-epic-audit-trail.sh`, `run-epic-risk-classifier.sh`, `run-epic-scope-resolver.sh` exist |
+| PR readiness protocol | `grep -n "ready-for-human-review\|needs-setup" docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md` | Label definitions live in protocol 92; `human-checkpoint-required` is net-new |
+| Orchestrator labeling steps | `grep -n "Step 8a\|ready-for-human-review" docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` | Step 8a/8c own readiness label application |
+| Epic protocol policy section | `grep -n "policy-recommender\|delegated-gate" docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` | Policy recommender and delegated gate already documented |
+| No existing checkpoint term | `grep -rn "human-checkpoint" docs/ scripts/` | Net-new except epic issue bodies |
+
+---
+
+## Follow-Up Item Breakdown
+
+### #1021 — Recommend upfront human checkpoints in run-epic policy
+
+**Goal**: Extend `run-epic-policy-recommender.sh` to emit `checkpoints[]` per
+eligible item using read-only signals from scope resolver output.
+
+**Files to change**:
+
+| File | Change |
+| --- | --- |
+| `scripts/development-workflow/run-epic-policy-recommender.sh` | Add checkpoint recommendation logic; output `checkpoints[]` with `item_number`, `stage`, `domain`, `reason`, `required_human_action`, `satisfaction_state` (`pending` or `waived` with rationale) |
+| `scripts/development-workflow/tests/test-run-epic-policy-recommender.sh` | Fixtures for schema/migration default (plan+technical), ambiguity default (spec+product), empty scope, waived-at-selection |
+| `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` | Document checkpoint recommendation step before mutation |
+| `docs/workflow/development-workflow/guardrails-enforcement.md` | Add checkpoint fields to config→policy mapping table (advisory; checkpoints are epic-policy fields, not `.ai-dev-workflow.yaml` schema) |
+
+**Tests**: Unit fixtures in `test-run-epic-policy-recommender.sh`; no mutation
+guards (read-only contract preserved).
+
+---
+
+### #1022 — Carry human checkpoints through PR readiness lifecycle
+
+**Goal**: Apply/remove `human-checkpoint-required` in Protocol 91 alongside
+existing readiness labels; record satisfaction transitions in audit comments.
+
+**Files to change**:
+
+| File | Change |
+| --- | --- |
+| `docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md` | Define `human-checkpoint-required` label, valid combinations, application/removal rules |
+| `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` | Step 8a/8c: evaluate item+stage-order checkpoints; apply label when blocking checkpoints remain `pending` |
+| `scripts/development-workflow/run-epic-audit-trail.sh` | Include checkpoint policy and satisfaction in PR disposition / epic ledger renders |
+| `scripts/development-workflow/tests/test-run-epic-audit-trail.sh` | Fixtures for checkpoint fields in audit output |
+
+**Tests**: Audit trail unit tests; protocol-level smoke assertions in
+`docs/testing/workflow/` (added by #1024).
+
+---
+
+### #1023 — Enforce human checkpoints in delegated and batch merge gates
+
+**Goal**: Block delegated review/merge and batch merge when item-applicable
+`pending` checkpoints remain (current or earlier stage per spec BR-4).
+
+**Files to change**:
+
+| File | Change |
+| --- | --- |
+| `scripts/development-workflow/run-epic-delegated-gate.sh` | Consume `checkpoints[]`; emit `merge_allowed=false` when blocking checkpoints exist |
+| `scripts/development-workflow/tests/test-run-epic-delegated-gate.sh` | Fixtures: same-item earlier-stage pending blocks implementation PR; other-item ignored; satisfied/waived permits |
+| `scripts/development-workflow/batch-merge.sh` (or gate helper it calls) | Honor checkpoint block before merge |
+| `docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md` | Document checkpoint gate in batch merge prerequisites |
+| `scripts/development-workflow/run-epic-risk-classifier.sh` | Optional: classify `pending` checkpoint as hard blocker (align with #919 `blocked` semantics) |
+
+**Tests**: Delegated gate unit tests; risk classifier interaction test if blocker
+added.
+
+---
+
+### #1024 — Document and test the human-checkpoint lifecycle
+
+**Goal**: Authoritative end-user documentation and smoke-test runbook covering
+the full lifecycle from policy selection through satisfaction.
+
+**Files to change**:
+
+| File | Change |
+| --- | --- |
+| `docs/workflow/development-workflow/guardrails.md` | Section relating checkpoints to stop conditions and delegated authority |
+| `docs/workflow/development-workflow/README.md` | Index link; short overview in orchestration section |
+| `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` | Final integrated checkpoint lifecycle section (may consolidate #1021 edits) |
+| `docs/testing/workflow/1020-human-checkpoint-policy-model.smoke-test.md` | New smoke runbook |
+| `CHANGELOG.md` | Entry when implementation items merge (not for spec/plan PRs) |
+
+**Tests**: Smoke runbook manual steps; optional workflow test script mirroring
+`949-run-epic-interactive-autonomy-defaults.smoke-test.md` pattern.
+
+---
+
+## Item #1020 Scope Boundary
+
+This item (#1020) is **complete** after:
+
+1. Spec PR merged (PR #1029).
+2. Plan PR merged (this document).
+
+No `feature/*` implementation PR is required for #1020. Tracker should move to
+**Plan Ready** after plan merge, then **Done** or remain open until epic
+completion — per tracker conventions, mark **Plan Ready** and let the epic
+runner advance #1021 next.
+
+---
+
+## Testing Strategy (epic-level)
+
+| Layer | Coverage |
+| --- | --- |
+| Policy recommender (#1021) | Unit fixtures for default signals and waiver paths |
+| Audit trail (#1022) | Render/apply tests for checkpoint fields |
+| Delegated gate (#1023) | Block/permit matrix: item scope, stage order, satisfaction states |
+| Batch merge (#1023) | Integration test or smoke step confirming checkpoint blocks merge |
+| Docs/smoke (#1024) | Human-executable runbook on a fixture epic |
+
+---
+
+## Rollout Notes
+
+- Introduce `human-checkpoint-required` as a new GitHub label in the template
+  repo (or document that adopters must create it) during #1022.
+- Checkpoint policy is epic-scoped; single-item `/run-item-work` runs without
+  epic policy do not gain checkpoints unless extended in a future item.
+- Default high-leverage signals are **recommendations**; humans must explicitly
+  waive with `waiver_rationale` — never silent removal.
+
+---
+
+## Acceptance Criteria Mapping
+
+| Spec AC | Plan coverage |
+| --- | --- |
+| AC1 checkpoint fields | #1021 recommender output shape; #1022 audit fields |
+| AC2 pre-mutation selection | #1021 recommender signals |
+| AC3 label distinction | #1022 protocol 92 + protocol 91 |
+| AC4 label/gate/audit interaction | #1022 + #1023 |
+| AC5 existing policy path | All items extend existing helpers, no parallel model |
+| AC6 implementation identification | This plan's follow-up breakdown |

--- a/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/2_1020-human-checkpoint-policy-model_implementation-plan.md
+++ b/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/2_1020-human-checkpoint-policy-model_implementation-plan.md
@@ -82,11 +82,17 @@ existing readiness labels; record satisfaction transitions in audit comments.
 
 ### #1023 — Enforce human checkpoints in delegated and batch merge gates
 
-**Goal**: Block delegated review/merge and batch merge when item-applicable
-`pending` checkpoints remain (current or earlier stage per spec BR-4).
+**Goal**: Block delegated review and delegated merge (and batch merge) when
+item-applicable `pending` checkpoints remain (current or earlier stage per spec
+BR-4).
 
 **Files to change**:
 
+| File | Change |
+| --- | --- |
+| `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` | Step 8 delegated-review loop: stop before reviewer dispatch when checkpoints block |
+| `docs/workflow/development-workflow/guardrails-enforcement.md` | Gate 4 (delegated review): add checkpoint block alongside existing stop checks |
+| `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` | Step 7 / delegated-review entry: honor checkpoint block before internal review dispatch |
 | File | Change |
 | --- | --- |
 | `scripts/development-workflow/run-epic-delegated-gate.sh` | Consume `checkpoints[]`; set `mergePermitted=false` and a blocking `decision` (e.g. `human_required`) when checkpoints block |

--- a/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/2_1020-human-checkpoint-policy-model_implementation-plan.md
+++ b/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/2_1020-human-checkpoint-policy-model_implementation-plan.md
@@ -90,14 +90,12 @@ BR-4).
 
 | File | Change |
 | --- | --- |
-| `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` | Step 8 delegated-review loop: stop before reviewer dispatch when checkpoints block |
-| `docs/workflow/development-workflow/guardrails-enforcement.md` | Gate 4 (delegated review): add checkpoint block alongside existing stop checks |
-| `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` | Step 7 / delegated-review entry: honor checkpoint block before internal review dispatch |
-| File | Change |
-| --- | --- |
 | `scripts/development-workflow/run-epic-delegated-gate.sh` | Consume `checkpoints[]`; set `mergePermitted=false` and a blocking `decision` (e.g. `human_required`) when checkpoints block |
 | `scripts/development-workflow/tests/test-run-epic-delegated-gate.sh` | Fixtures: same-item earlier-stage pending blocks implementation PR; other-item ignored; satisfied/waived permits |
 | `scripts/development-workflow/batch-merge.sh` (or gate helper it calls) | Honor checkpoint block before merge |
+| `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` | Step 8 delegated-review loop: stop before reviewer dispatch when checkpoints block |
+| `docs/workflow/development-workflow/guardrails-enforcement.md` | Gate 4 (delegated review): add checkpoint block alongside existing stop checks |
+| `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` | Step 7 / delegated-review entry: honor checkpoint block before internal review dispatch |
 | `docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md` | Document checkpoint gate in batch merge prerequisites |
 | `scripts/development-workflow/run-epic-risk-classifier.sh` | Optional: classify `pending` checkpoint as hard blocker (align with #919 `blocked` semantics) |
 

--- a/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/2_1020-human-checkpoint-policy-model_implementation-plan.md
+++ b/docs/specs/developments/20260622164905_1020-human-checkpoint-policy-model/2_1020-human-checkpoint-policy-model_implementation-plan.md
@@ -89,7 +89,7 @@ existing readiness labels; record satisfaction transitions in audit comments.
 
 | File | Change |
 | --- | --- |
-| `scripts/development-workflow/run-epic-delegated-gate.sh` | Consume `checkpoints[]`; emit `merge_allowed=false` when blocking checkpoints exist |
+| `scripts/development-workflow/run-epic-delegated-gate.sh` | Consume `checkpoints[]`; set `mergePermitted=false` and a blocking `decision` (e.g. `human_required`) when checkpoints block |
 | `scripts/development-workflow/tests/test-run-epic-delegated-gate.sh` | Fixtures: same-item earlier-stage pending blocks implementation PR; other-item ignored; satisfied/waived permits |
 | `scripts/development-workflow/batch-merge.sh` (or gate helper it calls) | Honor checkpoint block before merge |
 | `docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md` | Document checkpoint gate in batch merge prerequisites |

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -19,6 +19,11 @@ Before running anything:
 1. **Read the smoke test runbook** — provided by the human or located under `docs/testing/` (e.g. `docs/testing/[app]/[feature].smoke-test.md`).
 2. **Read the application source** for the pages under test — selectors, form structure, component patterns.
 
+Workflow-framework smoke tests live under `docs/testing/workflow/`. For
+delegated `/run-epic` human-checkpoint behavior, use
+[`workflow/1024-human-checkpoint-lifecycle.smoke-test.md`](workflow/1024-human-checkpoint-lifecycle.smoke-test.md)
+as the end-to-end lifecycle runbook.
+
 ---
 
 ## 2. Choose Execution Approach

--- a/docs/testing/workflow/1024-human-checkpoint-lifecycle.smoke-test.md
+++ b/docs/testing/workflow/1024-human-checkpoint-lifecycle.smoke-test.md
@@ -1,0 +1,211 @@
+# Smoke Test Runbook: Human Checkpoint Lifecycle
+
+**Feature**: Human Checkpoint Lifecycle
+**Spec**:
+[1_1020-human-checkpoint-policy-model_specs.md](../../specs/developments/20260622164905_1020-human-checkpoint-policy-model/1_1020-human-checkpoint-policy-model_specs.md)
+**Created in**: In Development stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+- [ ] You are reviewing the implementation PR for #1024.
+- [ ] The PR targets `develop-run-epic-human-checkpoints`.
+- [ ] The implementation branch includes the merged work for #1021, #1022, and
+      #1023.
+- [ ] Fixture tests are available and do not require live GitHub mutation.
+
+---
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| Policy recommender | `scripts/development-workflow/run-epic-policy-recommender.sh` |
+| Checkpoint lifecycle helper | `scripts/development-workflow/run-epic-checkpoint-lifecycle.sh` |
+| Delegated gate | `scripts/development-workflow/run-epic-delegated-gate.sh` |
+| Batch merge helper | `scripts/development-workflow/batch-merge.sh` |
+| Audit helper | `scripts/development-workflow/run-epic-audit-trail.sh` |
+| Run-epic protocol | `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` |
+| Readiness signal protocol | `docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md` |
+| Batch merge protocol | `docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify Policy Recommendation and Initial Summary
+
+**Maps to**: issue requirements 1, 2, and 3.
+
+1. Run the policy recommender fixture tests.
+2. Confirm eligible items with schema, migration, data-model, product ambiguity,
+   product/technical tradeoff, auth, permission, security, or sensitive-change
+   wording produce `effectivePolicy.checkpoints`.
+3. Confirm the run-epic protocol and command wrappers tell agents to present
+   checkpoint policy in the initial preflight summary alongside autonomy policy,
+   base branch, risk rationale, scoped items, and copy-paste command.
+
+**Expected result**: A `/run-epic` preflight makes checkpoint policy visible
+before any branch, tracker, PR, label, comment, or merge mutation.
+
+### Step 2: Verify Plan-Stage Database or Schema Checkpoint
+
+**Maps to**: issue requirement 2.
+
+1. Inspect the run-epic protocol examples.
+2. Confirm database schema, migration, or persistent data-model wording maps to
+   a `plan` / `technical` checkpoint.
+3. Confirm the required human action names plan approval, such as approving the
+   migration and rollback plan.
+4. Confirm an implementation-stage PR for the same item remains blocked while
+   the earlier plan-stage checkpoint is still `pending`.
+
+**Expected result**: Schema and migration work asks for human plan review before
+implementation can be delegated through merge.
+
+### Step 3: Verify Implementation-Stage Sensitive-Change Checkpoint
+
+**Maps to**: issue requirements 2 and 4.
+
+1. Inspect the run-epic protocol examples and policy recommender fixtures.
+2. Confirm auth, permission, security-sensitive automation, or merge behavior
+   wording maps to an `implementation` / `technical` checkpoint.
+3. Confirm the required human action names approval of the sensitive
+   implementation before delegated merge.
+
+**Expected result**: Sensitive implementation work cannot pass delegated review
+or merge solely because CI and automated reviewers are clean.
+
+### Step 4: Verify PR Readiness Label Lifecycle
+
+**Maps to**: issue requirements 1 and 4.
+
+1. Run the checkpoint lifecycle helper fixture tests.
+2. Confirm an applicable pending checkpoint applies `human-checkpoint-required`
+   and records a stable `<!-- run-epic:checkpoint-status -->` PR comment.
+3. Confirm `ready-for-human-review` may coexist with
+   `human-checkpoint-required` when automation is clean but a checkpoint remains
+   open.
+4. Confirm satisfaction via human approval/comment, or waiver with rationale,
+   removes `human-checkpoint-required` only after checkpoint state becomes
+   `satisfied` or `waived`.
+
+**Expected result**: Readiness labels distinguish automation-clean from
+checkpoint-satisfied state.
+
+### Step 5: Verify Delegated Gate Blocking
+
+**Maps to**: issue requirements 1 and 4.
+
+1. Run the delegated gate fixture tests.
+2. Confirm a pending checkpoint for the PR's item and current or earlier stage
+   returns `human_required`.
+3. Confirm the stop reason includes `human_checkpoint_required`, the affected
+   issue number, stage, domain, and required human action.
+4. Confirm satisfied checkpoints, future-stage checkpoints, and checkpoints for
+   other items do not block an otherwise clean PR.
+
+**Expected result**: Delegated merge cannot bypass an unsatisfied declared
+checkpoint.
+
+### Step 6: Verify Batch Merge Handling
+
+**Maps to**: issue requirements 1 and 4.
+
+1. Run the batch merge checkpoint fixture tests.
+2. Confirm discovery warns and skips PRs labeled `human-checkpoint-required` by
+   default, even when `ready-for-human-review` is present.
+3. Confirm explicit discovery can surface checkpointed PRs for protocol handling
+   with `--include-checkpointed`.
+4. Confirm merge mode refuses a stale `human-checkpoint-required` label.
+
+**Expected result**: Batch merge does not silently merge checkpointed PRs.
+
+### Step 7: Verify Audit Evidence
+
+**Maps to**: issue requirements 1 and 4.
+
+1. Run the audit trail fixture tests.
+2. Confirm PR disposition output includes invocation policy, checkpoint policy,
+   satisfaction states, pending applicable checkpoint count, reviewer outcome,
+   CI outcome, risk classification, and final decision.
+3. Confirm epic ledger output scopes checkpoints by item and updates marker
+   comments in place.
+
+**Expected result**: Delegated checkpoint decisions leave reproducible audit
+evidence without duplicate comments.
+
+### Step 8: Run Automated Validation
+
+**Maps to**: all issue requirements and acceptance criteria.
+
+1. Run:
+
+   ```bash
+   bash scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+   bash scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+   bash scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
+   bash scripts/development-workflow/tests/test-batch-merge-checkpoints.sh
+   bash scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+   python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop-run-epic-human-checkpoints
+   npx markdownlint-cli2 "docs/testing/workflow/1024-human-checkpoint-lifecycle.smoke-test.md" "docs/workflow/development-workflow/protocols/95-run-epic-protocol.md" "docs/testing/README.md" ".agents/skills/run-epic/SKILL.md" ".claude/commands/run-epic.md" ".cursor/commands/run-epic.md" "CHANGELOG.md"
+   find docs/testing/workflow -name "1024-human-checkpoint-lifecycle.smoke-test.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md
+   ```
+
+2. Confirm all commands pass.
+
+**Expected result**: Policy recommendation, readiness labels, satisfaction
+detection, delegated gate blocking, batch merge handling, audit output, shell
+quality, and documentation formatting are validated together.
+
+---
+
+## Assertions Checklist
+
+- [ ] Policy recommendation exposes checkpoints before mutation.
+- [ ] Plan-stage database/schema checkpoints are documented with a technical
+      approval action.
+- [ ] Implementation-stage sensitive-change checkpoints are documented with a
+      technical approval action.
+- [ ] Pending checkpoints apply `human-checkpoint-required` without replacing
+      `ready-for-human-review`.
+- [ ] Satisfied or waived checkpoints remove `human-checkpoint-required` only
+      with audit evidence.
+- [ ] Delegated gate returns `human_required` for applicable pending
+      checkpoints.
+- [ ] Batch merge discovery warns and skips checkpointed PRs by default.
+- [ ] Batch merge refuses stale checkpoint labels at merge time.
+- [ ] PR disposition and epic ledger audit output include checkpoint policy and
+      satisfaction state.
+- [ ] Command wrappers mention checkpoint policy in the initial run summary.
+
+---
+
+## Seed Data Reference
+
+No persistent seed data is required. Fixture tests create temporary checkpoint
+policy, PR label, reviewer, CI, delegated gate, batch merge, and audit inputs.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| No checkpoints appear in preflight output | Item metadata lacks a high-leverage signal or the checkpoint policy was not carried from recommender output | Add explicit checkpoint policy with `--checkpoints-file` or update metadata signals when appropriate. |
+| `human-checkpoint-required` disappears after a fix cycle | Label sync treated `needs-fixes` removal as satisfaction | Rerun lifecycle tests and require `satisfied` or `waived` checkpoint state before removing the label. |
+| Delegated gate blocks with no concrete action | Stop reason omitted checkpoint metadata | Include `human_checkpoint_required`, item number, stage, domain, and `required_human_action`. |
+| Batch merge includes checkpointed PRs silently | Discovery skipped the checkpoint-label filter | Verify `PR_HAS_HUMAN_CHECKPOINT` output and default skip behavior. |
+| Audit comments duplicate | Stable marker lookup failed | Reuse `<!-- run-epic:pr-disposition -->`, `<!-- run-epic:epic-ledger -->`, and `<!-- run-epic:checkpoint-status -->`. |
+
+---
+
+## Known Limitations
+
+- The smoke test uses fixture-backed shell tests for mutation-sensitive paths.
+  Live GitHub runs should use disposable PRs and should not bypass checkpoint
+  satisfaction by manually deleting labels.
+- Checkpoints are scoped to delegated epic policy. Non-epic single-item runs do
+  not receive checkpoint policy unless an orchestrator supplies it explicitly.

--- a/docs/workflow/development-workflow/guardrails-enforcement.md
+++ b/docs/workflow/development-workflow/guardrails-enforcement.md
@@ -66,6 +66,14 @@ model — there is **one** policy path, not two.
 | `audit.pr_disposition_record` | PR disposition audit required | `run-epic-audit-trail.sh apply-pr-disposition` (stable marker `<!-- run-epic:pr-disposition -->`) |
 | `audit.work_item_ledger_record` | Item-level ledger required | `run-epic-audit-trail.sh apply-epic-ledger` (stable marker `<!-- run-epic:epic-ledger -->`) when a parent/epic exists; otherwise "not applicable" |
 | `stop_conditions[]` | Named human-stops | Stop-and-name behavior (see section 4); these add to but never weaken the baseline stops |
+| Epic checkpoint policy (`checkpoints[]` on effective policy) | Stage-scoped, item-specific human stops declared before mutation | `run-epic-policy-recommender.sh` output (`recommendedPolicy.checkpoints`, `selectedPolicy.checkpoints`, `effectivePolicy.checkpoints`, `checkpointPolicy`); consumed by delegated gate (#1023) and audit trail (#1022); **not** a `.ai-dev-workflow.yaml` schema field |
+
+Epic human checkpoints extend the same run-epic policy object — they are not
+separate guardrails config fields. The recommender proposes them from read-only
+item metadata; the human selects or waives them before mutation. Audit evidence
+records original, recommended, selected, and effective checkpoint policy via
+`checkpointPolicy` on the recommender JSON output and later PR/epic ledger
+comments.
 
 ### Per-Stage Authority Resolution
 

--- a/docs/workflow/development-workflow/guardrails-enforcement.md
+++ b/docs/workflow/development-workflow/guardrails-enforcement.md
@@ -222,6 +222,7 @@ table is required for consistent stop reporting.
 | `unresolved_blocking_review` | A blocking review thread from a configured automated reviewer or a human reviewer remains unresolved. |
 | `high_risk_change` | The PR is classified above the configured `max_merge_risk` for the stage. |
 | `destructive_action` | The next action would delete branches, data, releases, or other non-recoverable artifacts. |
+| `human_checkpoint_required` | A declared stage-scoped human checkpoint for the PR's work item is still pending, or the PR still carries `human-checkpoint-required`. |
 | `missing_tracker_context` | A required tracker field (status, type, assignee, dependency link) is absent or unresolvable. |
 | `missing_required_secret_or_permission` | A required credential, GitHub permission, or access token is absent. |
 | `guardrails_config_unreadable` | The `guardrails` block in `.ai-dev-workflow.yaml` is missing required fields, uses invalid values, or is internally contradictory. |

--- a/docs/workflow/development-workflow/guardrails.md
+++ b/docs/workflow/development-workflow/guardrails.md
@@ -174,6 +174,7 @@ The following stop conditions are always in force:
 | `unresolved_blocking_review`          | A blocking review thread (from a reviewer or automated tool) is unresolved.            |
 | `high_risk_change`                    | The classified PR risk exceeds the stage's configured `max_merge_risk`.                |
 | `destructive_action`                  | The action would delete branches, data, releases, or other non-recoverable artifacts.  |
+| `human_checkpoint_required`           | A declared stage-scoped human checkpoint is still pending for the PR's work item.      |
 | `missing_tracker_context`             | The work item is missing required tracker metadata (status, type, or linked spec).     |
 | `missing_required_secret_or_permission` | A required credential or GitHub permission is absent.                                |
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1788,6 +1788,49 @@ Before running the readiness checklist below, perform a best-effort scan of the 
 
 5. After the scan: proceed to the readiness checklist below. The presence of `needs-setup` is a valid co-label with `ready-for-human-review` and does **not** block this checklist or prevent `ready-for-human-review` from being applied (BR-3). The checklist script does not check for or remove `needs-setup` — it is a deliberate signal, not a stale label.
 
+### Human Checkpoint Label Sync (pre-readiness)
+
+When the run carries an effective checkpoint policy (`checkpoints[]` on the epic
+invocation policy or a `checkpoint-policy.json` file saved at policy selection
+time), synchronize the `human-checkpoint-required` label and stable PR comment
+**after** CI and automated review are clean and **before** applying
+`ready-for-human-review`. This runs on every pass through Step 8a — including
+after fixer pushes — so label state always reflects current checkpoint
+satisfaction.
+
+**Timing**: Run after the infrastructure dependency scan above and before Check
+4 (`ready-for-human-review` application) in the readiness checklist.
+
+**Procedure**:
+
+1. Resolve the linked work item number (`ITEM_NUMBER`) and branch name
+   (`BRANCH`) for the PR.
+2. Locate the effective checkpoint policy JSON array (from epic handoff metadata,
+   `checkpoint-policy.json` in the run working directory, or
+   `invocation_policy.effective_policy.checkpoints`).
+3. Detect satisfaction from human signals and sync labels:
+
+   ```bash
+   ./scripts/development-workflow/run-epic-checkpoint-lifecycle.sh sync-pr-labels \
+     --pr "$PR_NUMBER" \
+     --item "$ITEM_NUMBER" \
+     --branch "$BRANCH" \
+     --checkpoints-file checkpoint-policy.json \
+     --write-checkpoints-file checkpoint-policy.json
+   ```
+
+4. When `BLOCKING_COUNT` is greater than zero, apply `ready-for-human-review`
+   **and** keep `human-checkpoint-required` (both labels may coexist per
+   protocol 92 BR-11/BR-3). Record checkpoint reason and required human action
+   in the `<!-- run-epic:checkpoint-status -->` comment posted by the script.
+5. When all applicable checkpoints are `satisfied` or `waived`, the script
+   removes `human-checkpoint-required` automatically.
+6. During fix cycles (Step 9): when applying `needs-fixes`, do **not** remove
+   `human-checkpoint-required` while checkpoints remain `pending`.
+
+**Skip condition**: When no checkpoint policy is in scope for this run (no
+`checkpoints[]` and no `checkpoint-policy.json`), skip this subsection.
+
 Run this checklist for **every PR**:
 
 ```bash
@@ -2120,6 +2163,8 @@ Verify all of the following. If any check fails, **do not report ready** — tre
 | `ready-for-regression` label                    | Present in `labels[].name` for `feature/*`, `fix/*`, `refactor/*`, `hotfix/*`, `backport/hotfix/*`; absent/ignored for `spec/*`, `implementation-plan/*`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | No `needs-fixes` label                          | `needs-fixes` absent from `labels[].name`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `needs-setup` label (if present)                | **Valid co-label** — `needs-setup` may be present alongside `ready-for-human-review` when the diff contains infrastructure dependency signals. Its presence does **not** constitute a verification failure and does not block this check. Do not remove it.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `human-checkpoint-required` label (when checkpoints in scope) | When the run carries checkpoint policy for this item: present if and only if applicable checkpoints remain `pending`; absent when all applicable checkpoints are `satisfied` or `waived`. Valid co-label with `ready-for-human-review`. When no checkpoint policy is in scope, ignore this check. |
+| Checkpoint status comment (when checkpoints in scope) | At least one PR comment containing `<!-- run-epic:checkpoint-status -->` whose blocking section matches the current label state. Skip when no checkpoint policy is in scope. |
 | All automated-reviewer `reviewThreads` resolved | GraphQL query above returns empty output — `isResolved: true` (or first comment body contains `✅ Addressed`) for every thread authored by a configured bot login (skip this check only when Step 7 was `skipped` because no review platforms are configured)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | Automated reviewer loop summary                 | At least one comment whose body contains `"Automated Reviewer Loop Summary"`, `"Reviewer Loop Summary"`, or `"No blocking PR feedback"` (skip this check only when Step 7 was `skipped` because no review platforms are configured), and the latest summary's `Result:` line is `clean` or `skipped`. **This is a hard requirement. Agents applying fixes MUST NOT remove or skip this check — the presence of the comment plus a clean/skipped result is the only reliable signal that Step 7 ran to completion successfully. A PR that has `ready-for-human-review` but lacks this comment or has `RESULT=escalate`, `pending_timeout`, `timeout`, `needs_fixes`, or any other non-clean terminal result is in an incomplete state and must re-run Step 7 or escalate.** (Note: the Step 7a summary comment posted by the internal review gate is a distinct comment from a distinct step — it does not satisfy this check. This check targets the external automated reviewer loop summary from Step 7 only.) |
 | CI checks                                       | All required status checks have `state: SUCCESS` or `conclusion: success` in `statusCheckRollup` (no check in `PENDING`, `FAILURE`, or `ERROR` state)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |

--- a/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -14,6 +14,7 @@ This is a **repo-wide definition**. All agents apply these labels consistently.
 | `needs-fixes`            | The PR still needs fixes before it is ready for human review. This may be due to human-requested changes, failing CI, or blocking automated PR feedback.                                                                                                                                                                 |
 | `ready-for-regression`   | Automated code reviews are clean (or skipped). E2e/regression tests should now run. Applied by the orchestrator (Step 7b) on implementation PRs (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`, `backport/hotfix/*`), and by the prepare-release flow (protocol `05`) on **production** release PRs (`release/*` → `main`) only. |
 | `needs-setup`            | PR introduces one or more infrastructure dependencies (env vars, secrets, DNS records, service account tokens, etc.) that require human setup steps before the feature can be safely enabled. Co-exists with `ready-for-human-review`; the human removes this label after completing (or intentionally deferring) setup. |
+| `human-checkpoint-required` | The PR's linked work item has at least one `pending` human checkpoint that applies to this PR: same `item_number` and either matching the PR's current workflow stage or an earlier stage not yet `satisfied`/`waived`. Human feedback or approval named in `required_human_action` is still required. Co-exists with `ready-for-human-review` when automation is clean but a checkpoint remains open. Does **not** satisfy when only `needs-setup` is removed. |
 
 ---
 
@@ -85,6 +86,56 @@ Apply this label when the agent's infrastructure dependency scan (Protocol 91 St
 - **BR-3**: `needs-setup` does not prevent `ready-for-human-review` from being applied, does not block CI from passing, and does not block automated review tools from completing. It co-exists with `ready-for-human-review`.
 - **BR-7**: When the human removes `needs-setup` (Use Case 3 — setup acknowledged), the `## Pre-merge Setup` section remains in the PR body as a historical record. When the agent rescans and finds no infrastructure dependencies (Use Case 4 — dependency removed from diff), the agent removes both the label and the section.
 - **BR-10**: `needs-setup` is distinct from `needs-fixes`. They have different semantics, different lifecycles, and may co-exist. `needs-fixes` signals reviewer-requested code changes; `needs-setup` signals out-of-band human configuration steps.
+
+---
+
+## Conditions for `human-checkpoint-required`
+
+Apply this label when the PR's linked work item has at least one checkpoint in
+`pending` state that applies to this PR's workflow stage or an earlier stage in
+the ordered sequence `spec` → `plan` → `implementation` (see
+`1020-human-checkpoint-policy-model` spec BR-2 and BR-4).
+
+**Who applies it**: The Work Item Runner (Protocol 91 Step 8a) via
+`run-epic-checkpoint-lifecycle.sh sync-pr-labels` after CI and automated review
+are clean and before or alongside applying `ready-for-human-review`.
+
+**Who removes it**: The script removes the label when every applicable
+checkpoint transitions to `satisfied` or `waived` with audit evidence. Removing
+`needs-fixes` or `needs-setup` does **not** remove this label.
+
+**Valid label combinations**:
+
+| Combination                                                         | Meaning                                                                                                                                                       |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ready-for-human-review` only                                       | Automation clean and no open checkpoints apply to this PR                                                                                                       |
+| `ready-for-human-review` + `human-checkpoint-required`              | Automation clean but explicit human checkpoint feedback is still required before delegated review/merge may proceed                                           |
+| `ready-for-human-review` + `needs-setup` + `human-checkpoint-required` | Automation clean, setup steps may still be required, and a checkpoint remains open                                                                         |
+| `needs-fixes` + `human-checkpoint-required`                         | Transitional — automation/reviewer fixes needed; checkpoint state persists independently                                                                    |
+
+**Invariants**:
+
+- **BR-11**: `ready-for-human-review` means automation-clean only; it does not
+  imply checkpoint satisfaction.
+- **BR-12**: `human-checkpoint-required` persists through ordinary fix cycles
+  while the checkpoint remains `pending`.
+- **BR-13**: Removing `human-checkpoint-required` requires `satisfaction_state`
+  of `satisfied` or `waived` with audit evidence recorded in the stable
+  `<!-- run-epic:checkpoint-status -->` PR comment.
+- **BR-14**: `needs-fixes` removal does not imply checkpoint satisfaction.
+
+**Satisfaction signals** (detected on reruns):
+
+- Explicit PR comment:
+  `<!-- run-epic:checkpoint-satisfied:<item>:<stage>:<domain> -->`
+- Explicit waiver comment:
+  `<!-- run-epic:checkpoint-waived:<item>:<stage>:<domain> --> <rationale>`
+- Human PR review approval (`APPROVED`) on a PR whose workflow stage matches
+  the checkpoint's `stage` satisfies **all** pending checkpoints at that stage
+  for the linked item in one action.
+
+The `human-checkpoint-required` GitHub label must exist in the repository's label
+settings before Step 8a can apply it. Suggested color: `#d93f0b` (orange-red).
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
+++ b/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
@@ -54,6 +54,14 @@ Parse the output. Each PR candidate is a block of `KEY=VALUE` lines terminated b
 
   When the user supplied an explicit PR list the script proceeds to per-PR readiness checks regardless of label status (some may not have the `ready-for-human-review` label — those are handled in Step 2).
 
+  If discovery warns that a PR is labeled `human-checkpoint-required`, treat it
+  as skipped until the named checkpoint is satisfied or waived. Do not add it
+  back to the candidate list just because `ready-for-human-review` is present.
+  To inspect an explicitly supplied checkpointed PR in the candidate table after
+  human confirmation, rerun discovery with `--include-checkpointed`; merge mode
+  will still refuse the stale label, so the checkpoint lifecycle helper must
+  record `satisfied` or `waived` evidence and sync labels before the merge step.
+
 ### 1c. Display the candidate summary table
 
 Print a summary table so the human can see what was discovered before any gate or merge:
@@ -91,6 +99,23 @@ For each candidate PR:
    Record the human's decision. If the human does not respond or exits, treat as **skip**.
 
 3. Do not silently skip or silently include an unready PR. The human must explicitly decide.
+
+4. If `PR_HAS_HUMAN_CHECKPOINT=true`, display a warning:
+
+   > **Warning**: PR #N — _title_ — still requires a human checkpoint.
+   > The required action must be completed and recorded before this batch can
+   > merge it.
+   >
+   > - Type **satisfied** only after the checkpoint lifecycle evidence records
+   >   `satisfied` or `waived` and the `human-checkpoint-required` label has
+   >   been synced away.
+   > - Type **skip** to exclude it from this run (outcome:
+   >   `skipped_human_checkpoint`).
+
+   Do not proceed on a verbal "include" alone. The merge helper refuses a stale
+   `human-checkpoint-required` label, so the concrete action is to satisfy or
+   waive the checkpoint, rerun label sync, rerun discovery, and continue only
+   after `PR_HAS_HUMAN_CHECKPOINT=false`.
 
 After Step 2, update the candidate list: remove any PRs the human chose to skip and mark them `skipped_not_ready` in the tracking state.
 

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -86,7 +86,7 @@ When autonomy policy is missing or ambiguous, derive a recommended policy from
 the resolver output before any mutating stage begins:
 
 ```bash
-./scripts/development-workflow/run-epic-policy-recommender.sh --scope <resolver-json> --original-command "<requested command>" [--base <branch>] [--delegate-review|--no-delegate-review] [--may-merge|--no-may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--json]
+./scripts/development-workflow/run-epic-policy-recommender.sh --scope <resolver-json> --original-command "<requested command>" [--base <branch>] [--delegate-review|--no-delegate-review] [--may-merge|--no-may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--checkpoints-file <json-array>] [--json]
 ```
 
 The recommender is also read-only. It must not update tracker status, create
@@ -95,6 +95,37 @@ comments. It produces recommended, selected, and effective policy values plus a
 copy-paste equivalent command for audit evidence. Use `--no-delegate-review` or
 `--no-may-merge` when the selected policy explicitly disables a recommended
 positive default.
+
+### Human-checkpoint recommendations
+
+Before mutation, the recommender classifies per-item human checkpoints from
+read-only scope metadata (title, type, labels, tracker status). High-leverage
+signals default to checkpoints:
+
+- **Plan + technical**: database schema, migration, or persistent data-model
+  wording.
+- **Spec + product**: unresolved product or acceptance-criteria ambiguity when
+  the item is still in Backlog or spec stage.
+- **Plan or implementation + both**: ambiguous product/technical tradeoffs.
+- **Implementation + technical**: security, auth, permission, or other
+  sensitive-change wording.
+
+The JSON output includes `recommendedPolicy.checkpoints`,
+`selectedPolicy.checkpoints`, `effectivePolicy.checkpoints`, and
+`checkpointPolicy` (`recommended`, `selected`, `effective`) for audit evidence.
+Each checkpoint record carries `item_number`, `stage`, `domain`, `reason`,
+`required_human_action`, and `satisfaction_state` (`pending` by default).
+
+Humans may accept recommendations as-is, customize them, or waive defaults with
+documented rationale before mutation begins. Pass an explicit selected checkpoint
+array with `--checkpoints-file <json-array>`; waived entries must include
+`waiver_rationale`. When recommendations exist and no `--checkpoints-file` is
+supplied, confirmation is required before mutation — silent auto-waiver is not
+permitted.
+
+Enforcement of checkpoints at PR readiness labels and delegated merge gates is
+implemented in follow-up items #1022 and #1023; this step only recommends and
+records policy.
 
 When a later delegated run reaches a candidate PR merge decision, classify that
 PR with:
@@ -286,14 +317,18 @@ Recommended defaults should favor the most automatic safe configuration:
 - `--max-risk medium` for workflow scripts, orchestration behavior, merge or
   cleanup automation, or shared workflow tooling when later
   `why_safe_to_merge` evidence can be produced.
+- Human-checkpoint recommendations per eligible item when metadata signals
+  schema/migration, product ambiguity, tradeoff ambiguity, or sensitive
+  implementation work (see **Human-checkpoint recommendations** above).
 - Never recommend `high` by default. High-risk work requires explicit human
   selection.
 
 Present a preflight summary before mutation: scoped issues, grouped states,
-base branch, recommended policy, risk rationale, and the copy-paste equivalent
-command. If confirmation is required, ask in-place and continue in the same run
-when the human accepts. Do not ask repeatedly for the same policy choice within
-the same invocation once selected/effective policy has been recorded.
+base branch, recommended policy, recommended checkpoints (if any), risk
+rationale, and the copy-paste equivalent command. If confirmation is required,
+ask in-place and continue in the same run when the human accepts. Do not ask
+repeatedly for the same policy choice within the same invocation once
+selected/effective policy has been recorded.
 
 Exact invocations with all effective policy values already supplied may skip the
 confirmation prompt, but they still record the original command, recommended

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -123,9 +123,23 @@ array with `--checkpoints-file <json-array>`; waived entries must include
 supplied, confirmation is required before mutation — silent auto-waiver is not
 permitted.
 
-Enforcement of checkpoints at PR readiness labels and delegated merge gates is
-implemented in follow-up items #1022 and #1023; this step only recommends and
-records policy.
+The preflight summary must show checkpoint policy alongside autonomy policy so
+the human can accept, customize, or waive checkpoints before mutation. Two common
+examples:
+
+- **Plan-stage database/schema checkpoint**: an item titled "Add tenant billing
+  migrations" should recommend a `plan` / `technical` checkpoint with a required
+  action such as "approve the migration and rollback plan". A later
+  implementation PR remains blocked until that plan-stage checkpoint is
+  `satisfied` or `waived`.
+- **Implementation-stage sensitive-change checkpoint**: an item touching auth,
+  permissions, security-sensitive automation, or merge behavior should recommend
+  an `implementation` / `technical` checkpoint with a required action such as
+  "approve the sensitive implementation before delegated merge".
+
+Checkpoint enforcement now spans PR readiness labels, delegated gates, batch
+merge, and audit comments. The lifecycle validation path is documented in
+[`docs/testing/workflow/1024-human-checkpoint-lifecycle.smoke-test.md`](../../../testing/workflow/1024-human-checkpoint-lifecycle.smoke-test.md).
 
 When a later delegated run reaches a candidate PR merge decision, classify that
 PR with:

--- a/scripts/development-workflow/batch-merge.sh
+++ b/scripts/development-workflow/batch-merge.sh
@@ -11,6 +11,7 @@
 #   # --- Discovery mode ---
 #   ./scripts/development-workflow/batch-merge.sh [--base <branch>] discover
 #   ./scripts/development-workflow/batch-merge.sh [--base <branch>] discover --prs 101,102,103
+#   ./scripts/development-workflow/batch-merge.sh [--base <branch>] discover --include-checkpointed --prs 101,102,103
 #
 #   # --- Per-PR merge mode ---
 #   ./scripts/development-workflow/batch-merge.sh [--base <branch>] merge --pr 101
@@ -30,6 +31,7 @@
 #   PR_READY_LABEL=true|false
 #   PR_IS_DRAFT=true|false
 #   PR_HAS_NEEDS_FIXES=true|false
+#   PR_HAS_HUMAN_CHECKPOINT=true|false
 #   PR_HAS_CHANGELOG=true|false
 #   PR_CREATED_AT=<ISO-8601>
 #   PR_ORDER=<1-based index in merge order>
@@ -84,12 +86,17 @@ TARGET_BASE="${TARGET_BASE:-develop}"
 usage() {
   cat >&2 <<'EOF'
 Usage:
-  batch-merge.sh [--base <branch>] discover [--prs <num1,num2,...>]
+  batch-merge.sh [--base <branch>] discover [--include-checkpointed] [--prs <num1,num2,...>]
   batch-merge.sh [--base <branch>] merge --pr <number>
   batch-merge.sh [--base <branch>] delete-branch --pr <number>
 
   --base  Target integration branch (default: develop).
           Override when merging PRs into an epic integration branch.
+
+  --include-checkpointed
+          Discovery only. Include PRs labeled human-checkpoint-required in the
+          candidate output after protocol-level confirmation. Merge mode still
+          refuses that label until checkpoint satisfaction evidence removes it.
 EOF
   exit 2
 }
@@ -112,7 +119,7 @@ fetch_pr_meta() {
     return 1
   }
 
-  local number title branch base created_at labels_csv ready_label is_draft has_needs_fixes
+  local number title branch base created_at labels_csv ready_label is_draft has_needs_fixes has_human_checkpoint
 
   number="$(printf '%s' "$json" | jq -r '.number')"
   title="$(printf '%s' "$json" | jq -r '.title')"
@@ -131,6 +138,11 @@ fetch_pr_meta() {
   else
     has_needs_fixes="false"
   fi
+  if printf '%s' "$json" | jq -r '.labels[].name' | grep -q '^human-checkpoint-required$'; then
+    has_human_checkpoint="true"
+  else
+    has_human_checkpoint="false"
+  fi
 
   # Check whether the PR diff touches CHANGELOG.md
   local has_changelog="false"
@@ -146,6 +158,7 @@ fetch_pr_meta() {
   print_kv PR_READY_LABEL    "$ready_label"
   print_kv PR_IS_DRAFT       "$is_draft"
   print_kv PR_HAS_NEEDS_FIXES "$has_needs_fixes"
+  print_kv PR_HAS_HUMAN_CHECKPOINT "$has_human_checkpoint"
   print_kv PR_HAS_CHANGELOG  "$has_changelog"
   print_kv PR_CREATED_AT     "$created_at"
 }
@@ -156,9 +169,14 @@ fetch_pr_meta() {
 
 cmd_discover() {
   local explicit_prs=""
+  local include_checkpointed="false"
 
   while [ $# -gt 0 ]; do
     case "$1" in
+      --include-checkpointed)
+        include_checkpointed="true"
+        shift
+        ;;
       --prs)
         [ $# -ge 2 ] && [ -n "${2:-}" ] || die "--prs requires a comma-separated value (e.g. --prs 101,102)"
         explicit_prs="$2"
@@ -239,11 +257,12 @@ cmd_discover() {
       continue
     fi
 
-    local base has_changelog is_draft has_needs_fixes
+    local base has_changelog is_draft has_needs_fixes has_human_checkpoint
     base="$(printf '%s\n' "$meta" | awk -F'=' '$1=="PR_BASE"{print $2}')"
     has_changelog="$(printf '%s\n' "$meta" | awk -F'=' '$1=="PR_HAS_CHANGELOG"{print $2}')"
     is_draft="$(printf '%s\n' "$meta" | awk -F'=' '$1=="PR_IS_DRAFT"{print $2}')"
     has_needs_fixes="$(printf '%s\n' "$meta" | awk -F'=' '$1=="PR_HAS_NEEDS_FIXES"{print $2}')"
+    has_human_checkpoint="$(printf '%s\n' "$meta" | awk -F'=' '$1=="PR_HAS_HUMAN_CHECKPOINT"{print $2}')"
 
     # Filter: only target develop (explicit mode may include any PR numbers)
     if [ "$base" != "$TARGET_BASE" ]; then
@@ -260,6 +279,14 @@ cmd_discover() {
     # Filter: skip PRs labeled needs-fixes (review cycle not complete)
     if [ "$has_needs_fixes" = "true" ]; then
       echo "WARNING: PR #${pr_num} is labeled needs-fixes — skipping" >&2
+      continue
+    fi
+
+    # Filter: skip unsatisfied human checkpoints unless the caller has already
+    # completed the protocol-level checkpoint confirmation path. Merge mode has
+    # a second hard guard and will still refuse a stale checkpoint label.
+    if [ "$has_human_checkpoint" = "true" ] && [ "$include_checkpointed" != "true" ]; then
+      echo "WARNING: PR #${pr_num} is labeled human-checkpoint-required — skipping until the named checkpoint is satisfied or waived and labels are synced" >&2
       continue
     fi
 
@@ -520,6 +547,10 @@ cmd_merge() {
 
   if printf '%s' "$pr_json" | jq -e '.labels[].name | select(. == "needs-fixes")' >/dev/null 2>&1; then
     merge_die "PR #${pr_num} is labeled needs-fixes"
+  fi
+
+  if printf '%s' "$pr_json" | jq -e '.labels[].name | select(. == "human-checkpoint-required")' >/dev/null 2>&1; then
+    merge_die "PR #${pr_num} is labeled human-checkpoint-required — satisfy or waive the checkpoint, record audit evidence, and sync labels before merging"
   fi
 
   # Guard: refuse to proceed if the working tree has unresolved conflict markers.

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1300,12 +1300,12 @@ run_bugbot_review() {
     [ -z "${review_json:-}" ] && continue
     body="$(printf '%s\n' "$review_json" | jq -r '.body')"
     _rv_state="$(printf '%s\n' "$review_json" | jq -r '.state // ""')"
-    [ -z "$body" ] && continue
     if [ "$_rv_state" = "CHANGES_REQUESTED" ]; then
       existing_blocking_count=$((existing_blocking_count + 1))
       printf '%s\n' "$review_json" >> "$existing_blocking_file"
       continue
     fi
+    [ -z "$body" ] && continue
     if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
       existing_suggestion_count=$((existing_suggestion_count + 1))
       continue
@@ -1594,9 +1594,10 @@ run_bugbot_review() {
             body="$(printf '%s\n' "$review_json" | jq -r '.body')"
             local _rv_state
             _rv_state="$(printf '%s\n' "$review_json" | jq -r '.state // ""')"
-            [ -z "$body" ] && continue
             if [ "$_rv_state" = "CHANGES_REQUESTED" ]; then
               : # requested changes are always blocking regardless of body text
+            elif [ -z "$body" ]; then
+              continue
             elif is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
               suggestion_count=$((suggestion_count + 1))
               comment_count=$((comment_count + 1))

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1288,7 +1288,7 @@ run_bugbot_review() {
     body="$(printf '%s\n' "$comment_json" | jq -r '.body')"
     [ -z "$body" ] && continue
     # Bugbot informational notes are counted as suggestions, not blockers (AC-4).
-    if is_soft_suggestion "$body"; then
+    if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
       existing_suggestion_count=$((existing_suggestion_count + 1))
       continue
     fi
@@ -1299,8 +1299,14 @@ run_bugbot_review() {
   while IFS= read -r review_json; do
     [ -z "${review_json:-}" ] && continue
     body="$(printf '%s\n' "$review_json" | jq -r '.body')"
+    _rv_state="$(printf '%s\n' "$review_json" | jq -r '.state // ""')"
     [ -z "$body" ] && continue
-    if is_soft_suggestion "$body"; then
+    if [ "$_rv_state" = "CHANGES_REQUESTED" ]; then
+      existing_blocking_count=$((existing_blocking_count + 1))
+      printf '%s\n' "$review_json" >> "$existing_blocking_file"
+      continue
+    fi
+    if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
       existing_suggestion_count=$((existing_suggestion_count + 1))
       continue
     fi
@@ -1476,7 +1482,7 @@ run_bugbot_review() {
             body="$(printf '%s\n' "$comment_json" | jq -r '.body')"
             [ -z "$body" ] && continue
             comment_count=$((comment_count + 1))
-            if is_soft_suggestion "$body"; then
+            if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
               suggestion_count=$((suggestion_count + 1))
             else
               blocking_count=$((blocking_count + 1))
@@ -1574,7 +1580,7 @@ run_bugbot_review() {
             body="$(printf '%s\n' "$comment_json" | jq -r '.body')"
             [ -z "$body" ] && continue
             comment_count=$((comment_count + 1))
-            if is_soft_suggestion "$body"; then
+            if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
               suggestion_count=$((suggestion_count + 1))
             else
               blocking_count=$((blocking_count + 1))
@@ -1589,7 +1595,9 @@ run_bugbot_review() {
             local _rv_state
             _rv_state="$(printf '%s\n' "$review_json" | jq -r '.state // ""')"
             [ -z "$body" ] && continue
-            if is_soft_suggestion "$body"; then
+            if [ "$_rv_state" = "CHANGES_REQUESTED" ]; then
+              : # requested changes are always blocking regardless of body text
+            elif is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
               suggestion_count=$((suggestion_count + 1))
               comment_count=$((comment_count + 1))
               continue

--- a/scripts/development-workflow/run-epic-audit-trail.sh
+++ b/scripts/development-workflow/run-epic-audit-trail.sh
@@ -80,6 +80,24 @@ table_cell_filter='
     | gsub("\\t"; " ");
 '
 
+checkpoint_stage_filter='
+  def stage_rank($stage):
+    if $stage == "spec" then 1
+    elif $stage == "plan" then 2
+    elif $stage == "implementation" then 3
+    else 0 end;
+  def stage_from_branch($branch):
+    if ($branch | test("^spec/")) then "spec"
+    elif ($branch | test("^implementation-plan/")) then "plan"
+    elif ($branch | test("^(feature|fix|refactor|hotfix|backport/hotfix)/")) then "implementation"
+    else "implementation" end;
+  def checkpoint_applies($cp; $item; $prStage):
+    (($cp.item_number | tonumber) == ($item | tonumber))
+    and ($cp.satisfaction_state // "pending") == "pending"
+    and (stage_rank($cp.stage) > 0)
+    and (stage_rank($cp.stage) <= stage_rank($prStage));
+'
+
 render_pr_disposition() {
   local json="$1"
   local missing
@@ -142,6 +160,55 @@ render_pr_disposition() {
         " | " + (($r[$field] // "") | cell) +
         " | " + (($s[$field] // "") | cell) +
         " | " + (($e[$field] // "") | cell) + " |"
+      '
+    fi
+    printf '\n### Checkpoint Policy\n\n'
+    if [ "$(printf '%s\n' "$json" | jq 'if (.checkpoint_policy // .checkpointPolicy // null) == null then 0 else 1 end')" -eq 0 ]; then
+      printf 'Not recorded.\n'
+    else
+      printf '%s\n' "$json" | jq -r "$checkpoint_stage_filter"'
+        (.checkpoint_policy // .checkpointPolicy // {}) as $cp |
+        (.item.number) as $itemNum |
+        (.pr.branch // "") as $branch |
+        ((.pr.stage // "") as $stage |
+          if ($branch | length) > 0 then stage_from_branch($branch)
+          elif ($stage | length) > 0 then $stage
+          else null end) as $prStage |
+        "- Field source: " + (($cp.field_source // $cp.fieldSource // "unknown") | tostring),
+        "- Pending applicable checkpoints: " + (
+          [($cp.effective // $cp.effectivePolicy // [])[]
+            | select(
+                if $prStage == null then
+                  (.satisfaction_state == "pending" and ((.item_number | tonumber) == ($itemNum | tonumber)))
+                else
+                  checkpoint_applies(.; ($itemNum | tostring); $prStage)
+                end
+              )] | length | tostring
+        )
+      '
+      printf '\n| Item | Stage | Domain | State | Reason | Required action |\n'
+      printf '| --- | --- | --- | --- | --- | --- |\n'
+      printf '%s\n' "$json" | jq -r "$table_cell_filter $checkpoint_stage_filter"'
+        (.checkpoint_policy // .checkpointPolicy // {}) as $cp |
+        (.item.number) as $itemNum |
+        (.pr.branch // "") as $branch |
+        ((.pr.stage // "") as $stage |
+          if ($branch | length) > 0 then stage_from_branch($branch)
+          elif ($stage | length) > 0 then $stage
+          else null end) as $prStage |
+        ($cp.effective // $cp.effectivePolicy // [])[]
+        | select((.item_number | tonumber) == ($itemNum | tonumber))
+        | select(
+            if $prStage == null then true
+            else checkpoint_applies(.; ($itemNum | tostring); $prStage) or (.satisfaction_state // "pending") != "pending"
+            end
+          ) |
+        "| #" + (.item_number | tostring) +
+        " | " + ((.stage // "") | cell) +
+        " | " + ((.domain // "") | cell) +
+        " | " + ((.satisfaction_state // "pending") | cell) +
+        " | " + ((.reason // "") | cell) +
+        " | " + ((.required_human_action // "") | cell) + " |"
       '
     fi
     printf '\n### Advisory Decisions\n\n'
@@ -266,16 +333,32 @@ render_epic_ledger() {
           ", maxRisk=" + (($policy.maxRisk // "") | tostring) +
           ", base=" + (($policy.base // "") | tostring)
         else "" end;
-      def notes_with_policy($base; $policy; $gate):
+      def checkpoint_note($checkpoints):
+        if (($checkpoints | type) == "array") and (($checkpoints | length) > 0) then
+          "Checkpoints: " + (
+            $checkpoints
+            | map("#" + (.item_number|tostring) + " " + (.stage // "") + "/" + (.domain // "") + "=" + (.satisfaction_state // "pending"))
+            | join(", ")
+          )
+        else "" end;
+      def notes_with_policy($base; $policy; $gate; $checkpoints):
         [
           ($base // ""),
           policy_note($policy),
+          checkpoint_note($checkpoints),
           (if (($gate // "") | tostring | length) > 0 then "Stop gate: " + ($gate | tostring) else "" end)
         ]
         | map(select((. | tostring | length) > 0))
         | join("\n");
+      def item_checkpoints($item; $rootPolicy):
+        if (($item.checkpoints // $item.effective_checkpoints // null) != null) then
+          ($item.checkpoints // $item.effective_checkpoints // [])
+        else
+          ($rootPolicy.checkpoints // [] | map(select((.item_number | tonumber) == ($item.issue_number | tonumber))))
+        end;
       .items[] |
       (.effective_policy // .effectivePolicy // $rootEffectivePolicy) as $effectivePolicy |
+      item_checkpoints(.; $rootEffectivePolicy) as $itemCheckpoints |
       (.stop_gate // .stopGate // .final_stop_gate // .finalStopGate // "") as $stopGate |
       "| #" + (.issue_number | tostring) + " " + ((.title // "") | cell) +
       " | " + (if .pr_number then "#" + (.pr_number | tostring) else "-" end) +
@@ -284,7 +367,7 @@ render_epic_ledger() {
       " | " + ((.review_result // "") | cell) +
       " | " + ((.decision // "") | cell) +
       " | " + ((.merge_cleanup // "") | cell) +
-      " | " + (notes_with_policy(.notes; $effectivePolicy; $stopGate) | cell) + " |"
+      " | " + (notes_with_policy(.notes; $effectivePolicy; $stopGate; $itemCheckpoints) | cell) + " |"
     '
   } | redact_text
 }

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -1,0 +1,451 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+# shellcheck source=scripts/development-workflow/workflow-lib.sh
+source "$SCRIPT_DIR/workflow-lib.sh"
+
+CHECKPOINT_MARKER="<!-- run-epic:checkpoint-status -->"
+SATISFIED_MARKER_PREFIX="<!-- run-epic:checkpoint-satisfied:"
+WAIVED_MARKER_PREFIX="<!-- run-epic:checkpoint-waived:"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/development-workflow/run-epic-checkpoint-lifecycle.sh stage-from-branch --branch <name>
+  ./scripts/development-workflow/run-epic-checkpoint-lifecycle.sh evaluate-blocking --item <number> --branch <name> --checkpoints-file <json-array>
+  ./scripts/development-workflow/run-epic-checkpoint-lifecycle.sh detect-satisfaction --item <number> --branch <name> --checkpoints-file <json-array> [--pr <number>]
+  ./scripts/development-workflow/run-epic-checkpoint-lifecycle.sh render-pr-checkpoint-comment --input <file>
+  ./scripts/development-workflow/run-epic-checkpoint-lifecycle.sh sync-pr-labels --pr <number> --item <number> --branch <name> --checkpoints-file <json-array> [--write-checkpoints-file <path>]
+
+Evaluates human-checkpoint policy for a PR, detects satisfaction from human
+review/comment signals, applies or removes human-checkpoint-required, and
+records checkpoint state in a stable PR comment.
+EOF
+}
+
+command="${1:-}"
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+pr_number=""
+item_number=""
+branch_name=""
+checkpoints_file=""
+write_checkpoints_file=""
+input_file=""
+
+error_exit() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_value() {
+  local option="$1"
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ] || [ "${2#--}" != "$2" ]; then
+    echo "$option requires a value." >&2
+    usage >&2
+    exit 64
+  fi
+}
+
+is_positive_int() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    0*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+load_checkpoints_json() {
+  local file="$1"
+  local json
+  if [ ! -f "$file" ]; then
+    error_exit "checkpoints file not found: $file"
+  fi
+  if ! json="$(jq -c '.' "$file" 2>/dev/null)"; then
+    error_exit "checkpoints file is not valid JSON: $file"
+  fi
+  if ! printf '%s\n' "$json" | jq -e 'type == "array"' >/dev/null; then
+    error_exit "checkpoints file must contain a JSON array"
+  fi
+  printf '%s\n' "$json"
+}
+
+checkpoint_jq_filter='
+  def stage_rank($stage):
+    if $stage == "spec" then 1
+    elif $stage == "plan" then 2
+    elif $stage == "implementation" then 3
+    else 0 end;
+  def stage_from_branch($branch):
+    if ($branch | test("^spec/")) then "spec"
+    elif ($branch | test("^implementation-plan/")) then "plan"
+    elif ($branch | test("^(feature|fix|refactor|hotfix|backport/hotfix)/")) then "implementation"
+    else "implementation" end;
+  def checkpoint_key($cp): "\($cp.item_number):\($cp.stage):\($cp.domain)";
+  def checkpoint_applies($cp; $item; $prStage):
+    ($cp.item_number | tonumber) == ($item | tonumber)
+    and ($cp.satisfaction_state // "pending") == "pending"
+    and (stage_rank($cp.stage) > 0)
+    and (stage_rank($cp.stage) <= stage_rank($prStage));
+'
+
+stage_from_branch() {
+  local branch="$1"
+  jq -r --arg branch "$branch" -n "$checkpoint_jq_filter"'stage_from_branch($branch)'
+}
+
+evaluate_blocking_json() {
+  local item="$1"
+  local branch="$2"
+  local checkpoints_json="$3"
+  printf '%s\n' "$checkpoints_json" | jq -c --arg item "$item" --arg branch "$branch" "$checkpoint_jq_filter"'
+    stage_from_branch($branch) as $prStage |
+    [.[] | select(checkpoint_applies(.; $item; $prStage))]
+  '
+}
+
+detect_satisfaction_json() {
+  local item="$1"
+  local branch="$2"
+  local checkpoints_json="$3"
+  local pr="${4:-}"
+
+  local reviews_json comments_json head_sha
+  reviews_json='[]'
+  comments_json='[]'
+  head_sha=""
+
+  if [ -n "$pr" ] && is_positive_int "$pr"; then
+    require_gh
+    if ! reviews_json="$(gh pr view "$pr" --json reviews --jq '.reviews // []' 2>/dev/null)"; then
+      error_exit "failed to read reviews for PR #$pr"
+    fi
+    if ! head_sha="$(gh pr view "$pr" --json headRefOid --jq '.headRefOid // ""' 2>/dev/null)"; then
+      error_exit "failed to read head SHA for PR #$pr"
+    fi
+    local repo
+    repo="$(repo_slug)"
+    if ! comments_json="$(gh api --paginate --slurp "repos/${repo}/issues/${pr}/comments?per_page=100" 2>/dev/null | jq -c '[.[].[]? | {author: (.user.login // ""), body: (.body // ""), createdAt: (.created_at // "")}]' 2>/dev/null)"; then
+      error_exit "failed to read comments for PR #$pr"
+    fi
+  fi
+
+  printf '%s\n' "$checkpoints_json" | jq -c \
+    --arg item "$item" \
+    --arg branch "$branch" \
+    --arg head_sha "$head_sha" \
+    --argjson reviews "$reviews_json" \
+    --argjson comments "$comments_json" \
+    "$checkpoint_jq_filter"'
+    def bot_login($login):
+      ($login // "") as $l |
+      ($l | test("^(coderabbitai|cursor\\[bot\\]|devin-ai-integration|greptile-apps|github-actions|dependabot|renovate|copilot|bot)$"; "i"))
+      or ($l | endswith("[bot]"));
+    def marker_match($body; $prefix; $item; $stage; $domain):
+      ($body // "") | contains($prefix + ($item|tostring) + ":" + $stage + ":" + $domain + " -->");
+    def parse_waiver_rationale($body; $prefix; $item; $stage; $domain):
+      ($body // "")
+      | capture($prefix + ($item|tostring) + ":" + $stage + ":" + $domain + " -->\\s*(?<rationale>.*)$"; "s")
+      | (.rationale // "") | gsub("\\s+$"; "");
+    def latest_human_review:
+      ($reviews // [])
+      | map(select(bot_login(.author.login) | not))
+      | map(select(
+          ($head_sha | length) == 0
+          or ((.commit.oid // "") == $head_sha)
+          or ((.commit // {}).oid? // "" | length) == 0
+        ))
+      | sort_by(.submittedAt // "")
+      | last // null;
+    def review_satisfies($cp):
+      (latest_human_review) as $latest |
+      ($latest != null) and (($latest.state // "") == "APPROVED");
+    def human_comments: ($comments // []) | map(select(bot_login(.author) | not));
+    def waiver_rationale_valid($body; $item; $stage; $domain):
+      (parse_waiver_rationale($body; "'"$WAIVED_MARKER_PREFIX"'"; ($item|tostring); $stage; $domain) | gsub("\\s"; "") | length) > 0;
+    stage_from_branch($branch) as $prStage |
+    map(
+      . as $cp |
+      if ($cp.item_number | tonumber) != ($item | tonumber) then .
+      elif (($cp.satisfaction_state // "pending") != "pending") then .
+      elif (stage_rank($cp.stage) > stage_rank($prStage)) then .
+      else
+        ($cp | del(.satisfaction_state, .satisfied_by, .satisfied_at, .waiver_rationale) | .satisfaction_state = "pending") as $base |
+        $base |
+        human_comments as $commentList |
+        (
+          ($commentList
+            | map(select(
+                marker_match(.body; "'"$WAIVED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain)
+              ))
+            | map(select(waiver_rationale_valid(.body; ($cp.item_number|tostring); $cp.stage; $cp.domain)))
+            | last) as $waivedComment
+          | if $waivedComment then
+              .satisfaction_state = "waived"
+              | .satisfied_by = ($waivedComment.author // "")
+              | .satisfied_at = ($waivedComment.createdAt // "")
+              | .waiver_rationale = (parse_waiver_rationale($waivedComment.body; "'"$WAIVED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain))
+            elif
+              ($commentList
+                | map(select(
+                    marker_match(.body; "'"$SATISFIED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain)
+                  ))
+                | length) > 0
+            then
+              ($commentList
+                | map(select(marker_match(.body; "'"$SATISFIED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain)))
+                | last) as $satisfiedComment
+              | .satisfaction_state = "satisfied"
+              | .satisfied_by = ($satisfiedComment.author // "")
+              | .satisfied_at = ($satisfiedComment.createdAt // "")
+            elif ($cp.stage == $prStage) and review_satisfies($cp) then
+              .satisfaction_state = "satisfied"
+              | .satisfied_by = (latest_human_review | .author.login // "pr_review_approved")
+              | .satisfied_at = (latest_human_review | .submittedAt // "")
+            else .
+            end
+        )
+      end
+    )
+  '
+}
+
+render_pr_checkpoint_comment() {
+  local json="$1"
+  {
+    printf '%s\n' "$CHECKPOINT_MARKER"
+    printf '## Human Checkpoint Status\n\n'
+    printf '%s\n' "$json" | jq -r '
+      "- Item: #" + (.item.number | tostring),
+      "- PR: #" + (.pr.number | tostring),
+      "- Branch: `" + (.pr.branch | tostring) + "`",
+      "- PR workflow stage: " + (.pr.stage | tostring),
+      "- Label required: " + ((.label_required // false) | tostring),
+      "- Label present: " + ((.label_present // false) | tostring)
+    '
+    printf '\n### Checkpoints\n\n'
+    if [ "$(printf '%s\n' "$json" | jq '(.checkpoints // []) | length')" -eq 0 ]; then
+      printf 'No checkpoints recorded for this PR.\n'
+    else
+      printf '| Item | Stage | Domain | State | Reason | Required human action | Satisfied by |\n'
+      printf '| --- | --- | --- | --- | --- | --- | --- |\n'
+      printf '%s\n' "$json" | jq -r '
+        def cell:
+          tostring
+          | gsub("\\|"; "\\\\|")
+          | gsub("\\r?\\n"; "<br>")
+          | gsub("\\t"; " ");
+        (.checkpoints // [])[] |
+        "| #" + (.item_number | tostring) +
+        " | " + ((.stage // "") | cell) +
+        " | " + ((.domain // "") | cell) +
+        " | " + ((.satisfaction_state // "pending") | cell) +
+        " | " + ((.reason // "") | cell) +
+        " | " + ((.required_human_action // "") | cell) +
+        " | " + ((.satisfied_by // "-") | cell) + " |"
+      '
+    fi
+    printf '\n### Blocking checkpoints\n\n'
+    if [ "$(printf '%s\n' "$json" | jq '(.blocking // []) | length')" -eq 0 ]; then
+      printf 'None — delegated review/merge may proceed when other gates pass.\n'
+    else
+      printf '%s\n' "$json" | jq -r '(.blocking // [])[] | "- #" + (.item_number|tostring) + " " + .stage + "/" + .domain + ": " + (.required_human_action // "")'
+    fi
+    printf '\n### Satisfaction signals\n\n'
+    printf '%s\n' "$json" | jq -r '
+      "- Explicit comment: `" + (.satisfaction_signals.comment_marker | tostring) + "`",
+      "- Explicit waiver: `" + (.satisfaction_signals.waiver_marker | tostring) + "`",
+      "- PR review approval on matching stage also satisfies the checkpoint."
+    '
+  }
+}
+
+find_marker_comment_id() {
+  local target="$1"
+  local marker="$2"
+  local repo comments
+
+  repo="$(repo_slug)"
+  if ! comments="$(gh api --paginate --slurp "repos/${repo}/issues/${target}/comments?per_page=100" 2>/dev/null)"; then
+    error_exit "failed to read comments for issue/PR #$target"
+  fi
+  printf '%s\n' "$comments" |
+    jq -r --arg marker "$marker" '[.[][]? | select((.body // "") | contains($marker))] | last | .id // empty'
+}
+
+apply_checkpoint_comment() {
+  local pr="$1"
+  local body="$2"
+  local repo comment_id
+
+  require_gh
+  repo="$(repo_slug)"
+  comment_id="$(find_marker_comment_id "$pr" "$CHECKPOINT_MARKER")"
+  if [ -n "$comment_id" ]; then
+    jq -n --arg body "$body" '{body: $body}' |
+      gh api -X PATCH "repos/${repo}/issues/comments/${comment_id}" --input - >/dev/null
+    printf 'UPDATED_COMMENT_ID=%s\n' "$comment_id"
+  else
+    jq -n --arg body "$body" '{body: $body}' |
+      gh api -X POST "repos/${repo}/issues/${pr}/comments" --input - >/dev/null
+    printf 'CREATED_COMMENT=1\n'
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --pr)
+      require_value "$@"
+      pr_number="$2"
+      shift 2
+      ;;
+    --item)
+      require_value "$@"
+      item_number="$2"
+      shift 2
+      ;;
+    --branch)
+      require_value "$@"
+      branch_name="$2"
+      shift 2
+      ;;
+    --checkpoints-file)
+      require_value "$@"
+      checkpoints_file="$2"
+      shift 2
+      ;;
+    --write-checkpoints-file)
+      require_value "$@"
+      write_checkpoints_file="$2"
+      shift 2
+      ;;
+    --input)
+      require_value "$@"
+      input_file="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+case "$command" in
+  stage-from-branch|evaluate-blocking|detect-satisfaction|render-pr-checkpoint-comment|sync-pr-labels)
+    ;;
+  *)
+    echo "ERROR: unknown or missing subcommand." >&2
+    usage >&2
+    exit 64
+    ;;
+esac
+
+case "$command" in
+  stage-from-branch)
+    [ -n "$branch_name" ] || error_exit "--branch is required"
+    stage_from_branch "$branch_name"
+    ;;
+  evaluate-blocking)
+    [ -n "$item_number" ] && is_positive_int "$item_number" || error_exit "--item must be a positive integer"
+    [ -n "$branch_name" ] || error_exit "--branch is required"
+    [ -n "$checkpoints_file" ] || error_exit "--checkpoints-file is required"
+    checkpoints_json="$(load_checkpoints_json "$checkpoints_file")"
+    evaluate_blocking_json "$item_number" "$branch_name" "$checkpoints_json"
+    ;;
+  detect-satisfaction)
+    [ -n "$item_number" ] && is_positive_int "$item_number" || error_exit "--item must be a positive integer"
+    [ -n "$branch_name" ] || error_exit "--branch is required"
+    [ -n "$checkpoints_file" ] || error_exit "--checkpoints-file is required"
+    checkpoints_json="$(load_checkpoints_json "$checkpoints_file")"
+    updated_json="$(detect_satisfaction_json "$item_number" "$branch_name" "$checkpoints_json" "$pr_number")"
+    if [ -n "$write_checkpoints_file" ]; then
+      printf '%s\n' "$updated_json" | jq '.' > "$write_checkpoints_file"
+    fi
+    printf '%s\n' "$updated_json"
+    ;;
+  render-pr-checkpoint-comment)
+    [ -n "$input_file" ] || error_exit "--input is required"
+    if [ ! -f "$input_file" ]; then
+      error_exit "input file not found: $input_file"
+    fi
+    render_pr_checkpoint_comment "$(jq -c '.' "$input_file")"
+    ;;
+  sync-pr-labels)
+    [ -n "$pr_number" ] && is_positive_int "$pr_number" || error_exit "--pr must be a positive integer"
+    [ -n "$item_number" ] && is_positive_int "$item_number" || error_exit "--item must be a positive integer"
+    [ -n "$branch_name" ] || error_exit "--branch is required"
+    [ -n "$checkpoints_file" ] || error_exit "--checkpoints-file is required"
+    require_gh
+    checkpoints_json="$(load_checkpoints_json "$checkpoints_file")"
+    updated_checkpoints="$(detect_satisfaction_json "$item_number" "$branch_name" "$checkpoints_json" "$pr_number")"
+    if [ -n "$write_checkpoints_file" ]; then
+      printf '%s\n' "$updated_checkpoints" | jq '.' > "$write_checkpoints_file"
+    fi
+    blocking_json="$(evaluate_blocking_json "$item_number" "$branch_name" "$updated_checkpoints")"
+    pr_stage="$(stage_from_branch "$branch_name")"
+    label_required="false"
+    if [ "$(printf '%s\n' "$blocking_json" | jq 'length')" -gt 0 ]; then
+      label_required="true"
+    fi
+    item_checkpoints_json="$(printf '%s\n' "$updated_checkpoints" | jq -c --arg item "$item_number" '[.[] | select((.item_number | tonumber) == ($item | tonumber))]')"
+    if [ "$label_required" = "true" ]; then
+      if ! gh pr edit "$pr_number" --add-label "human-checkpoint-required" >/dev/null 2>&1; then
+        error_exit "failed to apply human-checkpoint-required label on PR #$pr_number"
+      fi
+      printf 'LABEL_APPLIED=human-checkpoint-required\n'
+    else
+      if ! has_label="$(gh pr view "$pr_number" --json labels --jq '[.labels[].name | select(. == "human-checkpoint-required")] | length' 2>/dev/null)"; then
+        error_exit "failed to read labels for PR #$pr_number"
+      fi
+      if [ "$has_label" -gt 0 ]; then
+        if ! gh pr edit "$pr_number" --remove-label "human-checkpoint-required" >/dev/null 2>&1; then
+          error_exit "failed to remove human-checkpoint-required label on PR #$pr_number"
+        fi
+        printf 'LABEL_REMOVED=human-checkpoint-required\n'
+      else
+        printf 'LABEL_ABSENT=human-checkpoint-required\n'
+      fi
+    fi
+    if ! has_label_after="$(gh pr view "$pr_number" --json labels --jq '[.labels[].name | select(. == "human-checkpoint-required")] | length' 2>/dev/null)"; then
+      error_exit "failed to read labels for PR #$pr_number after label sync"
+    fi
+    label_present="false"
+    if [ "$has_label_after" -gt 0 ]; then
+      label_present="true"
+    fi
+    comment_payload="$(jq -n \
+      --argjson item "$(jq -n --argjson n "$item_number" '{number: ($n|tonumber)}')" \
+      --argjson pr "$(jq -n --argjson n "$pr_number" --arg branch "$branch_name" --arg stage "$pr_stage" '{number: ($n|tonumber), branch: $branch, stage: $stage}')" \
+      --argjson checkpoints "$item_checkpoints_json" \
+      --argjson blocking "$blocking_json" \
+      --argjson label_required "$label_required" \
+      --argjson label_present "$label_present" \
+      --arg satisfied_marker "${SATISFIED_MARKER_PREFIX}${item_number}:<stage>:<domain> -->" \
+      --arg waiver_marker "${WAIVED_MARKER_PREFIX}${item_number}:<stage>:<domain> --> <rationale>" \
+      '{
+        item: $item,
+        pr: $pr,
+        checkpoints: $checkpoints,
+        blocking: $blocking,
+        label_required: $label_required,
+        label_present: $label_present,
+        satisfaction_signals: {
+          comment_marker: $satisfied_marker,
+          waiver_marker: $waiver_marker
+        }
+      }')"
+    comment_body="$(render_pr_checkpoint_comment "$comment_payload")"
+    apply_checkpoint_comment "$pr_number" "$comment_body"
+    printf 'BLOCKING_COUNT=%s\n' "$(printf '%s\n' "$blocking_json" | jq 'length')"
+    ;;
+esac

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -131,7 +131,9 @@ detect_satisfaction_json() {
     local repo
     repo="$(repo_slug)"
     if [ -n "$head_sha" ]; then
-      head_created_at="$(gh api "repos/${repo}/commits/${head_sha}" --jq '.commit.committer.date // empty' 2>/dev/null || true)"
+      if ! head_created_at="$(gh api "repos/${repo}/commits/${head_sha}" --jq '.commit.committer.date // empty' 2>/dev/null)"; then
+        head_created_at=""
+      fi
     fi
     if ! comments_json="$(gh api --paginate --slurp "repos/${repo}/issues/${pr}/comments?per_page=100" 2>/dev/null | jq -c '[.[].[]? | {author: (.user.login // ""), body: (.body // ""), createdAt: (.created_at // "")}]' 2>/dev/null)"; then
       error_exit "failed to read comments for PR #$pr"

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -157,7 +157,6 @@ detect_satisfaction_json() {
       | map(select(
           ($head_sha | length) == 0
           or ((.commit.oid // "") == $head_sha)
-          or ((.commit // {}).oid? // "" | length) == 0
         ))
       | sort_by(.submittedAt // "")
       | last // null;

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -172,7 +172,9 @@ detect_satisfaction_json() {
       ($latest != null) and (($latest.state // "") == "APPROVED");
     def human_comments: ($comments // []) | map(select(bot_login(.author) | not));
     def signal_after_head($createdAt):
-      ($head_created_at | length) == 0 or (($createdAt // "") > $head_created_at);
+      if ($head_sha | length) == 0 then true
+      elif ($head_created_at | length) == 0 then false
+      else (($createdAt // "") > $head_created_at) end;
     def waiver_rationale_valid($body; $item; $stage; $domain):
       (parse_waiver_rationale($body; "'"$WAIVED_MARKER_PREFIX"'"; ($item|tostring); $stage; $domain) | gsub("\\s"; "") | length) > 0;
     stage_from_branch($branch) as $prStage |
@@ -181,7 +183,8 @@ detect_satisfaction_json() {
       if ($cp.item_number | tonumber) != ($item | tonumber) then .
       elif (($cp.satisfaction_state // "pending") != "pending")
         and (
-          ($head_sha | length) == 0
+          stage_rank($cp.stage) < stage_rank($prStage)
+          or ($head_sha | length) == 0
           or (($cp.satisfied_head_sha // "") == $head_sha)
         ) then .
       elif (stage_rank($cp.stage) > stage_rank($prStage)) then .

--- a/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh
@@ -114,10 +114,11 @@ detect_satisfaction_json() {
   local checkpoints_json="$3"
   local pr="${4:-}"
 
-  local reviews_json comments_json head_sha
+  local reviews_json comments_json head_sha head_created_at
   reviews_json='[]'
   comments_json='[]'
   head_sha=""
+  head_created_at=""
 
   if [ -n "$pr" ] && is_positive_int "$pr"; then
     require_gh
@@ -129,6 +130,9 @@ detect_satisfaction_json() {
     fi
     local repo
     repo="$(repo_slug)"
+    if [ -n "$head_sha" ]; then
+      head_created_at="$(gh api "repos/${repo}/commits/${head_sha}" --jq '.commit.committer.date // empty' 2>/dev/null || true)"
+    fi
     if ! comments_json="$(gh api --paginate --slurp "repos/${repo}/issues/${pr}/comments?per_page=100" 2>/dev/null | jq -c '[.[].[]? | {author: (.user.login // ""), body: (.body // ""), createdAt: (.created_at // "")}]' 2>/dev/null)"; then
       error_exit "failed to read comments for PR #$pr"
     fi
@@ -138,6 +142,7 @@ detect_satisfaction_json() {
     --arg item "$item" \
     --arg branch "$branch" \
     --arg head_sha "$head_sha" \
+    --arg head_created_at "$head_created_at" \
     --argjson reviews "$reviews_json" \
     --argjson comments "$comments_json" \
     "$checkpoint_jq_filter"'
@@ -164,18 +169,24 @@ detect_satisfaction_json() {
       (latest_human_review) as $latest |
       ($latest != null) and (($latest.state // "") == "APPROVED");
     def human_comments: ($comments // []) | map(select(bot_login(.author) | not));
+    def signal_after_head($createdAt):
+      ($head_created_at | length) == 0 or (($createdAt // "") > $head_created_at);
     def waiver_rationale_valid($body; $item; $stage; $domain):
       (parse_waiver_rationale($body; "'"$WAIVED_MARKER_PREFIX"'"; ($item|tostring); $stage; $domain) | gsub("\\s"; "") | length) > 0;
     stage_from_branch($branch) as $prStage |
     map(
       . as $cp |
       if ($cp.item_number | tonumber) != ($item | tonumber) then .
-      elif (($cp.satisfaction_state // "pending") != "pending") then .
+      elif (($cp.satisfaction_state // "pending") != "pending")
+        and (
+          ($head_sha | length) == 0
+          or (($cp.satisfied_head_sha // "") == $head_sha)
+        ) then .
       elif (stage_rank($cp.stage) > stage_rank($prStage)) then .
       else
-        ($cp | del(.satisfaction_state, .satisfied_by, .satisfied_at, .waiver_rationale) | .satisfaction_state = "pending") as $base |
+        ($cp | del(.satisfaction_state, .satisfied_by, .satisfied_at, .satisfied_head_sha, .waiver_rationale) | .satisfaction_state = "pending") as $base |
         $base |
-        human_comments as $commentList |
+        (human_comments | map(select(signal_after_head(.createdAt)))) as $commentList |
         (
           ($commentList
             | map(select(
@@ -187,6 +198,7 @@ detect_satisfaction_json() {
               .satisfaction_state = "waived"
               | .satisfied_by = ($waivedComment.author // "")
               | .satisfied_at = ($waivedComment.createdAt // "")
+              | if ($head_sha | length) > 0 then .satisfied_head_sha = $head_sha else . end
               | .waiver_rationale = (parse_waiver_rationale($waivedComment.body; "'"$WAIVED_MARKER_PREFIX"'"; ($cp.item_number|tostring); $cp.stage; $cp.domain))
             elif
               ($commentList
@@ -201,10 +213,12 @@ detect_satisfaction_json() {
               | .satisfaction_state = "satisfied"
               | .satisfied_by = ($satisfiedComment.author // "")
               | .satisfied_at = ($satisfiedComment.createdAt // "")
+              | if ($head_sha | length) > 0 then .satisfied_head_sha = $head_sha else . end
             elif ($cp.stage == $prStage) and review_satisfies($cp) then
               .satisfaction_state = "satisfied"
               | .satisfied_by = (latest_human_review | .author.login // "pr_review_approved")
               | .satisfied_at = (latest_human_review | .submittedAt // "")
+              | if ($head_sha | length) > 0 then .satisfied_head_sha = $head_sha else . end
             else .
             end
         )

--- a/scripts/development-workflow/run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/run-epic-delegated-gate.sh
@@ -122,8 +122,11 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
   def checkpoint_list:
     if ((.checkpoint_policy.effective // null) | type) == "array" then .checkpoint_policy.effective
     elif ((.checkpointPolicy.effective // null) | type) == "array" then .checkpointPolicy.effective
-    elif ((policy.effectivePolicy.checkpoints // null) | type) == "array" then policy.effectivePolicy.checkpoints
-    elif ((policy.checkpoints // null) | type) == "array" then policy.checkpoints
+    elif ((try .policy.effectivePolicy.checkpoints catch null) | type) == "array" then .policy.effectivePolicy.checkpoints
+    elif ((try .policy.effective_policy.checkpoints catch null) | type) == "array" then .policy.effective_policy.checkpoints
+    elif ((try .invocation_policy.effective_policy.checkpoints catch null) | type) == "array" then .invocation_policy.effective_policy.checkpoints
+    elif ((try .invocationPolicy.effectivePolicy.checkpoints catch null) | type) == "array" then .invocationPolicy.effectivePolicy.checkpoints
+    elif ((try .policy.checkpoints catch null) | type) == "array" then .policy.checkpoints
     else [] end;
   def item_number:
     (.item.number // .item.issue_number // .item.issueNumber // null);

--- a/scripts/development-workflow/run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/run-epic-delegated-gate.sh
@@ -109,6 +109,39 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     end;
   def implementation_branch:
     (.pr.headRefName // "") | test("^(feature|fix|refactor|hotfix|backport/hotfix)/");
+  def stage_rank($stage):
+    if $stage == "spec" then 1
+    elif $stage == "plan" then 2
+    elif $stage == "implementation" then 3
+    else 0 end;
+  def stage_from_branch($branch):
+    if ($branch | test("^spec/")) then "spec"
+    elif ($branch | test("^implementation-plan/")) then "plan"
+    elif ($branch | test("^(feature|fix|refactor|hotfix|backport/hotfix)/")) then "implementation"
+    else "implementation" end;
+  def checkpoint_list:
+    if ((.checkpoint_policy.effective // null) | type) == "array" then .checkpoint_policy.effective
+    elif ((.checkpointPolicy.effective // null) | type) == "array" then .checkpointPolicy.effective
+    elif ((policy.effectivePolicy.checkpoints // null) | type) == "array" then policy.effectivePolicy.checkpoints
+    elif ((policy.checkpoints // null) | type) == "array" then policy.checkpoints
+    else [] end;
+  def item_number:
+    (.item.number // .item.issue_number // .item.issueNumber // null);
+  def checkpoint_applies($cp; $item; $prStage):
+    ($item != null)
+    and (($cp.item_number | tonumber) == ($item | tonumber))
+    and (($cp.satisfaction_state // "pending") == "pending")
+    and (stage_rank($cp.stage) > 0)
+    and (stage_rank($cp.stage) <= stage_rank($prStage));
+  def pending_checkpoints:
+    (stage_from_branch(.pr.headRefName // "")) as $prStage |
+    (item_number) as $item |
+    checkpoint_list
+    | map(select(checkpoint_applies(.; $item; $prStage)));
+  def checkpoint_reason($cp):
+    "human checkpoint pending for issue #" + (($cp.item_number // item_number) | tostring) +
+    " " + (($cp.stage // "unknown") | tostring) + "/" + (($cp.domain // "unknown") | tostring) +
+    ": " + (($cp.required_human_action // $cp.reason // "human confirmation required") | tostring);
   def risk_merge_permitted:
     if (.risk // {}) | has("mergePermitted") then .risk.mergePermitted
     elif (.risk // {}) | has("merge_permitted") then .risk.merge_permitted
@@ -143,6 +176,13 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
   (if has_label("needs-setup")
    then add_reason($reasons; "needs-setup label is present")
    else $reasons end) as $reasons |
+  (pending_checkpoints) as $pendingCheckpoints |
+  (if ($pendingCheckpoints | length) > 0
+   then $reasons + ($pendingCheckpoints | map(checkpoint_reason(.)))
+   else $reasons end) as $reasons |
+  (if has_label("human-checkpoint-required") and (($pendingCheckpoints | length) == 0)
+   then add_reason($reasons; "human-checkpoint-required label is present; record satisfied or waived checkpoint evidence and remove the label before delegated merge")
+   else $reasons end) as $reasons |
   (if ((.statusChecks // []) | length) == 0
    then add_reason($reasons; "required CI state is missing")
    else $reasons end) as $reasons |
@@ -172,7 +212,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     decision: (
       if $count == 0 then "merge_allowed"
       elif ($reasons | any(test("reviewer blocking|CI checks|unresolved blocking|advisories"))) then "fix_required"
-      elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog"))) then "human_required"
+      elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog|human checkpoint|human-checkpoint"))) then "human_required"
       else "blocked"
       end
     ),
@@ -181,6 +221,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     nextAction: (
       if $count == 0 then "record merge evidence and use the repository merge protocol"
       elif ($reasons | any(test("reviewer blocking|CI checks|unresolved blocking|advisories"))) then "remove readiness labels, fix, rerun validation, reviewer loop, CI loop, and this gate"
+      elif ($reasons | any(test("human checkpoint|human-checkpoint"))) then "stop for the named human checkpoint action, record satisfied or waived evidence, sync labels, and rerun this gate"
       elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog"))) then "stop for human authority or setup before mutating"
       else "block until required state is available"
       end

--- a/scripts/development-workflow/run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/run-epic-delegated-gate.sh
@@ -139,7 +139,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     checkpoint_list
     | map(select(checkpoint_applies(.; $item; $prStage)));
   def checkpoint_reason($cp):
-    "human checkpoint pending for issue #" + (($cp.item_number // item_number) | tostring) +
+    "human_checkpoint_required: issue #" + (($cp.item_number // item_number) | tostring) +
     " " + (($cp.stage // "unknown") | tostring) + "/" + (($cp.domain // "unknown") | tostring) +
     ": " + (($cp.required_human_action // $cp.reason // "human confirmation required") | tostring);
   def risk_merge_permitted:
@@ -181,7 +181,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
    then $reasons + ($pendingCheckpoints | map(checkpoint_reason(.)))
    else $reasons end) as $reasons |
   (if has_label("human-checkpoint-required") and (($pendingCheckpoints | length) == 0)
-   then add_reason($reasons; "human-checkpoint-required label is present; record satisfied or waived checkpoint evidence and remove the label before delegated merge")
+   then add_reason($reasons; "human_checkpoint_required: human-checkpoint-required label is present; record satisfied or waived checkpoint evidence and remove the label before delegated merge")
    else $reasons end) as $reasons |
   (if ((.statusChecks // []) | length) == 0
    then add_reason($reasons; "required CI state is missing")
@@ -212,7 +212,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     decision: (
       if $count == 0 then "merge_allowed"
       elif ($reasons | any(test("reviewer blocking|CI checks|unresolved blocking|advisories"))) then "fix_required"
-      elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog|human checkpoint|human-checkpoint"))) then "human_required"
+      elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog|human_checkpoint_required|human-checkpoint"))) then "human_required"
       else "blocked"
       end
     ),
@@ -221,7 +221,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     nextAction: (
       if $count == 0 then "record merge evidence and use the repository merge protocol"
       elif ($reasons | any(test("reviewer blocking|CI checks|unresolved blocking|advisories"))) then "remove readiness labels, fix, rerun validation, reviewer loop, CI loop, and this gate"
-      elif ($reasons | any(test("human checkpoint|human-checkpoint"))) then "stop for the named human checkpoint action, record satisfied or waived evidence, sync labels, and rerun this gate"
+      elif ($reasons | any(test("human_checkpoint_required|human-checkpoint"))) then "stop for the named human checkpoint action, record satisfied or waived evidence, sync labels, and rerun this gate"
       elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog"))) then "stop for human authority or setup before mutating"
       else "block until required state is available"
       end

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -201,7 +201,7 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
   def risk_rank($risk): {"low": 1, "medium": 2, "high": 3}[$risk] // 0;
   def max_risk($a; $b): if risk_rank($a) >= risk_rank($b) then $a else $b end;
   def item_text:
-    [.items[]? | ((.title // "") + " " + (.type // "") + " " + ((.labels // []) | join(" ")) + " " + (.integrationBranchLabel // ""))]
+    [.items[]? | ((.title // "") + " " + (.body // "") + " " + (.type // "") + " " + ((.labels // []) | join(" ")) + " " + (.integrationBranchLabel // ""))]
     | join(" ")
     | ascii_downcase;
   def item_signal_text($item):
@@ -260,7 +260,7 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
             satisfaction_state: "pending"
           }]
         else . end
-      | if ($stage == "implementation") and ($text | test("auth|security|secret|permission|credential|sensitive")) then
+      | if $text | test("auth|security|secret|permission|credential|sensitive") then
           . + [{
             item_number: $num,
             stage: "implementation",

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -9,7 +9,7 @@ source "$SCRIPT_DIR/workflow-lib.sh"
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/development-workflow/run-epic-policy-recommender.sh --scope <resolver-json> --original-command <text> [--base <branch>] [--delegate-review|--no-delegate-review] [--may-merge|--no-may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--json]
+  ./scripts/development-workflow/run-epic-policy-recommender.sh --scope <resolver-json> --original-command <text> [--base <branch>] [--delegate-review|--no-delegate-review] [--may-merge|--no-may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--checkpoints-file <json-array>] [--json]
 
 Derives a read-only recommended /run-epic autonomy policy from resolver output.
 The helper does not update trackers, create branches, open PRs, edit labels,
@@ -24,6 +24,7 @@ delegate_review_override=""
 may_merge_override=""
 may_start_backlog_override=""
 max_risk_override=""
+checkpoints_file=""
 json_output=0
 
 error_exit() {
@@ -125,6 +126,11 @@ while [ "$#" -gt 0 ]; do
       max_risk_override="$2"
       shift 2
       ;;
+    --checkpoints-file)
+      require_value "$@"
+      checkpoints_file="$2"
+      shift 2
+      ;;
     --json)
       json_output=1
       shift
@@ -155,6 +161,19 @@ fi
 
 scope_json="$(load_scope_json "$scope_file")"
 
+checkpoints_override_json="null"
+if [ -n "$checkpoints_file" ]; then
+  if [ ! -f "$checkpoints_file" ]; then
+    error_exit "checkpoints file not found: $checkpoints_file"
+  fi
+  if ! checkpoints_override_json="$(jq -c '.' "$checkpoints_file" 2>/dev/null)"; then
+    error_exit "checkpoints file is not valid JSON: $checkpoints_file"
+  fi
+  if ! printf '%s\n' "$checkpoints_override_json" | jq -e 'type == "array"' >/dev/null; then
+    error_exit "checkpoints file must contain a JSON array"
+  fi
+fi
+
 if ! printf '%s\n' "$scope_json" | jq -e '
   (.groups | type) == "object" and
   (.items | type) == "array" and
@@ -176,7 +195,8 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
   --arg mayMergeOverride "$may_merge_override" \
   --arg mayStartBacklogOverride "$may_start_backlog_override" \
   --arg maxRiskOverride "$max_risk_override" \
-  --argjson reviewerCount "$reviewer_count" '
+  --argjson reviewerCount "$reviewer_count" \
+  --argjson checkpointsOverride "$checkpoints_override_json" '
   def bool_override($v): if $v == "" then null elif $v == "true" then true else false end;
   def risk_rank($risk): {"low": 1, "medium": 2, "high": 3}[$risk] // 0;
   def max_risk($a; $b): if risk_rank($a) >= risk_rank($b) then $a else $b end;
@@ -184,6 +204,104 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
     [.items[]? | ((.title // "") + " " + (.type // "") + " " + ((.labels // []) | join(" ")) + " " + (.integrationBranchLabel // ""))]
     | join(" ")
     | ascii_downcase;
+  def item_signal_text($item):
+    (($item.title // "") + " " + ($item.body // "") + " " + ($item.type // "") + " " + (($item.labels // []) | join(" ")) + " " + ($item.integrationBranchLabel // ""))
+    | ascii_downcase;
+  def infer_workflow_stage($item):
+    ($item.status // "" | ascii_downcase) as $s |
+    if $s == "backlog" or ($s | test("writing spec|spec in review|spec")) then "spec"
+    elif $s | test("writing plan|plan in review|plan") then "plan"
+    elif $s | test("development|implement") then "implementation"
+    else "implementation"
+    end;
+  def checkpoint_key($cp): "\($cp.item_number):\($cp.stage):\($cp.domain)";
+  def normalize_checkpoint($cp):
+    $cp
+    | .item_number |= (if type == "number" then . else tonumber? // . end)
+    | .satisfaction_state |= (. // "pending")
+    | if .satisfaction_state == "waived" and ((.waiver_rationale // "") | length) == 0 then
+        error("waived checkpoints require waiver_rationale")
+      else .
+      end;
+  def recommend_checkpoints_for_item($item):
+    item_signal_text($item) as $text |
+    infer_workflow_stage($item) as $stage |
+    ($item.number) as $num |
+    (
+      []
+      | if ($stage == "spec" or ($item.status // "" | ascii_downcase) == "backlog")
+          and ($text | test("ambiguous|unclear|\\btbd\\b|open question|acceptance criteria|unresolved product")) then
+          . + [{
+            item_number: $num,
+            stage: "spec",
+            domain: "product",
+            reason: "issue signals unresolved product requirements or acceptance-criteria ambiguity",
+            required_human_action: "confirm product requirements and acceptance criteria before spec work proceeds",
+            satisfaction_state: "pending"
+          }]
+        else . end
+      | if $text | test("schema|migration|database|data[ -]?model|\\bsql\\b|persistent data") then
+          . + [{
+            item_number: $num,
+            stage: "plan",
+            domain: "technical",
+            reason: "issue signals database schema, migration, or persistent data-model changes",
+            required_human_action: "review and approve proposed data model in the plan before implementation proceeds",
+            satisfaction_state: "pending"
+          }]
+        else . end
+      | if $text | test("trade[- ]?off|architecture.{0,30}product|product.{0,30}technical|ambiguous.{0,40}(architecture|product|technical)") then
+          . + [{
+            item_number: $num,
+            stage: (if $stage == "spec" then "plan" else $stage end),
+            domain: "both",
+            reason: "issue signals ambiguous product and technical tradeoffs",
+            required_human_action: "confirm product and technical direction before proceeding",
+            satisfaction_state: "pending"
+          }]
+        else . end
+      | if ($stage == "implementation") and ($text | test("auth|security|secret|permission|credential|sensitive")) then
+          . + [{
+            item_number: $num,
+            stage: "implementation",
+            domain: "technical",
+            reason: "issue signals security, auth, or other sensitive implementation changes",
+            required_human_action: "review security-sensitive implementation approach before delegated merge",
+            satisfaction_state: "pending"
+          }]
+        else . end
+    );
+  def item_eligible_for_checkpoints($item):
+    (($item.group // "eligible") | IN("eligible", "in_review"));
+  def recommended_checkpoints:
+    [.items[]? | select(item_eligible_for_checkpoints(.)) | recommend_checkpoints_for_item(.)[]]
+    | unique_by(checkpoint_key(.));
+  def checkpoint_matches($a; $b):
+    ($a.item_number == $b.item_number) and ($a.stage == $b.stage) and ($a.domain == $b.domain);
+  def selected_checkpoints($recommended):
+    if $checkpointsOverride == null then $recommended
+    else
+      ($checkpointsOverride | map(normalize_checkpoint(.))) as $override |
+      (
+        $recommended
+        | map(
+            . as $rec
+            | ($override | map(select(checkpoint_matches($rec; .))) | first) // $rec
+          )
+      ) as $merged
+      | $merged + (
+          $override
+          | map(
+              . as $ov
+              | if ($recommended | any(checkpoint_matches(.; $ov))) then empty else $ov end
+            )
+        )
+    end;
+  def effective_checkpoints($selected): $selected;
+  def checkpoint_field_source: if $checkpointsOverride == null then "recommended" else "explicit" end;
+  def has_recommended_checkpoints: (recommended_checkpoints | length) > 0;
+  def has_pending_checkpoints($checkpoints):
+    ($checkpoints | map(select(.satisfaction_state == "pending")) | length) > 0;
   def has_backlog: [.items[]? | select((.status // "") == "Backlog")] | length > 0;
   def has_dependency_blocker: [.items[]? | select((.dependencies.state // "") == "blocked")] | length > 0;
   def has_ambiguous: ((.groups.ambiguous // []) | length) > 0 or (.baseAmbiguous // false) == true;
@@ -226,6 +344,9 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
   (recommended_merge) as $recMerge |
   (recommended_risk) as $recRisk |
   (recommended_base) as $recBase |
+  (recommended_checkpoints) as $recCheckpoints |
+  (selected_checkpoints($recCheckpoints)) as $selCheckpoints |
+  (effective_checkpoints($selCheckpoints)) as $effCheckpoints |
   {
     originalCommand: $originalCommand,
     scope: {
@@ -247,35 +368,46 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
       delegateReview: $recReview,
       mayMerge: $recMerge,
       maxRisk: $recRisk,
-      base: $recBase
+      base: $recBase,
+      checkpoints: $recCheckpoints
     },
     selectedPolicy: {
       mayStartBacklog: value_bool($mayStartBacklogOverride; $recStart),
       delegateReview: value_bool($delegateReviewOverride; $recReview),
       mayMerge: value_bool($mayMergeOverride; $recMerge),
       maxRisk: value_string($maxRiskOverride; $recRisk),
-      base: value_string($baseOverride; $recBase)
+      base: value_string($baseOverride; $recBase),
+      checkpoints: $selCheckpoints
     },
     effectivePolicy: {
       mayStartBacklog: value_bool($mayStartBacklogOverride; $recStart),
       delegateReview: value_bool($delegateReviewOverride; $recReview),
       mayMerge: value_bool($mayMergeOverride; $recMerge),
       maxRisk: value_string($maxRiskOverride; $recRisk),
-      base: value_string($baseOverride; $recBase)
+      base: value_string($baseOverride; $recBase),
+      checkpoints: $effCheckpoints
+    },
+    checkpointPolicy: {
+      recommended: $recCheckpoints,
+      selected: $selCheckpoints,
+      effective: $effCheckpoints
     },
     fieldSources: {
       mayStartBacklog: source_for($mayStartBacklogOverride),
       delegateReview: source_for($delegateReviewOverride),
       mayMerge: source_for($mayMergeOverride),
       maxRisk: source_for($maxRiskOverride),
-      base: source_for($baseOverride)
+      base: source_for($baseOverride),
+      checkpoints: checkpoint_field_source
     },
     requiresConfirmation: ((
       [$mayStartBacklogOverride, $delegateReviewOverride, $mayMergeOverride, $maxRiskOverride, $baseOverride]
       | any(. == "")
-    ) or has_ambiguous),
+    ) or has_ambiguous or has_pending_checkpoints($effCheckpoints)),
     confirmationReason: (
       if has_ambiguous then "scope or base is ambiguous; confirm before mutation"
+      elif has_pending_checkpoints($effCheckpoints) then
+        "pending human checkpoints remain; confirm, customize, or waive before mutation"
       elif ([$mayStartBacklogOverride, $delegateReviewOverride, $mayMergeOverride, $maxRiskOverride, $baseOverride] | any(. == "")) then
         "one or more autonomy policy values were inferred from resolved scope"
       else "all autonomy policy values were explicit"
@@ -307,6 +439,11 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
         if $recBase == null then "base branch could not be inferred unambiguously"
         else "base branch inferred by resolver: " + ($recBase | tostring)
         end
+      ),
+      checkpoints: (
+        if ($recCheckpoints | length) == 0 then "no human checkpoints recommended for resolved scope"
+        else ($recCheckpoints | length | tostring) + " checkpoint(s) recommended from item metadata signals"
+        end
       )
     },
     copyPasteCommand: (
@@ -315,8 +452,26 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
       (if value_bool($mayMergeOverride; $recMerge) then " --may-merge" else "" end) +
       " --may-start-backlog " + (value_bool($mayStartBacklogOverride; $recStart) | tostring) +
       " --max-risk " + (value_string($maxRiskOverride; $recRisk) | tostring) +
-      (if value_string($baseOverride; $recBase) == null then "" else " --base " + (value_string($baseOverride; $recBase) | tostring) end)
+      (if value_string($baseOverride; $recBase) == null then "" else " --base " + (value_string($baseOverride; $recBase) | tostring) end) +
+      (if ($effCheckpoints | length) > 0 then
+        " --checkpoints-file checkpoint-policy.json"
+      else "" end)
     ),
+    copyPasteCheckpointCommand: (
+      if ($effCheckpoints | length) == 0 then null
+      else
+        "./scripts/development-workflow/run-epic-policy-recommender.sh --scope <resolver-json> --original-command \""
+        + $originalCommand + "\""
+        + (if value_bool($delegateReviewOverride; $recReview) then " --delegate-review" else "" end)
+        + (if value_bool($mayMergeOverride; $recMerge) then " --may-merge" else "" end)
+        + " --may-start-backlog " + (value_bool($mayStartBacklogOverride; $recStart) | tostring)
+        + " --max-risk " + (value_string($maxRiskOverride; $recRisk) | tostring)
+        + (if value_string($baseOverride; $recBase) == null then "" else " --base " + (value_string($baseOverride; $recBase) | tostring) end)
+        + " --checkpoints-file checkpoint-policy.json"
+      end
+    ),
+    checkpointPolicyExport: $effCheckpoints,
+    checkpointPolicyFile: (if ($effCheckpoints | length) > 0 then "checkpoint-policy.json" else null end),
     readOnlyGuarantee: "No tracker updates, branch creation, PR edits, labels, comments, merges, issue closure, or branch deletion were performed."
   }
 ')"
@@ -343,7 +498,20 @@ printf '%s\n' "$recommendation_json" | jq -r '
   "- Review: " + .rationale.delegateReview,
   "- Merge: " + .rationale.mayMerge,
   "- Risk: " + .rationale.maxRisk,
-  "- Base: " + .rationale.base
+  "- Base: " + .rationale.base,
+  "- Checkpoints: " + .rationale.checkpoints
 '
+checkpoint_count="$(printf '%s\n' "$recommendation_json" | jq -r '.effectivePolicy.checkpoints | length')"
+if [ "$checkpoint_count" -gt 0 ]; then
+  printf 'Human checkpoints (%s):\n' "$(printf '%s\n' "$recommendation_json" | jq -r '.fieldSources.checkpoints')"
+  printf '%s\n' "$recommendation_json" | jq -r '
+    .effectivePolicy.checkpoints[]
+    | "- #" + (.item_number | tostring) + " " + .stage + "/" + .domain + " [" + .satisfaction_state + "]: " + .reason
+  '
+fi
 printf 'Copy-paste equivalent: %s\n' "$(printf '%s\n' "$recommendation_json" | jq -r '.copyPasteCommand')"
+if printf '%s\n' "$recommendation_json" | jq -e '.checkpointPolicyFile != null' >/dev/null; then
+  printf 'Checkpoint policy file: %s (save checkpointPolicyExport JSON before re-run)\n' "$(printf '%s\n' "$recommendation_json" | jq -r '.checkpointPolicyFile')"
+  printf 'Recommender copy-paste: %s\n' "$(printf '%s\n' "$recommendation_json" | jq -r '.copyPasteCheckpointCommand')"
+fi
 printf 'Read-only: %s\n' "$(printf '%s\n' "$recommendation_json" | jq -r '.readOnlyGuarantee')"

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -298,7 +298,10 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
         )
     end;
   def effective_checkpoints($selected): $selected;
-  def checkpoint_field_source: if $checkpointsOverride == null then "recommended" else "explicit" end;
+  def checkpoint_field_source:
+    if $checkpointsOverride == null then "recommended"
+    elif ($checkpointsOverride | length) == 0 then "recommended"
+    else "explicit" end;
   def has_recommended_checkpoints: (recommended_checkpoints | length) > 0;
   def has_pending_checkpoints($checkpoints):
     ($checkpoints | map(select(.satisfaction_state == "pending")) | length) > 0;

--- a/scripts/development-workflow/run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/run-epic-scope-resolver.sh
@@ -489,6 +489,7 @@ enrich_item() {
   jq -n \
     --argjson number "$issue" \
     --arg title "$title" \
+    --arg body "$body" \
     --arg state "$state" \
     --arg stateReason "$state_reason" \
     --arg labels "$labels" \
@@ -503,6 +504,7 @@ enrich_item() {
     '{
       number: $number,
       title: $title,
+      body: $body,
       issueState: $state,
       issueStateReason: $stateReason,
       labels: (if $labels == "" then [] else ($labels | split(",")) end),

--- a/scripts/development-workflow/tests/test-batch-merge-checkpoints.sh
+++ b/scripts/development-workflow/tests/test-batch-merge-checkpoints.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# test-batch-merge-checkpoints.sh - Unit tests for batch merge checkpoint guards.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+HELPER="$REPO_ROOT/scripts/development-workflow/batch-merge.sh"
+
+TMP_ROOT="$(mktemp -d)"
+MOCK_BIN="$TMP_ROOT/bin"
+CALL_LOG="$TMP_ROOT/gh-calls.log"
+mkdir -p "$MOCK_BIN"
+: > "$CALL_LOG"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+cat > "$MOCK_BIN/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_GH_CALL_LOG"
+case "$*" in
+  auth\ status)
+    exit 0
+    ;;
+  pr\ list\ --base\ develop\ --label\ ready-for-human-review\ --state\ open\ --json\ number\ --jq\ .[].number)
+    printf '42\n43\n'
+    ;;
+  pr\ view\ 42\ --json\ number,title,headRefName,baseRefName,labels,createdAt,isDraft)
+    cat <<'JSON'
+{"number":42,"title":"checkpointed PR","headRefName":"feature/42-checkpointed","baseRefName":"develop","labels":[{"name":"ready-for-human-review"},{"name":"ready-for-regression"},{"name":"human-checkpoint-required"}],"createdAt":"2026-06-22T12:00:00Z","isDraft":false}
+JSON
+    ;;
+  pr\ view\ 43\ --json\ number,title,headRefName,baseRefName,labels,createdAt,isDraft)
+    cat <<'JSON'
+{"number":43,"title":"clean PR","headRefName":"feature/43-clean","baseRefName":"develop","labels":[{"name":"ready-for-human-review"},{"name":"ready-for-regression"}],"createdAt":"2026-06-22T12:01:00Z","isDraft":false}
+JSON
+    ;;
+  pr\ view\ 42\ --json\ headRefName,baseRefName,state,labels,isDraft)
+    cat <<'JSON'
+{"headRefName":"feature/42-checkpointed","baseRefName":"develop","state":"OPEN","labels":[{"name":"ready-for-human-review"},{"name":"ready-for-regression"},{"name":"human-checkpoint-required"}],"isDraft":false}
+JSON
+    ;;
+  pr\ diff\ 42\ --name-only|pr\ diff\ 43\ --name-only)
+    printf 'scripts/example.sh\n'
+    ;;
+  *)
+    printf 'unexpected gh invocation: gh %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+MOCK_GH
+chmod +x "$MOCK_BIN/gh"
+export PATH="$MOCK_BIN:$PATH"
+export MOCK_GH_CALL_LOG="$CALL_LOG"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+echo ""
+echo "=== Batch merge checkpoint guards ==="
+
+discover_stderr="$TMP_ROOT/discover.err"
+discover_output="$("$HELPER" discover 2>"$discover_stderr")"
+run_test "discovery_warns_about_checkpoint" "yes" "$(grep -q 'human-checkpoint-required' "$discover_stderr" && echo yes || echo no)"
+run_test "discovery_skips_checkpointed_pr" "no" "$(grep -q '^PR_NUMBER=42$' <<< "$discover_output" && echo yes || echo no)"
+run_test "discovery_keeps_clean_pr" "yes" "$(grep -q '^PR_NUMBER=43$' <<< "$discover_output" && echo yes || echo no)"
+
+include_output="$("$HELPER" discover --include-checkpointed --prs 42)"
+run_test "explicit_checkpoint_include_emits_candidate" "yes" "$(grep -q '^PR_NUMBER=42$' <<< "$include_output" && echo yes || echo no)"
+run_test "explicit_checkpoint_candidate_marks_flag" "true" "$(awk -F= '$1=="PR_HAS_HUMAN_CHECKPOINT"{print $2; exit}' <<< "$include_output")"
+
+set +e
+merge_output="$("$HELPER" merge --pr 42 2>&1)"
+merge_status=$?
+set -e
+run_test "merge_refuses_checkpoint_label_status" "2" "$merge_status"
+run_test "merge_refuses_checkpoint_label_message" "yes" "$(grep -q 'human-checkpoint-required' <<< "$merge_output" && echo yes || echo no)"
+
+echo ""
+echo "=== Summary ==="
+echo "Passed: $PASS_COUNT"
+echo "Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2177,7 +2177,15 @@ else
   actual="blocking"
 fi
 run_test "bugbot_same_line_severity_is_blocking" "blocking" "$actual"
-unset bugbot_clean_body bugbot_mixed_body bugbot_multiline_body bugbot_same_line_severity_body actual
+
+bugbot_same_line_mixed_body="Cursor Bugbot found no issues in this pull request, but the reviewer loop still drops blocking findings."
+if is_bugbot_clean_review "$bugbot_same_line_mixed_body"; then
+  actual="clean"
+else
+  actual="blocking"
+fi
+run_test "bugbot_same_line_mixed_phrase_is_blocking" "blocking" "$actual"
+unset bugbot_clean_body bugbot_mixed_body bugbot_multiline_body bugbot_same_line_severity_body bugbot_same_line_mixed_body actual
 
 # ---------------------------------------------------------------------------
 # Test 16.1: clean path — check run conclusion=success, no blocking comments

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2329,6 +2329,50 @@ rm -rf "$_bugbot_mock_dir_162b"
 unset _bugbot_mock_dir_162b actual_output actual_exit
 
 # ---------------------------------------------------------------------------
+# Test 16.2c: CHANGES_REQUESTED review blocks even with an empty body
+# ---------------------------------------------------------------------------
+_bugbot_mock_dir_162c="$(mktemp -d)"
+cat > "$_bugbot_mock_dir_162c/gh" <<'BUGBOT_GH_162C'
+#!/usr/bin/env bash
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc162csha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"user":{"login":"cursor[bot]"},"submitted_at":"2020-01-02T00:00:00Z","state":"CHANGES_REQUESTED","body":""}]\n'
+    exit 0 ;;
+  *"check-runs"*)
+    printf '{"check_runs":[{"name":"Cursor Bugbot","app":{"slug":"cursor"},"status":"completed","conclusion":"success","started_at":"2020-01-01T00:00:00Z"}]}\n'
+    exit 0 ;;
+  *"headRefOid"*)
+    printf 'abc162csha\n'; exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+BUGBOT_GH_162C
+chmod +x "$_bugbot_mock_dir_162c/gh"
+
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_bugbot_overrides"
+  _ec=0
+  PATH="$_bugbot_mock_dir_162c:$PATH" run_bugbot_review "42" "feature/42-test" "1" "5" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "bugbot_changes_requested_empty_body_blocks_result" "RESULT=needs_fixes" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "bugbot_changes_requested_empty_body_blocks_count" "1" \
+  "$(printf '%s\n' "$actual_output" | grep "^BLOCKING_COUNT=" | cut -d= -f2)"
+run_test "bugbot_changes_requested_empty_body_blocks_exit_code" "1" "$actual_exit"
+rm -rf "$_bugbot_mock_dir_162c"
+unset _bugbot_mock_dir_162c actual_output actual_exit
+
+# ---------------------------------------------------------------------------
 # Test 16.3: escalate (timeout) — run appeared but never completed
 # poll_interval=1, max_wait=2: loop runs once (sets check_appeared=1 via
 # in_progress status), then budget exhausted → REASON=timeout

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2144,6 +2144,42 @@ run_test "bugbot_bot_login_env_override" "my-custom-bugbot[bot]" "$actual"
 unset BUGBOT_BOT_LOGIN
 
 # ---------------------------------------------------------------------------
+# Test 16.0c-d: Bugbot clean summary detection must not hide finding markers
+# ---------------------------------------------------------------------------
+bugbot_clean_body="Cursor Bugbot found no new issues in this pull request."
+if is_bugbot_clean_review "$bugbot_clean_body"; then
+  actual="clean"
+else
+  actual="blocking"
+fi
+run_test "bugbot_clean_phrase_is_non_blocking" "clean" "$actual"
+
+bugbot_mixed_body=$'Cursor Bugbot found no issues in this pull request.\n\n**High Severity**\n\n<!-- BUGBOT_BUG_ID: abc123 -->'
+if is_bugbot_clean_review "$bugbot_mixed_body"; then
+  actual="clean"
+else
+  actual="blocking"
+fi
+run_test "bugbot_finding_markers_override_clean_phrase" "blocking" "$actual"
+
+bugbot_multiline_body=$'Cursor Bugbot found no issues in this pull request.\n\nThis review still describes a blocking workflow problem.'
+if is_bugbot_clean_review "$bugbot_multiline_body"; then
+  actual="clean"
+else
+  actual="blocking"
+fi
+run_test "bugbot_clean_phrase_in_multiline_body_is_blocking" "blocking" "$actual"
+
+bugbot_same_line_severity_body="Cursor Bugbot found no issues in this pull request. **High Severity**: still broken"
+if is_bugbot_clean_review "$bugbot_same_line_severity_body"; then
+  actual="clean"
+else
+  actual="blocking"
+fi
+run_test "bugbot_same_line_severity_is_blocking" "blocking" "$actual"
+unset bugbot_clean_body bugbot_mixed_body bugbot_multiline_body bugbot_same_line_severity_body actual
+
+# ---------------------------------------------------------------------------
 # Test 16.1: clean path — check run conclusion=success, no blocking comments
 # ---------------------------------------------------------------------------
 _bugbot_mock_dir_161="$(mktemp -d)"
@@ -2247,6 +2283,50 @@ run_test "bugbot_needs_fixes_blocking_count_nonzero" "1" \
 run_test "bugbot_needs_fixes_exit_code" "1" "$actual_exit"
 rm -rf "$_bugbot_mock_dir_162"
 unset _bugbot_mock_dir_162 actual_output actual_exit
+
+# ---------------------------------------------------------------------------
+# Test 16.2b: CHANGES_REQUESTED review blocks even with clean body text
+# ---------------------------------------------------------------------------
+_bugbot_mock_dir_162b="$(mktemp -d)"
+cat > "$_bugbot_mock_dir_162b/gh" <<'BUGBOT_GH_162B'
+#!/usr/bin/env bash
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc162bsha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"user":{"login":"cursor[bot]"},"submitted_at":"2020-01-02T00:00:00Z","state":"CHANGES_REQUESTED","body":"Cursor Bugbot found no issues in this pull request."}]\n'
+    exit 0 ;;
+  *"check-runs"*)
+    printf '{"check_runs":[{"name":"Cursor Bugbot","app":{"slug":"cursor"},"status":"completed","conclusion":"success","started_at":"2020-01-01T00:00:00Z"}]}\n'
+    exit 0 ;;
+  *"headRefOid"*)
+    printf 'abc162bsha\n'; exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+BUGBOT_GH_162B
+chmod +x "$_bugbot_mock_dir_162b/gh"
+
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_bugbot_overrides"
+  _ec=0
+  PATH="$_bugbot_mock_dir_162b:$PATH" run_bugbot_review "42" "feature/42-test" "1" "5" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "bugbot_changes_requested_clean_body_blocks_result" "RESULT=needs_fixes" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "bugbot_changes_requested_clean_body_blocks_count" "1" \
+  "$(printf '%s\n' "$actual_output" | grep "^BLOCKING_COUNT=" | cut -d= -f2)"
+run_test "bugbot_changes_requested_clean_body_blocks_exit_code" "1" "$actual_exit"
+rm -rf "$_bugbot_mock_dir_162b"
+unset _bugbot_mock_dir_162b actual_output actual_exit
 
 # ---------------------------------------------------------------------------
 # Test 16.3: escalate (timeout) — run appeared but never completed

--- a/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+++ b/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
@@ -4,11 +4,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
-GIT_COMMON_DIR="$(cd "$SCRIPT_DIR" && git rev-parse --git-common-dir)"
-case "$GIT_COMMON_DIR" in
-  /*) REPO_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd -P)" ;;
-  *) REPO_ROOT="$(cd "$SCRIPT_DIR/$GIT_COMMON_DIR/.." && pwd -P)" ;;
-esac
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 HELPER="$REPO_ROOT/scripts/development-workflow/run-epic-audit-trail.sh"
 
 TMP_ROOT="$(mktemp -d)"
@@ -125,7 +121,7 @@ cat > "$pr_fixture" <<'JSON'
 {
   "scope_source": "epic #916",
   "item": {"number": 920, "title": "Add autonomous epic audit trail"},
-  "pr": {"number": 10, "head_sha": "abc123"},
+  "pr": {"number": 10, "head_sha": "abc123", "branch": "implementation-plan/audit-trail"},
   "reviewer": {"result": "clean", "blocking_count": 0, "advisory_count": 2},
   "advisories": [
     {"source": "haystack|triage", "category": "docs\nsync", "decision": "accepted", "rationale": "stale after rg verification with Authorization: dummy Bearer dummy.value"},
@@ -172,6 +168,40 @@ cat > "$pr_fixture" <<'JSON'
   "protocol_deviations": [
     {"action": "accepted advisory", "impact": "none | expected", "mitigation": "documented\nrationale\twith ghp_FAKE_PLACEHOLDER /tmp/fake-placeholder/local"}
   ],
+  "checkpoint_policy": {
+    "field_source": "recommended",
+    "recommended": [
+      {
+        "item_number": 920,
+        "stage": "plan",
+        "domain": "technical",
+        "reason": "schema signals",
+        "required_human_action": "approve data model",
+        "satisfaction_state": "pending"
+      }
+    ],
+    "selected": [
+      {
+        "item_number": 920,
+        "stage": "plan",
+        "domain": "technical",
+        "reason": "schema signals",
+        "required_human_action": "approve data model",
+        "satisfaction_state": "pending"
+      }
+    ],
+    "effective": [
+      {
+        "item_number": 920,
+        "stage": "plan",
+        "domain": "technical",
+        "reason": "schema signals",
+        "required_human_action": "approve data model",
+        "satisfaction_state": "satisfied",
+        "satisfied_by": "human-reviewer"
+      }
+    ]
+  },
   "notes": "token ghp_FAKE_PLACEHOLDER /tmp/fake-placeholder/local"
 }
 JSON
@@ -190,7 +220,7 @@ cat > "$ledger_fixture" <<'JSON'
     }
   },
   "items": [
-    {"issue_number": 920, "title": "Add autonomous | epic audit trail", "pr_number": 10, "tracker_status": "In Development", "risk_level": "medium", "review_result": "clean", "decision": "merge_approved", "merge_cleanup": "verified", "notes": "ready\nBearer token.value"},
+    {"issue_number": 920, "title": "Add autonomous | epic audit trail", "pr_number": 10, "tracker_status": "In Development", "risk_level": "medium", "review_result": "clean", "decision": "merge_approved", "merge_cleanup": "verified", "notes": "ready\nBearer token.value", "checkpoints": [{"item_number": 920, "stage": "plan", "domain": "technical", "satisfaction_state": "satisfied"}]},
     {"issue_number": 918, "title": "Add delegated review and merge loop", "tracker_status": "Backlog", "risk_level": "-", "review_result": "-", "decision": "blocked", "merge_cleanup": "-", "notes": "depends on #920", "stop_gate": "blocked dependency"}
   ]
 }
@@ -236,6 +266,16 @@ run_test "renders_advisory_decision" "yes" "$(grep -q 'accepted' <<< "$pr_output
 run_test "renders_protocol_deviation" "yes" "$(grep -q 'documented<br>rationale' <<< "$pr_output" && echo yes || echo no)"
 run_test "renders_invocation_policy" "yes" "$(grep -q '### Invocation Policy' <<< "$pr_output" && grep -q 'accepted recommended policy' <<< "$pr_output" && echo yes || echo no)"
 run_test "renders_policy_table" "yes" "$(grep -q '| mayStartBacklog | true | true | true |' <<< "$pr_output" && grep -q '| maxRisk | medium | medium | medium |' <<< "$pr_output" && echo yes || echo no)"
+run_test "renders_checkpoint_policy" "yes" "$(grep -q '### Checkpoint Policy' <<< "$pr_output" && grep -q 'approve data model' <<< "$pr_output" && echo yes || echo no)"
+run_test "pending_checkpoint_count_excludes_satisfied" "0" "$(printf '%s\n' "$pr_output" | grep 'Pending applicable checkpoints:' | sed 's/.*: //')"
+
+stage_scoped_fixture="$TMP_ROOT/stage-scoped-checkpoints.json"
+jq '.checkpoint_policy.effective = [
+  {"item_number": 920, "stage": "plan", "domain": "technical", "reason": "plan pending", "required_human_action": "approve plan", "satisfaction_state": "pending"},
+  {"item_number": 920, "stage": "implementation", "domain": "technical", "reason": "impl pending", "required_human_action": "approve impl", "satisfaction_state": "pending"}
+] | .pr.branch = "implementation-plan/audit-trail"' "$pr_fixture" > "$stage_scoped_fixture"
+stage_scoped_output="$("$HELPER" render-pr-disposition --input "$stage_scoped_fixture")"
+run_test "pending_count_scoped_to_pr_stage" "1" "$(printf '%s\n' "$stage_scoped_output" | grep 'Pending applicable checkpoints:' | sed 's/.*: //')"
 run_test "escapes_pr_table_pipes" "yes" "$(grep -Fq 'haystack\\|triage' <<< "$pr_output" && grep -Fq 'none \\| expected' <<< "$pr_output" && echo yes || echo no)"
 run_test "normalizes_pr_table_newlines_tabs" "yes" "$(grep -Fq 'docs<br>sync' <<< "$pr_output" && grep -Fq 'documented<br>rationale with' <<< "$pr_output" && echo yes || echo no)"
 run_test "redacts_sensitive_values" "yes" "$(! grep -Eq 'ghp_FAKE_PLACEHOLDER|Authorization: dummy|Bearer dummy\\.value|/tmp/fake-placeholder' <<< "$pr_output" && grep -Fq 'Authorization: [REDACTED]' <<< "$pr_output" && grep -Fq 'Bearer [REDACTED]' <<< "$pr_output" && echo yes || echo no)"
@@ -250,6 +290,7 @@ run_test "escapes_ledger_table_pipes" "yes" "$(grep -Fq 'Add autonomous \\| epic
 run_test "normalizes_ledger_newlines" "yes" "$(grep -Fq 'ready<br>Bearer [REDACTED]' <<< "$ledger_output" && echo yes || echo no)"
 run_test "ledger_notes_include_effective_policy" "yes" "$(grep -Fq 'Effective policy: mayStartBacklog=true, delegateReview=true, mayMerge=true, maxRisk=medium, base=develop-delegated-epic-orchestration' <<< "$ledger_output" && echo yes || echo no)"
 run_test "ledger_notes_include_stop_gate" "yes" "$(grep -Fq 'Stop gate: blocked dependency' <<< "$ledger_output" && echo yes || echo no)"
+run_test "ledger_notes_include_checkpoints" "yes" "$(grep -Fq 'Checkpoints: #920 plan/technical=satisfied' <<< "$ledger_output" && echo yes || echo no)"
 
 explicit_output="$("$HELPER" render-epic-ledger --input "$explicit_fixture")"
 run_test "explicit_items_skip_epic_ledger" "yes" "$(grep -q 'Not applicable' <<< "$explicit_output" && echo yes || echo no)"
@@ -266,6 +307,32 @@ run_fails_contains "comment_patch_failure_errors" "patch failed" env MOCK_COMMEN
 
 ledger_create_output="$("$HELPER" apply-epic-ledger --input "$ledger_fixture" --epic 900)"
 run_test "creates_epic_ledger_when_missing" "CREATED_COMMENT=1" "$ledger_create_output"
+
+ledger_root_checkpoint_fixture="$TMP_ROOT/ledger-root-checkpoints.json"
+cat > "$ledger_root_checkpoint_fixture" <<'JSON'
+{
+  "epic": {"number": 916, "title": "Delegated epic orchestration"},
+  "invocation_policy": {
+    "effective_policy": {
+      "mayStartBacklog": true,
+      "delegateReview": true,
+      "mayMerge": true,
+      "maxRisk": "medium",
+      "base": "develop-delegated-epic-orchestration",
+      "checkpoints": [
+        {"item_number": 920, "stage": "plan", "domain": "technical", "satisfaction_state": "pending"},
+        {"item_number": 918, "stage": "plan", "domain": "technical", "satisfaction_state": "pending"}
+      ]
+    }
+  },
+  "items": [
+    {"issue_number": 920, "title": "Item A", "tracker_status": "In Development", "decision": "merge_approved"},
+    {"issue_number": 918, "title": "Item B", "tracker_status": "Backlog", "decision": "blocked"}
+  ]
+}
+JSON
+root_checkpoint_ledger_output="$("$HELPER" render-epic-ledger --input "$ledger_root_checkpoint_fixture")"
+run_test "ledger_root_checkpoints_scoped_by_item" "yes" "$(grep -Fq 'Checkpoints: #920 plan/technical=pending' <<< "$root_checkpoint_ledger_output" && ! grep '#918' <<< "$(grep 'Item A' <<< "$root_checkpoint_ledger_output")" && echo yes || echo no)"
 ledger_update_output="$(MOCK_COMMENT_MODE=existing "$HELPER" apply-epic-ledger --input "$ledger_fixture" --epic 900)"
 run_test "updates_existing_epic_ledger_comment" "UPDATED_COMMENT_ID=456" "$ledger_update_output"
 

--- a/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
@@ -36,9 +36,12 @@ case "$*" in
     fi
     ;;
   pr\ view\ 42\ --json\ headRefOid*)
-    printf 'abc123\n'
+    printf '%s\n' "${MOCK_HEAD_SHA:-abc123}"
     ;;
-  api\ repos/lhpaul/ai-dev-framework-template/commits/abc123\ --jq\ .commit.committer.date\ //\ empty)
+  api\ repos/lhpaul/ai-dev-framework-template/commits/*\ --jq\ .commit.committer.date\ //\ empty)
+    if [ "${MOCK_HEAD_DATE_FAIL:-0}" = "1" ]; then
+      exit 1
+    fi
     printf '2026-06-22T11:30:00Z\n'
     ;;
   pr\ view\ 42\ --json\ reviews*)
@@ -185,6 +188,7 @@ satisfied_file="$TMP_ROOT/satisfied-checkpoints.json"
 MOCK_COMMENT_MODE=satisfied "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 --write-checkpoints-file "$satisfied_file" >/dev/null
 run_test "detect_satisfaction_via_comment" "satisfied" "$(jq -r '.[0].satisfaction_state' "$satisfied_file")"
 run_test "comment_before_head_does_not_satisfy" "pending" "$(MOCK_COMMENT_MODE=satisfied-before-head "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
+run_test "missing_head_date_does_not_satisfy_comment" "pending" "$(MOCK_HEAD_DATE_FAIL=1 MOCK_COMMENT_MODE=satisfied "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
 
 run_test "stale_approval_does_not_satisfy" "pending" "$(MOCK_REVIEW_STALE_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
 
@@ -213,6 +217,7 @@ cat > "$satisfied_plan_file" <<'JSON'
 ]
 JSON
 run_test "preserves_satisfied_checkpoint_on_later_stage_pr" "satisfied" "$( "$HELPER" detect-satisfaction --item 1022 --branch feature/human-checkpoints --checkpoints-file "$satisfied_plan_file" --pr 42 | jq -r '.[0].satisfaction_state')"
+run_test "preserves_earlier_stage_on_different_head" "satisfied" "$(MOCK_HEAD_SHA=def456 "$HELPER" detect-satisfaction --item 1022 --branch feature/human-checkpoints --checkpoints-file "$satisfied_plan_file" --pr 42 | jq -r '.[0].satisfaction_state')"
 
 stale_satisfied_plan_file="$TMP_ROOT/stale-satisfied-plan-checkpoints.json"
 cat > "$stale_satisfied_plan_file" <<'JSON'

--- a/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
@@ -38,6 +38,9 @@ case "$*" in
   pr\ view\ 42\ --json\ headRefOid*)
     printf 'abc123\n'
     ;;
+  api\ repos/lhpaul/ai-dev-framework-template/commits/abc123\ --jq\ .commit.committer.date\ //\ empty)
+    printf '2026-06-22T11:30:00Z\n'
+    ;;
   pr\ view\ 42\ --json\ reviews*)
     if [ "${MOCK_REVIEW_APPROVED:-0}" = "1" ]; then
       cat <<'JSON'
@@ -68,6 +71,10 @@ JSON
     if [ "${MOCK_COMMENT_MODE:-empty}" = "satisfied" ]; then
       cat <<'JSON'
 [[{"user":{"login":"human-reviewer"},"body":"<!-- run-epic:checkpoint-satisfied:1022:plan:technical -->","created_at":"2026-06-22T12:00:00Z"}]]
+JSON
+    elif [ "${MOCK_COMMENT_MODE:-empty}" = "satisfied-before-head" ]; then
+      cat <<'JSON'
+[[{"user":{"login":"human-reviewer"},"body":"<!-- run-epic:checkpoint-satisfied:1022:plan:technical -->","created_at":"2026-06-22T10:00:00Z"}]]
 JSON
     elif [ "${MOCK_COMMENT_MODE:-empty}" = "bot-satisfied" ]; then
       cat <<'JSON'
@@ -177,6 +184,7 @@ run_test "satisfied_earlier_stage_not_reblocked" "0" "$(printf '%s\n' "$impl_blo
 satisfied_file="$TMP_ROOT/satisfied-checkpoints.json"
 MOCK_COMMENT_MODE=satisfied "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 --write-checkpoints-file "$satisfied_file" >/dev/null
 run_test "detect_satisfaction_via_comment" "satisfied" "$(jq -r '.[0].satisfaction_state' "$satisfied_file")"
+run_test "comment_before_head_does_not_satisfy" "pending" "$(MOCK_COMMENT_MODE=satisfied-before-head "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
 
 run_test "stale_approval_does_not_satisfy" "pending" "$(MOCK_REVIEW_STALE_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
 
@@ -200,11 +208,19 @@ run_test "single_approval_satisfies_all_at_stage" "0" "$(MOCK_REVIEW_APPROVED=1 
 satisfied_plan_file="$TMP_ROOT/satisfied-plan-checkpoints.json"
 cat > "$satisfied_plan_file" <<'JSON'
 [
-  {"item_number": 1022, "stage": "plan", "domain": "technical", "required_human_action": "a", "satisfaction_state": "satisfied", "satisfied_by": "human"},
+  {"item_number": 1022, "stage": "plan", "domain": "technical", "required_human_action": "a", "satisfaction_state": "satisfied", "satisfied_by": "human", "satisfied_head_sha": "abc123"},
   {"item_number": 1022, "stage": "implementation", "domain": "technical", "required_human_action": "b", "satisfaction_state": "pending"}
 ]
 JSON
 run_test "preserves_satisfied_checkpoint_on_later_stage_pr" "satisfied" "$( "$HELPER" detect-satisfaction --item 1022 --branch feature/human-checkpoints --checkpoints-file "$satisfied_plan_file" --pr 42 | jq -r '.[0].satisfaction_state')"
+
+stale_satisfied_plan_file="$TMP_ROOT/stale-satisfied-plan-checkpoints.json"
+cat > "$stale_satisfied_plan_file" <<'JSON'
+[
+  {"item_number": 1022, "stage": "plan", "domain": "technical", "required_human_action": "a", "satisfaction_state": "satisfied", "satisfied_by": "human", "satisfied_head_sha": "oldsha"}
+]
+JSON
+run_test "stale_satisfied_head_reverts_to_pending" "pending" "$( "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$stale_satisfied_plan_file" --pr 42 | jq -r '.[0].satisfaction_state')"
 
 no_block_after="$("$HELPER" evaluate-blocking --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$satisfied_file")"
 run_test "satisfied_checkpoint_not_blocking" "0" "$(printf '%s\n' "$no_block_after" | jq 'length')"

--- a/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
@@ -47,6 +47,10 @@ JSON
       cat <<'JSON'
 [{"state":"APPROVED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T11:00:00Z","commit":{"oid":"oldsha"}},{"state":"CHANGES_REQUESTED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T12:00:00Z","commit":{"oid":"abc123"}}]
 JSON
+    elif [ "${MOCK_REVIEW_MISSING_SHA_APPROVED:-0}" = "1" ]; then
+      cat <<'JSON'
+[{"state":"APPROVED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T11:00:00Z","commit":{}}]
+JSON
     else
       printf '[]\n'
     fi
@@ -175,6 +179,8 @@ MOCK_COMMENT_MODE=satisfied "$HELPER" detect-satisfaction --item 1022 --branch i
 run_test "detect_satisfaction_via_comment" "satisfied" "$(jq -r '.[0].satisfaction_state' "$satisfied_file")"
 
 run_test "stale_approval_does_not_satisfy" "pending" "$(MOCK_REVIEW_STALE_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
+
+run_test "missing_sha_approval_does_not_satisfy" "pending" "$(MOCK_REVIEW_MISSING_SHA_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
 
 run_test "latest_approval_satisfies" "satisfied" "$(MOCK_REVIEW_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
 

--- a/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
+++ b/scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# test-run-epic-checkpoint-lifecycle.sh - Unit tests for checkpoint PR lifecycle.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+HELPER="$REPO_ROOT/scripts/development-workflow/run-epic-checkpoint-lifecycle.sh"
+
+TMP_ROOT="$(mktemp -d)"
+MOCK_BIN="$TMP_ROOT/bin"
+CALL_LOG="$TMP_ROOT/gh-calls.log"
+mkdir -p "$MOCK_BIN"
+: > "$CALL_LOG"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+cat > "$MOCK_BIN/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_GH_CALL_LOG"
+case "$*" in
+  auth\ status)
+    exit 0
+    ;;
+  repo\ view\ --json\ nameWithOwner\ --jq\ .nameWithOwner)
+    printf 'lhpaul/ai-dev-framework-template\n'
+    ;;
+  pr\ view\ 42\ --json\ labels\ --jq\ *)
+    if [ "${MOCK_HAS_CHECKPOINT_LABEL:-0}" = "1" ]; then
+      printf '1\n'
+    else
+      printf '0\n'
+    fi
+    ;;
+  pr\ view\ 42\ --json\ headRefOid*)
+    printf 'abc123\n'
+    ;;
+  pr\ view\ 42\ --json\ reviews*)
+    if [ "${MOCK_REVIEW_APPROVED:-0}" = "1" ]; then
+      cat <<'JSON'
+[{"state":"APPROVED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T12:00:00Z","commit":{"oid":"abc123"}}]
+JSON
+    elif [ "${MOCK_REVIEW_STALE_APPROVED:-0}" = "1" ]; then
+      cat <<'JSON'
+[{"state":"APPROVED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T11:00:00Z","commit":{"oid":"oldsha"}},{"state":"CHANGES_REQUESTED","author":{"login":"human-reviewer"},"submittedAt":"2026-06-22T12:00:00Z","commit":{"oid":"abc123"}}]
+JSON
+    else
+      printf '[]\n'
+    fi
+    ;;
+  pr\ view\ 42\ --json\ headRefOid\ --jq\ .headRefOid)
+    printf 'abc123\n'
+    ;;
+  pr\ edit\ 42\ --add-label\ human-checkpoint-required)
+    printf 'added\n'
+    ;;
+  pr\ edit\ 42\ --remove-label\ human-checkpoint-required)
+    printf 'removed\n'
+    ;;
+  api\ --paginate\ --slurp\ repos/lhpaul/ai-dev-framework-template/issues/42/comments\?per_page=100)
+    if [ "${MOCK_COMMENT_MODE:-empty}" = "satisfied" ]; then
+      cat <<'JSON'
+[[{"user":{"login":"human-reviewer"},"body":"<!-- run-epic:checkpoint-satisfied:1022:plan:technical -->","created_at":"2026-06-22T12:00:00Z"}]]
+JSON
+    elif [ "${MOCK_COMMENT_MODE:-empty}" = "bot-satisfied" ]; then
+      cat <<'JSON'
+[[{"user":{"login":"cursor[bot]"},"body":"<!-- run-epic:checkpoint-satisfied:1022:plan:technical -->","created_at":"2026-06-22T12:00:00Z"}]]
+JSON
+    elif [ "${MOCK_COMMENT_MODE:-empty}" = "waived-no-rationale" ]; then
+      cat <<'JSON'
+[[{"user":{"login":"human-reviewer"},"body":"<!-- run-epic:checkpoint-waived:1022:plan:technical -->","created_at":"2026-06-22T12:00:00Z"}]]
+JSON
+    elif [ "${MOCK_COMMENT_MODE:-empty}" = "existing-marker" ]; then
+      cat <<'JSON'
+[[{"id":999,"user":{"login":"bot"},"body":"<!-- run-epic:checkpoint-status -->\nold"}]]
+JSON
+    else
+      printf '[]\n'
+    fi
+    ;;
+  api\ -X\ PATCH\ repos/lhpaul/ai-dev-framework-template/issues/comments/999\ --input\ -)
+    printf '{"id":999}\n'
+    ;;
+  api\ -X\ POST\ repos/lhpaul/ai-dev-framework-template/issues/42/comments\ --input\ -)
+    printf '{"id":1000}\n'
+    ;;
+  *)
+    printf 'unexpected gh invocation: gh %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+MOCK_GH
+chmod +x "$MOCK_BIN/gh"
+export PATH="$MOCK_BIN:$PATH"
+export MOCK_GH_CALL_LOG="$CALL_LOG"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_fails_contains() {
+  local name="$1" expected="$2"
+  shift 2
+  local output status
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ] && grep -Fq -- "$expected" <<< "$output"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected failure containing '${expected}'"
+    printf 'Status: %s\nOutput:\n%s\n' "$status" "$output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+checkpoints_file="$TMP_ROOT/checkpoints.json"
+cat > "$checkpoints_file" <<'JSON'
+[
+  {
+    "item_number": 1022,
+    "stage": "plan",
+    "domain": "technical",
+    "reason": "schema changes",
+    "required_human_action": "approve data model",
+    "satisfaction_state": "pending"
+  },
+  {
+    "item_number": 9999,
+    "stage": "plan",
+    "domain": "technical",
+    "reason": "other item",
+    "required_human_action": "ignore",
+    "satisfaction_state": "pending"
+  }
+]
+JSON
+
+echo ""
+echo "=== Run epic checkpoint lifecycle ==="
+
+run_fails_contains "requires_known_subcommand" "unknown or missing subcommand" "$HELPER"
+run_test "stage_from_spec_branch" "spec" "$("$HELPER" stage-from-branch --branch spec/human-checkpoints)"
+run_test "stage_from_plan_branch" "plan" "$("$HELPER" stage-from-branch --branch implementation-plan/human-checkpoints)"
+
+blocking_output="$("$HELPER" evaluate-blocking --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file")"
+run_test "evaluate_blocking_plan_stage" "1" "$(printf '%s\n' "$blocking_output" | jq 'length')"
+run_test "evaluate_blocking_same_item_only" "1022" "$(printf '%s\n' "$blocking_output" | jq -r '.[0].item_number')"
+
+impl_blocking="$("$HELPER" evaluate-blocking --item 1022 --branch feature/human-checkpoints --checkpoints-file "$checkpoints_file")"
+run_test "earlier_plan_checkpoint_blocks_implementation_pr" "1" "$(printf '%s\n' "$impl_blocking" | jq 'length')"
+
+satisfied_plan_file="$TMP_ROOT/satisfied-plan-checkpoint.json"
+printf '%s\n' '[{"item_number":1022,"stage":"plan","domain":"technical","reason":"schema","required_human_action":"approve","satisfaction_state":"satisfied","satisfied_by":"human"}]' > "$satisfied_plan_file"
+impl_blocking_after_plan="$("$HELPER" evaluate-blocking --item 1022 --branch feature/human-checkpoints --checkpoints-file "$satisfied_plan_file")"
+run_test "satisfied_earlier_stage_not_reblocked" "0" "$(printf '%s\n' "$impl_blocking_after_plan" | jq 'length')"
+
+satisfied_file="$TMP_ROOT/satisfied-checkpoints.json"
+MOCK_COMMENT_MODE=satisfied "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 --write-checkpoints-file "$satisfied_file" >/dev/null
+run_test "detect_satisfaction_via_comment" "satisfied" "$(jq -r '.[0].satisfaction_state' "$satisfied_file")"
+
+run_test "stale_approval_does_not_satisfy" "pending" "$(MOCK_REVIEW_STALE_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
+
+run_test "latest_approval_satisfies" "satisfied" "$(MOCK_REVIEW_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
+
+run_test "bot_satisfaction_marker_ignored" "pending" "$(MOCK_COMMENT_MODE=bot-satisfied "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
+
+run_test "waived_without_rationale_ignored" "pending" "$(MOCK_COMMENT_MODE=waived-no-rationale "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file" --pr 42 | jq -r '.[0].satisfaction_state')"
+
+multi_domain_file="$TMP_ROOT/multi-domain-checkpoints.json"
+cat > "$multi_domain_file" <<'JSON'
+[
+  {"item_number": 1022, "stage": "plan", "domain": "technical", "required_human_action": "a", "satisfaction_state": "pending"},
+  {"item_number": 1022, "stage": "plan", "domain": "product", "required_human_action": "b", "satisfaction_state": "pending"}
+]
+JSON
+run_test "single_approval_satisfies_all_at_stage" "0" "$(MOCK_REVIEW_APPROVED=1 "$HELPER" detect-satisfaction --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$multi_domain_file" --pr 42 | jq '[.[] | select(.satisfaction_state == "pending")] | length')"
+
+satisfied_plan_file="$TMP_ROOT/satisfied-plan-checkpoints.json"
+cat > "$satisfied_plan_file" <<'JSON'
+[
+  {"item_number": 1022, "stage": "plan", "domain": "technical", "required_human_action": "a", "satisfaction_state": "satisfied", "satisfied_by": "human"},
+  {"item_number": 1022, "stage": "implementation", "domain": "technical", "required_human_action": "b", "satisfaction_state": "pending"}
+]
+JSON
+run_test "preserves_satisfied_checkpoint_on_later_stage_pr" "satisfied" "$( "$HELPER" detect-satisfaction --item 1022 --branch feature/human-checkpoints --checkpoints-file "$satisfied_plan_file" --pr 42 | jq -r '.[0].satisfaction_state')"
+
+no_block_after="$("$HELPER" evaluate-blocking --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$satisfied_file")"
+run_test "satisfied_checkpoint_not_blocking" "0" "$(printf '%s\n' "$no_block_after" | jq 'length')"
+
+comment_input="$TMP_ROOT/comment-input.json"
+jq -n \
+  --argjson item '{"number":1022}' \
+  --argjson pr '{"number":42,"branch":"implementation-plan/human-checkpoints","stage":"plan"}' \
+  --argjson checkpoints "$(cat "$checkpoints_file")" \
+  --argjson blocking "$(printf '%s\n' "$blocking_output")" \
+  '{
+    item: $item,
+    pr: $pr,
+    checkpoints: $checkpoints,
+    blocking: $blocking,
+    label_required: true,
+    satisfaction_signals: {
+      comment_marker: "<!-- run-epic:checkpoint-satisfied:1022:plan:technical -->",
+      waiver_marker: "<!-- run-epic:checkpoint-waived:1022:plan:technical --> rationale"
+    }
+  }' > "$comment_input"
+comment_output="$("$HELPER" render-pr-checkpoint-comment --input "$comment_input")"
+run_test "renders_checkpoint_marker" "yes" "$(grep -q '<!-- run-epic:checkpoint-status -->' <<< "$comment_output" && echo yes || echo no)"
+run_test "renders_blocking_section" "yes" "$(grep -q 'approve data model' <<< "$comment_output" && echo yes || echo no)"
+
+sync_output="$("$HELPER" sync-pr-labels --pr 42 --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file")"
+run_test "sync_applies_label_when_blocking" "LABEL_APPLIED=human-checkpoint-required" "$(grep '^LABEL_APPLIED=' <<< "$sync_output" || true)"
+run_test "sync_reports_blocking_count" "BLOCKING_COUNT=1" "$(grep '^BLOCKING_COUNT=' <<< "$sync_output" || true)"
+run_test "sync_comment_scoped_to_item" "yes" "$(grep -Fq 'POST repos/lhpaul/ai-dev-framework-template/issues/42/comments' "$CALL_LOG" && ! grep -Fq '#9999' "$CALL_LOG" && echo yes || echo no)"
+
+sync_remove_output="$(MOCK_HAS_CHECKPOINT_LABEL=1 MOCK_COMMENT_MODE=satisfied "$HELPER" sync-pr-labels --pr 42 --item 1022 --branch implementation-plan/human-checkpoints --checkpoints-file "$checkpoints_file")"
+run_test "sync_removes_label_when_satisfied" "LABEL_REMOVED=human-checkpoint-required" "$(grep '^LABEL_REMOVED=' <<< "$sync_remove_output" || true)"
+
+echo ""
+echo "=== Summary ==="
+echo "Passed: $PASS_COUNT"
+echo "Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
@@ -263,6 +263,12 @@ pending_checkpoint_fixture="$(write_fixture pending-checkpoint '.item.number = 1
 run_test "pending_checkpoint_requires_human" "human_required" "$(decision_for "$pending_checkpoint_fixture")"
 run_test "pending_checkpoint_reason_names_action" "true" "$(reason_match_for "$pending_checkpoint_fixture" "approve delegated gate checkpoint handling")"
 
+snake_case_checkpoint_fixture="$(write_fixture snake-case-checkpoint '.item.number = 1023 | .pr.headRefName = "feature/1023-human-checkpoint-gates" | .policy.effective_policy.checkpoints = [{"item_number":1023,"stage":"implementation","domain":"technical","reason":"snake case policy","required_human_action":"approve snake case checkpoint","satisfaction_state":"pending"}]')"
+run_test "snake_case_policy_checkpoint_requires_human" "human_required" "$(decision_for "$snake_case_checkpoint_fixture")"
+
+invocation_policy_checkpoint_fixture="$(write_fixture invocation-policy-checkpoint '.item.number = 1023 | .pr.headRefName = "feature/1023-human-checkpoint-gates" | .invocation_policy.effective_policy.checkpoints = [{"item_number":1023,"stage":"implementation","domain":"technical","reason":"invocation policy","required_human_action":"approve invocation checkpoint","satisfaction_state":"pending"}]')"
+run_test "invocation_policy_checkpoint_requires_human" "human_required" "$(decision_for "$invocation_policy_checkpoint_fixture")"
+
 satisfied_checkpoint_fixture="$(write_fixture satisfied-checkpoint '.item.number = 1023 | .pr.headRefName = "feature/1023-human-checkpoint-gates" | .policy.checkpoints = [{"item_number":1023,"stage":"implementation","domain":"technical","reason":"sensitive merge gate behavior","required_human_action":"approve delegated gate checkpoint handling","satisfaction_state":"satisfied","satisfied_by":"lhpaul"}]')"
 run_test "satisfied_checkpoint_allows_merge" "merge_allowed" "$(decision_for "$satisfied_checkpoint_fixture")"
 

--- a/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
@@ -259,6 +259,22 @@ run_test "risk_gate_accepts_classifier_shape" "merge_allowed" "$(decision_for "$
 missing_risk_fixture="$(write_fixture missing-risk 'del(.risk)')"
 run_test "missing_risk_gate_requires_human" "human_required" "$(decision_for "$missing_risk_fixture")"
 
+pending_checkpoint_fixture="$(write_fixture pending-checkpoint '.item.number = 1023 | .pr.headRefName = "feature/1023-human-checkpoint-gates" | .policy.checkpoints = [{"item_number":1023,"stage":"implementation","domain":"technical","reason":"sensitive merge gate behavior","required_human_action":"approve delegated gate checkpoint handling","satisfaction_state":"pending"}]')"
+run_test "pending_checkpoint_requires_human" "human_required" "$(decision_for "$pending_checkpoint_fixture")"
+run_test "pending_checkpoint_reason_names_action" "true" "$(reason_match_for "$pending_checkpoint_fixture" "approve delegated gate checkpoint handling")"
+
+satisfied_checkpoint_fixture="$(write_fixture satisfied-checkpoint '.item.number = 1023 | .pr.headRefName = "feature/1023-human-checkpoint-gates" | .policy.checkpoints = [{"item_number":1023,"stage":"implementation","domain":"technical","reason":"sensitive merge gate behavior","required_human_action":"approve delegated gate checkpoint handling","satisfaction_state":"satisfied","satisfied_by":"lhpaul"}]')"
+run_test "satisfied_checkpoint_allows_merge" "merge_allowed" "$(decision_for "$satisfied_checkpoint_fixture")"
+
+other_item_checkpoint_fixture="$(write_fixture other-item-checkpoint '.item.number = 1023 | .pr.headRefName = "feature/1023-human-checkpoint-gates" | .policy.checkpoints = [{"item_number":9999,"stage":"implementation","domain":"technical","reason":"other item","required_human_action":"ignore","satisfaction_state":"pending"}]')"
+run_test "other_item_checkpoint_does_not_block" "merge_allowed" "$(decision_for "$other_item_checkpoint_fixture")"
+
+future_stage_checkpoint_fixture="$(write_fixture future-stage-checkpoint '.item.number = 1023 | .pr.headRefName = "implementation-plan/1023-human-checkpoint-gates" | .policy.checkpoints = [{"item_number":1023,"stage":"implementation","domain":"technical","reason":"future implementation review","required_human_action":"approve implementation","satisfaction_state":"pending"}]')"
+run_test "future_stage_checkpoint_does_not_block" "merge_allowed" "$(decision_for "$future_stage_checkpoint_fixture")"
+
+stale_checkpoint_label_fixture="$(write_fixture stale-checkpoint-label '.pr.labels += ["human-checkpoint-required"]')"
+run_test "stale_checkpoint_label_requires_human" "human_required" "$(decision_for "$stale_checkpoint_label_fixture")"
+
 audit_fixture="$(write_fixture audit-missing '.pr.auditDispositionPresent = false')"
 run_test "audit_required_before_merge" "blocked" "$(decision_for "$audit_fixture")"
 

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -219,6 +219,92 @@ run_test "text_output_names_effective_policy" "yes" "$(grep -q 'Effective policy
 PATH="$MOCK_BIN:$PATH" "$HELPER" --scope "$backlog_fixture" --original-command "\$run-epic issues 949" --json >/dev/null
 run_test "does_not_call_gh_or_git" "0" "$(wc -l < "$CALL_LOG" | tr -d ' ')"
 
+schema_fixture="$(write_fixture schema '{
+  "scopeSource": "items",
+  "epicNumber": null,
+  "itemInput": "200",
+  "baseBranch": "develop",
+  "baseAmbiguous": false,
+  "baseReason": "no integration branch label",
+  "policy": {"delegateReview": false, "mayMerge": false, "mayStartBacklog": false, "maxRisk": "low"},
+  "groups": {
+    "eligible": [{"number": 200, "title": "Add users table database migration", "status": "Backlog", "type": "Feature", "labels": ["database"], "dependencies": {"state": "none"}}],
+    "blocked": [],
+    "already_merged": [],
+    "in_review": [],
+    "ambiguous": []
+  },
+  "items": [
+    {"number": 200, "title": "Add users table database migration", "status": "Backlog", "type": "Feature", "labels": ["database"], "dependencies": {"state": "none"}}
+  ]
+}')"
+schema_output="$(recommend_json "$schema_fixture" "\$run-epic --items 200")"
+run_test "schema_scope_recommends_plan_checkpoint" "plan:technical" "$(printf '%s\n' "$schema_output" | jq -r '.recommendedPolicy.checkpoints[0] | .stage + ":" + .domain')"
+run_test "schema_checkpoint_pending" "pending" "$(printf '%s\n' "$schema_output" | jq -r '.recommendedPolicy.checkpoints[0].satisfaction_state')"
+run_test "schema_checkpoint_requires_confirmation" "true" "$(printf '%s\n' "$schema_output" | jq -r '.requiresConfirmation')"
+run_test "schema_copy_paste_includes_checkpoint_file" "yes" "$(printf '%s\n' "$schema_output" | jq -r '.copyPasteCommand' | grep -Fq -- '--checkpoints-file checkpoint-policy.json' && echo yes || echo no)"
+
+sensitive_fixture="$(write_fixture sensitive '{
+  "scopeSource": "items",
+  "epicNumber": null,
+  "itemInput": "300",
+  "baseBranch": "develop",
+  "baseAmbiguous": false,
+  "baseReason": "no integration branch label",
+  "policy": {"delegateReview": false, "mayMerge": false, "mayStartBacklog": false, "maxRisk": "low"},
+  "groups": {
+    "eligible": [],
+    "blocked": [],
+    "already_merged": [],
+    "in_review": [{"number": 300, "title": "Harden auth permission checks", "status": "Development in Review", "type": "Feature", "labels": []}],
+    "ambiguous": []
+  },
+  "items": [
+    {"number": 300, "title": "Harden auth permission checks", "status": "Development in Review", "type": "Feature", "labels": [], "group": "in_review"}
+  ]
+}')"
+sensitive_output="$(recommend_json "$sensitive_fixture" "\$run-epic --items 300")"
+run_test "sensitive_scope_recommends_implementation_checkpoint" "implementation:technical" "$(printf '%s\n' "$sensitive_output" | jq -r '.recommendedPolicy.checkpoints[0] | .stage + ":" + .domain')"
+
+run_test "docs_scope_has_no_checkpoints" "0" "$(printf '%s\n' "$docs_output" | jq -r '.recommendedPolicy.checkpoints | length')"
+
+waived_file="$TMP_ROOT/waived-checkpoints.json"
+printf '%s\n' '[{
+  "item_number": 200,
+  "stage": "plan",
+  "domain": "technical",
+  "reason": "issue signals database schema, migration, or persistent data-model changes",
+  "required_human_action": "review and approve proposed data model in the plan before implementation proceeds",
+  "satisfaction_state": "waived",
+  "waiver_rationale": "schema change is additive only and pre-approved in epic brief"
+}]' > "$waived_file"
+waived_output="$("$HELPER" --scope "$schema_fixture" --original-command "\$run-epic --items 200" --checkpoints-file "$waived_file" --json)"
+run_test "explicit_checkpoint_override_source" "explicit" "$(printf '%s\n' "$waived_output" | jq -r '.fieldSources.checkpoints')"
+run_test "waived_checkpoint_preserved" "waived" "$(printf '%s\n' "$waived_output" | jq -r '.effectivePolicy.checkpoints[0].satisfaction_state')"
+run_test "checkpoint_policy_audit_fields_present" "yes" "$(printf '%s\n' "$waived_output" | jq -e '.checkpointPolicy.recommended and .checkpointPolicy.selected and .checkpointPolicy.effective' >/dev/null && echo yes || echo no)"
+
+invalid_waived_file="$TMP_ROOT/invalid-waived.json"
+printf '%s\n' '[{"item_number": 200, "stage": "plan", "domain": "technical", "satisfaction_state": "waived"}]' > "$invalid_waived_file"
+run_fails_contains "rejects_waived_without_rationale" "waived checkpoints require waiver_rationale" "$HELPER" --scope "$schema_fixture" --original-command x --checkpoints-file "$invalid_waived_file" --json
+
+empty_checkpoints_file="$TMP_ROOT/empty-checkpoints.json"
+printf '%s\n' '[]' > "$empty_checkpoints_file"
+empty_override_output="$("$HELPER" --scope "$schema_fixture" --original-command "\$run-epic --items 200" --checkpoints-file "$empty_checkpoints_file" --json)"
+run_test "empty_checkpoint_override_keeps_recommended" "1" "$(printf '%s\n' "$empty_override_output" | jq -r '.effectivePolicy.checkpoints | length')"
+run_test "empty_checkpoint_override_still_requires_confirmation" "true" "$(printf '%s\n' "$empty_override_output" | jq -r '.requiresConfirmation')"
+
+checkpoint_text_output="$("$HELPER" --scope "$schema_fixture" --original-command "\$run-epic --items 200")"
+run_test "text_output_lists_checkpoints" "yes" "$(grep -q 'Human checkpoints' <<< "$checkpoint_text_output" && echo yes || echo no)"
+
+blocked_schema_fixture="$(write_fixture blocked-schema "$(jq '
+  .groups.eligible = []
+  | .groups.blocked = [.items[0] | .group = "blocked" | .dependencies.state = "blocked"]
+  | .items[0].group = "blocked"
+  | .items[0].dependencies.state = "blocked"
+' "$schema_fixture")")"
+blocked_schema_output="$(recommend_json "$blocked_schema_fixture" "\$run-epic --items 200")"
+run_test "blocked_item_skips_checkpoint_recommendation" "0" "$(printf '%s\n' "$blocked_schema_output" | jq -r '.recommendedPolicy.checkpoints | length')"
+
 echo ""
 echo "=== Summary ==="
 echo "Passed: $PASS_COUNT"

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -266,6 +266,28 @@ sensitive_fixture="$(write_fixture sensitive '{
 sensitive_output="$(recommend_json "$sensitive_fixture" "\$run-epic --items 300")"
 run_test "sensitive_scope_recommends_implementation_checkpoint" "implementation:technical" "$(printf '%s\n' "$sensitive_output" | jq -r '.recommendedPolicy.checkpoints[0] | .stage + ":" + .domain')"
 
+sensitive_backlog_fixture="$(write_fixture sensitive-backlog '{
+  "scopeSource": "items",
+  "epicNumber": null,
+  "itemInput": "301",
+  "baseBranch": "develop",
+  "baseAmbiguous": false,
+  "baseReason": "no integration branch label",
+  "policy": {"delegateReview": false, "mayMerge": false, "mayStartBacklog": false, "maxRisk": "low"},
+  "groups": {
+    "eligible": [{"number": 301, "title": "Add account controls", "body": "Must handle auth permissions before delegated merge.", "status": "Backlog", "type": "Feature", "labels": []}],
+    "blocked": [],
+    "already_merged": [],
+    "in_review": [],
+    "ambiguous": []
+  },
+  "items": [
+    {"number": 301, "title": "Add account controls", "body": "Must handle auth permissions before delegated merge.", "status": "Backlog", "type": "Feature", "labels": []}
+  ]
+}')"
+sensitive_backlog_output="$(recommend_json "$sensitive_backlog_fixture" "\$run-epic --items 301")"
+run_test "sensitive_backlog_recommends_implementation_checkpoint" "implementation:technical" "$(printf '%s\n' "$sensitive_backlog_output" | jq -r '.recommendedPolicy.checkpoints[0] | .stage + ":" + .domain')"
+
 run_test "docs_scope_has_no_checkpoints" "0" "$(printf '%s\n' "$docs_output" | jq -r '.recommendedPolicy.checkpoints | length')"
 
 waived_file="$TMP_ROOT/waived-checkpoints.json"

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -291,6 +291,7 @@ empty_checkpoints_file="$TMP_ROOT/empty-checkpoints.json"
 printf '%s\n' '[]' > "$empty_checkpoints_file"
 empty_override_output="$("$HELPER" --scope "$schema_fixture" --original-command "\$run-epic --items 200" --checkpoints-file "$empty_checkpoints_file" --json)"
 run_test "empty_checkpoint_override_keeps_recommended" "1" "$(printf '%s\n' "$empty_override_output" | jq -r '.effectivePolicy.checkpoints | length')"
+run_test "empty_checkpoint_override_source_remains_recommended" "recommended" "$(printf '%s\n' "$empty_override_output" | jq -r '.fieldSources.checkpoints')"
 run_test "empty_checkpoint_override_still_requires_confirmation" "true" "$(printf '%s\n' "$empty_override_output" | jq -r '.requiresConfirmation')"
 
 checkpoint_text_output="$("$HELPER" --scope "$schema_fixture" --original-command "\$run-epic --items 200")"

--- a/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
@@ -262,6 +262,7 @@ run_test "conflicting_labels_ambiguous" "2" "$(printf '%s\n' "$ambiguous_output"
 
 dependency_output="$(run_json --items 104)"
 run_test "satisfied_dependency_not_blocked" "eligible" "$(printf '%s\n' "$dependency_output" | jq -r '.items[0].group')"
+run_test "resolver_items_include_issue_body" "Depends on #103" "$(printf '%s\n' "$dependency_output" | jq -r '.items[0].body')"
 
 blocked_output="$(run_json --items 107)"
 run_test "blocked_dependency_group_detected" "blocked" "$(printf '%s\n' "$blocked_output" | jq -r '.items[0].group')"

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -229,8 +229,8 @@ is_bugbot_clean_review() {
       return 1
     fi
   done <<< "$body"
-  case "$body" in
-    *"found no new issues"*|*"found no potential issues"*|*"found no issues"*)
+  case "$normalized_line" in
+    "Cursor Bugbot found no new issues in this pull request."|"Cursor Bugbot found no potential issues in this pull request."|"Cursor Bugbot found no issues in this pull request.")
       return 0
       ;;
   esac

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -203,6 +203,40 @@ is_soft_suggestion() {
   [ "$saw_content" -eq 1 ]
 }
 
+is_bugbot_clean_review() {
+  local body="$1"
+  local line
+  local normalized_line
+  local non_empty_count=0
+
+  case "$body" in
+    *BUGBOT_BUG_ID*|*BUGBOT_REVIEW*|*"LOCATIONS START"*|*"DESCRIPTION START"*|*"Triggered by project rule"*|*'**High Severity**'*|*'**Medium Severity**'*|*'**Low Severity**'*)
+      return 1
+      ;;
+  esac
+  case "$body" in
+    *"found 1 potential issue"*|*"found 2 potential issue"*|*"found 3 potential issue"*|*"found 4 potential issue"*|*"found 5 potential issue"*)
+      return 1
+      ;;
+  esac
+  while IFS= read -r line; do
+    normalized_line="${line%$'\r'}"
+    normalized_line="${normalized_line#"${normalized_line%%[![:space:]]*}"}"
+    normalized_line="${normalized_line%"${normalized_line##*[![:space:]]}"}"
+    [ -z "$normalized_line" ] && continue
+    non_empty_count=$((non_empty_count + 1))
+    if [ "$non_empty_count" -gt 1 ]; then
+      return 1
+    fi
+  done <<< "$body"
+  case "$body" in
+    *"found no new issues"*|*"found no potential issues"*|*"found no issues"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 open_pr_number_for_branch() {
   require_gh
   gh pr list --head "$1" --state open --limit 100 --json number --jq '.[0].number // empty'


### PR DESCRIPTION
Graduates the `develop-run-epic-human-checkpoints` integration branch into `develop`. This epic adds an upfront human-checkpoint policy model for delegated `/run-epic` work, carries checkpoint requirements through PR readiness and audit evidence, enforces unsatisfied checkpoint blocks in delegated and batch merge gates, and documents the end-to-end lifecycle for future workflow runs.

Sub-items included:

- #1020 Specify human-checkpoint policy model for run-epic (PR #1029 spec, PR #1030 plan)
- #1021 Recommend upfront human checkpoints in run-epic policy (PR #1031)
- #1022 Carry human checkpoints through PR readiness lifecycle (PR #1032)
- #1023 Enforce human checkpoints in delegated and batch merge gates (PR #1034)
- #1024 Document and test the human-checkpoint lifecycle (PR #1036)

Merge strategy: **merge commit** (not squash or rebase).

Optional/deferred sub-items: none. Final scope resolution reported `eligible=0`, `blocked=0`, and `already_merged=5`.

Notes:

- `develop-run-epic-human-checkpoints` is 1 commit behind `develop`; the divergence was surfaced before opening this PR and graduation was approved.
- Graduation PRs are exempt from `ready-for-regression`; all implementation changes were reviewed and tested in the sub-item PRs before landing on the integration branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delegated merge and batch-merge gates plus orchestration protocols; risk is mitigated by read-only recommender phases, explicit waiver rules, and extensive fixture tests rather than production app runtime.
> 
> **Overview**
> Merges the **human-checkpoint** integration branch into `develop`, so delegated `/run-epic` runs can declare per-item human stops before mutation and enforce them through merge automation.
> 
> **Policy and preflight:** `run-epic-policy-recommender.sh` now infers `checkpoints[]` from read-only item metadata (schema/migration, product ambiguity, sensitive implementation, etc.), supports `--checkpoints-file` for accept/waive, and requires confirmation when pending checkpoints remain. Scope resolver output includes issue **body** for those signals. Agent/command docs call out **checkpoint policy** in the initial summary and audit trail.
> 
> **PR lifecycle:** New `run-epic-checkpoint-lifecycle.sh` syncs `human-checkpoint-required`, detects satisfaction/waiver from markers or human approval, and maintains `<!-- run-epic:checkpoint-status -->` comments. Protocols **91** and **92** define label rules (orthogonal to `ready-for-human-review`). Audit renders include checkpoint policy and pending counts.
> 
> **Gates:** `run-epic-delegated-gate.sh` returns `human_required` for applicable pending checkpoints or stale checkpoint labels. `batch-merge.sh` skips checkpointed PRs by default (`PR_HAS_HUMAN_CHECKPOINT`, `--include-checkpointed`) and refuses merge while the label is present.
> 
> **Collateral:** Spec/plan for #1020, guardrails stop `human_checkpoint_required`, smoke runbook **1024**, CHANGELOG entries, and broad shell test coverage.
> 
> **Reviewer loop (related hardening):** `is_bugbot_clean_review` and `CHANGES_REQUESTED` handling in `pr-review-loop.sh` so clean Bugbot phrases and empty bodies do not clear blocking review state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caadf601aaa5f7032575ec2033d95574c6c369d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->