### PR TITLE
docs(spec): route component releases to selected product repository

### DIFF
--- a/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/1_1356-route-component-releases-to-selected-product-repository_specs.md
+++ b/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/1_1356-route-component-releases-to-selected-product-repository_specs.md
@@ -1,0 +1,312 @@
+# Route Component Releases To The Selected Product Repository - Spec
+
+**Depends on**: 1353-artifact-ownership-product-release-contract
+
+---
+
+## Overview
+
+Workflow hubs coordinate release work for multiple product repositories, but a
+component release must execute against one selected product repository before it
+creates branches, changelog entries, release pull requests, tags, deployment
+evidence, or cleanup records. This feature makes that selection explicit for
+component release and cleanup work, prevents hub defaults from accidentally
+owning product release artifacts, and keeps tracker reconciliation in the hub.
+
+The existing single-repository release and hotfix workflows continue to behave
+as they do today. Product-repository release routing applies only when a
+workflow hub is coordinating a component release for a selected product
+repository.
+
+## Brief Objective List
+
+Derived from issue #1356:
+
+1. Make component release preparation and post-merge cleanup product-aware in
+   workflow-hub mode.
+2. Require explicit product-repository selection before component release
+   mutation.
+3. Resolve the selected product repository's checkout, branch model, changelog,
+   release pull requests, tag, CI, and deployment evidence from the product
+   release contract.
+4. Keep the hub as tracker owner while preventing hub defaults from being used
+   for product release artifacts.
+5. Preserve existing standalone release and hotfix paths for single-repository
+   mode.
+6. Ensure a component release uses only the selected product repository's
+   release artifacts.
+7. Fail missing or ambiguous product selection before any branch, pull request,
+   tag, or tracker mutation.
+8. Make cleanup safe and rerunnable for a partially completed component
+   release.
+9. Produce component release evidence that delivery-bundle reconciliation can
+   consume.
+
+## Spec-Dispatch Context
+
+Confirmed relationship decisions for epic #1352:
+
+- #1356 depends on #1353 as the foundational artifact ownership and product
+  release contract.
+- #1356 is not dependent on #1357. This spec provides component release
+  evidence that the later delivery-bundle workflow may consume, but it does not
+  define the delivery-bundle issue or manifest workflow.
+- #1356 is orthogonal to #1354, #1358, and #1359 beyond shared workflow-hub
+  release terminology.
+
+## Use Cases
+
+### Use Case 1: Prepare a component release from a workflow hub
+
+**Actor**: Workflow operator preparing a hub-managed component release.
+**Preconditions**: The workflow hub has a valid product release contract, and
+the operator intends to release one selected product repository.
+
+**Steps**:
+
+1. The operator starts release preparation from the workflow hub and names the
+   selected product repository.
+2. The workflow validates that exactly one known product repository is selected.
+3. The workflow shows the selected product repository, release base, release
+   branch pattern, changelog owner, tag owner, release record owner, deployment
+   evidence owner, cleanup evidence owner, and tracker reconciliation owner.
+4. The workflow prepares release artifacts only in the selected product
+   repository.
+5. The hub records release coordination and tracker evidence without creating
+   product-owned release artifacts in the hub.
+
+**Postconditions**: The component release has one product repository as the
+release artifact owner, and the hub has coordination evidence that points to
+that product release.
+
+**Information shown**:
+
+- Selected product repository key and repository identity.
+- Release base and release branch that will be used.
+- Product changelog, release pull request, tag, release record, CI, deployment,
+  and cleanup evidence ownership.
+- Hub tracker reconciliation ownership.
+- Stop reason when selection or contract validation fails.
+
+**Actions available**:
+
+- Continue when one selected product repository and a valid release contract are
+  present.
+- Stop before mutation when the product selection is missing, ambiguous,
+  unknown, unavailable, or invalid.
+- Correct the selection or product release contract and retry release
+  preparation.
+
+**Considerations**:
+
+- A workflow hub may coordinate many products, but one component release run
+  acts on exactly one selected product repository.
+- Hub-owned coordination evidence must not be treated as a product release
+  artifact.
+
+---
+
+### Use Case 2: Reject unsafe product selection before mutation
+
+**Actor**: Release runner or cleanup helper.
+**Preconditions**: The workflow is about to create or mutate a release branch,
+release pull request, changelog entry, tag, deployment evidence, cleanup record,
+or tracker state for a hub-managed component release.
+
+**Steps**:
+
+1. The runner reads the requested product repository selection.
+2. The runner compares the selection against the product release contract.
+3. The runner verifies that the selection resolves to one product repository
+   and that the release artifact owners are valid.
+4. The runner stops before any mutation if the selection is missing, ambiguous,
+   unknown, invalid, or names more than one product repository.
+5. The runner reports the required human action and leaves both hub and product
+   repositories unmodified.
+
+**Postconditions**: Unsafe component release routing cannot partially create
+release artifacts in the wrong repository.
+
+**Information shown**:
+
+- The invalid or missing selection.
+- The intended release operation that was blocked.
+- The required correction.
+- Confirmation that no release artifact mutation occurred.
+
+**Actions available**:
+
+- Retry with one explicit product repository selection.
+- Correct the product release contract.
+- Stop for human clarification when the release target is genuinely ambiguous.
+
+**Considerations**:
+
+- Tracker mutation is also blocked when the product selection itself is missing
+  or ambiguous, because tracker state would otherwise imply a release progressed
+  when no valid product release target was known.
+
+---
+
+### Use Case 3: Resume cleanup for a partially completed component release
+
+**Actor**: Workflow operator reconciling a component release after merge,
+interruption, or retry.
+**Preconditions**: A component release run may have created, merged, or cleaned
+some product-owned release artifacts already.
+
+**Steps**:
+
+1. The operator reruns cleanup from the workflow hub with the same selected
+   product repository.
+2. The workflow validates the same selected product repository and release
+   contract before mutating anything.
+3. The workflow reads current product release state from the selected product
+   repository.
+4. Already-completed cleanup actions are reported as complete rather than
+   repeated destructively.
+5. Missing cleanup actions are completed in the selected product repository.
+6. Hub tracker reconciliation is updated only after product-owned cleanup state
+   is confirmed.
+
+**Postconditions**: Cleanup can be retried safely and converges to one
+consistent product release state plus one hub-owned tracker reconciliation
+state.
+
+**Information shown**:
+
+- Product release pull request state.
+- Product release branch and tag cleanup status.
+- Product deployment or release evidence status.
+- Hub tracker reconciliation status.
+- Any remaining manual action.
+
+**Actions available**:
+
+- Continue cleanup when validation passes.
+- Report already-complete cleanup steps.
+- Stop before mutation when selected product repository evidence no longer
+  matches the original component release target.
+
+**Considerations**:
+
+- Cleanup must not infer a different product repository from the current hub
+  checkout, branch name, or tracker owner.
+
+## Component Release Routing Gate
+
+| Gate input | Allowed outcome | Required next action | Mirror surface | Example |
+| --- | --- | --- | --- | --- |
+| Exactly one selected product repository with a valid release contract | Continue | Prepare or clean up release artifacts in the selected product repository and reconcile tracker state in the hub | Release summary, PR body, cleanup log, and tracker comment | `faind-mobile-app` is selected and owns release branch, changelog, tag, deployment evidence, and cleanup evidence. |
+| No selected product repository in workflow-hub mode | Stop | Ask for one product repository selection before branch, pull request, tag, or tracker mutation | Stop summary and tracker-visible blocker evidence | The hub has multiple product repositories but the release command names none. |
+| More than one selected product repository | Stop | Split the release into one component release per product repository or choose one product | Stop summary and tracker-visible blocker evidence | The release request names both mobile and web product repositories. |
+| Unknown or unavailable product repository | Stop | Correct product release configuration or local product checkout availability | Stop summary and validation output | The selected key is not in the product release contract or its checkout cannot be resolved. |
+| Invalid release artifact ownership | Stop | Correct the release contract before mutation | Validation output and stop summary | The contract would write a product changelog, tag, or release record to the hub for a product-owned release. |
+| Single-repository mode | Continue with existing behavior | Use current release and hotfix paths without requiring a product repository selector | Release summary and existing PR evidence | A repository without workflow-hub mode prepares its own release from the current checkout. |
+
+## Business Rules
+
+- A workflow-hub component release must name exactly one selected product
+  repository before any release or cleanup mutation.
+- Product-owned release artifacts for a workflow-hub component release belong
+  to the selected product repository, not the hub.
+- Hub tracker reconciliation remains hub-owned after product release artifacts
+  are confirmed.
+- Missing, ambiguous, unknown, unavailable, or multi-target product selection
+  stops before branch, pull request, tag, changelog, deployment, cleanup, or
+  tracker mutation.
+- Release preparation and cleanup must use the same selected product repository
+  identity throughout one component release lifecycle.
+- Cleanup must be rerunnable and must report already-completed product cleanup
+  steps without requiring destructive repetition.
+- Single-repository release and hotfix paths do not require product repository
+  selection and keep their current artifact ownership.
+- Component release evidence must be stable enough for later delivery-bundle
+  reconciliation to identify the product repository, release artifact state,
+  deployment evidence, and hub tracker reconciliation outcome.
+
+## Statuses / Enum Values
+
+No new tracker statuses are introduced. Existing workflow statuses keep their
+current display labels and meanings. The values below are release-routing
+outcomes that must be visible in release and cleanup summaries.
+
+| Routing outcome | Display label | Description |
+| --- | --- | --- |
+| `component_release_routed` | Component release routed | One selected product repository and a valid release contract allow release or cleanup to continue. |
+| `missing_product_selection` | Missing product selection | No product repository was selected for a workflow-hub component release. |
+| `ambiguous_product_selection` | Ambiguous product selection | The product repository target cannot be resolved to exactly one configured product. |
+| `multiple_product_targets` | Multiple product targets | The release request names more than one product repository and must be split or narrowed. |
+| `invalid_release_contract` | Invalid release contract | The selected product repository release contract is missing, unsafe, or would route product artifacts to the wrong owner. |
+| `single_repo_release` | Single-repository release | The current repository owns the release path and no product repository selector is required. |
+
+## Operational Visibility
+
+- **Release routing summary**: Before mutation, release preparation and cleanup
+  show the selected product repository, artifact owners, release base, release
+  branch, and tracker reconciliation owner.
+- **Stop evidence**: Unsafe selection outcomes name the blocked operation, the
+  invalid or missing selection, and the human action required to continue.
+- **Product evidence**: Successful component release evidence names the product
+  release pull request, release branch, tag or release record when applicable,
+  CI outcome, deployment evidence, and cleanup status.
+- **Hub evidence**: Hub tracker reconciliation records the selected product
+  repository and points to product-owned release evidence instead of duplicating
+  product release artifacts.
+- **Rerun evidence**: Cleanup reports already-complete, completed-now, skipped,
+  and blocked cleanup steps so a later run can distinguish convergence from
+  silent omission.
+
+## Acceptance Criteria
+
+- [ ] A workflow-hub component release with exactly one selected product
+      repository validates the product release contract and prepares release
+      artifacts only in that selected product repository.
+- [ ] A workflow-hub component release with missing product selection stops
+      before branch, pull request, changelog, tag, deployment, cleanup, or
+      tracker mutation and reports the required selection.
+- [ ] A workflow-hub component release with ambiguous, unknown, unavailable, or
+      multiple product targets stops before mutation and names the unsafe
+      routing outcome.
+- [ ] Release preparation shows the selected product repository's release base,
+      release branch, changelog owner, release pull request owner, tag owner,
+      CI owner, deployment evidence owner, cleanup evidence owner, and hub
+      tracker reconciliation owner.
+- [ ] Post-merge cleanup for a component release validates the same selected
+      product repository before mutation and updates hub tracker state only
+      after product-owned cleanup state is confirmed.
+- [ ] Re-running cleanup after a partial component release reports completed
+      steps as already complete and safely completes missing cleanup steps
+      without switching product repositories.
+- [ ] Single-repository release and hotfix workflows continue without requiring
+      a product repository selector and continue to use current repository
+      release artifacts.
+- [ ] Component release evidence includes enough selected product repository,
+      release artifact, deployment, cleanup, and hub tracker reconciliation
+      information for a later delivery-bundle workflow to consume.
+
+## Out of Scope (MVP)
+
+- Defining the delivery-bundle issue or manifest workflow; #1357 owns that
+  behavior.
+- Reconciling component milestones and release status rollups; #1358 owns that
+  behavior.
+- Adoption guidance, assurance runbooks, or migration criteria for downstream
+  repositories; #1359 owns that behavior.
+- Changing single-repository release semantics beyond preserving current
+  compatibility.
+- Adding a new tracker status taxonomy for release routing outcomes.
+
+## Coverage Matrix
+
+| Brief objective | Coverage |
+| --- | --- |
+| Make component release preparation and post-merge cleanup product-aware in workflow-hub mode. | Overview, Use Cases 1 and 3, Business Rules, AC1, AC5, AC6 |
+| Require explicit product-repository selection before component release mutation. | Use Cases 1 and 2, Component Release Routing Gate, Business Rules, AC1, AC2, AC3 |
+| Resolve checkout, branch model, changelog, release pull requests, tag, CI, and deployment evidence from the product release contract. | Use Case 1, Component Release Routing Gate, Operational Visibility, AC4 |
+| Keep the hub as tracker owner while preventing hub defaults from being used for product release artifacts. | Overview, Use Case 1, Business Rules, Operational Visibility, AC5 |
+| Preserve existing standalone release and hotfix paths for single-repository mode. | Overview, Component Release Routing Gate, Business Rules, AC7 |
+| Ensure a component release uses only the selected product repository's release artifacts. | Use Case 1, Business Rules, AC1 |
+| Fail missing or ambiguous product selection before any branch, pull request, tag, or tracker mutation. | Use Case 2, Component Release Routing Gate, Business Rules, AC2, AC3 |
+| Make cleanup safe and rerunnable for a partially completed component release. | Use Case 3, Business Rules, Operational Visibility, AC5, AC6 |
+| Produce component release evidence that delivery-bundle reconciliation can consume. | Spec-Dispatch Context, Operational Visibility, AC8, Out of Scope |

