### PR TITLE
fix: add Linear priority drift detection in orchestrator loop (#974)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Linear priority drift detection** (#974): orchestrators applying Linear
-  MCP status updates now compare the post-write priority against the
-  dispatch-time value and emit `PRIORITY_DRIFT_WARNING` when drift is detected;
-  adds optional post-write re-read with `TRACKER_WRITE_UNCONFIRMED` and
-  one-retry logic when the status update is not reflected in the API read-back.
-  Updated `linear.md` and Protocol 90 deferred-action collection loop.
-
 ### Added
 
 - **Parallel implementation policy for `/run-work` batches** (#1052): `workflow-batch-lanes.sh`
@@ -75,6 +66,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Linear priority drift detection** (#974): orchestrators applying Linear
+  MCP status updates now compare the post-write priority against the
+  dispatch-time value and emit `PRIORITY_DRIFT_WARNING` when drift is detected;
+  adds optional post-write re-read with `TRACKER_WRITE_UNCONFIRMED` and
+  one-retry logic when the status update is not reflected in the API read-back.
+  Updated `linear.md` and Protocol 90 deferred-action collection loop.
 - **Post-merge cleanup missing local branch** (#1039): `post-merge-cleanup.sh`
   continues fetch, base checkout, and tracker closeout when the local branch is
   already deleted but a merged PR exists for that branch head (common after

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linear priority drift detection** (#974): orchestrators applying Linear
+  MCP status updates now compare the post-write priority against the
+  dispatch-time value and emit `PRIORITY_DRIFT_WARNING` when drift is detected;
+  adds optional post-write re-read with `TRACKER_WRITE_UNCONFIRMED` and
+  one-retry logic when the status update is not reflected in the API read-back.
+  Updated `linear.md` and Protocol 90 deferred-action collection loop.
+
 ### Added
 
 - **Parallel implementation policy for `/run-work` batches** (#1052): `workflow-batch-lanes.sh`

--- a/docs/workflow/development-workflow/integrations/linear.md
+++ b/docs/workflow/development-workflow/integrations/linear.md
@@ -143,6 +143,49 @@ The `TRACKER_UPDATE_REQUIRED:` format (used in protocol 91 Step 8b) is a
 complementary signal emitted by the agent-level summary when a tracker update
 could not be performed inline. Both formats must be collected and applied.
 
+### Priority Drift Detection
+
+The Linear API can return a stale or drifted priority value when an item is
+read back shortly after a write (e.g., a status update applied during
+post-merge cleanup). The priority returned in the API response may reflect
+a transient race condition between the write and the Linear webhook rather
+than an intentional change.
+
+**Detection rule**: After every `updateIssue` MCP call, read back the issue's
+current priority from the API response (or issue a follow-up `issue(id:)` query
+if the mutation response does not include the priority field). Compare the
+returned value against the priority recorded at pre-resolve time (Phase 1).
+If the values differ, emit the following warning to the run summary before
+continuing:
+
+```
+PRIORITY_DRIFT_WARNING: issue=<id> dispatch_priority=<value> current_priority=<value>
+  — priority changed between dispatch and post-update read.
+  Possible causes: concurrent edit, transient API artifact, or webhook race.
+  No workflow action taken. Human should verify the priority in Linear.
+```
+
+Do **not** silently accept the drifted value. Do **not** automatically restore
+the original priority — a concurrent human edit is a valid reason for the
+change. The warning surfaces the discrepancy for human review.
+
+**Post-write re-read (optional but recommended)**: After applying any
+`set_status` mutation, issue a follow-up `issue(id:)` query to confirm the
+write was reflected. If the returned status does not match the target status,
+emit:
+
+```
+TRACKER_WRITE_UNCONFIRMED: issue=<id> target_status=<expected> actual_status=<returned>
+  — status not reflected in API read-back after write.
+  May be a transient API artifact. Retry the update once; escalate if the
+  mismatch persists after retry.
+```
+
+Retry the `updateIssue` call once if `TRACKER_WRITE_UNCONFIRMED` fires. If the
+re-read still does not reflect the target status after one retry, log
+`TRACKER_SYNC_SKIPPED` (using the existing format) with `reason=write_unconfirmed_after_retry`
+and continue — do not block the workflow.
+
 ---
 
 ## Branch Naming with Linear

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -580,12 +580,24 @@ for each line in Work Item Runner output:
     "TRACKER_ACTION_REQUIRED=set_status issue=<id> target_status=<status>":
       status = strip_single_quotes(<status>)   # values with spaces are single-quoted
       call Linear MCP updateIssue(id, status=status)
+      # Priority drift detection: read back the issue and compare priority
+      # against the dispatch-time value recorded in Step 1a.
+      # Emit PRIORITY_DRIFT_WARNING if the values differ.
+      # See linear.md "Priority Drift Detection" for the full protocol.
     "TRACKER_ACTION_REQUIRED=create_item title=<title>":
       title = strip_single_quotes(<title>)     # values with spaces are single-quoted
       call Linear MCP createIssue(title=title, teamId=<team>)
     "TRACKER_UPDATE_REQUIRED: set issue #<N> status to \"<status>\"":
       call Linear MCP updateIssue(id=<N>, status=<status>)
+      # Priority drift detection applies here too — see linear.md.
 ```
+
+After each `updateIssue` call, perform a post-write re-read to confirm the
+status write was reflected. If the returned status does not match the target,
+retry once and emit `TRACKER_WRITE_UNCONFIRMED` if the mismatch persists.
+See [`linear.md`](../integrations/linear.md) "Priority Drift Detection" for
+the `PRIORITY_DRIFT_WARNING` and `TRACKER_WRITE_UNCONFIRMED` formats and
+retry rules.
 
 A deferred action that cannot be applied must be logged explicitly:
 


### PR DESCRIPTION
## Summary

- **`linear.md`**: Adds a new "Priority Drift Detection" section under the Bridge Pattern that instructs orchestrators to compare the post-write priority against the dispatch-time value after every `updateIssue` MCP call, emit `PRIORITY_DRIFT_WARNING` when the values differ, and optionally perform a post-write re-read with `TRACKER_WRITE_UNCONFIRMED` and a single retry.
- **Protocol 90 deferred-action loop**: Adds inline comments after `updateIssue` calls pointing to the new drift-detection protocol in `linear.md`.
- **CHANGELOG**: Adds a `Fixed` entry for #974.

## Context

After merging a spec PR, the Linear API returned `priority: 3` (Medium) for an issue that was dispatched at `priority: 2` (High). The discrepancy was silently accepted. This PR adds detection and explicit warning signals so the orchestrator surfaces the drift rather than allowing it to skew future prioritization.

Closes #974

## Test plan

- [ ] Review `linear.md` "Priority Drift Detection" section for accuracy and completeness.
- [ ] Review Protocol 90 deferred-action loop changes for correct placement of the new comments.
- [ ] Verify CHANGELOG entry follows the project format.

Made with [Cursor](https://cursor.com)