### PR TITLE
Graduate `model-cost-resilience` integration branch to develop

### DIFF
--- a/.cursor/agents/code-reviewer.md
+++ b/.cursor/agents/code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-model: inherit
+model: claude-sonnet-4-6
 description: Development review stage. Use when an implementation PR needs review against the spec, plan, and best practices. Applies fixes directly for blocking and important issues. Reports issues requiring human/product decisions.
 ---
 

--- a/.cursor/agents/design-reviewer.md
+++ b/.cursor/agents/design-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: design-reviewer
-model: inherit
+model: claude-sonnet-4-6
 description: Design review stage. Use when an implementation PR includes frontend file changes. Launches a browser via the configured browser_automation.provider, renders affected pages or components, captures screenshots, checks for console errors, and runs an axe-core accessibility check. Posts a structured PR comment with the verdict (Approved / Needs Revision / Skipped).
 ---
 

--- a/.cursor/agents/implementation-plan-reviewer.md
+++ b/.cursor/agents/implementation-plan-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: implementation-plan-reviewer
-model: inherit
+model: claude-sonnet-4-6
 description: Plan review stage. Use when an implementation plan branch or PR needs review for spec alignment, completeness, and feasibility. Reads the spec, plan, and codebase to validate the approach, and can push reviewer-loop fixes.
 ---
 

--- a/.cursor/agents/item-orchestrator.md
+++ b/.cursor/agents/item-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: item-orchestrator
-model: inherit
+model: claude-sonnet-4-6
 description: Coordination agent for a single workflow item. Resumes one development, branch, or PR and keeps it moving until it is waiting on a human, blocked, or escalated. Use when you want targeted advancement without scanning the full portfolio.
 ---
 

--- a/.cursor/agents/project-setup.md
+++ b/.cursor/agents/project-setup.md
@@ -1,6 +1,6 @@
 ---
 name: project-setup
-model: inherit
+model: claude-sonnet-4-6
 description: Onboarding agent. Run this when first setting up a new project from this template. Guides a structured conversation to generate all project-specific documentation (business domain, architecture, tech stack, best practices) and configures the framework for your project.
 ---
 

--- a/.cursor/agents/retrospective.md
+++ b/.cursor/agents/retrospective.md
@@ -1,6 +1,6 @@
 ---
 name: retrospective
-model: inherit
+model: claude-sonnet-4-6
 description: Retrospective analysis agent. Analyzes completed work (a batch or individual item) to identify process improvement opportunities, presents them to the human, and executes the chosen action for each.
 ---
 

--- a/.cursor/agents/smoke-tester.md
+++ b/.cursor/agents/smoke-tester.md
@@ -1,6 +1,6 @@
 ---
 name: smoke-tester
-model: inherit
+model: claude-sonnet-4-6
 description: Smoke test stage. Use when a code review has been approved and the implementation needs manual smoke testing before merge. Executes the smoke test runbook using browser automation.
 ---
 

--- a/.cursor/agents/spec-reviewer.md
+++ b/.cursor/agents/spec-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: spec-reviewer
-model: inherit
+model: claude-sonnet-4-6
 description: Spec review stage. Use when a spec branch or PR needs review for completeness, clarity, and testability. Applies fixes directly where possible, can push reviewer-loop fixes, and reports issues requiring human input.
 ---
 

--- a/.cursor/agents/tech-lead.md
+++ b/.cursor/agents/tech-lead.md
@@ -1,6 +1,6 @@
 ---
 name: tech-lead
-model: inherit
+model: claude-opus-4-7
 description: Plan Ready stage. Use when an implementation plan needs to be written. For Full Pipeline items, a spec must be approved first. For Refactor items, the work item brief replaces the spec. Reads the codebase, resolves technical approach questions, then writes the implementation plan, runs its reviewer gate, and resolves PR readiness.
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   errors fail fast with `REASON=unauthorized`/`forbidden` instead of
   `pending_timeout`; draft PRs skip Haystack with `REASON=pr-is-draft` and guidance
   to mark ready before rerunning.