--- a/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/1_1356-route-component-releases-to-selected-product-repository_specs.md
+++ b/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/1_1356-route-component-releases-to-selected-product-repository_specs.md
@@ -275,7 +275,7 @@ but each record identifies exactly one release target.
 | CI outcome | Required once product CI runs | `pending`, `passed`, `failed`, or `not_applicable` | One outcome for the product release validation surface | Lets bundle reconciliation distinguish validated and blocked releases. |
 | Deployment evidence outcome | Required when deployment evidence is expected | `pending`, `recorded`, `failed`, or `not_applicable` | One outcome for the deployment evidence surface | Shows whether product deployment evidence exists. |
 | Cleanup outcome | Required once cleanup starts | `not_started`, `partial`, `complete`, or `blocked` | One cleanup state for the selected product repository | Lets reruns and bundle reconciliation detect incomplete cleanup. |
-| Routing outcome | Required | Routing outcome display label or code | One value from the routing outcomes table | Explains whether release routing continued or stopped. |
+| Routing outcome | Required | Canonical routing outcome code | One code from the `Routing outcome` column in the routing outcomes table | Explains whether release routing continued or stopped. |
 | Release outcome | Required | `pending`, `completed`, `failed`, or `blocked` | Overall component release lifecycle state | Distinguishes final release state from routing validation state. |
 | Hub tracker reference | Required | Hub issue, project item, or tracker URL | One hub-owned tracker reference | Connects product evidence back to hub reconciliation. |
 | Human action required | Required when blocked | Short text instruction | One actionable correction or not applicable | Gives operators the next required step when routing or cleanup stops. |

