### PR TITLE
feat(review): configure haystack workflow defaults

### DIFF
--- a/.ai-dev-workflow.local.example.yaml
+++ b/.ai-dev-workflow.local.example.yaml
@@ -44,6 +44,13 @@ review:
   on_ready:
     github:
       - bugbot
+  haystack:
+    major_is_blocking: false
+    poll_interval_sec: 10
+    timeout_sec: 180
+    stop_rule:
+      max_triage_rounds: 10
+      no_progress_cycles: 4
   internal_reviewers_unavailable_policy: warn
 
 tools:

--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -52,6 +52,19 @@ review:
     # are clean and the PR has been converted with `gh pr ready`.
     github:
       - haystack
+
+  # Optional Haystack reviewer defaults. Omit this section to keep the built-in
+  # defaults used by scripts/development-workflow/haystack-reviewer.sh.
+  # Runtime environment variables still take precedence for one-off CI/local
+  # runs: HAYSTACK_REVIEWER_TIMEOUT, HAYSTACK_POLL_INTERVAL, and
+  # HAYSTACK_MAJOR_IS_BLOCKING.
+  # haystack:
+  #   major_is_blocking: false
+  #   poll_interval_sec: 15
+  #   timeout_sec: 120
+  #   stop_rule:
+  #     max_triage_rounds: 8
+  #     no_progress_cycles: 3
   #
   # Configurable codex-github options (set via env vars or script flags to codex-github-reviewer.sh):
   #   CODEX_GITHUB_TRIGGER_PHRASE  — trigger phrase sent to the bot (default: "@codex review")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Haystack false-positive catalog** (#1115): Added a machine-readable known
   false-positive catalog for recurring Haystack findings and surfaced matched
   dispositions in reviewer output.
