### PR TITLE
fix(lint): respect explicit language tag in WS001 shell check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`workflow-shell-snippet-lint.py` WS001 false-positives on non-shell fenced
+  code blocks** (#1468): `executable = language in {"bash", "sh", "shell",
+  "zsh"} or bool(SHELL_SIGNAL.search(content))` let the `SHELL_SIGNAL` content
+  heuristic override an explicit, non-shell language tag, so idiomatic
+  TypeScript/Python/SQL fences whose content happened to start a line with
+  `export`/`if`/`for`/`set` (etc.) were misclassified as executable shell and
+  flagged for a `workflow-shell-contract` marker they should never carry —
+  reproduced on `docs/best-practices/stack/supabase.md`'s pre-existing
+  `` ```typescript `` blocks in `--all` mode, and blocking PR #1467 (#1441) in
+  `--base-ref` (changed-lines) mode. An explicit language tag is now
+  authoritative: an explicit shell tag (`bash`/`sh`/`shell`/`zsh`) is always
+  executable, any other explicit tag is never executable regardless of
+  content, and only a genuinely ambiguous untagged fence still falls back to
+  `SHELL_SIGNAL`. Adds five permanent regression fixtures to
+  `scripts/lint/tests/test-workflow-shell-snippet-lint.sh` covering explicit
+  non-shell tags (`ts`, `typescript`, `python`, `sql`) with shell-signal
+  content (must pass) and an untagged fence with shell content (must still
+  fail).
 - **`retro-metrics.md` excluded from sync overwrites, with an approval-based
   bootstrap migration for inherited rows** (#1438):
   `docs/workflow/retro-metrics.md` and `docs/workflow/retro-metrics-platforms.md`

--- a/scripts/lint/tests/test-workflow-shell-snippet-lint.sh
+++ b/scripts/lint/tests/test-workflow-shell-snippet-lint.sh
@@ -47,6 +47,11 @@ run_fixture portable_for fail $'<!-- workflow-shell-contract: bash-zsh -->\n```s
 run_fixture portable_set fail $'<!-- workflow-shell-contract: bash-zsh -->\n```shell\nset -- $pair\n```'
 run_fixture portable_pass pass $'<!-- workflow-shell-contract: bash-zsh -->\n```shell\nwhile IFS= read -r item; do echo "$item"; done <<EOF\na\nEOF\n```'
 run_fixture typed_non_shell_boundary pass $'```text\nstatus only\n```\n\ngit status is referenced in prose, not a snippet.\n\n<!-- workflow-shell-contract: bash-zsh -->\n```bash\necho hello\n```'
+run_fixture explicit_ts_tag_ignores_shell_signal pass $'```ts\nexport const DEFAULT_LOCALE = \'es\';\n\nexport function toLocale(code: string | null): string {\n  if (code === null) return DEFAULT_LOCALE;\n  return code;\n}\n```'
+run_fixture explicit_typescript_tag_ignores_shell_signal pass $'```typescript\nexport function run(): void {\n  if (true) {\n    console.log("ok");\n  }\n}\n```'
+run_fixture explicit_python_tag_ignores_shell_signal pass $'```python\nimport os\n\nif __name__ == "__main__":\n    export = os.environ.get("X")\n```'
+run_fixture explicit_sql_tag_ignores_shell_signal pass $'```sql\nfor x in (1, 2, 3) loop\n  set y = x;\nend loop;\n```'
+run_fixture untagged_shell_signal_still_flagged fail $'```\ngit status\n```'
 
 contract_doc="docs/workflow/snippet-contract-only.md"
 contract_diff="$TMP_DIR/contract-only.diff"

--- a/scripts/lint/workflow-shell-snippet-lint.py
+++ b/scripts/lint/workflow-shell-snippet-lint.py
@@ -14,6 +14,7 @@ ROOTS = ("AGENTS.md", "docs/workflow/", "docs/best-practices/", ".agents/skills/
 FENCE = re.compile(r"^\s*```(?P<lang>[A-Za-z0-9_-]+)?\s*$", re.I)
 CONTRACT = re.compile(r"^\s*<!--\s*workflow-shell-contract:\s*(bash|bash-zsh)\s*-->\s*$")
 SHELL_SIGNAL = re.compile(r"(?m)^\s*(?:git|gh|bash|zsh|for|while|set|if|cd|export|source)\b")
+SHELL_LANGS = {"bash", "sh", "shell", "zsh"}
 PORTABLE_FOR = re.compile(r"\bfor\s+\w+\s+in\s+\$[A-Za-z_][A-Za-z0-9_]*\b")
 PORTABLE_SET = re.compile(r"\bset\s+--\s+\$[A-Za-z_][A-Za-z0-9_]*\b")
 BASH_ONLY = re.compile(r"BASH_SOURCE|<\(|\[\[|\$\{![^}]+\}|\b(?:readarray|mapfile)\b|\w+=\(")
@@ -107,7 +108,17 @@ def lint(path: str, changed: set[int]) -> list[Finding]:
         changed_here = any(index <= number < closer + 1 for number in changed)
         language = (opener.group("lang") or "").lower()
         content = "\n".join(fence_lines)
-        executable = language in {"bash", "sh", "shell", "zsh"} or bool(SHELL_SIGNAL.search(content))
+        # A fence with an explicit language tag is authoritative: an explicit
+        # shell tag (bash/sh/shell/zsh) is always executable, and any other
+        # explicit tag (ts, typescript, python, json, ...) is never executable
+        # shell, regardless of whether its content happens to contain a line
+        # that starts with a SHELL_SIGNAL keyword (e.g. idiomatic TypeScript
+        # `export`/`if` statements). Only an untagged fence is genuinely
+        # ambiguous and falls back to the content heuristic.
+        if language:
+            executable = language in SHELL_LANGS
+        else:
+            executable = bool(SHELL_SIGNAL.search(content))
         if changed_here and executable:
             contract = contract_before(lines, index)
             line = index + 1


### PR DESCRIPTION
## Summary

Fixes #1468.

`scripts/lint/workflow-shell-snippet-lint.py`'s `WS001` check had:

```python
executable = language in {"bash", "sh", "shell", "zsh"} or bool(SHELL_SIGNAL.search(content))
```

The `or bool(SHELL_SIGNAL.search(content))` branch let the content heuristic
override an explicit, non-shell language tag. Idiomatic TypeScript/Python/SQL
fences whose content happens to start a line with `export`/`if`/`for`/`set`
(the `SHELL_SIGNAL` keyword set) were misclassified as executable shell and
flagged for a `workflow-shell-contract` marker they should never need — the
`workflow-shell-contract` vocabulary only has `bash` / `bash-zsh`, so there
was no honest value that could silence the false positive without
mislabeling the block.

This was reproduced, unmodified, on `docs/best-practices/stack/supabase.md`'s
pre-existing ` ```typescript ` blocks in `--all` mode, and is the named
blocker for PR #1467 (issue #1441), whose merged plan explicitly excludes
script changes — this fix is scoped as its own change per human instruction.

## Fix

An explicit language tag is now authoritative:

- Explicit shell tag (`bash`/`sh`/`shell`/`zsh`) → always executable
  (unchanged from before).
- Any other explicit tag (`ts`, `typescript`, `python`, `sql`, `json`, ...) →
  never executable, regardless of content.
- No tag (untagged fence) → still ambiguous, falls back to the
  `SHELL_SIGNAL` content heuristic (unchanged from before).

This directly targets the root cause identified in the issue ("the bug is
specifically that an explicit non-shell tag is overridden by the
heuristic") without introducing a `KNOWN_NON_SHELL_LANGS` allowlist that
would need ongoing maintenance as new language tags are used in the repo's
docs.

## Verification (planted violations, per REVIEW.md Verification Discipline)

1. **Non-shell tag with shell-signal content must NOT be flagged** — a
   ` ```ts ` fence containing `export const ...` / `if (...)` passes clean
   (`exit=0`).
2. **Genuinely executable shell fence missing its marker must still be
   flagged** — a ` ```bash ` fence with no adjacent
   `<!-- workflow-shell-contract: ... -->` marker still fires `WS001`
   (`exit=1`), confirmed live against `docs/best-practices/stack/supabase.md:41`
   (an actual, pre-existing genuine finding — a `bash`-tagged `npx supabase
   gen types ...` command with no marker).
3. **Untagged fence with shell content must still be flagged** — a fenceless
   ` ``` ` block containing `git status` still fires `WS001` (`exit=1`).

Five permanent regression fixtures were added to
`scripts/lint/tests/test-workflow-shell-snippet-lint.sh` covering explicit
`ts`/`typescript`/`python`/`sql` tags with shell-signal content (must pass)
and an untagged fence with shell content (must still fail). All 15 fixtures
in the suite pass.

## Residual `--all` scan

`python3 scripts/lint/workflow-shell-snippet-lint.py --all` reports **502**
findings after this fix (down from 509 on unmodified `develop`). The 7
findings removed are all confirmed false positives from non-shell-tagged
fences (4 in `supabase.md`'s `` ```typescript `` blocks, 2 in
`sync-template.md`'s `` ```yaml `` block, 1 in `e2e-regression.md`'s
`` ```yaml `` block) whose content happened to start a line with `if:` /
`export`. Zero new findings were introduced.

The remaining 502 findings are a pre-existing backlog of `bash`/`sh`/`shell`/
`zsh`-tagged (or untagged-with-shell-content) fences missing their
`workflow-shell-contract` marker, unrelated to this bug — CI has never
surfaced them because it only lints changed lines (`--base-ref`), not `--all`.
This PR does not mass-annotate those files; that backlog is a separate,
larger scoped item if the repo wants `--all` to go clean (not addressed
here per the "prefer correct over expanding scope" guidance for this item).

## Standard obligations

- CHANGELOG entry added under `[Unreleased]` → `### Fixed`.
- `markdownlint-cli2`, heuristic lint, and duplicate-header check all clean
  on `CHANGELOG.md`.
- `workflow-shell-snippet-lint.py --base-ref origin/develop` (self-check on
  this PR's own diff) is clean.
- `workflow-shell-guard-lint.py --base-ref origin/develop` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell snippet detection in documentation.
  * Explicitly tagged non-shell code blocks are no longer incorrectly flagged as shell scripts.
  * Explicit shell blocks remain recognized, while untagged blocks continue to be checked for shell-like content.
* **Tests**
  * Added regression coverage for TypeScript, Python, SQL, and untagged shell snippets.
* **Documentation**
  * Updated the unreleased changelog with these improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->