### PR TITLE
fix(workflow): close PR-body issues when branch has no number (#1059)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Post-merge cleanup closes issues from PR body when branch slug lacks issue number** (#1059):
+  `post-merge-cleanup.sh` now parses the merged PR body and title for GitHub
+  closing keywords (`Closes #N`, `Fixes #N`, `Resolves #N`, etc.) when the
+  branch name contains no embedded issue number (e.g. `feature/model-cost-resilience`).
+  Each referenced issue is closed and its tracker status updated to Merged,
+  preventing silent skip of issue closeout on epic-slug branches.
 - **Post-merge cleanup missing local branch** (#1039): `post-merge-cleanup.sh`
   continues fetch, base checkout, and tracker closeout when the local branch is
   already deleted but a merged PR exists for that branch head (common after

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -437,11 +437,13 @@ else
         if [ -n "$CLOSES_ISSUES" ]; then
           echo "Found closing keyword refs in PR #${CLOSING_PR}: issues $(printf '%s' "$CLOSES_ISSUES" | tr '\n' ' ')"
           cd "$HUB_REPO_ROOT"
+          CLOSES_ISSUE_VIEW_FAILURES=0
           while IFS= read -r closes_issue_num; do
             [ -z "$closes_issue_num" ] && continue
             echo "Processing issue #${closes_issue_num} from PR #${CLOSING_PR} closing keywords..."
             if ! CLOSES_ISSUE_STATE="$(gh issue view "$closes_issue_num" --json state --jq '.state' 2>/dev/null)"; then
               echo "Warning: could not query issue #${closes_issue_num}; skipping close and tracker update for this ref." >&2
+              CLOSES_ISSUE_VIEW_FAILURES=$((CLOSES_ISSUE_VIEW_FAILURES + 1))
               continue
             fi
             update_tracker_status_best_effort "$closes_issue_num" "Merged"
@@ -457,6 +459,10 @@ else
               echo "Issue #${closes_issue_num} is already ${CLOSES_ISSUE_STATE}, skipping close."
             fi
           done <<< "$CLOSES_ISSUES"
+          if [ "$CLOSES_ISSUE_VIEW_FAILURES" -gt 0 ]; then
+            echo "ERROR: could not query ${CLOSES_ISSUE_VIEW_FAILURES} issue(s) from PR #${CLOSING_PR} closing refs (gh command failed)." >&2
+            exit 1
+          fi
         else
           echo "No issue number in branch name '$TO_DELETE' or PR #${CLOSING_PR} body; skipping issue close and tracker update."
         fi

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -419,10 +419,10 @@ else
     if [ -n "$pr_closes_repo" ]; then
       CLOSING_PR="${VERIFIED_MERGED_PR:-}"
       if [ -z "$CLOSING_PR" ]; then
-        CLOSING_PR="$(gh pr list --repo "$pr_closes_repo" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+        CLOSING_PR="$(gh pr list --repo "$pr_closes_repo" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)" # workflow-shell-guard: allow SH001 - best-effort lookup when no merged PR was pre-verified
       fi
       if [ -n "$CLOSING_PR" ]; then
-        PR_BODY="$(gh pr view "$CLOSING_PR" --repo "$pr_closes_repo" --json body,title --jq '.title + "\n" + .body' 2>/dev/null || true)"
+        PR_BODY="$(gh pr view "$CLOSING_PR" --repo "$pr_closes_repo" --json body,title --jq '.title + "\n" + .body' 2>/dev/null || true)" # workflow-shell-guard: allow SH001 - best-effort fetch; empty body skips closing-keyword parse below
         # GitHub closing keywords (case-insensitive): close/closes/closed, fix/fixes/fixed,
         # resolve/resolves/resolved — optionally followed by "issue" — then #NNN.
         CLOSES_ISSUES="$(printf '%s' "$PR_BODY" | grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+' | grep -oE '[0-9]+$' | sort -un || true)"

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -13,6 +13,12 @@
 # Uses `git branch -D` (force delete) because squash/rebase merges (e.g. GitHub
 # default) do not have the branch tip in develop's history, so -d would fail.
 #
+# Issue close: if an issue number is embedded in the branch name it is closed
+# directly. When the branch slug contains no issue number (e.g. epic-slug
+# branches like feature/model-cost-resilience), the merged PR body/title is
+# parsed for GitHub closing keywords (Closes #N, Fixes #N, Resolves #N, etc.)
+# and each referenced issue is closed and its tracker status updated to Merged.
+#
 
 set -euo pipefail
 
@@ -398,7 +404,61 @@ if [ -n "$ISSUE_IDENTIFIER" ]; then
     update_tracker_status_best_effort "$ISSUE_NUMBER" "Plan Ready"
   fi
 else
-  echo "No issue number detected in branch name '$TO_DELETE', skipping issue close and tracker update."
+  # No issue number in branch name — for implementation branches, fall back to
+  # parsing the merged PR body/title for GitHub closing keywords
+  # (Closes #NNN, Fixes #NNN, Resolves #NNN, etc.) so that epic-slug branches
+  # like feature/model-cost-resilience still close their linked issues.
+  if [ "$branch_owner_kind" = "implementation" ]; then
+    pr_closes_repo="$TARGET_GITHUB_REPO"
+    if [ -z "$pr_closes_repo" ]; then
+      if ! pr_closes_repo="$(repo_slug 2>/dev/null)"; then
+        echo "No issue number in branch name '$TO_DELETE' and could not resolve GitHub repository; skipping issue close and tracker update." >&2
+        pr_closes_repo=""
+      fi
+    fi
+    if [ -n "$pr_closes_repo" ]; then
+      CLOSING_PR="${VERIFIED_MERGED_PR:-}"
+      if [ -z "$CLOSING_PR" ]; then
+        CLOSING_PR="$(gh pr list --repo "$pr_closes_repo" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+      fi
+      if [ -n "$CLOSING_PR" ]; then
+        PR_BODY="$(gh pr view "$CLOSING_PR" --repo "$pr_closes_repo" --json body,title --jq '.title + "\n" + .body' 2>/dev/null || true)"
+        # GitHub closing keywords (case-insensitive): close/closes/closed, fix/fixes/fixed,
+        # resolve/resolves/resolved — optionally followed by "issue" — then #NNN.
+        CLOSES_ISSUES="$(printf '%s' "$PR_BODY" | grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+' | grep -oE '[0-9]+$' | sort -un || true)"
+        if [ -n "$CLOSES_ISSUES" ]; then
+          echo "Found closing keyword refs in PR #${CLOSING_PR}: issues $(printf '%s' "$CLOSES_ISSUES" | tr '\n' ' ')"
+          cd "$HUB_REPO_ROOT"
+          while IFS= read -r closes_issue_num; do
+            [ -z "$closes_issue_num" ] && continue
+            echo "Processing issue #${closes_issue_num} from PR #${CLOSING_PR} closing keywords..."
+            update_tracker_status_best_effort "$closes_issue_num" "Merged"
+            if ! CLOSES_ISSUE_STATE="$(gh issue view "$closes_issue_num" --json state --jq '.state' 2>/dev/null)"; then
+              echo "Warning: could not query issue #${closes_issue_num}; skipping close." >&2
+              continue
+            fi
+            if [ "$CLOSES_ISSUE_STATE" = "OPEN" ]; then
+              echo "Closing issue #${closes_issue_num}..."
+              if gh issue close "$closes_issue_num" --comment "Closed by PR #${CLOSING_PR}."; then
+                echo "Reasserting issue #${closes_issue_num} tracker status as Merged after close..."
+                update_tracker_status_best_effort "$closes_issue_num" "Merged" "" "allow-backward"
+              else
+                echo "Warning: could not close issue #${closes_issue_num}; continuing cleanup." >&2
+              fi
+            else
+              echo "Issue #${closes_issue_num} is already ${CLOSES_ISSUE_STATE}, skipping close."
+            fi
+          done <<< "$CLOSES_ISSUES"
+        else
+          echo "No issue number in branch name '$TO_DELETE' or PR #${CLOSING_PR} body; skipping issue close and tracker update."
+        fi
+      else
+        echo "No issue number in branch name '$TO_DELETE' and no merged PR found; skipping issue close and tracker update."
+      fi
+    fi
+  else
+    echo "No issue number detected in branch name '$TO_DELETE', skipping issue close and tracker update."
+  fi
 fi
 
 echo ""

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -425,7 +425,7 @@ else
         fi
       fi
       if [ -n "$CLOSING_PR" ]; then
-        if ! PR_BODY="$(gh pr view "$CLOSING_PR" --repo "$pr_closes_repo" --json body,title --jq '.title + "\n" + .body' 2>/dev/null)"; then
+        if ! PR_BODY="$(gh pr view "$CLOSING_PR" --repo "$pr_closes_repo" --json body,title --jq '(.title // "") + "\n" + (.body // "")' 2>/dev/null)"; then
           echo "ERROR: could not fetch PR #${CLOSING_PR} body from '$pr_closes_repo' (gh command failed)." >&2
           exit 1
         fi
@@ -441,8 +441,8 @@ else
             [ -z "$closes_issue_num" ] && continue
             echo "Processing issue #${closes_issue_num} from PR #${CLOSING_PR} closing keywords..."
             if ! CLOSES_ISSUE_STATE="$(gh issue view "$closes_issue_num" --json state --jq '.state' 2>/dev/null)"; then
-              echo "ERROR: could not query issue #${closes_issue_num} (gh command failed)." >&2
-              exit 1
+              echo "Warning: could not query issue #${closes_issue_num}; skipping close and tracker update for this ref." >&2
+              continue
             fi
             update_tracker_status_best_effort "$closes_issue_num" "Merged"
             if [ "$CLOSES_ISSUE_STATE" = "OPEN" ]; then

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -419,24 +419,32 @@ else
     if [ -n "$pr_closes_repo" ]; then
       CLOSING_PR="${VERIFIED_MERGED_PR:-}"
       if [ -z "$CLOSING_PR" ]; then
-        CLOSING_PR="$(gh pr list --repo "$pr_closes_repo" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)" # workflow-shell-guard: allow SH001 - best-effort lookup when no merged PR was pre-verified
+        if ! CLOSING_PR="$(gh pr list --repo "$pr_closes_repo" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null)"; then
+          echo "ERROR: could not query merged PRs for branch '$TO_DELETE' in '$pr_closes_repo' (gh command failed)." >&2
+          exit 1
+        fi
       fi
       if [ -n "$CLOSING_PR" ]; then
-        PR_BODY="$(gh pr view "$CLOSING_PR" --repo "$pr_closes_repo" --json body,title --jq '.title + "\n" + .body' 2>/dev/null || true)" # workflow-shell-guard: allow SH001 - best-effort fetch; empty body skips closing-keyword parse below
+        if ! PR_BODY="$(gh pr view "$CLOSING_PR" --repo "$pr_closes_repo" --json body,title --jq '.title + "\n" + .body' 2>/dev/null)"; then
+          echo "ERROR: could not fetch PR #${CLOSING_PR} body from '$pr_closes_repo' (gh command failed)." >&2
+          exit 1
+        fi
         # GitHub closing keywords (case-insensitive): close/closes/closed, fix/fixes/fixed,
         # resolve/resolves/resolved — optionally followed by "issue" — then #NNN.
-        CLOSES_ISSUES="$(printf '%s' "$PR_BODY" | grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+' | grep -oE '[0-9]+$' | sort -un || true)"
+        # Require a word boundary before the keyword so substrings like "disclose" or
+        # "hotfix" are not treated as closing keywords.
+        CLOSES_ISSUES="$(printf '%s' "$PR_BODY" | grep -ioE '(^|[[:space:]])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+' | grep -oE '[0-9]+$' | sort -un || true)"
         if [ -n "$CLOSES_ISSUES" ]; then
           echo "Found closing keyword refs in PR #${CLOSING_PR}: issues $(printf '%s' "$CLOSES_ISSUES" | tr '\n' ' ')"
           cd "$HUB_REPO_ROOT"
           while IFS= read -r closes_issue_num; do
             [ -z "$closes_issue_num" ] && continue
             echo "Processing issue #${closes_issue_num} from PR #${CLOSING_PR} closing keywords..."
-            update_tracker_status_best_effort "$closes_issue_num" "Merged"
             if ! CLOSES_ISSUE_STATE="$(gh issue view "$closes_issue_num" --json state --jq '.state' 2>/dev/null)"; then
-              echo "Warning: could not query issue #${closes_issue_num}; skipping close." >&2
-              continue
+              echo "ERROR: could not query issue #${closes_issue_num} (gh command failed)." >&2
+              exit 1
             fi
+            update_tracker_status_best_effort "$closes_issue_num" "Merged"
             if [ "$CLOSES_ISSUE_STATE" = "OPEN" ]; then
               echo "Closing issue #${closes_issue_num}..."
               if gh issue close "$closes_issue_num" --comment "Closed by PR #${CLOSING_PR}."; then

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -412,8 +412,8 @@ else
     pr_closes_repo="$TARGET_GITHUB_REPO"
     if [ -z "$pr_closes_repo" ]; then
       if ! pr_closes_repo="$(repo_slug 2>/dev/null)"; then
-        echo "No issue number in branch name '$TO_DELETE' and could not resolve GitHub repository; skipping issue close and tracker update." >&2
-        pr_closes_repo=""
+        echo "ERROR: could not resolve GitHub repository for PR-body issue closeout." >&2
+        exit 1
       fi
     fi
     if [ -n "$pr_closes_repo" ]; then


### PR DESCRIPTION
## Summary

- Fixes `post-merge-cleanup.sh` silently skipping issue close when the branch slug contains no embedded issue number (e.g. `feature/model-cost-resilience`).
- When no issue number is found in the branch name and the branch is an implementation type (`feature/fix/hotfix/refactor`), the script now looks up the merged PR and parses its body/title for GitHub closing keywords (`Closes #N`, `Fixes #N`, `Resolves #N`, etc.).
- Each referenced issue is updated to **Merged** in the tracker and closed with a comment pointing to the merged PR — preserving the same ordering and semantics as the branch-number-based flow.

## Root cause

`post-merge-cleanup.sh` used regex matching on the branch name to extract an issue number. Branches named by epic slug rather than issue number fell through to an `else` clause that logged "skipping" and did nothing. This caused issues #1044–#1046 to remain open after `feature/model-cost-resilience` (PR #1056) merged.

## Changes

- `scripts/development-workflow/post-merge-cleanup.sh`: Added PR-body fallback in the `else` branch of the issue extraction block.
- `CHANGELOG.md`: Added `### Fixed` entry under `[Unreleased]`.

## Test plan

- [ ] Merge a branch named without an issue number (e.g. `feature/model-cost-resilience`) that has `Closes #N` in the PR body — verify the linked issues are closed and tracker status updated.
- [ ] Merge a branch named with an issue number (e.g. `fix/1059-slug`) — verify existing flow is unchanged.
- [ ] Merge a branch with no issue number and no closing keywords in the PR body — verify the script logs "No issue number … skipping" and exits cleanly.
- [ ] `shellcheck -S warning` passes on the modified script.

Closes #1059

Made with [Cursor](https://cursor.com)