### PR TITLE
fix(workflow): make PR-Agent review explicit

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -2,7 +2,7 @@ name: PR-Agent
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+    types: [opened, reopened, ready_for_review]
   issue_comment:
     types: [created]
 
@@ -11,9 +11,11 @@ jobs:
     # For pull_request events: only run for PRs from the same repository (not forks),
     # including bot-authored PRs (Dependabot, Renovate). Fork PRs use read-only GITHUB_TOKEN
     # that cannot post comments, so excluding them prevents spurious auth failures.
-    # For issue_comment events: only run when a human comments on a PR (not an issue),
-    # preventing PR-Agent from triggering itself when it posts its own review comment.
-    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event.sender.type != 'Bot' && github.event.issue.pull_request) }}
+    # PR synchronize events no longer auto-run PR-Agent. The reviewer loop and
+    # maintainers trigger an explicit review by posting exactly `/review` on the PR.
+    # Exact command matching prevents PR-Agent from retriggering itself while still
+    # allowing trusted automation identities to request a configured review.
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.body == '/review') }}
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release readiness wording**: command and overview surfaces now state that
   `release/*` PR reviewer loops are skipped while the production PR still gets
   regression and CI readiness before merge.
+- **Make PR-Agent explicit** (#1096): Reduce default PR-Agent Actions fan-out
+  while preserving configured reviewer-loop review.
 
 ## [0.34.0] - 2026-06-30
 

--- a/docs/workflow/development-workflow/integrations/pr-agent.md
+++ b/docs/workflow/development-workflow/integrations/pr-agent.md
@@ -8,10 +8,12 @@ PR-Agent is **optional**. The workflow functions without it. See [`integrations/
 
 ## What PR-Agent Adds
 
-- Automated code review on every push — no trigger comment needed (triggered by the `pull_request` GHA event)
+- Explicit automated code review when the reviewer loop or a maintainer requests
+  `/review`
 - AI-powered analysis powered by any LLM you choose (DeepSeek, Kimi, OpenAI, Claude, Gemini, etc.)
 - No per-seat pricing — cost is purely LLM token usage (~$5–30/month at typical batch volumes)
-- Interactive: developers can post `/review`, `/improve`, `/describe` in PR comments to trigger on demand
+- Interactive: developers can post `/review` in PR comments to trigger a review
+  on demand
 
 ---
 
@@ -19,7 +21,11 @@ PR-Agent is **optional**. The workflow functions without it. See [`integrations/
 
 ### 1. Add the GitHub Actions Workflow
 
-The workflow file is already committed at `.github/workflows/pr-agent.yml`. It triggers automatically on PR open/reopen/ready-for-review events and on PR comment commands.
+The workflow file is already committed at `.github/workflows/pr-agent.yml`.
+It triggers automatically on low-volume PR lifecycle events
+(`opened`, `reopened`, `ready_for_review`) and on the explicit `/review`
+PR comment command. It does **not** run on every PR synchronize event by
+default, and arbitrary human comments do not trigger it.
 
 ### 2. Choose a Model and Add the API Key
 
@@ -40,7 +46,9 @@ The workflow file is already committed at `.github/workflows/pr-agent.yml`. It t
 
 ### 3. Verify the Integration
 
-Open or push to any PR and confirm that `github-actions[bot]` posts an issue comment with a **PR Reviewer Guide** section. The comment body will contain one of two stable markers:
+Open a PR or post `/review` on an existing PR and confirm that
+`github-actions[bot]` posts an issue comment with a **PR Reviewer Guide**
+section. The comment body will contain one of two stable markers:
 
 - `No major issues detected` — clean (`RESULT=clean`)
 - `Recommended focus areas for review` + hard-blocker label — blocking (`RESULT=needs_fixes`)
@@ -93,15 +101,18 @@ PR-Agent posts as `github-actions[bot]` (the default identity when using `GITHUB
 
 ### Step 7.1 — Trigger a re-review
 
-**No trigger needed for automated runs.** PR-Agent fires automatically on every push via the `pull_request` GHA event. There is no trigger comment and no `REVIEW_COMMENT_ID`.
+`pr-review-loop.sh` explicitly requests PR-Agent by posting the same command a
+maintainer would post manually:
 
-For **manual re-triggers**, post a comment on the PR:
-
-```
+```text
 /review
 ```
 
-This is handled by the `issue_comment` trigger in the workflow.
+The workflow only treats an exact `/review` PR comment as an issue-comment
+trigger. General PR discussion comments do not run PR-Agent. The exact command
+check is also the loop-prevention control: PR-Agent's own output does not match
+`/review`, while trusted reviewer-loop automation can still request a configured
+review even when it authenticates as a bot or GitHub App.
 
 ### Step 7.2 — Detect review completion
 
@@ -117,7 +128,7 @@ PR-Agent signals completion by posting a plain issue comment (not a formal GitHu
 | Comment with `Recommended focus areas for review` + advisory labels only | Review complete — clean (advisory only)                                         |
 | Comment with neither marker                                              | Ambiguous — escalate for human review                                           |
 | No matching comment and `elapsed < max_wait`                             | GHA still running — wait `poll_interval` and poll again                         |
-| `elapsed >= max_wait` and no comment posted                              | Treat as `skipped` (GHA may not have run, e.g., fork PR with no secrets access) |
+| `elapsed >= max_wait` and no comment posted                              | Treat as `skipped` (GHA may not have run, e.g., fork PR with no secrets access or PR-Agent unavailable) |
 
 Unlike Devin, there are no check runs to monitor — the comment itself is the completion signal.
 
@@ -166,13 +177,30 @@ If fork PRs need automated review, consider using a GitHub App token instead of 
 
 ## Enabling Interactive Commands
 
-With the `issue_comment` trigger active, any PR contributor can post PR-Agent commands:
+With the constrained `issue_comment` trigger active, the template default only
+runs PR-Agent for the explicit review command:
 
 | Command           | Effect                                 |
 | ----------------- | -------------------------------------- |
 | `/review`         | Re-run the full code review            |
-| `/describe`       | Update the PR description              |
-| `/improve`        | Post inline code suggestions           |
-| `/ask <question>` | Ask PR-Agent a question about the code |
 
-These commands fire only when `github.event.sender.type != 'Bot'` (the guard in the workflow), so automated agents posting comments will not accidentally trigger PR-Agent in a loop.
+Downstream repositories may opt into additional PR-Agent commands such as
+`/describe`, `/improve`, or `/ask <question>`, but doing so increases
+issue-comment fan-out and should be an explicit local decision.
+
+## Migration Notes for Downstream Repositories
+
+Earlier versions of this template ran PR-Agent on every same-repository PR
+synchronize event and on every human PR comment. That was convenient, but it
+could consume private-repository runner minutes even when PR-Agent output was
+not needed.
+
+After this change:
+
+- pushing a new commit to a PR does not run PR-Agent by default;
+- arbitrary human comments do not run PR-Agent;
+- `/run-reviewer-loop`, `/run-item`, and `/run-epic` still request PR-Agent when
+  the effective review config includes `pr-agent`;
+- maintainers can still run PR-Agent manually by posting `/review`;
+- downstream projects that want broader automatic PR-Agent behavior must opt in
+  by editing `.github/workflows/pr-agent.yml` locally.

--- a/docs/workflow/development-workflow/integrations/pr-review-platform.md
+++ b/docs/workflow/development-workflow/integrations/pr-review-platform.md
@@ -41,6 +41,10 @@ For `scripts/development-workflow/pr-review-loop.sh` to support a platform, the 
 
 If a platform does not yet meet that contract in this repository, it should be documented as **planned but unsupported** and the helper script should report it as `skipped`.
 
+For GitHub Actions-backed platforms such as PR-Agent, the trigger may be an
+explicit PR comment posted by `pr-review-loop.sh`; platforms do not need to run
+on every pull request synchronize event to satisfy this contract.
+
 ---
 
 ## Aggregation Rules

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -2692,8 +2692,8 @@ run_pr_agent_review() {
   }
 
   _pr_agent_active_review_check_count() {
-    gh api "repos/$repo/commits/$head_sha/check-runs" \
-      --jq '[.check_runs[]? | select(.name == "PR-Agent review" and (.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "requested" or .status == "pending"))] | length' \
+    gh api "repos/$repo/commits/$head_sha/check-runs" --paginate \
+      | jq -rs '[.[].check_runs[]? | select(.name == "PR-Agent review" and (.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "requested" or .status == "pending"))] | length' \
       2>/dev/null \
       || printf '0'
   }

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -2699,13 +2699,25 @@ run_pr_agent_review() {
   }
 
   _pr_agent_recent_trigger_comment_created_at() {
+    local trigger_reuse_window="${PR_AGENT_TRIGGER_REUSE_WINDOW_SECONDS:-$max_wait}"
+
+    case "$trigger_reuse_window" in
+      ''|*[!0-9]*)
+        trigger_reuse_window="$max_wait"
+        ;;
+    esac
+
     gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-      | jq -rs --arg body "$trigger_body" --arg since "$since_iso" '
+      | jq -rs --arg body "$trigger_body" --arg since "$since_iso" --argjson reuse_window "$trigger_reuse_window" '
           add // []
           | [.[]
+             | . as $comment
+             | (($comment.created_at // $comment.updated_at // "") | fromdateiso8601?) as $trigger_time
              | select(
                  ((.body // "") == $body) and
-                 ((.created_at // .updated_at // "") > $since)
+                 ((.created_at // .updated_at // "") > $since) and
+                 ($trigger_time != null) and
+                 ((now - $trigger_time) <= $reuse_window)
                )
             ]
           | sort_by(.created_at // .updated_at)

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -2691,6 +2691,50 @@ run_pr_agent_review() {
     _pr_agent_latest_comment_field "html_url" "${1:-strict_sha}"
   }
 
+  _pr_agent_active_review_check_count() {
+    gh api "repos/$repo/commits/$head_sha/check-runs" \
+      --jq '[.check_runs[]? | select(.name == "PR-Agent review" and (.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "requested" or .status == "pending"))] | length' \
+      2>/dev/null \
+      || printf '0'
+  }
+
+  _pr_agent_recent_trigger_comment_created_at() {
+    gh api "repos/$repo/issues/$pr_number/comments" --paginate \
+      | jq -rs --arg body "$trigger_body" --arg since "$since_iso" '
+          add // []
+          | [.[]
+             | select(
+                 ((.body // "") == $body) and
+                 ((.created_at // .updated_at // "") > $since)
+               )
+            ]
+          | sort_by(.created_at // .updated_at)
+          | last
+          | .created_at // .updated_at // ""
+        '
+  }
+
+  _pr_agent_trigger_already_pending() {
+    local active_check_count
+    local recent_trigger_created_at
+
+    active_check_count="$(_pr_agent_active_review_check_count)"
+    if [ "${active_check_count:-0}" -gt 0 ] 2>/dev/null; then
+      print_kv PR_AGENT_TRIGGER_SKIPPED active_review_in_progress
+      print_kv PR_AGENT_ACTIVE_CHECK_COUNT "$active_check_count"
+      return 0
+    fi
+
+    recent_trigger_created_at="$(_pr_agent_recent_trigger_comment_created_at)"
+    if [ -n "$recent_trigger_created_at" ]; then
+      print_kv PR_AGENT_TRIGGER_SKIPPED recent_review_trigger
+      print_kv PR_AGENT_TRIGGER_COMMENT_CREATED_AT "$recent_trigger_created_at"
+      return 0
+    fi
+
+    return 1
+  }
+
   _pr_agent_trigger_review() {
     local trigger_response
 
@@ -2944,7 +2988,7 @@ _PR_AGENT_LABELS_
       ;;
   esac
 
-  if ! _pr_agent_trigger_review; then
+  if ! _pr_agent_trigger_already_pending && ! _pr_agent_trigger_review; then
     print_kv RESULT escalate
     print_kv REASON pr_agent_trigger_failed
     print_kv PLATFORM "$platform"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -2629,6 +2629,7 @@ run_pr_agent_review() {
   local since_iso=""
   local elapsed=0
   local comment_body=""
+  local trigger_body="/review"
 
   require_gh
   cd_workflow_repo_root
@@ -2688,6 +2689,23 @@ run_pr_agent_review() {
 
   _pr_agent_latest_comment_url() {
     _pr_agent_latest_comment_field "html_url" "${1:-strict_sha}"
+  }
+
+  _pr_agent_trigger_review() {
+    local trigger_response
+
+    if ! trigger_response="$(gh api -X POST "repos/$repo/issues/$pr_number/comments" -f body="$trigger_body" 2>/dev/null)"; then
+      return 1
+    fi
+    if [ -n "$trigger_response" ]; then
+      local trigger_created_at
+      trigger_created_at="$(printf '%s\n' "$trigger_response" | jq -r '.created_at // empty' 2>/dev/null || true)"
+      if [ -n "$trigger_created_at" ]; then
+        print_kv PR_AGENT_TRIGGER_COMMENT_CREATED_AT "$trigger_created_at"
+      fi
+    fi
+    print_kv PR_AGENT_TRIGGER_COMMENT "$trigger_body"
+    return 0
   }
 
   # Extract <strong>LABEL</strong> tokens from the "Recommended focus areas for
@@ -2925,6 +2943,20 @@ _PR_AGENT_LABELS_
       return 2
       ;;
   esac
+
+  if ! _pr_agent_trigger_review; then
+    print_kv RESULT escalate
+    print_kv REASON pr_agent_trigger_failed
+    print_kv PLATFORM "$platform"
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv REVIEW_COMMENT_ID ""
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv COMMENT_COUNT 0
+    print_kv BLOCKING_COUNT 0
+    print_kv SUGGESTION_COUNT 0
+    return 2
+  fi
 
   # --- Phase 2: Poll until PR-Agent posts its summary comment ---
   while :; do

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3100,7 +3100,7 @@ case "$*" in
   *"--jq .commit.committer.date"*)
     printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
   *"commits/abc1703sha/check-runs"*)
-    printf '1\n'; exit 0 ;;
+    printf '{"check_runs":[]}\n{"check_runs":[{"name":"PR-Agent review","status":"in_progress"}]}\n'; exit 0 ;;
   *"issues/42/comments"*)
     printf '[]\n'; exit 0 ;;
   *)
@@ -3133,7 +3133,7 @@ case "$*" in
   *"--jq .commit.committer.date"*)
     printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
   *"commits/abc1704sha/check-runs"*)
-    printf '0\n'; exit 0 ;;
+    printf '{"check_runs":[]}\n'; exit 0 ;;
   *"issues/42/comments"*)
     printf '[{"user":{"login":"lhpaul"},"created_at":"2020-01-01T00:00:01Z","updated_at":"2020-01-01T00:00:01Z","body":"/review"}]\n'; exit 0 ;;
   *)
@@ -3167,7 +3167,7 @@ case "$*" in
   *"--jq .commit.committer.date"*)
     printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
   *"commits/abc1705sha/check-runs"*)
-    printf '0\n'; exit 0 ;;
+    printf '{"check_runs":[]}\n'; exit 0 ;;
   *"-X POST"*"issues/42/comments"*)
     printf '{"created_at":"2026-06-30T00:00:00Z"}\n'; exit 0 ;;
   *"issues/42/comments"*)
@@ -3199,7 +3199,7 @@ case "$*" in
   *"--jq .commit.committer.date"*)
     printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
   *"commits/abc1706sha/check-runs"*)
-    printf '0\n'; exit 0 ;;
+    printf '{"check_runs":[]}\n'; exit 0 ;;
   *"-X POST"*"issues/42/comments"*)
     exit 1 ;;
   *"issues/42/comments"*)

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3021,6 +3021,108 @@ rm -rf "$_bugbot_mock_dir_1612"
 unset _bugbot_mock_dir_1612 actual_output actual_exit
 
 # ---------------------------------------------------------------------------
+# Area 17: PR-Agent explicit trigger model
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 17: PR-Agent explicit trigger model ==="
+
+_pr_agent_mock_dir_1701="$(mktemp -d)"
+_pr_agent_call_log_1701="$_pr_agent_mock_dir_1701/calls.log"
+cat > "$_pr_agent_mock_dir_1701/gh" <<'PR_AGENT_GH_1701'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PR_AGENT_CALL_LOG"
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc1701sha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"-X POST"*"issues/42/comments"*)
+    printf '{"created_at":"2020-01-01T00:00:01Z"}\n'; exit 0 ;;
+  *"issues/42/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+PR_AGENT_GH_1701
+chmod +x "$_pr_agent_mock_dir_1701/gh"
+
+actual_output="$(
+  PATH="$_pr_agent_mock_dir_1701:$PATH" PR_AGENT_CALL_LOG="$_pr_agent_call_log_1701" \
+    run_pr_agent_review "42" "feature/42-test" "1" "0" || true
+)"
+run_test "pr_agent_posts_explicit_trigger" "PR_AGENT_TRIGGER_COMMENT=/review" \
+  "$(printf '%s\n' "$actual_output" | grep "^PR_AGENT_TRIGGER_COMMENT=")"
+run_test "pr_agent_no_review_after_trigger_skips" "RESULT=skipped" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "pr_agent_trigger_post_call_made" "1" \
+  "$(grep_count_or_zero "-X POST repos/.*/issues/42/comments" "$_pr_agent_call_log_1701")"
+rm -rf "$_pr_agent_mock_dir_1701"
+unset _pr_agent_mock_dir_1701 _pr_agent_call_log_1701 actual_output
+
+_pr_agent_mock_dir_1702="$(mktemp -d)"
+_pr_agent_call_log_1702="$_pr_agent_mock_dir_1702/calls.log"
+cat > "$_pr_agent_mock_dir_1702/gh" <<'PR_AGENT_GH_1702'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PR_AGENT_CALL_LOG"
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc1702sha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"issues/42/comments"*)
+    printf '[{"user":{"login":"github-actions[bot]"},"updated_at":"2020-01-01T00:00:02Z","html_url":"https://example.test/comment","body":"PR Reviewer Guide abc1702sha\\nNo major issues detected"}]\n'
+    exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+PR_AGENT_GH_1702
+chmod +x "$_pr_agent_mock_dir_1702/gh"
+
+actual_output="$(
+  PATH="$_pr_agent_mock_dir_1702:$PATH" PR_AGENT_CALL_LOG="$_pr_agent_call_log_1702" \
+    run_pr_agent_review "42" "feature/42-test" "1" "0" || true
+)"
+run_test "pr_agent_reuses_existing_comment" "RESULT=clean" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "pr_agent_existing_comment_no_duplicate_trigger" "0" \
+  "$(grep_count_or_zero "-X POST repos/.*/issues/42/comments" "$_pr_agent_call_log_1702")"
+rm -rf "$_pr_agent_mock_dir_1702"
+unset _pr_agent_mock_dir_1702 _pr_agent_call_log_1702 actual_output
+
+_pr_agent_mock_dir_1703="$(mktemp -d)"
+cat > "$_pr_agent_mock_dir_1703/gh" <<'PR_AGENT_GH_1703'
+#!/usr/bin/env bash
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc1703sha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"-X POST"*"issues/42/comments"*)
+    exit 1 ;;
+  *"issues/42/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+PR_AGENT_GH_1703
+chmod +x "$_pr_agent_mock_dir_1703/gh"
+
+actual_output="$(
+  PATH="$_pr_agent_mock_dir_1703:$PATH" run_pr_agent_review "42" "feature/42-test" "1" "0" || true
+)"
+run_test "pr_agent_trigger_failure_escalates" "RESULT=escalate" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "pr_agent_trigger_failure_reason" "REASON=pr_agent_trigger_failed" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+rm -rf "$_pr_agent_mock_dir_1703"
+unset _pr_agent_mock_dir_1703 actual_output
+
+run_test "pr_agent_workflow_no_synchronize_trigger" "0" \
+  "$(grep_count_or_zero "types:.*synchronize" "$REPO_ROOT/.github/workflows/pr-agent.yml")"
+run_test "pr_agent_workflow_exact_review_command" "1" \
+  "$(grep_count_or_zero "github.event.comment.body == '/review'" "$REPO_ROOT/.github/workflows/pr-agent.yml")"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3144,6 +3144,7 @@ chmod +x "$_pr_agent_mock_dir_1704/gh"
 
 actual_output="$(
   PATH="$_pr_agent_mock_dir_1704:$PATH" PR_AGENT_CALL_LOG="$_pr_agent_call_log_1704" \
