### PR TITLE
fix(review): add URL param completeness check to spec checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Spec review checklist: URL-parameterized state completeness check** (#973): adds an explicit check item to the Spec Review Checklist in `REVIEW.md` requiring that any URL-serialized state (query parameters, path parameters, hash fragments) introduced by a spec must define all parameter key names and allowed values; adds a corresponding `blocking` finding type to catch specs that leave the serialization contract underspecified, preventing this class of gap from reaching the external reviewer loop.
-
 ### Added
 
 - **Parallel implementation policy for `/run-work` batches** (#1052): `workflow-batch-lanes.sh`
@@ -70,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Spec review checklist: URL-parameterized state completeness check** (#973): adds an explicit check item to the Spec Review Checklist in `REVIEW.md` requiring that any URL-serialized state (query parameters, path parameters, hash fragments) introduced by a spec must define all parameter key names and allowed values; adds a corresponding `blocking` finding type to catch specs that leave the serialization contract underspecified, preventing this class of gap from reaching the external reviewer loop.
 - **Post-merge cleanup missing local branch** (#1039): `post-merge-cleanup.sh`
   continues fetch, base checkout, and tracker closeout when the local branch is
   already deleted but a merged PR exists for that branch head (common after

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Spec review checklist: URL-parameterized state completeness check** (#973): adds an explicit check item to the Spec Review Checklist in `REVIEW.md` requiring that any URL-serialized state (query parameters, path parameters, hash fragments) introduced by a spec must define all parameter key names and allowed values; adds a corresponding `blocking` finding type to catch specs that leave the serialization contract underspecified, preventing this class of gap from reaching the external reviewer loop.
+
 ### Added
 
 - **Parallel implementation policy for `/run-work` batches** (#1052): `workflow-batch-lanes.sh`

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -71,6 +71,7 @@ Check:
 - Business rules are unambiguous and non-contradictory
 - Scope boundaries and out-of-scope items are explicit
 - Status or enum changes include display labels and transitions
+- If the spec introduces URL-serialized state (query parameters, path parameters, hash fragments), the parameter keys and all allowed values are explicitly defined — a spec that leaves parameter names or value formats unspecified forces implementers to guess the serialization contract
 - The spec stays product-focused and does not over-prescribe technical design
 - Terms align with the project domain and existing business rules
 
@@ -79,6 +80,7 @@ Typical `blocking` issues:
 - Missing or ambiguous acceptance criteria
 - Contradictory business rules
 - Spec drift that would force engineering to guess
+- URL-serialized state introduced without explicit parameter key names and allowed values
 - `CHANGELOG.md` is modified in this PR — `spec/*` branches are exempt from CHANGELOG entries; remove any CHANGELOG modification before merging
 
 Typical `important` issues:


### PR DESCRIPTION
## Summary

- Adds an explicit check to the **Spec Review Checklist** in `REVIEW.md` requiring that any URL-serialized state (query parameters, path parameters, hash fragments) introduced by a spec must define all parameter key names and allowed values
- Adds a corresponding `blocking` finding type to the typical blocking issues list
- Prevents a class of spec completeness gaps from reaching the external Haystack reviewer, eliminating ~15-minute retry-loop delays per affected PR

## Root Cause

The spec reviewer checklist had no explicit check for URL-parameterized state completeness. When a spec introduced query-parameter-driven state (e.g., sort/filter), it could define *that* URL params are absent in the default state without ever naming the parameter keys or their allowed values. The "Acceptance criteria are specific and testable" check was satisfied, but the serialization contract remained unspecified — forcing implementers to guess.

This gap was caught downstream by Haystack in the ready-phase (after the spec passed internal review and the draft external review), requiring an extra fix commit and reviewer retry.

## Fix

Single change to `REVIEW.md` Spec Review Checklist:

**Check item added** (lines 74):
> If the spec introduces URL-serialized state (query parameters, path parameters, hash fragments), the parameter keys and all allowed values are explicitly defined — a spec that leaves parameter names or value formats unspecified forces implementers to guess the serialization contract

**Blocking issue added** (line 83):
> URL-serialized state introduced without explicit parameter key names and allowed values

## Document Quality Gate

- [x] Change is limited to `REVIEW.md` and `CHANGELOG.md`
- [x] No placeholders left behind
- [x] New check item is unambiguous and actionable
- [x] Blocking issue type directly matches the new check item
- [x] No duplication with existing checklist items

## Test Plan

- [ ] Verify the new checklist item appears in the Spec Review Checklist section of `REVIEW.md`
- [ ] Confirm the new blocking finding type is listed under "Typical `blocking` issues"
- [ ] Review a spec that introduces URL query params and confirm the reviewer applies the new check

Closes #973

Made with [Cursor](https://cursor.com)