### PR TITLE
fix(workflow): validate bounded prelude base labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Restore worktree CWD on checkpoint resume** (#1174): Add a resume preflight
   so checkpointed worktree-isolated runs cannot continue from the main clone.
+- **Bounded prelude base selection** (#1204): Require explicit-list
+  integration labels to cover the whole item set and verify shared
+  integration branches before selecting `develop-<slug>`.
 - **Bounded prelude PR lookup**: avoid paginating every historical PR targeting
   `develop` for unlabeled `/run-items` Backlog starts by using targeted
   issue-head PR search before falling back to legacy lookup paths.

--- a/docs/workflow/development-workflow/bounded-run-prelude.md
+++ b/docs/workflow/development-workflow/bounded-run-prelude.md
@@ -59,6 +59,9 @@ Related:
 The JSON output includes:
 
 - `scope` — full resolver payload (`groups`, `items`, `baseBranch`, `policy` flags)
+- `scope.baseReason`, `scope.baseWarnings`, and `scope.baseValidation` — the
+  selected base branch rationale, visible fallback warnings, and read-only
+  remote-branch validation result
 - `guardrails` — repository `guardrails` snapshot (`mode`, `backlog_start`)
 - `policyRecommendation` — same shape as `run-epic-policy-recommender.sh` alone
 - `policyRecommendation.confirmationSummary` — operator-facing summary lines for
@@ -90,6 +93,14 @@ The JSON output includes:
    pending checkpoints.
 5. **Epic-like items** — `run-item-scope-resolver.sh` rejects epic issues; use
    `--epic` instead.
+6. **Explicit-list base selection** — `--items` considers only the listed items.
+   No integration labels resolve to `develop`. Partial or mixed
+   `integration-branch:<slug>` coverage resolves to `develop` with a visible
+   warning. A shared label may resolve to `develop-<slug>` only when the current
+   repository remote confirms that branch exists; missing or unverifiable
+   branches fall back to `develop` with a warning. In workflow-hub mode, product
+   implementation base validation is deferred until the product repository is
+   selected.
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -891,7 +891,15 @@ For each item in the batch, prepare a short handoff:
 - Priority context
 - Parallelization notes or serialization reason
 - `BATCH_CONTEXT=true` — required for parallel batches so the Work Item Runner (protocol 91) activates worktree isolation
-- `BASE_BRANCH=develop-<slug>` — include this field when the item carries an `integration-branch:<slug>` label (see "Integration-branch base override" below). When `BASE_BRANCH` is present in the handoff, the Work Item Runner (protocol 91) **must** use it as the worktree base instead of the default `origin/develop` for all item types (feature, fix, refactor, spec, plan). The base-branch table in protocol 91 Step 3 applies only when `BASE_BRANCH` is absent from the handoff.
+- `BASE_BRANCH=<resolved-base>` — include the bounded-prelude-approved base,
+  normally `develop`. Use `develop-<slug>` only when the explicit-list or epic
+  scope has one shared `integration-branch:<slug>` label and the owning remote
+  branch validation has passed or has been explicitly deferred for a selected
+  product repository. When `BASE_BRANCH` is present in the handoff, the Work
+  Item Runner (protocol 91) **must** use it as the worktree base instead of the
+  default `origin/develop` for all item types (feature, fix, refactor, spec,
+  plan). The base-branch table in protocol 91 Step 3 applies only when
+  `BASE_BRANCH` is absent from the handoff.
 - Each item adds its own CHANGELOG entry as normal (see Step 3.6 for conflict resolution strategy)
 
 ### Worktree isolation requirement
@@ -902,7 +910,21 @@ Do **not** dispatch multiple Work Item Runners to operate in the same working di
 
 ### Integration-branch base override
 
-Before dispatching any Work Item Runner for a sub-item, check whether the item carries an `integration-branch:<slug>` label:
+Before dispatching Work Item Runners for an explicit-list batch, use the
+bounded prelude's resolved base. Do not let one item's
+`integration-branch:<slug>` label select the base for the whole batch.
+
+For explicit-list batches:
+
+- no listed integration labels: use `develop`;
+- partial label coverage: use `develop` and emit the prelude warning;
+- mixed labels: use `develop` and emit the prelude warning;
+- one shared label across every listed item: derive `develop-<slug>` and verify
+  it exists on the owning remote before adopting it;
+- missing or unverifiable `develop-<slug>`: use `develop` and emit the prelude
+  warning.
+
+Before dispatching any Work Item Runner for an epic sub-item, check whether the item carries an `integration-branch:<slug>` label:
 
 ```bash
 gh issue view <issue-number> --json labels --jq '.labels[].name | select(startswith("integration-branch:"))'
@@ -911,16 +933,23 @@ gh issue view <issue-number> --json labels --jq '.labels[].name | select(startsw
 If an `integration-branch:<slug>` label is found:
 
 1. **Derive the integration branch name**: `develop-<slug>`.
-2. **Verify the branch exists on the remote** (output `0` = does not exist, `1` = exists):
+2. **Verify the branch exists on the remote** using
+   `git ls-remote --exit-code --heads`. Exit `0` means the branch exists, exit
+   `2` means it is missing, and any other non-zero status means validation
+   failed:
 
    ```bash
-   BRANCH_EXISTS=$(set -o pipefail; git ls-remote origin "refs/heads/develop-<slug>" 2>/dev/null | wc -l | tr -d ' ') || {
+   set +e
+   git ls-remote --exit-code --heads origin develop-<slug> >/dev/null 2>&1
+   BRANCH_STATUS=$?
+   set -e
+   if [ "$BRANCH_STATUS" -ne 0 ] && [ "$BRANCH_STATUS" -ne 2 ]; then
      echo "WARNING: failed to verify whether develop-<slug> exists on origin; skipping auto-create for this item."
      continue
-   }
+   fi
    ```
 
-3. **If the branch does not exist** (`BRANCH_EXISTS` is `0`), create and push it from `develop`:
+3. **If the branch does not exist** (`BRANCH_STATUS` is `2`), create and push it from `develop`:
 
    ```bash
    git fetch origin develop

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -951,10 +951,11 @@ If an `integration-branch:<slug>` label is found:
 
 3. **If the branch does not exist** (`BRANCH_STATUS` is `2`), create and push it from `develop`:
 
-   ```bash
-   git fetch origin develop
-   git checkout -B develop-<slug> origin/develop
-   git push -u origin develop-<slug>
+	   ```bash
+	   set -euo pipefail
+	   git fetch origin develop
+	   git checkout -B develop-<slug> origin/develop
+	   git push -u origin develop-<slug>
    git switch develop  # return to develop immediately after creation
    ```
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -523,10 +523,11 @@ If the label is present:
 4. **If the branch does not exist** (`BRANCH_STATUS` is `2`), create and push it
    from the owning repository's default implementation branch:
 
-   ```bash
-   OWNING_REPO_ROOT="<current-or-selected-product-repository-root>"
-   OWNING_REMOTE="origin"
-   DEFAULT_IMPLEMENTATION_BRANCH="<default-implementation-branch>"
+	   ```bash
+	   set -euo pipefail
+	   OWNING_REPO_ROOT="<current-or-selected-product-repository-root>"
+	   OWNING_REMOTE="origin"
+	   DEFAULT_IMPLEMENTATION_BRANCH="<default-implementation-branch>"
    git -C "$OWNING_REPO_ROOT" fetch "$OWNING_REMOTE" "$DEFAULT_IMPLEMENTATION_BRANCH"
    git -C "$OWNING_REPO_ROOT" checkout -B develop-<slug> "$OWNING_REMOTE/$DEFAULT_IMPLEMENTATION_BRANCH"
    git -C "$OWNING_REPO_ROOT" push -u "$OWNING_REMOTE" develop-<slug>

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -493,24 +493,34 @@ gh issue view <issue-number> --json labels --jq '.labels[].name | select(startsw
 If the label is present:
 
 1. **Derive the integration branch name**: `develop-<slug>` (replace `<slug>` with the value after `integration-branch:`).
+   When the bounded prelude or portfolio handoff already resolved
+   `BASE_BRANCH=develop` because the label was partial, mixed, missing on the
+   remote, or unverifiable, do not re-adopt `develop-<slug>` silently. Preserve
+   the approved base and report the prelude warning before mutation.
 2. **Resolve the branch owner**. In `single_repo`, the integration branch is
    owned by the current repository. In `workflow_hub`, it is the product
    implementation base and must be checked against the selected product
    repository, not the hub repository. Hub-owned spec and plan artifacts still
    target the hub artifact base branch.
-3. **Verify the branch exists on the owning remote** (output `0` = does not
-   exist, `1` = exists):
+3. **Verify the branch exists on the owning remote** using
+   `git ls-remote --exit-code --heads`. Exit `0` means the branch exists, exit
+   `2` means it is missing, and any other non-zero status means validation
+   failed:
 
    ```bash
    OWNING_REPO_ROOT="<current-or-selected-product-repository-root>"
    OWNING_REMOTE="origin"
-   BRANCH_EXISTS=$(set -o pipefail; git -C "$OWNING_REPO_ROOT" ls-remote "$OWNING_REMOTE" "refs/heads/develop-<slug>" 2>/dev/null | wc -l | tr -d ' ') || {
+   set +e
+   git -C "$OWNING_REPO_ROOT" ls-remote --exit-code --heads "$OWNING_REMOTE" "develop-<slug>" >/dev/null 2>&1
+   BRANCH_STATUS=$?
+   set -e
+   if [ "$BRANCH_STATUS" -ne 0 ] && [ "$BRANCH_STATUS" -ne 2 ]; then
      echo "WARNING: failed to verify whether develop-<slug> exists on the owning remote; skipping auto-create for this item."
      continue  # or return 1 / exit 1 depending on surrounding loop/function context
-   }
+   fi
    ```
 
-4. **If the branch does not exist** (`BRANCH_EXISTS` is `0`), create and push it
+4. **If the branch does not exist** (`BRANCH_STATUS` is `2`), create and push it
    from the owning repository's default implementation branch:
 
    ```bash

--- a/scripts/development-workflow/run-bounded-prelude.sh
+++ b/scripts/development-workflow/run-bounded-prelude.sh
@@ -557,15 +557,28 @@ if ! jq -c \
         "Bounded run policy confirmation"
       end
     ),
-    scopeLines: [
+    scopeLines: ([
       source_line("Scope"; ($scopePayload.scopeSource // .scope.source // "unknown")),
       source_line("Resolved item"; (
         ($resolvedItem | tostring)
         + if ($resolvedTitle // "") == "" then "" else " - " + ($resolvedTitle | tostring) end
       )),
       source_line("Base"; (.effectivePolicy.base // "ambiguous")),
-      source_line("Base source"; (.fieldSources.base // "unknown"))
-    ],
+      source_line("Base source"; (.fieldSources.base // "unknown")),
+      source_line("Base reason"; ($scopePayload.baseReason // .scope.baseReason // "unknown"))
+    ] + [
+      ($scopePayload.baseWarnings // .scope.baseWarnings // [])[]?
+      | source_line("Base warning"; .)
+    ] + [
+      if (($scopePayload.baseValidation // .scope.baseValidation // null) == null) then empty
+      else source_line("Base validation"; (
+        (($scopePayload.baseValidation // .scope.baseValidation).result // "not_applicable")
+        + if ((($scopePayload.baseValidation // .scope.baseValidation).branch // "") == "") then ""
+          else " for " + (($scopePayload.baseValidation // .scope.baseValidation).branch | tostring)
+          end
+      ))
+      end
+    ]),
     policyLines: [
       source_line("May start Backlog"; (bool_text(.effectivePolicy.mayStartBacklog) + " (" + (.fieldSources.mayStartBacklog // "unknown") + ")")),
       source_line("Delegated review"; (bool_text(.effectivePolicy.delegateReview) + " (" + (.fieldSources.delegateReview // "unknown") + ")")),

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -372,6 +372,8 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
       epicNumber: .epicNumber,
       itemInput: .itemInput,
       baseReason: .baseReason,
+      baseWarnings: (.baseWarnings // []),
+      baseValidation: (.baseValidation // {branch: null, result: "not_applicable"}),
       itemCount: (.items | length),
       groups: {
         eligible: ((.groups.eligible // []) | length),

--- a/scripts/development-workflow/run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/run-epic-scope-resolver.sh
@@ -786,6 +786,7 @@ base_validation_branch=""
 
 base_branch=""
 base_reason=""
+set_ambiguous=0
 if [ -n "$base_override" ]; then
   base_branch="$base_override"
   base_reason="supplied --base override"
@@ -828,14 +829,24 @@ elif [ "$integration_count" -eq 1 ]; then
     fi
   fi
 elif [ "$integration_count" -gt 1 ]; then
-  base_branch="develop"
-  base_reason="mixed integration branch labels; falling back to develop"
   base_validation_result="skipped_mixed_labels"
-  base_warnings_json="$(printf '%s\n' "$integration_labels" | jq -R -s -c \
-    'split("\n") | map(select(. != "")) | [("mixed integration branch labels in scope: " + join(", ") + "; using develop")]')"
+  if [ -n "$epic_number" ]; then
+    base_branch=""
+    base_reason="conflicting integration branch labels"
+    set_ambiguous=1
+  else
+    base_branch="develop"
+    base_reason="mixed integration branch labels; falling back to develop"
+    base_warnings_json="$(printf '%s\n' "$integration_labels" | jq -R -s -c \
+      'split("\n") | map(select(. != "")) | [("mixed integration branch labels in scope: " + join(", ") + "; using develop")]')"
+  fi
 else
   base_branch="develop"
   base_reason="no integration branch label"
+fi
+
+if [ "$set_ambiguous" -eq 1 ]; then
+  items_json="$(printf '%s\n' "$items_json" | jq 'map(.group = "ambiguous" | .ambiguityReason = "conflicting integration branch labels")')"
 fi
 
 empty_epic=0

--- a/scripts/development-workflow/run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/run-epic-scope-resolver.sh
@@ -333,6 +333,20 @@ base_branch_cache_file() {
   printf '%s/prs_base_%s.json\n' "$tmp_dir" "$safe"
 }
 
+remote_branch_status() {
+  local branch="$1"
+  local status
+  set +e
+  git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1
+  status=$?
+  set -e
+  case "$status" in
+    0) printf 'exists\n' ;;
+    2) printf 'missing\n' ;;
+    *) printf 'failed\n' ;;
+  esac
+}
+
 fetch_prs_for_base() {
   local branch="$1"
   local cache_file encoded_branch
@@ -764,28 +778,64 @@ items_json="$(jq -s '.' "$items_file")"
 
 integration_labels="$(printf '%s\n' "$items_json" | jq -r '[.[].integrationBranchLabel | select(. != "")] | unique | .[]')"
 integration_count="$(printf '%s\n' "$integration_labels" | sed '/^$/d' | wc -l | tr -d ' ')"
+item_count="$(printf '%s\n' "$items_json" | jq 'length')"
+labeled_item_count="$(printf '%s\n' "$items_json" | jq '[.[] | select((.integrationBranchLabel // "") != "")] | length')"
+base_warnings_json="[]"
+base_validation_result="not_applicable"
+base_validation_branch=""
 
 base_branch=""
 base_reason=""
-set_ambiguous=0
 if [ -n "$base_override" ]; then
   base_branch="$base_override"
   base_reason="supplied --base override"
 elif [ "$integration_count" -eq 1 ]; then
   label="$(printf '%s\n' "$integration_labels" | sed -n '1p')"
-  base_branch="develop-${label#integration-branch:}"
-  base_reason="shared integration branch label ${label}"
+  candidate_branch="develop-${label#integration-branch:}"
+  base_validation_branch="$candidate_branch"
+  if [ "$labeled_item_count" -lt "$item_count" ]; then
+    base_branch="develop"
+    base_reason="partial integration branch label coverage for ${label}; falling back to develop"
+    base_validation_result="skipped_partial_label_coverage"
+    base_warnings_json="$(jq -nc \
+      --arg label "$label" \
+      --argjson labeled "$labeled_item_count" \
+      --argjson total "$item_count" \
+      '[("partial integration branch label " + $label + " applies to " + ($labeled|tostring) + " of " + ($total|tostring) + " items; using develop")]')"
+  elif [ "$base_branch_applies_to" != "current_repository_prs" ]; then
+    base_branch="$candidate_branch"
+    base_reason="shared integration branch label ${label}; branch validation deferred for ${base_branch_applies_to}"
+    base_validation_result="deferred"
+  else
+    base_validation_result="$(remote_branch_status "$candidate_branch")"
+    if [ "$base_validation_result" = "exists" ]; then
+      base_branch="$candidate_branch"
+      base_reason="shared integration branch label ${label}; remote branch verified"
+    elif [ "$base_validation_result" = "missing" ]; then
+      base_branch="develop"
+      base_reason="shared integration branch label ${label} points to missing branch ${candidate_branch}; falling back to develop"
+      base_warnings_json="$(jq -nc \
+        --arg label "$label" \
+        --arg branch "$candidate_branch" \
+        '[("integration branch " + $branch + " from label " + $label + " was not found on origin; using develop")]')"
+    else
+      base_branch="develop"
+      base_reason="could not verify integration branch ${candidate_branch}; falling back to develop"
+      base_warnings_json="$(jq -nc \
+        --arg label "$label" \
+        --arg branch "$candidate_branch" \
+        '[("could not verify integration branch " + $branch + " from label " + $label + "; using develop")]')"
+    fi
+  fi
 elif [ "$integration_count" -gt 1 ]; then
-  base_branch=""
-  base_reason="conflicting integration branch labels"
-  set_ambiguous=1
+  base_branch="develop"
+  base_reason="mixed integration branch labels; falling back to develop"
+  base_validation_result="skipped_mixed_labels"
+  base_warnings_json="$(printf '%s\n' "$integration_labels" | jq -R -s -c \
+    'split("\n") | map(select(. != "")) | [("mixed integration branch labels in scope: " + join(", ") + "; using develop")]')"
 else
   base_branch="develop"
   base_reason="no integration branch label"
-fi
-
-if [ "$set_ambiguous" -eq 1 ]; then
-  items_json="$(printf '%s\n' "$items_json" | jq 'map(.group = "ambiguous" | .ambiguityReason = "conflicting integration branch labels")')"
 fi
 
 empty_epic=0
@@ -797,9 +847,12 @@ summary_json="$(jq -n \
   --arg itemInput "$items_arg" \
   --arg baseBranch "$base_branch" \
   --arg baseReason "$base_reason" \
+  --arg baseValidationResult "$base_validation_result" \
+  --arg baseValidationBranch "$base_validation_branch" \
   --arg workflowMode "$workflow_mode" \
   --arg baseBranchAppliesTo "$base_branch_applies_to" \
   --arg baseBranchValidationNote "$base_branch_validation_note" \
+  --argjson baseWarnings "$base_warnings_json" \
   --argjson delegateReview "$delegate_review" \
   --argjson mayMerge "$may_merge" \
   --arg mayStartBacklog "$may_start_backlog" \
@@ -813,6 +866,11 @@ summary_json="$(jq -n \
     baseBranch: (if $baseBranch == "" then null else $baseBranch end),
     baseAmbiguous: ($baseBranch == ""),
     baseReason: $baseReason,
+    baseWarnings: $baseWarnings,
+    baseValidation: {
+      branch: (if $baseValidationBranch == "" then null else $baseValidationBranch end),
+      result: $baseValidationResult
+    },
     workflowMode: $workflowMode,
     baseBranchAppliesTo: $baseBranchAppliesTo,
     baseBranchValidationNote: $baseBranchValidationNote,
@@ -854,6 +912,7 @@ if [ "$(printf '%s\n' "$summary_json" | jq -r '.emptyEpicScope')" = "true" ]; th
   printf 'Native sub-issues: none resolved for epic #%s\n' "$epic_number"
 fi
 printf 'Base branch: %s (%s)\n' "${base_branch:-ambiguous}" "$base_reason"
+printf '%s\n' "$summary_json" | jq -r '.baseWarnings[]? | "WARNING: " + .'
 printf 'Workflow mode: %s\n' "$workflow_mode"
 printf 'Base applies to: %s\n' "$base_branch_applies_to"
 printf 'Base validation note: %s\n' "$base_branch_validation_note"

--- a/scripts/development-workflow/tests/test-run-bounded-prelude.sh
+++ b/scripts/development-workflow/tests/test-run-bounded-prelude.sh
@@ -61,6 +61,12 @@ run_test "prelude_help" "0" "$( "$PRELUDE" --help >/dev/null; echo 0)"
 run_test "items_resolver_internal_env_set" "yes" "$(
   grep -Fq 'RUN_EPIC_SCOPE_RESOLVER_INTERNAL_ITEMS=1' "$PRELUDE" && echo yes || echo no
 )"
+run_test "confirmation_summary_includes_base_reason" "yes" "$(
+  grep -Fq 'Base reason' "$PRELUDE" && echo yes || echo no
+)"
+run_test "confirmation_summary_includes_base_warning" "yes" "$(
+  grep -Fq 'Base warning' "$PRELUDE" && echo yes || echo no
+)"
 
 run_fails() {
   local name="$1" expected="$2"
@@ -172,6 +178,7 @@ run_test "guardrails_policy_source_reported" "guardrails" "$(printf '%s\n' "$lin
 run_test "guardrails_policy_not_marked_explicit" "false" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.policyRecommendation.confirmationReason | test("policy values are explicit")')"
 run_test "confirmation_summary_exists" "true" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.policyRecommendation.confirmationSummary.title == "Run item policy confirmation"')"
 run_test "confirmation_summary_scope_lines" "true" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.policyRecommendation.confirmationSummary.scopeLines | any(test("Resolved item"))')"
+run_test "confirmation_summary_base_reason_line" "true" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.policyRecommendation.confirmationSummary.scopeLines | any(test("Base reason"))')"
 run_test "confirmation_summary_policy_lines" "true" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.policyRecommendation.confirmationSummary.policyLines | any(test("May start Backlog.*guardrails"))')"
 run_test "confirmation_summary_copy_paste" "true" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.policyRecommendation.confirmationSummary.copyPasteLine | test("/run-item LEA-185")')"
 run_test "confirmation_summary_read_only" "true" "$(printf '%s\n' "$linear_prelude_out" | jq -r '.policyRecommendation.confirmationSummary.readOnlyLine | test("No tracker updates")')"

--- a/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
@@ -14,6 +14,7 @@ MOCK_BIN="$TMP_ROOT/bin"
 CALL_LOG="$TMP_ROOT/gh-calls.log"
 mkdir -p "$MOCK_BIN"
 : > "$CALL_LOG"
+REAL_GIT_PATH="$(command -v git)"
 
 # _config_backup / _config_file track any temporary .ai-dev-workflow.yaml swap
 # made during provider-normalization tests. _harness_exit restores the file on
@@ -140,9 +141,18 @@ JSON
       109) state="CLOSED"; state_reason="NOT_PLANNED"; labels_json='[{"name":"integration-branch:delegated-epic-orchestration"}]' ;;
       110) labels_json='[{"name":"integration-branch:delegated-epic-orchestration"}]' ;;
       111) body='Blocked by #108'; labels_json='[{"name":"integration-branch:delegated-epic-orchestration"}]' ;;
-      113) labels_json='[{"name":"integration-branch:foo"}]' ;;
-      114) labels_json='[]' ;;
-    esac
+	      113) labels_json='[{"name":"integration-branch:foo"}]' ;;
+	      114) labels_json='[]' ;;
+	      115) labels_json='[]' ;;
+	      116) labels_json='[{"name":"integration-branch:stale"}]' ;;
+	      117) labels_json='[{"name":"integration-branch:valid-shared"}]' ;;
+	      118) labels_json='[{"name":"integration-branch:valid-shared"}]' ;;
+	      119) labels_json='[{"name":"integration-branch:alpha"}]' ;;
+	      120) labels_json='[{"name":"integration-branch:beta"}]' ;;
+	      121) labels_json='[{"name":"integration-branch:remote-failure"}]' ;;
+	      122) labels_json='[{"name":"integration-branch:remote-failure"}]' ;;
+	      123) labels_json='[{"name":"integration-branch:stale"}]' ;;
+	    esac
     jq -n \
       --argjson number "$issue_number" \
       --arg title "$title" \
@@ -163,9 +173,18 @@ JSON
       101|102|103|104|107|109|110|111) labels_json='[{"name":"integration-branch:delegated-epic-orchestration"}]' ;;
       105) labels_json='[{"name":"integration-branch:alpha"}]' ;;
       106) labels_json='[{"name":"integration-branch:beta"}]' ;;
-      113) labels_json='[{"name":"integration-branch:foo"}]' ;;
-      114) labels_json='[]' ;;
-    esac
+	      113) labels_json='[{"name":"integration-branch:foo"}]' ;;
+	      114) labels_json='[]' ;;
+	      115) labels_json='[]' ;;
+	      116) labels_json='[{"name":"integration-branch:stale"}]' ;;
+	      117) labels_json='[{"name":"integration-branch:valid-shared"}]' ;;
+	      118) labels_json='[{"name":"integration-branch:valid-shared"}]' ;;
+	      119) labels_json='[{"name":"integration-branch:alpha"}]' ;;
+	      120) labels_json='[{"name":"integration-branch:beta"}]' ;;
+	      121) labels_json='[{"name":"integration-branch:remote-failure"}]' ;;
+	      122) labels_json='[{"name":"integration-branch:remote-failure"}]' ;;
+	      123) labels_json='[{"name":"integration-branch:stale"}]' ;;
+	    esac
     jq -n --argjson labels "$labels_json" '{labels:$labels}'
     ;;
   issue\ view\ *\ --json\ number,title,state)
