### PR TITLE
docs(plan): one product repository per implementation item

### DIFF
--- a/docs/specs/developments/20260731064618_1354-one-product-repository-per-implementation-item/2_1354-one-product-repository-per-implementation-item_implementation-plan.md
+++ b/docs/specs/developments/20260731064618_1354-one-product-repository-per-implementation-item/2_1354-one-product-repository-per-implementation-item_implementation-plan.md
@@ -128,10 +128,14 @@ product key.
       for unexpected runtime errors. Because stop outcomes also exit `0`, every
       mutating consumer must parse `continue_allowed` and refuse branch, PR,
       reviewer, CI, or cleanup mutation when it is `false`; no wrapper may treat
-      exit status alone as permission to continue. Classifier and orchestration
-      tests must assert the same field names, nullability, enum values,
-      exit-status semantics, fingerprint behavior, and `continue_allowed`
-      gating. Map to AC1-AC8.
+      exit status alone as permission to continue. Consumers may mutate only
+      after exit status `0`, valid JSON, successful schema validation, and
+      `continue_allowed` exactly equal to `true`; they must stop without
+      mutating on nonzero exits, parse errors, schema errors, missing fields,
+      invalid fields, `false`, or any other condition. Classifier and
+      orchestration tests must assert the same field names, nullability, enum
+      values, exit-status semantics, fingerprint behavior, fail-closed handling,
+      and `continue_allowed` gating. Map to AC1-AC8.
 - [ ] Extend `scripts/development-workflow/workflow-config-resolver.py` or its
       tests only where needed to expose configured product repository keys in a
       reusable form. Do not duplicate key validation outside the resolver; the
@@ -140,8 +144,9 @@ product key.
       implementation-stage decisions in `workflow_hub` call the shared
       classifier before branch, PR, reviewer, CI, or cleanup routing. It should
       print the routing outcome, selected product repository key, artifact owner,
-      and stop evidence, then gate mutation exclusively on `continue_allowed`.
-      Map to AC1-AC4 and AC7.
+      and stop evidence. Consumers may mutate only after exit status `0`, schema
+      validation, and `continue_allowed` exactly equal to `true`. Map to AC1-AC4
+      and AC7.
 - [ ] Update `scripts/development-workflow/discover-workflow-state.sh`,
       `run-item-scope-resolver.sh`, `run-epic-scope-resolver.sh`, and relevant
       run-item/run-items handoff code so summaries preserve the classifier

--- a/docs/specs/developments/20260731064618_1354-one-product-repository-per-implementation-item/2_1354-one-product-repository-per-implementation-item_implementation-plan.md
+++ b/docs/specs/developments/20260731064618_1354-one-product-repository-per-implementation-item/2_1354-one-product-repository-per-implementation-item_implementation-plan.md
@@ -95,7 +95,17 @@ product key.
       mode, action/stage, configured product repository keys, optional selected
       key values, and an explicit hub-only marker. Outputs must include a stable
       code, display label, selected key when valid, artifact owner, stop reason,
-      and required human action. The `--json` output contract is:
+      and required human action. The canonical configuration input is either
+      `--config <path>` for deterministic JSON fixtures or `--repo-root <path>`
+      for production resolution from the repo workflow config; explicit
+      `--config` wins over `--repo-root`, and `--repo-root` wins over the current
+      working directory. `--fixture <path>` supplies only item identity, stage,
+      selected keys, and hub-only markers; it must not override configured
+      product repositories. The JSON fixture schema is one object with
+      `repository_mode`, `stage`, `item_identifier`, `hub_only`, and
+      `selected_product_repo_keys` item fields plus configuration from either
+      the separate `--config` object or repo-root resolver output. The `--json`
+      output contract is:
       `outcome_code` string enum (`product_owned`, `hub_only`,
       `missing_target`, `ambiguous_target`, `multiple_targets`,
       `single_repo`); `display_label` string; `continue_allowed` boolean;
@@ -103,16 +113,25 @@ product key.
       enum (`selected_product_repository`, `hub_repository`,
       `current_repository`, `none`); `stop_reason` string or `null`;
       `required_human_action` string or `null`; `configured_product_repo_keys`
-      array of strings; `selected_product_repo_keys` array of strings;
-      `fingerprint` string; and `schema_version` string. The classifier exits
-      `0` when it emits this contract for any classified outcome, `2` for
-      malformed input or unreadable configuration, and nonzero for unexpected
-      runtime errors. Because stop outcomes also exit `0`, every mutating
-      consumer must parse `continue_allowed` and refuse branch, PR, reviewer,
-      CI, or cleanup mutation when it is `false`; no wrapper may treat exit
-      status alone as permission to continue. Classifier and orchestration tests
-      must assert the same field names, nullability, enum values, exit-status
-      semantics, and `continue_allowed` gating. Map to AC1-AC8.
+      array of strings sorted lexicographically; `selected_product_repo_keys`
+      array of strings sorted lexicographically; `fingerprint` string; and
+      `schema_version` string. The `fingerprint` is
+      `sha256(routing-fingerprint.v1 + "\n" + canonical_json)`, where
+      `canonical_json` is UTF-8 JSON with sorted object keys and no insignificant
+      whitespace over `schema_version`, `item_identifier`, `repository_mode`,
+      `stage`, sorted configured keys, sorted selected keys, and `hub_only`.
+      A mutating handoff that carries a fingerprint must reject the handoff when
+      the current classifier fingerprint differs; handoffs that reclassify
+      immediately before mutation treat the fingerprint as diagnostic evidence.
+      The classifier exits `0` when it emits this contract for any classified
+      outcome, `2` for malformed input or unreadable configuration, and nonzero
+      for unexpected runtime errors. Because stop outcomes also exit `0`, every
+      mutating consumer must parse `continue_allowed` and refuse branch, PR,
+      reviewer, CI, or cleanup mutation when it is `false`; no wrapper may treat
+      exit status alone as permission to continue. Classifier and orchestration
+      tests must assert the same field names, nullability, enum values,
+      exit-status semantics, fingerprint behavior, and `continue_allowed`
+      gating. Map to AC1-AC8.
 - [ ] Extend `scripts/development-workflow/workflow-config-resolver.py` or its
       tests only where needed to expose configured product repository keys in a
       reusable form. Do not duplicate key validation outside the resolver; the
@@ -216,6 +235,9 @@ workflow command tests, and smoke/manual review.
       for mirrored agent/skill wording.
 - [ ] Extend `scripts/development-workflow/tests/test-workflow-hub-docs.sh` for
       decomposition and hub-only/product-owned documentation coverage.
+- [ ] Run existing `scripts/development-workflow/tests/test-run-work-router.sh`
+      coverage to guard no-target, single-target, and multi-target routing after
+      shared classifier and next-action changes.
 
 ### Parser-Risk Addendum
 
@@ -269,11 +291,12 @@ workflow metadata and configured product repository keys.
 
 | Entity | Values / Scenario | File |
 | --- | --- | --- |
-| Workflow-hub fixture config | Two product repositories, `mobile-app` and `admin-portal`, with default branches and GitHub slugs | Temporary fixtures inside `scripts/development-workflow/tests/test-work-item-repository-routing.sh` and `test-workflow-orchestration-product-repo-aware.sh` |
-| Product-owned item fixture | One child item with selected key `mobile-app` | Temporary issue JSON/comment fixture in routing tests |
-| Missing-target fixture | Product-owned child with no selected key | Temporary issue JSON/comment fixture in routing tests |
-| Multiple-target fixture | Product-owned child naming both `mobile-app` and `admin-portal` | Temporary issue JSON/comment fixture in routing tests |
-| Hub-only fixture | Hub-owned workflow item with no product key | Temporary issue JSON/comment fixture in routing tests |
+| Workflow-hub fixture config | Two product repositories, `mobile-app` and `admin-portal`, with default branches and GitHub slugs | Persistent fixture `scripts/development-workflow/tests/fixtures/1354-routing/config-workflow-hub.json` used by classifier tests, orchestration tests, and the smoke runbook |
+| Product-owned item fixture | One child item with selected key `mobile-app` | Persistent fixture `scripts/development-workflow/tests/fixtures/1354-routing/product-owned.json` |
+| Product-owned peer fixture | One child item with selected key `admin-portal` | Persistent fixture `scripts/development-workflow/tests/fixtures/1354-routing/product-owned-admin-portal.json` |
+| Missing-target fixture | Product-owned child with no selected key | Persistent fixture `scripts/development-workflow/tests/fixtures/1354-routing/missing-target.json` |
+| Multiple-target fixture | Product-owned child naming both `mobile-app` and `admin-portal` | Persistent fixture `scripts/development-workflow/tests/fixtures/1354-routing/multiple-targets.json` |
+| Hub-only fixture | Hub-owned workflow item with no product key | Persistent fixture `scripts/development-workflow/tests/fixtures/1354-routing/hub-only.json` |
 
 ---
 
@@ -325,6 +348,7 @@ Bash and Python helper patterns in `scripts/development-workflow/`.
    - `bash scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh`
    - `bash scripts/development-workflow/tests/test-workflow-agent-product-repo-guidance.sh`
    - `bash scripts/development-workflow/tests/test-workflow-hub-docs.sh`
+   - `bash scripts/development-workflow/tests/test-run-work-router.sh`
    - `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
    - `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
 8. Update `CHANGELOG.md` under `[Unreleased]` with:

--- a/docs/specs/developments/20260731064618_1354-one-product-repository-per-implementation-item/2_1354-one-product-repository-per-implementation-item_implementation-plan.md
+++ b/docs/specs/developments/20260731064618_1354-one-product-repository-per-implementation-item/2_1354-one-product-repository-per-implementation-item_implementation-plan.md
@@ -107,9 +107,12 @@ product key.
       `fingerprint` string; and `schema_version` string. The classifier exits
       `0` when it emits this contract for any classified outcome, `2` for
       malformed input or unreadable configuration, and nonzero for unexpected
-      runtime errors. Classifier and orchestration tests must assert the same
-      field names, nullability, enum values, and exit-status semantics. Map to
-      AC1-AC8.
+      runtime errors. Because stop outcomes also exit `0`, every mutating
+      consumer must parse `continue_allowed` and refuse branch, PR, reviewer,
+      CI, or cleanup mutation when it is `false`; no wrapper may treat exit
+      status alone as permission to continue. Classifier and orchestration tests
+      must assert the same field names, nullability, enum values, exit-status
+      semantics, and `continue_allowed` gating. Map to AC1-AC8.
 - [ ] Extend `scripts/development-workflow/workflow-config-resolver.py` or its
       tests only where needed to expose configured product repository keys in a
       reusable form. Do not duplicate key validation outside the resolver; the
