### PR TITLE
docs(plan): route component releases to selected product repository

### DIFF
--- a/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/2_1356-route-component-releases-to-selected-product-repository_implementation-plan.md
+++ b/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/2_1356-route-component-releases-to-selected-product-repository_implementation-plan.md
@@ -99,27 +99,46 @@ evidence, or tracker state.
       contract containing selected product key, canonical repository identity,
       local checkout path/source, release base, release branch pattern, artifact
       owners, routing outcome code, release correlation key, contract revision
-      or digest, and human action when blocked. Map to AC1-AC4 and AC8.
+      field named `contract_revision`, and human action when blocked. The same
+      `contract_revision` field name and string format must appear in shell
+      output, JSON output, evidence records, cleanup validation, smoke tests,
+      and fixtures. Classified stop outcomes must emit structured output with
+      `mutation_allowed=false`; malformed input and internal helper failures
+      must exit nonzero. Map to AC1-AC4 and AC8.
 - [ ] Extend `scripts/development-workflow/workflow-config-resolver.py` only as
       needed to expose contract revision or digest and any missing normalized
       release target fields. Keep local checkout fields sourced from local-only
       config and keep forbidden local/secret validation in the existing release
       contract path. Map to AC1-AC4.
 - [ ] Extend `scripts/development-workflow/prepare-release-post-merge-cleanup.sh`
-      with `--repo <name>`, `--repo-root <path>`, and an optional
-      `--evidence-file <path>` argument. In workflow-hub mode, it must resolve
-      the product release target before querying merged release PRs or deleting
-      release branches, run product branch/tag cleanup in the selected product
-      repository, then return to the hub for tracker release stamping and status
-      transitions. It must validate the persisted release correlation key and
-      contract revision before mutation when an evidence file is provided. Map
-      to AC5 and AC6.
+      with `--repo <name>`, `--repo-root <path>`, and `--evidence-file <path>`
+      arguments. In workflow-hub mode, component release cleanup must require a
+      persisted evidence file or an equivalent mandatory target-binding file
+      before deleting branches, tags, cleanup evidence, or tracker state. The
+      helper must resolve the current product release target first, reject any
+      caller-supplied `--repo-root` that differs from the resolved hub checkout,
+      validate canonical repository identity, release correlation key, and
+      `contract_revision` against the current resolver output, then run product
+      branch/tag cleanup in the selected product repository before returning to
+      the hub for tracker release stamping and status transitions. Map to AC5
+      and AC6.
 - [ ] Add `scripts/development-workflow/component-release-evidence.sh` as a
       focused helper for rendering and validating the component release evidence
       record. The helper should accept explicit fields from release preparation
-      and cleanup, validate required values and allowed outcome enums, and write
-      deterministic JSON that later #1357 delivery-bundle reconciliation can
-      consume. Map to AC8.
+      and cleanup, derive target identity from the canonical resolver output or
+      persisted target binding, validate required values, allowed outcome enums,
+      and cross-field relationships, then write deterministic JSON that later
+      #1357 delivery-bundle reconciliation can consume. It must reject
+      mismatched product repository key, canonical repository identity, artifact
+      owner, release correlation key, or `contract_revision` before writing
+      evidence. Map to AC8.
+- [ ] Add per-release cleanup concurrency control to the release cleanup path.
+      Use a product-repository remote lock or lease keyed by release correlation
+      key before deleting remote release branches, tags, cleanup evidence, or
+      updating hub tracker state. Duplicate cleanup invocations for the same
+      correlation key must either observe the existing completed evidence and
+      exit idempotently or fail before mutation with a clear lock/lease owner
+      message. Map to AC5 and AC6.
 - [ ] Keep `scripts/development-workflow/post-merge-cleanup.sh` product-owned
       implementation cleanup behavior intact. Add documentation or a guard only
       if needed to distinguish implementation branch cleanup from release branch
@@ -182,15 +201,19 @@ workflow command tests, and smoke/manual release runbook verification.
    or tracker mutation and produce the canonical routing outcome code. Maps to
    AC2 and AC3.
 4. Release cleanup with a matching evidence file validates repository identity,
-   release correlation key, and contract revision before product cleanup
+   release correlation key, and `contract_revision` before product cleanup
    mutation. Maps to AC5.
 5. Release cleanup with mismatched persisted evidence stops before mutation and
    leaves hub tracker state unchanged. Maps to AC5 and AC6.
 6. Component release evidence validation accepts complete `pending`,
    `completed`, `failed`, and `blocked` records, rejects invalid routing,
-   release, CI, deployment, and cleanup outcomes, and requires the hub tracker
-   reference. Maps to AC8.
-7. Prepare-release documentation preserves single-repository release and hotfix
+   release, CI, deployment, and cleanup outcomes, rejects repository-key,
+   artifact-owner, correlation, and `contract_revision` cross-field
+   mismatches, and requires the hub tracker reference. Maps to AC8.
+7. Duplicate cleanup invocations for the same release correlation key acquire
+   only one active lock/lease and keep completed reruns idempotent. Maps to AC5
+   and AC6.
+8. Prepare-release documentation preserves single-repository release and hotfix
    behavior while adding workflow-hub product release target resolution. Maps to
    AC7.
 
@@ -204,10 +227,11 @@ workflow command tests, and smoke/manual release runbook verification.
 - [ ] Add `scripts/development-workflow/tests/test-component-release-target.sh`
       for release target routing outcomes and fail-closed mutation boundaries.
 - [ ] Add `scripts/development-workflow/tests/test-component-release-evidence.sh`
-      for evidence record validation and deterministic JSON output.
+      for evidence record validation, cross-field relationship checks, and
+      deterministic JSON output.
 - [ ] Extend `scripts/development-workflow/tests/test-prepare-release-tracker-cleanup.sh`
       for workflow-hub product release cleanup with matching and mismatched
-      evidence.
+      evidence plus duplicate/concurrent cleanup lock behavior.
 - [ ] Extend `scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh`
       for product checkout resolution and local-only config errors.
 - [ ] Extend `scripts/development-workflow/tests/test-workflow-agent-product-repo-guidance.sh`
@@ -231,8 +255,9 @@ release branch/correlation parsing, and structured release target output.
   - Cleanup outcomes: `not_started`, `partial`, `complete`, `blocked`, empty
     value, and unknown value.
   - Correlation identity: matching repository/correlation/revision values,
-    mismatched repository identity, mismatched correlation key, mismatched
-    contract revision, and missing persisted evidence.
+    mismatched repository identity, mismatched artifact owner, mismatched
+    correlation key, mismatched `contract_revision`, and missing persisted
+    evidence.
   - Branch pattern carry-through: default `release/v{version}`, product pattern
     using `{product_repo}`, unknown placeholder, and unresolved placeholder.
 - **Unit test mapping**:
@@ -247,21 +272,36 @@ release branch/correlation parsing, and structured release target output.
 - **Suppression semantics**: Not applicable. This feature does not introduce
   inline suppression directives.
 
-### Concurrent-Event-Source Addendum
+### Cleanup Concurrency And Idempotency Addendum
 
-- **Shared mutable state guards**: Not applicable; helpers are synchronous
-  command-line tools with process-local state.
-- **Re-entrancy / in-flight tracking**: Not applicable; no long-running release
-  daemon or concurrent queue is introduced.
-- **Event deduplication**: Not applicable; no event source is introduced.
+This feature does not introduce event listeners, sockets, timers, or async
+queues, but release cleanup can still be invoked concurrently by two operators
+or CI jobs. The implementation must therefore add a per-release concurrency
+control for cleanup and tracker reconciliation.
+
+- **Shared mutable state guards**: Acquire a product-repository remote lock or
+  lease keyed by the release correlation key before deleting remote branches,
+  tags, cleanup evidence, or updating hub tracker state. The lock evidence must
+  name the product repository, correlation key, `contract_revision`, caller, and
+  expiry or completion state.
+- **Re-entrancy / in-flight tracking**: A second cleanup invocation for the same
+  correlation key must detect an active lock and stop before mutation unless it
+  observes completed evidence for the same repository identity and
+  `contract_revision`, in which case it exits idempotently.
+- **Event deduplication**: Duplicate cleanup attempts for the same release
+  correlation key are deduplicated by the lock/lease and persisted evidence.
 - **Listener and resource cleanup**: Not applicable; no listeners, timers, or
-  handles are introduced.
-- **Race conditions at initialization**: Not applicable; helpers read current
-  file and GitHub state at invocation start.
-- **Race conditions at teardown**: Not applicable; cleanup runs as a bounded
-  command and exits.
+  handles are introduced. Lock release or completion marking is part of the
+  bounded cleanup command.
+- **Race conditions at initialization**: The cleanup helper must acquire the
+  lock before any mutable product or hub tracker operation. Validation without a
+  lock is read-only.
+- **Race conditions at teardown**: Cleanup must mark completed evidence before
+  releasing the lock. If cleanup fails, the lock/lease remains visible with the
+  failure reason or expires according to the documented lease policy.
 - **Error propagation across async boundaries**: Not applicable; scripts are
-  synchronous Bash/Python commands.
+  synchronous Bash/Python commands, but lock acquisition and release failures
+  must return nonzero and stop later mutation.
 
 ---
 
@@ -272,7 +312,7 @@ release branch/correlation parsing, and structured release target output.
 | Workflow hub release config | Valid hub with two product repositories, one explicit release pattern, one default release pattern, and matching local-only checkout entries | Temporary fixtures in `test-component-release-target.sh` and `test-workflow-config-resolver.sh` |
 | Invalid release config | Missing selection, multiple selection, unknown product key, invalid artifact owner, forbidden local path in versioned contract | Temporary fixtures in `test-component-release-target.sh` |
 | Evidence records | Complete pending/completed/failed/blocked component release records plus invalid enum and missing-field variants | Temporary fixtures in `test-component-release-evidence.sh` |
-| Cleanup state | Matching and mismatched persisted repository identity, release correlation key, and contract revision | Temporary fixtures in `test-prepare-release-tracker-cleanup.sh` |
+| Cleanup state | Matching and mismatched persisted repository identity, release correlation key, `contract_revision`, and lock/lease records | Temporary fixtures in `test-prepare-release-tracker-cleanup.sh` |
 
 ---
 
@@ -303,7 +343,8 @@ release branch/correlation parsing, and structured release target output.
 
 | Risk | Likelihood | Impact | Mitigation |
 | --- | --- | --- | --- |
-| Release preparation and cleanup resolve different product targets | Med | High | Persist canonical repository identity, release correlation key, and contract revision during preparation; cleanup must validate all three before mutation. |
+| Release preparation and cleanup resolve different product targets | Med | High | Persist canonical repository identity, release correlation key, and `contract_revision` during preparation; cleanup must validate all three before mutation. |
+| Concurrent cleanup invocations mutate the same release artifacts | Med | High | Use a per-release remote lock/lease keyed by release correlation and make completed reruns idempotent. |
 | Product local checkout leaks into versioned release contract | Low | High | Reuse resolver forbidden-data checks and source local checkout only from local config. |
 | Evidence record becomes too loose for #1357 delivery bundles | Med | Med | Validate required fields and allowed outcome enums in `component-release-evidence.sh`; include smoke and unit tests for every outcome. |
 | Existing single-repository release flow regresses | Low | High | Keep `single_repo_release` as the first routing outcome and add tests that run without `--repo`. |
@@ -328,7 +369,8 @@ existing Bash/Python helper style in `scripts/development-workflow/`.
    - Verify with focused fixtures before touching release cleanup.
 2. Add component release evidence:
    - Add `component-release-evidence.sh`.
-   - Validate required fields and allowed enum values.
+   - Validate required fields, allowed enum values, and cross-field
+     relationships against resolver output or persisted binding.
    - Ensure output is deterministic JSON and includes the release correlation
      key and hub tracker reference.
 3. Update release cleanup:
@@ -336,6 +378,8 @@ existing Bash/Python helper style in `scripts/development-workflow/`.
      evidence-file options.
    - Resolve product target before querying/deleting release branches.
    - Validate persisted release target before mutation.
+   - Acquire the per-release lock/lease before product branch/tag cleanup or
+     hub tracker reconciliation.
    - Keep tracker release stamping hub-owned and after product cleanup
      confirmation.
 4. Update prepare-release protocol and command guidance:
@@ -349,7 +393,7 @@ existing Bash/Python helper style in `scripts/development-workflow/`.
    - Extend release cleanup, config resolver, product repo commands, docs, and
      agent guidance tests.
 7. Run verification:
-   - `bash -n scripts/development-workflow/component-release-target.sh scripts/development-workflow/component-release-evidence.sh scripts/development-workflow/prepare-release-post-merge-cleanup.sh`
+   - `for script in scripts/development-workflow/component-release-target.sh scripts/development-workflow/component-release-evidence.sh scripts/development-workflow/prepare-release-post-merge-cleanup.sh; do bash -n "$script"; done`
    - `bash scripts/development-workflow/tests/test-component-release-target.sh`
    - `bash scripts/development-workflow/tests/test-component-release-evidence.sh`
    - `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`

--- a/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/2_1356-route-component-releases-to-selected-product-repository_implementation-plan.md
+++ b/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/2_1356-route-component-releases-to-selected-product-repository_implementation-plan.md
@@ -104,6 +104,12 @@ assertions must use the versioned release target keys above. Unsupported
 repository modes map to `unsupported_repository_mode` with
 `mutation_allowed=false`.
 
+Valid classified stop outcomes are successful classifications, not helper
+failures. `component-release-target.sh` must therefore exit `0` for valid
+fail-closed routing outcomes with `mutation_allowed=false`. It must exit
+nonzero for malformed input, unreadable config, invalid CLI usage, failed
+resolver calls, and internal helper failures.
+
 Allowed artifact owner values are `current_repository`, `product_repository`,
 `hub_repository`, and `not_applicable`. For `single_repo_release`, all five
 `artifact_owners.*` fields map to `current_repository`. For
@@ -163,13 +169,14 @@ blocked or unsupported target.
 - [ ] Add `scripts/development-workflow/component-release-evidence.sh` as a
       focused helper for rendering and validating the component release evidence
       record. The helper should accept explicit fields from release preparation
