### PR TITLE
feat: graphical design assets in the workflow (#1282)

### DIFF
--- a/.agents/skills/add-backlog-item/SKILL.md
+++ b/.agents/skills/add-backlog-item/SKILL.md
@@ -11,3 +11,8 @@ This is the Codex command-style alias for Claude Code `/add-backlog-item`.
 2. Read `docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md`.
 3. Prefer `./scripts/development-workflow/add-backlog-item.sh resolve` to determine the configured tracker destination before creating anything.
 4. Follow the protocol exactly. Do not invent tracker-specific fields when the configured integration cannot be resolved.
+5. When candidate files are supplied, follow Step 2b and
+   `docs/workflow/development-workflow/design-assets.md`: recognize likely design
+   assets, clarify ambiguous files once, attach or stage confirmed assets, and
+   record a `## Design assets` body section. Do not invent assets when none are
+   supplied.

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -50,6 +50,9 @@ Key rules:
   incoherent edits only to satisfy this requirement
 - For Full Pipeline: read spec + plan + runbook BEFORE writing any code
 - For Refactor: read plan + runbook BEFORE writing any code (no spec)
+- For UI-facing work, discover design assets per
+  `docs/workflow/development-workflow/design-assets.md` and use them as visual
+  references; do not invent assets when none exist
 - For Fast Track: require the Protocol 91 Fast Track blast-radius gate and
   Protocol 03 criteria to have passed before implementation; stop and report if
   scope expands, high call-site volume appears, or external-system impact is

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -55,4 +55,9 @@ protocol 01's Brief Objective List, Coverage Matrix, and Deferral Note
 requirements as part of that gate. For complex workflow decision-gate specs,
 include protocol 01's consistency matrix or not-applicable rationale.
 
+When creating the development folder, discover design assets per
+`docs/workflow/development-workflow/design-assets.md`. If confirmed tracker
+design assets exist, copy or download them into `<dev-folder>/assets/` and
+update the issue-body location note. Do not invent assets when none exist.
+
 Before updating tracker status as part of a standalone spec completion sequence, call `ensure_on_project_board <issue_number> "Writing Spec"` (from `scripts/development-workflow/workflow-lib.sh`) to register the issue on the project board if it is not already present.

--- a/.claude/agents/smoke-tester.md
+++ b/.claude/agents/smoke-tester.md
@@ -23,3 +23,10 @@ For project-specific execution instructions, read:
 **`docs/testing/README.md`**
 
 Always read the smoke test runbook and the testing README before beginning.
+
+When the runbook or work item may have graphical design references, discover
+assets per `docs/workflow/development-workflow/design-assets.md` and protocol
+`04` §3a. Execute any expected-vs-actual fidelity steps as a lightweight visual
+comparison and record PASS/FAIL with expected-vs-actual detail on failure. Do
+not invent a baseline when no assets exist; design-reviewer is not the primary
+fidelity gate.

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -69,4 +69,9 @@ Document Quality Gate entry. Fix all inconsistencies before proceeding to the
 lint check, and include the Document Quality Gate log in the draft PR
 description.
 
+Before writing or updating the smoke runbook (protocol 02 Step 4), discover
+design assets per `docs/workflow/development-workflow/design-assets.md`. When
+assets exist, include at least one expected-vs-actual fidelity step naming the
+reference(s); when none exist, omit fidelity steps and do not invent a baseline.
+
 Before updating tracker status as part of a standalone plan completion sequence, call `ensure_on_project_board <issue_number> "Writing Plan"` (from `scripts/development-workflow/workflow-lib.sh`) to register the issue on the project board if it is not already present.

--- a/.claude/commands/add-backlog-item.md
+++ b/.claude/commands/add-backlog-item.md
@@ -17,4 +17,9 @@ Key responsibilities:
 - For GitHub Issues (including when the provider is `github_projects`), prefer `./scripts/development-workflow/add-backlog-item.sh create --title "..." --body-file -` when `gh` is authenticated; otherwise follow the protocol manually.
 - For Linear, use Linear MCP/API per `docs/workflow/development-workflow/integrations/linear.md` when the shell helper cannot create the item.
 - Do not silently assume a tracker or duplicate items across clarification turns.
+- When candidate files are supplied, follow Step 2b in protocol `00` and
+  [`docs/workflow/development-workflow/design-assets.md`](../../docs/workflow/development-workflow/design-assets.md):
+  recognize likely design assets, ask one brief clarifying question for ambiguous
+  files, attach or stage confirmed assets (agent-driven for GitHub), and record a
+  `## Design assets` body section. Do not invent assets when none are supplied.
 - Return the created item identifier, URL, and a short recap to the user.

--- a/.codex/skills/workflow-implementer/SKILL.md
+++ b/.codex/skills/workflow-implementer/SKILL.md
@@ -10,7 +10,7 @@ Recommended model tier: `balanced`
 1. Read `AGENTS.md` for repository-wide rules and branch overrides.
 2. Read `docs/workflow/development-workflow/protocols/03-implement-development-protocol.md`.
 3. Follow that protocol exactly.
-4. For full-pipeline work, read the spec and plan first. For refactors, read the plan first (no spec). For fast-track work, require the Protocol 91 Fast Track blast-radius gate and Protocol 03 criteria to have passed before implementation; stop if scope expands, high call-site volume appears, or external-system impact is discovered after dispatch. For hotfixes, branch from `main`.
+4. For full-pipeline work, read the spec and plan first. For refactors, read the plan first (no spec). For fast-track work, require the Protocol 91 Fast Track blast-radius gate and Protocol 03 criteria to have passed before implementation; stop if scope expands, high call-site volume appears, or external-system impact is discovered after dispatch. For hotfixes, branch from `main`. For UI-facing work, discover design assets per `docs/workflow/development-workflow/design-assets.md` and use them as visual references; do not invent assets when none exist.
 5. Before writing or editing any repository file, verify you are on the intended workflow branch or inside the item worktree. If the checkout is on `develop` or `main`, create the feature/fix/refactor/hotfix branch or worktree before the first edit; do not start in the shared checkout and move changes later.
 6. For substantial or multi-part mutating implementation work, commit
    immediately after each completed logical sub-part, do not intentionally batch

--- a/.codex/skills/workflow-plan-writer/SKILL.md
+++ b/.codex/skills/workflow-plan-writer/SKILL.md
@@ -31,8 +31,12 @@ Recommended model tier: `premium`
 14. Before opening the draft plan PR, call `ensure_on_project_board <issue_number> "Writing Plan"` from `scripts/development-workflow/workflow-lib.sh`. This is a no-op when the issue is already on the board.
 15. Before creating the plan branch or opening the plan PR for a tracker-backed item, run `run-nested-artifact-guard.sh` with required `--mode`, `--issue`, `--expected-branch`, `--approved-base`, plus the expected `implementation-plan/*` branch and approved artifact base. Stop on missing base, duplicate artifacts, wrong-base PRs, or scan failures.
 16. Keep implementation files off `implementation-plan/*` branches. Before plan PR readiness, Protocol 91 Step 8a must run `check-documentation-stage-alignment.sh`; a mismatch must be corrected or escalated before `ready-for-human-review`.
-17. When the branch is created, continue through reviewer gate, PR creation, and PR readiness unless the protocol surfaces a real human decision.
-18. Resolve repository mode, artifact owner, and artifact base branch before
+17. Before writing or updating the smoke runbook, discover design assets per
+    `docs/workflow/development-workflow/design-assets.md`. When assets exist,
+    include at least one expected-vs-actual fidelity step; when none exist, omit
+    fidelity steps and do not invent a baseline.
+18. When the branch is created, continue through reviewer gate, PR creation, and PR readiness unless the protocol surfaces a real human decision.
+19. Resolve repository mode, artifact owner, and artifact base branch before
     writing: `single_repo` uses the current repository; `workflow_hub` keeps
     plans and plan PRs hub-owned on the hub artifact base branch, even when the
     product implementation base is different; `product_repo` should report the

--- a/.codex/skills/workflow-spec-writer/SKILL.md
+++ b/.codex/skills/workflow-spec-writer/SKILL.md
@@ -31,8 +31,12 @@ Recommended model tier: `premium`
    not-applicable rationale.
 9. Before opening the draft spec PR, call `ensure_on_project_board <issue_number> "Writing Spec"` from `scripts/development-workflow/workflow-lib.sh`. This is a no-op when the issue is already on the board.
 10. Before creating the spec branch or opening the spec PR for a tracker-backed item, run `run-nested-artifact-guard.sh` with required `--mode`, `--issue`, `--expected-branch`, `--approved-base`, plus the expected `spec/*` branch and approved artifact base. Stop on missing base, duplicate artifacts, wrong-base PRs, or scan failures.
-11. When the branch is created, continue through reviewer gate, PR creation, and PR readiness unless the protocol surfaces a real human decision.
-12. Resolve repository mode, artifact owner, and artifact base branch before
+11. When creating the development folder, discover design assets per
+    `docs/workflow/development-workflow/design-assets.md`. If confirmed tracker
+    design assets exist, copy or download them into `<dev-folder>/assets/` and
+    update the issue-body location note. Do not invent assets when none exist.
+12. When the branch is created, continue through reviewer gate, PR creation, and PR readiness unless the protocol surfaces a real human decision.
+13. Resolve repository mode, artifact owner, and artifact base branch before
    writing: `single_repo` uses the current repository; `workflow_hub` keeps specs
    and spec PRs hub-owned on the hub artifact base branch, even when the
    product implementation base is different; `product_repo` should report the

--- a/.cursor/agents/developer.md
+++ b/.cursor/agents/developer.md
@@ -50,6 +50,9 @@ Key rules:
   incoherent edits only to satisfy this requirement
 - For Full Pipeline: read spec + plan + runbook BEFORE writing any code
 - For Refactor: read plan + runbook BEFORE writing any code (no spec)
+- For UI-facing work, discover design assets per
+  `docs/workflow/development-workflow/design-assets.md` and use them as visual
+  references; do not invent assets when none exist
 - For Fast Track: require the Protocol 91 Fast Track blast-radius gate and
   Protocol 03 criteria to have passed before implementation; stop and report if
   scope expands, high call-site volume appears, or external-system impact is

--- a/.cursor/agents/product-manager.md
+++ b/.cursor/agents/product-manager.md
@@ -54,4 +54,9 @@ protocol 01's Brief Objective List, Coverage Matrix, and Deferral Note
 requirements as part of that gate. For complex workflow decision-gate specs,
 include protocol 01's consistency matrix or not-applicable rationale.
 
+When creating the development folder, discover design assets per
+`docs/workflow/development-workflow/design-assets.md`. If confirmed tracker
+design assets exist, copy or download them into `<dev-folder>/assets/` and
+update the issue-body location note. Do not invent assets when none exist.
+
 Before updating tracker status as part of a standalone spec completion sequence, call `ensure_on_project_board <issue_number> "Writing Spec"` (from `scripts/development-workflow/workflow-lib.sh`) to register the issue on the project board if it is not already present.

--- a/.cursor/agents/smoke-tester.md
+++ b/.cursor/agents/smoke-tester.md
@@ -22,3 +22,10 @@ For project-specific execution instructions, read:
 **`docs/testing/README.md`**
 
 Always read the smoke test runbook and the testing README before beginning.
+
+When the runbook or work item may have graphical design references, discover
+assets per `docs/workflow/development-workflow/design-assets.md` and protocol
+`04` §3a. Execute any expected-vs-actual fidelity steps as a lightweight visual
+comparison and record PASS/FAIL with expected-vs-actual detail on failure. Do
+not invent a baseline when no assets exist; design-reviewer is not the primary
+fidelity gate.

--- a/.cursor/agents/tech-lead.md
+++ b/.cursor/agents/tech-lead.md
@@ -68,6 +68,11 @@ Document Quality Gate entry. Fix all inconsistencies before proceeding to the
 lint check, and include the Document Quality Gate log in the draft PR
 description.
 
+Before writing or updating the smoke runbook (protocol 02 Step 4), discover
+design assets per `docs/workflow/development-workflow/design-assets.md`. When
+assets exist, include at least one expected-vs-actual fidelity step naming the
+reference(s); when none exist, omit fidelity steps and do not invent a baseline.
+
 Before updating tracker status as part of a standalone plan completion sequence, call `ensure_on_project_board <issue_number> "Writing Plan"` (from `scripts/development-workflow/workflow-lib.sh`) to register the issue on the project board if it is not already present.
 
 **Note**: This agent handles premium-tier reasoning tasks (architecture decisions). For best results, ensure your Cursor Composer is using a high-reasoning model (e.g., Claude Opus, GPT-4, or equivalent) when invoking this subagent, or edit this file to set `model:` to a specific premium model ID.

--- a/.cursor/commands/add-backlog-item.md
+++ b/.cursor/commands/add-backlog-item.md
@@ -15,4 +15,9 @@ Key responsibilities:
 - For GitHub Issues (including when the provider is `github_projects`), prefer `./scripts/development-workflow/add-backlog-item.sh create --title "..." --body-file -` when `gh` is authenticated; otherwise follow the protocol manually.
 - For Linear, use Linear MCP/API per `docs/workflow/development-workflow/integrations/linear.md` when the shell helper cannot create the item.
 - Do not silently assume a tracker or duplicate items across clarification turns.
+- When candidate files are supplied, follow Step 2b in protocol `00` and
+  `docs/workflow/development-workflow/design-assets.md`: recognize likely design
+  assets, ask one brief clarifying question for ambiguous files, attach or stage
+  confirmed assets (agent-driven for GitHub), and record a `## Design assets`
+  body section. Do not invent assets when none are supplied.
 - Return the created item identifier, URL, and a short recap to the user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Graphical design assets in the workflow** (#1282): add capture, storage,
+  discovery, and lightweight plan/smoke fidelity hooks for design references
+  without a visual-regression platform.
+
 ## [0.37.1] - 2026-07-20
 
 ### Fixed

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -8,6 +8,12 @@
 
 The smoke test _process_ (inputs, output format, pass criteria, fail handling) is defined in the [Smoke Test Protocol](../workflow/development-workflow/protocols/04-smoke-test-protocol.md). This guide covers **how** to execute tests in this specific repo.
 
+When a work item has graphical design references, runbooks may include optional
+expected-vs-actual fidelity steps. Discover assets and record PASS/FAIL detail
+per [`design-assets.md`](../workflow/development-workflow/design-assets.md) and
+protocol `04`. Omit fidelity steps when no assets exist — do not invent a
+baseline.
+
 If this repository has a preferred browser automation provider, declare it in `.ai-dev-workflow.yaml` under `browser_automation.provider`.
 
 ---

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -588,6 +588,12 @@ Protocol prefixes are stable family identifiers, not a promise of contiguous num
 - `90`-`99` are orchestration, readiness, and other cross-cutting operational protocols.
 - The numbering was normalized after an older stage was removed, so the current primary stages are contiguous again.
 
+### Design Assets
+
+- `docs/workflow/development-workflow/design-assets.md` — capture, storage
+  (`<dev-folder>/assets/`), discovery order, and lightweight plan/smoke fidelity
+  hooks for graphical design references (not a visual-regression platform)
+
 ### Core Protocols
 
 - `docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md`

--- a/docs/workflow/development-workflow/design-assets.md
+++ b/docs/workflow/development-workflow/design-assets.md
@@ -1,0 +1,169 @@
+# Design Assets Convention
+
+Canonical rules for capturing, storing, discovering, and lightly validating
+graphical design references in the AI development workflow.
+
+Protocols and command surfaces **link here** rather than redefining these rules.
+This is intentionally lightweight: it is **not** a visual-regression platform,
+pixel-diff harness, or `/merged-qa` (#1283) implementation.
+
+---
+
+## When this applies
+
+Use these rules when a backlog item or later stage may have design references
+such as HTML mockups, screenshots, photos, SVG comps, or PDF mockups.
+
+Do **not** invent assets when none were supplied. Orthogonal sibling work items
+are never asset sources for the current item.
+
+---
+
+## Recognition heuristics
+
+Classify each candidate file by extension (case insensitive). This is
+agent-facing guidance, not a parser/lint module.
+
+### Likely design assets
+
+Treat as design references (stage/attach without asking) when the extension is:
+
+| Kind | Extensions |
+| --- | --- |
+| HTML mockups | `.html`, `.htm` |
+| Images | `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg` |
+| PDF mockups | `.pdf` |
+
+### Clearly non-design
+
+Do **not** stage as design references (unless the human explicitly says they
+are):
+
+- Logs / dumps: `.log`, `.csv`
+- Common source: `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rs`, `.java`,
+  `.rb`, `.sh`
+- Lock/config dumps unless explicitly marked as design references
+
+### Ambiguous
+
+Ask **one** brief clarifying question covering the whole ambiguous set, then
+still create **exactly one** backlog item. Examples: `.md`, `.txt`, `.docx`,
+`.zip`, or mixed batches where intent is unclear.
+
+---
+
+## Storage layout
+
+| When | Where | Notes |
+| --- | --- | --- |
+| Backlog creation | Tracker attachments (GitHub Issues / Linear / provider-native) | Primary store before a development folder exists |
+| After development folder exists | `<dev-folder>/assets/` | Canonical on-disk location under `docs/specs/developments/<timestamp>_<slug>/` |
+| Always | Issue / work-item body section `## Design assets` | Lists locations and states that plan/smoke should use them as fidelity references |
+
+Exact folder name: **`assets/`** (not `design-assets/`). Only confirmed design
+reference files belong there; incidental attachments stay tracker-only and are
+not copied into `assets/`.
+
+### Migration rule
+
+When a development folder is created or first used and tracker design assets
+exist, copy or download confirmed design assets into `<dev-folder>/assets/` and
+update the issue-body location note. Do not invent assets when none exist.
+
+---
+
+## Issue-body template
+
+Include (or append) this section on the work item:
+
+```markdown
+## Design assets
+
+- **References**: <filenames or short labels>
+- **Locations**:
+  - Tracker attachments: <yes/no; names if known>
+  - Local / staged paths: <path notes if upload failed or pending>
+  - Development folder: `<dev-folder>/assets/` <when present>
+- **Usage**: Plan and smoke stages should treat these as expected visual
+  references for UI-facing work. Do not invent a baseline if this section is
+  absent or empty.
+```
+
+---
+
+## Capture at `/add-backlog-item`
+
+See protocol
+[`00-add-backlog-item-protocol.md`](protocols/00-add-backlog-item-protocol.md).
+Summary:
+
+1. Detect candidate files from the invocation (chat attachments, local paths).
+2. Classify each file (likely / ambiguous / non-design).
+3. Ask at most one brief clarifying question for the ambiguous set.
+4. Create exactly one backlog item (normal destination / Type / Priority / Size).
+5. Attach or upload confirmed design assets via provider-native means when
+   available; on failure, record local paths in the body and ask the human to
+   attach manually — do **not** fail item creation solely because upload failed.
+6. Ensure the `## Design assets` body section is present.
+
+### GitHub attach recipe (agent-driven)
+
+`add-backlog-item.sh` creates the issue and project fields; reliable binary
+attachment to GitHub Issues is not exposed as a stable `gh` subcommand, so
+agents attach after create:
+
+1. Prefer the GitHub UI or MCP attachment upload for the issue when available.
+2. Otherwise post an issue comment that lists each confirmed asset filename and
+   any durable URL the human/MCP produced, and keep the `## Design assets`
+   body section accurate (paths + “human attach requested” when needed).
+3. Never block creation on attach failure.
+
+Example comment body:
+
+```markdown
+## Design assets (staged)
+
+- `mockup.png` — please attach to this issue (local path noted in issue body).
+```
+
+For Linear and other providers, use the provider-native attachment API/MCP from
+the matching integration guide.
+
+---
+
+## Discovery order (agents)
+
+Before UI-facing plan or smoke work, check in order:
+
+1. Issue / work-item body `## Design assets` section (canonical pointers)
+2. Tracker attachments on the work item
+3. Linked files referenced from the issue body
+4. `<dev-folder>/assets/` when the development folder exists
+
+If none found: continue normally; do **not** invent a baseline.
+
+If locations conflict: ask the human once which reference is authoritative.
+
+---
+
+## Lightweight fidelity checks
+
+- **Plan writers** (protocol `02`): when discovery finds assets, include at least
+  one expected-vs-actual fidelity step in the smoke runbook that names the
+  reference asset(s). If none, omit fidelity steps.
+- **Smoke execution** (protocol `04`): when a runbook includes fidelity steps,
+  perform a lightweight human/agent visual comparison (not pixel diff). Record
+  PASS/FAIL with expected-vs-actual detail on failure.
+- **design-reviewer** is **not** the primary mockup-fidelity gate for this
+  convention. Optional design review remains separate from AC-driven smoke
+  fidelity steps.
+
+---
+
+## Non-goals
+
+- `/merged-qa` / #1283 implementation
+- Automated visual-regression platform (pixel diffs, baseline vaults, CI
+  screenshot suites)
+- Promoting design-reviewer to the primary fidelity gate
+- Treating sibling issues as asset sources

--- a/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
+++ b/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
@@ -51,6 +51,36 @@ If any of the above are missing or contradictory, ask **targeted** clarifying qu
 
 ---
 
+## Step 2b: Capture graphical design assets (when candidates are present)
+
+When the invocation includes candidate files (chat attachments, local paths, or
+explicit mockup references), follow the canonical convention in
+[`design-assets.md`](../design-assets.md) before creating the item:
+
+1. **Detect** candidate files from the invocation.
+2. **Classify** each file as likely design, clearly non-design, or ambiguous
+   using the extension heuristics in `design-assets.md`.
+3. **Clarify once** when any file is ambiguous (or a mixed batch is unclear): ask
+   one brief question covering the whole ambiguous set. Clearly non-design files
+   are not staged as design references unless the human explicitly says so.
+4. Proceed to create **exactly one** backlog item (Step 3) — asset handling must
+   not create duplicate items across clarification turns.
+5. **Attach or stage** confirmed design assets via provider-native means when
+   available. On attach/upload failure, record local paths in the issue body and
+   ask the human to attach manually; do **not** fail item creation solely because
+   upload failed. Reliable binary attach is agent-driven for GitHub (see the
+   attach recipe in `design-assets.md`); the shell helper creates the issue and
+   fields only.
+6. **Record** a `## Design assets` section in the item body (include it in the
+   initial body or append after create) using the template in `design-assets.md`.
+   State locations and that plan/smoke stages should use the assets as fidelity
+   references.
+
+When no candidate files are present, skip this step entirely — do not invent
+assets or a fidelity baseline.
+
+---
+
 ## Step 3: Create exactly one backlog item
 
 1. Create **one** item in the **confirmed** destination.
@@ -107,6 +137,8 @@ Return a short confirmation including:
 - **Identifier** (e.g. issue number, Linear key).
 - **URL** to the item.
 - **Title** and one-line recap of scope.
+- When Step 2b ran: which files were treated as design assets, where they are
+  stored (tracker attachment and/or path note), and any clarifying question asked.
 
 ---
 
@@ -217,6 +249,8 @@ When a human requests the creation of two or more related backlog items that tog
 - Do not silently pick a tracker when uncertain.
 - Do not create multiple items for one user request.
 - Do not start spec/plan/implementation work unless the user explicitly asks to advance stages afterward.
+- Do not invent design assets or a visual-regression baseline when none were supplied.
+- Do not implement `/merged-qa` (#1283) or promote design-reviewer as the primary fidelity gate here.
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
+++ b/docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md
@@ -313,6 +313,10 @@ If no blocking human decision remains:
 
    If the check fails, do not proceed. Report the mismatch to the caller so the working tree can be reset before retrying.
 3. Create the development folder: `docs/specs/developments/[YYYYMMDDHHMMSS]_[feature-slug]/`
+   - When confirmed design assets exist on the tracker item (see
+     [`design-assets.md`](../design-assets.md)), copy or download them into
+     `<dev-folder>/assets/` and update the issue-body `## Design assets`
+     location note. Do not invent assets when none exist.
 4. Write the spec file: `1_[feature-slug]_specs.md`
 5. **Board membership check (when a tracker issue ID is present)**: If an issue number is available (i.e., the workflow uses a configured issue tracker and an issue ID was provided or created), call `ensure_on_project_board <issue_number> "Writing Spec"` (sourcing `scripts/development-workflow/workflow-lib.sh`). If the issue is already on the project board, this is a no-op. If it is not, the function adds it and sets initial status to "Writing Spec". On any API failure, the function logs a warning and continues — this step must never block the commit or PR creation. Skip this step entirely when no issue ID is present (no-tracker workflows).
 6. **Do NOT update CHANGELOG**: `spec/*` branches are exempt from CHANGELOG entries. The changelog policy only applies to `feature/*`, `fix/*`, `refactor/*`, and `hotfix/*` branches. Do not create or modify `CHANGELOG.md` in this PR.

--- a/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -294,6 +294,20 @@ docs/testing/[app-or-section]/[feature-slug].smoke-test.md
 
 The runbook must cover all acceptance criteria from the spec (or from the work item brief for Refactor items). Each criterion must have at least one testable step.
 
+### Design-asset discovery and fidelity steps
+
+Before finalizing the runbook for UI-facing work, discover design assets using
+the order in [`design-assets.md`](../design-assets.md) (issue-body
+`## Design assets`, tracker attachments, linked files, `<dev-folder>/assets/`).
+
+- **When assets exist**: include at least one expected-vs-actual fidelity step
+  that names the reference asset(s). Fidelity is a lightweight visual
+  comparison, not a pixel-diff platform.
+- **When none exist**: omit fidelity steps; do **not** invent a baseline or
+  fail the plan for missing mockups.
+- If locations conflict, ask the human once which reference is authoritative.
+  Sibling issues are never asset sources for this item.
+
 ---
 
 ## Step 5: Git Execution

--- a/docs/workflow/development-workflow/protocols/04-smoke-test-protocol.md
+++ b/docs/workflow/development-workflow/protocols/04-smoke-test-protocol.md
@@ -52,6 +52,10 @@ Before writing any test code, read:
 - The **smoke test runbook**
 - The **project testing README** — for environment setup, execution approach, known limitations, and troubleshooting
 - **Application source code** for the pages under test (e.g. component templates) to understand selectors, labels, routes, and UI library patterns
+- **Design assets** when the runbook or work item references them — discover via
+  [`design-assets.md`](../design-assets.md) (issue-body `## Design assets`,
+  tracker attachments, linked files, `<dev-folder>/assets/`). Absence of assets
+  is not a failure; do not invent a baseline.
 
 ### 2. Choose and Execute the Test Approach
 
@@ -77,6 +81,20 @@ For each runbook step, record:
 - **Step number and description**
 - **Result**: PASS or FAIL
 - **Details**: What was observed (for failures, include expected vs. actual)
+
+### 3a. Design fidelity steps (when present)
+
+When the runbook includes expected-vs-actual fidelity steps against design
+assets:
+
+1. Execute them as a lightweight human/agent visual comparison (not pixel diff).
+2. Record PASS or FAIL like any other step.
+3. On FAIL, include expected-vs-actual detail naming the reference asset and what
+   differed in the UI under test.
+4. Do **not** treat design-reviewer as the primary fidelity gate; optional design
+   review remains separate from these AC-driven smoke steps.
+5. If the runbook has no fidelity steps (no assets were discovered at plan time),
+   skip this subsection — missing assets are not a smoke failure.
 
 ---
 

--- a/docs/workflow/development-workflow/templates/smoke-test-runbook-template.md
+++ b/docs/workflow/development-workflow/templates/smoke-test-runbook-template.md
@@ -60,6 +60,21 @@ Before running this smoke test:
 
 <!-- Add steps for each use case and acceptance criterion -->
 
+### Step N (optional): Design fidelity — expected vs actual
+
+> Include this step **only** when design assets were discovered for the item
+> (see `docs/workflow/development-workflow/design-assets.md`). Omit entirely
+> when none exist — do not invent a baseline.
+
+**Maps to**: [Acceptance criterion for UI fidelity, if any]
+
+1. Open the reference asset(s): `[filename(s) under tracker attachments and/or <dev-folder>/assets/]`
+2. Compare the implemented UI against that reference (lightweight visual check; not pixel diff).
+3. Record PASS/FAIL with expected-vs-actual detail on failure.
+
+**Expected result**: Implemented UI matches the named design reference for the
+scoped surfaces; differences that matter for the acceptance criteria are absent.
+
 ### Last Step: Validate & Shut Down
 
 - Verify all assertions in the checklist below are met


### PR DESCRIPTION
## Summary

- Add canonical `design-assets.md` convention for recognition, storage (`<dev-folder>/assets/`), discovery order, issue-body template, and lightweight fidelity rules
- Extend `/add-backlog-item` (protocol 00 + Claude/Cursor/Codex surfaces) to capture, clarify ambiguous files once, attach/stage via agent recipe, and record `## Design assets`
- Wire discovery + optional expected-vs-actual fidelity hooks into protocols 01/02/04, smoke runbook template, READMEs, and stage agent/skill mirrors (design-reviewer remains non-primary; #1283 out of scope)

## Test plan

- [x] `npx markdownlint-cli2` on touched workflow docs + CHANGELOG (0 issues)
- [x] `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- [x] `bash scripts/development-workflow/tests/test-add-backlog-item.sh` (32 passed; helper unchanged — attach remains agent-driven)
- [ ] Smoke runbook `docs/testing/workflow/1282-graphical-design-assets-workflow.smoke-test.md` (documentation path / AC1–AC9)

## Pre-Submission Self-Review

- Spec/plan coverage: AC1–AC9 mapped to convention, protocol 00 Step 2b, discovery/fidelity hooks, mirrors, CHANGELOG; no visual-regression platform; no #1281/#1284 edits; design-reviewer not promoted
- Sibling consistency: Claude/Cursor/Codex add-backlog + stage agent/skill mirrors updated; `.agents/skills` workflow-* resolve via `.codex/skills`
- Helper: documented GitHub attach recipe in `design-assets.md` (stable `gh` binary attach not practical in-shell)

Closes #1282

Made with [Cursor](https://cursor.com)