+- **Haystack workflow configuration** (#1116): Added repository-level Haystack
+  reviewer settings with validation, override precedence, and stop-rule
+  documentation.
 
 ## [0.35.0] - 2026-07-02
 

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -12,7 +12,7 @@ For information about Haystack's local git hooks (truncation checker, LLM_RULES.
 
 Key properties:
 
-- **Poll-retry on pending**: When `haystack triage` returns `status=pending` (analysis still in progress), `haystack-reviewer.sh` waits `HAYSTACK_POLL_INTERVAL` seconds (default: 15) and retries automatically until the analysis completes or the overall `HAYSTACK_REVIEWER_TIMEOUT` budget is exhausted. This eliminates the timing-gap false-negative where the reviewer loop ran within the first 2–4 minutes of a PR push and silently skipped findings.
+- **Poll-retry on pending**: When `haystack triage` returns `status=pending` (analysis still in progress), `haystack-reviewer.sh` waits the configured poll interval, defaulting to 15 seconds, and retries automatically until the analysis completes, the overall timeout budget expires, or a configured stop rule fires. This eliminates the timing-gap false-negative where the reviewer loop ran within the first 2–4 minutes of a PR push and silently skipped findings.
 - **Policy-verdict visibility**: After triage completes, `haystack-reviewer.sh` also reads `haystack pr-status <PR> --json`. When Haystack reports `needsHumanReview: true` or `analysisVerdict: "needs-review"`, the reviewer loop keeps the result non-blocking if there are no blocking findings but displays `haystack (needs-review: policy)` in the PR summary instead of `haystack (clean)`. The summary also records the Haystack bucket, `needsHumanReview`, and a disposition such as `blocking`, `policy-human-review`, `advisory-only`, or `good-to-merge`.
 - **No per-hour rate cap**: Unlike some hosted review services, Haystack triage is not subject to hourly review limits (as of the time of writing).
 - **Graceful degradation**: If the `haystack` CLI is absent or unauthenticated, the reviewer exits with `UNAVAILABLE` and the review loop continues with the remaining configured platforms.
@@ -54,6 +54,50 @@ review:
 ```
 
 No other configuration changes are required in `.ai-dev-workflow.yaml`.
+Repositories may optionally define Haystack reviewer defaults in the same
+`review` section:
+
+```yaml
+review:
+  on_ready:
+    github:
+      - haystack
+  haystack:
+    major_is_blocking: false
+    poll_interval_sec: 15
+    timeout_sec: 120
+    stop_rule:
+      max_triage_rounds: 8
+      no_progress_cycles: 3
+```
+
+All `review.haystack` fields are optional. Omitted fields fall back to the
+built-in defaults used by `haystack-reviewer.sh`.
+
+Supported settings:
+
+| Setting | Type | Default | Description |
+| ------- | ---- | ------- | ----------- |
+| `major_is_blocking` | boolean | `false` | Treat `Major` findings as blocking instead of advisory. |
+| `poll_interval_sec` | positive integer | `15` | Seconds to wait between transient `haystack triage --no-wait` calls. |
+| `timeout_sec` | positive integer | `120` | Total seconds allowed across all triage polling before `REASON=pending_timeout` or `REASON=timeout`. |
+| `stop_rule.max_triage_rounds` | positive integer | unset | Maximum number of triage calls before `REASON=max_triage_rounds`. |
+| `stop_rule.no_progress_cycles` | positive integer | unset | Maximum repeated unchanged transient-progress cycles before `REASON=no_progress_cycles`. |
+
+Validation is performed by
+`scripts/development-workflow/validate-workflow-config.sh`. Invalid booleans,
+non-positive integers, scalar `stop_rule` values, and unsupported
+`review.haystack` keys fail closed with setting-specific errors.
+
+Runtime overrides have this precedence:
+
+1. `--timeout <seconds>` passed directly to `haystack-reviewer.sh`.
+2. Environment variables for existing runtime controls:
+   `HAYSTACK_REVIEWER_TIMEOUT`, `HAYSTACK_POLL_INTERVAL`, and
+   `HAYSTACK_MAJOR_IS_BLOCKING`.
+3. `review.haystack` values in `.ai-dev-workflow.local.yaml`, then
+   `.ai-dev-workflow.yaml`.
+4. Built-in defaults.
 
 If the repository creates implementation PRs as drafts, prefer
 `review.on_ready.github` for Haystack. In this mode the reviewer loop lets
@@ -284,14 +328,18 @@ If both conditions hold, the finding is a false positive and can be dismissed. G
 
 ---
 
-## Timeout and Poll Interval Configuration
+## Timeout, Poll Interval, and Stop-rule Configuration
 
-`haystack-reviewer.sh` polls `haystack triage` until the analysis completes or the overall budget expires. Two environment variables control this behaviour:
+`haystack-reviewer.sh` polls `haystack triage` until the analysis completes,
+the overall budget expires, or a configured stop rule fires. Repository
+defaults live under `review.haystack`; existing environment variables remain
+available as one-run overrides.
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
-| `HAYSTACK_REVIEWER_TIMEOUT` | `120` | Total seconds the script may spend across all poll-retry calls. When this budget is exhausted while the analysis is still `pending`, the script exits with `REASON=pending_timeout`. |
-| `HAYSTACK_POLL_INTERVAL` | `15` | Seconds to wait between successive `haystack triage --no-wait` calls when the response carries `status=pending`. |
+| `HAYSTACK_REVIEWER_TIMEOUT` | `review.haystack.timeout_sec` or `120` | Total seconds the script may spend across all poll-retry calls. When this budget is exhausted while the analysis is still `pending`, the script exits with `REASON=pending_timeout`. |
+| `HAYSTACK_POLL_INTERVAL` | `review.haystack.poll_interval_sec` or `15` | Seconds to wait between successive `haystack triage --no-wait` calls when the response carries a transient `status`. |
+| `HAYSTACK_MAJOR_IS_BLOCKING` | `review.haystack.major_is_blocking` or `0` | Set to `1` to treat `Major` findings as blocking. |
 
 Override both via environment variable:
 
@@ -301,6 +349,14 @@ HAYSTACK_REVIEWER_TIMEOUT=180 HAYSTACK_POLL_INTERVAL=20 \
 ```
 
 If a single `haystack triage` call hangs (e.g., network issue), the script enforces a per-call timeout of `floor(remaining_budget / 2)` seconds (minimum 1 second) and retries as long as the overall budget allows. When the budget is finally exhausted due to a hung call, the script exits with `REASON=timeout` (exit code 2).
+
+Stop rules are configured only through `review.haystack.stop_rule`.
+`max_triage_rounds` caps the number of `haystack triage --no-wait` calls before
+the script exits with `REASON=max_triage_rounds`. `no_progress_cycles` compares
+a stable transient-progress signature and exits with
+`REASON=no_progress_cycles` when that signature repeats for the configured
+number of cycles. Completed Haystack payloads always take precedence over stop
+rules.
 
 ---
 
@@ -388,7 +444,7 @@ INFO: status=pending — waiting 15s before retry (15s elapsed of 120s budget)
 
 **Cause**: `haystack triage --no-wait` exits immediately when the Haystack cloud analysis is not yet complete. Haystack analysis typically takes 2–4 minutes after a PR is pushed.
 
-**Behaviour since issue #795**: `haystack-reviewer.sh` now **automatically polls and retries** when it receives `status=pending`. It waits `HAYSTACK_POLL_INTERVAL` seconds (default: 15) between calls and continues retrying until the analysis completes or the `HAYSTACK_REVIEWER_TIMEOUT` budget (default: 120 seconds) is exhausted.
+**Behaviour since issue #795**: `haystack-reviewer.sh` now **automatically polls and retries** when it receives `status=pending`. It waits the configured poll interval between calls and continues retrying until the analysis completes, the configured timeout budget is exhausted, or a configured stop rule fires.
 
 If the overall budget is exhausted while the analysis is still pending, the script emits:
 
@@ -402,7 +458,7 @@ REASON=pending_timeout
 
 **Recovery options**:
 
-1. **Increase the timeout**: Set `HAYSTACK_REVIEWER_TIMEOUT=300` to give Haystack more time to complete analysis.
+1. **Increase the timeout**: Set `HAYSTACK_REVIEWER_TIMEOUT=300` or `review.haystack.timeout_sec: 300` to give Haystack more time to complete analysis.
 2. **Re-run the review loop manually** after a few minutes: `./scripts/development-workflow/pr-review-loop.sh <pr_number>`.
 3. **Run haystack triage directly** if you need an immediate result:
 

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -28,7 +28,8 @@
 #   DISPLAY_RESULT=<value> (optional; used by pr-review-loop.sh summaries)
 #   POLICY_REVIEW_REQUIRED=0|1 (optional; present when pr-status is available)
 #   REASON=<value>   (only when RESULT=skipped — values: unavailable, timeout,
-#                     pending_timeout, unauthorized, forbidden)
+#                     invalid_config, pending_timeout, max_triage_rounds,
+#                     no_progress_cycles, unauthorized, forbidden)
 #
 # Polling behaviour for transient states (status=pending, status=error, etc.):
 #   When `haystack triage --no-wait` returns ANY non-empty status value other
@@ -41,9 +42,10 @@
 #   emitted.  If the budget is exhausted while the analysis is still transient,
 #   RESULT=skipped is emitted with REASON=pending_timeout (distinct from
 #   REASON=unavailable, which means the CLI is absent or triage returned
-#   status=none; REASON=unauthorized/forbidden for triage status=error with
-#   message=HTTP 401/403 (surfaced immediately, not poll-retried);
-#   and REASON=timeout, which means a single haystack triage call exceeded the
+#   status=none; REASON=max_triage_rounds/no_progress_cycles for configured
+#   stop-rule exhaustion; REASON=unauthorized/forbidden for triage status=error
+#   with message=HTTP 401/403 (surfaced immediately, not poll-retried); and
+#   REASON=timeout, which means a single haystack triage call exceeded the
 #   per-call OS timeout).
 #
 # Confirmed JSON schema (haystack triage <PR> --json as of 2026-05-25):
@@ -105,6 +107,65 @@ set -euo pipefail
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 
+HAYSTACK_CONFIG_TIMEOUT_SEC=""
+HAYSTACK_CONFIG_POLL_INTERVAL_SEC=""
+HAYSTACK_CONFIG_MAJOR_IS_BLOCKING=""
+HAYSTACK_CONFIG_MAX_TRIAGE_ROUNDS=""
+HAYSTACK_CONFIG_NO_PROGRESS_CYCLES=""
+
+resolve_workflow_repo_root() {
+  local repo_root
+  if [ -n "${HAYSTACK_WORKFLOW_REPO_ROOT:-}" ]; then
+    printf '%s\n' "$HAYSTACK_WORKFLOW_REPO_ROOT"
+    return 0
+  fi
+  if repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" && [ -n "$repo_root" ]; then
+    printf '%s\n' "$repo_root"
+    return 0
+  fi
+  pwd
+}
+
+load_workflow_haystack_config() {
+  local repo_root="$1"
+  local config_output=""
+  local config_key=""
+  local config_value=""
+
+  if ! config_output="$(python3 "$SCRIPT_DIR/workflow-config-resolver.py" review-haystack --repo-root "$repo_root" 2>&1)"; then
+    echo "ERROR: invalid Haystack workflow configuration" >&2
+    printf '%s\n' "$config_output" >&2
+    printf 'RESULT=skipped\n'
+    printf 'REASON=invalid_config\n'
+    printf 'BLOCKING_COUNT=0\n'
+    printf 'SUGGESTION_COUNT=0\n'
+    printf 'COMMENT_COUNT=0\n'
+    exit 3
+  fi
+
+  while IFS='=' read -r config_key config_value; do
+    case "$config_key" in
+      HAYSTACK_CONFIG_TIMEOUT_SEC)
+        HAYSTACK_CONFIG_TIMEOUT_SEC="$config_value"
+        ;;
+      HAYSTACK_CONFIG_POLL_INTERVAL_SEC)
+        HAYSTACK_CONFIG_POLL_INTERVAL_SEC="$config_value"
+        ;;
+      HAYSTACK_CONFIG_MAJOR_IS_BLOCKING)
+        HAYSTACK_CONFIG_MAJOR_IS_BLOCKING="$config_value"
+        ;;
+      HAYSTACK_CONFIG_MAX_TRIAGE_ROUNDS)
+        HAYSTACK_CONFIG_MAX_TRIAGE_ROUNDS="$config_value"
+        ;;
+      HAYSTACK_CONFIG_NO_PROGRESS_CYCLES)
+        HAYSTACK_CONFIG_NO_PROGRESS_CYCLES="$config_value"
+        ;;
+    esac
+  done <<EOF_CONFIG
+$config_output
+EOF_CONFIG
+}
+
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 if [ $# -lt 3 ]; then
@@ -137,9 +198,16 @@ case "$REPO" in
     ;;
 esac
 
-# Parse optional flags
-TIMEOUT="${HAYSTACK_REVIEWER_TIMEOUT:-120}"
-POLL_INTERVAL="${HAYSTACK_POLL_INTERVAL:-15}"
+WORKFLOW_REPO_ROOT="$(resolve_workflow_repo_root)"
+load_workflow_haystack_config "$WORKFLOW_REPO_ROOT"
+
+# Parse optional flags. Precedence: CLI timeout > env overrides > repository
+# review.haystack config > built-in defaults.
+TIMEOUT="${HAYSTACK_REVIEWER_TIMEOUT:-${HAYSTACK_CONFIG_TIMEOUT_SEC:-120}}"
+POLL_INTERVAL="${HAYSTACK_POLL_INTERVAL:-${HAYSTACK_CONFIG_POLL_INTERVAL_SEC:-15}}"
+MAJOR_IS_BLOCKING="${HAYSTACK_MAJOR_IS_BLOCKING:-${HAYSTACK_CONFIG_MAJOR_IS_BLOCKING:-0}}"
+MAX_TRIAGE_ROUNDS="$HAYSTACK_CONFIG_MAX_TRIAGE_ROUNDS"
+NO_PROGRESS_CYCLES="$HAYSTACK_CONFIG_NO_PROGRESS_CYCLES"
 PR_STATUS_CHECK="${HAYSTACK_PR_STATUS_CHECK:-1}"
 FALSE_POSITIVES_FILE="${HAYSTACK_FALSE_POSITIVES_FILE:-$SCRIPT_DIR/haystack-false-positives.json}"
 
@@ -165,6 +233,37 @@ esac
 case "$POLL_INTERVAL" in
   ''|0|*[!0-9]*)
     echo "ERROR: HAYSTACK_POLL_INTERVAL value '$POLL_INTERVAL' is not a positive integer (must be >= 1)" >&2
