### PR TITLE
docs(spec): bounded prelude base branch resolver label scope

### DIFF
--- a/docs/specs/developments/20260714164849_1204-bounded-prelude-base-branch-resolver-label-scope/1_1204-bounded-prelude-base-branch-resolver-label-scope_specs.md
+++ b/docs/specs/developments/20260714164849_1204-bounded-prelude-base-branch-resolver-label-scope/1_1204-bounded-prelude-base-branch-resolver-label-scope_specs.md
@@ -1,0 +1,273 @@
+# Bounded Prelude Base-Branch Resolver Label Scope - Spec
+
+---
+
+## Overview
+
+Explicit-list `/run-items` batches need predictable base-branch selection before
+any tracker, branch, or PR mutation begins. A stale or unrelated
+`integration-branch:<slug>` label on one item must not redirect the whole batch
+away from `develop`, especially when the inferred integration branch no longer
+exists.
+
+This change tightens the operator contract for bounded prelude base resolution:
+mixed or partial integration labels fall back to `develop` with a visible
+warning, and any selected integration branch must be confirmed to exist before
+it is presented as the batch base. The result should make batch dispatch safe
+without requiring humans to catch orphaned labels manually.
+
+## Brief Objective List
+
+Derived from issue #1204:
+
+1. Prevent one item's `integration-branch:<slug>` label from determining the
+   base branch for an entire explicit-list batch.
+2. Treat mixed, partial, or conflicting integration labels in an explicit-list
+   batch as a visible warning and use `develop` as the batch base.
+3. Verify that any integration branch selected from labels exists on the remote
+   before the bounded prelude adopts it.
+4. Fall back to `develop` with a clearly visible warning when a selected
+   integration branch does not exist.
+5. Apply the remote-existence guard anywhere bounded prelude base resolution
+   can select an integration branch, not only in the partial-label case.
+6. Preserve the read-only bounded prelude contract and avoid tracker, branch,
+   label, PR, or issue mutations during base resolution.
+7. Provide test or smoke coverage for partial-label, stale-branch, and valid
+   shared-label explicit-list scenarios.
+
+## Use Cases
+
+### Use Case 1: Operator starts an ordinary explicit-list batch
+
+**Actor**: Workflow operator.
+**Preconditions**: The operator invokes `/run-items` with two or more specific
+items, and none of the items are intentionally running on a shared integration
+branch.
+
+**Steps**:
+
+1. The bounded prelude reads the in-scope item metadata before any mutation.
+2. The prelude evaluates integration-branch labels only within the explicit
+   item list.
+3. The prelude resolves the batch base as `develop`.
+4. The operator reviews the policy summary and continues the batch under the
+   approved scope.
+
+**Postconditions**: The batch dispatches only the requested items and uses
+`develop` as the shared base.
+
+**Information shown**:
+
+- The resolved item list.
+- The selected base branch.
+- The reason the base branch was selected.
+- Any warnings that affected base selection.
+
+**Actions available**:
+
+- Confirm or stop the batch before mutation.
+- Remove stale labels separately if the warnings reveal cleanup work.
+
+**Considerations**:
+
+- The prelude must not inspect labels outside the explicit item list as reasons
+  to change the batch base.
+- Ordinary explicit-list batches should not need the operator to audit every
+  historical integration label manually.
+
+### Use Case 2: One listed item carries an orphaned integration label
+
+**Actor**: Workflow operator.
+**Preconditions**: The operator invokes `/run-items` for multiple items, and
+only one listed item carries an old `integration-branch:<slug>` label from a
+graduated or abandoned integration branch.
+
+**Steps**:
+
+1. The bounded prelude detects that the integration label applies to only a
+   subset of the explicit item list.
+2. The prelude emits a visible warning naming the partial integration label and
+   the affected item.
+3. The prelude resolves the batch base as `develop`.
+4. The operator can continue the batch or stop to clean up stale labels.
+
+**Postconditions**: The batch is not redirected to an integration branch because
+of a label that is not shared by the full explicit list.
+
+**Information shown**:
+
+- Which item or items carried the partial integration label.
+- That the label was ignored for batch-base selection.
+- That the selected base is `develop`.
+
+**Actions available**:
+
+- Continue with the direct-`develop` batch.
+- Stop and remove the orphaned label outside the prelude.
+
+**Considerations**:
+
+- The warning is required even when fallback to `develop` is safe, because it is
+  the operator's signal that tracker cleanup may still be needed.
+
+### Use Case 3: All listed items share a valid integration label
+
+**Actor**: Workflow operator.
+**Preconditions**: Every item in the explicit list carries the same
+`integration-branch:<slug>` label, and the corresponding integration branch
+exists on the owning remote.
+
+**Steps**:
+
+1. The bounded prelude verifies that the label is shared by every listed item.
+2. The prelude verifies that the corresponding integration branch exists.
+3. The prelude presents the integration branch as the selected base with a
+   clear reason.
+4. The operator reviews and confirms the batch policy before mutation.
+
+**Postconditions**: The batch can use the shared integration branch because the
+full scope and branch existence are both confirmed.
+
+**Information shown**:
+
+- The shared integration label.
+- The selected integration base.
+- Confirmation that the branch existence check passed.
+
+**Actions available**:
+
+- Continue with the integration-branch batch.
+- Stop and rerun with a different scope or policy.
+
+**Considerations**:
+
+- A shared label is not sufficient by itself; the remote branch must also exist.
+
+### Use Case 4: Shared integration label points to a deleted branch
+
+**Actor**: Workflow operator.
+**Preconditions**: Every listed item carries the same integration label, but the
+corresponding integration branch no longer exists on the owning remote.
+
+**Steps**:
+
+1. The bounded prelude verifies the shared label.
+2. The prelude checks remote branch existence.
+3. The prelude emits a visible warning that the labeled branch was not found.
+4. The prelude resolves the batch base as `develop`.
+
+**Postconditions**: A deleted integration branch cannot become the selected base
+for the batch.
+
+**Information shown**:
+
+- The shared integration label.
+- The missing integration branch name.
+- That the base fell back to `develop`.
+
+**Actions available**:
+
+- Continue with `develop`.
+- Stop and repair the tracker labels or recreate the integration branch outside
+  the bounded prelude.
+
+**Considerations**:
+
+- The fallback must not silently hide the stale branch condition.
+
+## Business Rules
+
+- Explicit-list base resolution must consider only the items in the explicit
+  list.
+- An integration label must not select a batch base unless every item in the
+  explicit list carries the same integration label.
+- If integration labels are absent, partial, mixed, or conflicting, the bounded
+  prelude must select `develop` for the explicit-list batch and emit a visible
+  warning for any non-empty label set.
+- Any integration branch selected from labels must be verified to exist on the
+  owning remote before it is adopted as the base.
+- If the integration branch existence check fails or finds no branch, the
+  bounded prelude must select `develop` and emit a visible warning.
+- The warning must name the reason for fallback: partial label coverage, mixed
+  labels, conflicting labels, failed branch verification, or missing branch.
+- Base-branch resolution must remain read-only: it must not create branches,
+  remove labels, update tracker fields, open PRs, or close issues.
+- The bounded prelude summary must expose the selected base and the reason for
+  selection in operator-facing language.
+- Single-item and epic-scoped workflows must not lose their existing
+  integration-branch behavior, but they must also avoid adopting a non-existent
+  integration branch silently.
+- Batch dispatch must continue to enforce the approved explicit item list and
+  must not use out-of-scope items to resolve the base.
+
+## Operational Visibility
+
+- **Policy summary**: The bounded prelude output shows the selected base branch,
+  why it was selected, and whether any fallback warning was triggered.
+- **Warning visibility**: Partial-label, mixed-label, branch-check failure, and
+  missing-branch cases are printed prominently enough for the operator to see
+  before confirming mutation.
+- **Scope visibility**: Warnings identify the in-scope items that supplied
+  integration labels, without implying any out-of-scope item can influence the
+  batch.
+- **Read-only visibility**: The summary continues to state that no tracker,
+  branch, PR, label, issue, merge, or cleanup mutation has happened.
+- **Review visibility**: Test or smoke evidence for the explicit-list resolver
+  cases is included in the implementation PR so reviewers can verify the
+  operator-facing contract.
+
+## Acceptance Criteria
+
+- [ ] In an explicit-list batch where no listed items have integration labels,
+      the bounded prelude resolves the base as `develop`.
+- [ ] In an explicit-list batch where only a subset of listed items carry an
+      integration label, the bounded prelude resolves the base as `develop` and
+      emits a visible partial-label warning.
+- [ ] In an explicit-list batch where listed items carry different integration
+      labels, the bounded prelude resolves the base as `develop` and emits a
+      visible mixed-label warning.
+- [ ] In an explicit-list batch where all listed items carry the same
+      integration label and the corresponding branch exists, the bounded prelude
+      may resolve the base as that integration branch and reports the successful
+      branch validation.
+- [ ] In an explicit-list batch where all listed items carry the same
+      integration label but the corresponding branch does not exist, the bounded
+      prelude resolves the base as `develop` and emits a visible missing-branch
+      warning.
+- [ ] If remote branch validation cannot complete, the bounded prelude does not
+      adopt the integration branch silently and reports the validation failure in
+      the pre-mutation summary.
+- [ ] The bounded prelude does not create or delete branches, add or remove
+      labels, update tracker status, open PRs, close issues, or perform cleanup
+      while resolving the base.
+- [ ] The operator-facing summary includes the selected base branch and the
+      reason for that selection for explicit-list batches.
+- [ ] Single-item or epic-scoped integration-branch resolution still respects
+      valid integration labels, while preventing a missing remote branch from
+      being adopted silently.
+- [ ] Automated test or smoke coverage exercises no-label, partial-label,
+      mixed-label, valid-shared-label, and stale-shared-label explicit-list
+      scenarios.
+
+## Coverage Matrix
+
+| Brief objective | Coverage |
+| --- | --- |
+| 1. Prevent one item's integration label from determining the whole batch base | AC2, AC3, BR1, BR2, BR10 |
+| 2. Use `develop` plus warning for mixed, partial, or conflicting labels | AC2, AC3, BR3, BR6 |
+| 3. Verify selected integration branch exists before adopting it | AC4, AC5, AC6, BR4 |
+| 4. Fall back to `develop` with visible warning when the branch is missing | AC5, AC6, BR5, BR6 |
+| 5. Apply remote-existence guard to any bounded prelude integration-base selection | AC9, BR4, BR9 |
+| 6. Preserve read-only bounded prelude behavior | AC7, BR7, Operational Visibility |
+| 7. Cover partial-label, stale-branch, and valid shared-label cases | AC10 |
+
+## Out of Scope (MVP)
+
+- Automatically removing orphaned `integration-branch:<slug>` labels from
+  tracker items.
+- Recreating deleted integration branches during bounded prelude execution.
+- Changing the human-approved item list or adding related items to a batch.
+- Changing merge authority, reviewer delegation, checkpoint policy, or risk
+  classification behavior.
+- Introducing a new tracker status or workflow stage.
+- Rewriting the broader integration-branch graduation workflow.


