### PR TITLE
feat(review): unify advisory findings contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **External reviewer recommendation** (#1117): Documented the
   one-external-reviewer default pattern and added non-blocking workflow-config
   warnings for advanced multi-reviewer setups.
+- **Unify advisory contract** (#1118): Added a provider-agnostic reviewer
+  advisory contract while preserving transition aliases.
 
 ## [0.35.0] - 2026-07-02
 

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -145,18 +145,23 @@ machine-readable finding arrays when Haystack triage returns a completed review
 result:
 
 ```text
-ADVISORY_FINDINGS_JSON=[{"severity":"advisory","category":"Minor","summary":"...","detail":"..."}]
+ADVISORY_FINDINGS=[{"source":"haystack","severity":"advisory","category":"Minor","summary":"...","detail":"..."}]
+ADVISORY_FINDINGS_JSON=[{"source":"haystack","severity":"advisory","category":"Minor","summary":"...","detail":"..."}]
 BLOCKING_FINDINGS_JSON=[{"severity":"blocking","category":"Logic error","summary":"...","detail":"..."}]
 ```
 
-These fields are compact single-line JSON arrays. Consumers should parse the
-substring after the first `=` as JSON; do not split array contents on spaces,
-commas, pipes, or additional equals signs.
+`ADVISORY_FINDINGS` is the canonical provider-agnostic advisory contract defined
+in [`pr-review-platform.md`](pr-review-platform.md). `ADVISORY_FINDINGS_JSON` is
+a deprecated compatibility alias retained for one transition release. These
+fields are compact single-line JSON arrays. Consumers should parse the substring
+after the first `=` as JSON; do not split array contents on spaces, commas,
+pipes, or additional equals signs.
 
 Each finding object includes these required fields:
 
 | Field | Description |
 | ----- | ----------- |
+| `source` | Always `haystack` for findings emitted by this wrapper. |
 | `severity` | Normalized workflow severity: `advisory` or `blocking`. |
 | `category` | Haystack category string, or `__UNKNOWN__` when Haystack omitted the category. |
 | `summary` | Short finding summary from `.summary`, `.title`, or `.message`; empty string when Haystack omitted compatible text. |
@@ -177,7 +182,8 @@ data:
 The structured arrays are derived from the same classification pass as
 `BLOCKING_COUNT` and `SUGGESTION_COUNT`, so counts and array lengths should
 match. Existing consumers may continue to rely only on `RESULT`,
-`BLOCKING_COUNT`, `SUGGESTION_COUNT`, and `COMMENT_COUNT`.
+`BLOCKING_COUNT`, `SUGGESTION_COUNT`, and `COMMENT_COUNT`, but new consumers
+should read `ADVISORY_FINDINGS` instead of provider-specific aliases.
 
 When `haystack pr-status --json` returns parseable JSON but a required policy
 field cannot be read, the reviewer fails closed with

--- a/docs/workflow/development-workflow/integrations/pr-review-platform.md
+++ b/docs/workflow/development-workflow/integrations/pr-review-platform.md
@@ -78,6 +78,55 @@ Additional rules:
 
 ---
 
+## Advisory Findings Contract
+
+`ADVISORY_FINDINGS` is the canonical provider-agnostic contract for non-blocking
+automated reviewer findings. Platform wrappers emit it as a compact single-line
+JSON array in their key-value stdout:
+
+```text
+ADVISORY_FINDINGS=[{"source":"haystack","category":"Minor","summary":"..."}]
+```
+
+Consumers must parse the substring after the first `=` as JSON. Do not split the
+JSON value on spaces, commas, pipes, or additional equals signs.
+
+Each advisory finding object includes these required fields:
+
+| Field | Description |
+| ----- | ----------- |
+| `source` | Stable review platform id, such as `pr-agent` or `haystack`. |
+| `category` | Provider category, label, or `Advisory` when the provider has no category. |
+| `summary` | Short human-readable advisory summary. |
+
+Finding objects may include these optional fields when the platform exposes
+them:
+
+| Field | Description |
+| ----- | ----------- |
+| `detail` | Longer reviewer detail or rationale. |
+| `url` | Link to the source review comment or finding. |
+| `path` | File path associated with the finding. |
+| `line` | Line number associated with the finding. |
+| `fix_hint` | Provider-supplied fix suggestion. |
+| `disposition` | Workflow disposition metadata, such as `known-false-positive`. |
+| `disposition_rule` | Stable rule id that produced the disposition. |
+| `disposition_rationale` | Human-readable disposition rationale. |
+
+`pr-review-loop.sh` aggregates platform-level `ADVISORY_FINDINGS` arrays and
+emits a final aggregate `ADVISORY_FINDINGS` value. Summary comments render from
+that unified list. `ADVISORY_DISPOSITION_REQUIRED=1` remains the preferred
+boolean trigger for advisory disposition work on clean exits.
+
+Transition aliases:
+
+- `ADVISORY_LABELS` remains a deprecated PR-Agent compatibility alias for one
+  transition release.
+- `ADVISORY_FINDINGS_JSON` remains a deprecated Haystack compatibility alias for
+  one transition release.
+
+---
+
 ## Platform Configuration
 
 The active review platforms for a repository are declared in `.ai-dev-workflow.yaml` at the repo root:

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -648,14 +648,17 @@ the normal merge gates: any net-new blocker still follows the standard
 
 ### PR-Agent "Possible Issue" advisory labels
 
-When `pr-review-loop.sh` returns `RESULT=clean` and the output contains an
-`ADVISORY_LABELS` key with `Possible Issue` entries, PR-Agent flagged advisory
-concerns but no hard-blocker labels. **No orchestrator action is required.**
+When `pr-review-loop.sh` returns `RESULT=clean` and the output contains
+`ADVISORY_FINDINGS` entries sourced from PR-Agent, PR-Agent flagged advisory
+concerns but no hard-blocker labels. `ADVISORY_LABELS` remains a deprecated
+compatibility alias for one transition release. **No orchestrator action is
+required.**
 
 `Possible Issue` findings are automatically acknowledged by the script and the loop
-exits clean. The advisory label is recorded in `ADVISORY_LABELS`. Do not dispatch a
-code-reviewer agent or re-invoke the loop because of these labels. Continue to record
-advisory dispositions in the post-clean summary flow defined below.
+exits clean. The advisory is recorded in the unified `ADVISORY_FINDINGS` list.
+Do not dispatch a code-reviewer agent or re-invoke the loop because of these
+findings. Continue to record advisory dispositions in the post-clean summary
+flow defined below.
 
 ---
 
@@ -671,23 +674,24 @@ this finding" and "here is why it was or was not addressed."
 Any clean exit where one or more of these signals is present:
 
 - `ADVISORY_DISPOSITION_REQUIRED=1`
+- `ADVISORY_FINDINGS` is a non-empty JSON array
 - `SUGGESTION_COUNT` is greater than zero
 - `POLICY_REVIEW_REQUIRED=1`
 - `ADVISORY_LABELS` is non-empty
 
 `ADVISORY_DISPOSITION_REQUIRED=1` is the preferred aggregate signal for new
-callers. The other fields remain valid fallback triggers for older script
-versions and for humans inspecting raw platform output.
+callers. `ADVISORY_FINDINGS` is the canonical advisory details source. The
+other fields remain valid fallback triggers for older script versions and for
+humans inspecting raw platform output.
 
 #### Procedure
 
 1. **For each advisory finding** listed in the "Advisory findings" section of
    the Automated Reviewer Loop Summary comment, review the available finding
-   context. PR-Agent advisory labels link to the source PR comment. Haystack
-   structured advisory entries include category, summary, detail, optional
-   source location, and optional fix hint directly in the summary. Policy-review
-   required entries include the policy handoff metadata available from the
-   reviewer output.
+   context. `ADVISORY_FINDINGS` entries include source, category, summary, and
+   optional URL, detail, source location, fix hint, and disposition metadata.
+   Policy-review required entries include the policy handoff metadata available
+   from the reviewer output.
 
 2. **Determine the disposition** — choose one per finding:
    - **Addressed** — the finding describes a real issue that was fixed in this PR. Cite the commit SHA.
@@ -793,9 +797,10 @@ before escalating:
      --max-wait 600
    ```
 
-   Treat `RESULT`, `BLOCKING_COUNT`, `SUGGESTION_COUNT`, and any
-   `ADVISORY_LABELS`/`POSSIBLE_ISSUE_EVAL_OUTCOME` lines as the authoritative
-   classification for this pass. Do not attempt to quote or paraphrase the PR-Agent
+   Treat `RESULT`, `BLOCKING_COUNT`, `SUGGESTION_COUNT`,
+   `ADVISORY_FINDINGS`, and any `POSSIBLE_ISSUE_EVAL_OUTCOME` lines as the
+   authoritative classification for this pass. `ADVISORY_LABELS` remains a
+   transition fallback only. Do not attempt to quote or paraphrase the PR-Agent
    body if the classifier blocked body access.
 
 2. If a traceable URL is needed, fetch metadata without printing the review body:

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -23,7 +23,8 @@
 #   BLOCKING_COUNT=<n>
 #   SUGGESTION_COUNT=<n>
 #   COMMENT_COUNT=<n>
-#   ADVISORY_FINDINGS_JSON=<json-array> (present for completed reviews)
+#   ADVISORY_FINDINGS=<json-array> (present for completed reviews)
+#   ADVISORY_FINDINGS_JSON=<json-array> (deprecated compatibility alias)
 #   BLOCKING_FINDINGS_JSON=<json-array> (present for completed reviews)
 #   DISPLAY_RESULT=<value> (optional; used by pr-review-loop.sh summaries)
 #   POLICY_REVIEW_REQUIRED=0|1 (optional; present when pr-status is available)
@@ -762,6 +763,7 @@ NORMALIZED_FINDINGS_JSON="$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -c \
     else
       $finding
       + {
+          source: "haystack",
           severity: "advisory",
           disposition: "known-false-positive",
           disposition_rule: ($rule.id // ""),
@@ -777,6 +779,7 @@ NORMALIZED_FINDINGS_JSON="$(printf '%s\n' "$TRIAGE_OUTPUT" | jq -c \
     (first_line([.source.line?, .source.startLine?, .line?, .startLine?]) // null) as $line |
     (first_string([.agentFixPrompt?, .fixPrompt?, .suggestion?]) // null) as $fix_hint |
     {
+      source: "haystack",
       severity: $severity,
       category: $category,
       summary: $summary,
@@ -940,6 +943,7 @@ if [ "$PR_STATUS_CHECK" != "0" ]; then
       printf 'BLOCKING_COUNT=%d\n' "$POLICY_BLOCKING_COUNT"
       printf 'SUGGESTION_COUNT=%d\n' "$SUGGESTION_COUNT"
       printf 'COMMENT_COUNT=%d\n' "$POLICY_COMMENT_COUNT"
+      printf 'ADVISORY_FINDINGS=%s\n' "$ADVISORY_FINDINGS_JSON"
       printf 'ADVISORY_FINDINGS_JSON=%s\n' "$ADVISORY_FINDINGS_JSON"
       printf 'BLOCKING_FINDINGS_JSON=%s\n' "$POLICY_BLOCKING_FINDINGS_JSON"
       printf 'POLICY_STATUS_AVAILABLE=0\n'
@@ -971,6 +975,7 @@ if [ "$BLOCKING_COUNT" -gt 0 ]; then
   printf 'BLOCKING_COUNT=%d\n' "$BLOCKING_COUNT"
   printf 'SUGGESTION_COUNT=%d\n' "$SUGGESTION_COUNT"
   printf 'COMMENT_COUNT=%d\n' "$COMMENT_COUNT"
+  printf 'ADVISORY_FINDINGS=%s\n' "$ADVISORY_FINDINGS_JSON"
   printf 'ADVISORY_FINDINGS_JSON=%s\n' "$ADVISORY_FINDINGS_JSON"
   printf 'BLOCKING_FINDINGS_JSON=%s\n' "$BLOCKING_FINDINGS_JSON"
   printf 'POLICY_STATUS_AVAILABLE=%d\n' "$POLICY_STATUS_AVAILABLE"
@@ -989,6 +994,7 @@ printf 'RESULT=clean\n'
 printf 'BLOCKING_COUNT=0\n'
 printf 'SUGGESTION_COUNT=%d\n' "$SUGGESTION_COUNT"
 printf 'COMMENT_COUNT=%d\n' "$COMMENT_COUNT"
+printf 'ADVISORY_FINDINGS=%s\n' "$ADVISORY_FINDINGS_JSON"
 printf 'ADVISORY_FINDINGS_JSON=%s\n' "$ADVISORY_FINDINGS_JSON"
 printf 'BLOCKING_FINDINGS_JSON=%s\n' "$BLOCKING_FINDINGS_JSON"
 printf 'POLICY_STATUS_AVAILABLE=%d\n' "$POLICY_STATUS_AVAILABLE"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -444,6 +444,31 @@ compact_advisory_findings_json() {
   printf '%s\n' "$raw_json" | jq -c 'if type == "array" then . else error("expected advisory finding array") end'
 }
 
+normalize_advisory_findings_json() {
+  local raw_json="$1"
+  local default_source="$2"
+  printf '%s\n' "$raw_json" | jq -c --arg source "$default_source" '
+    if type != "array" then
+      error("expected advisory finding array")
+    else
+      map(
+        if type == "object" then . else {summary: (.|tostring)} end
+        | .source = ((.source // $source) | tostring)
+        | .category = ((.category // "Advisory") | tostring)
+        | .summary = ((.summary // .message // .category // "Advisory finding") | tostring)
+      )
+    end
+  '
+}
+
+combine_advisory_findings_jsons() {
+  if [ "$#" -eq 0 ]; then
+    printf '[]'
+    return 0
+  fi
+  printf '%s\n' "$@" | jq -s -c 'add'
+}
+
 is_nonnegative_int() {
   case "${1:-}" in
     ''|*[!0-9]*) return 1 ;;
@@ -456,6 +481,7 @@ advisory_disposition_required_for_platform() {
   local suggestion_count="${2:-0}"
   local policy_review_required="${3:-0}"
   local advisory_labels="${4:-}"
+  local advisory_findings_json="${5:-}"
 
   [ "$result" = "clean" ] || return 1
   if is_nonnegative_int "$suggestion_count" && [ "$suggestion_count" -gt 0 ]; then
@@ -463,6 +489,10 @@ advisory_disposition_required_for_platform() {
   fi
   [ "$policy_review_required" = "1" ] && return 0
   [ -n "$advisory_labels" ] && return 0
+  if [ -n "$advisory_findings_json" ] \
+      && [ "$(printf '%s\n' "$advisory_findings_json" | jq 'if type == "array" then length else 0 end' 2>/dev/null || printf 0)" -gt 0 ]; then
+    return 0
+  fi
   return 1
 }
 
@@ -476,7 +506,7 @@ render_structured_advisory_entries() {
       | gsub("\\r?\\n"; " ")
       | gsub("[[:space:]][[:space:]]+"; " ");
     .[] |
-      "- " + $platform + ": " + ((.category // "Advisory") | one_line) + " - " + ((.summary // .message // "Advisory finding") | one_line),
+      "- " + ((.source // $platform) | one_line) + ": " + ((.category // "Advisory") | one_line) + " - " + ((.summary // .message // "Advisory finding") | one_line),
       (if ((.disposition // "") == "known-false-positive") then
         "  Disposition: Known false positive" +
         (if (((.disposition_rule // "") | tostring | length) > 0) then " (`" + ((.disposition_rule // "") | one_line) + "`)" else "" end) +
@@ -2164,6 +2194,7 @@ run_haystack_review() {
       print_kv BLOCKING_COUNT 0
       print_kv SUGGESTION_COUNT "$suggestion_count"
       for _haystack_field in \
+        ADVISORY_FINDINGS \
         ADVISORY_FINDINGS_JSON \
         BLOCKING_FINDINGS_JSON \
         POLICY_STATUS_AVAILABLE \
@@ -2197,6 +2228,7 @@ run_haystack_review() {
       print_kv BLOCKING_COUNT "$blocking_count"
       print_kv SUGGESTION_COUNT "$suggestion_count"
       for _haystack_field in \
+        ADVISORY_FINDINGS \
         ADVISORY_FINDINGS_JSON \
         BLOCKING_FINDINGS_JSON \
         POLICY_STATUS_AVAILABLE \
@@ -2943,6 +2975,23 @@ _EXTRACT_POSSIBLE_ISSUE_LABELS_
     printf '%s' "$result"
   }
 
+  _pr_agent_advisory_findings_json() {
+    local advisory_labels="$1"
+    local comment_url="${2:-}"
+    local labels_normalized
+    labels_normalized="$(printf '%s' "$advisory_labels" | tr '|' '\n')"
+    jq -R -s -c --arg source "pr-agent" --arg url "$comment_url" '
+      split("\n")
+      | map(select(length > 0))
+      | map(
+          {source: $source, category: ., summary: .}
+          + (if ($url | length) > 0 then {url: $url} else {} end)
+        )
+    ' <<_PR_AGENT_ADVISORY_FINDINGS_
+$labels_normalized
+_PR_AGENT_ADVISORY_FINDINGS_
+  }
+
   # Evaluate "Possible Issue" advisory labels found in a PR-Agent clean result.
   # "Possible Issue" findings are always treated as acknowledged without dispatching
   # a code-reviewer agent. In practice these findings have never been real blockers
@@ -3030,13 +3079,15 @@ _PR_AGENT_LABELS_
 
   case "$verdict" in
     clean)
-      local _advisory_labels _comment_url _advisory_entry _eval_status
+      local _advisory_labels _comment_url _advisory_entry _advisory_findings_json _eval_status
       _advisory_labels="$(_pr_agent_extract_advisory_labels "$comment_body")"
       if [ -n "$_advisory_labels" ]; then
         _comment_url="$(_pr_agent_latest_comment_url strict_sha)"
         _advisory_entry="${_advisory_labels}@@@${_comment_url}"
+        _advisory_findings_json="$(_pr_agent_advisory_findings_json "$_advisory_labels" "$_comment_url")"
       else
         _advisory_entry=""
+        _advisory_findings_json=""
       fi
       # Evaluate any "Possible Issue" advisory labels before emitting clean.
       _eval_status=0
@@ -3053,6 +3104,7 @@ _PR_AGENT_LABELS_
         print_kv COMMENT_COUNT 0
         print_kv BLOCKING_COUNT 0
         print_kv SUGGESTION_COUNT 0
+        [ -n "$_advisory_findings_json" ] && print_kv ADVISORY_FINDINGS "$_advisory_findings_json"
         [ -n "$_advisory_entry" ] && print_kv ADVISORY_LABELS "$_advisory_entry"
         return 3
       fi
@@ -3065,6 +3117,7 @@ _PR_AGENT_LABELS_
       print_kv COMMENT_COUNT 0
       print_kv BLOCKING_COUNT 0
       print_kv SUGGESTION_COUNT 0
+      [ -n "$_advisory_findings_json" ] && print_kv ADVISORY_FINDINGS "$_advisory_findings_json"
       [ -n "$_advisory_entry" ] && print_kv ADVISORY_LABELS "$_advisory_entry"
       return 0
       ;;
@@ -3140,13 +3193,15 @@ _PR_AGENT_LABELS_
   # --- Phase 3: Classify the comment body ---
   case "$verdict" in
     clean)
-      local _advisory_labels _comment_url _advisory_entry _eval_status
+      local _advisory_labels _comment_url _advisory_entry _advisory_findings_json _eval_status
       _advisory_labels="$(_pr_agent_extract_advisory_labels "$comment_body")"
       if [ -n "$_advisory_labels" ]; then
         _comment_url="$(_pr_agent_latest_comment_url recent_or_sha)"
         _advisory_entry="${_advisory_labels}@@@${_comment_url}"
+        _advisory_findings_json="$(_pr_agent_advisory_findings_json "$_advisory_labels" "$_comment_url")"
       else
         _advisory_entry=""
+        _advisory_findings_json=""
       fi
       # Evaluate any "Possible Issue" advisory labels before emitting clean.
       _eval_status=0
@@ -3163,6 +3218,7 @@ _PR_AGENT_LABELS_
         print_kv COMMENT_COUNT 0
         print_kv BLOCKING_COUNT 0
         print_kv SUGGESTION_COUNT 0
+        [ -n "$_advisory_findings_json" ] && print_kv ADVISORY_FINDINGS "$_advisory_findings_json"
         [ -n "$_advisory_entry" ] && print_kv ADVISORY_LABELS "$_advisory_entry"
         return 3
       fi
@@ -3175,6 +3231,7 @@ _PR_AGENT_LABELS_
       print_kv COMMENT_COUNT 0
       print_kv BLOCKING_COUNT 0
       print_kv SUGGESTION_COUNT 0
+      [ -n "$_advisory_findings_json" ] && print_kv ADVISORY_FINDINGS "$_advisory_findings_json"
       [ -n "$_advisory_entry" ] && print_kv ADVISORY_LABELS "$_advisory_entry"
       return 0
       ;;
@@ -5490,7 +5547,11 @@ for index in "${!platforms[@]}"; do
   platform_blocking_count="$(kv_value_default BLOCKING_COUNT "$platform_output" 0)"
   platform_suggestion_count="$(kv_value_default SUGGESTION_COUNT "$platform_output" 0)"
   platform_advisory_labels="$(kv_value_default ADVISORY_LABELS "$platform_output" "")"
-  platform_advisory_findings_json="$(kv_value_default ADVISORY_FINDINGS_JSON "$platform_output" "")"
+  platform_advisory_findings_json="$(kv_value_default ADVISORY_FINDINGS "$platform_output" "")"
+  if [ -z "$platform_advisory_findings_json" ]; then
+    platform_advisory_findings_json="$(kv_value_default ADVISORY_FINDINGS_JSON "$platform_output" "")"
+  fi
+  platform_advisory_findings_compact=""
   platform_policy_review_required="$(kv_value_default POLICY_REVIEW_REQUIRED "$platform_output" 0)"
   platform_reason="$(kv_value_default REASON "$platform_output" "")"
   if reviewer_failed_label_required_for_result "$platform_result" "$platform_reason"; then
@@ -5519,16 +5580,9 @@ for index in "${!platforms[@]}"; do
       aggregate_advisory_labels="$platform_advisory_labels"
     fi
   fi
-  if advisory_disposition_required_for_platform \
-      "$platform_result" "$platform_suggestion_count" "$platform_policy_review_required" "$platform_advisory_labels"; then
-    advisory_disposition_required=1
-  fi
-  if [ "$platform_result" = "clean" ] && [ "$platform_policy_review_required" = "1" ]; then
-    policy_review_disposition_required=1
-  fi
   last_platform="$platform_name"
   if [ -n "$platform_advisory_findings_json" ]; then
-    if ! platform_advisory_findings_compact="$(compact_advisory_findings_json "$platform_advisory_findings_json" 2>/dev/null)"; then
+    if ! platform_advisory_findings_compact="$(normalize_advisory_findings_json "$platform_advisory_findings_json" "$platform_name" 2>/dev/null)"; then
       aggregate_result="escalate"
       aggregate_reason="advisory_json_parse_failed"
       aggregate_output="$platform_output"
@@ -5541,6 +5595,14 @@ for index in "${!platforms[@]}"; do
       aggregate_advisory_findings_platforms+=("$platform_name")
       aggregate_advisory_findings_jsons+=("$platform_advisory_findings_compact")
     fi
+  fi
+  if advisory_disposition_required_for_platform \
+      "$platform_result" "$platform_suggestion_count" "$platform_policy_review_required" \
+      "$platform_advisory_labels" "$platform_advisory_findings_compact"; then
+    advisory_disposition_required=1
+  fi
+  if [ "$platform_result" = "clean" ] && [ "$platform_policy_review_required" = "1" ]; then
+    policy_review_disposition_required=1
   fi
 
   print_kv "PLATFORM_${platform_index}_NAME" "$platform_name"
@@ -5746,7 +5808,7 @@ _post_review_summary() {
 
 **Advisory findings (non-blocking):**"
   fi
-  if [ -n "$advisory_labels" ]; then
+  if [ -n "$advisory_labels" ] && [ "$structured_advisory_count" -eq 0 ]; then
     # Split entries by ||| separator using sed (IFS does not support multi-char
     # separators). Each entry has the form "<pipe-delimited labels>@@@<url>".
     local _entries_normalized
@@ -5774,26 +5836,6 @@ _ADVISORY_LABEL_LINES_
     done <<_ADVISORY_ENTRY_LINES_
 $_entries_normalized
 _ADVISORY_ENTRY_LINES_
-    # Append "Possible Issue" evaluation outcome when available.
-    if [ -n "$possible_issue_eval_outcome" ]; then
-      local _eval_note
-      case "$possible_issue_eval_outcome" in
-        acknowledged)
-          _eval_note="Auto-acknowledged: Possible Issue is advisory-only — loop proceeded clean"
-          ;;
-        fix_pushed)
-          _eval_note="Evaluated by code-reviewer: fix pushed — loop re-ran on new HEAD"
-          ;;
-        unavailable)
-          _eval_note="Evaluated by code-reviewer: unavailable — fell back to advisory-only (clean)"
-          ;;
-        *)
-          _eval_note="Evaluated by code-reviewer: outcome=${possible_issue_eval_outcome}"
-          ;;
-      esac
-      advisory_section="${advisory_section}
-  _Possible Issue evaluation_: ${_eval_note}"
-    fi
   fi
   if [ "$structured_advisory_count" -gt 0 ]; then
     local _adv_index=0
@@ -5816,6 +5858,25 @@ ${_structured_entries}"
       fi
       _adv_index=$((_adv_index + 1))
     done
+  fi
+  if [ -n "$possible_issue_eval_outcome" ] && [ "$advisory_finding_count" -gt 0 ]; then
+    local _eval_note
+    case "$possible_issue_eval_outcome" in
+      acknowledged)
+        _eval_note="Auto-acknowledged: Possible Issue is advisory-only — loop proceeded clean"
+        ;;
+      fix_pushed)
+        _eval_note="Evaluated by code-reviewer: fix pushed — loop re-ran on new HEAD"
+        ;;
+      unavailable)
+        _eval_note="Evaluated by code-reviewer: unavailable — fell back to advisory-only (clean)"
+        ;;
+      *)
+        _eval_note="Evaluated by code-reviewer: outcome=${possible_issue_eval_outcome}"
+        ;;
+    esac
+    advisory_section="${advisory_section}
+  _Possible Issue evaluation_: ${_eval_note}"
   fi
   if [ "${policy_review_disposition_required:-0}" = "1" ] && [ "$advisory_finding_count" -eq 0 ]; then
     local _policy_fallback="policy review required"
@@ -6242,6 +6303,12 @@ print_kv PLATFORM "$last_platform"
 print_kv COMMENT_COUNT "$total_comment_count"
 print_kv BLOCKING_COUNT "$total_blocking_count"
 print_kv SUGGESTION_COUNT "$total_suggestion_count"
+if [ "${#aggregate_advisory_findings_jsons[@]}" -gt 0 ]; then
+  aggregate_advisory_findings_json="$(combine_advisory_findings_jsons "${aggregate_advisory_findings_jsons[@]}")"
+else
+  aggregate_advisory_findings_json="[]"
+fi
+print_kv ADVISORY_FINDINGS "$aggregate_advisory_findings_json"
 advisory_disposition_required_output="$advisory_disposition_required"
 [ "$aggregate_result" != "clean" ] && advisory_disposition_required_output=0
 print_kv ADVISORY_DISPOSITION_REQUIRED "$advisory_disposition_required_output"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -511,7 +511,8 @@ render_structured_advisory_entries() {
         "  Disposition: Known false positive" +
         (if (((.disposition_rule // "") | tostring | length) > 0) then " (`" + ((.disposition_rule // "") | one_line) + "`)" else "" end) +
         (if (((.disposition_rationale // "") | tostring | length) > 0) then " - " + ((.disposition_rationale // "") | one_line) else "" end)
-       else empty end),
+      else empty end),
+      (if (((.url // "") | tostring | length) > 0) then "  Source: [view comment](" + ((.url // "") | one_line) + ")" else empty end),
       (if (((.detail // "") | tostring | length) > 0) then "  Detail: " + ((.detail // "") | one_line) else empty end),
       (if (((.path // "") | tostring | length) > 0) then
         "  Location: `" + ((.path // "") | one_line) +

--- a/scripts/development-workflow/tests/test-haystack-reviewer.sh
+++ b/scripts/development-workflow/tests/test-haystack-reviewer.sh
@@ -489,9 +489,12 @@ _reset_mocks
 _install_haystack_mock
 
 output=$(_run_reviewer 10 1)
+advisory_findings="$(_kv_value ADVISORY_FINDINGS "$output")"
 advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
 blocking_json="$(_kv_value BLOCKING_FINDINGS_JSON "$output")"
 
+run_test "structured_empty_advisory_findings_array" "0" "$(printf '%s\n' "$advisory_findings" | jq 'length')"
+run_test "structured_empty_advisory_alias_equal" "$advisory_findings" "$advisory_json"
 run_test "structured_empty_advisory_array" "0" "$(printf '%s\n' "$advisory_json" | jq 'length')"
 run_test "structured_empty_blocking_array" "0" "$(printf '%s\n' "$blocking_json" | jq 'length')"
 
@@ -501,8 +504,12 @@ _reset_mocks
 _install_haystack_mock
 
 output=$(_run_reviewer 10 1)
+advisory_findings="$(_kv_value ADVISORY_FINDINGS "$output")"
 advisory_json="$(_kv_value ADVISORY_FINDINGS_JSON "$output")"
 
+run_test "structured_multi_advisory_findings_count" "2" "$(printf '%s\n' "$advisory_findings" | jq 'length')"
+run_test "structured_multi_advisory_findings_source" "haystack|haystack" "$(printf '%s\n' "$advisory_findings" | jq -r 'map(.source) | join("|")')"
+run_test "structured_multi_advisory_findings_alias_equal" "$advisory_findings" "$advisory_json"
 run_test "structured_multi_advisory_count" "2" "$(printf '%s\n' "$advisory_json" | jq 'length')"
 run_test "structured_multi_advisory_order" "First advisory|Second advisory" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].summary + "|" + .[1].summary')"
 run_test "structured_multi_advisory_fix_hint" "Fix one" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].fix_hint')"
