### PR TITLE
feat(workflow): parallel run-work batch lanes (#1052)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Parallel implementation policy for `/run-work` batches** (#1052): `workflow-batch-lanes.sh`
+  assigns stage lanes with default implementation serialization (`max_concurrent: 1`);
+  `workflow-batch-plan.sh` emits `LOCAL_RUNTIME=none|exclusive` for implementation items;
+  Protocol 90 Step 3 and `guardrails.md` document optional `guardrails.parallelism` caps.
 - **Portfolio-only `/run-work` router** (#1051): `run-work-router.sh` and Protocol 96
   now support only `no_target_scan` and `explicit_list` under `/run-work`; single
   and epic targets emit `redirect_item` / `redirect_epic` with `REDIRECT_COMMAND`

--- a/docs/workflow/development-workflow/guardrails.md
+++ b/docs/workflow/development-workflow/guardrails.md
@@ -129,6 +129,40 @@ guardrails:
 
 ---
 
+## Portfolio parallelism (optional)
+
+The `parallelism` block under `guardrails` configures stage-lane caps for
+`/run-work` portfolio batches (Protocol 90 Step 3). It does not change per-stage
+protocol contracts — only how many items per lane may dispatch concurrently.
+
+| Field | Type | Default | Meaning |
+| ----- | ---- | ------- | ------- |
+| `max_concurrent_by_stage.spec` | integer | `0` (unlimited) | Max concurrent spec-lane items in one batch proposal. |
+| `max_concurrent_by_stage.plan` | integer | `0` (unlimited) | Max concurrent plan-lane items. |
+| `max_concurrent_by_stage.review` | integer | `0` (unlimited) | Max concurrent review-lane items. |
+| `max_concurrent_by_stage.implementation` | integer | `1` | Max concurrent implementation items (conservative default). |
+
+`0` means no cap for that lane. Higher implementation concurrency requires explicit
+configuration; `workflow-batch-plan.sh` may still emit `LOCAL_RUNTIME=exclusive` to
+hold items that would contend for local dev servers, databases, or ports even when
+the lane cap allows more than one implementation item.
+
+```yaml
+guardrails:
+  mode: delegated
+  parallelism:
+    max_concurrent_by_stage:
+      spec: 0
+      plan: 0
+      review: 0
+      implementation: 2
+```
+
+Resolved lane assignments and hold reasons are emitted by
+`scripts/development-workflow/workflow-batch-lanes.sh`.
+
+---
+
 ## Required Evidence
 
 The `required_evidence` field on each stage lists named evidence items that must

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -603,6 +603,48 @@ See [`linear.md`](../integrations/linear.md) for the full reference table.
 
 Group dispatch-eligible items and approved start-batch items into explicit batches. If Backlog items have only been proposed and not yet approved, do not continue to tracker mutation or dispatch for those items.
 
+### Stage-aware batch lanes (default implementation serialization)
+
+Before tool-fix ordering and file-level conflict checks, assign each candidate item
+to a **stage lane** and apply `max_concurrent_by_stage` caps:
+
+| Lane            | Typical `NEXT_ACTION` values                                      | Default max concurrent |
+| --------------- | ----------------------------------------------------------------- | ---------------------- |
+| `spec`          | `run-spec-review-and-open-pr`                                     | unlimited (`0`)        |
+| `plan`          | `write-plan`, `run-plan-review-and-open-pr`                         | unlimited (`0`)        |
+| `review`        | PR readiness / review actions (`resolve-pr-readiness`, etc.)      | unlimited (`0`)        |
+| `implementation`| `implement`, `resolve-development-pr`                             | **1**                  |
+
+**Helper**: run `workflow-batch-lanes.sh` on `workflow-batch-plan.sh` output (or use
+`--scan`) to emit `STAGE_LANE`, `DISPATCH=proposed|held`, `HOLD_REASON`, and
+`HELD_SUMMARY` lines per item. The script header reports resolved lane caps
+(`MAX_CONCURRENT_*`).
+
+**Configuration** (optional): declare overrides under `guardrails.parallelism` in
+`.ai-dev-workflow.yaml` (documented in `guardrails.md`). Example:
+
+```yaml
+guardrails:
+  parallelism:
+    max_concurrent_by_stage:
+      spec: 0
+      plan: 0
+      review: 0
+      implementation: 2
+```
+
+A value of `0` means unlimited for that lane.
+
+**`LOCAL_RUNTIME` signal**: `workflow-batch-plan.sh` emits `LOCAL_RUNTIME=none|exclusive`
+for implementation items based on plan-document heuristics (local dev server, port,
+database migration signals). When any proposed implementation item is `exclusive`,
+hold additional proposed implementation items with reason `local runtime exclusivity`.
+Git worktree isolation does **not** imply port/DB isolation — document this in batch
+proposals when implementation items are held.
+
+**Batch proposal output** must list held items with lane-cap, runtime exclusivity,
+file-overlap, or tool-fix reasons so operators see why work was deferred.
+
 **Safe to batch together**:
 
 - Multiple spec-creation items

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -175,6 +175,28 @@ Use this when:
 - The batch orchestrator needs a deterministic first-pass list of development-folder candidates
 - You want to separate portfolio-level batch planning from single-item orchestration
 
+### `workflow-batch-lanes.sh`
+
+Assigns stage lanes and `proposed` vs `held` dispatch status for portfolio batch
+proposals. Consumes `workflow-batch-plan.sh` output (or `--scan`).
+
+Usage:
+
+```bash
+./scripts/development-workflow/workflow-batch-plan.sh | ./scripts/development-workflow/workflow-batch-lanes.sh
+./scripts/development-workflow/workflow-batch-lanes.sh --scan
+```
+
+What it does:
+
+- Applies `max_concurrent_by_stage` caps (default: unlimited spec/plan/review, implementation `1`)
+- Emits `STAGE_LANE`, `DISPATCH`, `HOLD_REASON`, and `HELD_SUMMARY` per item
+- Honors `LOCAL_RUNTIME=exclusive` holds when multiple implementation items would contend
+
+Use this when:
+
+- Protocol 90 Step 3 needs deterministic lane assignments before dispatch
+
 ### Workflow hub product repository commands
 
 These commands run only when `.ai-dev-workflow.yaml` resolves to

--- a/scripts/development-workflow/tests/test-workflow-batch-lanes.sh
+++ b/scripts/development-workflow/tests/test-workflow-batch-lanes.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# test-workflow-batch-lanes.sh - Unit tests for stage lane assignment.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+LANES="$REPO_ROOT/scripts/development-workflow/workflow-batch-lanes.sh"
+BATCH_PLAN="$REPO_ROOT/scripts/development-workflow/workflow-batch-plan.sh"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+write_batch_block() {
+  local file="$1" slug="$2" next_action="$3" local_runtime="${4:-}"
+  {
+    cat <<EOF
+TARGET=development:docs/specs/developments/fake/$slug
+DEVELOPMENT_PATH=docs/specs/developments/fake/$slug
+SLUG=$slug
+NEXT_ACTION=$next_action
+BATCH_HINT=implementation
+PARALLEL_SAFE=conditional
+TOOL_FIX=no
+EOF
+    if [ -n "$local_runtime" ]; then
+      echo "LOCAL_RUNTIME=$local_runtime"
+    fi
+    echo
+  } >> "$file"
+}
+
+fixture_repo="$TMP_ROOT/repo"
+mkdir -p "$fixture_repo/docs/specs/developments"
+cat > "$fixture_repo/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+guardrails:
+  mode: manual
+YAML
+
+batch_file="$TMP_ROOT/mixed.batch"
+: > "$batch_file"
+write_batch_block "$batch_file" "item-spec" "run-spec-review-and-open-pr"
+write_batch_block "$batch_file" "item-plan" "write-plan"
+write_batch_block "$batch_file" "item-impl-a" "implement"
+write_batch_block "$batch_file" "item-impl-b" "implement"
+
+mixed_output="$("$LANES" --repo-root "$fixture_repo" < "$batch_file")"
+run_test "spec_lane_proposed" "proposed" "$(printf '%s\n' "$mixed_output" | awk '/SLUG=item-spec/{f=1} f&&/^DISPATCH=/{sub(/^DISPATCH=/,""); print; exit}')"
+run_test "plan_lane_proposed" "proposed" "$(printf '%s\n' "$mixed_output" | awk '/SLUG=item-plan/{f=1} f&&/^DISPATCH=/{sub(/^DISPATCH=/,""); print; exit}')"
+run_test "first_impl_proposed" "proposed" "$(printf '%s\n' "$mixed_output" | awk '/SLUG=item-impl-a/{f=1} f&&/^DISPATCH=/{sub(/^DISPATCH=/,""); print; exit}')"
+run_test "second_impl_held" "held" "$(printf '%s\n' "$mixed_output" | awk '/SLUG=item-impl-b/{f=1} f&&/^DISPATCH=/{sub(/^DISPATCH=/,""); print; exit}')"
+
+high_parallel_repo="$TMP_ROOT/high-parallel"
+mkdir -p "$high_parallel_repo/docs/specs/developments"
+cat > "$high_parallel_repo/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+guardrails:
+  mode: delegated
+  parallelism:
+    max_concurrent_by_stage:
+      spec: 0
+      plan: 0
+      review: 0
+      implementation: 3
+YAML
+
+exclusive_file="$TMP_ROOT/exclusive.batch"
+: > "$exclusive_file"
+write_batch_block "$exclusive_file" "impl-x" "implement" "exclusive"
+write_batch_block "$exclusive_file" "impl-y" "implement" "none"
+
+export WORKFLOW_MAX_CONCURRENT_IMPLEMENTATION=3
+exclusive_output="$("$LANES" --repo-root "$high_parallel_repo" < "$exclusive_file")"
+unset WORKFLOW_MAX_CONCURRENT_IMPLEMENTATION
+run_test "exclusive_holds_second_impl" "held" "$(printf '%s\n' "$exclusive_output" | awk '/SLUG=impl-y/{f=1} f&&/^DISPATCH=/{sub(/^DISPATCH=/,""); print; exit}')"
+run_test "exclusive_hold_reason" "local runtime exclusivity (another implementation item requires exclusive local runtime)" "$(printf '%s\n' "$exclusive_output" | awk '/SLUG=impl-y/{f=1} f&&/^HOLD_REASON=/{sub(/^HOLD_REASON=/,""); print; exit}')"
+
+# classify_local_runtime via workflow-batch-plan on a synthetic plan folder
+runtime_dev="$fixture_repo/docs/specs/developments/20260624120000_999-runtime-test"
+mkdir -p "$runtime_dev"
+cat > "$runtime_dev/2_999-runtime-test_implementation-plan.md" <<'MD'
+# Implementation plan
+
+## Files modified
+
+```
+src/app.ts
+```
+
+## Notes
+
+Requires local dev server on localhost port 3000.
+MD
+
+export WORKFLOW_SKIP_FETCH=1
+runtime_plan_out="$(cd "$fixture_repo" && "$BATCH_PLAN" "$runtime_dev" 2>/dev/null | awk '/^LOCAL_RUNTIME=/{print; exit}')"
+run_test "local_runtime_exclusive_from_plan" "LOCAL_RUNTIME=exclusive" "$runtime_plan_out"
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+[ "$FAIL_COUNT" -eq 0 ]

--- a/scripts/development-workflow/tests/test-workflow-batch-lanes.sh
+++ b/scripts/development-workflow/tests/test-workflow-batch-lanes.sh
@@ -111,6 +111,12 @@ export WORKFLOW_SKIP_FETCH=1
 runtime_plan_out="$(cd "$fixture_repo" && "$BATCH_PLAN" "$runtime_dev" 2>/dev/null | awk '/^LOCAL_RUNTIME=/{print; exit}')"
 run_test "local_runtime_exclusive_from_plan" "LOCAL_RUNTIME=exclusive" "$runtime_plan_out"
 
+skip_file="$TMP_ROOT/skip.batch"
+: > "$skip_file"
+write_batch_block "$skip_file" "skip-item" "skip"
+skip_output="$("$LANES" --repo-root "$fixture_repo" < "$skip_file")"
+run_test "skip_action_not_proposed" "skip" "$(printf '%s\n' "$skip_output" | awk '/SLUG=skip-item/{f=1} f&&/^DISPATCH=/{sub(/^DISPATCH=/,""); print; exit}')"
+
 echo ""
 echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
 [ "$FAIL_COUNT" -eq 0 ]

--- a/scripts/development-workflow/workflow-batch-lanes.sh
+++ b/scripts/development-workflow/workflow-batch-lanes.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+# shellcheck source=scripts/development-workflow/workflow-lib.sh
+source "$SCRIPT_DIR/workflow-lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/development-workflow/workflow-batch-lanes.sh [--repo-root <path>] [--scan [development-path ...]]
+  ./scripts/development-workflow/workflow-batch-lanes.sh [--repo-root <path>] < batch-plan-output
+
+Assigns stage lanes and dispatch vs held status for portfolio batch proposals.
+Reads workflow-batch-plan.sh key=value blocks from stdin, or runs --scan to
+generate them. Emits augmented item blocks plus lane-cap metadata for Protocol 90.
+
+Stage lanes: spec, plan, review, implementation.
+Default max concurrent: unlimited for spec/plan/review; implementation defaults to 1.
+Optional guardrails.parallelism.max_concurrent_by_stage in .ai-dev-workflow.yaml.
+EOF
+}
+
+stage_lane_for_next_action() {
+  case "$1" in
+    run-spec-review-and-open-pr) printf 'spec\n' ;;
+    write-plan|run-plan-review-and-open-pr) printf 'plan\n' ;;
+    run-code-review-and-open-pr|resolve-pr-readiness|resume-fix-loop|wait-human-review) printf 'review\n' ;;
+    implement|resolve-development-pr) printf 'implementation\n' ;;
+    *) printf 'review\n' ;;
+  esac
+}
+
+read_parallelism_caps() {
+  local config_file repo_root="$1"
+  config_file="$(workflow_config_file "$repo_root")"
+  if [ ! -f "$config_file" ]; then
+    printf '{"spec":0,"plan":0,"review":0,"implementation":1}\n'
+    return 0
+  fi
+
+  python3 - "$config_file" <<'PYEOF' || printf '{"spec":0,"plan":0,"review":0,"implementation":1}\n'
+import json, sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+defaults = {"spec": 0, "plan": 0, "review": 0, "implementation": 1}
+try:
+    import yaml
+except ImportError:
+    print(json.dumps(defaults))
+    sys.exit(0)
+
+try:
+    cfg = yaml.safe_load(path.read_text()) or {}
+except Exception:
+    print(json.dumps(defaults))
+    sys.exit(0)
+
+guardrails = cfg.get("guardrails") if isinstance(cfg, dict) else None
+parallelism = guardrails.get("parallelism") if isinstance(guardrails, dict) else None
+caps = parallelism.get("max_concurrent_by_stage") if isinstance(parallelism, dict) else None
+if not isinstance(caps, dict):
+    print(json.dumps(defaults))
+    sys.exit(0)
+
+out = dict(defaults)
+for lane in defaults:
+    val = caps.get(lane)
+    if isinstance(val, int) and val >= 0:
+        out[lane] = val
+print(json.dumps(out))
+PYEOF
+}
+
+repo_root=""
+scan_mode=0
+development_paths=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo-root)
+      shift
+      repo_root="${1:-}"
+      shift
+      ;;
+    --scan)
+      scan_mode=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      development_paths+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$repo_root" ]; then
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+
+cd "$repo_root" || exit 1
+
+caps_json="$(read_parallelism_caps "$repo_root")"
+max_spec="$(printf '%s' "$caps_json" | jq -r '.spec')"
+max_plan="$(printf '%s' "$caps_json" | jq -r '.plan')"
+max_review="$(printf '%s' "$caps_json" | jq -r '.review')"
+max_implementation="$(printf '%s' "$caps_json" | jq -r '.implementation')"
+
+# Test / operator overrides (optional).
+if [ -n "${WORKFLOW_MAX_CONCURRENT_SPEC:-}" ]; then max_spec="$WORKFLOW_MAX_CONCURRENT_SPEC"; fi
+if [ -n "${WORKFLOW_MAX_CONCURRENT_PLAN:-}" ]; then max_plan="$WORKFLOW_MAX_CONCURRENT_PLAN"; fi
+if [ -n "${WORKFLOW_MAX_CONCURRENT_REVIEW:-}" ]; then max_review="$WORKFLOW_MAX_CONCURRENT_REVIEW"; fi
+if [ -n "${WORKFLOW_MAX_CONCURRENT_IMPLEMENTATION:-}" ]; then max_implementation="$WORKFLOW_MAX_CONCURRENT_IMPLEMENTATION"; fi
+
+print_kv MAX_CONCURRENT_SPEC "$max_spec"
+print_kv MAX_CONCURRENT_PLAN "$max_plan"
+print_kv MAX_CONCURRENT_REVIEW "$max_review"
+print_kv MAX_CONCURRENT_IMPLEMENTATION "$max_implementation"
+echo
+
+batch_input=""
+if [ "$scan_mode" -eq 1 ]; then
+  scan_args=()
+  [ -n "${development_paths[*]:-}" ] && scan_args+=("${development_paths[@]}")
+  batch_input="$("$SCRIPT_DIR/workflow-batch-plan.sh" "${scan_args[@]}")"
+else
+  batch_input="$(cat)"
+fi
+
+if [ -z "${batch_input//[[:space:]]/}" ]; then
+  echo "(none)"
+  exit 0
+fi
+
+TMP_BLOCKS="$(mktemp)"
+TMP_META="$(mktemp)"
+trap 'rm -f "$TMP_BLOCKS" "$TMP_META"' EXIT
+
+# Parse item blocks (blank-line separated key=value groups).
+block_idx=0
+block_lines=()
+while IFS= read -r line || [ -n "$line" ]; do
+  if [ -z "${line//[[:space:]]/}" ]; then
+    if [ "${#block_lines[@]}" -gt 0 ]; then
+      printf '%s\n' "${block_lines[@]}" > "$TMP_BLOCKS.$block_idx"
+      block_idx=$((block_idx + 1))
+      block_lines=()
+    fi
+    continue
+  fi
+  block_lines+=("$line")
+done <<< "$batch_input"
+if [ "${#block_lines[@]}" -gt 0 ]; then
+  printf '%s\n' "${block_lines[@]}" > "$TMP_BLOCKS.$block_idx"
+  block_idx=$((block_idx + 1))
+fi
+
+lane_count_spec=0
+lane_count_plan=0
+lane_count_review=0
+lane_count_implementation=0
+
+idx=0
+while [ "$idx" -lt "$block_idx" ]; do
+  next_action=""
+  local_runtime="none"
+  slug=""
+  development_path=""
+  while IFS='=' read -r key value; do
+    case "$key" in
+      NEXT_ACTION) next_action="$value" ;;
+      LOCAL_RUNTIME) local_runtime="$value" ;;
+      SLUG) slug="$value" ;;
+      DEVELOPMENT_PATH) development_path="$value" ;;
+    esac
+  done < "$TMP_BLOCKS.$idx"
+
+  item_id="$slug"
+  [ -z "$item_id" ] && item_id="$development_path"
+  [ -z "$item_id" ] && item_id="unknown-item"
+
+  stage_lane="$(stage_lane_for_next_action "$next_action")"
+  dispatch="proposed"
+  hold_reason=""
+
+  case "$stage_lane" in
+    spec)
+      if [ "$max_spec" -gt 0 ] && [ "$lane_count_spec" -ge "$max_spec" ]; then
+        dispatch="held"
+        hold_reason="stage lane cap (max ${max_spec} for spec)"
+      else
+        lane_count_spec=$((lane_count_spec + 1))
+      fi
+      ;;
+    plan)
+      if [ "$max_plan" -gt 0 ] && [ "$lane_count_plan" -ge "$max_plan" ]; then
+        dispatch="held"
+        hold_reason="stage lane cap (max ${max_plan} for plan)"
+      else
+        lane_count_plan=$((lane_count_plan + 1))
+      fi
+      ;;
+    review)
+      if [ "$max_review" -gt 0 ] && [ "$lane_count_review" -ge "$max_review" ]; then
+        dispatch="held"
+        hold_reason="stage lane cap (max ${max_review} for review)"
+      else
+        lane_count_review=$((lane_count_review + 1))
+      fi
+      ;;
+    implementation)
+      if [ "$max_implementation" -gt 0 ] && [ "$lane_count_implementation" -ge "$max_implementation" ]; then
+        dispatch="held"
+        hold_reason="implementation lane cap (max ${max_implementation})"
+      else
+        lane_count_implementation=$((lane_count_implementation + 1))
+      fi
+      ;;
+  esac
+
+  hold_field="${hold_reason:--}"
+  printf '%s\t%s\t%s\t%s\t%s\n' "$idx" "$stage_lane" "$dispatch" "$hold_field" "$local_runtime" >> "$TMP_META"
+  idx=$((idx + 1))
+done
+
+# LOCAL_RUNTIME exclusivity: when any proposed implementation item is exclusive,
+# only one implementation item may dispatch in this batch.
+exclusive_in_batch=0
+proposed_impl_count=0
+while IFS=$'\t' read -r _ stage_lane dispatch hr local_runtime; do
+  if [ "$stage_lane" = "implementation" ] && [ "$dispatch" = "proposed" ]; then
+    proposed_impl_count=$((proposed_impl_count + 1))
+    if [ "$local_runtime" = "exclusive" ]; then
+      exclusive_in_batch=1
+    fi
+  fi
+done < "$TMP_META"
+
+if [ "$exclusive_in_batch" -eq 1 ] && [ "$proposed_impl_count" -gt 1 ]; then
+  kept_impl=0
+  : > "$TMP_META.new"
+  while IFS=$'\t' read -r block_index stage_lane dispatch hr local_runtime; do
+    hold_reason=""
+    if [ "$hr" != "-" ]; then
+      hold_reason="$hr"
+    fi
+    if [ "$stage_lane" = "implementation" ] && [ "$dispatch" = "proposed" ]; then
+      if [ "$kept_impl" -eq 0 ]; then
+        kept_impl=1
+      else
+        dispatch="held"
+        hold_reason="local runtime exclusivity (another implementation item requires exclusive local runtime)"
+      fi
+    fi
+    hold_field="${hold_reason:--}"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$block_index" "$stage_lane" "$dispatch" "$hold_field" "$local_runtime" >> "$TMP_META.new"
+  done < "$TMP_META"
+  mv "$TMP_META.new" "$TMP_META"
+fi
+
+idx=0
+while [ "$idx" -lt "$block_idx" ]; do
+  stage_lane=""
+  dispatch=""
+  hold_reason=""
+  while IFS=$'\t' read -r block_index s d hr _; do
+    if [ "$block_index" = "$idx" ]; then
+      stage_lane="$s"
+      dispatch="$d"
+      if [ "$hr" = "-" ]; then
+        hold_reason=""
+      else
+        hold_reason="$hr"
+      fi
+    fi
+  done < "$TMP_META"
+
+  item_id=""
+  while IFS='=' read -r key value; do
+    case "$key" in
+      SLUG) item_id="$value" ;;
+      DEVELOPMENT_PATH) [ -z "$item_id" ] && item_id="$value" ;;
+    esac
+  done < "$TMP_BLOCKS.$idx"
+  [ -z "$item_id" ] && item_id="unknown-item"
+
+  cat "$TMP_BLOCKS.$idx"
+  print_kv STAGE_LANE "$stage_lane"
+  print_kv DISPATCH "$dispatch"
+  if [ "$dispatch" = "held" ]; then
+    print_kv HOLD_REASON "$hold_reason"
+    print_kv HELD_SUMMARY "held — ${item_id}: ${hold_reason}"
+  fi
+  echo
+  idx=$((idx + 1))
+done

