### PR TITLE
fix(workflow): run-epic-delegated-gate.sh errors on incomplete input instead of degrading to worst-case human_required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   evaluation. Other optional `.pr`/`.reviewer`/`.risk`/`.policy` fields keep
   their existing per-field worst-case defaulting, which is intentional and
   covered by pre-existing tests (e.g. `missing_risk_gate_requires_human`).
+  Both new validations are type-strict, not just presence checks (CodeRabbit
+  review on this PR): `.pr.number` must be a positive integer (a string like
+  `"42"`, `0`, a negative number, or a non-integer all fail identity
+  validation the same as a missing value), `.pr.headRefName`/`.pr.baseRefName`
+  must be non-blank strings (a coerced-via-`tostring` number/array/object no
+  longer passes), and a present `.pr.inScope` must be a literal boolean —
+  `null`, a string, a number, or an object now errors explicitly instead of
+  being coerced by jq's `//` truthiness into an incorrect scope decision.
   Updated `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md`
   and `docs/workflow/development-workflow/guardrails-enforcement.md` (Gate 5)
   to document the new `not_applicable` decision and the omit-`pr.inScope`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of repeating this exact silent-drop defect. A non-object
   `.why_safe_to_merge` value (including `false`) is rejected as invalid
   evidence rather than silently rendered as absent.
