### PR TITLE
fix(workflow): validate post-merge QA option values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Post-merge QA scope flags** (#1306): Report clear validation errors when a
+  valued option is missing its argument instead of consuming the next flag or
+  exiting during argument shifting.
+
 ## [0.38.0] - 2026-07-21
 
 ### Added

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -25,28 +25,49 @@ epic=""
 issues_arg=""
 recent_merged=0
 json_output=0
+missing_value_option=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --base)
       shift
-      base="${1:-}"
-      shift
+      if [ "$#" -eq 0 ] || [[ "$1" == -* ]]; then
+        base=""
+        missing_value_option="--base"
+      else
+        base="$1"
+        shift
+      fi
       ;;
     --epic)
       shift
-      epic="${1:-}"
-      shift
+      if [ "$#" -eq 0 ] || [[ "$1" == -* ]]; then
+        epic=""
+        missing_value_option="--epic"
+      else
+        epic="$1"
+        shift
+      fi
       ;;
     --issues)
       shift
-      issues_arg="${1:-}"
-      shift
+      if [ "$#" -eq 0 ] || [[ "$1" == -* ]]; then
+        issues_arg=""
+        missing_value_option="--issues"
+      else
+        issues_arg="$1"
+        shift
+      fi
       ;;
     --recent-merged-prs)
       shift
-      recent_merged="${1:-0}"
-      shift
+      if [ "$#" -eq 0 ] || [[ "$1" == -* ]]; then
+        recent_merged=""
+        missing_value_option="--recent-merged-prs"
+      else
+        recent_merged="$1"
+        shift
+      fi
       ;;
     --json)
       json_output=1
@@ -63,6 +84,12 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
+
+if [ -n "$missing_value_option" ]; then
+  echo "$missing_value_option requires a value" >&2
+  usage >&2
+  exit 64
+fi
 
 if [ -z "$base" ]; then
   echo "--base is required (develop or develop-<slug>)" >&2

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -91,8 +91,12 @@ chmod +x "$MOCK_BIN/gh"
 export PATH="$MOCK_BIN:$PATH"
 
 run_fails_contains "requires_base" "--base is required" "$HELPER" --json
+run_fails_contains "requires_base_value" "--base requires a value" "$HELPER" --base --json
 run_fails_contains "rejects_feature_base" "Disallowed base" "$HELPER" --base feature/foo --json
 run_fails_contains "rejects_bad_recent" "--recent-merged-prs must be" "$HELPER" --base develop --recent-merged-prs no --json
+run_fails_contains "requires_epic_value" "--epic requires a value" "$HELPER" --base develop --epic --json
+run_fails_contains "requires_issues_value" "--issues requires a value" "$HELPER" --base develop --issues --json
+run_fails_contains "requires_recent_value" "--recent-merged-prs requires a value" "$HELPER" --base develop --recent-merged-prs --json
 
 out="$("$HELPER" --base develop --recent-merged-prs 1 --json)" || {
   echo "FAIL: recent_merged helper exited non-zero"


### PR DESCRIPTION
## Summary

- reject missing values for all valued post-merge QA scope flags
- preserve clear validation errors when the next token is another flag
- extend focused regression coverage for every valued option

Closes #1306

## Verification

- `bash scripts/development-workflow/tests/test-post-merge-qa-scope.sh`
- `shellcheck --severity=warning scripts/development-workflow/post-merge-qa-scope.sh scripts/development-workflow/tests/test-post-merge-qa-scope.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- changelog lint, heuristic lint, duplicate-header check, and `git diff --check`

## Self-review

Confirmed all four valued flags reject terminal and flag-like missing arguments before network calls, while valid scope resolution remains covered by the existing fixture tests.