--- a/scripts/development-workflow/workflow-batch-lanes.sh
+++ b/scripts/development-workflow/workflow-batch-lanes.sh
@@ -24,6 +24,7 @@ EOF
 
 stage_lane_for_next_action() {
   case "$1" in
+    skip|unknown|resolve-repository-selection) printf 'none\n' ;;
     run-spec-review-and-open-pr) printf 'spec\n' ;;
     write-plan|run-plan-review-and-open-pr) printf 'plan\n' ;;
     run-code-review-and-open-pr|resolve-pr-readiness|resume-fix-loop|wait-human-review) printf 'review\n' ;;
@@ -32,10 +33,23 @@ stage_lane_for_next_action() {
   esac
 }
 
+parallelism_config_file() {
+  local repo_root="$1"
+  if [ -n "${AI_DEV_WORKFLOW_CONFIG_FILE:-}" ] && [ -f "${AI_DEV_WORKFLOW_CONFIG_FILE}" ]; then
+    printf '%s\n' "${AI_DEV_WORKFLOW_CONFIG_FILE}"
+    return 0
+  fi
+  if [ -f "$repo_root/.ai-dev-workflow.yaml" ]; then
+    printf '%s/.ai-dev-workflow.yaml\n' "$repo_root"
+    return 0
+  fi
+  return 1
+}
+
 read_parallelism_caps() {
-  local config_file repo_root="$1"
-  config_file="$(workflow_config_file "$repo_root")"
-  if [ ! -f "$config_file" ]; then
+  local repo_root="$1"
+  local config_file=""
+  if ! config_file="$(parallelism_config_file "$repo_root")"; then
     printf '{"spec":0,"plan":0,"review":0,"implementation":1}\n'
     return 0
   fi
@@ -189,7 +203,11 @@ while [ "$idx" -lt "$block_idx" ]; do
   dispatch="proposed"
   hold_reason=""
 
-  case "$stage_lane" in
+  if [ "$stage_lane" = "none" ]; then
+    dispatch="skip"
+    hold_reason="not dispatch-eligible (${next_action})"
+  else
+    case "$stage_lane" in
     spec)
       if [ "$max_spec" -gt 0 ] && [ "$lane_count_spec" -ge "$max_spec" ]; then
         dispatch="held"
