### PR TITLE
feat(review): add CodeRabbit CLI review platform

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -43,7 +43,8 @@ review:
     # Ordered list of GitHub/App/CLI reviewers that can safely evaluate draft
     # PRs. These run before the PR is converted to ready.
     # Supported today by pr-review-loop.sh: greptile, devin, coderabbit,
-    # pr-agent, codex-github, claude-code-action, haystack, copilot, bugbot.
+    # coderabbit-cli, pr-agent, codex-github, claude-code-action, haystack,
+    # copilot, bugbot.
     github:
       - pr-agent
 
@@ -52,6 +53,11 @@ review:
     # are clean and the PR has been converted with `gh pr ready`.
     github:
       - bugbot
+  #
+  # CodeRabbit CLI platform options (local CLI reviewer; place "coderabbit-cli"
+  # in on_draft.github or on_ready.github to opt in; independent from the
+  # "coderabbit" GitHub App platform):
+  #   rate_limit_policy: warn      # warn|strict; default warn
   #
   # Configurable codex-github options (set via env vars or script flags to codex-github-reviewer.sh):
   #   CODEX_GITHUB_TRIGGER_PHRASE  — trigger phrase sent to the bot (default: "@codex review")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cross-check plan operational assumptions** (#1201): Record and re-verify
   cross-cutting plan assumptions so concurrent workflow work cannot silently
   invalidate implementation guidance.
