### PR TITLE
feat(workflow): add delivery bundle manifest workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/delivery-bundle.yml
+++ b/.github/ISSUE_TEMPLATE/delivery-bundle.yml
@@ -1,0 +1,63 @@
+name: Delivery bundle
+description: Track a hub-owned customer-facing delivery across component releases.
+title: "delivery-bundle: "
+labels: []
+body:
+  - type: input
+    id: delivery-title
+    attributes:
+      label: Delivery title
+      description: Customer-facing delivery name.
+      placeholder: Mobile and Web July delivery
+    validations:
+      required: true
+  - type: textarea
+    id: delivery-purpose
+    attributes:
+      label: Delivery purpose
+      description: What customer-facing outcome this bundle represents.
+    validations:
+      required: true
+  - type: input
+    id: parent-ref
+    attributes:
+      label: Parent epic or request
+      description: Hub epic, request, or delivery reference.
+      placeholder: "#1352"
+    validations:
+      required: true
+  - type: textarea
+    id: participating-components
+    attributes:
+      label: Participating product components
+      description: Product repository keys or component names expected in the bundle.
+      placeholder: |
+        mobile-app
+        web-app
+    validations:
+      required: true
+  - type: textarea
+    id: known-child-items
+    attributes:
+      label: Known child items
+      description: Source child issues or product work items, when known.
+      placeholder: |
+        #1356
+        #1357
+    validations:
+      required: false
+  - type: input
+    id: finalization-owner
+    attributes:
+      label: Finalization owner
+      description: Operator responsible for completing finalization.
+      placeholder: "@workflow-operator"
+    validations:
+      required: true
+  - type: textarea
+    id: rollout-notes
+    attributes:
+      label: Rollout notes
+      description: Release timing, rollout constraints, or known missing evidence.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/delivery-bundle.yml
+++ b/.github/ISSUE_TEMPLATE/delivery-bundle.yml
@@ -19,6 +19,14 @@ body:
     validations:
       required: true
   - type: input