@@ -118,7 +121,8 @@ product key.
       implementation-stage decisions in `workflow_hub` call the shared
       classifier before branch, PR, reviewer, CI, or cleanup routing. It should
       print the routing outcome, selected product repository key, artifact owner,
-      and stop evidence. Map to AC1-AC4 and AC7.
+      and stop evidence, then gate mutation exclusively on `continue_allowed`.
+      Map to AC1-AC4 and AC7.
 - [ ] Update `scripts/development-workflow/discover-workflow-state.sh`,
       `run-item-scope-resolver.sh`, `run-epic-scope-resolver.sh`, and relevant
       run-item/run-items handoff code so summaries preserve the classifier
@@ -181,7 +185,7 @@ workflow command tests, and smoke/manual review.
 
 1. `single_repo` mode returns the current repository target without requiring a
    product repository key. Maps to AC8.
-2. `workflow_hub` product-owned work with exactly one configured selected key
+2. `workflow_hub` product-owned work with exactly one valid selected key
    returns `Product owned`, artifact owner `selected product repository`, and
    includes the same key in handoff output. Maps to AC1 and AC7.
 3. Product-owned work with no key returns `Missing target`, stops before

--- a/docs/specs/developments/20260731064618_1354-one-product-repository-per-implementation-item/2_1354-one-product-repository-per-implementation-item_implementation-plan.md
+++ b/docs/specs/developments/20260731064618_1354-one-product-repository-per-implementation-item/2_1354-one-product-repository-per-implementation-item_implementation-plan.md
@@ -62,12 +62,18 @@ repository mode, work-item role, selected product repository keys, and stage.
 | Gate input | Allowed outcome | Required next action | Mirror surfaces |
 | --- | --- | --- | --- |
 | `single_repo` mode | `Single-repository` | Continue current repository workflow unchanged | Protocol 91, `workflow-next-action.sh`, smoke runbook |
-| `workflow_hub` product-owned item with exactly one configured product repository key | `Product owned` | Continue product implementation routing with that key in handoffs | Run-item/run-items/run-epic handoffs, PR/reviewer routing, cleanup |
+| `workflow_hub` product-owned item with exactly one valid selected product repository key on the item | `Product owned` | Continue product implementation routing with that selected key in handoffs | Run-item/run-items/run-epic handoffs, PR/reviewer routing, cleanup |
 | `workflow_hub` product-owned item with no selected key | `Missing target` | Stop before product branch, PR, reviewer, CI, or cleanup mutation; hub may record stop evidence | Next-action output, orchestrator summaries, smoke runbook |
 | `workflow_hub` product-owned item whose target cannot be resolved from confirmed tracker context | `Ambiguous target` | Stop before mutation and request routing clarification | Next-action output, orchestrator summaries, smoke runbook |
 | `workflow_hub` product-owned item with more than one selected key | `Multiple targets` | Stop and split or narrow to one product repository child | Add-backlog guidance, run-item/run-epic handoffs, smoke runbook |
 | `workflow_hub` hub-only item with no product repository key | `Hub only` | Continue hub-owned workflow artifacts in the hub repository | Spec/plan/review/cleanup guidance |
 | `workflow_hub` hub-only item with a product repository key | `Ambiguous target` | Stop until the operator removes the key or reclassifies the item as product-owned | Add-backlog guidance, next-action output |
+
+Precedence rule: a product-owned item with no selected key is always
+`Missing target`, even when the hub config contains multiple product
+repositories. `Ambiguous target` is reserved for conflicting, unknown, or
+unresolved target evidence, including a hub-only item that also carries a
+product key.
 
 ---
 
@@ -89,7 +95,21 @@ repository mode, work-item role, selected product repository keys, and stage.
       mode, action/stage, configured product repository keys, optional selected
       key values, and an explicit hub-only marker. Outputs must include a stable
       code, display label, selected key when valid, artifact owner, stop reason,
-      and required human action. Map to AC1-AC8.
+      and required human action. The `--json` output contract is:
+      `outcome_code` string enum (`product_owned`, `hub_only`,
+      `missing_target`, `ambiguous_target`, `multiple_targets`,
+      `single_repo`); `display_label` string; `continue_allowed` boolean;
+      `selected_product_repo_key` string or `null`; `artifact_owner` string
+      enum (`selected_product_repository`, `hub_repository`,
+      `current_repository`, `none`); `stop_reason` string or `null`;
+      `required_human_action` string or `null`; `configured_product_repo_keys`
+      array of strings; `selected_product_repo_keys` array of strings;
+      `fingerprint` string; and `schema_version` string. The classifier exits
+      `0` when it emits this contract for any classified outcome, `2` for
+      malformed input or unreadable configuration, and nonzero for unexpected
+      runtime errors. Classifier and orchestration tests must assert the same
+      field names, nullability, enum values, and exit-status semantics. Map to
+      AC1-AC8.
 - [ ] Extend `scripts/development-workflow/workflow-config-resolver.py` or its
       tests only where needed to expose configured product repository keys in a
       reusable form. Do not duplicate key validation outside the resolver; the
@@ -100,14 +120,18 @@ repository mode, work-item role, selected product repository keys, and stage.
       print the routing outcome, selected product repository key, artifact owner,
       and stop evidence. Map to AC1-AC4 and AC7.
 - [ ] Update `scripts/development-workflow/discover-workflow-state.sh`,
-      `run-epic-scope-resolver.sh`, and relevant run-item/run-items handoff
-      code so summaries preserve the classifier result instead of re-inferring
-      repository ownership from branch names or the current checkout. Map to
-      AC1-AC7.
+      `run-item-scope-resolver.sh`, `run-epic-scope-resolver.sh`, and relevant
+      run-item/run-items handoff code so summaries preserve the classifier
+      result, fingerprint, and stop evidence instead of re-inferring repository
+      ownership from branch names or the current checkout. Map to AC1-AC7.
 - [ ] Update `scripts/development-workflow/post-merge-cleanup.sh` and
       reviewer/CI handoff glue only to consume the already-classified selected
       key. They must not implement a second product-repository-selection path.
       Map to AC6 and AC7.
+- [ ] Add a stale-decision guard to every mutating handoff. Either reclassify
+      immediately before mutation or carry the classifier `fingerprint` and
+      reject the handoff when the item/configuration fingerprint has changed.
+      Map to AC2-AC4 and AC7.
 
 ### Workflow Documentation
 
@@ -196,10 +220,10 @@ workflow metadata and configured product repository keys.
 
 - **Edge-case enumeration**:
   - Valid selected keys: one configured key such as `mobile-app`.
-  - Missing target: empty selected key for product-owned work.
-  - Ambiguous target: no selected key when multiple configured product
-    repositories exist, an unknown key, or conflicting tracker text that cannot
-    be normalized to one key.
+  - Missing target: empty selected key for product-owned work, including when
+    multiple product repositories are configured.
+  - Ambiguous target: unknown key, unresolved key, conflicting tracker text that
+    cannot be normalized to one key, or hub-only marker plus a product key.
   - Multiple targets: two or more configured keys on one item.
   - Hub-only: explicit hub-only marker with no product key.
   - Hub-only conflict: hub-only marker plus product key.
@@ -208,10 +232,13 @@ workflow metadata and configured product repository keys.
     titles that contain a product name but are not the selected key source.
 - **Unit test mapping**:
   - `scripts/development-workflow/tests/test-work-item-repository-routing.sh`:
-    one automated test for every edge case above.
+    one automated test for every edge case above plus one contract assertion for
+    every JSON field and exit-status class.
   - `scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh`:
     one test each for product-owned continue, missing target stop, ambiguous
-    target stop, multiple target stop, and hub-only continue.
+    target stop, multiple target stop, hub-only continue, and preservation of
+    classifier result, fingerprint, and stop evidence through
+    `run-item-scope-resolver.sh`.
 - **Suppression semantics**: Not applicable. This feature does not introduce
   inline suppression directives.
 
@@ -225,7 +252,9 @@ workflow metadata and configured product repository keys.
 - **Listener and resource cleanup**: Not applicable; no long-lived listeners,
   timers, or handles are introduced.
 - **Race conditions at initialization**: Not applicable; commands read the
-  current tracker/config snapshot at invocation start.
+  current tracker/config snapshot at invocation start. Mutating handoffs must
+  still prevent stale decisions by reclassifying immediately before mutation or
+  validating the classifier `fingerprint`.
 - **Race conditions at teardown**: Not applicable; there is no teardown hook.
 - **Error propagation across async boundaries**: Not applicable; failures are
   synchronous command exit statuses and stop evidence.
@@ -246,27 +275,10 @@ workflow metadata and configured product repository keys.
 
 ## Documentation Updates
 