+- **`run-epic-delegated-gate.sh` degraded to worst-case `human_required` on
+  incomplete input instead of erroring** (#1435): an evidence file whose `.pr`
+  object was never populated (e.g. `.pr.number: null`, empty
+  `.pr.headRefName`/`.pr.baseRefName`) previously fell through to every
+  per-field worst-case default at once — reproduced against real evidence as
+  an 8-reason `human_required` verdict, at least 5 of the reasons factually
+  false for the PR at evaluation time. The gate now validates `.pr.number`,
+  `.pr.headRefName`, and `.pr.baseRefName` — the three identity fields every
+  live `gh pr view` read always populates — before evaluating any reason, and
+  refuses with a clear `ERROR:` naming the missing field(s) instead of
+  defaulting each one independently. Separately, `.pr.inScope` — meaningful
+  only for a resolved `/run-epic` scope — now short-circuits to a distinct
+  `not_applicable` decision with a single reason when explicitly `false`
+  (previously buried among unrelated defaulted reasons under
+  `human_required`), and is skipped entirely (no reason added) when the key is
+  absent, so `/run-items`/`/run-item` Gate 5 callers with no resolved epic
+  scope no longer need to hand-assemble `pr.inScope: true` to get a usable
+  evaluation. Other optional `.pr`/`.reviewer`/`.risk`/`.policy` fields keep
+  their existing per-field worst-case defaulting, which is intentional and
+  covered by pre-existing tests (e.g. `missing_risk_gate_requires_human`).
+  Updated `docs/workflow/development-workflow/protocols/95-run-epic-protocol.md`
+  and `docs/workflow/development-workflow/guardrails-enforcement.md` (Gate 5)
+  to document the new `not_applicable` decision and the omit-`pr.inScope`
+  guidance for non-run-epic callers.
 
 ## [0.41.0] - 2026-08-02
 

--- a/docs/workflow/development-workflow/guardrails-enforcement.md
+++ b/docs/workflow/development-workflow/guardrails-enforcement.md
@@ -175,6 +175,15 @@ and run the existing helpers:
 ./scripts/development-workflow/run-epic-delegated-gate.sh --input <evidence-file>
 ```
 
+The evidence file's `pr.inScope` field is meaningful only when the runner has
+a resolved `/run-epic` scope to check the candidate PR against. Protocol 90 and
+91 callers assembling evidence for a `/run-items` or `/run-item` PR that has no
+resolved epic scope should **omit** `pr.inScope` entirely — the gate skips the
+scope check when the field is absent rather than defaulting to out-of-scope.
+Only set `pr.inScope: false` when scope resolution genuinely excluded the
+candidate PR; the gate then short-circuits with `decision: "not_applicable"`
+instead of piling the mismatch in among unrelated reasons.
+
 Merge through the repository-approved merge path **only when all of the
 following are satisfied**:
 

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -653,13 +653,10 @@ same audit record with the result. If the gate reports `fix_required`, remove
 readiness labels, fix, rerun validation/reviewer/CI, and return to Step 8. If it
 reports `human_required`, stop for human authority, setup, access remediation,
 or risk tolerance. If it reports `blocked`, stop until required state is
-available. If it reports `not_applicable` (the evidence file's `pr.inScope`
-field is present and `false`), treat the candidate PR as `out_of_scope` per
-this step's closing note — it is never merged by this protocol. When the
-evidence omits `pr.inScope` entirely (for example, evidence assembled outside
-a resolved `/run-epic` scope), the gate skips the scope check rather than
-defaulting to `not_applicable` or `human_required`; it does not signal that a
-PR belongs to this epic's scope by itself.
+available. If it reports `not_applicable`, treat the candidate PR as
+`out_of_scope` per this step's closing note — it is never merged by this
+protocol. See [`guardrails-enforcement.md`](../guardrails-enforcement.md) Gate 5
+for the `pr.inScope` field contract this decision is derived from.
 
 If an in-scope child PR stops at readiness during a merge-granted run without a
 named blocker from this step, report `policy_inconsistent` in the PR

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -653,7 +653,13 @@ same audit record with the result. If the gate reports `fix_required`, remove
 readiness labels, fix, rerun validation/reviewer/CI, and return to Step 8. If it
 reports `human_required`, stop for human authority, setup, access remediation,
 or risk tolerance. If it reports `blocked`, stop until required state is
-available.
+available. If it reports `not_applicable` (the evidence file's `pr.inScope`
+field is present and `false`), treat the candidate PR as `out_of_scope` per
+this step's closing note — it is never merged by this protocol. When the
+evidence omits `pr.inScope` entirely (for example, evidence assembled outside
+a resolved `/run-epic` scope), the gate skips the scope check rather than
+defaulting to `not_applicable` or `human_required`; it does not signal that a
+PR belongs to this epic's scope by itself.
 
 If an in-scope child PR stops at readiness during a merge-granted run without a
 named blocker from this step, report `policy_inconsistent` in the PR

--- a/scripts/development-workflow/run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/run-epic-delegated-gate.sh
@@ -360,18 +360,38 @@ state_json="$(workflow_merge_ci_policy_into_json "$state_json" "$effective_root"
 # for).
 pr_identity_gaps="$(printf '%s\n' "$state_json" | jq -r '
   def trim_text($value): ($value // "" | tostring | gsub("^\\s+|\\s+$"; ""));
+  def valid_positive_int($value):
+    if ($value | type) != "number" then false
+    else ($value == ($value | floor)) and ($value > 0)
+    end;
+  def valid_nonblank_string($value):
+    if ($value | type) != "string" then false
+    else (trim_text($value) | length) > 0
+    end;
   (if (.pr | type) != "object" then ["pr"]
    else
      [
-       (if (.pr.number == null) then "pr.number" else empty end),
-       (if (trim_text(.pr.headRefName) | length) == 0 then "pr.headRefName" else empty end),
-       (if (trim_text(.pr.baseRefName) | length) == 0 then "pr.baseRefName" else empty end)
+       (if (valid_positive_int(.pr.number) | not) then "pr.number" else empty end),
+       (if (valid_nonblank_string(.pr.headRefName) | not) then "pr.headRefName" else empty end),
+       (if (valid_nonblank_string(.pr.baseRefName) | not) then "pr.baseRefName" else empty end)
      ]
    end) | join(", ")
 ' 2>/dev/null)" || error_exit "failed to validate evidence .pr object (jq parse error)"
 
 if [ -n "$pr_identity_gaps" ]; then
-  error_exit "evidence file's .pr object is missing required identity field(s): ${pr_identity_gaps}. A missing PR identity field cannot be distinguished from a genuine blocker, so this gate refuses to evaluate reasons against incomplete input instead of defaulting every unpopulated field to its worst-case interpretation. Populate .pr.number, .pr.headRefName, and .pr.baseRefName from a live PR read before calling this gate."
+  error_exit "evidence file's .pr object is missing required identity field(s): ${pr_identity_gaps}. A missing or malformed PR identity field (pr.number must be a positive integer; pr.headRefName/pr.baseRefName must be non-blank strings) cannot be distinguished from a genuine blocker, so this gate refuses to evaluate reasons against incomplete input instead of defaulting every unpopulated field to its worst-case interpretation. Populate .pr.number, .pr.headRefName, and .pr.baseRefName from a live PR read before calling this gate."
+fi
+
+# .pr.inScope is optional (see the scope short-circuit below), but when
+# present it must be a literal boolean. A non-boolean value (null, a string
+# such as "false", a number, or an object) is caller-side evidence-assembly
+# noise, not a real scope determination -- silently coercing it via jq's `//`
+# truthiness would (depending on the value) either wrongly skip the scope
+# check or wrongly trigger the not_applicable short-circuit for a PR whose
+# scope was never actually resolved to false.
+if printf '%s\n' "$state_json" | jq -e '(.pr | type) == "object" and (.pr | has("inScope")) and ((.pr.inScope | type) != "boolean")' >/dev/null 2>&1; then
+  pr_scope_type="$(printf '%s\n' "$state_json" | jq -r '.pr.inScope | type' 2>/dev/null)"
+  error_exit "evidence file's .pr.inScope field is present but not a boolean (got type: ${pr_scope_type:-unknown}). Omit .pr.inScope entirely when there is no resolved /run-epic scope to check the candidate PR against, or set it to the literal boolean true or false."
 fi
 
 material_evidence_json="$(printf '%s\n' "$state_json" | jq -cS '
@@ -653,10 +673,14 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     and (($reasons | length) > 0)
     and ($reasons | all(. == "PR merge state is not CLEAN"));
   def scope_field_present: (.pr | type) == "object" and (.pr | has("inScope"));
-  def scope_value_true: (.pr.inScope // false) == true;
+  # A literal boolean check, not truthiness: the bash preflight above already
+  # rejects a present non-boolean .pr.inScope before this jq program runs, but
+  # this definition stays independently correct (no `// false` defaulting) so
+  # it cannot mis-decide even if that upstream guard is ever bypassed.
+  def scope_value_false: (.pr.inScope | type) == "boolean" and (.pr.inScope == false);
 
   . as $state |
-  if (scope_field_present and (scope_value_true | not)) then
+  if (scope_field_present and scope_value_false) then
   {
     decision: "not_applicable",
     mergePermitted: false,

--- a/scripts/development-workflow/run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/run-epic-delegated-gate.sh
@@ -346,6 +346,34 @@ fi
 effective_root="${repo_root:-$(workflow_repo_root)}"
 state_json="$(workflow_merge_ci_policy_into_json "$state_json" "$effective_root" "$product_repo")"
 
+# Refuse to evaluate reasons against an incompletely populated .pr object. A
+# caller-side evidence-assembly failure that leaves .pr.number/.headRefName/
+# .baseRefName unpopulated is indistinguishable, field-by-field, from a real
+# blocker once the reasons cascade below applies its per-field worst-case
+# defaults — that conflation is what produces a misleading pile of false
+# blockers instead of a clear, actionable error. These three fields are the
+# minimal PR identity every live `gh pr view` read always populates, so their
+# absence is a reliable, low-false-positive signal of missing/failed evidence
+# assembly rather than a legitimate "field intentionally omitted" case (unlike
+# optional fields such as labels, mergeStateStatus, or auditDispositionPresent,
+# which existing callers legitimately omit and expect worst-case defaulting
+# for).
+pr_identity_gaps="$(printf '%s\n' "$state_json" | jq -r '
+  def trim_text($value): ($value // "" | tostring | gsub("^\\s+|\\s+$"; ""));
+  (if (.pr | type) != "object" then ["pr"]
+   else
+     [
+       (if (.pr.number == null) then "pr.number" else empty end),
+       (if (trim_text(.pr.headRefName) | length) == 0 then "pr.headRefName" else empty end),
+       (if (trim_text(.pr.baseRefName) | length) == 0 then "pr.baseRefName" else empty end)
+     ]
+   end) | join(", ")
+' 2>/dev/null)" || error_exit "failed to validate evidence .pr object (jq parse error)"
+
+if [ -n "$pr_identity_gaps" ]; then
+  error_exit "evidence file's .pr object is missing required identity field(s): ${pr_identity_gaps}. A missing PR identity field cannot be distinguished from a genuine blocker, so this gate refuses to evaluate reasons against incomplete input instead of defaulting every unpopulated field to its worst-case interpretation. Populate .pr.number, .pr.headRefName, and .pr.baseRefName from a live PR read before calling this gate."
+fi
+
 material_evidence_json="$(printf '%s\n' "$state_json" | jq -cS '
   def reviewer_checks:
     if ((.reviewerChecks // null) | type) == "array" then .reviewerChecks
@@ -624,8 +652,36 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     and pr_mergeable_ok
     and (($reasons | length) > 0)
     and ($reasons | all(. == "PR merge state is not CLEAN"));
+  def scope_field_present: (.pr | type) == "object" and (.pr | has("inScope"));
+  def scope_value_true: (.pr.inScope // false) == true;
 
   . as $state |
+  if (scope_field_present and (scope_value_true | not)) then
+  {
+    decision: "not_applicable",
+    mergePermitted: false,
+    exceptionalAdminMergePermitted: false,
+    reasons: ["candidate PR is not in the resolved run-epic scope"],
+    reviewerAccess: {
+      classification: "not_applicable",
+      pullRequest: (.pr.number // null),
+      headSha: pr_head_sha,
+      evidenceFingerprint: (.computedEvidenceFingerprint // ""),
+      blockedReviewerChecks: [],
+      primaryAction: "not applicable",
+      proposedAction: ""
+    },
+    nextAction: "not applicable: candidate PR is not in the resolved run-epic scope; no action is required from this gate for this PR",
+    pr: {
+      number: (.pr.number // null),
+      headRefName: (.pr.headRefName // ""),
+      baseRefName: (.pr.baseRefName // "")
+    },
+    policy: policy,
+    readOnlyGuarantee: "No reviewer-loop runs, CI polling, label edits, tracker updates, comments, merges, issue closure, or branch deletion were performed."
+  }
+  else
+  (
   [] as $reasons |
   (invalid_checkpoint_states) as $invalidCheckpointStates |
   (if ($invalidCheckpointStates | length) > 0
@@ -642,9 +698,6 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
    else $reasons end) as $reasons |
   (if (.item.status // "") == "Backlog" and ((policy.mayStartBacklog // false) != true)
    then add_reason($reasons; "Backlog item cannot start without explicit may-start-backlog authority")
-   else $reasons end) as $reasons |
-  (if (.pr.inScope // false) != true
-   then add_reason($reasons; "candidate PR is not in the resolved run-epic scope")
    else $reasons end) as $reasons |
   (if (if (.pr | has("isDraft")) then .pr.isDraft else true end) == true
    then add_reason($reasons; "PR is still draft")
@@ -713,7 +766,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
       elif ($reviewerAccessClassification | IN("access_restricted", "authorization_required", "authorization_stale", "audit_required")) then "human_required"
       elif $count == 0 then "merge_allowed"
       elif ($reasons | any(test("reviewer blocking|CI checks|unresolved blocking|advisories"))) then "fix_required"
-      elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog|human_checkpoint_required|human-checkpoint|graduation_approval_required"))) then "human_required"
+      elif ($reasons | any(test("authority|risk gate|needs-setup|Backlog|human_checkpoint_required|human-checkpoint|graduation_approval_required"))) then "human_required"
       else "blocked"
       end
     ),
@@ -728,7 +781,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
       elif ($reasons | any(test("reviewer blocking|CI checks|unresolved blocking|advisories"))) then "remove readiness labels, fix, rerun validation, reviewer loop, CI loop, and this gate"
       elif ($reasons | any(test("human_checkpoint_required|human-checkpoint"))) then "stop for the named human checkpoint action, record satisfied or waived evidence, sync labels, and rerun this gate"
       elif ($reasons | any(test("graduation_approval_required"))) then "stop for explicit graduation approval via /graduate-development before mutating"
-      elif ($reasons | any(test("authority|risk gate|needs-setup|not in the resolved|Backlog"))) then "stop for human authority or setup before mutating"
+      elif ($reasons | any(test("authority|risk gate|needs-setup|Backlog"))) then "stop for human authority or setup before mutating"
       else "block until required state is available"
       end
     ),
@@ -740,6 +793,8 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     policy: policy,
     readOnlyGuarantee: "No reviewer-loop runs, CI polling, label edits, tracker updates, comments, merges, issue closure, or branch deletion were performed."
   }
+  )
+  end
 ' 2>/dev/null)" || error_exit "failed to evaluate delegated gate decision (jq parse error)"
 
 if [ -z "$decision_json" ]; then

--- a/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
@@ -198,6 +198,39 @@ run_fails_contains "rejects_empty_fixture" "input file is empty" "$GATE" --input
 run_fails_contains "rejects_malformed_fixture" "input file is not valid JSON" "$GATE" --input "$malformed_file"
 run_fails_contains "rejects_whitespace_fixture" "input file is not valid JSON" "$GATE" --input "$whitespace_file"
 
+# --- incomplete .pr identity input must error, not degrade to a worst-case
+# --- decision full of false blockers (issue #1435) ---
+
+missing_pr_object_fixture="$(write_fixture missing-pr-object 'del(.pr)')"
+run_fails_contains "rejects_missing_pr_object" \
+  "evidence file's .pr object is missing required identity field(s): pr" \
+  "$GATE" --input "$missing_pr_object_fixture" --json
+
+# Exact reproduction of the reported evidence shape from issue #1435: the
+# evidence-assembly step ran but never populated .pr.number/.headRefName/
+# .baseRefName.
+unpopulated_pr_fixture="$(write_fixture unpopulated-pr \
+  '.pr.number = null | .pr.headRefName = "" | .pr.baseRefName = ""')"
+run_fails_contains "rejects_unpopulated_pr_identity" \
+  "evidence file's .pr object is missing required identity field(s): pr.number, pr.headRefName, pr.baseRefName" \
+  "$GATE" --input "$unpopulated_pr_fixture" --json
+run_test "unpopulated_pr_identity_no_worst_case_reasons" "no" "$(
+  set +e
+  output="$("$GATE" --input "$unpopulated_pr_fixture" --json 2>&1)"
+  set -e
+  grep -q '"decision": "human_required"' <<< "$output" && echo yes || echo no
+)"
+
+partial_pr_identity_fixture="$(write_fixture partial-pr-identity 'del(.pr.baseRefName)')"
+run_fails_contains "rejects_partial_pr_identity" \
+  "evidence file's .pr object is missing required identity field(s): pr.baseRefName" \
+  "$GATE" --input "$partial_pr_identity_fixture" --json
+
+# Genuinely complete input (full .pr identity, as every fixture below
+# supplies) with a real blocker must still report it — see
+# "requires_human_review_label" -> blocked below, which proves the
+# validation step does not swallow real findings.
+
 no_ci_fixture="$(write_fixture no-ci '.statusChecks = [] | .ciPolicy = "none"')"
 run_test "ci_policy_none_allows_empty_checks" "merge_allowed" "$(decision_for "$no_ci_fixture")"
 
@@ -254,7 +287,21 @@ backlog_denied_fixture="$(write_fixture backlog-denied '.item.status = "Backlog"
 run_test "backlog_policy_denied_requires_human" "human_required" "$(decision_for "$backlog_denied_fixture")"
 
 out_of_scope_fixture="$(write_fixture out-of-scope '.pr.inScope = false')"
-run_test "candidate_not_in_scope_requires_human" "human_required" "$(decision_for "$out_of_scope_fixture")"
+run_test "candidate_not_in_scope_is_not_applicable" "not_applicable" "$(decision_for "$out_of_scope_fixture")"
+run_test "candidate_not_in_scope_has_single_scope_reason" "1:candidate PR is not in the resolved run-epic scope" "$(
+  "$GATE" --input "$out_of_scope_fixture" --json |
+    jq -r '(.reasons | length | tostring) + ":" + .reasons[0]'
+)"
+run_test "candidate_not_in_scope_merge_not_permitted" "false" "$("$GATE" --input "$out_of_scope_fixture" --json | jq -r '.mergePermitted')"
+run_test "candidate_not_in_scope_reviewer_access_not_applicable" "not_applicable" "$("$GATE" --input "$out_of_scope_fixture" --json | jq -r '.reviewerAccess.classification')"
+
+# When the caller never populates .pr.inScope at all (e.g. a Protocol 90
+# explicit-batch item run through the shared Gate 5 path, which has no
+# resolved run-epic scope to be in or out of), the scope check must be
+# skipped entirely rather than defaulting to "out of scope" and blocking.
+scope_absent_fixture="$(write_fixture scope-absent 'del(.pr.inScope)')"
+run_test "missing_scope_field_does_not_block" "merge_allowed" "$(decision_for "$scope_absent_fixture")"
+run_test "missing_scope_field_reason_absent" "false" "$(reason_match_for "$scope_absent_fixture" "not in the resolved")"
 
 draft_fixture="$(write_fixture draft '.pr.isDraft = true')"
 run_test "draft_blocks" "blocked" "$(decision_for "$draft_fixture")"

--- a/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
@@ -226,6 +226,14 @@ run_fails_contains "rejects_partial_pr_identity" \
   "evidence file's .pr object is missing required identity field(s): pr.baseRefName" \
   "$GATE" --input "$partial_pr_identity_fixture" --json
 
+# Whitespace-only identity strings are not a legitimate value -- trim_text()
+# must treat them the same as empty.
+whitespace_pr_identity_fixture="$(write_fixture whitespace-pr-identity \
+  '.pr.headRefName = "   " | .pr.baseRefName = "\t\n"')"
+run_fails_contains "rejects_whitespace_only_pr_identity" \
+  "evidence file's .pr object is missing required identity field(s): pr.headRefName, pr.baseRefName" \
+  "$GATE" --input "$whitespace_pr_identity_fixture" --json
+
 # Genuinely complete input (full .pr identity, as every fixture below
 # supplies) with a real blocker must still report it — see
 # "requires_human_review_label" -> blocked below, which proves the

--- a/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
@@ -234,6 +234,68 @@ run_fails_contains "rejects_whitespace_only_pr_identity" \
   "evidence file's .pr object is missing required identity field(s): pr.headRefName, pr.baseRefName" \
   "$GATE" --input "$whitespace_pr_identity_fixture" --json
 
+# Non-scalar / wrong-typed identity values must fail the same way as absent
+# ones -- a coerced-via-tostring value (e.g. a number for headRefName) must
+# not be accepted as a valid string, and .pr.number must be a positive
+# integer, not merely non-null.
+string_number_fixture="$(write_fixture string-number-pr-identity '.pr.number = "42"')"
+run_fails_contains "rejects_string_pr_number" \
+  "evidence file's .pr object is missing required identity field(s): pr.number" \
+  "$GATE" --input "$string_number_fixture" --json
+
+zero_number_fixture="$(write_fixture zero-pr-identity '.pr.number = 0')"
+run_fails_contains "rejects_zero_pr_number" \
+  "evidence file's .pr object is missing required identity field(s): pr.number" \
+  "$GATE" --input "$zero_number_fixture" --json
+
+negative_number_fixture="$(write_fixture negative-pr-identity '.pr.number = -1')"
+run_fails_contains "rejects_negative_pr_number" \
+  "evidence file's .pr object is missing required identity field(s): pr.number" \
+  "$GATE" --input "$negative_number_fixture" --json
+
+non_integer_number_fixture="$(write_fixture non-integer-pr-identity '.pr.number = 3.5')"
+run_fails_contains "rejects_non_integer_pr_number" \
+  "evidence file's .pr object is missing required identity field(s): pr.number" \
+  "$GATE" --input "$non_integer_number_fixture" --json
+
+numeric_branch_name_fixture="$(write_fixture numeric-branch-name-pr-identity '.pr.headRefName = 918')"
+run_fails_contains "rejects_numeric_head_ref_name" \
+  "evidence file's .pr object is missing required identity field(s): pr.headRefName" \
+  "$GATE" --input "$numeric_branch_name_fixture" --json
+
+object_branch_name_fixture="$(write_fixture object-branch-name-pr-identity '.pr.baseRefName = {}')"
+run_fails_contains "rejects_object_base_ref_name" \
+  "evidence file's .pr object is missing required identity field(s): pr.baseRefName" \
+  "$GATE" --input "$object_branch_name_fixture" --json
+
+array_branch_name_fixture="$(write_fixture array-branch-name-pr-identity '.pr.headRefName = []')"
+run_fails_contains "rejects_array_head_ref_name" \
+  "evidence file's .pr object is missing required identity field(s): pr.headRefName" \
+  "$GATE" --input "$array_branch_name_fixture" --json
+
+# .pr.inScope must be a literal boolean when present -- a value that merely
+# coerces to falsy/truthy via jq's `//` operator (null, a string, a number,
+# an object) must not silently decide the scope outcome either way.
+null_in_scope_fixture="$(write_fixture null-in-scope '.pr.inScope = null')"
+run_fails_contains "rejects_null_in_scope" \
+  "evidence file's .pr.inScope field is present but not a boolean (got type: null)" \
+  "$GATE" --input "$null_in_scope_fixture" --json
+
+string_in_scope_fixture="$(write_fixture string-in-scope '.pr.inScope = "false"')"
+run_fails_contains "rejects_string_in_scope" \
+  "evidence file's .pr.inScope field is present but not a boolean (got type: string)" \
+  "$GATE" --input "$string_in_scope_fixture" --json
+
+numeric_in_scope_fixture="$(write_fixture numeric-in-scope '.pr.inScope = 0')"
+run_fails_contains "rejects_numeric_in_scope" \
+  "evidence file's .pr.inScope field is present but not a boolean (got type: number)" \
+  "$GATE" --input "$numeric_in_scope_fixture" --json
+
+object_in_scope_fixture="$(write_fixture object-in-scope '.pr.inScope = {}')"
+run_fails_contains "rejects_object_in_scope" \
+  "evidence file's .pr.inScope field is present but not a boolean (got type: object)" \
+  "$GATE" --input "$object_in_scope_fixture" --json
+
 # Genuinely complete input (full .pr identity, as every fixture below
 # supplies) with a real blocker must still report it — see
 # "requires_human_review_label" -> blocked below, which proves the


### PR DESCRIPTION
## Summary

Fixes #1435.

`run-epic-delegated-gate.sh` silently degraded to a worst-case
`human_required` decision when the evidence file's `.pr` object was never
populated. Reproduced against real saved evidence for PR #33
(`lhpaul/personal-finances`): the gate emitted an 8-reason `human_required`
verdict where at least 5 reasons were factually false for the real PR at
evaluation time — root cause was `.pr.number: null`, empty `.pr.headRefName`
and `.pr.baseRefName`, i.e. the evidence-assembly step never populated the
`.pr` object.

The core problem, per the issue: **missing or incomplete input is
indistinguishable from genuine blockers in the output.** A gate that emits
eight blockers, five of them false, teaches operators to distrust it.

## Changes

1. **Validate `.pr` identity before evaluating any reason.** `.pr.number`,
   `.pr.headRefName`, and `.pr.baseRefName` are the three fields every live
   `gh pr view` read always populates. Their absence is now a hard `ERROR:`
   naming the exact missing field(s), rather than each one defaulting
   independently to its own worst case.

   I deliberately scoped this validation to just these three identity fields
   rather than every top-level object the script consumes (as literally
   suggested in the issue's first bullet). Other optional fields — `.risk`,
   `.policy`, `.pr.labels`, `.pr.mergeStateStatus`, `.pr.auditDispositionPresent`
   — have existing, intentional per-field worst-case-default semantics that
   are exercised by pre-existing tests (`missing_risk_gate_requires_human`,
   `null_policy_fixture`, etc.). The reported bug's evidence dump shows only
   the three identity fields were even present (with placeholder worst-case
   values) — everything else was simply absent from the object — so
   validating identity presence catches exactly the reported failure mode
   without weakening the intentional "missing policy/risk data → be
   cautious" behavior those other fields already have.

2. **Promote out-of-scope to a distinct `not_applicable` decision.**
   When `.pr.inScope` is present and `false`, the gate now short-circuits
   with `decision: "not_applicable"` and a single reason, instead of mixing
   it into the `human_required` pile alongside unrelated defaulted reasons.

3. **Skip the scope check when `pr.inScope` is absent** (not merely falsy).
   This directly addresses the operational symptom reported in this batch's
   handoff: `pr.inScope` is meaningful only when there is a resolved
   `/run-epic` scope to check against. A `/run-items`/`/run-item` Gate 5
   caller has no such scope, so requiring it to hand-assemble
   `pr.inScope: true` just to avoid a false blocker was itself a workaround
   for this bug. Now the field is optional; omitting it means "scope check
   not applicable," not "out of scope."

4. **New test fixtures** for: missing `.pr` object, the exact bug-repro
   shape (`pr.number: null`, empty `headRefName`/`baseRefName`), partial
   identity, the new `not_applicable` decision (single reason, `mergePermitted:
   false`, `reviewerAccess.classification: not_applicable`), and the
   absent-`inScope` skip behavior (`merge_allowed`, no scope reason emitted).
   Updated the one existing test that asserted the old `human_required`
   behavior for explicit `inScope: false`.

5. **Docs**: `95-run-epic-protocol.md` documents the new `not_applicable`
   decision value; `guardrails-enforcement.md` Gate 5 tells Protocol 90/91
   callers to omit `pr.inScope` when there's no resolved scope.

## Verification

Full suite: `bash scripts/development-workflow/tests/test-run-epic-delegated-gate.sh`
→ 121 passed, 0 failed (110 pre-existing + 1 updated + 10 new, including a follow-up whitespace-only `.pr.headRefName`/`.baseRefName` fixture added during code review to close a Test Harness Coverage Checklist gap).

Manual planted-violation proof (mocked `gh`, both directions):

- **Incomplete input → clear error, not a false blocker pile**: feeding the
  exact bug-repro shape (`{"pr": {"number": null, "headRefName": "",
  "baseRefName": ""}}`) now exits 1 with
  `ERROR: evidence file's .pr object is missing required identity field(s):
  pr.number, pr.headRefName, pr.baseRefName. ...` — no `human_required`
  decision, no false reasons. (`run-epic-delegated-gate.sh` lines 349–369.)
- **Genuinely complete input with a real blocker still reports it**: a
  fully-populated `.pr` object missing only the `ready-for-human-review`
  label still returns `{"decision": "blocked", "reasons": ["ready-for-human-review
  label is missing"]}`. (`run-epic-delegated-gate.sh` lines 690–692 area,
  the `has_label("ready-for-human-review")` check.)
- **Operational fix confirmed**: a complete, ready evidence object with
  `pr.inScope` entirely absent (mirroring a `/run-items` batch PR) now
  returns `merge_allowed` with zero reasons — no hand-assembled
  `pr.inScope: true` workaround needed.

## Why this approach (vs. schema-validating every object)

The issue's Impact section also raises a broader "gameable in the other
direction" concern (no schema validation at all, so an operator could add
fields until the decision flips). That's a real but separate,
larger-scoped problem — full schema validation of every consumed object
is not something a Fast Track fix should take on. This PR fixes the
specific, reproduced false-negative defect: incomplete `.pr` identity
input degrading to a misleading worst-case verdict.

## Pre-Submission Self-Review Pass

Pre-submission self-review: stale markers - none introduced (verified via diff grep for TODO/FIXME/XXX/HACK); caller consistency - verified (`95-run-epic-protocol.md` and `guardrails-enforcement.md` Gate 5 updated to document the new `not_applicable` decision and the omit-`pr.inScope` guidance; no other repo surface references the removed inline `"candidate PR is not in the resolved run-epic scope"` reason-adding branch or the old `candidate_not_in_scope_requires_human` test name; a stale reference to the old test name in a frozen 918-delegated-review-merge-loop implementation-plan artifact is a historical record, not a live cross-reference); coverage - diff addresses the issue #1435 body's stated problem (worst-case degradation on incomplete `.pr` input) and proposed fix (validate `.pr` identity before evaluating reasons, promote out-of-scope to a distinct `not_applicable` decision, add regression fixtures); complex gate matrix - the gate's decision values (`merge_allowed`, `exceptional_bypass_authorized`, `fix_required`, `human_required`, `blocked`, and the new `not_applicable`) and their required next actions are enumerated together in `95-run-epic-protocol.md`'s Step 8 gate-outcome paragraph, which this PR updates in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delegated gate validation for incomplete or incorrectly formatted pull request details.
  * Explicitly excluded pull requests now receive a `not_applicable` decision and cannot be merged.
  * Pull requests without applicable scope information no longer produce incorrect out-of-scope or review-required results.
  * Optional fields continue to use safe worst-case defaults.

* **Documentation**
  * Clarified scope handling and decision outcomes in workflow and protocol guidance.
  * Added changelog coverage for the updated validation and decision flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