+    id: bundle-key
+    attributes:
+      label: Bundle key
+      description: Immutable delivery bundle key. Use only A-Z, a-z, 0-9, dot, underscore, or hyphen.
+      placeholder: mobile-web-july-delivery
+    validations:
+      required: true
+  - type: input
     id: parent-ref
     attributes:
       label: Parent epic or request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Route component releases to selected product repositories** (#1356): add
   canonical component release target and evidence helpers, plus product-aware
   release cleanup validation for workflow hubs.
+- **Add delivery bundle manifest workflow** (#1357): add hub-owned delivery
+  bundle issue and manifest tooling for coordinated component delivery evidence.
 
 ## [0.40.0] - 2026-07-30
 

--- a/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
+++ b/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
@@ -142,6 +142,32 @@ scripts/development-workflow/component-release-evidence.sh \
   --output /path/to/component-release-evidence.json
 ```
 
+When the component release belongs to an open hub-owned delivery bundle, attach
+that evidence to the bundle after the product release evidence file exists. The
+delivery bundle remains hub-owned; this handoff must not change the product
+release artifact owner or create a shared suite branch:
+
+<!-- workflow-shell-contract: bash-zsh -->
+```bash
+scripts/development-workflow/delivery-bundle-manifest.sh update-component \
+  --manifest "$DELIVERY_BUNDLE_MANIFEST" \
+  --bundle-key "$DELIVERY_BUNDLE_KEY" \
+  --expected-revision "$DELIVERY_BUNDLE_REVISION" \
+  --component-key "$TARGET_REPO_KEY" \
+  --evidence-file /path/to/component-release-evidence.json \
+  --component-tag "$COMPONENT_TAG" \
+  --component-version "$VERSION" \
+  --source-pr "$SOURCE_PR_NUMBER" \
+  --release-pr "$RELEASE_PR_NUMBER" \
+  --child-item "<tracker-item-or-child>" \
+  --child-release-state merged \
+  --json
+```
+
+If any delivery bundle field is unknown, leave the component release evidence in
+place and let the hub operator attach it later. Do not infer a bundle key from a
+temporary file path or product branch name.
+
 ---
 
 ## Step 2: Create the Release Branch

--- a/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
+++ b/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
@@ -149,16 +149,21 @@ release artifact owner or create a shared suite branch:
 
 <!-- workflow-shell-contract: bash-zsh -->
 ```bash
+DELIVERY_BUNDLE_MANIFEST="${DELIVERY_BUNDLE_MANIFEST:?}"
+DELIVERY_BUNDLE_KEY="${DELIVERY_BUNDLE_KEY:?}"
+DELIVERY_BUNDLE_REVISION="$(jq -r '.revision' "$DELIVERY_BUNDLE_MANIFEST")"
+
 scripts/development-workflow/delivery-bundle-manifest.sh update-component \
   --manifest "$DELIVERY_BUNDLE_MANIFEST" \
   --bundle-key "$DELIVERY_BUNDLE_KEY" \
-  --expected-revision "$DELIVERY_BUNDLE_REVISION" \
-  --component-key "$TARGET_REPO_KEY" \
+  --expected-revision "${DELIVERY_BUNDLE_REVISION:?}" \
+  --component-key "${TARGET_REPO_KEY:?}" \
   --evidence-file /path/to/component-release-evidence.json \
-  --component-tag "$COMPONENT_TAG" \
-  --component-version "$VERSION" \
-  --source-pr "$SOURCE_PR_NUMBER" \
-  --release-pr "$RELEASE_PR_NUMBER" \
+  --component-tag "${COMPONENT_TAG:?}" \
+  --component-version "${VERSION:?}" \
+  --source-pr "${SOURCE_PR_NUMBER:?}" \
+  --release-pr "${RELEASE_PR_NUMBER:?}" \
+  --hub-tracker-reconciliation-outcome complete \
   --child-item "<tracker-item-or-child>" \
   --child-release-state merged \
   --json

--- a/docs/workflow/development-workflow/repository-modes.md
+++ b/docs/workflow/development-workflow/repository-modes.md
@@ -79,6 +79,17 @@ updating hub tracker state. Duplicate cleanup attempts use a per-release lease
 keyed by `release_correlation_key`; a completed evidence record is the
 idempotent rerun signal.
 
+`scripts/development-workflow/delivery-bundle-manifest.sh` manages hub-owned
+`delivery_bundle_manifest.v1` records for coordinated customer-facing
+deliveries. Every command targets both a hub evidence file (`--manifest`) and an
+immutable logical delivery identity (`--bundle-key`). The helper reads
+`component_release_evidence.v1` records from selected product repositories,
+records component tags and release outcomes in the hub manifest, preserves
+source evidence files unchanged, and finalizes only when every declared current
+component has complete, consistent evidence. It does not create a shared suite
+version, shared release branch, product tag, GitHub Release, or product
+deployment artifact.
+
 In `single_repo` mode, all artifact ownership stays exactly as it works today:
 the tracker item, spec, plan, implementation branch, PR, CI, reviewer loop, smoke
 runbook, and release evidence are all handled in the same repository.

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -134,6 +134,64 @@ Usage:
   --output /tmp/component-release-evidence.json
 ```
 
+### `delivery-bundle-manifest.sh`
+
+Creates and updates hub-owned delivery bundle manifests that compose
+independently released product components into one customer-facing delivery.
+
+Usage:
+
+<!-- workflow-shell-contract: bash-zsh -->
+```bash
+./scripts/development-workflow/delivery-bundle-manifest.sh create \
+  --manifest /tmp/delivery-bundle.json \
+  --bundle-key mobile-web-july-delivery \
+  --title "Mobile and Web July delivery" \
+  --purpose "Coordinated customer-facing delivery" \
+  --parent-ref "#1352" \
+  --component mobile-app \
+  --component web-app \
+  --child-item "#1356" \
+  --finalization-owner "@workflow-operator" \
+  --json
+
+./scripts/development-workflow/delivery-bundle-manifest.sh update-component \
+  --manifest /tmp/delivery-bundle.json \
+  --bundle-key mobile-web-july-delivery \
+  --expected-revision 1 \
+  --component-key mobile-app \
+  --evidence-file /tmp/component-release-evidence.json \
+  --component-tag mobile-v1.4.0 \
+  --component-version 1.4.0 \
+  --source-pr 1411 \
+  --release-pr 1501 \
+  --child-item "#1356" \
+  --child-release-state merged \
+  --json
+
+./scripts/development-workflow/delivery-bundle-manifest.sh inspect \
+  --manifest /tmp/delivery-bundle.json \
+  --bundle-key mobile-web-july-delivery \
+  --json
+```
+
+What it does:
+
+- Emits and validates `delivery_bundle_manifest.v1`.
+- Requires both `--manifest` and immutable `--bundle-key` so a temporary file
+  path is never the only delivery identity.
+- Preserves component release evidence and records stable identity fields,
+  component tags, PR references, release outcomes, cleanup outcomes, hub
+  tracker reconciliation, child release state, readiness, and audit events in
+  the hub manifest.
+- Uses a manifest lock, expected-revision checks, staged JSON validation, and
+  atomic replacement for accepted mutations.
+- Fails closed with stable `ERROR_CODE=<code>` stderr for stale revisions,
+  conflicting evidence, malformed JSON, missing component tags, incomplete
+  evidence, and blocked finalization outcomes.
+- Finalizes only when every declared current component is complete and never
+  creates a shared suite version or shared release branch.
+
 ### `check-workflow-branch.sh`
 
 Checks whether a specific workflow branch already exists locally, remotely, or in an active worktree.

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -165,15 +165,46 @@ Usage:
   --component-version 1.4.0 \
   --source-pr 1411 \
   --release-pr 1501 \
+  --hub-tracker-reconciliation-outcome complete \
   --child-item "#1356" \
   --child-release-state merged \
+  --json
+
+./scripts/development-workflow/delivery-bundle-manifest.sh add-component \
+  --manifest /tmp/delivery-bundle.json \
+  --bundle-key mobile-web-july-delivery \
+  --expected-revision 2 \
+  --component-key web-app \
+  --json
+
+./scripts/development-workflow/delivery-bundle-manifest.sh remove-component \
+  --manifest /tmp/delivery-bundle.json \
+  --bundle-key mobile-web-july-delivery \
+  --expected-revision 3 \
+  --component-key web-app \
+  --reason "Moved to a later delivery" \
   --json
 
 ./scripts/development-workflow/delivery-bundle-manifest.sh inspect \
   --manifest /tmp/delivery-bundle.json \
   --bundle-key mobile-web-july-delivery \
   --json
+
+./scripts/development-workflow/delivery-bundle-manifest.sh finalize \
+  --manifest /tmp/delivery-bundle.json \
+  --bundle-key mobile-web-july-delivery \
+  --expected-revision 4 \
+  --json
 ```
+
+| Subcommand | Required flags beyond `--manifest` and `--bundle-key` |
+| --- | --- |
+| `create` | `--title`, `--purpose`, `--parent-ref`, `--component`, `--finalization-owner` |
+| `add-component` | `--expected-revision`, `--component-key` |
+| `update-component` | `--expected-revision`, `--component-key`, `--evidence-file`, `--component-tag`, `--source-pr`, `--release-pr`, `--child-item`, `--child-release-state` |
+| `remove-component` | `--expected-revision`, `--component-key`, `--reason` |
+| `inspect` | none |
+| `finalize` | `--expected-revision` |
 
 What it does:
 
@@ -186,6 +217,9 @@ What it does:
   the hub manifest.
 - Uses a manifest lock, expected-revision checks, staged JSON validation, and
   atomic replacement for accepted mutations.
+- Records lock owner metadata in `<manifest>.lock/owner.json`; if a process is
+  killed mid-mutation, inspect that file and remove the lock directory only
+  after confirming the owner process is no longer active.
 - Fails closed with stable `ERROR_CODE=<code>` stderr for stale revisions,
   conflicting evidence, malformed JSON, missing component tags, incomplete
   evidence, and blocked finalization outcomes.

--- a/scripts/development-workflow/delivery-bundle-manifest.sh
+++ b/scripts/development-workflow/delivery-bundle-manifest.sh
@@ -1,0 +1,546 @@
+#!/usr/bin/env bash
+#
+# Manage hub-owned delivery bundle manifests.
+
+set -euo pipefail
+
+python3 - "$@" <<'PY'
+import argparse
+import copy
+import datetime as dt
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+
+SCHEMA = "delivery_bundle_manifest.v1"
+EVIDENCE_SCHEMA = "component_release_evidence.v1"
+KEY_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+MISSING_BLOCKERS = [
+    "routing_evidence_missing",
+    "release_evidence_missing",
+    "ci_evidence_missing",
+    "deployment_evidence_missing",
+    "cleanup_evidence_missing",
+    "hub_tracker_reconciliation_missing",
+    "child_release_state_missing",
+]
+
+
+class Parser(argparse.ArgumentParser):
+    def error(self, message):
+        fail("invalid_arguments", message, 2)
+
+
+def fail(code, message, exit_code=1):
+    safe = str(message).replace("'", "'\\''")
+    print(f"ERROR_CODE={code} message='{safe}'", file=sys.stderr)
+    raise SystemExit(exit_code)
+
+
+def now():
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def validate_bundle_key(bundle_key):
+    if not bundle_key:
+        fail("missing_bundle_key", "--bundle-key is required", 2)
+    if not KEY_RE.match(bundle_key):
+        fail("invalid_bundle_key", "--bundle-key must contain only letters, numbers, '.', '_' or '-'", 2)
+
+
+def load_json_file(path, label, required=True):
+    if not path:
+        fail("invalid_arguments", f"{label} path is required", 2)
+    if not os.path.exists(path):
+        if required:
+            fail(f"{label}_not_found", f"{label} file not found: {path}")
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except json.JSONDecodeError as exc:
+        fail("invalid_json", f"{label} file is not valid JSON: {exc}")
+    if not isinstance(data, dict):
+        fail("invalid_json", f"{label} file must contain a JSON object")
+    return data
+
+
+def validate_manifest(data, bundle_key):
+    if data.get("schema_version") != SCHEMA:
+        fail("invalid_manifest_schema", f"manifest must use schema_version {SCHEMA}")
+    if data.get("bundle_key") != bundle_key:
+        fail("bundle_key_mismatch", "manifest bundle_key does not match --bundle-key")
+    if not isinstance(data.get("revision"), int) or data["revision"] < 1:
+        fail("invalid_manifest_revision", "manifest revision must be a positive integer")
+    return data
+
+
+def atomic_write(path, data):
+    parent = os.path.dirname(os.path.abspath(path)) or "."
+    os.makedirs(parent, exist_ok=True)
+    base = os.path.basename(path)
+    fd = None
+    tmp_path = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(prefix=f".{base}.", suffix=".tmp", dir=parent)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fd = None
+            json.dump(data, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        load_json_file(tmp_path, "staged_manifest")
+        os.replace(tmp_path, path)
+    except OSError as exc:
+        fail("manifest_write_failed", f"failed to write manifest atomically: {exc}")
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def with_lock(path, bundle_key, mutate):
+    lock_dir = f"{path}.lock"
+    try:
+        os.mkdir(lock_dir)
+    except FileExistsError:
+        fail("lock_unavailable", f"manifest lock is already held: {lock_dir}")
+    except OSError as exc:
+        fail("lock_unavailable", f"failed to acquire manifest lock: {exc}")
+    try:
+        current = load_json_file(path, "manifest", required=False)
+        if current is not None:
+            validate_manifest(current, bundle_key)
+        new_manifest, changed, result = mutate(current)
+        if changed:
+            atomic_write(path, new_manifest)
+        return result
+    finally:
+        shutil.rmtree(lock_dir, ignore_errors=True)
+
+
+def check_expected_revision(manifest, expected):
+    if expected is None:
+        fail("missing_expected_revision", "--expected-revision is required", 2)
+    if int(manifest["revision"]) != int(expected):
+        fail("stale_manifest_revision", "manifest revision does not match --expected-revision")
+
+
+def audit_event(event, revision, **extra):
+    payload = {"event": event, "revision": revision, "created_at": now()}
+    payload.update({k: v for k, v in extra.items() if v is not None and v != ""})
+    return payload
+
+
+def blocker_for_component(component):
+    if component.get("component_tag") in (None, ""):
+        return "missing_component_tag"
+    state = component.get("evidence_state")
+    if state == "conflicting":
+        return "conflicting_component_evidence"
+    if state == "stale":
+        return "stale_readiness"
+    if state in ("missing", "partial") and component.get("evidence_schema_version") != EVIDENCE_SCHEMA:
+        return "missing_component_evidence"
+    if state in ("missing", "partial"):
+        return "missing_component_evidence"
+    if component.get("evidence_schema_version") != EVIDENCE_SCHEMA:
+        return "missing_component_evidence"
+    if component.get("routing_outcome") != "component_release_routed":
+        return "missing_component_evidence"
+    release = component.get("release_outcome")
+    if release in (None, ""):
+        return "missing_component_evidence"
+    if release == "pending":
+        return "pending_component_outcome"
+    if release in ("failed", "blocked"):
+        return "blocked_component_outcome"
+    if release != "completed":
+        return "blocked_component_outcome"
+    for field in ("ci_outcome", "deployment_outcome"):
+        value = component.get(field)
+        if value in (None, ""):
+            return "missing_component_evidence"
+        if value == "pending":
+            return "pending_component_outcome"
+        if value in ("failed", "blocked"):
+            return "blocked_component_outcome"
+    if component.get("ci_outcome") not in ("passed", "not_applicable", "skipped"):
+        return "blocked_component_outcome"
+    if component.get("deployment_outcome") not in ("recorded", "not_applicable"):
+        return "blocked_component_outcome"
+    cleanup = component.get("cleanup_outcome")
+    if cleanup in (None, ""):
+        return "missing_component_evidence"
+    if cleanup in ("not_started", "partial", "pending"):
+        return "pending_component_outcome"
+    if cleanup != "complete":
+        return "blocked_component_outcome"
+    hub = component.get("hub_tracker_reconciliation_outcome")
+    if hub in (None, ""):
+        return "missing_component_evidence"
+    if hub == "pending":
+        return "pending_component_outcome"
+    if hub not in ("complete", "deferred"):
+        return "blocked_component_outcome"
+    child = component.get("child_release_state")
+    if child in (None, ""):
+        return "missing_component_evidence"
+    if child == "pending":
+        return "pending_component_outcome"
+    if child not in ("released", "merged"):
+        return "blocked_component_outcome"
+    return None
+
+
+def component_view(component):
+    result = copy.deepcopy(component)
+    blocker = blocker_for_component(component)
+    if blocker is None:
+        result["evidence_state"] = "verified"
+        result["blockers"] = []
+    elif component.get("evidence_schema_version") != EVIDENCE_SCHEMA:
+        result["evidence_state"] = "missing"
+        result["blockers"] = list(MISSING_BLOCKERS)
+    else:
+        result["evidence_state"] = "conflicting" if blocker == "conflicting_component_evidence" else "partial"
+        result["blockers"] = [blocker]
+    return result
+
+
+def inspect_manifest(manifest):
+    components = [component_view(c) for c in manifest.get("components", [])]
+    blockers = []
+    for comp in components:
+        for blocker in comp.get("blockers", []):
+            blockers.append({"component_key": comp.get("component_key"), "blocker": blocker})
+    ready = len(components) > 0 and not blockers
+    status = "ready_to_finalize" if ready else "blocked"
+    result = copy.deepcopy(manifest)
+    result["status"] = "finalized" if manifest.get("status") == "finalized" else status
+    result["components"] = components
+    result["readiness"] = {
+        "revision": manifest.get("revision"),
+        "ready": ready,
+        "status": result["status"],
+        "blockers": blockers,
+    }
+    return result
+
+
+def new_manifest(args):
+    return {
+        "schema_version": SCHEMA,
+        "bundle_key": args.bundle_key,
+        "title": args.title,
+        "purpose": args.purpose,
+        "parent_ref": args.parent_ref,
+        "child_items": args.child_item or [],
+        "finalization_owner": args.finalization_owner,
+        "rollout_notes": args.rollout_notes or "",
+        "status": "open",
+        "revision": 1,
+        "components": [
+            {
+                "component_key": key,
+                "evidence_state": "missing",
+                "blockers": list(MISSING_BLOCKERS),
+            }
+            for key in (args.component or [])
+        ],
+        "removed_components": [],
+        "readiness": None,
+        "finalization": None,
+        "audit_events": [audit_event("bundle_created", 1)],
+    }
+
+
+def stable_value(evidence, field):
+    if field in evidence:
+        return evidence[field]
+    binding = evidence.get("target_binding")
+    if isinstance(binding, dict):
+        return binding.get(field)
+    return None
+
+
+def evidence_hash(evidence):
+    encoded = json.dumps(evidence, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    import hashlib
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def component_from_evidence(args):
+    evidence = load_json_file(args.evidence_file, "evidence")
+    if evidence.get("schema_version") != EVIDENCE_SCHEMA:
+        fail("invalid_evidence_schema", f"evidence must use schema_version {EVIDENCE_SCHEMA}")
+    if not args.component_tag:
+        fail("missing_component_tag", "--component-tag is required", 2)
+    component = {
+        "component_key": args.component_key,
+        "evidence_state": "verified",
+        "evidence_schema_version": EVIDENCE_SCHEMA,
+        "evidence_hash": evidence_hash(evidence),
+        "selected_product_repo_key": stable_value(evidence, "selected_product_repo_key"),
+        "canonical_repository_identity": stable_value(evidence, "canonical_repository_identity"),
+        "release_correlation_key": stable_value(evidence, "release_correlation_key"),
+        "contract_revision": stable_value(evidence, "contract_revision"),
+        "component_tag": args.component_tag,
+        "component_version": args.component_version,
+        "source_pr": str(args.source_pr),
+        "release_pr": str(args.release_pr),
+        "routing_outcome": evidence.get("routing_outcome"),
+        "release_outcome": evidence.get("release_outcome"),
+        "ci_outcome": evidence.get("ci_outcome"),
+        "deployment_outcome": evidence.get("deployment_outcome"),
+        "cleanup_outcome": evidence.get("cleanup_outcome"),
+        "hub_tracker_ref": evidence.get("hub_tracker_ref"),
+        "hub_tracker_reconciliation_outcome": args.hub_tracker_reconciliation_outcome,
+        "child_item": args.child_item,
+        "child_release_state": args.child_release_state,
+    }
+    missing = [
+        field
+        for field in (
+            "selected_product_repo_key",
+            "canonical_repository_identity",
+            "release_correlation_key",
+            "contract_revision",
+        )
+        if not component.get(field)
+    ]
+    if missing:
+        fail("invalid_evidence_identity", "evidence is missing stable identity fields: " + ", ".join(missing))
+    return component
+
+
+def find_component(components, key):
+    for idx, component in enumerate(components):
+        if component.get("component_key") == key:
+            return idx, component
+    return None, None
+
+
+def invalidate_readiness(manifest):
+    if manifest.get("status") == "ready_to_finalize":
+        manifest["status"] = "open"
+    manifest["readiness"] = None
+
+
+def output(data, json_output):
+    if json_output:
+        print(json.dumps(data, indent=2, sort_keys=True))
+    else:
+        for key, value in data.items():
+            if isinstance(value, (dict, list)):
+                value = json.dumps(value, sort_keys=True)
+            print(f"{str(key).upper()}={value}")
+
+
+def cmd_create(args):
+    validate_bundle_key(args.bundle_key)
+    if not args.component:
+        fail("missing_component", "at least one --component is required", 2)
+    def mutate(current):
+        if current is not None:
+            fail("manifest_already_exists", "manifest already exists")
+        manifest = new_manifest(args)
+        return manifest, True, {"result": "created", "manifest": manifest}
+    output(with_lock(args.manifest, args.bundle_key, mutate), args.json)
+
+
+def cmd_add_component(args):
+    validate_bundle_key(args.bundle_key)
+    def mutate(current):
+        if current is None:
+            fail("manifest_not_found", "manifest file not found")
+        check_expected_revision(current, args.expected_revision)
+        if current.get("status") == "finalized":
+            fail("bundle_finalized", "finalized bundles cannot be changed")
+        manifest = copy.deepcopy(current)
+        idx, existing = find_component(manifest.get("components", []), args.component_key)
+        if existing is not None:
+            return manifest, False, {"result": "idempotent", "manifest": manifest}
+        manifest.setdefault("components", []).append({
+            "component_key": args.component_key,
+            "evidence_state": "missing",
+            "blockers": list(MISSING_BLOCKERS),
+        })
+        manifest["revision"] += 1
+        invalidate_readiness(manifest)
+        manifest.setdefault("audit_events", []).append(
+            audit_event("component_added", manifest["revision"], component_key=args.component_key)
+        )
+        return manifest, True, {"result": "updated", "manifest": manifest}
+    output(with_lock(args.manifest, args.bundle_key, mutate), args.json)
+
+
+def cmd_update_component(args):
+    validate_bundle_key(args.bundle_key)
+    incoming = component_from_evidence(args)
+    stable_fields = (
+        "selected_product_repo_key",
+        "canonical_repository_identity",
+        "release_correlation_key",
+        "contract_revision",
+    )
+    def mutate(current):
+        if current is None:
+            fail("manifest_not_found", "manifest file not found")
+        check_expected_revision(current, args.expected_revision)
+        if current.get("status") == "finalized":
+            fail("bundle_finalized", "finalized bundles cannot be changed")
+        manifest = copy.deepcopy(current)
+        idx, existing = find_component(manifest.get("components", []), args.component_key)
+        if existing is not None and existing.get("evidence_schema_version") == EVIDENCE_SCHEMA:
+            for field in stable_fields:
+                if existing.get(field) != incoming.get(field):
+                    fail("conflicting_component_evidence", f"component evidence conflicts on {field}")
+            if {k: existing.get(k) for k in incoming.keys()} == incoming:
+                return manifest, False, {"result": "idempotent", "manifest": manifest}
+        if idx is None:
+            manifest.setdefault("components", []).append(incoming)
+        else:
+            manifest["components"][idx] = incoming
+        manifest["revision"] += 1
+        invalidate_readiness(manifest)
+        manifest.setdefault("audit_events", []).append(
+            audit_event("component_updated", manifest["revision"], component_key=args.component_key)
+        )
+        return manifest, True, {"result": "updated", "manifest": manifest}
+    output(with_lock(args.manifest, args.bundle_key, mutate), args.json)
+
+
+def cmd_remove_component(args):
+    validate_bundle_key(args.bundle_key)
+    if not args.reason:
+        fail("missing_removal_reason", "--reason is required", 2)
+    def mutate(current):
+        if current is None:
+            fail("manifest_not_found", "manifest file not found")
+        check_expected_revision(current, args.expected_revision)
+        if current.get("status") == "finalized":
+            fail("bundle_finalized", "finalized bundles cannot be changed")
+        manifest = copy.deepcopy(current)
+        idx, existing = find_component(manifest.get("components", []), args.component_key)
+        if existing is None:
+            return manifest, False, {"result": "idempotent", "manifest": manifest}
+        removed = manifest["components"].pop(idx)
+        manifest["revision"] += 1
+        removed["removed_revision"] = manifest["revision"]
+        removed["reason"] = args.reason
+        manifest.setdefault("removed_components", []).append(removed)
+        invalidate_readiness(manifest)
+        manifest.setdefault("audit_events", []).append(
+            audit_event("component_removed", manifest["revision"], component_key=args.component_key, reason=args.reason)
+        )
+        return manifest, True, {"result": "updated", "manifest": manifest}
+    output(with_lock(args.manifest, args.bundle_key, mutate), args.json)
+
+
+def cmd_inspect(args):
+    validate_bundle_key(args.bundle_key)
+    manifest = validate_manifest(load_json_file(args.manifest, "manifest"), args.bundle_key)
+    output(inspect_manifest(manifest), args.json)
+
+
+def cmd_finalize(args):
+    validate_bundle_key(args.bundle_key)
+    def mutate(current):
+        if current is None:
+            fail("manifest_not_found", "manifest file not found")
+        check_expected_revision(current, args.expected_revision)
+        if current.get("status") == "finalized":
+            return current, False, {"result": "idempotent", "manifest": current}
+        readiness = current.get("readiness")
+        if isinstance(readiness, dict) and readiness.get("revision") != current.get("revision"):
+            fail("stale_readiness", "readiness was computed for an older manifest revision")
+        view = inspect_manifest(current)
+        blockers = view["readiness"]["blockers"]
+        if blockers:
+            fail(blockers[0]["blocker"], f"finalization blocked for {blockers[0]['component_key']}")
+        manifest = copy.deepcopy(current)
+        manifest["revision"] += 1
+        manifest["status"] = "finalized"
+        manifest["readiness"] = {
+            "revision": manifest["revision"],
+            "ready": True,
+            "status": "finalized",
+            "blockers": [],
+        }
+        manifest["finalization"] = {"revision": manifest["revision"], "finalized_at": now()}
+        manifest.setdefault("audit_events", []).append(
+            audit_event("bundle_finalized", manifest["revision"])
+        )
+        return manifest, True, {"result": "finalized", "manifest": manifest}
+    output(with_lock(args.manifest, args.bundle_key, mutate), args.json)
+
+
+def add_common(parser, expected=False):
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--bundle-key", required=True, dest="bundle_key")
+    if expected:
+        parser.add_argument("--expected-revision", required=True, type=int, dest="expected_revision")
+    parser.add_argument("--json", action="store_true")
+
+
+def main():
+    parser = Parser(prog="delivery-bundle-manifest.sh")
+    sub = parser.add_subparsers(dest="command", required=True, parser_class=Parser)
+
+    create = sub.add_parser("create")
+    add_common(create)
+    create.add_argument("--title", required=True)
+    create.add_argument("--purpose", required=True)
+    create.add_argument("--parent-ref", required=True, dest="parent_ref")
+    create.add_argument("--component", action="append", default=[])
+    create.add_argument("--child-item", action="append", default=[], dest="child_item")
+    create.add_argument("--finalization-owner", required=True, dest="finalization_owner")
+    create.add_argument("--rollout-notes", default="", dest="rollout_notes")
+    create.set_defaults(func=cmd_create)
+
+    add_component = sub.add_parser("add-component")
+    add_common(add_component, expected=True)
+    add_component.add_argument("--component-key", required=True, dest="component_key")
+    add_component.set_defaults(func=cmd_add_component)
+
+    update = sub.add_parser("update-component")
+    add_common(update, expected=True)
+    update.add_argument("--component-key", required=True, dest="component_key")
+    update.add_argument("--evidence-file", required=True, dest="evidence_file")
+    update.add_argument("--component-tag", required=True, dest="component_tag")
+    update.add_argument("--component-version", default=None, dest="component_version")
+    update.add_argument("--source-pr", required=True, dest="source_pr")
+    update.add_argument("--release-pr", required=True, dest="release_pr")
+    update.add_argument("--child-item", required=True, dest="child_item")
+    update.add_argument("--child-release-state", required=True, dest="child_release_state")
+    update.add_argument(
+        "--hub-tracker-reconciliation-outcome",
+        default="complete",
+        dest="hub_tracker_reconciliation_outcome",
+    )
+    update.set_defaults(func=cmd_update_component)
+
+    remove = sub.add_parser("remove-component")
+    add_common(remove, expected=True)
+    remove.add_argument("--component-key", required=True, dest="component_key")
+    remove.add_argument("--reason", required=True)
+    remove.set_defaults(func=cmd_remove_component)
+
+    inspect = sub.add_parser("inspect")
+    add_common(inspect)
+    inspect.set_defaults(func=cmd_inspect)
+
+    finalize = sub.add_parser("finalize")
+    add_common(finalize, expected=True)
+    finalize.set_defaults(func=cmd_finalize)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()
+PY

--- a/scripts/development-workflow/delivery-bundle-manifest.sh
+++ b/scripts/development-workflow/delivery-bundle-manifest.sh
@@ -158,8 +158,6 @@ def blocker_for_component(component):
         return "conflicting_component_evidence"
     if state == "stale":
         return "stale_readiness"
-    if state in ("missing", "partial") and component.get("evidence_schema_version") != EVIDENCE_SCHEMA:
-        return "missing_component_evidence"
     if state in ("missing", "partial"):
         return "missing_component_evidence"
     if component.get("evidence_schema_version") != EVIDENCE_SCHEMA:

--- a/scripts/development-workflow/delivery-bundle-manifest.sh
+++ b/scripts/development-workflow/delivery-bundle-manifest.sh
@@ -4,6 +4,11 @@
 
 set -euo pipefail
 
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR_CODE=missing_python3 message='python3 is required'" >&2
+  exit 2
+fi
+
 python3 - "$@" <<'PY'
 import argparse
 import copy
@@ -103,12 +108,23 @@ def atomic_write(path, data):
 
 def with_lock(path, bundle_key, mutate):
     lock_dir = f"{path}.lock"
+    parent = os.path.dirname(os.path.abspath(path)) or "."
+    try:
+        os.makedirs(parent, exist_ok=True)
+    except OSError as exc:
+        fail("manifest_write_failed", f"failed to create manifest directory: {exc}")
     try:
         os.mkdir(lock_dir)
     except FileExistsError:
         fail("lock_unavailable", f"manifest lock is already held: {lock_dir}")
     except OSError as exc:
         fail("lock_unavailable", f"failed to acquire manifest lock: {exc}")
+    owner_path = os.path.join(lock_dir, "owner.json")
+    try:
+        atomic_write(owner_path, {"pid": os.getpid(), "acquired_at": now()})
+    except SystemExit:
+        shutil.rmtree(lock_dir, ignore_errors=True)
+        raise
     try:
         current = load_json_file(path, "manifest", required=False)
         if current is not None:
@@ -313,7 +329,7 @@ def component_from_evidence(args):
     ]
     if missing:
         fail("invalid_evidence_identity", "evidence is missing stable identity fields: " + ", ".join(missing))
-    return component
+    return component_view(component)
 
 
 def find_component(components, key):
@@ -518,7 +534,7 @@ def main():
     update.add_argument("--child-release-state", required=True, dest="child_release_state")
     update.add_argument(
         "--hub-tracker-reconciliation-outcome",
-        default="complete",
+        default="pending",
         dest="hub_tracker_reconciliation_outcome",
     )
     update.set_defaults(func=cmd_update_component)

--- a/scripts/development-workflow/tests/test-delivery-bundle-manifest.sh
+++ b/scripts/development-workflow/tests/test-delivery-bundle-manifest.sh
@@ -20,6 +20,7 @@ TMP_ROOT="$(CDPATH='' cd -- "$TMP_ROOT" && pwd -P)"
 _harness_exit() {
   local status=$?
   rm -rf "$TMP_ROOT"
+  # 141 is SIGPIPE from a downstream consumer closing stdout early, not a test failure.
   case "$status" in
     141) exit 0 ;;
     *)   exit "$status" ;;

--- a/scripts/development-workflow/tests/test-delivery-bundle-manifest.sh
+++ b/scripts/development-workflow/tests/test-delivery-bundle-manifest.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# test-delivery-bundle-manifest.sh - delivery bundle manifest helper tests.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+HELPER="$REPO_ROOT/scripts/development-workflow/delivery-bundle-manifest.sh"
+
+TMP_ROOT="$(mktemp -d)"
+TMP_ROOT="$(CDPATH='' cd -- "$TMP_ROOT" && pwd -P)"
+
+_harness_exit() {
+  local status=$?
+  rm -rf "$TMP_ROOT"
+  case "$status" in
+    141) exit 0 ;;
+    *)   exit "$status" ;;
+  esac
+}
+trap _harness_exit EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_contains() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if grep -Fq -- "$expected" <<< "$actual"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected output to contain '${expected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_fails_contains() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  local output="" status=0
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ] && grep -Fq -- "$expected" <<< "$output"; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected failure containing '${expected}'"
+    printf 'Status: %s\nOutput:\n%s\n' "$status" "$output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+write_evidence() {
+  local path="$1"
+  local repo_key="$2"
+  local identity="$3"
+  local release_outcome="${4:-completed}"
+  local ci_outcome="${5:-passed}"
+  local deployment_outcome="${6:-recorded}"
+  local cleanup_outcome="${7:-complete}"
+  jq -cnS \
+    --arg repo_key "$repo_key" \
+    --arg identity "$identity" \
+    --arg release_outcome "$release_outcome" \
+    --arg ci_outcome "$ci_outcome" \
+    --arg deployment_outcome "$deployment_outcome" \
+    --arg cleanup_outcome "$cleanup_outcome" \
+    '{
+      schema_version:"component_release_evidence.v1",
+      target_binding:{
+        selected_product_repo_key:$repo_key,
+        canonical_repository_identity:$identity,
+        release_correlation_key:("sha256:" + $repo_key + "-correlation"),
+        contract_revision:("sha256:" + $repo_key + "-contract")
+      },
+      routing_outcome:"component_release_routed",
+      selected_product_repo_key:$repo_key,
+      canonical_repository_identity:$identity,
+      release_correlation_key:("sha256:" + $repo_key + "-correlation"),
+      contract_revision:("sha256:" + $repo_key + "-contract"),
+      release_branch:($repo_key + "/release/v1.0.0"),
+      release_outcome:$release_outcome,
+      ci_outcome:$ci_outcome,
+      deployment_outcome:$deployment_outcome,
+      cleanup_outcome:$cleanup_outcome,
+      hub_tracker_ref:"#1357"
+    }' > "$path"
+}
+
+create_bundle() {
+  local manifest="$1"
+  bash "$HELPER" create \
+    --manifest "$manifest" \
+    --bundle-key mobile-web-july-delivery \
+    --title "Mobile and Web July delivery" \
+    --purpose "Coordinated customer-facing July workflow-hub delivery" \
+    --parent-ref "#1352" \
+    --component mobile-app \
+    --component web-app \
+    --child-item "#1356" \
+    --child-item "#1357" \
+    --finalization-owner "@workflow-operator" \
+    --rollout-notes "No shared suite branch." \
+    --json >/dev/null
+}
+
+update_component() {
+  local manifest="$1"
+  local component="$2"
+  local evidence="$3"
+  local tag="$4"
+  local version="$5"
+  local source_pr="$6"
+  local release_pr="$7"
+  local child_item="$8"
+  bash "$HELPER" update-component \
+    --manifest "$manifest" \
+    --bundle-key mobile-web-july-delivery \
+    --expected-revision "$(jq -r '.revision' "$manifest")" \
+    --component-key "$component" \
+    --evidence-file "$evidence" \
+    --component-tag "$tag" \
+    --component-version "$version" \
+    --source-pr "$source_pr" \
+    --release-pr "$release_pr" \
+    --child-item "$child_item" \
+    --child-release-state merged \
+    --json
+}
+
+echo ""
+echo "=== Delivery bundle manifest ==="
+
+manifest="$TMP_ROOT/delivery-bundle.json"
+mobile_evidence="$TMP_ROOT/mobile-evidence.json"
+web_evidence="$TMP_ROOT/web-evidence.json"
+write_evidence "$mobile_evidence" mobile-app example/mobile-app
+write_evidence "$web_evidence" web-app example/web-app
+
+create_bundle "$manifest"
+run_test "create_schema" "delivery_bundle_manifest.v1" "$(jq -r '.schema_version' "$manifest")"
+run_test "create_bundle_key" "mobile-web-july-delivery" "$(jq -r '.bundle_key' "$manifest")"
+run_test "create_revision" "1" "$(jq -r '.revision' "$manifest")"
+run_test "create_components" "2" "$(jq -r '.components | length' "$manifest")"
+
+update_component "$manifest" mobile-app "$mobile_evidence" mobile-v1.4.0 1.4.0 1411 1501 "#1356" >/dev/null
+run_test "update_revision" "2" "$(jq -r '.revision' "$manifest")"
+run_test "update_tag" "mobile-v1.4.0" "$(jq -r '.components[] | select(.component_key == "mobile-app") | .component_tag' "$manifest")"
+run_test "web_still_declared" "1" "$(jq -r '[.components[] | select(.component_key == "web-app")] | length' "$manifest")"
+
+revision_before="$(jq -r '.revision' "$manifest")"
+audit_before="$(jq -r '.audit_events | length' "$manifest")"
+update_component "$manifest" mobile-app "$mobile_evidence" mobile-v1.4.0 1.4.0 1411 1501 "#1356" >/dev/null
+run_test "idempotent_revision_unchanged" "$revision_before" "$(jq -r '.revision' "$manifest")"
+run_test "idempotent_audit_unchanged" "$audit_before" "$(jq -r '.audit_events | length' "$manifest")"
+
+inspect_json="$(bash "$HELPER" inspect --manifest "$manifest" --bundle-key mobile-web-july-delivery --json)"
+run_test "inspect_partial_status" "blocked" "$(jq -r '.status' <<< "$inspect_json")"
+run_contains "inspect_missing_routing" "routing_evidence_missing" "$inspect_json"
+
+conflict_evidence="$TMP_ROOT/mobile-conflict.json"
+jq '.contract_revision = "sha256:conflict"' "$mobile_evidence" > "$conflict_evidence"
+manifest_hash="$(git hash-object "$manifest")"
+run_fails_contains \
+  "conflict_rejected" \
+  "ERROR_CODE=conflicting_component_evidence" \
+  update_component "$manifest" mobile-app "$conflict_evidence" mobile-v1.4.0 1.4.0 1411 1501 "#1356"
+run_test "conflict_preserves_manifest" "$manifest_hash" "$(git hash-object "$manifest")"
+
+stale_revision="$(jq -r '.revision' "$manifest")"
+bash "$HELPER" remove-component \
+  --manifest "$manifest" \
+  --bundle-key mobile-web-july-delivery \
+  --expected-revision "$stale_revision" \
+  --component-key web-app \
+  --reason "Split web delivery" \
+  --json >/dev/null
+run_test "remove_revision_incremented" "3" "$(jq -r '.revision' "$manifest")"
+run_test "remove_audited" "Split web delivery" "$(jq -r '.removed_components[] | select(.component_key == "web-app") | .reason' "$manifest")"
+manifest_hash="$(git hash-object "$manifest")"
+run_fails_contains \
+  "stale_revision_rejected" \
+  "ERROR_CODE=stale_manifest_revision" \
+  bash "$HELPER" finalize \
+    --manifest "$manifest" \
+    --bundle-key mobile-web-july-delivery \
+    --expected-revision "$stale_revision" \
+    --json
+run_test "stale_preserves_manifest" "$manifest_hash" "$(git hash-object "$manifest")"
+
+ready_bundle="$TMP_ROOT/ready-bundle.json"
+create_bundle "$ready_bundle"
+update_component "$ready_bundle" mobile-app "$mobile_evidence" mobile-v1.4.0 1.4.0 1411 1501 "#1356" >/dev/null
+update_component "$ready_bundle" web-app "$web_evidence" web-v2.8.1 2.8.1 1414 1503 "#1357" >/dev/null
+ready_inspect="$(bash "$HELPER" inspect --manifest "$ready_bundle" --bundle-key mobile-web-july-delivery --json)"
+run_test "ready_inspect_status" "ready_to_finalize" "$(jq -r '.status' <<< "$ready_inspect")"
+
+ready_add="$TMP_ROOT/ready-add.json"
+cp "$ready_bundle" "$ready_add"
+bash "$HELPER" add-component \
+  --manifest "$ready_add" \
+  --bundle-key mobile-web-july-delivery \
+  --expected-revision "$(jq -r '.revision' "$ready_add")" \
+  --component-key api-service \
+  --json >/dev/null
+run_test "add_invalidates_readiness" "null" "$(jq -c '.readiness' "$ready_add")"
+
+missing_tag="$TMP_ROOT/missing-tag.json"
+missing_evidence="$TMP_ROOT/missing-evidence.json"
+failed_outcome="$TMP_ROOT/failed-outcome.json"
+pending_outcome="$TMP_ROOT/pending-outcome.json"
+conflicting_outcome="$TMP_ROOT/conflicting-outcome.json"
+stale_readiness="$TMP_ROOT/stale-readiness.json"
+jq 'del((.components[] | select(.component_key == "mobile-app")).component_tag)' "$ready_bundle" > "$missing_tag"
+jq '(.components[] | select(.component_key == "web-app")).evidence_state = "missing"' "$ready_bundle" > "$missing_evidence"
+jq '(.components[] | select(.component_key == "mobile-app")).release_outcome = "failed"' "$ready_bundle" > "$failed_outcome"
+jq '(.components[] | select(.component_key == "mobile-app")).ci_outcome = "pending"' "$ready_bundle" > "$pending_outcome"
+jq '(.components[] | select(.component_key == "mobile-app")).evidence_state = "conflicting"' "$ready_bundle" > "$conflicting_outcome"
+jq '.readiness = {revision:(.revision - 1), ready:true, status:"ready_to_finalize", blockers:[]}' "$ready_bundle" > "$stale_readiness"
+
+for fixture in \
+  "$missing_tag|missing_component_tag" \
+  "$missing_evidence|missing_component_evidence" \
+  "$failed_outcome|blocked_component_outcome" \
+  "$pending_outcome|pending_component_outcome" \
+  "$conflicting_outcome|conflicting_component_evidence" \
+  "$stale_readiness|stale_readiness"
+do
+  fixture_path="${fixture%%|*}"
+  expected_error="${fixture##*|}"
+  manifest_hash="$(git hash-object "$fixture_path")"
+  run_fails_contains \
+    "finalize_rejects_${expected_error}" \
+    "ERROR_CODE=$expected_error" \
+    bash "$HELPER" finalize \
+      --manifest "$fixture_path" \
+      --bundle-key mobile-web-july-delivery \
+      --expected-revision "$(jq -r '.revision' "$fixture_path")" \
+      --json
+  run_test "finalize_${expected_error}_preserves_manifest" "$manifest_hash" "$(git hash-object "$fixture_path")"
+done
+
+mobile_hash="$(git hash-object "$mobile_evidence")"
+web_hash="$(git hash-object "$web_evidence")"
+revision_before="$(jq -r '.revision' "$ready_bundle")"
+bash "$HELPER" finalize \
+  --manifest "$ready_bundle" \
+  --bundle-key mobile-web-july-delivery \
+  --expected-revision "$revision_before" \
+  --json >/dev/null
+run_test "finalized_status" "finalized" "$(jq -r '.status' "$ready_bundle")"
+run_test "finalized_revision_incremented" "$((revision_before + 1))" "$(jq -r '.revision' "$ready_bundle")"
+run_test "finalized_event" "1" "$(jq -r '[.audit_events[] | select(.event == "bundle_finalized")] | length' "$ready_bundle")"
+run_test "finalized_no_shared_version" "" "$(jq -r '.shared_suite_version? // empty, .shared_release_branch? // empty' "$ready_bundle")"
+run_test "mobile_evidence_unchanged" "$mobile_hash" "$(git hash-object "$mobile_evidence")"
+run_test "web_evidence_unchanged" "$web_hash" "$(git hash-object "$web_evidence")"
+
+run_fails_contains \
+  "bundle_key_mismatch_rejected" \
+  "ERROR_CODE=bundle_key_mismatch" \
+  bash "$HELPER" inspect --manifest "$ready_bundle" --bundle-key other-bundle --json
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  echo "FAILURES: $FAIL_COUNT"
+  exit 1
+fi
+
+echo "All delivery bundle manifest tests passed ($PASS_COUNT assertions)."

