### PR TITLE
fix(workflow): check commit-status description in coderabbit_status_success_fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CodeRabbit success-status fallback ignored the description field** (#1437):
+  Both `coderabbit_status_success_fallback` call sites in `pr-review-loop.sh`
+  now reject a `success` CodeRabbit commit status whose description matches a
+  rate-limit or "review limit" not-actually-reviewed pattern (e.g. CodeRabbit's
+  confirmed "Review limit reached ... Next review available in: N minutes"
+  banner) via a new shared `coderabbit_success_status_count` helper, instead of
+  treating any `success` state as evidence a review completed. Closes the
+  false-clean risk left open by the existing thread-gate settle-wait
+  mitigation, which only audits existing threads and passes trivially when
+  CodeRabbit never actually reviewed the PR.
 - **Runners parking on backgrounded Step 7/8 loops** (#1434): Prohibit
   backgrounding `pr-review-loop.sh` / `pr-ci-loop.sh` and ending the turn to
   wait for them — the completion notification goes to the dispatcher, not the

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3897,6 +3897,46 @@ coderabbit_thread_gate_clean() {
   return 0
 }
 
+# Returns the count of CodeRabbit commit statuses for $head_sha on $repo that
+# are genuinely successful — i.e., context matches "coderabbit" (case
+# insensitive), the latest status per context has state == "success", AND the
+# status description does not match a rate-limit / not-actually-reviewed
+# pattern.
+#
+# Background (issue #1437): CodeRabbit can set a `success` commit status for
+# branch-protection compatibility while its description explicitly states the
+# review did not actually run. The confirmed real-world text (observed on
+# lhpaul/personal-finances PR #33) is "Review limit reached ... Next review
+# available in: N minutes" — note this does NOT contain the substring "rate
+# limit", so matching only the existing test("rate.?limit"; "i") comment-marker
+# regex used elsewhere in this script would miss it. The pattern below matches
+# both: the generic "rate limit" phrasing (kept for consistency with the
+# existing comment-marker regex, in case CodeRabbit also uses that wording in
+# a status description) AND the confirmed "review limit" / "next review
+# available" banner wording. Checking .state alone treats either case as a
+# completed clean review — a false clean. Both coderabbit_status_success_fallback
+# call sites in run_coderabbit_review use this helper so the description guard
+# is applied identically at both sites.
+#
+# Deduplicates by context (keeping the latest entry per context via
+# max_by(.updated_at)) before checking state/description, so a superseded
+# status is not counted — same dedup pattern used before this fix existed.
+coderabbit_success_status_count() {
+  local repo="$1" head_sha="$2"
+  gh api "repos/$repo/commits/$head_sha/statuses" --paginate \
+    | jq -s '[.[].[] | select(
+              (.context // "" | ascii_downcase | test("coderabbit"))
+            )]
+            | group_by(.context) | map(max_by(.updated_at))
+            | map(select(
+                .state == "success"
+                and ((.description // "")
+                     | test("rate.?limit|review limit|next review available"; "i")
+                     | not)
+              ))
+            | length'
+}
+
 run_coderabbit_review() {
   local pr_number="$1"
   local branch_name="$2"
@@ -4259,20 +4299,14 @@ run_coderabbit_review() {
         coderabbit_rate_limit_retries=$((coderabbit_rate_limit_retries + 1))
         echo "INFO: CodeRabbit rate limit detected (retry $coderabbit_rate_limit_retries/$coderabbit_rate_limit_max_retries) — checking for SUCCESS commit status before waiting" >&2
         # --- Early SUCCESS check before retry wait ---
-        # Check whether CodeRabbit already posted a SUCCESS commit status for the current
-        # HEAD SHA. This happens when CodeRabbit signals the result via a commit status
-        # during a rate-limit window on a parallel batch. If found, skip the retry wait
-        # entirely and treat the PR as clean via coderabbit_status_success_fallback.
+        # Check whether CodeRabbit already posted a genuine SUCCESS commit status for
+        # the current HEAD SHA (state == "success" AND description is not a rate-limit
+        # message — see coderabbit_success_status_count / issue #1437). This happens
+        # when CodeRabbit signals the result via a commit status during a rate-limit
+        # window on a parallel batch. If found, skip the retry wait entirely and treat
+        # the PR as clean via coderabbit_status_success_fallback.
         local coderabbit_early_success_count
-        coderabbit_early_success_count="$(
-          gh api "repos/$repo/commits/$head_sha/statuses" --paginate \
-            | jq -s '[.[].[] | select(
-                    (.context // "" | ascii_downcase | test("coderabbit"))
-                  )]
-                  | group_by(.context) | map(max_by(.updated_at))
-                  | map(select(.state == "success"))
-                  | length'
-        )"
+        coderabbit_early_success_count="$(coderabbit_success_status_count "$repo" "$head_sha")"
         if [ "${coderabbit_early_success_count:-0}" -gt 0 ]; then
           # SUCCESS status can appear while older CodeRabbit review threads stay unresolved
           # on the PR. Do not short-circuit to clean until GraphQL thread audit passes —
@@ -4326,26 +4360,16 @@ run_coderabbit_review() {
       if [ "$coderabbit_any_activity" -eq 0 ]; then
         # --- SUCCESS commit-status fallback ---
         # Before running stale-findings recovery or escalating, check whether CodeRabbit
-        # already posted a SUCCESS commit-status context for the current HEAD SHA. This
-        # happens during rate-limit windows on parallel batches: CodeRabbit signals the
-        # result via a commit status rather than an inline review comment. If found, treat
-        # the PR as clean and return immediately without scanning for stale findings.
-        # Context name is matched case-insensitively to guard against future renames.
-        local coderabbit_success_status_count
-        # Deduplicate by context (keep latest entry per context) before checking state,
-        # so a superseded status (e.g., an old success followed by a failure on the same
-        # context) is not counted. This matches the deduplication pattern used by the
-        # Devin adapter above.
-        coderabbit_success_status_count="$(
-          gh api "repos/$repo/commits/$head_sha/statuses" --paginate \
-            | jq -s '[.[].[] | select(
-                    (.context // "" | ascii_downcase | test("coderabbit"))
-                  )]
-                  | group_by(.context) | map(max_by(.updated_at))
-                  | map(select(.state == "success"))
-                  | length'
-        )"
-        if [ "${coderabbit_success_status_count:-0}" -gt 0 ]; then
+        # already posted a genuine SUCCESS commit-status context for the current HEAD SHA
+        # (state == "success" AND description is not a rate-limit message — see
+        # coderabbit_success_status_count / issue #1437). This happens during rate-limit
+        # windows on parallel batches: CodeRabbit signals the result via a commit status
+        # rather than an inline review comment. If found, treat the PR as clean and return
+        # immediately without scanning for stale findings. Context name is matched
+        # case-insensitively to guard against future renames.
+        local coderabbit_success_status_result_count
+        coderabbit_success_status_result_count="$(coderabbit_success_status_count "$repo" "$head_sha")"
+        if [ "${coderabbit_success_status_result_count:-0}" -gt 0 ]; then
           # SUCCESS status can appear while older CodeRabbit review threads stay unresolved
           # on the PR. Do not short-circuit to clean until GraphQL thread audit passes.
           # Wait before the audit: CodeRabbit may set SUCCESS while still posting inline

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3923,6 +3923,20 @@ coderabbit_thread_gate_clean() {
 # status is not counted — same dedup pattern used before this fix existed.
 coderabbit_success_status_count() {
   local repo="$1" head_sha="$2"
+  # Validate arguments before the API call: a missing repo or head_sha would
+  # otherwise build an invalid endpoint and fail inside the pipeline with an
+  # unstructured shell error. Print "0" and return 0 (rather than a nonzero
+  # exit) because both call sites assign this function's output directly via
+  # `var="$(coderabbit_success_status_count ...)"` under `set -e` — a nonzero
+  # return there aborts the entire reviewer-loop script immediately instead of
+  # letting the caller's normal "no success status found" path run. Treating
+  # invalid arguments as "no genuine success status found" is the same safe
+  # default the rest of this function already falls back to on API failure.
+  if [ -z "$repo" ] || [ -z "$head_sha" ]; then
+    echo "ERROR: coderabbit_success_status_count requires non-empty repo and head_sha arguments (got repo='${repo:-}' head_sha='${head_sha:-}')" >&2
+    printf '%s\n' 0
+    return 0
+  fi
   gh api "repos/$repo/commits/$head_sha/statuses" --paginate \
     | jq -s '[.[].[] | select(
               (.context // "" | ascii_downcase | test("coderabbit"))

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4146,23 +4146,36 @@ export MOCK_GH_OUTPUT='[{"context":"ci/build","state":"success","description":"r
 actual="$(coderabbit_success_status_count "owner/repo" "abc123")"
 run_test "coderabbit_success_status_count_non_coderabbit_context_ignored" "0" "$actual"
 
-# Argument validation: empty repo or head_sha must not call `gh api` (no
-# MOCK_GH_OUTPUT set — a call would fail loudly) and must safely return "0"
+# Argument validation: empty repo or head_sha must short-circuit before the
+# `gh api` call (asserted via MOCK_GH_CALL_LOG — the mock's default fallback
+# returns "[]"/exit 0 for ANY input, so checking only the return value/exit
+# code would pass even without the guard; the call-log assertion is what
+# actually proves the guard prevents the API call) and must safely return "0"
 # rather than propagating a nonzero exit status, since both call sites assign
 # this function's output via `var="$(coderabbit_success_status_count ...)"`
-# under `set -e euo pipefail`, where a nonzero return would abort the whole
+# under `set -euo pipefail`, where a nonzero return would abort the whole
 # reviewer-loop script instead of falling through to the normal "no success
 # status found" path.
 unset MOCK_GH_OUTPUT
+_call_log="$(mktemp)"
+export MOCK_GH_CALL_LOG="$_call_log"
 actual="$(coderabbit_success_status_count "" "abc123")"
 actual_exit=$?
 run_test "coderabbit_success_status_count_empty_repo_returns_zero" "0" "$actual"
 run_test "coderabbit_success_status_count_empty_repo_exit_zero" "0" "$actual_exit"
+run_test "coderabbit_success_status_count_empty_repo_no_api_call" "" "$(cat "$_call_log")"
+rm -f "$_call_log"
+unset MOCK_GH_CALL_LOG
 
+_call_log="$(mktemp)"
+export MOCK_GH_CALL_LOG="$_call_log"
 actual="$(coderabbit_success_status_count "owner/repo" "")"
 actual_exit=$?
 run_test "coderabbit_success_status_count_empty_head_sha_returns_zero" "0" "$actual"
 run_test "coderabbit_success_status_count_empty_head_sha_exit_zero" "0" "$actual_exit"
+run_test "coderabbit_success_status_count_empty_head_sha_no_api_call" "" "$(cat "$_call_log")"
+rm -f "$_call_log"
+unset MOCK_GH_CALL_LOG
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4070,6 +4070,72 @@ run_test "pr_agent_workflow_exact_review_command" "1" \
   "$(grep_count_or_zero "github.event.comment.body == '/review'" "$REPO_ROOT/.github/workflows/pr-agent.yml")"
 
 # ---------------------------------------------------------------------------
+# Area: coderabbit_success_status_count (issue #1437)
+#
+# Verifies the shared helper used by both coderabbit_status_success_fallback
+# call sites in run_coderabbit_review rejects a `success` commit status whose
+# description indicates the review was rate-limited / did not actually run,
+# while still counting a genuine success status as clean evidence. Uses the
+# same MOCK_GH_OUTPUT single-array pattern as Area 2 (check_unreplied_rest_comments):
+# --paginate | jq -s flattens via .[].[] so a single JSON array is sufficient.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area: coderabbit_success_status_count (issue #1437) ==="
+
+unset MOCK_GH_POST_EXIT MOCK_GH_POST_OUTPUT MOCK_GH_CALL_LOG MOCK_GH_EXIT
+
+# CONTROL: genuine success status with a normal description — must count as 1.
+# This is the "still reports clean for a genuine success description" direction.
+export MOCK_GH_OUTPUT='[{"context":"coderabbit/review","state":"success","description":"Review completed: 0 findings","updated_at":"2026-08-10T00:00:00Z"}]'
+actual="$(coderabbit_success_status_count "owner/repo" "abc123")"
+run_test "coderabbit_success_status_count_genuine_success" "1" "$actual"
+
+# PLANTED VIOLATION: success status whose description is CodeRabbit's confirmed
+# rate-limit banner text — must NOT count (0), proving the false-clean hole from
+# issue #1437 is closed. Before this fix, checking .state alone would have
+# returned 1 here (false clean).
+export MOCK_GH_OUTPUT='[{"context":"coderabbit/review","state":"success","description":"Review limit reached. Next review available in: 43 minutes","updated_at":"2026-08-10T00:00:00Z"}]'
+actual="$(coderabbit_success_status_count "owner/repo" "abc123")"
+run_test "coderabbit_success_status_count_rate_limited_description_rejected" "0" "$actual"
+
+# Rate-limit description with different casing and hyphen separator — regex is
+# the same test("rate.?limit"; "i") pattern already used elsewhere in this script.
+export MOCK_GH_OUTPUT='[{"context":"coderabbit/review","state":"success","description":"RATE-LIMIT: try again later","updated_at":"2026-08-10T00:00:00Z"}]'
+actual="$(coderabbit_success_status_count "owner/repo" "abc123")"
+run_test "coderabbit_success_status_count_rate_limit_hyphen_case_insensitive" "0" "$actual"
+
+# Non-success state is never counted regardless of description.
+export MOCK_GH_OUTPUT='[{"context":"coderabbit/review","state":"pending","description":"Reviewing...","updated_at":"2026-08-10T00:00:00Z"}]'
+actual="$(coderabbit_success_status_count "owner/repo" "abc123")"
+run_test "coderabbit_success_status_count_pending_not_counted" "0" "$actual"
+
+# Missing/null description on a genuine success status must still count (no
+# regression for the common case where CodeRabbit sets no description at all).
+export MOCK_GH_OUTPUT='[{"context":"coderabbit/review","state":"success","updated_at":"2026-08-10T00:00:00Z"}]'
+actual="$(coderabbit_success_status_count "owner/repo" "abc123")"
+run_test "coderabbit_success_status_count_missing_description_still_counts" "1" "$actual"
+
+# Dedup by context: an older genuine success is superseded by a newer
+# rate-limited success on the same context — only the latest (rejected) entry
+# should be considered, so the count must be 0.
+export MOCK_GH_OUTPUT='[{"context":"coderabbit/review","state":"success","description":"Review completed: 0 findings","updated_at":"2026-08-10T00:00:00Z"},{"context":"coderabbit/review","state":"success","description":"Review limit reached. Next review available in: 10 minutes","updated_at":"2026-08-10T00:05:00Z"}]'
+actual="$(coderabbit_success_status_count "owner/repo" "abc123")"
+run_test "coderabbit_success_status_count_dedup_latest_rate_limited" "0" "$actual"
+
+# Dedup by context: an older rate-limited success is superseded by a newer
+# genuine success on the same context — the count must be 1.
+export MOCK_GH_OUTPUT='[{"context":"coderabbit/review","state":"success","description":"Review limit reached. Next review available in: 10 minutes","updated_at":"2026-08-10T00:00:00Z"},{"context":"coderabbit/review","state":"success","description":"Review completed: 0 findings","updated_at":"2026-08-10T00:05:00Z"}]'
+actual="$(coderabbit_success_status_count "owner/repo" "abc123")"
+run_test "coderabbit_success_status_count_dedup_latest_genuine" "1" "$actual"
+
+# Non-coderabbit context is ignored entirely.
+export MOCK_GH_OUTPUT='[{"context":"ci/build","state":"success","description":"rate limit exceeded","updated_at":"2026-08-10T00:00:00Z"}]'
+actual="$(coderabbit_success_status_count "owner/repo" "abc123")"
+run_test "coderabbit_success_status_count_non_coderabbit_context_ignored" "0" "$actual"
+
+unset MOCK_GH_OUTPUT
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4104,6 +4104,19 @@ export MOCK_GH_OUTPUT='[{"context":"coderabbit/review","state":"success","descri
 actual="$(coderabbit_success_status_count "owner/repo" "abc123")"
 run_test "coderabbit_success_status_count_rate_limit_hyphen_case_insensitive" "0" "$actual"
 
+# Each alternative in the "rate.?limit|review limit|next review available"
+# regex must independently reject on its own — tested in isolation so a future
+# accidental removal of one alternative is caught even if the other two still
+# pass. "review limit" alone (no "rate limit" or "next review available" text).
+export MOCK_GH_OUTPUT='[{"context":"coderabbit/review","state":"success","description":"Review limit exceeded for this repository","updated_at":"2026-08-10T00:00:00Z"}]'
+actual="$(coderabbit_success_status_count "owner/repo" "abc123")"
+run_test "coderabbit_success_status_count_review_limit_phrase_alone_rejected" "0" "$actual"
+
+# "next review available" alone (no "rate limit" or "review limit" text).
+export MOCK_GH_OUTPUT='[{"context":"coderabbit/review","state":"success","description":"Please retry — next review available shortly","updated_at":"2026-08-10T00:00:00Z"}]'
+actual="$(coderabbit_success_status_count "owner/repo" "abc123")"
+run_test "coderabbit_success_status_count_next_review_available_phrase_alone_rejected" "0" "$actual"
+
 # Non-success state is never counted regardless of description.
 export MOCK_GH_OUTPUT='[{"context":"coderabbit/review","state":"pending","description":"Reviewing...","updated_at":"2026-08-10T00:00:00Z"}]'
 actual="$(coderabbit_success_status_count "owner/repo" "abc123")"
@@ -4133,7 +4146,23 @@ export MOCK_GH_OUTPUT='[{"context":"ci/build","state":"success","description":"r
 actual="$(coderabbit_success_status_count "owner/repo" "abc123")"
 run_test "coderabbit_success_status_count_non_coderabbit_context_ignored" "0" "$actual"
 
+# Argument validation: empty repo or head_sha must not call `gh api` (no
+# MOCK_GH_OUTPUT set — a call would fail loudly) and must safely return "0"
+# rather than propagating a nonzero exit status, since both call sites assign
+# this function's output via `var="$(coderabbit_success_status_count ...)"`
+# under `set -e euo pipefail`, where a nonzero return would abort the whole
+# reviewer-loop script instead of falling through to the normal "no success
+# status found" path.
 unset MOCK_GH_OUTPUT
+actual="$(coderabbit_success_status_count "" "abc123")"
+actual_exit=$?
+run_test "coderabbit_success_status_count_empty_repo_returns_zero" "0" "$actual"
+run_test "coderabbit_success_status_count_empty_repo_exit_zero" "0" "$actual_exit"
+
+actual="$(coderabbit_success_status_count "owner/repo" "")"
+actual_exit=$?
+run_test "coderabbit_success_status_count_empty_head_sha_returns_zero" "0" "$actual"
+run_test "coderabbit_success_status_count_empty_head_sha_exit_zero" "0" "$actual_exit"
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary

Fixes #1437.

`coderabbit_status_success_fallback` (both call sites in `run_coderabbit_review`
in `scripts/development-workflow/pr-review-loop.sh`) treated any CodeRabbit
commit status with `state == "success"` as evidence the review completed
cleanly, without inspecting the status's `.description` field. CodeRabbit can
set a `success` commit status for branch-protection compatibility while the
description explicitly states the review did not actually run. The confirmed
real-world text (observed on lhpaul/personal-finances PR #33) is:

> Review limit reached ... Next review available in: N minutes

Note this text does **not** contain the substring "rate limit", so a filter
using only the existing `test("rate.?limit"; "i")` comment-marker regex (as
literally proposed in the issue) would have missed the confirmed real banner —
this was caught by the planted-violation test during implementation (see
Verification below) and the regex was broadened accordingly.

The existing mitigation (`coderabbit_thread_gate_clean` + `FALLBACK_THREAD_SETTLE_WAIT`)
does not close this hole: a PR CodeRabbit never reviewed has zero threads, so
the thread audit passes trivially.

## Change

- Extracted a shared `coderabbit_success_status_count(repo, head_sha)` helper
  used by both call sites (early rate-limit-retry check, and `max_wait`
  timeout check). It dedups CodeRabbit-context statuses by context (latest per
  context via `max_by(.updated_at)`, same as before), then requires
  `state == "success"` **and** a description that does not match
  `rate.?limit|review limit|next review available` (case-insensitive).
- Both call sites now delegate to this helper instead of duplicating the jq
  filter inline.

## Verification (planted violation, both directions)

Direct jq proof (also exercised as unit tests, see below):

```
$ echo '[{"context":"coderabbit/review","state":"success","description":"Review limit reached. Next review available in: 43 minutes","updated_at":"..."}]' \
  | jq -s '...same filter as coderabbit_success_status_count...'
0   # planted rate-limited "success" status correctly rejected

$ echo '[{"context":"coderabbit/review","state":"success","description":"Review completed: 0 findings","updated_at":"..."}]' \
  | jq -s '...same filter...'
1   # genuine success status still counts as clean
```

Added 8 unit tests in `scripts/development-workflow/tests/test-pr-review-loop.sh`
(Area: `coderabbit_success_status_count`, issue #1437):
- genuine success counted
- planted rate-limited success rejected (confirmed real banner text)
- rate-limit hyphen/case-insensitivity variant rejected
- non-success state never counted
- missing description still counts (no regression)
- dedup: newer rate-limited status supersedes older genuine success → rejected
- dedup: newer genuine status supersedes older rate-limited status → counted
- non-coderabbit context ignored

`bash scripts/development-workflow/tests/test-pr-review-loop.sh` → 362 passed, 0 failed.
`bash scripts/development-workflow/tests/test-coderabbit-cli-pr-review-loop-dispatch.sh` → 6 passed, 0 failed.

## Protocol deviation

`.ai-dev-workflow.yaml` sets `review.on_draft.runner: [codex]`, unreachable
from a Claude Code subagent per Protocol 91 Step 7a. Applied the documented
remedy: a worktree-local, gitignored, uncommitted `.ai-dev-workflow.local.yaml`
overriding `review.on_draft.runner` to `[claude, codex]` for this run only. It
does not appear in this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved review status handling when automated review services report rate limits or unavailable reviews.
  - Prevented limited or incomplete review results from being incorrectly treated as successful completed reviews.
  - Improved reliability when processing duplicate, pending, or differently formatted status messages.

- **Documentation**
  - Added an unreleased changelog entry describing the review-status handling improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->