### PR TITLE
feat(workflow): add graduation closeout reconciliation

### DIFF
--- a/.agents/skills/graduate-development/SKILL.md
+++ b/.agents/skills/graduate-development/SKILL.md
@@ -11,3 +11,8 @@ This is the Codex command-style alias for Claude Code `/graduate-development`.
 2. Read `docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md`.
 3. Follow the protocol exactly for the provided development slug or integration branch.
 4. Do not merge without the human approval gates required by the protocol.
+5. After the graduation PR merges, run the Protocol 05b graduation closeout
+   helper so delivered sub-items and the parent epic are closed or moved to the
+   terminal tracker status in the right order.
+6. Stop and surface the closeout summary if any delivered sub-item fails
+   reconciliation or any skipped optional/deferred item needs human disposition.

--- a/.agents/skills/graduate-development/agents/openai.yaml
+++ b/.agents/skills/graduate-development/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Graduate development"
-  short_description: "Graduate an integration branch back into develop."
+  short_description: "Graduate an integration branch back into develop and reconcile tracker closeout."
   default_prompt: "Use $graduate-development to graduate the integration branch or development slug I provide."
 
 policy:

--- a/.claude/commands/graduate-development.md
+++ b/.claude/commands/graduate-development.md
@@ -16,4 +16,7 @@ Key responsibilities:
 - Check CHANGELOG handling (Step 2.5)
 - Open the graduation PR from `develop-<slug>` to `develop` using a merge-commit strategy (Step 3)
 - Run the automated reviewer loop and apply `ready-for-human-review` (Step 4); do NOT apply `ready-for-regression`
-- After human merges: delete the remote/local integration branch, close the epic issue, and surface any open optional sub-items for disposition (Step 5)
+- After human merges: delete the remote/local integration branch, run
+  `graduation-closeout.sh`, reconcile delivered sub-items to terminal tracker
+  status before closing the epic, and surface skipped optional/deferred items or
+  failed closeout entries for human disposition (Step 5)

--- a/.cursor/commands/graduate-development.md
+++ b/.cursor/commands/graduate-development.md
@@ -16,4 +16,7 @@ Key responsibilities:
 - Check CHANGELOG handling (Step 2.5)
 - Open the graduation PR from `develop-<slug>` to `develop` using a merge-commit strategy (Step 3)
 - Run the automated reviewer loop and apply `ready-for-human-review` (Step 4); do NOT apply `ready-for-regression`
