### PR TITLE
fix(workflow): grant graduation checkout read access

### DIFF
--- a/.github/workflows/update-tracker-on-merge.yml
+++ b/.github/workflows/update-tracker-on-merge.yml
@@ -37,10 +37,12 @@ concurrency:
   cancel-in-progress: false
 
 # Least-privilege permissions: only what this workflow needs.
+# - contents: read       — checkout repo for graduation closeout fallback scripts
 # - pull-requests: read  — read PR metadata (head.ref, merged flag)
 # - issues: write        — close the GitHub issue for impl branches
 # Note: Projects v2 mutations require GH_PROJECT_TOKEN (PAT) — not GITHUB_TOKEN.
 permissions:
+  contents: read
   pull-requests: read
   issues: write
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Graduation closeout checkout** (#1305): Grant the tracker merge workflow
+  read-only repository access required to run the graduation closeout fallback.
+
 ## [0.38.0] - 2026-07-21
 
 ### Added

--- a/scripts/development-workflow/check-tracker-merge-mapping.sh
+++ b/scripts/development-workflow/check-tracker-merge-mapping.sh
@@ -108,6 +108,16 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+# Checkout for graduation closeout requires contents: read when permissions: is explicit.
+if grep -Eq 'uses:[[:space:]]*actions/checkout@' "$WORKFLOW_FILE"; then
+  if grep -Eq '^[[:space:]]*contents:[[:space:]]*read[[:space:]]*$' "$WORKFLOW_FILE"; then
+    echo "OK: actions/checkout present with contents: read"
+  else
+    echo "ERROR: actions/checkout is used but permissions lack contents: read (checkout will 403)"
+    ERRORS=$((ERRORS + 1))
+  fi
+fi
+
 echo ""
 if [ "$ERRORS" -eq 0 ]; then
   echo "All 6 mappings correct (+ graduation closeout fallback)."

--- a/scripts/development-workflow/tests/test-check-tracker-merge-mapping.sh
+++ b/scripts/development-workflow/tests/test-check-tracker-merge-mapping.sh
@@ -79,6 +79,11 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
 jobs:
   update-tracker:
     runs-on: ubuntu-latest
@@ -94,6 +99,8 @@ jobs:
           elif [[ "$BRANCH" == develop-* ]]; then
             BRANCH_TYPE="graduation"
           fi
+      - name: Checkout repository for graduation closeout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Run graduation closeout fallback
         run: ./scripts/development-workflow/graduation-closeout-from-merged-pr.sh --graduation-pr 1
 YAML
@@ -104,6 +111,49 @@ printf '%s\n' "$valid_output" | grep -q 'All 6 mappings correct (+ graduation cl
   || fail "valid workflow output should confirm all mappings and graduation fallback"
 printf '%s\n' "$valid_output" | grep -q "OK: branch 'develop-\*' → graduation closeout fallback" \
   || fail "valid workflow output should acknowledge graduation closeout fallback"
+printf '%s\n' "$valid_output" | grep -q 'OK: actions/checkout present with contents: read' \
+  || fail "valid workflow output should confirm contents: read for checkout"
+
+missing_contents_workflow="$TMP_DIR/update-tracker-missing-contents.yml"
+cat > "$missing_contents_workflow" <<'YAML'
+name: Update tracker on merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  pull-requests: read
+  issues: write
+
+jobs:
+  update-tracker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect branch type
+        run: |
+          if [[ "$BRANCH" == spec/* ]]; then
+            TARGET_STATUS="Spec Ready"
+          elif [[ "$BRANCH" == implementation-plan/* ]]; then
+            TARGET_STATUS="Plan Ready"
+          elif [[ "$BRANCH" == feature/* || "$BRANCH" == fix/* || "$BRANCH" == refactor/* || "$BRANCH" == hotfix/* ]]; then
+            TARGET_STATUS="Merged"
+          elif [[ "$BRANCH" == develop-* ]]; then
+            BRANCH_TYPE="graduation"
+          fi
+      - name: Checkout repository for graduation closeout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - name: Run graduation closeout fallback
+        run: ./scripts/development-workflow/graduation-closeout-from-merged-pr.sh --graduation-pr 1
+YAML
+
+missing_contents_exit=0
+missing_contents_output="$(run_with_workflow "$missing_contents_workflow" 2>&1)" \
+  || missing_contents_exit=$?
+[ "$missing_contents_exit" -eq 1 ] \
+  || fail "workflow with checkout but no contents: read should fail"
+printf '%s\n' "$missing_contents_output" | grep -q 'permissions lack contents: read' \
+  || fail "missing contents: read should explain the checkout permission requirement"
 
 missing_graduation_workflow="$TMP_DIR/update-tracker-missing-graduation.yml"
 cat > "$missing_graduation_workflow" <<'YAML'


### PR DESCRIPTION
## Summary

- grant `actions/checkout` the least-privilege `contents: read` permission
- fail the tracker mapping validation when checkout lacks that permission
- cover both valid and missing-permission workflow fixtures

Closes #1305

## Verification

- `bash scripts/development-workflow/tests/test-check-tracker-merge-mapping.sh`
- `bash scripts/development-workflow/check-tracker-merge-mapping.sh`
- `shellcheck --severity=warning scripts/development-workflow/check-tracker-merge-mapping.sh scripts/development-workflow/tests/test-check-tracker-merge-mapping.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- changelog lint, heuristic lint, duplicate-header check, and `git diff --check`

## Self-review

Confirmed the workflow now grants only the read access required by the existing graduation-closeout checkout and the validator catches a future regression.