@@ -607,9 +614,13 @@ _reset_mocks
 _install_haystack_mock
 
 output=$(_run_reviewer 10 1)
+advisory_findings_line="$(printf '%s\n' "$output" | grep '^ADVISORY_FINDINGS=')"
 advisory_line="$(printf '%s\n' "$output" | grep '^ADVISORY_FINDINGS_JSON=')"
+advisory_findings="${advisory_findings_line#ADVISORY_FINDINGS=}"
 advisory_json="${advisory_line#ADVISORY_FINDINGS_JSON=}"
 
+run_test "structured_escaped_canonical_single_line" "1" "$(printf '%s\n' "$advisory_findings_line" | wc -l | tr -d ' ')"
+run_test "structured_escaped_canonical_alias_equal" "$advisory_findings" "$advisory_json"
 run_test "structured_escaped_single_line" "1" "$(printf '%s\n' "$advisory_line" | wc -l | tr -d ' ')"
 run_test "structured_escaped_detail" "Line one|Line two" "$(printf '%s\n' "$advisory_json" | jq -r '.[0].detail | gsub("\\n"; "|")')"
 # shellcheck disable=SC2016  # Expected value intentionally contains literal $PATH.

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1277,6 +1277,7 @@ printf 'RESULT=clean\n'
 printf 'BLOCKING_COUNT=0\n'
 printf 'SUGGESTION_COUNT=1\n'
 printf 'COMMENT_COUNT=1\n'
