### PR TITLE
fix(review-loop): classify Codex usage limits

### DIFF
--- a/docs/workflow/development-workflow/provider-contingency-runner-failover.md
+++ b/docs/workflow/development-workflow/provider-contingency-runner-failover.md
@@ -24,6 +24,26 @@ Related docs:
 
 **Do not:** Manually apply `ready-for-human-review` or remove `needs-fixes` without completing the reviewer loop.
 
+### Codex GitHub App Review Quota
+
+When `pr-review-loop.sh` runs the `codex-github` platform and the Codex GitHub
+App replies with a review-capacity message such as “You have reached your Codex
+usage limits for code reviews,” the loop reports:
+
+```text
+RESULT=escalate
+REASON=codex-github-usage-limit
+PLATFORM=codex-github
+COMMENT_COUNT=0
+BLOCKING_COUNT=0
+SUGGESTION_COUNT=0
+```
+
+This is reviewer unavailability, not a code-review finding. Do not dispatch a
+fixer agent and do not label the PR `needs-fixes` solely for this result. Wait
+for quota reset or add review capacity, then rerun the reviewer loop against the
+same PR head.
+
 ---
 
 ## Failure mode 2: Stream timeout or API error

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -28,6 +28,7 @@
 #   1 — NEEDS_REVISION (bot responded with blocking findings)
 #   2 — TIMED_OUT  (no bot response within max-wait; treat as unavailable under
 #                   configured internal_reviewers_unavailable_policy)
+#   3 — UNAVAILABLE (bot responded with review-capacity/quota exhaustion)
 #
 # Verdict parsing (three-path, blocking markers checked first per safe-fail):
 #   1. Blocking markers present → NEEDS_REVISION (exit 1)
@@ -226,6 +227,23 @@ codex_inline_review_comment_count_since() {
     return 3
   fi
   rm -f "$review_comment_tmpfile"
+}
+
+codex_response_is_usage_limit() {
+  local response="$1"
+  printf '%s\n' "$response" | grep -qiE "(reached[[:space:]]+your[[:space:]]+codex[[:space:]]+usage[[:space:]]+limits?|usage[[:space:]]+limits?[[:space:]]+for[[:space:]]+code[[:space:]]+reviews?|codex[[:space:]]+(review[[:space:]]+)?(usage[[:space:]]+limit|quota|capacity)|review[[:space:]]+capacity[[:space:]]+(exhausted|unavailable|limited)|quota[[:space:]]+(exceeded|exhausted|limit))"
+}
+
+codex_return_usage_limit() {
+  echo "VERDICT: UNAVAILABLE — Codex GitHub review usage limit reached"
+  echo "REASON=codex-github-usage-limit"
+  echo "COMMENT_COUNT=0"
+  echo "BLOCKING_COUNT=0"
+  echo "SUGGESTION_COUNT=0"
+  echo "---BEGIN BOT RESPONSE---"
+  echo "$1"
+  echo "---END BOT RESPONSE---"
+  exit 3
 }
 
 # ── Idempotency guard (BR-10) ─────────────────────────────────────────────────
@@ -433,7 +451,9 @@ while true; do
     # "no blocking issues". This avoids false positives without line-level filtering
     # (which would risk missing a genuine marker on the same line as a negation).
 
-    if echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+    if codex_response_is_usage_limit "$BOT_RESPONSE"; then
+      codex_return_usage_limit "$BOT_RESPONSE"
+    elif echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
       echo "VERDICT: NEEDS_REVISION"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
@@ -585,7 +605,9 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
   echo "INFO: async-arrival bot response detected during grace period"
 
   # Apply the same three-path verdict parsing as the main poll loop.