-- After human merges: delete the remote/local integration branch, close the epic issue, and surface any open optional sub-items for disposition (Step 5)
+- After human merges: delete the remote/local integration branch, run
+  `graduation-closeout.sh`, reconcile delivered sub-items to terminal tracker
+  status before closing the epic, and surface skipped optional/deferred items or
+  failed closeout entries for human disposition (Step 5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Add residual verification gate for sweep sub-items** (#1175): Require
   broad-scope workflow items to record residual evidence before readiness.
+- **Auto-close graduation sub-items** (#1178): Reconcile delivered
+  integration-branch sub-items and parent epics during graduation closeout.
 
 ### Changed
 

--- a/docs/testing/workflow/1178-auto-close-integration-branch-subitems-on-graduation.smoke-test.md
+++ b/docs/testing/workflow/1178-auto-close-integration-branch-subitems-on-graduation.smoke-test.md
@@ -118,7 +118,7 @@ without undoing successful work.
    wording, cross-repo refs ignored, and markdown punctuation boundaries.
 3. Confirm only current-repository plain `#<number>` closing refs are included
    in the closeout candidate set.
-4. Confirm the mocked closeout test reports `39 passed, 0 failed`.
+4. Confirm the mocked closeout test reports `43 passed, 0 failed`.
 
 **Expected result**: Issues referenced by merged sub-item PR closing keywords are
 included when available, and non-closing references do not trigger mutation.

--- a/docs/testing/workflow/1178-auto-close-integration-branch-subitems-on-graduation.smoke-test.md
+++ b/docs/testing/workflow/1178-auto-close-integration-branch-subitems-on-graduation.smoke-test.md
@@ -49,11 +49,13 @@ Before running this smoke test:
 2. Locate Step 5 (Post-Merge Cleanup).
 3. Confirm Step 5 instructs the operator to run the graduation closeout helper
    after the graduation PR merges.
-4. Confirm the step says the helper identifies the parent epic and planned
+4. Confirm the documented command includes `--slug`, `--graduation-pr`, and
+   `--epic`, with optional `--exclude-issue` and `--defer-epic-close` handling.
+5. Confirm the step says the helper identifies the parent epic and planned
    sub-items from native sub-issues or the `integration-branch:<slug>` label,
    and includes issues referenced by merged sub-item PR closing keywords when
    available.
-5. Confirm the step says delivered open sub-items are closed and moved to the
+6. Confirm the step says delivered open sub-items are closed and moved to the
    configured terminal status before the parent epic is closed.
 
 **Expected result**: Protocol 05b documents an explicit closeout mechanism and no
@@ -116,6 +118,7 @@ without undoing successful work.
    wording, cross-repo refs ignored, and markdown punctuation boundaries.
 3. Confirm only current-repository plain `#<number>` closing refs are included
    in the closeout candidate set.
+4. Confirm the mocked closeout test reports `39 passed, 0 failed`.
 
 **Expected result**: Issues referenced by merged sub-item PR closing keywords are
 included when available, and non-closing references do not trigger mutation.

--- a/docs/testing/workflow/1178-auto-close-integration-branch-subitems-on-graduation.smoke-test.md
+++ b/docs/testing/workflow/1178-auto-close-integration-branch-subitems-on-graduation.smoke-test.md
@@ -118,7 +118,7 @@ without undoing successful work.
    wording, cross-repo refs ignored, and markdown punctuation boundaries.
 3. Confirm only current-repository plain `#<number>` closing refs are included
    in the closeout candidate set.
-4. Confirm the mocked closeout test reports `43 passed, 0 failed`.
+4. Confirm the mocked closeout test reports `53 passed, 0 failed`.
 
 **Expected result**: Issues referenced by merged sub-item PR closing keywords are
 included when available, and non-closing references do not trigger mutation.

--- a/docs/testing/workflow/1178-auto-close-integration-branch-subitems-on-graduation.smoke-test.md
+++ b/docs/testing/workflow/1178-auto-close-integration-branch-subitems-on-graduation.smoke-test.md
@@ -118,7 +118,7 @@ without undoing successful work.
    wording, cross-repo refs ignored, and markdown punctuation boundaries.
 3. Confirm only current-repository plain `#<number>` closing refs are included
    in the closeout candidate set.
-4. Confirm the mocked closeout test reports `53 passed, 0 failed`.
+4. Confirm the mocked closeout test reports `58 passed, 0 failed`.
 
 **Expected result**: Issues referenced by merged sub-item PR closing keywords are
 included when available, and non-closing references do not trigger mutation.

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -280,7 +280,7 @@ not apply setup, sync files, or change runtime behavior.
 | Release             | `release/v[X.Y.Z]`           | `develop`   |
 | Development integration | `develop-<slug>`         | `develop`   |
 
-**Development integration branches** (`develop-<slug>`) are staging branches that collect all sub-item PRs for a multi-item grouped development. They are created by the orchestrator and deleted after the graduation PR merges to `develop`. Single-item developments do not use integration branches. See `docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md`.
+**Development integration branches** (`develop-<slug>`) are staging branches that collect all sub-item PRs for a multi-item grouped development. They are created by the orchestrator and deleted after the graduation PR merges to `develop`; graduation closeout then reconciles delivered sub-items and the parent epic to terminal tracker state. Single-item developments do not use integration branches. See `docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md`.
 
 Slug format:
 

--- a/docs/workflow/development-workflow/integrations/github-projects.md
+++ b/docs/workflow/development-workflow/integrations/github-projects.md
@@ -523,7 +523,9 @@ The helper validates that the graduation PR already merged from
 `develop-<slug>` to `develop`, then reconciles delivered planned sub-items
 before closing the parent epic. It discovers planned work from native GitHub
 sub-issues, the legacy `integration-branch:<slug>` label fallback, and closing
-keywords in merged PRs that targeted `develop-<slug>`.
+keywords in merged PRs that targeted `develop-<slug>`. If discovery is
+incomplete or no delivered sub-items can be identified, closeout fails and holds
+the parent epic open.
 
 For each delivered sub-item, it closes the GitHub issue when needed and then
 reasserts the terminal Project status so built-in GitHub Projects close
@@ -542,8 +544,9 @@ Use `GITHUB_PROJECT_STATUS_GRADUATED=Done` or
 `GITHUB_PROJECT_STATUS_GRADUATED=Released` in repositories whose Project board
 uses those labels for completed graduation work. The configured option must
 exist in the Project `Status` field. If closeout prints
-`GRADUATION_CLOSEOUT_RESULT=failed`, repair the listed `failed` items and rerun
-the helper before treating the graduation as complete.
+`GRADUATION_CLOSEOUT_RESULT=failed`, repair the listed `failed` items or
+discovery problem and rerun the helper before treating the graduation as
+complete.
 
 ---
 

--- a/docs/workflow/development-workflow/integrations/github-projects.md
+++ b/docs/workflow/development-workflow/integrations/github-projects.md
@@ -507,6 +507,45 @@ Use explicit issue numbers to avoid accidental broad transitions. Items not incl
 
 ---
 
+## Graduation Closeout Status
+
+After an integration branch graduation PR merges from `develop-<slug>` to
+`develop`, run the graduation closeout helper from Protocol 05b:
+
+```bash
+./scripts/development-workflow/graduation-closeout.sh \
+  --slug <slug> \
+  --graduation-pr <graduation-pr-number> \
+  --epic <epic-issue-number>
+```
+
+The helper reconciles delivered planned sub-items before closing the parent
+epic. It discovers planned work from native GitHub sub-issues, the legacy
+`integration-branch:<slug>` label fallback, and closing keywords in merged PRs
+that targeted `develop-<slug>`.
+
+For each delivered sub-item, it closes the GitHub issue when needed and then
+reasserts the terminal Project status so built-in GitHub Projects close
+automation cannot leave stale tracker state behind. Closed but non-terminal
+items receive only the Project status update. Already terminal items are
+reported without moving them backward. Optional, deferred, cancelled, or
+explicitly excluded sub-items remain open and are listed for human disposition.
+
+Terminal status is resolved in this order:
+
+- `GITHUB_PROJECT_STATUS_GRADUATED`
+- `GITHUB_PROJECT_STATUS_MERGED`
+- `Merged`
+
+Use `GITHUB_PROJECT_STATUS_GRADUATED=Done` or
+`GITHUB_PROJECT_STATUS_GRADUATED=Released` in repositories whose Project board
+uses those labels for completed graduation work. The configured option must
+exist in the Project `Status` field. If closeout prints
+`GRADUATION_CLOSEOUT_RESULT=failed`, repair the listed `failed` items and rerun
+the helper before treating the graduation as complete.
+
+---
+
 ## Prerequisites
 
 - **`gh` CLI** authenticated with a token that has `project` and `repo` scopes:

--- a/docs/workflow/development-workflow/integrations/github-projects.md
+++ b/docs/workflow/development-workflow/integrations/github-projects.md
@@ -519,10 +519,11 @@ After an integration branch graduation PR merges from `develop-<slug>` to
   --epic <epic-issue-number>
 ```
 
-The helper reconciles delivered planned sub-items before closing the parent
-epic. It discovers planned work from native GitHub sub-issues, the legacy
-`integration-branch:<slug>` label fallback, and closing keywords in merged PRs
-that targeted `develop-<slug>`.
+The helper validates that the graduation PR already merged from
+`develop-<slug>` to `develop`, then reconciles delivered planned sub-items
+before closing the parent epic. It discovers planned work from native GitHub
+sub-issues, the legacy `integration-branch:<slug>` label fallback, and closing
+keywords in merged PRs that targeted `develop-<slug>`.
 
 For each delivered sub-item, it closes the GitHub issue when needed and then
 reasserts the terminal Project status so built-in GitHub Projects close

--- a/docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md
@@ -290,6 +290,7 @@ After the human merges the graduation PR (must use a **merge commit**):
    Add `--exclude-issue <issue-number>` for optional, deferred, cancelled, or explicitly excluded sub-items that must remain open for human disposition. Add `--defer-epic-close` only when the human explicitly requests that the parent epic remain open after the core deliverable graduates.
 
    The helper:
+   - validates that the graduation PR is already merged from `develop-<slug>` to `develop`;
    - identifies planned sub-items from native GitHub sub-issues or the `integration-branch:<slug>` label fallback;
    - includes issue references from closing keywords in merged PRs targeting `develop-<slug>`;
    - closes open delivered sub-items and reasserts the configured terminal Project status;

--- a/docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md
@@ -278,16 +278,31 @@ After the human merges the graduation PR (must use a **merge commit**):
    git branch -d develop-<slug>
    ```
 
-4. **Close the epic issue** (BR-8, AC-9): Close the epic GitHub issue in the tracker, since the core planned deliverable has landed on `develop`. If optional sub-items remain open, leave a note on the epic before closing:
+4. **Run graduation closeout** (BR-8, BR-9, AC-9): Reconcile delivered planned sub-items and the parent epic with the tracker before reporting the integration branch as fully closed.
 
    ```bash
-   # Close the epic issue; substitute <epic-issue-number> with the actual issue number
-   gh issue close <epic-issue-number> --comment "Core deliverable graduated to \`develop\` via graduation PR. Epic closed. Remaining optional sub-items (if any) are listed below for disposition."
+   ./scripts/development-workflow/graduation-closeout.sh \
+     --slug <slug> \
+     --graduation-pr <graduation-pr-number> \
+     --epic <epic-issue-number>
    ```
 
-   If the human has explicitly requested to leave the epic open until all optional sub-items are resolved, defer the closure and note this in the cleanup summary.
+   Add `--exclude-issue <issue-number>` for optional, deferred, cancelled, or explicitly excluded sub-items that must remain open for human disposition. Add `--defer-epic-close` only when the human explicitly requests that the parent epic remain open after the core deliverable graduates.
 
-5. **Optional sub-item disposition** (Use Case 4, AC-10): For any native sub-issues or label-discovered sub-items that remain open at graduation time, surface them to the human for disposition. Prefer the native sub-issue list when available; use the label fallback for legacy epics:
+   The helper:
+   - identifies planned sub-items from native GitHub sub-issues or the `integration-branch:<slug>` label fallback;
+   - includes issue references from closing keywords in merged PRs targeting `develop-<slug>`;
+   - closes open delivered sub-items and reasserts the configured terminal Project status;
+   - updates closed-but-non-terminal delivered sub-items to the terminal Project status;
+   - reports already terminal sub-items without moving them backward;
+   - skips optional/deferred/excluded sub-items and reports the required human disposition;
+   - closes the parent epic only after delivered planned sub-items reconcile, unless epic closure is explicitly deferred.
+
+   Terminal Project status is resolved in this order: `GITHUB_PROJECT_STATUS_GRADUATED`, `GITHUB_PROJECT_STATUS_MERGED`, then `Merged`.
+
+   If `GRADUATION_CLOSEOUT_RESULT=failed`, stop and repair the listed `failed` items before claiming graduation cleanup is complete. Do not close the parent epic manually while delivered sub-item failures remain.
+
+5. **Optional sub-item disposition** (Use Case 4, AC-10): For any items listed under `skipped_optional`, surface them to the human for disposition. The helper has already left them open intentionally.
 
    ```bash
    gh issue list --label "integration-branch:<slug>" --state open --limit 1000 --json number,title,labels \
@@ -314,7 +329,7 @@ After the human merges the graduation PR (must use a **merge commit**):
    git worktree remove <worktree-path>
    ```
 
-7. Confirm to the human: "Integration branch `develop-<slug>` has been deleted. All sub-items are now on `develop`. Epic issue closed (or: left open — see disposition notes above)."
+7. Confirm to the human: "Integration branch `develop-<slug>` has been deleted. Delivered planned sub-items were reconciled by graduation closeout. Epic issue closed (or: left open — see disposition notes above)."
 
 ---
 
@@ -340,5 +355,5 @@ The following business rules from the spec are enforced by this protocol:
 | BR-5 | Step 2.5      | CHANGELOG absorb must be part of the graduation branch, not a prior merge        |
 | BR-6 | Step 4        | `ready-for-regression` NOT required for graduation PRs                           |
 | BR-7 | Step 5        | Post-graduation remote branch deletion is mandatory                              |
-| BR-8 | Step 5        | Epic issue closed after graduation (unless human defers)                         |
-| BR-9 | Step 5        | Sub-items already marked Done at merge time; no additional tracker update needed |
+| BR-8 | Step 5        | Epic issue closed after delivered sub-items reconcile (unless human defers)      |
+| BR-9 | Step 5        | Graduation closeout reconciles delivered sub-items and terminal Project status   |

--- a/docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md
@@ -297,6 +297,7 @@ After the human merges the graduation PR (must use a **merge commit**):
    - updates closed-but-non-terminal delivered sub-items to the terminal Project status;
    - reports already terminal sub-items without moving them backward;
    - skips optional/deferred/excluded sub-items and reports the required human disposition;
+   - fails closed when candidate discovery is incomplete or no delivered sub-items can be identified;
    - closes the parent epic only after delivered planned sub-items reconcile, unless epic closure is explicitly deferred.
 
    Terminal Project status is resolved in this order: `GITHUB_PROJECT_STATUS_GRADUATED`, `GITHUB_PROJECT_STATUS_MERGED`, then `Merged`.

--- a/scripts/development-workflow/graduation-closeout.sh
+++ b/scripts/development-workflow/graduation-closeout.sh
@@ -497,19 +497,29 @@ print_section() {
 
 validate_graduation_pr
 
+NATIVE_DISCOVERY_OK=1
 if ! discover_native_subissues; then
   echo "Warning: native sub-issue discovery failed for epic #${EPIC_ISSUE}; using label fallback only." >&2
+  NATIVE_DISCOVERY_OK=0
 fi
 if [ ! -s "$CANDIDATES_FILE" ]; then
   if ! discover_label_subitems; then
     echo "Warning: label fallback discovery failed for ${INTEGRATION_LABEL}." >&2
+    record_result "$FAILED_FILE" "discovery" "Candidate discovery" "label:${INTEGRATION_LABEL}" "label_fallback_failed"
   fi
 else
   # Still include label-discovered legacy items when native sub-issues exist.
-  discover_label_subitems || true
+  if ! discover_label_subitems && [ "$NATIVE_DISCOVERY_OK" -eq 0 ]; then
+    echo "Warning: label fallback discovery failed for ${INTEGRATION_LABEL}." >&2
+    record_result "$FAILED_FILE" "discovery" "Candidate discovery" "label:${INTEGRATION_LABEL}" "label_fallback_failed"
+  fi
 fi
 if ! discover_closing_keyword_refs; then
   echo "Warning: could not read merged PR closing-keyword references for ${INTEGRATION_BRANCH}." >&2
+  record_result "$FAILED_FILE" "discovery" "Candidate discovery" "pr:${INTEGRATION_BRANCH}" "merged_pr_discovery_failed"
+fi
+if [ ! -s "$CANDIDATES_FILE" ]; then
+  record_result "$FAILED_FILE" "discovery" "Candidate discovery" "native-subissue,label:${INTEGRATION_LABEL},pr:${INTEGRATION_BRANCH}" "no_delivered_subitems_discovered"
 fi
 
 cut -f1 "$CANDIDATES_FILE" | sort -n -u > "$UNIQUE_ISSUES_FILE"

--- a/scripts/development-workflow/graduation-closeout.sh
+++ b/scripts/development-workflow/graduation-closeout.sh
@@ -497,10 +497,8 @@ print_section() {
 
 validate_graduation_pr
 
-NATIVE_DISCOVERY_OK=1
 if ! discover_native_subissues; then
   echo "Warning: native sub-issue discovery failed for epic #${EPIC_ISSUE}; using label fallback only." >&2
-  NATIVE_DISCOVERY_OK=0
 fi
 if [ ! -s "$CANDIDATES_FILE" ]; then
   if ! discover_label_subitems; then
@@ -509,7 +507,7 @@ if [ ! -s "$CANDIDATES_FILE" ]; then
   fi
 else
   # Still include label-discovered legacy items when native sub-issues exist.
-  if ! discover_label_subitems && [ "$NATIVE_DISCOVERY_OK" -eq 0 ]; then
+  if ! discover_label_subitems; then
     echo "Warning: label fallback discovery failed for ${INTEGRATION_LABEL}." >&2
     record_result "$FAILED_FILE" "discovery" "Candidate discovery" "label:${INTEGRATION_LABEL}" "label_fallback_failed"
   fi

--- a/scripts/development-workflow/graduation-closeout.sh
+++ b/scripts/development-workflow/graduation-closeout.sh
@@ -215,6 +215,44 @@ extract_closing_issue_numbers() {
     | sort -un || true
 }
 
+validate_graduation_pr() {
+  local pr_json parsed state merged_at base_ref head_ref
+  if ! pr_json="$(gh pr view "$GRADUATION_PR" --json number,state,mergedAt,baseRefName,headRefName 2>/dev/null)"; then
+    echo "ERROR: could not read graduation PR #${GRADUATION_PR}." >&2
+    exit 1
+  fi
+  if ! parsed="$(printf '%s' "$pr_json" | python3 -c '
+import json, sys
+try:
+    pr = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+print(pr.get("state") or "")
+print(pr.get("mergedAt") or "")
+print(pr.get("baseRefName") or "")
+print(pr.get("headRefName") or "")
+')"; then
+    echo "ERROR: could not parse graduation PR #${GRADUATION_PR}." >&2
+    exit 1
+  fi
+  state="$(printf '%s\n' "$parsed" | sed -n '1p')"
+  merged_at="$(printf '%s\n' "$parsed" | sed -n '2p')"
+  base_ref="$(printf '%s\n' "$parsed" | sed -n '3p')"
+  head_ref="$(printf '%s\n' "$parsed" | sed -n '4p')"
+  if [ "$head_ref" != "$INTEGRATION_BRANCH" ]; then
+    echo "ERROR: graduation PR #${GRADUATION_PR} head is '${head_ref:-unknown}', expected '${INTEGRATION_BRANCH}'." >&2
+    exit 1
+  fi
+  if [ "$base_ref" != "develop" ]; then
+    echo "ERROR: graduation PR #${GRADUATION_PR} base is '${base_ref:-unknown}', expected 'develop'." >&2
+    exit 1
+  fi
+  if [ "$state" != "MERGED" ] && [ -z "$merged_at" ]; then
+    echo "ERROR: graduation PR #${GRADUATION_PR} has not merged yet; closeout is post-merge only." >&2
+    exit 1
+  fi
+}
+
 discover_native_subissues() {
   local after=""
   local has_next="true"
@@ -456,6 +494,8 @@ print_section() {
     echo "  (none)"
   fi
 }
+
+validate_graduation_pr
 
 if ! discover_native_subissues; then
   echo "Warning: native sub-issue discovery failed for epic #${EPIC_ISSUE}; using label fallback only." >&2

--- a/scripts/development-workflow/graduation-closeout.sh
+++ b/scripts/development-workflow/graduation-closeout.sh
@@ -1,0 +1,512 @@
+#!/usr/bin/env bash
+#
+# Reconcile delivered integration-branch sub-items after a graduation PR merges.
+#
+# Usage:
+#   ./scripts/development-workflow/graduation-closeout.sh --slug <slug> --graduation-pr <number> --epic <issue-number> [--exclude-issue <number>]... [--defer-epic-close]
+#
+# Env overrides:
+#   GITHUB_PROJECT_STATUS_GRADUATED  Terminal status for graduated work.
+#   GITHUB_PROJECT_STATUS_MERGED     Fallback terminal status.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+# shellcheck source=./workflow-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/workflow-lib.sh"
+
+SLUG=""
+GRADUATION_PR=""
+EPIC_ISSUE=""
+DEFER_EPIC_CLOSE=0
+declare -a EXCLUDED_ISSUES=()
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  graduation-closeout.sh --slug <slug> --graduation-pr <number> --epic <issue-number> [--exclude-issue <number>]... [--defer-epic-close]
+EOF
+}
+
+require_value() {
+  local option="$1"
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ] || [ "${2#--}" != "$2" ]; then
+    echo "$option requires a value." >&2
+    usage
+    exit 64
+  fi
+}
+
+is_positive_int() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    0*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+is_valid_slug() {
+  case "$1" in
+    ''|*[^a-zA-Z0-9._-]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --slug)
+      require_value "$@"
+      SLUG="$2"
+      shift 2
+      ;;
+    --graduation-pr)
+      require_value "$@"
+      GRADUATION_PR="$2"
+      shift 2
+      ;;
+    --epic)
+      require_value "$@"
+      EPIC_ISSUE="$2"
+      shift 2
+      ;;
+    --exclude-issue)
+      require_value "$@"
+      EXCLUDED_ISSUES+=("$2")
+      shift 2
+      ;;
+    --defer-epic-close)
+      DEFER_EPIC_CLOSE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 64
+      ;;
+  esac
+done
+
+if ! is_valid_slug "$SLUG"; then
+  echo "ERROR: --slug must be non-empty and contain only letters, numbers, dot, underscore, or hyphen." >&2
+  exit 64
+fi
+if ! is_positive_int "$GRADUATION_PR"; then
+  echo "ERROR: --graduation-pr must be a positive integer." >&2
+  exit 64
+fi
+if ! is_positive_int "$EPIC_ISSUE"; then
+  echo "ERROR: --epic must be a positive integer." >&2
+  exit 64
+fi
+for excluded in ${EXCLUDED_ISSUES[@]+"${EXCLUDED_ISSUES[@]}"}; do
+  if ! is_positive_int "$excluded"; then
+    echo "ERROR: --exclude-issue must be a positive integer." >&2
+    exit 64
+  fi
+done
+
+cd_workflow_repo_root
+require_gh
+
+REPO_SLUG="$(repo_slug)"
+REPO_OWNER="${REPO_SLUG%%/*}"
+REPO_NAME="${REPO_SLUG#*/}"
+INTEGRATION_BRANCH="develop-${SLUG}"
+INTEGRATION_LABEL="integration-branch:${SLUG}"
+TERMINAL_STATUS="${GITHUB_PROJECT_STATUS_GRADUATED:-${GITHUB_PROJECT_STATUS_MERGED:-Merged}}"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+CANDIDATES_FILE="$TMP_DIR/candidates.tsv"
+UNIQUE_ISSUES_FILE="$TMP_DIR/issues.txt"
+CLOSED_FILE="$TMP_DIR/closed.tsv"
+ALREADY_FILE="$TMP_DIR/already-terminal.tsv"
+SKIPPED_FILE="$TMP_DIR/skipped-optional.tsv"
+FAILED_FILE="$TMP_DIR/failed.tsv"
+: > "$CANDIDATES_FILE"
+: > "$CLOSED_FILE"
+: > "$ALREADY_FILE"
+: > "$SKIPPED_FILE"
+: > "$FAILED_FILE"
+
+append_candidate() {
+  local issue="$1"
+  local source="$2"
+  if is_positive_int "$issue"; then
+    printf '%s\t%s\n' "$issue" "$source" >> "$CANDIDATES_FILE"
+  fi
+}
+
+is_excluded_issue() {
+  local issue="$1"
+  local excluded
+  for excluded in ${EXCLUDED_ISSUES[@]+"${EXCLUDED_ISSUES[@]}"}; do
+    if [ "$excluded" = "$issue" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+is_skip_label() {
+  local labels_csv="$1"
+  local old_ifs="$IFS"
+  local label normalized
+  IFS=','
+  # shellcheck disable=SC2086
+  for label in $labels_csv; do
+    normalized="$(printf '%s' "$label" | tr '[:upper:]' '[:lower:]')"
+    case "$normalized" in
+      optional|deferred|cancelled|excluded-from-graduation|exclude-from-graduation)
+        IFS="$old_ifs"
+        return 0
+        ;;
+    esac
+  done
+  IFS="$old_ifs"
+  return 1
+}
+
+is_closeout_terminal_status() {
+  local status="$1"
+  if [ "$status" = "$TERMINAL_STATUS" ]; then
+    return 0
+  fi
+  case "$status" in
+    Done|Merged|Released|Cancelled) return 0 ;;
+    *) ;;
+  esac
+  is_terminal_tracker_status "$status"
+}
+
+tracker_status_for_issue() {
+  local issue="$1"
+  get_tracker_status_for_issue "$issue" | awk '
+    /^TRACKER_ACTION_REQUIRED=/ { next }
+    { value=$0 }
+    END { print value }
+  '
+}
+
+ensure_terminal_tracker_status() {
+  local issue="$1"
+  local before after
+  before="$(tracker_status_for_issue "$issue")"
+  if is_closeout_terminal_status "$before"; then
+    return 0
+  fi
+  update_tracker_status_best_effort "$issue" "$TERMINAL_STATUS" "" "allow-backward" >/dev/null
+  after="$(tracker_status_for_issue "$issue")"
+  is_closeout_terminal_status "$after"
+}
+
+extract_closing_issue_numbers() {
+  grep -ioE '(^|[^[:alnum:]_])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+' \
+    | grep -oE '[0-9]+$' \
+    | sort -un || true
+}
+
+discover_native_subissues() {
+  local after=""
+  local has_next="true"
+  local response
+  local -a graphql_args
+
+  while [ "$has_next" = "true" ]; do
+    graphql_args=(
+      gh api graphql
+      -F owner="$REPO_OWNER"
+      -F repo="$REPO_NAME"
+      -F number="$EPIC_ISSUE"
+    )
+    if [ -n "$after" ]; then
+      graphql_args+=(-f after="$after")
+    fi
+    # shellcheck disable=SC2016 # GraphQL variables are expanded by GitHub.
+    graphql_args+=(
+      -f query='
+        query($owner: String!, $repo: String!, $number: Int!, $after: String) {
+          repository(owner: $owner, name: $repo) {
+            issue(number: $number) {
+              subIssues(first: 100, after: $after) {
+                nodes {
+                  number
+                  title
+                  state
+                  labels(first: 50) { nodes { name } }
+                }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+        }
+      '
+    )
+    if ! response="$("${graphql_args[@]}" 2>/dev/null)"; then
+      return 1
+    fi
+    if [ -z "$response" ]; then
+      return 1
+    fi
+    printf '%s' "$response" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+issue = (((data.get("data") or {}).get("repository") or {}).get("issue") or {})
+subissues = issue.get("subIssues") or {}
+for node in subissues.get("nodes") or []:
+    number = node.get("number")
+    if number:
+        print(number)
+page = subissues.get("pageInfo") or {}
+print("HAS_NEXT=" + ("true" if page.get("hasNextPage") else "false"), file=sys.stderr)
+print("END_CURSOR=" + (page.get("endCursor") or ""), file=sys.stderr)
+' > "$TMP_DIR/native-page.out" 2> "$TMP_DIR/native-page.meta" || return 1
+    while IFS= read -r issue; do
+      [ -z "$issue" ] && continue
+      append_candidate "$issue" "native-subissue"
+    done < "$TMP_DIR/native-page.out"
+    has_next="$(awk -F= '/^HAS_NEXT=/{print $2}' "$TMP_DIR/native-page.meta")"
+    after="$(awk -F= '/^END_CURSOR=/{print $2}' "$TMP_DIR/native-page.meta")"
+    if [ -z "$has_next" ]; then
+      has_next="false"
+    fi
+  done
+  return 0
+}
+
+discover_label_subitems() {
+  local output
+  if ! output="$(gh issue list --label "$INTEGRATION_LABEL" --state all --limit 1000 --json number,title,state,labels --jq '.[] | .number' 2>/dev/null)"; then
+    return 1
+  fi
+  while IFS= read -r issue; do
+    [ -z "$issue" ] && continue
+    append_candidate "$issue" "label:${INTEGRATION_LABEL}"
+  done <<< "$output"
+}
+
+discover_closing_keyword_refs() {
+  local prs_json
+  if ! prs_json="$(gh pr list --state merged --base "$INTEGRATION_BRANCH" --limit 1000 --json number,title,body 2>/dev/null)"; then
+    return 1
+  fi
+  printf '%s' "$prs_json" | python3 -c '
+import json, sys
+try:
+    prs = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+for pr in prs or []:
+    number = pr.get("number")
+    text = ((pr.get("title") or "") + "\n" + (pr.get("body") or "")).replace("\t", " ")
+    if number:
+        print(f"PR\t{number}\t{text.replace(chr(10), chr(30))}")
+' > "$TMP_DIR/merged-prs.tsv"
+  while IFS="$(printf '\t')" read -r marker pr_number text; do
+    [ "$marker" = "PR" ] || continue
+    printf '%s' "$text" | tr "$(printf '\036')" '\n' | extract_closing_issue_numbers > "$TMP_DIR/pr-${pr_number}-issues.txt"
+    while IFS= read -r issue; do
+      [ -z "$issue" ] && continue
+      append_candidate "$issue" "pr:${pr_number}"
+    done < "$TMP_DIR/pr-${pr_number}-issues.txt"
+  done < "$TMP_DIR/merged-prs.tsv"
+}
+
+issue_source_summary() {
+  local issue="$1"
+  awk -F '\t' -v issue="$issue" '$1 == issue { print $2 }' "$CANDIDATES_FILE" \
+    | sort -u \
+    | paste -sd ',' -
+}
+
+issue_details_tsv() {
+  local issue="$1"
+  gh issue view "$issue" --json number,title,state,labels 2>/dev/null | python3 -c '
+import json, sys
+try:
+    item = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+labels = ",".join((label.get("name") or "") for label in (item.get("labels") or []))
+print("{}\t{}\t{}\t{}".format(
+    item.get("number") or "",
+    (item.get("title") or "").replace("\t", " "),
+    item.get("state") or "",
+    labels,
+))
+'
+}
+
+record_result() {
+  local file="$1"
+  local issue="$2"
+  local title="$3"
+  local source="$4"
+  local reason="$5"
+  printf '#%s\t%s\t%s\t%s\n' "$issue" "$title" "$source" "$reason" >> "$file"
+}
+
+close_issue_with_comment() {
+  local issue="$1"
+  local kind="$2"
+  local comment
+  comment="${kind} delivered via graduation PR #${GRADUATION_PR} from \`${INTEGRATION_BRANCH}\` to \`develop\`. Tracker status reconciled by graduation closeout."
+  gh issue close "$issue" --comment "$comment" >/dev/null
+}
+
+process_delivered_issue() {
+  local issue="$1"
+  local details title state labels source status
+  if ! details="$(issue_details_tsv "$issue")"; then
+    record_result "$FAILED_FILE" "$issue" "(unknown)" "$(issue_source_summary "$issue")" "could_not_read_issue"
+    return
+  fi
+  IFS="$(printf '\t')" read -r _ title state labels <<< "$details"
+  source="$(issue_source_summary "$issue")"
+  status="$(tracker_status_for_issue "$issue")"
+
+  if is_excluded_issue "$issue" || is_skip_label "$labels"; then
+    record_result "$SKIPPED_FILE" "$issue" "$title" "$source" "requires_human_disposition"
+    return
+  fi
+
+  if [ "$state" != "OPEN" ] && is_closeout_terminal_status "$status"; then
+    record_result "$ALREADY_FILE" "$issue" "$title" "$source" "already_terminal"
+    return
+  fi
+
+  if [ "$state" = "OPEN" ]; then
+    if ! close_issue_with_comment "$issue" "Sub-item"; then
+      record_result "$FAILED_FILE" "$issue" "$title" "$source" "issue_close_failed"
+      return
+    fi
+  fi
+
+  if ! ensure_terminal_tracker_status "$issue"; then
+    record_result "$FAILED_FILE" "$issue" "$title" "$source" "tracker_status_update_failed"
+    return
+  fi
+
+  record_result "$CLOSED_FILE" "$issue" "$title" "$source" "delivered_terminal"
+}
+
+process_epic() {
+  local failed_count="$1"
+  local details title state status
+  if [ "$DEFER_EPIC_CLOSE" -eq 1 ]; then
+    printf 'EPIC_RESULT=deferred\n'
+    printf 'EPIC_REASON=operator_deferred\n'
+    return 0
+  fi
+  if [ "$failed_count" -gt 0 ]; then
+    printf 'EPIC_RESULT=held\n'
+    printf 'EPIC_REASON=delivered_subitem_failures\n'
+    return 1
+  fi
+  if ! details="$(issue_details_tsv "$EPIC_ISSUE")"; then
+    printf 'EPIC_RESULT=failed\n'
+    printf 'EPIC_REASON=could_not_read_epic\n'
+    return 1
+  fi
+  IFS="$(printf '\t')" read -r _ title state _ <<< "$details"
+  status="$(tracker_status_for_issue "$EPIC_ISSUE")"
+  if [ "$state" != "OPEN" ] && is_closeout_terminal_status "$status"; then
+    printf 'EPIC_RESULT=already_terminal\n'
+    return 0
+  fi
+  if [ "$state" = "OPEN" ]; then
+    if ! close_issue_with_comment "$EPIC_ISSUE" "Epic"; then
+      printf 'EPIC_RESULT=failed\n'
+      printf 'EPIC_REASON=issue_close_failed\n'
+      return 1
+    fi
+  fi
+  if ! ensure_terminal_tracker_status "$EPIC_ISSUE"; then
+    printf 'EPIC_RESULT=failed\n'
+    printf 'EPIC_REASON=tracker_status_update_failed\n'
+    return 1
+  fi
+  printf 'EPIC_RESULT=closed\n'
+  return 0
+}
+
+count_file_lines() {
+  wc -l < "$1" | tr -d ' '
+}
+
+print_section() {
+  local name="$1"
+  local file="$2"
+  echo "${name}:"
+  if [ -s "$file" ]; then
+    sed 's/^/  /' "$file"
+  else
+    echo "  (none)"
+  fi
+}
+
+if ! discover_native_subissues; then
+  echo "Warning: native sub-issue discovery failed for epic #${EPIC_ISSUE}; using label fallback only." >&2
+fi
+if [ ! -s "$CANDIDATES_FILE" ]; then
+  if ! discover_label_subitems; then
+    echo "Warning: label fallback discovery failed for ${INTEGRATION_LABEL}." >&2
+  fi
+else
+  # Still include label-discovered legacy items when native sub-issues exist.
+  discover_label_subitems || true
+fi
+if ! discover_closing_keyword_refs; then
+  echo "Warning: could not read merged PR closing-keyword references for ${INTEGRATION_BRANCH}." >&2
+fi
+
+cut -f1 "$CANDIDATES_FILE" | sort -n -u > "$UNIQUE_ISSUES_FILE"
+
+while IFS= read -r issue; do
+  [ -z "$issue" ] && continue
+  if [ "$issue" = "$EPIC_ISSUE" ]; then
+    continue
+  fi
+  process_delivered_issue "$issue"
+done < "$UNIQUE_ISSUES_FILE"
+
+CLOSED_COUNT="$(count_file_lines "$CLOSED_FILE")"
+ALREADY_TERMINAL_COUNT="$(count_file_lines "$ALREADY_FILE")"
+SKIPPED_OPTIONAL_COUNT="$(count_file_lines "$SKIPPED_FILE")"
+FAILED_COUNT="$(count_file_lines "$FAILED_FILE")"
+
+EPIC_OUTPUT="$TMP_DIR/epic.out"
+EPIC_STATUS=0
+process_epic "$FAILED_COUNT" > "$EPIC_OUTPUT" || EPIC_STATUS=$?
+
+echo "GRADUATION_CLOSEOUT_RESULT=$([ "$FAILED_COUNT" -eq 0 ] && [ "$EPIC_STATUS" -eq 0 ] && echo pass || echo failed)"
+echo "SLUG=$SLUG"
+echo "INTEGRATION_BRANCH=$INTEGRATION_BRANCH"
+echo "GRADUATION_PR=$GRADUATION_PR"
+echo "EPIC_ISSUE=$EPIC_ISSUE"
+cat "$EPIC_OUTPUT"
+echo "TERMINAL_STATUS=$TERMINAL_STATUS"
+echo "CLOSED_COUNT=$CLOSED_COUNT"
+echo "ALREADY_TERMINAL_COUNT=$ALREADY_TERMINAL_COUNT"
+echo "SKIPPED_OPTIONAL_COUNT=$SKIPPED_OPTIONAL_COUNT"
+echo "FAILED_COUNT=$FAILED_COUNT"
+print_section "closed" "$CLOSED_FILE"
+print_section "already_terminal" "$ALREADY_FILE"
+print_section "skipped_optional" "$SKIPPED_FILE"
+print_section "failed" "$FAILED_FILE"
+
+if [ "$FAILED_COUNT" -gt 0 ] || [ "$EPIC_STATUS" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/development-workflow/tests/test-graduation-closeout.sh
+++ b/scripts/development-workflow/tests/test-graduation-closeout.sh
@@ -126,6 +126,10 @@ JSON
     ;;
   "pr list --state merged --base develop-test --limit 1000 --json number,title,body")
     case "${MOCK_PR_MODE:-single_ref}" in
+      fail)
+        printf 'mock pr list failure\n' >&2
+        exit 46
+        ;;
       none)
         printf '[]\n'
         ;;
@@ -259,6 +263,41 @@ last_output_body() {
 last_output_status() {
   head -n 1 <<< "$1"
 }
+
+echo ""
+echo "=== graduation closeout: discovery failures fail closed ==="
+reset_fixture
+export MOCK_NATIVE_MODE=fail
+export MOCK_PR_MODE=none
+write_issue 900 "Parent epic" OPEN
+set_status 900 "In Development"
+empty_discovery_result="$(run_closeout)"
+empty_discovery_body="$(last_output_body "$empty_discovery_result")"
+run_test "empty_discovery_exit_one" "1" "$(last_output_status "$empty_discovery_result")"
+run_contains "empty_discovery_failed_result" "GRADUATION_CLOSEOUT_RESULT=failed" "$empty_discovery_body"
+run_contains "empty_discovery_reason" "no_delivered_subitems_discovered" "$empty_discovery_body"
+run_contains "empty_discovery_epic_held" "EPIC_RESULT=held" "$empty_discovery_body"
+run_test "empty_discovery_no_epic_close" "OPEN" "$(python3 -c 'import json; print(json.load(open("'"$MOCK_STATE_DIR"'/900.json"))["state"])')"
+
+reset_fixture
+export MOCK_PR_MODE=fail
+write_issue 101 "Open child" OPEN
+write_issue 102 "Closed nonterminal" CLOSED
+write_issue 103 "Closed terminal" CLOSED
+write_issue 104 "Optional child" OPEN optional
+write_issue 900 "Parent epic" OPEN
+set_status 101 "In Development"
+set_status 102 "Development in Review"
+set_status 103 "Merged"
+set_status 104 "In Development"
+set_status 900 "In Development"
+pr_discovery_result="$(run_closeout)"
+pr_discovery_body="$(last_output_body "$pr_discovery_result")"
+run_test "pr_discovery_exit_one" "1" "$(last_output_status "$pr_discovery_result")"
+run_contains "pr_discovery_reason" "merged_pr_discovery_failed" "$pr_discovery_body"
+run_contains "pr_discovery_epic_held" "EPIC_RESULT=held" "$pr_discovery_body"
+run_test "pr_discovery_child_still_processed" "CLOSED" "$(python3 -c 'import json; print(json.load(open("'"$MOCK_STATE_DIR"'/101.json"))["state"])')"
+run_test "pr_discovery_no_epic_close" "OPEN" "$(python3 -c 'import json; print(json.load(open("'"$MOCK_STATE_DIR"'/900.json"))["state"])')"
 
 echo ""
 echo "=== graduation closeout: graduation PR validation ==="

--- a/scripts/development-workflow/tests/test-graduation-closeout.sh
+++ b/scripts/development-workflow/tests/test-graduation-closeout.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# test-graduation-closeout.sh - graduation closeout helper tests.
+#
+# Usage: bash scripts/development-workflow/tests/test-graduation-closeout.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+
+TMP_ROOT="$(mktemp -d)"
+MOCK_BIN="$TMP_ROOT/bin"
+FIXTURE_REPO="$TMP_ROOT/repo"
+MOCK_STATE_DIR="$TMP_ROOT/state"
+MOCK_STATUS_DIR="$TMP_ROOT/status"
+MOCK_CLOSE_LOG="$TMP_ROOT/close.log"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+cleanup() {
+  local status=$?
+  rm -rf "$TMP_ROOT"
+  case "$status" in
+    141) exit 0 ;;
+    *) exit "$status" ;;
+  esac
+}
+trap cleanup EXIT
+
+mkdir -p "$MOCK_BIN" "$FIXTURE_REPO/scripts/development-workflow" "$MOCK_STATE_DIR" "$MOCK_STATUS_DIR"
+cp "$REPO_ROOT/scripts/development-workflow/graduation-closeout.sh" "$FIXTURE_REPO/scripts/development-workflow/graduation-closeout.sh"
+chmod +x "$FIXTURE_REPO/scripts/development-workflow/graduation-closeout.sh"
+
+cat > "$FIXTURE_REPO/scripts/development-workflow/workflow-lib.sh" <<'STUB_LIB'
+#!/usr/bin/env bash
+
+cd_workflow_repo_root() {
+  cd "$WORKFLOW_FIXTURE_REPO"
+}
+
+require_gh() {
+  gh auth status >/dev/null
+}
+
+repo_slug() {
+  printf 'lhpaul/ai-dev-framework-template\n'
+}
+
+is_terminal_tracker_status() {
+  case "$1" in
+    Done|Merged|Released|Cancelled) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+get_tracker_status_for_issue() {
+  local issue="$1"
+  if [ -f "$MOCK_STATUS_DIR/$issue" ]; then
+    cat "$MOCK_STATUS_DIR/$issue"
+  fi
+}
+
+update_tracker_status_best_effort() {
+  local issue="$1"
+  local status="$2"
+  if [ "${MOCK_STATUS_FAIL_ISSUE:-}" = "$issue" ]; then
+    printf 'Warning: mocked status update failure for #%s\n' "$issue" >&2
+    return 0
+  fi
+  printf '%s\n' "$status" > "$MOCK_STATUS_DIR/$issue"
+}
+STUB_LIB
+
+cat > "$MOCK_BIN/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+case "$*" in
+  "auth status")
+    exit 0
+    ;;
+  api\ graphql*)
+    case "${MOCK_NATIVE_MODE:-children}" in
+      fail)
+        printf 'mock native failure\n' >&2
+        exit 42
+        ;;
+      empty)
+        cat <<'JSON'
+{"data":{"repository":{"issue":{"subIssues":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
+        ;;
+      *)
+        cat <<'JSON'
+{"data":{"repository":{"issue":{"subIssues":{"nodes":[{"number":101,"title":"Open child","state":"OPEN","labels":{"nodes":[]}},{"number":102,"title":"Closed nonterminal","state":"CLOSED","labels":{"nodes":[]}},{"number":103,"title":"Closed terminal","state":"CLOSED","labels":{"nodes":[]}},{"number":104,"title":"Optional child","state":"OPEN","labels":{"nodes":[{"name":"optional"}]}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
+        ;;
+    esac
+    ;;
+  issue\ list\ --label\ integration-branch:test\ --state\ all\ --limit\ 1000\ --json\ number,title,state,labels\ --jq\ .[]\ \|\ .number)
+    if [ -n "${MOCK_LABEL_ISSUES:-}" ]; then
+      printf '%s\n' "$MOCK_LABEL_ISSUES"
+    fi
+    ;;
+  "pr list --state merged --base develop-test --limit 1000 --json number,title,body")
+    case "${MOCK_PR_MODE:-single_ref}" in
+      none)
+        printf '[]\n'
+        ;;
+      parser)
+        cat <<'JSON'
+[{"number":21,"title":"Closes #301 and fixes #302","body":"(Resolves issue #303.)\n- closed #304\nDisclose #398\nhotfix #399\nnot closing #397\nowner/repo#396\nCloses owner/repo#395\nfixes #302"}]
+JSON
+        ;;
+      *)
+        cat <<'JSON'
+[{"number":11,"title":"Deliver extra item","body":"Closes #105"}]
+JSON
+        ;;
+    esac
+    ;;
+  issue\ view\ *\ --json\ number,title,state,labels)
+    issue="$3"
+    file="$MOCK_STATE_DIR/$issue.json"
+    if [ ! -f "$file" ]; then
+      printf 'missing fixture for issue #%s\n' "$issue" >&2
+      exit 44
+    fi
+    cat "$file"
+    ;;
+  issue\ close\ *\ --comment\ *)
+    issue="$3"
+    if [ "${MOCK_CLOSE_FAIL_ISSUE:-}" = "$issue" ]; then
+      printf 'mock close failure for #%s\n' "$issue" >&2
+      exit 45
+    fi
+    python3 - "$MOCK_STATE_DIR/$issue.json" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+data = json.load(open(path))
+data["state"] = "CLOSED"
+json.dump(data, open(path, "w"))
+PY
+    printf '%s\n' "$issue" >> "$MOCK_CLOSE_LOG"
+    ;;
+  *)
+    printf 'unexpected gh invocation: gh %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+MOCK_GH
+
+chmod +x "$MOCK_BIN/gh"
+export PATH="$MOCK_BIN:$PATH"
+export WORKFLOW_FIXTURE_REPO="$FIXTURE_REPO"
+export MOCK_STATE_DIR MOCK_STATUS_DIR MOCK_CLOSE_LOG
+
+run_test() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_contains() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if grep -Fq -- "$expected" <<< "$actual"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected output to contain '${expected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_not_contains() {
+  local name="$1"
+  local unexpected="$2"
+  local actual="$3"
+  if grep -Fq -- "$unexpected" <<< "$actual"; then
+    echo "FAIL: $name - output unexpectedly contained '${unexpected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  else
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  fi
+}
+
+write_issue() {
+  local number="$1"
+  local title="$2"
+  local state="$3"
+  local labels_csv="${4:-}"
+  python3 - "$MOCK_STATE_DIR/$number.json" "$number" "$title" "$state" "$labels_csv" <<'PY'
+import json
+import sys
+path, number, title, state, labels_csv = sys.argv[1:6]
+labels = [{"name": label} for label in labels_csv.split(",") if label]
+json.dump({"number": int(number), "title": title, "state": state, "labels": labels}, open(path, "w"))
+PY
+}
+
+set_status() {
+  printf '%s\n' "$2" > "$MOCK_STATUS_DIR/$1"
+}
+
+reset_fixture() {
+  rm -f "$MOCK_STATE_DIR"/*.json "$MOCK_STATUS_DIR"/* "$MOCK_CLOSE_LOG"
+  : > "$MOCK_CLOSE_LOG"
+  unset MOCK_NATIVE_MODE MOCK_LABEL_ISSUES MOCK_PR_MODE MOCK_CLOSE_FAIL_ISSUE MOCK_STATUS_FAIL_ISSUE GITHUB_PROJECT_STATUS_GRADUATED GITHUB_PROJECT_STATUS_MERGED
+}
+
+run_closeout() {
+  local output status
+  set +e
+  output="$(cd "$FIXTURE_REPO" && ./scripts/development-workflow/graduation-closeout.sh --slug test --graduation-pr 77 --epic 900 "$@" 2>&1)"
+  status=$?
+  set -e
+  printf '%s\n%s\n' "$status" "$output"
+}
+
+last_output_body() {
+  tail -n +2 <<< "$1"
+}
+
+last_output_status() {
+  head -n 1 <<< "$1"
+}
+
+echo ""
+echo "=== graduation closeout: native sub-issues and PR refs ==="
+reset_fixture
+write_issue 101 "Open child" OPEN
+write_issue 102 "Closed nonterminal" CLOSED
+write_issue 103 "Closed terminal" CLOSED
+write_issue 104 "Optional child" OPEN optional
+write_issue 105 "PR referenced child" OPEN
+write_issue 900 "Parent epic" OPEN
+set_status 101 "In Development"
+set_status 102 "Development in Review"
+set_status 103 "Merged"
+set_status 104 "In Development"
+set_status 105 "Plan Ready"
+set_status 900 "In Development"
+native_result="$(run_closeout)"
+native_body="$(last_output_body "$native_result")"
+run_test "native_exit_zero" "0" "$(last_output_status "$native_result")"
+run_contains "native_result_pass" "GRADUATION_CLOSEOUT_RESULT=pass" "$native_body"
+run_contains "native_closed_count" "CLOSED_COUNT=3" "$native_body"
+run_contains "native_already_count" "ALREADY_TERMINAL_COUNT=1" "$native_body"
+run_contains "native_skipped_count" "SKIPPED_OPTIONAL_COUNT=1" "$native_body"
+run_contains "native_failed_count" "FAILED_COUNT=0" "$native_body"
+run_contains "native_epic_closed" "EPIC_RESULT=closed" "$native_body"
+run_test "open_child_closed" "CLOSED" "$(python3 -c 'import json; print(json.load(open("'"$MOCK_STATE_DIR"'/101.json"))["state"])')"
+run_test "closed_nonterminal_status_updated" "Merged" "$(cat "$MOCK_STATUS_DIR/102")"
+run_test "optional_stays_open" "OPEN" "$(python3 -c 'import json; print(json.load(open("'"$MOCK_STATE_DIR"'/104.json"))["state"])')"
+run_contains "pr_ref_source_reported" "#105" "$native_body"
+run_contains "close_log_has_epic" "900" "$(cat "$MOCK_CLOSE_LOG")"
+
+echo ""
+echo "=== graduation closeout: label fallback ==="
+reset_fixture
+export MOCK_NATIVE_MODE=empty
+export MOCK_LABEL_ISSUES=$'201\n202'
+export MOCK_PR_MODE=none
+write_issue 201 "Fallback child A" OPEN
+write_issue 202 "Fallback child B" OPEN
+write_issue 900 "Parent epic" OPEN
+set_status 201 "In Development"
+set_status 202 "In Development"
+set_status 900 "In Development"
+fallback_result="$(run_closeout)"
+fallback_body="$(last_output_body "$fallback_result")"
+run_test "fallback_exit_zero" "0" "$(last_output_status "$fallback_result")"
+run_contains "fallback_closed_count" "CLOSED_COUNT=2" "$fallback_body"
+run_contains "fallback_label_source" "label:integration-branch:test" "$fallback_body"
+
+echo ""
+echo "=== graduation closeout: closing keyword parser ==="
+reset_fixture
+export MOCK_NATIVE_MODE=empty
+export MOCK_PR_MODE=parser
+for issue in 301 302 303 304 395 396 397 398 399; do
+  write_issue "$issue" "Parser $issue" OPEN
+  set_status "$issue" "In Development"
+done
+write_issue 900 "Parent epic" OPEN
+set_status 900 "In Development"
+parser_result="$(run_closeout)"
+parser_body="$(last_output_body "$parser_result")"
+run_test "parser_exit_zero" "0" "$(last_output_status "$parser_result")"
+run_contains "parser_variants_count" "CLOSED_COUNT=4" "$parser_body"
+run_contains "parser_parentheses_match" "#303" "$parser_body"
+run_contains "parser_markdown_match" "#304" "$parser_body"
+run_not_contains "parser_disclose_ignored" "#398" "$parser_body"
+run_not_contains "parser_hotfix_ignored" "#399" "$parser_body"
+run_not_contains "parser_cross_repo_ignored" "#395" "$parser_body"
+run_not_contains "parser_related_repo_ignored" "#396" "$parser_body"
+run_not_contains "parser_non_closing_ignored" "#397" "$parser_body"
+
+echo ""
+echo "=== graduation closeout: partial failure and epic hold ==="
+reset_fixture
+export MOCK_NATIVE_MODE=empty
+export MOCK_LABEL_ISSUES=$'401\n402'
+export MOCK_PR_MODE=none
+export MOCK_CLOSE_FAIL_ISSUE=401
+write_issue 401 "Fails close" OPEN
+write_issue 402 "Still closes" OPEN
+write_issue 900 "Parent epic" OPEN
+set_status 401 "In Development"
+set_status 402 "In Development"
+set_status 900 "In Development"
+failure_result="$(run_closeout)"
+failure_body="$(last_output_body "$failure_result")"
+run_test "failure_exit_one" "1" "$(last_output_status "$failure_result")"
+run_contains "failure_count" "FAILED_COUNT=1" "$failure_body"
+run_contains "failure_other_item_closed" "#402" "$failure_body"
+run_contains "failure_epic_held" "EPIC_RESULT=held" "$failure_body"
+run_test "failed_issue_stays_open" "OPEN" "$(python3 -c 'import json; print(json.load(open("'"$MOCK_STATE_DIR"'/401.json"))["state"])')"
+run_test "other_issue_closed" "CLOSED" "$(python3 -c 'import json; print(json.load(open("'"$MOCK_STATE_DIR"'/402.json"))["state"])')"
+
+echo ""
+echo "=== graduation closeout: defer epic and configured terminal status ==="
+reset_fixture
+export MOCK_NATIVE_MODE=empty
+export MOCK_LABEL_ISSUES="501"
+export MOCK_PR_MODE=none
+export GITHUB_PROJECT_STATUS_GRADUATED=Done
+write_issue 501 "Done child" OPEN
+write_issue 900 "Parent epic" OPEN
+set_status 501 "In Development"
+set_status 900 "In Development"
+defer_result="$(run_closeout --defer-epic-close)"
+defer_body="$(last_output_body "$defer_result")"
+run_test "defer_exit_zero" "0" "$(last_output_status "$defer_result")"
+run_contains "defer_epic" "EPIC_RESULT=deferred" "$defer_body"
+run_contains "configured_terminal_status" "TERMINAL_STATUS=Done" "$defer_body"
+run_test "done_status_written" "Done" "$(cat "$MOCK_STATUS_DIR/501")"
+run_test "deferred_epic_stays_open" "OPEN" "$(python3 -c 'import json; print(json.load(open("'"$MOCK_STATE_DIR"'/900.json"))["state"])')"
+
+echo ""
+echo "=== graduation closeout: already-terminal rerun behavior ==="
+reset_fixture
+export MOCK_NATIVE_MODE=empty
+export MOCK_LABEL_ISSUES="601"
+export MOCK_PR_MODE=none
+write_issue 601 "Already done" CLOSED
+write_issue 900 "Parent epic" CLOSED
+set_status 601 "Merged"
+set_status 900 "Merged"
+rerun_result="$(run_closeout)"
+rerun_body="$(last_output_body "$rerun_result")"
+run_test "rerun_exit_zero" "0" "$(last_output_status "$rerun_result")"
+run_contains "rerun_already_count" "ALREADY_TERMINAL_COUNT=1" "$rerun_body"
+run_contains "rerun_epic_already" "EPIC_RESULT=already_terminal" "$rerun_body"
+run_test "rerun_no_close_calls" "" "$(cat "$MOCK_CLOSE_LOG")"
+
+echo ""
+echo "Graduation closeout tests: $PASS_COUNT passed, $FAIL_COUNT failed."
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi

--- a/scripts/development-workflow/tests/test-graduation-closeout.sh
+++ b/scripts/development-workflow/tests/test-graduation-closeout.sh
@@ -100,6 +100,30 @@ JSON
       printf '%s\n' "$MOCK_LABEL_ISSUES"
     fi
     ;;
+  "pr view 77 --json number,state,mergedAt,baseRefName,headRefName")
+    case "${MOCK_GRADUATION_PR_MODE:-merged}" in
+      open)
+        cat <<'JSON'
+{"number":77,"state":"OPEN","mergedAt":null,"baseRefName":"develop","headRefName":"develop-test"}
+JSON
+        ;;
+      wrong_head)
+        cat <<'JSON'
+{"number":77,"state":"MERGED","mergedAt":"2026-07-15T12:00:00Z","baseRefName":"develop","headRefName":"feature/not-graduation"}
+JSON
+        ;;
+      wrong_base)
+        cat <<'JSON'
+{"number":77,"state":"MERGED","mergedAt":"2026-07-15T12:00:00Z","baseRefName":"main","headRefName":"develop-test"}
+JSON
+        ;;
+      *)
+        cat <<'JSON'
+{"number":77,"state":"MERGED","mergedAt":"2026-07-15T12:00:00Z","baseRefName":"develop","headRefName":"develop-test"}
+JSON
+        ;;
+    esac
+    ;;
   "pr list --state merged --base develop-test --limit 1000 --json number,title,body")
     case "${MOCK_PR_MODE:-single_ref}" in
       none)
@@ -216,7 +240,7 @@ set_status() {
 reset_fixture() {
   rm -f "$MOCK_STATE_DIR"/*.json "$MOCK_STATUS_DIR"/* "$MOCK_CLOSE_LOG"
   : > "$MOCK_CLOSE_LOG"
-  unset MOCK_NATIVE_MODE MOCK_LABEL_ISSUES MOCK_PR_MODE MOCK_CLOSE_FAIL_ISSUE MOCK_STATUS_FAIL_ISSUE GITHUB_PROJECT_STATUS_GRADUATED GITHUB_PROJECT_STATUS_MERGED
+  unset MOCK_NATIVE_MODE MOCK_LABEL_ISSUES MOCK_PR_MODE MOCK_GRADUATION_PR_MODE MOCK_CLOSE_FAIL_ISSUE MOCK_STATUS_FAIL_ISSUE GITHUB_PROJECT_STATUS_GRADUATED GITHUB_PROJECT_STATUS_MERGED
 }
 
 run_closeout() {
@@ -235,6 +259,24 @@ last_output_body() {
 last_output_status() {
   head -n 1 <<< "$1"
 }
+
+echo ""
+echo "=== graduation closeout: graduation PR validation ==="
+reset_fixture
+export MOCK_GRADUATION_PR_MODE=open
+export MOCK_NATIVE_MODE=empty
+export MOCK_LABEL_ISSUES="701"
+export MOCK_PR_MODE=none
+write_issue 701 "Should not close" OPEN
+write_issue 900 "Parent epic" OPEN
+set_status 701 "In Development"
+set_status 900 "In Development"
+validation_result="$(run_closeout)"
+validation_body="$(last_output_body "$validation_result")"
+run_test "validation_exit_one" "1" "$(last_output_status "$validation_result")"
+run_contains "validation_reports_unmerged_pr" "has not merged yet" "$validation_body"
+run_test "validation_does_not_close_child" "OPEN" "$(python3 -c 'import json; print(json.load(open("'"$MOCK_STATE_DIR"'/701.json"))["state"])')"
+run_test "validation_no_close_calls" "" "$(cat "$MOCK_CLOSE_LOG")"
 
 echo ""
 echo "=== graduation closeout: native sub-issues and PR refs ==="

--- a/scripts/development-workflow/tests/test-graduation-closeout.sh
+++ b/scripts/development-workflow/tests/test-graduation-closeout.sh
@@ -96,6 +96,10 @@ JSON
     esac
     ;;
   issue\ list\ --label\ integration-branch:test\ --state\ all\ --limit\ 1000\ --json\ number,title,state,labels\ --jq\ .[]\ \|\ .number)
+    if [ "${MOCK_LABEL_MODE:-ok}" = "fail" ]; then
+      printf 'mock label discovery failure\n' >&2
+      exit 47
+    fi
     if [ -n "${MOCK_LABEL_ISSUES:-}" ]; then
       printf '%s\n' "$MOCK_LABEL_ISSUES"
     fi
@@ -244,7 +248,7 @@ set_status() {
 reset_fixture() {
   rm -f "$MOCK_STATE_DIR"/*.json "$MOCK_STATUS_DIR"/* "$MOCK_CLOSE_LOG"
   : > "$MOCK_CLOSE_LOG"
-  unset MOCK_NATIVE_MODE MOCK_LABEL_ISSUES MOCK_PR_MODE MOCK_GRADUATION_PR_MODE MOCK_CLOSE_FAIL_ISSUE MOCK_STATUS_FAIL_ISSUE GITHUB_PROJECT_STATUS_GRADUATED GITHUB_PROJECT_STATUS_MERGED
+  unset MOCK_NATIVE_MODE MOCK_LABEL_MODE MOCK_LABEL_ISSUES MOCK_PR_MODE MOCK_GRADUATION_PR_MODE MOCK_CLOSE_FAIL_ISSUE MOCK_STATUS_FAIL_ISSUE GITHUB_PROJECT_STATUS_GRADUATED GITHUB_PROJECT_STATUS_MERGED
 }
 
 run_closeout() {
@@ -298,6 +302,27 @@ run_contains "pr_discovery_reason" "merged_pr_discovery_failed" "$pr_discovery_b
 run_contains "pr_discovery_epic_held" "EPIC_RESULT=held" "$pr_discovery_body"
 run_test "pr_discovery_child_still_processed" "CLOSED" "$(python3 -c 'import json; print(json.load(open("'"$MOCK_STATE_DIR"'/101.json"))["state"])')"
 run_test "pr_discovery_no_epic_close" "OPEN" "$(python3 -c 'import json; print(json.load(open("'"$MOCK_STATE_DIR"'/900.json"))["state"])')"
+
+reset_fixture
+export MOCK_LABEL_MODE=fail
+export MOCK_PR_MODE=none
+write_issue 101 "Open child" OPEN
+write_issue 102 "Closed nonterminal" CLOSED
+write_issue 103 "Closed terminal" CLOSED
+write_issue 104 "Optional child" OPEN optional
+write_issue 900 "Parent epic" OPEN
+set_status 101 "In Development"
+set_status 102 "Development in Review"
+set_status 103 "Merged"
+set_status 104 "In Development"
+set_status 900 "In Development"
+label_discovery_result="$(run_closeout)"
+label_discovery_body="$(last_output_body "$label_discovery_result")"
+run_test "label_discovery_exit_one" "1" "$(last_output_status "$label_discovery_result")"
+run_contains "label_discovery_reason" "label_fallback_failed" "$label_discovery_body"
+run_contains "label_discovery_epic_held" "EPIC_RESULT=held" "$label_discovery_body"
+run_test "label_discovery_child_still_processed" "CLOSED" "$(python3 -c 'import json; print(json.load(open("'"$MOCK_STATE_DIR"'/101.json"))["state"])')"
+run_test "label_discovery_no_epic_close" "OPEN" "$(python3 -c 'import json; print(json.load(open("'"$MOCK_STATE_DIR"'/900.json"))["state"])')"
 
 echo ""
 echo "=== graduation closeout: graduation PR validation ==="


### PR DESCRIPTION
## Summary
- add `graduation-closeout.sh` to reconcile delivered integration-branch sub-items and parent epics after graduation PR merges
- cover native sub-issue discovery, label fallback, closing-keyword refs, optional skips, partial failures, reruns, and configurable terminal status with mocked shell tests
- update Protocol 05b, command wrappers, GitHub Projects docs, smoke runbook, and changelog

## Tests
- `bash scripts/development-workflow/tests/test-graduation-closeout.sh`
- `bash scripts/development-workflow/tests/test-workflow-lib-github-projects.sh`
- `bash scripts/development-workflow/tests/test-prepare-release-tracker-cleanup.sh`
- `shellcheck scripts/development-workflow/graduation-closeout.sh scripts/development-workflow/tests/test-graduation-closeout.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md" "docs/workflow/development-workflow/integrations/github-projects.md" "docs/workflow/development-workflow/README.md" "docs/testing/workflow/1178-auto-close-integration-branch-subitems-on-graduation.smoke-test.md" "CHANGELOG.md" ".agents/skills/graduate-development/SKILL.md" ".claude/commands/graduate-development.md" ".cursor/commands/graduate-development.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`

Closes #1178

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The script closes issues and updates GitHub Projects via `gh`; mistakes could affect tracker state, but merged-PR validation, fail-closed discovery, explicit exclusions, and mocked tests reduce blast radius.
> 
> **Overview**
> Adds **`graduation-closeout.sh`** so post-merge graduation no longer depends on default-branch auto-close alone: after a merged `develop-<slug>` → `develop` PR, the helper discovers planned work (native sub-issues, `integration-branch:<slug>` label, closing keywords on merged sub-item PRs), closes delivered sub-items, reasserts terminal GitHub Projects status, then closes the epic unless deferred or closeout failed.
> 
> **Protocol 05b** Step 5 and **`/graduate-development`** surfaces (Claude, Cursor, Codex skill) now require running this helper and surfacing `skipped_optional` / `failed` output instead of manually closing the epic first. **BR-8/BR-9** are updated accordingly; **github-projects.md**, workflow README, smoke runbook, and **CHANGELOG** document flags (`--exclude-issue`, `--defer-epic-close`) and env-based terminal status. **`test-graduation-closeout.sh`** mocks `gh` for validation, discovery, parser edge cases, partial failure, and reruns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b25c6fd9223c5e364dcd34247feddbfa1c439a5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->