+printf 'ADVISORY_FINDINGS=[{"source":"haystack","severity":"advisory","category":"Minor","summary":"Structured note","detail":"Details","path":"script.sh","line":12,"fix_hint":"Consider simplifying"}]\n'
 printf 'ADVISORY_FINDINGS_JSON=[{"severity":"advisory","category":"Minor","summary":"Structured note","detail":"Details","path":"script.sh","line":12,"fix_hint":"Consider simplifying"}]\n'
 printf 'BLOCKING_FINDINGS_JSON=[]\n'
 printf 'POLICY_STATUS_AVAILABLE=1\n'
@@ -1302,6 +1303,9 @@ actual_output="$(
 run_test "haystack_forwards_advisory_findings_json" \
   'ADVISORY_FINDINGS_JSON=[{"severity":"advisory","category":"Minor","summary":"Structured note","detail":"Details","path":"script.sh","line":12,"fix_hint":"Consider simplifying"}]' \
   "$(printf '%s\n' "$actual_output" | grep "^ADVISORY_FINDINGS_JSON=")"
+run_test "haystack_forwards_advisory_findings" \
+  'ADVISORY_FINDINGS=[{"source":"haystack","severity":"advisory","category":"Minor","summary":"Structured note","detail":"Details","path":"script.sh","line":12,"fix_hint":"Consider simplifying"}]' \
+  "$(printf '%s\n' "$actual_output" | grep "^ADVISORY_FINDINGS=")"
 run_test "haystack_forwards_policy_review_required" "POLICY_REVIEW_REQUIRED=1" \
   "$(printf '%s\n' "$actual_output" | grep "^POLICY_REVIEW_REQUIRED=")"
 run_test "haystack_forwards_display_result" "DISPLAY_RESULT=needs-review: policy" \
