### PR TITLE
fix(workflow): scope run-epic PR lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Run-epic scope resolver PR lookup**: Avoid scanning the full repository PR
-  history by resolving linked PRs from cached `gh pr list --base` results for
+  history by resolving linked PRs from cached, paginated results scoped to
   `develop` and each item's integration branch.
 - **Workflow graduation guard**: Stop `/run-epic` delegated merges at
   `graduation_approval_required` for `develop-<slug>` -> `develop` graduation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Run-epic scope resolver PR lookup**: Avoid scanning the full repository PR
+  history by resolving linked PRs from cached `gh pr list --base` results for
+  `develop` and each item's integration branch.
 - **Workflow graduation guard**: Stop `/run-epic` delegated merges at
   `graduation_approval_required` for `develop-<slug>` -> `develop` graduation
   PRs unless explicit graduation approval is recorded.

--- a/scripts/development-workflow/run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/run-epic-scope-resolver.sh
@@ -325,7 +325,9 @@ integration_label_for_issue_json() {
 base_branch_cache_file() {
   local branch="$1"
   local safe
-  safe="$(printf '%s' "$branch" | tr -c 'A-Za-z0-9' '_')"
+  if ! safe="$(printf '%s' "$branch" | od -An -tx1 | tr -d ' \n')"; then
+    error_exit "failed to derive PR cache key for base branch ${branch}."
+  fi
   printf '%s/prs_base_%s.json\n' "$tmp_dir" "$safe"
 }
 
@@ -345,6 +347,31 @@ fetch_prs_for_base() {
   printf '%s\n' "$cache_file"
 }
 
+resolve_scope_pr_bases() {
+  local bases_file issue issue_json integration_label candidate_base
+  bases_file="$tmp_dir/pr_bases.txt"
+  printf '%s\n' "develop" > "$bases_file"
+  if [ -n "$base_override" ]; then
+    printf '%s\n' "$base_override" >> "$bases_file"
+  fi
+
+  while IFS= read -r issue; do
+    [ -n "$issue" ] || continue
+    if ! issue_json="$(gh issue view "$issue" --json labels 2>/dev/null)"; then
+      continue
+    fi
+    if ! integration_label="$(printf '%s\n' "$issue_json" | integration_label_for_issue_json)"; then
+      error_exit "failed to parse issue #${issue} integration branch label."
+    fi
+    if [ -n "$integration_label" ]; then
+      candidate_base="develop-${integration_label#integration-branch:}"
+      printf '%s\n' "$candidate_base" >> "$bases_file"
+    fi
+  done < "$subissues_file"
+
+  sort -u "$bases_file"
+}
+
 linked_pr_json() {
   local issue="$1"
   local integration_label="$2"
@@ -354,7 +381,7 @@ linked_pr_json() {
   if [ -n "$integration_label" ]; then
     candidate_base="develop-${integration_label#integration-branch:}"
   fi
-  bases="$(printf '%s\n%s\n%s\n' "develop" "$candidate_base" "$base_override" | sed '/^$/d' | sort -u)"
+  bases="$(printf '%s\n%s\n' "$scope_pr_bases" "$candidate_base" | sed '/^$/d' | sort -u)"
 
   open_prs="[]"
   merged_prs="[]"
@@ -571,6 +598,8 @@ if [ -n "$epic_number" ]; then
 else
   parse_explicit_items "$items_arg"
 fi
+
+scope_pr_bases="$(resolve_scope_pr_bases)"
 
 while IFS= read -r issue; do
   [ -n "$issue" ] || continue

--- a/scripts/development-workflow/run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/run-epic-scope-resolver.sh
@@ -162,7 +162,9 @@ esac
 tmp_dir="$(mktemp -d)"
 items_file="$tmp_dir/items.jsonl"
 subissues_file="$tmp_dir/subissues.jsonl"
+scope_label_failures_file="$tmp_dir/scope_label_failures.txt"
 touch "$items_file" "$subissues_file"
+: > "$scope_label_failures_file"
 
 cleanup() {
   rm -rf "$tmp_dir"
@@ -358,7 +360,8 @@ resolve_scope_pr_bases() {
   while IFS= read -r issue; do
     [ -n "$issue" ] || continue
     if ! issue_json="$(gh issue view "$issue" --json labels 2>/dev/null)"; then
-      error_exit "failed to read labels for issue #${issue} while resolving PR base candidates."
+      printf '%s\n' "$issue" >> "$scope_label_failures_file"
+      continue
     fi
     if ! integration_label="$(printf '%s\n' "$issue_json" | integration_label_for_issue_json)"; then
       error_exit "failed to parse issue #${issue} integration branch label."
@@ -480,7 +483,7 @@ dependency_json() {
 enrich_item() {
   local issue="$1"
   local issue_json title state state_reason labels integration_label status type priority pr_json dep_json group body
-  local merged_impl_count open_review_count dep_state ambiguity_reason
+  local merged_impl_count open_review_count dep_state ambiguity_reason scope_base_ambiguity_reason
 
   if ! issue_json="$(gh issue view "$issue" --json number,title,state,stateReason,body,labels,projectItems 2>/dev/null)"; then
     jq -n --argjson number "$issue" '{number:$number,title:"",state:"UNKNOWN",group:"ambiguous",ambiguityReason:"issue could not be read"}'
@@ -526,7 +529,15 @@ enrich_item() {
   ')"; then
     error_exit "failed to parse issue #${issue} priority."
   fi
-  pr_json="$(linked_pr_json "$issue" "$integration_label")"
+  scope_base_ambiguity_reason=""
+  if [ -z "$integration_label" ] && [ -z "$base_override" ] && [ -s "$scope_label_failures_file" ]; then
+    scope_base_ambiguity_reason="scope integration branch candidates could not be fully resolved"
+  fi
+  if [ -n "$scope_base_ambiguity_reason" ]; then
+    pr_json="$(jq -n '{open: [], merged: []}')"
+  else
+    pr_json="$(linked_pr_json "$issue" "$integration_label")"
+  fi
   dep_json="$(dependency_json "$body")"
   if ! merged_impl_count="$(printf '%s\n' "$pr_json" | jq '[.merged[] | select(.headRefName | test("^(feature|fix|refactor|hotfix)/"))] | length')"; then
     error_exit "failed to parse merged PR state for issue #${issue}."
@@ -540,7 +551,10 @@ enrich_item() {
 
   group="eligible"
   ambiguity_reason=""
-  if completed_status "$status" || [ "$state_reason" = "COMPLETED" ] \
+  if [ -n "$scope_base_ambiguity_reason" ]; then
+    group="ambiguous"
+    ambiguity_reason="$scope_base_ambiguity_reason"
+  elif completed_status "$status" || [ "$state_reason" = "COMPLETED" ] \
     || [ "$merged_impl_count" -gt 0 ]; then
     group="already_merged"
   elif [ "$status" = "Cancelled" ] || { [ "$state" = "CLOSED" ] && [ "$state_reason" != "COMPLETED" ]; }; then

--- a/scripts/development-workflow/run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/run-epic-scope-resolver.sh
@@ -335,9 +335,9 @@ fetch_prs_for_base() {
   cache_file="$(base_branch_cache_file "$branch")"
 
   if [ ! -f "$cache_file" ]; then
-    if ! gh pr list --repo "$repo" --state all --base "$branch" \
-      --json number,title,headRefName,baseRefName,state,isDraft,labels,mergedAt \
-      --limit 500 > "$cache_file" 2>/dev/null; then
+    if ! gh api --paginate --slurp \
+      "repos/${repo}/pulls?state=all&base=${branch}&per_page=100" \
+      > "$cache_file" 2>/dev/null; then
       error_exit "failed to read PRs targeting base branch ${branch}."
     fi
   fi
@@ -366,15 +366,15 @@ $candidate_base"
     cache_file="$(fetch_prs_for_base "$base")"
 
     if ! open_prs="$(jq --arg issue "$issue" --argjson acc "$open_prs" '
-          $acc + [ .[] | select(.state == "OPEN")
-            | select(.headRefName | test("^(spec|implementation-plan|feature|fix|refactor|hotfix)/" + $issue + "(-|$)"))
+          $acc + [ .[][] | select(.state == "open")
+            | select(.head.ref | test("^(spec|implementation-plan|feature|fix|refactor|hotfix)/" + $issue + "(-|$)"))
             | {
                 number,
                 title,
                 state: "OPEN",
-                headRefName,
-                baseRefName,
-                isDraft,
+                headRefName: .head.ref,
+                baseRefName: .base.ref,
+                isDraft: .draft,
                 labels: [.labels[].name]
               }
           ]' "$cache_file")"; then
@@ -382,17 +382,17 @@ $candidate_base"
     fi
 
     if ! merged_prs="$(jq --arg issue "$issue" --argjson acc "$merged_prs" '
-          $acc + [ .[] | select(.state == "MERGED")
-            | select(.headRefName | test("^(spec|implementation-plan|feature|fix|refactor|hotfix)/" + $issue + "(-|$)"))
+          $acc + [ .[][] | select(.merged_at != null)
+            | select(.head.ref | test("^(spec|implementation-plan|feature|fix|refactor|hotfix)/" + $issue + "(-|$)"))
             | {
                 number,
                 title,
                 state: "MERGED",
-                headRefName,
-                baseRefName,
+                headRefName: .head.ref,
+                baseRefName: .base.ref,
                 isDraft: false,
                 labels: [],
-                mergedAt
+                mergedAt: .merged_at
               }
           ]' "$cache_file")"; then
       error_exit "failed to parse merged PRs targeting ${base} while resolving issue #${issue}."

--- a/scripts/development-workflow/run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/run-epic-scope-resolver.sh
@@ -163,8 +163,6 @@ tmp_dir="$(mktemp -d)"
 items_file="$tmp_dir/items.jsonl"
 subissues_file="$tmp_dir/subissues.jsonl"
 touch "$items_file" "$subissues_file"
-open_prs_raw_cache=""
-closed_prs_raw_cache=""
 
 cleanup() {
   rm -rf "$tmp_dir"
@@ -324,55 +322,84 @@ integration_label_for_issue_json() {
   jq -r '[.labels[].name | select(startswith("integration-branch:"))] | first // ""'
 }
 
+base_branch_cache_file() {
+  local branch="$1"
+  local safe
+  safe="$(printf '%s' "$branch" | tr -c 'A-Za-z0-9' '_')"
+  printf '%s/prs_base_%s.json\n' "$tmp_dir" "$safe"
+}
+
+fetch_prs_for_base() {
+  local branch="$1"
+  local cache_file
+  cache_file="$(base_branch_cache_file "$branch")"
+
+  if [ ! -f "$cache_file" ]; then
+    if ! gh pr list --repo "$repo" --state all --base "$branch" \
+      --json number,title,headRefName,baseRefName,state,isDraft,labels,mergedAt \
+      --limit 500 > "$cache_file" 2>/dev/null; then
+      error_exit "failed to read PRs targeting base branch ${branch}."
+    fi
+  fi
+
+  printf '%s\n' "$cache_file"
+}
+
 linked_pr_json() {
   local issue="$1"
-  local open_prs merged_prs
+  local integration_label="$2"
+  local candidate_base bases base cache_file open_prs merged_prs
 
-  if [ -z "$open_prs_raw_cache" ]; then
-    if ! open_prs_raw_cache="$(gh api --paginate --slurp \
-      "repos/${repo}/pulls?state=open&per_page=100" 2>/dev/null)"; then
-      error_exit "failed to read open PRs while resolving issue #${issue}."
+  bases="develop"
+  if [ -n "$integration_label" ]; then
+    candidate_base="develop-${integration_label#integration-branch:}"
+    if [ "$candidate_base" != "develop" ]; then
+      bases="develop
+$candidate_base"
     fi
   fi
-  if ! open_prs="$(printf '%s\n' "$open_prs_raw_cache" | jq --arg issue "$issue" '
-        [ .[][]
-          | select(.head.ref | test("^(spec|implementation-plan|feature|fix|refactor|hotfix)/" + $issue + "(-|$)"))
-          | {
-              number,
-              title,
-              state: "OPEN",
-              headRefName: .head.ref,
-              baseRefName: .base.ref,
-              isDraft: .draft,
-              labels: [.labels[].name]
-            }
-        ]')"; then
-    error_exit "failed to parse open PRs while resolving issue #${issue}."
-  fi
 
-  if [ -z "$closed_prs_raw_cache" ]; then
-    if ! closed_prs_raw_cache="$(gh api --paginate --slurp \
-      "repos/${repo}/pulls?state=closed&per_page=100" 2>/dev/null)"; then
-      error_exit "failed to read closed PRs while resolving issue #${issue}."
+  open_prs="[]"
+  merged_prs="[]"
+  while IFS= read -r base; do
+    [ -n "$base" ] || continue
+    cache_file="$(fetch_prs_for_base "$base")"
+
+    if ! open_prs="$(jq --arg issue "$issue" --argjson acc "$open_prs" '
+          $acc + [ .[] | select(.state == "OPEN")
+            | select(.headRefName | test("^(spec|implementation-plan|feature|fix|refactor|hotfix)/" + $issue + "(-|$)"))
+            | {
+                number,
+                title,
+                state: "OPEN",
+                headRefName,
+                baseRefName,
+                isDraft,
+                labels: [.labels[].name]
+              }
+          ]' "$cache_file")"; then
+      error_exit "failed to parse open PRs targeting ${base} while resolving issue #${issue}."
     fi
-  fi
-  if ! merged_prs="$(printf '%s\n' "$closed_prs_raw_cache" | jq --arg issue "$issue" '
-        [ .[][]
-          | select(.merged_at != null)
-          | select(.head.ref | test("^(spec|implementation-plan|feature|fix|refactor|hotfix)/" + $issue + "(-|$)"))
-          | {
-              number,
-              title,
-              state: "MERGED",
-              headRefName: .head.ref,
-              baseRefName: .base.ref,
-              isDraft: false,
-              labels: [],
-              mergedAt: .merged_at
-            }
-        ]')"; then
-    error_exit "failed to parse merged PRs while resolving issue #${issue}."
-  fi
+
+    if ! merged_prs="$(jq --arg issue "$issue" --argjson acc "$merged_prs" '
+          $acc + [ .[] | select(.state == "MERGED")
+            | select(.headRefName | test("^(spec|implementation-plan|feature|fix|refactor|hotfix)/" + $issue + "(-|$)"))
+            | {
+                number,
+                title,
+                state: "MERGED",
+                headRefName,
+                baseRefName,
+                isDraft: false,
+                labels: [],
+                mergedAt
+              }
+          ]' "$cache_file")"; then
+      error_exit "failed to parse merged PRs targeting ${base} while resolving issue #${issue}."
+    fi
+  done <<EOF
+$bases
+EOF
 
   jq -n --argjson open "$open_prs" --argjson merged "$merged_prs" \
     '{open: $open, merged: $merged}'
@@ -475,7 +502,7 @@ enrich_item() {
   ')"; then
     error_exit "failed to parse issue #${issue} priority."
   fi
-  pr_json="$(linked_pr_json "$issue")"
+  pr_json="$(linked_pr_json "$issue" "$integration_label")"
   dep_json="$(dependency_json "$body")"
   if ! merged_impl_count="$(printf '%s\n' "$pr_json" | jq '[.merged[] | select(.headRefName | test("^(feature|fix|refactor|hotfix)/"))] | length')"; then
     error_exit "failed to parse merged PR state for issue #${issue}."

--- a/scripts/development-workflow/run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/run-epic-scope-resolver.sh
@@ -350,14 +350,11 @@ linked_pr_json() {
   local integration_label="$2"
   local candidate_base bases base cache_file open_prs merged_prs
 
-  bases="develop"
+  candidate_base=""
   if [ -n "$integration_label" ]; then
     candidate_base="develop-${integration_label#integration-branch:}"
-    if [ "$candidate_base" != "develop" ]; then
-      bases="develop
-$candidate_base"
-    fi
   fi
+  bases="$(printf '%s\n%s\n%s\n' "develop" "$candidate_base" "$base_override" | sed '/^$/d' | sort -u)"
 
   open_prs="[]"
   merged_prs="[]"

--- a/scripts/development-workflow/run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/run-epic-scope-resolver.sh
@@ -358,7 +358,7 @@ resolve_scope_pr_bases() {
   while IFS= read -r issue; do
     [ -n "$issue" ] || continue
     if ! issue_json="$(gh issue view "$issue" --json labels 2>/dev/null)"; then
-      continue
+      error_exit "failed to read labels for issue #${issue} while resolving PR base candidates."
     fi
     if ! integration_label="$(printf '%s\n' "$issue_json" | integration_label_for_issue_json)"; then
       error_exit "failed to parse issue #${issue} integration branch label."

--- a/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
@@ -153,6 +153,10 @@ JSON
     ;;
   issue\ view\ *\ --json\ labels)
     issue_number="${3}"
+    if [ "${MOCK_LABEL_FETCH_FAIL:-}" = "$issue_number" ]; then
+      printf 'label fetch failed for #%s\n' "$issue_number" >&2
+      exit 64
+    fi
     labels_json='[]'
     case "$issue_number" in
       101|102|103|104|107|109|110|111) labels_json='[{"name":"integration-branch:delegated-epic-orchestration"}]' ;;
@@ -254,6 +258,7 @@ run_fails_contains "rejects_flag_as_may_start_backlog_value" "--may-start-backlo
 run_fails_contains "rejects_flag_as_max_risk_value" "--max-risk requires a value" "$RESOLVER" --items 101 --max-risk --json
 run_fails_contains "missing_epic_clear_error" "not found or inaccessible" env MOCK_EPIC_MODE=missing "$RESOLVER" --epic 900
 run_fails_contains "parent_mismatch_rejected" "does not point back" env MOCK_PARENT_MODE=mismatch "$RESOLVER" --epic 900
+run_fails_contains "label_fetch_failure_rejected" "failed to read labels for issue #101" env MOCK_LABEL_FETCH_FAIL=101 "$RESOLVER" --items 101
 
 items_output="$(run_json --items 101,101,102 --delegate-review --may-merge --may-start-backlog true --max-risk medium)"
 run_test "explicit_items_deduped" "2" "$(printf '%s\n' "$items_output" | jq '.items | length')"

--- a/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
@@ -140,6 +140,7 @@ JSON
       109) state="CLOSED"; state_reason="NOT_PLANNED"; labels_json='[{"name":"integration-branch:delegated-epic-orchestration"}]' ;;
       110) labels_json='[{"name":"integration-branch:delegated-epic-orchestration"}]' ;;
       111) body='Blocked by #108'; labels_json='[{"name":"integration-branch:delegated-epic-orchestration"}]' ;;
+      113) labels_json='[{"name":"integration-branch:foo"}]' ;;
     esac
     jq -n \
       --argjson number "$issue_number" \
@@ -149,6 +150,17 @@ JSON
       --arg body "$body" \
       --argjson labels "$labels_json" \
       '{number:$number,title:$title,state:$state,stateReason:$stateReason,body:$body,labels:$labels,projectItems:[{priority:{name:"High"}}]}'
+    ;;
+  issue\ view\ *\ --json\ labels)
+    issue_number="${3}"
+    labels_json='[]'
+    case "$issue_number" in
+      101|102|103|104|107|109|110|111) labels_json='[{"name":"integration-branch:delegated-epic-orchestration"}]' ;;
+      105) labels_json='[{"name":"integration-branch:alpha"}]' ;;
+      106) labels_json='[{"name":"integration-branch:beta"}]' ;;
+      113) labels_json='[{"name":"integration-branch:foo"}]' ;;
+    esac
+    jq -n --argjson labels "$labels_json" '{labels:$labels}'
     ;;
   issue\ view\ *\ --json\ number,title,state)
     issue_number="${3}"
@@ -162,7 +174,7 @@ JSON
     case "$base" in
       develop-delegated-epic-orchestration)
         cat <<'JSON'
-[[{"number":2101,"title":"Merged plan PR","head":{"ref":"implementation-plan/101-one"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"closed","draft":false,"labels":[],"merged_at":"2026-06-12T11:00:00Z"},{"number":2102,"title":"Plan PR","head":{"ref":"implementation-plan/102-two"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"open","draft":false,"labels":[{"name":"ready-for-human-review"}],"merged_at":null},{"number":2103,"title":"Merged PR","head":{"ref":"feature/103-three"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"closed","draft":false,"labels":[],"merged_at":"2026-06-12T12:00:00Z"},{"number":2104,"title":"Closed unmerged PR","head":{"ref":"feature/104-four"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"closed","draft":false,"labels":[],"merged_at":null},{"number":2110,"title":"Unready PR","head":{"ref":"feature/110-ten"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"open","draft":false,"labels":[],"merged_at":null}]]
+[[{"number":2101,"title":"Merged plan PR","head":{"ref":"implementation-plan/101-one"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"closed","draft":false,"labels":[],"merged_at":"2026-06-12T11:00:00Z"},{"number":2102,"title":"Plan PR","head":{"ref":"implementation-plan/102-two"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"open","draft":false,"labels":[{"name":"ready-for-human-review"}],"merged_at":null},{"number":2103,"title":"Merged PR","head":{"ref":"feature/103-three"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"closed","draft":false,"labels":[],"merged_at":"2026-06-12T12:00:00Z"},{"number":2104,"title":"Closed unmerged PR","head":{"ref":"feature/104-four"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"closed","draft":false,"labels":[],"merged_at":null},{"number":2110,"title":"Unready PR","head":{"ref":"feature/110-ten"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"open","draft":false,"labels":[],"merged_at":null},{"number":2112,"title":"Merged unlabeled issue PR","head":{"ref":"feature/112-twelve"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"closed","draft":false,"labels":[],"merged_at":"2026-06-13T13:00:00Z"}]]
 JSON
         ;;
       develop-custom)
@@ -315,6 +327,18 @@ run_test "pr_lookup_avoids_unbounded_rest_history" "no" "$(
   grep -q 'pulls?state=\(open\|closed\|all\)&per_page=100' "$CALL_LOG" && echo yes || echo no
 )"
 run_test "pr_lookup_cache_preserves_grouping" "102" "$(printf '%s\n' "$cache_probe_output" | jq -r '.groups.in_review[0].number')"
+
+unlabeled_shared_base_output="$(run_json --items 101,112)"
+run_test "unlabeled_item_uses_scope_shared_base" "112" "$(printf '%s\n' "$unlabeled_shared_base_output" | jq -r '.groups.already_merged[] | select(.number == 112) | .number')"
+
+: > "$CALL_LOG"
+cache_collision_output="$(run_json --items 113 --base develop/foo)"
+run_test "pr_lookup_cache_keys_do_not_collide" "yes" "$(
+  grep -q 'pulls?state=all&base=develop-foo&per_page=100' "$CALL_LOG" &&
+    grep -q 'pulls?state=all&base=develop/foo&per_page=100' "$CALL_LOG" &&
+    echo yes || echo no
+)"
+run_test "cache_collision_probe_still_resolves_item" "113" "$(printf '%s\n' "$cache_collision_output" | jq -r '.items[0].number')"
 
 echo ""
 echo "=== Provider normalization and deferred-read signals (#966) ==="

--- a/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
@@ -258,8 +258,6 @@ run_fails_contains "rejects_flag_as_may_start_backlog_value" "--may-start-backlo
 run_fails_contains "rejects_flag_as_max_risk_value" "--max-risk requires a value" "$RESOLVER" --items 101 --max-risk --json
 run_fails_contains "missing_epic_clear_error" "not found or inaccessible" env MOCK_EPIC_MODE=missing "$RESOLVER" --epic 900
 run_fails_contains "parent_mismatch_rejected" "does not point back" env MOCK_PARENT_MODE=mismatch "$RESOLVER" --epic 900
-run_fails_contains "label_fetch_failure_rejected" "failed to read labels for issue #101" env MOCK_LABEL_FETCH_FAIL=101 "$RESOLVER" --items 101
-
 items_output="$(run_json --items 101,101,102 --delegate-review --may-merge --may-start-backlog true --max-risk medium)"
 run_test "explicit_items_deduped" "2" "$(printf '%s\n' "$items_output" | jq '.items | length')"
 run_test "explicit_items_no_expansion" "101,102" "$(printf '%s\n' "$items_output" | jq -r '[.items[].number] | join(",")')"
@@ -335,6 +333,14 @@ run_test "pr_lookup_cache_preserves_grouping" "102" "$(printf '%s\n' "$cache_pro
 
 unlabeled_shared_base_output="$(run_json --items 101,112)"
 run_test "unlabeled_item_uses_scope_shared_base" "112" "$(printf '%s\n' "$unlabeled_shared_base_output" | jq -r '.groups.already_merged[] | select(.number == 112) | .number')"
+
+label_fetch_failure_output="$(MOCK_LABEL_FETCH_FAIL=101 run_json --items 101,112)"
+run_test "label_fetch_failure_keeps_partial_scope" "2" "$(printf '%s\n' "$label_fetch_failure_output" | jq '.items | length')"
+run_test "label_fetch_failure_marks_unlabeled_ambiguous" "112" "$(printf '%s\n' "$label_fetch_failure_output" | jq -r '.groups.ambiguous[] | select(.number == 112) | .number')"
+run_test "label_fetch_failure_explains_ambiguity" "yes" "$(
+  printf '%s\n' "$label_fetch_failure_output" | jq -e '.groups.ambiguous[] | select(.number == 112) | .ambiguityReason == "scope integration branch candidates could not be fully resolved"' >/dev/null &&
+    echo yes || echo no
+)"
 
 : > "$CALL_LOG"
 cache_collision_output="$(run_json --items 113 --base develop/foo)"

--- a/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
@@ -157,15 +157,18 @@ JSON
     jq -n --argjson number "$issue_number" --arg state "$state" \
       '{number:$number,title:("Dependency " + ($number|tostring)),state:$state}'
     ;;
-  api\ --paginate\ --slurp\ repos/lhpaul/ai-dev-framework-template/pulls\?state=open\&per_page=100)
-    cat <<'JSON'
-[[{"number":2102,"title":"Plan PR","head":{"ref":"implementation-plan/102-two"},"base":{"ref":"develop-delegated-epic-orchestration"},"draft":false,"labels":[{"name":"ready-for-human-review"}],"merged_at":null},{"number":2110,"title":"Unready PR","head":{"ref":"feature/110-ten"},"base":{"ref":"develop-delegated-epic-orchestration"},"draft":false,"labels":[],"merged_at":null}]]
+  pr\ list\ --repo\ lhpaul/ai-dev-framework-template\ --state\ all\ --base\ *\ --json\ number,title,headRefName,baseRefName,state,isDraft,labels,mergedAt\ --limit\ 500)
+    base="$(printf '%s\n' "$*" | sed -n 's/.* --base \([^ ][^ ]*\) --json .*/\1/p')"
+    case "$base" in
+      develop-delegated-epic-orchestration)
+        cat <<'JSON'
+[{"number":2101,"title":"Merged plan PR","headRefName":"implementation-plan/101-one","baseRefName":"develop-delegated-epic-orchestration","state":"MERGED","isDraft":false,"labels":[],"mergedAt":"2026-06-12T11:00:00Z"},{"number":2102,"title":"Plan PR","headRefName":"implementation-plan/102-two","baseRefName":"develop-delegated-epic-orchestration","state":"OPEN","isDraft":false,"labels":[{"name":"ready-for-human-review"}],"mergedAt":null},{"number":2103,"title":"Merged PR","headRefName":"feature/103-three","baseRefName":"develop-delegated-epic-orchestration","state":"MERGED","isDraft":false,"labels":[],"mergedAt":"2026-06-12T12:00:00Z"},{"number":2104,"title":"Closed unmerged PR","headRefName":"feature/104-four","baseRefName":"develop-delegated-epic-orchestration","state":"CLOSED","isDraft":false,"labels":[],"mergedAt":null},{"number":2110,"title":"Unready PR","headRefName":"feature/110-ten","baseRefName":"develop-delegated-epic-orchestration","state":"OPEN","isDraft":false,"labels":[],"mergedAt":null}]
 JSON
-    ;;
-  api\ --paginate\ --slurp\ repos/lhpaul/ai-dev-framework-template/pulls\?state=closed\&per_page=100)
-    cat <<'JSON'
-[[{"number":2101,"title":"Merged plan PR","head":{"ref":"implementation-plan/101-one"},"base":{"ref":"develop-delegated-epic-orchestration"},"draft":false,"labels":[],"merged_at":"2026-06-12T11:00:00Z"},{"number":2103,"title":"Merged PR","head":{"ref":"feature/103-three"},"base":{"ref":"develop-delegated-epic-orchestration"},"draft":false,"labels":[],"merged_at":"2026-06-12T12:00:00Z"},{"number":2104,"title":"Closed unmerged PR","head":{"ref":"feature/104-four"},"base":{"ref":"develop-delegated-epic-orchestration"},"draft":false,"labels":[],"merged_at":null}]]
-JSON
+        ;;
+      *)
+        printf '[]\n'
+        ;;
+    esac
     ;;
   *)
     printf 'unexpected gh invocation: gh %s\n' "$*" >&2
@@ -293,6 +296,19 @@ run_test "json_read_only_guarantee" "yes" "$(
 run_test "no_mutating_gh_commands" "no" "$(
   grep -Eq '(^issue edit|^pr create|^pr merge|^project item-edit|^project item-add|mutation)' "$CALL_LOG" && echo yes || echo no
 )"
+
+: > "$CALL_LOG"
+cache_probe_output="$(run_json --items 101,102)"
+run_test "pr_lookup_uses_base_scoped_cli" "yes" "$(
+  grep -q 'pr list --repo lhpaul/ai-dev-framework-template --state all --base develop-delegated-epic-orchestration' "$CALL_LOG" && echo yes || echo no
+)"
+run_test "pr_lookup_includes_develop_base" "yes" "$(
+  grep -q 'pr list --repo lhpaul/ai-dev-framework-template --state all --base develop ' "$CALL_LOG" && echo yes || echo no
+)"
+run_test "pr_lookup_avoids_unbounded_rest_history" "no" "$(
+  grep -q 'pulls?state=' "$CALL_LOG" && echo yes || echo no
+)"
+run_test "pr_lookup_cache_preserves_grouping" "102" "$(printf '%s\n' "$cache_probe_output" | jq -r '.groups.in_review[0].number')"
 
 echo ""
 echo "=== Provider normalization and deferred-read signals (#966) ==="

--- a/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
@@ -165,6 +165,11 @@ JSON
 [[{"number":2101,"title":"Merged plan PR","head":{"ref":"implementation-plan/101-one"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"closed","draft":false,"labels":[],"merged_at":"2026-06-12T11:00:00Z"},{"number":2102,"title":"Plan PR","head":{"ref":"implementation-plan/102-two"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"open","draft":false,"labels":[{"name":"ready-for-human-review"}],"merged_at":null},{"number":2103,"title":"Merged PR","head":{"ref":"feature/103-three"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"closed","draft":false,"labels":[],"merged_at":"2026-06-12T12:00:00Z"},{"number":2104,"title":"Closed unmerged PR","head":{"ref":"feature/104-four"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"closed","draft":false,"labels":[],"merged_at":null},{"number":2110,"title":"Unready PR","head":{"ref":"feature/110-ten"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"open","draft":false,"labels":[],"merged_at":null}]]
 JSON
         ;;
+      develop-custom)
+        cat <<'JSON'
+[[{"number":2205,"title":"Merged override PR","head":{"ref":"feature/105-five"},"base":{"ref":"develop-custom"},"state":"closed","draft":false,"labels":[],"merged_at":"2026-06-13T12:00:00Z"}]]
+JSON
+        ;;
       *)
         printf '[[]]\n'
         ;;
@@ -256,7 +261,8 @@ run_test "text_policy_includes_max_risk" "yes" "$(grep -q 'Max risk: high' <<< "
 
 override_output="$(run_json --items 105,106 --base develop-custom)"
 run_test "base_override_wins" "develop-custom" "$(printf '%s\n' "$override_output" | jq -r '.baseBranch')"
-run_test "base_override_keeps_eligible" "2" "$(printf '%s\n' "$override_output" | jq '.groups.eligible | length')"
+run_test "base_override_lookup_detects_merged" "105" "$(printf '%s\n' "$override_output" | jq -r '.groups.already_merged[0].number')"
+run_test "base_override_keeps_remaining_eligible" "106" "$(printf '%s\n' "$override_output" | jq -r '.groups.eligible[0].number')"
 
 ambiguous_output="$(run_json --items 105,106)"
 run_test "conflicting_labels_no_base" "null" "$(printf '%s\n' "$ambiguous_output" | jq -r '.baseBranch')"

--- a/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
@@ -157,16 +157,16 @@ JSON
     jq -n --argjson number "$issue_number" --arg state "$state" \
       '{number:$number,title:("Dependency " + ($number|tostring)),state:$state}'
     ;;
-  pr\ list\ --repo\ lhpaul/ai-dev-framework-template\ --state\ all\ --base\ *\ --json\ number,title,headRefName,baseRefName,state,isDraft,labels,mergedAt\ --limit\ 500)
-    base="$(printf '%s\n' "$*" | sed -n 's/.* --base \([^ ][^ ]*\) --json .*/\1/p')"
+  api\ --paginate\ --slurp\ repos/lhpaul/ai-dev-framework-template/pulls\?state=all\&base=*\&per_page=100)
+    base="$(printf '%s\n' "$*" | sed -n 's/.*base=\([^&][^&]*\)&per_page=.*/\1/p')"
     case "$base" in
       develop-delegated-epic-orchestration)
         cat <<'JSON'
-[{"number":2101,"title":"Merged plan PR","headRefName":"implementation-plan/101-one","baseRefName":"develop-delegated-epic-orchestration","state":"MERGED","isDraft":false,"labels":[],"mergedAt":"2026-06-12T11:00:00Z"},{"number":2102,"title":"Plan PR","headRefName":"implementation-plan/102-two","baseRefName":"develop-delegated-epic-orchestration","state":"OPEN","isDraft":false,"labels":[{"name":"ready-for-human-review"}],"mergedAt":null},{"number":2103,"title":"Merged PR","headRefName":"feature/103-three","baseRefName":"develop-delegated-epic-orchestration","state":"MERGED","isDraft":false,"labels":[],"mergedAt":"2026-06-12T12:00:00Z"},{"number":2104,"title":"Closed unmerged PR","headRefName":"feature/104-four","baseRefName":"develop-delegated-epic-orchestration","state":"CLOSED","isDraft":false,"labels":[],"mergedAt":null},{"number":2110,"title":"Unready PR","headRefName":"feature/110-ten","baseRefName":"develop-delegated-epic-orchestration","state":"OPEN","isDraft":false,"labels":[],"mergedAt":null}]
+[[{"number":2101,"title":"Merged plan PR","head":{"ref":"implementation-plan/101-one"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"closed","draft":false,"labels":[],"merged_at":"2026-06-12T11:00:00Z"},{"number":2102,"title":"Plan PR","head":{"ref":"implementation-plan/102-two"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"open","draft":false,"labels":[{"name":"ready-for-human-review"}],"merged_at":null},{"number":2103,"title":"Merged PR","head":{"ref":"feature/103-three"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"closed","draft":false,"labels":[],"merged_at":"2026-06-12T12:00:00Z"},{"number":2104,"title":"Closed unmerged PR","head":{"ref":"feature/104-four"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"closed","draft":false,"labels":[],"merged_at":null},{"number":2110,"title":"Unready PR","head":{"ref":"feature/110-ten"},"base":{"ref":"develop-delegated-epic-orchestration"},"state":"open","draft":false,"labels":[],"merged_at":null}]]
 JSON
         ;;
       *)
-        printf '[]\n'
+        printf '[[]]\n'
         ;;
     esac
     ;;
@@ -299,14 +299,14 @@ run_test "no_mutating_gh_commands" "no" "$(
 
 : > "$CALL_LOG"
 cache_probe_output="$(run_json --items 101,102)"
-run_test "pr_lookup_uses_base_scoped_cli" "yes" "$(
-  grep -q 'pr list --repo lhpaul/ai-dev-framework-template --state all --base develop-delegated-epic-orchestration' "$CALL_LOG" && echo yes || echo no
+run_test "pr_lookup_uses_base_scoped_pagination" "yes" "$(
+  grep -q 'pulls?state=all&base=develop-delegated-epic-orchestration&per_page=100' "$CALL_LOG" && echo yes || echo no
 )"
 run_test "pr_lookup_includes_develop_base" "yes" "$(
-  grep -q 'pr list --repo lhpaul/ai-dev-framework-template --state all --base develop ' "$CALL_LOG" && echo yes || echo no
+  grep -q 'pulls?state=all&base=develop&per_page=100' "$CALL_LOG" && echo yes || echo no
 )"
 run_test "pr_lookup_avoids_unbounded_rest_history" "no" "$(
-  grep -q 'pulls?state=' "$CALL_LOG" && echo yes || echo no
+  grep -q 'pulls?state=\(open\|closed\|all\)&per_page=100' "$CALL_LOG" && echo yes || echo no
 )"
 run_test "pr_lookup_cache_preserves_grouping" "102" "$(printf '%s\n' "$cache_probe_output" | jq -r '.groups.in_review[0].number')"
 


### PR DESCRIPTION
## Summary
- replace unbounded REST scans of all open/closed PR history in run-epic-scope-resolver with cached base-scoped gh pr list calls
- resolve linked PRs from develop plus each item's integration branch base
- add regression coverage and changelog entry

## Root cause
The resolver cached repository-wide open and closed PR lists via REST pagination, so /run-epic had to pull the full closed PR history before classifying child items. Large downstream repositories can have 1000+ historical PRs, making scope resolution take many minutes.

## Validation
- bash scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
- bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md
- npx markdownlint-cli2 CHANGELOG.md
- python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md
- bash scripts/lint/tests/test-workflow-shell-guard-lint.sh
- git diff --check
- python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only workflow script and test changes; main risk is mis-classifying epic items if base/label resolution is wrong, not production runtime or auth paths.
> 
> **Overview**
> **Fixes slow `/run-epic` scope resolution** by replacing repository-wide open/closed PR pagination with **cached, base-scoped** `gh api` pulls (`state=all&base=<branch>`), so linked PRs are matched only on `develop`, each item’s `integration-branch:*` base, and optional `--base`.
> 
> **Behavior changes:** scope precomputes PR bases from sub-issue labels (with a separate labels-only fetch path); **unlabeled items** can still resolve PRs via the shared scope bases; if any scope label fetch fails and an item has no integration label (and no `--base`), PR lookup is skipped and that item is marked **ambiguous** with reason `scope integration branch candidates could not be fully resolved`. Cache keys use a hex encoding of the branch name so names like `develop/foo` vs `develop-foo` do not collide.
> 
> **Tests and docs:** the resolver test harness mocks base-scoped pulls, asserts no unbounded `pulls?state=…&per_page=100` without `base=`, and covers cache reuse, unlabeled shared-base merge detection, label-fetch failure, and cache-key collision; **CHANGELOG** records the fix under Fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5da7a798782174c02d47714a7e8a768c4004ea20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->