@@ -222,7 +240,8 @@ while [ "$idx" -lt "$block_idx" ]; do
         lane_count_implementation=$((lane_count_implementation + 1))
       fi
       ;;
-  esac
+    esac
+  fi
 
   hold_field="${hold_reason:--}"
   printf '%s\t%s\t%s\t%s\t%s\n' "$idx" "$stage_lane" "$dispatch" "$hold_field" "$local_runtime" >> "$TMP_META"
@@ -293,9 +312,11 @@ while [ "$idx" -lt "$block_idx" ]; do
   cat "$TMP_BLOCKS.$idx"
   print_kv STAGE_LANE "$stage_lane"
   print_kv DISPATCH "$dispatch"
-  if [ "$dispatch" = "held" ]; then
+  if [ "$dispatch" = "held" ] || [ "$dispatch" = "skip" ]; then
     print_kv HOLD_REASON "$hold_reason"
-    print_kv HELD_SUMMARY "held — ${item_id}: ${hold_reason}"
+    if [ "$dispatch" = "held" ]; then
+      print_kv HELD_SUMMARY "held — ${item_id}: ${hold_reason}"
+    fi
   fi
   echo
   idx=$((idx + 1))

--- a/scripts/development-workflow/workflow-batch-plan.sh
+++ b/scripts/development-workflow/workflow-batch-plan.sh
@@ -33,6 +33,32 @@ parallel_safe_for_action() {
   esac
 }
 
