### PR TITLE
feat(haystack): emit structured advisory findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Structured Haystack advisory findings** (#1113): Added structured Haystack
+  finding output for downstream review summaries and delegated advisory
+  dispositions.
+
 ## [0.35.0] - 2026-07-02
 
 ### Added

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -132,6 +132,12 @@ The structured arrays are derived from the same classification pass as
 match. Existing consumers may continue to rely only on `RESULT`,
 `BLOCKING_COUNT`, `SUGGESTION_COUNT`, and `COMMENT_COUNT`.
 
+When `haystack pr-status --json` returns parseable JSON but a required policy
+field cannot be read, the reviewer fails closed with
+`REASON=policy_status_parse_failed`. On that path, `BLOCKING_FINDINGS_JSON`
+includes a synthetic `Policy status parse failed` blocking entry so
+`BLOCKING_COUNT` still matches the blocking array length.
+
 Unavailable or skipped review paths keep their existing output contract and may
 omit the structured arrays. Treat missing arrays on skipped output as "no
 completed Haystack finding payload", not as an empty completed review.

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -124,7 +124,7 @@ data:
 | Field | Fallback order |
 | ----- | -------------- |
 | `path` | `.source.path`, `.source.file`, `.path`, `.file` |
-| `line` | `.source.line`, `.source.startLine`, `.line`, `.startLine` |
+| `line` | Positive integer values from `.source.line`, `.source.startLine`, `.line`, `.startLine` |
 | `fix_hint` | `.agentFixPrompt`, `.fixPrompt`, `.suggestion` |
 
 The structured arrays are derived from the same classification pass as

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -94,6 +94,52 @@ The `haystack triage --json` output schema uses a `.findings[].category` field a
 
 The `COMMENT_COUNT` output equals `BLOCKING_COUNT + SUGGESTION_COUNT`.
 
+## Structured Finding Output
+
+In addition to the existing count fields, `haystack-reviewer.sh` emits
+machine-readable finding arrays when Haystack triage returns a completed review
+result:
+
+```text
+ADVISORY_FINDINGS_JSON=[{"severity":"advisory","category":"Minor","summary":"...","detail":"..."}]
+BLOCKING_FINDINGS_JSON=[{"severity":"blocking","category":"Logic error","summary":"...","detail":"..."}]
+```
+
+These fields are compact single-line JSON arrays. Consumers should parse the
+substring after the first `=` as JSON; do not split array contents on spaces,
+commas, pipes, or additional equals signs.
+
+Each finding object includes these required fields:
+
+| Field | Description |
+| ----- | ----------- |
+| `severity` | Normalized workflow severity: `advisory` or `blocking`. |
+| `category` | Haystack category string, or `__UNKNOWN__` when Haystack omitted the category. |
+| `summary` | Short finding summary, or an empty string when Haystack omitted it. |
+| `detail` | Detailed finding text, or an empty string when Haystack omitted it. |
+
+The reviewer includes these optional fields when Haystack supplies compatible
+data:
+
+| Field | Fallback order |
+| ----- | -------------- |
+| `path` | `.source.path`, `.source.file`, `.path`, `.file` |
+| `line` | `.source.line`, `.source.startLine`, `.line`, `.startLine` |
+| `fix_hint` | `.agentFixPrompt`, `.fixPrompt`, `.suggestion` |
+
+The structured arrays are derived from the same classification pass as
+`BLOCKING_COUNT` and `SUGGESTION_COUNT`, so counts and array lengths should
+match. Existing consumers may continue to rely only on `RESULT`,
+`BLOCKING_COUNT`, `SUGGESTION_COUNT`, and `COMMENT_COUNT`.
+
+Unavailable or skipped review paths keep their existing output contract and may
+omit the structured arrays. Treat missing arrays on skipped output as "no
+completed Haystack finding payload", not as an empty completed review.
+
+`pr-review-loop.sh` does not list the structured Haystack advisory details in PR
+summary comments yet. That consumer-facing summary work is tracked separately in
+issue #1114.
+
 ## Review Policy Verdicts
 
 Haystack exposes two related but separate result channels:

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -115,8 +115,8 @@ Each finding object includes these required fields:
 | ----- | ----------- |
 | `severity` | Normalized workflow severity: `advisory` or `blocking`. |
 | `category` | Haystack category string, or `__UNKNOWN__` when Haystack omitted the category. |
-| `summary` | Short finding summary, or an empty string when Haystack omitted it. |
-| `detail` | Detailed finding text, or an empty string when Haystack omitted it. |
+| `summary` | Short finding summary from `.summary`, `.title`, or `.message`; empty string when Haystack omitted compatible text. |
+| `detail` | Detailed finding text from `.detail`, `.message`, or `.body`; empty string when Haystack omitted compatible text. |
 
 The reviewer includes these optional fields when Haystack supplies compatible
 data:

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -518,14 +518,16 @@ NORMALIZED_FINDINGS_JSON="$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -c --arg major_i
   def normalized:
     category as $category |
     (if blocking($category) then "blocking" else "advisory" end) as $severity |
+    (first_string([.summary?, .title?, .message?]) // "") as $summary |
+    (first_string([.detail?, .message?, .body?]) // "") as $detail |
     (first_string([.source.path?, .source.file?, .path?, .file?]) // null) as $path |
     (first_line([.source.line?, .source.startLine?, .line?, .startLine?]) // null) as $line |
     (first_string([.agentFixPrompt?, .fixPrompt?, .suggestion?]) // null) as $fix_hint |
     {
       severity: $severity,
       category: $category,
-      summary: ((.summary // "") | tostring),
-      detail: ((.detail // "") | tostring)
+      summary: $summary,
+      detail: $detail
     }
     + (if $path == null then {} else {path: $path} end)
     + (if $line == null then {} else {line: $line} end)

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -23,6 +23,8 @@
 #   BLOCKING_COUNT=<n>
 #   SUGGESTION_COUNT=<n>
 #   COMMENT_COUNT=<n>
+#   ADVISORY_FINDINGS_JSON=<json-array> (present for completed reviews)
+#   BLOCKING_FINDINGS_JSON=<json-array> (present for completed reviews)
 #   DISPLAY_RESULT=<value> (optional; used by pr-review-loop.sh summaries)
 #   POLICY_REVIEW_REQUIRED=0|1 (optional; present when pr-status is available)
 #   REASON=<value>   (only when RESULT=skipped — values: unavailable, timeout,
@@ -484,51 +486,73 @@ printf '%s\n' "$TRIAGE_OUTPUT" >&2
 #                      "Weak test coverage", "Major" (see NOTE above)
 # Unrecognised categories: blocking (safe-fail)
 
-# Extract all finding categories as newline-separated list.
+# Build a normalized finding snapshot once, then derive counts and structured
+# output arrays from that snapshot so the two contracts cannot drift.
 # Use '(.findings // [])[]' to avoid the jq-1.7.1-apple quirk where iterating
 # '.findings[]' with a '// "fallback"' alternative fires once on an empty array,
 # producing a spurious value. With '(.findings // [])[]', an empty/null .findings
 # array produces zero output — no sentinel is emitted spuriously.
 # Null/missing .category values are mapped to the sentinel "__UNKNOWN__" so they
 # are treated as blocking (safe-fail) rather than silently dropped.
-CATEGORIES="$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -r '
-  (.findings // [])[] |
-  if (.category | type) == "string" and .category != "" then .category
-  else "__UNKNOWN__"
-  end
+NORMALIZED_FINDINGS_JSON="$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -c --arg major_is_blocking "${HAYSTACK_MAJOR_IS_BLOCKING:-0}" '
+  def category:
+    if (.category | type) == "string" and .category != "" then .category
+    else "__UNKNOWN__"
+    end;
+  def known_category($category):
+    ["Logic error", "Critical", "Major", "Minor", "Advisory", "Nitpick", "Trivial", "Weak test coverage", "Rules violation", "Code contract violation"] | index($category) != null;
+  def blocking($category):
+    $category == "Logic error"
+    or $category == "Critical"
+    or ($category == "Major" and $major_is_blocking == "1")
+    or (known_category($category) | not);
+  def first_string($values):
+    $values | map(select((type == "string") and . != "")) | first;
+  def first_line($values):
+    $values
+    | map(select(. != null and . != ""))
+    | map(if type == "number" then .
+          elif type == "string" and test("^[0-9]+$") then tonumber
+          else empty end)
+    | first;
+  def normalized:
+    category as $category |
+    (if blocking($category) then "blocking" else "advisory" end) as $severity |
+    (first_string([.source.path?, .source.file?, .path?, .file?]) // null) as $path |
+    (first_line([.source.line?, .source.startLine?, .line?, .startLine?]) // null) as $line |
+    (first_string([.agentFixPrompt?, .fixPrompt?, .suggestion?]) // null) as $fix_hint |
+    {
+      severity: $severity,
+      category: $category,
+      summary: ((.summary // "") | tostring),
+      detail: ((.detail // "") | tostring)
+    }
+    + (if $path == null then {} else {path: $path} end)
+    + (if $line == null then {} else {line: $line} end)
+    + (if $fix_hint == null then {} else {fix_hint: $fix_hint} end);
+  [(.findings // [])[] | normalized]
 ')"
 
-BLOCKING_COUNT=0
-SUGGESTION_COUNT=0
+UNKNOWN_CATEGORIES="$(printf '%s\n' "$NORMALIZED_FINDINGS_JSON" | jq -r '
+  .[]
+  | .category as $category
+  | select($category == "__UNKNOWN__" or ((["Logic error", "Critical", "Major", "Minor", "Advisory", "Nitpick", "Trivial", "Weak test coverage", "Rules violation", "Code contract violation"] | index($category)) == null))
+  | .category
+')"
 
-if [ -n "$CATEGORIES" ]; then
+if [ -n "$UNKNOWN_CATEGORIES" ]; then
   while IFS= read -r category; do
     [ -z "${category:-}" ] && continue
-    case "$category" in
-      "Logic error"|"Critical")
-        BLOCKING_COUNT=$((BLOCKING_COUNT + 1))
-        ;;
-      "Major")
-        if [ "${HAYSTACK_MAJOR_IS_BLOCKING:-0}" = "1" ]; then
-          BLOCKING_COUNT=$((BLOCKING_COUNT + 1))
-        else
-          SUGGESTION_COUNT=$((SUGGESTION_COUNT + 1))
-        fi
-        ;;
-      "Minor"|"Advisory"|"Nitpick"|"Trivial"|"Weak test coverage"|"Rules violation"|"Code contract violation")
-        SUGGESTION_COUNT=$((SUGGESTION_COUNT + 1))
-        ;;
-      "__UNKNOWN__"|*)
-        # Null/missing or unrecognised category — safe-fail to blocking
-        echo "INFO: unrecognised finding category '$category' — treating as blocking (safe-fail)" >&2
-        BLOCKING_COUNT=$((BLOCKING_COUNT + 1))
-        ;;
-    esac
+    echo "INFO: unrecognised finding category '$category' — treating as blocking (safe-fail)" >&2
   done <<EOF
-$CATEGORIES
+$UNKNOWN_CATEGORIES
 EOF
 fi
 
+ADVISORY_FINDINGS_JSON="$(printf '%s\n' "$NORMALIZED_FINDINGS_JSON" | jq -c '[.[] | select(.severity == "advisory")]')"
+BLOCKING_FINDINGS_JSON="$(printf '%s\n' "$NORMALIZED_FINDINGS_JSON" | jq -c '[.[] | select(.severity == "blocking")]')"
+BLOCKING_COUNT="$(printf '%s\n' "$BLOCKING_FINDINGS_JSON" | jq 'length')"
+SUGGESTION_COUNT="$(printf '%s\n' "$ADVISORY_FINDINGS_JSON" | jq 'length')"
 COMMENT_COUNT=$((BLOCKING_COUNT + SUGGESTION_COUNT))
 
 echo "INFO: findings parsed — blocking: $BLOCKING_COUNT, advisory: $SUGGESTION_COUNT, total: $COMMENT_COUNT" >&2
@@ -650,6 +674,8 @@ if [ "$PR_STATUS_CHECK" != "0" ]; then
       printf 'BLOCKING_COUNT=1\n'
       printf 'SUGGESTION_COUNT=%d\n' "$SUGGESTION_COUNT"
       printf 'COMMENT_COUNT=%d\n' "$((SUGGESTION_COUNT + 1))"
+      printf 'ADVISORY_FINDINGS_JSON=%s\n' "$ADVISORY_FINDINGS_JSON"
+      printf 'BLOCKING_FINDINGS_JSON=%s\n' "$BLOCKING_FINDINGS_JSON"
       printf 'POLICY_STATUS_AVAILABLE=0\n'
       printf 'POLICY_REVIEW_REQUIRED=0\n'
       printf 'POLICY_DISPOSITION=blocking\n'
@@ -679,6 +705,8 @@ if [ "$BLOCKING_COUNT" -gt 0 ]; then
   printf 'BLOCKING_COUNT=%d\n' "$BLOCKING_COUNT"
   printf 'SUGGESTION_COUNT=%d\n' "$SUGGESTION_COUNT"
   printf 'COMMENT_COUNT=%d\n' "$COMMENT_COUNT"
+  printf 'ADVISORY_FINDINGS_JSON=%s\n' "$ADVISORY_FINDINGS_JSON"
+  printf 'BLOCKING_FINDINGS_JSON=%s\n' "$BLOCKING_FINDINGS_JSON"
   printf 'POLICY_STATUS_AVAILABLE=%d\n' "$POLICY_STATUS_AVAILABLE"
   printf 'POLICY_REVIEW_REQUIRED=%d\n' "$POLICY_REVIEW_REQUIRED"
   printf 'POLICY_DISPOSITION=%s\n' "$POLICY_DISPOSITION"
@@ -695,6 +723,8 @@ printf 'RESULT=clean\n'
 printf 'BLOCKING_COUNT=0\n'
 printf 'SUGGESTION_COUNT=%d\n' "$SUGGESTION_COUNT"
 printf 'COMMENT_COUNT=%d\n' "$COMMENT_COUNT"
+printf 'ADVISORY_FINDINGS_JSON=%s\n' "$ADVISORY_FINDINGS_JSON"
+printf 'BLOCKING_FINDINGS_JSON=%s\n' "$BLOCKING_FINDINGS_JSON"
 printf 'POLICY_STATUS_AVAILABLE=%d\n' "$POLICY_STATUS_AVAILABLE"
 printf 'POLICY_REVIEW_REQUIRED=%d\n' "$POLICY_REVIEW_REQUIRED"
 printf 'POLICY_DISPOSITION=%s\n' "$POLICY_DISPOSITION"

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -671,13 +671,23 @@ if [ "$PR_STATUS_CHECK" != "0" ]; then
       fi
     else
       echo "ERROR: haystack pr-status field parse failed — failing closed" >&2
+      POLICY_BLOCKING_FINDINGS_JSON="$(printf '%s\n' "$BLOCKING_FINDINGS_JSON" | jq -c '
+        . + [{
+          "severity": "blocking",
+          "category": "Policy status parse failed",
+          "summary": "Haystack policy status parse failed",
+          "detail": "haystack pr-status returned JSON but required fields could not be parsed"
+        }]
+      ')"
+      POLICY_BLOCKING_COUNT="$(printf '%s\n' "$POLICY_BLOCKING_FINDINGS_JSON" | jq 'length')"
+      POLICY_COMMENT_COUNT=$((POLICY_BLOCKING_COUNT + SUGGESTION_COUNT))
       printf 'RESULT=needs_fixes\n'
       printf 'REASON=policy_status_parse_failed\n'
-      printf 'BLOCKING_COUNT=1\n'
+      printf 'BLOCKING_COUNT=%d\n' "$POLICY_BLOCKING_COUNT"
       printf 'SUGGESTION_COUNT=%d\n' "$SUGGESTION_COUNT"
-      printf 'COMMENT_COUNT=%d\n' "$((SUGGESTION_COUNT + 1))"
+      printf 'COMMENT_COUNT=%d\n' "$POLICY_COMMENT_COUNT"
       printf 'ADVISORY_FINDINGS_JSON=%s\n' "$ADVISORY_FINDINGS_JSON"
-      printf 'BLOCKING_FINDINGS_JSON=%s\n' "$BLOCKING_FINDINGS_JSON"
+      printf 'BLOCKING_FINDINGS_JSON=%s\n' "$POLICY_BLOCKING_FINDINGS_JSON"
       printf 'POLICY_STATUS_AVAILABLE=0\n'
       printf 'POLICY_REVIEW_REQUIRED=0\n'
       printf 'POLICY_DISPOSITION=blocking\n'

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -483,7 +483,8 @@ printf '%s\n' "$TRIAGE_OUTPUT" >&2
 # Confirmed schema: .findings[].category (not .findings[].severity)
 # Blocking categories: "Logic error", "Critical"
 # Advisory categories: "Minor", "Advisory", "Nitpick", "Trivial",
-#                      "Weak test coverage", "Major" (see NOTE above)
+#                      "Weak test coverage", "Rules violation",
+#                      "Code contract violation", "Major" (see NOTE above)
 # Unrecognised categories: blocking (safe-fail)
 
 # Build a normalized finding snapshot once, then derive counts and structured
@@ -511,8 +512,8 @@ NORMALIZED_FINDINGS_JSON="$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -c --arg major_i
   def first_line($values):
     $values
     | map(select(. != null and . != ""))
-    | map(if type == "number" then .
-          elif type == "string" and test("^[0-9]+$") then tonumber
+    | map(if type == "number" and . >= 1 and floor == . then .
+          elif type == "string" and test("^[1-9][0-9]*$") then tonumber
           else empty end)
     | first;
   def normalized:

--- a/scripts/development-workflow/tests/test-haystack-reviewer.sh
+++ b/scripts/development-workflow/tests/test-haystack-reviewer.sh
@@ -250,6 +250,11 @@ _run_reviewer_exit_code() {
   fi
 }
 
+_kv_value() {
+  local key="$1" output="$2"
+  printf '%s\n' "$output" | sed -n "s/^${key}=//p" | head -n 1
+}
+
 # ---------------------------------------------------------------------------
 # Area 1: status=pending triggers poll-retry loop
 # ---------------------------------------------------------------------------
@@ -450,6 +455,123 @@ output=$(_run_reviewer 10 1)
 run_test "rules_violation_result" "RESULT=clean" "$(echo "$output" | grep '^RESULT=')"
 run_test "rules_violation_suggestion_count" "SUGGESTION_COUNT=1" "$(echo "$output" | grep '^SUGGESTION_COUNT=')"
 run_test "rules_violation_blocking_zero" "BLOCKING_COUNT=0" "$(echo "$output" | grep '^BLOCKING_COUNT=')"
+
+# ---------------------------------------------------------------------------
+# Area 5b: structured finding output
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 5b: structured finding output ==="
+
+# Test 5b.1: empty findings still emit parseable empty arrays.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":5,"findings":[]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+blocking_json="$(_kv_value BLOCKING_FINDINGS_JSON "$output")"
+
+run_test "structured_empty_advisory_array" "0" "$(printf '%s\n' "$advisory_json" | jq 'length')"
+run_test "structured_empty_blocking_array" "0" "$(printf '%s\n' "$blocking_json" | jq 'length')"
+
+# Test 5b.2: multiple advisories preserve one entry per finding and ordering.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Minor","summary":"First advisory","detail":"One","agentFixPrompt":"Fix one"},{"category":"Rules violation","summary":"Second advisory","detail":"Two"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+
+run_test "structured_multi_advisory_count" "2" "$(printf '%s\n' "$advisory_json" | jq 'length')"
+run_test "structured_multi_advisory_order" "First advisory|Second advisory" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].summary + "|" + .[1].summary')"
+run_test "structured_multi_advisory_fix_hint" "Fix one" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].fix_hint')"
+
+# Test 5b.3: mixed blocking/advisory payload partitions findings and counts.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":2,"findings":[{"category":"Logic error","summary":"Bad logic","detail":"Fix it"},{"category":"Minor","summary":"Small note","detail":"Optional"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+blocking_json="$(_kv_value BLOCKING_FINDINGS_JSON "$output")"
+
+run_test "structured_mixed_result" "RESULT=needs_fixes" "$(echo "$output" | grep '^RESULT=')"
+run_test "structured_mixed_advisory_count" "1" "$(printf '%s\n' "$advisory_json" | jq 'length')"
+run_test "structured_mixed_blocking_count" "1" "$(printf '%s\n' "$blocking_json" | jq 'length')"
+run_test "structured_mixed_blocking_category" "Logic error" "$(printf '%s\n' "$blocking_json" | jq -r '.[0].category')"
+
+# Test 5b.4: missing category safe-fails to blocking with __UNKNOWN__.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":2,"findings":[{"summary":"No category","detail":"Missing category"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+blocking_json="$(_kv_value BLOCKING_FINDINGS_JSON "$output")"
+
+run_test "structured_missing_category_result" "RESULT=needs_fixes" "$(echo "$output" | grep '^RESULT=')"
+run_test "structured_missing_category_value" "__UNKNOWN__" "$(printf '%s\n' "$blocking_json" | jq -r '.[0].category')"
+
+# Test 5b.5: unrecognized category safe-fails to blocking.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":2,"findings":[{"category":"Unexpected severity","summary":"Unknown","detail":"Unknown"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+blocking_json="$(_kv_value BLOCKING_FINDINGS_JSON "$output")"
+
+run_test "structured_unknown_category_result" "RESULT=needs_fixes" "$(echo "$output" | grep '^RESULT=')"
+run_test "structured_unknown_category_value" "Unexpected severity" "$(printf '%s\n' "$blocking_json" | jq -r '.[0].category')"
+
+# Test 5b.6: Major is advisory by default and blocking when opted in.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":3,"findings":[{"category":"Major","summary":"Major note","detail":"Policy"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+run_test "structured_major_default_advisory" "1" "$(printf '%s\n' "$advisory_json" | jq 'length')"
+
+_reset_mocks
+_install_haystack_mock
+output=$(HAYSTACK_MAJOR_IS_BLOCKING=1 _run_reviewer 10 1)
+blocking_json="$(_kv_value BLOCKING_FINDINGS_JSON "$output")"
+run_test "structured_major_opt_in_blocking" "1" "$(printf '%s\n' "$blocking_json" | jq 'length')"
+
+# Test 5b.7: optional source fields follow documented fallbacks.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Minor","summary":"Source path","detail":"","source":{"path":"a.sh","line":7}},{"category":"Minor","summary":"Source file","detail":"","source":{"file":"b.sh","startLine":"8"}},{"category":"Minor","summary":"Top path","detail":"","path":"c.sh","line":"9"},{"category":"Minor","summary":"Top file","detail":"","file":"d.sh","startLine":10}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+
+run_test "structured_source_path_fallbacks" "a.sh:7|b.sh:8|c.sh:9|d.sh:10" "$(printf '%s\n' "$advisory_json" | jq -r 'map(.path + ":" + (.line | tostring)) | join("|")')"
+
+# Test 5b.8: missing source omits optional fields without parse failure.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Minor","summary":"No source","detail":"No source","source":null}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+
+run_test "structured_missing_source_no_path" "false" "$(printf '%s\n' "$advisory_json" | jq '.[0] | has("path")')"
+run_test "structured_missing_source_no_line" "false" "$(printf '%s\n' "$advisory_json" | jq '.[0] | has("line")')"
+
+# Test 5b.9: escaping remains valid JSON on one key-value output line.
+# shellcheck disable=SC2016  # Fixture intentionally keeps literal $PATH in mocked Haystack output.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Minor","summary":"Quote \" pipe | equals = slash \\ test","detail":"Line one\nLine two","agentFixPrompt":"Use $PATH && echo ok"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+advisory_line="$(printf '%s\n' "$output" | grep '^ADVISORY_FINDINGS_JSON=')"
+advisory_json="${advisory_line#ADVISORY_FINDINGS_JSON=}"
+
+run_test "structured_escaped_single_line" "1" "$(printf '%s\n' "$advisory_line" | wc -l | tr -d ' ')"
+run_test "structured_escaped_detail" "Line one|Line two" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].detail | gsub("\\n"; "|")')"
+# shellcheck disable=SC2016  # Expected value intentionally contains literal $PATH.
+run_test "structured_escaped_fix_hint" 'Use $PATH && echo ok' "$(printf '%s\n' "$advisory_json" | jq -r '.[0].fix_hint')"
 
 # ---------------------------------------------------------------------------
 # Area 6: HAYSTACK_POLL_INTERVAL controls retry cadence (env var)

--- a/scripts/development-workflow/tests/test-haystack-reviewer.sh
+++ b/scripts/development-workflow/tests/test-haystack-reviewer.sh
@@ -584,6 +584,16 @@ advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
 run_test "structured_message_fallback_summary" "Message-only finding" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].summary')"
 run_test "structured_message_fallback_detail" "Message-only finding" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].detail')"
 
+# Test 5b.11: invalid line values are omitted.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Minor","summary":"Negative","detail":"","source":{"path":"negative.sh","line":-1}},{"category":"Minor","summary":"Zero","detail":"","source":{"path":"zero.sh","line":"0"}},{"category":"Minor","summary":"Decimal","detail":"","source":{"path":"decimal.sh","line":2.5}}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+
+run_test "structured_invalid_lines_omitted" "0" "$(printf '%s\n' "$advisory_json" | jq '[.[] | select(has("line"))] | length')"
+
 # ---------------------------------------------------------------------------
 # Area 6: HAYSTACK_POLL_INTERVAL controls retry cadence (env var)
 # ---------------------------------------------------------------------------

--- a/scripts/development-workflow/tests/test-haystack-reviewer.sh
+++ b/scripts/development-workflow/tests/test-haystack-reviewer.sh
@@ -961,11 +961,14 @@ chmod +x "$MOCK_BIN/jq"
 
 output=$(_run_reviewer 30 1)
 ec=$(cat "$_REVIEWER_EXIT_FILE")
+blocking_json="$(_kv_value BLOCKING_FINDINGS_JSON "$output")"
 
 run_test "policy_parse_failure_result" "RESULT=needs_fixes" "$(echo "$output" | grep '^RESULT=')"
 run_test "policy_parse_failure_reason" "REASON=policy_status_parse_failed" "$(echo "$output" | grep '^REASON=')"
 run_test "policy_parse_failure_blocking_count" "BLOCKING_COUNT=1" "$(echo "$output" | grep '^BLOCKING_COUNT=')"
 run_test "policy_parse_failure_comment_count" "COMMENT_COUNT=1" "$(echo "$output" | grep '^COMMENT_COUNT=')"
+run_test "policy_parse_failure_blocking_json_count" "1" "$(printf '%s\n' "$blocking_json" | jq 'length')"
+run_test "policy_parse_failure_blocking_json_category" "Policy status parse failed" "$(printf '%s\n' "$blocking_json" | jq -r '.[0].category')"
 run_test "policy_parse_failure_exit_code" "1" "$ec"
 rm -f "$MOCK_BIN/jq"
 unset TEST_HAYSTACK_PR_STATUS_CHECK

--- a/scripts/development-workflow/tests/test-haystack-reviewer.sh
+++ b/scripts/development-workflow/tests/test-haystack-reviewer.sh
@@ -573,6 +573,17 @@ run_test "structured_escaped_detail" "Line one|Line two" "$(printf '%s\n' "$advi
 # shellcheck disable=SC2016  # Expected value intentionally contains literal $PATH.
 run_test "structured_escaped_fix_hint" 'Use $PATH && echo ok' "$(printf '%s\n' "$advisory_json" | jq -r '.[0].fix_hint')"
 
+# Test 5b.10: Haystack message-only findings still populate text fields.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Minor","message":"Message-only finding"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+
+run_test "structured_message_fallback_summary" "Message-only finding" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].summary')"
+run_test "structured_message_fallback_detail" "Message-only finding" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].detail')"
+
 # ---------------------------------------------------------------------------
 # Area 6: HAYSTACK_POLL_INTERVAL controls retry cadence (env var)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add structured `ADVISORY_FINDINGS_JSON` and `BLOCKING_FINDINGS_JSON` outputs for completed Haystack reviews.
- Derive counts and structured arrays from one normalized findings snapshot so output contracts stay consistent.
- Document the structured finding contract and add focused tests for advisory/blocking partitioning, source fallbacks, unknown categories, Major policy, and escaping.

## Pre-Submission Self-Review
- Spec coverage: aligned with `#1113` spec and implementation plan for machine-readable advisory/blocking findings.
- Stale markers: checked touched implementation/docs for TODO/FIXME/XXX/PLACEHOLDER markers; none found.
- Sibling/caller consistency: preserved existing count fields and skipped-output behavior; documented that `pr-review-loop.sh` summary rendering remains deferred to `#1114`.
- Compatibility: existing consumers can keep using `RESULT`, `BLOCKING_COUNT`, `SUGGESTION_COUNT`, and `COMMENT_COUNT`; structured arrays are added for completed review payloads.

## Validation
- `bash scripts/development-workflow/tests/test-haystack-reviewer.sh`
- `shellcheck -S warning -x scripts/development-workflow/haystack-reviewer.sh scripts/development-workflow/tests/test-haystack-reviewer.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/integrations/haystack-triage.md" "docs/testing/workflow/1113-structured-advisory-findings.smoke-test.md" "docs/specs/developments/20260702083004_1113-structured-advisory-findings/2_1113-structured-advisory-findings_implementation-plan.md" "CHANGELOG.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py docs/workflow/development-workflow/integrations/haystack-triage.md docs/testing/workflow/1113-structured-advisory-findings.smoke-test.md docs/specs/developments/20260702083004_1113-structured-advisory-findings/2_1113-structured-advisory-findings_implementation-plan.md CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`

Closes #1113

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches reviewer-loop stdout contract and fail-closed policy parsing on a critical automation path, though legacy count-only consumers remain supported and tests are extensive.
> 
> **Overview**
> Adds **`ADVISORY_FINDINGS_JSON`** and **`BLOCKING_FINDINGS_JSON`** to completed `haystack-reviewer.sh` stdout so downstream tools can consume per-finding detail without re-parsing Haystack triage output. Existing **`RESULT`**, **`BLOCKING_COUNT`**, **`SUGGESTION_COUNT`**, and **`COMMENT_COUNT`** stay in place; skipped/unavailable paths still omit the arrays.
> 
> **`haystack-reviewer.sh`** replaces separate shell `case` counting with a single **`NORMALIZED_FINDINGS_JSON`** jq pass (severity, category, summary/detail fallbacks, optional path/line/fix_hint). Counts and both JSON arrays are derived from that snapshot so they cannot drift. Unknown categories still safe-fail to blocking with logging.
> 
> On **`haystack pr-status`** parse failure, the script now fails closed with a synthetic blocking finding in **`BLOCKING_FINDINGS_JSON`** so **`BLOCKING_COUNT`** matches array length (replacing a hardcoded `1`).
> 
> **`haystack-triage.md`** documents the contract and parsing rules; **`CHANGELOG.md`** notes the feature. **`test-haystack-reviewer.sh`** gains Area 5b coverage (partitioning, Major opt-in, source fallbacks, escaping, policy parse failure). PR summary rendering in **`pr-review-loop.sh`** is explicitly deferred (#1114).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca392a95d3d91873ce5e1e261cb6edf9dd97eee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->