### PR TITLE
fix(workflow): port Faind sync-template fixes (hotfix)

### DIFF
--- a/.agents/skills/run-items/SKILL.md
+++ b/.agents/skills/run-items/SKILL.md
@@ -44,8 +44,11 @@ proposal step.
    guardrails. When the relevant stages allow `may_merge_pr: true`, run
    Guardrails Enforcement Gate 5 for each in-scope PR, including
    `run-epic-risk-classifier.sh` and `run-epic-delegated-gate.sh`; continue only
-   when every in-scope PR returns `merge_allowed`. Then route into Protocol 94
-   batch merge using only the explicit in-scope PR list: run
+   when every in-scope PR returns `merge_allowed`. The bounded-prelude
+   confirmation (or explicit autonomy flags) recorded for this `/run-items`
+   invocation is the required merge gate for Protocol 90 `explicit_list` batches.
+   Then route into Protocol 94 batch merge using only the explicit in-scope PR list:
+   run
    `batch-merge.sh discover --prs <comma-separated-in-scope-prs>` and continue
    through merge, cleanup, and tracker reconciliation. Never use Protocol 94
    auto-discovery from `/run-items`. If any stage does not allow merge, finish at the

--- a/.claude/agents/item-orchestrator.md
+++ b/.claude/agents/item-orchestrator.md
@@ -40,6 +40,9 @@ config in `.ai-dev-workflow.yaml` and report effective values before any mutatio
 Enforce per-stage PR-open, delegated review, delegated merge, and completion gates
 per `docs/workflow/development-workflow/guardrails-enforcement.md` section 3.
 When no `guardrails` section is found, apply conservative defaults and state them.
+When the delegated merge gate returns `merge_allowed`, continue through merge,
+branch cleanup, `post-merge-cleanup.sh`, and live tracker verification before
+reporting the item terminal.
 
 That document is the single source of truth for this supporting role. Key responsibilities:
 

--- a/.cursor/agents/item-orchestrator.md
+++ b/.cursor/agents/item-orchestrator.md
@@ -39,6 +39,9 @@ config in `.ai-dev-workflow.yaml` and report effective values before any mutatio
 Enforce per-stage PR-open, delegated review, delegated merge, and completion gates
 per `docs/workflow/development-workflow/guardrails-enforcement.md` section 3.
 When no `guardrails` section is found, apply conservative defaults and state them.
+When the delegated merge gate returns `merge_allowed`, continue through merge,
+branch cleanup, `post-merge-cleanup.sh`, and live tracker verification before
+reporting the item terminal.
 
 That document is the single source of truth for this supporting role. Key responsibilities:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.3] - 2026-07-08