--- a/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/1_1356-route-component-releases-to-selected-product-repository_specs.md
+++ b/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/1_1356-route-component-releases-to-selected-product-repository_specs.md
@@ -2,6 +2,8 @@
 
 **Depends on**:
 [1353-artifact-ownership-product-release-contract](../20260730174200_1353-artifact-ownership-product-release-contract/1_1353-artifact-ownership-product-release-contract_specs.md)
+and
+[1354-one-product-repository-per-implementation-item](../20260731064618_1354-one-product-repository-per-implementation-item/1_1354-one-product-repository-per-implementation-item_specs.md)
 
 ---
 
@@ -50,11 +52,14 @@ Confirmed relationship decisions for epic #1352:
 
 - #1356 depends on #1353 as the foundational artifact ownership and product
   release contract.
+- #1356 depends on #1354 for the upstream one-product-repository selection and
+  pre-mutation blocking rules. This spec applies those rules to component
+  release preparation and cleanup rather than redefining the routing contract.
 - #1356 is not dependent on #1357. This spec provides component release
   evidence that the later delivery-bundle workflow may consume, but it does not
   define the delivery-bundle issue or manifest workflow.
-- #1356 is orthogonal to #1354, #1358, and #1359 beyond shared workflow-hub
-  release terminology.
+- #1356 is orthogonal to #1358 and #1359 beyond shared workflow-hub release
+  terminology.
 
 ## Use Cases
 
