### PR TITLE
feat(workflow): add actions cost audit guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Actions cost-audit guidance** (#1099): Add lightweight workflow run-volume
+  and wall-time audit guidance for retrospectives and downstream template-sync
+  reviews.
+
 ### Fixed
 
 - **Release readiness wording**: command and overview surfaces now state that

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -619,6 +619,7 @@ Repository helpers:
 - `docs/workflow/development-workflow/integrations/workflow-hub-github-app.md`
 - `docs/workflow/development-workflow/integrations/ci-cd-deployment.md`
 - `docs/workflow/development-workflow/integrations/e2e-regression.md`
+- `docs/workflow/development-workflow/integrations/actions-cost-audit.md`
 
 ---
 

--- a/docs/workflow/development-workflow/integrations/actions-cost-audit.md
+++ b/docs/workflow/development-workflow/integrations/actions-cost-audit.md
@@ -1,0 +1,114 @@
+# Integration: Actions Cost Audit
+
+Use `scripts/development-workflow/actions-cost-audit.sh` when maintainers need a
+lightweight view of recent GitHub Actions run volume before changing workflow
+defaults, running retrospectives, or reviewing downstream template-sync cost
+risk.
+
+The helper uses normal repository workflow-run visibility through `gh run list`.
+It does not call billing APIs, does not require billing-admin access, and does
+not mutate workflow files or repository settings.
+
+---
+
+## Quick Start
+
+From the repository root:
+
+```bash
+./scripts/development-workflow/actions-cost-audit.sh --limit 100
+```
+
+To inspect another repository or apply a recent timestamp cutoff:
+
+```bash
+./scripts/development-workflow/actions-cost-audit.sh \
+  --repo owner/repo \
+  --since 2026-07-01T00:00:00Z
+```
+
+The output is markdown so it can be pasted into a retrospective, a template-sync
+review, or a follow-up issue.
+
+---
+
+## What The Audit Shows
+
+The workflow summary groups recent runs by workflow and reports:
+
+- run count;
+- completed run count;
+- runs excluded from duration totals because timestamp data is incomplete;
+- total wall time from completed runs with usable timestamps;
+- average wall time from completed runs with usable timestamps;
+- dominant trigger events;
+- recent run IDs or URLs for follow-up inspection.
+
+Wall time is a comparable cost signal, not an exact billable-minute or dollar
+calculation. Use GitHub billing and usage dashboards for authoritative billing
+data.
+
+---
+
+## Public And Private Cost Framing
+
+Public template repositories using standard GitHub-hosted runners are generally
+zero-billable for Actions minutes. That does not prove the same workflow default
+is safe for private downstream repositories: inherited workflows can consume
+included or paid runner minutes once synchronized into a private repository.
+
+Larger runners, self-hosted runners, artifact/cache storage, and account plan
+terms can have different billing behavior. Treat this audit as a workflow-run
+volume and wall-time review, then use billing dashboards when exact costs are
+needed.
+
+---
+
+## Recommendation Outcomes
+
+Use these outcomes in the generated worksheet:
+
+| Outcome | Use when |
+| --- | --- |
+| `keep` | The workflow is high-signal: CI, reviewer gate, release gate, real regression, or real deploy value. |
+| `narrow` | The workflow is valuable but runs on more events, branches, or paths than necessary. |
+| `make opt-in` | The workflow is a placeholder or occasional diagnostic that should not run automatically downstream. |
+| `replace` | The workflow is useful but should move to a cheaper or more targeted mechanism. |
+| `disable` | The workflow no longer provides enough value to justify even low-cost automatic runs. |
+| `investigate` | More data is needed before changing triggers or defaults. |
+
+Prefer `keep` for high-signal checks even when they are visibly expensive:
+required CI, reviewer readiness gates, release gates, real regression suites, and
+real deployment workflows protect quality and release safety. Cost reduction
+should start with low-signal fan-out, placeholder jobs, duplicated checks, broad
+path triggers, or workflows that no longer gate a meaningful decision.
+
+---
+
+## Data Limitations
+
+The helper reports limitations directly in the output:
+
+- runs with missing or unparseable timestamps are counted but excluded from wall
+  time totals;
+- `--limit` can hide older high-volume workflows;
+- `--since` filters only the runs returned inside the inspected limit;
+- GitHub CLI authentication or repository permissions can prevent run history
+  access.
+
+If the helper reports no data, increase `--limit`, remove `--since`, or confirm
+that the current `gh` account can read Actions runs for the repository.
+
+---
+
+## Validation
+
+Focused coverage lives in:
+
+```bash
+bash scripts/development-workflow/tests/test-actions-cost-audit.sh
+```
+
+The test uses a mocked `gh` command and validates aggregation, incomplete data,
+empty data, permission failures, recommendation outcomes, and public/private
+cost-risk framing without live network access.

--- a/docs/workflow/development-workflow/integrations/e2e-regression.md
+++ b/docs/workflow/development-workflow/integrations/e2e-regression.md
@@ -95,3 +95,6 @@ The `ready-for-regression` label is applied to implementation PRs (`feature/*`, 
 - For projects without e2e tests, keep the placeholder disabled and do not
   configure it as a required check. The orchestrator will still apply the label,
   but the inactive placeholder will not spend runner minutes on browser setup.
+- Use [`actions-cost-audit.md`](actions-cost-audit.md) when reviewing whether
+  regression workflow run volume should stay as-is, be narrowed, or remain
+  opt-in for downstream private repositories.

--- a/docs/workflow/development-workflow/integrations/pr-agent.md
+++ b/docs/workflow/development-workflow/integrations/pr-agent.md
@@ -66,6 +66,11 @@ section. The comment body will contain one of two stable markers:
 
 For a moderate batch workflow (100 PRs/month, ~20K tokens each), expect **$3–15/month** with DeepSeek.
 
+To review the GitHub Actions runner-time side of PR-Agent usage, run the
+lightweight workflow audit in [`actions-cost-audit.md`](actions-cost-audit.md).
+That audit reports recent workflow run counts and wall time; it does not replace
+provider token-cost estimates or GitHub billing dashboards.
+
 ---
 
 ## Model Configuration

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -19,6 +19,35 @@ Use this when:
 - You want to make the template's bundled Codex skills and command-style aliases available in your local Codex environment
 - You are testing the workflow skills in a downstream repository created from this template
 
+### `actions-cost-audit.sh`
+
+Summarizes recent GitHub Actions workflow run volume and wall time by workflow
+using normal `gh run list` visibility.
+
+Usage:
+
+```bash
+./scripts/development-workflow/actions-cost-audit.sh --limit 100
+./scripts/development-workflow/actions-cost-audit.sh --repo owner/repo --since 2026-07-01T00:00:00Z
+```
+
+What it does:
+
+- Groups recent workflow runs by workflow name
+- Reports run count, completed count, incomplete duration count, total wall time,
+  average wall time, trigger events, and recent run links
+- Prints public/private repository cost-risk framing
+- Emits a recommendation worksheet for retrospectives and template-sync reviews
+
+Use this when:
+
+- You want to identify high-volume or high-wall-time workflow defaults without
+  billing-admin access
+- You are reviewing whether a workflow should be kept, narrowed, made opt-in,
+  replaced, disabled, or investigated
+- A downstream private repository may inherit template workflows that are
+  zero-billable in the public template but expensive after sync
+
 ### `add-backlog-item.sh`
 
 Resolves the configured issue tracker destination for backlog creation and can create a GitHub issue when `issue_tracker.provider` maps to GitHub Issues / GitHub Projects.

--- a/scripts/development-workflow/actions-cost-audit.sh
+++ b/scripts/development-workflow/actions-cost-audit.sh
@@ -193,13 +193,14 @@ jq -r --arg repo "$REPO" --arg since "$SINCE" --argjson limit "$LIMIT" '
               runs: ($items | length),
               completed: ($items | map(select(.status == "completed")) | length),
               incomplete: ($items | map(select(.durationIncomplete)) | length),
-              totalSeconds: $total,
+              totalSeconds: (if $duration_count > 0 then $total else null end),
+              sortSeconds: $total,
               averageSeconds: (if $duration_count > 0 then ($total / $duration_count) else null end),
               events: ($items | event_summary),
               recentRuns: ($items | run_id_summary)
             }
         )