-  if echo "$ASYNC_BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+  if codex_response_is_usage_limit "$ASYNC_BOT_RESPONSE"; then
+    codex_return_usage_limit "$ASYNC_BOT_RESPONSE"
+  elif echo "$ASYNC_BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
     echo "VERDICT: NEEDS_REVISION"
     echo "---BEGIN BOT RESPONSE---"
     echo "$ASYNC_BOT_RESPONSE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -231,7 +231,7 @@ codex_inline_review_comment_count_since() {
 
 codex_response_is_usage_limit() {
   local response="$1"
-  printf '%s\n' "$response" | grep -qiE "(reached[[:space:]]+your[[:space:]]+codex[[:space:]]+usage[[:space:]]+limits?|usage[[:space:]]+limits?[[:space:]]+for[[:space:]]+code[[:space:]]+reviews?|codex[[:space:]]+(review[[:space:]]+)?(usage[[:space:]]+limit|quota|capacity)|review[[:space:]]+capacity[[:space:]]+(exhausted|unavailable|limited)|quota[[:space:]]+(exceeded|exhausted|limit))"
+  printf '%s\n' "$response" | grep -qiE "(reached[[:space:]]+your[[:space:]]+codex[[:space:]]+usage[[:space:]]+limits?|codex[[:space:]]+usage[[:space:]]+limits?[[:space:]]+for[[:space:]]+code[[:space:]]+reviews?|codex[[:space:]]+(github[[:space:]]+app[[:space:]]+)?(review[[:space:]]+)?(usage[[:space:]]+limit|quota|capacity)|codex[[:space:]]+review[[:space:]]+capacity[[:space:]]+(exhausted|unavailable|limited))"
 }
 
 codex_return_usage_limit() {

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -745,6 +745,7 @@ run_codex_github_review() {
   local repo
   local reviewer_script
   local script_exit=0
+  local script_output=""
   local thread_check_output=""
   local thread_check_status=0
   local unresolved_count=0
@@ -805,11 +806,11 @@ run_codex_github_review() {
     effective_poll_interval="$max_wait"
   fi
   set +e
-  "$reviewer_script" "$pr_number" "$owner" "$repo_name" \
+  script_output="$("$reviewer_script" "$pr_number" "$owner" "$repo_name" \
     --bot-login "$bot_login" \
     --poll-interval "$effective_poll_interval" \
     --max-wait "$max_wait" \
-    --max-retriggers "$max_retriggers" >/dev/null 2>&1
+    --max-retriggers "$max_retriggers" 2>&1)"
   script_exit=$?
   set -e
 
@@ -847,13 +848,30 @@ run_codex_github_review() {
       print_kv SUGGESTION_COUNT 0
       return 1
       ;;
-    *)
+    3)
       print_kv RESULT escalate
-      print_kv REASON timeout
+      print_kv REASON codex-github-usage-limit
       print_kv PLATFORM "$platform"
       print_kv PR_NUMBER "$pr_number"
       print_kv BRANCH "$branch_name"
       print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv COMMENT_COUNT 0
+      print_kv BLOCKING_COUNT 0
+      print_kv SUGGESTION_COUNT 0
+      return 2
+      ;;
+    *)
+      local codex_reason
+      codex_reason="$(kv_value_default REASON "$script_output" timeout)"
+      print_kv RESULT escalate
+      print_kv REASON "$codex_reason"
+      print_kv PLATFORM "$platform"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv BRANCH "$branch_name"
+      print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv COMMENT_COUNT 0
+      print_kv BLOCKING_COUNT 0
+      print_kv SUGGESTION_COUNT 0
       return 2
       ;;
   esac

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2310,6 +2310,12 @@ _codex_usage_comment_output="$(cat "$_codex_usage_comment_mock_dir/output.txt")"
 run_test "codex_usage_limit_comment_exit_unavailable" "3" "$_codex_usage_comment_exit"
 run_test "codex_usage_limit_comment_reason" "REASON=codex-github-usage-limit" \
   "$(printf '%s\n' "$_codex_usage_comment_output" | grep "^REASON=")"
