### PR TITLE
fix(workflow): require approval for graduation merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Workflow graduation guard**: Stop `/run-epic` delegated merges at
+  `graduation_approval_required` for `develop-<slug>` -> `develop` graduation
+  PRs unless explicit graduation approval is recorded.
 - **Delegated merge cleanup guidance**: `/run-item` and `/run-epic` now state
   that delegated `merge_allowed` runs continue through branch cleanup,
   `post-merge-cleanup`, and live tracker verification before reporting terminal.

--- a/docs/workflow/development-workflow/guardrails-enforcement.md
+++ b/docs/workflow/development-workflow/guardrails-enforcement.md
@@ -223,6 +223,7 @@ table is required for consistent stop reporting.
 | `high_risk_change` | The PR is classified above the configured `max_merge_risk` for the stage. |
 | `destructive_action` | The next action would delete branches, data, releases, or other non-recoverable artifacts. |
 | `human_checkpoint_required` | A declared stage-scoped human checkpoint for the PR's work item is still pending, or the PR still carries `human-checkpoint-required`. |
+| `graduation_approval_required` | A `develop-<slug>` -> `develop` graduation PR is the next merge candidate but explicit human graduation approval has not been recorded through `/graduate-development <slug>`. |
 | `missing_tracker_context` | A required tracker field (status, type, assignee, dependency link) is absent or unresolvable. |
 | `missing_required_secret_or_permission` | A required credential, GitHub permission, or access token is absent. |
 | `guardrails_config_unreadable` | The `guardrails` block in `.ai-dev-workflow.yaml` is missing required fields, uses invalid values, or is internally contradictory. |

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -537,7 +537,14 @@ Before merge:
 10. Confirm the risk classifier permits merge under the invocation's
     `--max-risk`.
 11. Confirm the PR disposition audit comment exists for the reviewed head SHA.
-12. Run `run-epic-delegated-gate.sh` against the assembled evidence.
+12. Confirm the candidate PR is not a graduation PR
+    (`develop-<slug>` -> `develop`) unless explicit graduation approval has
+    been recorded in the assembled policy evidence as
+    `graduationApproved: true`. `/run-epic` delegated merge authority applies to
+    in-scope child PRs, not to integration-branch graduation. A graduation PR
+    without this approval must stop with `graduation_approval_required` and be
+    resumed through `/graduate-development <slug>`.
+13. Run `run-epic-delegated-gate.sh` against the assembled evidence.
 
 Proceed to the repository merge protocol only when the delegated gate reports
 `merge_allowed`. If the gate reports `fix_required`, remove readiness labels,
@@ -552,6 +559,9 @@ reports `blocked`, stop until required state is available.
 When all gates permit merge:
 
 1. Merge with the repository-approved merge path for the PR target branch.
+   This merge step is for in-scope child PRs. If the candidate is a graduation
+   PR (`develop-<slug>` -> `develop`), stop unless the explicit graduation
+   approval evidence described in the delegated gate checklist is present.
 2. Verify GitHub reports the PR state as `MERGED`.
 3. Delete or prune the merged branch as appropriate.
 4. Run post-merge cleanup for the correct base branch. For direct single-PR
@@ -603,4 +613,6 @@ real external condition or authority boundary, or the invocation policy forbids
 starting the remaining Backlog work. Final stop messages must name the exact
 gate: missing authority, risk classification, CI/check state, unresolved
 reviewer findings, tracker ambiguity, delegated gate state, or backlog-start
-policy.
+policy. When all child items are merged but the integration branch has not been
+explicitly approved for graduation, stop at `graduation_approval_required` and
+report the integration branch as `ready_for_graduation`.