--- a/scripts/development-workflow/tests/test-delivery-bundle-manifest.sh
+++ b/scripts/development-workflow/tests/test-delivery-bundle-manifest.sh
@@ -7,6 +7,13 @@ SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
 HELPER="$REPO_ROOT/scripts/development-workflow/delivery-bundle-manifest.sh"
 
+for tool in jq git python3; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "SETUP_ERROR=$tool is required" >&2
+    exit 2
+  fi
+done
+
 TMP_ROOT="$(mktemp -d)"
 TMP_ROOT="$(CDPATH='' cd -- "$TMP_ROOT" && pwd -P)"
 
@@ -142,6 +149,7 @@ update_component() {
     --component-version "$version" \
     --source-pr "$source_pr" \
     --release-pr "$release_pr" \
+    --hub-tracker-reconciliation-outcome complete \
     --child-item "$child_item" \
     --child-release-state merged \
     --json
@@ -161,6 +169,22 @@ run_test "create_schema" "delivery_bundle_manifest.v1" "$(jq -r '.schema_version
 run_test "create_bundle_key" "mobile-web-july-delivery" "$(jq -r '.bundle_key' "$manifest")"
 run_test "create_revision" "1" "$(jq -r '.revision' "$manifest")"
 run_test "create_components" "2" "$(jq -r '.components | length' "$manifest")"
+
+nested_manifest="$TMP_ROOT/nested/path/delivery-bundle.json"
+create_bundle "$nested_manifest"
+run_test "create_nested_manifest_directory" "delivery_bundle_manifest.v1" "$(jq -r '.schema_version' "$nested_manifest")"
+
+shell_manifest="$TMP_ROOT/shell-output.json"
+shell_output="$(bash "$HELPER" create \
+  --manifest "$shell_manifest" \
+  --bundle-key mobile-web-july-delivery \
+  --title "Mobile and Web July delivery" \
+  --purpose "Coordinated customer-facing July workflow-hub delivery" \
+  --parent-ref "#1352" \
+  --component mobile-app \
+  --finalization-owner "@workflow-operator")"
+run_contains "create_shell_output_result" "RESULT=created" "$shell_output"
+run_contains "create_shell_output_manifest" "MANIFEST=" "$shell_output"
 
 update_component "$manifest" mobile-app "$mobile_evidence" mobile-v1.4.0 1.4.0 1411 1501 "#1356" >/dev/null
 run_test "update_revision" "2" "$(jq -r '.revision' "$manifest")"
