### PR TITLE
fix(workflow): speed bounded prelude PR lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Bounded prelude PR lookup**: avoid paginating every historical PR targeting
+  `develop` for unlabeled `/run-items` Backlog starts by using targeted
+  issue-head PR search before falling back to legacy lookup paths.
 - **Zeki overlay workflow helper fixes** (#1191, #1192, #1193, #1194): honor
   configured GitHub Projects classification fields, default backlog priority to
   Normal, fail closed when GitHub trackers lack merge-status automation, and

--- a/scripts/development-workflow/run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/run-epic-scope-resolver.sh
@@ -356,9 +356,55 @@ fetch_prs_for_base() {
 # (develop-<slug>) that are not represented by integration-branch:* labels in scope.
 discover_prs_via_head_search() {
   local issue="$1"
-  local prefix query numbers number pr_json open merged
+  local prefix query numbers number pr_json open merged search_json primary_result primary_count
   open='[]'
   merged='[]'
+
+  if search_json="$(gh pr list --state all --search "${issue} in:head" \
+      --json number,title,state,headRefName,baseRefName,isDraft,labels,mergedAt \
+      --limit 100 2>/dev/null)"; then
+    if ! primary_result="$(jq --arg issue "$issue" '
+      {
+        open: [
+          .[]
+          | select(.state == "OPEN")
+          | select(.headRefName | test("^(spec|implementation-plan|feature|fix|refactor|hotfix)/" + $issue + "(-|$)"))
+          | {
+              number,
+              title,
+              state: "OPEN",
+              headRefName,
+              baseRefName,
+              isDraft,
+              labels: [.labels[].name]
+            }
+        ],
+        merged: [
+          .[]
+          | select(.mergedAt != null)
+          | select(.headRefName | test("^(spec|implementation-plan|feature|fix|refactor|hotfix)/" + $issue + "(-|$)"))
+          | {
+              number,
+              title,
+              state: "MERGED",
+              headRefName,
+              baseRefName,
+              isDraft: false,
+              labels: [],
+              mergedAt
+          }
+        ]
+      }
+    ' <<< "$search_json")"; then
+      primary_result=""
+    elif ! primary_count="$(printf '%s\n' "$primary_result" | jq '(.open | length) + (.merged | length)')"; then
+      primary_count=0
+    elif [ "$primary_count" -gt 0 ]; then
+      printf '%s\n' "$primary_result"
+      return 0
+    fi
+  fi
+
   for prefix in spec implementation-plan feature fix refactor hotfix; do
     query="repo:${repo} is:pr head:${prefix}/${issue}"
     numbers=""
@@ -464,6 +510,15 @@ linked_pr_json() {
     candidate_base="develop-${integration_label#integration-branch:}"
   fi
   bases="$(printf '%s\n%s\n' "$scope_pr_bases" "$candidate_base" | sed '/^$/d' | sort -u)"
+
+  # The default unlabeled develop scope is common for `/run-items` Backlog
+  # starts. Avoid paginating every historical PR targeting develop when the
+  # branch naming convention gives us a precise, issue-scoped lookup.
+  if [ -z "$integration_label" ] && [ "$bases" = "develop" ]; then
+    discover_prs_via_head_search "$issue" \
+      | jq '{open: (.open | unique_by(.number)), merged: (.merged | unique_by(.number))}'
+    return 0
+  fi
 
   open_prs="[]"
   merged_prs="[]"

--- a/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
@@ -206,6 +206,24 @@ JSON
     ;;
   search\ prs\ repo:lhpaul/ai-dev-framework-template\ is:pr\ head:*\ --json\ number\ -q\ .[].number)
     ;;
+  pr\ list\ --state\ all\ --search\ *\ in:head\ --json\ number,title,state,headRefName,baseRefName,isDraft,labels,mergedAt\ --limit\ 100)
+    [ "${MOCK_PR_LIST_SEARCH:-0}" = "1" ] || exit 64
+    search_issue="$(printf '%s\n' "$*" | sed -n 's/.*--search \([0-9][0-9]*\) in:head .*/\1/p')"
+    case "$search_issue" in
+      114)
+        if [ "${MOCK_PR_LIST_SEARCH_EMPTY:-}" = "$search_issue" ]; then
+          printf '[]\n'
+          exit 0
+        fi
+        cat <<'JSON'
+[{"number":2114,"title":"Unlabeled primary PR","state":"OPEN","headRefName":"feature/114-unlabeled-primary","baseRefName":"develop-missing-label","isDraft":false,"labels":[{"name":"ready-for-human-review"}],"mergedAt":null}]
+JSON
+        ;;
+      *)
+        printf '[]\n'
+        ;;
+    esac
+    ;;
   pr\ view\ 2114\ --json\ number,title,state,headRefName,baseRefName,isDraft,labels,mergedAt)
     cat <<'JSON'
 {"number":2114,"title":"Unlabeled fallback PR","state":"OPEN","headRefName":"feature/114-unlabeled-fallback","baseRefName":"develop-missing-label","isDraft":false,"labels":[{"name":"ready-for-human-review"}],"mergedAt":null}
