### PR TITLE
feat(workflow): validate existing branch reuse

### DIFF
--- a/.agents/skills/run-item/SKILL.md
+++ b/.agents/skills/run-item/SKILL.md
@@ -44,7 +44,14 @@ advances exactly one non-epic item through Protocol 91.
    `--allow-split`). Stop on `missing_base`, `blocked_duplicate`, `wrong_base`,
    or `scan_failed`; explicit split work requires parent approval and
    `--allow-split true`.
-7. Before dispatching a Backlog item into Writing Spec, run or consume
+7. After candidate discovery and a clean nested-artifact guard, run
+   `validate-branch-reuse.sh` with the issue, exact expected branch, approved
+   base, and artifact repo root. Only `compatible` may resume with
+   `workflow-next-action.sh`; `no_existing_branch` follows the fresh path.
+   Stop before mutation on `incompatible` or `verification_blocked`, report the
+   evidence and human action, and never delete, reset, rebase, check out, or
+   force-push the branch automatically. Tracking divergence is diagnostic only.
+8. Before dispatching a Backlog item into Writing Spec, run or consume
    `scripts/development-workflow/spec-dispatch-context.sh`. For direct
    single-item runs, pass the selected item plus relevant in-scope Backlog peers
    from the current tracker scan in `--items`; a selected-only scope may collect
@@ -52,7 +59,7 @@ advances exactly one non-epic item through Protocol 91.
    decisions and relationship outcomes to the spec writer; stop on
    `blocking=true` and report the helper's `humanAction`. Shared keywords alone
    are not dependency evidence.
-8. **Guardrails enforcement**: Use portfolio-resolved guardrails from handoff when
+9. **Guardrails enforcement**: Use portfolio-resolved guardrails from handoff when
    available; otherwise resolve from repo `guardrails` config. Report effective
    values before mutation. Enforce gates per
    `docs/workflow/development-workflow/guardrails-enforcement.md` section 3.
@@ -64,11 +71,11 @@ advances exactly one non-epic item through Protocol 91.
    items, run Protocol 91's residual gate before `ready-for-human-review`; block
    or escalate instead of reporting terminal when residual evidence is missing or
    incomplete.
-9. For `spec/*` and `implementation-plan/*` PRs, run Protocol 91 Step 8a's
+10. For `spec/*` and `implementation-plan/*` PRs, run Protocol 91 Step 8a's
    documentation-stage alignment checker before readiness; correct or escalate
    mismatches instead of applying `ready-for-human-review`.
-10. Epic-like targets must use `$run-epic` / `/run-epic`, not this command.
-11. When the delegated merge gate returns `merge_allowed`, continue through merge,
+11. Epic-like targets must use `$run-epic` / `/run-epic`, not this command.
+12. When the delegated merge gate returns `merge_allowed`, continue through merge,
    remote/local branch cleanup, `post-merge-cleanup.sh`, and live tracker
    verification before reporting the item terminal. Do not stop at
    `ready-for-human-review` in a delegated merge run.
@@ -76,7 +83,7 @@ advances exactly one non-epic item through Protocol 91.
    intermediate; `merge_denied` means the ready PR stops as
    `ready_human_merge` and no merge command is run. A merge-granted run that
    stops at readiness without a named blocker is `policy_inconsistent`.
-12. Before reporting any terminal state, run
+13. Before reporting any terminal state, run
     `scripts/development-workflow/item-completion-self-check.sh` for the claimed
     state and include its `## Ground-Truth Completion Verification` section in
     the Work Item Runner Summary. When Step 7 was configured, pass

--- a/.claude/agents/item-orchestrator.md
+++ b/.claude/agents/item-orchestrator.md
@@ -41,6 +41,15 @@ to commit immediately after each completed logical sub-part, avoid batching all
 completed sub-parts into one end-of-run commit, and never commit incomplete,
 failing, or incoherent edits only to satisfy this requirement.
 
+After candidate discovery and a clean nested-artifact guard, run
+`validate-branch-reuse.sh` with the issue, exact expected branch, approved base,
+and artifact repo root. A matching item number alone is insufficient. Only
+`compatible` may resume through `workflow-next-action.sh`;
+`no_existing_branch` follows the fresh path. Stop before mutation on
+`incompatible` or `verification_blocked`, report their distinct evidence and
+human action, and never delete, reset, rebase, check out, or force-push the
+branch automatically. Tracking divergence is diagnostic only.
+
 **Checkpoint-resume worktree preflight**: When resuming after a human-checkpoint
 pause from a prior worktree-isolated run, run Protocol 91's
 `worktree-resume-preflight.sh` before any mutation. Continue only from the

--- a/.claude/commands/run-item.md
+++ b/.claude/commands/run-item.md
@@ -31,6 +31,11 @@ The prelude command flags mirror this command's scope flags (`--target`, `--issu
   mutation. Worktree re-entry does not satisfy or waive checkpoint state.
 - Resolve exactly one non-epic workflow item
 - Use `scripts/development-workflow/` helpers for next-action classification
+- After candidate discovery and the nested-artifact guard, require a
+  `compatible` result from `validate-branch-reuse.sh` before reusing an existing
+  branch. Stop distinctly on incompatible or unverifiable evidence; never
+  delete or rewrite the branch automatically, and keep tracking divergence
+  diagnostic only.
 - In `workflow_hub`, state product repository and mutation target before implementation mutation
 - Continue until waiting on human, blocked, or escalated
 - If delegated merge authority is active and the merge gate returns

--- a/.codex/skills/workflow-item-orchestrator/SKILL.md
+++ b/.codex/skills/workflow-item-orchestrator/SKILL.md
@@ -38,7 +38,8 @@ Recommended model tier: `balanced`
 11. **Main-tree return rule (BATCH_CONTEXT=false / no worktree isolation)**: When dispatched WITHOUT worktree isolation (`BATCH_CONTEXT` is `false` or absent), this skill runs in the main working tree. Before emitting the Work Item Runner Summary and returning, switch the main working tree back to the integration branch (`git switch develop`, or whichever branch `integration_branch` specifies in `.ai-dev-workflow.yaml`). Verify with `git rev-parse --abbrev-ref HEAD`. If uncommitted changes block the switch, commit or stash first. Omitting this return step causes Protocol 90 Step 5.2 to fire "wrong branch + clean" auto-correct on every subsequent item.
 12. Before implementation mutation in `workflow_hub`, state the selected product repository, local path or remote identity, artifact owner, and mutation target. Stop before file edits, branch creation, commits, or implementation PR creation when product repository context is missing or ambiguous. Specs and plans remain hub-owned unless a later protocol says otherwise.
 13. Before dispatching a stage path that may create a branch or open a PR, pass the expected branch, expected worktree when known, approved base, and artifact-owning repo root. Run `run-nested-artifact-guard.sh --mode <pre-create|pre-pr> --issue <number> --expected-branch <branch> --approved-base <branch> --repo-root "$ARTIFACT_REPO_ROOT"` before mutation and stop on `missing_base`, `blocked_duplicate`, `wrong_base`, or `scan_failed`.
