### PR TITLE
docs(workflow): preserve published branch history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Clarify pushed branch updates** (#1262): Require focused follow-up commits
+  for corrections after a branch is published for review, preserving shared
+  history without force-pushing.
 - **Clarify run-work batch proposal categories** (#1187): Label
   informational, actionable-resume, proposed-batch, and held items separately
   in run-work scan proposals.

--- a/docs/best-practices/2-version-control.md
+++ b/docs/best-practices/2-version-control.md
@@ -94,6 +94,17 @@ The issue ID prefix is the canonical identifier when a tracker is in use. The sl
 - Every PR must update `CHANGELOG.md` under `[Unreleased]` before merge (see the CHANGELOG section below for exceptions)
 - Open PRs with `gh pr create` per the implementation protocol unless the team has adopted Haystack's submit workflow (see [`docs/workflow/development-workflow/integrations/haystack.md`](../workflow/development-workflow/integrations/haystack.md))
 
+### Published branch updates
+
+Once a branch has been pushed for review, treat its published history as shared.
+Record corrections as focused follow-up commits; do not amend published commits
+or rewrite the remote branch. Amendments remain appropriate only for unpublished
+local commits that do not require changing a branch already visible to reviewers.
+
+If an amend was attempted after publication, stop before force-pushing. Preserve
+the published history and use normal follow-up commits for a coherent recovery;
+ask for human direction when no safe recovery path is clear.
+
 ## Safety Rules
 
 The following actions require explicit human approval before executing:

--- a/docs/workflow/development-workflow/provider-contingency-runner-failover.md
+++ b/docs/workflow/development-workflow/provider-contingency-runner-failover.md
@@ -90,7 +90,7 @@ Then re-invoke:
 
 - Do **not** apply `ready-for-human-review` when the PR lacks an “Automated Reviewer Loop Summary” (or equivalent) comment unless Step 7 was explicitly skipped (no platforms configured).
 - Do **not** remove `needs-fixes` without a clean reviewer loop and CI evidence.
-- Do **not** force-push or amend published PR commits during recovery unless a human explicitly approves.
+- Do **not** force-push or amend published PR commits during recovery. Follow the [published branch update rule](../../best-practices/2-version-control.md#published-branch-updates): preserve shared history and use focused follow-up commits; ask for human direction when no safe recovery path is clear.
 - Do **not** assume the latest bot comment is the only active blocker — audit all open review threads on the current HEAD.
 
 ---


### PR DESCRIPTION
## Summary

- Adds canonical guidance for safe corrections to a branch that has already been pushed for review.
- Aligns runner-failover recovery guidance with the no-force-push rule.

## Verification

- Markdown lint and CHANGELOG duplicate-header checks passed.
- Smoke assertions confirm follow-up commits for published branches and distinguish unpublished local amendments.

## Self-review

Pre-submission self-review: stale markers - none; caller consistency - version-control and recovery surfaces aligned; coverage - AC1-AC5 addressed; complex gate matrix - not applicable (guidance only, no behavior change).

Closes #1262

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or auth changes.
> 
> **Overview**
> Documents how to fix work on branches **already pushed for review**: use **focused follow-up commits**, not amend or rewrite remote history.
> 
> Adds a **Published branch updates** subsection under Pull Requests in `docs/best-practices/2-version-control.md`, including recovery when an amend was attempted after publication (stop before force-push; escalate if unclear).
> 
> Updates the provider contingency **do-not** list to remove the exception that allowed force-push/amend during recovery when a human approved, and points runners at the canonical version-control rule.
> 
> Records the change under `[Unreleased]` **Fixed** in `CHANGELOG.md` (#1262).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1518895873cd9c2776b6b79b3aaff87c05d6ee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->