### PR TITLE
fix(workflow): port GitHub Projects overlay fixes

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -129,6 +129,9 @@ issue_tracker:
   # Example (Linear):
   #   custom_fields:
   #     project: my-linear-project-id
+  # Example (GitHub Projects board whose classification field is not named Type):
+  #   custom_fields:
+  #     type_field: Custom Type
   #
   # custom_fields:
   #   project: ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Zeki overlay workflow helper fixes** (#1191, #1192, #1193, #1194): honor
+  configured GitHub Projects classification fields, default backlog priority to
+  Normal, fail closed when GitHub trackers lack merge-status automation, and
+  encode/dedupe run-epic PR base lookups.
 - **Run-work scan helper caveats** (#1198): parse router guardrails without a
   PyYAML dependency and make batch-lane scan mode Bash 3.2 safe when no paths
   are supplied.

--- a/docs/workflow/development-workflow/integrations/github-projects.md
+++ b/docs/workflow/development-workflow/integrations/github-projects.md
@@ -10,7 +10,8 @@ GitHub Projects is **optional**. The workflow functions without it — the **Por
 
 - The **Portfolio Orchestrator** can read work item status, priority, and iteration autonomously via `gh` CLI
 - A custom **Status** field on the project board maps directly to workflow stages
-- Custom fields (Priority, Due date, Type) drive automated prioritization
+- Custom fields (Priority, Due date, Type / Custom Type) drive automated
+  prioritization
 - Labels on issues map to work item types and scope
 - Agents will read the **current brief** following tracker-agnostic rules in [`issue-tracker.md`](issue-tracker.md)
 
@@ -90,13 +91,15 @@ Add these custom fields to the project (via project settings UI or GraphQL):
 
 | Field    | Type                                                         | Purpose                                                                                 |
 | -------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
-| Priority | Single select: `Urgent`, `High`, `Medium`, `Low`             | Drives orchestrator prioritization                                                      |
+| Priority | Single select: `Urgent`, `High`, `Normal`, `Low`             | Drives orchestrator prioritization                                                      |
 | Size     | Single select: `XS`, `S`, `M`, `L`, `XL`                    | Drives work sizing and sprint planning                                                  |
 | Due date | Date                                                         | Items due within 2 weeks get priority boost                                             |
 | Type     | Single select: `Feature`, `Bug`, `Refactor`, `Workflow`      | Source of truth for work-item classification and workflow path routing                  |
 
-The **Type** field is the classification source of truth for GitHub Projects
-integrations:
+The classification field is the source of truth for GitHub Projects
+integrations. By default the workflow looks for `Custom Type`, `CustomType`,
+then `Type`. If your board uses a different name, set
+`issue_tracker.custom_fields.type_field` in `.ai-dev-workflow.yaml`.
 
 - `Feature` routes through the full pipeline: spec, plan, implementation.
 - `Bug` routes through the fast-track fix path when the scope check allows it.
@@ -197,6 +200,8 @@ list_open_workflow_type_issues
 
 `get_tracker_type_for_issue` and `update_tracker_type_best_effort` use the same
 targeted `repository.issue(...).projectItems` lookup as the Status helpers.
+The field metadata lookup honors `issue_tracker.custom_fields.type_field`, then
+falls back to `Custom Type`, `CustomType`, and `Type`.
 `list_open_workflow_type_issues` fetches open issues first and then
 cross-references a single project item-list result, so callers do not perform
 one full-board scan per issue.
@@ -215,8 +220,8 @@ Field IDs and option IDs are stable within a project.
 `update_tracker_status_best_effort` and `update_tracker_type_best_effort` cache
 field metadata in memory for the current shell process after the first targeted
 lookup, so repeated updates in the same run do not need repeated field metadata
-queries. Re-run the helper in a fresh shell if the project field configuration
-changes.
+queries. The Type cache is scoped by the configured classification field name.
+Re-run the helper in a fresh shell if the project field configuration changes.
 
 ---
 
@@ -516,12 +521,18 @@ Use explicit issue numbers to avoid accidental broad transitions. Items not incl
 
 ## Custom Fields
 
-The `issue_tracker.custom_fields` flat map in `.ai-dev-workflow.yaml` is available for provider-specific configuration extensions. For the `github_projects` provider, **no `custom_fields` keys are currently recognised by workflow scripts**.
+The `issue_tracker.custom_fields` flat map in `.ai-dev-workflow.yaml` is
+available for provider-specific configuration extensions. For the
+`github_projects` provider, workflow scripts currently recognize:
+
+| Key | Purpose |
+| --- | --- |
+| `type_field` | Overrides the GitHub Projects classification field name used by Type helpers, for example `Custom Type`. |
 
 Key points:
 
 - The `project_number` field is a standard top-level `issue_tracker` field — it is not a custom field and must remain under `issue_tracker` directly, not under `custom_fields`.
-- Any keys placed under `custom_fields` are silently ignored by all current GitHub Projects scripts.
+- Unrecognized keys placed under `custom_fields` are silently ignored by current GitHub Projects scripts.
 - Future provider-specific fields (e.g., additional project metadata) may be added here as the integration evolves.
 
 Read the `workflow_issue_tracker_custom_field` helper documentation in `scripts/development-workflow/workflow-lib.sh` for the parsing API available to future consumers.

--- a/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
+++ b/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
@@ -64,13 +64,15 @@ If any of the above are missing or contradictory, ask **targeted** clarifying qu
 
 ### Priority and Size inference heuristics (GitHub Projects)
 
-**Priority** — default `Medium` unless there is explicit urgency signal:
+**Priority** — default `Normal` unless there is explicit urgency signal.
+`Medium` remains accepted by helper scripts as a backward-compatible alias for
+`Normal`:
 
 | Signal | Priority |
 | ------ | -------- |
 | Human uses words like "urgent", "blocking", "ASAP", "critical", or "production issue" | `Urgent` or `High` |
 | Item blocks another in-progress item or a pending release | `High` |
-| Standard new feature, improvement, or process fix | `Medium` (default) |
+| Standard new feature, improvement, or process fix | `Normal` (default) |
 | Nice-to-have, polish, or exploratory work | `Low` |
 
 **Size** — infer from the scope of the change implied by the request:
@@ -89,11 +91,11 @@ Pass inferred values directly to the helper:
 ./scripts/development-workflow/add-backlog-item.sh create \
   --title "..." \
   --body-file - \
-  --priority Medium \
+  --priority Normal \
   --size S
 ```
 
-When the scope is genuinely unclear after reading the request, omit `--size` (leave it unset) rather than guessing. Do not omit `--priority` — the script defaults to `Medium` when the flag is absent.
+When the scope is genuinely unclear after reading the request, omit `--size` (leave it unset) rather than guessing. Do not omit `--priority` — the script defaults to `Normal` when the flag is absent.
 
 ---
 

--- a/scripts/development-workflow/add-backlog-item.sh
+++ b/scripts/development-workflow/add-backlog-item.sh
@@ -23,8 +23,9 @@ create
   When DESTINATION_KIND is github, creates one GitHub issue via gh (requires gh auth).
   For linear, other, or none, exits non-zero with guidance (agents follow 00-add-backlog-item-protocol.md).
 
-  --priority <value>  Optional. Set the project Priority field. Valid values: Urgent, High, Medium, Low.
-                      When omitted, defaults to Medium for GitHub Projects.
+  --priority <value>  Optional. Set the project Priority field. Valid values: Urgent, High, Normal, Low.
+                      Medium is accepted as a backward-compatible alias for Normal.
+                      When omitted, defaults to Normal for GitHub Projects.
   --size <value>      Optional. Set the project Size field. Valid values: XS, S, M, L, XL.
                       When omitted, the Size field is left unset.
   --type <value>      Optional. Set the project classification field. Valid values: Feature, Bug,
@@ -150,12 +151,12 @@ create_cmd() {
     # Ensure the issue is on the project board (adds it with Status=Backlog if absent).
     # The ensure_on_project_board helper is fail-open; it always returns 0.
     ensure_on_project_board "$issue_number" "Backlog"
-    # Update project Type, Priority (default Medium), and Size when GitHub Projects is configured.
+    # Update project Type, Priority (default Normal), and Size when GitHub Projects is configured.
     # The update_tracker_*_best_effort helpers are fail-open; they always return 0.
     if [ -n "$type_label" ]; then
       update_tracker_type_best_effort "$issue_number" "$type_label"
     fi
-    local effective_priority="${priority:-Medium}"
+    local effective_priority="${priority:-Normal}"
     update_tracker_priority_best_effort "$issue_number" "$effective_priority"
     if [ -n "$size" ]; then
       update_tracker_size_best_effort "$issue_number" "$size"

--- a/scripts/development-workflow/check-tracker-merge-mapping.sh
+++ b/scripts/development-workflow/check-tracker-merge-mapping.sh
@@ -24,10 +24,24 @@ SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../.." && pwd)"
 WORKFLOW_FILE="${WORKFLOW_FILE_OVERRIDE:-$REPO_ROOT/.github/workflows/update-tracker-on-merge.yml}"
 
+# shellcheck source=scripts/development-workflow/workflow-lib.sh
+source "$SCRIPT_DIR/workflow-lib.sh"
+
 if [ ! -f "$WORKFLOW_FILE" ]; then
-  echo "SKIP: workflow file not found: $WORKFLOW_FILE"
-  echo "Non-GitHub tracker providers intentionally omit update-tracker-on-merge.yml."
-  exit 0
+  provider_config="$(workflow_effective_config_file || true)"
+  provider="$(workflow_normalize_issue_tracker_provider "$(workflow_config_provider issue_tracker "$provider_config")")"
+  case "$provider" in
+    github|github_issues|github_projects)
+      echo "ERROR: workflow file not found: $WORKFLOW_FILE"
+      echo "GitHub-based tracker provider '${provider}' requires update-tracker-on-merge.yml."
+      exit 1
+      ;;
+    *)
+      echo "SKIP: workflow file not found: $WORKFLOW_FILE"
+      echo "Non-GitHub tracker providers intentionally omit update-tracker-on-merge.yml."
+      exit 0
+      ;;
+  esac
 fi
 
 ERRORS=0

--- a/scripts/development-workflow/run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/run-epic-scope-resolver.sh
@@ -335,12 +335,15 @@ base_branch_cache_file() {
 
 fetch_prs_for_base() {
   local branch="$1"
-  local cache_file
+  local cache_file encoded_branch
   cache_file="$(base_branch_cache_file "$branch")"
+  if ! encoded_branch="$(jq -nr --arg branch "$branch" '$branch | @uri')"; then
+    error_exit "failed to URI-encode base branch ${branch}."
+  fi
 
   if [ ! -f "$cache_file" ]; then
     if ! gh api --paginate --slurp \
-      "repos/${repo}/pulls?state=all&base=${branch}&per_page=100" \
+      "repos/${repo}/pulls?state=all&base=${encoded_branch}&per_page=100" \
       > "$cache_file" 2>/dev/null; then
       error_exit "failed to read PRs targeting base branch ${branch}."
     fi
@@ -506,10 +509,11 @@ EOF
 
   local _linked_result
   _linked_result="$(jq -n --argjson open "$open_prs" --argjson merged "$merged_prs" \
-    '{open: $open, merged: $merged}')"
+    '{open: ($open | unique_by(.number)), merged: ($merged | unique_by(.number))}')"
   if [ "$(printf '%s\n' "$_linked_result" | jq '(.open | length) + (.merged | length)')" -eq 0 ]; then
     _linked_result="$(discover_prs_via_head_search "$issue")"
   fi
+  _linked_result="$(printf '%s\n' "$_linked_result" | jq '{open: (.open | unique_by(.number)), merged: (.merged | unique_by(.number))}')"
   printf '%s\n' "$_linked_result"
 }
 

--- a/scripts/development-workflow/tests/test-add-backlog-item.sh
+++ b/scripts/development-workflow/tests/test-add-backlog-item.sh
@@ -4,8 +4,8 @@
 # Exercises issue #965's Priority/Size field updates:
 #   1. Malformed gh output warns and skips project field updates
 #   2. Non-numeric issue number in URL warns and skips project field updates
-#   3. Happy path: URL parsed, board membership checked, Priority defaults to Medium
-#   4. --priority flag: uses supplied value instead of Medium default
+#   3. Happy path: URL parsed, board membership checked, Priority defaults to Normal
+#   4. --priority flag: uses supplied value instead of Normal default
 #   5. --size flag: triggers Size field update
 #   6. No --size: Size field update is not called
 #   7. --type flag: triggers Type field update
@@ -73,7 +73,7 @@ case "$*" in
         printf '{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_123","project":{"id":"PVT_project_1","number":1},"status":{"name":"Backlog"},"type":{"name":"Feature"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}\n'
         ;;
       *"fields(first:"*)
-        printf '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_urgent","name":"Urgent"},{"id":"OPT_high","name":"High"},{"id":"OPT_medium","name":"Medium"},{"id":"OPT_low","name":"Low"}]},{"id":"PVTSSF_size","name":"Size","options":[{"id":"OPT_size_xs","name":"XS"},{"id":"OPT_size_s","name":"S"},{"id":"OPT_size_m","name":"M"},{"id":"OPT_size_l","name":"L"},{"id":"OPT_size_xl","name":"XL"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_type_feature","name":"Feature"},{"id":"OPT_type_bug","name":"Bug"},{"id":"OPT_type_refactor","name":"Refactor"},{"id":"OPT_type_workflow","name":"Workflow"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}\n'
+        printf '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_urgent","name":"Urgent"},{"id":"OPT_high","name":"High"},{"id":"OPT_normal","name":"Normal"},{"id":"OPT_low","name":"Low"}]},{"id":"PVTSSF_size","name":"Size","options":[{"id":"OPT_size_xs","name":"XS"},{"id":"OPT_size_s","name":"S"},{"id":"OPT_size_m","name":"M"},{"id":"OPT_size_l","name":"L"},{"id":"OPT_size_xl","name":"XL"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_type_feature","name":"Feature"},{"id":"OPT_type_bug","name":"Bug"},{"id":"OPT_type_refactor","name":"Refactor"},{"id":"OPT_type_workflow","name":"Workflow"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}\n'
         ;;
       *"updateProjectV2ItemFieldValue"*)
         printf '{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_item_123"}}}}\n'
@@ -164,7 +164,7 @@ run_test "nonnumeric_skips_board_check" "0" "$(count_log_matches 'projectItems')
 run_test "nonnumeric_skips_priority_update" "0" "$(count_log_matches 'updateProjectV2ItemFieldValue')"
 
 echo ""
-echo "=== create: happy path — issue URL in output, Priority defaults to Medium ==="
+echo "=== create: happy path — issue URL in output, Priority defaults to Normal ==="
 
 run_create "ok" --title "Test" --body "body"
 run_test "happy_path_exits_zero" "0" "$(get_exit)"
@@ -177,16 +177,23 @@ run_test "happy_path_prints_issue_url" "yes" "$url_in_output"
 board_check_count="$(count_log_matches 'projectItems')"
 run_test "happy_path_checks_board_membership" "yes" "$([ "$board_check_count" -ge 1 ] && echo yes || echo no)"
 run_test "happy_path_updates_priority" "1" "$(count_log_matches 'fieldId=PVTSSF_priority')"
-run_test "happy_path_default_priority_is_medium" "1" "$(count_log_matches 'optionId=OPT_medium')"
+run_test "happy_path_default_priority_is_normal" "1" "$(count_log_matches 'optionId=OPT_normal')"
 run_test "happy_path_skips_size_update" "0" "$(count_log_matches 'fieldId=PVTSSF_size')"
 
 echo ""
-echo "=== create: --priority flag overrides Medium default ==="
+echo "=== create: --priority flag overrides Normal default ==="
 
 run_create "ok" --title "Test" --body "body" --priority "High"
 run_test "explicit_priority_exits_zero" "0" "$(get_exit)"
 run_test "explicit_priority_high_used" "1" "$(count_log_matches 'optionId=OPT_high')"
-run_test "explicit_priority_not_medium" "0" "$(count_log_matches 'optionId=OPT_medium')"
+run_test "explicit_priority_not_normal" "0" "$(count_log_matches 'optionId=OPT_normal')"
+
+echo ""
+echo "=== create: Medium priority aliases to Normal ==="
+
+run_create "ok" --title "Test" --body "body" --priority "Medium"
+run_test "medium_priority_alias_exits_zero" "0" "$(get_exit)"
+run_test "medium_priority_alias_uses_normal" "1" "$(count_log_matches 'optionId=OPT_normal')"
 
 echo ""
 echo "=== create: --size flag updates Size field ==="

--- a/scripts/development-workflow/tests/test-check-tracker-merge-mapping.sh
+++ b/scripts/development-workflow/tests/test-check-tracker-merge-mapping.sh
@@ -18,15 +18,42 @@ fail() {
 
 run_with_workflow() {
   local workflow_file="$1"
-  WORKFLOW_FILE_OVERRIDE="$workflow_file" bash "$SCRIPT"
+  local config_file="${2:-}"
+  if [ -n "$config_file" ]; then
+    WORKFLOW_FILE_OVERRIDE="$workflow_file" AI_DEV_WORKFLOW_CONFIG_FILE="$config_file" bash "$SCRIPT"
+  else
+    WORKFLOW_FILE_OVERRIDE="$workflow_file" bash "$SCRIPT"
+  fi
 }
 
-missing_output="$(run_with_workflow "$TMP_DIR/missing-update-tracker-on-merge.yml")" \
-  || fail "missing workflow should be skipped successfully"
+linear_config="$TMP_DIR/linear.yaml"
+cat > "$linear_config" <<'YAML'
+schema_version: 2
+issue_tracker:
+  provider: linear
+YAML
+
+missing_output="$(run_with_workflow "$TMP_DIR/missing-update-tracker-on-merge.yml" "$linear_config")" \
+  || fail "missing workflow should be skipped successfully for non-GitHub providers"
 printf '%s\n' "$missing_output" | grep -q '^SKIP: workflow file not found:' \
   || fail "missing workflow output should explain the skip"
 printf '%s\n' "$missing_output" | grep -q 'Non-GitHub tracker providers intentionally omit update-tracker-on-merge.yml' \
   || fail "missing workflow output should identify non-GitHub tracker providers"
+
+github_config="$TMP_DIR/github-projects.yaml"
+cat > "$github_config" <<'YAML'
+schema_version: 2
+issue_tracker:
+  provider: github_projects
+YAML
+
+github_missing_exit=0
+github_missing_output="$(run_with_workflow "$TMP_DIR/missing-update-tracker-on-merge.yml" "$github_config" 2>&1)" \
+  || github_missing_exit=$?
+[ "$github_missing_exit" -eq 1 ] \
+  || fail "missing workflow should fail closed for GitHub-based tracker providers"
+printf '%s\n' "$github_missing_output" | grep -q "GitHub-based tracker provider 'github_projects' requires update-tracker-on-merge.yml" \
+  || fail "missing GitHub workflow output should explain the required workflow"
 
 valid_workflow="$TMP_DIR/update-tracker-on-merge.yml"
 touch "$valid_workflow"

--- a/scripts/development-workflow/tests/test-check-tracker-merge-mapping.sh
+++ b/scripts/development-workflow/tests/test-check-tracker-merge-mapping.sh
@@ -55,6 +55,21 @@ github_missing_output="$(run_with_workflow "$TMP_DIR/missing-update-tracker-on-m
 printf '%s\n' "$github_missing_output" | grep -q "GitHub-based tracker provider 'github_projects' requires update-tracker-on-merge.yml" \
   || fail "missing GitHub workflow output should explain the required workflow"
 
+github_hyphen_config="$TMP_DIR/github-projects-hyphen.yaml"
+cat > "$github_hyphen_config" <<'YAML'
+schema_version: 2
+issue_tracker:
+  provider: github-projects
+YAML
+
+github_hyphen_missing_exit=0
+github_hyphen_missing_output="$(run_with_workflow "$TMP_DIR/missing-update-tracker-on-merge.yml" "$github_hyphen_config" 2>&1)" \
+  || github_hyphen_missing_exit=$?
+[ "$github_hyphen_missing_exit" -eq 1 ] \
+  || fail "missing workflow should fail closed for hyphenated GitHub tracker providers"
+printf '%s\n' "$github_hyphen_missing_output" | grep -q "GitHub-based tracker provider 'github_projects' requires update-tracker-on-merge.yml" \
+  || fail "hyphenated GitHub workflow output should identify the normalized provider"
+
 valid_workflow="$TMP_DIR/update-tracker-on-merge.yml"
 touch "$valid_workflow"
 cat > "$valid_workflow" <<'YAML'

--- a/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
@@ -188,6 +188,11 @@ JSON
 [[{"number":2205,"title":"Merged override PR","head":{"ref":"feature/105-five"},"base":{"ref":"develop-custom"},"state":"closed","draft":false,"labels":[],"merged_at":"2026-06-13T12:00:00Z"}]]
 JSON
         ;;
+      develop)
+        cat <<'JSON'
+[[{"number":2102,"title":"Plan PR duplicate from develop","head":{"ref":"implementation-plan/102-two"},"base":{"ref":"develop"},"state":"open","draft":false,"labels":[{"name":"ready-for-human-review"}],"merged_at":null}]]
+JSON
+        ;;
       *)
         printf '[[]]\n'
         ;;
@@ -353,6 +358,7 @@ run_test "pr_lookup_avoids_unbounded_rest_history" "no" "$(
   grep -q 'pulls?state=\(open\|closed\|all\)&per_page=100' "$CALL_LOG" && echo yes || echo no
 )"
 run_test "pr_lookup_cache_preserves_grouping" "102" "$(printf '%s\n' "$cache_probe_output" | jq -r '.groups.in_review[0].number')"
+run_test "linked_prs_dedupe_overlapping_bases" "1" "$(printf '%s\n' "$cache_probe_output" | jq '[.items[] | select(.number == 102)][0].pullRequests.open | length')"
 
 unlabeled_shared_base_output="$(run_json --items 101,112)"
 run_test "unlabeled_item_uses_scope_shared_base" "112" "$(printf '%s\n' "$unlabeled_shared_base_output" | jq -r '.groups.already_merged[] | select(.number == 112) | .number')"
@@ -370,7 +376,7 @@ run_test "label_fetch_failure_avoids_unrelated_ambiguity" "yes" "$(
 cache_collision_output="$(run_json --items 113 --base develop/foo)"
 run_test "pr_lookup_cache_keys_do_not_collide" "yes" "$(
   grep -q 'pulls?state=all&base=develop-foo&per_page=100' "$CALL_LOG" &&
-    grep -q 'pulls?state=all&base=develop/foo&per_page=100' "$CALL_LOG" &&
+    grep -q 'pulls?state=all&base=develop%2Ffoo&per_page=100' "$CALL_LOG" &&
     echo yes || echo no
 )"
 run_test "cache_collision_probe_still_resolves_item" "113" "$(printf '%s\n' "$cache_collision_output" | jq -r '.items[0].number')"

--- a/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+++ b/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
@@ -148,6 +148,23 @@ JSON
 JSON
               ;;
           esac
+        elif [ "${MOCK_STATUS_FIELD_MODE:-existing}" = "custom_type_after_type" ]; then
+          case "$*" in
+            *"after=cursor_field_1"*)
+              cat <<'JSON'
+{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_custom_type","name":"Custom Type","options":[{"id":"OPT_workflow_custom","name":"Workflow"},{"id":"OPT_bug_custom","name":"Bug"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}
+JSON
+              ;;
+            *)
+              cat <<'JSON'
+{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_workflow","name":"Workflow"},{"id":"OPT_bug","name":"Bug"}]}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor_field_1"}}}}}
+JSON
+              ;;
+          esac
+        elif [ "${MOCK_STATUS_FIELD_MODE:-existing}" = "configured_type" ]; then
+          cat <<'JSON'
+{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_custom_type","name":"Custom Type","options":[{"id":"OPT_workflow_custom","name":"Workflow"}]},{"id":"PVTSSF_configured_type","name":"Configured Type","options":[{"id":"OPT_workflow_configured","name":"Workflow"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_workflow","name":"Workflow"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}
+JSON
         else
           cat <<'JSON'
 {"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_status","name":"Status","options":[{"id":"OPT_spec_ready","name":"Spec Ready"},{"id":"OPT_in_development","name":"In Development"},{"id":"OPT_merged","name":"Merged"},{"id":"OPT_released","name":"Released"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_workflow","name":"Workflow"},{"id":"OPT_bug","name":"Bug"},{"id":"OPT_refactor","name":"Refactor"},{"id":"OPT_feature","name":"Feature"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}
@@ -351,6 +368,7 @@ run_test "type_update_mutates_project_item" "1" "$(count_log_matches 'api graphq
 
 reset_log
 __workflow_project_type_field_cache_project_id=""
+__workflow_project_type_field_cache_preferred=""
 __workflow_project_type_field_cache_json=""
 export MOCK_STATUS_FIELD_MODE=paginated
 type_field_json="$(workflow_github_project_type_field_json "PVT_project_1")"
@@ -358,6 +376,45 @@ unset MOCK_STATUS_FIELD_MODE
 type_field_id="$(printf '%s' "$type_field_json" | jq -r '.field_id // empty')"
 run_test "type_field_lookup_paginates" "PVTSSF_type" "$type_field_id"
 run_test "type_field_lookup_uses_two_field_queries" "2" "$(count_log_matches 'fields')"
+
+reset_log
+__workflow_project_type_field_cache_project_id=""
+__workflow_project_type_field_cache_preferred=""
+__workflow_project_type_field_cache_json=""
+export MOCK_STATUS_FIELD_MODE=custom_type_after_type
+type_field_json="$(workflow_github_project_type_field_json "PVT_project_1")"
+unset MOCK_STATUS_FIELD_MODE
+type_field_id="$(printf '%s' "$type_field_json" | jq -r '.field_id // empty')"
+type_field_name="$(printf '%s' "$type_field_json" | jq -r '.field_name // empty')"
+run_test "type_field_prefers_custom_type_after_type" "PVTSSF_custom_type" "$type_field_id"
+run_test "type_field_reports_custom_type_name" "Custom Type" "$type_field_name"
+run_test "type_field_custom_type_after_type_uses_two_field_queries" "2" "$(count_log_matches 'fields')"
+
+reset_log
+__workflow_project_type_field_cache_project_id=""
+__workflow_project_type_field_cache_preferred=""
+__workflow_project_type_field_cache_json=""
+workflow_issue_tracker_custom_field() {
+  case "$1" in
+    type_field) printf 'Configured Type\n' ;;
+    *) printf '\n' ;;
+  esac
+}
+export MOCK_STATUS_FIELD_MODE=configured_type
+type_field_json="$(workflow_github_project_type_field_json "PVT_project_1")"
+unset MOCK_STATUS_FIELD_MODE
+type_field_id="$(printf '%s' "$type_field_json" | jq -r '.field_id // empty')"
+run_test "type_field_prefers_configured_name" "PVTSSF_configured_type" "$type_field_id"
+
+# Restore the real custom-field helper after the override above.
+# shellcheck source=scripts/development-workflow/workflow-lib.sh
+source "$REPO_ROOT/scripts/development-workflow/workflow-lib.sh"
+workflow_issue_tracker_provider_raw() {
+  printf '%s\n' "${MOCK_TRACKER_PROVIDER:-github_projects}"
+}
+workflow_issue_tracker_project_number() {
+  printf '%s\n' "${MOCK_TRACKER_PROJECT_NUMBER-1}"
+}
 
 reset_log
 type_field_output=""
@@ -369,6 +426,7 @@ run_test "type_field_empty_project_id_avoids_graphql" "0" "$(count_log_matches '
 
 reset_log
 __workflow_project_type_field_cache_project_id=""
+__workflow_project_type_field_cache_preferred=""
 __workflow_project_type_field_cache_json=""
 type_field_json="$(workflow_github_project_type_field_json "PVT_project_1")"
 type_field_id_one="$(printf '%s' "$type_field_json" | jq -r '.field_id // empty')"
@@ -380,6 +438,7 @@ run_test "type_field_cache_scoped_by_project" "2" "$(count_log_matches 'fields')
 
 reset_log
 __workflow_project_type_field_cache_project_id=""
+__workflow_project_type_field_cache_preferred=""
 __workflow_project_type_field_cache_json=""
 export MOCK_STATUS_FIELD_MODE=graphql_fail
 type_field_output=""
@@ -392,6 +451,7 @@ run_test "type_field_graphql_failure_no_cache" "" "$__workflow_project_type_fiel
 
 reset_log
 __workflow_project_type_field_cache_project_id=""
+__workflow_project_type_field_cache_preferred=""
 __workflow_project_type_field_cache_json=""
 export MOCK_STATUS_FIELD_MODE=graphql_fail
 type_field_stderr=""
@@ -418,6 +478,7 @@ run_test "status_field_graphql_failure_reports_captured_gh_stderr" "captured" "$
 
 reset_log
 __workflow_project_type_field_cache_project_id=""
+__workflow_project_type_field_cache_preferred=""
 __workflow_project_type_field_cache_json=""
 export MOCK_STATUS_FIELD_MODE=invalid_json
 type_update_output="$(update_tracker_type_best_effort 824 "Workflow" 2>&1)"

--- a/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+++ b/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
@@ -115,6 +115,14 @@ JSON
 	          cat <<'JSON'
 	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
 JSON
+	        elif [ "${MOCK_PROJECT_ITEM_MODE:-existing}" = "custom_type_only" ]; then
+	          cat <<'JSON'
+	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1},"status":{"name":"Spec Ready"},"customType":{"name":"Workflow"},"type":{"name":"Bug"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
+	        elif [ "${MOCK_PROJECT_ITEM_MODE:-existing}" = "configured_type_only" ]; then
+	          cat <<'JSON'
+	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1},"status":{"name":"Spec Ready"},"configuredType":{"name":"Workflow"},"customType":{"name":"Bug"},"type":{"name":"Bug"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
 	        elif [ "${MOCK_PROJECT_ITEM_MODE:-existing}" = "released" ]; then
 	          cat <<'JSON'
 	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1},"status":{"name":"Released"},"type":{"name":"Workflow"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
@@ -218,6 +226,13 @@ workflow_issue_tracker_project_number() {
   printf '%s\n' "${MOCK_TRACKER_PROJECT_NUMBER-1}"
 }
 
+workflow_issue_tracker_custom_field() {
+  case "$1" in
+    type_field) printf '%s\n' "${MOCK_TRACKER_TYPE_FIELD:-}" ;;
+    *) printf '\n' ;;
+  esac
+}
+
 PASS_COUNT=0
 FAIL_COUNT=0
 
@@ -259,6 +274,22 @@ reset_log
 tracker_type="$(get_tracker_type_for_issue 824)"
 run_test "targeted_type_read" "Workflow" "$tracker_type"
 run_test "type_read_avoids_full_board_scan" "" "$(forbidden_project_reads)"
+
+reset_log
+export MOCK_PROJECT_ITEM_MODE=custom_type_only
+tracker_type="$(get_tracker_type_for_issue 824)"
+unset MOCK_PROJECT_ITEM_MODE
+run_test "targeted_type_read_prefers_custom_type" "Workflow" "$tracker_type"
+run_test "custom_type_read_passes_empty_configured_field" "1" "$(count_log_matches 'typeFieldName=')"
+
+reset_log
+export MOCK_PROJECT_ITEM_MODE=configured_type_only
+export MOCK_TRACKER_TYPE_FIELD="Configured Type"
+tracker_type="$(get_tracker_type_for_issue 824)"
+unset MOCK_PROJECT_ITEM_MODE
+unset MOCK_TRACKER_TYPE_FIELD
+run_test "targeted_type_read_prefers_configured_field" "Workflow" "$tracker_type"
+run_test "configured_type_read_passes_field_name" "1" "$(count_log_matches 'typeFieldName=Configured Type')"
 
 reset_log
 export MOCK_PROJECT_ITEM_MODE=paginated

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -1223,6 +1223,7 @@ __workflow_github_project_id_cache_id=""
 __workflow_project_status_field_cache_project_id=""
 __workflow_project_status_field_cache_json=""
 __workflow_project_type_field_cache_project_id=""
+__workflow_project_type_field_cache_preferred=""
 __workflow_project_type_field_cache_json=""
 # Cache for named single-select fields (Priority, Size, etc.) — indexed by
 # "<project_id>:<field_name>" stored in parallel arrays.
@@ -1637,8 +1638,10 @@ EOF
 # absent. Callers must treat those cases as explicit lookup failures.
 workflow_github_project_type_field_json() {
   local project_id="$1"
-  local response cursor page_state field_json has_next end_cursor page_count line
+  local preferred_field response cursor page_state field_json field_rank best_field_json best_field_rank has_next end_cursor page_count line
   local -a graphql_args
+
+  preferred_field="$(workflow_issue_tracker_custom_field type_field "$(workflow_effective_config_file || true)")"
 
   if [ -z "$project_id" ]; then
     echo "Warning: project ID is empty; project Type field lookup cannot run." >&2
@@ -1647,8 +1650,11 @@ workflow_github_project_type_field_json() {
   fi
 
   if [ "$__workflow_project_type_field_cache_project_id" != "$project_id" ] || \
+     [ "$__workflow_project_type_field_cache_preferred" != "$preferred_field" ] || \
      [ -z "$__workflow_project_type_field_cache_json" ]; then
     __workflow_project_type_field_cache_json=""
+    best_field_json=""
+    best_field_rank=999
     cursor=""
     page_count=0
     while :; do
@@ -1691,6 +1697,7 @@ workflow_github_project_type_field_json() {
 
       if ! page_state="$(printf '%s' "$response" | python3 -c "
 import json, sys
+preferred = sys.argv[1]
 try:
     data = json.loads(sys.stdin.read(), strict=False)
 except Exception:
@@ -1698,10 +1705,21 @@ except Exception:
 field_connection = (((data.get('data') or {}).get('node') or {}).get('fields') or {})
 fields = field_connection.get('nodes') or []
 field_json = ''
+field_rank = 999
+fields_by_name = {}
 for field in fields:
-    if field.get('name') == 'Type':
+    name = field.get('name') or ''
+    if name:
+        fields_by_name[name] = field
+for rank, candidate in enumerate([preferred, 'Custom Type', 'CustomType', 'Type'], start=1):
+    if not candidate:
+        continue
+    field = fields_by_name.get(candidate)
+    if field:
+        field_rank = rank
         field_json = json.dumps({
             'field_id': field.get('id') or '',
+            'field_name': field.get('name') or '',
             'options': {option.get('name') or '': option.get('id') or '' for option in field.get('options') or []},
         }, separators=(',', ':'))
         break
@@ -1709,20 +1727,23 @@ page_info = field_connection.get('pageInfo') or {}
 has_next = 'true' if page_info.get('hasNextPage') else 'false'
 end_cursor = page_info.get('endCursor') or ''
 print('FIELD_JSON=' + field_json)
+print('FIELD_RANK=' + str(field_rank))
 print('HAS_NEXT=' + has_next)
 print('END_CURSOR=' + end_cursor)
-" 2>/dev/null)"; then
+" "$preferred_field" 2>/dev/null)"; then
         echo "Warning: could not parse GraphQL project Type field response for project '${project_id}'." >&2
         printf ''
         return 1
       fi
 
       field_json=""
+      field_rank=999
       has_next="false"
       end_cursor=""
       while IFS= read -r line; do
         case "$line" in
           FIELD_JSON=*) field_json="${line#FIELD_JSON=}" ;;
+          FIELD_RANK=*) field_rank="${line#FIELD_RANK=}" ;;
           HAS_NEXT=*) has_next="${line#HAS_NEXT=}" ;;
           END_CURSOR=*) end_cursor="${line#END_CURSOR=}" ;;
         esac
@@ -1730,8 +1751,13 @@ print('END_CURSOR=' + end_cursor)
 $page_state
 EOF
       if [ -n "$field_json" ]; then
-        __workflow_project_type_field_cache_json="$field_json"
-        break
+        if [ "$field_rank" -lt "$best_field_rank" ]; then
+          best_field_json="$field_json"
+          best_field_rank="$field_rank"
+        fi
+        if [ "$best_field_rank" -eq 1 ] || { [ -z "$preferred_field" ] && [ "$best_field_rank" -eq 2 ]; }; then
+          break
+        fi
       fi
       if [ "$has_next" != "true" ] || [ -z "$end_cursor" ]; then
         break
@@ -1744,12 +1770,14 @@ EOF
       fi
       cursor="$end_cursor"
     done
+    __workflow_project_type_field_cache_json="$best_field_json"
     if [ -z "$__workflow_project_type_field_cache_json" ]; then
       echo "Warning: project Type field not found for project '${project_id}'." >&2
       printf ''
       return 1
     fi
     __workflow_project_type_field_cache_project_id="$project_id"
+    __workflow_project_type_field_cache_preferred="$preferred_field"
   fi
 
   printf '%s' "$__workflow_project_type_field_cache_json"
@@ -2559,11 +2587,14 @@ print((data.get('options') or {}).get(sys.argv[1]) or '', end='')
 # update_tracker_priority_best_effort <issue_number> <priority_value>
 #
 # Best-effort update for the GitHub Projects Priority field.
-# Valid values: Urgent, High, Medium, Low
+# Valid values: Urgent, High, Normal, Low. Medium aliases to Normal.
 # Returns 0 in all failure cases (fail-open).
 update_tracker_priority_best_effort() {
   local issue_number="$1"
   local priority_value="$2"
+  if [ "$priority_value" = "Medium" ]; then
+    priority_value="Normal"
+  fi
   update_tracker_named_field_best_effort "$issue_number" "Priority" "$priority_value"
 }
 

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -1106,7 +1106,7 @@ workflow_issue_tracker_provider_raw() {
 
 workflow_normalize_issue_tracker_provider() {
   local raw="$1"
-  printf '%s' "$raw" | tr '[:upper:]' '[:lower:]'
+  printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '-' '_'
 }
 
 # emit_linear_deferred_action <action_type> <issue_id> [key=value]
@@ -1361,7 +1361,7 @@ workflow_github_project_item_for_issue() {
   local issue_number="$1"
   local project_number="$2"
   local project_owner project_id repo_owner repo_name response
-  local cursor page_state item_json has_next end_cursor page_count line missing_fields
+  local cursor page_state item_json has_next end_cursor page_count line missing_fields type_field_name
   local -a graphql_args
 
   case "$issue_number" in
@@ -1387,6 +1387,7 @@ workflow_github_project_item_for_issue() {
     printf ''
     return 0
   fi
+  type_field_name="$(workflow_issue_tracker_custom_field type_field "$(workflow_effective_config_file || true)")"
 
   cursor=""
   page_count=0
@@ -1396,6 +1397,7 @@ workflow_github_project_item_for_issue() {
       -f owner="$repo_owner"
       -f repo="$repo_name"
       -F issueNumber="$issue_number"
+      -f typeFieldName="$type_field_name"
     )
     if [ -n "$cursor" ]; then
       graphql_args+=(-f after="$cursor")
@@ -1403,7 +1405,7 @@ workflow_github_project_item_for_issue() {
     # shellcheck disable=SC2016 # GraphQL variables are expanded by GitHub, not by Bash.
     graphql_args+=(
       -f query='
-        query($owner: String!, $repo: String!, $issueNumber: Int!, $after: String) {
+        query($owner: String!, $repo: String!, $issueNumber: Int!, $typeFieldName: String!, $after: String) {
           repository(owner: $owner, name: $repo) {
             issue(number: $issueNumber) {
               projectItems(first: 100, after: $after) {
@@ -1411,6 +1413,15 @@ workflow_github_project_item_for_issue() {
                   id
                   project { id number }
                   status: fieldValueByName(name: "Status") {
+                    ... on ProjectV2ItemFieldSingleSelectValue { name }
+                  }
+                  configuredType: fieldValueByName(name: $typeFieldName) {
+                    ... on ProjectV2ItemFieldSingleSelectValue { name }
+                  }
+                  customType: fieldValueByName(name: "Custom Type") {
+                    ... on ProjectV2ItemFieldSingleSelectValue { name }
+                  }
+                  compactCustomType: fieldValueByName(name: "CustomType") {
                     ... on ProjectV2ItemFieldSingleSelectValue { name }
                   }
                   type: fieldValueByName(name: "Type") {
@@ -1436,6 +1447,7 @@ workflow_github_project_item_for_issue() {
     if ! page_state="$(printf '%s' "$response" | python3 -c "
 import json, sys
 project_id = sys.argv[1]
+preferred = sys.argv[2]
 try:
     data = json.loads(sys.stdin.read(), strict=False)
 except Exception:
@@ -1448,7 +1460,19 @@ for item in project_items.get('nodes') or []:
     project = item.get('project') or {}
     if project.get('id') == project_id:
         status_value = item.get('status') or item.get('fieldValueByName') or {}
-        type_value = item.get('type') or {}
+        type_candidates = []
+        if preferred:
+            type_candidates.append(item.get('configuredType') or {})
+        type_candidates.extend([
+            item.get('customType') or {},
+            item.get('compactCustomType') or {},
+            item.get('type') or {},
+        ])
+        type_value = {}
+        for candidate in type_candidates:
+            if candidate.get('name'):
+                type_value = candidate
+                break
         missing = []
         if not status_value.get('name'):
             missing.append('Status')
@@ -1469,7 +1493,7 @@ print('ITEM=' + match)
 print('MISSING_FIELDS=' + missing_fields)
 print('HAS_NEXT=' + has_next)
 print('END_CURSOR=' + end_cursor)
-" "$project_id" 2>/dev/null)"; then
+" "$project_id" "$type_field_name" 2>/dev/null)"; then
       echo "Warning: could not parse GraphQL project item response for issue #${issue_number}; tracker status not read." >&2
       printf ''
       return 0


### PR DESCRIPTION
## Summary

Ports the reusable Zeki overlay fixes for GitHub Projects and epic scope tooling:

- honor configured GitHub Projects classification fields via `issue_tracker.custom_fields.type_field`, with fallback to `Custom Type`, `CustomType`, then `Type`
- default backlog Priority to `Normal`, while accepting `Medium` as a backward-compatible alias
- fail closed when GitHub-based trackers are missing `update-tracker-on-merge.yml`
- URL-encode run-epic PR base lookups and dedupe linked PRs discovered through overlapping bases

Closes #1191
Closes #1192
Closes #1193
Closes #1194

## Self-Review

- Scope checked against issues #1191, #1192, #1193, and #1194.
- Changes are limited to workflow helper scripts, tests, docs, config comments, and CHANGELOG.
- No unrelated workflow behavior was refactored.

## Verification

- `bash scripts/development-workflow/tests/test-add-backlog-item.sh`
- `bash scripts/development-workflow/tests/test-check-tracker-merge-mapping.sh`
- `bash scripts/development-workflow/tests/test-run-epic-scope-resolver.sh`
- `bash scripts/development-workflow/tests/test-workflow-lib-github-projects.sh`
- `bash -n` on modified shell scripts
- `shellcheck --severity=warning` on modified shell/test scripts
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 CHANGELOG.md docs/workflow/development-workflow/integrations/github-projects.md docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md`
- `python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md docs/workflow/development-workflow/integrations/github-projects.md docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to workflow shell helpers, tests, and documentation; behavior is fail-open for tracker updates except the intentional fail-closed merge-mapping check for GitHub providers.
> 
> **Overview**
> Ports Zeki overlay fixes into the development workflow helpers so GitHub Projects boards behave correctly across classification fields, backlog defaults, merge automation checks, and epic PR discovery.
> 
> **GitHub Projects classification** — `issue_tracker.custom_fields.type_field` overrides the board’s Type column name; reads and updates prefer that field, then `Custom Type`, `CustomType`, and `Type`. GraphQL item lookups and Type field metadata caching are scoped to the configured name.
> 
> **Backlog priority** — Default project **Priority** is **Normal** (was **Medium**); `Medium` still maps to **Normal** for compatibility in `add-backlog-item.sh` and `update_tracker_priority_best_effort`.
> 
> **Merge workflow guard** — `check-tracker-merge-mapping.sh` loads workflow config and **errors** when a GitHub-based tracker is configured but `update-tracker-on-merge.yml` is missing; non-GitHub providers still **skip**. Provider normalization treats hyphenated names like `github-projects` as `github_projects`.
> 
> **Run-epic PR lookup** — Base branch names are URI-encoded in `gh api` pull requests queries (e.g. `develop/foo` → `develop%2Ffoo`), and linked open/merged PR lists are deduplicated by PR number when multiple bases overlap.
> 
> Docs, config examples, backlog protocol heuristics, and shell tests were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 253360a8d6f735b0aa021e99ad53efe57fb686fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->