### PR TITLE
feat: add planless overlap fallback

### DIFF
--- a/.agents/skills/run-items/SKILL.md
+++ b/.agents/skills/run-items/SKILL.md
@@ -67,9 +67,16 @@ proposal step.
     evidence visible until the parent records `Resolved` or stops for
     `unclear_requirements` and request `Human decision required`; do not widen
     the bounded list or replace this with an all-open-PR scan.
-12. Do not stop after advancing one item if another item in the explicit list still
+12. Before parallel implementation dispatch, run Protocol 90's planless overlap
+   gate from the current tracker snapshot and plan-derived file sets. Concrete
+   overlap pairs and suspected pairs without a matching current `allow_parallel`
+   decision are serialized by default; pass serial groups into
+   `workflow-batch-lanes.sh --overlap-input` or apply the identical hold result.
+   Keep the pair IDs, typed evidence, evidence hashes, accepted/stale decisions,
+   and held-item reasons visible in the confirmation and final summaries.
+13. Do not stop after advancing one item if another item in the explicit list still
    has a deterministic next action.
-13. Do not stop at transient in-flight CI/watch states. If a local watch exits
+14. Do not stop at transient in-flight CI/watch states. If a local watch exits
    early, duplicate checks are skipped/cancelled, or GitHub still shows pending
    or incomplete check evidence, re-query authoritative PR/check state and keep
    supervising until every in-scope PR is green, blocked, escalated, merged, or
@@ -77,17 +84,17 @@ proposal step.
    For sweep, batch, helper-extraction, numeric-target, or pattern-completeness
    items, require residual gate evidence before accepting an item as
    `ready-for-human-review`.
-14. For `spec/*` and `implementation-plan/*` PRs, require Protocol 91 Step 8a's
+15. For `spec/*` and `implementation-plan/*` PRs, require Protocol 91 Step 8a's
    documentation-stage alignment checker before accepting readiness. A
    mismatch keeps the item under supervision until corrected or escalated.
-15. Before accepting any in-scope item as terminal, require the item runner's
+16. Before accepting any in-scope item as terminal, require the item runner's
    `## Ground-Truth Completion Verification` output from
    `item-completion-self-check.sh` or run the helper directly from current
    artifact state. When Step 7 was configured, pass `--require-review-summary true`
    and `--require-review-threads true` (helper defaults are false). Missing
    self-check evidence, `discrepancy`, or `unavailable_required` keeps the item
    under Protocol 90 Step 5 supervision.
-16. After all in-scope PRs reach `ready-for-human-review`, inspect the effective
+17. After all in-scope PRs reach `ready-for-human-review`, inspect the effective
    guardrails. When the relevant stages allow `may_merge_pr: true`, run
    Guardrails Enforcement Gate 5 for each in-scope PR, including
    `run-epic-risk-classifier.sh` and `run-epic-delegated-gate.sh`; continue only
@@ -114,7 +121,7 @@ proposal step.
    `out_of_scope`. A `merge_granted` PR that stops at readiness without a
    named blocker is `policy_inconsistent`; a `merge_denied` PR stops at
    `ready_human_merge`.
-17. For single-item advancement use `$run-item`; for epic-scoped runs use `$run-epic`;
+18. For single-item advancement use `$run-item`; for epic-scoped runs use `$run-epic`;
    for read-only portfolio scan and proposal use `$run-work`.
 
 > **Deprecation notice**: `/run-epic --items` is deprecated. Use `/run-items` for

--- a/.agents/skills/run-work/SKILL.md
+++ b/.agents/skills/run-work/SKILL.md
@@ -26,6 +26,11 @@ command. It performs no mutation in any routing mode.
 4. For `no_target_scan`, follow Protocol 90 Steps 1–3 (scan + propose) only.
    Do **not** dispatch items — present the proposal and emit the recommended
    `/run-items` command for the operator to execute.
+   When proposing multiple implementation items, include Protocol 90's
+   planless overlap disposition from `workflow-batch-overlap.sh`: concrete
+   pairs and unconfirmed suspected pairs are serialized by default, and the
+   proposal shows pair IDs, typed evidence, evidence hashes, and held-item
+   reasons.
 5. In `no_target_scan` output, keep Protocol 90 report categories distinct:
    `INFORMATIONAL - not actionable in this proposal`,
    `ACTIONABLE RESUME - can advance now`,

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -58,6 +58,11 @@ That document is the single source of truth for this supporting role. Key respon
   helper's `humanAction`. Shared keywords alone are not dependency evidence.
 - Prioritize by due date (within 2 weeks) → priority → creation date
 - Build the largest safe explicit batch possible and document when work must be serialized
+- Before parallel implementation dispatch, run Protocol 90's planless overlap
+  gate from the current tracker snapshot and plan-derived file sets. Concrete
+  pairs and unconfirmed suspected pairs serialize by default; carry pair IDs,
+  typed evidence, evidence hashes, decisions, and held-item reasons in the
+  confirmation and final summaries.
 - For plan-writing handoffs, include the exact current-batch item list and any
   known same-surface open PR evidence for Protocol 02's
   `Cross-Cutting Operational Assumption Check`. Keep returned `Conflict`

--- a/.claude/commands/run-items.md
+++ b/.claude/commands/run-items.md
@@ -71,6 +71,13 @@ Key responsibilities:
   evidence visible until the parent records `Resolved` or stops for
   `unclear_requirements` and request `Human decision required`; do not widen
   the bounded list or replace this with an all-open-PR scan.
+- Before parallel implementation dispatch, run Protocol 90's planless overlap
+  gate from the current tracker snapshot and plan-derived file sets. Concrete
+  pairs and suspected pairs without a matching current `allow_parallel` decision
+  are serialized by default; pass serial groups into
+  `workflow-batch-lanes.sh --overlap-input` or apply the identical hold result.
+  Keep pair IDs, typed evidence, evidence hashes, accepted/stale decisions, and
+  held-item reasons visible in confirmation and final summaries.
 - In `workflow_hub`, state the selected product repository, artifact owner, and mutation
   target before implementation mutation; stop when context is missing or ambiguous.
 - Do not stop after advancing one item if another in the list still has a

--- a/.claude/commands/run-work.md
+++ b/.claude/commands/run-work.md
@@ -31,6 +31,11 @@ For bounded epic work: `/run-epic`.
 When mode is `no_target_scan`, follow Protocol 90 Steps 1–3 (scan + propose)
 only. Do not dispatch items under `/run-work`:
 
+For multi-item implementation proposals, include Protocol 90's planless overlap
+disposition from `workflow-batch-overlap.sh`. Concrete pairs and unconfirmed
+suspected pairs are serialized by default, and the proposal must show pair IDs,
+typed evidence, evidence hashes, and held-item reasons.
+
 In `workflow_hub`, preserve selected product repository context in implementation handoffs.
 This lets mutation-oriented follow-up commands route the artifact owner, local
 path or remote identity, and PR/reviewer/cleanup work without re-resolving or

--- a/.codex/skills/workflow-orchestrator/SKILL.md
+++ b/.codex/skills/workflow-orchestrator/SKILL.md
@@ -13,8 +13,13 @@ Recommended model tier: `economy`
 4. Treat the protocol as canonical. Use `workflow-item-orchestrator` for each selected or approved item when your runner supports skill-to-skill handoff; otherwise continue in the current session by following `91-orchestrate-work-protocol.md` item by item.
 5. Keep batching and prioritization decisions explicit, especially when work must be serialized because the runner cannot execute multiple item orchestrators concurrently.
 6. Before dispatching any Backlog item into Writing Spec, run `scripts/development-workflow/spec-dispatch-context.sh` for the selected item and in-scope batch. Pass non-blocking confirmed decisions and relationship outcomes to the item/spec handoff; stop on `blocking=true` and report the helper's `humanAction`. Shared keywords alone are not dependency evidence.
-7. Before dispatching an explicit-list batch where any runner may mutate, including sequential fallback, build the Protocol 90 isolation manifest and require a distinct absolute worktree path plus `isolation: "worktree"` for every mutating item. Stop before dispatch on missing isolation assignment or duplicate worktree path; non-isolated runners are allowed only when explicitly classified `read_only` and will not edit files, switch branches, commit, push, mutate PRs, change labels, or update tracker state.
-8. Include the incremental commit requirement in every substantial or
+7. Before parallel implementation dispatch, run Protocol 90's planless overlap
+   gate from the current tracker snapshot and plan-derived file sets. Concrete
+   pairs and unconfirmed suspected pairs serialize by default; carry pair IDs,
+   typed evidence, evidence hashes, decisions, and held-item reasons in the
+   confirmation and final summaries.
+8. Before dispatching an explicit-list batch where any runner may mutate, including sequential fallback, build the Protocol 90 isolation manifest and require a distinct absolute worktree path plus `isolation: "worktree"` for every mutating item. Stop before dispatch on missing isolation assignment or duplicate worktree path; non-isolated runners are allowed only when explicitly classified `read_only` and will not edit files, switch branches, commit, push, mutate PRs, change labels, or update tracker state.
+9. Include the incremental commit requirement in every substantial or
    multi-part mutating item handoff: commit immediately after each completed
    logical sub-part, do not intentionally batch all completed sub-parts into one
    final commit, and never commit incomplete or failing work only to satisfy the
