### PR TITLE
feat: add project advisory checks hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Add project advisory checks hook** (#1279): Let downstream projects append
+  diff-scoped informational checks to reviewer summaries without changing
+  reviewer results or readiness.
 - **Cross-check plan operational assumptions** (#1201): Record and re-verify
   cross-cutting plan assumptions so concurrent workflow work cannot silently
   invalidate implementation guidance.

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -751,6 +751,35 @@ Any clean exit where the script output includes one or more advisory label entri
 
 This step is mandatory when advisory findings are present. A summary comment that only lists finding names and links without dispositions leaves human reviewers and future retrospectives without visibility into whether findings were considered and why.
 
+### Project advisory checks hook
+
+After configured platform reviewers, review-thread checks, compare-mode
+settlement, and reviewer-failed label reconciliation have completed,
+`pr-review-loop.sh` runs the optional project extension
+`scripts/development-workflow/run-advisory-checks.sh <pr-number>` once when a
+PR number is available and the script exists.
+
+The extension is a summary hook only:
+
+- The supplied template script is a no-op that exits zero and emits no stdout.
+- Downstream projects may customize the script to run diff-scoped static
+  analysis or similar checks.
+- Non-empty stdout is inserted into the automated reviewer summary after ready
+  phase, compare-mode, and platform advisory details, and before any
+  regression-readiness annotation.
+- The extension owns its complete Markdown section heading. The recommended
+  heading is `**Advisory checks** _(informational - never blocks merge)_`.
+- Extension stderr is not included in the summary.
+- Missing PR context, a missing script, empty stdout, or a non-zero extension
+  exit is fail-open and never changes `RESULT`, `REASON`, blocker/suggestion
+  counts, labels, readiness decisions, or the reviewer-loop process exit.
+
+Project advisory checks are distinct from platform advisory dispositions. The
+mandatory `ADVISORY_LABELS` disposition flow above applies only to advisory
+findings emitted by configured review platforms. Project advisory notes are
+informational operator context unless another existing gate independently
+reports the same concern as blocking.
+
 ---
 
 ### Pre-post verification guard (mandatory before every `gh pr comment` / `gh pr review` call)

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -262,6 +262,7 @@ review aggregation and before the final reviewer-loop summary is posted.
 
 Usage:
 
+<!-- workflow-shell-contract: bash-zsh -->
 ```bash
 ./scripts/development-workflow/run-advisory-checks.sh <pr-number>
 ```
@@ -279,6 +280,7 @@ Customization contract:
 - Write a complete Markdown-ready advisory section to stdout when there is
   useful informational output, including the section heading. Example:
 
+  <!-- workflow-shell-contract: bash-zsh -->
   ```bash
   printf '\n\n**Advisory checks** _(informational - never blocks merge)_\n'
   printf -- '- Dead exports: none found\n'

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -255,6 +255,42 @@ Use this when:
 - The orchestrator is resuming a PR after a prior push or interruption
 - More than one automated reviewer is configured for a repository
 
+### `run-advisory-checks.sh`
+
+Optional project extension point invoked by `pr-review-loop.sh` after platform
+review aggregation and before the final reviewer-loop summary is posted.
+
+Usage:
+
+```bash
+./scripts/development-workflow/run-advisory-checks.sh <pr-number>
+```
+
+What it does by default:
+
+- Exits successfully and emits no stdout.
+- Defines the stable customization point for downstream projects that want to
+  append diff-scoped informational checks to the reviewer-loop summary.
+- Receives exactly one positional argument: the pull request number currently
+  being reviewed.
+
+Customization contract:
+
+- Write a complete Markdown-ready advisory section to stdout when there is
+  useful informational output, including the section heading. Example:
+
+  ```bash
+  printf '\n\n**Advisory checks** _(informational - never blocks merge)_\n'
+  printf -- '- Dead exports: none found\n'
+  ```
+
+- Keep diagnostics on stderr. `pr-review-loop.sh` suppresses extension stderr in
+  the summary.
+- The extension is advisory-only. Its output, failure, or absence never changes
+  `RESULT`, blocker counts, readiness labels, or the reviewer-loop exit status.
+- Missing PR context, a missing script, or empty stdout produces no summary
+  section.
+
 ### `workflow-next-action.sh`
 
 Classifies the next deterministic workflow action for a branch, PR, or development folder.

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4639,6 +4639,26 @@ ensure_pr_ready_for_after_clean() {
   ensure_pr_ready_for_ready_phase "$@"
 }
 
+run_project_advisory_checks() {
+  local pr_number_arg="${1:-}"
+  local script_path="${2:-$SCRIPT_DIR/run-advisory-checks.sh}"
+  local advisory_output=""
+
+  if [ -z "$pr_number_arg" ] || [ ! -f "$script_path" ]; then
+    return 0
+  fi
+
+  set +e
+  advisory_output="$(bash "$script_path" "$pr_number_arg" 2>/dev/null)"
+  set -e
+
+  if [ -n "$advisory_output" ]; then
+    printf '%s\n' "$advisory_output"
+  fi
+
+  return 0
+}
+
 # --- Compare-mode helpers ---
 # These functions are defined here (before the main execution block) so that
 # the test harness can load them via HARNESS_MODE=1 sourcing without executing
@@ -6098,6 +6118,7 @@ _post_review_summary() {
   local phase_net_new_blocker="${11:-0}"
   local phase_blocking_platform="${12:-}"
   local pre_after_clean_only_mode="${13:-0}"
+  local advisory_checks_section="${14:-}"
 
   if [ -z "$pr_number" ]; then
     return 0
@@ -6273,7 +6294,7 @@ Protocol 91 Step 7b requires this label on all \`${branch_name%%/*}/*\` PRs afte
 
 **Result:** ${result_line}
 **Platforms:** ${platform_list:-none}${policy_status_section}
-**Findings:** ${blocking} blocking, ${suggestions} suggestions${phase_section}${compare_section}${advisory_section}${regression_label_section}
+**Findings:** ${blocking} blocking, ${suggestions} suggestions${phase_section}${compare_section}${advisory_section}${advisory_checks_section}${regression_label_section}
 
 *Posted automatically by \`pr-review-loop.sh\`.*
 EOF
@@ -6592,6 +6613,8 @@ if reviewer_failed_label_required_for_result "$aggregate_result" "$aggregate_rea
 fi
 sync_reviewer_failed_label "$pr_number" "$reviewer_failed_required"
 
+advisory_checks_section="$(run_project_advisory_checks "$pr_number")"
+
 print_kv RESULT "$aggregate_result"
 print_kv PLATFORM "$last_platform"
 [ -n "$aggregate_reason" ] && print_kv REASON "$aggregate_reason"
@@ -6638,7 +6661,8 @@ case "$aggregate_result" in
       "$aggregate_possible_issue_eval_outcome" \
       "$phase_after_clean_enabled" "$phase_after_clean_platform_list" \
       "$phase_after_clean_started" "$phase_after_clean_net_new_blocker" \
-      "$phase_after_clean_blocking_platform" "$pre_after_clean_only"
+      "$phase_after_clean_blocking_platform" "$pre_after_clean_only" \
+      "$advisory_checks_section"
     exit 0
     ;;
   skipped)
@@ -6652,7 +6676,8 @@ case "$aggregate_result" in
       "$aggregate_possible_issue_eval_outcome" \
       "$phase_after_clean_enabled" "$phase_after_clean_platform_list" \
       "$phase_after_clean_started" "$phase_after_clean_net_new_blocker" \
-      "$phase_after_clean_blocking_platform" "$pre_after_clean_only"
+      "$phase_after_clean_blocking_platform" "$pre_after_clean_only" \
+      "$advisory_checks_section"
     exit 1
     ;;
   needs_rerun)
@@ -6667,7 +6692,8 @@ case "$aggregate_result" in
       "$aggregate_possible_issue_eval_outcome" \
       "$phase_after_clean_enabled" "$phase_after_clean_platform_list" \
       "$phase_after_clean_started" "$phase_after_clean_net_new_blocker" \
-      "$phase_after_clean_blocking_platform" "$pre_after_clean_only"
+      "$phase_after_clean_blocking_platform" "$pre_after_clean_only" \
+      "$advisory_checks_section"
     exit 3
     ;;
   escalate)
@@ -6678,7 +6704,8 @@ case "$aggregate_result" in
       "$aggregate_possible_issue_eval_outcome" \
       "$phase_after_clean_enabled" "$phase_after_clean_platform_list" \
       "$phase_after_clean_started" "$phase_after_clean_net_new_blocker" \
-      "$phase_after_clean_blocking_platform" "$pre_after_clean_only"
+      "$phase_after_clean_blocking_platform" "$pre_after_clean_only" \
+      "$advisory_checks_section"
     exit 2
     ;;
   *)

--- a/scripts/development-workflow/run-advisory-checks.sh
+++ b/scripts/development-workflow/run-advisory-checks.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Optional project extension point for pr-review-loop.sh.
+#
+# Usage:
+#   run-advisory-checks.sh <pr-number>
+#
+# Downstream projects may replace this no-op body with diff-scoped checks. When
+# emitting output, write a complete Markdown-ready advisory section to stdout,
+# for example:
+#
+#   printf '\n\n**Advisory checks** _(informational - never blocks merge)_\n'
+#   printf -- '- Dead exports: none found\n'
+#
+# Stderr is intentionally ignored by the caller, and this script's exit status
+# never changes the reviewer-loop result. Keep project-specific tooling bounded
+# and fail-open so advisory checks remain informational.
+
+_pr_number="${1:?Usage: $0 <pr-number>}"
+: "$_pr_number"
+
+exit 0

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -33,6 +33,7 @@ MOCK_BIN="$(mktemp -d)"
 _METRICS_TMP=""
 _METRICS_DIR=""
 _CONFIG_DIR=""
+_ADVISORY_TMP=""
 
 # Single EXIT trap: normalise SIGPIPE exit code (141 -> 0) and clean up temp
 # directories. A second trap would override this one, losing the 141 guard.
@@ -41,6 +42,7 @@ _harness_exit() {
   rm -rf "$MOCK_BIN"
   [ -n "${_METRICS_DIR:-}" ] && rm -rf "$_METRICS_DIR"
   [ -n "${_CONFIG_DIR:-}" ] && rm -rf "$_CONFIG_DIR"
+  [ -n "${_ADVISORY_TMP:-}" ] && rm -rf "$_ADVISORY_TMP"
   case "$status" in
     141) exit 0 ;;
     *)   exit "$status" ;;
@@ -211,6 +213,74 @@ grep_count_or_zero() {
     *) return "$status" ;;
   esac
 }
+
+# ---------------------------------------------------------------------------
+# Area 0a: project advisory checks hook
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 0a: project advisory checks hook ==="
+
+_ADVISORY_TMP="$(mktemp -d)"
+
+set +e
+_default_advisory_output="$(bash "$REPO_ROOT/scripts/development-workflow/run-advisory-checks.sh" 123)"
+_default_advisory_status=$?
+set -e
+run_test "project_advisory_default_stub_exit" "0" "$_default_advisory_status"
+run_test "project_advisory_default_stub_empty" "" "$_default_advisory_output"
+
+_marker_script="$_ADVISORY_TMP/marker-advisory.sh"
+_marker_file="$_ADVISORY_TMP/marker-count.txt"
+_empty_advisory_output_file="$_ADVISORY_TMP/project-advisory-empty.out"
+cat > "$_marker_script" <<'EOF_MARKER_ADVISORY'
+#!/usr/bin/env bash
+printf '%s\n' "${1:-}" >> "$MARKER_FILE"
+printf '\n\n**Advisory checks** _(informational - never blocks merge)_\n'
+printf -- '- marker ran for PR %s\n' "${1:-}"
+EOF_MARKER_ADVISORY
+chmod +x "$_marker_script"
+MARKER_FILE="$_marker_file" run_project_advisory_checks "" "$_marker_script" >"$_empty_advisory_output_file"
+if [ -e "$_marker_file" ]; then
+  _empty_pr_invoked="yes"
+else
+  _empty_pr_invoked="no"
+fi
+run_test "project_advisory_empty_pr_no_invoke" "no" "$_empty_pr_invoked"
+run_test "project_advisory_empty_pr_empty_output" "" "$(cat "$_empty_advisory_output_file")"
+
+_missing_advisory_output="$(run_project_advisory_checks 42 "$_ADVISORY_TMP/missing-advisory.sh")"
+run_test "project_advisory_missing_script_empty" "" "$_missing_advisory_output"
+
+_marker_output="$(MARKER_FILE="$_marker_file" run_project_advisory_checks 42 "$_marker_script")"
+run_test "project_advisory_marker_invoked_once" "1" "$(wc -l < "$_marker_file" | tr -d ' ')"
+run_test "project_advisory_multiline_preserved" "yes" "$(
+  if printf '%s\n' "$_marker_output" | grep -q 'marker ran for PR 42'; then
+    printf 'yes'
+  else
+    printf 'no'
+  fi
+)"
+
+_failing_advisory_script="$_ADVISORY_TMP/failing-advisory.sh"
+cat > "$_failing_advisory_script" <<'EOF_FAILING_ADVISORY'
+#!/usr/bin/env bash
+printf '\n\n**Advisory checks** _(informational - never blocks merge)_\n'
+printf -- '- diagnostic preserved\n'
+exit 17
+EOF_FAILING_ADVISORY
+chmod +x "$_failing_advisory_script"
+set +e
+_failing_advisory_output="$(run_project_advisory_checks 42 "$_failing_advisory_script")"
+_failing_advisory_status=$?
+set -e
+run_test "project_advisory_failure_returns_zero" "0" "$_failing_advisory_status"
+run_test "project_advisory_failure_preserves_stdout" "yes" "$(
+  if printf '%s\n' "$_failing_advisory_output" | grep -q 'diagnostic preserved'; then
+    printf 'yes'
+  else
+    printf 'no'
+  fi
+)"
 
 # ---------------------------------------------------------------------------
 # Area 0: draft/ready lifecycle config parsing
@@ -1475,16 +1545,17 @@ fi
 run_test "summary_policy_acknowledgements_section" "1" "$_policy_status_summary_count"
 unset _policy_status_summary_count
 
-# Test 10.7: blocking findings and advisory findings both remain visible in the summary.
+# Test 10.7: blocking, platform advisory, and project advisory findings remain
+# visible in the summary in the required order.
 _post_summary_source="$(awk '/^_post_review_summary\(\)/,/^}$/' \
   "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"
 eval "$_post_summary_source"
 # shellcheck disable=SC2329 # Invoked indirectly by the eval-loaded function.
 repo_slug() { printf "owner/repo\n"; }
 # shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
-compare_mode=0
+compare_mode=1
 # shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
-compare_verdicts=()
+compare_verdicts=("coderabbit" "clean")
 # shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
 platform_policy_status_notes=()
 # shellcheck disable=SC2034 # Read by the eval-loaded _post_review_summary function.
@@ -1513,16 +1584,37 @@ MOCK_GH_EXIT=0
 export MOCK_GH_EXIT
 MOCK_GH_COMMENTS_OUTPUT='[]'
 export MOCK_GH_COMMENTS_OUTPUT
+_project_advisory_section="
+
+**Advisory checks** _(informational - never blocks merge)_
+- Project-specific note"
 _post_review_summary "needs_fixes" "haystack_blocking_findings" "haystack (needs_fixes)" "1" "1" \
-  "Rules violation@@@https://github.com/lhpaul/ai-dev-framework-template/pull/952#issuecomment-1"
+  "Rules violation@@@https://github.com/lhpaul/ai-dev-framework-template/pull/952#issuecomment-1" \
+  "" "1" "haystack" "1" "0" "" "0" "$_project_advisory_section"
 if [ -n "${_summary_body_capture:-}" ] && grep -q "1 blocking finding(s) require fixes" "$_summary_body_capture" \
     && grep -q "Advisory findings (non-blocking):" "$_summary_body_capture" \
-    && grep -q "Rules violation" "$_summary_body_capture"; then
+    && grep -q "Rules violation" "$_summary_body_capture" \
+    && grep -q "Advisory checks" "$_summary_body_capture" \
+    && grep -q "Project-specific note" "$_summary_body_capture"; then
   _summary_advisory_split="yes"
 else
   _summary_advisory_split="no"
 fi
 run_test "summary_advisory_split_visible" "yes" "$_summary_advisory_split"
+_phase_line="$(grep -n "Ready reviewer phase" "$_summary_body_capture" | cut -d: -f1 | head -1)"
+_compare_line="$(grep -n "Compare mode" "$_summary_body_capture" | cut -d: -f1 | head -1)"
+_platform_advisory_line="$(grep -n "Advisory findings" "$_summary_body_capture" | cut -d: -f1 | head -1)"
+_project_advisory_line="$(grep -n "Advisory checks" "$_summary_body_capture" | cut -d: -f1 | head -1)"
+if [ -n "$_phase_line" ] && [ -n "$_compare_line" ] \
+    && [ -n "$_platform_advisory_line" ] && [ -n "$_project_advisory_line" ] \
+    && [ "$_phase_line" -lt "$_compare_line" ] \
+    && [ "$_compare_line" -lt "$_platform_advisory_line" ] \
+    && [ "$_platform_advisory_line" -lt "$_project_advisory_line" ]; then
+  _summary_project_advisory_order="yes"
+else
+  _summary_project_advisory_order="no"
+fi
+run_test "summary_project_advisory_order" "yes" "$_summary_project_advisory_order"
 rm -f "$_summary_call_log"
 rm -f "$_summary_body_capture"
 
@@ -1549,8 +1641,9 @@ fi
 run_test "summary_comment_read_failure_history_unavailable" "yes" "$_summary_read_failed_history"
 rm -f "$_summary_read_failed_body_capture"
 unset MOCK_GH_CALL_LOG MOCK_GH_BODY_CAPTURE MOCK_GH_EXIT MOCK_GH_COMMENTS_OUTPUT MOCK_GH_COMMENTS_EXIT MOCK_GH_UPDATED_AT
-unset _summary_advisory_split _post_summary_source
+unset _summary_advisory_split _summary_project_advisory_order _post_summary_source
 unset _summary_read_failed_body_capture _summary_read_failed_history
+unset _phase_line _compare_line _platform_advisory_line _project_advisory_line
 unset -f _post_review_summary
 unset compare_mode compare_verdicts platform_policy_status_notes pr_number branch_name
 


### PR DESCRIPTION
## Summary
- Add `run_project_advisory_checks` to append optional project advisory output to reviewer-loop summaries without changing reviewer results.
- Add the no-op `scripts/development-workflow/run-advisory-checks.sh` extension point.
- Cover empty PR context, missing script, multiline output, non-zero extension exits, summary ordering, and default no-op behavior.
- Document the extension contract in the workflow script README and Protocol 93.

## Verification
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` (330 passed, 0 failed)
- `bash scripts/development-workflow/run-advisory-checks.sh 123 | wc -c | tr -d " "` (0)
- `shellcheck --severity=warning scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/run-advisory-checks.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md" "docs/testing/workflow/1279-advisory-checks-hook.smoke-test.md" "scripts/development-workflow/README.md" "CHANGELOG.md"`
- `git diff --check`
- `bash -n scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/run-advisory-checks.sh scripts/development-workflow/tests/test-pr-review-loop.sh`

## Pre-submission self-review
Stale markers - none. Caller consistency - summary parameter 14, helper name, entry point, docs, smoke wording, and tests use the same contract. Coverage - all acceptance criteria addressed. Complex gate matrix - advisory hook result/exit invariants covered by harness and Protocol 93 wording. Test harness checklist - empty input, missing extension, multiline output, non-zero extension, marker invocation count, and summary ordering covered; concurrency is not applicable because the hook runs synchronously once in the existing reviewer-loop process.

Closes #1279

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Advisory-only, fail-open hook after existing gates; no changes to auth, merge logic, or reviewer RESULT/exit semantics beyond summary comment content.
> 
> **Overview**
> Adds an optional **project advisory checks** extension so repos can append diff-scoped informational notes to the automated reviewer-loop summary without affecting merge readiness.
> 
> `pr-review-loop.sh` gains `run_project_advisory_checks`, which runs `scripts/development-workflow/run-advisory-checks.sh <pr>` once after platform aggregation and reviewer-failed label sync. The shipped script is a no-op; downstream projects replace it to print a full Markdown section (heading + bullets) on stdout. That output is threaded into `_post_review_summary` **after** ready phase, compare mode, and platform advisory findings, and **before** regression-readiness text. Missing PR, missing script, empty stdout, stderr, and non-zero exit are all **fail-open**—they never change `RESULT`, counts, labels, or process exit codes.
> 
> Protocol 93, the development-workflow README, and CHANGELOG document the contract (distinct from mandatory `ADVISORY_LABELS` dispositions). `test-pr-review-loop.sh` adds Area 0a coverage plus summary ordering assertions for the new section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea8bc91f4c8802e3e92339ceac20dd3b6abfdaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->