### PR TITLE
fix(post-merge-cleanup): pull with explicit origin ref (#1058)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Post-merge cleanup pull without upstream tracking** (#1058): `post-merge-cleanup.sh`
+  now uses `git pull --ff-only origin "$DEVELOP_BRANCH"` instead of bare `git pull` so
+  integration branches created without `--set-upstream` no longer cause "no tracking
+  information" errors during cleanup.
 - **Post-merge cleanup missing local branch** (#1039): `post-merge-cleanup.sh`
   continues fetch, base checkout, and tracker closeout when the local branch is
   already deleted but a merged PR exists for that branch head (common after

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -225,8 +225,10 @@ echo "Checking out $DEVELOP_BRANCH..."
 git checkout "$DEVELOP_BRANCH"
 
 echo "Pulling $DEVELOP_BRANCH..."
-# --ff-only: fail cleanly if develop diverged (e.g. local commits) instead of creating a merge
-git pull --ff-only
+# Use explicit 'origin <branch>' so this works even when the local branch has no upstream
+# tracking set (e.g. integration branches created/pushed without --set-upstream).
+# --ff-only: fail cleanly if the branch diverged (e.g. local commits) instead of creating a merge.
+git pull --ff-only origin "$DEVELOP_BRANCH"
 
 if [ "$LOCAL_BRANCH_MISSING" -eq 1 ]; then
   echo "Skipping local branch delete for '$TO_DELETE' (already absent)."


### PR DESCRIPTION
## Summary

`post-merge-cleanup.sh` failed when the local integration branch had no upstream tracking configured, with:

```
There is no tracking information for the current branch.
Please specify which branch you want to merge with.
```

## Change

Replace bare `git pull --ff-only` with `git pull --ff-only origin "$DEVELOP_BRANCH"` so cleanup works regardless of whether the branch has upstream tracking set.

## Testing

The change is a one-line fix to a shell script. The explicit `origin <branch>` form is equivalent to the implicit form when tracking is configured, and fixes the failure when it is not.

Closes #1058

Made with [Cursor](https://cursor.com)