@@ -323,6 +341,23 @@ run_test "unready_open_pr_remains_eligible" "eligible" "$(printf '%s\n' "$unread
 head_search_output="$(run_json --items 114)"
 run_test "head_search_fallback_detects_unlabeled_open_pr" "in_review" "$(printf '%s\n' "$head_search_output" | jq -r '.items[0].group')"
 run_test "head_search_fallback_preserves_pr_number" "2114" "$(printf '%s\n' "$head_search_output" | jq -r '.items[0].pullRequests.open[0].number')"
+
+: > "$CALL_LOG"
+primary_pr_list_output="$(MOCK_PR_LIST_SEARCH=1 run_json --items 114)"
+run_test "primary_pr_list_detects_unlabeled_open_pr" "in_review" "$(printf '%s\n' "$primary_pr_list_output" | jq -r '.items[0].group')"
+run_test "primary_pr_list_uses_single_issue_search" "yes" "$(
+  grep -q 'pr list --state all --search 114 in:head' "$CALL_LOG" && echo yes || echo no
+)"
+run_test "primary_pr_list_avoids_prefix_search_loop" "no" "$(
+  awk 'index($0, "search prs repo:lhpaul/ai-dev-framework-template is:pr head:feature/114") { found=1 } END { print found ? "yes" : "no" }' "$CALL_LOG"
+)"
+
+: > "$CALL_LOG"
+primary_empty_fallback_output="$(MOCK_PR_LIST_SEARCH=1 MOCK_PR_LIST_SEARCH_EMPTY=114 run_json --items 114)"
+run_test "primary_empty_search_falls_back_to_prefix_loop" "in_review" "$(printf '%s\n' "$primary_empty_fallback_output" | jq -r '.items[0].group')"
+run_test "primary_empty_search_uses_prefix_fallback" "yes" "$(
+  awk 'index($0, "search prs repo:lhpaul/ai-dev-framework-template is:pr head:feature/114") { found=1 } END { print found ? "yes" : "no" }' "$CALL_LOG"
+)"
 
 head_search_boundary_output="$(run_json --items 11)"
 run_test "head_search_boundary_ignores_partial_issue_match" "eligible" "$(printf '%s\n' "$head_search_boundary_output" | jq -r '.items[0].group')"


### PR DESCRIPTION
## Summary
- Use a single issue-head PR search before the legacy prefix-search fallback in the run-epic scope resolver.
- Skip historical develop PR pagination for unlabeled develop-scoped /run-items Backlog starts.
- Add resolver test coverage for the new primary PR-list path and update the changelog.

## Validation
- bash scripts/development-workflow/tests/test-run-epic-scope-resolver.sh (75 passed, 0 failed)
- bash scripts/development-workflow/tests/test-run-bounded-prelude.sh (40 passed, 0 failed)
- npx markdownlint-cli2 CHANGELOG.md
- bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md
- git diff --check

## Notes
- ShellCheck was run on scripts/development-workflow/run-epic-scope-resolver.sh and only reported existing informational findings (SC1091 and SC2016) unrelated to this patch.
- Live bounded prelude for the 15-item proposed /run-items batch completed successfully after the patch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only resolver changes with preserved fallback behavior; scope grouping could differ only if the new search misses PRs the old path would find.
> 
> **Overview**
> **Bounded prelude / run-epic scope resolver** now finds linked PRs faster for the common unlabeled `develop` `/run-items` Backlog case by avoiding a full paginated scan of every PR ever opened against `develop`.
> 
> `discover_prs_via_head_search` tries one **`gh pr list`** search (`<issue> in:head`) and filters workflow branch prefixes before falling back to the existing per-prefix **`gh search prs`** loop. **`linked_pr_json`** takes a fast path when there is no integration label and the only base is `develop`, using that head search instead of **`fetch_prs_for_base`**.
> 
> Tests assert the primary search path, empty-search fallback, and that prefix search is skipped when the primary hit succeeds; **CHANGELOG** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f832d55d6d59fb216f1cd567734f1f93d2730fcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->