### PR TITLE
fix(workflow): use Bugbot for ready reviews

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -51,7 +51,7 @@ review:
     # Ordered list of GitHub/App/CLI reviewers that run only after draft gates
     # are clean and the PR has been converted with `gh pr ready`.
     github:
-      - haystack
+      - bugbot
   #
   # Configurable codex-github options (set via env vars or script flags to codex-github-reviewer.sh):
   #   CODEX_GITHUB_TRIGGER_PHRASE  — trigger phrase sent to the bot (default: "@codex review")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Reliable ready-phase PR review** (#1348): Use Cursor Bugbot instead of
+  Haystack for the repository's default ready-phase automated reviewer.
 - **Sync tracker-closeout workflow** (#1304): Include the merge-time tracker
   workflow in template-sync review so downstream projects can adopt graduation
   closeout together with its validation helpers.


### PR DESCRIPTION
## Summary

- replace Haystack with Cursor Bugbot in the repository default ready-phase reviewer configuration
- preserve PR-Agent as the draft-phase reviewer and retain optional Haystack platform support
- update the local gitignored reviewer override so this checkout uses Bugbot immediately

## Fast Track routing evidence

- Cross-layer result: no multi-layer signal; this changes one reviewer selector and its changelog entry
- Primary entity: `review.on_ready.github`; 1 tracked configuration occurrence changed
- External-system result: preflight passed — Cursor Bugbot completed PR #1346 in 1m38s with zero blocking findings or suggestions

## Verification

- `test-workflow-config-resolver.sh`: 74 passed
- `test-pr-review-loop.sh`: 309 passed
- `markdownlint-cli2 CHANGELOG.md`: clean
- markdown heuristic lint: clean
- changelog duplicate-header/link checks: clean
- `validate-workflow-config.sh`: clean
- `git diff --check`: clean

## Pre-submission self-review

Stale markers: none. Sibling/caller consistency: verified; Bugbot is already supported and documented, while Haystack remains an optional platform. Coverage: issue brief fully addressed. Complex workflow decision-gate matrix: not applicable because this changes provider selection without changing gate behavior.

Closes #1348

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only swap of the default ready-phase reviewer; no script or gate logic changes, and Haystack remains optional.
> 
> **Overview**
> **Ready-phase reviewer default** changes in `.ai-dev-workflow.yaml`: `review.on_ready.github` now lists **`bugbot`** instead of **`haystack`**, so Step 7 runs Cursor Bugbot only after draft gates pass and the PR is marked ready.
> 
> **Draft-phase config is unchanged** — `review.on_draft.github` still uses **PR-Agent**. Haystack stays a supported platform in docs and `pr-review-loop.sh`; it is no longer the template default for the ready phase.
> 
> **CHANGELOG** adds an `[Unreleased]` **Fixed** entry for **#1348**, noting the switch is intended to make ready-phase automated review more reliable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29c6be96043dec21e2dec882d3d0c20364d2c855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->