### PR TITLE
feat(review): document external reviewer defaults

### DIFF
--- a/.ai-dev-workflow.local.example.yaml
+++ b/.ai-dev-workflow.local.example.yaml
@@ -32,7 +32,10 @@ product_repos:
 # - set `review.on_draft.runner` to `cursor` while running `/run-work` from
 #   Cursor so Step 7a dispatches the Cursor review agents instead of Codex
 # - override GitHub/App reviewer lists to match the tools available on this
-#   machine, for example PR Agent during draft and Cursor Bugbot after ready
+#   machine; prefer one external reviewer per phase by default, for example
+#   PR Agent during draft and Cursor Bugbot after ready
+# - add multiple external reviewers only as an advanced local choice after
+#   accepting the extra cost, latency, duplicate-finding, and conflict trade-offs
 # - keep `internal_reviewers_unavailable_policy: warn` unless you explicitly
 #   want unavailable local reviewers to hard-fail the gate
 review:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Haystack workflow configuration** (#1116): Added repository-level Haystack
   reviewer settings with validation, override precedence, and stop-rule
   documentation.
+- **External reviewer recommendation** (#1117): Documented the
+  one-external-reviewer default pattern and added non-blocking workflow-config
+  warnings for advanced multi-reviewer setups.
 
 ## [0.35.0] - 2026-07-02
 

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -525,7 +525,12 @@ The expected sequence is:
 GitHub review platforms are declared in `.ai-dev-workflow.yaml` under
 `review.on_draft.github` and `review.on_ready.github`, with matching
 `.ai-dev-workflow.local.yaml` lists taking precedence for local tool/subscription
-differences. The repository helpers that support this loop are:
+differences. Prefer one external reviewer per repository or product plus the
+internal runner review gate; multi-bot external review remains supported as an
+advanced setup with added cost, latency, duplicate-finding, and conflict
+trade-offs. See
+[`integrations/pr-review-platform.md`](integrations/pr-review-platform.md) for
+the canonical guidance. The repository helpers that support this loop are:
 
 - `scripts/development-workflow/pr-review-loop.sh`
 - `scripts/development-workflow/pr-ci-loop.sh`

--- a/docs/workflow/development-workflow/integrations/pr-review-platform.md
+++ b/docs/workflow/development-workflow/integrations/pr-review-platform.md
@@ -17,6 +17,19 @@ Platform-specific setup lives in each platform's own integration doc. See:
 
 Automated PR reviewer tools are **post-push validation**. They do not replace the pre-PR review gate defined in [`REVIEW.md`](../../../../REVIEW.md).
 
+### Recommended Reviewer Count
+
+The recommended default is **one external automated reviewer per repository or
+product**, paired with the runner's internal review gate. The internal review
+gate handles workflow-contract review before the hosted or CLI reviewer checks
+the pushed PR.
+
+Multi-bot external review remains supported, but treat it as advanced usage.
+Each additional external reviewer can increase vendor or runner cost, add review
+latency, duplicate findings, and produce conflicting advice that needs explicit
+disposition. Use multiple external reviewers only when the repository or product
+has a clear reason to pay those coordination costs.
+
 Default policy is **sequential gating**:
 
 - Configure reviewer tools in a fixed order
@@ -94,6 +107,11 @@ passed. Matching lists in `.ai-dev-workflow.local.yaml` replace the shared
 tool/subscription differences. If the effective config is absent, or if both
 effective lists are omitted or empty, no reviewer tool runs and the result is
 skipped. Explicit `--platform` flags always override the config file.
+
+Keep each GitHub/App reviewer list to one external reviewer by default. The
+workflow configuration validator may emit a non-blocking warning when a phase
+lists more than one external reviewer, but multi-reviewer lists remain valid for
+advanced setups.
 
 `review.on_ready.github` is optional. Platforms listed there run only after
 draft GitHub reviewers are clean and the PR has been converted with

--- a/docs/workflow/development-workflow/repository-modes.md
+++ b/docs/workflow/development-workflow/repository-modes.md
@@ -121,6 +121,10 @@ In `workflow_hub` mode:
 - Reviewer-loop wrappers remain thin: they pass repository context through to
   shared scripts/helpers and do not implement independent product repository
   selection rules.
+- External reviewer configuration follows the same default in every repository
+  mode: one external reviewer per repository or product plus internal runner
+  review. Multi-bot external review remains valid as an advanced setup; see
+  [`integrations/pr-review-platform.md`](integrations/pr-review-platform.md).
 
 If product repository context is missing or ambiguous for mutation-oriented
 work, the agent must stop before modifying files, creating branches, committing,

--- a/scripts/development-workflow/tests/test-workflow-config-resolver.sh
+++ b/scripts/development-workflow/tests/test-workflow-config-resolver.sh
@@ -131,6 +131,65 @@ run_fails_contains \
   "--repo-root requires a value" \
   bash "$VALIDATOR" --repo-root
 
+single_external_reviewer_dir="$(fixture_dir single-external-reviewer)"
+cat > "$single_external_reviewer_dir/.ai-dev-workflow.yaml" <<'YAML'
+review:
+  on_draft:
+    github:
+      - pr-agent
+  on_ready:
+    github:
+      - bugbot
+YAML
+single_external_stdout="$TMP_ROOT/single-external.stdout"
+single_external_stderr="$TMP_ROOT/single-external.stderr"
+if bash "$VALIDATOR" --repo-root "$single_external_reviewer_dir" >"$single_external_stdout" 2>"$single_external_stderr"; then
+  run_contains "single_external_reviewer_validates" "TARGET_REPO_NAME=single-external-reviewer" "$(cat "$single_external_stdout")"
+  run_test "single_external_reviewer_no_warning" "" "$(cat "$single_external_stderr")"
+else
+  echo "FAIL: single_external_reviewer_validates - validator exited non-zero"
+  cat "$single_external_stderr"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+multi_draft_reviewer_dir="$(fixture_dir multi-draft-reviewers)"
+cat > "$multi_draft_reviewer_dir/.ai-dev-workflow.yaml" <<'YAML'
+review:
+  on_draft:
+    github:
+      - pr-agent
+      - bugbot
+YAML
+multi_draft_stdout="$TMP_ROOT/multi-draft.stdout"
+multi_draft_stderr="$TMP_ROOT/multi-draft.stderr"
+if bash "$VALIDATOR" --repo-root "$multi_draft_reviewer_dir" >"$multi_draft_stdout" 2>"$multi_draft_stderr"; then
+  run_contains "multi_draft_reviewers_still_valid" "TARGET_REPO_NAME=multi-draft-reviewers" "$(cat "$multi_draft_stdout")"
+  run_contains "multi_draft_reviewers_warn" "review.on_draft.github lists 2 external reviewers" "$(cat "$multi_draft_stderr")"
+else
+  echo "FAIL: multi_draft_reviewers_still_valid - validator exited non-zero"
+  cat "$multi_draft_stderr"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+multi_ready_reviewer_dir="$(fixture_dir multi-ready-reviewers)"
+cat > "$multi_ready_reviewer_dir/.ai-dev-workflow.local.yaml" <<'YAML'
+review:
+  on_ready:
+    github:
+      - haystack
+      - bugbot
+YAML
+multi_ready_stdout="$TMP_ROOT/multi-ready.stdout"
+multi_ready_stderr="$TMP_ROOT/multi-ready.stderr"
+if bash "$VALIDATOR" --repo-root "$multi_ready_reviewer_dir" >"$multi_ready_stdout" 2>"$multi_ready_stderr"; then
+  run_contains "multi_ready_reviewers_still_valid" "TARGET_REPO_NAME=multi-ready-reviewers" "$(cat "$multi_ready_stdout")"
+  run_contains "multi_ready_reviewers_warn" "review.on_ready.github lists 2 external reviewers" "$(cat "$multi_ready_stderr")"
+else
+  echo "FAIL: multi_ready_reviewers_still_valid - validator exited non-zero"
+  cat "$multi_ready_stderr"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
 hub_dir="$(fixture_dir workflow-hub)"
 cat > "$hub_dir/.ai-dev-workflow.yaml" <<'YAML'
 schema_version: 2

--- a/scripts/development-workflow/tests/test-workflow-config-resolver.sh
+++ b/scripts/development-workflow/tests/test-workflow-config-resolver.sh
@@ -190,6 +190,31 @@ else
   FAIL_COUNT=$((FAIL_COUNT + 1))
 fi
 
+local_override_single_reviewer_dir="$(fixture_dir local-override-single-reviewer)"
+cat > "$local_override_single_reviewer_dir/.ai-dev-workflow.yaml" <<'YAML'
+review:
+  on_ready:
+    github:
+      - haystack
+      - bugbot
+YAML
+cat > "$local_override_single_reviewer_dir/.ai-dev-workflow.local.yaml" <<'YAML'
+review:
+  on_ready:
+    github:
+      - bugbot
+YAML
+local_override_stdout="$TMP_ROOT/local-override-single.stdout"
+local_override_stderr="$TMP_ROOT/local-override-single.stderr"
+if bash "$VALIDATOR" --repo-root "$local_override_single_reviewer_dir" >"$local_override_stdout" 2>"$local_override_stderr"; then
+  run_contains "local_override_single_reviewer_validates" "TARGET_REPO_NAME=local-override-single-reviewer" "$(cat "$local_override_stdout")"
+  run_test "local_override_single_reviewer_no_warning" "" "$(cat "$local_override_stderr")"
+else
+  echo "FAIL: local_override_single_reviewer_validates - validator exited non-zero"
+  cat "$local_override_stderr"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
 hub_dir="$(fixture_dir workflow-hub)"
 cat > "$hub_dir/.ai-dev-workflow.yaml" <<'YAML'
 schema_version: 2

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -333,6 +333,25 @@ def raw_haystack_config(config: dict[str, Any], path: Path) -> dict[str, Any]:
     return as_mapping(review.get("haystack"), path, "review.haystack")
 
 
+def warn_on_multiple_external_reviewers(config: dict[str, Any], path: Path) -> None:
+    if "review" not in config:
+        return
+    review = as_mapping(config.get("review"), path, "review")
+    for phase in ("on_draft", "on_ready"):
+        if phase not in review:
+            continue
+        phase_config = as_mapping(review.get(phase), path, f"review.{phase}")
+        reviewers = as_list(phase_config.get("github"), path, f"review.{phase}.github")
+        if len(reviewers) > 1:
+            print(
+                "WARNING: "
+                f"{path}: review.{phase}.github lists {len(reviewers)} external reviewers; "
+                "one external reviewer per phase is recommended by default. "
+                "Multi-bot review remains supported as advanced usage.",
+                file=sys.stderr,
+            )
+
+
 def normalize_haystack_config(config: dict[str, Any], path: Path) -> dict[str, str]:
     haystack = raw_haystack_config(config, path)
     if not haystack:
@@ -388,6 +407,8 @@ def normalize_haystack_config(config: dict[str, Any], path: Path) -> dict[str, s
 def validate_workflow_config(shared: dict[str, Any], local: dict[str, Any], shared_path: Path, local_path: Path) -> None:
     normalize_haystack_config(shared, shared_path)
     normalize_haystack_config(local, local_path)
+    warn_on_multiple_external_reviewers(shared, shared_path)
+    warn_on_multiple_external_reviewers(local, local_path)
 
 
 def product_repos(shared: dict[str, Any], shared_path: Path) -> list[dict[str, Any]]:

--- a/scripts/development-workflow/workflow-config-resolver.py
+++ b/scripts/development-workflow/workflow-config-resolver.py
@@ -333,19 +333,34 @@ def raw_haystack_config(config: dict[str, Any], path: Path) -> dict[str, Any]:
     return as_mapping(review.get("haystack"), path, "review.haystack")
 
 
-def warn_on_multiple_external_reviewers(config: dict[str, Any], path: Path) -> None:
+def external_reviewers_for_phase(
+    config: dict[str, Any], path: Path, phase: str
+) -> tuple[list[Any], Path] | None:
     if "review" not in config:
-        return
+        return None
     review = as_mapping(config.get("review"), path, "review")
+    if phase not in review:
+        return None
+    phase_config = as_mapping(review.get(phase), path, f"review.{phase}")
+    if "github" not in phase_config:
+        return None
+    return as_list(phase_config.get("github"), path, f"review.{phase}.github"), path
+
+
+def warn_on_multiple_external_reviewers(
+    shared: dict[str, Any], local: dict[str, Any], shared_path: Path, local_path: Path
+) -> None:
     for phase in ("on_draft", "on_ready"):
-        if phase not in review:
+        effective = external_reviewers_for_phase(local, local_path, phase)
+        if effective is None:
+            effective = external_reviewers_for_phase(shared, shared_path, phase)
+        if effective is None:
             continue
-        phase_config = as_mapping(review.get(phase), path, f"review.{phase}")
-        reviewers = as_list(phase_config.get("github"), path, f"review.{phase}.github")
+        reviewers, source_path = effective
         if len(reviewers) > 1:
             print(
                 "WARNING: "
-                f"{path}: review.{phase}.github lists {len(reviewers)} external reviewers; "
+                f"{source_path}: review.{phase}.github lists {len(reviewers)} external reviewers; "
                 "one external reviewer per phase is recommended by default. "
                 "Multi-bot review remains supported as advanced usage.",
                 file=sys.stderr,
@@ -407,8 +422,7 @@ def normalize_haystack_config(config: dict[str, Any], path: Path) -> dict[str, s
 def validate_workflow_config(shared: dict[str, Any], local: dict[str, Any], shared_path: Path, local_path: Path) -> None:
     normalize_haystack_config(shared, shared_path)
     normalize_haystack_config(local, local_path)
-    warn_on_multiple_external_reviewers(shared, shared_path)
-    warn_on_multiple_external_reviewers(local, local_path)
+    warn_on_multiple_external_reviewers(shared, local, shared_path, local_path)
 
 
 def product_repos(shared: dict[str, Any], shared_path: Path) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

Implements #1117 by documenting the one-external-reviewer default pattern, cross-linking that guidance from workflow docs, updating the local config example, and adding non-blocking config warnings for advanced multi-reviewer setups.

Spec: docs/specs/developments/20260702121239_1117-document-one-external-reviewer-practice/1_1117-document-one-external-reviewer-practice_specs.md
Plan: docs/specs/developments/20260702121239_1117-document-one-external-reviewer-practice/2_1117-document-one-external-reviewer-practice_implementation-plan.md
Runbook: docs/testing/workflow/1117-document-one-external-reviewer-practice.smoke-test.md

## Test Plan

- `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`
- `bash scripts/development-workflow/validate-workflow-config.sh`
- `shellcheck --severity=warning -x scripts/development-workflow/tests/test-workflow-config-resolver.sh scripts/development-workflow/validate-workflow-config.sh`
- `python3 -m py_compile scripts/development-workflow/workflow-config-resolver.py`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`

## Deviations

None.

## CHANGELOG Preview

- **External reviewer recommendation** (#1117): Documented the one-external-reviewer default pattern and added non-blocking workflow-config warnings for advanced multi-reviewer setups.

## Pre-Submission Self-Review

Stale markers: none. Caller/config consistency: verified `review.on_draft.github` and `review.on_ready.github` docs, example config, resolver validation, and resolver tests are aligned. Coverage: all #1117 acceptance criteria are addressed, including continued multi-reviewer support and warning-only behavior.

Issue: #1117

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and advisory warnings only; multi-reviewer YAML remains valid and the review loop behavior is unchanged.
> 
> **Overview**
> Codifies **one external automated reviewer per repository/product** (plus the internal runner review gate) as the recommended default, with multi-bot setups called out as advanced due to cost, latency, duplicates, and conflicting advice.
> 
> **Docs and examples** — `pr-review-platform.md` gets a dedicated “Recommended Reviewer Count” section; the development workflow README, repository-modes doc, and `.ai-dev-workflow.local.example.yaml` comments are aligned and cross-linked.
> 
> **Validator behavior** — `workflow-config-resolver.py` now warns on stderr when the effective `review.on_draft.github` or `review.on_ready.github` list (local override wins) has more than one entry; validation still succeeds. Tests in `test-workflow-config-resolver.sh` cover single-reviewer silence, multi-reviewer warnings, and local override back to one reviewer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ced0b6cc1bbf6facb8b10cae9ef424ff7512805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->