@@ -208,15 +213,19 @@ state.
 
 ## Component Release Routing Gate
 
-| Gate input | Allowed outcome | Required next action | Mirror surface | Example |
-| --- | --- | --- | --- | --- |
-| Exactly one selected product repository with a valid release contract | Continue | Prepare or clean up release artifacts in the selected product repository and reconcile tracker state in the hub | Release summary, PR body, cleanup log, and tracker comment | `faind-mobile-app` is selected and owns release branch, changelog, tag, deployment evidence, and cleanup evidence. |
-| No selected product repository in workflow-hub mode | Stop | Ask for one product repository selection before branch, pull request, tag, or tracker mutation | Stop summary and tracker-visible blocker evidence | The hub has multiple product repositories but the release command names none. |
-| More than one selected product repository | Stop | Split the release into one component release per product repository or choose one product | Stop summary and tracker-visible blocker evidence | The release request names both mobile and web product repositories. |
-| Unknown product repository | Stop | Correct product release configuration before mutation | Stop summary and validation output | The selected key is not in the product release contract. |
-| Unavailable product repository checkout | Stop | Correct local-only checkout configuration before local mutation | Stop summary and validation output | The selected product repository is known, but its local checkout cannot be resolved when cleanup needs local files. |
-| Invalid release artifact ownership | Stop | Correct the release contract before mutation | Validation output and stop summary | The contract would write a product changelog, tag, or release record to the hub for a product-owned release. |
-| Single-repository mode | Continue with existing behavior | Use current release and hotfix paths without requiring a product repository selector | Release summary and existing PR evidence | A repository without workflow-hub mode prepares its own release from the current checkout. |
+Validation precedence is top-to-bottom. The first matching gate row determines
+the canonical routing outcome for release and cleanup summaries.
+
+| Gate input | Routing outcome | Allowed outcome | Required next action | Mirror surface | Example |
+| --- | --- | --- | --- | --- | --- |
+| Single-repository mode | `single_repo_release` | Continue with existing behavior | Use current release and hotfix paths without requiring a product repository selector | Release summary and existing PR evidence | A repository without workflow-hub mode prepares its own release from the current checkout. |
+| No selected product repository in workflow-hub mode | `missing_product_selection` | Stop | Ask for one product repository selection before branch, pull request, tag, or tracker mutation | Stop summary and tracker-visible blocker evidence | The hub has multiple product repositories but the release command names none. |
+| More than one selected product repository | `multiple_product_targets` | Stop | Split the release into one component release per product repository or choose one product | Stop summary and tracker-visible blocker evidence | The release request names both mobile and web product repositories. |
+| Unknown product repository | `unknown_product_repository` | Stop | Correct product release configuration before mutation | Stop summary and validation output | The selected key is not in the product release contract. |
+| One selected product repository cannot resolve to exactly one configured product repository | `ambiguous_product_selection` | Stop | Correct the selection or contract so one selected value maps to one product repository | Stop summary and validation output | A product alias matches multiple configured product repositories. |
+| Invalid release artifact ownership | `invalid_release_contract` | Stop | Correct the release contract before mutation | Validation output and stop summary | The contract would write a product changelog, tag, or release record to the hub for a product-owned release. |
+| Unavailable product repository checkout | `unavailable_product_repository_checkout` | Stop | Correct local-only checkout configuration before local mutation | Stop summary and validation output | The selected product repository is known, but its local checkout cannot be resolved when cleanup needs local files. |
+| Exactly one selected product repository with a valid release contract and required checkout availability | `component_release_routed` | Continue | Prepare or clean up release artifacts in the selected product repository and reconcile tracker state in the hub | Release summary, PR body, cleanup log, and tracker comment | `faind-mobile-app` is selected and owns release branch, changelog, tag, deployment evidence, and cleanup evidence. |
 
 ## Business Rules
 
@@ -256,7 +265,7 @@ but each record identifies exactly one release target.
 | Field | Presence | Type | Allowed values or format | Purpose |
 | --- | --- | --- | --- | --- |
 | Canonical product repository identity | Required | Owner and repository identity | One product repository from the release contract | Proves which product owns release artifacts. |