-14. Before dispatching a Backlog item into Writing Spec, run or consume
+14. After candidate discovery and a clean nested-artifact guard, run `validate-branch-reuse.sh` with the issue, exact expected branch, approved base, and artifact repo root. A matching item number is not sufficient: only `compatible` may resume through `workflow-next-action.sh`, while `no_existing_branch` follows the fresh path. Stop before mutation on `incompatible` or `verification_blocked`, report their distinct evidence and human action, and never delete, reset, rebase, check out, or force-push the branch automatically. Treat tracking divergence as diagnostic only.
+15. Before dispatching a Backlog item into Writing Spec, run or consume
     `scripts/development-workflow/spec-dispatch-context.sh`. For direct
     single-item runs, pass the selected item plus relevant in-scope Backlog peers
     from the current tracker scan in `--items`; a selected-only scope may collect
@@ -46,15 +47,15 @@ Recommended model tier: `balanced`
     decisions and relationship outcomes to the spec writer; stop on
     `blocking=true` and report the helper's `humanAction`. Shared keywords alone
     are not dependency evidence.
-15. **Guardrails enforcement**: At item-run start, use portfolio-resolved guardrails from handoff metadata when available; otherwise resolve from repo `guardrails` config. Report effective values before mutation. Enforce per-stage PR-open, delegated review, delegated merge, and completion gates per `docs/workflow/development-workflow/guardrails-enforcement.md` section 3. When no `guardrails` section is found, apply conservative defaults and state them. When the delegated merge gate returns `merge_allowed`, continue through merge, branch cleanup, `post-merge-cleanup.sh`, and live tracker verification before reporting the item terminal. Treat merge authority explicitly: `merge_granted` means readiness is intermediate; `merge_denied` means the ready PR stops as `ready_human_merge` and no merge command is run. A merge-granted run that stops at readiness without a named blocker is `policy_inconsistent`.
-16. For sweep, batch, helper-extraction, numeric-target, or pattern-completeness
+16. **Guardrails enforcement**: At item-run start, use portfolio-resolved guardrails from handoff metadata when available; otherwise resolve from repo `guardrails` config. Report effective values before mutation. Enforce per-stage PR-open, delegated review, delegated merge, and completion gates per `docs/workflow/development-workflow/guardrails-enforcement.md` section 3. When no `guardrails` section is found, apply conservative defaults and state them. When the delegated merge gate returns `merge_allowed`, continue through merge, branch cleanup, `post-merge-cleanup.sh`, and live tracker verification before reporting the item terminal. Treat merge authority explicitly: `merge_granted` means readiness is intermediate; `merge_denied` means the ready PR stops as `ready_human_merge` and no merge command is run. A merge-granted run that stops at readiness without a named blocker is `policy_inconsistent`.
+17. For sweep, batch, helper-extraction, numeric-target, or pattern-completeness
     items, run `scope-residual-gate.sh` before readiness and treat `block` or
     `escalate` as non-terminal.
-17. For `spec/*` and `implementation-plan/*` PRs, run Protocol 91 Step 8a's
+18. For `spec/*` and `implementation-plan/*` PRs, run Protocol 91 Step 8a's
     documentation-stage alignment checker before readiness. Include the
     alignment result in the runner summary when readiness is blocked; correct
     or escalate mismatches instead of applying `ready-for-human-review`.
