### PR TITLE
test(workflow): validate timeout mock helper argument

### DIFF
--- a/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
@@ -23,7 +23,15 @@ cat > "$MOCK_BIN/gh" <<'MOCK_GH'
 printf '%s\n' "$*" >> "$MOCK_GH_CALL_LOG"
 
 mock_sleep_if_requested() {
-  local var_name="$1"
+  local var_name="${1-}"
+  case "$var_name" in
+    [a-zA-Z_][a-zA-Z0-9_]*)
+      ;;
+    *)
+      printf 'ERROR: mock_sleep_if_requested requires an environment variable name\n' >&2
+      exit 64
+      ;;
+  esac
   local value="${!var_name:-0}"
 
   case "$value" in


### PR DESCRIPTION
## Summary

- follow up on late CodeRabbit finding from PR #1479
- validate mock_sleep_if_requested argument before indirect expansion
- emit structured ERROR output for missing or invalid variable names

## Validation

- bash -n scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
- shellcheck -x -S warning scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
- bash scripts/development-workflow/tests/test-run-epic-delegated-gate.sh

Follow-up for #1474.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional workflow timing parameters.
  * Invalid environment-variable names now produce a clear error and appropriate failure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->