### PR TITLE
feat(1077): complete run-items bounded prelude surfaces

### DIFF
--- a/.agents/skills/run-items/SKILL.md
+++ b/.agents/skills/run-items/SKILL.md
@@ -8,23 +8,36 @@ description: "Bounded multi-item execute command: advance two or more explicit w
 This is the Codex command-style alias for Claude Code `/run-items`.
 
 `/run-items` is the **bounded multi-item batch execute** command. It takes two or
-more explicit item targets and executes them through Protocol 90 in
-`explicit_list` mode, targeting `develop` directly without a portfolio scan or
+more explicit item targets, validates the list with the read-only router, runs
+the shared bounded prelude, and then executes through Protocol 90 in
+`explicit_list` mode. PRs target `develop` directly without a portfolio scan or
 proposal step.
 
 1. Read `AGENTS.md` for repository-wide rules.
-2. Require at least two explicit item targets (issue numbers, PR numbers, branch names,
-   or development folder paths). A single target must use `$run-item` instead.
-3. Read `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
-   and follow it in `explicit_list` mode with the supplied targets as the hard bounded scope.
-4. Resolve guardrails before any mutation: confirm effective autonomy mode, PR-open,
-   delegated review, and delegated merge permissions.
-5. Before implementation mutation in `workflow_hub`, state the selected product
+2. Run read-only router validation:
+   `./scripts/development-workflow/run-work-router.sh <target> [<target>...] [--json]`.
+   Continue only when the router returns `MODE=redirect_items` (or JSON
+   `mode: "redirect_items"`). Stop with redirect guidance for `no_target_scan`,
+   `redirect_item`, `redirect_epic`, or `ambiguous`.
+3. Run the read-only bounded prelude:
+   `./scripts/development-workflow/run-bounded-prelude.sh --original-command "<invocation>" --items "<comma-separated-list>" [policy flags] --json`.
+   Use a single comma-separated `--items` value such as `"978,979"`.
+4. When `policyRecommendation.requiresConfirmation` is true in the prelude JSON,
+   present policy/checkpoint recommendations and continue only after human
+   acceptance, customization, or waiver.
+5. Read `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
+   and follow it in `explicit_list` mode with the supplied targets as the hard
+   bounded scope.
+6. Target `develop` directly; `/run-items` does not create or target
+   `develop-<slug>` integration branches.
+7. Before implementation mutation in `workflow_hub`, state the selected product
    repository, artifact owner, and mutation target; stop when context is missing
    or ambiguous.
-6. Do not stop after advancing one item if another item in the explicit list still
+8. Do not stop after advancing one item if another item in the explicit list still
    has a deterministic next action.
-7. For single-item advancement use `$run-item`; for epic-scoped runs use `$run-epic`;
+9. Stop with in-scope PRs at `ready-for-human-review`; landing is a separate
+   `$batch-merge` step.
+10. For single-item advancement use `$run-item`; for epic-scoped runs use `$run-epic`;
    for read-only portfolio scan and proposal use `$run-work`.
 
 > **Deprecation notice**: `/run-epic --items` is deprecated. Use `/run-items` for

--- a/.agents/skills/run-items/agents/openai.yaml
+++ b/.agents/skills/run-items/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Run items"
+  short_description: "Multi-item bounded execute: advance an explicit list of two or more workflow items with shared prelude before Protocol 90 explicit_list."
+  default_prompt: "Use $run-items to advance an explicit list of two or more non-epic workflow items. Run run-work-router.sh first as read-only validation, then run run-bounded-prelude.sh read-only for scope, guardrails, policy, and checkpoints before following Protocol 90 explicit_list mode until all items reach a terminal state. Epic-like tokens stop the invocation and should use $run-epic. One token should use $run-item. Zero tokens should use $run-work."
+
+policy:
+  allow_implicit_invocation: false

--- a/.claude/commands/run-items.md
+++ b/.claude/commands/run-items.md
@@ -5,18 +5,44 @@ description: "Bounded multi-item execute command: advance two or more explicit w
 # Claude Code Command: Run Items
 
 `/run-items` is the **bounded multi-item batch execute** command. It takes two or
-more explicit item targets and executes them through Protocol 90 in
-`explicit_list` mode, targeting `develop` directly without a portfolio scan or
-proposal step.
+more explicit item targets, validates the list with the read-only router, runs
+the shared bounded prelude, and then executes through Protocol 90 in
+`explicit_list` mode. PRs target `develop` directly without creating an
+integration branch.
 