-| Product repository key | Required | Stable product key | One configured key from the hub product list | Lets hub summaries and operators match the contract entry. |
+| Product repository key | Required | Stable product key | One configured key from the product release contract | Lets hub summaries and operators match the contract entry accepted by routing. |
 | Release correlation key | Required | Stable text identifier | One value per attempted component release | Distinguishes separate releases for the same product repository. |
 | Release contract revision | Required | Version, commit, or digest reference | The contract version used when release preparation began | Lets cleanup detect contract drift before mutation. |
 | Release branch reference | Required when a release branch exists | Branch name or pull request branch reference | One valid branch reference for the selected product repository | Locates the product release branch. |
@@ -267,6 +276,7 @@ but each record identifies exactly one release target.
 | Deployment evidence outcome | Required when deployment evidence is expected | `pending`, `recorded`, `failed`, or `not_applicable` | One outcome for the deployment evidence surface | Shows whether product deployment evidence exists. |
 | Cleanup outcome | Required once cleanup starts | `not_started`, `partial`, `complete`, or `blocked` | One cleanup state for the selected product repository | Lets reruns and bundle reconciliation detect incomplete cleanup. |
 | Routing outcome | Required | Routing outcome display label or code | One value from the routing outcomes table | Explains whether release routing continued or stopped. |
+| Release outcome | Required | `pending`, `completed`, `failed`, or `blocked` | Overall component release lifecycle state | Distinguishes final release state from routing validation state. |
 | Hub tracker reference | Required | Hub issue, project item, or tracker URL | One hub-owned tracker reference | Connects product evidence back to hub reconciliation. |
 | Human action required | Required when blocked | Short text instruction | One actionable correction or not applicable | Gives operators the next required step when routing or cleanup stops. |
 
@@ -276,19 +286,19 @@ No new tracker statuses are introduced. Existing workflow statuses keep their
 current display labels and meanings. The values below are release-routing
 outcomes that must be visible in release and cleanup summaries.
 
-Validation precedence is top-to-bottom. The first matching failure maps to the
-canonical outcome for release and cleanup summaries.
+Validation precedence is the same order as the Component Release Routing Gate.
+The first matching gate row maps to exactly one canonical outcome.
 
 | Routing outcome | Display label | Description |
 | --- | --- | --- |
-| `component_release_routed` | Component release routed | One selected product repository and a valid release contract allow release or cleanup to continue. |
+| `single_repo_release` | Single-repository release | The current repository owns the release path and no product repository selector is required. |
 | `missing_product_selection` | Missing product selection | No product repository was selected for a workflow-hub component release. |
 | `multiple_product_targets` | Multiple product targets | The release request names more than one product repository up front and must be split or narrowed. |
 | `unknown_product_repository` | Unknown product repository | The selected product repository key is not present in the product release contract. |
 | `ambiguous_product_selection` | Ambiguous product selection | One requested product selection is present, but it cannot be resolved to exactly one known product repository. |
 | `invalid_release_contract` | Invalid release contract | The selected product repository release contract is missing required portable release fields, contains unsafe values, or would route product artifacts to the wrong owner. |
 | `unavailable_product_repository_checkout` | Unavailable product repository checkout | The selected product repository is known, but the local checkout needed for release or cleanup mutation is not available from local-only configuration. |
-| `single_repo_release` | Single-repository release | The current repository owns the release path and no product repository selector is required. |
+| `component_release_routed` | Component release routed | One selected product repository, a valid release contract, and required checkout availability allow release or cleanup to continue. |
 
 ## Operational Visibility
 

--- a/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/1_1356-route-component-releases-to-selected-product-repository_specs.md
+++ b/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/1_1356-route-component-releases-to-selected-product-repository_specs.md
@@ -1,6 +1,7 @@
 # Route Component Releases To The Selected Product Repository - Spec
 
-**Depends on**: 1353-artifact-ownership-product-release-contract
+**Depends on**:
+[1353-artifact-ownership-product-release-contract](../20260730174200_1353-artifact-ownership-product-release-contract/1_1353-artifact-ownership-product-release-contract_specs.md)
 
 ---
 
@@ -26,9 +27,10 @@ Derived from issue #1356:
    workflow-hub mode.
 2. Require explicit product-repository selection before component release
    mutation.
-3. Resolve the selected product repository's checkout, branch model, changelog,
-   release pull requests, tag, CI, and deployment evidence from the product
-   release contract.
+3. Resolve the selected product repository's canonical repository identity and
+   portable release fields from the product release contract, while resolving
+   local checkout and environment-specific details from local-only
+   configuration.
 4. Keep the hub as tracker owner while preventing hub defaults from being used
    for product release artifacts.
 5. Preserve existing standalone release and hotfix paths for single-repository
@@ -69,7 +71,8 @@ the operator intends to release one selected product repository.
 2. The workflow validates that exactly one known product repository is selected.
 3. The workflow shows the selected product repository, release base, release
    branch pattern, changelog owner, tag owner, release record owner, deployment
-   evidence owner, cleanup evidence owner, and tracker reconciliation owner.
+   evidence owner, cleanup evidence owner, tracker reconciliation owner, and
+   product CI evidence source.
 4. The workflow prepares release artifacts only in the selected product
    repository.
 5. The hub records release coordination and tracker evidence without creating
@@ -85,6 +88,8 @@ that product release.
 - Release base and release branch that will be used.
 - Product changelog, release pull request, tag, release record, CI, deployment,
   and cleanup evidence ownership.
+- Local checkout source from local-only configuration when local product files
+  must be inspected or mutated.
 - Hub tracker reconciliation ownership.
 - Stop reason when selection or contract validation fails.
 