--- a/scripts/development-workflow/run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/run-epic-delegated-gate.sh
@@ -133,6 +133,11 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     end;
   def implementation_branch:
     (.pr.headRefName // "") | test("^(feature|fix|refactor|hotfix|backport/hotfix)/");
+  def graduation_pr:
+    ((.pr.headRefName // "") | test("^develop-[^/]+$")) and
+    ((.pr.baseRefName // "") == "develop");
+  def graduation_approved:
+    (policy.graduationApproved // false) == true;
   def stage_rank($stage):
     if $stage == "spec" then 1
     elif $stage == "plan" then 2
@@ -184,6 +189,9 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
    else $reasons end) as $reasons |
   (if (policy.mayMerge // false) != true
    then add_reason($reasons; "delegated merge authority is missing")
+   else $reasons end) as $reasons |
+  (if graduation_pr and (graduation_approved | not)
+   then add_reason($reasons; "graduation_approval_required: PR #" + ((.pr.number // "unknown") | tostring) + " merges integration branch " + ((.pr.headRefName // "") | tostring) + " to " + ((.pr.baseRefName // "") | tostring) + "; run /graduate-development <slug> and record explicit human approval before delegated merge")
    else $reasons end) as $reasons |
   (if (.item.status // "") == "Backlog" and ((policy.mayStartBacklog // false) != true)
    then add_reason($reasons; "Backlog item cannot start without explicit may-start-backlog authority")
@@ -245,7 +253,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     decision: (
       if $count == 0 then "merge_allowed"
       elif ($reasons | any(test("reviewer blocking|CI checks|unresolved blocking|advisories"))) then "fix_required"
-      elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog|human_checkpoint_required|human-checkpoint"))) then "human_required"
+      elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog|human_checkpoint_required|human-checkpoint|graduation_approval_required"))) then "human_required"
       else "blocked"
       end
     ),
@@ -255,6 +263,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
       if $count == 0 then "record merge evidence and use the repository merge protocol"
       elif ($reasons | any(test("reviewer blocking|CI checks|unresolved blocking|advisories"))) then "remove readiness labels, fix, rerun validation, reviewer loop, CI loop, and this gate"
       elif ($reasons | any(test("human_checkpoint_required|human-checkpoint"))) then "stop for the named human checkpoint action, record satisfied or waived evidence, sync labels, and rerun this gate"
+      elif ($reasons | any(test("graduation_approval_required"))) then "stop for explicit graduation approval via /graduate-development before mutating"
       elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog"))) then "stop for human authority or setup before mutating"
       else "block until required state is available"
       end

--- a/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
@@ -243,6 +243,22 @@ run_test "implementation_pr_still_requires_regression_label" "blocked" "$(decisi
 implementation_skipped_with_label_fixture="$(write_fixture implementation-skipped-with-label '.statusChecks += [{"name": "E2E regression (placeholder)", "status": "COMPLETED", "conclusion": "SKIPPED"}]')"
 run_test "implementation_pr_with_regression_label_allows_skipped_check" "merge_allowed" "$(decision_for "$implementation_skipped_with_label_fixture")"
 
+graduation_fixture="$(write_fixture graduation '.pr.headRefName = "develop-graduation-guard" | .pr.baseRefName = "develop" | .pr.labels = ["ready-for-human-review"]')"
+run_test "graduation_pr_requires_explicit_approval" "human_required" "$(decision_for "$graduation_fixture")"
+run_test "graduation_pr_reason_names_guard" "true" "$(reason_match_for "$graduation_fixture" "graduation_approval_required")"
+
+missing_graduation_policy_fixture="$(write_fixture missing-graduation-policy '.pr.headRefName = "develop-graduation-guard" | .pr.baseRefName = "develop" | .pr.labels = ["ready-for-human-review"] | del(.policy.graduationApproved)')"
+run_test "missing_graduation_approval_defaults_unapproved" "human_required" "$(decision_for "$missing_graduation_policy_fixture")"
+
+develop_prefixed_path_fixture="$(write_fixture develop-prefixed-path '.pr.headRefName = "develop/graduation-guard" | .pr.baseRefName = "develop" | .pr.labels = ["ready-for-human-review"]')"
+run_test "develop_prefixed_path_branch_is_not_graduation" "merge_allowed" "$(decision_for "$develop_prefixed_path_fixture")"
+
+develop_branch_to_integration_fixture="$(write_fixture develop-branch-to-integration '.pr.headRefName = "develop-graduation-guard" | .pr.baseRefName = "develop-parent" | .pr.labels = ["ready-for-human-review"]')"
+run_test "develop_branch_to_non_develop_base_is_not_graduation" "merge_allowed" "$(decision_for "$develop_branch_to_integration_fixture")"
+
+approved_graduation_fixture="$(write_fixture approved-graduation '.pr.headRefName = "develop-graduation-guard" | .pr.baseRefName = "develop" | .pr.labels = ["ready-for-human-review"] | .policy.graduationApproved = true')"
+run_test "graduation_pr_allows_recorded_approval" "merge_allowed" "$(decision_for "$approved_graduation_fixture")"
+
 setup_fixture="$(write_fixture setup '.pr.labels += ["needs-setup"]')"
 run_test "needs_setup_requires_human" "human_required" "$(decision_for "$setup_fixture")"
 


### PR DESCRIPTION
## Summary

- Add a `graduation_approval_required` delegated-gate stop for `develop-<slug>` -> `develop` graduation PRs unless `policy.graduationApproved` is recorded.
- Document that `/run-epic` delegated merge authority applies to child PRs and must stop at `ready_for_graduation` for unapproved integration-branch graduation.
- Add regression coverage for blocked, explicitly approved, and false-positive graduation branch matching.

## Root Cause

`/run-epic` delegated merge authority did not distinguish in-scope child PRs from integration-branch graduation PRs, while the graduation protocol requires a separate explicit human approval gate.

## Validation

- `bash scripts/development-workflow/tests/test-run-epic-delegated-gate.sh` (74 passed)
- `shellcheck --severity=warning scripts/development-workflow/run-epic-delegated-gate.sh scripts/development-workflow/tests/test-run-epic-delegated-gate.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `npx markdownlint-cli2 CHANGELOG.md docs/workflow/development-workflow/guardrails-enforcement.md docs/workflow/development-workflow/protocols/95-run-epic-protocol.md`
- `git diff --check`

## Pre-Submission Self-Review

Stale markers: none. Caller/protocol consistency: verified against Protocol 95, the guardrails stop-condition table, and the delegated-gate helper. Coverage: the diff addresses the reported graduation-approval gap with enforcement and regression tests. Board membership check: not applicable; this is a direct workflow guard fix without a tracker issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delegated merge behavior for integration graduation PRs—a sensitive workflow boundary—but scope is narrow (gate + docs + tests) with explicit human handoff when approval is missing.
> 
> **Overview**
> **`/run-epic` delegated merge no longer treats integration graduation like child PRs.** When the next merge candidate is a `develop-<slug>` → `develop` graduation PR, the delegated gate blocks unless policy evidence includes `graduationApproved: true`; otherwise the run stops with `graduation_approval_required` and hands off to `/graduate-development <slug>`.
> 
> `run-epic-delegated-gate.sh` now classifies graduation PRs by head/base branch pattern, maps missing approval to `human_required`, and documents the unblock action in `nextAction`. Protocol 95 and the guardrails stop-condition table describe the same rule for pre-gate checks and epic closeout (`ready_for_graduation` when children are done but graduation is unapproved). Regression tests cover blocked, approved, missing policy, and non-graduation branch shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df7af79eea2f42d139053a4d2437c556d873b6cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->