### PR TITLE
fix(workflow): make Protocol 02 guidance portable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Make Protocol 02 parser guidance portable** (#1310): Inline the required
+  parser-risk and suppression intent so synced repositories do not depend on an
+  unavailable historical development fixture.
 - **Native GitHub Issue Type classification** (#1280): Recognize native Issue
   Types while preserving configured and custom-field precedence.
 - **Handle Haystack large-PR analysis skips** (#1311): Recognize authoritative current-head file-limit declines as terminal Haystack skips while preserving other reviewer gates and durable loop history.

--- a/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
+++ b/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md
@@ -214,7 +214,11 @@ If none of these signals apply, skip this entire block.
 - Where directives can appear
 - How multiple suppressions on one line are interpreted
 
-For acceptance intent and terminology, reference `docs/specs/developments/20260420120000_201-tech-lead-parser-regex-plan-requirements/1_201-tech-lead-parser-regex-plan-requirements_specs.md`.
+These parser-risk and suppression requirements are the complete required
+acceptance intent and terminology. Historical template or workflow-hub
+development artifacts may offer supplementary context, but they can be absent
+in receiving repositories and must never block plan authoring or sync
+validation.
 
 ### Cross-cutting checklist plans: safety, quality, or compliance categories
 

--- a/scripts/development-workflow/tests/test-protocol-02-portable-parser-guidance.sh
+++ b/scripts/development-workflow/tests/test-protocol-02-portable-parser-guidance.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# test-protocol-02-portable-parser-guidance.sh - Protocol 02 portability regression coverage.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+PROTOCOL="$REPO_ROOT/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md"
+SYNC_COMMAND="$REPO_ROOT/.claude/commands/sync-template.md"
+OBSOLETE_PATH="docs/specs/developments/20260420120000_201-tech-lead-parser-regex-plan-requirements/1_201-tech-lead-parser-regex-plan-requirements_specs.md"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '$expected', got '$actual'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+contains() {
+  local needle="$1"
+  local file="$2"
+
+  if grep -Fq -- "$needle" "$file"; then
+    printf 'yes\n'
+  else
+    printf 'no\n'
+  fi
+}
+
+run_test "obsolete_historical_reference_removed" "no" "$(contains "$OBSOLETE_PATH" "$PROTOCOL")"
+run_test "parser_risk_classification_retained" "yes" "$(contains 'Classification (parser-risk)' "$PROTOCOL")"
+run_test "edge_case_enumeration_retained" "yes" "$(contains 'Edge-case enumeration' "$PROTOCOL")"
+run_test "automated_unit_tests_retained" "yes" "$(contains 'Mandatory when parser-risk — Unit tests' "$PROTOCOL")"
+run_test "recognized_directives_retained" "yes" "$(contains 'Which directives are recognized' "$PROTOCOL")"
+run_test "directive_placement_retained" "yes" "$(contains 'Where directives can appear' "$PROTOCOL")"
+run_test "multiple_suppressions_retained" "yes" "$(contains 'How multiple suppressions on one line are interpreted' "$PROTOCOL")"
+run_test "optional_history_is_non_blocking" "yes" "$(contains 'must never block plan authoring or sync' "$PROTOCOL")"
+
+RECEIVING_REPO="$TMP_ROOT/receiving-repository"
+mkdir -p "$RECEIVING_REPO/docs/workflow/development-workflow/protocols"
+cp "$PROTOCOL" "$RECEIVING_REPO/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md"
+RECEIVING_PROTOCOL="$RECEIVING_REPO/docs/workflow/development-workflow/protocols/02-generate-implementation-plan-protocol.md"
+
+run_test "receiving_repo_needs_no_obsolete_historical_fixture" "no" "$(contains "$OBSOLETE_PATH" "$RECEIVING_PROTOCOL")"
+run_test "receiving_repo_parser_guidance_actionable" "yes" "$(contains 'Conditional — Suppression semantics' "$RECEIVING_PROTOCOL")"
+run_test "sync_command_keeps_missing_path_guard" "yes" "$(contains 'path verification' "$SYNC_COMMAND")"
+
+echo ""
+echo "${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
Closes #1310

## Summary
- make parser-risk and suppression guidance self-contained
- document historical workflow artifacts as optional context
- add a portable Protocol 02 regression harness

## Verification
- `bash scripts/development-workflow/tests/test-protocol-02-portable-parser-guidance.sh`
- `bash scripts/development-workflow/tests/test-sync-template-mode-scopes.sh`
- `shellcheck --severity=warning scripts/development-workflow/tests/test-protocol-02-portable-parser-guidance.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- Markdown lint, heuristic lint, and changelog duplicate-header checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes to workflow protocols; no application runtime, auth, or data-path behavior changes.
> 
> **Overview**
> **Protocol 02** no longer requires a link to a workflow-hub-only specs fixture for parser-risk and suppression semantics. The **parser-risk / suppression** acceptance intent is stated inline in `02-generate-implementation-plan-protocol.md`, with explicit language that historical development artifacts are optional and **must not** block plan authoring or template sync validation.
> 
> A new shell regression, `test-protocol-02-portable-parser-guidance.sh`, asserts the obsolete path is gone, core parser-risk headings remain, a minimal “receiving repo” copy of the protocol is still actionable, and `sync-template` still documents post-apply **path verification**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28bcd5b742f5c77ae3ed74b8b3d40c741730cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->