@@ -23,29 +28,29 @@ Recommended model tier: `economy`
    Protocol 90 isolation assignment, use a fresh runner, and require the child
    to invoke `checkpoint-resume-gate.sh` before mutation. Do not resume a paused
    runner while sibling runners remain active.
-9. For plan-writing handoffs, include the exact current-batch item list and any
+10. For plan-writing handoffs, include the exact current-batch item list and any
    known same-surface open PR evidence for Protocol 02's
    `Cross-Cutting Operational Assumption Check`. Keep returned `Conflict`
    evidence visible until it is `Resolved` by the parent or stopped for
    `unclear_requirements` and request `Human decision required`; do not let
    planners replace this bounded context with an unbounded scan of every open PR.
-10. Do not stop after dispatching a batch if any selected or approved item still has a deterministic next action.
-11. For `workflow_hub` implementation work, include workflow mode, artifact owner, selected product repository, local path or remote identity, and mutation target in item handoffs; stop before mutation-oriented dispatch when product repository context is missing or ambiguous. Missing mode or `single_repo` does not require `--repo`.
+11. Do not stop after dispatching a batch if any selected or approved item still has a deterministic next action.
+12. For `workflow_hub` implementation work, include workflow mode, artifact owner, selected product repository, local path or remote identity, and mutation target in item handoffs; stop before mutation-oriented dispatch when product repository context is missing or ambiguous. Missing mode or `single_repo` does not require `--repo`.
    Include the parent-approved base branch in mutation-oriented handoffs; child runners must use it with `run-nested-artifact-guard.sh --approved-base` before branch or PR creation.
-12. **Guardrails enforcement**: Before any artifact-mutating action, resolve the effective guardrails (three-layer precedence: repo config → session overrides → invocation overrides) and report them in the portfolio run summary. Enforce the six gates described in `docs/workflow/development-workflow/guardrails-enforcement.md`: load+report at run start, backlog-start gate, per-stage PR-open gate, delegated review gate, delegated merge gate, and completion gate. When no `guardrails` section is found, state "conservative defaults in effect."
-13. With `merge_granted`, readiness is not terminal; continue through delegated
+13. **Guardrails enforcement**: Before any artifact-mutating action, resolve the effective guardrails (three-layer precedence: repo config → session overrides → invocation overrides) and report them in the portfolio run summary. Enforce the six gates described in `docs/workflow/development-workflow/guardrails-enforcement.md`: load+report at run start, backlog-start gate, per-stage PR-open gate, delegated review gate, delegated merge gate, and completion gate. When no `guardrails` section is found, state "conservative defaults in effect."
+14. With `merge_granted`, readiness is not terminal; continue through delegated
    merge and report each in-scope PR as `merged`, `merge_blocked`, or
    `policy_inconsistent`. With `merge_denied`, ready PRs report
    `ready_human_merge`. Discovered unrelated PRs are `out_of_scope` and are not
    merged.
-14. When supervising sweep, batch, helper-extraction, numeric-target, or
+15. When supervising sweep, batch, helper-extraction, numeric-target, or
    pattern-completeness items, require residual gate evidence before accepting
    `ready-for-human-review` as terminal.
-15. When supervising `spec/*` or `implementation-plan/*` PRs, require Protocol
+16. When supervising `spec/*` or `implementation-plan/*` PRs, require Protocol
     91 Step 8a's documentation-stage alignment checker before accepting
     readiness. A mismatch keeps the item under supervision until corrected or
     escalated.
-16. Before accepting any item as terminal in a batch summary, require the
+17. Before accepting any item as terminal in a batch summary, require the
     Work Item Runner's `## Ground-Truth Completion Verification` section from
     `scripts/development-workflow/item-completion-self-check.sh` or run the
     helper directly from current artifact state. When Step 7 was configured, pass

--- a/.cursor/agents/orchestrator.md
+++ b/.cursor/agents/orchestrator.md
@@ -57,6 +57,11 @@ That document is the single source of truth for this supporting role. Key respon
   helper's `humanAction`. Shared keywords alone are not dependency evidence.
 - Prioritize by due date (within 2 weeks) → priority → creation date
 - Build the largest safe explicit batch possible and document when work must be serialized
+- Before parallel implementation dispatch, run Protocol 90's planless overlap
+  gate from the current tracker snapshot and plan-derived file sets. Concrete
+  pairs and unconfirmed suspected pairs serialize by default; carry pair IDs,
+  typed evidence, evidence hashes, decisions, and held-item reasons in the
+  confirmation and final summaries.
 - For plan-writing handoffs, include the exact current-batch item list and any
   known same-surface open PR evidence for Protocol 02's
   `Cross-Cutting Operational Assumption Check`. Keep returned `Conflict`

--- a/.cursor/commands/run-items.md
+++ b/.cursor/commands/run-items.md
@@ -70,6 +70,13 @@ Key responsibilities:
   evidence visible until the parent records `Resolved` or stops for
   `unclear_requirements` and request `Human decision required`; do not widen
   the bounded list or replace this with an all-open-PR scan.
+- Before parallel implementation dispatch, run Protocol 90's planless overlap
+  gate from the current tracker snapshot and plan-derived file sets. Concrete
+  pairs and suspected pairs without a matching current `allow_parallel` decision
+  are serialized by default; pass serial groups into
+  `workflow-batch-lanes.sh --overlap-input` or apply the identical hold result.
+  Keep pair IDs, typed evidence, evidence hashes, accepted/stale decisions, and
+  held-item reasons visible in confirmation and final summaries.
 - In `workflow_hub`, state the selected product repository, artifact owner, and mutation
   target before implementation mutation; stop when context is missing or ambiguous.
 - Do not stop after advancing one item if another in the list still has a

--- a/.cursor/commands/run-work.md
+++ b/.cursor/commands/run-work.md
@@ -27,6 +27,11 @@ For single-item work use `/run-item`. For bounded multi-item batch execution use
 When mode is `no_target_scan`, follow Protocol 90 Steps 1–3 (scan + propose)
 only. Do not dispatch items under `/run-work`:
 
