### PR TITLE
fix: scope Linear orchestrator discovery to configured project (#972)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linear orchestrator project scoping** (#972): Portfolio Orchestrator (`/run-work`) now
+  reads `issue_tracker.custom_fields.project` from `.ai-dev-workflow.yaml` and filters
+  Linear item-discovery queries to only items belonging to the configured project. If the
+  field is absent, a visible warning is emitted and the orchestrator falls back to the
+  previous unscoped team query. Prevents cross-codebase items from appearing as candidates
+  in repositories with multi-project Linear workspaces. Updated Protocol 90 Step 1a and
+  `integrations/linear.md` to document the new scoping behavior.
+
 ### Added
 
 - **Parallel implementation policy for `/run-work` batches** (#1052): `workflow-batch-lanes.sh`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Linear orchestrator project scoping** (#972): Portfolio Orchestrator (`/run-work`) now
-  reads `issue_tracker.custom_fields.project` from `.ai-dev-workflow.yaml` and filters
-  Linear item-discovery queries to only items belonging to the configured project. If the
-  field is absent, a visible warning is emitted and the orchestrator falls back to the
-  previous unscoped team query. Prevents cross-codebase items from appearing as candidates
-  in repositories with multi-project Linear workspaces. Updated Protocol 90 Step 1a and
-  `integrations/linear.md` to document the new scoping behavior.
-
 ### Added
 
 - **Parallel implementation policy for `/run-work` batches** (#1052): `workflow-batch-lanes.sh`
@@ -76,6 +66,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Linear orchestrator project scoping** (#972): Portfolio Orchestrator (`/run-work`) now
+  reads `issue_tracker.custom_fields.project` from `.ai-dev-workflow.yaml` and filters
+  Linear item-discovery queries to only items belonging to the configured project. If the
+  field is absent, a visible warning is emitted and the orchestrator falls back to the
+  previous unscoped team query. Prevents cross-codebase items from appearing as candidates
+  in repositories with multi-project Linear workspaces. Updated Protocol 90 Step 1a and
+  `integrations/linear.md` to document the new scoping behavior.
 - **Post-merge cleanup missing local branch** (#1039): `post-merge-cleanup.sh`
   continues fetch, base checkout, and tracker closeout when the local branch is
   already deleted but a merged PR exists for that branch head (common after

--- a/docs/workflow/development-workflow/integrations/linear.md
+++ b/docs/workflow/development-workflow/integrations/linear.md
@@ -73,10 +73,11 @@ Workflow status (Spec Ready, Plan Ready, In Development) is **not** stored in th
 
 When the **Portfolio Orchestrator** has Linear access, it should:
 
-1. Query work items by status to find items eligible for advancement
-2. Check the `Depends on` field (or linked work item relationships) for dependencies
-3. Sort eligible items: due within 2 weeks → priority → creation date
-4. Update work item status as stages complete (e.g., set to "In Development" when the feature branch is created)
+1. Read `issue_tracker.custom_fields.project` from `.ai-dev-workflow.yaml` and, if present, scope all item-discovery queries to that project. If absent, emit a warning and fall back to the unscoped team query (see Protocol 90 Step 1a).
+2. Query work items by status to find items eligible for advancement
+3. Check the `Depends on` field (or linked work item relationships) for dependencies
+4. Sort eligible items: due within 2 weeks → priority → creation date
+5. Update work item status as stages complete (e.g., set to "In Development" when the feature branch is created)
 
 ---
 
@@ -166,13 +167,13 @@ The `[slug]` is a short kebab-case description derived from the work item title 
 
 The `issue_tracker.custom_fields` flat map in `.ai-dev-workflow.yaml` holds provider-specific fields that extend the standard `issue_tracker` configuration. For the Linear provider, the following keys are recognised by workflow scripts:
 
-| Key                    | Format                   | Effect                                                                                                                                                                                                            |
-| ---------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `project`              | Linear project ID string | When set, issue creation associates the new issue with the specified Linear project. The project ID is found in the Linear project URL (`https://linear.app/<team>/projects/<project-id>`) or via the Linear API. |
-| `release_field`        | Custom field key/name    | Optional future write target for recording the shipped release on a Linear issue. Shell helpers warn that MCP/API access is required.                                                                             |
-| `release_label_prefix` | Label prefix string      | Label fallback for release stamping. Defaults to `release/`, producing labels like `release/v1.2.0`. Shell helpers warn that MCP/API access is required to apply it.                                               |
+| Key                    | Format                   | Effect                                                                                                                                                                                                                                                                        |
+| ---------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `project`              | Linear project ID string | When set, (1) scopes Portfolio Orchestrator item discovery to this project only — items from other projects are excluded from the candidate list; and (2) associates new issues with this project on creation. The project ID is found in the Linear project URL (`https://linear.app/<team>/projects/<project-id>`) or via the Linear API. |
+| `release_field`        | Custom field key/name    | Optional future write target for recording the shipped release on a Linear issue. Shell helpers warn that MCP/API access is required.                                                                                                                                         |
+| `release_label_prefix` | Label prefix string      | Label fallback for release stamping. Defaults to `release/`, producing labels like `release/v1.2.0`. Shell helpers warn that MCP/API access is required to apply it.                                                                                                          |
 
-When `project` is absent from `custom_fields` (or `custom_fields` itself is absent), issue creation proceeds without a project association — this is the current default behaviour and is fully backward-compatible.
+When `project` is absent from `custom_fields` (or `custom_fields` itself is absent), the Portfolio Orchestrator queries all open items visible to the API token — which may include items from other codebases or projects — and emits a visible warning. Issue creation proceeds without a project association. This fallback is fully backward-compatible but is not recommended for multi-project Linear workspaces.
 
 To set a project association, add the following to `.ai-dev-workflow.yaml` under `issue_tracker`:
 

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -237,10 +237,28 @@ When `issue_tracker.provider` is `linear`, the orchestrator is the only actor
 with Linear access. Apply the following discovery flow instead of the GitHub
 Projects pagination approach above:
 
+0. **Resolve the project filter** — before querying, check whether
+   `issue_tracker.custom_fields.project` is set in `.ai-dev-workflow.yaml`. If
+   it is set, record the project ID and use it to scope all discovery queries to
+   that project only (step 1 below). If it is absent, emit a visible warning and
+   fall back to the unscoped team query:
+
+   > **WARNING**: `issue_tracker.custom_fields.project` is not set in
+   > `.ai-dev-workflow.yaml`. Linear item discovery will query all open items
+   > visible to the API token, which may include items from other codebases or
+   > projects. To restrict discovery to the correct project, set
+   > `issue_tracker.custom_fields.project` to the Linear project ID for this
+   > repository. See `docs/workflow/development-workflow/integrations/linear.md`
+   > for setup instructions.
+
 1. **Query Linear via MCP** — call the Linear MCP `issues` or `team.issues`
-   query for all open items in the configured team. For each item, collect:
-   status (workflow stage label), type (Feature, Bug, Refactor), priority,
-   parent epic (if applicable), and dependency relationships.
+   query for open items. **When a project ID was resolved in step 0**, pass it
+   as a project-scoped filter (e.g., `project: { id: { eq: "<project-id>" } }`)
+   so only items belonging to the configured project are returned. When no
+   project ID is available (fallback mode), query all open items in the
+   configured team. For each item, collect: status (workflow stage label), type
+   (Feature, Bug, Refactor), priority, parent epic (if applicable), and
+   dependency relationships.
 
 2. **Format item context** — for each item, record the status as a structured
    context value (`ITEM_STATUS=<status>`) that the batch-planning step can


### PR DESCRIPTION
## Summary

- **Root cause**: `run-work` / Portfolio Orchestrator was querying all open items in the entire Linear team, surfacing items from unrelated codebases/projects.
- **Fix**: Protocol 90 Step 1a now reads `issue_tracker.custom_fields.project` from `.ai-dev-workflow.yaml` and passes the project ID as a filter in the Linear MCP item-discovery query. Items not belonging to the configured project are excluded.
- **Fallback**: When `custom_fields.project` is absent, a visible `WARNING` is emitted and the orchestrator falls back to the previous unscoped team query (fully backward-compatible).
- **Documentation**: `integrations/linear.md` updated to clarify that `custom_fields.project` now governs both issue creation _and_ item discovery scoping.

## Files changed

- `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` — adds step 0 to the Linear provider block in Step 1a: resolve project filter, apply it to the MCP query, or warn and fall back.
- `docs/workflow/development-workflow/integrations/linear.md` — updates the `project` custom field row and Orchestrator Instructions to document discovery scoping.
- `CHANGELOG.md` — adds entry under `[Unreleased] > Fixed`.

## Test plan

- [ ] Verify that a repo with `custom_fields.project` set in `.ai-dev-workflow.yaml` causes the orchestrator to include only items from that Linear project in its candidate list.
- [ ] Verify that a repo without `custom_fields.project` emits the documented WARNING and continues with the full team query.
- [ ] Verify that no existing behavior is broken for repos using `github_projects` as tracker provider (unaffected code path).

Closes #972

Made with [Cursor](https://cursor.com)