@@ -223,6 +247,43 @@ bash "$HELPER" add-component \
   --component-key api-service \
   --json >/dev/null
 run_test "add_invalidates_readiness" "null" "$(jq -c '.readiness' "$ready_add")"
+
+add_revision="$(jq -r '.revision' "$ready_add")"
+add_output="$(bash "$HELPER" add-component \
+  --manifest "$ready_add" \
+  --bundle-key mobile-web-july-delivery \
+  --expected-revision "$add_revision" \
+  --component-key api-service \
+  --json)"
+run_test "add_component_idempotent_result" "idempotent" "$(jq -r '.result' <<< "$add_output")"
+run_test "add_component_idempotent_revision" "$add_revision" "$(jq -r '.revision' "$ready_add")"
+
+run_fails_contains \
+  "invalid_bundle_key_rejected" \
+  "ERROR_CODE=invalid_bundle_key" \
+  bash "$HELPER" inspect --manifest "$ready_bundle" --bundle-key "bad key/#1" --json
+
+pending_default="$TMP_ROOT/pending-default.json"
+create_bundle "$pending_default"
+bash "$HELPER" update-component \
+  --manifest "$pending_default" \
+  --bundle-key mobile-web-july-delivery \
+  --expected-revision "$(jq -r '.revision' "$pending_default")" \
+  --component-key mobile-app \
+  --evidence-file "$mobile_evidence" \
+  --component-tag mobile-v1.4.0 \
+  --component-version 1.4.0 \
+  --source-pr 1411 \
+  --release-pr 1501 \
+  --child-item "#1356" \
+  --child-release-state merged \
+  --json >/dev/null
+run_test "hub_reconciliation_defaults_pending" "pending" \
+  "$(jq -r '.components[] | select(.component_key == "mobile-app") | .hub_tracker_reconciliation_outcome' "$pending_default")"
+run_test "pending_default_persisted_partial" "partial" \
+  "$(jq -r '.components[] | select(.component_key == "mobile-app") | .evidence_state' "$pending_default")"
+run_contains "pending_default_records_blocker" "pending_component_outcome" \
+  "$(jq -c '.components[] | select(.component_key == "mobile-app") | .blockers' "$pending_default")"
 
 missing_tag="$TMP_ROOT/missing-tag.json"
 missing_evidence="$TMP_ROOT/missing-evidence.json"


