### PR TITLE
fix(workflow): reduce CodeRabbit fallback latency in reviewer loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,24 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Reduce CodeRabbit fallback latency in reviewer loop** (#1433):
-  `pr-review-loop.sh`'s silent-non-trigger fallback (the proactive
-  `@coderabbitai review` nudge posted when CodeRabbit does not auto-trigger
-  after a push) previously waited a fixed `CODERABBIT_NO_TRIGGER_TIMEOUT`
-  default of 600 s regardless of `--max-wait`, burning up to 10 minutes of
-  pure idle wait on the common default invocation before nudging CodeRabbit —
-  the exact latency reported in the #1429/#1431 retrospective. The same fixed
-  default also meant the fallback could never fire at all on short-`--max-wait`
-  invocations (e.g. the 180 s spec/\*/implementation-plan/\* doc-branch
-  default), since elapsed could never reach 600 s before the outer `max_wait`
-  timeout exited the loop first. A new `coderabbit_no_trigger_timeout_default`
-  helper now computes the default as 180 s (matching the already-vetted
-  `CODERABBIT_RATE_LIMIT_WAIT` cadence used by the analogous rate-limit retry
-  path), capped at half of `--max-wait` so the fallback always has room to
-  both fire and complete a subsequent poll cycle before the outer timeout, and
-  floored at 30 s. An explicit `CODERABBIT_NO_TRIGGER_TIMEOUT` env var override
-  is still honored as-is (uncapped). This is purely a timing change — it does
-  not alter the `coderabbit_success_status_count` description guard (#1437)
-  that rejects a rate-limited `success` commit status.
+  `pr-review-loop.sh`'s silent-non-trigger fallback previously waited a fixed
+  600 s `CODERABBIT_NO_TRIGGER_TIMEOUT` default regardless of `--max-wait`,
+  burning up to 10 minutes of idle wait before proactively nudging CodeRabbit
+  — the latency reported in the #1429/#1431 retrospective — and could never
+  fire at all on short-`--max-wait` invocations. Replaced with a computed
+  default (`coderabbit_no_trigger_timeout_default`, extracted alongside a new
+  `coderabbit_resolve_no_trigger_timeout` override-resolution helper) that
+  scales with `--max-wait`; a timing change only, it does not affect the
+  `coderabbit_success_status_count` description guard from #1437. See the
+  "CodeRabbit silence patterns" section in
+  [`93-automated-reviewer-loop-protocol.md`](docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md#coderabbit-silence-patterns)
+  for the full effective-timeout table.
 - **CodeRabbit success-status fallback ignored the description field** (#1437):
   Both `coderabbit_status_success_fallback` call sites in `pr-review-loop.sh`
   now reject a `success` CodeRabbit commit status whose description matches a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Reduce CodeRabbit fallback latency in reviewer loop** (#1433):
+  `pr-review-loop.sh`'s silent-non-trigger fallback (the proactive
+  `@coderabbitai review` nudge posted when CodeRabbit does not auto-trigger
+  after a push) previously waited a fixed `CODERABBIT_NO_TRIGGER_TIMEOUT`
+  default of 600 s regardless of `--max-wait`, burning up to 10 minutes of
+  pure idle wait on the common default invocation before nudging CodeRabbit —
+  the exact latency reported in the #1429/#1431 retrospective. The same fixed
+  default also meant the fallback could never fire at all on short-`--max-wait`
+  invocations (e.g. the 180 s spec/\*/implementation-plan/\* doc-branch
+  default), since elapsed could never reach 600 s before the outer `max_wait`
+  timeout exited the loop first. A new `coderabbit_no_trigger_timeout_default`
+  helper now computes the default as 180 s (matching the already-vetted
+  `CODERABBIT_RATE_LIMIT_WAIT` cadence used by the analogous rate-limit retry
+  path), capped at half of `--max-wait` so the fallback always has room to
+  both fire and complete a subsequent poll cycle before the outer timeout, and
+  floored at 30 s. An explicit `CODERABBIT_NO_TRIGGER_TIMEOUT` env var override
+  is still honored as-is (uncapped). This is purely a timing change — it does
+  not alter the `coderabbit_success_status_count` description guard (#1437)
+  that rejects a rate-limited `success` commit status.
 - **CodeRabbit success-status fallback ignored the description field** (#1437):
   Both `coderabbit_status_success_fallback` call sites in `pr-review-loop.sh`
   now reject a `success` CodeRabbit commit status whose description matches a

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -439,16 +439,26 @@ elapses, the loop times out and exits `escalate`.
 no "Reviews paused" comment, and no rate-limit comment. CodeRabbit stays silent with no
 visible signal.
 
-**Script behavior**: After `CODERABBIT_NO_TRIGGER_TIMEOUT` seconds of silence (default: 180 s,
-capped at half of the invocation's `--max-wait` so the fallback always has room to fire
-before the outer timeout — see `coderabbit_no_trigger_timeout_default` in
-`pr-review-loop.sh`; reduced from a fixed 600 s in issue #1433 to cut the idle wait before
-the proactive nudge) with no activity, no "Reviews paused" comment, and no rate-limit
-comment, `pr-review-loop.sh` posts `@coderabbitai review` to force a fresh review. The
-`coderabbit_no_trigger_retriggers` counter is incremented; `CODERABBIT_RATE_LIMIT_MAX_RETRIES`
-is the combined cap for total retrigger attempts across both this mechanism and the
-rate-limit retry path. The elapsed timer resets after posting so the triggered review has a
-full polling window.
+**Script behavior**: After `CODERABBIT_NO_TRIGGER_TIMEOUT` seconds of silence with no
+activity, no "Reviews paused" comment, and no rate-limit comment, `pr-review-loop.sh` posts
+`@coderabbitai review` to force a fresh review. The `coderabbit_no_trigger_retriggers`
+counter is incremented; `CODERABBIT_RATE_LIMIT_MAX_RETRIES` is the combined cap for total
+retrigger attempts across both this mechanism and the rate-limit retry path. The elapsed
+timer resets after posting so the triggered review has a full polling window.
+
+**Default timeout (issue #1433)**: reduced from a fixed 600 s to a computed default via
+`coderabbit_no_trigger_timeout_default` in `pr-review-loop.sh`, following this effective-timeout
+rule based on the invocation's `--max-wait`:
+
+| `--max-wait`          | Effective `CODERABBIT_NO_TRIGGER_TIMEOUT` default                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| >= 360 s (e.g. the 1200 s script default, or the 2400 s large-diff default) | 180 s — the hardcoded default; the half-`max_wait` cap does not bind.                                    |
+| 60 s – 359 s            | `floor(max_wait / 2)` — the cap binds and is always less than `max_wait`, guaranteeing room for a subsequent poll cycle before the outer timeout. |
+| < 60 s (e.g. the 180 s spec/\*/implementation-plan/\* doc-branch default) | `max(30 s, floor(max_wait / 2))` — a 30 s floor takes precedence over the halved cap; for `max_wait` at or below ~30 s this can leave little or no room before the outer timeout, but this repo never configures `--max-wait` below 180 s, so this is a defensive edge case rather than a realistic operating point. |
+
+An explicit `CODERABBIT_NO_TRIGGER_TIMEOUT` env var override is honored as-is (uncapped);
+`coderabbit_resolve_no_trigger_timeout` validates it and falls back to the computed default
+(with a `WARN` message) only when the override is not a positive integer.
 
 **Trigger condition**: Allowed up to `CODERABBIT_RATE_LIMIT_MAX_RETRIES` times total. If
 the cap is reached and CodeRabbit still has not responded, the loop exits `escalate`.
@@ -456,9 +466,9 @@ the cap is reached and CodeRabbit still has not responded, the loop exits `escal
 #### Diagnosing a stalled loop (manual polling)
 
 When an agent is polling manually — or when `pr-review-loop.sh` has been running for more
-than 3 minutes with no CodeRabbit activity on a default-`--max-wait` invocation (scale this
-proportionally for a custom `--max-wait`; see `coderabbit_no_trigger_timeout_default`) —
-check these markers before escalating:
+than the effective `CODERABBIT_NO_TRIGGER_TIMEOUT` window with no CodeRabbit activity (180 s
+on the default 1200 s `--max-wait` invocation; see the effective-timeout table above for
+other `--max-wait` values) — check these markers before escalating:
 
 1. **Check for a "Reviews paused" comment**: run:
 
@@ -475,9 +485,9 @@ check these markers before escalating:
    `max_wait` window before concluding CodeRabbit is unresponsive.
 
 3. **If neither marker is present and the effective `CODERABBIT_NO_TRIGGER_TIMEOUT` window has
-   elapsed with no activity** (default 180 s on a default-`--max-wait` invocation; see
-   `coderabbit_no_trigger_timeout_default`), Pattern 2 (silent non-trigger) is likely. The
-   script will post the retrigger automatically once that window elapses.
+   elapsed with no activity** (see the effective-timeout table above), Pattern 2 (silent
+   non-trigger) is likely. The script will post the retrigger automatically once that window
+   elapses.
 
 #### When to escalate vs. wait
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -439,12 +439,16 @@ elapses, the loop times out and exits `escalate`.
 no "Reviews paused" comment, and no rate-limit comment. CodeRabbit stays silent with no
 visible signal.
 
-**Script behavior**: After `CODERABBIT_NO_TRIGGER_TIMEOUT` seconds of silence (default: 600 s)
-with no activity, no "Reviews paused" comment, and no rate-limit comment, `pr-review-loop.sh`
-posts `@coderabbitai review` to force a fresh review. The `coderabbit_no_trigger_retriggers`
-counter is incremented; `CODERABBIT_RATE_LIMIT_MAX_RETRIES` is the combined cap for total
-retrigger attempts across both this mechanism and the rate-limit retry path. The elapsed
-timer resets after posting so the triggered review has a full polling window.
+**Script behavior**: After `CODERABBIT_NO_TRIGGER_TIMEOUT` seconds of silence (default: 180 s,
+capped at half of the invocation's `--max-wait` so the fallback always has room to fire
+before the outer timeout — see `coderabbit_no_trigger_timeout_default` in
+`pr-review-loop.sh`; reduced from a fixed 600 s in issue #1433 to cut the idle wait before
+the proactive nudge) with no activity, no "Reviews paused" comment, and no rate-limit
+comment, `pr-review-loop.sh` posts `@coderabbitai review` to force a fresh review. The
+`coderabbit_no_trigger_retriggers` counter is incremented; `CODERABBIT_RATE_LIMIT_MAX_RETRIES`
+is the combined cap for total retrigger attempts across both this mechanism and the
+rate-limit retry path. The elapsed timer resets after posting so the triggered review has a
+full polling window.
 
 **Trigger condition**: Allowed up to `CODERABBIT_RATE_LIMIT_MAX_RETRIES` times total. If
 the cap is reached and CodeRabbit still has not responded, the loop exits `escalate`.
@@ -452,7 +456,9 @@ the cap is reached and CodeRabbit still has not responded, the loop exits `escal
 #### Diagnosing a stalled loop (manual polling)
 
 When an agent is polling manually — or when `pr-review-loop.sh` has been running for more
-than 10 minutes with no CodeRabbit activity — check these markers before escalating:
+than 3 minutes with no CodeRabbit activity on a default-`--max-wait` invocation (scale this
+proportionally for a custom `--max-wait`; see `coderabbit_no_trigger_timeout_default`) —
+check these markers before escalating:
 
 1. **Check for a "Reviews paused" comment**: run:
 
@@ -468,9 +474,10 @@ than 10 minutes with no CodeRabbit activity — check these markers before escal
    current HEAD push. If the script already posted the retrigger, wait for the full
    `max_wait` window before concluding CodeRabbit is unresponsive.
 
-3. **If neither marker is present and >10 min have elapsed with no activity**, Pattern 2
-   (silent non-trigger) is likely. The script will post the retrigger automatically once
-   `CODERABBIT_NO_TRIGGER_TIMEOUT` (default: 600 s) elapses.
+3. **If neither marker is present and the effective `CODERABBIT_NO_TRIGGER_TIMEOUT` window has
+   elapsed with no activity** (default 180 s on a default-`--max-wait` invocation; see
+   `coderabbit_no_trigger_timeout_default`), Pattern 2 (silent non-trigger) is likely. The
+   script will post the retrigger automatically once that window elapses.
 
 #### When to escalate vs. wait
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3951,6 +3951,58 @@ coderabbit_success_status_count() {
             | length'
 }
 
+# coderabbit_no_trigger_timeout_default <max_wait>
+#
+# Computes the default silent-non-trigger fallback timeout (issue #1433):
+# how long run_coderabbit_review waits with zero CodeRabbit activity before
+# proactively posting "@coderabbitai review" (see the "Auto-retrigger: detect
+# CodeRabbit silent non-trigger after push" block below).
+#
+# Background: the previous fixed default was 600 s, decoupled from max_wait.
+# Two problems: (1) on the common default invocation (max_wait=1200 s), it
+# burned up to 10 minutes of pure idle wait before nudging CodeRabbit — the
+# exact "waited out CodeRabbit auto-trigger timeouts" latency reported in
+# #1433 from the #1429/#1431 retrospective; (2) on short-max_wait
+# invocations (e.g. the 180 s spec/*  and implementation-plan/* doc-branch
+# default — see the "Branch-type-aware default timeout" section in --help),
+# elapsed could never reach 600 before the outer max_wait timeout exits the
+# loop, so the silent-non-trigger safety net never had a chance to fire at
+# all on those branches.
+#
+# Fix: default to 180 s — the same already-vetted "give CodeRabbit time,
+# then nudge" cadence CODERABBIT_RATE_LIMIT_WAIT already uses elsewhere in
+# this script for the analogous rate-limit retry path — capped at half of
+# max_wait so the fallback always has room to both fire and still complete a
+# subsequent poll cycle before the outer max_wait timeout, no matter how
+# small max_wait is. Floors at 30 s so pathologically small max_wait values
+# still get one nudge attempt rather than an unusably tiny window.
+#
+# This is purely a *timing* change: it does not touch, weaken, or bypass the
+# coderabbit_success_status_count description guard (#1437) that prevents a
+# rate-limited "success" commit status from being treated as a real clean
+# review — that check runs unconditionally on whatever HEAD SHA state exists
+# when it is reached, regardless of how quickly this function got there.
+#
+# Only used to compute the *default* — an explicit CODERABBIT_NO_TRIGGER_TIMEOUT
+# env var override is honored as-is (uncapped) by the caller, matching how
+# other env-var overrides in this script are treated.
+coderabbit_no_trigger_timeout_default() {
+  local max_wait="${1:-0}"
+  local hardcoded_default=180
+  local floor=30
+  local effective="$hardcoded_default"
+  if [[ "$max_wait" =~ ^[0-9]+$ ]] && [ "$max_wait" -gt 0 ]; then
+    local half_max_wait=$((max_wait / 2))
+    if [ "$half_max_wait" -lt "$effective" ]; then
+      effective="$half_max_wait"
+    fi
+  fi
+  if [ "$effective" -lt "$floor" ]; then
+    effective="$floor"
+  fi
+  printf '%s\n' "$effective"
+}
+
 run_coderabbit_review() {
   local pr_number="$1"
   local branch_name="$2"
@@ -4148,7 +4200,10 @@ run_coderabbit_review() {
   local coderabbit_rate_limit_retries=0
   local coderabbit_rate_limit_max_retries="${CODERABBIT_RATE_LIMIT_MAX_RETRIES:-2}"
   local coderabbit_rate_limit_wait="${CODERABBIT_RATE_LIMIT_WAIT:-180}"
-  local coderabbit_no_trigger_timeout="${CODERABBIT_NO_TRIGGER_TIMEOUT:-600}"
+  # See coderabbit_no_trigger_timeout_default (issue #1433) for why the default
+  # is computed from max_wait rather than a fixed constant. An explicit
+  # CODERABBIT_NO_TRIGGER_TIMEOUT env var override is honored as-is, uncapped.
+  local coderabbit_no_trigger_timeout="${CODERABBIT_NO_TRIGGER_TIMEOUT:-$(coderabbit_no_trigger_timeout_default "$max_wait")}"
   local coderabbit_no_trigger_retriggers=0
   if ! [[ "$coderabbit_rate_limit_max_retries" =~ ^[0-9]+$ ]]; then
     echo "WARN: CODERABBIT_RATE_LIMIT_MAX_RETRIES must be a non-negative integer; defaulting to 2" >&2
@@ -4159,8 +4214,10 @@ run_coderabbit_review() {
     coderabbit_rate_limit_wait=180
   fi
   if ! [[ "$coderabbit_no_trigger_timeout" =~ ^[0-9]+$ ]] || [ "$coderabbit_no_trigger_timeout" -le 0 ]; then
-    echo "WARN: CODERABBIT_NO_TRIGGER_TIMEOUT must be a positive integer; defaulting to 600" >&2
-    coderabbit_no_trigger_timeout=600
+    local coderabbit_no_trigger_timeout_fallback
+    coderabbit_no_trigger_timeout_fallback="$(coderabbit_no_trigger_timeout_default "$max_wait")"
+    echo "WARN: CODERABBIT_NO_TRIGGER_TIMEOUT must be a positive integer; defaulting to ${coderabbit_no_trigger_timeout_fallback}" >&2
+    coderabbit_no_trigger_timeout="$coderabbit_no_trigger_timeout_fallback"
   fi
 
   while :; do
@@ -4251,10 +4308,12 @@ run_coderabbit_review() {
     # CodeRabbit sometimes does not auto-trigger after a push commit: no review
     # appears, no "Reviews paused" comment, and no rate-limit comment — CodeRabbit
     # simply stays silent. When no activity has been seen after
-    # CODERABBIT_NO_TRIGGER_TIMEOUT seconds (default 600 s), post
-    # "@coderabbitai review" to force a fresh review. Uses
-    # CODERABBIT_RATE_LIMIT_MAX_RETRIES as the combined retrigger cap so callers
-    # have a single knob for total retrigger attempts across both mechanisms.
+    # CODERABBIT_NO_TRIGGER_TIMEOUT seconds (default: see
+    # coderabbit_no_trigger_timeout_default — 180 s, capped at half of
+    # max_wait; issue #1433), post "@coderabbitai review" to force a fresh
+    # review. Uses CODERABBIT_RATE_LIMIT_MAX_RETRIES as the combined retrigger
+    # cap so callers have a single knob for total retrigger attempts across
+    # both mechanisms.
     if [ "$coderabbit_any_activity" -eq 0 ] \
         && [ "$coderabbit_retrigger_attempted" -eq 0 ] \
         && [ "$coderabbit_no_trigger_retriggers" -lt "$coderabbit_rate_limit_max_retries" ] \

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3992,7 +3992,8 @@ coderabbit_no_trigger_timeout_default() {
   local floor=30
   local effective="$hardcoded_default"
   if [[ "$max_wait" =~ ^[0-9]+$ ]] && [ "$max_wait" -gt 0 ]; then
-    local half_max_wait=$((max_wait / 2))
+    local half_max_wait
+    half_max_wait=$((max_wait / 2))
     if [ "$half_max_wait" -lt "$effective" ]; then
       effective="$half_max_wait"
     fi

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -3971,11 +3971,22 @@ coderabbit_success_status_count() {
 #
 # Fix: default to 180 s — the same already-vetted "give CodeRabbit time,
 # then nudge" cadence CODERABBIT_RATE_LIMIT_WAIT already uses elsewhere in
-# this script for the analogous rate-limit retry path — capped at half of
-# max_wait so the fallback always has room to both fire and still complete a
-# subsequent poll cycle before the outer max_wait timeout, no matter how
-# small max_wait is. Floors at 30 s so pathologically small max_wait values
-# still get one nudge attempt rather than an unusably tiny window.
+# this script for the analogous rate-limit retry path.
+#
+# Effective-timeout rule (piecewise, by max_wait):
+#   - max_wait >= 360 s: effective = 180 s (the hardcoded default; the half-
+#     max_wait cap below does not bind).
+#   - 60 s <= max_wait < 360 s: effective = floor(max_wait / 2) (the cap
+#     binds and is always < max_wait, so a subsequent poll cycle is
+#     guaranteed to have room before the outer max_wait timeout).
+#   - max_wait < 60 s: effective = max(30, floor(max_wait / 2)) — the 30 s
+#     floor takes precedence over the halved cap in this range. For
+#     max_wait <= ~30 s this can leave little or no room before the outer
+#     timeout (the floor exists only so a pathologically small max_wait
+#     still gets one nudge attempt rather than a zero-second window). This
+#     repo never configures --max-wait below 180 s (the doc-branch default;
+#     see PR_REVIEW_LOOP_DOC_MAX_WAIT in --help), so this range is a
+#     defensive edge case, not a realistic operating point.
 #
 # This is purely a *timing* change: it does not touch, weaken, or bypass the
 # coderabbit_success_status_count description guard (#1437) that prevents a
@@ -3991,9 +4002,16 @@ coderabbit_no_trigger_timeout_default() {
   local hardcoded_default=180
   local floor=30
   local effective="$hardcoded_default"
-  if [[ "$max_wait" =~ ^[0-9]+$ ]] && [ "$max_wait" -gt 0 ]; then
+  if [[ "$max_wait" =~ ^[0-9]+$ ]] && [ "$((10#$max_wait))" -gt 0 ]; then
+    # Force base-10 interpretation with the `10#` prefix: a caller-supplied
+    # value with a leading zero (e.g. "080") passes the ^[0-9]+$ digit check
+    # above but is otherwise parsed as octal by bash arithmetic expansion,
+    # and "080" is not a valid octal literal (8 is not an octal digit) —
+    # `$((080 / 2))` errors with "value too great for base" and aborts the
+    # script under `set -euo pipefail`. See the
+    # no_trigger_timeout_default_leading_zero_max_wait_normalized_base10 test.
     local half_max_wait
-    half_max_wait=$((max_wait / 2))
+    half_max_wait=$((10#$max_wait / 2))
     if [ "$half_max_wait" -lt "$effective" ]; then
       effective="$half_max_wait"
     fi
@@ -4002,6 +4020,35 @@ coderabbit_no_trigger_timeout_default() {
     effective="$floor"
   fi
   printf '%s\n' "$effective"
+}
+
+# coderabbit_resolve_no_trigger_timeout <max_wait>
+#
+# Resolves the effective CODERABBIT_NO_TRIGGER_TIMEOUT for a given max_wait:
+# honors an explicit CODERABBIT_NO_TRIGGER_TIMEOUT env var override (uncapped)
+# when it is set and a valid positive integer, printing a WARN to stderr and
+# falling back to coderabbit_no_trigger_timeout_default(<max_wait>) when it is
+# set but invalid, or computing that default directly when it is unset.
+#
+# Extracted as its own function (rather than inlined in run_coderabbit_review)
+# specifically so tests can exercise the production override-resolution path
+# directly — including the env var precedence and validation-failure fallback
+# — without needing to drive run_coderabbit_review's full polling loop.
+coderabbit_resolve_no_trigger_timeout() {
+  local max_wait="$1"
+  local override="${CODERABBIT_NO_TRIGGER_TIMEOUT:-}"
+  if [ -z "$override" ]; then
+    coderabbit_no_trigger_timeout_default "$max_wait"
+    return 0
+  fi
+  if ! [[ "$override" =~ ^[0-9]+$ ]] || [ "$((10#$override))" -le 0 ]; then
+    local fallback
+    fallback="$(coderabbit_no_trigger_timeout_default "$max_wait")"
+    echo "WARN: CODERABBIT_NO_TRIGGER_TIMEOUT must be a positive integer; defaulting to ${fallback}" >&2
+    printf '%s\n' "$fallback"
+    return 0
+  fi
+  printf '%s\n' "$override"
 }
 
 run_coderabbit_review() {
@@ -4201,10 +4248,12 @@ run_coderabbit_review() {
   local coderabbit_rate_limit_retries=0
   local coderabbit_rate_limit_max_retries="${CODERABBIT_RATE_LIMIT_MAX_RETRIES:-2}"
   local coderabbit_rate_limit_wait="${CODERABBIT_RATE_LIMIT_WAIT:-180}"
-  # See coderabbit_no_trigger_timeout_default (issue #1433) for why the default
-  # is computed from max_wait rather than a fixed constant. An explicit
-  # CODERABBIT_NO_TRIGGER_TIMEOUT env var override is honored as-is, uncapped.
-  local coderabbit_no_trigger_timeout="${CODERABBIT_NO_TRIGGER_TIMEOUT:-$(coderabbit_no_trigger_timeout_default "$max_wait")}"
+  # See coderabbit_resolve_no_trigger_timeout / coderabbit_no_trigger_timeout_default
+  # (issue #1433) for why the default is computed from max_wait rather than a
+  # fixed constant, and for env var override / validation-fallback handling
+  # (including the WARN-and-fallback path for an invalid explicit override).
+  local coderabbit_no_trigger_timeout
+  coderabbit_no_trigger_timeout="$(coderabbit_resolve_no_trigger_timeout "$max_wait")"
   local coderabbit_no_trigger_retriggers=0
   if ! [[ "$coderabbit_rate_limit_max_retries" =~ ^[0-9]+$ ]]; then
     echo "WARN: CODERABBIT_RATE_LIMIT_MAX_RETRIES must be a non-negative integer; defaulting to 2" >&2
@@ -4213,12 +4262,6 @@ run_coderabbit_review() {
   if ! [[ "$coderabbit_rate_limit_wait" =~ ^[0-9]+$ ]] || [ "$coderabbit_rate_limit_wait" -le 0 ]; then
     echo "WARN: CODERABBIT_RATE_LIMIT_WAIT must be a positive integer; defaulting to 180" >&2
     coderabbit_rate_limit_wait=180
-  fi
-  if ! [[ "$coderabbit_no_trigger_timeout" =~ ^[0-9]+$ ]] || [ "$coderabbit_no_trigger_timeout" -le 0 ]; then
-    local coderabbit_no_trigger_timeout_fallback
-    coderabbit_no_trigger_timeout_fallback="$(coderabbit_no_trigger_timeout_default "$max_wait")"
-    echo "WARN: CODERABBIT_NO_TRIGGER_TIMEOUT must be a positive integer; defaulting to ${coderabbit_no_trigger_timeout_fallback}" >&2
-    coderabbit_no_trigger_timeout="$coderabbit_no_trigger_timeout_fallback"
   fi
 
   while :; do

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4178,6 +4178,91 @@ rm -f "$_call_log"
 unset MOCK_GH_CALL_LOG
 
 # ---------------------------------------------------------------------------
+# Area: coderabbit_no_trigger_timeout_default (issue #1433)
+#
+# Verifies the computed default for the CodeRabbit silent-non-trigger fallback
+# timeout (scripts/development-workflow/pr-review-loop.sh lines 3989-4004).
+# Prior behavior: a fixed 600 s default, decoupled from --max-wait. Two bugs
+# this fixes: (1) latency — 600 s of pure idle wait before the proactive
+# "@coderabbitai review" nudge on the common default max_wait=1200 invocation;
+# (2) correctness — on short-max_wait invocations (e.g. the 180 s doc-branch
+# default) elapsed could never reach 600 before the outer max_wait exit, so
+# the silent-non-trigger safety net could never fire at all.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area: coderabbit_no_trigger_timeout_default (issue #1433) ==="
+
+# CONTROL / latency fix: the common default invocation (max_wait=1200, the
+# hardcoded default in main()) must now yield 180 — a 420 s (7 min) reduction
+# from the old fixed 600 s default. half_max_wait=600 does not cap the 180 s
+# hardcoded default, so the hardcoded value wins.
+actual="$(coderabbit_no_trigger_timeout_default 1200)"
+run_test "no_trigger_timeout_default_common_max_wait_1200" "180" "$actual"
+
+# PLANTED VIOLATION / correctness fix: doc-branch default max_wait=180. Under
+# the OLD fixed-600 default, elapsed could never reach 600 before the loop's
+# own "elapsed >= max_wait" (180) exit fires first — the silent-non-trigger
+# retrigger block (pr-review-loop.sh ~line 4315,
+# `coderabbit_no_trigger_retriggers < ... && elapsed >= coderabbit_no_trigger_timeout`)
+# would be permanently unreachable on these branches. The half-max_wait cap
+# (line 3996) must produce 90 (half of 180, below the 180 hardcoded default)
+# so the fallback has room to fire with a full max_wait/2 remaining for a
+# subsequent poll cycle. Reverting the cap (deleting lines 3994-3999, leaving
+# only the hardcoded 180 default) makes this assertion fail — 180 is not < 180
+# under `--max-wait 180`, so the retrigger could never fire before timeout;
+# this was manually verified during implementation (see PR description) and
+# is the concrete regression this test guards against.
+actual="$(coderabbit_no_trigger_timeout_default 180)"
+run_test "no_trigger_timeout_default_doc_branch_max_wait_180_capped" "90" "$actual"
+
+# Large-diff invocation (max_wait=2400): half is 1200, well above the 180
+# hardcoded default, so the cap must NOT kick in — the hardcoded default wins.
+actual="$(coderabbit_no_trigger_timeout_default 2400)"
+run_test "no_trigger_timeout_default_large_diff_max_wait_2400_uncapped" "180" "$actual"
+
+# Floor: a pathologically small max_wait (40) yields half_max_wait=20, below
+# the 30 s floor (line 4000-4002) — the floor must win over the smaller capped
+# value so at least one nudge attempt has a usable window.
+actual="$(coderabbit_no_trigger_timeout_default 40)"
+run_test "no_trigger_timeout_default_floor_applies_below_30" "30" "$actual"
+
+# Boundary: max_wait=360 -> half=180, exactly equal to the hardcoded default.
+# The cap only applies when half_max_wait is STRICTLY less than the hardcoded
+# default (line 3996 uses `-lt`), so at the boundary the hardcoded default
+# must still be the result (not fall through to some other branch).
+actual="$(coderabbit_no_trigger_timeout_default 360)"
+run_test "no_trigger_timeout_default_boundary_max_wait_360" "180" "$actual"
+
+# Invalid/empty max_wait must safely fall back to the hardcoded default
+# instead of crashing on arithmetic with a non-numeric value.
+actual="$(coderabbit_no_trigger_timeout_default "")"
+run_test "no_trigger_timeout_default_empty_max_wait_fallback" "180" "$actual"
+
+actual="$(coderabbit_no_trigger_timeout_default "not-a-number")"
+run_test "no_trigger_timeout_default_non_numeric_max_wait_fallback" "180" "$actual"
+
+# Zero max_wait must not attempt a division-relevant cap and must fall back to
+# the hardcoded default (guarded by `-gt 0` on line 3994).
+actual="$(coderabbit_no_trigger_timeout_default 0)"
+run_test "no_trigger_timeout_default_zero_max_wait_fallback" "180" "$actual"
+
+# ---------------------------------------------------------------------------
+# Area: run_coderabbit_review honors an explicit CODERABBIT_NO_TRIGGER_TIMEOUT
+# override uncapped (issue #1433) — the computed default above is only used
+# when the env var is unset.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area: CODERABBIT_NO_TRIGGER_TIMEOUT explicit override (issue #1433) ==="
+
+# An explicit override larger than the computed default for the given
+# max_wait must be honored as-is (uncapped) rather than silently reduced —
+# same pattern already used by CODERABBIT_RATE_LIMIT_WAIT / _MAX_RETRIES.
+export CODERABBIT_NO_TRIGGER_TIMEOUT=900
+actual="${CODERABBIT_NO_TRIGGER_TIMEOUT:-$(coderabbit_no_trigger_timeout_default 180)}"
+run_test "no_trigger_timeout_explicit_override_honored_uncapped" "900" "$actual"
+unset CODERABBIT_NO_TRIGGER_TIMEOUT
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4246,20 +4246,50 @@ run_test "no_trigger_timeout_default_non_numeric_max_wait_fallback" "180" "$actu
 actual="$(coderabbit_no_trigger_timeout_default 0)"
 run_test "no_trigger_timeout_default_zero_max_wait_fallback" "180" "$actual"
 
+# Leading-zero decimal input (CodeRabbit finding on PR #1458): "080" passes
+# the ^[0-9]+$ digit-only regex guard but, without base-10 normalization, bash
+# arithmetic expansion parses a leading-zero literal as octal — and "080" is
+# not a valid octal literal (8 is not an octal digit), so `$((080 / 2))`
+# errors with "value too great for base" and aborts the script under
+# `set -euo pipefail`. The `10#$max_wait` prefix forces base-10 interpretation
+# so this must safely compute 40 (half of 80) instead of erroring.
+actual="$(coderabbit_no_trigger_timeout_default 080)"
+run_test "no_trigger_timeout_default_leading_zero_max_wait_normalized_base10" "40" "$actual"
+
 # ---------------------------------------------------------------------------
-# Area: run_coderabbit_review honors an explicit CODERABBIT_NO_TRIGGER_TIMEOUT
-# override uncapped (issue #1433) — the computed default above is only used
-# when the env var is unset.
+# Area: coderabbit_resolve_no_trigger_timeout (issue #1433, CodeRabbit finding
+# on PR #1458) — exercises the actual production override-resolution path
+# used by run_coderabbit_review, not just the underlying default-computation
+# helper tested above.
 # ---------------------------------------------------------------------------
 echo ""
-echo "=== Area: CODERABBIT_NO_TRIGGER_TIMEOUT explicit override (issue #1433) ==="
+echo "=== Area: coderabbit_resolve_no_trigger_timeout (issue #1433) ==="
+
+# No override set: must fall through to coderabbit_no_trigger_timeout_default.
+unset CODERABBIT_NO_TRIGGER_TIMEOUT
+actual="$(coderabbit_resolve_no_trigger_timeout 180)"
+run_test "no_trigger_resolve_no_override_uses_computed_default" "90" "$actual"
 
 # An explicit override larger than the computed default for the given
 # max_wait must be honored as-is (uncapped) rather than silently reduced —
 # same pattern already used by CODERABBIT_RATE_LIMIT_WAIT / _MAX_RETRIES.
 export CODERABBIT_NO_TRIGGER_TIMEOUT=900
-actual="${CODERABBIT_NO_TRIGGER_TIMEOUT:-$(coderabbit_no_trigger_timeout_default 180)}"
-run_test "no_trigger_timeout_explicit_override_honored_uncapped" "900" "$actual"
+actual="$(coderabbit_resolve_no_trigger_timeout 180)"
+run_test "no_trigger_resolve_explicit_override_honored_uncapped" "900" "$actual"
+unset CODERABBIT_NO_TRIGGER_TIMEOUT
+
+# An invalid explicit override (non-numeric) must fall back to the computed
+# default (with a WARN to stderr, not asserted here) rather than propagating
+# a bad value or crashing the script.
+export CODERABBIT_NO_TRIGGER_TIMEOUT="not-a-number"
+actual="$(coderabbit_resolve_no_trigger_timeout 180 2>/dev/null)"
+run_test "no_trigger_resolve_invalid_override_falls_back_to_default" "90" "$actual"
+unset CODERABBIT_NO_TRIGGER_TIMEOUT
+
+# A zero explicit override (fails the `-le 0` guard) must also fall back.
+export CODERABBIT_NO_TRIGGER_TIMEOUT=0
+actual="$(coderabbit_resolve_no_trigger_timeout 1200 2>/dev/null)"
+run_test "no_trigger_resolve_zero_override_falls_back_to_default" "180" "$actual"
 unset CODERABBIT_NO_TRIGGER_TIMEOUT
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #1433. During the retro for PRs #1429 and #1431, both implementation PRs repeatedly waited out CodeRabbit auto-trigger timeouts before `pr-review-loop.sh` posted an explicit `@coderabbitai review` fallback request, burning substantial wall-clock time.

Root cause: `CODERABBIT_NO_TRIGGER_TIMEOUT` had a fixed default of 600s regardless of `--max-wait`:

- On the common default invocation (`--max-wait 1200`), that's 10 minutes of pure idle wait before the loop proactively nudges CodeRabbit.
- On short-`--max-wait` invocations (e.g. the 180s spec/\*/implementation-plan/\* doc-branch default), elapsed could never reach 600s before the outer `max_wait` timeout exited the loop first — the silent-non-trigger safety net could never fire at all on those branches.

## Change

Added `coderabbit_no_trigger_timeout_default(<max_wait>)`:

- Defaults to 180s — the same already-vetted "give CodeRabbit time, then nudge" cadence `CODERABBIT_RATE_LIMIT_WAIT` already uses for the analogous rate-limit retry path.
- Capped at half of `max_wait` so the fallback always has room to both fire and complete a subsequent poll cycle before the outer timeout, regardless of how small `max_wait` is.
- Floored at 30s so pathologically small `max_wait` values still get one nudge attempt.
- An explicit `CODERABBIT_NO_TRIGGER_TIMEOUT` env var override is still honored as-is (uncapped), matching how other env-var overrides in this script behave.

## Safety property preserved (#1437 interaction)

This is purely a *timing* change to when the fallback nudge is posted. It does **not** touch, weaken, or bypass the `coderabbit_success_status_count` description guard added in #1437, which rejects a `success` commit status whose description indicates a rate limit (preventing a false-clean). That check runs unconditionally on whatever HEAD SHA state exists when it's reached, independent of how quickly this function got there.

## Testing

- 9 new unit tests for `coderabbit_no_trigger_timeout_default` covering: common default (1200→180), doc-branch cap (180→90), large-diff uncapped (2400→180), floor (40→30), boundary (360→180), and invalid/empty/zero `max_wait` fallback.
- 1 new test proving an explicit `CODERABBIT_NO_TRIGGER_TIMEOUT` override is honored uncapped.
- **Planted-violation proof**: temporarily removed the half-`max_wait` cap (`scripts/development-workflow/pr-review-loop.sh:3994-3999`) — the doc-branch and floor tests failed as expected (`no_trigger_timeout_default_doc_branch_max_wait_180_capped` expected 90, got 180; `no_trigger_timeout_default_floor_applies_below_30` expected 30, got 180). Reverted — all 379 tests pass again.
- Full suite: `bash scripts/development-workflow/tests/test-pr-review-loop.sh` → 379 passed, 0 failed.
- `shellcheck --severity=warning` clean on both changed scripts (matches the CI gate).
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop` clean.
- Markdown lints (markdownlint-cli2, heuristic lint, duplicate-header check) clean on `CHANGELOG.md` and touched docs.

## Docs

Updated Protocol 93's CodeRabbit silence-pattern section (Pattern 2 and manual-diagnosis guidance) to reflect the new proportional default instead of the old fixed 600s value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated review handling by calculating silent no-trigger timeouts based on the configured maximum wait time.
  * Added safeguards for very short, invalid, or zero wait values.
  * Preserved explicit timeout overrides without applying automatic limits.

* **Documentation**
  * Updated guidance to reflect dynamic timeout behavior, automatic retries, and shared retry limits.

* **Tests**
  * Added coverage for timeout boundaries, fallback behavior, and explicit override handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->