@@ -117,11 +122,13 @@ or tracker state for a hub-managed component release.
 
 1. The runner reads the requested product repository selection.
 2. The runner compares the selection against the product release contract.
-3. The runner verifies that the selection resolves to one product repository
-   and that the release artifact owners are valid.
-4. The runner stops before any mutation if the selection is missing, ambiguous,
+3. The runner verifies that the versioned contract resolves the canonical
+   repository identity and portable release fields for one product repository.
+4. The runner verifies local-only checkout availability separately when local
+   product files must be inspected or mutated.
+5. The runner stops before any mutation if the selection is missing, ambiguous,
    unknown, invalid, or names more than one product repository.
-5. The runner reports the required human action and leaves both hub and product
+6. The runner reports the required human action and leaves both hub and product
    repositories unmodified.
 
 **Postconditions**: Unsafe component release routing cannot partially create
@@ -161,12 +168,16 @@ some product-owned release artifacts already.
    product repository.
 2. The workflow validates the same selected product repository and release
    contract before mutating anything.
-3. The workflow reads current product release state from the selected product
+3. The workflow compares the persisted release target with the current selected
+   product repository, release correlation key, and release contract revision.
+4. The workflow stops before mutation when the persisted release target no
+   longer matches current release state.
+5. The workflow reads current product release state from the selected product
    repository.
-4. Already-completed cleanup actions are reported as complete rather than
+6. Already-completed cleanup actions are reported as complete rather than
    repeated destructively.
-5. Missing cleanup actions are completed in the selected product repository.
-6. Hub tracker reconciliation is updated only after product-owned cleanup state
+7. Missing cleanup actions are completed in the selected product repository.
+8. Hub tracker reconciliation is updated only after product-owned cleanup state
    is confirmed.
 
 **Postconditions**: Cleanup can be retried safely and converges to one
@@ -177,6 +188,7 @@ state.
 
 - Product release pull request state.
 - Product release branch and tag cleanup status.
+- Persisted release correlation key and contract revision or digest.
 - Product deployment or release evidence status.
 - Hub tracker reconciliation status.
 - Any remaining manual action.
@@ -185,8 +197,9 @@ state.
 
 - Continue cleanup when validation passes.
 - Report already-complete cleanup steps.
-- Stop before mutation when selected product repository evidence no longer
-  matches the original component release target.
+- Stop before mutation when the persisted canonical repository identity,
+  release correlation key, or contract revision no longer matches the current
+  release target.
 
 **Considerations**:
 
@@ -200,7 +213,8 @@ state.
 | Exactly one selected product repository with a valid release contract | Continue | Prepare or clean up release artifacts in the selected product repository and reconcile tracker state in the hub | Release summary, PR body, cleanup log, and tracker comment | `faind-mobile-app` is selected and owns release branch, changelog, tag, deployment evidence, and cleanup evidence. |
 | No selected product repository in workflow-hub mode | Stop | Ask for one product repository selection before branch, pull request, tag, or tracker mutation | Stop summary and tracker-visible blocker evidence | The hub has multiple product repositories but the release command names none. |
 | More than one selected product repository | Stop | Split the release into one component release per product repository or choose one product | Stop summary and tracker-visible blocker evidence | The release request names both mobile and web product repositories. |
-| Unknown or unavailable product repository | Stop | Correct product release configuration or local product checkout availability | Stop summary and validation output | The selected key is not in the product release contract or its checkout cannot be resolved. |
+| Unknown product repository | Stop | Correct product release configuration before mutation | Stop summary and validation output | The selected key is not in the product release contract. |
+| Unavailable product repository checkout | Stop | Correct local-only checkout configuration before local mutation | Stop summary and validation output | The selected product repository is known, but its local checkout cannot be resolved when cleanup needs local files. |
 | Invalid release artifact ownership | Stop | Correct the release contract before mutation | Validation output and stop summary | The contract would write a product changelog, tag, or release record to the hub for a product-owned release. |
 | Single-repository mode | Continue with existing behavior | Use current release and hotfix paths without requiring a product repository selector | Release summary and existing PR evidence | A repository without workflow-hub mode prepares its own release from the current checkout. |
 
@@ -217,13 +231,44 @@ state.
   tracker mutation.
 - Release preparation and cleanup must use the same selected product repository
   identity throughout one component release lifecycle.
+- Release preparation must persist an immutable release target containing the
+  canonical repository identity, release correlation key, and release contract
+  revision or digest before cleanup can later mutate product release artifacts.
+- Cleanup must validate the persisted release target against current selection
+  and contract state before mutation, and must stop when any persisted value
+  differs.
 - Cleanup must be rerunnable and must report already-completed product cleanup
   steps without requiring destructive repetition.
 - Single-repository release and hotfix paths do not require product repository
   selection and keep their current artifact ownership.