+- **CodeRabbit CLI review platform** (#1375): Add an optional Step 7 CodeRabbit
+  CLI reviewer with explicit skipped and rate-limit handling.
 
 ### Fixed
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -371,6 +371,10 @@ Typical `important` issues:
 - Use the CodeRabbit CLI as an optional pre-push review tool for local changes.
 - In Claude Code: `/coderabbit:review`. Standalone: `cr` or `cr --agent`.
 - CodeRabbit CLI findings complement the pre-PR review gate but do not replace it.
+- When `coderabbit-cli` is configured as a Step 7 platform, require script
+  evidence from `pr-review-loop.sh`: `RESULT=clean` is fresh review evidence;
+  `RESULT=skipped` with unavailable, auth, timeout, invalid-output, or
+  rate-limit reasons is only availability evidence.
 - See [`docs/workflow/development-workflow/integrations/coderabbit.md`](docs/workflow/development-workflow/integrations/coderabbit.md) for setup and usage modes.
 
 ### Automated PR Reviewers

--- a/docs/workflow/development-workflow/integrations/coderabbit.md
+++ b/docs/workflow/development-workflow/integrations/coderabbit.md
@@ -16,7 +16,7 @@ CodeRabbit is **optional**. The workflow functions without it. See [`integration
 
 ## Usage Modes
 
-CodeRabbit supports two independent usage modes in this framework:
+CodeRabbit supports three independent usage modes in this framework:
 
 ### CLI-only (Path A — default)
 
@@ -37,13 +37,66 @@ coderabbit auth login
 
 The `.coderabbit.yaml` at the repo root ships with `auto_review.enabled: false` so the GitHub App (if installed) does not auto-review PRs.
 
-### External PR reviewer (Path B)
+### CLI Step 7 reviewer (Path B)
+
+Use the CodeRabbit CLI as a configured Step 7 platform without installing the
+GitHub App. Add `coderabbit-cli` to `review.on_draft.github` or
+`review.on_ready.github`:
+
+```yaml
+review:
+  on_draft:
+    github:
+      - coderabbit-cli
+  coderabbit_cli:
+    rate_limit_policy: warn
+```
+
+The platform runs `cr --agent --base <pr-base>` when `cr` is installed. If `cr`
+is absent and `coderabbit` is available, it runs
+`coderabbit review --agent --base <pr-base>`. The PR base is read with
+`gh pr view <number> --json baseRefName,headRefName`; if that lookup is
+unavailable, the companion script falls back to `develop`.
+
+The CLI path is intentionally not enabled by default. It requires local CLI
+installation and authentication in the runner environment.
+
+#### CLI Result Mapping
+
+`scripts/development-workflow/coderabbit-cli-reviewer.sh` emits the same
+companion-script contract as other CLI reviewers:
+
+- `RESULT=clean` when agent JSON includes a recognized findings array and no
+  blocking findings.
+- `RESULT=needs_fixes` when one or more findings have blocking severity.
+- `RESULT=skipped` with `REASON=unavailable`, `unauthorized`, `invalid_json`,
+  `ambiguous_output`, `no_output`, `timeout`, or `rate_limited` when a fresh
+  reliable review did not complete.
+- `RESULT=escalate` with `REASON=rate_limited` when the rate-limit policy is
+  strict.
+
+The default rate-limit policy is `warn`, which records
+`RESULT=skipped`, `REASON=rate_limited`, and `DISPLAY_RESULT=rate_limited`.
+Set `CODERABBIT_CLI_RATE_LIMIT_POLICY=strict` or configure
+`review.coderabbit_cli.rate_limit_policy: strict` to stop readiness on rate
+limit instead.
+
+`coderabbit-cli` does not post GitHub review threads in this MVP, so
+`bot_login_for_platform coderabbit-cli` returns empty. The script-owned
+Automated Reviewer Loop Summary is the durable evidence. A skipped CLI result
+must be reported as unavailable or rate-limited evidence, not as "CodeRabbit CLI
+found no issues."
+
+### GitHub App PR reviewer (Path C)
 
 To enable CodeRabbit as a Step 7 automated PR reviewer platform:
 
 1. Set `reviews.auto_review.enabled: true` in `.coderabbit.yaml`
 2. Add `coderabbit` to `review.on_draft.github` or `review.on_ready.github` in `.ai-dev-workflow.yaml`
 3. Install the CodeRabbit GitHub App on the repository
+
+The `coderabbit` App platform remains separate from `coderabbit-cli`. It uses
+the `coderabbitai[bot]` review/comment evidence path described below.
 
 ---
 
@@ -110,7 +163,7 @@ If either check fails, `coderabbit` is classified as `unreachable`. The configur
 
 ---
 
-## Setup (Path B only)
+## Setup (Path C only)
 
 ### 1. Install the CodeRabbit GitHub App
 

--- a/docs/workflow/development-workflow/integrations/pr-review-platform.md
+++ b/docs/workflow/development-workflow/integrations/pr-review-platform.md
@@ -6,7 +6,8 @@ Platform-specific setup lives in each platform's own integration doc. See:
 
 - [`integrations/bugbot.md`](bugbot.md)
 - [`integrations/claude-code-action.md`](claude-code-action.md)
-- [`integrations/coderabbit.md`](coderabbit.md)
+- [`integrations/coderabbit.md`](coderabbit.md) for both `coderabbit` and
+  `coderabbit-cli`
 - [`integrations/greptile.md`](greptile.md)
 - [`integrations/devin.md`](devin.md)
 - [`integrations/haystack-triage.md`](haystack-triage.md)
@@ -61,6 +62,9 @@ Additional rules:
 - Suggestions are non-blocking regardless of platform
 - `needs_fixes` summaries should include the blocking reviewer tool identity
 - Unsupported configured platforms may be reported as `skipped` with a reason such as `unsupported-platform`
+- A configured platform that reports `skipped` is not evidence of a fresh clean
+  review. Treat the platform reason as availability evidence, for example
+  missing CLI, missing authentication, or rate limiting.
 - CI starts only after the aggregate reviewer result is `clean` or `skipped`
 
 ---
@@ -86,6 +90,10 @@ review:
     # and authenticated via `haystack setup`. No GitHub App required.
     # See integrations/haystack-triage.md for setup instructions.
       - haystack
+    # coderabbit-cli: CodeRabbit CLI reviewer. Requires `cr` or `coderabbit`
+    # installed and authenticated locally. No GitHub App required. Missing CLI
+    # or auth emits RESULT=skipped, not clean review evidence.
+    # - coderabbit-cli
 ```
 
 The helper script reads this file automatically when no `--platform` flag is
@@ -130,6 +138,8 @@ The script emits:
 - One aggregate `RESULT=...`
 - Ordered `PLATFORM_<n>_NAME` / `PLATFORM_<n>_RESULT` records
 - Platform-specific counts and blocking summaries for the platform that stopped the loop
+- Platform-specific `REASON=` / `DISPLAY_RESULT=` records for skipped or
+  escalated reviewer availability states when the platform emits them
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -91,6 +91,19 @@ evidence are not authoritative. If the exact terminal reason is absent, keep
 following the existing pending, unavailable, finding, or timeout path rather
 than manually posting a clean summary.
 
+#### CodeRabbit CLI unavailable or rate-limited reviews
+
+When `coderabbit-cli` is configured in `review.on_draft.github` or
+`review.on_ready.github`, `pr-review-loop.sh` dispatches
+`coderabbit-cli-reviewer.sh` instead of the CodeRabbit GitHub App path. The CLI
+platform may return `RESULT=skipped` for missing CLI installation, missing auth,
+invalid or ambiguous output, timeout, or warning-policy rate limits. This is
+permissive for aggregate sequencing but is not evidence that a fresh CodeRabbit
+CLI review found no issues.
+
+Strict CLI rate-limit policy returns `RESULT=escalate` with
+`REASON=rate_limited`. Treat that like any other platform escalation.
+
 **Scope note**: This pre-flight checks `review.on_draft.github` and
 `review.on_ready.github` (external reviewers used by Protocol 93 / Step 7). The
 internal reviewer gate in Protocol 91 Step 7a separately checks
@@ -778,6 +791,9 @@ Examples of claims that must be directly supported:
 
 - "CodeRabbit APPROVED" — requires a review event with `state: APPROVED` or a transcript
   excerpt such as "All discussions resolved" or an explicit approval statement.
+- "CodeRabbit CLI found no issues" — requires `coderabbit-cli` script output
+  with `RESULT=clean`; `RESULT=skipped` with `REASON=unavailable`,
+  `unauthorized`, or `rate_limited` is not a clean review.
 - "Devin found no issues" — requires a Devin comment body confirming no findings, not
   merely the absence of a `CHANGES_REQUESTED` review.
 - "All platforms passed" — requires at least one supporting excerpt per platform cited.
@@ -893,6 +909,9 @@ After processing the requested PR(s), report:
 
 - **Ready for human review**: PR link, branch, and that the internal review gate, every configured automated reviewer, and CI are all clean (or skipped). For spec and plan PRs, mention that the `Document Quality Gate` log is present. Confirm that `gh pr ready` was run (after Step 7a APPROVED, before Step 7) to convert the draft PR to non-draft.
 - **Escalated**: PR link, reason (no progress over consecutive cycles, finding reappeared after fix, max cycles, timeout, or review platform escalate).
-- **Skipped**: If no review platform is configured, or a configured platform is currently unsupported and therefore skipped, note that in the result for the listed PR(s).
+- **Skipped**: If no review platform is configured, or a configured platform is
+  currently unsupported, unavailable, unauthenticated, rate-limited under
+  warning policy, or otherwise skipped, note that in the result for the listed
+  PR(s).
 
 The final summary comment posted on the PR (per the PR feedback tracking subsection) serves as the durable record; the summary to the user is a concise pointer to the PR and its outcome.

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -232,8 +232,9 @@ Runs one or more automated PR review platforms in order, then classifies finding
 
 Usage:
 
+<!-- workflow-shell-contract: bash -->
 ```bash
-./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch feature/my-branch] [--platform greptile] [--platform devin] [--platform coderabbit] [--platform coderabbit-cli]
+bash ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch feature/my-branch] [--platform greptile] [--platform devin] [--platform coderabbit] [--platform coderabbit-cli]
 ```
 
 What it does:

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -233,7 +233,7 @@ Runs one or more automated PR review platforms in order, then classifies finding
 Usage:
 
 ```bash
-./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch feature/my-branch] [--platform greptile] [--platform devin] [--platform coderabbit]
+./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch feature/my-branch] [--platform greptile] [--platform devin] [--platform coderabbit] [--platform coderabbit-cli]
 ```
 
 What it does:
@@ -243,6 +243,9 @@ What it does:
 - Stops on the first platform that reports blocking findings or escalation
 - Reports a stable aggregate `RESULT=clean|needs_fixes|escalate|skipped`
 - Emits ordered per-platform `PLATFORM_<n>_*` records plus the matching compatibility fixer
+- Supports `coderabbit` for the CodeRabbit GitHub App and `coderabbit-cli` for
+  the local CodeRabbit CLI; unavailable CLI/auth/rate-limit states are reported
+  as skipped or escalated evidence, not as a fresh clean review
 - If no GitHub reviewers are configured, reports `RESULT=skipped`
 
 Use this when:

--- a/scripts/development-workflow/coderabbit-cli-reviewer.sh
+++ b/scripts/development-workflow/coderabbit-cli-reviewer.sh
@@ -339,6 +339,11 @@ case "$parse_status" in
     if [ "$comment_count" -eq 0 ] && [ "$rate_limit_output" = true ]; then
       emit_rate_limited_result
     fi
+    if [ "$comment_count" -eq 0 ] && [ "$auth_output" = true ]; then
+      echo "WARN: CodeRabbit CLI authentication appears unavailable" >&2
+      print_result skipped 0 0 0 unauthorized "unavailable"
+      exit 3
+    fi
     if [ "$blocking_count" -gt 0 ]; then
       print_result needs_fixes "$comment_count" "$blocking_count" "$suggestion_count"
       exit 1

--- a/scripts/development-workflow/coderabbit-cli-reviewer.sh
+++ b/scripts/development-workflow/coderabbit-cli-reviewer.sh
@@ -112,7 +112,7 @@ esac
 rate_limit_policy_from_config() {
   local config_file
   local value=""
-  config_file="$(workflow_config_file 2>/dev/null || true)"
+  config_file="$(workflow_effective_config_file 2>/dev/null || true)"
   if [ -n "$config_file" ] && [ -f "$config_file" ]; then
     value="$(
       awk '
@@ -232,40 +232,11 @@ if [ "$cli_exit" -eq 124 ]; then
   exit 3
 fi
 
-stdout_is_json=false
-if printf '%s\n' "$cli_stdout" | jq -e 'type == "object" or type == "array"' >/dev/null 2>&1; then
-  stdout_is_json=true
-fi
-
-stdout_json_rate_limited=false
-if [ "$stdout_is_json" = true ] && printf '%s\n' "$cli_stdout" | jq -e '
-  def rate_limit_text:
-    test("rate[ -]?limit|too many requests|HTTP[[:space:]]*429"; "i");
-  if ((.findings? // null) | type) == "array" then
-    false
-  else
-    [
-      .. | objects
-      | (.error? // empty), (.reason? // empty), (.status? // empty)
-      | strings
-      | select(rate_limit_text)
-    ] | length > 0
-  end
-' >/dev/null 2>&1; then
-  stdout_json_rate_limited=true
-fi
-
-if printf '%s\n' "$cli_stderr" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
-  emit_rate_limited_result
-elif [ "$stdout_json_rate_limited" = true ]; then
-  emit_rate_limited_result
-elif [ "$stdout_is_json" = false ] && printf '%s\n' "$combined_output" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
-  emit_rate_limited_result
-fi
-
 if [ -z "$(printf '%s' "$cli_stdout" | tr -d '[:space:]')" ]; then
   echo "WARN: CodeRabbit CLI produced no JSON output (exit $cli_exit)" >&2
-  if printf '%s\n' "$combined_output" | grep -Eiq 'auth|login|unauthori[sz]ed|forbidden|401|403'; then
+  if printf '%s\n' "$combined_output" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
+    emit_rate_limited_result
+  elif printf '%s\n' "$combined_output" | grep -Eiq 'auth|login|unauthori[sz]ed|forbidden|401|403'; then
     print_result skipped 0 0 0 unauthorized "unavailable"
   else
     print_result skipped 0 0 0 no_output "skipped"
@@ -324,6 +295,10 @@ parse_result="$(
 )" || parse_result=""
 
 parse_status="$(printf '%s\n' "$parse_result" | awk -F= '$1 == "PARSE_STATUS" { print $2; exit }')"
+rate_limit_output=false
+if printf '%s\n' "$combined_output" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
+  rate_limit_output=true
+fi
 case "$parse_status" in
   ok)
     comment_count="$(printf '%s\n' "$parse_result" | awk -F= '$1 == "COMMENT_COUNT" { print $2; exit }')"
@@ -332,6 +307,9 @@ case "$parse_status" in
     comment_count="${comment_count:-0}"
     blocking_count="${blocking_count:-0}"
     suggestion_count="${suggestion_count:-0}"
+    if [ "$comment_count" -eq 0 ] && [ "$rate_limit_output" = true ]; then
+      emit_rate_limited_result
+    fi
     if [ "$blocking_count" -gt 0 ]; then
       print_result needs_fixes "$comment_count" "$blocking_count" "$suggestion_count"
       exit 1
@@ -340,7 +318,7 @@ case "$parse_status" in
     exit 0
     ;;
   missing_findings)
-    if printf '%s\n' "$combined_output" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
+    if [ "$rate_limit_output" = true ]; then
       emit_rate_limited_result
     elif printf '%s\n' "$combined_output" | grep -Eiq 'auth|login|unauthori[sz]ed|forbidden|401|403'; then
       echo "WARN: CodeRabbit CLI authentication appears unavailable" >&2
@@ -357,7 +335,7 @@ case "$parse_status" in
     exit 3
     ;;
   *)
-    if printf '%s\n' "$combined_output" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
+    if [ "$rate_limit_output" = true ]; then
       emit_rate_limited_result
     elif printf '%s\n' "$combined_output" | grep -Eiq 'auth|login|unauthori[sz]ed|forbidden|401|403'; then
       echo "WARN: CodeRabbit CLI authentication appears unavailable" >&2

--- a/scripts/development-workflow/coderabbit-cli-reviewer.sh
+++ b/scripts/development-workflow/coderabbit-cli-reviewer.sh
@@ -54,6 +54,8 @@ valid_slug_component() {
   esac
 }
 
+AUTH_PATTERN='unauthori[sz]ed|forbidden|(^|[^[:alnum:]_])(401|403)([^[:alnum:]_]|$)|auth(entication)?[[:space:]_-]+(failed|required|error|unavailable)|login[[:space:]_-]+(failed|required)'
+
 if [ "$#" -lt 3 ]; then
   usage
   exit 3
@@ -109,10 +111,9 @@ case "$TIMEOUT" in
     ;;
 esac
 
-rate_limit_policy_from_config() {
-  local config_file
+rate_limit_policy_from_file() {
+  local config_file="$1"
   local value=""
-  config_file="$(workflow_effective_config_file 2>/dev/null || true)"
   if [ -n "$config_file" ] && [ -f "$config_file" ]; then
     value="$(
       awk '
@@ -135,6 +136,24 @@ rate_limit_policy_from_config() {
       ' "$config_file"
     )"
   fi
+  printf '%s' "$value"
+}
+
+rate_limit_policy_from_config() {
+  local config_file
+  local local_file
+  local value=""
+
+  local_file="$(workflow_local_config_file 2>/dev/null || true)"
+  if [ -n "$local_file" ] && [ -f "$local_file" ]; then
+    value="$(rate_limit_policy_from_file "$local_file")"
+  fi
+
+  if [ -z "$value" ]; then
+    config_file="$(workflow_effective_config_file 2>/dev/null || true)"
+    value="$(rate_limit_policy_from_file "$config_file")"
+  fi
+
   printf '%s' "$value"
 }
 
@@ -236,7 +255,7 @@ if [ -z "$(printf '%s' "$cli_stdout" | tr -d '[:space:]')" ]; then
   echo "WARN: CodeRabbit CLI produced no JSON output (exit $cli_exit)" >&2
   if printf '%s\n' "$combined_output" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
     emit_rate_limited_result
-  elif printf '%s\n' "$cli_stderr" | grep -Eiq 'auth|login|unauthori[sz]ed|forbidden|401|403'; then
+  elif printf '%s\n' "$cli_stderr" | grep -Eiq "$AUTH_PATTERN"; then
     print_result skipped 0 0 0 unauthorized "unavailable"
   else
     print_result skipped 0 0 0 no_output "skipped"
@@ -313,11 +332,11 @@ if printf '%s\n' "$combined_output" | grep -Eiq 'rate[ -]?limit|too many request
   rate_limit_output=true
 fi
 auth_output=false
-if printf '%s\n' "$cli_stderr" | grep -Eiq 'auth|login|unauthori[sz]ed|forbidden|401|403'; then
+if printf '%s\n' "$cli_stderr" | grep -Eiq "$AUTH_PATTERN"; then
   auth_output=true
 elif [ -n "$normalized_stdout_json" ] && printf '%s\n' "$normalized_stdout_json" | jq -e '
   def auth_text:
-    test("auth|login|unauthori[sz]ed|forbidden|401|403"; "i");
+    test("unauthori[sz]ed|forbidden|(^|[^[:alnum:]_])(401|403)([^[:alnum:]_]|$)|auth(entication)?[[:space:]_-]+(failed|required|error|unavailable)|login[[:space:]_-]+(failed|required)"; "i");
   if type == "object" then
     [(.error? // empty), (.reason? // empty), (.status? // empty)]
     | map(select(type == "string"))
@@ -347,6 +366,11 @@ case "$parse_status" in
     if [ "$blocking_count" -gt 0 ]; then
       print_result needs_fixes "$comment_count" "$blocking_count" "$suggestion_count"
       exit 1
+    fi
+    if [ "$cli_exit" -ne 0 ]; then
+      echo "WARN: CodeRabbit CLI exited non-zero after producing non-blocking JSON (exit $cli_exit)" >&2
+      print_result skipped 0 0 0 cli_failed "skipped"
+      exit 3
     fi
     print_result clean "$comment_count" 0 "$suggestion_count"
     exit 0

--- a/scripts/development-workflow/coderabbit-cli-reviewer.sh
+++ b/scripts/development-workflow/coderabbit-cli-reviewer.sh
@@ -236,7 +236,7 @@ if [ -z "$(printf '%s' "$cli_stdout" | tr -d '[:space:]')" ]; then
   echo "WARN: CodeRabbit CLI produced no JSON output (exit $cli_exit)" >&2
   if printf '%s\n' "$combined_output" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
     emit_rate_limited_result
-  elif printf '%s\n' "$combined_output" | grep -Eiq 'auth|login|unauthori[sz]ed|forbidden|401|403'; then
+  elif printf '%s\n' "$cli_stderr" | grep -Eiq 'auth|login|unauthori[sz]ed|forbidden|401|403'; then
     print_result skipped 0 0 0 unauthorized "unavailable"
   else
     print_result skipped 0 0 0 no_output "skipped"
@@ -244,8 +244,21 @@ if [ -z "$(printf '%s' "$cli_stdout" | tr -d '[:space:]')" ]; then
   exit 3
 fi
 
+normalized_stdout_json="$(
+  printf '%s\n' "$cli_stdout" | jq -sc '
+    def event_finding:
+      select(((.type // "") | tostring | ascii_downcase) == "finding")
+      | (.finding // .data // .);
+    if length == 1 then
+      .[0]
+    else
+      {findings: [.[] | objects | event_finding]}
+    end
+  ' 2>/dev/null
+)" || normalized_stdout_json=""
+
 parse_result="$(
-  printf '%s\n' "$cli_stdout" | jq -r '
+  printf '%s\n' "$normalized_stdout_json" | jq -r '
     def walk_scalars:
       if type == "object" then .[] | walk_scalars
       elif type == "array" then .[] | walk_scalars
@@ -299,6 +312,22 @@ rate_limit_output=false
 if printf '%s\n' "$combined_output" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
   rate_limit_output=true
 fi
+auth_output=false
+if printf '%s\n' "$cli_stderr" | grep -Eiq 'auth|login|unauthori[sz]ed|forbidden|401|403'; then
+  auth_output=true
+elif [ -n "$normalized_stdout_json" ] && printf '%s\n' "$normalized_stdout_json" | jq -e '
+  def auth_text:
+    test("auth|login|unauthori[sz]ed|forbidden|401|403"; "i");
+  if type == "object" then
+    [(.error? // empty), (.reason? // empty), (.status? // empty)]
+    | map(select(type == "string"))
+    | any(auth_text)
+  else
+    false
+  end
+' >/dev/null 2>&1; then
+  auth_output=true
+fi
 case "$parse_status" in
   ok)
     comment_count="$(printf '%s\n' "$parse_result" | awk -F= '$1 == "COMMENT_COUNT" { print $2; exit }')"
@@ -320,7 +349,7 @@ case "$parse_status" in
   missing_findings)
     if [ "$rate_limit_output" = true ]; then
       emit_rate_limited_result
-    elif printf '%s\n' "$combined_output" | grep -Eiq 'auth|login|unauthori[sz]ed|forbidden|401|403'; then
+    elif [ "$auth_output" = true ]; then
       echo "WARN: CodeRabbit CLI authentication appears unavailable" >&2
       print_result skipped 0 0 0 unauthorized "unavailable"
     else
@@ -337,7 +366,7 @@ case "$parse_status" in
   *)
     if [ "$rate_limit_output" = true ]; then
       emit_rate_limited_result
-    elif printf '%s\n' "$combined_output" | grep -Eiq 'auth|login|unauthori[sz]ed|forbidden|401|403'; then
+    elif [ "$auth_output" = true ]; then
       echo "WARN: CodeRabbit CLI authentication appears unavailable" >&2
       print_result skipped 0 0 0 unauthorized "unavailable"
     else

--- a/scripts/development-workflow/coderabbit-cli-reviewer.sh
+++ b/scripts/development-workflow/coderabbit-cli-reviewer.sh
@@ -195,7 +195,7 @@ run_with_timeout() {
     sleep 1
     elapsed=$((elapsed + 1))
   done
-  if kill -0 "$child_pid" 2>/dev/null; then
+  if [ "$elapsed" -ge "$timeout_seconds" ]; then
     kill "$child_pid" 2>/dev/null || true
     wait "$child_pid" 2>/dev/null || true
     return 124
@@ -232,12 +232,35 @@ if [ "$cli_exit" -eq 124 ]; then
   exit 3
 fi
 
-if printf '%s\n' "$combined_output" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
-  if printf '%s\n' "$cli_stdout" | jq -e 'type == "object" or type == "array"' >/dev/null 2>&1; then
-    :
+stdout_is_json=false
+if printf '%s\n' "$cli_stdout" | jq -e 'type == "object" or type == "array"' >/dev/null 2>&1; then
+  stdout_is_json=true
+fi
+
+stdout_json_rate_limited=false
+if [ "$stdout_is_json" = true ] && printf '%s\n' "$cli_stdout" | jq -e '
+  def rate_limit_text:
+    test("rate[ -]?limit|too many requests|HTTP[[:space:]]*429"; "i");
+  if ((.findings? // null) | type) == "array" then
+    false
   else
-    emit_rate_limited_result
-  fi
+    [
+      .. | objects
+      | (.error? // empty), (.reason? // empty), (.status? // empty)
+      | strings
+      | select(rate_limit_text)
+    ] | length > 0
+  end
+' >/dev/null 2>&1; then
+  stdout_json_rate_limited=true
+fi
+
+if printf '%s\n' "$cli_stderr" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
+  emit_rate_limited_result
+elif [ "$stdout_json_rate_limited" = true ]; then
+  emit_rate_limited_result
+elif [ "$stdout_is_json" = false ] && printf '%s\n' "$combined_output" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
+  emit_rate_limited_result
 fi
 
 if [ -z "$(printf '%s' "$cli_stdout" | tr -d '[:space:]')" ]; then

--- a/scripts/development-workflow/coderabbit-cli-reviewer.sh
+++ b/scripts/development-workflow/coderabbit-cli-reviewer.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+# coderabbit-cli-reviewer.sh - CodeRabbit CLI reviewer for Step 7.
+#
+# Wraps CodeRabbit CLI agent-mode review output and emits the standard
+# companion-script key=value contract consumed by pr-review-loop.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/development-workflow/workflow-lib.sh
+source "$SCRIPT_DIR/workflow-lib.sh"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: coderabbit-cli-reviewer.sh <pr_number> <owner> <repo> [--timeout <seconds>]
+
+Options:
+  --timeout <seconds>  Maximum seconds to wait for the CodeRabbit CLI.
+                       Defaults to CODERABBIT_CLI_REVIEW_TIMEOUT or 120.
+EOF
+}
+
+print_result() {
+  local result="$1"
+  local comment_count="$2"
+  local blocking_count="$3"
+  local suggestion_count="$4"
+  local reason="${5:-}"
+  local display_result="${6:-}"
+
+  print_kv RESULT "$result"
+  print_kv COMMENT_COUNT "$comment_count"
+  print_kv BLOCKING_COUNT "$blocking_count"
+  print_kv SUGGESTION_COUNT "$suggestion_count"
+  [ -n "$reason" ] && print_kv REASON "$reason"
+  [ -n "$display_result" ] && print_kv DISPLAY_RESULT "$display_result"
+  return 0
+}
+
+emit_rate_limited_result() {
+  echo "WARN: CodeRabbit CLI rate limit detected" >&2
+  if [ "$RATE_LIMIT_POLICY" = "strict" ]; then
+    print_result escalate 0 0 0 rate_limited "rate_limited"
+    exit 2
+  fi
+  print_result skipped 0 0 0 rate_limited "rate_limited"
+  exit 3
+}
+
+valid_slug_component() {
+  case "$1" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+if [ "$#" -lt 3 ]; then
+  usage
+  exit 3
+fi
+
+PR_NUMBER="$1"
+OWNER="$2"
+REPO="$3"
+shift 3
+
+case "$PR_NUMBER" in
+  ''|0|*[!0-9]*)
+    echo "ERROR: PR number '$PR_NUMBER' is not a valid positive integer" >&2
+    exit 3
+    ;;
+esac
+if ! valid_slug_component "$OWNER"; then
+  echo "ERROR: owner '$OWNER' contains invalid characters" >&2
+  exit 3
+fi
+if ! valid_slug_component "$REPO"; then
+  echo "ERROR: repo '$REPO' contains invalid characters" >&2
+  exit 3
+fi
+
+TIMEOUT="${CODERABBIT_CLI_REVIEW_TIMEOUT:-120}"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --timeout)
+      if [ "$#" -lt 2 ] || [ -z "${2:-}" ]; then
+        echo "ERROR: --timeout requires a value" >&2
+        exit 3
+      fi
+      TIMEOUT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown option '$1'" >&2
+      usage
+      exit 3
+      ;;
+  esac
+done
+
+case "$TIMEOUT" in
+  ''|0|*[!0-9]*)
+    echo "ERROR: --timeout value '$TIMEOUT' is not a positive integer" >&2
+    exit 3
+    ;;
+esac
+
+rate_limit_policy_from_config() {
+  local config_file
+  local value=""
+  config_file="$(workflow_config_file 2>/dev/null || true)"
+  if [ -n "$config_file" ] && [ -f "$config_file" ]; then
+    value="$(
+      awk '
+        function trim(v) {
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+          gsub(/^["'"'"']|["'"'"']$/, "", v)
+          return v
+        }
+        /^review:[[:space:]]*$/ { in_review=1; next }
+        in_review && /^[^[:space:]#].*:[[:space:]]*/ { in_review=0 }
+        in_review && /^[[:space:]][[:space:]]coderabbit_cli:[[:space:]]*$/ { in_cli=1; next }
+        in_cli && /^[[:space:]][[:space:]][^[:space:]#].*:[[:space:]]*/ { in_cli=0 }
+        in_cli && /^[[:space:]][[:space:]][[:space:]][[:space:]]rate_limit_policy:[[:space:]]*/ {
+          line = $0
+          sub(/^[[:space:]]*rate_limit_policy:[[:space:]]*/, "", line)
+          sub(/[[:space:]]+#.*$/, "", line)
+          print trim(line)
+          exit
+        }
+      ' "$config_file"
+    )"
+  fi
+  printf '%s' "$value"
+}
+
+RATE_LIMIT_POLICY="${CODERABBIT_CLI_RATE_LIMIT_POLICY:-}"
+if [ -z "$RATE_LIMIT_POLICY" ]; then
+  RATE_LIMIT_POLICY="$(rate_limit_policy_from_config)"
+fi
+RATE_LIMIT_POLICY="${RATE_LIMIT_POLICY:-warn}"
+case "$RATE_LIMIT_POLICY" in
+  warn|strict) ;;
+  *)
+    echo "WARN: invalid CodeRabbit CLI rate-limit policy '$RATE_LIMIT_POLICY'; defaulting to warn" >&2
+    RATE_LIMIT_POLICY="warn"
+    ;;
+esac
+
+BASE_BRANCH=""
+HEAD_BRANCH=""
+if command -v gh >/dev/null 2>&1; then
+  pr_json=""
+  if pr_json="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json baseRefName,headRefName 2>/dev/null)"; then
+    BASE_BRANCH="$(printf '%s\n' "$pr_json" | jq -r '.baseRefName // empty' 2>/dev/null || true)"
+    HEAD_BRANCH="$(printf '%s\n' "$pr_json" | jq -r '.headRefName // empty' 2>/dev/null || true)"
+  fi
+fi
+BASE_BRANCH="${BASE_BRANCH:-develop}"
+
+if command -v cr >/dev/null 2>&1; then
+  CODERABBIT_CMD="cr"
+  CODERABBIT_SUBCOMMAND=""
+elif command -v coderabbit >/dev/null 2>&1; then
+  CODERABBIT_CMD="coderabbit"
+  CODERABBIT_SUBCOMMAND="review"
+else
+  echo "INFO: CodeRabbit CLI not found on PATH" >&2
+  print_result skipped 0 0 0 unavailable "unavailable"
+  exit 3
+fi
+print_kv CLI_COMMAND "$CODERABBIT_CMD"
+print_kv BASE_BRANCH "$BASE_BRANCH"
+[ -n "$HEAD_BRANCH" ] && print_kv HEAD_BRANCH "$HEAD_BRANCH"
+
+run_with_timeout() {
+  local timeout_seconds="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+  shift 3
+
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$timeout_seconds" "$@" >"$stdout_file" 2>"$stderr_file"
+    return $?
+  fi
+
+  "$@" >"$stdout_file" 2>"$stderr_file" &
+  local child_pid=$!
+  local elapsed=0
+  while kill -0 "$child_pid" 2>/dev/null && [ "$elapsed" -lt "$timeout_seconds" ]; do
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  if kill -0 "$child_pid" 2>/dev/null; then
+    kill "$child_pid" 2>/dev/null || true
+    wait "$child_pid" 2>/dev/null || true
+    return 124
+  fi
+  wait "$child_pid"
+}
+
+stdout_file="$(mktemp)"
+stderr_file="$(mktemp)"
+cleanup() {
+  rm -f "${stdout_file:-}" "${stderr_file:-}"
+}
+trap cleanup EXIT
+
+set +e
+if [ -n "$CODERABBIT_SUBCOMMAND" ]; then
+  run_with_timeout "$TIMEOUT" "$stdout_file" "$stderr_file" \
+    "$CODERABBIT_CMD" "$CODERABBIT_SUBCOMMAND" --agent --base "$BASE_BRANCH"
+else
+  run_with_timeout "$TIMEOUT" "$stdout_file" "$stderr_file" \
+    "$CODERABBIT_CMD" --agent --base "$BASE_BRANCH"
+fi
+cli_exit=$?
+set -e
+
+cli_stdout="$(cat "$stdout_file" 2>/dev/null || true)"
+cli_stderr="$(cat "$stderr_file" 2>/dev/null || true)"
+combined_output="${cli_stdout}
+${cli_stderr}"
+
+if [ "$cli_exit" -eq 124 ]; then
+  echo "WARN: CodeRabbit CLI timed out after ${TIMEOUT}s" >&2
+  print_result skipped 0 0 0 timeout "timeout"
+  exit 3
+fi
+
+if printf '%s\n' "$combined_output" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
+  if printf '%s\n' "$cli_stdout" | jq -e 'type == "object" or type == "array"' >/dev/null 2>&1; then
+    :
+  else
+    emit_rate_limited_result
+  fi
+fi
+
+if [ -z "$(printf '%s' "$cli_stdout" | tr -d '[:space:]')" ]; then
+  echo "WARN: CodeRabbit CLI produced no JSON output (exit $cli_exit)" >&2
+  if printf '%s\n' "$combined_output" | grep -Eiq 'auth|login|unauthori[sz]ed|forbidden|401|403'; then
+    print_result skipped 0 0 0 unauthorized "unavailable"
+  else
+    print_result skipped 0 0 0 no_output "skipped"
+  fi
+  exit 3
+fi
+
+parse_result="$(
+  printf '%s\n' "$cli_stdout" | jq -r '
+    def walk_scalars:
+      if type == "object" then .[] | walk_scalars
+      elif type == "array" then .[] | walk_scalars
+      else . end;
+    def finding_arrays:
+      if type == "array" then
+        .
+      else
+        [
+          .findings?, .comments?, .issues?, .results?, .reviews?, .feedback?,
+          .review.findings?, .review.comments?, .review.issues?,
+          .data.findings?, .data.comments?, .data.issues?
+        ]
+        | map(select(type == "array"))
+        | if length == 0 then null else add end
+      end;
+    def severity_text:
+      [
+        .severity?, .level?, .category?, .type?, .priority?, .impact?,
+        .classification?, .kind?, .status?, .state?
+      ]
+      | map(select(type == "string"))
+      | join(" ")
+      | ascii_downcase;
+    def blocking:
+      severity_text as $s
+      | ($s | test("critical|blocker|blocking|error|bug|security|vulnerability|high|major|must.fix|changes.requested|needs.fixes|needs.changes"));
+    def advisory:
+      severity_text as $s
+      | ($s | test("minor|low|medium|suggestion|advisory|nit|nitpick|trivial|warning|info|informational|style"));
+    . as $root
+    | ($root | finding_arrays) as $findings
+    | if ($findings | type) != "array" then
+        "PARSE_STATUS=missing_findings"
+      else
+        ($findings | length) as $comments
+        | ($findings | map(select(blocking)) | length) as $blocking
+        | ($findings | map(select((blocking | not) and advisory)) | length) as $explicit_advisory
+        | ($comments - $blocking) as $suggestions
+        | if ($findings | map(select((blocking | not) and (advisory | not))) | length) > 0 then
+            "PARSE_STATUS=ambiguous"
+          else
+            "PARSE_STATUS=ok\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking)\nSUGGESTION_COUNT=\($suggestions)\nEXPLICIT_ADVISORY_COUNT=\($explicit_advisory)"
+          end
+      end
+  ' 2>/dev/null
+)" || parse_result=""
+
+parse_status="$(printf '%s\n' "$parse_result" | awk -F= '$1 == "PARSE_STATUS" { print $2; exit }')"
+case "$parse_status" in
+  ok)
+    comment_count="$(printf '%s\n' "$parse_result" | awk -F= '$1 == "COMMENT_COUNT" { print $2; exit }')"
+    blocking_count="$(printf '%s\n' "$parse_result" | awk -F= '$1 == "BLOCKING_COUNT" { print $2; exit }')"
+    suggestion_count="$(printf '%s\n' "$parse_result" | awk -F= '$1 == "SUGGESTION_COUNT" { print $2; exit }')"
+    comment_count="${comment_count:-0}"
+    blocking_count="${blocking_count:-0}"
+    suggestion_count="${suggestion_count:-0}"
+    if [ "$blocking_count" -gt 0 ]; then
+      print_result needs_fixes "$comment_count" "$blocking_count" "$suggestion_count"
+      exit 1
+    fi
+    print_result clean "$comment_count" 0 "$suggestion_count"
+    exit 0
+    ;;
+  missing_findings)
+    if printf '%s\n' "$combined_output" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
+      emit_rate_limited_result
+    elif printf '%s\n' "$combined_output" | grep -Eiq 'auth|login|unauthori[sz]ed|forbidden|401|403'; then
+      echo "WARN: CodeRabbit CLI authentication appears unavailable" >&2
+      print_result skipped 0 0 0 unauthorized "unavailable"
+    else
+      echo "WARN: CodeRabbit CLI JSON did not contain a recognized findings array" >&2
+      print_result skipped 0 0 0 invalid_json "skipped"
+    fi
+    exit 3
+    ;;
+  ambiguous)
+    echo "WARN: CodeRabbit CLI JSON contained findings with ambiguous severity" >&2
+    print_result skipped 0 0 0 ambiguous_output "skipped"
+    exit 3
+    ;;
+  *)
+    if printf '%s\n' "$combined_output" | grep -Eiq 'rate[ -]?limit|too many requests|HTTP[[:space:]]*429'; then
+      emit_rate_limited_result
+    elif printf '%s\n' "$combined_output" | grep -Eiq 'auth|login|unauthori[sz]ed|forbidden|401|403'; then
+      echo "WARN: CodeRabbit CLI authentication appears unavailable" >&2
+      print_result skipped 0 0 0 unauthorized "unavailable"
+    else
+      echo "WARN: CodeRabbit CLI output was not recognized as valid JSON" >&2
+      print_result skipped 0 0 0 invalid_json "skipped"
+    fi
+    exit 3
+    ;;
+esac

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -172,7 +172,7 @@ _interruptible_sleep() {
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--repo owner/repo|product-name] [--product-repo name] [--repo-root path] [--platform greptile] [--platform greptile,devin,pr-agent,coderabbit,codex-github,claude-code-action,copilot,haystack,bugbot] [--ready-phase haystack] [--phase-after-clean haystack] [--draft-github-only] [--pre-after-clean-only] [--poll-interval seconds] [--max-wait seconds] [--post-final-summary] [--compare]
+Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--repo owner/repo|product-name] [--product-repo name] [--repo-root path] [--platform greptile] [--platform greptile,devin,pr-agent,coderabbit,coderabbit-cli,codex-github,claude-code-action,copilot,haystack,bugbot] [--ready-phase haystack] [--phase-after-clean haystack] [--draft-github-only] [--pre-after-clean-only] [--poll-interval seconds] [--max-wait seconds] [--post-final-summary] [--compare]
        ./scripts/development-workflow/pr-review-loop.sh unlock <pr-number>
 
 Runs the automated PR review loop for one or more platforms in sequence. Before
@@ -2150,6 +2150,115 @@ run_haystack_review() {
       print_kv COMMENT_COUNT 0
       print_kv BLOCKING_COUNT 0
       print_kv SUGGESTION_COUNT 0
+      return 0
+      ;;
+  esac
+}
+
+run_coderabbit_cli_review() {
+  # Runs coderabbit-cli-reviewer.sh and maps its exit codes to the standard
+  # pr-review-loop key=value output contract. This is separate from the
+  # coderabbit GitHub App platform, which uses bot comments/reviews.
+  local pr_number="$1"
+  local branch_name="$2"
+  local poll_interval="$3"
+  local max_wait="$4"
+  local platform="coderabbit-cli"
+  local reviewer_script
+  local script_exit=0
+  local script_output=""
+  local blocking_count=0
+  local suggestion_count=0
+  local comment_count=0
+
+  : "$poll_interval"
+  require_gh
+  cd_workflow_repo_root
+
+  local owner repo_name repo
+  repo="$(repo_slug)"
+  owner="$(printf '%s\n' "$repo" | cut -d/ -f1)"
+  repo_name="$(printf '%s\n' "$repo" | cut -d/ -f2)"
+
+  reviewer_script="$(workflow_repo_root)/scripts/development-workflow/coderabbit-cli-reviewer.sh"
+
+  local coderabbit_cli_stderr_file
+  coderabbit_cli_stderr_file="$(mktemp)"
+  trap 'rm -f "${coderabbit_cli_stderr_file:-}"' RETURN
+
+  set +e
+  script_output="$("$reviewer_script" "$pr_number" "$owner" "$repo_name" --timeout "$max_wait" 2>"$coderabbit_cli_stderr_file")"
+  script_exit=$?
+  set -e
+
+  if [ -s "$coderabbit_cli_stderr_file" ]; then
+    echo "INFO: coderabbit-cli-reviewer.sh stderr:" >&2
+    cat "$coderabbit_cli_stderr_file" >&2
+  fi
+  rm -f "$coderabbit_cli_stderr_file"
+
+  blocking_count="$(kv_value_default BLOCKING_COUNT "$script_output" 0)"
+  suggestion_count="$(kv_value_default SUGGESTION_COUNT "$script_output" 0)"
+  comment_count="$(kv_value_default COMMENT_COUNT "$script_output" 0)"
+
+  case "$script_exit" in
+    0)
+      print_kv RESULT clean
+      print_kv PLATFORM "$platform"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv BRANCH "$branch_name"
+      print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv COMMENT_COUNT "$comment_count"
+      print_kv BLOCKING_COUNT 0
+      print_kv SUGGESTION_COUNT "$suggestion_count"
+      return 0
+      ;;
+    1)
+      [ "$blocking_count" -eq 0 ] && blocking_count=1
+      [ "$comment_count" -eq 0 ] && comment_count=1
+      print_kv RESULT needs_fixes
+      print_kv PLATFORM "$platform"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv BRANCH "$branch_name"
+      print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv REASON coderabbit_cli_blocking_findings
+      print_kv COMMENT_COUNT "$comment_count"
+      print_kv BLOCKING_COUNT "$blocking_count"
+      print_kv SUGGESTION_COUNT "$suggestion_count"
+      return 1
+      ;;
+    2)
+      local coderabbit_cli_reason
+      local coderabbit_cli_display_result
+      coderabbit_cli_reason="$(kv_value_default REASON "$script_output" rate_limited)"
+      coderabbit_cli_display_result="$(kv_value_default DISPLAY_RESULT "$script_output" "")"
+      print_kv RESULT escalate
+      print_kv REASON "$coderabbit_cli_reason"
+      [ -n "$coderabbit_cli_display_result" ] && print_kv DISPLAY_RESULT "$coderabbit_cli_display_result"
+      print_kv PLATFORM "$platform"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv BRANCH "$branch_name"
+      print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv COMMENT_COUNT "$comment_count"
+      print_kv BLOCKING_COUNT "$blocking_count"
+      print_kv SUGGESTION_COUNT "$suggestion_count"
+      return 2
+      ;;
+    *)
+      local coderabbit_cli_reason
+      local coderabbit_cli_display_result
+      coderabbit_cli_reason="$(kv_value_default REASON "$script_output" unavailable)"
+      coderabbit_cli_display_result="$(kv_value_default DISPLAY_RESULT "$script_output" "")"
+      print_kv RESULT skipped
+      print_kv REASON "$coderabbit_cli_reason"
+      [ -n "$coderabbit_cli_display_result" ] && print_kv DISPLAY_RESULT "$coderabbit_cli_display_result"
+      print_kv PLATFORM "$platform"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv BRANCH "$branch_name"
+      print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv COMMENT_COUNT "$comment_count"
+      print_kv BLOCKING_COUNT "$blocking_count"
+      print_kv SUGGESTION_COUNT "$suggestion_count"
       return 0
       ;;
   esac
