### PR TITLE
fix(workflow): render why_safe_to_merge in PR disposition audit comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   proposed option 2), added `warn_unknown_pr_disposition_keys`, which emits a
   non-fatal `WARN` to stderr for any top-level PR-disposition input key not in
   a maintained allowlist, so a future unconsumed field degrades visibly
-  instead of repeating this exact silent-drop defect.
+  instead of repeating this exact silent-drop defect. Code review found that
+  the initial presence check (`.why_safe_to_merge // null`) used jq's `//`
+  operator, which treats a boolean `false` value the same as an absent field
+  — so a `false`-valued `.why_safe_to_merge` silently rendered as
+  "Not recorded." instead of being rejected as the wrong type, letting apply
+  mode write an audit comment for invalid evidence. Replaced the check with
+  an explicit `== null` presence test plus an explicit `type != "object"`
+  rejection, with a matching planted-violation regression test for the
+  boolean case.
 
 ## [0.41.0] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is ever called); its jq capture now uses the same `error_exit`-at-point-of-
   failure guard, with matching planted-violation regression tests for both
   the `apply-*` and direct `render-*` paths.
+- **`why_safe_to_merge` evidence silently dropped from the PR disposition audit
+  comment** (#1436): `run-epic-risk-classifier.sh` requires a complete
+  `.why_safe_to_merge` block (`scope`, `tests`, `reviewer_outcome`,
+  `ci_outcome`, `rollback_or_cleanup_risk`) before it will assign `medium`
+  risk, but `render_pr_disposition` — the only function that renders the
+  durable audit comment — never referenced `.why_safe_to_merge` anywhere in
+  its jq programs. Because the renderer is jq-based, an unconsumed top-level
+  key like `why_safe_to_merge` was silently dropped instead of raising an
+  error or warning, so a caller could pass the classifier's full output
+  (including a complete `why_safe_to_merge` block) into `apply-pr-disposition`
+  and the merge justification required for the risk decision would never
+  appear in the posted comment. Added a "Why Safe to Merge" section to
+  `render_pr_disposition`, mirroring the "Risk Reasons" section's rendering
+  pattern and using the same `error_exit`-at-point-of-failure guard shape as
+  the other optional sections (`invocation_policy`, `checkpoint_policy`,
+  `verification`, `protocol_deviations`) established by #1430, so a
+  wrong-typed `.why_safe_to_merge` value fails loudly instead of crashing
+  mid-render. As a complementary defense-in-depth measure (this issue's
+  proposed option 2), added `warn_unknown_pr_disposition_keys`, which emits a
+  non-fatal `WARN` to stderr for any top-level PR-disposition input key not in
+  a maintained allowlist, so a future unconsumed field degrades visibly
+  instead of repeating this exact silent-drop defect.
 
 ## [0.41.0] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,15 +102,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   proposed option 2), added `warn_unknown_pr_disposition_keys`, which emits a
   non-fatal `WARN` to stderr for any top-level PR-disposition input key not in
   a maintained allowlist, so a future unconsumed field degrades visibly
-  instead of repeating this exact silent-drop defect. Code review found that
-  the initial presence check (`.why_safe_to_merge // null`) used jq's `//`
-  operator, which treats a boolean `false` value the same as an absent field
-  — so a `false`-valued `.why_safe_to_merge` silently rendered as
-  "Not recorded." instead of being rejected as the wrong type, letting apply
-  mode write an audit comment for invalid evidence. Replaced the check with
-  an explicit `== null` presence test plus an explicit `type != "object"`
-  rejection, with a matching planted-violation regression test for the
-  boolean case.
+  instead of repeating this exact silent-drop defect. A non-object
+  `.why_safe_to_merge` value (including `false`) is rejected as invalid
+  evidence rather than silently rendered as absent.
 
 ## [0.41.0] - 2026-08-02
 

--- a/scripts/development-workflow/run-epic-audit-trail.sh
+++ b/scripts/development-workflow/run-epic-audit-trail.sh
@@ -10,6 +10,17 @@ PR_MARKER="<!-- run-epic:pr-disposition -->"
 EPIC_MARKER="<!-- run-epic:epic-ledger -->"
 REVIEWER_ACCESS_BYPASS_MARKER="<!-- reviewer-access-bypass -->"
 
+# Top-level keys render_pr_disposition() actually consumes. Kept in sync
+# manually with that function's jq programs — see warn_unknown_pr_disposition_keys()
+# below (issue #1436: render_pr_disposition is jq-based, so an unrecognized
+# top-level key like why_safe_to_merge used to be silently dropped from the
+# rendered comment instead of producing any warning).
+PR_DISPOSITION_KNOWN_KEYS='[
+  "scope_source", "item", "pr", "reviewer", "risk", "merge_authority",
+  "final_decision", "advisories", "invocation_policy", "checkpoint_policy",
+  "checkpointPolicy", "verification", "protocol_deviations", "why_safe_to_merge"
+]'
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -122,14 +133,14 @@ render_pr_disposition() {
   #
   # The same -e-ignored context also means a failing jq call *inside* the
   # `{ ... } | redact_text` body block below (e.g. a wrong-typed
-  # .invocation_policy, .checkpoint_policy, .verification, or
-  # .protocol_deviations) would not abort execution either — worse, because
+  # .invocation_policy, .checkpoint_policy, .verification, .why_safe_to_merge,
+  # or .protocol_deviations) would not abort execution either — worse, because
   # `{ ... }` is the first stage of a pipeline, bash runs it in its own
   # subshell (pipelines run every non-last stage in a subshell unless
   # `shopt -s lastpipe` is active, which this script does not set), so a
   # shared flag variable set inside that block cannot be read after the
   # pipe: it would still show its initial value once the pipe returns,
-  # silently masking the failure a second way. Each of those four optional
+  # silently masking the failure a second way. Each of those five optional
   # sections below therefore calls `error_exit` immediately (via
   # `|| error_exit ...`) the moment its jq capture fails, instead of
   # deferring to a flag check — `exit` is not subject to -e semantics at
@@ -181,6 +192,20 @@ render_pr_disposition() {
     '
     printf '\n### Risk Reasons\n\n'
     printf '%s\n' "$json" | jq -r '(.risk.reasons // [])[]? | "- " + (.|tostring)'
+    printf '\n### Why Safe to Merge\n\n'
+    if [ "$(printf '%s\n' "$json" | jq 'if (.why_safe_to_merge // null) == null then 0 else 1 end')" -eq 0 ]; then
+      printf 'Not recorded.\n'
+    else
+      rendered="$(printf '%s\n' "$json" | jq -r '
+        (.why_safe_to_merge // {}) as $w |
+        "- Scope: " + (($w.scope // "") | tostring),
+        "- Tests: " + (($w.tests // "") | tostring),
+        "- Reviewer outcome: " + (($w.reviewer_outcome // "") | tostring),
+        "- CI outcome: " + (($w.ci_outcome // "") | tostring),
+        "- Rollback or cleanup risk: " + (($w.rollback_or_cleanup_risk // "") | tostring)
+      ')" || error_exit "failed to render why-safe-to-merge detail (jq error above)"
+      printf '%s\n' "$rendered"
+    fi
     printf '\n### Invocation Policy\n\n'
     if [ "$(printf '%s\n' "$json" | jq 'if (.invocation_policy // null) == null then 0 else 1 end')" -eq 0 ]; then
       printf 'Not recorded.\n'
@@ -346,6 +371,25 @@ warn_per_finding_advisories() {
       printf 'WARN: %d advisory entry/entries contain generic bulk-acceptance rationale; per-finding rationale is required by protocol\n' \
         "$bulk_rationale" >&2
     fi
+  fi
+}
+
+# Complement to the "Why Safe to Merge" section fix (issue #1436): render_pr_disposition()
+# is jq-based, so passing an unrecognized top-level key (a typo, a renamed
+# field, or evidence a caller believed would be rendered) is silently dropped
+# from the audit comment rather than reported. This warns — non-fatally, so a
+# forward-compatible caller adding a new top-level field is not blocked — the
+# same way warn_per_finding_advisories() warns on protocol-shape issues that
+# don't rise to a hard error.
+warn_unknown_pr_disposition_keys() {
+  local json="$1"
+  local unknown
+  unknown="$(printf '%s\n' "$json" | jq -r --argjson known "$PR_DISPOSITION_KNOWN_KEYS" '
+    (keys - $known) | join(", ")
+  ' 2>/dev/null)" || error_exit "failed to check for unknown PR disposition keys (jq parse error)"
+  if [ -n "$unknown" ]; then
+    printf 'WARN: unrecognized top-level PR disposition field(s) will not appear in the rendered audit comment: %s\n' \
+      "$unknown" >&2
   fi
 }
 
@@ -584,6 +628,7 @@ case "$command" in
   render-pr-disposition)
     validate_advisories "$input_json"
     warn_per_finding_advisories "$input_json"
+    warn_unknown_pr_disposition_keys "$input_json"
     render_pr_disposition "$input_json"
     ;;
   apply-pr-disposition)
@@ -592,6 +637,7 @@ case "$command" in
     fi
     validate_advisories "$input_json"
     warn_per_finding_advisories "$input_json"
+    warn_unknown_pr_disposition_keys "$input_json"
     body="$(render_pr_disposition "$input_json")" || error_exit "failed to render PR disposition (see error above)"
     apply_comment "$pr_number" "$PR_MARKER" "$body"
     ;;

--- a/scripts/development-workflow/run-epic-audit-trail.sh
+++ b/scripts/development-workflow/run-epic-audit-trail.sh
@@ -193,16 +193,20 @@ render_pr_disposition() {
     printf '\n### Risk Reasons\n\n'
     printf '%s\n' "$json" | jq -r '(.risk.reasons // [])[]? | "- " + (.|tostring)'
     printf '\n### Why Safe to Merge\n\n'
-    if [ "$(printf '%s\n' "$json" | jq 'if (.why_safe_to_merge // null) == null then 0 else 1 end')" -eq 0 ]; then
+    if [ "$(printf '%s\n' "$json" | jq 'if .why_safe_to_merge == null then 0 else 1 end')" -eq 0 ]; then
       printf 'Not recorded.\n'
     else
       rendered="$(printf '%s\n' "$json" | jq -r '
-        (.why_safe_to_merge // {}) as $w |
-        "- Scope: " + (($w.scope // "") | tostring),
-        "- Tests: " + (($w.tests // "") | tostring),
-        "- Reviewer outcome: " + (($w.reviewer_outcome // "") | tostring),
-        "- CI outcome: " + (($w.ci_outcome // "") | tostring),
-        "- Rollback or cleanup risk: " + (($w.rollback_or_cleanup_risk // "") | tostring)
+        if (.why_safe_to_merge | type) != "object" then
+          error("why_safe_to_merge must be an object")
+        else
+          .why_safe_to_merge as $w |
+          "- Scope: " + (($w.scope // "") | tostring),
+          "- Tests: " + (($w.tests // "") | tostring),
+          "- Reviewer outcome: " + (($w.reviewer_outcome // "") | tostring),
+          "- CI outcome: " + (($w.ci_outcome // "") | tostring),
+          "- Rollback or cleanup risk: " + (($w.rollback_or_cleanup_risk // "") | tostring)
+        end
       ')" || error_exit "failed to render why-safe-to-merge detail (jq error above)"
       printf '%s\n' "$rendered"
     fi

--- a/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+++ b/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
@@ -307,6 +307,14 @@ missing_why_safe_to_merge_fixture="$TMP_ROOT/missing-why-safe-to-merge.json"
 jq 'del(.why_safe_to_merge)' "$pr_fixture" > "$missing_why_safe_to_merge_fixture"
 wrong_typed_why_safe_to_merge_fixture="$TMP_ROOT/wrong-typed-why-safe-to-merge.json"
 jq '.why_safe_to_merge = "a-string"' "$pr_fixture" > "$wrong_typed_why_safe_to_merge_fixture"
+# CodeRabbit finding on this PR: jq's `//` operator treats `false` as falsy,
+# so `.why_safe_to_merge // null` previously evaluated a boolean `false` value
+# the same as an absent field — silently falling back to "Not recorded."
+# instead of rejecting the wrong type, letting apply mode write an audit
+# comment for invalid evidence. boolean_why_safe_to_merge_fixture exercises
+# that specific falsy-boolean edge case.
+boolean_why_safe_to_merge_fixture="$TMP_ROOT/boolean-why-safe-to-merge.json"
+jq '.why_safe_to_merge = false' "$pr_fixture" > "$boolean_why_safe_to_merge_fixture"
 # Same issue's complementary ask: a strict-unknown-keys warning so a future
 # unconsumed top-level key degrades loudly (a warning, not silent data loss)
 # instead of repeating this exact defect.
@@ -687,6 +695,23 @@ run_test "apply_pr_disposition_wrong_typed_why_safe_to_merge_writes_no_comment" 
 run_fails_contains "render_pr_disposition_rejects_wrong_typed_why_safe_to_merge" \
   "failed to render why-safe-to-merge detail" \
   "$HELPER" render-pr-disposition --input "$wrong_typed_why_safe_to_merge_fixture"
+
+# CodeRabbit finding on this PR: `false // null` evaluates to `null` in jq, so
+# a boolean `false` value for .why_safe_to_merge was previously treated as
+# absent (falling back to "Not recorded.") instead of being rejected as the
+# wrong type — letting apply mode write an audit comment for invalid
+# evidence. The fix replaced the `//`-based presence check with an explicit
+# `== null` check plus an explicit `type != "object"` rejection.
+calls_before="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_fails_contains "apply_pr_disposition_rejects_boolean_why_safe_to_merge" \
+  "failed to render why-safe-to-merge detail" \
+  "$HELPER" apply-pr-disposition --input "$boolean_why_safe_to_merge_fixture" --pr 10
+calls_after="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_test "apply_pr_disposition_boolean_why_safe_to_merge_writes_no_comment" "$calls_before" "$calls_after"
+
+run_fails_contains "render_pr_disposition_rejects_boolean_why_safe_to_merge" \
+  "failed to render why-safe-to-merge detail" \
+  "$HELPER" render-pr-disposition --input "$boolean_why_safe_to_merge_fixture"
 
 echo ""
 echo "=== Summary ==="

--- a/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+++ b/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
@@ -461,6 +461,19 @@ run_fails_contains "comment_list_failure_errors" "failed to read comments" env M
 run_fails_contains "comment_post_failure_errors" "post failed" env MOCK_COMMENT_MODE=post-fail "$HELPER" apply-pr-disposition --input "$pr_fixture" --pr 10
 run_fails_contains "comment_patch_failure_errors" "patch failed" env MOCK_COMMENT_MODE=patch-fail "$HELPER" apply-pr-disposition --input "$pr_fixture" --pr 10
 
+# CodeRabbit finding on this PR: the unknown-key warning was only exercised
+# via render-pr-disposition above. Confirm the apply-pr-disposition path
+# warns identically (non-fatal) and still writes the comment — the contract
+# is "warn, don't block", so a caller must not lose the audit write over an
+# unrecognized field.
+unknown_key_apply_output="$("$HELPER" apply-pr-disposition --input "$unknown_key_fixture" --pr 10 2>&1)"
+run_test "apply_pr_disposition_warns_on_unknown_key_and_still_writes_comment" "yes" "$(
+  grep -q 'unrecognized top-level PR disposition field(s)' <<< "$unknown_key_apply_output" &&
+    grep -q 'mystery_field' <<< "$unknown_key_apply_output" &&
+    grep -q 'CREATED_COMMENT=1' <<< "$unknown_key_apply_output" &&
+    echo yes || echo no
+)"
+
 ledger_create_output="$("$HELPER" apply-epic-ledger --input "$ledger_fixture" --epic 900)"
 run_test "creates_epic_ledger_when_missing" "CREATED_COMMENT=1" "$ledger_create_output"
 

--- a/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+++ b/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
@@ -151,6 +151,13 @@ cat > "$pr_fixture" <<'JSON'
   "risk": {"level": "medium", "reasons": ["workflow script change"]},
   "merge_authority": "--max-risk medium delegated by user",
   "final_decision": "merge_approved",
+  "why_safe_to_merge": {
+    "scope": "audit trail rendering only, no schema migration",
+    "tests": "unit tests in test-run-epic-audit-trail.sh, all green",
+    "reviewer_outcome": "clean, 0 blocking",
+    "ci_outcome": "green on abc123",
+    "rollback_or_cleanup_risk": "low - additive rendering change only"
+  },
   "invocation_policy": {
     "original_command": "$run-epic issues 920 /tmp/fake-placeholder/local",
     "copy_paste_command": "$run-epic --items 920 --delegate-review --may-merge --may-start-backlog true --max-risk medium --base develop-delegated-epic-orchestration",
@@ -222,8 +229,7 @@ cat > "$pr_fixture" <<'JSON'
         "satisfied_by": "human-reviewer"
       }
     ]
-  },
-  "notes": "token ghp_FAKE_PLACEHOLDER /tmp/fake-placeholder/local"
+  }
 }
 JSON
 
@@ -289,6 +295,23 @@ jq '.verification = "a-string"' "$pr_fixture" > "$wrong_typed_verification_fixtu
 # CodeRabbit-flagged sections did.
 wrong_typed_protocol_deviations_fixture="$TMP_ROOT/wrong-typed-protocol-deviations.json"
 jq '.protocol_deviations = "a-string"' "$pr_fixture" > "$wrong_typed_protocol_deviations_fixture"
+# Issue #1436: .why_safe_to_merge is required by run-epic-risk-classifier.sh's
+# why_safe_complete() for medium-risk PRs but, before this fix, was never
+# rendered by render_pr_disposition() — a jq-based renderer silently drops
+# unconsumed top-level keys instead of warning. missing_why_safe_to_merge_fixture
+# and wrong_typed_why_safe_to_merge_fixture exercise both failure directions of
+# the fix: the "Not recorded." fallback when absent, and the same
+# error_exit-on-jq-failure guard shape used by the other optional sections
+# above when the value is present but the wrong JSON type.
+missing_why_safe_to_merge_fixture="$TMP_ROOT/missing-why-safe-to-merge.json"
+jq 'del(.why_safe_to_merge)' "$pr_fixture" > "$missing_why_safe_to_merge_fixture"
+wrong_typed_why_safe_to_merge_fixture="$TMP_ROOT/wrong-typed-why-safe-to-merge.json"
+jq '.why_safe_to_merge = "a-string"' "$pr_fixture" > "$wrong_typed_why_safe_to_merge_fixture"
+# Same issue's complementary ask: a strict-unknown-keys warning so a future
+# unconsumed top-level key degrades loudly (a warning, not silent data loss)
+# instead of repeating this exact defect.
+unknown_key_fixture="$TMP_ROOT/unknown-key.json"
+jq '.mystery_field = "surprise"' "$pr_fixture" > "$unknown_key_fixture"
 
 bypass_fixture="$TMP_ROOT/reviewer-access-bypass.json"
 cat > "$bypass_fixture" <<'JSON'
@@ -365,6 +388,18 @@ run_test "renders_pr_marker" "yes" "$(grep -q '<!-- run-epic:pr-disposition -->'
 run_test "renders_reviewed_sha" "yes" "$(grep -q 'abc123' <<< "$pr_output" && echo yes || echo no)"
 run_test "renders_advisory_decision" "yes" "$(grep -q 'accepted' <<< "$pr_output" && echo yes || echo no)"
 run_test "renders_protocol_deviation" "yes" "$(grep -q 'documented<br>rationale' <<< "$pr_output" && echo yes || echo no)"
+# Issue #1436: assert on the actual rendered content of every why_safe_to_merge
+# field, not just section presence — a header with no field content would
+# still be silent data loss for the evidence a medium-risk merge relies on.
+run_test "renders_why_safe_to_merge_section" "yes" "$(
+  grep -q '### Why Safe to Merge' <<< "$pr_output" &&
+    grep -Fq -- '- Scope: audit trail rendering only, no schema migration' <<< "$pr_output" &&
+    grep -Fq -- '- Tests: unit tests in test-run-epic-audit-trail.sh, all green' <<< "$pr_output" &&
+    grep -Fq -- '- Reviewer outcome: clean, 0 blocking' <<< "$pr_output" &&
+    grep -Fq -- '- CI outcome: green on abc123' <<< "$pr_output" &&
+    grep -Fq -- '- Rollback or cleanup risk: low - additive rendering change only' <<< "$pr_output" &&
+    echo yes || echo no
+)"
 run_test "renders_invocation_policy" "yes" "$(grep -q '### Invocation Policy' <<< "$pr_output" && grep -q 'accepted recommended policy' <<< "$pr_output" && echo yes || echo no)"
 run_test "renders_policy_table" "yes" "$(grep -q '| mayStartBacklog | true | true | true |' <<< "$pr_output" && grep -q '| maxRisk | medium | medium | medium |' <<< "$pr_output" && echo yes || echo no)"
 run_test "renders_checkpoint_policy" "yes" "$(grep -q '### Checkpoint Policy' <<< "$pr_output" && grep -q 'approve data model' <<< "$pr_output" && echo yes || echo no)"
@@ -383,6 +418,18 @@ run_test "redacts_sensitive_values" "yes" "$(! grep -Eq 'ghp_FAKE_PLACEHOLDER|Au
 
 legacy_policy_output="$("$HELPER" render-pr-disposition --input "$legacy_policy_fixture")"
 run_test "legacy_pr_disposition_policy_optional" "yes" "$(grep -q 'Not recorded' <<< "$legacy_policy_output" && echo yes || echo no)"
+
+missing_why_output="$("$HELPER" render-pr-disposition --input "$missing_why_safe_to_merge_fixture")"
+run_test "why_safe_to_merge_optional_when_absent" "yes" "$(
+  awk '/### Why Safe to Merge/,/### Invocation Policy/' <<< "$missing_why_output" | grep -q 'Not recorded.' && echo yes || echo no
+)"
+
+unknown_key_stderr="$("$HELPER" render-pr-disposition --input "$unknown_key_fixture" 2>&1 >/dev/null)"
+run_test "warns_on_unrecognized_top_level_key" "yes" "$(
+  grep -q 'unrecognized top-level PR disposition field(s)' <<< "$unknown_key_stderr" &&
+    grep -q 'mystery_field' <<< "$unknown_key_stderr" &&
+    echo yes || echo no
+)"
 
 ledger_output="$("$HELPER" render-epic-ledger --input "$ledger_fixture")"
 run_test "renders_ledger_marker" "yes" "$(grep -q '<!-- run-epic:epic-ledger -->' <<< "$ledger_output" && echo yes || echo no)"
@@ -615,6 +662,31 @@ run_test "apply_pr_disposition_wrong_typed_advisories_writes_no_comment" "$calls
 run_fails_contains "render_pr_disposition_rejects_wrong_typed_advisories" \
   "failed to validate advisory entries" \
   "$HELPER" render-pr-disposition --input "$wrong_typed_advisories_fixture"
+
+echo ""
+echo "=== Planted-violation regression: why_safe_to_merge must render and must not silently degrade (issue #1436) ==="
+# Before this fix, render_pr_disposition() never referenced .why_safe_to_merge
+# anywhere in its jq programs, so the medium-risk merge evidence
+# run-epic-risk-classifier.sh's why_safe_complete() requires was silently
+# dropped from the durable audit comment with no error or warning. The
+# rendering assertion above (renders_why_safe_to_merge_section) proves the
+# positive direction with a complete block. This section proves the negative
+# direction: a wrong-typed .why_safe_to_merge value (present, not
+# null/absent) is caught by the same error_exit-on-jq-failure guard shape
+# used for invocation_policy/checkpoint_policy/verification/protocol_deviations
+# above, rather than crashing mid-render and silently posting a partial
+# comment.
+
+calls_before="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_fails_contains "apply_pr_disposition_rejects_wrong_typed_why_safe_to_merge" \
+  "failed to render why-safe-to-merge detail" \
+  "$HELPER" apply-pr-disposition --input "$wrong_typed_why_safe_to_merge_fixture" --pr 10
+calls_after="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_test "apply_pr_disposition_wrong_typed_why_safe_to_merge_writes_no_comment" "$calls_before" "$calls_after"
+
+run_fails_contains "render_pr_disposition_rejects_wrong_typed_why_safe_to_merge" \
+  "failed to render why-safe-to-merge detail" \
+  "$HELPER" render-pr-disposition --input "$wrong_typed_why_safe_to_merge_fixture"
 
 echo ""
 echo "=== Summary ==="


### PR DESCRIPTION
## Summary

Closes #1436.

`run-epic-risk-classifier.sh` requires a complete `.why_safe_to_merge` block
(`scope`, `tests`, `reviewer_outcome`, `ci_outcome`, `rollback_or_cleanup_risk`)
before it will assign `medium` risk (`why_safe_complete()`), but
`render_pr_disposition` — the only function that renders the durable PR
disposition audit comment — never referenced `.why_safe_to_merge` anywhere in
its jq programs. Because the renderer is jq-based, an unconsumed top-level key
is silently dropped instead of raising an error or warning, so a caller could
pass the classifier's full output (including a complete `why_safe_to_merge`
block) into `apply-pr-disposition` and the merge justification the risk
decision depends on would never appear in the posted comment.

There is a pleasing irony worth naming directly: this batch run has had to
post the `WHY_SAFE_TO_MERGE` block as a separate PR comment on every
medium-risk PR so far, precisely because of the defect this PR fixes.

## Approach

The issue proposed two options. I implemented **option 1** (add a rendered
section) as the primary fix, since the classifier already treats this
evidence as required for medium-risk PRs — it should be visible in the audit
trail that records the merge decision. I also added a lightweight version of
**option 2** (unknown-key warning) as a complement, not a substitute, per the
issue's own framing:

1. **"Why Safe to Merge" section** added to `render_pr_disposition`,
   positioned right after "Risk Reasons" (before "Invocation Policy"),
   mirroring that section's simple bullet-list rendering pattern. It follows
   the "Not recorded." optional-section shape used by `Invocation Policy` /
   `Checkpoint Policy` when absent, and reuses the exact
   `error_exit`-at-point-of-failure jq-capture guard shape established by
   #1430 for the other optional sections (`invocation_policy`,
   `checkpoint_policy`, `verification`, `protocol_deviations`) — a wrong-typed
   `.why_safe_to_merge` value now fails loudly instead of crashing mid-render
   inside the `{ ... } | redact_text` body pipe.
2. **`warn_unknown_pr_disposition_keys`**: a new non-fatal warning, wired into
   both `render-pr-disposition` and `apply-pr-disposition`, that lists any
   top-level PR-disposition input key not in a maintained allowlist. This is
   defense-in-depth against the *next* unconsumed field silently disappearing
   the same way `why_safe_to_merge` did — a forward-compatible caller adding a
   genuinely new field still isn't blocked, but the drop is now visible on
   stderr instead of silent.

## Verification (planted violation, both directions)

- **Positive direction** — `renders_why_safe_to_merge_section`
  (`scripts/development-workflow/tests/test-run-epic-audit-trail.sh:394-401`):
  asserts the actual rendered content of all five `why_safe_to_merge` fields
  (not just header presence) against a fixture that mirrors a real medium-risk
  PR's evidence.
- **Negative direction — absence**: `why_safe_to_merge_optional_when_absent`
  (`test-run-epic-audit-trail.sh:424-427`) confirms the section falls back to
  `Not recorded.` when the field is absent, scoped to the section (not a
  false-positive match elsewhere in the comment).
- **Negative direction — wrong type**: new "Planted-violation regression:
  why_safe_to_merge must render and must not silently degrade (issue #1436)"
  block (`test-run-epic-audit-trail.sh:667-689`) proves a wrong-typed
  `.why_safe_to_merge` (present, not null — a string instead of an object)
  is rejected with `failed to render why-safe-to-merge detail` via both the
  direct `render-pr-disposition` path and the `apply-pr-disposition` path,
  and asserts **zero** additional `gh` calls were made in the `apply-*` case
  (no partial/silent comment write) — same evidence shape as the existing
  #1430 regression tests for the other optional sections.
- **Unknown-key warning**: `warns_on_unrecognized_top_level_key`
  (`test-run-epic-audit-trail.sh:429-434`) plants an unrecognized
  `mystery_field` top-level key and asserts the exact WARN text and field
  name appear on stderr.
- Manually reproduced all four cases outside the mocked harness (mocked `gh`
  on `PATH` first, per the `gh`-mocking discipline established after the
  #1430 runner's stray-comment incident) before writing them as fixtures:
  complete block renders correctly, absent block falls back to "Not
  recorded.", wrong-typed block fails loudly with no `gh` call, unknown key
  warns without failing.
- `bash scripts/development-workflow/tests/test-run-epic-risk-classifier.sh`
  → 77/77 passing (unaffected — confirms the classifier's `why_safe_to_merge`
  schema, which this PR's renderer now mirrors, is unchanged).

## Follow-up fix: boolean `why_safe_to_merge` value (Pass 2 code review)

CodeRabbit's Pass 2 review of this PR found that the initial presence check
(`.why_safe_to_merge // null`) used jq's `//` operator, which treats a
boolean `false` value the same as an absent field. A `why_safe_to_merge:
false` input therefore silently rendered "Not recorded." instead of being
rejected as the wrong type, letting apply mode write an audit comment for
invalid evidence — the same silent-degradation defect class this PR set out
to close.

Fixed by replacing the `//`-based presence check with an explicit `== null`
test, and by making the render branch explicitly reject any non-object value
via jq's `type != "object"` guard instead of relying on indexing to fail.
Added a planted-violation regression test for the boolean case (render and
apply paths, plus the no-additional-`gh`-call assertion), and updated the
existing CHANGELOG entry for #1436 per the fixes-to-unreleased-work
convention (commit `4f56ccb`).

- Full suite after this fix:
  `bash scripts/development-workflow/tests/test-run-epic-audit-trail.sh`
  → 85/85 passing (up from 68 before this PR's additions; 82/82 after the
  initial `why_safe_to_merge` fix, then 85/85 after the boolean-value fix).
- `shellcheck -x scripts/development-workflow/run-epic-audit-trail.sh
  scripts/development-workflow/tests/test-run-epic-audit-trail.sh` → only
  the two pre-existing info-level findings (SC2016, SC2269), confirmed
  present on `develop` before this change; no new findings.

## Incidental cleanup

Removed an unused top-level `.notes` field from the PR-disposition test
fixture — it was never consumed by `render_pr_disposition` (unlike
`.items[].notes` in the epic-ledger fixture, which is real) and, after this
PR's new unknown-key warning, was correctly flagged as an unrecognized field,
which broke an unrelated pre-existing assertion (`no_warn_when_advisory_count_zero`)
that expects zero stderr for a clean, fully-consumed input.

## Protocol deviation

Step 7a: `.ai-dev-workflow.yaml` configures `review.on_draft.runner: [codex]`,
which is not reliably reachable from a Claude Code subagent runner per
Protocol 91's documented reachability table. Applied the documented remedy: a
worktree-local, gitignored `.ai-dev-workflow.local.yaml` overriding
`review.on_draft.runner` to `[claude, codex]` for this run only. It does not
appear in this PR's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Audit comments now display available “Why Safe to Merge” evidence.
  - Unrecognized top-level disposition fields generate non-blocking warnings instead of being silently ignored.

- **Bug Fixes**
  - Added strict validation and fallback handling for missing or malformed safe-to-merge evidence, including boolean values.
  - Invalid evidence no longer results in audit comments being posted.

- **Documentation**
  - Added an Unreleased changelog entry describing these audit improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
