### PR TITLE
Handle Haystack review check run state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Haystack GitHub App review checks** (#1188): treat configured Haystack
+  check runs as reviewer-loop state instead of generic CI, with check-run
+  fallback/readback when CLI triage cannot return completed findings.
+
 ## [0.36.3] - 2026-07-08
 
 ### Fixed

--- a/docs/workflow/development-workflow/integrations/haystack-triage.md
+++ b/docs/workflow/development-workflow/integrations/haystack-triage.md
@@ -8,15 +8,16 @@ For information about Haystack's local git hooks (truncation checker, LLM_RULES.
 
 ## Overview
 
-`haystack-reviewer.sh` wraps the `haystack triage <PR> --json` CLI call and emits the standard key-value output contract consumed by `pr-review-loop.sh`. Teams that declare `haystack` in `review.on_ready.github` gain a review platform that produces actionable, file-anchored findings with fix prompts — without requiring any additional GitHub App installation.
+`haystack-reviewer.sh` wraps the `haystack triage <PR> --json` CLI call and emits the standard key-value output contract consumed by `pr-review-loop.sh`. Teams that declare `haystack` in `review.on_ready.github` gain a review platform that produces actionable, file-anchored findings with fix prompts. When the Haystack GitHub App is installed, the same reviewer state may also appear as a `Haystack / Review` check run on the PR.
 
 Key properties:
 
 - **Poll-retry on pending**: When `haystack triage` returns `status=pending` (analysis still in progress), `haystack-reviewer.sh` waits `HAYSTACK_POLL_INTERVAL` seconds (default: 15) and retries automatically until the analysis completes or the overall `HAYSTACK_REVIEWER_TIMEOUT` budget is exhausted. This eliminates the timing-gap false-negative where the reviewer loop ran within the first 2–4 minutes of a PR push and silently skipped findings.
+- **GitHub App check-run fallback**: When CLI triage is unavailable, times out, or stays pending past the timeout budget, `haystack-reviewer.sh` reads the latest `Haystack / Review` check run for the PR head. The check run is used as fallback/readback evidence; CLI triage remains the preferred source because it exposes richer finding details and fix prompts.
 - **Policy-verdict visibility**: After triage completes, `haystack-reviewer.sh` also reads `haystack pr-status <PR> --json`. When Haystack reports `needsHumanReview: true` or `analysisVerdict: "needs-review"`, the reviewer loop keeps the result non-blocking if there are no blocking findings but displays `haystack (needs-review: policy)` in the PR summary instead of `haystack (clean)`. The summary also records the Haystack bucket, `needsHumanReview`, and a disposition such as `blocking`, `policy-human-review`, `advisory-only`, or `good-to-merge`.
 - **No per-hour rate cap**: Unlike some hosted review services, Haystack triage is not subject to hourly review limits (as of the time of writing).
-- **Graceful degradation**: If the `haystack` CLI is absent or unauthenticated, the reviewer exits with `UNAVAILABLE` and the review loop continues with the remaining configured platforms.
-- **No GitHub App required**: This integration uses the CLI only. Haystack does not post inline GitHub review threads in this MVP — findings are reported locally via the key-value output.
+- **Graceful degradation**: If neither CLI triage nor the GitHub App check run is reachable, the reviewer exits with `UNAVAILABLE` and the review loop continues with the remaining configured platforms.
+- **GitHub App optional**: The CLI path is still sufficient. The GitHub App check run is optional fallback/readback state and must not be treated as ordinary CI when `haystack` is configured as a reviewer.
 
 ---
 
@@ -53,7 +54,7 @@ review:
       - haystack
 ```
 
-No other configuration changes are required in `.ai-dev-workflow.yaml`.
+No other configuration changes are required in `.ai-dev-workflow.yaml`. If a repository uses the Haystack GitHub App check run under a non-default name, set `HAYSTACK_CHECK_NAME` for the reviewer and CI loop; the default is `Haystack / Review`.
 
 If the repository creates implementation PRs as drafts, prefer
 `review.on_ready.github` for Haystack. In this mode the reviewer loop lets
@@ -66,11 +67,11 @@ draft, so running it before `gh pr ready` can produce avoidable
 
 ## Bot Login Identifier
 
-Haystack triage does not post inline GitHub review threads in this MVP. The Haystack CLI reads triage results locally and does not push findings to the GitHub PR review thread API.
+Haystack triage does not post inline GitHub review threads in this integration. The Haystack CLI reads triage results locally and does not push findings to the GitHub PR review thread API. The Haystack GitHub App can publish a check run, but that check run is not a review thread.
 
 Because no GitHub review threads are posted, the `check_unresolved_threads` gate is not invoked for Haystack. `bot_login_for_platform("haystack")` returns an empty string `""`, which signals to `pr-review-loop.sh` that no thread audit is needed.
 
-If a future integration adds a Haystack GitHub App with inline thread posting, this can be updated to the actual bot login (e.g., `haystack-ai[bot]`).
+If a future integration adds Haystack inline thread posting, this can be updated to the actual bot login (e.g., `haystack-ai[bot]`). A check run alone does not require changing the bot login.
 
 ---
 
@@ -102,6 +103,7 @@ Haystack exposes two related but separate result channels:
 | ----------- | ------------- | ----------------------- |
 | `haystack triage <PR> --json` | Code-review findings in `.findings[]` and rating | Blocking categories stop the loop; advisory categories increment `SUGGESTION_COUNT` |
 | `haystack pr-status <PR> --json` | Pipeline/review-policy verdicts such as `analysisVerdict`, `needsHumanReview`, `bucket`, `hasReviewer`, and `haystackRating` | Non-blocking visibility signal when no blocking triage findings exist |
+| `Haystack / Review` check run | GitHub App status, details URL, output summary, and annotations when installed | Fallback/readback source when CLI triage cannot return completed findings; ignored by `pr-ci-loop.sh` as generic CI when Haystack is configured as a reviewer |
 
 When `pr-status` reports `needsHumanReview: true` or
 `analysisVerdict: "needs-review"`, `haystack-reviewer.sh` emits:

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -201,13 +201,19 @@ fetch_haystack_check_run_json() {
   fi
   [ -n "$head_sha" ] || return 1
 
-  if ! runs_json="$(gh api "repos/${OWNER}/${REPO}/commits/${head_sha}/check-runs" 2>/dev/null)"; then
+  if ! runs_json="$(gh api --paginate --slurp "repos/${OWNER}/${REPO}/commits/${head_sha}/check-runs" 2>/dev/null)"; then
     return 1
   fi
   [ -n "$runs_json" ] || return 1
 
   if ! check_json="$(printf '%s\n' "$runs_json" | jq -c --arg name "$CHECK_NAME" '
-    (.check_runs // [])
+    [
+      if type == "array" then
+        .[] | (.check_runs[]? // empty)
+      else
+        .check_runs[]? // empty
+      end
+    ]
     | map(select((.name // "") == $name))
     | sort_by(.started_at // .completed_at // "")
     | last // empty

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -289,9 +289,9 @@ EOF
       return 0
       ;;
     failure|FAILURE|action_required|ACTION_REQUIRED|startup_failure|STARTUP_FAILURE)
-      if [ "$comment_count" -eq 0 ] && [ "${findings_count:-0}" -gt 0 ]; then
-        # The check run reported findings but did not expose category lines in
-        # the summary. Fail closed rather than treating a failed review as clean.
+      if [ "$comment_count" -eq 0 ] && [ "${findings_count:-unknown}" != "0" ]; then
+        # The check run failed but did not expose parseable category lines. Fail
+        # closed unless the summary explicitly reports zero findings.
         blocking_count=1
         comment_count=1
       fi

--- a/scripts/development-workflow/haystack-reviewer.sh
+++ b/scripts/development-workflow/haystack-reviewer.sh
@@ -137,6 +137,7 @@ esac
 TIMEOUT="${HAYSTACK_REVIEWER_TIMEOUT:-120}"
 POLL_INTERVAL="${HAYSTACK_POLL_INTERVAL:-15}"
 PR_STATUS_CHECK="${HAYSTACK_PR_STATUS_CHECK:-1}"
+CHECK_NAME="${HAYSTACK_CHECK_NAME:-Haystack / Review}"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -164,9 +165,188 @@ case "$POLL_INTERVAL" in
     ;;
 esac
 
+# ── GitHub App check-run fallback ─────────────────────────────────────────────
+
+_classify_haystack_category() {
+  local category="$1"
+  case "$category" in
+    "Logic error"|"Critical")
+      printf 'blocking'
+      ;;
+    "Major")
+      if [ "${HAYSTACK_MAJOR_IS_BLOCKING:-0}" = "1" ]; then
+        printf 'blocking'
+      else
+        printf 'advisory'
+      fi
+      ;;
+    "Minor"|"Advisory"|"Nitpick"|"Trivial"|"Weak test coverage"|"Rules violation"|"Code contract violation")
+      printf 'advisory'
+      ;;
+    *)
+      printf 'blocking'
+      ;;
+  esac
+}
+
+fetch_haystack_check_run_json() {
+  command -v gh >/dev/null 2>&1 || return 1
+
+  local head_sha=""
+  local runs_json=""
+  local check_json=""
+
+  if ! head_sha="$(gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha // empty' 2>/dev/null)"; then
+    return 1
+  fi
+  [ -n "$head_sha" ] || return 1
+
+  if ! runs_json="$(gh api "repos/${OWNER}/${REPO}/commits/${head_sha}/check-runs" 2>/dev/null)"; then
+    return 1
+  fi
+  [ -n "$runs_json" ] || return 1
+
+  if ! check_json="$(printf '%s\n' "$runs_json" | jq -c --arg name "$CHECK_NAME" '
+    (.check_runs // [])
+    | map(select((.name // "") == $name))
+    | sort_by(.started_at // .completed_at // "")
+    | last // empty
+  ' 2>/dev/null)"; then
+    return 1
+  fi
+  [ -n "$check_json" ] || return 1
+
+  printf '%s\n' "$check_json"
+}
+
+emit_haystack_check_run_result() {
+  local check_json=""
+  local status=""
+  local conclusion=""
+  local details_url=""
+  local summary=""
+  local title=""
+  local categories=""
+  local category=""
+  local classification=""
+  local blocking_count=0
+  local suggestion_count=0
+  local comment_count=0
+  local findings_count=""
+
+  if ! check_json="$(fetch_haystack_check_run_json)"; then
+    return 3
+  fi
+
+  status="$(printf '%s\n' "$check_json" | jq -r '.status // ""')"
+  conclusion="$(printf '%s\n' "$check_json" | jq -r '.conclusion // ""')"
+  details_url="$(printf '%s\n' "$check_json" | jq -r '.details_url // .detailsUrl // ""')"
+  summary="$(printf '%s\n' "$check_json" | jq -r '.output.summary // ""')"
+  title="$(printf '%s\n' "$check_json" | jq -r '.output.title // ""')"
+
+  if [ "$status" != "completed" ] && [ "$status" != "COMPLETED" ]; then
+    printf 'RESULT=skipped\n'
+    printf 'REASON=pending_check_run\n'
+    printf 'BLOCKING_COUNT=0\n'
+    printf 'SUGGESTION_COUNT=0\n'
+    printf 'COMMENT_COUNT=0\n'
+    printf 'CHECK_RUN_STATUS=%s\n' "$status"
+    printf 'CHECK_RUN_CONCLUSION=%s\n' "$conclusion"
+    [ -n "$details_url" ] && printf 'CHECK_RUN_URL=%s\n' "$details_url"
+    return 2
+  fi
+
+  categories="$(printf '%s\n' "$summary" | sed -n 's/^[[:space:]]*[-*][[:space:]][[:space:]]*//;s/^\*\*\[\([^]]*\)\]\*\*.*/\1/p')"
+  if [ -n "$categories" ]; then
+    while IFS= read -r category; do
+      [ -z "${category:-}" ] && continue
+      classification="$(_classify_haystack_category "$category")"
+      case "$classification" in
+        blocking) blocking_count=$((blocking_count + 1)) ;;
+        *)        suggestion_count=$((suggestion_count + 1)) ;;
+      esac
+    done <<EOF
+$categories
+EOF
+  fi
+  comment_count=$((blocking_count + suggestion_count))
+
+  findings_count="$(printf '%s\n' "$summary" | sed -n 's/^\*\*Findings:\*\* \([0-9][0-9]*\).*/\1/p' | head -n 1)"
+  case "$findings_count" in
+    ''|*[!0-9]*) findings_count="" ;;
+  esac
+
+  case "$conclusion" in
+    success|SUCCESS|neutral|NEUTRAL|skipped|SKIPPED)
+      printf 'RESULT=clean\n'
+      printf 'BLOCKING_COUNT=0\n'
+      printf 'SUGGESTION_COUNT=%d\n' "$suggestion_count"
+      printf 'COMMENT_COUNT=%d\n' "$comment_count"
+      printf 'CHECK_RUN_STATUS=%s\n' "$status"
+      printf 'CHECK_RUN_CONCLUSION=%s\n' "$conclusion"
+      [ -n "$title" ] && printf 'CHECK_RUN_TITLE=%s\n' "$title"
+      [ -n "$details_url" ] && printf 'CHECK_RUN_URL=%s\n' "$details_url"
+      return 0
+      ;;
+    failure|FAILURE|action_required|ACTION_REQUIRED|startup_failure|STARTUP_FAILURE)
+      if [ "$comment_count" -eq 0 ] && [ "${findings_count:-0}" -gt 0 ]; then
+        # The check run reported findings but did not expose category lines in
+        # the summary. Fail closed rather than treating a failed review as clean.
+        blocking_count=1
+        comment_count=1
+      fi
+      if [ "$blocking_count" -gt 0 ]; then
+        printf 'RESULT=needs_fixes\n'
+        printf 'BLOCKING_COUNT=%d\n' "$blocking_count"
+        printf 'SUGGESTION_COUNT=%d\n' "$suggestion_count"
+        printf 'COMMENT_COUNT=%d\n' "$comment_count"
+        printf 'CHECK_RUN_STATUS=%s\n' "$status"
+        printf 'CHECK_RUN_CONCLUSION=%s\n' "$conclusion"
+        [ -n "$title" ] && printf 'CHECK_RUN_TITLE=%s\n' "$title"
+        [ -n "$details_url" ] && printf 'CHECK_RUN_URL=%s\n' "$details_url"
+        return 1
+      fi
+      printf 'RESULT=clean\n'
+      printf 'BLOCKING_COUNT=0\n'
+      printf 'SUGGESTION_COUNT=%d\n' "$suggestion_count"
+      printf 'COMMENT_COUNT=%d\n' "$comment_count"
+      printf 'CHECK_RUN_STATUS=%s\n' "$status"
+      printf 'CHECK_RUN_CONCLUSION=%s\n' "$conclusion"
+      [ -n "$title" ] && printf 'CHECK_RUN_TITLE=%s\n' "$title"
+      [ -n "$details_url" ] && printf 'CHECK_RUN_URL=%s\n' "$details_url"
+      return 0
+      ;;
+    *)
+      printf 'RESULT=skipped\n'
+      printf 'REASON=check_run_%s\n' "${conclusion:-unknown}"
+      printf 'BLOCKING_COUNT=0\n'
+      printf 'SUGGESTION_COUNT=0\n'
+      printf 'COMMENT_COUNT=0\n'
+      printf 'CHECK_RUN_STATUS=%s\n' "$status"
+      printf 'CHECK_RUN_CONCLUSION=%s\n' "$conclusion"
+      [ -n "$details_url" ] && printf 'CHECK_RUN_URL=%s\n' "$details_url"
+      return 2
+      ;;
+  esac
+}
+
+emit_check_run_fallback_or_skip() {
+  local fallback_exit=0
+  set +e
+  emit_haystack_check_run_result
+  fallback_exit=$?
+  set -e
+  [ "$fallback_exit" -ne 3 ] && exit "$fallback_exit"
+  return 1
+}
+
 # ── Availability check ────────────────────────────────────────────────────────
 
 if ! command -v haystack >/dev/null 2>&1; then
+  echo "INFO: haystack CLI not found in PATH — trying GitHub App check-run fallback" >&2
+  if emit_check_run_fallback_or_skip; then
+    :
+  fi
   echo "INFO: haystack CLI not found in PATH — skipping (UNAVAILABLE)" >&2
   printf 'RESULT=skipped\n'
   printf 'REASON=unavailable\n'
@@ -449,6 +629,10 @@ if [ "$TRIAGE_EXIT" -eq 124 ]; then
   # A single haystack triage call exceeded its per-call OS timeout and the
   # overall budget was exhausted.
   echo "INFO: haystack triage timed out after ${TIMEOUT}s" >&2
+  echo "INFO: trying GitHub App check-run fallback after triage timeout" >&2
+  if emit_check_run_fallback_or_skip; then
+    :
+  fi
   printf 'RESULT=skipped\n'
   printf 'REASON=timeout\n'
   printf 'BLOCKING_COUNT=0\n'
@@ -465,6 +649,10 @@ if [ "$TRIAGE_EXIT" -eq 200 ]; then
   # REASON=unavailable (CLI not found / auth failure) and REASON=timeout
   # (per-call OS timeout).
   echo "INFO: haystack triage transient state persisted — budget exhausted after ${TIMEOUT}s (pending_timeout)" >&2
+  echo "INFO: trying GitHub App check-run fallback after pending_timeout" >&2
+  if emit_check_run_fallback_or_skip; then
+    :
+  fi
   printf 'RESULT=skipped\n'
   printf 'REASON=pending_timeout\n'
   printf 'BLOCKING_COUNT=0\n'

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -109,6 +109,44 @@ export WORKFLOW_TARGET_GITHUB_REPO="$repo"
 export GH_REPO="$repo"
 min_no_checks_wait=$((poll_interval * 2))
 
+configured_reviewer_check_names_json() {
+  local config_file="${1:-}"
+  local platform=""
+  local -a names=()
+
+  if [ -z "$config_file" ]; then
+    config_file="$(workflow_effective_config_file 2>/dev/null || workflow_config_file)"
+  fi
+
+  if [ -f "$config_file" ]; then
+    while IFS= read -r platform; do
+      platform="$(printf '%s' "$platform" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+      [ -z "$platform" ] && continue
+      case "$platform" in
+        haystack)
+          names+=("${HAYSTACK_CHECK_NAME:-Haystack / Review}")
+          ;;
+        bugbot)
+          names+=("${BUGBOT_CHECK_NAME:-Cursor Bugbot}")
+          ;;
+      esac
+    done < <(
+      if [ "$config_file" = "$(workflow_config_file)" ]; then
+        WORKFLOW_APPLY_LOCAL_REVIEW_OVERRIDES=1 workflow_config_review_platforms "$config_file"
+      else
+        workflow_config_review_platforms "$config_file"
+      fi
+    )
+  fi
+
+  if [ "${#names[@]}" -eq 0 ]; then
+    printf '[]\n'
+    return 0
+  fi
+
+  printf '%s\n' "${names[@]}" | jq -R . | jq -s .
+}
+
 # is_devin_status_stale <pr_number> <repo>
 #
 # Returns 0 (stale — safe to skip) when:
@@ -265,11 +303,63 @@ while :; do
     print_kv PENDING_CHECKS ""
     exit 1
   fi
+  reviewer_check_names="$(
+    configured_reviewer_check_names_json
+  )"
+  if ! ci_checks_json="$(
+    printf '%s\n' "$normalized_checks_json" | jq --argjson reviewer_names "$reviewer_check_names" '
+      [
+        .[]
+        | select(
+            (.name // .context // .workflowName // "unknown") as $check_name
+            | ($reviewer_names | index($check_name) | not)
+          )
+      ]
+    '
+  )"; then
+    print_kv RESULT red
+    print_kv PR_NUMBER "$pr_number"
+    print_kv REPO "$repo"
+    print_kv REASON check_json_parse_failed
+    print_kv TOTAL_CHECK_COUNT 0
+    print_kv FAILING_CHECK_COUNT 1
+    print_kv FAILING_CHECKS check_json_parse_failed
+    print_kv PENDING_CHECK_COUNT 0
+    print_kv PENDING_CHECKS ""
+    print_kv REVIEWER_CHECK_COUNT 0
+    print_kv REVIEWER_CHECKS ""
+    exit 1
+  fi
+  reviewer_check_count="$(
+    printf '%s\n' "$normalized_checks_json" | jq --argjson reviewer_names "$reviewer_check_names" '
+      [
+        .[]
+        | select(
+            (.name // .context // .workflowName // "unknown") as $check_name
+            | ($reviewer_names | index($check_name))
+          )
+      ]
+      | length
+    '
+  )"
+  reviewer_check_list="$(
+    printf '%s\n' "$normalized_checks_json" | jq -r --argjson reviewer_names "$reviewer_check_names" '
+      [
+        .[]
+        | select(
+            (.name // .context // .workflowName // "unknown") as $check_name
+            | ($reviewer_names | index($check_name))
+          )
+        | (.name // .context // .workflowName // "unknown")
+      ]
+      | join(",")
+    '
+  )"
   total_check_count="$(
-    printf '%s\n' "$normalized_checks_json" | jq 'length'
+    printf '%s\n' "$ci_checks_json" | jq 'length'
   )"
   pending_count="$(
-    printf '%s\n' "$normalized_checks_json" | jq '
+    printf '%s\n' "$ci_checks_json" | jq '
       .
       | map(select(
           ((.status // "") != "" and (.status != "COMPLETED"))
@@ -282,7 +372,7 @@ while :; do
     '
   )"
   pending_list="$(
-    printf '%s\n' "$normalized_checks_json" | jq -r '
+    printf '%s\n' "$ci_checks_json" | jq -r '
       .
       | map(select(
           ((.status // "") != "" and (.status != "COMPLETED"))
@@ -296,7 +386,7 @@ while :; do
     '
   )"
   failing_count="$(
-    printf '%s\n' "$normalized_checks_json" | jq '
+    printf '%s\n' "$ci_checks_json" | jq '
       .
       | map(select(
           (.conclusion == "FAILURE")
@@ -311,7 +401,7 @@ while :; do
     '
   )"
   failing_list="$(
-    printf '%s\n' "$normalized_checks_json" | jq -r '
+    printf '%s\n' "$ci_checks_json" | jq -r '
       .
       | map(select(
           (.conclusion == "FAILURE")
@@ -366,6 +456,8 @@ while :; do
     print_kv FAILING_CHECKS "$failing_list"
     print_kv PENDING_CHECK_COUNT "$pending_count"
     print_kv PENDING_CHECKS "$pending_list"
+    print_kv REVIEWER_CHECK_COUNT "$reviewer_check_count"
+    print_kv REVIEWER_CHECKS "$reviewer_check_list"
     exit 1
   fi
 
@@ -384,6 +476,8 @@ while :; do
     print_kv FAILING_CHECKS ""
     print_kv PENDING_CHECK_COUNT 0
     print_kv PENDING_CHECKS ""
+    print_kv REVIEWER_CHECK_COUNT "$reviewer_check_count"
+    print_kv REVIEWER_CHECKS "$reviewer_check_list"
     exit 0
   fi
 
@@ -396,6 +490,8 @@ while :; do
     print_kv FAILING_CHECKS "$failing_list"
     print_kv PENDING_CHECK_COUNT "$pending_count"
     print_kv PENDING_CHECKS "$pending_list"
+    print_kv REVIEWER_CHECK_COUNT "$reviewer_check_count"
+    print_kv REVIEWER_CHECKS "$reviewer_check_list"
     exit 2
   fi
 

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -304,7 +304,7 @@ while :; do
     exit 1
   fi
   reviewer_check_names="$(
-    configured_reviewer_check_names_json
+    configured_reviewer_check_names_json ""
   )"
   if ! ci_checks_json="$(
     printf '%s\n' "$normalized_checks_json" | jq --argjson reviewer_names "$reviewer_check_names" '

--- a/scripts/development-workflow/tests/test-haystack-reviewer.sh
+++ b/scripts/development-workflow/tests/test-haystack-reviewer.sh
@@ -1174,6 +1174,48 @@ run_test "check_run_fallback_advisory_blocking_zero" "BLOCKING_COUNT=0" "$(echo 
 run_test "check_run_fallback_advisory_suggestions" "SUGGESTION_COUNT=2" "$(echo "$output" | grep '^SUGGESTION_COUNT=')"
 run_test "check_run_fallback_advisory_exit_code" "0" "$ec"
 
+_check_summary_custom='**Verdict:** `pass`
+**Rating:** `5/5`
+**Findings:** 0'
+MOCK_GH_CHECK_RUNS="$(
+  jq -n --arg summary "$_check_summary_custom" '[
+    {
+      check_runs: [
+        {
+          name: "Unrelated Check",
+          status: "completed",
+          conclusion: "failure",
+          started_at: "2026-07-12T15:25:22Z"
+        }
+      ]
+    },
+    {
+      check_runs: [
+        {
+          name: "Custom Haystack Review",
+          status: "completed",
+          conclusion: "success",
+          details_url: "https://haystackeditor.com/review/owner/repo/123",
+          started_at: "2026-07-12T15:26:22Z",
+          output: {title: "Haystack passed", summary: $summary}
+        }
+      ]
+    }
+  ]'
+)"
+export MOCK_GH_CHECK_RUNS
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"status":"pending"}'
+MOCK_HAYSTACK_EXITS='0'
+_install_mock_with_exits
+_install_gh_check_run_mock
+
+output=$(HAYSTACK_CHECK_NAME="Custom Haystack Review" _run_reviewer 1 1)
+ec=$(cat "$_REVIEWER_EXIT_FILE")
+
+run_test "check_run_fallback_custom_paginated_name_result" "RESULT=clean" "$(echo "$output" | grep '^RESULT=')"
+run_test "check_run_fallback_custom_paginated_name_conclusion" "CHECK_RUN_CONCLUSION=success" "$(echo "$output" | grep '^CHECK_RUN_CONCLUSION=')"
+run_test "check_run_fallback_custom_paginated_name_exit_code" "0" "$ec"
+
 MOCK_GH_CHECK_RUNS="$(
   jq -n '{
     check_runs: [
@@ -1201,6 +1243,20 @@ run_test "check_run_fallback_unparseable_failure_result" "RESULT=needs_fixes" "$
 run_test "check_run_fallback_unparseable_failure_blocking" "BLOCKING_COUNT=1" "$(echo "$output" | grep '^BLOCKING_COUNT=')"
 run_test "check_run_fallback_unparseable_failure_exit_code" "1" "$ec"
 
+MOCK_GH_CHECK_RUNS='not-json'
+export MOCK_GH_CHECK_RUNS
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"status":"pending"}'
+MOCK_HAYSTACK_EXITS='0'
+_install_mock_with_exits
+_install_gh_check_run_mock
+
+output=$(_run_reviewer 1 1)
+ec=$(cat "$_REVIEWER_EXIT_FILE")
+
+run_test "check_run_fallback_malformed_json_result" "RESULT=skipped" "$(echo "$output" | grep '^RESULT=')"
+run_test "check_run_fallback_malformed_json_reason" "REASON=pending_timeout" "$(echo "$output" | grep '^REASON=')"
+run_test "check_run_fallback_malformed_json_exit_code" "2" "$ec"
+
 MOCK_GH_CHECK_RUNS="$(
   jq -n '{
     check_runs: [
@@ -1226,7 +1282,7 @@ run_test "check_run_fallback_pending_result" "RESULT=skipped" "$(echo "$output" 
 run_test "check_run_fallback_pending_reason" "REASON=pending_check_run" "$(echo "$output" | grep '^REASON=')"
 run_test "check_run_fallback_pending_exit_code" "2" "$ec"
 
-unset MOCK_GH_CHECK_RUNS _check_summary_blocking _check_summary_advisory
+unset MOCK_GH_CHECK_RUNS _check_summary_blocking _check_summary_advisory _check_summary_custom
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/development-workflow/tests/test-haystack-reviewer.sh
+++ b/scripts/development-workflow/tests/test-haystack-reviewer.sh
@@ -1179,6 +1179,33 @@ MOCK_GH_CHECK_RUNS="$(
     check_runs: [
       {
         name: "Haystack / Review",
+        status: "completed",
+        conclusion: "failure",
+        details_url: "https://haystackeditor.com/review/owner/repo/123",
+        started_at: "2026-07-12T15:26:22Z",
+        output: {title: "Haystack found issues", summary: "Haystack found issues but did not expose structured category output."}
+      }
+    ]
+  }'
+)"
+export MOCK_GH_CHECK_RUNS
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"status":"pending"}'
+MOCK_HAYSTACK_EXITS='0'
+_install_mock_with_exits
+_install_gh_check_run_mock
+
+output=$(_run_reviewer 1 1)
+ec=$(cat "$_REVIEWER_EXIT_FILE")
+
+run_test "check_run_fallback_unparseable_failure_result" "RESULT=needs_fixes" "$(echo "$output" | grep '^RESULT=')"
+run_test "check_run_fallback_unparseable_failure_blocking" "BLOCKING_COUNT=1" "$(echo "$output" | grep '^BLOCKING_COUNT=')"
+run_test "check_run_fallback_unparseable_failure_exit_code" "1" "$ec"
+
+MOCK_GH_CHECK_RUNS="$(
+  jq -n '{
+    check_runs: [
+      {
+        name: "Haystack / Review",
         status: "in_progress",
         conclusion: null,
         started_at: "2026-07-12T15:26:22Z"

--- a/scripts/development-workflow/tests/test-haystack-reviewer.sh
+++ b/scripts/development-workflow/tests/test-haystack-reviewer.sh
@@ -199,6 +199,34 @@ MOCK_HAYSTACK
   chmod +x "$MOCK_BIN/haystack"
 }
 
+_install_gh_check_run_mock() {
+  cat > "$MOCK_BIN/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"repos/owner/repo/pulls/123"*"--jq .head.sha"*)
+    printf '%s\n' "${MOCK_GH_HEAD_SHA:-abc123sha}"
+    exit 0
+    ;;
+  *"repos/owner/repo/commits/"*"/check-runs"*)
+    if [ "${MOCK_GH_CHECK_RUNS_FAIL:-0}" = "1" ]; then
+      exit 1
+    fi
+    if [ -n "${MOCK_GH_CHECK_RUNS:-}" ]; then
+      printf '%s\n' "$MOCK_GH_CHECK_RUNS"
+    else
+      printf '{"check_runs":[]}\n'
+    fi
+    exit 0
+    ;;
+  *)
+    printf 'unexpected gh invocation: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+MOCK_GH
+  chmod +x "$MOCK_BIN/gh"
+}
+
 _call_count() {
   # Returns number of times the mock haystack was called.
   if [ ! -f "$CALL_LOG" ]; then echo "0"; return; fi
@@ -1063,6 +1091,115 @@ run_test "http_401_result" "RESULT=skipped" "$(echo "$output" | grep '^RESULT=')
 run_test "http_401_reason" "REASON=unauthorized" "$(echo "$output" | grep '^REASON=')"
 run_test "http_401_exit_code" "3" "$ec"
 run_test "http_401_single_call" "1" "$calls"
+
+# ---------------------------------------------------------------------------
+# Area 12: GitHub App check-run fallback
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 12: GitHub App check-run fallback ==="
+
+_check_summary_blocking="$(cat <<'SUMMARY_BLOCKING'
+**Verdict:** `has-issues`
+**Rating:** `3/5`
+**Findings:** 3
+
+**[Logic error]** - Sticky fingerprint mismatch can delay escalation.
+**[Rules violation]** - Config invariants are not validated.
+**[Weak test coverage]** - Remediation branch selection lacks coverage.
+SUMMARY_BLOCKING
+)"
+MOCK_GH_CHECK_RUNS="$(
+  jq -n --arg summary "$_check_summary_blocking" '{
+    check_runs: [
+      {
+        name: "Haystack / Review",
+        status: "completed",
+        conclusion: "failure",
+        details_url: "https://haystackeditor.com/review/owner/repo/123",
+        started_at: "2026-07-12T15:26:22Z",
+        output: {title: "Haystack found 3 issues", summary: $summary}
+      }
+    ]
+  }'
+)"
+export MOCK_GH_CHECK_RUNS
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"status":"pending"}'
+MOCK_HAYSTACK_EXITS='0'
+_install_mock_with_exits
+_install_gh_check_run_mock
+
+output=$(_run_reviewer 1 1)
+ec=$(cat "$_REVIEWER_EXIT_FILE")
+
+run_test "check_run_fallback_blocking_result" "RESULT=needs_fixes" "$(echo "$output" | grep '^RESULT=')"
+run_test "check_run_fallback_blocking_count" "BLOCKING_COUNT=1" "$(echo "$output" | grep '^BLOCKING_COUNT=')"
+run_test "check_run_fallback_suggestion_count" "SUGGESTION_COUNT=2" "$(echo "$output" | grep '^SUGGESTION_COUNT=')"
+run_test "check_run_fallback_conclusion" "CHECK_RUN_CONCLUSION=failure" "$(echo "$output" | grep '^CHECK_RUN_CONCLUSION=')"
+run_test "check_run_fallback_blocking_exit_code" "1" "$ec"
+
+_check_summary_advisory="$(cat <<'SUMMARY_ADVISORY'
+**Verdict:** `has-issues`
+**Rating:** `4/5`
+**Findings:** 2
+
+- **[Rules violation]** - Changelog placement needs review.
+- **[Weak test coverage]** - Add focused coverage.
+SUMMARY_ADVISORY
+)"
+MOCK_GH_CHECK_RUNS="$(
+  jq -n --arg summary "$_check_summary_advisory" '{
+    check_runs: [
+      {
+        name: "Haystack / Review",
+        status: "completed",
+        conclusion: "failure",
+        details_url: "https://haystackeditor.com/review/owner/repo/123",
+        started_at: "2026-07-12T15:26:22Z",
+        output: {title: "Haystack found 2 issues", summary: $summary}
+      }
+    ]
+  }'
+)"
+export MOCK_GH_CHECK_RUNS
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"status":"pending"}'
+MOCK_HAYSTACK_EXITS='0'
+_install_mock_with_exits
+_install_gh_check_run_mock
+
+output=$(_run_reviewer 1 1)
+ec=$(cat "$_REVIEWER_EXIT_FILE")
+
+run_test "check_run_fallback_advisory_result" "RESULT=clean" "$(echo "$output" | grep '^RESULT=')"
+run_test "check_run_fallback_advisory_blocking_zero" "BLOCKING_COUNT=0" "$(echo "$output" | grep '^BLOCKING_COUNT=')"
+run_test "check_run_fallback_advisory_suggestions" "SUGGESTION_COUNT=2" "$(echo "$output" | grep '^SUGGESTION_COUNT=')"
+run_test "check_run_fallback_advisory_exit_code" "0" "$ec"
+
+MOCK_GH_CHECK_RUNS="$(
+  jq -n '{
+    check_runs: [
+      {
+        name: "Haystack / Review",
+        status: "in_progress",
+        conclusion: null,
+        started_at: "2026-07-12T15:26:22Z"
+      }
+    ]
+  }'
+)"
+export MOCK_GH_CHECK_RUNS
+MOCK_HAYSTACK_OUTPUTS='{"owner":"owner","repo":"repo","prNumber":123,"status":"pending"}'
+MOCK_HAYSTACK_EXITS='0'
+_install_mock_with_exits
+_install_gh_check_run_mock
+
+output=$(_run_reviewer 1 1)
+ec=$(cat "$_REVIEWER_EXIT_FILE")
+
+run_test "check_run_fallback_pending_result" "RESULT=skipped" "$(echo "$output" | grep '^RESULT=')"
+run_test "check_run_fallback_pending_reason" "REASON=pending_check_run" "$(echo "$output" | grep '^REASON=')"
+run_test "check_run_fallback_pending_exit_code" "2" "$ec"
+
+unset MOCK_GH_CHECK_RUNS _check_summary_blocking _check_summary_advisory
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -344,6 +344,19 @@ run_contains "ci_loop_ignores_configured_haystack_review_check" "RESULT=green" "
 run_contains "ci_loop_reports_ignored_reviewer_check" "REVIEWER_CHECKS=Haystack / Review" "$ci_haystack_review_output"
 run_contains "ci_loop_counts_only_ci_checks" "TOTAL_CHECK_COUNT=1" "$ci_haystack_review_output"
 
+ci_custom_haystack_review_output="$(
+  AI_DEV_WORKFLOW_CONFIG_FILE="$ci_haystack_config" \
+  HAYSTACK_CHECK_NAME="Custom Haystack Review" \
+  GH_PR_VIEW_JSON='{"headRefName":"feature/900-product-routing","labels":[],"isDraft":false,"comments":[],"statusCheckRollup":[{"__typename":"CheckRun","name":"Custom Haystack Review","status":"COMPLETED","conclusion":"FAILURE"},{"__typename":"CheckRun","name":"Unit Tests","status":"COMPLETED","conclusion":"SUCCESS"}]}' \
+  PATH="$stub_bin:$PATH" "$REPO_ROOT/scripts/development-workflow/pr-ci-loop.sh" \
+    72 \
+    --repo example/mobile-app \
+    --poll-interval 1 \
+    --max-wait 2
+)"
+run_contains "ci_loop_uses_custom_haystack_check_name" "RESULT=green" "$ci_custom_haystack_review_output"
+run_contains "ci_loop_reports_custom_reviewer_check" "REVIEWER_CHECKS=Custom Haystack Review" "$ci_custom_haystack_review_output"
+
 run_fails_contains \
   "ci_loop_still_fails_real_ci_with_haystack_review_check" \
   "FAILING_CHECKS=Unit Tests" \

--- a/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+++ b/scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
@@ -250,6 +250,10 @@ case "$1" in
     ;;
   pr)
     if [ "$2" = "view" ]; then
+      if [ -n "${GH_PR_VIEW_JSON:-}" ]; then
+        printf '%s\n' "$GH_PR_VIEW_JSON"
+        exit 0
+      fi
       printf '{"headRefName":"feature/900-product-routing","labels":[],"isDraft":false,"comments":[],"statusCheckRollup":[]}\n'
       exit 0
     fi
@@ -317,6 +321,39 @@ ci_output="$(
 )"
 run_contains "ci_loop_targets_explicit_repo" "REPO=example/mobile-app" "$ci_output"
 run_contains "ci_loop_reports_green" "RESULT=green" "$ci_output"
+
+ci_haystack_config="$TMP_ROOT/ci-haystack-workflow.yaml"
+cat > "$ci_haystack_config" <<'YAML'
+schema_version: 2
+review:
+  on_ready:
+    github:
+      - haystack
+YAML
+
+ci_haystack_review_output="$(
+  AI_DEV_WORKFLOW_CONFIG_FILE="$ci_haystack_config" \
+  GH_PR_VIEW_JSON='{"headRefName":"feature/900-product-routing","labels":[],"isDraft":false,"comments":[],"statusCheckRollup":[{"__typename":"CheckRun","name":"Haystack / Review","status":"COMPLETED","conclusion":"FAILURE"},{"__typename":"CheckRun","name":"Unit Tests","status":"COMPLETED","conclusion":"SUCCESS"}]}' \
+  PATH="$stub_bin:$PATH" "$REPO_ROOT/scripts/development-workflow/pr-ci-loop.sh" \
+    70 \
+    --repo example/mobile-app \
+    --poll-interval 1 \
+    --max-wait 2
+)"
+run_contains "ci_loop_ignores_configured_haystack_review_check" "RESULT=green" "$ci_haystack_review_output"
+run_contains "ci_loop_reports_ignored_reviewer_check" "REVIEWER_CHECKS=Haystack / Review" "$ci_haystack_review_output"
+run_contains "ci_loop_counts_only_ci_checks" "TOTAL_CHECK_COUNT=1" "$ci_haystack_review_output"
+
+run_fails_contains \
+  "ci_loop_still_fails_real_ci_with_haystack_review_check" \
+  "FAILING_CHECKS=Unit Tests" \
+  env AI_DEV_WORKFLOW_CONFIG_FILE="$ci_haystack_config" \
+    GH_PR_VIEW_JSON='{"headRefName":"feature/900-product-routing","labels":[],"isDraft":false,"comments":[],"statusCheckRollup":[{"__typename":"CheckRun","name":"Haystack / Review","status":"COMPLETED","conclusion":"FAILURE"},{"__typename":"CheckRun","name":"Unit Tests","status":"COMPLETED","conclusion":"FAILURE"}]}' \
+    PATH="$stub_bin:$PATH" "$REPO_ROOT/scripts/development-workflow/pr-ci-loop.sh" \
+    71 \
+    --repo example/mobile-app \
+    --poll-interval 1 \
+    --max-wait 2
 
 ci_product_log="$TMP_ROOT/ci-product-gh-args.log"
 ci_product_output="$(


### PR DESCRIPTION
## Summary
- Treat configured Haystack and Bugbot check runs as reviewer-loop state in pr-ci-loop instead of ordinary CI.
- Add Haystack GitHub App check-run fallback/readback when CLI triage is unavailable, times out, or remains pending.
- Document the check-run behavior and cover blocking, advisory-only, and pending fallback cases.

## Verification
- bash scripts/development-workflow/tests/test-haystack-reviewer.sh
- bash scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
- shellcheck -x -S warning scripts/development-workflow/pr-ci-loop.sh scripts/development-workflow/haystack-reviewer.sh scripts/development-workflow/tests/test-haystack-reviewer.sh scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
- npx markdownlint-cli2 CHANGELOG.md docs/workflow/development-workflow/integrations/haystack-triage.md
- bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md
- git diff --check

## Pre-submission self-review
- Confirmed CLI triage remains preferred and the check run is only fallback/readback evidence.
- Confirmed failed reviewer checks are removed from generic CI counts only when the matching reviewer platform is configured.
- Confirmed failed check runs with findings but no parseable categories fail closed.

Closes #1188