### PR TITLE
chore(workflow): enable delegated medium-risk execution

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -178,38 +178,33 @@ template:
 # named stop conditions, audit-evidence rules).
 #
 # Two-step lifecycle (default for this template):
-# Execute commands (/run-item, /run-epic) stop at ready-for-human-review.
-# Merge is performed separately via /batch-merge (human confirms the merge plan).
-# Bounded prelude always requires confirmation before mutation — see
-# docs/workflow/development-workflow/bounded-run-prelude.md.
+# Delegated execution permits Backlog starts and merges within the per-stage
+# risk limits below. Bounded prelude still reports the resolved policy before
+# mutation — see docs/workflow/development-workflow/bounded-run-prelude.md.
 
 guardrails:
   # mode: delegated — agents may merge within per-stage permissions and risk limits.
-  # All stages default to may_merge_pr: false, implementing the two-step lifecycle
-  # where execute commands stop at ready-for-human-review and /batch-merge is used
-  # to land work. Override per-stage values to grant merge authority for specific stages.
   mode: delegated
 
-  # backlog_start — agents must receive an explicit human instruction (via /run-item
-  # or /run-epic with --may-start-backlog true) before starting a new backlog item.
+  # backlog_start — agents may start eligible Backlog work without an additional
+  # policy confirmation.
   backlog_start:
-    allow_without_confirmation: false
+    allow_without_confirmation: true
 
-  # stages — all stages have may_merge_pr: false by default (two-step lifecycle).
-  # Override specific stages to grant merge authority when needed.
+  # stages — delegated merge authority is enabled up to medium risk.
   stages:
     spec:
       may_open_pr: true
-      may_merge_pr: false
-      max_merge_risk: low
+      may_merge_pr: true
+      max_merge_risk: medium
     plan:
       may_open_pr: true
-      may_merge_pr: false
-      max_merge_risk: low
+      may_merge_pr: true
+      max_merge_risk: medium
     implementation:
       may_open_pr: true
-      may_merge_pr: false
-      max_merge_risk: low
+      may_merge_pr: true
+      max_merge_risk: medium
 
   # stop_conditions — baseline stops that hold in all modes (additive, never removable).
   stop_conditions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Enable delegated medium-risk execution** (#1274): Allow Backlog starts and
+  delegated merges through medium risk for spec, plan, and implementation
+  stages.
 - **Faind sync-template follow-ups** (#1271): port reusable downstream fixes for
   team-prefixed epic head-search, nested-guard guidance, terminal completion
   self-check requirements, sync-template completion verification, and


### PR DESCRIPTION
## Summary

- enable Backlog starts without an additional policy confirmation
- grant delegated merge authority through medium risk for spec, plan, and implementation
- update the changelog

Closes #1274

## Verification

- `bash scripts/development-workflow/tests/test-run-bounded-prelude.sh`
- `bash scripts/development-workflow/tests/test-run-epic-policy-recommender.sh`
- `./scripts/development-workflow/run-bounded-prelude.sh --original-command '$run-item 1273' --issue 1273 --json` (resolved `mayStartBacklog=true`, `mayMerge=true`, `maxRisk=medium`)\n- `npx markdownlint-cli2 CHANGELOG.md`\n- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`\n- `git diff --check`\n\n## Pre-submission self-review\n\nReviewed `git diff develop...HEAD`. The change intentionally affects only the repository guardrail defaults and their matching changelog entry. All three stages receive the same explicitly requested policy; stop conditions and required audit records remain unchanged. No caller or sibling configuration requires a separate update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises default agent authority for starting backlog work and merging PRs; mitigated by unchanged stop conditions, medium (not high) merge ceiling, and bounded-prelude policy reporting before mutation.
> 
> **Overview**
> Shifts the **template** `guardrails` defaults in `.ai-dev-workflow.yaml` from a **two-step** model (execute stops at human review; merge via `/batch-merge`) to **delegated execution** within explicit risk limits.
> 
> **Backlog start:** `backlog_start.allow_without_confirmation` is set to **`true`**, so agents may start eligible Backlog items without an extra policy confirmation (still subject to bounded prelude reporting and runtime gates).
> 
> **Merge authority:** For **spec**, **plan**, and **implementation**, `may_merge_pr` is **`true`** and `max_merge_risk` is **`medium`** (was `false` / `low`). Inline comments now describe delegated merge up to medium risk instead of defaulting all stages to no merge.
> 
> **Unchanged:** `mode: delegated`, baseline **stop_conditions**, and **audit** requirements (`pr_disposition_record`, `work_item_ledger_record`).
> 
> `CHANGELOG.md` records the policy change under **Fixed** for #1274.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e1b55b034c942f953dedd63befc062cacf5848. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->