+    exit 3
+    ;;
+esac
+
+case "$MAJOR_IS_BLOCKING" in
+  1|true|TRUE)
+    MAJOR_IS_BLOCKING=1
+    ;;
+  ''|0|false|FALSE)
+    MAJOR_IS_BLOCKING=0
+    ;;
+  *)
+    echo "ERROR: HAYSTACK_MAJOR_IS_BLOCKING value '$MAJOR_IS_BLOCKING' must be 0 or 1" >&2
+    exit 3
+    ;;
+esac
+
+case "$MAX_TRIAGE_ROUNDS" in
+  '')
+    ;;
+  0|*[!0-9]*)
+    echo "ERROR: review.haystack.stop_rule.max_triage_rounds value '$MAX_TRIAGE_ROUNDS' is not a positive integer (must be >= 1)" >&2
+    exit 3
+    ;;
+esac
+
+case "$NO_PROGRESS_CYCLES" in
+  '')
+    ;;
+  0|*[!0-9]*)
+    echo "ERROR: review.haystack.stop_rule.no_progress_cycles value '$NO_PROGRESS_CYCLES' is not a positive integer (must be >= 1)" >&2
     exit 3
     ;;
 esac
@@ -292,6 +391,9 @@ TRIAGE_EXIT=0
 elapsed=0
 LOOP_START_TS="$(date +%s 2>/dev/null || printf '0')"
 TRIAGE_STDERR=$(mktemp)
+TRIAGE_ROUND_COUNT=0
+LAST_PROGRESS_SIGNATURE=""
+NO_PROGRESS_REPEAT_COUNT=0
 
 while true; do
   rm -f "$TRIAGE_STDERR"
