### PR TITLE
fix(1079): guardrails repo defaults + always-confirm bounded prelude

### DIFF
--- a/.agents/skills/run-item/SKILL.md
+++ b/.agents/skills/run-item/SKILL.md
@@ -16,8 +16,12 @@ advances exactly one non-epic item through Protocol 91.
    `./scripts/development-workflow/run-bounded-prelude.sh --original-command "<invocation>" <scope flags> --json`
    See `docs/workflow/development-workflow/bounded-run-prelude.md`.
 3. When `policyRecommendation.requiresConfirmation` is true in the prelude JSON,
-   present policy/checkpoint recommendations and continue only after human
-   acceptance or customization.
+   print the resolved policy summary. If all autonomy flags (`--delegate-review`,
+   `--may-merge`, `--may-start-backlog`, `--max-risk`) were provided explicitly
+   in the invocation, those explicit flags serve as human confirmation — proceed
+   immediately after printing the summary. Otherwise (any flag was inferred from
+   scope, scope is ambiguous, or pending checkpoints remain), stop and ask the
+   human to confirm, customize, or re-invoke with corrected flags.
 4. Read `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`
    and follow it exactly. Do **not** delegate to `workflow-item-orchestrator` in the
    same run after Step 2 — that skill also runs the prelude and would duplicate

--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -174,69 +174,47 @@ template:
 # enforcement reference (effective-guardrails resolution, five enforcement gates,
 # named stop conditions, audit-evidence rules).
 #
-# guardrails:
-#   # mode — overall autonomy level for this repository.
-#   # Accepted values: manual | assisted | delegated | autonomous
-#   # Default: manual (agents draft and propose; a human performs every merge)
-#   mode: manual
-#
-#   # backlog_start — controls whether an agent may pick up a backlog item and begin
-#   # spec/plan/implementation work without a human confirming each item.
-#   backlog_start:
-#     # allow_without_confirmation — when false (default), an agent must receive an explicit
-#     # human instruction before starting a new backlog item.
-#     allow_without_confirmation: false   # default: false
-#
-#   # stages — per-stage permissions for spec, plan, and implementation.
-#   # Each stage can be configured independently.
-#   stages:
-#     spec:
-#       # may_open_pr — whether an agent may open a pull request for this stage.
-#       # Default: true (agents always draft PRs)
-#       may_open_pr: true
-#       # may_merge_pr — whether an agent may merge a clean pull request for this stage.
-#       # Default: false (a human must merge unless explicitly set to true)
-#       may_merge_pr: false
-#       # max_merge_risk — the highest risk level at which an agent may merge.
-#       # An agent must stop and defer to a human for any risk above this level.
-#       # Accepted values: low | medium | high
-#       # Default: low
-#       max_merge_risk: low
-#
-#     plan:
-#       may_open_pr: true
-#       may_merge_pr: false
-#       max_merge_risk: low
-#
-#     implementation:
-#       may_open_pr: true
-#       may_merge_pr: false
-#       max_merge_risk: low
-#       # required_evidence — named evidence items that must be present before an agent
-#       # may merge at this stage. Absence of any listed item causes the agent to stop.
-#       # Example values: regression, smoke_test, security_review
-#       required_evidence:
-#         - regression
-#
-#   # stop_conditions — situations in which an agent must stop and defer to a human,
-#   # regardless of mode and regardless of per-stage permissions.
-#   # These conditions are NEVER weaker than today's behavior; they hold in all modes.
-#   stop_conditions:
-#     - unclear_requirements          # requirement or acceptance criterion is ambiguous
-#     - architecture_decision         # choice requires human input on architecture
-#     - failing_ci                    # required CI checks are red
-#     - unresolved_blocking_review    # a blocking review thread is unresolved
-#     - high_risk_change              # classified risk exceeds the configured max_merge_risk
-#     - destructive_action            # action would delete branches, data, or releases
-#     - missing_tracker_context       # work item is missing required tracker metadata
-#     - missing_required_secret_or_permission  # a required credential or GitHub permission is absent
-#
-#   # audit — records that an agent must create after acting under delegated or autonomous mode.
-#   audit:
-#     # pr_disposition_record — a stable comment on the PR summarizing the merge decision,
-#     # the risk classification, and the evidence consulted. Required in delegated/autonomous.
-#     pr_disposition_record: required
-#     # work_item_ledger_record — a comment on the work item (issue/tracker card) recording
-#     # the stage completed, the PR merged, and the agent session that acted.
-#     # Required in delegated/autonomous.
-#     work_item_ledger_record: required
+# Two-step lifecycle (default for this template):
+# Execute commands (/run-item, /run-epic) stop at ready-for-human-review.
+# Merge is performed separately via /batch-merge (human confirms the merge plan).
+# Bounded prelude always requires confirmation before mutation — see
+# docs/workflow/development-workflow/bounded-run-prelude.md.
+
+guardrails:
+  # mode: delegated — agents may merge within per-stage permissions and risk limits.
+  # All stages default to may_merge_pr: false, implementing the two-step lifecycle
+  # where execute commands stop at ready-for-human-review and /batch-merge is used
+  # to land work. Override per-stage values to grant merge authority for specific stages.
+  mode: delegated
+
+  # backlog_start — agents must receive an explicit human instruction (via /run-item
+  # or /run-epic with --may-start-backlog true) before starting a new backlog item.
+  backlog_start:
+    allow_without_confirmation: false
+
+  # stages — all stages have may_merge_pr: false by default (two-step lifecycle).
+  # Override specific stages to grant merge authority when needed.
+  stages:
+    spec:
+      may_open_pr: true
+      may_merge_pr: false
+      max_merge_risk: low
+    plan:
+      may_open_pr: true
+      may_merge_pr: false
+      max_merge_risk: low
+    implementation:
+      may_open_pr: true
+      may_merge_pr: false
+      max_merge_risk: low
+
+  # stop_conditions — baseline stops that hold in all modes (additive, never removable).
+  stop_conditions:
+    - unclear_requirements
+    - architecture_decision
+    - failing_ci
+    - unresolved_blocking_review
+    - high_risk_change
+    - destructive_action
+    - missing_tracker_context
+    - missing_required_secret_or_permission