@@ -1369,6 +1373,12 @@ else
   _advisory_trigger_count=0
 fi
 run_test "advisory_disposition_required_by_labels" "1" "$_advisory_trigger_count"
+if advisory_disposition_required_for_platform clean 0 0 "" '[{"source":"haystack","category":"Minor","summary":"Structured note"}]'; then
+  _advisory_trigger_count=1
+else
+  _advisory_trigger_count=0
+fi
+run_test "advisory_disposition_required_by_findings" "1" "$_advisory_trigger_count"
 if advisory_disposition_required_for_platform needs_fixes 1 1 "Possible Issue"; then
   _advisory_trigger_count=1
 else
@@ -1397,6 +1407,8 @@ unset _count_validation_ok _count_fail_closed
 if grep -qF 'advisory_disposition_required_output="$advisory_disposition_required"' \
     "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh" \
     && grep -qF 'print_kv ADVISORY_DISPOSITION_REQUIRED "$advisory_disposition_required_output"' \
+      "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh" \
+    && grep -qF 'print_kv ADVISORY_FINDINGS "$aggregate_advisory_findings_json"' \
       "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"; then
   _advisory_signal_emitted=1
 else
@@ -3307,6 +3319,44 @@ run_test "pr_agent_existing_comment_no_duplicate_trigger" "0" \
   "$(grep_count_or_zero "-X POST repos/.*/issues/42/comments" "$_pr_agent_call_log_1702")"
 rm -rf "$_pr_agent_mock_dir_1702"
 unset _pr_agent_mock_dir_1702 _pr_agent_call_log_1702 actual_output