### PR DESCRIPTION
## Summary

- Adds the product spec for issue #1204.
- Defines explicit-list `/run-items` base-branch behavior when integration labels are absent, partial, mixed, valid, or stale.
- Keeps the spec product-focused and defers implementation design to the plan stage.

Spec file: `docs/specs/developments/20260714164849_1204-bounded-prelude-base-branch-resolver-label-scope/1_1204-bounded-prelude-base-branch-resolver-label-scope_specs.md`

Refs #1204

## Open Questions

None.

## Coverage Matrix Summary

- Objective 1 -> AC2, AC3, BR1, BR2, BR10
- Objective 2 -> AC2, AC3, BR3, BR6
- Objective 3 -> AC4, AC5, AC6, BR4
- Objective 4 -> AC5, AC6, BR5, BR6
- Objective 5 -> AC9, BR4, BR9
- Objective 6 -> AC7, BR7, Operational Visibility
- Objective 7 -> AC10

## Deferral Notes

None. No tracker brief objectives were moved to out of scope.

## Document Quality Gate

- Brief coverage: Checked - all issue #1204 brief objectives map to acceptance criteria, business rules, or operational visibility.
- Internal consistency: Checked - explicit-list, integration-label, fallback, and branch-validation terms are used consistently.
- Naming and casing consistency: Checked - `develop`, `/run-items`, `integration-branch:<slug>`, and bounded prelude terms are consistent.
- Behavioral guarantees: Checked - read-only behavior, fallback rules, warning visibility, and branch-existence guarantees are backed by business rules and acceptance criteria.
- Reviewer-risk categories: Checked - API surface, concurrency, snapshot semantics, edge cases, hidden dependencies, accidental implementation design, and stale template content reviewed.
- Placeholder cleanup: Checked - mandatory placeholder grep returned no output.
- Optional sections: Not applicable - no UX or status/enum sections are needed because this is operator workflow behavior, not UI or entity status design.

