### PR TITLE
fix(workflow): support Linear run-item guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linear-backed run-item guardrails**: bounded `/run-item` runs now accept
+  Linear issue keys, apply repository guardrail defaults before policy
+  recommendation, and avoid requiring PyYAML for guardrail parsing.
+
 ## [0.35.0] - 2026-07-02
 
 ### Added

--- a/scripts/development-workflow/run-bounded-prelude.sh
+++ b/scripts/development-workflow/run-bounded-prelude.sh
@@ -207,6 +207,42 @@ json_get() {
   printf '%s\n' "$json" | jq -r "$filter"
 }
 
+guardrails_scope_may_merge() {
+  local guardrails="$1" scope_file="$2"
+  jq -nr --argjson guardrails "$guardrails" --slurpfile scope "$scope_file" '
+    def infer_stage($status):
+      ($status | ascii_downcase) as $s |
+      if $s == "backlog" or ($s | test("writing spec|spec in review|spec")) then "spec"
+      elif $s | test("writing plan|plan in review|plan") then "plan"
+      elif $s | test("development|implement") then "implementation"
+      else "implementation"
+      end;
+    [$scope[0].items[]? | infer_stage(.status // "")] | unique as $stages |
+    if ($stages | length) == 0 then "false"
+    elif all($stages[]; ($guardrails.stages[.].may_merge_pr // false) == true) then "true"
+    else "false"
+    end
+  '
+}
+
+guardrails_scope_max_risk() {
+  local guardrails="$1" scope_file="$2"
+  jq -nr --argjson guardrails "$guardrails" --slurpfile scope "$scope_file" '
+    def infer_stage($status):
+      ($status | ascii_downcase) as $s |
+      if $s == "backlog" or ($s | test("writing spec|spec in review|spec")) then "spec"
+      elif $s | test("writing plan|plan in review|plan") then "plan"
+      elif $s | test("development|implement") then "implementation"
+      else "implementation"
+      end;
+    def rank($risk): {"low":1,"medium":2,"high":3}[$risk] // 1;
+    [$scope[0].items[]? | infer_stage(.status // "")] | unique as $stages |
+    if ($stages | length) == 0 then "low"
+    else [$stages[] | ($guardrails.stages[.].max_merge_risk // "low")] | min_by(rank(.))
+    end
+  '
+}
+
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --original-command)
@@ -394,22 +430,6 @@ if [ -z "$delegate_review_override" ]; then
   esac
   delegate_review_source="$guardrails_source"
 fi
-if [ -z "$may_merge_override" ]; then
-  if [ "$(json_get "$guardrails_json" '[.stages.spec.may_merge_pr, .stages.plan.may_merge_pr, .stages.implementation.may_merge_pr] | any')" = "true" ]; then
-    may_merge_override="true"
-  else
-    may_merge_override="false"
-  fi
-  may_merge_source="$guardrails_source"
-fi
-if [ -z "$max_risk_override" ]; then
-  max_risk_override="$(json_get "$guardrails_json" '
-    def rank: {"low":1,"medium":2,"high":3}[.] // 0;
-    [.stages.spec.max_merge_risk, .stages.plan.max_merge_risk, .stages.implementation.max_merge_risk]
-    | max_by(rank)
-  ')"
-  max_risk_source="$guardrails_source"
-fi
 
 resolver_common=()
 [ -n "$base_override" ] && resolver_common+=(--base "$base_override")
@@ -441,6 +461,15 @@ case "$scope_mode" in
     fi
     ;;
 esac
+
+if [ -z "$may_merge_override" ]; then
+  may_merge_override="$(guardrails_scope_may_merge "$guardrails_json" "$scope_file")"
+  may_merge_source="$guardrails_source"
+fi
+if [ -z "$max_risk_override" ]; then
+  max_risk_override="$(guardrails_scope_max_risk "$guardrails_json" "$scope_file")"
+  max_risk_source="$guardrails_source"
+fi
 
 policy_args=(
   --scope "$scope_file"

--- a/scripts/development-workflow/run-bounded-prelude.sh
+++ b/scripts/development-workflow/run-bounded-prelude.sh
@@ -46,12 +46,16 @@ error_exit() {
 
 emit_guardrails_unreadable_stop() {
   local detail="${1:-}"
+  local affected="${original_command:-unknown scope}"
+  local human_action="fix the guardrails block in .ai-dev-workflow.yaml, then rerun the bounded command"
   if [ "$json_output" -eq 1 ]; then
-    jq -nc --arg detail "$detail" \
-      '{stopCondition: "guardrails_config_unreadable", readOnlyGuarantee: "No tracker updates, branch creation, PR edits, labels, comments, merges, issue closure, or branch deletion were performed.", detail: $detail}'
+    jq -nc --arg detail "$detail" --arg affected "$affected" --arg humanAction "$human_action" \
+      '{stopCondition: "guardrails_config_unreadable", affectedWorkItem: $affected, humanActionRequired: $humanAction, readOnlyGuarantee: "No tracker updates, branch creation, PR edits, labels, comments, merges, issue closure, or branch deletion were performed.", detail: $detail}'
     exit 1
   fi
-  printf 'STOP: guardrails_config_unreadable\n'
+  printf "STOP: guardrail 'guardrails_config_unreadable' halted this run\n"
+  printf 'Affected work item: %s\n' "$affected"
+  printf 'Human action required: %s\n' "$human_action"
   if [ -n "$detail" ]; then
     printf '%s\n' "$detail" >&2
   fi
@@ -70,32 +74,109 @@ require_value() {
 read_guardrails_json() {
   local config_file py_result _py_exit
   if ! config_file="$(workflow_effective_config_file 2>/dev/null)"; then
-    printf '%s\n' '{"section":"absent","mode":"manual","backlog_start":false}'
+    printf '%s\n' '{"section":"absent","mode":"manual","backlog_start":false,"stages":{"spec":{"may_open_pr":true,"may_merge_pr":false,"max_merge_risk":"low","required_evidence":[]},"plan":{"may_open_pr":true,"may_merge_pr":false,"max_merge_risk":"low","required_evidence":[]},"implementation":{"may_open_pr":true,"may_merge_pr":false,"max_merge_risk":"low","required_evidence":[]}},"stop_conditions":[],"audit":{"pr_disposition_record":"not_required","work_item_ledger_record":"not_required"}}'
     return 0
   fi
 
   _py_exit=0
-  py_result="$(python3 - "$config_file" <<'PYEOF'
-import sys, json
+  py_result="$(python3 - "$config_file" "$SCRIPT_DIR/workflow-config-resolver.py" <<'PYEOF'
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+
+DEFAULT_STAGE = {
+    "may_open_pr": True,
+    "may_merge_pr": False,
+    "max_merge_risk": "low",
+    "required_evidence": [],
+}
+DEFAULT_STAGES = {
+    "spec": dict(DEFAULT_STAGE),
+    "plan": dict(DEFAULT_STAGE),
+    "implementation": dict(DEFAULT_STAGE),
+}
+DEFAULT_AUDIT = {
+    "pr_disposition_record": "not_required",
+    "work_item_ledger_record": "not_required",
+}
+
+
+def as_bool(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() == "true"
+    return bool(value)
+
+
+def default_guardrails(section="absent"):
+    return {
+        "section": section,
+        "mode": "manual",
+        "backlog_start": False,
+        "stages": DEFAULT_STAGES,
+        "stop_conditions": [],
+        "audit": DEFAULT_AUDIT,
+    }
+
+
 try:
-    import yaml
-    with open(sys.argv[1], 'r') as f:
-        cfg = yaml.safe_load(f) or {}
+    sys.dont_write_bytecode = True
+    resolver_path = Path(sys.argv[2])
+    spec = importlib.util.spec_from_file_location("workflow_config_resolver", resolver_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {resolver_path}")
+    resolver = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(resolver)
+    cfg = resolver.parse_yaml_subset(Path(sys.argv[1]))
     guardrails = cfg.get('guardrails') if isinstance(cfg, dict) else None
     if not isinstance(guardrails, dict):
-        print(json.dumps({"section": "absent", "mode": "manual", "backlog_start": False}))
+        print(json.dumps(default_guardrails()))
         sys.exit(0)
     mode = guardrails.get('mode', 'manual')
     if mode not in ('manual', 'assisted', 'delegated', 'autonomous'):
-        mode = 'manual'
+        raise ValueError(f"guardrails.mode must be manual, assisted, delegated, or autonomous, got {mode!r}")
     backlog_start_cfg = guardrails.get('backlog_start', {})
     if isinstance(backlog_start_cfg, dict):
         allow = backlog_start_cfg.get('allow_without_confirmation', False)
     else:
         allow = False
-    if not isinstance(allow, bool):
-        allow = str(allow).lower() == 'true'
-    print(json.dumps({"section": "present", "mode": mode, "backlog_start": allow}))
+    stages_cfg = guardrails.get("stages", {})
+    stages = {}
+    for stage in ("spec", "plan", "implementation"):
+        cfg_stage = stages_cfg.get(stage, {}) if isinstance(stages_cfg, dict) else {}
+        stage_out = dict(DEFAULT_STAGE)
+        if isinstance(cfg_stage, dict):
+            if "may_open_pr" in cfg_stage:
+                stage_out["may_open_pr"] = as_bool(cfg_stage["may_open_pr"])
+            if "may_merge_pr" in cfg_stage:
+                stage_out["may_merge_pr"] = as_bool(cfg_stage["may_merge_pr"])
+            if "max_merge_risk" in cfg_stage:
+                risk = cfg_stage["max_merge_risk"]
+                if risk not in ("low", "medium", "high"):
+                    raise ValueError(
+                        f"guardrails.stages.{stage}.max_merge_risk must be low, medium, or high, got {risk!r}"
+                    )
+                stage_out["max_merge_risk"] = risk
+            evidence = cfg_stage.get("required_evidence", [])
+            stage_out["required_evidence"] = evidence if isinstance(evidence, list) else []
+        stages[stage] = stage_out
+    stops = guardrails.get("stop_conditions", [])
+    audit_cfg = guardrails.get("audit", {})
+    audit = dict(DEFAULT_AUDIT)
+    if isinstance(audit_cfg, dict):
+        audit["pr_disposition_record"] = audit_cfg.get("pr_disposition_record", "not_required")
+        audit["work_item_ledger_record"] = audit_cfg.get("work_item_ledger_record", "not_required")
+    print(json.dumps({
+        "section": "present",
+        "mode": mode,
+        "backlog_start": as_bool(allow),
+        "stages": stages,
+        "stop_conditions": stops if isinstance(stops, list) else [],
+        "audit": audit,
+    }))
 except Exception as exc:
     print(f"failed to parse guardrails from {sys.argv[1]}: {exc}", file=sys.stderr)
     sys.exit(2)
@@ -106,10 +187,15 @@ PYEOF
     emit_guardrails_unreadable_stop "failed to read guardrails from workflow config $config_file"
   fi
   if [ "$_py_exit" -ne 0 ]; then
-    py_result='{"section":"absent","mode":"manual","backlog_start":false}'
+    py_result='{"section":"absent","mode":"manual","backlog_start":false,"stages":{"spec":{"may_open_pr":true,"may_merge_pr":false,"max_merge_risk":"low","required_evidence":[]},"plan":{"may_open_pr":true,"may_merge_pr":false,"max_merge_risk":"low","required_evidence":[]},"implementation":{"may_open_pr":true,"may_merge_pr":false,"max_merge_risk":"low","required_evidence":[]}},"stop_conditions":[],"audit":{"pr_disposition_record":"not_required","work_item_ledger_record":"not_required"}}'
   fi
 
   printf '%s\n' "$py_result"
+}
+
+json_get() {
+  local json="$1" filter="$2"
+  printf '%s\n' "$json" | jq -r "$filter"
 }
 
 while [ "$#" -gt 0 ]; do
@@ -269,6 +355,33 @@ cleanup() {
 }
 trap cleanup EXIT
 
+guardrails_json="$(read_guardrails_json)"
+if [ "$(json_get "$guardrails_json" '.section')" = "present" ]; then
+  if [ -z "$may_start_backlog_override" ]; then
+    may_start_backlog_override="$(json_get "$guardrails_json" '.backlog_start | tostring')"
+  fi
+  if [ -z "$delegate_review_override" ]; then
+    case "$(json_get "$guardrails_json" '.mode')" in
+      assisted|delegated|autonomous) delegate_review_override="true" ;;
+      *) delegate_review_override="false" ;;
+    esac
+  fi
+  if [ -z "$may_merge_override" ]; then
+    if [ "$(json_get "$guardrails_json" '[.stages.spec.may_merge_pr, .stages.plan.may_merge_pr, .stages.implementation.may_merge_pr] | any')" = "true" ]; then
+      may_merge_override="true"
+    else
+      may_merge_override="false"
+    fi
+  fi
+  if [ -z "$max_risk_override" ]; then
+    max_risk_override="$(json_get "$guardrails_json" '
+      def rank: {"low":1,"medium":2,"high":3}[.] // 0;
+      [.stages.spec.max_merge_risk, .stages.plan.max_merge_risk, .stages.implementation.max_merge_risk]
+      | max_by(rank)
+    ')"
+  fi
+fi
+
 resolver_common=()
 [ -n "$base_override" ] && resolver_common+=(--base "$base_override")
 [ "$delegate_review_override" = "true" ] && resolver_common+=(--delegate-review)
@@ -316,8 +429,6 @@ if ! "$SCRIPT_DIR/run-epic-policy-recommender.sh" "${policy_args[@]+"${policy_ar
   error_exit "policy recommendation failed"
 fi
 
-guardrails_json="$(read_guardrails_json)"
-
 prelude_json="$(jq -nc \
   --slurpfile scope "$scope_file" \
   --slurpfile policy "$policy_file" \
@@ -341,6 +452,10 @@ printf 'Guardrails: section=%s mode=%s backlog_start=%s\n' \
   "$(jq -r '.guardrails.section' <<<"$prelude_json")" \
   "$(jq -r '.guardrails.mode' <<<"$prelude_json")" \
   "$(jq -r '.guardrails.backlog_start' <<<"$prelude_json")"
+if [ "$(jq -r '.guardrails.section' <<<"$prelude_json")" = "absent" ]; then
+  printf 'no `guardrails` section found; conservative defaults are in effect\n'
+  printf 'Default guardrails: mode=manual; stages.*.may_open_pr=true; stages.*.may_merge_pr=false; stages.*.max_merge_risk=low; backlog_start.allow_without_confirmation=false; audit records not required\n'
+fi
 printf 'Requires confirmation: %s\n' "$(jq -r '.policyRecommendation.requiresConfirmation' <<<"$prelude_json")"
 printf 'Reason: %s\n' "$(jq -r '.policyRecommendation.confirmationReason' <<<"$prelude_json")"
 printf 'Copy-paste: %s\n' "$(jq -r '.policyRecommendation.copyPasteCommand' <<<"$prelude_json")"

--- a/scripts/development-workflow/run-bounded-prelude.sh
+++ b/scripts/development-workflow/run-bounded-prelude.sh
@@ -356,30 +356,28 @@ cleanup() {
 trap cleanup EXIT
 
 guardrails_json="$(read_guardrails_json)"
-if [ "$(json_get "$guardrails_json" '.section')" = "present" ]; then
-  if [ -z "$may_start_backlog_override" ]; then
-    may_start_backlog_override="$(json_get "$guardrails_json" '.backlog_start | tostring')"
+if [ -z "$may_start_backlog_override" ]; then
+  may_start_backlog_override="$(json_get "$guardrails_json" '.backlog_start | tostring')"
+fi
+if [ -z "$delegate_review_override" ]; then
+  case "$(json_get "$guardrails_json" '.mode')" in
+    assisted|delegated|autonomous) delegate_review_override="true" ;;
+    *) delegate_review_override="false" ;;
+  esac
+fi
+if [ -z "$may_merge_override" ]; then
+  if [ "$(json_get "$guardrails_json" '[.stages.spec.may_merge_pr, .stages.plan.may_merge_pr, .stages.implementation.may_merge_pr] | any')" = "true" ]; then
+    may_merge_override="true"
+  else
+    may_merge_override="false"
   fi
-  if [ -z "$delegate_review_override" ]; then
-    case "$(json_get "$guardrails_json" '.mode')" in
-      assisted|delegated|autonomous) delegate_review_override="true" ;;
-      *) delegate_review_override="false" ;;
-    esac
-  fi
-  if [ -z "$may_merge_override" ]; then
-    if [ "$(json_get "$guardrails_json" '[.stages.spec.may_merge_pr, .stages.plan.may_merge_pr, .stages.implementation.may_merge_pr] | any')" = "true" ]; then
-      may_merge_override="true"
-    else
-      may_merge_override="false"
-    fi
-  fi
-  if [ -z "$max_risk_override" ]; then
-    max_risk_override="$(json_get "$guardrails_json" '
-      def rank: {"low":1,"medium":2,"high":3}[.] // 0;
-      [.stages.spec.max_merge_risk, .stages.plan.max_merge_risk, .stages.implementation.max_merge_risk]
-      | max_by(rank)
-    ')"
-  fi
+fi
+if [ -z "$max_risk_override" ]; then
+  max_risk_override="$(json_get "$guardrails_json" '
+    def rank: {"low":1,"medium":2,"high":3}[.] // 0;
+    [.stages.spec.max_merge_risk, .stages.plan.max_merge_risk, .stages.implementation.max_merge_risk]
+    | max_by(rank)
+  ')"
 fi
 
 resolver_common=()

--- a/scripts/development-workflow/run-bounded-prelude.sh
+++ b/scripts/development-workflow/run-bounded-prelude.sh
@@ -72,14 +72,15 @@ require_value() {
 }
 
 read_guardrails_json() {
-  local config_file py_result _py_exit
+  local config_file py_result _py_exit err_file parse_detail
   if ! config_file="$(workflow_effective_config_file 2>/dev/null)"; then
     printf '%s\n' '{"section":"absent","mode":"manual","backlog_start":false,"stages":{"spec":{"may_open_pr":true,"may_merge_pr":false,"max_merge_risk":"low","required_evidence":[]},"plan":{"may_open_pr":true,"may_merge_pr":false,"max_merge_risk":"low","required_evidence":[]},"implementation":{"may_open_pr":true,"may_merge_pr":false,"max_merge_risk":"low","required_evidence":[]}},"stop_conditions":[],"audit":{"pr_disposition_record":"not_required","work_item_ledger_record":"not_required"}}'
     return 0
   fi
 
   _py_exit=0
-  py_result="$(python3 - "$config_file" "$SCRIPT_DIR/workflow-config-resolver.py" <<'PYEOF'
+  err_file="$(mktemp)"
+  py_result="$(python3 - "$config_file" "$SCRIPT_DIR/workflow-config-resolver.py" 2>"$err_file" <<'PYEOF'
 import importlib.util
 import json
 from pathlib import Path
@@ -184,8 +185,16 @@ PYEOF
   )" || _py_exit=$?
 
   if [ "$_py_exit" -eq 2 ]; then
-    emit_guardrails_unreadable_stop "failed to read guardrails from workflow config $config_file"
+    parse_detail="$(awk 'BEGIN{out=""} {out = out (out == "" ? "" : " ") $0} END{print out}' "$err_file")" || parse_detail=""
+    rm -f "$err_file"
+    if [ -n "$parse_detail" ]; then
+      printf '%s\n' "$parse_detail" >&2
+      return 2
+    fi
+    printf 'failed to read guardrails from workflow config %s\n' "$config_file" >&2
+    return 2
   fi
+  rm -f "$err_file"
   if [ "$_py_exit" -ne 0 ]; then
     py_result='{"section":"absent","mode":"manual","backlog_start":false,"stages":{"spec":{"may_open_pr":true,"may_merge_pr":false,"max_merge_risk":"low","required_evidence":[]},"plan":{"may_open_pr":true,"may_merge_pr":false,"max_merge_risk":"low","required_evidence":[]},"implementation":{"may_open_pr":true,"may_merge_pr":false,"max_merge_risk":"low","required_evidence":[]}},"stop_conditions":[],"audit":{"pr_disposition_record":"not_required","work_item_ledger_record":"not_required"}}'
   fi
@@ -355,15 +364,35 @@ cleanup() {
 }
 trap cleanup EXIT
 
-guardrails_json="$(read_guardrails_json)"
+guardrails_error_file="$tmp_dir/guardrails-error.txt"
+if ! guardrails_json="$(read_guardrails_json 2>"$guardrails_error_file")"; then
+  guardrails_detail="$(awk 'BEGIN{out=""} {out = out (out == "" ? "" : " ") $0} END{print out}' "$guardrails_error_file")" || guardrails_detail=""
+  rm -f "$guardrails_error_file"
+  if [ -n "$guardrails_detail" ]; then
+    emit_guardrails_unreadable_stop "$guardrails_detail"
+  fi
+  emit_guardrails_unreadable_stop "failed to read guardrails from workflow config"
+fi
+rm -f "$guardrails_error_file"
+guardrails_section="$(json_get "$guardrails_json" '.section')"
+guardrails_source="conservative-defaults"
+if [ "$guardrails_section" = "present" ]; then
+  guardrails_source="guardrails"
+fi
+may_start_backlog_source=""
+delegate_review_source=""
+may_merge_source=""
+max_risk_source=""
 if [ -z "$may_start_backlog_override" ]; then
   may_start_backlog_override="$(json_get "$guardrails_json" '.backlog_start | tostring')"
+  may_start_backlog_source="$guardrails_source"
 fi
 if [ -z "$delegate_review_override" ]; then
   case "$(json_get "$guardrails_json" '.mode')" in
     assisted|delegated|autonomous) delegate_review_override="true" ;;
     *) delegate_review_override="false" ;;
   esac
+  delegate_review_source="$guardrails_source"
 fi
 if [ -z "$may_merge_override" ]; then
   if [ "$(json_get "$guardrails_json" '[.stages.spec.may_merge_pr, .stages.plan.may_merge_pr, .stages.implementation.may_merge_pr] | any')" = "true" ]; then
@@ -371,6 +400,7 @@ if [ -z "$may_merge_override" ]; then
   else
     may_merge_override="false"
   fi
+  may_merge_source="$guardrails_source"
 fi
 if [ -z "$max_risk_override" ]; then
   max_risk_override="$(json_get "$guardrails_json" '
@@ -378,6 +408,7 @@ if [ -z "$max_risk_override" ]; then
     [.stages.spec.max_merge_risk, .stages.plan.max_merge_risk, .stages.implementation.max_merge_risk]
     | max_by(rank)
   ')"
+  max_risk_source="$guardrails_source"
 fi
 
 resolver_common=()
@@ -426,6 +457,30 @@ policy_args+=(--json)
 if ! "$SCRIPT_DIR/run-epic-policy-recommender.sh" "${policy_args[@]+"${policy_args[@]}"}" > "$policy_file"; then
   error_exit "policy recommendation failed"
 fi
+policy_adjusted_file="$tmp_dir/policy.adjusted.json"
+if ! jq -c \
+  --arg mayStartBacklogSource "$may_start_backlog_source" \
+  --arg delegateReviewSource "$delegate_review_source" \
+  --arg mayMergeSource "$may_merge_source" \
+  --arg maxRiskSource "$max_risk_source" \
+  '
+  def maybe_source($field; $source):
+    if $source == "" then . else setpath(["fieldSources", $field]; $source) end;
+  . as $policy
+  | maybe_source("mayStartBacklog"; $mayStartBacklogSource)
+  | maybe_source("delegateReview"; $delegateReviewSource)
+  | maybe_source("mayMerge"; $mayMergeSource)
+  | maybe_source("maxRisk"; $maxRiskSource)
+  | if (
+      [$mayStartBacklogSource, $delegateReviewSource, $mayMergeSource, $maxRiskSource]
+      | any(. != "")
+    ) and .confirmationReason == "policy values are explicit; review resolved policy and confirm before mutation" then
+      .confirmationReason = "one or more autonomy policy values were resolved from repository guardrails or conservative defaults; review resolved policy and confirm before mutation"
+    else . end
+  ' "$policy_file" > "$policy_adjusted_file"; then
+  error_exit "policy source adjustment failed"
+fi
+mv "$policy_adjusted_file" "$policy_file"
 
 prelude_json="$(jq -nc \
   --slurpfile scope "$scope_file" \

--- a/scripts/development-workflow/run-item-scope-resolver.sh
+++ b/scripts/development-workflow/run-item-scope-resolver.sh
@@ -10,7 +10,7 @@ usage() {
   cat <<'EOF'
 Usage:
   ./scripts/development-workflow/run-item-scope-resolver.sh --target <token> [--base <branch>] [--delegate-review] [--may-merge] [--may-start-backlog <true|false>] [--max-risk <low|medium|high>] [--json]
-  ./scripts/development-workflow/run-item-scope-resolver.sh --issue <number> [--base <branch>] ... [--json]
+  ./scripts/development-workflow/run-item-scope-resolver.sh --issue <issue-id> [--base <branch>] ... [--json]
   ./scripts/development-workflow/run-item-scope-resolver.sh --branch <name> [--base <branch>] ... [--json]
   ./scripts/development-workflow/run-item-scope-resolver.sh --pr <number> [--base <branch>] ... [--json]
   ./scripts/development-workflow/run-item-scope-resolver.sh --development <path> [--base <branch>] ... [--json]
@@ -69,6 +69,21 @@ valid_max_risk() {
   esac
 }
 
+is_linear_identifier() {
+  [[ "$1" =~ ^[A-Za-z]+-[0-9]+$ ]]
+}
+
+tracker_provider() {
+  local config_file raw_provider
+  config_file="$(workflow_effective_config_file 2>/dev/null)" || config_file=""
+  if [ -n "$config_file" ]; then
+    raw_provider="$(workflow_config_provider issue_tracker "$config_file")"
+  else
+    raw_provider="$(workflow_issue_tracker_provider_raw)"
+  fi
+  workflow_normalize_issue_tracker_provider "$raw_provider"
+}
+
 have_cmd() {
   command -v "$1" >/dev/null 2>&1
 }
@@ -121,6 +136,11 @@ resolve_token_kind() {
   local repo_root pr_num pr_state issue_state
   token="${token#./}"
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || repo_root=""
+
+  if [ "$(tracker_provider)" = "linear" ] && is_linear_identifier "$token"; then
+    printf 'issue'
+    return 0
+  fi
 
   if [ -n "$repo_root" ] && [ -d "$repo_root/$token" ] && [[ "$token" == docs/specs/developments/* ]]; then
     printf 'dev_folder'
@@ -265,17 +285,24 @@ item_input=""
 resolved_issue=""
 
 if [ -n "$issue_number" ]; then
-  if ! is_positive_int "$issue_number"; then
-    error_exit "invalid --issue number: $issue_number"
+  if is_positive_int "$issue_number"; then
+    resolved_issue="$issue_number"
+  elif [ "$(tracker_provider)" = "linear" ] && is_linear_identifier "$issue_number"; then
+    resolved_issue="$issue_number"
+  else
+    error_exit "invalid --issue identifier: $issue_number"
   fi
-  resolved_issue="$issue_number"
   item_input="$issue_number"
 elif [ -n "$target_token" ]; then
   item_input="$target_token"
   kind="$(resolve_token_kind "$target_token")" || error_exit "could not resolve --target '$target_token'"
   case "$kind" in
     issue)
-      resolved_issue="${target_token#\#}"
+      if is_linear_identifier "$target_token"; then
+        resolved_issue="$target_token"
+      else
+        resolved_issue="${target_token#\#}"
+      fi
       ;;
     pr)
       pr_num="${target_token#\#}"
@@ -307,14 +334,111 @@ elif [ -n "$development_path" ]; then
   resolved_issue="$(issue_from_development_path "$development_path")" || error_exit "could not resolve issue from $development_path"
 fi
 
-set +e
-is_epic_issue "$resolved_issue"
-epic_check=$?
-set -e
-if [ "$epic_check" -eq 0 ]; then
-  error_exit "issue #$resolved_issue is epic-like; use /run-epic or run-epic-scope-resolver instead"
-elif [ "$epic_check" -eq 2 ]; then
-  error_exit "cannot verify epic scope for issue #$resolved_issue without gh CLI"
+if is_positive_int "$resolved_issue"; then
+  set +e
+  is_epic_issue "$resolved_issue"
+  epic_check=$?
+  set -e
+  if [ "$epic_check" -eq 0 ]; then
+    error_exit "issue #$resolved_issue is epic-like; use /run-epic or run-epic-scope-resolver instead"
+  elif [ "$epic_check" -eq 2 ]; then
+    error_exit "cannot verify epic scope for issue #$resolved_issue without gh CLI"
+  fi
+fi
+
+if ! is_positive_int "$resolved_issue"; then
+  provider="$(tracker_provider)"
+  if [ "$provider" != "linear" ]; then
+    error_exit "non-numeric issue identifiers are supported only when issue_tracker.provider is linear"
+  fi
+  base_branch="${base_override:-develop}"
+  base_reason="default develop base; Linear tracker details are deferred to the orchestrator"
+  if [ -n "$base_override" ]; then
+    base_reason="supplied --base override"
+  fi
+  out_json="$(jq -n \
+    --arg itemInput "$item_input" \
+    --arg resolvedIssue "$resolved_issue" \
+    --arg baseBranch "$base_branch" \
+    --arg baseReason "$base_reason" \
+    --arg maxRisk "$max_risk" \
+    --arg mayStartBacklog "$may_start_backlog" \
+    --argjson delegateReview "$delegate_review" \
+    --argjson mayMerge "$may_merge" \
+    '{
+      scopeSource: "item",
+      epicNumber: null,
+      itemInput: $itemInput,
+      resolvedIssueNumber: null,
+      resolvedIssueIdentifier: $resolvedIssue,
+      trackerReadDeferred: true,
+      baseBranch: $baseBranch,
+      baseAmbiguous: false,
+      baseReason: $baseReason,
+      policy: {
+        delegateReview: ($delegateReview == 1),
+        mayMerge: ($mayMerge == 1),
+        mayStartBacklog: ($mayStartBacklog == "true"),
+        maxRisk: $maxRisk
+      },
+      readOnlyGuarantee: "No tracker status, branch, PR, merge, issue-close, or cleanup mutation was performed.",
+      groups: {
+        eligible: [{
+          number: $resolvedIssue,
+          identifier: $resolvedIssue,
+          title: "",
+          body: "",
+          issueState: "",
+          issueStateReason: "",
+          labels: [],
+          integrationBranchLabel: "",
+          status: "Backlog",
+          type: "",
+          priority: "",
+          dependencies: {state: "none", issues: []},
+          pullRequests: {open: [], merged: []},
+          group: "eligible",
+          trackerReadDeferred: true,
+          ambiguityReason: null
+        }],
+        blocked: [],
+        already_merged: [],
+        in_review: [],
+        ambiguous: [],
+        out_of_scope: []
+      },
+      items: [{
+        number: $resolvedIssue,
+        identifier: $resolvedIssue,
+        title: "",
+        body: "",
+        issueState: "",
+        issueStateReason: "",
+        labels: [],
+        integrationBranchLabel: "",
+        status: "Backlog",
+        type: "",
+        priority: "",
+        dependencies: {state: "none", issues: []},
+        pullRequests: {open: [], merged: []},
+        group: "eligible",
+        trackerReadDeferred: true,
+        ambiguityReason: null
+      }]
+    }')"
+  if [ "$json_output" -eq 1 ]; then
+    printf '%s\n' "$out_json"
+    exit 0
+  fi
+  printf 'PROVIDER=linear\n'
+  printf 'TRACKER_READ_DEFERRED=yes\n'
+  printf 'Run Item Scope Resolver\n'
+  printf 'Resolved issue: %s\n' "$resolved_issue"
+  printf 'Item input: %s\n' "$item_input"
+  printf 'Base branch: %s (%s)\n' "$base_branch" "$base_reason"
+  printf -- '- eligible %s [Linear tracker details deferred]\n' "$resolved_issue"
+  printf 'Read-only: %s\n' "$(printf '%s\n' "$out_json" | jq -r '.readOnlyGuarantee')"
+  exit 0
 fi
 
 resolver_args=(

--- a/scripts/development-workflow/tests/test-run-bounded-prelude.sh
+++ b/scripts/development-workflow/tests/test-run-bounded-prelude.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
 HELPER="$REPO_ROOT/scripts/development-workflow/run-epic-policy-recommender.sh"
 PRELUDE="$REPO_ROOT/scripts/development-workflow/run-bounded-prelude.sh"
+ITEM_RESOLVER="$REPO_ROOT/scripts/development-workflow/run-item-scope-resolver.sh"
 
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
@@ -79,6 +80,73 @@ run_fails "reject_epic_and_issue" "not --epic with item flags" \
   "$PRELUDE" --original-command "/run-item 1" --epic 1047 --issue 1049
 run_fails "reject_multiple_item_flags" "exactly one item target flag" \
   "$PRELUDE" --original-command "/run-item 1" --issue 1049 --branch feature/1049-x
+
+guardrails_config="$TMP_ROOT/ai-dev-workflow-linear-guardrails.yaml"
+cat > "$guardrails_config" <<'YAML'
+schema_version: 2
+review:
+  on_draft:
+    runner:
+      - codex
+issue_tracker:
+  provider: linear
+guardrails:
+  mode: assisted
+  backlog_start:
+    allow_without_confirmation: true
+  stages:
+    spec:
+      may_open_pr: true
+      may_merge_pr: false
+      max_merge_risk: low
+    plan:
+      may_open_pr: true
+      may_merge_pr: false
+      max_merge_risk: low
+    implementation:
+      may_open_pr: true
+      may_merge_pr: false
+      max_merge_risk: low
+YAML
+
+github_config="$TMP_ROOT/ai-dev-workflow-github.yaml"
+cat > "$github_config" <<'YAML'
+schema_version: 2
+issue_tracker:
+  provider: github_projects
+YAML
+
+linear_prelude_out="$(AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" \
+  "$PRELUDE" --original-command "/run-item LEA-185" --issue LEA-185 --json)"
+run_test "linear_issue_identifier_resolves" "LEA-185" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.scope.resolvedIssueIdentifier')"
+run_test "guardrails_section_present" "present" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.guardrails.section')"
+run_test "guardrails_backlog_start_applied" "true" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.policyRecommendation.effectivePolicy.mayStartBacklog')"
+run_test "guardrails_merge_stays_false" "false" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.policyRecommendation.effectivePolicy.mayMerge')"
+run_test "guardrails_implementation_merge_reported" "false" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.guardrails.stages.implementation.may_merge_pr')"
+
+linear_target_prelude_out="$(AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" \
+  "$PRELUDE" --original-command "/run-item LEA-185" --target LEA-185 --json)"
+run_test "linear_target_identifier_resolves" "LEA-185" "$(printf '%s\n' "$linear_target_prelude_out" | jq -r '.scope.resolvedIssueIdentifier')"
+
+linear_resolver_text="$(AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" \
+  "$ITEM_RESOLVER" --issue LEA-185)"
+run_test "linear_resolver_text_defers_tracker" "true" "$(grep -q 'TRACKER_READ_DEFERRED=yes' <<<"$linear_resolver_text" && echo true || echo false)"
+
+linear_resolver_json="$(AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" \
+  "$ITEM_RESOLVER" --issue LEA-185 --json)"
+run_test "linear_resolver_json_defers_tracker" "true" "$(printf '%s\n' "$linear_resolver_json" | jq -r '.trackerReadDeferred')"
+run_test "linear_resolver_json_uses_backlog_placeholder" "Backlog" "$(printf '%s\n' "$linear_resolver_json" | jq -r '.items[0].status')"
+
+linear_target_json="$(AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" \
+  "$ITEM_RESOLVER" --target LEA-185 --json)"
+run_test "linear_target_json_defers_tracker" "true" "$(printf '%s\n' "$linear_target_json" | jq -r '.trackerReadDeferred')"
+
+run_fails "reject_linear_identifier_with_underscore" "invalid --issue identifier" \
+  env AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" "$ITEM_RESOLVER" --issue A_B-123
+run_fails "reject_whitespace_issue_identifier" "invalid --issue identifier" \
+  env AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" "$ITEM_RESOLVER" --issue "   "
+run_fails "reject_linear_identifier_for_non_linear_provider" "invalid --issue identifier" \
+  env AI_DEV_WORKFLOW_CONFIG_FILE="$github_config" "$ITEM_RESOLVER" --issue LEA-185
 
 printf '\nResults: %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/development-workflow/tests/test-run-bounded-prelude.sh
+++ b/scripts/development-workflow/tests/test-run-bounded-prelude.sh
@@ -116,6 +116,17 @@ issue_tracker:
   provider: github_projects
 YAML
 
+absent_guardrails_config="$TMP_ROOT/ai-dev-workflow-linear-no-guardrails.yaml"
+cat > "$absent_guardrails_config" <<'YAML'
+schema_version: 2
+review:
+  on_draft:
+    runner:
+      - codex
+issue_tracker:
+  provider: linear
+YAML
+
 linear_prelude_out="$(AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" \
   "$PRELUDE" --original-command "/run-item LEA-185" --issue LEA-185 --json)"
 run_test "linear_issue_identifier_resolves" "LEA-185" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.scope.resolvedIssueIdentifier')"
@@ -140,6 +151,14 @@ run_test "linear_resolver_json_uses_backlog_placeholder" "Backlog" "$(printf '%s
 linear_target_json="$(AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" \
   "$ITEM_RESOLVER" --target LEA-185 --json)"
 run_test "linear_target_json_defers_tracker" "true" "$(printf '%s\n' "$linear_target_json" | jq -r '.trackerReadDeferred')"
+
+absent_guardrails_out="$(AI_DEV_WORKFLOW_CONFIG_FILE="$absent_guardrails_config" \
+  "$PRELUDE" --original-command "/run-item LEA-185" --issue LEA-185 --json)"
+run_test "absent_guardrails_section_reported" "absent" "$(printf '%s\n' "$absent_guardrails_out" | jq -r '.guardrails.section')"
+run_test "absent_guardrails_backlog_default_applied" "false" "$(printf '%s\n' "$absent_guardrails_out" | jq -r '.policyRecommendation.effectivePolicy.mayStartBacklog')"
+run_test "absent_guardrails_review_default_applied" "false" "$(printf '%s\n' "$absent_guardrails_out" | jq -r '.policyRecommendation.effectivePolicy.delegateReview')"
+run_test "absent_guardrails_merge_default_applied" "false" "$(printf '%s\n' "$absent_guardrails_out" | jq -r '.policyRecommendation.effectivePolicy.mayMerge')"
+run_test "absent_guardrails_risk_default_applied" "low" "$(printf '%s\n' "$absent_guardrails_out" | jq -r '.policyRecommendation.effectivePolicy.maxRisk')"
 
 run_fails "reject_linear_identifier_with_underscore" "invalid --issue identifier" \
   env AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" "$ITEM_RESOLVER" --issue A_B-123

--- a/scripts/development-workflow/tests/test-run-bounded-prelude.sh
+++ b/scripts/development-workflow/tests/test-run-bounded-prelude.sh
@@ -139,6 +139,25 @@ guardrails:
       max_merge_risk: extreme
 YAML
 
+stage_guardrails_config="$TMP_ROOT/ai-dev-workflow-stage-guardrails.yaml"
+cat > "$stage_guardrails_config" <<'YAML'
+schema_version: 2
+issue_tracker:
+  provider: linear
+guardrails:
+  mode: assisted
+  stages:
+    spec:
+      may_merge_pr: false
+      max_merge_risk: low
+    plan:
+      may_merge_pr: true
+      max_merge_risk: high
+    implementation:
+      may_merge_pr: true
+      max_merge_risk: high
+YAML
+
 linear_prelude_out="$(AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" \
   "$PRELUDE" --original-command "/run-item LEA-185" --issue LEA-185 --json)"
 run_test "linear_issue_identifier_resolves" "LEA-185" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.scope.resolvedIssueIdentifier')"
@@ -184,6 +203,11 @@ run_test "invalid_guardrails_json_fails" "true" "$([ "$invalid_guardrails_status
 run_test "invalid_guardrails_json_detail" "true" "$(
   printf '%s\n' "$invalid_guardrails_out" | jq -r '.detail | test("max_merge_risk")' 2>/dev/null || echo false
 )"
+
+stage_guardrails_out="$(AI_DEV_WORKFLOW_CONFIG_FILE="$stage_guardrails_config" \
+  "$PRELUDE" --original-command "/run-item LEA-185" --issue LEA-185 --json)"
+run_test "stage_guardrails_active_merge_limit" "false" "$(printf '%s\n' "$stage_guardrails_out" | jq -r '.policyRecommendation.effectivePolicy.mayMerge')"
+run_test "stage_guardrails_active_risk_limit" "low" "$(printf '%s\n' "$stage_guardrails_out" | jq -r '.policyRecommendation.effectivePolicy.maxRisk')"
 
 run_fails "reject_linear_identifier_with_underscore" "invalid --issue identifier" \
   env AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" "$ITEM_RESOLVER" --issue A_B-123

--- a/scripts/development-workflow/tests/test-run-bounded-prelude.sh
+++ b/scripts/development-workflow/tests/test-run-bounded-prelude.sh
@@ -127,6 +127,18 @@ issue_tracker:
   provider: linear
 YAML
 
+invalid_guardrails_config="$TMP_ROOT/ai-dev-workflow-invalid-guardrails.yaml"
+cat > "$invalid_guardrails_config" <<'YAML'
+schema_version: 2
+issue_tracker:
+  provider: linear
+guardrails:
+  mode: assisted
+  stages:
+    implementation:
+      max_merge_risk: extreme
+YAML
+
 linear_prelude_out="$(AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" \
   "$PRELUDE" --original-command "/run-item LEA-185" --issue LEA-185 --json)"
 run_test "linear_issue_identifier_resolves" "LEA-185" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.scope.resolvedIssueIdentifier')"
@@ -134,6 +146,8 @@ run_test "guardrails_section_present" "present" "$(printf '%s\n' "$linear_prelud
 run_test "guardrails_backlog_start_applied" "true" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.policyRecommendation.effectivePolicy.mayStartBacklog')"
 run_test "guardrails_merge_stays_false" "false" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.policyRecommendation.effectivePolicy.mayMerge')"
 run_test "guardrails_implementation_merge_reported" "false" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.guardrails.stages.implementation.may_merge_pr')"
+run_test "guardrails_policy_source_reported" "guardrails" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.policyRecommendation.fieldSources.mayStartBacklog')"
+run_test "guardrails_policy_not_marked_explicit" "false" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.policyRecommendation.confirmationReason | test("policy values are explicit")')"
 
 linear_target_prelude_out="$(AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" \
   "$PRELUDE" --original-command "/run-item LEA-185" --target LEA-185 --json)"
@@ -159,6 +173,17 @@ run_test "absent_guardrails_backlog_default_applied" "false" "$(printf '%s\n' "$
 run_test "absent_guardrails_review_default_applied" "false" "$(printf '%s\n' "$absent_guardrails_out" | jq -r '.policyRecommendation.effectivePolicy.delegateReview')"
 run_test "absent_guardrails_merge_default_applied" "false" "$(printf '%s\n' "$absent_guardrails_out" | jq -r '.policyRecommendation.effectivePolicy.mayMerge')"
 run_test "absent_guardrails_risk_default_applied" "low" "$(printf '%s\n' "$absent_guardrails_out" | jq -r '.policyRecommendation.effectivePolicy.maxRisk')"
+run_test "absent_guardrails_policy_source_reported" "conservative-defaults" "$(printf '%s\n' "$absent_guardrails_out" | jq -r '.policyRecommendation.fieldSources.delegateReview')"
+
+set +e
+invalid_guardrails_out="$(AI_DEV_WORKFLOW_CONFIG_FILE="$invalid_guardrails_config" \
+  "$PRELUDE" --original-command "/run-item LEA-185" --issue LEA-185 --json 2>&1)"
+invalid_guardrails_status=$?
+set -e
+run_test "invalid_guardrails_json_fails" "true" "$([ "$invalid_guardrails_status" -ne 0 ] && echo true || echo false)"
+run_test "invalid_guardrails_json_detail" "true" "$(
+  printf '%s\n' "$invalid_guardrails_out" | jq -r '.detail | test("max_merge_risk")' 2>/dev/null || echo false
+)"
 
 run_fails "reject_linear_identifier_with_underscore" "invalid --issue identifier" \
   env AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" "$ITEM_RESOLVER" --issue A_B-123


### PR DESCRIPTION
## Summary
- Support Linear-style issue identifiers such as `LEA-185` in `run-item-scope-resolver.sh` for both `--issue` and direct `--target` item selectors.
- Apply repository guardrail defaults before bounded-prelude scope and policy recommendation so configured backlog-start, review delegation, merge, and risk defaults affect the emitted policy.
- Parse guardrails with the repository's built-in workflow config parser instead of requiring PyYAML, and keep unreadable guardrails as a structured stop.

## Validation
- `bash scripts/development-workflow/tests/test-run-bounded-prelude.sh`
- `shellcheck --severity=warning scripts/development-workflow/run-bounded-prelude.sh scripts/development-workflow/run-item-scope-resolver.sh scripts/development-workflow/tests/test-run-bounded-prelude.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `bash scripts/development-workflow/tests/test-run-epic-scope-resolver.sh`
- `npx markdownlint-cli2 "CHANGELOG.md"`
- `find CHANGELOG.md -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py`
- Manual: temp Linear config with `/run-item LEA-185` returned `LEA-185 true false` for resolved key, backlog start, and merge permission.

## CHANGELOG
- Added an `[Unreleased]` Fixed entry for Linear-backed run-item guardrails.

## Test Harness Coverage Checklist
- Empty/zero-length input: existing no-scope and multiple-selector failure paths remain covered.
- Whitespace-only input: added `reject_whitespace_issue_identifier`.
- Boundary values: numeric GitHub issue flow remains covered by neighboring resolver tests; new Linear key flow covers valid key shape and invalid underscore key.
- Missing environment variables: not applicable; these tests provide explicit fixture config paths and do not require secrets.
- Concurrent execution: not applicable; fixtures live under a per-run `mktemp -d` directory.
- Negative assertions: added malformed Linear key and non-Linear-provider rejection cases.
- Single EXIT trap: unchanged single cleanup trap.
- Variable-length quoting safety: fixture config paths are quoted through each invocation.
- `BASH_SOURCE` / sourced mode: not applicable; this harness is executed directly.
- Sourced-function ordering: not applicable; the harness invokes scripts as commands.

## Pre-submission self-review
Stale markers: none found in `git diff develop...HEAD`. Caller consistency: verified `run-bounded-prelude.sh` passes configured guardrail defaults into `run-item-scope-resolver.sh` before policy generation, and the item resolver preserves numeric GitHub issue behavior while deferring Linear tracker reads. Coverage: addresses the verified Leasity PR #450 reusable fixes without bringing in Leasity-specific `.ai-dev-workflow.yaml` or changelog content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reorders when autonomy defaults apply and changes effective merge/risk for deferred Linear scope; mistakes could allow or block mutations incorrectly, but changes are read-only prelude paths with expanded fixture coverage.
> 
> **Overview**
> Bounded **`/run-item`** prelude now resolves **repository guardrails before scope and policy recommendation**, so backlog-start, review delegation, merge permission, and max risk come from `.ai-dev-workflow.yaml` (or conservative defaults) instead of only CLI overrides. Guardrails are parsed via **`workflow-config-resolver.py`** (no PyYAML); invalid config fails with a structured **`guardrails_config_unreadable`** stop that includes affected work item and human action.
> 
> **`run-item-scope-resolver.sh`** accepts **Linear-style keys** (e.g. `LEA-185`) on `--issue` and `--target` when `issue_tracker.provider` is `linear`, emitting deferred-read scope JSON with a Backlog placeholder status for policy staging. Numeric GitHub issue behavior is unchanged; non-Linear repos reject alphanumeric issue IDs.
> 
> Policy JSON now records **`fieldSources`** and adjusts **`confirmationReason`** when values were inferred from guardrails rather than explicit flags. Tests and CHANGELOG cover Linear fixtures, absent/invalid guardrails, and stage-based merge/risk limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a0bc4ad838a7685a111fb14e34098443737c4ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->