### PR TITLE
docs(plan): add actions cost audit guidance plan

### DIFF
--- a/docs/specs/developments/20260701091532_1099-actions-cost-audit-guidance/2_1099-actions-cost-audit-guidance_implementation-plan.md
+++ b/docs/specs/developments/20260701091532_1099-actions-cost-audit-guidance/2_1099-actions-cost-audit-guidance_implementation-plan.md
@@ -1,0 +1,228 @@
+# Actions Cost-Audit Guidance - Implementation Plan
+
+**Spec**: [1_1099-actions-cost-audit-guidance_specs.md](1_1099-actions-cost-audit-guidance_specs.md)
+**Smoke test runbook**: [1099-actions-cost-audit-guidance.smoke-test.md](../../../testing/workflow/1099-actions-cost-audit-guidance.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add a small repository-level GitHub Actions audit helper that reads
+recent workflow runs with `gh run list`, aggregates run count and wall-time
+signals by workflow, and prints a markdown summary suitable for retrospectives
+and template-sync reviews. Pair it with integration documentation, focused
+mocked shell tests, and a smoke runbook that validates the output structure and
+cost-risk framing.
+
+**Estimated complexity**: S
+
+**Rationale**: The implementation is limited to one shell helper, one focused
+test harness, and documentation. The main risk is robustly handling incomplete
+GitHub CLI data and date fields without presenting approximate wall time as
+billing-accurate cost.
+
+**Dependencies**: None. Issue #1098 reduced placeholder workflow fan-out, but
+this guidance can be implemented independently.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `be484a0` |
+| Template repository mode | `sed -n '1,220p' .ai-dev-workflow.yaml` | `template.is_template: true`; item is generic workflow tooling, so the template-fit check passes. |
+| Existing cost-audit files | `find scripts/development-workflow scripts/development-workflow/tests docs/workflow/development-workflow/integrations -maxdepth 1 -type f \| rg 'actions-cost\|cost-audit\|cost'` | No existing cost-audit helper, test, or integration doc found. |
+| GitHub CLI run fields | `gh run list --help \| sed -n '/--json/,/Options inherited/p'` | `gh run list` supports `workflowName`, `databaseId`, `createdAt`, `startedAt`, `updatedAt`, `status`, `conclusion`, `event`, and `headBranch`. |
+| Live run data shape | `gh run list --limit 3 --json databaseId,workflowName,status,conclusion,createdAt,updatedAt,event,headBranch` | Recent runs returned the required workflow names, IDs, timestamps, events, and statuses. |
+| Workflow script inventory | `find scripts/development-workflow -maxdepth 1 -type f \| sort` | New helper belongs under `scripts/development-workflow/`; new focused test belongs under `scripts/development-workflow/tests/`. |
+| Related cost guidance | `rg -n "runner minutes\|workflow runs\|billing\|gh run\|retrospective\|template-sync" docs/workflow docs/testing scripts CHANGELOG.md` | Existing docs mention placeholder regression minutes, PR-Agent Actions cost, and retrospective/template-sync contexts, but no reusable audit output format. |
+| Shell test pattern | `sed -n '1,260p' scripts/development-workflow/tests/test-placeholder-workflows-opt-in.sh` | Existing focused workflow tests use portable Bash assertions over committed scripts/docs. |
+| Integration docs inventory | `find docs/workflow/development-workflow/integrations -maxdepth 1 -type f \| sort` | New documentation should be added as `docs/workflow/development-workflow/integrations/actions-cost-audit.md`. |
+
+---
+
+## Layer-by-Layer Changes
+
+### Database / Data Layer
+
+- [ ] No database or seed-data changes.
+
+### Backend / API
+
+- [ ] Add `scripts/development-workflow/actions-cost-audit.sh`.
+- [ ] The helper reads recent workflow runs through `gh run list --json` using
+      normal repository workflow-run visibility.
+- [ ] Support these options:
+  - `--limit <n>`: number of recent runs to inspect, defaulting to a conservative
+    value such as `100`.
+  - `--repo <owner/repo>`: optional repository override passed through to `gh`.
+  - `--since <iso-date>`: optional inclusive cutoff for `createdAt`; when
+    omitted, the helper reports the most recent `--limit` runs.
+  - `--format markdown`: initial and default output format.
+- [ ] Aggregate by `workflowName`, using a stable fallback such as
+      `workflow:<workflowDatabaseId>` or `unknown-workflow` when the name is
+      absent.
+- [ ] Compute wall time from `startedAt` when available, otherwise `createdAt`,
+      through `updatedAt`. Mark runs with missing or unparseable timestamps as
+      incomplete instead of including them in duration totals.
+- [ ] Print a compact markdown report with:
+  - audit scope and data-limit notes;
+  - workflow summary table with run count, completed count, incomplete count,
+    total wall time, average wall time, dominant events, and recent run IDs;
+  - public/private cost-risk framing;
+  - recommendation worksheet using the outcomes `keep`, `narrow`,
+    `make opt-in`, `replace`, `disable`, and `investigate`;
+  - high-signal keep guidance for CI checks, reviewer gates, release gates, real
+    regression workflows, and real deploy workflows.
+- [ ] Fail clearly when `gh` or `jq` is unavailable, or when `gh run list`
+      returns a permission/authentication failure.
+- [ ] Treat an empty run list as a successful audit with a visible "no data"
+      limitation, not as a shell failure.
+
+### Shared Packages / Libraries
+
+- [ ] No shared package changes.
+
+### Frontend / UI
+
+- [ ] No frontend changes.
+
+### Infrastructure / Configuration
+
+- [ ] No GitHub workflow trigger or repository setting changes.
+- [ ] Do not add billing API dependencies, organization-level permissions, or
+      automatic workflow mutations.
+
+---
+
+## Testing Strategy
+
+**Test types**: Unit-style shell tests, static documentation validation, smoke
+runbook.
+
+**Key scenarios to test**:
+
+1. Successful markdown output groups run count and wall time by workflow (AC1,
+   AC2, AC7).
+2. Missing timestamps or incomplete runs are visible as data limitations and do
+   not corrupt duration totals (AC3).
+3. `gh` permission/authentication failure exits non-zero with an actionable
+   error (AC3).
+4. Empty run history prints a usable "no workflow run data" report (AC3, AC7).
+5. Public/private cost-risk language appears in the generated report and
+   explains that public-template results are not proof of private downstream
+   cost safety (AC4, AC8).
+6. The recommendation worksheet includes `keep`, `narrow`, `make opt-in`,
+   `replace`, `disable`, and `investigate` (AC5, AC6, AC7, AC8).
+
+**Smoke test runbook**:
+`docs/testing/workflow/1099-actions-cost-audit-guidance.smoke-test.md`
+
+**Regression suite**: Add `scripts/development-workflow/tests/test-actions-cost-audit.sh`
+with a mocked `gh` command and deterministic JSON fixtures embedded in the test
+or written to a temporary directory. The test should run without live GitHub
+network access by default.
+
+### Parser-risk addendum
+
+Parser-risk classification: not applicable. The helper consumes structured JSON
+from `gh run list` with `jq`; it does not add a custom parser, linter, scanner,
+regex engine, suppression syntax, or free-form markdown/code/log scanner.
+
+### Concurrent-event-source addendum
+
+Concurrent-event-source classification: not applicable. The helper is a
+single-process command with no event listeners, timers, sockets, or shared
+mutable state across asynchronous contexts.
+
+---
+
+## Seed Data
+
+No application seed data is required.
+
+| Entity | Values / Scenario | File |
+| --- | --- | --- |
+| Mock workflow run JSON | Multiple workflows, incomplete timestamps, empty list, and permission failure | `scripts/development-workflow/tests/test-actions-cost-audit.sh` temporary fixtures |
+
+---
+
+## Documentation Updates
+
+- [ ] `scripts/development-workflow/README.md` - add usage and purpose for
+      `actions-cost-audit.sh`.
+- [ ] `docs/workflow/development-workflow/integrations/actions-cost-audit.md` -
+      add the cost-audit runbook, output interpretation guidance, public/private
+      cost-risk framing, and recommendation vocabulary.
+- [ ] `docs/workflow/development-workflow/integrations/e2e-regression.md` -
+      link the cost-audit guidance where placeholder regression cost is
+      discussed.
+- [ ] `docs/workflow/development-workflow/integrations/pr-agent.md` - link the
+      cost-audit guidance from the PR-Agent cost discussion.
+- [ ] `docs/workflow/development-workflow/README.md` - add the new integration
+      guide to the Protocol And Integration Index.
+- [ ] `AGENTS.md` - no update expected; this does not change agent commands,
+      project structure, or standing conventions.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Wall time is mistaken for exact billable minutes | Med | Med | Label the metric as wall time, document that exact billing requires GitHub billing or organization metrics, and avoid dollar estimates. |
+| Missing timestamps or partial permissions create misleading totals | Med | Med | Track incomplete runs separately and print data-limit notes in the report. |
+| Date parsing behaves differently across macOS and Linux | Med | Low | Use `jq` date parsing for ISO timestamps rather than platform-specific `date` flags. |
+| Recommendation heuristics appear too authoritative | Low | Med | Present outcomes as a worksheet and decision guide; avoid automatic destructive recommendations. |
+| Shell portability or quoting bugs | Low | Med | Use strict Bash, focused mocked tests, ShellCheck, and workflow shell guard. |
+
+---
+
+## Code Samples
+
+No production code samples are included in this plan.
+
+---
+
+## Implementation Order
+
+1. Create `scripts/development-workflow/actions-cost-audit.sh`.
+   - Implement strict argument parsing for `--limit`, `--repo`, `--since`, and
+     `--format markdown`.
+   - Validate required local commands (`gh`, `jq`) before invoking GitHub.
+   - Use `gh run list --json databaseId,workflowName,workflowDatabaseId,status,conclusion,createdAt,startedAt,updatedAt,event,headBranch,url`.
+   - Ensure `gh` failures print a clear error and exit non-zero.
+2. Implement aggregation and markdown rendering.
+   - Group by workflow name/fallback ID.
+   - Compute completed and incomplete run counts.
+   - Compute total and average wall-time minutes only from runs with valid start
+     and end timestamps.
+   - Include recent run IDs/URLs and dominant events as context.
+   - Include the public/private cost-risk note and recommendation worksheet.
+3. Add `scripts/development-workflow/tests/test-actions-cost-audit.sh`.
+   - Mock `gh` through `PATH` using temporary scripts.
+   - Cover successful aggregation, incomplete timestamp handling, empty data,
+     permission/auth failure, recommendation outcomes, and public/private
+     framing.
+4. Update documentation listed in **Documentation Updates**.
+   - Keep the new integration guide focused on repository-level workflow-run
+     visibility, not billing-admin dashboards.
+   - Include example commands:
+     `./scripts/development-workflow/actions-cost-audit.sh --limit 100` and
+     `./scripts/development-workflow/actions-cost-audit.sh --repo owner/repo --since 2026-07-01T00:00:00Z`.
+5. Update the smoke runbook during implementation if the final command options
+   or output headings differ from this plan.
+6. Update `CHANGELOG.md` under `[Unreleased]` / `Added` with this literal entry:
+   `- **Actions cost-audit guidance** (#1099): Add lightweight workflow run-volume and wall-time audit guidance for retrospectives and downstream template-sync reviews.`
+7. Run focused validation:
+   - `bash scripts/development-workflow/tests/test-actions-cost-audit.sh`
+   - `shellcheck --severity=warning scripts/development-workflow/actions-cost-audit.sh scripts/development-workflow/tests/test-actions-cost-audit.sh`
+   - `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
+   - `npx markdownlint-cli2 "scripts/development-workflow/README.md" "docs/workflow/development-workflow/README.md" "docs/workflow/development-workflow/integrations/actions-cost-audit.md" "docs/workflow/development-workflow/integrations/e2e-regression.md" "docs/workflow/development-workflow/integrations/pr-agent.md" "docs/testing/workflow/1099-actions-cost-audit-guidance.smoke-test.md" "CHANGELOG.md"`
+   - `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
+   - `git diff --check`
+8. Run a live non-mutating smoke check when authenticated `gh` is available:
+   `./scripts/development-workflow/actions-cost-audit.sh --limit 10`.
+   Confirm the output groups workflows, includes cost-risk framing, and reports
+   any data limitations without exposing secrets.

--- a/docs/testing/workflow/1099-actions-cost-audit-guidance.smoke-test.md
+++ b/docs/testing/workflow/1099-actions-cost-audit-guidance.smoke-test.md
@@ -1,0 +1,146 @@
+# Smoke Test Runbook: Actions Cost-Audit Guidance
+
+**Feature**: Actions cost-audit guidance
+**Spec**: [1_1099-actions-cost-audit-guidance_specs.md](../../specs/developments/20260701091532_1099-actions-cost-audit-guidance/1_1099-actions-cost-audit-guidance_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] You are in the repository root.
+- [ ] The implementation branch for #1099 is checked out.
+- [ ] `gh` is authenticated when running the optional live smoke step.
+- [ ] `jq`, `shellcheck`, and the repository markdown lint tooling are available.
+
+---
+
+## Test Data
+
+No application seed data is required.
+
+| Item | Value |
+| --- | --- |
+| Audit helper | `scripts/development-workflow/actions-cost-audit.sh` |
+| Focused test | `scripts/development-workflow/tests/test-actions-cost-audit.sh` |
+| Integration guide | `docs/workflow/development-workflow/integrations/actions-cost-audit.md` |
+| Recommendation outcomes | `keep`, `narrow`, `make opt-in`, `replace`, `disable`, `investigate` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Run Focused Static Tests
+
+**Maps to**: AC1, AC2, AC3, AC4, AC6, AC7, AC8
+
+1. Run `bash scripts/development-workflow/tests/test-actions-cost-audit.sh`.
+2. Confirm the test output reports success.
+
+**Expected result**: Mocked `gh` fixtures validate aggregation by workflow,
+duration handling, incomplete data visibility, empty data handling,
+permission-failure handling, recommendation outcomes, and public/private
+cost-risk framing.
+
+### Step 2: Run Shell Quality Checks
+
+**Maps to**: AC3, AC8
+
+1. Run:
+   `shellcheck --severity=warning scripts/development-workflow/actions-cost-audit.sh scripts/development-workflow/tests/test-actions-cost-audit.sh`.
+2. Run:
+   `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`.
+
+**Expected result**: ShellCheck and the workflow shell guard pass without new
+warnings.
+
+### Step 3: Validate Documentation and Output Contract
+
+**Maps to**: AC4, AC5, AC6, AC7, AC8
+
+1. Open `docs/workflow/development-workflow/integrations/actions-cost-audit.md`.
+2. Confirm it explains public-template zero-billable standard-runner assumptions
+   separately from private downstream runner-minute risk.
+3. Confirm it states that the helper reports wall time, not exact dollars.
+4. Confirm it describes when to keep high-signal workflows despite cost.
+5. Confirm it documents all recommendation outcomes:
+   `keep`, `narrow`, `make opt-in`, `replace`, `disable`, and `investigate`.
+6. Confirm the example output is compact enough to paste into a retrospective or
+   template-sync review.
+
+**Expected result**: Maintainers can use the guide without billing-admin access
+and can copy the recommendation format into review notes.
+
+### Step 4: Run Markdown Validation
+
+**Maps to**: AC7, AC8
+
+1. Run markdown lint on the changed docs and this runbook.
+2. Run the repository heuristic markdown lint command against workflow docs,
+   testing docs, and `CHANGELOG.md`.
+
+**Expected result**: Markdown lint and heuristic lint pass.
+
+### Step 5: Run Optional Live Audit
+
+**Maps to**: AC1, AC2, AC3, AC7
+
+1. Run `./scripts/development-workflow/actions-cost-audit.sh --limit 10`.
+2. Confirm the command exits successfully.
+3. Confirm the output groups recent runs by workflow.
+4. Confirm total or average wall-time signals are present when timestamp data is
+   available.
+5. Confirm any unavailable or incomplete data is called out explicitly.
+
+**Expected result**: A maintainer with normal repository workflow-run
+visibility can generate a useful audit summary without billing-admin access.
+
+---
+
+## Assertions Checklist
+
+- [ ] AC1: Maintainers can inspect recent workflow run counts by workflow using
+      normal repository workflow-run visibility.
+- [ ] AC2: Maintainers can inspect recent workflow wall time or an equivalent
+      duration signal by workflow.
+- [ ] AC3: The audit output identifies unavailable, incomplete, or
+      permission-limited workflow run data.
+- [ ] AC4: Guidance distinguishes public-repository zero-billable template runs
+      from private downstream runner-minute cost risk.
+- [ ] AC5: Guidance explains when to keep workflows despite cost, including
+      high-signal checks, release gates, and real regression or deployment jobs.
+- [ ] AC6: Guidance supports `keep`, `narrow`, `make opt-in`, `replace`,
+      `disable`, and `investigate`.
+- [ ] AC7: Output is suitable for retrospectives or template-sync reviews,
+      including compact summary and decision rationale.
+- [ ] AC8: Tests or static validation cover the output structure and
+      public-vs-private cost-risk framing.
+
+---
+
+## Seed Data Reference
+
+No seed data is required.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `gh` reports authentication or permission failure | The current account cannot read workflow runs for the repository | Authenticate with `gh auth login` or rerun against a repository where the account has Actions read visibility. |
+| Live audit shows no workflow runs | The repository has no recent runs in the inspected limit or date range | Increase `--limit`, remove `--since`, or confirm Actions are enabled for the repository. |
+| Duration totals are lower than expected | Some runs are missing start or end timestamps | Check the data-limitation notes and inspect recent run IDs directly with `gh run view`. |
+| Shell tests fail while live audit works | Mock fixture or output contract drifted during implementation | Update the focused test to match the intended stable output headings and rerun it. |
+
+---
+
+## Known Limitations
+
+- The audit reports workflow-run wall time, not exact billable minutes or dollar
+  cost.
+- The live smoke step depends on current GitHub CLI authentication and
+  repository Actions visibility.


### PR DESCRIPTION
## Summary

Adds the implementation plan and smoke test runbook for #1099 Actions cost-audit guidance.

Approach: add a lightweight `gh run list` based audit helper, mocked shell coverage, and workflow documentation that makes Actions run volume and wall-time visible without billing-admin access.

Complexity: S. The work is scoped to one shell helper, one focused test harness, and documentation.

Key risks: wall time being confused with exact billable minutes, incomplete GitHub run data, and overly authoritative recommendations. The plan mitigates these with explicit data-limit notes, public/private cost-risk framing, and a recommendation worksheet rather than automatic workflow mutation.

Artifacts:

- Plan: `docs/specs/developments/20260701091532_1099-actions-cost-audit-guidance/2_1099-actions-cost-audit-guidance_implementation-plan.md`
- Smoke runbook: `docs/testing/workflow/1099-actions-cost-audit-guidance.smoke-test.md`

## Document Quality Gate

- Spec/brief coverage: Checked - all #1099 acceptance criteria map to implementation steps and smoke/test coverage.
- Implementation-order consistency: Checked - helper, test, documentation paths, and command options are consistent across the plan and runbook.
- Verification support: Checked - scope claims cite the Verification Log commands and current repo evidence.
- Behavioral guarantees: Checked - data-limit handling, non-mutating output, and no billing-admin dependency name the intended mechanisms.
- Parser/API/concurrency checklist: Checked - parser-risk and concurrent-event-source are explicitly classified as not applicable with rationale.
- CHANGELOG literal format: Checked - implementation-stage literal uses the required `**Bold Title** (#N):` format.
- Not-applicable rationale: Checked - database, frontend, infrastructure mutation, parser-risk, and concurrency exclusions include rationale.

Refs #1099

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no workflow, auth, or production code impact.
> 
> **Overview**
> Adds **#1099** planning artifacts only: an implementation plan and a smoke-test runbook. No shell helper, tests, or integration docs are introduced in this diff.
> 
> The plan specifies a future `actions-cost-audit.sh` helper (`gh run list` + `jq`) that aggregates run counts and **wall time** by workflow, emits markdown with data-limit notes, public/private cost-risk framing, and a recommendation worksheet (`keep`, `narrow`, `make opt-in`, `replace`, `disable`, `investigate`). It also outlines mocked shell tests, doc touchpoints, validation commands, and a planned `CHANGELOG` entry.
> 
> The new smoke runbook maps acceptance criteria to focused tests, ShellCheck/workflow guard, doc contract checks, markdown lint, and an optional live `gh` audit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdc6832307042fdb9cea28210dee0899cd90b76a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->