### PR TITLE
fix(workflow): backport downstream reviewer corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release readiness wording**: command and overview surfaces now state that
   `release/*` PR reviewer loops are skipped while the production PR still gets
   regression and CI readiness before merge.
+- **Downstream template-sync reviewer corrections**: Codex reviewer idempotency,
+  workflow-hub GitHub App private-key paths, and optional Claude workflow tests
+  now handle downstream sync edge cases without false failures.
 
 ## [0.34.0] - 2026-06-30
 

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -244,8 +244,8 @@ IDEM_STDERR=$(mktemp)
 IDEM_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>"$IDEM_STDERR" \
-  | jq -c --arg sha "$CURRENT_SHA" --arg marker "review triggered by workflow runner" --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" \
-    '[.[] | select(.user.login != $bot and .user.login != $bot_plain) | select((.body | contains($sha)) and (.body | ascii_downcase | contains($marker)))] | sort_by(.created_at) | reverse | .[0] // empty | {id: .id, created_at: .created_at, body: .body}' \
+  | jq -sc --arg sha "$CURRENT_SHA" --arg marker "review triggered by workflow runner" --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" \
+    '[.[][] | select(.user.login != $bot and .user.login != $bot_plain) | select((.body | contains($sha)) and (.body | ascii_downcase | contains($marker)))] | sort_by(.created_at) | reverse | .[0] // empty | {id: .id, created_at: .created_at, body: .body}' \
   > "$IDEM_TMPFILE"; then
   TRIGGER_COMMENT_INFO=$(head -c 2000 "$IDEM_TMPFILE")
 else

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -244,8 +244,8 @@ IDEM_STDERR=$(mktemp)
 IDEM_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>"$IDEM_STDERR" \
-  | jq -r --arg sha "$CURRENT_SHA" --arg marker "review triggered by workflow runner" --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" \
-    '.[] | select(.user.login != $bot and .user.login != $bot_plain) | select((.body | contains($sha)) and (.body | ascii_downcase | contains($marker))) | {id: .id, created_at: .created_at, body: .body}' \
+  | jq -c --arg sha "$CURRENT_SHA" --arg marker "review triggered by workflow runner" --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" \
+    '[.[] | select(.user.login != $bot and .user.login != $bot_plain) | select((.body | contains($sha)) and (.body | ascii_downcase | contains($marker)))] | sort_by(.created_at) | reverse | .[0] // empty | {id: .id, created_at: .created_at, body: .body}' \
   > "$IDEM_TMPFILE"; then
   TRIGGER_COMMENT_INFO=$(head -c 2000 "$IDEM_TMPFILE")
 else

--- a/scripts/development-workflow/github-app-token.sh
+++ b/scripts/development-workflow/github-app-token.sh
@@ -84,16 +84,37 @@ create_jwt() {
   printf '%s.%s\n' "$signing_input" "$signature"
 }
 