-      | sort_by(-.totalSeconds, -.runs, .workflow)) as $summary
+      | sort_by(-.sortSeconds, -.runs, .workflow)) as $summary
     | "# GitHub Actions Cost Audit\n\n" +
       scope_line +
       "Runs included: " + ($filtered_count | tostring) + ". Incomplete duration records: " + ($incomplete_count | tostring) + ".\n\n" +

--- a/scripts/development-workflow/actions-cost-audit.sh
+++ b/scripts/development-workflow/actions-cost-audit.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: actions-cost-audit.sh [--limit <count>] [--repo <owner/repo>] [--since <iso-date>] [--format markdown]
+
+Summarize recent GitHub Actions workflow run volume and wall time by workflow.
+
+Options:
+  --limit <count>      Number of recent runs to inspect. Default: 100.
+  --repo <owner/repo>  Repository to inspect. Defaults to gh's current repository.
+  --since <iso-date>   Include runs created at or after this ISO-8601 UTC timestamp.
+  --format markdown    Output format. Only markdown is currently supported.
+  -h, --help           Show this help.
+USAGE
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+LIMIT=100
+REPO=""
+SINCE=""
+FORMAT="markdown"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --limit)
+      [ "$#" -ge 2 ] || fail "--limit requires a value"
+      LIMIT="$2"
+      shift 2
+      ;;
+    --repo)
+      [ "$#" -ge 2 ] || fail "--repo requires a value"
+      REPO="$2"
+      shift 2
+      ;;
+    --since)
+      [ "$#" -ge 2 ] || fail "--since requires a value"
+      SINCE="$2"
+      shift 2
+      ;;
+    --format)
+      [ "$#" -ge 2 ] || fail "--format requires a value"
+      FORMAT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+case "$LIMIT" in
+  ''|*[!0-9]*)
+    fail "--limit must be a positive integer"
+    ;;
+esac
+[ "$LIMIT" -gt 0 ] || fail "--limit must be greater than 0"
+
+[ "$FORMAT" = "markdown" ] || fail "unsupported --format '$FORMAT'; only markdown is supported"
+
+command -v gh >/dev/null 2>&1 || fail "gh CLI is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+
+if [ -n "$SINCE" ]; then
+  jq -n --arg since "$SINCE" '$since | fromdateiso8601' >/dev/null \
+    || fail "--since must be an ISO-8601 UTC timestamp, for example 2026-07-01T00:00:00Z"
+fi
+
+FIELDS="databaseId,workflowName,workflowDatabaseId,status,conclusion,createdAt,startedAt,updatedAt,event,headBranch,url"
+GH_ARGS=(run list --limit "$LIMIT" --json "$FIELDS")
+if [ -n "$REPO" ]; then
+  GH_ARGS+=(--repo "$REPO")
+fi
+
+if ! RUNS_JSON=$(gh "${GH_ARGS[@]}" 2>&1); then
+  printf 'ERROR: gh run list failed. Confirm gh authentication and repository Actions read visibility.\n' >&2
+  printf '%s\n' "$RUNS_JSON" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$RUNS_JSON" | jq -e 'type == "array"' >/dev/null 2>&1; then
+  fail "gh run list returned unexpected non-array JSON"
+fi
+
+jq -r --arg repo "$REPO" --arg since "$SINCE" --argjson limit "$LIMIT" '
+  def parse_time:
+    if . == null or . == "" then null
+    else try fromdateiso8601 catch null
+    end;
+
+  def minutes($seconds):
+    if $seconds == null then "n/a"
+    else (((($seconds / 60) * 10 | round) / 10) | tostring) + "m"
+    end;
+
+  def safe_cell:
+    tostring | gsub("\\|"; "\\|") | gsub("\n"; " ");
+
+  def run_key:
+    if (.workflowName // "") != "" then .workflowName
+    elif (.workflowDatabaseId // "") != "" then "workflow:" + (.workflowDatabaseId | tostring)
+    else "unknown-workflow"
+    end;
+
+  def run_url:
+    if (.url // "") != "" then .url
+    elif (.databaseId // "") != "" then "#" + (.databaseId | tostring)
+    else "unknown"
+    end;
+
+  def event_summary:
+    map(.event // "unknown")
+    | group_by(.)
+    | map({event: .[0], count: length})
+    | sort_by(-.count, .event)
+    | .[0:3]
+    | map(.event + " (" + (.count | tostring) + ")")
+    | join(", ");
+
+  def run_id_summary:
+    map(run_url)
+    | .[0:5]
+    | join(", ");
+
+  def normalize:
+    . as $run
+    | ($run.createdAt | parse_time) as $created
+    | ($run.startedAt | parse_time) as $started
+    | ($run.updatedAt | parse_time) as $updated
+    | (($started // $created) as $start
+      | if ($run.status == "completed" and $start != null and $updated != null and $updated >= $start)
+        then ($updated - $start)
+        else null
+        end) as $duration
+    | $run + {
+        workflowKey: ($run | run_key),
+        createdEpoch: $created,
+        durationSeconds: $duration,
+        durationIncomplete: ($duration == null)
+      };
+
+  def recommendation_outcomes:
+    "## Recommendation outcomes\n\n" +
+    "| Outcome | Use when |\n" +
+    "| --- | --- |\n" +
+    "| keep | The workflow is high-signal: CI, reviewer gate, release gate, real regression, or real deploy value. |\n" +
+    "| narrow | The workflow is valuable but runs on more events, branches, or paths than necessary. |\n" +
+    "| make opt-in | The workflow is a placeholder or occasional diagnostic that should not run automatically downstream. |\n" +
+    "| replace | The workflow is useful but should move to a cheaper or more targeted mechanism. |\n" +
+    "| disable | The workflow no longer provides enough value to justify even low-cost automatic runs. |\n" +
+    "| investigate | More data is needed before changing triggers or defaults. |\n";
+
+  def cost_framing:
+    "## Public/private cost-risk framing\n\n" +
+    "- Public template repositories using standard GitHub-hosted runners are generally zero-billable for Actions minutes.\n" +
+    "- Private downstream repositories can consume included or paid runner minutes for the same inherited workflow defaults.\n" +
+    "- Larger runners, self-hosted runners, storage, and account-specific plan terms may differ; use billing dashboards for exact cost.\n" +
+    "- This audit reports workflow-run wall time, not exact billable minutes or dollar cost.\n";
+
+  def scope_line:
+    "Scope: " + (if $repo == "" then "current repository" else $repo end) +
+    ", recent run limit " + ($limit | tostring) +
+    (if $since == "" then "" else ", since " + $since end) + ".\n\n";
+
+  def render_empty:
+    "# GitHub Actions Cost Audit\n\n" +
+    scope_line +
+    "No workflow run data was available for the selected scope. This can mean the repository has no matching runs, the inspected limit is too small, or the current account lacks workflow-run visibility.\n\n" +
+    cost_framing + "\n" +
+    recommendation_outcomes;
+
+  def render_report($runs):
+    ($runs | length) as $filtered_count
+    | ($runs | map(select(.durationIncomplete)) | length) as $incomplete_count
+    | ($runs
+      | group_by(.workflowKey)
+      | map(
+          . as $items
+          | ($items | map(.durationSeconds // 0) | add) as $total
+          | ($items | map(select(.durationSeconds != null)) | length) as $duration_count
+          | {
+              workflow: $items[0].workflowKey,
+              runs: ($items | length),
+              completed: ($items | map(select(.status == "completed")) | length),
+              incomplete: ($items | map(select(.durationIncomplete)) | length),
+              totalSeconds: $total,
+              averageSeconds: (if $duration_count > 0 then ($total / $duration_count) else null end),
+              events: ($items | event_summary),
+              recentRuns: ($items | run_id_summary)
+            }
+        )
+      | sort_by(-.totalSeconds, -.runs, .workflow)) as $summary
+    | "# GitHub Actions Cost Audit\n\n" +
+      scope_line +
+      "Runs included: " + ($filtered_count | tostring) + ". Incomplete duration records: " + ($incomplete_count | tostring) + ".\n\n" +
+      "## Workflow summary\n\n" +
+      "| Workflow | Runs | Completed | Incomplete duration | Total wall time | Avg wall time | Dominant events | Recent runs |\n" +
+      "| --- | ---: | ---: | ---: | ---: | ---: | --- | --- |\n" +
+      ($summary
+       | map("| " + (.workflow | safe_cell) +
+             " | " + (.runs | tostring) +
+             " | " + (.completed | tostring) +
+             " | " + (.incomplete | tostring) +
+             " | " + minutes(.totalSeconds) +
+             " | " + minutes(.averageSeconds) +
+             " | " + (.events | safe_cell) +
+             " | " + (.recentRuns | safe_cell) + " |")
+       | join("\n")) +
+      "\n\n## Data limitations\n\n" +
+      "- Runs without complete start/end timestamps are counted but excluded from wall-time totals.\n" +
+      "- The inspected run limit can hide older high-volume workflows; increase `--limit` or use `--since` for a wider review.\n" +
+      "- GitHub workflow-run visibility is repository-permission scoped. Billing-admin data is intentionally not required.\n\n" +
+      cost_framing + "\n" +
+      "## Recommendation worksheet\n\n" +
+      "| Workflow | Suggested outcome | Rationale |\n" +
+      "| --- | --- | --- |\n" +
+      ($summary
+       | map("| " + (.workflow | safe_cell) + " | investigate | Review volume, wall time, trigger scope, and quality/release value before changing defaults. |")
+       | join("\n")) +
+      "\n\n" +
+      recommendation_outcomes;
+
+  map(normalize)
+  | if $since == "" then .
+    else map(select(.createdEpoch != null and .createdEpoch >= ($since | fromdateiso8601)))
+    end
+  | sort_by(.createdEpoch // 0)
+  | reverse
+  | if length == 0 then render_empty else render_report(.) end
+' <<<"$RUNS_JSON"

--- a/scripts/development-workflow/tests/test-actions-cost-audit.sh
+++ b/scripts/development-workflow/tests/test-actions-cost-audit.sh
@@ -95,6 +95,19 @@ case "${GH_MOCK_MODE:-success}" in
     "url": "https://github.example/runs/202"
   },
   {
+    "databaseId": 203,
+    "workflowName": "In Progress Only",
+    "workflowDatabaseId": 44,
+    "status": "in_progress",
+    "conclusion": null,
+    "createdAt": "2026-07-01T09:00:00Z",
+    "startedAt": "2026-07-01T09:01:00Z",
+    "updatedAt": null,
+    "event": "pull_request",
+    "headBranch": "feature/example",
+    "url": "https://github.example/runs/203"
+  },
+  {
     "databaseId": 301,
     "workflowName": "Old Workflow",
     "workflowDatabaseId": 33,
@@ -132,8 +145,9 @@ run_audit() {
 output="$(GH_MOCK_MODE=success run_audit --limit 5)"
 assert_contains "$output" '^# GitHub Actions Cost Audit$' "report heading missing"
 assert_contains "$output" '\| CI \| 2 \| 1 \| 1 \| 10m \| 10m \|' "CI aggregation should include incomplete run and completed duration"
+assert_contains "$output" '\| In Progress Only \| 1 \| 0 \| 1 \| n/a \| n/a \|' "all-incomplete workflow durations should render as n/a"
 assert_contains "$output" '\| PR-Agent \| 2 \| 2 \| 0 \| 5m \| 2\.5m \|' "PR-Agent aggregation should sum and average duration"
-assert_contains "$output" 'Incomplete duration records: 1' "incomplete duration count missing"
+assert_contains "$output" 'Incomplete duration records: 2' "incomplete duration count missing"
 assert_contains "$output" 'Public/private cost-risk framing' "cost-risk framing section missing"
 assert_contains "$output" 'Private downstream repositories can consume included or paid runner minutes' "private downstream risk language missing"
 assert_contains "$output" '\| make opt-in \|' "make opt-in recommendation outcome missing"

--- a/scripts/development-workflow/tests/test-actions-cost-audit.sh
+++ b/scripts/development-workflow/tests/test-actions-cost-audit.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/development-workflow/actions-cost-audit.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local text="$1"
+  local pattern="$2"
+  local message="$3"
+
+  printf '%s\n' "$text" | grep -Eq "$pattern" || fail "$message"
+}
+
+assert_not_contains() {
+  local text="$1"
+  local pattern="$2"
+  local message="$3"
+
+  if printf '%s\n' "$text" | grep -Eq "$pattern"; then
+    fail "$message"
+  fi
+}
+
+cat > "$TMP_DIR/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${GH_MOCK_MODE:-success}" in
+  success)
+    cat <<'JSON'
+[
+  {
+    "databaseId": 101,
+    "workflowName": "PR-Agent",
+    "workflowDatabaseId": 11,
+    "status": "completed",
+    "conclusion": "success",
+    "createdAt": "2026-07-01T13:00:00Z",
+    "startedAt": "2026-07-01T13:01:00Z",
+    "updatedAt": "2026-07-01T13:04:00Z",
+    "event": "issue_comment",
+    "headBranch": "feature/example",
+    "url": "https://github.example/runs/101"
+  },
+  {
+    "databaseId": 102,
+    "workflowName": "PR-Agent",
+    "workflowDatabaseId": 11,
+    "status": "completed",
+    "conclusion": "success",
+    "createdAt": "2026-07-01T12:00:00Z",
+    "startedAt": "2026-07-01T12:00:30Z",
+    "updatedAt": "2026-07-01T12:02:30Z",
+    "event": "issue_comment",
+    "headBranch": "feature/example",
+    "url": "https://github.example/runs/102"
+  },
+  {
+    "databaseId": 201,
+    "workflowName": "CI",
+    "workflowDatabaseId": 22,
+    "status": "completed",
+    "conclusion": "success",
+    "createdAt": "2026-07-01T11:00:00Z",
+    "startedAt": "2026-07-01T11:00:00Z",
+    "updatedAt": "2026-07-01T11:10:00Z",
+    "event": "pull_request",
+    "headBranch": "feature/example",
+    "url": "https://github.example/runs/201"
+  },
+  {
+    "databaseId": 202,
+    "workflowName": "CI",
+    "workflowDatabaseId": 22,
+    "status": "in_progress",
+    "conclusion": null,
+    "createdAt": "2026-07-01T10:00:00Z",
+    "startedAt": "2026-07-01T10:01:00Z",
+    "updatedAt": null,
+    "event": "pull_request",
+    "headBranch": "feature/example",
+    "url": "https://github.example/runs/202"
+  },
+  {
+    "databaseId": 301,
+    "workflowName": "Old Workflow",
+    "workflowDatabaseId": 33,
+    "status": "completed",
+    "conclusion": "success",
+    "createdAt": "2026-06-01T10:00:00Z",
+    "startedAt": "2026-06-01T10:00:00Z",
+    "updatedAt": "2026-06-01T10:05:00Z",
+    "event": "push",
+    "headBranch": "develop",
+    "url": "https://github.example/runs/301"
+  }
+]
+JSON
+    ;;
+  empty)
+    printf '[]\n'
+    ;;
+  fail)
+    printf 'HTTP 403: Resource not accessible by integration\n' >&2
+    exit 1
+    ;;
+  *)
+    printf 'unknown GH_MOCK_MODE\n' >&2
+    exit 2
+    ;;
+esac
+MOCK_GH
+chmod +x "$TMP_DIR/gh"
+
+run_audit() {
+  PATH="$TMP_DIR:$PATH" "$SCRIPT" "$@"
+}
+
+output="$(GH_MOCK_MODE=success run_audit --limit 5)"
+assert_contains "$output" '^# GitHub Actions Cost Audit$' "report heading missing"
+assert_contains "$output" '\| CI \| 2 \| 1 \| 1 \| 10m \| 10m \|' "CI aggregation should include incomplete run and completed duration"
+assert_contains "$output" '\| PR-Agent \| 2 \| 2 \| 0 \| 5m \| 2\.5m \|' "PR-Agent aggregation should sum and average duration"
+assert_contains "$output" 'Incomplete duration records: 1' "incomplete duration count missing"
+assert_contains "$output" 'Public/private cost-risk framing' "cost-risk framing section missing"
+assert_contains "$output" 'Private downstream repositories can consume included or paid runner minutes' "private downstream risk language missing"
+assert_contains "$output" '\| make opt-in \|' "make opt-in recommendation outcome missing"
+assert_contains "$output" '\| keep \|' "keep recommendation outcome missing"
+assert_contains "$output" '\| investigate \|' "investigate recommendation outcome missing"
+
+repo_output="$(GH_MOCK_MODE=success run_audit --limit 1 --repo "owner/repo with space")"
+assert_contains "$repo_output" 'owner/repo with space' "repo argument with spaces should be preserved in output"
+
+since_output="$(GH_MOCK_MODE=success run_audit --limit 5 --since 2026-07-01T00:00:00Z)"
+assert_contains "$since_output" 'since 2026-07-01T00:00:00Z' "since scope should be printed"
+assert_not_contains "$since_output" 'Old Workflow' "since filter should remove older runs"
+
+empty_output="$(GH_MOCK_MODE=empty run_audit --limit 5)"
+assert_contains "$empty_output" 'No workflow run data was available' "empty run history should produce no-data report"
+assert_contains "$empty_output" '\| disable \|' "empty report should still include recommendation vocabulary"
+
+if GH_MOCK_MODE=fail run_audit --limit 5 >"$TMP_DIR/fail.out" 2>"$TMP_DIR/fail.err"; then
+  fail "permission failure should exit non-zero"
+fi
+assert_contains "$(cat "$TMP_DIR/fail.err")" 'ERROR: gh run list failed' "permission failure should include actionable error"
+
+if run_audit --limit 0 >"$TMP_DIR/limit.out" 2>"$TMP_DIR/limit.err"; then
+  fail "limit zero should exit non-zero"
+fi
+assert_contains "$(cat "$TMP_DIR/limit.err")" 'limit must be greater than 0' "limit validation message missing"
+
+if run_audit --limit " " >"$TMP_DIR/blank-limit.out" 2>"$TMP_DIR/blank-limit.err"; then
+  fail "whitespace-only limit should exit non-zero"
+fi
+assert_contains "$(cat "$TMP_DIR/blank-limit.err")" 'limit must be a positive integer' "blank limit validation message missing"
+
+if run_audit --since not-a-date >"$TMP_DIR/since.out" 2>"$TMP_DIR/since.err"; then
+  fail "invalid since timestamp should exit non-zero"
+fi
+assert_contains "$(cat "$TMP_DIR/since.err")" 'ISO-8601 UTC timestamp' "invalid since validation message missing"
+
+printf 'actions cost audit checks passed\n'


### PR DESCRIPTION
## Summary

Implements #1099 by adding a lightweight GitHub Actions cost-audit helper and the accompanying guidance for retrospectives and downstream template-sync reviews.

What changed:

- Added `scripts/development-workflow/actions-cost-audit.sh` to aggregate recent workflow run count and wall time by workflow using `gh run list`.
- Added `scripts/development-workflow/tests/test-actions-cost-audit.sh` with mocked `gh` coverage for aggregation, incomplete data, empty data, permission failures, recommendation outcomes, public/private framing, and input validation.
- Added `docs/workflow/development-workflow/integrations/actions-cost-audit.md` and linked it from the workflow README, e2e regression guide, PR-Agent guide, and scripts README.
- Added the #1099 `[Unreleased]` CHANGELOG entry.

Spec: `docs/specs/developments/20260701091532_1099-actions-cost-audit-guidance/1_1099-actions-cost-audit-guidance_specs.md`
Plan: `docs/specs/developments/20260701091532_1099-actions-cost-audit-guidance/2_1099-actions-cost-audit-guidance_implementation-plan.md`
Smoke runbook: `docs/testing/workflow/1099-actions-cost-audit-guidance.smoke-test.md`

## Verification

- `bash scripts/development-workflow/tests/test-actions-cost-audit.sh`
- `shellcheck --severity=warning scripts/development-workflow/actions-cost-audit.sh scripts/development-workflow/tests/test-actions-cost-audit.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 "scripts/development-workflow/README.md" "docs/workflow/development-workflow/README.md" "docs/workflow/development-workflow/integrations/actions-cost-audit.md" "docs/workflow/development-workflow/integrations/e2e-regression.md" "docs/workflow/development-workflow/integrations/pr-agent.md" "docs/testing/workflow/1099-actions-cost-audit-guidance.smoke-test.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`
- `./scripts/development-workflow/actions-cost-audit.sh --limit 10`

## Pre-Submission Self-Review

Stale markers: none found in added staged lines.
Caller/sibling consistency: verified helper name, doc links, README index entry, smoke runbook expectations, and CHANGELOG entry match.
Coverage: all #1099 acceptance criteria are addressed by the helper output, integration guide, mocked tests, and smoke runbook.
Plan deviations: none.

## Test Harness Coverage Checklist

- Empty / zero-length input: checked via mocked empty `gh run list` response.
- Whitespace-only input: checked via whitespace-only `--limit` validation.
- Boundary values: checked via `--limit 0` validation and normal positive limit runs.
- Missing / absent environment variables: not applicable; helper has no required environment variables.
- Concurrent / parallel execution: not applicable; helper is read-only and test fixtures are isolated in `mktemp -d`.
- Negative assertions: checked via permission failure, invalid limit, invalid timestamp, and since-filter exclusion assertions.
- Single EXIT trap: checked; harness uses one cleanup trap.
- Variable-length quoting safety: checked via `--repo "owner/repo with space"`.
- `BASH_SOURCE` / harness guard placement: not applicable; harness is executed directly and does not support sourced mode.
- Sourced-function ordering: not applicable; harness does not source other scripts.

## Script-Accuracy Self-Check

Script: `scripts/development-workflow/actions-cost-audit.sh`

- Options `--limit`, `--repo`, `--since`, `--format`: verified in source option parser and usage text.
- GitHub data source `gh run list`: verified in source command construction.
- JSON fields `workflowName`, run IDs, timestamps, status, conclusion, event, branch, URL: verified in source `FIELDS` list.
- Permission/auth failure path: verified in source `gh run list failed` error branch and focused test.
- Markdown output sections: verified in source render functions and focused test.
- Public/private framing and recommendation outcomes: verified in source render functions, docs, and focused test.

## CHANGELOG Preview

- **Actions cost-audit guidance** (#1099): Add lightweight workflow run-volume and wall-time audit guidance for retrospectives and downstream template-sync reviews.

Closes #1099

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only shell helper and docs only; no workflow triggers, secrets, or billing mutations.
> 
> **Overview**
> Adds a **read-only maintainer helper** to review recent GitHub Actions **run volume and wall time** before changing workflow defaults, running retrospectives, or judging template-sync cost risk in private downstream repos.
> 
> `scripts/development-workflow/actions-cost-audit.sh` calls `gh run list` (no billing APIs), aggregates by workflow, and prints **markdown** with a summary table, data-limitation notes, public/private cost framing, and a recommendation worksheet (`keep`, `narrow`, `make opt-in`, etc.). Options include `--limit`, `--repo`, and `--since`.
> 
> Documentation and wiring: new `integrations/actions-cost-audit.md`, entries in the workflow and scripts READMEs, and pointers from the e2e-regression and PR-Agent integration guides. **`test-actions-cost-audit.sh`** mocks `gh` for aggregation, empty data, validation, and permission failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 823578dcb5a23c7463b533053b2f11982b2987c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Why Safe To Merge

```json
{
  "why_safe_to_merge": {
    "scope": "Adds one read-only GitHub Actions audit helper, one mocked shell test, workflow documentation links, and the #1099 CHANGELOG entry. It does not change workflow triggers, repository settings, labels, tracker state, or billing configuration.",
    "tests": "Focused mocked shell test, ShellCheck, workflow shell guard, markdownlint, markdown heuristic lint, changelog duplicate/header checks, git diff whitespace check, and live non-mutating audit smoke check all passed. The Bugbot duration finding was fixed and covered by a new all-incomplete workflow regression assertion.",
    "reviewer_outcome": "Internal code review approved. Automated reviewer loop reran after the Bugbot fix and returned clean with zero unresolved review threads.",
    "ci_outcome": "pr-ci-loop.sh for PR #1111 returned RESULT=green with no failing or pending checks after ready-for-regression was applied.",
    "rollback_or_cleanup_risk": "Low. Rollback is removing the helper, its focused test, docs links, integration guide, and CHANGELOG entry. The helper is read-only and has no persistent side effects."
  }
}
```
