### PR TITLE
docs(plan): deprecate direct Cursor item-orchestrator path

### DIFF
--- a/docs/specs/developments/20260713211636_1190-deprecate-direct-item-orchestrator-cursor-runs/2_1190-deprecate-direct-item-orchestrator-cursor-runs_implementation-plan.md
+++ b/docs/specs/developments/20260713211636_1190-deprecate-direct-item-orchestrator-cursor-runs/2_1190-deprecate-direct-item-orchestrator-cursor-runs_implementation-plan.md
@@ -1,0 +1,227 @@
+# Deprecate Direct Item-Orchestrator Command for Cursor Runs - Implementation Plan
+
+**Spec**: [1_1190-deprecate-direct-item-orchestrator-cursor-runs_specs.md](1_1190-deprecate-direct-item-orchestrator-cursor-runs_specs.md)
+**Smoke test runbook**: [1190-deprecate-direct-item-orchestrator-cursor-runs.smoke-test.md](../../../testing/workflow/1190-deprecate-direct-item-orchestrator-cursor-runs.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Update the Cursor-facing command and agent guidance so `/run-item`
+is the only normal user-facing entrypoint while `item-orchestrator` remains an
+internal subagent/handoff role. Keep mirrored Claude/Codex/shared docs aligned
+where they mention the same entrypoint, and add smoke-test coverage that checks
+the canonical Cursor path plus model-routing intent.
+
+**Estimated complexity**: M
+
+**Rationale**: The change is mostly documentation and command-wrapper guidance,
+but it spans mirrored agent surfaces and workflow docs. The main risk is either
+over-removing internal `item-orchestrator` references that are still needed for
+subagent dispatch, or under-updating Cursor-facing prose that still tells users
+to invoke `/item-orchestrator` directly.
+
+**Dependencies**: Spec PR #1195 is merged to `develop`.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `b460337` |
+| Template-fit check | Read `.ai-dev-workflow.yaml` and spec | `template.is_template: true`; spec is generic workflow tooling for this template, not downstream framework-specific behavior |
+| Primary run-item surfaces | `rg -l "item-orchestrator\|/item-orchestrator\|/run-item\|run-item" AGENTS.md .cursor/commands .cursor/agents .claude/commands .claude/agents .agents/skills .codex/skills docs/workflow/development-workflow docs/testing/workflow -g '*.md' -g '*.yaml' -g '*.mdc' \| sort` | Live search found the command, agent, skill, workflow-doc, and smoke-test surfaces that need review; implementation should update the targeted subset listed below and leave unrelated historical smoke tests intact unless they describe current guidance |
+| Current Cursor user-facing conflict | Read `AGENTS.md` Cursor note and `.cursor/commands/run-item.md` | `AGENTS.md` currently says Cursor users may invoke `/item-orchestrator` directly; `.cursor/commands/run-item.md` does not yet state Cursor internal handoff/model-routing behavior |
+| Model-routing source | Read `docs/workflow/development-workflow/agent-model-config.md` and `.cursor/agents/*.md` | Cursor agent model pins already exist; implementation should preserve these assignments and explain that `/run-item` can route through them internally |
+
+---
+
+## Layer-by-Layer Changes
+
+### Documentation / Command Guidance
+
+- [ ] Update `AGENTS.md` Cursor note so users are directed to workflow commands
+      first, especially `/run-item <target>` for single-item advancement. Keep
+      Cursor subagents documented as configured internal/expert roles, but do
+      not present `/item-orchestrator` as the normal user-facing path.
+- [ ] Update the **Workflow Commands** row for **Advance One Item** in `AGENTS.md`
+      only if needed to clarify that Cursor users invoke `/run-item`, while the
+      `item-orchestrator` role is internal/subagent execution support rather
+      than an alternate user entrypoint.
+- [ ] Update `.cursor/commands/run-item.md` to define the Cursor execution
+      contract:
+      - `/run-item` runs the bounded prelude first.
+      - After confirmation, Cursor should hand off internally to the configured
+        `item-orchestrator` and stage subagents when supported.
+      - The handoff preserves confirmed scope and selected policy.
+      - The receiving internal context must not rerun the bounded prelude or
+        re-prompt for the same confirmed policy.
+      - If internal handoff is unavailable, the fallback still starts from
+        `/run-item` and must preserve Protocol 91 stops.
+- [ ] Update `.cursor/agents/item-orchestrator.md` so its description and opening
+      guidance identify it as an internal target for `/run-item` handoff and
+      legacy compatibility, not the normal command users should invoke.
+- [ ] Update `.claude/commands/run-item.md`, `.claude/agents/item-orchestrator.md`,
+      `.agents/skills/run-item/SKILL.md`, and
+      `.codex/skills/workflow-item-orchestrator/SKILL.md` only where needed to
+      preserve mirrored terminology and avoid contradicting the Cursor-specific
+      handoff contract. Do not add Cursor-only behavior to non-Cursor surfaces.
+- [ ] Review `.cursor/commands/run-item-work.md` and `.claude/commands/run-item-work.md`
+      to ensure their deprecation wording still points to `/run-item` and does
+      not encourage direct `item-orchestrator` use.
+- [ ] Review `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
+      where it mentions Cursor `/item-orchestrator` dispatch. If retained, label
+      it as internal dispatch from orchestration, not user-facing invocation.
+- [ ] Update `docs/workflow/development-workflow/agent-model-config.md` to
+      reinforce the model-routing intent: Cursor pins subagent models so
+      `/run-item` internal handoff can use the role-appropriate model instead of
+      relying on the parent Composer model.
+
+### Smoke Test Coverage
+
+- [ ] Add `docs/testing/workflow/1190-deprecate-direct-item-orchestrator-cursor-runs.smoke-test.md`
+      covering all acceptance criteria from the spec.
+- [ ] The smoke test should inspect Cursor and shared guidance surfaces, not run
+      an end-to-end live Cursor session. It should verify:
+      - Cursor user-facing guidance names `/run-item <target>` as canonical.
+      - Cursor docs do not instruct normal direct `/item-orchestrator`
+        invocation.
+      - Remaining `item-orchestrator` references are internal, compatibility, or
+        historical test context.
+      - `/run-item` handoff preserves bounded prelude confirmation.
+      - Model-routing intent points at configured Cursor subagents.
+      - Mirrored run-item surfaces remain consistent.
+
+### Tests / Tooling
+
+- [ ] Run markdown lint on every modified markdown file plus this plan and the
+      smoke runbook.
+- [ ] Run a targeted `rg` verification after implementation to inspect remaining
+      direct `/item-orchestrator` references and classify each as internal,
+      compatibility, or historical.
+
+### Changelog
+
+- [ ] Add an `[Unreleased]` entry during implementation:
+      `- **Deprecate direct Cursor item-orchestrator path** (#1190): Clarify that Cursor users start single-item work with /run-item while internal handoff preserves configured subagent model routing.`
+
+---
+
+## Testing Strategy
+
+**Test types**: Documentation inspection, smoke checklist, markdown lint.
+
+**Key scenarios to test**:
+
+1. Cursor `/run-item` is the canonical user-facing command for single-item work
+   and maps to AC1.
+2. Direct `/item-orchestrator` references are no longer presented as the normal
+   Cursor path and map to AC2 and AC3.
+3. The Cursor `/run-item` handoff contract preserves bounded prelude scope and
+   policy without duplicate prompts and maps to AC4 and AC5.
+4. Stage-specific model routing through configured Cursor agents is documented
+   and maps to AC6 and AC8.
+5. Mirrored Cursor, Claude, Codex, and shared workflow surfaces remain aligned
+   and map to AC7.
+
+**Smoke test runbook**: `docs/testing/workflow/1190-deprecate-direct-item-orchestrator-cursor-runs.smoke-test.md`
+
+**Regression suite**: No automated application regression suite applies. This is
+a repository workflow documentation change; markdown lint and repository
+inspection smoke coverage are the appropriate verification layer.
+
+### Parser-risk addendum
+
+Not applicable. The plan does not introduce parser, scanner, lint rule, regex
+engine, or structured-text parsing behavior.
+
+### Concurrent-event-source addendum
+
+Not applicable. The plan does not introduce event listeners, callbacks, timers,
+async queues, or shared mutable runtime state.
+
+---
+
+## Seed Data
+
+No seed data is required.
+
+| Entity | Values / Scenario | File |
+| --- | --- | --- |
+| None | Documentation and workflow guidance inspection only | Not applicable |
+
+---
+
+## Documentation Updates
+
+- [ ] `AGENTS.md` - update Cursor user guidance and, if needed, the single-item
+      workflow command row.
+- [ ] `.cursor/commands/run-item.md` - define Cursor's canonical `/run-item`
+      handoff contract.
+- [ ] `.cursor/agents/item-orchestrator.md` - clarify internal/compatibility role.
+- [ ] `.claude/commands/run-item.md` - keep mirrored canonical entrypoint wording
+      consistent without adding Cursor-only behavior.
+- [ ] `.claude/agents/item-orchestrator.md` - keep mirrored internal role wording
+      consistent where applicable.
+- [ ] `.agents/skills/run-item/SKILL.md` - keep Codex command alias wording
+      consistent with canonical `/run-item`.
+- [ ] `.codex/skills/workflow-item-orchestrator/SKILL.md` - keep legacy Codex
+      orchestrator wording from contradicting `/run-item` as canonical.
+- [ ] `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
+      - clarify Cursor `item-orchestrator` mentions as internal dispatch where
+      currently ambiguous.
+- [ ] `docs/workflow/development-workflow/agent-model-config.md` - document why
+      Cursor `/run-item` internal handoff preserves configured model routing.
+- [ ] `docs/testing/workflow/1190-deprecate-direct-item-orchestrator-cursor-runs.smoke-test.md`
+      - add smoke coverage for this feature.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Internal dispatch references are removed or over-deprecated | Medium | Medium | Keep `item-orchestrator` as an internal subagent role and only deprecate direct normal user invocation |
+| Cursor-specific behavior leaks into Claude or Codex guidance | Medium | Low | Update mirrored surfaces only for canonical terminology; keep Cursor handoff details in Cursor-facing docs |
+| A remaining `/item-orchestrator` mention is misclassified | Medium | Medium | Add smoke-test steps requiring every remaining direct mention to be classified as internal, compatibility, or historical |
+| Implementation forgets model-routing motivation | Low | Medium | Update `agent-model-config.md` and smoke-test assertions to verify Cursor model-routing intent |
+
+---
+
+## Code Samples
+
+No code samples are included. Implementation should edit markdown guidance and
+smoke-test files only.
+
+---
+
+## Implementation Order
+
+1. Update Cursor-facing user guidance in `AGENTS.md` so `/run-item <target>` is
+   the normal single-item entrypoint and direct `/item-orchestrator` use is not
+   advertised as the normal path.
+2. Update `.cursor/commands/run-item.md` with the post-prelude internal handoff
+   contract and fallback behavior.
+3. Update `.cursor/agents/item-orchestrator.md` so it describes an internal
+   `/run-item` handoff role and legacy compatibility rather than a normal direct
+   command.
+4. Review and minimally update mirrored run-item surfaces:
+   `.claude/commands/run-item.md`, `.claude/agents/item-orchestrator.md`,
+   `.agents/skills/run-item/SKILL.md`, and
+   `.codex/skills/workflow-item-orchestrator/SKILL.md`.
+5. Review deprecated alias surfaces `.cursor/commands/run-item-work.md` and
+   `.claude/commands/run-item-work.md`; update only if they imply direct
+   `item-orchestrator` usage.
+6. Update Protocol 90 and `agent-model-config.md` where needed to distinguish
+   internal dispatch from user-facing invocation and to capture model-routing
+   intent.
+7. Add the smoke test runbook for #1190.
+8. Add the `[Unreleased]` CHANGELOG entry using the literal from the Changelog
+   section above.
+9. Run:
+   `rg -n "Invoke them directly|/item-orchestrator|Cursor.*item-orchestrator|item-orchestrator.*Cursor" AGENTS.md .cursor .claude .agents .codex docs/workflow/development-workflow docs/testing/workflow`
+   and confirm each remaining hit is internal, compatibility, or historical
+   smoke-test context.
+10. Run markdown lint on all changed markdown files.
+11. Commit with a Conventional Commit message and open the implementation PR.

--- a/docs/testing/workflow/1190-deprecate-direct-item-orchestrator-cursor-runs.smoke-test.md
+++ b/docs/testing/workflow/1190-deprecate-direct-item-orchestrator-cursor-runs.smoke-test.md
@@ -1,0 +1,169 @@
+# Smoke Test Runbook: Deprecate Direct Item-Orchestrator Command for Cursor Runs
+
+**Feature**: Deprecate direct item-orchestrator command for Cursor runs (#1190)
+**Spec**: [1_1190-deprecate-direct-item-orchestrator-cursor-runs_specs.md](../../specs/developments/20260713211636_1190-deprecate-direct-item-orchestrator-cursor-runs/1_1190-deprecate-direct-item-orchestrator-cursor-runs_specs.md)
+**Implementation plan**: [2_1190-deprecate-direct-item-orchestrator-cursor-runs_implementation-plan.md](../../specs/developments/20260713211636_1190-deprecate-direct-item-orchestrator-cursor-runs/2_1190-deprecate-direct-item-orchestrator-cursor-runs_implementation-plan.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+This feature changes workflow guidance and thin command/agent surfaces. The smoke
+test is performed by repository inspection on the implementation branch.
+
+- [ ] The implementation branch for #1190 is checked out.
+- [ ] A terminal at the repository root is available.
+- [ ] `rg`, `git`, and `markdownlint-cli2` are available.
+
+---
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| Cursor command | `.cursor/commands/run-item.md` |
+| Cursor orchestrator agent | `.cursor/agents/item-orchestrator.md` |
+| Shared guidance | `AGENTS.md` |
+| Model-routing guidance | `docs/workflow/development-workflow/agent-model-config.md` |
+| Mirrored run-item surfaces | `.claude/commands/run-item.md`, `.agents/skills/run-item/SKILL.md`, `.codex/skills/workflow-item-orchestrator/SKILL.md` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Confirm Cursor canonical command guidance
+
+**Maps to**: AC1
+
+1. Read `AGENTS.md`.
+2. Read `.cursor/commands/run-item.md`.
+3. Confirm both identify `/run-item <target>` as the normal Cursor path for a
+   single non-epic workflow item.
+
+**Expected result**: Cursor users are directed to `/run-item`, not to direct
+`/item-orchestrator` invocation, for normal single-item advancement.
+
+### Step 2: Classify remaining direct item-orchestrator references
+
+**Maps to**: AC2, AC3
+
+Run:
+
+```bash
+rg -n "Invoke them directly|/item-orchestrator|Cursor.*item-orchestrator|item-orchestrator.*Cursor" \
+  AGENTS.md .cursor .claude .agents .codex docs/workflow/development-workflow docs/testing/workflow
+```
+
+For every remaining hit, classify it as one of:
+
+- internal handoff / internal dispatch,
+- legacy compatibility,
+- historical smoke-test context,
+- or a defect.
+
+**Expected result**: No current Cursor-facing guidance presents direct
+`/item-orchestrator` invocation as the normal user-facing path. Any remaining
+reference is clearly internal, compatibility-oriented, or historical.
+
+### Step 3: Verify Cursor handoff contract
+
+**Maps to**: AC4, AC5
+
+1. Read `.cursor/commands/run-item.md`.
+2. Confirm it states that `/run-item` runs the bounded prelude first.
+3. Confirm it states that internal handoff preserves confirmed scope and selected
+   policy.
+4. Confirm it states that the receiving internal orchestration context must not
+   duplicate the bounded prelude or re-prompt for the same confirmed policy.
+
+**Expected result**: The Cursor `/run-item` command describes a single prelude
+and a no-duplicate-prompt internal handoff.
+
+### Step 4: Verify stage-specific model-routing intent
+
+**Maps to**: AC6, AC8
+
+1. Read `docs/workflow/development-workflow/agent-model-config.md`.
+2. Confirm the Cursor model defaults still pin stage-specific agents such as
+   `item-orchestrator`, `product-manager`, `tech-lead`, `developer`, and
+   `code-reviewer`.
+3. Confirm the updated guidance explains that `/run-item` can use internal
+   handoff so these configured roles/models are preserved.
+
+**Expected result**: Model-routing intent is explicit and tied to `/run-item`
+internal handoff, not to direct manual `/item-orchestrator` invocation.
+
+### Step 5: Verify mirrored run-item surfaces stay aligned
+
+**Maps to**: AC7
+
+Inspect:
+
+```bash
+rg -n "canonical single-item|bounded prelude|RUN_ITEM_POLICY_CONFIRMED|item-orchestrator|/run-item" \
+  .cursor/commands/run-item.md \
+  .cursor/agents/item-orchestrator.md \
+  .claude/commands/run-item.md \
+  .claude/agents/item-orchestrator.md \
+  .agents/skills/run-item/SKILL.md \
+  .codex/skills/workflow-item-orchestrator/SKILL.md
+```
+
+**Expected result**: The surfaces agree that `/run-item` is canonical, the
+bounded prelude remains first, and any `item-orchestrator` wording is compatible
+with the internal role.
+
+### Last Step: Validate markdown
+
+Run markdown lint on changed markdown files, including this runbook.
+
+**Expected result**: Markdown lint exits successfully.
+
+---
+
+## Assertions Checklist
+
+Each checkbox maps to an acceptance criterion from the spec.
+
+- [ ] AC1: Cursor command guidance presents `/run-item <target>` as canonical.
+- [ ] AC2: Cursor-facing docs do not instruct users to directly invoke
+      `/item-orchestrator` as the normal workflow path.
+- [ ] AC3: Remaining direct `item-orchestrator` references are internal,
+      compatibility, or historical.
+- [ ] AC4: Cursor `/run-item` runs the bounded prelude before internal handoff.
+- [ ] AC5: Internal handoff does not duplicate the prelude or re-prompt for the
+      same confirmed policy.
+- [ ] AC6: Stage-specific handoff guidance covers configured Cursor agents.
+- [ ] AC7: Mirrored `/run-item`, `/run-item-work`, and `item-orchestrator`
+      surfaces remain aligned.
+- [ ] AC8: Smoke or documentation coverage verifies canonical Cursor path and
+      model-routing intent.
+
+---
+
+## Seed Data Reference
+
+No seed data is required.
+
+| Entity | Scenario | How to load |
+| --- | --- | --- |
+| None | Repository workflow guidance inspection | Not applicable |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Search still finds `/item-orchestrator` in user-facing prose | A guidance file still advertises direct invocation | Reword it to point users to `/run-item` and describe `item-orchestrator` as internal or compatibility-only |
+| Markdown lint reports broken links | Relative path depth from `docs/testing/workflow/` is wrong | Use `../../specs/developments/...` for spec and plan links |
+| Model-routing assertion is unclear | `agent-model-config.md` does not connect pinned Cursor agents to `/run-item` handoff | Add a short note tying internal handoff to configured Cursor subagent model assignments |
+
+---
+
+## Known Limitations
+
+- This smoke test verifies repository guidance and command surfaces. It does not
+  launch a live Cursor session or prove Cursor's runtime dispatch behavior.


### PR DESCRIPTION
## Summary

Adds the implementation plan and smoke test runbook for issue #1190. The plan scopes implementation to Cursor/shared workflow guidance, model-routing documentation, smoke coverage, and the implementation CHANGELOG entry.

Plan: `docs/specs/developments/20260713211636_1190-deprecate-direct-item-orchestrator-cursor-runs/2_1190-deprecate-direct-item-orchestrator-cursor-runs_implementation-plan.md`

Runbook: `docs/testing/workflow/1190-deprecate-direct-item-orchestrator-cursor-runs.smoke-test.md`

## Approach

- Clarify `/run-item` as the normal Cursor single-item entrypoint.
- Keep `item-orchestrator` as internal handoff / compatibility where needed.
- Preserve the bounded prelude and no-duplicate-prompt contract.
- Tie Cursor internal handoff to configured subagent model routing.
- Add repository-inspection smoke coverage for the guidance surfaces.

## Complexity

Medium - mostly documentation and thin command/agent guidance, but it spans mirrored workflow surfaces and must avoid over-removing internal dispatch references.

## Document Quality Gate

- Spec/brief coverage: Checked - all eight spec acceptance criteria map to implementation steps and smoke assertions.
- Implementation-order consistency: Checked - file list, implementation order, and documentation updates describe the same targeted surfaces.
- Verification support: Checked - scope statements cite live `rg` verification and source file reads in the Verification Log.
- Behavioral guarantees: Checked - bounded prelude, no duplicate prompt, and model-routing guarantees name their documentation mechanisms.
- Parser/API/concurrency checklist: Not applicable - this plan changes markdown guidance only; no parser, API surface, snapshot, or concurrent-event behavior is introduced.
- CHANGELOG literal format: Checked - implementation CHANGELOG entry uses the project bold-title format under `[Unreleased]`.
- Not-applicable rationale: Checked - no seed data or runtime regression suite applies because this is a workflow documentation change.

Closes #1190

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New markdown only; no runtime, auth, or application code. Risk is limited to plan/runbook accuracy for a later docs implementation PR.
> 
> **Overview**
> Adds **planning-only** artifacts for #1190: an implementation plan and a repository-inspection smoke runbook. No workflow command files or `AGENTS.md` are changed in this PR.
> 
> The **implementation plan** scopes follow-on work: make `/run-item <target>` the normal Cursor entry for single-item runs, keep `item-orchestrator` as internal handoff/legacy, document bounded prelude + no-duplicate-prompt handoff, align mirrored Claude/Codex/skills surfaces, update Protocol 90 and `agent-model-config.md` for model routing, and add an `[Unreleased]` CHANGELOG line during implementation.
> 
> The **smoke runbook** maps all eight spec acceptance criteria to `rg`/read steps (canonical `/run-item`, classify remaining `/item-orchestrator` mentions, handoff contract, model-routing intent, mirrored surface alignment, markdown lint).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f20c0b190de5ced1f80c68f0440cc90dfaca547. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->