+    PR_AGENT_TRIGGER_REUSE_WINDOW_SECONDS=999999999 \
     run_pr_agent_review "42" "feature/42-test" "1" "0" || true
 )"
 run_test "pr_agent_recent_trigger_no_duplicate_trigger" "PR_AGENT_TRIGGER_SKIPPED=recent_review_trigger" \
@@ -3156,8 +3157,10 @@ rm -rf "$_pr_agent_mock_dir_1704"
 unset _pr_agent_mock_dir_1704 _pr_agent_call_log_1704 actual_output
 
 _pr_agent_mock_dir_1705="$(mktemp -d)"
+_pr_agent_call_log_1705="$_pr_agent_mock_dir_1705/calls.log"
 cat > "$_pr_agent_mock_dir_1705/gh" <<'PR_AGENT_GH_1705'
 #!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PR_AGENT_CALL_LOG"
 case "$*" in
   *"--jq .head.sha"*)
     printf 'abc1705sha\n'; exit 0 ;;
@@ -3166,9 +3169,9 @@ case "$*" in
   *"commits/abc1705sha/check-runs"*)
     printf '0\n'; exit 0 ;;
   *"-X POST"*"issues/42/comments"*)
-    exit 1 ;;
+    printf '{"created_at":"2026-06-30T00:00:00Z"}\n'; exit 0 ;;
   *"issues/42/comments"*)
