### PR TITLE
fix(post-merge-cleanup): tolerate deleted local branch (#1039)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Post-merge cleanup missing local branch** (#1039): `post-merge-cleanup.sh`
+  continues fetch, base checkout, and tracker closeout when the local branch is
+  already deleted but a merged PR exists for that branch head (common after
+  delegated merge with `--delete-branch`).
 - **Workflow-hub base branch routing**: `/run-epic` scope resolution and
   spec/plan orchestration now distinguish hub artifact bases from product
   implementation bases, so a hub repository can use `main` while product

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -182,12 +182,39 @@ print_kv TRACKER_REPO_ROOT "$HUB_REPO_ROOT"
 
 cd "$CLEANUP_REPO_ROOT" || exit 1
 
+LOCAL_BRANCH_MISSING=0
+VERIFIED_MERGED_PR=""
 if ! git show-ref --quiet "refs/heads/$TO_DELETE"; then
-  echo "Local branch '$TO_DELETE' does not exist." >&2
-  exit 2
+  merged_pr_lookup_repo="$TARGET_GITHUB_REPO"
+  if [ -z "$merged_pr_lookup_repo" ]; then
+    if ! merged_pr_lookup_repo="$(repo_slug)"; then
+      echo "Local branch '$TO_DELETE' does not exist and merged PR lookup repo could not be resolved." >&2
+      exit 2
+    fi
+  fi
+  if ! VERIFIED_MERGED_PR="$(gh pr list \
+    --repo "$merged_pr_lookup_repo" \
+    --state merged \
+    --head "$TO_DELETE" \
+    --limit 1 \
+    --json number \
+    --jq '.[0].number // empty')"; then
+    echo "Local branch '$TO_DELETE' does not exist and merged PR lookup failed (gh command failed)." >&2
+    exit 2
+  fi
+  if [ -z "$VERIFIED_MERGED_PR" ]; then
+    echo "Local branch '$TO_DELETE' does not exist and no merged PR was found for that branch head." >&2
+    exit 2
+  fi
+  LOCAL_BRANCH_MISSING=1
+  echo "Local branch '$TO_DELETE' is already gone; verified merged PR #${VERIFIED_MERGED_PR} — continuing with fetch, base update, and tracker cleanup."
 fi
 
-echo "Post-merge cleanup: will switch to $DEVELOP_BRANCH in $CLEANUP_REPO_ROOT, update it, and delete local branch '$TO_DELETE'."
+if [ "$LOCAL_BRANCH_MISSING" -eq 1 ]; then
+  echo "Post-merge cleanup: will switch to $DEVELOP_BRANCH in $CLEANUP_REPO_ROOT (local branch '$TO_DELETE' already removed)."
+else
+  echo "Post-merge cleanup: will switch to $DEVELOP_BRANCH in $CLEANUP_REPO_ROOT, update it, and delete local branch '$TO_DELETE'."
+fi
 echo ""
 
 echo "Fetching origin..."
@@ -201,6 +228,9 @@ echo "Pulling $DEVELOP_BRANCH..."
 # --ff-only: fail cleanly if develop diverged (e.g. local commits) instead of creating a merge
 git pull --ff-only
 
+if [ "$LOCAL_BRANCH_MISSING" -eq 1 ]; then
+  echo "Skipping local branch delete for '$TO_DELETE' (already absent)."
+else
 echo "Deleting local branch '$TO_DELETE'..."
 # Check whether a worktree is still using this branch; if so, remove it first.
 # git branch -D fails with "error: cannot delete branch 'X' used by worktree" in that case.
@@ -246,6 +276,7 @@ if [ -n "$WORKTREE_PATH" ]; then
 fi
 # -D: branch is already merged on remote (squash/rebase merges don't leave tip in develop)
 git branch -D "$TO_DELETE"
+fi
 
 # --- Update tracker status and close associated GitHub issue (if any) ---
 
@@ -337,6 +368,11 @@ if [ -n "$ISSUE_IDENTIFIER" ]; then
       }
       if [ -n "$MERGED_PR" ]; then
         CLOSE_COMMENT="Closed by PR #${MERGED_PR}."
