### PR TITLE
feat(workflow): add spec dispatch relationship context

### DIFF
--- a/.agents/skills/run-item/SKILL.md
+++ b/.agents/skills/run-item/SKILL.md
@@ -43,8 +43,11 @@ advances exactly one non-epic item through Protocol 91.
    Stop on `missing_base`, `blocked_duplicate`, `wrong_base`, or `scan_failed`;
    explicit split work requires parent approval and `--allow-split true`.
 7. Before dispatching a Backlog item into Writing Spec, run or consume
-   `scripts/development-workflow/spec-dispatch-context.sh`. Pass non-blocking
-   confirmed decisions and relationship outcomes to the spec writer; stop on
+   `scripts/development-workflow/spec-dispatch-context.sh`. For direct
+   single-item runs, pass the selected item plus relevant in-scope Backlog peers
+   from the current tracker scan in `--items`; a selected-only scope may collect
+   decisions but cannot classify peer relationships. Pass non-blocking confirmed
+   decisions and relationship outcomes to the spec writer; stop on
    `blocking=true` and report the helper's `humanAction`. Shared keywords alone
    are not dependency evidence.
 8. **Guardrails enforcement**: Use portfolio-resolved guardrails from handoff when

--- a/.agents/skills/run-item/SKILL.md
+++ b/.agents/skills/run-item/SKILL.md
@@ -42,7 +42,12 @@ advances exactly one non-epic item through Protocol 91.
    artifact-owning repo root (`--repo-root "$ARTIFACT_REPO_ROOT"`).
    Stop on `missing_base`, `blocked_duplicate`, `wrong_base`, or `scan_failed`;
    explicit split work requires parent approval and `--allow-split true`.
-7. **Guardrails enforcement**: Use portfolio-resolved guardrails from handoff when
+7. Before dispatching a Backlog item into Writing Spec, run or consume
+   `scripts/development-workflow/spec-dispatch-context.sh`. Pass non-blocking
+   confirmed decisions and relationship outcomes to the spec writer; stop on
+   `blocking=true` and report the helper's `humanAction`. Shared keywords alone
+   are not dependency evidence.
+8. **Guardrails enforcement**: Use portfolio-resolved guardrails from handoff when
    available; otherwise resolve from repo `guardrails` config. Report effective
    values before mutation. Enforce gates per
    `docs/workflow/development-workflow/guardrails-enforcement.md` section 3.
@@ -54,11 +59,11 @@ advances exactly one non-epic item through Protocol 91.
    items, run Protocol 91's residual gate before `ready-for-human-review`; block
    or escalate instead of reporting terminal when residual evidence is missing or
    incomplete.
-8. For `spec/*` and `implementation-plan/*` PRs, run Protocol 91 Step 8a's
+9. For `spec/*` and `implementation-plan/*` PRs, run Protocol 91 Step 8a's
    documentation-stage alignment checker before readiness; correct or escalate
    mismatches instead of applying `ready-for-human-review`.
-9. Epic-like targets must use `$run-epic` / `/run-epic`, not this command.
-10. When the delegated merge gate returns `merge_allowed`, continue through merge,
+10. Epic-like targets must use `$run-epic` / `/run-epic`, not this command.
+11. When the delegated merge gate returns `merge_allowed`, continue through merge,
    remote/local branch cleanup, `post-merge-cleanup.sh`, and live tracker
    verification before reporting the item terminal. Do not stop at
    `ready-for-human-review` in a delegated merge run.
@@ -66,7 +71,7 @@ advances exactly one non-epic item through Protocol 91.
    intermediate; `merge_denied` means the ready PR stops as
    `ready_human_merge` and no merge command is run. A merge-granted run that
    stops at readiness without a named blocker is `policy_inconsistent`.
-11. Before reporting any terminal state, run
+12. Before reporting any terminal state, run
     `scripts/development-workflow/item-completion-self-check.sh` for the claimed
     state and include its `## Ground-Truth Completion Verification` section in
     the Work Item Runner Summary. Treat `discrepancy` and

