### PR TITLE
feat(haystack): classify known false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Advisory disposition triggers** (#1114): Added reviewer-loop advisory
   disposition triggers for Haystack advisory counts, policy-review-required
   results, and advisory labels.
+- **Haystack false-positive catalog** (#1115): Added a machine-readable known
+  false-positive catalog for recurring Haystack findings and surfaced matched
+  dispositions in reviewer output.
 
 ## [0.35.0] - 2026-07-02
 

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -190,8 +190,9 @@ Set `HAYSTACK_FALSE_POSITIVES_FILE=/path/to/catalog.json` to test an alternate
 catalog. If the catalog is missing, empty, malformed, or not a JSON array, the
 reviewer logs a warning and continues without applying known false-positive
 dispositions. The same fail-closed behavior applies when any catalog rule is
-invalid, such as a category-only rule with no evidence predicate. That preserves
-the original severity classification instead of silently masking findings.
+invalid, such as a category-only rule with no evidence predicate or a pattern
+that cannot compile as a regular expression. That preserves the original
+severity classification instead of silently masking findings.
 
 This template catalog is machine-readable. Downstream projects that maintain a
 prose false-positive guide, such as Helm-style `false-positives.md`, should

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -123,6 +123,9 @@ data:
 
 | Field | Fallback order |
 | ----- | -------------- |
+| `disposition` | Present when a maintained catalog rule classifies the finding; currently `known-false-positive`. |
+| `disposition_rule` | Stable catalog rule id that matched the finding. |
+| `disposition_rationale` | Human-readable rationale from the catalog rule. |
 | `path` | `.source.path`, `.source.file`, `.path`, `.file` |
 | `line` | Positive integer values from `.source.line`, `.source.startLine`, `.line`, `.startLine` |
 | `fix_hint` | `.agentFixPrompt`, `.fixPrompt`, `.suggestion` |
@@ -142,9 +145,58 @@ Unavailable or skipped review paths keep their existing output contract and may
 omit the structured arrays. Treat missing arrays on skipped output as "no
 completed Haystack finding payload", not as an empty completed review.
 
-`pr-review-loop.sh` does not list the structured Haystack advisory details in PR
-summary comments yet. That consumer-facing summary work is tracked separately in
-issue #1114.
+`pr-review-loop.sh` lists structured Haystack advisory details in PR summary
+comments. When a finding carries a known false-positive disposition, the summary
+shows the matched rule id and rationale without hiding the original category,
+summary, detail, location, or fix hint.
+
+## Machine-readable False-positive Catalog
+
+Known recurring false positives are maintained in
+`scripts/development-workflow/haystack-false-positives.json`. The reviewer reads
+that catalog before normalizing completed Haystack findings. A matched finding
+keeps its original reviewer context and gains these structured fields:
+
+```text
+disposition=known-false-positive
+disposition_rule=<catalog rule id>
+disposition_rationale=<catalog rationale>
+```
+
+The matching finding is treated as advisory for reviewer-loop readiness. Other
+gates still apply: CI, merge-risk classification, human checkpoints, and
+unmatched blocking findings can still stop the PR.
+
+Catalog entries are JSON objects with these fields:
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
+| `id` | Yes | Stable rule id for audit and summary output. |
+| `label` | Recommended | Human-readable rule label. |
+| `category` | Yes | Exact Haystack category required for the rule to match. |
+| `text_patterns` | Optional | Case-insensitive regular expressions evaluated against summary plus detail. |
+| `summary_patterns` | Optional | Case-insensitive regular expressions evaluated against summary only. |
+| `detail_patterns` | Optional | Case-insensitive regular expressions evaluated against detail only. |
+| `path_patterns` | Optional | Regular expressions evaluated against the normalized path. |
+| `rationale` | Yes | Human-readable explanation for why the finding is a known false positive. |
+
+Pattern fields are intentionally conjunctive by field group: when a rule
+declares both text and path patterns, both groups must match. Within a field
+group, any listed pattern may match. Rules should stay narrow enough that they
+cannot hide real findings that merely share a category. A valid rule must
+include at least one non-empty pattern field in addition to category.
+
+Set `HAYSTACK_FALSE_POSITIVES_FILE=/path/to/catalog.json` to test an alternate
+catalog. If the catalog is missing, empty, malformed, or not a JSON array, the
+reviewer logs a warning and continues without applying known false-positive
+dispositions. The same fail-closed behavior applies when any catalog rule is
+invalid, such as a category-only rule with no evidence predicate. That preserves
+the original severity classification instead of silently masking findings.
+
+This template catalog is machine-readable. Downstream projects that maintain a
+prose false-positive guide, such as Helm-style `false-positives.md`, should
+cross-reference the catalog rule ids from their prose notes rather than
+duplicating matching logic in narrative form.
 
 ## Review Policy Verdicts
 

--- a/scripts/development-workflow/haystack-false-positives.json
+++ b/scripts/development-workflow/haystack-false-positives.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "changelog-keep-changelog-unreleased-structure",
+    "label": "CHANGELOG structure false positive",
+    "category": "Rules violation",
+    "text_patterns": [
+      "keep-changelog-unreleased-structure-canonical"
+    ],
+    "path_patterns": [
+      "(^|/)CHANGELOG\\.md$"
+    ],
+    "rationale": "Haystack can misread correctly nested Keep a Changelog entries from PR diffs; markdownlint and the duplicate-header check are authoritative."
+  },
+  {
+    "id": "hotfix-backport-changelog-structure",
+    "label": "Hotfix backport CHANGELOG structure false positive",
+    "category": "Rules violation",
+    "text_patterns": [
+      "(hotfix|backport).*(CHANGELOG|\\[Unreleased\\])|(CHANGELOG|\\[Unreleased\\]).*(hotfix|backport)"
+    ],
+    "path_patterns": [
+      "(^|/)CHANGELOG\\.md$"
+    ],
+    "rationale": "Hotfix backport diffs can show the main-branch empty Unreleased section even though the develop-side merge preserves the correct changelog structure."
+  },
+  {
+    "id": "agent-doc-mirror-guidance-stale-advisory",
+    "label": "Agent-doc mirror guidance stale advisory",
+    "category": "Rules violation",
+    "text_patterns": [
+      "front matter|\\.cursor/skills|surface"
+    ],
+    "rationale": "Tool-specific front matter differences and the intentionally absent Cursor skills tree are not workflow-body drift; compare live mirrored content before treating the finding as actionable."
+  }
+]

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -103,6 +103,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 if [ $# -lt 3 ]; then
@@ -139,6 +141,7 @@ esac
 TIMEOUT="${HAYSTACK_REVIEWER_TIMEOUT:-120}"
 POLL_INTERVAL="${HAYSTACK_POLL_INTERVAL:-15}"
 PR_STATUS_CHECK="${HAYSTACK_PR_STATUS_CHECK:-1}"
+FALSE_POSITIVES_FILE="${HAYSTACK_FALSE_POSITIVES_FILE:-$SCRIPT_DIR/haystack-false-positives.json}"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -187,6 +190,55 @@ if ! command -v jq >/dev/null 2>&1; then
   printf 'COMMENT_COUNT=0\n'
   exit 3
 fi
+
+load_false_positive_catalog() {
+  local catalog_file="$1"
+  local catalog_json
+
+  if [ ! -f "$catalog_file" ]; then
+    echo "WARN: Haystack false-positive catalog not found at $catalog_file; continuing without catalog matches" >&2
+    printf '[]\n'
+    return 0
+  fi
+  if [ ! -s "$catalog_file" ]; then
+    echo "WARN: Haystack false-positive catalog is empty at $catalog_file; continuing without catalog matches" >&2
+    printf '[]\n'
+    return 0
+  fi
+  if ! catalog_json="$(jq -c '
+      def pattern_values($value):
+        if ($value | type) == "array" then
+          [$value[]? | select(type == "string" and . != "")]
+        elif ($value | type) == "string" and $value != "" then
+          [$value]
+        else
+          []
+        end;
+      def has_match_predicate:
+        (
+          pattern_values(.summary_patterns // .summary_pattern)
+          + pattern_values(.detail_patterns // .detail_pattern)
+          + pattern_values(.text_patterns // .text_pattern)
+          + pattern_values(.path_patterns // .path_pattern)
+        ) | length > 0;
+      if type == "array"
+         and all(.[]; type == "object"
+           and ((.id // "") | type == "string" and . != "")
+           and ((.category // "") | type == "string" and . != "")
+           and ((.rationale // "") | type == "string" and . != "")
+           and has_match_predicate)
+      then .
+      else error("catalog must be an array of valid false-positive rules")
+      end
+    ' "$catalog_file" 2>/dev/null)"; then
+    echo "WARN: Haystack false-positive catalog could not be parsed at $catalog_file; continuing without catalog matches" >&2
+    printf '[]\n'
+    return 0
+  fi
+  printf '%s\n' "$catalog_json"
+}
+
+FALSE_POSITIVE_CATALOG_JSON="$(load_false_positive_catalog "$FALSE_POSITIVES_FILE")"
 
 echo "INFO: haystack CLI found: $(command -v haystack)" >&2
 echo "INFO: poll-retry loop — polling every ${POLL_INTERVAL}s, overall timeout: ${TIMEOUT}s" >&2
@@ -495,7 +547,9 @@ printf '%s\n' "$TRIAGE_OUTPUT" >&2
 # array produces zero output — no sentinel is emitted spuriously.
 # Null/missing .category values are mapped to the sentinel "__UNKNOWN__" so they
 # are treated as blocking (safe-fail) rather than silently dropped.
-NORMALIZED_FINDINGS_JSON="$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -c --arg major_is_blocking "${HAYSTACK_MAJOR_IS_BLOCKING:-0}" '
+NORMALIZED_FINDINGS_JSON="$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -c \
+  --arg major_is_blocking "${HAYSTACK_MAJOR_IS_BLOCKING:-0}" \
+  --argjson false_positive_catalog "$FALSE_POSITIVE_CATALOG_JSON" '
   def category:
     if (.category | type) == "string" and .category != "" then .category
     else "__UNKNOWN__"
@@ -516,6 +570,46 @@ NORMALIZED_FINDINGS_JSON="$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -c --arg major_i
           elif type == "string" and test("^[1-9][0-9]*$") then tonumber
           else empty end)
     | first;
+  def pattern_list($value):
+    if ($value | type) == "array" then
+      [$value[]? | select(type == "string" and . != "")]
+    elif ($value | type) == "string" and $value != "" then
+      [$value]
+    else
+      []
+    end;
+  def any_pattern_matches($text; $patterns):
+    ($patterns | length) == 0
+    or any($patterns[]; . as $pattern | (($text // "" | tostring) | test($pattern ; "i")));
+  def path_patterns_match($path; $patterns):
+    ($patterns | length) == 0
+    or ((($path // "") | tostring | length) > 0
+        and any($patterns[]; . as $pattern | ((($path // "") | tostring) | test($pattern))));
+  def rule_matches($rule; $finding):
+    ($rule | type) == "object"
+    and (($rule.id // "") | type == "string" and . != "")
+    and (($rule.category // "") == $finding.category)
+    and ((pattern_list($rule.summary_patterns // $rule.summary_pattern)
+          + pattern_list($rule.detail_patterns // $rule.detail_pattern)
+          + pattern_list($rule.text_patterns // $rule.text_pattern)
+          + pattern_list($rule.path_patterns // $rule.path_pattern)) | length > 0)
+    and any_pattern_matches($finding.summary; pattern_list($rule.summary_patterns // $rule.summary_pattern))
+    and any_pattern_matches($finding.detail; pattern_list($rule.detail_patterns // $rule.detail_pattern))
+    and any_pattern_matches(($finding.summary + "\n" + $finding.detail); pattern_list($rule.text_patterns // $rule.text_pattern))
+    and path_patterns_match(($finding.path // ""); pattern_list($rule.path_patterns // $rule.path_pattern));
+  def apply_false_positive_catalog($finding):
+    ([ $false_positive_catalog[]? | select(rule_matches(.; $finding)) ][0]) as $rule |
+    if $rule == null then
+      $finding
+    else
+      $finding
+      + {
+          severity: "advisory",
+          disposition: "known-false-positive",
+          disposition_rule: ($rule.id // ""),
+          disposition_rationale: ($rule.rationale // "Known false positive")
+        }
+    end;
   def normalized:
     category as $category |
     (if blocking($category) then "blocking" else "advisory" end) as $severity |
@@ -532,7 +626,8 @@ NORMALIZED_FINDINGS_JSON="$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -c --arg major_i
     }
     + (if $path == null then {} else {path: $path} end)
     + (if $line == null then {} else {line: $line} end)
-    + (if $fix_hint == null then {} else {fix_hint: $fix_hint} end);
+    + (if $fix_hint == null then {} else {fix_hint: $fix_hint} end)
+    | apply_false_positive_catalog(.);
   [(.findings // [])[] | normalized]
 ')"
 

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -221,12 +221,22 @@ load_false_positive_catalog() {
           + pattern_values(.text_patterns // .text_pattern)
           + pattern_values(.path_patterns // .path_pattern)
         ) | length > 0;
+      def regex_compiles($pattern):
+        try ("" | test($pattern) | true) catch false;
+      def patterns_compile:
+        all((
+          pattern_values(.summary_patterns // .summary_pattern)
+          + pattern_values(.detail_patterns // .detail_pattern)
+          + pattern_values(.text_patterns // .text_pattern)
+          + pattern_values(.path_patterns // .path_pattern)
+        )[]; regex_compiles(.));
       if type == "array"
          and all(.[]; type == "object"
            and ((.id // "") | type == "string" and . != "")
            and ((.category // "") | type == "string" and . != "")
            and ((.rationale // "") | type == "string" and . != "")
-           and has_match_predicate)
+           and has_match_predicate
+           and patterns_compile)
       then .
       else error("catalog must be an array of valid false-positive rules")
       end
@@ -580,11 +590,11 @@ NORMALIZED_FINDINGS_JSON="$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -c \
     end;
   def any_pattern_matches($text; $patterns):
     ($patterns | length) == 0
-    or any($patterns[]; . as $pattern | (($text // "" | tostring) | test($pattern ; "i")));
+    or any($patterns[]; . as $pattern | try (($text // "" | tostring) | test($pattern ; "i")) catch false);
   def path_patterns_match($path; $patterns):
     ($patterns | length) == 0
     or ((($path // "") | tostring | length) > 0
-        and any($patterns[]; . as $pattern | ((($path // "") | tostring) | test($pattern))));
+        and any($patterns[]; . as $pattern | try ((($path // "") | tostring) | test($pattern)) catch false));
   def rule_matches($rule; $finding):
     ($rule | type) == "object"
     and (($rule.id // "") | type == "string" and . != "")

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -477,6 +477,11 @@ render_structured_advisory_entries() {
       | gsub("[[:space:]][[:space:]]+"; " ");
     .[] |
       "- " + $platform + ": " + ((.category // "Advisory") | one_line) + " - " + ((.summary // .message // "Advisory finding") | one_line),
+      (if ((.disposition // "") == "known-false-positive") then
+        "  Disposition: Known false positive" +
+        (if (((.disposition_rule // "") | tostring | length) > 0) then " (`" + ((.disposition_rule // "") | one_line) + "`)" else "" end) +
+        (if (((.disposition_rationale // "") | tostring | length) > 0) then " - " + ((.disposition_rationale // "") | one_line) else "" end)
+       else empty end),
       (if (((.detail // "") | tostring | length) > 0) then "  Detail: " + ((.detail // "") | one_line) else empty end),
       (if (((.path // "") | tostring | length) > 0) then
         "  Location: `" + ((.path // "") | one_line) +

--- a/scripts/development-workflow/tests/test-haystack-reviewer.sh
+++ b/scripts/development-workflow/tests/test-haystack-reviewer.sh
@@ -595,6 +595,110 @@ advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
 run_test "structured_invalid_lines_omitted" "0" "$(printf '%s\n' "$advisory_json" | jq '[.[] | select(has("line"))] | length')"
 
 # ---------------------------------------------------------------------------
+# Area 5c: known false-positive catalog
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 5c: known false-positive catalog ==="
+
+# Test 5c.1: CHANGELOG structure false positives are dispositioned.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Rules violation","summary":"keep-changelog-unreleased-structure-canonical flagged CHANGELOG structure","detail":"CHANGELOG entry appears outside [Unreleased] in the diff","path":"CHANGELOG.md"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+
+run_test "known_fp_changelog_result" "RESULT=clean" "$(echo "$output" | grep '^RESULT=')"
+run_test "known_fp_changelog_disposition" "known-false-positive" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].disposition')"
+run_test "known_fp_changelog_rule" "changelog-keep-changelog-unreleased-structure" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].disposition_rule')"
+
+# Test 5c.2: hotfix backport CHANGELOG false positives are dispositioned.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Rules violation","summary":"hotfix backport changed CHANGELOG [Unreleased] structure","detail":"Backport diff appears to remove [Unreleased] content","source":{"path":"CHANGELOG.md","line":7}}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+
+run_test "known_fp_hotfix_result" "RESULT=clean" "$(echo "$output" | grep '^RESULT=')"
+run_test "known_fp_hotfix_disposition" "known-false-positive" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].disposition')"
+run_test "known_fp_hotfix_rule" "hotfix-backport-changelog-structure" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].disposition_rule')"
+
+# Test 5c.3: stale mirror guidance false positives are dispositioned.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Rules violation","summary":"Mirror guidance needs review for Claude and Cursor agent surfaces","detail":"Only tool-specific front matter and absent .cursor/skills surface differ"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+
+run_test "known_fp_mirror_disposition" "known-false-positive" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].disposition')"
+run_test "known_fp_mirror_rule" "agent-doc-mirror-guidance-stale-advisory" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].disposition_rule')"
+
+# Test 5c.4: unrelated Rules violation keeps existing advisory classification without disposition.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Rules violation","summary":"Workflow contract drift","detail":"A real protocol step is missing from a mirrored command file","path":"docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+
+run_test "known_fp_negative_result" "RESULT=clean" "$(echo "$output" | grep '^RESULT=')"
+run_test "known_fp_negative_no_disposition" "false" "$(printf '%s\n' "$advisory_json" | jq '.[0] | has("disposition")')"
+
+# Test 5c.5: unknown categories retain safe-fail blocking behavior.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":2,"findings":[{"category":"Unexpected severity","summary":"keep-changelog-unreleased-structure-canonical flagged CHANGELOG structure","detail":"CHANGELOG entry appears outside [Unreleased]","path":"CHANGELOG.md"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+blocking_json="$(_kv_value BLOCKING_FINDINGS_JSON "$output")"
+
+run_test "known_fp_unknown_category_result" "RESULT=needs_fixes" "$(echo "$output" | grep '^RESULT=')"
+run_test "known_fp_unknown_category_blocking" "1" "$(printf '%s\n' "$blocking_json" | jq 'length')"
+run_test "known_fp_unknown_category_no_disposition" "false" "$(printf '%s\n' "$blocking_json" | jq '.[0] | has("disposition")')"
+
+# Test 5c.6: multiple findings are classified independently.
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Rules violation","summary":"keep-changelog-unreleased-structure-canonical flagged CHANGELOG structure","detail":"CHANGELOG entry appears outside [Unreleased]","path":"CHANGELOG.md"},{"category":"Minor","summary":"Unrelated note","detail":"Optional cleanup"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(_run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+
+run_test "known_fp_multi_count" "2" "$(printf '%s\n' "$advisory_json" | jq 'length')"
+run_test "known_fp_multi_first_disposition" "known-false-positive" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].disposition')"
+run_test "known_fp_multi_second_no_disposition" "false" "$(printf '%s\n' "$advisory_json" | jq '.[1] | has("disposition")')"
+
+# Test 5c.7: malformed catalog override preserves original classification.
+bad_catalog_file="$(mktemp)"
+printf '{not-json\n' > "$bad_catalog_file"
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Rules violation","summary":"keep-changelog-unreleased-structure-canonical flagged CHANGELOG structure","detail":"CHANGELOG entry appears outside [Unreleased]","path":"CHANGELOG.md"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(HAYSTACK_FALSE_POSITIVES_FILE="$bad_catalog_file" _run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+rm -f "$bad_catalog_file"
+
+run_test "known_fp_bad_catalog_result" "RESULT=clean" "$(echo "$output" | grep '^RESULT=')"
+run_test "known_fp_bad_catalog_no_disposition" "false" "$(printf '%s\n' "$advisory_json" | jq '.[0] | has("disposition")')"
+
+# Test 5c.8: category-only catalog rules are invalid and preserve original classification.
+category_only_catalog_file="$(mktemp)"
+printf '[{"id":"category-only","category":"Rules violation","rationale":"Too broad"}]\n' > "$category_only_catalog_file"
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Rules violation","summary":"Any rules violation","detail":"No catalog evidence predicate should match this"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(HAYSTACK_FALSE_POSITIVES_FILE="$category_only_catalog_file" _run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+rm -f "$category_only_catalog_file"
+
+run_test "known_fp_category_only_result" "RESULT=clean" "$(echo "$output" | grep '^RESULT=')"
+run_test "known_fp_category_only_no_disposition" "false" "$(printf '%s\n' "$advisory_json" | jq '.[0] | has("disposition")')"
+
+# ---------------------------------------------------------------------------
 # Area 6: HAYSTACK_POLL_INTERVAL controls retry cadence (env var)
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/development-workflow/tests/test-haystack-reviewer.sh
+++ b/scripts/development-workflow/tests/test-haystack-reviewer.sh
@@ -698,6 +698,20 @@ rm -f "$category_only_catalog_file"
 run_test "known_fp_category_only_result" "RESULT=clean" "$(echo "$output" | grep '^RESULT=')"
 run_test "known_fp_category_only_no_disposition" "false" "$(printf '%s\n' "$advisory_json" | jq '.[0] | has("disposition")')"
 
+# Test 5c.9: invalid regex catalog rules are invalid and preserve original classification.
+invalid_regex_catalog_file="$(mktemp)"
+printf '[{"id":"invalid-regex","category":"Rules violation","rationale":"Bad regex","text_patterns":["["]}]\n' > "$invalid_regex_catalog_file"
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Rules violation","summary":"Any rules violation","detail":"Invalid regex must not abort matching"}]}'
+_reset_mocks
+_install_haystack_mock
+
+output=$(HAYSTACK_FALSE_POSITIVES_FILE="$invalid_regex_catalog_file" _run_reviewer 10 1)
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+rm -f "$invalid_regex_catalog_file"
+
+run_test "known_fp_invalid_regex_result" "RESULT=clean" "$(echo "$output" | grep '^RESULT=')"
+run_test "known_fp_invalid_regex_no_disposition" "false" "$(printf '%s\n' "$advisory_json" | jq '.[0] | has("disposition")')"
+
 # ---------------------------------------------------------------------------
 # Area 6: HAYSTACK_POLL_INTERVAL controls retry cadence (env var)
 # ---------------------------------------------------------------------------

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1578,7 +1578,7 @@ run_test "summary_advisory_split_visible" "yes" "$_summary_advisory_split"
 
 aggregate_advisory_findings_platforms=("haystack")
 aggregate_advisory_findings_jsons=(
-  "$(jq -nc '[{"severity":"advisory","category":"Minor","summary":"Summary with \"quotes\", pipe | equals =, and newline text","detail":"Line one\nLine two","path":"scripts/example.sh","line":12,"fix_hint":"Use $PATH && echo ok"}]')"
+  "$(jq -nc '[{"severity":"advisory","category":"Minor","summary":"Summary with \"quotes\", pipe | equals =, and newline text","detail":"Line one\nLine two","path":"scripts/example.sh","line":12,"fix_hint":"Use $PATH && echo ok","disposition":"known-false-positive","disposition_rule":"test-rule","disposition_rationale":"Known noisy reviewer pattern"}]')"
 )
 advisory_disposition_required=1
 policy_review_disposition_required=0
@@ -1588,7 +1588,8 @@ if [ -n "${_summary_body_capture:-}" ] \
     && grep -q 'haystack: Minor - Summary with "quotes", pipe | equals =, and newline text' "$_summary_body_capture" \
     && grep -q "Detail: Line one Line two" "$_summary_body_capture" \
     && grep -q 'Location: `scripts/example.sh:12`' "$_summary_body_capture" \
-    && grep -q 'Fix hint: Use $PATH && echo ok' "$_summary_body_capture"; then
+    && grep -q 'Fix hint: Use $PATH && echo ok' "$_summary_body_capture" \
+    && grep -q 'Disposition: Known false positive (`test-rule`) - Known noisy reviewer pattern' "$_summary_body_capture"; then
   _structured_summary_rendered="yes"
 else
   _structured_summary_rendered="no"


### PR DESCRIPTION
## Summary
- Add a repository-owned machine-readable Haystack false-positive catalog.
- Classify matching completed Haystack findings with `known-false-positive` disposition fields while preserving category, summary, detail, location, and fix hint context.
- Render matched false-positive rule and rationale in reviewer-loop summaries.
- Document catalog fields, matching semantics, override behavior, and fail-closed invalid catalog handling.

## Test Plan
- [x] `bash scripts/development-workflow/tests/test-haystack-reviewer.sh` — 213 passed, 0 failed
- [x] `bash scripts/development-workflow/tests/test-pr-review-loop.sh` — 291 passed, 0 failed
- [x] `jq -e 'type == "array" and all(.[]; has("id") and has("category") and has("rationale"))' scripts/development-workflow/haystack-false-positives.json`
- [x] `shellcheck --severity=warning -x scripts/development-workflow/haystack-reviewer.sh scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-haystack-reviewer.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- [x] `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- [x] `npx markdownlint-cli2 "docs/workflow/development-workflow/integrations/haystack-triage.md" "docs/testing/workflow/1115-machine-readable-false-positive-catalog.smoke-test.md" "CHANGELOG.md"`
- [x] `python3 scripts/lint/markdown-heuristic-lint.py docs/workflow/development-workflow/integrations/haystack-triage.md docs/testing/workflow/1115-machine-readable-false-positive-catalog.smoke-test.md CHANGELOG.md`
- [x] `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- [x] `git diff --check`

## Test Harness Coverage Checklist
- [x] CHANGELOG positive match receives `known-false-positive` and the catalog rule id.
- [x] Hotfix backport positive match receives `known-false-positive` and the hotfix rule id.
- [x] Mirror guidance positive match receives `known-false-positive` and the mirror rule id.
- [x] Negative lookalike remains advisory without a false-positive disposition.
- [x] Unknown category retains safe-fail blocking behavior without a false-positive disposition.
- [x] Multiple findings are classified independently.
- [x] Malformed catalog override preserves original classification.
- [x] Category-only catalog rule is invalid and preserves original classification.
- [x] Invalid regex catalog rule is invalid and preserves original classification.
- [x] Reviewer-loop summary renders the known false-positive rule and rationale without hiding original finding details.

## Pre-submission Self-review
- [x] Compared implementation against the approved spec and plan for #1115.
- [x] Confirmed no `.ai-dev-workflow.yaml` schema change was added; #1116 owns that integration point.
- [x] Confirmed catalog matching requires category plus at least one evidence predicate, preventing category-only match-all rules.
- [x] Confirmed invalid regex patterns fail closed instead of aborting matching.
- [x] Confirmed unmatched findings and unknown categories keep existing severity behavior.
- [x] Confirmed reviewer-loop summaries append disposition evidence rather than replacing original finding details.
- [x] Checked for stale TODO/FIXME-style markers in touched implementation and documentation.

## CHANGELOG Preview
- `Added` — `**Haystack false-positive catalog** (#1115): Added a machine-readable known false-positive catalog for recurring Haystack findings and surfaced matched dispositions in reviewer output.`

Closes #1115

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Catalog rules can downgrade matched findings to advisory; invalid or overly broad rules could hide real issues, though validation requires evidence predicates and rejects broken catalogs entirely.
> 
> **Overview**
> Adds a **machine-readable false-positive catalog** (`haystack-false-positives.json`) and wires it into Haystack triage normalization so recurring noisy `Rules violation` findings can be labeled without dropping the original finding text.
> 
> **`haystack-reviewer.sh`** loads the catalog (override via `HAYSTACK_FALSE_POSITIVES_FILE`), validates rules with jq (category plus at least one pattern; invalid regex or category-only rules fail closed), and when a rule matches, annotates the finding with `disposition`, `disposition_rule`, and `disposition_rationale` while keeping severity **advisory**. Malformed or missing catalogs log a warning and leave classification unchanged.
> 
> **`pr-review-loop.sh`** now prints those disposition lines in automated PR summary comments alongside existing detail, location, and fix hints. **Docs** describe the new structured fields, catalog schema, and matching semantics; **CHANGELOG** records #1115. **Tests** cover positive matches, negatives, unknown categories, multi-finding independence, and bad-catalog overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf853ec77a61525877bef762e12c0da0ce5c4041. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->