--- a/.codex/skills/workflow-item-orchestrator/SKILL.md
+++ b/.codex/skills/workflow-item-orchestrator/SKILL.md
@@ -11,8 +11,12 @@ Recommended model tier: `balanced`
 2. Run the read-only bounded prelude before mutation unless handoff metadata includes
    `BATCH_CONTEXT=true` (portfolio batch dispatch — skip prelude per Protocol 91):
    `./scripts/development-workflow/run-bounded-prelude.sh --original-command "<invocation>" <scope flags> --json`
-   See `docs/workflow/development-workflow/bounded-run-prelude.md`. When
-   `policyRecommendation.requiresConfirmation` is true, stop for human acceptance
+   See `docs/workflow/development-workflow/bounded-run-prelude.md`. Print the
+   resolved policy summary. If all autonomy flags (`--delegate-review`,
+   `--may-merge`, `--may-start-backlog`, `--max-risk`) were provided explicitly
+   in the invocation, those explicit flags serve as human confirmation — proceed
+   immediately after printing the summary. Otherwise (any flag was inferred,
+   scope is ambiguous, or pending checkpoints remain), stop for human acceptance
    or customization before continuing.
 3. Read `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`.
 4. Prefer the helper scripts in `scripts/development-workflow/` for next-action classification, resume behavior, CI polling, and automated review polling before using ad hoc shell commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Guardrails repo defaults and always-confirm bounded prelude** (#1079):
+  `.ai-dev-workflow.yaml` now ships an uncommented `guardrails` block with
+  `mode: delegated` and all stages `may_merge_pr: false`, implementing the
+  two-step lifecycle (execute commands stop at `ready-for-human-review`; merge
+  via `/batch-merge`). The bounded prelude always sets `requiresConfirmation: true`
+  so every mutating orchestration command shows the resolved policy before mutation.
+  `guardrails.md` documents the two-step lifecycle and always-confirm contract.
 - **Parallel implementation policy for `/run-work` batches** (#1052): `workflow-batch-lanes.sh`
   assigns stage lanes with default implementation serialization (`max_concurrent: 1`);
   `workflow-batch-plan.sh` emits `LOCAL_RUNTIME=none|exclusive` for implementation items;

--- a/docs/workflow/development-workflow/bounded-run-prelude.md
+++ b/docs/workflow/development-workflow/bounded-run-prelude.md
@@ -59,9 +59,13 @@ The JSON output includes:
 1. **Read-only** — no tracker updates, branches, PRs, merges, or issue closure.
 2. **One policy path** — single-item runs use the same recommender and checkpoint
    schema as `/run-epic` (no parallel autonomy system).
-3. **Human confirmation** — when `requiresConfirmation` is true, accept or
-   customize policy/checkpoints before mutation (waive checkpoints in PR body
-   or via `--checkpoints-file` on re-run).
+3. **Always-confirm** — `requiresConfirmation` is always `true`. The orchestrator
+   must present the resolved policy to the human before any mutation. When all
+   autonomy flags were provided explicitly in the invocation command, those
+   explicit flags serve as the human's confirmation and the orchestrator may
+   proceed immediately after printing the policy summary. When any flag was
+   inferred or scope is ambiguous, the orchestrator must stop and wait for
+   explicit human acceptance or re-invocation with corrected flags.
 4. **Epic-like items** — `run-item-scope-resolver.sh` rejects epic issues; use
    `--epic` instead.
 

--- a/docs/workflow/development-workflow/bounded-run-prelude.md
+++ b/docs/workflow/development-workflow/bounded-run-prelude.md
@@ -64,8 +64,9 @@ The JSON output includes:
    autonomy flags were provided explicitly in the invocation command, those
    explicit flags serve as the human's confirmation and the orchestrator may
    proceed immediately after printing the policy summary. When any flag was
-   inferred or scope is ambiguous, the orchestrator must stop and wait for
-   explicit human acceptance or re-invocation with corrected flags.
+   inferred, scope is ambiguous, or pending checkpoints remain, the orchestrator
+   must stop and wait for explicit human acceptance or re-invocation with
+   corrected flags.
 4. **Epic-like items** — `run-item-scope-resolver.sh` rejects epic issues; use
    `--epic` instead.
 

--- a/docs/workflow/development-workflow/guardrails.md
+++ b/docs/workflow/development-workflow/guardrails.md
@@ -235,6 +235,40 @@ leave informational comments).
 
 ---
 
+## Two-Step Lifecycle and Always-Confirm
+
+The framework ships a **two-step lifecycle** as its default operating model:
+
+1. **Execute** — `/run-item`, `/run-items`, or `/run-epic` advance work to
+   `ready-for-human-review`. These commands stop before merge.
+2. **Land** — `/batch-merge` (or manual merge) lands ready PRs after a human
+   confirms the merge plan.
+
+This separation keeps humans in control of what goes into the integration branch
+while still automating the preparation, review, and CI-readiness steps.
+
+### Always-Confirm Prelude
+
+Every mutating orchestration command (`/run-item`, `/run-items`, `/run-epic`) runs
+the **shared bounded prelude** before any artifact mutation. The prelude always
+sets `requiresConfirmation: true`, which means:
+
+- The resolved policy is always printed before work starts.
+- When all autonomy flags were provided explicitly in the invocation (e.g.,
+  `--delegate-review --may-merge --may-start-backlog true --max-risk high`), those
+  explicit flags serve as the human's confirmation and the orchestrator may
+  proceed immediately after printing the summary.
+- When any flag was inferred or scope is ambiguous, the orchestrator stops and
+  waits for the human to confirm or re-invoke with corrected flags.
+
+**`/run-work` is exempt**: the portfolio scan is read-only (no mutation), so the
+bounded prelude is not required. Only the execute commands run the prelude.
+
+See [`bounded-run-prelude.md`](bounded-run-prelude.md) for the full prelude
+contract and script reference.
+
+---
+
 ## Safe Defaults and Migration Note
 
 **No action is required** for existing repositories. The `guardrails` section in

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -105,10 +105,17 @@ mutation in Step 1 or later:
   --json
 ```
 
-See [`bounded-run-prelude.md`](../bounded-run-prelude.md). If
-`policyRecommendation.requiresConfirmation` is true, or guardrails cannot be
-read (`guardrails_config_unreadable`), stop before mutation per
-`guardrails-enforcement.md`.
+See [`bounded-run-prelude.md`](../bounded-run-prelude.md).
+
+**Always-confirm**: `policyRecommendation.requiresConfirmation` is always `true`.
+The orchestrator must print the resolved policy summary before any mutation.
+- When all autonomy flags (`--delegate-review`, `--may-merge`, `--may-start-backlog`,
+  `--max-risk`) were provided explicitly in the invocation, those explicit flags
+  serve as the human's confirmation — proceed immediately after printing the summary.
+- When any flag was inferred from scope or scope is ambiguous, stop before mutation
+  and ask the human to confirm or re-invoke with corrected flags.
+- When guardrails cannot be read (`guardrails_config_unreadable`), stop before
+  mutation per `guardrails-enforcement.md`.
 
 **Portfolio batch dispatch (`BATCH_CONTEXT=true`)**: When the Portfolio
 Orchestrator dispatches this protocol from Protocol 90, the bounded prelude is

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -112,8 +112,9 @@ The orchestrator must print the resolved policy summary before any mutation.
 - When all autonomy flags (`--delegate-review`, `--may-merge`, `--may-start-backlog`,
   `--max-risk`) were provided explicitly in the invocation, those explicit flags
   serve as the human's confirmation — proceed immediately after printing the summary.
-- When any flag was inferred from scope or scope is ambiguous, stop before mutation
-  and ask the human to confirm or re-invoke with corrected flags.
+- When any flag was inferred from scope, scope is ambiguous, or pending checkpoints
+  remain, stop before mutation and ask the human to confirm or re-invoke with
+  corrected flags.
 - When guardrails cannot be read (`guardrails_config_unreadable`), stop before
   mutation per `guardrails-enforcement.md`.
 

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -410,17 +410,14 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
       base: source_for($baseOverride),
       checkpoints: checkpoint_field_source
     },
-    requiresConfirmation: ((
-      [$mayStartBacklogOverride, $delegateReviewOverride, $mayMergeOverride, $maxRiskOverride, $baseOverride]
-      | any(. == "")
-    ) or has_ambiguous or has_pending_checkpoints($effCheckpoints)),
+    requiresConfirmation: true,
     confirmationReason: (
       if has_ambiguous then "scope or base is ambiguous; confirm before mutation"
       elif has_pending_checkpoints($effCheckpoints) then
         "pending human checkpoints remain; confirm, customize, or waive before mutation"
       elif ([$mayStartBacklogOverride, $delegateReviewOverride, $mayMergeOverride, $maxRiskOverride, $baseOverride] | any(. == "")) then
         "one or more autonomy policy values were inferred from resolved scope"
-      else "all autonomy policy values were explicit"
+      else "policy values are explicit; review resolved policy and confirm before mutation"
       end
     ),
     rationale: {

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -415,7 +415,7 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
       if has_ambiguous then "scope or base is ambiguous; confirm before mutation"
       elif has_pending_checkpoints($effCheckpoints) then
         "pending human checkpoints remain; confirm, customize, or waive before mutation"
-      elif ([$mayStartBacklogOverride, $delegateReviewOverride, $mayMergeOverride, $maxRiskOverride, $baseOverride] | any(. == "")) then
+      elif ([$mayStartBacklogOverride, $delegateReviewOverride, $mayMergeOverride, $maxRiskOverride] | any(. == "")) then
         "one or more autonomy policy values were inferred from resolved scope"
       else "policy values are explicit; review resolved policy and confirm before mutation"
       end

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -169,7 +169,7 @@ explicit_output="$("$HELPER" \
   --max-risk low \
   --base develop \
   --json)"
-run_test "explicit_policy_skips_confirmation" "false" "$(printf '%s\n' "$explicit_output" | jq -r '.requiresConfirmation')"
+run_test "explicit_policy_always_confirms" "true" "$(printf '%s\n' "$explicit_output" | jq -r '.requiresConfirmation')"
 run_test "explicit_backlog_choice_preserved" "false" "$(printf '%s\n' "$explicit_output" | jq -r '.effectivePolicy.mayStartBacklog')"
 run_test "explicit_sources_recorded" "explicit" "$(printf '%s\n' "$explicit_output" | jq -r '.fieldSources.maxRisk')"
 run_test "copy_paste_command_is_canonical" "1" "$(printf '%s\n' "$explicit_output" | jq -r '.copyPasteCommand' | grep -o -- '--max-risk' | wc -l | tr -d ' ')"


### PR DESCRIPTION
## Summary

Implements #1079 (Epic #1072 child item 5 — Finalize orchestration commands).

### Changes

- **`.ai-dev-workflow.yaml`**: Uncomments and configures the `guardrails` block with sensible defaults — `mode: delegated`, all stages `may_merge_pr: false`, `backlog_start.allow_without_confirmation: false`. This implements the **two-step lifecycle**: execute commands (`/run-item`, `/run-epic`) stop at `ready-for-human-review`; merging is done separately via `/batch-merge`.

- **`run-epic-policy-recommender.sh`**: Changes `requiresConfirmation` from conditionally-true to always `true`. Updates `confirmationReason` for the all-explicit case to say "policy values are explicit; review resolved policy and confirm before mutation".

- **`bounded-run-prelude.md`**: Updates Contract section 3 to document the always-confirm rule: the orchestrator must print the resolved policy before any mutation; explicit invocation flags serve as human confirmation.

- **`guardrails.md`**: Adds "Two-Step Lifecycle and Always-Confirm" section documenting the execute→land model and the always-confirm prelude behavior.

- **`91-orchestrate-work-protocol.md`**: Updates the "Bounded prelude" subsection in Step 0 to reflect that `requiresConfirmation` is always `true` and describes the explicit-flags-as-confirmation rule.

### Acceptance Criteria

- [x] `.ai-dev-workflow.yaml` has uncommented `guardrails` block with `mode: delegated` and all stages `may_merge_pr: false`
- [x] `run-epic-policy-recommender.sh` always outputs `requiresConfirmation: true`
- [x] `bounded-run-prelude.md` contract documents always-confirm rule
- [x] `guardrails.md` documents two-step lifecycle and always-confirm
- [x] Protocol 91 Step 0 references always-confirm semantics
- [x] CHANGELOG entry added under `[Unreleased]`
- [x] Markdown lint passes (0 errors)
- [x] YAML validates cleanly

## Test plan

- [ ] Run `run-bounded-prelude.sh --issue 1079 --original-command "/run-item 1079" --delegate-review --may-merge --may-start-backlog true --max-risk high --json` — verify `policyRecommendation.requiresConfirmation` is `true` and `confirmationReason` is "policy values are explicit; review resolved policy and confirm before mutation"
- [ ] Verify `.ai-dev-workflow.yaml` YAML parses without error
- [ ] Verify `guardrails.md` and `bounded-run-prelude.md` render correctly

Closes #1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S24T9ztvqA1QcbGhatVHtR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default orchestration and template guardrails behavior for all adopters of the workflow YAML and mutating `/run-item`/`/run-epic` paths; mistaken operator assumptions about auto-proceed on explicit flags could affect autonomy gates.
> 
> **Overview**
> Ships **active template guardrails** and tightens **bounded prelude** behavior so execute commands prepare work for human review while merge stays a separate, confirmed step.
> 
> **`.ai-dev-workflow.yaml`** replaces the long commented example with a live `guardrails` block: `mode: delegated`, `backlog_start.allow_without_confirmation: false`, and **all stages** `may_merge_pr: false`, documenting the default **two-step lifecycle** ( `/run-item` / `/run-epic` stop at `ready-for-human-review`; landing via `/batch-merge`).
> 
> **`run-epic-policy-recommender.sh`** now always emits `requiresConfirmation: true` (no longer skips confirmation when every autonomy flag is explicit). `confirmationReason` still distinguishes ambiguous scope, pending checkpoints, inferred flags, and the all-explicit case (“review resolved policy and confirm before mutation”). The recommender test is renamed to expect confirmation even for fully explicit invocations.
> 
> **Orchestrator docs and skills** (`bounded-run-prelude.md`, `guardrails.md`, Protocol 91 Step 0, `run-item`, `workflow-item-orchestrator`) align on **always-confirm**: print the resolved policy before mutation; if `--delegate-review`, `--may-merge`, `--may-start-backlog`, and `--max-risk` were all passed explicitly, those flags count as confirmation and the run may continue after the summary—otherwise stop for human acceptance or corrected flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dec4a6d64bb652aed1b8c99cb56c5a24588c0fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->