### PR TITLE
fix(review): preserve initiating override source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Preserve local reviewer overrides** (#1033): Apply the initiating
+  checkout's effective reviewer policy when review work resolves temporary
+  target-branch configuration, without exposing local settings.
 - **Clarify run-work batch proposal categories** (#1187): Label
   informational, actionable-resume, proposed-batch, and held items separately
   in run-work scan proposals.

--- a/docs/workflow/development-workflow/provider-contingency-runner-failover.md
+++ b/docs/workflow/development-workflow/provider-contingency-runner-failover.md
@@ -56,6 +56,18 @@ Typical timeout thresholds for long agents are documented in [`agent-model-confi
 
 Tool-specific agent files (`.cursor/agents/`, `.claude/agents/`, `.codex/skills/`) share the same protocols — only the invocation surface changes.
 
+### Local reviewer overrides across temporary worktrees
+
+When reviewer execution moves into a temporary worktree, the review loop resolves
+the local reviewer-policy fields from the initiating checkout and applies that
+effective policy to the temporary target-branch configuration. It records only
+whether the policy source is `local_override` or `shared`; it does not copy,
+commit, or print local configuration contents or paths.
+
+If the initiating local policy cannot be resolved, the loop stops with an
+actionable error rather than silently choosing a different shared reviewer. When
+there is no local reviewer override, the shared-policy path remains unchanged.
+
 ---
 
 ## Resume checklist

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -5259,6 +5259,29 @@ _check_release_pr_guard() {
   return 1
 }
 
+resolve_local_review_override_root() {
+  local initiating_root="$1"
+  local caller_override_root="${WORKFLOW_LOCAL_REVIEW_OVERRIDE_ROOT:-}"
+  local override_context=""
+  local override_source=""
+
+  if [ -n "$caller_override_root" ]; then
+    if [ ! -d "$caller_override_root" ]; then
+      return 1
+    fi
+    printf '%s\n' "$caller_override_root"
+    return 0
+  fi
+
+  if ! override_context="$(workflow_review_override_context "$initiating_root")"; then
+    return 1
+  fi
+  override_source="$(workflow_context_value "LOCAL_OVERRIDE_SOURCE" "$override_context")"
+  if [ -n "$override_source" ]; then
+    printf '%s\n' "$initiating_root"
+  fi
+}
+
 # Skip the main execution block when sourced in test-harness mode.
 # All function definitions above (including normalize_platform_verdict,
 # append_compare_metrics_row, and restore_regression_label_if_missing) are
@@ -5381,14 +5404,11 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-review_override_context=""
-if ! review_override_context="$(workflow_review_override_context "$repo_root")"; then
+if ! local_review_override_root="$(resolve_local_review_override_root "$repo_root")"; then
   echo "ERROR: could not resolve the initiating checkout's local reviewer policy." >&2
   exit 2
 fi
-local_override_source="$(workflow_context_value "LOCAL_OVERRIDE_SOURCE" "$review_override_context")"
-if [ -n "$local_override_source" ]; then
-  local_review_override_root="$repo_root"
+if [ -n "$local_review_override_root" ]; then
   export WORKFLOW_LOCAL_REVIEW_OVERRIDE_ROOT="$local_review_override_root"
   review_policy_source="local_override"
 else

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -5274,6 +5274,8 @@ pr_number=""
 branch_name=""
 repo_selector=""
 repo_root="$(workflow_repo_root)"
+local_review_override_root=""
+review_policy_source="shared"
 poll_interval=120
 poll_interval_explicit=0
 max_wait=1200
@@ -5378,6 +5380,20 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
+
+review_override_context=""
+if ! review_override_context="$(workflow_review_override_context "$repo_root")"; then
+  echo "ERROR: could not resolve the initiating checkout's local reviewer policy." >&2
+  exit 2
+fi
+local_override_source="$(workflow_context_value "LOCAL_OVERRIDE_SOURCE" "$review_override_context")"
+if [ -n "$local_override_source" ]; then
+  local_review_override_root="$repo_root"
+  export WORKFLOW_LOCAL_REVIEW_OVERRIDE_ROOT="$local_review_override_root"
+  review_policy_source="local_override"
+else
+  unset WORKFLOW_LOCAL_REVIEW_OVERRIDE_ROOT
+fi
 
 if [ -z "$pr_number" ]; then
   usage >&2
@@ -5573,6 +5589,8 @@ if [ "${#phase_after_clean_platforms[@]}" -eq 0 ]; then
     done < <(WORKFLOW_APPLY_LOCAL_REVIEW_OVERRIDES=1 workflow_config_review_phase_after_clean_platforms "$config_file")
   fi
 fi
+
+print_kv REVIEW_POLICY_SOURCE "$review_policy_source"
 
 if [ "$pre_after_clean_only" -eq 1 ]; then
   filter_pre_after_clean_platforms

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -346,6 +346,25 @@ temp_override_parsed="$(
 )"
 run_test "local_review_override_applies_to_temp_config_when_forced" "pr-agent,bugbot" "$temp_override_parsed"
 
+_TEMP_WORKTREE_DIR="$(mktemp -d)"
+initiating_override_parsed="$(
+  workflow_repo_root() { printf '%s\n' "$_TEMP_WORKTREE_DIR"; }
+  WORKFLOW_LOCAL_REVIEW_OVERRIDE_ROOT="$_LOCAL_OVERRIDE_DIR" \
+    WORKFLOW_APPLY_LOCAL_REVIEW_OVERRIDES=1 \
+    workflow_config_review_platforms "$_TEMP_CONFIG" | paste -sd ',' -
+)"
+run_test "initiating_local_override_applies_in_temp_worktree" "pr-agent,bugbot" "$initiating_override_parsed"
+rm -rf "$_TEMP_WORKTREE_DIR"
+unset _TEMP_WORKTREE_DIR initiating_override_parsed
+
+missing_override_status=0
+if WORKFLOW_LOCAL_REVIEW_OVERRIDE_ROOT="$_LOCAL_OVERRIDE_DIR/missing" workflow_local_config_file >/dev/null 2>&1; then
+  missing_override_status=0
+else
+  missing_override_status=$?
+fi
+run_test "unavailable_initiating_override_stops_resolution" "1" "$missing_override_status"
+
 cat > "$_LOCAL_OVERRIDE_DIR/.ai-dev-workflow.local.yaml" <<'YAML'
 review:
   on_ready:

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -354,8 +354,14 @@ initiating_override_parsed="$(
     workflow_config_review_platforms "$_TEMP_CONFIG" | paste -sd ',' -
 )"
 run_test "initiating_local_override_applies_in_temp_worktree" "pr-agent,bugbot" "$initiating_override_parsed"
+
+caller_override_root="$(
+  WORKFLOW_LOCAL_REVIEW_OVERRIDE_ROOT="$_LOCAL_OVERRIDE_DIR" \
+    resolve_local_review_override_root "$_TEMP_WORKTREE_DIR"
+)"
+run_test "caller_override_root_is_preserved" "$_LOCAL_OVERRIDE_DIR" "$caller_override_root"
 rm -rf "$_TEMP_WORKTREE_DIR"
-unset _TEMP_WORKTREE_DIR initiating_override_parsed
+unset _TEMP_WORKTREE_DIR initiating_override_parsed caller_override_root
 
 missing_override_status=0
 if WORKFLOW_LOCAL_REVIEW_OVERRIDE_ROOT="$_LOCAL_OVERRIDE_DIR/missing" workflow_local_config_file >/dev/null 2>&1; then

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -35,8 +35,28 @@ workflow_effective_config_file() {
   return 1
 }
 
+workflow_local_review_override_root() {
+  local override_root="${WORKFLOW_LOCAL_REVIEW_OVERRIDE_ROOT:-}"
+
+  if [ -n "$override_root" ]; then
+    if [ ! -d "$override_root" ]; then
+      echo "ERROR: configured local reviewer override source is unavailable." >&2
+      return 1
+    fi
+    printf '%s\n' "$override_root"
+    return 0
+  fi
+
+  workflow_repo_root
+}
+
 workflow_local_config_file() {
-  printf '%s/.ai-dev-workflow.local.yaml\n' "$(workflow_repo_root)"
+  local override_root
+
+  if ! override_root="$(workflow_local_review_override_root)"; then
+    return 1
+  fi
+  printf '%s/.ai-dev-workflow.local.yaml\n' "$override_root"
 }
 
 workflow_is_default_config_file() {


### PR DESCRIPTION
## Summary

- Preserves the initiating checkout local reviewer policy while resolving temporary target-branch configuration.
- Fails closed if that configured override source is unavailable and reports only `local_override` or `shared` as policy source.

## Verification

- Reviewer-loop harness: 308 passed.
- Shell syntax, ShellCheck, workflow shell guard, Markdown lint, and CHANGELOG checks passed.

## Decision-gate matrix evidence

| Initiating policy | Override source | Outcome | Visibility |
| --- | --- | --- | --- |
| Present | Available | Preserve field-level local policy over the target config | `REVIEW_POLICY_SOURCE=local_override` |
| Present | Unavailable | Stop reviewer-policy resolution | Error only; no source path or config content |
| Absent | Not set | Use shared policy unchanged | `REVIEW_POLICY_SOURCE=shared` |

## Self-review

Pre-submission self-review: stale markers - none; caller consistency - draft/ready resolution and duplicate warnings share the source context; coverage - AC1-AC6 addressed; complex gate matrix - included above.

Closes #1033

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reviewer-loop config resolution for worktree/temporary-target scenarios; mis-resolution could skip or mis-apply platforms, though behavior is fail-closed and covered by expanded harness tests.
> 
> **Overview**
> **Reviewer policy now follows the checkout that started the loop**, not only the temporary worktree used to resolve PR base config. When `.ai-dev-workflow.local.yaml` applies on the initiating tree, `pr-review-loop.sh` sets `WORKFLOW_LOCAL_REVIEW_OVERRIDE_ROOT` before loading target-branch review settings so draft/ready platform lists and related local fields match that policy.
> 
> **Failure and visibility behavior is tightened.** If a local override is expected but the override root is missing or invalid, the script exits with an error instead of falling back to shared config. It prints `REVIEW_POLICY_SOURCE=local_override` or `shared` only—no local file paths or contents.
> 
> `workflow-lib.sh` routes `workflow_local_config_file` through the optional override root. Docs (`provider-contingency-runner-failover.md`) and harness tests cover temp-worktree application, caller-preserved roots, and unavailable override handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 891393784fa659831e474fce674daef287ffff7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->