-18. Before any terminal Work Item Runner Summary (`ready`, `done`, `blocked`,
+19. Before any terminal Work Item Runner Summary (`ready`, `done`, `blocked`,
     `escalated`, waiting on human, waiting on merge, or cleanup complete), run
     `scripts/development-workflow/item-completion-self-check.sh` for the claimed
     state and paste its `## Ground-Truth Completion Verification` section into

--- a/.cursor/agents/item-orchestrator.md
+++ b/.cursor/agents/item-orchestrator.md
@@ -48,6 +48,15 @@ to commit immediately after each completed logical sub-part, avoid batching all
 completed sub-parts into one end-of-run commit, and never commit incomplete,
 failing, or incoherent edits only to satisfy this requirement.
 
+After candidate discovery and a clean nested-artifact guard, run
+`validate-branch-reuse.sh` with the issue, exact expected branch, approved base,
+and artifact repo root. A matching item number alone is insufficient. Only
+`compatible` may resume through `workflow-next-action.sh`;
+`no_existing_branch` follows the fresh path. Stop before mutation on
+`incompatible` or `verification_blocked`, report their distinct evidence and
+human action, and never delete, reset, rebase, check out, or force-push the
+branch automatically. Tracking divergence is diagnostic only.
+
 **Checkpoint-resume worktree preflight**: When resuming after a human-checkpoint
 pause from a prior worktree-isolated run, run Protocol 91's
 `worktree-resume-preflight.sh` before any mutation. Continue only from the

--- a/.cursor/commands/run-item.md
+++ b/.cursor/commands/run-item.md
@@ -47,6 +47,11 @@ Key responsibilities:
   mutation. Worktree re-entry does not satisfy or waive checkpoint state.
 - Resolve the request to exactly one non-epic workflow item
 - Use helper scripts in `scripts/development-workflow/` for next-action classification
+- After candidate discovery and the nested-artifact guard, require a
+  `compatible` result from `validate-branch-reuse.sh` before reusing an existing
+  branch. Stop distinctly on incompatible or unverifiable evidence; never
+  delete or rewrite the branch automatically, and keep tracking divergence
+  diagnostic only.
 - In `workflow_hub`, state selected product repository, artifact owner, and mutation target before implementation mutation
 - Continue through creator, reviewer, PR, automated review, and CI until terminal
 - If delegated merge authority is active and the merge gate returns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Validate Existing Workflow Branches Before Reuse** (#1179): Require
+  positive approved-base ancestry evidence before resuming an existing item
+  branch.
+
 ### Fixed
 
 - **Sync tracker-closeout workflow** (#1304): Include the merge-time tracker

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -490,11 +490,13 @@ If the tracker is unavailable, log a warning and proceed — do not block advanc
 
    - Continue dispatching the implementation stage as if the item was `Plan Ready` (the pre-dispatch tracker status update, which ran earlier in this step and was a no-op because the status was already "In Development", will re-run for the corrected dispatch and advance the tracker back to `In Development`). The brief "Plan Ready" state between the stale reset and the new dispatch is intentional and transient — the orchestrator runs sequentially, so no concurrent observer will act on this intermediate value.
 
-4. **If either check returns non-zero** (branch or PR found): the item is genuinely in progress — do not reset the status. Resume from the existing branch or PR using `workflow-next-action.sh` (AC-8).
+4. **If either check returns non-zero** (branch or PR found): the item is genuinely in progress — do not reset the status. Before reusing a branch, complete the branch-reuse validation gate below. Only a `compatible` result may reach `workflow-next-action.sh` (AC-8).
 
 ### Pre-dispatch branch check
 
-Before dispatching any creator-stage agent, run all three checks below. An existing branch or active worktree means work already exists and should be resumed rather than restarted.
+Before dispatching any creator-stage agent, run all three checks below. An
+existing branch or active worktree means work may already exist, but a matching
+item identifier alone does not authorize reuse.
 
 ```bash
 git branch -r | grep "<branch-prefix>/<slug>"
@@ -509,7 +511,9 @@ git worktree list | grep "<branch-prefix>/<slug>"
 | Implement (Feature)     | `feature/[slug]`               |
 | Implement (Refactor)    | `refactor/[slug]`              |
 
-If any check returns a match: **do not re-dispatch**. Resume from the existing branch or PR with `workflow-next-action.sh`.
+If any check returns a match, record the exact candidate and **do not
+re-dispatch yet**. Continue through the nested-artifact guard and branch-reuse
+validation gate below before calling `workflow-next-action.sh`.
 
 ### Nested artifact guard before child dispatch
 
@@ -538,6 +542,42 @@ Set `ARTIFACT_REPO_ROOT` to the repository that owns the branch and PR being
 guarded. In `workflow_hub` mode, implementation artifacts live in the selected
 product checkout, not the hub checkout; hub-owned spec and plan artifacts keep
 using the hub repository root.
+
+### Existing-branch reuse validation
+
+After candidate discovery and a clean nested-artifact guard, validate the exact
+expected branch against the run's approved base:
+
+```bash
+./scripts/development-workflow/validate-branch-reuse.sh \
+  --issue "$ISSUE_NUMBER" \
+  --branch "<branch-prefix>/<slug>" \
+  --approved-base "$BASE_BRANCH" \
+  --repo-root "$ARTIFACT_REPO_ROOT" \
+  --json
+```
+
+The helper is read-only and does not fetch or mutate refs. Callers must refresh
+required refs before invoking it. Route its structured `RESULT` as follows:
+
+| Result | Required next action |
+| --- | --- |
+| `no_existing_branch` | Continue the fresh-branch path only when discovery also found no candidate. If a previously discovered candidate disappeared, stop as `reuse_verification_blocked`. |
+| `compatible` | Report the resolved base/candidate refs and tips, keep tracking divergence as separate diagnostic evidence, and resume with `workflow-next-action.sh --branch <branch>`. |
+| `incompatible` | Stop as `incompatible_reuse_blocked` before creator dispatch, file/Git mutation, PR/label mutation, or tracker mutation. Name the item, branch, approved base, failed ancestry evidence, and the helper's `HUMAN_ACTION`. |
+| `verification_blocked` | Stop as `reuse_verification_blocked` before mutation. Name the unavailable or ambiguous evidence and the helper's `HUMAN_ACTION`; do not report it as confirmed incompatibility. |
+
+Only positive evidence from
+`git merge-base --is-ancestor <approved-base-tip> <candidate-tip>` authorizes
+reuse. Local-versus-remote ahead/behind counts are diagnostic and never replace
+the approved-base decision. The runner must not automatically delete, reset,
+rebase, check out, force-push, or otherwise rewrite an incompatible or
+unverifiable branch. Any destructive cleanup or different recovery path
+requires a separate explicit human decision.
+
+Record one of `fresh_branch`, `compatible_reuse`,
+`incompatible_reuse_blocked`, or `reuse_verification_blocked` in the Work Item
+Runner summary.
 
 ### Integration-branch base override (sub-items with `integration-branch:<slug>` label)
 

--- a/scripts/development-workflow/tests/test-validate-branch-reuse.sh
+++ b/scripts/development-workflow/tests/test-validate-branch-reuse.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# test-validate-branch-reuse.sh - disposable Git coverage for branch reuse.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+VALIDATOR="$REPO_ROOT/scripts/development-workflow/validate-branch-reuse.sh"
+TMP_ROOT="$(mktemp -d)"
+REAL_GIT="$(command -v git)"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+cleanup() {
+  local status=$?
+  rm -rf "$TMP_ROOT"
+  case "$status" in
+    141) exit 0 ;;
+    *) exit "$status" ;;
+  esac
+}
+trap cleanup EXIT
+
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    printf 'PASS: %s\n' "$name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    printf "FAIL: %s - expected '%s', got '%s'\n" "$name" "$expected" "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_contains() {
+  local name="$1" expected="$2" actual="$3"
+  if grep -Fq -- "$expected" <<< "$actual"; then
+    printf 'PASS: %s\n' "$name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    printf "FAIL: %s - expected output to contain '%s'\n" "$name" "$expected"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+validator_output() {
+  local status output
+  set +e
+  output="$("$VALIDATOR" "$@" 2>&1)"
+  status=$?
+  set -e
+  printf '%s\n%s\n' "$status" "$output"
+}
+
+validator_output_with_path() {
+  local path_prefix="$1"
+  local status output
+  shift
+  set +e
+  output="$(PATH="$path_prefix:$PATH" "$VALIDATOR" "$@" 2>&1)"
+  status=$?
+  set -e
+  printf '%s\n%s\n' "$status" "$output"
+}
+
+body() {
+  tail -n +2 <<< "$1"
+}
+
+status_code() {
+  head -n 1 <<< "$1"
+}
+
+field() {
+  local key="$1" output="$2"
+  sed -n "s/^${key}=//p" <<< "$output" | head -n 1
+}
+
+make_repo() {
+  local name="$1"
+  local repo="$TMP_ROOT/$name/repo"
+  local origin="$TMP_ROOT/$name/origin.git"
+  mkdir -p "$TMP_ROOT/$name"
+  "$REAL_GIT" init -q --bare "$origin"
+  "$REAL_GIT" init -q -b develop "$repo"
+  "$REAL_GIT" -C "$repo" config user.email test@example.com
+  "$REAL_GIT" -C "$repo" config user.name Test
+  "$REAL_GIT" -C "$repo" commit -q --allow-empty -m "initial"
+  "$REAL_GIT" -C "$repo" remote add origin "$origin"
+  "$REAL_GIT" -C "$repo" push -q -u origin develop
+  printf '%s\n' "$repo"
+}
+
+make_compatible_local_branch() {
+  local repo="$1" branch="$2"
+  local parent tree commit
+  parent="$("$REAL_GIT" -C "$repo" rev-parse refs/remotes/origin/develop)"
+  tree="$("$REAL_GIT" -C "$repo" rev-parse "${parent}^{tree}")"
+  commit="$(printf 'candidate\n' | "$REAL_GIT" -C "$repo" commit-tree "$tree" -p "$parent")"
+  "$REAL_GIT" -C "$repo" update-ref "refs/heads/$branch" "$commit"
+}
+
+snapshot_repo() {
+  local repo="$1"
+  {
+    "$REAL_GIT" -C "$repo" show-ref | sort
+    "$REAL_GIT" -C "$repo" worktree list --porcelain
+    "$REAL_GIT" -C "$repo" symbolic-ref -q HEAD || true
+    "$REAL_GIT" -C "$repo" status --porcelain=v1
+  }
+}
+
+branch="feature/1179-stale-branch-reuse"
+
+repo="$(make_repo no-existing)"
+"$REAL_GIT" -C "$repo" branch feature/11790-lookalike
+"$REAL_GIT" -C "$repo" tag "backup-feature-1179-stale-branch-reuse"
+out="$(validator_output --issue 1179 --branch "$branch" --approved-base develop --repo-root "$repo")"
+run_test "no_existing_branch_exit_zero" "0" "$(status_code "$out")"
+run_test "no_existing_branch_uses_fresh_path" "no_existing_branch" "$(field RESULT "$(body "$out")")"
+run_contains "lookalike_refs_do_not_match" "No exact local, remote-tracking, or worktree-owned ref" "$(body "$out")"
+
+repo="$(make_repo compatible-local)"
+make_compatible_local_branch "$repo" "$branch"
+before="$(snapshot_repo "$repo")"
+out="$(validator_output --issue 1179 --branch "$branch" --approved-base develop --repo-root "$repo")"
+after="$(snapshot_repo "$repo")"
+run_test "compatible_local_exit_zero" "0" "$(status_code "$out")"
+run_test "compatible_local_branch_resumes" "compatible" "$(field RESULT "$(body "$out")")"
+run_test "compatible_local_source" "local" "$(field CANDIDATE_SOURCE "$(body "$out")")"
+run_test "compatible_local_validator_is_read_only" "$before" "$after"
+
+repo="$(make_repo compatible-remote)"
+make_compatible_local_branch "$repo" "$branch"
+"$REAL_GIT" -C "$repo" push -q origin "$branch"
+"$REAL_GIT" -C "$repo" branch -D "$branch" >/dev/null
+out="$(validator_output --issue 1179 --branch "$branch" --approved-base develop --repo-root "$repo")"
+run_test "compatible_remote_only_branch_resumes" "compatible" "$(field RESULT "$(body "$out")")"
+run_test "compatible_remote_only_source" "remote_only" "$(field CANDIDATE_SOURCE "$(body "$out")")"
+run_test "compatible_remote_only_tracking" "remote_only" "$(field TRACKING_STATE "$(body "$out")")"
+
+repo="$(make_repo compatible-worktree)"
+worktree_path="$TMP_ROOT/compatible-worktree/linked worktree"
+"$REAL_GIT" -C "$repo" worktree add -q -b "$branch" "$worktree_path" refs/remotes/origin/develop
+worktree_path="$(CDPATH='' cd -- "$worktree_path" && pwd -P)"
+before="$(snapshot_repo "$repo")"
+out="$(validator_output --issue 1179 --branch "$branch" --approved-base develop --repo-root "$repo")"
+after="$(snapshot_repo "$repo")"
+run_test "compatible_worktree_branch_resumes" "compatible" "$(field RESULT "$(body "$out")")"
+run_test "compatible_worktree_source" "worktree" "$(field CANDIDATE_SOURCE "$(body "$out")")"
+run_test "compatible_worktree_path" "$worktree_path" "$(field WORKTREE_PATH "$(body "$out")")"
+run_test "compatible_worktree_validator_is_read_only" "$before" "$after"
+
+repo="$(make_repo incompatible)"
+"$REAL_GIT" -C "$repo" branch "$branch" refs/remotes/origin/develop
+"$REAL_GIT" -C "$repo" commit -q --allow-empty -m "advance approved base"
+"$REAL_GIT" -C "$repo" push -q origin develop
+before="$(snapshot_repo "$repo")"
+out="$(validator_output --issue 1179 --branch "$branch" --approved-base develop --repo-root "$repo")"
+after="$(snapshot_repo "$repo")"
+run_test "incompatible_base_exit_one" "1" "$(status_code "$out")"
+run_test "incompatible_base_blocks" "incompatible" "$(field RESULT "$(body "$out")")"
+run_contains "incompatible_base_recovery_names_item" "item #1179" "$(body "$out")"
+run_contains "incompatible_base_recovery_forbids_automatic_rewrite" "do not delete, reset, rebase, or force-push automatically" "$(body "$out")"
+run_test "incompatible_validator_is_read_only" "$before" "$after"
+
+repo="$(make_repo stale-tracking)"
+make_compatible_local_branch "$repo" "$branch"
+"$REAL_GIT" -C "$repo" push -q origin "$branch"
+remote_tip="$("$REAL_GIT" -C "$repo" rev-parse "refs/remotes/origin/$branch")"
+tree="$("$REAL_GIT" -C "$repo" rev-parse "${remote_tip}^{tree}")"
+local_tip="$(printf 'local ahead\n' | "$REAL_GIT" -C "$repo" commit-tree "$tree" -p "$remote_tip")"
+"$REAL_GIT" -C "$repo" update-ref "refs/heads/$branch" "$local_tip"
+out="$(validator_output --issue 1179 --branch "$branch" --approved-base develop --repo-root "$repo")"
+run_test "stale_tracking_ref_is_diagnostic" "compatible" "$(field RESULT "$(body "$out")")"
+run_test "stale_tracking_state" "local_ahead" "$(field TRACKING_STATE "$(body "$out")")"
+run_test "stale_tracking_ahead_count" "1" "$(field AHEAD "$(body "$out")")"
+
+repo="$(make_repo missing-base)"
+make_compatible_local_branch "$repo" "$branch"
+out="$(validator_output --issue 1179 --branch "$branch" --approved-base develop-missing --repo-root "$repo")"
+run_test "missing_base_exit_three" "3" "$(status_code "$out")"
+run_test "missing_base_blocks" "verification_blocked" "$(field RESULT "$(body "$out")")"
+run_contains "missing_base_recovery" "Restore or fetch the approved base" "$(body "$out")"
+
+repo="$(make_repo ambiguous-worktree)"
+make_compatible_local_branch "$repo" "$branch"
+mock_bin="$TMP_ROOT/ambiguous-worktree/bin"
+mkdir -p "$mock_bin"
+cat > "$mock_bin/git" <<'MOCK_GIT'
+#!/usr/bin/env bash
+if [ "$#" -ge 5 ] &&
+   [ "$1" = "-C" ] &&
+   [ "$3" = "worktree" ] &&
+   [ "$4" = "list" ] &&
+   [ "$5" = "--porcelain" ]; then
+  printf 'worktree /tmp/first\nHEAD deadbeef\nbranch refs/heads/feature/1179-stale-branch-reuse\n\n'
+  printf 'worktree /tmp/second\nHEAD deadbeef\nbranch refs/heads/feature/1179-stale-branch-reuse\n\n'
+  exit 0
+fi
+exec "$REAL_GIT" "$@"
+MOCK_GIT
+chmod +x "$mock_bin/git"
+export REAL_GIT
+out="$(validator_output_with_path "$mock_bin" --issue 1179 --branch "$branch" --approved-base develop --repo-root "$repo")"
+run_test "ambiguous_ref_exit_three" "3" "$(status_code "$out")"
+run_test "ambiguous_ref_blocks" "verification_blocked" "$(field RESULT "$(body "$out")")"
+run_contains "ambiguous_ref_reason" "ambiguously registered to multiple worktrees" "$(body "$out")"
+
+repo="$(make_repo ancestry-failure)"
+make_compatible_local_branch "$repo" "$branch"
+mock_bin="$TMP_ROOT/ancestry-failure/bin"
+mkdir -p "$mock_bin"
+cat > "$mock_bin/git" <<'MOCK_GIT'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = "--is-ancestor" ]; then
+    exit 42
+  fi
+done
+exec "$REAL_GIT" "$@"
+MOCK_GIT
+chmod +x "$mock_bin/git"
+out="$(validator_output_with_path "$mock_bin" --issue 1179 --branch "$branch" --approved-base develop --repo-root "$repo")"
+run_test "ancestry_query_failure_exit_three" "3" "$(status_code "$out")"
+run_test "ancestry_query_failure_blocks" "verification_blocked" "$(field RESULT "$(body "$out")")"
+run_contains "ancestry_query_failure_reason" "Ancestry query failed" "$(body "$out")"
+
+repo="$(make_repo structured-output)"
+make_compatible_local_branch "$repo" "$branch"
+out="$(validator_output --issue 1179 --branch "$branch" --approved-base develop --repo-root "$repo" --json)"
+shell_result="$(field RESULT "$(body "$out")")"
+json_record="$(sed -n '/^{/,$p' <<< "$(body "$out")")"
+json_result="$(jq -r '.result' <<< "$json_record")"
+run_test "shell_and_json_outputs_agree" "$shell_result" "$json_result"
+run_test "json_item" "1179" "$(jq -r '.item' <<< "$json_record")"
+run_test "json_candidate_tip_matches_shell" "$(field CANDIDATE_TIP "$(body "$out")")" "$(jq -r '.candidate.tip' <<< "$json_record")"
+run_test "json_human_action_matches_shell" "$(field HUMAN_ACTION "$(body "$out")")" "$(jq -r '.humanAction' <<< "$json_record")"
+
+printf '\nResults: %s passed, %s failed\n' "$PASS_COUNT" "$FAIL_COUNT"
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/development-workflow/tests/test-validate-branch-reuse.sh
+++ b/scripts/development-workflow/tests/test-validate-branch-reuse.sh
@@ -113,6 +113,19 @@ snapshot_repo() {
 
 branch="feature/1179-stale-branch-reuse"
 
+repo="$(make_repo invalid-input)"
+out="$(validator_output --issue 1179 --branch "" --approved-base develop --repo-root "$repo")"
+run_test "empty_branch_rejected" "2" "$(status_code "$out")"
+run_contains "empty_branch_has_clear_error" "missing value for --branch" "$(body "$out")"
+out="$(validator_output --issue 1179 --branch "   " --approved-base develop --repo-root "$repo")"
+run_test "whitespace_branch_rejected" "2" "$(status_code "$out")"
+run_contains "whitespace_branch_has_clear_error" "invalid workflow branch name" "$(body "$out")"
+out="$(validator_output --issue 0 --branch feature/0-invalid --approved-base develop --repo-root "$repo")"
+run_test "zero_issue_rejected" "2" "$(status_code "$out")"
+out="$(validator_output --issue 1 --branch feature/1-minimum --approved-base develop --repo-root "$repo")"
+run_test "minimum_issue_accepted" "0" "$(status_code "$out")"
+run_test "minimum_issue_fresh_path" "no_existing_branch" "$(field RESULT "$(body "$out")")"
+
 repo="$(make_repo no-existing)"
 "$REAL_GIT" -C "$repo" branch feature/11790-lookalike
 "$REAL_GIT" -C "$repo" tag "backup-feature-1179-stale-branch-reuse"

--- a/scripts/development-workflow/validate-branch-reuse.sh
+++ b/scripts/development-workflow/validate-branch-reuse.sh
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+# validate-branch-reuse.sh
+#
+# Read-only validation for reusing an existing workflow branch. Compatibility
+# requires positive ancestry evidence from the explicitly approved base.
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: validate-branch-reuse.sh --issue <number> --branch <branch> --approved-base <branch> --repo-root <path> [options]
+
+Options:
+  --remote <name>  Remote used for ref resolution (default: origin)
+  --json           Append a JSON record after the stable key=value output
+  --help           Show this help
+USAGE
+}
+
+require_value() {
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ]; then
+    printf 'ERROR: missing value for %s\n' "${1:-<unknown>}" >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+issue=""
+branch=""
+approved_base=""
+repo_root=""
+remote="origin"
+json_output="false"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --issue)
+      require_value "$@"
+      issue="${2:-}"
+      shift 2
+      ;;
+    --branch)
+      require_value "$@"
+      branch="${2:-}"
+      shift 2
+      ;;
+    --approved-base)
+      require_value "$@"
+      approved_base="${2:-}"
+      shift 2
+      ;;
+    --repo-root)
+      require_value "$@"
+      repo_root="${2:-}"
+      shift 2
+      ;;
+    --remote)
+      require_value "$@"
+      remote="${2:-}"
+      shift 2
+      ;;
+    --json)
+      json_output="true"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'ERROR: unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$issue" ] || [ -z "$branch" ] || [ -z "$approved_base" ] || [ -z "$repo_root" ]; then
+  usage >&2
+  exit 2
+fi
+
+case "$issue" in
+  *[!0-9]*|"")
+    printf 'ERROR: --issue must be a positive numeric identifier\n' >&2
+    exit 2
+    ;;
+esac
+
+if [ "$issue" -le 0 ]; then
+  printf 'ERROR: --issue must be a positive numeric identifier\n' >&2
+  exit 2
+fi
+
+if ! git check-ref-format --branch "$branch" >/dev/null 2>&1; then
+  printf 'ERROR: invalid workflow branch name: %s\n' "$branch" >&2
+  exit 2
+fi
+
+if ! git check-ref-format --branch "$approved_base" >/dev/null 2>&1; then
+  printf 'ERROR: invalid approved base branch name: %s\n' "$approved_base" >&2
+  exit 2
+fi
+
+if ! git check-ref-format --branch "$remote" >/dev/null 2>&1; then
+  printf 'ERROR: invalid remote name: %s\n' "$remote" >&2
+  exit 2
+fi
+
+if [ ! -d "$repo_root" ]; then
+  printf 'ERROR: repository root does not exist: %s\n' "$repo_root" >&2
+  exit 2
+fi
+
+repo_root="$(CDPATH='' cd -- "$repo_root" && pwd -P)"
+if ! git -C "$repo_root" rev-parse --git-dir >/dev/null 2>&1; then
+  printf 'ERROR: repository root is not a Git repository: %s\n' "$repo_root" >&2
+  exit 2
+fi
+
+if [ "$json_output" = "true" ] && ! command -v jq >/dev/null 2>&1; then
+  printf 'ERROR: jq is required for --json output\n' >&2
+  exit 2
+fi
+
+local_candidate_ref="refs/heads/$branch"
+remote_candidate_ref="refs/remotes/$remote/$branch"
+local_base_ref="refs/heads/$approved_base"
+remote_base_ref="refs/remotes/$remote/$approved_base"
+
+result=""
+reason=""
+human_action=""
+candidate_source=""
+candidate_ref=""
+candidate_tip=""
+base_source=""
+base_ref=""
+base_tip=""
+worktree_path=""
+remote_ref=""
+remote_tip=""
+tracking_state="not_applicable"
+ahead=""
+behind=""
+exit_code=0
+
+ref_state() {
+  local ref="$1"
+  local status
+  git -C "$repo_root" show-ref --verify --quiet "$ref"
+  status=$?
+  case "$status" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) return 2 ;;
+  esac
+}
+
+resolve_commit() {
+  local ref="$1"
+  git -C "$repo_root" rev-parse --verify "${ref}^{commit}" 2>/dev/null
+}
+
+emit_output() {
+  printf 'ITEM=%s\n' "$issue"
+  printf 'BRANCH=%s\n' "$branch"
+  printf 'APPROVED_BASE=%s\n' "$approved_base"
+  printf 'REMOTE=%s\n' "$remote"
+  printf 'REPO_ROOT=%s\n' "$repo_root"
+  printf 'RESULT=%s\n' "$result"
+  printf 'REASON=%s\n' "$reason"
+  printf 'CANDIDATE_SOURCE=%s\n' "$candidate_source"
+  printf 'CANDIDATE_REF=%s\n' "$candidate_ref"
+  printf 'CANDIDATE_TIP=%s\n' "$candidate_tip"
+  printf 'BASE_SOURCE=%s\n' "$base_source"
+  printf 'BASE_REF=%s\n' "$base_ref"
+  printf 'BASE_TIP=%s\n' "$base_tip"
+  printf 'WORKTREE_PATH=%s\n' "$worktree_path"
+  printf 'REMOTE_REF=%s\n' "$remote_ref"
+  printf 'REMOTE_TIP=%s\n' "$remote_tip"
+  printf 'TRACKING_STATE=%s\n' "$tracking_state"
+  printf 'AHEAD=%s\n' "$ahead"
+  printf 'BEHIND=%s\n' "$behind"
+  printf 'HUMAN_ACTION=%s\n' "$human_action"
+
+  if [ "$json_output" = "true" ]; then
+    jq -n \
+      --arg item "$issue" \
+      --arg branch "$branch" \
+      --arg approvedBase "$approved_base" \
+      --arg remote "$remote" \
+      --arg repoRoot "$repo_root" \
+      --arg result "$result" \
+      --arg reason "$reason" \
+      --arg candidateSource "$candidate_source" \
+      --arg candidateRef "$candidate_ref" \
+      --arg candidateTip "$candidate_tip" \
+      --arg baseSource "$base_source" \
+      --arg baseRef "$base_ref" \
+      --arg baseTip "$base_tip" \
+      --arg worktreePath "$worktree_path" \
+      --arg remoteRef "$remote_ref" \
+      --arg remoteTip "$remote_tip" \
+      --arg trackingState "$tracking_state" \
+      --arg ahead "$ahead" \
+      --arg behind "$behind" \
+      --arg humanAction "$human_action" \
+      '{
+        item: $item,
+        branch: $branch,
+        approvedBase: $approvedBase,
+        remote: $remote,
+        repoRoot: $repoRoot,
+        result: $result,
+        reason: $reason,
+        candidate: {
+          source: $candidateSource,
+          ref: $candidateRef,
+          tip: $candidateTip,
+          worktreePath: $worktreePath
+        },
+        base: {
+          source: $baseSource,
+          ref: $baseRef,
+          tip: $baseTip
+        },
+        tracking: {
+          remoteRef: $remoteRef,
+          remoteTip: $remoteTip,
+          state: $trackingState,
+          ahead: $ahead,
+          behind: $behind
+        },
+        humanAction: $humanAction
+      }'
+  fi
+}
+
+set +e
+ref_state "$remote_base_ref"
+remote_base_status=$?
+ref_state "$local_base_ref"
+local_base_status=$?
+ref_state "$local_candidate_ref"
+local_candidate_status=$?
+ref_state "$remote_candidate_ref"
+remote_candidate_status=$?
+set -e
+
+for ref_status in \
+  "$remote_base_status" \
+  "$local_base_status" \
+  "$local_candidate_status" \
+  "$remote_candidate_status"; do
+  if [ "$ref_status" -eq 2 ]; then
+    result="verification_blocked"
+    reason="Git ref discovery failed while validating branch reuse"
+    human_action="Restore readable repository ref state for item #$issue and retry the branch-reuse validation."
+    exit_code=3
+    emit_output
+    exit "$exit_code"
+  fi
+done
+
+if [ "$remote_base_status" -eq 0 ]; then
+  base_source="remote"
+  base_ref="$remote_base_ref"
+elif [ "$local_base_status" -eq 0 ]; then
+  base_source="local"
+  base_ref="$local_base_ref"
+else
+  result="verification_blocked"
+  reason="Approved base '$approved_base' could not be resolved from '$remote_base_ref' or '$local_base_ref'"
+  human_action="Restore or fetch the approved base '$approved_base' for item #$issue, then retry without substituting another base."
+  exit_code=3
+  emit_output
+  exit "$exit_code"
+fi
+
+if ! base_tip="$(resolve_commit "$base_ref")" || [ -z "$base_tip" ]; then
+  result="verification_blocked"
+  reason="Approved base ref '$base_ref' did not resolve to a commit"
+  human_action="Repair the approved base '$approved_base' for item #$issue and retry branch-reuse validation."
+  exit_code=3
+  emit_output
+  exit "$exit_code"
+fi
+
+if [ "$local_candidate_status" -eq 0 ]; then
+  candidate_source="local"
+  candidate_ref="$local_candidate_ref"
+elif [ "$remote_candidate_status" -eq 0 ]; then
+  candidate_source="remote_only"
+  candidate_ref="$remote_candidate_ref"
+else
+  result="no_existing_branch"
+  reason="No exact local, remote-tracking, or worktree-owned ref exists for '$branch'"
+  human_action="Continue the canonical fresh-branch path for item #$issue from approved base '$approved_base'."
+  emit_output
+  exit 0
+fi
+
+if ! candidate_tip="$(resolve_commit "$candidate_ref")" || [ -z "$candidate_tip" ]; then
+  result="verification_blocked"
+  reason="Candidate ref '$candidate_ref' did not resolve to a commit"
+  human_action="Restore unambiguous commit evidence for branch '$branch' on item #$issue and retry."
+  exit_code=3
+  emit_output
+  exit "$exit_code"
+fi
+
+if [ "$local_candidate_status" -eq 0 ]; then
+  worktree_output=""
+  if ! worktree_output="$(git -C "$repo_root" worktree list --porcelain 2>/dev/null)"; then
+    result="verification_blocked"
+    reason="Registered worktree state could not be read for local branch '$branch'"
+    human_action="Restore readable worktree metadata for item #$issue and retry branch-reuse validation."
+    exit_code=3
+    emit_output
+    exit "$exit_code"
+  fi
+
+  worktree_paths="$(
+    awk -v expected_ref="$local_candidate_ref" '
+      function flush_entry() {
+        if (path != "" && ref == expected_ref) {
+          print path
+        }
+      }
+      /^worktree / {
+        flush_entry()
+        path = substr($0, 10)
+        ref = ""
+        next
+      }
+      /^branch / {
+        ref = substr($0, 8)
+        next
+      }
+      END {
+        flush_entry()
+      }
+    ' <<EOF
+$worktree_output
+EOF
+  )"
+  worktree_count="$(awk 'NF { count++ } END { print count + 0 }' <<< "$worktree_paths")"
+  if [ "$worktree_count" -gt 1 ]; then
+    result="verification_blocked"
+    reason="Candidate branch '$branch' is ambiguously registered to multiple worktrees"
+    human_action="Correct ambiguous worktree ownership for item #$issue and retry without deleting or rewriting the branch automatically."
+    exit_code=3
+    emit_output
+    exit "$exit_code"
+  fi
+  if [ "$worktree_count" -eq 1 ]; then
+    worktree_path="$worktree_paths"
+    candidate_source="worktree"
+  fi
+fi
+
+if [ "$remote_candidate_status" -eq 0 ]; then
+  remote_ref="$remote_candidate_ref"
+  if ! remote_tip="$(resolve_commit "$remote_ref")" || [ -z "$remote_tip" ]; then
+    result="verification_blocked"
+    reason="Remote-tracking ref '$remote_ref' did not resolve to a commit"
+    human_action="Restore readable remote-tracking evidence for item #$issue and retry."
+    exit_code=3
+    emit_output
+    exit "$exit_code"
+  fi
+fi
+
+if [ "$local_candidate_status" -eq 0 ] && [ "$remote_candidate_status" -eq 0 ]; then
+  divergence=""
+  if ! divergence="$(git -C "$repo_root" rev-list --left-right --count "$remote_tip...$candidate_tip" 2>/dev/null)"; then
+    result="verification_blocked"
+    reason="Local-versus-remote divergence could not be calculated for '$branch'"
+    human_action="Restore readable branch history for item #$issue and retry; do not infer base compatibility from tracking state."
+    exit_code=3
+    emit_output
+    exit "$exit_code"
+  fi
+  behind="$(awk '{ print $1 }' <<< "$divergence")"
+  ahead="$(awk '{ print $2 }' <<< "$divergence")"
+  if [ "$ahead" -eq 0 ] && [ "$behind" -eq 0 ]; then
+    tracking_state="equal"
+  elif [ "$ahead" -gt 0 ] && [ "$behind" -eq 0 ]; then
+    tracking_state="local_ahead"
+  elif [ "$ahead" -eq 0 ] && [ "$behind" -gt 0 ]; then
+    tracking_state="local_behind"
+  else
+    tracking_state="diverged"
+  fi
+elif [ "$local_candidate_status" -eq 0 ]; then
+  tracking_state="remote_missing"
+else
+  tracking_state="remote_only"
+  ahead="0"
+  behind="0"
+fi
+
+set +e
+git -C "$repo_root" merge-base --is-ancestor "$base_tip" "$candidate_tip" >/dev/null 2>&1
+ancestry_status=$?
+set -e
+
+case "$ancestry_status" in
+  0)
+    result="compatible"
+    reason="Approved base tip '$base_tip' is an ancestor of candidate tip '$candidate_tip'"
+    human_action="Resume the canonical workflow for item #$issue on branch '$branch'; treat tracking divergence only as diagnostic evidence."
+    exit_code=0
+    ;;
+  1)
+    result="incompatible"
+    reason="Approved base tip '$base_tip' is not an ancestor of candidate tip '$candidate_tip'"
+    human_action="Inspect and preserve or manually remove branch '$branch' for item #$issue, then retry from approved base '$approved_base'; do not delete, reset, rebase, or force-push automatically."
+    exit_code=1
+    ;;
+  *)
+    result="verification_blocked"
+    reason="Ancestry query failed for approved base '$base_ref' and candidate '$candidate_ref'"
+    human_action="Restore readable Git history for item #$issue and retry, or request an explicit human recovery decision."
+    exit_code=3
+    ;;
+esac
+
+emit_output
+exit "$exit_code"


### PR DESCRIPTION
## Summary

Add a read-only, fail-closed branch-reuse validator so `/run-item` requires positive approved-base ancestry evidence before resuming an existing item branch. The validator distinguishes compatibility from local/remote tracking divergence and covers local, remote-only, and worktree-owned candidates.

Protocol 91 and the Codex, Claude, and Cursor runner surfaces now route the same four outcomes: fresh branch, compatible reuse, incompatible reuse blocked, and verification blocked.

## Approved artifacts

- Spec: `docs/specs/developments/20260723110011_1179-stale-branch-reuse/1_1179-stale-branch-reuse_specs.md`
- Plan: `docs/specs/developments/20260723110011_1179-stale-branch-reuse/2_1179-stale-branch-reuse_implementation-plan.md`
- Smoke runbook: `docs/testing/workflow/1179-stale-branch-reuse.smoke-test.md`

## Verification

- `bash scripts/development-workflow/tests/test-validate-branch-reuse.sh` — 42 passed
- `bash scripts/development-workflow/tests/test-run-nested-artifact-guard.sh` — 66 passed
- `bash scripts/development-workflow/tests/test-worktree-resume-preflight.sh` — 14 passed
- `shellcheck scripts/development-workflow/validate-branch-reuse.sh scripts/development-workflow/tests/test-validate-branch-reuse.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- Markdownlint across all changed Markdown surfaces — 0 errors
- Markdown heuristic lint and CHANGELOG duplicate/link-reference checks — passed

## Pre-submission self-review

- Stale markers: none.
- Sibling/caller consistency: verified across Protocol 91 and all seven planned runner skill/agent/command mirrors.
- Coverage: all 12 spec acceptance criteria are addressed; the harness covers fresh, compatible local/remote/worktree, incompatible, stale-tracking, missing/ambiguous/failed-query, structured-output, read-only, and invalid-input paths.
- Branch-stage discipline: verified; implementation files are on `feature/1179-stale-branch-reuse`.
- Complex gate matrix: applicable. The approved spec and plan contain the full consistency matrix; Protocol 91's `Existing-branch reuse validation` table implements the same inputs, outcomes, and required next actions across the mirrored surfaces.

## Test Harness Coverage Checklist

- Empty, whitespace-only, zero/minimum boundary, negative, and path-with-spaces cases: covered.
- Missing required environment variables: not applicable; the validator has no required environment variables and receives all required context through validated flags.
- Concurrent execution: safe by design; the validator is read-only, has no shared writable state, and the harness uses isolated temporary repositories.
- Single EXIT trap: verified.
- `BASH_SOURCE`/sourced ordering: not applicable; the harness executes the validator and does not source it.

## Script-Accuracy Self-Check

Script: `scripts/development-workflow/validate-branch-reuse.sh`

- Required flags and optional `--remote`/`--json`: verified against argument parsing and usage text.
- Results `no_existing_branch`, `compatible`, `incompatible`, and `verification_blocked`: verified against emitted `RESULT=` assignments.
- Exit codes 0, 1, 2, and 3: verified against the result and invocation paths.
- Stable shell keys and JSON fields: verified by `shell_and_json_outputs_agree`.
- Read-only behavior and local/remote divergence diagnostics: verified by repository snapshots and dedicated tracking tests.

## Deviations

None.

## CHANGELOG

`Added`: Require positive approved-base ancestry evidence before resuming an existing item branch.

Closes #1179

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when item runs may resume vs. stop on existing branches across orchestration paths; mistakes could block legitimate resumes or allow wrong-base work, though the validator is read-only and forbids automatic branch rewrites.
> 
> **Overview**
> Adds a **read-only** `validate-branch-reuse.sh` gate so `/run-item` only resumes an existing item branch when `git merge-base --is-ancestor` proves the run’s **approved base** is an ancestor of the candidate tip. The helper emits `no_existing_branch`, `compatible`, `incompatible`, or `verification_blocked` (plus optional JSON); local/remote ahead-behind is **diagnostic only** and never substitutes for that ancestry check. Runners must **not** auto-delete, reset, rebase, check out, or force-push blocked branches.
> 
> **Protocol 91** and the mirrored **Codex, Claude, and Cursor** run-item surfaces now run this validator after candidate discovery and a clean nested-artifact guard; only `compatible` may call `workflow-next-action.sh`, while `no_existing_branch` stays on the fresh-branch path. A disposable Git test harness exercises compatible/incompatible/blocked paths and read-only behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a195d26744760a2060cc934596779c821394ba21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->