-- Component release evidence must be stable enough for later delivery-bundle
-  reconciliation to identify the product repository, release artifact state,
-  deployment evidence, and hub tracker reconciliation outcome.
+- Component release evidence must follow the component release evidence record
+  so later delivery-bundle reconciliation can identify the product repository,
+  release artifact state, deployment evidence, cleanup outcome, routing outcome,
+  and hub tracker reconciliation outcome.
+
+## Component Release Evidence Record
+
+Component release evidence is a machine-readable record that can be linked from
+the hub tracker item and consumed by later delivery-bundle reconciliation. A
+record may represent a completed, blocked, failed, or pending component release,
+but each record identifies exactly one release target.
+
+| Field | Presence | Type | Allowed values or format | Purpose |
+| --- | --- | --- | --- | --- |
+| Canonical product repository identity | Required | Owner and repository identity | One product repository from the release contract | Proves which product owns release artifacts. |
+| Product repository key | Required | Stable product key | One configured key from the hub product list | Lets hub summaries and operators match the contract entry. |
+| Release correlation key | Required | Stable text identifier | One value per attempted component release | Distinguishes separate releases for the same product repository. |
+| Release contract revision | Required | Version, commit, or digest reference | The contract version used when release preparation began | Lets cleanup detect contract drift before mutation. |
+| Release branch reference | Required when a release branch exists | Branch name or pull request branch reference | One valid branch reference for the selected product repository | Locates the product release branch. |
+| Release pull request reference | Required when a release pull request exists | Pull request URL or number plus repository identity | One product repository pull request | Locates the product release pull request. |
+| Product changelog reference | Optional | File path or release note reference | Product-owned changelog location or not applicable | Shows where release notes were prepared. |
+| Tag or release record reference | Optional | Tag name, release URL, or not applicable | Product-owned tag or release record | Shows the shipped product release marker when one exists. |
+| CI outcome | Required once product CI runs | `pending`, `passed`, `failed`, or `not_applicable` | One outcome for the product release validation surface | Lets bundle reconciliation distinguish validated and blocked releases. |
+| Deployment evidence outcome | Required when deployment evidence is expected | `pending`, `recorded`, `failed`, or `not_applicable` | One outcome for the deployment evidence surface | Shows whether product deployment evidence exists. |
+| Cleanup outcome | Required once cleanup starts | `not_started`, `partial`, `complete`, or `blocked` | One cleanup state for the selected product repository | Lets reruns and bundle reconciliation detect incomplete cleanup. |
+| Routing outcome | Required | Routing outcome display label or code | One value from the routing outcomes table | Explains whether release routing continued or stopped. |
+| Hub tracker reference | Required | Hub issue, project item, or tracker URL | One hub-owned tracker reference | Connects product evidence back to hub reconciliation. |
+| Human action required | Required when blocked | Short text instruction | One actionable correction or not applicable | Gives operators the next required step when routing or cleanup stops. |
 
 ## Statuses / Enum Values
 
@@ -231,13 +276,18 @@ No new tracker statuses are introduced. Existing workflow statuses keep their
 current display labels and meanings. The values below are release-routing
 outcomes that must be visible in release and cleanup summaries.
 
+Validation precedence is top-to-bottom. The first matching failure maps to the
+canonical outcome for release and cleanup summaries.
+
 | Routing outcome | Display label | Description |
 | --- | --- | --- |
 | `component_release_routed` | Component release routed | One selected product repository and a valid release contract allow release or cleanup to continue. |
 | `missing_product_selection` | Missing product selection | No product repository was selected for a workflow-hub component release. |
-| `ambiguous_product_selection` | Ambiguous product selection | The product repository target cannot be resolved to exactly one configured product. |
-| `multiple_product_targets` | Multiple product targets | The release request names more than one product repository and must be split or narrowed. |
-| `invalid_release_contract` | Invalid release contract | The selected product repository release contract is missing, unsafe, or would route product artifacts to the wrong owner. |
+| `multiple_product_targets` | Multiple product targets | The release request names more than one product repository up front and must be split or narrowed. |
+| `unknown_product_repository` | Unknown product repository | The selected product repository key is not present in the product release contract. |
+| `ambiguous_product_selection` | Ambiguous product selection | One requested product selection is present, but it cannot be resolved to exactly one known product repository. |
+| `invalid_release_contract` | Invalid release contract | The selected product repository release contract is missing required portable release fields, contains unsafe values, or would route product artifacts to the wrong owner. |
+| `unavailable_product_repository_checkout` | Unavailable product repository checkout | The selected product repository is known, but the local checkout needed for release or cleanup mutation is not available from local-only configuration. |
 | `single_repo_release` | Single-repository release | The current repository owns the release path and no product repository selector is required. |
 
 ## Operational Visibility
@@ -249,7 +299,8 @@ outcomes that must be visible in release and cleanup summaries.
   invalid or missing selection, and the human action required to continue.
 - **Product evidence**: Successful component release evidence names the product
   release pull request, release branch, tag or release record when applicable,
-  CI outcome, deployment evidence, and cleanup status.
+  CI outcome, deployment evidence, cleanup status, release correlation key, and
+  release contract revision.
 - **Hub evidence**: Hub tracker reconciliation records the selected product
   repository and points to product-owned release evidence instead of duplicating
   product release artifacts.
@@ -270,19 +321,21 @@ outcomes that must be visible in release and cleanup summaries.
       routing outcome.
 - [ ] Release preparation shows the selected product repository's release base,
       release branch, changelog owner, release pull request owner, tag owner,
-      CI owner, deployment evidence owner, cleanup evidence owner, and hub
-      tracker reconciliation owner.
+      product CI evidence source, deployment evidence owner, cleanup evidence
+      owner, and hub tracker reconciliation owner.
 - [ ] Post-merge cleanup for a component release validates the same selected
-      product repository before mutation and updates hub tracker state only
-      after product-owned cleanup state is confirmed.
+      product repository, release correlation key, and release contract revision
+      before mutation and updates hub tracker state only after product-owned
+      cleanup state is confirmed.
 - [ ] Re-running cleanup after a partial component release reports completed
       steps as already complete and safely completes missing cleanup steps
       without switching product repositories.
 - [ ] Single-repository release and hotfix workflows continue without requiring
       a product repository selector and continue to use current repository
       release artifacts.