+
+_pr_agent_mock_dir_1702b="$(mktemp -d)"
+_pr_agent_call_log_1702b="$_pr_agent_mock_dir_1702b/calls.log"
+cat > "$_pr_agent_mock_dir_1702b/gh" <<'PR_AGENT_GH_1702B'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$PR_AGENT_CALL_LOG"
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc1702bsha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"issues/42/comments"*)
+    printf '[{"user":{"login":"github-actions[bot]"},"updated_at":"2020-01-01T00:00:02Z","html_url":"https://example.test/comment-1702b","body":"PR Reviewer Guide abc1702bsha\\nRecommended focus areas for review\\n<strong>Possible Issue</strong>\\n<strong>Performance Concern</strong>\\n---"}]\n'
+    exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+PR_AGENT_GH_1702B
+chmod +x "$_pr_agent_mock_dir_1702b/gh"
+
+actual_output="$(
+  PATH="$_pr_agent_mock_dir_1702b:$PATH" PR_AGENT_CALL_LOG="$_pr_agent_call_log_1702b" \
+    run_pr_agent_review "42" "feature/42-test" "1" "0" || true
+)"
+_pr_agent_advisory_findings="$(kv_value ADVISORY_FINDINGS "$actual_output")"
+run_test "pr_agent_advisory_emits_legacy_labels" \
+  "ADVISORY_LABELS=Possible Issue|Performance Concern@@@https://example.test/comment-1702b" \
+  "$(printf '%s\n' "$actual_output" | grep "^ADVISORY_LABELS=")"
+run_test "pr_agent_advisory_findings_count" "2" \
+  "$(printf '%s\n' "$_pr_agent_advisory_findings" | jq 'length')"
+run_test "pr_agent_advisory_findings_sources" "pr-agent|pr-agent" \
+  "$(printf '%s\n' "$_pr_agent_advisory_findings" | jq -r 'map(.source) | join("|")')"
+run_test "pr_agent_advisory_findings_categories" "Possible Issue|Performance Concern" \
+  "$(printf '%s\n' "$_pr_agent_advisory_findings" | jq -r 'map(.category) | join("|")')"
+run_test "pr_agent_advisory_findings_url" "https://example.test/comment-1702b" \
+  "$(printf '%s\n' "$_pr_agent_advisory_findings" | jq -r '.[0].url')"
+rm -rf "$_pr_agent_mock_dir_1702b"
+unset _pr_agent_mock_dir_1702b _pr_agent_call_log_1702b actual_output _pr_agent_advisory_findings
 
 _pr_agent_mock_dir_1703="$(mktemp -d)"
 _pr_agent_call_log_1703="$_pr_agent_mock_dir_1703/calls.log"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1590,7 +1590,7 @@ run_test "summary_advisory_split_visible" "yes" "$_summary_advisory_split"
 
 aggregate_advisory_findings_platforms=("haystack")
 aggregate_advisory_findings_jsons=(
-  "$(jq -nc '[{"severity":"advisory","category":"Minor","summary":"Summary with \"quotes\", pipe | equals =, and newline text","detail":"Line one\nLine two","path":"scripts/example.sh","line":12,"fix_hint":"Use $PATH && echo ok","disposition":"known-false-positive","disposition_rule":"test-rule","disposition_rationale":"Known noisy reviewer pattern"}]')"
+  "$(jq -nc '[{"source":"haystack","severity":"advisory","category":"Minor","summary":"Summary with \"quotes\", pipe | equals =, and newline text","url":"https://example.test/advisory","detail":"Line one\nLine two","path":"scripts/example.sh","line":12,"fix_hint":"Use $PATH && echo ok","disposition":"known-false-positive","disposition_rule":"test-rule","disposition_rationale":"Known noisy reviewer pattern"}]')"
 )
 advisory_disposition_required=1
 policy_review_disposition_required=0