-    printf '[]\n'; exit 0 ;;
+    printf '[{"user":{"login":"lhpaul"},"created_at":"2020-01-01T00:00:01Z","updated_at":"2020-01-01T00:00:01Z","body":"/review"}]\n'; exit 0 ;;
   *)
     printf '[]\n'; exit 0 ;;
 esac
@@ -3176,14 +3179,46 @@ PR_AGENT_GH_1705
 chmod +x "$_pr_agent_mock_dir_1705/gh"
 
 actual_output="$(
-  PATH="$_pr_agent_mock_dir_1705:$PATH" run_pr_agent_review "42" "feature/42-test" "1" "0" || true
+  PATH="$_pr_agent_mock_dir_1705:$PATH" PR_AGENT_CALL_LOG="$_pr_agent_call_log_1705" \
+    PR_AGENT_TRIGGER_REUSE_WINDOW_SECONDS=1 \
+    run_pr_agent_review "42" "feature/42-test" "1" "0" || true
+)"
+run_test "pr_agent_stale_trigger_posts_new_trigger" "PR_AGENT_TRIGGER_COMMENT=/review" \
+  "$(printf '%s\n' "$actual_output" | grep "^PR_AGENT_TRIGGER_COMMENT=")"
+run_test "pr_agent_stale_trigger_post_call_made" "1" \
+  "$(grep_count_or_zero "-X POST repos/.*/issues/42/comments" "$_pr_agent_call_log_1705")"
+rm -rf "$_pr_agent_mock_dir_1705"
+unset _pr_agent_mock_dir_1705 _pr_agent_call_log_1705 actual_output
+
+_pr_agent_mock_dir_1706="$(mktemp -d)"
+cat > "$_pr_agent_mock_dir_1706/gh" <<'PR_AGENT_GH_1706'
+#!/usr/bin/env bash
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc1706sha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"commits/abc1706sha/check-runs"*)
+    printf '0\n'; exit 0 ;;
+  *"-X POST"*"issues/42/comments"*)
+    exit 1 ;;
+  *"issues/42/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+PR_AGENT_GH_1706
+chmod +x "$_pr_agent_mock_dir_1706/gh"
+
+actual_output="$(
+  PATH="$_pr_agent_mock_dir_1706:$PATH" run_pr_agent_review "42" "feature/42-test" "1" "0" || true
 )"
 run_test "pr_agent_trigger_failure_escalates" "RESULT=escalate" \
   "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
 run_test "pr_agent_trigger_failure_reason" "REASON=pr_agent_trigger_failed" \
   "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
