### PR TITLE
fix(workflow): correct epic issue detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Workflow item routing no longer treats every GitHub issue as epic-like**:
+  `/run-work` and `/run-item` now read GitHub sub-issue `totalCount` instead of
+  the `subIssues` object key count, and the bounded prelude uses bash-3.2-safe
+  empty-array expansion for stock macOS shells.
 - **Release readiness wording**: command and overview surfaces now state that
   `release/*` PR reviewer loops are skipped while the production PR still gets
   regression and CI readiness before merge.

--- a/scripts/development-workflow/run-bounded-prelude.sh
+++ b/scripts/development-workflow/run-bounded-prelude.sh
@@ -278,12 +278,12 @@ resolver_common=()
 
 case "$scope_mode" in
   epic)
-  if ! "$SCRIPT_DIR/run-epic-scope-resolver.sh" --epic "$epic_number" "${resolver_common[@]}" --json > "$scope_file"; then
+  if ! "$SCRIPT_DIR/run-epic-scope-resolver.sh" --epic "$epic_number" "${resolver_common[@]+"${resolver_common[@]}"}" --json > "$scope_file"; then
     error_exit "epic scope resolution failed"
   fi
     ;;
   items)
-  if ! "$SCRIPT_DIR/run-epic-scope-resolver.sh" --items "$items_arg" "${resolver_common[@]}" --json > "$scope_file"; then
+  if ! "$SCRIPT_DIR/run-epic-scope-resolver.sh" --items "$items_arg" "${resolver_common[@]+"${resolver_common[@]}"}" --json > "$scope_file"; then
     error_exit "items scope resolution failed"
   fi
     ;;
@@ -294,7 +294,7 @@ case "$scope_mode" in
     [ -n "$item_branch" ] && item_args+=(--branch "$item_branch")
     [ -n "$item_pr" ] && item_args+=(--pr "$item_pr")
     [ -n "$item_development" ] && item_args+=(--development "$item_development")
-    if ! "$SCRIPT_DIR/run-item-scope-resolver.sh" "${item_args[@]}" "${resolver_common[@]}" --json > "$scope_file"; then
+    if ! "$SCRIPT_DIR/run-item-scope-resolver.sh" "${item_args[@]+"${item_args[@]}"}" "${resolver_common[@]+"${resolver_common[@]}"}" --json > "$scope_file"; then
       error_exit "item scope resolution failed"
     fi
     ;;
@@ -312,7 +312,7 @@ policy_args=(
 [ -n "$checkpoints_file" ] && policy_args+=(--checkpoints-file "$checkpoints_file")
 policy_args+=(--json)
 
-if ! "$SCRIPT_DIR/run-epic-policy-recommender.sh" "${policy_args[@]}" > "$policy_file"; then
+if ! "$SCRIPT_DIR/run-epic-policy-recommender.sh" "${policy_args[@]+"${policy_args[@]}"}" > "$policy_file"; then
   error_exit "policy recommendation failed"
 fi
 

--- a/scripts/development-workflow/run-item-scope-resolver.sh
+++ b/scripts/development-workflow/run-item-scope-resolver.sh
@@ -101,7 +101,7 @@ is_epic_issue() {
     return 2
   fi
   local sub_count=0 issue_type=0
-  sub_count="$(gh issue view "$num" --json subIssues --jq '.subIssues | length' 2>/dev/null)" || sub_count=0
+  sub_count="$(gh issue view "$num" --json subIssues --jq '.subIssues.totalCount' 2>/dev/null)" || sub_count=0
   case "${sub_count:-}" in
     ''|*[!0-9]*) sub_count="0" ;;
   esac

--- a/scripts/development-workflow/run-work-router.sh
+++ b/scripts/development-workflow/run-work-router.sh
@@ -235,7 +235,7 @@ is_epic_issue() {
   # Try sub-issues first; if that API field is unavailable, still check the epic label.
   local sub_count issue_type
   sub_count="$(gh issue view "$issue_num" --json subIssues \
-    --jq '.subIssues | length' 2>/dev/null)" || sub_count=""
+    --jq '.subIssues.totalCount' 2>/dev/null)" || sub_count=""
   case "${sub_count:-}" in
     ''|*[!0-9]*) sub_count="0" ;;
   esac

--- a/scripts/development-workflow/tests/test-run-work-router.sh
+++ b/scripts/development-workflow/tests/test-run-work-router.sh
@@ -102,6 +102,28 @@ case "$*" in
     ;;
 esac
 
+emit_issue_subissues() {
+  local issue_num="$1" jq_filter="$2"
+  local json
+  case "$issue_num" in
+    977)
+      json='{"subIssues":{"nodes":[{"number":101},{"number":102}],"totalCount":2}}'
+      ;;
+    978|979)
+      json='{"subIssues":{"nodes":[],"totalCount":0}}'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  if [ -n "$jq_filter" ]; then
+    printf '%s\n' "$json" | jq -r "$jq_filter"
+  else
+    printf '%s\n' "$json"
+  fi
+}
+
 # ---- issue view ----
 # Matches: gh issue view <number> --json state --jq .state
 # or:      gh issue view <number> --json subIssues --jq ...
