### PR TITLE
fix(sync): include tracker workflow in manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sync tracker-closeout workflow** (#1304): Include the merge-time tracker
+  workflow in template-sync review so downstream projects can adopt graduation
+  closeout together with its validation helpers.
+
 ## [0.38.0] - 2026-07-21
 
 ### Added

--- a/scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh
+++ b/scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh
@@ -399,8 +399,10 @@ run_contains "mode_scope_has_product_entries" "mode_scope: product_repo_injectio
 hub_sync_scope_output="$(python3 "$SYNC_SELECTOR" --manifest "$REPO_ROOT/sync-manifest.yaml" --role workflow_hub)"
 product_sync_scope_output="$(python3 "$SYNC_SELECTOR" --manifest "$REPO_ROOT/sync-manifest.yaml" --role product_repo)"
 run_contains "mode_scope_hub_selects_hub_docs" "SELECTED category=always_sync mode_scope=hub_only path=docs/workflow/ glob=**/*" "$hub_sync_scope_output"
+run_contains "mode_scope_hub_selects_tracker_merge_workflow" "SELECTED category=special_handling mode_scope=shared path=.github/workflows/update-tracker-on-merge.yml glob=" "$hub_sync_scope_output"
 run_contains "mode_scope_hub_skips_product_injection" "SKIPPED category=project_specific mode_scope=product_repo_injection path=AGENTS.md glob= mixed_content=true annotation_scheme=html_comments reason=scope_not_applicable" "$hub_sync_scope_output"
 run_contains "mode_scope_product_selects_injection" "SELECTED category=project_specific mode_scope=product_repo_injection path=AGENTS.md glob=" "$product_sync_scope_output"
+run_contains "mode_scope_product_selects_tracker_merge_workflow" "SELECTED category=special_handling mode_scope=shared path=.github/workflows/update-tracker-on-merge.yml glob=" "$product_sync_scope_output"
 run_contains "mode_scope_product_skips_hub_docs" "SKIPPED category=always_sync mode_scope=hub_only path=docs/workflow/ glob=**/* mixed_content= annotation_scheme= reason=scope_not_applicable" "$product_sync_scope_output"
 run_not_contains "mode_scope_product_does_not_select_hub_docs" "SELECTED category=always_sync mode_scope=hub_only path=docs/workflow/" "$product_sync_scope_output"
 

--- a/sync-manifest.yaml
+++ b/sync-manifest.yaml
@@ -141,6 +141,9 @@ categories:
     - path: .github/workflows/e2e-regression.yml
       mode_scope: shared
       note: label-gated e2e/regression placeholder; customize with project-specific test logic
+    - path: .github/workflows/update-tracker-on-merge.yml
+      mode_scope: shared
+      note: tracker automation may be customized; review and retain graduation closeout wiring when adopted
     - path: e2e/
       glob: "**/*"
       mode_scope: shared


### PR DESCRIPTION
## Summary

- include the tracker merge workflow as shared special handling
- verify it is selected for workflow hubs and product repositories

Closes #1304

## Verification

- `bash scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh`
- `python3 scripts/development-workflow/select-sync-manifest-entries.py --manifest sync-manifest.yaml --role single_repo`
- `shellcheck --severity=warning scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- changelog lint, heuristic lint, duplicate-header check, and `git diff --check`

## Self-review

Confirmed this focused diff addresses the manifest omission without changing project-specific workflow content. The new regression checks both applicable repository roles.