-      and cleanup, derive target identity from the canonical resolver output or
-      persisted target binding, validate required values, allowed outcome enums,
-      and cross-field relationships, then write deterministic JSON that later
-      #1357 delivery-bundle reconciliation can consume. It must reject
-      mismatched product repository key, canonical repository identity, artifact
-      owner, release correlation key, or `contract_revision` before writing
-      evidence. Map to AC8.
+      and cleanup, plus a required `--binding-file <path>` containing canonical
+      resolver output or a persisted target binding. It must validate required
+      values, allowed outcome enums, and cross-field relationships against that
+      independent binding, then write deterministic JSON that later #1357
+      delivery-bundle reconciliation can consume. It must reject mismatched
+      product repository key, canonical repository identity, artifact owner,
+      release correlation key, or `contract_revision` before writing evidence.
+      Map to AC8.
 - [ ] Add per-release cleanup concurrency control to the release cleanup path.
       Use a product-repository remote lock or lease keyed by release correlation
       key before deleting remote release branches, tags, cleanup evidence, or

--- a/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/2_1356-route-component-releases-to-selected-product-repository_implementation-plan.md
+++ b/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/2_1356-route-component-releases-to-selected-product-repository_implementation-plan.md
@@ -104,6 +104,17 @@ assertions must use the versioned release target keys above. Unsupported
 repository modes map to `unsupported_repository_mode` with
 `mutation_allowed=false`.
 
+Allowed artifact owner values are `current_repository`, `product_repository`,
+`hub_repository`, and `not_applicable`. For `single_repo_release`, all five
+`artifact_owners.*` fields map to `current_repository`. For
+`component_release_routed`, a singular classifier owner of `product_repository`
+maps `artifact_owners.release`, `artifact_owners.ci`,
+`artifact_owners.deployment`, and `artifact_owners.cleanup` to
+`product_repository`, and maps `artifact_owners.tracker` to `hub_repository`.
+For stop outcomes, mutable owners map to `not_applicable` unless the helper can
+prove a read-only hub tracker owner; it must never report a product owner for a
+blocked or unsupported target.
+
 ---
 
 ## Layer-by-Layer Changes

--- a/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/2_1356-route-component-releases-to-selected-product-repository_implementation-plan.md
+++ b/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/2_1356-route-component-releases-to-selected-product-repository_implementation-plan.md
@@ -70,12 +70,39 @@ checkout availability, and persisted release evidence.
 | One selected value cannot resolve to one product repository | `ambiguous_product_selection` | Stop | Correct selection or contract before mutation | Resolver output and release target helper |
 | Release contract would route product artifacts to the wrong owner or lacks required portable fields | `invalid_release_contract` | Stop | Correct versioned release contract before mutation | Resolver validation, prepare-release protocol, smoke runbook |
 | Product checkout required but unavailable locally | `unavailable_product_repository_checkout` | Stop | Correct local-only checkout config before local mutation | Resolver `--require-local`, hub status/sync guidance |
+| Repository mode is unsupported for component releases | `unsupported_repository_mode` | Stop | Correct repository mode or use the supported single-repository release workflow | Release target helper, prepare-release protocol |
 | Exactly one valid product target and required local checkout available | `component_release_routed` | Continue | Mutate product-owned release artifacts in the selected product repository and hub-owned tracker reconciliation in the hub | Release summary, PR body, cleanup log, component release evidence |
 
 Validation precedence is the table order above. Every mutating release or
 cleanup command must produce exactly one canonical routing outcome code before
 it mutates files, branches, pull requests, tags, deployment evidence, cleanup
 evidence, or tracker state.
+
+### Release Target Adapter Contract
+
+`component-release-target.sh --json` must emit versioned JSON with
+`schema_version="component_release_target.v1"` and these exact keys:
+`routing_outcome`, `mutation_allowed`, `selected_product_repo_key`,
+`canonical_repository_identity`, `local_checkout.path`,
+`local_checkout.source`, `release_base`, `release_branch_pattern`,
+`artifact_owners.release`, `artifact_owners.ci`,
+`artifact_owners.deployment`, `artifact_owners.cleanup`,
+`artifact_owners.tracker`, `release_correlation_key`, `contract_revision`, and
+`human_action`. The shell output mode must use the same contract with uppercase
+keys: `SCHEMA_VERSION`, `ROUTING_OUTCOME`, `MUTATION_ALLOWED`,
+`SELECTED_PRODUCT_REPO_KEY`, `CANONICAL_REPOSITORY_IDENTITY`,
+`LOCAL_CHECKOUT_PATH`, `LOCAL_CHECKOUT_SOURCE`, `RELEASE_BASE`,
+`RELEASE_BRANCH_PATTERN`, `ARTIFACT_OWNER_RELEASE`, `ARTIFACT_OWNER_CI`,
+`ARTIFACT_OWNER_DEPLOYMENT`, `ARTIFACT_OWNER_CLEANUP`,
+`ARTIFACT_OWNER_TRACKER`, `RELEASE_CORRELATION_KEY`, `CONTRACT_REVISION`, and
+`HUMAN_ACTION`.
+
+The release target adapter may consume existing resolver or routing outputs
+such as `outcome_code` and singular `artifact_owner`, but those names are
+internal inputs only. Evidence records, cleanup validation, fixtures, and smoke
+assertions must use the versioned release target keys above. Unsupported
+repository modes map to `unsupported_repository_mode` with
+`mutation_allowed=false`.
 
 ---
 
@@ -229,6 +256,11 @@ workflow command tests, and smoke/manual release runbook verification.
 - [ ] Add `scripts/development-workflow/tests/test-component-release-evidence.sh`
       for evidence record validation, cross-field relationship checks, and
       deterministic JSON output.
+- [ ] Add `scripts/development-workflow/tests/setup-component-release-fixture.sh`
+      for the smoke runbook. It must create temporary single-repository and
+      workflow-hub fixtures, two product repository checkouts, local-only
+      checkout entries, invalid-selection variants, seeded branch/tag/evidence
+      cleanup state, lock state, and a mocked or disposable tracker state file.
 - [ ] Extend `scripts/development-workflow/tests/test-prepare-release-tracker-cleanup.sh`
       for workflow-hub product release cleanup with matching and mismatched
       evidence plus duplicate/concurrent cleanup lock behavior.
@@ -393,17 +425,42 @@ existing Bash/Python helper style in `scripts/development-workflow/`.
    - Extend release cleanup, config resolver, product repo commands, docs, and
      agent guidance tests.
 7. Run verification:
-   - `for script in scripts/development-workflow/component-release-target.sh scripts/development-workflow/component-release-evidence.sh scripts/development-workflow/prepare-release-post-merge-cleanup.sh; do bash -n "$script"; done`
-   - `bash scripts/development-workflow/tests/test-component-release-target.sh`
-   - `bash scripts/development-workflow/tests/test-component-release-evidence.sh`
-   - `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`
-   - `bash scripts/development-workflow/tests/test-prepare-release-tracker-cleanup.sh`
-   - `bash scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh`
-   - `bash scripts/development-workflow/tests/test-workflow-agent-product-repo-guidance.sh`
-   - `bash scripts/development-workflow/tests/test-workflow-hub-docs.sh`
-   - `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
-   - `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
-   - `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop-multi-repo-releases`
-   - `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop-multi-repo-releases`
+
+   ```bash
+   set -euo pipefail
+
+   changed_shell_files=(
+     scripts/development-workflow/component-release-target.sh
+     scripts/development-workflow/component-release-evidence.sh
+     scripts/development-workflow/prepare-release-post-merge-cleanup.sh
+     scripts/development-workflow/tests/test-component-release-target.sh
+     scripts/development-workflow/tests/test-component-release-evidence.sh
+     scripts/development-workflow/tests/setup-component-release-fixture.sh
+   )
+
+   for script in "${changed_shell_files[@]}"; do
+     bash -n "$script"
+   done
+
+   shellcheck "${changed_shell_files[@]}"
+   bash scripts/development-workflow/tests/test-component-release-target.sh
+   bash scripts/development-workflow/tests/test-component-release-evidence.sh
+   bash scripts/development-workflow/tests/test-workflow-config-resolver.sh
+   bash scripts/development-workflow/tests/test-prepare-release-tracker-cleanup.sh
+   bash scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh
+   bash scripts/development-workflow/tests/test-workflow-agent-product-repo-guidance.sh
+   bash scripts/development-workflow/tests/test-workflow-hub-docs.sh
+   npx markdownlint-cli2 \
+     "docs/specs/developments/**/*.md" \
+     "docs/testing/workflow/**/*.md" \
+     "CHANGELOG.md"
+   find docs/specs/developments docs/testing/workflow -name "*.md" -print0 \
+     | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md
+   python3 scripts/lint/workflow-shell-snippet-lint.py \
+     --base-ref origin/develop-multi-repo-releases
+   python3 scripts/lint/workflow-shell-guard-lint.py \
+     --base-ref origin/develop-multi-repo-releases
+   ```
+
 8. Update `CHANGELOG.md` under `[Unreleased]` during implementation with:
    `- **Route component releases to selected product repositories** (#1356): Add workflow-hub component release routing, cleanup, and evidence handling for selected product repositories.`