--- a/.agents/skills/run-items/SKILL.md
+++ b/.agents/skills/run-items/SKILL.md
@@ -28,17 +28,23 @@ proposal step.
 5. Read `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
    and follow it in `explicit_list` mode with the supplied targets as the hard
    bounded scope.
-6. Target `develop` directly; `/run-items` does not create or target
+6. Before dispatching any Backlog item into Writing Spec, run
+   `scripts/development-workflow/spec-dispatch-context.sh` for the selected
+   item and explicit item list. Pass non-blocking confirmed decisions and
+   relationship outcomes to the item/spec handoff; stop on `blocking=true` and
+   report the helper's `humanAction`. Shared keywords alone are not dependency
+   evidence.
+7. Target `develop` directly; `/run-items` does not create or target
    `develop-<slug>` integration branches.
-7. Before implementation mutation in `workflow_hub`, state the selected product
+8. Before implementation mutation in `workflow_hub`, state the selected product
    repository, artifact owner, and mutation target; stop when context is missing
    or ambiguous.
-8. For each in-scope item, pass the approved base and artifact-owning repo root
+9. For each in-scope item, pass the approved base and artifact-owning repo root
    to branch and PR creation paths and require
    `run-nested-artifact-guard.sh --repo-root "$ARTIFACT_REPO_ROOT"` before mutation. Stop on
    `missing_base`, `blocked_duplicate`, `wrong_base`, or `scan_failed` instead
    of widening scope or inferring a base.
-9. Before dispatching an explicit-list batch where any runner may mutate,
+10. Before dispatching an explicit-list batch where any runner may mutate,
    including sequential fallback, build the Protocol 90 isolation manifest and
    require a distinct absolute worktree path plus `isolation: "worktree"` for
    every mutating item. Stop before dispatch on missing isolation assignment or
@@ -50,9 +56,9 @@ proposal step.
    logical sub-part, do not intentionally batch all completed sub-parts into one
    final commit, and never commit incomplete or failing work only to satisfy the
    rule.
-10. Do not stop after advancing one item if another item in the explicit list still
+11. Do not stop after advancing one item if another item in the explicit list still
    has a deterministic next action.
-11. Do not stop at transient in-flight CI/watch states. If a local watch exits
+12. Do not stop at transient in-flight CI/watch states. If a local watch exits
    early, duplicate checks are skipped/cancelled, or GitHub still shows pending
    or incomplete check evidence, re-query authoritative PR/check state and keep
    supervising until every in-scope PR is green, blocked, escalated, merged, or
@@ -60,15 +66,15 @@ proposal step.
    For sweep, batch, helper-extraction, numeric-target, or pattern-completeness
    items, require residual gate evidence before accepting an item as
    `ready-for-human-review`.
-12. For `spec/*` and `implementation-plan/*` PRs, require Protocol 91 Step 8a's
+13. For `spec/*` and `implementation-plan/*` PRs, require Protocol 91 Step 8a's
    documentation-stage alignment checker before accepting readiness. A
    mismatch keeps the item under supervision until corrected or escalated.
-13. Before accepting any in-scope item as terminal, require the item runner's
+14. Before accepting any in-scope item as terminal, require the item runner's
    `## Ground-Truth Completion Verification` output from
    `item-completion-self-check.sh` or run the helper directly from current
    artifact state. Missing self-check evidence, `discrepancy`, or
    `unavailable_required` keeps the item under Protocol 90 Step 5 supervision.
-14. After all in-scope PRs reach `ready-for-human-review`, inspect the effective
+15. After all in-scope PRs reach `ready-for-human-review`, inspect the effective
    guardrails. When the relevant stages allow `may_merge_pr: true`, run
    Guardrails Enforcement Gate 5 for each in-scope PR, including
    `run-epic-risk-classifier.sh` and `run-epic-delegated-gate.sh`; continue only
@@ -89,7 +95,7 @@ proposal step.
    `out_of_scope`. A `merge_granted` PR that stops at readiness without a
    named blocker is `policy_inconsistent`; a `merge_denied` PR stops at
    `ready_human_merge`.
-15. For single-item advancement use `$run-item`; for epic-scoped runs use `$run-epic`;
+16. For single-item advancement use `$run-item`; for epic-scoped runs use `$run-epic`;
    for read-only portfolio scan and proposal use `$run-work`.
 
 > **Deprecation notice**: `/run-epic --items` is deprecated. Use `/run-items` for

--- a/.claude/agents/item-orchestrator.md
+++ b/.claude/agents/item-orchestrator.md
@@ -63,6 +63,11 @@ That document is the single source of truth for this supporting role. Key respon
 
 - Stay scoped to one item at a time
 - Use `workflow-next-action.sh` to determine the next deterministic action for the selected development folder, branch, or PR
+- Before dispatching a Backlog item into Writing Spec, run or consume
+  `scripts/development-workflow/spec-dispatch-context.sh`. Pass non-blocking
+  confirmed decisions and relationship outcomes to the spec writer; stop on
+  `blocking=true` and report the helper's `humanAction`. Shared keywords alone
+  are not dependency evidence.
 - Dispatch the matching stage agent when the runner supports it; otherwise continue in the current context using the referenced protocol
 - Run reviewer gate, PR readiness, automated review, and CI until the item is actually waiting on a human, blocked, or escalated
 - For sweep, batch, helper-extraction, numeric-target, or pattern-completeness

--- a/.claude/agents/item-orchestrator.md
+++ b/.claude/agents/item-orchestrator.md
@@ -64,8 +64,11 @@ That document is the single source of truth for this supporting role. Key respon
 - Stay scoped to one item at a time
 - Use `workflow-next-action.sh` to determine the next deterministic action for the selected development folder, branch, or PR
 - Before dispatching a Backlog item into Writing Spec, run or consume
-  `scripts/development-workflow/spec-dispatch-context.sh`. Pass non-blocking
-  confirmed decisions and relationship outcomes to the spec writer; stop on
+  `scripts/development-workflow/spec-dispatch-context.sh`. For direct
+  single-item runs, pass the selected item plus relevant in-scope Backlog peers
+  from the current tracker scan in `--items`; a selected-only scope may collect
+  decisions but cannot classify peer relationships. Pass non-blocking confirmed
+  decisions and relationship outcomes to the spec writer; stop on
   `blocking=true` and report the helper's `humanAction`. Shared keywords alone
   are not dependency evidence.
 - Dispatch the matching stage agent when the runner supports it; otherwise continue in the current context using the referenced protocol

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -51,6 +51,11 @@ That document is the single source of truth for this supporting role. Key respon
 
 - Read current state from the issue tracker (if configured) and/or `docs/specs/developments/`
 - Determine what can safely advance and which Backlog items should be proposed to start, respecting dependencies
+- Before dispatching any Backlog item into Writing Spec, run
+  `scripts/development-workflow/spec-dispatch-context.sh` for the selected item
+  and in-scope batch. Pass non-blocking confirmed decisions and relationship
+  outcomes to the item/spec handoff; stop on `blocking=true` and report the
+  helper's `humanAction`. Shared keywords alone are not dependency evidence.
 - Prioritize by due date (within 2 weeks) → priority → creation date
 - Build the largest safe explicit batch possible and document when work must be serialized
 - Before dispatching an explicit-list batch where any runner may mutate,

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -41,6 +41,14 @@ PRs, or scan failures.
 
 That document is the single source of truth for this stage. Do not skip the alignment conversation. Once ambiguity is resolved, continue through reviewer gate, PR creation, and PR readiness unless the protocol requires human input.
 
+When the handoff includes output from
+`scripts/development-workflow/spec-dispatch-context.sh`, read it before the
+alignment conversation. Preserve confirmed decisions and non-blocking
+relationship outcomes as product constraints. Do not turn helper mechanics,
+token matching, JSON fields, or implementation algorithms into spec
+requirements. If context is `blocking=true` or `Unclear`, stop for the named
+human relationship decision.
+
 Before opening the draft PR, complete protocol 01's Document Quality Gate and include the gate log in the PR description. For tracker-backed items, follow protocol 01's Brief Objective List, Coverage Matrix, and Deferral Note requirements as part of that gate.
 
 Before updating tracker status as part of a standalone spec completion sequence, call `ensure_on_project_board <issue_number> "Writing Spec"` (from `scripts/development-workflow/workflow-lib.sh`) to register the issue on the project board if it is not already present.

--- a/.codex/skills/workflow-item-orchestrator/SKILL.md
+++ b/.codex/skills/workflow-item-orchestrator/SKILL.md
@@ -38,15 +38,20 @@ Recommended model tier: `balanced`
 11. **Main-tree return rule (BATCH_CONTEXT=false / no worktree isolation)**: When dispatched WITHOUT worktree isolation (`BATCH_CONTEXT` is `false` or absent), this skill runs in the main working tree. Before emitting the Work Item Runner Summary and returning, switch the main working tree back to the integration branch (`git switch develop`, or whichever branch `integration_branch` specifies in `.ai-dev-workflow.yaml`). Verify with `git rev-parse --abbrev-ref HEAD`. If uncommitted changes block the switch, commit or stash first. Omitting this return step causes Protocol 90 Step 5.2 to fire "wrong branch + clean" auto-correct on every subsequent item.
 12. Before implementation mutation in `workflow_hub`, state the selected product repository, local path or remote identity, artifact owner, and mutation target. Stop before file edits, branch creation, commits, or implementation PR creation when product repository context is missing or ambiguous. Specs and plans remain hub-owned unless a later protocol says otherwise.
 13. Before dispatching a stage path that may create a branch or open a PR, pass the expected branch, expected worktree when known, approved base, and artifact-owning repo root. Run `run-nested-artifact-guard.sh --repo-root "$ARTIFACT_REPO_ROOT"` before mutation and stop on `missing_base`, `blocked_duplicate`, `wrong_base`, or `scan_failed`.
-14. **Guardrails enforcement**: At item-run start, use portfolio-resolved guardrails from handoff metadata when available; otherwise resolve from repo `guardrails` config. Report effective values before mutation. Enforce per-stage PR-open, delegated review, delegated merge, and completion gates per `docs/workflow/development-workflow/guardrails-enforcement.md` section 3. When no `guardrails` section is found, apply conservative defaults and state them. When the delegated merge gate returns `merge_allowed`, continue through merge, branch cleanup, `post-merge-cleanup.sh`, and live tracker verification before reporting the item terminal. Treat merge authority explicitly: `merge_granted` means readiness is intermediate; `merge_denied` means the ready PR stops as `ready_human_merge` and no merge command is run. A merge-granted run that stops at readiness without a named blocker is `policy_inconsistent`.
-15. For sweep, batch, helper-extraction, numeric-target, or pattern-completeness
+14. Before dispatching a Backlog item into Writing Spec, run or consume
+    `scripts/development-workflow/spec-dispatch-context.sh`. Pass non-blocking
+    confirmed decisions and relationship outcomes to the spec writer; stop on
+    `blocking=true` and report the helper's `humanAction`. Shared keywords alone
+    are not dependency evidence.
+15. **Guardrails enforcement**: At item-run start, use portfolio-resolved guardrails from handoff metadata when available; otherwise resolve from repo `guardrails` config. Report effective values before mutation. Enforce per-stage PR-open, delegated review, delegated merge, and completion gates per `docs/workflow/development-workflow/guardrails-enforcement.md` section 3. When no `guardrails` section is found, apply conservative defaults and state them. When the delegated merge gate returns `merge_allowed`, continue through merge, branch cleanup, `post-merge-cleanup.sh`, and live tracker verification before reporting the item terminal. Treat merge authority explicitly: `merge_granted` means readiness is intermediate; `merge_denied` means the ready PR stops as `ready_human_merge` and no merge command is run. A merge-granted run that stops at readiness without a named blocker is `policy_inconsistent`.
+16. For sweep, batch, helper-extraction, numeric-target, or pattern-completeness
     items, run `scope-residual-gate.sh` before readiness and treat `block` or
     `escalate` as non-terminal.
-16. For `spec/*` and `implementation-plan/*` PRs, run Protocol 91 Step 8a's
+17. For `spec/*` and `implementation-plan/*` PRs, run Protocol 91 Step 8a's
     documentation-stage alignment checker before readiness. Include the
     alignment result in the runner summary when readiness is blocked; correct
     or escalate mismatches instead of applying `ready-for-human-review`.
-17. Before any terminal Work Item Runner Summary (`ready`, `done`, `blocked`,
+18. Before any terminal Work Item Runner Summary (`ready`, `done`, `blocked`,
     `escalated`, waiting on human, waiting on merge, or cleanup complete), run
     `scripts/development-workflow/item-completion-self-check.sh` for the claimed
     state and paste its `## Ground-Truth Completion Verification` section into

--- a/.codex/skills/workflow-item-orchestrator/SKILL.md
+++ b/.codex/skills/workflow-item-orchestrator/SKILL.md
@@ -39,8 +39,11 @@ Recommended model tier: `balanced`
 12. Before implementation mutation in `workflow_hub`, state the selected product repository, local path or remote identity, artifact owner, and mutation target. Stop before file edits, branch creation, commits, or implementation PR creation when product repository context is missing or ambiguous. Specs and plans remain hub-owned unless a later protocol says otherwise.
 13. Before dispatching a stage path that may create a branch or open a PR, pass the expected branch, expected worktree when known, approved base, and artifact-owning repo root. Run `run-nested-artifact-guard.sh --repo-root "$ARTIFACT_REPO_ROOT"` before mutation and stop on `missing_base`, `blocked_duplicate`, `wrong_base`, or `scan_failed`.
 14. Before dispatching a Backlog item into Writing Spec, run or consume
-    `scripts/development-workflow/spec-dispatch-context.sh`. Pass non-blocking
-    confirmed decisions and relationship outcomes to the spec writer; stop on
+    `scripts/development-workflow/spec-dispatch-context.sh`. For direct
+    single-item runs, pass the selected item plus relevant in-scope Backlog peers
+    from the current tracker scan in `--items`; a selected-only scope may collect
+    decisions but cannot classify peer relationships. Pass non-blocking confirmed
+    decisions and relationship outcomes to the spec writer; stop on
     `blocking=true` and report the helper's `humanAction`. Shared keywords alone
     are not dependency evidence.
 15. **Guardrails enforcement**: At item-run start, use portfolio-resolved guardrails from handoff metadata when available; otherwise resolve from repo `guardrails` config. Report effective values before mutation. Enforce per-stage PR-open, delegated review, delegated merge, and completion gates per `docs/workflow/development-workflow/guardrails-enforcement.md` section 3. When no `guardrails` section is found, apply conservative defaults and state them. When the delegated merge gate returns `merge_allowed`, continue through merge, branch cleanup, `post-merge-cleanup.sh`, and live tracker verification before reporting the item terminal. Treat merge authority explicitly: `merge_granted` means readiness is intermediate; `merge_denied` means the ready PR stops as `ready_human_merge` and no merge command is run. A merge-granted run that stops at readiness without a named blocker is `policy_inconsistent`.

--- a/.codex/skills/workflow-orchestrator/SKILL.md
+++ b/.codex/skills/workflow-orchestrator/SKILL.md
@@ -12,29 +12,30 @@ Recommended model tier: `economy`
 3. Prefer the helper scripts in `scripts/development-workflow/` for state discovery, batch planning, next-action classification, resume behavior, CI polling, and automated review polling before using ad hoc shell commands.
 4. Treat the protocol as canonical. Use `workflow-item-orchestrator` for each selected or approved item when your runner supports skill-to-skill handoff; otherwise continue in the current session by following `91-orchestrate-work-protocol.md` item by item.
 5. Keep batching and prioritization decisions explicit, especially when work must be serialized because the runner cannot execute multiple item orchestrators concurrently.
-6. Before dispatching an explicit-list batch where any runner may mutate, including sequential fallback, build the Protocol 90 isolation manifest and require a distinct absolute worktree path plus `isolation: "worktree"` for every mutating item. Stop before dispatch on missing isolation assignment or duplicate worktree path; non-isolated runners are allowed only when explicitly classified `read_only` and will not edit files, switch branches, commit, push, mutate PRs, change labels, or update tracker state.
-7. Include the incremental commit requirement in every substantial or
+6. Before dispatching any Backlog item into Writing Spec, run `scripts/development-workflow/spec-dispatch-context.sh` for the selected item and in-scope batch. Pass non-blocking confirmed decisions and relationship outcomes to the item/spec handoff; stop on `blocking=true` and report the helper's `humanAction`. Shared keywords alone are not dependency evidence.
+7. Before dispatching an explicit-list batch where any runner may mutate, including sequential fallback, build the Protocol 90 isolation manifest and require a distinct absolute worktree path plus `isolation: "worktree"` for every mutating item. Stop before dispatch on missing isolation assignment or duplicate worktree path; non-isolated runners are allowed only when explicitly classified `read_only` and will not edit files, switch branches, commit, push, mutate PRs, change labels, or update tracker state.
+8. Include the incremental commit requirement in every substantial or
    multi-part mutating item handoff: commit immediately after each completed
    logical sub-part, do not intentionally batch all completed sub-parts into one
    final commit, and never commit incomplete or failing work only to satisfy the
    rule.
-8. Do not stop after dispatching a batch if any selected or approved item still has a deterministic next action.
-9. For `workflow_hub` implementation work, include workflow mode, artifact owner, selected product repository, local path or remote identity, and mutation target in item handoffs; stop before mutation-oriented dispatch when product repository context is missing or ambiguous. Missing mode or `single_repo` does not require `--repo`.
+9. Do not stop after dispatching a batch if any selected or approved item still has a deterministic next action.
+10. For `workflow_hub` implementation work, include workflow mode, artifact owner, selected product repository, local path or remote identity, and mutation target in item handoffs; stop before mutation-oriented dispatch when product repository context is missing or ambiguous. Missing mode or `single_repo` does not require `--repo`.
    Include the parent-approved base branch in mutation-oriented handoffs; child runners must use it with `run-nested-artifact-guard.sh --approved-base` before branch or PR creation.
-10. **Guardrails enforcement**: Before any artifact-mutating action, resolve the effective guardrails (three-layer precedence: repo config → session overrides → invocation overrides) and report them in the portfolio run summary. Enforce the six gates described in `docs/workflow/development-workflow/guardrails-enforcement.md`: load+report at run start, backlog-start gate, per-stage PR-open gate, delegated review gate, delegated merge gate, and completion gate. When no `guardrails` section is found, state "conservative defaults in effect."
-11. With `merge_granted`, readiness is not terminal; continue through delegated
+11. **Guardrails enforcement**: Before any artifact-mutating action, resolve the effective guardrails (three-layer precedence: repo config → session overrides → invocation overrides) and report them in the portfolio run summary. Enforce the six gates described in `docs/workflow/development-workflow/guardrails-enforcement.md`: load+report at run start, backlog-start gate, per-stage PR-open gate, delegated review gate, delegated merge gate, and completion gate. When no `guardrails` section is found, state "conservative defaults in effect."
+12. With `merge_granted`, readiness is not terminal; continue through delegated
    merge and report each in-scope PR as `merged`, `merge_blocked`, or
    `policy_inconsistent`. With `merge_denied`, ready PRs report
    `ready_human_merge`. Discovered unrelated PRs are `out_of_scope` and are not
    merged.
-12. When supervising sweep, batch, helper-extraction, numeric-target, or
+13. When supervising sweep, batch, helper-extraction, numeric-target, or
    pattern-completeness items, require residual gate evidence before accepting
    `ready-for-human-review` as terminal.
-13. When supervising `spec/*` or `implementation-plan/*` PRs, require Protocol
+14. When supervising `spec/*` or `implementation-plan/*` PRs, require Protocol
     91 Step 8a's documentation-stage alignment checker before accepting
     readiness. A mismatch keeps the item under supervision until corrected or
     escalated.
-14. Before accepting any item as terminal in a batch summary, require the
+15. Before accepting any item as terminal in a batch summary, require the
     Work Item Runner's `## Ground-Truth Completion Verification` section from
     `scripts/development-workflow/item-completion-self-check.sh` or run the
     helper directly from current artifact state. Do not declare the batch item

--- a/.codex/skills/workflow-spec-writer/SKILL.md
+++ b/.codex/skills/workflow-spec-writer/SKILL.md
@@ -11,16 +11,23 @@ Recommended model tier: `premium`
 2. Read `docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md`.
 3. Follow that protocol exactly.
 4. Keep the spec product-focused; implementation details belong in the plan stage.
-5. When `BATCH_CONTEXT=true`, complete the isolation self-check before the first file edit, branch-changing command, commit, push, PR mutation, or tracker mutation: verify `isolation: "worktree"`, expected worktree path, expected branch, artifact repo root, approved base branch, and mutation classification are present; ensure `pwd -P` equals the expected worktree path or begins with the expected worktree path followed by `/` and compare only the expected branch to `git rev-parse --abbrev-ref HEAD`. Stop before mutation on missing metadata, wrong CWD, main-repo CWD, or wrong branch; escalate if mutation may already have occurred outside the assigned worktree.
-6. For substantial or multi-part mutating spec work, commit immediately after
+5. When the handoff includes output from
+   `scripts/development-workflow/spec-dispatch-context.sh`, read it before the
+   alignment conversation. Preserve confirmed decisions and non-blocking
+   relationship outcomes as product constraints. Do not turn helper mechanics,
+   token matching, JSON fields, or implementation algorithms into spec
+   requirements. If context is `blocking=true` or `Unclear`, stop for the named
+   human relationship decision.
+6. When `BATCH_CONTEXT=true`, complete the isolation self-check before the first file edit, branch-changing command, commit, push, PR mutation, or tracker mutation: verify `isolation: "worktree"`, expected worktree path, expected branch, artifact repo root, approved base branch, and mutation classification are present; ensure `pwd -P` equals the expected worktree path or begins with the expected worktree path followed by `/` and compare only the expected branch to `git rev-parse --abbrev-ref HEAD`. Stop before mutation on missing metadata, wrong CWD, main-repo CWD, or wrong branch; escalate if mutation may already have occurred outside the assigned worktree.
+7. For substantial or multi-part mutating spec work, commit immediately after
    each completed logical sub-part, do not intentionally batch all completed
    sub-parts into one end-of-run commit, and never commit incomplete, failing,
    or incoherent edits only to satisfy the requirement.
-7. Before opening the draft spec PR, complete Protocol 01's Document Quality Gate and include the gate log in the PR description. For tracker-backed briefs, include the mandatory Brief Objective List, Coverage Matrix, and PR-visible Deferral Notes as part of that gate.
-8. Before opening the draft spec PR, call `ensure_on_project_board <issue_number> "Writing Spec"` from `scripts/development-workflow/workflow-lib.sh`. This is a no-op when the issue is already on the board.
-9. Before creating the spec branch or opening the spec PR for a tracker-backed item, run `run-nested-artifact-guard.sh` with the expected `spec/*` branch and approved artifact base. Stop on missing base, duplicate artifacts, wrong-base PRs, or scan failures.
-10. When the branch is created, continue through reviewer gate, PR creation, and PR readiness unless the protocol surfaces a real human decision.
-11. Resolve repository mode, artifact owner, and artifact base branch before
+8. Before opening the draft spec PR, complete Protocol 01's Document Quality Gate and include the gate log in the PR description. For tracker-backed briefs, include the mandatory Brief Objective List, Coverage Matrix, and PR-visible Deferral Notes as part of that gate.
+9. Before opening the draft spec PR, call `ensure_on_project_board <issue_number> "Writing Spec"` from `scripts/development-workflow/workflow-lib.sh`. This is a no-op when the issue is already on the board.
+10. Before creating the spec branch or opening the spec PR for a tracker-backed item, run `run-nested-artifact-guard.sh` with the expected `spec/*` branch and approved artifact base. Stop on missing base, duplicate artifacts, wrong-base PRs, or scan failures.
+11. When the branch is created, continue through reviewer gate, PR creation, and PR readiness unless the protocol surfaces a real human decision.
+12. Resolve repository mode, artifact owner, and artifact base branch before
    writing: `single_repo` uses the current repository; `workflow_hub` keeps specs
    and spec PRs hub-owned on the hub artifact base branch, even when the
    product implementation base is different; `product_repo` should report the

--- a/.cursor/agents/item-orchestrator.md
+++ b/.cursor/agents/item-orchestrator.md
@@ -71,8 +71,11 @@ That document is the single source of truth for this supporting role. Key respon
 - Stay scoped to one item at a time
 - Use `workflow-next-action.sh` to determine the next deterministic action for the selected development folder, branch, or PR
 - Before dispatching a Backlog item into Writing Spec, run or consume
-  `scripts/development-workflow/spec-dispatch-context.sh`. Pass non-blocking
-  confirmed decisions and relationship outcomes to the spec writer; stop on
+  `scripts/development-workflow/spec-dispatch-context.sh`. For direct
+  single-item runs, pass the selected item plus relevant in-scope Backlog peers
+  from the current tracker scan in `--items`; a selected-only scope may collect
+  decisions but cannot classify peer relationships. Pass non-blocking confirmed
+  decisions and relationship outcomes to the spec writer; stop on
   `blocking=true` and report the helper's `humanAction`. Shared keywords alone
   are not dependency evidence.
 - Dispatch the matching stage agent when the runner supports it; otherwise continue in the current context using the referenced protocol

--- a/.cursor/agents/item-orchestrator.md
+++ b/.cursor/agents/item-orchestrator.md
@@ -70,6 +70,11 @@ That document is the single source of truth for this supporting role. Key respon
 
 - Stay scoped to one item at a time
 - Use `workflow-next-action.sh` to determine the next deterministic action for the selected development folder, branch, or PR
+- Before dispatching a Backlog item into Writing Spec, run or consume
+  `scripts/development-workflow/spec-dispatch-context.sh`. Pass non-blocking
+  confirmed decisions and relationship outcomes to the spec writer; stop on
+  `blocking=true` and report the helper's `humanAction`. Shared keywords alone
+  are not dependency evidence.
 - Dispatch the matching stage agent when the runner supports it; otherwise continue in the current context using the referenced protocol
 - Run reviewer gate, PR readiness, automated review, and CI until the item is actually waiting on a human, blocked, or escalated
 - For sweep, batch, helper-extraction, numeric-target, or pattern-completeness

--- a/.cursor/agents/orchestrator.md
+++ b/.cursor/agents/orchestrator.md
@@ -50,6 +50,11 @@ That document is the single source of truth for this supporting role. Key respon
 
 - Read current state from the issue tracker (if configured) and/or `docs/specs/developments/`
 - Determine what can safely advance and which Backlog items should be proposed to start, respecting dependencies
+- Before dispatching any Backlog item into Writing Spec, run
+  `scripts/development-workflow/spec-dispatch-context.sh` for the selected item
+  and in-scope batch. Pass non-blocking confirmed decisions and relationship
+  outcomes to the item/spec handoff; stop on `blocking=true` and report the
+  helper's `humanAction`. Shared keywords alone are not dependency evidence.
 - Prioritize by due date (within 2 weeks) → priority → creation date
 - Build the largest safe explicit batch possible and document when work must be serialized
 - Before dispatching an explicit-list batch where any runner may mutate,

--- a/.cursor/agents/product-manager.md
+++ b/.cursor/agents/product-manager.md
@@ -40,6 +40,14 @@ PRs, or scan failures.
 
 That document is the single source of truth for this stage. Do not skip the alignment conversation. Once ambiguity is resolved, continue through reviewer gate, PR creation, and PR readiness unless the protocol requires human input.
 
+When the handoff includes output from
+`scripts/development-workflow/spec-dispatch-context.sh`, read it before the
+alignment conversation. Preserve confirmed decisions and non-blocking
+relationship outcomes as product constraints. Do not turn helper mechanics,
+token matching, JSON fields, or implementation algorithms into spec
+requirements. If context is `blocking=true` or `Unclear`, stop for the named
+human relationship decision.
+
 Before opening the draft PR, complete protocol 01's Document Quality Gate and include the gate log in the PR description. For tracker-backed items, follow protocol 01's Brief Objective List, Coverage Matrix, and Deferral Note requirements as part of that gate.
 
 Before updating tracker status as part of a standalone spec completion sequence, call `ensure_on_project_board <issue_number> "Writing Spec"` (from `scripts/development-workflow/workflow-lib.sh`) to register the issue on the project board if it is not already present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Prevent false dependency dispatch context** (#1182): Add
+  spec-dispatch relationship context so orchestrators do not infer dependencies
+  from keyword overlap alone.
 - **Block Implementation Code in Plan PRs** (#1206): Add a
   documentation-stage alignment gate that blocks spec and plan PR readiness when
   implementation files are present.

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -47,6 +47,13 @@ The process moves through the stages below in order. The point of this section i
 
 The backlog is where work starts. A work item exists here before the team commits to a solution. This stage is about priority, timing, dependencies, and clarity of the request.
 
+Before a Backlog item enters spec writing, orchestration builds a conservative
+spec-dispatch context when possible. Shared terminology with another in-scope
+item is not enough to create a dependency: the workflow records relationships as
+`Dependent`, `Orthogonal`, or `Unclear`, preserves human-confirmed design
+decisions from tracker comments or current-session context, and stops for a
+human decision when ambiguity could change product scope.
+
 ### Spec
 
 The spec explains **what** should happen and **why** it matters. It should describe actors, workflows, business rules, acceptance criteria, scope boundaries, and any product-facing measurement requirements in product terms.

--- a/docs/workflow/development-workflow/integrations/issue-tracker.md
+++ b/docs/workflow/development-workflow/integrations/issue-tracker.md
@@ -28,6 +28,10 @@ If the agent does not have direct tracker access, it must ask the human to paste
 
 - **Prefer recency**: newer comments override older ones if they conflict.
 - **Prefer explicit decisions**: “Decision: …”, “We will …”, “Out of scope: …” are high-signal.
+- **Preserve confirmed design decisions for spec dispatch**: comments with
+  explicit human correction, approval, clarification, or decision language can
+  feed `spec-dispatch-context.sh` so spec writers receive confirmed product
+  constraints before drafting begins.
 - **Don’t guess**: if comments introduce ambiguity or contradict the spec/plan, **stop and ask** for clarification.
 - **Don’t silently discard** tracker context: if it changes scope/requirements, call it out explicitly in the stage output (spec/plan/PR).
 

--- a/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
+++ b/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
@@ -34,6 +34,16 @@ Before starting, read:
 
 **Tracker workflow status**: The **Work Item Runner** owns workflow-status transitions for this stage. When this protocol is run under normal orchestration, expect the runner to set **Writing Spec** before dispatch, **Spec in Review** when the PR is human-ready, and **Spec Ready** only after merge. If you invoke this protocol standalone, mirror the same status progression manually.
 
+**Spec-dispatch context**: When the Work Item Runner or Portfolio Orchestrator
+provides output from `scripts/development-workflow/spec-dispatch-context.sh`,
+read it before the alignment conversation. Preserve `confirmedDecisions[]` and
+non-blocking relationship outcomes as product constraints in the spec. Do not
+turn helper mechanics, token matching, JSON fields, or implementation algorithms
+into spec requirements. If the supplied context says a relationship is
+`Dependent`, cite the concrete evidence. If it says `Orthogonal`, avoid adding
+dependency language from shared terminology alone. If the context is `Unclear`
+or `blocking=true`, stop and ask for the named human decision before drafting.
+
 **Repository mode ownership**: Resolve repository mode before creating or
 reviewing spec artifacts. Missing mode or explicit `single_repo` means the
 current repository owns the spec. In `workflow_hub` mode, the hub owns specs and

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -501,11 +501,13 @@ and a `blocking` flag. Shared keywords alone are not dependency evidence:
 means a human decision is needed before spec dispatch.
 
 If `blocking=true`, stop before batch approval, tracker status changes, branch
-creation, or Work Item Runner dispatch for that item. Report the `Unclear`
-relationship and `humanAction` in the batch proposal instead of treating the
-item as dispatch-eligible. If `blocking=false`, include the concise relationship
-summary and any confirmed decisions in the Work Item Runner handoff so the spec
-writer preserves the context without inventing dependency assumptions.
+creation, or Work Item Runner dispatch for that item. Report the helper
+`humanAction`; when the block comes from peer ambiguity, include the `Unclear`
+relationship row, and when it comes from confirmed-decision conflict, report the
+decision conflict instead of treating the item as dispatch-eligible. If
+`blocking=false`, include the concise relationship summary and any confirmed
+decisions in the Work Item Runner handoff so the spec writer preserves the
+context without inventing dependency assumptions.
 
 ### Stale `In Development` correction (AC-6, AC-7, AC-8, AC-10)
 

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -480,6 +480,33 @@ This rule changes the default `/run-work` behavior from "only resume already-sta
 
 Before batching an item, check its `Depends on` field or tracker dependency data. If any dependency is not yet `Merged` or `Released`, skip the item and record it as blocked.
 
+### Spec-dispatch relationship context gate
+
+Before tracker mutation or Work Item Runner dispatch for any Backlog item that
+will enter **Writing Spec**, build conservative spec-dispatch context:
+
+```bash
+./scripts/development-workflow/spec-dispatch-context.sh \
+  --selected <issue-number> \
+  --items <comma-separated-in-scope-issue-numbers> \
+  [--confirmed-decision-file <jsonl-file>] \
+  --json
+```
+
+The helper output is an ephemeral dispatch-context object. It may include
+human-confirmed decisions, relationship rows for meaningful terminology overlap,
+and a `blocking` flag. Shared keywords alone are not dependency evidence:
+`Dependent` requires concrete issue-reference or prerequisite evidence,
+`Orthogonal` means the items can be specified independently, and `Unclear`
+means a human decision is needed before spec dispatch.
+
+If `blocking=true`, stop before batch approval, tracker status changes, branch
+creation, or Work Item Runner dispatch for that item. Report the `Unclear`
+relationship and `humanAction` in the batch proposal instead of treating the
+item as dispatch-eligible. If `blocking=false`, include the concise relationship
+summary and any confirmed decisions in the Work Item Runner handoff so the spec
+writer preserves the context without inventing dependency assumptions.
+
 ### Stale `In Development` correction (AC-6, AC-7, AC-8, AC-10)
 
 > **Scan-only mode gate (`/run-work`)**: When the routing entrypoint is `/run-work` (scan-only mode), this section is **skipped entirely** — no tracker mutations occur during the scan-and-propose phase. This correction runs only when executing a full portfolio run via `/run-items` or an equivalent dispatch entrypoint.

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -342,15 +342,18 @@ run or consume the spec-dispatch context helper:
 ```bash
 ./scripts/development-workflow/spec-dispatch-context.sh \
   --selected <issue-number> \
-  --items <issue-number> \
+  --items <selected-and-in-scope-backlog-peer-issue-numbers> \
   [--confirmed-decision-file <jsonl-file>] \
   --json
 ```
 
 When the item is dispatched by Protocol 90, use the handoff-provided context
 instead of recomputing it unless the handoff is missing or stale. When running
-directly, a one-item scope still lets the helper collect human-confirmed
-decisions from the issue and optional current-session decision file.
+directly, populate `--items` with the selected item plus the relevant in-scope
+Backlog peers from the current tracker scan so keyword-overlap relationships can
+be classified on the single-item path. If no peer scope is available, the helper
+still collects human-confirmed decisions from the issue and optional
+current-session decision file, but peer relationship classification is skipped.
 
 If helper output has `blocking=true`, stop before tracker mutation, branch
 creation, or spec-writer dispatch and report the `humanAction`. If it is not

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -334,6 +334,31 @@ route classification. Repository labels such as `workflow`, `bug`,
 `enhancement`, and `type:*` are legacy classification hints only; do not rely on
 them when Type is available.
 
+### Spec-dispatch relationship context gate
+
+Before a direct single-item run transitions a Backlog item into **Writing Spec**,
+run or consume the spec-dispatch context helper:
+
+```bash
+./scripts/development-workflow/spec-dispatch-context.sh \
+  --selected <issue-number> \
+  --items <issue-number> \
+  [--confirmed-decision-file <jsonl-file>] \
+  --json
+```
+
+When the item is dispatched by Protocol 90, use the handoff-provided context
+instead of recomputing it unless the handoff is missing or stale. When running
+directly, a one-item scope still lets the helper collect human-confirmed
+decisions from the issue and optional current-session decision file.
+
+If helper output has `blocking=true`, stop before tracker mutation, branch
+creation, or spec-writer dispatch and report the `humanAction`. If it is not
+blocking, pass `confirmedDecisions[]` and `relationships[]` to
+`01-generate-spec-protocol.md`. Shared terminology alone must not be treated as
+a dependency; `Dependent` requires concrete evidence, `Orthogonal` means no
+ordering dependency, and `Unclear` requires a human relationship decision.
+
 > **Linear provider — deferred status reads**: When `workflow-next-action.sh`
 > (or `workflow-batch-plan.sh`) returns a `TRACKER_ACTION_REQUIRED=read_status
 > issue=<id>` line in place of an empty status, the item's status was deferred —

--- a/scripts/development-workflow/spec-dispatch-context.sh
+++ b/scripts/development-workflow/spec-dispatch-context.sh
@@ -184,7 +184,7 @@ text_contains_negated_dependency() {
   compact="$(printf '%s\n' "$lower" | tr '\n' ' ')"
   issue_pattern="$(issue_ref_pattern "$issue")"
   printf '%s\n' "$compact" \
-    | grep -Eiq "(not|without)[^.!?]{0,120}(${issue_pattern})"
+    | grep -Eiq "(^|[^a-z])(not|without)[^.!?]{0,120}(${issue_pattern})"
 }
 
 has_coupling_language() {

--- a/scripts/development-workflow/spec-dispatch-context.sh
+++ b/scripts/development-workflow/spec-dispatch-context.sh
@@ -124,40 +124,66 @@ significant_terms() {
   ' | sort -u
 }
 
+issue_ref_pattern() {
+  local issue="$1"
+  printf '(^|[^0-9#])#%s([^0-9]|$)|(^|[^0-9#])%s([^0-9]|$)' "$issue" "$issue"
+}
+
+dependency_phrase_pattern() {
+  printf 'depends on|dependent on|blocked by|requires|waiting on'
+}
+
 text_contains_dependency() {
   local text="$1" issue="$2"
-  local lower compact match
+  local lower compact match issue_pattern dependency_pattern
   lower="$(printf '%s\n' "$text" | tr '[:upper:]' '[:lower:]')"
   compact="$(printf '%s\n' "$lower" | tr '\n' ' ')"
+  issue_pattern="$(issue_ref_pattern "$issue")"
+  dependency_pattern="$(dependency_phrase_pattern)"
   while IFS= read -r match; do
     if [ -z "$match" ]; then
       continue
     fi
-    if printf '%s\n' "$match" | grep -Eiq "^(not|without)[^.!?]{0,40}(depends on|blocked by|requires|waiting on)"; then
+    if printf '%s\n' "$match" | grep -Eiq "^(not|without)[^.!?]{0,40}(${dependency_pattern})"; then
       continue
     fi
-    if printf '%s\n' "$match" | grep -Eiq "(not|without)[^.!?]{0,80}(^|[^0-9#])#?${issue}([^0-9]|$)"; then
+    if printf '%s\n' "$match" | grep -Eiq "(not|without)[^.!?]{0,80}(${issue_pattern})"; then
       continue
     fi
     return 0
   done <<EOF
-$(printf '%s\n' "$compact" | grep -Eio "((not|without)[^.!?]{0,40})?(depends on|blocked by|requires|waiting on)[^.!?]{0,120}(^|[^0-9#])#?${issue}([^0-9]|$)" || true)
+$(printf '%s\n' "$compact" | grep -Eio "((not|without)[^.!?]{0,40})?(${dependency_pattern})[^.!?]{0,120}(${issue_pattern})" || true)
 EOF
   return 1
 }
 
 text_contains_negated_dependency() {
   local text="$1" issue="$2"
-  local lower compact
+  local lower compact issue_pattern
   lower="$(printf '%s\n' "$text" | tr '[:upper:]' '[:lower:]')"
   compact="$(printf '%s\n' "$lower" | tr '\n' ' ')"
+  issue_pattern="$(issue_ref_pattern "$issue")"
   printf '%s\n' "$compact" \
-    | grep -Eiq "(not|without)[^.!?]{0,120}(^|[^0-9#])#?${issue}([^0-9]|$)"
+    | grep -Eiq "(not|without)[^.!?]{0,120}(${issue_pattern})"
 }
 
 has_coupling_language() {
   printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]' \
-    | grep -Eq 'depends|dependent|blocked|requires|required|waiting on|prerequisite|coupled|coupling|shared|coordinate|coordination|same data|same schema|must align|must share'
+    | awk '
+      {
+        line = $0
+        gsub(/[^a-z0-9]+/, " ", line)
+        if (line ~ /(^| )(depends|dependent|blocked|requires|required|prerequisite|coupled|coupling|shared|coordinate|coordination)( |$)/ ||
+            line ~ /(^| )waiting on( |$)/ ||
+            line ~ /(^| )same data( |$)/ ||
+            line ~ /(^| )same schema( |$)/ ||
+            line ~ /(^| )must align( |$)/ ||
+            line ~ /(^| )must share( |$)/) {
+          found = 1
+        }
+      }
+      END { exit found ? 0 : 1 }
+    '
 }
 
 json_array_from_lines() {
@@ -285,7 +311,18 @@ jq '
 confirmed_json="$(jq -s 'add' "$decision_file_json" "$comment_decisions_json")"
 relationships_json="$(if [ -s "$relationships_file" ]; then jq -s . "$relationships_file"; else printf '[]\n'; fi)"
 blocking="$(printf '%s\n' "$relationships_json" | jq 'any(.[]; .blocking == true)')"
-human_action="$(printf '%s\n' "$relationships_json" | jq -r '[.[] | select(.blocking == true) | .humanAction] | map(select(. != null)) | first // empty')"
+human_actions_json="$(printf '%s\n' "$relationships_json" | jq '[.[] | select(.blocking == true) | .humanAction] | map(select(. != null)) | unique')"
+decision_conflict="$(printf '%s\n' "$confirmed_json" | jq '
+  def normalized: (.summary // "" | ascii_downcase);
+  def says_independent: normalized | test("orthogonal|independent|unrelated|no dependency|not dependent|not blocked");
+  def says_dependent: normalized | test("depends on|dependent on|blocked by|requires|waiting on|prerequisite");
+  (any(.[]; says_independent) and any(.[]; says_dependent))
+')"
+if [ "$decision_conflict" = "true" ]; then
+  blocking=true
+  human_actions_json="$(printf '%s\n' "$human_actions_json" | jq --arg selected "$selected" '. + ["Resolve conflicting confirmed decisions for #\($selected) before spec dispatch."]')"
+fi
+human_action="$(printf '%s\n' "$human_actions_json" | jq -r 'join(" ")')"
 if [ -n "$human_action" ]; then
   human_action_json="$(jq -n --arg action "$human_action" '$action')"
 else

--- a/scripts/development-workflow/spec-dispatch-context.sh
+++ b/scripts/development-workflow/spec-dispatch-context.sh
@@ -363,9 +363,14 @@ blocking="$(printf '%s\n' "$relationships_json" | jq 'any(.[]; .blocking == true
 human_actions_json="$(printf '%s\n' "$relationships_json" | jq '[.[] | select(.blocking == true) | .humanAction] | map(select(. != null)) | unique')"
 decision_conflict="$(printf '%s\n' "$confirmed_json" | jq '
   def normalized: (.summary // "" | ascii_downcase);
-  def says_independent: normalized | test("orthogonal|independent|unrelated|no dependency|not dependent|not blocked");
-  def says_dependent: normalized | test("(depends on|dependent on|blocked by|requires|waiting on|prerequisite)[^.?!;]{0,80}#[0-9]+");
-  (any(.[]; says_independent) and any(.[]; says_dependent))
+  def dependency_text: normalized | gsub("(?:not blocked|not dependent)[^.?!;]{0,80}#[0-9]+"; "");
+  def refs_for($text; $pattern):
+    [$text | scan($pattern + "[^.?!;]{0,80}#[0-9]+") | scan("#[0-9]+") | ltrimstr("#") | tonumber];
+  def independent_refs: refs_for(normalized; "(?:orthogonal|independent|unrelated|no dependency|not dependent|not blocked)");
+  def dependent_refs: refs_for(dependency_text; "(?:depends on|dependent on|blocked by|requires|waiting on|prerequisite)");
+  [.[] | independent_refs[]?] as $independent
+  | [.[] | dependent_refs[]?] as $dependent
+  | any($independent[]; . as $issue | any($dependent[]; . == $issue))
 ')"
 if [ "$decision_conflict" = "true" ]; then
   blocking=true

--- a/scripts/development-workflow/spec-dispatch-context.sh
+++ b/scripts/development-workflow/spec-dispatch-context.sh
@@ -129,6 +129,9 @@ text_contains_dependency() {
   local lower compact match
   lower="$(printf '%s\n' "$text" | tr '[:upper:]' '[:lower:]')"
   compact="$(printf '%s\n' "$lower" | tr '\n' ' ')"
+  if printf '%s\n' "$compact" | grep -Eiq "(not|without)[^.!?]{0,120}(^|[^0-9#])#?${issue}([^0-9]|$)"; then
+    return 1
+  fi
   match="$(printf '%s\n' "$compact" | grep -Eio "(depends on|blocked by|requires|waiting on)[^.!?]{0,120}(^|[^0-9#])#?${issue}([^0-9]|$)" | head -1 || true)"
   if [ -z "$match" ]; then
     return 1

--- a/scripts/development-workflow/spec-dispatch-context.sh
+++ b/scripts/development-workflow/spec-dispatch-context.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/development-workflow/spec-dispatch-context.sh --selected <issue-number> --items <comma-separated-issue-numbers> [--confirmed-decision-file <path>] [--json]
+
+Build conservative spec-dispatch relationship context for Backlog spec starts.
+EOF
+}
+
+selected=""
+items_arg=""
+confirmed_decision_file=""
+json_output=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --selected)
+      shift
+      selected="${1:-}"
+      shift
+      ;;
+    --items)
+      shift
+      items_arg="${1:-}"
+      shift
+      ;;
+    --confirmed-decision-file)
+      shift
+      confirmed_decision_file="${1:-}"
+      shift
+      ;;
+    --json)
+      json_output=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+if ! printf '%s\n' "$selected" | grep -Eq '^[1-9][0-9]*$'; then
+  echo "--selected must be a positive issue number" >&2
+  exit 64
+fi
+
+if [ -z "$items_arg" ]; then
+  items_arg="$selected"
+fi
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+items_file="$tmp_dir/items"
+printf '%s\n' "$items_arg" \
+  | tr ',' '\n' \
+  | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+  | awk 'NF && !seen[$0]++ { print }' > "$items_file"
+
+if ! grep -qx "$selected" "$items_file"; then
+  printf '%s\n' "$selected" >> "$items_file"
+fi
+
+while IFS= read -r issue; do
+  if ! printf '%s\n' "$issue" | grep -Eq '^[1-9][0-9]*$'; then
+    echo "Invalid issue in --items: $issue" >&2
+    exit 64
+  fi
+done < "$items_file"
+
+issue_json_dir="$tmp_dir/issues"
+mkdir -p "$issue_json_dir"
+
+while IFS= read -r issue; do
+  if ! gh issue view "$issue" --json number,title,body,comments > "$issue_json_dir/$issue.json"; then
+    echo "Failed to read issue #$issue" >&2
+    exit 1
+  fi
+done < "$items_file"
+
+issue_text() {
+  local issue="$1"
+  jq -r '[.title // "", .body // ""] | join("\n")' "$issue_json_dir/$issue.json"
+}
+
+significant_terms() {
+  awk '
+    BEGIN {
+      split("a an and are as at be by can for from has have if in into is it its of on or that the this to was were when with without will would should could must issue issues item items spec specs plan plans implementation workflow agent agents add added update updated selected peer current target context dispatch human", stop_words)
+      for (i in stop_words) stop[stop_words[i]] = 1
+    }
+    {
+      line = tolower($0)
+      gsub(/[^a-z0-9#]+/, " ", line)
+      n = split(line, parts, /[[:space:]]+/)
+      delete kept
+      kept_count = 0
+      for (i = 1; i <= n; i++) {
+        term = parts[i]
+        gsub(/^#+/, "", term)
+        if (length(term) < 4 || stop[term]) {
+          continue
+        }
+        kept[++kept_count] = term
+        print "term:" term
+      }
+      for (i = 1; i < kept_count; i++) {
+        print "phrase:" kept[i] " " kept[i + 1]
+      }
+    }
+  ' | sort -u
+}
+
+text_contains_dependency() {
+  local text="$1" issue="$2"
+  local lower compact match
+  lower="$(printf '%s\n' "$text" | tr '[:upper:]' '[:lower:]')"
+  compact="$(printf '%s\n' "$lower" | tr '\n' ' ')"
+  match="$(printf '%s\n' "$compact" | grep -Eio "(depends on|blocked by|requires|waiting on)[^.!?]{0,120}#?${issue}([^0-9]|$)" | head -1 || true)"
+  if [ -z "$match" ]; then
+    return 1
+  fi
+  if printf '%s\n' "$match" | grep -Eiq "(not|without)[^.!?]{0,80}#?${issue}([^0-9]|$)"; then
+    return 1
+  fi
+  return 0
+}
+
+has_coupling_language() {
+  printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]' \
+    | grep -Eq 'depends|dependent|blocked|requires|required|waiting on|prerequisite|coupled|coupling|shared|coordinate|coordination|same data|same schema|must align|must share'
+}
+
+json_array_from_lines() {
+  if [ -s "$1" ]; then
+    jq -R . "$1" | jq -s .
+  else
+    printf '[]\n'
+  fi
+}
+
+selected_text_file="$tmp_dir/selected.txt"
+issue_text "$selected" > "$selected_text_file"
+selected_terms="$tmp_dir/selected_terms"
+significant_terms < "$selected_text_file" > "$selected_terms"
+
+relationships_file="$tmp_dir/relationships.jsonl"
+: > "$relationships_file"
+
+while IFS= read -r peer; do
+  [ "$peer" = "$selected" ] && continue
+
+  peer_text_file="$tmp_dir/peer-$peer.txt"
+  issue_text "$peer" > "$peer_text_file"
+  peer_terms="$tmp_dir/peer-$peer-terms"
+  significant_terms < "$peer_text_file" > "$peer_terms"
+
+  overlap_file="$tmp_dir/overlap-$peer"
+  comm -12 "$selected_terms" "$peer_terms" > "$overlap_file"
+
+  phrase_count="$(grep -c '^phrase:' "$overlap_file" || true)"
+  term_count="$(grep -c '^term:' "$overlap_file" || true)"
+  if [ "$phrase_count" -lt 1 ] && [ "$term_count" -lt 2 ]; then
+    continue
+  fi
+
+  overlap_terms_file="$tmp_dir/overlap-$peer-terms"
+  sed 's/^[^:]*://' "$overlap_file" > "$overlap_terms_file"
+
+  evidence_file="$tmp_dir/evidence-$peer"
+  : > "$evidence_file"
+  outcome="Orthogonal"
+  selected_text="$(cat "$selected_text_file")"
+  peer_text="$(cat "$peer_text_file")"
+
+  if text_contains_dependency "$selected_text" "$peer"; then
+    outcome="Dependent"
+    printf 'Selected issue contains an explicit dependency phrase referencing #%s.\n' "$peer" >> "$evidence_file"
+  fi
+  if text_contains_dependency "$peer_text" "$selected"; then
+    outcome="Dependent"
+    printf 'Peer issue #%s contains an explicit dependency phrase referencing #%s.\n' "$peer" "$selected" >> "$evidence_file"
+  fi
+
+  if [ "$outcome" != "Dependent" ] && {
+    has_coupling_language "$selected_text" || has_coupling_language "$peer_text"
+  }; then
+    outcome="Unclear"
+    printf 'Meaningful overlap plus coupling language lacks concrete dependency or independence evidence.\n' >> "$evidence_file"
+  fi
+
+  if [ ! -s "$evidence_file" ]; then
+    printf 'Meaningful terminology overlap without concrete dependency evidence.\n' >> "$evidence_file"
+  fi
+
+  blocking=false
+  human_action_json=null
+  dispatch_instruction="Treat the relationship as orthogonal; do not add dependency context from shared terminology alone."
+  if [ "$outcome" = "Dependent" ]; then
+    dispatch_instruction="Include the concrete dependency evidence in the spec-dispatch context."
+  elif [ "$outcome" = "Unclear" ]; then
+    blocking=true
+    human_action_json="$(jq -n --arg peer "$peer" --arg selected "$selected" '"Confirm whether #\($selected) depends on #\($peer), is orthogonal to it, or needs a narrower design decision before spec dispatch."')"
+    dispatch_instruction="Stop before spec dispatch until a human resolves the relationship."
+  fi
+
+  overlap_json="$(json_array_from_lines "$overlap_terms_file")"
+  evidence_json="$(json_array_from_lines "$evidence_file")"
+  peer_title="$(jq -r '.title // ""' "$issue_json_dir/$peer.json")"
+
+  jq -nc \
+    --argjson issue "$peer" \
+    --arg title "$peer_title" \
+    --arg outcome "$outcome" \
+    --argjson overlapTerms "$overlap_json" \
+    --argjson evidence "$evidence_json" \
+    --arg dispatchInstruction "$dispatch_instruction" \
+    --argjson blocking "$blocking" \
+    --argjson humanAction "$human_action_json" \
+    '{issue: $issue, title: $title, outcome: $outcome, overlapTerms: $overlapTerms, evidence: $evidence, dispatchInstruction: $dispatchInstruction, blocking: $blocking, humanAction: $humanAction}' \
+    >> "$relationships_file"
+done < "$items_file"
+
+decision_file_json="$tmp_dir/decisions-file.json"
+if [ -n "$confirmed_decision_file" ] && [ -s "$confirmed_decision_file" ]; then
+  jq -s --argjson selected "$selected" \
+    '[.[] | select((.issue // .item_number // .number | tonumber) == $selected) | {summary: (.summary // .decision // .body // ""), source: (.source // "confirmed decision file")} | select(.summary != "")]' \
+    "$confirmed_decision_file" > "$decision_file_json"
+else
+  printf '[]\n' > "$decision_file_json"
+fi
+
+comment_decisions_json="$tmp_dir/decisions-comments.json"
+jq '
+  [
+    .comments[]?
+    | (.body // "") as $body
+    | select($body | test("(?i)(confirmed|approved|correction|clarifying|decision)"))
+    | {
+        summary: ($body | gsub("\\s+"; " ") | .[0:240]),
+        source: (.url // (.author.login // "issue comment"))
+      }
+  ]
+' "$issue_json_dir/$selected.json" > "$comment_decisions_json"
+
+confirmed_json="$(jq -s 'add' "$decision_file_json" "$comment_decisions_json")"
+relationships_json="$(if [ -s "$relationships_file" ]; then jq -s . "$relationships_file"; else printf '[]\n'; fi)"
+blocking="$(printf '%s\n' "$relationships_json" | jq 'any(.[]; .blocking == true)')"
+human_action="$(printf '%s\n' "$relationships_json" | jq -r '[.[] | select(.blocking == true) | .humanAction] | map(select(. != null)) | first // empty')"
+if [ -n "$human_action" ]; then
+  human_action_json="$(jq -n --arg action "$human_action" '$action')"
+else
+  human_action_json=null
+fi
+
+selected_json="$(jq '{number, title, briefExcerpt: ((.body // "") | gsub("\\s+"; " ") | .[0:300])}' "$issue_json_dir/$selected.json")"
+
+if [ "$json_output" -eq 1 ]; then
+  jq -n \
+    --argjson selected "$selected_json" \
+    --argjson confirmedDecisions "$confirmed_json" \
+    --argjson relationships "$relationships_json" \
+    --argjson blocking "$blocking" \
+    --argjson humanAction "$human_action_json" \
+    '{selected: $selected, confirmedDecisions: $confirmedDecisions, relationships: $relationships, blocking: $blocking, humanAction: $humanAction}'
+else
+  printf 'Selected: #%s %s\n' "$selected" "$(jq -r '.title // ""' "$issue_json_dir/$selected.json")"
+  printf 'Blocking: %s\n' "$blocking"
+  printf '%s\n' "$relationships_json" | jq -r '.[] | "- #\(.issue) \(.outcome): \(.dispatchInstruction)"'
+  if [ -n "$human_action" ]; then
+    printf 'Human action: %s\n' "$human_action"
+  fi
+fi

--- a/scripts/development-workflow/spec-dispatch-context.sh
+++ b/scripts/development-workflow/spec-dispatch-context.sh
@@ -126,7 +126,7 @@ significant_terms() {
 
 issue_ref_pattern() {
   local issue="$1"
-  printf '(^|[^0-9#])#%s([^0-9]|$)|(^|[^0-9#])%s([^0-9]|$)' "$issue" "$issue"
+  printf '(^|[^0-9#])#%s([^0-9]|$)' "$issue"
 }
 
 dependency_phrase_pattern() {
@@ -344,7 +344,7 @@ confirmed_json="$(jq -s 'add' "$decision_file_json" "$comment_decisions_json")"
 relationships_json="$(if [ -s "$relationships_file" ]; then jq -s . "$relationships_file"; else printf '[]\n'; fi)"
 relationships_json="$(printf '%s\n' "$relationships_json" | jq --argjson decisions "$confirmed_json" '
   def decision_text: (.summary // "" | ascii_downcase);
-  def says_independent: decision_text | test("orthogonal|independent|unrelated|no dependency|not dependent|not blocked");
+  def says_independent: decision_text | test("orthogonal|independent|unrelated|no dependency|not dependent");
   def references_issue($issue): decision_text | test("#" + ($issue | tostring) + "([^0-9]|$)");
   def confirmed_orthogonal($issue): any($decisions[]?; says_independent and references_issue($issue));
   map(
@@ -366,7 +366,7 @@ decision_conflict="$(printf '%s\n' "$confirmed_json" | jq '
   def dependency_text: normalized | gsub("(?:not blocked|not dependent)[^.?!;]{0,80}#[0-9]+"; "");
   def refs_for($text; $pattern):
     [$text | scan($pattern + "[^.?!;]{0,80}#[0-9]+") | scan("#[0-9]+") | ltrimstr("#") | tonumber];
-  def independent_refs: refs_for(normalized; "(?:orthogonal|independent|unrelated|no dependency|not dependent|not blocked)");
+  def independent_refs: refs_for(normalized; "(?:orthogonal|independent|unrelated|no dependency|not dependent)");
   def dependent_refs: refs_for(dependency_text; "(?:depends on|dependent on|blocked by|requires|waiting on|prerequisite)");
   [.[] | independent_refs[]?] as $independent
   | [.[] | dependent_refs[]?] as $dependent

--- a/scripts/development-workflow/spec-dispatch-context.sh
+++ b/scripts/development-workflow/spec-dispatch-context.sh
@@ -353,7 +353,7 @@ relationships_json="$(printf '%s\n' "$relationships_json" | jq --argjson decisio
       | .blocking = false
       | .humanAction = null
       | .dispatchInstruction = "Treat the relationship as orthogonal based on confirmed human decision context."
-      | .evidence += ["Confirmed human decision marks this peer relationship as orthogonal."]
+      | .evidence = ["Confirmed human decision marks this peer relationship as orthogonal."]
     else
       .
     end

--- a/scripts/development-workflow/spec-dispatch-context.sh
+++ b/scripts/development-workflow/spec-dispatch-context.sh
@@ -180,8 +180,7 @@ has_coupling_language() {
       {
         line = $0
         gsub(/[^a-z0-9]+/, " ", line)
-        if (line ~ /(^| )(depends|dependent|blocked|prerequisite|coupled|coupling|shared|coordinate|coordination)( |$)/ ||
-            line ~ /(^| )waiting on( |$)/ ||
+        if (line ~ /(^| )(coupled|coupling|shared|coordinate|coordination)( |$)/ ||
             line ~ /(^| )same data( |$)/ ||
             line ~ /(^| )same schema( |$)/ ||
             line ~ /(^| )must align( |$)/ ||
@@ -331,7 +330,7 @@ human_actions_json="$(printf '%s\n' "$relationships_json" | jq '[.[] | select(.b
 decision_conflict="$(printf '%s\n' "$confirmed_json" | jq '
   def normalized: (.summary // "" | ascii_downcase);
   def says_independent: normalized | test("orthogonal|independent|unrelated|no dependency|not dependent|not blocked");
-  def says_dependent: normalized | test("depends on|dependent on|blocked by|requires|waiting on|prerequisite");
+  def says_dependent: normalized | test("(depends on|dependent on|blocked by|requires|waiting on|prerequisite)[^.?!;]{0,80}#[0-9]+");
   (any(.[]; says_independent) and any(.[]; says_dependent))
 ')"
 if [ "$decision_conflict" = "true" ]; then

--- a/scripts/development-workflow/spec-dispatch-context.sh
+++ b/scripts/development-workflow/spec-dispatch-context.sh
@@ -129,17 +129,21 @@ text_contains_dependency() {
   local lower compact match
   lower="$(printf '%s\n' "$text" | tr '[:upper:]' '[:lower:]')"
   compact="$(printf '%s\n' "$lower" | tr '\n' ' ')"
-  if printf '%s\n' "$compact" | grep -Eiq "(not|without)[^.!?]{0,120}(^|[^0-9#])#?${issue}([^0-9]|$)"; then
-    return 1
-  fi
-  match="$(printf '%s\n' "$compact" | grep -Eio "(depends on|blocked by|requires|waiting on)[^.!?]{0,120}(^|[^0-9#])#?${issue}([^0-9]|$)" | head -1 || true)"
-  if [ -z "$match" ]; then
-    return 1
-  fi
-  if printf '%s\n' "$match" | grep -Eiq "(not|without)[^.!?]{0,80}(^|[^0-9#])#?${issue}([^0-9]|$)"; then
-    return 1
-  fi
-  return 0
+  while IFS= read -r match; do
+    if [ -z "$match" ]; then
+      continue
+    fi
+    if printf '%s\n' "$match" | grep -Eiq "^(not|without)[^.!?]{0,40}(depends on|blocked by|requires|waiting on)"; then
+      continue
+    fi
+    if printf '%s\n' "$match" | grep -Eiq "(not|without)[^.!?]{0,80}(^|[^0-9#])#?${issue}([^0-9]|$)"; then
+      continue
+    fi
+    return 0
+  done <<EOF
+$(printf '%s\n' "$compact" | grep -Eio "((not|without)[^.!?]{0,40})?(depends on|blocked by|requires|waiting on)[^.!?]{0,120}(^|[^0-9#])#?${issue}([^0-9]|$)" || true)
+EOF
+  return 1
 }
 
 text_contains_negated_dependency() {

--- a/scripts/development-workflow/spec-dispatch-context.sh
+++ b/scripts/development-workflow/spec-dispatch-context.sh
@@ -129,14 +129,23 @@ text_contains_dependency() {
   local lower compact match
   lower="$(printf '%s\n' "$text" | tr '[:upper:]' '[:lower:]')"
   compact="$(printf '%s\n' "$lower" | tr '\n' ' ')"
-  match="$(printf '%s\n' "$compact" | grep -Eio "(depends on|blocked by|requires|waiting on)[^.!?]{0,120}#?${issue}([^0-9]|$)" | head -1 || true)"
+  match="$(printf '%s\n' "$compact" | grep -Eio "(depends on|blocked by|requires|waiting on)[^.!?]{0,120}(^|[^0-9#])#?${issue}([^0-9]|$)" | head -1 || true)"
   if [ -z "$match" ]; then
     return 1
   fi
-  if printf '%s\n' "$match" | grep -Eiq "(not|without)[^.!?]{0,80}#?${issue}([^0-9]|$)"; then
+  if printf '%s\n' "$match" | grep -Eiq "(not|without)[^.!?]{0,80}(^|[^0-9#])#?${issue}([^0-9]|$)"; then
     return 1
   fi
   return 0
+}
+
+text_contains_negated_dependency() {
+  local text="$1" issue="$2"
+  local lower compact
+  lower="$(printf '%s\n' "$text" | tr '[:upper:]' '[:lower:]')"
+  compact="$(printf '%s\n' "$lower" | tr '\n' ' ')"
+  printf '%s\n' "$compact" \
+    | grep -Eiq "(not|without)[^.!?]{0,120}(^|[^0-9#])#?${issue}([^0-9]|$)"
 }
 
 has_coupling_language() {
@@ -195,9 +204,19 @@ while IFS= read -r peer; do
     printf 'Peer issue #%s contains an explicit dependency phrase referencing #%s.\n' "$peer" "$selected" >> "$evidence_file"
   fi
 
+  negated_dependency=false
+  if text_contains_negated_dependency "$selected_text" "$peer"; then
+    negated_dependency=true
+    printf 'Selected issue explicitly negates a dependency on #%s.\n' "$peer" >> "$evidence_file"
+  fi
+  if text_contains_negated_dependency "$peer_text" "$selected"; then
+    negated_dependency=true
+    printf 'Peer issue #%s explicitly negates a dependency on #%s.\n' "$peer" "$selected" >> "$evidence_file"
+  fi
+
   if [ "$outcome" != "Dependent" ] && {
     has_coupling_language "$selected_text" || has_coupling_language "$peer_text"
-  }; then
+  } && [ "$negated_dependency" != "true" ]; then
     outcome="Unclear"
     printf 'Meaningful overlap plus coupling language lacks concrete dependency or independence evidence.\n' >> "$evidence_file"
   fi

--- a/scripts/development-workflow/spec-dispatch-context.sh
+++ b/scripts/development-workflow/spec-dispatch-context.sh
@@ -130,7 +130,7 @@ issue_ref_pattern() {
 }
 
 dependency_phrase_pattern() {
-  printf 'depends on|dependent on|blocked by|requires|waiting on'
+  printf 'depends on|dependent on|blocked by|requires|waiting on|prerequisite'
 }
 
 text_contains_dependency() {

--- a/scripts/development-workflow/spec-dispatch-context.sh
+++ b/scripts/development-workflow/spec-dispatch-context.sh
@@ -133,6 +133,16 @@ dependency_phrase_pattern() {
   printf 'depends on|dependent on|blocked by|requires|waiting on|prerequisite'
 }
 
+text_contains_without_dependency() {
+  local text="$1" issue="$2"
+  local lower compact issue_pattern
+  lower="$(printf '%s\n' "$text" | tr '[:upper:]' '[:lower:]')"
+  compact="$(printf '%s\n' "$lower" | tr '\n' ' ')"
+  issue_pattern="$(issue_ref_pattern "$issue")"
+  printf '%s\n' "$compact" \
+    | grep -Eiq "(cannot|can not|can't)[^.!?]{0,80}without[^.!?]{0,80}(${issue_pattern})"
+}
+
 text_contains_dependency() {
   local text="$1" issue="$2"
   local lower sentence match issue_pattern dependency_pattern first_ref
@@ -142,6 +152,9 @@ text_contains_dependency() {
   while IFS= read -r sentence; do
     if [ -z "$sentence" ]; then
       continue
+    fi
+    if text_contains_without_dependency "$sentence" "$issue"; then
+      return 0
     fi
     if text_contains_negated_dependency "$sentence" "$issue"; then
       continue
@@ -302,7 +315,11 @@ while IFS= read -r peer; do
 done < "$items_file"
 
 decision_file_json="$tmp_dir/decisions-file.json"
-if [ -n "$confirmed_decision_file" ] && [ -s "$confirmed_decision_file" ]; then
+if [ -n "$confirmed_decision_file" ]; then
+  if [ ! -s "$confirmed_decision_file" ]; then
+    echo "Confirmed decision file is missing or empty: $confirmed_decision_file" >&2
+    exit 66
+  fi
   jq -s --argjson selected "$selected" \
     '[.[] | select((.issue // .item_number // .number | tonumber) == $selected) | {summary: (.summary // .decision // .body // ""), source: (.source // "confirmed decision file")} | select(.summary != "")]' \
     "$confirmed_decision_file" > "$decision_file_json"
@@ -325,6 +342,23 @@ jq '
 
 confirmed_json="$(jq -s 'add' "$decision_file_json" "$comment_decisions_json")"
 relationships_json="$(if [ -s "$relationships_file" ]; then jq -s . "$relationships_file"; else printf '[]\n'; fi)"
+relationships_json="$(printf '%s\n' "$relationships_json" | jq --argjson decisions "$confirmed_json" '
+  def decision_text: (.summary // "" | ascii_downcase);
+  def says_independent: decision_text | test("orthogonal|independent|unrelated|no dependency|not dependent|not blocked");
+  def references_issue($issue): decision_text | test("#" + ($issue | tostring) + "([^0-9]|$)");
+  def confirmed_orthogonal($issue): any($decisions[]?; says_independent and references_issue($issue));
+  map(
+    if confirmed_orthogonal(.issue) then
+      .outcome = "Orthogonal"
+      | .blocking = false
+      | .humanAction = null
+      | .dispatchInstruction = "Treat the relationship as orthogonal based on confirmed human decision context."
+      | .evidence += ["Confirmed human decision marks this peer relationship as orthogonal."]
+    else
+      .
+    end
+  )
+')"
 blocking="$(printf '%s\n' "$relationships_json" | jq 'any(.[]; .blocking == true)')"
 human_actions_json="$(printf '%s\n' "$relationships_json" | jq '[.[] | select(.blocking == true) | .humanAction] | map(select(. != null)) | unique')"
 decision_conflict="$(printf '%s\n' "$confirmed_json" | jq '

--- a/scripts/development-workflow/spec-dispatch-context.sh
+++ b/scripts/development-workflow/spec-dispatch-context.sh
@@ -93,7 +93,7 @@ done < "$items_file"
 
 issue_text() {
   local issue="$1"
-  jq -r '[.title // "", .body // ""] | join("\n")' "$issue_json_dir/$issue.json"
+  jq -r '[.title // "", .body // "", (.comments[]?.body // empty)] | join("\n")' "$issue_json_dir/$issue.json"
 }
 
 significant_terms() {
@@ -135,24 +135,31 @@ dependency_phrase_pattern() {
 
 text_contains_dependency() {
   local text="$1" issue="$2"
-  local lower compact match issue_pattern dependency_pattern
+  local lower sentence match issue_pattern dependency_pattern first_ref
   lower="$(printf '%s\n' "$text" | tr '[:upper:]' '[:lower:]')"
-  compact="$(printf '%s\n' "$lower" | tr '\n' ' ')"
   issue_pattern="$(issue_ref_pattern "$issue")"
   dependency_pattern="$(dependency_phrase_pattern)"
-  while IFS= read -r match; do
-    if [ -z "$match" ]; then
+  while IFS= read -r sentence; do
+    if [ -z "$sentence" ]; then
       continue
     fi
-    if printf '%s\n' "$match" | grep -Eiq "^(not|without)[^.!?]{0,40}(${dependency_pattern})"; then
+    if text_contains_negated_dependency "$sentence" "$issue"; then
       continue
     fi
-    if printf '%s\n' "$match" | grep -Eiq "(not|without)[^.!?]{0,80}(${issue_pattern})"; then
-      continue
-    fi
-    return 0
+    while IFS= read -r match; do
+      if [ -z "$match" ]; then
+        continue
+      fi
+      first_ref="$(printf '%s\n' "$match" | grep -Eo '#[0-9]+' | head -1 || true)"
+      if [ -n "$first_ref" ] && [ "$first_ref" != "#$issue" ]; then
+        continue
+      fi
+      return 0
+    done <<EOF_MATCH
+$(printf '%s\n' "$sentence" | grep -Eio "(${dependency_pattern})[^.!?]{0,120}(${issue_pattern})" || true)
+EOF_MATCH
   done <<EOF
-$(printf '%s\n' "$compact" | grep -Eio "((not|without)[^.!?]{0,40})?(${dependency_pattern})[^.!?]{0,120}(${issue_pattern})" || true)
+$(printf '%s\n' "$lower" | tr '\n' ' ' | awk '{ gsub(/[.!?]+/, "\n"); print }')
 EOF
   return 1
 }
@@ -173,7 +180,7 @@ has_coupling_language() {
       {
         line = $0
         gsub(/[^a-z0-9]+/, " ", line)
-        if (line ~ /(^| )(depends|dependent|blocked|requires|required|prerequisite|coupled|coupling|shared|coordinate|coordination)( |$)/ ||
+        if (line ~ /(^| )(depends|dependent|blocked|prerequisite|coupled|coupling|shared|coordinate|coordination)( |$)/ ||
             line ~ /(^| )waiting on( |$)/ ||
             line ~ /(^| )same data( |$)/ ||
             line ~ /(^| )same schema( |$)/ ||
@@ -210,12 +217,23 @@ while IFS= read -r peer; do
   peer_terms="$tmp_dir/peer-$peer-terms"
   significant_terms < "$peer_text_file" > "$peer_terms"
 
+  selected_text="$(cat "$selected_text_file")"
+  peer_text="$(cat "$peer_text_file")"
+  selected_depends_on_peer=false
+  peer_depends_on_selected=false
+  if text_contains_dependency "$selected_text" "$peer"; then
+    selected_depends_on_peer=true
+  fi
+  if text_contains_dependency "$peer_text" "$selected"; then
+    peer_depends_on_selected=true
+  fi
+
   overlap_file="$tmp_dir/overlap-$peer"
   comm -12 "$selected_terms" "$peer_terms" > "$overlap_file"
 
   phrase_count="$(grep -c '^phrase:' "$overlap_file" || true)"
   term_count="$(grep -c '^term:' "$overlap_file" || true)"
-  if [ "$phrase_count" -lt 1 ] && [ "$term_count" -lt 2 ]; then
+  if [ "$selected_depends_on_peer" != "true" ] && [ "$peer_depends_on_selected" != "true" ] && [ "$phrase_count" -lt 1 ] && [ "$term_count" -lt 2 ]; then
     continue
   fi
 
@@ -225,14 +243,12 @@ while IFS= read -r peer; do
   evidence_file="$tmp_dir/evidence-$peer"
   : > "$evidence_file"
   outcome="Orthogonal"
-  selected_text="$(cat "$selected_text_file")"
-  peer_text="$(cat "$peer_text_file")"
 
-  if text_contains_dependency "$selected_text" "$peer"; then
+  if [ "$selected_depends_on_peer" = "true" ]; then
     outcome="Dependent"
     printf 'Selected issue contains an explicit dependency phrase referencing #%s.\n' "$peer" >> "$evidence_file"
   fi
-  if text_contains_dependency "$peer_text" "$selected"; then
+  if [ "$peer_depends_on_selected" = "true" ]; then
     outcome="Dependent"
     printf 'Peer issue #%s contains an explicit dependency phrase referencing #%s.\n' "$peer" "$selected" >> "$evidence_file"
   fi
@@ -300,7 +316,7 @@ jq '
   [
     .comments[]?
     | (.body // "") as $body
-    | select($body | test("(?i)(confirmed|approved|correction|clarifying|decision)"))
+	    | select($body | test("(?i)\\b(confirmed|approved|correction|clarifying|decision)\\b"))
     | {
         summary: ($body | gsub("\\s+"; " ") | .[0:240]),
         source: (.url // (.author.login // "issue comment"))

--- a/scripts/development-workflow/tests/test-spec-dispatch-context.sh
+++ b/scripts/development-workflow/tests/test-spec-dispatch-context.sh
@@ -176,6 +176,14 @@ non_conflicting_decision_file="$TMP_ROOT/non-conflicting-decisions.jsonl"
 non_conflicting_decision_output="$("$HELPER" --selected 100 --items 100 --confirmed-decision-file "$non_conflicting_decision_file" --json)"
 run_test "requires_detail_decision_not_conflict" "false" "$(printf '%s\n' "$non_conflicting_decision_output" | jq -r '.blocking')"
 
+different_peer_decision_file="$TMP_ROOT/different-peer-decisions.jsonl"
+{
+  printf '%s\n' '{"issue":100,"summary":"Decision: selected work is not blocked by #101.","source":"session"}'
+  printf '%s\n' '{"issue":100,"summary":"Decision: selected work depends on #102.","source":"session"}'
+} > "$different_peer_decision_file"
+different_peer_decision_output="$("$HELPER" --selected 100 --items 100 --confirmed-decision-file "$different_peer_decision_file" --json)"
+run_test "different_peer_decisions_do_not_conflict" "false" "$(printf '%s\n' "$different_peer_decision_output" | jq -r '.blocking')"
+
 dependent_output="$("$HELPER" --selected 100 --items 100,102 --json)"
 run_test "dependent_outcome" "Dependent" "$(printf '%s\n' "$dependent_output" | jq -r '.relationships[0].outcome')"
 run_test "dependent_not_blocking" "false" "$(printf '%s\n' "$dependent_output" | jq -r '.blocking')"

--- a/scripts/development-workflow/tests/test-spec-dispatch-context.sh
+++ b/scripts/development-workflow/tests/test-spec-dispatch-context.sh
@@ -53,6 +53,11 @@ JSON
 {"number":108,"title":"Negated blocked-by public-site component","body":"This is not blocked by #100. It shares public site component language but can proceed independently.","comments":[]}
 JSON
     ;;
+  109)
+    cat <<'JSON'
+{"number":109,"title":"Mixed dependency public-site component","body":"This depends on #100 for the API layer. It is not related to #100 for the UI layer.","comments":[]}
+JSON
+    ;;
   107)
     cat <<'JSON'
 {"number":107,"title":"Larger issue reference public-site component","body":"This depends on #2100 for unrelated public site component catalog work.","comments":[]}
@@ -117,6 +122,10 @@ run_test "negative_lookalike_not_blocking" "false" "$(printf '%s\n' "$negative_o
 negated_dependency_output="$("$HELPER" --selected 100 --items 100,108 --json)"
 run_test "negated_dependency_phrase_not_dependent" "not-dependent" "$(printf '%s\n' "$negated_dependency_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"
 run_test "negated_dependency_phrase_not_blocking" "false" "$(printf '%s\n' "$negated_dependency_output" | jq -r '.blocking')"
+
+mixed_dependency_output="$("$HELPER" --selected 100 --items 100,109 --json)"
+run_test "mixed_dependency_keeps_dependent" "Dependent" "$(printf '%s\n' "$mixed_dependency_output" | jq -r '.relationships[0].outcome')"
+run_test "mixed_dependency_not_blocking" "false" "$(printf '%s\n' "$mixed_dependency_output" | jq -r '.blocking')"
 
 boundary_output="$("$HELPER" --selected 100 --items 100,107 --json)"
 run_test "larger_issue_number_not_dependent" "not-dependent" "$(printf '%s\n' "$boundary_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"

--- a/scripts/development-workflow/tests/test-spec-dispatch-context.sh
+++ b/scripts/development-workflow/tests/test-spec-dispatch-context.sh
@@ -48,6 +48,11 @@ JSON
 {"number":104,"title":"Negative dependency lookalike public-site component","body":"This requires clarification, not #100. It shares public site component language but does not name a prerequisite.","comments":[]}
 JSON
     ;;
+  108)
+    cat <<'JSON'
+{"number":108,"title":"Negated blocked-by public-site component","body":"This is not blocked by #100. It shares public site component language but can proceed independently.","comments":[]}
+JSON
+    ;;
   107)
     cat <<'JSON'
 {"number":107,"title":"Larger issue reference public-site component","body":"This depends on #2100 for unrelated public site component catalog work.","comments":[]}
@@ -108,6 +113,10 @@ run_test "unclear_human_action" "yes" "$(printf '%s\n' "$unclear_output" | jq -r
 negative_output="$("$HELPER" --selected 100 --items 100,104 --json)"
 run_test "negative_lookalike_not_dependent" "not-dependent" "$(printf '%s\n' "$negative_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"
 run_test "negative_lookalike_not_blocking" "false" "$(printf '%s\n' "$negative_output" | jq -r '.blocking')"
+
+negated_dependency_output="$("$HELPER" --selected 100 --items 100,108 --json)"
+run_test "negated_dependency_phrase_not_dependent" "not-dependent" "$(printf '%s\n' "$negated_dependency_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"
+run_test "negated_dependency_phrase_not_blocking" "false" "$(printf '%s\n' "$negated_dependency_output" | jq -r '.blocking')"
 
 boundary_output="$("$HELPER" --selected 100 --items 100,107 --json)"
 run_test "larger_issue_number_not_dependent" "not-dependent" "$(printf '%s\n' "$boundary_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"

--- a/scripts/development-workflow/tests/test-spec-dispatch-context.sh
+++ b/scripts/development-workflow/tests/test-spec-dispatch-context.sh
@@ -103,6 +103,11 @@ JSON
 {"number":118,"title":"Without public-site component","body":"This cannot proceed without #100 for the public site component.","comments":[]}
 JSON
     ;;
+  119)
+    cat <<'JSON'
+{"number":119,"title":"Sprint number public-site component","body":"This requires sprint 100 for public site component planning, not an issue reference.","comments":[]}
+JSON
+    ;;
   107)
     cat <<'JSON'
 {"number":107,"title":"Larger issue reference public-site component","body":"This depends on #2100 for unrelated public site component catalog work.","comments":[]}
@@ -207,6 +212,11 @@ run_test "orthogonal_decision_overrides_dependency" "Orthogonal" "$(printf '%s\n
 run_test "orthogonal_decision_override_not_blocking" "false" "$(printf '%s\n' "$orthogonal_override_output" | jq -r '.blocking')"
 run_test "orthogonal_decision_replaces_dependency_evidence" "no-stale-evidence" "$(printf '%s\n' "$orthogonal_override_output" | jq -r 'if (.relationships[0].evidence | join(" ") | test("explicit dependency phrase")) then "stale-evidence" else "no-stale-evidence" end')"
 
+not_blocked_override_file="$TMP_ROOT/not-blocked-override.jsonl"
+printf '%s\n' '{"issue":100,"summary":"Decision: selected work is not blocked by #102.","source":"session"}' > "$not_blocked_override_file"
+not_blocked_override_output="$("$HELPER" --selected 100 --items 100,102 --confirmed-decision-file "$not_blocked_override_file" --json)"
+run_test "not_blocked_does_not_override_dependency" "Dependent" "$(printf '%s\n' "$not_blocked_override_output" | jq -r '.relationships[0].outcome')"
+
 comment_dependency_output="$("$HELPER" --selected 100 --items 100,114 --json)"
 run_test "comment_dependency_bypasses_overlap_gate" "Dependent" "$(printf '%s\n' "$comment_dependency_output" | jq -r '.relationships[0].outcome')"
 run_test "comment_dependency_not_blocking" "false" "$(printf '%s\n' "$comment_dependency_output" | jq -r '.blocking')"
@@ -247,6 +257,10 @@ run_test "independent_word_not_blocking" "false" "$(printf '%s\n' "$independent_
 bare_requires_output="$("$HELPER" --selected 100 --items 100,113 --json)"
 run_test "bare_requires_not_unclear" "Orthogonal" "$(printf '%s\n' "$bare_requires_output" | jq -r '.relationships[0].outcome')"
 run_test "bare_requires_not_blocking" "false" "$(printf '%s\n' "$bare_requires_output" | jq -r '.blocking')"
+
+bare_number_output="$("$HELPER" --selected 100 --items 100,119 --json)"
+run_test "bare_number_not_dependent" "not-dependent" "$(printf '%s\n' "$bare_number_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"
+run_test "bare_number_not_blocking" "false" "$(printf '%s\n' "$bare_number_output" | jq -r '.blocking')"
 
 boundary_output="$("$HELPER" --selected 100 --items 100,107 --json)"
 run_test "larger_issue_number_not_dependent" "not-dependent" "$(printf '%s\n' "$boundary_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"

--- a/scripts/development-workflow/tests/test-spec-dispatch-context.sh
+++ b/scripts/development-workflow/tests/test-spec-dispatch-context.sh
@@ -58,6 +58,21 @@ JSON
 {"number":109,"title":"Mixed dependency public-site component","body":"This depends on #100 for the API layer. It is not related to #100 for the UI layer.","comments":[]}
 JSON
     ;;
+  110)
+    cat <<'JSON'
+{"number":110,"title":"Independent public-site component content","body":"This independent public site component content can proceed alone.","comments":[]}
+JSON
+    ;;
+  111)
+    cat <<'JSON'
+{"number":111,"title":"Dependent-on public-site component","body":"This is dependent on #100 for the selected unit-stage output.","comments":[]}
+JSON
+    ;;
+  112)
+    cat <<'JSON'
+{"number":112,"title":"Coupled public-site component validation","body":"Coordinate shared public site component validation behavior with the selected work before writing acceptance criteria.","comments":[]}
+JSON
+    ;;
   107)
     cat <<'JSON'
 {"number":107,"title":"Larger issue reference public-site component","body":"This depends on #2100 for unrelated public site component catalog work.","comments":[]}
@@ -106,14 +121,31 @@ printf '%s\n' '{"issue":100,"summary":"Human confirmed this is one component ins
 decision_output="$("$HELPER" --selected 100 --items 100 --confirmed-decision-file "$decision_file" --json)"
 run_test "decision_file_included" "Human confirmed this is one component instance." "$(printf '%s\n' "$decision_output" | jq -r '.confirmedDecisions[] | select(.source == "session") | .summary')"
 
+conflicting_decision_file="$TMP_ROOT/conflicting-decisions.jsonl"
+{
+  printf '%s\n' '{"issue":100,"summary":"Decision: selected work depends on #200.","source":"session"}'
+  printf '%s\n' '{"issue":100,"summary":"Decision: selected work is orthogonal to #200.","source":"session"}'
+} > "$conflicting_decision_file"
+conflicting_decision_output="$("$HELPER" --selected 100 --items 100 --confirmed-decision-file "$conflicting_decision_file" --json)"
+run_test "conflicting_decisions_block" "true" "$(printf '%s\n' "$conflicting_decision_output" | jq -r '.blocking')"
+run_test "conflicting_decisions_human_action" "yes" "$(printf '%s\n' "$conflicting_decision_output" | jq -r '.humanAction | test("conflicting confirmed decisions") | if . then "yes" else "no" end')"
+
 dependent_output="$("$HELPER" --selected 100 --items 100,102 --json)"
 run_test "dependent_outcome" "Dependent" "$(printf '%s\n' "$dependent_output" | jq -r '.relationships[0].outcome')"
 run_test "dependent_not_blocking" "false" "$(printf '%s\n' "$dependent_output" | jq -r '.blocking')"
+
+dependent_on_output="$("$HELPER" --selected 100 --items 100,111 --json)"
+run_test "dependent_on_outcome" "Dependent" "$(printf '%s\n' "$dependent_on_output" | jq -r '.relationships[0].outcome')"
+run_test "dependent_on_not_blocking" "false" "$(printf '%s\n' "$dependent_on_output" | jq -r '.blocking')"
 
 unclear_output="$("$HELPER" --selected 100 --items 100,103 --json)"
 run_test "unclear_outcome" "Unclear" "$(printf '%s\n' "$unclear_output" | jq -r '.relationships[0].outcome')"
 run_test "unclear_blocks" "true" "$(printf '%s\n' "$unclear_output" | jq -r '.blocking')"
 run_test "unclear_human_action" "yes" "$(printf '%s\n' "$unclear_output" | jq -r '.humanAction | test("Confirm whether") | if . then "yes" else "no" end')"
+
+multi_unclear_output="$("$HELPER" --selected 100 --items 100,103,112 --json)"
+run_test "multi_unclear_human_action_includes_first_peer" "yes" "$(printf '%s\n' "$multi_unclear_output" | jq -r '.humanAction | test("#103") | if . then "yes" else "no" end')"
+run_test "multi_unclear_human_action_includes_second_peer" "yes" "$(printf '%s\n' "$multi_unclear_output" | jq -r '.humanAction | test("#112") | if . then "yes" else "no" end')"
 
 negative_output="$("$HELPER" --selected 100 --items 100,104 --json)"
 run_test "negative_lookalike_not_dependent" "not-dependent" "$(printf '%s\n' "$negative_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"
@@ -126,6 +158,10 @@ run_test "negated_dependency_phrase_not_blocking" "false" "$(printf '%s\n' "$neg
 mixed_dependency_output="$("$HELPER" --selected 100 --items 100,109 --json)"
 run_test "mixed_dependency_keeps_dependent" "Dependent" "$(printf '%s\n' "$mixed_dependency_output" | jq -r '.relationships[0].outcome')"
 run_test "mixed_dependency_not_blocking" "false" "$(printf '%s\n' "$mixed_dependency_output" | jq -r '.blocking')"
+
+independent_word_output="$("$HELPER" --selected 100 --items 100,110 --json)"
+run_test "independent_word_not_unclear" "Orthogonal" "$(printf '%s\n' "$independent_word_output" | jq -r '.relationships[0].outcome')"
+run_test "independent_word_not_blocking" "false" "$(printf '%s\n' "$independent_word_output" | jq -r '.blocking')"
 
 boundary_output="$("$HELPER" --selected 100 --items 100,107 --json)"
 run_test "larger_issue_number_not_dependent" "not-dependent" "$(printf '%s\n' "$boundary_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"

--- a/scripts/development-workflow/tests/test-spec-dispatch-context.sh
+++ b/scripts/development-workflow/tests/test-spec-dispatch-context.sh
@@ -197,6 +197,7 @@ printf '%s\n' '{"issue":100,"summary":"Decision: selected work is orthogonal to 
 orthogonal_override_output="$("$HELPER" --selected 100 --items 100,102 --confirmed-decision-file "$orthogonal_override_file" --json)"
 run_test "orthogonal_decision_overrides_dependency" "Orthogonal" "$(printf '%s\n' "$orthogonal_override_output" | jq -r '.relationships[0].outcome')"
 run_test "orthogonal_decision_override_not_blocking" "false" "$(printf '%s\n' "$orthogonal_override_output" | jq -r '.blocking')"
+run_test "orthogonal_decision_replaces_dependency_evidence" "no-stale-evidence" "$(printf '%s\n' "$orthogonal_override_output" | jq -r 'if (.relationships[0].evidence | join(" ") | test("explicit dependency phrase")) then "stale-evidence" else "no-stale-evidence" end')"
 
 comment_dependency_output="$("$HELPER" --selected 100 --items 100,114 --json)"
 run_test "comment_dependency_bypasses_overlap_gate" "Dependent" "$(printf '%s\n' "$comment_dependency_output" | jq -r '.relationships[0].outcome')"

--- a/scripts/development-workflow/tests/test-spec-dispatch-context.sh
+++ b/scripts/development-workflow/tests/test-spec-dispatch-context.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# test-spec-dispatch-context.sh - Unit tests for spec dispatch relationship context.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+HELPER="$REPO_ROOT/scripts/development-workflow/spec-dispatch-context.sh"
+
+TMP_ROOT="$(mktemp -d)"
+MOCK_BIN="$TMP_ROOT/bin"
+mkdir -p "$MOCK_BIN"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+cat > "$MOCK_BIN/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+
+if [ "$1" != "issue" ] || [ "$2" != "view" ]; then
+  echo "unexpected gh invocation: $*" >&2
+  exit 64
+fi
+
+issue="$3"
+
+case "$issue" in
+  100)
+    cat <<'JSON'
+{"number":100,"title":"Internal public-site component unit stages","body":"Build unit stages as an internal state switcher within one public site component instance.","comments":[{"body":"Decision: the selected item uses one component instance with an internal switcher.","url":"https://example.test/comments/1"}]}
+JSON
+    ;;
+  101)
+    cat <<'JSON'
+{"number":101,"title":"Multiple public-site component instances","body":"Allow multiple instances of the same public site component type in the catalog.","comments":[]}
+JSON
+    ;;
+  102)
+    cat <<'JSON'
+{"number":102,"title":"Dependent public-site component catalog","body":"This depends on #100 because the catalog needs the selected unit-stage output first.","comments":[]}
+JSON
+    ;;
+  103)
+    cat <<'JSON'
+{"number":103,"title":"Coupled public-site component schema","body":"Coordinate shared public site component schema behavior with the selected work before writing acceptance criteria.","comments":[]}
+JSON
+    ;;
+  104)
+    cat <<'JSON'
+{"number":104,"title":"Negative dependency lookalike public-site component","body":"This requires clarification, not #100. It shares public site component language but does not name a prerequisite.","comments":[]}
+JSON
+    ;;
+  105)
+    cat <<'JSON'
+{"number":105,"title":"Workflow helper alpha","body":"Tighten helper behavior.","comments":[]}
+JSON
+    ;;
+  106)
+    cat <<'JSON'
+{"number":106,"title":"Workflow runner beta","body":"Document runner behavior.","comments":[]}
+JSON
+    ;;
+  *)
+    echo "unknown issue $issue" >&2
+    exit 1
+    ;;
+esac
+MOCK_GH
+chmod +x "$MOCK_BIN/gh"
+export PATH="$MOCK_BIN:$PATH"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+orthogonal_output="$("$HELPER" --selected 100 --items 100,101 --json)"
+run_test "orthogonal_overlap_outcome" "Orthogonal" "$(printf '%s\n' "$orthogonal_output" | jq -r '.relationships[0].outcome')"
+run_test "orthogonal_not_blocking" "false" "$(printf '%s\n' "$orthogonal_output" | jq -r '.blocking')"
+run_test "issue_comment_decision_included" "yes" "$(printf '%s\n' "$orthogonal_output" | jq -r '.confirmedDecisions[0].summary | test("internal switcher") | if . then "yes" else "no" end')"
+
+decision_file="$TMP_ROOT/decisions.jsonl"
+printf '%s\n' '{"issue":100,"summary":"Human confirmed this is one component instance.","source":"session"}' > "$decision_file"
+decision_output="$("$HELPER" --selected 100 --items 100 --confirmed-decision-file "$decision_file" --json)"
+run_test "decision_file_included" "Human confirmed this is one component instance." "$(printf '%s\n' "$decision_output" | jq -r '.confirmedDecisions[] | select(.source == "session") | .summary')"
+
+dependent_output="$("$HELPER" --selected 100 --items 100,102 --json)"
+run_test "dependent_outcome" "Dependent" "$(printf '%s\n' "$dependent_output" | jq -r '.relationships[0].outcome')"
+run_test "dependent_not_blocking" "false" "$(printf '%s\n' "$dependent_output" | jq -r '.blocking')"
+
+unclear_output="$("$HELPER" --selected 100 --items 100,103 --json)"
+run_test "unclear_outcome" "Unclear" "$(printf '%s\n' "$unclear_output" | jq -r '.relationships[0].outcome')"
+run_test "unclear_blocks" "true" "$(printf '%s\n' "$unclear_output" | jq -r '.blocking')"
+run_test "unclear_human_action" "yes" "$(printf '%s\n' "$unclear_output" | jq -r '.humanAction | test("Confirm whether") | if . then "yes" else "no" end')"
+
+negative_output="$("$HELPER" --selected 100 --items 100,104 --json)"
+run_test "negative_lookalike_not_dependent" "not-dependent" "$(printf '%s\n' "$negative_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"
+
+low_overlap_output="$("$HELPER" --selected 105 --items 105,106 --json)"
+run_test "low_impact_overlap_ignored" "0" "$(printf '%s\n' "$low_overlap_output" | jq -r '.relationships | length')"
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+[ "$FAIL_COUNT" -eq 0 ]

--- a/scripts/development-workflow/tests/test-spec-dispatch-context.sh
+++ b/scripts/development-workflow/tests/test-spec-dispatch-context.sh
@@ -48,6 +48,11 @@ JSON
 {"number":104,"title":"Negative dependency lookalike public-site component","body":"This requires clarification, not #100. It shares public site component language but does not name a prerequisite.","comments":[]}
 JSON
     ;;
+  107)
+    cat <<'JSON'
+{"number":107,"title":"Larger issue reference public-site component","body":"This depends on #2100 for unrelated public site component catalog work.","comments":[]}
+JSON
+    ;;
   105)
     cat <<'JSON'
 {"number":105,"title":"Workflow helper alpha","body":"Tighten helper behavior.","comments":[]}
@@ -102,6 +107,10 @@ run_test "unclear_human_action" "yes" "$(printf '%s\n' "$unclear_output" | jq -r
 
 negative_output="$("$HELPER" --selected 100 --items 100,104 --json)"
 run_test "negative_lookalike_not_dependent" "not-dependent" "$(printf '%s\n' "$negative_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"
+run_test "negative_lookalike_not_blocking" "false" "$(printf '%s\n' "$negative_output" | jq -r '.blocking')"
+
+boundary_output="$("$HELPER" --selected 100 --items 100,107 --json)"
+run_test "larger_issue_number_not_dependent" "not-dependent" "$(printf '%s\n' "$boundary_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"
 
 low_overlap_output="$("$HELPER" --selected 105 --items 105,106 --json)"
 run_test "low_impact_overlap_ignored" "0" "$(printf '%s\n' "$low_overlap_output" | jq -r '.relationships | length')"

--- a/scripts/development-workflow/tests/test-spec-dispatch-context.sh
+++ b/scripts/development-workflow/tests/test-spec-dispatch-context.sh
@@ -93,6 +93,11 @@ JSON
 {"number":116,"title":"Negated sentence public-site component","body":"This does not depend on #100, but it requires #100 discussion notes. It shares public site component wording.","comments":[]}
 JSON
     ;;
+  117)
+    cat <<'JSON'
+{"number":117,"title":"Prerequisite public-site component","body":"This has prerequisite #100 before the public site component can proceed.","comments":[]}
+JSON
+    ;;
   107)
     cat <<'JSON'
 {"number":107,"title":"Larger issue reference public-site component","body":"This depends on #2100 for unrelated public site component catalog work.","comments":[]}
@@ -166,6 +171,10 @@ run_test "dependent_not_blocking" "false" "$(printf '%s\n' "$dependent_output" |
 dependent_on_output="$("$HELPER" --selected 100 --items 100,111 --json)"
 run_test "dependent_on_outcome" "Dependent" "$(printf '%s\n' "$dependent_on_output" | jq -r '.relationships[0].outcome')"
 run_test "dependent_on_not_blocking" "false" "$(printf '%s\n' "$dependent_on_output" | jq -r '.blocking')"
+
+prerequisite_output="$("$HELPER" --selected 100 --items 100,117 --json)"
+run_test "prerequisite_outcome" "Dependent" "$(printf '%s\n' "$prerequisite_output" | jq -r '.relationships[0].outcome')"
+run_test "prerequisite_not_blocking" "false" "$(printf '%s\n' "$prerequisite_output" | jq -r '.blocking')"
 
 comment_dependency_output="$("$HELPER" --selected 100 --items 100,114 --json)"
 run_test "comment_dependency_bypasses_overlap_gate" "Dependent" "$(printf '%s\n' "$comment_dependency_output" | jq -r '.relationships[0].outcome')"

--- a/scripts/development-workflow/tests/test-spec-dispatch-context.sh
+++ b/scripts/development-workflow/tests/test-spec-dispatch-context.sh
@@ -98,6 +98,11 @@ JSON
 {"number":117,"title":"Prerequisite public-site component","body":"This has prerequisite #100 before the public site component can proceed.","comments":[]}
 JSON
     ;;
+  118)
+    cat <<'JSON'
+{"number":118,"title":"Without public-site component","body":"This cannot proceed without #100 for the public site component.","comments":[]}
+JSON
+    ;;
   107)
     cat <<'JSON'
 {"number":107,"title":"Larger issue reference public-site component","body":"This depends on #2100 for unrelated public site component catalog work.","comments":[]}
@@ -147,6 +152,13 @@ printf '%s\n' '{"issue":100,"summary":"Human confirmed this is one component ins
 decision_output="$("$HELPER" --selected 100 --items 100 --confirmed-decision-file "$decision_file" --json)"
 run_test "decision_file_included" "Human confirmed this is one component instance." "$(printf '%s\n' "$decision_output" | jq -r '.confirmedDecisions[] | select(.source == "session") | .summary')"
 
+if "$HELPER" --selected 100 --items 100 --confirmed-decision-file "$TMP_ROOT/missing-decisions.jsonl" --json >/dev/null 2>&1; then
+  missing_decision_result="success"
+else
+  missing_decision_result="failure"
+fi
+run_test "missing_decision_file_fails" "failure" "$missing_decision_result"
+
 conflicting_decision_file="$TMP_ROOT/conflicting-decisions.jsonl"
 {
   printf '%s\n' '{"issue":100,"summary":"Decision: selected work depends on #200.","source":"session"}'
@@ -175,6 +187,16 @@ run_test "dependent_on_not_blocking" "false" "$(printf '%s\n' "$dependent_on_out
 prerequisite_output="$("$HELPER" --selected 100 --items 100,117 --json)"
 run_test "prerequisite_outcome" "Dependent" "$(printf '%s\n' "$prerequisite_output" | jq -r '.relationships[0].outcome')"
 run_test "prerequisite_not_blocking" "false" "$(printf '%s\n' "$prerequisite_output" | jq -r '.blocking')"
+
+without_dependency_output="$("$HELPER" --selected 100 --items 100,118 --json)"
+run_test "without_dependency_outcome" "Dependent" "$(printf '%s\n' "$without_dependency_output" | jq -r '.relationships[0].outcome')"
+run_test "without_dependency_not_blocking" "false" "$(printf '%s\n' "$without_dependency_output" | jq -r '.blocking')"
+
+orthogonal_override_file="$TMP_ROOT/orthogonal-override.jsonl"
+printf '%s\n' '{"issue":100,"summary":"Decision: selected work is orthogonal to #102.","source":"session"}' > "$orthogonal_override_file"
+orthogonal_override_output="$("$HELPER" --selected 100 --items 100,102 --confirmed-decision-file "$orthogonal_override_file" --json)"
+run_test "orthogonal_decision_overrides_dependency" "Orthogonal" "$(printf '%s\n' "$orthogonal_override_output" | jq -r '.relationships[0].outcome')"
+run_test "orthogonal_decision_override_not_blocking" "false" "$(printf '%s\n' "$orthogonal_override_output" | jq -r '.blocking')"
 
 comment_dependency_output="$("$HELPER" --selected 100 --items 100,114 --json)"
 run_test "comment_dependency_bypasses_overlap_gate" "Dependent" "$(printf '%s\n' "$comment_dependency_output" | jq -r '.relationships[0].outcome')"

--- a/scripts/development-workflow/tests/test-spec-dispatch-context.sh
+++ b/scripts/development-workflow/tests/test-spec-dispatch-context.sh
@@ -25,7 +25,7 @@ issue="$3"
 case "$issue" in
   100)
     cat <<'JSON'
-{"number":100,"title":"Internal public-site component unit stages","body":"Build unit stages as an internal state switcher within one public site component instance.","comments":[{"body":"Decision: the selected item uses one component instance with an internal switcher.","url":"https://example.test/comments/1"}]}
+{"number":100,"title":"Internal public-site component unit stages","body":"Build unit stages as an internal state switcher within one public site component instance.","comments":[{"body":"Decision: the selected item uses one component instance with an internal switcher.","url":"https://example.test/comments/1"},{"body":"We still have indecision around naming, but no settled outcome here.","url":"https://example.test/comments/2"}]}
 JSON
     ;;
   101)
@@ -73,6 +73,26 @@ JSON
 {"number":112,"title":"Coupled public-site component validation","body":"Coordinate shared public site component validation behavior with the selected work before writing acceptance criteria.","comments":[]}
 JSON
     ;;
+  113)
+    cat <<'JSON'
+{"number":113,"title":"Clarification public-site component","body":"This requires clarification for public site component copy, but does not name another issue.","comments":[]}
+JSON
+    ;;
+  114)
+    cat <<'JSON'
+{"number":114,"title":"Remote blocker","body":"Different words only.","comments":[{"body":"Decision: this depends on #100 for the selected output.","url":"https://example.test/comments/114"}]}
+JSON
+    ;;
+  115)
+    cat <<'JSON'
+{"number":115,"title":"Different-target public-site component","body":"This depends on #200, but is not related to #100. It shares public site component wording.","comments":[]}
+JSON
+    ;;
+  116)
+    cat <<'JSON'
+{"number":116,"title":"Negated sentence public-site component","body":"This does not depend on #100, but it requires #100 discussion notes. It shares public site component wording.","comments":[]}
+JSON
+    ;;
   107)
     cat <<'JSON'
 {"number":107,"title":"Larger issue reference public-site component","body":"This depends on #2100 for unrelated public site component catalog work.","comments":[]}
@@ -115,6 +135,7 @@ orthogonal_output="$("$HELPER" --selected 100 --items 100,101 --json)"
 run_test "orthogonal_overlap_outcome" "Orthogonal" "$(printf '%s\n' "$orthogonal_output" | jq -r '.relationships[0].outcome')"
 run_test "orthogonal_not_blocking" "false" "$(printf '%s\n' "$orthogonal_output" | jq -r '.blocking')"
 run_test "issue_comment_decision_included" "yes" "$(printf '%s\n' "$orthogonal_output" | jq -r '.confirmedDecisions[0].summary | test("internal switcher") | if . then "yes" else "no" end')"
+run_test "comment_decision_substring_ignored" "1" "$(printf '%s\n' "$orthogonal_output" | jq -r '.confirmedDecisions | length')"
 
 decision_file="$TMP_ROOT/decisions.jsonl"
 printf '%s\n' '{"issue":100,"summary":"Human confirmed this is one component instance.","source":"session"}' > "$decision_file"
@@ -138,6 +159,10 @@ dependent_on_output="$("$HELPER" --selected 100 --items 100,111 --json)"
 run_test "dependent_on_outcome" "Dependent" "$(printf '%s\n' "$dependent_on_output" | jq -r '.relationships[0].outcome')"
 run_test "dependent_on_not_blocking" "false" "$(printf '%s\n' "$dependent_on_output" | jq -r '.blocking')"
 
+comment_dependency_output="$("$HELPER" --selected 100 --items 100,114 --json)"
+run_test "comment_dependency_bypasses_overlap_gate" "Dependent" "$(printf '%s\n' "$comment_dependency_output" | jq -r '.relationships[0].outcome')"
+run_test "comment_dependency_not_blocking" "false" "$(printf '%s\n' "$comment_dependency_output" | jq -r '.blocking')"
+
 unclear_output="$("$HELPER" --selected 100 --items 100,103 --json)"
 run_test "unclear_outcome" "Unclear" "$(printf '%s\n' "$unclear_output" | jq -r '.relationships[0].outcome')"
 run_test "unclear_blocks" "true" "$(printf '%s\n' "$unclear_output" | jq -r '.blocking')"
@@ -159,9 +184,21 @@ mixed_dependency_output="$("$HELPER" --selected 100 --items 100,109 --json)"
 run_test "mixed_dependency_keeps_dependent" "Dependent" "$(printf '%s\n' "$mixed_dependency_output" | jq -r '.relationships[0].outcome')"
 run_test "mixed_dependency_not_blocking" "false" "$(printf '%s\n' "$mixed_dependency_output" | jq -r '.blocking')"
 
+different_target_output="$("$HELPER" --selected 100 --items 100,115 --json)"
+run_test "different_target_not_dependent" "not-dependent" "$(printf '%s\n' "$different_target_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"
+run_test "different_target_not_blocking" "false" "$(printf '%s\n' "$different_target_output" | jq -r '.blocking')"
+
+negated_sentence_output="$("$HELPER" --selected 100 --items 100,116 --json)"
+run_test "negated_sentence_not_dependent" "not-dependent" "$(printf '%s\n' "$negated_sentence_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"
+run_test "negated_sentence_not_blocking" "false" "$(printf '%s\n' "$negated_sentence_output" | jq -r '.blocking')"
+
 independent_word_output="$("$HELPER" --selected 100 --items 100,110 --json)"
 run_test "independent_word_not_unclear" "Orthogonal" "$(printf '%s\n' "$independent_word_output" | jq -r '.relationships[0].outcome')"
 run_test "independent_word_not_blocking" "false" "$(printf '%s\n' "$independent_word_output" | jq -r '.blocking')"
+
+bare_requires_output="$("$HELPER" --selected 100 --items 100,113 --json)"
+run_test "bare_requires_not_unclear" "Orthogonal" "$(printf '%s\n' "$bare_requires_output" | jq -r '.relationships[0].outcome')"
+run_test "bare_requires_not_blocking" "false" "$(printf '%s\n' "$bare_requires_output" | jq -r '.blocking')"
 
 boundary_output="$("$HELPER" --selected 100 --items 100,107 --json)"
 run_test "larger_issue_number_not_dependent" "not-dependent" "$(printf '%s\n' "$boundary_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"

--- a/scripts/development-workflow/tests/test-spec-dispatch-context.sh
+++ b/scripts/development-workflow/tests/test-spec-dispatch-context.sh
@@ -108,6 +108,11 @@ JSON
 {"number":119,"title":"Sprint number public-site component","body":"This requires sprint 100 for public site component planning, not an issue reference.","comments":[]}
 JSON
     ;;
+  120)
+    cat <<'JSON'
+{"number":120,"title":"Cannot wait public-site component","body":"This cannot wait because it depends on #100 for public site component sequencing.","comments":[]}
+JSON
+    ;;
   107)
     cat <<'JSON'
 {"number":107,"title":"Larger issue reference public-site component","body":"This depends on #2100 for unrelated public site component catalog work.","comments":[]}
@@ -192,6 +197,10 @@ run_test "different_peer_decisions_do_not_conflict" "false" "$(printf '%s\n' "$d
 dependent_output="$("$HELPER" --selected 100 --items 100,102 --json)"
 run_test "dependent_outcome" "Dependent" "$(printf '%s\n' "$dependent_output" | jq -r '.relationships[0].outcome')"
 run_test "dependent_not_blocking" "false" "$(printf '%s\n' "$dependent_output" | jq -r '.blocking')"
+
+cannot_output="$("$HELPER" --selected 100 --items 100,120 --json)"
+run_test "cannot_subword_keeps_dependency" "Dependent" "$(printf '%s\n' "$cannot_output" | jq -r '.relationships[0].outcome')"
+run_test "cannot_subword_not_blocking" "false" "$(printf '%s\n' "$cannot_output" | jq -r '.blocking')"
 
 dependent_on_output="$("$HELPER" --selected 100 --items 100,111 --json)"
 run_test "dependent_on_outcome" "Dependent" "$(printf '%s\n' "$dependent_on_output" | jq -r '.relationships[0].outcome')"

--- a/scripts/development-workflow/tests/test-spec-dispatch-context.sh
+++ b/scripts/development-workflow/tests/test-spec-dispatch-context.sh
@@ -151,6 +151,14 @@ conflicting_decision_output="$("$HELPER" --selected 100 --items 100 --confirmed-
 run_test "conflicting_decisions_block" "true" "$(printf '%s\n' "$conflicting_decision_output" | jq -r '.blocking')"
 run_test "conflicting_decisions_human_action" "yes" "$(printf '%s\n' "$conflicting_decision_output" | jq -r '.humanAction | test("conflicting confirmed decisions") | if . then "yes" else "no" end')"
 
+non_conflicting_decision_file="$TMP_ROOT/non-conflicting-decisions.jsonl"
+{
+  printf '%s\n' '{"issue":100,"summary":"Decision: selected work is orthogonal to #200.","source":"session"}'
+  printf '%s\n' '{"issue":100,"summary":"Follow-up requires more detail before implementation.","source":"session"}'
+} > "$non_conflicting_decision_file"
+non_conflicting_decision_output="$("$HELPER" --selected 100 --items 100 --confirmed-decision-file "$non_conflicting_decision_file" --json)"
+run_test "requires_detail_decision_not_conflict" "false" "$(printf '%s\n' "$non_conflicting_decision_output" | jq -r '.blocking')"
+
 dependent_output="$("$HELPER" --selected 100 --items 100,102 --json)"
 run_test "dependent_outcome" "Dependent" "$(printf '%s\n' "$dependent_output" | jq -r '.relationships[0].outcome')"
 run_test "dependent_not_blocking" "false" "$(printf '%s\n' "$dependent_output" | jq -r '.blocking')"
@@ -202,6 +210,7 @@ run_test "bare_requires_not_blocking" "false" "$(printf '%s\n' "$bare_requires_o
 
 boundary_output="$("$HELPER" --selected 100 --items 100,107 --json)"
 run_test "larger_issue_number_not_dependent" "not-dependent" "$(printf '%s\n' "$boundary_output" | jq -r 'if .relationships[0].outcome == "Dependent" then "dependent" else "not-dependent" end')"
+run_test "larger_issue_number_not_blocking" "false" "$(printf '%s\n' "$boundary_output" | jq -r '.blocking')"
 
 low_overlap_output="$("$HELPER" --selected 105 --items 105,106 --json)"
 run_test "low_impact_overlap_ignored" "0" "$(printf '%s\n' "$low_overlap_output" | jq -r '.relationships | length')"


### PR DESCRIPTION
## Summary

- Add `spec-dispatch-context.sh` to build conservative Backlog spec-dispatch context from issue text, comments, and optional confirmed-decision JSONL.
- Classify meaningful overlap as `Dependent`, `Orthogonal`, or `Unclear`, with `blocking=true` only for ambiguous relationships that need a human decision.
- Wire the helper requirement into Protocol 90, Protocol 91, Protocol 01, tracker docs, README, mirrored agent/skill guidance, and CHANGELOG.

## Validation

- `bash scripts/development-workflow/tests/test-spec-dispatch-context.sh`
- `shellcheck scripts/development-workflow/spec-dispatch-context.sh scripts/development-workflow/tests/test-spec-dispatch-context.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `git diff --cached --check`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- Live helper smoke: `./scripts/development-workflow/spec-dispatch-context.sh --selected 1182 --items 1182 --json`

## Review Gate

- Internal code review against `REVIEW.md`: approved, no blocking findings.
- Nested artifact guard pre-create and pre-pr: `RESULT=clean` for `feature/1182-prevent-false-dependencies-from-keyword-overlap` on base `develop`.

Closes #1182

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Backlog items may enter spec writing across batch and single-item orchestration; misclassification could block or mis-order work, though behavior is conservative and covered by extensive unit tests.
> 
> **Overview**
> Adds **`spec-dispatch-context.sh`** so Backlog → Writing Spec dispatch no longer treats keyword overlap as dependency evidence. The helper reads issue text, comments, and optional confirmed-decision JSONL, classifies peer relationships as **`Dependent`**, **`Orthogonal`**, or **`Unclear`**, and sets **`blocking=true`** when a human must resolve ambiguity or conflicting decisions.
> 
> **Protocol and docs:** New **spec-dispatch relationship context** gates in Protocol **90** (batch) and **91** (single-item), plus prerequisites in Protocol **01**, workflow README, and issue-tracker guidance.
> 
> **Runners:** Orchestrators and `/run-item` / `/run-items` must run or consume the helper before spec dispatch; spec writers must honor handoff context without encoding helper mechanics into specs.
> 
> **Tests:** `test-spec-dispatch-context.sh` covers dependency phrases, negation, coupling language, decision overrides, and blocking cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9556f6ed3d89297d6da4dec03f1adec190819e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->