+
+### Fixed
+
+- **Faind sync-template follow-ups** (#1171) (hotfix): port reusable downstream
+  fixes for backlog Type propagation, release/hotfix reviewer-loop summary
+  failures, explicit-list resolver invocation, PR head-search scope fallback,
+  and delegated `/run-items` merge guidance.
+
 ## [0.36.2] - 2026-07-07
 
 ### Fixed
@@ -1147,7 +1156,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.36.2...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.36.3...HEAD
+[0.36.3]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.36.2...v0.36.3
 [0.36.2]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.36.1...v0.36.2
 [0.36.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.36.0...v0.36.1
 [0.36.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.35.0...v0.36.0

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -64,7 +64,12 @@ This protocol is entered from two paths:
 - **From `/run-items`** (Protocol 96, `explicit_list` mode, when implemented):
   Two or more explicit targets were supplied as a hard bounded scope; the
   orchestrator runs that exact bounded set through all steps including dispatch
-  (Steps 4–5).
+  (Steps 4–5). When guardrails permit delegated merge, `/run-items` may continue
+  after `ready-for-human-review` through Guardrails Enforcement Gate 5 and scoped
+  Protocol 94 batch merge per `.agents/skills/run-items/SKILL.md` rule 10. The
+  bounded-prelude confirmation recorded for that invocation is the merge gate;
+  Step 5.5 below applies to batches proposed by `/run-work`, not to this
+  explicit-list execution path.
 
 When the routing mode is `redirect_item`, `redirect_epic`, or `redirect_items`,
 `/run-work` performs **no mutation**. The classifier emits `REDIRECT_COMMAND`

--- a/scripts/development-workflow/add-backlog-item.sh
+++ b/scripts/development-workflow/add-backlog-item.sh
@@ -11,7 +11,7 @@ usage() {
   cat <<'EOF'
 Usage:
   add-backlog-item.sh resolve
-  add-backlog-item.sh create --title <title> (--body <text> | --body-file <path>) [--label <name>] ... [--priority <value>] [--size <value>]
+  add-backlog-item.sh create --title <title> (--body <text> | --body-file <path>) [--label <name>] ... [--type <value>] [--priority <value>] [--size <value>]
 
 resolve
   Prints machine-readable lines:
@@ -27,6 +27,8 @@ create
                       When omitted, defaults to Medium for GitHub Projects.
   --size <value>      Optional. Set the project Size field. Valid values: XS, S, M, L, XL.
                       When omitted, the Size field is left unset.
+  --type <value>      Optional. Set the project classification field. Valid values: Feature, Bug,
+                      Refactor, Workflow. When omitted, the Type field is left unset.
 EOF
 }
 
@@ -47,7 +49,7 @@ resolve_cmd() {
 
 create_cmd() {
   local caller_pwd="$PWD"
-  local title="" body="" body_file="" priority="" size="" labels=()
+  local title="" body="" body_file="" priority="" size="" type_label="" labels=()
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -79,6 +81,11 @@ create_cmd() {
       --size)
         [ $# -lt 2 ] || [ -z "${2:-}" ] && { echo "Missing value for --size" >&2; usage >&2; exit 2; }
         size="$2"
+        shift 2
+        ;;
+      --type)
+        [ $# -lt 2 ] || [ -z "${2:-}" ] && { echo "Missing value for --type" >&2; usage >&2; exit 2; }
+        type_label="$2"
         shift 2
         ;;
       -h|--help)
@@ -143,8 +150,11 @@ create_cmd() {
     # Ensure the issue is on the project board (adds it with Status=Backlog if absent).
     # The ensure_on_project_board helper is fail-open; it always returns 0.
     ensure_on_project_board "$issue_number" "Backlog"
-    # Update project Priority (default Medium) and Size when GitHub Projects is configured.
+    # Update project Type, Priority (default Medium), and Size when GitHub Projects is configured.
     # The update_tracker_*_best_effort helpers are fail-open; they always return 0.
+    if [ -n "$type_label" ]; then
+      update_tracker_type_best_effort "$issue_number" "$type_label"
+    fi
     local effective_priority="${priority:-Medium}"
     update_tracker_priority_best_effort "$issue_number" "$effective_priority"
     if [ -n "$size" ]; then

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -5186,11 +5186,19 @@ EOF
   if [ "$_comment_posted" -eq 0 ]; then
     _body_tmpfile="$(mktemp)"
     printf '%s' "$_comment_body" > "$_body_tmpfile"
-    gh pr comment "$_pr_number" --body-file "$_body_tmpfile" >/dev/null 2>&1
+    if gh pr comment "$_pr_number" --body-file "$_body_tmpfile" >/dev/null 2>&1; then
+      _comment_posted=1
+    else
+      echo "WARN: failed to post release guard summary comment for PR ${_pr_number}" >&2
+    fi
     rm -f "$_body_tmpfile"
   fi
 
   set -e
+  if [ "$_comment_posted" -eq 0 ]; then
+    return 1
+  fi
+  return 0
 }
 
 if [ "$_release_guard_fired" -eq 0 ]; then
@@ -5204,7 +5212,13 @@ if [ "$_release_guard_fired" -eq 0 ]; then
   # Remove any stale reviewer-failed label left from a prior failed run so the
   # PR is not misleadingly labeled after a clean release-guard skip exit.
   sync_reviewer_failed_label "$pr_number" 0
-  post_release_guard_summary "$pr_number" "${branch_name:-}"
+  if ! post_release_guard_summary "$pr_number" "${branch_name:-}"; then
+    print_kv RESULT escalate
+    print_kv REASON release_guard_summary_failed
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "${branch_name:-}"
+    exit 1
+  fi
   exit 0
 fi
 # --- End release PR early-exit guard ---

--- a/scripts/development-workflow/run-bounded-prelude.sh
+++ b/scripts/development-workflow/run-bounded-prelude.sh
@@ -464,7 +464,7 @@ case "$scope_mode" in
   fi
     ;;
   items)
-  if ! "$SCRIPT_DIR/run-epic-scope-resolver.sh" --items "$items_arg" "${resolver_common[@]+"${resolver_common[@]}"}" --json > "$scope_file"; then
+  if ! RUN_EPIC_SCOPE_RESOLVER_INTERNAL_ITEMS=1 "$SCRIPT_DIR/run-epic-scope-resolver.sh" --items "$items_arg" "${resolver_common[@]+"${resolver_common[@]}"}" --json > "$scope_file"; then
     error_exit "items scope resolution failed"
   fi
     ;;

--- a/scripts/development-workflow/run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/run-epic-scope-resolver.sh
@@ -349,6 +349,63 @@ fetch_prs_for_base() {
   printf '%s\n' "$cache_file"
 }
 
+# Fallback when label-derived base scans miss PRs on integration branches
+# (develop-<slug>) that are not represented by integration-branch:* labels in scope.
+discover_prs_via_head_search() {
+  local issue="$1"
+  local prefix query numbers number pr_json open merged
+  open='[]'
+  merged='[]'
+  for prefix in spec implementation-plan feature fix refactor hotfix; do
+    query="repo:${repo} is:pr head:${prefix}/${issue}"
+    numbers=""
+    if ! numbers="$(gh search prs "$query" --json number -q '.[].number' 2>/dev/null)"; then
+      numbers=""
+    fi
+    for number in $numbers; do
+      [ -n "$number" ] || continue
+      pr_json=""
+      if ! pr_json="$(gh pr view "$number" --json number,title,state,headRefName,baseRefName,isDraft,labels,mergedAt 2>/dev/null)"; then
+        continue
+      fi
+      if printf '%s\n' "$pr_json" | jq -e '.mergedAt != null' >/dev/null 2>&1; then
+        merged="$(printf '%s\n' "$pr_json" | jq --argjson acc "$merged" '
+          $acc + [{
+            number: .number,
+            title: .title,
+            state: "MERGED",
+            headRefName: .headRefName,
+            baseRefName: .baseRefName,
+            isDraft: false,
+            labels: [],
+            mergedAt: .mergedAt
+          }]
+        ')"
+      elif [ "$(printf '%s\n' "$pr_json" | jq -r '.state')" = "OPEN" ]; then
+        open="$(printf '%s\n' "$pr_json" | jq --argjson acc "$open" '
+          $acc + [{
+            number: .number,
+            title: .title,
+            state: "OPEN",
+            headRefName: .headRefName,
+            baseRefName: .baseRefName,
+            isDraft: .isDraft,
+            labels: [.labels[].name]
+          }]
+        ')"
+      fi
+    done
+  done
+  jq -n --argjson open "$open" --argjson merged "$merged" '{open: $open, merged: $merged}'
+}
+
+discover_integration_bases_for_issue() {
+  local issue="$1"
+  discover_prs_via_head_search "$issue" \
+    | jq -r '.open[].baseRefName, .merged[].baseRefName' \
+    | awk '/^develop-/ { print }'
+}
+
 resolve_scope_pr_bases() {
   local bases_file issue issue_json integration_label candidate_base
   bases_file="$tmp_dir/pr_bases.txt"
@@ -375,6 +432,14 @@ resolve_scope_pr_bases() {
       candidate_base="develop-${integration_label#integration-branch:}"
       printf '%s\n' "$candidate_base" >> "$bases_file"
     fi
+  done < "$subissues_file"
+
+  while IFS= read -r issue; do
+    [ -n "$issue" ] || continue
+    while IFS= read -r base; do
+      [ -n "$base" ] || continue
+      printf '%s\n' "$base" >> "$bases_file"
+    done < <(discover_integration_bases_for_issue "$issue")
   done < "$subissues_file"
 
   sort -u "$bases_file"
@@ -433,8 +498,13 @@ linked_pr_json() {
 $bases
 EOF
 
-  jq -n --argjson open "$open_prs" --argjson merged "$merged_prs" \
-    '{open: $open, merged: $merged}'
+  local _linked_result
+  _linked_result="$(jq -n --argjson open "$open_prs" --argjson merged "$merged_prs" \
+    '{open: $open, merged: $merged}')"
+  if [ "$(printf '%s\n' "$_linked_result" | jq '(.open | length) + (.merged | length)')" -eq 0 ]; then
+    _linked_result="$(discover_prs_via_head_search "$issue")"
+  fi
+  printf '%s\n' "$_linked_result"
 }
 
 dependency_json() {

--- a/scripts/development-workflow/tests/test-add-backlog-item.sh
+++ b/scripts/development-workflow/tests/test-add-backlog-item.sh
@@ -8,6 +8,7 @@
 #   4. --priority flag: uses supplied value instead of Medium default
 #   5. --size flag: triggers Size field update
 #   6. No --size: Size field update is not called
+#   7. --type flag: triggers Type field update
 #
 # Usage: bash scripts/development-workflow/tests/test-add-backlog-item.sh
 
@@ -72,7 +73,7 @@ case "$*" in
         printf '{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_123","project":{"id":"PVT_project_1","number":1},"status":{"name":"Backlog"},"type":{"name":"Feature"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}\n'
         ;;
       *"fields(first:"*)
-        printf '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_urgent","name":"Urgent"},{"id":"OPT_high","name":"High"},{"id":"OPT_medium","name":"Medium"},{"id":"OPT_low","name":"Low"}]},{"id":"PVTSSF_size","name":"Size","options":[{"id":"OPT_size_xs","name":"XS"},{"id":"OPT_size_s","name":"S"},{"id":"OPT_size_m","name":"M"},{"id":"OPT_size_l","name":"L"},{"id":"OPT_size_xl","name":"XL"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}\n'
+        printf '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_urgent","name":"Urgent"},{"id":"OPT_high","name":"High"},{"id":"OPT_medium","name":"Medium"},{"id":"OPT_low","name":"Low"}]},{"id":"PVTSSF_size","name":"Size","options":[{"id":"OPT_size_xs","name":"XS"},{"id":"OPT_size_s","name":"S"},{"id":"OPT_size_m","name":"M"},{"id":"OPT_size_l","name":"L"},{"id":"OPT_size_xl","name":"XL"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_type_feature","name":"Feature"},{"id":"OPT_type_bug","name":"Bug"},{"id":"OPT_type_refactor","name":"Refactor"},{"id":"OPT_type_workflow","name":"Workflow"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}\n'
         ;;
       *"updateProjectV2ItemFieldValue"*)
         printf '{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_item_123"}}}}\n'
@@ -195,6 +196,15 @@ run_test "size_flag_exits_zero" "0" "$(get_exit)"
 run_test "size_flag_updates_size_field" "1" "$(count_log_matches 'fieldId=PVTSSF_size')"
 run_test "size_flag_uses_m_option" "1" "$(count_log_matches 'optionId=OPT_size_m')"
 run_test "size_flag_also_updates_priority" "1" "$(count_log_matches 'fieldId=PVTSSF_priority')"
+
+echo ""
+echo "=== create: --type flag updates Type field ==="
+
+run_create "ok" --title "Test" --body "body" --type "Workflow"
+run_test "type_flag_exits_zero" "0" "$(get_exit)"
+run_test "type_flag_updates_type_field" "1" "$(count_log_matches 'fieldId=PVTSSF_type')"
+run_test "type_flag_uses_workflow_option" "1" "$(count_log_matches 'optionId=OPT_type_workflow')"
+run_test "type_flag_also_updates_priority" "1" "$(count_log_matches 'fieldId=PVTSSF_priority')"
 
 echo ""
 echo "=== create: Linear provider — emits TRACKER_ACTION_REQUIRED=create_item title=... ==="

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2156,6 +2156,13 @@ case "$*" in
     printf '%s\n' "${INTEG_MOCK_HEAD_JSON:-$_hdr_default}"
     exit 0
     ;;
+  pr\ comment\ *)
+    if [ "${INTEG_MOCK_PR_COMMENT_FAIL:-0}" = "1" ]; then
+      printf 'mock pr comment failure\n' >&2
+      exit 64
+    fi
+    exit 0
+    ;;
   *"pr edit"*|*"api"*|*"pr view"*)
     exit 0
     ;;
@@ -2193,6 +2200,23 @@ run_test "mainloop_release_guard_posts_summary" "1" "$(
 )"
 rm -f "$_integ_gh_log"
 unset INTEG_MOCK_GH_LOG
+unset INTEG_MOCK_HEAD_JSON
+
+# Test 15.1b: release guard escalates if it cannot post the required summary marker
+export INTEG_MOCK_HEAD_JSON='{"headRefName":"release/v9.9.10"}'
+export INTEG_MOCK_PR_COMMENT_FAIL=1
+_integ_out=""
+_integ_exit=0
+set +e
+_integ_out="$(_run_loop_integration 997)"
+_integ_exit=$?
+set -e
+run_test "mainloop_release_guard_comment_failure_result" "RESULT=escalate" \
+  "$(printf '%s\n' "$_integ_out" | grep '^RESULT=' | tail -1)"
+run_test "mainloop_release_guard_comment_failure_reason" "REASON=release_guard_summary_failed" \
+  "$(printf '%s\n' "$_integ_out" | grep '^REASON=' | tail -1)"
+run_test "mainloop_release_guard_comment_failure_exit1" "1" "$_integ_exit"
+unset INTEG_MOCK_PR_COMMENT_FAIL
 unset INTEG_MOCK_HEAD_JSON
 
 # Test 15.2: hotfix/* head branch → main loop also emits RESULT=skipped, exits 0

--- a/scripts/development-workflow/tests/test-run-bounded-prelude.sh
+++ b/scripts/development-workflow/tests/test-run-bounded-prelude.sh
@@ -58,6 +58,9 @@ run_test "item_policy_copy_paste" "true" "$(printf '%s\n' "$policy_out" | jq -r 
 run_test "item_policy_delegate" "true" "$(printf '%s\n' "$policy_out" | jq -r '.effectivePolicy.delegateReview')"
 
 run_test "prelude_help" "0" "$( "$PRELUDE" --help >/dev/null; echo 0)"
+run_test "items_resolver_internal_env_set" "yes" "$(
+  grep -Fq 'RUN_EPIC_SCOPE_RESOLVER_INTERNAL_ITEMS=1' "$PRELUDE" && echo yes || echo no
+)"
 
 run_fails() {
   local name="$1" expected="$2"

--- a/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
@@ -141,6 +141,7 @@ JSON
       110) labels_json='[{"name":"integration-branch:delegated-epic-orchestration"}]' ;;
       111) body='Blocked by #108'; labels_json='[{"name":"integration-branch:delegated-epic-orchestration"}]' ;;
       113) labels_json='[{"name":"integration-branch:foo"}]' ;;