## Checks Run

- `grep -n "\\[Step [0-9]\\]\\|\\[Who initiates\\|\\[What must be\\|\\[Rule [0-9]\\|\\[UX rule\\|\\[Out of scope item\\|\\[Question [0-9]\\|\\[Code value\\|\\[Display label\\|\\[Description\\]\\|\\[feature-slug-[0-9]\\|<!-- Delete this section\\|<!-- Replace this comment\\|<!-- Depends on:\\|\\*\\*Language\\*\\*:" docs/specs/developments/20260714164849_1204-bounded-prelude-base-branch-resolver-label-scope/1_1204-bounded-prelude-base-branch-resolver-label-scope_specs.md` - no output
- `npx markdownlint-cli2 "docs/specs/developments/20260714164849_1204-bounded-prelude-base-branch-resolver-label-scope/1_1204-bounded-prelude-base-branch-resolver-label-scope_specs.md"`
- `python3 scripts/lint/markdown-heuristic-lint.py docs/specs/developments/20260714164849_1204-bounded-prelude-base-branch-resolver-label-scope/1_1204-bounded-prelude-base-branch-resolver-label-scope_specs.md`
- `bash -c 'source scripts/development-workflow/workflow-lib.sh && ensure_on_project_board 1204 "Writing Spec"'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only spec addition with no runtime, auth, or data-path changes.
> 
> **Overview**
> Introduces the **issue #1204** product spec for how explicit-list `/run-items` batches choose a base branch during the read-only **bounded prelude**, before any tracker or git mutations.
> 
> The spec defines that **only in-scope listed items** may influence base resolution, and an `integration-branch:<slug>` label applies as the batch base **only when every listed item shares the same label**. Partial, mixed, or conflicting labels must **fall back to `develop`** with **visible warnings** (including naming the fallback reason). Any integration branch chosen from labels must be **verified on the remote** before adoption; missing branches or failed checks also fall back to `develop` with warnings, without silent adoption.
> 
> It preserves the **read-only prelude** contract (no branch/label/PR/issue mutations during resolution), extends the same remote-existence guard to **single-item and epic-scoped** resolution, and lists **acceptance criteria**, business rules, operational visibility, and out-of-scope items (e.g. auto-removing orphaned labels). Implementation is deferred to a later plan/PR; this change is spec documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4cce029fa990e10818b16861768655fc3c22d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->