### PR TITLE
fix(workflow): clarify post-merge QA tracker scope

### DIFF
--- a/.agents/skills/post-merge-qa/SKILL.md
+++ b/.agents/skills/post-merge-qa/SKILL.md
@@ -18,6 +18,8 @@ exactly. `/merged-qa-tester` is a compatibility alias with identical behavior.
 
 ## Scope helper
 
+<!-- workflow-shell-contract: bash-zsh -->
+
 ```bash
 ./scripts/development-workflow/post-merge-qa-scope.sh \
   --base <develop|develop-slug> \

--- a/.agents/skills/post-merge-qa/SKILL.md
+++ b/.agents/skills/post-merge-qa/SKILL.md
@@ -21,7 +21,8 @@ exactly. `/merged-qa-tester` is a compatibility alias with identical behavior.
 ```bash
 ./scripts/development-workflow/post-merge-qa-scope.sh \
   --base <develop|develop-slug> \
-  [--epic <n>] [--issues <csv>] [--recent-merged-prs <n>] \
+  [--epic <n>] [--issues <csv>] [--tracker-items <csv>] \
+  [--recent-merged-prs <n>] \
   --json
 ```
 

--- a/.codex/skills/post-merge-qa/SKILL.md
+++ b/.codex/skills/post-merge-qa/SKILL.md
@@ -18,6 +18,8 @@ exactly. `/merged-qa-tester` is a compatibility alias with identical behavior.
 
 ## Scope helper
 
+<!-- workflow-shell-contract: bash-zsh -->
+
 ```bash
 ./scripts/development-workflow/post-merge-qa-scope.sh \
   --base <develop|develop-slug> \

--- a/.codex/skills/post-merge-qa/SKILL.md
+++ b/.codex/skills/post-merge-qa/SKILL.md
@@ -21,7 +21,8 @@ exactly. `/merged-qa-tester` is a compatibility alias with identical behavior.
 ```bash
 ./scripts/development-workflow/post-merge-qa-scope.sh \
   --base <develop|develop-slug> \
-  [--epic <n>] [--issues <csv>] [--recent-merged-prs <n>] \
+  [--epic <n>] [--issues <csv>] [--tracker-items <csv>] \
+  [--recent-merged-prs <n>] \
   --json
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Post-merge QA scope discovery**: Prefer configured tracker post-merge items
+  on `develop`, keep integration-branch QA semantics explicit, and allow
+  provider-backed tracker IDs to seed the read-only scope helper.
 - **Bugbot explicit skip handling** (#1381): Treat Cursor Bugbot explicit skip
   comments as warning-only skipped reviews instead of unavailable or blocking
   reviewer failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Post-merge QA scope discovery**: Prefer configured tracker post-merge items
+  on `develop`, keep integration-branch QA semantics explicit, and allow
+  provider-backed tracker IDs to seed the read-only scope helper.
 - **Template sync review hardening**: Backport reviewer-discovered safeguards
   for batch merge metadata, reviewed-head pinning, delegated epic merge
   evidence, reviewer-loop blockers, reviewer bypass authorization, PR-bound
@@ -29,9 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Post-merge QA scope discovery**: Prefer configured tracker post-merge items
-  on `develop`, keep integration-branch QA semantics explicit, and allow
-  provider-backed tracker IDs to seed the read-only scope helper.
 - **Bugbot explicit skip handling** (#1381): Treat Cursor Bugbot explicit skip
   comments as warning-only skipped reviews instead of unavailable or blocking
   reviewer failures.

--- a/docs/workflow/development-workflow/protocols/08-post-merge-qa-protocol.md
+++ b/docs/workflow/development-workflow/protocols/08-post-merge-qa-protocol.md
@@ -62,7 +62,10 @@ Default proposal preference (when the operator did not already pin items):
 - For `develop`: provider-backed tracker items in the repository's configured
   post-merge state (for example, `Merged`) that have shipped onto `QA_BASE`.
   Resolve the provider from `.ai-dev-workflow.yaml` (`issue_tracker.provider`)
-  when configured; do not hardcode one tracker vendor into the protocol.
+  when configured; do not hardcode one tracker vendor into the protocol. When
+  the helper sees a configured provider but no `--tracker-items`, it must return
+  an empty `tracker-post-merge` proposal and require discovery before human
+  confirmation; it must not silently substitute a PR-derived fallback.
 - For `develop-<slug>`: items and PRs associated with that integration branch
   and already merged into that branch. Do not require final post-merge tracker
   state for integration-branch QA unless the repository's tracker workflow

--- a/docs/workflow/development-workflow/protocols/08-post-merge-qa-protocol.md
+++ b/docs/workflow/development-workflow/protocols/08-post-merge-qa-protocol.md
@@ -64,8 +64,9 @@ Default proposal preference (when the operator did not already pin items):
   Resolve the provider from `.ai-dev-workflow.yaml` (`issue_tracker.provider`)
   when configured; do not hardcode one tracker vendor into the protocol. When
   the helper sees a configured provider but no `--tracker-items`, it must return
-  an empty `tracker-post-merge` proposal and require discovery before human
-  confirmation; it must not silently substitute a PR-derived fallback.
+  an empty, non-confirmable `tracker-post-merge` proposal (`discoveryRequired:
+  true`) and require discovery before human confirmation; it must not silently
+  substitute a PR-derived fallback.
 - For `develop-<slug>`: items and PRs associated with that integration branch
   and already merged into that branch. Do not require final post-merge tracker
   state for integration-branch QA unless the repository's tracker workflow

--- a/docs/workflow/development-workflow/protocols/08-post-merge-qa-protocol.md
+++ b/docs/workflow/development-workflow/protocols/08-post-merge-qa-protocol.md
@@ -45,6 +45,8 @@ Record the resolved target as `QA_BASE`.
 
 Prefer the helper:
 
+<!-- workflow-shell-contract: bash-zsh -->
+
 ```bash
 ./scripts/development-workflow/post-merge-qa-scope.sh \
   --base "$QA_BASE" \

--- a/docs/workflow/development-workflow/protocols/08-post-merge-qa-protocol.md
+++ b/docs/workflow/development-workflow/protocols/08-post-merge-qa-protocol.md
@@ -50,21 +50,34 @@ Prefer the helper:
   --base "$QA_BASE" \
   [--epic <number>] \
   [--issues <csv>] \