+For multi-item implementation proposals, include Protocol 90's planless overlap
+disposition from `workflow-batch-overlap.sh`. Concrete pairs and unconfirmed
+suspected pairs are serialized by default, and the proposal must show pair IDs,
+typed evidence, evidence hashes, and held-item reasons.
+
 In `workflow_hub`, preserve selected product repository context in
 implementation handoffs so mutation-oriented follow-up commands can route the
 artifact owner, local path or remote identity, and PR/reviewer/cleanup work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Add Planless Batch Overlap Fallback** (#1289): Derive explicit brief targets for planless implementation pairs and serialize concrete or unconfirmed suspected overlaps.
 - **Add project advisory checks hook** (#1279): Let downstream projects append
   diff-scoped informational checks to reviewer summaries without changing
   reviewer results or readiness.

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -931,10 +931,52 @@ Priority is determined by the orchestrator using the following ordered tiebreake
 The batch summary must list the conflicting item pair, the overlapping file path(s), and the
 resulting batch assignment for each item (BR-7).
 
-**Unknown-set handling** (BR-3): Items with `FILE_SET=unknown` are not automatically serialized
-but are flagged in the batch summary with a warning noting that file-level conflict detection was
-not possible for that item (no plan document, or plan contains no extractable file list). The
-batch proceeds as-is with the unknown-set items included.
+**Unknown-set handling and brief fallback** (BR-3): Items with `FILE_SET=unknown`
+must pass the planless overlap fallback before parallel dispatch. The
+orchestrator assembles a provider-neutral current snapshot for the remaining
+implementation candidates after dependency and tool-fix filtering:
+
+- `id`
+- current tracker `title`
+- current tracker `brief` or description
+- plan-derived `fileSet`
+- `priority`
+- `createdAt`
+- `nextAction`
+
+Run:
+
+<!-- workflow-shell-contract: bash-zsh -->
+```bash
+./scripts/development-workflow/workflow-batch-overlap.sh --input <snapshot.json> --json
+```
+
+The helper preserves exact plan-file intersections as the highest-confidence
+`concrete` result. For planless or empty file sets, it extracts explicit typed
+targets from titles and briefs: repo-relative file paths, route literals,
+function/method identifiers, and explicitly cued modules/helpers/scripts or
+services. Generic shared workflow words alone are not overlap evidence.
+
+Pair classifications are:
+
+- `concrete`: serialize the pair; the later item starts only after the prior
+  item's implementation PR is merged into the approved base.
+- `suspected`: serialize by default unless a current pair-scoped decision record
+  authorizes `allow_parallel` for the same batch fingerprint, pair ID, and
+  evidence hash.
+- `no_actionable_overlap`: keep the items parallel-eligible while preserving
+  all other dependency, tool-fix, runtime, lane-capacity, isolation, and nested
+  artifact gates. This is not proof of independence.
+
+When the classifier emits `serialGroups`, pass the same overlap input to
+`workflow-batch-lanes.sh --overlap-input <snapshot.json>` or otherwise apply
+the identical result: keep the highest-priority member of each serial group in
+the current lane and hold the remaining members with the reason
+`held — pending overlap-serialized item merge`. The batch confirmation summary
+must list every `concrete` or `suspected` pair, its typed evidence, evidence
+hash, default dispatch, and required next action. The final batch summary must
+include the resulting overlap disposition and any accepted or rejected stale
+pair-scoped human decision.
 
 **Human override** (BR-6): The orchestrator must **never** autonomously dispatch an override.
 Only an explicit human instruction enables parallel dispatch when a conflict has been detected.

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -340,16 +340,50 @@ Use this when:
 - The batch orchestrator needs a deterministic first-pass list of development-folder candidates
 - You want to separate portfolio-level batch planning from single-item orchestration
 
-### `workflow-batch-lanes.sh`
+### `workflow-batch-overlap.sh`
 
-Assigns stage lanes and `proposed` vs `held` dispatch status for portfolio batch
-proposals. Consumes `workflow-batch-plan.sh` output (or `--scan`).
+Classifies concrete, suspected, and non-actionable implementation overlap for
+multi-item batch proposals from a provider-neutral item snapshot.
 
 Usage:
 
+<!-- workflow-shell-contract: bash-zsh -->
+```bash
+./scripts/development-workflow/workflow-batch-overlap.sh --input batch-items.json --json
+```
+
+Input items include `id`, current tracker `title` and `brief`, plan-derived
+`fileSet`, `priority`, `createdAt`, and `nextAction`. Optional JSONL decision
+records can authorize `allow_parallel` only for a suspected pair when the batch
+fingerprint, pair ID, and evidence hash match the current proposal.
+
+What it does:
+
+- Preserves exact plan file-set intersections as concrete overlap
+- Extracts explicit file, route, function, and module/helper/script targets from
+  planless item briefs
+- Serializes concrete overlaps and unconfirmed suspected overlaps by default
+- Emits stable pair IDs, evidence hashes, accepted/stale decisions, and
+  transitive serial groups
+
+Use this when:
+
+- Protocol 90 needs to evaluate implementation overlap before assigning
+  multiple planless or mixed-evidence items to parallel lanes
+
+### `workflow-batch-lanes.sh`
+
+Assigns stage lanes and `proposed` vs `held` dispatch status for portfolio batch
+proposals. Consumes `workflow-batch-plan.sh` output (or `--scan`) and can apply
+serial groups from `workflow-batch-overlap.sh`.
+
+Usage:
+
+<!-- workflow-shell-contract: bash-zsh -->
 ```bash
 ./scripts/development-workflow/workflow-batch-plan.sh | ./scripts/development-workflow/workflow-batch-lanes.sh
 ./scripts/development-workflow/workflow-batch-lanes.sh --scan
+./scripts/development-workflow/workflow-batch-lanes.sh --overlap-input batch-items.json < batch-plan-output.txt
 ```
 
 What it does:
@@ -357,6 +391,8 @@ What it does:
 - Applies `max_concurrent_by_stage` caps (default: unlimited spec/plan/review, implementation `1`)
 - Emits `STAGE_LANE`, `DISPATCH`, `HOLD_REASON`, and `HELD_SUMMARY` per item
 - Honors `LOCAL_RUNTIME=exclusive` holds when multiple implementation items would contend
+- Holds lower-priority members of classifier serial groups until the prior item
+  merges into the approved base
 
 Use this when:
 

--- a/scripts/development-workflow/tests/test-workflow-batch-lanes.sh
+++ b/scripts/development-workflow/tests/test-workflow-batch-lanes.sh
@@ -180,6 +180,39 @@ run_test "overlap_held_item_serialized" "held" "$(block_value "$overlap_output" 
 run_test "overlap_hold_reason" "planless overlap serialization (overlap-a--overlap-b); held until prior item merges into approved base" "$(block_value "$overlap_output" "overlap-b" "HOLD_REASON")"
 run_test "overlap_group_visible" "overlap-a--overlap-b" "$(block_value "$overlap_output" "overlap-b" "OVERLAP_SERIAL_GROUP")"
 
+numeric_overlap_batch="$TMP_ROOT/numeric-overlap.batch"
+: > "$numeric_overlap_batch"
+write_batch_block "$numeric_overlap_batch" "1001-overlap-a" "implement" "" "Plan Ready"
+write_batch_block "$numeric_overlap_batch" "1002-overlap-b" "implement" "" "Plan Ready"
+numeric_overlap_input="$TMP_ROOT/numeric-overlap-input.json"
+jq -n '{
+  items: [
+    {
+      id: "1001",
+      title: "Users endpoint",
+      brief: "Update GET /api/users.",
+      fileSet: "unknown",
+      priority: "High",
+      createdAt: "2026-01-01T00:00:00Z",
+      nextAction: "implement"
+    },
+    {
+      id: "1002",
+      title: "User details",
+      brief: "Update GET /api/users/:id.",
+      fileSet: "unknown",
+      priority: "Normal",
+      createdAt: "2026-01-02T00:00:00Z",
+      nextAction: "implement"
+    }
+  ]
+}' > "$numeric_overlap_input"
+export WORKFLOW_MAX_CONCURRENT_IMPLEMENTATION=3
+numeric_overlap_output="$("$LANES" --repo-root "$high_parallel_repo" --overlap-input "$numeric_overlap_input" < "$numeric_overlap_batch")"
+unset WORKFLOW_MAX_CONCURRENT_IMPLEMENTATION
+run_test "overlap_numeric_issue_alias_holds_slug" "held" "$(block_value "$numeric_overlap_output" "1002-overlap-b" "DISPATCH")"
+run_test "overlap_numeric_group_visible_on_slug" "1001--1002" "$(block_value "$numeric_overlap_output" "1002-overlap-b" "OVERLAP_SERIAL_GROUP")"
+
 # classify_local_runtime via workflow-batch-plan on a synthetic plan folder
 runtime_dev="$fixture_repo/docs/specs/developments/20260624120000_999-runtime-test"
 mkdir -p "$runtime_dev"

--- a/scripts/development-workflow/tests/test-workflow-batch-lanes.sh
+++ b/scripts/development-workflow/tests/test-workflow-batch-lanes.sh
@@ -145,6 +145,41 @@ unset WORKFLOW_MAX_CONCURRENT_IMPLEMENTATION
 run_test "exclusive_holds_second_impl" "held" "$(block_value "$exclusive_output" "impl-y" "DISPATCH")"
 run_test "exclusive_hold_reason" "local runtime exclusivity (another implementation item requires exclusive local runtime)" "$(block_value "$exclusive_output" "impl-y" "HOLD_REASON")"
 
+overlap_batch="$TMP_ROOT/overlap.batch"
+: > "$overlap_batch"
+write_batch_block "$overlap_batch" "overlap-a" "implement" "" "Plan Ready"
+write_batch_block "$overlap_batch" "overlap-b" "implement" "" "Plan Ready"
+overlap_input="$TMP_ROOT/overlap-input.json"
+jq -n '{
+  items: [
+    {
+      id: "overlap-a",
+      title: "Users endpoint",
+      brief: "Update GET /api/users.",
+      fileSet: "unknown",
+      priority: "High",
+      createdAt: "2026-01-01T00:00:00Z",
+      nextAction: "implement"
+    },
+    {
+      id: "overlap-b",
+      title: "User details",
+      brief: "Update GET /api/users/:id.",
+      fileSet: "unknown",
+      priority: "Normal",
+      createdAt: "2026-01-02T00:00:00Z",
+      nextAction: "implement"
+    }
+  ]
+}' > "$overlap_input"
+export WORKFLOW_MAX_CONCURRENT_IMPLEMENTATION=3
+overlap_output="$("$LANES" --repo-root "$high_parallel_repo" --overlap-input "$overlap_input" < "$overlap_batch")"
+unset WORKFLOW_MAX_CONCURRENT_IMPLEMENTATION
+run_test "overlap_keep_item_proposed" "proposed" "$(block_value "$overlap_output" "overlap-a" "DISPATCH")"
+run_test "overlap_held_item_serialized" "held" "$(block_value "$overlap_output" "overlap-b" "DISPATCH")"
+run_test "overlap_hold_reason" "planless overlap serialization (overlap-a--overlap-b); held until prior item merges into approved base" "$(block_value "$overlap_output" "overlap-b" "HOLD_REASON")"
+run_test "overlap_group_visible" "overlap-a--overlap-b" "$(block_value "$overlap_output" "overlap-b" "OVERLAP_SERIAL_GROUP")"
+
 # classify_local_runtime via workflow-batch-plan on a synthetic plan folder
 runtime_dev="$fixture_repo/docs/specs/developments/20260624120000_999-runtime-test"
 mkdir -p "$runtime_dev"