@@ -1598,6 +1598,7 @@ platform_policy_status_notes=()
 _post_review_summary "clean" "" "haystack (clean)" "0" "1" ""
 if [ -n "${_summary_body_capture:-}" ] \
     && grep -q 'haystack: Minor - Summary with "quotes", pipe | equals =, and newline text' "$_summary_body_capture" \
+    && grep -q 'Source: \[view comment\](https://example.test/advisory)' "$_summary_body_capture" \
     && grep -q "Detail: Line one Line two" "$_summary_body_capture" \
     && grep -q 'Location: `scripts/example.sh:12`' "$_summary_body_capture" \
     && grep -q 'Fix hint: Use $PATH && echo ok' "$_summary_body_capture" \


### PR DESCRIPTION
## Summary

Implements #1118 by introducing canonical `ADVISORY_FINDINGS` reviewer output across PR-Agent, Haystack, and the aggregate reviewer loop while preserving transition aliases.

## Changes

- Add provider-agnostic advisory normalization and aggregate `ADVISORY_FINDINGS` output in `pr-review-loop.sh`.
- Emit canonical `ADVISORY_FINDINGS` from Haystack while retaining `ADVISORY_FINDINGS_JSON` as a deprecated alias.
- Convert PR-Agent advisory labels into unified finding objects while retaining `ADVISORY_LABELS`.
- Update generic review-platform docs, Haystack docs, Protocol 93, and CHANGELOG.
- Add shell regression assertions for canonical/alias equality, PR-Agent label normalization, and aggregate advisory disposition triggers.

