### PR TITLE
fix(workflow): make reviewer guard event-driven

### DIFF
--- a/.github/workflows/reviewer-loop-guard.yml
+++ b/.github/workflows/reviewer-loop-guard.yml
@@ -7,20 +7,17 @@
 #   ### Automated Reviewer Loop Summary
 #   *Posted automatically by `pr-review-loop.sh`.*
 #
+# Event model:
+#   pull_request_target — performs one fast summary check and posts the
+#     PR-scoped status immediately. Missing summaries fail without sleeping.
+#   issue_comment — ignores non-PR and non-summary comments, then re-checks the
+#     PR comments and posts success when the canonical summary is present.
+#
 # In-scope branch prefixes (configurable via IN_SCOPE_PREFIXES env var):
 #   feature/  fix/  refactor/  hotfix/
 #
-# Explicit comment-existence polling (configurable via env vars):
-#   GUARD_MAX_WAIT      — total seconds to wait for the summary comment (default: 600)
-#   GUARD_POLL_INTERVAL — seconds to wait between polls (default: 30)
-#   Together these allow up to GUARD_MAX_WAIT seconds of polling so
-#   pr-review-loop.sh can finish posting its summary before the guard fails.
-#   The guard polls repeatedly until either the comment is found or GUARD_MAX_WAIT
-#   seconds have elapsed. This explicit comment-existence check is robust regardless
-#   of how long pr-review-loop.sh takes to post — it eliminates the timing race
-#   that occurred with the previous fixed-count grace-period approach.
-#
 # Branches outside the in-scope list always pass (status set to success).
+# Fork-head PRs are skipped and do not receive guard statuses from this workflow.
 #
 # The commit-status context name uses a PR-number suffix
 # ("Reviewer-loop completion guard (#<PR_NUMBER>)") to prevent two PRs that
@@ -39,35 +36,85 @@ name: Reviewer-loop completion guard
 on:
   pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize]
+  issue_comment:
+    types: [created, edited]
 
 concurrency:
-  group: reviewer-loop-guard-${{ github.event.pull_request.number }}
+  group: reviewer-loop-guard-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   guard:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
     runs-on: ubuntu-latest
     permissions:
+      issues: read
       pull-requests: read
       statuses: write
 
     steps:
       - name: Check for Automated Reviewer Loop Summary comment
-        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_NAME: ${{ github.event_name }}
           REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          BRANCH: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_BRANCH: ${{ github.event.pull_request.head.ref }}
+          EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
           # Override IN_SCOPE_PREFIXES in your repository to customise which branches
           # are subject to this guard. Default covers the four standard implementation
           # prefixes. Branches outside this list always pass.
           IN_SCOPE_PREFIXES: "feature/ fix/ refactor/ hotfix/"
         run: |
+          set -euo pipefail
+
+          MARKER1="### Automated Reviewer Loop Summary"
+          # shellcheck disable=SC2016
+          MARKER2='*Posted automatically by `pr-review-loop.sh`.*'
+
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            case "$COMMENT_BODY" in
+              *"$MARKER1"*"$MARKER2"*|*"$MARKER2"*"$MARKER1"*) ;;
+              *)
+                echo "Issue comment does not contain the canonical reviewer-loop summary markers; skipping."
+                exit 0
+                ;;
+            esac
+          fi
+
+          if ! pr_json="$(gh api "repos/$REPO/pulls/$PR_NUMBER")"; then
+            echo "ERROR: failed to fetch PR #${PR_NUMBER} metadata."
+            exit 1
+          fi
+
+          if ! HEAD_SHA="$(printf '%s\n' "$pr_json" | jq -er '.head.sha')"; then
+            echo "ERROR: pull request head SHA is missing for PR #${PR_NUMBER}." >&2
+            exit 1
+          fi
+          if ! BRANCH="$(printf '%s\n' "$pr_json" | jq -er '.head.ref')"; then
+            echo "ERROR: pull request head branch is missing for PR #${PR_NUMBER}." >&2
+            exit 1
+          fi
+          if ! HEAD_REPO="$(printf '%s\n' "$pr_json" | jq -er '.head.repo.full_name')"; then
+            echo "ERROR: pull request head repository is missing for PR #${PR_NUMBER}." >&2
+            exit 1
+          fi
+
+          if [ "$EVENT_NAME" != "issue_comment" ]; then
+            HEAD_SHA="${EVENT_HEAD_SHA:-$HEAD_SHA}"
+            BRANCH="${EVENT_BRANCH:-$BRANCH}"
+            HEAD_REPO="${EVENT_HEAD_REPO:-$HEAD_REPO}"
+          fi
+
           echo "PR #${PR_NUMBER}: evaluating branch '${BRANCH}' against in-scope prefixes: ${IN_SCOPE_PREFIXES}"
 
