### PR TITLE
chore(agents): update model defaults and Bugbot handling

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 description: Development review stage. Use when an implementation PR needs review against the spec, plan, and best practices. Applies fixes directly for blocking and important issues. Reports issues requiring human/product decisions.
 tools: Read, Grep, Glob, Write, Edit, Bash
 ---

--- a/.claude/agents/design-reviewer.md
+++ b/.claude/agents/design-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: design-reviewer
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 description: Design review stage. Use when an implementation PR includes frontend file changes. Launches a browser via the configured browser_automation.provider, renders affected pages or components, captures screenshots, checks for console errors, and runs an axe-core accessibility check. Posts a structured PR comment with the verdict (Approved / Needs Revision / Skipped).
 tools: Read, Grep, Glob, Bash
 ---

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,6 +1,6 @@
 ---
 name: developer
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 description: In Development stage. Handles four paths — Full Pipeline (feature with spec+plan), Refactor (code restructuring with plan only, no spec), Fast Track (bug or simple change, no spec/plan needed), and Hotfix (critical production bug from main). Implements code, verifies build/lint/tests, opens PRs, and resolves reviewer / CI readiness.
 tools: Read, Grep, Glob, Write, Edit, Bash
 ---

--- a/.claude/agents/implementation-plan-reviewer.md
+++ b/.claude/agents/implementation-plan-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: implementation-plan-reviewer
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 description: Plan review stage. Use when an implementation plan branch or PR needs review for spec alignment, completeness, and feasibility. Reads the spec, plan, and codebase to validate the approach, and can push reviewer-loop fixes.
 tools: Read, Grep, Glob, Write, Edit, Bash
 ---

--- a/.claude/agents/item-orchestrator.md
+++ b/.claude/agents/item-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: item-orchestrator
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 description: Coordination agent for a single workflow item via /run-item (or deprecated /run-item-work). Runs the shared bounded prelude then Protocol 91 until waiting on a human, blocked, or escalated.
 tools: Read, Grep, Glob, Write, Edit, Bash, Agent
 ---

--- a/.claude/agents/post-merge-qa.md
+++ b/.claude/agents/post-merge-qa.md
@@ -1,6 +1,6 @@
 ---
 name: post-merge-qa
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 description: Post-merge QA on develop or develop-<slug>. Confirmed scope, environment preflight, flow/UX exercise, optional design-asset fidelity, one fix PR for safe defects (no backlog item).
 ---
 

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -1,6 +1,6 @@
 ---
 name: product-manager
-model: claude-opus-4-8
+model: claude-opus-5
 description: Spec Ready stage. Use when a new feature needs a spec written. Conducts a structured alignment conversation with the human, then writes the feature spec, runs its reviewer gate, and resolves PR readiness. Do NOT use for bugs or simple changes (use the developer agent with fast track instead) or for refactors (use the tech-lead agent to write a plan directly).
 tools: Read, Grep, Glob, Write, Edit, Bash
 ---

--- a/.claude/agents/project-setup.md
+++ b/.claude/agents/project-setup.md
@@ -1,6 +1,6 @@
 ---
 name: project-setup
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 description: Onboarding agent. Run this when first setting up a new project from this template. Guides a structured conversation to generate all project-specific documentation (business domain, architecture, tech stack, best practices) and configures the framework for your project.
 tools: Read, Grep, Glob, Write, Edit, Bash
 ---

--- a/.claude/agents/retrospective.md
+++ b/.claude/agents/retrospective.md
@@ -1,6 +1,6 @@
 ---
 name: retrospective
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 description: Retrospective analysis agent. Analyzes completed work (a batch or individual item) to identify process improvement opportunities, presents them to the human, and executes the chosen action for each. Use after a batch or item run to surface workflow improvements, or invoke on-demand with a PR number, branch, or date as scope hint.
 tools: Read, Grep, Glob, Write, Edit, Bash
 ---

--- a/.claude/agents/smoke-tester.md
+++ b/.claude/agents/smoke-tester.md
@@ -1,6 +1,6 @@
 ---
 name: smoke-tester
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 description: Smoke test stage. Use when a code review has been approved and the implementation needs manual smoke testing before merge. Executes the smoke test runbook using browser automation.
 tools: Read, Grep, Glob, Bash, Write
 ---

--- a/.claude/agents/spec-reviewer.md
+++ b/.claude/agents/spec-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: spec-reviewer
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 description: Spec review stage. Use when a spec branch or PR needs review for completeness, clarity, and testability. Applies fixes directly where possible, can push reviewer-loop fixes, and reports issues requiring human input.
 tools: Read, Grep, Glob, Write, Edit, Bash
 ---

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -1,6 +1,6 @@
 ---
 name: tech-lead
-model: claude-opus-4-8
+model: claude-opus-5
 description: Plan Ready stage. Use when an implementation plan needs to be written. For Full Pipeline items, a spec must be approved first. For Refactor items, the work item brief replaces the spec. Reads the codebase, resolves technical approach questions, then writes the implementation plan, runs its reviewer gate, and resolves PR readiness.
 tools: Read, Grep, Glob, Write, Edit, Bash
 ---

--- a/.codex/skills/workflow-retrospective/SKILL.md
+++ b/.codex/skills/workflow-retrospective/SKILL.md
@@ -5,7 +5,7 @@ description: Run a retrospective analysis on completed work to identify process 
 
 # Workflow Retrospective
 
-Recommended model tier: `economy`
+Recommended model tier: `balanced`
 
 **Meta-Retrospective**: If the user invokes this skill with a meta scope (e.g., "run meta-retro", "periodic verification", or similar phrasing indicating trend analysis of prior improvements), follow `docs/workflow/development-workflow/protocols/06b-meta-retrospective-protocol.md` instead of the regular retrospective flow below. The meta-retrospective includes a platform evaluation step (Step 2b) that reads `docs/workflow/retro-metrics-platforms.md` and reports the running exclusive-block rate for each review platform against the graduation criteria. When fewer than 30 compare-mode runs are logged, Step 2b explicitly states data is insufficient for a graduation decision.
 

--- a/.cursor/agents/automated-reviewer-loop.md
+++ b/.cursor/agents/automated-reviewer-loop.md
@@ -1,6 +1,6 @@
 ---
 name: automated-reviewer-loop
-model: auto
+model: fast
 description: Run the automated reviewer loop (and CI loop) for a PR. Use when the user wants to run the reviewer loop on a specific PR or the current branch's PR until it is ready for human review or escalated.
 ---
 

--- a/.cursor/agents/automated-reviewer-loop.md
+++ b/.cursor/agents/automated-reviewer-loop.md
@@ -1,6 +1,6 @@
 ---
 name: automated-reviewer-loop
-model: fast
+model: auto
 description: Run the automated reviewer loop (and CI loop) for a PR. Use when the user wants to run the reviewer loop on a specific PR or the current branch's PR until it is ready for human review or escalated.
 ---
 

--- a/.cursor/agents/code-reviewer.md
+++ b/.cursor/agents/code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-model: claude-sonnet-4-6
+model: cursor-grok-4.5-high
 description: Development review stage. Use when an implementation PR needs review against the spec, plan, and best practices. Applies fixes directly for blocking and important issues. Reports issues requiring human/product decisions.
 ---
 

--- a/.cursor/agents/design-reviewer.md
+++ b/.cursor/agents/design-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: design-reviewer
-model: claude-sonnet-4-6
+model: auto
 description: Design review stage. Use when an implementation PR includes frontend file changes. Launches a browser via the configured browser_automation.provider, renders affected pages or components, captures screenshots, checks for console errors, and runs an axe-core accessibility check. Posts a structured PR comment with the verdict (Approved / Needs Revision / Skipped).
 ---
 

--- a/.cursor/agents/developer.md
+++ b/.cursor/agents/developer.md
@@ -1,6 +1,6 @@
 ---
 name: developer
-model: claude-sonnet-4-6
+model: cursor-grok-4.5-high
 description: In Development stage. Handles four paths — Full Pipeline (feature with spec+plan), Refactor (code restructuring with plan only, no spec), Fast Track (bug or simple change, no spec/plan needed), and Hotfix (critical production bug from main). Implements code, verifies build/lint/tests, opens PRs, and resolves reviewer / CI readiness.
 tools: Read, Grep, Glob, Write, Edit, Bash
 ---