+- **Model cost resilience documentation** (#1044, #1045, #1046): pins explicit
+  Cursor subagent models in `.cursor/agents/*.md` and documents tier defaults in
+  `agent-model-config.md`; adds a provider quota/timeout/runner failover runbook
+  and an experimental opt-in LLM router integration pattern for tier-aligned
+  fallback chains.
 
 ### Fixed
 

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -613,6 +613,7 @@ Repository helpers:
 - `docs/workflow/development-workflow/integrations/devin.md`
 - `docs/workflow/development-workflow/integrations/coderabbit.md`
 - `docs/workflow/development-workflow/integrations/haystack.md`
+- `docs/workflow/development-workflow/integrations/llm-router.md`
 - `docs/workflow/development-workflow/integrations/github-projects.md`
 - `docs/workflow/development-workflow/integrations/workflow-hub-github-app.md`
 - `docs/workflow/development-workflow/integrations/ci-cd-deployment.md`

--- a/docs/workflow/development-workflow/agent-model-config.md
+++ b/docs/workflow/development-workflow/agent-model-config.md
@@ -44,8 +44,35 @@ If you prefer different names (`small/medium/large`, `fast/standard/pro`, etc.),
 Use the tier names as stable policy and map them to whatever your current runner and provider support.
 
 - In Claude Code, map the tier to the model family or explicit model ID configured in `.claude/agents/*.md`.
-- In Cursor, `fast` is usually a good fit for `economy`, while `inherit` or a pinned high-reasoning model is usually a better fit for `balanced` and `premium`.
+- In Cursor, pin explicit model IDs in `.cursor/agents/*.md` for every long-running or review-loop agent. Use `fast` for `economy` tier agents only.
 - In any runner, prefer keeping the tier intent stable even when provider model names change.
+
+### Cursor model defaults (template)
+
+Pin models in `.cursor/agents/*.md` so subagents do not inherit the parent Composer model during long orchestration or review-fix loops. **`inherit` is acceptable only for ad-hoc, single-turn invocations** where you intentionally want the current Composer model — not for orchestrators, item runners, fixer agents, or reviewer-loop agents.
+
+| Agent | Tier | Cursor `model` (template default) |
+| ----- | ---- | ----------------------------------- |
+| `orchestrator` | `economy` | `fast` |
+| `automated-reviewer-loop` | `economy` | `fast` |
+| `item-orchestrator` | `balanced` | `claude-sonnet-4-6` |
+| `developer` | `balanced` | `claude-sonnet-4-6` |
+| `code-reviewer` | `balanced` | `claude-sonnet-4-6` |
+| `spec-reviewer` | `balanced` | `claude-sonnet-4-6` |
+| `implementation-plan-reviewer` | `balanced` | `claude-sonnet-4-6` |
+| `smoke-tester` | `balanced` | `claude-sonnet-4-6` |
+| `retrospective` | `balanced` | `claude-sonnet-4-6` |
+| `project-setup` | `balanced` | `claude-sonnet-4-6` |
+| `design-reviewer` | `balanced` | `claude-sonnet-4-6` |
+| `product-manager` | `premium` | `claude-opus-4-7` |
+| `tech-lead` | `premium` | `claude-opus-4-7` |
+
+Claude Code equivalents live in `.claude/agents/*.md` (Haiku for economy, Sonnet for balanced, Opus for premium). Update pinned IDs when your provider deprecates a model; keep the tier intent stable.
+
+See also:
+
+- [`provider-contingency-runner-failover.md`](provider-contingency-runner-failover.md) — quota, timeout, and runner-switch recovery
+- [`integrations/llm-router.md`](integrations/llm-router.md) — optional tier-based fallback chains (experimental)
 
 ---
 
@@ -99,9 +126,9 @@ This affects all future invocations until changed back.
 
 **Cursor model field values:**
 
-- `fast`: Uses Cursor's fast model (recommended for economy-tier agents)
-- `inherit`: Uses the current Composer model (recommended for balanced/premium-tier agents)
-- Specific model ID: Uses that exact model (e.g., `claude-opus-4-7`, `gpt-4-turbo`)
+- `fast`: Uses Cursor's fast model (recommended for `economy`-tier agents only)
+- Pinned model ID: Uses that exact model (recommended for `balanced` and `premium` agents, e.g. `claude-sonnet-4-6`, `claude-opus-4-7`)
+- `inherit`: Uses the current Composer model — **discouraged** for orchestrators, item runners, fixer agents, and reviewer-loop agents because it leaks parent-session cost into long runs; reserve for intentional one-off overrides
 
 **Precedence**: When multiple agent locations exist (`.cursor/agents/`, `.claude/agents/`, `.codex/agents/`), Cursor uses `.cursor/agents/` first, then `.claude/agents/`, then `.codex/agents/`.
 
@@ -155,6 +182,8 @@ A PR that has readiness labels but **no reviewer loop summary comment** is the c
 ```
 
 The item-orchestrator uses the Step 8c independent verification gate to detect any missing labels or comments and automatically re-enters the correct resume point (Step 7a, Step 7, or Step 8).
+
+For quota exhaustion, stream timeouts, and runner failover (Cursor ↔ Codex ↔ Claude Code), see [`provider-contingency-runner-failover.md`](provider-contingency-runner-failover.md).
 
 ### Warning
 

--- a/docs/workflow/development-workflow/integrations/llm-router.md
+++ b/docs/workflow/development-workflow/integrations/llm-router.md
@@ -1,0 +1,85 @@
+# LLM Router Integration (Experimental / Opt-In)
+
+> **Status:** Experimental pattern documentation only. The template does **not** ship, install, or configure any router product. Adopters wire their own router behind an OpenAI-compatible endpoint.
+
+Use this guide when primary subscription quotas are exhausted during long `/run-work` batches or review-fix loops and you want **tier-aligned fallback chains** without forking the framework’s economy / balanced / premium policy.
+
+Related:
+
+- [`../agent-model-config.md`](../agent-model-config.md) — tier definitions and Cursor default model pins
+- [`../provider-contingency-runner-failover.md`](../provider-contingency-runner-failover.md) — PR-level resume when a session aborts mid-turn
+
+---
+
+## Pattern overview
+
+1. Define three router **combos** mapped to framework tiers:
+
+   | Combo | Framework tier | Typical use |
+   | ----- | -------------- | ----------- |
+   | `fw-economy` | `economy` | Orchestration, reviewer-loop coordination |
+   | `fw-balanced` | `balanced` | Implementation, fixers, most reviews |
+   | `fw-premium` | `premium` | Spec and plan authoring |
+
+2. Configure each combo as an ordered fallback chain, for example:
+
+   - **Primary:** subscription model the runner already uses
+   - **Secondary:** paid low-cost API model (e.g. GLM, DeepSeek, MiniMax — vendor-neutral examples)
+   - **Stop:** do not chain to unstable “free forever” proxies for client or production code
+
+3. Point Cursor, Claude Code, or Codex at a **local OpenAI-compatible base URL** served by your router (product-specific; not bundled here).
+
+4. Align router model IDs with pinned values in `.cursor/agents/*.md` and `.claude/agents/*.md` so subagents stay on the intended tier when the router selects a fallback.
+
+---
+
+## Runner alignment
+
+| Runner | Configuration surface |
+| ------ | --------------------- |
+| Cursor | `.cursor/agents/<agent>.md` `model` field + Cursor settings for custom OpenAI-compatible endpoints |
+| Claude Code | `.claude/agents/*.md` model IDs + Claude Code provider / base URL settings |
+| Codex | Provider and model settings for the Codex CLI or IDE integration |
+
+Keep **tier intent** stable in agent files; change router combo mappings when you add or remove fallback models.
+
+---
+
+## Reference implementations (examples only)
+
+These are **illustrative** third-party tools — not dependencies of this template:
+
+- [9Router](https://github.com/deanxv/9router) — multi-provider OpenAI-compatible proxy
+- [claude-code-router](https://github.com/musistudio/claude-code-router) — routing layer for Claude Code-style clients
+
+Evaluate licensing, privacy, and operational fit before adoption.
+
+---
+
+## Guardrails (required reading)
+
+### Terms of service and OAuth
+
+Routing consumer OAuth sessions through unofficial proxies may violate provider terms (e.g. Anthropic consumer ToS updates in 2026). Prefer official API keys and documented enterprise paths for production or client work.
+
+### Privacy
+
+Do **not** route client repositories, credentials, or sensitive code through opaque free proxies. Run routers on infrastructure you control; log and retention policies must match your compliance requirements.
+
+### Quality
+
+Fallback models may fail review-fix loops or mis-parse workflow scripts. Reserve strong models for `balanced` and `premium` tiers; use economy fallbacks only for mechanical coordination.
+
+### Continuity limits
+
+Routers do not replace PR-level resume. Mid-turn failures still require [`provider-contingency-runner-failover.md`](../provider-contingency-runner-failover.md) and `workflow-next-action.sh`.
+
+---
+
+## Explicit non-goals
+
+- No router install scripts in this template
+- No default `.ai-dev-workflow.yaml` keys until the pattern is validated in downstream dogfooding
+- No endorsement of a single vendor or “always free” model tier for production workflow automation
+
+When dogfooding validates a pattern, downstream repos may document their router combo YAML in `.ai-dev-workflow.local.yaml` (local-only) and link back to this guide.

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -889,6 +889,7 @@ When work already exists, resume rather than restart.
 - If a workflow branch already exists, use `workflow-next-action.sh --branch <branch>`
 - If a PR already exists, use `workflow-next-action.sh --pr <number>`
 - If labels indicate `needs-fixes`, enter the fix loop instead of reopening the stage from scratch
+- If a run aborts mid-turn due to model quota, stream timeout, or runner unavailability, follow [`provider-contingency-runner-failover.md`](../provider-contingency-runner-failover.md) before manually changing PR labels or restarting from scratch
 
 The Work Item Runner owns the full control loop for this item until it reaches a terminal condition.
 

--- a/docs/workflow/development-workflow/provider-contingency-runner-failover.md
+++ b/docs/workflow/development-workflow/provider-contingency-runner-failover.md
@@ -52,7 +52,7 @@ Typical timeout thresholds for long agents are documented in [`agent-model-confi
 2. Pull latest on the item branch or integration branch as appropriate.
 3. Run the [Resume checklist](#resume-checklist).
 4. Re-invoke the workflow entrypoint your alternate runner supports (`/run-item-work`, `/run-reviewer-loop`, Codex skills, or Claude Code agents) using the **same PR number**.
-5. Do **not** manually apply readiness labels; let Step 7 / Step 8 / Step 8c apply them after verification.
+5. Do **not** manually apply readiness labels; let the item-orchestrator apply them in protocol 91 Steps 7b and 8a after Step 7 (reviewer loop), Step 8 (CI), and Step 8c verification succeed.
 
 Tool-specific agent files (`.cursor/agents/`, `.claude/agents/`, `.codex/skills/`) share the same protocols — only the invocation surface changes.
 

--- a/docs/workflow/development-workflow/provider-contingency-runner-failover.md
+++ b/docs/workflow/development-workflow/provider-contingency-runner-failover.md
@@ -1,0 +1,104 @@
+# Provider Contingency and Runner Failover
+
+Long orchestration runs (`/run-work`, `/run-epic`, `/run-item-work`, `/run-reviewer-loop`) can be interrupted when a model quota is exhausted, a stream times out, or the primary runner becomes unavailable. PR-level state persists across these failures — use the playbooks below instead of manually re-labeling PRs or restarting from scratch.
+
+Related docs:
+
+- [`agent-model-config.md`](agent-model-config.md) — tier assignments, resume checklist, timed-out run detection
+- [`protocols/91-orchestrate-work-protocol.md`](protocols/91-orchestrate-work-protocol.md) — item-orchestrator Step 7 / Step 8 contract
+- [`protocols/93-automated-reviewer-loop-protocol.md`](protocols/93-automated-reviewer-loop-protocol.md) — standalone reviewer + CI loop
+- [`integrations/llm-router.md`](integrations/llm-router.md) — optional tier-based model fallback (experimental)
+
+---
+
+## Failure mode 1: Model quota or rate limit
+
+**Symptoms:** HTTP 429, “rate limit”, “quota exceeded”, or the runner refuses to start a turn on the configured model.
+
+**Same runner — swap model or enable router fallback:**
+
+1. Stop retrying the same premium model in a tight loop.
+2. For Cursor: confirm `.cursor/agents/<agent>.md` uses tier-appropriate pinned models (see [`agent-model-config.md`](agent-model-config.md)); temporarily downgrade only when the task is mechanical.
+3. For optional router setups, switch the runner to a router combo for the agent’s tier (see [`integrations/llm-router.md`](integrations/llm-router.md)).
+4. Resume at PR level — the in-flight session may abort mid-turn, but branch commits and PR comments remain.
+
+**Do not:** Manually apply `ready-for-human-review` or remove `needs-fixes` without completing the reviewer loop.
+
+---
+
+## Failure mode 2: Stream timeout or API error
+
+**Symptoms:** “Stream idle timeout”, connection reset, or the agent stops mid-step with no terminal PR summary.
+
+**When to retry the same agent vs resume via item orchestration:**
+
+| Situation | Action |
+| --------- | ------ |
+| Failure before any commit or PR update | Re-invoke the same stage agent from a clean checkout of the item branch |
+| Failure after commits landed on the PR branch | Inspect PR state (checklist below), run `workflow-next-action.sh`, then `/run-item-work --pr <n>` or `/run-reviewer-loop` |
+| Reviewer loop interrupted (labels present, no loop summary) | `/run-reviewer-loop` or item-orchestrator — see [Resume checklist](#resume-checklist) |
+
+Typical timeout thresholds for long agents are documented in [`agent-model-config.md`](agent-model-config.md#expected-run-durations).
+
+---
+
+## Failure mode 3: Runner unavailable
+
+**Symptoms:** Cursor, Codex, or Claude Code cannot run agents (auth failure, extension outage, CI runner offline).
+
+**Migrate to an alternate runner:**
+
+1. Use the **same repository** and **same PR** — do not fork state into a new PR unless the protocol requires it.
+2. Pull latest on the item branch or integration branch as appropriate.
+3. Run the [Resume checklist](#resume-checklist).
+4. Re-invoke the workflow entrypoint your alternate runner supports (`/run-item-work`, `/run-reviewer-loop`, Codex skills, or Claude Code agents) using the **same PR number**.
+5. Do **not** manually apply readiness labels; let Step 7 / Step 8 / Step 8c apply them after verification.
+
+Tool-specific agent files (`.cursor/agents/`, `.claude/agents/`, `.codex/skills/`) share the same protocols — only the invocation surface changes.
+
+---
+
+## Resume checklist
+
+Run from the repository root (or selected product repo in `workflow_hub` mode):
+
+```bash
+gh pr view <pr_number> --json isDraft,labels,comments,statusCheckRollup
+./scripts/development-workflow/workflow-next-action.sh --pr <pr_number>
+```
+
+Interpret signals (full table in [`agent-model-config.md`](agent-model-config.md#detection-checklist)):
+
+- **Non-draft + `ready-for-regression` + no reviewer loop summary** → Step 7 incomplete; run `/run-reviewer-loop`.
+- **`needs-fixes` present** → address blocking findings or rerun fixer path before readiness labels.
+- **CI failing or pending** → complete Step 8 (`pr-ci-loop.sh`) after Step 7 is clean.
+
+Then re-invoke:
+
+```bash
+# Item still in flight
+/run-item-work --pr <pr_number>
+
+# Reviewer/CI only
+/run-reviewer-loop
+```
+
+---
+
+## Do-not list
+
+- Do **not** apply `ready-for-human-review` when the PR lacks an “Automated Reviewer Loop Summary” (or equivalent) comment unless Step 7 was explicitly skipped (no platforms configured).
+- Do **not** remove `needs-fixes` without a clean reviewer loop and CI evidence.
+- Do **not** force-push or amend published PR commits during recovery unless a human explicitly approves.
+- Do **not** assume the latest bot comment is the only active blocker — audit all open review threads on the current HEAD.
+
+---
+
+## When to escalate to a human
+
+Escalate when:
+
+- `workflow-next-action.sh` returns an ambiguous or blocked state you cannot resolve in one fix pass
+- Checkpoint or setup labels (`human-checkpoint-required`, `needs-setup`) block delegated merge
+- Repeated quota failures affect `premium`-tier spec/plan work and product decisions are needed
+- Runner migration requires credentials or repo access you do not have in the alternate environment

--- a/docs/workflow/development-workflow/provider-contingency-runner-failover.md
+++ b/docs/workflow/development-workflow/provider-contingency-runner-failover.md
@@ -69,9 +69,10 @@ gh pr view <pr_number> --json isDraft,labels,comments,statusCheckRollup
 
 Interpret signals (full table in [`agent-model-config.md`](agent-model-config.md#detection-checklist)):
 
-- **Non-draft + `ready-for-regression` + no reviewer loop summary** → Step 7 incomplete; run `/run-reviewer-loop`.
+- **`ready-for-human-review` + no reviewer loop summary** → likely incomplete Step 7; run `/run-item-work --pr <n>` or `/run-reviewer-loop` (**exception:** Step 7 `skipped` when no review platforms are configured — no summary is posted by design).
+- **`ready-for-regression` only + no reviewer loop summary** → not automatically incomplete; Step 7 can exit `skipped` (no platforms), then Step 7b applies the label with no summary. Use `workflow-next-action.sh` before rerunning `/run-reviewer-loop`.
 - **`needs-fixes` present** → address blocking findings or rerun fixer path before readiness labels.
-- **CI failing or pending** → complete Step 8 (`pr-ci-loop.sh`) after Step 7 is clean.
+- **CI failing or pending** → complete Step 8 (`pr-ci-loop.sh`) after Step 7 is clean or legitimately skipped.
 
 Then re-invoke:
 


### PR DESCRIPTION
## Summary

Graduates the `develop-model-cost-resilience` integration branch to `develop`, landing model-cost and provider-resilience documentation and Cursor agent model pins from epic #1043.

## Sub-items

- #1044 Pin Cursor agent models to framework tiers (eliminate unsafe inherit defaults) (PR #1056)
- #1045 Document provider contingency and runner failover for long orchestration runs (PR #1056)
- #1046 Optional LLM router integration pattern for tier combos and fallback (experimental) (PR #1056)

Merge strategy: **merge commit** (not squash or rebase).

No optional or deferred sub-items remain open for this integration branch.

## Test plan

- [ ] Reviewer loop clean on graduation PR
- [ ] CI green
- [ ] Merge using **Create a merge commit** (not squash/rebase)
- [ ] Post-merge: delete `develop-model-cost-resilience`, close epic #1043

Refs #1043


Made with [Cursor](https://cursor.com)