-          # Check whether the branch matches any in-scope prefix
+          if [ "$HEAD_REPO" != "$REPO" ]; then
+            echo "PR #${PR_NUMBER} head repository '${HEAD_REPO}' differs from base '${REPO}'; skipping guard status."
+            exit 0
+          fi
+
           in_scope=false
           for prefix in $IN_SCOPE_PREFIXES; do
             if [[ "$BRANCH" == "${prefix}"* ]]; then
@@ -76,13 +123,10 @@ jobs:
             fi
           done
 
-          # Build the PR-specific context name: including the PR number prevents two
-          # PRs that share the same commit SHA (e.g. a release PR and its backport)
-          # from overwriting each other's guard result.
           GUARD_CONTEXT="Reviewer-loop completion guard (#${PR_NUMBER})"
 
           if [ "$in_scope" = "false" ]; then
-            echo "Branch '${BRANCH}' is not in scope — posting success status (guard skipped)."
+            echo "Branch '${BRANCH}' is not in scope; posting success status (guard skipped)."
             gh api \
               --method POST \
               "repos/$REPO/statuses/$HEAD_SHA" \
@@ -92,88 +136,34 @@ jobs:
             exit 0
           fi
 
-          echo "Branch '${BRANCH}' is in scope — inspecting PR comments for reviewer-loop summary."
+          echo "Branch '${BRANCH}' is in scope; inspecting PR comments for reviewer-loop summary."
 