--- a/.cursor/agents/implementation-plan-reviewer.md
+++ b/.cursor/agents/implementation-plan-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: implementation-plan-reviewer
-model: claude-sonnet-4-6
+model: cursor-grok-4.5-high
 description: Plan review stage. Use when an implementation plan branch or PR needs review for spec alignment, completeness, and feasibility. Reads the spec, plan, and codebase to validate the approach, and can push reviewer-loop fixes.
 ---
 

--- a/.cursor/agents/item-orchestrator.md
+++ b/.cursor/agents/item-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: item-orchestrator
-model: claude-sonnet-4-6
+model: auto
 description: Internal Cursor handoff agent for a single workflow item after /run-item resolves the bounded prelude; direct use is legacy compatibility. Runs Protocol 91 until waiting on a human, blocked, or escalated.
 ---
 

--- a/.cursor/agents/orchestrator.md
+++ b/.cursor/agents/orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrator
-model: fast
+model: auto
 description: Portfolio orchestration agent (Protocol 90). In scan mode (invoked via /run-work), discovers what can advance or start and proposes the largest safe batch. In execute mode (invoked via /run-items), dispatches approved item work with an explicit bounded scope and supervises each item until waiting on a human, blocked, or escalated.
 ---
 

--- a/.cursor/agents/orchestrator.md
+++ b/.cursor/agents/orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrator
-model: auto
+model: fast
 description: Portfolio orchestration agent (Protocol 90). In scan mode (invoked via /run-work), discovers what can advance or start and proposes the largest safe batch. In execute mode (invoked via /run-items), dispatches approved item work with an explicit bounded scope and supervises each item until waiting on a human, blocked, or escalated.
 ---
 

--- a/.cursor/agents/post-merge-qa.md
+++ b/.cursor/agents/post-merge-qa.md
@@ -1,6 +1,6 @@
 ---
 name: post-merge-qa
-model: claude-sonnet-4-6
+model: auto
 description: Post-merge QA on develop or develop-<slug>. Discovers confirmed scope, preflights the environment, exercises flows, optional design-asset fidelity, and opens one fix PR when safely actionable defects exist (no new backlog item).
 ---
 

--- a/.cursor/agents/product-manager.md
+++ b/.cursor/agents/product-manager.md
@@ -1,6 +1,6 @@
 ---
 name: product-manager
-model: claude-opus-4-7
+model: cursor-grok-4.5-high
 description: Spec Ready stage. Use when a new feature needs a spec written. Conducts a structured alignment conversation with the human, then writes the feature spec, runs its reviewer gate, and resolves PR readiness. Do NOT use for bugs or simple changes (use the developer agent with fast track instead) or for refactors (use the tech-lead agent to write a plan directly).
 ---
 

--- a/.cursor/agents/project-setup.md
+++ b/.cursor/agents/project-setup.md
@@ -1,6 +1,6 @@
 ---
 name: project-setup
-model: claude-sonnet-4-6
+model: auto
 description: Onboarding agent. Run this when first setting up a new project from this template. Guides a structured conversation to generate all project-specific documentation (business domain, architecture, tech stack, best practices) and configures the framework for your project.
 ---
 

--- a/.cursor/agents/retrospective.md
+++ b/.cursor/agents/retrospective.md
@@ -1,6 +1,6 @@
 ---
 name: retrospective
-model: claude-sonnet-4-6
+model: auto
 description: Retrospective analysis agent. Analyzes completed work (a batch or individual item) to identify process improvement opportunities, presents them to the human, and executes the chosen action for each.
 ---
 

--- a/.cursor/agents/smoke-tester.md
+++ b/.cursor/agents/smoke-tester.md
@@ -1,6 +1,6 @@
 ---
 name: smoke-tester
-model: claude-sonnet-4-6
+model: auto
 description: Smoke test stage. Use when a code review has been approved and the implementation needs manual smoke testing before merge. Executes the smoke test runbook using browser automation.
 ---
 

--- a/.cursor/agents/spec-reviewer.md
+++ b/.cursor/agents/spec-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: spec-reviewer
-model: claude-sonnet-4-6
+model: cursor-grok-4.5-high
 description: Spec review stage. Use when a spec branch or PR needs review for completeness, clarity, and testability. Applies fixes directly where possible, can push reviewer-loop fixes, and reports issues requiring human input.
 ---
 

--- a/.cursor/agents/tech-lead.md
+++ b/.cursor/agents/tech-lead.md
@@ -86,4 +86,4 @@ reference(s); when none exist, omit fidelity steps and do not invent a baseline.
 
 Before updating tracker status as part of a standalone plan completion sequence, call `ensure_on_project_board <issue_number> "Writing Plan"` (from `scripts/development-workflow/workflow-lib.sh`) to register the issue on the project board if it is not already present.
 
-**Note**: This agent handles premium-tier reasoning tasks for architecture decisions. See `docs/workflow/development-workflow/agent-model-config.md` for canonical model override guidance.
+**Note**: This agent handles premium-tier reasoning tasks for architecture decisions. See [the canonical model override guidance](../../docs/workflow/development-workflow/agent-model-config.md).

--- a/.cursor/agents/tech-lead.md
+++ b/.cursor/agents/tech-lead.md
@@ -1,6 +1,6 @@
 ---
 name: tech-lead
-model: claude-opus-4-7
+model: cursor-grok-4.5-high
 description: Plan Ready stage. Use when an implementation plan needs to be written. For Full Pipeline items, a spec must be approved first. For Refactor items, the work item brief replaces the spec. Reads the codebase, resolves technical approach questions, then writes the implementation plan, runs its reviewer gate, and resolves PR readiness.
 ---
 
@@ -86,4 +86,4 @@ reference(s); when none exist, omit fidelity steps and do not invent a baseline.
 
 Before updating tracker status as part of a standalone plan completion sequence, call `ensure_on_project_board <issue_number> "Writing Plan"` (from `scripts/development-workflow/workflow-lib.sh`) to register the issue on the project board if it is not already present.
 
-**Note**: This agent handles premium-tier reasoning tasks (architecture decisions). For best results, ensure your Cursor Composer is using a high-reasoning model (e.g., Claude Opus, GPT-4, or equivalent) when invoking this subagent, or edit this file to set `model:` to a specific premium model ID.
+**Note**: This agent handles premium-tier reasoning tasks (architecture decisions). The template pins it to Grok 4.5 High for Cursor runs; if Cursor exposes that model under a different local ID, update the `model:` field to match your model picker.

--- a/.cursor/agents/tech-lead.md
+++ b/.cursor/agents/tech-lead.md
@@ -86,4 +86,4 @@ reference(s); when none exist, omit fidelity steps and do not invent a baseline.
 
 Before updating tracker status as part of a standalone plan completion sequence, call `ensure_on_project_board <issue_number> "Writing Plan"` (from `scripts/development-workflow/workflow-lib.sh`) to register the issue on the project board if it is not already present.
 