-| Invocation | Action |
-| ---------- | ------ |
-| Two or more targets | `explicit_list` — Protocol 90 bounded portfolio batch |
-| One target | Error — use `/run-item <target>` for a single item |
+| Invocation | Router mode | Action |
+| ---------- | ----------- | ------ |
+| No target | `no_target_scan` | **Stop** — use `/run-work` for scan-only discovery |
+| One non-epic target | `redirect_item` | **Stop** — use `/run-item <target>` |
+| One epic target / `--epic` | `redirect_epic` | **Stop** — use `/run-epic --epic <n>` |
+| Two or more non-epic targets | `redirect_items` | Continue to bounded prelude, then Protocol 90 `explicit_list` |
+| Ambiguous target | `ambiguous` | **Stop** — report `stopReason`; do not mutate |
 
-## Bounded execution via Protocol 90
+## Bounded prelude and Protocol 90
 
-Follow Protocol 90 in `explicit_list` mode:
+1. Run read-only router validation:
+
+   ```bash
+   ./scripts/development-workflow/run-work-router.sh <target> [<target>...] [--json]
+   ```
+
+   Continue only when the router returns `MODE=redirect_items` (or JSON
+   `mode: "redirect_items"`). Use the resolved scope as the hard bounded list.
+2. Run the shared bounded prelude before mutation:
+
+   ```bash
+   ./scripts/development-workflow/run-bounded-prelude.sh \
+     --original-command "/run-items <target> <target>" \
+     --items "<comma-separated-list>" \
+     [policy flags] \
+     --json
+   ```
+
+   `--items` takes a single comma-separated string such as `"978,979"`. When the
+   prelude reports `policyRecommendation.requiresConfirmation: true`, present
+   the policy/checkpoint recommendation and continue only after human acceptance,
+   customization, or waiver.
+3. Follow Protocol 90 in `explicit_list` mode:
 
 `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
 
@@ -25,13 +51,14 @@ Key responsibilities:
 - Require at least two explicit item targets (issue numbers, PR numbers, branch names,
   or development folder paths).
 - Use the supplied targets as the hard bounded scope for Protocol 90 `explicit_list` mode.
-- Resolve guardrails before any mutation; confirm effective autonomy mode, PR-open,
-  delegated review, and delegated merge permissions.
-- Infer the execution base branch from `--base` or the applicable default.
+- Target `develop` directly; `/run-items` does not create or target
+  `develop-<slug>` integration branches.
 - In `workflow_hub`, state the selected product repository, artifact owner, and mutation
   target before implementation mutation; stop when context is missing or ambiguous.
 - Do not stop after advancing one item if another in the list still has a
   deterministic next action.
+- Stop with in-scope PRs at `ready-for-human-review`; landing is a separate
+  `/batch-merge` step.
 
 For single-item advancement use `/run-item`. For epic-scoped runs use `/run-epic`.
 For read-only portfolio scan and proposal use `/run-work`.

--- a/.cursor/commands/run-items.md
+++ b/.cursor/commands/run-items.md
@@ -5,15 +5,43 @@ description: "Execute an explicit bounded batch: two or more items through Proto
 # Cursor Command: Run Items
 
 `/run-items` is the **bounded multi-item batch execute** command. It takes two or
-more explicit item targets and executes them through Protocol 90 in
-`explicit_list` mode, targeting `develop` directly.
+more explicit item targets, validates the list with the read-only router, runs
+the shared bounded prelude, and then executes through Protocol 90 in
+`explicit_list` mode. PRs target `develop` directly.
 
-| Invocation | Action |
-| ---------- | ------ |
-| Two or more targets | `explicit_list` — Protocol 90 bounded portfolio batch |
-| One target | Error — use `/run-item <target>` for a single item |
+| Invocation | Router mode | Action |
+| ---------- | ----------- | ------ |
+| No target | `no_target_scan` | **Stop** — use `/run-work` for scan-only discovery |
+| One non-epic target | `redirect_item` | **Stop** — use `/run-item <target>` |
+| One epic target / `--epic` | `redirect_epic` | **Stop** — use `/run-epic --epic <n>` |
+| Two or more non-epic targets | `redirect_items` | Continue to bounded prelude, then Protocol 90 `explicit_list` |
+| Ambiguous target | `ambiguous` | **Stop** — report `stopReason`; do not mutate |
 
-Follow Protocol 90 in `explicit_list` mode:
+## Bounded prelude and Protocol 90
+
+1. Run read-only router validation:
+
+   ```bash
+   ./scripts/development-workflow/run-work-router.sh <target> [<target>...] [--json]
+   ```
+
+   Continue only when the router returns `MODE=redirect_items` (or JSON
+   `mode: "redirect_items"`). Use the resolved scope as the hard bounded list.
+2. Run the shared bounded prelude before mutation:
+
+   ```bash
+   ./scripts/development-workflow/run-bounded-prelude.sh \
+     --original-command "/run-items <target> <target>" \
+     --items "<comma-separated-list>" \
+     [policy flags] \
+     --json
+   ```
+
+   `--items` takes a single comma-separated string such as `"978,979"`. When the
+   prelude reports `policyRecommendation.requiresConfirmation: true`, present
+   the policy/checkpoint recommendation and continue only after human acceptance,
+   customization, or waiver.
+3. Follow Protocol 90 in `explicit_list` mode:
 
 `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
 
