### PR TITLE
chore(review): use CodeRabbit ready reviewer

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -52,7 +52,7 @@ review:
     # Ordered list of GitHub/App/CLI reviewers that run only after draft gates
     # are clean and the PR has been converted with `gh pr ready`.
     github:
-      - bugbot
+      - coderabbit
   #
   # CodeRabbit CLI platform options (local CLI reviewer; place "coderabbit-cli"
   # in on_draft.github or on_ready.github to opt in; independent from the

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,15 +3,11 @@
 # This file controls CodeRabbit's behavior for this repository.
 # Docs: https://docs.coderabbit.ai/reference/configuration
 #
-# This repository is configured for CLI-only mode (Path A):
-# - auto PR reviews are disabled (auto_review.enabled: false below)
-# - pr-review-loop.sh invokes CodeRabbit on demand via @coderabbitai review
-#   when "coderabbit" is listed in review.platforms in .ai-dev-workflow.yaml
-# - draft PR reviews remain disabled
-#
-# To re-enable External PR reviewer mode (Path B):
-#   1. Set reviews.auto_review.enabled to true below
-#   2. Add "coderabbit" to review.platforms in .ai-dev-workflow.yaml if not present
+# This repository is configured for GitHub App PR reviewer mode:
+# - auto PR reviews are enabled for non-draft PRs targeting develop
+# - pr-review-loop.sh treats "coderabbit" in review.on_ready.github as the
+#   durable ready-phase reviewer signal
+# - draft PR reviews remain disabled so the workflow's draft gates run first
 
 reviews:
   tools:
@@ -19,11 +15,11 @@ reviews:
       enabled: true
       timeout_ms: 600000
   auto_review:
-    enabled: false
+    enabled: true
     drafts: false
+    auto_pause_after_reviewed_commits: 1
     base_branches:
       - develop
-      - main
   path_filters:
     - "!dist/**"
     - "!**/*.generated.*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CodeRabbit ready-phase reviewer**: Replace Bugbot with CodeRabbit as the
+  default ready-phase external PR reviewer and enable budget-conscious
+  non-draft `develop` auto-review.
 - **Agent model defaults** (#1394): Use Cursor `fast` for economy coordination
   agents, `auto` for lower-risk balanced agents, and Grok 4.5 High for complex
   Cursor authoring and review agents; update Claude Code agents to Sonnet 5 /

--- a/docs/workflow/development-workflow/integrations/coderabbit.md
+++ b/docs/workflow/development-workflow/integrations/coderabbit.md
@@ -18,7 +18,7 @@ CodeRabbit is **optional**. The workflow functions without it. See [`integration
 
 CodeRabbit supports three independent usage modes in this framework:
 
-### CLI-only (Path A — default)
+### CLI-only (Path A)
 
 Use the CodeRabbit CLI locally before pushing. No GitHub App needed.
 
@@ -35,7 +35,9 @@ coderabbit auth login
 /coderabbit:review
 ```
 
-The `.coderabbit.yaml` at the repo root ships with `auto_review.enabled: false` so the GitHub App (if installed) does not auto-review PRs.
+Use this mode by keeping `reviews.auto_review.enabled: false` in
+`.coderabbit.yaml` and leaving `coderabbit` out of `review.on_draft.github` and
+`review.on_ready.github`.
 
 ### CLI Step 7 reviewer (Path B)
 
@@ -97,6 +99,10 @@ To enable CodeRabbit as a Step 7 automated PR reviewer platform:
 
 The `coderabbit` App platform remains separate from `coderabbit-cli`. It uses
 the `coderabbitai[bot]` review/comment evidence path described below.
+
+This template repository uses this mode for ready-phase PR review: CodeRabbit
+auto-review is enabled for non-draft PRs targeting `develop`, and
+`.ai-dev-workflow.yaml` lists `coderabbit` under `review.on_ready.github`.
 
 ---
 


### PR DESCRIPTION
## Summary

- replace Bugbot with CodeRabbit as the ready-phase external reviewer
- enable CodeRabbit GitHub App auto-review for non-draft PRs targeting `develop`
- keep CodeRabbit auto-review budget-conscious with early incremental pause
- update CodeRabbit integration docs so CLI-only is no longer described as this repository's default

## Validation

- `python3` YAML parse check for `.ai-dev-workflow.yaml` and `.coderabbit.yaml`
- `npx markdownlint-cli2 docs/workflow/development-workflow/integrations/coderabbit.md CHANGELOG.md`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled automatic CodeRabbit reviews for non-draft pull requests targeting `develop`.
  * Added automatic pausing after a reviewed commit to reduce redundant reviews.

* **Documentation**
  * Updated CodeRabbit integration guidance to reflect the available review modes and current repository configuration.

* **Changelog**
  * Documented the switch from Bugbot to CodeRabbit for ready-phase pull request reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->