### PR TITLE
feat(review): require advisory dispositions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Structured Haystack advisory findings** (#1113): Added structured Haystack
   finding output for downstream review summaries and delegated advisory
   dispositions.
+- **Advisory disposition triggers** (#1114): Added reviewer-loop advisory
+  disposition triggers for Haystack advisory counts, policy-review-required
+  results, and advisory labels.
 
 ## [0.35.0] - 2026-07-02
 

--- a/docs/testing/workflow/1114-advisory-disposition-triggers.smoke-test.md
+++ b/docs/testing/workflow/1114-advisory-disposition-triggers.smoke-test.md
@@ -35,7 +35,7 @@ Before running this smoke test:
    clean review with one structured advisory finding.
 2. Verify the reviewer-loop output remains clean and reports zero blocking
    findings.
-3. Verify the output includes an advisory-disposition-required signal.
+3. Verify the output includes `ADVISORY_DISPOSITION_REQUIRED=1`.
 4. Verify the Automated Reviewer Loop Summary lists the Haystack advisory
    category and summary.
 
@@ -62,8 +62,7 @@ escalate the advisory without manually rerunning Haystack for basic context.
 
 1. Run a fixture where the review result is clean, blocking count is zero, and
    policy review is required.
-2. Verify the reviewer-loop output reports an advisory-disposition-required
-   signal.
+2. Verify the reviewer-loop output reports `ADVISORY_DISPOSITION_REQUIRED=1`.
 3. Verify the summary includes a policy acknowledgement or policy advisory entry.
 
 **Expected result**: Policy-required evidence cannot disappear into a generic
@@ -76,7 +75,7 @@ clean result.
 1. Run or inspect the fixture that simulates a clean PR-Agent result with an
    advisory label.
 2. Verify the existing advisory-label summary entry is still present.
-3. Verify the advisory-disposition-required behavior applies to the label.
+3. Verify `ADVISORY_DISPOSITION_REQUIRED=1` applies to the label.
 
 **Expected result**: Existing PR-Agent advisory behavior is preserved.
 
@@ -90,10 +89,10 @@ clean result.
 
 Each checkbox maps to an acceptance criterion from the spec.
 
-- [ ] AC-1: Clean output with advisory count greater than zero requires
-      disposition before readiness is complete.
-- [ ] AC-2: Clean output with policy review required requires disposition before
-      readiness is complete.
+- [ ] AC-1: Clean output with advisory count greater than zero emits
+      `ADVISORY_DISPOSITION_REQUIRED=1` before readiness is complete.
+- [ ] AC-2: Clean output with policy review required emits
+      `ADVISORY_DISPOSITION_REQUIRED=1` before readiness is complete.
 - [ ] AC-3: Existing advisory-label disposition behavior still runs.
 - [ ] AC-4: Haystack structured advisory details are listed in the reviewer-loop
       summary.

--- a/docs/testing/workflow/705-claude-code-action-review-platform.smoke-test.md
+++ b/docs/testing/workflow/705-claude-code-action-review-platform.smoke-test.md
@@ -216,9 +216,14 @@ The companion script exits with code 3 (unavailable) when the dispatch itself fa
    ```bash
    scripts/development-workflow/pr-review-loop.sh <pr_number> --platform codex-github
    ```
-3. Compare the key names in both outputs
+3. Compare the shared platform key names in both outputs.
 
-**Expected result**: Both platform outputs contain exactly: `RESULT`, `PLATFORM`, `PR_NUMBER`, `BRANCH`, `FIX_AGENT`, `COMMENT_COUNT`, `BLOCKING_COUNT`, `SUGGESTION_COUNT`. No extra or missing keys in the `claude-code-action` clean output.
+**Expected result**: Both platform outputs contain the same shared platform keys:
+`RESULT`, `PLATFORM`, `PR_NUMBER`, `BRANCH`, `FIX_AGENT`, `COMMENT_COUNT`,
+`BLOCKING_COUNT`, and `SUGGESTION_COUNT`. Aggregate reviewer-loop telemetry such
+as `ADVISORY_DISPOSITION_REQUIRED` may also appear after platform aggregation,
+but `claude-code-action` must not emit platform-specific keys that `codex-github`
+does not emit.
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -661,15 +661,33 @@ advisory dispositions in the post-clean summary flow defined below.
 
 ### Advisory finding dispositions (post-clean)
 
-When `pr-review-loop.sh` exits `clean` and the output contains a non-empty `ADVISORY_LABELS` value (advisory findings from any configured platform), the runner must document the disposition of each advisory finding and update the summary comment before marking the PR ready. This closes the gap between "we saw this finding" and "here is why it was or was not addressed."
+When `pr-review-loop.sh` exits `clean` and the output reports advisory evidence,
+the runner must document the disposition of each advisory finding and update the
+summary comment before marking the PR ready. This closes the gap between "we saw
+this finding" and "here is why it was or was not addressed."
 
 #### When this step triggers
 
-Any clean exit where the script output includes one or more advisory label entries in the `ADVISORY_LABELS` key (comma-separated names, e.g. `Possible Issue,Logic Issue`).
+Any clean exit where one or more of these signals is present:
+
+- `ADVISORY_DISPOSITION_REQUIRED=1`
+- `SUGGESTION_COUNT` is greater than zero
+- `POLICY_REVIEW_REQUIRED=1`
+- `ADVISORY_LABELS` is non-empty
+
+`ADVISORY_DISPOSITION_REQUIRED=1` is the preferred aggregate signal for new
+callers. The other fields remain valid fallback triggers for older script
+versions and for humans inspecting raw platform output.
 
 #### Procedure
 
-1. **For each advisory finding** listed in the "Advisory findings" section of the Automated Reviewer Loop Summary comment, read the full finding text from the linked PR comment.
+1. **For each advisory finding** listed in the "Advisory findings" section of
+   the Automated Reviewer Loop Summary comment, review the available finding
+   context. PR-Agent advisory labels link to the source PR comment. Haystack
+   structured advisory entries include category, summary, detail, optional
+   source location, and optional fix hint directly in the summary. Policy-review
+   required entries include the policy handoff metadata available from the
+   reviewer output.
 
 2. **Determine the disposition** — choose one per finding:
    - **Addressed** — the finding describes a real issue that was fixed in this PR. Cite the commit SHA.

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -444,6 +444,13 @@ compact_advisory_findings_json() {
   printf '%s\n' "$raw_json" | jq -c 'if type == "array" then . else error("expected advisory finding array") end'
 }
 
+is_nonnegative_int() {
+  case "${1:-}" in
+    ''|*[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 advisory_disposition_required_for_platform() {
   local result="$1"
   local suggestion_count="${2:-0}"
@@ -451,7 +458,7 @@ advisory_disposition_required_for_platform() {
   local advisory_labels="${4:-}"
 
   [ "$result" = "clean" ] || return 1
-  if [[ "$suggestion_count" =~ ^[0-9]+$ ]] && [ "$suggestion_count" -gt 0 ]; then
+  if is_nonnegative_int "$suggestion_count" && [ "$suggestion_count" -gt 0 ]; then
     return 0
   fi
   [ "$policy_review_required" = "1" ] && return 0
@@ -5481,6 +5488,18 @@ for index in "${!platforms[@]}"; do
   platform_reason="$(kv_value_default REASON "$platform_output" "")"
   if reviewer_failed_label_required_for_result "$platform_result" "$platform_reason"; then
     reviewer_failed_required=1
+  fi
+  if ! is_nonnegative_int "$platform_comment_count" \
+      || ! is_nonnegative_int "$platform_blocking_count" \
+      || ! is_nonnegative_int "$platform_suggestion_count"; then
+    aggregate_result="escalate"
+    aggregate_reason="platform_count_parse_failed"
+    aggregate_output="$platform_output"
+    aggregate_status=2
+    reviewer_failed_required=1
+    last_platform="$platform_name"
+    platform_result_tokens+=("${platform_name}:escalated (platform_count_parse_failed)")
+    break
   fi
 
   total_comment_count=$((total_comment_count + platform_comment_count))

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -431,6 +431,55 @@ kv_value_default() {
   fi
 }
 
+emit_companion_field_if_present() {
+  local key="$1"
+  local kv_output="$2"
+  local value
+  value="$(kv_value "$key" "$kv_output")"
+  [ -n "$value" ] && print_kv "$key" "$value"
+}
+
+compact_advisory_findings_json() {
+  local raw_json="$1"
+  printf '%s\n' "$raw_json" | jq -c 'if type == "array" then . else error("expected advisory finding array") end'
+}
+
+advisory_disposition_required_for_platform() {
+  local result="$1"
+  local suggestion_count="${2:-0}"
+  local policy_review_required="${3:-0}"
+  local advisory_labels="${4:-}"
+
+  [ "$result" = "clean" ] || return 1
+  if [[ "$suggestion_count" =~ ^[0-9]+$ ]] && [ "$suggestion_count" -gt 0 ]; then
+    return 0
+  fi
+  [ "$policy_review_required" = "1" ] && return 0
+  [ -n "$advisory_labels" ] && return 0
+  return 1
+}
+
+render_structured_advisory_entries() {
+  local platform="$1"
+  local findings_json="$2"
+
+  printf '%s\n' "$findings_json" | jq -r --arg platform "$platform" '
+    def one_line:
+      tostring
+      | gsub("\\r?\\n"; " ")
+      | gsub("[[:space:]][[:space:]]+"; " ");
+    .[] |
+      "- " + $platform + ": " + ((.category // "Advisory") | one_line) + " - " + ((.summary // .message // "Advisory finding") | one_line),
+      (if (((.detail // "") | tostring | length) > 0) then "  Detail: " + ((.detail // "") | one_line) else empty end),
+      (if (((.path // "") | tostring | length) > 0) then
+        "  Location: `" + ((.path // "") | one_line) +
+        (if (.line // null) == null then "" else ":" + ((.line // "") | one_line) end) +
+        "`"
+      else empty end),
+      (if (((.fix_hint // "") | tostring | length) > 0) then "  Fix hint: " + ((.fix_hint // "") | one_line) else empty end)
+  '
+}
+
 emit_prefixed_platform_output() {
   local index="$1"
   local kv_output="$2"
@@ -2012,6 +2061,7 @@ run_haystack_review() {
   local blocking_count=0
   local suggestion_count=0
   local comment_count=0
+  local _haystack_field
 
   require_gh
   cd_workflow_repo_root
@@ -2099,6 +2149,22 @@ run_haystack_review() {
       print_kv COMMENT_COUNT "$comment_count"
       print_kv BLOCKING_COUNT 0
       print_kv SUGGESTION_COUNT "$suggestion_count"
+      for _haystack_field in \
+        ADVISORY_FINDINGS_JSON \
+        BLOCKING_FINDINGS_JSON \
+        POLICY_STATUS_AVAILABLE \
+        POLICY_REVIEW_REQUIRED \
+        POLICY_DISPOSITION \
+        POLICY_VERDICT \
+        POLICY_ANALYSIS_STATUS \
+        POLICY_BUCKET \
+        POLICY_RATING \
+        POLICY_HAS_REVIEWER \
+        POLICY_NEEDS_HUMAN \
+        DISPLAY_RESULT; do
+        emit_companion_field_if_present "$_haystack_field" "$script_output"
+      done
+      unset _haystack_field
       return 0
       ;;
     1)
@@ -2116,6 +2182,22 @@ run_haystack_review() {
       print_kv COMMENT_COUNT "$comment_count"
       print_kv BLOCKING_COUNT "$blocking_count"
       print_kv SUGGESTION_COUNT "$suggestion_count"
+      for _haystack_field in \
+        ADVISORY_FINDINGS_JSON \
+        BLOCKING_FINDINGS_JSON \
+        POLICY_STATUS_AVAILABLE \
+        POLICY_REVIEW_REQUIRED \
+        POLICY_DISPOSITION \
+        POLICY_VERDICT \
+        POLICY_ANALYSIS_STATUS \
+        POLICY_BUCKET \
+        POLICY_RATING \
+        POLICY_HAS_REVIEWER \
+        POLICY_NEEDS_HUMAN \
+        DISPLAY_RESULT; do
+        emit_companion_field_if_present "$_haystack_field" "$script_output"
+      done
+      unset _haystack_field
       return 1
       ;;
     2)
@@ -5306,6 +5388,8 @@ total_comment_count=0
 total_blocking_count=0
 total_suggestion_count=0
 aggregate_advisory_labels=""
+advisory_disposition_required=0
+policy_review_disposition_required=0
 reviewer_failed_required=0
 declare -a compare_verdicts=()
 # Per-platform result tokens for the PR summary comment.
@@ -5314,6 +5398,8 @@ declare -a platform_result_tokens=()
 # Per-platform review-policy status notes for the PR summary comment. Haystack
 # emits these from `pr-status`; other platforms normally leave this empty.
 declare -a platform_policy_status_notes=()
+declare -a aggregate_advisory_findings_platforms=()
+declare -a aggregate_advisory_findings_jsons=()
 # Compare-mode: track the first blocking platform seen so later clean platforms
 # do not overwrite the aggregate. These variables are set once and never reset.
 compare_first_blocking_result=""
@@ -5390,6 +5476,8 @@ for index in "${!platforms[@]}"; do
   platform_blocking_count="$(kv_value_default BLOCKING_COUNT "$platform_output" 0)"
   platform_suggestion_count="$(kv_value_default SUGGESTION_COUNT "$platform_output" 0)"
   platform_advisory_labels="$(kv_value_default ADVISORY_LABELS "$platform_output" "")"
+  platform_advisory_findings_json="$(kv_value_default ADVISORY_FINDINGS_JSON "$platform_output" "")"
+  platform_policy_review_required="$(kv_value_default POLICY_REVIEW_REQUIRED "$platform_output" 0)"
   platform_reason="$(kv_value_default REASON "$platform_output" "")"
   if reviewer_failed_label_required_for_result "$platform_result" "$platform_reason"; then
     reviewer_failed_required=1
@@ -5405,7 +5493,29 @@ for index in "${!platforms[@]}"; do
       aggregate_advisory_labels="$platform_advisory_labels"
     fi
   fi
+  if advisory_disposition_required_for_platform \
+      "$platform_result" "$platform_suggestion_count" "$platform_policy_review_required" "$platform_advisory_labels"; then
+    advisory_disposition_required=1
+  fi
+  if [ "$platform_result" = "clean" ] && [ "$platform_policy_review_required" = "1" ]; then
+    policy_review_disposition_required=1
+  fi
   last_platform="$platform_name"
+  if [ -n "$platform_advisory_findings_json" ]; then
+    if ! platform_advisory_findings_compact="$(compact_advisory_findings_json "$platform_advisory_findings_json" 2>/dev/null)"; then
+      aggregate_result="escalate"
+      aggregate_reason="advisory_json_parse_failed"
+      aggregate_output="$platform_output"
+      aggregate_status=2
+      reviewer_failed_required=1
+      platform_result_tokens+=("${platform_name}:escalated (advisory_json_parse_failed)")
+      break
+    fi
+    if [ "$platform_advisory_findings_compact" != "[]" ]; then
+      aggregate_advisory_findings_platforms+=("$platform_name")
+      aggregate_advisory_findings_jsons+=("$platform_advisory_findings_compact")
+    fi
+  fi
 
   print_kv "PLATFORM_${platform_index}_NAME" "$platform_name"
   print_kv "PLATFORM_${platform_index}_RESULT" "$platform_result"
@@ -5455,6 +5565,8 @@ for index in "${!platforms[@]}"; do
   unset _policy_status_available _policy_bucket _policy_needs_human
   unset _policy_disposition _policy_verdict _policy_analysis_status
   unset _policy_rating _policy_has_reviewer _policy_note
+  unset platform_advisory_findings_json platform_advisory_findings_compact
+  unset platform_policy_review_required
 
   # In compare mode, record a normalized verdict for each platform before
   # deciding whether to break. The normalized verdict captures clean / blocking /
@@ -5595,11 +5707,20 @@ _post_review_summary() {
   # Each entry's labels are pipe-separated. Render each label as a list item,
   # linking to the PR-Agent comment URL when available.
   local advisory_section=""
-  if [ -n "$advisory_labels" ]; then
+  local advisory_finding_count=0
+  local structured_advisory_count=0
+  if declare -p aggregate_advisory_findings_jsons >/dev/null 2>&1; then
+    structured_advisory_count="${#aggregate_advisory_findings_jsons[@]}"
+  fi
+  if [ -n "$advisory_labels" ] \
+      || [ "$structured_advisory_count" -gt 0 ] \
+      || [ "${advisory_disposition_required:-0}" = "1" ]; then
     local _entry _labels _url _label
     advisory_section="
 
 **Advisory findings (non-blocking):**"
+  fi
+  if [ -n "$advisory_labels" ]; then
     # Split entries by ||| separator using sed (IFS does not support multi-char
     # separators). Each entry has the form "<pipe-delimited labels>@@@<url>".
     local _entries_normalized
@@ -5620,6 +5741,7 @@ _post_review_summary() {
           advisory_section="${advisory_section}
 - ${_label}"
         fi
+        advisory_finding_count=$((advisory_finding_count + 1))
       done <<_ADVISORY_LABEL_LINES_
 $_labels_normalized
 _ADVISORY_LABEL_LINES_
@@ -5646,6 +5768,42 @@ _ADVISORY_ENTRY_LINES_
       advisory_section="${advisory_section}
   _Possible Issue evaluation_: ${_eval_note}"
     fi
+  fi
+  if [ "$structured_advisory_count" -gt 0 ]; then
+    local _adv_index=0
+    local _structured_entries=""
+    while [ "$_adv_index" -lt "$structured_advisory_count" ]; do
+      if _structured_entries="$(
+        render_structured_advisory_entries \
+          "${aggregate_advisory_findings_platforms[$_adv_index]}" \
+          "${aggregate_advisory_findings_jsons[$_adv_index]}"
+      )"; then
+        if [ -n "$_structured_entries" ]; then
+          advisory_section="${advisory_section}
+${_structured_entries}"
+          advisory_finding_count=$((advisory_finding_count + $(printf '%s\n' "$_structured_entries" | grep -c '^- ' || true)))
+        fi
+      else
+        advisory_section="${advisory_section}
+- Structured advisory findings could not be rendered; rerun the reviewer loop."
+        advisory_finding_count=$((advisory_finding_count + 1))
+      fi
+      _adv_index=$((_adv_index + 1))
+    done
+  fi
+  if [ "${policy_review_disposition_required:-0}" = "1" ] && [ "$advisory_finding_count" -eq 0 ]; then
+    local _policy_fallback="policy review required"
+    if declare -p platform_policy_status_notes >/dev/null 2>&1 \
+        && [ "${#platform_policy_status_notes[@]}" -gt 0 ]; then
+      _policy_fallback="$(IFS=' '; printf '%s' "${platform_policy_status_notes[*]}")"
+    fi
+    advisory_section="${advisory_section}
+- Policy review required: ${_policy_fallback}"
+    advisory_finding_count=$((advisory_finding_count + 1))
+  fi
+  if [ "${advisory_disposition_required:-0}" = "1" ] && [ "$advisory_finding_count" -eq 0 ]; then
+    advisory_section="${advisory_section}
+- Advisory count reported without structured finding details; review platform output reported ${suggestions} suggestion(s)."
   fi
 
   # Step 7b regression-label assertion (clean path, implementation PRs only).
@@ -5812,6 +5970,7 @@ if [ -z "$last_platform" ]; then
   print_kv COMMENT_COUNT 0
   print_kv BLOCKING_COUNT 0
   print_kv SUGGESTION_COUNT 0
+  print_kv ADVISORY_DISPOSITION_REQUIRED 0
   print_kv UNRESOLVED_THREAD_COUNT 0
   _post_review_summary "skipped" "not_configured" "none" "0" "0" "" "" "0" "" "0" "0" "" "0"
   sync_reviewer_failed_label "$pr_number" 0
@@ -6057,6 +6216,7 @@ print_kv PLATFORM "$last_platform"
 print_kv COMMENT_COUNT "$total_comment_count"
 print_kv BLOCKING_COUNT "$total_blocking_count"
 print_kv SUGGESTION_COUNT "$total_suggestion_count"
+print_kv ADVISORY_DISPOSITION_REQUIRED "$advisory_disposition_required"
 
 if [ -n "$aggregate_output" ]; then
   review_comment_id="$(kv_value REVIEW_COMMENT_ID "$aggregate_output")"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -6216,7 +6216,9 @@ print_kv PLATFORM "$last_platform"
 print_kv COMMENT_COUNT "$total_comment_count"
 print_kv BLOCKING_COUNT "$total_blocking_count"
 print_kv SUGGESTION_COUNT "$total_suggestion_count"
-print_kv ADVISORY_DISPOSITION_REQUIRED "$advisory_disposition_required"
+advisory_disposition_required_output="$advisory_disposition_required"
+[ "$aggregate_result" != "clean" ] && advisory_disposition_required_output=0
+print_kv ADVISORY_DISPOSITION_REQUIRED "$advisory_disposition_required_output"
 
 if [ -n "$aggregate_output" ]; then
   review_comment_id="$(kv_value REVIEW_COMMENT_ID "$aggregate_output")"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1378,8 +1378,10 @@ run_test "advisory_disposition_not_required_for_blocking_result" "0" "$_advisory
 unset _advisory_trigger_count
 
 # Test 10.1e: final aggregate output emits the disposition-required signal.
-if grep -qF 'print_kv ADVISORY_DISPOSITION_REQUIRED "$advisory_disposition_required"' \
-    "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"; then
+if grep -qF 'advisory_disposition_required_output="$advisory_disposition_required"' \
+    "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh" \
+    && grep -qF 'print_kv ADVISORY_DISPOSITION_REQUIRED "$advisory_disposition_required_output"' \
+      "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"; then
   _advisory_signal_emitted=1
 else
   _advisory_signal_emitted=0

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1377,7 +1377,23 @@ fi
 run_test "advisory_disposition_not_required_for_blocking_result" "0" "$_advisory_trigger_count"
 unset _advisory_trigger_count
 
-# Test 10.1e: final aggregate output emits the disposition-required signal.
+# Test 10.1e: platform count parsing accepts only non-negative integers.
+if is_nonnegative_int "0" && is_nonnegative_int "12" && ! is_nonnegative_int "abc" && ! is_nonnegative_int "1abc"; then
+  _count_validation_ok=1
+else
+  _count_validation_ok=0
+fi
+run_test "platform_count_validation_nonnegative_int_only" "1" "$_count_validation_ok"
+if grep -qF 'aggregate_reason="platform_count_parse_failed"' \
+    "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"; then
+  _count_fail_closed=1
+else
+  _count_fail_closed=0
+fi
+run_test "platform_count_parse_failure_fails_closed" "1" "$_count_fail_closed"
+unset _count_validation_ok _count_fail_closed
+
+# Test 10.1f: final aggregate output emits the disposition-required signal.
 if grep -qF 'advisory_disposition_required_output="$advisory_disposition_required"' \
     "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh" \
     && grep -qF 'print_kv ADVISORY_DISPOSITION_REQUIRED "$advisory_disposition_required_output"' \
@@ -1389,7 +1405,7 @@ fi
 run_test "advisory_disposition_required_signal_emitted" "1" "$_advisory_signal_emitted"
 unset _advisory_signal_emitted
 
-# Test 10.1f: malformed advisory JSON is rejected before summary rendering.
+# Test 10.1g: malformed advisory JSON is rejected before summary rendering.
 set +e
 compact_advisory_findings_json '{"not":"an array"}' >/dev/null 2>&1
 _compact_status=$?

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1262,6 +1262,54 @@ rm -rf "$_haystack_reviewer_stub"
 unset MOCK_GH_OUTPUT _haystack_auth_overrides actual_output actual_exit
 workflow_repo_root() { printf '%s\n' "${HARNESS_REPO_ROOT:-$REPO_ROOT}"; }
 
+# test: run_haystack_review forwards structured advisory and policy fields
+_haystack_structured_overrides='
+  cd_workflow_repo_root() { :; }
+  repo_slug() { printf "owner/repo\n"; }
+  require_gh() { :; }
+'
+export MOCK_GH_OUTPUT="false"
+_haystack_reviewer_stub="$(mktemp -d)"
+mkdir -p "$_haystack_reviewer_stub/scripts/development-workflow"
+cat > "$_haystack_reviewer_stub/scripts/development-workflow/haystack-reviewer.sh" <<'HAYSTACK_STUB'
+#!/usr/bin/env bash
+printf 'RESULT=clean\n'
+printf 'BLOCKING_COUNT=0\n'
+printf 'SUGGESTION_COUNT=1\n'
+printf 'COMMENT_COUNT=1\n'
+printf 'ADVISORY_FINDINGS_JSON=[{"severity":"advisory","category":"Minor","summary":"Structured note","detail":"Details","path":"script.sh","line":12,"fix_hint":"Consider simplifying"}]\n'
+printf 'BLOCKING_FINDINGS_JSON=[]\n'
+printf 'POLICY_STATUS_AVAILABLE=1\n'
+printf 'POLICY_REVIEW_REQUIRED=1\n'
+printf 'POLICY_DISPOSITION=policy-human-review\n'
+printf 'POLICY_VERDICT=needs-review\n'
+printf 'POLICY_ANALYSIS_STATUS=ready\n'
+printf 'POLICY_BUCKET=needs-assignment\n'
+printf 'POLICY_RATING=4\n'
+printf 'POLICY_HAS_REVIEWER=false\n'
+printf 'POLICY_NEEDS_HUMAN=true\n'
+printf 'DISPLAY_RESULT=needs-review: policy\n'
+exit 0
+HAYSTACK_STUB
+chmod +x "$_haystack_reviewer_stub/scripts/development-workflow/haystack-reviewer.sh"
+workflow_repo_root() { printf "%s\n" "$_haystack_reviewer_stub"; }
+actual_output="$(
+  eval "$_haystack_structured_overrides"
+  _ec=0
+  run_haystack_review "42" "feature/test" "1" "30" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+run_test "haystack_forwards_advisory_findings_json" \
+  'ADVISORY_FINDINGS_JSON=[{"severity":"advisory","category":"Minor","summary":"Structured note","detail":"Details","path":"script.sh","line":12,"fix_hint":"Consider simplifying"}]' \
+  "$(printf '%s\n' "$actual_output" | grep "^ADVISORY_FINDINGS_JSON=")"
+run_test "haystack_forwards_policy_review_required" "POLICY_REVIEW_REQUIRED=1" \
+  "$(printf '%s\n' "$actual_output" | grep "^POLICY_REVIEW_REQUIRED=")"
+run_test "haystack_forwards_display_result" "DISPLAY_RESULT=needs-review: policy" \
+  "$(printf '%s\n' "$actual_output" | grep "^DISPLAY_RESULT=")"
+rm -rf "$_haystack_reviewer_stub"
+unset MOCK_GH_OUTPUT _haystack_structured_overrides actual_output
+workflow_repo_root() { printf '%s\n' "${HARNESS_REPO_ROOT:-$REPO_ROOT}"; }
+
 # ---------------------------------------------------------------------------
 # Area 10: per-platform result tokens in summary comment (#755)
 #
@@ -1301,6 +1349,66 @@ run_test "policy_review_compare_verdict" "advisory" "$(normalize_platform_verdic
 run_test "policy_review_does_not_override_needs_fixes" "blocking" "$(normalize_platform_verdict needs_fixes "$_platform_output")"
 run_test "policy_review_does_not_override_skipped" "unavailable" "$(normalize_platform_verdict skipped "$_platform_output")"
 unset _platform_output _prt_display_override _prt_disp
+
+# Test 10.1d: advisory-disposition trigger helper covers all clean advisory signals.
+if advisory_disposition_required_for_platform clean 1 0 ""; then
+  _advisory_trigger_count=1
+else
+  _advisory_trigger_count=0
+fi
+run_test "advisory_disposition_required_by_suggestion_count" "1" "$_advisory_trigger_count"
+if advisory_disposition_required_for_platform clean 0 1 ""; then
+  _advisory_trigger_count=1
+else
+  _advisory_trigger_count=0
+fi
+run_test "advisory_disposition_required_by_policy" "1" "$_advisory_trigger_count"
+if advisory_disposition_required_for_platform clean 0 0 "Possible Issue@@@https://example.test/comment"; then
+  _advisory_trigger_count=1
+else
+  _advisory_trigger_count=0
+fi
+run_test "advisory_disposition_required_by_labels" "1" "$_advisory_trigger_count"
+if advisory_disposition_required_for_platform needs_fixes 1 1 "Possible Issue"; then
+  _advisory_trigger_count=1
+else
+  _advisory_trigger_count=0
+fi
+run_test "advisory_disposition_not_required_for_blocking_result" "0" "$_advisory_trigger_count"
+unset _advisory_trigger_count
+
+# Test 10.1e: final aggregate output emits the disposition-required signal.
+if grep -qF 'print_kv ADVISORY_DISPOSITION_REQUIRED "$advisory_disposition_required"' \
+    "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"; then
+  _advisory_signal_emitted=1
+else
+  _advisory_signal_emitted=0
+fi
+run_test "advisory_disposition_required_signal_emitted" "1" "$_advisory_signal_emitted"
+unset _advisory_signal_emitted
+
+# Test 10.1f: malformed advisory JSON is rejected before summary rendering.
+set +e
+compact_advisory_findings_json '{"not":"an array"}' >/dev/null 2>&1
+_compact_status=$?
+set -e
+if [ "$_compact_status" -ne 0 ]; then
+  _compact_rejected=1
+else
+  _compact_rejected=0
+fi
+run_test "advisory_json_non_array_rejected" "1" "$_compact_rejected"
+set +e
+compact_advisory_findings_json '[{"category":"Minor"}' >/dev/null 2>&1
+_compact_status=$?
+set -e
+if [ "$_compact_status" -ne 0 ]; then
+  _compact_rejected=1
+else
+  _compact_rejected=0
+fi
+run_test "advisory_json_malformed_rejected" "1" "$_compact_rejected"
+unset _compact_status _compact_rejected
 
 # Test 10.1c: policy metadata is rendered as an explicit handoff note.
 _platform_name="haystack"
@@ -1449,10 +1557,46 @@ else
   _summary_advisory_split="no"
 fi
 run_test "summary_advisory_split_visible" "yes" "$_summary_advisory_split"
+
+aggregate_advisory_findings_platforms=("haystack")
+aggregate_advisory_findings_jsons=(
+  "$(jq -nc '[{"severity":"advisory","category":"Minor","summary":"Summary with \"quotes\", pipe | equals =, and newline text","detail":"Line one\nLine two","path":"scripts/example.sh","line":12,"fix_hint":"Use $PATH && echo ok"}]')"
+)
+advisory_disposition_required=1
+policy_review_disposition_required=0
+platform_policy_status_notes=()
+_post_review_summary "clean" "" "haystack (clean)" "0" "1" ""
+if [ -n "${_summary_body_capture:-}" ] \
+    && grep -q 'haystack: Minor - Summary with "quotes", pipe | equals =, and newline text' "$_summary_body_capture" \
+    && grep -q "Detail: Line one Line two" "$_summary_body_capture" \
+    && grep -q 'Location: `scripts/example.sh:12`' "$_summary_body_capture" \
+    && grep -q 'Fix hint: Use $PATH && echo ok' "$_summary_body_capture"; then
+  _structured_summary_rendered="yes"
+else
+  _structured_summary_rendered="no"
+fi
+run_test "summary_structured_haystack_advisory_rendered" "yes" "$_structured_summary_rendered"
+
+aggregate_advisory_findings_platforms=()
+aggregate_advisory_findings_jsons=()
+advisory_disposition_required=1
+policy_review_disposition_required=1
+platform_policy_status_notes=("haystack: bucket=needs-assignment; needsHumanReview=true;")
+_post_review_summary "clean" "" "haystack (needs-review: policy)" "0" "0" ""
+if [ -n "${_summary_body_capture:-}" ] \
+    && grep -q "Policy review required: haystack: bucket=needs-assignment; needsHumanReview=true;" "$_summary_body_capture"; then
+  _policy_fallback_rendered="yes"
+else
+  _policy_fallback_rendered="no"
+fi
+run_test "summary_policy_required_fallback_rendered" "yes" "$_policy_fallback_rendered"
 rm -f "$_summary_call_log"
 rm -f "$_summary_body_capture"
 unset MOCK_GH_CALL_LOG MOCK_GH_BODY_CAPTURE MOCK_GH_EXIT MOCK_GH_COMMENTS_OUTPUT
-unset _summary_advisory_split _post_summary_source
+unset _summary_advisory_split _structured_summary_rendered _policy_fallback_rendered
+unset _post_summary_source aggregate_advisory_findings_platforms
+unset aggregate_advisory_findings_jsons advisory_disposition_required
+unset policy_review_disposition_required
 unset -f _post_review_summary
 unset compare_mode compare_verdicts platform_policy_status_notes pr_number branch_name
 


### PR DESCRIPTION
## Summary

- Forward Haystack structured advisory and policy fields through `pr-review-loop.sh`.
- Emit `ADVISORY_DISPOSITION_REQUIRED` when clean output has advisory count, policy review required, or advisory labels.
- Render Haystack structured advisories and policy fallback entries in the reviewer-loop summary.
- Update Protocol 93, smoke runbooks, and CHANGELOG for the new disposition trigger contract.

## Links

- Spec: `docs/specs/developments/20260702095847_1114-advisory-disposition-triggers/1_1114-advisory-disposition-triggers_specs.md`
- Plan: `docs/specs/developments/20260702095847_1114-advisory-disposition-triggers/2_1114-advisory-disposition-triggers_implementation-plan.md`
- Smoke: `docs/testing/workflow/1114-advisory-disposition-triggers.smoke-test.md`

## Test Plan

- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` (289 passed, 0 failed)
- `bash scripts/development-workflow/tests/test-haystack-reviewer.sh` (191 passed, 0 failed)
- `shellcheck --severity=warning -x scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md" "docs/testing/workflow/1114-advisory-disposition-triggers.smoke-test.md" "docs/testing/workflow/705-claude-code-action-review-platform.smoke-test.md" "CHANGELOG.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md docs/testing/workflow/1114-advisory-disposition-triggers.smoke-test.md docs/testing/workflow/705-claude-code-action-review-platform.smoke-test.md CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`

## Test Harness Coverage Checklist

- Empty / zero-length input: covered by existing no-advisory summary and existing empty output paths.
- Whitespace-only input: not applicable; this change parses structured key-value fields and compact JSON arrays, not free-form primary whitespace input.
- Boundary values: covered for advisory count 0 vs 1 and clean vs needs_fixes trigger behavior.
- Missing / absent environment variables: existing harness mocks exercise missing/failed `gh` state; this change adds no required environment variables.
- Concurrent / parallel execution: not applicable; no shared-state writer was added beyond the existing single summary comment update path.
- Negative assertions: malformed and non-array advisory JSON are rejected; needs_fixes does not require advisory disposition.
- Bash harness specifics: existing single EXIT trap retained; path-like summary location rendering covered; sourced function ordering retained through HARNESS_MODE.

## Deviations

None.

## CHANGELOG Preview

- **Advisory disposition triggers** (#1114): Added reviewer-loop advisory disposition triggers for Haystack advisory counts, policy-review-required results, and advisory labels.

## Pre-submission Self-review

Stale markers: none found in `git diff origin/develop-external-review-loop-hardening...HEAD`.
Caller consistency: verified Protocol 93, the #1114 smoke runbook, and the older Claude Code Action smoke runbook do not contradict the new aggregate output signal.
Coverage: all #1114 acceptance criteria are covered by script behavior, harness assertions, Protocol 93 updates, and smoke-runbook updates.

Closes #1114

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch the central reviewer-loop aggregation and readiness contract; malformed inputs now escalate instead of silently continuing, which is safer but can surface new `escalate` outcomes if platform output regresses.
> 
> **Overview**
> Clean reviewer-loop exits can now **require advisory disposition** before readiness: aggregated output emits **`ADVISORY_DISPOSITION_REQUIRED=1`** when a platform is clean but has suggestions, policy review required, or PR-Agent advisory labels (forced to `0` when the aggregate result is not clean).
> 
> **`pr-review-loop.sh`** forwards Haystack companion fields (e.g. `ADVISORY_FINDINGS_JSON`, policy metadata), aggregates structured advisories with **fail-closed** handling for bad platform counts or malformed advisory JSON, and extends the Automated Reviewer Loop Summary with Haystack lines (category, detail, location, fix hint) plus policy-review fallbacks when disposition is required but no listable finding exists.
> 
> **Protocol 93** and smoke runbooks (#1114, #705) document the new trigger contract and that aggregate keys like `ADVISORY_DISPOSITION_REQUIRED` may appear after platform aggregation without breaking platform parity checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d9aa6668c943ccee8f6fd10604191346764208f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->