+      114) labels_json='[]' ;;
     esac
     jq -n \
       --argjson number "$issue_number" \
@@ -163,6 +164,7 @@ JSON
       105) labels_json='[{"name":"integration-branch:alpha"}]' ;;
       106) labels_json='[{"name":"integration-branch:beta"}]' ;;
       113) labels_json='[{"name":"integration-branch:foo"}]' ;;
+      114) labels_json='[]' ;;
     esac
     jq -n --argjson labels "$labels_json" '{labels:$labels}'
     ;;
@@ -190,6 +192,16 @@ JSON
         printf '[[]]\n'
         ;;
     esac
+    ;;
+  search\ prs\ repo:lhpaul/ai-dev-framework-template\ is:pr\ head:feature/114\ --json\ number\ -q\ .[].number)
+    printf '2114\n'
+    ;;
+  search\ prs\ repo:lhpaul/ai-dev-framework-template\ is:pr\ head:*\ --json\ number\ -q\ .[].number)
+    ;;
+  pr\ view\ 2114\ --json\ number,title,state,headRefName,baseRefName,isDraft,labels,mergedAt)
+    cat <<'JSON'
+{"number":2114,"title":"Unlabeled fallback PR","state":"OPEN","headRefName":"feature/114-unlabeled-fallback","baseRefName":"develop-missing-label","isDraft":false,"labels":[{"name":"ready-for-human-review"}],"mergedAt":null}
+JSON
     ;;
   *)
     printf 'unexpected gh invocation: gh %s\n' "$*" >&2
