### PR TITLE
feat(workflow): shared bounded run prelude (#1049)

### DIFF
--- a/.cursor/commands/run-item-work.md
+++ b/.cursor/commands/run-item-work.md
@@ -13,6 +13,10 @@ Follow the single-item orchestration protocol exactly as defined in:
 
 `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`
 
+Before mutation, run the shared bounded prelude (scope + guardrails + policy/checkpoints):
+
+`docs/workflow/development-workflow/bounded-run-prelude.md` — `run-bounded-prelude.sh`
+
 Key responsibilities:
 
 - Resolve the request to exactly one workflow item

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Shared bounded run prelude** (#1049): `run-bounded-prelude.sh` unifies scope
+  resolution, repository guardrails snapshot, and policy/checkpoint recommendation
+  for `/run-item` and `/run-epic`; adds `run-item-scope-resolver.sh` and extends
+  `run-epic-policy-recommender.sh` for `scopeSource=item`.
 - **Human checkpoint lifecycle documentation** (#1024): adds an end-to-end
   smoke-test runbook for checkpoint recommendation, readiness labels,
   satisfaction detection, delegated gate blocking, batch merge handling, audit

--- a/docs/workflow/development-workflow/bounded-run-prelude.md
+++ b/docs/workflow/development-workflow/bounded-run-prelude.md
@@ -1,0 +1,75 @@
+# Shared Bounded Run Prelude
+
+Read-only helpers that unify scope resolution, repository guardrails snapshot,
+and policy/checkpoint recommendation for **`/run-item`** and **`/run-epic`** before
+any artifact mutation.
+
+Related:
+
+- [`protocols/95-run-epic-protocol.md`](protocols/95-run-epic-protocol.md) — epic bounded runs
+- [`protocols/91-orchestrate-work-protocol.md`](protocols/91-orchestrate-work-protocol.md) — single-item control loop (after prelude)
+- [`guardrails-enforcement.md`](guardrails-enforcement.md) — effective guardrails layering
+- Spec: [`../../specs/developments/20260625150000_1048-orchestration-command-refactor/1_1048-orchestration-command-refactor_specs.md`](../../specs/developments/20260625150000_1048-orchestration-command-refactor/1_1048-orchestration-command-refactor_specs.md)
+
+---
+
+## Scripts
+
+| Script | Purpose |
+| ------ | ------- |
+| `run-bounded-prelude.sh` | **Primary entry** — scope + guardrails + policy recommender JSON |
+| `run-item-scope-resolver.sh` | Resolve one non-epic target to recommender-compatible scope (`scopeSource=item`) |
+| `run-epic-scope-resolver.sh` | Epic or explicit item list scope (`scopeSource=epic` or `items`) |
+| `run-epic-policy-recommender.sh` | Policy, checkpoints, and copy-paste command (shared) |
+
+---
+
+## Usage
+
+**Single item** (issue, branch, PR, development folder, or router token):
+
+```bash
+./scripts/development-workflow/run-bounded-prelude.sh \
+  --original-command "/run-item 1049" \
+  --issue 1049 \
+  --delegate-review --may-merge --may-start-backlog true --max-risk medium \
+  --json
+```
+
+**Epic**:
+
+```bash
+./scripts/development-workflow/run-bounded-prelude.sh \
+  --original-command "/run-epic issues 1047" \
+  --epic 1047 \
+  --delegate-review --may-merge --may-start-backlog true --max-risk medium \
+  --json
+```
+
+The JSON output includes:
+
+- `scope` — full resolver payload (`groups`, `items`, `baseBranch`, `policy` flags)
+- `guardrails` — repository `guardrails` snapshot (`mode`, `backlog_start`)
+- `policyRecommendation` — same shape as `run-epic-policy-recommender.sh` alone
+
+---
+
+## Contract
+
+1. **Read-only** — no tracker updates, branches, PRs, merges, or issue closure.
+2. **One policy path** — single-item runs use the same recommender and checkpoint
+   schema as `/run-epic` (no parallel autonomy system).
+3. **Human confirmation** — when `requiresConfirmation` is true, accept or
+   customize policy/checkpoints before mutation (waive checkpoints in PR body
+   or via `--checkpoints-file` on re-run).
+4. **Epic-like items** — `run-item-scope-resolver.sh` rejects epic issues; use
+   `--epic` instead.
+
+---
+
+## Orchestrator integration
+
+- **`/run-item`** and **`/run-epic`** agents should call `run-bounded-prelude.sh`
+  before Protocol 91 or 95 mutation steps.
+- **`/run-work`** portfolio runs do **not** use this prelude (Protocol 90 batch
+  proposal path).

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -96,6 +96,25 @@ The Work Item Runner:
 3. Executes creator, review-gate, PR, CI, and automated-review work as one continuous control loop
 4. Stops only when the item is truly waiting on a human, blocked, or escalated
 
+### Bounded prelude (read-only gate)
+
+When invoked through **`/run-item`** or the `/run-item-work` compatibility alias
+with bounded scope flags, run the shared bounded prelude **before** any artifact
+mutation in Step 1 or later:
+
+```bash
+./scripts/development-workflow/run-bounded-prelude.sh \
+  --original-command "<invocation>" \
+  <scope flags> \
+  [--delegate-review ...] \
+  --json
+```
+
+See [`bounded-run-prelude.md`](../bounded-run-prelude.md). If
+`policyRecommendation.requiresConfirmation` is true, or guardrails cannot be
+read (`guardrails_config_unreadable`), stop before mutation per
+`guardrails-enforcement.md`.
+
 ### Persistent orchestration contract
 
 A single Work Item Runner run should keep advancing the selected item until it reaches one of these **terminal conditions**:

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -85,7 +85,10 @@ update tracker status, create branches, open or edit PRs, merge PRs, close
 issues, or delete branches.
 
 When autonomy policy is missing or ambiguous, derive a recommended policy from
-the resolver output before any mutating stage begins:
+the resolver output before any mutating stage begins. For a single combined
+read-only step (scope + repository guardrails snapshot + policy recommendation),
+use [`bounded-run-prelude.md`](../bounded-run-prelude.md) and
+`run-bounded-prelude.sh` — the same path `/run-item` uses before Protocol 91.
 
 ```bash
 ./scripts/development-workflow/run-epic-policy-recommender.sh --scope <resolver-json> --original-command "<requested command>" [--base <branch>] [--delegate-review|--no-delegate-review] [--may-merge|--no-may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--checkpoints-file <json-array>] [--json]

--- a/scripts/development-workflow/run-bounded-prelude.sh
+++ b/scripts/development-workflow/run-bounded-prelude.sh
@@ -55,17 +55,12 @@ require_value() {
 
 read_guardrails_json() {
   local config_file py_result _py_exit
-  _py_exit=0
-  if [ -n "${AI_DEV_WORKFLOW_CONFIG_FILE:-}" ]; then
-    config_file="${AI_DEV_WORKFLOW_CONFIG_FILE}"
-  else
-    config_file="$(workflow_config_file 2>/dev/null)" || _py_exit=$?
-    if [ "$_py_exit" -ne 0 ] || [ -z "${config_file:-}" ] || [ ! -f "$config_file" ]; then
-      printf '%s\n' '{"section":"absent","mode":"manual","backlog_start":false}'
-      return 0
-    fi
+  if ! config_file="$(workflow_effective_config_file 2>/dev/null)"; then
+    printf '%s\n' '{"section":"absent","mode":"manual","backlog_start":false}'
+    return 0
   fi
 
+  _py_exit=0
   py_result="$(python3 - "$config_file" <<'PYEOF'
 import sys, json
 try:
@@ -87,10 +82,18 @@ try:
     if not isinstance(allow, bool):
         allow = str(allow).lower() == 'true'
     print(json.dumps({"section": "present", "mode": mode, "backlog_start": allow}))
-except Exception:
-    print(json.dumps({"section": "absent", "mode": "manual", "backlog_start": False}))
+except Exception as exc:
+    print(f"failed to parse guardrails from {sys.argv[1]}: {exc}", file=sys.stderr)
+    sys.exit(2)
 PYEOF
-  )" || py_result='{"section":"absent","mode":"manual","backlog_start":false}'
+  )" || _py_exit=$?
+
+  if [ "$_py_exit" -eq 2 ]; then
+    error_exit "failed to read guardrails from workflow config $config_file"
+  fi
+  if [ "$_py_exit" -ne 0 ]; then
+    py_result='{"section":"absent","mode":"manual","backlog_start":false}'
+  fi
 
   printf '%s\n' "$py_result"
 }
@@ -229,8 +232,8 @@ if [ "$item_selector_count" -gt 1 ]; then
 fi
 
 if [ -z "${AI_DEV_WORKFLOW_CONFIG_FILE:-}" ]; then
-  _resolved_config="$(workflow_config_file 2>/dev/null)" || _resolved_config=""
-  if [ -n "$_resolved_config" ] && [ -f "$_resolved_config" ]; then
+  _resolved_config="$(workflow_effective_config_file 2>/dev/null)" || _resolved_config=""
+  if [ -n "$_resolved_config" ]; then
     export AI_DEV_WORKFLOW_CONFIG_FILE="$_resolved_config"
   fi
 fi

--- a/scripts/development-workflow/run-bounded-prelude.sh
+++ b/scripts/development-workflow/run-bounded-prelude.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+# shellcheck source=scripts/development-workflow/workflow-lib.sh
+source "$SCRIPT_DIR/workflow-lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/development-workflow/run-bounded-prelude.sh --original-command "<text>" [--json] \
+    (--epic <issue> | --items <list> | --target <token> | --issue <n> | --branch <name> | --pr <n> | --development <path>) \
+    [--base <branch>] [--delegate-review|--no-delegate-review] [--may-merge|--no-may-merge] \
+    [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--checkpoints-file <json-array>]
+
+Read-only shared bounded prelude for /run-item and /run-epic: scope resolution,
+repository guardrails snapshot, and policy/checkpoint recommendation. No tracker,
+branch, PR, merge, or cleanup mutation.
+EOF
+}
+
+original_command=""
+json_output=0
+scope_mode=""
+epic_number=""
+items_arg=""
+item_target=""
+item_issue=""
+item_branch=""
+item_pr=""
+item_development=""
+base_override=""
+delegate_review_override=""
+may_merge_override=""
+may_start_backlog_override=""
+max_risk_override=""
+checkpoints_file=""
+
+error_exit() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_value() {
+  local option="$1"
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ] || [ "${2#--}" != "$2" ]; then
+    echo "$option requires a value." >&2
+    usage >&2
+    exit 64
+  fi
+}
+
+read_guardrails_json() {
+  local config_file py_result _py_exit
+  _py_exit=0
+  if [ -n "${AI_DEV_WORKFLOW_CONFIG_FILE:-}" ]; then
+    config_file="${AI_DEV_WORKFLOW_CONFIG_FILE}"
+  else
+    config_file="$(workflow_config_file 2>/dev/null)" || _py_exit=$?
+    if [ "$_py_exit" -ne 0 ] || [ -z "${config_file:-}" ] || [ ! -f "$config_file" ]; then
+      printf '%s\n' '{"section":"absent","mode":"manual","backlog_start":false}'
+      return 0
+    fi
+  fi
+
+  py_result="$(python3 - "$config_file" <<'PYEOF'
+import sys, json
+try:
+    import yaml
+    with open(sys.argv[1], 'r') as f:
+        cfg = yaml.safe_load(f) or {}
+    guardrails = cfg.get('guardrails') if isinstance(cfg, dict) else None
+    if not isinstance(guardrails, dict):
+        print(json.dumps({"section": "absent", "mode": "manual", "backlog_start": False}))
+        sys.exit(0)
+    mode = guardrails.get('mode', 'manual')
+    if mode not in ('manual', 'assisted', 'delegated', 'autonomous'):
+        mode = 'manual'
+    backlog_start_cfg = guardrails.get('backlog_start', {})
+    if isinstance(backlog_start_cfg, dict):
+        allow = backlog_start_cfg.get('allow_without_confirmation', False)
+    else:
+        allow = False
+    if not isinstance(allow, bool):
+        allow = str(allow).lower() == 'true'
+    print(json.dumps({"section": "present", "mode": mode, "backlog_start": allow}))
+except Exception:
+    print(json.dumps({"section": "absent", "mode": "manual", "backlog_start": False}))
+PYEOF
+  )" || py_result='{"section":"absent","mode":"manual","backlog_start":false}'
+
+  printf '%s\n' "$py_result"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --original-command)
+      require_value "$@"
+      original_command="$2"
+      shift 2
+      ;;
+    --epic)
+      require_value "$@"
+      epic_number="$2"
+      scope_mode="epic"
+      shift 2
+      ;;
+    --items)
+      require_value "$@"
+      items_arg="$2"
+      scope_mode="items"
+      shift 2
+      ;;
+    --target)
+      require_value "$@"
+      item_target="$2"
+      scope_mode="item"
+      shift 2
+      ;;
+    --issue)
+      require_value "$@"
+      item_issue="$2"
+      scope_mode="item"
+      shift 2
+      ;;
+    --branch)
+      require_value "$@"
+      item_branch="$2"
+      scope_mode="item"
+      shift 2
+      ;;
+    --pr)
+      require_value "$@"
+      item_pr="$2"
+      scope_mode="item"
+      shift 2
+      ;;
+    --development)
+      require_value "$@"
+      item_development="$2"
+      scope_mode="item"
+      shift 2
+      ;;
+    --base)
+      require_value "$@"
+      base_override="$2"
+      shift 2
+      ;;
+    --delegate-review)
+      delegate_review_override="true"
+      shift
+      ;;
+    --delegate-review=*)
+      delegate_review_override="${1#*=}"
+      shift
+      ;;
+    --no-delegate-review)
+      delegate_review_override="false"
+      shift
+      ;;
+    --may-merge)
+      may_merge_override="true"
+      shift
+      ;;
+    --may-merge=*)
+      may_merge_override="${1#*=}"
+      shift
+      ;;
+    --no-may-merge)
+      may_merge_override="false"
+      shift
+      ;;
+    --may-start-backlog)
+      require_value "$@"
+      may_start_backlog_override="$2"
+      shift 2
+      ;;
+    --max-risk)
+      require_value "$@"
+      max_risk_override="$2"
+      shift 2
+      ;;
+    --checkpoints-file)
+      require_value "$@"
+      checkpoints_file="$2"
+      shift 2
+      ;;
+    --json)
+      json_output=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+[ -n "$original_command" ] || error_exit "--original-command is required"
+[ -n "$scope_mode" ] || error_exit "exactly one scope selector is required (--epic, --items, or item target flags)"
+
+tmp_dir="$(mktemp -d)"
+scope_file="$tmp_dir/scope.json"
+policy_file="$tmp_dir/policy.json"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+resolver_common=()
+[ -n "$base_override" ] && resolver_common+=(--base "$base_override")
+[ "$delegate_review_override" = "true" ] && resolver_common+=(--delegate-review)
+[ "$may_merge_override" = "true" ] && resolver_common+=(--may-merge)
+[ -n "$may_start_backlog_override" ] && resolver_common+=(--may-start-backlog "$may_start_backlog_override")
+[ -n "$max_risk_override" ] && resolver_common+=(--max-risk "$max_risk_override")
+
+case "$scope_mode" in
+  epic)
+  if ! "$SCRIPT_DIR/run-epic-scope-resolver.sh" --epic "$epic_number" "${resolver_common[@]}" --json > "$scope_file"; then
+    error_exit "epic scope resolution failed"
+  fi
+    ;;
+  items)
+  if ! "$SCRIPT_DIR/run-epic-scope-resolver.sh" --items "$items_arg" "${resolver_common[@]}" --json > "$scope_file"; then
+    error_exit "items scope resolution failed"
+  fi
+    ;;
+  item)
+    item_args=()
+    [ -n "$item_target" ] && item_args+=(--target "$item_target")
+    [ -n "$item_issue" ] && item_args+=(--issue "$item_issue")
+    [ -n "$item_branch" ] && item_args+=(--branch "$item_branch")
+    [ -n "$item_pr" ] && item_args+=(--pr "$item_pr")
+    [ -n "$item_development" ] && item_args+=(--development "$item_development")
+    if ! "$SCRIPT_DIR/run-item-scope-resolver.sh" "${item_args[@]}" "${resolver_common[@]}" --json > "$scope_file"; then
+      error_exit "item scope resolution failed"
+    fi
+    ;;
+esac
+
+policy_args=(
+  --scope "$scope_file"
+  --original-command "$original_command"
+)
+[ -n "$base_override" ] && policy_args+=(--base "$base_override")
+[ -n "$delegate_review_override" ] && policy_args+=(--delegate-review="$delegate_review_override")
+[ -n "$may_merge_override" ] && policy_args+=(--may-merge="$may_merge_override")
+[ -n "$may_start_backlog_override" ] && policy_args+=(--may-start-backlog "$may_start_backlog_override")
+[ -n "$max_risk_override" ] && policy_args+=(--max-risk "$max_risk_override")
+[ -n "$checkpoints_file" ] && policy_args+=(--checkpoints-file "$checkpoints_file")
+policy_args+=(--json)
+
+if ! "$SCRIPT_DIR/run-epic-policy-recommender.sh" "${policy_args[@]}" > "$policy_file"; then
+  error_exit "policy recommendation failed"
+fi
+
+guardrails_json="$(read_guardrails_json)"
+
+prelude_json="$(jq -nc \
+  --slurpfile scope "$scope_file" \
+  --slurpfile policy "$policy_file" \
+  --argjson guardrails "$guardrails_json" \
+  '{
+    preludeVersion: 1,
+    scope: $scope[0],
+    guardrails: $guardrails,
+    policyRecommendation: $policy[0],
+    readOnlyGuarantee: "No tracker updates, branch creation, PR edits, labels, comments, merges, issue closure, or branch deletion were performed."
+  }')"
+
+if [ "$json_output" -eq 1 ]; then
+  printf '%s\n' "$prelude_json"
+  exit 0
+fi
+
+printf 'Bounded Run Prelude\n'
+printf 'Scope source: %s\n' "$(jq -r '.scope.scopeSource' <<<"$prelude_json")"
+printf 'Guardrails: section=%s mode=%s backlog_start=%s\n' \
+  "$(jq -r '.guardrails.section' <<<"$prelude_json")" \
+  "$(jq -r '.guardrails.mode' <<<"$prelude_json")" \
+  "$(jq -r '.guardrails.backlog_start' <<<"$prelude_json")"
+printf 'Requires confirmation: %s\n' "$(jq -r '.policyRecommendation.requiresConfirmation' <<<"$prelude_json")"
+printf 'Reason: %s\n' "$(jq -r '.policyRecommendation.confirmationReason' <<<"$prelude_json")"
+printf 'Copy-paste: %s\n' "$(jq -r '.policyRecommendation.copyPasteCommand' <<<"$prelude_json")"
+printf 'Read-only: %s\n' "$(jq -r '.readOnlyGuarantee' <<<"$prelude_json")"

--- a/scripts/development-workflow/run-bounded-prelude.sh
+++ b/scripts/development-workflow/run-bounded-prelude.sh
@@ -22,7 +22,9 @@ EOF
 
 original_command=""
 json_output=0
-scope_mode=""
+scope_epic_set=0
+scope_items_set=0
+item_selector_count=0
 epic_number=""
 items_arg=""
 item_target=""
@@ -103,43 +105,43 @@ while [ "$#" -gt 0 ]; do
     --epic)
       require_value "$@"
       epic_number="$2"
-      scope_mode="epic"
+      scope_epic_set=1
       shift 2
       ;;
     --items)
       require_value "$@"
       items_arg="$2"
-      scope_mode="items"
+      scope_items_set=1
       shift 2
       ;;
     --target)
       require_value "$@"
       item_target="$2"
-      scope_mode="item"
+      item_selector_count=$((item_selector_count + 1))
       shift 2
       ;;
     --issue)
       require_value "$@"
       item_issue="$2"
-      scope_mode="item"
+      item_selector_count=$((item_selector_count + 1))
       shift 2
       ;;
     --branch)
       require_value "$@"
       item_branch="$2"
-      scope_mode="item"
+      item_selector_count=$((item_selector_count + 1))
       shift 2
       ;;
     --pr)
       require_value "$@"
       item_pr="$2"
-      scope_mode="item"
+      item_selector_count=$((item_selector_count + 1))
       shift 2
       ;;
     --development)
       require_value "$@"
       item_development="$2"
-      scope_mode="item"
+      item_selector_count=$((item_selector_count + 1))
       shift 2
       ;;
     --base)
@@ -203,7 +205,44 @@ while [ "$#" -gt 0 ]; do
 done
 
 [ -n "$original_command" ] || error_exit "--original-command is required"
-[ -n "$scope_mode" ] || error_exit "exactly one scope selector is required (--epic, --items, or item target flags)"
+
+if [ "$scope_epic_set" -eq 1 ] && [ "$scope_items_set" -eq 1 ]; then
+  error_exit "pass exactly one of --epic or --items, not both"
+fi
+if [ "$scope_epic_set" -eq 1 ] && [ "$item_selector_count" -gt 0 ]; then
+  error_exit "pass exactly one scope selector group (--epic, --items, or one item target flag), not --epic with item flags"
+fi
+if [ "$scope_items_set" -eq 1 ] && [ "$item_selector_count" -gt 0 ]; then
+  error_exit "pass exactly one scope selector group (--epic, --items, or one item target flag), not --items with item flags"
+fi
+
+scope_group_count=0
+[ "$scope_epic_set" -eq 1 ] && scope_group_count=$((scope_group_count + 1))
+[ "$scope_items_set" -eq 1 ] && scope_group_count=$((scope_group_count + 1))
+[ "$item_selector_count" -gt 0 ] && scope_group_count=$((scope_group_count + 1))
+
+if [ "$scope_group_count" -ne 1 ]; then
+  error_exit "pass exactly one scope selector group (--epic, --items, or one item target flag)"
+fi
+if [ "$item_selector_count" -gt 1 ]; then
+  error_exit "pass exactly one item target flag (--target, --issue, --branch, --pr, or --development)"
+fi
+
+if [ -z "${AI_DEV_WORKFLOW_CONFIG_FILE:-}" ]; then
+  _resolved_config="$(workflow_config_file 2>/dev/null)" || _resolved_config=""
+  if [ -n "$_resolved_config" ] && [ -f "$_resolved_config" ]; then
+    export AI_DEV_WORKFLOW_CONFIG_FILE="$_resolved_config"
+  fi
+fi
+
+scope_mode=""
+if [ "$scope_epic_set" -eq 1 ]; then
+  scope_mode="epic"
+elif [ "$scope_items_set" -eq 1 ]; then
+  scope_mode="items"
+else
+  scope_mode="item"
+fi
 
 tmp_dir="$(mktemp -d)"
 scope_file="$tmp_dir/scope.json"

--- a/scripts/development-workflow/run-bounded-prelude.sh
+++ b/scripts/development-workflow/run-bounded-prelude.sh
@@ -73,7 +73,8 @@ try:
         sys.exit(0)
     mode = guardrails.get('mode', 'manual')
     if mode not in ('manual', 'assisted', 'delegated', 'autonomous'):
-        mode = 'manual'
+        print(f"invalid guardrails.mode: {mode}", file=sys.stderr)
+        sys.exit(2)
     backlog_start_cfg = guardrails.get('backlog_start', {})
     if isinstance(backlog_start_cfg, dict):
         allow = backlog_start_cfg.get('allow_without_confirmation', False)

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -182,7 +182,12 @@ if ! printf '%s\n' "$scope_json" | jq -e '
   error_exit "scope JSON must include object fields groups and policy plus array field items"
 fi
 
-config_file="$(workflow_config_file)"
+config_file=""
+if [ -n "${AI_DEV_WORKFLOW_CONFIG_FILE:-}" ]; then
+  config_file="${AI_DEV_WORKFLOW_CONFIG_FILE}"
+else
+  config_file="$(workflow_config_file)"
+fi
 if ! reviewers="$(workflow_config_review_on_draft_runner "$config_file")"; then
   error_exit "failed to read review.on_draft.runner from workflow config: $config_file"
 fi

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -183,10 +183,8 @@ if ! printf '%s\n' "$scope_json" | jq -e '
 fi
 
 config_file=""
-if [ -n "${AI_DEV_WORKFLOW_CONFIG_FILE:-}" ]; then
-  config_file="${AI_DEV_WORKFLOW_CONFIG_FILE}"
-else
-  config_file="$(workflow_config_file)"
+if ! config_file="$(workflow_effective_config_file 2>/dev/null)"; then
+  error_exit "workflow config file not found"
 fi
 if ! reviewers="$(workflow_config_review_on_draft_runner "$config_file")"; then
   error_exit "failed to read review.on_draft.runner from workflow config: $config_file"

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -332,12 +332,16 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
   def value_string($override; $recommended):
     if $override == "" then $recommended else $override end;
   def command_prefix:
-    if ($originalCommand | test("^/run-epic(\\s|$)")) then "/run-epic" else "$run-epic" end;
+    if ($originalCommand | test("^/run-item(\\s|$)")) then "/run-item"
+    elif ($originalCommand | test("^/run-epic(\\s|$)")) then "/run-epic"
+    else "$run-epic" end;
   def canonical_scope_command:
     if (.scopeSource // "") == "epic" and (.epicNumber // null) != null then
       command_prefix + " issues " + (.epicNumber | tostring)
     elif (.scopeSource // "") == "items" and ((.itemInput // "") | tostring | length) > 0 then
       command_prefix + " --items " + ((.itemInput // "") | tostring)
+    elif (.scopeSource // "") == "item" and ((.itemInput // "") | tostring | length) > 0 then
+      "/run-item " + ((.itemInput // "") | tostring)
     else
       $originalCommand
     end;

--- a/scripts/development-workflow/run-item-scope-resolver.sh
+++ b/scripts/development-workflow/run-item-scope-resolver.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+# shellcheck source=scripts/development-workflow/workflow-lib.sh
+source "$SCRIPT_DIR/workflow-lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/development-workflow/run-item-scope-resolver.sh --target <token> [--base <branch>] [--delegate-review] [--may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--json]
+  ./scripts/development-workflow/run-item-scope-resolver.sh --issue <number> [--base <branch>] ... [--json]
+  ./scripts/development-workflow/run-item-scope-resolver.sh --branch <name> [--base <branch>] ... [--json]
+  ./scripts/development-workflow/run-item-scope-resolver.sh --pr <number> [--base <branch>] ... [--json]
+  ./scripts/development-workflow/run-item-scope-resolver.sh --development <path> [--base <branch>] ... [--json]
+
+Resolves exactly one non-epic workflow item into scope JSON compatible with
+run-epic-policy-recommender.sh (scopeSource=item). Read-only — no tracker,
+branch, PR, merge, or cleanup mutation.
+EOF
+}
+
+json_output=0
+target_token=""
+issue_number=""
+branch_name=""
+pr_number=""
+development_path=""
+base_override=""
+delegate_review=0
+may_merge=0
+may_start_backlog="false"
+max_risk="low"
+
+error_exit() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_value() {
+  local option="$1"
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ] || [ "${2#--}" != "$2" ]; then
+    echo "$option requires a value." >&2
+    usage >&2
+    exit 64
+  fi
+}
+
+is_positive_int() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    0*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+is_boolean() {
+  case "$1" in
+    true|false) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+valid_max_risk() {
+  case "$1" in
+    low|medium|high) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+have_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+issue_from_branch() {
+  local b="$1"
+  if [[ "$b" =~ ^(fix|feature|hotfix|refactor)/([0-9]+)($|-) ]]; then
+    printf '%s\n' "${BASH_REMATCH[2]}"
+    return 0
+  fi
+  if [[ "$b" =~ ^(fix|feature|hotfix|refactor)/([a-zA-Z]{2,6}-([0-9]+))($|-) ]]; then
+    printf '%s\n' "${BASH_REMATCH[3]}"
+    return 0
+  fi
+  if [[ "$b" =~ ^(spec|implementation-plan)/([0-9]+)($|-) ]]; then
+    printf '%s\n' "${BASH_REMATCH[2]}"
+    return 0
+  fi
+  if [[ "$b" =~ ^(spec|implementation-plan)/([a-zA-Z]{2,6}-([0-9]+))($|-) ]]; then
+    printf '%s\n' "${BASH_REMATCH[3]}"
+    return 0
+  fi
+  return 1
+}
+
+is_epic_issue() {
+  local num="$1"
+  if ! have_cmd gh; then
+    return 1
+  fi
+  local sub_count issue_type
+  sub_count="$(gh issue view "$num" --json subIssues --jq '.subIssues | length' 2>/dev/null)" || return 1
+  case "${sub_count:-}" in
+    ''|*[!0-9]*) sub_count="0" ;;
+  esac
+  issue_type="$(gh issue view "$num" --json labels \
+    --jq '[.labels[].name] | map(ascii_downcase) | map(select(. == "epic")) | length' 2>/dev/null)" || issue_type="0"
+  case "${issue_type:-}" in
+    ''|*[!0-9]*) issue_type="0" ;;
+  esac
+  if [ "$sub_count" -gt 0 ] || [ "$issue_type" -gt 0 ]; then
+    return 0
+  fi
+  return 1
+}
+
+resolve_token_kind() {
+  local token="$1"
+  local repo_root pr_num pr_state issue_state
+  token="${token#./}"
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || repo_root=""
+
+  if [ -n "$repo_root" ] && [ -d "$repo_root/$token" ] && [[ "$token" == docs/specs/developments/* ]]; then
+    printf 'dev_folder'
+    return 0
+  fi
+
+  pr_num="${token#\#}"
+  if is_positive_int "$pr_num" && have_cmd gh; then
+    pr_state="$(gh pr view "$pr_num" --json state --jq '.state' 2>/dev/null)" || true
+    if [ -n "$pr_state" ]; then
+      printf 'pr'
+      return 0
+    fi
+    issue_state="$(gh issue view "$pr_num" --json state --jq '.state' 2>/dev/null)" || true
+    if [ -n "$issue_state" ]; then
+      printf 'issue'
+      return 0
+    fi
+    return 1
+  fi
+
+  case "$token" in
+    feature/*|fix/*|refactor/*|hotfix/*|spec/*|implementation-plan/*|plan/*)
+      if git show-ref --verify --quiet "refs/remotes/origin/$token" 2>/dev/null \
+        || git show-ref --verify --quiet "refs/heads/$token" 2>/dev/null; then
+        printf 'branch'
+        return 0
+      fi
+      return 1
+      ;;
+  esac
+  return 1
+}
+
+issue_from_development_path() {
+  local path="$1"
+  local slug branch_ref issue
+  slug="$(basename "$path" | sed 's/^[0-9]\{14\}_//')"
+  if [[ "$slug" =~ ^([0-9]+)- ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    if issue_from_branch "$ref" >/dev/null 2>&1; then
+      issue="$(issue_from_branch "$ref")"
+      printf '%s\n' "$issue"
+      return 0
+    fi
+  done < <(git show-ref 2>/dev/null | sed -n 's|.*refs/remotes/origin/||p' | grep -F "$slug" || true)
+  return 1
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --target)
+      require_value "$@"
+      target_token="$2"
+      shift 2
+      ;;
+    --issue)
+      require_value "$@"
+      issue_number="$2"
+      shift 2
+      ;;
+    --branch)
+      require_value "$@"
+      branch_name="$2"
+      shift 2
+      ;;
+    --pr)
+      require_value "$@"
+      pr_number="$2"
+      shift 2
+      ;;
+    --development)
+      require_value "$@"
+      development_path="$2"
+      shift 2
+      ;;
+    --base)
+      require_value "$@"
+      base_override="$2"
+      shift 2
+      ;;
+    --delegate-review)
+      delegate_review=1
+      shift
+      ;;
+    --may-merge)
+      may_merge=1
+      shift
+      ;;
+    --may-start-backlog)
+      require_value "$@"
+      may_start_backlog="$2"
+      shift 2
+      ;;
+    --max-risk)
+      require_value "$@"
+      max_risk="$2"
+      shift 2
+      ;;
+    --json)
+      json_output=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+inputs=0
+[ -n "$target_token" ] && inputs=$((inputs + 1))
+[ -n "$issue_number" ] && inputs=$((inputs + 1))
+[ -n "$branch_name" ] && inputs=$((inputs + 1))
+[ -n "$pr_number" ] && inputs=$((inputs + 1))
+[ -n "$development_path" ] && inputs=$((inputs + 1))
+
+if [ "$inputs" -ne 1 ]; then
+  usage >&2
+  exit 64
+fi
+
+if ! is_boolean "$may_start_backlog"; then
+  echo "ERROR: --may-start-backlog must be true or false." >&2
+  exit 64
+fi
+if ! valid_max_risk "$max_risk"; then
+  echo "ERROR: --max-risk must be one of low, medium, or high." >&2
+  exit 64
+fi
+
+item_input=""
+resolved_issue=""
+
+if [ -n "$issue_number" ]; then
+  if ! is_positive_int "$issue_number"; then
+    error_exit "invalid --issue number: $issue_number"
+  fi
+  resolved_issue="$issue_number"
+  item_input="$issue_number"
+elif [ -n "$target_token" ]; then
+  item_input="$target_token"
+  kind="$(resolve_token_kind "$target_token")" || error_exit "could not resolve --target '$target_token'"
+  case "$kind" in
+    issue)
+      resolved_issue="${target_token#\#}"
+      ;;
+    pr)
+      pr_num="${target_token#\#}"
+      head="$(gh pr view "$pr_num" --json headRefName --jq '.headRefName' 2>/dev/null)" || error_exit "could not read PR #$pr_num"
+      resolved_issue="$(issue_from_branch "$head")" || error_exit "could not extract issue from PR branch $head"
+      ;;
+    branch)
+      resolved_issue="$(issue_from_branch "$target_token")" || error_exit "could not extract issue number from branch $target_token"
+      ;;
+    dev_folder)
+      resolved_issue="$(issue_from_development_path "$target_token")" || error_exit "could not resolve issue from development path $target_token"
+      ;;
+    *)
+      error_exit "unsupported resolved kind for target"
+      ;;
+  esac
+elif [ -n "$branch_name" ]; then
+  item_input="$branch_name"
+  resolved_issue="$(issue_from_branch "$branch_name")" || error_exit "could not extract issue number from branch $branch_name"
+elif [ -n "$pr_number" ]; then
+  if ! is_positive_int "$pr_number"; then
+    error_exit "invalid --pr number: $pr_number"
+  fi
+  item_input="$pr_number"
+  head="$(gh pr view "$pr_number" --json headRefName --jq '.headRefName' 2>/dev/null)" || error_exit "could not read PR #$pr_number"
+  resolved_issue="$(issue_from_branch "$head")" || error_exit "could not extract issue from PR branch $head"
+elif [ -n "$development_path" ]; then
+  item_input="$development_path"
+  resolved_issue="$(issue_from_development_path "$development_path")" || error_exit "could not resolve issue from $development_path"
+fi
+
+if is_epic_issue "$resolved_issue"; then
+  error_exit "issue #$resolved_issue is epic-like; use /run-epic or run-epic-scope-resolver instead"
+fi
+
+resolver_args=(
+  --items "$resolved_issue"
+  --may-start-backlog "$may_start_backlog"
+  --max-risk "$max_risk"
+)
+[ -n "$base_override" ] && resolver_args+=(--base "$base_override")
+[ "$delegate_review" -eq 1 ] && resolver_args+=(--delegate-review)
+[ "$may_merge" -eq 1 ] && resolver_args+=(--may-merge)
+resolver_args+=(--json)
+
+if ! scope_json="$("$SCRIPT_DIR/run-epic-scope-resolver.sh" "${resolver_args[@]}")"; then
+  error_exit "underlying scope resolver failed for issue #$resolved_issue"
+fi
+
+out_json="$(printf '%s\n' "$scope_json" | jq -c \
+  --arg itemInput "$item_input" \
+  --argjson resolvedIssue "$resolved_issue" \
+  '.scopeSource = "item" | .epicNumber = null | .itemInput = $itemInput | .resolvedIssueNumber = $resolvedIssue')"
+
+if [ "$json_output" -eq 1 ]; then
+  printf '%s\n' "$out_json"
+  exit 0
+fi
+
+printf 'Run Item Scope Resolver\n'
+printf 'Resolved issue: #%s\n' "$resolved_issue"
+printf 'Item input: %s\n' "$item_input"
+printf 'Base branch: %s (%s)\n' "$(printf '%s\n' "$out_json" | jq -r '.baseBranch // "ambiguous"')" "$(printf '%s\n' "$out_json" | jq -r '.baseReason')"
+printf '%s\n' "$out_json" | jq -r '.groups.eligible[]? | "- eligible #\(.number) \(.title)"'
+printf '%s\n' "$out_json" | jq -r '.groups.blocked[]? | "- blocked #\(.number) \(.title)"'
+printf '%s\n' "$out_json" | jq -r '.groups.ambiguous[]? | "- ambiguous #\(.number) \(.title)"'
+printf 'Read-only: %s\n' "$(printf '%s\n' "$out_json" | jq -r '.readOnlyGuarantee')"

--- a/scripts/development-workflow/run-item-scope-resolver.sh
+++ b/scripts/development-workflow/run-item-scope-resolver.sh
@@ -99,13 +99,13 @@ is_epic_issue() {
   if ! have_cmd gh; then
     return 1
   fi
-  local sub_count issue_type
-  sub_count="$(gh issue view "$num" --json subIssues --jq '.subIssues | length' 2>/dev/null)" || return 1
+  local sub_count=0 issue_type=0
+  sub_count="$(gh issue view "$num" --json subIssues --jq '.subIssues | length' 2>/dev/null)" || sub_count=0
   case "${sub_count:-}" in
     ''|*[!0-9]*) sub_count="0" ;;
   esac
   issue_type="$(gh issue view "$num" --json labels \
-    --jq '[.labels[].name] | map(ascii_downcase) | map(select(. == "epic")) | length' 2>/dev/null)" || issue_type="0"
+    --jq '[.labels[].name] | map(ascii_downcase) | map(select(. == "epic")) | length' 2>/dev/null)" || issue_type=0
   case "${issue_type:-}" in
     ''|*[!0-9]*) issue_type="0" ;;
   esac

--- a/scripts/development-workflow/run-item-scope-resolver.sh
+++ b/scripts/development-workflow/run-item-scope-resolver.sh
@@ -83,11 +83,11 @@ issue_from_branch() {
     printf '%s\n' "${BASH_REMATCH[3]}"
     return 0
   fi
-  if [[ "$b" =~ ^(spec|implementation-plan)/([0-9]+)($|-) ]]; then
+  if [[ "$b" =~ ^(spec|implementation-plan|plan)/([0-9]+)($|-) ]]; then
     printf '%s\n' "${BASH_REMATCH[2]}"
     return 0
   fi
-  if [[ "$b" =~ ^(spec|implementation-plan)/([a-zA-Z]{2,6}-([0-9]+))($|-) ]]; then
+  if [[ "$b" =~ ^(spec|implementation-plan|plan)/([a-zA-Z]{2,6}-([0-9]+))($|-) ]]; then
     printf '%s\n' "${BASH_REMATCH[3]}"
     return 0
   fi

--- a/scripts/development-workflow/tests/test-run-bounded-prelude.sh
+++ b/scripts/development-workflow/tests/test-run-bounded-prelude.sh
@@ -58,5 +58,27 @@ run_test "item_policy_delegate" "true" "$(printf '%s\n' "$policy_out" | jq -r '.
 
 run_test "prelude_help" "0" "$( "$PRELUDE" --help >/dev/null; echo 0)"
 
+run_fails() {
+  local name="$1" expected="$2"
+  shift 2
+  set +e
+  local out status
+  out="$("$@" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ] && grep -Fq -- "$expected" <<<"$out"; then
+    pass=$((pass + 1))
+    printf 'ok %s\n' "$name"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL %s status=%s\n%s\n' "$name" "$status" "$out"
+  fi
+}
+
+run_fails "reject_epic_and_issue" "not --epic with item flags" \
+  "$PRELUDE" --original-command "/run-item 1" --epic 1047 --issue 1049
+run_fails "reject_multiple_item_flags" "exactly one item target flag" \
+  "$PRELUDE" --original-command "/run-item 1" --issue 1049 --branch feature/1049-x
+
 printf '\nResults: %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/development-workflow/tests/test-run-bounded-prelude.sh
+++ b/scripts/development-workflow/tests/test-run-bounded-prelude.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# test-run-bounded-prelude.sh - Fixture tests for shared bounded prelude output shape.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+HELPER="$REPO_ROOT/scripts/development-workflow/run-epic-policy-recommender.sh"
+PRELUDE="$REPO_ROOT/scripts/development-workflow/run-bounded-prelude.sh"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+pass=0
+fail=0
+
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    pass=$((pass + 1))
+    printf 'ok %s\n' "$name"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL %s expected=%s actual=%s\n' "$name" "$expected" "$actual"
+  fi
+}
+
+write_fixture() {
+  local name="$1" json="$2"
+  local path="$TMP_ROOT/${name}.json"
+  printf '%s\n' "$json" >"$path"
+  printf '%s\n' "$path"
+}
+
+item_scope='{
+  "scopeSource": "item",
+  "epicNumber": null,
+  "itemInput": "1049",
+  "resolvedIssueNumber": 1049,
+  "baseBranch": "develop-orchestration-command-refactor",
+  "baseAmbiguous": false,
+  "baseReason": "shared integration branch label",
+  "policy": {"delegateReview": false, "mayMerge": false, "mayStartBacklog": false, "maxRisk": "low"},
+  "groups": {
+    "eligible": [{"number": 1049, "title": "Shared bounded prelude", "status": "Backlog", "type": "Workflow", "labels": [], "body": "workflow orchestration"}],
+    "blocked": [], "already_merged": [], "in_review": [], "ambiguous": [], "out_of_scope": []
+  },
+  "items": [{"number": 1049, "title": "Shared bounded prelude", "status": "Backlog", "type": "Workflow", "labels": [], "body": "workflow orchestration"}]
+}'
+
+item_fixture="$(write_fixture item-scope "$item_scope")"
+policy_out="$(AI_DEV_WORKFLOW_CONFIG_FILE="$REPO_ROOT/.ai-dev-workflow.yaml" \
+  "$HELPER" --scope "$item_fixture" --original-command "/run-item 1049" \
+  --delegate-review --may-merge --may-start-backlog true --max-risk medium --json)"
+
+run_test "item_policy_copy_paste" "true" "$(printf '%s\n' "$policy_out" | jq -r '(.copyPasteCommand | test("/run-item 1049"))')"
+run_test "item_policy_delegate" "true" "$(printf '%s\n' "$policy_out" | jq -r '.effectivePolicy.delegateReview')"
+
+run_test "prelude_help" "0" "$( "$PRELUDE" --help >/dev/null; echo 0)"
+
+printf '\nResults: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -18,6 +18,23 @@ workflow_config_file() {
   printf '%s/.ai-dev-workflow.yaml\n' "$(workflow_repo_root)"
 }
 
+# workflow_effective_config_file
+# Honors AI_DEV_WORKFLOW_CONFIG_FILE when it points to an existing file;
+# otherwise falls back to the repository default .ai-dev-workflow.yaml when present.
+workflow_effective_config_file() {
+  local default
+  if [ -n "${AI_DEV_WORKFLOW_CONFIG_FILE:-}" ] && [ -f "${AI_DEV_WORKFLOW_CONFIG_FILE}" ]; then
+    printf '%s\n' "${AI_DEV_WORKFLOW_CONFIG_FILE}"
+    return 0
+  fi
+  default="$(workflow_config_file)"
+  if [ -f "$default" ]; then
+    printf '%s\n' "$default"
+    return 0
+  fi
+  return 1
+}
+
 workflow_local_config_file() {
   printf '%s/.ai-dev-workflow.local.yaml\n' "$(workflow_repo_root)"
 }


### PR DESCRIPTION
## Summary

- Adds `run-bounded-prelude.sh` to combine scope resolution, repository guardrails snapshot, and policy/checkpoint recommendation for bounded `/run-item` and `/run-epic` invocations.
- Adds `run-item-scope-resolver.sh` for single non-epic targets (`scopeSource=item`) and extends `run-epic-policy-recommender.sh` with `/run-item` copy-paste commands.
- Documents the shared prelude in `bounded-run-prelude.md` and wires references from Protocol 95 and the `/run-item-work` Cursor command.

Closes #1049

## Test plan

- [x] `bash scripts/development-workflow/tests/test-run-bounded-prelude.sh`
- [x] Manual: `run-item-scope-resolver.sh --issue 1049 --json` against live GitHub
- [ ] CI workflow tests


Made with [Cursor](https://cursor.com)