+# classify_local_runtime <development-folder-path>
+#
+# Heuristic classifier for implementation items that likely require an
+# exclusive local dev server, database, or port-bound resource. Scans the
+# implementation plan (when present) for runtime-contention signals.
+#
+# Prints: none | exclusive
+classify_local_runtime() {
+  local dev_path="$1"
+  local plan_file
+  plan_file="$(find "$dev_path" -maxdepth 1 -name '2_*_implementation-plan.md' | head -1)"
+  if [ -z "$plan_file" ]; then
+    printf 'none\n'
+    return 0
+  fi
+
+  if grep -qiE \
+    '(local[[:space:]]+dev[[:space:]]+server|dev[[:space:]]+server|localhost|127\.0\.0\.1|port[[:space:]]*[0-9]{2,5}|database[[:space:]]+migration|schema[[:space:]]+migration|exclusive[[:space:]]+runtime|shared[[:space:]]+database|docker[[:space:]]+compose|supabase[[:space:]]+local)' \
+    "$plan_file"; then
+    printf 'exclusive\n'
+    return 0
+  fi
+
+  printf 'none\n'
+}
+
 # Canonical tool file list for tool-fix classification.
 # Each entry is checked with a delimiter-aware regex to reject superstrings.
 CANONICAL_EXACT_PATHS=(
@@ -499,11 +525,13 @@ for development_path in "${development_paths[@]}"; do
     esac
   done <<< "$next_action_output"
 
-  # Extract file set for implementation-stage items only (BR-1).
+  # Extract file set and local-runtime class for implementation-stage items only (BR-1).
   file_set=""
+  local_runtime=""
   case "$next_action" in
     implement|resolve-development-pr)
       file_set="$(extract_file_set "$development_path")"
+      local_runtime="$(classify_local_runtime "$development_path")"
       ;;
   esac
 
@@ -537,5 +565,6 @@ for development_path in "${development_paths[@]}"; do
   print_kv TOOL_FIX "$tool_fix"
   [ "$tool_fix" = "yes" ] && print_kv TOOL_FIX_FILES "$tool_fix_files"
   [ -n "$file_set" ] && print_kv FILE_SET "$file_set"
+  [ -n "$local_runtime" ] && print_kv LOCAL_RUNTIME "$local_runtime"
   echo
 done


### PR DESCRIPTION
## Summary
- Adds `workflow-batch-lanes.sh` for stage-aware portfolio batch proposals with default implementation serialization (max 1 concurrent).
- Extends `workflow-batch-plan.sh` with `LOCAL_RUNTIME=none|exclusive` heuristics for implementation items.
- Documents Protocol 90 Step 3 lane caps and optional `guardrails.parallelism` in `guardrails.md`.

## Test plan
- [x] `bash scripts/development-workflow/tests/test-workflow-batch-lanes.sh` (7 passed)
- [ ] CI guard + markdown lint

Closes #1052 (epic #1047 child).

Made with [Cursor](https://cursor.com)