+  [--tracker-items <csv>] \
   [--recent-merged-prs <n>] \
   --json
 ```
 
 Default proposal preference (when the operator did not already pin items):
 
-- Items / PRs already merged onto `QA_BASE`, or
-- When an epic is indicated: items associated with that epic’s integration
-  branch
+- For `develop`: provider-backed tracker items in the repository's configured
+  post-merge state (for example, `Merged`) that have shipped onto `QA_BASE`.
+  Resolve the provider from `.ai-dev-workflow.yaml` (`issue_tracker.provider`)
+  when configured; do not hardcode one tracker vendor into the protocol.
+- For `develop-<slug>`: items and PRs associated with that integration branch
+  and already merged into that branch. Do not require final post-merge tracker
+  state for integration-branch QA unless the repository's tracker workflow
+  explicitly does so.
+- If provider-backed tracker discovery is unavailable, unclear, or not
+  configured, fall back to recently merged PRs on `QA_BASE` and state that the
+  proposal is PR-derived.
+- When an epic is indicated: items associated with that epic's integration
+  branch, plus any PRs merged into the resolved QA base for those items.
 
 Honor explicit operator inputs (single item, several items, epic, recent merged
 PRs) as seeds or filters.
 
-Present the proposal to the human. **Do not exercise flows until the human
-confirms or adjusts the scope.**
+Every proposal must state its scope source (`tracker-post-merge`,
+`integration-branch`, `merged-prs`, `explicit`, or `epic`) and whether it is
+provider-backed or fallback. Present the proposal to the human. **Do not
+exercise flows until the human confirms or adjusts the scope.**
 
 | Confirmed scope | Action |
 | --- | --- |

--- a/docs/workflow/development-workflow/protocols/08-post-merge-qa-protocol.md
+++ b/docs/workflow/development-workflow/protocols/08-post-merge-qa-protocol.md
@@ -78,8 +78,10 @@ PRs) as seeds or filters.
 
 Every proposal must state its scope source (`tracker-post-merge`,
 `integration-branch`, `merged-prs`, `explicit`, or `epic`) and whether it is
-provider-backed or fallback. Present the proposal to the human. **Do not
-exercise flows until the human confirms or adjusts the scope.**
+provider-backed or fallback. The helper emits `scopeSource`, `providerBacked`,
+and `fallback` in JSON, and renders the same metadata in text output. Present
+the proposal to the human. **Do not exercise flows until the human confirms or
+adjusts the scope.**
 
 | Confirmed scope | Action |
 | --- | --- |

--- a/docs/workflow/development-workflow/protocols/08-post-merge-qa-protocol.md
+++ b/docs/workflow/development-workflow/protocols/08-post-merge-qa-protocol.md
@@ -67,10 +67,11 @@ Default proposal preference (when the operator did not already pin items):
   an empty, non-confirmable `tracker-post-merge` proposal (`discoveryRequired:
   true`) and require discovery before human confirmation; it must not silently
   substitute a PR-derived fallback.
-- For `develop-<slug>`: items and PRs associated with that integration branch
-  and already merged into that branch. Do not require final post-merge tracker
-  state for integration-branch QA unless the repository's tracker workflow
-  explicitly does so.
+- For `develop-<slug>`: items associated with a PR merged into that integration
+  branch, plus those merged PRs. Do not require final post-merge tracker state
+  for integration-branch QA unless the repository's tracker workflow explicitly
+  does so. If item discovery is unavailable, identify the proposal as a
+  PR-derived fallback.
 - If provider-backed tracker discovery is unavailable, unclear, or not
   configured, fall back to recently merged PRs on `QA_BASE` and state that the
   proposal is PR-derived.

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -210,6 +210,16 @@ append_rows_from_json_array() {
   done < <(jq -c '.[]' "$json_file")
 }
 
+# Keep only GitHub issues explicitly associated with a merged implementation PR.
+# Closing references are unavailable for non-default PR bases, so accept either
+# an issue reference in the title/body or a canonical workflow branch identifier.
+filter_issues_referenced_by_merged_prs() {
+  local issues_file="$1" merged_prs_file="$2" output_file="$3"
+  jq --slurpfile merged_prs "$merged_prs_file" \
+    '[.[] | .number as $number | select(any($merged_prs[0][]?; ((.headRefName // "") | test("^(feature|fix|refactor|hotfix|spec|implementation-plan)/" + ($number | tostring) + "(-|$)")) or (((.title // "") + "\n" + (.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))]' \
+    "$issues_file" > "$output_file"
+}
+
 # Explicit issues (file-backed loop — exits abort the main script)
 if [ -n "$issues_arg" ]; then
   issues_list="$tmp_dir/issues-list.txt"
@@ -274,8 +284,18 @@ if [ -n "$epic" ]; then
     fi
     if gh issue list --label "$integration_label" --state all --limit 50 \
       --json number,title,url > "$tmp_dir/epic-issues.json" 2>/dev/null; then
-      append_rows_from_json_array "$tmp_dir/epic-issues.json" "issue" "epic #$epic via $integration_label (limit 50)" "$epic"
-      append_note "Epic issue list is capped at 50 (not fully paginated)."
+      if gh pr list --base "$base" --state merged --limit 50 \
+        --json number,title,url,mergedAt,headRefName,body > "$tmp_dir/epic-merged-prs.json"; then
+        if ! filter_issues_referenced_by_merged_prs "$tmp_dir/epic-issues.json" "$tmp_dir/epic-merged-prs.json" "$tmp_dir/epic-merged-issues.json"; then
+          echo "Failed to match epic issues to merged PRs for base '$base'" >&2
+          exit 1
+        fi
+        append_rows_from_json_array "$tmp_dir/epic-merged-issues.json" "issue" "epic #$epic via $integration_label and merged PR references (limit 50)" "$epic"
+        append_rows_from_json_array "$tmp_dir/epic-merged-prs.json" "pull_request" "epic #$epic merged PRs into $base (limit 50)"
+        append_note "Epic issue and merged-PR lists are capped at 50 and include only explicitly associated items."
+      else
+        append_note "Could not list merged PRs for epic #$epic on $base; no label-only items were proposed."
+      fi
     else
       append_note "Could not list issues for label $integration_label; ask the human to supply --issues."
     fi
@@ -300,14 +320,12 @@ if [ ! -s "$candidates_file" ] && [ "$recent_merged" -eq 0 ] && [ -z "$issues_ar
       integration_label="integration-branch:$integration_slug"
       if gh issue list --label "$integration_label" --state all --limit 50 \
         --json number,title,url > "$tmp_dir/default-integration-label-issues.json" 2>/dev/null; then
-        jq --slurpfile merged_prs "$tmp_dir/default-merged.json" \
-          '[.[] | select(.number as $number | any($merged_prs[0][]?; (((.headRefName // "") + "\n" + (.title // "") + "\n" + (.body // "")) | test("(^|[^0-9])" + ($number | tostring) + "([^0-9]|$)"))))]' \
-          "$tmp_dir/default-integration-label-issues.json" > "$tmp_dir/default-integration-issues.json" || {
+        filter_issues_referenced_by_merged_prs "$tmp_dir/default-integration-label-issues.json" "$tmp_dir/default-merged.json" "$tmp_dir/default-integration-issues.json" || {
           echo "Failed to match integration-branch issues to merged PRs for base '$base'" >&2
           exit 1
         }
         append_rows_from_json_array "$tmp_dir/default-integration-issues.json" "issue" "default integration branch via $integration_label and merged PR references (limit 50)"
-        append_note "Integration-branch issue list is capped at 50 and includes only items referenced by merged PR title, body, or branch name."
+        append_note "Integration-branch issue list is capped at 50 and includes only items explicitly referenced by merged PR title, body, or canonical branch name."
       else
         integration_discovery_degraded=true
         append_note "Could not list issues for label $integration_label; the default proposal includes only merged PRs."

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -220,6 +220,13 @@ filter_issues_referenced_by_merged_prs() {
     "$issues_file" > "$output_file"
 }
 
+filter_merged_prs_for_issues() {
+  local merged_prs_file="$1" issues_file="$2" output_file="$3"
+  jq --slurpfile issues "$issues_file" \
+    '($issues[0] | map(.number)) as $issue_numbers | [.[] | . as $pr | select(any($issue_numbers[]; . as $number | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix|spec|implementation-plan)/" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))]' \
+    "$merged_prs_file" > "$output_file"
+}
+
 # Explicit issues (file-backed loop — exits abort the main script)
 if [ -n "$issues_arg" ]; then
   issues_list="$tmp_dir/issues-list.txt"
@@ -245,6 +252,10 @@ fi
 if [ -n "$tracker_items_arg" ]; then
   tracker_items_list="$tmp_dir/tracker-items-list.txt"
   printf '%s\n' "$tracker_items_arg" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | awk 'NF' > "$tracker_items_list"
+  if [ ! -s "$tracker_items_list" ]; then
+    echo "--tracker-items must contain at least one tracker item" >&2
+    exit 64
+  fi
   while IFS= read -r tracker_item; do
     if ! printf '%s\n' "$tracker_item" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._:-]*$'; then
       echo "Invalid tracker item in --tracker-items: $tracker_item" >&2
@@ -291,7 +302,11 @@ if [ -n "$epic" ]; then
           exit 1
         fi
         append_rows_from_json_array "$tmp_dir/epic-merged-issues.json" "issue" "epic #$epic via $integration_label and merged PR references (limit 50)" "$epic"
-        append_rows_from_json_array "$tmp_dir/epic-merged-prs.json" "pull_request" "epic #$epic merged PRs into $base (limit 50)"
+        if ! filter_merged_prs_for_issues "$tmp_dir/epic-merged-prs.json" "$tmp_dir/epic-merged-issues.json" "$tmp_dir/epic-associated-prs.json"; then
+          echo "Failed to match merged PRs to epic issues for base '$base'" >&2
+          exit 1
+        fi
+        append_rows_from_json_array "$tmp_dir/epic-associated-prs.json" "pull_request" "epic #$epic associated merged PRs into $base (limit 50)"
         append_note "Epic issue and merged-PR lists are capped at 50 and include only explicitly associated items."
       else
         append_note "Could not list merged PRs for epic #$epic on $base; no label-only items were proposed."

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -290,12 +290,36 @@ notes_json="$(if [ -s "$notes_file" ]; then jq -e -s '[.[].note]' "$notes_file";
   exit 1
 }
 
+scope_source="merged-prs"
+provider_backed=false
+fallback=true
+if [ -n "$tracker_items_arg" ]; then
+  scope_source="tracker-post-merge"
+  provider_backed=true
+  fallback=false
+elif [ -n "$issues_arg" ]; then
+  scope_source="explicit"
+  fallback=false
+elif [ -n "$epic" ]; then
+  scope_source="epic"
+  fallback=false
+elif [ "$base" != "develop" ]; then
+  scope_source="integration-branch"
+  fallback=false
+fi
+
 result="$(jq -n \
   --arg base "$base" \
+  --arg scope_source "$scope_source" \
+  --argjson provider_backed "$provider_backed" \
+  --argjson fallback "$fallback" \
   --argjson candidates "$candidates_json" \
   --argjson notes "$notes_json" \
   '{
     base: $base,
+    scopeSource: $scope_source,
+    providerBacked: $provider_backed,
+    fallback: $fallback,
     candidateCount: ($candidates | length),
     candidates: $candidates,
     notes: $notes,
@@ -311,6 +335,9 @@ if [ "$json_output" -eq 1 ]; then
   printf '%s\n' "$result"
 else
   printf 'QA base: %s\n' "$base"
+  printf 'Scope source: %s\n' "$(printf '%s' "$result" | jq -er '.scopeSource')"
+  printf 'Provider-backed: %s\n' "$(printf '%s' "$result" | jq -er '.providerBacked')"
+  printf 'Fallback: %s\n' "$(printf '%s' "$result" | jq -er '.fallback')"
   printf 'Candidates: %s\n' "$(printf '%s' "$result" | jq -er '.candidateCount')"
   printf '%s\n' "$result" | jq -r '.candidates[]? | "- [\(.kind) #\(.number // .id)] \(.title) — \(.reason)"'
   printf '%s\n' "$result" | jq -r '.notes[]? | "Note: \(.)"'

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -144,8 +144,11 @@ candidates_file="$tmp_dir/candidates.jsonl"
 notes_file="$tmp_dir/notes.jsonl"
 : > "$notes_file"
 
-effective_config_file="$(workflow_effective_config_file)"
-tracker_provider_raw="$(workflow_config_provider issue_tracker "$effective_config_file")"
+effective_config_file="$(workflow_effective_config_file 2>/dev/null || true)"
+tracker_provider_raw=""
+if [ -n "$effective_config_file" ]; then
+  tracker_provider_raw="$(workflow_config_provider issue_tracker "$effective_config_file")"
+fi
 tracker_provider="$(workflow_normalize_issue_tracker_provider "$tracker_provider_raw")"
 tracker_discovery_required=false
 if [ "$base" = "develop" ] && [ -n "$tracker_provider" ] && [ "$tracker_provider" != "none" ]; then

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -289,20 +289,26 @@ if [ ! -s "$candidates_file" ] && [ "$recent_merged" -eq 0 ] && [ -z "$issues_ar
   if [ "$tracker_discovery_required" = true ]; then
     append_note "Configured issue tracker '$tracker_provider' requires provider-backed post-merge discovery on develop. Resolve eligible items and pass them with --tracker-items before human confirmation; PR-derived fallback was not proposed."
   else
+    if ! gh pr list --base "$base" --state merged --limit 10 \
+      --json number,title,url,mergedAt,closingIssuesReferences > "$tmp_dir/default-merged.json"; then
+      echo "Failed to list default merged PRs for base '$base'" >&2
+      exit 1
+    fi
     if [[ "$base" =~ ^develop-(.+)$ ]]; then
       integration_label="integration-branch:${BASH_REMATCH[1]}"
       if gh issue list --label "$integration_label" --state all --limit 50 \
-        --json number,title,url > "$tmp_dir/default-integration-issues.json" 2>/dev/null; then
-        append_rows_from_json_array "$tmp_dir/default-integration-issues.json" "issue" "default integration branch via $integration_label (limit 50)"
-        append_note "Integration-branch issue list is capped at 50 (not fully paginated)."
+        --json number,title,url > "$tmp_dir/default-integration-label-issues.json" 2>/dev/null; then
+        jq --slurpfile merged_prs "$tmp_dir/default-merged.json" \
+          '[.[] | select(.number as $number | any($merged_prs[0][]?.closingIssuesReferences[]?; .number == $number))]' \
+          "$tmp_dir/default-integration-label-issues.json" > "$tmp_dir/default-integration-issues.json" || {
+          echo "Failed to match integration-branch issues to merged PRs for base '$base'" >&2
+          exit 1
+        }
+        append_rows_from_json_array "$tmp_dir/default-integration-issues.json" "issue" "default integration branch via $integration_label and merged PR closing references (limit 50)"
+        append_note "Integration-branch issue list is capped at 50 and includes only items referenced by merged PRs."
       else
         append_note "Could not list issues for label $integration_label; the default proposal includes only merged PRs."
       fi
-    fi
-    if ! gh pr list --base "$base" --state merged --limit 10 \
-      --json number,title,url,mergedAt > "$tmp_dir/default-merged.json"; then
-      echo "Failed to list default merged PRs for base '$base'" >&2
-      exit 1
     fi
     append_rows_from_json_array "$tmp_dir/default-merged.json" "pull_request" "default: up to 10 recent merged PRs into $base"
     append_note "No explicit scope flags; proposed up to 10 recent merged PRs into $base (capped, not fully paginated). Confirm or adjust before testing."

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -285,28 +285,31 @@ if [ -n "$epic" ]; then
 fi
 
 # Default: if no filters produced candidates, suggest recent merged
+integration_discovery_degraded=false
 if [ ! -s "$candidates_file" ] && [ "$recent_merged" -eq 0 ] && [ -z "$issues_arg" ] && [ -z "$tracker_items_arg" ] && [ -z "$epic" ]; then
   if [ "$tracker_discovery_required" = true ]; then
     append_note "Configured issue tracker '$tracker_provider' requires provider-backed post-merge discovery on develop. Resolve eligible items and pass them with --tracker-items before human confirmation; PR-derived fallback was not proposed."
   else
     if ! gh pr list --base "$base" --state merged --limit 10 \
-      --json number,title,url,mergedAt,closingIssuesReferences > "$tmp_dir/default-merged.json"; then
+      --json number,title,url,mergedAt,headRefName,body > "$tmp_dir/default-merged.json"; then
       echo "Failed to list default merged PRs for base '$base'" >&2
       exit 1
     fi
     if [[ "$base" =~ ^develop-(.+)$ ]]; then
-      integration_label="integration-branch:${BASH_REMATCH[1]}"
+      integration_slug="$(printf '%s' "$base" | sed 's/^develop-//')"
+      integration_label="integration-branch:$integration_slug"
       if gh issue list --label "$integration_label" --state all --limit 50 \
         --json number,title,url > "$tmp_dir/default-integration-label-issues.json" 2>/dev/null; then
         jq --slurpfile merged_prs "$tmp_dir/default-merged.json" \
-          '[.[] | select(.number as $number | any($merged_prs[0][]?.closingIssuesReferences[]?; .number == $number))]' \
+          '[.[] | select(.number as $number | any($merged_prs[0][]?; (((.headRefName // "") + "\n" + (.title // "") + "\n" + (.body // "")) | test("(^|[^0-9])" + ($number | tostring) + "([^0-9]|$)"))))]' \
           "$tmp_dir/default-integration-label-issues.json" > "$tmp_dir/default-integration-issues.json" || {
           echo "Failed to match integration-branch issues to merged PRs for base '$base'" >&2
           exit 1
         }
-        append_rows_from_json_array "$tmp_dir/default-integration-issues.json" "issue" "default integration branch via $integration_label and merged PR closing references (limit 50)"
-        append_note "Integration-branch issue list is capped at 50 and includes only items referenced by merged PRs."
+        append_rows_from_json_array "$tmp_dir/default-integration-issues.json" "issue" "default integration branch via $integration_label and merged PR references (limit 50)"
+        append_note "Integration-branch issue list is capped at 50 and includes only items referenced by merged PR title, body, or branch name."
       else
+        integration_discovery_degraded=true
         append_note "Could not list issues for label $integration_label; the default proposal includes only merged PRs."
       fi
     fi
@@ -341,8 +344,12 @@ elif [ "$recent_merged" -gt 0 ]; then
   scope_source="explicit"
   fallback=false
 elif [ "$base" != "develop" ]; then
-  scope_source="integration-branch"
-  fallback=false
+  if [ "$integration_discovery_degraded" = true ]; then
+    scope_source="merged-prs"
+  else
+    scope_source="integration-branch"
+    fallback=false
+  fi
 elif [ "$tracker_discovery_required" = true ]; then
   scope_source="tracker-post-merge"
   fallback=false
@@ -351,7 +358,7 @@ fi
 confirmation_required=true
 discovery_required=false
 empty_scope_stop="If the human confirms an empty scope, stop without preflight, flows, or a fix PR."
-if [ "$tracker_discovery_required" = true ] && [ ! -s "$candidates_file" ]; then
+if [ "$tracker_discovery_required" = true ] && [ ! -s "$candidates_file" ] && [ "$recent_merged" -eq 0 ] && [ -z "$issues_arg" ] && [ -z "$tracker_items_arg" ] && [ -z "$epic" ]; then
   confirmation_required=false
   discovery_required=true
   empty_scope_stop="Provider-backed tracker discovery is required before QA scope can be confirmed."

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -144,7 +144,8 @@ candidates_file="$tmp_dir/candidates.jsonl"
 notes_file="$tmp_dir/notes.jsonl"
 : > "$notes_file"
 
-tracker_provider_raw="$(workflow_issue_tracker_provider_raw)"
+effective_config_file="$(workflow_effective_config_file)"
+tracker_provider_raw="$(workflow_config_provider issue_tracker "$effective_config_file")"
 tracker_provider="$(workflow_normalize_issue_tracker_provider "$tracker_provider_raw")"
 tracker_discovery_required=false
 if [ "$base" = "develop" ] && [ -n "$tracker_provider" ] && [ "$tracker_provider" != "none" ]; then

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -115,6 +115,16 @@ if [ -z "$base" ]; then
   exit 64
 fi
 
+scope_flag_count=0
+[ -n "$epic" ] && scope_flag_count=$((scope_flag_count + 1))
+[ -n "$issues_arg" ] && scope_flag_count=$((scope_flag_count + 1))
+[ -n "$tracker_items_arg" ] && scope_flag_count=$((scope_flag_count + 1))
+[ "$recent_merged" != "0" ] && scope_flag_count=$((scope_flag_count + 1))
+if [ "$scope_flag_count" -gt 1 ]; then
+  echo "--epic, --issues, --tracker-items, and --recent-merged-prs cannot be combined" >&2
+  exit 64
+fi
+
 if ! printf '%s\n' "$base" | grep -Eq '^develop(-[A-Za-z0-9][A-Za-z0-9._-]*)?$'; then
   echo "Disallowed base '$base'. Allowed: develop or develop-<slug>." >&2
   exit 64
@@ -216,14 +226,14 @@ append_rows_from_json_array() {
 filter_issues_referenced_by_merged_prs() {
   local issues_file="$1" merged_prs_file="$2" output_file="$3"
   jq --slurpfile merged_prs "$merged_prs_file" \
-    '[.[] | .number as $number | select(any($merged_prs[0][]?; . as $pr | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/")) and (((($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/([A-Za-z][A-Za-z0-9]{0,7}-)?" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))))]' \
+    '[.[] | .number as $number | select(any($merged_prs[0][]?; . as $pr | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/")) and (((($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/([A-Za-z][A-Za-z0-9]{0,7}-)?" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^[:alnum:]])#" + ($number | tostring) + "([^[:alnum:]]|$)"))))))]' \
     "$issues_file" > "$output_file"
 }
 
 filter_merged_prs_for_issues() {
   local merged_prs_file="$1" issues_file="$2" output_file="$3"
   jq --slurpfile issues "$issues_file" \
-    '($issues[0] | map(.number)) as $issue_numbers | [.[] | . as $pr | select((($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/")) and any($issue_numbers[]; . as $number | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/([A-Za-z][A-Za-z0-9]{0,7}-)?" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))]' \
+    '($issues[0] | map(.number)) as $issue_numbers | [.[] | . as $pr | select((($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/")) and any($issue_numbers[]; . as $number | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/([A-Za-z][A-Za-z0-9]{0,7}-)?" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^[:alnum:]])#" + ($number | tostring) + "([^[:alnum:]]|$)"))))]' \
     "$merged_prs_file" > "$output_file"
 }
 
@@ -452,7 +462,7 @@ else
   if [ "$(printf '%s' "$result" | jq -er '.confirmationRequired')" = true ]; then
     echo "Confirmation required before exercising flows."
   else
-    echo "Provider-backed tracker discovery is required before QA scope can be confirmed."
+    printf '%s\n' "$result" | jq -er '.emptyScopeStop'
   fi
   echo "Read-only guarantee: No tracker updates, branch creation, PR edits, merges, issue closure, or flow exercise were performed."
 fi

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -9,6 +9,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/workflow-lib.sh"
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -139,6 +143,13 @@ candidates_file="$tmp_dir/candidates.jsonl"
 : > "$candidates_file"
 notes_file="$tmp_dir/notes.jsonl"
 : > "$notes_file"
+
+tracker_provider_raw="$(workflow_issue_tracker_provider_raw)"
+tracker_provider="$(workflow_normalize_issue_tracker_provider "$tracker_provider_raw")"
+tracker_discovery_required=false
+if [ "$base" = "develop" ] && [ -n "$tracker_provider" ] && [ "$tracker_provider" != "none" ]; then
+  tracker_discovery_required=true
+fi
 
 append_note() {
   jq -nc --arg note "$1" '{note: $note}' >> "$notes_file"
@@ -271,14 +282,17 @@ fi
 
 # Default: if no filters produced candidates, suggest recent merged
 if [ ! -s "$candidates_file" ] && [ "$recent_merged" -eq 0 ] && [ -z "$issues_arg" ] && [ -z "$tracker_items_arg" ] && [ -z "$epic" ]; then
-  if ! gh pr list --base "$base" --state merged --limit 10 \
-    --json number,title,url,mergedAt > "$tmp_dir/default-merged.json"; then
-    echo "Failed to list default merged PRs for base '$base'" >&2
-    exit 1
+  if [ "$tracker_discovery_required" = true ]; then
+    append_note "Configured issue tracker '$tracker_provider' requires provider-backed post-merge discovery on develop. Resolve eligible items and pass them with --tracker-items before human confirmation; PR-derived fallback was not proposed."
+  else
+    if ! gh pr list --base "$base" --state merged --limit 10 \
+      --json number,title,url,mergedAt > "$tmp_dir/default-merged.json"; then
+      echo "Failed to list default merged PRs for base '$base'" >&2
+      exit 1
+    fi
+    append_rows_from_json_array "$tmp_dir/default-merged.json" "pull_request" "default: up to 10 recent merged PRs into $base"
+    append_note "No explicit scope flags; proposed up to 10 recent merged PRs into $base (capped, not fully paginated). Confirm or adjust before testing."
   fi
-  append_rows_from_json_array "$tmp_dir/default-merged.json" "pull_request" "default: up to 10 recent merged PRs into $base"
-  append_note "No explicit scope flags; proposed up to 10 recent merged PRs into $base (capped, not fully paginated). Confirm or adjust before testing."
-  append_note "If the repository has a configured issue tracker, provider-backed post-merge item discovery should be performed before accepting this PR-derived fallback."
 fi
 
 candidates_json="$(if [ -s "$candidates_file" ]; then jq -e -s 'unique_by(.kind + ":" + .id)' "$candidates_file"; else printf '[]\n'; fi)" || {
@@ -303,8 +317,14 @@ elif [ -n "$issues_arg" ]; then
 elif [ -n "$epic" ]; then
   scope_source="epic"
   fallback=false
+elif [ "$recent_merged" -gt 0 ]; then
+  scope_source="explicit"
+  fallback=false
 elif [ "$base" != "develop" ]; then
   scope_source="integration-branch"
+  fallback=false
+elif [ "$tracker_discovery_required" = true ]; then
+  scope_source="tracker-post-merge"
   fallback=false
 fi
 

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -13,16 +13,20 @@ usage() {
   cat <<'EOF'
 Usage:
   ./scripts/development-workflow/post-merge-qa-scope.sh --base <develop|develop-slug>
-      [--epic <number>] [--issues <csv>] [--recent-merged-prs <n>] [--json]
+      [--epic <number>] [--issues <csv>] [--tracker-items <csv>]
+      [--recent-merged-prs <n>] [--json]
 
 Read-only: proposes post-merge QA scope for human confirmation.
 List queries are intentionally capped with --limit; confirm or adjust before testing.
+Provider-backed tracker discovery should be performed by the configured tracker
+connector/CLI and passed with --tracker-items. This helper remains provider-neutral.
 EOF
 }
 
 base=""
 epic=""
 issues_arg=""
+tracker_items_arg=""
 recent_merged=0
 json_output=0
 missing_value_option=""
@@ -56,6 +60,16 @@ while [ "$#" -gt 0 ]; do
         missing_value_option="--issues"
       else
         issues_arg="$1"
+        shift
+      fi
+      ;;
+    --tracker-items)
+      shift
+      if [ "$#" -eq 0 ] || [[ "$1" == -* ]]; then
+        tracker_items_arg=""
+        missing_value_option="--tracker-items"
+      else
+        tracker_items_arg="$1"
         shift
       fi
       ;;
@@ -131,14 +145,20 @@ append_note() {
 }
 
 append_candidate() {
-  local kind="$1" number="$2" title="$3" url="$4" reason="$5"
+  local kind="$1" identifier="$2" title="$3" url="$4" reason="$5"
   jq -nc \
     --arg kind "$kind" \
-    --argjson number "$number" \
+    --arg id "$identifier" \
     --arg title "$title" \
     --arg url "$url" \
     --arg reason "$reason" \
-    '{kind: $kind, number: $number, title: $title, url: $url, reason: $reason}' \
+    '{
+      kind: $kind,
+      id: $id,
+      title: $title,
+      url: $url,
+      reason: $reason
+    } + (if ($id | test("^[1-9][0-9]*$")) then {number: ($id | tonumber)} else {} end)' \
     >> "$candidates_file"
 }
 
@@ -195,6 +215,21 @@ if [ -n "$issues_arg" ]; then
   done < "$issues_list"
 fi
 
+# Provider-backed tracker items resolved outside this helper. Keep this generic:
+# Linear, Jira, ClickUp, GitHub Projects, and other trackers use different APIs.
+if [ -n "$tracker_items_arg" ]; then
+  tracker_items_list="$tmp_dir/tracker-items-list.txt"
+  printf '%s\n' "$tracker_items_arg" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | awk 'NF' > "$tracker_items_list"
+  while IFS= read -r tracker_item; do
+    if ! printf '%s\n' "$tracker_item" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._:-]*$'; then
+      echo "Invalid tracker item in --tracker-items: $tracker_item" >&2
+      exit 64
+    fi
+    append_candidate "tracker_item" "$tracker_item" "$tracker_item" "" "explicit provider-backed tracker item input"
+  done < "$tracker_items_list"
+  append_note "Tracker items were supplied explicitly after provider-backed discovery outside this helper."
+fi
+
 # Recent merged PRs into base (intentionally capped; human confirms)
 if [ "$recent_merged" -gt 0 ]; then
   if ! gh pr list --base "$base" --state merged --limit "$recent_merged" \
@@ -235,7 +270,7 @@ if [ -n "$epic" ]; then
 fi
 
 # Default: if no filters produced candidates, suggest recent merged
-if [ ! -s "$candidates_file" ] && [ "$recent_merged" -eq 0 ] && [ -z "$issues_arg" ] && [ -z "$epic" ]; then
+if [ ! -s "$candidates_file" ] && [ "$recent_merged" -eq 0 ] && [ -z "$issues_arg" ] && [ -z "$tracker_items_arg" ] && [ -z "$epic" ]; then
   if ! gh pr list --base "$base" --state merged --limit 10 \
     --json number,title,url,mergedAt > "$tmp_dir/default-merged.json"; then
     echo "Failed to list default merged PRs for base '$base'" >&2
@@ -243,9 +278,10 @@ if [ ! -s "$candidates_file" ] && [ "$recent_merged" -eq 0 ] && [ -z "$issues_ar
   fi
   append_rows_from_json_array "$tmp_dir/default-merged.json" "pull_request" "default: up to 10 recent merged PRs into $base"
   append_note "No explicit scope flags; proposed up to 10 recent merged PRs into $base (capped, not fully paginated). Confirm or adjust before testing."
+  append_note "If the repository has a configured issue tracker, provider-backed post-merge item discovery should be performed before accepting this PR-derived fallback."
 fi
 
-candidates_json="$(if [ -s "$candidates_file" ]; then jq -e -s 'unique_by(.kind + ":" + (.number|tostring))' "$candidates_file"; else printf '[]\n'; fi)" || {
+candidates_json="$(if [ -s "$candidates_file" ]; then jq -e -s 'unique_by(.kind + ":" + .id)' "$candidates_file"; else printf '[]\n'; fi)" || {
   echo "Failed to build candidates JSON" >&2
   exit 1
 }
@@ -276,7 +312,7 @@ if [ "$json_output" -eq 1 ]; then
 else
   printf 'QA base: %s\n' "$base"
   printf 'Candidates: %s\n' "$(printf '%s' "$result" | jq -er '.candidateCount')"
-  printf '%s\n' "$result" | jq -r '.candidates[]? | "- [\(.kind) #\(.number)] \(.title) — \(.reason)"'
+  printf '%s\n' "$result" | jq -r '.candidates[]? | "- [\(.kind) #\(.number // .id)] \(.title) — \(.reason)"'
   printf '%s\n' "$result" | jq -r '.notes[]? | "Note: \(.)"'
   echo "Confirmation required before exercising flows."
   echo "Read-only guarantee: No tracker updates, branch creation, PR edits, merges, issue closure, or flow exercise were performed."

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -216,14 +216,14 @@ append_rows_from_json_array() {
 filter_issues_referenced_by_merged_prs() {
   local issues_file="$1" merged_prs_file="$2" output_file="$3"
   jq --slurpfile merged_prs "$merged_prs_file" \
-    '[.[] | .number as $number | select(any($merged_prs[0][]?; . as $pr | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/")) and (((($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/(([A-Z][A-Z0-9]{1,7}|[a-z][a-z0-9])-)?" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))))]' \
+    '[.[] | .number as $number | select(any($merged_prs[0][]?; . as $pr | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/")) and (((($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/([A-Za-z][A-Za-z0-9]{0,7}-)?" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))))]' \
     "$issues_file" > "$output_file"
 }
 
 filter_merged_prs_for_issues() {
   local merged_prs_file="$1" issues_file="$2" output_file="$3"
   jq --slurpfile issues "$issues_file" \
-    '($issues[0] | map(.number)) as $issue_numbers | [.[] | . as $pr | select((($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/")) and any($issue_numbers[]; . as $number | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/(([A-Z][A-Z0-9]{1,7}|[a-z][a-z0-9])-)?" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))]' \
+    '($issues[0] | map(.number)) as $issue_numbers | [.[] | . as $pr | select((($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/")) and any($issue_numbers[]; . as $number | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/([A-Za-z][A-Za-z0-9]{0,7}-)?" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))]' \
     "$merged_prs_file" > "$output_file"
 }
 
@@ -281,6 +281,7 @@ if [ "$recent_merged" -gt 0 ]; then
   append_note "Merged-PR proposal is capped at --recent-merged-prs=$recent_merged (not fully paginated)."
 fi
 
+epic_discovery_degraded=false
 # Epic association (best-effort)
 if [ -n "$epic" ]; then
   if ! gh issue view "$epic" --json number,title,url,labels,body > "$tmp_dir/epic.json" 2>/dev/null; then
@@ -313,9 +314,11 @@ if [ -n "$epic" ]; then
         append_rows_from_json_array "$tmp_dir/epic-associated-prs.json" "pull_request" "epic #$epic associated merged PRs into $base (limit 50)"
         append_note "Epic issue and merged-PR lists are capped at 50 and include only explicitly associated items."
       else
+        epic_discovery_degraded=true
         append_note "Could not list merged PRs for epic #$epic on $base; no label-only items were proposed."
       fi
     else
+      epic_discovery_degraded=true
       append_note "Could not list issues for label $integration_label; ask the human to supply --issues."
     fi
   else
@@ -376,7 +379,11 @@ elif [ -n "$issues_arg" ]; then
   fallback=false
 elif [ -n "$epic" ]; then
   scope_source="epic"
-  fallback=false
+  if [ "$epic_discovery_degraded" = true ]; then
+    fallback=true
+  else
+    fallback=false
+  fi
 elif [ "$recent_merged" -gt 0 ]; then
   scope_source="explicit"
   fallback=false
@@ -399,6 +406,10 @@ if [ "$tracker_discovery_required" = true ] && [ ! -s "$candidates_file" ] && [ 
   confirmation_required=false
   discovery_required=true
   empty_scope_stop="Provider-backed tracker discovery is required before QA scope can be confirmed."
+elif [ "$epic_discovery_degraded" = true ] && [ ! -s "$candidates_file" ]; then
+  confirmation_required=false
+  discovery_required=true
+  empty_scope_stop="Epic discovery failed before a concrete QA scope could be confirmed; supply --issues, --tracker-items, or rerun discovery."
 fi
 
 result="$(jq -n \

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -289,6 +289,16 @@ if [ ! -s "$candidates_file" ] && [ "$recent_merged" -eq 0 ] && [ -z "$issues_ar
   if [ "$tracker_discovery_required" = true ]; then
     append_note "Configured issue tracker '$tracker_provider' requires provider-backed post-merge discovery on develop. Resolve eligible items and pass them with --tracker-items before human confirmation; PR-derived fallback was not proposed."
   else
+    if [[ "$base" =~ ^develop-(.+)$ ]]; then
+      integration_label="integration-branch:${BASH_REMATCH[1]}"
+      if gh issue list --label "$integration_label" --state all --limit 50 \
+        --json number,title,url > "$tmp_dir/default-integration-issues.json" 2>/dev/null; then
+        append_rows_from_json_array "$tmp_dir/default-integration-issues.json" "issue" "default integration branch via $integration_label (limit 50)"
+        append_note "Integration-branch issue list is capped at 50 (not fully paginated)."
+      else
+        append_note "Could not list issues for label $integration_label; the default proposal includes only merged PRs."
+      fi
+    fi
     if ! gh pr list --base "$base" --state merged --limit 10 \
       --json number,title,url,mergedAt > "$tmp_dir/default-merged.json"; then
       echo "Failed to list default merged PRs for base '$base'" >&2

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -348,13 +348,25 @@ elif [ "$tracker_discovery_required" = true ]; then
   fallback=false
 fi
 
+confirmation_required=true
+discovery_required=false
+empty_scope_stop="If the human confirms an empty scope, stop without preflight, flows, or a fix PR."
+if [ "$tracker_discovery_required" = true ] && [ ! -s "$candidates_file" ]; then
+  confirmation_required=false
+  discovery_required=true
+  empty_scope_stop="Provider-backed tracker discovery is required before QA scope can be confirmed."
+fi
+
 result="$(jq -n \
   --arg base "$base" \
   --arg scope_source "$scope_source" \
   --argjson provider_backed "$provider_backed" \
   --argjson fallback "$fallback" \
+  --argjson confirmation_required "$confirmation_required" \
+  --argjson discovery_required "$discovery_required" \
   --argjson candidates "$candidates_json" \
   --argjson notes "$notes_json" \
+  --arg empty_scope_stop "$empty_scope_stop" \
   '{
     base: $base,
     scopeSource: $scope_source,
@@ -363,8 +375,9 @@ result="$(jq -n \
     candidateCount: ($candidates | length),
     candidates: $candidates,
     notes: $notes,
-    confirmationRequired: true,
-    emptyScopeStop: "If the human confirms an empty scope, stop without preflight, flows, or a fix PR.",
+    confirmationRequired: $confirmation_required,
+    discoveryRequired: $discovery_required,
+    emptyScopeStop: $empty_scope_stop,
     readOnlyGuarantee: "No tracker updates, branch creation, PR edits, merges, issue closure, or flow exercise were performed."
   }')" || {
   echo "Failed to build scope proposal JSON" >&2
@@ -381,6 +394,10 @@ else
   printf 'Candidates: %s\n' "$(printf '%s' "$result" | jq -er '.candidateCount')"
   printf '%s\n' "$result" | jq -r '.candidates[]? | "- [\(.kind) #\(.number // .id)] \(.title) — \(.reason)"'
   printf '%s\n' "$result" | jq -r '.notes[]? | "Note: \(.)"'
-  echo "Confirmation required before exercising flows."
+  if [ "$(printf '%s' "$result" | jq -er '.confirmationRequired')" = true ]; then
+    echo "Confirmation required before exercising flows."
+  else
+    echo "Provider-backed tracker discovery is required before QA scope can be confirmed."
+  fi
   echo "Read-only guarantee: No tracker updates, branch creation, PR edits, merges, issue closure, or flow exercise were performed."
 fi

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -216,14 +216,14 @@ append_rows_from_json_array() {
 filter_issues_referenced_by_merged_prs() {
   local issues_file="$1" merged_prs_file="$2" output_file="$3"
   jq --slurpfile merged_prs "$merged_prs_file" \
-    '[.[] | .number as $number | select(any($merged_prs[0][]?; ((.headRefName // "") | test("^(feature|fix|refactor|hotfix|spec|implementation-plan)/" + ($number | tostring) + "(-|$)")) or (((.title // "") + "\n" + (.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))]' \
+    '[.[] | .number as $number | select(any($merged_prs[0][]?; . as $pr | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/")) and (((($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))))]' \
     "$issues_file" > "$output_file"
 }
 
 filter_merged_prs_for_issues() {
   local merged_prs_file="$1" issues_file="$2" output_file="$3"
   jq --slurpfile issues "$issues_file" \
-    '($issues[0] | map(.number)) as $issue_numbers | [.[] | . as $pr | select(any($issue_numbers[]; . as $number | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix|spec|implementation-plan)/" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))]' \
+    '($issues[0] | map(.number)) as $issue_numbers | [.[] | . as $pr | select((($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/")) and any($issue_numbers[]; . as $number | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))]' \
     "$merged_prs_file" > "$output_file"
 }
 
@@ -231,6 +231,10 @@ filter_merged_prs_for_issues() {
 if [ -n "$issues_arg" ]; then
   issues_list="$tmp_dir/issues-list.txt"
   printf '%s\n' "$issues_arg" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | awk 'NF' > "$issues_list"
+  if [ ! -s "$issues_list" ]; then
+    echo "--issues must contain at least one issue" >&2
+    exit 64
+  fi
   while IFS= read -r issue; do
     if ! printf '%s\n' "$issue" | grep -Eq '^[1-9][0-9]*$'; then
       echo "Invalid issue in --issues: $issue" >&2

--- a/scripts/development-workflow/post-merge-qa-scope.sh
+++ b/scripts/development-workflow/post-merge-qa-scope.sh
@@ -216,14 +216,14 @@ append_rows_from_json_array() {
 filter_issues_referenced_by_merged_prs() {
   local issues_file="$1" merged_prs_file="$2" output_file="$3"
   jq --slurpfile merged_prs "$merged_prs_file" \
-    '[.[] | .number as $number | select(any($merged_prs[0][]?; . as $pr | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/")) and (((($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))))]' \
+    '[.[] | .number as $number | select(any($merged_prs[0][]?; . as $pr | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/")) and (((($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/(([A-Z][A-Z0-9]{1,7}|[a-z][a-z0-9])-)?" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))))]' \
     "$issues_file" > "$output_file"
 }
 
 filter_merged_prs_for_issues() {
   local merged_prs_file="$1" issues_file="$2" output_file="$3"
   jq --slurpfile issues "$issues_file" \
-    '($issues[0] | map(.number)) as $issue_numbers | [.[] | . as $pr | select((($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/")) and any($issue_numbers[]; . as $number | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))]' \
+    '($issues[0] | map(.number)) as $issue_numbers | [.[] | . as $pr | select((($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/")) and any($issue_numbers[]; . as $number | (($pr.headRefName // "") | test("^(feature|fix|refactor|hotfix)/(([A-Z][A-Z0-9]{1,7}|[a-z][a-z0-9])-)?" + ($number | tostring) + "(-|$)")) or ((($pr.title // "") + "\n" + ($pr.body // "")) | test("(^|[^0-9])#" + ($number | tostring) + "([^0-9]|$)"))))]' \
     "$merged_prs_file" > "$output_file"
 }
 

--- a/scripts/development-workflow/tests/fixtures/post-merge-qa-tracker-none.yaml
+++ b/scripts/development-workflow/tests/fixtures/post-merge-qa-tracker-none.yaml
@@ -1,0 +1,3 @@
+schema_version: 2
+issue_tracker:
+  provider: none

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -56,7 +56,7 @@ set -euo pipefail
 case "$*" in
   *"pr list"*"--base develop-demo"*)
     cat <<'JSON'
-[{"number":101,"title":"Merged feature","url":"https://example.test/pr/101","mergedAt":"2026-07-01T00:00:00Z","headRefName":"fix/51-merged-feature","body":"Implements #51"},{"number":102,"title":"Unrelated work","url":"https://example.test/pr/102","mergedAt":"2026-07-02T00:00:00Z","headRefName":"fix/99-unrelated","body":"Implements #99"}]
+[{"number":101,"title":"Merged feature","url":"https://example.test/pr/101","mergedAt":"2026-07-01T00:00:00Z","headRefName":"fix/51-merged-feature","body":"Implements #51"},{"number":102,"title":"Unrelated work","url":"https://example.test/pr/102","mergedAt":"2026-07-02T00:00:00Z","headRefName":"fix/99-unrelated","body":"Implements #99"},{"number":103,"title":"Spec only","url":"https://example.test/pr/103","mergedAt":"2026-07-03T00:00:00Z","headRefName":"spec/52-spec-only","body":"Documents #52"},{"number":104,"title":"Plan only #53","url":"https://example.test/pr/104","mergedAt":"2026-07-04T00:00:00Z","headRefName":"implementation-plan/53-plan-only","body":"Plans #53"}]
 JSON
     ;;
   *"pr list"*"--base develop-empty"*)
@@ -94,7 +94,7 @@ JSON
       exit 1
     fi
     cat <<'JSON'
-[{"number":50,"title":"Epic","url":"https://example.test/issues/50"},{"number":51,"title":"Child","url":"https://example.test/issues/51"}]
+[{"number":50,"title":"Epic","url":"https://example.test/issues/50"},{"number":51,"title":"Child","url":"https://example.test/issues/51"},{"number":52,"title":"Spec-only child","url":"https://example.test/issues/52"},{"number":53,"title":"Plan-only child","url":"https://example.test/issues/53"}]
 JSON
     ;;
   *)
@@ -207,6 +207,8 @@ run_test "epic_self_excluded" "no" "$(printf '%s' "$out3" | jq -er 'any(.candida
 run_test "epic_scope_source" "epic" "$(printf '%s' "$out3" | jq -er '.scopeSource')"
 run_test "epic_merged_pr_included" "yes" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 101) | if . then "yes" else "no" end')"
 run_test "epic_unrelated_pr_excluded" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 102) | if . then "yes" else "no" end')"
+run_test "epic_excludes_spec_only_issue" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 52) | if . then "yes" else "no" end')"
+run_test "epic_excludes_plan_only_pr" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 104) | if . then "yes" else "no" end')"
 
 out_integration="$("$HELPER" --base develop-demo --json)" || {
   echo "FAIL: integration helper exited non-zero"
@@ -227,6 +229,7 @@ run_test "degraded_integration_uses_pr_fallback" "merged-prs" "$(printf '%s' "$o
 run_test "degraded_integration_is_fallback" "true" "$(printf '%s' "$out_integration_fallback" | jq -er '.fallback')"
 
 run_fails_contains "rejects_invalid_issues" "Invalid issue in --issues" "$HELPER" --base develop --issues "abc" --json
+run_fails_contains "rejects_empty_issues" "--issues must contain at least one" "$HELPER" --base develop --issues "," --json
 run_fails_contains "rejects_invalid_tracker_items" "Invalid tracker item in --tracker-items" "$HELPER" --base develop --tracker-items "bad/item" --json
 run_fails_contains "rejects_empty_tracker_items" "--tracker-items must contain at least one" "$HELPER" --base develop --tracker-items "," --json
 run_fails_contains "rejects_missing_issue" "Failed to read issue" "$HELPER" --base develop --issues "999001" --json

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
 HELPER="$REPO_ROOT/scripts/development-workflow/post-merge-qa-scope.sh"
+NO_TRACKER_CONFIG="$SCRIPT_DIR/fixtures/post-merge-qa-tracker-none.yaml"
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -119,6 +120,14 @@ out_tracker_required="$("$HELPER" --base develop --json)" || {
 run_test "configured_tracker_requires_discovery" "0" "$(printf '%s' "$out_tracker_required" | jq -er '.candidateCount')"
 run_test "configured_tracker_scope_source" "tracker-post-merge" "$(printf '%s' "$out_tracker_required" | jq -er '.scopeSource')"
 run_test "configured_tracker_is_not_fallback" "false" "$(printf '%s' "$out_tracker_required" | jq -er '.fallback')"
+
+out_no_tracker="$(AI_DEV_WORKFLOW_CONFIG_FILE="$NO_TRACKER_CONFIG" "$HELPER" --base develop --json)" || {
+  echo "FAIL: no-tracker override helper exited non-zero"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  out_no_tracker="{}"
+}
+run_test "no_tracker_override_uses_pr_fallback" "merged-prs" "$(printf '%s' "$out_no_tracker" | jq -er '.scopeSource')"
+run_test "no_tracker_override_is_fallback" "true" "$(printf '%s' "$out_no_tracker" | jq -er '.fallback')"
 
 out2="$("$HELPER" --base develop --issues 42 --json)" || {
   echo "FAIL: explicit_issue helper exited non-zero"

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -56,7 +56,7 @@ set -euo pipefail
 case "$*" in
   *"pr list"*"--base develop-demo"*)
     cat <<'JSON'
-[{"number":101,"title":"Merged feature","url":"https://example.test/pr/101","mergedAt":"2026-07-01T00:00:00Z","headRefName":"fix/51-merged-feature","body":"Implements #51"},{"number":102,"title":"Unrelated work","url":"https://example.test/pr/102","mergedAt":"2026-07-02T00:00:00Z","headRefName":"fix/99-unrelated","body":"Implements #99"},{"number":103,"title":"Spec only","url":"https://example.test/pr/103","mergedAt":"2026-07-03T00:00:00Z","headRefName":"spec/52-spec-only","body":"Documents #52"},{"number":104,"title":"Plan only #53","url":"https://example.test/pr/104","mergedAt":"2026-07-04T00:00:00Z","headRefName":"implementation-plan/53-plan-only","body":"Plans #53"}]
+[{"number":101,"title":"Merged feature","url":"https://example.test/pr/101","mergedAt":"2026-07-01T00:00:00Z","headRefName":"feature/ENG-51-merged-feature","body":"Implementation branch uses tracker prefix"},{"number":102,"title":"Unrelated work","url":"https://example.test/pr/102","mergedAt":"2026-07-02T00:00:00Z","headRefName":"fix/99-unrelated","body":"Implements #99"},{"number":103,"title":"Spec only","url":"https://example.test/pr/103","mergedAt":"2026-07-03T00:00:00Z","headRefName":"spec/52-spec-only","body":"Documents #52"},{"number":104,"title":"Plan only #53","url":"https://example.test/pr/104","mergedAt":"2026-07-04T00:00:00Z","headRefName":"implementation-plan/53-plan-only","body":"Plans #53"},{"number":105,"title":"Lowercase tracker prefix","url":"https://example.test/pr/105","mergedAt":"2026-07-05T00:00:00Z","headRefName":"fix/lh-54-lowercase-prefix","body":"Implementation branch uses lowercase tracker prefix"}]
 JSON
     ;;
   *"pr list"*"--base develop-empty"*)
@@ -94,7 +94,7 @@ JSON
       exit 1
     fi
     cat <<'JSON'
-[{"number":50,"title":"Epic","url":"https://example.test/issues/50"},{"number":51,"title":"Child","url":"https://example.test/issues/51"},{"number":52,"title":"Spec-only child","url":"https://example.test/issues/52"},{"number":53,"title":"Plan-only child","url":"https://example.test/issues/53"}]
+[{"number":50,"title":"Epic","url":"https://example.test/issues/50"},{"number":51,"title":"Child","url":"https://example.test/issues/51"},{"number":52,"title":"Spec-only child","url":"https://example.test/issues/52"},{"number":53,"title":"Plan-only child","url":"https://example.test/issues/53"},{"number":54,"title":"Lowercase-prefix child","url":"https://example.test/issues/54"}]
 JSON
     ;;
   *)
@@ -209,6 +209,7 @@ run_test "epic_merged_pr_included" "yes" "$(printf '%s' "$out3" | jq -er 'any(.c
 run_test "epic_unrelated_pr_excluded" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 102) | if . then "yes" else "no" end')"
 run_test "epic_excludes_spec_only_issue" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 52) | if . then "yes" else "no" end')"
 run_test "epic_excludes_plan_only_pr" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 104) | if . then "yes" else "no" end')"
+run_test "epic_includes_lowercase_tracker_prefix_issue" "yes" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 54) | if . then "yes" else "no" end')"
 
 out_integration="$("$HELPER" --base develop-demo --json)" || {
   echo "FAIL: integration helper exited non-zero"
@@ -217,6 +218,7 @@ out_integration="$("$HELPER" --base develop-demo --json)" || {
 }
 run_test "integration_scope_source" "integration-branch" "$(printf '%s' "$out_integration" | jq -er '.scopeSource')"
 run_test "integration_default_includes_labelled_issue" "yes" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 51) | if . then "yes" else "no" end')"
+run_test "integration_default_includes_lowercase_tracker_prefix_issue" "yes" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 54) | if . then "yes" else "no" end')"
 run_test "integration_default_excludes_unmerged_labelled_issue" "no" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 50) | if . then "yes" else "no" end')"
 run_test "integration_default_includes_merged_pr" "yes" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 101) | if . then "yes" else "no" end')"
 

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -200,6 +200,7 @@ out3="$("$HELPER" --base develop-demo --epic 50 --json)" || {
 run_test "epic_child_included" "yes" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .number == 51) | if . then "yes" else "no" end')"
 run_test "epic_self_excluded" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .number == 50) | if . then "yes" else "no" end')"
 run_test "epic_scope_source" "epic" "$(printf '%s' "$out3" | jq -er '.scopeSource')"
+run_test "epic_merged_pr_included" "yes" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 101) | if . then "yes" else "no" end')"
 
 out_integration="$("$HELPER" --base develop-demo --json)" || {
   echo "FAIL: integration helper exited non-zero"

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -57,7 +57,7 @@ case "$*" in
   *"pr list"*"--state merged"*)
     # Include a malformed row to verify skip-and-continue behavior
     cat <<'JSON'
-[{"number":101,"title":"Merged feature","url":"https://example.test/pr/101","mergedAt":"2026-07-01T00:00:00Z"},{"number":null,"title":"Bad","url":"https://example.test/pr/bad"}]
+[{"number":101,"title":"Merged feature","url":"https://example.test/pr/101","mergedAt":"2026-07-01T00:00:00Z","closingIssuesReferences":[{"number":51}]},{"number":null,"title":"Bad","url":"https://example.test/pr/bad"}]
 JSON
     ;;
   *"issue view"*"--json"*)
@@ -190,6 +190,7 @@ out_integration="$("$HELPER" --base develop-demo --json)" || {
 }
 run_test "integration_scope_source" "integration-branch" "$(printf '%s' "$out_integration" | jq -er '.scopeSource')"
 run_test "integration_default_includes_labelled_issue" "yes" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 51) | if . then "yes" else "no" end')"
+run_test "integration_default_excludes_unmerged_labelled_issue" "no" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 50) | if . then "yes" else "no" end')"
 run_test "integration_default_includes_merged_pr" "yes" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 101) | if . then "yes" else "no" end')"
 
 run_fails_contains "rejects_invalid_issues" "Invalid issue in --issues" "$HELPER" --base develop --issues "abc" --json

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -56,7 +56,7 @@ set -euo pipefail
 case "$*" in
   *"pr list"*"--base develop-demo"*)
     cat <<'JSON'
-[{"number":101,"title":"Merged feature","url":"https://example.test/pr/101","mergedAt":"2026-07-01T00:00:00Z","headRefName":"feature/ENG-51-merged-feature","body":"Implementation branch uses tracker prefix"},{"number":102,"title":"Unrelated work","url":"https://example.test/pr/102","mergedAt":"2026-07-02T00:00:00Z","headRefName":"fix/99-unrelated","body":"Implements #99"},{"number":103,"title":"Spec only","url":"https://example.test/pr/103","mergedAt":"2026-07-03T00:00:00Z","headRefName":"spec/52-spec-only","body":"Documents #52"},{"number":104,"title":"Plan only #53","url":"https://example.test/pr/104","mergedAt":"2026-07-04T00:00:00Z","headRefName":"implementation-plan/53-plan-only","body":"Plans #53"},{"number":105,"title":"Lowercase tracker prefix","url":"https://example.test/pr/105","mergedAt":"2026-07-05T00:00:00Z","headRefName":"fix/lh-54-lowercase-prefix","body":"Implementation branch uses lowercase tracker prefix"}]
+[{"number":101,"title":"Merged feature","url":"https://example.test/pr/101","mergedAt":"2026-07-01T00:00:00Z","headRefName":"feature/ENG-51-merged-feature","body":"Implementation branch uses tracker prefix"},{"number":102,"title":"Unrelated work","url":"https://example.test/pr/102","mergedAt":"2026-07-02T00:00:00Z","headRefName":"fix/99-unrelated","body":"Implements #99"},{"number":103,"title":"Spec only","url":"https://example.test/pr/103","mergedAt":"2026-07-03T00:00:00Z","headRefName":"spec/52-spec-only","body":"Documents #52"},{"number":104,"title":"Plan only #53","url":"https://example.test/pr/104","mergedAt":"2026-07-04T00:00:00Z","headRefName":"implementation-plan/53-plan-only","body":"Plans #53"},{"number":105,"title":"Lowercase tracker prefix","url":"https://example.test/pr/105","mergedAt":"2026-07-05T00:00:00Z","headRefName":"fix/lh-54-lowercase-prefix","body":"Implementation branch uses lowercase tracker prefix"},{"number":106,"title":"Short uppercase tracker prefix","url":"https://example.test/pr/106","mergedAt":"2026-07-06T00:00:00Z","headRefName":"feature/A-55-short-uppercase-prefix","body":"Implementation branch uses short uppercase tracker prefix"},{"number":107,"title":"Long lowercase tracker prefix","url":"https://example.test/pr/107","mergedAt":"2026-07-07T00:00:00Z","headRefName":"refactor/abc-56-long-lowercase-prefix","body":"Implementation branch uses long lowercase tracker prefix"}]
 JSON
     ;;
   *"pr list"*"--base develop-empty"*)
@@ -94,7 +94,7 @@ JSON
       exit 1
     fi
     cat <<'JSON'
-[{"number":50,"title":"Epic","url":"https://example.test/issues/50"},{"number":51,"title":"Child","url":"https://example.test/issues/51"},{"number":52,"title":"Spec-only child","url":"https://example.test/issues/52"},{"number":53,"title":"Plan-only child","url":"https://example.test/issues/53"},{"number":54,"title":"Lowercase-prefix child","url":"https://example.test/issues/54"}]
+[{"number":50,"title":"Epic","url":"https://example.test/issues/50"},{"number":51,"title":"Child","url":"https://example.test/issues/51"},{"number":52,"title":"Spec-only child","url":"https://example.test/issues/52"},{"number":53,"title":"Plan-only child","url":"https://example.test/issues/53"},{"number":54,"title":"Lowercase-prefix child","url":"https://example.test/issues/54"},{"number":55,"title":"Short-uppercase-prefix child","url":"https://example.test/issues/55"},{"number":56,"title":"Long-lowercase-prefix child","url":"https://example.test/issues/56"}]
 JSON
     ;;
   *)
@@ -210,6 +210,18 @@ run_test "epic_unrelated_pr_excluded" "no" "$(printf '%s' "$out3" | jq -er 'any(
 run_test "epic_excludes_spec_only_issue" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 52) | if . then "yes" else "no" end')"
 run_test "epic_excludes_plan_only_pr" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 104) | if . then "yes" else "no" end')"
 run_test "epic_includes_lowercase_tracker_prefix_issue" "yes" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 54) | if . then "yes" else "no" end')"
+run_test "epic_includes_short_uppercase_tracker_prefix_issue" "yes" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 55) | if . then "yes" else "no" end')"
+run_test "epic_includes_long_lowercase_tracker_prefix_issue" "yes" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 56) | if . then "yes" else "no" end')"
+
+out_epic_degraded="$(FAIL_INTEGRATION_ISSUE_LIST=1 "$HELPER" --base develop-demo --epic 50 --json)" || {
+  echo "FAIL: degraded epic helper exited non-zero"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  out_epic_degraded="{}"
+}
+run_test "degraded_epic_scope_source" "epic" "$(printf '%s' "$out_epic_degraded" | jq -er '.scopeSource')"
+run_test "degraded_epic_is_fallback" "true" "$(printf '%s' "$out_epic_degraded" | jq -er '.fallback')"
+run_test "degraded_epic_is_not_confirmable" "false" "$(printf '%s' "$out_epic_degraded" | jq -er '.confirmationRequired')"
+run_test "degraded_epic_requires_discovery" "true" "$(printf '%s' "$out_epic_degraded" | jq -er '.discoveryRequired')"
 
 out_integration="$("$HELPER" --base develop-demo --json)" || {
   echo "FAIL: integration helper exited non-zero"
@@ -219,6 +231,8 @@ out_integration="$("$HELPER" --base develop-demo --json)" || {
 run_test "integration_scope_source" "integration-branch" "$(printf '%s' "$out_integration" | jq -er '.scopeSource')"
 run_test "integration_default_includes_labelled_issue" "yes" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 51) | if . then "yes" else "no" end')"
 run_test "integration_default_includes_lowercase_tracker_prefix_issue" "yes" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 54) | if . then "yes" else "no" end')"
+run_test "integration_default_includes_short_uppercase_tracker_prefix_issue" "yes" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 55) | if . then "yes" else "no" end')"
+run_test "integration_default_includes_long_lowercase_tracker_prefix_issue" "yes" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 56) | if . then "yes" else "no" end')"
 run_test "integration_default_excludes_unmerged_labelled_issue" "no" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 50) | if . then "yes" else "no" end')"
 run_test "integration_default_includes_merged_pr" "yes" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 101) | if . then "yes" else "no" end')"
 

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -127,6 +127,8 @@ out_tracker_required="$("$HELPER" --base develop --json)" || {
 run_test "configured_tracker_requires_discovery" "0" "$(printf '%s' "$out_tracker_required" | jq -er '.candidateCount')"
 run_test "configured_tracker_scope_source" "tracker-post-merge" "$(printf '%s' "$out_tracker_required" | jq -er '.scopeSource')"
 run_test "configured_tracker_is_not_fallback" "false" "$(printf '%s' "$out_tracker_required" | jq -er '.fallback')"
+run_test "configured_tracker_is_not_confirmable" "false" "$(printf '%s' "$out_tracker_required" | jq -er '.confirmationRequired')"
+run_test "configured_tracker_requires_discovery_flag" "true" "$(printf '%s' "$out_tracker_required" | jq -er '.discoveryRequired')"
 
 out_no_tracker="$(AI_DEV_WORKFLOW_CONFIG_FILE="$NO_TRACKER_CONFIG" "$HELPER" --base develop --json)" || {
   echo "FAIL: no-tracker override helper exited non-zero"

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -54,6 +54,11 @@ cat >"$MOCK_BIN/gh" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
+  *"pr list"*"--base develop-demo"*)
+    cat <<'JSON'
+[{"number":101,"title":"Merged feature","url":"https://example.test/pr/101","mergedAt":"2026-07-01T00:00:00Z","headRefName":"fix/51-merged-feature","body":"Implements #51"},{"number":102,"title":"Unrelated work","url":"https://example.test/pr/102","mergedAt":"2026-07-02T00:00:00Z","headRefName":"fix/99-unrelated","body":"Implements #99"}]
+JSON
+    ;;
   *"pr list"*"--base develop-empty"*)
     echo '[]'
     ;;
@@ -201,6 +206,7 @@ run_test "epic_child_included" "yes" "$(printf '%s' "$out3" | jq -er 'any(.candi
 run_test "epic_self_excluded" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .number == 50) | if . then "yes" else "no" end')"
 run_test "epic_scope_source" "epic" "$(printf '%s' "$out3" | jq -er '.scopeSource')"
 run_test "epic_merged_pr_included" "yes" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 101) | if . then "yes" else "no" end')"
+run_test "epic_unrelated_pr_excluded" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 102) | if . then "yes" else "no" end')"
 
 out_integration="$("$HELPER" --base develop-demo --json)" || {
   echo "FAIL: integration helper exited non-zero"
@@ -222,6 +228,7 @@ run_test "degraded_integration_is_fallback" "true" "$(printf '%s' "$out_integrat
 
 run_fails_contains "rejects_invalid_issues" "Invalid issue in --issues" "$HELPER" --base develop --issues "abc" --json
 run_fails_contains "rejects_invalid_tracker_items" "Invalid tracker item in --tracker-items" "$HELPER" --base develop --tracker-items "bad/item" --json
+run_fails_contains "rejects_empty_tracker_items" "--tracker-items must contain at least one" "$HELPER" --base develop --tracker-items "," --json
 run_fails_contains "rejects_missing_issue" "Failed to read issue" "$HELPER" --base develop --issues "999001" --json
 
 echo ""

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -54,10 +54,13 @@ cat >"$MOCK_BIN/gh" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
+  *"pr list"*"--base develop-empty"*)
+    echo '[]'
+    ;;
   *"pr list"*"--state merged"*)
     # Include a malformed row to verify skip-and-continue behavior
     cat <<'JSON'
-[{"number":101,"title":"Merged feature","url":"https://example.test/pr/101","mergedAt":"2026-07-01T00:00:00Z","closingIssuesReferences":[{"number":51}]},{"number":null,"title":"Bad","url":"https://example.test/pr/bad"}]
+[{"number":101,"title":"Merged feature","url":"https://example.test/pr/101","mergedAt":"2026-07-01T00:00:00Z","headRefName":"fix/51-merged-feature","body":"Implements #51"},{"number":null,"title":"Bad","url":"https://example.test/pr/bad"}]
 JSON
     ;;
   *"issue view"*"--json"*)
@@ -81,6 +84,10 @@ JSON
     fi
     ;;
   *"issue list"*"integration-branch:demo"*)
+    if [ "$FAIL_INTEGRATION_ISSUE_LIST" = "1" ]; then
+      echo "integration issue query failed" >&2
+      exit 1
+    fi
     cat <<'JSON'
 [{"number":50,"title":"Epic","url":"https://example.test/issues/50"},{"number":51,"title":"Child","url":"https://example.test/issues/51"}]
 JSON
@@ -93,6 +100,7 @@ esac
 STUB
 chmod +x "$MOCK_BIN/gh"
 export PATH="$MOCK_BIN:$PATH"
+export FAIL_INTEGRATION_ISSUE_LIST=""
 
 mkdir -p "$(dirname -- "$DOWNSTREAM_HELPER")"
 cp "$HELPER" "$DOWNSTREAM_HELPER"
@@ -129,6 +137,14 @@ run_test "configured_tracker_scope_source" "tracker-post-merge" "$(printf '%s' "
 run_test "configured_tracker_is_not_fallback" "false" "$(printf '%s' "$out_tracker_required" | jq -er '.fallback')"
 run_test "configured_tracker_is_not_confirmable" "false" "$(printf '%s' "$out_tracker_required" | jq -er '.confirmationRequired')"
 run_test "configured_tracker_requires_discovery_flag" "true" "$(printf '%s' "$out_tracker_required" | jq -er '.discoveryRequired')"
+
+out_explicit_empty="$("$HELPER" --base develop-empty --recent-merged-prs 1 --json)" || {
+  echo "FAIL: explicit empty helper exited non-zero"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  out_explicit_empty="{}"
+}
+run_test "explicit_empty_scope_remains_confirmable" "true" "$(printf '%s' "$out_explicit_empty" | jq -er '.confirmationRequired')"
+run_test "explicit_empty_scope_does_not_require_discovery" "false" "$(printf '%s' "$out_explicit_empty" | jq -er '.discoveryRequired')"
 
 out_no_tracker="$(AI_DEV_WORKFLOW_CONFIG_FILE="$NO_TRACKER_CONFIG" "$HELPER" --base develop --json)" || {
   echo "FAIL: no-tracker override helper exited non-zero"
@@ -194,6 +210,14 @@ run_test "integration_scope_source" "integration-branch" "$(printf '%s' "$out_in
 run_test "integration_default_includes_labelled_issue" "yes" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 51) | if . then "yes" else "no" end')"
 run_test "integration_default_excludes_unmerged_labelled_issue" "no" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 50) | if . then "yes" else "no" end')"
 run_test "integration_default_includes_merged_pr" "yes" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 101) | if . then "yes" else "no" end')"
+
+out_integration_fallback="$(FAIL_INTEGRATION_ISSUE_LIST=1 "$HELPER" --base develop-demo --json)" || {
+  echo "FAIL: degraded integration helper exited non-zero"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  out_integration_fallback="{}"
+}
+run_test "degraded_integration_uses_pr_fallback" "merged-prs" "$(printf '%s' "$out_integration_fallback" | jq -er '.scopeSource')"
+run_test "degraded_integration_is_fallback" "true" "$(printf '%s' "$out_integration_fallback" | jq -er '.fallback')"
 
 run_fails_contains "rejects_invalid_issues" "Invalid issue in --issues" "$HELPER" --base develop --issues "abc" --json
 run_fails_contains "rejects_invalid_tracker_items" "Invalid tracker item in --tracker-items" "$HELPER" --base develop --tracker-items "bad/item" --json

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -108,8 +108,17 @@ run_test "recent_merged_count" "1" "$(printf '%s' "$out" | jq -er '.candidateCou
 run_test "confirmation_required" "true" "$(printf '%s' "$out" | jq -er '.confirmationRequired')"
 run_test "read_only_present" "yes" "$(printf '%s' "$out" | jq -er 'if .readOnlyGuarantee then "yes" else "no" end')"
 run_test "base_echoed" "develop" "$(printf '%s' "$out" | jq -er '.base')"
-run_test "default_scope_source" "merged-prs" "$(printf '%s' "$out" | jq -er '.scopeSource')"
-run_test "default_is_fallback" "true" "$(printf '%s' "$out" | jq -er '.fallback')"
+run_test "recent_merged_scope_source" "explicit" "$(printf '%s' "$out" | jq -er '.scopeSource')"
+run_test "recent_merged_is_not_fallback" "false" "$(printf '%s' "$out" | jq -er '.fallback')"
+
+out_tracker_required="$("$HELPER" --base develop --json)" || {
+  echo "FAIL: configured tracker helper exited non-zero"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  out_tracker_required="{}"
+}
+run_test "configured_tracker_requires_discovery" "0" "$(printf '%s' "$out_tracker_required" | jq -er '.candidateCount')"
+run_test "configured_tracker_scope_source" "tracker-post-merge" "$(printf '%s' "$out_tracker_required" | jq -er '.scopeSource')"
+run_test "configured_tracker_is_not_fallback" "false" "$(printf '%s' "$out_tracker_required" | jq -er '.fallback')"
 
 out2="$("$HELPER" --base develop --issues 42 --json)" || {
   echo "FAIL: explicit_issue helper exited non-zero"

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -56,7 +56,7 @@ set -euo pipefail
 case "$*" in
   *"pr list"*"--base develop-demo"*)
     cat <<'JSON'
-[{"number":101,"title":"Merged feature","url":"https://example.test/pr/101","mergedAt":"2026-07-01T00:00:00Z","headRefName":"feature/ENG-51-merged-feature","body":"Implementation branch uses tracker prefix"},{"number":102,"title":"Unrelated work","url":"https://example.test/pr/102","mergedAt":"2026-07-02T00:00:00Z","headRefName":"fix/99-unrelated","body":"Implements #99"},{"number":103,"title":"Spec only","url":"https://example.test/pr/103","mergedAt":"2026-07-03T00:00:00Z","headRefName":"spec/52-spec-only","body":"Documents #52"},{"number":104,"title":"Plan only #53","url":"https://example.test/pr/104","mergedAt":"2026-07-04T00:00:00Z","headRefName":"implementation-plan/53-plan-only","body":"Plans #53"},{"number":105,"title":"Lowercase tracker prefix","url":"https://example.test/pr/105","mergedAt":"2026-07-05T00:00:00Z","headRefName":"fix/lh-54-lowercase-prefix","body":"Implementation branch uses lowercase tracker prefix"},{"number":106,"title":"Short uppercase tracker prefix","url":"https://example.test/pr/106","mergedAt":"2026-07-06T00:00:00Z","headRefName":"feature/A-55-short-uppercase-prefix","body":"Implementation branch uses short uppercase tracker prefix"},{"number":107,"title":"Long lowercase tracker prefix","url":"https://example.test/pr/107","mergedAt":"2026-07-07T00:00:00Z","headRefName":"refactor/abc-56-long-lowercase-prefix","body":"Implementation branch uses long lowercase tracker prefix"}]
+[{"number":101,"title":"Merged feature","url":"https://example.test/pr/101","mergedAt":"2026-07-01T00:00:00Z","headRefName":"feature/ENG-51-merged-feature","body":"Implementation branch uses tracker prefix"},{"number":102,"title":"Unrelated work","url":"https://example.test/pr/102","mergedAt":"2026-07-02T00:00:00Z","headRefName":"fix/99-unrelated","body":"Implements #99"},{"number":103,"title":"Spec only","url":"https://example.test/pr/103","mergedAt":"2026-07-03T00:00:00Z","headRefName":"spec/52-spec-only","body":"Documents #52"},{"number":104,"title":"Plan only #53","url":"https://example.test/pr/104","mergedAt":"2026-07-04T00:00:00Z","headRefName":"implementation-plan/53-plan-only","body":"Plans #53"},{"number":105,"title":"Lowercase tracker prefix","url":"https://example.test/pr/105","mergedAt":"2026-07-05T00:00:00Z","headRefName":"fix/lh-54-lowercase-prefix","body":"Implementation branch uses lowercase tracker prefix"},{"number":106,"title":"Short uppercase tracker prefix","url":"https://example.test/pr/106","mergedAt":"2026-07-06T00:00:00Z","headRefName":"feature/A-55-short-uppercase-prefix","body":"Implementation branch uses short uppercase tracker prefix"},{"number":107,"title":"Long lowercase tracker prefix","url":"https://example.test/pr/107","mergedAt":"2026-07-07T00:00:00Z","headRefName":"refactor/abc-56-long-lowercase-prefix","body":"Implementation branch uses long lowercase tracker prefix"},{"number":108,"title":"Color update","url":"https://example.test/pr/108","mergedAt":"2026-07-08T00:00:00Z","headRefName":"fix/77-color-update","body":"Use color #51a3d2"}]
 JSON
     ;;
   *"pr list"*"--base develop-empty"*)
@@ -119,6 +119,7 @@ run_fails_contains "requires_epic_value" "--epic requires a value" "$HELPER" --b
 run_fails_contains "requires_issues_value" "--issues requires a value" "$HELPER" --base develop --issues --json
 run_fails_contains "requires_tracker_items_value" "--tracker-items requires a value" "$HELPER" --base develop --tracker-items --json
 run_fails_contains "requires_recent_value" "--recent-merged-prs requires a value" "$HELPER" --base develop --recent-merged-prs --json
+run_fails_contains "rejects_mixed_scope_flags" "cannot be combined" "$HELPER" --base develop --tracker-items LEA-223 --recent-merged-prs 1 --json
 
 out="$("$HELPER" --base develop --recent-merged-prs 1 --json)" || {
   echo "FAIL: recent_merged helper exited non-zero"
@@ -207,6 +208,7 @@ run_test "epic_self_excluded" "no" "$(printf '%s' "$out3" | jq -er 'any(.candida
 run_test "epic_scope_source" "epic" "$(printf '%s' "$out3" | jq -er '.scopeSource')"
 run_test "epic_merged_pr_included" "yes" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 101) | if . then "yes" else "no" end')"
 run_test "epic_unrelated_pr_excluded" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 102) | if . then "yes" else "no" end')"
+run_test "epic_hex_color_reference_excluded" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 108) | if . then "yes" else "no" end')"
 run_test "epic_excludes_spec_only_issue" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 52) | if . then "yes" else "no" end')"
 run_test "epic_excludes_plan_only_pr" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 104) | if . then "yes" else "no" end')"
 run_test "epic_includes_lowercase_tracker_prefix_issue" "yes" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 54) | if . then "yes" else "no" end')"
@@ -222,6 +224,17 @@ run_test "degraded_epic_scope_source" "epic" "$(printf '%s' "$out_epic_degraded"
 run_test "degraded_epic_is_fallback" "true" "$(printf '%s' "$out_epic_degraded" | jq -er '.fallback')"
 run_test "degraded_epic_is_not_confirmable" "false" "$(printf '%s' "$out_epic_degraded" | jq -er '.confirmationRequired')"
 run_test "degraded_epic_requires_discovery" "true" "$(printf '%s' "$out_epic_degraded" | jq -er '.discoveryRequired')"
+out_epic_degraded_text="$(FAIL_INTEGRATION_ISSUE_LIST=1 "$HELPER" --base develop-demo --epic 50)" || {
+  echo "FAIL: degraded epic text helper exited non-zero"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  out_epic_degraded_text=""
+}
+if grep -Fq -- "Epic discovery failed before a concrete QA scope could be confirmed" <<<"$out_epic_degraded_text"; then
+  degraded_epic_text_reason="yes"
+else
+  degraded_epic_text_reason="no"
+fi
+run_test "degraded_epic_text_uses_actual_reason" "yes" "$degraded_epic_text_reason"
 
 out_integration="$("$HELPER" --base develop-demo --json)" || {
   echo "FAIL: integration helper exited non-zero"

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -108,6 +108,8 @@ run_test "recent_merged_count" "1" "$(printf '%s' "$out" | jq -er '.candidateCou
 run_test "confirmation_required" "true" "$(printf '%s' "$out" | jq -er '.confirmationRequired')"
 run_test "read_only_present" "yes" "$(printf '%s' "$out" | jq -er 'if .readOnlyGuarantee then "yes" else "no" end')"
 run_test "base_echoed" "develop" "$(printf '%s' "$out" | jq -er '.base')"
+run_test "default_scope_source" "merged-prs" "$(printf '%s' "$out" | jq -er '.scopeSource')"
+run_test "default_is_fallback" "true" "$(printf '%s' "$out" | jq -er '.fallback')"
 
 out2="$("$HELPER" --base develop --issues 42 --json)" || {
   echo "FAIL: explicit_issue helper exited non-zero"
@@ -115,6 +117,7 @@ out2="$("$HELPER" --base develop --issues 42 --json)" || {
   out2="{}"
 }
 run_test "explicit_issue" "42" "$(printf '%s' "$out2" | jq -er '.candidates[0].number')"
+run_test "explicit_scope_source" "explicit" "$(printf '%s' "$out2" | jq -er '.scopeSource')"
 
 out_tracker="$("$HELPER" --base develop --tracker-items LEA-223,LEA-224 --json)" || {
   echo "FAIL: tracker_items helper exited non-zero"
@@ -123,6 +126,8 @@ out_tracker="$("$HELPER" --base develop --tracker-items LEA-223,LEA-224 --json)"
 }
 run_test "tracker_items_count" "2" "$(printf '%s' "$out_tracker" | jq -er '.candidateCount')"
 run_test "tracker_item_id" "LEA-223" "$(printf '%s' "$out_tracker" | jq -er '.candidates[0].id')"
+run_test "tracker_scope_source" "tracker-post-merge" "$(printf '%s' "$out_tracker" | jq -er '.scopeSource')"
+run_test "tracker_is_provider_backed" "true" "$(printf '%s' "$out_tracker" | jq -er '.providerBacked')"
 out_tracker_text="$("$HELPER" --base develop --tracker-items LEA-223)" || {
   echo "FAIL: tracker_items text helper exited non-zero"
   FAIL_COUNT=$((FAIL_COUNT + 1))
@@ -142,6 +147,14 @@ out3="$("$HELPER" --base develop-demo --epic 50 --json)" || {
 }
 run_test "epic_child_included" "yes" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .number == 51) | if . then "yes" else "no" end')"
 run_test "epic_self_excluded" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .number == 50) | if . then "yes" else "no" end')"
+run_test "epic_scope_source" "epic" "$(printf '%s' "$out3" | jq -er '.scopeSource')"
+
+out_integration="$("$HELPER" --base develop-demo --json)" || {
+  echo "FAIL: integration helper exited non-zero"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  out_integration="{}"
+}
+run_test "integration_scope_source" "integration-branch" "$(printf '%s' "$out_integration" | jq -er '.scopeSource')"
 
 run_fails_contains "rejects_invalid_issues" "Invalid issue in --issues" "$HELPER" --base develop --issues "abc" --json
 run_fails_contains "rejects_invalid_tracker_items" "Invalid tracker item in --tracker-items" "$HELPER" --base develop --tracker-items "bad/item" --json

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -189,6 +189,8 @@ out_integration="$("$HELPER" --base develop-demo --json)" || {
   out_integration="{}"
 }
 run_test "integration_scope_source" "integration-branch" "$(printf '%s' "$out_integration" | jq -er '.scopeSource')"
+run_test "integration_default_includes_labelled_issue" "yes" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "issue" and .number == 51) | if . then "yes" else "no" end')"
+run_test "integration_default_includes_merged_pr" "yes" "$(printf '%s' "$out_integration" | jq -er 'any(.candidates[]; .kind == "pull_request" and .number == 101) | if . then "yes" else "no" end')"
 
 run_fails_contains "rejects_invalid_issues" "Invalid issue in --issues" "$HELPER" --base develop --issues "abc" --json
 run_fails_contains "rejects_invalid_tracker_items" "Invalid tracker item in --tracker-items" "$HELPER" --base develop --tracker-items "bad/item" --json

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -96,6 +96,7 @@ run_fails_contains "rejects_feature_base" "Disallowed base" "$HELPER" --base fea
 run_fails_contains "rejects_bad_recent" "--recent-merged-prs must be" "$HELPER" --base develop --recent-merged-prs no --json
 run_fails_contains "requires_epic_value" "--epic requires a value" "$HELPER" --base develop --epic --json
 run_fails_contains "requires_issues_value" "--issues requires a value" "$HELPER" --base develop --issues --json
+run_fails_contains "requires_tracker_items_value" "--tracker-items requires a value" "$HELPER" --base develop --tracker-items --json
 run_fails_contains "requires_recent_value" "--recent-merged-prs requires a value" "$HELPER" --base develop --recent-merged-prs --json
 
 out="$("$HELPER" --base develop --recent-merged-prs 1 --json)" || {
@@ -115,6 +116,25 @@ out2="$("$HELPER" --base develop --issues 42 --json)" || {
 }
 run_test "explicit_issue" "42" "$(printf '%s' "$out2" | jq -er '.candidates[0].number')"
 
+out_tracker="$("$HELPER" --base develop --tracker-items LEA-223,LEA-224 --json)" || {
+  echo "FAIL: tracker_items helper exited non-zero"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  out_tracker="{}"
+}
+run_test "tracker_items_count" "2" "$(printf '%s' "$out_tracker" | jq -er '.candidateCount')"
+run_test "tracker_item_id" "LEA-223" "$(printf '%s' "$out_tracker" | jq -er '.candidates[0].id')"
+out_tracker_text="$("$HELPER" --base develop --tracker-items LEA-223)" || {
+  echo "FAIL: tracker_items text helper exited non-zero"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  out_tracker_text=""
+}
+if grep -Fq -- "[tracker_item #LEA-223]" <<<"$out_tracker_text"; then
+  tracker_text_present="yes"
+else
+  tracker_text_present="no"
+fi
+run_test "tracker_item_text_id" "yes" "$tracker_text_present"
+
 out3="$("$HELPER" --base develop-demo --epic 50 --json)" || {
   echo "FAIL: epic helper exited non-zero"
   FAIL_COUNT=$((FAIL_COUNT + 1))
@@ -124,6 +144,7 @@ run_test "epic_child_included" "yes" "$(printf '%s' "$out3" | jq -er 'any(.candi
 run_test "epic_self_excluded" "no" "$(printf '%s' "$out3" | jq -er 'any(.candidates[]; .number == 50) | if . then "yes" else "no" end')"
 
 run_fails_contains "rejects_invalid_issues" "Invalid issue in --issues" "$HELPER" --base develop --issues "abc" --json
+run_fails_contains "rejects_invalid_tracker_items" "Invalid tracker item in --tracker-items" "$HELPER" --base develop --tracker-items "bad/item" --json
 run_fails_contains "rejects_missing_issue" "Failed to read issue" "$HELPER" --base develop --issues "999001" --json
 
 echo ""

--- a/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
+++ b/scripts/development-workflow/tests/test-post-merge-qa-scope.sh
@@ -16,6 +16,9 @@ TMP_ROOT="$(mktemp -d)" || {
 }
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
+DOWNSTREAM_ROOT="$TMP_ROOT/downstream"
+DOWNSTREAM_HELPER="$DOWNSTREAM_ROOT/scripts/development-workflow/post-merge-qa-scope.sh"
+
 run_test() {
   local name="$1" expected="$2" actual="$3"
   if [ "$actual" = "$expected" ]; then
@@ -91,6 +94,10 @@ STUB
 chmod +x "$MOCK_BIN/gh"
 export PATH="$MOCK_BIN:$PATH"
 
+mkdir -p "$(dirname -- "$DOWNSTREAM_HELPER")"
+cp "$HELPER" "$DOWNSTREAM_HELPER"
+cp "$REPO_ROOT/scripts/development-workflow/workflow-lib.sh" "$(dirname -- "$DOWNSTREAM_HELPER")/workflow-lib.sh"
+
 run_fails_contains "requires_base" "--base is required" "$HELPER" --json
 run_fails_contains "requires_base_value" "--base requires a value" "$HELPER" --base --json
 run_fails_contains "rejects_feature_base" "Disallowed base" "$HELPER" --base feature/foo --json
@@ -128,6 +135,15 @@ out_no_tracker="$(AI_DEV_WORKFLOW_CONFIG_FILE="$NO_TRACKER_CONFIG" "$HELPER" --b
 }
 run_test "no_tracker_override_uses_pr_fallback" "merged-prs" "$(printf '%s' "$out_no_tracker" | jq -er '.scopeSource')"
 run_test "no_tracker_override_is_fallback" "true" "$(printf '%s' "$out_no_tracker" | jq -er '.fallback')"
+
+out_no_config="$(cd "$DOWNSTREAM_ROOT" && "$DOWNSTREAM_HELPER" --base develop --json)" || {
+  echo "FAIL: no-config helper exited non-zero"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  out_no_config="{}"
+}
+run_test "no_config_uses_pr_fallback" "merged-prs" "$(printf '%s' "$out_no_config" | jq -er '.scopeSource')"
+run_test "no_config_is_not_provider_backed" "false" "$(printf '%s' "$out_no_config" | jq -er '.providerBacked')"
+run_test "no_config_is_fallback" "true" "$(printf '%s' "$out_no_config" | jq -er '.fallback')"
 
 out2="$("$HELPER" --base develop --issues 42 --json)" || {
   echo "FAIL: explicit_issue helper exited non-zero"


### PR DESCRIPTION
## Summary

- Backport the verified post-merge QA tracker-scope behavior from lhpaul/leasity-exchanges-prototype#559.
- Accept provider-neutral `--tracker-items` values and preserve generic tracker identifiers in JSON and text output.
- Define tracker-post-merge discovery on `develop`, integration-branch behavior on `develop-<slug>`, and an explicit merged-PR fallback.

## Verification

- `bash -n scripts/development-workflow/post-merge-qa-scope.sh`
- `bash -n scripts/development-workflow/tests/test-post-merge-qa-scope.sh`
- `shellcheck scripts/development-workflow/post-merge-qa-scope.sh scripts/development-workflow/tests/test-post-merge-qa-scope.sh`
- `bash scripts/development-workflow/tests/test-post-merge-qa-scope.sh` (21 passed)
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/08-post-merge-qa-protocol.md" "CHANGELOG.md"`
- `git diff --check`

