### PR TITLE
fix(workflow): refine acceptance criteria checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Fix bounded-prelude acceptance criteria checkpoints** (#1184): Stop treating
+  populated Acceptance Criteria sections as standalone product checkpoint
+  signals while preserving checkpoints for unresolved, empty, or placeholder
+  criteria.
 - **Require worktree isolation for concurrent runners** (#1205): Require
   concurrent mutating batch dispatches to use distinct isolated worktrees and
   pre-mutation runner self-checks.

--- a/docs/workflow/development-workflow/bounded-run-prelude.md
+++ b/docs/workflow/development-workflow/bounded-run-prelude.md
@@ -91,9 +91,14 @@ The JSON output includes:
    the same item and policy. It never waives new guardrail stops, failed review,
    failed CI, risk violations, missing permissions, destructive-action stops, or
    pending checkpoints.
-5. **Epic-like items** — `run-item-scope-resolver.sh` rejects epic issues; use
+5. **Acceptance Criteria checkpoint signal** — populated Acceptance Criteria
+   sections are normal issue structure and do not create a product checkpoint by
+   themselves. Product checkpoints remain recommended for unresolved product
+   language, open questions, empty Acceptance Criteria sections, and
+   placeholder-only criteria such as `TBD` or `to be defined`.
+6. **Epic-like items** — `run-item-scope-resolver.sh` rejects epic issues; use
    `--epic` instead.
-6. **Explicit-list base selection** — `--items` considers only the listed items.
+7. **Explicit-list base selection** — `--items` considers only the listed items.
    No integration labels resolve to `develop`. Partial or mixed
    `integration-branch:<slug>` coverage resolves to `develop` with a visible
    warning. A shared label may resolve to `develop-<slug>` only when the current

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -102,8 +102,10 @@ signals default to checkpoints:
 
 - **Plan + technical**: database schema, migration, or persistent data-model
   wording.
-- **Spec + product**: unresolved product or acceptance-criteria ambiguity when
-  the item is still in Backlog or spec stage.
+- **Spec + product**: unresolved product language, open questions, empty
+  Acceptance Criteria sections, or placeholder-only acceptance criteria when
+  the item is still in Backlog or spec stage. A populated Acceptance Criteria
+  heading is normal issue structure and is not a checkpoint signal by itself.
 - **Plan or implementation + both**: ambiguous product/technical tradeoffs.
 - **Implementation + technical**: security, auth, permission, or other
   sensitive-change wording.

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -210,6 +210,8 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
   def item_signal_text($item):
     (($item.title // "") + " " + ($item.body // "") + " " + ($item.type // "") + " " + (($item.labels // []) | join(" ")) + " " + ($item.integrationBranchLabel // ""))
     | ascii_downcase;
+  def has_nonblank_lines($lines):
+    any($lines[]?; (gsub("^[[:space:]]+"; "") | gsub("[[:space:]]+$"; "") | length) > 0);
   def acceptance_criteria_sections($item):
     (($item.body // "") | gsub("\r\n"; "\n") | split("\n")) as $lines |
     reduce range(0; ($lines | length)) as $i (
@@ -217,7 +219,9 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
       ($lines[$i]) as $line |
       if ($line | test("^#{1,6}[[:space:]]+acceptance criteria[[:space:]]*$"; "i")) then
         if .active then
-          .sections += [(.current | join("\n"))] | .active = true | .current = []
+          (if has_nonblank_lines(.current) then .sections += [(.current | join("\n"))] else . end)
+          | .active = true
+          | .current = []
         else
           .active = true | .current = []
         end

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -210,6 +210,47 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
   def item_signal_text($item):
     (($item.title // "") + " " + ($item.body // "") + " " + ($item.type // "") + " " + (($item.labels // []) | join(" ")) + " " + ($item.integrationBranchLabel // ""))
     | ascii_downcase;
+  def acceptance_criteria_sections($item):
+    (($item.body // "") | gsub("\r\n"; "\n") | split("\n")) as $lines |
+    reduce range(0; ($lines | length)) as $i (
+      {sections: [], active: false, current: []};
+      ($lines[$i]) as $line |
+      if ($line | test("^#{1,6}[[:space:]]+acceptance criteria[[:space:]]*$"; "i")) then
+        if .active then
+          .sections += [(.current | join("\n"))] | .active = true | .current = []
+        else
+          .active = true | .current = []
+        end
+      elif (.active and ($line | test("^#{1,6}[[:space:]]+"))) then
+        .sections += [(.current | join("\n"))] | .active = false | .current = []
+      elif .active then
+        .current += [$line]
+      else
+        .
+      end
+    )
+    | if .active then .sections += [(.current | join("\n"))] else . end
+    | .sections;
+  def normalized_criteria_lines($section):
+    ($section | split("\n"))
+    | map(
+        gsub("^[[:space:]]*(-|\\*|\\+|[0-9]+\\.)[[:space:]]+"; "")
+        | gsub("^[[:space:]]*\\[[ xX]\\][[:space:]]+"; "")
+        | gsub("^[[:space:]]+"; "")
+        | gsub("[[:space:]]+$"; "")
+      )
+    | map(select(length > 0));
+  def criteria_section_problem($section):
+    normalized_criteria_lines($section) as $lines |
+    if ($lines | length) == 0 then "empty acceptance criteria"
+    elif all($lines[]; test("^(tbd|todo|n/a|na|none|placeholder|to be defined|to be determined|coming soon)\\.?$"; "i")) then "placeholder acceptance criteria"
+    else ""
+    end;
+  def acceptance_criteria_problem($item):
+    acceptance_criteria_sections($item)
+    | map(criteria_section_problem(.))
+    | map(select(length > 0))
+    | .[0] // "";
   def infer_workflow_stage($item):
     ($item.status // "" | ascii_downcase) as $s |
     if $s == "backlog" or ($s | test("writing spec|spec in review|spec")) then "spec"
@@ -229,16 +270,18 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
   def recommend_checkpoints_for_item($item):
     item_signal_text($item) as $text |
     infer_workflow_stage($item) as $stage |
+    acceptance_criteria_problem($item) as $criteria_problem |
+    ($text | test("ambiguous|unclear|\\btbd\\b|open question|unresolved product")) as $unresolved_product_signal |
     ($item.number) as $num |
     (
       []
       | if ($stage == "spec" or ($item.status // "" | ascii_downcase) == "backlog")
-          and ($text | test("ambiguous|unclear|\\btbd\\b|open question|acceptance criteria|unresolved product")) then
+          and (($criteria_problem | length) > 0 or $unresolved_product_signal) then
           . + [{
             item_number: $num,
             stage: "spec",
             domain: "product",
-            reason: "issue signals unresolved product requirements or acceptance-criteria ambiguity",
+            reason: (if ($criteria_problem | length) > 0 then $criteria_problem else "issue signals unresolved product requirements or acceptance-criteria ambiguity" end),
             required_human_action: "confirm product requirements and acceptance criteria before spec work proceeds",
             satisfaction_state: "pending"
           }]

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -212,21 +212,28 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
     | ascii_downcase;
   def has_nonblank_lines($lines):
     any($lines[]?; (gsub("^[[:space:]]+"; "") | gsub("[[:space:]]+$"; "") | length) > 0);
+  def heading_level($line):
+    if ($line | test("^#{1,6}[[:space:]]+")) then
+      ($line | capture("^(?<marks>#{1,6})[[:space:]]+").marks | length)
+    else 0 end;
+  def acceptance_criteria_heading($line):
+    $line | test("^#{1,6}[[:space:]]+acceptance criteria[[:space:]]*:?[[:space:]]*$"; "i");
   def acceptance_criteria_sections($item):
     (($item.body // "") | gsub("\r\n"; "\n") | split("\n")) as $lines |
     reduce range(0; ($lines | length)) as $i (
-      {sections: [], active: false, current: []};
+      {sections: [], active: false, current: [], level: 0};
       ($lines[$i]) as $line |
-      if ($line | test("^#{1,6}[[:space:]]+acceptance criteria[[:space:]]*$"; "i")) then
+      if acceptance_criteria_heading($line) then
         if .active then
           (if has_nonblank_lines(.current) then .sections += [(.current | join("\n"))] else . end)
           | .active = true
+          | .level = heading_level($line)
           | .current = []
         else
-          .active = true | .current = []
+          .active = true | .level = heading_level($line) | .current = []
         end
-      elif (.active and ($line | test("^#{1,6}[[:space:]]+"))) then
-        .sections += [(.current | join("\n"))] | .active = false | .current = []
+      elif (.active and (heading_level($line) > 0) and (heading_level($line) <= .level)) then
+        .sections += [(.current | join("\n"))] | .active = false | .level = 0 | .current = []
       elif .active then
         .current += [$line]
       else
@@ -237,6 +244,7 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
     | .sections;
   def normalized_criteria_lines($section):
     ($section | split("\n"))
+    | map(select(test("^#{1,6}[[:space:]]+") | not))
     | map(
         gsub("^[[:space:]]*(-|\\*|\\+|[0-9]+\\.)[[:space:]]+"; "")
         | gsub("^[[:space:]]*\\[[ xX]\\][[:space:]]+"; "")

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -373,6 +373,10 @@ lookalike_fixture="$(write_fixture lookalike "$(jq '.groups.eligible[0].body = "
 lookalike_output="$(recommend_json "$lookalike_fixture" "\$run-epic --items 401")"
 run_test "acceptance_criteria_phrase_in_complete_body_is_not_checkpoint_signal" "0" "$(printf '%s\n' "$lookalike_output" | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "spec" and .domain == "product")] | length')"
 
+duplicate_heading_fixture="$(write_fixture duplicate-heading "$(jq '.groups.eligible[0].body = "## Acceptance Criteria\n\n## Acceptance Criteria\n- The later repeated heading has real criteria.\n" | .items[0].body = .groups.eligible[0].body' "$complete_criteria_fixture")")"
+duplicate_heading_output="$(recommend_json "$duplicate_heading_fixture" "\$run-epic --items 401")"
+run_test "duplicate_acceptance_criteria_heading_before_content_is_not_empty_section" "0" "$(printf '%s\n' "$duplicate_heading_output" | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "spec" and .domain == "product")] | length')"
+
 second_empty_fixture="$(write_fixture second-empty "$(jq '.groups.eligible[0].body = "## Acceptance Criteria\n- First section is complete.\n\n## Acceptance Criteria\n\n## Notes\nSecond section is empty.\n" | .items[0].body = .groups.eligible[0].body' "$complete_criteria_fixture")")"
 second_empty_output="$(recommend_json "$second_empty_fixture" "\$run-epic --items 401")"
 run_test "second_empty_acceptance_criteria_section_recommends_checkpoint" "empty acceptance criteria" "$(printf '%s\n' "$second_empty_output" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "spec" and .domain == "product") | .reason')"

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -4,11 +4,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
-GIT_COMMON_DIR="$(cd "$SCRIPT_DIR" && git rev-parse --git-common-dir)"
-case "$GIT_COMMON_DIR" in
-  /*) REPO_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd -P)" ;;
-  *) REPO_ROOT="$(cd "$SCRIPT_DIR/$GIT_COMMON_DIR/.." && pwd -P)" ;;
-esac
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd -P)"
 HELPER="$REPO_ROOT/scripts/development-workflow/run-epic-policy-recommender.sh"
 
 TMP_ROOT="$(mktemp -d)"
@@ -248,7 +244,7 @@ run_items_output="$("$HELPER" --scope "$backlog_fixture" --original-command "/ru
 run_test "run_items_copy_paste_uses_run_items" "yes" "$(
   run_items_copy_paste="$(printf '%s\n' "$run_items_output" | jq -r '.copyPasteCommand')"
   if grep -Fq -- '/run-items 949' <<<"$run_items_copy_paste" &&
-    ! grep -Fq -- '$run-epic' <<<"$run_items_copy_paste"; then
+    ! grep -Fq -- "\$run-epic" <<<"$run_items_copy_paste"; then
     echo yes
   else
     echo no
@@ -334,6 +330,56 @@ sensitive_backlog_output="$(recommend_json "$sensitive_backlog_fixture" "\$run-e
 run_test "sensitive_backlog_recommends_implementation_checkpoint" "implementation:technical" "$(printf '%s\n' "$sensitive_backlog_output" | jq -r '.recommendedPolicy.checkpoints[0] | .stage + ":" + .domain')"
 
 run_test "docs_scope_has_no_checkpoints" "0" "$(printf '%s\n' "$docs_output" | jq -r '.recommendedPolicy.checkpoints | length')"
+
+complete_criteria_fixture="$(write_fixture complete-criteria '{
+  "scopeSource": "items",
+  "epicNumber": null,
+  "itemInput": "401",
+  "baseBranch": "develop",
+  "baseAmbiguous": false,
+  "baseReason": "no integration branch label",
+  "policy": {"delegateReview": false, "mayMerge": false, "mayStartBacklog": false, "maxRisk": "low"},
+  "groups": {
+    "eligible": [{"number": 401, "title": "Add clear workflow report labels", "body": "## Problem\nThe report is hard to scan.\n\n## Acceptance Criteria\n- The report labels each proposed item.\n- The report names held items.\n", "status": "Backlog", "type": "Workflow", "labels": [], "dependencies": {"state": "none"}}],
+    "blocked": [],
+    "already_merged": [],
+    "in_review": [],
+    "ambiguous": []
+  },
+  "items": [
+    {"number": 401, "title": "Add clear workflow report labels", "body": "## Problem\nThe report is hard to scan.\n\n## Acceptance Criteria\n- The report labels each proposed item.\n- The report names held items.\n", "status": "Backlog", "type": "Workflow", "labels": []}
+  ]
+}')"
+complete_criteria_output="$(recommend_json "$complete_criteria_fixture" "\$run-epic --items 401")"
+run_test "complete_acceptance_criteria_has_no_product_checkpoint" "0" "$(printf '%s\n' "$complete_criteria_output" | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "spec" and .domain == "product")] | length')"
+
+case_variant_fixture="$(write_fixture case-variant "$(jq '.groups.eligible[0].body = "## ACCEPTANCE CRITERIA\n- The heading case is normalized.\n" | .items[0].body = .groups.eligible[0].body' "$complete_criteria_fixture")")"
+case_variant_output="$(recommend_json "$case_variant_fixture" "\$run-epic --items 401")"
+run_test "acceptance_criteria_heading_case_variants_are_normal_structure" "0" "$(printf '%s\n' "$case_variant_output" | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "spec" and .domain == "product")] | length')"
+
+empty_criteria_fixture="$(write_fixture empty-criteria "$(jq '.groups.eligible[0].body = "## Acceptance Criteria\n\n## Notes\nMore detail later.\n" | .items[0].body = .groups.eligible[0].body' "$complete_criteria_fixture")")"
+empty_criteria_output="$(recommend_json "$empty_criteria_fixture" "\$run-epic --items 401")"
+run_test "empty_acceptance_criteria_recommends_product_checkpoint" "empty acceptance criteria" "$(printf '%s\n' "$empty_criteria_output" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "spec" and .domain == "product") | .reason')"
+
+placeholder_criteria_fixture="$(write_fixture placeholder-criteria "$(jq '.groups.eligible[0].body = "## Acceptance Criteria\n- TBD\n- To be defined\n" | .items[0].body = .groups.eligible[0].body' "$complete_criteria_fixture")")"
+placeholder_criteria_output="$(recommend_json "$placeholder_criteria_fixture" "\$run-epic --items 401")"
+run_test "placeholder_acceptance_criteria_recommends_product_checkpoint" "placeholder acceptance criteria" "$(printf '%s\n' "$placeholder_criteria_output" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "spec" and .domain == "product") | .reason')"
+
+open_question_fixture="$(write_fixture open-question "$(jq '.groups.eligible[0].body = "## Problem\nOpen question: should this apply to epics too?\n\n## Acceptance Criteria\n- The report labels each proposed item.\n" | .items[0].body = .groups.eligible[0].body' "$complete_criteria_fixture")")"
+open_question_output="$(recommend_json "$open_question_fixture" "\$run-epic --items 401")"
+run_test "populated_criteria_with_open_question_still_recommends_checkpoint" "issue signals unresolved product requirements or acceptance-criteria ambiguity" "$(printf '%s\n' "$open_question_output" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "spec" and .domain == "product") | .reason')"
+
+lookalike_fixture="$(write_fixture lookalike "$(jq '.groups.eligible[0].body = "The acceptance criteria are listed below.\n\n## Acceptance Criteria\n- The populated list is enough.\n" | .items[0].body = .groups.eligible[0].body' "$complete_criteria_fixture")")"
+lookalike_output="$(recommend_json "$lookalike_fixture" "\$run-epic --items 401")"
+run_test "acceptance_criteria_phrase_in_complete_body_is_not_checkpoint_signal" "0" "$(printf '%s\n' "$lookalike_output" | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "spec" and .domain == "product")] | length')"
+
+second_empty_fixture="$(write_fixture second-empty "$(jq '.groups.eligible[0].body = "## Acceptance Criteria\n- First section is complete.\n\n## Acceptance Criteria\n\n## Notes\nSecond section is empty.\n" | .items[0].body = .groups.eligible[0].body' "$complete_criteria_fixture")")"
+second_empty_output="$(recommend_json "$second_empty_fixture" "\$run-epic --items 401")"
+run_test "second_empty_acceptance_criteria_section_recommends_checkpoint" "empty acceptance criteria" "$(printf '%s\n' "$second_empty_output" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "spec" and .domain == "product") | .reason')"
+
+plan_stage_criteria_fixture="$(write_fixture plan-stage-criteria "$(jq '.groups.eligible[0].status = "Plan Ready" | .items[0].status = "Plan Ready"' "$empty_criteria_fixture")")"
+plan_stage_criteria_output="$(recommend_json "$plan_stage_criteria_fixture" "\$run-epic --items 401")"
+run_test "plan_stage_acceptance_criteria_body_does_not_create_spec_checkpoint" "0" "$(printf '%s\n' "$plan_stage_criteria_output" | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "spec" and .domain == "product")] | length')"
 
 waived_file="$TMP_ROOT/waived-checkpoints.json"
 printf '%s\n' '[{

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -361,9 +361,21 @@ empty_criteria_fixture="$(write_fixture empty-criteria "$(jq '.groups.eligible[0
 empty_criteria_output="$(recommend_json "$empty_criteria_fixture" "\$run-epic --items 401")"
 run_test "empty_acceptance_criteria_recommends_product_checkpoint" "empty acceptance criteria" "$(printf '%s\n' "$empty_criteria_output" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "spec" and .domain == "product") | .reason')"
 
+colon_empty_criteria_fixture="$(write_fixture colon-empty-criteria "$(jq '.groups.eligible[0].body = "## Acceptance Criteria:\n\n## Notes\nMore detail later.\n" | .items[0].body = .groups.eligible[0].body' "$complete_criteria_fixture")")"
+colon_empty_criteria_output="$(recommend_json "$colon_empty_criteria_fixture" "\$run-epic --items 401")"
+run_test "empty_acceptance_criteria_heading_with_colon_recommends_product_checkpoint" "empty acceptance criteria" "$(printf '%s\n' "$colon_empty_criteria_output" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "spec" and .domain == "product") | .reason')"
+
 placeholder_criteria_fixture="$(write_fixture placeholder-criteria "$(jq '.groups.eligible[0].body = "## Acceptance Criteria\n- TBD\n- To be defined\n" | .items[0].body = .groups.eligible[0].body' "$complete_criteria_fixture")")"
 placeholder_criteria_output="$(recommend_json "$placeholder_criteria_fixture" "\$run-epic --items 401")"
 run_test "placeholder_acceptance_criteria_recommends_product_checkpoint" "placeholder acceptance criteria" "$(printf '%s\n' "$placeholder_criteria_output" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "spec" and .domain == "product") | .reason')"
+
+nested_placeholder_fixture="$(write_fixture nested-placeholder "$(jq '.groups.eligible[0].body = "## Acceptance Criteria\n### Required behavior\n- TBD\n" | .items[0].body = .groups.eligible[0].body' "$complete_criteria_fixture")")"
+nested_placeholder_output="$(recommend_json "$nested_placeholder_fixture" "\$run-epic --items 401")"
+run_test "nested_acceptance_criteria_heading_placeholder_recommends_checkpoint" "placeholder acceptance criteria" "$(printf '%s\n' "$nested_placeholder_output" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "spec" and .domain == "product") | .reason')"
+
+nested_complete_fixture="$(write_fixture nested-complete "$(jq '.groups.eligible[0].body = "## Acceptance Criteria\n### Required behavior\n- The user can run the bounded prelude.\n" | .items[0].body = .groups.eligible[0].body' "$complete_criteria_fixture")")"
+nested_complete_output="$(recommend_json "$nested_complete_fixture" "\$run-epic --items 401")"
+run_test "nested_acceptance_criteria_heading_with_real_criteria_is_complete" "0" "$(printf '%s\n' "$nested_complete_output" | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "spec" and .domain == "product")] | length')"
 
 open_question_fixture="$(write_fixture open-question "$(jq '.groups.eligible[0].body = "## Problem\nOpen question: should this apply to epics too?\n\n## Acceptance Criteria\n- The report labels each proposed item.\n" | .items[0].body = .groups.eligible[0].body' "$complete_criteria_fixture")")"
 open_question_output="$(recommend_json "$open_question_fixture" "\$run-epic --items 401")"


### PR DESCRIPTION
## Summary

- Replace the broad `acceptance criteria` checkpoint keyword with section-aware Acceptance Criteria parsing.
- Keep product checkpoints for unresolved product language, empty criteria, and placeholder-only criteria.
- Update bounded prelude / run-epic checkpoint docs and add focused parser-risk tests.

Closes #1184

## Document Quality Gate

Not applicable - this is an implementation PR, not a spec or plan PR.

## Pre-Submission Self-Review

- Reviewed `git diff origin/develop...HEAD` for scope and confirmed changes are limited to #1184.
- Confirmed populated Acceptance Criteria headings no longer trigger product checkpoints by themselves.
- Confirmed empty and placeholder Acceptance Criteria sections still produce product checkpoint recommendations.
- Confirmed the test harness resolves helpers from the active worktree so isolated worktree validation tests the branch under review.

## Verification

- `bash scripts/development-workflow/tests/test-run-epic-policy-recommender.sh`
- `shellcheck -x scripts/development-workflow/run-epic-policy-recommender.sh scripts/development-workflow/tests/test-run-epic-policy-recommender.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/bounded-run-prelude.md" "docs/workflow/development-workflow/protocols/95-run-epic-protocol.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when bounded runs pause for human product checkpoints before mutation; behavior is well-tested but affects orchestration preflight for backlog/spec items.
> 
> **Overview**
> Fixes **false-positive product checkpoints** during bounded prelude (`/run-item`, `/run-items`, `/run-epic`) when issues already have real Acceptance Criteria.
> 
> **`run-epic-policy-recommender.sh`** no longer treats the phrase `acceptance criteria` anywhere in title/body as a spec-stage product checkpoint. It now parses markdown **Acceptance Criteria** headings (case/colon variants, nested subheadings, multiple sections) and only recommends a product checkpoint when criteria are **empty**, **placeholder-only** (e.g. TBD), or when separate **unresolved product** signals remain (ambiguous language, open questions). Issues with populated criteria lists skip the checkpoint unless those other signals fire.
> 
> **Docs** (`bounded-run-prelude.md`, Protocol 95) and **CHANGELOG** describe the new rule. **`test-run-epic-policy-recommender.sh`** adds focused fixtures for complete, empty, placeholder, nested, duplicate-heading, and open-question cases; the harness also resolves the repo root from the active worktree path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f24df23e64178e096cd4134945ba5762523c7f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->