@@ -237,8 +256,34 @@ esac
 MOCK_GH
 chmod +x "$MOCK_BIN/gh"
 
+cat > "$MOCK_BIN/git" <<'MOCK_GIT'
+#!/usr/bin/env bash
+printf 'git %s\n' "$*" >> "$MOCK_GH_CALL_LOG"
+
+case "$*" in
+  ls-remote\ --exit-code\ --heads\ origin\ develop-delegated-epic-orchestration)
+    printf 'abc123\trefs/heads/develop-delegated-epic-orchestration\n'
+    exit 0
+    ;;
+  ls-remote\ --exit-code\ --heads\ origin\ develop-valid-shared)
+    printf 'abc123\trefs/heads/develop-valid-shared\n'
+    exit 0
+    ;;
+  ls-remote\ --exit-code\ --heads\ origin\ develop-stale)
+    exit 2
+    ;;
+  ls-remote\ --exit-code\ --heads\ origin\ develop-remote-failure)
+    exit 128
+    ;;
+esac
+
+exec "$REAL_GIT_PATH" "$@"
+MOCK_GIT
+chmod +x "$MOCK_BIN/git"
+
 export PATH="$MOCK_BIN:$PATH"
 export MOCK_GH_CALL_LOG="$CALL_LOG"
+export REAL_GIT_PATH
 export GITHUB_PROJECT_OWNER="lhpaul"
 export GITHUB_PROJECT_NUMBER="1"
 
