### PR TITLE
fix(review): recognize Bugbot clean review wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Bugbot clean-review parsing** (#1350): Recognize Bugbot's current
+  no-new-issues review template without hiding mixed messages that contain
+  blocking finding markers.
 - **Reliable ready-phase PR review** (#1348): Use Cursor Bugbot instead of
   Haystack for the repository's default ready-phase automated reviewer.
 - **Sync tracker-closeout workflow** (#1304): Include the merge-time tracker

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2556,6 +2556,22 @@ else
 fi
 run_test "bugbot_clean_phrase_is_non_blocking" "clean" "$actual"
 
+bugbot_current_clean_body=$'<!-- BUGBOT_REVIEW -->\n✅ Bugbot reviewed your changes and found no new issues!\n\n_Comment `@cursor review` or `bugbot run` to trigger another review on this PR_\n\n<sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a195d26744760a2060cc934596779c821394ba21. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>'
+if is_bugbot_clean_review "$bugbot_current_clean_body"; then
+  actual="clean"
+else
+  actual="blocking"
+fi
+run_test "bugbot_current_clean_review_is_non_blocking" "clean" "$actual"
+
+bugbot_current_mixed_body="$bugbot_current_clean_body"$'\n\n**Medium Severity**\n\n<!-- BUGBOT_BUG_ID: abc123 -->'
+if is_bugbot_clean_review "$bugbot_current_mixed_body"; then
+  actual="clean"
+else
+  actual="blocking"
+fi
+run_test "bugbot_current_finding_markers_override_clean_phrase" "blocking" "$actual"
+
 bugbot_mixed_body=$'Cursor Bugbot found no issues in this pull request.\n\n**High Severity**\n\n<!-- BUGBOT_BUG_ID: abc123 -->'
 if is_bugbot_clean_review "$bugbot_mixed_body"; then
   actual="clean"
@@ -2587,7 +2603,7 @@ else
   actual="blocking"
 fi
 run_test "bugbot_same_line_mixed_phrase_is_blocking" "blocking" "$actual"
-unset bugbot_clean_body bugbot_mixed_body bugbot_multiline_body bugbot_same_line_severity_body bugbot_same_line_mixed_body actual
+unset bugbot_clean_body bugbot_current_clean_body bugbot_current_mixed_body bugbot_mixed_body bugbot_multiline_body bugbot_same_line_severity_body bugbot_same_line_mixed_body actual
 
 if is_bugbot_disabled_message "Bugbot is disabled for this repository."; then
   actual="disabled"

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -394,10 +394,13 @@ is_bugbot_clean_review() {
   local body="$1"
   local line
   local normalized_line
-  local non_empty_count=0
+  local reviewed_commit
+  local review_footer_prefix='<sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit '
+  local review_footer_suffix='. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>'
+  local saw_clean_phrase=0
 
   case "$body" in
-    *BUGBOT_BUG_ID*|*BUGBOT_REVIEW*|*"LOCATIONS START"*|*"DESCRIPTION START"*|*"Triggered by project rule"*|*'**High Severity**'*|*'**Medium Severity**'*|*'**Low Severity**'*)
+    *BUGBOT_BUG_ID*|*"LOCATIONS START"*|*"DESCRIPTION START"*|*"Triggered by project rule"*|*'**High Severity**'*|*'**Medium Severity**'*|*'**Low Severity**'*)
       return 1
       ;;
   esac
@@ -411,17 +414,28 @@ is_bugbot_clean_review() {
     normalized_line="${normalized_line#"${normalized_line%%[![:space:]]*}"}"
     normalized_line="${normalized_line%"${normalized_line##*[![:space:]]}"}"
     [ -z "$normalized_line" ] && continue
-    non_empty_count=$((non_empty_count + 1))
-    if [ "$non_empty_count" -gt 1 ]; then
-      return 1
-    fi
+    case "$normalized_line" in
+      "Cursor Bugbot found no new issues in this pull request."|"Cursor Bugbot found no potential issues in this pull request."|"Cursor Bugbot found no issues in this pull request."|"✅ Bugbot reviewed your changes and found no new issues!")
+        [ "$saw_clean_phrase" -eq 0 ] || return 1
+        saw_clean_phrase=1
+        continue
+        ;;
+      '<!-- BUGBOT_REVIEW -->'|'_Comment `@cursor review` or `bugbot run` to trigger another review on this PR_')
+        continue
+        ;;
+    esac
+    case "$normalized_line" in
+      "$review_footer_prefix"*"$review_footer_suffix")
+        reviewed_commit="${normalized_line#"$review_footer_prefix"}"
+        reviewed_commit="${reviewed_commit%"$review_footer_suffix"}"
+        if [[ "$reviewed_commit" =~ ^[0-9a-f]{40}$ ]]; then
+          continue
+        fi
+        ;;
+    esac
+    return 1
   done <<< "$body"
-  case "$normalized_line" in
-    "Cursor Bugbot found no new issues in this pull request."|"Cursor Bugbot found no potential issues in this pull request."|"Cursor Bugbot found no issues in this pull request.")
-      return 0
-      ;;
-  esac
-  return 1
+  [ "$saw_clean_phrase" -eq 1 ]
 }
 
 is_bugbot_disabled_message() {


### PR DESCRIPTION
## Summary

- recognize Bugbot’s current structured no-new-issues review body
- keep unknown or mixed finding content fail-closed
- cover the exact live review template and severity-marker override

## Validation

- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` (311 passed)
- `shellcheck --severity=warning scripts/development-workflow/workflow-lib.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- changelog Markdown and duplicate-header checks
- `git diff --check`

Closes #1350

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to Bugbot comment classification in workflow shell helpers with dedicated regression tests; no auth, data, or merge-path changes.
> 
> **Overview**
> **Bugbot clean-review detection** in `workflow-lib.sh` is reworked so the PR review loop no longer misclassifies Cursor Bugbot’s current structured “no new issues” body as blocking.
> 
> `is_bugbot_clean_review` now walks normalized lines instead of requiring a single non-empty line. It accepts the legacy one-liners, the ✅ “reviewed your changes” phrase, `<!-- BUGBOT_REVIEW -->`, the re-review hint line, and the standard “Reviewed by Cursor Bugbot for commit …” footer when the SHA is valid. **`<!-- BUGBOT_REVIEW -->` is no longer an automatic blocker** in the early body scan—that marker can appear on clean reviews.
> 
> **Fail-closed behavior is unchanged** for `BUGBOT_BUG_ID`, severity labels, location/description blocks, and “found N potential issue” wording. Tests cover the live template, a clean-only case, and a mixed body where severity markers must still win over the clean phrase. CHANGELOG documents the fix (#1350).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13dd886cac695005a55bde9fd21b2dada1f2e944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->