### PR TITLE
fix(workflow): clarify run-items CI continuation

### DIFF
--- a/.agents/skills/run-items/SKILL.md
+++ b/.agents/skills/run-items/SKILL.md
@@ -35,7 +35,12 @@ proposal step.
    or ambiguous.
 8. Do not stop after advancing one item if another item in the explicit list still
    has a deterministic next action.
-9. After all in-scope PRs reach `ready-for-human-review`, inspect the effective
+9. Do not stop at transient in-flight CI/watch states. If a local watch exits
+   early, duplicate checks are skipped/cancelled, or GitHub still shows pending
+   or incomplete check evidence, re-query authoritative PR/check state and keep
+   supervising until every in-scope PR is green, blocked, escalated, merged, or
+   held by guardrails.
+10. After all in-scope PRs reach `ready-for-human-review`, inspect the effective
    guardrails. When the relevant stages allow `may_merge_pr: true`, run
    Guardrails Enforcement Gate 5 for each in-scope PR, including
    `run-epic-risk-classifier.sh` and `run-epic-delegated-gate.sh`; continue only
@@ -48,7 +53,7 @@ proposal step.
    `stages.<stage>.may_merge_pr: false` guardrail for each affected PR, and tell
    the human to invoke `$batch-merge` or adjust guardrails to permit delegated
    merging.
-10. For single-item advancement use `$run-item`; for epic-scoped runs use `$run-epic`;
+11. For single-item advancement use `$run-item`; for epic-scoped runs use `$run-epic`;
    for read-only portfolio scan and proposal use `$run-work`.
 
 > **Deprecation notice**: `/run-epic --items` is deprecated. Use `/run-items` for

--- a/.claude/commands/run-items.md
+++ b/.claude/commands/run-items.md
@@ -57,6 +57,11 @@ Key responsibilities:
   target before implementation mutation; stop when context is missing or ambiguous.
 - Do not stop after advancing one item if another in the list still has a
   deterministic next action.
+- Do not stop at transient in-flight CI/watch states. If a local watch exits
+  early, duplicate checks are skipped/cancelled, or GitHub still shows pending
+  or incomplete check evidence, re-query authoritative PR/check state and keep
+  supervising until every in-scope PR is green, blocked, escalated, merged, or
+  held by guardrails.
 - After all in-scope PRs reach `ready-for-human-review`, inspect the effective
   guardrails. When the relevant stages allow `may_merge_pr: true`, run
   Guardrails Enforcement Gate 5 for each in-scope PR, including

--- a/.cursor/commands/run-items.md
+++ b/.cursor/commands/run-items.md
@@ -55,6 +55,11 @@ Key responsibilities:
 - In `workflow_hub`, include selected product repository context in implementation handoffs.
 - Do not stop after advancing one item if another in the list still has a
   deterministic next action.
+- Do not stop at transient in-flight CI/watch states. If a local watch exits
+  early, duplicate checks are skipped/cancelled, or GitHub still shows pending
+  or incomplete check evidence, re-query authoritative PR/check state and keep
+  supervising until every in-scope PR is green, blocked, escalated, merged, or
+  held by guardrails.
 - After all in-scope PRs reach `ready-for-human-review`, inspect the effective
   guardrails. When the relevant stages allow `may_merge_pr: true`, run
   Guardrails Enforcement Gate 5 for each in-scope PR, including

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Run-items CI continuation** (#1162): clarify that same-session
+  `/run-items` supervision must continue past transient watch failures,
+  skipped duplicate check noise, and incomplete CI evidence until a real
+  terminal condition is reached.
 - **Downstream template-sync follow-ups**: upstream reusable Leasity sync-review
   corrections for PR-Agent triggering, guarded command matching, guardrails
   parse diagnostics, tracker-provider checks, scope-base resolution, and GitHub

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -1286,6 +1286,17 @@ a missing summary when review platforms are configured, or a non-clean
 reviewer-loop result remains in progress and must be redispatched or escalated
 instead of included in the done-report.
 
+**In-flight CI/watch states are non-terminal:** A transient watch failure,
+cancelled duplicate run, skipped superseded run, pending/queued check, or
+incomplete `statusCheckRollup` snapshot does not end a same-session
+`/run-items` execution. Re-query the authoritative PR state (`gh pr view` plus
+the required GraphQL review-thread read), re-run `pr-ci-loop.sh` when CI evidence
+is incomplete or newly triggered, and continue supervising until the PR is green,
+blocked by a named stop condition, escalated by the retry/timeout limits, merged
+through an allowed delegated path, or handed off because the effective guardrails
+forbid merge. Do not hand control back to the human merely because a local
+watch command exited early while GitHub still shows work in progress.
+
 Before reporting any PR as ready for human review, independently query the actual PR state via `gh pr view`. Run this check for every PR that a Work Item Runner reports as ready:
 
 ```bash
@@ -1657,6 +1668,12 @@ The orchestrator prepares and validates the batch but **does not merge autonomou
 After all currently eligible items have reached a terminal condition, provide a consolidated summary.
 
 > **Done-report source rule**: Every field in this summary — labels present, CHANGELOG touched, reviewer loop completed, CI green — must be sourced from the artifact queries run in Step 5.1, not from agent self-reports. If Step 5.1 was not run for a PR, run it now before writing the summary. Never assert that a PR is "ready" based solely on what a Work Item Runner claimed.
+>
+> **No in-flight handoff rule**: Do not write the final summary while any
+> in-scope PR still has pending/queued checks, incomplete CI evidence, a stale or
+> missing reviewer-loop summary, or an unresolved transient watch failure. Those
+> states remain under Step 5 supervision until they become green, blocked,
+> escalated, merged, or explicitly held by guardrails.
 
 ```markdown
 ## Batch Orchestration Summary

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1784,6 +1784,16 @@ Prefer the helper script:
 ./scripts/development-workflow/pr-ci-loop.sh <pr_number>
 ```
 
+If a local watch/poll command exits before GitHub has reached a final state,
+treat that as an incomplete observation, not as a terminal item state. Re-query
+`gh pr view <pr_number> --json statusCheckRollup,labels,isDraft,headRefOid`,
+ignore superseded duplicate runs that are cancelled or skipped in favor of newer
+checks for the same head SHA, and re-run `pr-ci-loop.sh` whenever required
+checks are still pending/queued or the regression label was just applied. A
+same-session runner must continue the Step 8 loop until the helper returns
+`green`, `red`, or `timeout`; only `red` and `timeout` trigger the actions in the
+table below.
+
 Interpret the result as follows:
 
 | Result    | Action                                                                                                         |


### PR DESCRIPTION
## Summary

- Clarify that same-session `/run-items` supervision must continue past transient watch failures, skipped duplicate check noise, and incomplete CI evidence.
- Add the same continuation rule to Codex, Claude, and Cursor `/run-items` command surfaces.
- Add a changelog entry for #1162.

Closes #1162

## Verification

- `npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md" "docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md" ".agents/skills/run-items/SKILL.md" ".claude/commands/run-items.md" ".cursor/commands/run-items.md" "CHANGELOG.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`

## Pre-submission self-review

- Stale markers: none found in touched text.
- Caller consistency: Protocol 90, Protocol 91, and all `/run-items` command surfaces use matching continuation language.
- Coverage: addresses the issue body by making transient CI/watch states non-terminal and requiring authoritative re-query before handoff.