@@ -22,12 +50,13 @@ Key responsibilities:
 - Require at least two explicit item targets (issue numbers, PR numbers, branch names,
   or development folder paths).
 - Use the supplied targets as the hard bounded scope for Protocol 90 `explicit_list` mode.
-- Resolve guardrails before any mutation; confirm effective autonomy mode, PR-open,
-  delegated review, and delegated merge permissions.
-- Infer the execution base branch from `--base` or the applicable default.
+- Target `develop` directly; `/run-items` does not create or target
+  `develop-<slug>` integration branches.
 - In `workflow_hub`, include selected product repository context in implementation handoffs.
 - Do not stop after advancing one item if another in the list still has a
   deterministic next action.
+- Stop with in-scope PRs at `ready-for-human-review`; landing is a separate
+  `/batch-merge` step.
 
 For single-item advancement use `/run-item`. For epic-scoped runs use `/run-epic`.
 For read-only portfolio scan and proposal use `/run-work`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so every mutating orchestration command shows the resolved policy before mutation.
   `guardrails.md` documents the two-step lifecycle and always-confirm contract.
 - **Scan-only `/run-work` — portfolio batch proposals without mutation** (#1076): `/run-work` is now fully read-only in all routing modes; `explicit_list` is replaced by `redirect_items` (emits `REDIRECT_COMMAND=/run-items ...` for multi-target invocations); `no_target_scan` produces a portfolio scan + batch proposal only with no item dispatch; `run-work-router.sh`, Protocol 96, Protocol 90 routing entrypoint, and all command/skill surfaces updated accordingly.
+- **`/run-items` bounded multi-item execute command** (#1077): command and skill
+  surfaces now validate explicit lists with the read-only router, run the shared
+  bounded prelude before Protocol 90 `explicit_list` execution, target `develop`
+  directly, and include Codex OpenAI metadata for repo-scoped skill discovery.
 - **Final orchestration command map — command surfaces sync** (#1080): updates all
   operator surfaces (AGENTS.md, README.md, skills, Cursor commands, agents) to
   reflect the finalized command map: `/run-work` = read-only portfolio scan,


### PR DESCRIPTION
## Summary

Completes the `/run-items` implementation surfaces for #1077 by adding the missing router-validation and shared bounded-prelude instructions to Claude, Cursor, and Codex command surfaces, plus Codex OpenAI metadata for repo-scoped skill discovery.

## Spec and Plan

- Spec: `docs/specs/developments/20260627084102_1077-run-items-command/1_1077-run-items-command_specs.md`
- Plan: `docs/specs/developments/20260627084102_1077-run-items-command/2_1077-run-items-command_implementation-plan.md`

## Test Plan

- `npx markdownlint-cli2 .claude/commands/run-items.md .cursor/commands/run-items.md .agents/skills/run-items/SKILL.md CHANGELOG.md`
- `python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `bash scripts/development-workflow/tests/test-run-work-router.sh`

## Pre-submission Self-review

Stale markers: none. Caller/sibling consistency: verified run-items surfaces use current router mode `redirect_items`, route sub-two/epic/ambiguous invocations away, and keep Protocol 90 execution as `explicit_list`. Coverage: approved #1077 plan gaps addressed; router script changes were already present on `develop` and verified by tests.

Closes #1077

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-metadata only; no workflow script or runtime behavior changes in this diff.
> 
> **Overview**
> **Completes #1077 operator documentation** for `/run-items` so Claude, Cursor, and Codex surfaces describe the same bounded execute flow as Protocol 96/90.
> 
> The command docs now require **read-only** `run-work-router.sh` validation (continue only on `redirect_items`) and **`run-bounded-prelude.sh`** with a comma-separated `--items` list before any mutation, including human confirmation when `policyRecommendation.requiresConfirmation` is true. A **router-mode table** documents when to stop and redirect to `/run-work`, `/run-item`, or `/run-epic` instead of proceeding.
> 
> Execution guidance is tightened: PRs **target `develop` directly** (no `develop-<slug>` integration branch), in-scope work **stops at `ready-for-human-review`**, and merge is deferred to **`/batch-merge`**. Inline guardrail/base-branch resolution steps were removed from these surfaces in favor of the shared prelude.
> 
> Adds **`.agents/skills/run-items/agents/openai.yaml`** for Codex skill discovery and records the change under **`[Unreleased]`** in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 417cea4792488da9ee0fb7cbcf0c14ddb0297c53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->