--- a/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/2_1356-route-component-releases-to-selected-product-repository_implementation-plan.md
+++ b/docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/2_1356-route-component-releases-to-selected-product-repository_implementation-plan.md
@@ -1,0 +1,365 @@
+# Route Component Releases To The Selected Product Repository - Implementation Plan
+
+**Spec**:
+[`1_1356-route-component-releases-to-selected-product-repository_specs.md`](./1_1356-route-component-releases-to-selected-product-repository_specs.md)
+**Smoke test runbook**:
+[`docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md`](../../../testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Add one release-target resolution path for component releases,
+then thread that resolved target through prepare-release guidance, release
+post-merge cleanup, and component-release evidence. Reuse the #1353 product
+release contract and #1354 one-target routing rules instead of creating a
+parallel repository-selection model.
+
+**Estimated complexity**: M
+
+**Rationale**: The work is mostly Bash/Python workflow tooling and
+documentation, but it touches release preparation, release cleanup, tracker
+reconciliation, and evidence that later delivery-bundle work will consume. The
+main risk is allowing release preparation and cleanup to derive product targets
+from different sources.
+
+**Dependencies**: #1353 and #1354 are merged through implementation on
+`develop-multi-repo-releases`; #1356 spec PR #1409 is merged and sets #1356 to
+`Spec Ready`.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `fbdcff7` |
+| Template-fit check | `rg -n "template:|is_template" .ai-dev-workflow.yaml` | `template.is_template: true`; the feature is generic workflow tooling and release orchestration, not downstream framework-specific code. |
+| Release and cleanup surface scan | `rg -l "prepare-release\\|prepare release\\|release branch\\|release contract\\|TARGET_RELEASE\\|deployment evidence\\|cleanup evidence\\|component release\\|Release outcome\\|Routing outcome" scripts/development-workflow docs/workflow/development-workflow .claude/agents .cursor/agents .codex/skills .agents/skills REVIEW.md \| sort` | Relevant implementation surfaces include `05-prepare-release-protocol.md`, `prepare-release-post-merge-cleanup.sh`, `post-merge-cleanup.sh`, `workflow-config-resolver.py`, `validate-workflow-config.sh`, `repository-modes.md`, `cross-repo-pr-flow.md`, `workflow-hub-setup.md`, `.agents/skills/prepare-release/SKILL.md`, and tests under `scripts/development-workflow/tests/`. |
+| Existing resolver release contract support | `rg -n "normalize_release_contract\\|validate_release_branch_pattern\\|TARGET_LOCAL_PATH\\|release_contract" scripts/development-workflow/workflow-config-resolver.py scripts/development-workflow/validate-workflow-config.sh` | The resolver already normalizes product release contract fields and separates local checkout resolution behind `--require-local`; the implementation should extend this path rather than parse config independently. |
+| Cleanup baseline | `rg -n "product repository selection is required\\|BRANCH_LIFECYCLE\\|Spec branch\\|Implementation plan branch" scripts/development-workflow/post-merge-cleanup.sh` | Implementation branch cleanup already requires product selection in `workflow_hub`; release cleanup remains current-repository oriented and needs product-target support. |
+| Existing test surfaces | `find scripts/development-workflow/tests -maxdepth 1 -type f \| sort \| rg "release|cleanup|config|workflow-hub|product-repo|orchestration"` | Relevant tests include `test-workflow-config-resolver.sh`, `test-prepare-release-tracker-cleanup.sh`, `test-post-merge-cleanup.sh`, `test-workflow-hub-product-repo-commands.sh`, `test-workflow-hub-docs.sh`, and agent guidance tests. |
+| Design assets | `gh issue view 1356 --json body --jq '.body' \| sed -n '/## Design assets/,+8p'` | No design assets section or tracker design references found; no fidelity step is required. |
+
+---
+
+## Cross-Cutting Operational Assumption Check
+
+### Applicable
+
+| Assumption surface | Recorded value | Authoritative source | Verified at | Bounded cross-check scope | Result |
+| --- | --- | --- | --- | --- | --- |
+| Plan artifact base | `develop-multi-repo-releases` | `/run-epic 1352` effective policy and #1409 base branch | 2026-07-31, repo `fbdcff7` | Current #1356 plan branch only | `Verified` |
+| Release contract authority | Product repository key and portable release fields come from #1353's product release contract; local checkout comes from local-only config | #1353 merged spec/implementation and `workflow-config-resolver.py` release contract support | 2026-07-31, repo `fbdcff7` | #1356 plan plus same-epic downstream #1357 evidence consumer | `Verified` |
+| One-target routing authority | Component releases apply #1354's one-product-repository and pre-mutation blocking rules | #1354 merged spec/implementation and #1356 spec dependencies | 2026-07-31, repo `fbdcff7` | #1356 release-routing plan only | `Verified` |
+
+---
+
+## Complex Workflow Decision-Gate Matrix
+
+This plan modifies release decision-gate behavior because release mutation
+depends on repository mode, product selection, release contract validity, local
+checkout availability, and persisted release evidence.
+
+| Gate input | Routing outcome | Allowed outcome | Required next action | Mirror surfaces |
+| --- | --- | --- | --- | --- |
+| Single-repository mode | `single_repo_release` | Continue | Use current release and hotfix workflow unchanged | `05-prepare-release-protocol.md`, release cleanup helper, smoke runbook |
+| Workflow hub release with no product selection | `missing_product_selection` | Stop | Request one product repository before branch, PR, tag, changelog, deployment, cleanup, or tracker mutation | Release target helper, prepare-release protocol, cleanup helper |
+| Workflow hub release with multiple product targets | `multiple_product_targets` | Stop | Split or narrow to one component release per product repository | Release target helper and smoke runbook |
+| Selected key absent from product release contract | `unknown_product_repository` | Stop | Correct the hub product release contract or selected key | Resolver output, release target helper |
+| One selected value cannot resolve to one product repository | `ambiguous_product_selection` | Stop | Correct selection or contract before mutation | Resolver output and release target helper |
+| Release contract would route product artifacts to the wrong owner or lacks required portable fields | `invalid_release_contract` | Stop | Correct versioned release contract before mutation | Resolver validation, prepare-release protocol, smoke runbook |
+| Product checkout required but unavailable locally | `unavailable_product_repository_checkout` | Stop | Correct local-only checkout config before local mutation | Resolver `--require-local`, hub status/sync guidance |
+| Exactly one valid product target and required local checkout available | `component_release_routed` | Continue | Mutate product-owned release artifacts in the selected product repository and hub-owned tracker reconciliation in the hub | Release summary, PR body, cleanup log, component release evidence |
+
+Validation precedence is the table order above. Every mutating release or
+cleanup command must produce exactly one canonical routing outcome code before
+it mutates files, branches, pull requests, tags, deployment evidence, cleanup
+evidence, or tracker state.
+
+---
+
+## Layer-by-Layer Changes
+
+### Database / Data Layer
+
+- [ ] No database, migration, or seed-data changes.
+
+### Backend / API
+
+- [ ] No HTTP API changes.
+
+### Shared Workflow Tooling
+
+- [ ] Add `scripts/development-workflow/component-release-target.sh` as the
+      single release-target entry point. It should call
+      `workflow-config-resolver.py validate --repo <name> --require-local` when
+      workflow-hub product mutation needs a local checkout, accept
+      single-repository mode without `--repo`, and emit a stable shell and JSON
+      contract containing selected product key, canonical repository identity,
+      local checkout path/source, release base, release branch pattern, artifact
+      owners, routing outcome code, release correlation key, contract revision
+      or digest, and human action when blocked. Map to AC1-AC4 and AC8.
+- [ ] Extend `scripts/development-workflow/workflow-config-resolver.py` only as
+      needed to expose contract revision or digest and any missing normalized
+      release target fields. Keep local checkout fields sourced from local-only
+      config and keep forbidden local/secret validation in the existing release
+      contract path. Map to AC1-AC4.
+- [ ] Extend `scripts/development-workflow/prepare-release-post-merge-cleanup.sh`
+      with `--repo <name>`, `--repo-root <path>`, and an optional
+      `--evidence-file <path>` argument. In workflow-hub mode, it must resolve
+      the product release target before querying merged release PRs or deleting
+      release branches, run product branch/tag cleanup in the selected product
+      repository, then return to the hub for tracker release stamping and status
+      transitions. It must validate the persisted release correlation key and
+      contract revision before mutation when an evidence file is provided. Map
+      to AC5 and AC6.
+- [ ] Add `scripts/development-workflow/component-release-evidence.sh` as a
+      focused helper for rendering and validating the component release evidence
+      record. The helper should accept explicit fields from release preparation
+      and cleanup, validate required values and allowed outcome enums, and write
+      deterministic JSON that later #1357 delivery-bundle reconciliation can
+      consume. Map to AC8.
+- [ ] Keep `scripts/development-workflow/post-merge-cleanup.sh` product-owned
+      implementation cleanup behavior intact. Add documentation or a guard only
+      if needed to distinguish implementation branch cleanup from release branch
+      cleanup so operators use the correct helper. Map to AC5.
+
+### Workflow Documentation
+
+- [ ] `docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md`:
+      replace any ambiguous current-checkout release steps with release target
+      resolution, product checkout binding, evidence record creation, and
+      fail-closed behavior for missing, multiple, unknown, ambiguous, invalid,
+      or unavailable targets. Preserve current single-repository and hotfix
+      behavior. Map to AC1-AC4, AC7, and AC8.
+- [ ] `docs/workflow/development-workflow/cross-repo-pr-flow.md`: add the
+      component-release release-target checkpoint and evidence handoff from the
+      hub to selected product repository and back to hub tracker reconciliation.
+      Map to AC1, AC4, and AC8.
+- [ ] `docs/workflow/development-workflow/repository-modes.md`: add the
+      canonical routing outcome codes, release evidence record pointer, and
+      cleanup rerun contract for component releases. Map to AC1-AC8.
+- [ ] `docs/workflow/development-workflow/workflow-hub-setup.md`: document the
+      operator workflow for selecting one product repository for a component
+      release and storing local checkout config outside versioned release
+      contract fields. Map to AC2-AC4.
+- [ ] `docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md`
+      and `05b-graduate-development-protocol.md`: add cross-links where release
+      evidence or integration branch graduation hands off to component release
+      preparation. Map to AC8.
+
+### Agent And Skill Guidance
+
+- [ ] `.agents/skills/prepare-release/SKILL.md`: require the agent to resolve
+      the component release target and evidence record before product release
+      mutation in workflow-hub mode. Map to AC1-AC8.
+- [ ] `.agents/skills/prepare-release/agents/openai.yaml`: keep command
+      metadata aligned if it contains behavior text for release ownership.
+      Map to AC1-AC8.
+- [ ] `docs/workflow/development-workflow/README.md` and
+      `scripts/development-workflow/README.md`: add short references to
+      component release routing only if the implementation adds new helper
+      commands that operators must discover from command tables. Map to AC1.
+
+---
+
+## Testing Strategy
+
+**Test types**: Unit-style shell/Python fixture tests, integration-style
+workflow command tests, and smoke/manual release runbook verification.
+
+**Key scenarios to test**:
+
+1. Single-repository release target resolution returns `single_repo_release`
+   and does not require a product repository selector. Maps to AC7.
+2. Workflow-hub component release with exactly one selected product repository
+   and valid release contract returns `component_release_routed`, product-owned
+   artifact owners, local checkout source, release base, branch pattern,
+   correlation key, and contract revision. Maps to AC1 and AC4.
+3. Missing, multiple, unknown, ambiguous, invalid-contract, and unavailable
+   checkout cases stop before branch, PR, tag, changelog, deployment, cleanup,
+   or tracker mutation and produce the canonical routing outcome code. Maps to
+   AC2 and AC3.
+4. Release cleanup with a matching evidence file validates repository identity,
+   release correlation key, and contract revision before product cleanup
+   mutation. Maps to AC5.
+5. Release cleanup with mismatched persisted evidence stops before mutation and
+   leaves hub tracker state unchanged. Maps to AC5 and AC6.
+6. Component release evidence validation accepts complete `pending`,
+   `completed`, `failed`, and `blocked` records, rejects invalid routing,
+   release, CI, deployment, and cleanup outcomes, and requires the hub tracker
+   reference. Maps to AC8.
+7. Prepare-release documentation preserves single-repository release and hotfix
+   behavior while adding workflow-hub product release target resolution. Maps to
+   AC7.
+
+**Smoke test runbook**:
+`docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md`
+
+**Regression suite**:
+
+- [ ] Extend `scripts/development-workflow/tests/test-workflow-config-resolver.sh`
+      for release contract revision/digest and local checkout separation.
+- [ ] Add `scripts/development-workflow/tests/test-component-release-target.sh`
+      for release target routing outcomes and fail-closed mutation boundaries.
+- [ ] Add `scripts/development-workflow/tests/test-component-release-evidence.sh`
+      for evidence record validation and deterministic JSON output.
+- [ ] Extend `scripts/development-workflow/tests/test-prepare-release-tracker-cleanup.sh`
+      for workflow-hub product release cleanup with matching and mismatched
+      evidence.
+- [ ] Extend `scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh`
+      for product checkout resolution and local-only config errors.
+- [ ] Extend `scripts/development-workflow/tests/test-workflow-agent-product-repo-guidance.sh`
+      and `scripts/development-workflow/tests/test-workflow-hub-docs.sh` for
+      mirrored prepare-release and documentation guidance.
+
+### Parser-Risk Addendum
+
+This plan is parser-risk because it introduces shell/JSON evidence validation,
+release branch/correlation parsing, and structured release target output.
+
+- **Edge-case enumeration**:
+  - Routing outcomes: each canonical routing outcome from the spec table, plus
+    invalid or missing outcome values.
+  - Release outcomes: `pending`, `completed`, `failed`, `blocked`, empty value,
+    and unknown value.
+  - CI outcomes: `pending`, `passed`, `failed`, `not_applicable`, empty value,
+    and unknown value.
+  - Deployment outcomes: `pending`, `recorded`, `failed`, `not_applicable`,
+    empty value, and unknown value.
+  - Cleanup outcomes: `not_started`, `partial`, `complete`, `blocked`, empty
+    value, and unknown value.
+  - Correlation identity: matching repository/correlation/revision values,
+    mismatched repository identity, mismatched correlation key, mismatched
+    contract revision, and missing persisted evidence.
+  - Branch pattern carry-through: default `release/v{version}`, product pattern
+    using `{product_repo}`, unknown placeholder, and unresolved placeholder.
+- **Unit test mapping**:
+  - `scripts/development-workflow/tests/test-component-release-target.sh`:
+    routing outcomes, local checkout availability, branch pattern carry-through,
+    and fail-closed mutation boundaries.
+  - `scripts/development-workflow/tests/test-component-release-evidence.sh`:
+    outcome enum validation, required field validation, deterministic JSON, and
+    persisted-target mismatch cases.
+  - `scripts/development-workflow/tests/test-prepare-release-tracker-cleanup.sh`:
+    cleanup evidence matching/mismatching and hub tracker mutation ordering.
+- **Suppression semantics**: Not applicable. This feature does not introduce
+  inline suppression directives.
+
+### Concurrent-Event-Source Addendum
+
+- **Shared mutable state guards**: Not applicable; helpers are synchronous
+  command-line tools with process-local state.
+- **Re-entrancy / in-flight tracking**: Not applicable; no long-running release
+  daemon or concurrent queue is introduced.
+- **Event deduplication**: Not applicable; no event source is introduced.
+- **Listener and resource cleanup**: Not applicable; no listeners, timers, or
+  handles are introduced.
+- **Race conditions at initialization**: Not applicable; helpers read current
+  file and GitHub state at invocation start.
+- **Race conditions at teardown**: Not applicable; cleanup runs as a bounded
+  command and exits.
+- **Error propagation across async boundaries**: Not applicable; scripts are
+  synchronous Bash/Python commands.
+
+---
+
+## Seed Data
+
+| Entity | Values / Scenario | File |
+| --- | --- | --- |
+| Workflow hub release config | Valid hub with two product repositories, one explicit release pattern, one default release pattern, and matching local-only checkout entries | Temporary fixtures in `test-component-release-target.sh` and `test-workflow-config-resolver.sh` |
+| Invalid release config | Missing selection, multiple selection, unknown product key, invalid artifact owner, forbidden local path in versioned contract | Temporary fixtures in `test-component-release-target.sh` |
+| Evidence records | Complete pending/completed/failed/blocked component release records plus invalid enum and missing-field variants | Temporary fixtures in `test-component-release-evidence.sh` |
+| Cleanup state | Matching and mismatched persisted repository identity, release correlation key, and contract revision | Temporary fixtures in `test-prepare-release-tracker-cleanup.sh` |
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md`
+      - component release target resolution, evidence, and fail-closed release
+      mutation behavior.
+- [ ] `docs/workflow/development-workflow/cross-repo-pr-flow.md` - selected
+      product release handoff and hub tracker reconciliation.
+- [ ] `docs/workflow/development-workflow/repository-modes.md` - release
+      routing outcomes, evidence record, and cleanup rerun contract.
+- [ ] `docs/workflow/development-workflow/workflow-hub-setup.md` - operator
+      setup and local checkout separation for component releases.
+- [ ] `docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md`
+      and `docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md`
+      - cross-links to component release evidence where release handoff applies.
+- [ ] `.agents/skills/prepare-release/SKILL.md` and, if behavior text changes,
+      `.agents/skills/prepare-release/agents/openai.yaml` - command guidance
+      for workflow-hub component releases.
+- [ ] `docs/workflow/development-workflow/README.md` and
+      `scripts/development-workflow/README.md` only if new helper commands need
+      command-table discoverability.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Release preparation and cleanup resolve different product targets | Med | High | Persist canonical repository identity, release correlation key, and contract revision during preparation; cleanup must validate all three before mutation. |
+| Product local checkout leaks into versioned release contract | Low | High | Reuse resolver forbidden-data checks and source local checkout only from local config. |
+| Evidence record becomes too loose for #1357 delivery bundles | Med | Med | Validate required fields and allowed outcome enums in `component-release-evidence.sh`; include smoke and unit tests for every outcome. |
+| Existing single-repository release flow regresses | Low | High | Keep `single_repo_release` as the first routing outcome and add tests that run without `--repo`. |
+| Release cleanup mutates hub tracker before product cleanup is confirmed | Med | High | Cleanup implementation order must perform product validation/cleanup first and update hub tracker only after product evidence is complete. |
+
+---
+
+## Code Samples
+
+No production code samples are included. Implementation should follow the
+existing Bash/Python helper style in `scripts/development-workflow/`.
+
+---
+
+## Implementation Order
+
+1. Extend resolver/release-target support:
+   - Add or expose contract revision/digest and normalized release target fields
+     through `workflow-config-resolver.py`.
+   - Add `component-release-target.sh` using the resolver as the only authority
+     for product keys, portable release fields, and local checkout source.
+   - Verify with focused fixtures before touching release cleanup.
+2. Add component release evidence:
+   - Add `component-release-evidence.sh`.
+   - Validate required fields and allowed enum values.
+   - Ensure output is deterministic JSON and includes the release correlation
+     key and hub tracker reference.
+3. Update release cleanup:
+   - Extend `prepare-release-post-merge-cleanup.sh` with product repository and
+     evidence-file options.
+   - Resolve product target before querying/deleting release branches.
+   - Validate persisted release target before mutation.
+   - Keep tracker release stamping hub-owned and after product cleanup
+     confirmation.
+4. Update prepare-release protocol and command guidance:
+   - Update `05-prepare-release-protocol.md` and `.agents/skills/prepare-release/SKILL.md`.
+   - Add command-table references only where new helpers need discoverability.
+5. Update workflow-hub documentation:
+   - Update repository modes, cross-repo PR flow, workflow hub setup, and
+     release handoff cross-links per **Documentation Updates**.
+6. Add and extend tests:
+   - Add target/evidence helper tests.
+   - Extend release cleanup, config resolver, product repo commands, docs, and
+     agent guidance tests.
+7. Run verification:
+   - `bash -n scripts/development-workflow/component-release-target.sh scripts/development-workflow/component-release-evidence.sh scripts/development-workflow/prepare-release-post-merge-cleanup.sh`
+   - `bash scripts/development-workflow/tests/test-component-release-target.sh`
+   - `bash scripts/development-workflow/tests/test-component-release-evidence.sh`
+   - `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`
+   - `bash scripts/development-workflow/tests/test-prepare-release-tracker-cleanup.sh`
+   - `bash scripts/development-workflow/tests/test-workflow-hub-product-repo-commands.sh`
+   - `bash scripts/development-workflow/tests/test-workflow-agent-product-repo-guidance.sh`
+   - `bash scripts/development-workflow/tests/test-workflow-hub-docs.sh`
+   - `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
+   - `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
+   - `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop-multi-repo-releases`
+   - `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop-multi-repo-releases`
+8. Update `CHANGELOG.md` under `[Unreleased]` during implementation with:
+   `- **Route component releases to selected product repositories** (#1356): Add workflow-hub component release routing, cleanup, and evidence handling for selected product repositories.`

--- a/docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md
+++ b/docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md
@@ -199,6 +199,9 @@ jq -e '.local_checkout.path | length > 0' "$TARGET_JSON"
 jq -e '.release_base | length > 0' "$TARGET_JSON"
 jq -e '.release_branch_pattern | length > 0' "$TARGET_JSON"
 jq -e '.artifact_owners.release == "product_repository"' "$TARGET_JSON"
+jq -e '.artifact_owners.ci == "product_repository"' "$TARGET_JSON"
+jq -e '.artifact_owners.deployment == "product_repository"' "$TARGET_JSON"
+jq -e '.artifact_owners.cleanup == "product_repository"' "$TARGET_JSON"
 jq -e '.artifact_owners.tracker == "hub_repository"' "$TARGET_JSON"
 jq -e '.release_correlation_key | length > 0' "$TARGET_JSON"
 jq -e '.contract_revision | length > 0' "$TARGET_JSON"
@@ -291,7 +294,7 @@ scripts/development-workflow/component-release-evidence.sh \
   --ci-outcome pending \
   --deployment-outcome not_applicable \
   --cleanup-outcome not_started \
-  --hub-tracker-ref "fixture:1356-smoke" \
+  --hub-tracker-ref "$TEST_TRACKER_ISSUE" \
   --json > "$EVIDENCE_JSON"
 
 TARGET_REPOSITORY="$(jq -r '.canonical_repository_identity' "$TARGET_JSON")"
@@ -305,7 +308,8 @@ jq -e --arg value "$TARGET_CORRELATION" \
 jq -e --arg value "$TARGET_REVISION" \
   '.contract_revision == $value' "$EVIDENCE_JSON"
 jq -e '.routing_outcome == "component_release_routed"' "$EVIDENCE_JSON"
-jq -e '.hub_tracker_ref == "fixture:1356-smoke"' "$EVIDENCE_JSON"
+jq --arg expected "$TEST_TRACKER_ISSUE" \
+  -e '.hub_tracker_ref == $expected' "$EVIDENCE_JSON"
 
 scripts/development-workflow/component-release-evidence.sh \
   --target-file "$TARGET_JSON" \
@@ -313,7 +317,7 @@ scripts/development-workflow/component-release-evidence.sh \
   --ci-outcome pending \
   --deployment-outcome not_applicable \
   --cleanup-outcome not_started \
-  --hub-tracker-ref "fixture:1356-smoke" \
+  --hub-tracker-ref "$TEST_TRACKER_ISSUE" \
   --json > "$EVIDENCE_DUPLICATE_JSON"
 
 cmp "$EVIDENCE_JSON" "$EVIDENCE_DUPLICATE_JSON"
@@ -326,7 +330,7 @@ do
     --ci-outcome passed \
     --deployment-outcome recorded \
     --cleanup-outcome complete \
-    --hub-tracker-ref "fixture:1356-smoke" \
+    --hub-tracker-ref "$TEST_TRACKER_ISSUE" \
     --json > "$SMOKE_TMP/${release_outcome}-evidence.json"
 
   jq -e --arg value "$release_outcome" \
@@ -345,7 +349,7 @@ do
     --ci-outcome pending \
     --deployment-outcome not_applicable \
     --cleanup-outcome not_started \
-    --hub-tracker-ref "fixture:1356-smoke" \
+    --hub-tracker-ref "$TEST_TRACKER_ISSUE" \
     --json > "$MISMATCH_OUTPUT"
   then
     echo "mismatched evidence was accepted: $mismatch" >&2
@@ -367,7 +371,7 @@ if scripts/development-workflow/component-release-evidence.sh \
   --ci-outcome pending \
   --deployment-outcome not_applicable \
   --cleanup-outcome not_started \
-  --hub-tracker-ref "fixture:1356-smoke" \
+  --hub-tracker-ref "$TEST_TRACKER_ISSUE" \
   --json > "$SMOKE_TMP/invalid-evidence.json"
 then
   echo "invalid evidence was accepted" >&2

--- a/docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md
+++ b/docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md
@@ -17,6 +17,8 @@ Before running every scenario:
 - [ ] Hub tracker mutation uses a mocked tracker or disposable fixture issue.
       The smoke test must reject live work-item references unless the operator
       passes an explicit destructive-test option supported by the implementation.
+- [ ] Run all command blocks below in the same Bash shell after **Fixture Setup**
+      so the guarded temporary directory and exported variables are shared.
 
 Before Step 1:
 
@@ -46,6 +48,76 @@ Before Steps 2 through 5:
 
 ---
 
+## Fixture Setup
+
+Run this setup once. It creates an owned temporary directory, loads the
+single-repository and workflow-hub fixtures, and records the exact paths and
+test-only tracker state used by later scenarios.
+
+```bash
+set -euo pipefail
+
+SMOKE_TMP="$(mktemp -d "${TMPDIR:-/tmp}/1356-component-release.XXXXXX")"
+cleanup_smoke_tmp() {
+  case "$(basename "${SMOKE_TMP:-}")" in
+    1356-component-release.*)
+      [ -d "$SMOKE_TMP" ] && rm -rf "$SMOKE_TMP"
+      ;;
+  esac
+}
+trap cleanup_smoke_tmp EXIT
+
+FIXTURE_JSON="$SMOKE_TMP/fixtures.json"
+
+bash scripts/development-workflow/tests/setup-component-release-fixture.sh \
+  --work-dir "$SMOKE_TMP" \
+  --json > "$FIXTURE_JSON"
+
+export SMOKE_TMP FIXTURE_JSON
+export SINGLE_REPO_FIXTURE
+export HUB_FIXTURE PRODUCT_REPO_KEY ALT_PRODUCT_REPO_KEY PRODUCT_REPO_PATH
+export RELEASE_VERSION TEST_TRACKER_ISSUE TRACKER_STATE_FILE
+
+SINGLE_REPO_FIXTURE="$(jq -r '.single_repo.path' "$FIXTURE_JSON")"
+HUB_FIXTURE="$(jq -r '.workflow_hub.path' "$FIXTURE_JSON")"
+PRODUCT_REPO_KEY="$(jq -r '.workflow_hub.selected_product_repo_key' "$FIXTURE_JSON")"
+ALT_PRODUCT_REPO_KEY="$(jq -r '.workflow_hub.alternate_product_repo_key' "$FIXTURE_JSON")"
+PRODUCT_REPO_PATH="$(jq -r '.workflow_hub.selected_product_repo_path' "$FIXTURE_JSON")"
+RELEASE_VERSION="$(jq -r '.release.version' "$FIXTURE_JSON")"
+TEST_TRACKER_ISSUE="$(jq -r '.tracker.issue' "$FIXTURE_JSON")"
+TRACKER_STATE_FILE="$(jq -r '.tracker.state_file' "$FIXTURE_JSON")"
+
+jq -e '.workflow_hub.product_repos | length >= 2' "$FIXTURE_JSON"
+jq --arg expected "$PRODUCT_REPO_KEY" \
+  -e '.workflow_hub.product_repos | index($expected)' "$FIXTURE_JSON"
+jq --arg expected "$ALT_PRODUCT_REPO_KEY" \
+  -e '.workflow_hub.product_repos | index($expected)' "$FIXTURE_JSON"
+jq --arg expected "$PRODUCT_REPO_PATH" \
+  -e '.workflow_hub.local_paths[$expected] == true' "$FIXTURE_JSON"
+jq -e '.workflow_hub.release_contract.branch_pattern | length > 0' "$FIXTURE_JSON"
+jq -e '.invalid_fixtures | keys | length >= 6' "$FIXTURE_JSON"
+jq -e '.evidence_mismatch_fixtures | keys | length >= 5' "$FIXTURE_JSON"
+jq -e '.cleanup.seeded_branch == true' "$FIXTURE_JSON"
+jq -e '.cleanup.seeded_tag == true' "$FIXTURE_JSON"
+jq -e '.cleanup.seeded_lock == true' "$FIXTURE_JSON"
+
+case "$TEST_TRACKER_ISSUE" in
+  test:*|mock:*|fixture:*) ;;
+  *)
+    echo "refusing live tracker issue: $TEST_TRACKER_ISSUE" >&2
+    exit 1
+    ;;
+esac
+
+test -d "$SINGLE_REPO_FIXTURE/.git"
+test -d "$HUB_FIXTURE/.git"
+test -d "$PRODUCT_REPO_PATH/.git"
+test -f "$TRACKER_STATE_FILE"
+test -z "$(git -C "$PRODUCT_REPO_PATH" status --porcelain)"
+```
+
+---
+
 ## Smoke Test Steps
 
 ### Step 1: Validate single-repository compatibility
@@ -59,10 +131,12 @@ Before Steps 2 through 5:
 4. Confirm no product repository selector is required.
 
 ```bash
-SINGLE_REPO_FIXTURE="/tmp/1356-single-repo"
-TARGET_JSON="/tmp/1356-single-repo-target.json"
-SINGLE_REPO_STATUS_BEFORE="/tmp/1356-single-repo-status-before.txt"
-SINGLE_REPO_STATUS_AFTER="/tmp/1356-single-repo-status-after.txt"
+set -euo pipefail
+: "${SMOKE_TMP:?run fixture setup first}"
+
+TARGET_JSON="$SMOKE_TMP/single-repo-target.json"
+SINGLE_REPO_STATUS_BEFORE="$SMOKE_TMP/single-repo-status-before.txt"
+SINGLE_REPO_STATUS_AFTER="$SMOKE_TMP/single-repo-status-after.txt"
 
 test -d "$SINGLE_REPO_FIXTURE/.git"
 git -C "$SINGLE_REPO_FIXTURE" status --porcelain \
@@ -98,11 +172,12 @@ not require workflow-hub product selection.
    and `contract_revision`.
 
 ```bash
-HUB_FIXTURE="/tmp/1356-workflow-hub"
-PRODUCT_REPO_KEY="mobile-app"
-TARGET_JSON="/tmp/1356-component-target.json"
-HUB_STATUS_BEFORE="/tmp/1356-hub-status-before.txt"
-HUB_STATUS_AFTER="/tmp/1356-hub-status-after.txt"
+set -euo pipefail
+: "${SMOKE_TMP:?run fixture setup first}"
+
+TARGET_JSON="$SMOKE_TMP/component-target.json"
+HUB_STATUS_BEFORE="$SMOKE_TMP/hub-status-before.txt"
+HUB_STATUS_AFTER="$SMOKE_TMP/hub-status-after.txt"
 
 test -d "$HUB_FIXTURE/.git"
 git -C "$HUB_FIXTURE" status --porcelain > "$HUB_STATUS_BEFORE"
@@ -117,7 +192,8 @@ git -C "$HUB_FIXTURE" status --porcelain > "$HUB_STATUS_AFTER"
 PRODUCT_REPO_PATH="$(jq -r '.local_checkout.path' "$TARGET_JSON")"
 
 jq -e '.routing_outcome == "component_release_routed"' "$TARGET_JSON"
-jq -e '.selected_product_repo_key == env.PRODUCT_REPO_KEY' "$TARGET_JSON"
+jq --arg expected "$PRODUCT_REPO_KEY" \
+  -e '.selected_product_repo_key == $expected' "$TARGET_JSON"
 jq -e '.canonical_repository_identity | length > 0' "$TARGET_JSON"
 jq -e '.local_checkout.path | length > 0' "$TARGET_JSON"
 jq -e '.release_base | length > 0' "$TARGET_JSON"
@@ -148,52 +224,35 @@ product repository, while tracker reconciliation remains hub-owned.
    unavailable.
 
 ```bash
-HUB_FIXTURE="/tmp/1356-workflow-hub"
+set -euo pipefail
+: "${SMOKE_TMP:?run fixture setup first}"
 
-for fixture in \
-  missing-product-selection \
-  multiple-product-targets \
-  unknown-product-repository \
-  ambiguous-product-selection \
-  invalid-release-contract \
-  unavailable-product-repository-checkout
+while read -r fixture expected
 do
-  TARGET_JSON="/tmp/1356-${fixture}.json"
+  FIXTURE_ROOT="$(jq -r --arg key "$fixture" \
+    '.invalid_fixtures[$key]' "$FIXTURE_JSON")"
+  TARGET_JSON="$SMOKE_TMP/${fixture}.json"
 
   scripts/development-workflow/component-release-target.sh \
-    --repo-root "$HUB_FIXTURE/fixtures/$fixture" \
+    --repo-root "$FIXTURE_ROOT" \
     --require-local \
     --json > "$TARGET_JSON"
 
-  case "$fixture" in
-    missing-product-selection)
-      jq -e '.routing_outcome == "missing_product_selection"' "$TARGET_JSON"
-      ;;
-    multiple-product-targets)
-      jq -e '.routing_outcome == "multiple_product_targets"' "$TARGET_JSON"
-      ;;
-    unknown-product-repository)
-      jq -e '.routing_outcome == "unknown_product_repository"' "$TARGET_JSON"
-      ;;
-    ambiguous-product-selection)
-      jq -e '.routing_outcome == "ambiguous_product_selection"' "$TARGET_JSON"
-      ;;
-    invalid-release-contract)
-      jq -e '.routing_outcome == "invalid_release_contract"' "$TARGET_JSON"
-      ;;
-    unavailable-product-repository-checkout)
-      jq -e \
-        '.routing_outcome == "unavailable_product_repository_checkout"' \
-        "$TARGET_JSON"
-      ;;
-  esac
-
+  jq --arg expected "$expected" \
+    -e '.routing_outcome == $expected' "$TARGET_JSON"
   jq -e '.mutation_allowed == false' "$TARGET_JSON"
-done
+done <<'CASES'
+missing_product_selection missing_product_selection
+multiple_product_targets multiple_product_targets
+unknown_product_repository unknown_product_repository
+ambiguous_product_selection ambiguous_product_selection
+invalid_release_contract invalid_release_contract
+unavailable_product_repository_checkout unavailable_product_repository_checkout
+CASES
 
 if scripts/development-workflow/component-release-target.sh \
-  --repo-root "$HUB_FIXTURE/fixtures/malformed" \
-  --json > /tmp/1356-malformed-target.json
+  --repo-root "$(jq -r '.invalid_fixtures.malformed' "$FIXTURE_JSON")" \
+  --json > "$SMOKE_TMP/malformed-target.json"
 then
   echo "malformed target input was accepted" >&2
   exit 1
@@ -219,8 +278,12 @@ canonical routing outcome: `missing_product_selection`,
 4. Try an invalid outcome value and a missing required field.
 
 ```bash
-TARGET_JSON="/tmp/1356-component-target.json"
-EVIDENCE_JSON="/tmp/1356-component-evidence.json"
+set -euo pipefail
+: "${SMOKE_TMP:?run fixture setup first}"
+
+TARGET_JSON="$SMOKE_TMP/component-target.json"
+EVIDENCE_JSON="$SMOKE_TMP/component-evidence.json"
+EVIDENCE_DUPLICATE_JSON="$SMOKE_TMP/component-evidence-duplicate.json"
 
 scripts/development-workflow/component-release-evidence.sh \
   --target-file "$TARGET_JSON" \
@@ -244,6 +307,17 @@ jq -e --arg value "$TARGET_REVISION" \
 jq -e '.routing_outcome == "component_release_routed"' "$EVIDENCE_JSON"
 jq -e '.hub_tracker_ref == "fixture:1356-smoke"' "$EVIDENCE_JSON"
 
+scripts/development-workflow/component-release-evidence.sh \
+  --target-file "$TARGET_JSON" \
+  --release-outcome pending \
+  --ci-outcome pending \
+  --deployment-outcome not_applicable \
+  --cleanup-outcome not_started \
+  --hub-tracker-ref "fixture:1356-smoke" \
+  --json > "$EVIDENCE_DUPLICATE_JSON"
+
+cmp "$EVIDENCE_JSON" "$EVIDENCE_DUPLICATE_JSON"
+
 for release_outcome in completed failed blocked
 do
   scripts/development-workflow/component-release-evidence.sh \
@@ -253,11 +327,39 @@ do
     --deployment-outcome recorded \
     --cleanup-outcome complete \
     --hub-tracker-ref "fixture:1356-smoke" \
-    --json > "/tmp/1356-${release_outcome}-evidence.json"
+    --json > "$SMOKE_TMP/${release_outcome}-evidence.json"
 
   jq -e --arg value "$release_outcome" \
-    '.release_outcome == $value' "/tmp/1356-${release_outcome}-evidence.json"
+    '.release_outcome == $value' "$SMOKE_TMP/${release_outcome}-evidence.json"
 done
+
+while read -r mismatch
+do
+  MISMATCH_TARGET="$(jq -r --arg key "$mismatch" \
+    '.evidence_mismatch_fixtures[$key]' "$FIXTURE_JSON")"
+  MISMATCH_OUTPUT="$SMOKE_TMP/${mismatch}-accepted-evidence.json"
+
+  if scripts/development-workflow/component-release-evidence.sh \
+    --target-file "$MISMATCH_TARGET" \
+    --release-outcome pending \
+    --ci-outcome pending \
+    --deployment-outcome not_applicable \
+    --cleanup-outcome not_started \
+    --hub-tracker-ref "fixture:1356-smoke" \
+    --json > "$MISMATCH_OUTPUT"
+  then
+    echo "mismatched evidence was accepted: $mismatch" >&2
+    exit 1
+  fi
+
+  test ! -s "$MISMATCH_OUTPUT"
+done <<'MISMATCHES'
+repository_key
+canonical_repository_identity
+artifact_owner
+release_correlation_key
+contract_revision
+MISMATCHES
 
 if scripts/development-workflow/component-release-evidence.sh \
   --target-file "$TARGET_JSON" \
@@ -266,7 +368,7 @@ if scripts/development-workflow/component-release-evidence.sh \
   --deployment-outcome not_applicable \
   --cleanup-outcome not_started \
   --hub-tracker-ref "fixture:1356-smoke" \
-  --json > /tmp/1356-invalid-evidence.json
+  --json > "$SMOKE_TMP/invalid-evidence.json"
 then
   echo "invalid evidence was accepted" >&2
   exit 1
@@ -292,31 +394,43 @@ invalid or incomplete records are rejected with a clear error.
    contract revision differs from the current target.
 
 ```bash
-HUB_FIXTURE="/tmp/1356-workflow-hub"
-PRODUCT_REPO_KEY="mobile-app"
-TARGET_JSON="/tmp/1356-component-target.json"
-EVIDENCE_JSON="/tmp/1356-component-evidence.json"
-TEST_TRACKER_REF="fixture:1356-smoke"
-TEST_TRACKER_ISSUE="fixture-1356-smoke"
-CLEANUP_JSON="/tmp/1356-cleanup-output.json"
-CLEANUP_RERUN_JSON="/tmp/1356-cleanup-rerun-output.json"
-PRODUCT_REPO_PATH="$(jq -r '.local_checkout.path' "$TARGET_JSON")"
-RELEASE_BRANCH="release/v9.9.9-test"
+set -euo pipefail
+: "${SMOKE_TMP:?run fixture setup first}"
 
-case "$TEST_TRACKER_REF" in
+TARGET_JSON="$SMOKE_TMP/component-target.json"
+EVIDENCE_JSON="$SMOKE_TMP/component-evidence.json"
+CLEANUP_JSON="$SMOKE_TMP/cleanup-output.json"
+CLEANUP_RERUN_JSON="$SMOKE_TMP/cleanup-rerun-output.json"
+PRODUCT_STATE_BEFORE="$SMOKE_TMP/product-state-before.txt"
+PRODUCT_STATE_AFTER_REJECT="$SMOKE_TMP/product-state-after-reject.txt"
+TRACKER_STATE_BEFORE_REJECT="$SMOKE_TMP/tracker-before-reject.json"
+TRACKER_STATE_AFTER_REJECT="$SMOKE_TMP/tracker-after-reject.json"
+PRODUCT_REPO_PATH="$(jq -r '.local_checkout.path' "$TARGET_JSON")"
+RELEASE_BRANCH_PATTERN="$(jq -r '.release_branch_pattern' "$TARGET_JSON")"
+RELEASE_BRANCH="${RELEASE_BRANCH_PATTERN//\{version\}/$RELEASE_VERSION}"
+RELEASE_BRANCH="${RELEASE_BRANCH//\{product_repo\}/$PRODUCT_REPO_KEY}"
+RELEASE_TAG="v$RELEASE_VERSION"
+
+case "$TEST_TRACKER_ISSUE" in
   test:*|mock:*|fixture:*) ;;
   *)
-    echo "refusing live tracker reference: $TEST_TRACKER_REF" >&2
+    echo "refusing live tracker issue: $TEST_TRACKER_ISSUE" >&2
     exit 1
     ;;
 esac
+
+git -C "$PRODUCT_REPO_PATH" ls-remote --exit-code --heads origin \
+  "$RELEASE_BRANCH" > "$SMOKE_TMP/pre-cleanup-branch.txt"
+git -C "$PRODUCT_REPO_PATH" ls-remote --exit-code --tags origin \
+  "refs/tags/$RELEASE_TAG" > "$SMOKE_TMP/pre-cleanup-tag.txt"
+git -C "$PRODUCT_REPO_PATH" ls-remote --heads --tags origin \
+  > "$PRODUCT_STATE_BEFORE"
 
 scripts/development-workflow/prepare-release-post-merge-cleanup.sh \
   --repo "$PRODUCT_REPO_KEY" \
   --repo-root "$HUB_FIXTURE" \
   --evidence-file "$EVIDENCE_JSON" \
   --issues "$TEST_TRACKER_ISSUE" \
-  --best-effort \
   --json > "$CLEANUP_JSON"
 
 scripts/development-workflow/prepare-release-post-merge-cleanup.sh \
@@ -324,29 +438,47 @@ scripts/development-workflow/prepare-release-post-merge-cleanup.sh \
   --repo-root "$HUB_FIXTURE" \
   --evidence-file "$EVIDENCE_JSON" \
   --issues "$TEST_TRACKER_ISSUE" \
-  --best-effort \
   --json > "$CLEANUP_RERUN_JSON"
 
 jq -e '.cleanup_outcome == "complete"' "$CLEANUP_JSON"
 jq -e '.tracker_mutation.repository_owner == "hub_repository"' "$CLEANUP_JSON"
-jq -e '.tracker_mutation.issue == env.TEST_TRACKER_ISSUE' "$CLEANUP_JSON"
-jq -e '.product_cleanup.repository_key == env.PRODUCT_REPO_KEY' "$CLEANUP_JSON"
+jq --arg expected "$TEST_TRACKER_ISSUE" \
+  -e '.tracker_mutation.issue == $expected' "$CLEANUP_JSON"
+jq --arg expected "$PRODUCT_REPO_KEY" \
+  -e '.product_cleanup.repository_key == $expected' "$CLEANUP_JSON"
+jq -e '.cleanup_lock.owner | length > 0' "$CLEANUP_JSON"
+jq -e '.cleanup_lock.release_correlation_key | length > 0' "$CLEANUP_JSON"
+jq -e '.product_cleanup.remote_branch_deleted == true' "$CLEANUP_JSON"
+jq -e '.product_cleanup.remote_tag_deleted == true' "$CLEANUP_JSON"
+jq -e '.cleanup_evidence.status == "complete"' "$CLEANUP_JSON"
+jq -e '.tracker_mutation.after_product_cleanup == true' "$CLEANUP_JSON"
 jq -e '.product_cleanup.already_complete == true' "$CLEANUP_RERUN_JSON"
 test -z "$(git -C "$PRODUCT_REPO_PATH" status --porcelain)"
 ! git -C "$PRODUCT_REPO_PATH" ls-remote --exit-code --heads origin \
   "$RELEASE_BRANCH"
+! git -C "$PRODUCT_REPO_PATH" ls-remote --exit-code --tags origin \
+  "refs/tags/$RELEASE_TAG"
+
+git -C "$PRODUCT_REPO_PATH" ls-remote --heads --tags origin \
+  > "$PRODUCT_STATE_BEFORE"
+cp "$TRACKER_STATE_FILE" "$TRACKER_STATE_BEFORE_REJECT"
 
 if scripts/development-workflow/prepare-release-post-merge-cleanup.sh \
   --repo "$PRODUCT_REPO_KEY" \
   --repo-root "$HUB_FIXTURE" \
-  --evidence-file "/tmp/1356-mismatched-evidence.json" \
+  --evidence-file "$(jq -r '.cleanup.mismatched_evidence_file' "$FIXTURE_JSON")" \
   --issues "$TEST_TRACKER_ISSUE" \
-  --best-effort \
-  --json > /tmp/1356-mismatched-cleanup.json
+  --json > "$SMOKE_TMP/mismatched-cleanup.json"
 then
   echo "mismatched evidence cleanup was accepted" >&2
   exit 1
 fi
+
+git -C "$PRODUCT_REPO_PATH" ls-remote --heads --tags origin \
+  > "$PRODUCT_STATE_AFTER_REJECT"
+cp "$TRACKER_STATE_FILE" "$TRACKER_STATE_AFTER_REJECT"
+cmp "$PRODUCT_STATE_BEFORE" "$PRODUCT_STATE_AFTER_REJECT"
+cmp "$TRACKER_STATE_BEFORE_REJECT" "$TRACKER_STATE_AFTER_REJECT"
 ```
 
 **Expected result**: Matching evidence allows safe rerunnable cleanup;
@@ -358,7 +490,8 @@ mismatched evidence stops before product or hub tracker mutation.
 - Remove any temporary fixture files or test branches created for the smoke run.
 
 ```bash
-rm -f /tmp/1356-*.json /tmp/1356-*.txt
+set -euo pipefail
+: "${SMOKE_TMP:?run fixture setup first}"
 
 for repo in "$SINGLE_REPO_FIXTURE" "$HUB_FIXTURE" "$PRODUCT_REPO_PATH"
 do
@@ -366,6 +499,9 @@ do
     test -z "$(git -C "$repo" status --porcelain)"
   fi
 done
+
+cleanup_smoke_tmp
+trap - EXIT
 ```
 
 ---

--- a/docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md
+++ b/docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md
@@ -67,6 +67,56 @@ cleanup_smoke_tmp() {
 }
 trap cleanup_smoke_tmp EXIT
 
+real_path() {
+  python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$1"
+}
+
+require_owned_path() {
+  candidate="$1"
+  test -e "$candidate"
+  resolved_candidate="$(real_path "$candidate")"
+  resolved_root="$(real_path "$SMOKE_TMP")"
+  case "$resolved_candidate" in
+    "$resolved_root"/*) ;;
+    *)
+      echo "fixture path escapes SMOKE_TMP: $candidate" >&2
+      exit 1
+      ;;
+  esac
+}
+
+require_clean_git() {
+  repo_path="$1"
+  status_file="$2"
+  git -C "$repo_path" status --porcelain > "$status_file"
+  test ! -s "$status_file"
+}
+
+expect_no_remote_ref() {
+  repo_path="$1"
+  ref_kind="$2"
+  ref_name="$3"
+  output_file="$4"
+
+  set +e
+  git -C "$repo_path" ls-remote --exit-code "$ref_kind" origin "$ref_name" \
+    > "$output_file"
+  status=$?
+  set -e
+
+  case "$status" in
+    2) ;;
+    0)
+      echo "remote ref still exists: $ref_kind $ref_name" >&2
+      exit 1
+      ;;
+    *)
+      echo "remote ref check failed with status $status: $ref_kind $ref_name" >&2
+      exit "$status"
+      ;;
+  esac
+}
+
 FIXTURE_JSON="$SMOKE_TMP/fixtures.json"
 
 bash scripts/development-workflow/tests/setup-component-release-fixture.sh \
@@ -100,6 +150,8 @@ jq -e '.evidence_mismatch_fixtures | keys | length >= 5' "$FIXTURE_JSON"
 jq -e '.cleanup.seeded_branch == true' "$FIXTURE_JSON"
 jq -e '.cleanup.seeded_tag == true' "$FIXTURE_JSON"
 jq -e '.cleanup.seeded_lock == true' "$FIXTURE_JSON"
+jq -e '.invalid_fixtures.malformed | length > 0' "$FIXTURE_JSON"
+jq -e '.cleanup.mismatched_evidence_file | length > 0' "$FIXTURE_JSON"
 
 case "$TEST_TRACKER_ISSUE" in
   test:*|mock:*|fixture:*) ;;
@@ -113,7 +165,12 @@ test -d "$SINGLE_REPO_FIXTURE/.git"
 test -d "$HUB_FIXTURE/.git"
 test -d "$PRODUCT_REPO_PATH/.git"
 test -f "$TRACKER_STATE_FILE"
-test -z "$(git -C "$PRODUCT_REPO_PATH" status --porcelain)"
+require_owned_path "$SINGLE_REPO_FIXTURE"
+require_owned_path "$HUB_FIXTURE"
+require_owned_path "$PRODUCT_REPO_PATH"
+require_owned_path "$TRACKER_STATE_FILE"
+require_owned_path "$(jq -r '.cleanup.mismatched_evidence_file' "$FIXTURE_JSON")"
+require_clean_git "$PRODUCT_REPO_PATH" "$SMOKE_TMP/product-status.txt"
 ```
 
 ---
@@ -176,6 +233,7 @@ set -euo pipefail
 : "${SMOKE_TMP:?run fixture setup first}"
 
 TARGET_JSON="$SMOKE_TMP/component-target.json"
+TARGET_BINDING_JSON="$SMOKE_TMP/component-target-binding.json"
 HUB_STATUS_BEFORE="$SMOKE_TMP/hub-status-before.txt"
 HUB_STATUS_AFTER="$SMOKE_TMP/hub-status-after.txt"
 
@@ -190,6 +248,8 @@ scripts/development-workflow/component-release-target.sh \
 
 git -C "$HUB_FIXTURE" status --porcelain > "$HUB_STATUS_AFTER"
 PRODUCT_REPO_PATH="$(jq -r '.local_checkout.path' "$TARGET_JSON")"
+require_owned_path "$PRODUCT_REPO_PATH"
+cp "$TARGET_JSON" "$TARGET_BINDING_JSON"
 
 jq -e '.routing_outcome == "component_release_routed"' "$TARGET_JSON"
 jq --arg expected "$PRODUCT_REPO_KEY" \
@@ -206,7 +266,7 @@ jq -e '.artifact_owners.tracker == "hub_repository"' "$TARGET_JSON"
 jq -e '.release_correlation_key | length > 0' "$TARGET_JSON"
 jq -e '.contract_revision | length > 0' "$TARGET_JSON"
 test -d "$PRODUCT_REPO_PATH/.git"
-test -z "$(git -C "$PRODUCT_REPO_PATH" status --porcelain)"
+require_clean_git "$PRODUCT_REPO_PATH" "$SMOKE_TMP/product-status-after-target.txt"
 cmp "$HUB_STATUS_BEFORE" "$HUB_STATUS_AFTER"
 ```
 
@@ -235,11 +295,16 @@ do
   FIXTURE_ROOT="$(jq -r --arg key "$fixture" \
     '.invalid_fixtures[$key]' "$FIXTURE_JSON")"
   TARGET_JSON="$SMOKE_TMP/${fixture}.json"
+  require_owned_path "$FIXTURE_ROOT"
 
-  scripts/development-workflow/component-release-target.sh \
+  if ! scripts/development-workflow/component-release-target.sh \
     --repo-root "$FIXTURE_ROOT" \
     --require-local \
     --json > "$TARGET_JSON"
+  then
+    echo "classified stop outcome returned nonzero: $fixture" >&2
+    exit 1
+  fi
 
   jq --arg expected "$expected" \
     -e '.routing_outcome == $expected' "$TARGET_JSON"
@@ -253,8 +318,11 @@ invalid_release_contract invalid_release_contract
 unavailable_product_repository_checkout unavailable_product_repository_checkout
 CASES
 
+MALFORMED_FIXTURE_ROOT="$(jq -r '.invalid_fixtures.malformed' "$FIXTURE_JSON")"
+require_owned_path "$MALFORMED_FIXTURE_ROOT"
+
 if scripts/development-workflow/component-release-target.sh \
-  --repo-root "$(jq -r '.invalid_fixtures.malformed' "$FIXTURE_JSON")" \
+  --repo-root "$MALFORMED_FIXTURE_ROOT" \
   --json > "$SMOKE_TMP/malformed-target.json"
 then
   echo "malformed target input was accepted" >&2
@@ -285,11 +353,13 @@ set -euo pipefail
 : "${SMOKE_TMP:?run fixture setup first}"
 
 TARGET_JSON="$SMOKE_TMP/component-target.json"
+TARGET_BINDING_JSON="$SMOKE_TMP/component-target-binding.json"
 EVIDENCE_JSON="$SMOKE_TMP/component-evidence.json"
 EVIDENCE_DUPLICATE_JSON="$SMOKE_TMP/component-evidence-duplicate.json"
 
 scripts/development-workflow/component-release-evidence.sh \
   --target-file "$TARGET_JSON" \
+  --binding-file "$TARGET_BINDING_JSON" \
   --release-outcome pending \
   --ci-outcome pending \
   --deployment-outcome not_applicable \
@@ -313,6 +383,7 @@ jq --arg expected "$TEST_TRACKER_ISSUE" \
 
 scripts/development-workflow/component-release-evidence.sh \
   --target-file "$TARGET_JSON" \
+  --binding-file "$TARGET_BINDING_JSON" \
   --release-outcome pending \
   --ci-outcome pending \
   --deployment-outcome not_applicable \
@@ -326,6 +397,7 @@ for release_outcome in completed failed blocked
 do
   scripts/development-workflow/component-release-evidence.sh \
     --target-file "$TARGET_JSON" \
+    --binding-file "$TARGET_BINDING_JSON" \
     --release-outcome "$release_outcome" \
     --ci-outcome passed \
     --deployment-outcome recorded \
@@ -342,9 +414,11 @@ do
   MISMATCH_TARGET="$(jq -r --arg key "$mismatch" \
     '.evidence_mismatch_fixtures[$key]' "$FIXTURE_JSON")"
   MISMATCH_OUTPUT="$SMOKE_TMP/${mismatch}-accepted-evidence.json"
+  require_owned_path "$MISMATCH_TARGET"
 
   if scripts/development-workflow/component-release-evidence.sh \
     --target-file "$MISMATCH_TARGET" \
+    --binding-file "$TARGET_BINDING_JSON" \
     --release-outcome pending \
     --ci-outcome pending \
     --deployment-outcome not_applicable \
@@ -367,6 +441,7 @@ MISMATCHES
 
 if scripts/development-workflow/component-release-evidence.sh \
   --target-file "$TARGET_JSON" \
+  --binding-file "$TARGET_BINDING_JSON" \
   --release-outcome invalid \
   --ci-outcome pending \
   --deployment-outcome not_applicable \
@@ -410,6 +485,9 @@ PRODUCT_STATE_AFTER_REJECT="$SMOKE_TMP/product-state-after-reject.txt"
 TRACKER_STATE_BEFORE_REJECT="$SMOKE_TMP/tracker-before-reject.json"
 TRACKER_STATE_AFTER_REJECT="$SMOKE_TMP/tracker-after-reject.json"
 PRODUCT_REPO_PATH="$(jq -r '.local_checkout.path' "$TARGET_JSON")"
+require_owned_path "$PRODUCT_REPO_PATH"
+MISMATCHED_EVIDENCE_FILE="$(jq -r '.cleanup.mismatched_evidence_file' "$FIXTURE_JSON")"
+require_owned_path "$MISMATCHED_EVIDENCE_FILE"
 RELEASE_BRANCH_PATTERN="$(jq -r '.release_branch_pattern' "$TARGET_JSON")"
 RELEASE_BRANCH="${RELEASE_BRANCH_PATTERN//\{version\}/$RELEASE_VERSION}"
 RELEASE_BRANCH="${RELEASE_BRANCH//\{product_repo\}/$PRODUCT_REPO_KEY}"
@@ -457,11 +535,11 @@ jq -e '.product_cleanup.remote_tag_deleted == true' "$CLEANUP_JSON"
 jq -e '.cleanup_evidence.status == "complete"' "$CLEANUP_JSON"
 jq -e '.tracker_mutation.after_product_cleanup == true' "$CLEANUP_JSON"
 jq -e '.product_cleanup.already_complete == true' "$CLEANUP_RERUN_JSON"
-test -z "$(git -C "$PRODUCT_REPO_PATH" status --porcelain)"
-! git -C "$PRODUCT_REPO_PATH" ls-remote --exit-code --heads origin \
-  "$RELEASE_BRANCH"
-! git -C "$PRODUCT_REPO_PATH" ls-remote --exit-code --tags origin \
-  "refs/tags/$RELEASE_TAG"
+require_clean_git "$PRODUCT_REPO_PATH" "$SMOKE_TMP/product-status-after-cleanup.txt"
+expect_no_remote_ref "$PRODUCT_REPO_PATH" --heads "$RELEASE_BRANCH" \
+  "$SMOKE_TMP/post-cleanup-branch.txt"
+expect_no_remote_ref "$PRODUCT_REPO_PATH" --tags "refs/tags/$RELEASE_TAG" \
+  "$SMOKE_TMP/post-cleanup-tag.txt"
 
 git -C "$PRODUCT_REPO_PATH" ls-remote --heads --tags origin \
   > "$PRODUCT_STATE_BEFORE"
@@ -470,7 +548,7 @@ cp "$TRACKER_STATE_FILE" "$TRACKER_STATE_BEFORE_REJECT"
 if scripts/development-workflow/prepare-release-post-merge-cleanup.sh \
   --repo "$PRODUCT_REPO_KEY" \
   --repo-root "$HUB_FIXTURE" \
-  --evidence-file "$(jq -r '.cleanup.mismatched_evidence_file' "$FIXTURE_JSON")" \
+  --evidence-file "$MISMATCHED_EVIDENCE_FILE" \
   --issues "$TEST_TRACKER_ISSUE" \
   --json > "$SMOKE_TMP/mismatched-cleanup.json"
 then
@@ -500,7 +578,7 @@ set -euo pipefail
 for repo in "$SINGLE_REPO_FIXTURE" "$HUB_FIXTURE" "$PRODUCT_REPO_PATH"
 do
   if [ -n "${repo:-}" ] && [ -d "$repo/.git" ]; then
-    test -z "$(git -C "$repo" status --porcelain)"
+    require_clean_git "$repo" "$SMOKE_TMP/$(basename "$repo")-final-status.txt"
   fi
 done
 

--- a/docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md
+++ b/docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md
@@ -1,0 +1,175 @@
+# Smoke Test Runbook: Route Component Releases To The Selected Product Repository
+
+**Feature**: Route component releases to the selected product repository
+**Spec**:
+[`docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/1_1356-route-component-releases-to-selected-product-repository_specs.md`](../../specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/1_1356-route-component-releases-to-selected-product-repository_specs.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] You are in the workflow hub checkout.
+- [ ] A workflow-hub fixture or test repository configuration has at least two
+      product repositories and local-only checkout entries for the selected
+      product repository.
+- [ ] The selected product repository checkout is clean.
+- [ ] The implementation branch for #1356 is checked out or merged into the
+      test branch.
+
+---
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| Hub mode | `workflow_hub` |
+| Selected product repository | One configured product repository key, such as `mobile-app` |
+| Alternate product repository | A second configured product repository key |
+| Release version | Test version such as `9.9.9-test` |
+| Release correlation key | Stable value for the test release attempt |
+| Hub tracker reference | GitHub issue #1356 or a fixture tracker URL |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Validate single-repository compatibility
+
+**Maps to**: AC7
+
+1. Use a single-repository fixture or omit workflow-hub mode.
+2. Run the implemented release target resolution command without a product
+   repository selector.
+3. Confirm the routing outcome is `single_repo_release`.
+4. Confirm no product repository selector is required.
+
+**Expected result**: The release path remains current-repository owned and does
+not require workflow-hub product selection.
+
+### Step 2: Validate selected product release routing
+
+**Maps to**: AC1, AC4
+
+1. Use a workflow-hub fixture with one selected product repository.
+2. Run the implemented release target resolution command with that selected
+   product repository.
+3. Confirm the routing outcome is `component_release_routed`.
+4. Confirm the output names the selected product repository, canonical
+   repository identity, local checkout source, release base, release branch
+   pattern, product artifact owners, hub tracker owner, release correlation key,
+   and contract revision or digest.
+
+**Expected result**: Product release artifacts are assigned only to the selected
+product repository, while tracker reconciliation remains hub-owned.
+
+### Step 3: Validate fail-closed unsafe selection outcomes
+
+**Maps to**: AC2, AC3
+
+1. Run release target resolution with no selected product repository in
+   workflow-hub mode.
+2. Repeat with multiple selected products.
+3. Repeat with an unknown selected product.
+4. Repeat with ambiguous product selection fixture data.
+5. Repeat with an invalid release artifact owner.
+6. Repeat with a selected product whose local checkout is required but
+   unavailable.
+
+**Expected result**: Each run stops before mutation and reports exactly one
+canonical routing outcome: `missing_product_selection`,
+`multiple_product_targets`, `unknown_product_repository`,
+`ambiguous_product_selection`, `invalid_release_contract`, or
+`unavailable_product_repository_checkout`.
+
+### Step 4: Validate component release evidence
+
+**Maps to**: AC8
+
+1. Generate a component release evidence record for a pending release attempt.
+2. Generate records for completed, failed, and blocked release attempts.
+3. Confirm each record includes canonical product repository identity, product
+   repository key, release correlation key, contract revision, routing outcome,
+   release outcome, CI outcome, deployment outcome, cleanup outcome, and hub
+   tracker reference.
+4. Try an invalid outcome value and a missing required field.
+
+**Expected result**: Valid evidence records are accepted and deterministic;
+invalid or incomplete records are rejected with a clear error.
+
+### Step 5: Validate rerunnable cleanup guard
+
+**Maps to**: AC5, AC6
+
+1. Run release cleanup with evidence whose repository identity, release
+   correlation key, and contract revision match the current selected product
+   repository.
+2. Confirm already-complete cleanup steps are reported as already complete.
+3. Confirm missing product cleanup steps are completed in the selected product
+   repository.
+4. Confirm hub tracker reconciliation happens only after product cleanup
+   evidence is confirmed.
+5. Repeat with evidence whose repository identity, release correlation key, or
+   contract revision differs from the current target.
+
+**Expected result**: Matching evidence allows safe rerunnable cleanup;
+mismatched evidence stops before product or hub tracker mutation.
+
+### Last Step: Validate & Shut Down
+
+- Verify all assertions below are satisfied.
+- Remove any temporary fixture files or test branches created for the smoke run.
+
+---
+
+## Assertions Checklist
+
+- [ ] A workflow-hub component release with one selected product repository
+      routes release artifacts only to that product repository.
+- [ ] Missing product selection stops before branch, pull request, changelog,
+      tag, deployment, cleanup, or tracker mutation.
+- [ ] Ambiguous, unknown, unavailable, and multiple product targets stop before
+      mutation with canonical routing outcomes.
+- [ ] Release preparation shows release base, release branch, artifact owners,
+      product CI evidence source, deployment evidence owner, cleanup evidence
+      owner, and hub tracker reconciliation owner.
+- [ ] Cleanup validates repository identity, release correlation key, and
+      contract revision before mutation.
+- [ ] Cleanup reruns report already-complete steps and complete only missing
+      selected-product cleanup.
+- [ ] Single-repository release and hotfix behavior remains selector-free.
+- [ ] Component release evidence includes routing, release, CI, deployment,
+      cleanup, and hub tracker reconciliation information for later bundle work.
+
+---
+
+## Seed Data Reference
+
+The following seed data must be present:
+
+| Entity | Scenario | How to load |
+| --- | --- | --- |
+| Workflow-hub config fixture | Two product repositories with valid release contracts | Test fixture created by implementation tests |
+| Local config fixture | Selected product checkout path stored outside versioned config | Test fixture created by implementation tests |
+| Evidence fixture | Matching and mismatched release correlation records | Test fixture created by implementation tests |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Target resolution reports missing product selection | The workflow-hub release command omitted the selected product repository | Rerun with one product repository key from the release contract. |
+| Cleanup stops on contract revision mismatch | Evidence was generated from a different release contract than the current selection | Reconfirm the intended release target before retrying cleanup. |
+| Product checkout unavailable | Local-only config does not point to a clean product checkout | Correct local-only checkout configuration and rerun target resolution. |
+
+---
+
+## Known Limitations
+
+- This smoke test uses workflow fixtures or non-production repositories. Do not
+  run release branch or tag mutation against a production product repository
+  during smoke validation.

--- a/docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md
+++ b/docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md
@@ -10,19 +10,26 @@
 
 ## Prerequisites
 
-Before running this smoke test:
+Before running every scenario:
 
 - [ ] The implementation branch for #1356 is checked out or merged into the
       test branch.
-- [ ] Steps 2 through 5 are run from the workflow hub checkout.
-- [ ] Step 1 has a single-repository fixture or temporary checkout available.
-- [ ] Steps 2 through 5 have a workflow-hub fixture or test repository
-      configuration with at least two product repositories and local-only
-      checkout entries for the selected product repository.
-- [ ] The selected product repository checkout is clean.
 - [ ] Hub tracker mutation uses a mocked tracker or disposable fixture issue.
       The smoke test must reject live work-item references unless the operator
       passes an explicit destructive-test option supported by the implementation.
+
+Before Step 1:
+
+- [ ] A single-repository fixture or temporary checkout is available. Step 1
+      must not require workflow-hub fixture data or a product selector.
+
+Before Steps 2 through 5:
+
+- [ ] You are in the workflow hub checkout.
+- [ ] A workflow-hub fixture or test repository configuration has at least two
+      product repositories and local-only checkout entries for the selected
+      product repository.
+- [ ] The selected product repository checkout is clean.
 
 ---
 
@@ -54,14 +61,24 @@ Before running this smoke test:
 ```bash
 SINGLE_REPO_FIXTURE="/tmp/1356-single-repo"
 TARGET_JSON="/tmp/1356-single-repo-target.json"
+SINGLE_REPO_STATUS_BEFORE="/tmp/1356-single-repo-status-before.txt"
+SINGLE_REPO_STATUS_AFTER="/tmp/1356-single-repo-status-after.txt"
+
+test -d "$SINGLE_REPO_FIXTURE/.git"
+git -C "$SINGLE_REPO_FIXTURE" status --porcelain \
+  > "$SINGLE_REPO_STATUS_BEFORE"
 
 scripts/development-workflow/component-release-target.sh \
   --repo-root "$SINGLE_REPO_FIXTURE" \
   --json > "$TARGET_JSON"
 
+git -C "$SINGLE_REPO_FIXTURE" status --porcelain \
+  > "$SINGLE_REPO_STATUS_AFTER"
+
 jq -e '.routing_outcome == "single_repo_release"' "$TARGET_JSON"
 jq -e '.selected_product_repo_key == null' "$TARGET_JSON"
 jq -e '.mutation_allowed == true' "$TARGET_JSON"
+cmp "$SINGLE_REPO_STATUS_BEFORE" "$SINGLE_REPO_STATUS_AFTER"
 ```
 
 **Expected result**: The release path remains current-repository owned and does
@@ -84,12 +101,20 @@ not require workflow-hub product selection.
 HUB_FIXTURE="/tmp/1356-workflow-hub"
 PRODUCT_REPO_KEY="mobile-app"
 TARGET_JSON="/tmp/1356-component-target.json"
+HUB_STATUS_BEFORE="/tmp/1356-hub-status-before.txt"
+HUB_STATUS_AFTER="/tmp/1356-hub-status-after.txt"
+
+test -d "$HUB_FIXTURE/.git"
+git -C "$HUB_FIXTURE" status --porcelain > "$HUB_STATUS_BEFORE"
 
 scripts/development-workflow/component-release-target.sh \
   --repo "$PRODUCT_REPO_KEY" \
   --repo-root "$HUB_FIXTURE" \
   --require-local \
   --json > "$TARGET_JSON"
+
+git -C "$HUB_FIXTURE" status --porcelain > "$HUB_STATUS_AFTER"
+PRODUCT_REPO_PATH="$(jq -r '.local_checkout.path' "$TARGET_JSON")"
 
 jq -e '.routing_outcome == "component_release_routed"' "$TARGET_JSON"
 jq -e '.selected_product_repo_key == env.PRODUCT_REPO_KEY' "$TARGET_JSON"
@@ -101,6 +126,9 @@ jq -e '.artifact_owners.release == "product_repository"' "$TARGET_JSON"
 jq -e '.artifact_owners.tracker == "hub_repository"' "$TARGET_JSON"
 jq -e '.release_correlation_key | length > 0' "$TARGET_JSON"
 jq -e '.contract_revision | length > 0' "$TARGET_JSON"
+test -d "$PRODUCT_REPO_PATH/.git"
+test -z "$(git -C "$PRODUCT_REPO_PATH" status --porcelain)"
+cmp "$HUB_STATUS_BEFORE" "$HUB_STATUS_AFTER"
 ```
 
 **Expected result**: Product release artifacts are assigned only to the selected
@@ -162,6 +190,14 @@ do
 
   jq -e '.mutation_allowed == false' "$TARGET_JSON"
 done
+
+if scripts/development-workflow/component-release-target.sh \
+  --repo-root "$HUB_FIXTURE/fixtures/malformed" \
+  --json > /tmp/1356-malformed-target.json
+then
+  echo "malformed target input was accepted" >&2
+  exit 1
+fi
 ```
 
 **Expected result**: Each run stops before mutation and reports exactly one
@@ -208,6 +244,21 @@ jq -e --arg value "$TARGET_REVISION" \
 jq -e '.routing_outcome == "component_release_routed"' "$EVIDENCE_JSON"
 jq -e '.hub_tracker_ref == "fixture:1356-smoke"' "$EVIDENCE_JSON"
 
+for release_outcome in completed failed blocked
+do
+  scripts/development-workflow/component-release-evidence.sh \
+    --target-file "$TARGET_JSON" \
+    --release-outcome "$release_outcome" \
+    --ci-outcome passed \
+    --deployment-outcome recorded \
+    --cleanup-outcome complete \
+    --hub-tracker-ref "fixture:1356-smoke" \
+    --json > "/tmp/1356-${release_outcome}-evidence.json"
+
+  jq -e --arg value "$release_outcome" \
+    '.release_outcome == $value' "/tmp/1356-${release_outcome}-evidence.json"
+done
+
 if scripts/development-workflow/component-release-evidence.sh \
   --target-file "$TARGET_JSON" \
   --release-outcome invalid \
@@ -247,6 +298,10 @@ TARGET_JSON="/tmp/1356-component-target.json"
 EVIDENCE_JSON="/tmp/1356-component-evidence.json"
 TEST_TRACKER_REF="fixture:1356-smoke"
 TEST_TRACKER_ISSUE="fixture-1356-smoke"
+CLEANUP_JSON="/tmp/1356-cleanup-output.json"
+CLEANUP_RERUN_JSON="/tmp/1356-cleanup-rerun-output.json"
+PRODUCT_REPO_PATH="$(jq -r '.local_checkout.path' "$TARGET_JSON")"
+RELEASE_BRANCH="release/v9.9.9-test"
 
 case "$TEST_TRACKER_REF" in
   test:*|mock:*|fixture:*) ;;
@@ -261,25 +316,33 @@ scripts/development-workflow/prepare-release-post-merge-cleanup.sh \
   --repo-root "$HUB_FIXTURE" \
   --evidence-file "$EVIDENCE_JSON" \
   --issues "$TEST_TRACKER_ISSUE" \
-  --best-effort
+  --best-effort \
+  --json > "$CLEANUP_JSON"
 
 scripts/development-workflow/prepare-release-post-merge-cleanup.sh \
   --repo "$PRODUCT_REPO_KEY" \
   --repo-root "$HUB_FIXTURE" \
   --evidence-file "$EVIDENCE_JSON" \
   --issues "$TEST_TRACKER_ISSUE" \
-  --best-effort
+  --best-effort \
+  --json > "$CLEANUP_RERUN_JSON"
 
-jq -e '.cleanup_outcome == "complete"' "$EVIDENCE_JSON"
-jq -e '.tracker_mutation.repository_owner == "hub_repository"' "$EVIDENCE_JSON"
-jq -e '.product_cleanup.repository_key == env.PRODUCT_REPO_KEY' "$EVIDENCE_JSON"
+jq -e '.cleanup_outcome == "complete"' "$CLEANUP_JSON"
+jq -e '.tracker_mutation.repository_owner == "hub_repository"' "$CLEANUP_JSON"
+jq -e '.tracker_mutation.issue == env.TEST_TRACKER_ISSUE' "$CLEANUP_JSON"
+jq -e '.product_cleanup.repository_key == env.PRODUCT_REPO_KEY' "$CLEANUP_JSON"
+jq -e '.product_cleanup.already_complete == true' "$CLEANUP_RERUN_JSON"
+test -z "$(git -C "$PRODUCT_REPO_PATH" status --porcelain)"
+! git -C "$PRODUCT_REPO_PATH" ls-remote --exit-code --heads origin \
+  "$RELEASE_BRANCH"
 
 if scripts/development-workflow/prepare-release-post-merge-cleanup.sh \
   --repo "$PRODUCT_REPO_KEY" \
   --repo-root "$HUB_FIXTURE" \
   --evidence-file "/tmp/1356-mismatched-evidence.json" \
   --issues "$TEST_TRACKER_ISSUE" \
-  --best-effort
+  --best-effort \
+  --json > /tmp/1356-mismatched-cleanup.json
 then
   echo "mismatched evidence cleanup was accepted" >&2
   exit 1
@@ -293,6 +356,17 @@ mismatched evidence stops before product or hub tracker mutation.
 
 - Verify all assertions below are satisfied.
 - Remove any temporary fixture files or test branches created for the smoke run.
+
+```bash
+rm -f /tmp/1356-*.json /tmp/1356-*.txt
+
+for repo in "$SINGLE_REPO_FIXTURE" "$HUB_FIXTURE" "$PRODUCT_REPO_PATH"
+do
+  if [ -n "${repo:-}" ] && [ -d "$repo/.git" ]; then
+    test -z "$(git -C "$repo" status --porcelain)"
+  fi
+done
+```
 
 ---
 

--- a/docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md
+++ b/docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md
@@ -12,13 +12,17 @@
 
 Before running this smoke test:
 
-- [ ] You are in the workflow hub checkout.
-- [ ] A workflow-hub fixture or test repository configuration has at least two
-      product repositories and local-only checkout entries for the selected
-      product repository.
-- [ ] The selected product repository checkout is clean.
 - [ ] The implementation branch for #1356 is checked out or merged into the
       test branch.
+- [ ] Steps 2 through 5 are run from the workflow hub checkout.
+- [ ] Step 1 has a single-repository fixture or temporary checkout available.
+- [ ] Steps 2 through 5 have a workflow-hub fixture or test repository
+      configuration with at least two product repositories and local-only
+      checkout entries for the selected product repository.
+- [ ] The selected product repository checkout is clean.
+- [ ] Hub tracker mutation uses a mocked tracker or disposable fixture issue.
+      The smoke test must reject live work-item references unless the operator
+      passes an explicit destructive-test option supported by the implementation.
 
 ---
 
@@ -31,7 +35,7 @@ Before running this smoke test:
 | Alternate product repository | A second configured product repository key |
 | Release version | Test version such as `9.9.9-test` |
 | Release correlation key | Stable value for the test release attempt |
-| Hub tracker reference | GitHub issue #1356 or a fixture tracker URL |
+| Hub tracker reference | `test:*`, `mock:*`, or `fixture:*` tracker reference only |
 
 ---
 
@@ -47,6 +51,19 @@ Before running this smoke test:
 3. Confirm the routing outcome is `single_repo_release`.
 4. Confirm no product repository selector is required.
 
+```bash
+SINGLE_REPO_FIXTURE="/tmp/1356-single-repo"
+TARGET_JSON="/tmp/1356-single-repo-target.json"
+
+scripts/development-workflow/component-release-target.sh \
+  --repo-root "$SINGLE_REPO_FIXTURE" \
+  --json > "$TARGET_JSON"
+
+jq -e '.routing_outcome == "single_repo_release"' "$TARGET_JSON"
+jq -e '.selected_product_repo_key == null' "$TARGET_JSON"
+jq -e '.mutation_allowed == true' "$TARGET_JSON"
+```
+
 **Expected result**: The release path remains current-repository owned and does
 not require workflow-hub product selection.
 
@@ -61,7 +78,30 @@ not require workflow-hub product selection.
 4. Confirm the output names the selected product repository, canonical
    repository identity, local checkout source, release base, release branch
    pattern, product artifact owners, hub tracker owner, release correlation key,
-   and contract revision or digest.
+   and `contract_revision`.
+
+```bash
+HUB_FIXTURE="/tmp/1356-workflow-hub"
+PRODUCT_REPO_KEY="mobile-app"
+TARGET_JSON="/tmp/1356-component-target.json"
+
+scripts/development-workflow/component-release-target.sh \
+  --repo "$PRODUCT_REPO_KEY" \
+  --repo-root "$HUB_FIXTURE" \
+  --require-local \
+  --json > "$TARGET_JSON"
+
+jq -e '.routing_outcome == "component_release_routed"' "$TARGET_JSON"
+jq -e '.selected_product_repo_key == env.PRODUCT_REPO_KEY' "$TARGET_JSON"
+jq -e '.canonical_repository_identity | length > 0' "$TARGET_JSON"
+jq -e '.local_checkout.path | length > 0' "$TARGET_JSON"
+jq -e '.release_base | length > 0' "$TARGET_JSON"
+jq -e '.release_branch_pattern | length > 0' "$TARGET_JSON"
+jq -e '.artifact_owners.release == "product_repository"' "$TARGET_JSON"
+jq -e '.artifact_owners.tracker == "hub_repository"' "$TARGET_JSON"
+jq -e '.release_correlation_key | length > 0' "$TARGET_JSON"
+jq -e '.contract_revision | length > 0' "$TARGET_JSON"
+```
 
 **Expected result**: Product release artifacts are assigned only to the selected
 product repository, while tracker reconciliation remains hub-owned.
@@ -78,6 +118,51 @@ product repository, while tracker reconciliation remains hub-owned.
 5. Repeat with an invalid release artifact owner.
 6. Repeat with a selected product whose local checkout is required but
    unavailable.
+
+```bash
+HUB_FIXTURE="/tmp/1356-workflow-hub"
+
+for fixture in \
+  missing-product-selection \
+  multiple-product-targets \
+  unknown-product-repository \
+  ambiguous-product-selection \
+  invalid-release-contract \
+  unavailable-product-repository-checkout
+do
+  TARGET_JSON="/tmp/1356-${fixture}.json"
+
+  scripts/development-workflow/component-release-target.sh \
+    --repo-root "$HUB_FIXTURE/fixtures/$fixture" \
+    --require-local \
+    --json > "$TARGET_JSON"
+
+  case "$fixture" in
+    missing-product-selection)
+      jq -e '.routing_outcome == "missing_product_selection"' "$TARGET_JSON"
+      ;;
+    multiple-product-targets)
+      jq -e '.routing_outcome == "multiple_product_targets"' "$TARGET_JSON"
+      ;;
+    unknown-product-repository)
+      jq -e '.routing_outcome == "unknown_product_repository"' "$TARGET_JSON"
+      ;;
+    ambiguous-product-selection)
+      jq -e '.routing_outcome == "ambiguous_product_selection"' "$TARGET_JSON"
+      ;;
+    invalid-release-contract)
+      jq -e '.routing_outcome == "invalid_release_contract"' "$TARGET_JSON"
+      ;;
+    unavailable-product-repository-checkout)
+      jq -e \
+        '.routing_outcome == "unavailable_product_repository_checkout"' \
+        "$TARGET_JSON"
+      ;;
+  esac
+
+  jq -e '.mutation_allowed == false' "$TARGET_JSON"
+done
+```
 
 **Expected result**: Each run stops before mutation and reports exactly one
 canonical routing outcome: `missing_product_selection`,
@@ -97,6 +182,46 @@ canonical routing outcome: `missing_product_selection`,
    tracker reference.
 4. Try an invalid outcome value and a missing required field.
 
+```bash
+TARGET_JSON="/tmp/1356-component-target.json"
+EVIDENCE_JSON="/tmp/1356-component-evidence.json"
+
+scripts/development-workflow/component-release-evidence.sh \
+  --target-file "$TARGET_JSON" \
+  --release-outcome pending \
+  --ci-outcome pending \
+  --deployment-outcome not_applicable \
+  --cleanup-outcome not_started \
+  --hub-tracker-ref "fixture:1356-smoke" \
+  --json > "$EVIDENCE_JSON"
+
+TARGET_REPOSITORY="$(jq -r '.canonical_repository_identity' "$TARGET_JSON")"
+TARGET_CORRELATION="$(jq -r '.release_correlation_key' "$TARGET_JSON")"
+TARGET_REVISION="$(jq -r '.contract_revision' "$TARGET_JSON")"
+
+jq -e --arg value "$TARGET_REPOSITORY" \
+  '.canonical_repository_identity == $value' "$EVIDENCE_JSON"
+jq -e --arg value "$TARGET_CORRELATION" \
+  '.release_correlation_key == $value' "$EVIDENCE_JSON"
+jq -e --arg value "$TARGET_REVISION" \
+  '.contract_revision == $value' "$EVIDENCE_JSON"
+jq -e '.routing_outcome == "component_release_routed"' "$EVIDENCE_JSON"
+jq -e '.hub_tracker_ref == "fixture:1356-smoke"' "$EVIDENCE_JSON"
+
+if scripts/development-workflow/component-release-evidence.sh \
+  --target-file "$TARGET_JSON" \
+  --release-outcome invalid \
+  --ci-outcome pending \
+  --deployment-outcome not_applicable \
+  --cleanup-outcome not_started \
+  --hub-tracker-ref "fixture:1356-smoke" \
+  --json > /tmp/1356-invalid-evidence.json
+then
+  echo "invalid evidence was accepted" >&2
+  exit 1
+fi
+```
+
 **Expected result**: Valid evidence records are accepted and deterministic;
 invalid or incomplete records are rejected with a clear error.
 
@@ -114,6 +239,52 @@ invalid or incomplete records are rejected with a clear error.
    evidence is confirmed.
 5. Repeat with evidence whose repository identity, release correlation key, or
    contract revision differs from the current target.
+
+```bash
+HUB_FIXTURE="/tmp/1356-workflow-hub"
+PRODUCT_REPO_KEY="mobile-app"
+TARGET_JSON="/tmp/1356-component-target.json"
+EVIDENCE_JSON="/tmp/1356-component-evidence.json"
+TEST_TRACKER_REF="fixture:1356-smoke"
+TEST_TRACKER_ISSUE="fixture-1356-smoke"
+
+case "$TEST_TRACKER_REF" in
+  test:*|mock:*|fixture:*) ;;
+  *)
+    echo "refusing live tracker reference: $TEST_TRACKER_REF" >&2
+    exit 1
+    ;;
+esac
+
+scripts/development-workflow/prepare-release-post-merge-cleanup.sh \
+  --repo "$PRODUCT_REPO_KEY" \
+  --repo-root "$HUB_FIXTURE" \
+  --evidence-file "$EVIDENCE_JSON" \
+  --issues "$TEST_TRACKER_ISSUE" \
+  --best-effort
+
+scripts/development-workflow/prepare-release-post-merge-cleanup.sh \
+  --repo "$PRODUCT_REPO_KEY" \
+  --repo-root "$HUB_FIXTURE" \
+  --evidence-file "$EVIDENCE_JSON" \
+  --issues "$TEST_TRACKER_ISSUE" \
+  --best-effort
+
+jq -e '.cleanup_outcome == "complete"' "$EVIDENCE_JSON"
+jq -e '.tracker_mutation.repository_owner == "hub_repository"' "$EVIDENCE_JSON"
+jq -e '.product_cleanup.repository_key == env.PRODUCT_REPO_KEY' "$EVIDENCE_JSON"
+
+if scripts/development-workflow/prepare-release-post-merge-cleanup.sh \
+  --repo "$PRODUCT_REPO_KEY" \
+  --repo-root "$HUB_FIXTURE" \
+  --evidence-file "/tmp/1356-mismatched-evidence.json" \
+  --issues "$TEST_TRACKER_ISSUE" \
+  --best-effort
+then
+  echo "mismatched evidence cleanup was accepted" >&2
+  exit 1
+fi
+```
 
 **Expected result**: Matching evidence allows safe rerunnable cleanup;
 mismatched evidence stops before product or hub tracker mutation.
@@ -140,6 +311,8 @@ mismatched evidence stops before product or hub tracker mutation.
       contract revision before mutation.
 - [ ] Cleanup reruns report already-complete steps and complete only missing
       selected-product cleanup.
+- [ ] Cleanup uses only a disposable fixture issue or mocked tracker by default,
+      never live issue #1356.
 - [ ] Single-repository release and hotfix behavior remains selector-free.
 - [ ] Component release evidence includes routing, release, CI, deployment,
       cleanup, and hub tracker reconciliation information for later bundle work.


### PR DESCRIPTION
## Summary

- Adds the #1356 implementation plan for workflow-hub component release routing.
- Adds the smoke test runbook covering selected product routing, unsafe-selection stops, evidence records, rerunnable cleanup, and single-repository compatibility.
- Plans implementation around existing #1353 release contracts and #1354 one-target routing rather than a new selection model.

Issue: #1356
Plan: docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/2_1356-route-component-releases-to-selected-product-repository_implementation-plan.md
Smoke: docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md

## Complexity / Risks

- Complexity: M.
- Key risks: release preparation and cleanup resolving different product targets; evidence record too loose for #1357; single-repository release regression.
- Mitigations: persisted release target, validated evidence helper, explicit single-repo routing outcome, and focused shell/Python tests.

## Document Quality Gate

- Spec/brief coverage: Checked - all #1356 ACs map to implementation layers, tests, and smoke steps.
- Implementation-order consistency: Checked - helper names, docs, tests, and verification commands use consistent file paths and outcome names.
- Verification support: Checked - scope and file-list claims cite the Verification Log.
- Behavioral guarantees: Checked - fail-closed routing, persisted target validation, deterministic evidence output, and tracker-after-product-cleanup ordering name their mechanisms.
- Complex workflow decision-gate matrix: Checked - plan includes gate inputs, canonical outcomes, allowed outcomes, next actions, and mirror surfaces.
- Parser/API/concurrency checklist: Checked - parser-risk addendum is included; API and concurrency are not applicable because this is synchronous CLI workflow tooling with no HTTP API.
- CHANGELOG literal format: Checked - implementation order includes the project changelog bullet format with issue number.
- Not-applicable rationale: Checked - no database, seed data beyond fixtures, frontend, or design fidelity work applies.

## Validation

- `npx markdownlint-cli2 "docs/specs/developments/20260731105659_1356-route-component-releases-to-selected-product-repository/2_1356-route-component-releases-to-selected-product-repository_implementation-plan.md" "docs/testing/workflow/1356-route-component-releases-to-selected-product-repository.smoke-test.md"`: passed.
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`: passed.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an implementation plan for routing component releases to a selected product repository.
  * Documented safe handling for invalid repository selections, release evidence validation, cleanup safeguards, and preservation of existing release behavior.
  * Added a smoke-test runbook covering selected-repository routing, compatibility checks, rerunnable cleanup, shutdown checks, fixtures, assertions, production limitations, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->