### PR TITLE
docs(workflow): clarify Cursor model quota guidance

### DIFF
--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -30,6 +30,12 @@ Repository-specific workflow providers live in `.ai-dev-workflow.yaml`. Today, `
 - Always update CHANGELOG before opening a PR (except spec/plan-only PRs; for fixes to unreleased work, update the existing entry instead of adding a new one; in parallel batches, each PR adds its own CHANGELOG entry as normal; merge conflicts are resolved at merge time); **hotfix exception**: `hotfix/*` PRs write a new versioned section (e.g., `[1.0.1] - YYYY-MM-DD`) as the **first `##` section** in `CHANGELOG.md` (above all existing headers, including prior hotfix versions and `[Unreleased]`) — hotfixes patch released code and are released immediately on merge
 - No `git push --force`, `reset --hard`, or rebase on shared branches without explicit human approval
 - Humans merge PRs — agents open them
+- Cursor Task/subagent runs consume model quota according to the subagent's
+  configured `model` in `.cursor/agents/*.md`, not just the Composer model.
+  Use `/run-item` and the configured subagents for normal workflow runs; override
+  a subagent model only for a specific complexity, cost, quota, or failover
+  reason and restore the tier intent afterward. See
+  `docs/workflow/development-workflow/agent-model-config.md`.
 
 ### Development artifacts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Cursor model quota guidance** (#1407): Clarify Cursor Task/subagent model
+  quota behavior and the decision path for one-off subagent model overrides.
+
 ## [0.40.0] - 2026-07-30
 
 ### Added

--- a/docs/workflow/development-workflow/agent-model-config.md
+++ b/docs/workflow/development-workflow/agent-model-config.md
@@ -74,6 +74,19 @@ Set models in `.cursor/agents/*.md` so subagents do not inherit the parent Compo
 
 The `fast` economy assignments below are intentional for high-volume orchestration loops where predictable cost and latency matter more than deep reasoning. The remaining `auto` assignments are for lower-risk balanced agents that primarily verify or run checklist-style workflows; Cursor may route those runs to different concrete models over time, so their cost and latency can vary by workspace settings. Balanced agents that author production code or perform deep review stay pinned to Grok 4.5 High to keep complex reasoning capacity predictable.
 
+Cursor Task/subagent runs consume quota for the model selected by the subagent's
+`model` field. Setting the Composer to a cheaper or more expensive model does
+not automatically change a pinned subagent. Treat `fast`, `auto`, pinned IDs,
+and `inherit` as quota controls:
+
+- `fast` is the predictable low-cost path for high-volume coordination.
+- `auto` lets Cursor choose the backing model, so quality, latency, and quota
+  usage can change with workspace settings.
+- A pinned model gives predictable capability and predictable quota class, but
+  it can exhaust that model's quota sooner during long review-fix loops.
+- `inherit` intentionally spends whatever model the Composer currently uses;
+  use it only when that inheritance is the desired override.
+
 | Agent | Tier | Cursor `model` (template default) |
 | ----- | ---- | ----------------------------------- |
 | `orchestrator` | `economy` | `fast` |
@@ -140,6 +153,21 @@ Cursor subagents use the `model` field in `.cursor/agents/<agent>.md`. To overri
 
 - Switch your Composer's model before invoking the subagent (e.g., `/developer`), or
 - Create a duplicate agent file (e.g., `developer-premium.md`) with a different `model` value
+
+Use this decision path before overriding Cursor models:
+
+1. If the task matches the normal workflow role, keep the checked-in subagent
+   model so the tier policy and quota expectations remain stable.
+2. If a run is failing because the selected model lacks reasoning capacity,
+   temporarily move only that role to the next higher tier or a pinned
+   high-reasoning model.
+3. If quota or latency is the blocker and the task is mechanical, temporarily
+   move only that role to `fast` or `auto`.
+4. If you need the subagent to follow the current Composer model for one run,
+   use `inherit` deliberately and record why; do not leave long-running
+   orchestrators, item runners, reviewer loops, or fix-loop agents on `inherit`.
+5. After the one-off run, restore the repository's tier intent unless the team
+   is intentionally changing the default for future work.
 
 **Option 2 — Permanent change:**
 Edit the model configuration for the agent:


### PR DESCRIPTION
## Summary
- document Cursor Task/subagent model quota behavior
- add a one-off Cursor model override decision path
- surface the guidance in the Cursor workflow rule

## Verification
- `npx markdownlint-cli2 ".cursor/rules/workflow.mdc" "docs/workflow/development-workflow/agent-model-config.md" "CHANGELOG.md"`
- `git diff --check`

Closes #1407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on how model selection affects Cursor task and subagent quota usage.
  * Documented recommended workflows for using configured models and temporary model overrides.
  * Clarified the behavior of `fast`, `auto`, pinned models, and inherited model settings.
  * Added an Unreleased changelog entry for these workflow updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->