### PR TITLE
fix(workflow): reviewer-loop preflight for Bugbot/Haystack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and validates `ci_policy` (`required` vs explicit `none`) before delegated
   orchestration. Hub `workflow_hub.product_repos[]` accepts optional `ci_policy`;
   delegated merge gates honor `ciPolicy: none` when CI checks are absent.
+- **Reviewer-loop preflight guards** (#1028, #1035, #1037): Bugbot activation is
+  detected from `cursor[bot]` comments before polling; Haystack triage HTTP 401/403
+  errors fail fast with `REASON=unauthorized`/`forbidden` instead of
+  `pending_timeout`; draft PRs skip Haystack with `REASON=pr-is-draft` and guidance
+  to mark ready before rerunning.
 
 ### Fixed
 

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -26,7 +26,7 @@
 #   DISPLAY_RESULT=<value> (optional; used by pr-review-loop.sh summaries)
 #   POLICY_REVIEW_REQUIRED=0|1 (optional; present when pr-status is available)
 #   REASON=<value>   (only when RESULT=skipped — values: unavailable, timeout,
-#                     pending_timeout)
+#                     pending_timeout, unauthorized, forbidden)
 #
 # Polling behaviour for transient states (status=pending, status=error, etc.):
 #   When `haystack triage --no-wait` returns ANY non-empty status value other
@@ -38,7 +38,9 @@
 #   "status" field — this is the only condition under which RESULT=clean may be
 #   emitted.  If the budget is exhausted while the analysis is still transient,
 #   RESULT=skipped is emitted with REASON=pending_timeout (distinct from
-#   REASON=unavailable, which means the CLI is absent or authentication failed,
+#   REASON=unavailable, which means the CLI is absent or triage returned
+#   status=none; REASON=unauthorized/forbidden for triage status=error with
+#   message=HTTP 401/403 (surfaced immediately, not poll-retried);
 #   and REASON=timeout, which means a single haystack triage call exceeded the
 #   per-call OS timeout).
 #
@@ -198,6 +200,26 @@ echo "INFO: poll-retry loop — polling every ${POLL_INTERVAL}s, overall timeout
 # invocation of `haystack triage` against a hung network call. It is capped to
 # at most half the remaining budget so the loop always gets at least one retry
 # after a timed-out call.
+
+haystack_triage_auth_error_reason() {
+  local triage_output="$1"
+  local status message
+
+  status="$(printf '%s\n' "$triage_output" | jq -r '.status // empty' 2>/dev/null || true)"
+  [ "$status" != "error" ] && return 1
+  message="$(printf '%s\n' "$triage_output" | jq -r '.message // empty' 2>/dev/null || true)"
+  case "$message" in
+    HTTP\ 401)
+      printf 'unauthorized'
+      return 0
+      ;;
+    HTTP\ 403)
+      printf 'forbidden'
+      return 0
+      ;;
+  esac
+  return 1
+}
 
 TRIAGE_OUTPUT=""
 TRIAGE_EXIT=0
@@ -386,7 +408,19 @@ while true; do
     *)
       # Non-empty, non-"none" status value (e.g. "pending", "error",
       # "Rating synthesis not available", or any future transient state).
-      # Treat as transient — poll-retry after POLL_INTERVAL.
+      # Authorization/API errors (HTTP 401/403) are permanent — fail fast.
+      _auth_reason="$(haystack_triage_auth_error_reason "$TRIAGE_OUTPUT" || true)"
+      if [ -n "${_auth_reason:-}" ]; then
+        echo "INFO: haystack triage returned status=error with message=$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -r '.message // empty' 2>/dev/null || true) — treating as ${_auth_reason} (not retrying)" >&2
+        rm -f "$TRIAGE_STDERR"
+        printf 'RESULT=skipped\n'
+        printf 'REASON=%s\n' "$_auth_reason"
+        printf 'BLOCKING_COUNT=0\n'
+        printf 'SUGGESTION_COUNT=0\n'
+        printf 'COMMENT_COUNT=0\n'
+        exit 3
+      fi
+      # Treat other transient states as still synthesizing — poll-retry after POLL_INTERVAL.
       # NEVER map an unknown or error status to "clean"; only a genuinely
       # completed result (empty STATUS_VALUE above) may yield RESULT=clean.
       echo "INFO: status='${STATUS_VALUE}' — still synthesizing; waiting ${POLL_INTERVAL}s before retry (${elapsed}s elapsed of ${TIMEOUT}s budget)" >&2

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -205,9 +205,11 @@ haystack_triage_auth_error_reason() {
   local triage_output="$1"
   local status message
 
-  status="$(printf '%s\n' "$triage_output" | jq -r '.status // empty' 2>/dev/null || true)"
+  status="$(printf '%s\n' "$triage_output" | jq -r '.status // empty' 2>/dev/null)"
+  status="${status:-}"
   [ "$status" != "error" ] && return 1
-  message="$(printf '%s\n' "$triage_output" | jq -r '.message // empty' 2>/dev/null || true)"
+  message="$(printf '%s\n' "$triage_output" | jq -r '.message // empty' 2>/dev/null)"
+  message="${message:-}"
   case "$message" in
     HTTP\ 401)
       printf 'unauthorized'
@@ -409,9 +411,11 @@ while true; do
       # Non-empty, non-"none" status value (e.g. "pending", "error",
       # "Rating synthesis not available", or any future transient state).
       # Authorization/API errors (HTTP 401/403) are permanent — fail fast.