@@ -299,6 +311,10 @@ run_test "merged_pr_group_detected" "already_merged" "$(printf '%s\n' "$merged_o
 
 unready_pr_output="$(run_json --items 110)"
 run_test "unready_open_pr_remains_eligible" "eligible" "$(printf '%s\n' "$unready_pr_output" | jq -r '.items[0].group')"
+
+head_search_output="$(run_json --items 114)"
+run_test "head_search_fallback_detects_unlabeled_open_pr" "in_review" "$(printf '%s\n' "$head_search_output" | jq -r '.items[0].group')"
+run_test "head_search_fallback_preserves_pr_number" "2114" "$(printf '%s\n' "$head_search_output" | jq -r '.items[0].pullRequests.open[0].number')"
 
 closed_output="$(run_json --items 109)"
 run_test "closed_not_planned_not_complete" "ambiguous" "$(printf '%s\n' "$closed_output" | jq -r '.items[0].group')"


### PR DESCRIPTION
## Summary

Ports the reusable template-level fixes discovered in downstream Faind PR #46:

- add `--type` support to `add-backlog-item.sh` so GitHub Projects Type can be set at creation
- make release/hotfix reviewer-loop guard summary comment failures escalate instead of silently exiting skipped
- mark `/run-items` prelude calls to the internal `--items` resolver path so deprecated-user-flag warnings stay suppressed
- add a bounded PR head-search fallback for scope resolution when integration-label-derived base scans miss linked PRs
- clarify delegated `/run-items` merge continuation in command, agent, and Protocol 90 surfaces