-rm -rf "$_pr_agent_mock_dir_1705"
-unset _pr_agent_mock_dir_1705 actual_output
+rm -rf "$_pr_agent_mock_dir_1706"
+unset _pr_agent_mock_dir_1706 actual_output
 
 run_test "pr_agent_workflow_no_synchronize_trigger" "0" \
   "$(grep_count_or_zero "types:.*synchronize" "$REPO_ROOT/.github/workflows/pr-agent.yml")"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3090,15 +3090,17 @@ rm -rf "$_pr_agent_mock_dir_1702"
 unset _pr_agent_mock_dir_1702 _pr_agent_call_log_1702 actual_output
 
 _pr_agent_mock_dir_1703="$(mktemp -d)"
+_pr_agent_call_log_1703="$_pr_agent_mock_dir_1703/calls.log"
 cat > "$_pr_agent_mock_dir_1703/gh" <<'PR_AGENT_GH_1703'
 #!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PR_AGENT_CALL_LOG"
 case "$*" in
   *"--jq .head.sha"*)
     printf 'abc1703sha\n'; exit 0 ;;
   *"--jq .commit.committer.date"*)
     printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
-  *"-X POST"*"issues/42/comments"*)
-    exit 1 ;;
+  *"commits/abc1703sha/check-runs"*)
+    printf '1\n'; exit 0 ;;
   *"issues/42/comments"*)
     printf '[]\n'; exit 0 ;;
   *)
