### PR TITLE
fix(workflow): invocation_policy/checkpoint_policy boolean-false presence check (#1461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`render_pr_disposition`'s `invocation_policy`/`checkpoint_policy` presence
+  checks silently misclassified a boolean `false` value as absent** (#1461):
+  the same falsy-boolean defect fixed for `.why_safe_to_merge` in PR #1460
+  (#1436) — jq's `//` operator treats `false` as falsy, so
+  `(.invocation_policy // null) == null` and
+  `(.checkpoint_policy // .checkpointPolicy // null) == null` both silently
+  rendered "Not recorded." for an explicit boolean `false` value instead of
+  rejecting the wrong type. `scripts/development-workflow/run-epic-audit-trail.sh`'s
+  `render_pr_disposition()` now uses explicit `== null` presence checks plus
+  explicit `type != "object"` rejection guards for both sections, mirroring
+  the `why_safe_to_merge` pattern. Adds `boolean_invocation_policy_fixture`
+  and `boolean_checkpoint_policy_fixture` regression tests to
+  `scripts/development-workflow/tests/test-run-epic-audit-trail.sh`.
 - **`workflow-shell-snippet-lint.py` WS001 false-positives on non-shell fenced
   code blocks** (#1468): `executable = language in {"bash", "sh", "shell",
   "zsh"} or bool(SHELL_SIGNAL.search(content))` let the `SHELL_SIGNAL` content

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,19 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`render_pr_disposition`'s `invocation_policy`/`checkpoint_policy` presence
-  checks silently misclassified a boolean `false` value as absent** (#1461):
-  the same falsy-boolean defect fixed for `.why_safe_to_merge` in PR #1460
-  (#1436) — jq's `//` operator treats `false` as falsy, so
-  `(.invocation_policy // null) == null` and
-  `(.checkpoint_policy // .checkpointPolicy // null) == null` both silently
-  rendered "Not recorded." for an explicit boolean `false` value instead of
-  rejecting the wrong type. `scripts/development-workflow/run-epic-audit-trail.sh`'s
-  `render_pr_disposition()` now uses explicit `== null` presence checks plus
-  explicit `type != "object"` rejection guards for both sections, mirroring
-  the `why_safe_to_merge` pattern. Adds `boolean_invocation_policy_fixture`
-  and `boolean_checkpoint_policy_fixture` regression tests to
-  `scripts/development-workflow/tests/test-run-epic-audit-trail.sh`.
+- **`render_pr_disposition` rejects invalid invocation and checkpoint policy
+  values** (#1461): explicit null checks prevent boolean `false` values from
+  being rendered as absent. The renderer now requires policy objects, and
+  regression tests cover render and apply paths.
 - **`workflow-shell-snippet-lint.py` WS001 false-positives on non-shell fenced
   code blocks** (#1468): `executable = language in {"bash", "sh", "shell",
   "zsh"} or bool(SHELL_SIGNAL.search(content))` let the `SHELL_SIGNAL` content

--- a/scripts/development-workflow/run-epic-audit-trail.sh
+++ b/scripts/development-workflow/run-epic-audit-trail.sh
@@ -212,79 +212,95 @@ render_pr_disposition() {
       printf '%s\n' "$rendered"
     fi
     printf '\n### Invocation Policy\n\n'
-    if [ "$(printf '%s\n' "$json" | jq 'if (.invocation_policy // null) == null then 0 else 1 end')" -eq 0 ]; then
+    if [ "$(printf '%s\n' "$json" | jq 'if .invocation_policy == null then 0 else 1 end')" -eq 0 ]; then
       printf 'Not recorded.\n'
     else
       rendered="$(printf '%s\n' "$json" | jq -r '
-        (.invocation_policy // {}) as $p |
-        "- Original command: `" + (($p.original_command // $p.originalCommand // "") | tostring) + "`",
-        "- Copy-paste equivalent: `" + (($p.copy_paste_command // $p.copyPasteCommand // "") | tostring) + "`",
-        "- Confirmation: " + (($p.confirmation // $p.confirmationReason // "not recorded") | tostring)
+        if (.invocation_policy | type) != "object" then
+          error("invocation_policy must be an object")
+        else
+          .invocation_policy as $p |
+          "- Original command: `" + (($p.original_command // $p.originalCommand // "") | tostring) + "`",
+          "- Copy-paste equivalent: `" + (($p.copy_paste_command // $p.copyPasteCommand // "") | tostring) + "`",
+          "- Confirmation: " + (($p.confirmation // $p.confirmationReason // "not recorded") | tostring)
+        end
       ')" || error_exit "failed to render invocation policy detail (jq error above)"
       printf '%s\n' "$rendered"
       printf '\n| Field | Recommended | Selected | Effective |\n'
       printf '| --- | --- | --- | --- |\n'
       rendered="$(printf '%s\n' "$json" | jq -r "$table_cell_filter"'
-        (.invocation_policy // {}) as $p |
-        ($p.recommended_policy // $p.recommendedPolicy // {}) as $r |
-        ($p.selected_policy // $p.selectedPolicy // {}) as $s |
-        ($p.effective_policy // $p.effectivePolicy // {}) as $e |
-        ["mayStartBacklog", "delegateReview", "mayMerge", "maxRisk", "base"][] as $field |
-        "| " + $field +
-        " | " + (($r[$field] // "") | cell) +
-        " | " + (($s[$field] // "") | cell) +
-        " | " + (($e[$field] // "") | cell) + " |"
+        if (.invocation_policy | type) != "object" then
+          error("invocation_policy must be an object")
+        else
+          .invocation_policy as $p |
+          ($p.recommended_policy // $p.recommendedPolicy // {}) as $r |
+          ($p.selected_policy // $p.selectedPolicy // {}) as $s |
+          ($p.effective_policy // $p.effectivePolicy // {}) as $e |
+          ["mayStartBacklog", "delegateReview", "mayMerge", "maxRisk", "base"][] as $field |
+          "| " + $field +
+          " | " + (($r[$field] // "") | cell) +
+          " | " + (($s[$field] // "") | cell) +
+          " | " + (($e[$field] // "") | cell) + " |"
+        end
       ')" || error_exit "failed to render invocation policy table (jq error above)"
       printf '%s\n' "$rendered"
     fi
     printf '\n### Checkpoint Policy\n\n'
-    if [ "$(printf '%s\n' "$json" | jq 'if (.checkpoint_policy // .checkpointPolicy // null) == null then 0 else 1 end')" -eq 0 ]; then
+    if [ "$(printf '%s\n' "$json" | jq 'if (.checkpoint_policy == null) and (.checkpointPolicy == null) then 0 else 1 end')" -eq 0 ]; then
       printf 'Not recorded.\n'
     else
       rendered="$(printf '%s\n' "$json" | jq -r "$checkpoint_stage_filter"'
-        (.checkpoint_policy // .checkpointPolicy // {}) as $cp |
-        (.item.number) as $itemNum |
-        (.pr.branch // "") as $branch |
-        ((.pr.stage // "") as $stage |
-          if ($branch | length) > 0 then stage_from_branch($branch)
-          elif ($stage | length) > 0 then $stage
-          else null end) as $prStage |
-        "- Field source: " + (($cp.field_source // $cp.fieldSource // "unknown") | tostring),
-        "- Pending applicable checkpoints: " + (
-          [($cp.effective // $cp.effectivePolicy // [])[]
-            | select(
-                if $prStage == null then
-                  (.satisfaction_state == "pending" and ((.item_number | tonumber) == ($itemNum | tonumber)))
-                else
-                  checkpoint_applies(.; ($itemNum | tostring); $prStage)
-                end
-              )] | length | tostring
-        )
+        (if .checkpoint_policy != null then .checkpoint_policy else .checkpointPolicy end) as $cp |
+        if ($cp | type) != "object" then
+          error("checkpoint_policy must be an object")
+        else
+          (.item.number) as $itemNum |
+          (.pr.branch // "") as $branch |
+          ((.pr.stage // "") as $stage |
+            if ($branch | length) > 0 then stage_from_branch($branch)
+            elif ($stage | length) > 0 then $stage
+            else null end) as $prStage |
+          "- Field source: " + (($cp.field_source // $cp.fieldSource // "unknown") | tostring),
+          "- Pending applicable checkpoints: " + (
+            [($cp.effective // $cp.effectivePolicy // [])[]
+              | select(
+                  if $prStage == null then
+                    (.satisfaction_state == "pending" and ((.item_number | tonumber) == ($itemNum | tonumber)))
+                  else
+                    checkpoint_applies(.; ($itemNum | tostring); $prStage)
+                  end
+                )] | length | tostring
+          )
+        end
       ')" || error_exit "failed to render checkpoint policy detail (jq error above)"
       printf '%s\n' "$rendered"
       printf '\n| Item | Stage | Domain | State | Reason | Required action |\n'
       printf '| --- | --- | --- | --- | --- | --- |\n'
       rendered="$(printf '%s\n' "$json" | jq -r "$table_cell_filter $checkpoint_stage_filter"'
-        (.checkpoint_policy // .checkpointPolicy // {}) as $cp |
-        (.item.number) as $itemNum |
-        (.pr.branch // "") as $branch |
-        ((.pr.stage // "") as $stage |
-          if ($branch | length) > 0 then stage_from_branch($branch)
-          elif ($stage | length) > 0 then $stage
-          else null end) as $prStage |
-        ($cp.effective // $cp.effectivePolicy // [])[]
-        | select((.item_number | tonumber) == ($itemNum | tonumber))
-        | select(
-            if $prStage == null then true
-            else checkpoint_applies(.; ($itemNum | tostring); $prStage) or (.satisfaction_state // "pending") != "pending"
-            end
-          ) |
-        "| #" + (.item_number | tostring) +
-        " | " + ((.stage // "") | cell) +
-        " | " + ((.domain // "") | cell) +
-        " | " + ((.satisfaction_state // "pending") | cell) +
-        " | " + ((.reason // "") | cell) +
-        " | " + ((.required_human_action // "") | cell) + " |"
+        (if .checkpoint_policy != null then .checkpoint_policy else .checkpointPolicy end) as $cp |
+        if ($cp | type) != "object" then
+          error("checkpoint_policy must be an object")
+        else
+          (.item.number) as $itemNum |
+          (.pr.branch // "") as $branch |
+          ((.pr.stage // "") as $stage |
+            if ($branch | length) > 0 then stage_from_branch($branch)
+            elif ($stage | length) > 0 then $stage
+            else null end) as $prStage |
+          ($cp.effective // $cp.effectivePolicy // [])[]
+          | select((.item_number | tonumber) == ($itemNum | tonumber))
+          | select(
+              if $prStage == null then true
+              else checkpoint_applies(.; ($itemNum | tostring); $prStage) or (.satisfaction_state // "pending") != "pending"
+              end
+            ) |
+          "| #" + (.item_number | tostring) +
+          " | " + ((.stage // "") | cell) +
+          " | " + ((.domain // "") | cell) +
+          " | " + ((.satisfaction_state // "pending") | cell) +
+          " | " + ((.reason // "") | cell) +
+          " | " + ((.required_human_action // "") | cell) + " |"
+        end
       ')" || error_exit "failed to render checkpoint policy table (jq error above)"
       printf '%s\n' "$rendered"
     fi

--- a/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
+++ b/scripts/development-workflow/tests/test-run-epic-audit-trail.sh
@@ -315,6 +315,15 @@ jq '.why_safe_to_merge = "a-string"' "$pr_fixture" > "$wrong_typed_why_safe_to_m
 # that specific falsy-boolean edge case.
 boolean_why_safe_to_merge_fixture="$TMP_ROOT/boolean-why-safe-to-merge.json"
 jq '.why_safe_to_merge = false' "$pr_fixture" > "$boolean_why_safe_to_merge_fixture"
+# Issue #1461: the same `(.field // null) == null` falsy-boolean-`false`
+# defect fixed above for .why_safe_to_merge also existed for .invocation_policy
+# and .checkpoint_policy, which used the identical `//`-based presence check.
+# boolean_invocation_policy_fixture and boolean_checkpoint_policy_fixture
+# exercise that same falsy-boolean edge case for those two sections.
+boolean_invocation_policy_fixture="$TMP_ROOT/boolean-invocation-policy.json"
+jq '.invocation_policy = false' "$pr_fixture" > "$boolean_invocation_policy_fixture"
+boolean_checkpoint_policy_fixture="$TMP_ROOT/boolean-checkpoint-policy.json"
+jq '.checkpoint_policy = false' "$pr_fixture" > "$boolean_checkpoint_policy_fixture"
 # Same issue's complementary ask: a strict-unknown-keys warning so a future
 # unconsumed top-level key degrades loudly (a warning, not silent data loss)
 # instead of repeating this exact defect.
@@ -806,6 +815,38 @@ run_test "apply_pr_disposition_boolean_why_safe_to_merge_writes_no_comment" "$ca
 run_fails_contains "render_pr_disposition_rejects_boolean_why_safe_to_merge" \
   "failed to render why-safe-to-merge detail" \
   "$HELPER" render-pr-disposition --input "$boolean_why_safe_to_merge_fixture"
+
+echo ""
+echo "=== Planted-violation regression: invocation_policy/checkpoint_policy boolean false must not be misclassified as absent (issue #1461) ==="
+# Same falsy-boolean defect class as boolean_why_safe_to_merge above: the
+# presence checks for .invocation_policy and .checkpoint_policy previously
+# used `(.field // null) == null` / `(.checkpoint_policy // .checkpointPolicy
+# // null) == null`, both of which treat a boolean `false` value the same as
+# an absent field, silently falling back to "Not recorded." instead of
+# rejecting the wrong type. The fix replaced both with explicit `== null`
+# presence checks plus explicit `type != "object"` rejection guards.
+
+calls_before="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_fails_contains "apply_pr_disposition_rejects_boolean_invocation_policy" \
+  "failed to render invocation policy detail" \
+  "$HELPER" apply-pr-disposition --input "$boolean_invocation_policy_fixture" --pr 10
+calls_after="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_test "apply_pr_disposition_boolean_invocation_policy_writes_no_comment" "$calls_before" "$calls_after"
+
+run_fails_contains "render_pr_disposition_rejects_boolean_invocation_policy" \
+  "failed to render invocation policy detail" \
+  "$HELPER" render-pr-disposition --input "$boolean_invocation_policy_fixture"
+
+calls_before="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_fails_contains "apply_pr_disposition_rejects_boolean_checkpoint_policy" \
+  "failed to render checkpoint policy detail" \
+  "$HELPER" apply-pr-disposition --input "$boolean_checkpoint_policy_fixture" --pr 10
+calls_after="$(wc -l < "$CALL_LOG" | tr -d ' ')"
+run_test "apply_pr_disposition_boolean_checkpoint_policy_writes_no_comment" "$calls_before" "$calls_after"
+
+run_fails_contains "render_pr_disposition_rejects_boolean_checkpoint_policy" \
+  "failed to render checkpoint policy detail" \
+  "$HELPER" render-pr-disposition --input "$boolean_checkpoint_policy_fixture"
 
 echo ""
 echo "=== Summary ==="


### PR DESCRIPTION
## Summary

Fixes #1461.

Discovered during Step 7a Pass 2 code review of PR #1460 (issue #1436). PR
#1460 fixed a defect in `render_pr_disposition`'s new "Why Safe to Merge"
section where the presence check `(.why_safe_to_merge // null) == null`
treated a boolean `false` value the same as an absent field, because jq's
`//` operator treats `false` as falsy. The same `(.field // null) == null`
presence-check pattern was still used for two other optional sections in
`render_pr_disposition` (`scripts/development-workflow/run-epic-audit-trail.sh`):

- `invocation_policy` (`(.invocation_policy // null) == null`)
- `checkpoint_policy` (`(.checkpoint_policy // .checkpointPolicy // null) == null`,
  which also has to resolve two aliased field names)

A boolean `false` value for either field would silently render as "Not
recorded." instead of being rejected as the wrong type — the exact same
silent-degradation risk class as the `why_safe_to_merge` defect (and the
#1430 wrong-typed-optional-section defect before it).

## Fix

In `render_pr_disposition()`, mirroring the `why_safe_to_merge` pattern
established in PR #1460:

1. **`invocation_policy`**: presence check changed to an explicit
   `.invocation_policy == null` test. Both jq invocations that render this
   section (the "detail" call and the "table" call) now add an explicit
   `if (.invocation_policy | type) != "object" then error(...) else ... end`
   type guard.
2. **`checkpoint_policy`**: presence check changed to
   `(.checkpoint_policy == null) and (.checkpointPolicy == null)` (present if
   *either* alias is non-null, matching the existing alias convention). Both
   jq invocations now first resolve the alias with
   `(if .checkpoint_policy != null then .checkpoint_policy else .checkpointPolicy end) as $cp`,
   then add the same `type != "object"` guard before using `$cp`.
3. `why_safe_to_merge` and all other sections (`verification`,
   `protocol_deviations`, `advisories`, etc.) are untouched.
4. All existing `error_exit` wrapper messages ("failed to render invocation
   policy detail/table (jq error above)", "failed to render checkpoint
   policy detail/table (jq error above)") are unchanged — these are asserted
   by existing tests.

## Verification (planted violation)

- Added `boolean_invocation_policy_fixture` and
  `boolean_checkpoint_policy_fixture` to
  `scripts/development-workflow/tests/test-run-epic-audit-trail.sh`, mirroring
  the existing `boolean_why_safe_to_merge_fixture` convention.
- New "Planted-violation regression" test block covers both fixtures via
  both the `apply-pr-disposition` path (asserting the correct
  `failed to render ... policy detail` message and that **zero** additional
  `gh` calls were made — no partial/silent comment write) and the direct
  `render-pr-disposition` path.
- Confirmed the new tests fail without the fix (6 failures reproduced via a
  temporary stash of the script-only change) and all 111 tests pass with the
  fix applied:

```
$ bash scripts/development-workflow/tests/test-run-epic-audit-trail.sh
...
=== Summary ===
Passed: 111
Failed: 0
```

- `shellcheck --severity=warning` and
  `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
  both clean on the two modified `.sh` files.

## Scope

Only `scripts/development-workflow/run-epic-audit-trail.sh`,
`scripts/development-workflow/tests/test-run-epic-audit-trail.sh`, and
`CHANGELOG.md` were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed policy validation so explicit `false` values are no longer treated as missing.
  - Added validation for invocation and checkpoint policies, including support for recognized naming formats.
  - Invalid policy values now produce clear errors instead of being rendered or applied.
  - Prevented comments from being written when policy data is invalid.

- **Tests**
  - Added regression coverage for invalid boolean policy values in render and apply modes.

- **Documentation**
  - Documented the policy validation fixes in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->