## Consistency Matrix

| Gate input | Allowed outcome | Required next action | Mirror surfaces |
| --- | --- | --- | --- |
| `develop` with configured tracker post-merge items | `tracker-post-merge` scope | Propose configured tracker items before QA | Protocol, skill wrappers, scope helper |
| `develop-<slug>` | `integration-branch` scope | Propose items and PRs merged into that branch; do not require final tracker state by default | Protocol, skill wrappers |
| Tracker unavailable, unclear, or unconfigured | `merged-prs` fallback | Propose recent merged PRs and state that the source is fallback | Protocol, scope helper |
| Explicit tracker IDs | `explicit` scope | Pass IDs through `--tracker-items`; retain provider-neutral IDs in output | Scope helper, focused tests |

## Script-Accuracy Self-Check

Script: `scripts/development-workflow/post-merge-qa-scope.sh`

- `--tracker-items` parsing, provider-neutral validation, JSON `id`, numeric `number` compatibility, and text rendering fallback were verified directly against the changed script.
- Default merged-PR fallback is suppressed for explicit tracker items and warns when provider-backed discovery should precede fallback.

## Pre-submission Self-Review

Stale markers: none. Caller and mirror consistency: verified across both skill wrappers, protocol, helper, and focused test. Coverage: issue #1453 outcome is fully addressed. Complex decision-gate matrix: included above.

Closes #1453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Post-merge QA scope discovery now accepts externally provided tracker items.
  * Scope results identify their source and whether they use tracker-backed or fallback discovery.
  * Human-readable and JSON outputs include tracker-aware identifiers and scope metadata.
  * Configured tracker workflows can require provider-backed discovery before confirmation.

* **Documentation**
  * Updated post-merge QA guidance, command usage, workflow requirements, and changelog details.

* **Tests**
  * Added coverage for tracker inputs, validation, discovery, fallback behavior, and output metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->