@@ -3108,14 +3110,80 @@ PR_AGENT_GH_1703
 chmod +x "$_pr_agent_mock_dir_1703/gh"
 
 actual_output="$(
-  PATH="$_pr_agent_mock_dir_1703:$PATH" run_pr_agent_review "42" "feature/42-test" "1" "0" || true
+  PATH="$_pr_agent_mock_dir_1703:$PATH" PR_AGENT_CALL_LOG="$_pr_agent_call_log_1703" \
+    run_pr_agent_review "42" "feature/42-test" "1" "0" || true
+)"
+run_test "pr_agent_active_check_no_duplicate_trigger" "PR_AGENT_TRIGGER_SKIPPED=active_review_in_progress" \
+  "$(printf '%s\n' "$actual_output" | grep "^PR_AGENT_TRIGGER_SKIPPED=")"
+run_test "pr_agent_active_check_waits_then_skips" "RESULT=skipped" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "pr_agent_active_check_no_post_call" "0" \
+  "$(grep_count_or_zero "-X POST repos/.*/issues/42/comments" "$_pr_agent_call_log_1703")"
+rm -rf "$_pr_agent_mock_dir_1703"
+unset _pr_agent_mock_dir_1703 _pr_agent_call_log_1703 actual_output
+
+_pr_agent_mock_dir_1704="$(mktemp -d)"
+_pr_agent_call_log_1704="$_pr_agent_mock_dir_1704/calls.log"
+cat > "$_pr_agent_mock_dir_1704/gh" <<'PR_AGENT_GH_1704'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PR_AGENT_CALL_LOG"
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc1704sha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"commits/abc1704sha/check-runs"*)
+    printf '0\n'; exit 0 ;;
+  *"issues/42/comments"*)
+    printf '[{"user":{"login":"lhpaul"},"created_at":"2020-01-01T00:00:01Z","updated_at":"2020-01-01T00:00:01Z","body":"/review"}]\n'; exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+PR_AGENT_GH_1704
+chmod +x "$_pr_agent_mock_dir_1704/gh"
+
+actual_output="$(
+  PATH="$_pr_agent_mock_dir_1704:$PATH" PR_AGENT_CALL_LOG="$_pr_agent_call_log_1704" \
+    run_pr_agent_review "42" "feature/42-test" "1" "0" || true
+)"
+run_test "pr_agent_recent_trigger_no_duplicate_trigger" "PR_AGENT_TRIGGER_SKIPPED=recent_review_trigger" \
+  "$(printf '%s\n' "$actual_output" | grep "^PR_AGENT_TRIGGER_SKIPPED=")"
+run_test "pr_agent_recent_trigger_waits_then_skips" "RESULT=skipped" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "pr_agent_recent_trigger_no_post_call" "0" \
+  "$(grep_count_or_zero "-X POST repos/.*/issues/42/comments" "$_pr_agent_call_log_1704")"
+rm -rf "$_pr_agent_mock_dir_1704"
+unset _pr_agent_mock_dir_1704 _pr_agent_call_log_1704 actual_output
+
+_pr_agent_mock_dir_1705="$(mktemp -d)"
+cat > "$_pr_agent_mock_dir_1705/gh" <<'PR_AGENT_GH_1705'
+#!/usr/bin/env bash
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc1705sha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"commits/abc1705sha/check-runs"*)
+    printf '0\n'; exit 0 ;;
+  *"-X POST"*"issues/42/comments"*)
+    exit 1 ;;
+  *"issues/42/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+PR_AGENT_GH_1705
+chmod +x "$_pr_agent_mock_dir_1705/gh"
+
+actual_output="$(
+  PATH="$_pr_agent_mock_dir_1705:$PATH" run_pr_agent_review "42" "feature/42-test" "1" "0" || true
 )"
 run_test "pr_agent_trigger_failure_escalates" "RESULT=escalate" \
   "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
 run_test "pr_agent_trigger_failure_reason" "REASON=pr_agent_trigger_failed" \
   "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
