### PR TITLE
docs(plan): document external reviewer practice

### DIFF
--- a/docs/specs/developments/20260702121239_1117-document-one-external-reviewer-practice/2_1117-document-one-external-reviewer-practice_implementation-plan.md
+++ b/docs/specs/developments/20260702121239_1117-document-one-external-reviewer-practice/2_1117-document-one-external-reviewer-practice_implementation-plan.md
@@ -1,0 +1,136 @@
+# One External Reviewer Practice - Implementation Plan
+
+**Spec**: [1_1117-document-one-external-reviewer-practice_specs.md](1_1117-document-one-external-reviewer-practice_specs.md)
+**Smoke test runbook**: [1117-document-one-external-reviewer-practice.smoke-test.md](../../../testing/workflow/1117-document-one-external-reviewer-practice.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add canonical guidance in the generic automated review platform
+documentation, cross-reference it from repository-mode/configuration guidance,
+and make `.ai-dev-workflow.local.example.yaml` demonstrate the recommended
+single external ready-phase reviewer pattern. Implement the optional validator
+warning as a non-blocking stderr warning in `workflow-config-resolver.py` so
+otherwise valid multi-reviewer configurations continue to pass validation.
+
+**Estimated complexity**: S
+
+**Rationale**: The change is limited to workflow documentation, one config
+example, and one existing standard-library Python resolver with focused shell
+tests.
+
+**Dependencies**: #1113 is Merged, satisfying the epic dependency chain for
+advisory-hardening work. No external service dependency is required.
+
+## Verification Log
+
+| Check | Command / query | Result |
+| ----- | --------------- | ------ |
+| Repo revision | `git rev-parse --short HEAD` | `141cc08` |
+| External reviewer/config references | `rg -l "review.on_draft.github|review.on_ready.github|external reviewer|Automated PR Review Platforms|validate-workflow-config" docs/workflow/development-workflow .ai-dev-workflow.yaml .ai-dev-workflow.local.example.yaml scripts/development-workflow tests 2>/dev/null \| sort` | Key implementation targets include `docs/workflow/development-workflow/integrations/pr-review-platform.md`, `docs/workflow/development-workflow/README.md`, `docs/workflow/development-workflow/repository-modes.md`, `.ai-dev-workflow.local.example.yaml`, `scripts/development-workflow/workflow-config-resolver.py`, and `scripts/development-workflow/tests/test-workflow-config-resolver.sh`. |
+| Resolver validation surface | `rg -n "review\\.on_draft|review\\.on_ready|normalize_haystack_config|validate_workflow_config|warnings" scripts/development-workflow/tests/test-workflow-config-resolver.sh scripts/development-workflow/workflow-config-resolver.py` | `validate_workflow_config` currently validates Haystack config only; resolver tests already cover validator wrapper behavior and config resolver output. |
+
+## Layer-by-Layer Changes
+
+### Documentation
+
+- [ ] Update
+      `docs/workflow/development-workflow/integrations/pr-review-platform.md`
+      with a "Recommended Reviewer Count" section that states one external
+      reviewer per repository/product is the default operating model, paired
+      with internal runner review.
+- [ ] Update `docs/workflow/development-workflow/README.md` so the central
+      review configuration notes point to the same recommendation and do not
+      imply that multi-bot external review is the default.
+- [ ] Update `docs/workflow/development-workflow/repository-modes.md` so
+      repository-mode guidance applies the same recommendation to
+      `single_repo`, `workflow_hub`, and `product_repo` contexts.
+
+### Infrastructure / Configuration
+
+- [ ] Update `.ai-dev-workflow.local.example.yaml` so the Cursor pilot example
+      uses one external reviewer in the ready phase and explains that additional
+      external reviewers are advanced/local choices.
+
+### Workflow Configuration Resolver
+
+- [ ] Add a small warning helper in
+      `scripts/development-workflow/workflow-config-resolver.py` that inspects
+      `review.on_draft.github` and `review.on_ready.github` after YAML parsing.
+- [ ] Emit a non-blocking warning when either effective list contains more than
+      one external reviewer. The warning should name the config path and state
+      that one external reviewer per phase is recommended.
+- [ ] Call the warning helper from `validate_workflow_config` for both shared
+      and local config. Do not raise `ConfigError`; valid multi-reviewer config
+      must still exit successfully.
+
+## Testing Strategy
+
+**Test types**: Unit-style shell tests, config validation, markdown lint, and
+smoke-test runbook.
+
+**Key scenarios to test**:
+
+1. Single external reviewer in each phase validates without warning. Maps to
+   AC-1 and AC-3.
+2. More than one external reviewer in `review.on_draft.github` validates
+   successfully and emits a non-blocking warning. Maps to AC-4 and AC-5.
+3. More than one external reviewer in `review.on_ready.github` validates
+   successfully and emits a non-blocking warning. Maps to AC-4 and AC-5.
+4. Documentation describes the recommended pattern and advanced multi-bot
+   trade-offs. Maps to AC-1, AC-2, and AC-3.
+
+**Smoke test runbook**:
+`docs/testing/workflow/1117-document-one-external-reviewer-practice.smoke-test.md`
+
+**Regression suite**: Update
+`scripts/development-workflow/tests/test-workflow-config-resolver.sh` with
+warning and no-warning fixtures.
+
+## Seed Data
+
+No seed data is required.
+
+## Documentation Updates
+
+- [ ] `docs/workflow/development-workflow/integrations/pr-review-platform.md`
+      - add the canonical recommendation and advanced multi-bot trade-offs.
+- [ ] `docs/workflow/development-workflow/README.md` - cross-reference the
+      recommendation near review configuration notes.
+- [ ] `docs/workflow/development-workflow/repository-modes.md` - clarify that
+      the recommendation applies across repository modes.
+- [ ] `.ai-dev-workflow.local.example.yaml` - adjust the local override example
+      comments to model one external ready-phase reviewer by default.
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| ---- | ---------- | ------ | ---------- |
+| Warning breaks scripts that expect quiet stdout | Medium | Medium | Emit warnings to stderr only and keep existing stdout key/value output unchanged. |
+| Documentation duplicates provider-specific guidance | Low | Low | Put canonical reviewer-count guidance in `pr-review-platform.md` and cross-reference it from other docs. |
+| Multi-reviewer users think support was removed | Low | Medium | Explicitly state multi-bot external review remains supported as advanced usage. |
+
+## Implementation Order
+
+1. Update `pr-review-platform.md` with the canonical one-external-reviewer
+   recommendation, advanced multi-bot trade-offs, and support guarantee.
+2. Update `README.md`, `repository-modes.md`, and
+   `.ai-dev-workflow.local.example.yaml` to cross-reference or demonstrate the
+   same recommendation without duplicating the full guidance.
+3. Add the non-blocking multi-reviewer warning helper to
+   `workflow-config-resolver.py`, called from `validate_workflow_config`.
+4. Add `test-workflow-config-resolver.sh` coverage for no-warning,
+   draft-phase warning, and ready-phase warning cases. Confirm the warning does
+   not turn validation into a failure.
+5. Update this runbook's "Updated in" line if implementation changes the final
+   verification commands.
+6. Update `CHANGELOG.md` under `[Unreleased]`:
+   `- **External reviewer recommendation** (#1117): Documented the one-external-reviewer default pattern and added non-blocking workflow-config warnings for advanced multi-reviewer setups.`
+7. Verify with:
+   - `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`
+   - `bash scripts/development-workflow/validate-workflow-config.sh`
+   - `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
+   - `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
+   - `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
+   - `git diff --check`

--- a/docs/testing/workflow/1117-document-one-external-reviewer-practice.smoke-test.md
+++ b/docs/testing/workflow/1117-document-one-external-reviewer-practice.smoke-test.md
@@ -1,0 +1,127 @@
+# Smoke Test Runbook: One External Reviewer Practice
+
+**Feature**: One external reviewer practice
+**Spec**: [1_1117-document-one-external-reviewer-practice_specs.md](../../specs/developments/20260702121239_1117-document-one-external-reviewer-practice/1_1117-document-one-external-reviewer-practice_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: Plan Ready stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] You are on the implementation branch for #1117.
+- [ ] Repository dependencies required for shell tests are installed.
+- [ ] `gh`, `jq`, `python3`, and `npx` are available.
+
+## Test Data
+
+No application seed data is required.
+
+Use temporary workflow config fixtures created by
+`scripts/development-workflow/tests/test-workflow-config-resolver.sh`.
+
+## Smoke Test Steps
+
+### Step 1: Verify Documentation Recommendation
+
+**Maps to**: AC-1, AC-2, AC-3, AC-5
+
+1. Open `docs/workflow/development-workflow/integrations/pr-review-platform.md`.
+2. Confirm it recommends one external automated reviewer per repository or
+   product plus internal runner review as the default pattern.
+3. Confirm it describes multi-bot external review as advanced usage.
+4. Confirm it names cost, latency, duplicated findings, and conflicting advice
+   as trade-offs.
+5. Open `docs/workflow/development-workflow/README.md` and
+   `docs/workflow/development-workflow/repository-modes.md`.
+6. Confirm both files point maintainers to the same recommendation without
+   contradicting the canonical guidance.
+
+**Expected result**: The docs consistently recommend one external reviewer by
+default while preserving multi-bot support as advanced usage.
+
+### Step 2: Verify Non-Blocking Warning Behavior
+
+**Maps to**: AC-4, AC-5
+
+1. Run:
+
+   ```bash
+   bash scripts/development-workflow/tests/test-workflow-config-resolver.sh
+   ```
+
+2. Confirm the test output includes passing coverage for:
+   - a single-reviewer config with no warning,
+   - multiple draft reviewers with a warning and success exit,
+   - multiple ready reviewers with a warning and success exit.
+
+**Expected result**: Multi-reviewer configurations remain valid and produce only
+non-blocking warnings.
+
+### Step 3: Verify Repository Config Validation
+
+**Maps to**: AC-4, AC-5
+
+1. Run:
+
+   ```bash
+   bash scripts/development-workflow/validate-workflow-config.sh
+   ```
+
+2. Confirm the command exits successfully.
+
+**Expected result**: The repository's current workflow configuration remains
+valid.
+
+### Step 4: Verify Markdown And Changelog Hygiene
+
+**Maps to**: AC-1, AC-2, AC-3
+
+1. Run:
+
+   ```bash
+   npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"
+   ```
+
+2. Run:
+
+   ```bash
+   find docs/specs/developments docs/testing/workflow -name "*.md" -print0 \
+     | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md
+   ```
+
+3. Run:
+
+   ```bash
+   bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md
+   ```
+
+4. Run:
+
+   ```bash
+   git diff --check
+   ```
+
+**Expected result**: Markdown, heuristic, changelog, and whitespace checks pass.
+
+## Assertions Checklist
+
+- [ ] AC-1: External review documentation recommends one external reviewer per
+      repository or product plus internal runner review.
+- [ ] AC-2: Documentation describes multi-bot usage as advanced and names cost,
+      latency, duplicated findings, and conflict trade-offs.
+- [ ] AC-3: Repository-mode or related configuration guidance points to the same
+      recommendation.
+- [ ] AC-4: Multiple external reviewers produce a non-blocking warning when the
+      validator warning is implemented.
+- [ ] AC-5: Existing multi-reviewer configurations remain supported.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| Config resolver tests fail on missing warning | Warning helper is not called from validation path | Confirm `validate_workflow_config` invokes the helper for shared and local config. |
+| Warning appears on stdout | Warning output stream changed | Emit warnings to stderr so existing stdout consumers keep working. |
+| Markdown lint fails on long tables | New prose was added to a table cell | Wrap long guidance in paragraphs instead of wide table cells. |


### PR DESCRIPTION
## Summary

Adds the implementation plan and smoke test runbook for #1117. The plan updates canonical review-platform docs, cross-references repository-mode guidance, adjusts the local config example, and adds a non-blocking workflow-config warning for advanced multi-reviewer setups.

Plan: docs/specs/developments/20260702121239_1117-document-one-external-reviewer-practice/2_1117-document-one-external-reviewer-practice_implementation-plan.md
Runbook: docs/testing/workflow/1117-document-one-external-reviewer-practice.smoke-test.md

## Approach

Complexity: S. Scope is limited to docs, one config example, one existing Python resolver, and resolver shell tests.

## Key Risks

- Warning output must stay on stderr so existing stdout consumers keep working.
- Multi-reviewer support must remain valid; the warning is advisory only.

## Document Quality Gate

- Spec/brief coverage: Checked - all ACs map to implementation steps and smoke coverage.
- Implementation-order consistency: Checked - file list and implementation order agree across sections.
- Verification support: Checked - scope claims cite repo revision and live rg results.
- Behavioral guarantees: Checked - non-blocking behavior is tied to warning-only stderr output and no ConfigError.
- Parser/API/concurrency checklist: Not applicable - no parser-risk, API-surface, snapshot, or concurrent-event signals apply.
- CHANGELOG literal format: Checked - literal uses the required **Bold Title** (#N): format.
- Not-applicable rationale: Checked - no seed data or database changes apply.

Issue: #1117

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime or config behavior changes in the diff.
> 
> **Overview**
> Adds **planning-only** artifacts for #1117: an implementation plan and a smoke-test runbook. No workflow docs, resolver code, or config examples are changed in this diff.
> 
> The plan spells out the intended follow-up work: canonical **one external reviewer** guidance in `pr-review-platform.md`, cross-links from `README.md` and `repository-modes.md`, a single ready-phase reviewer in `.ai-dev-workflow.local.example.yaml`, and **stderr-only** non-blocking warnings in `workflow-config-resolver.py` when `review.on_draft.github` or `review.on_ready.github` lists more than one reviewer (validation still succeeds). It also lists resolver shell-test cases, a planned `CHANGELOG.md` entry, and verification commands.
> 
> The smoke runbook maps acceptance criteria to manual checks (doc wording, resolver tests, `validate-workflow-config.sh`, markdown/changelog lint) and documents troubleshooting for warning stream and validation path issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6df2138a0ca34c55c3f028ddc3c018ab2dca7809. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->