--- a/scripts/development-workflow/tests/test-workflow-batch-overlap.sh
+++ b/scripts/development-workflow/tests/test-workflow-batch-overlap.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# test-workflow-batch-overlap.sh - Unit tests for planless batch overlap detection.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+OVERLAP="$REPO_ROOT/scripts/development-workflow/workflow-batch-overlap.sh"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+write_items() {
+  local path="$1"
+  shift
+  printf '%s\n' "$@" | jq -s '{items: .}' > "$path"
+}
+
+item_json() {
+  local id="$1" title="$2" brief="$3" file_set="${4:-unknown}" priority="${5:-Normal}" created_at="${6:-2026-01-01T00:00:00Z}" next_action="${7:-implement}"
+  jq -cn \
+    --arg id "$id" \
+    --arg title "$title" \
+    --arg brief "$brief" \
+    --arg fileSet "$file_set" \
+    --arg priority "$priority" \
+    --arg createdAt "$created_at" \
+    --arg nextAction "$next_action" \
+    '{id:$id,title:$title,brief:$brief,fileSet:$fileSet,priority:$priority,createdAt:$createdAt,nextAction:$nextAction}'
+}
+
+class_for() {
+  "$OVERLAP" --input "$1" --json | jq -r '.pairs[0].classification'
+}
+
+source_for() {
+  "$OVERLAP" --input "$1" --json | jq -r '.pairs[0].source'
+}
+
+dispatch_for() {
+  if [ -n "${2:-}" ]; then
+    "$OVERLAP" --input "$1" --decision-file "$2" --json | jq -r '.pairs[0].defaultDispatch'
+  else
+    "$OVERLAP" --input "$1" --json | jq -r '.pairs[0].defaultDispatch'
+  fi
+}
+
+pair_value() {
+  "$OVERLAP" --input "$1" --json | jq -r "$2"
+}
+
+same_route="$TMP_ROOT/same-route.json"
+write_items "$same_route" \
+  "$(item_json route-a "Users endpoint" "Update GET /api/users/:id validation.")" \
+  "$(item_json route-b "Users logging" "Add tracing for GET /api/users/:id.")"
+run_test "same_route_is_concrete" "concrete" "$(class_for "$same_route")"
+run_test "same_route_source" "brief" "$(source_for "$same_route")"
+
+parent_route="$TMP_ROOT/parent-route.json"
+write_items "$parent_route" \
+  "$(item_json parent-a "Users endpoint" "Update GET /api/users.")" \
+  "$(item_json parent-b "User details" "Update GET /api/users/:id.")"
+run_test "parent_route_is_suspected" "suspected" "$(class_for "$parent_route")"
+run_test "suspected_defaults_serial" "serial" "$(dispatch_for "$parent_route")"
+
+same_function="$TMP_ROOT/same-function.json"
+write_items "$same_function" \
+  "$(item_json fn-a "Policy parser" "Update resolvePolicy() for empty policy.")" \
+  "$(item_json fn-b "Policy reporter" "Add tests for function resolvePolicy.")"
+run_test "same_function_is_concrete" "concrete" "$(class_for "$same_function")"
+
+same_module="$TMP_ROOT/same-module.json"
+write_items "$same_module" \
+  "$(item_json mod-a "Review helper" "Change helper \`checkpoint-resume-gate.sh\`.")" \
+  "$(item_json mod-b "Review helper docs" "Update script \`checkpoint-resume-gate.sh\`.")"
+run_test "same_module_is_concrete" "concrete" "$(class_for "$same_module")"
+
+plan_overlap="$TMP_ROOT/plan-overlap.json"
+write_items "$plan_overlap" \
+  "$(item_json plan-a "A" "Unrelated text." "src/a.ts,scripts/tool.sh")" \
+  "$(item_json plan-b "B" "Another unrelated brief." "scripts/tool.sh,src/b.ts")"
+run_test "plan_overlap_remains_concrete" "concrete" "$(class_for "$plan_overlap")"
+run_test "plan_overlap_source" "plan" "$(source_for "$plan_overlap")"
+
+fallback_downgrade="$TMP_ROOT/fallback-downgrade.json"
+write_items "$fallback_downgrade" \
+  "$(item_json plan-c "A" "Update GET /one." "src/shared.ts")" \
+  "$(item_json plan-d "B" "Update GET /two." "src/shared.ts")"
+run_test "fallback_cannot_downgrade_plan" "plan" "$(source_for "$fallback_downgrade")"
+
+mixed_disagreement="$TMP_ROOT/mixed-disagreement.json"
+write_items "$mixed_disagreement" \
+  "$(item_json mix-a "A" "Update GET /api/users." "src/a.ts")" \
+  "$(item_json mix-b "B" "Update GET /api/users/:id." "src/b.ts")"
+run_test "mixed_evidence_disagreement_is_suspected" "suspected" "$(class_for "$mixed_disagreement")"
+run_test "mixed_evidence_source" "mixed" "$(source_for "$mixed_disagreement")"
+
+unrelated="$TMP_ROOT/unrelated.json"
+write_items "$unrelated" \
+  "$(item_json unrelated-a "Billing" "Update GET /api/invoices.")" \
+  "$(item_json unrelated-b "Users" "Update reconcileUsers().")"
+run_test "unrelated_targets_remain_eligible" "no_actionable_overlap" "$(class_for "$unrelated")"
+run_test "unrelated_dispatch" "parallel_eligible" "$(dispatch_for "$unrelated")"
+
+generic="$TMP_ROOT/generic.json"
+write_items "$generic" \
+  "$(item_json generic-a "Workflow review" "Improve workflow review batch behavior.")" \
+  "$(item_json generic-b "Workflow plan" "Improve workflow plan implementation behavior.")"
+run_test "generic_terms_do_not_overlap" "no_actionable_overlap" "$(class_for "$generic")"
+
+empty_brief="$TMP_ROOT/empty-brief.json"
+write_items "$empty_brief" \
+  "$(item_json empty-a "" "")" \
+  "$(item_json empty-b "" "")"
+run_test "empty_brief_is_no_actionable_overlap" "no_actionable_overlap" "$(class_for "$empty_brief")"
+
+transitive="$TMP_ROOT/transitive.json"
+write_items "$transitive" \
+  "$(item_json trans-a "A" "Update GET /a." "unknown" "High" "2026-01-01T00:00:00Z")" \
+  "$(item_json trans-b "B" "Update GET /a and GET /b." "unknown" "Normal" "2026-01-02T00:00:00Z")" \
+  "$(item_json trans-c "C" "Update GET /b." "unknown" "Normal" "2026-01-03T00:00:00Z")"
+run_test "transitive_overlaps_form_one_serial_group" "trans-a,trans-b,trans-c" "$(pair_value "$transitive" '.serialGroups[0].itemIds | join(",")')"
+run_test "priority_orders_serial_keep" "trans-a" "$(pair_value "$transitive" '.serialGroups[0].keepItemId')"
+
+decision_probe="$("$OVERLAP" --input "$parent_route" --json)"
+batch_fp="$(printf '%s\n' "$decision_probe" | jq -r '.batchFingerprint')"
+evidence_hash="$(printf '%s\n' "$decision_probe" | jq -r '.pairs[0].evidenceHash')"
+decision_file="$TMP_ROOT/decisions.jsonl"
+printf '{"batchFingerprint":"%s","pairId":"parent-a--parent-b","evidenceHash":"%s","decision":"allow_parallel","recordedHumanInstruction":"approved current suspected pair"}\n' "$batch_fp" "$evidence_hash" > "$decision_file"
+run_test "matching_pair_decision_allows_parallel" "parallel_eligible" "$(dispatch_for "$parent_route" "$decision_file")"
+
+reversed_decision="$TMP_ROOT/reversed-decisions.jsonl"
+printf '{"batchFingerprint":"%s","itemIds":["parent-b","parent-a"],"evidenceHash":"%s","decision":"allow_parallel"}\n' "$batch_fp" "$evidence_hash" > "$reversed_decision"
+run_test "reversed_pair_order_matches" "parallel_eligible" "$(dispatch_for "$parent_route" "$reversed_decision")"
+
+stale_decision="$TMP_ROOT/stale-decisions.jsonl"
+printf '{"batchFingerprint":"sha256:stale","pairId":"parent-a--parent-b","evidenceHash":"%s","decision":"allow_parallel"}\n' "$evidence_hash" > "$stale_decision"
+run_test "stale_decision_does_not_apply" "serial" "$(dispatch_for "$parent_route" "$stale_decision")"
+
+duplicate_ids="$TMP_ROOT/duplicate.json"
+write_items "$duplicate_ids" \
+  "$(item_json dup "A" "GET /a")" \
+  "$(item_json dup "B" "GET /b")"
+run_test "duplicate_ids_rejected" "yes" "$("$OVERLAP" --input "$duplicate_ids" --json >/dev/null 2>&1 && echo no || echo yes)"
+
+missing_fields="$TMP_ROOT/missing-fields.json"
+jq -n '{items:[{id:"a",title:"A"},{id:"b",title:"B",nextAction:"implement"}]}' > "$missing_fields"
+run_test "missing_fields_fail_closed" "yes" "$("$OVERLAP" --input "$missing_fields" --json >/dev/null 2>&1 && echo no || echo yes)"
+
+invalid_json="$TMP_ROOT/invalid.json"
+printf '{"items": [' > "$invalid_json"
+run_test "invalid_json_rejected" "yes" "$("$OVERLAP" --input "$invalid_json" --json >/dev/null 2>&1 && echo no || echo yes)"
+
+reordered="$TMP_ROOT/reordered.json"
+write_items "$reordered" \
+  "$(item_json route-b "Users logging" "Add tracing for GET /api/users/:id.")" \
+  "$(item_json route-a "Users endpoint" "Update GET /api/users/:id validation.")"
+run_test "input_order_is_stable" "$(pair_value "$same_route" '.pairs[0].pairId')" "$(pair_value "$reordered" '.pairs[0].pairId')"
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+[ "$FAIL_COUNT" -eq 0 ]

--- a/scripts/development-workflow/workflow-batch-lanes.sh
+++ b/scripts/development-workflow/workflow-batch-lanes.sh
@@ -9,8 +9,8 @@ source "$SCRIPT_DIR/workflow-lib.sh"
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/development-workflow/workflow-batch-lanes.sh [--repo-root <path>] [--scan [development-path ...]]
-  ./scripts/development-workflow/workflow-batch-lanes.sh [--repo-root <path>] < batch-plan-output
+  ./scripts/development-workflow/workflow-batch-lanes.sh [--repo-root <path>] [--overlap-input <json-file>] [--scan [development-path ...]]
+  ./scripts/development-workflow/workflow-batch-lanes.sh [--repo-root <path>] [--overlap-input <json-file>] < batch-plan-output
 
 Assigns stage lanes and dispatch vs held status for portfolio batch proposals.
 Reads workflow-batch-plan.sh key=value blocks from stdin, or runs --scan to
@@ -219,6 +219,7 @@ PYEOF
 
 repo_root=""
 scan_mode=0
+overlap_input=""
 development_paths=()
 
 while [ "$#" -gt 0 ]; do
@@ -230,6 +231,11 @@ while [ "$#" -gt 0 ]; do
       ;;
     --scan)
       scan_mode=1
+      shift
+      ;;
+    --overlap-input)
+      shift
+      overlap_input="${1:-}"
       shift
       ;;
     -h|--help)
@@ -285,7 +291,8 @@ fi
 
 TMP_BLOCKS="$(mktemp)"
 TMP_META="$(mktemp)"
-trap 'rm -f "$TMP_BLOCKS" "$TMP_META"' EXIT
+TMP_OVERLAP="$(mktemp)"
+trap 'rm -f "$TMP_BLOCKS" "$TMP_META" "$TMP_OVERLAP"' EXIT
 
 # Parse item blocks (blank-line separated key=value groups).
 block_idx=0
@@ -414,6 +421,44 @@ if [ "$exclusive_in_batch" -eq 1 ] && [ "$proposed_impl_count" -gt 1 ]; then
   mv "$TMP_META.new" "$TMP_META"
 fi
 
+# Planless/brief overlap dispositions: Protocol 90 may supply a provider-neutral
+# item snapshot for workflow-batch-overlap.sh. Serial groups hold every member
+# except the group's selected keep item before dispatch.
+if [ -n "$overlap_input" ]; then
+  if [ ! -f "$overlap_input" ]; then
+    echo "ERROR: overlap input file not found: $overlap_input" >&2
+    exit 1
+  fi
+  "$SCRIPT_DIR/workflow-batch-overlap.sh" --input "$overlap_input" --json > "$TMP_OVERLAP"
+  : > "$TMP_META.new"
+  while IFS=$'\t' read -r block_index stage_lane dispatch hr local_runtime; do
+    hold_reason=""
+    if [ "$hr" != "-" ]; then
+      hold_reason="$hr"
+    fi
+
+    item_id=""
+    development_path=""
+    while IFS='=' read -r key value; do
+      case "$key" in
+        SLUG) item_id="$value" ;;
+        DEVELOPMENT_PATH) development_path="$value" ;;
+      esac
+    done < "$TMP_BLOCKS.$block_index"
+    [ -z "$item_id" ] && item_id="$development_path"
+
+    overlap_group="$(jq -r --arg id "$item_id" '.serialGroups[]? | select((.heldItemIds // []) | index($id)) | .groupId' "$TMP_OVERLAP" | head -1)"
+    if [ -n "$overlap_group" ] && [ "$stage_lane" = "implementation" ] && [ "$dispatch" = "proposed" ]; then
+      dispatch="held"
+      hold_reason="planless overlap serialization (${overlap_group}); held until prior item merges into approved base"
+    fi
+
+    hold_field="${hold_reason:--}"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$block_index" "$stage_lane" "$dispatch" "$hold_field" "$local_runtime" >> "$TMP_META.new"
+  done < "$TMP_META"
+  mv "$TMP_META.new" "$TMP_META"
+fi
+
 idx=0
 while [ "$idx" -lt "$block_idx" ]; do
   stage_lane=""
@@ -438,6 +483,7 @@ while [ "$idx" -lt "$block_idx" ]; do
   skip_reason=""
   pr_metadata_status=""
   pr_metadata_reason=""
+  overlap_group=""
   while IFS='=' read -r key value; do
     case "$key" in
       SLUG) item_id="$value" ;;
@@ -455,8 +501,14 @@ while [ "$idx" -lt "$block_idx" ]; do
   report_category="$(report_category_for_item "$dispatch" "$status" "$next_action" "$labels" "$pr_metadata_status")"
   report_label="$(report_label_for_category "$report_category")"
   report_reason="$(report_reason_for_item "$report_category" "$dispatch" "$status" "$next_action" "$hold_reason" "$skip_reason" "$labels" "$pr_metadata_status" "$pr_metadata_reason")"
+  if [ -n "$overlap_input" ]; then
+    overlap_group="$(jq -r --arg id "$item_id" '.serialGroups[]? | select(((.itemIds // []) | index($id)) or ((.heldItemIds // []) | index($id)) or (.keepItemId == $id)) | .groupId' "$TMP_OVERLAP" | head -1)"
+  fi
 
   cat "$TMP_BLOCKS.$idx"
+  if [ -n "$overlap_group" ]; then
+    print_kv OVERLAP_SERIAL_GROUP "$overlap_group"
+  fi
   print_kv STAGE_LANE "$stage_lane"
   print_kv DISPATCH "$dispatch"
   print_kv REPORT_CATEGORY "$report_category"

--- a/scripts/development-workflow/workflow-batch-lanes.sh
+++ b/scripts/development-workflow/workflow-batch-lanes.sh
@@ -162,6 +162,38 @@ report_reason_for_item() {
   esac
 }
 
+append_alias() {
+  local alias_file="$1"
+  local value="$2"
+  [ -n "$value" ] || return 0
+  printf '%s\n' "$value" >> "$alias_file"
+}
+
+block_alias_file() {
+  local block_file="$1"
+  local alias_file="$2"
+  local item_id="" development_path="" target="" slug_issue=""
+
+  : > "$alias_file"
+  while IFS='=' read -r key value; do
+    case "$key" in
+      SLUG) item_id="$value" ;;
+      DEVELOPMENT_PATH) development_path="$value" ;;
+      TARGET) target="$value" ;;
+    esac
+  done < "$block_file"
+
+  append_alias "$alias_file" "$item_id"
+  append_alias "$alias_file" "$development_path"
+  append_alias "$alias_file" "$target"
+  if [[ "$item_id" =~ ^([0-9]+)(-|$) ]]; then
+    slug_issue="${BASH_REMATCH[1]}"
+    append_alias "$alias_file" "$slug_issue"
+  fi
+  awk 'NF && !seen[$0]++' "$alias_file" > "$alias_file.tmp"
+  mv "$alias_file.tmp" "$alias_file"
+}
+
 parallelism_config_file() {
   local repo_root="$1"
   if [ -n "${AI_DEV_WORKFLOW_CONFIG_FILE:-}" ] && [ -f "${AI_DEV_WORKFLOW_CONFIG_FILE}" ]; then
@@ -292,7 +324,8 @@ fi
 TMP_BLOCKS="$(mktemp)"
 TMP_META="$(mktemp)"
 TMP_OVERLAP="$(mktemp)"
-trap 'rm -f "$TMP_BLOCKS" "$TMP_META" "$TMP_OVERLAP"' EXIT
+TMP_ALIASES="$(mktemp)"
+trap 'rm -f "$TMP_BLOCKS" "$TMP_META" "$TMP_OVERLAP" "$TMP_ALIASES"' EXIT
 
 # Parse item blocks (blank-line separated key=value groups).
 block_idx=0
@@ -437,17 +470,13 @@ if [ -n "$overlap_input" ]; then
       hold_reason="$hr"
     fi
 
-    item_id=""
-    development_path=""
-    while IFS='=' read -r key value; do
-      case "$key" in
-        SLUG) item_id="$value" ;;
-        DEVELOPMENT_PATH) development_path="$value" ;;
-      esac
-    done < "$TMP_BLOCKS.$block_index"
-    [ -z "$item_id" ] && item_id="$development_path"
-
-    overlap_group="$(jq -r --arg id "$item_id" '.serialGroups[]? | select((.heldItemIds // []) | index($id)) | .groupId' "$TMP_OVERLAP" | head -1)"
+    block_alias_file "$TMP_BLOCKS.$block_index" "$TMP_ALIASES"
+    overlap_group=""
+    while IFS= read -r alias_id; do
+      [ -n "$alias_id" ] || continue
+      overlap_group="$(jq -r --arg id "$alias_id" '.serialGroups[]? | select((.heldItemIds // []) | index($id)) | .groupId' "$TMP_OVERLAP" | head -1)"
+      [ -n "$overlap_group" ] && break
+    done < "$TMP_ALIASES"
     if [ -n "$overlap_group" ] && [ "$stage_lane" = "implementation" ] && [ "$dispatch" = "proposed" ]; then
       dispatch="held"
       hold_reason="planless overlap serialization (${overlap_group}); held until prior item merges into approved base"
@@ -502,7 +531,12 @@ while [ "$idx" -lt "$block_idx" ]; do
   report_label="$(report_label_for_category "$report_category")"
   report_reason="$(report_reason_for_item "$report_category" "$dispatch" "$status" "$next_action" "$hold_reason" "$skip_reason" "$labels" "$pr_metadata_status" "$pr_metadata_reason")"
   if [ -n "$overlap_input" ]; then
-    overlap_group="$(jq -r --arg id "$item_id" '.serialGroups[]? | select(((.itemIds // []) | index($id)) or ((.heldItemIds // []) | index($id)) or (.keepItemId == $id)) | .groupId' "$TMP_OVERLAP" | head -1)"
+    block_alias_file "$TMP_BLOCKS.$idx" "$TMP_ALIASES"
+    while IFS= read -r alias_id; do
+      [ -n "$alias_id" ] || continue
+      overlap_group="$(jq -r --arg id "$alias_id" '.serialGroups[]? | select(((.itemIds // []) | index($id)) or ((.heldItemIds // []) | index($id)) or (.keepItemId == $id)) | .groupId' "$TMP_OVERLAP" | head -1)"
+      [ -n "$overlap_group" ] && break
+    done < "$TMP_ALIASES"
   fi
 
   cat "$TMP_BLOCKS.$idx"

--- a/scripts/development-workflow/workflow-batch-overlap.sh
+++ b/scripts/development-workflow/workflow-batch-overlap.sh
@@ -1,0 +1,500 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/development-workflow/workflow-batch-overlap.sh --input <json-file> [--decision-file <jsonl-file>] [--json]
+
+Classifies pairwise implementation overlap for batch proposals from a
+provider-neutral item snapshot. The helper is read-only and performs no tracker,
+GitHub, branch, label, or filesystem mutations.
+EOF
+}
+
+input_file=""
+decision_file=""
+json_output=0
+
+require_value() {
+  local option="$1"
+  if [ "$#" -lt 2 ] || [ -z "${2:-}" ] || [ "${2#--}" != "$2" ]; then
+    echo "$option requires a value." >&2
+    usage >&2
+    exit 64
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --input)
+      require_value "$@"
+      input_file="$2"
+      shift 2
+      ;;
+    --decision-file)
+      require_value "$@"
+      decision_file="$2"
+      shift 2
+      ;;
+    --json)
+      json_output=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+if [ -z "$input_file" ]; then
+  echo "ERROR: --input is required." >&2
+  usage >&2
+  exit 64
+fi
+
+python3 - "$input_file" "$decision_file" "$json_output" <<'PYEOF'
+import hashlib
+import json
+import re
+import sys
+from pathlib import PurePosixPath
+
+input_file, decision_file, json_output = sys.argv[1], sys.argv[2], sys.argv[3] == "1"
+
+IMPLEMENTATION_ACTIONS = {"implement", "resolve-development-pr"}
+PRIORITY_RANK = {"urgent": 0, "high": 1, "normal": 2, "medium": 2, "low": 3}
+GENERIC_TERMS = {
+    "workflow",
+    "review",
+    "reviewer",
+    "batch",
+    "item",
+    "plan",
+    "implementation",
+    "development",
+    "feature",
+    "fix",
+    "fallback",
+    "protocol",
+}
+
+
+def fail(message: str, code: int = 1) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def load_json_file(path: str) -> dict:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError:
+        fail(f"input file not found: {path}")
+    except json.JSONDecodeError as error:
+        fail(f"input file is not valid JSON: {path}: {error}")
+    if not isinstance(data, dict):
+        fail("input JSON must be an object")
+    return data
+
+
+def stable_json(value) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def sha256(value) -> str:
+    return "sha256:" + hashlib.sha256(stable_json(value).encode("utf-8")).hexdigest()
+
+
+def normalize_id(value) -> str:
+    text = str(value or "").strip()
+    if not text:
+      fail("each item requires a non-empty id")
+    return text
+
+
+def normalize_path(value: str) -> str:
+    text = value.strip().strip("`'\"“”‘’.,;:)")
+    text = text.replace("\\", "/")
+    text = re.sub(r"^\./+", "", text)
+    return str(PurePosixPath(text)).lower()
+
+
+def normalize_route(value: str) -> str:
+    text = value.strip().strip("`'\"“”‘’.,;)")
+    text = re.sub(r"[?#].*$", "", text)
+    if not text.startswith("/"):
+        text = "/" + text
+    text = re.sub(r"/+", "/", text)
+    return text.rstrip("/") if text != "/" else text
+
+
+def normalize_identifier(value: str) -> str:
+    return value.strip().strip("`'\"“”‘’.,;:)(").replace("_", "-").lower()
+
+
+def parse_file_set(value):
+    if value is None:
+        return []
+    if isinstance(value, str):
+        if value.strip().lower() in {"", "unknown", "none", "-"}:
+            return []
+        parts = re.split(r"[,;\n]", value)
+    elif isinstance(value, list):
+        parts = value
+    else:
+        return []
+    normalized = []
+    for part in parts:
+        text = normalize_path(str(part))
+        if text and text not in {"unknown", "none", "-"}:
+            normalized.append(text)
+    return sorted(set(normalized))
+
+
+def add_signal(signals: set[tuple[str, str]], kind: str, value: str) -> None:
+    value = value.strip()
+    if not value:
+        return
+    if kind in {"function", "module"}:
+        value = normalize_identifier(value)
+        if value in GENERIC_TERMS or len(value) < 2:
+            return
+    elif kind == "route":
+        value = normalize_route(value)
+    elif kind == "file":
+        value = normalize_path(value)
+        if "/" not in value and "." not in value:
+            return
+    signals.add((kind, value))
+
+
+def extract_signals(title: str, brief: str) -> list[dict]:
+    text = f"{title or ''}\n{brief or ''}"
+    signals: set[tuple[str, str]] = set()
+
+    for match in re.finditer(r"(?<![A-Za-z0-9_./-])([A-Za-z0-9_.-]+(?:[\\/][A-Za-z0-9_.:@{}()[\\]-]+)+)", text):
+        add_signal(signals, "file", match.group(1))
+
+    for match in re.finditer(r"\b(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(/[A-Za-z0-9_:@{}()[\].~!$&'*+,;=%/-]+)", text, re.I):
+        add_signal(signals, "route", match.group(1))
+    for match in re.finditer(r"(?<![A-Za-z0-9_])(/[A-Za-z0-9_:@{}()[\].~!$&'*+,;=%/-]+)", text):
+        route = match.group(1)
+        if "." not in route.rsplit("/", 1)[-1]:
+            add_signal(signals, "route", route)
+
+    for match in re.finditer(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(\)", text):
+        add_signal(signals, "function", match.group(1))
+    for match in re.finditer(r"\b(?:function|method|resolver|handler)\s+[`'\"]?([A-Za-z_][A-Za-z0-9_]*)[`'\"]?", text, re.I):
+        add_signal(signals, "function", match.group(1))
+
+    module_cue = r"(?:module|package|component|helper|script|service)"
+    for match in re.finditer(rf"\b{module_cue}\s+[`'\"]([^`'\"\n]+)[`'\"]", text, re.I):
+        add_signal(signals, "module", match.group(1))
+    for match in re.finditer(rf"\b{module_cue}\s+([A-Za-z][A-Za-z0-9_.-]{{2,}})", text, re.I):
+        add_signal(signals, "module", match.group(1))
+
+    return [{"type": kind, "value": value} for kind, value in sorted(signals)]
+
+
+def signal_set(signals: list[dict]) -> set[tuple[str, str]]:
+    return {(signal["type"], signal["value"]) for signal in signals}
+
+
+def basename_without_ext(path: str) -> str:
+    name = path.rstrip("/").rsplit("/", 1)[-1]
+    return re.sub(r"\.[^.]+$", "", name).lower()
+
+
+def related_signals(left: list[dict], right: list[dict]) -> list[dict]:
+    related = []
+    for l_signal in left:
+        for r_signal in right:
+            l_type, l_value = l_signal["type"], l_signal["value"]
+            r_type, r_value = r_signal["type"], r_signal["value"]
+            if l_type == r_type == "route":
+                l_route = l_value.rstrip("/")
+                r_route = r_value.rstrip("/")
+                if l_route != r_route and (l_route.startswith(r_route + "/") or r_route.startswith(l_route + "/")):
+                    related.append({"left": l_signal, "right": r_signal, "reason": "one route is a parent of the other"})
+            elif {l_type, r_type} == {"file", "module"}:
+                file_value = l_value if l_type == "file" else r_value
+                module_value = l_value if l_type == "module" else r_value
+                base = basename_without_ext(file_value)
+                if base and (base == module_value or base in module_value or module_value in base):
+                    related.append({"left": l_signal, "right": r_signal, "reason": "module signal is related to a path basename"})
+    return related
+
+
+def pair_id(left_id: str, right_id: str) -> str:
+    return "--".join(sorted([left_id, right_id]))
+
+
+def item_sort_key(item: dict):
+    priority = PRIORITY_RANK.get(str(item.get("priority", "")).lower(), 2)
+    created = str(item.get("createdAt") or item.get("created_at") or "")
+    return (priority, created, item["id"])
+
+
+def classify_pair(left: dict, right: dict) -> dict:
+    pair = pair_id(left["id"], right["id"])
+    shared_files = sorted(set(left["planFiles"]) & set(right["planFiles"]))
+    left_signals = left["signals"]
+    right_signals = right["signals"]
+    shared_signals = [{"type": kind, "value": value} for kind, value in sorted(signal_set(left_signals) & signal_set(right_signals))]
+    related = related_signals(left_signals, right_signals)
+    has_plan_evidence = bool(left["planFiles"] or right["planFiles"])
+
+    if shared_files:
+        classification = "concrete"
+        source = "plan"
+        explanation = "Plan-derived file sets intersect exactly."
+        evidence = {"sharedFiles": shared_files}
+    elif shared_signals:
+        classification = "concrete"
+        source = "brief"
+        explanation = "Brief-derived typed implementation targets match exactly."
+        evidence = {"sharedSignals": shared_signals}
+    elif related:
+        classification = "suspected"
+        source = "mixed" if has_plan_evidence else "brief"
+        explanation = "Brief-derived targets are related but not identical."
+        evidence = {"relatedSignals": related}
+    elif has_plan_evidence and (left_signals or right_signals):
+        classification = "suspected"
+        source = "mixed"
+        explanation = "Plan-derived and brief-derived evidence do not prove independence; require pair-scoped disposition."
+        evidence = {"leftSignals": left_signals, "rightSignals": right_signals}
+    else:
+        classification = "no_actionable_overlap"
+        source = "none"
+        explanation = "No actionable overlap found; this is not proof of independence."
+        evidence = {"leftSignals": left_signals, "rightSignals": right_signals}
+
+    requires_confirmation = classification == "suspected"
+    default_dispatch = "serial" if classification in {"concrete", "suspected"} else "parallel_eligible"
+    required_next_action = (
+        "serialize_pair_until_prior_item_merges"
+        if classification == "concrete"
+        else "require_pair_scoped_parallel_decision_or_serialize"
+        if classification == "suspected"
+        else "continue_other_gates"
+    )
+    evidence_hash = sha256({
+        "pairId": pair,
+        "classification": classification,
+        "source": source,
+        "evidence": evidence,
+        "explanation": explanation,
+    })
+
+    return {
+        "pairId": pair,
+        "itemIds": [left["id"], right["id"]],
+        "classification": classification,
+        "source": source,
+        "confidence": "high" if classification == "concrete" else "medium" if classification == "suspected" else "none",
+        "signals": evidence,
+        "explanation": explanation,
+        "defaultDispatch": default_dispatch,
+        "confirmationRequired": requires_confirmation,
+        "requiredNextAction": required_next_action,
+        "evidenceHash": evidence_hash,
+        "decision": {"status": "not_required" if not requires_confirmation else "missing"},
+    }
+
+
+def load_decisions(path: str) -> list[dict]:
+    if not path:
+        return []
+    decisions = []
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            for line_number, line in enumerate(handle, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    value = json.loads(line)
+                except json.JSONDecodeError:
+                    decisions.append({"status": "invalid_json", "line": line_number})
+                    continue
+                if isinstance(value, dict):
+                    decisions.append(value)
+    except FileNotFoundError:
+        return []
+    return decisions
+
+
+def apply_decisions(pairs: list[dict], batch_fingerprint: str, decisions: list[dict]) -> list[dict]:
+    stale = []
+    for pair in pairs:
+        if pair["classification"] != "suspected":
+            continue
+        accepted = None
+        for decision in decisions:
+            if decision.get("status") == "invalid_json":
+                stale.append(decision)
+                continue
+            normalized_pair = pair_id(str(decision.get("itemIds", ["", ""])[0]), str(decision.get("itemIds", ["", ""])[1])) if isinstance(decision.get("itemIds"), list) and len(decision.get("itemIds")) == 2 else str(decision.get("pairId", ""))
+            if normalized_pair != pair["pairId"]:
+                continue
+            if decision.get("batchFingerprint") != batch_fingerprint:
+                stale.append({**decision, "status": "stale_batch"})
+                continue
+            if decision.get("evidenceHash") != pair["evidenceHash"]:
+                stale.append({**decision, "status": "stale_evidence"})
+                continue
+            if decision.get("decision") not in {"allow_parallel", "serialize"}:
+                stale.append({**decision, "status": "invalid_decision"})
+                continue
+            accepted = decision
+        if accepted:
+            pair["decision"] = {
+                "status": "accepted",
+                "decision": accepted["decision"],
+                "recordedInstruction": accepted.get("recordedHumanInstruction", accepted.get("instruction", "")),
+            }
+            if accepted["decision"] == "allow_parallel":
+                pair["defaultDispatch"] = "parallel_eligible"
+                pair["requiredNextAction"] = "continue_other_gates_with_pair_decision"
+            else:
+                pair["defaultDispatch"] = "serial"
+        else:
+            pair["decision"] = {"status": "missing", "decision": "serialize"}
+    return stale
+
+
+def serial_groups(items_by_id: dict, pairs: list[dict]) -> list[dict]:
+    parent = {item_id: item_id for item_id in items_by_id}
+
+    def find(value):
+        while parent[value] != value:
+            parent[value] = parent[parent[value]]
+            value = parent[value]
+        return value
+
+    def union(left, right):
+        l_root, r_root = find(left), find(right)
+        if l_root != r_root:
+            parent[r_root] = l_root
+
+    serial_pairs = [
+        pair for pair in pairs
+        if pair["defaultDispatch"] == "serial" and pair["classification"] in {"concrete", "suspected"}
+    ]
+    for pair in serial_pairs:
+        union(pair["itemIds"][0], pair["itemIds"][1])
+
+    grouped: dict[str, list[str]] = {}
+    for pair in serial_pairs:
+        for item_id in pair["itemIds"]:
+            grouped.setdefault(find(item_id), [])
+    for item_id in parent:
+        root = find(item_id)
+        if root in grouped:
+            grouped[root].append(item_id)
+
+    groups = []
+    for group_items in grouped.values():
+        unique_items = sorted(set(group_items), key=lambda item_id: item_sort_key(items_by_id[item_id]))
+        group_pairs = [pair["pairId"] for pair in serial_pairs if set(pair["itemIds"]).issubset(set(unique_items))]
+        if len(unique_items) > 1:
+            groups.append({
+                "groupId": "--".join(unique_items),
+                "itemIds": unique_items,
+                "keepItemId": unique_items[0],
+                "heldItemIds": unique_items[1:],
+                "pairs": sorted(group_pairs),
+                "reason": "brief/plan overlap serialization; held items start after the prior item merges into the approved base",
+            })
+    return sorted(groups, key=lambda group: group["groupId"])
+
+
+data = load_json_file(input_file)
+raw_items = data.get("items")
+if not isinstance(raw_items, list) or not raw_items:
+    fail("input JSON requires a non-empty items array")
+
+items = []
+seen = set()
+for raw in raw_items:
+    if not isinstance(raw, dict):
+        fail("each item must be an object")
+    item_id = normalize_id(raw.get("id"))
+    if item_id in seen:
+        fail(f"duplicate item id: {item_id}")
+    seen.add(item_id)
+    next_action = str(raw.get("nextAction") or raw.get("next_action") or "").strip()
+    if not next_action:
+        fail(f"item {item_id} requires nextAction")
+    item = {
+        "id": item_id,
+        "title": str(raw.get("title") or ""),
+        "brief": str(raw.get("brief") or raw.get("description") or ""),
+        "priority": str(raw.get("priority") or "Normal"),
+        "createdAt": str(raw.get("createdAt") or raw.get("created_at") or ""),
+        "nextAction": next_action,
+        "planFiles": parse_file_set(raw.get("fileSet", raw.get("file_set"))),
+    }
+    item["signals"] = extract_signals(item["title"], item["brief"])
+    items.append(item)
+
+implementation_items = [item for item in items if item["nextAction"] in IMPLEMENTATION_ACTIONS]
+items_by_id = {item["id"]: item for item in implementation_items}
+batch_fingerprint = sha256({
+    "items": [
+        {
+            "id": item["id"],
+            "title": item["title"],
+            "brief": item["brief"],
+            "fileSet": item["planFiles"],
+            "priority": item["priority"],
+            "createdAt": item["createdAt"],
+            "nextAction": item["nextAction"],
+        }
+        for item in sorted(implementation_items, key=lambda item: item["id"])
+    ]
+})
+
+pairs = []
+sorted_items = sorted(implementation_items, key=lambda item: item["id"])
+for left_index, left in enumerate(sorted_items):
+    for right in sorted_items[left_index + 1:]:
+        pairs.append(classify_pair(left, right))
+
+stale_decisions = apply_decisions(pairs, batch_fingerprint, load_decisions(decision_file))
+groups = serial_groups(items_by_id, pairs)
+result = {
+    "batchFingerprint": batch_fingerprint,
+    "itemCount": len(implementation_items),
+    "pairs": pairs,
+    "serialGroups": groups,
+    "staleDecisions": stale_decisions,
+    "readOnlyGuarantee": "No tracker reads, tracker writes, GitHub calls, branch changes, labels, comments, files, or dispatch state were mutated.",
+}
+
+if json_output:
+    print(json.dumps(result, indent=2, sort_keys=True))
+else:
+    print(f"BATCH_FINGERPRINT={batch_fingerprint}")
+    print(f"PAIR_COUNT={len(pairs)}")
+    print(f"SERIAL_GROUP_COUNT={len(groups)}")
+    for pair in pairs:
+        print(f"PAIR={pair['pairId']}")
+        print(f"PAIR_CLASSIFICATION={pair['classification']}")
+        print(f"PAIR_SOURCE={pair['source']}")
+        print(f"PAIR_DEFAULT_DISPATCH={pair['defaultDispatch']}")
+        print(f"PAIR_EVIDENCE_HASH={pair['evidenceHash']}")
+    for group in groups:
+        print(f"SERIAL_GROUP={group['groupId']}")
+        print(f"SERIAL_GROUP_KEEP={group['keepItemId']}")
+        print(f"SERIAL_GROUP_HELD={','.join(group['heldItemIds'])}")
+PYEOF


### PR DESCRIPTION
## Summary
- Add `workflow-batch-overlap.sh` to classify concrete, suspected, and non-actionable implementation overlap from provider-neutral item snapshots.
- Wire `workflow-batch-lanes.sh --overlap-input` so concrete and unconfirmed suspected serial groups hold lower-priority items before dispatch.
- Update Protocol 90 plus run-work/run-items and orchestrator mirrors to carry overlap evidence, pair decisions, and held-item reasons.

## Verification
- `bash scripts/development-workflow/tests/test-workflow-batch-overlap.sh`
- `bash scripts/development-workflow/tests/test-workflow-batch-lanes.sh`
- `bash scripts/development-workflow/tests/test-run-work-router.sh`
- `bash scripts/development-workflow/tests/test-run-bounded-prelude.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop`
- `shellcheck --severity=warning scripts/development-workflow/workflow-batch-overlap.sh scripts/development-workflow/workflow-batch-lanes.sh scripts/development-workflow/tests/test-workflow-batch-overlap.sh scripts/development-workflow/tests/test-workflow-batch-lanes.sh`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md" "scripts/development-workflow/README.md" ".agents/skills/run-work/SKILL.md" ".agents/skills/run-items/SKILL.md" ".codex/skills/workflow-orchestrator/SKILL.md" ".claude/agents/orchestrator.md" ".cursor/agents/orchestrator.md" ".claude/commands/run-work.md" ".cursor/commands/run-work.md" ".claude/commands/run-items.md" ".cursor/commands/run-items.md" "CHANGELOG.md"`
- `git diff --check`

## Smoke Test
- Executed `docs/testing/workflow/1289-planless-overlap-fallback.smoke-test.md` steps through the classifier harness, lane harness, Protocol 90/mirror inspection, shell/static validation, and cleanup of temporary harness fixtures.

## Self-review
- Scope stays within workflow batch planning, lane assignment, protocol docs, command mirrors, tests, and changelog.
- Helper is read-only and provider-neutral; it does not query tracker/GitHub or mutate dispatch state.
- Plan-derived exact file intersections remain authoritative; fallback evidence only adds concrete/suspected/no-actionable overlap disposition for planless or mixed evidence.

Closes #1289

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default parallel dispatch for multi-item implementation batches by holding overlapping planless pairs; behavior is conservative and confined to workflow scripts/docs, but misclassification could delay or over-serialize work.
> 
> **Overview**
> Adds a **planless overlap fallback** so multi-item implementation batches can detect conflicts when plans lack file lists, instead of only warning on unknown file sets.
> 
> A new read-only helper **`workflow-batch-overlap.sh`** classifies item pairs as **concrete**, **suspected**, or **no actionable overlap** from a tracker snapshot (titles, briefs, plan file sets). Plan intersections stay authoritative; briefs supply typed targets (paths, routes, functions, named scripts/modules). **Concrete** and unconfirmed **suspected** pairs default to **serialization**; suspected pairs can opt into parallel only via matching pair-scoped **`allow_parallel`** decision records (batch fingerprint, pair ID, evidence hash).
> 
> **`workflow-batch-lanes.sh`** gains **`--overlap-input`** to apply transitive serial groups: lower-priority items are **held** until the keep item merges, with **`OVERLAP_SERIAL_GROUP`** and hold reasons on lane output. Issue/slug alias matching covers numeric IDs vs development-folder slugs.
> 
> **Protocol 90** (BR-3) now requires this gate before parallel implementation dispatch and documents summary fields (pair IDs, evidence, hashes, decisions). **`/run-work`**, **`/run-items`**, and orchestrator mirrors across agents/skills/commands are aligned to run the gate, feed lanes, and surface overlap disposition in proposals and batch summaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00ef05fa1c03a31e028cffe257eecabb94edcb6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->