+      elif [ -n "$VERIFIED_MERGED_PR" ]; then
+        MERGED_PR="$VERIFIED_MERGED_PR"
+        CLOSE_COMMENT="Closed by PR #${MERGED_PR}."
+      fi
+      if [ -n "$MERGED_PR" ]; then
         echo "Closing issue #$ISSUE_NUMBER..."
         if gh issue close "$ISSUE_NUMBER" --comment "$CLOSE_COMMENT"; then
           echo "Reasserting issue #$ISSUE_NUMBER tracker status as Merged after close..."
@@ -366,4 +402,8 @@ else
 fi
 
 echo ""
-echo "Done. You are on $DEVELOP_BRANCH and '$TO_DELETE' has been removed locally."
+if [ "$LOCAL_BRANCH_MISSING" -eq 1 ]; then
+  echo "Done. You are on $DEVELOP_BRANCH; local branch '$TO_DELETE' was already removed."
+else
+  echo "Done. You are on $DEVELOP_BRANCH and '$TO_DELETE' has been removed locally."
+fi

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -264,7 +264,14 @@ case "$1" in
           exit 0
           ;;
         *" --json number "*)
-          [ -n "${GH_PR_LIST_NUMBER:-}" ] && printf '%s\n' "$GH_PR_LIST_NUMBER"
+          if [ -n "${GH_PR_LIST_NUMBER:-}" ]; then
+            printf '%s\n' "$GH_PR_LIST_NUMBER"
+            exit 0
+          fi
+          if [ -n "${GH_PR_LIST_HEAD:-}" ] && [[ " $* " == *" --head ${GH_PR_LIST_HEAD} "* ]]; then
+            printf '%s\n' "${GH_PR_LIST_HEAD_NUMBER:-42}"
+            exit 0
+          fi
           exit 0
           ;;
       esac
@@ -439,6 +446,25 @@ run_contains \
   "post_merge_cleanup_deletes_integration_branch" \
   "Deleted branch spec/integration-cleanup" \
   "$cleanup_output"
+
+already_deleted_output="$(
+  GH_PR_LIST_BASE=develop-workflow-hub-mode \
+  GH_PR_LIST_HEAD=spec/already-deleted \
+  GH_PR_LIST_HEAD_NUMBER=99 \
+  WORKFLOW_TARGET_GITHUB_REPO=example/workflow-hub \
+  PATH="$stub_bin:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/post-merge-cleanup.sh" \
+    --repo-root "$cleanup_repo" \
+    spec/already-deleted
+)"
+run_contains \
+  "post_merge_cleanup_continues_when_local_branch_missing" \
+  "already gone; verified merged PR #99" \
+  "$already_deleted_output"
+run_contains \
+  "post_merge_cleanup_skips_delete_when_local_branch_missing" \
+  "Skipping local branch delete" \
+  "$already_deleted_output"
 
 echo ""
 echo "Passed: $PASS_COUNT"


### PR DESCRIPTION
## Summary

- When `post-merge-cleanup.sh` is invoked for a branch name whose local ref is already gone, verify a merged PR exists for that head via `gh pr list` and continue cleanup instead of exiting with error code 2.
- Still runs fetch, base checkout/pull, and tracker status/close logic; skips worktree removal and `git branch -D` when the local branch is absent.
- Reuses the verified merged PR number when closing implementation issues if the second lookup is redundant.

## Test plan

- [x] `bash scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh` (40 passed, including new missing-branch cases)
- [ ] Manual: merge a PR with `--delete-branch`, delete local branch if still present, run `post-merge-cleanup.sh <branch>` and confirm tracker closeout completes

Closes #1039


Made with [Cursor](https://cursor.com)