### PR TITLE
feat(tracker): read native GitHub issue types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Native GitHub Issue Type classification** (#1280): Recognize native Issue
+  Types while preserving configured and custom-field precedence.
 - **Handle Haystack large-PR analysis skips** (#1311): Recognize authoritative current-head file-limit declines as terminal Haystack skips while preserving other reviewer gates and durable loop history.
 - **Bugbot clean-review parsing** (#1350): Recognize Bugbot's current
   no-new-issues review template without hiding mixed messages that contain

--- a/docs/workflow/development-workflow/integrations/github-projects.md
+++ b/docs/workflow/development-workflow/integrations/github-projects.md
@@ -200,8 +200,10 @@ list_open_workflow_type_issues
 
 `get_tracker_type_for_issue` and `update_tracker_type_best_effort` use the same
 targeted `repository.issue(...).projectItems` lookup as the Status helpers.
-The field metadata lookup honors `issue_tracker.custom_fields.type_field`, then
-falls back to `Custom Type`, `CustomType`, and `Type`.
+The targeted Type read honors `issue_tracker.custom_fields.type_field`, then
+GitHub's native Issue Type, then `Custom Type`, `CustomType`, and `Type`.
+Type writes remain limited to configured project fields; this does not add
+native Issue Type mutation support.
 `list_open_workflow_type_issues` fetches open issues first and then
 cross-references a single project item-list result, so callers do not perform
 one full-board scan per issue.

--- a/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+++ b/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
@@ -123,6 +123,22 @@ JSON
 	          cat <<'JSON'
 	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1},"status":{"name":"Spec Ready"},"configuredType":{"name":"Workflow"},"customType":{"name":"Bug"},"type":{"name":"Bug"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
 JSON
+	        elif [ "${MOCK_PROJECT_ITEM_MODE:-existing}" = "native_type_only" ]; then
+	          cat <<'JSON'
+	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1},"status":{"name":"Spec Ready"},"content":{"issueType":{"name":"Feature"}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
+	        elif [ "${MOCK_PROJECT_ITEM_MODE:-existing}" = "native_with_custom_type" ]; then
+	          cat <<'JSON'
+	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1},"status":{"name":"Spec Ready"},"content":{"issueType":{"name":"Feature"}},"customType":{"name":"Refactor"},"compactCustomType":{"name":"Bug"},"type":{"name":"Workflow"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
+	        elif [ "${MOCK_PROJECT_ITEM_MODE:-existing}" = "configured_and_native_type" ]; then
+	          cat <<'JSON'
+	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1},"status":{"name":"Spec Ready"},"configuredType":{"name":"Workflow"},"content":{"issueType":{"name":"Feature"}},"customType":{"name":"Refactor"},"type":{"name":"Bug"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
+	        elif [ "${MOCK_PROJECT_ITEM_MODE:-existing}" = "null_native_with_custom_type" ]; then
+	          cat <<'JSON'
+	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1},"status":{"name":"Spec Ready"},"content":{"issueType":null},"customType":{"name":"Refactor"},"type":{"name":"Bug"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
 	        elif [ "${MOCK_PROJECT_ITEM_MODE:-existing}" = "released" ]; then
 	          cat <<'JSON'
 	{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_824","project":{"id":"PVT_project_1","number":1},"status":{"name":"Released"},"type":{"name":"Workflow"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
@@ -290,6 +306,43 @@ unset MOCK_PROJECT_ITEM_MODE
 unset MOCK_TRACKER_TYPE_FIELD
 run_test "targeted_type_read_prefers_configured_field" "Workflow" "$tracker_type"
 run_test "configured_type_read_passes_field_name" "1" "$(count_log_matches 'typeFieldName=Configured Type')"
+
+reset_log
+export MOCK_PROJECT_ITEM_MODE=native_type_only
+tracker_type="$(get_tracker_type_for_issue 824)"
+unset MOCK_PROJECT_ITEM_MODE
+run_test "targeted_type_read_uses_native_issue_type" "Feature" "$tracker_type"
+run_test "native_type_read_requests_issue_type" "1" "$(count_log_matches 'issueType')"
+
+reset_log
+export MOCK_PROJECT_ITEM_MODE=native_type_only
+native_type_stderr="$(workflow_github_project_item_for_issue 824 1 2>&1 >/dev/null || true)"
+unset MOCK_PROJECT_ITEM_MODE
+case "$native_type_stderr" in
+  *"named exactly 'Type'"*) native_type_warning_result="warned" ;;
+  *) native_type_warning_result="clean" ;;
+esac
+run_test "native_type_read_suppresses_missing_type_warning" "clean" "$native_type_warning_result"
+
+reset_log
+export MOCK_PROJECT_ITEM_MODE=native_with_custom_type
+tracker_type="$(get_tracker_type_for_issue 824)"
+unset MOCK_PROJECT_ITEM_MODE
+run_test "targeted_type_read_prefers_native_over_custom_fields" "Feature" "$tracker_type"
+
+reset_log
+export MOCK_PROJECT_ITEM_MODE=configured_and_native_type
+export MOCK_TRACKER_TYPE_FIELD="Configured Type"
+tracker_type="$(get_tracker_type_for_issue 824)"
+unset MOCK_PROJECT_ITEM_MODE
+unset MOCK_TRACKER_TYPE_FIELD
+run_test "targeted_type_read_prefers_configured_over_native" "Workflow" "$tracker_type"
+
+reset_log
+export MOCK_PROJECT_ITEM_MODE=null_native_with_custom_type
+tracker_type="$(get_tracker_type_for_issue 824)"
+unset MOCK_PROJECT_ITEM_MODE
+run_test "targeted_type_read_falls_back_when_native_is_null" "Refactor" "$tracker_type"
 
 reset_log
 export MOCK_PROJECT_ITEM_MODE=paginated

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -1446,6 +1446,9 @@ workflow_github_project_item_for_issue() {
                 nodes {
                   id
                   project { id number }
+                  content {
+                    ... on Issue { issueType { name } }
+                  }
                   status: fieldValueByName(name: "Status") {
                     ... on ProjectV2ItemFieldSingleSelectValue { name }
                   }
@@ -1494,10 +1497,13 @@ for item in project_items.get('nodes') or []:
     project = item.get('project') or {}
     if project.get('id') == project_id:
         status_value = item.get('status') or item.get('fieldValueByName') or {}
+        content = item.get('content') or {}
+        native_type = content.get('issueType') if isinstance(content, dict) else None
         type_candidates = []
         if preferred:
             type_candidates.append(item.get('configuredType') or {})
         type_candidates.extend([
+            native_type or {},
             item.get('customType') or {},
             item.get('compactCustomType') or {},
             item.get('type') or {},


### PR DESCRIPTION
## Summary
- read native GitHub Issue Types in the targeted Project item lookup
- preserve configured, native, and legacy custom-field precedence
- cover native resolution, warning suppression, precedence, and null fallback

## Verification
- `bash scripts/development-workflow/tests/test-workflow-lib-github-projects.sh`
- `shellcheck --severity=warning scripts/development-workflow/workflow-lib.sh scripts/development-workflow/tests/test-workflow-lib-github-projects.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- Markdown lint and CHANGELOG checks

## Pre-submission self-review
Stale markers: none. Caller consistency: verified shared helper consumers. Coverage: all spec acceptance criteria addressed. Complex gate matrix: retained in the approved plan.

Closes #1280

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how workflow items are classified for routing and discovery, but scope is read-only with explicit precedence and broad shell tests; misclassification could affect orchestration if GitHub’s native type disagrees with project fields.
> 
> **Overview**
> **GitHub Projects type reads** now resolve classification from GitHub’s native **Issue Type** (`content.issueType.name`) in the targeted `repository.issue(...).projectItems` GraphQL lookup, without changing how types are written (still project custom fields only).
> 
> **Precedence** for `get_tracker_type_for_issue` is: configured `type_field` → native Issue Type → `Custom Type` / `CustomType` / legacy `Type`. When native type is present, the helper no longer emits the “missing Type field” warning that applied when only project fields were considered.
> 
> Docs (`github-projects.md`) and **CHANGELOG** (#1280) describe the new read path; **`test-workflow-lib-github-projects.sh`** adds mocks and assertions for native-only reads, native-over-custom precedence, configured-over-native, null-native fallback, and warning suppression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69b4ddf15c83f9d068277579aa5713675515072c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->