### PR TITLE
docs(plan): incremental commit requirement for dispatch

### DIFF
--- a/docs/specs/developments/20260714170150_1176-incremental-commit-requirement-for-dispatch/2_1176-incremental-commit-requirement-for-dispatch_implementation-plan.md
+++ b/docs/specs/developments/20260714170150_1176-incremental-commit-requirement-for-dispatch/2_1176-incremental-commit-requirement-for-dispatch_implementation-plan.md
@@ -1,0 +1,193 @@
+# Incremental Commit Requirement for Dispatch — Implementation Plan
+
+**Spec**: [1_1176-incremental-commit-requirement-for-dispatch_specs.md](1_1176-incremental-commit-requirement-for-dispatch_specs.md)
+**Smoke test runbook**: [1176-incremental-commit-requirement-for-dispatch.smoke-test.md](../../../testing/workflow/1176-incremental-commit-requirement-for-dispatch.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add an explicit incremental checkpoint-commit requirement to the
+item dispatch contract and mirror it into the runner-facing agent and skill
+surfaces that prepare or receive item handoffs. Recovery guidance will treat the
+latest committed checkpoint, including local commits in an assigned worktree, as
+the preferred resume boundary while preserving the existing review, CI,
+readiness-label, tracker, and merge gates.
+
+**Estimated complexity**: M
+
+**Rationale**: The runtime behavior is documentation and prompt guidance, but it
+crosses multiple workflow surfaces: Protocol 90 batch dispatch, Protocol 91 item
+handoffs and fixer redispatch, Protocol 95 epic dispatch, mirrored Claude/Cursor
+agents, Codex skills, and review guidance. The key risk is contradictory commit
+instructions, especially around fixer agents that currently push only once per
+review cycle.
+
+**Dependencies**: None.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `38829f7` |
+| Template-fit check | Read `.ai-dev-workflow.yaml` and issue #1176 spec | `template.is_template: true`; spec is workflow-tooling guidance and framework-agnostic. |
+| Dispatch and recovery protocol surfaces | `rg -l "Stage-agent handoff branch-skip requirement|Fixer agent worktree isolation rule|For each item in the batch, prepare a short handoff|redispatch / resume|Checkpoint-resume worktree preflight" docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md docs/workflow/development-workflow/protocols/95-run-epic-protocol.md \| sort` | 3 files: Protocols 90, 91, and 95. |
+| Existing incremental-commit language | `rg -n "commit immediately|completed logical sub-part|batch all|end-of-run commit|incremental commit|committed checkpoint|No partial work committed" docs/workflow .claude/agents .cursor/agents .codex/skills .agents/skills REVIEW.md scripts/development-workflow \|\| true` | No existing dispatch requirement; only unrelated release wording and permission-denial "No partial work committed" text. |
+| Worktree/dispatch mirrored surfaces | `rg -l 'BATCH_CONTEXT branch-skip rule|Pre-mutation isolation self-check|Stage-agent handoff branch-skip requirement|Worktree git discipline|Dispatch the matching stage agent|workflow-item-orchestrator|workflow-orchestrator' .claude/agents .cursor/agents .codex/skills .agents/skills \| sort` | Core runner-facing matches include `.claude/agents/developer.md`, `.cursor/agents/developer.md`, `.claude/agents/item-orchestrator.md`, `.cursor/agents/item-orchestrator.md`, `.agents/skills/run-item/SKILL.md`, `.codex/skills/workflow-implementer/SKILL.md`, `.codex/skills/workflow-item-orchestrator/SKILL.md`, and `.codex/skills/workflow-orchestrator/SKILL.md`. |
+| Planning checklist impact search | `grep -rl "02-generate-implementation-plan-protocol\\|03-implement-development-protocol" .claude/agents/ .cursor/agents/ .codex/skills/ \| sort` | 6 files reference planning or implementation protocols: `.claude/agents/developer.md`, `.cursor/agents/developer.md`, `.claude/agents/tech-lead.md`, `.cursor/agents/tech-lead.md`, `.codex/skills/workflow-implementer/SKILL.md`, `.codex/skills/workflow-plan-writer/SKILL.md`. |
+
+---
+
+## Layer-by-Layer Changes
+
+### Workflow Protocols
+
+- [ ] Update `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` so each mutating Work Item Runner handoff for substantial or multi-part work includes an **Incremental commit requirement**:
+  - commit immediately after each completed logical sub-part;
+  - do not intentionally batch all completed sub-parts into one end-of-run commit;
+  - single-step work may still produce one final commit when there is no meaningful completed intermediate checkpoint;
+  - the reason is crash recovery for committed partial progress;
+  - the instruction is scoped to the assigned item, branch, and worktree.
+- [ ] Update `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` in three places:
+  - stage-agent handoff requirements, so creator agents see the same checkpoint-commit instruction before work starts;
+  - fixer-agent handoff requirements, reconciling incremental **local commits** with the existing anti-churn rule that fixer agents should push once per review cycle;
+  - supervision/recovery guidance, so interrupted runs inspect the item branch, local worktree commits, and uncommitted edits before resuming.
+- [ ] Update `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` so epic-scoped item execution passes the same incremental-commit requirement into child item handoffs and recovery language.
+- [ ] Update `docs/workflow/development-workflow/README.md` to summarize incremental commits as a recoverability convention in the orchestrator/runner overview without changing the staged lifecycle.
+- [ ] Update `docs/workflow/development-workflow/protocols/03-implement-development-protocol.md` so direct developer-stage runs understand that multi-part implementation work should create coherent checkpoint commits after completed sub-parts, while broken/incomplete edits must not be committed.
+
+### Agent And Skill Guidance
+
+- [ ] Update dispatcher/runner prompts that prepare item handoffs:
+  - `.claude/agents/orchestrator.md`
+  - `.cursor/agents/orchestrator.md`
+  - `.claude/agents/item-orchestrator.md`
+  - `.cursor/agents/item-orchestrator.md`
+  - `.agents/skills/run-item/SKILL.md`
+  - `.agents/skills/run-items/SKILL.md`
+  - `.agents/skills/run-epic/SKILL.md`
+  - `.codex/skills/workflow-orchestrator/SKILL.md`
+  - `.codex/skills/workflow-item-orchestrator/SKILL.md`
+- [ ] Update stage-agent surfaces that can perform substantial mutating work:
+  - `.claude/agents/product-manager.md`
+  - `.cursor/agents/product-manager.md`
+  - `.claude/agents/tech-lead.md`
+  - `.cursor/agents/tech-lead.md`
+  - `.claude/agents/developer.md`
+  - `.cursor/agents/developer.md`
+  - `.codex/skills/workflow-spec-writer/SKILL.md`
+  - `.codex/skills/workflow-plan-writer/SKILL.md`
+  - `.codex/skills/workflow-implementer/SKILL.md`
+  - `.codex/skills/workflow-spec-writer/agents/openai.yaml`
+  - `.codex/skills/workflow-plan-writer/agents/openai.yaml`
+  - `.codex/skills/workflow-implementer/agents/openai.yaml`
+- [ ] Update compact OpenAI skill prompts where they carry the same dispatch contract:
+  - `.agents/skills/run-item/agents/openai.yaml`
+  - `.agents/skills/run-items/agents/openai.yaml`
+  - `.agents/skills/run-epic/agents/openai.yaml`
+  - `.codex/skills/workflow-orchestrator/agents/openai.yaml`
+  - `.codex/skills/workflow-item-orchestrator/agents/openai.yaml`
+
+### Review Guidance
+
+- [ ] Update `REVIEW.md` for PRs that add or modify item dispatch, stage-agent handoff, or recovery behavior:
+  - reviewers should confirm the incremental commit requirement is visible before mutating item work starts;
+  - reviewers should confirm the guidance does not weaken internal review, automated reviewer loop, CI, readiness labels, tracker transitions, or human merge policy;
+  - reviewers should confirm fixer-agent guidance preserves the push-once reviewer-loop rule while allowing local checkpoint commits.
+
+### Tests And Runbooks
+
+- [ ] Add the smoke test runbook at `docs/testing/workflow/1176-incremental-commit-requirement-for-dispatch.smoke-test.md`.
+- [ ] No database, API, UI, infrastructure, or seed-data changes are required.
+
+---
+
+## Cross-Cutting Guidance Assessment
+
+This change modifies a cross-surface workflow safety convention, not a parser,
+API, or concurrent event source. It does not add a new planning checklist to
+Protocol 02, so Protocol 02 itself does not need a new checklist block. The
+tech-lead and plan-writer receiving-agent prompts still need the concise
+incremental-commit instruction because they can be dispatched for substantial
+plan-stage work.
+
+The implementation must still update all dispatch, receiver, recovery, and
+review surfaces named above. Leaving the requirement only in Protocol 90 would
+not satisfy AC1 or AC8 because stage agents and recovery operators would not
+consistently see it at the point of work.
+
+---
+
+## Testing Strategy
+
+**Test types**: Documentation lint, smoke/manual workflow verification.
+
+**Key scenarios to test**:
+
+1. Batch item dispatch includes the incremental commit requirement before work starts (AC1, AC2, AC3, AC7, AC8).
+2. Stage-agent and fixer handoffs preserve item/worktree scope and do not authorize sibling edits or recovery actions (AC7).
+3. Recovery guidance treats committed checkpoint commits as the preferred resume boundary and treats no newer commit as acceptable evidence when no completed sub-part existed (AC4, AC5).
+4. PR readiness guidance remains unchanged: review, reviewer loop, CI, readiness labels, tracker status, and human merge policy still gate readiness (AC6).
+
+**Smoke test runbook**: `docs/testing/workflow/1176-incremental-commit-requirement-for-dispatch.smoke-test.md`
+
+**Regression suite**: No executable regression suite currently covers these Markdown workflow contracts. The implementation should run markdown lint and the workflow heuristic markdown linter over the changed docs.
+
+---
+
+## Seed Data
+
+No seed data is required.
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` — add the batch-dispatch incremental commit requirement.
+- [ ] `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md` — add stage-agent, fixer-agent, and recovery checkpoint-commit guidance.
+- [ ] `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` — add epic-scoped item handoff and recovery guidance.
+- [ ] `docs/workflow/development-workflow/protocols/03-implement-development-protocol.md` — align direct developer-stage commit guidance with coherent checkpoint commits.
+- [ ] `docs/workflow/development-workflow/README.md` — summarize the recoverability convention in the workflow overview.
+- [ ] `REVIEW.md` — add review checks for dispatch/recovery guidance changes.
+- [ ] Agent and skill files listed in **Agent And Skill Guidance** — mirror the dispatch requirement in every runner-facing and stage-receiving surface.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Fixer-agent guidance conflicts with the existing reviewer-loop push-once rule. | Medium | Medium | Specify that coherent local checkpoint commits are allowed or required for substantial fixer work, but the fixer still pushes once after all addressable fixes for the cycle are complete. |
+| Agents commit broken intermediate states just to satisfy the new requirement. | Medium | Medium | Define a logical sub-part as a coherent checkpoint and explicitly exempt incomplete, failing, or incoherent edits. |
+| The requirement is only added to one protocol and is not visible to receiving agents. | Medium | High | Update Protocols 90/91/95 plus the mirrored orchestrator, item-orchestrator, and developer skill/agent surfaces. Verify with smoke-test searches. |
+| Recovery operators assume commits replace validation. | Low | High | Preserve existing review, reviewer-loop, CI, readiness-label, tracker, and merge gate language in protocols and `REVIEW.md`. |
+
+---
+
+## Code Samples
+
+No production code samples are required. Any implementation snippets should be
+plain Markdown guidance, not executable shell.
+
+---
+
+## Implementation Order
+
+1. Update Protocol 90 batch handoff text to include the incremental checkpoint-commit requirement for mutating item dispatches. Keep the read-only carve-out unchanged.
+2. Update Protocol 91 stage-agent handoff text so every creator-stage handoff carries the requirement with the existing scope and worktree instructions.
+3. Update Protocol 91 fixer-agent text so substantial fixer work may create coherent local checkpoint commits but still pushes once per review cycle after all addressable fixes are complete.
+4. Update Protocol 91 recovery/supervision text so recovery inspects item branch history, local worktree commits, and uncommitted edits before deciding whether to resume from the latest committed checkpoint or treat the absence of a newer checkpoint as evidence that no completed sub-part existed.
+5. Update Protocol 95 epic handoff and recovery text so epic-scoped item agents receive the same requirement before work starts.
+6. Update the mirrored orchestrator and item-orchestrator agent/skill files named in this plan. Keep wording intentionally parallel to the protocol text.
+7. Update stage-receiving guidance in the product-manager, tech-lead, developer, workflow-spec-writer, workflow-plan-writer, and workflow-implementer surfaces listed in **Agent And Skill Guidance**.
+8. Update `REVIEW.md` to add dispatch/recovery review checks and ensure reviewers verify that validation gates remain unchanged.
+9. Update `docs/workflow/development-workflow/README.md` with a short operator-facing overview of the recoverability convention.
+10. Add/update the implementation `CHANGELOG.md` entry under `[Unreleased]` using this literal format:
+    `- **Require incremental checkpoint commits for item dispatch** (#1176): Adds recoverability guidance requiring coherent checkpoint commits after completed logical sub-parts of long-running item work.`
+11. Run documentation verification:
+    - `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
+    - `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
+    - `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
+12. Run the smoke test runbook and confirm all AC-mapped assertions pass.

--- a/docs/testing/workflow/1176-incremental-commit-requirement-for-dispatch.smoke-test.md
+++ b/docs/testing/workflow/1176-incremental-commit-requirement-for-dispatch.smoke-test.md
@@ -1,0 +1,142 @@
+# Smoke Test Runbook: Incremental Commit Requirement for Dispatch
+
+**Feature**: Incremental commit requirement for dispatch
+**Spec**: [1_1176-incremental-commit-requirement-for-dispatch_specs.md](../../specs/developments/20260714170150_1176-incremental-commit-requirement-for-dispatch/1_1176-incremental-commit-requirement-for-dispatch_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] You are on a branch containing the implementation for issue #1176.
+- [ ] The repository has no unrelated uncommitted changes.
+- [ ] Markdown lint dependencies are installed or available through `npx`.
+
+---
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| Long-running item example | A mutating workflow item with multiple coherent sub-parts |
+| Single-step item example | A workflow item with no meaningful intermediate checkpoint |
+| Recovery boundary | Latest committed checkpoint on the item branch or assigned worktree |
+| Preserved gates | Internal review, automated reviewer loop, CI, readiness labels, tracker transitions, human merge policy |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Verify Batch Dispatch Visibility
+
+**Maps to**: AC1, AC2, AC3, AC7, AC8
+
+1. Open `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`.
+2. Find the Work Item Runner handoff section.
+3. Confirm mutating item handoffs require committing immediately after each completed logical sub-part.
+4. Confirm the text says agents must not intentionally batch all completed sub-parts into one end-of-run commit.
+5. Confirm the text exempts truly single-step work with no meaningful completed intermediate checkpoint.
+6. Confirm the text scopes commits to the assigned item, branch, and worktree.
+
+**Expected result**: A receiving Work Item Runner sees the incremental commit requirement before mutating work starts.
+
+### Step 2: Verify Stage-Agent And Fixer Handoffs
+
+**Maps to**: AC1, AC2, AC3, AC6, AC7, AC8
+
+1. Open `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`.
+2. Confirm the stage-agent handoff requirement includes the same incremental commit instruction.
+3. Confirm fixer-agent guidance reconciles local checkpoint commits with the existing rule to push once per review cycle.
+4. Confirm no text permits committing incomplete, failing, or incoherent partial edits.
+5. Confirm no text weakens reviewer-loop, CI, readiness-label, tracker, or merge gates.
+
+**Expected result**: Creator and fixer agents receive consistent commit guidance without changing PR readiness requirements.
+
+### Step 3: Verify Epic-Scoped Dispatch
+
+**Maps to**: AC1, AC2, AC4, AC5, AC7, AC8
+
+1. Open `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md`.
+2. Confirm epic-scoped child item execution passes the incremental commit requirement into item handoffs.
+3. Confirm recovery guidance points operators to committed checkpoints on the item branch or assigned worktree.
+4. Confirm absence of a newer checkpoint is acceptable evidence when no completed sub-part existed after the last checkpoint.
+
+**Expected result**: Epic-scoped runs get the same recoverability behavior as explicit-list and single-item runs.
+
+### Step 4: Verify Mirrored Agent And Skill Surfaces
+
+**Maps to**: AC1, AC2, AC7, AC8
+
+1. Run a repository search for the core phrase:
+
+   ```bash
+   rg -n "completed logical sub-part|incremental commit requirement|checkpoint commit" \
+     docs/workflow/development-workflow/protocols \
+     .claude/agents .cursor/agents .agents/skills .codex/skills REVIEW.md
+   ```
+
+2. Confirm results include the updated orchestrator, item-orchestrator, and developer-facing surfaces named in the implementation plan.
+3. Confirm the mirrored text uses the same core terms: completed logical sub-part, coherent checkpoint, assigned item/branch/worktree, and no end-of-run batching.
+
+**Expected result**: The requirement is not stranded in a single protocol; receiving agents and reviewers can find it.
+
+### Step 5: Verify Recovery And Readiness Gates
+
+**Maps to**: AC4, AC5, AC6
+
+1. Search the changed docs for `reviewer loop`, `CI`, `ready-for-human-review`, and `tracker`.
+2. Confirm incremental commits are described as crash-safety checkpoints only.
+3. Confirm final PR readiness still depends on the normal internal review, automated reviewer loop, CI, readiness labels, tracker transitions, and human merge policy.
+4. Confirm recovery still inspects live branch, PR, and worktree state.
+
+**Expected result**: Incremental commits improve recovery but do not bypass any existing validation or merge gate.
+
+### Step 6: Run Documentation Checks
+
+**Maps to**: AC8
+
+1. Run markdown lint on the changed documentation files.
+2. Run the workflow heuristic Markdown linter.
+3. If the implementation updates `CHANGELOG.md`, run the duplicate-header check.
+
+**Expected result**: Documentation checks pass.
+
+---
+
+## Assertions Checklist
+
+- [ ] Long-running mutating item dispatches require commits after each completed logical sub-part.
+- [ ] Dispatch guidance prohibits batching all completed sub-parts into one end-of-run commit.
+- [ ] Single-step work with no meaningful intermediate checkpoint may still use one final commit.
+- [ ] Recovery operators can inspect item branch or worktree commit history for completed checkpoints.
+- [ ] Absence of a newer checkpoint is acceptable recovery evidence when no completed sub-part existed.
+- [ ] Incremental commits do not change internal review, automated reviewer loop, CI, readiness-label, tracker-transition, or human merge gates.
+- [ ] Concurrent batch and epic-scoped guidance keeps commits and recovery scoped to the assigned item, branch, and worktree.
+- [ ] The requirement is visible in both dispatcher and receiving-agent guidance.
+
+---
+
+## Seed Data Reference
+
+No application seed data is required.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Only Protocol 90 mentions the requirement | Mirrored stage-agent or skill guidance was missed | Update Protocol 91 and the agent/skill surfaces listed in the implementation plan. |
+| Fixer guidance says both "commit per sub-part" and "one commit, then push" without distinction | Local checkpoint commits were not distinguished from reviewer-loop pushes | Clarify that substantial fixer work may create local checkpoint commits but pushes once after all addressable fixes are complete. |
+| Agents could interpret the rule as timer-based commits | The coherent-checkpoint boundary was omitted | Add text that incomplete, failing, or incoherent edits must not be committed just to satisfy a timer. |
+| Recovery guidance ignores unpushed local commits | The worktree recovery surface was missed | Add explicit inspection of local worktree commits and uncommitted edits before resuming. |
+
+---
+
+## Known Limitations
+
+- This runbook validates documentation and prompt surfaces. It does not simulate
+  a killed runner process.


### PR DESCRIPTION
## Summary

Adds the implementation plan and smoke test runbook for issue #1176, covering the incremental checkpoint-commit requirement for long-running item dispatches.

## Plan Scope

- Add dispatcher and receiving-agent guidance so substantial item work commits after each completed logical sub-part.
- Preserve the single-final-commit allowance for truly single-step work.
- Preserve existing review, reviewer-loop, CI, readiness-label, tracker, and human merge gates.
- Reconcile fixer-agent local checkpoint commits with the existing push-once reviewer-loop anti-churn rule.

## Complexity / Risk

Estimated complexity: M. The implementation is documentation and prompt guidance, but it spans Protocols 90/91/95, direct developer-stage guidance, mirrored Claude/Cursor/Codex surfaces, and REVIEW.md.

## Artifacts

- Plan: `docs/specs/developments/20260714170150_1176-incremental-commit-requirement-for-dispatch/2_1176-incremental-commit-requirement-for-dispatch_implementation-plan.md`
- Smoke runbook: `docs/testing/workflow/1176-incremental-commit-requirement-for-dispatch.smoke-test.md`

## Document Quality Gate

- Spec/brief coverage: Checked - all ACs map to implementation steps and smoke-test assertions.
- Implementation-order consistency: Checked - protocol, agent, skill, review, README, and CHANGELOG steps agree with the file lists.
- Verification support: Checked - broad file-surface claims cite live Verification Log searches.
- Behavioral guarantees: Checked - coherent checkpoint, local worktree commit, push-once fixer behavior, and unchanged readiness gates name their enforcing guidance.
- Parser/API/concurrency checklist: Not applicable - no parser, API-surface, snapshot, or concurrent-event-source implementation is introduced by this plan.
- Cross-cutting guidance: Checked - dispatch, receiver, recovery, and review surfaces are explicitly enumerated.
- CHANGELOG literal format: Checked - implementation step uses the required `**Bold Title** (#1176):` format.

## Validation

- `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`
- `./scripts/development-workflow/run-nested-artifact-guard.sh --mode pre-pr --issue 1176 --expected-branch implementation-plan/1176-incremental-commit-requirement-for-dispatch --approved-base develop`

Related to #1176.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime, API, or auth changes; follow-on PRs that apply the plan carry the main risk of inconsistent commit guidance across surfaces.
> 
> **Overview**
> Adds **planning artifacts only** for issue #1176: an implementation plan and a workflow smoke-test runbook. This PR does not change protocols, agents, skills, or `REVIEW.md` yet.
> 
> The plan defines how a future implementation will require **incremental checkpoint commits** after each completed logical sub-part on long-running item dispatches, scoped to the assigned item/branch/worktree, while allowing a single final commit for truly single-step work. It schedules updates across Protocols **90/91/95**, developer protocol **03**, workflow **README**, mirrored orchestrator/item-orchestrator/stage-agent surfaces, and **REVIEW.md**, plus recovery that resumes from the latest committed checkpoint (including local worktree commits) without weakening review, CI, readiness labels, tracker, or merge gates. It also calls out reconciling **fixer** local checkpoint commits with the existing **push-once-per-review-cycle** rule.
> 
> The new smoke runbook maps acceptance criteria to manual checks (dispatch visibility, stage/fixer/epic handoffs, mirrored surfaces via `rg`, preserved readiness gates, and markdown lint commands) and includes troubleshooting for common wording gaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78ad7f096ede94d93420209ed82b53171bab8ab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->