### PR TITLE
docs(plan): haystack workflow configuration

### DIFF
--- a/docs/specs/developments/20260702113258_1116-haystack-workflow-config/2_1116-haystack-workflow-config_implementation-plan.md
+++ b/docs/specs/developments/20260702113258_1116-haystack-workflow-config/2_1116-haystack-workflow-config_implementation-plan.md
@@ -1,0 +1,263 @@
+# Haystack Workflow Configuration - Implementation Plan
+
+**Spec**: [Haystack Workflow Configuration - Spec](1_1116-haystack-workflow-config_specs.md)
+**Smoke test runbook**: [1116 Haystack workflow configuration smoke test](../../../testing/workflow/1116-haystack-workflow-config.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Extend the existing standard-library workflow config resolver with
+validated `review.haystack` settings and a shell-safe command that prints the
+effective Haystack defaults. Update `haystack-reviewer.sh` to read those
+defaults before applying existing environment-variable and CLI overrides, then
+document the configuration surface and add focused shell tests.
+
+**Estimated complexity**: M
+
+**Rationale**: The change spans the YAML subset parser, validation behavior, a
+stateful polling shell script, docs, examples, and regression tests. No external
+API or database change is required, but the stop-rule behavior needs careful
+bounded-loop semantics.
+
+**Dependencies**: #1113, #1114, and #1115 must be merged first because this work
+builds on the structured advisory output, disposition handling, and
+false-positive catalog behavior those items introduced.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| ----- | --------------- | ------ |
+| Repo revision | `git rev-parse --short HEAD` | `07dcc73` |
+| Current Haystack runtime controls | `rg -n "HAYSTACK_REVIEWER_TIMEOUT\|HAYSTACK_POLL_INTERVAL\|HAYSTACK_MAJOR_IS_BLOCKING\|HAYSTACK_PR_STATUS_CHECK\|HAYSTACK_FALSE_POSITIVES_FILE" scripts/development-workflow/haystack-reviewer.sh docs/workflow/development-workflow/integrations/haystack-triage.md scripts/development-workflow/tests/test-haystack-reviewer.sh` | Existing runtime settings are script/env-driven in `haystack-reviewer.sh`; docs mention timeout, poll interval, major policy, and false-positive catalog overrides. |
+| Workflow config resolver surface | `rg -n "workflow-config-resolver\|validate\|review:" scripts/development-workflow/workflow-config-resolver.py scripts/development-workflow/validate-workflow-config.sh scripts/development-workflow/tests/test-workflow-config-resolver.sh .ai-dev-workflow.yaml .ai-dev-workflow.local.example.yaml` | `validate` currently routes through resolver context loading; review local override support exists, but no Haystack-specific schema exists. |
+| Reviewer-loop Haystack dispatch | `rg -n "run_haystack_review\|haystack-reviewer.sh" scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-pr-review-loop.sh` | `pr-review-loop.sh` delegates Haystack behavior to `haystack-reviewer.sh` and passes only `--timeout` from reviewer-loop max wait. |
+
+---
+
+## Layer-by-Layer Changes
+
+### Database / Data Layer
+
+- [ ] No database or seed-data changes are required.
+
+### Backend / API
+
+- [ ] No service endpoint or external API changes are required.
+
+### Shared Packages / Libraries
+
+- [ ] `scripts/development-workflow/workflow-config-resolver.py`:
+  - Add validation helpers for optional `review.haystack` settings in shared
+    and local workflow configs.
+  - Support only these keys: `major_is_blocking`, `poll_interval_sec`,
+    `timeout_sec`, and `stop_rule` with `max_triage_rounds` and
+    `no_progress_cycles`.
+  - Require `major_is_blocking` to be a boolean.
+  - Require all numeric settings to be positive integers.
+  - Reject unknown Haystack keys with setting-specific error messages.
+  - Preserve omission semantics: no section, missing nested `stop_rule`, or
+    omitted optional keys stays valid and falls back to defaults.
+  - Add a `review-haystack` command that prints shell-safe values such as
+    `HAYSTACK_CONFIG_TIMEOUT_SEC`, `HAYSTACK_CONFIG_POLL_INTERVAL_SEC`,
+    `HAYSTACK_CONFIG_MAJOR_IS_BLOCKING`, `HAYSTACK_CONFIG_MAX_TRIAGE_ROUNDS`,
+    and `HAYSTACK_CONFIG_NO_PROGRESS_CYCLES`.
+- [ ] `scripts/development-workflow/validate-workflow-config.sh`: keep the
+  wrapper contract intact while ensuring the resolver's validation path checks
+  the new Haystack schema.
+
+### Frontend / UI
+
+- [ ] No frontend or UI changes are required.
+
+### Infrastructure / Configuration
+
+- [ ] `.ai-dev-workflow.yaml`: add a commented or inactive example for
+  `review.haystack` near the existing review configuration so template
+  consumers can discover supported shared defaults.
+- [ ] `.ai-dev-workflow.local.example.yaml`: add a local override example for
+  `review.haystack` with representative safe values.
+- [ ] `scripts/development-workflow/haystack-reviewer.sh`:
+  - Resolve the repository root with `git rev-parse --show-toplevel`, falling
+    back to the current directory only when Git metadata is unavailable.
+  - Invoke `workflow-config-resolver.py review-haystack --repo-root <root>` and
+    fail closed with exit code `3` when config parsing or validation fails.
+  - Apply precedence in this order:
+    - `--timeout` CLI flag for timeout only.
+    - Existing environment variables:
+      `HAYSTACK_REVIEWER_TIMEOUT`, `HAYSTACK_POLL_INTERVAL`,
+      `HAYSTACK_MAJOR_IS_BLOCKING`.
+    - Repository config from `review.haystack`.
+    - Current built-in defaults: timeout `120`, poll interval `15`, major
+      findings advisory by default.
+  - Keep `HAYSTACK_PR_STATUS_CHECK` and `HAYSTACK_FALSE_POSITIVES_FILE` as
+    environment-only controls because they are outside the #1116 config scope.
+  - Implement stop-rule settings inside the existing triage poll loop:
+    - `max_triage_rounds` caps the number of `haystack triage --no-wait` calls
+      and exits `RESULT=skipped`, `REASON=max_triage_rounds` when exhausted
+      before a completed result appears.
+    - `no_progress_cycles` compares a stable transient-progress signature
+      derived from status value plus finding/category counts available in the
+      transient payload and exits `RESULT=skipped`, `REASON=no_progress_cycles`
+      when the same signature repeats for the configured number of cycles.
+    - A completed Haystack payload still exits the loop before stop rules can
+      turn a completed result into a skipped result.
+- [ ] `scripts/development-workflow/pr-review-loop.sh`: update only comments or
+  field forwarding if `haystack-reviewer.sh` adds new `REASON` values; keep the
+  existing companion-script call contract unless tests show the wrapper needs
+  explicit pass-through.
+
+---
+
+## Testing Strategy
+
+**Test types**: Unit, integration-style shell tests, smoke, and documentation lint.
+
+**Key scenarios to test**:
+
+1. Missing `review.haystack` preserves current defaults and behavior (AC-2).
+2. Valid shared config values are emitted by the resolver and used by
+   `haystack-reviewer.sh` (AC-1, AC-3).
+3. Local config can override shared Haystack defaults through the same local
+   config family as existing review overrides (AC-3).
+4. Environment variables override repository config for timeout, poll interval,
+   and major policy (AC-4).
+5. `--timeout` overrides both env and config for timeout when
+   `pr-review-loop.sh` supplies a max-wait budget (AC-4).
+6. Invalid booleans, numeric values, unknown keys, and malformed YAML fail
+   validation with setting-specific feedback (AC-5).
+7. Stop-rule thresholds terminate only transient polling and never suppress a
+   completed Haystack result (AC-1, AC-3).
+8. Documentation and examples describe settings, defaults, and precedence
+   consistently (AC-6, AC-7).
+
+**Smoke test runbook**:
+`docs/testing/workflow/1116-haystack-workflow-config.smoke-test.md`
+
+**Regression suite**: Extend the shell regression tests that already cover the
+resolver and Haystack reviewer. No browser or product-app regression suite
+applies to this workflow-script feature.
+
+### Parser-risk addendum
+
+This plan is parser-risk because it changes structured YAML parsing and
+validation behavior in `workflow-config-resolver.py`.
+
+**Edge-case enumeration**:
+
+- Missing `review.haystack` section in a valid config.
+- Empty `review.haystack: {}` equivalent represented by an empty mapping.
+- Boolean values `true` and `false` for `major_is_blocking`.
+- Negative boolean lookalikes such as `"true"`, `yes`, `1`, and `blocking`.
+- Positive integer values for `poll_interval_sec`, `timeout_sec`,
+  `stop_rule.max_triage_rounds`, and `stop_rule.no_progress_cycles`.
+- Negative numeric lookalikes: `0`, `-1`, `1.5`, `"15"`, and `fifteen`.
+- Unknown top-level Haystack key under `review.haystack`.
+- Unknown nested key under `review.haystack.stop_rule`.
+- `stop_rule` present as a scalar or list instead of a mapping.
+- Shared config plus local config where local Haystack values intentionally
+  override shared values.
+- Malformed YAML indentation under `review.haystack`.
+- Environment values overriding parsed repository values without rewriting
+  config files.
+- CLI `--timeout` overriding env and repository timeout values.
+- Transient Haystack status repeating the same progress signature until
+  `no_progress_cycles` is exhausted.
+- Transient Haystack polling reaching `max_triage_rounds` before completion.
+- Haystack completion arriving before either stop-rule threshold is reached.
+
+**Unit test mapping**:
+
+- `scripts/development-workflow/tests/test-workflow-config-resolver.sh`:
+  missing section, empty mapping, valid booleans, invalid boolean lookalikes,
+  valid positive integers, invalid numeric lookalikes, unknown keys, malformed
+  YAML, `stop_rule` type validation, nested stop-rule key validation, and
+  shared-plus-local override precedence.
+- `scripts/development-workflow/tests/test-haystack-reviewer.sh`: config-derived
+  timeout, poll interval, major policy, env override precedence, CLI timeout
+  precedence, `max_triage_rounds`, `no_progress_cycles`, and completion before
+  stop-rule exhaustion.
+- `scripts/development-workflow/tests/test-pr-review-loop.sh`: only update if
+  new `REASON` fields or wrapper comments need assertion coverage.
+
+**Suppression semantics**: Not applicable. This feature does not add inline
+suppression directives or rule-specific suppression parsing.
+
+---
+
+## Seed Data
+
+No persistent seed data is required.
+
+| Entity | Values / Scenario | File |
+| ------ | ----------------- | ---- |
+| Temporary workflow config fixture | Shared and local `review.haystack` variants created by shell tests | `scripts/development-workflow/tests/test-workflow-config-resolver.sh` |
+| Mock Haystack responses | Pending, repeated-progress, and completed JSON payloads | `scripts/development-workflow/tests/test-haystack-reviewer.sh` |
+
+---
+
+## Documentation Updates
+
+- [ ] `.ai-dev-workflow.yaml` - show the optional shared `review.haystack`
+  configuration surface.
+- [ ] `.ai-dev-workflow.local.example.yaml` - show local override examples for
+  Haystack reviewer behavior.
+- [ ] `docs/workflow/development-workflow/integrations/haystack-triage.md` -
+  document settings, defaults, precedence, validation, and stop-rule purpose.
+- [ ] `docs/project/2-repo-architecture.md` - no update; placeholder project
+  architecture is not changed by workflow script configuration.
+- [ ] `docs/project/3-software-architecture.md` - no update; the tech stack and
+  architecture patterns do not change.
+- [ ] `docs/project/4-database-model.md` - no update; no data model change.
+- [ ] `AGENTS.md` - no update; command workflow and agent guidance are unchanged.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| ---- | ---------- | ------ | ---------- |
+| Config validation rejects existing repositories unexpectedly | Low | Medium | Keep the whole section optional and validate only present `review.haystack` keys. |
+| Env/config precedence becomes ambiguous | Medium | Medium | Implement a single resolver load step, then explicit assignment order in `haystack-reviewer.sh`, with tests for config, env, and CLI precedence. |
+| Stop-rule thresholds skip a completed analysis | Low | High | Check for completed payload before applying stop-rule exits and add tests where completion arrives before thresholds. |
+| Shell config loading introduces quoting issues | Medium | Medium | Use resolver shell-safe output with `shlex.quote`; avoid hand-parsing YAML in shell. |
+| Local config accidentally becomes shared policy | Low | Medium | Keep local overrides in `.ai-dev-workflow.local.example.yaml` and do not commit `.ai-dev-workflow.local.yaml`. |
+
+---
+
+## Implementation Order
+
+1. Extend `workflow-config-resolver.py` with Haystack config normalization and
+   validation helpers for shared and local configs.
+2. Add the `review-haystack` resolver command and shell-safe output fields.
+3. Add resolver tests for valid configs, invalid configs, unknown keys, malformed
+   YAML, and local-overrides-shared precedence.
+4. Update `haystack-reviewer.sh` to load config defaults, preserve env/CLI
+   precedence, validate effective values, and emit clear errors on invalid
+   config.
+5. Implement `max_triage_rounds` and `no_progress_cycles` in the existing
+   transient-status poll loop.
+6. Extend `test-haystack-reviewer.sh` for config-derived defaults, env override
+   precedence, CLI timeout precedence, and both stop-rule exits.
+7. Update `pr-review-loop.sh` and `test-pr-review-loop.sh` only if the wrapper
+   needs to recognize or forward new reason fields beyond its current generic
+   forwarding.
+8. Update `.ai-dev-workflow.yaml`, `.ai-dev-workflow.local.example.yaml`, and
+   `docs/workflow/development-workflow/integrations/haystack-triage.md`.
+9. Update `CHANGELOG.md` under `[Unreleased]` with this literal entry:
+   `- **Haystack workflow configuration** (#1116): Added repository-level Haystack reviewer settings with validation, override precedence, and stop-rule documentation.`
+10. Run verification:
+    - `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`
+    - `bash scripts/development-workflow/tests/test-haystack-reviewer.sh`
+    - `bash scripts/development-workflow/tests/test-pr-review-loop.sh` if
+      `pr-review-loop.sh` or its tests are touched.
+    - `bash scripts/development-workflow/validate-workflow-config.sh`
+    - `shellcheck --severity=warning -x scripts/development-workflow/haystack-reviewer.sh scripts/development-workflow/validate-workflow-config.sh scripts/development-workflow/tests/test-haystack-reviewer.sh scripts/development-workflow/tests/test-workflow-config-resolver.sh`
+    - `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
+    - `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
+    - `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
+    - `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
+    - `git diff --check`
+

--- a/docs/testing/workflow/1116-haystack-workflow-config.smoke-test.md
+++ b/docs/testing/workflow/1116-haystack-workflow-config.smoke-test.md
@@ -1,0 +1,148 @@
+# Smoke Test Runbook: Haystack Workflow Configuration
+
+**Feature**: Haystack workflow configuration
+**Spec**: [Haystack Workflow Configuration - Spec](../../specs/developments/20260702113258_1116-haystack-workflow-config/1_1116-haystack-workflow-config_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] You are in a clean checkout of this repository.
+- [ ] `gh`, `git`, `jq`, `bash`, and `python3` are available.
+- [ ] The implementation branch for #1116 is checked out.
+- [ ] The Haystack CLI is available if running the reviewer against a real PR;
+      otherwise use the automated shell tests with mocked Haystack responses.
+
+---
+
+## Test Data
+
+| Item | Value |
+| ---- | ----- |
+| Shared config fixture | Temporary `.ai-dev-workflow.yaml` containing `review.haystack` |
+| Local config fixture | Temporary `.ai-dev-workflow.local.yaml` overriding shared values |
+| Mock PR target | `owner/repo#123` in `test-haystack-reviewer.sh` |
+| Mock transient payload | JSON with a non-empty `status` field |
+| Mock completed payload | JSON without a `status` field and with `findings` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Validate default omission behavior
+
+**Maps to**: AC-1, AC-2
+
+1. Run `bash scripts/development-workflow/validate-workflow-config.sh`.
+2. Run `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`.
+3. Confirm the resolver tests include a config with no `review.haystack`
+   section and that it remains valid.
+
+**Expected result**: Existing repositories without `review.haystack` validate and
+keep current Haystack defaults.
+
+### Step 2: Validate configured Haystack defaults
+
+**Maps to**: AC-1, AC-3
+
+1. In the resolver test output, confirm valid `review.haystack` fixtures cover:
+   `major_is_blocking`, `poll_interval_sec`, `timeout_sec`,
+   `stop_rule.max_triage_rounds`, and `stop_rule.no_progress_cycles`.
+2. Run `bash scripts/development-workflow/tests/test-haystack-reviewer.sh`.
+3. Confirm the reviewer tests exercise config-derived timeout, poll interval,
+   major policy, max triage rounds, and no-progress cycles.
+
+**Expected result**: Valid repository config values are consumed by the reviewer
+and affect Haystack review behavior.
+
+### Step 3: Validate override precedence
+
+**Maps to**: AC-4
+
+1. Confirm `test-workflow-config-resolver.sh` includes shared-plus-local
+   precedence coverage for `review.haystack`.
+2. Confirm `test-haystack-reviewer.sh` includes environment-variable overrides
+   for timeout, poll interval, and major policy.
+3. Confirm a `--timeout` reviewer invocation overrides both config and
+   `HAYSTACK_REVIEWER_TIMEOUT`.
+
+**Expected result**: Runtime overrides are deterministic and do not modify
+repository config files.
+
+### Step 4: Validate invalid config failures
+
+**Maps to**: AC-5
+
+1. Run `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`.
+2. Confirm invalid boolean, invalid positive-integer, unknown-key, scalar
+   `stop_rule`, and malformed YAML cases fail with setting-specific messages.
+3. Confirm `haystack-reviewer.sh` fails closed when the resolver reports invalid
+   config.
+
+**Expected result**: Invalid Haystack settings are caught before reviewer-loop
+behavior changes.
+
+### Step 5: Validate docs and examples
+
+**Maps to**: AC-6, AC-7
+
+1. Inspect `.ai-dev-workflow.yaml` for the shared `review.haystack` example.
+2. Inspect `.ai-dev-workflow.local.example.yaml` for local override examples.
+3. Inspect `docs/workflow/development-workflow/integrations/haystack-triage.md`
+   for defaults, precedence, stop-rule explanation, and validation guidance.
+4. Run markdown lint over the changed docs.
+
+**Expected result**: Operators can discover settings, defaults, and override
+rules without reading script internals.
+
+### Last Step: Validate and shut down
+
+1. Run all verification commands listed in the implementation plan.
+2. Verify all assertions below are satisfied.
+3. Remove any temporary fixture directories created during manual smoke checks.
+
+---
+
+## Assertions Checklist
+
+- [ ] Optional `review.haystack` settings are supported without requiring the
+      section in existing repositories.
+- [ ] Valid repository settings affect Haystack reviewer behavior.
+- [ ] Environment variables take precedence over repository settings.
+- [ ] CLI `--timeout` takes precedence over timeout env/config defaults.
+- [ ] Invalid settings fail validation with setting-specific feedback.
+- [ ] Documentation explains settings, defaults, precedence, validation, and
+      stop-rule purpose.
+- [ ] The local workflow config example includes representative Haystack values.
+
+---
+
+## Seed Data Reference
+
+No persistent seed data is required.
+
+| Entity | Scenario | How to load |
+| ------ | -------- | ----------- |
+| Temporary workflow config | Shared and local Haystack settings | Created inside shell tests |
+| Mock Haystack response sequence | Pending, repeated-progress, and completed payloads | Created inside `test-haystack-reviewer.sh` |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| Resolver tests fail before Haystack assertions | YAML subset parser rejected fixture syntax | Use the same two-space mapping/list style as existing resolver tests. |
+| Reviewer tests skip with unavailable Haystack | Mock `haystack` binary is not first in `PATH` | Re-run the test script without overriding `TEST_REVIEWER_PATH`. |
+| Markdown lint reports broken links | Relative path depth is wrong from the plan or runbook location | Recalculate links from the file containing the link and rerun markdownlint. |
+
+---
+
+## Known Limitations
+
+- Real Haystack service timing is not deterministic; automated reviewer tests use
+  mocked Haystack payloads for stop-rule assertions.


### PR DESCRIPTION
## Summary

- Add the #1116 implementation plan for repository-level Haystack reviewer configuration.
- Add the smoke-test runbook covering config defaults, override precedence, validation failures, and docs/examples.
- Classify the work as parser-risk because it changes YAML/config parsing and validation behavior.

## Document Quality Gate

- Spec/brief coverage: Checked - all seven acceptance criteria map to implementation steps, test scenarios, or smoke assertions.
- Implementation-order consistency: Checked - resolver, reviewer, docs, examples, and tests are listed consistently across sections.
- Verification support: Checked - scope claims cite live `rg` checks and repo revision `07dcc73` in the Verification Log.
- Behavioral guarantees: Checked - precedence and stop-rule behavior name the exact enforcing mechanisms.
- Parser/API/concurrency checklist: Checked - parser-risk addendum includes edge-case enumeration and unit-test mapping; API and concurrency checks are not applicable because no API surface or concurrent event source is introduced.
- CHANGELOG literal format: Checked - implementation-stage literal uses the project `**Bold Title** (#N):` changelog format.
- Not-applicable rationale: Checked - database, backend/API, frontend/UI, suppression semantics, and project docs no-op decisions include rationale.

## Verification

- `npx markdownlint-cli2 "docs/specs/developments/20260702113258_1116-haystack-workflow-config/2_1116-haystack-workflow-config_implementation-plan.md" "docs/testing/workflow/1116-haystack-workflow-config.smoke-test.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py docs/specs/developments/20260702113258_1116-haystack-workflow-config/2_1116-haystack-workflow-config_implementation-plan.md docs/testing/workflow/1116-haystack-workflow-config.smoke-test.md`
- `git diff --check`

Issue: #1116

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime, config parsing, or reviewer behavior changes in this diff.
> 
> **Overview**
> Adds **planning and verification docs only** for #1116—no workflow scripts or YAML examples are changed in this PR.
> 
> Introduces the **implementation plan** for repository-level `review.haystack` settings: optional schema in `workflow-config-resolver.py`, a `review-haystack` shell-safe export, `haystack-reviewer.sh` precedence (CLI → env → repo config → defaults), stop rules (`max_triage_rounds`, `no_progress_cycles`), parser-risk edge cases, test mapping, risks, ordered implementation steps, and a planned CHANGELOG line.
> 
> Adds a **smoke-test runbook** that maps acceptance criteria to validate/resolver/reviewer tests, override precedence, invalid-config failure, and future docs/examples checks, plus assertions, troubleshooting, and mocked-Haystack limitations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4ad3e47076acca488ed806f254786196599f69f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->