### PR TITLE
docs(plan): placeholder workflows opt-in

### DIFF
--- a/docs/specs/developments/20260701075304_1098-placeholder-workflows-opt-in/2_1098-placeholder-workflows-opt-in_implementation-plan.md
+++ b/docs/specs/developments/20260701075304_1098-placeholder-workflows-opt-in/2_1098-placeholder-workflows-opt-in_implementation-plan.md
@@ -1,0 +1,234 @@
+# Placeholder Workflows Opt-In - Implementation Plan
+
+**Spec**: [1_1098-placeholder-workflows-opt-in_specs.md](1_1098-placeholder-workflows-opt-in_specs.md)
+**Smoke test runbook**: [1098-placeholder-workflows-opt-in.smoke-test.md](../../../testing/workflow/1098-placeholder-workflows-opt-in.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Make the template placeholder deploy workflow manual-only with an
+explicit confirmation input, and keep the placeholder regression workflow
+label-compatible while preventing dependency and browser installation unless a
+downstream maintainer explicitly enables placeholder regression. Update the
+workflow integration docs and protocol references so they distinguish real
+project regression checks from inactive template scaffolding.
+
+**Estimated complexity**: M
+
+**Rationale**: The code changes are small, but they touch shared GitHub Actions
+defaults, workflow documentation, and static validation for behavior that
+downstream repositories inherit.
+
+**Dependencies**: None.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `471c3ae` |
+| Deploy placeholder default behavior | `rg -n "push:|workflow_dispatch|github.event_name == 'push'|deploy-(develop\|production)|Template placeholder" .github/workflows/deploy.yml` | `deploy.yml` currently has `push` triggers for `develop` and `main`, plus both placeholder jobs include `github.event_name == 'push'` clauses. |
+| Regression placeholder cost path | `rg -n "ready-for-regression|Install Playwright browsers|npx playwright install|npm ci|pull_request|ENABLE|vars\\." .github/workflows/e2e-regression.yml .github/workflows/apply-regression-label.yml docs/workflow/development-workflow/integrations/e2e-regression.md docs/workflow/development-workflow/integrations/ci-enforcement.md` | `e2e-regression.yml` currently runs on `pull_request` label/synchronize/reopened events and reaches `npm ci` plus `npx playwright install --with-deps chromium` whenever `ready-for-regression` is present; no opt-in variable is present. |
+| Existing label-gated protocol guidance | `rg -n "ready-for-regression|e2e/regression|regression" docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md \| head -80` | Protocols `05`, `91`, and `92` already require `ready-for-regression` for configured implementation and production release regression gates; wording needs clarification that inactive placeholders may skip until enabled or replaced. |
+| Documentation surfaces | `find docs/workflow/development-workflow/integrations docs/testing/workflow scripts/development-workflow/tests -maxdepth 1 -type f \| sort` | Existing integration docs include `ci-cd-deployment.md`, `e2e-regression.md`, and `ci-enforcement.md`; existing workflow test directory supports focused shell tests. |
+
+---
+
+## Layer-by-Layer Changes
+
+### Infrastructure / Configuration
+
+- [ ] Update `.github/workflows/deploy.yml` so placeholder deploy jobs no longer
+      run on default branch pushes. Keep `workflow_dispatch` and add an explicit
+      confirmation input for temporary placeholder validation. Both placeholder
+      jobs should require the manual dispatch event, matching environment input,
+      and the confirmation input before running.
+- [ ] Update `.github/workflows/e2e-regression.yml` so the workflow remains
+      compatible with the `ready-for-regression` label model, but the placeholder
+      `npm ci`, Playwright browser install, and test steps only run when an
+      explicit downstream opt-in is set. Use a clearly named repository variable
+      such as `ENABLE_TEMPLATE_PLACEHOLDER_REGRESSION=true`; an unset variable
+      must be treated as disabled.
+- [ ] Preserve the existing `pull_request` label/synchronize/reopened trigger
+      shape for regression so downstream repositories can replace the placeholder
+      with a real suite without changing the staged workflow's label semantics.
+- [ ] Do not modify `.github/workflows/apply-regression-label.yml` unless the
+      implementation discovers a direct label lifecycle bug. The label automation
+      should continue to apply `ready-for-regression`; the placeholder regression
+      workflow is responsible for treating the label as non-expensive until the
+      placeholder is enabled or replaced.
+
+### Documentation
+
+- [ ] Update deployment guidance to explain that template deploy placeholders
+      are inactive on push by default, how to run a temporary manual placeholder
+      validation, and how downstream projects should replace the placeholder with
+      real push-triggered deployment logic.
+- [ ] Update regression guidance to explain the opt-in variable for placeholder
+      regression, that an unset variable skips dependency and browser setup, and
+      that real project suites should remain label-gated by
+      `ready-for-regression` when configured.
+- [ ] Update CI enforcement guidance so the auto-applied
+      `ready-for-regression` label is described as a readiness signal for real
+      regression checks, not as permission for inactive placeholders to spend
+      runner minutes.
+- [ ] Update protocol wording in `05`, `91`, and `92` only where needed to
+      clarify that label-gated regression means configured real regression
+      checks or an explicitly enabled placeholder.
+
+### Shared Workflow Tests
+
+- [ ] Add `scripts/development-workflow/tests/test-placeholder-workflows-opt-in.sh`
+      with static checks for deploy push inactivity, regression opt-in gating,
+      preserved `ready-for-regression` trigger semantics, and documentation
+      coverage.
+- [ ] Ensure the test fails if `deploy.yml` reintroduces a default `push` trigger
+      for placeholder deploy jobs or if `e2e-regression.yml` can reach
+      dependency/browser install without the explicit opt-in guard.
+
+---
+
+## Testing Strategy
+
+**Test types**: Static shell validation, workflow syntax validation, markdown
+linting, and smoke/manual review.
+
+**Key scenarios to test**:
+
+1. Default deploy push is inactive - maps to AC1.
+2. Placeholder regression dependency and browser installation is blocked unless
+   opt-in is enabled - maps to AC2.
+3. `ready-for-regression` label automation remains intact but cannot by itself
+   trigger expensive placeholder regression work - maps to AC3 and AC7.
+4. Deployment activation docs explain replacing or explicitly validating the
+   placeholder - maps to AC4.
+5. Regression activation docs explain the opt-in variable and the real
+   label-gated replacement path - maps to AC5 and AC6.
+
+**Smoke test runbook**: `docs/testing/workflow/1098-placeholder-workflows-opt-in.smoke-test.md`
+
+**Regression suite**: Add
+`scripts/development-workflow/tests/test-placeholder-workflows-opt-in.sh` to the
+workflow test suite.
+
+### Parser-risk Addendum
+
+This plan is parser-risk because the new shell test statically scans GitHub
+Actions YAML and markdown documentation with structured-text checks.
+
+- **Edge-case enumeration**:
+  - Deploy workflow has a top-level `push:` trigger active in the `on:` block.
+  - Deploy workflow has only `workflow_dispatch` but a job-level `if` clause
+    still contains `github.event_name == 'push'`.
+  - Deploy workflow references a placeholder deploy job without requiring the
+    explicit confirmation input.
+  - Regression workflow preserves the `ready-for-regression` label condition,
+    but expensive steps are missing the explicit opt-in guard.
+  - Regression workflow contains `npx playwright install` in a step that can run
+    when the opt-in variable is unset.
+  - Documentation mentions label-gated regression but omits the inactive
+    placeholder default or downstream activation path.
+- **Unit test mapping**:
+  - `scripts/development-workflow/tests/test-placeholder-workflows-opt-in.sh`
+    should include a focused assertion for each edge case above.
+- **Suppression semantics**: Not applicable - the static checks do not support
+  inline suppression directives.
+
+### Concurrent-Event-Source Addendum
+
+Not applicable. The workflows receive multiple GitHub event types, but the
+implementation does not introduce shared mutable state across concurrent event
+handlers. GitHub Actions jobs evaluate each event independently.
+
+---
+
+## Seed Data
+
+No seed data is required.
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/workflow/development-workflow/integrations/ci-cd-deployment.md` -
+      document dispatch-only placeholder deploy defaults, confirmation input,
+      and downstream replacement guidance for real push-triggered deploys.
+- [ ] `docs/workflow/development-workflow/integrations/e2e-regression.md` -
+      document the placeholder regression opt-in variable, default skip
+      behavior, and real label-gated regression activation path.
+- [ ] `docs/workflow/development-workflow/integrations/ci-enforcement.md` -
+      clarify that `apply-regression-label.yml` still applies the readiness
+      signal but inactive placeholders must not spend runner minutes.
+- [ ] `docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md`
+      - clarify that production release regression waits for configured real
+      regression checks or an explicitly enabled placeholder.
+- [ ] `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`
+      - clarify Step 7b/Step 8 wording for configured real regression checks
+      while preserving the label requirement.
+- [ ] `docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md`
+      - clarify the readiness label meaning after placeholder regression becomes
+      inactive by default.
+- [ ] `docs/testing/workflow/1098-placeholder-workflows-opt-in.smoke-test.md` -
+      add the smoke runbook during Plan Ready and update it during
+      implementation if commands or activation names change.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Downstream projects assume deploys still run on every push after syncing | Medium | Medium | Document that placeholders are inactive by default and that real deploy workflows should reintroduce project-specific push triggers. |
+| Gating placeholder regression causes a required check to be skipped in a repository that already made the placeholder required | Low | Medium | Document the opt-in variable and recommend replacing the placeholder with a real required check before enforcing branch protection. |
+| Static workflow checks become brittle because they scan YAML text | Medium | Low | Keep assertions focused on stable contract strings and validate with `actionlint` in addition to the focused shell test. |
+| Protocol wording accidentally weakens the real regression label requirement | Low | High | Limit protocol edits to clarification that real configured regression remains label-gated; do not change label application rules. |
+
+---
+
+## Code Samples
+
+No production code samples are included. Workflow details should be implemented
+directly in the implementation PR and validated with `actionlint`.
+
+---
+
+## Implementation Order
+
+1. Update `.github/workflows/deploy.yml`.
+   - Remove the default `push` trigger for placeholder deploys.
+   - Keep `workflow_dispatch` with the existing environment choice.
+   - Add an explicit confirmation input such as `confirm_placeholder`.
+   - Gate `deploy-develop` and `deploy-production` on manual dispatch, matching
+     environment, and confirmation.
+   - Verify by reading the workflow and confirming no placeholder job can run
+     from a push event.
+2. Update `.github/workflows/e2e-regression.yml`.
+   - Keep the `pull_request` trigger and `ready-for-regression` label condition.
+   - Add the explicit placeholder opt-in guard, using an unset repository
+     variable as disabled.
+   - Ensure expensive steps (`npm ci`, Playwright browser install, and test run)
+     cannot execute when the opt-in guard is false.
+   - Verify by confirming the workflow still references
+     `ready-for-regression` and that expensive steps are gated by the opt-in
+     mechanism.
+3. Add `scripts/development-workflow/tests/test-placeholder-workflows-opt-in.sh`.
+   - Assert deploy placeholders are dispatch-only and confirmation-gated.
+   - Assert regression placeholders preserve label semantics but require the
+     explicit opt-in before dependency/browser installation.
+   - Assert the docs name the inactive defaults and downstream activation paths.
+4. Update documentation listed in **Documentation Updates**.
+   - Keep protocol label requirements intact.
+   - Clearly distinguish inactive placeholders from configured real regression
+     and deploy workflows.
+5. Update `docs/testing/workflow/1098-placeholder-workflows-opt-in.smoke-test.md`
+   if implementation details differ from this plan.
+6. Run focused validation:
+   - `bash scripts/development-workflow/tests/test-placeholder-workflows-opt-in.sh`
+   - `shellcheck scripts/development-workflow/tests/test-placeholder-workflows-opt-in.sh`
+   - `actionlint .github/workflows/deploy.yml .github/workflows/e2e-regression.yml`
+   - `npx markdownlint-cli2 "docs/specs/developments/20260701075304_1098-placeholder-workflows-opt-in/2_1098-placeholder-workflows-opt-in_implementation-plan.md" "docs/testing/workflow/1098-placeholder-workflows-opt-in.smoke-test.md" "docs/workflow/development-workflow/integrations/ci-cd-deployment.md" "docs/workflow/development-workflow/integrations/e2e-regression.md" "docs/workflow/development-workflow/integrations/ci-enforcement.md" "docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md" "docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md" "docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md"`
+   - `git diff --check`
+7. Update `CHANGELOG.md` under `[Unreleased]` with:
+   - `- **Placeholder workflows opt-in** (#1098): Make template placeholder deploy and regression workflows opt-in so downstream repositories do not spend runner minutes before configuring real pipelines.`

--- a/docs/testing/workflow/1098-placeholder-workflows-opt-in.smoke-test.md
+++ b/docs/testing/workflow/1098-placeholder-workflows-opt-in.smoke-test.md
@@ -1,0 +1,144 @@
+# Smoke Test Runbook: Placeholder Workflows Opt-In
+
+**Feature**: Placeholder workflows opt-in
+**Spec**: [1_1098-placeholder-workflows-opt-in_specs.md](../../specs/developments/20260701075304_1098-placeholder-workflows-opt-in/1_1098-placeholder-workflows-opt-in_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] You are in the repository root.
+- [ ] The implementation branch for #1098 is checked out.
+- [ ] GitHub Actions workflow validation tools used by the repository are
+      available locally.
+
+---
+
+## Test Data
+
+No application seed data is required.
+
+| Item | Value |
+| --- | --- |
+| Deploy workflow | `.github/workflows/deploy.yml` |
+| Regression workflow | `.github/workflows/e2e-regression.yml` |
+| Opt-in variable | `ENABLE_TEMPLATE_PLACEHOLDER_REGRESSION` |
+| Regression label | `ready-for-regression` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Validate Placeholder Deploy Defaults
+
+**Maps to**: AC1, AC4, AC7
+
+1. Open `.github/workflows/deploy.yml`.
+2. Confirm placeholder deploy jobs do not run from default `push` events.
+3. Confirm manual dispatch remains available for temporary placeholder
+   validation.
+4. Confirm each placeholder deploy job requires an explicit confirmation input
+   before it runs.
+
+**Expected result**: A downstream repository that syncs the template and pushes
+to `develop` or `main` does not run a placeholder deploy by default.
+
+### Step 2: Validate Placeholder Regression Opt-In
+
+**Maps to**: AC2, AC3, AC5, AC7
+
+1. Open `.github/workflows/e2e-regression.yml`.
+2. Confirm the workflow still recognizes the `ready-for-regression` label.
+3. Confirm the placeholder dependency install, browser install, and test run are
+   gated behind an explicit opt-in.
+4. Confirm an unset opt-in variable prevents browser dependency installation.
+
+**Expected result**: Adding `ready-for-regression` alone does not install
+Playwright or browser dependencies when placeholder regression is not enabled.
+
+### Step 3: Validate Label Automation Relationship
+
+**Maps to**: AC3, AC6, AC7
+
+1. Open `.github/workflows/apply-regression-label.yml`.
+2. Confirm implementation PR label automation still applies
+   `ready-for-regression`.
+3. Confirm the regression workflow or docs make the label a readiness signal for
+   configured real regression checks while keeping inactive placeholders cheap.
+
+**Expected result**: Real project regression can remain label-gated, and the
+template placeholder cannot spend browser-install minutes by label alone.
+
+### Step 4: Run Static Validation
+
+**Maps to**: AC1, AC2, AC3, AC7
+
+1. Run `bash scripts/development-workflow/tests/test-placeholder-workflows-opt-in.sh`.
+2. Run `actionlint .github/workflows/deploy.yml .github/workflows/e2e-regression.yml`.
+3. Run markdown lint on the changed docs and this runbook.
+
+**Expected result**: The focused static test, workflow syntax validation, and
+documentation lint all pass.
+
+### Step 5: Validate Documentation Coverage
+
+**Maps to**: AC4, AC5, AC6
+
+1. Open `docs/workflow/development-workflow/integrations/ci-cd-deployment.md`.
+2. Confirm it explains the inactive deploy placeholder default and downstream
+   replacement path.
+3. Open `docs/workflow/development-workflow/integrations/e2e-regression.md`.
+4. Confirm it explains the placeholder regression opt-in and the real
+   label-gated replacement path.
+5. Open the updated protocol docs and confirm they still require
+   `ready-for-regression` for configured real regression gates.
+
+**Expected result**: Downstream maintainers can tell how to keep placeholders
+inactive, how to opt in temporarily, and how to enable real deploy/regression
+workflows intentionally.
+
+---
+
+## Assertions Checklist
+
+- [ ] AC1: Placeholder deploy jobs do not run on every push by default unless a
+      downstream project opts in or replaces the placeholder.
+- [ ] AC2: Placeholder regression jobs do not install Playwright or browser
+      dependencies unless regression is intentionally enabled.
+- [ ] AC3: `ready-for-regression` label automation does not accidentally trigger
+      expensive placeholder regression work when regression is not enabled.
+- [ ] AC4: Documentation explains the recommended downstream activation path for
+      real deploy workflows.
+- [ ] AC5: Documentation explains the recommended downstream activation path for
+      real regression workflows.
+- [ ] AC6: Existing release and reviewer-loop protocol guidance still describes
+      how real regression should be label-gated when configured.
+- [ ] AC7: Tests or static validation cover default-inactive deploy behavior,
+      default-inactive regression behavior, and the label-trigger relationship.
+
+---
+
+## Seed Data Reference
+
+No seed data is required.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Static test reports deploy push trigger still present | Placeholder deploy workflow can still run on default branch pushes | Remove the push activation path or add the missing confirmation gate, then rerun the test. |
+| Static test reports Playwright install is ungated | The expensive regression steps can still run without explicit opt-in | Add or restore the opt-in guard around dependency install, browser install, and test execution. |
+| `actionlint` fails | Workflow syntax is invalid after trigger or input edits | Fix the reported workflow syntax and rerun `actionlint`. |
+
+---
+
+## Known Limitations
+
+- This runbook validates the template placeholder contract. It does not validate
+  any downstream project's real deployment provider or real regression suite.


### PR DESCRIPTION
## Summary

Adds the implementation plan and smoke test runbook for #1098, covering opt-in placeholder deploy and regression workflow behavior for the Actions cost reduction epic.

## Approach

- Make placeholder deploy jobs manual-only with explicit confirmation.
- Gate placeholder regression dependency/browser installs behind explicit downstream opt-in while preserving the `ready-for-regression` label model for real suites.
- Add static validation and documentation updates to keep defaults inactive by design.

## Complexity

M - small workflow changes, but shared template defaults and protocol docs require careful validation.

## Key Risks

- Downstream repos that relied on placeholder push deploys need clear replacement guidance.
- Required placeholder regression checks could become skipped unless downstream opts in or replaces the placeholder.

## Artifacts

- Plan: `docs/specs/developments/20260701075304_1098-placeholder-workflows-opt-in/2_1098-placeholder-workflows-opt-in_implementation-plan.md`
- Smoke runbook: `docs/testing/workflow/1098-placeholder-workflows-opt-in.smoke-test.md`

Refs #1098

## Document Quality Gate

- Spec/brief coverage: Checked - all acceptance criteria map to implementation steps and smoke coverage.
- Implementation-order consistency: Checked - workflow names, docs, opt-in variable, and validation steps are consistent across the plan and runbook.
- Verification support: Checked - existing workflow triggers, regression cost path, protocol references, and documentation surfaces cite Verification Log commands.
- Behavioral guarantees: Checked - default-inactive deploy and regression guarantees name the workflow trigger, confirmation input, and opt-in guard mechanisms.
- Parser/API/concurrency checklist: Checked - parser-risk static workflow scanning is classified with edge cases and test mapping; concurrency is marked not applicable with rationale.
- CHANGELOG literal format: Checked - implementation CHANGELOG literal uses the repository `**Bold Title** (#N):` format.
- Not-applicable rationale: Checked - seed data and concurrency exclusions include rationale.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only PR with no changes to GitHub Actions or production paths; follow-up workflow edits carry the operational risk called out in the plan.
> 
> **Overview**
> Adds **Plan Ready** artifacts for #1098: an implementation plan and a smoke test runbook. No workflow, script, or integration doc edits land in this PR—the diff is documentation only.
> 
> The plan spells out the follow-up work: make template **deploy** placeholders **dispatch-only** with a confirmation input (no default `push`), gate placeholder **e2e regression** `npm ci` / Playwright installs behind **`ENABLE_TEMPLATE_PLACEHOLDER_REGRESSION`**, keep **`ready-for-regression`** label semantics, add **`test-placeholder-workflows-opt-in.sh`**, and update CI/CD, regression, enforcement, and protocol docs plus **CHANGELOG**.
> 
> The runbook maps acceptance criteria to manual checks and commands (`actionlint`, the new shell test, markdown lint) for when that implementation ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbd38995b06b568206be6752d7a25fe5204a0888. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->