### PR TITLE
fix(workflow): patch sync-template guardrails (hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.2] - 2026-07-07
+
+### Fixed
+
+- **Downstream sync-template guardrails** (#1168) (hotfix): clarify that
+  GitHub Projects merge automation is provider-specific and ensure mixed-stage
+  guardrail scopes use the highest configured merge-risk ceiling.
+
 ## [0.36.1] - 2026-07-07
 
 ### Fixed
@@ -1137,7 +1145,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.36.1...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.36.2...HEAD
+[0.36.2]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.36.1...v0.36.2
 [0.36.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.36.0...v0.36.1
 [0.36.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.35.0...v0.36.0
 [0.35.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.34.0...v0.35.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Downstream sync-template guardrails** (#1168) (hotfix): clarify that
   GitHub Projects merge automation is provider-specific and ensure mixed-stage
-  guardrail scopes use the highest configured merge-risk ceiling.
+  guardrail scopes use the highest configured merge-risk ceiling. Release and
+  hotfix reviewer-loop skips now also post the canonical summary marker required
+  by the PR policy guard.
 
 ## [0.36.1] - 2026-07-07
 

--- a/docs/workflow/development-workflow/integrations/github-projects.md
+++ b/docs/workflow/development-workflow/integrations/github-projects.md
@@ -392,11 +392,21 @@ The **Portfolio Orchestrator**, **Work Item Runner**, or stage agent updates the
 
 ---
 
-## Automated Tracker Updates on PR Merge (GitHub Actions)
+## Automated Tracker Updates on PR Merge (GitHub Projects + GitHub Actions)
 
-The repository ships a GitHub Actions workflow (`.github/workflows/update-tracker-on-merge.yml`)
-that automatically updates the GitHub Projects status whenever a workflow PR is merged to `develop`.
-This eliminates the stale-status problem that occurs between orchestrator runs.
+GitHub Projects-backed repositories may include a GitHub Actions workflow
+(`.github/workflows/update-tracker-on-merge.yml`) that automatically updates the
+GitHub Projects status whenever a workflow PR is merged to `develop`. This
+automation applies only when `.ai-dev-workflow.yaml` declares
+`issue_tracker.provider: github_projects` and the repository has configured the
+project variables listed below.
+
+For Linear-backed repositories, do not add this GitHub Projects workflow. Use
+the Linear MCP/API closeout path described in [`linear.md`](linear.md) instead.
+For GitHub Issues without Projects, PR merge cleanup can close issues, but there
+is no Project Status field to update. This provider-specific scoping avoids the
+stale-status problem that occurs between orchestrator runs in GitHub Projects
+repositories without implying equivalent behavior for every tracker provider.
 
 ### Branch-to-status mapping
 
@@ -418,7 +428,7 @@ This eliminates the stale-status problem that occurs between orchestrator runs.
 5. Updates the `Status` field to the appropriate value
 6. For implementation branches (`feature/*`, `fix/*`, `refactor/*`, `hotfix/*`): also closes the GitHub issue
 
-### Required configuration
+### Required configuration (GitHub Projects only)
 
 Set the following as **repository variables** (not secrets — these are not sensitive):
 
@@ -440,7 +450,7 @@ gh variable set GITHUB_PROJECT_OWNER --body "<your-github-username-or-org>"
 - Minimum permissions: `pull-requests: read`, `issues: write`, `projects: write`
 - All external action SHAs are pinned to exact commit hashes (no floating `@v7` tags)
 
-### Relationship to `post-merge-cleanup`
+### Relationship to `post-merge-cleanup` (GitHub Projects only)
 
 The GitHub Actions workflow and the `post-merge-cleanup` CLI command perform the same tracker
 update logic. They are complementary:

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -5130,6 +5130,69 @@ if [ -z "$branch_name" ] && [ -n "$_release_guard_head" ]; then
   branch_name="$_release_guard_head"
 fi
 
+post_release_guard_summary() {
+  local _pr_number="$1"
+  local _branch_name="$2"
+  local _repo _existing_comment_id _patch_payload _comment_posted _body_tmpfile
+  local _comment_body
+
+  if [ -z "$_pr_number" ]; then
+    return 0
+  fi
+
+  _comment_body="$(cat <<EOF
+### Automated Reviewer Loop Summary
+
+**Result:** skipped — release/hotfix PR reviewer loop intentionally skipped
+**Platforms:** none
+**Findings:** 0 blocking, 0 suggestions
+**Release readiness:** Review happens on develop-targeting feature/fix PRs. For \`${_branch_name:-release/hotfix}\` PRs targeting \`main\`, validate release artifacts, run \`pr-ci-loop.sh\`, then apply \`ready-for-human-review\` when CI is green.
+
+*Posted automatically by \`pr-review-loop.sh\`.*
+EOF
+)"
+
+  set +e
+
+  _existing_comment_id=""
+  _repo="$(repo_slug 2>/dev/null)"
+  if [ -n "$_repo" ]; then
+    _existing_comment_id="$(
+      gh api "repos/$_repo/issues/$_pr_number/comments" --paginate 2>/dev/null \
+        | jq -rs '
+            add // []
+            | [.[]
+               | select(
+                   (.body // "" | contains("### Automated Reviewer Loop Summary")) and
+                   (.body // "" | contains("*Posted automatically by `pr-review-loop.sh`.*"))
+                 )
+              ]
+            | sort_by(.created_at)
+            | last
+            | .id // empty
+          '
+    )"
+  fi
+
+  _patch_payload="$(jq -n --arg body "$_comment_body" '{body: $body}')"
+  _comment_posted=0
+  if [ -n "$_repo" ] && [ -n "$_existing_comment_id" ]; then
+    if gh api "repos/$_repo/issues/comments/$_existing_comment_id" \
+        --method PATCH \
+        --input - <<< "$_patch_payload" >/dev/null 2>&1; then
+      _comment_posted=1
+    fi
+  fi
+  if [ "$_comment_posted" -eq 0 ]; then
+    _body_tmpfile="$(mktemp)"
+    printf '%s' "$_comment_body" > "$_body_tmpfile"
+    gh pr comment "$_pr_number" --body-file "$_body_tmpfile" >/dev/null 2>&1
+    rm -f "$_body_tmpfile"
+  fi
+
+  set -e
+}
+
 if [ "$_release_guard_fired" -eq 0 ]; then
   echo "Release PR detected — reviewer loop skipped." >&2
   echo "Review happens on develop-targeting feature/fix PRs, not on release/* or hotfix/* branches." >&2
@@ -5141,6 +5204,7 @@ if [ "$_release_guard_fired" -eq 0 ]; then
   # Remove any stale reviewer-failed label left from a prior failed run so the
   # PR is not misleadingly labeled after a clean release-guard skip exit.
   sync_reviewer_failed_label "$pr_number" 0
+  post_release_guard_summary "$pr_number" "${branch_name:-}"
   exit 0
 fi
 # --- End release PR early-exit guard ---

--- a/scripts/development-workflow/run-bounded-prelude.sh
+++ b/scripts/development-workflow/run-bounded-prelude.sh
@@ -256,7 +256,7 @@ guardrails_scope_max_risk() {
     def rank($risk): {"low":1,"medium":2,"high":3}[$risk] // 1;
     [$scope[0].items[]? | infer_stage(.status // "")] | unique as $stages |
     if ($stages | length) == 0 then "low"
-    else [$stages[] | ($guardrails.stages[.].max_merge_risk // "low")] | min_by(rank(.))
+    else [$stages[] | ($guardrails.stages[.].max_merge_risk // "low")] | max_by(rank(.))
     end
   '
 }

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2146,6 +2146,7 @@ trap '_integration_cleanup' EXIT
 #  - everything else: succeed silently
 cat > "$_integration_mock_bin/gh" <<'INTEG_GH_MOCK'
 #!/usr/bin/env bash
+[ -n "${INTEG_MOCK_GH_LOG:-}" ] && printf '%s\n' "$*" >> "$INTEG_MOCK_GH_LOG"
 case "$*" in
   *"headRefName"*)
     # Use a variable for the default to avoid the bash brace-balance issue:
@@ -2174,6 +2175,8 @@ _run_loop_integration() {
 
 # Test 15.1: release/* head branch → main loop emits RESULT=skipped, REASON=release_pr, exits 0
 export INTEG_MOCK_HEAD_JSON='{"headRefName":"release/v9.9.9"}'
+_integ_gh_log="$(mktemp)"
+export INTEG_MOCK_GH_LOG="$_integ_gh_log"
 _integ_out=""
 _integ_exit=0
 set +e
@@ -2185,10 +2188,17 @@ run_test "mainloop_release_guard_result_skipped" "RESULT=skipped" \
 run_test "mainloop_release_guard_reason_release_pr" "REASON=release_pr" \
   "$(printf '%s\n' "$_integ_out" | grep '^REASON=')"
 run_test "mainloop_release_guard_exit0" "0" "$_integ_exit"
+run_test "mainloop_release_guard_posts_summary" "1" "$(
+  grep -c -- 'pr comment 999 --body-file' "$_integ_gh_log" 2>/dev/null || true
+)"
+rm -f "$_integ_gh_log"
+unset INTEG_MOCK_GH_LOG
 unset INTEG_MOCK_HEAD_JSON
 
 # Test 15.2: hotfix/* head branch → main loop also emits RESULT=skipped, exits 0
 export INTEG_MOCK_HEAD_JSON='{"headRefName":"hotfix/v9.9.1"}'
+_integ_gh_log="$(mktemp)"
+export INTEG_MOCK_GH_LOG="$_integ_gh_log"
 _integ_out=""
 _integ_exit=0
 set +e
@@ -2198,6 +2208,11 @@ set -e
 run_test "mainloop_hotfix_guard_result_skipped" "RESULT=skipped" \
   "$(printf '%s\n' "$_integ_out" | grep '^RESULT=')"
 run_test "mainloop_hotfix_guard_exit0" "0" "$_integ_exit"
+run_test "mainloop_hotfix_guard_posts_summary" "1" "$(
+  grep -c -- 'pr comment 998 --body-file' "$_integ_gh_log" 2>/dev/null || true
+)"
+rm -f "$_integ_gh_log"
+unset INTEG_MOCK_GH_LOG
 unset INTEG_MOCK_HEAD_JSON
 
 # Test 15.3: --branch release/v9.9.9 flag → guard fires without a gh call, exits 0

--- a/scripts/development-workflow/tests/test-run-bounded-prelude.sh
+++ b/scripts/development-workflow/tests/test-run-bounded-prelude.sh
@@ -227,6 +227,27 @@ stage_guardrails_out="$(AI_DEV_WORKFLOW_CONFIG_FILE="$stage_guardrails_config" \
 run_test "stage_guardrails_active_merge_limit" "false" "$(printf '%s\n' "$stage_guardrails_out" | jq -r '.policyRecommendation.effectivePolicy.mayMerge')"
 run_test "stage_guardrails_active_risk_limit" "low" "$(printf '%s\n' "$stage_guardrails_out" | jq -r '.policyRecommendation.effectivePolicy.maxRisk')"
 
+multi_stage_scope="$(write_fixture multi-stage-scope '{
+  "items": [
+    {"number": 1, "status": "Spec Ready"},
+    {"number": 2, "status": "In Development"}
+  ]
+}')"
+multi_stage_guardrails='{
+  "stages": {
+    "spec": {"max_merge_risk": "low"},
+    "plan": {"max_merge_risk": "medium"},
+    "implementation": {"max_merge_risk": "high"}
+  }
+}'
+multi_stage_max_risk="$(
+  {
+    awk '/^guardrails_scope_max_risk/ { in_func = 1 } in_func { print } in_func && /^}/ { exit }' "$PRELUDE"
+    printf 'guardrails_scope_max_risk "$1" "$2"\n'
+  } | bash -s -- "$multi_stage_guardrails" "$multi_stage_scope"
+)"
+run_test "stage_guardrails_multi_stage_max_risk_uses_highest" "high" "$multi_stage_max_risk"
+
 run_fails "reject_linear_identifier_with_underscore" "invalid --issue identifier" \
   env AI_DEV_WORKFLOW_CONFIG_FILE="$guardrails_config" "$ITEM_RESOLVER" --issue A_B-123
 run_fails "reject_whitespace_issue_identifier" "invalid --issue identifier" \


### PR DESCRIPTION
## Summary

Hotfix for downstream sync-template regressions surfaced by lhpaul/leasity-exchanges-prototype#480.

- Clarifies that `update-tracker-on-merge.yml` automation is GitHub Projects-specific and points Linear-backed repositories to the Linear closeout path instead.
- Corrects bounded-prelude mixed-stage guardrail risk aggregation to use the highest configured merge-risk ceiling.
- Adds focused coverage for mixed spec + implementation scopes.
- Aligns the release/hotfix reviewer-loop skip path with PR policy by posting the canonical summary marker when the skip is intentional.

Closes #1168.

## Verification

- `git diff --check`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh`
- `bash scripts/development-workflow/tests/test-run-bounded-prelude.sh`
- `bash scripts/development-workflow/tests/test-reviewer-loop-guard-workflow.sh`
- `bash scripts/development-workflow/tests/test-check-tracker-merge-mapping.sh`
- `shellcheck --severity=warning scripts/development-workflow/run-bounded-prelude.sh scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-run-bounded-prelude.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `npx markdownlint-cli2 "CHANGELOG.md" "docs/workflow/development-workflow/integrations/github-projects.md"`

## Pre-Submission Self-Review

Pre-submission self-review: stale markers none; caller consistency verified against GitHub Projects/Linear tracker docs, bounded-prelude guardrail policy, release/hotfix reviewer-loop skip behavior, and actual `pr-policy.yml` trigger text; coverage addresses issue #1168 with focused multi-stage guardrails and release/hotfix summary regression tests. The Leasity reviewer-loop guard test reversal was intentionally not ported because this template repo's workflow text already uses `opened|reopened|ready_for_review`.