### PR DESCRIPTION
## Summary

- Adds `delivery-bundle-manifest.sh` for hub-owned `delivery_bundle_manifest.v1` create, update, add, inspect, remove, and finalize flows.
- Adds the delivery bundle issue template and regression coverage for atomic update semantics, idempotency, conflict/stale rejection, finalization blockers, and source evidence preservation.
- Documents delivery bundle ownership, release evidence handoff, helper usage, and the changelog entry for #1357.

## Pre-Submission Self-Review

- Scope check: diff is limited to the #1357 helper, test, issue template, workflow docs, and changelog. #1358 milestone reconciliation and #1359 adoption/assurance are not implemented here.
- Cross-cutting assumptions: still valid. Artifact owner is the hub repository; component release evidence remains product-owned and is read-only input. Approved base is `develop-multi-repo-releases`.
- Parser/concurrency risk: covered by structured JSON validation, immutable `bundle_key`, expected revision checks, manifest lock, atomic replacement, stable error codes, and regression tests.
- Residual evidence: not applicable; this is a bounded helper implementation, not a sweep or helper-extraction cleanup.

## Validation

- `bash scripts/development-workflow/tests/test-delivery-bundle-manifest.sh` passed with 38 assertions.
- `bash scripts/development-workflow/tests/test-component-release-evidence.sh` passed with 13 assertions.
- `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "docs/workflow/development-workflow/**/*.md" "scripts/development-workflow/README.md" "CHANGELOG.md"` passed with 0 issues.
- `python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md docs/specs/developments/20260731164352_1357-delivery-bundle-issue-manifest-workflow/2_1357-delivery-bundle-issue-manifest-workflow_implementation-plan.md docs/testing/workflow/1357-delivery-bundle-issue-manifest-workflow.smoke-test.md docs/workflow/development-workflow/repository-modes.md docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md scripts/development-workflow/README.md` passed.
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop` passed.
- `shellcheck scripts/development-workflow/delivery-bundle-manifest.sh scripts/development-workflow/tests/test-delivery-bundle-manifest.sh` passed.
- `git diff --check origin/develop-multi-repo-releases...HEAD` passed.

Closes #1357


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tooling to create, inspect, update, and finalize delivery bundle manifests.
  - Added component release evidence tracking, readiness checks, audit history, revision control, and validation.
  - Added a GitHub issue template for documenting delivery bundles.

- **Documentation**
  - Documented the delivery bundle workflow, release evidence procedures, and command usage.
  - Added an unreleased changelog entry.

- **Tests**
  - Added coverage for manifest lifecycle operations, validation, idempotency, failures, and finalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->