-**Note**: This agent handles premium-tier reasoning tasks (architecture decisions). The template pins it to Grok 4.5 High for Cursor runs; if Cursor exposes that model under a different local ID, update the `model:` field to match your model picker.
+**Note**: This agent handles premium-tier reasoning tasks for architecture decisions. See `docs/workflow/development-workflow/agent-model-config.md` for canonical model override guidance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Bugbot usage-limit reviewer classification** (#1394): Escalate Cursor
+  Bugbot usage/spend-limit responses instead of treating neutral checks as
+  clean.
 - **Fail closed on checkpoint resume isolation** (#1285): Require complete
   worktree context and stop resumed isolated runners before mutation when the
   session starts in the main clone or cannot prove its assignment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Cursor agent model defaults** (#1394): Use Cursor `auto` for most
-  subagents and pin Grok 4.5 High for complex authoring and review agents.
+- **Agent model defaults** (#1394): Use Cursor `auto` for most subagents, pin
+  Grok 4.5 High for complex Cursor authoring and review agents, update Claude
+  Code agents to Sonnet 5 / Opus 5, and document Codex tier mappings for
+  GPT-5.6 Luna / Terra / Sol.
 - **Access-restricted reviewer merge gate** (#1288): Distinguish verified
   reviewer App-access restrictions from CI and review failures, prefer access
   remediation, and permit an audited protection bypass only after fresh named

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Cursor agent model defaults** (#1394): Use Cursor `auto` for most
+  subagents and pin Grok 4.5 High for complex authoring and review agents.
 - **Access-restricted reviewer merge gate** (#1288): Distinguish verified
   reviewer App-access restrictions from CI and review failures, prefer access
   remediation, and permit an audited protection bypass only after fresh named

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Agent model defaults** (#1394): Use Cursor `auto` for most subagents, pin
-  Grok 4.5 High for complex Cursor authoring and review agents, update Claude
-  Code agents to Sonnet 5 / Opus 5, and document Codex tier mappings for
-  GPT-5.6 Luna / Terra / Sol.
+- **Agent model defaults** (#1394): Use Cursor `fast` for economy coordination
+  agents, `auto` for lower-risk balanced agents, and Grok 4.5 High for complex
+  Cursor authoring and review agents; update Claude Code agents to Sonnet 5 /
+  Opus 5, and document Codex tier mappings for GPT-5.6 Luna / Terra / Sol.
 - **Access-restricted reviewer merge gate** (#1288): Distinguish verified
   reviewer App-access restrictions from CI and review failures, prefer access
   remediation, and permit an audited protection bypass only after fresh named

--- a/docs/workflow/development-workflow/agent-model-config.md
+++ b/docs/workflow/development-workflow/agent-model-config.md
@@ -44,28 +44,29 @@ If you prefer different names (`small/medium/large`, `fast/standard/pro`, etc.),
 Use the tier names as stable policy and map them to whatever your current runner and provider support.
 
 - In Claude Code, map the tier to the model family or explicit model ID configured in `.claude/agents/*.md`.
-- In Cursor, pin explicit model IDs in `.cursor/agents/*.md` for every long-running or review-loop agent. Use `fast` for `economy` tier agents only.
+- In Cursor, set `.cursor/agents/*.md` to `auto` for ordinary coordination and QA agents, and pin an explicit high-reasoning model for agents that author or deeply review specs, plans, and code.
 - In any runner, prefer keeping the tier intent stable even when provider model names change.
 
 ### Cursor model defaults (template)
 
-Pin models in `.cursor/agents/*.md` so subagents do not inherit the parent Composer model during long orchestration or review-fix loops. **`inherit` is acceptable only for ad-hoc, single-turn invocations** where you intentionally want the current Composer model — not for orchestrators, item runners, fixer agents, or reviewer-loop agents.
+Set models in `.cursor/agents/*.md` so subagents do not inherit the parent Composer model during long orchestration or review-fix loops. The template default is `auto` for most agents and `cursor-grok-4.5-high` for complex authoring and review work. If Cursor's model picker exposes Grok 4.5 under a different local ID, update the pinned value but preserve the same split. **`inherit` is acceptable only for ad-hoc, single-turn invocations** where you intentionally want the current Composer model — not for orchestrators, item runners, fixer agents, or reviewer-loop agents.
 
 | Agent | Tier | Cursor `model` (template default) |
 | ----- | ---- | ----------------------------------- |
-| `orchestrator` | `economy` | `fast` |
-| `automated-reviewer-loop` | `economy` | `fast` |
-| `item-orchestrator` | `balanced` | `claude-sonnet-4-6` |
-| `developer` | `balanced` | `claude-sonnet-4-6` |
-| `code-reviewer` | `balanced` | `claude-sonnet-4-6` |
-| `spec-reviewer` | `balanced` | `claude-sonnet-4-6` |
-| `implementation-plan-reviewer` | `balanced` | `claude-sonnet-4-6` |
-| `smoke-tester` | `balanced` | `claude-sonnet-4-6` |
-| `retrospective` | `balanced` | `claude-sonnet-4-6` |
-| `project-setup` | `balanced` | `claude-sonnet-4-6` |
-| `design-reviewer` | `balanced` | `claude-sonnet-4-6` |
-| `product-manager` | `premium` | `claude-opus-4-7` |
-| `tech-lead` | `premium` | `claude-opus-4-7` |
+| `orchestrator` | `economy` | `auto` |
+| `automated-reviewer-loop` | `economy` | `auto` |
+| `item-orchestrator` | `balanced` | `auto` |
+| `developer` | `balanced` | `cursor-grok-4.5-high` |
+| `code-reviewer` | `balanced` | `cursor-grok-4.5-high` |
+| `spec-reviewer` | `balanced` | `cursor-grok-4.5-high` |
+| `implementation-plan-reviewer` | `balanced` | `cursor-grok-4.5-high` |
+| `smoke-tester` | `balanced` | `auto` |
+| `retrospective` | `balanced` | `auto` |
+| `project-setup` | `balanced` | `auto` |
+| `design-reviewer` | `balanced` | `auto` |
+| `post-merge-qa` | `balanced` | `auto` |
+| `product-manager` | `premium` | `cursor-grok-4.5-high` |
+| `tech-lead` | `premium` | `cursor-grok-4.5-high` |
 
 Claude Code equivalents live in `.claude/agents/*.md` (Haiku for economy, Sonnet for balanced, Opus for premium). Update pinned IDs when your provider deprecates a model; keep the tier intent stable.
 
@@ -120,14 +121,15 @@ Cursor subagents use the `model` field in `.cursor/agents/<agent>.md`. To overri
 Edit the model configuration for the agent:
 
 - **Claude Code**: Edit the `model` field in `.claude/agents/*.md`
-- **Cursor**: Edit the `model` field in `.cursor/agents/*.md` (values: `fast`, `inherit`, or a specific model ID)
+- **Cursor**: Edit the `model` field in `.cursor/agents/*.md` (values: `auto`, `fast`, `inherit`, or a specific model ID)
 
 This affects all future invocations until changed back.
 
 **Cursor model field values:**
 
-- `fast`: Uses Cursor's fast model (recommended for `economy`-tier agents only)
-- Pinned model ID: Uses that exact model (recommended for `balanced` and `premium` agents, e.g. `claude-sonnet-4-6`, `claude-opus-4-7`)
+- `auto`: Lets Cursor route to an appropriate model (template default for most coordination, QA, setup, and retrospective agents)
+- `fast`: Uses Cursor's fast model (use only when you intentionally want the cheapest/fastest path)
+- Pinned model ID: Uses that exact model (template default for complex authoring and review agents, e.g. `cursor-grok-4.5-high`)
 - `inherit`: Uses the current Composer model — **discouraged** for orchestrators, item runners, fixer agents, and reviewer-loop agents because it leaks parent-session cost into long runs; reserve for intentional one-off overrides
 
 **Precedence**: When multiple agent locations exist (`.cursor/agents/`, `.claude/agents/`, `.codex/agents/`), Cursor uses `.cursor/agents/` first, then `.claude/agents/`, then `.codex/agents/`.

--- a/docs/workflow/development-workflow/agent-model-config.md
+++ b/docs/workflow/development-workflow/agent-model-config.md
@@ -70,14 +70,14 @@ Codex skills intentionally store recommended tiers rather than concrete model ID
 
 ### Cursor model defaults (template)
 
-Set models in `.cursor/agents/*.md` so subagents do not inherit the parent Composer model during long orchestration or review-fix loops. The template default is `auto` for most agents and `cursor-grok-4.5-high` for complex authoring and review work. If Cursor's model picker exposes Grok 4.5 under a different local ID, update the pinned value but preserve the same split. See the Cursor model field value guide below for when `inherit` is acceptable.
+Set models in `.cursor/agents/*.md` so subagents do not inherit the parent Composer model during long orchestration or review-fix loops. The template default is `fast` for economy coordination agents, `auto` for lower-risk balanced agents, and `cursor-grok-4.5-high` for complex authoring and review work. If Cursor's model picker exposes Grok 4.5 under a different local ID, update the pinned value but preserve the same split. See the Cursor model field value guide below for when `inherit` is acceptable.
 
-The `auto` assignments below are intentional for economy and lower-risk balanced agents that primarily coordinate, verify, or run checklist-style workflows. Cursor may route those runs to different concrete models over time, so their cost and latency can vary by workspace settings. Balanced agents that author production code or perform deep review stay pinned to Grok 4.5 High to keep complex reasoning capacity predictable.
+The `fast` economy assignments below are intentional for high-volume orchestration loops where predictable cost and latency matter more than deep reasoning. The remaining `auto` assignments are for lower-risk balanced agents that primarily verify or run checklist-style workflows; Cursor may route those runs to different concrete models over time, so their cost and latency can vary by workspace settings. Balanced agents that author production code or perform deep review stay pinned to Grok 4.5 High to keep complex reasoning capacity predictable.
 
 | Agent | Tier | Cursor `model` (template default) |
 | ----- | ---- | ----------------------------------- |
-| `orchestrator` | `economy` | `auto` |
-| `automated-reviewer-loop` | `economy` | `auto` |
+| `orchestrator` | `economy` | `fast` |
+| `automated-reviewer-loop` | `economy` | `fast` |
 | `item-orchestrator` | `balanced` | `auto` |
 | `developer` | `balanced` | `cursor-grok-4.5-high` |
 | `code-reviewer` | `balanced` | `cursor-grok-4.5-high` |
@@ -151,8 +151,8 @@ This affects all future invocations until changed back.
 
 **Cursor model field values:**
 
-- `auto`: Lets Cursor route to an appropriate model (template default for most coordination, QA, setup, and retrospective agents)
-- `fast`: Uses Cursor's fast model (use only when you intentionally want the cheapest/fastest path)
+- `fast`: Uses Cursor's fast model (template default for economy coordination agents where predictable cost and latency matter most)
+- `auto`: Lets Cursor route to an appropriate model (template default for lower-risk balanced QA, setup, and retrospective agents)
 - Pinned model ID: Uses that exact model (template default for complex authoring and review agents, e.g. `cursor-grok-4.5-high`)
 - `inherit`: Uses the current Composer model — **discouraged** for orchestrators, item runners, fixer agents, and reviewer-loop agents because it leaks parent-session cost into long runs; reserve for intentional one-off overrides
 

--- a/docs/workflow/development-workflow/agent-model-config.md
+++ b/docs/workflow/development-workflow/agent-model-config.md
@@ -128,8 +128,9 @@ Use your runner’s “one-off model override” mechanism.
 
 Claude Code example (if applicable):
 
+<!-- workflow-shell-contract: bash -->
 ```bash
-claude --agent developer --model claude-opus-5
+bash -lc 'claude --agent developer --model claude-opus-5'
 ```
 
 **Cursor:**

--- a/docs/workflow/development-workflow/agent-model-config.md
+++ b/docs/workflow/development-workflow/agent-model-config.md
@@ -72,6 +72,8 @@ Codex skills intentionally store recommended tiers rather than concrete model ID
 
 Set models in `.cursor/agents/*.md` so subagents do not inherit the parent Composer model during long orchestration or review-fix loops. The template default is `auto` for most agents and `cursor-grok-4.5-high` for complex authoring and review work. If Cursor's model picker exposes Grok 4.5 under a different local ID, update the pinned value but preserve the same split. See the Cursor model field value guide below for when `inherit` is acceptable.
 
+The `auto` assignments below are intentional for economy and lower-risk balanced agents that primarily coordinate, verify, or run checklist-style workflows. Cursor may route those runs to different concrete models over time, so their cost and latency can vary by workspace settings. Balanced agents that author production code or perform deep review stay pinned to Grok 4.5 High to keep complex reasoning capacity predictable.
+
 | Agent | Tier | Cursor `model` (template default) |
 | ----- | ---- | ----------------------------------- |
 | `orchestrator` | `economy` | `auto` |

--- a/docs/workflow/development-workflow/agent-model-config.md
+++ b/docs/workflow/development-workflow/agent-model-config.md
@@ -45,7 +45,28 @@ Use the tier names as stable policy and map them to whatever your current runner
 
 - In Claude Code, map the tier to the model family or explicit model ID configured in `.claude/agents/*.md`.
 - In Cursor, set `.cursor/agents/*.md` to `auto` for ordinary coordination and QA agents, and pin an explicit high-reasoning model for agents that author or deeply review specs, plans, and code.
+- In Codex, keep skills tier-based (`economy`, `balanced`, `premium`) and map the active runner model to the current OpenAI model family.
 - In any runner, prefer keeping the tier intent stable even when provider model names change.
+
+### Claude Code model defaults (template)
+
+Claude Code agents pin concrete model IDs in `.claude/agents/*.md`.
+
+| Tier | Claude Code `model` (template default) | Used for |
+| ---- | -------------------------------------- | -------- |
+| `economy` | `claude-haiku-4-5-20251001` | Portfolio orchestration and mechanical reviewer-loop coordination |
+| `balanced` | `claude-sonnet-5` | Implementation, review, setup, QA, smoke testing, item orchestration, and retrospectives |
+| `premium` | `claude-opus-5` | Spec writing and technical planning |
+
+### Codex / OpenAI model mapping (template)
+
+Codex skills intentionally store recommended tiers rather than concrete model IDs. Map those tiers to the current OpenAI family in the Codex runner or model picker:
+
+| Tier | OpenAI model mapping | Used for |
+| ---- | -------------------- | -------- |
+| `economy` | `gpt-5.6-luna` | Mechanical coordination and high-volume checklist work |
+| `balanced` | `gpt-5.6-terra` | Implementation, review, setup, QA, item orchestration, and retrospectives |
+| `premium` | `gpt-5.6-sol` | Spec writing and technical planning |
 
 ### Cursor model defaults (template)
 
@@ -68,7 +89,7 @@ Set models in `.cursor/agents/*.md` so subagents do not inherit the parent Compo
 | `product-manager` | `premium` | `cursor-grok-4.5-high` |
 | `tech-lead` | `premium` | `cursor-grok-4.5-high` |
 
-Claude Code equivalents live in `.claude/agents/*.md` (Haiku for economy, Sonnet for balanced, Opus for premium). Update pinned IDs when your provider deprecates a model; keep the tier intent stable.
+Update pinned IDs and tier mappings when your provider deprecates a model; keep the tier intent stable.
 
 See also:
 
@@ -108,7 +129,7 @@ Use your runner’s “one-off model override” mechanism.
 Claude Code example (if applicable):
 
 ```bash
-claude --agent developer --model claude-opus-4-7
+claude --agent developer --model claude-opus-5
 ```
 
 **Cursor:**

--- a/docs/workflow/development-workflow/agent-model-config.md
+++ b/docs/workflow/development-workflow/agent-model-config.md
@@ -70,7 +70,7 @@ Codex skills intentionally store recommended tiers rather than concrete model ID
 
 ### Cursor model defaults (template)
 
-Set models in `.cursor/agents/*.md` so subagents do not inherit the parent Composer model during long orchestration or review-fix loops. The template default is `auto` for most agents and `cursor-grok-4.5-high` for complex authoring and review work. If Cursor's model picker exposes Grok 4.5 under a different local ID, update the pinned value but preserve the same split. **`inherit` is acceptable only for ad-hoc, single-turn invocations** where you intentionally want the current Composer model — not for orchestrators, item runners, fixer agents, or reviewer-loop agents.
+Set models in `.cursor/agents/*.md` so subagents do not inherit the parent Composer model during long orchestration or review-fix loops. The template default is `auto` for most agents and `cursor-grok-4.5-high` for complex authoring and review work. If Cursor's model picker exposes Grok 4.5 under a different local ID, update the pinned value but preserve the same split. See the Cursor model field value guide below for when `inherit` is acceptable.
 
 | Agent | Tier | Cursor `model` (template default) |
 | ----- | ---- | ----------------------------------- |

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1165,6 +1165,23 @@ bugbot_return_disabled() {
   return 2
 }
 
+bugbot_return_usage_limit() {
+  local pr_number="$1"
+  local branch_name="$2"
+
+  echo "INFO: Bugbot could not run because the Cursor usage or spend limit was reached. Raise the limit or wait for quota reset, then rerun the reviewer loop." >&2
+  print_kv RESULT escalate
+  print_kv REASON bugbot-usage-limit
+  print_kv PLATFORM bugbot
+  print_kv PR_NUMBER "$pr_number"
+  print_kv BRANCH "$branch_name"
+  print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+  print_kv COMMENT_COUNT 0
+  print_kv BLOCKING_COUNT 0
+  print_kv SUGGESTION_COUNT 0
+  return 2
+}
+
 bugbot_check_disabled_issue_comments() {
   local repo="$1"
   local pr_number="$2"
@@ -1190,6 +1207,50 @@ bugbot_check_disabled_issue_comments() {
     return 1
   fi
   printf '%s\n' "$output"
+  return 0
+}
+
+bugbot_escalate_for_unavailable_issue_comments() {
+  local repo="$1"
+  local pr_number="$2"
+  local branch_name="$3"
+  local bot_login="$4"
+  local since_iso="$5"
+  local context="$6"
+  local body
+  local unavailable_bodies
+  local _comments_rc=0
+
+  set +e
+  unavailable_bodies="$(bugbot_check_disabled_issue_comments "$repo" "$pr_number" "$bot_login" "$since_iso")"
+  _comments_rc=$?
+  set -e
+  if [ "$_comments_rc" -ne 0 ]; then
+    echo "WARN: run_bugbot_review: ${context} issue-comment fetch failed for PR #$pr_number" >&2
+    print_kv RESULT escalate
+    print_kv REASON fetch-failed
+    print_kv PLATFORM bugbot
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv COMMENT_COUNT 0
+    print_kv BLOCKING_COUNT 0
+    print_kv SUGGESTION_COUNT 0
+    return 2
+  fi
+
+  while IFS= read -r body; do
+    [ -z "$body" ] && continue
+    if is_bugbot_disabled_message "$body"; then
+      bugbot_return_disabled "$pr_number" "$branch_name"
+      return 2
+    fi
+    if is_bugbot_usage_limit_message "$body"; then
+      bugbot_return_usage_limit "$pr_number" "$branch_name"
+      return 2
+    fi
+  done <<< "$unavailable_bodies"
+
   return 0
 }
 
@@ -1270,9 +1331,6 @@ bugbot_escalate_if_disabled_without_check_run() {
   local since_iso="$5"
   local head_sha="$6"
   local check_name="$7"
-  local body
-  local disabled_bodies
-  local _comments_rc=0
   local _preflight_rc=0
 
   set +e
@@ -1297,30 +1355,13 @@ bugbot_escalate_if_disabled_without_check_run() {
   fi
 
   set +e
-  disabled_bodies="$(bugbot_check_disabled_issue_comments "$repo" "$pr_number" "$bot_login" "$since_iso")"
-  _comments_rc=$?
+  bugbot_escalate_for_unavailable_issue_comments \
+    "$repo" "$pr_number" "$branch_name" "$bot_login" "$since_iso" "disabled-preflight"
+  local _unavailable_comments_rc=$?
   set -e
-  if [ "$_comments_rc" -ne 0 ]; then
-    echo "WARN: run_bugbot_review: disabled-preflight issue-comment fetch failed for PR #$pr_number" >&2
-    print_kv RESULT escalate
-    print_kv REASON fetch-failed
-    print_kv PLATFORM bugbot
-    print_kv PR_NUMBER "$pr_number"
-    print_kv BRANCH "$branch_name"
-    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
-    print_kv COMMENT_COUNT 0
-    print_kv BLOCKING_COUNT 0
-    print_kv SUGGESTION_COUNT 0
+  if [ "$_unavailable_comments_rc" -eq 2 ]; then
     return 2
   fi
-
-  while IFS= read -r body; do
-    [ -z "$body" ] && continue
-    if is_bugbot_disabled_message "$body"; then
-      bugbot_return_disabled "$pr_number" "$branch_name"
-      return 2
-    fi
-  done <<< "$disabled_bodies"
 
   return 0
 }
@@ -1900,6 +1941,17 @@ run_bugbot_review() {
           ;;
 
         neutral|cancelled|skipped)
+          # A neutral check is clean only when Cursor did not also post an
+          # unavailable/quota issue comment for this head.
+          set +e
+          bugbot_escalate_for_unavailable_issue_comments \
+            "$repo" "$pr_number" "$branch_name" "$bot_login" "$since_iso" "neutral-conclusion"
+          local _bb_neutral_unavailable_rc=$?
+          set -e
+          if [ "$_bb_neutral_unavailable_rc" -eq 2 ]; then
+            return 2
+          fi
+
           # Non-blocking informational outcome — clean, no real findings.
           print_kv RESULT clean
           print_kv PLATFORM "$platform"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1182,6 +1182,21 @@ bugbot_return_usage_limit() {
   return 2
 }
 
+bugbot_since_iso_for_sha() {
+  local repo="$1"
+  local head_sha="$2"
+  local since_iso
+  local _bb_now_iso
+
+  since_iso="$(gh api "repos/$repo/commits/$head_sha" --jq '.commit.committer.date // empty' 2>/dev/null || true)"
+  if [ -z "$since_iso" ]; then
+    since_iso="$(date -u -v-24H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '24 hours ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
+  fi
+  _bb_now_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  [ "$since_iso" \> "$_bb_now_iso" ] && since_iso="$_bb_now_iso"
+  printf '%s\n' "$since_iso"
+}
+
 bugbot_check_disabled_issue_comments() {
   local repo="$1"
   local pr_number="$2"
@@ -1440,16 +1455,7 @@ run_bugbot_review() {
   fi
 
   # Resolve the commit timestamp to scope findings to this HEAD.
-  set +e
-  since_iso="$(gh api "repos/$repo/commits/$head_sha" --jq '.commit.committer.date // empty' 2>/dev/null)"
-  set -e
-  if [ -z "$since_iso" ]; then
-    since_iso="$(date -u -v-24H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '24 hours ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
-  fi
-  # Cap to now to handle clock-skew / rebase that produces a future committer.date.
-  _bb_now_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-  [ "$since_iso" \> "$_bb_now_iso" ] && since_iso="$_bb_now_iso"
-  unset _bb_now_iso
+  since_iso="$(bugbot_since_iso_for_sha "$repo" "$head_sha")"
 
   # --- Phase 1: Check for existing blocking cursor[bot] findings on current HEAD ---
   # If blocking findings already exist (e.g. from a previous trigger in the same
@@ -1943,9 +1949,11 @@ run_bugbot_review() {
         neutral|cancelled|skipped)
           # A neutral check is clean only when Cursor did not also post an
           # unavailable/quota issue comment for this head.
+          local _bb_neutral_since_iso
+          _bb_neutral_since_iso="$(bugbot_since_iso_for_sha "$repo" "$_current_sha")"
           set +e
           bugbot_escalate_for_unavailable_issue_comments \
-            "$repo" "$pr_number" "$branch_name" "$bot_login" "$since_iso" "neutral-conclusion"
+            "$repo" "$pr_number" "$branch_name" "$bot_login" "$_bb_neutral_since_iso" "neutral-conclusion"
           local _bb_neutral_unavailable_rc=$?
           set -e
           if [ "$_bb_neutral_unavailable_rc" -eq 2 ]; then

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1236,6 +1236,7 @@ bugbot_escalate_for_unavailable_issue_comments() {
   local bot_login="$4"
   local since_iso="$5"
   local context="$6"
+  local allow_usage_limit="${7:-1}"
   local body
   local unavailable_bodies
   local _comments_rc=0
@@ -1264,7 +1265,7 @@ bugbot_escalate_for_unavailable_issue_comments() {
       bugbot_return_disabled "$pr_number" "$branch_name"
       return 2
     fi
-    if is_bugbot_usage_limit_message "$body"; then
+    if [ "$allow_usage_limit" -eq 1 ] && is_bugbot_usage_limit_message "$body"; then
       bugbot_return_usage_limit "$pr_number" "$branch_name"
       return 2
     fi
@@ -1375,7 +1376,7 @@ bugbot_escalate_if_disabled_without_check_run() {
 
   set +e
   bugbot_escalate_for_unavailable_issue_comments \
-    "$repo" "$pr_number" "$branch_name" "$bot_login" "$since_iso" "disabled-preflight"
+    "$repo" "$pr_number" "$branch_name" "$bot_login" "$since_iso" "disabled-preflight" 0
   local _unavailable_comments_rc=$?
   set -e
   if [ "$_unavailable_comments_rc" -eq 2 ]; then
@@ -1737,7 +1738,7 @@ run_bugbot_review() {
                 )
             ]
             | sort_by(.started_at) | last
-            | ((.status // "") + " " + (.conclusion // ""))
+            | ((.status // "") + " " + (.conclusion // "") + " " + (.started_at // ""))
           ' 2>/dev/null
     )"
     _fetch_rc=$?
@@ -1755,9 +1756,11 @@ run_bugbot_review() {
       print_kv SUGGESTION_COUNT 0
       return 2
     fi
-    read -r status_val conclusion <<< "$_fetch_output"
+    local check_started_at=""
+    read -r status_val conclusion check_started_at <<< "$_fetch_output"
     status_val="${status_val:-}"
     conclusion="${conclusion:-}"
+    check_started_at="${check_started_at:-}"
 
     if [ "$status_val" != "completed" ]; then
       set +e
@@ -1981,9 +1984,13 @@ run_bugbot_review() {
         neutral|cancelled|skipped)
           # A neutral check is clean only when Cursor did not also post an
           # unavailable/quota issue comment for this head.
+          local _unavailable_since_iso="$_current_since_iso"
+          if [ -n "$check_started_at" ] && [ "$check_started_at" \> "$_unavailable_since_iso" ]; then
+            _unavailable_since_iso="$check_started_at"
+          fi
           set +e
           bugbot_escalate_for_unavailable_issue_comments \
-            "$repo" "$pr_number" "$branch_name" "$bot_login" "$_current_since_iso" "neutral-conclusion"
+            "$repo" "$pr_number" "$branch_name" "$bot_login" "$_unavailable_since_iso" "neutral-conclusion" 1
           local _bb_neutral_unavailable_rc=$?
           set -e
           if [ "$_bb_neutral_unavailable_rc" -eq 2 ]; then

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1188,13 +1188,15 @@ bugbot_since_iso_for_sha() {
   local since_iso
   local _bb_now_iso
 
-  since_iso="$(gh api "repos/$repo/commits/$head_sha" --jq '.commit.committer.date // empty' 2>/dev/null || true)"
+  if ! since_iso="$(gh api "repos/$repo/commits/$head_sha" --jq '.commit.committer.date // empty' 2>/dev/null)"; then
+    return 1
+  fi
   if [ -z "$since_iso" ]; then
-    since_iso="$(date -u -v-24H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '24 hours ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
+    return 1
   fi
   _bb_now_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   if [ "$since_iso" \> "$_bb_now_iso" ]; then
-    since_iso="$(date -u -v-24H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '24 hours ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
+    return 1
   fi
   printf '%s\n' "$since_iso"
 }
@@ -1457,7 +1459,19 @@ run_bugbot_review() {
   fi
 
   # Resolve the commit timestamp to scope findings to this HEAD.
-  since_iso="$(bugbot_since_iso_for_sha "$repo" "$head_sha")"
+  if ! since_iso="$(bugbot_since_iso_for_sha "$repo" "$head_sha")"; then
+    echo "WARN: run_bugbot_review: could not resolve commit timestamp for PR #$pr_number (SHA=$head_sha) — returning unavailable" >&2
+    print_kv RESULT escalate
+    print_kv REASON fetch-failed
+    print_kv PLATFORM "$platform"
+    print_kv PR_NUMBER "$pr_number"
+    print_kv BRANCH "$branch_name"
+    print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv COMMENT_COUNT 0
+    print_kv BLOCKING_COUNT 0
+    print_kv SUGGESTION_COUNT 0
+    return 2
+  fi
 
   # --- Phase 1: Check for existing blocking cursor[bot] findings on current HEAD ---
   # If blocking findings already exist (e.g. from a previous trigger in the same
@@ -1467,9 +1481,9 @@ run_bugbot_review() {
   local _existing_reviews_rc=0
   existing_comments="$(
     gh api "repos/$repo/pulls/$pr_number/comments" --paginate 2>/dev/null \
-      | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
+      | jq -r --arg bot "$bot_login" --arg since "$since_iso" --arg sha "$head_sha" '
           .[]
-          | select((.user.login == $bot or .user.login == ($bot + "[bot]")) and .created_at > $since and .in_reply_to_id == null)
+          | select((.user.login == $bot or .user.login == ($bot + "[bot]")) and .created_at > $since and .commit_id == $sha and .in_reply_to_id == null)
           | { path, line: (.line // .original_line // 0), body: (.body // "") }
           | @json
         ' 2>/dev/null
@@ -1477,11 +1491,12 @@ run_bugbot_review() {
   _existing_comments_rc=$?
   existing_reviews="$(
     gh api "repos/$repo/pulls/$pr_number/reviews" --paginate 2>/dev/null \
-      | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
+      | jq -r --arg bot "$bot_login" --arg since "$since_iso" --arg sha "$head_sha" '
           .[]
           | select(
               (.user.login == $bot or .user.login == ($bot + "[bot]")) and
               .submitted_at > $since and
+              .commit_id == $sha and
               (
                 .state == "CHANGES_REQUESTED" or
                 .state == "COMMENTED"
@@ -1695,7 +1710,19 @@ run_bugbot_review() {
     fi
     unset _sha_rc
     local _current_since_iso
-    _current_since_iso="$(bugbot_since_iso_for_sha "$repo" "$_current_sha")"
+    if ! _current_since_iso="$(bugbot_since_iso_for_sha "$repo" "$_current_sha")"; then
+      echo "WARN: run_bugbot_review: could not resolve commit timestamp for PR #$pr_number (SHA=$_current_sha) — returning unavailable" >&2
+      print_kv RESULT escalate
+      print_kv REASON fetch-failed
+      print_kv PLATFORM "$platform"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv BRANCH "$branch_name"
+      print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv COMMENT_COUNT 0
+      print_kv BLOCKING_COUNT 0
+      print_kv SUGGESTION_COUNT 0
+      return 2
+    fi
 
     set +e
     local _fetch_rc=0
@@ -1755,10 +1782,10 @@ run_bugbot_review() {
 	          local _clean_comments_rc=0
 	          _clean_comments="$(
 	            gh api "repos/$repo/pulls/$pr_number/comments" --paginate 2>/dev/null \
-	              | jq -r --arg bot "$bot_login" --arg since "$_current_since_iso" '
-                  .[]
-                  | select((.user.login == $bot or .user.login == ($bot + "[bot]")) and .created_at > $since and .in_reply_to_id == null)
-                  | { path, line: (.line // .original_line // 0), body: (.body // "") }
+	              | jq -r --arg bot "$bot_login" --arg since "$_current_since_iso" --arg sha "$_current_sha" '
+	                  .[]
+	                  | select((.user.login == $bot or .user.login == ($bot + "[bot]")) and .created_at > $since and .commit_id == $sha and .in_reply_to_id == null)
+	                  | { path, line: (.line // .original_line // 0), body: (.body // "") }
                   | @json
                 ' 2>/dev/null
           )"
@@ -1834,22 +1861,23 @@ run_bugbot_review() {
 	          local _blocking_reviews_rc=0
 	          _blocking_comments="$(
 	            gh api "repos/$repo/pulls/$pr_number/comments" --paginate 2>/dev/null \
-	              | jq -r --arg bot "$bot_login" --arg since "$_current_since_iso" '
-                  .[]
-                  | select((.user.login == $bot or .user.login == ($bot + "[bot]")) and .created_at > $since and .in_reply_to_id == null)
-                  | { path, line: (.line // .original_line // 0), body: (.body // "") }
+	              | jq -r --arg bot "$bot_login" --arg since "$_current_since_iso" --arg sha "$_current_sha" '
+	                  .[]
+	                  | select((.user.login == $bot or .user.login == ($bot + "[bot]")) and .created_at > $since and .commit_id == $sha and .in_reply_to_id == null)
+	                  | { path, line: (.line // .original_line // 0), body: (.body // "") }
                   | @json
                 ' 2>/dev/null
           )"
 	          _blocking_comments_rc=$?
 	          _blocking_reviews="$(
 	            gh api "repos/$repo/pulls/$pr_number/reviews" --paginate 2>/dev/null \
-	              | jq -r --arg bot "$bot_login" --arg since "$_current_since_iso" '
-                  .[]
-                  | select(
-                      (.user.login == $bot or .user.login == ($bot + "[bot]")) and
-                      .submitted_at > $since and
-                      (
+	              | jq -r --arg bot "$bot_login" --arg since "$_current_since_iso" --arg sha "$_current_sha" '
+	                  .[]
+	                  | select(
+	                      (.user.login == $bot or .user.login == ($bot + "[bot]")) and
+	                      .submitted_at > $since and
+	                      .commit_id == $sha and
+	                      (
                         .state == "CHANGES_REQUESTED" or
                         .state == "COMMENTED"
                       )

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1193,7 +1193,9 @@ bugbot_since_iso_for_sha() {
     since_iso="$(date -u -v-24H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '24 hours ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
   fi
   _bb_now_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-  [ "$since_iso" \> "$_bb_now_iso" ] && since_iso="$_bb_now_iso"
+  if [ "$since_iso" \> "$_bb_now_iso" ]; then
+    since_iso="$(date -u -v-24H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '24 hours ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
+  fi
   printf '%s\n' "$since_iso"
 }
 
@@ -1692,6 +1694,8 @@ run_bugbot_review() {
       _current_sha="$head_sha"
     fi
     unset _sha_rc
+    local _current_since_iso
+    _current_since_iso="$(bugbot_since_iso_for_sha "$repo" "$_current_sha")"
 
     set +e
     local _fetch_rc=0
@@ -1731,7 +1735,7 @@ run_bugbot_review() {
     if [ "$status_val" != "completed" ]; then
       set +e
       bugbot_escalate_if_disabled_without_check_run \
-        "$repo" "$pr_number" "$branch_name" "$bot_login" "$since_iso" "$_current_sha" "$check_name"
+        "$repo" "$pr_number" "$branch_name" "$bot_login" "$_current_since_iso" "$_current_sha" "$check_name"
       local _bb_disabled_poll_rc=$?
       set -e
       if [ "$_bb_disabled_poll_rc" -eq 2 ]; then
@@ -1747,11 +1751,11 @@ run_bugbot_review() {
           # comments to confirm and collect any suggestions.
           blocking_lines_file="$(mktemp)"
           set +e
-          local _clean_comments
-          local _clean_comments_rc=0
-          _clean_comments="$(
-            gh api "repos/$repo/pulls/$pr_number/comments" --paginate 2>/dev/null \
-              | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
+	          local _clean_comments
+	          local _clean_comments_rc=0
+	          _clean_comments="$(
+	            gh api "repos/$repo/pulls/$pr_number/comments" --paginate 2>/dev/null \
+	              | jq -r --arg bot "$bot_login" --arg since "$_current_since_iso" '
                   .[]
                   | select((.user.login == $bot or .user.login == ($bot + "[bot]")) and .created_at > $since and .in_reply_to_id == null)
                   | { path, line: (.line // .original_line // 0), body: (.body // "") }
@@ -1825,22 +1829,22 @@ run_bugbot_review() {
           # Blocking findings. Read cursor[bot] reviews/comments for the summary.
           blocking_lines_file="$(mktemp)"
           set +e
-          local _blocking_comments _blocking_reviews
-          local _blocking_comments_rc=0
-          local _blocking_reviews_rc=0
-          _blocking_comments="$(
-            gh api "repos/$repo/pulls/$pr_number/comments" --paginate 2>/dev/null \
-              | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
+	          local _blocking_comments _blocking_reviews
+	          local _blocking_comments_rc=0
+	          local _blocking_reviews_rc=0
+	          _blocking_comments="$(
+	            gh api "repos/$repo/pulls/$pr_number/comments" --paginate 2>/dev/null \
+	              | jq -r --arg bot "$bot_login" --arg since "$_current_since_iso" '
                   .[]
                   | select((.user.login == $bot or .user.login == ($bot + "[bot]")) and .created_at > $since and .in_reply_to_id == null)
                   | { path, line: (.line // .original_line // 0), body: (.body // "") }
                   | @json
                 ' 2>/dev/null
           )"
-          _blocking_comments_rc=$?
-          _blocking_reviews="$(
-            gh api "repos/$repo/pulls/$pr_number/reviews" --paginate 2>/dev/null \
-              | jq -r --arg bot "$bot_login" --arg since "$since_iso" '
+	          _blocking_comments_rc=$?
+	          _blocking_reviews="$(
+	            gh api "repos/$repo/pulls/$pr_number/reviews" --paginate 2>/dev/null \
+	              | jq -r --arg bot "$bot_login" --arg since "$_current_since_iso" '
                   .[]
                   | select(
                       (.user.login == $bot or .user.login == ($bot + "[bot]")) and
@@ -1949,11 +1953,9 @@ run_bugbot_review() {
         neutral|cancelled|skipped)
           # A neutral check is clean only when Cursor did not also post an
           # unavailable/quota issue comment for this head.
-          local _bb_neutral_since_iso
-          _bb_neutral_since_iso="$(bugbot_since_iso_for_sha "$repo" "$_current_sha")"
           set +e
           bugbot_escalate_for_unavailable_issue_comments \
-            "$repo" "$pr_number" "$branch_name" "$bot_login" "$_bb_neutral_since_iso" "neutral-conclusion"
+            "$repo" "$pr_number" "$branch_name" "$bot_login" "$_current_since_iso" "neutral-conclusion"
           local _bb_neutral_unavailable_rc=$?
           set -e
           if [ "$_bb_neutral_unavailable_rc" -eq 2 ]; then

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2791,6 +2791,20 @@ else
 fi
 run_test "bugbot_usage_limit_message_detected" "usage_limit" "$actual"
 
+if is_bugbot_usage_limit_message "Bugbot could not run: usage/spend limit reached"; then
+  actual="usage_limit"
+else
+  actual="active"
+fi
+run_test "bugbot_usage_spend_slash_message_detected" "usage_limit" "$actual"
+
+if is_bugbot_usage_limit_message "Bugbot could not run: usage/spend-limit reached"; then
+  actual="usage_limit"
+else
+  actual="active"
+fi
+run_test "bugbot_usage_spend_hyphen_message_detected" "usage_limit" "$actual"
+
 if is_bugbot_usage_limit_message "Cursor Bugbot found no issues in this pull request."; then
   actual="usage_limit"
 else

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2931,7 +2931,7 @@ case "$*" in
   *"pulls/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/reviews"*)
-    printf '[{"user":{"login":"cursor[bot]"},"submitted_at":"2020-01-02T00:00:00Z","state":"CHANGES_REQUESTED","body":"Cursor Bugbot found no issues in this pull request."}]\n'
+    printf '[{"user":{"login":"cursor[bot]"},"submitted_at":"2020-01-02T00:00:00Z","commit_id":"abc162bsha","state":"CHANGES_REQUESTED","body":"Cursor Bugbot found no issues in this pull request."}]\n'
     exit 0 ;;
   *"check-runs"*)
     printf '{"check_runs":[{"name":"Cursor Bugbot","app":{"slug":"cursor"},"status":"completed","conclusion":"success","started_at":"2020-01-01T00:00:00Z"}]}\n'
@@ -2975,7 +2975,7 @@ case "$*" in
   *"pulls/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/reviews"*)
-    printf '[{"user":{"login":"cursor[bot]"},"submitted_at":"2020-01-02T00:00:00Z","state":"CHANGES_REQUESTED","body":""}]\n'
+    printf '[{"user":{"login":"cursor[bot]"},"submitted_at":"2020-01-02T00:00:00Z","commit_id":"abc162csha","state":"CHANGES_REQUESTED","body":""}]\n'
     exit 0 ;;
   *"check-runs"*)
     printf '{"check_runs":[{"name":"Cursor Bugbot","app":{"slug":"cursor"},"status":"completed","conclusion":"success","started_at":"2020-01-01T00:00:00Z"}]}\n'
@@ -3158,7 +3158,7 @@ case "$*" in
     printf '[]\n'; exit 0 ;;
   # Phase 1 reviews — one blocking CHANGES_REQUESTED from cursor[bot]
   *"pulls/"*"/reviews"*)
-    printf '[{"user":{"login":"cursor[bot]"},"submitted_at":"2020-01-02T00:00:00Z","state":"CHANGES_REQUESTED","body":"BUGBOT_REVIEW: null pointer at src/lib.c:10"}]\n'
+    printf '[{"user":{"login":"cursor[bot]"},"submitted_at":"2020-01-02T00:00:00Z","commit_id":"abc166sha","state":"CHANGES_REQUESTED","body":"BUGBOT_REVIEW: null pointer at src/lib.c:10"}]\n'
     exit 0 ;;
   # check-runs and trigger POST must NOT be reached (function returns early)
   *"check-runs"*)
@@ -3524,7 +3524,7 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"check-runs"*)
-    printf '{"check_runs":[{"name":"Cursor Bugbot","app":{"slug":"cursor"},"status":"completed","conclusion":"neutral","started_at":"2020-01-03T00:00:01Z"}]}\n'
+    printf '{"check_runs":[{"name":"Cursor Bugbot","app":{"slug":"cursor"},"status":"completed","conclusion":"neutral","started_at":"2020-01-01T00:00:01Z"}]}\n'
     exit 0 ;;
   *"headRefOid"*)
     printf 'abc1692new\n'; exit 0 ;;

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2784,6 +2784,20 @@ else
 fi
 run_test "bugbot_generic_disabled_phrase_not_matched" "active" "$actual"
 
+if is_bugbot_usage_limit_message "Bugbot couldn't run - usage limit reached"; then
+  actual="usage_limit"
+else
+  actual="active"
+fi
+run_test "bugbot_usage_limit_message_detected" "usage_limit" "$actual"
+
+if is_bugbot_usage_limit_message "Cursor Bugbot found no issues in this pull request."; then
+  actual="usage_limit"
+else
+  actual="active"
+fi
+run_test "bugbot_clean_phrase_not_usage_limit" "active" "$actual"
+
 # ---------------------------------------------------------------------------
 # Test 16.1: clean path — check run conclusion=success, no blocking comments
 # ---------------------------------------------------------------------------
@@ -3421,6 +3435,59 @@ run_test "bugbot_neutral_suggestion_count" "SUGGESTION_COUNT=0" \
 run_test "bugbot_neutral_exit_code" "0" "$actual_exit"
 rm -rf "$_bugbot_mock_dir_169"
 unset _bugbot_mock_dir_169 actual_output actual_exit
+
+# ---------------------------------------------------------------------------
+# Test 16.9.1: neutral usage-limit comment escalates
+#
+# Cursor can conclude the check run as neutral while posting an issue comment
+# that Bugbot could not run because a usage/spend limit was reached. That is
+# unavailable, not clean.
+# ---------------------------------------------------------------------------
+_bugbot_mock_dir_1691="$(mktemp -d)"
+cat > "$_bugbot_mock_dir_1691/gh" <<'BUGBOT_GH_1691'
+#!/usr/bin/env bash
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc1691sha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"--method POST"*)
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"user":{"login":"cursor[bot]"},"created_at":"2020-01-01T00:00:01Z","body":"Bugbot could not run - usage limit reached. The organization hit a usage or spend limit."}]\n'
+    exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"check-runs"*)
+    printf '{"check_runs":[{"name":"Cursor Bugbot","app":{"slug":"cursor"},"status":"completed","conclusion":"neutral","started_at":"2020-01-01T00:00:00Z"}]}\n'
+    exit 0 ;;
+  *"headRefOid"*)
+    printf 'abc1691sha\n'; exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+BUGBOT_GH_1691
+chmod +x "$_bugbot_mock_dir_1691/gh"
+
+unset BUGBOT_BOT_LOGIN BUGBOT_CHECK_NAME BUGBOT_TRIGGER_COMMENT
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_bugbot_overrides"
+  _ec=0
+  PATH="$_bugbot_mock_dir_1691:$PATH" run_bugbot_review "42" "feature/42-test" "1" "5" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "bugbot_neutral_usage_limit_result" "RESULT=escalate" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "bugbot_neutral_usage_limit_reason" "REASON=bugbot-usage-limit" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+run_test "bugbot_neutral_usage_limit_exit_code" "2" "$actual_exit"
+rm -rf "$_bugbot_mock_dir_1691"
+unset _bugbot_mock_dir_1691 actual_output actual_exit
 
 # ---------------------------------------------------------------------------
 # Test 16.10: run_platform_review routes "bugbot" to run_bugbot_review

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3489,6 +3489,53 @@ run_test "bugbot_neutral_usage_limit_exit_code" "2" "$actual_exit"
 rm -rf "$_bugbot_mock_dir_1691"
 unset _bugbot_mock_dir_1691 actual_output actual_exit
 
+# Test 16.9.2: neutral usage-limit comment from prior head is ignored
+_bugbot_mock_dir_1692="$(mktemp -d)"
+cat > "$_bugbot_mock_dir_1692/gh" <<'BUGBOT_GH_1692'
+#!/usr/bin/env bash
+case "$*" in
+  *"commits/abc1692old"*".commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"commits/abc1692new"*".commit.committer.date"*)
+    printf '2020-01-03T00:00:00Z\n'; exit 0 ;;
+  *"--jq .head.sha"*)
+    printf 'abc1692old\n'; exit 0 ;;
+  *"--method POST"*)
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"user":{"login":"cursor[bot]"},"created_at":"2020-01-02T00:00:00Z","body":"Bugbot could not run - usage limit reached."}]\n'
+    exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"check-runs"*)
+    printf '{"check_runs":[{"name":"Cursor Bugbot","app":{"slug":"cursor"},"status":"completed","conclusion":"neutral","started_at":"2020-01-03T00:00:01Z"}]}\n'
+    exit 0 ;;
+  *"headRefOid"*)
+    printf 'abc1692new\n'; exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+BUGBOT_GH_1692
+chmod +x "$_bugbot_mock_dir_1692/gh"
+
+unset BUGBOT_BOT_LOGIN BUGBOT_CHECK_NAME BUGBOT_TRIGGER_COMMENT
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_bugbot_overrides"
+  _ec=0
+  PATH="$_bugbot_mock_dir_1692:$PATH" run_bugbot_review "42" "feature/42-test" "1" "5" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "bugbot_neutral_stale_usage_limit_result" "RESULT=clean" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "bugbot_neutral_stale_usage_limit_exit_code" "0" "$actual_exit"
+rm -rf "$_bugbot_mock_dir_1692"
+unset _bugbot_mock_dir_1692 actual_output actual_exit
+
 # ---------------------------------------------------------------------------
 # Test 16.10: run_platform_review routes "bugbot" to run_bugbot_review
 # ---------------------------------------------------------------------------

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -452,7 +452,7 @@ is_bugbot_disabled_message() {
 is_bugbot_usage_limit_message() {
   local body="$1"
 
-  printf '%s\n' "$body" | grep -Eiq 'usage or spend limit|usage[ -]?limit|spend[ -]?limit'
+  printf '%s\n' "$body" | grep -Eiq 'usage or spend limit|usage[/-]spend[ -]?limit|usage[ -]?limit|spend[ -]?limit'
 }
 
 open_pr_number_for_branch() {

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -449,6 +449,12 @@ is_bugbot_disabled_message() {
   return 1
 }
 
+is_bugbot_usage_limit_message() {
+  local body="$1"
+
+  printf '%s\n' "$body" | grep -Eiq 'usage or spend limit|usage[ -]?limit|spend[ -]?limit'
+}
+
 open_pr_number_for_branch() {
   require_gh
   gh pr list --head "$1" --state open --limit 100 --json number --jq '.[0].number // empty'


### PR DESCRIPTION
## Summary

- Update Cursor subagent frontmatter so most agents use `auto` and complex authoring/review agents use `cursor-grok-4.5-high`.
- Update Claude Code agent frontmatter to keep Haiku 4.5 for economy coordination, use Sonnet 5 for balanced agents, and use Opus 5 for premium spec/plan agents.
- Keep Codex skills tier-based, document the GPT-5.6 Luna / Terra / Sol tier mapping, and move `workflow-retrospective` to the balanced tier.
- Escalate Cursor Bugbot usage/spend-limit responses instead of treating neutral Bugbot check runs as clean.
- Document the model split in `agent-model-config.md` and update the CHANGELOG entries.

## Pre-Submission Self-Review

- Reviewed `git diff origin/develop...HEAD` for scope and stale references.
- Confirmed current `.cursor/agents/*.md` frontmatter matches the intended auto/Grok split.
- Confirmed current `.claude/agents/*.md` frontmatter matches the intended Haiku/Sonnet 5/Opus 5 split.
- Confirmed Codex skills continue to use tiers, with only retrospective corrected from economy to balanced.
- Left old model names in historical CHANGELOG entries and sync-template examples only.
- Added a regression test for the Bugbot neutral-check plus usage-limit issue-comment path.
- Nested-artifact guard result: clean for issue #1394 in both pre-create and pre-pr modes.

## Verification

- `git diff --check`
- `bash -n scripts/development-workflow/workflow-lib.sh`
- `bash -n scripts/development-workflow/pr-review-loop.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` — 335 passed, 0 failed
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop`
- `shellcheck --severity=error scripts/development-workflow/workflow-lib.sh scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `npx markdownlint-cli2 CHANGELOG.md docs/workflow/development-workflow/agent-model-config.md`
- `npx markdownlint-cli2 CHANGELOG.md docs/workflow/development-workflow/agent-model-config.md .codex/skills/workflow-retrospective/SKILL.md`
- Python frontmatter check for all `.cursor/agents/*.md` model values
- Python frontmatter/tier check for all `.claude/agents/*.md` model values and `.codex/skills/workflow-retrospective/SKILL.md`
- `scripts/development-workflow/run-nested-artifact-guard.sh --mode pre-pr --issue 1394 --expected-branch feature/1394-cursor-agent-model-defaults --approved-base develop --repo-root /Users/lhpaul/Git/ai-dev-framework-template`

## Source Notes

- Anthropic docs checked: Claude model overview, choosing a model, Sonnet 5 migration, and Opus 5 migration.
- OpenAI docs checked: latest-model resolver returned `gpt-5.6-sol`, plus GPT-5.6 latest model and migration guidance.

Closes #1394


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Workflow Improvements**
  * Updated automated review and development workflows with refreshed model-selection defaults.
  * Improved handling of automated review service unavailability and usage limits by escalating affected checks instead of marking them clean.

* **Documentation**
  * Updated workflow guidance and the unreleased changelog with current model configuration and review-gate behavior.

* **Tests**
  * Added coverage for usage-limit detection and escalation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->