-- [ ] Component release evidence includes enough selected product repository,
-      release artifact, deployment, cleanup, and hub tracker reconciliation
+- [ ] Component release evidence follows the component release evidence record
+      and includes selected product repository, release correlation, release
+      artifact, CI, deployment, cleanup, routing, and hub tracker reconciliation
       information for a later delivery-bundle workflow to consume.
 
 ## Out of Scope (MVP)
@@ -303,7 +356,7 @@ outcomes that must be visible in release and cleanup summaries.
 | --- | --- |
 | Make component release preparation and post-merge cleanup product-aware in workflow-hub mode. | Overview, Use Cases 1 and 3, Business Rules, AC1, AC5, AC6 |
 | Require explicit product-repository selection before component release mutation. | Use Cases 1 and 2, Component Release Routing Gate, Business Rules, AC1, AC2, AC3 |
-| Resolve checkout, branch model, changelog, release pull requests, tag, CI, and deployment evidence from the product release contract. | Use Case 1, Component Release Routing Gate, Operational Visibility, AC4 |
+| Resolve canonical repository identity and portable release fields from the product release contract while resolving local checkout from local-only configuration. | Use Cases 1 and 2, Component Release Routing Gate, Component Release Evidence Record, Operational Visibility, AC4 |
 | Keep the hub as tracker owner while preventing hub defaults from being used for product release artifacts. | Overview, Use Case 1, Business Rules, Operational Visibility, AC5 |
 | Preserve existing standalone release and hotfix paths for single-repository mode. | Overview, Component Release Routing Gate, Business Rules, AC7 |
 | Ensure a component release uses only the selected product repository's release artifacts. | Use Case 1, Business Rules, AC1 |


### PR DESCRIPTION
## Summary

- Adds the #1356 product-focused spec for routing workflow-hub component releases to one selected product repository.
- Defines the release-routing gate, unsafe selection outcomes, rerunnable cleanup expectations, and delivery-bundle evidence handoff.
- Preserves existing single-repository release and hotfix behavior.

Issue: #1356
Spec: docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/1_1356-route-component-releases-to-selected-product-repository_specs.md

## Coverage Matrix Summary

- Product-aware release preparation and cleanup: mapped to Overview, Use Cases 1 and 3, Business Rules, AC1, AC5, AC6.
- Explicit product-repository selection before mutation: mapped to Use Cases 1 and 2, Component Release Routing Gate, Business Rules, AC1, AC2, AC3.
- Release contract resolution for checkout, branch, changelog, PR, tag, CI, and deployment evidence: mapped to Use Case 1, routing gate, Operational Visibility, AC4.
- Hub tracker ownership with product artifact ownership: mapped to Overview, Use Case 1, Business Rules, Operational Visibility, AC5.
- Existing single-repository release and hotfix compatibility: mapped to Overview, routing gate, Business Rules, AC7.
- Selected product release artifacts only: mapped to Use Case 1, Business Rules, AC1.
- Fail closed for missing or ambiguous selection before mutation: mapped to Use Case 2, routing gate, Business Rules, AC2, AC3.
- Safe rerunnable cleanup: mapped to Use Case 3, Business Rules, Operational Visibility, AC5, AC6.
- Delivery-bundle-consumable evidence: mapped to Spec-Dispatch Context, Operational Visibility, AC8, Out of Scope.

## Deferral Notes

- Delivery-bundle issue and manifest workflow are deferred to #1357; no human confirmation requested because #1356 only produces evidence for that later workflow.
- Component milestone and release status rollups are deferred to #1358; no human confirmation requested because #1356 only defines component release routing.
- Adoption guidance and assurance are deferred to #1359; no human confirmation requested because #1356 is a release-routing spec.
- New tracker status taxonomy is out of scope; no human confirmation requested because release-routing outcomes are operator-visible outputs, not new tracker statuses.

## Document Quality Gate

- Brief coverage: Checked - all brief objectives map to acceptance criteria or out of scope.
- Internal consistency: Checked - product repository selection, component release, hub tracker reconciliation, and single-repository compatibility terms are used consistently.
- Behavioral guarantees: Checked - fail-closed routing, single target ownership, rerunnable cleanup, and tracker reconciliation guarantees are covered by business rules and ACs.
- Complex workflow decision-gate matrix: Checked - Component Release Routing Gate lists inputs, allowed outcomes, required next actions, mirror surfaces, and examples.
- Reviewer-risk categories: Checked - API surface, concurrency, snapshot semantics, edge cases, template placeholders, hidden dependencies, and stale template content reviewed.
- Placeholder cleanup: Checked - mandatory placeholder grep returned no output.
- Not-applicable rationale: Checked - UI rules are omitted because this spec has no user interface; new tracker statuses are omitted because routing outcomes are not tracker states.

## Validation

- Placeholder grep: passed, no output.
- `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`: passed.
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`: passed.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a specification for routing component releases and cleanup to one selected product repository.
  * Documented product and checkout validation, persisted release-target checks, failure handling, rerunnable cleanup, tracker reconciliation, and machine-readable operational evidence.
  * Defined expected routing outcomes, acceptance criteria, scope boundaries, and coverage mapping.
  * Confirmed that existing single-repository release and hotfix behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->