-          # Fetch all PR comments and check for the canonical two-marker combination.
-          # Both markers must be present in the same comment body.
-          # MARKER1: "### Automated Reviewer Loop Summary"
-          # MARKER2: the "Posted automatically by pr-review-loop.sh" attribution line
-          # (passed via jq --arg to avoid inline quoting of backtick characters).
-          MARKER1="### Automated Reviewer Loop Summary"
-          # shellcheck disable=SC2016
-          MARKER2='*Posted automatically by `pr-review-loop.sh`.*'
+          if ! FOUND="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            | jq -rs --arg m1 "$MARKER1" --arg m2 "$MARKER2" \
+            'add // []
+            | [.[] | select(
+              (.body // "" | contains($m1)) and
+              (.body // "" | contains($m2))
+            )] | length')"; then
+            echo "ERROR: failed to fetch PR comments; posting retry-oriented failure status."
+            gh api \
+              --method POST \
+              "repos/$REPO/statuses/$HEAD_SHA" \
+              -f state="failure" \
+              -f description="Could not fetch PR comments. Re-run the workflow to retry." \
+              -f context="$GUARD_CONTEXT"
+            exit 1
+          fi
 
-          # Explicit comment-existence polling: pr-review-loop.sh posts its summary
-          # after the reviewer loop finishes, which can take several minutes on slow
-          # runners or when reviewer bots take time to respond. The previous fixed-count
-          # grace period (3 × 30 s = 90 s) proved insufficient across multiple batches.
-          #
-          # This loop polls every GUARD_POLL_INTERVAL seconds until either:
-          #   (a) the summary comment is found — guard passes immediately, or
-          #   (b) GUARD_MAX_WAIT total seconds have elapsed — guard fails.
-          #
-          # Defaults: 30 s interval, 600 s max wait (up to 21 poll attempts).
-          # Override via env vars in the workflow dispatch or repository variables.
-          GUARD_MAX_WAIT="${GUARD_MAX_WAIT:-600}"
-          GUARD_POLL_INTERVAL="${GUARD_POLL_INTERVAL:-30}"
-          case "$GUARD_MAX_WAIT" in
-            ''|0|*[!0-9]*) echo "ERROR: GUARD_MAX_WAIT must be a positive integer (got: '$GUARD_MAX_WAIT')" >&2; exit 1 ;;
-          esac
-          case "$GUARD_POLL_INTERVAL" in
-            ''|0|*[!0-9]*) echo "ERROR: GUARD_POLL_INTERVAL must be a positive integer (got: '$GUARD_POLL_INTERVAL')" >&2; exit 1 ;;
-          esac
-
-          FOUND=0
-          elapsed=0
-          poll=0
-          while true; do
-            poll=$((poll + 1))
-            echo "Poll attempt ${poll} (elapsed: ${elapsed}s / max: ${GUARD_MAX_WAIT}s): fetching PR comments..."
-            # gh api --paginate | jq -s produces [[page1_items], [page2_items], ...].
-            # Use 'add // []' to flatten pages before selecting comment objects.
-            FOUND=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
-              --paginate \
-              | jq -rs --arg m1 "$MARKER1" --arg m2 "$MARKER2" \
-              'add // []
-              | [.[] | select(
-                (.body // "" | contains($m1)) and
-                (.body // "" | contains($m2))
-              )] | length') || {
-              echo "ERROR: failed to fetch PR comments — treating as transient failure (posting failure status)."
-              gh api \
-                --method POST \
-                "repos/$REPO/statuses/$HEAD_SHA" \
-                -f state="failure" \
-                -f description="Could not fetch PR comments. Re-run the workflow to retry." \
-                -f context="$GUARD_CONTEXT"
-              exit 1
-            }
-            echo "Reviewer-loop summary comments found: ${FOUND}"
-            if [ "${FOUND:-0}" -gt 0 ]; then
-              break
-            fi
-            # Check whether we have exceeded the maximum wait time
-            if [ "$elapsed" -ge "$GUARD_MAX_WAIT" ]; then
-              echo "Maximum wait time (${GUARD_MAX_WAIT}s) exceeded without finding the summary comment."
-              break
-            fi
-            # Sleep for the poll interval, but not longer than the remaining wait budget
-            remaining=$((GUARD_MAX_WAIT - elapsed))
-            sleep_time=$GUARD_POLL_INTERVAL
-            if [ "$sleep_time" -gt "$remaining" ]; then
-              sleep_time=$remaining
-            fi
-            echo "Summary not yet present — waiting ${sleep_time}s before next poll."
-            sleep "$sleep_time"
-            elapsed=$((elapsed + sleep_time))
-          done
+          echo "Reviewer-loop summary comments found: ${FOUND}"
 
           if [ "${FOUND:-0}" -gt 0 ]; then
             STATE="success"
             DESCRIPTION="Reviewer-loop summary present."
           else
             STATE="failure"
-            DESCRIPTION="No reviewer-loop summary found after ${elapsed}s. Run the automated reviewer loop before merging."
+            DESCRIPTION="No reviewer-loop summary found. Run the automated reviewer loop before merging."
           fi
 
           gh api \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regression and CI readiness before merge.
 - **Make PR-Agent explicit** (#1096): Reduce default PR-Agent Actions fan-out
   while preserving configured reviewer-loop review.
+- **Event-driven reviewer guard** (#1097): Replace default long reviewer-loop
+  guard polling with a fast PR check plus summary-comment readiness refresh.
 
 ## [0.34.0] - 2026-06-30
 

--- a/docs/testing/workflow/1097-event-driven-reviewer-guard.smoke-test.md
+++ b/docs/testing/workflow/1097-event-driven-reviewer-guard.smoke-test.md
@@ -115,10 +115,17 @@ the fork-head pull request, matching the existing same-repository restriction.
 ## Scenario 7: Local tests cover guard behavior
 
 1. Run the focused guard tests added by the implementation.
+
+   ```bash
+   bash scripts/development-workflow/tests/test-reviewer-loop-guard-workflow.sh
+   ```
+
 2. Run markdown and workflow shell validation.
 
-**Expected result**: Tests cover missing-summary, summary-present,
-summary-comment, non-summary comment, fork-head, and out-of-scope scenarios.
+**Expected result**: The focused test passes and covers the configured triggers,
+absence of default polling, summary marker matching, non-summary comment skips,
+fork-head skips, out-of-scope success, and the unchanged PR-scoped status
+context.
 
 ---
 

--- a/docs/testing/workflow/613-enforce-regression-label-and-reviewer-loop-via-ci.smoke-test.md
+++ b/docs/testing/workflow/613-enforce-regression-label-and-reviewer-loop-via-ci.smoke-test.md
@@ -69,7 +69,7 @@ Before running this smoke test:
 
 ### Step 2: Verify the reviewer-loop guard fails on the new PR
 
-1. Wait for the `reviewer-loop-guard` workflow run to complete on the fixture PR (typically < 60 s).
+1. Wait for the `reviewer-loop-guard` workflow run to complete on the fixture PR.
 2. Check the commit status:
 
    ```bash
@@ -121,14 +121,8 @@ Before running this smoke test:
 *Posted automatically by \`pr-review-loop.sh\`.*"
    ```
 
-2. Push a no-op commit to trigger the `synchronize` event:
-
-   ```bash
-   git commit --allow-empty -m "chore: trigger synchronize event for guard re-evaluation"
-   git push
-   ```
-
-3. Wait for the guard workflow to complete, then re-check the commit status:
+2. Wait for the guard's `issue_comment` event path to complete, then re-check
+   the commit status:
 
    ```bash
    HEAD_SHA=$(gh pr view "$PR_NUM" --json headRefOid --jq '.headRefOid')
@@ -140,6 +134,8 @@ Before running this smoke test:
 
 - `state` is `"success"`.
 - `description` indicates the reviewer-loop summary is present.
+- No extra push is required; the summary comment event refreshes readiness for
+  the current PR head SHA.
 - **Maps to**: Acceptance Criterion #6 (guard passes once the summary comment is present).
 
 ---
@@ -165,7 +161,7 @@ Before running this smoke test:
 
 **Expected result**:
 
-- A new status is posted for the new `HEAD_SHA` under context `Reviewer-loop completion guard (#<PR_NUMBER>)`.
+- A new status is posted quickly for the new `HEAD_SHA` under context `Reviewer-loop completion guard (#<PR_NUMBER>)`.
 - `state` reflects whether the canonical summary comment is present on the PR at evaluation time.
 - **Maps to**: Acceptance Criterion #7 (guard re-evaluates on every push).
 
@@ -275,7 +271,7 @@ Each checkbox maps to an acceptance criterion from the spec.
 - [ ] **AC #6**: After posting the canonical summary comment, the guard check transitioned to passing.
 - [ ] **AC #7**: A subsequent push caused the guard to re-evaluate and post a fresh status on the new SHA.
 - [ ] **AC #9** (defer to CI): Both workflow files pass `actionlint` with no new warnings (verified in the implementation PR's CI run).
-- [ ] **AC #10** (defer to CI): Each workflow declares only the minimum permissions required (`pull-requests: write` for the label workflow; `pull-requests: read` + `statuses: write` for the guard).
+- [ ] **AC #10** (defer to CI): Each workflow declares only the minimum permissions required (`pull-requests: write` for the label workflow; `issues: read` + `pull-requests: read` + `statuses: write` for the guard).
 
 ---
 
@@ -291,7 +287,7 @@ No seed data is required. The smoke test uses fixture branches and PRs created i
 | --- | --- | --- |
 | `apply-regression-label` workflow fails with "Label not found" | The `ready-for-regression` label does not exist in the repo and `gh label create --force` was not included | Verify the workflow includes the `gh label create --force` step before `gh pr edit --add-label` |
 | Guard workflow fails with a GitHub API error instead of a status check | `statuses: write` permission missing from the workflow | Add `statuses: write` under `permissions` in `reviewer-loop-guard.yml` |
-| Guard reports "failure" even after posting the summary comment | Comment body does not contain both required markers | Confirm the comment contains exactly `### Automated Reviewer Loop Summary` and `*Posted automatically by \`pr-review-loop.sh\`.*` |
+| Guard reports "failure" even after posting the summary comment | Comment body does not contain both required markers, or the `issue_comment` workflow did not run | Confirm the comment contains exactly `### Automated Reviewer Loop Summary` and `*Posted automatically by \`pr-review-loop.sh\`.*`; inspect the guard workflow run for the comment event |
 | Out-of-scope branch (`spec/*`) receives the label | `IN_SCOPE_PREFIXES` env var contains an unexpected value | Check the env var default in `apply-regression-label.yml`; ensure `spec/` is not included |
 | `actionlint` reports warnings on the new workflow files | YAML syntax issue or unsupported action reference | Fix the reported lines; re-run `actionlint` |
 
@@ -301,3 +297,5 @@ No seed data is required. The smoke test uses fixture branches and PRs created i
 
 - The guard check uses the GitHub Commit Statuses API (not Checks API). Some branch protection UIs surface statuses and checks in separate sections. Downstream maintainers must search for `Reviewer-loop completion guard (#<PR_NUMBER>)` in the "Statuses" section, not only under "GitHub Actions checks", when configuring branch protection. Because the context name includes the PR number, wildcard matching (e.g. via GitHub Rulesets) is required to enforce it as a required status check.
 - The smoke test steps require a repository where the workflows are active. This runbook cannot be executed entirely offline.
+- Fork-head PRs are skipped by the reviewer-loop guard and do not receive guard
+  statuses from this workflow.

--- a/docs/workflow/development-workflow/integrations/ci-enforcement.md
+++ b/docs/workflow/development-workflow/integrations/ci-enforcement.md
@@ -45,9 +45,13 @@ every commit batch.
 
 **File**: `.github/workflows/reviewer-loop-guard.yml`
 
-**What it does**: Posts a GitHub commit status check (`success` or `failure`) on
-every in-scope implementation PR push to assert that the automated reviewer-loop
-summary comment is present. The check is named
+**What it does**: Posts a GitHub commit status check (`success` or `failure`) for
+in-scope implementation PRs to assert that the automated reviewer-loop summary
+comment is present. Pull request events perform one fast summary check and post
+the PR-scoped status immediately; the workflow no longer sleeps or polls for
+several minutes by default. A summary `issue_comment` event re-checks the pull
+request comments and refreshes the passing status after `pr-review-loop.sh`
+posts the canonical summary. The check is named
 **"Reviewer-loop completion guard (#\<PR_NUMBER\>)"** — the PR number is included
 in the context name so that two PRs sharing the same commit SHA (e.g. a release
 PR and its backport) cannot overwrite each other's guard result.
@@ -66,9 +70,20 @@ changes to the reviewer-loop script's output contract are required.
 - `failure` (transient) — the GitHub API call to fetch comments failed; the
   workflow exits with code 1 so GitHub retries the check on the next event.
 
+**Comment-event behavior**: The `issue_comment` path only runs for pull request
+comments that contain the canonical summary markers. Normal comments do not
+change reviewer-loop readiness. When a summary comment is detected, the workflow
+fetches the pull request's current head SHA and branch before posting the status,
+so repeated or edited summary comments are idempotent for the current PR head.
+
 **Non-implementation branches always pass**: Branches whose prefix does not match
 `IN_SCOPE_PREFIXES` receive a `success` status with the description
 "Not an implementation branch; guard skipped."
+
+**Fork-head PRs are skipped**: The guard preserves the same-repository
+restriction used by the existing `pull_request_target` path. If the PR head
+repository differs from the base repository, the workflow exits without posting
+reviewer-loop readiness statuses.
 
 ---
 
@@ -166,7 +181,7 @@ repository.
 | Workflow | Permissions declared |
 | -------- | -------------------- |
 | `apply-regression-label.yml` | `pull-requests: write` (minimum required to add a label) |
-| `reviewer-loop-guard.yml` | `pull-requests: read`, `statuses: write` (minimum required to read comments and post a commit status) |
+| `reviewer-loop-guard.yml` | `issues: read`, `pull-requests: read`, `statuses: write` (minimum required to read comments, read PR metadata, and post a commit status) |
 
 No other permissions are requested. Both workflows use the default
 `GITHUB_TOKEN` injected by GitHub Actions and do not require any additional

--- a/scripts/development-workflow/tests/test-reviewer-loop-guard-workflow.sh
+++ b/scripts/development-workflow/tests/test-reviewer-loop-guard-workflow.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# test-reviewer-loop-guard-workflow.sh - Static checks for reviewer-loop guard workflow.
+#
+# Usage: bash scripts/development-workflow/tests/test-reviewer-loop-guard-workflow.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+WORKFLOW="$REPO_ROOT/.github/workflows/reviewer-loop-guard.yml"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+contains() {
+  local pattern="$1"
+  grep -Fq -- "$pattern" "$WORKFLOW" && echo yes || echo no
+}
+
+not_contains() {
+  local pattern="$1"
+  grep -Fq -- "$pattern" "$WORKFLOW" && echo no || echo yes
+}
+
+echo ""
+echo "=== Reviewer-loop guard workflow static checks ==="
+
+run_test "workflow_exists" "yes" "$([ -f "$WORKFLOW" ] && echo yes || echo no)"
+run_test "pull_request_target_trigger_present" "yes" "$(contains "pull_request_target:")"
+run_test "issue_comment_trigger_present" "yes" "$(contains "issue_comment:")"
+run_test "issue_comment_created_edited" "yes" "$(contains "types: [created, edited]")"
+run_test "pr_event_types_preserved" "yes" "$(contains "types: [opened, reopened, ready_for_review, synchronize]")"
+
+run_test "no_default_max_wait" "yes" "$(not_contains "GUARD_MAX_WAIT")"
+run_test "no_poll_interval" "yes" "$(not_contains "GUARD_POLL_INTERVAL")"
+run_test "no_sleep_polling" "yes" "$(not_contains "sleep ")"
+run_test "missing_summary_fails_without_elapsed_wait" "yes" "$(contains "No reviewer-loop summary found. Run the automated reviewer loop before merging.")"
+
+run_test "summary_marker_one_checked" "yes" "$(contains "MARKER1=\"### Automated Reviewer Loop Summary\"")"
+run_test "summary_marker_two_checked" "yes" "$(contains "MARKER2='*Posted automatically by \`pr-review-loop.sh\`.*'")"
+run_test "non_summary_comment_skips" "yes" "$(contains "Issue comment does not contain the canonical reviewer-loop summary markers; skipping.")"
+run_test "comment_path_fetches_current_pr" "yes" "$(contains 'gh api "repos/$REPO/pulls/$PR_NUMBER"')"
+run_test "comment_path_fetches_current_comments" "yes" "$(contains 'gh api "repos/$REPO/issues/$PR_NUMBER/comments"')"
+
+run_test "fork_head_guard_present" "yes" "$(contains 'HEAD_REPO" != "$REPO')"
+run_test "fork_head_skip_no_status" "yes" "$(contains "skipping guard status")"
+run_test "out_of_scope_success_preserved" "yes" "$(contains "Not an implementation branch; guard skipped.")"
+run_test "status_context_preserved" "yes" "$(contains 'Reviewer-loop completion guard (#${PR_NUMBER})')"
+run_test "in_scope_prefixes_preserved" "yes" "$(contains "IN_SCOPE_PREFIXES: \"feature/ fix/ refactor/ hotfix/\"")"
+
+run_test "permissions_include_issues_read" "yes" "$(contains "issues: read")"
+run_test "permissions_include_pull_requests_read" "yes" "$(contains "pull-requests: read")"
+run_test "permissions_include_statuses_write" "yes" "$(contains "statuses: write")"
+
+echo ""
+echo "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Replaces the reviewer-loop guard default long polling path with a fast PR-event summary check.
- Adds an `issue_comment` summary path that refreshes the PR-scoped status when `pr-review-loop.sh` posts its canonical summary.
- Preserves out-of-scope branch success semantics and skips fork-head PRs without posting readiness statuses.

## Spec and Plan
- Spec: `docs/specs/developments/20260630160033_1097-event-driven-reviewer-guard/1_1097-event-driven-reviewer-guard_specs.md`
- Plan: `docs/specs/developments/20260630160033_1097-event-driven-reviewer-guard/2_1097-event-driven-reviewer-guard_implementation-plan.md`
- Smoke: `docs/testing/workflow/1097-event-driven-reviewer-guard.smoke-test.md`

## Verification
- `bash scripts/development-workflow/tests/test-reviewer-loop-guard-workflow.sh`
- `shellcheck --severity=warning scripts/development-workflow/tests/test-reviewer-loop-guard-workflow.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop-actions-cost-reduction`
- `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `actionlint .github/workflows/reviewer-loop-guard.yml`
- `git diff --check`

## GitHub Actions Security Checklist
- Explicit permissions: `issues: read`, `pull-requests: read`, `statuses: write`.
- No third-party actions are used, so no `uses:` pins are required.
- Existing PR event scope is preserved; the added comment path ignores non-PR/non-summary comments.
- Existing concurrency remains PR-number scoped across PR and comment events.
- Same-repository head guard is preserved for both event paths; fork-head PRs are skipped before any status write.

## CHANGELOG
- `Fixed`: Event-driven reviewer guard (#1097).

## Pre-submission self-review
Pre-submission self-review: stale markers - none, caller consistency - verified across workflow/docs/runbooks, coverage - AC1-AC7 addressed by workflow behavior, static test, docs, and smoke runbook.

Closes #1097

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge-readiness timing for implementation PRs (immediate failure vs prior grace polling) and adds comment-triggered status writes, though markers, scope rules, and fork skipping stay aligned with existing CI enforcement docs.
> 
> **Overview**
> The **reviewer-loop completion guard** no longer sleeps or polls for up to several minutes waiting for `pr-review-loop.sh` to post its summary. On **`pull_request_target`** events it performs a single comment scan and posts **success** or **failure** immediately when the summary is missing.
> 
> A new **`issue_comment`** trigger (created/edited) re-runs the guard only when the comment body contains both canonical markers (`### Automated Reviewer Loop Summary` and the `pr-review-loop.sh` attribution line), so posting the summary can flip the PR-scoped status **without an extra push**. Non-summary comments and fork-head PRs are skipped; in-scope prefix rules and the `Reviewer-loop completion guard (#<PR>)` context are unchanged.
> 
> Docs, smoke runbooks, and **`test-reviewer-loop-guard-workflow.sh`** are updated to describe the event model, permissions (`issues: read`), and the new verification command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddbeec1c65eb28bff793b1f66f684e9277a412f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->