### PR TITLE
feat(1075): finalize orchestration guardrail defaults

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -218,3 +218,7 @@ guardrails:
     - destructive_action
     - missing_tracker_context
     - missing_required_secret_or_permission
+
+  audit:
+    pr_disposition_record: required
+    work_item_ledger_record: required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   via `/batch-merge`). The bounded prelude always sets `requiresConfirmation: true`
   so every mutating orchestration command shows the resolved policy before mutation.
   `guardrails.md` documents the two-step lifecycle and always-confirm contract.
+  The default guardrails block also requires PR disposition and work-item ledger
+  audit records.
 - **Scan-only `/run-work` — portfolio batch proposals without mutation** (#1076): `/run-work` is now fully read-only in all routing modes; `explicit_list` is replaced by `redirect_items` (emits `REDIRECT_COMMAND=/run-items ...` for multi-target invocations); `no_target_scan` produces a portfolio scan + batch proposal only with no item dispatch; `run-work-router.sh`, Protocol 96, Protocol 90 routing entrypoint, and all command/skill surfaces updated accordingly.
 - **`/run-items` bounded multi-item execute command** (#1077): command and skill
   surfaces now validate explicit lists with the read-only router, run the shared
   bounded prelude before Protocol 90 `explicit_list` execution, target `develop`
-  directly, and include Codex OpenAI metadata for repo-scoped skill discovery.
+  directly, document the shared prelude contract, and include Codex OpenAI
+  metadata for repo-scoped skill discovery.
 - **Final orchestration command map — command surfaces sync** (#1080): updates all
   operator surfaces (AGENTS.md, README.md, skills, Cursor commands, agents) to
   reflect the finalized command map: `/run-work` = read-only portfolio scan,

--- a/docs/workflow/development-workflow/bounded-run-prelude.md
+++ b/docs/workflow/development-workflow/bounded-run-prelude.md
@@ -1,8 +1,8 @@
 # Shared Bounded Run Prelude
 
 Read-only helpers that unify scope resolution, repository guardrails snapshot,
-and policy/checkpoint recommendation for **`/run-item`** and **`/run-epic`** before
-any artifact mutation.
+and policy/checkpoint recommendation for **`/run-item`**, **`/run-items`**, and
+**`/run-epic`** before any artifact mutation.
 
 Related:
 
@@ -46,6 +46,16 @@ Related:
   --json
 ```
 
+**Explicit item list**:
+
+```bash
+./scripts/development-workflow/run-bounded-prelude.sh \
+  --original-command "/run-items 1049 1050" \
+  --items "1049,1050" \
+  --delegate-review --may-merge --may-start-backlog true --max-risk medium \
+  --json
+```
+
 The JSON output includes:
 
 - `scope` — full resolver payload (`groups`, `items`, `baseBranch`, `policy` flags)
@@ -57,8 +67,9 @@ The JSON output includes:
 ## Contract
 
 1. **Read-only** — no tracker updates, branches, PRs, merges, or issue closure.
-2. **One policy path** — single-item runs use the same recommender and checkpoint
-   schema as `/run-epic` (no parallel autonomy system).
+2. **One policy path** — single-item and explicit-list runs use the same
+   recommender and checkpoint schema as `/run-epic` (no parallel autonomy
+   system).
 3. **Always-confirm** — `requiresConfirmation` is always `true`. The orchestrator
    must present the resolved policy to the human before any mutation. When all
    autonomy flags were provided explicitly in the invocation command, those
@@ -76,5 +87,7 @@ The JSON output includes:
 
 - **`/run-item`** and **`/run-epic`** agents should call `run-bounded-prelude.sh`
   before Protocol 91 or 95 mutation steps.
+- **`/run-items`** agents should call `run-bounded-prelude.sh` before Protocol
+  90 `explicit_list` mutation steps.
 - **`/run-work`** portfolio runs do **not** use this prelude (Protocol 90 batch
   proposal path).


### PR DESCRIPTION
## Summary

- add the required guardrails audit defaults to `.ai-dev-workflow.yaml`
- document `/run-items` as a shared bounded prelude consumer
- update existing unreleased changelog bullets for the completed orchestration-command epic work

Closes #1075

## Verification

- `ruby -e "require 'yaml'; YAML.load_file('.ai-dev-workflow.yaml'); puts 'yaml ok'"`\n- `npx markdownlint-cli2 docs/workflow/development-workflow/bounded-run-prelude.md CHANGELOG.md`\n- `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md" docs/workflow/development-workflow/bounded-run-prelude.md`\n- `python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`\n- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`\n- `git diff --check && bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`\n- `bash scripts/development-workflow/tests/test-run-work-router.sh`\n\n## Self-review\n\n- Scope stays inside approved #1075 reconciliation: active guardrails audit defaults and bounded prelude documentation sync.\n- No command dispatch semantics changed; router behavior remains covered by existing tests.\n- Changelog updates amend existing unreleased epic entries instead of adding duplicate release notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and default YAML only; orchestration dispatch and router semantics are unchanged per the PR scope.
> 
> **Overview**
> Ships **required** guardrails audit defaults in `.ai-dev-workflow.yaml`: `pr_disposition_record` and `work_item_ledger_record` under `guardrails.audit`, so delegated template runs must record PR disposition and work-item ledger evidence per existing enforcement docs.
> 
> **Bounded run prelude** docs now treat **`/run-items`** like `/run-item` and `/run-epic`: shared prelude scope, an `--items` usage example, and a note to call `run-bounded-prelude.sh` before Protocol 90 `explicit_list` mutation.
> 
> **CHANGELOG** amends unreleased bullets (#1079, #1077) to mention audit defaults and prelude documentation—no new command or router behavior in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d100405cc0adfc4bc0d1f7595e440a06967035c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->