### PR TITLE
fix(workflows): make placeholders opt in

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,6 @@
 name: Deploy (Template Placeholder)
 
 on:
-  push:
-    branches:
-      - develop
-      - main
   workflow_dispatch:
     inputs:
       environment:
@@ -15,6 +11,11 @@ on:
         options:
           - develop
           - production
+      confirm_placeholder:
+        description: "Run the template placeholder deploy job"
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -23,9 +24,10 @@ permissions:
 jobs:
   deploy-develop:
     name: Deploy to develop (placeholder)
-    if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
-      (github.event_name == 'workflow_dispatch' && inputs.environment == 'develop')
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.environment == 'develop' &&
+      inputs.confirm_placeholder == true
     runs-on: ubuntu-latest
     environment: develop
     concurrency:
@@ -44,9 +46,10 @@ jobs:
 
   deploy-production:
     name: Deploy to production (placeholder)
-    if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'workflow_dispatch' && inputs.environment == 'production')
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.environment == 'production' &&
+      inputs.confirm_placeholder == true
     runs-on: ubuntu-latest
     environment: production
     concurrency:

--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -18,8 +18,11 @@ jobs:
   e2e:
     name: E2E regression (placeholder)
     if: >-
-      (github.event.action == 'labeled' && github.event.label.name == 'ready-for-regression') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ready-for-regression'))
+      vars.ENABLE_TEMPLATE_PLACEHOLDER_REGRESSION == 'true' &&
+      (
+        (github.event.action == 'labeled' && github.event.label.name == 'ready-for-regression') ||
+        (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'ready-for-regression'))
+      )
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   while preserving configured reviewer-loop review.
 - **Event-driven reviewer guard** (#1097): Replace default long reviewer-loop
   guard polling with a fast PR check plus summary-comment readiness refresh.
+- **Placeholder workflows opt-in** (#1098): Make template placeholder deploy and
+  regression workflows opt-in so downstream repositories do not spend runner
+  minutes before configuring real pipelines.
 
 ## [0.34.0] - 2026-06-30
 

--- a/docs/testing/workflow/1098-placeholder-workflows-opt-in.smoke-test.md
+++ b/docs/testing/workflow/1098-placeholder-workflows-opt-in.smoke-test.md
@@ -27,6 +27,7 @@ No application seed data is required.
 | Deploy workflow | `.github/workflows/deploy.yml` |
 | Regression workflow | `.github/workflows/e2e-regression.yml` |
 | Opt-in variable | `ENABLE_TEMPLATE_PLACEHOLDER_REGRESSION` |
+| Deploy confirmation input | `confirm_placeholder` |
 | Regression label | `ready-for-regression` |
 
 ---

--- a/docs/workflow/development-workflow/integrations/ci-cd-deployment.md
+++ b/docs/workflow/development-workflow/integrations/ci-cd-deployment.md
@@ -10,11 +10,31 @@ The workflow is intentionally generic so downstream repositories can implement t
 
 ## Default Behavior
 
-- Push to `develop` runs the `deploy-develop` job and targets the `develop` GitHub Environment.
-- Push to `main` runs the `deploy-production` job and targets the `production` GitHub Environment.
-- Manual runs are supported with `workflow_dispatch` and an `environment` input (`develop` or `production`).
+- Placeholder deploy jobs are inactive by default and do not run on push.
+- Manual placeholder validation is supported with `workflow_dispatch`, an
+  `environment` input (`develop` or `production`), and
+  `confirm_placeholder: true`.
+- Downstream repositories should reintroduce push triggers only after replacing
+  the placeholder steps with project-specific deployment logic.
 
-The included deploy steps are no-op placeholders (`echo` commands) so the workflow remains safe and passing in this template repository.
+The included deploy steps are no-op placeholders (`echo` commands). They remain
+available for explicit validation, but the template does not spend runner time
+on every default-branch push before a downstream project has a real deployment
+pipeline.
+
+---
+
+## Temporary Placeholder Validation
+
+Use manual dispatch only when you intentionally want to validate that GitHub
+Environments and workflow permissions are wired correctly:
+
+1. Open the `Deploy (Template Placeholder)` workflow in GitHub Actions.
+2. Choose `Run workflow`.
+3. Select `develop` or `production`.
+4. Set `confirm_placeholder` to `true`.
+
+Leaving `confirm_placeholder` as `false` skips the placeholder deploy jobs.
 
 ---
 
@@ -26,6 +46,13 @@ Replace the placeholder deploy steps with project-specific logic, usually:
 2. Authenticate with the deployment platform (OIDC/service principal/API token).
 3. Execute deployment command(s) for the selected environment.
 4. Optionally add post-deploy smoke checks and rollback hooks.
+
+After replacing the placeholder with real deployment logic, choose the trigger
+model that matches your release policy. Common downstream choices are:
+
+- Push to `develop` deploys a staging or preview environment.
+- Push to `main` deploys production after branch protection and release checks.
+- Manual `workflow_dispatch` remains available for controlled promotions.
 
 You should also configure repository/environment secrets and protection rules in GitHub Environments:
 
@@ -43,11 +70,13 @@ Each job uses its own fixed concurrency group (`deploy-develop` and `deploy-prod
 
 The `deploy-develop` job keeps `cancel-in-progress: true` so redundant staging deploys are discarded quickly.
 
-Note: `workflow_dispatch` sets `github.ref` to the branch selected in the "Use workflow from" dropdown, not the target environment. Using fixed group names (`deploy-develop` / `deploy-production`) prevents a manual production deploy triggered from `develop` from being cancelled by a subsequent push to `develop`.
+Note: `workflow_dispatch` sets `github.ref` to the branch selected in the "Use workflow from" dropdown, not the target environment. Using fixed group names (`deploy-develop` / `deploy-production`) prevents a manual production deploy triggered from `develop` from being cancelled by another deploy workflow run.
 
 ---
 
 ## Notes
 
 - This template does not store deployment credentials or provider-specific commands.
+- The placeholder workflow is intentionally opt-in to avoid private downstream
+  repositories spending Actions minutes before real deployment value exists.
 - Keep production deployments protected (reviewers, required checks, branch protections) according to your project's risk profile.

--- a/docs/workflow/development-workflow/integrations/ci-enforcement.md
+++ b/docs/workflow/development-workflow/integrations/ci-enforcement.md
@@ -22,6 +22,11 @@ pull request opened from an in-scope implementation branch prefix (`feature/`,
 `fix/`, `refactor/`, `hotfix/`). Runs on PR `opened`, `reopened`,
 `ready_for_review`, and `synchronize` events.
 
+The label is a readiness signal for configured real regression checks. It does
+not by itself enable inactive placeholder regression work; the template
+placeholder in `.github/workflows/e2e-regression.yml` still requires explicit
+downstream opt-in before dependency or browser installation runs.
+
 **Idempotent**: If the label is already present, the workflow completes without
 error and without duplicating the label.
 
@@ -203,3 +208,9 @@ The CI workflows complement, not replace, the agent-side checklist. The agent
 Step 5.1 check in Protocol 91 remains the authoritative gate for the agent
 runner; the CI workflows provide a structural backstop that catches cases where
 the agent did not run or skipped the check.
+
+When a downstream repository has not configured real regression tests, the
+auto-applied label may be present while the template placeholder remains
+inactive. That is expected: the label preserves staged workflow semantics, while
+explicitly enabled placeholder or real regression workflows decide whether
+expensive checks run.

--- a/docs/workflow/development-workflow/integrations/e2e-regression.md
+++ b/docs/workflow/development-workflow/integrations/e2e-regression.md
@@ -4,7 +4,13 @@ This template includes a label-gated GitHub Actions workflow for e2e/regression 
 
 - `.github/workflows/e2e-regression.yml`
 
-The workflow triggers on PRs targeting `develop` or `main` when the `ready-for-regression` label is present. It is intentionally generic so downstream repositories can implement their own test suites.
+The placeholder workflow listens for PRs targeting `develop` or `main` when the
+`ready-for-regression` label is present, but the placeholder job is disabled by
+default. It installs dependencies and browsers only when the repository variable
+`ENABLE_TEMPLATE_PLACEHOLDER_REGRESSION` is set to `true`.
+
+The file is intentionally generic so downstream repositories can replace it with
+their own label-gated test suites.
 
 ---
 
@@ -14,7 +20,8 @@ The `ready-for-regression` label is applied by the orchestrator (Step 7b in `91-
 
 1. Step 7a: Internal review gate passes
 2. Step 7: External automated reviewers are clean
-3. **Step 7b: `ready-for-regression` label is applied** (triggers this workflow)
+3. **Step 7b: `ready-for-regression` label is applied** (triggers configured
+   real regression checks, or this placeholder when explicitly enabled)
 4. Step 8: CI loop polls `statusCheckRollup` — the e2e job appears as a check
 
 Regression tests are expensive in time and compute, so they only run after all reviewer gates confirm the code is clean.
@@ -42,7 +49,15 @@ This means e2e tests re-run automatically after fixer pushes — the label stays
 
 ## Default Behavior
 
-The template ships with a minimal Playwright project at `e2e/` that has one always-passing baseline test. This keeps the template pipeline green without external dependencies.
+The template ships with a minimal Playwright project at `e2e/` that has one
+always-passing baseline test. The placeholder workflow is inactive by default so
+private downstream repositories do not install Playwright or browser
+dependencies before regression is intentionally enabled.
+
+To run the placeholder as a temporary validation check, create a repository
+variable named `ENABLE_TEMPLATE_PLACEHOLDER_REGRESSION` with value `true`. Remove
+that variable or set it to any other value to return the placeholder to the
+disabled default.
 
 ---
 
@@ -57,7 +72,11 @@ Replace the placeholder e2e project with project-specific tests:
 
 You may also:
 
-- Add the `E2E regression (placeholder)` check as a required status check in branch protection rules.
+- Remove the `ENABLE_TEMPLATE_PLACEHOLDER_REGRESSION` guard once the placeholder
+  steps are replaced by a real suite that should always run after
+  `ready-for-regression`.
+- Add the real e2e/regression check as a required status check in branch
+  protection rules.
 - Split into multiple workflow files for different test suites (each gated on `ready-for-regression`).
 - Add environment variables or secrets for test infrastructure.
 
@@ -65,7 +84,7 @@ You may also:
 
 ## Scope
 
-The `ready-for-regression` label is applied to implementation PRs (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`) and to **production** release PRs (`release/*` → `main`) per [`05-prepare-release-protocol.md`](../protocols/05-prepare-release-protocol.md) Step 7.4, so e2e/regression can run before merge. Spec and plan PRs (`spec/*`, `implementation-plan/*`) skip this label and regression testing.
+The `ready-for-regression` label is applied to implementation PRs (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`) and to **production** release PRs (`release/*` → `main`) per [`05-prepare-release-protocol.md`](../protocols/05-prepare-release-protocol.md) Step 7.4, so configured real e2e/regression checks can run before merge. Spec and plan PRs (`spec/*`, `implementation-plan/*`) skip this label and regression testing.
 
 ---
 
@@ -73,4 +92,6 @@ The `ready-for-regression` label is applied to implementation PRs (`feature/*`, 
 
 - The label persists on the PR after e2e tests pass. It is not removed.
 - This workflow does not store test credentials or environment URLs in the template.
-- For projects without e2e tests, the baseline test keeps the check green. Alternatively, remove the workflow file and do not configure the check as required — the orchestrator will still apply the label but the CI loop will not block on a missing check.
+- For projects without e2e tests, keep the placeholder disabled and do not
+  configure it as a required check. The orchestrator will still apply the label,
+  but the inactive placeholder will not spend runner minutes on browser setup.

--- a/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
+++ b/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
@@ -158,7 +158,10 @@ in the release branch or document the decision to defer with a comment on the is
 
 ### 7.3 Regression label (release / `main` PR only)
 
-Apply the `ready-for-regression` label to the **production PR only** so label-gated e2e/regression runs (see [`integrations/e2e-regression.md`](../integrations/e2e-regression.md) and `.github/workflows/e2e-regression.yml`).
+Apply the `ready-for-regression` label to the **production PR only** so
+configured real regression checks, or an explicitly enabled placeholder, can run
+(see [`integrations/e2e-regression.md`](../integrations/e2e-regression.md) and
+`.github/workflows/e2e-regression.yml`).
 
 ```bash
 gh pr edit <pr_number> --add-label "ready-for-regression"

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -1327,7 +1327,12 @@ Verify all of the following by querying artifact state directly. If any check fa
 
 1. Applies the label directly: `gh pr edit <pr_number> --add-label "ready-for-regression"`
 2. Logs the deviation: `PROTOCOL_DEVIATION: ready-for-regression was missing on PR #<N> (<branch-type>) — applied by orchestrator Step 5.1`
-3. **Re-polls CI** — the label triggers the `e2e-regression.yml` workflow. The CI check row in this verification table was evaluated _before_ the label was applied, so the e2e check was not yet in `statusCheckRollup`. After applying the label, wait for CI to settle using `pr-ci-loop.sh <pr_number>` before re-running this verification. Do not mark the PR ready until the re-polled CI check is green.
+3. **Re-polls CI** — the label triggers configured real regression workflows,
+   or an explicitly enabled placeholder. The CI check row in this verification
+   table was evaluated _before_ the label was applied, so configured e2e checks
+   may not yet be in `statusCheckRollup`. After applying the label, wait for CI
+   to settle using `pr-ci-loop.sh <pr_number>` before re-running this
+   verification. Do not mark the PR ready until the re-polled CI check is green.
 
 > **`refactor/*` is not exempt**: Orchestrators must not skip the `ready-for-regression` check for `refactor/*` PRs. Refactors require regression testing before merge regardless of their content. This check has the same priority and remediation path as for `fix/*` or `feature/*` PRs.
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1690,7 +1690,7 @@ discarded when the orchestration session ends.
 
 ## Step 7b: Regression Label (Implementation PRs Only)
 
-After Step 7 completes with result `clean` or `skipped`, and **before** entering Step 8, apply the `ready-for-regression` label on implementation PRs to trigger label-gated e2e/regression CI checks.
+After Step 7 completes with result `clean` or `skipped`, and **before** entering Step 8, apply the `ready-for-regression` label on implementation PRs to trigger configured real regression CI checks, or an explicitly enabled placeholder regression workflow.
 
 **Applies to**: PRs on branches `feature/*`, `fix/*`, `refactor/*`, `hotfix/*`, `backport/hotfix/*`
 **Does not apply to**: PRs on branches `spec/*`, `implementation-plan/*`, or graduation PRs (`develop-<slug>` → `develop`) — see the label derivation table in Step 8a for the graduation PR exemption (BR-6)
@@ -1704,7 +1704,7 @@ After Step 7 completes with result `clean` or `skipped`, and **before** entering
 gh pr edit <pr_number> --add-label "ready-for-regression"
 ```
 
-This label triggers the `e2e-regression.yml` workflow (or project-specific equivalents). Step 8's CI loop (`pr-ci-loop.sh`) will then naturally pick up the e2e check as part of its green/red polling via `statusCheckRollup`.
+This label triggers the `e2e-regression.yml` workflow (or project-specific equivalents). The template placeholder remains inactive unless explicitly enabled; downstream real regression suites should keep this label gate when they replace the placeholder. Step 8's CI loop (`pr-ci-loop.sh`) will then naturally pick up configured e2e checks as part of its green/red polling via `statusCheckRollup`.
 
 The `gh pr edit --add-label` command is idempotent — applying a label that already exists is a no-op. When the label is already present from a previous cycle, the `synchronize` event from the latest push will have already re-triggered the workflow.
 

--- a/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -12,7 +12,7 @@ This is a **repo-wide definition**. All agents apply these labels consistently.
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `ready-for-human-review` | The PR is ready for a human reviewer. CI is green. The `REVIEW.md` gate is satisfied. Every configured automated reviewer is clean or skipped.                                                                                                                                                                           |
 | `needs-fixes`            | The PR still needs fixes before it is ready for human review. This may be due to human-requested changes, failing CI, or blocking automated PR feedback.                                                                                                                                                                 |
-| `ready-for-regression`   | Automated code reviews are clean (or skipped). E2e/regression tests should now run. Applied by the orchestrator (Step 7b) on implementation PRs (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`, `backport/hotfix/*`), and by the prepare-release flow (protocol `05`) on **production** release PRs (`release/*` → `main`) only. |
+| `ready-for-regression`   | Automated code reviews are clean (or skipped). Configured real e2e/regression tests, or an explicitly enabled placeholder, should now run. Applied by the orchestrator (Step 7b) on implementation PRs (`feature/*`, `fix/*`, `hotfix/*`, `refactor/*`, `backport/hotfix/*`), and by the prepare-release flow (protocol `05`) on **production** release PRs (`release/*` → `main`) only. |
 | `needs-setup`            | PR introduces one or more infrastructure dependencies (env vars, secrets, DNS records, service account tokens, etc.) that require human setup steps before the feature can be safely enabled. Co-exists with `ready-for-human-review`; the human removes this label after completing (or intentionally deferring) setup. |
 | `human-checkpoint-required` | The PR's linked work item has at least one `pending` human checkpoint that applies to this PR: same `item_number` and either matching the PR's current workflow stage or an earlier stage not yet `satisfied`/`waived`. Human feedback or approval named in `required_human_action` is still required. Co-exists with `ready-for-human-review` when automation is clean but a checkpoint remains open. Does **not** satisfy when only `needs-setup` is removed. |
 
@@ -57,7 +57,10 @@ Apply this label when **all** of the following are true:
 
 Release PRs typically do not use the same draft → `gh pr ready` path as feature work; internal review may be minimal when the change set is changelog/version-only — still apply this label only after Step 7 is `clean` or `skipped` per protocol `05`.
 
-This label is **not removed** after e2e tests pass — it persists on the PR. The `ready-for-human-review` label is what ultimately signals human readiness after CI (including e2e) is green.
+This label is **not removed** after e2e tests pass — it persists on the PR. The
+`ready-for-human-review` label is what ultimately signals human readiness after
+CI, including configured real e2e/regression checks or an explicitly enabled
+placeholder, is green.
 
 This label is **not applied** to spec or plan PRs (`spec/*`, `implementation-plan/*`). It **is** applied to qualifying release PRs per Case B above.
 

--- a/scripts/development-workflow/tests/test-placeholder-workflows-opt-in.sh
+++ b/scripts/development-workflow/tests/test-placeholder-workflows-opt-in.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)"
+DEPLOY_WORKFLOW="$ROOT_DIR/.github/workflows/deploy.yml"
+REGRESSION_WORKFLOW="$ROOT_DIR/.github/workflows/e2e-regression.yml"
+DEPLOY_DOC="$ROOT_DIR/docs/workflow/development-workflow/integrations/ci-cd-deployment.md"
+REGRESSION_DOC="$ROOT_DIR/docs/workflow/development-workflow/integrations/e2e-regression.md"
+CI_DOC="$ROOT_DIR/docs/workflow/development-workflow/integrations/ci-enforcement.md"
+PROTOCOL_05="$ROOT_DIR/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md"
+PROTOCOL_90="$ROOT_DIR/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md"
+PROTOCOL_91="$ROOT_DIR/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md"
+PROTOCOL_92="$ROOT_DIR/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  local message="$3"
+
+  grep -Eq "$pattern" "$file" || fail "$message"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  local message="$3"
+
+  if grep -Eq "$pattern" "$file"; then
+    fail "$message"
+  fi
+}
+
+assert_contains "$DEPLOY_WORKFLOW" '^[[:space:]]*workflow_dispatch:' \
+  "deploy placeholder must remain manually runnable via workflow_dispatch"
+assert_contains "$DEPLOY_WORKFLOW" 'confirm_placeholder:' \
+  "deploy placeholder must expose an explicit confirmation input"
+assert_contains "$DEPLOY_WORKFLOW" 'inputs\.confirm_placeholder == true' \
+  "deploy placeholder jobs must require explicit confirmation"
+assert_not_contains "$DEPLOY_WORKFLOW" '^[[:space:]]*push:' \
+  "deploy placeholder must not declare a default push trigger"
+assert_not_contains "$DEPLOY_WORKFLOW" "github\\.event_name == 'push'" \
+  "deploy placeholder jobs must not contain push-event activation clauses"
+
+assert_contains "$REGRESSION_WORKFLOW" "ready-for-regression" \
+  "regression placeholder must preserve ready-for-regression label semantics"
+assert_contains "$REGRESSION_WORKFLOW" "ENABLE_TEMPLATE_PLACEHOLDER_REGRESSION" \
+  "regression placeholder must document the explicit opt-in variable in workflow logic"
+assert_contains "$REGRESSION_WORKFLOW" "vars\\.ENABLE_TEMPLATE_PLACEHOLDER_REGRESSION == 'true'" \
+  "regression placeholder job must require the opt-in variable to be true"
+assert_contains "$REGRESSION_WORKFLOW" 'npx playwright install --with-deps chromium' \
+  "regression placeholder still needs the browser install step for explicitly enabled placeholders"
+
+regression_if_line="$(grep -n "ENABLE_TEMPLATE_PLACEHOLDER_REGRESSION" "$REGRESSION_WORKFLOW" | head -1 | cut -d: -f1)"
+install_line="$(grep -n "npx playwright install" "$REGRESSION_WORKFLOW" | head -1 | cut -d: -f1)"
+[ -n "$regression_if_line" ] || fail "could not locate regression opt-in guard"
+[ -n "$install_line" ] || fail "could not locate Playwright install step"
+if [ "$regression_if_line" -ge "$install_line" ]; then
+  fail "regression opt-in guard must appear before expensive browser install step"
+fi
+
+assert_contains "$DEPLOY_DOC" 'inactive by default|does not run on push by default' \
+  "deployment docs must explain the inactive default"
+assert_contains "$DEPLOY_DOC" 'confirm_placeholder' \
+  "deployment docs must name the placeholder confirmation input"
+assert_contains "$REGRESSION_DOC" 'ENABLE_TEMPLATE_PLACEHOLDER_REGRESSION' \
+  "regression docs must name the opt-in variable"
+assert_contains "$REGRESSION_DOC" 'inactive by default|disabled by default' \
+  "regression docs must explain the inactive default"
+assert_contains "$CI_DOC" 'inactive placeholder|explicitly enabled placeholder' \
+  "CI enforcement docs must distinguish readiness labels from placeholder activation"
+assert_contains "$PROTOCOL_05" 'configured real regression|explicitly enabled placeholder' \
+  "release protocol must preserve label-gated guidance for configured regression"
+assert_contains "$PROTOCOL_90" 'configured real regression|explicitly enabled placeholder' \
+  "batch orchestration protocol must preserve label-gated guidance for configured regression"
+assert_contains "$PROTOCOL_91" 'configured real regression|explicitly enabled placeholder' \
+  "orchestration protocol must preserve label-gated guidance for configured regression"
+assert_contains "$PROTOCOL_92" 'configured real regression|explicitly enabled placeholder' \
+  "readiness protocol must preserve label-gated guidance for configured regression"
+
+printf 'placeholder workflow opt-in checks passed\n'


### PR DESCRIPTION
## Summary

Implements #1098 for the Actions cost reduction epic.

- Makes `.github/workflows/deploy.yml` dispatch-only for placeholder deploys, with explicit `confirm_placeholder` gating.
- Keeps `.github/workflows/e2e-regression.yml` label-compatible while requiring `ENABLE_TEMPLATE_PLACEHOLDER_REGRESSION=true` before dependency/browser install runs.
- Adds a focused static workflow guard test and updates deployment, regression, CI enforcement, protocol, smoke, and CHANGELOG docs.

## Spec and Plan

- Spec: `docs/specs/developments/20260701075304_1098-placeholder-workflows-opt-in/1_1098-placeholder-workflows-opt-in_specs.md`
- Plan: `docs/specs/developments/20260701075304_1098-placeholder-workflows-opt-in/2_1098-placeholder-workflows-opt-in_implementation-plan.md`
- Smoke: `docs/testing/workflow/1098-placeholder-workflows-opt-in.smoke-test.md`

## Test Plan

- `bash scripts/development-workflow/tests/test-placeholder-workflows-opt-in.sh`
- `shellcheck --severity=warning scripts/development-workflow/tests/test-placeholder-workflows-opt-in.sh`
- `actionlint .github/workflows/deploy.yml .github/workflows/e2e-regression.yml`
- `npx markdownlint-cli2 "docs/specs/developments/20260701075304_1098-placeholder-workflows-opt-in/2_1098-placeholder-workflows-opt-in_implementation-plan.md" "docs/testing/workflow/1098-placeholder-workflows-opt-in.smoke-test.md" "docs/workflow/development-workflow/integrations/ci-cd-deployment.md" "docs/workflow/development-workflow/integrations/e2e-regression.md" "docs/workflow/development-workflow/integrations/ci-enforcement.md" "docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md" "docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md" "docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md" "docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md" CHANGELOG.md`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `git diff --check`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop-actions-cost-reduction`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`

## Pre-submission self-review

Stale markers: none in the changed diff. Caller/sibling consistency: verified across deploy, e2e regression, CI enforcement, Protocols 05/90/91/92, smoke runbook, and CHANGELOG. Coverage: all #1098 acceptance criteria are addressed. Test harness checklist: applies to the new shell guard; empty/missing doc/workflow paths fail explicitly through assertions, negative assertions cover forbidden push activation, and no shared state is written so concurrent execution is safe.

## CHANGELOG Preview

- **Placeholder workflows opt-in** (#1098): Make template placeholder deploy and regression workflows opt-in so downstream repositories do not spend runner minutes before configuring real pipelines.

Closes #1098

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/workflow and documentation changes only; default behavior is fewer runs. Downstream repos that relied on automatic placeholder runs on push or label must explicitly opt in or replace workflows.
> 
> **Overview**
> **Template placeholder GitHub Actions no longer run on every push or label by default**, so downstream repos avoid spending runner minutes before real pipelines exist.
> 
> **Deploy** (`.github/workflows/deploy.yml`): removes `push` on `develop`/`main`. Placeholder jobs run only on `workflow_dispatch` when `confirm_placeholder` is `true` and the chosen `environment` matches.
> 
> **E2E regression placeholder** (`.github/workflows/e2e-regression.yml`): keeps `ready-for-regression` label semantics, but the job runs only when repo variable `ENABLE_TEMPLATE_PLACEHOLDER_REGRESSION` is `'true'` (so label alone does not trigger Playwright/browser install).
> 
> **Docs and protocols** (deployment, e2e, CI enforcement, prepare-release, batch/single orchestration, readiness signals): describe inactive defaults, temporary opt-in, and that `ready-for-regression` still gates **configured real** regression—not the inactive placeholder.
> 
> Adds static guard `scripts/development-workflow/tests/test-placeholder-workflows-opt-in.sh`, smoke runbook updates, and a **CHANGELOG** entry for #1098.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc3686c5542f29cec2624a530ba0d95f81666629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->