### PR TITLE
fix(workflow): clean hub-owned sync branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Hub-owned sync-template cleanup** (#1273): Allow merged
+  `feature/sync-template-*` branches to clean up in workflow-hub repositories
+  without a product-repository selection.
 - **Enable delegated medium-risk execution** (#1274): Allow Backlog starts and
   delegated merges through medium risk for spec, plan, and implementation
   stages.

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -98,7 +98,14 @@ branch_owner_kind="hub"
 selected_product_default_branch=""
 
 case "$(branch_prefix "$TO_DELETE")" in
-  feature|fix|refactor|hotfix)
+  feature)
+    # Template sync branches are created and merged on the workflow hub itself.
+    # They are not product-repository implementation artifacts.
+    if [ "$workflow_mode" != "workflow_hub" ] || [[ "$TO_DELETE" != feature/sync-template-* ]]; then
+      branch_owner_kind="implementation"
+    fi
+    ;;
+  fix|refactor|hotfix)
     branch_owner_kind="implementation"
     ;;
   spec|implementation-plan)

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -232,6 +232,19 @@ run_test "spec_remote_ref_remains" "yes" "$(
   fi
 )"
 
+hub_sync_branch="feature/sync-template-v0.37.0"
+hub_sync_repo="$(make_repo hub-sync "$hub_sync_branch" yes)"
+printf 'mode: workflow_hub\n' >"$hub_sync_repo/.ai-dev-workflow.yaml"
+hub_sync_output="$(
+  GH_MERGED_HEAD="$hub_sync_branch" \
+  GH_MERGED_PR=80 \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$hub_sync_repo" --base develop "$hub_sync_branch"
+)"
+run_contains "hub_sync_branch_is_hub_owned" "ACTION_REPOSITORY_KIND=hub_owned" "$hub_sync_output"
+run_contains "hub_sync_branch_skips_product_repo_requirement" "BRANCH_LIFECYCLE=unclassified" "$hub_sync_output"
+
 fail_branch="feature/noissue-delete-fails"
 fail_repo="$(make_repo delete-fails "$fail_branch" yes)"
 fail_bin="$TMP_ROOT/fail-bin"


### PR DESCRIPTION
## Summary

- classify `feature/sync-template-*` branches as hub-owned in workflow-hub cleanup
- retain product-repository routing for all other feature branches
- cover the regression with a workflow-hub fixture

Closes #1273

## Verification

- `bash scripts/development-workflow/tests/test-post-merge-cleanup.sh`
- `npx markdownlint-cli2 CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `git diff --check`

## Pre-submission self-review

Reviewed `git diff develop...HEAD`. The hub-only exception is restricted to the documented sync-template branch prefix and workflow-hub mode; all other branch routing remains unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow branch-prefix exception in post-merge cleanup with a dedicated test; product-repo routing for other feature branches is unchanged.
> 
> **Overview**
> **Post-merge cleanup** in workflow-hub mode no longer treats merged `feature/sync-template-*` branches like product implementation work: they stay **hub-owned**, so cleanup can run **without** `--repo` and is not forced through product-repository routing.
> 
> **`post-merge-cleanup.sh`** splits `feature` from `fix|refactor|hotfix` and only marks a feature branch as implementation when it is *not* workflow-hub mode *or* the name does not match `feature/sync-template-*`. Other feature branches still require product-repository selection as before.
> 
> A **workflow-hub fixture test** asserts hub-owned kind and unclassified lifecycle for a sync-template branch. **CHANGELOG** documents the fix (#1273).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5a8f9b2b37482035e46c4c38b68fe060d751260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->