### PR TITLE
fix(workflow): harden run-work scan helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Run-work scan helper caveats** (#1198): parse router guardrails without a
+  PyYAML dependency and make batch-lane scan mode Bash 3.2 safe when no paths
+  are supplied.
 - **Haystack GitHub App review checks** (#1188): treat configured Haystack
   check runs as reviewer-loop state instead of generic CI, with check-run
   fallback/readback when CLI triage cannot return completed findings.

--- a/scripts/development-workflow/run-work-router.sh
+++ b/scripts/development-workflow/run-work-router.sh
@@ -150,27 +150,26 @@ read_guardrails_config() {
     return 0
   fi
 
-  # Use python3 to safely parse YAML (avoid jq YAML limitations).
+  # Use the repo's stdlib-only workflow config parser so the router does not
+  # depend on PyYAML being installed in the runner environment.
   # Capture exit code explicitly — do not use || true to suppress failures.
   local py_result _py_exit
   _py_exit=0
-  py_result="$(python3 - "$config_file" <<'PYEOF'
+  py_result="$(python3 - "$config_file" "$SCRIPT_DIR/workflow-config-resolver.py" <<'PYEOF'
 import sys, json
+import importlib.util
+from pathlib import Path
 
 try:
-    # Try to import yaml; fall back to basic parsing if unavailable.
-    try:
-        import yaml
-        with open(sys.argv[1], 'r') as f:
-            cfg = yaml.safe_load(f) or {}
-    except ImportError:
-        sys.stderr.write(
-            "run-work-router: error: PyYAML is required to parse guardrails config.\n"
-            "Install it with: pip install pyyaml  (or pip3 install pyyaml)\n"
-            "Applying conservative guardrails defaults (mode=manual, backlog_start=false).\n"
-        )
-        print(json.dumps({"section": "absent", "mode": "manual", "backlog_start": False}))
-        sys.exit(0)
+    sys.dont_write_bytecode = True
+    config_path = Path(sys.argv[1])
+    resolver_path = Path(sys.argv[2])
+    spec = importlib.util.spec_from_file_location("workflow_config_resolver", resolver_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load workflow-config-resolver.py")
+    resolver = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(resolver)
+    cfg = resolver.parse_yaml_subset(config_path)
 
     guardrails = cfg.get('guardrails') if isinstance(cfg, dict) else None
     if not isinstance(guardrails, dict):

--- a/scripts/development-workflow/tests/test-run-work-router.sh
+++ b/scripts/development-workflow/tests/test-run-work-router.sh
@@ -424,20 +424,19 @@ popd > /dev/null
 run_test "single_dev_folder_mode" "redirect_item" \
   "$(printf '%s\n' "$output_devfolder" | grep '^MODE=' | cut -d= -f2-)"
 
-# --- PyYAML unavailable: conservative defaults applied ----------------------
+# --- PyYAML unavailable: stdlib parser still reads guardrails ----------------
 # Simulates PyYAML being unavailable by injecting a fake yaml module into
-# PYTHONPATH. Verifies the router applies conservative safe defaults
-# (mode=manual, backlog_start=false) and does not silently misparse config.
+# PYTHONPATH. The router must use the repo's stdlib-only YAML subset parser and
+# still report the configured guardrails instead of falling back to defaults.
 mkdir -p "$TMP_ROOT/no_yaml"
 cat > "$TMP_ROOT/no_yaml/yaml.py" <<'NO_YAML'
 raise ImportError("test: yaml not available for fallback test")
 NO_YAML
 # Uses AI_DEV_WORKFLOW_CONFIG_FILE to supply a config with delegated mode.
-# When PyYAML is absent, the router must ignore the config and use safe defaults.
 output_fallback="$(AI_DEV_WORKFLOW_CONFIG_FILE="$FAKE_REPO_DIR/.ai-dev-workflow.yaml" PYTHONPATH="$TMP_ROOT/no_yaml" PATH="$MOCK_BIN:$PATH" "$ROUTER" 2>/dev/null)"
-run_test "guardrails_nopyaml_mode_defaults_to_manual" "manual" \
+run_test "guardrails_nopyaml_mode_uses_config" "delegated" \
   "$(printf '%s\n' "$output_fallback" | grep '^GUARDRAILS_MODE=' | cut -d= -f2-)"
-run_test "guardrails_nopyaml_backlog_defaults_to_false" "false" \
+run_test "guardrails_nopyaml_backlog_uses_config" "true" \
   "$(printf '%s\n' "$output_fallback" | grep '^GUARDRAILS_BACKLOG_START=' | cut -d= -f2-)"
 
 # --- Space-separated multi-target list → redirect_items (AC3) ---------------

--- a/scripts/development-workflow/tests/test-workflow-batch-lanes.sh
+++ b/scripts/development-workflow/tests/test-workflow-batch-lanes.sh
@@ -65,6 +65,9 @@ run_test "plan_lane_proposed" "proposed" "$(printf '%s\n' "$mixed_output" | awk 
 run_test "first_impl_proposed" "proposed" "$(printf '%s\n' "$mixed_output" | awk '/SLUG=item-impl-a/{f=1} f&&/^DISPATCH=/{sub(/^DISPATCH=/,""); print; exit}')"
 run_test "second_impl_held" "held" "$(printf '%s\n' "$mixed_output" | awk '/SLUG=item-impl-b/{f=1} f&&/^DISPATCH=/{sub(/^DISPATCH=/,""); print; exit}')"
 
+scan_no_paths_output="$("$LANES" --repo-root "$fixture_repo" --scan 2>&1)"
+run_test "scan_mode_no_paths_returns_none" "yes" "$(printf '%s\n' "$scan_no_paths_output" | grep -q '^(none)$' && echo yes || echo no)"
+
 high_parallel_repo="$TMP_ROOT/high-parallel"
 mkdir -p "$high_parallel_repo/docs/specs/developments"
 cat > "$high_parallel_repo/.ai-dev-workflow.yaml" <<'YAML'

--- a/scripts/development-workflow/workflow-batch-lanes.sh
+++ b/scripts/development-workflow/workflow-batch-lanes.sh
@@ -140,9 +140,11 @@ echo
 
 batch_input=""
 if [ "$scan_mode" -eq 1 ]; then
-  scan_args=()
-  [ -n "${development_paths[*]:-}" ] && scan_args+=("${development_paths[@]}")
-  batch_input="$("$SCRIPT_DIR/workflow-batch-plan.sh" "${scan_args[@]}")"
+  if [ "${#development_paths[@]}" -gt 0 ]; then
+    batch_input="$("$SCRIPT_DIR/workflow-batch-plan.sh" --repo-root "$repo_root" "${development_paths[@]}")"
+  else
+    batch_input="$("$SCRIPT_DIR/workflow-batch-plan.sh" --repo-root "$repo_root")"
+  fi
 else
   batch_input="$(cat)"
 fi


### PR DESCRIPTION
## Summary

- Parse `/run-work` router guardrails with the repo's stdlib-only workflow config parser instead of requiring PyYAML.
- Make `workflow-batch-lanes.sh --scan` Bash 3.2 safe when no explicit paths are supplied and forward `--repo-root` to `workflow-batch-plan.sh`.
- Add focused regressions for PyYAML-free guardrail parsing and no-path scan mode.

## Verification

- `bash scripts/development-workflow/tests/test-run-work-router.sh` — 58 passed, 0 failed
- `bash scripts/development-workflow/tests/test-workflow-batch-lanes.sh` — 9 passed, 0 failed
- `shellcheck -x scripts/development-workflow/run-work-router.sh scripts/development-workflow/workflow-batch-lanes.sh scripts/development-workflow/tests/test-run-work-router.sh scripts/development-workflow/tests/test-workflow-batch-lanes.sh`
- `npx markdownlint-cli2 CHANGELOG.md && bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `./scripts/development-workflow/run-work-router.sh --json` reports `GUARDRAILS_SECTION=present`, `GUARDRAILS_MODE=delegated`, `GUARDRAILS_BACKLOG_START=false` without a PyYAML warning

## Pre-submission self-review

Stale markers: none. Caller consistency: verified changed scan-mode call path and router guardrails extraction stay aligned with existing helper contracts. Coverage: addresses #1198's PyYAML-free router parsing and Bash 3.2 no-path scan failure modes with focused regression tests.

Closes #1198

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shell-only workflow helper changes with focused tests; no auth, data, or merge-path logic changes.
> 
> **Overview**
> Hardens `/run-work` portfolio scan helpers so they behave correctly on minimal runner environments (no PyYAML, Bash 3.2).
> 
> **`run-work-router.sh`** now loads guardrails from `.ai-dev-workflow.yaml` via the repo’s stdlib-only `workflow-config-resolver.py` (`parse_yaml_subset`) instead of requiring PyYAML. When PyYAML is missing, configured `guardrails.mode` and `backlog_start` are still reported rather than conservative manual defaults.
> 
> **`workflow-batch-lanes.sh --scan`** avoids Bash 3.2–unsafe empty-array expansion when no development paths are passed, always forwards `--repo-root` to `workflow-batch-plan.sh`, and returns `(none)` cleanly in the no-path scan case.
> 
> Regressions cover PyYAML-free guardrail parsing and no-path scan mode; **CHANGELOG** documents the fix for #1198.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8751ac5368bc5602b93c2526851ed46e35ebaf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->