@@ -4312,6 +4421,7 @@ bot_login_for_platform() {
   # threads from any other GHA workflow to PR-Agent.
   case "$1" in
     coderabbit)   printf 'coderabbitai\n' ;;
+    coderabbit-cli) printf '\n' ;;
     devin)        printf 'devin-ai-integration\n' ;;
     greptile)     printf 'greptile-apps\n' ;;
     pr-agent)     printf '\n' ;;
@@ -4459,6 +4569,9 @@ run_platform_review() {
       ;;
     coderabbit)
       run_coderabbit_review "$pr_number" "$branch_name" "$poll_interval" "$max_wait"
+      ;;
+    coderabbit-cli)
+      run_coderabbit_cli_review "$pr_number" "$branch_name" "$poll_interval" "$max_wait"
       ;;
     pr-agent)
       run_pr_agent_review "$pr_number" "$branch_name" "$poll_interval" "$max_wait"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -2183,11 +2183,16 @@ run_coderabbit_cli_review() {
   reviewer_script="$(workflow_repo_root)/scripts/development-workflow/coderabbit-cli-reviewer.sh"
 
   local coderabbit_cli_stderr_file
+  local coderabbit_cli_config_file="${AI_DEV_WORKFLOW_CONFIG_FILE:-${config_file:-}}"
   coderabbit_cli_stderr_file="$(mktemp)"
   trap 'rm -f "${coderabbit_cli_stderr_file:-}"' RETURN
 
   set +e
-  script_output="$("$reviewer_script" "$pr_number" "$owner" "$repo_name" --timeout "$max_wait" 2>"$coderabbit_cli_stderr_file")"
+  if [ -n "$coderabbit_cli_config_file" ] && [ -f "$coderabbit_cli_config_file" ]; then
+    script_output="$(AI_DEV_WORKFLOW_CONFIG_FILE="$coderabbit_cli_config_file" "$reviewer_script" "$pr_number" "$owner" "$repo_name" --timeout "$max_wait" 2>"$coderabbit_cli_stderr_file")"
+  else
+    script_output="$("$reviewer_script" "$pr_number" "$owner" "$repo_name" --timeout "$max_wait" 2>"$coderabbit_cli_stderr_file")"
+  fi
   script_exit=$?
   set -e
 

--- a/scripts/development-workflow/tests/test-coderabbit-cli-pr-review-loop-dispatch.sh
+++ b/scripts/development-workflow/tests/test-coderabbit-cli-pr-review-loop-dispatch.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Dispatch tests for the CodeRabbit CLI pr-review-loop platform.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '$expected', got '$actual'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+HARNESS_MODE=1 source "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
+
+actual="$(bot_login_for_platform coderabbit-cli)"
+run_test "bot_login_for_platform_coderabbit_cli_empty" "" "$actual"
+
+actual="$(bot_login_for_platform coderabbit)"
+run_test "bot_login_for_platform_coderabbit_app_unchanged" "coderabbitai" "$actual"
+
+_coderabbit_cli_dispatch_called=0
+_coderabbit_app_dispatch_called=0
+run_coderabbit_cli_review() {
+  _coderabbit_cli_dispatch_called=1
+  print_kv RESULT skipped
+  print_kv REASON unavailable
+  print_kv COMMENT_COUNT 0
+  print_kv BLOCKING_COUNT 0
+  print_kv SUGGESTION_COUNT 0
+}
+run_coderabbit_review() {
+  _coderabbit_app_dispatch_called=1
+  print_kv RESULT clean
+  print_kv COMMENT_COUNT 0
+  print_kv BLOCKING_COUNT 0
+  print_kv SUGGESTION_COUNT 0
+}
+
+run_platform_review "coderabbit-cli" "999" "feature/test" "30" "120" >/dev/null 2>&1 || true
+run_test "run_platform_review_routes_to_coderabbit_cli" "1" "$_coderabbit_cli_dispatch_called"
+run_test "run_platform_review_does_not_call_app_for_cli" "0" "$_coderabbit_app_dispatch_called"
+
+_coderabbit_cli_dispatch_called=0
+_coderabbit_app_dispatch_called=0
+run_platform_review "coderabbit" "999" "feature/test" "30" "120" >/dev/null 2>&1 || true
+run_test "run_platform_review_routes_to_coderabbit_app" "1" "$_coderabbit_app_dispatch_called"
+run_test "run_platform_review_does_not_call_cli_for_app" "0" "$_coderabbit_cli_dispatch_called"
+
+unset -f run_coderabbit_cli_review run_coderabbit_review
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  echo "FAIL: $FAIL_COUNT test(s) failed"
+  exit 1
+fi
+
+echo "PASS: $PASS_COUNT test(s) passed"

--- a/scripts/development-workflow/tests/test-coderabbit-cli-reviewer.sh
+++ b/scripts/development-workflow/tests/test-coderabbit-cli-reviewer.sh
@@ -138,6 +138,20 @@ run_test "blocking_finding_count" "BLOCKING_COUNT=1" "$(line_for BLOCKING_COUNT)
 run_test "blocking_finding_exit" "1" "$(exit_code)"
 
 reset_mocks
+set_mock_stdout '{"type":"finding","finding":{"severity":"High","message":"fix this"}}
+{"type":"complete","summary":"done"}'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "ndjson_blocking_finding_result" "RESULT=needs_fixes" "$(line_for RESULT)"
+run_test "ndjson_blocking_finding_count" "BLOCKING_COUNT=1" "$(line_for BLOCKING_COUNT)"
+
+reset_mocks
+set_mock_stdout '{"type":"status","message":"review started"}
+{"type":"complete","summary":"done"}'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "ndjson_no_findings_result" "RESULT=clean" "$(line_for RESULT)"
+run_test "ndjson_no_findings_comments" "COMMENT_COUNT=0" "$(line_for COMMENT_COUNT)"
+
+reset_mocks
 set_mock_stdout '{"findings":[{"severity":"Minor","message":"consider this"}]}'
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "advisory_only_result" "RESULT=clean" "$(line_for RESULT)"
@@ -149,6 +163,12 @@ run_reviewer "$MOCK_BIN:$PATH"
 run_test "missing_findings_result" "RESULT=skipped" "$(line_for RESULT)"
 run_test "missing_findings_reason" "REASON=invalid_json" "$(line_for REASON)"
 run_test "missing_findings_exit" "3" "$(exit_code)"
+
+reset_mocks
+set_mock_stdout '{"summary":"authentication docs mention login behavior"}'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "missing_findings_auth_text_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "missing_findings_auth_text_reason" "REASON=invalid_json" "$(line_for REASON)"
 
 reset_mocks
 set_mock_stdout '{"error":"HTTP 429 rate limit exceeded"}'

--- a/scripts/development-workflow/tests/test-coderabbit-cli-reviewer.sh
+++ b/scripts/development-workflow/tests/test-coderabbit-cli-reviewer.sh
@@ -189,6 +189,12 @@ run_test "json_unauthorized_result" "RESULT=skipped" "$(line_for RESULT)"
 run_test "json_unauthorized_reason" "REASON=unauthorized" "$(line_for REASON)"
 
 reset_mocks
+set_mock_stdout '{"findings":[],"error":"Unauthorized. Run coderabbit auth login --agent."}'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "empty_findings_json_unauthorized_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "empty_findings_json_unauthorized_reason" "REASON=unauthorized" "$(line_for REASON)"
+
+reset_mocks
 set_mock_stdout '{"findings":[{"severity":"Needs Triage","message":"unclear"}]}'
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "ambiguous_finding_result" "RESULT=skipped" "$(line_for RESULT)"

--- a/scripts/development-workflow/tests/test-coderabbit-cli-reviewer.sh
+++ b/scripts/development-workflow/tests/test-coderabbit-cli-reviewer.sh
@@ -17,11 +17,12 @@ NO_CLI_BIN="$(mktemp -d)"
 CALL_LOG="$(mktemp)"
 OUTPUT_FILE="$(mktemp)"
 EXIT_FILE="$(mktemp)"
+POLICY_CONFIG_FILE="$(mktemp)"
 
 cleanup() {
   local status=$?
   rm -rf "$MOCK_BIN" "$NO_CLI_BIN"
-  rm -f "$CALL_LOG" "$OUTPUT_FILE" "$EXIT_FILE"
+  rm -f "$CALL_LOG" "$OUTPUT_FILE" "$EXIT_FILE" "$POLICY_CONFIG_FILE"
   exit "$status"
 }
 trap cleanup EXIT
@@ -95,6 +96,7 @@ reset_mocks() {
   export MOCK_CALL_LOG
   unset MOCK_CODERABBIT_STDOUT MOCK_CODERABBIT_STDERR MOCK_CODERABBIT_EXIT MOCK_CODERABBIT_SLEEP
   unset CODERABBIT_CLI_RATE_LIMIT_POLICY CODERABBIT_CLI_REVIEW_TIMEOUT
+  unset AI_DEV_WORKFLOW_CONFIG_FILE
 }
 
 set_mock_stdout() {
@@ -155,6 +157,12 @@ run_test "json_rate_limit_result" "RESULT=skipped" "$(line_for RESULT)"
 run_test "json_rate_limit_reason" "REASON=rate_limited" "$(line_for REASON)"
 
 reset_mocks
+set_mock_stdout '{"findings":[],"error":"HTTP 429 rate limit exceeded"}'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "empty_findings_json_rate_limit_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "empty_findings_json_rate_limit_reason" "REASON=rate_limited" "$(line_for REASON)"
+
+reset_mocks
 set_mock_stdout '{"error":"Unauthorized. Run coderabbit auth login --agent."}'
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "json_unauthorized_result" "RESULT=skipped" "$(line_for RESULT)"
@@ -206,6 +214,28 @@ export MOCK_CODERABBIT_STDERR
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "rate_limit_stderr_with_json_result" "RESULT=skipped" "$(line_for RESULT)"
 run_test "rate_limit_stderr_with_json_reason" "REASON=rate_limited" "$(line_for REASON)"
+
+reset_mocks
+set_mock_stdout '{"findings":[{"severity":"Critical","message":"fix this"}]}'
+MOCK_CODERABBIT_STDERR='HTTP 429 rate limit exceeded'
+export MOCK_CODERABBIT_STDERR
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "blocking_json_with_rate_limit_stderr_result" "RESULT=needs_fixes" "$(line_for RESULT)"
+run_test "blocking_json_with_rate_limit_stderr_exit" "1" "$(exit_code)"
+
+reset_mocks
+cat > "$POLICY_CONFIG_FILE" <<'YAML'
+review:
+  coderabbit_cli:
+    rate_limit_policy: strict
+YAML
+set_mock_stdout '{"findings":[]}'
+MOCK_CODERABBIT_STDERR='HTTP 429 rate limit exceeded'
+AI_DEV_WORKFLOW_CONFIG_FILE="$POLICY_CONFIG_FILE"
+export MOCK_CODERABBIT_STDERR AI_DEV_WORKFLOW_CONFIG_FILE
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "rate_limit_policy_effective_config_result" "RESULT=escalate" "$(line_for RESULT)"
+run_test "rate_limit_policy_effective_config_exit" "2" "$(exit_code)"
 
 reset_mocks
 set_mock_stdout '{"findings":[]}'

--- a/scripts/development-workflow/tests/test-coderabbit-cli-reviewer.sh
+++ b/scripts/development-workflow/tests/test-coderabbit-cli-reviewer.sh
@@ -72,6 +72,9 @@ printf '%s\n' "$0 $*" >> "$MOCK_CALL_LOG"
 if [ -n "${MOCK_CODERABBIT_STDERR:-}" ]; then
   printf '%s\n' "$MOCK_CODERABBIT_STDERR" >&2
 fi
+if [ -n "${MOCK_CODERABBIT_SLEEP:-}" ]; then
+  sleep "$MOCK_CODERABBIT_SLEEP"
+fi
 if [ -n "${MOCK_CODERABBIT_STDOUT:-}" ]; then
   printf '%s\n' "$MOCK_CODERABBIT_STDOUT"
 fi
@@ -90,7 +93,7 @@ reset_mocks() {
   install_cli_mock cr
   install_cli_mock coderabbit
   export MOCK_CALL_LOG
-  unset MOCK_CODERABBIT_STDOUT MOCK_CODERABBIT_STDERR MOCK_CODERABBIT_EXIT
+  unset MOCK_CODERABBIT_STDOUT MOCK_CODERABBIT_STDERR MOCK_CODERABBIT_EXIT MOCK_CODERABBIT_SLEEP
   unset CODERABBIT_CLI_RATE_LIMIT_POLICY CODERABBIT_CLI_REVIEW_TIMEOUT
 }
 
@@ -195,6 +198,24 @@ set_mock_stdout '{"findings":[{"severity":"Minor","message":"mentions HTTP 429 i
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "rate_limit_text_inside_json_result" "RESULT=clean" "$(line_for RESULT)"
 run_test "rate_limit_text_inside_json_suggestions" "SUGGESTION_COUNT=1" "$(line_for SUGGESTION_COUNT)"
+
+reset_mocks
+set_mock_stdout '{"findings":[]}'
+MOCK_CODERABBIT_STDERR='HTTP 429 rate limit exceeded'
+export MOCK_CODERABBIT_STDERR
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "rate_limit_stderr_with_json_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "rate_limit_stderr_with_json_reason" "REASON=rate_limited" "$(line_for REASON)"
+
+reset_mocks
+set_mock_stdout '{"findings":[]}'
+MOCK_CODERABBIT_SLEEP=2
+CODERABBIT_CLI_REVIEW_TIMEOUT=1
+export MOCK_CODERABBIT_SLEEP CODERABBIT_CLI_REVIEW_TIMEOUT
+run_reviewer "$MOCK_BIN:$NO_CLI_BIN"
+run_test "fallback_timeout_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "fallback_timeout_reason" "REASON=timeout" "$(line_for REASON)"
+run_test "fallback_timeout_exit" "3" "$(exit_code)"
 
 reset_mocks
 set_mock_stdout '{"findings":[{"severity":"Minor"},{"severity":"Critical"}]}'

--- a/scripts/development-workflow/tests/test-coderabbit-cli-reviewer.sh
+++ b/scripts/development-workflow/tests/test-coderabbit-cli-reviewer.sh
@@ -18,10 +18,11 @@ CALL_LOG="$(mktemp)"
 OUTPUT_FILE="$(mktemp)"
 EXIT_FILE="$(mktemp)"
 POLICY_CONFIG_FILE="$(mktemp)"
+LOCAL_CONFIG_ROOT="$(mktemp -d)"
 
 cleanup() {
   local status=$?
-  rm -rf "$MOCK_BIN" "$NO_CLI_BIN"
+  rm -rf "$MOCK_BIN" "$NO_CLI_BIN" "$LOCAL_CONFIG_ROOT"
   rm -f "$CALL_LOG" "$OUTPUT_FILE" "$EXIT_FILE" "$POLICY_CONFIG_FILE"
   exit "$status"
 }
@@ -97,6 +98,7 @@ reset_mocks() {
   unset MOCK_CODERABBIT_STDOUT MOCK_CODERABBIT_STDERR MOCK_CODERABBIT_EXIT MOCK_CODERABBIT_SLEEP
   unset CODERABBIT_CLI_RATE_LIMIT_POLICY CODERABBIT_CLI_REVIEW_TIMEOUT
   unset AI_DEV_WORKFLOW_CONFIG_FILE
+  unset WORKFLOW_LOCAL_REVIEW_OVERRIDE_ROOT
 }
 
 set_mock_stdout() {
@@ -242,6 +244,13 @@ run_test "rate_limit_stderr_with_json_result" "RESULT=skipped" "$(line_for RESUL
 run_test "rate_limit_stderr_with_json_reason" "REASON=rate_limited" "$(line_for REASON)"
 
 reset_mocks
+set_mock_stdout '{"findings":[]}'
+MOCK_CODERABBIT_STDERR='author metadata: login hint is informational'
+export MOCK_CODERABBIT_STDERR
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "benign_auth_like_stderr_with_json_result" "RESULT=clean" "$(line_for RESULT)"
+
+reset_mocks
 set_mock_stdout '{"findings":[{"severity":"Critical","message":"fix this"}]}'
 MOCK_CODERABBIT_STDERR='HTTP 429 rate limit exceeded'
 export MOCK_CODERABBIT_STDERR
@@ -264,6 +273,20 @@ run_test "rate_limit_policy_effective_config_result" "RESULT=escalate" "$(line_f
 run_test "rate_limit_policy_effective_config_exit" "2" "$(exit_code)"
 
 reset_mocks
+cat > "$LOCAL_CONFIG_ROOT/.ai-dev-workflow.local.yaml" <<'YAML'
+review:
+  coderabbit_cli:
+    rate_limit_policy: strict
+YAML
+set_mock_stdout '{"findings":[]}'
+MOCK_CODERABBIT_STDERR='HTTP 429 rate limit exceeded'
+WORKFLOW_LOCAL_REVIEW_OVERRIDE_ROOT="$LOCAL_CONFIG_ROOT"
+export MOCK_CODERABBIT_STDERR WORKFLOW_LOCAL_REVIEW_OVERRIDE_ROOT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "rate_limit_policy_local_config_result" "RESULT=escalate" "$(line_for RESULT)"
+run_test "rate_limit_policy_local_config_exit" "2" "$(exit_code)"
+
+reset_mocks
 set_mock_stdout '{"findings":[]}'
 MOCK_CODERABBIT_SLEEP=2
 CODERABBIT_CLI_REVIEW_TIMEOUT=1
@@ -280,6 +303,15 @@ export MOCK_CODERABBIT_EXIT
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "nonzero_valid_json_result" "RESULT=needs_fixes" "$(line_for RESULT)"
 run_test "nonzero_valid_json_exit" "1" "$(exit_code)"
+
+reset_mocks
+set_mock_stdout '{"findings":[]}'
+MOCK_CODERABBIT_EXIT=7
+export MOCK_CODERABBIT_EXIT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "nonzero_clean_json_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "nonzero_clean_json_reason" "REASON=cli_failed" "$(line_for REASON)"
+run_test "nonzero_clean_json_exit" "3" "$(exit_code)"
 
 reset_mocks
 MOCK_CODERABBIT_STDOUT=''

--- a/scripts/development-workflow/tests/test-coderabbit-cli-reviewer.sh
+++ b/scripts/development-workflow/tests/test-coderabbit-cli-reviewer.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Unit tests for coderabbit-cli-reviewer.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)"
+REVIEWER="$REPO_ROOT/scripts/development-workflow/coderabbit-cli-reviewer.sh"
+
+if [ ! -f "$REVIEWER" ]; then
+  echo "ERROR: coderabbit-cli-reviewer.sh not found at $REVIEWER" >&2
+  exit 1
+fi
+
+MOCK_BIN="$(mktemp -d)"
+NO_CLI_BIN="$(mktemp -d)"
+CALL_LOG="$(mktemp)"
+OUTPUT_FILE="$(mktemp)"
+EXIT_FILE="$(mktemp)"
+
+cleanup() {
+  local status=$?
+  rm -rf "$MOCK_BIN" "$NO_CLI_BIN"
+  rm -f "$CALL_LOG" "$OUTPUT_FILE" "$EXIT_FILE"
+  exit "$status"
+}
+trap cleanup EXIT
+
+for _cmd in awk bash cat dirname grep jq mktemp rm sleep tr; do
+  _cmd_path="$(command -v "$_cmd")"
+  ln -sf "$_cmd_path" "$NO_CLI_BIN/$_cmd"
+done
+unset _cmd _cmd_path
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '$expected', got '$actual'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+install_gh_mock() {
+  cat > "$1/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"pr view 123"*"--json baseRefName,headRefName"*)
+    printf '{"baseRefName":"main","headRefName":"feature/test"}\n'
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+MOCK_GH
+  chmod +x "$1/gh"
+}
+
+install_cli_mock() {
+  local target="$1"
+  cat > "$MOCK_BIN/$target" <<'MOCK_CLI'
+#!/usr/bin/env bash
+printf '%s\n' "$0 $*" >> "$MOCK_CALL_LOG"
+if [ -n "${MOCK_CODERABBIT_STDERR:-}" ]; then
+  printf '%s\n' "$MOCK_CODERABBIT_STDERR" >&2
+fi
+if [ -n "${MOCK_CODERABBIT_STDOUT:-}" ]; then
+  printf '%s\n' "$MOCK_CODERABBIT_STDOUT"
+fi
+exit "${MOCK_CODERABBIT_EXIT:-0}"
+MOCK_CLI
+  chmod +x "$MOCK_BIN/$target"
+}
+
+reset_mocks() {
+  rm -f "$CALL_LOG" "$OUTPUT_FILE" "$EXIT_FILE"
+  CALL_LOG="$(mktemp)"
+  OUTPUT_FILE="$(mktemp)"
+  EXIT_FILE="$(mktemp)"
+  rm -f "$MOCK_BIN/cr" "$MOCK_BIN/coderabbit" "$MOCK_BIN/gh"
+  install_gh_mock "$MOCK_BIN"
+  install_cli_mock cr
+  install_cli_mock coderabbit
+  export MOCK_CALL_LOG
+  unset MOCK_CODERABBIT_STDOUT MOCK_CODERABBIT_STDERR MOCK_CODERABBIT_EXIT
+  unset CODERABBIT_CLI_RATE_LIMIT_POLICY CODERABBIT_CLI_REVIEW_TIMEOUT
+}
+
+set_mock_stdout() {
+  MOCK_CODERABBIT_STDOUT="$1"
+  export MOCK_CODERABBIT_STDOUT
+}
+
+run_reviewer() {
+  local path_value="$1"
+  shift
+  set +e
+  PATH="$path_value" "$REVIEWER" 123 owner repo "$@" >"$OUTPUT_FILE" 2>/dev/null
+  local status=$?
+  set -e
+  printf '%s\n' "$status" > "$EXIT_FILE"
+}
+
+line_for() {
+  local key="$1"
+  grep "^${key}=" "$OUTPUT_FILE" | head -n 1 || true
+}
+
+exit_code() {
+  cat "$EXIT_FILE"
+}
+
+reset_mocks
+set_mock_stdout '{"findings":[]}'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "clean_empty_findings_result" "RESULT=clean" "$(line_for RESULT)"
+run_test "clean_empty_findings_comments" "COMMENT_COUNT=0" "$(line_for COMMENT_COUNT)"
+run_test "clean_empty_findings_exit" "0" "$(exit_code)"
+
+reset_mocks
+set_mock_stdout '{"findings":[{"severity":"Critical","message":"fix this"}]}'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "blocking_finding_result" "RESULT=needs_fixes" "$(line_for RESULT)"
+run_test "blocking_finding_count" "BLOCKING_COUNT=1" "$(line_for BLOCKING_COUNT)"
+run_test "blocking_finding_exit" "1" "$(exit_code)"
+
+reset_mocks
+set_mock_stdout '{"findings":[{"severity":"Minor","message":"consider this"}]}'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "advisory_only_result" "RESULT=clean" "$(line_for RESULT)"
+run_test "advisory_only_suggestions" "SUGGESTION_COUNT=1" "$(line_for SUGGESTION_COUNT)"
+
+reset_mocks
+set_mock_stdout '{"summary":"complete"}'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "missing_findings_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "missing_findings_reason" "REASON=invalid_json" "$(line_for REASON)"
+run_test "missing_findings_exit" "3" "$(exit_code)"
+
+reset_mocks
+set_mock_stdout '{"error":"HTTP 429 rate limit exceeded"}'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "json_rate_limit_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "json_rate_limit_reason" "REASON=rate_limited" "$(line_for REASON)"
+
+reset_mocks
+set_mock_stdout '{"error":"Unauthorized. Run coderabbit auth login --agent."}'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "json_unauthorized_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "json_unauthorized_reason" "REASON=unauthorized" "$(line_for REASON)"
+
+reset_mocks
+set_mock_stdout '{"findings":[{"severity":"Needs Triage","message":"unclear"}]}'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "ambiguous_finding_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "ambiguous_finding_reason" "REASON=ambiguous_output" "$(line_for REASON)"
+
+reset_mocks
+set_mock_stdout 'not json'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "invalid_json_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "invalid_json_reason" "REASON=invalid_json" "$(line_for REASON)"
+
+reset_mocks
+MOCK_CODERABBIT_STDOUT=''
+MOCK_CODERABBIT_STDERR='HTTP 429 rate limit exceeded'
+MOCK_CODERABBIT_EXIT=1
+export MOCK_CODERABBIT_STDOUT MOCK_CODERABBIT_STDERR MOCK_CODERABBIT_EXIT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "rate_limit_warn_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "rate_limit_warn_reason" "REASON=rate_limited" "$(line_for REASON)"
+run_test "rate_limit_warn_display" "DISPLAY_RESULT=rate_limited" "$(line_for DISPLAY_RESULT)"
+run_test "rate_limit_warn_exit" "3" "$(exit_code)"
+
+reset_mocks
+MOCK_CODERABBIT_STDERR='too many requests'
+MOCK_CODERABBIT_EXIT=1
+CODERABBIT_CLI_RATE_LIMIT_POLICY=strict
+export MOCK_CODERABBIT_STDERR MOCK_CODERABBIT_EXIT CODERABBIT_CLI_RATE_LIMIT_POLICY
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "rate_limit_strict_result" "RESULT=escalate" "$(line_for RESULT)"
+run_test "rate_limit_strict_reason" "REASON=rate_limited" "$(line_for REASON)"
+run_test "rate_limit_strict_exit" "2" "$(exit_code)"
+
+reset_mocks
+set_mock_stdout '{"findings":[{"severity":"Minor","message":"mentions HTTP 429 inside a finding body"}]}'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "rate_limit_text_inside_json_result" "RESULT=clean" "$(line_for RESULT)"
+run_test "rate_limit_text_inside_json_suggestions" "SUGGESTION_COUNT=1" "$(line_for SUGGESTION_COUNT)"
+
+reset_mocks
+set_mock_stdout '{"findings":[{"severity":"Minor"},{"severity":"Critical"}]}'
+MOCK_CODERABBIT_EXIT=7
+export MOCK_CODERABBIT_EXIT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "nonzero_valid_json_result" "RESULT=needs_fixes" "$(line_for RESULT)"
+run_test "nonzero_valid_json_exit" "1" "$(exit_code)"
+
+reset_mocks
+MOCK_CODERABBIT_STDOUT=''
+MOCK_CODERABBIT_EXIT=1
+export MOCK_CODERABBIT_STDOUT MOCK_CODERABBIT_EXIT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "nonzero_empty_output_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "nonzero_empty_output_exit" "3" "$(exit_code)"
+
+reset_mocks
+set_mock_stdout '{"findings":[{"severity":"Low"},{"severity":"Major"},{"severity":"Nitpick"}]}'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "multiple_findings_result" "RESULT=needs_fixes" "$(line_for RESULT)"
+run_test "multiple_findings_blocking" "BLOCKING_COUNT=1" "$(line_for BLOCKING_COUNT)"
+run_test "multiple_findings_suggestions" "SUGGESTION_COUNT=2" "$(line_for SUGGESTION_COUNT)"
+
+reset_mocks
+set_mock_stdout '[{"severity":"Low"},{"severity":"Minor"}]'
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "top_level_array_result" "RESULT=clean" "$(line_for RESULT)"
+run_test "top_level_array_suggestions" "SUGGESTION_COUNT=2" "$(line_for SUGGESTION_COUNT)"
+
+reset_mocks
+rm -f "$MOCK_BIN/cr"
+set_mock_stdout '{"findings":[]}'
+run_reviewer "$MOCK_BIN:$NO_CLI_BIN"
+run_test "fallback_coderabbit_result" "RESULT=clean" "$(line_for RESULT)"
+run_test "fallback_coderabbit_command" "CLI_COMMAND=coderabbit" "$(line_for CLI_COMMAND)"
+run_test "fallback_coderabbit_base" "BASE_BRANCH=main" "$(line_for BASE_BRANCH)"
+
+reset_mocks
+run_reviewer "$NO_CLI_BIN"
+run_test "missing_cli_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "missing_cli_reason" "REASON=unavailable" "$(line_for REASON)"
+run_test "missing_cli_exit" "3" "$(exit_code)"
+
+reset_mocks
+MOCK_CODERABBIT_STDERR='Unauthorized, run coderabbit auth login --agent'
+MOCK_CODERABBIT_EXIT=1
+export MOCK_CODERABBIT_STDERR MOCK_CODERABBIT_EXIT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "unauthorized_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "unauthorized_reason" "REASON=unauthorized" "$(line_for REASON)"
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  echo "FAIL: $FAIL_COUNT test(s) failed"
+  exit 1
+fi
+
+echo "PASS: $PASS_COUNT test(s) passed"


### PR DESCRIPTION
## Summary
- add a local CodeRabbit CLI reviewer wrapper
- wire coderabbit-cli into pr-review-loop separately from the existing CodeRabbit GitHub App platform
- document configuration and update Protocol 93, REVIEW.md, scripts README, and changelog

## Validation
- bash scripts/development-workflow/tests/test-coderabbit-cli-reviewer.sh
- bash scripts/development-workflow/tests/test-coderabbit-cli-pr-review-loop-dispatch.sh
- bash scripts/development-workflow/tests/test-pr-review-loop.sh
- shellcheck --severity=warning on touched shell files
- npx markdownlint-cli2 docs/testing/workflow/1375-coderabbit-cli-review-platform.smoke-test.md REVIEW.md docs/workflow/development-workflow/integrations/coderabbit.md docs/workflow/development-workflow/integrations/pr-review-platform.md docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md scripts/development-workflow/README.md CHANGELOG.md
- python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop
- python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop
- bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md
- git diff origin/develop...HEAD --check

Checkpoint note: implementation/security and plan checkpoints remain pending before merge.

Closes #1375

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Step 7 readiness semantics for anyone enabling the platform; mis-treating `skipped` as clean could weaken gates, though docs and tests emphasize fail-closed behavior.
> 
> **Overview**
> Introduces **`coderabbit-cli`** as an optional Step 7 automated reviewer, separate from the existing **`coderabbit`** GitHub App path. Opt in by listing `coderabbit-cli` under `review.on_draft.github` or `review.on_ready.github`; optional `review.coderabbit_cli.rate_limit_policy` (`warn` | `strict`) or `CODERABBIT_CLI_RATE_LIMIT_POLICY`.
> 
> **`coderabbit-cli-reviewer.sh`** runs `cr` / `coderabbit review --agent` against the PR base (from `gh pr view`, else `develop`), normalizes agent JSON/NDJSON, classifies blocking vs advisory severities, and emits the standard `RESULT=` / counts contract. Missing CLI, auth failures, timeouts, bad JSON, ambiguous severities, and rate limits map to **`skipped`** or **`escalate`** (strict rate limit)—not **`clean`**.
> 
> **`pr-review-loop.sh`** adds `run_coderabbit_cli_review`, routes `coderabbit-cli` in `run_platform_review`, and returns an empty bot login so thread auditing does not treat CLI output as GitHub bot comments. **REVIEW.md**, Protocol 93, and integration docs state that only script **`RESULT=clean`** counts as a fresh CLI pass; **`skipped`** is availability evidence only.
> 
> Unit and dispatch tests cover JSON edge cases, rate-limit policies, and routing vs the App platform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b44c95b6b368d93f21159fef23a8dbb191eed4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->