+run_test "codex_usage_limit_comment_comment_count" "COMMENT_COUNT=0" \
+  "$(printf '%s\n' "$_codex_usage_comment_output" | grep "^COMMENT_COUNT=")"
+run_test "codex_usage_limit_comment_blocking_count" "BLOCKING_COUNT=0" \
+  "$(printf '%s\n' "$_codex_usage_comment_output" | grep "^BLOCKING_COUNT=")"
+run_test "codex_usage_limit_comment_suggestion_count" "SUGGESTION_COUNT=0" \
+  "$(printf '%s\n' "$_codex_usage_comment_output" | grep "^SUGGESTION_COUNT=")"
 rm -rf "$_codex_usage_comment_mock_dir"
 unset _codex_usage_comment_mock_dir _codex_usage_comment_output _codex_usage_comment_exit
 
@@ -2348,6 +2354,12 @@ _codex_usage_review_output="$(cat "$_codex_usage_review_mock_dir/output.txt")"
 run_test "codex_usage_limit_review_exit_unavailable" "3" "$_codex_usage_review_exit"
 run_test "codex_usage_limit_review_reason" "REASON=codex-github-usage-limit" \
   "$(printf '%s\n' "$_codex_usage_review_output" | grep "^REASON=")"
+run_test "codex_usage_limit_review_comment_count" "COMMENT_COUNT=0" \
+  "$(printf '%s\n' "$_codex_usage_review_output" | grep "^COMMENT_COUNT=")"
+run_test "codex_usage_limit_review_blocking_count" "BLOCKING_COUNT=0" \
+  "$(printf '%s\n' "$_codex_usage_review_output" | grep "^BLOCKING_COUNT=")"
+run_test "codex_usage_limit_review_suggestion_count" "SUGGESTION_COUNT=0" \
+  "$(printf '%s\n' "$_codex_usage_review_output" | grep "^SUGGESTION_COUNT=")"
 rm -rf "$_codex_usage_review_mock_dir"
 unset _codex_usage_review_mock_dir _codex_usage_review_output _codex_usage_review_exit
 
@@ -2439,8 +2451,14 @@ run_test "codex_usage_limit_loop_result" "RESULT=escalate" \
   "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
 run_test "codex_usage_limit_loop_reason" "REASON=codex-github-usage-limit" \
   "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+run_test "codex_usage_limit_loop_platform" "PLATFORM=codex-github" \
+  "$(printf '%s\n' "$actual_output" | grep "^PLATFORM=")"
+run_test "codex_usage_limit_loop_comment_zero" "COMMENT_COUNT=0" \
+  "$(printf '%s\n' "$actual_output" | grep "^COMMENT_COUNT=")"
 run_test "codex_usage_limit_loop_blocking_zero" "BLOCKING_COUNT=0" \
   "$(printf '%s\n' "$actual_output" | grep "^BLOCKING_COUNT=")"
+run_test "codex_usage_limit_loop_suggestion_zero" "SUGGESTION_COUNT=0" \
+  "$(printf '%s\n' "$actual_output" | grep "^SUGGESTION_COUNT=")"
 run_test "codex_usage_limit_loop_exit_code" "2" "$actual_exit"
 rm -rf "$_codex_usage_loop_tmp"
 unset _codex_usage_loop_tmp _codex_overrides actual_output actual_exit

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2275,6 +2275,82 @@ run_test "codex_trigger_idempotency_paginated_single_object" "1" \
   "$(printf '%s\n' "$_codex_paginated_selected_trigger" | wc -l | tr -d ' ')"
 unset _codex_trigger_comments _codex_selected_trigger _codex_paginated_trigger_comments _codex_paginated_selected_trigger
 