## Pre-Submission Self-Review

- Diff reviewed against `origin/develop-external-review-loop-hardening`.
- Spec/plan coverage checked: AC-1 through AC-7 are covered by scripts, docs, tests, and CHANGELOG.
- Parser-risk checks included: JSON key-value parsing preserves values after the first `=`, validates arrays, preserves source/category/summary, and avoids duplicate alias rendering.
- No stale TODO/FIXME/debug markers added.
- CHANGELOG entry uses the required `**Bold Title** (#1118):` format under `[Unreleased]`.

## Verification

- `bash scripts/development-workflow/tests/test-haystack-reviewer.sh` — 229 passed, 0 failed
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` — 298 passed, 0 failed
- `bash scripts/development-workflow/validate-workflow-config.sh`
- `bash -n scripts/development-workflow/haystack-reviewer.sh && bash -n scripts/development-workflow/pr-review-loop.sh`
- `shellcheck --severity=warning -x scripts/development-workflow/haystack-reviewer.sh scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-haystack-reviewer.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop-external-review-loop-hardening`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/integrations/pr-review-platform.md" "docs/workflow/development-workflow/integrations/haystack-triage.md" "docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md" "docs/testing/workflow/1118-unify-advisory-contract.smoke-test.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`

Refs #1118

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stdout key-value contracts and summary/disposition logic in `pr-review-loop.sh` and Haystack output; aliases limit breakage, but consumers must switch to `ADVISORY_FINDINGS` to avoid relying on deprecated fields.
> 
> **Overview**
> Introduces **`ADVISORY_FINDINGS`** as the canonical, provider-agnostic JSON array for non-blocking reviewer output, while **`ADVISORY_LABELS`** (PR-Agent) and **`ADVISORY_FINDINGS_JSON`** (Haystack) remain deprecated one-release aliases.
> 
> **`haystack-reviewer.sh`** now emits `ADVISORY_FINDINGS` alongside the alias and adds a required **`source: haystack`** field on normalized finding objects.
> 
> **`pr-review-loop.sh`** normalizes and merges per-platform advisory arrays, prints aggregate **`ADVISORY_FINDINGS`**, maps PR-Agent labels into unified objects (with optional comment **`url`**), prefers `ADVISORY_FINDINGS` over the Haystack alias when aggregating, and uses non-empty findings to drive **`ADVISORY_DISPOSITION_REQUIRED`**. Summary rendering prefers structured findings (including **`source`** and URLs) and skips duplicate legacy label bullets when structured data is present.
> 
> Docs (**`pr-review-platform.md`**, Haystack triage, Protocol 93) and shell tests document the contract and assert canonical/alias parity and PR-Agent normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f34bd67bf5e8eb90a0b65527c137c272f835abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->