-      _auth_reason="$(haystack_triage_auth_error_reason "$TRIAGE_OUTPUT" || true)"
-      if [ -n "${_auth_reason:-}" ]; then
-        echo "INFO: haystack triage returned status=error with message=$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -r '.message // empty' 2>/dev/null || true) — treating as ${_auth_reason} (not retrying)" >&2
+      _auth_reason=""
+      if _auth_reason="$(haystack_triage_auth_error_reason "$TRIAGE_OUTPUT")"; then
+        _error_msg="$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -r '.message // empty' 2>/dev/null)"
+        _error_msg="${_error_msg:-unknown}"
+        echo "INFO: haystack triage returned status=error with message=${_error_msg} — treating as ${_auth_reason} (not retrying)" >&2
         rm -f "$TRIAGE_STDERR"
         printf 'RESULT=skipped\n'
         printf 'REASON=%s\n' "$_auth_reason"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4459,7 +4459,7 @@ reviewer_failed_label_required_for_result() {
       ;;
     skipped)
       case "$reason" in
-        unavailable|timeout|thread-check-failed|pending_timeout|forbidden|unauthorized|pr-is-draft)
+        unavailable|timeout|thread-check-failed|pending_timeout|forbidden|unauthorized)
           return 0
           ;;
       esac

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1172,16 +1172,25 @@ bugbot_check_disabled_issue_comments() {
   local since_iso="$4"
 
   set +e
-  gh api "repos/$repo/issues/$pr_number/comments" --paginate 2>/dev/null \
-    | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
-        .[]
-        | select(
-            (.user.login == $bot or .user.login == ($bot + "[bot]")) and
-            .created_at > $since
-          )
-        | .body // ""
-      ' 2>/dev/null
+  local output
+  output="$(
+    gh api "repos/$repo/issues/$pr_number/comments" --paginate 2>/dev/null \
+      | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
+          .[]
+          | select(
+              (.user.login == $bot or .user.login == ($bot + "[bot]")) and
+              .created_at > $since
+            )
+          | .body // ""
+        ' 2>/dev/null
+  )"
+  local _comments_rc=$?
   set -e
