### PR TITLE
fix(workflow): refine checkpoint data-model signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Fail closed on checkpoint resume isolation** (#1285): Require complete
   worktree context and stop resumed isolated runners before mutation when the
   session starts in the main clone or cannot prove its assignment.
+- **Fix bounded-prelude data-model checkpoint signals** (#1287): Stop incidental
+  data-adjacent issue-body terms from creating technical checkpoints while
+  preserving explainable checkpoints for explicit migration and schema-change
+  evidence.
 
 ## [0.39.0] - 2026-07-27
 

--- a/docs/workflow/development-workflow/bounded-run-prelude.md
+++ b/docs/workflow/development-workflow/bounded-run-prelude.md
@@ -96,9 +96,16 @@ The JSON output includes:
    themselves. Product checkpoints remain recommended for unresolved product
    language, open questions, empty Acceptance Criteria sections, and
    placeholder-only criteria such as `TBD` or `to be defined`.
-6. **Epic-like items** — `run-item-scope-resolver.sh` rejects epic issues; use
+6. **Data-model checkpoint signal** — incidental issue-body vocabulary such as
+   `schema`, `database`, `SQL`, `persistent data`, or `data model` is not enough
+   to create a technical checkpoint. Data-model checkpoints require an explicit
+   migration/schema label, action-oriented title intent, or migration-specific
+   body phrase such as `CREATE TABLE`, `ALTER TABLE`, `new column`, or
+   `database migration`. The checkpoint reason must name the exact matched
+   signal so the human can see why the checkpoint exists.
+7. **Epic-like items** — `run-item-scope-resolver.sh` rejects epic issues; use
    `--epic` instead.
-7. **Explicit-list base selection** — `--items` considers only the listed items.
+8. **Explicit-list base selection** — `--items` considers only the listed items.
    No integration labels resolve to `develop`. Partial or mixed
    `integration-branch:<slug>` coverage resolves to `develop` with a visible
    warning. A shared label may resolve to `develop-<slug>` only when the current

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -100,8 +100,10 @@ Before mutation, the recommender classifies per-item human checkpoints from
 read-only scope metadata (title, type, labels, tracker status). High-leverage
 signals default to checkpoints:
 
-- **Plan + technical**: database schema, migration, or persistent data-model
-  wording.
+- **Plan + technical**: explicit migration/schema labels, action-oriented title
+  intent, or migration-specific body phrases. Generic issue-body mentions of
+  `schema`, `database`, `SQL`, `persistent data`, or `data model` are not enough
+  by themselves.
 - **Spec + product**: unresolved product language, open questions, empty
   Acceptance Criteria sections, or placeholder-only acceptance criteria when
   the item is still in Backlog or spec stage. A populated Acceptance Criteria
@@ -127,11 +129,12 @@ The preflight summary must show checkpoint policy alongside autonomy policy so
 the human can accept, customize, or waive checkpoints before mutation. Two common
 examples:
 
-- **Plan-stage database/schema checkpoint**: an item titled "Add tenant billing
-  migrations" should recommend a `plan` / `technical` checkpoint with a required
-  action such as "approve the migration and rollback plan". A later
-  implementation PR remains blocked until that plan-stage checkpoint is
-  `satisfied` or `waived`.
+- **Plan-stage database/schema checkpoint**: an item with a
+  `database-migration` label, a title such as "Add tenant billing schema
+  column", or body text containing `ALTER TABLE` should recommend a `plan` /
+  `technical` checkpoint with a reason that names the exact matched label,
+  title phrase, or body phrase. A later implementation PR remains blocked until
+  that plan-stage checkpoint is `satisfied` or `waived`.
 - **Implementation-stage sensitive-change checkpoint**: an item touching auth,
   permissions, security-sensitive automation, or merge behavior should recommend
   an `implementation` / `technical` checkpoint with a required action such as
@@ -352,9 +355,10 @@ Recommended defaults should favor the most automatic safe configuration:
 - `--max-risk medium` for workflow scripts, orchestration behavior, merge or
   cleanup automation, or shared workflow tooling when later
   `why_safe_to_merge` evidence can be produced.
-- Human-checkpoint recommendations per eligible item when metadata signals
-  schema/migration, product ambiguity, tradeoff ambiguity, or sensitive
-  implementation work (see **Human-checkpoint recommendations** above).
+- Human-checkpoint recommendations per eligible item when source-aware metadata
+  signals explicit schema/migration work, product ambiguity, tradeoff ambiguity,
+  or sensitive implementation work (see **Human-checkpoint recommendations**
+  above).
 - Never recommend `high` by default. High-risk work requires explicit human
   selection.
 

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -210,6 +210,54 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
   def item_signal_text($item):
     (($item.title // "") + " " + ($item.body // "") + " " + ($item.type // "") + " " + (($item.labels // []) | join(" ")) + " " + ($item.integrationBranchLabel // ""))
     | ascii_downcase;
+  def stable_unique:
+    reduce .[] as $value ([]; if index($value) then . else . + [$value] end);
+  def normalize_signal_label:
+    ascii_downcase | gsub("[ _]+"; "-");
+  def data_model_label_signals($item):
+    [
+      ($item.labels // [])[]?
+      | tostring as $label
+      | ($label | normalize_signal_label) as $normalized
+      | select($normalized | IN(
+          "migration",
+          "database-migration",
+          "schema-migration",
+          "db-migration",
+          "schema-change",
+          "data-model-change"
+        ))
+      | "label '\''\($label)'\''"
+    ];
+  def regex_matches($text; $regex):
+    [$text | match($regex; "ig").string];
+  def title_regex_matches($text; $regex):
+    regex_matches($text; $regex) | map("title phrase '\''\(.)'\''");
+  def body_regex_matches($text; $regex):
+    regex_matches($text; $regex)
+    | map(gsub("^[^[:alnum:]]+"; "") | gsub("[^[:alnum:]]+$"; ""))
+    | map("body phrase '\''\(.)'\''");
+  def data_model_title_signals($item):
+    ($item.title // "") as $title |
+    (
+      title_regex_matches($title; "\\b(database[[:space:]-]+migration|schema[[:space:]-]+migration|data[ -]?model[[:space:]-]+migration)\\b")
+      +
+      title_regex_matches($title; "\\b(add|create|alter|change|update|modify|rename|drop|remove|migrate)\\b.{0,80}\\b(schema|table|column|database|data[ -]?model|persistent[ -]?model)\\b")
+    );
+  def data_model_body_signals($item):
+    ($item.body // "") as $body |
+    (
+      body_regex_matches($body; "\\bCREATE[[:space:]]+TABLE\\b")
+      +
+      body_regex_matches($body; "\\bALTER[[:space:]]+TABLE\\b")
+      +
+      body_regex_matches($body; "\\bnew[[:space:]]+column\\b")
+      +
+      body_regex_matches($body; "(^|[^[:alnum:]_-])database[[:space:]]+migration($|[^[:alnum:]_-])")
+    );
+  def data_model_signals($item):
+    (data_model_label_signals($item) + data_model_title_signals($item) + data_model_body_signals($item))
+    | stable_unique;
   def has_nonblank_lines($lines):
     any($lines[]?; (gsub("^[[:space:]]+"; "") | gsub("[[:space:]]+$"; "") | length) > 0);
   def heading_level($line):
@@ -281,6 +329,7 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
       end;
   def recommend_checkpoints_for_item($item):
     item_signal_text($item) as $text |
+    data_model_signals($item) as $data_model_signals |
     infer_workflow_stage($item) as $stage |
     acceptance_criteria_problem($item) as $criteria_problem |
     ($text | test("ambiguous|unclear|\\btbd\\b|open question|unresolved product")) as $unresolved_product_signal |
@@ -298,12 +347,12 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
             satisfaction_state: "pending"
           }]
         else . end
-      | if $text | test("schema|migration|database|data[ -]?model|\\bsql\\b|persistent data") then
+      | if ($data_model_signals | length) > 0 then
           . + [{
             item_number: $num,
             stage: "plan",
             domain: "technical",
-            reason: "issue signals database schema, migration, or persistent data-model changes",
+            reason: ("data-model checkpoint matched " + ($data_model_signals | join("; "))),
             required_human_action: "review and approve proposed data model in the plan before implementation proceeds",
             satisfaction_state: "pending"
           }]

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -284,6 +284,124 @@ run_test "schema_scope_recommends_plan_checkpoint" "plan:technical" "$(printf '%
 run_test "schema_checkpoint_pending" "pending" "$(printf '%s\n' "$schema_output" | jq -r '.recommendedPolicy.checkpoints[0].satisfaction_state')"
 run_test "schema_checkpoint_requires_confirmation" "true" "$(printf '%s\n' "$schema_output" | jq -r '.requiresConfirmation')"
 run_test "schema_copy_paste_includes_checkpoint_file" "yes" "$(printf '%s\n' "$schema_output" | jq -r '.copyPasteCommand' | grep -Fq -- '--checkpoints-file checkpoint-policy.json' && echo yes || echo no)"
+run_test "schema_checkpoint_reason_names_title_signal" "yes" "$(printf '%s\n' "$schema_output" | jq -r '.recommendedPolicy.checkpoints[0].reason' | grep -Fq "title phrase 'database migration'" && echo yes || echo no)"
+
+generic_data_body_fixture="$(write_fixture generic-data-body '{
+  "scopeSource": "items",
+  "epicNumber": null,
+  "itemInput": "201",
+  "baseBranch": "develop",
+  "baseAmbiguous": false,
+  "baseReason": "no integration branch label",
+  "policy": {"delegateReview": false, "mayMerge": false, "mayStartBacklog": false, "maxRisk": "low"},
+  "groups": {
+    "eligible": [{"number": 201, "title": "Classify transient PostgREST responses", "body": "The response schema includes SQL and database-shaped persistent data in a data model-like payload, but no migration is proposed.", "status": "Plan Ready", "type": "Workflow", "labels": [], "dependencies": {"state": "none"}}],
+    "blocked": [],
+    "already_merged": [],
+    "in_review": [],
+    "ambiguous": []
+  },
+  "items": [
+    {"number": 201, "title": "Classify transient PostgREST responses", "body": "The response schema includes SQL and database-shaped persistent data in a data model-like payload, but no migration is proposed.", "status": "Plan Ready", "type": "Workflow", "labels": []}
+  ]
+}')"
+generic_data_body_output="$(recommend_json "$generic_data_body_fixture" "\$run-epic --items 201")"
+run_test "generic_data_body_terms_do_not_checkpoint" "0" "$(printf '%s\n' "$generic_data_body_output" | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "plan" and .domain == "technical")] | length')"
+
+resilient_read_fixture="$(write_fixture resilient-read "$(jq '
+  .groups.eligible[0].number = 202
+  | .groups.eligible[0].title = "resilient-read helper for raw PostgREST transient error classification"
+  | .groups.eligible[0].body = "Classifies raw PostgREST responses, transient error shapes, database-facing responses, and schema-shaped payloads without changing tables or persistent data."
+  | .items[0] = .groups.eligible[0]
+' "$generic_data_body_fixture")")"
+resilient_read_output="$(recommend_json "$resilient_read_fixture" "\$run-epic --items 202")"
+run_test "resilient_read_body_has_no_data_model_checkpoint" "0" "$(printf '%s\n' "$resilient_read_output" | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "plan" and .domain == "technical")] | length')"
+
+generic_label_fixture="$(write_fixture generic-label "$(jq '
+  .groups.eligible[0].number = 203
+  | .groups.eligible[0].title = "Tune database-facing report wording"
+  | .groups.eligible[0].body = "No migration work."
+  | .groups.eligible[0].labels = ["database"]
+  | .items[0] = .groups.eligible[0]
+' "$generic_data_body_fixture")")"
+generic_label_output="$(recommend_json "$generic_label_fixture" "\$run-epic --items 203")"
+run_test "generic_database_label_does_not_checkpoint" "0" "$(printf '%s\n' "$generic_label_output" | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "plan" and .domain == "technical")] | length')"
+
+label_signal_fixture="$(write_fixture label-signal "$(jq '
+  .groups.eligible[0].number = 204
+  | .groups.eligible[0].title = "Prepare release migration runbook"
+  | .groups.eligible[0].body = "No extra signal."
+  | .groups.eligible[0].labels = ["Database Migration", "schema-change"]
+  | .items[0] = .groups.eligible[0]
+' "$generic_data_body_fixture")")"
+label_signal_output="$(recommend_json "$label_signal_fixture" "\$run-epic --items 204")"
+run_test "explicit_migration_labels_checkpoint_with_exact_reason" "yes" "$(printf '%s\n' "$label_signal_output" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "plan" and .domain == "technical") | .reason' | grep -Fq "label 'Database Migration'; label 'schema-change'" && echo yes || echo no)"
+
+action_title_fixture="$(write_fixture action-title "$(jq '
+  .groups.eligible[0].number = 205
+  | .groups.eligible[0].title = "Add customer schema column"
+  | .groups.eligible[0].body = "Plan-ready implementation."
+  | .groups.eligible[0].labels = []
+  | .items[0] = .groups.eligible[0]
+' "$generic_data_body_fixture")")"
+action_title_output="$(recommend_json "$action_title_fixture" "\$run-epic --items 205")"
+run_test "action_oriented_schema_title_checkpoints" "yes" "$(printf '%s\n' "$action_title_output" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "plan" and .domain == "technical") | .reason' | grep -Fq "title phrase 'Add customer schema column'" && echo yes || echo no)"
+
+false_signal_title_fixture="$(write_fixture false-signal-title "$(jq '
+  .groups.eligible[0].number = 206
+  | .groups.eligible[0].title = "Fix false data-model change signal"
+  | .groups.eligible[0].body = "The bug is a checkpoint false positive."
+  | .items[0] = .groups.eligible[0]
+' "$generic_data_body_fixture")")"
+false_signal_title_output="$(recommend_json "$false_signal_title_fixture" "\$run-epic --items 206")"
+run_test "false_signal_title_does_not_checkpoint" "0" "$(printf '%s\n' "$false_signal_title_output" | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "plan" and .domain == "technical")] | length')"
+
+migration_title_fixture="$(write_fixture migration-title "$(jq '
+  .groups.eligible[0].number = 207
+  | .groups.eligible[0].title = "Plan database migration rollout"
+  | .groups.eligible[0].body = "Plan-ready implementation."
+  | .items[0] = .groups.eligible[0]
+' "$generic_data_body_fixture")")"
+migration_title_output="$(recommend_json "$migration_title_fixture" "\$run-epic --items 207")"
+run_test "migration_title_phrases_checkpoint" "yes" "$(printf '%s\n' "$migration_title_output" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "plan" and .domain == "technical") | .reason' | grep -Fq "title phrase 'database migration'" && echo yes || echo no)"
+
+body_phrase_fixture="$(write_fixture body-phrase "$(jq '
+  .groups.eligible[0].number = 208
+  | .groups.eligible[0].title = "Apply stored procedure updates"
+  | .groups.eligible[0].body = "Use CREATE TABLE for the fixture, ALTER TABLE for the rollout, add a new column, and document the database migration."
+  | .items[0] = .groups.eligible[0]
+' "$generic_data_body_fixture")")"
+body_phrase_output="$(recommend_json "$body_phrase_fixture" "\$run-epic --items 208")"
+run_test "migration_body_phrases_checkpoint_with_exact_reason" "yes" "$(printf '%s\n' "$body_phrase_output" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "plan" and .domain == "technical") | .reason' | grep -Fq "body phrase 'CREATE TABLE'; body phrase 'ALTER TABLE'; body phrase 'new column'; body phrase 'database migration'" && echo yes || echo no)"
+
+lookalike_migration_fixture="$(write_fixture lookalike-migration "$(jq '
+  .groups.eligible[0].number = 209
+  | .groups.eligible[0].title = "Document SQL vocabulary"
+  | .groups.eligible[0].body = "CREATE TABLETOP, ALTER TABLET, a new columnist, and database migration-guide text are not migration evidence."
+  | .items[0] = .groups.eligible[0]
+' "$generic_data_body_fixture")")"
+lookalike_migration_output="$(recommend_json "$lookalike_migration_fixture" "\$run-epic --items 209")"
+run_test "migration_phrase_lookalikes_do_not_checkpoint" "0" "$(printf '%s\n' "$lookalike_migration_output" | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "plan" and .domain == "technical")] | length')"
+
+multi_signal_fixture="$(write_fixture multi-signal "$(jq '
+  .groups.eligible[0].number = 210
+  | .groups.eligible[0].title = "Add account table"
+  | .groups.eligible[0].body = "CREATE TABLE accounts. CREATE TABLE accounts."
+  | .groups.eligible[0].labels = ["database-migration", "database-migration"]
+  | .items[0] = .groups.eligible[0]
+' "$generic_data_body_fixture")")"
+multi_signal_output="$(recommend_json "$multi_signal_fixture" "\$run-epic --items 210")"
+run_test "data_model_signals_are_ordered_and_deduplicated" "data-model checkpoint matched label 'database-migration'; title phrase 'Add account table'; body phrase 'CREATE TABLE'" "$(printf '%s\n' "$multi_signal_output" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "plan" and .domain == "technical") | .reason')"
+
+variant_item_output="$(recommend_json "$schema_fixture" "/run-item 200")"
+variant_items_output="$(recommend_json "$schema_fixture" "/run-items 200 201")"
+variant_epic_output="$(recommend_json "$schema_fixture" "\$run-epic --items 200")"
+run_test "bounded_command_variants_share_data_model_classifier" "yes" "$(
+  item_reason="$(printf '%s\n' "$variant_item_output" | jq -r '.recommendedPolicy.checkpoints[0].reason')"
+  items_reason="$(printf '%s\n' "$variant_items_output" | jq -r '.recommendedPolicy.checkpoints[0].reason')"
+  epic_reason="$(printf '%s\n' "$variant_epic_output" | jq -r '.recommendedPolicy.checkpoints[0].reason')"
+  [ "$item_reason" = "$items_reason" ] && [ "$items_reason" = "$epic_reason" ] && echo yes || echo no
+)"
 
 sensitive_fixture="$(write_fixture sensitive '{
   "scopeSource": "items",
@@ -402,7 +520,7 @@ printf '%s\n' '[{
   "item_number": 200,
   "stage": "plan",
   "domain": "technical",
-  "reason": "issue signals database schema, migration, or persistent data-model changes",
+  "reason": "schema change is additive only",
   "required_human_action": "review and approve proposed data model in the plan before implementation proceeds",
   "satisfaction_state": "waived",
   "waiver_rationale": "schema change is additive only and pre-approved in epic brief"
@@ -411,6 +529,20 @@ waived_output="$("$HELPER" --scope "$schema_fixture" --original-command "\$run-e
 run_test "explicit_checkpoint_override_source" "explicit" "$(printf '%s\n' "$waived_output" | jq -r '.fieldSources.checkpoints')"
 run_test "waived_checkpoint_preserved" "waived" "$(printf '%s\n' "$waived_output" | jq -r '.effectivePolicy.checkpoints[0].satisfaction_state')"
 run_test "checkpoint_policy_audit_fields_present" "yes" "$(printf '%s\n' "$waived_output" | jq -e '.checkpointPolicy.recommended and .checkpointPolicy.selected and .checkpointPolicy.effective' >/dev/null && echo yes || echo no)"
+
+satisfied_file="$TMP_ROOT/satisfied-checkpoints.json"
+printf '%s\n' '[{
+  "item_number": 200,
+  "stage": "plan",
+  "domain": "technical",
+  "reason": "human-approved migration plan",
+  "required_human_action": "review and approve proposed data model in the plan before implementation proceeds",
+  "satisfaction_state": "satisfied",
+  "satisfied_by": "workflow operator",
+  "satisfaction_evidence": "approved in implementation handoff"
+}]' > "$satisfied_file"
+satisfied_output="$("$HELPER" --scope "$schema_fixture" --original-command "\$run-epic --items 200" --checkpoints-file "$satisfied_file" --json)"
+run_test "satisfied_checkpoint_preserved" "satisfied:human-approved migration plan" "$(printf '%s\n' "$satisfied_output" | jq -r '.effectivePolicy.checkpoints[0] | .satisfaction_state + ":" + .reason')"
 
 invalid_waived_file="$TMP_ROOT/invalid-waived.json"
 printf '%s\n' '[{"item_number": 200, "stage": "plan", "domain": "technical", "satisfaction_state": "waived"}]' > "$invalid_waived_file"


### PR DESCRIPTION
## Summary
- narrow data-model checkpoint detection to explicit labels and action-oriented migration/schema signals
- report matched checkpoint signals in policy recommendations
- add focused recommender coverage and update workflow docs/changelog

## Validation
- bash scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
- bash scripts/development-workflow/tests/test-run-epic-checkpoint-lifecycle.sh
- bash scripts/development-workflow/tests/test-run-epic-audit-trail.sh
- shellcheck --severity=warning scripts/development-workflow/run-epic-policy-recommender.sh scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
- python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop
- npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"
- markdown heuristic lint
- git diff --check

Closes #1287

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only policy recommendation logic with expanded tests; reduces mistaken human checkpoints without changing merge or auth paths.
> 
> **Overview**
> Fixes **bounded-prelude false positives** (#1287) where incidental issue text (`schema`, `database`, `SQL`, `persistent data`, `data model`) or a generic `database` label could recommend a plan/technical checkpoint.
> 
> **`run-epic-policy-recommender.sh`** now gates data-model checkpoints on **source-aware signals**: normalized migration/schema labels, action-oriented title patterns, and migration-specific body phrases (`CREATE TABLE`, `ALTER TABLE`, `new column`, `database migration`). Checkpoint **`reason`** strings cite the exact matched label/title/body signals (deduplicated). Generic vocabulary alone no longer qualifies.
> 
> **Docs** (`bounded-run-prelude.md`, Protocol 95) and **CHANGELOG** describe the new rules and examples. **`test-run-epic-policy-recommender.sh`** adds negative/positive fixtures (including lookalikes and `/run-item` vs `$run-epic` parity) and extends satisfied-checkpoint override coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c62520faaa6bc0f5f52cfe278bd341f62d1c151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->