### PR TITLE
fix(orchestration): epic-only /run-epic, remove --items (#1078)

### DIFF
--- a/.agents/skills/run-epic/SKILL.md
+++ b/.agents/skills/run-epic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-epic
-description: "Compatibility/advanced alias: resolve a native GitHub epic or explicit item list into a bounded workflow execution scope, with optional delegated review and merge gates. For the recommended starting point, use /run-work <epic-target> instead. Use /run-epic when you need direct control over delegation flags (--delegate-review, --may-merge, --max-risk)."
+description: "Compatibility/advanced alias: resolve a native GitHub epic into a bounded workflow execution scope, with optional delegated review and merge gates. For the recommended starting point, use /run-work <epic-target> instead. Use /run-epic when you need direct control over delegation flags (--delegate-review, --may-merge, --max-risk). For explicit item lists, use /run-items."
 ---
 
 # Run Epic
@@ -16,9 +16,10 @@ This is the Codex command-style alias for Claude Code `/run-epic`.
 1. Read `AGENTS.md` for repository-wide rules.
 2. Read `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md`.
 3. Run `./scripts/development-workflow/run-epic-scope-resolver.sh` with the
-   requested `--epic` or `--items` arguments plus any invocation policy flags:
+   `--epic <issue-number>` argument plus any invocation policy flags:
    `--delegate-review`, `--may-merge`, `--may-start-backlog <true|false>`,
    `--max-risk <low|medium|high>`, and `--base <branch>`.
+   For explicit item lists, use `/run-items` instead of `--items`.
    In `workflow_hub` mode, treat the resolver's base as the product
    implementation base. Do not block because that branch is absent from the hub
    repository; validate it only after the owning product repository is selected.

--- a/.cursor/commands/run-epic.md
+++ b/.cursor/commands/run-epic.md
@@ -1,5 +1,5 @@
 ---
-description: "Compatibility/advanced alias: resolve a native GitHub epic or explicit item list into a bounded workflow execution scope, with optional delegated review and merge gates. For the recommended starting point, use /run-work <epic-target> instead. Usage: /run-epic --epic <issue-number> | --items <issue-number>[,<issue-number>...] [--base <branch>] [--delegate-review] [--may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--json]"
+description: "Compatibility/advanced alias: resolve a native GitHub epic into a bounded workflow execution scope, with optional delegated review and merge gates. For the recommended starting point, use /run-work <epic-target> instead. For explicit item lists, use /run-items. Usage: /run-epic --epic <issue-number> [--base <branch>] [--delegate-review] [--may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--json]"
 ---
 
 # Cursor Command: Run Epic
@@ -17,8 +17,8 @@ Follow the resolver protocol exactly as defined in:
 
 Key responsibilities:
 
-- Require exactly one of `--epic` or `--items`.
-- Resolve native GitHub sub-issues for `--epic`; keep `--items` exact.
+- Require `--epic <issue-number>`. For explicit item lists, use `/run-items`.
+- Resolve native GitHub sub-issues for the epic.
 - Infer the execution base branch from `--base`, shared
   `integration-branch:<slug>`, or the applicable default.
 - In `workflow_hub` mode, treat that base as the product implementation base;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Epic-only `/run-epic`** (#1078): removed `--items` from the user-facing
+  surface of `/run-epic`. Protocol 95, `run-epic-scope-resolver.sh` usage text,
+  `.agents/skills/run-epic/SKILL.md`, and `.cursor/commands/run-epic.md` now
+  document `--epic <issue-number>` as the only operator entry point. The
+  `--items` flag is retained internally in the scope resolver for scripts
+  (e.g., the Linear orchestration smoke test) but emits a deprecation warning
+  when used. Operators who need explicit item lists should use `/run-items`.
+
 ### Added
 
 - **Parallel implementation policy for `/run-work` batches** (#1052): `workflow-batch-lanes.sh`

--- a/docs/workflow/development-workflow/bounded-run-prelude.md
+++ b/docs/workflow/development-workflow/bounded-run-prelude.md
@@ -19,7 +19,7 @@ Related:
 | ------ | ------- |
 | `run-bounded-prelude.sh` | **Primary entry** — scope + guardrails + policy recommender JSON |
 | `run-item-scope-resolver.sh` | Resolve one non-epic target to recommender-compatible scope (`scopeSource=item`) |
-| `run-epic-scope-resolver.sh` | Epic or explicit item list scope (`scopeSource=epic` or `items`) |
+| `run-epic-scope-resolver.sh` | Epic scope (`scopeSource=epic`); `--items` is an internal-only flag |
 | `run-epic-policy-recommender.sh` | Policy, checkpoints, and copy-paste command (shared) |
 
 ---

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -1,10 +1,9 @@
 # Protocol: Run Epic
 
 **Agent role**: Epic Runner (`run-epic`)
-**Purpose**: Convert a native GitHub epic or explicit item list into a bounded
-execution set, then run an explicitly authorized delegated review and merge
-loop with pre-merge risk classification, audit evidence, cleanup, and
-rediscovery
+**Purpose**: Convert a native GitHub epic into a bounded execution set, then
+run an explicitly authorized delegated review and merge loop with pre-merge
+risk classification, audit evidence, cleanup, and rediscovery
 
 The first phase is a **read-only resolver protocol**, not an implementation
 protocol. It exists to make scoped multi-item work explicit before an agent
@@ -36,13 +35,13 @@ for the full routing specification.
 ## Overview
 
 Use this protocol when a human invokes `/run-epic`, `$run-epic`, or asks to run
-an epic / bounded item list as a delegated workflow batch.
+a native GitHub epic as a delegated workflow batch. For explicit item lists, use
+`/run-items` instead.
 
-The resolver supports exactly one scope source:
+The resolver accepts one scope source:
 
 ```bash
 ./scripts/development-workflow/run-epic-scope-resolver.sh --epic <issue-number>
-./scripts/development-workflow/run-epic-scope-resolver.sh --items <issue-number>[,<issue-number>...]
 ```
 
 Optional flags:
@@ -189,17 +188,12 @@ the evidence omits `ciPolicy` / `ci_policy`.
 
 ## Step 1: Validate Scope Input
 
-Require exactly one of:
+Require `--epic <issue-number>`. The `--items` flag is not a user-facing option
+for `/run-epic`; operators who need explicit item lists should use `/run-items`
+instead.
 
-- `--epic <issue-number>`
-- `--items <issue-number>[,<issue-number>...]`
-
-Issue numbers must be positive integers. Reject empty values, zero, non-numeric
-tokens, and mixed `--epic` plus `--items` invocations before any repository or
-tracker lookup.
-
-Explicit item lists are exact. Do not expand siblings, parent epics, labels, or
-linked issues from an explicit list. Duplicate item numbers may be collapsed.
+The epic issue number must be a positive integer. Reject empty values, zero, and
+non-numeric tokens before any repository or tracker lookup.
 
 ---
 
@@ -226,10 +220,11 @@ sub-issue enumeration. Apply this flow instead:
    If the Linear item has no children, report an empty scope clearly — do not
    treat the parent item itself as the only scope item.
 
-2. **For `--items`** — the explicit list is a hard scope boundary (BR-7). Do
-   not expand to siblings, parent epics, or label-matched items. Fetch each
-   listed item's metadata via the Linear MCP before passing it to the scope
-   resolver.
+2. **For internal explicit-item paths** — when a script passes `--items`
+   internally, the explicit list is a hard scope boundary (BR-7). Do not expand
+   to siblings, parent epics, or label-matched items. Fetch each listed item's
+   metadata via the Linear MCP before passing it to the scope resolver. Users
+   invoking `/run-epic` directly should use `/run-items` instead.
 
 3. **Pass pre-resolved data** — the scope resolver (`run-epic-scope-resolver.sh`)
    cannot reach Linear itself. Supply item metadata as structured input. The

--- a/scripts/development-workflow/run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/run-epic-scope-resolver.sh
@@ -10,11 +10,12 @@ usage() {
   cat <<'EOF'
 Usage:
   ./scripts/development-workflow/run-epic-scope-resolver.sh --epic <issue-number> [--base <branch>] [--delegate-review] [--may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--json]
-  ./scripts/development-workflow/run-epic-scope-resolver.sh --items <issue-number>[,<issue-number>...] [--base <branch>] [--delegate-review] [--may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--json]
 
-Resolves a delegated epic or explicit item list into a read-only execution set.
+Resolves a delegated epic into a read-only execution set.
 The resolver never starts backlog items, updates tracker status, creates
 branches, opens PRs, merges PRs, closes issues, or deletes branches.
+
+For explicit item lists, use /run-items instead of --items.
 EOF
 }
 
@@ -72,6 +73,8 @@ while [ "$#" -gt 0 ]; do
       ;;
     --items)
       require_value "$@"
+      # --items is a deprecated internal flag. Users should use /run-items instead.
+      echo "DEPRECATED: --items is not a user-facing flag for run-epic-scope-resolver.sh. Use /run-items for explicit item lists." >&2
       items_arg="$2"
       shift 2
       ;;
@@ -115,11 +118,11 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ -n "$epic_number" ] && [ -n "$items_arg" ]; then
-  echo "ERROR: pass exactly one of --epic or --items, not both." >&2
+  echo "ERROR: pass --epic or --items, not both." >&2
   exit 64
 fi
 if [ -z "$epic_number" ] && [ -z "$items_arg" ]; then
-  echo "ERROR: pass exactly one of --epic or --items." >&2
+  echo "ERROR: --epic <issue-number> is required. For explicit item lists, use /run-items." >&2
   exit 64
 fi
 if [ -n "$epic_number" ] && ! is_positive_int "$epic_number"; then

--- a/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
@@ -224,7 +224,7 @@ run_json() {
 echo ""
 echo "=== Run epic scope resolver ==="
 
-run_fails_contains "requires_scope" "pass exactly one of --epic or --items" "$RESOLVER"
+run_fails_contains "requires_scope" "--epic <issue-number> is required" "$RESOLVER"
 run_fails_contains "rejects_both_scope_inputs" "not both" "$RESOLVER" --epic 900 --items 101
 run_fails_contains "rejects_invalid_items" "not a positive integer" "$RESOLVER" --items "101,nope"
 run_fails_contains "rejects_empty_item_token" "contains an empty item" "$RESOLVER" --items "101,,102"


### PR DESCRIPTION
## Summary

Removes `--items` from the user-facing surface of `/run-epic`. The command now accepts only `--epic <issue-number>` for operator entry. Operators who need explicit item lists should use `/run-items` instead.

## Changes

- **`scripts/development-workflow/run-epic-scope-resolver.sh`**: Updated `usage()` to show only `--epic`; updated validation error message; added deprecation warning to stderr when `--items` is used (functional behavior preserved for internal scripts).
- **`docs/workflow/development-workflow/protocols/95-run-epic-protocol.md`**: Updated purpose line, Overview scope source, and Step 1 validation to reflect `--epic`-only operator entry. Updated Linear provider Step 2 note to clarify `--items` is internal-only.
- **`.agents/skills/run-epic/SKILL.md`**: Updated description and step 3 to remove `--items` from operator instructions.
- **`.cursor/commands/run-epic.md`**: Updated frontmatter description and key responsibilities bullet.
- **`docs/workflow/development-workflow/bounded-run-prelude.md`**: Updated table entry to note `--items` is internal-only.
- **`CHANGELOG.md`**: Added `### Changed` entry under `[Unreleased]`.

## Backward compatibility

The `--items` flag still works in `run-epic-scope-resolver.sh` for internal script usage (e.g., `docs/testing/workflow/966-linear-orchestration-support.smoke-test.md` uses it). It emits a deprecation warning to stderr which existing tests suppress with `2>/dev/null`.

## Closes

Closes #1078

Part of epic #1072 — Finalize orchestration commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CLI messaging changes only; internal `--items` behavior is preserved with a stderr deprecation warning.
> 
> **Overview**
> **`/run-epic` is now epic-only for operators** — documented entry is `--epic <issue-number>` only. Explicit issue lists are directed to **`/run-items`** across Protocol 95, the bounded-run prelude, Codex skill, and Cursor command.
> 
> **`run-epic-scope-resolver.sh`** still accepts `--items` for internal callers (e.g. Linear smoke tests) but prints a **deprecation warning** on stderr and updates usage/errors so missing scope asks for `--epic` or points to `/run-items`. Tests were adjusted for the new error text.
> 
> **CHANGELOG** records the surface change under `[Unreleased]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3823e811f790fe2b1fd5177a852fec114152302c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->