### PR TITLE
fix(workflow): delete merged implementation branches

### DIFF
--- a/.claude/commands/post-merge-cleanup.md
+++ b/.claude/commands/post-merge-cleanup.md
@@ -1,7 +1,8 @@
 ---
 description: >
-  After a development PR is merged and the remote branch deleted, sync with origin,
-  switch to the merged PR's base branch, pull, delete the local branch, and update the related issue in the issue tracker.
+  After a development PR is merged, sync with origin, switch to the merged PR's
+  base branch, pull, verify or delete the remote implementation branch, delete the local branch,
+  and update the related issue in the issue tracker.
   Usage: /post-merge-cleanup [--base base-branch] [branch-name]
 allowed-tools: Bash(./scripts/development-workflow/post-merge-cleanup.sh:*), Bash(git branch:*), Bash(gh issue:*), Bash(gh api:*), Bash(gh project:*), mcp__claude_ai_Linear__get_issue, mcp__claude_ai_Linear__save_issue, mcp__claude_ai_Linear__list_issue_statuses
 # If using a different issue tracker, add its MCP tool names here (e.g. mcp__jira__update_issue).
@@ -17,7 +18,18 @@ Run the post-merge cleanup script from the repository root.
 - **With `branch-name`**: delete that local branch (e.g. `feature/my-feature`).
 - **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and fails closed if that lookup is unavailable.
 
-The script will: fetch origin, checkout the merged PR's base branch, pull, delete the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote), and for implementation branches (`fix/*`, `feature/*`, `hotfix/*`, `refactor/*`) automatically close the associated GitHub issue if a merged PR is found for the branch. If the user is not in the repo root, `cd` to the repo root first (e.g. use the workspace root or ask which directory is the repo).
+The script will: fetch origin, checkout the merged PR's base branch, pull,
+verify or delete the remote branch for implementation branches only after the
+PR is confirmed merged, delete the local branch with `git branch -D`
+(force-delete; safe because the branch is already merged on the remote), and
+for implementation branches (`fix/*`, `feature/*`, `hotfix/*`, `refactor/*`)
+automatically close the associated GitHub issue if a merged PR is found for the
+branch. If the user is not in the repo root, `cd` to the repo root first (e.g.
+use the workspace root or ask which directory is the repo).
+
+For implementation branches, cleanup is complete only when the script reports
+`REMOTE_DELETE_RESULT=deleted` or `REMOTE_DELETE_RESULT=not_found`. Spec and
+implementation-plan branches are expected-persistent remotely.
 
 Do not skip steps or change the order. If the script fails, show the error and stop.
 

--- a/.claude/skills/post-merge-cleanup.md
+++ b/.claude/skills/post-merge-cleanup.md
@@ -1,8 +1,9 @@
 ---
 name: post-merge-cleanup
 description: >
-  After a development PR is merged and the remote branch deleted, sync with origin,
-  switch to the merged PR's base branch, pull, delete the local branch, and update the related issue in the issue tracker.
+  After a development PR is merged, sync with origin, switch to the merged PR's
+  base branch, pull, verify or delete the remote implementation branch, delete the local branch,
+  and update the related issue in the issue tracker.
   Usage: /post-merge-cleanup [--base base-branch] [branch-name]
 ---
 
@@ -16,7 +17,16 @@ Run the post-merge cleanup script from the repository root.
 - **With `branch-name`**: delete that local branch (e.g. `feature/my-feature`).
 - **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and fails closed if that lookup is unavailable.
 
-The script will: fetch origin, checkout the merged PR's base branch, pull, then delete the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote). If the user is not in the repo root, change to the repo root first.
+The script will: fetch origin, checkout the merged PR's base branch, pull,
+verify or delete the remote branch for implementation branches only after the
+PR is confirmed merged, then delete the local branch with `git branch -D`
+(force-delete; safe because the branch is already merged on the remote). If the
+user is not in the repo root, change to the repo root first.
+
+For implementation branches (`feature/*`, `fix/*`, `refactor/*`, `hotfix/*`),
+cleanup is complete only when the script reports `REMOTE_DELETE_RESULT=deleted`
+or `REMOTE_DELETE_RESULT=not_found`. Spec and implementation-plan branches are
+expected-persistent remotely.
 
 Do not skip steps or change the order. If the script fails, show the error and stop.
 

