### PR TITLE
docs(plan): pushed branch update discipline

### DIFF
--- a/docs/specs/developments/20260718100346_1262-avoid-amending-pushed-pr-branches/2_1262-avoid-amending-pushed-pr-branches_implementation-plan.md
+++ b/docs/specs/developments/20260718100346_1262-avoid-amending-pushed-pr-branches/2_1262-avoid-amending-pushed-pr-branches_implementation-plan.md
@@ -1,0 +1,61 @@
+# Pushed Branch Update Discipline - Implementation Plan
+
+**Spec**: `1_1262-avoid-amending-pushed-pr-branches_specs.md`
+**Smoke test runbook**: `docs/testing/workflow/1262-pushed-branch-update-discipline.smoke-test.md`
+
+## Summary
+
+**Approach**: Add one canonical version-control rule for already-published PR
+branches, then cross-reference it from delegated-review recovery guidance.
+
+**Estimated complexity**: S
+
+**Rationale**: Documentation-only change across two existing workflow surfaces.
+
+**Dependencies**: None
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `2280735` |
+| Existing guidance | `rg -n -i 'force-push|amend.*published' docs .codex scripts` | Existing no-force-push and recovery guidance lacks the follow-up-commit rule |
+
+## Layer-by-Layer Changes
+
+### Infrastructure / Configuration
+
+- [ ] Update `docs/best-practices/2-version-control.md` with the canonical
+  distinction between unpublished amendments and corrections after a PR branch
+  is published; require focused follow-up commits in the latter case.
+- [ ] Update `docs/workflow/development-workflow/provider-contingency-runner-failover.md`
+  to point recovery work to the canonical rule and prohibit force-push recovery.
+
+## Testing Strategy
+
+**Test types**: Documentation smoke test and Markdown lint.
+
+1. Verify the canonical guidance explicitly covers AC1–AC4.
+2. Verify no guidance changes merge, CI, or branch-protection authority (AC5).
+
+## Seed Data
+
+None; this change has no runtime data.
+
+## Documentation Updates
+
+- [ ] `docs/best-practices/2-version-control.md` — add the canonical rule.
+- [ ] `docs/workflow/development-workflow/provider-contingency-runner-failover.md` — align recovery instructions.
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Guidance contradicts an existing rule | Low | Medium | Cross-reference the canonical version-control wording and lint both files. |
+
+## Implementation Order
+
+1. Add the canonical published-branch update rule and unpublished/local distinction.
+2. Align failover recovery guidance with that rule.
+3. Add the smoke runbook and run Markdown lint.
+4. Update `CHANGELOG.md` under `[Unreleased]` with `**Clarify pushed branch updates** (#1262): ...`.

--- a/docs/testing/workflow/1262-pushed-branch-update-discipline.smoke-test.md
+++ b/docs/testing/workflow/1262-pushed-branch-update-discipline.smoke-test.md
@@ -1,0 +1,25 @@
+# Smoke Test Runbook: Pushed Branch Update Discipline
+
+**Feature**: Pushed Branch Update Discipline
+**Spec**: `docs/specs/developments/20260718100346_1262-avoid-amending-pushed-pr-branches/1_1262-avoid-amending-pushed-pr-branches_specs.md`
+
+## Prerequisites
+
+- [ ] A clean checkout of the implementation branch.
+
+## Smoke Test Steps
+
+1. Read the version-control guidance after locating the published-branch rule.
+   **Expected result**: it requires a follow-up commit for a correction after a
+   branch is pushed for review and distinguishes unpublished local amendments.
+2. Read the failover recovery guidance.
+   **Expected result**: it refers to the same no-force-push recovery rule.
+
+## Assertions Checklist
+
+- [ ] AC1–AC4: Published-branch guidance is clear, safe, and consistent.
+- [ ] AC5: No merge, CI, or branch-protection behavior is changed.
+
+## Known Limitations
+
+- This documentation-only runbook does not perform a force-push.


### PR DESCRIPTION
## Summary

- Plan canonical published-branch guidance and aligned recovery wording.

Refs #1262

## Document Quality Gate

- Spec coverage: Checked - all ACs map to plan steps and smoke checks.
- Technical accuracy: Checked against current documentation surfaces.
- Verification log: Checked - records current revision and live searches.
- Complex workflow decision-gate matrix: Not applicable - no workflow decision gate changes.
- Stage alignment: Checked - plan and runbook only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime, CI, or policy enforcement changes.
> 
> **Overview**
> Adds **planning and verification docs only** for issue #1262; it does not yet change version-control or failover guidance.
> 
> Introduces an **implementation plan** that records a doc-only approach: define a canonical rule in `docs/best-practices/2-version-control.md` (follow-up commits on published PR branches vs local unpublished amendments), align `provider-contingency-runner-failover.md` recovery text with no force-push, then changelog and Markdown lint. The plan includes a verification log noting current guidance lacks an explicit follow-up-commit rule.
> 
> Adds a **smoke-test runbook** with manual read-through steps and AC1–AC5 checks (including that merge/CI/branch protection stay unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e04bfc0cb1bdec59920bc372207f3903b67c9944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->