### PR TITLE
refactor(docs): port i18n no-literal-string doctrine and catalogue reference (#1441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sections, following the same reviewer/implementer-mirror pattern already used
   for Filter-Schema Canary Tests. Documentation-only change; see the PR
   description for the recursive proof this item's own rule was applied to.
+- **Port i18n no-literal-string doctrine and catalogue reference** (#1441):
+  adds `docs/best-practices/stack/i18n.md` with the portable no-hardcoded-string
+  doctrine, a React Native/i18next worked example, and the dynamic-key scanner
+  pitfall, plus a conditional `REVIEW.md` review-gate check.
 
 ### Fixed
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -322,6 +322,15 @@ Additional checks for **PRs that add or modify an automated check, guard, lint r
 - **Same-PR inclusion** (blocking): confirm the proof is part of this PR's evidence, not deferred to a follow-up PR or assumed from a prior similar change.
 - **Exemption**: pure refactors of already-proven validation logic, with no behavior change, are exempt from re-proof; the PR evidence should state the exemption rationale.
 
+Additional checks for **PRs that add or modify user-facing copy in a
+project with a configured i18n / catalogue convention** (see
+`docs/best-practices/stack/i18n.md`):
+
+- **Applicability gate**: this check applies only to a downstream project that has adopted an i18n / catalogue convention for user-facing copy. When a project has not adopted this convention, this check is not applicable; do not treat it as a blanket requirement for every PR in every repository.
+- **Enforcement is active** (blocking when applicable): confirm the project's no-hardcoded-string enforcement mechanism (a lint rule or equivalent machine check) is configured and currently enabled, not merely documented as a convention.
+- **Catalogue parity** (blocking when applicable): confirm every catalogue/locale file the project ships is updated together in this PR — no locale is left with a missing or stale key that another locale added.
+- **Planted-violation proof for enforcement changes**: when this PR adds or materially modifies the enforcement mechanism itself (the lint rule config, a custom key-extraction scanner, or equivalent), apply the "PRs that add or modify an automated check, guard, lint rule, or CI job" block above in full, including explicit coverage of any dynamic/non-literal key argument form the scanner is meant to reject — this block does not restate that requirement, it delegates to it.
+
 Additional checks for **PRs that add a feature (when a committed E2E suite exists)**:
 
 - **Applicability gate**: this check applies only when the repository has a committed, non-placeholder E2E/functional suite (i.e., `docs/testing/README.md` Section 2's "committed automated spec" path is filled in, and the repo's E2E CI job runs real tests rather than this template's placeholder). When no such suite exists yet, this check is not applicable; record the not-applicable rationale rather than silently skipping it.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -324,7 +324,7 @@ Additional checks for **PRs that add or modify an automated check, guard, lint r
 
 Additional checks for **PRs that add or modify user-facing copy in a
 project with a configured i18n / catalogue convention** (see
-`docs/best-practices/stack/i18n.md`):
+[`docs/best-practices/stack/i18n.md`](docs/best-practices/stack/i18n.md)):
 
 - **Applicability gate**: this check applies only to a downstream project that has adopted an i18n / catalogue convention for user-facing copy. When a project has not adopted this convention, this check is not applicable; do not treat it as a blanket requirement for every PR in every repository.
 - **Enforcement is active** (blocking when applicable): confirm the project's no-hardcoded-string enforcement mechanism (a lint rule or equivalent machine check) is configured and currently enabled, not merely documented as a convention.

--- a/docs/best-practices/3-testing.md
+++ b/docs/best-practices/3-testing.md
@@ -85,7 +85,7 @@ Any PR that adds or materially modifies an automated check, guard, lint rule, or
 
 See `REVIEW.md` → Code Review Checklist → Pass 2 → "PRs that add or modify an automated check, guard, lint rule, or CI job" for the reviewer-facing enforcement of this rule.
 
-For a worked instance of this rule — a regex-based key-extraction scanner, its full edge-case table, and a named dynamic-key concatenation gap (`t('x.' + k)`) that a naive first version missed and a fix closed with permanent regression tests — see `docs/best-practices/stack/i18n.md` → "Key-extraction scanner and the dynamic-key pitfall."
+For a worked instance of this rule — a regex-based key-extraction scanner, its full edge-case table, and a named dynamic-key concatenation gap (`t('x.' + k)`) that a naive first version missed and a fix closed with documented regression cases — see [`docs/best-practices/stack/i18n.md` § Key-extraction scanner and the dynamic-key pitfall](stack/i18n.md#key-extraction-scanner-and-the-dynamic-key-pitfall).
 
 ## Test Data and Seed Data
 

--- a/docs/best-practices/3-testing.md
+++ b/docs/best-practices/3-testing.md
@@ -85,6 +85,8 @@ Any PR that adds or materially modifies an automated check, guard, lint rule, or
 
 See `REVIEW.md` → Code Review Checklist → Pass 2 → "PRs that add or modify an automated check, guard, lint rule, or CI job" for the reviewer-facing enforcement of this rule.
 
+For a worked instance of this rule — a regex-based key-extraction scanner, its full edge-case table, and a named dynamic-key concatenation gap (`t('x.' + k)`) that a naive first version missed and a fix closed with permanent regression tests — see `docs/best-practices/stack/i18n.md` → "Key-extraction scanner and the dynamic-key pitfall."
+
 ## Test Data and Seed Data
 
 - Tests that require data should use deterministic seed data, not random values

--- a/docs/best-practices/STACK-SPECIFIC.md
+++ b/docs/best-practices/STACK-SPECIFIC.md
@@ -15,14 +15,15 @@
 
 ## Best Practices by Technology
 
-| Area      | File                                    |
-| --------- | --------------------------------------- |
-| Language  | `stack/[technology].md`                 |
-| Framework | `stack/[technology].md`                 |
-| Styling   | `stack/[technology].md` — if applicable |
-| Database  | `stack/[technology].md` — if applicable |
-| API       | `stack/[technology].md` — if applicable |
-| Supabase  | [stack/supabase.md](stack/supabase.md)  |
+| Area                         | File                                             |
+| ---------------------------- | ------------------------------------------------ |
+| Language                     | `stack/[technology].md`                          |
+| Framework                    | `stack/[technology].md`                          |
+| Styling                      | `stack/[technology].md` — if applicable          |
+| Database                     | `stack/[technology].md` — if applicable          |
+| API                          | `stack/[technology].md` — if applicable          |
+| Supabase                     | [stack/supabase.md](stack/supabase.md)           |
+| Internationalization (i18n)  | [stack/i18n.md](stack/i18n.md) — if applicable   |
 
 > **Setup agent**: Replace each `stack/[technology].md` above with actual links to the
 > files generated under `docs/best-practices/stack/`. Remove rows that don't apply.

--- a/docs/best-practices/stack/i18n.md
+++ b/docs/best-practices/stack/i18n.md
@@ -246,6 +246,7 @@ tell "no keys used here" apart from "keys used here that I couldn't verify."
 | E12 | multi-line call, literal on its own line | key extracted (the regex must not be anchored to a single line) |
 | E13 | `t('a.x' + suffix)` | zero keys, one dynamic finding — a quoted prefix followed by concatenation is **not** the static key; the real runtime key is unverifiable |
 | E13b | `t('a.' + section + '.title')` | zero keys, one dynamic finding — same rule, multi-segment concatenation |
+| E14 | `` t('it\'s') `` (an escaped quote inside the literal) | **known limitation**: the closing-quote scan is correctly skipped past the escaped quote, so this is *not* reported as dynamic — but the escape sequence is copied into the extracted value verbatim rather than being unescaped, so the "key" the scanner reports is `it\'s` (backslash included), not the actual runtime key `it's`; a catalogue that stores the key without the stray backslash triggers a false missing-key finding |
 
 ### The dynamic-key pitfall (named, per this item's requirement)
 

--- a/docs/best-practices/stack/i18n.md
+++ b/docs/best-practices/stack/i18n.md
@@ -127,7 +127,18 @@ void i18n.use(initReactI18next).init({
   fallbackLng: 'es',
   keySeparator: false,
   interpolation: { escapeValue: false }, // the UI layer already escapes values
-  react: { useSuspense: false }, // resources are bundled synchronously above
+  // Resources are bundled synchronously above (no async backend plugin), so
+  // there is nothing to await. `initImmediate: false` makes that guarantee
+  // explicit — i18next skips its `setTimeout`-deferred init path once
+  // `resources` are present, but that is an internal fast path, not part of
+  // its public contract. Setting `initImmediate: false` pins the same
+  // synchronous outcome so it does not silently regress into the deferred
+  // (next-tick) path if this config is edited later — e.g. resources moved
+  // behind a synchronous backend — which is what keeps `useSuspense: false`
+  // safe: a component that calls `t()` right after this module loads must
+  // never observe a still-initializing instance and get back raw keys.
+  initImmediate: false,
+  react: { useSuspense: false },
 });
 
 export default i18n;

--- a/docs/best-practices/stack/i18n.md
+++ b/docs/best-practices/stack/i18n.md
@@ -1,0 +1,299 @@
+# Internationalization (i18n) Best Practices
+
+This document covers the portable doctrine for internationalizing user-facing
+copy, plus one fully worked, production-proven example (React Native +
+i18next). Adopt the doctrine on any stack; adopt the worked example only if
+your stack matches it. See "What is portable / not portable" below for the
+line between the two.
+
+---
+
+## Doctrine (stack-agnostic)
+
+These rules apply regardless of language or UI framework:
+
+- **No hard-coded user-facing literal string in UI markup.** Copy lives in a
+  catalogue and is resolved by key lookup at render time, not written inline
+  in a component/template.
+- **Catalogues have a primary locale and at least one fallback locale.**
+  Ship both together; do not leave a translation missing in the fallback
+  because the primary locale changed first. Add or update every locale file
+  in the same change.
+- **Enforcement must be machine-checked, not prose.** A style-guide sentence
+  that says "don't hard-code strings" does not hold once a codebase has more
+  than a handful of screens. The convention needs an automated check — a
+  lint rule, a static scanner, or an equivalent CI gate — that fails a PR
+  containing a violation. Do not add a suppression escape hatch (an
+  `eslint-disable`-equivalent) to get a screen merged; put the string in the
+  catalogue instead.
+- **The enforcement mechanism itself is subject to
+  [planted-violation-proof discipline](../3-testing.md#planted-violation-proofs).**
+  Introducing or materially modifying the check that catches hard-coded
+  strings (the lint rule config, a custom key-extraction scanner, or
+  equivalent) requires the same fails-when-present / passes-when-absent
+  proof, at a concrete file and line, as any other automated check. A
+  described-but-unexercised i18n lint rule is a declared-but-unverified
+  control, not a working one.
+- **Data-driven copy goes through the same catalogue discipline as static
+  copy.** When user-facing text originates in the database (a stored enum
+  value, an error code, a category label) rather than in markup, resolve it
+  through the catalogue by a stable code — never persist the already-
+  translated display string. The same rule applies to values that are
+  locale-resolved from a data row (e.g., a label stored per-locale in a
+  table): resolve by the active locale, falling back to the primary locale,
+  the same way a static catalogue lookup falls back.
+- **Currency, dates, and numbers are not catalogue strings.** Route them
+  through the platform's locale-aware formatting facility (e.g. `Intl` in
+  JS/TS) parameterized by the active locale, rather than hand-writing a
+  per-locale format table. Verify the platform's locale output actually
+  matches the target format (decimal/thousands separators, month names) —
+  do not assume the default matches the mockup.
+
+---
+
+## Worked example: React Native + i18next
+
+> **This section is one illustrative stack, not a universal requirement.**
+> The doctrine above is the portable part. The specific runtime
+> (`i18next`/`react-i18next`), device-locale library (`expo-localization`),
+> and lint plugin (`eslint-plugin-i18next`) below are one production-proven
+> combination for a React Native/Expo app — adapt or replace them entirely
+> for a different stack.
+
+### Stack
+
+| Piece | Choice |
+| --- | --- |
+| Runtime | `i18next` + `react-i18next` |
+| Device locale | `expo-localization` → `getLocales()[0]?.languageCode`, mapped to a supported locale, defaulting to a primary locale |
+| Catalogues | flat, dotted-key JSON per locale (e.g. `home.pending_title`), not nested objects |
+| Wiring | a single module that initializes i18next once, at import time, and exports a `setLocale()` helper |
+| Enforcement | `eslint-plugin-i18next`'s `no-literal-string` rule — see below |
+
+### Catalogue and resolver skeleton
+
+Flat, dotted-key catalogues avoid a nested-object walk (`i18next`'s default
+`keySeparator: '.'` would otherwise try to walk a dotted key like
+`"home.pending_title"` into a non-existent nested `home` object and silently
+return the key string instead of the translation — set `keySeparator:
+false`):
+
+```json
+// en.json / es.json — flat, dotted keys; every segment is snake_case
+{
+  "home.pending_title": "Pending",
+  "settings_banks.disconnect_confirm": "Disconnect this bank?"
+}
+```
+
+```ts
+// i18n/locale.ts — kept free of any i18next import, so it is unit-testable
+// without booting the i18n runtime.
+import { getLocales } from 'expo-localization';
+
+export const SUPPORTED_LOCALES = ['es', 'en'] as const;
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+export const DEFAULT_LOCALE: SupportedLocale = 'es';
+
+export function toSupportedLocale(
+  languageCode: string | null | undefined,
+): SupportedLocale {
+  if (languageCode === null || languageCode === undefined) return DEFAULT_LOCALE;
+  const normalized = languageCode.toLowerCase().split(/[-_]/)[0];
+  if (!normalized) return DEFAULT_LOCALE;
+  return (SUPPORTED_LOCALES as readonly string[]).includes(normalized)
+    ? (normalized as SupportedLocale)
+    : DEFAULT_LOCALE;
+}
+
+export function resolveDeviceLocale(): SupportedLocale {
+  return toSupportedLocale(getLocales()[0]?.languageCode);
+}
+```
+
+```ts
+// i18n/index.ts — imported once, for its side effect, before any
+// `useTranslation()` call in the app.
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import en from './en.json';
+import es from './es.json';
+import { resolveDeviceLocale } from './locale';
+
+void i18n.use(initReactI18next).init({
+  resources: { es: { translation: es }, en: { translation: en } },
+  lng: resolveDeviceLocale(),
+  fallbackLng: 'es',
+  keySeparator: false,
+  interpolation: { escapeValue: false }, // the UI layer already escapes values
+  react: { useSuspense: false }, // resources are bundled synchronously above
+});
+
+export default i18n;
+```
+
+### The lint rule
+
+The "no literal string in JSX" rule is machine-enforced, appended to the
+app's ESLint flat config:
+
+```js
+{
+  files: ['app/**/*.tsx', 'src/**/*.tsx'],
+  plugins: { i18next: i18nextPlugin },
+  rules: {
+    'i18next/no-literal-string': ['error', {
+      mode: 'jsx-text-only',
+      'jsx-attributes': {
+        exclude: ['testID', 'accessibilityLabel', 'accessible'],
+      },
+    }],
+  },
+}
+```
+
+**Known coverage gap**: `mode: 'jsx-text-only'` checks JSX *text children*
+only. A literal string in a JSX attribute (`title="Settings"`) or nested
+inside an object literal passed through an attribute (`options={{ title:
+'Settings' }}`) is **not** reported by this mode — the `jsx-attributes`
+exclude list has no effect under `jsx-text-only` and is kept only so the
+config does not silently drift from this rule block. Attribute-level copy
+still needs manual review; it is not machine-enforced by this configuration.
+Tightening this (an attribute-aware mode, or a second rule pass) is a
+follow-up a project can choose to make, not assumed here.
+
+---
+
+## Key-extraction scanner and the dynamic-key pitfall
+
+A companion, narrower need shows up in test/CI tooling: verifying that every
+catalogue key referenced in source (`t('some.key')`) actually exists in
+every locale catalogue, and vice versa (no orphaned keys). That requires
+extracting every `t(...)` call's key argument from source text. The worked
+example below is a regex-based scanner (not a full parser) that does this
+for the common case, with its edge cases enumerated and each one covered by
+a named test.
+
+```ts
+// A regex-based key extractor: matches the common case, documents its
+// limitations rather than pulling in a full TypeScript parser.
+const CALL_REGEX = /\bt\s*\(/g;
+
+function parseFirstArgument(source: string, startIndex: number): string | null {
+  let i = startIndex;
+  while (i < source.length && /\s/.test(source.charAt(i))) i++;
+  const quote = source.charAt(i);
+  if (quote !== "'" && quote !== '"') return null;
+  i++;
+  let value = '';
+  while (i < source.length) {
+    const ch = source.charAt(i);
+    if (ch === '\\') { value += source.slice(i, i + 2); i += 2; continue; }
+    if (ch === quote) {
+      // The closing quote must be immediately followed (modulo whitespace)
+      // by an argument terminator — a `,` starting a trailing options
+      // argument, or the closing `)`. Anything else (most notably a `+`)
+      // means the quoted text was only a prefix of a larger, non-static
+      // expression and must be treated as dynamic. See "The dynamic-key
+      // pitfall" below.
+      let j = i + 1;
+      while (j < source.length && /\s/.test(source.charAt(j))) j++;
+      const next = source.charAt(j);
+      if (next === ',' || next === ')') return value;
+      return null;
+    }
+    value += ch;
+    i++;
+  }
+  return null; // unterminated string — treat as non-literal rather than throw
+}
+```
+
+Every `t(...)` call whose first argument does not parse to a static string
+literal is reported as a **dynamic finding** rather than silently skipped —
+a scanner that only collects static keys and ignores everything else cannot
+tell "no keys used here" apart from "keys used here that I couldn't verify."
+
+### Edge-case table
+
+| # | Input | Expected |
+| --- | --- | --- |
+| E1 | `t('home.title')` | one key, `home.title` |
+| E2 | `t("home.title")` | double quotes accepted; same key |
+| E3 | `label={t('a.x')} icon={t('a.y')}` on one line | **two** keys — the scan is global, not first-match |
+| E4 | `t('a.confirm', { count })` | key extracted, trailing options argument ignored |
+| E5 | `t(someVariable)` | zero keys, one dynamic finding |
+| E6 | `` t(`a.${x}`) `` | zero keys, one dynamic finding (template literal) |
+| E7 | `t('')` | one dynamic finding (empty key), not an empty-string key |
+| E8 | `expect('x')`, `require('x')`, `useT('x')` | zero keys — the callee must be exactly `t`, preceded by a non-identifier boundary |
+| E9 | `obj.t('a.x')` | one key — a member-expression callee is still `t` |
+| E10 | `// t('a.removed')` in a comment | **known limitation**: still matched; the only consequence is requiring a catalogue key that exists, so source files scanned this way must contain no commented-out `t(` call |
+| E11 | `t(cond ? 'a.x' : 'a.y')` | zero keys, one dynamic finding — a conditional key is not a literal |
+| E12 | multi-line call, literal on its own line | key extracted (the regex must not be anchored to a single line) |
+| E13 | `t('a.x' + suffix)` | zero keys, one dynamic finding — a quoted prefix followed by concatenation is **not** the static key; the real runtime key is unverifiable |
+| E13b | `t('a.' + section + '.title')` | zero keys, one dynamic finding — same rule, multi-segment concatenation |
+
+### The dynamic-key pitfall (named, per this item's requirement)
+
+**A naive first version of a scanner like this one can get E13/E13b wrong.**
+In the reference implementation this document is adapted from, the first
+version of `parseFirstArgument` returned the literal's content as soon as it
+saw the closing quote, with no check for what followed it. That accepted
+`t('a.x' + suffix)` as the static key `a.x`, reporting **zero dynamic
+findings** for a call whose actual runtime key is unverifiable — the
+opposite of the goal, and exactly the kind of gap that lets a real dynamic
+key sneak past the check "verified." The bug was caught in code review
+(a CodeRabbit finding on the source pull request), not by the scanner's own
+initial test suite, because that suite had no case for a quoted prefix
+followed by more code.
+
+**The fix**: after finding the closing quote, keep scanning forward past any
+whitespace; the very next character must be an argument terminator (`,` or
+`)`). If it is anything else — a `+`, another operator, more code — the
+match is not a bare literal and must be classified as dynamic, not returned
+as though the quoted prefix were the whole key. E13 and E13b above are the
+permanent regression tests that pin this behavior: they fail against the
+naive (pre-fix) version and pass against the fixed version shown in this
+document's code block.
+
+**Any downstream port of a scanner in this class must ship its own
+equivalent dynamic-key test coverage before the enforcement can be trusted**
+— reproducing this document's code without reproducing E13/E13b (or an
+equivalent case for your own language's concatenation/interpolation syntax)
+reintroduces the exact gap described above.
+
+---
+
+## What is portable / not portable
+
+| Bucket | Content | Applies to |
+| --- | --- | --- |
+| **1. Portable doctrine** | No-hard-coded-string rule, primary + fallback locale catalogues, "enforcement must be machine-checked," planted-violation-proof discipline applied to the enforcement mechanism itself, data-driven-copy-through-catalogue pattern | Any stack, any language |
+| **2. Stack-specific worked example** | The exact `i18next`/`react-i18next`/`expo-localization` config, the flat-key JSON catalogue shape, the ESLint rule block, and the regex-based key-extraction scanner (including its edge-case table and the dynamic-key concatenation gap) | React Native / Expo / i18next projects specifically — adapt or replace for another stack |
+| **3. Not portable at all** | The actual runtime source files, their test suites, and the specific catalogue content of any one application | Stays in that application's own repository; not a template concern |
+
+A project adopting this convention should implement bucket 1 always, adopt
+bucket 2 only if its stack matches (or adapt the pattern to its own stack),
+and never expect bucket 3 to be shipped by a framework template.
+
+---
+
+## Source
+
+Adapted from `lhpaul/personal-finances` issue #34 and its implementation PR
+[#41](https://github.com/lhpaul/personal-finances/pull/41) (merged). The
+lint rule's enforcement was verified with a three-run lint transcript in
+that PR: a run on the clean, migrated tree passes; a run with one deliberate
+literal string planted in a component fails, naming the exact file and line
+(`apps/mobile/src/dev/DesignSystemGallery.tsx:76:34`); removing the planted
+literal and re-running restores the passing result. `grep -rn
+"no-literal-string" apps packages` in that PR shows only the rule
+configuration and explanatory comments — no suppression anywhere. The
+dynamic-key fix described above was applied as a same-PR follow-up commit
+responding to a CodeRabbit review thread on PR #41 (scanner logic and its
+E13/E13b regression tests), before merge. This document reproduces the
+worked example and the pitfall as illustrative, non-executed reference
+material — see `REVIEW.md`'s conditional i18n checklist block below for what
+a project that actually adopts this convention must verify in its own,
+executable copy.

--- a/docs/best-practices/stack/i18n.md
+++ b/docs/best-practices/stack/i18n.md
@@ -67,7 +67,7 @@ These rules apply regardless of language or UI framework:
 | Runtime | `i18next` + `react-i18next` |
 | Device locale | `expo-localization` → `getLocales()[0]?.languageCode`, mapped to a supported locale, defaulting to a primary locale |
 | Catalogues | flat, dotted-key JSON per locale (e.g. `home.pending_title`), not nested objects |
-| Wiring | a single module that initializes i18next once, at import time, and exports a `setLocale()` helper |
+| Wiring | a single module that initializes i18next once, at import time, from the resolved device locale |
 | Enforcement | `eslint-plugin-i18next`'s `no-literal-string` rule — see below |
 
 ### Catalogue and resolver skeleton
@@ -241,7 +241,7 @@ tell "no keys used here" apart from "keys used here that I couldn't verify."
 | E8 | `expect('x')`, `require('x')`, `useT('x')` | zero keys — the callee must be exactly `t`, preceded by a non-identifier boundary |
 | E9 | `obj.t('a.x')` | one key — a member-expression callee is still `t` |
 | E10 | `// t('a.removed')` in a comment | **known limitation**: still matched; the only consequence is requiring a catalogue key that exists, so source files scanned this way must contain no commented-out `t(` call |
-| E10b | `"see t('a.removed') in the code"` inside a string literal | **known limitation**: same as E10 — the scanner reads raw source text, not tokens, so a `t(...)`-shaped substring inside an unrelated string literal is matched too; this can mark an orphaned key as used, never the reverse |
+| E10b | `"see t('a.removed') in the code"` inside a string literal | **known limitation**: same as E10 — the scanner reads raw source text, not tokens, so a `t(...)`-shaped substring inside an unrelated string literal is matched too; this can create a false missing-key finding or mark an orphaned key as used |
 | E11 | `t(cond ? 'a.x' : 'a.y')` | zero keys, one dynamic finding — a conditional key is not a literal |
 | E12 | multi-line call, literal on its own line | key extracted (the regex must not be anchored to a single line) |
 | E13 | `t('a.x' + suffix)` | zero keys, one dynamic finding — a quoted prefix followed by concatenation is **not** the static key; the real runtime key is unverifiable |

--- a/docs/best-practices/stack/i18n.md
+++ b/docs/best-practices/stack/i18n.md
@@ -78,8 +78,9 @@ Flat, dotted-key catalogues avoid a nested-object walk (`i18next`'s default
 return the key string instead of the translation — set `keySeparator:
 false`):
 
+`en.json` / `es.json` — flat, dotted keys; every segment is snake_case:
+
 ```json
-// en.json / es.json — flat, dotted keys; every segment is snake_case
 {
   "home.pending_title": "Pending",
   "settings_banks.disconnect_confirm": "Disconnect this bank?"
@@ -240,6 +241,7 @@ tell "no keys used here" apart from "keys used here that I couldn't verify."
 | E8 | `expect('x')`, `require('x')`, `useT('x')` | zero keys — the callee must be exactly `t`, preceded by a non-identifier boundary |
 | E9 | `obj.t('a.x')` | one key — a member-expression callee is still `t` |
 | E10 | `// t('a.removed')` in a comment | **known limitation**: still matched; the only consequence is requiring a catalogue key that exists, so source files scanned this way must contain no commented-out `t(` call |
+| E10b | `"see t('a.removed') in the code"` inside a string literal | **known limitation**: same as E10 — the scanner reads raw source text, not tokens, so a `t(...)`-shaped substring inside an unrelated string literal is matched too; this can mark an orphaned key as used, never the reverse |
 | E11 | `t(cond ? 'a.x' : 'a.y')` | zero keys, one dynamic finding — a conditional key is not a literal |
 | E12 | multi-line call, literal on its own line | key extracted (the regex must not be anchored to a single line) |
 | E13 | `t('a.x' + suffix)` | zero keys, one dynamic finding — a quoted prefix followed by concatenation is **not** the static key; the real runtime key is unverifiable |
@@ -264,9 +266,11 @@ whitespace; the very next character must be an argument terminator (`,` or
 `)`). If it is anything else — a `+`, another operator, more code — the
 match is not a bare literal and must be classified as dynamic, not returned
 as though the quoted prefix were the whole key. E13 and E13b above are the
-permanent regression tests that pin this behavior: they fail against the
+documented regression cases that pin this behavior: they fail against the
 naive (pre-fix) version and pass against the fixed version shown in this
-document's code block.
+document's code block. (This document's table entries are illustrative,
+non-executed reference material — see "Source" below; a downstream project
+adopting this scanner must reproduce them as its own executable tests.)
 
 **Any downstream port of a scanner in this class must ship its own
 equivalent dynamic-key test coverage before the enforcement can be trusted**


### PR DESCRIPTION
## Summary

Implements #1441 per the merged implementation plan (`docs/specs/developments/20260811002516_1441-i18n-lint-rule-port/2_1441-i18n-lint-rule-port_implementation-plan.md`, Refactor path, no spec).

The plan's Template-Fit Check concluded the issue's literal ask ("port the lint rule with its test suite, and the catalogue/resolver skeleton") fails as stated: this template ships no application source tree and no JS/TS unit-test runner (Jest/Vitest) — the only tracked JS/TS surfaces are the placeholder `e2e/` Playwright scaffold and `hooks/` Haystack git-hook internals, neither a product application. The port therefore ships as documentation, not live code:

- **`docs/best-practices/stack/i18n.md`** (new): a worked-reference doc separating portable doctrine (no hard-coded user-facing strings; primary + fallback locale catalogues; enforcement must be machine-checked; planted-violation-proof discipline applied to the enforcement mechanism itself; data-driven-copy-through-catalogue pattern) from an illustrative React Native + i18next worked example (catalogue/resolver skeleton, ESLint config block, and a regex-based key-extraction scanner with its full E1-E13b edge-case table). Names the dynamic-key concatenation gap (`t('x.' + k)`) that a naive first version of the reference scanner accepted as a static key with zero dynamic findings — caught by a CodeRabbit review thread on the source PR before merge, closed with permanent E13/E13b regression tests.
- **`REVIEW.md`**: adds one conditional "Additional checks" block (Code Review Checklist, Pass 2, placed after the existing "automated check, guard, lint rule, or CI job" block) requiring, for projects that have adopted an i18n/catalogue convention, that the enforcement mechanism be active, catalogues stay in parity, and any new/modified enforcement mechanism carry a planted-violation proof per the existing generic block (delegates to it rather than restating it).
- **`docs/best-practices/3-testing.md`**: one-line cross-reference inside the existing "Planted-Violation Proofs" section pointing to `i18n.md`'s worked scanner/dynamic-key example.
- **`docs/best-practices/STACK-SPECIFIC.md`**: new "Internationalization (i18n)" row in the "Best Practices by Technology" table, mirroring the existing Supabase row.

## Reference material

Adapted from `lhpaul/personal-finances` issue #34 and merged PR [#41](https://github.com/lhpaul/personal-finances/pull/41):

- `apps/mobile/eslint.config.mjs` — the `i18next/no-literal-string` config block.
- `apps/mobile/src/i18n/{index,locale}.ts` — the runtime wiring and device-locale resolver.
- `apps/mobile/src/test-utils/catalogue-key-scan.ts` / `.test.ts` — the key-extraction scanner and its edge-case suite (E1-E12 in the original PR).
- Follow-up commit `306baae` ("fix(mobile): reject concatenated t() call keys in catalogue-key-scan") — the dynamic-key fix and its E13/E13b regression tests, applied as a same-PR follow-up responding to CodeRabbit thread `PRRT_kwDOTqQsJM6VvDJJ` on PR #41, before merge.
- PR #41's own three-run lint transcript (fails on a planted literal at `apps/mobile/src/dev/DesignSystemGallery.tsx:76:34`, passes before/after) and `grep -rn "no-literal-string" apps packages` showing zero `eslint-disable` usages — both cited in the new doc's "Source" section as the proof the worked example is production-proven.

## Verification

- `npx markdownlint-cli2` against all six affected/added Markdown files (the plan, `i18n.md`, `STACK-SPECIFIC.md`, `3-testing.md`, the smoke-test runbook, `REVIEW.md`): 0 issues.
- Heuristic lint (`scripts/lint/markdown-heuristic-lint.py`), scoped to `docs/specs/developments/20260811002516_1441-i18n-lint-rule-port/` and `docs/testing/workflow/`: 0 issues.
- `scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`: passed (no duplicate sub-headers, all section headings have link references).
- Smoke test runbook (`docs/testing/workflow/1441-i18n-lint-rule-port.smoke-test.md`) executed manually — all 5 steps and the assertions checklist confirmed against the shipped `i18n.md`/`REVIEW.md`/cross-reference content.

## Scope discipline

Implemented exactly what the merged plan specifies — no application code, no scripts, no CI changes, and no new automated check added to this repository. No files under `apps/`, `src/`, `scripts/lint/`, or any executable JS/TS path were added.

## Verification Discipline note (REVIEW.md)

This is a documentation-only PR that ships no executable check or lint rule in this repository. The literal planted-violation-proof obligation in `REVIEW.md`'s "PRs that add or modify an automated check, guard, lint rule, or CI job" block therefore does not bind this PR itself — no proof is fabricated here. The illustrative scanner code block inside `i18n.md` is not executed by this repository's own CI; its correctness is evidenced instead by the cited, already-merged, already-tested reference implementation (E1-E13b passing in `personal-finances`) and by this PR's own careful transcription, not by a fresh run in this repo.

## WHY_SAFE_TO_MERGE

- **scope**: Exactly the four files the merged plan specifies (`docs/best-practices/stack/i18n.md` new; `REVIEW.md`, `docs/best-practices/3-testing.md`, `docs/best-practices/STACK-SPECIFIC.md` each get one small, additive edit), plus the CHANGELOG entry. No application code, script, or CI file touched.
- **tests**: No unit/integration/CI test tier applies (documentation-only, per the plan's Testing Strategy). Verification is markdown lint (`markdownlint-cli2`, 0 issues), the heuristic lint script (0 issues), the CHANGELOG duplicate-header/link-reference check (passed), and the smoke-test runbook's 5 manual steps (all confirmed).
- **reviewer_outcome**: to be filled after Step 7/7a completes.
- **ci_outcome**: to be filled after Step 8 completes (head SHA: see below).
- **rollback_or_cleanup_risk**: Low. Pure documentation addition/edit; reverting the commit fully removes it with no data, schema, or runtime impact, and no other item in this batch touches the same files (per the plan's Cross-Cutting Operational Assumption Check).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added internationalization best practices covering translation catalogues, locale fallback, formatting, and data-driven copy.
  * Added a React Native example demonstrating locale resolution, runtime setup, catalogue usage, and translation checks.
  * Documented translation-key scanning limitations, dynamic keys, edge cases, and regression-testing guidance.
  * Updated technology references to include the internationalization guide.
  * Added review guidance for user-facing copy, locale parity, and enforcement changes.
  * Added a changelog entry summarizing the new internationalization guidance and review practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->