-- [ ] `docs/workflow/development-workflow/repository-modes.md` - define
-      one-target routing outcomes and display labels.
-- [ ] `docs/workflow/development-workflow/workflow-hub-setup.md` - document hub
-      epic plus repository-scoped child decomposition.
-- [ ] `docs/workflow/development-workflow/cross-repo-pr-flow.md` - require
-      routing evidence before product-owned mutation.
-- [ ] `docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md`
-      - document tracker authoring for product-owned and hub-only children.
-- [ ] `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
-      - require routing classifier output in mutating batch handoffs.
-- [ ] `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`
-      - require routing classifier output before item implementation mutation.
-- [ ] `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` -
-      require routing classifier output before epic child implementation
-      mutation.
-- [ ] `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
-      - consume selected key rather than selecting product repositories.
-- [ ] `docs/workflow/development-workflow/protocols/04-smoke-test-protocol.md`
-      - consume selected key for product-owned smoke validation.
-- [ ] Agent and skill guidance listed in **Agent And Skill Guidance** - mirror
-      the classifier-result wording without duplicating selection logic.
+The canonical documentation inventory lives in
+[Workflow Documentation](#workflow-documentation) and
+[Agent And Skill Guidance](#agent-and-skill-guidance). Keep file additions and
+scope updates there so implementation has one source of truth.
 
 ---
 
@@ -310,6 +322,7 @@ Bash and Python helper patterns in `scripts/development-workflow/`.
    - `bash scripts/development-workflow/tests/test-workflow-agent-product-repo-guidance.sh`
    - `bash scripts/development-workflow/tests/test-workflow-hub-docs.sh`
    - `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
+   - `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
 8. Update `CHANGELOG.md` under `[Unreleased]` with:
    `- **One product repository per implementation item** (#1354): enforce one-target workflow-hub routing before product implementation mutation.`
 9. Complete the smoke test runbook and record any manual findings before PR

--- a/docs/specs/developments/20260731064618_1354-one-product-repository-per-implementation-item/2_1354-one-product-repository-per-implementation-item_implementation-plan.md
+++ b/docs/specs/developments/20260731064618_1354-one-product-repository-per-implementation-item/2_1354-one-product-repository-per-implementation-item_implementation-plan.md
@@ -1,0 +1,316 @@
+# One Product Repository Per Implementation Item - Implementation Plan
+
+**Spec**:
+[`1_1354-one-product-repository-per-implementation-item_specs.md`](./1_1354-one-product-repository-per-implementation-item_specs.md)
+**Smoke test runbook**:
+[`docs/testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md`](../../../testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add one shared routing contract that classifies a workflow-hub
+work item as product-owned, hub-only, missing target, ambiguous target, multiple
+targets, or single-repository. Wire that classification into item dispatch,
+implementation handoffs, PR/reviewer routing, cleanup, and documentation so
+product implementation mutation cannot proceed without exactly one selected
+product repository key.
+
+**Estimated complexity**: M
+
+**Rationale**: The implementation is mostly workflow tooling and documentation,
+but it crosses multiple command paths that currently pass product repository
+context independently. The main risk is inconsistent enforcement between
+run-item, run-items, run-epic, PR inspection, and cleanup.
+
+**Dependencies**: #1353 is merged through implementation and provides the
+canonical product repository key and artifact ownership contract. The #1354
+spec PR #1404 is merged into `develop-multi-repo-releases`.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `ebaaab2` |
+| Product-routing surface scan | `rg -l "selected product repository\|product repository selection\|workflow_hub" scripts/development-workflow docs/workflow/development-workflow .claude/agents .cursor/agents .codex/skills .agents/skills REVIEW.md \| sort \| wc -l` | 97 files mention the workflow-hub or selected-product-repository surface. The plan narrows implementation to shared scripts, protocol handoffs, tests, and agent/skill guidance that create or consume mutating item context. |
+| Existing routing entry points | `rg -l "workflow-next-action\|repository_context_for_action\|github_repo_args_for_action\|selected product repository" scripts/development-workflow/tests docs/testing/workflow \| sort` | Relevant existing coverage lives in `test-workflow-orchestration-product-repo-aware.sh`, `test-workflow-hub-smoke-fixtures.sh`, `test-workflow-agent-product-repo-guidance.sh`, and workflow smoke runbooks 878, 879, 880, and 883. |
+| Product repository key resolver | `sed -n '470,570p' scripts/development-workflow/workflow-config-resolver.py && sed -n '1010,1085p' scripts/development-workflow/workflow-config-resolver.py` | Existing resolver normalizes configured product repositories, rejects unknown keys, rejects ambiguous selection when more than one product repository exists, and exposes `list-product-repos`. |
+| Current next-action behavior | `sed -n '130,230p' scripts/development-workflow/workflow-next-action.sh && sed -n '380,430p' scripts/development-workflow/workflow-next-action.sh` | PR and branch inspection already route implementation artifacts to a selected product repository in `workflow_hub`, but the decision is not backed by a shared tracker-level one-target contract. |
+| Template-fit check | `rg -n "template:|is_template" .ai-dev-workflow.yaml` | `template.is_template: true`; the spec is generic workflow tooling and does not reference a downstream framework runtime, so planning can proceed. |
+
+---
+
+## Cross-Cutting Operational Assumption Check
+
+### Applicable
+
+| Assumption surface | Recorded value | Authoritative source | Verified at | Bounded cross-check scope | Result |
+| --- | --- | --- | --- | --- | --- |
+| Plan base | `develop-multi-repo-releases` | `/run-epic 1352` effective policy and PR #1404 base branch | 2026-07-31, repo `ebaaab2` | Epic #1352 child scope and current #1354 plan branch only | `Verified` |
+| Product repository key identity | Stable `workflow_hub.product_repos[].name` key from #1353 | `workflow-config-resolver.py` and #1353 merged contract | 2026-07-31, repo `ebaaab2` | #1354 plan plus same-epic remaining items #1356-#1359 that will consume the routing contract later | `Verified` |
+| Planning artifact owner | Hub repository owns specs and plans; selected product repository owns product implementation artifacts | #1353 merged contract and #1354 spec | 2026-07-31, repo `ebaaab2` | Hub-owned #1354 plan PR only; product implementation routing is deferred to the implementation branch | `Verified` |
+
+---
+
+## Complex Workflow Decision-Gate Matrix
+
+This plan modifies workflow decision-gate behavior because routing depends on
+repository mode, work-item role, selected product repository keys, and stage.
+
+| Gate input | Allowed outcome | Required next action | Mirror surfaces |
+| --- | --- | --- | --- |
+| `single_repo` mode | `Single-repository` | Continue current repository workflow unchanged | Protocol 91, `workflow-next-action.sh`, smoke runbook |
+| `workflow_hub` product-owned item with exactly one configured product repository key | `Product owned` | Continue product implementation routing with that key in handoffs | Run-item/run-items/run-epic handoffs, PR/reviewer routing, cleanup |
+| `workflow_hub` product-owned item with no selected key | `Missing target` | Stop before product branch, PR, reviewer, CI, or cleanup mutation; hub may record stop evidence | Next-action output, orchestrator summaries, smoke runbook |
+| `workflow_hub` product-owned item whose target cannot be resolved from confirmed tracker context | `Ambiguous target` | Stop before mutation and request routing clarification | Next-action output, orchestrator summaries, smoke runbook |
+| `workflow_hub` product-owned item with more than one selected key | `Multiple targets` | Stop and split or narrow to one product repository child | Add-backlog guidance, run-item/run-epic handoffs, smoke runbook |
+| `workflow_hub` hub-only item with no product repository key | `Hub only` | Continue hub-owned workflow artifacts in the hub repository | Spec/plan/review/cleanup guidance |
+| `workflow_hub` hub-only item with a product repository key | `Ambiguous target` | Stop until the operator removes the key or reclassifies the item as product-owned | Add-backlog guidance, next-action output |
+
+---
+
+## Layer-by-Layer Changes
+
+### Database / Data Layer
+
+- [ ] No database, migration, or seed-data changes. The routing contract is
+      workflow metadata and command behavior only.
+
+### Backend / API
+
+- [ ] No HTTP API changes.
+
+### Shared Workflow Tooling
+
+- [ ] Add `scripts/development-workflow/work-item-repository-routing.py` as the
+      shared classifier for item-level routing. Inputs must include repository
+      mode, action/stage, configured product repository keys, optional selected
+      key values, and an explicit hub-only marker. Outputs must include a stable
+      code, display label, selected key when valid, artifact owner, stop reason,
+      and required human action. Map to AC1-AC8.
+- [ ] Extend `scripts/development-workflow/workflow-config-resolver.py` or its
+      tests only where needed to expose configured product repository keys in a
+      reusable form. Do not duplicate key validation outside the resolver; the
+      classifier consumes resolver output. Map to AC1, AC2, and AC4.
+- [ ] Update `scripts/development-workflow/workflow-next-action.sh` so
+      implementation-stage decisions in `workflow_hub` call the shared
+      classifier before branch, PR, reviewer, CI, or cleanup routing. It should
+      print the routing outcome, selected product repository key, artifact owner,
+      and stop evidence. Map to AC1-AC4 and AC7.
+- [ ] Update `scripts/development-workflow/discover-workflow-state.sh`,
+      `run-epic-scope-resolver.sh`, and relevant run-item/run-items handoff
+      code so summaries preserve the classifier result instead of re-inferring
+      repository ownership from branch names or the current checkout. Map to
+      AC1-AC7.
+- [ ] Update `scripts/development-workflow/post-merge-cleanup.sh` and
+      reviewer/CI handoff glue only to consume the already-classified selected
+      key. They must not implement a second product-repository-selection path.
+      Map to AC6 and AC7.
+
+### Workflow Documentation
+
+- [ ] `docs/workflow/development-workflow/repository-modes.md`: add the
+      one-target routing model, display labels, stop outcomes, and statement
+      that the selected key is `workflow_hub.product_repos[].name`. Map to all
+      ACs.
+- [ ] `docs/workflow/development-workflow/workflow-hub-setup.md`: document how
+      operators decompose cross-repository work into a hub epic plus one
+      repository-scoped child per product repository. Map to AC4-AC6.
+- [ ] `docs/workflow/development-workflow/cross-repo-pr-flow.md`: add the
+      pre-mutation routing checkpoint and handoff evidence expectations. Map to
+      AC1-AC4 and AC7.
+- [ ] `docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md`:
+      document the tracker authoring requirements for product-owned children,
+      hub-only children, and split/narrow actions. Map to AC4-AC6.
+- [ ] `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`,
+      `91-orchestrate-work-protocol.md`, and `95-run-epic-protocol.md`: require
+      the classifier result in mutating handoffs and stop on missing, ambiguous,
+      or multiple targets. Map to AC1-AC7.
+- [ ] `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
+      and `04-smoke-test-protocol.md`: clarify that product-owned validation
+      consumes the selected key and hub-only work has no product key. Map to
+      AC6 and AC7.
+
+### Agent And Skill Guidance
+
+- [ ] Update Claude, Cursor, Codex, and `.agents` guidance that currently says
+      "selected product repository" so it names the classifier result and
+      selected product repository key, while preserving thin wrappers around the
+      shared scripts. Required targets include `.claude/agents/orchestrator.md`,
+      `.claude/agents/item-orchestrator.md`, `.claude/agents/developer.md`,
+      `.claude/agents/automated-reviewer-loop.md`, `.claude/agents/smoke-tester.md`,
+      the corresponding `.cursor/agents/` files, `.codex/skills/workflow-item-orchestrator/SKILL.md`,
+      `.codex/skills/workflow-implementer/SKILL.md`,
+      `.codex/skills/workflow-reviewer-loop/SKILL.md`, and the matching
+      `.agents/skills/` command wrappers. Map to AC6 and AC7.
+
+---
+
+## Testing Strategy
+
+**Test types**: Unit-style shell/Python fixture tests, integration-style
+workflow command tests, and smoke/manual review.
+
+**Key scenarios to test**:
+
+1. `single_repo` mode returns the current repository target without requiring a
+   product repository key. Maps to AC8.
+2. `workflow_hub` product-owned work with exactly one configured selected key
+   returns `Product owned`, artifact owner `selected product repository`, and
+   includes the same key in handoff output. Maps to AC1 and AC7.
+3. Product-owned work with no key returns `Missing target`, stops before
+   product artifact mutation, and allows hub-owned stop evidence. Maps to AC2.
+4. Product-owned work with an ambiguous or unknown key returns
+   `Ambiguous target` and stops before mutation. Maps to AC3.
+5. Product-owned work with multiple selected keys returns `Multiple targets`
+   and tells the operator to split or narrow the child item. Maps to AC4.
+6. Hub-only work with no product key returns `Hub only` and routes hub-owned
+   artifacts to the hub repository. Maps to AC6.
+7. Cross-repository requests are represented in docs and smoke evidence as a
+   hub epic with one product-owned child per product repository. Maps to AC5.
+8. Release execution, delivery bundles, milestones, and adoption assurance are
+   left to #1356-#1359. Maps to AC9.
+
+**Smoke test runbook**:
+`docs/testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md`
+
+**Regression suite**:
+
+- [ ] Add `scripts/development-workflow/tests/test-work-item-repository-routing.sh`
+      for classifier outcomes and edge cases.
+- [ ] Extend `scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh`
+      for run-item/run-epic handoff behavior and stop evidence.
+- [ ] Extend `scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh`
+      for dry-run product branch, PR, reviewer, and cleanup routing.
+- [ ] Extend `scripts/development-workflow/tests/test-workflow-agent-product-repo-guidance.sh`
+      for mirrored agent/skill wording.
+- [ ] Extend `scripts/development-workflow/tests/test-workflow-hub-docs.sh` for
+      decomposition and hub-only/product-owned documentation coverage.
+
+### Parser-Risk Addendum
+
+This plan is parser-risk because it introduces a classifier over structured
+workflow metadata and configured product repository keys.
+
+- **Edge-case enumeration**:
+  - Valid selected keys: one configured key such as `mobile-app`.
+  - Missing target: empty selected key for product-owned work.
+  - Ambiguous target: no selected key when multiple configured product
+    repositories exist, an unknown key, or conflicting tracker text that cannot
+    be normalized to one key.
+  - Multiple targets: two or more configured keys on one item.
+  - Hub-only: explicit hub-only marker with no product key.
+  - Hub-only conflict: hub-only marker plus product key.
+  - Single-repository: missing workflow mode or `single_repo`.
+  - Negative lookalikes: branch names, GitHub repo slugs, local paths, and PR
+    titles that contain a product name but are not the selected key source.
+- **Unit test mapping**:
+  - `scripts/development-workflow/tests/test-work-item-repository-routing.sh`:
+    one automated test for every edge case above.
+  - `scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh`:
+    one test each for product-owned continue, missing target stop, ambiguous
+    target stop, multiple target stop, and hub-only continue.
+- **Suppression semantics**: Not applicable. This feature does not introduce
+  inline suppression directives.
+
+### Concurrent-Event-Source Addendum
+
+- **Shared mutable state guards**: Not applicable; the implementation is
+  command-line routing with process-local state.
+- **Re-entrancy / in-flight tracking**: Not applicable; each command invocation
+  resolves one snapshot and exits.
+- **Event deduplication**: Not applicable; no event listeners are introduced.
+- **Listener and resource cleanup**: Not applicable; no long-lived listeners,
+  timers, or handles are introduced.
+- **Race conditions at initialization**: Not applicable; commands read the
+  current tracker/config snapshot at invocation start.
+- **Race conditions at teardown**: Not applicable; there is no teardown hook.
+- **Error propagation across async boundaries**: Not applicable; failures are
+  synchronous command exit statuses and stop evidence.
+
+---
+
+## Seed Data
+
+| Entity | Values / Scenario | File |
+| --- | --- | --- |
+| Workflow-hub fixture config | Two product repositories, `mobile-app` and `admin-portal`, with default branches and GitHub slugs | Temporary fixtures inside `scripts/development-workflow/tests/test-work-item-repository-routing.sh` and `test-workflow-orchestration-product-repo-aware.sh` |
+| Product-owned item fixture | One child item with selected key `mobile-app` | Temporary issue JSON/comment fixture in routing tests |
+| Missing-target fixture | Product-owned child with no selected key | Temporary issue JSON/comment fixture in routing tests |
+| Multiple-target fixture | Product-owned child naming both `mobile-app` and `admin-portal` | Temporary issue JSON/comment fixture in routing tests |
+| Hub-only fixture | Hub-owned workflow item with no product key | Temporary issue JSON/comment fixture in routing tests |
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/workflow/development-workflow/repository-modes.md` - define
+      one-target routing outcomes and display labels.
+- [ ] `docs/workflow/development-workflow/workflow-hub-setup.md` - document hub
+      epic plus repository-scoped child decomposition.
+- [ ] `docs/workflow/development-workflow/cross-repo-pr-flow.md` - require
+      routing evidence before product-owned mutation.
+- [ ] `docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md`
+      - document tracker authoring for product-owned and hub-only children.
+- [ ] `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
+      - require routing classifier output in mutating batch handoffs.
+- [ ] `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`
+      - require routing classifier output before item implementation mutation.
+- [ ] `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md` -
+      require routing classifier output before epic child implementation
+      mutation.
+- [ ] `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
+      - consume selected key rather than selecting product repositories.
+- [ ] `docs/workflow/development-workflow/protocols/04-smoke-test-protocol.md`
+      - consume selected key for product-owned smoke validation.
+- [ ] Agent and skill guidance listed in **Agent And Skill Guidance** - mirror
+      the classifier-result wording without duplicating selection logic.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Different commands classify the same item differently | Medium | High | Centralize routing in one helper and make wrappers consume its output. |
+| Tracker text parsing becomes brittle | Medium | Medium | Keep accepted metadata narrow, test negative lookalikes, and prefer configured product repository keys over free text. |
+| Hub-only workflow work is accidentally forced into a product repository | Low | High | Require a distinct hub-only outcome with no product repository key and tests for hub-only conflict cases. |
+| Later epic items need release, bundle, milestone, or adoption behavior not covered here | Medium | Medium | Keep those behaviors out of #1354 and reference #1356-#1359 in docs and smoke assertions. |
+
+---
+
+## Code Samples
+
+No production code samples are included. Implementation should follow existing
+Bash and Python helper patterns in `scripts/development-workflow/`.
+
+---
+
+## Implementation Order
+
+1. Add the routing classifier and focused fixture tests for product-owned,
+   hub-only, missing, ambiguous, multiple-target, and single-repository
+   outcomes.
+2. Wire the classifier into `workflow-next-action.sh` and workflow discovery so
+   mutating implementation paths receive one normalized routing result.
+3. Wire run-item/run-items/run-epic handoff paths to report the routing result
+   and stop before mutation when the result is missing, ambiguous, or multiple.
+4. Update reviewer, CI, smoke, and cleanup handoff glue to consume the selected
+   product repository key from the classifier result.
+5. Update workflow documentation and mirrored agent/skill guidance listed
+   above.
+6. Extend regression tests for orchestration, smoke fixtures, docs, and mirrored
+   guidance.
+7. Run validation:
+   - `bash scripts/development-workflow/tests/test-work-item-repository-routing.sh`
+   - `bash scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh`
+   - `bash scripts/development-workflow/tests/test-workflow-hub-smoke-fixtures.sh`
+   - `bash scripts/development-workflow/tests/test-workflow-agent-product-repo-guidance.sh`
+   - `bash scripts/development-workflow/tests/test-workflow-hub-docs.sh`
+   - `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
+8. Update `CHANGELOG.md` under `[Unreleased]` with:
+   `- **One product repository per implementation item** (#1354): enforce one-target workflow-hub routing before product implementation mutation.`
+9. Complete the smoke test runbook and record any manual findings before PR
+   readiness.

--- a/docs/testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md
+++ b/docs/testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md
@@ -1,0 +1,186 @@
+# Smoke Test Runbook: One Product Repository Per Implementation Item
+
+**Feature**: One product repository per implementation item
+**Spec**:
+[`1_1354-one-product-repository-per-implementation-item_specs.md`](../../specs/developments/20260731064618_1354-one-product-repository-per-implementation-item/1_1354-one-product-repository-per-implementation-item_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] Use a clean checkout on the implementation branch for #1354.
+- [ ] Run from the repository root.
+- [ ] Prepare workflow-hub fixture config with two configured product
+      repository keys, such as `mobile-app` and `admin-portal`.
+- [ ] Confirm #1353 ownership and release contract behavior is present on the
+      branch under test.
+
+---
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| Workflow mode | `workflow_hub` fixture |
+| Product repository key A | `mobile-app` |
+| Product repository key B | `admin-portal` |
+| Product-owned child | Fixture issue or command input selecting `mobile-app` |
+| Missing-target child | Fixture issue or command input with no selected key |
+| Ambiguous child | Fixture issue or command input with conflicting or unresolved target evidence |
+| Multi-target child | Fixture issue or command input selecting both product keys |
+| Hub-only child | Fixture issue or command input explicitly marked hub-only with no product key |
+| Single-repository fixture | Default or `single_repo` mode config |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Product-Owned Child Routes To One Repository
+
+**Maps to**: AC1, AC7
+
+1. Run the routing or orchestration command for a product-owned child that
+   selects `mobile-app`.
+2. Inspect the command output.
+
+**Expected result**: The output shows `Product owned`, selected key
+`mobile-app`, product artifact owner `selected product repository`, and no stop
+reason.
+
+### Step 2: Missing Product Target Stops Before Mutation
+
+**Maps to**: AC2
+
+1. Run the routing or orchestration command for a product-owned child with no
+   selected product repository key.
+2. Confirm no product branch, PR, reviewer, CI, or cleanup mutation occurs.
+
+**Expected result**: The output shows `Missing target` or equivalent stop
+evidence and allows only hub-owned stop evidence to be recorded.
+
+### Step 3: Ambiguous Product Target Stops Before Mutation
+
+**Maps to**: AC3
+
+1. Run the routing or orchestration command for a product-owned child whose
+   tracker context cannot resolve to one configured key.
+2. Confirm no product branch, PR, reviewer, CI, or cleanup mutation occurs.
+
+**Expected result**: The output shows `Ambiguous target` or equivalent stop
+evidence and identifies the required routing clarification.
+
+### Step 4: Multiple Product Targets Require Split Or Narrowing
+
+**Maps to**: AC4
+
+1. Run the routing or orchestration command for a child that names both
+   `mobile-app` and `admin-portal`.
+2. Inspect the required next action.
+
+**Expected result**: The output shows `Multiple targets` and instructs the
+operator to split the request into repository-scoped children or narrow the
+child to one selected product repository key.
+
+### Step 5: Cross-Repository Request Uses Epic Plus Children
+
+**Maps to**: AC5
+
+1. Review the documentation and fixture data for a cross-repository request.
+2. Confirm it uses one hub epic plus one product-owned child per selected
+   product repository.
+
+**Expected result**: The request is not represented as one multi-target child,
+and each product-owned child has exactly one selected product repository key.
+
+### Step 6: Hub-Only Work Does Not Require Product Key
+
+**Maps to**: AC6
+
+1. Run the routing or orchestration command for a hub-only child with no
+   product repository key.
+2. Inspect artifact owner and mutation target output.
+
+**Expected result**: The output shows `Hub only`, routes hub-owned artifacts to
+the hub repository, and does not require a product repository selector.
+
+### Step 7: Single-Repository Work Keeps Current Behavior
+
+**Maps to**: AC8
+
+1. Run the routing or orchestration command in the default or `single_repo`
+   fixture.
+2. Confirm no product repository selector is required.
+
+**Expected result**: The output shows single-repository behavior using the
+current repository as artifact owner.
+
+### Step 8: Out-Of-Scope Epic Peers Remain Separate
+
+**Maps to**: AC9
+
+1. Review docs and implementation output for release execution, delivery bundle,
+   milestone, and adoption behavior.
+2. Confirm #1354 only enforces one-target routing and tracker decomposition.
+
+**Expected result**: Product release execution remains scoped to #1356,
+delivery-bundle behavior to #1357, milestone reconciliation to #1358, and
+adoption assurance to #1359.
+
+### Last Step: Validate And Shut Down
+
+- Verify all assertions in the checklist below are met.
+- Remove any temporary fixture directories created during the smoke run.
+
+---
+
+## Assertions Checklist
+
+- [ ] Product-owned hub work with exactly one selected key can advance and shows
+      that key as the product mutation target.
+- [ ] Product-owned hub work with no selected key stops before product artifact
+      mutation and reports `Missing target` or equivalent evidence.
+- [ ] Product-owned hub work with ambiguous target evidence stops before product
+      artifact mutation and reports `Ambiguous target` or equivalent evidence.
+- [ ] Product-owned hub work with multiple selected keys stops before mutation
+      and asks for split or narrowing.
+- [ ] Cross-repository requests use a hub epic plus one product-owned child per
+      product repository.
+- [ ] Hub-only coordination work routes in the hub without a product key.
+- [ ] Selected repository context is visible in implementation, review, CI,
+      cleanup, and release handoff summaries.
+- [ ] `single_repo` workflows do not require product repository selection.
+- [ ] #1354 does not implement release execution, delivery bundles, milestones,
+      or adoption assurance behavior.
+
+---
+
+## Seed Data Reference
+
+| Entity | Scenario | How to load |
+| --- | --- | --- |
+| Workflow-hub config | Two product repositories | Use the fixture created by the #1354 implementation tests. |
+| Product-owned child | One selected key | Use the fixture issue/input for `mobile-app`. |
+| Missing-target child | No selected key | Use the fixture issue/input with product-owned role and no key. |
+| Ambiguous child | Conflicting or unresolved target evidence | Use the fixture issue/input with ambiguous target context. |
+| Hub-only child | Hub-owned work with no selected key | Use the fixture issue/input marked hub-only. |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Command falls back to the hub for product-owned work | Routing classifier was skipped or product-owned role was not passed | Re-run with the fixture that exercises the shared classifier and inspect stop evidence. |
+| Multi-target child advances | Selected-key parser accepted more than one key | Check routing classifier tests for the multiple-target case. |
+| Hub-only child asks for a product key | Hub-only marker is not being passed to the classifier | Verify the hub-only fixture and command handoff. |
+
+---
+
+## Known Limitations
+
+- This smoke test uses deterministic fixtures rather than live product
+  repositories. Live product release behavior belongs to #1356.

--- a/docs/testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md
+++ b/docs/testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md
@@ -51,10 +51,21 @@ Before running this smoke test:
    ```bash
    python3 scripts/development-workflow/work-item-repository-routing.py \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/product-owned.json \
-     --json
+     --json | tee /tmp/1354-routing-product-owned.json
    ```
 
 2. Confirm the command exits `0`.
+3. Run:
+
+   ```bash
+   jq -e '
+     .outcome_code == "product_owned"
+     and .continue_allowed == true
+     and .selected_product_repo_key == "mobile-app"
+     and .artifact_owner == "selected_product_repository"
+     and .stop_reason == null
+   ' /tmp/1354-routing-product-owned.json
+   ```
 
 **Expected result**: The output shows `Product owned`, selected key
 `mobile-app`, `outcome_code=product_owned`, `continue_allowed=true`, artifact
@@ -69,16 +80,32 @@ owner `selected_product_repository`, and no stop reason.
    ```bash
    python3 scripts/development-workflow/work-item-repository-routing.py \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/missing-target.json \
-     --json
+     --json | tee /tmp/1354-routing-missing-target.json
    ```
 
 2. Confirm the command exits `0`.
-3. Run the corresponding orchestration dry-run fixture and confirm no product
-   branch, PR, reviewer, CI, or cleanup command is invoked.
+3. Run:
+
+   ```bash
+   jq -e '
+     .outcome_code == "missing_target"
+     and .continue_allowed == false
+     and .selected_product_repo_key == null
+     and .artifact_owner == "none"
+     and .stop_reason != null
+   ' /tmp/1354-routing-missing-target.json
+   ```
+
+4. Run the orchestration regression that exercises the same stop fixture:
+
+   ```bash
+   bash scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+   ```
 
 **Expected result**: The output shows `Missing target` or equivalent stop
 evidence, `outcome_code=missing_target`, `continue_allowed=false`, and allows
-only hub-owned stop evidence to be recorded.
+only hub-owned stop evidence to be recorded. The orchestration regression
+asserts that no product branch, PR, reviewer, CI, or cleanup command is invoked.
 
 ### Step 3: Ambiguous Product Target Stops Before Mutation
 
@@ -89,16 +116,32 @@ only hub-owned stop evidence to be recorded.
    ```bash
    python3 scripts/development-workflow/work-item-repository-routing.py \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/ambiguous-target.json \
-     --json
+     --json | tee /tmp/1354-routing-ambiguous-target.json
    ```
 
 2. Confirm the command exits `0`.
-3. Run the corresponding orchestration dry-run fixture and confirm no product
-   branch, PR, reviewer, CI, or cleanup command is invoked.
+3. Run:
+
+   ```bash
+   jq -e '
+     .outcome_code == "ambiguous_target"
+     and .continue_allowed == false
+     and .selected_product_repo_key == null
+     and .artifact_owner == "none"
+     and .required_human_action != null
+   ' /tmp/1354-routing-ambiguous-target.json
+   ```
+
+4. Run the orchestration regression that exercises the same stop fixture:
+
+   ```bash
+   bash scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
+   ```
 
 **Expected result**: The output shows `Ambiguous target` or equivalent stop
 evidence, `outcome_code=ambiguous_target`, `continue_allowed=false`, and
-identifies the required routing clarification.
+identifies the required routing clarification. The orchestration regression
+asserts that no product branch, PR, reviewer, CI, or cleanup command is invoked.
 
 ### Step 4: Multiple Product Targets Require Split Or Narrowing
 
@@ -109,11 +152,21 @@ identifies the required routing clarification.
    ```bash
    python3 scripts/development-workflow/work-item-repository-routing.py \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/multiple-targets.json \
-     --json
+     --json | tee /tmp/1354-routing-multiple-targets.json
    ```
 
 2. Confirm the command exits `0`.
-3. Inspect the required next action.
+3. Run:
+
+   ```bash
+   jq -e '
+     .outcome_code == "multiple_targets"
+     and .continue_allowed == false
+     and .selected_product_repo_key == null
+     and .artifact_owner == "none"
+     and (.required_human_action | test("split|narrow"; "i"))
+   ' /tmp/1354-routing-multiple-targets.json
+   ```
 
 **Expected result**: The output shows `Multiple targets` and instructs the
 operator to split the request into repository-scoped children or narrow the
@@ -148,11 +201,20 @@ and each product-owned child has exactly one selected product repository key.
    ```bash
    python3 scripts/development-workflow/work-item-repository-routing.py \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/hub-only.json \
-     --json
+     --json | tee /tmp/1354-routing-hub-only.json
    ```
 
 2. Confirm the command exits `0`.
-3. Inspect artifact owner and mutation target output.
+3. Run:
+
+   ```bash
+   jq -e '
+     .outcome_code == "hub_only"
+     and .continue_allowed == true
+     and .selected_product_repo_key == null
+     and .artifact_owner == "hub_repository"
+   ' /tmp/1354-routing-hub-only.json
+   ```
 
 **Expected result**: The output shows `Hub only`, routes hub-owned artifacts to
 the hub repository, does not require a product repository selector, and includes
@@ -167,11 +229,20 @@ the hub repository, does not require a product repository selector, and includes
    ```bash
    python3 scripts/development-workflow/work-item-repository-routing.py \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/single-repo.json \
-     --json
+     --json | tee /tmp/1354-routing-single-repo.json
    ```
 
 2. Confirm the command exits `0`.
-3. Confirm no product repository selector is required.
+3. Run:
+
+   ```bash
+   jq -e '
+     .outcome_code == "single_repo"
+     and .continue_allowed == true
+     and .selected_product_repo_key == null
+     and .artifact_owner == "current_repository"
+   ' /tmp/1354-routing-single-repo.json
+   ```
 
 **Expected result**: The output shows single-repository behavior using the
 current repository as artifact owner and includes `outcome_code=single_repo`.
@@ -183,12 +254,22 @@ current repository as artifact owner and includes `outcome_code=single_repo`.
 1. Run:
 
    ```bash
-   rg -n "#1356|#1357|#1358|#1359|release execution|delivery-bundle|milestone|adoption" \
-     docs/workflow/development-workflow \
-     docs/specs/developments/20260731064618_1354-one-product-repository-per-implementation-item
+   changed_files="$(git diff --name-only origin/develop-multi-repo-releases...HEAD -- \
+     scripts/development-workflow docs/workflow/development-workflow)"
+   match_count=0
+   if [ -n "$changed_files" ]; then
+     printf '%s\n' "$changed_files" > /tmp/1354-routing-changed-files.txt
+     while IFS= read -r file; do
+       if rg -n "#1356|#1357|#1358|#1359|release execution|delivery-bundle|milestone|adoption" "$file"; then
+         match_count=$((match_count + 1))
+       fi
+     done < /tmp/1354-routing-changed-files.txt
+   fi
+   test "$match_count" -eq 0
    ```
 
-2. Confirm #1354 only enforces one-target routing and tracker decomposition.
+2. Confirm the command exits `0`, proving the #1354 implementation changed
+   files did not absorb peer epic behavior.
 
 **Expected result**: Product release execution remains scoped to #1356,
 delivery-bundle behavior to #1357, milestone reconciliation to #1358, and
@@ -200,7 +281,7 @@ adoption assurance to #1359.
 - Remove any temporary smoke output files created during the smoke run:
 
   ```bash
-  rm -f /tmp/1354-routing-*.json
+  rm -f /tmp/1354-routing-*.json /tmp/1354-routing-changed-files.txt
   ```
 
 ---

--- a/docs/testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md
+++ b/docs/testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md
@@ -17,8 +17,14 @@ Before running this smoke test:
       branch under test. This runbook validates the post-merge implementation
       state.
 - [ ] Run from the repository root.
-- [ ] Prepare workflow-hub fixture config with two configured product
-      repository keys, such as `mobile-app` and `admin-portal`.
+- [ ] Export the canonical workflow-hub fixture config and a run-specific
+      temporary directory:
+
+      ```bash
+      export ROUTING_CONFIG="scripts/development-workflow/tests/fixtures/1354-routing/config-workflow-hub.json"
+      export ROUTING_TMP="$(mktemp -d "${TMPDIR:-/tmp}/1354-routing.XXXXXX")"
+      ```
+
 - [ ] Confirm #1353 ownership and release contract behavior is present on the
       branch under test.
 
@@ -31,7 +37,9 @@ Before running this smoke test:
 | Workflow mode | `workflow_hub` fixture |
 | Product repository key A | `mobile-app` |
 | Product repository key B | `admin-portal` |
+| Workflow-hub config fixture | `scripts/development-workflow/tests/fixtures/1354-routing/config-workflow-hub.json` |
 | Product-owned fixture | `scripts/development-workflow/tests/fixtures/1354-routing/product-owned.json` |
+| Product-owned peer fixture | `scripts/development-workflow/tests/fixtures/1354-routing/product-owned-admin-portal.json` |
 | Missing-target fixture | `scripts/development-workflow/tests/fixtures/1354-routing/missing-target.json` |
 | Ambiguous fixture | `scripts/development-workflow/tests/fixtures/1354-routing/ambiguous-target.json` |
 | Multi-target fixture | `scripts/development-workflow/tests/fixtures/1354-routing/multiple-targets.json` |
@@ -50,8 +58,9 @@ Before running this smoke test:
 
    ```bash
    python3 scripts/development-workflow/work-item-repository-routing.py \
+     --config "$ROUTING_CONFIG" \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/product-owned.json \
-     --json | tee /tmp/1354-routing-product-owned.json
+     --json | tee "$ROUTING_TMP/product-owned.json"
    ```
 
 2. Confirm the command exits `0`.
@@ -63,8 +72,9 @@ Before running this smoke test:
      and .continue_allowed == true
      and .selected_product_repo_key == "mobile-app"
      and .artifact_owner == "selected_product_repository"
+     and (.configured_product_repo_keys | sort) == ["admin-portal", "mobile-app"]
      and .stop_reason == null
-   ' /tmp/1354-routing-product-owned.json
+   ' "$ROUTING_TMP/product-owned.json"
    ```
 
 **Expected result**: The output shows `Product owned`, selected key
@@ -79,8 +89,9 @@ owner `selected_product_repository`, and no stop reason.
 
    ```bash
    python3 scripts/development-workflow/work-item-repository-routing.py \
+     --config "$ROUTING_CONFIG" \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/missing-target.json \
-     --json | tee /tmp/1354-routing-missing-target.json
+     --json | tee "$ROUTING_TMP/missing-target.json"
    ```
 
 2. Confirm the command exits `0`.
@@ -92,8 +103,9 @@ owner `selected_product_repository`, and no stop reason.
      and .continue_allowed == false
      and .selected_product_repo_key == null
      and .artifact_owner == "none"
+     and (.configured_product_repo_keys | sort) == ["admin-portal", "mobile-app"]
      and .stop_reason != null
-   ' /tmp/1354-routing-missing-target.json
+   ' "$ROUTING_TMP/missing-target.json"
    ```
 
 4. Run the orchestration regression that exercises the same stop fixture:
@@ -115,8 +127,9 @@ asserts that no product branch, PR, reviewer, CI, or cleanup command is invoked.
 
    ```bash
    python3 scripts/development-workflow/work-item-repository-routing.py \
+     --config "$ROUTING_CONFIG" \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/ambiguous-target.json \
-     --json | tee /tmp/1354-routing-ambiguous-target.json
+     --json | tee "$ROUTING_TMP/ambiguous-target.json"
    ```
 
 2. Confirm the command exits `0`.
@@ -128,8 +141,9 @@ asserts that no product branch, PR, reviewer, CI, or cleanup command is invoked.
      and .continue_allowed == false
      and .selected_product_repo_key == null
      and .artifact_owner == "none"
+     and (.configured_product_repo_keys | sort) == ["admin-portal", "mobile-app"]
      and .required_human_action != null
-   ' /tmp/1354-routing-ambiguous-target.json
+   ' "$ROUTING_TMP/ambiguous-target.json"
    ```
 
 4. Run the orchestration regression that exercises the same stop fixture:
@@ -151,8 +165,9 @@ asserts that no product branch, PR, reviewer, CI, or cleanup command is invoked.
 
    ```bash
    python3 scripts/development-workflow/work-item-repository-routing.py \
+     --config "$ROUTING_CONFIG" \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/multiple-targets.json \
-     --json | tee /tmp/1354-routing-multiple-targets.json
+     --json | tee "$ROUTING_TMP/multiple-targets.json"
    ```
 
 2. Confirm the command exits `0`.
@@ -164,8 +179,9 @@ asserts that no product branch, PR, reviewer, CI, or cleanup command is invoked.
      and .continue_allowed == false
      and .selected_product_repo_key == null
      and .artifact_owner == "none"
+     and (.configured_product_repo_keys | sort) == ["admin-portal", "mobile-app"]
      and (.required_human_action | test("split|narrow"; "i"))
-   ' /tmp/1354-routing-multiple-targets.json
+   ' "$ROUTING_TMP/multiple-targets.json"
    ```
 
 **Expected result**: The output shows `Multiple targets` and instructs the
@@ -183,10 +199,26 @@ child to one selected product repository key. The JSON output includes
    bash scripts/development-workflow/tests/test-workflow-hub-docs.sh
    ```
 
-2. Inspect the fixture directory:
+2. Assert each product-owned child fixture routes to exactly one product
+   repository and none returns `multiple_targets`:
 
    ```bash
-   find scripts/development-workflow/tests/fixtures/1354-routing -maxdepth 1 -type f -name "*.json" -print
+   for fixture in \
+     scripts/development-workflow/tests/fixtures/1354-routing/product-owned.json \
+     scripts/development-workflow/tests/fixtures/1354-routing/product-owned-admin-portal.json
+   do
+     output="$ROUTING_TMP/child-$(basename "$fixture")"
+     python3 scripts/development-workflow/work-item-repository-routing.py \
+       --config "$ROUTING_CONFIG" \
+       --fixture "$fixture" \
+       --json | tee "$output"
+     jq -e '
+       .outcome_code == "product_owned"
+       and .outcome_code != "multiple_targets"
+       and (.selected_product_repo_keys | length) == 1
+       and (.configured_product_repo_keys | sort) == ["admin-portal", "mobile-app"]
+     ' "$output"
+   done
    ```
 
 **Expected result**: The request is not represented as one multi-target child,
@@ -200,8 +232,9 @@ and each product-owned child has exactly one selected product repository key.
 
    ```bash
    python3 scripts/development-workflow/work-item-repository-routing.py \
+     --config "$ROUTING_CONFIG" \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/hub-only.json \
-     --json | tee /tmp/1354-routing-hub-only.json
+     --json | tee "$ROUTING_TMP/hub-only.json"
    ```
 
 2. Confirm the command exits `0`.
@@ -213,7 +246,8 @@ and each product-owned child has exactly one selected product repository key.
      and .continue_allowed == true
      and .selected_product_repo_key == null
      and .artifact_owner == "hub_repository"
-   ' /tmp/1354-routing-hub-only.json
+     and (.configured_product_repo_keys | sort) == ["admin-portal", "mobile-app"]
+   ' "$ROUTING_TMP/hub-only.json"
    ```
 
 **Expected result**: The output shows `Hub only`, routes hub-owned artifacts to
@@ -228,8 +262,9 @@ the hub repository, does not require a product repository selector, and includes
 
    ```bash
    python3 scripts/development-workflow/work-item-repository-routing.py \
+     --config "$ROUTING_CONFIG" \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/single-repo.json \
-     --json | tee /tmp/1354-routing-single-repo.json
+     --json | tee "$ROUTING_TMP/single-repo.json"
    ```
 
 2. Confirm the command exits `0`.
@@ -241,7 +276,7 @@ the hub repository, does not require a product repository selector, and includes
      and .continue_allowed == true
      and .selected_product_repo_key == null
      and .artifact_owner == "current_repository"
-   ' /tmp/1354-routing-single-repo.json
+   ' "$ROUTING_TMP/single-repo.json"
    ```
 
 **Expected result**: The output shows single-repository behavior using the
@@ -254,17 +289,17 @@ current repository as artifact owner and includes `outcome_code=single_repo`.
 1. Run:
 
    ```bash
+   git rev-parse --verify origin/develop-multi-repo-releases >/dev/null
    changed_files="$(git diff --name-only origin/develop-multi-repo-releases...HEAD -- \
      scripts/development-workflow docs/workflow/development-workflow)"
+   test -n "$changed_files"
    match_count=0
-   if [ -n "$changed_files" ]; then
-     printf '%s\n' "$changed_files" > /tmp/1354-routing-changed-files.txt
-     while IFS= read -r file; do
-       if rg -n "#1356|#1357|#1358|#1359|release execution|delivery-bundle|milestone|adoption" "$file"; then
-         match_count=$((match_count + 1))
-       fi
-     done < /tmp/1354-routing-changed-files.txt
-   fi
+   printf '%s\n' "$changed_files" > "$ROUTING_TMP/changed-files.txt"
+   while IFS= read -r file; do
+     if rg -n "#1356|#1357|#1358|#1359|release execution|delivery-bundle|milestone|adoption" "$file"; then
+       match_count=$((match_count + 1))
+     fi
+   done < "$ROUTING_TMP/changed-files.txt"
    test "$match_count" -eq 0
    ```
 
@@ -281,7 +316,9 @@ adoption assurance to #1359.
 - Remove any temporary smoke output files created during the smoke run:
 
   ```bash
-  rm -f /tmp/1354-routing-*.json /tmp/1354-routing-changed-files.txt
+  test -n "$ROUTING_TMP"
+  rm -rf "$ROUTING_TMP"
+  test ! -e "$ROUTING_TMP"
   ```
 
 ---

--- a/docs/testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md
+++ b/docs/testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md
@@ -21,6 +21,7 @@ Before running this smoke test:
       temporary directory:
 
       ```bash
+   set -euo pipefail
       export ROUTING_CONFIG="scripts/development-workflow/tests/fixtures/1354-routing/config-workflow-hub.json"
       export ROUTING_TMP="$(mktemp -d "${TMPDIR:-/tmp}/1354-routing.XXXXXX")"
       ```
@@ -57,6 +58,7 @@ Before running this smoke test:
 1. Run:
 
    ```bash
+   set -euo pipefail
    python3 scripts/development-workflow/work-item-repository-routing.py \
      --config "$ROUTING_CONFIG" \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/product-owned.json \
@@ -67,12 +69,14 @@ Before running this smoke test:
 3. Run:
 
    ```bash
+   set -euo pipefail
    jq -e '
      .outcome_code == "product_owned"
      and .continue_allowed == true
      and .selected_product_repo_key == "mobile-app"
      and .artifact_owner == "selected_product_repository"
      and (.configured_product_repo_keys | sort) == ["admin-portal", "mobile-app"]
+     and has("stop_reason")
      and .stop_reason == null
    ' "$ROUTING_TMP/product-owned.json"
    ```
@@ -88,6 +92,7 @@ owner `selected_product_repository`, and no stop reason.
 1. Run:
 
    ```bash
+   set -euo pipefail
    python3 scripts/development-workflow/work-item-repository-routing.py \
      --config "$ROUTING_CONFIG" \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/missing-target.json \
@@ -98,9 +103,11 @@ owner `selected_product_repository`, and no stop reason.
 3. Run:
 
    ```bash
+   set -euo pipefail
    jq -e '
      .outcome_code == "missing_target"
      and .continue_allowed == false
+     and has("selected_product_repo_key")
      and .selected_product_repo_key == null
      and .artifact_owner == "none"
      and (.configured_product_repo_keys | sort) == ["admin-portal", "mobile-app"]
@@ -111,6 +118,7 @@ owner `selected_product_repository`, and no stop reason.
 4. Run the orchestration regression that exercises the same stop fixture:
 
    ```bash
+   set -euo pipefail
    bash scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
    ```
 
@@ -126,6 +134,7 @@ asserts that no product branch, PR, reviewer, CI, or cleanup command is invoked.
 1. Run:
 
    ```bash
+   set -euo pipefail
    python3 scripts/development-workflow/work-item-repository-routing.py \
      --config "$ROUTING_CONFIG" \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/ambiguous-target.json \
@@ -136,9 +145,11 @@ asserts that no product branch, PR, reviewer, CI, or cleanup command is invoked.
 3. Run:
 
    ```bash
+   set -euo pipefail
    jq -e '
      .outcome_code == "ambiguous_target"
      and .continue_allowed == false
+     and has("selected_product_repo_key")
      and .selected_product_repo_key == null
      and .artifact_owner == "none"
      and (.configured_product_repo_keys | sort) == ["admin-portal", "mobile-app"]
@@ -149,6 +160,7 @@ asserts that no product branch, PR, reviewer, CI, or cleanup command is invoked.
 4. Run the orchestration regression that exercises the same stop fixture:
 
    ```bash
+   set -euo pipefail
    bash scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh
    ```
 
@@ -164,6 +176,7 @@ asserts that no product branch, PR, reviewer, CI, or cleanup command is invoked.
 1. Run:
 
    ```bash
+   set -euo pipefail
    python3 scripts/development-workflow/work-item-repository-routing.py \
      --config "$ROUTING_CONFIG" \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/multiple-targets.json \
@@ -174,9 +187,11 @@ asserts that no product branch, PR, reviewer, CI, or cleanup command is invoked.
 3. Run:
 
    ```bash
+   set -euo pipefail
    jq -e '
      .outcome_code == "multiple_targets"
      and .continue_allowed == false
+     and has("selected_product_repo_key")
      and .selected_product_repo_key == null
      and .artifact_owner == "none"
      and (.configured_product_repo_keys | sort) == ["admin-portal", "mobile-app"]
@@ -196,6 +211,7 @@ child to one selected product repository key. The JSON output includes
 1. Run the docs regression test:
 
    ```bash
+   set -euo pipefail
    bash scripts/development-workflow/tests/test-workflow-hub-docs.sh
    ```
 
@@ -203,6 +219,7 @@ child to one selected product repository key. The JSON output includes
    repository and none returns `multiple_targets`:
 
    ```bash
+   set -euo pipefail
    for fixture in \
      scripts/development-workflow/tests/fixtures/1354-routing/product-owned.json \
      scripts/development-workflow/tests/fixtures/1354-routing/product-owned-admin-portal.json
@@ -231,6 +248,7 @@ and each product-owned child has exactly one selected product repository key.
 1. Run:
 
    ```bash
+   set -euo pipefail
    python3 scripts/development-workflow/work-item-repository-routing.py \
      --config "$ROUTING_CONFIG" \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/hub-only.json \
@@ -241,9 +259,11 @@ and each product-owned child has exactly one selected product repository key.
 3. Run:
 
    ```bash
+   set -euo pipefail
    jq -e '
      .outcome_code == "hub_only"
      and .continue_allowed == true
+     and has("selected_product_repo_key")
      and .selected_product_repo_key == null
      and .artifact_owner == "hub_repository"
      and (.configured_product_repo_keys | sort) == ["admin-portal", "mobile-app"]
@@ -261,6 +281,7 @@ the hub repository, does not require a product repository selector, and includes
 1. Run:
 
    ```bash
+   set -euo pipefail
    python3 scripts/development-workflow/work-item-repository-routing.py \
      --config "$ROUTING_CONFIG" \
      --fixture scripts/development-workflow/tests/fixtures/1354-routing/single-repo.json \
@@ -271,9 +292,11 @@ the hub repository, does not require a product repository selector, and includes
 3. Run:
 
    ```bash
+   set -euo pipefail
    jq -e '
      .outcome_code == "single_repo"
      and .continue_allowed == true
+     and has("selected_product_repo_key")
      and .selected_product_repo_key == null
      and .artifact_owner == "current_repository"
    ' "$ROUTING_TMP/single-repo.json"
@@ -289,6 +312,7 @@ current repository as artifact owner and includes `outcome_code=single_repo`.
 1. Run:
 
    ```bash
+   set -euo pipefail
    git rev-parse --verify origin/develop-multi-repo-releases >/dev/null
    changed_files="$(git diff --name-only origin/develop-multi-repo-releases...HEAD -- \
      scripts/development-workflow docs/workflow/development-workflow)"
@@ -296,8 +320,16 @@ current repository as artifact owner and includes `outcome_code=single_repo`.
    match_count=0
    printf '%s\n' "$changed_files" > "$ROUTING_TMP/changed-files.txt"
    while IFS= read -r file; do
-     if rg -n "#1356|#1357|#1358|#1359|release execution|delivery-bundle|milestone|adoption" "$file"; then
+     set +e
+     rg -n "#1356|#1357|#1358|#1359|release execution|delivery-bundle|milestone|adoption" "$file"
+     rg_status=$?
+     set -e
+     if [ "$rg_status" -eq 0 ]; then
        match_count=$((match_count + 1))
+     elif [ "$rg_status" -eq 1 ]; then
+       :
+     else
+       exit "$rg_status"
      fi
    done < "$ROUTING_TMP/changed-files.txt"
    test "$match_count" -eq 0
@@ -316,6 +348,7 @@ adoption assurance to #1359.
 - Remove any temporary smoke output files created during the smoke run:
 
   ```bash
+   set -euo pipefail
   test -n "$ROUTING_TMP"
   rm -rf "$ROUTING_TMP"
   test ! -e "$ROUTING_TMP"

--- a/docs/testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md
+++ b/docs/testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md
@@ -13,6 +13,9 @@
 Before running this smoke test:
 
 - [ ] Use a clean checkout on the implementation branch for #1354.
+- [ ] Confirm the #1354 implementation and its required tests are landed in the
+      branch under test. This runbook validates the post-merge implementation
+      state.
 - [ ] Run from the repository root.
 - [ ] Prepare workflow-hub fixture config with two configured product
       repository keys, such as `mobile-app` and `admin-portal`.
@@ -28,12 +31,12 @@ Before running this smoke test:
 | Workflow mode | `workflow_hub` fixture |
 | Product repository key A | `mobile-app` |
 | Product repository key B | `admin-portal` |
-| Product-owned child | Fixture issue or command input selecting `mobile-app` |
-| Missing-target child | Fixture issue or command input with no selected key |
-| Ambiguous child | Fixture issue or command input with conflicting or unresolved target evidence |
-| Multi-target child | Fixture issue or command input selecting both product keys |
-| Hub-only child | Fixture issue or command input explicitly marked hub-only with no product key |
-| Single-repository fixture | Default or `single_repo` mode config |
+| Product-owned fixture | `scripts/development-workflow/tests/fixtures/1354-routing/product-owned.json` |
+| Missing-target fixture | `scripts/development-workflow/tests/fixtures/1354-routing/missing-target.json` |
+| Ambiguous fixture | `scripts/development-workflow/tests/fixtures/1354-routing/ambiguous-target.json` |
+| Multi-target fixture | `scripts/development-workflow/tests/fixtures/1354-routing/multiple-targets.json` |
+| Hub-only fixture | `scripts/development-workflow/tests/fixtures/1354-routing/hub-only.json` |
+| Single-repository fixture | `scripts/development-workflow/tests/fixtures/1354-routing/single-repo.json` |
 
 ---
 
@@ -43,55 +46,95 @@ Before running this smoke test:
 
 **Maps to**: AC1, AC7
 
-1. Run the routing or orchestration command for a product-owned child that
-   selects `mobile-app`.
-2. Inspect the command output.
+1. Run:
+
+   ```bash
+   python3 scripts/development-workflow/work-item-repository-routing.py \
+     --fixture scripts/development-workflow/tests/fixtures/1354-routing/product-owned.json \
+     --json
+   ```
+
+2. Confirm the command exits `0`.
 
 **Expected result**: The output shows `Product owned`, selected key
-`mobile-app`, product artifact owner `selected product repository`, and no stop
-reason.
+`mobile-app`, `outcome_code=product_owned`, `continue_allowed=true`, artifact
+owner `selected_product_repository`, and no stop reason.
 
 ### Step 2: Missing Product Target Stops Before Mutation
 
 **Maps to**: AC2
 
-1. Run the routing or orchestration command for a product-owned child with no
-   selected product repository key.
-2. Confirm no product branch, PR, reviewer, CI, or cleanup mutation occurs.
+1. Run:
+
+   ```bash
+   python3 scripts/development-workflow/work-item-repository-routing.py \
+     --fixture scripts/development-workflow/tests/fixtures/1354-routing/missing-target.json \
+     --json
+   ```
+
+2. Confirm the command exits `0`.
+3. Run the corresponding orchestration dry-run fixture and confirm no product
+   branch, PR, reviewer, CI, or cleanup command is invoked.
 
 **Expected result**: The output shows `Missing target` or equivalent stop
-evidence and allows only hub-owned stop evidence to be recorded.
+evidence, `outcome_code=missing_target`, `continue_allowed=false`, and allows
+only hub-owned stop evidence to be recorded.
 
 ### Step 3: Ambiguous Product Target Stops Before Mutation
 
 **Maps to**: AC3
 
-1. Run the routing or orchestration command for a product-owned child whose
-   tracker context cannot resolve to one configured key.
-2. Confirm no product branch, PR, reviewer, CI, or cleanup mutation occurs.
+1. Run:
+
+   ```bash
+   python3 scripts/development-workflow/work-item-repository-routing.py \
+     --fixture scripts/development-workflow/tests/fixtures/1354-routing/ambiguous-target.json \
+     --json
+   ```
+
+2. Confirm the command exits `0`.
+3. Run the corresponding orchestration dry-run fixture and confirm no product
+   branch, PR, reviewer, CI, or cleanup command is invoked.
 
 **Expected result**: The output shows `Ambiguous target` or equivalent stop
-evidence and identifies the required routing clarification.
+evidence, `outcome_code=ambiguous_target`, `continue_allowed=false`, and
+identifies the required routing clarification.
 
 ### Step 4: Multiple Product Targets Require Split Or Narrowing
 
 **Maps to**: AC4
 
-1. Run the routing or orchestration command for a child that names both
-   `mobile-app` and `admin-portal`.
-2. Inspect the required next action.
+1. Run:
+
+   ```bash
+   python3 scripts/development-workflow/work-item-repository-routing.py \
+     --fixture scripts/development-workflow/tests/fixtures/1354-routing/multiple-targets.json \
+     --json
+   ```
+
+2. Confirm the command exits `0`.
+3. Inspect the required next action.
 
 **Expected result**: The output shows `Multiple targets` and instructs the
 operator to split the request into repository-scoped children or narrow the
-child to one selected product repository key.
+child to one selected product repository key. The JSON output includes
+`outcome_code=multiple_targets` and `continue_allowed=false`.
 
 ### Step 5: Cross-Repository Request Uses Epic Plus Children
 
 **Maps to**: AC5
 
-1. Review the documentation and fixture data for a cross-repository request.
-2. Confirm it uses one hub epic plus one product-owned child per selected
-   product repository.
+1. Run the docs regression test:
+
+   ```bash
+   bash scripts/development-workflow/tests/test-workflow-hub-docs.sh
+   ```
+
+2. Inspect the fixture directory:
+
+   ```bash
+   find scripts/development-workflow/tests/fixtures/1354-routing -maxdepth 1 -type f -name "*.json" -print
+   ```
 
 **Expected result**: The request is not represented as one multi-target child,
 and each product-owned child has exactly one selected product repository key.
@@ -100,30 +143,51 @@ and each product-owned child has exactly one selected product repository key.
 
 **Maps to**: AC6
 
-1. Run the routing or orchestration command for a hub-only child with no
-   product repository key.
-2. Inspect artifact owner and mutation target output.
+1. Run:
+
+   ```bash
+   python3 scripts/development-workflow/work-item-repository-routing.py \
+     --fixture scripts/development-workflow/tests/fixtures/1354-routing/hub-only.json \
+     --json
+   ```
+
+2. Confirm the command exits `0`.
+3. Inspect artifact owner and mutation target output.
 
 **Expected result**: The output shows `Hub only`, routes hub-owned artifacts to
-the hub repository, and does not require a product repository selector.
+the hub repository, does not require a product repository selector, and includes
+`outcome_code=hub_only` with `continue_allowed=true`.
 
 ### Step 7: Single-Repository Work Keeps Current Behavior
 
 **Maps to**: AC8
 
-1. Run the routing or orchestration command in the default or `single_repo`
-   fixture.
-2. Confirm no product repository selector is required.
+1. Run:
+
+   ```bash
+   python3 scripts/development-workflow/work-item-repository-routing.py \
+     --fixture scripts/development-workflow/tests/fixtures/1354-routing/single-repo.json \
+     --json
+   ```
+
+2. Confirm the command exits `0`.
+3. Confirm no product repository selector is required.
 
 **Expected result**: The output shows single-repository behavior using the
-current repository as artifact owner.
+current repository as artifact owner and includes `outcome_code=single_repo`.
 
 ### Step 8: Out-Of-Scope Epic Peers Remain Separate
 
 **Maps to**: AC9
 
-1. Review docs and implementation output for release execution, delivery bundle,
-   milestone, and adoption behavior.
+1. Run:
+
+   ```bash
+   rg -n "#1356|#1357|#1358|#1359|release execution|delivery-bundle|milestone|adoption" \
+     docs/workflow/development-workflow \
+     docs/specs/developments/20260731064618_1354-one-product-repository-per-implementation-item
+   ```
+
 2. Confirm #1354 only enforces one-target routing and tracker decomposition.
 
 **Expected result**: Product release execution remains scoped to #1356,
@@ -133,7 +197,11 @@ adoption assurance to #1359.
 ### Last Step: Validate And Shut Down
 
 - Verify all assertions in the checklist below are met.
-- Remove any temporary fixture directories created during the smoke run.
+- Remove any temporary smoke output files created during the smoke run:
+
+  ```bash
+  rm -f /tmp/1354-routing-*.json
+  ```
 
 ---
 
@@ -162,11 +230,11 @@ adoption assurance to #1359.
 
 | Entity | Scenario | How to load |
 | --- | --- | --- |
-| Workflow-hub config | Two product repositories | Use the fixture created by the #1354 implementation tests. |
-| Product-owned child | One selected key | Use the fixture issue/input for `mobile-app`. |
-| Missing-target child | No selected key | Use the fixture issue/input with product-owned role and no key. |
-| Ambiguous child | Conflicting or unresolved target evidence | Use the fixture issue/input with ambiguous target context. |
-| Hub-only child | Hub-owned work with no selected key | Use the fixture issue/input marked hub-only. |
+| Workflow-hub config | Two product repositories | `scripts/development-workflow/tests/fixtures/1354-routing/config-workflow-hub.json` |
+| Product-owned child | One selected key | `scripts/development-workflow/tests/fixtures/1354-routing/product-owned.json` |
+| Missing-target child | No selected key | `scripts/development-workflow/tests/fixtures/1354-routing/missing-target.json` |
+| Ambiguous child | Conflicting or unresolved target evidence | `scripts/development-workflow/tests/fixtures/1354-routing/ambiguous-target.json` |
+| Hub-only child | Hub-owned work with no selected key | `scripts/development-workflow/tests/fixtures/1354-routing/hub-only.json` |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds the #1354 implementation plan for enforcing one product repository per workflow-hub implementation item.
- Adds the smoke runbook covering product-owned, hub-only, missing, ambiguous, multiple-target, and single-repository routing outcomes.
- Plans a shared routing classifier plus orchestration, cleanup, reviewer, docs, and agent/skill handoff updates.

## Complexity / Risks

- Complexity: M - the change is workflow tooling and documentation, but it crosses several command paths.
- Main risk: inconsistent routing decisions if wrappers re-implement product repository selection instead of consuming one classifier result.

## Document Quality Gate

- Spec/brief coverage: Checked - all acceptance criteria map to implementation steps and smoke or regression coverage.
- Implementation-order consistency: Checked - file list, classifier name, routing outcomes, and validation commands agree across sections.
- Verification support: Checked - broad scope claims cite the Verification Log.
- Behavioral guarantees: Checked - one-target, missing-target, ambiguous-target, multiple-target, hub-only, and single-repository guarantees name classifier mechanisms and tests.
- Complex workflow decision-gate matrix: Checked - plan includes the routing decision-gate matrix and mirror surfaces.
- Parser/API/concurrency checklist: Checked - parser-risk addendum is included; API and concurrency are not applicable because no HTTP API or event sources are introduced.
- CHANGELOG literal format: Checked - implementation-order literal uses the project `**Bold Title** (#N):` format.
- Not-applicable rationale: Checked - database, HTTP API, seed-data, and concurrency omissions include rationale.

## Validation

- `grep -RIn "\\[Feature\\|\\[Link\\|\\[Step\\|\\[Actor\\|\\[Criterion\\|\\[Entity\\|\\[value\\|TODO\\|TBD\\|<!--" docs/specs/developments/20260731064618_1354-one-product-repository-per-implementation-item/2_1354-one-product-repository-per-implementation-item_implementation-plan.md docs/testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md`
- `npx markdownlint-cli2 docs/specs/developments/20260731064618_1354-one-product-repository-per-implementation-item/2_1354-one-product-repository-per-implementation-item_implementation-plan.md docs/testing/workflow/1354-one-product-repository-per-implementation-item.smoke-test.md`

Related to #1354


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an implementation plan for assigning each workflow-hub implementation item to exactly one product repository.
  * Documented routing behavior for single, missing, ambiguous, multiple-target, product-owned, and hub-only items.
  * Added guidance covering orchestration, handoffs, pull requests, reviews, CI, cleanup, and agent workflows.
  * Documented safeguards that prevent changes when a single product repository cannot be identified.
  * Added a smoke-test runbook with setup, scenarios, expected outcomes, troubleshooting, shutdown steps, and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->