### PR TITLE
chore(release): v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0] - 2026-07-19
+
 ### Added
 
 - **Prevent false dependency dispatch context** (#1182): Add
@@ -1235,7 +1237,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.claude/settings.json` with pre-approved permissions for common git and fetch operations; `.claude/settings.local.json.example` documenting machine-specific overrides for optional integrations
 - `.gitignore` covering local Claude settings, `.env` files, and common system files
 
-[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.36.3...HEAD
+[Unreleased]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.37.0...HEAD
+[0.37.0]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.36.3...v0.37.0
 [0.36.3]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.36.2...v0.36.3
 [0.36.2]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.36.1...v0.36.2
 [0.36.1]: https://github.com/lhpaul/ai-dev-framework-template/compare/v0.36.0...v0.36.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-dev-framework-template",
-  "version": "0.36.1",
+  "version": "0.37.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-dev-framework-template",
-      "version": "0.36.1",
+      "version": "0.37.0",
       "devDependencies": {
         "markdownlint-cli2": "0.22.0",
         "markdownlint-rule-relative-links": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-dev-framework-template",
-  "version": "0.36.1",
+  "version": "0.37.0",
   "private": true,
   "description": "Root package for markdown lint tooling",
   "scripts": {


### PR DESCRIPTION
## Release v0.37.0

This release packages the accumulated workflow, orchestration, reviewer-loop,
and documentation improvements listed in `CHANGELOG.md`.

See the full release notes in the [`0.37.0` changelog section](https://github.com/lhpaul/ai-dev-framework-template/blob/release/v0.37.0/CHANGELOG.md#0370---2026-07-19).

Validation completed:

- `git diff --check`
- Changelog duplicate-header and link-reference checks
- Manifest version consistency for `package.json` and `package-lock.json`