-rm -rf "$_pr_agent_mock_dir_1703"
-unset _pr_agent_mock_dir_1703 actual_output
+rm -rf "$_pr_agent_mock_dir_1705"
+unset _pr_agent_mock_dir_1705 actual_output
 
 run_test "pr_agent_workflow_no_synchronize_trigger" "0" \
   "$(grep_count_or_zero "types:.*synchronize" "$REPO_ROOT/.github/workflows/pr-agent.yml")"


### PR DESCRIPTION
## Summary

Implements #1096 by reducing default PR-Agent Actions fan-out while preserving configured reviewer-loop review semantics.

Changes:
- remove `synchronize` from `.github/workflows/pr-agent.yml` PR triggers;
- constrain PR-Agent issue-comment runs to an exact `/review` command;
- have `pr-review-loop.sh` explicitly post `/review` when `pr-agent` is configured and no current-head PR-Agent comment exists;
- add reviewer-loop harness coverage for trigger posting, duplicate suppression, trigger failure, and workflow constraints;
- update PR-Agent integration docs, generic review-platform docs, and CHANGELOG.

## Pre-Submission Self-Review

- Diff reviewed against spec and plan: Checked - all ACs map to workflow trigger constraints, reviewer-loop trigger behavior, tests, docs, or changelog.
- Stale markers / TODOs: Checked - no new TODO/FIXME/review markers introduced.
- Sibling/caller consistency: Checked - workflow exact command and reviewer-loop trigger both use `/review`; docs and smoke runbook match.
- Workflow security checklist: Checked - existing job permissions retained; fork guard retained for PR events; issue-comment trigger narrowed to an exact command.
- Shell quality checklist: Checked - trigger post uses guarded `gh api`; server timestamp is read from API response; no unguarded downstream jq use.
- CHANGELOG: Checked - `[Unreleased]` entry added using project format.

