### PR TITLE
fix(workflow): preserve reviewer loop retry history

### DIFF
--- a/.agents/skills/retrospective/SKILL.md
+++ b/.agents/skills/retrospective/SKILL.md
@@ -10,3 +10,6 @@ This is the Codex command-style alias for Claude Code `/retrospective`.
 1. Read `AGENTS.md` for repository-wide rules.
 2. Read `.codex/skills/workflow-retrospective/SKILL.md`.
 3. Follow the `workflow-retrospective` skill exactly.
+4. For automated-reviewer retry-loop metrics, prefer the
+   `reviewer_loop_history.v1` payload from the latest script-owned
+   reviewer-loop summary comment before using legacy timestamp heuristics.

--- a/.claude/agents/retrospective.md
+++ b/.claude/agents/retrospective.md
@@ -14,7 +14,15 @@ That document is the single source of truth for this role. Key responsibilities:
 - Resolve scope from the user's hint (PR number, branch, batch date) or default to recent PRs in the repository
 - Gather GitHub PR metadata and git history for the relevant PRs using `gh`; also analyze conversation context when available
 - Synthesize findings into a categorized list using the fixed taxonomy (workflow-process, agent-behavior, configuration, documentation, code-quality, tooling) with severity signals (high, medium, low)
-- After synthesizing findings (Step 3), populate the required metrics block (Step 3d): batch identifier, human interventions count, Step 5.2 violations count, automated-reviewer retry loops count, escalations count, and prior action item recurrence assessment. Record `unavailable` for any field that cannot be reliably determined.
+- After synthesizing findings (Step 3), populate the required metrics block
+  (Step 3d): batch identifier, human interventions count, Step 5.2 violations
+  count, automated-reviewer retry loops count, escalations count, and prior
+  action item recurrence assessment. For automated-reviewer retry loops, parse
+  `reviewer_loop_history.v1` from the latest script-owned reviewer-loop summary
+  comment first and calculate `max(entries.length - 1, 0)` when
+  `history_status` is `available`; otherwise record `unavailable (<reason>)`
+  before falling back to legacy timestamp heuristics. Record `unavailable` for
+  any field that cannot be reliably determined.
 - Present findings to the human before taking any action, including the metrics block alongside improvement opportunities
 - For each opportunity, execute the human's chosen action: "Address now" (apply fix, commit, push — no new PR), "Add to backlog" (create GitHub issue directly via `gh issue create`), or "Skip"
 - After executing Step 5 actions, append the finalized metrics block to `docs/workflow/retro-metrics.md` as a new table row

--- a/.codex/skills/workflow-retrospective/SKILL.md
+++ b/.codex/skills/workflow-retrospective/SKILL.md
@@ -14,7 +14,15 @@ Recommended model tier: `economy`
 3. Resolve scope from the user's request (PR number, branch name, batch date) or default to recent PRs in the repository.
 4. Gather GitHub PR metadata (review cycles, finding types, labels, merge conflicts) and git history (commit patterns, fix-commit ratio) using `gh`. When conversation context is available, also analyze manual interventions, human corrections, and agent deviations from the current session.
 5. Synthesize findings into a categorized list using the fixed taxonomy and severity signals defined in the protocol.
-6. After synthesizing findings, populate the required metrics block (see Step 3d in the protocol): batch identifier, human interventions count, Step 5.2 violations count, automated-reviewer retry loops count, escalations count, prior action item recurrence assessment. Record `unavailable` for any field that cannot be reliably determined.
+6. After synthesizing findings, populate the required metrics block (see Step 3d
+   in the protocol): batch identifier, human interventions count, Step 5.2
+   violations count, automated-reviewer retry loops count, escalations count,
+   prior action item recurrence assessment. For automated-reviewer retry loops,
+   parse `reviewer_loop_history.v1` from the latest script-owned reviewer-loop
+   summary comment first and calculate `max(entries.length - 1, 0)` when
+   `history_status` is `available`; otherwise record `unavailable (<reason>)`
+   before falling back to legacy timestamp heuristics. Record `unavailable` for
+   any field that cannot be reliably determined.
 7. Present findings to the human, including the metrics block alongside improvement opportunities. For each opportunity, accept the human's choice of "Address now", "Add to backlog", or "Skip" — then execute the chosen action.
 8. "Address now": apply simple fix on a `fix/[slug]` branch, open a PR to `develop`, and proceed through normal review/CI gates — do not push directly to shared branches. "Add to backlog": create GitHub issue directly via `gh issue create`. "Skip": move on.
 9. After all opportunities are acted on, append the finalized metrics block to `docs/workflow/retro-metrics.md` as a new table row.

--- a/.cursor/agents/retrospective.md
+++ b/.cursor/agents/retrospective.md
@@ -13,7 +13,15 @@ That document is the single source of truth for this role. Key responsibilities:
 - Resolve scope from the user's hint (PR number, branch, batch date) or default to recent PRs in the repository
 - Gather GitHub PR metadata and git history for the relevant PRs; also analyze conversation context when available
 - Synthesize findings into a categorized list using the fixed taxonomy (workflow-process, agent-behavior, configuration, documentation, code-quality, tooling) with severity signals (high, medium, low)