@@ -318,9 +363,34 @@ run_test "base_override_lookup_detects_merged" "105" "$(printf '%s\n' "$override
 run_test "base_override_keeps_remaining_eligible" "106" "$(printf '%s\n' "$override_output" | jq -r '.groups.eligible[0].number')"
 
 ambiguous_output="$(run_json --items 105,106)"
-run_test "conflicting_labels_no_base" "null" "$(printf '%s\n' "$ambiguous_output" | jq -r '.baseBranch')"
-run_test "conflicting_labels_base_ambiguous" "true" "$(printf '%s\n' "$ambiguous_output" | jq -r '.baseAmbiguous')"
-run_test "conflicting_labels_ambiguous" "2" "$(printf '%s\n' "$ambiguous_output" | jq '.groups.ambiguous | length')"
+run_test "conflicting_labels_fall_back_to_develop" "develop" "$(printf '%s\n' "$ambiguous_output" | jq -r '.baseBranch')"
+run_test "conflicting_labels_base_not_ambiguous" "false" "$(printf '%s\n' "$ambiguous_output" | jq -r '.baseAmbiguous')"
+run_test "conflicting_labels_warning" "true" "$(printf '%s\n' "$ambiguous_output" | jq -r '.baseWarnings | any(test("mixed integration branch labels"))')"
+run_test "conflicting_labels_keep_items_eligible" "2" "$(printf '%s\n' "$ambiguous_output" | jq '.groups.eligible | length')"
+
+no_label_output="$(run_json --items 114,115)"
+run_test "explicit_no_label_base_develop" "develop" "$(printf '%s\n' "$no_label_output" | jq -r '.baseBranch')"
+run_test "explicit_no_label_has_no_warning" "0" "$(printf '%s\n' "$no_label_output" | jq '.baseWarnings | length')"
+
+partial_label_output="$(run_json --items 115,116)"
+run_test "partial_label_falls_back_to_develop" "develop" "$(printf '%s\n' "$partial_label_output" | jq -r '.baseBranch')"
+run_test "partial_label_warning" "true" "$(printf '%s\n' "$partial_label_output" | jq -r '.baseWarnings | any(test("partial integration branch label"))')"
+run_test "partial_label_validation_skipped" "skipped_partial_label_coverage" "$(printf '%s\n' "$partial_label_output" | jq -r '.baseValidation.result')"
+
+valid_shared_label_output="$(run_json --items 117,118)"
+run_test "valid_shared_label_uses_integration_base" "develop-valid-shared" "$(printf '%s\n' "$valid_shared_label_output" | jq -r '.baseBranch')"
+run_test "valid_shared_label_validation_exists" "exists" "$(printf '%s\n' "$valid_shared_label_output" | jq -r '.baseValidation.result')"
+run_test "valid_shared_label_reason_reports_validation" "true" "$(printf '%s\n' "$valid_shared_label_output" | jq -r '.baseReason | test("remote branch verified")')"
+
+stale_shared_label_output="$(run_json --items 116,123)"
+run_test "stale_shared_label_falls_back_to_develop" "develop" "$(printf '%s\n' "$stale_shared_label_output" | jq -r '.baseBranch')"
+run_test "stale_shared_label_validation_missing" "missing" "$(printf '%s\n' "$stale_shared_label_output" | jq -r '.baseValidation.result')"
+run_test "stale_shared_label_warning" "true" "$(printf '%s\n' "$stale_shared_label_output" | jq -r '.baseWarnings | any(test("was not found on origin"))')"
+
+remote_failure_output="$(run_json --items 121,122)"
+run_test "remote_failure_falls_back_to_develop" "develop" "$(printf '%s\n' "$remote_failure_output" | jq -r '.baseBranch')"
+run_test "remote_failure_validation_failed" "failed" "$(printf '%s\n' "$remote_failure_output" | jq -r '.baseValidation.result')"
+run_test "remote_failure_warning" "true" "$(printf '%s\n' "$remote_failure_output" | jq -r '.baseWarnings | any(test("could not verify"))')"
 
 dependency_output="$(run_json --items 104)"
 run_test "satisfied_dependency_not_blocked" "eligible" "$(printf '%s\n' "$dependency_output" | jq -r '.items[0].group')"