--- a/.codex/skills/post-merge-cleanup/SKILL.md
+++ b/.codex/skills/post-merge-cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: post-merge-cleanup
-description: After a development PR is merged and the remote branch deleted, sync with origin, switch to the merged PR's base branch, pull, delete the local branch, and update the related issue in the issue tracker. Use when you want to clean up the local repo post-merge.
+description: After a development PR is merged, sync with origin, switch to the merged PR's base branch, pull, verify or delete the remote implementation branch, delete the local branch, and update the related issue in the issue tracker. Use when you want to clean up the local repo post-merge.
 ---
 
 # Post-merge cleanup
@@ -27,7 +27,12 @@ description: After a development PR is merged and the remote branch deleted, syn
    - **GitHub Issues/Projects**: The script already closes the GitHub issue for implementation branches (if a merged PR is found). You still need to update the GitHub Projects board status field via `gh` CLI / GraphQL (per `docs/workflow/development-workflow/integrations/github-projects.md`).
    - **Other trackers**: Follow the same idea — set the issue to the appropriate status per the table above. See `docs/workflow/development-workflow/integrations/issue-tracker.md` and the tracker-specific doc under `docs/workflow/development-workflow/integrations/`.
    - If no issue identifier is present in the branch name or no tracker is in use, skip this step.
-7. Before reporting cleanup or tracker reconciliation complete for a workflow
+7. For implementation branches (`feature/*`, `fix/*`, `refactor/*`,
+   `hotfix/*`), verify the script reports `REMOTE_DELETE_RESULT=deleted` or
+   `REMOTE_DELETE_RESULT=not_found` before claiming cleanup complete. A
+   `skipped` or `failed` remote deletion result is non-terminal. Spec and
+   implementation-plan branches are expected-persistent remotely.
+8. Before reporting cleanup or tracker reconciliation complete for a workflow
    item, run `scripts/development-workflow/item-completion-self-check.sh` with
    `--stage cleanup` and the expected tracker status when claimed. Include its
    `## Ground-Truth Completion Verification` section in the cleanup report; a
@@ -40,4 +45,4 @@ If this post-merge cleanup is the final action for a work item that was advanced
 
 Only suggest this when the cleanup is for a standalone item run (not when called as part of a batch merge or orchestrator flow, which handle retrospectives at their own level). See `docs/workflow/development-workflow/protocols/06-retrospective-protocol.md`.
 
-The script (step 1) fetches origin, checks out the merged PR's base branch, pulls, deletes the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote), and for implementation branches (`fix/*`, `feature/*`, `hotfix/*`, `refactor/*`) automatically closes the associated GitHub issue if a merged PR is found. Do not change the order or skip steps.
+The script (step 1) fetches origin, checks out the merged PR's base branch, pulls, verifies or deletes the remote implementation branch after confirming the PR is merged, deletes the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote), and for implementation branches (`fix/*`, `feature/*`, `hotfix/*`, `refactor/*`) automatically closes the associated GitHub issue if a merged PR is found. Do not change the order or skip steps.

--- a/.cursor/commands/post-merge-cleanup.md
+++ b/.cursor/commands/post-merge-cleanup.md
@@ -1,7 +1,8 @@
 ---
 description: >
-  After a development PR is merged and the remote branch deleted, sync with origin,
-  switch to the merged PR's base branch, pull, delete the local branch, and update the related issue in the issue tracker.
+  After a development PR is merged, sync with origin, switch to the merged PR's
+  base branch, pull, verify or delete the remote implementation branch, delete the local branch,
+  and update the related issue in the issue tracker.
   Usage: /post-merge-cleanup [--base base-branch] [branch-name]
 ---
 
@@ -15,7 +16,18 @@ Run the post-merge cleanup script from the repository root.
 - **With `branch-name`**: delete that local branch (e.g. `feature/my-feature`).
 - **With `--base base-branch`**: explicitly choose the cleanup base branch. When omitted for hub-owned cleanup, the script queries the merged PR base and fails closed if that lookup is unavailable.
 