@@ -121,16 +143,16 @@ case "$*" in
   issue\ view\ 999999\ --json\ state\ --jq\ .state)
     exit 1   # not found
     ;;
-  issue\ view\ 978\ --json\ subIssues\ --jq\ '.subIssues | length')
-    printf '0\n'
+  issue\ view\ 978\ --json\ subIssues\ --jq\ *)
+    emit_issue_subissues 978 "$7"
     exit 0
     ;;
-  issue\ view\ 979\ --json\ subIssues\ --jq\ '.subIssues | length')
-    printf '0\n'
+  issue\ view\ 979\ --json\ subIssues\ --jq\ *)
+    emit_issue_subissues 979 "$7"
     exit 0
     ;;
-  issue\ view\ 977\ --json\ subIssues\ --jq\ '.subIssues | length')
-    printf '2\n'    # epic-like: has 2 sub-issues
+  issue\ view\ 977\ --json\ subIssues\ --jq\ *)
+    emit_issue_subissues 977 "$7"
     exit 0
     ;;
   issue\ view\ 977\ --json\ labels\ --jq\ '[.labels[].name] | map(ascii_downcase) | map(select(. == "epic")) | length')


### PR DESCRIPTION
## Summary

- Apply the workflow-router fix from mome-cl/mome-platform#1436 to this template repo.
- Read GitHub sub-issue `totalCount` instead of counting keys on the `subIssues` object.
- Make bounded-prelude array expansion safe under bash 3.2 with `set -u`.
- Update the router test mock to emit real `gh --json subIssues`-shaped JSON and run the requested `--jq` filter through `jq`.

## Root Cause

GitHub CLI returns `subIssues` as an object containing fields such as `nodes` and `totalCount`. The previous `.subIssues | length` filter counted object keys, so ordinary issues with zero sub-issues could be classified as epic-like.

## Test Plan

- `bash scripts/development-workflow/tests/test-run-work-router.sh` (58 passed)
- `/bin/bash scripts/development-workflow/tests/test-run-bounded-prelude.sh` (5 passed)
- `shellcheck --severity=warning scripts/development-workflow/run-work-router.sh scripts/development-workflow/run-item-scope-resolver.sh scripts/development-workflow/run-bounded-prelude.sh scripts/development-workflow/tests/test-run-work-router.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`
- `git diff --check origin/develop...HEAD`

## CHANGELOG

- Added `[Unreleased]` `Fixed` entry for workflow item routing and bash 3.2 bounded-prelude compatibility.

## Pre-Submission Self-Review

Pre-submission self-review: stale markers — none found in `origin/develop...HEAD`; caller consistency — verified both epic-classification call sites and bounded-prelude resolver/policy call sites; coverage — diff addresses the MOME PR #1436 root cause in this repo and updates the router mock so `.subIssues | length` would regress.

## Test Harness Coverage Checklist

- Empty / zero-length input: existing no-target and empty-subIssues cases cover empty routing/sub-issue inputs.
- Whitespace-only input: existing `whitespace_only_arg_mode` covers whitespace-only routing input.
- Boundary values: mock now covers `totalCount=0` and `totalCount=2`; bounded prelude fixture covers empty optional array path under bash 3.2.
- Missing environment variables: not directly applicable; harness creates isolated mock PATH and temp state.
- Concurrent execution: not applicable; harness uses per-run `mktemp` isolation.
- Negative assertions: non-epic issue `978` would fail if the filter regressed to `.subIssues | length` because the mock now feeds a real object through `jq`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only routing and prelude shell changes with targeted test updates; no auth, merge, or data-path changes.
> 
> **Overview**
> Fixes **workflow routing** so `/run-work` and `/run-item` no longer treat ordinary GitHub issues as epic-like when they have zero sub-issues.
> 
> **Epic detection** now uses GitHub’s `subIssues.totalCount` in `run-work-router.sh` and `run-item-scope-resolver.sh` instead of counting keys on the `subIssues` object (which could be non-zero even with an empty `nodes` list).
> 
> **Bounded prelude** (`run-bounded-prelude.sh`) uses bash-3.2-safe optional array expansion (`"${arr[@]+"${arr[@]}"}"`) when calling scope and policy scripts, avoiding failures under `set -u` on stock macOS bash.
> 
> **Tests**: the router harness mock emits realistic `subIssues` JSON and applies the caller’s `--jq` filter via `jq`, so regressions to `.subIssues | length` would fail. **CHANGELOG** documents the fix under `[Unreleased]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbfa98e0b12488e8c9de8cb634bc2b0298a8e876. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->