@@ -400,7 +470,8 @@ run_test "unlabeled_item_uses_scope_shared_base" "112" "$(printf '%s\n' "$unlabe
 
 label_fetch_failure_output="$(MOCK_LABEL_FETCH_FAIL=101 run_json --items 101,112)"
 run_test "label_fetch_failure_keeps_partial_scope" "2" "$(printf '%s\n' "$label_fetch_failure_output" | jq '.items | length')"
-run_test "label_fetch_failure_falls_back_to_full_issue_labels" "develop-delegated-epic-orchestration" "$(printf '%s\n' "$label_fetch_failure_output" | jq -r '.baseBranch')"
+run_test "label_fetch_failure_partial_label_uses_develop" "develop" "$(printf '%s\n' "$label_fetch_failure_output" | jq -r '.baseBranch')"
+run_test "label_fetch_failure_partial_label_warns" "true" "$(printf '%s\n' "$label_fetch_failure_output" | jq -r '.baseWarnings | any(test("partial integration branch label"))')"
 run_test "label_fetch_failure_does_not_poison_unrelated_unlabeled_item" "112" "$(printf '%s\n' "$label_fetch_failure_output" | jq -r '.groups.already_merged[] | select(.number == 112) | .number')"
 run_test "label_fetch_failure_avoids_unrelated_ambiguity" "yes" "$(
   ! printf '%s\n' "$label_fetch_failure_output" | jq -e '.groups.ambiguous[] | select(.number == 112)' >/dev/null &&

