### PR TITLE
fix(workflow): stop apply-* audit guards from posting incomplete records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `|| error_exit` as defense in depth. `render_epic_ledger`'s guard was
   audited and confirmed already safe in both call contexts (it uses a
   directly-tested `if ! jq -e ...; then error_exit; fi`, not the
-  assign-then-test pattern) and was left unchanged.
+  assign-then-test pattern) and was left unchanged. A deeper instance of the
+  same defect class (found by CodeRabbit on this PR) affected the *optional*
+  `invocation_policy`, `checkpoint_policy`, and `verification` sections of
+  `render_pr_disposition`, which are not covered by the required-field guard:
+  a wrong-typed value crashed jq mid-render inside the `{ ... } | redact_text`
+  body pipe, and because that block runs as a non-last pipeline stage — in
+  its own subshell — execution continued past the crash and the function
+  still returned exit 0 with a silently degraded section. Each of the five
+  risky jq captures in those sections now calls `error_exit` immediately on
+  failure (a deferred flag would not survive the subshell boundary).
 
 ## [0.41.0] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for batch merge metadata, reviewed-head pinning, delegated epic merge
   evidence, reviewer-loop blockers, reviewer bypass authorization, PR-bound
   cleanup, and workflow branch push-lock cleanup.
+- **`run-epic-audit-trail.sh` required-field guard inert in `apply-*` modes**
+  (#1430): `render_pr_disposition` and `render_reviewer_access_bypass` could
+  post an incomplete audit comment and exit 0 when a required field was
+  wrong-typed (e.g. `.item` a string instead of an object). Bash's `set -e`
+  does not abort a function whose commands run inside a context where -e is
+  already ignored — which a nested command substitution is — so the guard's
+  `jq` computation crashed silently, `$missing` read empty, and
+  `apply-pr-disposition` / `apply-reviewer-access-bypass` posted a blank or
+  partial record while reporting success. Every dotted field lookup in both
+  guards is now wrapped in `try ... catch null` so a wrong-typed value is
+  reported as missing (not a jq crash), the guard's own jq exit status is
+  captured explicitly via `||` instead of relying on `-e` propagation, and
+  all three `apply-*` call sites (`apply-pr-disposition`, `apply-epic-ledger`,
+  `apply-reviewer-access-bypass`) now propagate a render failure with
+  `|| error_exit` as defense in depth. `render_epic_ledger`'s guard was
+  audited and confirmed already safe in both call contexts (it uses a
+  directly-tested `if ! jq -e ...; then error_exit; fi`, not the
+  assign-then-test pattern) and was left unchanged.
 
 ## [0.41.0] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its own subshell — execution continued past the crash and the function
   still returned exit 0 with a silently degraded section. Each of the five
   risky jq captures in those sections now calls `error_exit` immediately on
-  failure (a deferred flag would not survive the subshell boundary).
+  failure (a deferred flag would not survive the subshell boundary). Review
+  of that fix found the same defect class also unpatched in the *optional*
+  `protocol_deviations` section (no upstream validator, unlike `.advisories`,
+  which `validate_advisories` already protects before `render_pr_disposition`
+  is ever called); its jq capture now uses the same `error_exit`-at-point-of-
+  failure guard, with matching planted-violation regression tests for both
+  the `apply-*` and direct `render-*` paths.
 
 ## [0.41.0] - 2026-08-02
 

--- a/scripts/development-workflow/run-epic-audit-trail.sh
+++ b/scripts/development-workflow/run-epic-audit-trail.sh
@@ -104,22 +104,38 @@ checkpoint_stage_filter='
 render_pr_disposition() {
   local json="$1"
   local missing
+  local missing_status=0
 
+  # NOTE: this function is called both directly (render-pr-disposition) and
+  # via command substitution, e.g. `body="$(render_pr_disposition ...)"`
+  # (apply-pr-disposition). Bash's `set -e` does not abort a function whose
+  # commands run inside a context where -e is already being ignored (which a
+  # nested command substitution is), so a failing `jq` call below would
+  # otherwise silently produce an empty $missing and let this guard pass
+  # vacuously in apply mode. Each dotted field lookup is wrapped in
+  # `try ... catch null` so a wrong-typed value (e.g. .item being a string)
+  # is reported as missing instead of crashing jq outright, and the exit
+  # status of the jq call itself is captured explicitly via `||` (not
+  # relied upon via -e propagation) so any other jq failure still aborts
+  # loudly in both call contexts. See issue #1430.
   missing="$(printf '%s\n' "$json" | jq -r '
     [
-      ["scope_source", .scope_source],
-      ["item.number", .item.number],
-      ["item.title", .item.title],
-      ["pr.number", .pr.number],
-      ["pr.head_sha", .pr.head_sha],
-      ["reviewer.result", .reviewer.result],
-      ["risk.level", .risk.level],
-      ["merge_authority", .merge_authority],
-      ["final_decision", .final_decision]
+      ["scope_source", (try .scope_source catch null)],
+      ["item.number", (try .item.number catch null)],
+      ["item.title", (try .item.title catch null)],
+      ["pr.number", (try .pr.number catch null)],
+      ["pr.head_sha", (try .pr.head_sha catch null)],
+      ["reviewer.result", (try .reviewer.result catch null)],
+      ["risk.level", (try .risk.level catch null)],
+      ["merge_authority", (try .merge_authority catch null)],
+      ["final_decision", (try .final_decision catch null)]
     ]
     | map(select(.[1] == null or (.[1] | tostring | length == 0)) | .[0])
     | join(", ")
-  ')"
+  ')" || missing_status=$?
+  if [ "$missing_status" -ne 0 ]; then
+    error_exit "failed to evaluate required PR disposition fields (jq exit ${missing_status})"
+  fi
   if [ -n "$missing" ]; then
     error_exit "missing required PR disposition fields: $missing"
   fi
@@ -378,27 +394,37 @@ render_epic_ledger() {
 render_reviewer_access_bypass() {
   local json="$1"
   local missing
+  local missing_status=0
 
+  # See the identical note in render_pr_disposition(): this function is
+  # called directly (render-reviewer-access-bypass) and via command
+  # substitution (apply-reviewer-access-bypass). Every dotted lookup is
+  # wrapped in `try ... catch null` so a wrong-typed value reports as
+  # missing instead of crashing jq, and the jq exit status is captured
+  # explicitly via `||` rather than relied upon via `set -e` propagation.
   missing="$(printf '%s\n' "$json" | jq -r '
     [
-      ["authorization.authorized_by", (.authorization.authorized_by // .authorization.authorizedBy)],
-      ["authorization.authorized_at", (.authorization.authorized_at // .authorization.authorizedAt)],
-      ["authorization.authorization_text", (.authorization.authorization_text // .authorization.authorizationText)],
-      ["pr.number", .pr.number],
-      ["pr.head_sha", (.pr.head_sha // .pr.headSha)],
-      ["evidence_fingerprint", (.evidence_fingerprint // .evidenceFingerprint)],
-      ["ci.result", (.ci.result // .ci_result)],
-      ["reviewer.result", (.reviewer.result // .reviewer.status)],
-      ["blocked_check.name", (.blocked_check.name // .blockedCheck.name)],
-      ["access.evidence", (.access.evidence // .accessRestriction.evidence)],
-      ["access.remediation_status", (.access.remediation_status // .access.remediationStatus)],
-      ["access.bypass_reason", (.access.bypass_reason // .access.bypassReason // .accessRestriction.bypassReason)],
-      ["proposed_action", (.proposed_action // .proposedAction)],
-      ["state", .state]
+      ["authorization.authorized_by", (try (.authorization.authorized_by // .authorization.authorizedBy) catch null)],
+      ["authorization.authorized_at", (try (.authorization.authorized_at // .authorization.authorizedAt) catch null)],
+      ["authorization.authorization_text", (try (.authorization.authorization_text // .authorization.authorizationText) catch null)],
+      ["pr.number", (try .pr.number catch null)],
+      ["pr.head_sha", (try (.pr.head_sha // .pr.headSha) catch null)],
+      ["evidence_fingerprint", (try (.evidence_fingerprint // .evidenceFingerprint) catch null)],
+      ["ci.result", (try (.ci.result // .ci_result) catch null)],
+      ["reviewer.result", (try (.reviewer.result // .reviewer.status) catch null)],
+      ["blocked_check.name", (try (.blocked_check.name // .blockedCheck.name) catch null)],
+      ["access.evidence", (try (.access.evidence // .accessRestriction.evidence) catch null)],
+      ["access.remediation_status", (try (.access.remediation_status // .access.remediationStatus) catch null)],
+      ["access.bypass_reason", (try (.access.bypass_reason // .access.bypassReason // .accessRestriction.bypassReason) catch null)],
+      ["proposed_action", (try (.proposed_action // .proposedAction) catch null)],
+      ["state", (try .state catch null)]
     ]
     | map(select(.[1] == null or (.[1] | tostring | length == 0)) | .[0])
     | join(", ")
-  ')"
+  ')" || missing_status=$?
+  if [ "$missing_status" -ne 0 ]; then
+    error_exit "failed to evaluate required reviewer access-bypass fields (jq exit ${missing_status})"
+  fi
   if [ -n "$missing" ]; then
     error_exit "missing required reviewer access-bypass fields: $missing"
   fi
@@ -536,7 +562,7 @@ case "$command" in
     fi
     validate_advisories "$input_json"
     warn_per_finding_advisories "$input_json"
-    body="$(render_pr_disposition "$input_json")"
+    body="$(render_pr_disposition "$input_json")" || error_exit "failed to render PR disposition (see error above)"
     apply_comment "$pr_number" "$PR_MARKER" "$body"
     ;;
   render-epic-ledger)
@@ -546,7 +572,7 @@ case "$command" in
     if [ -z "$epic_number" ] || ! is_positive_int "$epic_number"; then
       error_exit "--epic must be a positive integer"
     fi
-    body="$(render_epic_ledger "$input_json")"
+    body="$(render_epic_ledger "$input_json")" || error_exit "failed to render epic ledger (see error above)"
     apply_comment "$epic_number" "$EPIC_MARKER" "$body"
     ;;
   render-reviewer-access-bypass)
@@ -557,7 +583,7 @@ case "$command" in
       error_exit "--pr must be a positive integer"
     fi
     validate_reviewer_access_bypass_scope "$input_json" "$pr_number"
-    body="$(render_reviewer_access_bypass "$input_json")"
+    body="$(render_reviewer_access_bypass "$input_json")" || error_exit "failed to render reviewer access-bypass audit (see error above)"
     apply_comment "$pr_number" "$REVIEWER_ACCESS_BYPASS_MARKER" "$body"
     ;;
 esac

--- a/scripts/development-workflow/run-epic-audit-trail.sh
+++ b/scripts/development-workflow/run-epic-audit-trail.sh
@@ -105,6 +105,7 @@ render_pr_disposition() {
   local json="$1"
   local missing
   local missing_status=0
+  local rendered
 
   # NOTE: this function is called both directly (render-pr-disposition) and
   # via command substitution, e.g. `body="$(render_pr_disposition ...)"`
@@ -118,6 +119,24 @@ render_pr_disposition() {
   # status of the jq call itself is captured explicitly via `||` (not
   # relied upon via -e propagation) so any other jq failure still aborts
   # loudly in both call contexts. See issue #1430.
+  #
+  # The same -e-ignored context also means a failing jq call *inside* the
+  # `{ ... } | redact_text` body block below (e.g. a wrong-typed
+  # .invocation_policy, .checkpoint_policy, or .verification) would not
+  # abort execution either — worse, because `{ ... }` is the first stage of
+  # a pipeline, bash runs it in its own subshell (pipelines run every
+  # non-last stage in a subshell unless `shopt -s lastpipe` is active,
+  # which this script does not set), so a shared flag variable set inside
+  # that block cannot be read after the pipe: it would still show its
+  # initial value once the pipe returns, silently masking the failure a
+  # second way. Each of those three optional sections below therefore
+  # calls `error_exit` immediately (via `|| error_exit ...`) the moment
+  # its jq capture fails, instead of deferring to a flag check — `exit` is
+  # not subject to -e semantics at all, so it terminates the `{ ... }`
+  # subshell right there; combined with `pipefail`, that makes the whole
+  # `{ ... } | redact_text` pipeline (and therefore this function, and the
+  # apply-* command substitution around it) report the failure reliably in
+  # both call contexts. See CodeRabbit finding on PR #1459 (issue #1430).
   missing="$(printf '%s\n' "$json" | jq -r '
     [
       ["scope_source", (try .scope_source catch null)],
@@ -161,15 +180,16 @@ render_pr_disposition() {
     if [ "$(printf '%s\n' "$json" | jq 'if (.invocation_policy // null) == null then 0 else 1 end')" -eq 0 ]; then
       printf 'Not recorded.\n'
     else
-      printf '%s\n' "$json" | jq -r '
+      rendered="$(printf '%s\n' "$json" | jq -r '
         (.invocation_policy // {}) as $p |
         "- Original command: `" + (($p.original_command // $p.originalCommand // "") | tostring) + "`",
         "- Copy-paste equivalent: `" + (($p.copy_paste_command // $p.copyPasteCommand // "") | tostring) + "`",
         "- Confirmation: " + (($p.confirmation // $p.confirmationReason // "not recorded") | tostring)
-      '
+      ')" || error_exit "failed to render invocation policy detail (jq error above)"
+      printf '%s\n' "$rendered"
       printf '\n| Field | Recommended | Selected | Effective |\n'
       printf '| --- | --- | --- | --- |\n'
-      printf '%s\n' "$json" | jq -r "$table_cell_filter"'
+      rendered="$(printf '%s\n' "$json" | jq -r "$table_cell_filter"'
         (.invocation_policy // {}) as $p |
         ($p.recommended_policy // $p.recommendedPolicy // {}) as $r |
         ($p.selected_policy // $p.selectedPolicy // {}) as $s |
@@ -179,13 +199,14 @@ render_pr_disposition() {
         " | " + (($r[$field] // "") | cell) +
         " | " + (($s[$field] // "") | cell) +
         " | " + (($e[$field] // "") | cell) + " |"
-      '
+      ')" || error_exit "failed to render invocation policy table (jq error above)"
+      printf '%s\n' "$rendered"
     fi
     printf '\n### Checkpoint Policy\n\n'
     if [ "$(printf '%s\n' "$json" | jq 'if (.checkpoint_policy // .checkpointPolicy // null) == null then 0 else 1 end')" -eq 0 ]; then
       printf 'Not recorded.\n'
     else
-      printf '%s\n' "$json" | jq -r "$checkpoint_stage_filter"'
+      rendered="$(printf '%s\n' "$json" | jq -r "$checkpoint_stage_filter"'
         (.checkpoint_policy // .checkpointPolicy // {}) as $cp |
         (.item.number) as $itemNum |
         (.pr.branch // "") as $branch |
@@ -204,10 +225,11 @@ render_pr_disposition() {
                 end
               )] | length | tostring
         )
-      '
+      ')" || error_exit "failed to render checkpoint policy detail (jq error above)"
+      printf '%s\n' "$rendered"
       printf '\n| Item | Stage | Domain | State | Reason | Required action |\n'
       printf '| --- | --- | --- | --- | --- | --- |\n'
-      printf '%s\n' "$json" | jq -r "$table_cell_filter $checkpoint_stage_filter"'
+      rendered="$(printf '%s\n' "$json" | jq -r "$table_cell_filter $checkpoint_stage_filter"'
         (.checkpoint_policy // .checkpointPolicy // {}) as $cp |
         (.item.number) as $itemNum |
         (.pr.branch // "") as $branch |
@@ -228,7 +250,8 @@ render_pr_disposition() {
         " | " + ((.satisfaction_state // "pending") | cell) +
         " | " + ((.reason // "") | cell) +
         " | " + ((.required_human_action // "") | cell) + " |"
-      '
+      ')" || error_exit "failed to render checkpoint policy table (jq error above)"
+      printf '%s\n' "$rendered"
     fi
     printf '\n### Advisory Decisions\n\n'
     if [ "$(printf '%s\n' "$json" | jq '(.advisories // []) | length')" -eq 0 ]; then
@@ -245,7 +268,7 @@ render_pr_disposition() {
       '
     fi
     printf '\n### Verification Evidence\n\n'
-    printf '%s\n' "$json" | jq -r '
+    rendered="$(printf '%s\n' "$json" | jq -r '
       (.verification // {}) as $v |
       "- Labels: " + (($v.labels // []) | join(", ")),
       "- CI result: " + (($v.ci_result // "unknown") | tostring),
@@ -254,7 +277,8 @@ render_pr_disposition() {
       "- PR merge state: " + (($v.merge_state // "unknown") | tostring),
       "- Issue state: " + (($v.issue_state // "unknown") | tostring),
       "- Project status: " + (($v.project_status // "unknown") | tostring)
-    '
+    ')" || error_exit "failed to render verification evidence (jq error above)"
+    printf '%s\n' "$rendered"
     printf '\n### Protocol Deviations\n\n'
     if [ "$(printf '%s\n' "$json" | jq '(.protocol_deviations // []) | length')" -eq 0 ]; then
       printf 'None.\n'

--- a/scripts/development-workflow/run-epic-audit-trail.sh
+++ b/scripts/development-workflow/run-epic-audit-trail.sh
@@ -122,21 +122,26 @@ render_pr_disposition() {
   #
   # The same -e-ignored context also means a failing jq call *inside* the
   # `{ ... } | redact_text` body block below (e.g. a wrong-typed
-  # .invocation_policy, .checkpoint_policy, or .verification) would not
-  # abort execution either — worse, because `{ ... }` is the first stage of
-  # a pipeline, bash runs it in its own subshell (pipelines run every
-  # non-last stage in a subshell unless `shopt -s lastpipe` is active,
-  # which this script does not set), so a shared flag variable set inside
-  # that block cannot be read after the pipe: it would still show its
-  # initial value once the pipe returns, silently masking the failure a
-  # second way. Each of those three optional sections below therefore
-  # calls `error_exit` immediately (via `|| error_exit ...`) the moment
-  # its jq capture fails, instead of deferring to a flag check — `exit` is
-  # not subject to -e semantics at all, so it terminates the `{ ... }`
-  # subshell right there; combined with `pipefail`, that makes the whole
-  # `{ ... } | redact_text` pipeline (and therefore this function, and the
-  # apply-* command substitution around it) report the failure reliably in
-  # both call contexts. See CodeRabbit finding on PR #1459 (issue #1430).
+  # .invocation_policy, .checkpoint_policy, .verification, or
+  # .protocol_deviations) would not abort execution either — worse, because
+  # `{ ... }` is the first stage of a pipeline, bash runs it in its own
+  # subshell (pipelines run every non-last stage in a subshell unless
+  # `shopt -s lastpipe` is active, which this script does not set), so a
+  # shared flag variable set inside that block cannot be read after the
+  # pipe: it would still show its initial value once the pipe returns,
+  # silently masking the failure a second way. Each of those four optional
+  # sections below therefore calls `error_exit` immediately (via
+  # `|| error_exit ...`) the moment its jq capture fails, instead of
+  # deferring to a flag check — `exit` is not subject to -e semantics at
+  # all, so it terminates the `{ ... }` subshell right there; combined with
+  # `pipefail`, that makes the whole `{ ... } | redact_text` pipeline (and
+  # therefore this function, and the apply-* command substitution around
+  # it) report the failure reliably in both call contexts. (.advisories has
+  # the same defect-class risk but is caught upstream instead, by
+  # `validate_advisories`, which runs before this function is ever called
+  # and crashes loudly on a wrong-typed value or a non-object array element
+  # in a non-subshell context.) See CodeRabbit finding on PR #1459
+  # (issue #1430).
   missing="$(printf '%s\n' "$json" | jq -r '
     [
       ["scope_source", (try .scope_source catch null)],
@@ -280,17 +285,18 @@ render_pr_disposition() {
     ')" || error_exit "failed to render verification evidence (jq error above)"
     printf '%s\n' "$rendered"
     printf '\n### Protocol Deviations\n\n'
-    if [ "$(printf '%s\n' "$json" | jq '(.protocol_deviations // []) | length')" -eq 0 ]; then
+    if [ "$(printf '%s\n' "$json" | jq '(.protocol_deviations // []) | if type == "array" then length else 1 end')" -eq 0 ]; then
       printf 'None.\n'
     else
       printf '| Action | Impact | Mitigation |\n'
       printf '| --- | --- | --- |\n'
-      printf '%s\n' "$json" | jq -r "$table_cell_filter"'
+      rendered="$(printf '%s\n' "$json" | jq -r "$table_cell_filter"'
         (.protocol_deviations // [])[] |
         "| " + ((.action // "") | cell) +
         " | " + ((.impact // "") | cell) +
         " | " + ((.mitigation // "") | cell) + " |"
-      '
+      ')" || error_exit "failed to render protocol deviations (jq error above)"
+      printf '%s\n' "$rendered"
     fi
   } | redact_text
 }

--- a/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+++ b/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
@@ -266,6 +266,22 @@ wrong_typed_item_fixture="$TMP_ROOT/wrong-typed-item.json"
 jq '.item = "a-string"' "$pr_fixture" > "$wrong_typed_item_fixture"
 wrong_typed_ledger_epic_fixture="$TMP_ROOT/wrong-typed-ledger-epic.json"
 jq '.epic = "a-string"' "$ledger_fixture" > "$wrong_typed_ledger_epic_fixture"
+# CodeRabbit finding on PR #1459: a wrong-typed *optional* section
+# (invocation_policy / checkpoint_policy / verification — none of which
+# are part of the required-field guard above) crashed jq mid-render, deep
+# inside the `{ ... } | redact_text` body pipe. That failure could not
+# reach the caller via the top-level `missing` guard at all, and — because
+# the `{ ... }` block runs in its own subshell as a non-last pipeline
+# stage — a shared flag variable set inside it is invisible once the pipe
+# returns, so even a deferred-check fix would silently mask the failure a
+# second way. wrong_typed_invocation_policy_fixture is present (not null)
+# but the wrong JSON type, which is the reproduction shape.
+wrong_typed_invocation_policy_fixture="$TMP_ROOT/wrong-typed-invocation-policy.json"
+jq '.invocation_policy = "a-string"' "$pr_fixture" > "$wrong_typed_invocation_policy_fixture"
+wrong_typed_checkpoint_policy_fixture="$TMP_ROOT/wrong-typed-checkpoint-policy.json"
+jq '.checkpoint_policy = "a-string"' "$pr_fixture" > "$wrong_typed_checkpoint_policy_fixture"
+wrong_typed_verification_fixture="$TMP_ROOT/wrong-typed-verification.json"
+jq '.verification = "a-string"' "$pr_fixture" > "$wrong_typed_verification_fixture"
 
 bypass_fixture="$TMP_ROOT/reviewer-access-bypass.json"
 cat > "$bypass_fixture" <<'JSON'
@@ -505,6 +521,55 @@ run_fails_contains "render_pr_disposition_rejects_wrong_typed_item" \
 run_fails_contains "render_reviewer_access_bypass_rejects_wrong_typed_authorization" \
   "missing required reviewer access-bypass fields: authorization.authorized_by, authorization.authorized_at, authorization.authorization_text" \
   "$HELPER" render-reviewer-access-bypass --input "$wrong_typed_bypass_fixture"
+
+echo ""
+echo "=== Planted-violation regression: wrong-typed optional section must not silently degrade (CodeRabbit finding, #1430) ==="
+# A second, deeper layer of the same defect class (found by CodeRabbit
+# reviewing this PR): invocation_policy, checkpoint_policy, and
+# verification are *optional* fields, not covered by the required-field
+# `missing` guard above. A wrong-typed value for any of them (present, not
+# null/absent) crashed jq mid-render inside the `{ ... } | redact_text`
+# body pipe. In apply mode this was worse than the top-level guard bug:
+# execution continued past the crash to the end of the block (still inside
+# the -e-ignored substitution context), so the function returned exit 0
+# with a body that silently dropped just that one section, and
+# apply-pr-disposition posted it. Each of the five risky jq captures in
+# render_pr_disposition now calls error_exit immediately on failure rather
+# than deferring to a flag (a shared flag set inside `{ ... }` would not
+# survive the pipe: `{ ... } | redact_text` runs the `{ ... }` stage in its
+# own subshell as a non-last pipeline stage).
+
+calls_before="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_fails_contains "apply_pr_disposition_rejects_wrong_typed_invocation_policy" \
+  "failed to render invocation policy detail" \
+  "$HELPER" apply-pr-disposition --input "$wrong_typed_invocation_policy_fixture" --pr 10
+calls_after="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_test "apply_pr_disposition_wrong_typed_invocation_policy_writes_no_comment" "$calls_before" "$calls_after"
+
+calls_before="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_fails_contains "apply_pr_disposition_rejects_wrong_typed_checkpoint_policy" \
+  "failed to render checkpoint policy detail" \
+  "$HELPER" apply-pr-disposition --input "$wrong_typed_checkpoint_policy_fixture" --pr 10
+calls_after="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_test "apply_pr_disposition_wrong_typed_checkpoint_policy_writes_no_comment" "$calls_before" "$calls_after"
+
+calls_before="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_fails_contains "apply_pr_disposition_rejects_wrong_typed_verification" \
+  "failed to render verification evidence" \
+  "$HELPER" apply-pr-disposition --input "$wrong_typed_verification_fixture" --pr 10
+calls_after="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_test "apply_pr_disposition_wrong_typed_verification_writes_no_comment" "$calls_before" "$calls_after"
+
+# Same three cases via the direct render-* path.
+run_fails_contains "render_pr_disposition_rejects_wrong_typed_invocation_policy" \
+  "failed to render invocation policy detail" \
+  "$HELPER" render-pr-disposition --input "$wrong_typed_invocation_policy_fixture"
+run_fails_contains "render_pr_disposition_rejects_wrong_typed_checkpoint_policy" \
+  "failed to render checkpoint policy detail" \
+  "$HELPER" render-pr-disposition --input "$wrong_typed_checkpoint_policy_fixture"
+run_fails_contains "render_pr_disposition_rejects_wrong_typed_verification" \
+  "failed to render verification evidence" \
+  "$HELPER" render-pr-disposition --input "$wrong_typed_verification_fixture"
 
 echo ""
 echo "=== Summary ==="

--- a/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+++ b/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
@@ -282,6 +282,13 @@ wrong_typed_checkpoint_policy_fixture="$TMP_ROOT/wrong-typed-checkpoint-policy.j
 jq '.checkpoint_policy = "a-string"' "$pr_fixture" > "$wrong_typed_checkpoint_policy_fixture"
 wrong_typed_verification_fixture="$TMP_ROOT/wrong-typed-verification.json"
 jq '.verification = "a-string"' "$pr_fixture" > "$wrong_typed_verification_fixture"
+# Same defect class, found during review of this PR's fix: .protocol_deviations
+# is an optional array field with no upstream validator (unlike .advisories,
+# which is protected by validate_advisories before render_pr_disposition is
+# ever called). A wrong-typed value crashed jq mid-render the same way the
+# CodeRabbit-flagged sections did.
+wrong_typed_protocol_deviations_fixture="$TMP_ROOT/wrong-typed-protocol-deviations.json"
+jq '.protocol_deviations = "a-string"' "$pr_fixture" > "$wrong_typed_protocol_deviations_fixture"
 
 bypass_fixture="$TMP_ROOT/reviewer-access-bypass.json"
 cat > "$bypass_fixture" <<'JSON'
@@ -570,6 +577,44 @@ run_fails_contains "render_pr_disposition_rejects_wrong_typed_checkpoint_policy"
 run_fails_contains "render_pr_disposition_rejects_wrong_typed_verification" \
   "failed to render verification evidence" \
   "$HELPER" render-pr-disposition --input "$wrong_typed_verification_fixture"
+
+echo ""
+echo "=== Planted-violation regression: wrong-typed protocol_deviations must not silently degrade (found in review of PR #1459) ==="
+# .protocol_deviations has no upstream validator (unlike .advisories, which
+# validate_advisories protects before render_pr_disposition is ever called),
+# so its jq capture inside the { ... } | redact_text body pipe needed the
+# same point-of-failure error_exit guard applied to invocation_policy,
+# checkpoint_policy, and verification above.
+
+calls_before="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_fails_contains "apply_pr_disposition_rejects_wrong_typed_protocol_deviations" \
+  "failed to render protocol deviations" \
+  "$HELPER" apply-pr-disposition --input "$wrong_typed_protocol_deviations_fixture" --pr 10
+calls_after="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_test "apply_pr_disposition_wrong_typed_protocol_deviations_writes_no_comment" "$calls_before" "$calls_after"
+
+run_fails_contains "render_pr_disposition_rejects_wrong_typed_protocol_deviations" \
+  "failed to render protocol deviations" \
+  "$HELPER" render-pr-disposition --input "$wrong_typed_protocol_deviations_fixture"
+
+# .advisories confirmatory coverage: validate_advisories already crashes
+# loudly on a wrong-typed .advisories value before render_pr_disposition is
+# reached, in both call contexts. This is not a fix in this PR — confirmatory
+# only, kept alongside the protocol_deviations regression above so future
+# changes to validate_advisories don't silently reopen the same defect class.
+wrong_typed_advisories_fixture="$TMP_ROOT/wrong-typed-advisories.json"
+jq '.advisories = "a-string"' "$pr_fixture" > "$wrong_typed_advisories_fixture"
+
+calls_before="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_fails_contains "apply_pr_disposition_rejects_wrong_typed_advisories" \
+  "failed to validate advisory entries" \
+  "$HELPER" apply-pr-disposition --input "$wrong_typed_advisories_fixture" --pr 10
+calls_after="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_test "apply_pr_disposition_wrong_typed_advisories_writes_no_comment" "$calls_before" "$calls_after"
+
+run_fails_contains "render_pr_disposition_rejects_wrong_typed_advisories" \
+  "failed to validate advisory entries" \
+  "$HELPER" render-pr-disposition --input "$wrong_typed_advisories_fixture"
 
 echo ""
 echo "=== Summary ==="

--- a/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+++ b/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
@@ -262,6 +262,11 @@ bad_ledger_fixture="$TMP_ROOT/bad-ledger.json"
 cat > "$bad_ledger_fixture" <<'JSON'
 {"epic": {"number": 916, "title": "Bad"}, "items": "not an array"}
 JSON
+wrong_typed_item_fixture="$TMP_ROOT/wrong-typed-item.json"
+jq '.item = "a-string"' "$pr_fixture" > "$wrong_typed_item_fixture"
+wrong_typed_ledger_epic_fixture="$TMP_ROOT/wrong-typed-ledger-epic.json"
+jq '.epic = "a-string"' "$ledger_fixture" > "$wrong_typed_ledger_epic_fixture"
+
 bypass_fixture="$TMP_ROOT/reviewer-access-bypass.json"
 cat > "$bypass_fixture" <<'JSON'
 {
@@ -302,6 +307,8 @@ cat > "$bypass_fixture" <<'JSON'
 JSON
 bad_bypass_fixture="$TMP_ROOT/bad-bypass.json"
 jq 'del(.authorization.authorized_by)' "$bypass_fixture" > "$bad_bypass_fixture"
+wrong_typed_bypass_fixture="$TMP_ROOT/wrong-typed-bypass.json"
+jq '.authorization = "a-string"' "$bypass_fixture" > "$wrong_typed_bypass_fixture"
 mismatched_bypass_pr_fixture="$TMP_ROOT/mismatched-bypass-pr.json"
 jq '.pr.number = 99' "$bypass_fixture" > "$mismatched_bypass_pr_fixture"
 mismatched_bypass_action_fixture="$TMP_ROOT/mismatched-bypass-action.json"
@@ -449,6 +456,48 @@ run_test "warns_on_bulk_acceptance_rationale" "yes" \
 no_advisory_stderr="$("$HELPER" render-pr-disposition --input "$no_advisory_fixture" 2>&1 >/dev/null)"
 run_test "no_warn_when_advisory_count_zero" "yes" \
   "$(printf '%s' "$no_advisory_stderr" | wc -c | tr -d ' ' | grep -qx '0' && echo yes || echo no)"
+
+echo ""
+echo "=== Planted-violation regression: apply-* required-field guard must not be inert (#1430) ==="
+# Prior to the fix, a wrong-typed field (e.g. .item being a string instead of
+# an object) made the required-field jq computation crash silently inside a
+# command-substituted context (`body="$(render_pr_disposition ...)"`), which
+# `set -e` does not abort. The guard's own [ -n "$missing" ] check then read
+# an empty string (jq produced no stdout) and passed vacuously, so apply-*
+# posted an incomplete audit comment and exited 0. These tests plant that
+# exact violation against all three apply-* subcommands and assert each now
+# fails loudly with no partial gh write, while a complete input still
+# succeeds (already proven above by the creates_*/updates_* tests).
+
+calls_before="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_fails_contains "apply_pr_disposition_rejects_wrong_typed_item" \
+  "missing required PR disposition fields: item.number, item.title" \
+  "$HELPER" apply-pr-disposition --input "$wrong_typed_item_fixture" --pr 10
+calls_after="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_test "apply_pr_disposition_wrong_type_writes_no_comment" "$calls_before" "$calls_after"
+
+calls_before="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_fails_contains "apply_epic_ledger_rejects_wrong_typed_epic" \
+  "missing required epic ledger fields" \
+  "$HELPER" apply-epic-ledger --input "$wrong_typed_ledger_epic_fixture" --epic 900
+calls_after="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_test "apply_epic_ledger_wrong_type_writes_no_comment" "$calls_before" "$calls_after"
+
+calls_before="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_fails_contains "apply_reviewer_access_bypass_rejects_wrong_typed_authorization" \
+  "missing required reviewer access-bypass fields: authorization.authorized_by, authorization.authorized_at, authorization.authorization_text" \
+  "$HELPER" apply-reviewer-access-bypass --input "$wrong_typed_bypass_fixture" --pr 42
+calls_after="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_test "apply_reviewer_access_bypass_wrong_type_writes_no_comment" "$calls_before" "$calls_after"
+
+# Same defect, exercised via the direct render-* path too: a wrong-typed
+# field must be reported precisely as missing rather than crashing jq.
+run_fails_contains "render_pr_disposition_rejects_wrong_typed_item" \
+  "missing required PR disposition fields: item.number, item.title" \
+  "$HELPER" render-pr-disposition --input "$wrong_typed_item_fixture"
+run_fails_contains "render_reviewer_access_bypass_rejects_wrong_typed_authorization" \
+  "missing required reviewer access-bypass fields: authorization.authorized_by, authorization.authorized_at, authorization.authorization_text" \
+  "$HELPER" render-reviewer-access-bypass --input "$wrong_typed_bypass_fixture"
 
 echo ""
 echo "=== Summary ==="

--- a/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+++ b/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
@@ -464,9 +464,16 @@ echo "=== Planted-violation regression: apply-* required-field guard must not be
 # command-substituted context (`body="$(render_pr_disposition ...)"`), which
 # `set -e` does not abort. The guard's own [ -n "$missing" ] check then read
 # an empty string (jq produced no stdout) and passed vacuously, so apply-*
-# posted an incomplete audit comment and exited 0. These tests plant that
-# exact violation against all three apply-* subcommands and assert each now
-# fails loudly with no partial gh write, while a complete input still
+# posted an incomplete audit comment and exited 0. render_pr_disposition() and
+# render_reviewer_access_bypass() had this defect and were fixed with
+# try/catch + explicit jq-exit-status capture (see the comments in
+# run-epic-audit-trail.sh). render_epic_ledger() uses a different guard shape
+# (`jq -e ... ; if ! ...` — the jq exit status is already control-flow-tested,
+# so a crash correctly triggers `error_exit` even before this fix); it was
+# audited and left unchanged, and its wrong_typed_epic case below is a
+# confirmatory coverage test, not a regression case for this PR. These tests
+# plant the violation against all three apply-* subcommands and assert each
+# now fails loudly with no partial gh write, while a complete input still
 # succeeds (already proven above by the creates_*/updates_* tests).
 
 calls_before="$(wc -l < "$CALL_LOG" | tr -d ' ')"


### PR DESCRIPTION
## Summary

Fixes #1430. `render_pr_disposition` and `render_reviewer_access_bypass` in
`scripts/development-workflow/run-epic-audit-trail.sh` had a required-field
guard that could crash silently on a wrong-typed field (e.g. `.item` being a
string) inside a command-substitution context
(`body="$(render_pr_disposition ...)"` in `apply-*` subcommands). Bash's
`set -e` does not abort a function whose commands run inside a context where
`-e` is already ignored — which a nested command substitution is — so the
guard's `jq` computation crashed silently, `$missing` read empty (jq produced
no stdout on the crash), the `[ -n "$missing" ]` guard passed vacuously, and
`apply-pr-disposition` / `apply-reviewer-access-bypass` posted an incomplete
audit comment while exiting 0.

## Changes

- Wrap every dotted field lookup in `render_pr_disposition` and
  `render_reviewer_access_bypass` with `try ... catch null` so a wrong-typed
  value reports as missing instead of crashing jq outright.
- Capture the guard's jq exit status explicitly via `||` instead of relying
  on `set -e` propagation, so any other jq failure also aborts loudly in
  both `render-*` and `apply-*` call contexts.
- Add `|| error_exit` at all three `apply-*` call sites as defense in depth.
- Audited `render_epic_ledger`'s guard: it already uses a directly-tested
  `if ! jq -e ...; then error_exit; fi`, which is immune to this defect in
  both call contexts (verified empirically). Left unchanged.
- Added planted-violation regression tests for all three `apply-*`
  subcommands plus the direct `render-*` path.

## Verification

- All 53 pre-existing tests in `test-run-epic-audit-trail.sh` still pass.
- 8 new planted-violation tests added; all pass against the fixed script.
- Confirmed against the actual pre-fix script (checked out from `HEAD`) that
  6 of the 8 new tests fail exactly as the issue describes:
  `apply_pr_disposition_rejects_wrong_typed_item` (exit 0 instead of
  failing), `apply_pr_disposition_wrong_type_writes_no_comment` (a comment
  WAS posted), `apply_reviewer_access_bypass_rejects_wrong_typed_authorization`,
  `apply_reviewer_access_bypass_wrong_type_writes_no_comment`,
  `render_pr_disposition_rejects_wrong_typed_item` (raw jq exit 5 leaking
  through instead of a clean guard message), and
  `render_reviewer_access_bypass_rejects_wrong_typed_authorization`. The two
  `render_epic_ledger`-targeted tests passed even against the pre-fix code,
  confirming that function was never actually affected.

## Protocol deviation

`.ai-dev-workflow.yaml` sets `review.on_draft.runner: [codex]`, which is
unreachable from this Claude Code subagent per Protocol 91 Step 7a's
reachability table. Applied the documented remedy: a worktree-local,
gitignored, uncommitted `.ai-dev-workflow.local.yaml` overriding
`review.on_draft.runner` to `[claude, codex]` for this run only. It does not
appear in this PR's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit-trail validation for incorrectly typed or missing fields.
  * Added clearer error reporting when data cannot be processed.
  * Prevented malformed audit entries from creating incomplete comments.
  * Ensured rendering failures are detected and reported by all apply actions.

* **Tests**
  * Added regression coverage for malformed pull request, ledger, and reviewer access data.

* **Documentation**
  * Added an unreleased changelog entry describing these improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->