### PR TITLE
fix(workflow): handle Bugbot explicit skips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Bugbot explicit skip handling** (#1381): Treat Cursor Bugbot explicit skip
+  comments as warning-only skipped reviews instead of unavailable or blocking
+  reviewer failures.
+
 ## [0.40.0] - 2026-07-30
 
 ### Added

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1900,7 +1900,7 @@ run_bugbot_review() {
             return 1
           fi
 
-          if [ "$clean_explicit_skip_seen" -eq 1 ]; then
+          if [ "$clean_explicit_skip_seen" -eq 1 ] && [ "$blocking_count" -eq 0 ]; then
             rm -f "$blocking_lines_file"
             bugbot_return_explicit_skip "$pr_number" "$branch_name"
             return 0

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -18,6 +18,8 @@ if [ "${HARNESS_MODE:-0}" -eq 1 ] && [ "${BASH_SOURCE[0]}" != "$0" ]; then
   _HARNESS_MODE_EFFECTIVE=1
 fi
 
+BUGBOT_HANDLED_SKIP_RC=3
+
 # --- unlock subcommand ---
 # Must run before the single-instance lock guard so stale-lock recovery always
 # works: if a previous invocation crashed, the lock guard would re-acquire the
@@ -1182,6 +1184,23 @@ bugbot_return_usage_limit() {
   return 2
 }
 
+bugbot_return_explicit_skip() {
+  local pr_number="$1"
+  local branch_name="$2"
+
+  echo "WARN: Bugbot explicitly skipped this PR. Treating the skip as a non-blocking warning; no Bugbot review findings were produced." >&2
+  print_kv RESULT skipped
+  print_kv REASON explicit-skip
+  print_kv PLATFORM bugbot
+  print_kv PR_NUMBER "$pr_number"
+  print_kv BRANCH "$branch_name"
+  print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+  print_kv COMMENT_COUNT 1
+  print_kv BLOCKING_COUNT 0
+  print_kv SUGGESTION_COUNT 1
+  return 0
+}
+
 bugbot_since_iso_for_sha() {
   local repo="$1"
   local head_sha="$2"
@@ -1229,6 +1248,10 @@ bugbot_check_disabled_issue_comments() {
   return 0
 }
 
+# Returns:
+#   0 when no unavailable/skip comment applies
+#   2 when an escalation or disabled/usage-limit outcome was emitted
+#   BUGBOT_HANDLED_SKIP_RC when an explicit successful skip outcome was emitted
 bugbot_escalate_for_unavailable_issue_comments() {
   local repo="$1"
   local pr_number="$2"
@@ -1268,6 +1291,10 @@ bugbot_escalate_for_unavailable_issue_comments() {
     if [ "$allow_usage_limit" -eq 1 ] && is_bugbot_usage_limit_message "$body"; then
       bugbot_return_usage_limit "$pr_number" "$branch_name"
       return 2
+    fi
+    if is_bugbot_explicit_skip_message "$body"; then
+      bugbot_return_explicit_skip "$pr_number" "$branch_name"
+      return "$BUGBOT_HANDLED_SKIP_RC"
     fi
   done <<< "$unavailable_bodies"
 
@@ -1381,6 +1408,9 @@ bugbot_escalate_if_disabled_without_check_run() {
   set -e
   if [ "$_unavailable_comments_rc" -eq 2 ]; then
     return 2
+  fi
+  if [ "$_unavailable_comments_rc" -eq "$BUGBOT_HANDLED_SKIP_RC" ]; then
+    return "$BUGBOT_HANDLED_SKIP_RC"
   fi
 
   return 0
@@ -1556,6 +1586,11 @@ run_bugbot_review() {
       existing_suggestion_count=$((existing_suggestion_count + 1))
       continue
     fi
+    if is_bugbot_explicit_skip_message "$body"; then
+      rm -f "$existing_blocking_file"
+      bugbot_return_explicit_skip "$pr_number" "$branch_name"
+      return 0
+    fi
     # Bugbot informational notes are counted as suggestions, not blockers (AC-4).
     if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
       existing_suggestion_count=$((existing_suggestion_count + 1))
@@ -1601,6 +1636,11 @@ run_bugbot_review() {
       fi
       existing_suggestion_count=$((existing_suggestion_count + 1))
       continue
+    fi
+    if is_bugbot_explicit_skip_message "$body"; then
+      rm -f "$existing_blocking_file"
+      bugbot_return_explicit_skip "$pr_number" "$branch_name"
+      return 0
     fi
     if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
       existing_suggestion_count=$((existing_suggestion_count + 1))
@@ -1675,6 +1715,9 @@ run_bugbot_review() {
     set -e
     if [ "$_bb_disabled_rc" -eq 2 ]; then
       return 2
+    fi
+    if [ "$_bb_disabled_rc" -eq "$BUGBOT_HANDLED_SKIP_RC" ]; then
+      return 0
     fi
     # No Cursor Bugbot check run for this head — post the trigger comment.
     set +e
@@ -1771,6 +1814,9 @@ run_bugbot_review() {
       if [ "$_bb_disabled_poll_rc" -eq 2 ]; then
         return 2
       fi
+      if [ "$_bb_disabled_poll_rc" -eq "$BUGBOT_HANDLED_SKIP_RC" ]; then
+        return 0
+      fi
     fi
 
     if [ "$status_val" = "completed" ]; then
@@ -1815,6 +1861,10 @@ run_bugbot_review() {
             comment_count=$((comment_count + 1))
             if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
               suggestion_count=$((suggestion_count + 1))
+            elif is_bugbot_explicit_skip_message "$body"; then
+              rm -f "$blocking_lines_file"
+              bugbot_return_explicit_skip "$pr_number" "$branch_name"
+              return 0
             else
               blocking_count=$((blocking_count + 1))
               printf '%s\n' "$comment_json" >> "$blocking_lines_file"
@@ -1914,6 +1964,10 @@ run_bugbot_review() {
             comment_count=$((comment_count + 1))
             if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
               suggestion_count=$((suggestion_count + 1))
+            elif is_bugbot_explicit_skip_message "$body"; then
+              rm -f "$blocking_lines_file"
+              bugbot_return_explicit_skip "$pr_number" "$branch_name"
+              return 0
             else
               blocking_count=$((blocking_count + 1))
               inline_count=$((inline_count + 1))
@@ -1934,6 +1988,10 @@ run_bugbot_review() {
               suggestion_count=$((suggestion_count + 1))
               comment_count=$((comment_count + 1))
               continue
+            elif is_bugbot_explicit_skip_message "$body"; then
+              rm -f "$blocking_lines_file"
+              bugbot_return_explicit_skip "$pr_number" "$branch_name"
+              return 0
             fi
             # For COMMENTED reviews, treat as blocking when there are inline
             # blocking comments (umbrella review) or when the body carries
@@ -1995,6 +2053,9 @@ run_bugbot_review() {
           set -e
           if [ "$_bb_neutral_unavailable_rc" -eq 2 ]; then
             return 2
+          fi
+          if [ "$_bb_neutral_unavailable_rc" -eq "$BUGBOT_HANDLED_SKIP_RC" ]; then
+            return 0
           fi
 
           # Non-blocking informational outcome — clean, no real findings.

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1554,6 +1554,7 @@ run_bugbot_review() {
   fi
 
   existing_blocking_file="$(mktemp)"
+  local existing_explicit_skip_seen=0
 
   while IFS= read -r comment_json; do
     [ -z "${comment_json:-}" ] && continue
@@ -1587,9 +1588,9 @@ run_bugbot_review() {
       continue
     fi
     if is_bugbot_explicit_skip_message "$body"; then
-      rm -f "$existing_blocking_file"
-      bugbot_return_explicit_skip "$pr_number" "$branch_name"
-      return 0
+      existing_explicit_skip_seen=1
+      existing_suggestion_count=$((existing_suggestion_count + 1))
+      continue
     fi
     # Bugbot informational notes are counted as suggestions, not blockers (AC-4).
     if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
@@ -1638,9 +1639,9 @@ run_bugbot_review() {
       continue
     fi
     if is_bugbot_explicit_skip_message "$body"; then
-      rm -f "$existing_blocking_file"
-      bugbot_return_explicit_skip "$pr_number" "$branch_name"
-      return 0
+      existing_explicit_skip_seen=1
+      existing_suggestion_count=$((existing_suggestion_count + 1))
+      continue
     fi
     if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
       existing_suggestion_count=$((existing_suggestion_count + 1))
@@ -1649,6 +1650,12 @@ run_bugbot_review() {
     existing_blocking_count=$((existing_blocking_count + 1))
     printf '%s\n' "$review_json" >> "$existing_blocking_file"
   done <<< "$existing_reviews"
+
+  if [ "$existing_explicit_skip_seen" -eq 1 ] && [ "$existing_blocking_count" -eq 0 ]; then
+    rm -f "$existing_blocking_file"
+    bugbot_return_explicit_skip "$pr_number" "$branch_name"
+    return 0
+  fi
 
   if [ "$existing_blocking_count" -gt 0 ]; then
     print_kv RESULT needs_fixes
@@ -1826,6 +1833,7 @@ run_bugbot_review() {
           # No blocking findings per the check run. Read cursor[bot] inline
           # comments to confirm and collect any suggestions.
           blocking_lines_file="$(mktemp)"
+          local clean_explicit_skip_seen=0
           set +e
 	          local _clean_comments
 	          local _clean_comments_rc=0
@@ -1862,9 +1870,8 @@ run_bugbot_review() {
             if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
               suggestion_count=$((suggestion_count + 1))
             elif is_bugbot_explicit_skip_message "$body"; then
-              rm -f "$blocking_lines_file"
-              bugbot_return_explicit_skip "$pr_number" "$branch_name"
-              return 0
+              clean_explicit_skip_seen=1
+              suggestion_count=$((suggestion_count + 1))
             else
               blocking_count=$((blocking_count + 1))
               printf '%s\n' "$comment_json" >> "$blocking_lines_file"
@@ -1893,6 +1900,12 @@ run_bugbot_review() {
             return 1
           fi
 
+          if [ "$clean_explicit_skip_seen" -eq 1 ]; then
+            rm -f "$blocking_lines_file"
+            bugbot_return_explicit_skip "$pr_number" "$branch_name"
+            return 0
+          fi
+
           rm -f "$blocking_lines_file"
           print_kv RESULT clean
           print_kv PLATFORM "$platform"
@@ -1908,6 +1921,7 @@ run_bugbot_review() {
         failure|action_required)
           # Blocking findings. Read cursor[bot] reviews/comments for the summary.
           blocking_lines_file="$(mktemp)"
+          local blocking_explicit_skip_seen=0
           set +e
 	          local _blocking_comments _blocking_reviews
 	          local _blocking_comments_rc=0
@@ -1965,9 +1979,8 @@ run_bugbot_review() {
             if is_soft_suggestion "$body" || is_bugbot_clean_review "$body"; then
               suggestion_count=$((suggestion_count + 1))
             elif is_bugbot_explicit_skip_message "$body"; then
-              rm -f "$blocking_lines_file"
-              bugbot_return_explicit_skip "$pr_number" "$branch_name"
-              return 0
+              blocking_explicit_skip_seen=1
+              suggestion_count=$((suggestion_count + 1))
             else
               blocking_count=$((blocking_count + 1))
               inline_count=$((inline_count + 1))
@@ -1989,9 +2002,10 @@ run_bugbot_review() {
               comment_count=$((comment_count + 1))
               continue
             elif is_bugbot_explicit_skip_message "$body"; then
-              rm -f "$blocking_lines_file"
-              bugbot_return_explicit_skip "$pr_number" "$branch_name"
-              return 0
+              blocking_explicit_skip_seen=1
+              suggestion_count=$((suggestion_count + 1))
+              comment_count=$((comment_count + 1))
+              continue
             fi
             # For COMMENTED reviews, treat as blocking when there are inline
             # blocking comments (umbrella review) or when the body carries
@@ -2011,6 +2025,12 @@ run_bugbot_review() {
             blocking_count=$((blocking_count + 1))
             printf '%s\n' "$review_json" >> "$blocking_lines_file"
           done <<< "${_blocking_reviews:-}"
+
+          if [ "$blocking_explicit_skip_seen" -eq 1 ] && [ "$blocking_count" -eq 0 ]; then
+            rm -f "$blocking_lines_file"
+            bugbot_return_explicit_skip "$pr_number" "$branch_name"
+            return 0
+          fi
 
           # Ensure BLOCKING_COUNT >= 1 when the check run verdict is blocking,
           # even when cursor[bot] embeds all findings in the review body.

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -1185,6 +1185,11 @@ bugbot_return_usage_limit() {
 }
 
 bugbot_return_explicit_skip() {
+  if [ "$#" -ne 2 ]; then
+    echo "ERROR: bugbot_return_explicit_skip requires exactly 2 arguments." >&2
+    return 1
+  fi
+
   local pr_number="$1"
   local branch_name="$2"
 

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2998,6 +2998,8 @@ case "$*" in
     printf 'abc162bsha\n'; exit 0 ;;
   *"--jq .commit.committer.date"*)
     printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"--method POST"*)
+    printf 'ERROR: trigger POST reached unexpectedly\n' >&2; exit 1 ;;
   *"pulls/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/reviews"*)
@@ -3195,10 +3197,8 @@ case "$*" in
     exit 0 ;;
   *"check-runs"*)
     printf '{"check_runs":[]}\n'; exit 0 ;;
-  *"--method POST"*)
-    printf 'ERROR: trigger POST reached unexpectedly\n' >&2; exit 1 ;;
   *)
-    printf '[]\n'; exit 0 ;;
+    printf 'ERROR: unexpected gh call: %s\n' "$*" >&2; exit 1 ;;
 esac
 BUGBOT_GH_164B
 chmod +x "$_bugbot_mock_dir_164b/gh"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2812,6 +2812,22 @@ else
 fi
 run_test "bugbot_clean_phrase_not_usage_limit" "active" "$actual"
 
+bugbot_explicit_skip_body="Skipping Bugbot: your auto mode classified this PR to skip. Visit the Bugbot dashboard to update your settings."
+if is_bugbot_explicit_skip_message "$bugbot_explicit_skip_body"; then
+  actual="explicit_skip"
+else
+  actual="active"
+fi
+run_test "bugbot_explicit_skip_message_detected" "explicit_skip" "$actual"
+
+if is_bugbot_explicit_skip_message "Cursor Bugbot found no issues in this pull request."; then
+  actual="explicit_skip"
+else
+  actual="active"
+fi
+run_test "bugbot_clean_phrase_not_explicit_skip" "active" "$actual"
+unset bugbot_explicit_skip_body actual
+
 # ---------------------------------------------------------------------------
 # Test 16.1: clean path — check run conclusion=success, no blocking comments
 # ---------------------------------------------------------------------------
@@ -3100,6 +3116,58 @@ run_test "bugbot_unavailable_reason" "REASON=unavailable" \
 run_test "bugbot_unavailable_exit_code" "2" "$actual_exit"
 rm -rf "$_bugbot_mock_dir_164"
 unset _bugbot_mock_dir_164 actual_output actual_exit
+
+# ---------------------------------------------------------------------------
+# Test 16.4b: explicit Bugbot skip issue comment is warning-only
+#
+# Cursor can post an issue comment saying Bugbot skipped the PR before a check
+# run appears. That is an explicit platform decision, not an unavailable
+# reviewer; the loop must surface it as RESULT=skipped and avoid trigger POST.
+# ---------------------------------------------------------------------------
+_bugbot_mock_dir_164b="$(mktemp -d)"
+cat > "$_bugbot_mock_dir_164b/gh" <<'BUGBOT_GH_164B'
+#!/usr/bin/env bash
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc164bsha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"user":{"login":"cursor[bot]"},"created_at":"2020-01-02T00:00:00Z","body":"Skipping Bugbot: your auto mode classified this PR to skip. Visit the Bugbot dashboard to update your settings."}]\n'
+    exit 0 ;;
+  *"check-runs"*)
+    printf '{"check_runs":[]}\n'; exit 0 ;;
+  *"--method POST"*)
+    printf 'ERROR: trigger POST reached unexpectedly\n' >&2; exit 1 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+BUGBOT_GH_164B
+chmod +x "$_bugbot_mock_dir_164b/gh"
+
+unset BUGBOT_BOT_LOGIN BUGBOT_CHECK_NAME BUGBOT_TRIGGER_COMMENT
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_bugbot_overrides"
+  _ec=0
+  PATH="$_bugbot_mock_dir_164b:$PATH" run_bugbot_review "42" "feature/42-test" "1" "5" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "bugbot_explicit_skip_result" "RESULT=skipped" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "bugbot_explicit_skip_reason" "REASON=explicit-skip" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+run_test "bugbot_explicit_skip_blocking_count" "BLOCKING_COUNT=0" \
+  "$(printf '%s\n' "$actual_output" | grep "^BLOCKING_COUNT=")"
+run_test "bugbot_explicit_skip_exit_code" "0" "$actual_exit"
+rm -rf "$_bugbot_mock_dir_164b"
+unset _bugbot_mock_dir_164b actual_output actual_exit
 
 # ---------------------------------------------------------------------------
 # Test 16.5: escalate (head-sha-unavailable) — pulls API returns empty SHA

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2883,6 +2883,60 @@ run_test "bugbot_clean_exit_code" "0" "$actual_exit"
 rm -rf "$_bugbot_mock_dir_161"
 unset _bugbot_mock_dir_161 actual_output actual_exit
 
+# A successful check-run with both an explicit skip and a real finding must
+# preserve the blocker. The comments endpoint returns empty for Phase 1, then
+# mixed comments for the success-conclusion inspection.
+_bugbot_mock_dir_161b="$(mktemp -d)"
+printf '0\n' > "$_bugbot_mock_dir_161b/comment_calls"
+cat > "$_bugbot_mock_dir_161b/gh" <<'BUGBOT_GH_161B'
+#!/usr/bin/env bash
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc161bsha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    calls_file="$(dirname "$0")/comment_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    if [ "$calls" -eq 1 ]; then
+      printf '[]\n'
+    else
+      printf '[{"user":{"login":"cursor[bot]"},"created_at":"2020-01-02T00:00:00Z","commit_id":"abc161bsha","path":"src/lib.c","line":10,"body":"Skipping Bugbot: your auto mode classified this PR to skip. Visit the Bugbot dashboard to update your settings."},{"user":{"login":"cursor[bot]"},"created_at":"2020-01-02T00:01:00Z","commit_id":"abc161bsha","path":"src/lib.c","line":11,"body":"BUGBOT_REVIEW: null pointer"}]\n'
+    fi
+    exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"check-runs"*)
+    printf '{"check_runs":[{"name":"Cursor Bugbot","app":{"slug":"cursor"},"status":"completed","conclusion":"success","started_at":"2020-01-01T00:00:00Z"}]}\n'
+    exit 0 ;;
+  *"headRefOid"*)
+    printf 'abc161bsha\n'; exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+BUGBOT_GH_161B
+chmod +x "$_bugbot_mock_dir_161b/gh"
+
+unset BUGBOT_BOT_LOGIN BUGBOT_CHECK_NAME BUGBOT_TRIGGER_COMMENT
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_bugbot_overrides"
+  _ec=0
+  PATH="$_bugbot_mock_dir_161b:$PATH" run_bugbot_review "42" "feature/42-test" "1" "5" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "bugbot_success_blocker_beats_explicit_skip_result" "RESULT=needs_fixes" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "bugbot_success_blocker_beats_explicit_skip_blocking_count" "BLOCKING_COUNT=1" \
+  "$(printf '%s\n' "$actual_output" | grep "^BLOCKING_COUNT=")"
+run_test "bugbot_success_blocker_beats_explicit_skip_exit_code" "1" "$actual_exit"
+rm -rf "$_bugbot_mock_dir_161b"
+unset _bugbot_mock_dir_161b actual_output actual_exit
+
 # ---------------------------------------------------------------------------
 # Test 16.2: needs_fixes path — conclusion=failure, blocking cursor[bot] review
 # ---------------------------------------------------------------------------

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3257,6 +3257,48 @@ run_test "bugbot_existing_findings_exit_code" "1" "$actual_exit"
 rm -rf "$_bugbot_mock_dir_166"
 unset _bugbot_mock_dir_166 actual_output actual_exit
 
+# Existing blockers must take precedence over an explicit skip comment.
+_bugbot_mock_dir_166b="$(mktemp -d)"
+cat > "$_bugbot_mock_dir_166b/gh" <<'BUGBOT_GH_166B'
+#!/usr/bin/env bash
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc166bsha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[{"user":{"login":"cursor[bot]"},"created_at":"2020-01-02T00:00:00Z","commit_id":"abc166bsha","path":"src/lib.c","line":10,"body":"BUGBOT_REVIEW: null pointer"},{"user":{"login":"cursor[bot]"},"created_at":"2020-01-02T00:01:00Z","commit_id":"abc166bsha","path":"src/lib.c","line":11,"body":"Skipping Bugbot: your auto mode classified this PR to skip. Visit the Bugbot dashboard to update your settings."}]\n'
+    exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"check-runs"*)
+    printf 'ERROR: check-runs reached unexpectedly\n' >&2; exit 1 ;;
+  *"--method POST"*)
+    printf 'ERROR: trigger POST reached unexpectedly\n' >&2; exit 1 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+BUGBOT_GH_166B
+chmod +x "$_bugbot_mock_dir_166b/gh"
+
+unset BUGBOT_BOT_LOGIN BUGBOT_CHECK_NAME BUGBOT_TRIGGER_COMMENT
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_bugbot_overrides"
+  _ec=0
+  PATH="$_bugbot_mock_dir_166b:$PATH" run_bugbot_review "42" "feature/42-test" "1" "5" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "bugbot_existing_blocker_beats_explicit_skip_result" "RESULT=needs_fixes" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "bugbot_existing_blocker_beats_explicit_skip_blocking_count" "BLOCKING_COUNT=1" \
+  "$(printf '%s\n' "$actual_output" | grep "^BLOCKING_COUNT=")"
+run_test "bugbot_existing_blocker_beats_explicit_skip_exit_code" "1" "$actual_exit"
+rm -rf "$_bugbot_mock_dir_166b"
+unset _bugbot_mock_dir_166b actual_output actual_exit
+
 # ---------------------------------------------------------------------------
 # Test 16.7: trigger-failed path — trigger comment POST fails
 #

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -450,6 +450,11 @@ is_bugbot_disabled_message() {
 }
 
 is_bugbot_explicit_skip_message() {
+  if [ "$#" -ne 1 ]; then
+    echo "ERROR: is_bugbot_explicit_skip_message requires exactly 1 argument." >&2
+    return 1
+  fi
+
   local body="$1"
 
   case "$body" in

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -449,6 +449,17 @@ is_bugbot_disabled_message() {
   return 1
 }
 
+is_bugbot_explicit_skip_message() {
+  local body="$1"
+
+  case "$body" in
+    *"Skipping Bugbot:"*|*"Bugbot skipped"*|*"Bugbot was skipped"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 is_bugbot_usage_limit_message() {
   local body="$1"
 


### PR DESCRIPTION
## Summary
- classify explicit Cursor Bugbot skip comments as warning-only skipped reviews
- return `RESULT=skipped` / `REASON=explicit-skip` with zero blocking findings
- add regression coverage for the downstream skip text

## Verification
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh`
- `git diff --check`

Closes #1381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Explicit Bugbot skips are now treated as non-blocking skipped reviews rather than unavailable or failed reviews.
  * Skipped reviews complete successfully without triggering unnecessary review requests.
  * Existing blocking findings continue to take precedence over skip notices.

* **Tests**
  * Added coverage for recognizing valid Bugbot skip messages and ignoring ordinary clean-review comments.

* **Documentation**
  * Documented the updated Bugbot skip behavior in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->