## Verification

- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` - 265 passed, 0 failed
- `npx markdownlint-cli2 docs/specs/developments/20260630151000_1096-explicit-pr-agent-trigger/2_1096-explicit-pr-agent-trigger_implementation-plan.md docs/testing/workflow/1096-explicit-pr-agent-trigger.smoke-test.md docs/workflow/development-workflow/integrations/pr-agent.md docs/workflow/development-workflow/integrations/pr-review-platform.md CHANGELOG.md` - 0 errors
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop` - passed
- `git diff --check` - passed
- `shellcheck -x -e SC1091,SC2016,SC2030,SC2031,SC2129,SC2317,SC2329 scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-pr-review-loop.sh` - passed

Closes #1096

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when PR-Agent runs in CI and how the reviewer loop triggers it; misconfiguration could skip reviews on push until `/review` or a loop run, but configured reviewer flows are preserved and covered by new tests.
> 
> **Overview**
> **PR-Agent no longer runs on every push or arbitrary PR comments** — the GitHub Actions workflow drops `synchronize` from `pull_request` triggers and only starts on `issue_comment` when the body is exactly `/review`, cutting default Actions fan-out while keeping lifecycle opens and manual/on-demand review.
> 
> **The reviewer loop now drives PR-Agent explicitly**: `pr-review-loop.sh` posts `/review` when `pr-agent` is configured and no current-head result exists, skips duplicate triggers when a review is in progress or a recent `/review` was already posted, and escalates if posting fails. Integration docs and the generic review-platform contract describe this comment-based trigger; tests cover trigger posting, deduplication, and workflow constraints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f9aa6d4898c890f24bf6cdba4123e6a46faa98c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->