-- After synthesizing findings (Step 3), populate the required metrics block (Step 3d): batch identifier, human interventions count, Step 5.2 violations count, automated-reviewer retry loops count, escalations count, and prior action item recurrence assessment. Record `unavailable` for any field that cannot be reliably determined.
+- After synthesizing findings (Step 3), populate the required metrics block
+  (Step 3d): batch identifier, human interventions count, Step 5.2 violations
+  count, automated-reviewer retry loops count, escalations count, and prior
+  action item recurrence assessment. For automated-reviewer retry loops, parse
+  `reviewer_loop_history.v1` from the latest script-owned reviewer-loop summary
+  comment first and calculate `max(entries.length - 1, 0)` when
+  `history_status` is `available`; otherwise record `unavailable (<reason>)`
+  before falling back to legacy timestamp heuristics. Record `unavailable` for
+  any field that cannot be reliably determined.
 - Present findings to the human before taking any action, including the metrics block alongside improvement opportunities
 - For each opportunity, execute the human's chosen action: "Address now" (apply fix, commit, push — no new PR), "Add to backlog" (create GitHub issue directly), or "Skip"
 - After executing Step 5 actions, append the finalized metrics block to `docs/workflow/retro-metrics.md` as a new table row

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Reviewer-loop retry history** (#1243): Preserve machine-readable
+  reviewer-loop iteration history so retrospectives can report exact retry
+  metrics.
 - **Decision gate consistency matrix** (#1242): Added consistency-matrix
   evidence for complex workflow decision-gate documentation changes before PR
   readiness.

--- a/docs/workflow/development-workflow/protocols/06-retrospective-protocol.md
+++ b/docs/workflow/development-workflow/protocols/06-retrospective-protocol.md
@@ -58,6 +58,13 @@ From this data, extract:
 - **Labels applied / missing**: were expected labels (`ready-for-human-review`, `needs-fixes`, `ready-for-regression`) applied correctly?
 - **Merge conflicts**: did the PR require conflict resolution?
 - **Automated reviewer findings**: CodeRabbit, Greptile, or other configured platforms (if visible in PR comments or reviews)
+- **Reviewer-loop history**: read the latest script-owned
+  `### Automated Reviewer Loop Summary` comment and parse the fenced
+  `reviewer_loop_history.v1` JSON block before using timestamp heuristics.
+  When `history_status` is `available`, use `entries` as the authoritative
+  iteration history. When the block is absent, malformed, unreadable, or reports
+  `history_status: unavailable`, record `unavailable (<reason>)` for exact
+  retry metrics instead of treating the PR as zero retries.
 
 ### 2b. Git history analysis
 
@@ -275,7 +282,7 @@ After completing Steps 3a–3c (backlog query, template cross-reference, and cat
 | **Batch identifier**                        | The PR numbers or batch date used as the scope in Step 1 (e.g., "PRs #301–#315" or "2026-04-24")                                                                                                                                              | Step 1 scope resolution                           |
 | **Human interventions count**               | Number of moments where the human had to correct the agent's direction mid-run (not counting routine choices like approving a retrospective output)                                                                                           | Step 2c conversation context, or PR event history |
 | **Step 5.2 violations count**               | Number of instances where the automated reviewer found a Step 5.2 (PR-readiness) violation during the batch                                                                                                                                   | PR comments and review cycles                     |
-| **Automated-reviewer retry loops count**    | Number of additional `pr-review-loop.sh` iterations beyond the first pass (i.e., how many re-runs were needed after findings were addressed)                                                                                                  | PR comment timestamps and review rounds           |
+| **Automated-reviewer retry loops count**    | Number of additional `pr-review-loop.sh` iterations beyond the first pass. When durable history is available, calculate `max(entries.length - 1, 0)` from `reviewer_loop_history.v1`; otherwise report `unavailable (<reason>)`.             | Reviewer-loop history block, then legacy PR comment timestamps and review rounds |
 | **Escalations count**                       | Number of items that escalated past the automated reviewer retry limit (source: PR labels or conversation notes indicating escalation)                                                                                                        | PR labels, conversation notes                     |
 | **Prior action item recurrence assessment** | For each open action item from prior retrospectives whose targeted failure mode was observable in this batch, record whether it "recurred" or "did not recur". If no prior action items are relevant to this batch, record "none applicable". | Comparison with prior retrospective output        |
 
@@ -283,6 +290,17 @@ After completing Steps 3a–3c (backlog query, template cross-reference, and cat
 
 - **"Unavailable" is a valid value**: if a field cannot be reliably determined from available GitHub data or conversation context, record `unavailable` — not blank and not a guess (BR-7).
 - **Zero is a valid value**: a batch that produced zero human interventions is a meaningful data point (BR-1).
+- **Durable reviewer-loop history is authoritative**: for automated-reviewer
+  retry metrics, prefer the latest `reviewer_loop_history.v1` JSON payload from
+  the script-owned summary comment. Use:
+  - `iteration_count = entries.length`
+  - `automated_reviewer_retry_loops_count = max(iteration_count - 1, 0)` when
+    `history_status` is `available`
+  - `unavailable (<reason>)` when the block is absent, malformed, unreadable, or
+    explicitly reports unavailable
+- **Iteration evidence**: when durable history is available, include the
+  per-iteration result, blocker count, and timestamp or stable ordering evidence
+  in the retrospective notes supporting the metrics block.
 - This metrics block is part of the retrospective output presented in Step 4 alongside improvement opportunities.
 
 ### Severity signals

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -5135,6 +5135,35 @@ reviewer_loop_history_unavailable_stub_body() {
   printf '```\n'
 }
 
+reviewer_loop_history_select_summary_record() {
+  jq -rs '
+    (add // []) as $all
+    | [
+        $all[]
+        | select(
+            (.body // "" | contains("### Automated Reviewer Loop Summary")) and
+            (.body // "" | contains("*Posted automatically by `pr-review-loop.sh`.*"))
+          )
+      ]
+    | sort_by(.created_at) as $comments
+    | (
+        $comments
+        | map(
+            select(
+              (.body // "" | contains("reviewer_loop_history.v1")) and
+              (.body // "" | test("\"history_status\"[[:space:]]*:[[:space:]]*\"available\""))
+            )
+          )
+        | last
+      ) as $history_source
+    | ($comments | last) as $target
+    | {
+        id: ($target.id // ""),
+        body: (($history_source.body // $target.body) // "")
+      }
+  '
+}
+
 reviewer_loop_history_append_to_summary() {
   local comment_body="$1"
   local existing_body="${2:-}"
@@ -5427,18 +5456,7 @@ EOF
     if ! _existing_comment_record="$(
         set -o pipefail
         gh api "repos/$_repo/issues/$_pr_number/comments" --paginate 2>/dev/null \
-          | jq -rs '
-              add // []
-              | [.[]
-                 | select(
-                     (.body // "" | contains("### Automated Reviewer Loop Summary")) and
-                     (.body // "" | contains("*Posted automatically by `pr-review-loop.sh`.*"))
-                   )
-                ]
-              | sort_by(.created_at)
-              | last
-              | {id: (.id // ""), body: (.body // "")}
-            '
+          | reviewer_loop_history_select_summary_record
       )"; then
       echo "WARN: failed to fetch existing summary comments for PR ${_pr_number}; will create a new comment with unavailable history" >&2
       _existing_comment_record=""
@@ -6122,18 +6140,7 @@ EOF
     _existing_comment_record="$(
       set -o pipefail
       gh api "repos/$_repo/issues/$pr_number/comments" --paginate 2>/dev/null \
-        | jq -rs '
-            add // []
-            | [.[]
-               | select(
-                   (.body // "" | contains("### Automated Reviewer Loop Summary")) and
-                   (.body // "" | contains("*Posted automatically by `pr-review-loop.sh`.*"))
-                 )
-              ]
-            | sort_by(.created_at)
-            | last
-            | {id: (.id // ""), body: (.body // "")}
-          '
+        | reviewer_loop_history_select_summary_record
     )" \
       || {
         echo "WARN: failed to fetch existing summary comments for PR ${pr_number}; will create a new comment with unavailable history" >&2

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4895,6 +4895,271 @@ doc_branch_default_poll_interval() {
   printf '%s\n' "$interval"
 }
 
+REVIEWER_LOOP_HISTORY_SCHEMA="reviewer_loop_history.v1"
+REVIEWER_LOOP_HISTORY_MARKER="<!-- reviewer-loop-history:v1 -->"
+
+reviewer_loop_history_extract_latest_json() {
+  awk -v marker="$REVIEWER_LOOP_HISTORY_MARKER" '
+    index($0, marker) > 0 {
+      seen_marker = 1
+      in_json = 0
+      block = ""
+      next
+    }
+    seen_marker && $0 ~ /^```json[[:space:]]*$/ {
+      in_json = 1
+      block = ""
+      next
+    }
+    in_json && $0 ~ /^```[[:space:]]*$/ {
+      latest = block
+      in_json = 0
+      seen_marker = 0
+      next
+    }
+    in_json {
+      block = block $0 "\n"
+    }
+    END {
+      printf "%s", latest
+    }
+  '
+}
+
+reviewer_loop_history_platforms_json() {
+  local platform_list="${1:-}"
+
+  printf '%s\n' "$platform_list" |
+    jq -R -s -c 'split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(length > 0 and . != "none"))'
+}
+
+reviewer_loop_history_current_head_sha() {
+  local head_sha=""
+  [ -n "${pr_number:-}" ] || return 0
+  if ! head_sha="$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid // ""' 2>/dev/null)"; then
+    head_sha=""
+  fi
+  printf '%s\n' "$head_sha"
+}
+
+reviewer_loop_history_recorded_at() {
+  local recorded_at=""
+  [ -n "${pr_number:-}" ] || return 0
+  if ! recorded_at="$(gh pr view "$pr_number" --json updatedAt --jq '.updatedAt // ""' 2>/dev/null)"; then
+    recorded_at=""
+  fi
+  printf '%s\n' "$recorded_at"
+}
+
+reviewer_loop_history_build_entry() {
+  local iteration="$1"
+  local result="$2"
+  local reason="$3"
+  local platform_list="$4"
+  local blocking="$5"
+  local suggestions="$6"
+  local phase_enabled="${7:-0}"
+  local phase_platform_list="${8:-}"
+  local phase_started="${9:-0}"
+  local phase_net_new_blocker="${10:-0}"
+  local phase_blocking_platform="${11:-}"
+  local platforms_json
+  local head_sha
+  local recorded_at
+
+  platforms_json="$(reviewer_loop_history_platforms_json "$platform_list")" || platforms_json='[]'
+  head_sha="$(reviewer_loop_history_current_head_sha)"
+  recorded_at="$(reviewer_loop_history_recorded_at)"
+
+  jq -n \
+    --argjson iteration "$iteration" \
+    --arg recordedAt "$recorded_at" \
+    --arg headSha "$head_sha" \
+    --arg result "$result" \
+    --arg reason "$reason" \
+    --argjson platforms "$platforms_json" \
+    --argjson blockingCount "${blocking:-0}" \
+    --argjson suggestionCount "${suggestions:-0}" \
+    --argjson unresolvedThreadCount "${unresolved_thread_count:-0}" \
+    --argjson lateThreadsFound "${late_thread_count:-0}" \
+    --argjson phaseEnabled "${phase_enabled:-0}" \
+    --arg phasePlatforms "$phase_platform_list" \
+    --argjson phaseStarted "${phase_started:-0}" \
+    --argjson phaseNetNewBlocker "${phase_net_new_blocker:-0}" \
+    --arg phaseBlockingPlatform "$phase_blocking_platform" \
+    '{
+      iteration: $iteration,
+      recorded_at: $recordedAt,
+      head_sha: $headSha,
+      result: $result,
+      reason: $reason,
+      platforms: $platforms,
+      blocking_count: $blockingCount,
+      suggestion_count: $suggestionCount,
+      unresolved_thread_count: $unresolvedThreadCount,
+      late_threads_found: $lateThreadsFound,
+      phase_after_clean: {
+        enabled: ($phaseEnabled == 1),
+        platforms: ($phasePlatforms | split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(length > 0))),
+        started: ($phaseStarted == 1),
+        net_new_blocker: ($phaseNetNewBlocker == 1),
+        blocking_platform: $phaseBlockingPlatform
+      }
+    }'
+}
+
+reviewer_loop_history_payload_from_existing() {
+  local existing_body="${1:-}"
+  local result="$2"
+  local reason="$3"
+  local platform_list="$4"
+  local blocking="$5"
+  local suggestions="$6"
+  local phase_enabled="${7:-0}"
+  local phase_platform_list="${8:-}"
+  local phase_started="${9:-0}"
+  local phase_net_new_blocker="${10:-0}"
+  local phase_blocking_platform="${11:-}"
+  local existing_json=""
+  local payload=""
+  local history_status="available"
+  local unavailable_reason=""
+  local append_safe=1
+  local entry=""
+  local iteration=1
+  local updated_at
+
+  existing_json="$(printf '%s\n' "$existing_body" | reviewer_loop_history_extract_latest_json)"
+  if [ -n "$existing_json" ]; then
+    if ! payload="$(printf '%s\n' "$existing_json" | jq -c '.' 2>/dev/null)"; then
+      history_status="unavailable"
+      unavailable_reason="malformed_history"
+      append_safe=0
+    elif ! printf '%s\n' "$payload" |
+        jq -e --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" '.schema == $schema and (.entries | type) == "array"' >/dev/null 2>&1; then
+      history_status="unavailable"
+      unavailable_reason="unknown_schema"
+      append_safe=0
+    elif [ "$(printf '%s\n' "$payload" | jq -r '.history_status // "available"')" = "unavailable" ]; then
+      history_status="unavailable"
+      unavailable_reason="$(printf '%s\n' "$payload" | jq -r '.history_unavailable_reason // "prior_unavailable"')"
+      append_safe=0
+    fi
+  elif printf '%s\n' "$existing_body" | grep -Fq "$REVIEWER_LOOP_HISTORY_MARKER"; then
+    history_status="unavailable"
+    unavailable_reason="missing_history_json"
+    append_safe=0
+  else
+    payload="$(jq -n \
+      --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" \
+      --argjson prNumber "${pr_number:-0}" \
+      '{schema: $schema, pr_number: $prNumber, updated_at: "", history_status: "available", history_unavailable_reason: "", entries: []}')"
+  fi
+
+  if [ "$append_safe" -eq 1 ]; then
+    iteration="$(printf '%s\n' "$payload" | jq '(.entries // []) | length + 1')"
+    entry="$(reviewer_loop_history_build_entry "$iteration" "$result" "$reason" "$platform_list" \
+      "$blocking" "$suggestions" "$phase_enabled" "$phase_platform_list" \
+      "$phase_started" "$phase_net_new_blocker" "$phase_blocking_platform")"
+    updated_at="$(printf '%s\n' "$entry" | jq -r '.recorded_at // ""')"
+    printf '%s\n' "$payload" | jq \
+      --arg updatedAt "$updated_at" \
+      --argjson entry "$entry" \
+      '.updated_at = $updatedAt
+       | .history_status = "available"
+       | .history_unavailable_reason = ""
+       | .entries = ((.entries // []) + [$entry])'
+  else
+    updated_at="$(reviewer_loop_history_recorded_at)"
+    jq -n \
+      --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" \
+      --argjson prNumber "${pr_number:-0}" \
+      --arg updatedAt "$updated_at" \
+      --arg status "$history_status" \
+      --arg reason "$unavailable_reason" \
+      '{
+        schema: $schema,
+        pr_number: $prNumber,
+        updated_at: $updatedAt,
+        history_status: $status,
+        history_unavailable_reason: $reason,
+        entries: []
+      }'
+  fi
+}
+
+reviewer_loop_history_render_section() {
+  local payload="$1"
+  local status
+  local reason
+  local count
+
+  status="$(printf '%s\n' "$payload" | jq -r '.history_status // "available"')"
+  reason="$(printf '%s\n' "$payload" | jq -r '.history_unavailable_reason // ""')"
+  count="$(printf '%s\n' "$payload" | jq '(.entries // []) | length')"
+
+  printf '\n\n<details>\n'
+  if [ "$status" = "available" ]; then
+    printf '<summary>Reviewer-loop history (%s iteration%s)</summary>\n\n' \
+      "$count" "$([ "$count" -eq 1 ] && printf '' || printf 's')"
+  else
+    printf '<summary>Reviewer-loop history unavailable (%s)</summary>\n\n' "${reason:-unknown}"
+  fi
+  printf '%s\n' "$REVIEWER_LOOP_HISTORY_MARKER"
+  printf '```json\n'
+  printf '%s\n' "$payload" | jq '.'
+  printf '```\n'
+  printf '</details>'
+}
+
+reviewer_loop_history_unavailable_stub_body() {
+  local reason="${1:-unknown}"
+  local updated_at
+  updated_at="$(reviewer_loop_history_recorded_at)"
+
+  printf '%s\n' "$REVIEWER_LOOP_HISTORY_MARKER"
+  printf '```json\n'
+  jq -n \
+    --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" \
+    --argjson prNumber "${pr_number:-0}" \
+    --arg updatedAt "$updated_at" \
+    --arg reason "$reason" \
+    '{
+      schema: $schema,
+      pr_number: $prNumber,
+      updated_at: $updatedAt,
+      history_status: "unavailable",
+      history_unavailable_reason: $reason,
+      entries: []
+    }'
+  printf '```\n'
+}
+
+reviewer_loop_history_append_to_summary() {
+  local comment_body="$1"
+  local existing_body="${2:-}"
+  shift 2
+  local payload
+  local section
+
+  if ! payload="$(reviewer_loop_history_payload_from_existing "$existing_body" "$@" 2>/dev/null)"; then
+    payload="$(jq -n \
+      --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" \
+      --argjson prNumber "${pr_number:-0}" \
+      --arg updatedAt "$(reviewer_loop_history_recorded_at)" \
+      '{
+        schema: $schema,
+        pr_number: $prNumber,
+        updated_at: $updatedAt,
+        history_status: "unavailable",
+        history_unavailable_reason: "history_render_failed",
+        entries: []
+      }')"
+  fi
+  section="$(reviewer_loop_history_render_section "$payload")"
+  printf '%s%s\n' "$comment_body" "$section"
+}
+
 # ---------------------------------------------------------------------------
 # _check_release_pr_guard <pr_number> [<branch_name>]
 #
@@ -5135,6 +5400,8 @@ post_release_guard_summary() {
   local _branch_name="$2"
   local _repo _existing_comment_id _patch_payload _comment_posted _body_tmpfile
   local _comment_body
+  local _existing_comment_body=""
+  local _existing_comment_record=""
 
   if [ -z "$_pr_number" ]; then
     return 0
@@ -5157,22 +5424,34 @@ EOF
   _existing_comment_id=""
   _repo="$(repo_slug 2>/dev/null)"
   if [ -n "$_repo" ]; then
-    _existing_comment_id="$(
-      gh api "repos/$_repo/issues/$_pr_number/comments" --paginate 2>/dev/null \
-        | jq -rs '
-            add // []
-            | [.[]
-               | select(
-                   (.body // "" | contains("### Automated Reviewer Loop Summary")) and
-                   (.body // "" | contains("*Posted automatically by `pr-review-loop.sh`.*"))
-                 )
-              ]
-            | sort_by(.created_at)
-            | last
-            | .id // empty
-          '
-    )"
+    if ! _existing_comment_record="$(
+        set -o pipefail
+        gh api "repos/$_repo/issues/$_pr_number/comments" --paginate 2>/dev/null \
+          | jq -rs '
+              add // []
+              | [.[]
+                 | select(
+                     (.body // "" | contains("### Automated Reviewer Loop Summary")) and
+                     (.body // "" | contains("*Posted automatically by `pr-review-loop.sh`.*"))
+                   )
+                ]
+              | sort_by(.created_at)
+              | last
+              | {id: (.id // ""), body: (.body // "")}
+            '
+      )"; then
+      echo "WARN: failed to fetch existing summary comments for PR ${_pr_number}; will create a new comment with unavailable history" >&2
+      _existing_comment_record=""
+      _existing_comment_body="$(reviewer_loop_history_unavailable_stub_body comment_read_failed)"
+    fi
+    if [ -n "$_existing_comment_record" ]; then
+      _existing_comment_id="$(printf '%s\n' "$_existing_comment_record" | jq -r '.id // empty' 2>/dev/null)" || _existing_comment_id=""
+      _existing_comment_body="$(printf '%s\n' "$_existing_comment_record" | jq -r '.body // ""' 2>/dev/null)" || _existing_comment_body=""
+    fi
   fi
+
+  _comment_body="$(reviewer_loop_history_append_to_summary "$_comment_body" "$_existing_comment_body" \
+    "skipped" "release_pr" "none" "0" "0" "0" "" "0" "0" "")"
 
   _patch_payload="$(jq -n --arg body "$_comment_body" '{body: $body}')"
   _comment_posted=0
@@ -5834,11 +6113,14 @@ EOF
   # The marker string "*Posted automatically by `pr-review-loop.sh`.*" is unique
   # to this script and is present in every comment it posts.
   local _existing_comment_id=""
+  local _existing_comment_body=""
   local _repo
+  local _existing_comment_record=""
   _repo="$(repo_slug 2>/dev/null)" \
     || { echo "WARN: repo_slug failed in _post_review_summary; will post new comment without update-in-place check" >&2; _repo=""; }
   if [ -n "$_repo" ]; then
-    _existing_comment_id="$(
+    _existing_comment_record="$(
+      set -o pipefail
       gh api "repos/$_repo/issues/$pr_number/comments" --paginate 2>/dev/null \
         | jq -rs '
             add // []
@@ -5850,11 +6132,24 @@ EOF
               ]
             | sort_by(.created_at)
             | last
-            | .id // empty
+            | {id: (.id // ""), body: (.body // "")}
           '
     )" \
-      || { echo "WARN: failed to fetch existing summary comments for PR ${pr_number}; will create a new comment" >&2; _existing_comment_id=""; }
+      || {
+        echo "WARN: failed to fetch existing summary comments for PR ${pr_number}; will create a new comment with unavailable history" >&2
+        _existing_comment_record=""
+        _existing_comment_body="$(reviewer_loop_history_unavailable_stub_body comment_read_failed)"
+      }
+    if [ -n "$_existing_comment_record" ]; then
+      _existing_comment_id="$(printf '%s\n' "$_existing_comment_record" | jq -r '.id // empty' 2>/dev/null)" || _existing_comment_id=""
+      _existing_comment_body="$(printf '%s\n' "$_existing_comment_record" | jq -r '.body // ""' 2>/dev/null)" || _existing_comment_body=""
+    fi
   fi
+
+  comment_body="$(reviewer_loop_history_append_to_summary "$comment_body" "$_existing_comment_body" \
+    "$result" "$reason" "$platform_list" "$blocking" "$suggestions" \
+    "$phase_enabled" "$phase_platform_list" "$phase_started" \
+    "$phase_net_new_blocker" "$phase_blocking_platform")"
 
   local _patch_payload
   _patch_payload="$(jq -n --arg body "$comment_body" '{body: $body}')"
@@ -6194,9 +6489,17 @@ case "$aggregate_result" in
     ;;
   needs_rerun)
     # PR-Agent "Possible Issue" evaluation pushed a fix; orchestrator must
-    # re-invoke the loop on the new HEAD. No summary comment is posted here —
-    # the loop re-runs from the top and posts the summary on its terminal exit.
+    # re-invoke the loop on the new HEAD. Preserve this completed iteration
+    # before exit so retrospective retry metrics do not lose the fix-pushed run.
     # RESULT=needs_rerun is already emitted by the general print_kv block above.
+    _post_review_summary "$aggregate_result" "$aggregate_reason" \
+      "$_summary_platform_list" \
+      "$total_blocking_count" "$total_suggestion_count" \
+      "$aggregate_advisory_labels" \
+      "$aggregate_possible_issue_eval_outcome" \
+      "$phase_after_clean_enabled" "$phase_after_clean_platform_list" \
+      "$phase_after_clean_started" "$phase_after_clean_net_new_blocker" \
+      "$phase_after_clean_blocking_platform" "$pre_after_clean_only"
     exit 3
     ;;
   escalate)

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4895,6 +4895,263 @@ doc_branch_default_poll_interval() {
   printf '%s\n' "$interval"
 }
 
+REVIEWER_LOOP_HISTORY_SCHEMA="reviewer_loop_history.v1"
+REVIEWER_LOOP_HISTORY_MARKER="<!-- reviewer-loop-history:v1 -->"
+
+reviewer_loop_history_extract_latest_json() {
+  awk -v marker="$REVIEWER_LOOP_HISTORY_MARKER" '
+    index($0, marker) > 0 {
+      seen_marker = 1
+      in_json = 0
+      block = ""
+      next
+    }
+    seen_marker && $0 ~ /^```json[[:space:]]*$/ {
+      in_json = 1
+      block = ""
+      next
+    }
+    in_json && $0 ~ /^```[[:space:]]*$/ {
+      latest = block
+      in_json = 0
+      seen_marker = 0
+      next
+    }
+    in_json {
+      block = block $0 "\n"
+    }
+    END {
+      printf "%s", latest
+    }
+  '
+}
+
+reviewer_loop_history_platforms_json() {
+  local platform_list="${1:-}"
+
+  printf '%s\n' "$platform_list" |
+    jq -R -s -c 'split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(length > 0 and . != "none"))'
+}
+
+reviewer_loop_history_current_head_sha() {
+  [ -n "${pr_number:-}" ] || return 0
+  gh pr view "$pr_number" --json headRefOid --jq '.headRefOid // ""' 2>/dev/null || true
+}
+
+reviewer_loop_history_recorded_at() {
+  [ -n "${pr_number:-}" ] || return 0
+  gh pr view "$pr_number" --json updatedAt --jq '.updatedAt // ""' 2>/dev/null || true
+}
+
+reviewer_loop_history_build_entry() {
+  local iteration="$1"
+  local result="$2"
+  local reason="$3"
+  local platform_list="$4"
+  local blocking="$5"
+  local suggestions="$6"
+  local phase_enabled="${7:-0}"
+  local phase_platform_list="${8:-}"
+  local phase_started="${9:-0}"
+  local phase_net_new_blocker="${10:-0}"
+  local phase_blocking_platform="${11:-}"
+  local platforms_json
+  local head_sha
+  local recorded_at
+
+  platforms_json="$(reviewer_loop_history_platforms_json "$platform_list")" || platforms_json='[]'
+  head_sha="$(reviewer_loop_history_current_head_sha)"
+  recorded_at="$(reviewer_loop_history_recorded_at)"
+
+  jq -n \
+    --argjson iteration "$iteration" \
+    --arg recordedAt "$recorded_at" \
+    --arg headSha "$head_sha" \
+    --arg result "$result" \
+    --arg reason "$reason" \
+    --argjson platforms "$platforms_json" \
+    --argjson blockingCount "${blocking:-0}" \
+    --argjson suggestionCount "${suggestions:-0}" \
+    --argjson unresolvedThreadCount "${unresolved_thread_count:-0}" \
+    --argjson lateThreadsFound "${late_thread_count:-0}" \
+    --argjson phaseEnabled "${phase_enabled:-0}" \
+    --arg phasePlatforms "$phase_platform_list" \
+    --argjson phaseStarted "${phase_started:-0}" \
+    --argjson phaseNetNewBlocker "${phase_net_new_blocker:-0}" \
+    --arg phaseBlockingPlatform "$phase_blocking_platform" \
+    '{
+      iteration: $iteration,
+      recorded_at: $recordedAt,
+      head_sha: $headSha,
+      result: $result,
+      reason: $reason,
+      platforms: $platforms,
+      blocking_count: $blockingCount,
+      suggestion_count: $suggestionCount,
+      unresolved_thread_count: $unresolvedThreadCount,
+      late_threads_found: $lateThreadsFound,
+      phase_after_clean: {
+        enabled: ($phaseEnabled == 1),
+        platforms: ($phasePlatforms | split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(length > 0))),
+        started: ($phaseStarted == 1),
+        net_new_blocker: ($phaseNetNewBlocker == 1),
+        blocking_platform: $phaseBlockingPlatform
+      }
+    }'
+}
+
+reviewer_loop_history_payload_from_existing() {
+  local existing_body="${1:-}"
+  local result="$2"
+  local reason="$3"
+  local platform_list="$4"
+  local blocking="$5"
+  local suggestions="$6"
+  local phase_enabled="${7:-0}"
+  local phase_platform_list="${8:-}"
+  local phase_started="${9:-0}"
+  local phase_net_new_blocker="${10:-0}"
+  local phase_blocking_platform="${11:-}"
+  local existing_json=""
+  local payload=""
+  local history_status="available"
+  local unavailable_reason=""
+  local append_safe=1
+  local entry=""
+  local iteration=1
+  local updated_at
+
+  existing_json="$(printf '%s\n' "$existing_body" | reviewer_loop_history_extract_latest_json)"
+  if [ -n "$existing_json" ]; then
+    if ! payload="$(printf '%s\n' "$existing_json" | jq -c '.' 2>/dev/null)"; then
+      history_status="unavailable"
+      unavailable_reason="malformed_history"
+      append_safe=0
+    elif ! printf '%s\n' "$payload" |
+        jq -e --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" '.schema == $schema and (.entries | type) == "array"' >/dev/null 2>&1; then
+      history_status="unavailable"
+      unavailable_reason="unknown_schema"
+      append_safe=0
+    elif [ "$(printf '%s\n' "$payload" | jq -r '.history_status // "available"')" = "unavailable" ]; then
+      history_status="unavailable"
+      unavailable_reason="$(printf '%s\n' "$payload" | jq -r '.history_unavailable_reason // "prior_unavailable"')"
+      append_safe=0
+    fi
+  elif printf '%s\n' "$existing_body" | grep -Fq "$REVIEWER_LOOP_HISTORY_MARKER"; then
+    history_status="unavailable"
+    unavailable_reason="missing_history_json"
+    append_safe=0
+  else
+    payload="$(jq -n \
+      --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" \
+      --argjson prNumber "${pr_number:-0}" \
+      '{schema: $schema, pr_number: $prNumber, updated_at: "", history_status: "available", history_unavailable_reason: "", entries: []}')"
+  fi
+
+  if [ "$append_safe" -eq 1 ]; then
+    iteration="$(printf '%s\n' "$payload" | jq '(.entries // []) | length + 1')"
+    entry="$(reviewer_loop_history_build_entry "$iteration" "$result" "$reason" "$platform_list" \
+      "$blocking" "$suggestions" "$phase_enabled" "$phase_platform_list" \
+      "$phase_started" "$phase_net_new_blocker" "$phase_blocking_platform")"
+    updated_at="$(printf '%s\n' "$entry" | jq -r '.recorded_at // ""')"
+    printf '%s\n' "$payload" | jq \
+      --arg updatedAt "$updated_at" \
+      --argjson entry "$entry" \
+      '.updated_at = $updatedAt
+       | .history_status = "available"
+       | .history_unavailable_reason = ""
+       | .entries = ((.entries // []) + [$entry])'
+  else
+    updated_at="$(reviewer_loop_history_recorded_at)"
+    jq -n \
+      --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" \
+      --argjson prNumber "${pr_number:-0}" \
+      --arg updatedAt "$updated_at" \
+      --arg status "$history_status" \
+      --arg reason "$unavailable_reason" \
+      '{
+        schema: $schema,
+        pr_number: $prNumber,
+        updated_at: $updatedAt,
+        history_status: $status,
+        history_unavailable_reason: $reason,
+        entries: []
+      }'
+  fi
+}
+
+reviewer_loop_history_render_section() {
+  local payload="$1"
+  local status
+  local reason
+  local count
+
+  status="$(printf '%s\n' "$payload" | jq -r '.history_status // "available"')"
+  reason="$(printf '%s\n' "$payload" | jq -r '.history_unavailable_reason // ""')"
+  count="$(printf '%s\n' "$payload" | jq '(.entries // []) | length')"
+
+  printf '\n\n<details>\n'
+  if [ "$status" = "available" ]; then
+    printf '<summary>Reviewer-loop history (%s iteration%s)</summary>\n\n' \
+      "$count" "$([ "$count" -eq 1 ] && printf '' || printf 's')"
+  else
+    printf '<summary>Reviewer-loop history unavailable (%s)</summary>\n\n' "${reason:-unknown}"
+  fi
+  printf '%s\n' "$REVIEWER_LOOP_HISTORY_MARKER"
+  printf '```json\n'
+  printf '%s\n' "$payload" | jq '.'
+  printf '```\n'
+  printf '</details>'
+}
+
+reviewer_loop_history_unavailable_stub_body() {
+  local reason="${1:-unknown}"
+  local updated_at
+  updated_at="$(reviewer_loop_history_recorded_at)"
+
+  printf '%s\n' "$REVIEWER_LOOP_HISTORY_MARKER"
+  printf '```json\n'
+  jq -n \
+    --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" \
+    --argjson prNumber "${pr_number:-0}" \
+    --arg updatedAt "$updated_at" \
+    --arg reason "$reason" \
+    '{
+      schema: $schema,
+      pr_number: $prNumber,
+      updated_at: $updatedAt,
+      history_status: "unavailable",
+      history_unavailable_reason: $reason,
+      entries: []
+    }'
+  printf '```\n'
+}
+
+reviewer_loop_history_append_to_summary() {
+  local comment_body="$1"
+  local existing_body="${2:-}"
+  shift 2
+  local payload
+  local section
+
+  if ! payload="$(reviewer_loop_history_payload_from_existing "$existing_body" "$@" 2>/dev/null)"; then
+    payload="$(jq -n \
+      --arg schema "$REVIEWER_LOOP_HISTORY_SCHEMA" \
+      --argjson prNumber "${pr_number:-0}" \
+      --arg updatedAt "$(reviewer_loop_history_recorded_at)" \
+      '{
+        schema: $schema,
+        pr_number: $prNumber,
+        updated_at: $updatedAt,
+        history_status: "unavailable",
+        history_unavailable_reason: "history_render_failed",
+        entries: []
+      }')"
+  fi
+  section="$(reviewer_loop_history_render_section "$payload")"
+  printf '%s%s\n' "$comment_body" "$section"
+}
+
 # ---------------------------------------------------------------------------
 # _check_release_pr_guard <pr_number> [<branch_name>]
 #
@@ -5135,6 +5392,8 @@ post_release_guard_summary() {
   local _branch_name="$2"
   local _repo _existing_comment_id _patch_payload _comment_posted _body_tmpfile
   local _comment_body
+  local _existing_comment_body=""
+  local _existing_comment_record=""
 
   if [ -z "$_pr_number" ]; then
     return 0
@@ -5157,22 +5416,33 @@ EOF
   _existing_comment_id=""
   _repo="$(repo_slug 2>/dev/null)"
   if [ -n "$_repo" ]; then
-    _existing_comment_id="$(
-      gh api "repos/$_repo/issues/$_pr_number/comments" --paginate 2>/dev/null \
-        | jq -rs '
-            add // []
-            | [.[]
-               | select(
-                   (.body // "" | contains("### Automated Reviewer Loop Summary")) and
-                   (.body // "" | contains("*Posted automatically by `pr-review-loop.sh`.*"))
-                 )
-              ]
-            | sort_by(.created_at)
-            | last
-            | .id // empty
-          '
-    )"
+    if ! _existing_comment_record="$(
+        gh api "repos/$_repo/issues/$_pr_number/comments" --paginate 2>/dev/null \
+          | jq -rs '
+              add // []
+              | [.[]
+                 | select(
+                     (.body // "" | contains("### Automated Reviewer Loop Summary")) and
+                     (.body // "" | contains("*Posted automatically by `pr-review-loop.sh`.*"))
+                   )
+                ]
+              | sort_by(.created_at)
+              | last
+              | {id: (.id // ""), body: (.body // "")}
+            '
+      )"; then
+      echo "WARN: failed to fetch existing summary comments for PR ${_pr_number}; will create a new comment with unavailable history" >&2
+      _existing_comment_record=""
+      _existing_comment_body="$(reviewer_loop_history_unavailable_stub_body comment_read_failed)"
+    fi
+    if [ -n "$_existing_comment_record" ]; then
+      _existing_comment_id="$(printf '%s\n' "$_existing_comment_record" | jq -r '.id // empty' 2>/dev/null)" || _existing_comment_id=""
+      _existing_comment_body="$(printf '%s\n' "$_existing_comment_record" | jq -r '.body // ""' 2>/dev/null)" || _existing_comment_body=""
+    fi
   fi
+
+  _comment_body="$(reviewer_loop_history_append_to_summary "$_comment_body" "$_existing_comment_body" \
+    "skipped" "release_pr" "none" "0" "0" "0" "" "0" "0" "")"
 
   _patch_payload="$(jq -n --arg body "$_comment_body" '{body: $body}')"
   _comment_posted=0
@@ -5834,11 +6104,13 @@ EOF
   # The marker string "*Posted automatically by `pr-review-loop.sh`.*" is unique
   # to this script and is present in every comment it posts.
   local _existing_comment_id=""
+  local _existing_comment_body=""
   local _repo
+  local _existing_comment_record=""
   _repo="$(repo_slug 2>/dev/null)" \
     || { echo "WARN: repo_slug failed in _post_review_summary; will post new comment without update-in-place check" >&2; _repo=""; }
   if [ -n "$_repo" ]; then
-    _existing_comment_id="$(
+    _existing_comment_record="$(
       gh api "repos/$_repo/issues/$pr_number/comments" --paginate 2>/dev/null \
         | jq -rs '
             add // []
@@ -5850,11 +6122,24 @@ EOF
               ]
             | sort_by(.created_at)
             | last
-            | .id // empty
+            | {id: (.id // ""), body: (.body // "")}
           '
     )" \
-      || { echo "WARN: failed to fetch existing summary comments for PR ${pr_number}; will create a new comment" >&2; _existing_comment_id=""; }
+      || {
+        echo "WARN: failed to fetch existing summary comments for PR ${pr_number}; will create a new comment with unavailable history" >&2
+        _existing_comment_record=""
+        _existing_comment_body="$(reviewer_loop_history_unavailable_stub_body comment_read_failed)"
+      }
+    if [ -n "$_existing_comment_record" ]; then
+      _existing_comment_id="$(printf '%s\n' "$_existing_comment_record" | jq -r '.id // empty' 2>/dev/null)" || _existing_comment_id=""
+      _existing_comment_body="$(printf '%s\n' "$_existing_comment_record" | jq -r '.body // ""' 2>/dev/null)" || _existing_comment_body=""
+    fi
   fi
+
+  comment_body="$(reviewer_loop_history_append_to_summary "$comment_body" "$_existing_comment_body" \
+    "$result" "$reason" "$platform_list" "$blocking" "$suggestions" \
+    "$phase_enabled" "$phase_platform_list" "$phase_started" \
+    "$phase_net_new_blocker" "$phase_blocking_platform")"
 
   local _patch_payload
   _patch_payload="$(jq -n --arg body "$comment_body" '{body: $body}')"
@@ -6194,9 +6479,17 @@ case "$aggregate_result" in
     ;;
   needs_rerun)
     # PR-Agent "Possible Issue" evaluation pushed a fix; orchestrator must
-    # re-invoke the loop on the new HEAD. No summary comment is posted here —
-    # the loop re-runs from the top and posts the summary on its terminal exit.
+    # re-invoke the loop on the new HEAD. Preserve this completed iteration
+    # before exit so retrospective retry metrics do not lose the fix-pushed run.
     # RESULT=needs_rerun is already emitted by the general print_kv block above.
+    _post_review_summary "$aggregate_result" "$aggregate_reason" \
+      "$_summary_platform_list" \
+      "$total_blocking_count" "$total_suggestion_count" \
+      "$aggregate_advisory_labels" \
+      "$aggregate_possible_issue_eval_outcome" \
+      "$phase_after_clean_enabled" "$phase_after_clean_platform_list" \
+      "$phase_after_clean_started" "$phase_after_clean_net_new_blocker" \
+      "$phase_after_clean_blocking_platform" "$pre_after_clean_only"
     exit 3
     ;;
   escalate)

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -105,6 +105,10 @@ case "$*" in
     printf '%s\n' "${MOCK_GH_HEAD_SHA:-}"
     exit "${MOCK_GH_EXIT:-0}"
     ;;
+  *"updatedAt"*)
+    printf '%s\n' "${MOCK_GH_UPDATED_AT:-2026-07-18T00:00:00Z}"
+    exit "${MOCK_GH_EXIT:-0}"
+    ;;
   # gh api repos/.../issues/.../comments — used by restore_regression_label_if_missing
   # to check for prior reviewer-loop summary comments (Area 11 summary-comment gate).
   # Tests set MOCK_GH_COMMENTS_OUTPUT to control the returned JSON; defaults to an
@@ -1451,10 +1455,187 @@ fi
 run_test "summary_advisory_split_visible" "yes" "$_summary_advisory_split"
 rm -f "$_summary_call_log"
 rm -f "$_summary_body_capture"
-unset MOCK_GH_CALL_LOG MOCK_GH_BODY_CAPTURE MOCK_GH_EXIT MOCK_GH_COMMENTS_OUTPUT
+
+if ! _summary_read_failed_body_capture="$(mktemp)"; then
+  echo "ERROR: failed to allocate read-failure summary body capture temp file" >&2
+  exit 1
+fi
+if [ -z "$_summary_read_failed_body_capture" ]; then
+  echo "ERROR: mktemp returned an empty read-failure summary body capture path" >&2
+  exit 1
+fi
+export MOCK_GH_BODY_CAPTURE="$_summary_read_failed_body_capture"
+MOCK_GH_EXIT=0
+MOCK_GH_COMMENTS_EXIT=1
+MOCK_GH_UPDATED_AT="2026-07-18T00:10:00Z"
+export MOCK_GH_EXIT MOCK_GH_COMMENTS_EXIT MOCK_GH_UPDATED_AT
+_post_review_summary "clean" "" "bugbot (clean)" "0" "0"
+if [ -n "${_summary_read_failed_body_capture:-}" ] \
+    && grep -q "comment_read_failed" "$_summary_read_failed_body_capture"; then
+  _summary_read_failed_history="yes"
+else
+  _summary_read_failed_history="no"
+fi
+run_test "summary_comment_read_failure_history_unavailable" "yes" "$_summary_read_failed_history"
+rm -f "$_summary_read_failed_body_capture"
+unset MOCK_GH_CALL_LOG MOCK_GH_BODY_CAPTURE MOCK_GH_EXIT MOCK_GH_COMMENTS_OUTPUT MOCK_GH_COMMENTS_EXIT MOCK_GH_UPDATED_AT
 unset _summary_advisory_split _post_summary_source
+unset _summary_read_failed_body_capture _summary_read_failed_history
 unset -f _post_review_summary
 unset compare_mode compare_verdicts platform_policy_status_notes pr_number branch_name
+
+# ---------------------------------------------------------------------------
+# Area 10b: reviewer-loop history payload (#1243)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 10b: reviewer-loop history payload ==="
+
+pr_number=42
+branch_name="fix/42-history"
+unresolved_thread_count=0
+late_thread_count=0
+MOCK_GH_HEAD_SHA="abc-history-1"
+MOCK_GH_UPDATED_AT="2026-07-18T00:00:00Z"
+export MOCK_GH_HEAD_SHA MOCK_GH_UPDATED_AT
+
+_history_payload="$(reviewer_loop_history_payload_from_existing "" \
+  "clean" "" "bugbot (clean)" "0" "0" "1" "bugbot" "1" "0" "")"
+run_test "history_first_entry_schema" "reviewer_loop_history.v1" \
+  "$(printf '%s\n' "$_history_payload" | jq -r '.schema')"
+run_test "history_first_entry_count" "1" \
+  "$(printf '%s\n' "$_history_payload" | jq '(.entries // []) | length')"
+run_test "history_first_entry_zero_retries" "0" \
+  "$(printf '%s\n' "$_history_payload" | jq '((.entries // []) | length) - 1')"
+run_test "history_first_entry_result" "clean" \
+  "$(printf '%s\n' "$_history_payload" | jq -r '.entries[0].result')"
+
+_history_existing_body="$(cat <<EOF_HISTORY
+### Automated Reviewer Loop Summary
+
+*Posted automatically by \`pr-review-loop.sh\`.*
+
+<details>
+<summary>Reviewer-loop history (1 iteration)</summary>
+
+<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+$(printf '%s\n' "$_history_payload" | jq '.')
+\`\`\`
+</details>
+EOF_HISTORY
+)"
+MOCK_GH_HEAD_SHA="abc-history-2"
+MOCK_GH_UPDATED_AT="2026-07-18T00:05:00Z"
+_history_payload_2="$(reviewer_loop_history_payload_from_existing "$_history_existing_body" \
+  "needs_fixes" "unresolved_review_threads" "bugbot (needs_fixes)" "1" "0" "1" "bugbot" "1" "1" "review_threads")"
+run_test "history_append_entry_count" "2" \
+  "$(printf '%s\n' "$_history_payload_2" | jq '(.entries // []) | length')"
+run_test "history_append_second_iteration" "2" \
+  "$(printf '%s\n' "$_history_payload_2" | jq '.entries[1].iteration')"
+run_test "history_append_preserves_first_result" "clean" \
+  "$(printf '%s\n' "$_history_payload_2" | jq -r '.entries[0].result')"
+run_test "history_append_records_blocking_count" "1" \
+  "$(printf '%s\n' "$_history_payload_2" | jq '.entries[1].blocking_count')"
+
+_history_empty_entries_body=$'### Automated Reviewer Loop Summary\n\n<!-- reviewer-loop-history:v1 -->\n```json\n{\"schema\":\"reviewer_loop_history.v1\",\"history_status\":\"available\",\"entries\":[]}\n```\n'
+_history_empty_entries_payload="$(reviewer_loop_history_payload_from_existing "$_history_empty_entries_body" \
+  "clean" "" "bugbot (clean)" "0" "0")"
+run_test "history_empty_entries_append_count" "1" \
+  "$(printf '%s\n' "$_history_empty_entries_payload" | jq '(.entries // []) | length')"
+
+_history_needs_rerun_payload="$(reviewer_loop_history_payload_from_existing "" \
+  "needs_rerun" "" "pr-agent (needs_rerun)" "0" "0")"
+run_test "history_needs_rerun_result" "needs_rerun" \
+  "$(printf '%s\n' "$_history_needs_rerun_payload" | jq -r '.entries[0].result')"
+
+_history_same_sha_body="$(cat <<EOF_HISTORY_SAME_SHA
+### Automated Reviewer Loop Summary
+
+<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+$(printf '%s\n' "$_history_payload" | jq '.')
+\`\`\`
+EOF_HISTORY_SAME_SHA
+)"
+MOCK_GH_HEAD_SHA="abc-history-1"
+_history_same_sha_payload="$(reviewer_loop_history_payload_from_existing "$_history_same_sha_body" \
+  "clean" "transient_retry" "bugbot (clean)" "0" "0")"
+run_test "history_same_sha_duplicate_appends" "2" \
+  "$(printf '%s\n' "$_history_same_sha_payload" | jq '(.entries // []) | length')"
+
+_history_latest_body="$(cat <<EOF_HISTORY_LATEST
+### Automated Reviewer Loop Summary
+
+<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+{"schema":"reviewer_loop_history.v1","history_status":"available","entries":[{"iteration":1,"result":"old"}]}
+\`\`\`
+
+Some adjacent Markdown that must not be consumed.
+
+<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+{"schema":"reviewer_loop_history.v1","history_status":"available","entries":[{"iteration":1,"result":"latest"}]}
+\`\`\`
+Trailing summary text.
+EOF_HISTORY_LATEST
+)"
+_history_latest_payload="$(reviewer_loop_history_payload_from_existing "$_history_latest_body" \
+  "clean" "" "bugbot (clean)" "0" "0")"
+run_test "history_latest_block_preserved" "latest" \
+  "$(printf '%s\n' "$_history_latest_payload" | jq -r '.entries[0].result')"
+run_test "history_fence_boundary_append_count" "2" \
+  "$(printf '%s\n' "$_history_latest_payload" | jq '(.entries // []) | length')"
+
+_history_malformed_body=$'### Automated Reviewer Loop Summary\n\n<!-- reviewer-loop-history:v1 -->\n```json\n{ not json\n```\n'
+_history_malformed_payload="$(reviewer_loop_history_payload_from_existing "$_history_malformed_body" \
+  "clean" "" "bugbot (clean)" "0" "0")"
+run_test "history_malformed_unavailable" "unavailable" \
+  "$(printf '%s\n' "$_history_malformed_payload" | jq -r '.history_status')"
+run_test "history_malformed_reason" "malformed_history" \
+  "$(printf '%s\n' "$_history_malformed_payload" | jq -r '.history_unavailable_reason')"
+
+_history_wrong_schema_body=$'### Automated Reviewer Loop Summary\n\n<!-- reviewer-loop-history:v1 -->\n```json\n{\"schema\":\"other.v1\",\"entries\":[]}\n```\n'
+_history_wrong_schema_payload="$(reviewer_loop_history_payload_from_existing "$_history_wrong_schema_body" \
+  "clean" "" "bugbot (clean)" "0" "0")"
+run_test "history_wrong_schema_reason" "unknown_schema" \
+  "$(printf '%s\n' "$_history_wrong_schema_payload" | jq -r '.history_unavailable_reason')"
+
+_history_prior_unavailable_body=$'### Automated Reviewer Loop Summary\n\n<!-- reviewer-loop-history:v1 -->\n```json\n{\"schema\":\"reviewer_loop_history.v1\",\"history_status\":\"unavailable\",\"history_unavailable_reason\":\"comment_read_failed\",\"entries\":[]}\n```\n'
+_history_prior_unavailable_payload="$(reviewer_loop_history_payload_from_existing "$_history_prior_unavailable_body" \
+  "clean" "" "bugbot (clean)" "0" "0")"
+run_test "history_prior_unavailable_preserved" "comment_read_failed" \
+  "$(printf '%s\n' "$_history_prior_unavailable_payload" | jq -r '.history_unavailable_reason')"
+
+_history_read_failed_body="$(reviewer_loop_history_unavailable_stub_body comment_read_failed)"
+_history_read_failed_payload="$(reviewer_loop_history_payload_from_existing "$_history_read_failed_body" \
+  "clean" "" "bugbot (clean)" "0" "0")"
+run_test "history_read_failure_unavailable" "unavailable" \
+  "$(printf '%s\n' "$_history_read_failed_payload" | jq -r '.history_status')"
+run_test "history_read_failure_reason" "comment_read_failed" \
+  "$(printf '%s\n' "$_history_read_failed_payload" | jq -r '.history_unavailable_reason')"
+
+_history_rendered_section="$(reviewer_loop_history_render_section "$_history_payload_2")"
+if printf '%s\n' "$_history_rendered_section" | grep -qF "$REVIEWER_LOOP_HISTORY_MARKER" \
+    && printf '%s\n' "$_history_rendered_section" | grep -qF "Reviewer-loop history (2 iterations)"; then
+  _history_rendered_ok="yes"
+else
+  _history_rendered_ok="no"
+fi
+run_test "history_rendered_section" "yes" "$_history_rendered_ok"
+
+unset _history_payload _history_existing_body _history_payload_2
+unset _history_empty_entries_body _history_empty_entries_payload
+unset _history_needs_rerun_payload
+unset _history_same_sha_body _history_same_sha_payload
+unset _history_latest_body _history_latest_payload
+unset _history_malformed_body _history_malformed_payload
+unset _history_wrong_schema_body _history_wrong_schema_payload
+unset _history_prior_unavailable_body _history_prior_unavailable_payload
+unset _history_read_failed_body _history_read_failed_payload
+unset _history_rendered_section _history_rendered_ok
+unset MOCK_GH_HEAD_SHA MOCK_GH_UPDATED_AT
+unset pr_number branch_name unresolved_thread_count late_thread_count
 
 # ---------------------------------------------------------------------------
 # Area 11: Step 7b regression-label auto-restore (Option C, issue #805)

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1587,6 +1587,27 @@ run_test "history_latest_block_preserved" "latest" \
 run_test "history_fence_boundary_append_count" "2" \
   "$(printf '%s\n' "$_history_latest_payload" | jq '(.entries // []) | length')"
 
+_history_summary_comments="$(cat <<EOF_HISTORY_COMMENTS
+[
+  {
+    "id": 101,
+    "created_at": "2026-07-18T00:00:00Z",
+    "body": "### Automated Reviewer Loop Summary\n\n*Posted automatically by \`pr-review-loop.sh\`.*\n\n<!-- reviewer-loop-history:v1 -->\n\`\`\`json\n{\"schema\":\"reviewer_loop_history.v1\",\"history_status\":\"available\",\"entries\":[{\"iteration\":1,\"result\":\"needs_fixes\"}]}\n\`\`\`"
+  },
+  {
+    "id": 102,
+    "created_at": "2026-07-18T00:05:00Z",
+    "body": "### Automated Reviewer Loop Summary\n\n*Posted automatically by \`pr-review-loop.sh\`.*\n\n<!-- reviewer-loop-history:v1 -->\n\`\`\`json\n{\"schema\":\"reviewer_loop_history.v1\",\"history_status\":\"unavailable\",\"history_unavailable_reason\":\"comment_read_failed\",\"entries\":[]}\n\`\`\`"
+  }
+]
+EOF_HISTORY_COMMENTS
+)"
+_history_selected_record="$(printf '%s\n' "$_history_summary_comments" | reviewer_loop_history_select_summary_record)"
+run_test "history_selector_targets_newest_comment" "102" \
+  "$(printf '%s\n' "$_history_selected_record" | jq '.id')"
+run_test "history_selector_preserves_available_history" "needs_fixes" \
+  "$(printf '%s\n' "$_history_selected_record" | jq -r '.body' | reviewer_loop_history_extract_latest_json | jq -r '.entries[0].result')"
+
 _history_malformed_body=$'### Automated Reviewer Loop Summary\n\n<!-- reviewer-loop-history:v1 -->\n```json\n{ not json\n```\n'
 _history_malformed_payload="$(reviewer_loop_history_payload_from_existing "$_history_malformed_body" \
   "clean" "" "bugbot (clean)" "0" "0")"
@@ -1629,6 +1650,7 @@ unset _history_empty_entries_body _history_empty_entries_payload
 unset _history_needs_rerun_payload
 unset _history_same_sha_body _history_same_sha_payload
 unset _history_latest_body _history_latest_payload
+unset _history_summary_comments _history_selected_record
 unset _history_malformed_body _history_malformed_payload
 unset _history_wrong_schema_body _history_wrong_schema_payload
 unset _history_prior_unavailable_body _history_prior_unavailable_payload

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -105,6 +105,10 @@ case "$*" in
     printf '%s\n' "${MOCK_GH_HEAD_SHA:-}"
     exit "${MOCK_GH_EXIT:-0}"
     ;;
+  *"updatedAt"*)
+    printf '%s\n' "${MOCK_GH_UPDATED_AT:-2026-07-18T00:00:00Z}"
+    exit "${MOCK_GH_EXIT:-0}"
+    ;;
   # gh api repos/.../issues/.../comments — used by restore_regression_label_if_missing
   # to check for prior reviewer-loop summary comments (Area 11 summary-comment gate).
   # Tests set MOCK_GH_COMMENTS_OUTPUT to control the returned JSON; defaults to an
@@ -1455,6 +1459,159 @@ unset MOCK_GH_CALL_LOG MOCK_GH_BODY_CAPTURE MOCK_GH_EXIT MOCK_GH_COMMENTS_OUTPUT
 unset _summary_advisory_split _post_summary_source
 unset -f _post_review_summary
 unset compare_mode compare_verdicts platform_policy_status_notes pr_number branch_name
+
+# ---------------------------------------------------------------------------
+# Area 10b: reviewer-loop history payload (#1243)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 10b: reviewer-loop history payload ==="
+
+pr_number=42
+branch_name="fix/42-history"
+unresolved_thread_count=0
+late_thread_count=0
+MOCK_GH_HEAD_SHA="abc-history-1"
+MOCK_GH_UPDATED_AT="2026-07-18T00:00:00Z"
+export MOCK_GH_HEAD_SHA MOCK_GH_UPDATED_AT
+
+_history_payload="$(reviewer_loop_history_payload_from_existing "" \
+  "clean" "" "bugbot (clean)" "0" "0" "1" "bugbot" "1" "0" "")"
+run_test "history_first_entry_schema" "reviewer_loop_history.v1" \
+  "$(printf '%s\n' "$_history_payload" | jq -r '.schema')"
+run_test "history_first_entry_count" "1" \
+  "$(printf '%s\n' "$_history_payload" | jq '(.entries // []) | length')"
+run_test "history_first_entry_zero_retries" "0" \
+  "$(printf '%s\n' "$_history_payload" | jq '((.entries // []) | length) - 1')"
+run_test "history_first_entry_result" "clean" \
+  "$(printf '%s\n' "$_history_payload" | jq -r '.entries[0].result')"
+
+_history_existing_body="$(cat <<EOF_HISTORY
+### Automated Reviewer Loop Summary
+
+*Posted automatically by \`pr-review-loop.sh\`.*
+
+<details>
+<summary>Reviewer-loop history (1 iteration)</summary>
+
+<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+$(printf '%s\n' "$_history_payload" | jq '.')
+\`\`\`
+</details>
+EOF_HISTORY
+)"
+MOCK_GH_HEAD_SHA="abc-history-2"
+MOCK_GH_UPDATED_AT="2026-07-18T00:05:00Z"
+_history_payload_2="$(reviewer_loop_history_payload_from_existing "$_history_existing_body" \
+  "needs_fixes" "unresolved_review_threads" "bugbot (needs_fixes)" "1" "0" "1" "bugbot" "1" "1" "review_threads")"
+run_test "history_append_entry_count" "2" \
+  "$(printf '%s\n' "$_history_payload_2" | jq '(.entries // []) | length')"
+run_test "history_append_second_iteration" "2" \
+  "$(printf '%s\n' "$_history_payload_2" | jq '.entries[1].iteration')"
+run_test "history_append_preserves_first_result" "clean" \
+  "$(printf '%s\n' "$_history_payload_2" | jq -r '.entries[0].result')"
+run_test "history_append_records_blocking_count" "1" \
+  "$(printf '%s\n' "$_history_payload_2" | jq '.entries[1].blocking_count')"
+
+_history_empty_entries_body=$'### Automated Reviewer Loop Summary\n\n<!-- reviewer-loop-history:v1 -->\n```json\n{\"schema\":\"reviewer_loop_history.v1\",\"history_status\":\"available\",\"entries\":[]}\n```\n'
+_history_empty_entries_payload="$(reviewer_loop_history_payload_from_existing "$_history_empty_entries_body" \
+  "clean" "" "bugbot (clean)" "0" "0")"
+run_test "history_empty_entries_append_count" "1" \
+  "$(printf '%s\n' "$_history_empty_entries_payload" | jq '(.entries // []) | length')"
+
+_history_needs_rerun_payload="$(reviewer_loop_history_payload_from_existing "" \
+  "needs_rerun" "" "pr-agent (needs_rerun)" "0" "0")"
+run_test "history_needs_rerun_result" "needs_rerun" \
+  "$(printf '%s\n' "$_history_needs_rerun_payload" | jq -r '.entries[0].result')"
+
+_history_same_sha_body="$(cat <<EOF_HISTORY_SAME_SHA
+### Automated Reviewer Loop Summary
+
+<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+$(printf '%s\n' "$_history_payload" | jq '.')
+\`\`\`
+EOF_HISTORY_SAME_SHA
+)"
+MOCK_GH_HEAD_SHA="abc-history-1"
+_history_same_sha_payload="$(reviewer_loop_history_payload_from_existing "$_history_same_sha_body" \
+  "clean" "transient_retry" "bugbot (clean)" "0" "0")"
+run_test "history_same_sha_duplicate_appends" "2" \
+  "$(printf '%s\n' "$_history_same_sha_payload" | jq '(.entries // []) | length')"
+
+_history_latest_body="$(cat <<EOF_HISTORY_LATEST
+### Automated Reviewer Loop Summary
+
+<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+{"schema":"reviewer_loop_history.v1","history_status":"available","entries":[{"iteration":1,"result":"old"}]}
+\`\`\`
+
+Some adjacent Markdown that must not be consumed.
+
+<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+{"schema":"reviewer_loop_history.v1","history_status":"available","entries":[{"iteration":1,"result":"latest"}]}
+\`\`\`
+Trailing summary text.
+EOF_HISTORY_LATEST
+)"
+_history_latest_payload="$(reviewer_loop_history_payload_from_existing "$_history_latest_body" \
+  "clean" "" "bugbot (clean)" "0" "0")"
+run_test "history_latest_block_preserved" "latest" \
+  "$(printf '%s\n' "$_history_latest_payload" | jq -r '.entries[0].result')"
+run_test "history_fence_boundary_append_count" "2" \
+  "$(printf '%s\n' "$_history_latest_payload" | jq '(.entries // []) | length')"
+
+_history_malformed_body=$'### Automated Reviewer Loop Summary\n\n<!-- reviewer-loop-history:v1 -->\n```json\n{ not json\n```\n'
+_history_malformed_payload="$(reviewer_loop_history_payload_from_existing "$_history_malformed_body" \
+  "clean" "" "bugbot (clean)" "0" "0")"
+run_test "history_malformed_unavailable" "unavailable" \
+  "$(printf '%s\n' "$_history_malformed_payload" | jq -r '.history_status')"
+run_test "history_malformed_reason" "malformed_history" \
+  "$(printf '%s\n' "$_history_malformed_payload" | jq -r '.history_unavailable_reason')"
+
+_history_wrong_schema_body=$'### Automated Reviewer Loop Summary\n\n<!-- reviewer-loop-history:v1 -->\n```json\n{\"schema\":\"other.v1\",\"entries\":[]}\n```\n'
+_history_wrong_schema_payload="$(reviewer_loop_history_payload_from_existing "$_history_wrong_schema_body" \
+  "clean" "" "bugbot (clean)" "0" "0")"
+run_test "history_wrong_schema_reason" "unknown_schema" \
+  "$(printf '%s\n' "$_history_wrong_schema_payload" | jq -r '.history_unavailable_reason')"
+
+_history_prior_unavailable_body=$'### Automated Reviewer Loop Summary\n\n<!-- reviewer-loop-history:v1 -->\n```json\n{\"schema\":\"reviewer_loop_history.v1\",\"history_status\":\"unavailable\",\"history_unavailable_reason\":\"comment_read_failed\",\"entries\":[]}\n```\n'
+_history_prior_unavailable_payload="$(reviewer_loop_history_payload_from_existing "$_history_prior_unavailable_body" \
+  "clean" "" "bugbot (clean)" "0" "0")"
+run_test "history_prior_unavailable_preserved" "comment_read_failed" \
+  "$(printf '%s\n' "$_history_prior_unavailable_payload" | jq -r '.history_unavailable_reason')"
+
+_history_read_failed_body="$(reviewer_loop_history_unavailable_stub_body comment_read_failed)"
+_history_read_failed_payload="$(reviewer_loop_history_payload_from_existing "$_history_read_failed_body" \
+  "clean" "" "bugbot (clean)" "0" "0")"
+run_test "history_read_failure_unavailable" "unavailable" \
+  "$(printf '%s\n' "$_history_read_failed_payload" | jq -r '.history_status')"
+run_test "history_read_failure_reason" "comment_read_failed" \
+  "$(printf '%s\n' "$_history_read_failed_payload" | jq -r '.history_unavailable_reason')"
+
+_history_rendered_section="$(reviewer_loop_history_render_section "$_history_payload_2")"
+if printf '%s\n' "$_history_rendered_section" | grep -qF "$REVIEWER_LOOP_HISTORY_MARKER" \
+    && printf '%s\n' "$_history_rendered_section" | grep -qF "Reviewer-loop history (2 iterations)"; then
+  _history_rendered_ok="yes"
+else
+  _history_rendered_ok="no"
+fi
+run_test "history_rendered_section" "yes" "$_history_rendered_ok"
+
+unset _history_payload _history_existing_body _history_payload_2
+unset _history_empty_entries_body _history_empty_entries_payload
+unset _history_needs_rerun_payload
+unset _history_same_sha_body _history_same_sha_payload
+unset _history_latest_body _history_latest_payload
+unset _history_malformed_body _history_malformed_payload
+unset _history_wrong_schema_body _history_wrong_schema_payload
+unset _history_prior_unavailable_body _history_prior_unavailable_payload
+unset _history_read_failed_body _history_read_failed_payload
+unset _history_rendered_section _history_rendered_ok
+unset MOCK_GH_HEAD_SHA MOCK_GH_UPDATED_AT
+unset pr_number branch_name unresolved_thread_count late_thread_count
 
 # ---------------------------------------------------------------------------
 # Area 11: Step 7b regression-label auto-restore (Option C, issue #805)


### PR DESCRIPTION
## Summary

- Add a script-owned `reviewer_loop_history.v1` JSON payload to the existing automated reviewer-loop summary comment.
- Preserve retry entries across summary updates and expose unavailable states instead of treating unreadable history as zero retries.
- Update retrospective protocol and runner guidance to prefer durable reviewer-loop history for exact retry metrics.

Closes #1243

## Links

- Spec: `docs/specs/developments/20260716104000_1243-preserve-reviewer-loop-retry-history/1_1243-preserve-reviewer-loop-retry-history_specs.md`
- Plan: `docs/specs/developments/20260716104000_1243-preserve-reviewer-loop-retry-history/2_1243-preserve-reviewer-loop-retry-history_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/1243-preserve-reviewer-loop-retry-history.smoke-test.md`

## Document Quality Gate

- Scope checked against approved spec and implementation plan for #1243.
- Existing readiness, CI, tracker, label, and merge-authority semantics left unchanged.
- Durable history is appended to the existing single script-owned summary comment rather than creating duplicate timeline comments.

## Parser-Risk Checklist

| Edge | Coverage |
| --- | --- |
| Missing history block | `history_first_entry_*` tests create iteration 1 and zero retries |
| Malformed JSON | `history_malformed_*` tests return unavailable with `malformed_history` |
| Wrong schema | `history_wrong_schema_reason` returns unavailable with `unknown_schema` |
| Empty entries | `history_empty_entries_append_count` appends the first entry |
| Multiple blocks | `history_latest_block_preserved` chooses the latest block |
| Fence boundary | `history_fence_boundary_append_count` keeps adjacent Markdown out of JSON |
| Prior unavailable | `history_prior_unavailable_preserved` preserves the prior reason |
| Needs rerun | `history_needs_rerun_result` records `needs_rerun` |
| Duplicate same SHA | `history_same_sha_duplicate_appends` appends without overwrite |
| Comment API read failure | `history_read_failure_*` preserves `comment_read_failed` |
| Duplicate summary comments | Existing Area 13 summary update-in-place tests remain green |

## Validation

- `bash -n scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` - 306 passed, 0 failed
- `shellcheck --severity=warning -x scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/06-retrospective-protocol.md" ".claude/agents/retrospective.md" ".cursor/agents/retrospective.md" ".codex/skills/workflow-retrospective/SKILL.md" ".agents/skills/retrospective/SKILL.md" "docs/testing/workflow/1243-preserve-reviewer-loop-retry-history.smoke-test.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `git diff --check`

## Smoke Test

Deterministic shell harness coverage was used for this tooling change instead of creating a disposable live reviewer PR. The runbook scenarios are covered by mocked PR comment fixtures in `scripts/development-workflow/tests/test-pr-review-loop.sh`, including multi-iteration append, single clean run, malformed/unavailable history, and duplicate-summary update-in-place behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `pr-review-loop.sh` summary comment behavior and retrospective metrics sourcing; risk is mitigated by extensive harness tests and fail-closed unavailable states when history cannot be read.
> 
> **Overview**
> Adds durable **`reviewer_loop_history.v1`** JSON to the existing script-owned **Automated Reviewer Loop Summary** comment so each loop run appends an iteration record (result, blockers, head SHA, timestamps) instead of losing retry context on in-place comment updates.
> 
> **`pr-review-loop.sh`** gains history extract/append/render helpers, merges prior history when PATCHing the single summary comment (including release-guard skips), surfaces **`history_status: unavailable`** when JSON is missing or corrupt, and posts a summary on **`needs_rerun`** so fix-pushed cycles count toward retrospective metrics. **`06-retrospective-protocol.md`** and retrospective agents/skills now treat that payload as authoritative for automated-reviewer retry loops (`max(entries.length - 1, 0)`), with legacy timestamp heuristics only as fallback.
> 
> **`test-pr-review-loop.sh`** adds Area 10b coverage for schema, append, malformed history, comment-read failures, and summary selector behavior; **CHANGELOG** documents the change (#1243).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed3dd2b892ce011765f4ad4efb1951f08c757e3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
## why_safe_to_merge

```json
{
  "why_safe_to_merge": {
    "scope": "Single workflow-tooling PR for reviewer-loop summary history and retrospective metric guidance; no product runtime, database, auth, or deployment behavior changed.",
    "tests": "Reviewer-loop harness passed with 306 tests, including comment-read failure recovery, available-history preservation, parser edge cases, duplicate summary update-in-place, and Bugbot review-thread regression coverage.",
    "reviewer_outcome": "Step 7a internal review approved after fixing hidden comments API pipeline failure; PR-Agent clean; Cursor Bugbot clean on commit ed3dd2b with zero unresolved review threads and no late-arriving threads.",
    "ci_outcome": "pr-ci-loop.sh reported green for PR #1261: 8 checks, 0 failing, 0 pending, including Markdown lint, policy, PR-Agent review, ShellCheck static analysis, workflow test harnesses, and Cursor Bugbot.",
    "rollback_or_cleanup_risk": "Rollback is limited to reverting the workflow script/test/doc changes; no persistent data migration or external configuration change. Post-merge cleanup only deletes the implementation branch/worktree."
  }
}
```