+_codex_usage_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_usage_comment_mock_dir/gh" <<'CODEX_USAGE_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcusage1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":101,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":201,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"You have reached your Codex usage limits for code reviews."}]\n'
+    exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+CODEX_USAGE_COMMENT_GH
+chmod +x "$_codex_usage_comment_mock_dir/gh"
+
+_codex_usage_comment_output=""
+_codex_usage_comment_exit=0
+PATH="$_codex_usage_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_usage_comment_mock_dir/output.txt" 2>&1 || _codex_usage_comment_exit=$?
+_codex_usage_comment_output="$(cat "$_codex_usage_comment_mock_dir/output.txt")"
+run_test "codex_usage_limit_comment_exit_unavailable" "3" "$_codex_usage_comment_exit"
+run_test "codex_usage_limit_comment_reason" "REASON=codex-github-usage-limit" \
+  "$(printf '%s\n' "$_codex_usage_comment_output" | grep "^REASON=")"
+rm -rf "$_codex_usage_comment_mock_dir"
+unset _codex_usage_comment_mock_dir _codex_usage_comment_output _codex_usage_comment_exit
+
+_codex_usage_review_mock_dir="$(mktemp -d)"
+cat > "$_codex_usage_review_mock_dir/gh" <<'CODEX_USAGE_REVIEW_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcreview1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":102,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex review capacity exhausted. Please rerun after quota reset."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+CODEX_USAGE_REVIEW_GH
+chmod +x "$_codex_usage_review_mock_dir/gh"
+
+_codex_usage_review_output=""
+_codex_usage_review_exit=0
+PATH="$_codex_usage_review_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_usage_review_mock_dir/output.txt" 2>&1 || _codex_usage_review_exit=$?
+_codex_usage_review_output="$(cat "$_codex_usage_review_mock_dir/output.txt")"
+run_test "codex_usage_limit_review_exit_unavailable" "3" "$_codex_usage_review_exit"
+run_test "codex_usage_limit_review_reason" "REASON=codex-github-usage-limit" \
+  "$(printf '%s\n' "$_codex_usage_review_output" | grep "^REASON=")"
+rm -rf "$_codex_usage_review_mock_dir"
+unset _codex_usage_review_mock_dir _codex_usage_review_output _codex_usage_review_exit
+
 _unlock_pr="80213$$"
 _unlock_lock_dir="/tmp/pr-review-loop-${_unlock_pr}.lockdir"
 rm -rf "$_unlock_lock_dir"
@@ -2330,6 +2406,44 @@ run_test "codex_thread_check_failure_reason" "REASON=thread-check-failed" \
   "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
 run_test "codex_thread_check_failure_exit_code" "2" "$actual_exit"
 unset _codex_overrides actual_output actual_exit
+
+_codex_usage_loop_tmp="$(mktemp -d)"
+mkdir -p "$_codex_usage_loop_tmp/scripts/development-workflow"
+cat > "$_codex_usage_loop_tmp/scripts/development-workflow/codex-github-reviewer.sh" <<'CODEX_USAGE_LOOP_REVIEWER'
+#!/usr/bin/env bash
+printf 'VERDICT: UNAVAILABLE — Codex GitHub review usage limit reached\n'
+printf 'REASON=codex-github-usage-limit\n'
+printf 'COMMENT_COUNT=0\n'
+printf 'BLOCKING_COUNT=0\n'
+printf 'SUGGESTION_COUNT=0\n'
+exit 3
+CODEX_USAGE_LOOP_REVIEWER
+chmod +x "$_codex_usage_loop_tmp/scripts/development-workflow/codex-github-reviewer.sh"
+_codex_overrides='
+  cd_workflow_repo_root() { :; }
+  repo_slug() { printf "owner/repo\n"; }
+  require_gh() { :; }
+  workflow_repo_root() { printf "%s\n" "$_codex_usage_loop_tmp"; }
+  check_unresolved_threads() { printf "0\n"; return 0; }
+'
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_codex_overrides"
+  _ec=0
+  run_codex_github_review "42" "fix/42-test" "1" "5" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "codex_usage_limit_loop_result" "RESULT=escalate" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "codex_usage_limit_loop_reason" "REASON=codex-github-usage-limit" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+run_test "codex_usage_limit_loop_blocking_zero" "BLOCKING_COUNT=0" \
+  "$(printf '%s\n' "$actual_output" | grep "^BLOCKING_COUNT=")"
+run_test "codex_usage_limit_loop_exit_code" "2" "$actual_exit"
+rm -rf "$_codex_usage_loop_tmp"
+unset _codex_usage_loop_tmp _codex_overrides actual_output actual_exit
 
 _post_summary_source="$(awk '/^_post_review_summary\(\)/,/^}$/' \
   "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2310,6 +2310,9 @@ PATH="$_codex_usage_comment_mock_dir:$PATH" \
   >"$_codex_usage_comment_mock_dir/output.txt" 2>&1 || _codex_usage_comment_exit=$?
 _codex_usage_comment_output="$(cat "$_codex_usage_comment_mock_dir/output.txt")"
 run_test "codex_usage_limit_comment_exit_unavailable" "3" "$_codex_usage_comment_exit"