+  if [ "$_comments_rc" -ne 0 ]; then
+    return 1
+  fi
+  printf '%s\n' "$output"
+  return 0
 }
 
 bugbot_cursor_check_run_count() {
@@ -1220,6 +1229,8 @@ bugbot_escalate_if_disabled_without_check_run() {
   local check_name="$7"
   local run_count
   local body
+  local disabled_bodies
+  local _comments_rc=0
 
   set +e
   run_count="$(bugbot_cursor_check_run_count "$repo" "$head_sha" "$check_name")"
@@ -1228,13 +1239,31 @@ bugbot_escalate_if_disabled_without_check_run() {
     return 0
   fi
 
+  set +e
+  disabled_bodies="$(bugbot_check_disabled_issue_comments "$repo" "$pr_number" "$bot_login" "$since_iso")"
+  _comments_rc=$?
+  set -e
+  if [ "$_comments_rc" -ne 0 ]; then
+    echo "WARN: run_bugbot_review: disabled-preflight issue-comment fetch failed for PR #$pr_number" >&2
+    print_kv RESULT escalate
+    print_kv REASON fetch-failed
+    print_kv PLATFORM bugbot
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv COMMENT_COUNT 0
+    print_kv BLOCKING_COUNT 0
+    print_kv SUGGESTION_COUNT 0
+    return 2
+  fi
+
   while IFS= read -r body; do
     [ -z "$body" ] && continue
     if is_bugbot_disabled_message "$body"; then
       bugbot_return_disabled "$pr_number" "$branch_name"
       return 2
     fi
-  done <<< "$(bugbot_check_disabled_issue_comments "$repo" "$pr_number" "$bot_login" "$since_iso")"
+  done <<< "$disabled_bodies"
 
   return 0
 }
@@ -1907,8 +1936,23 @@ run_haystack_review() {
 
   set +e
   local is_draft
+  local _draft_rc=0
   is_draft="$(gh pr view "$pr_number" --repo "$owner/$repo_name" --json isDraft --jq '.isDraft' 2>/dev/null)"
+  _draft_rc=$?
   set -e
+  if [ "$_draft_rc" -ne 0 ] || [ -z "$is_draft" ]; then
+    echo "WARN: could not determine draft state for PR #$pr_number before Haystack review" >&2
+    print_kv RESULT escalate
+    print_kv REASON draft-state-unavailable
+    print_kv PLATFORM "$platform"
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv COMMENT_COUNT 0
+    print_kv BLOCKING_COUNT 0
+    print_kv SUGGESTION_COUNT 0
+    return 2
+  fi
   if [ "$is_draft" = "true" ]; then
     echo "INFO: PR #$pr_number is draft — Haystack does not review draft PRs; mark ready with gh pr ready $pr_number before rerunning" >&2
     print_kv RESULT skipped

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1148,6 +1148,38 @@ run_copilot_review() {
   return 2
 }
 
+bugbot_return_disabled() {
+  local pr_number="$1"
+  local branch_name="$2"
+
+  echo "INFO: Bugbot is disabled for this repository. Enable Bugbot for this repository in the Cursor dashboard, then rerun the reviewer loop." >&2
+  print_kv RESULT escalate
+  print_kv REASON bugbot-disabled
+  print_kv PLATFORM bugbot
+  print_kv PR_NUMBER "$pr_number"
+  print_kv BRANCH "$branch_name"
+  print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+  print_kv COMMENT_COUNT 0
+  print_kv BLOCKING_COUNT 0
+  print_kv SUGGESTION_COUNT 0
+  return 2
+}
+
+bugbot_check_disabled_issue_comments() {
+  local repo="$1"
+  local pr_number="$2"
+  local bot_login="$3"
+
+  set +e
+  gh api "repos/$repo/issues/$pr_number/comments" --paginate 2>/dev/null \
+    | jq -r --arg bot "$bot_login" '
+        .[]
+        | select(.user.login == $bot or .user.login == ($bot + "[bot]"))
+        | .body // ""
+      ' 2>/dev/null
+  set -e
+}
+
 run_bugbot_review() {
   # Triggers Cursor Bugbot for the given PR, polls the "Cursor Bugbot" check run
   # on the PR head SHA until the run completes or the budget is exhausted, then
@@ -1233,6 +1265,14 @@ run_bugbot_review() {
   [ "$since_iso" \> "$_bb_now_iso" ] && since_iso="$_bb_now_iso"
   unset _bb_now_iso
 
+  while IFS= read -r body; do
+    [ -z "$body" ] && continue
+    if is_bugbot_disabled_message "$body"; then
+      bugbot_return_disabled "$pr_number" "$branch_name"
+      return 2
+    fi
+  done <<< "$(bugbot_check_disabled_issue_comments "$repo" "$pr_number" "$bot_login")"
+
   # --- Phase 1: Check for existing blocking cursor[bot] findings on current HEAD ---
   # If blocking findings already exist (e.g. from a previous trigger in the same
   # review cycle) return needs_fixes immediately without re-triggering.
@@ -1287,6 +1327,11 @@ run_bugbot_review() {
     [ -z "${comment_json:-}" ] && continue
     body="$(printf '%s\n' "$comment_json" | jq -r '.body')"
     [ -z "$body" ] && continue
+    if is_bugbot_disabled_message "$body"; then
+      rm -f "$existing_blocking_file"
+      bugbot_return_disabled "$pr_number" "$branch_name"
+      return 2
+    fi
     # Bugbot informational notes are counted as suggestions, not blockers (AC-4).
     if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
       existing_suggestion_count=$((existing_suggestion_count + 1))
@@ -1306,6 +1351,11 @@ run_bugbot_review() {
       continue
     fi
     [ -z "$body" ] && continue
+    if is_bugbot_disabled_message "$body"; then
+      rm -f "$existing_blocking_file"
+      bugbot_return_disabled "$pr_number" "$branch_name"
+      return 2
+    fi
     if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
       existing_suggestion_count=$((existing_suggestion_count + 1))
       continue
@@ -1697,6 +1747,14 @@ run_bugbot_review() {
       check_appeared=1
     fi
 
+    while IFS= read -r body; do
+      [ -z "$body" ] && continue
+      if is_bugbot_disabled_message "$body"; then
+        bugbot_return_disabled "$pr_number" "$branch_name"
+        return 2
+      fi
+    done <<< "$(bugbot_check_disabled_issue_comments "$repo" "$pr_number" "$bot_login")"
+
     # Signal safety: _interruptible_sleep runs `sleep` as a background job and
     # blocks on bash's built-in `wait`, which is interruptible by signals.  When
     # SIGTERM arrives during this wait, the TERM trap fires immediately — killing
@@ -1747,7 +1805,7 @@ run_haystack_review() {
   #   2 → RESULT=escalate; REASON forwarded from companion script:
   #         REASON=timeout         — per-call OS timeout exhausted budget
   #         REASON=pending_timeout — analysis stayed pending past timeout budget
-  #   3 → RESULT=skipped / REASON=unavailable → propagated as RESULT=skipped
+  #   3 → RESULT=skipped; REASON forwarded (unavailable, unauthorized, forbidden, …)
   local pr_number="$1"
   local branch_name="$2"
   # poll_interval and max_wait passed for interface consistency; haystack-reviewer.sh
@@ -1766,12 +1824,30 @@ run_haystack_review() {
   require_gh
   cd_workflow_repo_root
 
-  reviewer_script="$(workflow_repo_root)/scripts/development-workflow/haystack-reviewer.sh"
-
   local owner repo_name repo
   repo="$(repo_slug)"
   owner="$(printf '%s\n' "$repo" | cut -d/ -f1)"
   repo_name="$(printf '%s\n' "$repo" | cut -d/ -f2)"
+
+  set +e
+  local is_draft
+  is_draft="$(gh pr view "$pr_number" --repo "$owner/$repo_name" --json isDraft --jq '.isDraft' 2>/dev/null)"
+  set -e
+  if [ "$is_draft" = "true" ]; then
+    echo "INFO: PR #$pr_number is draft — Haystack does not review draft PRs; mark ready with gh pr ready $pr_number before rerunning" >&2
+    print_kv RESULT skipped
+    print_kv REASON pr-is-draft
+    print_kv PLATFORM "$platform"
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv COMMENT_COUNT 0
+    print_kv BLOCKING_COUNT 0
+    print_kv SUGGESTION_COUNT 0
+    return 0
+  fi
+
+  reviewer_script="$(workflow_repo_root)/scripts/development-workflow/haystack-reviewer.sh"
 
   # Haystack-reviewer.sh manages its own poll-retry loop internally; honor the
   # caller-provided max_wait budget as the overall timeout.
@@ -1849,9 +1925,12 @@ run_haystack_review() {
       return 2
       ;;
     *)
-      # Exit 3 (UNAVAILABLE) and any unexpected exit code → skipped.
+      # Exit 3 (UNAVAILABLE/auth errors) and any unexpected exit code → skipped.
+      local haystack_reason
+      haystack_reason="$(printf '%s\n' "$script_output" | grep '^REASON=' | cut -d= -f2 | head -n 1)"
+      haystack_reason="${haystack_reason:-unavailable}"
       print_kv RESULT skipped
-      print_kv REASON unavailable
+      print_kv REASON "$haystack_reason"
       print_kv PLATFORM "$platform"
       print_kv PR_NUMBER "$pr_number"
       print_kv BRANCH "$branch_name"
@@ -4193,7 +4272,7 @@ reviewer_failed_label_required_for_result() {
       ;;
     skipped)
       case "$reason" in
-        unavailable|timeout|thread-check-failed|pending_timeout)
+        unavailable|timeout|thread-check-failed|pending_timeout|forbidden|unauthorized|pr-is-draft)
           return 0
           ;;
       esac

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1184,6 +1184,61 @@ bugbot_check_disabled_issue_comments() {
   set -e
 }
 
+bugbot_cursor_check_run_count() {
+  local repo="$1"
+  local head_sha="$2"
+  local check_name="$3"
+  local count
+
+  set +e
+  count="$(
+    gh api "repos/$repo/commits/$head_sha/check-runs" --paginate 2>/dev/null \
+      | jq -se --arg name "$check_name" '
+          [ .[].check_runs[]
+            | select(
+                ((.app.slug // "") | test("cursor"; "i")) or
+                (.name == $name)
+              )
+          ] | length
+        ' 2>/dev/null
+  )"
+  set -e
+  if [ -z "${count:-}" ]; then
+    return 1
+  fi
+  printf '%s\n' "$count"
+  return 0
+}
+
+bugbot_escalate_if_disabled_without_check_run() {
+  local repo="$1"
+  local pr_number="$2"
+  local branch_name="$3"
+  local bot_login="$4"
+  local since_iso="$5"
+  local head_sha="$6"
+  local check_name="$7"
+  local run_count
+  local body
+
+  set +e
+  run_count="$(bugbot_cursor_check_run_count "$repo" "$head_sha" "$check_name")"
+  set -e
+  if [ -n "${run_count:-}" ] && [ "$run_count" -gt 0 ]; then
+    return 0
+  fi
+
+  while IFS= read -r body; do
+    [ -z "$body" ] && continue
+    if is_bugbot_disabled_message "$body"; then
+      bugbot_return_disabled "$pr_number" "$branch_name"
+      return 2
+    fi
+  done <<< "$(bugbot_check_disabled_issue_comments "$repo" "$pr_number" "$bot_login" "$since_iso")"
+
+  return 0
+}
+
 run_bugbot_review() {
   # Triggers Cursor Bugbot for the given PR, polls the "Cursor Bugbot" check run
   # on the PR head SHA until the run completes or the budget is exhausted, then
@@ -1269,14 +1324,6 @@ run_bugbot_review() {
   [ "$since_iso" \> "$_bb_now_iso" ] && since_iso="$_bb_now_iso"
   unset _bb_now_iso
 
-  while IFS= read -r body; do
-    [ -z "$body" ] && continue
-    if is_bugbot_disabled_message "$body"; then
-      bugbot_return_disabled "$pr_number" "$branch_name"
-      return 2
-    fi
-  done <<< "$(bugbot_check_disabled_issue_comments "$repo" "$pr_number" "$bot_login" "$since_iso")"
-
   # --- Phase 1: Check for existing blocking cursor[bot] findings on current HEAD ---
   # If blocking findings already exist (e.g. from a previous trigger in the same
   # review cycle) return needs_fixes immediately without re-triggering.
@@ -1332,9 +1379,16 @@ run_bugbot_review() {
     body="$(printf '%s\n' "$comment_json" | jq -r '.body')"
     [ -z "$body" ] && continue
     if is_bugbot_disabled_message "$body"; then
-      rm -f "$existing_blocking_file"
-      bugbot_return_disabled "$pr_number" "$branch_name"
-      return 2
+      set +e
+      _bb_disabled_run_count="$(bugbot_cursor_check_run_count "$repo" "$head_sha" "$check_name")"
+      set -e
+      if [ -z "${_bb_disabled_run_count:-}" ] || [ "$_bb_disabled_run_count" -eq 0 ]; then
+        rm -f "$existing_blocking_file"
+        bugbot_return_disabled "$pr_number" "$branch_name"
+        return 2
+      fi
+      existing_suggestion_count=$((existing_suggestion_count + 1))
+      continue
     fi
     # Bugbot informational notes are counted as suggestions, not blockers (AC-4).
     if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
@@ -1356,9 +1410,16 @@ run_bugbot_review() {
     fi
     [ -z "$body" ] && continue
     if is_bugbot_disabled_message "$body"; then
-      rm -f "$existing_blocking_file"
-      bugbot_return_disabled "$pr_number" "$branch_name"
-      return 2
+      set +e
+      _bb_disabled_run_count="$(bugbot_cursor_check_run_count "$repo" "$head_sha" "$check_name")"
+      set -e
+      if [ -z "${_bb_disabled_run_count:-}" ] || [ "$_bb_disabled_run_count" -eq 0 ]; then
+        rm -f "$existing_blocking_file"
+        bugbot_return_disabled "$pr_number" "$branch_name"
+        return 2
+      fi
+      existing_suggestion_count=$((existing_suggestion_count + 1))
+      continue
     fi
     if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
       existing_suggestion_count=$((existing_suggestion_count + 1))
@@ -1426,6 +1487,14 @@ run_bugbot_review() {
   _bb_run_count="${_bb_run_count:-0}"
 
   if [ "$_bb_run_count" -eq 0 ]; then
+    set +e
+    bugbot_escalate_if_disabled_without_check_run \
+      "$repo" "$pr_number" "$branch_name" "$bot_login" "$since_iso" "$head_sha" "$check_name"
+    local _bb_disabled_rc=$?
+    set -e
+    if [ "$_bb_disabled_rc" -eq 2 ]; then
+      return 2
+    fi
     # No Cursor Bugbot check run for this head — post the trigger comment.
     set +e
     gh api "repos/$repo/issues/$pr_number/comments" --method POST \
@@ -1495,6 +1564,17 @@ run_bugbot_review() {
     read -r status_val conclusion <<< "$_fetch_output"
     status_val="${status_val:-}"
     conclusion="${conclusion:-}"
+
+    if [ "$status_val" != "completed" ]; then
+      set +e
+      bugbot_escalate_if_disabled_without_check_run \
+        "$repo" "$pr_number" "$branch_name" "$bot_login" "$since_iso" "$_current_sha" "$check_name"
+      local _bb_disabled_poll_rc=$?
+      set -e
+      if [ "$_bb_disabled_poll_rc" -eq 2 ]; then
+        return 2
+      fi
+    fi
 
     if [ "$status_val" = "completed" ]; then
       check_appeared=1
@@ -1750,14 +1830,6 @@ run_bugbot_review() {
     if [ "$check_appeared" -eq 0 ] && [ -n "$status_val" ]; then
       check_appeared=1
     fi
-
-    while IFS= read -r body; do
-      [ -z "$body" ] && continue
-      if is_bugbot_disabled_message "$body"; then
-        bugbot_return_disabled "$pr_number" "$branch_name"
-        return 2
-      fi
-    done <<< "$(bugbot_check_disabled_issue_comments "$repo" "$pr_number" "$bot_login" "$since_iso")"
 
     # Signal safety: _interruptible_sleep runs `sleep` as a background job and
     # blocks on bash's built-in `wait`, which is interruptible by signals.  When

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1169,12 +1169,16 @@ bugbot_check_disabled_issue_comments() {
   local repo="$1"
   local pr_number="$2"
   local bot_login="$3"
+  local since_iso="$4"
 
   set +e
   gh api "repos/$repo/issues/$pr_number/comments" --paginate 2>/dev/null \
-    | jq -r --arg bot "$bot_login" '
+    | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
         .[]
-        | select(.user.login == $bot or .user.login == ($bot + "[bot]"))
+        | select(
+            (.user.login == $bot or .user.login == ($bot + "[bot]")) and
+            .created_at > $since
+          )
         | .body // ""
       ' 2>/dev/null
   set -e
@@ -1271,7 +1275,7 @@ run_bugbot_review() {
       bugbot_return_disabled "$pr_number" "$branch_name"
       return 2
     fi
-  done <<< "$(bugbot_check_disabled_issue_comments "$repo" "$pr_number" "$bot_login")"
+  done <<< "$(bugbot_check_disabled_issue_comments "$repo" "$pr_number" "$bot_login" "$since_iso")"
 
   # --- Phase 1: Check for existing blocking cursor[bot] findings on current HEAD ---
   # If blocking findings already exist (e.g. from a previous trigger in the same
@@ -1753,7 +1757,7 @@ run_bugbot_review() {
         bugbot_return_disabled "$pr_number" "$branch_name"
         return 2
       fi
-    done <<< "$(bugbot_check_disabled_issue_comments "$repo" "$pr_number" "$bot_login")"
+    done <<< "$(bugbot_check_disabled_issue_comments "$repo" "$pr_number" "$bot_login" "$since_iso")"
 
     # Signal safety: _interruptible_sleep runs `sleep` as a background job and
     # blocks on bash's built-in `wait`, which is interruptible by signals.  When

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1219,24 +1219,44 @@ bugbot_cursor_check_run_count() {
   return 0
 }
 
-# Returns: 0 when no Cursor check run exists on head (disabled signal may apply),
-# 1 when at least one check run exists (ignore disabled comments),
-# 2 when the check-run count could not be fetched.
+# Returns: 0 when disabled issue comments should be evaluated for this head,
+# 1 when a completed successful Cursor check run makes them stale,
+# 2 when the check-run lookup could not be fetched.
 bugbot_disabled_preflight_applies_for_head() {
   local repo="$1"
   local head_sha="$2"
   local check_name="$3"
-  local run_count
-  local _run_count_rc=0
+  local fetch_output=""
+  local status=""
+  local conclusion=""
+  local _fetch_rc=0
 
   set +e
-  run_count="$(bugbot_cursor_check_run_count "$repo" "$head_sha" "$check_name")"
-  _run_count_rc=$?
+  fetch_output="$(
+    gh api "repos/$repo/commits/$head_sha/check-runs" --paginate 2>/dev/null \
+      | jq -se -r --arg name "$check_name" '
+          [ .[].check_runs[]
+            | select(
+                ((.app.slug // "") | test("cursor"; "i")) or
+                (.name == $name)
+              )
+          ]
+          | sort_by(.started_at) | last
+          | ((.status // "") + " " + (.conclusion // ""))
+        ' 2>/dev/null
+  )"
+  _fetch_rc=$?
   set -e
-  if [ "$_run_count_rc" -ne 0 ]; then
+  if [ "$_fetch_rc" -ne 0 ]; then
     return 2
   fi
-  if [ "$run_count" -gt 0 ]; then
+  if [ -z "$fetch_output" ]; then
+    return 0
+  fi
+  read -r status conclusion <<< "$fetch_output"
+  status="${status:-}"
+  conclusion="${conclusion:-}"
+  if [ "$status" = "completed" ] && [ "$conclusion" = "success" ]; then
     return 1
   fi
   return 0

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1219,6 +1219,29 @@ bugbot_cursor_check_run_count() {
   return 0
 }
 
+# Returns: 0 when no Cursor check run exists on head (disabled signal may apply),
+# 1 when at least one check run exists (ignore disabled comments),
+# 2 when the check-run count could not be fetched.
+bugbot_disabled_preflight_applies_for_head() {
+  local repo="$1"
+  local head_sha="$2"
+  local check_name="$3"
+  local run_count
+  local _run_count_rc=0
+
+  set +e
+  run_count="$(bugbot_cursor_check_run_count "$repo" "$head_sha" "$check_name")"
+  _run_count_rc=$?
+  set -e
+  if [ "$_run_count_rc" -ne 0 ]; then
+    return 2
+  fi
+  if [ "$run_count" -gt 0 ]; then
+    return 1
+  fi
+  return 0
+}
+
 bugbot_escalate_if_disabled_without_check_run() {
   local repo="$1"
   local pr_number="$2"
@@ -1227,15 +1250,29 @@ bugbot_escalate_if_disabled_without_check_run() {
   local since_iso="$5"
   local head_sha="$6"
   local check_name="$7"
-  local run_count
   local body
   local disabled_bodies
   local _comments_rc=0
+  local _preflight_rc=0
 
   set +e
-  run_count="$(bugbot_cursor_check_run_count "$repo" "$head_sha" "$check_name")"
+  bugbot_disabled_preflight_applies_for_head "$repo" "$head_sha" "$check_name"
+  _preflight_rc=$?
   set -e
-  if [ -n "${run_count:-}" ] && [ "$run_count" -gt 0 ]; then
+  if [ "$_preflight_rc" -eq 2 ]; then
+    echo "WARN: run_bugbot_review: check-run count fetch failed during disabled preflight for PR #$pr_number" >&2
+    print_kv RESULT escalate
+    print_kv REASON fetch-failed
+    print_kv PLATFORM bugbot
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv COMMENT_COUNT 0
+    print_kv BLOCKING_COUNT 0
+    print_kv SUGGESTION_COUNT 0
+    return 2
+  fi
+  if [ "$_preflight_rc" -eq 1 ]; then
     return 0
   fi
 
@@ -1409,9 +1446,24 @@ run_bugbot_review() {
     [ -z "$body" ] && continue
     if is_bugbot_disabled_message "$body"; then
       set +e
-      _bb_disabled_run_count="$(bugbot_cursor_check_run_count "$repo" "$head_sha" "$check_name")"
+      bugbot_disabled_preflight_applies_for_head "$repo" "$head_sha" "$check_name"
+      local _bb_disabled_rc=$?
       set -e
-      if [ -z "${_bb_disabled_run_count:-}" ] || [ "$_bb_disabled_run_count" -eq 0 ]; then
+      if [ "$_bb_disabled_rc" -eq 2 ]; then
+        rm -f "$existing_blocking_file"
+        echo "WARN: run_bugbot_review: check-run count fetch failed during disabled preflight for PR #$pr_number" >&2
+        print_kv RESULT escalate
+        print_kv REASON fetch-failed
+        print_kv PLATFORM "$platform"
+        print_kv PR_NUMBER "$pr_number"
+        print_kv BRANCH "$branch_name"
+        print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+        print_kv COMMENT_COUNT 0
+        print_kv BLOCKING_COUNT 0
+        print_kv SUGGESTION_COUNT 0
+        return 2
+      fi
+      if [ "$_bb_disabled_rc" -eq 0 ]; then
         rm -f "$existing_blocking_file"
         bugbot_return_disabled "$pr_number" "$branch_name"
         return 2
@@ -1440,9 +1492,24 @@ run_bugbot_review() {
     [ -z "$body" ] && continue
     if is_bugbot_disabled_message "$body"; then
       set +e
-      _bb_disabled_run_count="$(bugbot_cursor_check_run_count "$repo" "$head_sha" "$check_name")"
+      bugbot_disabled_preflight_applies_for_head "$repo" "$head_sha" "$check_name"
+      local _bb_disabled_review_rc=$?
       set -e
-      if [ -z "${_bb_disabled_run_count:-}" ] || [ "$_bb_disabled_run_count" -eq 0 ]; then
+      if [ "$_bb_disabled_review_rc" -eq 2 ]; then
+        rm -f "$existing_blocking_file"
+        echo "WARN: run_bugbot_review: check-run count fetch failed during disabled preflight for PR #$pr_number" >&2
+        print_kv RESULT escalate
+        print_kv REASON fetch-failed
+        print_kv PLATFORM "$platform"
+        print_kv PR_NUMBER "$pr_number"
+        print_kv BRANCH "$branch_name"
+        print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+        print_kv COMMENT_COUNT 0
+        print_kv BLOCKING_COUNT 0
+        print_kv SUGGESTION_COUNT 0
+        return 2
+      fi
+      if [ "$_bb_disabled_review_rc" -eq 0 ]; then
         rm -f "$existing_blocking_file"
         bugbot_return_disabled "$pr_number" "$branch_name"
         return 2

--- a/scripts/development-workflow/tests/test-haystack-reviewer.sh
+++ b/scripts/development-workflow/tests/test-haystack-reviewer.sh
@@ -1033,6 +1033,38 @@ run_test "policy_no_timeout_hung_status_exit_code" "0" "$ec"
 unset TEST_HAYSTACK_PR_STATUS_CHECK TEST_REVIEWER_PATH MOCK_HAYSTACK_SLEEPS
 
 # ---------------------------------------------------------------------------
+# Area 11: triage HTTP 401/403 auth errors fail fast (#1035)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 11: triage HTTP 401/403 auth errors ==="
+
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"status":"error","message":"HTTP 403"}'
+MOCK_HAYSTACK_EXITS='0'
+_install_mock_with_exits
+
+output=$(_run_reviewer 30 1)
+calls=$(_call_count)
+ec=$(cat "$_REVIEWER_EXIT_FILE")
+
+run_test "http_403_result" "RESULT=skipped" "$(echo "$output" | grep '^RESULT=')"
+run_test "http_403_reason" "REASON=forbidden" "$(echo "$output" | grep '^REASON=')"
+run_test "http_403_exit_code" "3" "$ec"
+run_test "http_403_single_call" "1" "$calls"
+
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"status":"error","message":"HTTP 401"}'
+MOCK_HAYSTACK_EXITS='0'
+_install_mock_with_exits
+
+output=$(_run_reviewer 30 1)
+calls=$(_call_count)
+ec=$(cat "$_REVIEWER_EXIT_FILE")
+
+run_test "http_401_result" "RESULT=skipped" "$(echo "$output" | grep '^RESULT=')"
+run_test "http_401_reason" "REASON=unauthorized" "$(echo "$output" | grep '^REASON=')"
+run_test "http_401_exit_code" "3" "$ec"
+run_test "http_401_single_call" "1" "$calls"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2918,7 +2918,7 @@ case "$*" in
   *"--jq .commit.committer.date"*)
     printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    printf '[{"user":{"login":"cursor[bot]"},"body":"Bugbot is disabled for this repository."}]\n'
+    printf '[{"user":{"login":"cursor[bot]"},"created_at":"2020-01-02T00:00:00Z","body":"Bugbot is disabled for this repository."}]\n'
     exit 0 ;;
   *"pulls/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
@@ -2949,6 +2949,47 @@ run_test "bugbot_disabled_preflight_reason" "REASON=bugbot-disabled" \
 run_test "bugbot_disabled_preflight_exit_code" "2" "$actual_exit"
 rm -rf "$_bugbot_mock_dir_1611"
 unset _bugbot_mock_dir_1611 actual_output actual_exit
+
+# Test 16.12: stale disabled issue comment before HEAD is ignored
+_bugbot_mock_dir_1612="$(mktemp -d)"
+cat > "$_bugbot_mock_dir_1612/gh" <<'BUGBOT_GH_1612'
+#!/usr/bin/env bash
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc1612sha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-02T00:00:00Z\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"user":{"login":"cursor[bot]"},"created_at":"2020-01-01T00:00:00Z","body":"Bugbot is disabled for this repository."}]\n'
+    exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"check-runs"*)
+    printf '{"check_runs":[{"name":"Cursor Bugbot","app":{"slug":"cursor"},"status":"completed","conclusion":"success","started_at":"2020-01-02T00:00:00Z"}]}\n'
+    exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+BUGBOT_GH_1612
+chmod +x "$_bugbot_mock_dir_1612/gh"
+
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_bugbot_overrides"
+  PATH="$_bugbot_mock_dir_1612:$PATH"
+  _ec=0
+  run_bugbot_review "42" "feature/42-test" "1" "5" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "bugbot_stale_disabled_comment_result" "RESULT=clean" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "bugbot_stale_disabled_comment_exit_code" "0" "$actual_exit"
+rm -rf "$_bugbot_mock_dir_1612"
+unset _bugbot_mock_dir_1612 actual_output actual_exit
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1137,6 +1137,8 @@ run_platform_review "haystack" "999" "feature/test" "30" "120" >/dev/null 2>&1 |
 run_test "run_platform_review_routes_to_run_haystack_review" "1" "$_haystack_dispatch_called"
 unset -f run_haystack_review
 unset _haystack_dispatch_called
+HARNESS_MODE=1 source "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
+workflow_repo_root() { printf '%s\n' "${HARNESS_REPO_ROOT:-$REPO_ROOT}"; }
 
 # test: legacy ensure_pr_ready_for_after_clean wrapper converts draft PRs before ready-phase reviewers
 _call_log="$(mktemp)"
@@ -1184,6 +1186,59 @@ ready_status=$?
 set -e
 run_test "after_clean_ready_fails_closed_on_ready_error" "2" "$ready_status"
 unset MOCK_GH_OUTPUT MOCK_GH_EXIT MOCK_GH_READY_EXIT ready_status
+
+# test: run_haystack_review skips draft PRs before invoking haystack-reviewer.sh
+_haystack_draft_overrides='
+  cd_workflow_repo_root() { :; }
+  repo_slug() { printf "owner/repo\n"; }
+  require_gh() { :; }
+'
+export MOCK_GH_OUTPUT="true"
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_haystack_draft_overrides"
+  _ec=0
+  run_haystack_review "42" "feature/test" "1" "30" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "haystack_skips_draft_pr_result" "RESULT=skipped" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "haystack_skips_draft_pr_reason" "REASON=pr-is-draft" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+run_test "haystack_skips_draft_pr_exit_code" "0" "$actual_exit"
+unset MOCK_GH_OUTPUT _haystack_draft_overrides actual_output actual_exit
+
+# test: run_haystack_review forwards Haystack auth errors from companion script
+_haystack_auth_overrides='
+  cd_workflow_repo_root() { :; }
+  repo_slug() { printf "owner/repo\n"; }
+  require_gh() { :; }
+'
+export MOCK_GH_OUTPUT="false"
+_haystack_reviewer_stub="$(mktemp -d)"
+mkdir -p "$_haystack_reviewer_stub/scripts/development-workflow"
+cat > "$_haystack_reviewer_stub/scripts/development-workflow/haystack-reviewer.sh" <<'HAYSTACK_STUB'
+#!/usr/bin/env bash
+printf 'RESULT=skipped\nREASON=forbidden\nBLOCKING_COUNT=0\nSUGGESTION_COUNT=0\nCOMMENT_COUNT=0\n'
+exit 3
+HAYSTACK_STUB
+chmod +x "$_haystack_reviewer_stub/scripts/development-workflow/haystack-reviewer.sh"
+workflow_repo_root() { printf "%s\n" "$_haystack_reviewer_stub"; }
+actual_output="$(
+  eval "$_haystack_auth_overrides"
+  _ec=0
+  run_haystack_review "42" "feature/test" "1" "30" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "haystack_forwards_auth_reason" "REASON=forbidden" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+run_test "haystack_forwards_auth_exit_code" "0" "$actual_exit"
+rm -rf "$_haystack_reviewer_stub"
+unset MOCK_GH_OUTPUT _haystack_auth_overrides actual_output actual_exit
+workflow_repo_root() { printf '%s\n' "${HARNESS_REPO_ROOT:-$REPO_ROOT}"; }
 
 # ---------------------------------------------------------------------------
 # Area 10: per-platform result tokens in summary comment (#755)
@@ -2187,6 +2242,20 @@ fi
 run_test "bugbot_same_line_mixed_phrase_is_blocking" "blocking" "$actual"
 unset bugbot_clean_body bugbot_mixed_body bugbot_multiline_body bugbot_same_line_severity_body bugbot_same_line_mixed_body actual
 
+if is_bugbot_disabled_message "Bugbot is disabled for this repository."; then
+  actual="disabled"
+else
+  actual="active"
+fi
+run_test "bugbot_disabled_message_detected" "disabled" "$actual"
+
+if is_bugbot_disabled_message "Cursor Bugbot found no issues in this pull request."; then
+  actual="disabled"
+else
+  actual="active"
+fi
+run_test "bugbot_clean_phrase_not_disabled" "active" "$actual"
+
 # ---------------------------------------------------------------------------
 # Test 16.1: clean path — check run conclusion=success, no blocking comments
 # ---------------------------------------------------------------------------
@@ -2834,6 +2903,52 @@ run_platform_review "bugbot" "999" "feature/test" "30" "120" >/dev/null 2>&1 || 
 run_test "run_platform_review_routes_to_run_bugbot_review" "1" "$_bugbot_dispatch_called"
 unset -f run_bugbot_review
 unset _bugbot_dispatch_called
+HARNESS_MODE=1 source "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
+workflow_repo_root() { printf '%s\n' "${HARNESS_REPO_ROOT:-$REPO_ROOT}"; }
+
+# ---------------------------------------------------------------------------
+# Test 16.11: disabled Bugbot preflight — escalate with bugbot-disabled
+# ---------------------------------------------------------------------------
+_bugbot_mock_dir_1611="$(mktemp -d)"
+cat > "$_bugbot_mock_dir_1611/gh" <<'BUGBOT_GH_1611'
+#!/usr/bin/env bash
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc1611sha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"user":{"login":"cursor[bot]"},"body":"Bugbot is disabled for this repository."}]\n'
+    exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"check-runs"*)
+    printf '{"check_runs":[]}\n'; exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+BUGBOT_GH_1611
+chmod +x "$_bugbot_mock_dir_1611/gh"
+
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_bugbot_overrides"
+  PATH="$_bugbot_mock_dir_1611:$PATH"
+  _ec=0
+  run_bugbot_review "42" "feature/42-test" "1" "30" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "bugbot_disabled_preflight_result" "RESULT=escalate" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "bugbot_disabled_preflight_reason" "REASON=bugbot-disabled" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+run_test "bugbot_disabled_preflight_exit_code" "2" "$actual_exit"
+rm -rf "$_bugbot_mock_dir_1611"
+unset _bugbot_mock_dir_1611 actual_output actual_exit
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1210,6 +1210,28 @@ run_test "haystack_skips_draft_pr_reason" "REASON=pr-is-draft" \
 run_test "haystack_skips_draft_pr_exit_code" "0" "$actual_exit"
 unset MOCK_GH_OUTPUT _haystack_draft_overrides actual_output actual_exit
 
+# test: run_haystack_review escalates when draft state cannot be determined
+_haystack_draft_overrides='
+  cd_workflow_repo_root() { :; }
+  repo_slug() { printf "owner/repo\n"; }
+  require_gh() { :; }
+'
+export MOCK_GH_OUTPUT=""
+export MOCK_GH_EXIT=1
+actual_output="$(
+  eval "$_haystack_draft_overrides"
+  _ec=0
+  run_haystack_review "42" "feature/test" "1" "30" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "haystack_draft_state_unavailable_result" "RESULT=escalate" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "haystack_draft_state_unavailable_reason" "REASON=draft-state-unavailable" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+run_test "haystack_draft_state_unavailable_exit_code" "2" "$actual_exit"
+unset MOCK_GH_OUTPUT MOCK_GH_EXIT _haystack_draft_overrides actual_output actual_exit
+
 # test: run_haystack_review forwards Haystack auth errors from companion script
 _haystack_auth_overrides='
   cd_workflow_repo_root() { :; }

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2256,6 +2256,13 @@ else
 fi
 run_test "bugbot_clean_phrase_not_disabled" "active" "$actual"
 
+if is_bugbot_disabled_message "This repository setting is disabled for this repository in general."; then
+  actual="disabled"
+else
+  actual="active"
+fi
+run_test "bugbot_generic_disabled_phrase_not_matched" "active" "$actual"
+
 # ---------------------------------------------------------------------------
 # Test 16.1: clean path — check run conclusion=success, no blocking comments
 # ---------------------------------------------------------------------------

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -387,6 +387,17 @@ is_bugbot_clean_review() {
   return 1
 }
 
+is_bugbot_disabled_message() {
+  local body="$1"
+
+  case "$body" in
+    *"Bugbot is disabled"*|*"bugbot is disabled"*|*"disabled for this repository"*|*"Bugbot has not been enabled"*|*"Bugbot isn't enabled"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 open_pr_number_for_branch() {
   require_gh
   gh pr list --head "$1" --state open --limit 100 --json number --jq '.[0].number // empty'

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -391,7 +391,7 @@ is_bugbot_disabled_message() {
   local body="$1"
 
   case "$body" in
-    *"Bugbot is disabled"*|*"bugbot is disabled"*|*"disabled for this repository"*|*"Bugbot has not been enabled"*|*"Bugbot isn't enabled"*)
+    *"Bugbot is disabled"*|*"Bugbot has not been enabled"*|*"Bugbot isn't enabled"*)
       return 0
       ;;
   esac


### PR DESCRIPTION
## Summary

- **#1028**: Detect `cursor[bot]` “Bugbot is disabled” issue comments before triggering/polling; escalate with `REASON=bugbot-disabled` and dashboard guidance.
- **#1035**: `haystack-reviewer.sh` exits immediately on triage `status=error` with `message=HTTP 401`/`HTTP 403` (`REASON=unauthorized`/`forbidden`) instead of `pending_timeout`.
- **#1037**: `run_haystack_review()` skips draft PRs with `REASON=pr-is-draft` and guidance to `gh pr ready` before rerunning.

## Test plan

- [x] `bash scripts/development-workflow/tests/test-haystack-reviewer.sh`
- [x] `bash scripts/development-workflow/tests/test-pr-review-loop.sh`
- [ ] Run reviewer loop on this PR

Closes #1028, #1035, #1037

Made with [Cursor](https://cursor.com)