-The script will: fetch origin, checkout the merged PR's base branch, pull, delete the local branch with `git branch -D` (force-delete; safe because the branch is already merged on the remote), and for implementation branches (`fix/*`, `feature/*`, `hotfix/*`, `refactor/*`) automatically close the associated GitHub issue if a merged PR is found for the branch. If the user is not in the repo root, `cd` to the repo root first (e.g. use the workspace root or ask which directory is the repo).
+The script will: fetch origin, checkout the merged PR's base branch, pull,
+verify or delete the remote branch for implementation branches only after the
+PR is confirmed merged, delete the local branch with `git branch -D`
+(force-delete; safe because the branch is already merged on the remote), and
+for implementation branches (`fix/*`, `feature/*`, `hotfix/*`, `refactor/*`)
+automatically close the associated GitHub issue if a merged PR is found for the
+branch. If the user is not in the repo root, `cd` to the repo root first (e.g.
+use the workspace root or ask which directory is the repo).
+
+For implementation branches, cleanup is complete only when the script reports
+`REMOTE_DELETE_RESULT=deleted` or `REMOTE_DELETE_RESULT=not_found`. Spec and
+implementation-plan branches are expected-persistent remotely.
 
 Do not skip steps or change the order. If the script fails, show the error and stop.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Delete remote implementation branches after merge** (#1185): Ensure
+  multi-stage item cleanup deletes merged implementation branches while treating
+  spec and plan branches as expected-persistent.
 - **Fix bounded-prelude acceptance criteria checkpoints** (#1184): Stop treating
   populated Acceptance Criteria sections as standalone product checkpoint
   signals while preserving checkpoints for unresolved, empty, or placeholder

--- a/docs/testing/workflow/1185-delete-remote-implementation-branch-after-merge.smoke-test.md
+++ b/docs/testing/workflow/1185-delete-remote-implementation-branch-after-merge.smoke-test.md
@@ -50,7 +50,8 @@ Before running this smoke test:
    ./scripts/development-workflow/post-merge-cleanup.sh --base develop feature/1185-smoke-cleanup
    ```
 
-4. Confirm the output reports the remote branch as deleted or already absent.
+4. Confirm the output reports `REMOTE_DELETE_RESULT=deleted` or
+   `REMOTE_DELETE_RESULT=not_found`.
 5. Confirm `origin/feature/1185-smoke-cleanup` no longer exists.
 
 **Expected result**: Cleanup only runs after merged-state verification and the
@@ -65,9 +66,9 @@ remote implementation branch is gone afterward.
 2. Run the cleanup path against that branch.
 3. Inspect the output.
 
-**Expected result**: The helper skips remote deletion, names the non-merged PR
-state, and does not report terminal cleanup success for the implementation
-branch.
+**Expected result**: The helper reports `REMOTE_DELETE_RESULT=skipped`, names
+the non-merged state or missing merged PR evidence, and does not report terminal
+cleanup success for the implementation branch.
 
 ### Step 3: Verify already absent remote branches are successful
 
@@ -77,8 +78,8 @@ branch.
 2. Run the cleanup helper for that branch.
 3. Inspect the output.
 
-**Expected result**: Cleanup reports the remote branch as already absent or
-already complete and continues local/tracker cleanup.
+**Expected result**: Cleanup reports `REMOTE_DELETE_RESULT=not_found` and
+`REMOTE_DELETE_STATUS=already_absent`, then continues local/tracker cleanup.
 
 ### Step 4: Verify spec and plan branch classification
 

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -1205,7 +1205,10 @@ Scan local branches for two categories of stale / orphaned entries that clutter 
 
 **Category A — Workflow-prefix branches whose upstream PR has been merged**
 
-Workflow branches (`feature/`, `fix/`, `refactor/`, `hotfix/`, `spec/`, `implementation-plan/`) that were used for a PR which has since merged are safe to delete but are not cleaned up automatically by `post-merge-cleanup.sh` when other PRs in the same batch merge later.
+Workflow branches (`feature/`, `fix/`, `refactor/`, `hotfix/`, `spec/`, `implementation-plan/`) that were used for a PR which has since merged are safe to delete locally when they are not part of the current batch. Classify the branch lifecycle before reporting:
+
+- `feature/*`, `fix/*`, `refactor/*`, and `hotfix/*` are implementation branches. After the implementation PR is confirmed merged, the remote branch is `expected_deleted`; a remaining `origin/<branch>` ref is a cleanup finding.
+- `spec/*` and `implementation-plan/*` are documentation-stage branches. After merge, their remote branches are `expected_persistent`; do not report them as implementation cleanup failures.
 
 ```bash
 # List all local branches matching workflow prefixes
@@ -1221,6 +1224,14 @@ For each branch found, check whether its upstream PR has been merged:
 gh pr list --state merged --head <branch> --json number,mergedAt \
   --jq '.[0] | "PR #\(.number) merged at \(.mergedAt)"'
 # Non-empty output → merged; the local branch is stale and safe to delete
+```
+
+For merged implementation branches, also check whether the remote branch still exists:
+
+```bash
+# For each merged implementation branch <branch>:
+git ls-remote --heads origin <branch>
+# Non-empty output → remote implementation branch cleanup is incomplete.
 ```
 
 **Category B — `worktree-agent-*` branches with no remote counterpart and no open/merged PR**
@@ -1244,11 +1255,14 @@ gh pr list --state all --head <branch> --json number,state --jq '.[0] | .number'
 
 **Action when stale or orphaned branches are found:**
 
-1. List every stale / orphaned branch with its category and a suggested cleanup command:
+1. List every stale / orphaned branch with its category, lifecycle, merged PR context, and a suggested cleanup command:
 
    ```bash
-   # Category A — stale workflow branch (upstream PR merged):
+   # Category A — stale local workflow branch (upstream PR merged):
    git branch -D <branch>
+
+   # Category A — remote implementation branch still present after merge:
+   ./scripts/development-workflow/post-merge-cleanup.sh --base <base> <branch>
 
    # Category B — orphaned worktree-agent branch (no remote, no PR):
    git branch -D <branch>

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -2782,6 +2782,15 @@ state according to this table:
 - After cleanup, re-read the live tracker status and Project status. If the live
   status does not match the expected value in the table above, re-apply the
   tracker transition before reporting the item terminal.
+- For implementation branches (`feature/*`, `fix/*`, `refactor/*`, and
+  `hotfix/*`), `post-merge-cleanup.sh` must report remote branch cleanup
+  evidence before the item is terminal. Accept `REMOTE_DELETE_RESULT=deleted`
+  or `REMOTE_DELETE_RESULT=not_found` as successful/idempotent outcomes after a
+  merged PR is verified. Treat `REMOTE_DELETE_RESULT=skipped` or
+  `REMOTE_DELETE_RESULT=failed` as non-terminal cleanup failures and report the
+  named branch and PR context. Spec and implementation-plan branches are
+  expected-persistent remotely and do not require implementation remote deletion
+  evidence.
 - Before reporting post-merge cleanup or tracker reconciliation complete, run
   `item-completion-self-check.sh` for the cleanup claim, using the current base
   branch (the merged workflow branch should already be deleted), the current

--- a/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
+++ b/docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md
@@ -277,7 +277,17 @@ After a clean or resolved merge, in order:
    > (with locked-worktree handling) before deleting the local branch. Any manual worktree
    > removal step here is redundant and risks breaking the cleanup sequence.
 
-   `post-merge-cleanup.sh` requires a local branch to exist. Because `batch-merge.sh` merges via `origin/<branch>` without creating a local tracking branch, create a temporary local branch first:
+   `post-merge-cleanup.sh` verifies or performs guarded remote cleanup for
+   implementation branches. If `batch-merge.sh delete-branch` already removed
+   the remote branch, `post-merge-cleanup.sh` reports
+   `REMOTE_DELETE_RESULT=not_found` / `REMOTE_DELETE_STATUS=already_absent` and
+   continues. If the remote implementation branch still exists, the helper
+   deletes it only after confirming the PR is `MERGED`; if deletion fails, the
+   cleanup is non-terminal.
+
+   The helper requires a local branch to exist. Because `batch-merge.sh` merges
+   via `origin/<branch>` without creating a local tracking branch, create a
+   temporary local branch first:
 
    ```bash
    BRANCH="$(gh pr view <number> --json headRefName --jq '.headRefName')"

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
-# Post-merge cleanup: fetch origin, checkout the merge base, pull, and delete the
-# local branch that was just merged (remote branch already deleted).
+# Post-merge cleanup: fetch origin, checkout the merge base, pull, delete the
+# local branch that was just merged, and verify or delete merged implementation
+# branches on the remote.
 # Keeps the local repo clean after merging developments.
 #
 # Usage:
@@ -23,7 +24,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./workflow-lib.sh
+# shellcheck source=scripts/development-workflow/workflow-lib.sh
 . "$SCRIPT_DIR/workflow-lib.sh"
 
 cd_workflow_repo_root
@@ -99,6 +100,9 @@ selected_product_default_branch=""
 case "$(branch_prefix "$TO_DELETE")" in
   feature|fix|refactor|hotfix)
     branch_owner_kind="implementation"
+    ;;
+  spec|implementation-plan)
+    branch_owner_kind="expected_persistent"
     ;;
 esac
 
@@ -185,8 +189,91 @@ print_kv ACTION_REPOSITORY "$ACTION_REPOSITORY"
 [ -n "$TARGET_GITHUB_REPO" ] && print_kv TARGET_GITHUB_REPO "$TARGET_GITHUB_REPO"
 print_kv CLEANUP_REPO_ROOT "$CLEANUP_REPO_ROOT"
 print_kv TRACKER_REPO_ROOT "$HUB_REPO_ROOT"
+case "$branch_owner_kind" in
+  implementation)
+    print_kv BRANCH_LIFECYCLE "expected_deleted"
+    ;;
+  expected_persistent)
+    print_kv BRANCH_LIFECYCLE "expected_persistent"
+    ;;
+  *)
+    print_kv BRANCH_LIFECYCLE "unclassified"
+    ;;
+esac
 
 cd "$CLEANUP_REPO_ROOT" || exit 1
+
+remote_cleanup_repo_slug() {
+  if [ -n "$TARGET_GITHUB_REPO" ]; then
+    printf '%s\n' "$TARGET_GITHUB_REPO"
+    return 0
+  fi
+  repo_slug
+}
+
+verify_merged_pr_for_branch() {
+  local branch="$1"
+  local lookup_repo="$2"
+
+  gh pr list \
+    --repo "$lookup_repo" \
+    --state merged \
+    --head "$branch" \
+    --limit 1 \
+    --json number \
+    --jq '.[0].number // empty'
+}
+
+cleanup_remote_implementation_branch() {
+  local branch="$1"
+  local lookup_repo merged_pr push_err push_exit
+
+  if [ "$branch_owner_kind" != "implementation" ]; then
+    return 0
+  fi
+
+  if ! lookup_repo="$(remote_cleanup_repo_slug)"; then
+    print_kv REMOTE_DELETE_RESULT "skipped"
+    print_kv_escaped ERROR_MESSAGE "Could not resolve GitHub repository for remote implementation branch cleanup."
+    echo "ERROR: could not resolve GitHub repository for remote implementation branch cleanup." >&2
+    return 1
+  fi
+
+  if ! merged_pr="$(verify_merged_pr_for_branch "$branch" "$lookup_repo")"; then
+    print_kv REMOTE_DELETE_RESULT "skipped"
+    print_kv_escaped ERROR_MESSAGE "Could not query merged PRs for branch '${branch}' in '${lookup_repo}'."
+    echo "ERROR: could not query merged PRs for branch '$branch' in '$lookup_repo'." >&2
+    return 1
+  fi
+
+  if [ -z "$merged_pr" ]; then
+    print_kv REMOTE_DELETE_RESULT "skipped"
+    print_kv REMOTE_DELETE_REASON "pr_not_merged"
+    print_kv_escaped ERROR_MESSAGE "Remote implementation branch '${branch}' was not deleted because no merged PR was found."
+    echo "ERROR: remote implementation branch '$branch' was not deleted because no merged PR was found." >&2
+    return 1
+  fi
+
+  print_kv REMOTE_DELETE_PR_NUMBER "$merged_pr"
+  push_err="$(git push origin --delete "$branch" 2>&1)" && push_exit=0 || push_exit=$?
+  if [ "$push_exit" -eq 0 ]; then
+    print_kv REMOTE_DELETE_RESULT "deleted"
+    echo "Remote implementation branch '$branch' deleted after merged PR #${merged_pr}."
+    return 0
+  fi
+
+  if printf '%s\n' "$push_err" | grep -Eiq "remote ref does not exist|unable to delete .* remote ref does not exist|not found"; then
+    print_kv REMOTE_DELETE_RESULT "not_found"
+    print_kv REMOTE_DELETE_STATUS "already_absent"
+    echo "Remote implementation branch '$branch' already absent after merged PR #${merged_pr}."
+    return 0
+  fi
+
+  print_kv REMOTE_DELETE_RESULT "failed"
+  print_kv_escaped ERROR_MESSAGE "Failed to delete remote implementation branch '${branch}' (exit ${push_exit}): ${push_err}"
+  echo "ERROR: failed to delete remote implementation branch '$branch': $push_err" >&2
+  return 1
+}
 
 LOCAL_BRANCH_MISSING=0
 VERIFIED_MERGED_PR=""
@@ -235,6 +322,8 @@ echo "Pulling $DEVELOP_BRANCH..."
 # tracking set (e.g. integration branches created/pushed without --set-upstream).
 # --ff-only: fail cleanly if the branch diverged (e.g. local commits) instead of creating a merge.
 git pull --ff-only origin "$DEVELOP_BRANCH"
+
+cleanup_remote_implementation_branch "$TO_DELETE"
 
 if [ "$LOCAL_BRANCH_MISSING" -eq 1 ]; then
   echo "Skipping local branch delete for '$TO_DELETE' (already absent)."

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -262,7 +262,7 @@ cleanup_remote_implementation_branch() {
     return 0
   fi
 
-  if printf '%s\n' "$push_err" | grep -Eiq "remote ref does not exist|unable to delete .* remote ref does not exist|not found"; then
+  if printf '%s\n' "$push_err" | grep -Eiq "remote ref does not exist|unable to delete .* remote ref does not exist"; then
     print_kv REMOTE_DELETE_RESULT "not_found"
     print_kv REMOTE_DELETE_STATUS "already_absent"
     echo "Remote implementation branch '$branch' already absent after merged PR #${merged_pr}."

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+HELPER="$REPO_ROOT/scripts/development-workflow/post-merge-cleanup.sh"
+REAL_GIT="$(command -v git)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+run_test() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '$expected', got '$actual'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_contains() {
+  local name="$1"
+  local needle="$2"
+  local haystack="$3"
+
+  if grep -Fq "$needle" <<<"$haystack"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected output to contain '$needle'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_fails_contains() {
+  local name="$1"
+  local needle="$2"
+  shift 2
+  local output status
+
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+
+  if [ "$status" -ne 0 ] && grep -Fq "$needle" <<<"$output"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected failure output to contain '$needle' (status $status)"
+    printf '%s\n' "$output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+write_gh_stub() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat >"$dir/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+args=" $* "
+
+case "$1 $2" in
+  "pr list")
+    head=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --head)
+          head="${2:-}"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    if [ -n "${GH_PR_LIST_FAIL:-}" ]; then
+      echo "mock pr list failure" >&2
+      exit 1
+    fi
+    if [ "$head" = "${GH_MERGED_HEAD:-}" ] && [ -n "${GH_MERGED_PR:-}" ]; then
+      if [[ "$args" == *"--jq"* ]]; then
+        printf '%s\n' "$GH_MERGED_PR"
+      else
+        printf '[{"number":%s}]\n' "$GH_MERGED_PR"
+      fi
+    else
+      if [[ "$args" == *"--jq"* ]]; then
+        printf '\n'
+      else
+        printf '[]\n'
+      fi
+    fi
+    ;;
+  "pr view")
+    if [[ "$args" == *"--jq"* ]]; then
+      printf '\n'
+    else
+      printf '{"body":"","title":""}\n'
+    fi
+    ;;
+  "issue view")
+    if [[ "$args" == *"--jq"* ]]; then
+      printf 'CLOSED\n'
+    else
+      printf '{"state":"CLOSED"}\n'
+    fi
+    ;;
+  "issue close")
+    printf 'closed\n'
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$dir/gh"
+}
+
+write_git_failure_stub() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat >"$dir/git" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "push" ] && [ "${2:-}" = "origin" ] && [ "${3:-}" = "--delete" ] && [ "${4:-}" = "${GIT_FAIL_DELETE_BRANCH:-}" ]; then
+  echo "permission denied deleting ${4}" >&2
+  exit 1
+fi
+
+exec "$REAL_GIT" "$@"
+STUB
+  chmod +x "$dir/git"
+}
+
+make_repo() {
+  local name="$1"
+  local branch="$2"
+  local push_branch="${3:-yes}"
+  local bare="$TMP_ROOT/${name}.git"
+  local repo="$TMP_ROOT/$name"
+
+  "$REAL_GIT" init --bare -q -b develop "$bare"
+  "$REAL_GIT" init -q -b develop "$repo"
+  "$REAL_GIT" -C "$repo" config user.email "fixture@example.com"
+  "$REAL_GIT" -C "$repo" config user.name "Fixture User"
+  printf 'base\n' >"$repo/README.md"
+  "$REAL_GIT" -C "$repo" add README.md
+  "$REAL_GIT" -C "$repo" commit -q -m "initial base"
+  "$REAL_GIT" -C "$repo" remote add origin "$bare"
+  "$REAL_GIT" -C "$repo" push -q -u origin develop
+  "$REAL_GIT" -C "$repo" checkout -q -b "$branch"
+  printf 'branch\n' >"$repo/branch.txt"
+  "$REAL_GIT" -C "$repo" add branch.txt
+  "$REAL_GIT" -C "$repo" commit -q -m "branch fixture"
+  if [ "$push_branch" = "yes" ]; then
+    "$REAL_GIT" -C "$repo" push -q -u origin "$branch"
+  fi
+  "$REAL_GIT" -C "$repo" checkout -q develop
+  printf '%s\n' "$repo"
+}
+
+stub_bin="$TMP_ROOT/bin"
+write_gh_stub "$stub_bin"
+
+merged_branch="feature/noissue-cleanup"
+merged_repo="$(make_repo merged "$merged_branch" yes)"
+merged_output="$(
+  GH_MERGED_HEAD="$merged_branch" \
+  GH_MERGED_PR=77 \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$merged_repo" --base develop "$merged_branch"
+)"
+run_contains "merged_implementation_remote_deleted" "REMOTE_DELETE_RESULT=deleted" "$merged_output"
+run_contains "merged_implementation_records_pr" "REMOTE_DELETE_PR_NUMBER=77" "$merged_output"
+run_test "merged_implementation_remote_ref_absent" "" "$("$REAL_GIT" -C "$merged_repo" ls-remote --heads origin "$merged_branch")"
+
+absent_branch="feature/noissue-already-absent"
+absent_repo="$(make_repo absent "$absent_branch" no)"
+absent_output="$(
+  GH_MERGED_HEAD="$absent_branch" \
+  GH_MERGED_PR=78 \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$absent_repo" --base develop "$absent_branch"
+)"
+run_contains "already_absent_remote_is_successful" "REMOTE_DELETE_RESULT=not_found" "$absent_output"
+run_contains "already_absent_remote_status" "REMOTE_DELETE_STATUS=already_absent" "$absent_output"
+
+unmerged_branch="feature/noissue-unmerged"
+unmerged_repo="$(make_repo unmerged "$unmerged_branch" yes)"
+run_fails_contains \
+  "unmerged_implementation_skips_remote_delete" \
+  "REMOTE_DELETE_REASON=pr_not_merged" \
+  env WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+    PATH="$stub_bin:$PATH" \
+    "$HELPER" --repo-root "$unmerged_repo" --base develop "$unmerged_branch"
+run_test "unmerged_remote_ref_still_exists" "yes" "$(
+  if "$REAL_GIT" -C "$unmerged_repo" ls-remote --heads origin "$unmerged_branch" | grep -q .; then
+    printf 'yes'
+  else
+    printf 'no'
+  fi
+)"
+
+spec_branch="spec/noissue-persistent"
+spec_repo="$(make_repo spec "$spec_branch" yes)"
+spec_output="$(
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$spec_repo" --base develop "$spec_branch"
+)"
+run_contains "spec_branch_expected_persistent" "BRANCH_LIFECYCLE=expected_persistent" "$spec_output"
+run_test "spec_remote_ref_remains" "yes" "$(
+  if "$REAL_GIT" -C "$spec_repo" ls-remote --heads origin "$spec_branch" | grep -q .; then
+    printf 'yes'
+  else
+    printf 'no'
+  fi
+)"
+
+fail_branch="feature/noissue-delete-fails"
+fail_repo="$(make_repo delete-fails "$fail_branch" yes)"
+fail_bin="$TMP_ROOT/fail-bin"
+write_gh_stub "$fail_bin"
+write_git_failure_stub "$fail_bin"
+run_fails_contains \
+  "remote_delete_failure_blocks_cleanup" \
+  "REMOTE_DELETE_RESULT=failed" \
+  env GH_MERGED_HEAD="$fail_branch" \
+    GH_MERGED_PR=79 \
+    GIT_FAIL_DELETE_BRANCH="$fail_branch" \
+    REAL_GIT="$REAL_GIT" \
+    WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+    PATH="$fail_bin:$PATH" \
+    "$HELPER" --repo-root "$fail_repo" --base develop "$fail_branch"
+run_test "failed_delete_local_branch_remains" "yes" "$(
+  if "$REAL_GIT" -C "$fail_repo" show-ref --quiet "refs/heads/$fail_branch"; then
+    printf 'yes'
+  else
+    printf 'no'
+  fi
+)"
+
+echo ""
+echo "Passed: $PASS_COUNT"
+echo "Failed: $FAIL_COUNT"
+
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
## Summary

- Make `post-merge-cleanup.sh` verify or delete remote implementation branches after confirming the PR is merged.
- Classify implementation branches as `expected_deleted` and spec/plan branches as `expected_persistent` in cleanup and workflow guidance.
- Add focused post-merge cleanup regression coverage for deleted, already absent, unmerged, persistent, and failed remote branch cleanup paths.

Closes #1185

## Document Quality Gate

- [x] Documentation updates are scoped to the cleanup contract and branch lifecycle guidance.
- [x] CHANGELOG updated under `[Unreleased]`.

## Pre-Submission Self-Review

- Remote deletion only runs for implementation branch prefixes and only after a merged PR is verified.
- `not_found` is treated as successful/idempotent for already-deleted remote branches.
- Spec and implementation-plan branches remain expected-persistent remotely.
- Cleanup failures exit non-zero before local cleanup can imply terminal success.

## Verification

- `bash scripts/development-workflow/tests/test-post-merge-cleanup.sh`
- `bash scripts/development-workflow/tests/test-batch-merge-checkpoints.sh`
- `shellcheck -x scripts/development-workflow/post-merge-cleanup.sh scripts/development-workflow/tests/test-post-merge-cleanup.sh scripts/development-workflow/tests/test-batch-merge-checkpoints.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md" "docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md" "docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md" "docs/testing/workflow/1185-delete-remote-implementation-branch-after-merge.smoke-test.md" ".codex/skills/post-merge-cleanup/SKILL.md" ".claude/skills/post-merge-cleanup.md" ".claude/commands/post-merge-cleanup.md" ".cursor/commands/post-merge-cleanup.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes guarded git remote deletion and orchestration terminal criteria; mistakes could delete wrong branches or block cleanup, but merged-PR verification and skip paths for unmerged/spec branches reduce exposure.
> 
> **Overview**
> **Post-merge cleanup** now removes merged **implementation** branches on `origin` after verifying a merged PR, while **spec** and **implementation-plan** branches stay **expected-persistent** remotely.
> 
> `post-merge-cleanup.sh` adds `cleanup_remote_implementation_branch` (merged PR check via `gh`, then `git push origin --delete`), emits **`BRANCH_LIFECYCLE`** and **`REMOTE_DELETE_RESULT`** (`deleted`, `not_found`, `skipped`, `failed`), and fails non-zero when remote deletion is required but does not succeed.
> 
> Agent commands/skills and protocols **90**, **91**, and **94** now require terminal cleanup only when `REMOTE_DELETE_RESULT` is `deleted` or `not_found`; batch stale-branch checks flag lingering remote implementation refs. A regression test file **`test-post-merge-cleanup.sh`** and smoke-test doc updates cover the new contract; **CHANGELOG** records the fix (#1185).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11fa7a51e8a037a633b7206836b6e7d7a1f6181f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->