--- a/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
+++ b/scripts/development-workflow/tests/test-run-epic-scope-resolver.sh
@@ -104,6 +104,10 @@ JSON
 {"data":{"repository":{"issue":{"number":900,"title":"Epic","subIssues":{"nodes":[{"number":101,"title":"One","state":"OPEN"}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor_page_1"}}}}}}
 JSON
           fi
+        elif [ "${MOCK_EPIC_MODE:-populated}" = "mixed-labels" ]; then
+          cat <<'JSON'
+{"data":{"repository":{"issue":{"number":900,"title":"Epic","subIssues":{"nodes":[{"number":105,"title":"Five","state":"OPEN"},{"number":106,"title":"Six","state":"OPEN"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
         else
           cat <<'JSON'
 {"data":{"repository":{"issue":{"number":900,"title":"Epic","subIssues":{"nodes":[{"number":101,"title":"One","state":"OPEN"},{"number":102,"title":"Two","state":"OPEN"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
@@ -441,6 +445,11 @@ run_test "epic_subissues_resolved" "101,102" "$(printf '%s\n' "$epic_output" | j
 
 paginated_output="$(MOCK_EPIC_MODE=paginated run_json --epic 900)"
 run_test "epic_pagination_resolved" "101,102" "$(printf '%s\n' "$paginated_output" | jq -r '[.items[].number] | join(",")')"
+
+epic_mixed_output="$(MOCK_EPIC_MODE=mixed-labels run_json --epic 900)"
+run_test "epic_mixed_labels_no_base" "null" "$(printf '%s\n' "$epic_mixed_output" | jq -r '.baseBranch')"
+run_test "epic_mixed_labels_base_ambiguous" "true" "$(printf '%s\n' "$epic_mixed_output" | jq -r '.baseAmbiguous')"
+run_test "epic_mixed_labels_mark_items_ambiguous" "2" "$(printf '%s\n' "$epic_mixed_output" | jq '.groups.ambiguous | length')"
 
 empty_output="$(MOCK_EPIC_MODE=empty run_json --epic 900)"
 run_test "empty_epic_reports_scope" "true" "$(printf '%s\n' "$empty_output" | jq -r '.emptyEpicScope')"


### PR DESCRIPTION
## Summary
- require explicit-list integration labels to cover every listed item before selecting an integration base
- verify shared integration branches with `git ls-remote --exit-code --heads` and surface missing/failed validation warnings before mutation
- expose base reason/warnings/validation in bounded prelude summaries and update workflow docs

## Validation
- `bash scripts/development-workflow/tests/test-run-epic-scope-resolver.sh`
- `bash scripts/development-workflow/tests/test-run-bounded-prelude.sh`
- `shellcheck --severity=warning scripts/development-workflow/run-epic-scope-resolver.sh scripts/development-workflow/run-bounded-prelude.sh scripts/development-workflow/run-epic-policy-recommender.sh scripts/development-workflow/tests/test-run-epic-scope-resolver.sh scripts/development-workflow/tests/test-run-bounded-prelude.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/**/*.md" "docs/testing/workflow/1204-bounded-prelude-base-branch-resolver-label-scope.smoke-test.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`

Closes #1204

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default worktree/PR base selection for multi-item runs, which can mis-route work if validation or warnings are ignored; behavior is read-only in the prelude with fallbacks to `develop` and epic mixed-label ambiguity is unchanged.
> 
> **Overview**
> Tightens **how explicit-list `/run-items` scopes pick `BASE_BRANCH`** before batch handoff: integration labels must cover every listed item, mixed or partial label sets fall back to `develop` with warnings instead of ambiguous bases, and a single shared label only becomes `develop-<slug>` after `git ls-remote --exit-code --heads` confirms the branch (or validation is deferred in workflow-hub mode).
> 
> **`run-epic-scope-resolver.sh`** adds `remote_branch_status`, emits `baseWarnings` / `baseValidation` on the scope JSON, and keeps **epic** runs ambiguous when integration labels conflict while **explicit lists** stay on `develop` with visible warnings. **`run-bounded-prelude.sh`** and the policy recommender surface base reason, warnings, and validation in `confirmationSummary`; protocols **90** and **91** require batch dispatch to use the prelude-approved base and block silently re-promoting `develop-<slug>` when the prelude already chose `develop`.
> 
> Docs and harness tests are updated to match the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b06ace049e7cd5df34e1dc75bd7359056f05d503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->