+run_test "codex_usage_limit_comment_verdict" \
+  "VERDICT: UNAVAILABLE — Codex GitHub review usage limit reached" \
+  "$(printf '%s\n' "$_codex_usage_comment_output" | grep "^VERDICT:")"
 run_test "codex_usage_limit_comment_reason" "REASON=codex-github-usage-limit" \
   "$(printf '%s\n' "$_codex_usage_comment_output" | grep "^REASON=")"
 run_test "codex_usage_limit_comment_comment_count" "COMMENT_COUNT=0" \
@@ -2356,6 +2359,9 @@ PATH="$_codex_usage_review_mock_dir:$PATH" \
   >"$_codex_usage_review_mock_dir/output.txt" 2>&1 || _codex_usage_review_exit=$?
 _codex_usage_review_output="$(cat "$_codex_usage_review_mock_dir/output.txt")"
 run_test "codex_usage_limit_review_exit_unavailable" "3" "$_codex_usage_review_exit"
+run_test "codex_usage_limit_review_verdict" \
+  "VERDICT: UNAVAILABLE — Codex GitHub review usage limit reached" \
+  "$(printf '%s\n' "$_codex_usage_review_output" | grep "^VERDICT:")"
 run_test "codex_usage_limit_review_reason" "REASON=codex-github-usage-limit" \
   "$(printf '%s\n' "$_codex_usage_review_output" | grep "^REASON=")"
 run_test "codex_usage_limit_review_comment_count" "COMMENT_COUNT=0" \

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2295,7 +2295,9 @@ case "$*" in
     printf '[{"id":201,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"You have reached your Codex usage limits for code reviews."}]\n'
     exit 0 ;;
   *)
-    printf '[]\n'; exit 0 ;;
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
 esac
 CODEX_USAGE_COMMENT_GH
 chmod +x "$_codex_usage_comment_mock_dir/gh"
@@ -2339,7 +2341,9 @@ case "$*" in
   *"issues/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
   *)
-    printf '[]\n'; exit 0 ;;
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
 esac
 CODEX_USAGE_REVIEW_GH
 chmod +x "$_codex_usage_review_mock_dir/gh"


### PR DESCRIPTION
## Summary

- classify Codex GitHub App usage-limit and review-capacity responses as reviewer unavailable
- map that condition through pr-review-loop as RESULT=escalate / REASON=codex-github-usage-limit with zero finding counts
- add regression coverage for PR comment and PR review-body responses, plus loop-level mapping
- document the operator action: wait for quota reset or add capacity, then rerun the same-head reviewer loop

## Verification

- bash -n scripts/development-workflow/codex-github-reviewer.sh scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-pr-review-loop.sh
- bash scripts/development-workflow/tests/test-pr-review-loop.sh
- git diff --check
- npx markdownlint-cli2 docs/workflow/development-workflow/provider-contingency-runner-failover.md

Closes #1476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Review workflows now detect when automated review capacity or quota is unavailable.
  - Reports reviewer unavailability without dispatching fixes or marking changes as needing fixes.
  - Preserves pull request state for retry after capacity is restored.

- **Documentation**
  - Added guidance for handling automated reviewer quota exhaustion.

- **Tests**
  - Added coverage for usage-limit detection, unavailable-review reporting, and escalation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->