+normalize_private_key_path() {
+  local raw_path="$1"
+
+  case "$raw_path" in
+    \~)
+      printf '%s\n' "$HOME"
+      ;;
+    \~/*)
+      printf '%s/%s\n' "$HOME" "${raw_path#\~/}"
+      ;;
+    /*)
+      printf '%s\n' "$raw_path"
+      ;;
+    *)
+      printf '%s/%s\n' "$REPO_ROOT" "$raw_path"
+      ;;
+  esac
+}
+
 load_private_key_file() {
   local private_key_path="$1"
   local secret_ref="$2"
   local tmp_dir="$3"
+  local resolved_private_key_path
 
   if [ -n "$private_key_path" ]; then
-    if [ ! -r "$private_key_path" ]; then
+    resolved_private_key_path="$(normalize_private_key_path "$private_key_path")"
+    if [ ! -r "$resolved_private_key_path" ]; then
       die "missing_private_key: configured private key path is not readable for selected product repository"
     fi
-    printf '%s\n' "$private_key_path"
+    printf '%s\n' "$resolved_private_key_path"
     return 0
   fi
 
@@ -123,8 +144,12 @@ exchange_token() {
   TOKEN_TMP_DIR="$(mktemp -d)"
 
   local key_file
-  key_file="$(load_private_key_file "$private_key_path" "$secret_ref" "$TOKEN_TMP_DIR")"
-  jwt="$(create_jwt "$app_id" "$key_file" "$TOKEN_TMP_DIR")"
+  if ! key_file="$(load_private_key_file "$private_key_path" "$secret_ref" "$TOKEN_TMP_DIR")"; then
+    exit 1
+  fi
+  if ! jwt="$(create_jwt "$app_id" "$key_file" "$TOKEN_TMP_DIR")"; then
+    die "missing_private_key: failed to sign GitHub App JWT with selected private key"
+  fi
 
   if [ -n "${WORKFLOW_GITHUB_APP_TOKEN_EXCHANGE_CMD:-}" ]; then
     if ! token="$("$WORKFLOW_GITHUB_APP_TOKEN_EXCHANGE_CMD" "$app_id" "$installation_id" "$jwt")"; then

--- a/scripts/development-workflow/tests/test-claude-code-action-reviewer.sh
+++ b/scripts/development-workflow/tests/test-claude-code-action-reviewer.sh
@@ -36,6 +36,7 @@ run_test() {
 }
 
 REVIEWER_SCRIPT="scripts/development-workflow/claude-code-action-reviewer.sh"
+# shellcheck disable=SC2034 # Consumed by the sourced reviewer script.
 CLAUDE_CODE_ACTION_REVIEWER_LIBRARY_MODE=1
 # shellcheck source=scripts/development-workflow/claude-code-action-reviewer.sh
 source "$REVIEWER_SCRIPT"
@@ -488,20 +489,24 @@ echo ""
 echo "=== Area 8: workflow prompt configuration ==="
 
 _workflow_file=".github/workflows/claude-code-review.yml"
-# shellcheck disable=SC2016 # Literal GitHub expression expected in workflow YAML.
-if grep -q 'prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ inputs.pr_number }}"' "$_workflow_file"; then
-  _has_prompt=1
-else
-  _has_prompt=0
-fi
-run_test "workflow_has_explicit_code_review_prompt" "1" "$_has_prompt"
+if [ -f "$_workflow_file" ]; then
+  # shellcheck disable=SC2016 # Literal GitHub expression expected in workflow YAML.
+  if grep -q 'prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ inputs.pr_number }}"' "$_workflow_file"; then
+    _has_prompt=1
+  else
+    _has_prompt=0
+  fi
+  run_test "workflow_has_explicit_code_review_prompt" "1" "$_has_prompt"
 
-if grep -q 'plugins: "code-review@claude-code-plugins"' "$_workflow_file"; then
-  _has_plugin=1
+  if grep -q 'plugins: "code-review@claude-code-plugins"' "$_workflow_file"; then
+    _has_plugin=1
+  else
+    _has_plugin=0
+  fi
+  run_test "workflow_has_code_review_plugin" "1" "$_has_plugin"
 else
-  _has_plugin=0
+  echo "INFO: optional Claude Code Action workflow not present; skipping workflow prompt assertions"
 fi
-run_test "workflow_has_code_review_plugin" "1" "$_has_plugin"
 unset _workflow_file _has_prompt _has_plugin
 
 # ---------------------------------------------------------------------------

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1855,14 +1855,39 @@ _codex_trigger_comments='[
 ]'
 _codex_selected_trigger="$(
   printf '%s\n' "$_codex_trigger_comments" \
-    | jq -c --arg sha "abc123" --arg marker "review triggered by workflow runner" --arg bot "chatgpt-codex-connector[bot]" --arg bot_plain "chatgpt-codex-connector" \
-      '[.[] | select(.user.login != $bot and .user.login != $bot_plain) | select((.body | contains($sha)) and (.body | ascii_downcase | contains($marker)))] | sort_by(.created_at) | reverse | .[0] // empty | {id: .id, created_at: .created_at, body: .body}'
+    | jq -sc --arg sha "abc123" --arg marker "review triggered by workflow runner" --arg bot "chatgpt-codex-connector[bot]" --arg bot_plain "chatgpt-codex-connector" \
+      '[.[][] | select(.user.login != $bot and .user.login != $bot_plain) | select((.body | contains($sha)) and (.body | ascii_downcase | contains($marker)))] | sort_by(.created_at) | reverse | .[0] // empty | {id: .id, created_at: .created_at, body: .body}'
 )"
 run_test "codex_trigger_idempotency_selects_newest" "222" \
   "$(printf '%s\n' "$_codex_selected_trigger" | jq -r '.id')"
 run_test "codex_trigger_idempotency_single_object" "1" \
   "$(printf '%s\n' "$_codex_selected_trigger" | wc -l | tr -d ' ')"
-unset _codex_trigger_comments _codex_selected_trigger
+_codex_paginated_trigger_comments='[
+  {
+    "id": 111,
+    "created_at": "2026-01-01T00:00:00Z",
+    "user": {"login": "alice"},
+    "body": "Review triggered by workflow runner for abc123"
+  }
+]
+[
+  {
+    "id": 222,
+    "created_at": "2026-01-01T00:05:00Z",
+    "user": {"login": "bob"},
+    "body": "Review triggered by workflow runner for abc123"
+  }
+]'
+_codex_paginated_selected_trigger="$(
+  printf '%s\n' "$_codex_paginated_trigger_comments" \
+    | jq -sc --arg sha "abc123" --arg marker "review triggered by workflow runner" --arg bot "chatgpt-codex-connector[bot]" --arg bot_plain "chatgpt-codex-connector" \
+      '[.[][] | select(.user.login != $bot and .user.login != $bot_plain) | select((.body | contains($sha)) and (.body | ascii_downcase | contains($marker)))] | sort_by(.created_at) | reverse | .[0] // empty | {id: .id, created_at: .created_at, body: .body}'
+)"
+run_test "codex_trigger_idempotency_paginated_selects_newest" "222" \
+  "$(printf '%s\n' "$_codex_paginated_selected_trigger" | jq -r '.id')"
+run_test "codex_trigger_idempotency_paginated_single_object" "1" \
+  "$(printf '%s\n' "$_codex_paginated_selected_trigger" | wc -l | tr -d ' ')"
+unset _codex_trigger_comments _codex_selected_trigger _codex_paginated_trigger_comments _codex_paginated_selected_trigger
 
 _unlock_pr="80213$$"
 _unlock_lock_dir="/tmp/pr-review-loop-${_unlock_pr}.lockdir"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1833,6 +1833,37 @@ fi
 run_test "codex_reviewer_ack_wait_signal" "yes" "$_codex_ack_wait_signal"
 unset _codex_ack_wait_signal
 
+_codex_trigger_comments='[
+  {
+    "id": 111,
+    "created_at": "2026-01-01T00:00:00Z",
+    "user": {"login": "alice"},
+    "body": "Review triggered by workflow runner for abc123"
+  },
+  {
+    "id": 222,
+    "created_at": "2026-01-01T00:05:00Z",
+    "user": {"login": "bob"},
+    "body": "Review triggered by workflow runner for abc123"
+  },
+  {
+    "id": 333,
+    "created_at": "2026-01-01T00:10:00Z",
+    "user": {"login": "chatgpt-codex-connector[bot]"},
+    "body": "Review triggered by workflow runner for abc123"
+  }
+]'
+_codex_selected_trigger="$(
+  printf '%s\n' "$_codex_trigger_comments" \
+    | jq -c --arg sha "abc123" --arg marker "review triggered by workflow runner" --arg bot "chatgpt-codex-connector[bot]" --arg bot_plain "chatgpt-codex-connector" \
+      '[.[] | select(.user.login != $bot and .user.login != $bot_plain) | select((.body | contains($sha)) and (.body | ascii_downcase | contains($marker)))] | sort_by(.created_at) | reverse | .[0] // empty | {id: .id, created_at: .created_at, body: .body}'
+)"
+run_test "codex_trigger_idempotency_selects_newest" "222" \
+  "$(printf '%s\n' "$_codex_selected_trigger" | jq -r '.id')"
+run_test "codex_trigger_idempotency_single_object" "1" \
+  "$(printf '%s\n' "$_codex_selected_trigger" | wc -l | tr -d ' ')"
+unset _codex_trigger_comments _codex_selected_trigger
+
 _unlock_pr="80213$$"
 _unlock_lock_dir="/tmp/pr-review-loop-${_unlock_pr}.lockdir"
 rm -rf "$_unlock_lock_dir"

--- a/scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh
@@ -391,6 +391,61 @@ printf 'fixture-installation-token\n'
 SH
 chmod +x "$token_exchange_stub"
 
+relative_key_dir="$(fixture_dir relative-key)"
+mkdir -p "$relative_key_dir/keys"
+make_private_key "$relative_key_dir/keys/mobile-app.pem"
+cat > "$relative_key_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      github_app:
+        app_id: "12345"
+        installation_id: "999"
+YAML
+cat > "$relative_key_dir/.ai-dev-workflow.local.yaml" <<'YAML'
+product_repos:
+  - name: mobile-app
+    github_app:
+      private_key_path: keys/mobile-app.pem
+YAML
+relative_token="$(
+  WORKFLOW_GITHUB_APP_TOKEN_EXCHANGE_CMD="$token_exchange_stub" \
+    bash "$TOKEN_HELPER" --repo-root "$relative_key_dir" --repo mobile-app --print-token
+)"
+run_equals "token_helper_relative_private_key_path" "fixture-installation-token" "$relative_token"
+
+tilde_key_dir="$(fixture_dir tilde-key)"
+tilde_home="$tilde_key_dir/home"
+mkdir -p "$tilde_home"
+make_private_key "$tilde_home/mobile-app.pem"
+cat > "$tilde_key_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+mode: workflow_hub
+
+workflow_hub:
+  product_repos:
+    - name: mobile-app
+      github_repo: example/mobile-app
+      github_app:
+        app_id: "12345"
+        installation_id: "999"
+YAML
+cat > "$tilde_key_dir/.ai-dev-workflow.local.yaml" <<'YAML'
+product_repos:
+  - name: mobile-app
+    github_app:
+      private_key_path: ~/mobile-app.pem
+YAML
+tilde_token="$(
+  HOME="$tilde_home" WORKFLOW_GITHUB_APP_TOKEN_EXCHANGE_CMD="$token_exchange_stub" \
+    bash "$TOKEN_HELPER" --repo-root "$tilde_key_dir" --repo mobile-app --print-token
+)"
+run_equals "token_helper_tilde_private_key_path" "fixture-installation-token" "$tilde_token"
+
 token_stdout="$(
   WORKFLOW_GITHUB_APP_TOKEN_EXCHANGE_CMD="$token_exchange_stub" \
     bash "$TOKEN_HELPER" --repo-root "$hub_dir" --repo mobile-app --print-token 2>"$TMP_ROOT/token.stderr"


### PR DESCRIPTION
## Summary

- Backport downstream sync reviewer corrections from `lhpaul/seia#474` into the template.
- Make Codex GitHub reviewer idempotency select the newest existing human trigger comment for a commit SHA.
- Normalize workflow-hub GitHub App private-key paths for `~`, absolute paths, and repo-root-relative paths.
- Skip optional Claude Code Action workflow assertions in downstream repos that do not sync that workflow.
- Add regression coverage for the Codex trigger selection and GitHub App private-key path cases.

## Root Cause

The downstream sync exposed template-level edge cases: duplicate Codex trigger comments could produce malformed multi-line IDs, documented private-key path forms were checked literally, and an optional workflow assertion was mandatory in downstream repos.

## Verification

- `bash scripts/development-workflow/tests/test-pr-review-loop.sh`
- `bash scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh`
- `bash scripts/development-workflow/tests/test-claude-code-action-reviewer.sh`
- `shellcheck --severity=warning scripts/development-workflow/codex-github-reviewer.sh scripts/development-workflow/github-app-token.sh scripts/development-workflow/tests/test-claude-code-action-reviewer.sh scripts/development-workflow/tests/test-pr-review-loop.sh scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `bash -n scripts/development-workflow/codex-github-reviewer.sh scripts/development-workflow/github-app-token.sh scripts/development-workflow/tests/test-claude-code-action-reviewer.sh scripts/development-workflow/tests/test-pr-review-loop.sh scripts/development-workflow/tests/test-workflow-hub-pr-auth.sh`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`
- `npx markdownlint-cli2 CHANGELOG.md`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`

## Pre-Submission Self-Review

Stale markers: none. Caller/sibling consistency: verified across changed reviewer/token helpers and their test coverage. Coverage: fast-track fix addresses the downstream reviewer findings and includes regression tests for the script edge cases.

## CHANGELOG

- Added an `[Unreleased]` `Fixed` entry for downstream template-sync reviewer corrections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow shell/test hardening for downstream sync edge cases; no auth model or reviewer policy changes beyond path resolution and idempotency selection.
> 
> **Overview**
> Backports template fixes so **downstream sync** stops failing on Codex idempotency, workflow-hub GitHub App key paths, and optional Claude workflow checks.
> 
> **Codex GitHub reviewer** idempotency now **slurps paginated comments**, filters human trigger posts for the current SHA, and picks the **newest** match (`sort_by` + `reverse` + `.[0]`) instead of emitting multiple jq objects that could corrupt trigger comment IDs.
> 
> **Workflow-hub GitHub App auth** resolves `private_key_path` via new `normalize_private_key_path` (`~`, `~/…`, absolute, or **repo-root-relative** under `REPO_ROOT`). `exchange_token` fails clearly if key load or JWT signing fails.
> 
> **Claude Code Action tests** only assert workflow prompt/plugin YAML when `.github/workflows/claude-code-review.yml` exists; otherwise they log and skip (repos that do not sync that workflow).
> 
> Regression tests cover Codex trigger selection (including paginated pages) and relative/tilde private-key token exchange. **CHANGELOG** `[Unreleased]` documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25a29078769babf08c95c8bf020599f319cb2906. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->