@@ -315,6 +417,12 @@ while true; do
   fi
   POLL_CALL_TIMEOUT=$(( remaining / 2 ))
   [ "$POLL_CALL_TIMEOUT" -lt 1 ] && POLL_CALL_TIMEOUT=1
+
+  TRIAGE_ROUND_COUNT=$((TRIAGE_ROUND_COUNT + 1))
+  if [ -n "$MAX_TRIAGE_ROUNDS" ] && [ "$TRIAGE_ROUND_COUNT" -gt "$MAX_TRIAGE_ROUNDS" ]; then
+    TRIAGE_EXIT=201  # sentinel: max_triage_rounds exhausted
+    break
+  fi
 
   echo "INFO: running: haystack triage ${OWNER}/${REPO}#${PR_NUMBER} --json --no-wait (elapsed: ${elapsed}s, per-call timeout: ${POLL_CALL_TIMEOUT}s)" >&2
 
@@ -491,6 +599,26 @@ while true; do
       # Treat other transient states as still synthesizing — poll-retry after POLL_INTERVAL.
       # NEVER map an unknown or error status to "clean"; only a genuinely
       # completed result (empty STATUS_VALUE above) may yield RESULT=clean.
+      if [ -n "$NO_PROGRESS_CYCLES" ]; then
+        PROGRESS_SIGNATURE="$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -c '
+          {
+            status: (.status // ""),
+            message: (.message // ""),
+            finding_count: ((.findings // []) | length),
+            categories: [(.findings // [])[]? | (.category // "__UNKNOWN__")] | sort
+          }
+        ' 2>/dev/null || printf 'status=%s' "$STATUS_VALUE")"
+        if [ "$PROGRESS_SIGNATURE" = "$LAST_PROGRESS_SIGNATURE" ]; then
+          NO_PROGRESS_REPEAT_COUNT=$((NO_PROGRESS_REPEAT_COUNT + 1))
+        else
+          LAST_PROGRESS_SIGNATURE="$PROGRESS_SIGNATURE"
+          NO_PROGRESS_REPEAT_COUNT=0
+        fi
+        if [ "$NO_PROGRESS_REPEAT_COUNT" -ge "$NO_PROGRESS_CYCLES" ]; then
+          TRIAGE_EXIT=202  # sentinel: no_progress_cycles exhausted
+          break
+        fi
+      fi
       echo "INFO: status='${STATUS_VALUE}' — still synthesizing; waiting ${POLL_INTERVAL}s before retry (${elapsed}s elapsed of ${TIMEOUT}s budget)" >&2
       # Check budget BEFORE sleeping so we don't overshoot the timeout.
       if [ $((elapsed + POLL_INTERVAL)) -ge "$TIMEOUT" ]; then
@@ -537,6 +665,26 @@ if [ "$TRIAGE_EXIT" -eq 200 ]; then
   exit 2
 fi
 
+if [ "$TRIAGE_EXIT" -eq 201 ]; then
+  echo "INFO: haystack triage stopped after ${MAX_TRIAGE_ROUNDS} triage rounds without completed analysis (max_triage_rounds)" >&2
+  printf 'RESULT=skipped\n'
+  printf 'REASON=max_triage_rounds\n'
+  printf 'BLOCKING_COUNT=0\n'
+  printf 'SUGGESTION_COUNT=0\n'
+  printf 'COMMENT_COUNT=0\n'
+  exit 2
+fi
+
+if [ "$TRIAGE_EXIT" -eq 202 ]; then
+  echo "INFO: haystack triage progress did not change for ${NO_PROGRESS_CYCLES} repeated cycles (no_progress_cycles)" >&2
+  printf 'RESULT=skipped\n'
+  printf 'REASON=no_progress_cycles\n'
+  printf 'BLOCKING_COUNT=0\n'
+  printf 'SUGGESTION_COUNT=0\n'
+  printf 'COMMENT_COUNT=0\n'
+  exit 2
+fi
+
 echo "INFO: haystack triage raw output:" >&2
 printf '%s\n' "$TRIAGE_OUTPUT" >&2
 
@@ -558,7 +706,7 @@ printf '%s\n' "$TRIAGE_OUTPUT" >&2
 # Null/missing .category values are mapped to the sentinel "__UNKNOWN__" so they
 # are treated as blocking (safe-fail) rather than silently dropped.
 NORMALIZED_FINDINGS_JSON="$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -c \
-  --arg major_is_blocking "${HAYSTACK_MAJOR_IS_BLOCKING:-0}" \
+  --arg major_is_blocking "$MAJOR_IS_BLOCKING" \
   --argjson false_positive_catalog "$FALSE_POSITIVE_CATALOG_JSON" '
   def category:
     if (.category | type) == "string" and .category != "" then .category

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -2056,8 +2056,10 @@ run_haystack_review() {
   #   0 → RESULT=clean    (no blocking findings)
   #   1 → RESULT=needs_fixes (one or more blocking findings)
   #   2 → RESULT=escalate; REASON forwarded from companion script:
-  #         REASON=timeout         — per-call OS timeout exhausted budget
-  #         REASON=pending_timeout — analysis stayed pending past timeout budget
+  #         REASON=timeout             — per-call OS timeout exhausted budget
+  #         REASON=pending_timeout     — analysis stayed pending past timeout budget
+  #         REASON=max_triage_rounds   — configured triage-round stop rule fired
+  #         REASON=no_progress_cycles  — configured no-progress stop rule fired
   #   3 → RESULT=skipped; REASON forwarded (unavailable, unauthorized, forbidden, …)
   local pr_number="$1"
   local branch_name="$2"

--- a/scripts/development-workflow/tests/test-haystack-reviewer.sh
+++ b/scripts/development-workflow/tests/test-haystack-reviewer.sh
@@ -72,7 +72,7 @@ _harness_exit() {
 }
 trap _harness_exit EXIT
 
-for _cmd in bash env jq mktemp date cat rm wc sed tr sleep; do
+for _cmd in bash env jq mktemp date cat rm wc sed tr sleep python3 dirname; do
   _cmd_path="$(command -v "$_cmd")"
   ln -sf "$_cmd_path" "$NO_TIMEOUT_BIN/$_cmd"
 done
@@ -248,6 +248,27 @@ _run_reviewer_exit_code() {
     echo $?
     set -e
   fi
+}
+
+_run_reviewer_with_config() {
+  # Runs haystack-reviewer.sh against a temporary workflow config root without
+  # setting timeout/poll env vars, so repository config values are observable.
+  local config_root="$1"
+  local reviewer_path="${TEST_REVIEWER_PATH:-$MOCK_BIN:$PATH}"
+  rm -f "$_REVIEWER_OUTPUT_FILE" "$_REVIEWER_EXIT_FILE"
+  set +e
+  HAYSTACK_WORKFLOW_REPO_ROOT="$config_root" \
+  HAYSTACK_PR_STATUS_CHECK="${TEST_HAYSTACK_PR_STATUS_CHECK:-0}" \
+  MOCK_CALL_LOG="$CALL_LOG" \
+  MOCK_RESPONSE_SEQ="$RESPONSE_SEQ_FILE" \
+  MOCK_EXIT_SEQ="$EXIT_SEQ_FILE" \
+  MOCK_SLEEP_SEQ="$SLEEP_SEQ_FILE" \
+  PATH="$reviewer_path" \
+    bash "$HAYSTACK_REVIEWER" "123" "owner" "repo" \
+    >"$_REVIEWER_OUTPUT_FILE" 2>/dev/null
+  echo $? > "$_REVIEWER_EXIT_FILE"
+  set -e
+  cat "$_REVIEWER_OUTPUT_FILE"
 }
 
 _kv_value() {
@@ -537,6 +558,27 @@ output=$(HAYSTACK_MAJOR_IS_BLOCKING=1 _run_reviewer 10 1)
 blocking_json="$(_kv_value BLOCKING_FINDINGS_JSON "$output")"
 run_test "structured_major_opt_in_blocking" "1" "$(printf '%s\n' "$blocking_json" | jq 'length')"
 
+major_config_root="$MOCK_BIN/major-config-root"
+mkdir -p "$major_config_root"
+cat > "$major_config_root/.ai-dev-workflow.yaml" <<'YAML'
+review:
+  haystack:
+    major_is_blocking: true
+    timeout_sec: 10
+    poll_interval_sec: 1
+YAML
+_reset_mocks
+_install_haystack_mock
+output=$(_run_reviewer_with_config "$major_config_root")
+blocking_json="$(_kv_value BLOCKING_FINDINGS_JSON "$output")"
+run_test "structured_major_config_blocking" "1" "$(printf '%s\n' "$blocking_json" | jq 'length')"
+
+_reset_mocks
+_install_haystack_mock
+output=$(HAYSTACK_MAJOR_IS_BLOCKING=0 _run_reviewer_with_config "$major_config_root")
+advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
+run_test "structured_major_env_overrides_config" "1" "$(printf '%s\n' "$advisory_json" | jq 'length')"
+
 # Test 5b.7: optional source fields follow documented fallbacks.
 MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"rating":4,"findings":[{"category":"Minor","summary":"Source path","detail":"","source":{"path":"a.sh","line":7}},{"category":"Minor","summary":"Source file","detail":"","source":{"file":"b.sh","startLine":"8"}},{"category":"Minor","summary":"Top path","detail":"","path":"c.sh","line":"9"},{"category":"Minor","summary":"Top file","detail":"","file":"d.sh","startLine":10}]}'
 _reset_mocks
@@ -748,6 +790,79 @@ calls=$(_call_count)
 
 run_test "custom_poll_interval_result" "RESULT=clean" "$(echo "$output" | grep '^RESULT=')"
 run_test "custom_poll_interval_call_count" "2" "$calls"
+
+# ---------------------------------------------------------------------------
+# Area 6b: review.haystack config defaults and stop rules
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 6b: review.haystack config defaults and stop rules ==="
+
+config_root="$MOCK_BIN/config-root"
+mkdir -p "$config_root"
+cat > "$config_root/.ai-dev-workflow.yaml" <<'YAML'
+review:
+  haystack:
+    poll_interval_sec: 1
+    timeout_sec: 30
+    stop_rule:
+      max_triage_rounds: 1
+YAML
+MOCK_HAYSTACK_OUTPUTS='{"status":"pending"}
+{"status":"pending"}
+{"owner":"owner","repo":"repo","prNumber":123,"rating":5,"findings":[]}'
+_reset_mocks
+_install_haystack_mock
+output=$(_run_reviewer_with_config "$config_root")
+calls=$(_call_count)
+run_test "config_max_triage_rounds_reason" "max_triage_rounds" "$(_kv_value REASON "$output")"
+run_test "config_max_triage_rounds_call_count" "1" "$calls"
+
+cat > "$config_root/.ai-dev-workflow.yaml" <<'YAML'
+review:
+  haystack:
+    poll_interval_sec: 1
+    timeout_sec: 30
+    stop_rule:
+      no_progress_cycles: 1
+YAML
+MOCK_HAYSTACK_OUTPUTS='{"status":"pending","message":"still working","findings":[]}
+{"status":"pending","message":"still working","findings":[]}
+{"owner":"owner","repo":"repo","prNumber":123,"rating":5,"findings":[]}'
+_reset_mocks
+_install_haystack_mock
+output=$(_run_reviewer_with_config "$config_root")
+calls=$(_call_count)
+run_test "config_no_progress_cycles_reason" "no_progress_cycles" "$(_kv_value REASON "$output")"
+run_test "config_no_progress_cycles_call_count" "2" "$calls"
+
+cat > "$config_root/.ai-dev-workflow.yaml" <<'YAML'
+review:
+  haystack:
+    poll_interval_sec: 1
+    timeout_sec: 30
+    stop_rule:
+      max_triage_rounds: 3
+      no_progress_cycles: 1
+YAML
+MOCK_HAYSTACK_OUTPUTS='{"status":"pending","message":"still working","findings":[]}
+{"owner":"owner","repo":"repo","prNumber":123,"rating":5,"findings":[]}'
+_reset_mocks
+_install_haystack_mock
+output=$(_run_reviewer_with_config "$config_root")
+run_test "config_completion_before_stop_rules" "RESULT=clean" "$(echo "$output" | grep '^RESULT=')"
+
+invalid_config_root="$MOCK_BIN/invalid-config-root"
+mkdir -p "$invalid_config_root"
+cat > "$invalid_config_root/.ai-dev-workflow.yaml" <<'YAML'
+review:
+  haystack:
+    poll_interval_sec: 0
+YAML
+_reset_mocks
+_install_haystack_mock
+output=$(_run_reviewer_with_config "$invalid_config_root")
+run_test "config_invalid_reason" "invalid_config" "$(_kv_value REASON "$output")"
+run_test "config_invalid_exit_code" "3" "$(_run_reviewer_exit_code)"
 
 # ---------------------------------------------------------------------------
 # Area 7: argument validation still works after refactor

--- a/scripts/development-workflow/tests/test-workflow-config-resolver.sh
+++ b/scripts/development-workflow/tests/test-workflow-config-resolver.sh
@@ -457,6 +457,102 @@ local_review_output="$(workflow_review_override_context "$local_review_dir")"
 run_contains "local_review_override_runner" "REVIEW_ON_DRAFT_RUNNER=claude,with-comma,codex" "$local_review_output"
 run_contains "local_review_override_source" "LOCAL_OVERRIDE_SOURCE=runner:.ai-dev-workflow.local.yaml,policy:.ai-dev-workflow.local.yaml" "$local_review_output"
 
+haystack_empty_dir="$(fixture_dir haystack-empty)"
+haystack_empty_output="$(python3 "$RESOLVER" review-haystack --repo-root "$haystack_empty_dir")"
+run_contains "haystack_empty_timeout" "HAYSTACK_CONFIG_TIMEOUT_SEC=" "$haystack_empty_output"
+run_contains "haystack_empty_poll_interval" "HAYSTACK_CONFIG_POLL_INTERVAL_SEC=" "$haystack_empty_output"
+run_contains "haystack_empty_major_policy" "HAYSTACK_CONFIG_MAJOR_IS_BLOCKING=" "$haystack_empty_output"
+run_contains "haystack_empty_max_rounds" "HAYSTACK_CONFIG_MAX_TRIAGE_ROUNDS=" "$haystack_empty_output"
+run_contains "haystack_empty_no_progress" "HAYSTACK_CONFIG_NO_PROGRESS_CYCLES=" "$haystack_empty_output"
+
+haystack_dir="$(fixture_dir haystack-config)"
+cat > "$haystack_dir/.ai-dev-workflow.yaml" <<'YAML'
+schema_version: 2
+review:
+  haystack:
+    major_is_blocking: false
+    poll_interval_sec: 15
+    timeout_sec: 120
+    stop_rule:
+      max_triage_rounds: 8
+      no_progress_cycles: 3
+YAML
+cat > "$haystack_dir/.ai-dev-workflow.local.yaml" <<'YAML'
+review:
+  haystack:
+    major_is_blocking: true
+    poll_interval_sec: 10
+    timeout_sec: 180
+    stop_rule:
+      max_triage_rounds: 12
+      no_progress_cycles: 4
+YAML
+haystack_output="$(python3 "$RESOLVER" review-haystack --repo-root "$haystack_dir")"
+run_contains "haystack_local_major_overrides_shared" "HAYSTACK_CONFIG_MAJOR_IS_BLOCKING=1" "$haystack_output"
+run_contains "haystack_local_poll_overrides_shared" "HAYSTACK_CONFIG_POLL_INTERVAL_SEC=10" "$haystack_output"
+run_contains "haystack_local_timeout_overrides_shared" "HAYSTACK_CONFIG_TIMEOUT_SEC=180" "$haystack_output"
+run_contains "haystack_local_max_rounds_overrides_shared" "HAYSTACK_CONFIG_MAX_TRIAGE_ROUNDS=12" "$haystack_output"
+run_contains "haystack_local_no_progress_overrides_shared" "HAYSTACK_CONFIG_NO_PROGRESS_CYCLES=4" "$haystack_output"
+validator_haystack_output="$(bash "$VALIDATOR" --repo-root "$haystack_dir")"
+run_contains "haystack_validate_accepts_valid_config" "TARGET_REPO_NAME=haystack-config" "$validator_haystack_output"
+
+haystack_invalid_bool_dir="$(fixture_dir haystack-invalid-bool)"
+cat > "$haystack_invalid_bool_dir/.ai-dev-workflow.yaml" <<'YAML'
+review:
+  haystack:
+    major_is_blocking: "true"
+YAML
+run_fails_contains \
+  "haystack_rejects_string_boolean" \
+  "review.haystack.major_is_blocking must be a boolean" \
+  python3 "$RESOLVER" review-haystack --repo-root "$haystack_invalid_bool_dir"
+
+haystack_invalid_number_dir="$(fixture_dir haystack-invalid-number)"
+cat > "$haystack_invalid_number_dir/.ai-dev-workflow.yaml" <<'YAML'
+review:
+  haystack:
+    poll_interval_sec: 0
+YAML
+run_fails_contains \
+  "haystack_rejects_zero_poll_interval" \
+  "review.haystack.poll_interval_sec must be a positive integer" \
+  python3 "$RESOLVER" review-haystack --repo-root "$haystack_invalid_number_dir"
+
+haystack_unknown_key_dir="$(fixture_dir haystack-unknown-key)"
+cat > "$haystack_unknown_key_dir/.ai-dev-workflow.yaml" <<'YAML'
+review:
+  haystack:
+    timeout_sec: 120
+    unknown_option: true
+YAML
+run_fails_contains \
+  "haystack_rejects_unknown_key" \
+  "review.haystack contains unsupported field(s): unknown_option" \
+  python3 "$RESOLVER" review-haystack --repo-root "$haystack_unknown_key_dir"
+
+haystack_unknown_stop_rule_dir="$(fixture_dir haystack-unknown-stop-rule)"
+cat > "$haystack_unknown_stop_rule_dir/.ai-dev-workflow.yaml" <<'YAML'
+review:
+  haystack:
+    stop_rule:
+      mystery: 1
+YAML
+run_fails_contains \
+  "haystack_rejects_unknown_stop_rule_key" \
+  "review.haystack.stop_rule contains unsupported field(s): mystery" \
+  python3 "$RESOLVER" review-haystack --repo-root "$haystack_unknown_stop_rule_dir"
+
+haystack_scalar_stop_rule_dir="$(fixture_dir haystack-scalar-stop-rule)"
+cat > "$haystack_scalar_stop_rule_dir/.ai-dev-workflow.yaml" <<'YAML'
+review:
+  haystack:
+    stop_rule: 3
+YAML
+run_fails_contains \
+  "haystack_rejects_scalar_stop_rule" \
+  "field 'review.haystack.stop_rule' must be a mapping" \
+  python3 "$RESOLVER" review-haystack --repo-root "$haystack_scalar_stop_rule_dir"
+
 stale_review_dir="$(fixture_dir stale-review-overrides)"
 mkdir -p "$stale_review_dir/.tmp"
 cat > "$stale_review_dir/.tmp/template-config.json" <<'JSON'

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -21,6 +21,8 @@ from typing import Any
 
 VALID_MODES = {"single_repo", "workflow_hub", "product_repo"}
 VALID_CI_POLICIES = {"required", "none"}
+HAYSTACK_KEYS = {"major_is_blocking", "poll_interval_sec", "timeout_sec", "stop_rule"}
+HAYSTACK_STOP_RULE_KEYS = {"max_triage_rounds", "no_progress_cycles"}
 LOCAL_ONLY_KEYS = {
     "local_path",
     "checkout_path",
@@ -310,6 +312,84 @@ def normalize_ci_policy(raw: Any, shared_path: Path, field_path: str) -> str:
     return value
 
 
+def positive_int_string(value: Any, path: Path, field_path: str) -> str:
+    if not isinstance(value, str) or not re.match(r"^[1-9][0-9]*$", value):
+        raise ConfigError(f"{path}: {field_path} must be a positive integer")
+    return value
+
+
+def bool_string(value: Any, path: Path, field_path: str) -> str:
+    if not isinstance(value, bool):
+        raise ConfigError(f"{path}: {field_path} must be a boolean")
+    return "1" if value else "0"
+
+
+def raw_haystack_config(config: dict[str, Any], path: Path) -> dict[str, Any]:
+    if "review" not in config:
+        return {}
+    review = as_mapping(config.get("review"), path, "review")
+    if "haystack" not in review:
+        return {}
+    return as_mapping(review.get("haystack"), path, "review.haystack")
+
+
+def normalize_haystack_config(config: dict[str, Any], path: Path) -> dict[str, str]:
+    haystack = raw_haystack_config(config, path)
+    if not haystack:
+        return {}
+
+    unknown = sorted(str(key) for key in haystack if key not in HAYSTACK_KEYS)
+    if unknown:
+        raise ConfigError(
+            f"{path}: review.haystack contains unsupported field(s): {', '.join(unknown)}"
+        )
+
+    normalized: dict[str, str] = {}
+    if "major_is_blocking" in haystack:
+        normalized["HAYSTACK_CONFIG_MAJOR_IS_BLOCKING"] = bool_string(
+            haystack.get("major_is_blocking"), path, "review.haystack.major_is_blocking"
+        )
+    if "poll_interval_sec" in haystack:
+        normalized["HAYSTACK_CONFIG_POLL_INTERVAL_SEC"] = positive_int_string(
+            haystack.get("poll_interval_sec"), path, "review.haystack.poll_interval_sec"
+        )
+    if "timeout_sec" in haystack:
+        normalized["HAYSTACK_CONFIG_TIMEOUT_SEC"] = positive_int_string(
+            haystack.get("timeout_sec"), path, "review.haystack.timeout_sec"
+        )
+
+    if "stop_rule" in haystack:
+        stop_rule = as_mapping(
+            haystack.get("stop_rule"), path, "review.haystack.stop_rule"
+        )
+        unknown_stop_rule = sorted(
+            str(key) for key in stop_rule if key not in HAYSTACK_STOP_RULE_KEYS
+        )
+        if unknown_stop_rule:
+            raise ConfigError(
+                f"{path}: review.haystack.stop_rule contains unsupported field(s): {', '.join(unknown_stop_rule)}"
+            )
+        if "max_triage_rounds" in stop_rule:
+            normalized["HAYSTACK_CONFIG_MAX_TRIAGE_ROUNDS"] = positive_int_string(
+                stop_rule.get("max_triage_rounds"),
+                path,
+                "review.haystack.stop_rule.max_triage_rounds",
+            )
+        if "no_progress_cycles" in stop_rule:
+            normalized["HAYSTACK_CONFIG_NO_PROGRESS_CYCLES"] = positive_int_string(
+                stop_rule.get("no_progress_cycles"),
+                path,
+                "review.haystack.stop_rule.no_progress_cycles",
+            )
+
+    return normalized
+
+
+def validate_workflow_config(shared: dict[str, Any], local: dict[str, Any], shared_path: Path, local_path: Path) -> None:
+    normalize_haystack_config(shared, shared_path)
+    normalize_haystack_config(local, local_path)
+
+
 def product_repos(shared: dict[str, Any], shared_path: Path) -> list[dict[str, Any]]:
     workflow_hub = as_mapping(shared.get("workflow_hub"), shared_path, "workflow_hub")
     repos = as_list(workflow_hub.get("product_repos"), shared_path, "workflow_hub.product_repos")
@@ -570,6 +650,7 @@ def first_present(*values: Any) -> str:
 def resolve_auth_context(args: argparse.Namespace) -> dict[str, str]:
     repo_root = repo_root_from_args(args.repo_root)
     shared, local, shared_path, local_path = load_configs(repo_root)
+    validate_workflow_config(shared, local, shared_path, local_path)
     mode = mode_from_shared(shared, shared_path)
     if mode != "workflow_hub":
         return {
@@ -636,6 +717,7 @@ def resolve_auth_context(args: argparse.Namespace) -> dict[str, str]:
 def resolve_context(args: argparse.Namespace) -> dict[str, str]:
     repo_root = repo_root_from_args(args.repo_root)
     shared, local, shared_path, local_path = load_configs(repo_root)
+    validate_workflow_config(shared, local, shared_path, local_path)
     mode = mode_from_shared(shared, shared_path)
     context: dict[str, str] = {
         "WORKFLOW_MODE": mode,
@@ -727,7 +809,8 @@ def scalar_from_path(data: dict[str, Any], path: list[str]) -> str:
 
 def resolve_review_overrides(args: argparse.Namespace) -> dict[str, str]:
     repo_root = repo_root_from_args(args.repo_root)
-    _, local, _, _ = load_configs(repo_root)
+    shared, local, shared_path, local_path = load_configs(repo_root)
+    validate_workflow_config(shared, local, shared_path, local_path)
 
     local_runner, has_local_runner = list_override_from_path(local, ["review", "on_draft", "runner"])
     runner = local_runner
@@ -770,6 +853,23 @@ def resolve_review_overrides(args: argparse.Namespace) -> dict[str, str]:
         "INTERNAL_REVIEWERS_UNAVAILABLE_POLICY_SOURCE": policy_source,
         "LOCAL_OVERRIDE_SOURCE": ",".join(sources),
     }
+
+
+def resolve_haystack_config(args: argparse.Namespace) -> dict[str, str]:
+    repo_root = repo_root_from_args(args.repo_root)
+    shared, local, shared_path, local_path = load_configs(repo_root)
+    shared_values = normalize_haystack_config(shared, shared_path)
+    local_values = normalize_haystack_config(local, local_path)
+    values = {
+        "HAYSTACK_CONFIG_MAJOR_IS_BLOCKING": "",
+        "HAYSTACK_CONFIG_POLL_INTERVAL_SEC": "",
+        "HAYSTACK_CONFIG_TIMEOUT_SEC": "",
+        "HAYSTACK_CONFIG_MAX_TRIAGE_ROUNDS": "",
+        "HAYSTACK_CONFIG_NO_PROGRESS_CYCLES": "",
+    }
+    values.update(shared_values)
+    values.update(local_values)
+    return values
 
 
 def print_shell_context(values: dict[str, str]) -> None:
@@ -837,6 +937,11 @@ def cmd_review_overrides(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_review_haystack(args: argparse.Namespace) -> int:
+    print_context(args, resolve_haystack_config(args))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Resolve AI workflow repository context")
     subcommands = parser.add_subparsers(dest="command", required=True)
@@ -889,6 +994,11 @@ def build_parser() -> argparse.ArgumentParser:
     overrides.add_argument("--repo-root")
     overrides.add_argument("--json", action="store_true", help="print JSON instead of shell KEY=value")
     overrides.set_defaults(func=cmd_review_overrides)
+
+    haystack = subcommands.add_parser("review-haystack", help="print Haystack review config values")
+    haystack.add_argument("--repo-root")
+    haystack.add_argument("--json", action="store_true", help="print JSON instead of shell KEY=value")
+    haystack.set_defaults(func=cmd_review_haystack)
     return parser
 
 


### PR DESCRIPTION
## Summary

- Add validated `review.haystack` workflow config for Haystack timeout, poll interval, major-finding policy, and stop rules.
- Load repository Haystack defaults in `haystack-reviewer.sh` while preserving env/CLI precedence.
- Document shared/local examples, update Haystack triage guidance, and add resolver/reviewer regression tests.

## Spec and Plan

- Spec: `docs/specs/developments/20260702113258_1116-haystack-workflow-config/1_1116-haystack-workflow-config_specs.md`
- Plan: `docs/specs/developments/20260702113258_1116-haystack-workflow-config/2_1116-haystack-workflow-config_implementation-plan.md`
- Smoke test: `docs/testing/workflow/1116-haystack-workflow-config.smoke-test.md`

## Verification

- `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh` — 90 passed, 0 failed
- `bash scripts/development-workflow/tests/test-haystack-reviewer.sh` — 222 passed, 0 failed
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` — 291 passed, 0 failed
- `bash scripts/development-workflow/validate-workflow-config.sh`
- `shellcheck --severity=warning -x scripts/development-workflow/haystack-reviewer.sh scripts/development-workflow/validate-workflow-config.sh scripts/development-workflow/tests/test-haystack-reviewer.sh scripts/development-workflow/tests/test-workflow-config-resolver.sh scripts/development-workflow/pr-review-loop.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`

## CHANGELOG Preview

- **Haystack workflow configuration** (#1116): Added repository-level Haystack reviewer settings with validation, override precedence, and stop-rule documentation.

## Pre-submission Self-review

Stale markers: none found in the PR diff. Caller consistency: verified `haystack-reviewer.sh`, `workflow-config-resolver.py`, `pr-review-loop.sh`, tests, examples, and docs use the same config keys and reason strings. Coverage: all #1116 acceptance criteria are addressed, including optional omission defaults, valid config use, env/CLI precedence, invalid config validation, docs, and local example coverage. Test harness checklist: covered empty config, invalid values, boundary stop-rule thresholds, missing runtime env defaults, and no-timeout fallback fixture requirements.

Issue: #1116

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core reviewer-loop polling and skip reasons for Haystack; misconfiguration could skip reviews early, though invalid config fails closed and tests cover precedence and stop rules.
> 
> **Overview**
> Adds optional **`review.haystack`** in `.ai-dev-workflow.yaml` / local overrides so repos can set Haystack poll interval, timeout, whether **Major** findings block, and **stop rules** (`max_triage_rounds`, `no_progress_cycles`) without relying only on env vars.
> 
> **`workflow-config-resolver.py`** gains a `review-haystack` command and strict validation (booleans, positive integers, unknown keys, scalar `stop_rule`). **`haystack-reviewer.sh`** loads that config at startup (local YAML wins over shared), applies precedence **CLI `--timeout` → env → YAML → defaults**, and can exit early with `REASON=invalid_config`, `max_triage_rounds`, or `no_progress_cycles` when limits fire. Completed triage still wins over stop rules.
> 
> Docs, example YAML, CHANGELOG, **`pr-review-loop.sh`** reason mapping, and resolver/reviewer tests are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02f659d85e96a7a56aa76651a2b21f37db01d4b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->