Excluded downstream changes already present here: PR-Agent exact `/review` trigger and consolidated `pr-policy.yml`.

## Verification

- `bash -n scripts/development-workflow/add-backlog-item.sh scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/run-bounded-prelude.sh scripts/development-workflow/run-epic-scope-resolver.sh scripts/development-workflow/tests/test-add-backlog-item.sh scripts/development-workflow/tests/test-pr-review-loop.sh scripts/development-workflow/tests/test-run-bounded-prelude.sh scripts/development-workflow/tests/test-run-epic-scope-resolver.sh`
- `bash scripts/development-workflow/tests/test-add-backlog-item.sh`
- `bash scripts/development-workflow/tests/test-run-bounded-prelude.sh`
- `bash scripts/development-workflow/tests/test-run-epic-scope-resolver.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/main`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `npx markdownlint-cli2 "CHANGELOG.md" "docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md"`
- `git diff --check`

## Self-review

- Branch descends from `origin/main` for hotfix flow.
- Diff addresses issue #1171 and the reusable failure modes from Faind PR #46.
- No downstream-specific PR-Agent or PR policy workflow changes were ported because they already exist in this template.
- Shell changes use guarded `gh` calls and preserve fail-open behavior except where missing release/hotfix summary markers must escalate.

Closes #1171