### PR TITLE
fix(review-loop): require Codex current-head evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-clean type (e.g. a usage-limit response) instead of the scan
   stopping at whichever "requires attention" response was returned first,
   so a usage-limit review returned before a tied blocking review no longer
-  silently discards the blocker.
+  silently discards the blocker; and the shared terminal-evidence tie-break
+  (used for terminal-comment-vs-review and terminal-comment-vs-terminal-
+  comment ties) now checks blocking before the binary requires-attention
+  distinction, so two tied responses that are both "requires attention"
+  (e.g. a usage-limit root comment and a blocking submitted review, or two
+  tied root comments) no longer keep whichever was evaluated first when
+  one side is strictly more severe.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -549,7 +549,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   written to fix for approval only — a clean response like "This is not
   only safe to merge but looks good" was misread as a merge refusal.
   `codex_response_is_blocking` now applies that same idiom-stripping
-  normalization before matching.
+  normalization before matching. A fourth consecutive missing-negation-word
+  finding (`wouldn't`) prompted a proactive sweep of the remaining common
+  English negation forms in one pass — `was/wasn't`, `were/weren't`,
+  `would/wouldn't`, `has/hasn't`, `have/haven't`, `had/hadn't` (contracted
+  and space-separated) are now all included in `CODEX_NEGATION_WORDS`,
+  rather than continuing to fix them one synonym at a time. `did not`/
+  `didn't` is deliberately excluded from this sweep despite being an
+  equally common form: it already appears baked into
+  `CODEX_NEGATED_APPROVAL_TARGET_WORDS` as part of the atomic phrase
+  "didn't find any major issues" (itself a clean signal). Adding bare
+  `didn't` as a general negation word was verified during development to
+  introduce a genuine false positive — a doubly-reinforced clean response
+  ("Codex didn't find any major issues and looks good.") would misclassify
+  as `NEEDS_REVISION` because "didn't" matches as a bare negation and
+  reaches the separate "looks good" target later in the same unpunctuated
+  sentence — caught and reverted before being committed. A regression test
+  guards against this specific gap being silently reintroduced later.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,7 +162,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an environment-setup error — it does not: unlike an environment-setup
   error, a usage-limit notice terminates the invocation immediately upon
   detection rather than being retained through the rest of the poll
-  window for a later, strictly newer review to potentially supersede.
+  window for a later, strictly newer review to potentially supersede;
+  `CODEX_NEGATED_APPROVAL_PATTERN`'s target alternation now also covers
+  "no blocking issues"/"didn't find any major issues", not just
+  "approved"/"lgtm"/"looks good" — those are approval signals in
+  `CODEX_APPROVAL_PATTERN` too, but were left unguarded, so a
+  hedged/uncertain response like "I cannot confirm there are no blocking
+  issues" still matched "no blocking issues" and was classified APPROVED;
+  and `codex_response_is_usage_limit`'s second alternative ("codex usage
+  limits for code reviews") had the exact same unguarded-mention gap as
+  the third alternative fixed in the same round — missed in that first
+  pass since only the third alternative was narrowed then — so a clean
+  review discussing the phrase in a docs context was itself misclassified
+  as a usage-limit notice; it now requires an exhaustion word after "code
+  reviews" too.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The classification helpers (`codex_response_is_blocking` and friends)
   now match via a here-string instead of a piped `printf`, since
   classifying the untruncated response means `grep -q`'s early-exit
-  behavior on a long input could otherwise SIGPIPE the writer.
+  behavior on a long input could otherwise SIGPIPE the writer; and the
+  four reviews-endpoint jq queries (main poll, async-arrival, async-final,
+  async-reaction-final) no longer slice a submitted review's body to
+  5000 characters inside the query itself — that upstream truncation
+  fed directly into the "full, untruncated response" classification path
+  described above, so a submitted review with an approval phrase before
+  the 5000-char query cutoff and a blocking marker after it was still
+  misclassified as APPROVED even with the shell-level fix in place (the
+  slice is dropped entirely; GitHub review bodies are capped well below
+  any size that would make this unsafe, and the query already writes to
+  a temp file rather than a piped consumer, so there is no SIGPIPE risk).
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,12 +131,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unrecognized-format tier, so a setup-error comment tied at the same
   timestamp as a genuine but unrecognized-format review can no longer win
   the tie-break and replace the review's safe-fail NEEDS_REVISION with an
-  UNAVAILABLE-style `codex-github-environment-missing` verdict; and
+  UNAVAILABLE-style `codex-github-environment-missing` verdict;
   `CODEX_APPROVAL_PATTERN`'s positive alternatives now require `\b` word
   boundaries, since the negated-approval fix above only catches
   SPACE-separated negations ("not approved") — a CONCATENATED negation
   prefix like "unapproved" or "disapproved" still matched the bare
-  "approved" substring and was reported as APPROVED.
+  "approved" substring and was reported as APPROVED; and
+  `CODEX_NEGATED_APPROVAL_PATTERN` now tolerates optional Markdown
+  emphasis markers between the negation and approval words, since GitHub's
+  rendered bold (e.g. "This change is **not** approved") has `**` wedged
+  directly between "not" and the following space in the raw comment body,
+  which broke the pattern's original unbroken-whitespace adjacency
+  requirement and let the negation go undetected.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,7 +175,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pass since only the third alternative was narrowed then — so a clean
   review discussing the phrase in a docs context was itself misclassified
   as a usage-limit notice; it now requires an exhaustion word after "code
-  reviews" too.
+  reviews" too; and `CODEX_NEGATED_APPROVAL_PATTERN`'s bounded `{0,3}`
+  filler-word window (added to handle "not YET approved") was itself
+  proven insufficient — a response with 5 intervening words between the
+  negation and approval word exceeded the bound and was still classified
+  APPROVED. Replaced with an unbounded same-sentence scope (`[^.!?]*`
+  between the negation and approval words): this closes the whole class
+  of "negation not immediately adjacent to approval word" gap at once
+  (this was the fourth round of narrowly-scoped fixes to this same
+  pattern — space-separated, concatenated-prefix, Markdown-wrapped,
+  bounded-window — each of which Codex found the next edge of), while a
+  sentence terminator between them still correctly prevents an unrelated
+  later sentence's approval phrase from being treated as negated by an
+  earlier sentence's negation word. Also corrected the same *retention*
+  vs *priority* rule ambiguity as the integrations-doc fix above in
+  `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`,
+  which had not yet been updated when the integrations doc was fixed.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   comment and a submitted review now resolve in favor of blocking evidence
   regardless of which side supplied it; the terminal root comment is selected
   independently of the latest (possibly non-terminal) root comment so a later
-  acknowledgement can no longer discard an earlier blocking one; and a failed
+  acknowledgement can no longer discard an earlier blocking one; a failed
   root-comments fetch during the async grace period, the post-acknowledgement
   re-poll, and the post-reaction re-poll now fails closed (`TIMED_OUT`)
-  instead of silently falling through to a clean submitted review.
+  instead of silently falling through to a clean submitted review; and the
+  final acknowledgement re-poll now preserves a recorded environment-setup
+  error over a thumbs-up reaction, matching the post-reaction re-poll's
+  existing behavior.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,7 +298,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in an otherwise clean review (e.g. "No blocking issues found. The
   tests correctly cover the `must fix` marker.") still matched
   `CODEX_BLOCKING_PATTERN` and returned `NEEDS_REVISION` for an
-  actually-clean review.
+  actually-clean review. `codex_strip_quoted_spans` now also strips
+  single-quoted spans (`'...'`) — the fourth quoting style found
+  unprotected after straight-quote, backtick, and blockquote. Single
+  quotes needed a stricter boundary than the other three styles: a bare
+  `'[^']*'` would also match the span between two unrelated apostrophes
+  in contractions (e.g. "isn't approved, but it's fine" would have its
+  "approved" deleted by a naive strip treating those two apostrophes as
+  an opening/closing pair), so the opening quote must be preceded by
+  whitespace-or-start-of-line and the closing quote by whitespace or
+  punctuation, which a contraction's word-internal apostrophe never
+  satisfies.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no longer resolve to a silent `APPROVED` — the setup error is retained
   unless the review is itself strictly newer; and an environment-setup-error
   comment is no longer silently discarded by a later plain acknowledgement
-  observed in the same comments fetch.
+  observed in the same comments fetch; a clean SHA-pinned terminal root
+  comment and a strictly newer environment-setup-error comment in the same
+  fetch no longer resolve to a silent `APPROVED` — environment-error
+  checking is now a final, independent step applied to whichever of
+  (terminal comment, review) won, instead of only being reachable from the
+  review-vs-ancillary-comment branch; and root-comment-sourced bodies (not
+  truncated at scan time, unlike review bodies) are now also truncated via
+  `jq -Rrs` instead of a piped `head`, closing the same `SIGPIPE` crash path
+  for a root comment body large enough to exceed a pipe buffer.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,7 +190,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   earlier sentence's negation word. Also corrected the same *retention*
   vs *priority* rule ambiguity as the integrations-doc fix above in
   `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`,
-  which had not yet been updated when the integrations doc was fixed.
+  which had not yet been updated when the integrations doc was fixed. Two
+  more negation gaps surfaced once the pattern was unbounded: the target
+  alternation had "approved" but not the bare verb "approve", and the
+  pattern only checked negation-THEN-approval order, so an approval
+  phrase appearing BEFORE the negation in the same sentence (e.g. "This
+  looks good at first glance, but I cannot approve this change") wasn't
+  caught. Both alternation orders are now checked, and the target list
+  includes the bare verb. Separately, `codex_scan_comment_evidence` now
+  tracks `COMMENT_LATEST_IS_TERMINAL` (whether the "latest ancillary
+  comment" is actually the SHA-pinned terminal comment itself, not a
+  genuinely separate one): when a clean terminal review's own finding
+  text happened to quote the environment-setup message or usage-limit
+  wording, `codex_combine_terminal_evidence`'s ancillary-override check
+  re-classified that SAME terminal comment as a genuinely separate
+  ancillary setup failure, downgrading APPROVED to
+  `codex-github-environment-missing` — a case the existing "terminal
+  comment never routed through the environment-error classifier"
+  guarantee did not cover, since it only applied to the terminal-vs-review
+  combine path, not this separate ancillary-override check.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Codex GitHub terminal evidence**: `codex-github-reviewer.sh` no longer
+  treats a thumbs-up reaction on the trigger comment as a clean review result,
+  ignores submitted Codex reviews that are not pinned to the current PR head,
+  and reports missing Codex cloud environments as unavailable instead of clean.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   first tie-break as reviews; and blocking is now checked before
   usage-limit in every verdict path, so a blocking finding whose text
   happens to mention "usage limit" is no longer misrouted to an
-  unavailable verdict.
+  unavailable verdict; and a bodyless submitted review tied with a clean
+  SHA-pinned terminal comment is no longer treated as absent — presence is
+  now checked via the review's timestamp (always set for a genuine review)
+  instead of its body, so an empty body still participates in the
+  not-a-clean-approval-first tie-break instead of silently losing to a
+  clean terminal comment.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -390,6 +390,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no longer bails out on fence markers — it keeps only its existing
   `codex_strip_quoted_spans` normalization, since a blocking false
   positive on quoted/fenced text is safe on its own.
+- **Codex GitHub reviewer now consults GitHub's structured review `state`
+  field**: `codex-github-reviewer.sh` relied entirely on free-text body
+  parsing (`codex_response_is_blocking`/`codex_response_is_approved`) to
+  classify a submitted review, even though the reviews-endpoint response
+  carries GitHub's own authoritative `state`
+  (`APPROVED`/`CHANGES_REQUESTED`/`COMMENTED`/`PENDING`/`DISMISSED`)
+  directly. A review with state `CHANGES_REQUESTED` but a clean-sounding
+  or ambiguous body (e.g. "Looks good overall, but see the note below.")
+  fell through to the unrecognized-format safe-fail — or, worse, could
+  match `CODEX_APPROVAL_PATTERN` outright and return `APPROVED` — instead
+  of being recognized as blocking on GitHub's own signal. All four
+  reviews-endpoint `jq` queries (main poll, async-arrival, async-final,
+  async-reaction-final) now also extract `state`; `codex_select_review_
+  evidence` tracks it as `SELECTED_REVIEW_STATE` alongside the tied
+  review's body/timestamp; `codex_combine_terminal_evidence` threads it
+  through as a new `review_state` parameter and exposes
+  `COMBINED_REVIEW_STATE`, set only when an actual submitted review (not
+  a SHA-pinned terminal comment, which has no review state) is the
+  winning evidence. Every verdict-parsing call site now short-circuits to
+  blocking when the winning review's state is `CHANGES_REQUESTED`, ahead
+  of free-text classification; the two "blocking terminal/review evidence
+  always wins outright" checks inside `codex_combine_terminal_evidence`
+  (guarding against a same-fetch usage-limit notice or environment-setup
+  error silently overriding a real blocker) now also treat a
+  `CHANGES_REQUESTED` state as blocking, not just a free-text match.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   distinction, so two tied responses that are both "requires attention"
   (e.g. a usage-limit root comment and a blocking submitted review, or two
   tied root comments) no longer keep whichever was evaluated first when
-  one side is strictly more severe.
+  one side is strictly more severe; and a usage-limit response that ALSO
+  contains an approval phrase (e.g. "No blocking issues could be evaluated
+  because you have reached your Codex usage limits") is no longer
+  misclassified as a clean approval by the tie-break — the requires-
+  attention classifier now checks usage-limit alongside blocking before
+  falling back to the approval check.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   input before classifying (a source gate isn't used here, unlike the
   already-safe environment-error check, since a genuine usage-limit
   notice can legitimately arrive via the reviews endpoint too).
+  `codex_response_is_approved` now also strips the "not only X" idiom
+  before running the negation check: "Not only X, (but) Y" is an
+  affirmative intensifier construction (both X and Y are being asserted,
+  not negated), not a negation of X, so `CODEX_NEGATION_WORDS`' bare
+  "not" alternative — which has no way to distinguish this idiom from a
+  genuine negation — misclassified "Not only does this look good, it is
+  approved" as negated even though both phrases are affirmative.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Codex GitHub terminal evidence**: `codex-github-reviewer.sh` no longer
   treats a thumbs-up reaction on the trigger comment as a clean review result,
   ignores submitted Codex reviews that are not pinned to the current PR head,
-  rejects root PR comments as clean evidence because they are not SHA-pinned, and
-  reports missing Codex cloud environments as unavailable instead of clean.
+  accepts only root PR comments that include a current-head `Reviewed commit`
+  marker as terminal evidence, and reports missing Codex cloud environments as
+  unavailable instead of clean.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,7 +147,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   qualifier words between the negation and approval words (e.g. "This
   change is not **yet** approved"), generalizing past the specific
   adjacency assumptions of the three prior negation fixes above instead
-  of special-casing yet another interrupting-word pattern.
+  of special-casing yet another interrupting-word pattern; and
+  `codex_response_is_usage_limit`'s broad "codex ... usage limit/quota/
+  capacity" alternative now requires an accompanying exhaustion/
+  unavailability word directly after the noun, since it previously matched
+  ANY mention of those words — a clean submitted review merely discussing
+  this PR's own usage-limit-detection code (e.g. "No blocking issues
+  found. The Codex usage limit handling looks correct.") was itself
+  misclassified as a usage-limit notice, winning a same-timestamp tie
+  against a genuinely clean terminal comment and returning UNAVAILABLE
+  instead of APPROVED for an actually-clean PR. Also corrected
+  `docs/workflow/development-workflow/integrations/codex-github.md`,
+  which claimed a usage-limit notice follows the same *retention* rule as
+  an environment-setup error — it does not: unlike an environment-setup
+  error, a usage-limit notice terminates the invocation immediately upon
+  detection rather than being retained through the rest of the poll
+  window for a later, strictly newer review to potentially supersede.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,7 +237,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   setup-error body silently replace the quota body. `codex_scan_comment_
   evidence` now tracks whether the currently-held ancillary comment is
   specifically a usage-limit notice, and once one is tracked, only
-  another usage-limit notice may replace it.
+  another usage-limit notice may replace it. `codex_response_is_approved`
+  now strips quoted spans (text between a pair of straight double-quotes)
+  before matching `CODEX_APPROVAL_PATTERN`, since a SHA-pinned review can
+  quote a clean phrase while rejecting it (e.g. `The documented bot
+  response "No blocking issues found" is inaccurate`) and the pattern's
+  substring match couldn't distinguish quotation/discussion of a phrase
+  from an assertion of it. Separately, `CODEX_NEGATED_APPROVAL_PATTERN`'s
+  `[^.!?]*` span only excluded sentence terminators, not clause
+  separators, so an unrelated negation in an earlier semicolon-joined
+  clause of the same sentence (e.g. "Tests are not required for this
+  documentation-only change; looks good") still spanned into a later,
+  unrelated clean clause; the character class now also excludes `;`.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   review-vs-ancillary-comment branch; and root-comment-sourced bodies (not
   truncated at scan time, unlike review bodies) are now also truncated via
   `jq -Rrs` instead of a piped `head`, closing the same `SIGPIPE` crash path
-  for a root comment body large enough to exceed a pipe buffer.
+  for a root comment body large enough to exceed a pipe buffer; a blocking
+  SHA-pinned terminal or review finding is no longer discarded by a
+  same-or-newer environment-setup-error comment — blocking evidence now
+  always wins outright, regardless of timing; and a SHA-pinned terminal
+  comment is no longer misclassified as an environment-setup error when its
+  finding text happens to quote the setup sentence verbatim (e.g. flagging
+  stale documentation) — terminal evidence is never routed through the
+  environment-error classifier.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -486,6 +486,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   return `APPROVED`. Backtick-pair stripping now runs on the same
   newline-flattened body as the double-/single-quote passes, alongside
   them, instead of as a separate line-oriented pass afterward.
+- **Codex GitHub reviewer recognizes "don't approve" and multi-backtick
+  code spans**: `CODEX_NEGATION_WORDS` was missing "don't"/"do not"
+  entirely — only the third-person singular form ("does not"/"doesn't")
+  was covered — so a response like "This looks good at first glance, but
+  I don't approve this change." had the earlier positive phrase win and
+  returned `APPROVED` instead of falling through to the negated-approval
+  check; "don't"/"do not" is now included alongside every other verb's
+  contracted and space-separated forms. Separately,
+  `codex_strip_quoted_spans`' backtick-pair regex (`` `[^`]*` ``)
+  mishandled CommonMark's actual code-span delimiter-run matching: a code
+  span can be delimited by a run of 2+ backticks, not just a single pair,
+  and the naive regex treated an adjacent 2-backtick run as two separate
+  EMPTY single-backtick pairs (each backtick immediately "closing"
+  against its neighbor with zero content between), stripping only the
+  empty delimiter markers and leaving the actual enclosed content fully
+  exposed. Rather than write CommonMark-compliant delimiter-run matching
+  in regex, `codex_response_has_fence_marker`'s backtick threshold is
+  lowered from 3+ to 2+, so a 2+-backtick run disqualifies the same way a
+  3+ run always has; single backtick pairs are unaffected and still get
+  precise stripping. The tilde threshold stays at 3+, since GFM only uses
+  tildes for fenced code blocks, never inline code spans.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   usage-limit > clean approval), so two tied responses that were both
   merely "requires attention" (e.g. a usage-limit notice and a genuinely
   unrecognized-format response) are now ranked correctly against each
-  other instead of the scan keeping whichever was evaluated first.
+  other instead of the scan keeping whichever was evaluated first; and
+  verdict classification now runs against the full, untruncated response
+  instead of the 10000-char truncated copy — a SHA-pinned root review
+  longer than the cutoff with an approval phrase before it and a blocking
+  marker after it no longer has its blocker silently discarded (the
+  truncated copy is still used for the script's own displayed output).
+  The classification helpers (`codex_response_is_blocking` and friends)
+  now match via a here-string instead of a piped `printf`, since
+  classifying the untruncated response means `grep -q`'s early-exit
+  behavior on a long input could otherwise SIGPIPE the writer.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -414,7 +414,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   always wins outright" checks inside `codex_combine_terminal_evidence`
   (guarding against a same-fetch usage-limit notice or environment-setup
   error silently overriding a real blocker) now also treat a
-  `CHANGES_REQUESTED` state as blocking, not just a free-text match.
+  `CHANGES_REQUESTED` state as blocking, not just a free-text match. Two
+  followup gaps in that same `state`-field integration were also fixed:
+  (1) `codex_select_review_evidence`'s tie-break for reviews sharing the
+  same second-resolution timestamp ranked purely on `codex_response_
+  priority(body)`, which had no notion of `state` — two tied reviews, one
+  clean and one `CHANGES_REQUESTED` whose body also happened to contain
+  an approval phrase, both scored the same priority from body text alone,
+  so whichever the API returned first silently kept the selection and the
+  `CHANGES_REQUESTED` review's state was discarded before the caller's
+  short-circuit ever saw it; `codex_response_priority` now also ranks a
+  `CHANGES_REQUESTED` state at the blocking tier regardless of body text.
+  (2) A review with state `DISMISSED` still matched the SHA/commit/
+  timestamp filters (dismissal doesn't change `commit_id` or
+  `submitted_at`), so its now-stale body text could still be selected as
+  fresh terminal evidence on an idempotent rerun even though GitHub no
+  longer treats a dismissed review as active; all four reviews-endpoint
+  `jq` queries now exclude `state == DISMISSED` entirely at the source.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   into verdict parsing is now gated on the winning evidence's timestamp
   instead of its body content, so a bodyless-but-selected review reaches
   the documented unrecognized-response safe-fail (`NEEDS_REVISION`)
-  instead of falling through to `TIMED_OUT`.
+  instead of falling through to `TIMED_OUT`; and among tied current-head
+  reviews, a blocking one now always wins outright over any other
+  non-clean type (e.g. a usage-limit response) instead of the scan
+  stopping at whichever "requires attention" response was returned first,
+  so a usage-limit review returned before a tied blocking review no longer
+  silently discards the blocker.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unrecognized-format tier, so a setup-error comment tied at the same
   timestamp as a genuine but unrecognized-format review can no longer win
   the tie-break and replace the review's safe-fail NEEDS_REVISION with an
-  UNAVAILABLE-style `codex-github-environment-missing` verdict.
+  UNAVAILABLE-style `codex-github-environment-missing` verdict; and
+  `CODEX_APPROVAL_PATTERN`'s positive alternatives now require `\b` word
+  boundaries, since the negated-approval fix above only catches
+  SPACE-separated negations ("not approved") — a CONCATENATED negation
+  prefix like "unapproved" or "disapproved" still matched the bare
+  "approved" substring and was reported as APPROVED.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -374,9 +374,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   response should produce. The guard now lives in a new shared
   `codex_response_has_fence_marker` helper used INSIDE every
   positive/actionable classifier (usage-limit, environment-error,
-  blocking, approved) rather than scattered at call sites, so every
-  current and future caller benefits automatically — the same lesson
+  approved) rather than scattered at call sites, so every current and
+  future caller benefits automatically — the same lesson
   `codex_response_is_blocking` already taught for quote-stripping.
+  `codex_response_is_blocking` briefly gained the same fence-marker guard
+  "for consistency" and was found to be the wrong call for that one
+  classifier: unlike a usage-limit/environment-error/approval false
+  negative (always safe — it only defaults toward `NEEDS_REVISION`), a
+  blocking false negative is unsafe, since Protocol 93 requires a
+  detected blocking finding to always win outright over other evidence
+  (e.g. a same-fetch usage-limit notice); bailing out on fence presence
+  let a real blocker outside a fence go undetected just because the same
+  review also contained an unrelated fenced example elsewhere, silently
+  breaking that "blocking always wins" invariant. `codex_response_is_blocking`
+  no longer bails out on fence markers — it keeps only its existing
+  `codex_strip_quoted_spans` normalization, since a blocking false
+  positive on quoted/fenced text is safe on its own.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,7 +248,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   separators, so an unrelated negation in an earlier semicolon-joined
   clause of the same sentence (e.g. "Tests are not required for this
   documentation-only change; looks good") still spanned into a later,
-  unrelated clean clause; the character class now also excludes `;`.
+  unrelated clean clause; the character class now also excludes `;` and
+  `,` (a followup finding showed a comma-joined clause crossed the
+  semicolon-only exclusion the same way). A new shared
+  `codex_strip_quoted_spans` helper now strips both straight-double-quoted
+  spans AND backtick-quoted (Markdown inline code) spans — the earlier
+  quote-stripping fix only handled straight quotes, so a review quoting a
+  clean phrase with backticks instead still matched — and this stripping
+  now runs ONCE, before BOTH the negation check and the positive approval
+  check, since the earlier fix only quote-stripped the positive check: an
+  otherwise-clean response quoting a REJECTION phrase from elsewhere
+  (e.g. test/documentation text) still tripped the negation check on the
+  unstripped body and incorrectly safe-failed. The helper is scoped to
+  `codex_response_is_approved` only and never applied before
+  `codex_response_reviews_current_head`'s SHA extraction, which itself
+  relies on backtick-delimited `Reviewed commit:` markers.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,7 +364,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   converging. Single/inline backtick pairs on one line (not a 3+-backtick
   run) are unaffected and still get precise, stable stripping, since
   inline code references are common in genuinely clean review comments
-  and have not shown this same repeated-edge-case pattern.
+  and have not shown this same repeated-edge-case pattern. That fence-
+  marker guard was added to `codex_response_is_approved` only, so a
+  clean SHA-pinned review that quotes a REAL quota notice inside a fenced
+  example (e.g. "No blocking issues found" followed by a fenced block
+  containing "You have reached your Codex usage limits") still matched
+  the usage-limit pattern on the unstripped fence content and returned
+  `UNAVAILABLE` instead of the safe-fail `NEEDS_REVISION` a fenced
+  response should produce. The guard now lives in a new shared
+  `codex_response_has_fence_marker` helper used INSIDE every
+  positive/actionable classifier (usage-limit, environment-error,
+  blocking, approved) rather than scattered at call sites, so every
+  current and future caller benefits automatically — the same lesson
+  `codex_response_is_blocking` already taught for quote-stripping.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   misclassified as APPROVED even with the shell-level fix in place (the
   slice is dropped entirely; GitHub review bodies are capped well below
   any size that would make this unsafe, and the query already writes to
-  a temp file rather than a piped consumer, so there is no SIGPIPE risk).
+  a temp file rather than a piped consumer, so there is no SIGPIPE risk);
+  `codex_response_is_approved` now rejects negated approval phrases (e.g.
+  "This change is **not** approved") instead of matching the unbounded
+  `approved`/`lgtm`/`looks good` alternatives unconditionally, which used
+  to report a rejecting terminal response as APPROVED instead of the
+  documented unrecognized-format safe-fail; and `codex_response_priority`
+  now ranks an ancillary environment-setup-error comment at the same
+  lower availability tier as a usage-limit notice instead of at the
+  unrecognized-format tier, so a setup-error comment tied at the same
+  timestamp as a genuine but unrecognized-format review can no longer win
+  the tie-break and replace the review's safe-fail NEEDS_REVISION with an
+  UNAVAILABLE-style `codex-github-environment-missing` verdict.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,7 +315,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on the same line to match, and the quoted content between the opening
   and closing fence spans arbitrarily many separate lines) — the fifth
   quoting style found unprotected, after straight-quote, backtick,
-  blockquote, and single-quote.
+  blockquote, and single-quote. That pass's initial implementation
+  toggled its "inside fence" state on ANY line with 3+ backticks, with no
+  regard for the LENGTH of the opening delimiter; GitHub-flavored
+  Markdown's actual fence semantics require a delimiter of at least the
+  opening fence's length to close it, so a longer outer fence (e.g. four
+  backticks) safely quoting content that itself contains a shorter
+  (three-backtick) fence incorrectly closed on the inner delimiter,
+  re-exposing everything after it — including a quoted clean phrase — to
+  classification. The awk pass now tracks the opening delimiter's length
+  (via the POSIX two-argument `match()`, not the gawk-only three-argument
+  array-capture form, since this environment's `awk` is the POSIX "one
+  true awk") and only closes on a delimiter of at least that length.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   submitted in the same second; and usage-limit comments are now retained
   and compared independently the same way environment-error comments
   already were, so an older clean review no longer silently wins over a
-  newer usage-limit notice.
+  newer usage-limit notice; two current-head terminal root comments tied at
+  the same second no longer collapse to whichever was scanned last —
+  terminal-comment selection now applies the same not-a-clean-approval-
+  first tie-break as reviews; and blocking is now checked before
+  usage-limit in every verdict path, so a blocking finding whose text
+  happens to mention "usage limit" is no longer misrouted to an
+  unavailable verdict.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clean, instead of only some of them, and now also allow a genuinely fresh
   (strictly newer) current-head review to supersede a now-stale recorded
   environment error rather than blocking recovery indefinitely within the
-  same invocation; and the timestamp tie-break helper now treats a response
+  same invocation; the timestamp tie-break helper now treats a response
   containing both a blocking marker and an approval phrase as blocking
   first, matching the verdict classifier's own blocking-first priority,
-  instead of misclassifying it as a clean approval.
+  instead of misclassifying it as a clean approval; a submitted review body
+  large enough to exceed a pipe buffer no longer crashes the script with
+  `SIGPIPE`/exit 141 under `pipefail` — truncation now happens inside `jq`
+  (codepoint slice) instead of via a piped `head`; a clean review and a
+  strictly newer environment-setup-error comment observed in the same poll
+  no longer resolve to a silent `APPROVED` — the setup error is retained
+  unless the review is itself strictly newer; and an environment-setup-error
+  comment is no longer silently discarded by a later plain acknowledgement
+  observed in the same comments fetch.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -431,6 +431,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fresh terminal evidence on an idempotent rerun even though GitHub no
   longer treats a dismissed review as active; all four reviews-endpoint
   `jq` queries now exclude `state == DISMISSED` entirely at the source.
+  (3) A third, separate tie-break — `codex_select_terminal_evidence`,
+  used when a SHA-pinned terminal root comment and a current-head review
+  share the same second-resolution timestamp — had the same class of gap
+  as (1) but was missed by that fix, since it's a different function with
+  its own `codex_response_priority` calls: a clean-looking root comment
+  and a same-timestamp `CHANGES_REQUESTED` review whose body also read
+  clean both scored priority 0 from body text, and since the comment is
+  always the "current" side of this comparison, the review could never
+  outrank it, discarding its `CHANGES_REQUESTED` state. `codex_select_
+  terminal_evidence` now accepts optional current/candidate state
+  parameters (empty for a root comment, which has no review state) and
+  passes them into `codex_response_priority`, so a same-timestamp
+  `CHANGES_REQUESTED` review wins this tie-break too, regardless of which
+  side is "current".
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Codex GitHub terminal evidence**: `codex-github-reviewer.sh` no longer
   treats a thumbs-up reaction on the trigger comment as a clean review result,
   ignores submitted Codex reviews that are not pinned to the current PR head,
-  and reports missing Codex cloud environments as unavailable instead of clean.
+  rejects root PR comments as clean evidence because they are not SHA-pinned, and
+  reports missing Codex cloud environments as unavailable instead of clean.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,7 +280,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not negated), not a negation of X, so `CODEX_NEGATION_WORDS`' bare
   "not" alternative — which has no way to distinguish this idiom from a
   genuine negation — misclassified "Not only does this look good, it is
-  approved" as negated even though both phrases are affirmative.
+  approved" as negated even though both phrases are affirmative. That
+  strip only covered Title-Case and lowercase forms; a fully uppercase
+  emphasis form ("NOT ONLY does this look good, it is approved") slipped
+  through. Every letter is now bracket-expanded for both cases (rather
+  than relying on sed's `I` substitution flag, whose support varies
+  across sed implementations).
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,7 +227,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   semantics: a usage-limit notice wins unconditionally over non-blocking
   terminal/review evidence (no newest-wins comparison at all, since
   detecting it terminates the invocation immediately by design), while an
-  environment-setup error keeps the existing newest-wins comparison.
+  environment-setup error keeps the existing newest-wins comparison. That
+  fix only protected usage-limit precedence INSIDE
+  `codex_combine_terminal_evidence`, but `codex_scan_comment_evidence`'s
+  upstream tracking could already discard a usage-limit comment in favor
+  of a LATER environment-error comment within the SAME fetch, before
+  `codex_combine_terminal_evidence` was ever reached — both set
+  `is_actionable=1`, so the unconditional overwrite let the later
+  setup-error body silently replace the quota body. `codex_scan_comment_
+  evidence` now tracks whether the currently-held ancillary comment is
+  specifically a usage-limit notice, and once one is tracked, only
+  another usage-limit notice may replace it.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,7 +262,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unstripped body and incorrectly safe-failed. The helper is scoped to
   `codex_response_is_approved` only and never applied before
   `codex_response_reviews_current_head`'s SHA extraction, which itself
-  relies on backtick-delimited `Reviewed commit:` markers.
+  relies on backtick-delimited `Reviewed commit:` markers. Separately,
+  the top-level verdict-parsing elif chains' usage-limit check (all 4
+  call sites) had no source gate and was not quote-stripped, so a clean
+  terminal review that merely quotes an actual quota message (e.g. "No
+  blocking issues found. The docs accurately quote: You have reached
+  your Codex usage limits.") was reclassified as UNAVAILABLE instead of
+  APPROVED — a case `COMMENT_LATEST_IS_TERMINAL` does not cover, since
+  that guard only protects the ancillary-evidence combination stage, not
+  this separate final verdict check. The check now quote-strips its
+  input before classifying (a source gate isn't used here, unlike the
+  already-safe environment-error check, since a genuine usage-limit
+  notice can legitimately arrive via the reviews endpoint too).
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -525,7 +525,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   target-word list either, and unlike the passive form's "not be merged",
   the imperative form's negation word isn't even adjacent to an
   approval-vocabulary word at all. `do not merge`/`don't merge` are now
-  recognized alongside the passive form.
+  recognized alongside the passive form. That fix immediately surfaced a
+  third sibling — `cannot be merged` — the same underlying gap: enumerating
+  one merge-refusal phrasing at a time in `CODEX_BLOCKING_PATTERN` kept
+  producing the next unenumerated synonym. Rather than add a fourth
+  one-off alternative, a new `CODEX_MERGE_REFUSAL_PATTERN` is built from
+  the existing `CODEX_NEGATION_WORDS` list against a `merge(d)` target —
+  the same construction `CODEX_NEGATED_APPROVAL_PATTERN` already uses —
+  so any negation word already known to this file, including future
+  additions, automatically covers merge refusals too, without needing
+  its own enumeration round-trip. `CODEX_BLOCKING_PATTERN`'s three
+  manually-enumerated merge-refusal alternatives are replaced by this
+  single generalized pattern.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now checked via the review's timestamp (always set for a genuine review)
   instead of its body, so an empty body still participates in the
   not-a-clean-approval-first tie-break instead of silently losing to a
-  clean terminal comment.
+  clean terminal comment; and the main-loop and async verdict paths' entry
+  into verdict parsing is now gated on the winning evidence's timestamp
+  instead of its body content, so a bodyless-but-selected review reaches
+  the documented unrecognized-response safe-fail (`NEEDS_REVISION`)
+  instead of falling through to `TIMED_OUT`.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -536,7 +536,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   additions, automatically covers merge refusals too, without needing
   its own enumeration round-trip. `CODEX_BLOCKING_PATTERN`'s three
   manually-enumerated merge-refusal alternatives are replaced by this
-  single generalized pattern.
+  single generalized pattern. Two more gaps surfaced immediately from
+  that generalization: `CODEX_NEGATION_WORDS` was still missing
+  "shouldn't"/"should not" and "mustn't"/"must not", so those contracted
+  refusals bypassed both the merge-refusal and negated-approval checks —
+  now added, automatically fixing both checks at once (the point of
+  generalizing on a shared word list). Separately, `codex_response_is_
+  blocking`'s new merge-refusal pattern reuses `CODEX_NEGATION_WORDS`'
+  bare "not" alternative the same way the negated-approval pattern does,
+  so it inherited the same "not only X" affirmative-idiom
+  misclassification that `codex_strip_not_only_idiom` was originally
+  written to fix for approval only — a clean response like "This is not
+  only safe to merge but looks good" was misread as a merge refusal.
+  `codex_response_is_blocking` now applies that same idiom-stripping
+  normalization before matching.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -445,6 +445,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   passes them into `codex_response_priority`, so a same-timestamp
   `CHANGES_REQUESTED` review wins this tie-break too, regardless of which
   side is "current".
+- **Codex GitHub reviewer strips multi-line quoted spans**:
+  `codex_strip_quoted_spans`' double-quote stripping ran inside a single
+  `sed` invocation, which operates per-line by default (each line is its
+  own pattern space) — a straight-double-quote pair spanning a newline
+  (e.g. a bot quoting multi-line text as `The documented response "` /
+  `No blocking issues found` / `" is inaccurate` across three lines) was
+  never stripped at all, since the opening and closing quote sit in
+  different sed pattern spaces. The quoted clean phrase reached
+  classification unstripped and matched `CODEX_APPROVAL_PATTERN`,
+  returning `APPROVED` instead of the documented unrecognized-format
+  safe-fail. Newlines are now swapped for a control-character placeholder
+  before the double-/single-quote stripping passes (restoring them
+  immediately after, before the line-oriented backtick pass), so a quote
+  pair is stripped regardless of how many original lines it spans.
+  Blockquote-line deletion and backtick-pair stripping remain
+  line-oriented, which is correct by design for both (a GFM blockquote
+  marker only means anything at the start of a line, and GFM defines an
+  inline code span as never crossing a line).
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -518,7 +518,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   phrase alone won, returning `APPROVED`. `CODEX_BLOCKING_PATTERN` (checked
   first in the verdict-parsing chain, before approval) now recognizes an
   explicit should/must-not-be-merged verdict outright, regardless of what
-  an earlier hedge phrase in the same response says.
+  an earlier hedge phrase in the same response says. That fix only
+  covered the PASSIVE form; the IMPERATIVE form ("do not merge"/"don't
+  merge") is a separate, common phrasing the same gap applies to for the
+  identical reason — "merge" isn't in the negated-approval mechanism's
+  target-word list either, and unlike the passive form's "not be merged",
+  the imperative form's negation word isn't even adjacent to an
+  approval-vocabulary word at all. `do not merge`/`don't merge` are now
+  recognized alongside the passive form.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   closed (`TIMED_OUT`) instead of silently falling through to a clean
   submitted review; the final acknowledgement re-poll now preserves a
   recorded environment-setup error over a thumbs-up reaction, matching the
-  post-reaction re-poll's existing behavior; and all four `APPROVED` exit
-  sites (main poll loop, async-arrival grace, async-final,
-  async-reaction-final) now check a previously recorded environment-setup
-  error before exiting clean, instead of only some of them.
+  post-reaction re-poll's existing behavior; all four `APPROVED` exit sites
+  (main poll loop, async-arrival grace, async-final, async-reaction-final)
+  now check a previously recorded environment-setup error before exiting
+  clean, instead of only some of them, and now also allow a genuinely fresh
+  (strictly newer) current-head review to supersede a now-stale recorded
+  environment error rather than blocking recovery indefinitely within the
+  same invocation; and the timestamp tie-break helper now treats a response
+  containing both a blocking marker and an approval phrase as blocking
+  first, matching the verdict classifier's own blocking-first priority,
+  instead of misclassifying it as a clean approval.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   comment is no longer misclassified as an environment-setup error when its
   finding text happens to quote the setup sentence verbatim (e.g. flagging
   stale documentation) — terminal evidence is never routed through the
-  environment-error classifier.
+  environment-error classifier; multiple current-head reviews tied at the
+  same second-resolution `submitted_at` timestamp no longer collapse to an
+  arbitrary array-order pick via `sort_by | last` — every tied review is
+  now considered and the one requiring attention (if any) wins, so a
+  blocking review can no longer be silently discarded by a clean one
+  submitted in the same second; and usage-limit comments are now retained
+  and compared independently the same way environment-error comments
+  already were, so an older clean review no longer silently wins over a
+  newer usage-limit notice.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,7 +308,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an opening/closing pair), so the opening quote must be preceded by
   whitespace-or-start-of-line and the closing quote by whitespace or
   punctuation, which a contraction's word-internal apostrophe never
-  satisfies.
+  satisfies. `codex_strip_quoted_spans` now also strips fenced Markdown
+  code blocks (```` ```...``` ````) via a separate `awk` pre-pass, since
+  they're a multi-line construct the existing single-line `sed`
+  substitutions can't handle (a fence marker line has no paired backtick
+  on the same line to match, and the quoted content between the opening
+  and closing fence spans arbitrarily many separate lines) — the fifth
+  quoting style found unprotected, after straight-quote, backtick,
+  blockquote, and single-quote.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,7 +326,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   classification. The awk pass now tracks the opening delimiter's length
   (via the POSIX two-argument `match()`, not the gawk-only three-argument
   array-capture form, since this environment's `awk` is the POSIX "one
-  true awk") and only closes on a delimiter of at least that length.
+  true awk") and only closes on a delimiter of at least that length. That
+  fix checked length but not GitHub-flavored Markdown's other closing-
+  fence requirement: a closing delimiter must be followed by nothing but
+  optional whitespace. A line like `` ```not-a-close `` is, per GFM, a
+  new *opening* fence with an info string, not a close, but the
+  length-only check treated it as closing regardless, incorrectly
+  re-exposing a quoted clean phrase positioned after it (and hiding
+  genuine rejection text positioned after THAT, since the length-only
+  check then misread the real closing delimiter as opening yet another
+  fence). This completes GFM's fenced-code-block spec — open, length,
+  close-only-whitespace — as the deliberately final fence-specific
+  refinement here, rather than another reactive edge-case patch: an
+  unclosed fence at end-of-input is already handled safely by
+  construction (everything after an opening delimiter that never finds a
+  valid close stays stripped), so the state machine now correctly
+  implements the finite GFM fence-closing rule end to end.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rendered bold (e.g. "This change is **not** approved") has `**` wedged
   directly between "not" and the following space in the raw comment body,
   which broke the pattern's original unbroken-whitespace adjacency
-  requirement and let the negation go undetected.
+  requirement and let the negation go undetected; and
+  `CODEX_NEGATED_APPROVAL_PATTERN` now tolerates up to 3 intervening
+  qualifier words between the negation and approval words (e.g. "This
+  change is not **yet** approved"), generalizing past the specific
+  adjacency assumptions of the three prior negation fixes above instead
+  of special-casing yet another interrupting-word pattern.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,7 +208,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `codex-github-environment-missing` — a case the existing "terminal
   comment never routed through the environment-error classifier"
   guarantee did not cover, since it only applied to the terminal-vs-review
-  combine path, not this separate ancillary-override check.
+  combine path, not this separate ancillary-override check. The reverse
+  alternation order added above ("looks good ... cannot approve") turned
+  out to be over-broad in practice: it matched ANY later negation word in
+  the same sentence regardless of what it actually negated, so a
+  genuinely clean response like "Looks good overall; tests were not run."
+  was incorrectly flagged as negated. It has been removed — the
+  forward-only match plus the bare-verb addition already covers the
+  original "cannot approve" case without this false-positive class.
+  Separately, `codex_combine_terminal_evidence` previously applied the
+  same newest-wins comparison to a usage-limit ancillary comment as it
+  does to an environment-setup error, so a clean current-head review
+  returned in the SAME poll fetch as (and strictly newer than) a
+  usage-limit notice let the review win, and the quota body never reached
+  `codex_return_usage_limit` — contradicting the documented immediate-
+  termination contract for usage-limit. Usage-limit and environment-error
+  are now handled as two separate checks with their own retention
+  semantics: a usage-limit notice wins unconditionally over non-blocking
+  terminal/review evidence (no newest-wins comparison at all, since
+  detecting it terminates the invocation immediately by design), while an
+  environment-setup error keeps the existing newest-wins comparison.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accepts only root PR comments that include a current-head `Reviewed commit`
   marker as terminal evidence, and reports missing Codex cloud environments as
   unavailable instead of clean. Timestamp ties between a SHA-pinned root
-  comment and a submitted review now resolve in favor of blocking evidence
-  regardless of which side supplied it; the terminal root comment is selected
-  independently of the latest (possibly non-terminal) root comment so a later
-  acknowledgement can no longer discard an earlier blocking one; a failed
-  root-comments fetch during the async grace period, the post-acknowledgement
-  re-poll, and the post-reaction re-poll now fails closed (`TIMED_OUT`)
-  instead of silently falling through to a clean submitted review; and the
-  final acknowledgement re-poll now preserves a recorded environment-setup
-  error over a thumbs-up reaction, matching the post-reaction re-poll's
-  existing behavior.
+  comment and a submitted review now resolve away from a clean approval
+  regardless of which side supplied it — covering both explicitly blocking
+  evidence and an unrecognized-format response that the verdict classifier
+  would otherwise safe-fail to `NEEDS_REVISION`; the terminal root comment is
+  selected independently of the latest (possibly non-terminal) root comment
+  so a later acknowledgement can no longer discard an earlier blocking one; a
+  failed root-comments fetch during the async grace period, the
+  post-acknowledgement re-poll, and the post-reaction re-poll now fails
+  closed (`TIMED_OUT`) instead of silently falling through to a clean
+  submitted review; the final acknowledgement re-poll now preserves a
+  recorded environment-setup error over a thumbs-up reaction, matching the
+  post-reaction re-poll's existing behavior; and all four `APPROVED` exit
+  sites (main poll loop, async-arrival grace, async-final,
+  async-reaction-final) now check a previously recorded environment-setup
+  error before exiting clean, instead of only some of them.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,7 +285,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   emphasis form ("NOT ONLY does this look good, it is approved") slipped
   through. Every letter is now bracket-expanded for both cases (rather
   than relying on sed's `I` substitution flag, whose support varies
-  across sed implementations).
+  across sed implementations). `CODEX_NEGATION_WORDS` also now includes
+  "unable to", which was absent entirely, so "I am unable to approve
+  this change" wasn't recognized as a rejection while an earlier "looks
+  good" in the same sentence still matched. `codex_strip_quoted_spans`
+  now also deletes GitHub-flavored Markdown blockquote lines (a line
+  starting with `>`), since a review discussing a quoted clean phrase via
+  blockquote syntax rather than straight/backtick quotes was likewise
+  unprotected. And `codex_response_is_blocking` — never quote-stripped at
+  all, unlike the approval/negation checks — now shares the same
+  `codex_strip_quoted_spans` normalization, since a quoted blocker token
+  in an otherwise clean review (e.g. "No blocking issues found. The
+  tests correctly cover the `must fix` marker.") still matched
+  `CODEX_BLOCKING_PATTERN` and returned `NEEDS_REVISION` for an
+  actually-clean review.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,6 +342,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   construction (everything after an opening delimiter that never finds a
   valid close stays stripped), so the state machine now correctly
   implements the finite GFM fence-closing rule end to end.
+- **Codex GitHub fenced-code-block detection replaced with a conservative
+  heuristic**: a fifth consecutive fence-parsing gap surfaced — GitHub-
+  flavored Markdown's entirely separate TILDE-delimited fence syntax
+  (`~~~...~~~`), which the backtick-only precise parser never recognized
+  at all, so a quoted clean phrase inside a tilde fence stayed fully
+  exposed to classification. Rather than continue precisely
+  re-implementing GFM's fence grammar one construct at a time (detect,
+  length, close-only-whitespace, and now tilde variants — each round
+  surfaced the next undiscovered edge case), `codex_strip_quoted_spans`
+  no longer attempts to parse fence boundaries at all: the entire awk
+  state machine was removed. `codex_response_is_approved` instead treats
+  the mere presence of a fence-opener marker (3+ consecutive backticks or
+  tildes) anywhere in the response as disqualifying for a clean verdict,
+  without attempting to determine where it opens or closes. This is a
+  deliberate tradeoff — a small amount of false-`NEEDS_REVISION` risk (a
+  genuinely clean response that happens to include an example code fence)
+  in exchange for closing the entire class of quoted/fenced-phrase-
+  misread-as-assertion bugs in one step, since four rounds of chasing
+  precision produced four more false-`APPROVED` gaps instead of
+  converging. Single/inline backtick pairs on one line (not a 3+-backtick
+  run) are unaffected and still get precise, stable stripping, since
+  inline code references are common in genuinely clean review comments
+  and have not shown this same repeated-edge-case pattern.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ignores submitted Codex reviews that are not pinned to the current PR head,
   accepts only root PR comments that include a current-head `Reviewed commit`
   marker as terminal evidence, and reports missing Codex cloud environments as
-  unavailable instead of clean.
+  unavailable instead of clean. Timestamp ties between a SHA-pinned root
+  comment and a submitted review now resolve in favor of blocking evidence
+  regardless of which side supplied it; the terminal root comment is selected
+  independently of the latest (possibly non-terminal) root comment so a later
+  acknowledgement can no longer discard an earlier blocking one; and a failed
+  root-comments fetch during the async grace period, the post-acknowledgement
+  re-poll, and the post-reaction re-poll now fails closed (`TIMED_OUT`)
+  instead of silently falling through to a clean submitted review.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -507,6 +507,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   3+ run always has; single backtick pairs are unaffected and still get
   precise stripping. The tilde threshold stays at 3+, since GFM only uses
   tildes for fenced code blocks, never inline code spans.
+- **Codex GitHub reviewer recognizes explicit merge-refusal verdicts**:
+  the negated-approval mechanism (`CODEX_NEGATED_APPROVAL_PATTERN`) only
+  fires when a negation word is followed by one of a fixed list of
+  approval-vocabulary target words (`approve[ds]?`, `lgtm`, `looks good`,
+  etc.) within the same sentence. A response like "This looks good at
+  first glance, but this should not be merged until tests pass." negates
+  "merged" — a word outside that target list entirely — so the
+  negated-approval check never matched, and the earlier "looks good"
+  phrase alone won, returning `APPROVED`. `CODEX_BLOCKING_PATTERN` (checked
+  first in the verdict-parsing chain, before approval) now recognizes an
+  explicit should/must-not-be-merged verdict outright, regardless of what
+  an earlier hedge phrase in the same response says.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -459,10 +459,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before the double-/single-quote stripping passes (restoring them
   immediately after, before the line-oriented backtick pass), so a quote
   pair is stripped regardless of how many original lines it spans.
-  Blockquote-line deletion and backtick-pair stripping remain
-  line-oriented, which is correct by design for both (a GFM blockquote
-  marker only means anything at the start of a line, and GFM defines an
-  inline code span as never crossing a line).
+  Blockquote-line deletion remains line-oriented, which is correct by
+  design (a GFM blockquote marker only means anything at the start of a
+  line); backtick-pair stripping was ALSO kept line-oriented at the time,
+  reasoning that GFM inline code spans never cross a line — see the
+  followup fix below, which found that reasoning incorrect.
+- **Codex GitHub reviewer fixes two followup gaps in the multi-line quote
+  fix above**: (1) the single-quote pattern's boundary alternatives
+  (`(^|[[:space:]])` and `([[:space:].,;:!?]|$)`) didn't include the
+  newline-flattening placeholder character, so a single-quoted span
+  occupying an ENTIRE original line by itself (e.g. a bot's `The
+  documented response is:` / `'No blocking issues found'` / `That claim
+  is inaccurate` across three lines) has the placeholder — not real
+  whitespace, not true start/end-of-string — immediately before/after the
+  quote once flattened, so neither boundary matched and the quoted clean
+  phrase survived, returning `APPROVED`. The placeholder is now included
+  as an additional valid boundary character. (2) Backtick-pair stripping
+  was deliberately kept line-oriented in the multi-line quote fix,
+  reasoning that "GFM defines an inline code span as never crossing a
+  line" — that reasoning was wrong: CommonMark/GFM inline code spans CAN
+  legitimately span multiple lines (embedded line endings are normalized
+  to spaces in the rendered output); only FENCED, triple-backtick code
+  blocks have line-anchored open/close semantics, a different construct.
+  A single-backtick code span split across lines was never stripped,
+  letting the coded clean phrase reach classification unstripped and
+  return `APPROVED`. Backtick-pair stripping now runs on the same
+  newline-flattened body as the double-/single-quote passes, alongside
+  them, instead of as a separate line-oriented pass afterward.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,12 +92,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   distinction, so two tied responses that are both "requires attention"
   (e.g. a usage-limit root comment and a blocking submitted review, or two
   tied root comments) no longer keep whichever was evaluated first when
-  one side is strictly more severe; and a usage-limit response that ALSO
+  one side is strictly more severe; a usage-limit response that ALSO
   contains an approval phrase (e.g. "No blocking issues could be evaluated
   because you have reached your Codex usage limits") is no longer
-  misclassified as a clean approval by the tie-break — the requires-
-  attention classifier now checks usage-limit alongside blocking before
-  falling back to the approval check.
+  misclassified as a clean approval by the tie-break; and the previously
+  binary "requires attention" tie-break is replaced by a four-tier numeric
+  priority (`codex_response_priority`: blocking > unrecognized format >
+  usage-limit > clean approval), so two tied responses that were both
+  merely "requires attention" (e.g. a usage-limit notice and a genuinely
+  unrecognized-format response) are now ranked correctly against each
+  other instead of the scan keeping whichever was evaluated first.
 - **Workflow sync hardening backports**: delegated epic resolution now fails
   closed on unknown tracker statuses, security-advisory fix evidence is verified
   against the current PR head, CodeRabbit CLI review evidence fails closed when

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -114,7 +114,9 @@ never be hidden behind an "unavailable" verdict. This applies within a
 single poll as
 well as across polls: an environment-setup error is not silently discarded
 by a same-fetch or later plain acknowledgement, since a bare acknowledgement
-carries no information and is never treated as competing evidence.
+carries no information and is never treated as competing evidence. A
+usage-limit notice follows the same retention and priority rules as an
+environment-setup error throughout this section.
 
 ## Troubleshooting
 

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -5,6 +5,13 @@ It is triggered by `scripts/development-workflow/codex-github-reviewer.sh`,
 which posts the configured Codex trigger phrase to the pull request and waits
 for Codex review evidence on the current head commit.
 
+The reviewer requires terminal evidence that can be tied to the current PR head:
+a submitted GitHub review whose `commit_id` matches the current `headRefOid`, or
+a Codex-authored PR comment after the SHA-tagged trigger that contains an
+explicit clean verdict. A thumbs-up reaction on the trigger comment is only an
+acknowledgement; it is not SHA-pinned review evidence and does not make the PR
+clean by itself.
+
 ## Prerequisites
 
 Before a repository keeps `codex-github` in `review.on_ready.github`, verify:
@@ -78,12 +85,21 @@ If the result is `needs_fixes`, address the reported review threads and rerun
 the reviewer loop. If the result is `escalate` or `skipped` with an availability
 reason, treat that as integration setup evidence rather than a clean review.
 
+Codex may also respond to `@codex review` with a setup message such as
+`To use Codex here, create an environment for this repo`. That is an unavailable
+review path, not a clean result. Create the Codex cloud environment or remove
+`codex-github` from the configured reviewer list until the integration can
+produce current-head review evidence.
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Action |
 | --- | --- | --- |
 | The loop waits until timeout after posting `@codex review` | Codex GitHub is not installed, not enabled for the repository, or the account cannot run reviews | Install/enable the integration, confirm account access, then rerun the loop |
+| Codex leaves only a thumbs-up reaction on the trigger comment | Codex acknowledged the trigger but did not publish SHA-pinned review evidence | Treat the run as unavailable; do not mark the PR clean from the reaction alone |
+| Codex says to create an environment for this repo | Manual trigger path is missing a Codex cloud environment | Create the environment or remove `codex-github` from the reviewer list until it is available |
 | Codex review threads remain open after a fix commit | GitHub did not auto-resolve a fixed thread | Verify the current head addresses the finding, then resolve the thread or rerun review if unsure |
+| Codex submitted a review for an older commit | Review arrived for a stale head SHA | Push or retrigger only if needed, then wait for a submitted review whose `commit_id` matches the current head |
 | Thread authors do not match the default bot login | Repository uses a different Codex bot identity | Set `CODEX_GITHUB_BOT_LOGIN` to the observed bot login |
 | Old threads are still visible but marked outdated | GitHub marked the original diff location stale after the fix | Outdated threads are non-blocking in workflow readiness audits |
 

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -13,6 +13,14 @@ otherwise they are used for acknowledgement, usage-limit, and setup-failure
 detection only. A thumbs-up reaction on the trigger comment is only an
 acknowledgement and does not make the PR clean by itself.
 
+When the SHA-pinned root comment and a submitted review are both terminal
+evidence, the strictly newer one wins; on an exact timestamp tie, blocking
+evidence always wins regardless of which side supplied it, and a later
+non-terminal (ancillary) root comment never discards an earlier SHA-pinned
+blocking one. A failed fetch of Codex root PR comments — including during the
+async grace-period poll — is treated as unavailable, not as absence of
+evidence, so it cannot be silently overridden by a clean submitted review.
+
 ## Prerequisites
 
 Before a repository keeps `codex-github` in `review.on_ready.github`, verify:

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -14,12 +14,15 @@ detection only. A thumbs-up reaction on the trigger comment is only an
 acknowledgement and does not make the PR clean by itself.
 
 When the SHA-pinned root comment and a submitted review are both terminal
-evidence, the strictly newer one wins; on an exact timestamp tie, blocking
-evidence always wins regardless of which side supplied it, and a later
-non-terminal (ancillary) root comment never discards an earlier SHA-pinned
-blocking one. A failed fetch of Codex root PR comments — including during the
-async grace-period poll — is treated as unavailable, not as absence of
-evidence, so it cannot be silently overridden by a clean submitted review.
+evidence, the strictly newer one wins; on an exact timestamp tie, any
+response that is not a clean approval — blocking or unrecognized format,
+either of which the verdict classifier would not exit `APPROVED` for —
+always wins over an approved one, regardless of which side supplied it, and
+a later non-terminal (ancillary) root comment never discards an earlier
+SHA-pinned blocking one. A failed fetch of Codex root PR comments — including
+during the async grace-period poll — is treated as unavailable, not as
+absence of evidence, so it cannot be silently overridden by a clean
+submitted review.
 
 ## Prerequisites
 

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -115,8 +115,16 @@ single poll as
 well as across polls: an environment-setup error is not silently discarded
 by a same-fetch or later plain acknowledgement, since a bare acknowledgement
 carries no information and is never treated as competing evidence. A
-usage-limit notice follows the same retention and priority rules as an
-environment-setup error throughout this section.
+usage-limit notice follows the same PRIORITY rules as an environment-setup
+error for ranking purposes (e.g. against a same-timestamp unrecognized-format
+response), but not the same RETENTION rule: unlike an environment-setup
+error, a usage-limit notice terminates the invocation immediately as soon as
+it is detected (`VERDICT: UNAVAILABLE`), rather than being retained through
+the rest of the poll window for a later, strictly newer review to
+potentially supersede. Codex hitting its own usage limit is treated as a
+harder stop than a misconfigured environment, since a fresh useful review
+arriving moments later in the same short poll window is unlikely once quota
+is exhausted.
 
 ## Troubleshooting
 

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -7,10 +7,11 @@ for Codex review evidence on the current head commit.
 
 The reviewer requires terminal evidence that can be tied to the current PR head:
 a submitted GitHub review whose `commit_id` matches the current `headRefOid`, or
-current-head inline review comments. Codex-authored root PR comments are used for
-acknowledgement, usage-limit, and setup-failure detection only; they are not
-SHA-pinned clean evidence. A thumbs-up reaction on the trigger comment is only
-an acknowledgement and does not make the PR clean by itself.
+current-head inline review comments. Codex-authored root PR comments are terminal
+only when they include a `Reviewed commit` marker matching the current head;
+otherwise they are used for acknowledgement, usage-limit, and setup-failure
+detection only. A thumbs-up reaction on the trigger comment is only an
+acknowledgement and does not make the PR clean by itself.
 
 ## Prerequisites
 

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -107,7 +107,10 @@ a later thumbs-up reaction or by review/comment evidence that is not
 strictly newer than the recorded error — but a genuinely fresh, strictly
 newer current-head review (e.g. after an operator creates the environment
 mid-poll) is allowed to supersede it, following the same newest-wins rule
-applied to every other evidence type.
+applied to every other evidence type. This applies within a single poll as
+well as across polls: an environment-setup error is not silently discarded
+by a same-fetch or later plain acknowledgement, since a bare acknowledgement
+carries no information and is never treated as competing evidence.
 
 ## Troubleshooting
 

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -101,7 +101,13 @@ Codex may also respond to `@codex review` with a setup message such as
 `To use Codex here, create an environment for this repo`. That is an unavailable
 review path, not a clean result. Create the Codex cloud environment or remove
 `codex-github` from the configured reviewer list until the integration can
-produce current-head review evidence.
+produce current-head review evidence. Within a single invocation's poll
+window, a recorded environment-setup error cannot be silently overridden by
+a later thumbs-up reaction or by review/comment evidence that is not
+strictly newer than the recorded error — but a genuinely fresh, strictly
+newer current-head review (e.g. after an operator creates the environment
+mid-poll) is allowed to supersede it, following the same newest-wins rule
+applied to every other evidence type.
 
 ## Troubleshooting
 

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -7,10 +7,10 @@ for Codex review evidence on the current head commit.
 
 The reviewer requires terminal evidence that can be tied to the current PR head:
 a submitted GitHub review whose `commit_id` matches the current `headRefOid`, or
-a Codex-authored PR comment after the SHA-tagged trigger that contains an
-explicit clean verdict. A thumbs-up reaction on the trigger comment is only an
-acknowledgement; it is not SHA-pinned review evidence and does not make the PR
-clean by itself.
+current-head inline review comments. Codex-authored root PR comments are used for
+acknowledgement, usage-limit, and setup-failure detection only; they are not
+SHA-pinned clean evidence. A thumbs-up reaction on the trigger comment is only
+an acknowledgement and does not make the PR clean by itself.
 
 ## Prerequisites
 

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -107,7 +107,11 @@ a later thumbs-up reaction or by review/comment evidence that is not
 strictly newer than the recorded error — but a genuinely fresh, strictly
 newer current-head review (e.g. after an operator creates the environment
 mid-poll) is allowed to supersede it, following the same newest-wins rule
-applied to every other evidence type. This applies within a single poll as
+applied to every other evidence type. A blocking terminal or review finding
+is the one exception to newest-wins: it always wins outright over an
+environment-setup error regardless of timing, so an actionable finding can
+never be hidden behind an "unavailable" verdict. This applies within a
+single poll as
 well as across polls: an environment-setup error is not silently discarded
 by a same-fetch or later plain acknowledgement, since a bare acknowledgement
 carries no information and is never treated as competing evidence.

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -130,9 +130,16 @@ silently overridden by a later thumbs-up reaction or by review/comment
 evidence that is not strictly newer than it — but a genuinely fresh,
 strictly newer current-head review (e.g. after the operator creates the
 environment mid-poll) is allowed to supersede it, matching the newest-wins
-rule applied to every other evidence type. This applies within a single
-poll as well as across polls: an environment-setup error is not silently
-discarded by a same-fetch or later plain acknowledgement, since a bare
+rule applied to every other evidence type. A blocking terminal or review
+finding is the one exception to newest-wins: it always wins outright over
+an environment-setup error regardless of timing, so an actionable finding
+can never be hidden behind an "unavailable" verdict. Likewise, a SHA-pinned
+terminal comment is never classified as an environment-setup error even if
+its finding text happens to quote the setup sentence verbatim — terminal
+evidence is never routed through the environment-error classifier. This
+applies within a single poll as well as across polls: an environment-setup
+error is not silently discarded by a same-fetch or later plain
+acknowledgement, since a bare
 acknowledgement carries no information and is never treated as competing
 evidence.
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -136,8 +136,10 @@ an environment-setup error regardless of timing, so an actionable finding
 can never be hidden behind an "unavailable" verdict. Likewise, a SHA-pinned
 terminal comment is never classified as an environment-setup error even if
 its finding text happens to quote the setup sentence verbatim — terminal
-evidence is never routed through the environment-error classifier. This
-applies within a single poll as well as across polls: an environment-setup
+evidence is never routed through the environment-error classifier. A
+usage-limit notice follows the same retention and priority rules as an
+environment-setup error throughout this section. This applies within a
+single poll as well as across polls: an environment-setup
 error is not silently discarded by a same-fetch or later plain
 acknowledgement, since a bare
 acknowledgement carries no information and is never treated as competing

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -127,6 +127,21 @@ Likewise, a Codex response asking the operator to create a cloud environment for
 the repo is setup failure evidence; do not use the empty review/comment from
 that path as a clean result.
 
+When both a SHA-pinned root comment and a submitted review qualify as terminal
+evidence, the strictly newer one wins. On an exact timestamp tie (GitHub
+timestamps are second-resolution), blocking evidence must win regardless of
+which side supplied it — a clean submitted review tied with a blocking root
+comment (or vice versa) must resolve to blocking, not to whichever side
+happens to be evaluated first. Selecting the terminal root comment must also
+be independent of the latest root comment overall: a later non-terminal
+acknowledgement or setup-error comment must never discard an earlier
+SHA-pinned blocking root comment.
+
+Root comments are a terminal evidence source, so a failed fetch of Codex root
+PR comments (including during the async grace-period poll) must be treated as
+unavailable and must not let a clean submitted review be accepted before the
+root comments are known. Fail closed, not open.
+
 **Scope note**: This pre-flight checks `review.on_draft.github` and
 `review.on_ready.github` (external reviewers used by Protocol 93 / Step 7). The
 internal reviewer gate in Protocol 91 Step 7a separately checks

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -125,7 +125,12 @@ are not SHA-pinned clean evidence; use them only for acknowledgement,
 usage-limit, and setup-failure detection.
 Likewise, a Codex response asking the operator to create a cloud environment for
 the repo is setup failure evidence; do not use the empty review/comment from
-that path as a clean result.
+that path as a clean result. This recorded environment error cannot be
+silently overridden by a later thumbs-up reaction or by review/comment
+evidence that is not strictly newer than it — but a genuinely fresh,
+strictly newer current-head review (e.g. after the operator creates the
+environment mid-poll) is allowed to supersede it, matching the newest-wins
+rule applied to every other evidence type.
 
 When both a SHA-pinned root comment and a submitted review qualify as terminal
 evidence, the strictly newer one wins. On an exact timestamp tie (GitHub

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -130,7 +130,11 @@ silently overridden by a later thumbs-up reaction or by review/comment
 evidence that is not strictly newer than it — but a genuinely fresh,
 strictly newer current-head review (e.g. after the operator creates the
 environment mid-poll) is allowed to supersede it, matching the newest-wins
-rule applied to every other evidence type.
+rule applied to every other evidence type. This applies within a single
+poll as well as across polls: an environment-setup error is not silently
+discarded by a same-fetch or later plain acknowledgement, since a bare
+acknowledgement carries no information and is never treated as competing
+evidence.
 
 When both a SHA-pinned root comment and a submitted review qualify as terminal
 evidence, the strictly newer one wins. On an exact timestamp tie (GitHub

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -107,6 +107,22 @@ CLI review found no issues.
 Strict CLI rate-limit policy returns `RESULT=escalate` with
 `REASON=rate_limited`. Treat that like any other platform escalation.
 
+#### Codex GitHub terminal evidence
+
+When `codex-github` is configured, `pr-review-loop.sh` must only treat the
+platform as clean after Codex publishes evidence tied to the current PR head:
+
+- a Codex-authored PR comment after the SHA-tagged trigger with an explicit
+  clean verdict, or
+- a submitted Codex GitHub review whose `commit_id` matches the current
+  `headRefOid`.
+
+A thumbs-up reaction on the trigger comment is an acknowledgement only. It is
+not SHA-pinned review evidence and must be treated as unavailable, not clean.
+Likewise, a Codex response asking the operator to create a cloud environment for
+the repo is setup failure evidence; do not use the empty review/comment from
+that path as a clean result.
+
 **Scope note**: This pre-flight checks `review.on_draft.github` and
 `review.on_ready.github` (external reviewers used by Protocol 93 / Step 7). The
 internal reviewer gate in Protocol 91 Step 7a separately checks

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -112,13 +112,14 @@ Strict CLI rate-limit policy returns `RESULT=escalate` with
 When `codex-github` is configured, `pr-review-loop.sh` must only treat the
 platform as clean after Codex publishes evidence tied to the current PR head:
 
-- a Codex-authored PR comment after the SHA-tagged trigger with an explicit
-  clean verdict, or
 - a submitted Codex GitHub review whose `commit_id` matches the current
-  `headRefOid`.
+  `headRefOid`, or
+- current-head Codex inline review comments, treated as findings.
 
 A thumbs-up reaction on the trigger comment is an acknowledgement only. It is
 not SHA-pinned review evidence and must be treated as unavailable, not clean.
+Codex-authored root PR comments are not SHA-pinned clean evidence; use them only
+for acknowledgement, usage-limit, and setup-failure detection.
 Likewise, a Codex response asking the operator to create a cloud environment for
 the repo is setup failure evidence; do not use the empty review/comment from
 that path as a clean result.

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -114,12 +114,15 @@ platform as clean after Codex publishes evidence tied to the current PR head:
 
 - a submitted Codex GitHub review whose `commit_id` matches the current
   `headRefOid`, or
+- a Codex-authored root PR comment with a `Reviewed commit` marker matching the
+  current `headRefOid`, or
 - current-head Codex inline review comments, treated as findings.
 
 A thumbs-up reaction on the trigger comment is an acknowledgement only. It is
 not SHA-pinned review evidence and must be treated as unavailable, not clean.
-Codex-authored root PR comments are not SHA-pinned clean evidence; use them only
-for acknowledgement, usage-limit, and setup-failure detection.
+Codex-authored root PR comments without a current-head `Reviewed commit` marker
+are not SHA-pinned clean evidence; use them only for acknowledgement,
+usage-limit, and setup-failure detection.
 Likewise, a Codex response asking the operator to create a cloud environment for
 the repo is setup failure evidence; do not use the empty review/comment from
 that path as a clean result.

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -129,9 +129,12 @@ that path as a clean result.
 
 When both a SHA-pinned root comment and a submitted review qualify as terminal
 evidence, the strictly newer one wins. On an exact timestamp tie (GitHub
-timestamps are second-resolution), blocking evidence must win regardless of
-which side supplied it — a clean submitted review tied with a blocking root
-comment (or vice versa) must resolve to blocking, not to whichever side
+timestamps are second-resolution), any response that is not a clean approval
+must win regardless of which side supplied it — this covers both explicitly
+blocking evidence and an unrecognized-format response (which the verdict
+classifier would otherwise safe-fail to `NEEDS_REVISION`); a clean submitted
+review tied with a blocking or unrecognized-format root comment (or vice
+versa) must resolve away from the clean approval, not to whichever side
 happens to be evaluated first. Selecting the terminal root comment must also
 be independent of the latest root comment overall: a later non-terminal
 acknowledgement or setup-error comment must never discard an earlier

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -137,8 +137,12 @@ can never be hidden behind an "unavailable" verdict. Likewise, a SHA-pinned
 terminal comment is never classified as an environment-setup error even if
 its finding text happens to quote the setup sentence verbatim — terminal
 evidence is never routed through the environment-error classifier. A
-usage-limit notice follows the same retention and priority rules as an
-environment-setup error throughout this section. This applies within a
+usage-limit notice follows the same PRIORITY rules as an environment-setup
+error for ranking purposes, but NOT the same RETENTION rule: unlike an
+environment-setup error, a usage-limit notice terminates the invocation
+immediately upon detection (exit code 3), rather than being retained
+through the rest of the poll window for a later, strictly newer review to
+potentially supersede it. This applies within a
 single poll as well as across polls: an environment-setup
 error is not silently discarded by a same-fetch or later plain
 acknowledgement, since a bare

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -266,15 +266,28 @@ codex_response_is_approved() {
   printf '%s\n' "$body" | grep -qiE "$CODEX_APPROVAL_PATTERN"
 }
 
+# True when a response is NOT the clean-approval path — i.e. it is either
+# explicitly blocking or an unrecognized format that the documented verdict
+# classifier safe-fails to NEEDS_REVISION (see "Verdict parsing" header
+# comment). Used by the tie-break below so an unrecognized-format response
+# is treated with the same tie-break priority as an explicitly blocking one,
+# not silently outranked by a clean approval on a timestamp tie.
+codex_response_requires_attention() {
+  local body="$1"
+  ! codex_response_is_approved "$body"
+}
+
 # Decides whether CANDIDATE terminal ("review"-sourced) evidence should
 # replace CURRENT terminal evidence. A strictly later candidate always wins.
 # GitHub timestamps are second-resolution, so ties are possible; on an exact
-# tie, blocking evidence must never be discarded in favor of clean/ancillary
-# evidence, regardless of which side (submitted review vs SHA-pinned root
-# comment) supplied it. This makes the tie-break symmetric: if the candidate
-# is blocking and the current evidence is not, the candidate wins; if the
-# current evidence is blocking and the candidate is not, the current evidence
-# is kept.
+# tie, evidence that is not a clean approval (blocking OR unrecognized
+# format — anything the verdict classifier would not exit APPROVED for)
+# must never be discarded in favor of an approved response, regardless of
+# which side (submitted review vs SHA-pinned root comment) supplied it. This
+# makes the tie-break symmetric: if the candidate requires attention and the
+# current evidence is a clean approval, the candidate wins; if the current
+# evidence requires attention and the candidate is a clean approval, the
+# current evidence is kept.
 codex_select_terminal_evidence() {
   local current_body="$1" current_time="$2"
   local candidate_body="$3" candidate_time="$4"
@@ -283,7 +296,7 @@ codex_select_terminal_evidence() {
     return 0
   fi
   if [ "$candidate_time" = "$current_time" ]; then
-    if codex_response_is_blocking "$candidate_body" && ! codex_response_is_blocking "$current_body"; then
+    if codex_response_requires_attention "$candidate_body" && ! codex_response_requires_attention "$current_body"; then
       return 0
     fi
   fi
@@ -324,10 +337,11 @@ codex_scan_comment_evidence() {
 # Combines comment-sourced evidence (terminal SHA-pinned root comment vs.
 # latest ancillary comment, from codex_scan_comment_evidence) with
 # review-sourced evidence (from the pulls/{PR}/reviews endpoint) into a
-# single winning result, applying blocking-first tie-breaking
+# single winning result, applying not-a-clean-approval-first tie-breaking
 # (codex_select_terminal_evidence) so a genuine submitted review only
 # supersedes a SHA-pinned terminal root comment when it is strictly newer, or
-# tied and itself blocking while the comment is not.
+# tied and itself not a clean approval (blocking or unrecognized format)
+# while the comment is.
 # Sets: COMBINED_BODY, COMBINED_TIME, COMBINED_SOURCE ("review", "comment",
 # or "" if no evidence at all). LABEL is used only for INFO logging.
 codex_combine_terminal_evidence() {

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -243,35 +243,57 @@ codex_inline_review_comment_count_since() {
 # FULL, untruncated response (see BOT_RESPONSE_FULL below) rather than a
 # pre-truncated copy.
 
-# Returns true if the response contains a fence-opener marker (3+
-# consecutive backticks or tildes) ANYWHERE. Used by every positive-
-# signal classifier below (usage-limit, environment-error, approved) as a
-# conservative guard: a genuine SHA-pinned clean review can QUOTE example
-# text inside a fenced block (e.g. demonstrating what a usage-limit
-# notice looks like) without that text being a genuine assertion, and
-# after 5 rounds of precisely parsing GFM's fence-open/close semantics
-# repeatedly surfaced the next undiscovered edge case (see
-# codex_strip_quoted_spans below), the project's chosen direction is to
-# stop trying to determine what's inside vs. outside a fence and instead
-# treat the mere PRESENCE of a fence marker as disqualifying for any of
-# these positive/actionable classifications. This was initially added
-# only to codex_response_is_approved, but the SAME ambiguity applies
-# equally to usage-limit and environment-error detection — a fenced
-# example that merely QUOTES quota/setup-error wording must not trigger
-# an actual UNAVAILABLE verdict for an otherwise clean review (fresh
-# evidence from PR #1490 finding 3796042503, a followup to 3795661290:
-# the fence guard was added to codex_response_is_approved alone, but
-# codex_response_is_usage_limit's own callers were unguarded, so fenced
-# quota text still triggered a false UNAVAILABLE for a clean review).
-# Embedding this check INSIDE each shared classifier — rather than
-# requiring every call site to remember to apply it — is deliberate:
+# Returns true if the response contains a fence-opener marker (2+
+# consecutive backticks, or 3+ consecutive tildes) ANYWHERE. Used by
+# every positive-signal classifier below (usage-limit, environment-error,
+# approved) as a conservative guard: a genuine SHA-pinned clean review
+# can QUOTE example text inside a fenced block (e.g. demonstrating what a
+# usage-limit notice looks like) without that text being a genuine
+# assertion, and after 5 rounds of precisely parsing GFM's fence-open/
+# close semantics repeatedly surfaced the next undiscovered edge case
+# (see codex_strip_quoted_spans below), the project's chosen direction is
+# to stop trying to determine what's inside vs. outside a fence and
+# instead treat the mere PRESENCE of a fence marker as disqualifying for
+# any of these positive/actionable classifications. This was initially
+# added only to codex_response_is_approved, but the SAME ambiguity
+# applies equally to usage-limit and environment-error detection — a
+# fenced example that merely QUOTES quota/setup-error wording must not
+# trigger an actual UNAVAILABLE verdict for an otherwise clean review
+# (fresh evidence from PR #1490 finding 3796042503, a followup to
+# 3795661290: the fence guard was added to codex_response_is_approved
+# alone, but codex_response_is_usage_limit's own callers were unguarded,
+# so fenced quota text still triggered a false UNAVAILABLE for a clean
+# review). Embedding this check INSIDE each shared classifier — rather
+# than requiring every call site to remember to apply it — is deliberate:
 # scattering the guard across call sites is exactly the pattern that
 # produced this gap in the first place (codex_response_is_blocking
 # learned the same lesson earlier for quote-stripping, PR #1490 finding
 # 3793367887).
+#
+# The backtick threshold was lowered from 3+ to 2+ after
+# codex_strip_quoted_spans' naive `[^\`]*` backtick-pair regex was found
+# to mishandle CommonMark's actual delimiter-run matching: a code span
+# CAN be delimited by a run of 2+ backticks (not just a single pair), and
+# the opening/closing runs must be equal length — but the naive regex
+# treats an adjacent 2-backtick run as two separate EMPTY single-backtick
+# pairs (each backtick immediately "closes" against its neighbor with
+# zero content between), stripping only the empty delimiter pairs
+# themselves and leaving the actual enclosed content fully exposed (e.g.
+# a double-backtick-quoted `` `` No blocking issues found `` `` survived
+# stripping intact and matched CODEX_APPROVAL_PATTERN, fresh evidence
+# from PR #1490 finding 3798756834). Rather than write CommonMark-
+# compliant delimiter-run matching in regex (not realistically
+# expressible as a plain substitution), a 2+-backtick run now disqualifies
+# the same way a 3+ run always has — single backtick PAIRS (exactly one
+# backtick on each side, still extremely common in genuinely clean review
+# comments) are unaffected and still get precise stripping via
+# codex_strip_quoted_spans. Tildes are NOT lowered to 2+: GFM only uses
+# tildes for FENCED code blocks (3+ required), never for inline code
+# spans, so a lower tilde threshold would have no corresponding real gap
+# to close.
 codex_response_has_fence_marker() {
   local response="$1"
-  grep -qE '(`{3,}|~{3,})' <<< "$response"
+  grep -qE '(`{2,}|~{3,})' <<< "$response"
 }
 
 codex_response_is_usage_limit() {
@@ -401,7 +423,7 @@ CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t 
 # "cannot approve" fixed for finding 3790023141, just a different
 # inability phrase).
 CODEX_NEGATED_APPROVAL_TARGET_WORDS='(approve[ds]?|lgtm|look(s|ing)?[[:space:]]+good|no[[:space:]]+blocking[[:space:]]+issues?|didn.t find[[:space:]]+any major[[:space:]]+issues)'
-CODEX_NEGATION_WORDS='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never|unable[[:space:]]+to)'
+CODEX_NEGATION_WORDS='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|do[[:space:]]+not|don.t|never|unable[[:space:]]+to)'
 CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*${CODEX_NEGATED_APPROVAL_TARGET_WORDS}"
 
 # Strips quoted spans — text between a pair of straight double-quotes

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -477,7 +477,7 @@ while true; do
     > "$REVIEW_TMPFILE" 2>"$REVIEW_STDERR"; then
     REVIEW_BODY=$(jq -r '.body // empty' "$REVIEW_TMPFILE" | head -c 5000)
     REVIEW_TIME=$(jq -r '.created_at // empty' "$REVIEW_TMPFILE")
-    if [ -n "$REVIEW_BODY" ] && codex_response_time_should_replace "$REVIEW_TIME" "$BOT_RESPONSE_TIME"; then
+    if [ -n "$REVIEW_BODY" ] && { [ "$BOT_RESPONSE_SOURCE" != "review" ] || codex_response_time_should_replace "$REVIEW_TIME" "$BOT_RESPONSE_TIME"; }; then
       BOT_RESPONSE="$REVIEW_BODY"
       BOT_RESPONSE_TIME="$REVIEW_TIME"
       BOT_RESPONSE_SOURCE="review"
@@ -655,6 +655,7 @@ sleep "$POLL_INTERVAL"
 # Single grace poll: check both PR comments and PR reviews
 ASYNC_BOT_RESPONSE=""
 ASYNC_BOT_RESPONSE_SOURCE=""
+ASYNC_BOT_RESPONSE_TIME=""
 
 if ! ASYNC_INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME"); then
   echo "VERDICT: TIMED_OUT — failed to fetch Codex inline review comments during async grace period (treated as unavailable)"
@@ -682,9 +683,10 @@ ASYNC_POLL_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>/dev/null \
   | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
-      '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | .body // empty' \
+      '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | {created_at:(.created_at // ""), body:(.body // "")}' \
 	  > "$ASYNC_POLL_TMPFILE" 2>/dev/null; then
-	  ASYNC_BOT_RESPONSE=$(head -c 10000 "$ASYNC_POLL_TMPFILE")
+	  ASYNC_BOT_RESPONSE=$(jq -r '.body // empty' "$ASYNC_POLL_TMPFILE" | head -c 10000)
+	  ASYNC_BOT_RESPONSE_TIME=$(jq -r '.created_at // empty' "$ASYNC_POLL_TMPFILE")
 	  if [ -n "$ASYNC_BOT_RESPONSE" ]; then
 	    ASYNC_BOT_RESPONSE_SOURCE="comment"
 	    if codex_response_reviews_current_head "$ASYNC_BOT_RESPONSE"; then
@@ -699,11 +701,13 @@ ASYNC_REVIEW_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
   2>/dev/null \
   | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
+      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
   > "$ASYNC_REVIEW_TMPFILE" 2>/dev/null; then
-  ASYNC_REVIEW_BODY=$(head -c 5000 "$ASYNC_REVIEW_TMPFILE")
-	  if [ -n "$ASYNC_REVIEW_BODY" ]; then
+  ASYNC_REVIEW_BODY=$(jq -r '.body // empty' "$ASYNC_REVIEW_TMPFILE" | head -c 5000)
+  ASYNC_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_REVIEW_TMPFILE")
+	  if [ -n "$ASYNC_REVIEW_BODY" ] && { [ "$ASYNC_BOT_RESPONSE_SOURCE" != "review" ] || codex_response_time_should_replace "$ASYNC_REVIEW_TIME" "$ASYNC_BOT_RESPONSE_TIME"; }; then
 	    ASYNC_BOT_RESPONSE="$ASYNC_REVIEW_BODY"
+	    ASYNC_BOT_RESPONSE_TIME="$ASYNC_REVIEW_TIME"
 	    ASYNC_BOT_RESPONSE_SOURCE="review"
     echo "INFO: async-arrival bot response detected via PR reviews endpoint"
   fi
@@ -753,13 +757,15 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
 	    fi
 	    ASYNC_FINAL_BOT_RESPONSE=""
 	    ASYNC_FINAL_BOT_RESPONSE_SOURCE=""
+	    ASYNC_FINAL_BOT_RESPONSE_TIME=""
 	    ASYNC_FINAL_POLL_TMPFILE=$(mktemp)
     if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
       2>/dev/null \
       | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
-          '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | .body // empty' \
+          '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | {created_at:(.created_at // ""), body:(.body // "")}' \
 	      > "$ASYNC_FINAL_POLL_TMPFILE" 2>/dev/null; then
-	      ASYNC_FINAL_BOT_RESPONSE=$(head -c 10000 "$ASYNC_FINAL_POLL_TMPFILE")
+	      ASYNC_FINAL_BOT_RESPONSE=$(jq -r '.body // empty' "$ASYNC_FINAL_POLL_TMPFILE" | head -c 10000)
+	      ASYNC_FINAL_BOT_RESPONSE_TIME=$(jq -r '.created_at // empty' "$ASYNC_FINAL_POLL_TMPFILE")
 	      if [ -n "$ASYNC_FINAL_BOT_RESPONSE" ]; then
 	        ASYNC_FINAL_BOT_RESPONSE_SOURCE="comment"
 	        if codex_response_reviews_current_head "$ASYNC_FINAL_BOT_RESPONSE"; then
@@ -774,12 +780,14 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
       2>/dev/null \
       | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
+          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
       > "$ASYNC_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
-      ASYNC_FINAL_REVIEW_BODY=$(head -c 5000 "$ASYNC_FINAL_REVIEW_TMPFILE")
-	      if [ -n "$ASYNC_FINAL_REVIEW_BODY" ]; then
-	        ASYNC_FINAL_BOT_RESPONSE="$ASYNC_FINAL_REVIEW_BODY"
-	        ASYNC_FINAL_BOT_RESPONSE_SOURCE="review"
+      ASYNC_FINAL_REVIEW_BODY=$(jq -r '.body // empty' "$ASYNC_FINAL_REVIEW_TMPFILE" | head -c 5000)
+      ASYNC_FINAL_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_FINAL_REVIEW_TMPFILE")
+		      if [ -n "$ASYNC_FINAL_REVIEW_BODY" ] && { [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" != "review" ] || codex_response_time_should_replace "$ASYNC_FINAL_REVIEW_TIME" "$ASYNC_FINAL_BOT_RESPONSE_TIME"; }; then
+		        ASYNC_FINAL_BOT_RESPONSE="$ASYNC_FINAL_REVIEW_BODY"
+		        ASYNC_FINAL_BOT_RESPONSE_TIME="$ASYNC_FINAL_REVIEW_TIME"
+		        ASYNC_FINAL_BOT_RESPONSE_SOURCE="review"
         echo "INFO: final async bot response detected via PR reviews endpoint"
       fi
     else
@@ -863,13 +871,15 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
 
   ASYNC_REACTION_FINAL_BOT_RESPONSE=""
   ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE=""
+  ASYNC_REACTION_FINAL_BOT_RESPONSE_TIME=""
   ASYNC_REACTION_FINAL_POLL_TMPFILE=$(mktemp)
   if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
     2>/dev/null \
     | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
-        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | .body // empty' \
+        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | {created_at:(.created_at // ""), body:(.body // "")}' \
     > "$ASYNC_REACTION_FINAL_POLL_TMPFILE" 2>/dev/null; then
-    ASYNC_REACTION_FINAL_BOT_RESPONSE=$(head -c 10000 "$ASYNC_REACTION_FINAL_POLL_TMPFILE")
+    ASYNC_REACTION_FINAL_BOT_RESPONSE=$(jq -r '.body // empty' "$ASYNC_REACTION_FINAL_POLL_TMPFILE" | head -c 10000)
+    ASYNC_REACTION_FINAL_BOT_RESPONSE_TIME=$(jq -r '.created_at // empty' "$ASYNC_REACTION_FINAL_POLL_TMPFILE")
     if [ -n "$ASYNC_REACTION_FINAL_BOT_RESPONSE" ]; then
       ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE="comment"
       if codex_response_reviews_current_head "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
@@ -884,11 +894,13 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>/dev/null \
     | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
     > "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
-    ASYNC_REACTION_FINAL_REVIEW_BODY=$(head -c 5000 "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE")
-    if [ -n "$ASYNC_REACTION_FINAL_REVIEW_BODY" ]; then
+    ASYNC_REACTION_FINAL_REVIEW_BODY=$(jq -r '.body // empty' "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE" | head -c 5000)
+    ASYNC_REACTION_FINAL_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE")
+    if [ -n "$ASYNC_REACTION_FINAL_REVIEW_BODY" ] && { [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" != "review" ] || codex_response_time_should_replace "$ASYNC_REACTION_FINAL_REVIEW_TIME" "$ASYNC_REACTION_FINAL_BOT_RESPONSE_TIME"; }; then
       ASYNC_REACTION_FINAL_BOT_RESPONSE="$ASYNC_REACTION_FINAL_REVIEW_BODY"
+      ASYNC_REACTION_FINAL_BOT_RESPONSE_TIME="$ASYNC_REACTION_FINAL_REVIEW_TIME"
       ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE="review"
       echo "INFO: final async reaction bot response detected via PR reviews endpoint"
     fi

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -295,42 +295,37 @@ CODEX_BLOCKING_PATTERN='(changes[[:space:]]+requested|blocking[[:space:]]+issues
 # mode.
 CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)'
 # Negated forms of the approval phrases above. CODEX_APPROVAL_PATTERN's
-# "approved"/"lgtm"/"looks good" alternatives are unbounded substring
-# matches, so a rejecting response like "This change is not approved"
-# matched them unconditionally and was classified APPROVED instead of
-# falling through to the documented unrecognized-format safe-fail (fresh
-# evidence from PR #1490 finding 3789722818). Checked BEFORE the positive
-# approval pattern in codex_response_is_approved so a negated approval
-# phrase can never be reported as approved. This handles SPACE-separated
-# negations ("not approved"); CODEX_APPROVAL_PATTERN's \b boundaries above
-# separately handle CONCATENATED negation prefixes ("unapproved"). The
-# optional [*_~]{0,3} groups between the negation word and the approval
-# word tolerate Markdown emphasis markers wedged between them (e.g. "This
-# change is **not** approved" — GitHub renders **not** as bold, but the
-# raw text has "**" directly between "not" and the following space, which
-# broke the plain [[:space:]]+ adjacency this pattern originally required;
-# fresh evidence from PR #1490 finding 3789878264, a followup to
-# 3789851555/3789722818). The optional ([[:space:]]+[*_~]{0,3}[[:alpha:]'-]{1,20}[*_~]{0,3}){0,3}
-# group tolerates up to 3 intervening qualifier words between the
-# negation and the approval word (e.g. "not YET approved", "not FULLY
-# approved YET"), since a rigid negation-immediately-adjacent-to-approval
-# requirement is a losing enumeration game against arbitrary English
-# phrasing — every prior round of this fix (space-separated, concatenated
-# prefix, Markdown-wrapped) narrowed one specific adjacency assumption and
-# Codex found the next one; allowing a bounded window of filler words
-# generalizes past this specific class of gap instead of special-casing
-# it again (fresh evidence from PR #1490 finding 3789904716, a followup to
-# 3789878264/3789851555/3789722818). The target alternation now also
-# covers "no blocking issues"/"didn't find any major issues", not just
-# "approved"/"lgtm"/"looks good": those are approval SIGNALS in
-# CODEX_APPROVAL_PATTERN too, but were left unguarded by this negation
-# check, so a hedged/uncertain response like "I cannot confirm there are
-# no blocking issues" still matched CODEX_APPROVAL_PATTERN's "no blocking
-# issues" alternative and was classified APPROVED (fresh evidence from PR
-# #1490 finding 3789958775). The existing filler-word tolerance already
-# generalizes to this case ("cannot" + "confirm there are" (3 filler
-# words) + "no blocking issues") without further changes.
-CODEX_NEGATED_APPROVAL_PATTERN='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)[*_~]{0,3}([[:space:]]+[*_~]{0,3}[[:alpha:]'"'"'-]{1,20}[*_~]{0,3}){0,3}[[:space:]]+[*_~]{0,3}(be[[:space:]]+)?[*_~]{0,3}(approved|lgtm|look(s|ing)?[[:space:]]+good|no[[:space:]]+blocking[[:space:]]+issues?|didn.t find[[:space:]]+any major[[:space:]]+issues)'
+# alternatives are unbounded substring matches, so a rejecting response
+# like "This change is not approved" matched them unconditionally and was
+# classified APPROVED instead of falling through to the documented
+# unrecognized-format safe-fail. Checked BEFORE the positive approval
+# pattern in codex_response_is_approved so a negated approval phrase can
+# never be reported as approved.
+#
+# This went through several rounds of narrowly-scoped fixes (PR #1490
+# findings 3789722818, 3789851555, 3789878264, 3789904716, 3789958775):
+# require a negation word directly adjacent to the approval word, then
+# tolerate a concatenated prefix ("unapproved"), then Markdown emphasis
+# markers wedged in the middle ("**not** approved"), then a BOUNDED
+# window of up to 3 intervening qualifier words ("not YET approved").
+# Each fix narrowed one specific adjacency assumption and Codex found the
+# next one, up to and including the bounded-window fix itself: 5
+# intervening words ("I cannot confidently confirm that there are no
+# blocking issues") exceeded the {0,3} bound (fresh evidence from PR
+# #1490 finding 3789992792) — the reviewer's own stated remediation was
+# "avoid relying on a bounded filler-word count".
+#
+# [^.!?]* (any character except a sentence terminator, UNBOUNDED) between
+# the negation word and the approval word closes this whole class of gap
+# at once: it matches a negation and an approval word co-occurring
+# anywhere within the same sentence, regardless of how much text sits
+# between them or how it's formatted (Markdown markers included, since
+# they aren't excluded by the character class), while a period/!/?
+# between them correctly prevents an unrelated LATER sentence's approval
+# phrase from being treated as negated by an EARLIER sentence's negation
+# word (e.g. "The variable name is not great. No blocking issues found."
+# still classifies as approved).
+CODEX_NEGATED_APPROVAL_PATTERN='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)[^.!?]*(approved|lgtm|look(s|ing)?[[:space:]]+good|no[[:space:]]+blocking[[:space:]]+issues?|didn.t find[[:space:]]+any major[[:space:]]+issues)'
 
 codex_response_is_blocking() {
   local body="$1"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -244,7 +244,16 @@ codex_inline_review_comment_count_since() {
 # pre-truncated copy.
 codex_response_is_usage_limit() {
   local response="$1"
-  grep -qiE "(reached[[:space:]]+your[[:space:]]+codex[[:space:]]+usage[[:space:]]+limits?|codex[[:space:]]+usage[[:space:]]+limits?[[:space:]]+for[[:space:]]+code[[:space:]]+reviews?|codex[[:space:]]+(github[[:space:]]+app[[:space:]]+)?(review[[:space:]]+)?(usage[[:space:]]+limit|quota|capacity)|codex[[:space:]]+review[[:space:]]+capacity[[:space:]]+(exhausted|unavailable|limited))" <<< "$response"
+  # The third alternative previously matched ANY "codex ... usage
+  # limit/quota/capacity" substring with no requirement for accompanying
+  # exhaustion/unavailability wording, so a clean submitted review merely
+  # discussing this PR's own usage-limit-detection code (e.g. "No blocking
+  # issues found. The Codex usage limit handling looks correct.") was
+  # itself misclassified as a usage-limit notice (fresh evidence from PR
+  # #1490 finding 3789928781). It now requires an exhaustion/unavailability
+  # word directly after the noun, mirroring the structure already used by
+  # the fourth alternative ("capacity exhausted/unavailable/limited").
+  grep -qiE "(reached[[:space:]]+your[[:space:]]+codex[[:space:]]+usage[[:space:]]+limits?|codex[[:space:]]+usage[[:space:]]+limits?[[:space:]]+for[[:space:]]+code[[:space:]]+reviews?|codex[[:space:]]+(github[[:space:]]+app[[:space:]]+)?(review[[:space:]]+)?(usage[[:space:]]+limit|quota|capacity)[[:space:]]+(reached|exceeded|exhausted|hit|unavailable|limited)|codex[[:space:]]+review[[:space:]]+capacity[[:space:]]+(exhausted|unavailable|limited))" <<< "$response"
 }
 
 codex_response_is_environment_error() {

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -275,6 +275,36 @@ codex_return_reaction_without_review() {
   exit 2
 }
 
+codex_return_head_changed() {
+  echo "VERDICT: TIMED_OUT — PR head changed while waiting for Codex review evidence (treated as unavailable)"
+  echo "REASON=codex-github-head-changed"
+  echo "COMMENT_COUNT=0"
+  echo "BLOCKING_COUNT=0"
+  echo "SUGGESTION_COUNT=0"
+  exit 2
+}
+
+codex_require_current_head() {
+  local latest_sha
+  if ! latest_sha=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid --jq '.headRefOid' | head -c 100); then
+    echo "ERROR: could not revalidate PR #$PR_NUMBER HEAD SHA" >&2
+    echo "VERDICT: TIMED_OUT — could not revalidate PR HEAD SHA (treated as unavailable)"
+    echo "REASON=codex-github-head-unavailable"
+    exit 2
+  fi
+  latest_sha=$(printf '%s' "$latest_sha" | cut -c1-12)
+  if [ -z "$latest_sha" ]; then
+    echo "ERROR: could not revalidate PR #$PR_NUMBER HEAD SHA (empty result)" >&2
+    echo "VERDICT: TIMED_OUT — could not revalidate PR HEAD SHA (treated as unavailable)"
+    echo "REASON=codex-github-head-unavailable"
+    exit 2
+  fi
+  if [ "$latest_sha" != "$CURRENT_SHA" ]; then
+    echo "INFO: PR head changed during Codex polling (started at $CURRENT_SHA, now $latest_sha)"
+    codex_return_head_changed
+  fi
+}
+
 # ── Idempotency guard (BR-10) ─────────────────────────────────────────────────
 # Check whether a trigger comment for the current commit SHA already exists.
 # We look for a comment body containing BOTH the trigger phrase AND the SHA to
@@ -432,6 +462,7 @@ while true; do
     exit 2
   fi
   if [ "$INLINE_REVIEW_COMMENT_COUNT" -gt 0 ]; then
+    codex_require_current_head
     echo "VERDICT: NEEDS_REVISION"
     echo "INFO: detected $INLINE_REVIEW_COMMENT_COUNT Codex inline review comment(s) after trigger"
     exit 1
@@ -441,13 +472,9 @@ while true; do
     echo "VERDICT: TIMED_OUT — failed to fetch Codex trigger reactions (treated as unavailable)"
     exit 2
   fi
-  if [ "$APPROVAL_REACTION_COUNT" -gt 0 ]; then
-    echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID"
-    codex_return_reaction_without_review
-  fi
-
   if [ -n "$BOT_RESPONSE" ]; then
     echo "INFO: bot response detected"
+    codex_require_current_head
 
     # ── Verdict parsing ───────────────────────────────────────────────────────
     # Three-path classification (per spec BR-4 and implementation plan risk table).
@@ -506,6 +533,11 @@ while true; do
       echo "---END BOT RESPONSE---"
       exit 1
     fi
+  fi
+
+  if [ "$APPROVAL_REACTION_COUNT" -gt 0 ]; then
+    echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID"
+    codex_return_reaction_without_review
   fi
   done  # end inner poll loop
 
@@ -584,6 +616,7 @@ if ! ASYNC_INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since
   exit 2
 fi
 if [ "$ASYNC_INLINE_REVIEW_COMMENT_COUNT" -gt 0 ]; then
+  codex_require_current_head
   echo "VERDICT: NEEDS_REVISION"
   echo "INFO: detected $ASYNC_INLINE_REVIEW_COMMENT_COUNT Codex inline review comment(s) during async grace period"
   exit 1
@@ -600,11 +633,6 @@ if [ -n "$ASYNC_TRIGGER_COMMENT_ID" ]; then
   fi
   ASYNC_APPROVAL_REACTION_COUNT=$((ASYNC_APPROVAL_REACTION_COUNT + ASYNC_EXTRA_APPROVAL_REACTION_COUNT))
 fi
-if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
-  echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID during async grace period"
-  codex_return_reaction_without_review
-fi
-
 ASYNC_POLL_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>/dev/null \
@@ -633,6 +661,7 @@ fi
 
 if [ -n "$ASYNC_BOT_RESPONSE" ]; then
   echo "INFO: async-arrival bot response detected during grace period"
+  codex_require_current_head
 
   # Apply the same three-path verdict parsing as the main poll loop.
   if codex_response_is_usage_limit "$ASYNC_BOT_RESPONSE"; then
@@ -660,6 +689,7 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
       exit 2
     fi
     if [ "$ASYNC_INLINE_REVIEW_COMMENT_COUNT" -gt 0 ]; then
+      codex_require_current_head
       echo "VERDICT: NEEDS_REVISION"
       echo "INFO: detected $ASYNC_INLINE_REVIEW_COMMENT_COUNT Codex inline review comment(s) after async acknowledgement"
       exit 1
@@ -686,6 +716,11 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     echo "---END BOT RESPONSE---"
     exit 1
   fi
+fi
+
+if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
+  echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID during async grace period"
+  codex_return_reaction_without_review
 fi
 
 echo "INFO: no bot response during async grace period"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -266,45 +266,57 @@ codex_response_is_approved() {
   printf '%s\n' "$body" | grep -qiE "$CODEX_APPROVAL_PATTERN"
 }
 
-# True when a response is NOT the clean-approval path — i.e. it is
-# explicitly blocking, a usage-limit notice, or an unrecognized format
-# that the documented verdict classifier safe-fails to NEEDS_REVISION
-# (see "Verdict parsing" header comment). Blocking and usage-limit are
-# checked FIRST, matching the classifier's own priority: a response
-# containing both an approval phrase and a blocking marker (e.g. "No
-# blocking issues found. Must fix ...") is blocking, not approved, and a
-# response containing both an approval phrase and usage-limit wording
-# (e.g. "No blocking issues could be evaluated because you have reached
-# your Codex usage limits") is a usage-limit notice, not approved (fresh
-# evidence from PR #1490 finding 3789555934 — the earlier mixed-
-# blocking-and-approval fix checked only blocking, leaving the analogous
-# mixed-usage-limit-and-approval case unguarded). Used by the tie-break
-# below so neither an unrecognized-format response, a mixed
-# blocking+approval response, nor a mixed usage-limit+approval response
-# is silently outranked by a clean approval on a timestamp tie.
-codex_response_requires_attention() {
+# Ranks a response into one of four priority tiers, highest wins on a
+# timestamp tie (see codex_select_terminal_evidence and
+# codex_select_review_evidence below). Checked in this exact order so a
+# response matching multiple patterns resolves to its most severe tier:
+#
+#   3 — blocking: an actual finding. Must never be hidden regardless of
+#       what else the response says (e.g. "No blocking issues found.
+#       Must fix ..." is blocking, not approved).
+#   2 — unrecognized format: neither blocking, usage-limit, nor approved.
+#       The documented verdict classifier safe-fails this to
+#       NEEDS_REVISION (see "Verdict parsing" header comment) because it
+#       could be a disguised rejection in an unexpected format. Ranked
+#       ABOVE usage-limit: a permissive unavailable-policy consumer could
+#       treat a usage-limit UNAVAILABLE more leniently than an explicit
+#       NEEDS_REVISION, so an ambiguous response must not be silently
+#       demoted behind a mere availability notice (fresh evidence from PR
+#       #1490 finding 3789597796).
+#   1 — usage-limit: Codex hit its review quota. A response containing
+#       both an approval phrase and usage-limit wording (e.g. "No
+#       blocking issues could be evaluated because you have reached your
+#       Codex usage limits") is a usage-limit notice, not approved (fresh
+#       evidence from PR #1490 finding 3789555934).
+#   0 — clean approval: the only tier that produces APPROVED.
+#
+# A single binary requires-attention flag is not enough: two tied
+# responses that are BOTH "not a clean approval" (e.g. a usage-limit root
+# comment and a blocking submitted review, or a usage-limit response and
+# an unrecognized-format response) need their own internal ranking, not
+# just a tie that keeps whichever was evaluated first (fresh evidence
+# from PR #1490 finding 3789521036).
+codex_response_priority() {
   local body="$1"
-  codex_response_is_blocking "$body" || codex_response_is_usage_limit "$body" || ! codex_response_is_approved "$body"
+  if codex_response_is_blocking "$body"; then
+    printf '3\n'
+  elif codex_response_is_usage_limit "$body"; then
+    printf '1\n'
+  elif codex_response_is_approved "$body"; then
+    printf '0\n'
+  else
+    printf '2\n'
+  fi
 }
 
 # Decides whether CANDIDATE terminal ("review"-sourced) evidence should
-# replace CURRENT terminal evidence. A strictly later candidate always wins.
-# GitHub timestamps are second-resolution, so ties are possible; on an exact
-# tie, evidence is ranked in three tiers — blocking > other-attention-
-# requiring (e.g. unrecognized format, a usage-limit notice) > clean
-# approval — and the higher tier wins regardless of which side (submitted
-# review vs SHA-pinned root comment) supplied it. Checking only the binary
-# requires-attention distinction is not enough: two tied responses that are
-# BOTH "requires attention" (e.g. a usage-limit root comment and a blocking
-# submitted review) would keep whichever was CURRENT even when the
-# candidate is strictly more severe (blocking), silently discarding an
-# actionable finding behind an unavailable verdict (fresh evidence from PR
-# #1490 finding 3789521036 — the prior fix addressed only
-# codex_select_review_evidence's own review-vs-review scan, leaving this
-# shared cross-source selector, used for terminal-comment-vs-terminal-
-# comment and terminal-vs-review ties, unchanged). Blocking is checked
-# first; only if neither side is blocking does the requires-attention tier
-# decide the tie.
+# replace CURRENT terminal evidence. A strictly later candidate always
+# wins. GitHub timestamps are second-resolution, so ties are possible; on
+# an exact tie, the strictly higher-priority response wins
+# (codex_response_priority) regardless of which side (submitted review vs
+# SHA-pinned root comment) supplied it, and regardless of which side is
+# CURRENT vs. candidate. A tie in priority keeps CURRENT (arbitrary but
+# stable — both sides are equivalent for verdict purposes at that tier).
 codex_select_terminal_evidence() {
   local current_body="$1" current_time="$2"
   local candidate_body="$3" candidate_time="$4"
@@ -313,10 +325,10 @@ codex_select_terminal_evidence() {
     return 0
   fi
   if [ "$candidate_time" = "$current_time" ]; then
-    if codex_response_is_blocking "$candidate_body" && ! codex_response_is_blocking "$current_body"; then
-      return 0
-    fi
-    if codex_response_requires_attention "$candidate_body" && ! codex_response_requires_attention "$current_body"; then
+    local candidate_priority current_priority
+    candidate_priority=$(codex_response_priority "$candidate_body")
+    current_priority=$(codex_response_priority "$current_body")
+    if [ "$candidate_priority" -gt "$current_priority" ]; then
       return 0
     fi
   fi
@@ -400,59 +412,40 @@ codex_scan_comment_evidence() {
 # every review sharing the max timestamp rather than collapsing to one via
 # `sort_by | last`). GitHub timestamps are second-resolution, so multiple
 # reviews genuinely CAN tie; picking an arbitrary one by array order could
-# silently discard a blocking review in favor of a clean one submitted in
-# the same second (fresh evidence from PR #1490 finding 3788008326). Among
-# tied reviews, a BLOCKING one always wins outright over any other
-# non-clean type (e.g. a usage-limit response) — scanning stops at the
-# first "requires attention" match without this priority let a tied
-# usage-limit response returned before a blocking one silently discard
-# the blocker, emitting UNAVAILABLE instead of NEEDS_REVISION (fresh
-# evidence from PR #1490 finding 3789477520). If no tied review is
-# blocking, the first one requiring attention (unrecognized format, e.g.
-# usage-limit text) is used; if none require attention, every tied review
-# is a clean approval and any one is equivalent, so the first is used.
+# silently discard a more severe response in favor of a less severe one
+# submitted in the same second (fresh evidence from PR #1490 findings
+# 3788008326, 3789477520, and 3789597796). Tracks the highest-priority
+# tied review via codex_response_priority (blocking > unrecognized format
+# > usage-limit > clean approval) rather than stopping at the first match
+# for a single binary tier — a scan that only distinguishes "requires
+# attention" from "clean" cannot correctly rank two tied responses that
+# are both "requires attention" but at different severities.
 # Sets: SELECTED_REVIEW_BODY, SELECTED_REVIEW_TIME.
 codex_select_review_evidence() {
   local reviews_file="$1"
   SELECTED_REVIEW_BODY=""
   SELECTED_REVIEW_TIME=""
-  # Presence is tracked via explicit found-flags, not by checking whether
-  # the candidate/blocking/attention body strings are non-empty — a
-  # winning review's body can legitimately be empty (see
+  # Presence is tracked via an explicit found-flag, not by checking
+  # whether the selected body string is non-empty — a winning review's
+  # body can legitimately be empty (see
   # codex_combine_terminal_evidence's review_time-based presence check
   # above), so inferring "not yet found" from string emptiness would
   # reintroduce that exact bug here.
-  local have_default=0 have_blocking=0 have_attention=0
-  local blocking_body="" blocking_time=""
-  local attention_body="" attention_time=""
-  local line created_at body
+  local have_selection=0
+  local best_priority=-1
+  local line created_at body priority
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     created_at=$(printf '%s' "$line" | jq -r '.created_at // empty')  # workflow-shell-guard: allow SH003 - $line is a compact JSON object already validated parseable by the preceding jq -sc call; empty is a normal absent-field case, not a failure
     body=$(printf '%s' "$line" | jq -r '.body // empty')  # workflow-shell-guard: allow SH003 - same pre-validated $line as above; empty body is not a failure
-    if [ "$have_default" -eq 0 ]; then
+    priority=$(codex_response_priority "$body")
+    if [ "$have_selection" -eq 0 ] || [ "$priority" -gt "$best_priority" ]; then
       SELECTED_REVIEW_BODY="$body"
       SELECTED_REVIEW_TIME="$created_at"
-      have_default=1
-    fi
-    if [ "$have_blocking" -eq 0 ] && codex_response_is_blocking "$body"; then
-      blocking_body="$body"
-      blocking_time="$created_at"
-      have_blocking=1
-    fi
-    if [ "$have_attention" -eq 0 ] && codex_response_requires_attention "$body"; then
-      attention_body="$body"
-      attention_time="$created_at"
-      have_attention=1
+      best_priority="$priority"
+      have_selection=1
     fi
   done < "$reviews_file"
-  if [ "$have_blocking" -eq 1 ]; then
-    SELECTED_REVIEW_BODY="$blocking_body"
-    SELECTED_REVIEW_TIME="$blocking_time"
-  elif [ "$have_attention" -eq 1 ]; then
-    SELECTED_REVIEW_BODY="$attention_body"
-    SELECTED_REVIEW_TIME="$attention_time"
-  fi
 }
 
 # Combines comment-sourced evidence (terminal SHA-pinned root comment vs.
@@ -503,9 +496,9 @@ codex_combine_terminal_evidence() {
   # review-poll jq queries' filter, but its body CAN legitimately be
   # empty. Checking review_body would treat an empty-bodied tied review
   # as absent, letting a clean terminal comment win the tie-break by
-  # default even though codex_response_requires_attention correctly
-  # classifies an empty body as an unrecognized response requiring
-  # attention (fresh evidence from PR #1490 finding 3788118857).
+  # default even though codex_response_priority correctly ranks an empty
+  # body as an unrecognized response (priority 2) requiring attention
+  # (fresh evidence from PR #1490 finding 3788118857).
   if [ -n "$review_time" ]; then
     if [ "$COMBINED_SOURCE" = "review" ]; then
       if codex_select_terminal_evidence "$COMBINED_BODY" "$COMBINED_TIME" "$review_body" "$review_time"; then

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -315,6 +315,14 @@ codex_select_terminal_evidence() {
 # the latest comment prevents a later ancillary comment (e.g. a thumbs-up
 # acknowledgement or a "waiting" note) from silently discarding an earlier
 # SHA-pinned blocking root comment.
+#
+# An environment-setup-error comment is treated as the priority ancillary
+# signal once seen: a later PLAIN comment (e.g. an acknowledgement) does not
+# overwrite it, so an actionable setup failure is not silently lost to a
+# no-information comment that happens to arrive later in the same fetch
+# (fresh evidence from PR #1490 finding 3787786945). A LATER environment-
+# error comment still updates it, keeping the most recent one.
+#
 # Sets: COMMENT_TERMINAL_BODY, COMMENT_TERMINAL_TIME, COMMENT_LATEST_BODY,
 # COMMENT_LATEST_TIME.
 codex_scan_comment_evidence() {
@@ -323,13 +331,19 @@ codex_scan_comment_evidence() {
   COMMENT_TERMINAL_TIME=""
   COMMENT_LATEST_BODY=""
   COMMENT_LATEST_TIME=""
-  local line created_at body
+  local comment_latest_is_env_error=0
+  local line created_at body is_env_error
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     created_at=$(printf '%s' "$line" | jq -r '.created_at // empty')  # workflow-shell-guard: allow SH003 - $line is a compact JSON object already validated parseable by the preceding jq -sc call; empty is a normal absent-field case, not a failure
     body=$(printf '%s' "$line" | jq -r '.body // empty')  # workflow-shell-guard: allow SH003 - same pre-validated $line as above; empty body is not a failure
-    COMMENT_LATEST_BODY="$body"
-    COMMENT_LATEST_TIME="$created_at"
+    is_env_error=0
+    codex_response_is_environment_error "$body" && is_env_error=1
+    if [ "$comment_latest_is_env_error" -eq 0 ] || [ "$is_env_error" -eq 1 ]; then
+      COMMENT_LATEST_BODY="$body"
+      COMMENT_LATEST_TIME="$created_at"
+      comment_latest_is_env_error="$is_env_error"
+    fi
     if codex_response_reviews_current_head "$body"; then
       COMMENT_TERMINAL_BODY="$body"
       COMMENT_TERMINAL_TIME="$created_at"
@@ -340,11 +354,15 @@ codex_scan_comment_evidence() {
 # Combines comment-sourced evidence (terminal SHA-pinned root comment vs.
 # latest ancillary comment, from codex_scan_comment_evidence) with
 # review-sourced evidence (from the pulls/{PR}/reviews endpoint) into a
-# single winning result, applying not-a-clean-approval-first tie-breaking
-# (codex_select_terminal_evidence) so a genuine submitted review only
-# supersedes a SHA-pinned terminal root comment when it is strictly newer, or
-# tied and itself not a clean approval (blocking or unrecognized format)
-# while the comment is.
+# single winning result. A SHA-pinned terminal comment applies the existing
+# not-a-clean-approval-first tie-break (codex_select_terminal_evidence) so a
+# genuine submitted review only supersedes it when strictly newer, or tied
+# and itself not a clean approval. A bare ancillary comment (acknowledgement,
+# "waiting" note) carries no information and is always outranked by a
+# genuine review regardless of timing. An ancillary comment that is
+# specifically a recorded environment-setup error is treated as actionable
+# evidence, not noise: it uses the same tie-break as SHA-pinned evidence, so
+# only a strictly newer review can supersede it.
 # Sets: COMBINED_BODY, COMBINED_TIME, COMBINED_SOURCE ("review", "comment",
 # or "" if no evidence at all). LABEL is used only for INFO logging.
 codex_combine_terminal_evidence() {
@@ -369,18 +387,36 @@ codex_combine_terminal_evidence() {
   fi
 
   if [ -n "$review_body" ]; then
-    if [ "$COMBINED_SOURCE" != "review" ]; then
-      # No terminal comment evidence yet: a genuine submitted review always
-      # outranks ancillary/absent comment evidence.
+    if [ "$COMBINED_SOURCE" = "review" ]; then
+      # SHA-pinned terminal comment already present: existing tie-break.
+      if codex_select_terminal_evidence "$COMBINED_BODY" "$COMBINED_TIME" "$review_body" "$review_time"; then
+        COMBINED_BODY="$review_body"
+        COMBINED_TIME="$review_time"
+        COMBINED_SOURCE="review"
+        echo "INFO: $label detected via PR reviews endpoint (supersedes SHA-pinned comment)"
+      fi
+    elif [ "$COMBINED_SOURCE" = "comment" ] && codex_response_is_environment_error "$COMBINED_BODY"; then
+      # Ancillary evidence is specifically a recorded environment-setup
+      # error. Unlike a bare acknowledgement, this IS actionable evidence,
+      # so a review must not silently discard it regardless of timing — only
+      # a strictly newer review may supersede it (fresh evidence from PR
+      # #1490 finding 3787786943).
+      if codex_select_terminal_evidence "$COMBINED_BODY" "$COMBINED_TIME" "$review_body" "$review_time"; then
+        COMBINED_BODY="$review_body"
+        COMBINED_TIME="$review_time"
+        COMBINED_SOURCE="review"
+        echo "INFO: $label detected via PR reviews endpoint (supersedes environment-setup error)"
+      else
+        echo "INFO: $label environment-setup error retained over non-newer review evidence"
+      fi
+    else
+      # No terminal comment evidence, and any ancillary comment present is
+      # not an environment-setup error (e.g. a bare acknowledgement): a
+      # genuine submitted review always outranks it regardless of timing.
       COMBINED_BODY="$review_body"
       COMBINED_TIME="$review_time"
       COMBINED_SOURCE="review"
       echo "INFO: $label detected via PR reviews endpoint"
-    elif codex_select_terminal_evidence "$COMBINED_BODY" "$COMBINED_TIME" "$review_body" "$review_time"; then
-      COMBINED_BODY="$review_body"
-      COMBINED_TIME="$review_time"
-      COMBINED_SOURCE="review"
-      echo "INFO: $label detected via PR reviews endpoint (supersedes SHA-pinned comment)"
     fi
   fi
 }
@@ -608,7 +644,12 @@ while true; do
     | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
         '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
     > "$REVIEW_TMPFILE" 2>"$REVIEW_STDERR"; then
-    REVIEW_BODY=$(jq -r '.body // empty' "$REVIEW_TMPFILE" | head -c 5000)  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
+    # Truncation happens inside jq (codepoint slice), not via a piped `head`,
+    # so a long body cannot trigger SIGPIPE on jq under `set -o pipefail`
+    # (an external `| head -c N` pipe closes early on long output, and the
+    # writer's resulting SIGPIPE would otherwise abort the whole script
+    # before any VERDICT line is emitted).
+    REVIEW_BODY=$(jq -r '(.body // empty) | .[0:5000]' "$REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
     REVIEW_TIME=$(jq -r '.created_at // empty' "$REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads the same pre-validated tmpfile as the body extraction above; empty time is not a failure
   else
     REVIEW_ERR=$(cat "$REVIEW_STDERR")
@@ -842,7 +883,9 @@ if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
   | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
       '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
   > "$ASYNC_REVIEW_TMPFILE" 2>/dev/null; then
-  ASYNC_REVIEW_BODY=$(jq -r '.body // empty' "$ASYNC_REVIEW_TMPFILE" | head -c 5000)  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
+  # Truncation happens inside jq (codepoint slice) to avoid SIGPIPE on jq
+  # under `set -o pipefail` (see rationale above the main-loop equivalent).
+  ASYNC_REVIEW_BODY=$(jq -r '(.body // empty) | .[0:5000]' "$ASYNC_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
   ASYNC_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads the same pre-validated tmpfile as the body extraction above; empty time is not a failure
 else
   rm -f "$ASYNC_REVIEW_TMPFILE"
@@ -924,7 +967,10 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
       | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
           '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
       > "$ASYNC_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
-      ASYNC_FINAL_REVIEW_BODY=$(jq -r '.body // empty' "$ASYNC_FINAL_REVIEW_TMPFILE" | head -c 5000)  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
+      # Truncation happens inside jq (codepoint slice) to avoid SIGPIPE on
+      # jq under `set -o pipefail` (see rationale above the main-loop
+      # equivalent).
+      ASYNC_FINAL_REVIEW_BODY=$(jq -r '(.body // empty) | .[0:5000]' "$ASYNC_FINAL_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
       ASYNC_FINAL_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_FINAL_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads the same pre-validated tmpfile as the body extraction above; empty time is not a failure
     else
       rm -f "$ASYNC_FINAL_REVIEW_TMPFILE"
@@ -1044,7 +1090,9 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
     | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
         '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
     > "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
-    ASYNC_REACTION_FINAL_REVIEW_BODY=$(jq -r '.body // empty' "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE" | head -c 5000)  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
+    # Truncation happens inside jq (codepoint slice) to avoid SIGPIPE on jq
+    # under `set -o pipefail` (see rationale above the main-loop equivalent).
+    ASYNC_REACTION_FINAL_REVIEW_BODY=$(jq -r '(.body // empty) | .[0:5000]' "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
     ASYNC_REACTION_FINAL_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads the same pre-validated tmpfile as the body extraction above; empty time is not a failure
   else
     rm -f "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -264,7 +264,19 @@ codex_response_reviews_current_head() {
 # same rules. See "Verdict parsing" header comment for the rationale behind
 # each marker.
 CODEX_BLOCKING_PATTERN='(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)'
-CODEX_APPROVAL_PATTERN='(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)'
+# \b word boundaries around the positive approval words: without them,
+# "approved" as a bare substring matched inside prefixed negative forms
+# like "unapproved" or "disapproved" (no space/word-break before
+# "approved" in either), so a current-head response saying "This change
+# remains unapproved" was still classified APPROVED instead of falling
+# through to the documented safe-fail (fresh evidence from PR #1490
+# finding 3789851555 — a followup to finding 3789722818, whose fix only
+# handled SPACE-separated negations like "not approved"; \b closes the
+# concatenated-negation-prefix gap that a space-only negation check
+# cannot). Verified portable across BSD grep (macOS default), GNU grep,
+# and ugrep — all treat \b as a GNU-style word-boundary extension in -E
+# mode.
+CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)'
 # Negated forms of the approval phrases above. CODEX_APPROVAL_PATTERN's
 # "approved"/"lgtm"/"looks good" alternatives are unbounded substring
 # matches, so a rejecting response like "This change is not approved"
@@ -272,7 +284,9 @@ CODEX_APPROVAL_PATTERN='(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space
 # falling through to the documented unrecognized-format safe-fail (fresh
 # evidence from PR #1490 finding 3789722818). Checked BEFORE the positive
 # approval pattern in codex_response_is_approved so a negated approval
-# phrase can never be reported as approved.
+# phrase can never be reported as approved. This handles SPACE-separated
+# negations ("not approved"); CODEX_APPROVAL_PATTERN's \b boundaries above
+# separately handle CONCATENATED negation prefixes ("unapproved").
 CODEX_NEGATED_APPROVAL_PATTERN='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)[[:space:]]+(be[[:space:]]+)?(approved|lgtm|look(s|ing)?[[:space:]]+good)'
 
 codex_response_is_blocking() {

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -39,8 +39,10 @@
 #      "no blocking issues found"; bare "blocking" excluded (too broad).
 #   2. Approval signals present → APPROVED (exit 0)
 #      Signals (case-insensitive): "approved", "lgtm", "looks good",
-#      "didn't find any major issues", "no blocking issues", or a Codex
-#      thumbs-up reaction on the trigger comment
+#      "didn't find any major issues", or "no blocking issues" from a
+#      current-head comment or submitted review. A Codex thumbs-up reaction on
+#      the trigger comment is an acknowledgement only; it is not SHA-pinned
+#      review evidence and must not approve the PR by itself.
 #   3. Neither found (unrecognized format) → safe-fails to NEEDS_REVISION (exit 1)
 #
 # Response source detection (two sources polled each cycle):
@@ -48,9 +50,10 @@
 #     BOT_LOGIN_PLAIN (login without [bot] suffix). Codex posts "clean" results
 #     here from the non-[bot] account (e.g. "chatgpt-codex-connector").
 #   - pulls/{PR}/reviews   — GitHub Review objects; matches both logins. Codex
-#     posts findings here from the [bot]-suffixed account. Polled as fallback
-#     when no PR comment is found; review body safe-fails to NEEDS_REVISION,
-#     which causes pr-review-loop.sh to count unresolved inline threads.
+#     posts findings here from the [bot]-suffixed account. Only submitted
+#     reviews whose commit_id starts with the current head SHA are considered.
+#     The review body safe-fails to NEEDS_REVISION, which causes
+#     pr-review-loop.sh to count unresolved inline threads.
 #
 # Idempotency (BR-10):
 #   Before posting a trigger comment, the script queries existing PR comments
@@ -234,6 +237,11 @@ codex_response_is_usage_limit() {
   printf '%s\n' "$response" | grep -qiE "(reached[[:space:]]+your[[:space:]]+codex[[:space:]]+usage[[:space:]]+limits?|codex[[:space:]]+usage[[:space:]]+limits?[[:space:]]+for[[:space:]]+code[[:space:]]+reviews?|codex[[:space:]]+(github[[:space:]]+app[[:space:]]+)?(review[[:space:]]+)?(usage[[:space:]]+limit|quota|capacity)|codex[[:space:]]+review[[:space:]]+capacity[[:space:]]+(exhausted|unavailable|limited))"
 }
 
+codex_response_is_environment_error() {
+  local response="$1"
+  printf '%s\n' "$response" | grep -qiE "(to[[:space:]]+use[[:space:]]+codex[[:space:]]+here,[[:space:]]+create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo|create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo|codex[[:space:]]+cloud[[:space:]]+environment)"
+}
+
 codex_return_usage_limit() {
   echo "VERDICT: UNAVAILABLE — Codex GitHub review usage limit reached"
   echo "REASON=codex-github-usage-limit"
@@ -244,6 +252,27 @@ codex_return_usage_limit() {
   echo "$1"
   echo "---END BOT RESPONSE---"
   exit 3
+}
+
+codex_return_environment_error() {
+  echo "VERDICT: TIMED_OUT — Codex GitHub review environment missing (treated as unavailable)"
+  echo "REASON=codex-github-environment-missing"
+  echo "COMMENT_COUNT=0"
+  echo "BLOCKING_COUNT=0"
+  echo "SUGGESTION_COUNT=0"
+  echo "---BEGIN BOT RESPONSE---"
+  echo "$1"
+  echo "---END BOT RESPONSE---"
+  exit 2
+}
+
+codex_return_reaction_without_review() {
+  echo "VERDICT: TIMED_OUT — Codex thumbs-up reaction is not SHA-pinned review evidence (treated as unavailable)"
+  echo "REASON=codex-github-reaction-without-review"
+  echo "COMMENT_COUNT=0"
+  echo "BLOCKING_COUNT=0"
+  echo "SUGGESTION_COUNT=0"
+  exit 2
 }
 
 # ── Idempotency guard (BR-10) ─────────────────────────────────────────────────
@@ -386,8 +415,8 @@ while true; do
     REVIEW_TMPFILE=$(mktemp)
     if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
       2>/dev/null \
-      | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-          '.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time) | .body' \
+      | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
+          '.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha))) | .body' \
       > "$REVIEW_TMPFILE" 2>/dev/null; then
       REVIEW_BODY=$(head -c 5000 "$REVIEW_TMPFILE")
       if [ -n "$REVIEW_BODY" ]; then
@@ -413,9 +442,8 @@ while true; do
     exit 2
   fi
   if [ "$APPROVAL_REACTION_COUNT" -gt 0 ]; then
-    echo "VERDICT: APPROVED"
     echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID"
-    exit 0
+    codex_return_reaction_without_review
   fi
 
   if [ -n "$BOT_RESPONSE" ]; then
@@ -436,8 +464,9 @@ while true; do
     #
     # 2. Explicit approval signals present → APPROVED (exit 0)   [checked second]
     #    Approval signals: "approved", "lgtm", "looks good",
-    #    "didn't find any major issues", "no blocking issues", or a Codex
-    #    thumbs-up reaction on the trigger comment (checked above).
+    #    "didn't find any major issues", or "no blocking issues" from a
+    #    current-head comment or submitted review. A Codex thumbs-up reaction on
+    #    the trigger comment is not SHA-pinned and is unavailable, not clean.
     #
     # 3. Neither found (unrecognized response format) → NEEDS_REVISION (exit 1)
     #    Safe-fail: default to NEEDS_REVISION when the format is unrecognized to
@@ -453,6 +482,8 @@ while true; do
 
     if codex_response_is_usage_limit "$BOT_RESPONSE"; then
       codex_return_usage_limit "$BOT_RESPONSE"
+    elif codex_response_is_environment_error "$BOT_RESPONSE"; then
+      codex_return_environment_error "$BOT_RESPONSE"
     elif echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
       echo "VERDICT: NEEDS_REVISION"
       echo "---BEGIN BOT RESPONSE---"
@@ -466,7 +497,7 @@ while true; do
       echo "---END BOT RESPONSE---"
       exit 0
     elif echo "$BOT_RESPONSE" | grep -qi "If Codex has suggestions, it will comment; otherwise it will react with"; then
-      echo "INFO: Codex acknowledgement detected; waiting for thumbs-up reaction or inline review comments"
+      echo "INFO: Codex acknowledgement detected; waiting for current-head review, clean comment, or inline review comments"
       continue
     else
       echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
@@ -570,9 +601,8 @@ if [ -n "$ASYNC_TRIGGER_COMMENT_ID" ]; then
   ASYNC_APPROVAL_REACTION_COUNT=$((ASYNC_APPROVAL_REACTION_COUNT + ASYNC_EXTRA_APPROVAL_REACTION_COUNT))
 fi
 if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
-  echo "VERDICT: APPROVED"
   echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID during async grace period"
-  exit 0
+  codex_return_reaction_without_review
 fi
 
 ASYNC_POLL_TMPFILE=$(mktemp)
@@ -589,8 +619,8 @@ if [ -z "$ASYNC_BOT_RESPONSE" ]; then
   ASYNC_REVIEW_TMPFILE=$(mktemp)
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>/dev/null \
-    | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-        '.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time) | .body' \
+    | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
+        '.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha))) | .body' \
     > "$ASYNC_REVIEW_TMPFILE" 2>/dev/null; then
     ASYNC_REVIEW_BODY=$(head -c 5000 "$ASYNC_REVIEW_TMPFILE")
     if [ -n "$ASYNC_REVIEW_BODY" ]; then
@@ -607,6 +637,8 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
   # Apply the same three-path verdict parsing as the main poll loop.
   if codex_response_is_usage_limit "$ASYNC_BOT_RESPONSE"; then
     codex_return_usage_limit "$ASYNC_BOT_RESPONSE"
+  elif codex_response_is_environment_error "$ASYNC_BOT_RESPONSE"; then
+    codex_return_environment_error "$ASYNC_BOT_RESPONSE"
   elif echo "$ASYNC_BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
     echo "VERDICT: NEEDS_REVISION"
     echo "---BEGIN BOT RESPONSE---"
@@ -620,7 +652,7 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     echo "---END BOT RESPONSE---"
     exit 0
   elif echo "$ASYNC_BOT_RESPONSE" | grep -qi "If Codex has suggestions, it will comment; otherwise it will react with"; then
-    echo "INFO: async-arrival Codex acknowledgement detected without approval reaction or inline comments"
+    echo "INFO: async-arrival Codex acknowledgement detected without current-head review, clean comment, or inline comments"
     echo "INFO: waiting ${POLL_INTERVAL}s for final Codex async signal..."
     sleep "$POLL_INTERVAL"
     if ! ASYNC_INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME"); then
@@ -644,9 +676,8 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
       ASYNC_APPROVAL_REACTION_COUNT=$((ASYNC_APPROVAL_REACTION_COUNT + ASYNC_EXTRA_APPROVAL_REACTION_COUNT))
     fi
     if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
-      echo "VERDICT: APPROVED"
       echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID after async acknowledgement"
-      exit 0
+      codex_return_reaction_without_review
     fi
   else
     echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -354,15 +354,22 @@ codex_scan_comment_evidence() {
 # Combines comment-sourced evidence (terminal SHA-pinned root comment vs.
 # latest ancillary comment, from codex_scan_comment_evidence) with
 # review-sourced evidence (from the pulls/{PR}/reviews endpoint) into a
-# single winning result. A SHA-pinned terminal comment applies the existing
-# not-a-clean-approval-first tie-break (codex_select_terminal_evidence) so a
-# genuine submitted review only supersedes it when strictly newer, or tied
-# and itself not a clean approval. A bare ancillary comment (acknowledgement,
-# "waiting" note) carries no information and is always outranked by a
-# genuine review regardless of timing. An ancillary comment that is
-# specifically a recorded environment-setup error is treated as actionable
-# evidence, not noise: it uses the same tie-break as SHA-pinned evidence, so
-# only a strictly newer review can supersede it.
+# single winning result. A SHA-pinned terminal comment and a genuine
+# submitted review apply the not-a-clean-approval-first tie-break
+# (codex_select_terminal_evidence): the strictly newer one wins, or on a
+# tie the one that is not a clean approval wins.
+#
+# An ancillary comment that is specifically a recorded environment-setup
+# error is treated as actionable evidence in its own right, not noise, and
+# is checked independently of whichever of (terminal comment, review) won
+# above — a SHA-pinned terminal comment or a review must not silently
+# discard a same-or-newer environment-setup error just because it competed
+# with a different evidence type (fresh evidence from PR #1490 finding
+# 3787868727: the terminal-comment branch previously never considered the
+# environment error at all). Only strictly newer terminal/review evidence
+# supersedes it. A bare non-error ancillary comment (acknowledgement,
+# "waiting" note) carries no information and never competes with anything.
+#
 # Sets: COMBINED_BODY, COMBINED_TIME, COMBINED_SOURCE ("review", "comment",
 # or "" if no evidence at all). LABEL is used only for INFO logging.
 codex_combine_terminal_evidence() {
@@ -380,43 +387,40 @@ codex_combine_terminal_evidence() {
     COMBINED_TIME="$comment_terminal_time"
     COMBINED_SOURCE="review"
     echo "INFO: $label detected via SHA-pinned PR comment"
-  elif [ -n "$comment_latest_body" ]; then
-    COMBINED_BODY="$comment_latest_body"
-    COMBINED_TIME="$comment_latest_time"
-    COMBINED_SOURCE="comment"
   fi
 
   if [ -n "$review_body" ]; then
     if [ "$COMBINED_SOURCE" = "review" ]; then
-      # SHA-pinned terminal comment already present: existing tie-break.
       if codex_select_terminal_evidence "$COMBINED_BODY" "$COMBINED_TIME" "$review_body" "$review_time"; then
         COMBINED_BODY="$review_body"
         COMBINED_TIME="$review_time"
         COMBINED_SOURCE="review"
         echo "INFO: $label detected via PR reviews endpoint (supersedes SHA-pinned comment)"
       fi
-    elif [ "$COMBINED_SOURCE" = "comment" ] && codex_response_is_environment_error "$COMBINED_BODY"; then
-      # Ancillary evidence is specifically a recorded environment-setup
-      # error. Unlike a bare acknowledgement, this IS actionable evidence,
-      # so a review must not silently discard it regardless of timing — only
-      # a strictly newer review may supersede it (fresh evidence from PR
-      # #1490 finding 3787786943).
-      if codex_select_terminal_evidence "$COMBINED_BODY" "$COMBINED_TIME" "$review_body" "$review_time"; then
-        COMBINED_BODY="$review_body"
-        COMBINED_TIME="$review_time"
-        COMBINED_SOURCE="review"
-        echo "INFO: $label detected via PR reviews endpoint (supersedes environment-setup error)"
-      else
-        echo "INFO: $label environment-setup error retained over non-newer review evidence"
-      fi
     else
-      # No terminal comment evidence, and any ancillary comment present is
-      # not an environment-setup error (e.g. a bare acknowledgement): a
-      # genuine submitted review always outranks it regardless of timing.
       COMBINED_BODY="$review_body"
       COMBINED_TIME="$review_time"
       COMBINED_SOURCE="review"
       echo "INFO: $label detected via PR reviews endpoint"
+    fi
+  fi
+
+  if [ -z "$COMBINED_SOURCE" ] && [ -n "$comment_latest_body" ]; then
+    # Neither a SHA-pinned terminal comment nor a review produced any
+    # evidence: fall back to the latest bare ancillary comment (may be an
+    # environment-setup error, an acknowledgement, or other non-terminal
+    # text) so the outer verdict classifier still has something to inspect.
+    COMBINED_BODY="$comment_latest_body"
+    COMBINED_TIME="$comment_latest_time"
+    COMBINED_SOURCE="comment"
+  fi
+
+  if [ -n "$comment_latest_body" ] && codex_response_is_environment_error "$comment_latest_body"; then
+    if [ -z "$COMBINED_TIME" ] || ! codex_select_terminal_evidence "$comment_latest_body" "$comment_latest_time" "$COMBINED_BODY" "$COMBINED_TIME"; then
+      COMBINED_BODY="$comment_latest_body"
+      COMBINED_TIME="$comment_latest_time"
+      COMBINED_SOURCE="comment"
+      echo "INFO: $label environment-setup error retained over non-newer terminal/review evidence"
     fi
   fi
 }
@@ -667,8 +671,15 @@ while true; do
   BOT_RESPONSE="$COMBINED_BODY"
   BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
   # Truncate here (post-combine) — mirrors the prior per-source truncation but
-  # applies uniformly regardless of which source won.
-  BOT_RESPONSE=$(printf '%s' "$BOT_RESPONSE" | head -c 10000)
+  # applies uniformly regardless of which source won. Root-comment-sourced
+  # bodies are not truncated at scan time (unlike review bodies, which are
+  # already sliced to 5000 chars inside jq), so a body near GitHub's
+  # per-comment size limit could still exceed a pipe buffer here. `jq -Rs`
+  # slurps its entire stdin before producing any output, so the writer
+  # (printf) is always fully drained and can never receive SIGPIPE, unlike
+  # a piped `head -c N` which can close early on long input (fresh evidence
+  # from PR #1490 finding 3787868733).
+  BOT_RESPONSE=$(printf '%s' "$BOT_RESPONSE" | jq -Rrs '.[0:10000]')
 
   if ! INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME"); then
     echo "VERDICT: TIMED_OUT — failed to fetch Codex inline review comments (treated as unavailable)"
@@ -900,7 +911,10 @@ codex_combine_terminal_evidence "async-arrival bot response" \
   "$ASYNC_REVIEW_BODY" "$ASYNC_REVIEW_TIME"
 ASYNC_BOT_RESPONSE="$COMBINED_BODY"
 ASYNC_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
-ASYNC_BOT_RESPONSE=$(printf '%s' "$ASYNC_BOT_RESPONSE" | head -c 10000)
+# `jq -Rs` slurps its entire stdin before producing output, avoiding
+# SIGPIPE on long root-comment-sourced bodies (see rationale above the
+# main-loop equivalent).
+ASYNC_BOT_RESPONSE=$(printf '%s' "$ASYNC_BOT_RESPONSE" | jq -Rrs '.[0:10000]')
 
 if [ -n "$ASYNC_BOT_RESPONSE" ]; then
   echo "INFO: async-arrival bot response detected during grace period"
@@ -985,7 +999,10 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
       "$ASYNC_FINAL_REVIEW_BODY" "$ASYNC_FINAL_REVIEW_TIME"
     ASYNC_FINAL_BOT_RESPONSE="$COMBINED_BODY"
     ASYNC_FINAL_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
-    ASYNC_FINAL_BOT_RESPONSE=$(printf '%s' "$ASYNC_FINAL_BOT_RESPONSE" | head -c 10000)
+    # `jq -Rs` slurps its entire stdin before producing output, avoiding
+    # SIGPIPE on long root-comment-sourced bodies (see rationale above the
+    # main-loop equivalent).
+    ASYNC_FINAL_BOT_RESPONSE=$(printf '%s' "$ASYNC_FINAL_BOT_RESPONSE" | jq -Rrs '.[0:10000]')
 
     if [ -n "$ASYNC_FINAL_BOT_RESPONSE" ]; then
       echo "INFO: final async bot response detected after acknowledgement wait"
@@ -1107,7 +1124,10 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
     "$ASYNC_REACTION_FINAL_REVIEW_BODY" "$ASYNC_REACTION_FINAL_REVIEW_TIME"
   ASYNC_REACTION_FINAL_BOT_RESPONSE="$COMBINED_BODY"
   ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
-  ASYNC_REACTION_FINAL_BOT_RESPONSE=$(printf '%s' "$ASYNC_REACTION_FINAL_BOT_RESPONSE" | head -c 10000)
+  # `jq -Rs` slurps its entire stdin before producing output, avoiding
+  # SIGPIPE on long root-comment-sourced bodies (see rationale above the
+  # main-loop equivalent).
+  ASYNC_REACTION_FINAL_BOT_RESPONSE=$(printf '%s' "$ASYNC_REACTION_FINAL_BOT_RESPONSE" | jq -Rrs '.[0:10000]')
 
   if [ -n "$ASYNC_REACTION_FINAL_BOT_RESPONSE" ]; then
     codex_require_current_head

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -478,16 +478,27 @@ codex_strip_quoted_spans() {
 
 codex_response_is_blocking() {
   local body="$1"
-  # A misdetected blocking finding inside a fenced example is already
-  # SAFE by itself (it only pushes the verdict toward NEEDS_REVISION, the
-  # conservative direction, never toward APPROVED) — but the fence guard
-  # is applied here too for consistency with every other classifier
-  # below, rather than leaving one classifier's fence-handling
-  # inconsistent with the rest and inviting the next Codex finding that
-  # specifically targets this asymmetry.
-  if codex_response_has_fence_marker "$body"; then
-    return 1
-  fi
+  # UNLIKE the other three classifiers, this one deliberately does NOT
+  # bail out on codex_response_has_fence_marker: a false NEGATIVE here is
+  # NOT safe the way it is for usage-limit/environment-error/approved. A
+  # genuinely asserted blocking finding OUTSIDE a fence, in a review that
+  # also happens to contain an unrelated fenced code example elsewhere,
+  # must still be detected — Protocol 93 requires blocking terminal/
+  # review evidence to always win outright over other evidence (e.g. a
+  # same-fetch usage-limit notice), and codex_combine_terminal_evidence's
+  # "blocking always wins" check depends on this function correctly
+  # reporting TRUE for such a review. Bailing out here on fence presence
+  # briefly broke that invariant: a real blocker got silently overridden
+  # by a later ancillary notice because is_blocking incorrectly reported
+  # FALSE (fresh evidence from PR #1490 finding 3796396399, a regression
+  # introduced by finding 3796042503's "apply the guard everywhere for
+  # consistency" fix — consistency across all four classifiers was the
+  # wrong call for this one, since a blocking false-negative and an
+  # approval/quota false-positive are not symmetric risks). A blocking
+  # false POSITIVE on quoted/fenced text remains safe on its own (it only
+  # pushes toward NEEDS_REVISION), so no fence guard is needed here for
+  # that direction either — codex_strip_quoted_spans' straight-quote/
+  # backtick-pair/blockquote/single-quote stripping is enough.
   grep -qiE "$CODEX_BLOCKING_PATTERN" <<< "$(codex_strip_quoted_spans "$body")"
 }
 

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -249,10 +249,123 @@ codex_response_reviews_current_head() {
   [ -n "$reviewed_sha" ] && { printf '%s\n' "$CURRENT_SHA" | grep -qi "^$reviewed_sha" || printf '%s\n' "$reviewed_sha" | grep -qi "^$CURRENT_SHA"; }
 }
 
-codex_response_time_should_replace() {
-  local candidate_time="$1"
-  local current_time="$2"
-  [ -z "$current_time" ] || [ "$candidate_time" \> "$current_time" ]
+# Blocking/approval marker patterns, centralized so every classification site
+# (main poll, async grace, async-final, async-reaction-final) uses the exact
+# same rules. See "Verdict parsing" header comment for the rationale behind
+# each marker.
+CODEX_BLOCKING_PATTERN='(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)'
+CODEX_APPROVAL_PATTERN='(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)'
+
+codex_response_is_blocking() {
+  local body="$1"
+  printf '%s\n' "$body" | grep -qiE "$CODEX_BLOCKING_PATTERN"
+}
+
+codex_response_is_approved() {
+  local body="$1"
+  printf '%s\n' "$body" | grep -qiE "$CODEX_APPROVAL_PATTERN"
+}
+
+# Decides whether CANDIDATE terminal ("review"-sourced) evidence should
+# replace CURRENT terminal evidence. A strictly later candidate always wins.
+# GitHub timestamps are second-resolution, so ties are possible; on an exact
+# tie, blocking evidence must never be discarded in favor of clean/ancillary
+# evidence, regardless of which side (submitted review vs SHA-pinned root
+# comment) supplied it. This makes the tie-break symmetric: if the candidate
+# is blocking and the current evidence is not, the candidate wins; if the
+# current evidence is blocking and the candidate is not, the current evidence
+# is kept.
+codex_select_terminal_evidence() {
+  local current_body="$1" current_time="$2"
+  local candidate_body="$3" candidate_time="$4"
+  [ -z "$current_time" ] && return 0
+  if [ "$candidate_time" \> "$current_time" ]; then
+    return 0
+  fi
+  if [ "$candidate_time" = "$current_time" ]; then
+    if codex_response_is_blocking "$candidate_body" && ! codex_response_is_blocking "$current_body"; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# Scans a JSON-lines file (one compact object per line, in ascending
+# created_at/id order — as produced by the comment-poll jq queries below) of
+# bot-authored root PR comments and separates SHA-pinned TERMINAL evidence
+# (a "Reviewed commit" marker naming the current head) from the latest
+# comment overall (ancillary: acknowledgement, environment-setup error, or
+# other non-terminal text). Selecting the terminal comment independently from
+# the latest comment prevents a later ancillary comment (e.g. a thumbs-up
+# acknowledgement or a "waiting" note) from silently discarding an earlier
+# SHA-pinned blocking root comment.
+# Sets: COMMENT_TERMINAL_BODY, COMMENT_TERMINAL_TIME, COMMENT_LATEST_BODY,
+# COMMENT_LATEST_TIME.
+codex_scan_comment_evidence() {
+  local comments_file="$1"
+  COMMENT_TERMINAL_BODY=""
+  COMMENT_TERMINAL_TIME=""
+  COMMENT_LATEST_BODY=""
+  COMMENT_LATEST_TIME=""
+  local line created_at body
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    created_at=$(printf '%s' "$line" | jq -r '.created_at // empty')  # workflow-shell-guard: allow SH003 - $line is a compact JSON object already validated parseable by the preceding jq -sc call; empty is a normal absent-field case, not a failure
+    body=$(printf '%s' "$line" | jq -r '.body // empty')  # workflow-shell-guard: allow SH003 - same pre-validated $line as above; empty body is not a failure
+    COMMENT_LATEST_BODY="$body"
+    COMMENT_LATEST_TIME="$created_at"
+    if codex_response_reviews_current_head "$body"; then
+      COMMENT_TERMINAL_BODY="$body"
+      COMMENT_TERMINAL_TIME="$created_at"
+    fi
+  done < "$comments_file"
+}
+
+# Combines comment-sourced evidence (terminal SHA-pinned root comment vs.
+# latest ancillary comment, from codex_scan_comment_evidence) with
+# review-sourced evidence (from the pulls/{PR}/reviews endpoint) into a
+# single winning result, applying blocking-first tie-breaking
+# (codex_select_terminal_evidence) so a genuine submitted review only
+# supersedes a SHA-pinned terminal root comment when it is strictly newer, or
+# tied and itself blocking while the comment is not.
+# Sets: COMBINED_BODY, COMBINED_TIME, COMBINED_SOURCE ("review", "comment",
+# or "" if no evidence at all). LABEL is used only for INFO logging.
+codex_combine_terminal_evidence() {
+  local label="$1"
+  local comment_terminal_body="$2" comment_terminal_time="$3"
+  local comment_latest_body="$4" comment_latest_time="$5"
+  local review_body="$6" review_time="$7"
+
+  COMBINED_BODY=""
+  COMBINED_TIME=""
+  COMBINED_SOURCE=""
+
+  if [ -n "$comment_terminal_body" ]; then
+    COMBINED_BODY="$comment_terminal_body"
+    COMBINED_TIME="$comment_terminal_time"
+    COMBINED_SOURCE="review"
+    echo "INFO: $label detected via SHA-pinned PR comment"
+  elif [ -n "$comment_latest_body" ]; then
+    COMBINED_BODY="$comment_latest_body"
+    COMBINED_TIME="$comment_latest_time"
+    COMBINED_SOURCE="comment"
+  fi
+
+  if [ -n "$review_body" ]; then
+    if [ "$COMBINED_SOURCE" != "review" ]; then
+      # No terminal comment evidence yet: a genuine submitted review always
+      # outranks ancillary/absent comment evidence.
+      COMBINED_BODY="$review_body"
+      COMBINED_TIME="$review_time"
+      COMBINED_SOURCE="review"
+      echo "INFO: $label detected via PR reviews endpoint"
+    elif codex_select_terminal_evidence "$COMBINED_BODY" "$COMBINED_TIME" "$review_body" "$review_time"; then
+      COMBINED_BODY="$review_body"
+      COMBINED_TIME="$review_time"
+      COMBINED_SOURCE="review"
+      echo "INFO: $label detected via PR reviews endpoint (supersedes SHA-pinned comment)"
+    fi
+  fi
 }
 
 codex_return_usage_limit() {
@@ -433,23 +546,17 @@ while true; do
   # contains jq-special characters (e.g., double quote, backslash).
   POLL_STDERR=$(mktemp)
   POLL_TMPFILE=$(mktemp)
+  BOT_RESPONSE=""
   BOT_RESPONSE_SOURCE=""
-  BOT_RESPONSE_TIME=""
   if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
     2>"$POLL_STDERR" \
-    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
-        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | {created_at:(.created_at // ""), body:(.body // "")}' \
+    | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
+        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | .[] | {created_at:(.created_at // ""), body:(.body // "")}' \
     > "$POLL_TMPFILE"; then
-	    # Truncate after successful API call — no SIGPIPE risk here
-	    BOT_RESPONSE=$(jq -r '.body // empty' "$POLL_TMPFILE" | head -c 10000)
-	    BOT_RESPONSE_TIME=$(jq -r '.created_at // empty' "$POLL_TMPFILE")
-	    if [ -n "$BOT_RESPONSE" ]; then
-	      BOT_RESPONSE_SOURCE="comment"
-	      if codex_response_reviews_current_head "$BOT_RESPONSE"; then
-	        BOT_RESPONSE_SOURCE="review"
-	        echo "INFO: bot response detected via SHA-pinned PR comment"
-	      fi
-	    fi
+    # Scan ALL matching root comments (not just the latest) so a SHA-pinned
+    # terminal comment (Reviewed commit marker) is not discarded in favor of
+    # a later ancillary comment (e.g. an acknowledgement).
+    codex_scan_comment_evidence "$POLL_TMPFILE"
     rm -f "$POLL_STDERR" "$POLL_TMPFILE"
     CONSECUTIVE_API_FAILURES=0
   else
@@ -475,14 +582,8 @@ while true; do
     | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
         '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
     > "$REVIEW_TMPFILE" 2>"$REVIEW_STDERR"; then
-    REVIEW_BODY=$(jq -r '.body // empty' "$REVIEW_TMPFILE" | head -c 5000)
-    REVIEW_TIME=$(jq -r '.created_at // empty' "$REVIEW_TMPFILE")
-    if [ -n "$REVIEW_BODY" ] && { [ "$BOT_RESPONSE_SOURCE" != "review" ] || codex_response_time_should_replace "$REVIEW_TIME" "$BOT_RESPONSE_TIME"; }; then
-      BOT_RESPONSE="$REVIEW_BODY"
-      BOT_RESPONSE_TIME="$REVIEW_TIME"
-      BOT_RESPONSE_SOURCE="review"
-      echo "INFO: bot response detected via PR reviews endpoint"
-    fi
+    REVIEW_BODY=$(jq -r '.body // empty' "$REVIEW_TMPFILE" | head -c 5000)  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
+    REVIEW_TIME=$(jq -r '.created_at // empty' "$REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads the same pre-validated tmpfile as the body extraction above; empty time is not a failure
   else
     REVIEW_ERR=$(cat "$REVIEW_STDERR")
     rm -f "$REVIEW_STDERR" "$REVIEW_TMPFILE"
@@ -491,6 +592,16 @@ while true; do
     exit 2
   fi
   rm -f "$REVIEW_STDERR" "$REVIEW_TMPFILE"
+
+  codex_combine_terminal_evidence "bot response" \
+    "$COMMENT_TERMINAL_BODY" "$COMMENT_TERMINAL_TIME" \
+    "$COMMENT_LATEST_BODY" "$COMMENT_LATEST_TIME" \
+    "$REVIEW_BODY" "$REVIEW_TIME"
+  BOT_RESPONSE="$COMBINED_BODY"
+  BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
+  # Truncate here (post-combine) — mirrors the prior per-source truncation but
+  # applies uniformly regardless of which source won.
+  BOT_RESPONSE=$(printf '%s' "$BOT_RESPONSE" | head -c 10000)
 
   if ! INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME"); then
     echo "VERDICT: TIMED_OUT — failed to fetch Codex inline review comments (treated as unavailable)"
@@ -550,13 +661,13 @@ while true; do
       SEEN_ENVIRONMENT_RESPONSE="$BOT_RESPONSE"
       echo "INFO: Codex environment setup response detected; waiting for fresh current-head review evidence"
       continue
-    elif [ "$BOT_RESPONSE_SOURCE" = "review" ] && echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+    elif [ "$BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$BOT_RESPONSE"; then
       echo "VERDICT: NEEDS_REVISION"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 1
-    elif [ "$BOT_RESPONSE_SOURCE" = "review" ] && echo "$BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
+    elif [ "$BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$BOT_RESPONSE"; then
       echo "VERDICT: APPROVED"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
@@ -655,7 +766,6 @@ sleep "$POLL_INTERVAL"
 # Single grace poll: check both PR comments and PR reviews
 ASYNC_BOT_RESPONSE=""
 ASYNC_BOT_RESPONSE_SOURCE=""
-ASYNC_BOT_RESPONSE_TIME=""
 
 if ! ASYNC_INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME"); then
   echo "VERDICT: TIMED_OUT — failed to fetch Codex inline review comments during async grace period (treated as unavailable)"
@@ -682,20 +792,19 @@ fi
 ASYNC_POLL_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>/dev/null \
-  | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
-      '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | {created_at:(.created_at // ""), body:(.body // "")}' \
-	  > "$ASYNC_POLL_TMPFILE" 2>/dev/null; then
-	  ASYNC_BOT_RESPONSE=$(jq -r '.body // empty' "$ASYNC_POLL_TMPFILE" | head -c 10000)
-	  ASYNC_BOT_RESPONSE_TIME=$(jq -r '.created_at // empty' "$ASYNC_POLL_TMPFILE")
-	  if [ -n "$ASYNC_BOT_RESPONSE" ]; then
-	    ASYNC_BOT_RESPONSE_SOURCE="comment"
-	    if codex_response_reviews_current_head "$ASYNC_BOT_RESPONSE"; then
-	      ASYNC_BOT_RESPONSE_SOURCE="review"
-	      echo "INFO: async-arrival bot response detected via SHA-pinned PR comment"
-	    fi
-	  fi
+  | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
+      '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | .[] | {created_at:(.created_at // ""), body:(.body // "")}' \
+  > "$ASYNC_POLL_TMPFILE" 2>/dev/null; then
+  codex_scan_comment_evidence "$ASYNC_POLL_TMPFILE"
+  rm -f "$ASYNC_POLL_TMPFILE"
+else
+  rm -f "$ASYNC_POLL_TMPFILE"
+  # Root comments are a terminal evidence source: a failed fetch here must be
+  # treated as unavailable BEFORE any clean review evidence from the reviews
+  # endpoint is accepted below (Finding #3 — fail closed, not fail open).
+  echo "VERDICT: TIMED_OUT — failed to fetch Codex root comments during async grace period (treated as unavailable)"
+  exit 2
 fi
-rm -f "$ASYNC_POLL_TMPFILE"
 
 ASYNC_REVIEW_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
@@ -703,20 +812,22 @@ if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
   | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
       '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
   > "$ASYNC_REVIEW_TMPFILE" 2>/dev/null; then
-  ASYNC_REVIEW_BODY=$(jq -r '.body // empty' "$ASYNC_REVIEW_TMPFILE" | head -c 5000)
-  ASYNC_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_REVIEW_TMPFILE")
-	  if [ -n "$ASYNC_REVIEW_BODY" ] && { [ "$ASYNC_BOT_RESPONSE_SOURCE" != "review" ] || codex_response_time_should_replace "$ASYNC_REVIEW_TIME" "$ASYNC_BOT_RESPONSE_TIME"; }; then
-	    ASYNC_BOT_RESPONSE="$ASYNC_REVIEW_BODY"
-	    ASYNC_BOT_RESPONSE_TIME="$ASYNC_REVIEW_TIME"
-	    ASYNC_BOT_RESPONSE_SOURCE="review"
-    echo "INFO: async-arrival bot response detected via PR reviews endpoint"
-  fi
+  ASYNC_REVIEW_BODY=$(jq -r '.body // empty' "$ASYNC_REVIEW_TMPFILE" | head -c 5000)  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
+  ASYNC_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads the same pre-validated tmpfile as the body extraction above; empty time is not a failure
 else
   rm -f "$ASYNC_REVIEW_TMPFILE"
   echo "VERDICT: TIMED_OUT — failed to fetch Codex PR reviews during async grace period (treated as unavailable)"
   exit 2
 fi
 rm -f "$ASYNC_REVIEW_TMPFILE"
+
+codex_combine_terminal_evidence "async-arrival bot response" \
+  "$COMMENT_TERMINAL_BODY" "$COMMENT_TERMINAL_TIME" \
+  "$COMMENT_LATEST_BODY" "$COMMENT_LATEST_TIME" \
+  "$ASYNC_REVIEW_BODY" "$ASYNC_REVIEW_TIME"
+ASYNC_BOT_RESPONSE="$COMBINED_BODY"
+ASYNC_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
+ASYNC_BOT_RESPONSE=$(printf '%s' "$ASYNC_BOT_RESPONSE" | head -c 10000)
 
 if [ -n "$ASYNC_BOT_RESPONSE" ]; then
   echo "INFO: async-arrival bot response detected during grace period"
@@ -729,13 +840,13 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     SEEN_ENVIRONMENT_ERROR=1
     SEEN_ENVIRONMENT_RESPONSE="$ASYNC_BOT_RESPONSE"
     echo "INFO: async-arrival Codex environment setup response detected without fresh review evidence"
-  elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && echo "$ASYNC_BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+  elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_BOT_RESPONSE"; then
     echo "VERDICT: NEEDS_REVISION"
     echo "---BEGIN BOT RESPONSE---"
     echo "$ASYNC_BOT_RESPONSE"
     echo "---END BOT RESPONSE---"
     exit 1
-  elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && echo "$ASYNC_BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
+  elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_BOT_RESPONSE"; then
     echo "VERDICT: APPROVED"
     echo "---BEGIN BOT RESPONSE---"
     echo "$ASYNC_BOT_RESPONSE"
@@ -757,24 +868,21 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
 	    fi
 	    ASYNC_FINAL_BOT_RESPONSE=""
 	    ASYNC_FINAL_BOT_RESPONSE_SOURCE=""
-	    ASYNC_FINAL_BOT_RESPONSE_TIME=""
 	    ASYNC_FINAL_POLL_TMPFILE=$(mktemp)
     if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
       2>/dev/null \
-      | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
-          '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | {created_at:(.created_at // ""), body:(.body // "")}' \
-	      > "$ASYNC_FINAL_POLL_TMPFILE" 2>/dev/null; then
-	      ASYNC_FINAL_BOT_RESPONSE=$(jq -r '.body // empty' "$ASYNC_FINAL_POLL_TMPFILE" | head -c 10000)
-	      ASYNC_FINAL_BOT_RESPONSE_TIME=$(jq -r '.created_at // empty' "$ASYNC_FINAL_POLL_TMPFILE")
-	      if [ -n "$ASYNC_FINAL_BOT_RESPONSE" ]; then
-	        ASYNC_FINAL_BOT_RESPONSE_SOURCE="comment"
-	        if codex_response_reviews_current_head "$ASYNC_FINAL_BOT_RESPONSE"; then
-	          ASYNC_FINAL_BOT_RESPONSE_SOURCE="review"
-	          echo "INFO: final async bot response detected via SHA-pinned PR comment"
-	        fi
-	      fi
-	    fi
-    rm -f "$ASYNC_FINAL_POLL_TMPFILE"
+      | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
+          '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | .[] | {created_at:(.created_at // ""), body:(.body // "")}' \
+      > "$ASYNC_FINAL_POLL_TMPFILE" 2>/dev/null; then
+      codex_scan_comment_evidence "$ASYNC_FINAL_POLL_TMPFILE"
+      rm -f "$ASYNC_FINAL_POLL_TMPFILE"
+    else
+      rm -f "$ASYNC_FINAL_POLL_TMPFILE"
+      # Fail closed (Finding #3): a failed root-comment fetch must not let a
+      # clean review from the reviews endpoint be accepted below.
+      echo "VERDICT: TIMED_OUT — failed to fetch Codex root comments after async acknowledgement (treated as unavailable)"
+      exit 2
+    fi
 
     ASYNC_FINAL_REVIEW_TMPFILE=$(mktemp)
     if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
@@ -782,20 +890,22 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
       | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
           '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
       > "$ASYNC_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
-      ASYNC_FINAL_REVIEW_BODY=$(jq -r '.body // empty' "$ASYNC_FINAL_REVIEW_TMPFILE" | head -c 5000)
-      ASYNC_FINAL_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_FINAL_REVIEW_TMPFILE")
-		      if [ -n "$ASYNC_FINAL_REVIEW_BODY" ] && { [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" != "review" ] || codex_response_time_should_replace "$ASYNC_FINAL_REVIEW_TIME" "$ASYNC_FINAL_BOT_RESPONSE_TIME"; }; then
-		        ASYNC_FINAL_BOT_RESPONSE="$ASYNC_FINAL_REVIEW_BODY"
-		        ASYNC_FINAL_BOT_RESPONSE_TIME="$ASYNC_FINAL_REVIEW_TIME"
-		        ASYNC_FINAL_BOT_RESPONSE_SOURCE="review"
-        echo "INFO: final async bot response detected via PR reviews endpoint"
-      fi
+      ASYNC_FINAL_REVIEW_BODY=$(jq -r '.body // empty' "$ASYNC_FINAL_REVIEW_TMPFILE" | head -c 5000)  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
+      ASYNC_FINAL_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_FINAL_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads the same pre-validated tmpfile as the body extraction above; empty time is not a failure
     else
       rm -f "$ASYNC_FINAL_REVIEW_TMPFILE"
       echo "VERDICT: TIMED_OUT — failed to fetch Codex PR reviews after async acknowledgement (treated as unavailable)"
       exit 2
     fi
     rm -f "$ASYNC_FINAL_REVIEW_TMPFILE"
+
+    codex_combine_terminal_evidence "final async bot response" \
+      "$COMMENT_TERMINAL_BODY" "$COMMENT_TERMINAL_TIME" \
+      "$COMMENT_LATEST_BODY" "$COMMENT_LATEST_TIME" \
+      "$ASYNC_FINAL_REVIEW_BODY" "$ASYNC_FINAL_REVIEW_TIME"
+    ASYNC_FINAL_BOT_RESPONSE="$COMBINED_BODY"
+    ASYNC_FINAL_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
+    ASYNC_FINAL_BOT_RESPONSE=$(printf '%s' "$ASYNC_FINAL_BOT_RESPONSE" | head -c 10000)
 
     if [ -n "$ASYNC_FINAL_BOT_RESPONSE" ]; then
       echo "INFO: final async bot response detected after acknowledgement wait"
@@ -806,13 +916,13 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
         SEEN_ENVIRONMENT_ERROR=1
         SEEN_ENVIRONMENT_RESPONSE="$ASYNC_FINAL_BOT_RESPONSE"
         echo "INFO: final async Codex environment setup response detected without fresh review evidence"
-      elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && echo "$ASYNC_FINAL_BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+      elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_FINAL_BOT_RESPONSE"; then
         echo "VERDICT: NEEDS_REVISION"
         echo "---BEGIN BOT RESPONSE---"
         echo "$ASYNC_FINAL_BOT_RESPONSE"
         echo "---END BOT RESPONSE---"
         exit 1
-      elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && echo "$ASYNC_FINAL_BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
+      elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_FINAL_BOT_RESPONSE"; then
         echo "VERDICT: APPROVED"
         echo "---BEGIN BOT RESPONSE---"
         echo "$ASYNC_FINAL_BOT_RESPONSE"
@@ -871,24 +981,21 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
 
   ASYNC_REACTION_FINAL_BOT_RESPONSE=""
   ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE=""
-  ASYNC_REACTION_FINAL_BOT_RESPONSE_TIME=""
   ASYNC_REACTION_FINAL_POLL_TMPFILE=$(mktemp)
   if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
     2>/dev/null \
-    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
-        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | {created_at:(.created_at // ""), body:(.body // "")}' \
+    | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
+        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | .[] | {created_at:(.created_at // ""), body:(.body // "")}' \
     > "$ASYNC_REACTION_FINAL_POLL_TMPFILE" 2>/dev/null; then
-    ASYNC_REACTION_FINAL_BOT_RESPONSE=$(jq -r '.body // empty' "$ASYNC_REACTION_FINAL_POLL_TMPFILE" | head -c 10000)
-    ASYNC_REACTION_FINAL_BOT_RESPONSE_TIME=$(jq -r '.created_at // empty' "$ASYNC_REACTION_FINAL_POLL_TMPFILE")
-    if [ -n "$ASYNC_REACTION_FINAL_BOT_RESPONSE" ]; then
-      ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE="comment"
-      if codex_response_reviews_current_head "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
-        ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE="review"
-        echo "INFO: final async reaction bot response detected via SHA-pinned PR comment"
-      fi
-    fi
+    codex_scan_comment_evidence "$ASYNC_REACTION_FINAL_POLL_TMPFILE"
+    rm -f "$ASYNC_REACTION_FINAL_POLL_TMPFILE"
+  else
+    rm -f "$ASYNC_REACTION_FINAL_POLL_TMPFILE"
+    # Fail closed (Finding #3): a failed root-comment fetch must not let a
+    # clean review from the reviews endpoint be accepted below.
+    echo "VERDICT: TIMED_OUT — failed to fetch Codex root comments after async reaction (treated as unavailable)"
+    exit 2
   fi
-  rm -f "$ASYNC_REACTION_FINAL_POLL_TMPFILE"
 
   ASYNC_REACTION_FINAL_REVIEW_TMPFILE=$(mktemp)
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
@@ -896,20 +1003,22 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
     | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
         '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
     > "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
-    ASYNC_REACTION_FINAL_REVIEW_BODY=$(jq -r '.body // empty' "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE" | head -c 5000)
-    ASYNC_REACTION_FINAL_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE")
-    if [ -n "$ASYNC_REACTION_FINAL_REVIEW_BODY" ] && { [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" != "review" ] || codex_response_time_should_replace "$ASYNC_REACTION_FINAL_REVIEW_TIME" "$ASYNC_REACTION_FINAL_BOT_RESPONSE_TIME"; }; then
-      ASYNC_REACTION_FINAL_BOT_RESPONSE="$ASYNC_REACTION_FINAL_REVIEW_BODY"
-      ASYNC_REACTION_FINAL_BOT_RESPONSE_TIME="$ASYNC_REACTION_FINAL_REVIEW_TIME"
-      ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE="review"
-      echo "INFO: final async reaction bot response detected via PR reviews endpoint"
-    fi
+    ASYNC_REACTION_FINAL_REVIEW_BODY=$(jq -r '.body // empty' "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE" | head -c 5000)  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
+    ASYNC_REACTION_FINAL_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads the same pre-validated tmpfile as the body extraction above; empty time is not a failure
   else
     rm -f "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE"
     echo "VERDICT: TIMED_OUT — failed to fetch Codex PR reviews after async reaction (treated as unavailable)"
     exit 2
   fi
   rm -f "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE"
+
+  codex_combine_terminal_evidence "final async reaction bot response" \
+    "$COMMENT_TERMINAL_BODY" "$COMMENT_TERMINAL_TIME" \
+    "$COMMENT_LATEST_BODY" "$COMMENT_LATEST_TIME" \
+    "$ASYNC_REACTION_FINAL_REVIEW_BODY" "$ASYNC_REACTION_FINAL_REVIEW_TIME"
+  ASYNC_REACTION_FINAL_BOT_RESPONSE="$COMBINED_BODY"
+  ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
+  ASYNC_REACTION_FINAL_BOT_RESPONSE=$(printf '%s' "$ASYNC_REACTION_FINAL_BOT_RESPONSE" | head -c 10000)
 
   if [ -n "$ASYNC_REACTION_FINAL_BOT_RESPONSE" ]; then
     codex_require_current_head
@@ -919,13 +1028,13 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
       SEEN_ENVIRONMENT_ERROR=1
       SEEN_ENVIRONMENT_RESPONSE="$ASYNC_REACTION_FINAL_BOT_RESPONSE"
       echo "INFO: final async reaction Codex environment setup response detected without fresh review evidence"
-    elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+    elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
       echo "VERDICT: NEEDS_REVISION"
       echo "---BEGIN BOT RESPONSE---"
       echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 1
-    elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
+    elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
       echo "VERDICT: APPROVED"
       echo "---BEGIN BOT RESPONSE---"
       echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -613,17 +613,31 @@ codex_response_priority() {
 # SHA-pinned root comment) supplied it, and regardless of which side is
 # CURRENT vs. candidate. A tie in priority keeps CURRENT (arbitrary but
 # stable — both sides are equivalent for verdict purposes at that tier).
+#
+# Optional 5th/6th args (current_state/candidate_state) carry GitHub's
+# structured review state for whichever side is review-sourced (empty for
+# a SHA-pinned root comment, which has no review state). Without these,
+# a same-second tie between a clean-looking root comment and a
+# CHANGES_REQUESTED review whose body ALSO reads clean (e.g. "Looks good
+# overall, but see inline comments") scored both sides priority 0 from
+# body text alone, so the already-selected comment won the tie and the
+# review's CHANGES_REQUESTED state was discarded (fresh evidence from PR
+# #1490 finding 3797160202, a followup to 3796982553 that fixed this
+# exact class of gap for the review-vs-review tie-break in
+# codex_select_review_evidence but missed this separate comment-vs-review
+# tie-break, which has its own priority calculation).
 codex_select_terminal_evidence() {
   local current_body="$1" current_time="$2"
   local candidate_body="$3" candidate_time="$4"
+  local current_state="${5:-}" candidate_state="${6:-}"
   [ -z "$current_time" ] && return 0
   if [ "$candidate_time" \> "$current_time" ]; then
     return 0
   fi
   if [ "$candidate_time" = "$current_time" ]; then
     local candidate_priority current_priority
-    candidate_priority=$(codex_response_priority "$candidate_body")
-    current_priority=$(codex_response_priority "$current_body")
+    candidate_priority=$(codex_response_priority "$candidate_body" "$candidate_state")
+    current_priority=$(codex_response_priority "$current_body" "$current_state")
     if [ "$candidate_priority" -gt "$current_priority" ]; then
       return 0
     fi
@@ -861,7 +875,11 @@ codex_combine_terminal_evidence() {
   # (fresh evidence from PR #1490 finding 3788118857).
   if [ -n "$review_time" ]; then
     if [ "$COMBINED_SOURCE" = "review" ]; then
-      if codex_select_terminal_evidence "$COMBINED_BODY" "$COMBINED_TIME" "$review_body" "$review_time"; then
+      # CURRENT here is always the SHA-pinned terminal comment (no review
+      # state of its own) — this branch only runs when COMBINED_SOURCE
+      # was just set to "review" by the terminal-comment block above, so
+      # CANDIDATE's review_state is the only side with a real state.
+      if codex_select_terminal_evidence "$COMBINED_BODY" "$COMBINED_TIME" "$review_body" "$review_time" "" "$review_state"; then
         COMBINED_BODY="$review_body"
         COMBINED_TIME="$review_time"
         COMBINED_SOURCE="review"
@@ -949,7 +967,7 @@ codex_combine_terminal_evidence() {
       # state counts as blocking here too (fresh evidence from PR #1490
       # finding 3796396391).
       :
-    elif [ -z "$COMBINED_TIME" ] || ! codex_select_terminal_evidence "$comment_latest_body" "$comment_latest_time" "$COMBINED_BODY" "$COMBINED_TIME"; then
+    elif [ -z "$COMBINED_TIME" ] || ! codex_select_terminal_evidence "$comment_latest_body" "$comment_latest_time" "$COMBINED_BODY" "$COMBINED_TIME" "" "$COMBINED_REVIEW_STATE"; then
       COMBINED_BODY="$comment_latest_body"
       COMBINED_TIME="$comment_latest_time"
       COMBINED_SOURCE="comment"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -1109,7 +1109,18 @@ while true; do
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 1
-    elif codex_response_is_usage_limit "$BOT_RESPONSE_FULL"; then
+    elif codex_response_is_usage_limit "$(codex_strip_quoted_spans "$BOT_RESPONSE_FULL")"; then
+      # Quote-stripped before checking: unlike the environment-error
+      # check below (already safe — it's gated on source == "comment",
+      # and a terminal SHA-pinned review always has source == "review" by
+      # construction), this check has no source gate, since a genuine
+      # usage-limit notice CAN legitimately arrive via the reviews
+      # endpoint too. A clean terminal review that merely QUOTES an
+      # actual quota message (e.g. "No blocking issues found. The docs
+      # accurately quote: You have reached your Codex usage limits.")
+      # was still reclassified as UNAVAILABLE without this stripping
+      # (fresh evidence from PR #1490 finding 3793259351, a followup to
+      # 3790122058/3793219190/3793219192).
       codex_return_usage_limit "$BOT_RESPONSE"
     elif [ "$BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$BOT_RESPONSE_FULL"; then
       SEEN_ENVIRONMENT_ERROR=1
@@ -1311,7 +1322,9 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
     echo "$ASYNC_BOT_RESPONSE"
     echo "---END BOT RESPONSE---"
     exit 1
-  elif codex_response_is_usage_limit "$ASYNC_BOT_RESPONSE_FULL"; then
+  elif codex_response_is_usage_limit "$(codex_strip_quoted_spans "$ASYNC_BOT_RESPONSE_FULL")"; then
+    # Quote-stripped before checking — see the main-loop equivalent above
+    # for the rationale (PR #1490 finding 3793259351).
     codex_return_usage_limit "$ASYNC_BOT_RESPONSE"
   elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_BOT_RESPONSE_FULL"; then
     SEEN_ENVIRONMENT_ERROR=1
@@ -1408,7 +1421,9 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
         echo "$ASYNC_FINAL_BOT_RESPONSE"
         echo "---END BOT RESPONSE---"
         exit 1
-      elif codex_response_is_usage_limit "$ASYNC_FINAL_BOT_RESPONSE_FULL"; then
+      elif codex_response_is_usage_limit "$(codex_strip_quoted_spans "$ASYNC_FINAL_BOT_RESPONSE_FULL")"; then
+        # Quote-stripped before checking — see the main-loop equivalent
+        # above for the rationale (PR #1490 finding 3793259351).
         codex_return_usage_limit "$ASYNC_FINAL_BOT_RESPONSE"
       elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_FINAL_BOT_RESPONSE_FULL"; then
         SEEN_ENVIRONMENT_ERROR=1
@@ -1544,7 +1559,9 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
       echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 1
-    elif codex_response_is_usage_limit "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL"; then
+    elif codex_response_is_usage_limit "$(codex_strip_quoted_spans "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL")"; then
+      # Quote-stripped before checking — see the main-loop equivalent
+      # above for the rationale (PR #1490 finding 3793259351).
       codex_return_usage_limit "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
     elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL"; then
       SEEN_ENVIRONMENT_ERROR=1

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -951,6 +951,9 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     fi
     if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
       echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID after async acknowledgement"
+      if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ]; then
+        codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
+      fi
       codex_return_reaction_without_review
     fi
   elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "comment" ]; then

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -242,8 +242,43 @@ codex_inline_review_comment_count_since() {
 # still-writing printf. This matters once classification runs on the
 # FULL, untruncated response (see BOT_RESPONSE_FULL below) rather than a
 # pre-truncated copy.
+
+# Returns true if the response contains a fence-opener marker (3+
+# consecutive backticks or tildes) ANYWHERE. Used by every positive-
+# signal classifier below (usage-limit, environment-error, approved) as a
+# conservative guard: a genuine SHA-pinned clean review can QUOTE example
+# text inside a fenced block (e.g. demonstrating what a usage-limit
+# notice looks like) without that text being a genuine assertion, and
+# after 5 rounds of precisely parsing GFM's fence-open/close semantics
+# repeatedly surfaced the next undiscovered edge case (see
+# codex_strip_quoted_spans below), the project's chosen direction is to
+# stop trying to determine what's inside vs. outside a fence and instead
+# treat the mere PRESENCE of a fence marker as disqualifying for any of
+# these positive/actionable classifications. This was initially added
+# only to codex_response_is_approved, but the SAME ambiguity applies
+# equally to usage-limit and environment-error detection — a fenced
+# example that merely QUOTES quota/setup-error wording must not trigger
+# an actual UNAVAILABLE verdict for an otherwise clean review (fresh
+# evidence from PR #1490 finding 3796042503, a followup to 3795661290:
+# the fence guard was added to codex_response_is_approved alone, but
+# codex_response_is_usage_limit's own callers were unguarded, so fenced
+# quota text still triggered a false UNAVAILABLE for a clean review).
+# Embedding this check INSIDE each shared classifier — rather than
+# requiring every call site to remember to apply it — is deliberate:
+# scattering the guard across call sites is exactly the pattern that
+# produced this gap in the first place (codex_response_is_blocking
+# learned the same lesson earlier for quote-stripping, PR #1490 finding
+# 3793367887).
+codex_response_has_fence_marker() {
+  local response="$1"
+  grep -qE '(`{3,}|~{3,})' <<< "$response"
+}
+
 codex_response_is_usage_limit() {
   local response="$1"
+  if codex_response_has_fence_marker "$response"; then
+    return 1
+  fi
   # The third alternative previously matched ANY "codex ... usage
   # limit/quota/capacity" substring with no requirement for accompanying
   # exhaustion/unavailability wording, so a clean submitted review merely
@@ -266,6 +301,9 @@ codex_response_is_usage_limit() {
 
 codex_response_is_environment_error() {
   local response="$1"
+  if codex_response_has_fence_marker "$response"; then
+    return 1
+  fi
   grep -qiE "to[[:space:]]+use[[:space:]]+codex[[:space:]]+here,[[:space:]]+create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo" <<< "$response"
 }
 
@@ -415,14 +453,16 @@ CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*${CODEX_NEGATED_
 # producing one more undiscovered edge case each round (PR #1490 findings
 # 3793453010, 3793497787, a closing-validity followup, and 3795661290).
 # Rather than continue precisely re-implementing GFM's fence grammar one
-# construct at a time, codex_response_is_approved below now treats the
-# mere PRESENCE of a fence-opener marker (3+ consecutive backticks or
-# tildes) ANYWHERE in the response as disqualifying for a clean verdict,
-# without attempting to determine where it opens or closes. This is a
-# deliberate, explicit tradeoff: a small amount of false-NEEDS_REVISION
-# risk (a genuinely clean response that happens to include an example
-# code fence) in exchange for closing the entire class of "quoted/fenced
-# clean phrase misread as an assertion" bug in one step, rather than the
+# construct at a time, codex_response_has_fence_marker above (used by
+# every positive/actionable classifier: usage-limit, environment-error,
+# blocking, approved) now treats the mere PRESENCE of a fence-opener
+# marker (3+ consecutive backticks or tildes) ANYWHERE in the response as
+# disqualifying, without attempting to determine where it opens or
+# closes. This is a deliberate, explicit tradeoff: a small amount of
+# false-NEEDS_REVISION risk (a genuinely clean response that happens to
+# include an example code fence) in exchange for closing the entire class
+# of "quoted/fenced clean phrase misread as an assertion" bug in one
+# step, rather than the
 # previous direction of chasing precision at the cost of repeated
 # false-APPROVED gaps. Single/inline backticks (a PAIR on one line, not a
 # 3+-run) are unaffected by this and still get the precise, stable
@@ -438,6 +478,16 @@ codex_strip_quoted_spans() {
 
 codex_response_is_blocking() {
   local body="$1"
+  # A misdetected blocking finding inside a fenced example is already
+  # SAFE by itself (it only pushes the verdict toward NEEDS_REVISION, the
+  # conservative direction, never toward APPROVED) — but the fence guard
+  # is applied here too for consistency with every other classifier
+  # below, rather than leaving one classifier's fence-handling
+  # inconsistent with the rest and inviting the next Codex finding that
+  # specifically targets this asymmetry.
+  if codex_response_has_fence_marker "$body"; then
+    return 1
+  fi
   grep -qiE "$CODEX_BLOCKING_PATTERN" <<< "$(codex_strip_quoted_spans "$body")"
 }
 
@@ -464,16 +514,10 @@ codex_strip_not_only_idiom() {
 codex_response_is_approved() {
   local body="$1"
   # A fence-opener marker (3+ consecutive backticks or tildes) ANYWHERE
-  # in the response — see the "Fenced Markdown code blocks" comment above
-  # codex_strip_quoted_spans for the full rationale — disqualifies a
-  # clean verdict outright, without attempting to determine where the
-  # fence opens or closes. This deliberately trades a small amount of
-  # false-NEEDS_REVISION risk for closing the entire class of
-  # quoted/fenced-phrase-misread-as-assertion bugs at once, after four
-  # rounds of precise-fence-parsing fixes each surfaced the next
-  # undiscovered GFM fence edge case (most recently PR #1490 finding
-  # 3795661290, the tilde-fence variant).
-  if grep -qE '(`{3,}|~{3,})' <<< "$body"; then
+  # in the response — see codex_response_has_fence_marker above for the
+  # full rationale — disqualifies a clean verdict outright, without
+  # attempting to determine where the fence opens or closes.
+  if codex_response_has_fence_marker "$body"; then
     return 1
   fi
   local normalized_body

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -395,6 +395,8 @@ echo "INFO: MAX_WAIT=${MAX_WAIT}s total; up to $((MAX_RETRIGGERS + 1)) attempt(s
 RETRIGGER_COUNT=0
 CONSECUTIVE_API_FAILURES=0
 MAX_CONSECUTIVE_FAILURES=3
+SEEN_ENVIRONMENT_ERROR=0
+SEEN_ENVIRONMENT_RESPONSE=""
 # Outer retrigger loop. TOTAL_ELAPSED tracks the full shared wait budget.
 # TRIGGER_TIME is updated to the retrigger comment's timestamp after each
 # retrigger post, scoping the next inner poll to responses after that point.
@@ -441,21 +443,19 @@ while true; do
   # Also check PR reviews — Codex posts findings as a GitHub Review object
   # (via pulls/{PR}/reviews), not as a plain PR comment. Combining both sources
   # ensures we detect findings immediately instead of waiting for a timeout.
-  if [ -z "$BOT_RESPONSE" ]; then
-    REVIEW_TMPFILE=$(mktemp)
-    if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
-      2>/dev/null \
-      | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-          '.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha))) | .body' \
-      > "$REVIEW_TMPFILE" 2>/dev/null; then
-      REVIEW_BODY=$(head -c 5000 "$REVIEW_TMPFILE")
-      if [ -n "$REVIEW_BODY" ]; then
-        BOT_RESPONSE="$REVIEW_BODY"
-        echo "INFO: bot response detected via PR reviews endpoint"
-      fi
+  REVIEW_TMPFILE=$(mktemp)
+  if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+    2>/dev/null \
+    | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
+        '.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha))) | .body' \
+    > "$REVIEW_TMPFILE" 2>/dev/null; then
+    REVIEW_BODY=$(head -c 5000 "$REVIEW_TMPFILE")
+    if [ -n "$REVIEW_BODY" ]; then
+      BOT_RESPONSE="$REVIEW_BODY"
+      echo "INFO: bot response detected via PR reviews endpoint"
     fi
-    rm -f "$REVIEW_TMPFILE"
   fi
+  rm -f "$REVIEW_TMPFILE"
 
   if ! INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME"); then
     echo "VERDICT: TIMED_OUT — failed to fetch Codex inline review comments (treated as unavailable)"
@@ -510,7 +510,10 @@ while true; do
     if codex_response_is_usage_limit "$BOT_RESPONSE"; then
       codex_return_usage_limit "$BOT_RESPONSE"
     elif codex_response_is_environment_error "$BOT_RESPONSE"; then
-      codex_return_environment_error "$BOT_RESPONSE"
+      SEEN_ENVIRONMENT_ERROR=1
+      SEEN_ENVIRONMENT_RESPONSE="$BOT_RESPONSE"
+      echo "INFO: Codex environment setup response detected; waiting for fresh current-head review evidence"
+      continue
     elif echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
       echo "VERDICT: NEEDS_REVISION"
       echo "---BEGIN BOT RESPONSE---"
@@ -643,21 +646,19 @@ if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
 fi
 rm -f "$ASYNC_POLL_TMPFILE"
 
-if [ -z "$ASYNC_BOT_RESPONSE" ]; then
-  ASYNC_REVIEW_TMPFILE=$(mktemp)
-  if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
-    2>/dev/null \
-    | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha))) | .body' \
-    > "$ASYNC_REVIEW_TMPFILE" 2>/dev/null; then
-    ASYNC_REVIEW_BODY=$(head -c 5000 "$ASYNC_REVIEW_TMPFILE")
-    if [ -n "$ASYNC_REVIEW_BODY" ]; then
-      ASYNC_BOT_RESPONSE="$ASYNC_REVIEW_BODY"
-      echo "INFO: async-arrival bot response detected via PR reviews endpoint"
-    fi
+ASYNC_REVIEW_TMPFILE=$(mktemp)
+if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+  2>/dev/null \
+  | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
+      '.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha))) | .body' \
+  > "$ASYNC_REVIEW_TMPFILE" 2>/dev/null; then
+  ASYNC_REVIEW_BODY=$(head -c 5000 "$ASYNC_REVIEW_TMPFILE")
+  if [ -n "$ASYNC_REVIEW_BODY" ]; then
+    ASYNC_BOT_RESPONSE="$ASYNC_REVIEW_BODY"
+    echo "INFO: async-arrival bot response detected via PR reviews endpoint"
   fi
-  rm -f "$ASYNC_REVIEW_TMPFILE"
 fi
+rm -f "$ASYNC_REVIEW_TMPFILE"
 
 if [ -n "$ASYNC_BOT_RESPONSE" ]; then
   echo "INFO: async-arrival bot response detected during grace period"
@@ -667,7 +668,9 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
   if codex_response_is_usage_limit "$ASYNC_BOT_RESPONSE"; then
     codex_return_usage_limit "$ASYNC_BOT_RESPONSE"
   elif codex_response_is_environment_error "$ASYNC_BOT_RESPONSE"; then
-    codex_return_environment_error "$ASYNC_BOT_RESPONSE"
+    SEEN_ENVIRONMENT_ERROR=1
+    SEEN_ENVIRONMENT_RESPONSE="$ASYNC_BOT_RESPONSE"
+    echo "INFO: async-arrival Codex environment setup response detected without fresh review evidence"
   elif echo "$ASYNC_BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
     echo "VERDICT: NEEDS_REVISION"
     echo "---BEGIN BOT RESPONSE---"
@@ -721,6 +724,10 @@ fi
 if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
   echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID during async grace period"
   codex_return_reaction_without_review
+fi
+
+if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ]; then
+  codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
 fi
 
 echo "INFO: no bot response during async grace period"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -326,19 +326,25 @@ CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t 
 # word (e.g. "The variable name is not great. No blocking issues found."
 # still classifies as approved).
 #
-# Two more gaps surfaced once the pattern was unbounded (PR #1490 finding
-# 3790023141): (a) the target alternation had "approved" but not the bare
-# verb "approve", so "I cannot approve this change" wasn't recognized;
-# (b) the pattern only checked negation-THEN-approval order, so an
-# approval phrase appearing BEFORE the negation in the same sentence
-# ("This looks good at first glance, but I cannot approve this change")
-# wasn't caught, since "looks good" preceded "cannot" rather than
-# following it. Both alternation orders are now checked (approval-word
-# ... negation-word, in addition to negation-word ... approval-word), and
-# the target list includes the bare verb.
+# The target alternation had "approved" but not the bare verb "approve",
+# so "I cannot approve this change" wasn't recognized (PR #1490 finding
+# 3790023141). This is a forward negation-THEN-approval match: "cannot"
+# precedes "approve" in that sentence, so adding the bare verb to the
+# target list is sufficient on its own — no reverse-order (approval-word
+# ... negation-word) alternative is needed. An earlier version of this
+# fix DID add a reverse-order alternative, reasoning that "looks good"
+# preceded "cannot" in the same example; that reverse check was over-
+# broad in practice — it matched ANY later negation word in the same
+# sentence regardless of what the negation actually referred to, so a
+# genuinely clean response like "Looks good overall; tests were not run."
+# (the negation refers to the unrelated "tests were not run" clause, not
+# to the approval) was incorrectly flagged as negated (PR #1490 finding
+# 3790062089). The reverse-order alternative has been removed; the
+# forward-only match plus the bare-verb addition covers the original
+# "cannot approve" case without this false-positive class.
 CODEX_NEGATED_APPROVAL_TARGET_WORDS='(approve[ds]?|lgtm|look(s|ing)?[[:space:]]+good|no[[:space:]]+blocking[[:space:]]+issues?|didn.t find[[:space:]]+any major[[:space:]]+issues)'
 CODEX_NEGATION_WORDS='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)'
-CODEX_NEGATED_APPROVAL_PATTERN="(${CODEX_NEGATION_WORDS}[^.!?]*${CODEX_NEGATED_APPROVAL_TARGET_WORDS}|${CODEX_NEGATED_APPROVAL_TARGET_WORDS}[^.!?]*${CODEX_NEGATION_WORDS})"
+CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?]*${CODEX_NEGATED_APPROVAL_TARGET_WORDS}"
 
 codex_response_is_blocking() {
   local body="$1"
@@ -655,20 +661,49 @@ codex_combine_terminal_evidence() {
   # that guarantee only applies to the terminal-vs-review combine path
   # above, not this separate ancillary-override check (fresh evidence from
   # PR #1490 finding 3790023143).
-  if [ "$comment_latest_is_terminal" -eq 0 ] && [ -n "$comment_latest_body" ] && { codex_response_is_environment_error "$comment_latest_body" || codex_response_is_usage_limit "$comment_latest_body"; }; then
+  # Usage-limit and environment-error are handled as two SEPARATE checks,
+  # not one shared condition, because they have different retention
+  # semantics (documented in docs/workflow/development-workflow/
+  # integrations/codex-github.md and protocols/93-automated-reviewer-loop-
+  # protocol.md): an environment-setup error is retained through the poll
+  # window and can be superseded by strictly newer terminal/review
+  # evidence, but a usage-limit notice terminates the invocation
+  # IMMEDIATELY upon detection (codex_return_usage_limit exits before any
+  # further polling can happen) and is never superseded — including by a
+  # clean review returned in the SAME fetch. The previous shared
+  # newest-wins comparison let a same-fetch review that happened to have a
+  # later timestamp silently discard the usage-limit notice before it ever
+  # reached codex_return_usage_limit, contradicting the documented
+  # immediate-termination contract (fresh evidence from PR #1490 finding
+  # 3790062091, a followup to 3789928786/3789992794).
+  if [ "$comment_latest_is_terminal" -eq 0 ] && [ -n "$comment_latest_body" ] && codex_response_is_usage_limit "$comment_latest_body"; then
     if [ -n "$COMBINED_SOURCE" ] && codex_response_is_blocking "$COMBINED_BODY"; then
       # Blocking terminal/review evidence always wins outright — it is
-      # never discarded by an environment-setup error or a usage-limit
-      # notice, regardless of timing, so an actionable finding can never be
-      # hidden behind an "unavailable" verdict (fresh evidence from PR
-      # #1490 finding 3787943162; Protocol 93 requires blocking evidence to
-      # never be silently discarded).
+      # never discarded by a usage-limit notice, regardless of timing, so
+      # an actionable finding can never be hidden behind an "unavailable"
+      # verdict (fresh evidence from PR #1490 finding 3787943162; Protocol
+      # 93 requires blocking evidence to never be silently discarded).
+      :
+    else
+      COMBINED_BODY="$comment_latest_body"
+      COMBINED_TIME="$comment_latest_time"
+      COMBINED_SOURCE="comment"
+      echo "INFO: $label usage-limit notice takes immediate precedence over terminal/review evidence, including same-fetch evidence"
+    fi
+  elif [ "$comment_latest_is_terminal" -eq 0 ] && [ -n "$comment_latest_body" ] && codex_response_is_environment_error "$comment_latest_body"; then
+    if [ -n "$COMBINED_SOURCE" ] && codex_response_is_blocking "$COMBINED_BODY"; then
+      # Blocking terminal/review evidence always wins outright — it is
+      # never discarded by an environment-setup error, regardless of
+      # timing, so an actionable finding can never be hidden behind an
+      # "unavailable" verdict (fresh evidence from PR #1490 finding
+      # 3787943162; Protocol 93 requires blocking evidence to never be
+      # silently discarded).
       :
     elif [ -z "$COMBINED_TIME" ] || ! codex_select_terminal_evidence "$comment_latest_body" "$comment_latest_time" "$COMBINED_BODY" "$COMBINED_TIME"; then
       COMBINED_BODY="$comment_latest_body"
       COMBINED_TIME="$comment_latest_time"
       COMBINED_SOURCE="comment"
-      echo "INFO: $label environment-setup error or usage-limit notice retained over non-newer terminal/review evidence"
+      echo "INFO: $label environment-setup error retained over non-newer terminal/review evidence"
     fi
   fi
 }

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -325,7 +325,20 @@ CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t 
 # phrase from being treated as negated by an EARLIER sentence's negation
 # word (e.g. "The variable name is not great. No blocking issues found."
 # still classifies as approved).
-CODEX_NEGATED_APPROVAL_PATTERN='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)[^.!?]*(approved|lgtm|look(s|ing)?[[:space:]]+good|no[[:space:]]+blocking[[:space:]]+issues?|didn.t find[[:space:]]+any major[[:space:]]+issues)'
+#
+# Two more gaps surfaced once the pattern was unbounded (PR #1490 finding
+# 3790023141): (a) the target alternation had "approved" but not the bare
+# verb "approve", so "I cannot approve this change" wasn't recognized;
+# (b) the pattern only checked negation-THEN-approval order, so an
+# approval phrase appearing BEFORE the negation in the same sentence
+# ("This looks good at first glance, but I cannot approve this change")
+# wasn't caught, since "looks good" preceded "cannot" rather than
+# following it. Both alternation orders are now checked (approval-word
+# ... negation-word, in addition to negation-word ... approval-word), and
+# the target list includes the bare verb.
+CODEX_NEGATED_APPROVAL_TARGET_WORDS='(approve[ds]?|lgtm|look(s|ing)?[[:space:]]+good|no[[:space:]]+blocking[[:space:]]+issues?|didn.t find[[:space:]]+any major[[:space:]]+issues)'
+CODEX_NEGATION_WORDS='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)'
+CODEX_NEGATED_APPROVAL_PATTERN="(${CODEX_NEGATION_WORDS}[^.!?]*${CODEX_NEGATED_APPROVAL_TARGET_WORDS}|${CODEX_NEGATED_APPROVAL_TARGET_WORDS}[^.!?]*${CODEX_NEGATION_WORDS})"
 
 codex_response_is_blocking() {
   local body="$1"
@@ -450,13 +463,24 @@ codex_select_terminal_evidence() {
 # PR #1490 finding 3788078189).
 #
 # Sets: COMMENT_TERMINAL_BODY, COMMENT_TERMINAL_TIME, COMMENT_LATEST_BODY,
-# COMMENT_LATEST_TIME.
+# COMMENT_LATEST_TIME, COMMENT_LATEST_IS_TERMINAL.
 codex_scan_comment_evidence() {
   local comments_file="$1"
   COMMENT_TERMINAL_BODY=""
   COMMENT_TERMINAL_TIME=""
   COMMENT_LATEST_BODY=""
   COMMENT_LATEST_TIME=""
+  # Tracks whether the comment currently held in COMMENT_LATEST_BODY is
+  # ITSELF the SHA-pinned terminal comment (as opposed to a genuinely
+  # separate ancillary comment). codex_combine_terminal_evidence uses this
+  # to skip re-classifying a terminal comment as an ancillary
+  # environment-error/usage-limit notice just because its own finding
+  # text happens to quote that wording (fresh evidence from PR #1490
+  # finding 3790023143 — a case not caught by the existing "terminal
+  # comment never routed through the environment-error classifier"
+  # protection, since that protection only covers the terminal-vs-review
+  # combine path, not this separate ancillary-override check).
+  COMMENT_LATEST_IS_TERMINAL=0
   local comment_latest_is_actionable=0
   local line created_at body is_actionable is_terminal
   while IFS= read -r line; do
@@ -474,6 +498,7 @@ codex_scan_comment_evidence() {
     if [ "$comment_latest_is_actionable" -eq 0 ] || [ "$is_actionable" -eq 1 ]; then
       COMMENT_LATEST_BODY="$body"
       COMMENT_LATEST_TIME="$created_at"
+      COMMENT_LATEST_IS_TERMINAL="$is_terminal"
       comment_latest_is_actionable="$is_actionable"
     fi
     if [ "$is_terminal" -eq 1 ]; then
@@ -558,11 +583,16 @@ codex_select_review_evidence() {
 #
 # Sets: COMBINED_BODY, COMBINED_TIME, COMBINED_SOURCE ("review", "comment",
 # or "" if no evidence at all). LABEL is used only for INFO logging.
+# COMMENT_LATEST_IS_TERMINAL (8th arg) gates the ancillary-override check
+# below: it must never fire when the "latest ancillary comment" IS
+# actually the terminal comment itself, not a genuinely separate ancillary
+# one (see the comment above that check).
 codex_combine_terminal_evidence() {
   local label="$1"
   local comment_terminal_body="$2" comment_terminal_time="$3"
   local comment_latest_body="$4" comment_latest_time="$5"
   local review_body="$6" review_time="$7"
+  local comment_latest_is_terminal="$8"
 
   COMBINED_BODY=""
   COMBINED_TIME=""
@@ -609,7 +639,23 @@ codex_combine_terminal_evidence() {
     COMBINED_SOURCE="comment"
   fi
 
-  if [ -n "$comment_latest_body" ] && { codex_response_is_environment_error "$comment_latest_body" || codex_response_is_usage_limit "$comment_latest_body"; }; then
+  # comment_latest_is_terminal must be 0 (a genuinely separate ancillary
+  # comment, not the terminal comment itself) before applying this
+  # override: when a clean SHA-pinned terminal comment/review's OWN
+  # finding text happens to quote or discuss environment-error/usage-limit
+  # wording (e.g. reviewing this file's own detection code, or flagging
+  # stale docs that describe the setup message), codex_scan_comment_evidence
+  # can end up tracking that SAME terminal comment as COMMENT_LATEST_BODY
+  # (there being no other, genuinely ancillary comment). Without this
+  # guard, re-running the environment-error/usage-limit classifier on that
+  # text here reclassified a clean terminal review as an ancillary setup
+  # failure and downgraded APPROVED to codex-github-environment-missing —
+  # a case the "terminal comment never routed through the environment-error
+  # classifier" guarantee elsewhere in this function did NOT cover, since
+  # that guarantee only applies to the terminal-vs-review combine path
+  # above, not this separate ancillary-override check (fresh evidence from
+  # PR #1490 finding 3790023143).
+  if [ "$comment_latest_is_terminal" -eq 0 ] && [ -n "$comment_latest_body" ] && { codex_response_is_environment_error "$comment_latest_body" || codex_response_is_usage_limit "$comment_latest_body"; }; then
     if [ -n "$COMBINED_SOURCE" ] && codex_response_is_blocking "$COMBINED_BODY"; then
       # Blocking terminal/review evidence always wins outright — it is
       # never discarded by an environment-setup error or a usage-limit
@@ -876,7 +922,7 @@ while true; do
   codex_combine_terminal_evidence "bot response" \
     "$COMMENT_TERMINAL_BODY" "$COMMENT_TERMINAL_TIME" \
     "$COMMENT_LATEST_BODY" "$COMMENT_LATEST_TIME" \
-    "$REVIEW_BODY" "$REVIEW_TIME"
+    "$REVIEW_BODY" "$REVIEW_TIME" "$COMMENT_LATEST_IS_TERMINAL"
   BOT_RESPONSE="$COMBINED_BODY"
   BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
   # Captured immediately after combine, before any intervening call could
@@ -1142,7 +1188,7 @@ rm -f "$ASYNC_REVIEW_TMPFILE"
 codex_combine_terminal_evidence "async-arrival bot response" \
   "$COMMENT_TERMINAL_BODY" "$COMMENT_TERMINAL_TIME" \
   "$COMMENT_LATEST_BODY" "$COMMENT_LATEST_TIME" \
-  "$ASYNC_REVIEW_BODY" "$ASYNC_REVIEW_TIME"
+  "$ASYNC_REVIEW_BODY" "$ASYNC_REVIEW_TIME" "$COMMENT_LATEST_IS_TERMINAL"
 ASYNC_BOT_RESPONSE="$COMBINED_BODY"
 ASYNC_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
 # Captured before any intervening call could touch COMBINED_TIME (see
@@ -1242,7 +1288,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
     codex_combine_terminal_evidence "final async bot response" \
       "$COMMENT_TERMINAL_BODY" "$COMMENT_TERMINAL_TIME" \
       "$COMMENT_LATEST_BODY" "$COMMENT_LATEST_TIME" \
-      "$ASYNC_FINAL_REVIEW_BODY" "$ASYNC_FINAL_REVIEW_TIME"
+      "$ASYNC_FINAL_REVIEW_BODY" "$ASYNC_FINAL_REVIEW_TIME" "$COMMENT_LATEST_IS_TERMINAL"
     ASYNC_FINAL_BOT_RESPONSE="$COMBINED_BODY"
     ASYNC_FINAL_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
     # Captured before any intervening call could touch COMBINED_TIME (see
@@ -1379,7 +1425,7 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
   codex_combine_terminal_evidence "final async reaction bot response" \
     "$COMMENT_TERMINAL_BODY" "$COMMENT_TERMINAL_TIME" \
     "$COMMENT_LATEST_BODY" "$COMMENT_LATEST_TIME" \
-    "$ASYNC_REACTION_FINAL_REVIEW_BODY" "$ASYNC_REACTION_FINAL_REVIEW_TIME"
+    "$ASYNC_REACTION_FINAL_REVIEW_BODY" "$ASYNC_REACTION_FINAL_REVIEW_TIME" "$COMMENT_LATEST_IS_TERMINAL"
   ASYNC_REACTION_FINAL_BOT_RESPONSE="$COMBINED_BODY"
   ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
   # Captured before any intervening call could touch COMBINED_TIME (see

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -477,28 +477,44 @@ codex_strip_quoted_spans() {
   # GFM blockquote marker only means anything at the start of a line.
   local no_blockquotes
   no_blockquotes=$(sed -E '/^[[:space:]]*>/d' <<< "$body")
-  # Double-quote and single-quote pairs, UNLIKE backtick pairs (see
-  # below), can legitimately span a newline — a bot can quote multi-line
-  # text inside one straight-quote pair (e.g. `The documented response
-  # "\nNo blocking issues found\n" is inaccurate`). sed's substitution
-  # operates per-line by default (each line is its own pattern space), so
-  # a quote pair split across two lines was never stripped at all,
-  # letting the quoted clean phrase reach classification unstripped and
-  # return APPROVED (fresh evidence from PR #1490 finding 3797334339).
-  # Newlines are swapped for a control-character placeholder before these
-  # two substitutions — collapsing the body to one sed "line" so `[^"]*`/
-  # `[^']*` can match across what were originally separate lines — then
-  # restored immediately after, before the backtick pass below.
+  # Double-quote, single-quote, AND backtick code-span pairs can all
+  # legitimately span a newline: a bot can quote multi-line text inside
+  # one straight-quote pair (e.g. `The documented response "\nNo blocking
+  # issues found\n" is inaccurate`), and — corrected here — CommonMark/GFM
+  # inline code spans are NOT line-bound the way this function previously
+  # assumed; a code span's contents can include line endings, which are
+  # normalized to spaces in the rendered output (the earlier "an inline
+  # code span never crosses a line" comment on the backtick pass was
+  # simply wrong, per fresh evidence from PR #1490 finding 3798665086 —
+  # only FENCED, triple-backtick blocks have line-anchored open/close
+  # semantics; that is a different construct from a single/paired-backtick
+  # inline code span). sed's substitution operates per-line by default
+  # (each line is its own pattern space), so any of these three pair
+  # styles split across two lines was never stripped at all, letting the
+  # quoted/coded clean phrase reach classification unstripped and return
+  # APPROVED (fresh evidence from PR #1490 findings 3797334339 and
+  # 3798665086). Newlines are swapped for a control-character placeholder
+  # before all three substitutions — collapsing the body to one sed
+  # "line" so `[^"]*`/`[^\`]*`/`[^']*` can match across what were
+  # originally separate lines — then restored immediately after.
+  #
+  # The single-quote pattern's boundary alternatives ((^|[[:space:]]) and
+  # ([[:space:].,;:!?]|$)) also need the placeholder added explicitly: a
+  # single-quoted span occupying an ENTIRE original line by itself (e.g.
+  # `The documented response is:` / `'No blocking issues found'` / `That
+  # claim is inaccurate` across three lines) has the placeholder — not
+  # real whitespace and not true start/end-of-string — immediately before
+  # and after the quote once flattened, so neither boundary alternative
+  # matched and the span survived unstripped (fresh evidence from PR
+  # #1490 finding 3798665078). The placeholder itself is a legitimate
+  # word-break in the original text (it stands in for a real newline), so
+  # treating it as an additional boundary character is correct, not a
+  # workaround.
   local nl_placeholder=$'\x01'
   local flattened stripped
   flattened=$(printf '%s' "$no_blockquotes" | tr '\n' "$nl_placeholder")
-  stripped=$(sed -E "s/\"[^\"]*\"//g; s/(^|[[:space:]])${sq}[^${sq}]*${sq}([[:space:].,;:!?]|\$)/\\1\\2/g" <<< "$flattened")
-  stripped=$(printf '%s' "$stripped" | tr "$nl_placeholder" '\n')
-  # Backtick pairs are intentionally NOT included in the flattening above:
-  # GFM defines an inline code span as never crossing a line (an
-  # unclosed backtick run at end-of-line is not code), so keeping this
-  # substitution line-oriented is correct per spec, not a gap.
-  sed -E "s/\`[^\`]*\`//g" <<< "$stripped"
+  stripped=$(sed -E "s/\"[^\"]*\"//g; s/\`[^\`]*\`//g; s/(^|[[:space:]]|${nl_placeholder})${sq}[^${sq}]*${sq}([[:space:].,;:!?]|${nl_placeholder}|\$)/\\1\\2/g" <<< "$flattened")
+  printf '%s' "$stripped" | tr "$nl_placeholder" '\n'
 }
 
 codex_response_is_blocking() {

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -265,6 +265,15 @@ codex_response_reviews_current_head() {
 # each marker.
 CODEX_BLOCKING_PATTERN='(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)'
 CODEX_APPROVAL_PATTERN='(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)'
+# Negated forms of the approval phrases above. CODEX_APPROVAL_PATTERN's
+# "approved"/"lgtm"/"looks good" alternatives are unbounded substring
+# matches, so a rejecting response like "This change is not approved"
+# matched them unconditionally and was classified APPROVED instead of
+# falling through to the documented unrecognized-format safe-fail (fresh
+# evidence from PR #1490 finding 3789722818). Checked BEFORE the positive
+# approval pattern in codex_response_is_approved so a negated approval
+# phrase can never be reported as approved.
+CODEX_NEGATED_APPROVAL_PATTERN='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)[[:space:]]+(be[[:space:]]+)?(approved|lgtm|look(s|ing)?[[:space:]]+good)'
 
 codex_response_is_blocking() {
   local body="$1"
@@ -273,6 +282,9 @@ codex_response_is_blocking() {
 
 codex_response_is_approved() {
   local body="$1"
+  if grep -qiE "$CODEX_NEGATED_APPROVAL_PATTERN" <<< "$body"; then
+    return 1
+  fi
   grep -qiE "$CODEX_APPROVAL_PATTERN" <<< "$body"
 }
 
@@ -293,11 +305,21 @@ codex_response_is_approved() {
 #       NEEDS_REVISION, so an ambiguous response must not be silently
 #       demoted behind a mere availability notice (fresh evidence from PR
 #       #1490 finding 3789597796).
-#   1 — usage-limit: Codex hit its review quota. A response containing
-#       both an approval phrase and usage-limit wording (e.g. "No
-#       blocking issues could be evaluated because you have reached your
-#       Codex usage limits") is a usage-limit notice, not approved (fresh
-#       evidence from PR #1490 finding 3789555934).
+#   1 — usage-limit / environment error: two distinct "review was
+#       unavailable" notices, ranked at the same lower availability tier.
+#       Codex hit its review quota, OR the repo has no Codex environment
+#       configured. A response containing both an approval phrase and
+#       usage-limit wording (e.g. "No blocking issues could be evaluated
+#       because you have reached your Codex usage limits") is a
+#       usage-limit notice, not approved (fresh evidence from PR #1490
+#       finding 3789555934). An ancillary environment-setup-error comment
+#       must rank here too, not at the unrecognized-format tier: tied
+#       against a genuine (if unrecognized-format) review, an
+#       environment-setup error is a weaker, merely-informational
+#       availability notice and must not silently replace the review's
+#       safe-fail NEEDS_REVISION with an UNAVAILABLE-style
+#       codex-github-environment-missing verdict (fresh evidence from PR
+#       #1490 finding 3789722821).
 #   0 — clean approval: the only tier that produces APPROVED.
 #
 # A single binary requires-attention flag is not enough: two tied
@@ -310,7 +332,7 @@ codex_response_priority() {
   local body="$1"
   if codex_response_is_blocking "$body"; then
     printf '3\n'
-  elif codex_response_is_usage_limit "$body"; then
+  elif codex_response_is_usage_limit "$body" || codex_response_is_environment_error "$body"; then
     printf '1\n'
   elif codex_response_is_approved "$body"; then
     printf '0\n'

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -283,14 +283,21 @@ codex_response_requires_attention() {
 # Decides whether CANDIDATE terminal ("review"-sourced) evidence should
 # replace CURRENT terminal evidence. A strictly later candidate always wins.
 # GitHub timestamps are second-resolution, so ties are possible; on an exact
-# tie, evidence that is not a clean approval (blocking OR unrecognized
-# format — anything the verdict classifier would not exit APPROVED for)
-# must never be discarded in favor of an approved response, regardless of
-# which side (submitted review vs SHA-pinned root comment) supplied it. This
-# makes the tie-break symmetric: if the candidate requires attention and the
-# current evidence is a clean approval, the candidate wins; if the current
-# evidence requires attention and the candidate is a clean approval, the
-# current evidence is kept.
+# tie, evidence is ranked in three tiers — blocking > other-attention-
+# requiring (e.g. unrecognized format, a usage-limit notice) > clean
+# approval — and the higher tier wins regardless of which side (submitted
+# review vs SHA-pinned root comment) supplied it. Checking only the binary
+# requires-attention distinction is not enough: two tied responses that are
+# BOTH "requires attention" (e.g. a usage-limit root comment and a blocking
+# submitted review) would keep whichever was CURRENT even when the
+# candidate is strictly more severe (blocking), silently discarding an
+# actionable finding behind an unavailable verdict (fresh evidence from PR
+# #1490 finding 3789521036 — the prior fix addressed only
+# codex_select_review_evidence's own review-vs-review scan, leaving this
+# shared cross-source selector, used for terminal-comment-vs-terminal-
+# comment and terminal-vs-review ties, unchanged). Blocking is checked
+# first; only if neither side is blocking does the requires-attention tier
+# decide the tie.
 codex_select_terminal_evidence() {
   local current_body="$1" current_time="$2"
   local candidate_body="$3" candidate_time="$4"
@@ -299,6 +306,9 @@ codex_select_terminal_evidence() {
     return 0
   fi
   if [ "$candidate_time" = "$current_time" ]; then
+    if codex_response_is_blocking "$candidate_body" && ! codex_response_is_blocking "$current_body"; then
+      return 0
+    fi
     if codex_response_requires_attention "$candidate_body" && ! codex_response_requires_attention "$current_body"; then
       return 0
     fi

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -451,7 +451,7 @@ CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t 
 # "cannot approve" fixed for finding 3790023141, just a different
 # inability phrase).
 CODEX_NEGATED_APPROVAL_TARGET_WORDS='(approve[ds]?|lgtm|look(s|ing)?[[:space:]]+good|no[[:space:]]+blocking[[:space:]]+issues?|didn.t find[[:space:]]+any major[[:space:]]+issues)'
-CODEX_NEGATION_WORDS='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|do[[:space:]]+not|don.t|never|unable[[:space:]]+to)'
+CODEX_NEGATION_WORDS='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|do[[:space:]]+not|don.t|should[[:space:]]+not|shouldn.t|must[[:space:]]+not|mustn.t|never|unable[[:space:]]+to)'
 CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*${CODEX_NEGATED_APPROVAL_TARGET_WORDS}"
 # Any CODEX_NEGATION_WORDS alternative, followed within the same clause
 # by "merge"/"merged" (with or without an intervening "be"), is treated
@@ -600,24 +600,46 @@ codex_response_is_blocking() {
   # pushes toward NEEDS_REVISION), so no fence guard is needed here for
   # that direction either — codex_strip_quoted_spans' straight-quote/
   # backtick-pair/blockquote/single-quote stripping is enough.
-  grep -qiE "$CODEX_BLOCKING_PATTERN" <<< "$(codex_strip_quoted_spans "$body")"
+  #
+  # codex_strip_not_only_idiom is also applied here now: CODEX_BLOCKING_
+  # PATTERN's generalized merge-refusal alternative
+  # (CODEX_MERGE_REFUSAL_PATTERN) reuses CODEX_NEGATION_WORDS' bare "not"
+  # alternative the same way CODEX_NEGATED_APPROVAL_PATTERN does, so it
+  # inherits the exact same "not only X" affirmative-idiom
+  # misclassification that motivated codex_strip_not_only_idiom in the
+  # first place — a clean response like "This is not only safe to merge
+  # but looks good" has "not" followed by "merge" within the same clause
+  # and was misread as a merge refusal, returning NEEDS_REVISION for a
+  # genuinely clean review (fresh evidence from PR #1490 finding
+  # 3799277922). This is a false POSITIVE (pushes toward the safe
+  # NEEDS_REVISION direction, never toward incorrectly APPROVED), unlike
+  # every other gap fixed in this function, but is still worth closing
+  # since needlessly blocking a clean review triggers an unnecessary fix
+  # cycle.
+  local normalized_body
+  normalized_body=$(codex_strip_not_only_idiom "$(codex_strip_quoted_spans "$body")")
+  grep -qiE "$CODEX_BLOCKING_PATTERN" <<< "$normalized_body"
 }
 
-# Strips the "not only X" idiom — used ONLY by codex_response_is_approved
-# below. "Not only X, (but) Y" is an AFFIRMATIVE intensifier construction
-# (BOTH X and Y are being asserted, not negated: "Not only does this look
-# good, it is approved" means both "looks good" and "is approved" hold),
-# not a negation of X, so CODEX_NEGATION_WORDS' bare "not" alternative —
-# which has no way to distinguish this idiom from a genuine negation —
-# misclassified it as negated (fresh evidence from PR #1490 finding
-# 3793299512). Stripped entirely (not just skipped) so the leftover "not"
-# cannot accidentally trigger a match against some OTHER target word
-# later in the same clause. Every letter is bracket-expanded for both
-# cases (rather than relying on sed's `I` substitution flag, whose
-# support varies across sed implementations), since the original
-# [Nn]ot/[Oo]nly form only covered Title-Case and lowercase, not a fully
-# uppercase emphasis form like "NOT ONLY" (fresh evidence from PR #1490
-# finding 3793330278, a followup to 3793299512).
+# Strips the "not only X" idiom — used by codex_response_is_approved and
+# codex_response_is_blocking below (originally added for approval only,
+# see codex_response_is_blocking's own comment for why the blocking
+# classifier needed it too once its merge-refusal pattern started reusing
+# CODEX_NEGATION_WORDS' bare "not" alternative). "Not only X, (but) Y" is
+# an AFFIRMATIVE intensifier construction (BOTH X and Y are being
+# asserted, not negated: "Not only does this look good, it is approved"
+# means both "looks good" and "is approved" hold), not a negation of X,
+# so CODEX_NEGATION_WORDS' bare "not" alternative — which has no way to
+# distinguish this idiom from a genuine negation — misclassified it as
+# negated (fresh evidence from PR #1490 finding 3793299512). Stripped
+# entirely (not just skipped) so the leftover "not" cannot accidentally
+# trigger a match against some OTHER target word later in the same
+# clause. Every letter is bracket-expanded for both cases (rather than
+# relying on sed's `I` substitution flag, whose support varies across sed
+# implementations), since the original [Nn]ot/[Oo]nly form only covered
+# Title-Case and lowercase, not a fully uppercase emphasis form like "NOT
+# ONLY" (fresh evidence from PR #1490 finding 3793330278, a followup to
+# 3793299512).
 codex_strip_not_only_idiom() {
   local body="$1"
   sed -E 's/[Nn][Oo][Tt][[:space:]]+[Oo][Nn][Ll][Yy]//g' <<< "$body"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -252,8 +252,16 @@ codex_response_is_usage_limit() {
   # itself misclassified as a usage-limit notice (fresh evidence from PR
   # #1490 finding 3789928781). It now requires an exhaustion/unavailability
   # word directly after the noun, mirroring the structure already used by
-  # the fourth alternative ("capacity exhausted/unavailable/limited").
-  grep -qiE "(reached[[:space:]]+your[[:space:]]+codex[[:space:]]+usage[[:space:]]+limits?|codex[[:space:]]+usage[[:space:]]+limits?[[:space:]]+for[[:space:]]+code[[:space:]]+reviews?|codex[[:space:]]+(github[[:space:]]+app[[:space:]]+)?(review[[:space:]]+)?(usage[[:space:]]+limit|quota|capacity)[[:space:]]+(reached|exceeded|exhausted|hit|unavailable|limited)|codex[[:space:]]+review[[:space:]]+capacity[[:space:]]+(exhausted|unavailable|limited))" <<< "$response"
+  # the fourth alternative ("capacity exhausted/unavailable/limited"). The
+  # second alternative ("codex usage limits for code reviews") had the
+  # exact same unguarded-mention gap — e.g. "No blocking issues found. The
+  # docs correctly explain Codex usage limits for code reviews." — missed
+  # in the first pass since only the third alternative was narrowed then;
+  # it now requires an exhaustion word after "code reviews" too (fresh
+  # evidence from PR #1490 finding 3789958776, a followup to 3789928781).
+  # The real "reached your ... limits for code reviews" phrasing remains
+  # covered by the first alternative regardless of this narrowing.
+  grep -qiE "(reached[[:space:]]+your[[:space:]]+codex[[:space:]]+usage[[:space:]]+limits?|codex[[:space:]]+usage[[:space:]]+limits?[[:space:]]+for[[:space:]]+code[[:space:]]+reviews?[[:space:]]+(reached|exceeded|exhausted|hit|unavailable|limited)|codex[[:space:]]+(github[[:space:]]+app[[:space:]]+)?(review[[:space:]]+)?(usage[[:space:]]+limit|quota|capacity)[[:space:]]+(reached|exceeded|exhausted|hit|unavailable|limited)|codex[[:space:]]+review[[:space:]]+capacity[[:space:]]+(exhausted|unavailable|limited))" <<< "$response"
 }
 
 codex_response_is_environment_error() {
@@ -312,8 +320,17 @@ CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t 
 # Codex found the next one; allowing a bounded window of filler words
 # generalizes past this specific class of gap instead of special-casing
 # it again (fresh evidence from PR #1490 finding 3789904716, a followup to
-# 3789878264/3789851555/3789722818).
-CODEX_NEGATED_APPROVAL_PATTERN='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)[*_~]{0,3}([[:space:]]+[*_~]{0,3}[[:alpha:]'"'"'-]{1,20}[*_~]{0,3}){0,3}[[:space:]]+[*_~]{0,3}(be[[:space:]]+)?[*_~]{0,3}(approved|lgtm|look(s|ing)?[[:space:]]+good)'
+# 3789878264/3789851555/3789722818). The target alternation now also
+# covers "no blocking issues"/"didn't find any major issues", not just
+# "approved"/"lgtm"/"looks good": those are approval SIGNALS in
+# CODEX_APPROVAL_PATTERN too, but were left unguarded by this negation
+# check, so a hedged/uncertain response like "I cannot confirm there are
+# no blocking issues" still matched CODEX_APPROVAL_PATTERN's "no blocking
+# issues" alternative and was classified APPROVED (fresh evidence from PR
+# #1490 finding 3789958775). The existing filler-word tolerance already
+# generalizes to this case ("cannot" + "confirm there are" (3 filler
+# words) + "no blocking issues") without further changes.
+CODEX_NEGATED_APPROVAL_PATTERN='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)[*_~]{0,3}([[:space:]]+[*_~]{0,3}[[:alpha:]'"'"'-]{1,20}[*_~]{0,3}){0,3}[[:space:]]+[*_~]{0,3}(be[[:space:]]+)?[*_~]{0,3}(approved|lgtm|look(s|ing)?[[:space:]]+good|no[[:space:]]+blocking[[:space:]]+issues?|didn.t find[[:space:]]+any major[[:space:]]+issues)'
 
 codex_response_is_blocking() {
   local body="$1"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -40,9 +40,10 @@
 #   2. Approval signals present → APPROVED (exit 0)
 #      Signals (case-insensitive): "approved", "lgtm", "looks good",
 #      "didn't find any major issues", or "no blocking issues" from a
-#      submitted review pinned to the current head. Codex root PR comments and
-#      thumbs-up reactions are acknowledgements only; they are not SHA-pinned
-#      review evidence and must not approve the PR by themselves.
+#      submitted review pinned to the current head, or a root PR comment that
+#      names the current head in a Reviewed commit marker. Other Codex root PR
+#      comments and thumbs-up reactions are acknowledgements only; they are not
+#      SHA-pinned review evidence and must not approve the PR by themselves.
 #   3. Neither found (unrecognized format) → safe-fails to NEEDS_REVISION (exit 1)
 #
 # Response source detection (two sources polled each cycle):
@@ -248,6 +249,12 @@ codex_response_reviews_current_head() {
   [ -n "$reviewed_sha" ] && printf '%s\n' "$CURRENT_SHA" | grep -qi "^$reviewed_sha"
 }
 
+codex_response_time_should_replace() {
+  local candidate_time="$1"
+  local current_time="$2"
+  [ -z "$current_time" ] || [ "$candidate_time" = "$current_time" ] || [ "$candidate_time" \> "$current_time" ]
+}
+
 codex_return_usage_limit() {
   echo "VERDICT: UNAVAILABLE — Codex GitHub review usage limit reached"
   echo "REASON=codex-github-usage-limit"
@@ -427,13 +434,15 @@ while true; do
   POLL_STDERR=$(mktemp)
   POLL_TMPFILE=$(mktemp)
   BOT_RESPONSE_SOURCE=""
+  BOT_RESPONSE_TIME=""
   if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
     2>"$POLL_STDERR" \
     | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
-        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | .body // empty' \
+        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | {created_at:(.created_at // ""), body:(.body // "")}' \
     > "$POLL_TMPFILE"; then
 	    # Truncate after successful API call — no SIGPIPE risk here
-	    BOT_RESPONSE=$(head -c 10000 "$POLL_TMPFILE")
+	    BOT_RESPONSE=$(jq -r '.body // empty' "$POLL_TMPFILE" | head -c 10000)
+	    BOT_RESPONSE_TIME=$(jq -r '.created_at // empty' "$POLL_TMPFILE")
 	    if [ -n "$BOT_RESPONSE" ]; then
 	      BOT_RESPONSE_SOURCE="comment"
 	      if codex_response_reviews_current_head "$BOT_RESPONSE"; then
@@ -464,11 +473,13 @@ while true; do
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>"$REVIEW_STDERR" \
     | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
     > "$REVIEW_TMPFILE" 2>"$REVIEW_STDERR"; then
-    REVIEW_BODY=$(head -c 5000 "$REVIEW_TMPFILE")
-    if [ -n "$REVIEW_BODY" ]; then
+    REVIEW_BODY=$(jq -r '.body // empty' "$REVIEW_TMPFILE" | head -c 5000)
+    REVIEW_TIME=$(jq -r '.created_at // empty' "$REVIEW_TMPFILE")
+    if [ -n "$REVIEW_BODY" ] && codex_response_time_should_replace "$REVIEW_TIME" "$BOT_RESPONSE_TIME"; then
       BOT_RESPONSE="$REVIEW_BODY"
+      BOT_RESPONSE_TIME="$REVIEW_TIME"
       BOT_RESPONSE_SOURCE="review"
       echo "INFO: bot response detected via PR reviews endpoint"
     fi
@@ -516,8 +527,9 @@ while true; do
     # 2. Explicit approval signals present → APPROVED (exit 0)   [checked second]
     #    Approval signals: "approved", "lgtm", "looks good",
     #    "didn't find any major issues", or "no blocking issues" from a
-    #    submitted review pinned to the current head. A Codex root PR comment or
-    #    thumbs-up reaction is not SHA-pinned and is unavailable, not clean.
+    #    submitted review pinned to the current head, or a root PR comment that
+    #    names the current head in a Reviewed commit marker. Other Codex root PR
+    #    comments and thumbs-up reactions are unavailable, not clean.
     #
     # 3. Neither found (unrecognized response format) → NEEDS_REVISION (exit 1)
     #    Safe-fail: default to NEEDS_REVISION when the format is unrecognized to
@@ -916,6 +928,9 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
       echo "---END BOT RESPONSE---"
       exit 1
     fi
+  fi
+  if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ]; then
+    codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
   fi
   codex_return_reaction_without_review
 fi

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -351,33 +351,49 @@ CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t 
 # separate one, but the span crossed the semicolon and matched anyway
 # (PR #1490 finding 3790122061, the same class of gap as 3790062089
 # above but on the forward-order side rather than the removed reverse
-# alternative). The character class now also excludes `;`.
+# alternative). The character class also excludes `;` and `,`: a comma-
+# joined clause (e.g. "Tests are not required, but looks good") crossed
+# the semicolon-only exclusion the same way the semicolon-crossing case
+# crossed the original unbounded span (fresh evidence from PR #1490
+# finding 3793219193, a followup to 3790122061/3790062089).
 CODEX_NEGATED_APPROVAL_TARGET_WORDS='(approve[ds]?|lgtm|look(s|ing)?[[:space:]]+good|no[[:space:]]+blocking[[:space:]]+issues?|didn.t find[[:space:]]+any major[[:space:]]+issues)'
 CODEX_NEGATION_WORDS='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)'
-CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;]*${CODEX_NEGATED_APPROVAL_TARGET_WORDS}"
+CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*${CODEX_NEGATED_APPROVAL_TARGET_WORDS}"
 
 codex_response_is_blocking() {
   local body="$1"
   grep -qiE "$CODEX_BLOCKING_PATTERN" <<< "$body"
 }
 
+# Strips quoted spans — text between a pair of straight double-quotes
+# ("...") AND text between a pair of backticks (`...`, Markdown inline
+# code) — used ONLY by codex_response_is_approved below, never applied to
+# the body before codex_response_reviews_current_head's SHA extraction
+# (which itself relies on backtick-delimited `Reviewed commit:` markers
+# and must see the original, unstripped body). A SHA-pinned review can
+# QUOTE a clean phrase, in either quoting style, while REJECTING it (e.g.
+# `The documented bot response "No blocking issues found" is inaccurate`
+# or the Markdown-code equivalent using backticks), and both
+# CODEX_APPROVAL_PATTERN and CODEX_NEGATED_APPROVAL_PATTERN's substring
+# matches can't distinguish quotation/discussion of a phrase from an
+# assertion of it (fresh evidence from PR #1490 findings 3790122058 and
+# 3793219190 — straight-quote and backtick-quote versions of the same
+# gap — plus 3793219192, which found that only the POSITIVE check was
+# quote-stripped and a quoted REJECTION phrase, e.g. `No blocking issues
+# found. The tests cover "This change is not approved".`, still tripped
+# the NEGATION check on the unstripped body).
+codex_strip_quoted_spans() {
+  local body="$1"
+  sed -E 's/"[^"]*"//g; s/`[^`]*`//g' <<< "$body"
+}
+
 codex_response_is_approved() {
   local body="$1"
-  if grep -qiE "$CODEX_NEGATED_APPROVAL_PATTERN" <<< "$body"; then
+  local unquoted_body
+  unquoted_body=$(codex_strip_quoted_spans "$body")
+  if grep -qiE "$CODEX_NEGATED_APPROVAL_PATTERN" <<< "$unquoted_body"; then
     return 1
   fi
-  # Strip quoted spans (text between a pair of straight double-quotes)
-  # before matching CODEX_APPROVAL_PATTERN: a SHA-pinned review can QUOTE
-  # a clean phrase while REJECTING it (e.g. `The documented bot response
-  # "No blocking issues found" is inaccurate and should be corrected`),
-  # and CODEX_APPROVAL_PATTERN's substring match can't distinguish
-  # quotation/discussion of a phrase from an assertion of it. Removing
-  # quoted text first means only a genuinely UNQUOTED approval phrase can
-  # still match; a real approval elsewhere in the same response (outside
-  # any quotes) is unaffected (fresh evidence from PR #1490 finding
-  # 3790122058).
-  local unquoted_body
-  unquoted_body=$(sed -E 's/"[^"]*"//g' <<< "$body")
   grep -qiE "$CODEX_APPROVAL_PATTERN" <<< "$unquoted_body"
 }
 

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -451,7 +451,26 @@ CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t 
 # "cannot approve" fixed for finding 3790023141, just a different
 # inability phrase).
 CODEX_NEGATED_APPROVAL_TARGET_WORDS='(approve[ds]?|lgtm|look(s|ing)?[[:space:]]+good|no[[:space:]]+blocking[[:space:]]+issues?|didn.t find[[:space:]]+any major[[:space:]]+issues)'
-CODEX_NEGATION_WORDS='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|do[[:space:]]+not|don.t|should[[:space:]]+not|shouldn.t|must[[:space:]]+not|mustn.t|never|unable[[:space:]]+to)'
+# Proactive sweep of the remaining common English negation forms not yet
+# covered (was/were/would/has/have/had, contracted and space-separated),
+# added in one pass after four consecutive findings each surfaced one
+# more missing modal-verb negation one at a time (don't, should/mustn't,
+# and finally wouldn't — fresh evidence from PR #1490 finding 3799391883
+# — prompted this sweep rather than continuing to fix them one at a
+# time). "did not"/"didn't" is DELIBERATELY excluded despite being an
+# equally common negation form: it already appears baked into
+# CODEX_NEGATED_APPROVAL_TARGET_WORDS above as part of the atomic phrase
+# "didn't find any major issues" (itself a clean/approval signal, not
+# something to negate). Adding bare "didn.t" here was verified to
+# introduce a genuine false positive: a response like "Codex didn't find
+# any major issues and looks good." — doubly-reinforced clean, not
+# rejected — matched NEGATION_WORDS on "didn't" and then reached the
+# separate "looks good" target later in the same unpunctuated sentence,
+# misclassifying a clean review as NEEDS_REVISION. Caught and reverted
+# during this sweep's own verification before ever being committed;
+# left undocumented here it would be an easy trap for a future sweep to
+# re-introduce.
+CODEX_NEGATION_WORDS='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|was[[:space:]]+not|wasn.t|were[[:space:]]+not|weren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|would[[:space:]]+not|wouldn.t|does[[:space:]]+not|doesn.t|do[[:space:]]+not|don.t|has[[:space:]]+not|hasn.t|have[[:space:]]+not|haven.t|had[[:space:]]+not|hadn.t|should[[:space:]]+not|shouldn.t|must[[:space:]]+not|mustn.t|never|unable[[:space:]]+to)'
 CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*${CODEX_NEGATED_APPROVAL_TARGET_WORDS}"
 # Any CODEX_NEGATION_WORDS alternative, followed within the same clause
 # by "merge"/"merged" (with or without an intervening "be"), is treated

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -246,13 +246,13 @@ codex_response_reviews_current_head() {
   local response="$1"
   local reviewed_sha
   reviewed_sha=$(printf '%s\n' "$response" | sed -n 's/.*Reviewed commit:[^`]*`\([0-9a-fA-F]\{7,40\}\)`.*/\1/p' | tail -n 1)
-  [ -n "$reviewed_sha" ] && printf '%s\n' "$CURRENT_SHA" | grep -qi "^$reviewed_sha"
+  [ -n "$reviewed_sha" ] && { printf '%s\n' "$CURRENT_SHA" | grep -qi "^$reviewed_sha" || printf '%s\n' "$reviewed_sha" | grep -qi "^$CURRENT_SHA"; }
 }
 
 codex_response_time_should_replace() {
   local candidate_time="$1"
   local current_time="$2"
-  [ -z "$current_time" ] || [ "$candidate_time" = "$current_time" ] || [ "$candidate_time" \> "$current_time" ]
+  [ -z "$current_time" ] || [ "$candidate_time" \> "$current_time" ]
 }
 
 codex_return_usage_limit() {

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -446,8 +446,8 @@ while true; do
   REVIEW_TMPFILE=$(mktemp)
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>/dev/null \
-    | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha))) | .body' \
+    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
     > "$REVIEW_TMPFILE" 2>/dev/null; then
     REVIEW_BODY=$(head -c 5000 "$REVIEW_TMPFILE")
     if [ -n "$REVIEW_BODY" ]; then
@@ -649,8 +649,8 @@ rm -f "$ASYNC_POLL_TMPFILE"
 ASYNC_REVIEW_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
   2>/dev/null \
-  | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-      '.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha))) | .body' \
+  | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
+      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
   > "$ASYNC_REVIEW_TMPFILE" 2>/dev/null; then
   ASYNC_REVIEW_BODY=$(head -c 5000 "$ASYNC_REVIEW_TMPFILE")
   if [ -n "$ASYNC_REVIEW_BODY" ]; then
@@ -711,8 +711,8 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     ASYNC_FINAL_REVIEW_TMPFILE=$(mktemp)
     if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
       2>/dev/null \
-      | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-          '.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha))) | .body' \
+      | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
+          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
       > "$ASYNC_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
       ASYNC_FINAL_REVIEW_BODY=$(head -c 5000 "$ASYNC_FINAL_REVIEW_TMPFILE")
       if [ -n "$ASYNC_FINAL_REVIEW_BODY" ]; then

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -232,21 +232,31 @@ codex_inline_review_comment_count_since() {
   rm -f "$review_comment_tmpfile"
 }
 
+# All classification helpers below match against the response via a
+# here-string (`<<<`), not a piped `printf`. A here-string is written to a
+# temp file/buffer by the shell BEFORE the command starts reading, so a
+# `grep -q` match that closes its input early (as soon as it finds a
+# match, per POSIX/GNU semantics) can never cause the writer side to
+# receive SIGPIPE — unlike `printf | grep -q`, where an early match on a
+# response large enough to require multiple pipe writes can SIGPIPE the
+# still-writing printf. This matters once classification runs on the
+# FULL, untruncated response (see BOT_RESPONSE_FULL below) rather than a
+# pre-truncated copy.
 codex_response_is_usage_limit() {
   local response="$1"
-  printf '%s\n' "$response" | grep -qiE "(reached[[:space:]]+your[[:space:]]+codex[[:space:]]+usage[[:space:]]+limits?|codex[[:space:]]+usage[[:space:]]+limits?[[:space:]]+for[[:space:]]+code[[:space:]]+reviews?|codex[[:space:]]+(github[[:space:]]+app[[:space:]]+)?(review[[:space:]]+)?(usage[[:space:]]+limit|quota|capacity)|codex[[:space:]]+review[[:space:]]+capacity[[:space:]]+(exhausted|unavailable|limited))"
+  grep -qiE "(reached[[:space:]]+your[[:space:]]+codex[[:space:]]+usage[[:space:]]+limits?|codex[[:space:]]+usage[[:space:]]+limits?[[:space:]]+for[[:space:]]+code[[:space:]]+reviews?|codex[[:space:]]+(github[[:space:]]+app[[:space:]]+)?(review[[:space:]]+)?(usage[[:space:]]+limit|quota|capacity)|codex[[:space:]]+review[[:space:]]+capacity[[:space:]]+(exhausted|unavailable|limited))" <<< "$response"
 }
 
 codex_response_is_environment_error() {
   local response="$1"
-  printf '%s\n' "$response" | grep -qiE "to[[:space:]]+use[[:space:]]+codex[[:space:]]+here,[[:space:]]+create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo"
+  grep -qiE "to[[:space:]]+use[[:space:]]+codex[[:space:]]+here,[[:space:]]+create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo" <<< "$response"
 }
 
 codex_response_reviews_current_head() {
   local response="$1"
   local reviewed_sha
-  reviewed_sha=$(printf '%s\n' "$response" | sed -n 's/.*Reviewed commit:[^`]*`\([0-9a-fA-F]\{7,40\}\)`.*/\1/p' | tail -n 1)
-  [ -n "$reviewed_sha" ] && { printf '%s\n' "$CURRENT_SHA" | grep -qi "^$reviewed_sha" || printf '%s\n' "$reviewed_sha" | grep -qi "^$CURRENT_SHA"; }
+  reviewed_sha=$(sed -n 's/.*Reviewed commit:[^`]*`\([0-9a-fA-F]\{7,40\}\)`.*/\1/p' <<< "$response" | tail -n 1)
+  [ -n "$reviewed_sha" ] && { grep -qi "^$reviewed_sha" <<< "$CURRENT_SHA" || grep -qi "^$CURRENT_SHA" <<< "$reviewed_sha"; }
 }
 
 # Blocking/approval marker patterns, centralized so every classification site
@@ -258,12 +268,12 @@ CODEX_APPROVAL_PATTERN='(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space
 
 codex_response_is_blocking() {
   local body="$1"
-  printf '%s\n' "$body" | grep -qiE "$CODEX_BLOCKING_PATTERN"
+  grep -qiE "$CODEX_BLOCKING_PATTERN" <<< "$body"
 }
 
 codex_response_is_approved() {
   local body="$1"
-  printf '%s\n' "$body" | grep -qiE "$CODEX_APPROVAL_PATTERN"
+  grep -qiE "$CODEX_APPROVAL_PATTERN" <<< "$body"
 }
 
 # Ranks a response into one of four priority tiers, highest wins on a
@@ -798,6 +808,15 @@ while true; do
   # verdict parsing and hit the unrecognized-format safe-fail instead of
   # being treated as "no response at all").
   BOT_RESPONSE_TIME="$COMBINED_TIME"
+  # BOT_RESPONSE_FULL (untruncated) is what every classifier below matches
+  # against — a truncated copy could cut off a blocking marker that
+  # appears after the cutoff in a long root comment, letting the response
+  # fall through to an approval or unavailable verdict while a real
+  # finding sits just past the cut point (fresh evidence from PR #1490
+  # finding 3789634709). BOT_RESPONSE itself is truncated below and used
+  # ONLY for the "---BEGIN/END BOT RESPONSE---" display in the script's
+  # own output, never for classification.
+  BOT_RESPONSE_FULL="$BOT_RESPONSE"
   # Truncate here (post-combine) — mirrors the prior per-source truncation but
   # applies uniformly regardless of which source won. Root-comment-sourced
   # bodies are not truncated at scan time (unlike review bodies, which are
@@ -860,7 +879,7 @@ while true; do
     # "no blocking issues". This avoids false positives without line-level filtering
     # (which would risk missing a genuine marker on the same line as a negation).
 
-    if [ "$BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$BOT_RESPONSE"; then
+    if [ "$BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$BOT_RESPONSE_FULL"; then
       # Blocking is checked first, ahead of usage-limit: a terminal/review
       # finding whose text happens to mention "usage limit" as part of an
       # actionable finding (e.g. flagging stale docs that describe it) must
@@ -871,15 +890,15 @@ while true; do
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 1
-    elif codex_response_is_usage_limit "$BOT_RESPONSE"; then
+    elif codex_response_is_usage_limit "$BOT_RESPONSE_FULL"; then
       codex_return_usage_limit "$BOT_RESPONSE"
-    elif [ "$BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$BOT_RESPONSE"; then
+    elif [ "$BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$BOT_RESPONSE_FULL"; then
       SEEN_ENVIRONMENT_ERROR=1
       SEEN_ENVIRONMENT_RESPONSE="$BOT_RESPONSE"
       SEEN_ENVIRONMENT_TIME="$COMBINED_TIME"
       echo "INFO: Codex environment setup response detected; waiting for fresh current-head review evidence"
       continue
-    elif [ "$BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$BOT_RESPONSE"; then
+    elif [ "$BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$BOT_RESPONSE_FULL"; then
       if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ] && ! [ "$COMBINED_TIME" \> "$SEEN_ENVIRONMENT_TIME" ]; then
         codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
       fi
@@ -888,7 +907,7 @@ while true; do
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 0
-    elif echo "$BOT_RESPONSE" | grep -qi "If Codex has suggestions, it will comment; otherwise it will react with"; then
+    elif grep -qi "If Codex has suggestions, it will comment; otherwise it will react with" <<< "$BOT_RESPONSE_FULL"; then
       echo "INFO: Codex acknowledgement detected; waiting for current-head review or inline review comments"
       continue
     elif [ "$BOT_RESPONSE_SOURCE" = "comment" ]; then
@@ -1050,6 +1069,10 @@ ASYNC_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
 # Captured before any intervening call could touch COMBINED_TIME (see
 # rationale above the main-loop equivalent).
 ASYNC_BOT_RESPONSE_TIME="$COMBINED_TIME"
+# Untruncated copy used for classification below (see rationale above the
+# main-loop equivalent — a truncated copy could cut off a blocking marker
+# in a long root comment).
+ASYNC_BOT_RESPONSE_FULL="$ASYNC_BOT_RESPONSE"
 # `jq -Rs` slurps its entire stdin before producing output, avoiding
 # SIGPIPE on long root-comment-sourced bodies (see rationale above the
 # main-loop equivalent).
@@ -1062,20 +1085,20 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
   # Apply the same three-path verdict parsing as the main poll loop.
   # Blocking is checked first, ahead of usage-limit (see rationale above
   # the main-loop equivalent).
-  if [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_BOT_RESPONSE"; then
+  if [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_BOT_RESPONSE_FULL"; then
     echo "VERDICT: NEEDS_REVISION"
     echo "---BEGIN BOT RESPONSE---"
     echo "$ASYNC_BOT_RESPONSE"
     echo "---END BOT RESPONSE---"
     exit 1
-  elif codex_response_is_usage_limit "$ASYNC_BOT_RESPONSE"; then
+  elif codex_response_is_usage_limit "$ASYNC_BOT_RESPONSE_FULL"; then
     codex_return_usage_limit "$ASYNC_BOT_RESPONSE"
-  elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_BOT_RESPONSE"; then
+  elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_BOT_RESPONSE_FULL"; then
     SEEN_ENVIRONMENT_ERROR=1
     SEEN_ENVIRONMENT_RESPONSE="$ASYNC_BOT_RESPONSE"
     SEEN_ENVIRONMENT_TIME="$COMBINED_TIME"
     echo "INFO: async-arrival Codex environment setup response detected without fresh review evidence"
-  elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_BOT_RESPONSE"; then
+  elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_BOT_RESPONSE_FULL"; then
     if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ] && ! [ "$COMBINED_TIME" \> "$SEEN_ENVIRONMENT_TIME" ]; then
       codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
     fi
@@ -1084,7 +1107,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
     echo "$ASYNC_BOT_RESPONSE"
     echo "---END BOT RESPONSE---"
     exit 0
-  elif echo "$ASYNC_BOT_RESPONSE" | grep -qi "If Codex has suggestions, it will comment; otherwise it will react with"; then
+  elif grep -qi "If Codex has suggestions, it will comment; otherwise it will react with" <<< "$ASYNC_BOT_RESPONSE_FULL"; then
     echo "INFO: async-arrival Codex acknowledgement detected without current-head review or inline comments"
     echo "INFO: waiting ${POLL_INTERVAL}s for final Codex async signal..."
     sleep "$POLL_INTERVAL"
@@ -1145,6 +1168,9 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
     # Captured before any intervening call could touch COMBINED_TIME (see
     # rationale above the main-loop equivalent).
     ASYNC_FINAL_BOT_RESPONSE_TIME="$COMBINED_TIME"
+    # Untruncated copy used for classification below (see rationale above
+    # the main-loop equivalent).
+    ASYNC_FINAL_BOT_RESPONSE_FULL="$ASYNC_FINAL_BOT_RESPONSE"
     # `jq -Rs` slurps its entire stdin before producing output, avoiding
     # SIGPIPE on long root-comment-sourced bodies (see rationale above the
     # main-loop equivalent).
@@ -1155,20 +1181,20 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
       codex_require_current_head
       # Blocking is checked first, ahead of usage-limit (see rationale
       # above the main-loop equivalent).
-      if [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_FINAL_BOT_RESPONSE"; then
+      if [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_FINAL_BOT_RESPONSE_FULL"; then
         echo "VERDICT: NEEDS_REVISION"
         echo "---BEGIN BOT RESPONSE---"
         echo "$ASYNC_FINAL_BOT_RESPONSE"
         echo "---END BOT RESPONSE---"
         exit 1
-      elif codex_response_is_usage_limit "$ASYNC_FINAL_BOT_RESPONSE"; then
+      elif codex_response_is_usage_limit "$ASYNC_FINAL_BOT_RESPONSE_FULL"; then
         codex_return_usage_limit "$ASYNC_FINAL_BOT_RESPONSE"
-      elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_FINAL_BOT_RESPONSE"; then
+      elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_FINAL_BOT_RESPONSE_FULL"; then
         SEEN_ENVIRONMENT_ERROR=1
         SEEN_ENVIRONMENT_RESPONSE="$ASYNC_FINAL_BOT_RESPONSE"
         SEEN_ENVIRONMENT_TIME="$COMBINED_TIME"
         echo "INFO: final async Codex environment setup response detected without fresh review evidence"
-      elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_FINAL_BOT_RESPONSE"; then
+      elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_FINAL_BOT_RESPONSE_FULL"; then
         if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ] && ! [ "$COMBINED_TIME" \> "$SEEN_ENVIRONMENT_TIME" ]; then
           codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
         fi
@@ -1179,7 +1205,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
         exit 0
       elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "comment" ]; then
         echo "INFO: final async Codex root comment is not SHA-pinned terminal evidence"
-      elif ! echo "$ASYNC_FINAL_BOT_RESPONSE" | grep -qi "If Codex has suggestions, it will comment; otherwise it will react with"; then
+      elif ! grep -qi "If Codex has suggestions, it will comment; otherwise it will react with" <<< "$ASYNC_FINAL_BOT_RESPONSE_FULL"; then
         echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
         echo "---BEGIN BOT RESPONSE---"
         echo "$ASYNC_FINAL_BOT_RESPONSE"
@@ -1278,6 +1304,9 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
   # Captured before any intervening call could touch COMBINED_TIME (see
   # rationale above the main-loop equivalent).
   ASYNC_REACTION_FINAL_BOT_RESPONSE_TIME="$COMBINED_TIME"
+  # Untruncated copy used for classification below (see rationale above
+  # the main-loop equivalent).
+  ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL="$ASYNC_REACTION_FINAL_BOT_RESPONSE"
   # `jq -Rs` slurps its entire stdin before producing output, avoiding
   # SIGPIPE on long root-comment-sourced bodies (see rationale above the
   # main-loop equivalent).
@@ -1287,20 +1316,20 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
     codex_require_current_head
     # Blocking is checked first, ahead of usage-limit (see rationale above
     # the main-loop equivalent).
-    if [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
+    if [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL"; then
       echo "VERDICT: NEEDS_REVISION"
       echo "---BEGIN BOT RESPONSE---"
       echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 1
-    elif codex_response_is_usage_limit "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
+    elif codex_response_is_usage_limit "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL"; then
       codex_return_usage_limit "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
-    elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
+    elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL"; then
       SEEN_ENVIRONMENT_ERROR=1
       SEEN_ENVIRONMENT_RESPONSE="$ASYNC_REACTION_FINAL_BOT_RESPONSE"
       SEEN_ENVIRONMENT_TIME="$COMBINED_TIME"
       echo "INFO: final async reaction Codex environment setup response detected without fresh review evidence"
-    elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
+    elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL"; then
       if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ] && ! [ "$COMBINED_TIME" \> "$SEEN_ENVIRONMENT_TIME" ]; then
         codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
       fi
@@ -1311,7 +1340,7 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
       exit 0
     elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "comment" ]; then
       echo "INFO: final async reaction Codex root comment is not SHA-pinned terminal evidence"
-    elif ! echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE" | grep -qi "If Codex has suggestions, it will comment; otherwise it will react with"; then
+    elif ! grep -qi "If Codex has suggestions, it will comment; otherwise it will react with" <<< "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL"; then
       echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
       echo "---BEGIN BOT RESPONSE---"
       echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -40,9 +40,9 @@
 #   2. Approval signals present → APPROVED (exit 0)
 #      Signals (case-insensitive): "approved", "lgtm", "looks good",
 #      "didn't find any major issues", or "no blocking issues" from a
-#      current-head comment or submitted review. A Codex thumbs-up reaction on
-#      the trigger comment is an acknowledgement only; it is not SHA-pinned
-#      review evidence and must not approve the PR by itself.
+#      submitted review pinned to the current head. Codex root PR comments and
+#      thumbs-up reactions are acknowledgements only; they are not SHA-pinned
+#      review evidence and must not approve the PR by themselves.
 #   3. Neither found (unrecognized format) → safe-fails to NEEDS_REVISION (exit 1)
 #
 # Response source detection (two sources polled each cycle):
@@ -185,10 +185,9 @@ if [ "$POLL_INTERVAL" -gt "$MAX_WAIT" ]; then
 fi
 echo "INFO: Poll interval: ${POLL_INTERVAL}s, Max wait (total): ${MAX_WAIT}s"
 
-# Derive plain bot login (without [bot] suffix) for matching PR-comment responses.
-# Codex posts "clean" results as regular PR comments from the non-[bot] account
-# (e.g. "chatgpt-codex-connector"), while findings are posted as GitHub Reviews
-# from the [bot]-suffixed account (e.g. "chatgpt-codex-connector[bot]").
+# Derive plain bot login (without [bot] suffix) for matching PR-comment
+# acknowledgements from the non-[bot] account (e.g. "chatgpt-codex-connector").
+# Findings are posted as GitHub Reviews from the [bot]-suffixed account.
 BOT_LOGIN_PLAIN="${BOT_LOGIN%\[bot\]}"
 echo "INFO: Bot login (plain, for PR-comment matching): $BOT_LOGIN_PLAIN"
 
@@ -418,13 +417,17 @@ while true; do
   # contains jq-special characters (e.g., double quote, backslash).
   POLL_STDERR=$(mktemp)
   POLL_TMPFILE=$(mktemp)
+  BOT_RESPONSE_SOURCE=""
   if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
     2>"$POLL_STDERR" \
     | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
         '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
     > "$POLL_TMPFILE"; then
-    # Truncate after successful API call — no SIGPIPE risk here
-    BOT_RESPONSE=$(head -c 10000 "$POLL_TMPFILE")
+	    # Truncate after successful API call — no SIGPIPE risk here
+	    BOT_RESPONSE=$(head -c 10000 "$POLL_TMPFILE")
+	    if [ -n "$BOT_RESPONSE" ]; then
+	      BOT_RESPONSE_SOURCE="comment"
+	    fi
     rm -f "$POLL_STDERR" "$POLL_TMPFILE"
     CONSECUTIVE_API_FAILURES=0
   else
@@ -452,6 +455,7 @@ while true; do
     REVIEW_BODY=$(head -c 5000 "$REVIEW_TMPFILE")
     if [ -n "$REVIEW_BODY" ]; then
       BOT_RESPONSE="$REVIEW_BODY"
+      BOT_RESPONSE_SOURCE="review"
       echo "INFO: bot response detected via PR reviews endpoint"
     fi
   fi
@@ -492,8 +496,8 @@ while true; do
     # 2. Explicit approval signals present → APPROVED (exit 0)   [checked second]
     #    Approval signals: "approved", "lgtm", "looks good",
     #    "didn't find any major issues", or "no blocking issues" from a
-    #    current-head comment or submitted review. A Codex thumbs-up reaction on
-    #    the trigger comment is not SHA-pinned and is unavailable, not clean.
+    #    submitted review pinned to the current head. A Codex root PR comment or
+    #    thumbs-up reaction is not SHA-pinned and is unavailable, not clean.
     #
     # 3. Neither found (unrecognized response format) → NEEDS_REVISION (exit 1)
     #    Safe-fail: default to NEEDS_REVISION when the format is unrecognized to
@@ -514,20 +518,23 @@ while true; do
       SEEN_ENVIRONMENT_RESPONSE="$BOT_RESPONSE"
       echo "INFO: Codex environment setup response detected; waiting for fresh current-head review evidence"
       continue
-    elif echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+    elif [ "$BOT_RESPONSE_SOURCE" = "review" ] && echo "$BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
       echo "VERDICT: NEEDS_REVISION"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 1
-    elif echo "$BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
+    elif [ "$BOT_RESPONSE_SOURCE" = "review" ] && echo "$BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
       echo "VERDICT: APPROVED"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 0
     elif echo "$BOT_RESPONSE" | grep -qi "If Codex has suggestions, it will comment; otherwise it will react with"; then
-      echo "INFO: Codex acknowledgement detected; waiting for current-head review, clean comment, or inline review comments"
+      echo "INFO: Codex acknowledgement detected; waiting for current-head review or inline review comments"
+      continue
+    elif [ "$BOT_RESPONSE_SOURCE" = "comment" ]; then
+      echo "INFO: Codex root comment is not SHA-pinned terminal evidence; waiting for current-head review or inline comments"
       continue
     else
       echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
@@ -613,6 +620,7 @@ sleep "$POLL_INTERVAL"
 
 # Single grace poll: check both PR comments and PR reviews
 ASYNC_BOT_RESPONSE=""
+ASYNC_BOT_RESPONSE_SOURCE=""
 
 if ! ASYNC_INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME"); then
   echo "VERDICT: TIMED_OUT — failed to fetch Codex inline review comments during async grace period (treated as unavailable)"
@@ -641,8 +649,11 @@ if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>/dev/null \
   | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
       '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
-  > "$ASYNC_POLL_TMPFILE" 2>/dev/null; then
-  ASYNC_BOT_RESPONSE=$(head -c 10000 "$ASYNC_POLL_TMPFILE")
+	  > "$ASYNC_POLL_TMPFILE" 2>/dev/null; then
+	  ASYNC_BOT_RESPONSE=$(head -c 10000 "$ASYNC_POLL_TMPFILE")
+	  if [ -n "$ASYNC_BOT_RESPONSE" ]; then
+	    ASYNC_BOT_RESPONSE_SOURCE="comment"
+	  fi
 fi
 rm -f "$ASYNC_POLL_TMPFILE"
 
@@ -653,10 +664,11 @@ if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
       '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
   > "$ASYNC_REVIEW_TMPFILE" 2>/dev/null; then
   ASYNC_REVIEW_BODY=$(head -c 5000 "$ASYNC_REVIEW_TMPFILE")
-  if [ -n "$ASYNC_REVIEW_BODY" ]; then
-    ASYNC_BOT_RESPONSE="$ASYNC_REVIEW_BODY"
-    echo "INFO: async-arrival bot response detected via PR reviews endpoint"
-  fi
+	  if [ -n "$ASYNC_REVIEW_BODY" ]; then
+	    ASYNC_BOT_RESPONSE="$ASYNC_REVIEW_BODY"
+	    ASYNC_BOT_RESPONSE_SOURCE="review"
+	    echo "INFO: async-arrival bot response detected via PR reviews endpoint"
+	  fi
 fi
 rm -f "$ASYNC_REVIEW_TMPFILE"
 
@@ -671,20 +683,20 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     SEEN_ENVIRONMENT_ERROR=1
     SEEN_ENVIRONMENT_RESPONSE="$ASYNC_BOT_RESPONSE"
     echo "INFO: async-arrival Codex environment setup response detected without fresh review evidence"
-  elif echo "$ASYNC_BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+  elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && echo "$ASYNC_BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
     echo "VERDICT: NEEDS_REVISION"
     echo "---BEGIN BOT RESPONSE---"
     echo "$ASYNC_BOT_RESPONSE"
     echo "---END BOT RESPONSE---"
     exit 1
-  elif echo "$ASYNC_BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
+  elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && echo "$ASYNC_BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
     echo "VERDICT: APPROVED"
     echo "---BEGIN BOT RESPONSE---"
     echo "$ASYNC_BOT_RESPONSE"
     echo "---END BOT RESPONSE---"
     exit 0
   elif echo "$ASYNC_BOT_RESPONSE" | grep -qi "If Codex has suggestions, it will comment; otherwise it will react with"; then
-    echo "INFO: async-arrival Codex acknowledgement detected without current-head review, clean comment, or inline comments"
+    echo "INFO: async-arrival Codex acknowledgement detected without current-head review or inline comments"
     echo "INFO: waiting ${POLL_INTERVAL}s for final Codex async signal..."
     sleep "$POLL_INTERVAL"
     if ! ASYNC_INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME"); then
@@ -696,16 +708,20 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
       echo "VERDICT: NEEDS_REVISION"
       echo "INFO: detected $ASYNC_INLINE_REVIEW_COMMENT_COUNT Codex inline review comment(s) after async acknowledgement"
       exit 1
-    fi
-    ASYNC_FINAL_BOT_RESPONSE=""
-    ASYNC_FINAL_POLL_TMPFILE=$(mktemp)
+	    fi
+	    ASYNC_FINAL_BOT_RESPONSE=""
+	    ASYNC_FINAL_BOT_RESPONSE_SOURCE=""
+	    ASYNC_FINAL_POLL_TMPFILE=$(mktemp)
     if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
       2>/dev/null \
       | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
           '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
-      > "$ASYNC_FINAL_POLL_TMPFILE" 2>/dev/null; then
-      ASYNC_FINAL_BOT_RESPONSE=$(head -c 10000 "$ASYNC_FINAL_POLL_TMPFILE")
-    fi
+	      > "$ASYNC_FINAL_POLL_TMPFILE" 2>/dev/null; then
+	      ASYNC_FINAL_BOT_RESPONSE=$(head -c 10000 "$ASYNC_FINAL_POLL_TMPFILE")
+	      if [ -n "$ASYNC_FINAL_BOT_RESPONSE" ]; then
+	        ASYNC_FINAL_BOT_RESPONSE_SOURCE="comment"
+	      fi
+	    fi
     rm -f "$ASYNC_FINAL_POLL_TMPFILE"
 
     ASYNC_FINAL_REVIEW_TMPFILE=$(mktemp)
@@ -715,10 +731,11 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
           '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
       > "$ASYNC_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
       ASYNC_FINAL_REVIEW_BODY=$(head -c 5000 "$ASYNC_FINAL_REVIEW_TMPFILE")
-      if [ -n "$ASYNC_FINAL_REVIEW_BODY" ]; then
-        ASYNC_FINAL_BOT_RESPONSE="$ASYNC_FINAL_REVIEW_BODY"
-        echo "INFO: final async bot response detected via PR reviews endpoint"
-      fi
+	      if [ -n "$ASYNC_FINAL_REVIEW_BODY" ]; then
+	        ASYNC_FINAL_BOT_RESPONSE="$ASYNC_FINAL_REVIEW_BODY"
+	        ASYNC_FINAL_BOT_RESPONSE_SOURCE="review"
+	        echo "INFO: final async bot response detected via PR reviews endpoint"
+	      fi
     fi
     rm -f "$ASYNC_FINAL_REVIEW_TMPFILE"
 
@@ -731,18 +748,20 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
         SEEN_ENVIRONMENT_ERROR=1
         SEEN_ENVIRONMENT_RESPONSE="$ASYNC_FINAL_BOT_RESPONSE"
         echo "INFO: final async Codex environment setup response detected without fresh review evidence"
-      elif echo "$ASYNC_FINAL_BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+      elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && echo "$ASYNC_FINAL_BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
         echo "VERDICT: NEEDS_REVISION"
         echo "---BEGIN BOT RESPONSE---"
         echo "$ASYNC_FINAL_BOT_RESPONSE"
         echo "---END BOT RESPONSE---"
         exit 1
-      elif echo "$ASYNC_FINAL_BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
+      elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && echo "$ASYNC_FINAL_BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
         echo "VERDICT: APPROVED"
         echo "---BEGIN BOT RESPONSE---"
         echo "$ASYNC_FINAL_BOT_RESPONSE"
         echo "---END BOT RESPONSE---"
         exit 0
+      elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "comment" ]; then
+        echo "INFO: final async Codex root comment is not SHA-pinned terminal evidence"
       elif ! echo "$ASYNC_FINAL_BOT_RESPONSE" | grep -qi "If Codex has suggestions, it will comment; otherwise it will react with"; then
         echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
         echo "---BEGIN BOT RESPONSE---"
@@ -766,6 +785,8 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
       echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID after async acknowledgement"
       codex_return_reaction_without_review
     fi
+  elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "comment" ]; then
+    echo "INFO: async-arrival Codex root comment is not SHA-pinned terminal evidence"
   else
     echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
     echo "---BEGIN BOT RESPONSE---"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -354,9 +354,9 @@ if [ -z "$TRIGGER_TIME" ]; then
   echo "INFO: posting trigger comment to PR #$PR_NUMBER..."
   # Use gh api --method POST to capture the GitHub-server-assigned created_at
   # timestamp. Using 'date -u' here would risk clock skew between the local
-  # machine and GitHub's API server. Poll filters use >= because GitHub
-  # timestamps are second-resolution and bot responses can share the trigger
-  # second.
+  # machine and GitHub's API server. SHA-pinned review filters use >= because
+  # GitHub timestamps are second-resolution and bot responses can share the
+  # trigger second.
   # Guard with 'if !' to emit TIMED_OUT (exit 2) on failure instead of letting
   # set -e exit with code 1 (NEEDS_REVISION) without a VERDICT line.
   if ! TRIGGER_RESPONSE=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
@@ -422,7 +422,7 @@ while true; do
   if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
     2>"$POLL_STDERR" \
     | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at >= $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
+        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
     > "$POLL_TMPFILE"; then
 	    # Truncate after successful API call — no SIGPIPE risk here
 	    BOT_RESPONSE=$(head -c 10000 "$POLL_TMPFILE")
@@ -656,7 +656,7 @@ ASYNC_POLL_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>/dev/null \
   | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-      '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at >= $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
+      '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
 	  > "$ASYNC_POLL_TMPFILE" 2>/dev/null; then
 	  ASYNC_BOT_RESPONSE=$(head -c 10000 "$ASYNC_POLL_TMPFILE")
 	  if [ -n "$ASYNC_BOT_RESPONSE" ]; then
@@ -727,7 +727,7 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
       2>/dev/null \
       | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-          '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at >= $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
+          '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
 	      > "$ASYNC_FINAL_POLL_TMPFILE" 2>/dev/null; then
 	      ASYNC_FINAL_BOT_RESPONSE=$(head -c 10000 "$ASYNC_FINAL_POLL_TMPFILE")
 	      if [ -n "$ASYNC_FINAL_BOT_RESPONSE" ]; then

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -387,14 +387,29 @@ codex_strip_quoted_spans() {
   sed -E 's/"[^"]*"//g; s/`[^`]*`//g' <<< "$body"
 }
 
+# Strips the "not only X" idiom — used ONLY by codex_response_is_approved
+# below. "Not only X, (but) Y" is an AFFIRMATIVE intensifier construction
+# (BOTH X and Y are being asserted, not negated: "Not only does this look
+# good, it is approved" means both "looks good" and "is approved" hold),
+# not a negation of X, so CODEX_NEGATION_WORDS' bare "not" alternative —
+# which has no way to distinguish this idiom from a genuine negation —
+# misclassified it as negated (fresh evidence from PR #1490 finding
+# 3793299512). Stripped entirely (not just skipped) so the leftover "not"
+# cannot accidentally trigger a match against some OTHER target word
+# later in the same clause.
+codex_strip_not_only_idiom() {
+  local body="$1"
+  sed -E 's/[Nn]ot[[:space:]]+[Oo]nly//g' <<< "$body"
+}
+
 codex_response_is_approved() {
   local body="$1"
-  local unquoted_body
-  unquoted_body=$(codex_strip_quoted_spans "$body")
-  if grep -qiE "$CODEX_NEGATED_APPROVAL_PATTERN" <<< "$unquoted_body"; then
+  local normalized_body
+  normalized_body=$(codex_strip_not_only_idiom "$(codex_strip_quoted_spans "$body")")
+  if grep -qiE "$CODEX_NEGATED_APPROVAL_PATTERN" <<< "$normalized_body"; then
     return 1
   fi
-  grep -qiE "$CODEX_APPROVAL_PATTERN" <<< "$unquoted_body"
+  grep -qiE "$CODEX_APPROVAL_PATTERN" <<< "$normalized_body"
 }
 
 # Ranks a response into one of four priority tiers, highest wins on a

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -446,20 +446,27 @@ while true; do
   # Also check PR reviews — Codex posts findings as a GitHub Review object
   # (via pulls/{PR}/reviews), not as a plain PR comment. Combining both sources
   # ensures we detect findings immediately instead of waiting for a timeout.
+  REVIEW_STDERR=$(mktemp)
   REVIEW_TMPFILE=$(mktemp)
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
-    2>/dev/null \
+    2>"$REVIEW_STDERR" \
     | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
         '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
-    > "$REVIEW_TMPFILE" 2>/dev/null; then
+    > "$REVIEW_TMPFILE" 2>"$REVIEW_STDERR"; then
     REVIEW_BODY=$(head -c 5000 "$REVIEW_TMPFILE")
     if [ -n "$REVIEW_BODY" ]; then
       BOT_RESPONSE="$REVIEW_BODY"
       BOT_RESPONSE_SOURCE="review"
       echo "INFO: bot response detected via PR reviews endpoint"
     fi
+  else
+    REVIEW_ERR=$(cat "$REVIEW_STDERR")
+    rm -f "$REVIEW_STDERR" "$REVIEW_TMPFILE"
+    echo "WARNING: failed to fetch or parse Codex PR reviews: $REVIEW_ERR" >&2
+    echo "VERDICT: TIMED_OUT — failed to fetch Codex PR reviews (treated as unavailable)"
+    exit 2
   fi
-  rm -f "$REVIEW_TMPFILE"
+  rm -f "$REVIEW_STDERR" "$REVIEW_TMPFILE"
 
   if ! INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME"); then
     echo "VERDICT: TIMED_OUT — failed to fetch Codex inline review comments (treated as unavailable)"
@@ -667,8 +674,12 @@ if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
 	  if [ -n "$ASYNC_REVIEW_BODY" ]; then
 	    ASYNC_BOT_RESPONSE="$ASYNC_REVIEW_BODY"
 	    ASYNC_BOT_RESPONSE_SOURCE="review"
-	    echo "INFO: async-arrival bot response detected via PR reviews endpoint"
-	  fi
+    echo "INFO: async-arrival bot response detected via PR reviews endpoint"
+  fi
+else
+  rm -f "$ASYNC_REVIEW_TMPFILE"
+  echo "VERDICT: TIMED_OUT — failed to fetch Codex PR reviews during async grace period (treated as unavailable)"
+  exit 2
 fi
 rm -f "$ASYNC_REVIEW_TMPFILE"
 
@@ -734,8 +745,12 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
 	      if [ -n "$ASYNC_FINAL_REVIEW_BODY" ]; then
 	        ASYNC_FINAL_BOT_RESPONSE="$ASYNC_FINAL_REVIEW_BODY"
 	        ASYNC_FINAL_BOT_RESPONSE_SOURCE="review"
-	        echo "INFO: final async bot response detected via PR reviews endpoint"
-	      fi
+        echo "INFO: final async bot response detected via PR reviews endpoint"
+      fi
+    else
+      rm -f "$ASYNC_FINAL_REVIEW_TMPFILE"
+      echo "VERDICT: TIMED_OUT — failed to fetch Codex PR reviews after async acknowledgement (treated as unavailable)"
+      exit 2
     fi
     rm -f "$ASYNC_FINAL_REVIEW_TMPFILE"
 

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -836,6 +836,87 @@ fi
 
 if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
   echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID during async grace period"
+  echo "INFO: waiting ${POLL_INTERVAL}s for final Codex review evidence after async reaction..."
+  sleep "$POLL_INTERVAL"
+  if ! ASYNC_INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME"); then
+    echo "VERDICT: TIMED_OUT — failed to fetch Codex inline review comments after async reaction (treated as unavailable)"
+    exit 2
+  fi
+  if [ "$ASYNC_INLINE_REVIEW_COMMENT_COUNT" -gt 0 ]; then
+    codex_require_current_head
+    echo "VERDICT: NEEDS_REVISION"
+    echo "INFO: detected $ASYNC_INLINE_REVIEW_COMMENT_COUNT Codex inline review comment(s) after async reaction"
+    exit 1
+  fi
+
+  ASYNC_REACTION_FINAL_BOT_RESPONSE=""
+  ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE=""
+  ASYNC_REACTION_FINAL_POLL_TMPFILE=$(mktemp)
+  if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
+    2>/dev/null \
+    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
+        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | .body // empty' \
+    > "$ASYNC_REACTION_FINAL_POLL_TMPFILE" 2>/dev/null; then
+    ASYNC_REACTION_FINAL_BOT_RESPONSE=$(head -c 10000 "$ASYNC_REACTION_FINAL_POLL_TMPFILE")
+    if [ -n "$ASYNC_REACTION_FINAL_BOT_RESPONSE" ]; then
+      ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE="comment"
+      if codex_response_reviews_current_head "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
+        ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE="review"
+        echo "INFO: final async reaction bot response detected via SHA-pinned PR comment"
+      fi
+    fi
+  fi
+  rm -f "$ASYNC_REACTION_FINAL_POLL_TMPFILE"
+
+  ASYNC_REACTION_FINAL_REVIEW_TMPFILE=$(mktemp)
+  if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+    2>/dev/null \
+    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
+    > "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
+    ASYNC_REACTION_FINAL_REVIEW_BODY=$(head -c 5000 "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE")
+    if [ -n "$ASYNC_REACTION_FINAL_REVIEW_BODY" ]; then
+      ASYNC_REACTION_FINAL_BOT_RESPONSE="$ASYNC_REACTION_FINAL_REVIEW_BODY"
+      ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE="review"
+      echo "INFO: final async reaction bot response detected via PR reviews endpoint"
+    fi
+  else
+    rm -f "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE"
+    echo "VERDICT: TIMED_OUT — failed to fetch Codex PR reviews after async reaction (treated as unavailable)"
+    exit 2
+  fi
+  rm -f "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE"
+
+  if [ -n "$ASYNC_REACTION_FINAL_BOT_RESPONSE" ]; then
+    codex_require_current_head
+    if codex_response_is_usage_limit "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
+      codex_return_usage_limit "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
+    elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
+      SEEN_ENVIRONMENT_ERROR=1
+      SEEN_ENVIRONMENT_RESPONSE="$ASYNC_REACTION_FINAL_BOT_RESPONSE"
+      echo "INFO: final async reaction Codex environment setup response detected without fresh review evidence"
+    elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+      echo "VERDICT: NEEDS_REVISION"
+      echo "---BEGIN BOT RESPONSE---"
+      echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
+      echo "---END BOT RESPONSE---"
+      exit 1
+    elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
+      echo "VERDICT: APPROVED"
+      echo "---BEGIN BOT RESPONSE---"
+      echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
+      echo "---END BOT RESPONSE---"
+      exit 0
+    elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "comment" ]; then
+      echo "INFO: final async reaction Codex root comment is not SHA-pinned terminal evidence"
+    elif ! echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE" | grep -qi "If Codex has suggestions, it will comment; otherwise it will react with"; then
+      echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
+      echo "---BEGIN BOT RESPONSE---"
+      echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
+      echo "---END BOT RESPONSE---"
+      exit 1
+    fi
+  fi
   codex_return_reaction_without_review
 fi
 

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -241,6 +241,13 @@ codex_response_is_environment_error() {
   printf '%s\n' "$response" | grep -qiE "to[[:space:]]+use[[:space:]]+codex[[:space:]]+here,[[:space:]]+create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo"
 }
 
+codex_response_reviews_current_head() {
+  local response="$1"
+  local reviewed_sha
+  reviewed_sha=$(printf '%s\n' "$response" | sed -n 's/.*Reviewed commit:[^`]*`\([0-9a-fA-F]\{7,40\}\)`.*/\1/p' | tail -n 1)
+  [ -n "$reviewed_sha" ] && printf '%s\n' "$CURRENT_SHA" | grep -qi "^$reviewed_sha"
+}
+
 codex_return_usage_limit() {
   echo "VERDICT: UNAVAILABLE — Codex GitHub review usage limit reached"
   echo "REASON=codex-github-usage-limit"
@@ -429,6 +436,10 @@ while true; do
 	    BOT_RESPONSE=$(head -c 10000 "$POLL_TMPFILE")
 	    if [ -n "$BOT_RESPONSE" ]; then
 	      BOT_RESPONSE_SOURCE="comment"
+	      if codex_response_reviews_current_head "$BOT_RESPONSE"; then
+	        BOT_RESPONSE_SOURCE="review"
+	        echo "INFO: bot response detected via SHA-pinned PR comment"
+	      fi
 	    fi
     rm -f "$POLL_STDERR" "$POLL_TMPFILE"
     CONSECUTIVE_API_FAILURES=0
@@ -664,6 +675,10 @@ if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
 	  ASYNC_BOT_RESPONSE=$(head -c 10000 "$ASYNC_POLL_TMPFILE")
 	  if [ -n "$ASYNC_BOT_RESPONSE" ]; then
 	    ASYNC_BOT_RESPONSE_SOURCE="comment"
+	    if codex_response_reviews_current_head "$ASYNC_BOT_RESPONSE"; then
+	      ASYNC_BOT_RESPONSE_SOURCE="review"
+	      echo "INFO: async-arrival bot response detected via SHA-pinned PR comment"
+	    fi
 	  fi
 fi
 rm -f "$ASYNC_POLL_TMPFILE"
@@ -735,6 +750,10 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
 	      ASYNC_FINAL_BOT_RESPONSE=$(head -c 10000 "$ASYNC_FINAL_POLL_TMPFILE")
 	      if [ -n "$ASYNC_FINAL_BOT_RESPONSE" ]; then
 	        ASYNC_FINAL_BOT_RESPONSE_SOURCE="comment"
+	        if codex_response_reviews_current_head "$ASYNC_FINAL_BOT_RESPONSE"; then
+	          ASYNC_FINAL_BOT_RESPONSE_SOURCE="review"
+	          echo "INFO: final async bot response detected via SHA-pinned PR comment"
+	        fi
 	      fi
 	    fi
     rm -f "$ASYNC_FINAL_POLL_TMPFILE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -488,7 +488,18 @@ codex_scan_comment_evidence() {
   # combine path, not this separate ancillary-override check).
   COMMENT_LATEST_IS_TERMINAL=0
   local comment_latest_is_actionable=0
-  local line created_at body is_actionable is_terminal
+  # Tracks whether the CURRENTLY tracked ancillary comment is specifically
+  # a usage-limit notice (as opposed to a merely-actionable environment-
+  # error). Once a usage-limit notice is tracked, only ANOTHER usage-limit
+  # notice may replace it — a later environment-setup error in the same
+  # fetch must never silently discard it, since codex_combine_terminal_
+  # evidence's immediate-termination handling for usage-limit only
+  # protects it there, after this scan has already produced its single
+  # COMMENT_LATEST_BODY; discarding it here means that downstream
+  # protection never gets a chance to apply (fresh evidence from PR #1490
+  # finding 3790092216, a followup to 3790062091/3789928786/3789992794).
+  local comment_latest_is_usage_limit=0
+  local line created_at body is_actionable is_terminal is_usage_limit should_update
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     created_at=$(printf '%s' "$line" | jq -r '.created_at // empty')  # workflow-shell-guard: allow SH003 - $line is a compact JSON object already validated parseable by the preceding jq -sc call; empty is a normal absent-field case, not a failure
@@ -496,16 +507,27 @@ codex_scan_comment_evidence() {
     is_terminal=0
     codex_response_reviews_current_head "$body" && is_terminal=1
     is_actionable=0
+    is_usage_limit=0
     if [ "$is_terminal" -eq 0 ]; then
-      if codex_response_is_environment_error "$body" || codex_response_is_usage_limit "$body"; then
+      codex_response_is_usage_limit "$body" && is_usage_limit=1
+      if [ "$is_usage_limit" -eq 1 ] || codex_response_is_environment_error "$body"; then
         is_actionable=1
       fi
     fi
-    if [ "$comment_latest_is_actionable" -eq 0 ] || [ "$is_actionable" -eq 1 ]; then
+    should_update=0
+    if [ "$comment_latest_is_actionable" -eq 0 ]; then
+      should_update=1
+    elif [ "$comment_latest_is_usage_limit" -eq 1 ]; then
+      [ "$is_usage_limit" -eq 1 ] && should_update=1
+    elif [ "$is_actionable" -eq 1 ]; then
+      should_update=1
+    fi
+    if [ "$should_update" -eq 1 ]; then
       COMMENT_LATEST_BODY="$body"
       COMMENT_LATEST_TIME="$created_at"
       COMMENT_LATEST_IS_TERMINAL="$is_terminal"
       comment_latest_is_actionable="$is_actionable"
+      comment_latest_is_usage_limit="$is_usage_limit"
     fi
     if [ "$is_terminal" -eq 1 ]; then
       # Apply the same not-a-clean-approval-first tie-break used for

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -753,6 +753,13 @@ while true; do
     "$REVIEW_BODY" "$REVIEW_TIME"
   BOT_RESPONSE="$COMBINED_BODY"
   BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
+  # Captured immediately after combine, before any intervening call could
+  # touch COMBINED_TIME, so presence can be checked below without relying
+  # on BOT_RESPONSE's body being non-empty (fresh evidence from PR #1490
+  # finding 3788164224: a bodyless-but-selected review must still enter
+  # verdict parsing and hit the unrecognized-format safe-fail instead of
+  # being treated as "no response at all").
+  BOT_RESPONSE_TIME="$COMBINED_TIME"
   # Truncate here (post-combine) — mirrors the prior per-source truncation but
   # applies uniformly regardless of which source won. Root-comment-sourced
   # bodies are not truncated at scan time (unlike review bodies, which are
@@ -779,7 +786,7 @@ while true; do
     echo "VERDICT: TIMED_OUT — failed to fetch Codex trigger reactions (treated as unavailable)"
     exit 2
   fi
-  if [ -n "$BOT_RESPONSE" ]; then
+  if [ -n "$BOT_RESPONSE_TIME" ]; then
     echo "INFO: bot response detected"
     codex_require_current_head
 
@@ -1002,12 +1009,15 @@ codex_combine_terminal_evidence "async-arrival bot response" \
   "$ASYNC_REVIEW_BODY" "$ASYNC_REVIEW_TIME"
 ASYNC_BOT_RESPONSE="$COMBINED_BODY"
 ASYNC_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
+# Captured before any intervening call could touch COMBINED_TIME (see
+# rationale above the main-loop equivalent).
+ASYNC_BOT_RESPONSE_TIME="$COMBINED_TIME"
 # `jq -Rs` slurps its entire stdin before producing output, avoiding
 # SIGPIPE on long root-comment-sourced bodies (see rationale above the
 # main-loop equivalent).
 ASYNC_BOT_RESPONSE=$(printf '%s' "$ASYNC_BOT_RESPONSE" | jq -Rrs '.[0:10000]')  # workflow-shell-guard: allow SH003 - jq -R treats input as raw text (not JSON), so it cannot fail on malformed content; a genuine jq internal failure still trips `set -e` since this is a bare assignment, which is the desired fail-closed behavior
 
-if [ -n "$ASYNC_BOT_RESPONSE" ]; then
+if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
   echo "INFO: async-arrival bot response detected during grace period"
   codex_require_current_head
 
@@ -1094,12 +1104,15 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
       "$ASYNC_FINAL_REVIEW_BODY" "$ASYNC_FINAL_REVIEW_TIME"
     ASYNC_FINAL_BOT_RESPONSE="$COMBINED_BODY"
     ASYNC_FINAL_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
+    # Captured before any intervening call could touch COMBINED_TIME (see
+    # rationale above the main-loop equivalent).
+    ASYNC_FINAL_BOT_RESPONSE_TIME="$COMBINED_TIME"
     # `jq -Rs` slurps its entire stdin before producing output, avoiding
     # SIGPIPE on long root-comment-sourced bodies (see rationale above the
     # main-loop equivalent).
     ASYNC_FINAL_BOT_RESPONSE=$(printf '%s' "$ASYNC_FINAL_BOT_RESPONSE" | jq -Rrs '.[0:10000]')  # workflow-shell-guard: allow SH003 - jq -R treats input as raw text (not JSON), so it cannot fail on malformed content; a genuine jq internal failure still trips `set -e` since this is a bare assignment, which is the desired fail-closed behavior
 
-    if [ -n "$ASYNC_FINAL_BOT_RESPONSE" ]; then
+    if [ -n "$ASYNC_FINAL_BOT_RESPONSE_TIME" ]; then
       echo "INFO: final async bot response detected after acknowledgement wait"
       codex_require_current_head
       # Blocking is checked first, ahead of usage-limit (see rationale
@@ -1224,12 +1237,15 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
     "$ASYNC_REACTION_FINAL_REVIEW_BODY" "$ASYNC_REACTION_FINAL_REVIEW_TIME"
   ASYNC_REACTION_FINAL_BOT_RESPONSE="$COMBINED_BODY"
   ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
+  # Captured before any intervening call could touch COMBINED_TIME (see
+  # rationale above the main-loop equivalent).
+  ASYNC_REACTION_FINAL_BOT_RESPONSE_TIME="$COMBINED_TIME"
   # `jq -Rs` slurps its entire stdin before producing output, avoiding
   # SIGPIPE on long root-comment-sourced bodies (see rationale above the
   # main-loop equivalent).
   ASYNC_REACTION_FINAL_BOT_RESPONSE=$(printf '%s' "$ASYNC_REACTION_FINAL_BOT_RESPONSE" | jq -Rrs '.[0:10000]')  # workflow-shell-guard: allow SH003 - jq -R treats input as raw text (not JSON), so it cannot fail on malformed content; a genuine jq internal failure still trips `set -e` since this is a bare assignment, which is the desired fail-closed behavior
 
-  if [ -n "$ASYNC_REACTION_FINAL_BOT_RESPONSE" ]; then
+  if [ -n "$ASYNC_REACTION_FINAL_BOT_RESPONSE_TIME" ]; then
     codex_require_current_head
     # Blocking is checked first, ahead of usage-limit (see rationale above
     # the main-loop equivalent).

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -668,6 +668,9 @@ while true; do
       echo "---END BOT RESPONSE---"
       exit 1
     elif [ "$BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$BOT_RESPONSE"; then
+      if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ]; then
+        codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
+      fi
       echo "VERDICT: APPROVED"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
@@ -847,6 +850,9 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     echo "---END BOT RESPONSE---"
     exit 1
   elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_BOT_RESPONSE"; then
+    if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ]; then
+      codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
+    fi
     echo "VERDICT: APPROVED"
     echo "---BEGIN BOT RESPONSE---"
     echo "$ASYNC_BOT_RESPONSE"
@@ -923,6 +929,9 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
         echo "---END BOT RESPONSE---"
         exit 1
       elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_FINAL_BOT_RESPONSE"; then
+        if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ]; then
+          codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
+        fi
         echo "VERDICT: APPROVED"
         echo "---BEGIN BOT RESPONSE---"
         echo "$ASYNC_FINAL_BOT_RESPONSE"
@@ -1038,6 +1047,9 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
       echo "---END BOT RESPONSE---"
       exit 1
     elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
+      if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ]; then
+        codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
+      fi
       echo "VERDICT: APPROVED"
       echo "---BEGIN BOT RESPONSE---"
       echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -293,8 +293,18 @@ CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t 
 # raw text has "**" directly between "not" and the following space, which
 # broke the plain [[:space:]]+ adjacency this pattern originally required;
 # fresh evidence from PR #1490 finding 3789878264, a followup to
-# 3789851555/3789722818).
-CODEX_NEGATED_APPROVAL_PATTERN='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)[*_~]{0,3}[[:space:]]+(be[[:space:]]+)?[*_~]{0,3}(approved|lgtm|look(s|ing)?[[:space:]]+good)'
+# 3789851555/3789722818). The optional ([[:space:]]+[*_~]{0,3}[[:alpha:]'-]{1,20}[*_~]{0,3}){0,3}
+# group tolerates up to 3 intervening qualifier words between the
+# negation and the approval word (e.g. "not YET approved", "not FULLY
+# approved YET"), since a rigid negation-immediately-adjacent-to-approval
+# requirement is a losing enumeration game against arbitrary English
+# phrasing — every prior round of this fix (space-separated, concatenated
+# prefix, Markdown-wrapped) narrowed one specific adjacency assumption and
+# Codex found the next one; allowing a bounded window of filler words
+# generalizes past this specific class of gap instead of special-casing
+# it again (fresh evidence from PR #1490 finding 3789904716, a followup to
+# 3789878264/3789851555/3789722818).
+CODEX_NEGATED_APPROVAL_PATTERN='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)[*_~]{0,3}([[:space:]]+[*_~]{0,3}[[:alpha:]'"'"'-]{1,20}[*_~]{0,3}){0,3}[[:space:]]+[*_~]{0,3}(be[[:space:]]+)?[*_~]{0,3}(approved|lgtm|look(s|ing)?[[:space:]]+good)'
 
 codex_response_is_blocking() {
   local body="$1"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -355,36 +355,49 @@ CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t 
 # joined clause (e.g. "Tests are not required, but looks good") crossed
 # the semicolon-only exclusion the same way the semicolon-crossing case
 # crossed the original unbounded span (fresh evidence from PR #1490
-# finding 3793219193, a followup to 3790122061/3790062089).
+# finding 3793219193, a followup to 3790122061/3790062089). "unable to"
+# is also included: it wasn't in the negation-word list at all, so "I am
+# unable to approve this change" wasn't recognized as a rejection while
+# an earlier "looks good" in the same sentence still matched (fresh
+# evidence from PR #1490 finding 3793367883, the same class of gap as
+# "cannot approve" fixed for finding 3790023141, just a different
+# inability phrase).
 CODEX_NEGATED_APPROVAL_TARGET_WORDS='(approve[ds]?|lgtm|look(s|ing)?[[:space:]]+good|no[[:space:]]+blocking[[:space:]]+issues?|didn.t find[[:space:]]+any major[[:space:]]+issues)'
-CODEX_NEGATION_WORDS='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)'
+CODEX_NEGATION_WORDS='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never|unable[[:space:]]+to)'
 CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*${CODEX_NEGATED_APPROVAL_TARGET_WORDS}"
-
-codex_response_is_blocking() {
-  local body="$1"
-  grep -qiE "$CODEX_BLOCKING_PATTERN" <<< "$body"
-}
 
 # Strips quoted spans — text between a pair of straight double-quotes
 # ("...") AND text between a pair of backticks (`...`, Markdown inline
-# code) — used ONLY by codex_response_is_approved below, never applied to
-# the body before codex_response_reviews_current_head's SHA extraction
-# (which itself relies on backtick-delimited `Reviewed commit:` markers
-# and must see the original, unstripped body). A SHA-pinned review can
-# QUOTE a clean phrase, in either quoting style, while REJECTING it (e.g.
-# `The documented bot response "No blocking issues found" is inaccurate`
-# or the Markdown-code equivalent using backticks), and both
-# CODEX_APPROVAL_PATTERN and CODEX_NEGATED_APPROVAL_PATTERN's substring
-# matches can't distinguish quotation/discussion of a phrase from an
-# assertion of it (fresh evidence from PR #1490 findings 3790122058 and
-# 3793219190 — straight-quote and backtick-quote versions of the same
-# gap — plus 3793219192, which found that only the POSITIVE check was
-# quote-stripped and a quoted REJECTION phrase, e.g. `No blocking issues
-# found. The tests cover "This change is not approved".`, still tripped
-# the NEGATION check on the unstripped body).
+# code) — used by codex_response_is_approved AND codex_response_is_blocking
+# below, never applied to the body before codex_response_reviews_current_
+# head's SHA extraction (which itself relies on backtick-delimited
+# `Reviewed commit:` markers and must see the original, unstripped body).
+# A SHA-pinned review can QUOTE a clean OR blocking phrase, in either
+# quoting style, while discussing (not asserting) it — e.g. `The
+# documented bot response "No blocking issues found" is inaccurate` or
+# `No blocking issues found. The tests correctly cover the "must fix"
+# marker.` — and CODEX_APPROVAL_PATTERN, CODEX_NEGATED_APPROVAL_PATTERN,
+# and CODEX_BLOCKING_PATTERN's substring matches can't distinguish
+# quotation/discussion of a phrase from an assertion of it (fresh
+# evidence from PR #1490 findings 3790122058 and 3793219190 —
+# straight-quote and backtick-quote versions of the approval gap —
+# 3793219192, which found that only the POSITIVE check was quote-stripped
+# and a quoted REJECTION phrase still tripped the NEGATION check on the
+# unstripped body — and 3793367887, which found that
+# codex_response_is_blocking wasn't quote-stripped at all, so a quoted
+# blocker token in an otherwise clean review still rejected it). Also
+# strips GitHub-flavored Markdown blockquote LINES (a line starting with
+# `>`, optionally indented): a review discussing a quoted clean phrase via
+# blockquote syntax rather than straight/backtick quotes was likewise
+# unprotected (fresh evidence from PR #1490 finding 3793367885).
 codex_strip_quoted_spans() {
   local body="$1"
-  sed -E 's/"[^"]*"//g; s/`[^`]*`//g' <<< "$body"
+  sed -E 's/"[^"]*"//g; s/`[^`]*`//g; /^[[:space:]]*>/d' <<< "$body"
+}
+
+codex_response_is_blocking() {
+  local body="$1"
+  grep -qiE "$CODEX_BLOCKING_PATTERN" <<< "$(codex_strip_quoted_spans "$body")"
 }
 
 # Strips the "not only X" idiom — used ONLY by codex_response_is_approved

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -220,7 +220,7 @@ codex_inline_review_comment_count_since() {
   review_comment_tmpfile=$(mktemp)
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments" --paginate \
     | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$trigger_time" --arg sha "$CURRENT_SHA" \
-      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .created_at > $trigger_time and ((.commit_id // "") | startswith($sha)))] | length' \
+      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .created_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | length' \
     > "$review_comment_tmpfile"; then
     cat "$review_comment_tmpfile"
   else
@@ -354,8 +354,9 @@ if [ -z "$TRIGGER_TIME" ]; then
   echo "INFO: posting trigger comment to PR #$PR_NUMBER..."
   # Use gh api --method POST to capture the GitHub-server-assigned created_at
   # timestamp. Using 'date -u' here would risk clock skew between the local
-  # machine and GitHub's API server, causing bot responses to be silently
-  # filtered out during polling (created_at > TRIGGER_TIME would be false).
+  # machine and GitHub's API server. Poll filters use >= because GitHub
+  # timestamps are second-resolution and bot responses can share the trigger
+  # second.
   # Guard with 'if !' to emit TIMED_OUT (exit 2) on failure instead of letting
   # set -e exit with code 1 (NEEDS_REVISION) without a VERDICT line.
   if ! TRIGGER_RESPONSE=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
@@ -421,7 +422,7 @@ while true; do
   if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
     2>"$POLL_STDERR" \
     | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
+        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at >= $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
     > "$POLL_TMPFILE"; then
 	    # Truncate after successful API call — no SIGPIPE risk here
 	    BOT_RESPONSE=$(head -c 10000 "$POLL_TMPFILE")
@@ -451,7 +452,7 @@ while true; do
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>"$REVIEW_STDERR" \
     | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
     > "$REVIEW_TMPFILE" 2>"$REVIEW_STDERR"; then
     REVIEW_BODY=$(head -c 5000 "$REVIEW_TMPFILE")
     if [ -n "$REVIEW_BODY" ]; then
@@ -655,7 +656,7 @@ ASYNC_POLL_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>/dev/null \
   | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-      '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
+      '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at >= $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
 	  > "$ASYNC_POLL_TMPFILE" 2>/dev/null; then
 	  ASYNC_BOT_RESPONSE=$(head -c 10000 "$ASYNC_POLL_TMPFILE")
 	  if [ -n "$ASYNC_BOT_RESPONSE" ]; then
@@ -668,7 +669,7 @@ ASYNC_REVIEW_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
   2>/dev/null \
   | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
+      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
   > "$ASYNC_REVIEW_TMPFILE" 2>/dev/null; then
   ASYNC_REVIEW_BODY=$(head -c 5000 "$ASYNC_REVIEW_TMPFILE")
 	  if [ -n "$ASYNC_REVIEW_BODY" ]; then
@@ -726,7 +727,7 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
       2>/dev/null \
       | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-          '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
+          '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at >= $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
 	      > "$ASYNC_FINAL_POLL_TMPFILE" 2>/dev/null; then
 	      ASYNC_FINAL_BOT_RESPONSE=$(head -c 10000 "$ASYNC_FINAL_POLL_TMPFILE")
 	      if [ -n "$ASYNC_FINAL_BOT_RESPONSE" ]; then
@@ -739,7 +740,7 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
       2>/dev/null \
       | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
+          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | .body // empty' \
       > "$ASYNC_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
       ASYNC_FINAL_REVIEW_BODY=$(head -c 5000 "$ASYNC_FINAL_REVIEW_TMPFILE")
 	      if [ -n "$ASYNC_FINAL_REVIEW_BODY" ]; then

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -266,18 +266,25 @@ codex_response_is_approved() {
   printf '%s\n' "$body" | grep -qiE "$CODEX_APPROVAL_PATTERN"
 }
 
-# True when a response is NOT the clean-approval path — i.e. it is either
-# explicitly blocking or an unrecognized format that the documented verdict
-# classifier safe-fails to NEEDS_REVISION (see "Verdict parsing" header
-# comment). Blocking is checked FIRST, matching the classifier's blocking-
-# first priority: a response containing both an approval phrase and a
-# blocking marker (e.g. "No blocking issues found. Must fix ...") is
-# blocking, not approved. Used by the tie-break below so neither an
-# unrecognized-format response nor a mixed blocking+approval response is
-# silently outranked by a clean approval on a timestamp tie.
+# True when a response is NOT the clean-approval path — i.e. it is
+# explicitly blocking, a usage-limit notice, or an unrecognized format
+# that the documented verdict classifier safe-fails to NEEDS_REVISION
+# (see "Verdict parsing" header comment). Blocking and usage-limit are
+# checked FIRST, matching the classifier's own priority: a response
+# containing both an approval phrase and a blocking marker (e.g. "No
+# blocking issues found. Must fix ...") is blocking, not approved, and a
+# response containing both an approval phrase and usage-limit wording
+# (e.g. "No blocking issues could be evaluated because you have reached
+# your Codex usage limits") is a usage-limit notice, not approved (fresh
+# evidence from PR #1490 finding 3789555934 — the earlier mixed-
+# blocking-and-approval fix checked only blocking, leaving the analogous
+# mixed-usage-limit-and-approval case unguarded). Used by the tie-break
+# below so neither an unrecognized-format response, a mixed
+# blocking+approval response, nor a mixed usage-limit+approval response
+# is silently outranked by a clean approval on a timestamp tie.
 codex_response_requires_attention() {
   local body="$1"
-  codex_response_is_blocking "$body" || ! codex_response_is_approved "$body"
+  codex_response_is_blocking "$body" || codex_response_is_usage_limit "$body" || ! codex_response_is_approved "$body"
 }
 
 # Decides whether CANDIDATE terminal ("review"-sourced) evidence should

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -421,7 +421,7 @@ while true; do
   if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
     2>"$POLL_STDERR" \
     | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-        '.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time) | .body' \
+        '[.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
     > "$POLL_TMPFILE"; then
     # Truncate after successful API call — no SIGPIPE risk here
     BOT_RESPONSE=$(head -c 10000 "$POLL_TMPFILE")
@@ -640,7 +640,7 @@ ASYNC_POLL_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>/dev/null \
   | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-      '.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time) | .body' \
+      '[.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
   > "$ASYNC_POLL_TMPFILE" 2>/dev/null; then
   ASYNC_BOT_RESPONSE=$(head -c 10000 "$ASYNC_POLL_TMPFILE")
 fi
@@ -696,6 +696,60 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
       echo "VERDICT: NEEDS_REVISION"
       echo "INFO: detected $ASYNC_INLINE_REVIEW_COMMENT_COUNT Codex inline review comment(s) after async acknowledgement"
       exit 1
+    fi
+    ASYNC_FINAL_BOT_RESPONSE=""
+    ASYNC_FINAL_POLL_TMPFILE=$(mktemp)
+    if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
+      2>/dev/null \
+      | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
+          '[.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
+      > "$ASYNC_FINAL_POLL_TMPFILE" 2>/dev/null; then
+      ASYNC_FINAL_BOT_RESPONSE=$(head -c 10000 "$ASYNC_FINAL_POLL_TMPFILE")
+    fi
+    rm -f "$ASYNC_FINAL_POLL_TMPFILE"
+
+    ASYNC_FINAL_REVIEW_TMPFILE=$(mktemp)
+    if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+      2>/dev/null \
+      | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
+          '.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at > $trigger_time and ((.commit_id // "") | startswith($sha))) | .body' \
+      > "$ASYNC_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
+      ASYNC_FINAL_REVIEW_BODY=$(head -c 5000 "$ASYNC_FINAL_REVIEW_TMPFILE")
+      if [ -n "$ASYNC_FINAL_REVIEW_BODY" ]; then
+        ASYNC_FINAL_BOT_RESPONSE="$ASYNC_FINAL_REVIEW_BODY"
+        echo "INFO: final async bot response detected via PR reviews endpoint"
+      fi
+    fi
+    rm -f "$ASYNC_FINAL_REVIEW_TMPFILE"
+
+    if [ -n "$ASYNC_FINAL_BOT_RESPONSE" ]; then
+      echo "INFO: final async bot response detected after acknowledgement wait"
+      codex_require_current_head
+      if codex_response_is_usage_limit "$ASYNC_FINAL_BOT_RESPONSE"; then
+        codex_return_usage_limit "$ASYNC_FINAL_BOT_RESPONSE"
+      elif codex_response_is_environment_error "$ASYNC_FINAL_BOT_RESPONSE"; then
+        SEEN_ENVIRONMENT_ERROR=1
+        SEEN_ENVIRONMENT_RESPONSE="$ASYNC_FINAL_BOT_RESPONSE"
+        echo "INFO: final async Codex environment setup response detected without fresh review evidence"
+      elif echo "$ASYNC_FINAL_BOT_RESPONSE" | grep -qiE "(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)"; then
+        echo "VERDICT: NEEDS_REVISION"
+        echo "---BEGIN BOT RESPONSE---"
+        echo "$ASYNC_FINAL_BOT_RESPONSE"
+        echo "---END BOT RESPONSE---"
+        exit 1
+      elif echo "$ASYNC_FINAL_BOT_RESPONSE" | grep -qiE "(approved|lgtm|looks[[:space:]]+good|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)"; then
+        echo "VERDICT: APPROVED"
+        echo "---BEGIN BOT RESPONSE---"
+        echo "$ASYNC_FINAL_BOT_RESPONSE"
+        echo "---END BOT RESPONSE---"
+        exit 0
+      elif ! echo "$ASYNC_FINAL_BOT_RESPONSE" | grep -qi "If Codex has suggestions, it will comment; otherwise it will react with"; then
+        echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
+        echo "---BEGIN BOT RESPONSE---"
+        echo "$ASYNC_FINAL_BOT_RESPONSE"
+        echo "---END BOT RESPONSE---"
+        exit 1
+      fi
     fi
     if ! ASYNC_APPROVAL_REACTION_COUNT=$(codex_trigger_approval_reaction_count "$TRIGGER_COMMENT_ID"); then
       echo "VERDICT: TIMED_OUT — failed to fetch Codex trigger reactions after async acknowledgement (treated as unavailable)"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -520,7 +520,7 @@ while true; do
 
     if codex_response_is_usage_limit "$BOT_RESPONSE"; then
       codex_return_usage_limit "$BOT_RESPONSE"
-    elif codex_response_is_environment_error "$BOT_RESPONSE"; then
+    elif [ "$BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$BOT_RESPONSE"; then
       SEEN_ENVIRONMENT_ERROR=1
       SEEN_ENVIRONMENT_RESPONSE="$BOT_RESPONSE"
       echo "INFO: Codex environment setup response detected; waiting for fresh current-head review evidence"
@@ -690,7 +690,7 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
   # Apply the same three-path verdict parsing as the main poll loop.
   if codex_response_is_usage_limit "$ASYNC_BOT_RESPONSE"; then
     codex_return_usage_limit "$ASYNC_BOT_RESPONSE"
-  elif codex_response_is_environment_error "$ASYNC_BOT_RESPONSE"; then
+  elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_BOT_RESPONSE"; then
     SEEN_ENVIRONMENT_ERROR=1
     SEEN_ENVIRONMENT_RESPONSE="$ASYNC_BOT_RESPONSE"
     echo "INFO: async-arrival Codex environment setup response detected without fresh review evidence"
@@ -759,7 +759,7 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
       codex_require_current_head
       if codex_response_is_usage_limit "$ASYNC_FINAL_BOT_RESPONSE"; then
         codex_return_usage_limit "$ASYNC_FINAL_BOT_RESPONSE"
-      elif codex_response_is_environment_error "$ASYNC_FINAL_BOT_RESPONSE"; then
+      elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_FINAL_BOT_RESPONSE"; then
         SEEN_ENVIRONMENT_ERROR=1
         SEEN_ENVIRONMENT_RESPONSE="$ASYNC_FINAL_BOT_RESPONSE"
         echo "INFO: final async Codex environment setup response detected without fresh review evidence"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -341,33 +341,34 @@ codex_response_reviews_current_head() {
 # same rules. See "Verdict parsing" header comment for the rationale behind
 # each marker.
 #
-# (should|must)[[:space:]]+not[[:space:]]+be[[:space:]]+merged targets an
-# explicit merge-refusal verdict that the negated-approval mechanism
-# below (CODEX_NEGATED_APPROVAL_PATTERN) cannot catch: that mechanism
-# only fires when a negation word is followed by one of a fixed list of
-# approval-vocabulary target words (approve[ds]?, lgtm, looks good, etc.)
-# within the same sentence, but a response like "This looks good at
-# first glance, but this should not be merged until tests pass." negates
-# "merged" — a word outside that target list entirely — so the negated-
-# approval check never matches and the earlier "looks good" phrase alone
-# wins, returning APPROVED (fresh evidence from PR #1490 finding
-# 3798880969, a followup to the "don't approve" fix that closed the
-# adjacent-to-an-approval-word case but not this direct-merge-refusal
-# case). Checked here, in CODEX_BLOCKING_PATTERN (evaluated first in the
+# Explicit merge-refusal verdicts (e.g. "should not be merged", "do not
+# merge", "cannot be merged") are a separate signal the negated-approval
+# mechanism below (CODEX_NEGATED_APPROVAL_PATTERN) cannot catch: that
+# mechanism only fires when a negation word is followed by one of a
+# fixed list of approval-vocabulary target words (approve[ds]?, lgtm,
+# looks good, etc.) within the same sentence, but a response like "This
+# looks good at first glance, but this should not be merged until tests
+# pass." negates "merged" — a word outside that target list entirely —
+# so the negated-approval check never matches and the earlier "looks
+# good" phrase alone wins, returning APPROVED. This was FIRST fixed by
+# manually enumerating one phrasing at a time directly in
+# CODEX_BLOCKING_PATTERN — "(should|must) not be merged" (fresh evidence
+# from PR #1490 finding 3798880969), then "do not merge"/"don't merge"
+# (finding 3798999561) — and each fix immediately surfaced the next
+# unenumerated synonym ("cannot be merged", finding 3799159335),
+# confirming this is the SAME kind of open-ended-vocabulary problem
+# CODEX_NEGATED_APPROVAL_PATTERN already solved by construction rather
+# than by enumeration. CODEX_MERGE_REFUSAL_PATTERN below reuses
+# CODEX_NEGATION_WORDS (defined further down) the same way
+# CODEX_NEGATED_APPROVAL_PATTERN does, against a "merge(d)" target,
+# so any negation word already known to this file — including future
+# additions to CODEX_NEGATION_WORDS — automatically covers merge
+# refusals too, without needing its own one-off enumeration. Checked
+# here, in CODEX_BLOCKING_PATTERN (evaluated first in the
 # verdict-parsing chain, before approval), an explicit refusal to merge
 # is recognized as blocking outright regardless of what an earlier
-# hedge phrase in the same response says. That fix only covered the
-# PASSIVE form ("should/must not be merged"); the IMPERATIVE form ("do
-# not merge"/"don't merge") is a separate, common phrasing that the same
-# gap applies to for the identical reason — "merge" isn't in
-# CODEX_NEGATED_APPROVAL_TARGET_WORDS either, and unlike the passive
-# form's "not be merged", the imperative form's negation word ("do not"/
-# "don't") isn't even adjacent to an approval-vocabulary word at all, so
-# no plausible extension of the negated-approval mechanism could catch
-# it (fresh evidence from PR #1490 finding 3798999561, a followup to
-# 3798880969 that fixed the passive form only). do[[:space:]]+not[[:space:]]+
-# merge and don.t[[:space:]]+merge are added alongside the passive form.
-CODEX_BLOCKING_PATTERN='(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|(should|must)[[:space:]]+not[[:space:]]+be[[:space:]]+merged|do[[:space:]]+not[[:space:]]+merge|don.t[[:space:]]+merge|❌)'
+# hedge phrase in the same response says.
+CODEX_BLOCKING_PATTERN='(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)'
 # \b word boundaries around the positive approval words: without them,
 # "approved" as a bare substring matched inside prefixed negative forms
 # like "unapproved" or "disapproved" (no space/word-break before
@@ -452,6 +453,16 @@ CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t 
 CODEX_NEGATED_APPROVAL_TARGET_WORDS='(approve[ds]?|lgtm|look(s|ing)?[[:space:]]+good|no[[:space:]]+blocking[[:space:]]+issues?|didn.t find[[:space:]]+any major[[:space:]]+issues)'
 CODEX_NEGATION_WORDS='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|do[[:space:]]+not|don.t|never|unable[[:space:]]+to)'
 CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*${CODEX_NEGATED_APPROVAL_TARGET_WORDS}"
+# Any CODEX_NEGATION_WORDS alternative, followed within the same clause
+# by "merge"/"merged" (with or without an intervening "be"), is treated
+# as an explicit merge-refusal verdict — see the comment above
+# CODEX_BLOCKING_PATTERN for why this is built by reusing the negation
+# vocabulary rather than enumerating merge-refusal phrasings one at a
+# time. Appended to CODEX_BLOCKING_PATTERN below (not folded into its
+# own literal above) because it depends on CODEX_NEGATION_WORDS, which
+# must be defined first.
+CODEX_MERGE_REFUSAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*(be[[:space:]]+)?merged?"
+CODEX_BLOCKING_PATTERN="${CODEX_BLOCKING_PATTERN%)}|${CODEX_MERGE_REFUSAL_PATTERN})"
 
 # Strips quoted spans — text between a pair of straight double-quotes
 # ("...") AND text between a pair of backticks (`...`, Markdown inline

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -421,8 +421,8 @@ while true; do
   BOT_RESPONSE_SOURCE=""
   if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
     2>"$POLL_STDERR" \
-    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
+    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
+        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | .body // empty' \
     > "$POLL_TMPFILE"; then
 	    # Truncate after successful API call — no SIGPIPE risk here
 	    BOT_RESPONSE=$(head -c 10000 "$POLL_TMPFILE")
@@ -655,8 +655,8 @@ fi
 ASYNC_POLL_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>/dev/null \
-  | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-      '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
+  | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
+      '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | .body // empty' \
 	  > "$ASYNC_POLL_TMPFILE" 2>/dev/null; then
 	  ASYNC_BOT_RESPONSE=$(head -c 10000 "$ASYNC_POLL_TMPFILE")
 	  if [ -n "$ASYNC_BOT_RESPONSE" ]; then
@@ -726,8 +726,8 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
 	    ASYNC_FINAL_POLL_TMPFILE=$(mktemp)
     if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
       2>/dev/null \
-      | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-          '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
+      | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg trigger_comment_id "$TRIGGER_COMMENT_ID" \
+          '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time or (.created_at == $trigger_time and ((.id // 0 | tostring | tonumber) > ($trigger_comment_id | tonumber))))] | sort_by(.created_at, .id) | last | .body // empty' \
 	      > "$ASYNC_FINAL_POLL_TMPFILE" 2>/dev/null; then
 	      ASYNC_FINAL_BOT_RESPONSE=$(head -c 10000 "$ASYNC_FINAL_POLL_TMPFILE")
 	      if [ -n "$ASYNC_FINAL_BOT_RESPONSE" ]; then

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -402,11 +402,27 @@ CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*${CODEX_NEGATED_
 # and the closing quote by whitespace/punctuation-or-end, which a
 # contraction's apostrophe never satisfies (the letters on both sides of
 # it are word characters, not whitespace), so genuine quotation is
-# distinguished from an apostrophe embedded in a word.
+# distinguished from an apostrophe embedded in a word. Fenced Markdown
+# code blocks (```...```) are stripped FIRST via a separate awk pass,
+# since they're a MULTI-LINE construct the single-line sed substitutions
+# below can't handle: a fence marker line (```` ``` ````, optionally with
+# a language tag) has no PAIRED backtick on the same line for the
+# existing single-backtick-pair substitution to match against, and the
+# quoted content between the opening/closing fence spans arbitrarily many
+# separate lines. A review quoting a clean signal inside a fenced block
+# was the fifth quoting style found unprotected, after straight-quote,
+# backtick, blockquote, and single-quote (fresh evidence from PR #1490
+# finding 3793453010).
 codex_strip_quoted_spans() {
   local body="$1"
   local sq="'"
-  sed -E "s/\"[^\"]*\"//g; s/\`[^\`]*\`//g; /^[[:space:]]*>/d; s/(^|[[:space:]])${sq}[^${sq}]*${sq}([[:space:].,;:!?]|\$)/\\1\\2/g" <<< "$body"
+  local unfenced_body
+  unfenced_body=$(awk '
+    /^[[:space:]]*```/ { infence = !infence; next }
+    infence { next }
+    { print }
+  ' <<< "$body")
+  sed -E "s/\"[^\"]*\"//g; s/\`[^\`]*\`//g; /^[[:space:]]*>/d; s/(^|[[:space:]])${sq}[^${sq}]*${sq}([[:space:].,;:!?]|\$)/\\1\\2/g" <<< "$unfenced_body"
 }
 
 codex_response_is_blocking() {

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -412,15 +412,41 @@ CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*${CODEX_NEGATED_
 # separate lines. A review quoting a clean signal inside a fenced block
 # was the fifth quoting style found unprotected, after straight-quote,
 # backtick, blockquote, and single-quote (fresh evidence from PR #1490
-# finding 3793453010).
+# finding 3793453010). The awk pass tracks the LENGTH of the opening
+# fence delimiter and only closes on a delimiter of AT LEAST that length
+# — matching GitHub-flavored Markdown's actual fence semantics, where a
+# longer outer fence (e.g. four backticks) can safely quote content that
+# itself contains a shorter (three-backtick) fence without the inner one
+# prematurely closing the block. A naive "any 3+ backtick line toggles
+# the state" implementation (the original version of this pass)
+# incorrectly closed on the inner delimiter, re-exposing everything after
+# it — including a quoted clean phrase — to classification (fresh
+# evidence from PR #1490 finding 3793497787, a followup to 3793453010).
+# Uses the POSIX two-argument `match()` (setting `RLENGTH`), not the
+# gawk-only three-argument form with an array capture, since this
+# environment's `awk` is the POSIX "one true awk", not gawk.
 codex_strip_quoted_spans() {
   local body="$1"
   local sq="'"
   local unfenced_body
   unfenced_body=$(awk '
-    /^[[:space:]]*```/ { infence = !infence; next }
-    infence { next }
-    { print }
+    {
+      line = $0
+      sub(/^[[:space:]]*/, "", line)
+      if (match(line, /^`{3,}/)) {
+        candidate_len = RLENGTH
+        if (!infence) {
+          infence = 1
+          fencelen = candidate_len
+          next
+        } else if (candidate_len >= fencelen) {
+          infence = 0
+          next
+        }
+      }
+      if (infence) next
+      print
+    }
   ' <<< "$body")
   sed -E "s/\"[^\"]*\"//g; s/\`[^\`]*\`//g; /^[[:space:]]*>/d; s/(^|[[:space:]])${sq}[^${sq}]*${sq}([[:space:].,;:!?]|\$)/\\1\\2/g" <<< "$unfenced_body"
 }

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -321,7 +321,12 @@ codex_select_terminal_evidence() {
 # overwrite it, so an actionable setup failure is not silently lost to a
 # no-information comment that happens to arrive later in the same fetch
 # (fresh evidence from PR #1490 finding 3787786945). A LATER environment-
-# error comment still updates it, keeping the most recent one.
+# error comment still updates it, keeping the most recent one. A SHA-pinned
+# TERMINAL comment is never classified as an environment error even if its
+# text happens to quote the setup sentence (e.g. a blocking finding about
+# stale documentation that reproduces it verbatim) — terminal evidence is
+# always genuine review content, not a bare setup-failure message (fresh
+# evidence from PR #1490 finding 3787943163).
 #
 # Sets: COMMENT_TERMINAL_BODY, COMMENT_TERMINAL_TIME, COMMENT_LATEST_BODY,
 # COMMENT_LATEST_TIME.
@@ -332,19 +337,23 @@ codex_scan_comment_evidence() {
   COMMENT_LATEST_BODY=""
   COMMENT_LATEST_TIME=""
   local comment_latest_is_env_error=0
-  local line created_at body is_env_error
+  local line created_at body is_env_error is_terminal
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     created_at=$(printf '%s' "$line" | jq -r '.created_at // empty')  # workflow-shell-guard: allow SH003 - $line is a compact JSON object already validated parseable by the preceding jq -sc call; empty is a normal absent-field case, not a failure
     body=$(printf '%s' "$line" | jq -r '.body // empty')  # workflow-shell-guard: allow SH003 - same pre-validated $line as above; empty body is not a failure
+    is_terminal=0
+    codex_response_reviews_current_head "$body" && is_terminal=1
     is_env_error=0
-    codex_response_is_environment_error "$body" && is_env_error=1
+    if [ "$is_terminal" -eq 0 ]; then
+      codex_response_is_environment_error "$body" && is_env_error=1
+    fi
     if [ "$comment_latest_is_env_error" -eq 0 ] || [ "$is_env_error" -eq 1 ]; then
       COMMENT_LATEST_BODY="$body"
       COMMENT_LATEST_TIME="$created_at"
       comment_latest_is_env_error="$is_env_error"
     fi
-    if codex_response_reviews_current_head "$body"; then
+    if [ "$is_terminal" -eq 1 ]; then
       COMMENT_TERMINAL_BODY="$body"
       COMMENT_TERMINAL_TIME="$created_at"
     fi
@@ -367,8 +376,13 @@ codex_scan_comment_evidence() {
 # with a different evidence type (fresh evidence from PR #1490 finding
 # 3787868727: the terminal-comment branch previously never considered the
 # environment error at all). Only strictly newer terminal/review evidence
-# supersedes it. A bare non-error ancillary comment (acknowledgement,
-# "waiting" note) carries no information and never competes with anything.
+# supersedes it — EXCEPT when that terminal/review evidence is itself
+# blocking: a blocking finding always wins outright and is never discarded
+# by an environment-setup error regardless of timing, so an actionable
+# finding can never be hidden behind an "unavailable" verdict (fresh
+# evidence from PR #1490 finding 3787943162). A bare non-error ancillary
+# comment (acknowledgement, "waiting" note) carries no information and
+# never competes with anything.
 #
 # Sets: COMBINED_BODY, COMBINED_TIME, COMBINED_SOURCE ("review", "comment",
 # or "" if no evidence at all). LABEL is used only for INFO logging.
@@ -416,7 +430,15 @@ codex_combine_terminal_evidence() {
   fi
 
   if [ -n "$comment_latest_body" ] && codex_response_is_environment_error "$comment_latest_body"; then
-    if [ -z "$COMBINED_TIME" ] || ! codex_select_terminal_evidence "$comment_latest_body" "$comment_latest_time" "$COMBINED_BODY" "$COMBINED_TIME"; then
+    if [ -n "$COMBINED_SOURCE" ] && codex_response_is_blocking "$COMBINED_BODY"; then
+      # Blocking terminal/review evidence always wins outright — it is
+      # never discarded by an environment-setup error, regardless of
+      # timing, so an actionable finding can never be hidden behind an
+      # "unavailable" verdict (fresh evidence from PR #1490 finding
+      # 3787943162; Protocol 93 requires blocking evidence to never be
+      # silently discarded).
+      :
+    elif [ -z "$COMBINED_TIME" ] || ! codex_select_terminal_evidence "$comment_latest_body" "$comment_latest_time" "$COMBINED_BODY" "$COMBINED_TIME"; then
       COMBINED_BODY="$comment_latest_body"
       COMBINED_TIME="$comment_latest_time"
       COMBINED_SOURCE="comment"
@@ -679,7 +701,7 @@ while true; do
   # (printf) is always fully drained and can never receive SIGPIPE, unlike
   # a piped `head -c N` which can close early on long input (fresh evidence
   # from PR #1490 finding 3787868733).
-  BOT_RESPONSE=$(printf '%s' "$BOT_RESPONSE" | jq -Rrs '.[0:10000]')
+  BOT_RESPONSE=$(printf '%s' "$BOT_RESPONSE" | jq -Rrs '.[0:10000]')  # workflow-shell-guard: allow SH003 - jq -R treats input as raw text (not JSON), so it cannot fail on malformed content; a genuine jq internal failure still trips `set -e` since this is a bare assignment, which is the desired fail-closed behavior
 
   if ! INLINE_REVIEW_COMMENT_COUNT=$(codex_inline_review_comment_count_since "$TRIGGER_TIME"); then
     echo "VERDICT: TIMED_OUT — failed to fetch Codex inline review comments (treated as unavailable)"
@@ -914,7 +936,7 @@ ASYNC_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
 # `jq -Rs` slurps its entire stdin before producing output, avoiding
 # SIGPIPE on long root-comment-sourced bodies (see rationale above the
 # main-loop equivalent).
-ASYNC_BOT_RESPONSE=$(printf '%s' "$ASYNC_BOT_RESPONSE" | jq -Rrs '.[0:10000]')
+ASYNC_BOT_RESPONSE=$(printf '%s' "$ASYNC_BOT_RESPONSE" | jq -Rrs '.[0:10000]')  # workflow-shell-guard: allow SH003 - jq -R treats input as raw text (not JSON), so it cannot fail on malformed content; a genuine jq internal failure still trips `set -e` since this is a bare assignment, which is the desired fail-closed behavior
 
 if [ -n "$ASYNC_BOT_RESPONSE" ]; then
   echo "INFO: async-arrival bot response detected during grace period"
@@ -1002,7 +1024,7 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     # `jq -Rs` slurps its entire stdin before producing output, avoiding
     # SIGPIPE on long root-comment-sourced bodies (see rationale above the
     # main-loop equivalent).
-    ASYNC_FINAL_BOT_RESPONSE=$(printf '%s' "$ASYNC_FINAL_BOT_RESPONSE" | jq -Rrs '.[0:10000]')
+    ASYNC_FINAL_BOT_RESPONSE=$(printf '%s' "$ASYNC_FINAL_BOT_RESPONSE" | jq -Rrs '.[0:10000]')  # workflow-shell-guard: allow SH003 - jq -R treats input as raw text (not JSON), so it cannot fail on malformed content; a genuine jq internal failure still trips `set -e` since this is a bare assignment, which is the desired fail-closed behavior
 
     if [ -n "$ASYNC_FINAL_BOT_RESPONSE" ]; then
       echo "INFO: final async bot response detected after acknowledgement wait"
@@ -1127,7 +1149,7 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
   # `jq -Rs` slurps its entire stdin before producing output, avoiding
   # SIGPIPE on long root-comment-sourced bodies (see rationale above the
   # main-loop equivalent).
-  ASYNC_REACTION_FINAL_BOT_RESPONSE=$(printf '%s' "$ASYNC_REACTION_FINAL_BOT_RESPONSE" | jq -Rrs '.[0:10000]')
+  ASYNC_REACTION_FINAL_BOT_RESPONSE=$(printf '%s' "$ASYNC_REACTION_FINAL_BOT_RESPONSE" | jq -Rrs '.[0:10000]')  # workflow-shell-guard: allow SH003 - jq -R treats input as raw text (not JSON), so it cannot fail on malformed content; a genuine jq internal failure still trips `set -e` since this is a bare assignment, which is the desired fail-closed behavior
 
   if [ -n "$ASYNC_REACTION_FINAL_BOT_RESPONSE" ]; then
     codex_require_current_head

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -384,30 +384,58 @@ codex_scan_comment_evidence() {
 # `sort_by | last`). GitHub timestamps are second-resolution, so multiple
 # reviews genuinely CAN tie; picking an arbitrary one by array order could
 # silently discard a blocking review in favor of a clean one submitted in
-# the same second (fresh evidence from PR #1490 finding 3788008326). Picks
-# the first tied review that requires attention (blocking or unrecognized
-# format); if none do, every tied review is a clean approval and any one is
-# equivalent, so the first is used.
+# the same second (fresh evidence from PR #1490 finding 3788008326). Among
+# tied reviews, a BLOCKING one always wins outright over any other
+# non-clean type (e.g. a usage-limit response) — scanning stops at the
+# first "requires attention" match without this priority let a tied
+# usage-limit response returned before a blocking one silently discard
+# the blocker, emitting UNAVAILABLE instead of NEEDS_REVISION (fresh
+# evidence from PR #1490 finding 3789477520). If no tied review is
+# blocking, the first one requiring attention (unrecognized format, e.g.
+# usage-limit text) is used; if none require attention, every tied review
+# is a clean approval and any one is equivalent, so the first is used.
 # Sets: SELECTED_REVIEW_BODY, SELECTED_REVIEW_TIME.
 codex_select_review_evidence() {
   local reviews_file="$1"
   SELECTED_REVIEW_BODY=""
   SELECTED_REVIEW_TIME=""
+  # Presence is tracked via explicit found-flags, not by checking whether
+  # the candidate/blocking/attention body strings are non-empty — a
+  # winning review's body can legitimately be empty (see
+  # codex_combine_terminal_evidence's review_time-based presence check
+  # above), so inferring "not yet found" from string emptiness would
+  # reintroduce that exact bug here.
+  local have_default=0 have_blocking=0 have_attention=0
+  local blocking_body="" blocking_time=""
+  local attention_body="" attention_time=""
   local line created_at body
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     created_at=$(printf '%s' "$line" | jq -r '.created_at // empty')  # workflow-shell-guard: allow SH003 - $line is a compact JSON object already validated parseable by the preceding jq -sc call; empty is a normal absent-field case, not a failure
     body=$(printf '%s' "$line" | jq -r '.body // empty')  # workflow-shell-guard: allow SH003 - same pre-validated $line as above; empty body is not a failure
-    if [ -z "$SELECTED_REVIEW_BODY" ]; then
+    if [ "$have_default" -eq 0 ]; then
       SELECTED_REVIEW_BODY="$body"
       SELECTED_REVIEW_TIME="$created_at"
+      have_default=1
     fi
-    if codex_response_requires_attention "$body"; then
-      SELECTED_REVIEW_BODY="$body"
-      SELECTED_REVIEW_TIME="$created_at"
-      break
+    if [ "$have_blocking" -eq 0 ] && codex_response_is_blocking "$body"; then
+      blocking_body="$body"
+      blocking_time="$created_at"
+      have_blocking=1
+    fi
+    if [ "$have_attention" -eq 0 ] && codex_response_requires_attention "$body"; then
+      attention_body="$body"
+      attention_time="$created_at"
+      have_attention=1
     fi
   done < "$reviews_file"
+  if [ "$have_blocking" -eq 1 ]; then
+    SELECTED_REVIEW_BODY="$blocking_body"
+    SELECTED_REVIEW_TIME="$blocking_time"
+  elif [ "$have_attention" -eq 1 ]; then
+    SELECTED_REVIEW_BODY="$attention_body"
+    SELECTED_REVIEW_TIME="$attention_time"
+  fi
 }
 
 # Combines comment-sourced evidence (terminal SHA-pinned root comment vs.

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -356,8 +356,18 @@ codex_response_reviews_current_head() {
 # case). Checked here, in CODEX_BLOCKING_PATTERN (evaluated first in the
 # verdict-parsing chain, before approval), an explicit refusal to merge
 # is recognized as blocking outright regardless of what an earlier
-# hedge phrase in the same response says.
-CODEX_BLOCKING_PATTERN='(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|(should|must)[[:space:]]+not[[:space:]]+be[[:space:]]+merged|❌)'
+# hedge phrase in the same response says. That fix only covered the
+# PASSIVE form ("should/must not be merged"); the IMPERATIVE form ("do
+# not merge"/"don't merge") is a separate, common phrasing that the same
+# gap applies to for the identical reason — "merge" isn't in
+# CODEX_NEGATED_APPROVAL_TARGET_WORDS either, and unlike the passive
+# form's "not be merged", the imperative form's negation word ("do not"/
+# "don't") isn't even adjacent to an approval-vocabulary word at all, so
+# no plausible extension of the negated-approval mechanism could catch
+# it (fresh evidence from PR #1490 finding 3798999561, a followup to
+# 3798880969 that fixed the passive form only). do[[:space:]]+not[[:space:]]+
+# merge and don.t[[:space:]]+merge are added alongside the passive form.
+CODEX_BLOCKING_PATTERN='(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|(should|must)[[:space:]]+not[[:space:]]+be[[:space:]]+merged|do[[:space:]]+not[[:space:]]+merge|don.t[[:space:]]+merge|❌)'
 # \b word boundaries around the positive approval words: without them,
 # "approved" as a bare substring matched inside prefixed negative forms
 # like "unapproved" or "disapproved" (no space/word-break before

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -397,6 +397,7 @@ CONSECUTIVE_API_FAILURES=0
 MAX_CONSECUTIVE_FAILURES=3
 SEEN_ENVIRONMENT_ERROR=0
 SEEN_ENVIRONMENT_RESPONSE=""
+SEEN_APPROVAL_REACTION=0
 # Outer retrigger loop. TOTAL_ELAPSED tracks the full shared wait budget.
 # TRIGGER_TIME is updated to the retrigger comment's timestamp after each
 # retrigger post, scoping the next inner poll to responses after that point.
@@ -555,7 +556,9 @@ while true; do
 
   if [ "$APPROVAL_REACTION_COUNT" -gt 0 ]; then
     echo "INFO: detected Codex thumbs-up reaction on trigger comment $TRIGGER_COMMENT_ID"
-    codex_return_reaction_without_review
+    echo "INFO: waiting for current-head review evidence before treating reaction as terminal"
+    SEEN_APPROVAL_REACTION=1
+    continue
   fi
   done  # end inner poll loop
 
@@ -819,6 +822,10 @@ fi
 
 if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ]; then
   codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
+fi
+
+if [ "$SEEN_APPROVAL_REACTION" -eq 1 ]; then
+  codex_return_reaction_without_review
 fi
 
 echo "INFO: no bot response during async grace period"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -286,8 +286,15 @@ CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t 
 # approval pattern in codex_response_is_approved so a negated approval
 # phrase can never be reported as approved. This handles SPACE-separated
 # negations ("not approved"); CODEX_APPROVAL_PATTERN's \b boundaries above
-# separately handle CONCATENATED negation prefixes ("unapproved").
-CODEX_NEGATED_APPROVAL_PATTERN='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)[[:space:]]+(be[[:space:]]+)?(approved|lgtm|look(s|ing)?[[:space:]]+good)'
+# separately handle CONCATENATED negation prefixes ("unapproved"). The
+# optional [*_~]{0,3} groups between the negation word and the approval
+# word tolerate Markdown emphasis markers wedged between them (e.g. "This
+# change is **not** approved" — GitHub renders **not** as bold, but the
+# raw text has "**" directly between "not" and the following space, which
+# broke the plain [[:space:]]+ adjacency this pattern originally required;
+# fresh evidence from PR #1490 finding 3789878264, a followup to
+# 3789851555/3789722818).
+CODEX_NEGATED_APPROVAL_PATTERN='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)[*_~]{0,3}[[:space:]]+(be[[:space:]]+)?[*_~]{0,3}(approved|lgtm|look(s|ing)?[[:space:]]+good)'
 
 codex_response_is_blocking() {
   local body="$1"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -425,6 +425,25 @@ CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*${CODEX_NEGATED_
 # Uses the POSIX two-argument `match()` (setting `RLENGTH`), not the
 # gawk-only three-argument form with an array capture, since this
 # environment's `awk` is the POSIX "one true awk", not gawk.
+#
+# This completes GFM's actual (finite, well-specified) fenced-code-block
+# rule: an opening delimiter (3+ backticks, optionally followed by an
+# info string) is closed by the first later delimiter that is (a) at
+# least as long as the opening one AND (b) followed by nothing but
+# optional whitespace. A candidate closing line that has trailing
+# non-whitespace content — e.g. ```` ```not-a-close ```` — is, per GFM,
+# an entirely different construct (a NEW opening fence with an info
+# string), not a close, but a length-only check (the previous version of
+# this fix) treated it as closing regardless, re-exposing quoted content
+# after it (fresh evidence from PR #1490 finding, followup to
+# 3793497787/3793453010). This is deliberately the LAST fence-specific
+# refinement here, not another reactive edge-case patch: GFM's fence spec
+# is genuinely finite (open, length, close-only-whitespace), and all
+# three parts are now implemented. An unclosed fence at end-of-input is
+# already handled safely by construction — `infence` simply stays true
+# through the rest of the loop, so everything after an opening delimiter
+# that never finds a valid close is stripped, which is the conservative
+# (never-expose-ambiguous-content) direction.
 codex_strip_quoted_spans() {
   local body="$1"
   local sq="'"
@@ -435,13 +454,18 @@ codex_strip_quoted_spans() {
       sub(/^[[:space:]]*/, "", line)
       if (match(line, /^`{3,}/)) {
         candidate_len = RLENGTH
+        rest = substr(line, RSTART + RLENGTH)
         if (!infence) {
           infence = 1
           fencelen = candidate_len
           next
         } else if (candidate_len >= fencelen) {
-          infence = 0
-          next
+          trimmed_rest = rest
+          gsub(/[[:space:]]/, "", trimmed_rest)
+          if (trimmed_rest == "") {
+            infence = 0
+            next
+          }
         }
       }
       if (infence) next

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -473,7 +473,32 @@ CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*${CODEX_NEGATED_
 codex_strip_quoted_spans() {
   local body="$1"
   local sq="'"
-  sed -E "s/\"[^\"]*\"//g; s/\`[^\`]*\`//g; /^[[:space:]]*>/d; s/(^|[[:space:]])${sq}[^${sq}]*${sq}([[:space:].,;:!?]|\$)/\\1\\2/g" <<< "$body"
+  # Blockquote lines are deleted first, line-oriented, by definition — a
+  # GFM blockquote marker only means anything at the start of a line.
+  local no_blockquotes
+  no_blockquotes=$(sed -E '/^[[:space:]]*>/d' <<< "$body")
+  # Double-quote and single-quote pairs, UNLIKE backtick pairs (see
+  # below), can legitimately span a newline — a bot can quote multi-line
+  # text inside one straight-quote pair (e.g. `The documented response
+  # "\nNo blocking issues found\n" is inaccurate`). sed's substitution
+  # operates per-line by default (each line is its own pattern space), so
+  # a quote pair split across two lines was never stripped at all,
+  # letting the quoted clean phrase reach classification unstripped and
+  # return APPROVED (fresh evidence from PR #1490 finding 3797334339).
+  # Newlines are swapped for a control-character placeholder before these
+  # two substitutions — collapsing the body to one sed "line" so `[^"]*`/
+  # `[^']*` can match across what were originally separate lines — then
+  # restored immediately after, before the backtick pass below.
+  local nl_placeholder=$'\x01'
+  local flattened stripped
+  flattened=$(printf '%s' "$no_blockquotes" | tr '\n' "$nl_placeholder")
+  stripped=$(sed -E "s/\"[^\"]*\"//g; s/(^|[[:space:]])${sq}[^${sq}]*${sq}([[:space:].,;:!?]|\$)/\\1\\2/g" <<< "$flattened")
+  stripped=$(printf '%s' "$stripped" | tr "$nl_placeholder" '\n')
+  # Backtick pairs are intentionally NOT included in the flattening above:
+  # GFM defines an inline code span as never crossing a line (an
+  # unclosed backtick run at end-of-line is not code), so keeping this
+  # substitution line-oriented is correct per spec, not a gap.
+  sed -E "s/\`[^\`]*\`//g" <<< "$stripped"
 }
 
 codex_response_is_blocking() {

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -402,77 +402,38 @@ CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*${CODEX_NEGATED_
 # and the closing quote by whitespace/punctuation-or-end, which a
 # contraction's apostrophe never satisfies (the letters on both sides of
 # it are word characters, not whitespace), so genuine quotation is
-# distinguished from an apostrophe embedded in a word. Fenced Markdown
-# code blocks (```...```) are stripped FIRST via a separate awk pass,
-# since they're a MULTI-LINE construct the single-line sed substitutions
-# below can't handle: a fence marker line (```` ``` ````, optionally with
-# a language tag) has no PAIRED backtick on the same line for the
-# existing single-backtick-pair substitution to match against, and the
-# quoted content between the opening/closing fence spans arbitrarily many
-# separate lines. A review quoting a clean signal inside a fenced block
-# was the fifth quoting style found unprotected, after straight-quote,
-# backtick, blockquote, and single-quote (fresh evidence from PR #1490
-# finding 3793453010). The awk pass tracks the LENGTH of the opening
-# fence delimiter and only closes on a delimiter of AT LEAST that length
-# — matching GitHub-flavored Markdown's actual fence semantics, where a
-# longer outer fence (e.g. four backticks) can safely quote content that
-# itself contains a shorter (three-backtick) fence without the inner one
-# prematurely closing the block. A naive "any 3+ backtick line toggles
-# the state" implementation (the original version of this pass)
-# incorrectly closed on the inner delimiter, re-exposing everything after
-# it — including a quoted clean phrase — to classification (fresh
-# evidence from PR #1490 finding 3793497787, a followup to 3793453010).
-# Uses the POSIX two-argument `match()` (setting `RLENGTH`), not the
-# gawk-only three-argument form with an array capture, since this
-# environment's `awk` is the POSIX "one true awk", not gawk.
+# distinguished from an apostrophe embedded in a word.
 #
-# This completes GFM's actual (finite, well-specified) fenced-code-block
-# rule: an opening delimiter (3+ backticks, optionally followed by an
-# info string) is closed by the first later delimiter that is (a) at
-# least as long as the opening one AND (b) followed by nothing but
-# optional whitespace. A candidate closing line that has trailing
-# non-whitespace content — e.g. ```` ```not-a-close ```` — is, per GFM,
-# an entirely different construct (a NEW opening fence with an info
-# string), not a close, but a length-only check (the previous version of
-# this fix) treated it as closing regardless, re-exposing quoted content
-# after it (fresh evidence from PR #1490 finding, followup to
-# 3793497787/3793453010). This is deliberately the LAST fence-specific
-# refinement here, not another reactive edge-case patch: GFM's fence spec
-# is genuinely finite (open, length, close-only-whitespace), and all
-# three parts are now implemented. An unclosed fence at end-of-input is
-# already handled safely by construction — `infence` simply stays true
-# through the rest of the loop, so everything after an opening delimiter
-# that never finds a valid close is stripped, which is the conservative
-# (never-expose-ambiguous-content) direction.
+# Fenced Markdown code blocks (```...``` or ~~~...~~~) are deliberately
+# NOT precisely parsed here, unlike the single-line constructs above.
+# Four consecutive rounds of chasing GitHub-flavored Markdown's fence
+# semantics — detecting a fence at all, tracking the opening delimiter's
+# LENGTH (a longer outer fence can safely contain a shorter inner one),
+# requiring a closing delimiter to be followed by nothing but whitespace,
+# and finally discovering GFM's entirely separate TILDE-delimited fence
+# syntax that a backtick-only implementation missed altogether — kept
+# producing one more undiscovered edge case each round (PR #1490 findings
+# 3793453010, 3793497787, a closing-validity followup, and 3795661290).
+# Rather than continue precisely re-implementing GFM's fence grammar one
+# construct at a time, codex_response_is_approved below now treats the
+# mere PRESENCE of a fence-opener marker (3+ consecutive backticks or
+# tildes) ANYWHERE in the response as disqualifying for a clean verdict,
+# without attempting to determine where it opens or closes. This is a
+# deliberate, explicit tradeoff: a small amount of false-NEEDS_REVISION
+# risk (a genuinely clean response that happens to include an example
+# code fence) in exchange for closing the entire class of "quoted/fenced
+# clean phrase misread as an assertion" bug in one step, rather than the
+# previous direction of chasing precision at the cost of repeated
+# false-APPROVED gaps. Single/inline backticks (a PAIR on one line, not a
+# 3+-run) are unaffected by this and still get the precise, stable
+# stripping below — only multi-backtick/tilde FENCE markers trigger the
+# conservative bail-out, since inline code references (e.g. `` `foo.py` ``)
+# are extremely common in genuinely clean review comments and haven't
+# shown this same repeated-edge-case pattern.
 codex_strip_quoted_spans() {
   local body="$1"
   local sq="'"
-  local unfenced_body
-  unfenced_body=$(awk '
-    {
-      line = $0
-      sub(/^[[:space:]]*/, "", line)
-      if (match(line, /^`{3,}/)) {
-        candidate_len = RLENGTH
-        rest = substr(line, RSTART + RLENGTH)
-        if (!infence) {
-          infence = 1
-          fencelen = candidate_len
-          next
-        } else if (candidate_len >= fencelen) {
-          trimmed_rest = rest
-          gsub(/[[:space:]]/, "", trimmed_rest)
-          if (trimmed_rest == "") {
-            infence = 0
-            next
-          }
-        }
-      }
-      if (infence) next
-      print
-    }
-  ' <<< "$body")
-  sed -E "s/\"[^\"]*\"//g; s/\`[^\`]*\`//g; /^[[:space:]]*>/d; s/(^|[[:space:]])${sq}[^${sq}]*${sq}([[:space:].,;:!?]|\$)/\\1\\2/g" <<< "$unfenced_body"
+  sed -E "s/\"[^\"]*\"//g; s/\`[^\`]*\`//g; /^[[:space:]]*>/d; s/(^|[[:space:]])${sq}[^${sq}]*${sq}([[:space:].,;:!?]|\$)/\\1\\2/g" <<< "$body"
 }
 
 codex_response_is_blocking() {
@@ -502,6 +463,19 @@ codex_strip_not_only_idiom() {
 
 codex_response_is_approved() {
   local body="$1"
+  # A fence-opener marker (3+ consecutive backticks or tildes) ANYWHERE
+  # in the response — see the "Fenced Markdown code blocks" comment above
+  # codex_strip_quoted_spans for the full rationale — disqualifies a
+  # clean verdict outright, without attempting to determine where the
+  # fence opens or closes. This deliberately trades a small amount of
+  # false-NEEDS_REVISION risk for closing the entire class of
+  # quoted/fenced-phrase-misread-as-assertion bugs at once, after four
+  # rounds of precise-fence-parsing fixes each surfaced the next
+  # undiscovered GFM fence edge case (most recently PR #1490 finding
+  # 3795661290, the tilde-fence variant).
+  if grep -qE '(`{3,}|~{3,})' <<< "$body"; then
+    return 1
+  fi
   local normalized_body
   normalized_body=$(codex_strip_not_only_idiom "$(codex_strip_quoted_spans "$body")")
   if grep -qiE "$CODEX_NEGATED_APPROVAL_PATTERN" <<< "$normalized_body"; then

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -220,8 +220,8 @@ codex_inline_review_comment_count_since() {
   local review_comment_tmpfile
   review_comment_tmpfile=$(mktemp)
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments" --paginate \
-    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$trigger_time" \
-      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .created_at > $trigger_time)] | length' \
+    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$trigger_time" --arg sha "$CURRENT_SHA" \
+      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .created_at > $trigger_time and ((.commit_id // "") | startswith($sha)))] | length' \
     > "$review_comment_tmpfile"; then
     cat "$review_comment_tmpfile"
   else
@@ -239,7 +239,7 @@ codex_response_is_usage_limit() {
 
 codex_response_is_environment_error() {
   local response="$1"
-  printf '%s\n' "$response" | grep -qiE "(to[[:space:]]+use[[:space:]]+codex[[:space:]]+here,[[:space:]]+create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo|create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo|codex[[:space:]]+cloud[[:space:]]+environment)"
+  printf '%s\n' "$response" | grep -qiE "(to[[:space:]]+use[[:space:]]+codex[[:space:]]+here,[[:space:]]+create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo|create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo)"
 }
 
 codex_return_usage_limit() {
@@ -420,8 +420,8 @@ while true; do
   POLL_TMPFILE=$(mktemp)
   if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
     2>"$POLL_STDERR" \
-    | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-        '[.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
+    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
+        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
     > "$POLL_TMPFILE"; then
     # Truncate after successful API call — no SIGPIPE risk here
     BOT_RESPONSE=$(head -c 10000 "$POLL_TMPFILE")
@@ -639,8 +639,8 @@ fi
 ASYNC_POLL_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
   2>/dev/null \
-  | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-      '[.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
+  | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
+      '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
   > "$ASYNC_POLL_TMPFILE" 2>/dev/null; then
   ASYNC_BOT_RESPONSE=$(head -c 10000 "$ASYNC_POLL_TMPFILE")
 fi
@@ -701,8 +701,8 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     ASYNC_FINAL_POLL_TMPFILE=$(mktemp)
     if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
       2>/dev/null \
-      | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
-          '[.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
+      | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" \
+          '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain) | select(.created_at > $trigger_time)] | sort_by(.created_at) | last | .body // empty' \
       > "$ASYNC_FINAL_POLL_TMPFILE" 2>/dev/null; then
       ASYNC_FINAL_BOT_RESPONSE=$(head -c 10000 "$ASYNC_FINAL_POLL_TMPFILE")
     fi

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -269,12 +269,15 @@ codex_response_is_approved() {
 # True when a response is NOT the clean-approval path — i.e. it is either
 # explicitly blocking or an unrecognized format that the documented verdict
 # classifier safe-fails to NEEDS_REVISION (see "Verdict parsing" header
-# comment). Used by the tie-break below so an unrecognized-format response
-# is treated with the same tie-break priority as an explicitly blocking one,
-# not silently outranked by a clean approval on a timestamp tie.
+# comment). Blocking is checked FIRST, matching the classifier's blocking-
+# first priority: a response containing both an approval phrase and a
+# blocking marker (e.g. "No blocking issues found. Must fix ...") is
+# blocking, not approved. Used by the tie-break below so neither an
+# unrecognized-format response nor a mixed blocking+approval response is
+# silently outranked by a clean approval on a timestamp tie.
 codex_response_requires_attention() {
   local body="$1"
-  ! codex_response_is_approved "$body"
+  codex_response_is_blocking "$body" || ! codex_response_is_approved "$body"
 }
 
 # Decides whether CANDIDATE terminal ("review"-sourced) evidence should
@@ -538,6 +541,15 @@ CONSECUTIVE_API_FAILURES=0
 MAX_CONSECUTIVE_FAILURES=3
 SEEN_ENVIRONMENT_ERROR=0
 SEEN_ENVIRONMENT_RESPONSE=""
+# Timestamp the environment-error evidence was observed at (the same
+# COMBINED_TIME the response was classified from). Compared against fresh
+# terminal evidence's own timestamp at each APPROVED exit site so a
+# strictly newer clean review (e.g. after an operator fixes the Codex cloud
+# environment mid-poll) can supersede a now-stale recorded failure, while a
+# same-or-older approval still cannot silently override it — the same
+# newest-wins-with-ties-favoring-non-clean rule applied to every other
+# evidence type in this script.
+SEEN_ENVIRONMENT_TIME=""
 SEEN_APPROVAL_REACTION=0
 # Outer retrigger loop. TOTAL_ELAPSED tracks the full shared wait budget.
 # TRIGGER_TIME is updated to the retrigger comment's timestamp after each
@@ -673,6 +685,7 @@ while true; do
     elif [ "$BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$BOT_RESPONSE"; then
       SEEN_ENVIRONMENT_ERROR=1
       SEEN_ENVIRONMENT_RESPONSE="$BOT_RESPONSE"
+      SEEN_ENVIRONMENT_TIME="$COMBINED_TIME"
       echo "INFO: Codex environment setup response detected; waiting for fresh current-head review evidence"
       continue
     elif [ "$BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$BOT_RESPONSE"; then
@@ -682,7 +695,7 @@ while true; do
       echo "---END BOT RESPONSE---"
       exit 1
     elif [ "$BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$BOT_RESPONSE"; then
-      if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ]; then
+      if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ] && ! [ "$COMBINED_TIME" \> "$SEEN_ENVIRONMENT_TIME" ]; then
         codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
       fi
       echo "VERDICT: APPROVED"
@@ -856,6 +869,7 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
   elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_BOT_RESPONSE"; then
     SEEN_ENVIRONMENT_ERROR=1
     SEEN_ENVIRONMENT_RESPONSE="$ASYNC_BOT_RESPONSE"
+    SEEN_ENVIRONMENT_TIME="$COMBINED_TIME"
     echo "INFO: async-arrival Codex environment setup response detected without fresh review evidence"
   elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_BOT_RESPONSE"; then
     echo "VERDICT: NEEDS_REVISION"
@@ -864,7 +878,7 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     echo "---END BOT RESPONSE---"
     exit 1
   elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_BOT_RESPONSE"; then
-    if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ]; then
+    if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ] && ! [ "$COMBINED_TIME" \> "$SEEN_ENVIRONMENT_TIME" ]; then
       codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
     fi
     echo "VERDICT: APPROVED"
@@ -935,6 +949,7 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
       elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_FINAL_BOT_RESPONSE"; then
         SEEN_ENVIRONMENT_ERROR=1
         SEEN_ENVIRONMENT_RESPONSE="$ASYNC_FINAL_BOT_RESPONSE"
+        SEEN_ENVIRONMENT_TIME="$COMBINED_TIME"
         echo "INFO: final async Codex environment setup response detected without fresh review evidence"
       elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_FINAL_BOT_RESPONSE"; then
         echo "VERDICT: NEEDS_REVISION"
@@ -943,7 +958,7 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
         echo "---END BOT RESPONSE---"
         exit 1
       elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_FINAL_BOT_RESPONSE"; then
-        if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ]; then
+        if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ] && ! [ "$COMBINED_TIME" \> "$SEEN_ENVIRONMENT_TIME" ]; then
           codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
         fi
         echo "VERDICT: APPROVED"
@@ -1053,6 +1068,7 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
     elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
       SEEN_ENVIRONMENT_ERROR=1
       SEEN_ENVIRONMENT_RESPONSE="$ASYNC_REACTION_FINAL_BOT_RESPONSE"
+      SEEN_ENVIRONMENT_TIME="$COMBINED_TIME"
       echo "INFO: final async reaction Codex environment setup response detected without fresh review evidence"
     elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
       echo "VERDICT: NEEDS_REVISION"
@@ -1061,7 +1077,7 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
       echo "---END BOT RESPONSE---"
       exit 1
     elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
-      if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ]; then
+      if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ] && ! [ "$COMBINED_TIME" \> "$SEEN_ENVIRONMENT_TIME" ]; then
         codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
       fi
       echo "VERDICT: APPROVED"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -330,6 +330,11 @@ codex_select_terminal_evidence() {
 # a blocking finding about stale documentation that reproduces it
 # verbatim) — terminal evidence is always genuine review content, not a
 # bare failure message (fresh evidence from PR #1490 finding 3787943163).
+# When TWO terminal comments share a timestamp, the not-a-clean-approval-
+# first tie-break (codex_select_terminal_evidence) decides which one is
+# tracked, so a later clean terminal comment cannot silently discard an
+# earlier blocking one submitted in the same second (fresh evidence from
+# PR #1490 finding 3788078189).
 #
 # Sets: COMMENT_TERMINAL_BODY, COMMENT_TERMINAL_TIME, COMMENT_LATEST_BODY,
 # COMMENT_LATEST_TIME.
@@ -359,8 +364,15 @@ codex_scan_comment_evidence() {
       comment_latest_is_actionable="$is_actionable"
     fi
     if [ "$is_terminal" -eq 1 ]; then
-      COMMENT_TERMINAL_BODY="$body"
-      COMMENT_TERMINAL_TIME="$created_at"
+      # Apply the same not-a-clean-approval-first tie-break used for
+      # submitted reviews when TWO terminal comments share a timestamp:
+      # an unconditional overwrite would let a later clean comment
+      # silently discard an earlier blocking one submitted in the same
+      # second (fresh evidence from PR #1490 finding 3788078189).
+      if codex_select_terminal_evidence "$COMMENT_TERMINAL_BODY" "$COMMENT_TERMINAL_TIME" "$body" "$created_at"; then
+        COMMENT_TERMINAL_BODY="$body"
+        COMMENT_TERMINAL_TIME="$created_at"
+      fi
     fi
   done < "$comments_file"
 }
@@ -795,7 +807,18 @@ while true; do
     # "no blocking issues". This avoids false positives without line-level filtering
     # (which would risk missing a genuine marker on the same line as a negation).
 
-    if codex_response_is_usage_limit "$BOT_RESPONSE"; then
+    if [ "$BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$BOT_RESPONSE"; then
+      # Blocking is checked first, ahead of usage-limit: a terminal/review
+      # finding whose text happens to mention "usage limit" as part of an
+      # actionable finding (e.g. flagging stale docs that describe it) must
+      # not be misrouted to an unavailable verdict before the blocking
+      # classifier runs (fresh evidence from PR #1490 finding 3788078191).
+      echo "VERDICT: NEEDS_REVISION"
+      echo "---BEGIN BOT RESPONSE---"
+      echo "$BOT_RESPONSE"
+      echo "---END BOT RESPONSE---"
+      exit 1
+    elif codex_response_is_usage_limit "$BOT_RESPONSE"; then
       codex_return_usage_limit "$BOT_RESPONSE"
     elif [ "$BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$BOT_RESPONSE"; then
       SEEN_ENVIRONMENT_ERROR=1
@@ -803,12 +826,6 @@ while true; do
       SEEN_ENVIRONMENT_TIME="$COMBINED_TIME"
       echo "INFO: Codex environment setup response detected; waiting for fresh current-head review evidence"
       continue
-    elif [ "$BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$BOT_RESPONSE"; then
-      echo "VERDICT: NEEDS_REVISION"
-      echo "---BEGIN BOT RESPONSE---"
-      echo "$BOT_RESPONSE"
-      echo "---END BOT RESPONSE---"
-      exit 1
     elif [ "$BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$BOT_RESPONSE"; then
       if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ] && ! [ "$COMBINED_TIME" \> "$SEEN_ENVIRONMENT_TIME" ]; then
         codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
@@ -987,19 +1004,21 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
   codex_require_current_head
 
   # Apply the same three-path verdict parsing as the main poll loop.
-  if codex_response_is_usage_limit "$ASYNC_BOT_RESPONSE"; then
+  # Blocking is checked first, ahead of usage-limit (see rationale above
+  # the main-loop equivalent).
+  if [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_BOT_RESPONSE"; then
+    echo "VERDICT: NEEDS_REVISION"
+    echo "---BEGIN BOT RESPONSE---"
+    echo "$ASYNC_BOT_RESPONSE"
+    echo "---END BOT RESPONSE---"
+    exit 1
+  elif codex_response_is_usage_limit "$ASYNC_BOT_RESPONSE"; then
     codex_return_usage_limit "$ASYNC_BOT_RESPONSE"
   elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_BOT_RESPONSE"; then
     SEEN_ENVIRONMENT_ERROR=1
     SEEN_ENVIRONMENT_RESPONSE="$ASYNC_BOT_RESPONSE"
     SEEN_ENVIRONMENT_TIME="$COMBINED_TIME"
     echo "INFO: async-arrival Codex environment setup response detected without fresh review evidence"
-  elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_BOT_RESPONSE"; then
-    echo "VERDICT: NEEDS_REVISION"
-    echo "---BEGIN BOT RESPONSE---"
-    echo "$ASYNC_BOT_RESPONSE"
-    echo "---END BOT RESPONSE---"
-    exit 1
   elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_BOT_RESPONSE"; then
     if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ] && ! [ "$COMBINED_TIME" \> "$SEEN_ENVIRONMENT_TIME" ]; then
       codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
@@ -1075,19 +1094,21 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     if [ -n "$ASYNC_FINAL_BOT_RESPONSE" ]; then
       echo "INFO: final async bot response detected after acknowledgement wait"
       codex_require_current_head
-      if codex_response_is_usage_limit "$ASYNC_FINAL_BOT_RESPONSE"; then
+      # Blocking is checked first, ahead of usage-limit (see rationale
+      # above the main-loop equivalent).
+      if [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_FINAL_BOT_RESPONSE"; then
+        echo "VERDICT: NEEDS_REVISION"
+        echo "---BEGIN BOT RESPONSE---"
+        echo "$ASYNC_FINAL_BOT_RESPONSE"
+        echo "---END BOT RESPONSE---"
+        exit 1
+      elif codex_response_is_usage_limit "$ASYNC_FINAL_BOT_RESPONSE"; then
         codex_return_usage_limit "$ASYNC_FINAL_BOT_RESPONSE"
       elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_FINAL_BOT_RESPONSE"; then
         SEEN_ENVIRONMENT_ERROR=1
         SEEN_ENVIRONMENT_RESPONSE="$ASYNC_FINAL_BOT_RESPONSE"
         SEEN_ENVIRONMENT_TIME="$COMBINED_TIME"
         echo "INFO: final async Codex environment setup response detected without fresh review evidence"
-      elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_FINAL_BOT_RESPONSE"; then
-        echo "VERDICT: NEEDS_REVISION"
-        echo "---BEGIN BOT RESPONSE---"
-        echo "$ASYNC_FINAL_BOT_RESPONSE"
-        echo "---END BOT RESPONSE---"
-        exit 1
       elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_FINAL_BOT_RESPONSE"; then
         if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ] && ! [ "$COMBINED_TIME" \> "$SEEN_ENVIRONMENT_TIME" ]; then
           codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"
@@ -1202,19 +1223,21 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
 
   if [ -n "$ASYNC_REACTION_FINAL_BOT_RESPONSE" ]; then
     codex_require_current_head
-    if codex_response_is_usage_limit "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
+    # Blocking is checked first, ahead of usage-limit (see rationale above
+    # the main-loop equivalent).
+    if [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
+      echo "VERDICT: NEEDS_REVISION"
+      echo "---BEGIN BOT RESPONSE---"
+      echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
+      echo "---END BOT RESPONSE---"
+      exit 1
+    elif codex_response_is_usage_limit "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
       codex_return_usage_limit "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
     elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
       SEEN_ENVIRONMENT_ERROR=1
       SEEN_ENVIRONMENT_RESPONSE="$ASYNC_REACTION_FINAL_BOT_RESPONSE"
       SEEN_ENVIRONMENT_TIME="$COMBINED_TIME"
       echo "INFO: final async reaction Codex environment setup response detected without fresh review evidence"
-    elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
-      echo "VERDICT: NEEDS_REVISION"
-      echo "---BEGIN BOT RESPONSE---"
-      echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
-      echo "---END BOT RESPONSE---"
-      exit 1
     elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$ASYNC_REACTION_FINAL_BOT_RESPONSE"; then
       if [ "$SEEN_ENVIRONMENT_ERROR" -eq 1 ] && ! [ "$COMBINED_TIME" \> "$SEEN_ENVIRONMENT_TIME" ]; then
         codex_return_environment_error "$SEEN_ENVIRONMENT_RESPONSE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -316,17 +316,20 @@ codex_select_terminal_evidence() {
 # acknowledgement or a "waiting" note) from silently discarding an earlier
 # SHA-pinned blocking root comment.
 #
-# An environment-setup-error comment is treated as the priority ancillary
-# signal once seen: a later PLAIN comment (e.g. an acknowledgement) does not
-# overwrite it, so an actionable setup failure is not silently lost to a
-# no-information comment that happens to arrive later in the same fetch
-# (fresh evidence from PR #1490 finding 3787786945). A LATER environment-
-# error comment still updates it, keeping the most recent one. A SHA-pinned
-# TERMINAL comment is never classified as an environment error even if its
-# text happens to quote the setup sentence (e.g. a blocking finding about
-# stale documentation that reproduces it verbatim) — terminal evidence is
-# always genuine review content, not a bare setup-failure message (fresh
-# evidence from PR #1490 finding 3787943163).
+# An ACTIONABLE ancillary comment — either an environment-setup error or a
+# usage-limit notice — is treated as the priority ancillary signal once
+# seen: a later PLAIN comment (e.g. an acknowledgement) does not overwrite
+# it, so an actionable failure is not silently lost to a no-information
+# comment that happens to arrive later in the same fetch (fresh evidence
+# from PR #1490 finding 3787786945, generalized in finding 3788008327 to
+# also cover usage-limit comments — the same evidence-loss pattern applied
+# to both classifiers, not just environment errors). A LATER actionable
+# comment still updates it, keeping the most recent one. A SHA-pinned
+# TERMINAL comment is never classified as either an environment error or a
+# usage-limit notice, even if its text happens to quote that wording (e.g.
+# a blocking finding about stale documentation that reproduces it
+# verbatim) — terminal evidence is always genuine review content, not a
+# bare failure message (fresh evidence from PR #1490 finding 3787943163).
 #
 # Sets: COMMENT_TERMINAL_BODY, COMMENT_TERMINAL_TIME, COMMENT_LATEST_BODY,
 # COMMENT_LATEST_TIME.
@@ -336,28 +339,63 @@ codex_scan_comment_evidence() {
   COMMENT_TERMINAL_TIME=""
   COMMENT_LATEST_BODY=""
   COMMENT_LATEST_TIME=""
-  local comment_latest_is_env_error=0
-  local line created_at body is_env_error is_terminal
+  local comment_latest_is_actionable=0
+  local line created_at body is_actionable is_terminal
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     created_at=$(printf '%s' "$line" | jq -r '.created_at // empty')  # workflow-shell-guard: allow SH003 - $line is a compact JSON object already validated parseable by the preceding jq -sc call; empty is a normal absent-field case, not a failure
     body=$(printf '%s' "$line" | jq -r '.body // empty')  # workflow-shell-guard: allow SH003 - same pre-validated $line as above; empty body is not a failure
     is_terminal=0
     codex_response_reviews_current_head "$body" && is_terminal=1
-    is_env_error=0
+    is_actionable=0
     if [ "$is_terminal" -eq 0 ]; then
-      codex_response_is_environment_error "$body" && is_env_error=1
+      if codex_response_is_environment_error "$body" || codex_response_is_usage_limit "$body"; then
+        is_actionable=1
+      fi
     fi
-    if [ "$comment_latest_is_env_error" -eq 0 ] || [ "$is_env_error" -eq 1 ]; then
+    if [ "$comment_latest_is_actionable" -eq 0 ] || [ "$is_actionable" -eq 1 ]; then
       COMMENT_LATEST_BODY="$body"
       COMMENT_LATEST_TIME="$created_at"
-      comment_latest_is_env_error="$is_env_error"
+      comment_latest_is_actionable="$is_actionable"
     fi
     if [ "$is_terminal" -eq 1 ]; then
       COMMENT_TERMINAL_BODY="$body"
       COMMENT_TERMINAL_TIME="$created_at"
     fi
   done < "$comments_file"
+}
+
+# Scans a JSON-lines file (one compact object per line) of current-head
+# submitted reviews that are ALL TIED at the globally latest submitted_at
+# timestamp (produced by the review-poll jq queries below, which select
+# every review sharing the max timestamp rather than collapsing to one via
+# `sort_by | last`). GitHub timestamps are second-resolution, so multiple
+# reviews genuinely CAN tie; picking an arbitrary one by array order could
+# silently discard a blocking review in favor of a clean one submitted in
+# the same second (fresh evidence from PR #1490 finding 3788008326). Picks
+# the first tied review that requires attention (blocking or unrecognized
+# format); if none do, every tied review is a clean approval and any one is
+# equivalent, so the first is used.
+# Sets: SELECTED_REVIEW_BODY, SELECTED_REVIEW_TIME.
+codex_select_review_evidence() {
+  local reviews_file="$1"
+  SELECTED_REVIEW_BODY=""
+  SELECTED_REVIEW_TIME=""
+  local line created_at body
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    created_at=$(printf '%s' "$line" | jq -r '.created_at // empty')  # workflow-shell-guard: allow SH003 - $line is a compact JSON object already validated parseable by the preceding jq -sc call; empty is a normal absent-field case, not a failure
+    body=$(printf '%s' "$line" | jq -r '.body // empty')  # workflow-shell-guard: allow SH003 - same pre-validated $line as above; empty body is not a failure
+    if [ -z "$SELECTED_REVIEW_BODY" ]; then
+      SELECTED_REVIEW_BODY="$body"
+      SELECTED_REVIEW_TIME="$created_at"
+    fi
+    if codex_response_requires_attention "$body"; then
+      SELECTED_REVIEW_BODY="$body"
+      SELECTED_REVIEW_TIME="$created_at"
+      break
+    fi
+  done < "$reviews_file"
 }
 
 # Combines comment-sourced evidence (terminal SHA-pinned root comment vs.
@@ -429,20 +467,20 @@ codex_combine_terminal_evidence() {
     COMBINED_SOURCE="comment"
   fi
 
-  if [ -n "$comment_latest_body" ] && codex_response_is_environment_error "$comment_latest_body"; then
+  if [ -n "$comment_latest_body" ] && { codex_response_is_environment_error "$comment_latest_body" || codex_response_is_usage_limit "$comment_latest_body"; }; then
     if [ -n "$COMBINED_SOURCE" ] && codex_response_is_blocking "$COMBINED_BODY"; then
       # Blocking terminal/review evidence always wins outright — it is
-      # never discarded by an environment-setup error, regardless of
-      # timing, so an actionable finding can never be hidden behind an
-      # "unavailable" verdict (fresh evidence from PR #1490 finding
-      # 3787943162; Protocol 93 requires blocking evidence to never be
-      # silently discarded).
+      # never discarded by an environment-setup error or a usage-limit
+      # notice, regardless of timing, so an actionable finding can never be
+      # hidden behind an "unavailable" verdict (fresh evidence from PR
+      # #1490 finding 3787943162; Protocol 93 requires blocking evidence to
+      # never be silently discarded).
       :
     elif [ -z "$COMBINED_TIME" ] || ! codex_select_terminal_evidence "$comment_latest_body" "$comment_latest_time" "$COMBINED_BODY" "$COMBINED_TIME"; then
       COMBINED_BODY="$comment_latest_body"
       COMBINED_TIME="$comment_latest_time"
       COMBINED_SOURCE="comment"
-      echo "INFO: $label environment-setup error retained over non-newer terminal/review evidence"
+      echo "INFO: $label environment-setup error or usage-limit notice retained over non-newer terminal/review evidence"
     fi
   fi
 }
@@ -667,16 +705,19 @@ while true; do
   REVIEW_TMPFILE=$(mktemp)
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>"$REVIEW_STDERR" \
-    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
+    | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:((.body // "") | .[0:5000])} end' \
     > "$REVIEW_TMPFILE" 2>"$REVIEW_STDERR"; then
-    # Truncation happens inside jq (codepoint slice), not via a piped `head`,
-    # so a long body cannot trigger SIGPIPE on jq under `set -o pipefail`
-    # (an external `| head -c N` pipe closes early on long output, and the
-    # writer's resulting SIGPIPE would otherwise abort the whole script
-    # before any VERDICT line is emitted).
-    REVIEW_BODY=$(jq -r '(.body // empty) | .[0:5000]' "$REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
-    REVIEW_TIME=$(jq -r '.created_at // empty' "$REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads the same pre-validated tmpfile as the body extraction above; empty time is not a failure
+    # Selects every review tied at the latest submitted_at timestamp (not
+    # just one via sort_by | last) and picks the one requiring attention if
+    # any do, so a blocking review is never discarded in favor of a clean
+    # one that happens to share the same second-resolution timestamp
+    # (fresh evidence from PR #1490 finding 3788008326). Truncation happens
+    # inside jq (codepoint slice), not via a piped `head`, so a long body
+    # cannot trigger SIGPIPE on jq under `set -o pipefail`.
+    codex_select_review_evidence "$REVIEW_TMPFILE"
+    REVIEW_BODY="$SELECTED_REVIEW_BODY"
+    REVIEW_TIME="$SELECTED_REVIEW_TIME"
   else
     REVIEW_ERR=$(cat "$REVIEW_STDERR")
     rm -f "$REVIEW_STDERR" "$REVIEW_TMPFILE"
@@ -913,13 +954,16 @@ fi
 ASYNC_REVIEW_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
   2>/dev/null \
-  | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
+  | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
+      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:((.body // "") | .[0:5000])} end' \
   > "$ASYNC_REVIEW_TMPFILE" 2>/dev/null; then
-  # Truncation happens inside jq (codepoint slice) to avoid SIGPIPE on jq
-  # under `set -o pipefail` (see rationale above the main-loop equivalent).
-  ASYNC_REVIEW_BODY=$(jq -r '(.body // empty) | .[0:5000]' "$ASYNC_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
-  ASYNC_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads the same pre-validated tmpfile as the body extraction above; empty time is not a failure
+  # Selects every review tied at the latest timestamp and picks the one
+  # requiring attention, if any (see rationale above the main-loop
+  # equivalent). Truncation happens inside jq (codepoint slice) to avoid
+  # SIGPIPE on jq under `set -o pipefail`.
+  codex_select_review_evidence "$ASYNC_REVIEW_TMPFILE"
+  ASYNC_REVIEW_BODY="$SELECTED_REVIEW_BODY"
+  ASYNC_REVIEW_TIME="$SELECTED_REVIEW_TIME"
 else
   rm -f "$ASYNC_REVIEW_TMPFILE"
   echo "VERDICT: TIMED_OUT — failed to fetch Codex PR reviews during async grace period (treated as unavailable)"
@@ -1000,14 +1044,16 @@ if [ -n "$ASYNC_BOT_RESPONSE" ]; then
     ASYNC_FINAL_REVIEW_TMPFILE=$(mktemp)
     if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
       2>/dev/null \
-      | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
+      | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
+          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:((.body // "") | .[0:5000])} end' \
       > "$ASYNC_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
-      # Truncation happens inside jq (codepoint slice) to avoid SIGPIPE on
-      # jq under `set -o pipefail` (see rationale above the main-loop
-      # equivalent).
-      ASYNC_FINAL_REVIEW_BODY=$(jq -r '(.body // empty) | .[0:5000]' "$ASYNC_FINAL_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
-      ASYNC_FINAL_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_FINAL_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads the same pre-validated tmpfile as the body extraction above; empty time is not a failure
+      # Selects every review tied at the latest timestamp and picks the one
+      # requiring attention, if any (see rationale above the main-loop
+      # equivalent). Truncation happens inside jq (codepoint slice) to
+      # avoid SIGPIPE on jq under `set -o pipefail`.
+      codex_select_review_evidence "$ASYNC_FINAL_REVIEW_TMPFILE"
+      ASYNC_FINAL_REVIEW_BODY="$SELECTED_REVIEW_BODY"
+      ASYNC_FINAL_REVIEW_TIME="$SELECTED_REVIEW_TIME"
     else
       rm -f "$ASYNC_FINAL_REVIEW_TMPFILE"
       echo "VERDICT: TIMED_OUT — failed to fetch Codex PR reviews after async acknowledgement (treated as unavailable)"
@@ -1126,13 +1172,16 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
   ASYNC_REACTION_FINAL_REVIEW_TMPFILE=$(mktemp)
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>/dev/null \
-    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | sort_by(.submitted_at) | last | {created_at:(.submitted_at // ""), body:(.body // "")}' \
+    | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:((.body // "") | .[0:5000])} end' \
     > "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
-    # Truncation happens inside jq (codepoint slice) to avoid SIGPIPE on jq
-    # under `set -o pipefail` (see rationale above the main-loop equivalent).
-    ASYNC_REACTION_FINAL_REVIEW_BODY=$(jq -r '(.body // empty) | .[0:5000]' "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads a tmpfile already validated as parseable JSON by the preceding gh|jq call; empty body means no evidence yet, not a failure, and is checked downstream via [ -n ]
-    ASYNC_REACTION_FINAL_REVIEW_TIME=$(jq -r '.created_at // empty' "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE")  # workflow-shell-guard: allow SH003 - reads the same pre-validated tmpfile as the body extraction above; empty time is not a failure
+    # Selects every review tied at the latest timestamp and picks the one
+    # requiring attention, if any (see rationale above the main-loop
+    # equivalent). Truncation happens inside jq (codepoint slice) to avoid
+    # SIGPIPE on jq under `set -o pipefail`.
+    codex_select_review_evidence "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE"
+    ASYNC_REACTION_FINAL_REVIEW_BODY="$SELECTED_REVIEW_BODY"
+    ASYNC_REACTION_FINAL_REVIEW_TIME="$SELECTED_REVIEW_TIME"
   else
     rm -f "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE"
     echo "VERDICT: TIMED_OUT — failed to fetch Codex PR reviews after async reaction (treated as unavailable)"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -396,10 +396,15 @@ codex_strip_quoted_spans() {
 # misclassified it as negated (fresh evidence from PR #1490 finding
 # 3793299512). Stripped entirely (not just skipped) so the leftover "not"
 # cannot accidentally trigger a match against some OTHER target word
-# later in the same clause.
+# later in the same clause. Every letter is bracket-expanded for both
+# cases (rather than relying on sed's `I` substitution flag, whose
+# support varies across sed implementations), since the original
+# [Nn]ot/[Oo]nly form only covered Title-Case and lowercase, not a fully
+# uppercase emphasis form like "NOT ONLY" (fresh evidence from PR #1490
+# finding 3793330278, a followup to 3793299512).
 codex_strip_not_only_idiom() {
   local body="$1"
-  sed -E 's/[Nn]ot[[:space:]]+[Oo]nly//g' <<< "$body"
+  sed -E 's/[Nn][Oo][Tt][[:space:]]+[Oo][Nn][Ll][Yy]//g' <<< "$body"
 }
 
 codex_response_is_approved() {

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -239,7 +239,7 @@ codex_response_is_usage_limit() {
 
 codex_response_is_environment_error() {
   local response="$1"
-  printf '%s\n' "$response" | grep -qiE "(to[[:space:]]+use[[:space:]]+codex[[:space:]]+here,[[:space:]]+create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo|create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo)"
+  printf '%s\n' "$response" | grep -qiE "to[[:space:]]+use[[:space:]]+codex[[:space:]]+here,[[:space:]]+create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo"
 }
 
 codex_return_usage_limit() {

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -342,9 +342,19 @@ CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t 
 # 3790062089). The reverse-order alternative has been removed; the
 # forward-only match plus the bare-verb addition covers the original
 # "cannot approve" case without this false-positive class.
+#
+# The [^.!?]* span only excluded sentence terminators, not clause
+# separators, so an unrelated negation in an EARLIER clause of the SAME
+# sentence still spanned into a LATER, unrelated clean clause — e.g.
+# "Tests are not required for this documentation-only change; looks
+# good" has "not" in one semicolon-joined clause and "looks good" in a
+# separate one, but the span crossed the semicolon and matched anyway
+# (PR #1490 finding 3790122061, the same class of gap as 3790062089
+# above but on the forward-order side rather than the removed reverse
+# alternative). The character class now also excludes `;`.
 CODEX_NEGATED_APPROVAL_TARGET_WORDS='(approve[ds]?|lgtm|look(s|ing)?[[:space:]]+good|no[[:space:]]+blocking[[:space:]]+issues?|didn.t find[[:space:]]+any major[[:space:]]+issues)'
 CODEX_NEGATION_WORDS='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|does[[:space:]]+not|doesn.t|never)'
-CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?]*${CODEX_NEGATED_APPROVAL_TARGET_WORDS}"
+CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;]*${CODEX_NEGATED_APPROVAL_TARGET_WORDS}"
 
 codex_response_is_blocking() {
   local body="$1"
@@ -356,7 +366,19 @@ codex_response_is_approved() {
   if grep -qiE "$CODEX_NEGATED_APPROVAL_PATTERN" <<< "$body"; then
     return 1
   fi
-  grep -qiE "$CODEX_APPROVAL_PATTERN" <<< "$body"
+  # Strip quoted spans (text between a pair of straight double-quotes)
+  # before matching CODEX_APPROVAL_PATTERN: a SHA-pinned review can QUOTE
+  # a clean phrase while REJECTING it (e.g. `The documented bot response
+  # "No blocking issues found" is inaccurate and should be corrected`),
+  # and CODEX_APPROVAL_PATTERN's substring match can't distinguish
+  # quotation/discussion of a phrase from an assertion of it. Removing
+  # quoted text first means only a genuinely UNQUOTED approval phrase can
+  # still match; a real approval elsewhere in the same response (outside
+  # any quotes) is unaffected (fresh evidence from PR #1490 finding
+  # 3790122058).
+  local unquoted_body
+  unquoted_body=$(sed -E 's/"[^"]*"//g' <<< "$body")
+  grep -qiE "$CODEX_APPROVAL_PATTERN" <<< "$unquoted_body"
 }
 
 # Ranks a response into one of four priority tiers, highest wins on a

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -389,10 +389,24 @@ CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*${CODEX_NEGATED_
 # strips GitHub-flavored Markdown blockquote LINES (a line starting with
 # `>`, optionally indented): a review discussing a quoted clean phrase via
 # blockquote syntax rather than straight/backtick quotes was likewise
-# unprotected (fresh evidence from PR #1490 finding 3793367885).
+# unprotected (fresh evidence from PR #1490 finding 3793367885). Also
+# strips single-quoted spans ('...') — the fourth quoting style found
+# unprotected after straight-quote, backtick, and blockquote (fresh
+# evidence from PR #1490 finding 3793410331). Single quotes need a
+# stricter boundary than the other three styles: a bare `'[^']*'` would
+# also match the space between two UNRELATED apostrophes in contractions
+# (e.g. "isn't approved, but it's fine" — a naive strip would treat the
+# apostrophe in "isn't" and the apostrophe in "it's" as an opening/closing
+# pair and delete everything between them, including "approved"). The
+# opening quote is required to be preceded by whitespace-or-start-of-line
+# and the closing quote by whitespace/punctuation-or-end, which a
+# contraction's apostrophe never satisfies (the letters on both sides of
+# it are word characters, not whitespace), so genuine quotation is
+# distinguished from an apostrophe embedded in a word.
 codex_strip_quoted_spans() {
   local body="$1"
-  sed -E 's/"[^"]*"//g; s/`[^`]*`//g; /^[[:space:]]*>/d' <<< "$body"
+  local sq="'"
+  sed -E "s/\"[^\"]*\"//g; s/\`[^\`]*\`//g; /^[[:space:]]*>/d; s/(^|[[:space:]])${sq}[^${sq}]*${sq}([[:space:].,;:!?]|\$)/\\1\\2/g" <<< "$body"
 }
 
 codex_response_is_blocking() {

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -340,7 +340,24 @@ codex_response_reviews_current_head() {
 # (main poll, async grace, async-final, async-reaction-final) uses the exact
 # same rules. See "Verdict parsing" header comment for the rationale behind
 # each marker.
-CODEX_BLOCKING_PATTERN='(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)'
+#
+# (should|must)[[:space:]]+not[[:space:]]+be[[:space:]]+merged targets an
+# explicit merge-refusal verdict that the negated-approval mechanism
+# below (CODEX_NEGATED_APPROVAL_PATTERN) cannot catch: that mechanism
+# only fires when a negation word is followed by one of a fixed list of
+# approval-vocabulary target words (approve[ds]?, lgtm, looks good, etc.)
+# within the same sentence, but a response like "This looks good at
+# first glance, but this should not be merged until tests pass." negates
+# "merged" — a word outside that target list entirely — so the negated-
+# approval check never matches and the earlier "looks good" phrase alone
+# wins, returning APPROVED (fresh evidence from PR #1490 finding
+# 3798880969, a followup to the "don't approve" fix that closed the
+# adjacent-to-an-approval-word case but not this direct-merge-refusal
+# case). Checked here, in CODEX_BLOCKING_PATTERN (evaluated first in the
+# verdict-parsing chain, before approval), an explicit refusal to merge
+# is recognized as blocking outright regardless of what an earlier
+# hedge phrase in the same response says.
+CODEX_BLOCKING_PATTERN='(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|(should|must)[[:space:]]+not[[:space:]]+be[[:space:]]+merged|❌)'
 # \b word boundaries around the positive approval words: without them,
 # "approved" as a bare substring matched inside prefixed negative forms
 # like "unapproved" or "disapproved" (no space/word-break before

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -737,11 +737,18 @@ codex_scan_comment_evidence() {
 # for a single binary tier — a scan that only distinguishes "requires
 # attention" from "clean" cannot correctly rank two tied responses that
 # are both "requires attention" but at different severities.
-# Sets: SELECTED_REVIEW_BODY, SELECTED_REVIEW_TIME.
+# Sets: SELECTED_REVIEW_BODY, SELECTED_REVIEW_TIME, SELECTED_REVIEW_STATE.
+# SELECTED_REVIEW_STATE is GitHub's own structured review state
+# (APPROVED/CHANGES_REQUESTED/COMMENTED/PENDING/DISMISSED, or empty if
+# the reviews-endpoint jq query behind $reviews_file predates this field
+# — a legacy caller passing an older tmpfile format degrades to empty
+# state rather than failing) — see codex_combine_terminal_evidence for
+# why this is threaded separately from body-text classification.
 codex_select_review_evidence() {
   local reviews_file="$1"
   SELECTED_REVIEW_BODY=""
   SELECTED_REVIEW_TIME=""
+  SELECTED_REVIEW_STATE=""
   # Presence is tracked via an explicit found-flag, not by checking
   # whether the selected body string is non-empty — a winning review's
   # body can legitimately be empty (see
@@ -750,15 +757,17 @@ codex_select_review_evidence() {
   # reintroduce that exact bug here.
   local have_selection=0
   local best_priority=-1
-  local line created_at body priority
+  local line created_at body state priority
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     created_at=$(printf '%s' "$line" | jq -r '.created_at // empty')  # workflow-shell-guard: allow SH003 - $line is a compact JSON object already validated parseable by the preceding jq -sc call; empty is a normal absent-field case, not a failure
     body=$(printf '%s' "$line" | jq -r '.body // empty')  # workflow-shell-guard: allow SH003 - same pre-validated $line as above; empty body is not a failure
+    state=$(printf '%s' "$line" | jq -r '.state // empty')  # workflow-shell-guard: allow SH003 - same pre-validated $line as above; empty state is not a failure
     priority=$(codex_response_priority "$body")
     if [ "$have_selection" -eq 0 ] || [ "$priority" -gt "$best_priority" ]; then
       SELECTED_REVIEW_BODY="$body"
       SELECTED_REVIEW_TIME="$created_at"
+      SELECTED_REVIEW_STATE="$state"
       best_priority="$priority"
       have_selection=1
     fi
@@ -790,21 +799,37 @@ codex_select_review_evidence() {
 # never competes with anything.
 #
 # Sets: COMBINED_BODY, COMBINED_TIME, COMBINED_SOURCE ("review", "comment",
-# or "" if no evidence at all). LABEL is used only for INFO logging.
-# COMMENT_LATEST_IS_TERMINAL (8th arg) gates the ancillary-override check
-# below: it must never fire when the "latest ancillary comment" IS
-# actually the terminal comment itself, not a genuinely separate ancillary
-# one (see the comment above that check).
+# or "" if no evidence at all), COMBINED_REVIEW_STATE. LABEL is used only
+# for INFO logging. COMMENT_LATEST_IS_TERMINAL (8th arg) gates the
+# ancillary-override check below: it must never fire when the "latest
+# ancillary comment" IS actually the terminal comment itself, not a
+# genuinely separate ancillary one (see the comment above that check).
+#
+# COMBINED_REVIEW_STATE carries GitHub's own structured review state
+# (e.g. CHANGES_REQUESTED) for the caller's verdict-parsing chain to
+# check ahead of/alongside free-text classification — relying solely on
+# body-text parsing (codex_response_is_blocking/is_approved) let a
+# submitted review with state CHANGES_REQUESTED but ambiguous or
+# clean-sounding body wording ("Looks good overall, but see the note
+# below.") fall through to the unrecognized-format safe-fail or even a
+# false APPROVED instead of being recognized as blocking on GitHub's own
+# authoritative signal (fresh evidence from PR #1490 finding 3796396391).
+# It is set ONLY when review_body/review_time (the actual submitted
+# review, from the reviews endpoint) is the winning evidence — never when
+# a SHA-pinned terminal COMMENT wins instead (comments have no review
+# state) or when an ancillary comment later overrides the winner below.
 codex_combine_terminal_evidence() {
   local label="$1"
   local comment_terminal_body="$2" comment_terminal_time="$3"
   local comment_latest_body="$4" comment_latest_time="$5"
   local review_body="$6" review_time="$7"
   local comment_latest_is_terminal="$8"
+  local review_state="$9"
 
   COMBINED_BODY=""
   COMBINED_TIME=""
   COMBINED_SOURCE=""
+  COMBINED_REVIEW_STATE=""
 
   if [ -n "$comment_terminal_body" ]; then
     COMBINED_BODY="$comment_terminal_body"
@@ -827,12 +852,14 @@ codex_combine_terminal_evidence() {
         COMBINED_BODY="$review_body"
         COMBINED_TIME="$review_time"
         COMBINED_SOURCE="review"
+        COMBINED_REVIEW_STATE="$review_state"
         echo "INFO: $label detected via PR reviews endpoint (supersedes SHA-pinned comment)"
       fi
     else
       COMBINED_BODY="$review_body"
       COMBINED_TIME="$review_time"
       COMBINED_SOURCE="review"
+      COMBINED_REVIEW_STATE="$review_state"
       echo "INFO: $label detected via PR reviews endpoint"
     fi
   fi
@@ -879,32 +906,41 @@ codex_combine_terminal_evidence() {
   # immediate-termination contract (fresh evidence from PR #1490 finding
   # 3790062091, a followup to 3789928786/3789992794).
   if [ "$comment_latest_is_terminal" -eq 0 ] && [ -n "$comment_latest_body" ] && codex_response_is_usage_limit "$comment_latest_body"; then
-    if [ -n "$COMBINED_SOURCE" ] && codex_response_is_blocking "$COMBINED_BODY"; then
+    if [ -n "$COMBINED_SOURCE" ] && { [ "$COMBINED_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$COMBINED_BODY"; }; then
       # Blocking terminal/review evidence always wins outright — it is
       # never discarded by a usage-limit notice, regardless of timing, so
       # an actionable finding can never be hidden behind an "unavailable"
       # verdict (fresh evidence from PR #1490 finding 3787943162; Protocol
-      # 93 requires blocking evidence to never be silently discarded).
+      # 93 requires blocking evidence to never be silently discarded). A
+      # winning review's own CHANGES_REQUESTED state counts as blocking
+      # here too, alongside free-text detection, so a same-fetch
+      # usage-limit notice can't silently override a structurally
+      # blocking review whose body text happens to be ambiguous (fresh
+      # evidence from PR #1490 finding 3796396391).
       :
     else
       COMBINED_BODY="$comment_latest_body"
       COMBINED_TIME="$comment_latest_time"
       COMBINED_SOURCE="comment"
+      COMBINED_REVIEW_STATE=""
       echo "INFO: $label usage-limit notice takes immediate precedence over terminal/review evidence, including same-fetch evidence"
     fi
   elif [ "$comment_latest_is_terminal" -eq 0 ] && [ -n "$comment_latest_body" ] && codex_response_is_environment_error "$comment_latest_body"; then
-    if [ -n "$COMBINED_SOURCE" ] && codex_response_is_blocking "$COMBINED_BODY"; then
+    if [ -n "$COMBINED_SOURCE" ] && { [ "$COMBINED_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$COMBINED_BODY"; }; then
       # Blocking terminal/review evidence always wins outright — it is
       # never discarded by an environment-setup error, regardless of
       # timing, so an actionable finding can never be hidden behind an
       # "unavailable" verdict (fresh evidence from PR #1490 finding
       # 3787943162; Protocol 93 requires blocking evidence to never be
-      # silently discarded).
+      # silently discarded). A winning review's own CHANGES_REQUESTED
+      # state counts as blocking here too (fresh evidence from PR #1490
+      # finding 3796396391).
       :
     elif [ -z "$COMBINED_TIME" ] || ! codex_select_terminal_evidence "$comment_latest_body" "$comment_latest_time" "$COMBINED_BODY" "$COMBINED_TIME"; then
       COMBINED_BODY="$comment_latest_body"
       COMBINED_TIME="$comment_latest_time"
       COMBINED_SOURCE="comment"
+      COMBINED_REVIEW_STATE=""
       echo "INFO: $label environment-setup error retained over non-newer terminal/review evidence"
     fi
   fi
@@ -1131,7 +1167,7 @@ while true; do
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>"$REVIEW_STDERR" \
     | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // "")} end' \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
     > "$REVIEW_TMPFILE" 2>"$REVIEW_STDERR"; then
     # Selects every review tied at the latest submitted_at timestamp (not
     # just one via sort_by | last) and picks the one requiring attention if
@@ -1147,6 +1183,7 @@ while true; do
     codex_select_review_evidence "$REVIEW_TMPFILE"
     REVIEW_BODY="$SELECTED_REVIEW_BODY"
     REVIEW_TIME="$SELECTED_REVIEW_TIME"
+    REVIEW_STATE="$SELECTED_REVIEW_STATE"
   else
     REVIEW_ERR=$(cat "$REVIEW_STDERR")
     rm -f "$REVIEW_STDERR" "$REVIEW_TMPFILE"
@@ -1159,7 +1196,7 @@ while true; do
   codex_combine_terminal_evidence "bot response" \
     "$COMMENT_TERMINAL_BODY" "$COMMENT_TERMINAL_TIME" \
     "$COMMENT_LATEST_BODY" "$COMMENT_LATEST_TIME" \
-    "$REVIEW_BODY" "$REVIEW_TIME" "$COMMENT_LATEST_IS_TERMINAL"
+    "$REVIEW_BODY" "$REVIEW_TIME" "$COMMENT_LATEST_IS_TERMINAL" "$REVIEW_STATE"
   BOT_RESPONSE="$COMBINED_BODY"
   BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
   # Captured immediately after combine, before any intervening call could
@@ -1169,6 +1206,11 @@ while true; do
   # verdict parsing and hit the unrecognized-format safe-fail instead of
   # being treated as "no response at all").
   BOT_RESPONSE_TIME="$COMBINED_TIME"
+  # Captured alongside COMBINED_TIME for the same reason — GitHub's
+  # structured review state, non-empty only when the winning evidence is
+  # an actual submitted review (not a SHA-pinned terminal comment, which
+  # has no review state).
+  BOT_RESPONSE_REVIEW_STATE="$COMBINED_REVIEW_STATE"
   # BOT_RESPONSE_FULL (untruncated) is what every classifier below matches
   # against — a truncated copy could cut off a blocking marker that
   # appears after the cutoff in a long root comment, letting the response
@@ -1240,12 +1282,17 @@ while true; do
     # "no blocking issues". This avoids false positives without line-level filtering
     # (which would risk missing a genuine marker on the same line as a negation).
 
-    if [ "$BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$BOT_RESPONSE_FULL"; then
+    if [ "$BOT_RESPONSE_SOURCE" = "review" ] && { [ "$BOT_RESPONSE_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$BOT_RESPONSE_FULL"; }; then
       # Blocking is checked first, ahead of usage-limit: a terminal/review
       # finding whose text happens to mention "usage limit" as part of an
       # actionable finding (e.g. flagging stale docs that describe it) must
       # not be misrouted to an unavailable verdict before the blocking
       # classifier runs (fresh evidence from PR #1490 finding 3788078191).
+      # A submitted review's own CHANGES_REQUESTED state short-circuits
+      # straight to blocking here, ahead of free-text classification, so a
+      # review GitHub itself marked as requesting changes is never
+      # misclassified from its body wording alone (fresh evidence from PR
+      # #1490 finding 3796396391).
       echo "VERDICT: NEEDS_REVISION"
       echo "---BEGIN BOT RESPONSE---"
       echo "$BOT_RESPONSE"
@@ -1416,7 +1463,7 @@ ASYNC_REVIEW_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
   2>/dev/null \
   | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // "")} end' \
+      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
   > "$ASYNC_REVIEW_TMPFILE" 2>/dev/null; then
   # Selects every review tied at the latest timestamp and picks the one
   # requiring attention, if any (see rationale above the main-loop
@@ -1426,6 +1473,7 @@ if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
   codex_select_review_evidence "$ASYNC_REVIEW_TMPFILE"
   ASYNC_REVIEW_BODY="$SELECTED_REVIEW_BODY"
   ASYNC_REVIEW_TIME="$SELECTED_REVIEW_TIME"
+  ASYNC_REVIEW_STATE="$SELECTED_REVIEW_STATE"
 else
   rm -f "$ASYNC_REVIEW_TMPFILE"
   echo "VERDICT: TIMED_OUT — failed to fetch Codex PR reviews during async grace period (treated as unavailable)"
@@ -1436,12 +1484,14 @@ rm -f "$ASYNC_REVIEW_TMPFILE"
 codex_combine_terminal_evidence "async-arrival bot response" \
   "$COMMENT_TERMINAL_BODY" "$COMMENT_TERMINAL_TIME" \
   "$COMMENT_LATEST_BODY" "$COMMENT_LATEST_TIME" \
-  "$ASYNC_REVIEW_BODY" "$ASYNC_REVIEW_TIME" "$COMMENT_LATEST_IS_TERMINAL"
+  "$ASYNC_REVIEW_BODY" "$ASYNC_REVIEW_TIME" "$COMMENT_LATEST_IS_TERMINAL" "$ASYNC_REVIEW_STATE"
 ASYNC_BOT_RESPONSE="$COMBINED_BODY"
 ASYNC_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
 # Captured before any intervening call could touch COMBINED_TIME (see
 # rationale above the main-loop equivalent).
 ASYNC_BOT_RESPONSE_TIME="$COMBINED_TIME"
+# See rationale above the main-loop equivalent (BOT_RESPONSE_REVIEW_STATE).
+ASYNC_BOT_RESPONSE_REVIEW_STATE="$COMBINED_REVIEW_STATE"
 # Untruncated copy used for classification below (see rationale above the
 # main-loop equivalent — a truncated copy could cut off a blocking marker
 # in a long root comment).
@@ -1458,7 +1508,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
   # Apply the same three-path verdict parsing as the main poll loop.
   # Blocking is checked first, ahead of usage-limit (see rationale above
   # the main-loop equivalent).
-  if [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_BOT_RESPONSE_FULL"; then
+  if [ "$ASYNC_BOT_RESPONSE_SOURCE" = "review" ] && { [ "$ASYNC_BOT_RESPONSE_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$ASYNC_BOT_RESPONSE_FULL"; }; then
     echo "VERDICT: NEEDS_REVISION"
     echo "---BEGIN BOT RESPONSE---"
     echo "$ASYNC_BOT_RESPONSE"
@@ -1518,7 +1568,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
     if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
       2>/dev/null \
       | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // "")} end' \
+          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
       > "$ASYNC_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
       # Selects every review tied at the latest timestamp and picks the one
       # requiring attention, if any (see rationale above the main-loop
@@ -1528,6 +1578,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
       codex_select_review_evidence "$ASYNC_FINAL_REVIEW_TMPFILE"
       ASYNC_FINAL_REVIEW_BODY="$SELECTED_REVIEW_BODY"
       ASYNC_FINAL_REVIEW_TIME="$SELECTED_REVIEW_TIME"
+      ASYNC_FINAL_REVIEW_STATE="$SELECTED_REVIEW_STATE"
     else
       rm -f "$ASYNC_FINAL_REVIEW_TMPFILE"
       echo "VERDICT: TIMED_OUT — failed to fetch Codex PR reviews after async acknowledgement (treated as unavailable)"
@@ -1538,12 +1589,14 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
     codex_combine_terminal_evidence "final async bot response" \
       "$COMMENT_TERMINAL_BODY" "$COMMENT_TERMINAL_TIME" \
       "$COMMENT_LATEST_BODY" "$COMMENT_LATEST_TIME" \
-      "$ASYNC_FINAL_REVIEW_BODY" "$ASYNC_FINAL_REVIEW_TIME" "$COMMENT_LATEST_IS_TERMINAL"
+      "$ASYNC_FINAL_REVIEW_BODY" "$ASYNC_FINAL_REVIEW_TIME" "$COMMENT_LATEST_IS_TERMINAL" "$ASYNC_FINAL_REVIEW_STATE"
     ASYNC_FINAL_BOT_RESPONSE="$COMBINED_BODY"
     ASYNC_FINAL_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
     # Captured before any intervening call could touch COMBINED_TIME (see
     # rationale above the main-loop equivalent).
     ASYNC_FINAL_BOT_RESPONSE_TIME="$COMBINED_TIME"
+    # See rationale above the main-loop equivalent (BOT_RESPONSE_REVIEW_STATE).
+    ASYNC_FINAL_BOT_RESPONSE_REVIEW_STATE="$COMBINED_REVIEW_STATE"
     # Untruncated copy used for classification below (see rationale above
     # the main-loop equivalent).
     ASYNC_FINAL_BOT_RESPONSE_FULL="$ASYNC_FINAL_BOT_RESPONSE"
@@ -1557,7 +1610,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
       codex_require_current_head
       # Blocking is checked first, ahead of usage-limit (see rationale
       # above the main-loop equivalent).
-      if [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_FINAL_BOT_RESPONSE_FULL"; then
+      if [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && { [ "$ASYNC_FINAL_BOT_RESPONSE_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$ASYNC_FINAL_BOT_RESPONSE_FULL"; }; then
         echo "VERDICT: NEEDS_REVISION"
         echo "---BEGIN BOT RESPONSE---"
         echo "$ASYNC_FINAL_BOT_RESPONSE"
@@ -1657,7 +1710,7 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>/dev/null \
     | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // "")} end' \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
     > "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
     # Selects every review tied at the latest timestamp and picks the one
     # requiring attention, if any (see rationale above the main-loop
@@ -1667,6 +1720,7 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
     codex_select_review_evidence "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE"
     ASYNC_REACTION_FINAL_REVIEW_BODY="$SELECTED_REVIEW_BODY"
     ASYNC_REACTION_FINAL_REVIEW_TIME="$SELECTED_REVIEW_TIME"
+    ASYNC_REACTION_FINAL_REVIEW_STATE="$SELECTED_REVIEW_STATE"
   else
     rm -f "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE"
     echo "VERDICT: TIMED_OUT — failed to fetch Codex PR reviews after async reaction (treated as unavailable)"
@@ -1677,12 +1731,14 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
   codex_combine_terminal_evidence "final async reaction bot response" \
     "$COMMENT_TERMINAL_BODY" "$COMMENT_TERMINAL_TIME" \
     "$COMMENT_LATEST_BODY" "$COMMENT_LATEST_TIME" \
-    "$ASYNC_REACTION_FINAL_REVIEW_BODY" "$ASYNC_REACTION_FINAL_REVIEW_TIME" "$COMMENT_LATEST_IS_TERMINAL"
+    "$ASYNC_REACTION_FINAL_REVIEW_BODY" "$ASYNC_REACTION_FINAL_REVIEW_TIME" "$COMMENT_LATEST_IS_TERMINAL" "$ASYNC_REACTION_FINAL_REVIEW_STATE"
   ASYNC_REACTION_FINAL_BOT_RESPONSE="$COMBINED_BODY"
   ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
   # Captured before any intervening call could touch COMBINED_TIME (see
   # rationale above the main-loop equivalent).
   ASYNC_REACTION_FINAL_BOT_RESPONSE_TIME="$COMBINED_TIME"
+  # See rationale above the main-loop equivalent (BOT_RESPONSE_REVIEW_STATE).
+  ASYNC_REACTION_FINAL_BOT_RESPONSE_REVIEW_STATE="$COMBINED_REVIEW_STATE"
   # Untruncated copy used for classification below (see rationale above
   # the main-loop equivalent).
   ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL="$ASYNC_REACTION_FINAL_BOT_RESPONSE"
@@ -1695,7 +1751,7 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
     codex_require_current_head
     # Blocking is checked first, ahead of usage-limit (see rationale above
     # the main-loop equivalent).
-    if [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_blocking "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL"; then
+    if [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] && { [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL"; }; then
       echo "VERDICT: NEEDS_REVISION"
       echo "---BEGIN BOT RESPONSE---"
       echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -581,7 +581,20 @@ codex_response_is_approved() {
 # from PR #1490 finding 3789521036).
 codex_response_priority() {
   local body="$1"
-  if codex_response_is_blocking "$body"; then
+  local state="${2:-}"
+  # A structurally CHANGES_REQUESTED review ranks at the blocking tier
+  # regardless of its body text, mirroring the verdict-parsing chain's own
+  # CHANGES_REQUESTED short-circuit. Without this, two current-head
+  # reviews tied at the same second — one genuinely clean, one
+  # CHANGES_REQUESTED but whose body ALSO happens to contain an approval
+  # phrase like "Looks good" — both scored priority 0 from body text
+  # alone, so whichever the API happened to return first won the tie
+  # (since this scan only replaces the selection on a STRICTLY greater
+  # priority): if the clean review was returned first, the
+  # CHANGES_REQUESTED review's state was silently discarded and never
+  # even reached the caller's CHANGES_REQUESTED check, producing a false
+  # APPROVED (fresh evidence from PR #1490 finding 3796982553).
+  if [ "$state" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$body"; then
     printf '3\n'
   elif codex_response_is_usage_limit "$body" || codex_response_is_environment_error "$body"; then
     printf '1\n'
@@ -763,7 +776,7 @@ codex_select_review_evidence() {
     created_at=$(printf '%s' "$line" | jq -r '.created_at // empty')  # workflow-shell-guard: allow SH003 - $line is a compact JSON object already validated parseable by the preceding jq -sc call; empty is a normal absent-field case, not a failure
     body=$(printf '%s' "$line" | jq -r '.body // empty')  # workflow-shell-guard: allow SH003 - same pre-validated $line as above; empty body is not a failure
     state=$(printf '%s' "$line" | jq -r '.state // empty')  # workflow-shell-guard: allow SH003 - same pre-validated $line as above; empty state is not a failure
-    priority=$(codex_response_priority "$body")
+    priority=$(codex_response_priority "$body" "$state")
     if [ "$have_selection" -eq 0 ] || [ "$priority" -gt "$best_priority" ]; then
       SELECTED_REVIEW_BODY="$body"
       SELECTED_REVIEW_TIME="$created_at"
@@ -1162,12 +1175,25 @@ while true; do
   # Also check PR reviews — Codex posts findings as a GitHub Review object
   # (via pulls/{PR}/reviews), not as a plain PR comment. Combining both sources
   # ensures we detect findings immediately instead of waiting for a timeout.
+  # A review with state DISMISSED is excluded here rather than merely
+  # deprioritized: GitHub itself no longer treats a dismissed review as
+  # active evidence, but this script's selection was still choosing it on
+  # an idempotent rerun — the SHA/timestamp filters above have no reason
+  # to exclude it (dismissal doesn't change commit_id or submitted_at),
+  # so a dismissed review's now-stale body text (e.g. "No blocking issues
+  # found", recorded before it was dismissed) could still win the
+  # tie-break and be classified as fresh terminal approval evidence
+  # (fresh evidence from PR #1490 finding 3796982554). Filtering it out at
+  # the source, rather than only gating the approval branch downstream,
+  # also prevents a dismissed review's state or body from winning
+  # codex_select_review_evidence's priority tie-break for ANY verdict, not
+  # just approval.
   REVIEW_STDERR=$(mktemp)
   REVIEW_TMPFILE=$(mktemp)
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>"$REVIEW_STDERR" \
     | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
     > "$REVIEW_TMPFILE" 2>"$REVIEW_STDERR"; then
     # Selects every review tied at the latest submitted_at timestamp (not
     # just one via sort_by | last) and picks the one requiring attention if
@@ -1463,7 +1489,7 @@ ASYNC_REVIEW_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
   2>/dev/null \
   | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
+      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
   > "$ASYNC_REVIEW_TMPFILE" 2>/dev/null; then
   # Selects every review tied at the latest timestamp and picks the one
   # requiring attention, if any (see rationale above the main-loop
@@ -1568,7 +1594,7 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
     if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
       2>/dev/null \
       | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
+          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
       > "$ASYNC_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
       # Selects every review tied at the latest timestamp and picks the one
       # requiring attention, if any (see rationale above the main-loop
@@ -1710,7 +1736,7 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>/dev/null \
     | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
     > "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
     # Selects every review tied at the latest timestamp and picks the one
     # requiring attention, if any (see rationale above the main-loop

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -453,7 +453,15 @@ codex_combine_terminal_evidence() {
     echo "INFO: $label detected via SHA-pinned PR comment"
   fi
 
-  if [ -n "$review_body" ]; then
+  # Presence is checked via review_time, not review_body: a genuine
+  # selected review is guaranteed a non-empty submitted_at by the
+  # review-poll jq queries' filter, but its body CAN legitimately be
+  # empty. Checking review_body would treat an empty-bodied tied review
+  # as absent, letting a clean terminal comment win the tie-break by
+  # default even though codex_response_requires_attention correctly
+  # classifies an empty body as an unrecognized response requiring
+  # attention (fresh evidence from PR #1490 finding 3788118857).
+  if [ -n "$review_time" ]; then
     if [ "$COMBINED_SOURCE" = "review" ]; then
       if codex_select_terminal_evidence "$COMBINED_BODY" "$COMBINED_TIME" "$review_body" "$review_time"; then
         COMBINED_BODY="$review_body"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -774,15 +774,19 @@ while true; do
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>"$REVIEW_STDERR" \
     | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:((.body // "") | .[0:5000])} end' \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // "")} end' \
     > "$REVIEW_TMPFILE" 2>"$REVIEW_STDERR"; then
     # Selects every review tied at the latest submitted_at timestamp (not
     # just one via sort_by | last) and picks the one requiring attention if
     # any do, so a blocking review is never discarded in favor of a clean
     # one that happens to share the same second-resolution timestamp
-    # (fresh evidence from PR #1490 finding 3788008326). Truncation happens
-    # inside jq (codepoint slice), not via a piped `head`, so a long body
-    # cannot trigger SIGPIPE on jq under `set -o pipefail`.
+    # (fresh evidence from PR #1490 finding 3788008326). The body is NOT
+    # sliced here — classification must see the complete review body (fresh
+    # evidence from PR #1490 finding 3789679344: slicing here loses content
+    # past the cutoff before BOT_RESPONSE_FULL is ever set, defeating the
+    # classify-full/truncate-only-for-display contract below). No SIGPIPE
+    # risk: jq redirects to a temp file (`>`), not to a piped consumer that
+    # could early-close its read end.
     codex_select_review_evidence "$REVIEW_TMPFILE"
     REVIEW_BODY="$SELECTED_REVIEW_BODY"
     REVIEW_TIME="$SELECTED_REVIEW_TIME"
@@ -1044,12 +1048,13 @@ ASYNC_REVIEW_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
   2>/dev/null \
   | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:((.body // "") | .[0:5000])} end' \
+      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // "")} end' \
   > "$ASYNC_REVIEW_TMPFILE" 2>/dev/null; then
   # Selects every review tied at the latest timestamp and picks the one
   # requiring attention, if any (see rationale above the main-loop
-  # equivalent). Truncation happens inside jq (codepoint slice) to avoid
-  # SIGPIPE on jq under `set -o pipefail`.
+  # equivalent). The body is NOT sliced here — see the main-loop comment
+  # above for why classification needs the complete body (PR #1490 finding
+  # 3789679344) and why this is still SIGPIPE-safe.
   codex_select_review_evidence "$ASYNC_REVIEW_TMPFILE"
   ASYNC_REVIEW_BODY="$SELECTED_REVIEW_BODY"
   ASYNC_REVIEW_TIME="$SELECTED_REVIEW_TIME"
@@ -1143,12 +1148,13 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
     if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
       2>/dev/null \
       | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:((.body // "") | .[0:5000])} end' \
+          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // "")} end' \
       > "$ASYNC_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
       # Selects every review tied at the latest timestamp and picks the one
       # requiring attention, if any (see rationale above the main-loop
-      # equivalent). Truncation happens inside jq (codepoint slice) to
-      # avoid SIGPIPE on jq under `set -o pipefail`.
+      # equivalent). The body is NOT sliced here — see the main-loop
+      # comment above for why classification needs the complete body (PR
+      # #1490 finding 3789679344) and why this is still SIGPIPE-safe.
       codex_select_review_evidence "$ASYNC_FINAL_REVIEW_TMPFILE"
       ASYNC_FINAL_REVIEW_BODY="$SELECTED_REVIEW_BODY"
       ASYNC_FINAL_REVIEW_TIME="$SELECTED_REVIEW_TIME"
@@ -1279,12 +1285,13 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>/dev/null \
     | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:((.body // "") | .[0:5000])} end' \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // "")} end' \
     > "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
     # Selects every review tied at the latest timestamp and picks the one
     # requiring attention, if any (see rationale above the main-loop
-    # equivalent). Truncation happens inside jq (codepoint slice) to avoid
-    # SIGPIPE on jq under `set -o pipefail`.
+    # equivalent). The body is NOT sliced here — see the main-loop comment
+    # above for why classification needs the complete body (PR #1490
+    # finding 3789679344) and why this is still SIGPIPE-safe.
     codex_select_review_evidence "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE"
     ASYNC_REACTION_FINAL_REVIEW_BODY="$SELECTED_REVIEW_BODY"
     ASYNC_REACTION_FINAL_REVIEW_TIME="$SELECTED_REVIEW_TIME"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2641,6 +2641,47 @@ run_test "codex_stale_root_review_comment_not_approved" "no" "$_codex_stale_root
 rm -rf "$_codex_stale_root_review_comment_mock_dir"
 unset _codex_stale_root_review_comment_mock_dir _codex_stale_root_review_comment_output _codex_stale_root_review_comment_exit _codex_stale_root_review_comment_approved
 
+_codex_newer_root_blocks_old_review_mock_dir="$(mktemp -d)"
+cat > "$_codex_newer_root_blocks_old_review_mock_dir/gh" <<'CODEX_NEWER_ROOT_BLOCKS_OLD_REVIEW_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'feed12341234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":123,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"feed12341234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":223,"created_at":"2026-01-01T00:00:02Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: newer root finding.\\n\\n**Reviewed commit:** `feed1234`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_NEWER_ROOT_BLOCKS_OLD_REVIEW_GH
+chmod +x "$_codex_newer_root_blocks_old_review_mock_dir/gh"
+
+_codex_newer_root_blocks_old_review_output=""
+_codex_newer_root_blocks_old_review_exit=0
+PATH="$_codex_newer_root_blocks_old_review_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_newer_root_blocks_old_review_mock_dir/output.txt" 2>&1 || _codex_newer_root_blocks_old_review_exit=$?
+_codex_newer_root_blocks_old_review_output="$(cat "$_codex_newer_root_blocks_old_review_mock_dir/output.txt")"
+run_test "codex_newer_root_blocks_old_review_exit_needs_revision" "1" "$_codex_newer_root_blocks_old_review_exit"
+run_test "codex_newer_root_blocks_old_review_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_newer_root_blocks_old_review_output" | grep "^VERDICT:")"
+rm -rf "$_codex_newer_root_blocks_old_review_mock_dir"
+unset _codex_newer_root_blocks_old_review_mock_dir _codex_newer_root_blocks_old_review_output _codex_newer_root_blocks_old_review_exit
+
 _codex_reaction_with_review_mock_dir="$(mktemp -d)"
 cat > "$_codex_reaction_with_review_mock_dir/gh" <<'CODEX_REACTION_WITH_REVIEW_GH'
 #!/usr/bin/env bash
@@ -2779,6 +2820,46 @@ run_test "codex_async_reaction_then_late_review_approved" "VERDICT: APPROVED" \
   "$(printf '%s\n' "$_codex_async_reaction_then_review_output" | grep "^VERDICT:")"
 rm -rf "$_codex_async_reaction_then_review_mock_dir"
 unset _codex_async_reaction_then_review_mock_dir _codex_async_reaction_then_review_output _codex_async_reaction_then_review_exit
+
+_codex_async_reaction_environment_mock_dir="$(mktemp -d)"
+cat > "$_codex_async_reaction_environment_mock_dir/gh" <<'CODEX_ASYNC_REACTION_ENVIRONMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abc789aa1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":124,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[{"content":"+1","user":{"login":"chatgpt-codex-connector[bot]"}}]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":224,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"To use Codex here, create an environment for this repo."}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_ASYNC_REACTION_ENVIRONMENT_GH
+chmod +x "$_codex_async_reaction_environment_mock_dir/gh"
+
+_codex_async_reaction_environment_output=""
+_codex_async_reaction_environment_exit=0
+PATH="$_codex_async_reaction_environment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_async_reaction_environment_mock_dir/output.txt" 2>&1 || _codex_async_reaction_environment_exit=$?
+_codex_async_reaction_environment_output="$(cat "$_codex_async_reaction_environment_mock_dir/output.txt")"
+run_test "codex_async_reaction_environment_exit_unavailable" "2" "$_codex_async_reaction_environment_exit"
+run_test "codex_async_reaction_environment_reason" "REASON=codex-github-environment-missing" \
+  "$(printf '%s\n' "$_codex_async_reaction_environment_output" | grep "^REASON=")"
+rm -rf "$_codex_async_reaction_environment_mock_dir"
+unset _codex_async_reaction_environment_mock_dir _codex_async_reaction_environment_output _codex_async_reaction_environment_exit
 
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3166,6 +3166,69 @@ run_test "codex_async_reaction_environment_reason" "REASON=codex-github-environm
 rm -rf "$_codex_async_reaction_environment_mock_dir"
 unset _codex_async_reaction_environment_mock_dir _codex_async_reaction_environment_output _codex_async_reaction_environment_exit
 
+# Reproduces Codex finding 3786691880-followup (P2, comment id 3787460055):
+# the final acknowledgement re-poll must preserve a recorded environment
+# setup error instead of returning reaction-without-review when a thumbs-up
+# reaction is also present. Sequence: initial async-grace poll finds the
+# acknowledgement comment (no review, no reaction yet) -> sleeps -> final
+# re-poll finds an environment-setup comment (sets SEEN_ENVIRONMENT_ERROR)
+# -> trigger reactions endpoint reports a thumbs-up -> expect
+# codex-github-environment-missing, not codex-github-reaction-without-review.
+_codex_ack_repoll_env_then_reaction_mock_dir="$(mktemp -d)"
+printf '0\n' > "$_codex_ack_repoll_env_then_reaction_mock_dir/comment_calls"
+cat > "$_codex_ack_repoll_env_then_reaction_mock_dir/gh" <<'CODEX_ACK_REPOLL_ENV_THEN_REACTION_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'ackrepoll1234567890a\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":126,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[{"content":"+1","user":{"login":"chatgpt-codex-connector[bot]"}}]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    calls_file="$(dirname "$0")/comment_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    # Calls 1-2 are the pre-trigger dedup check and the main poll-loop's
+    # bot-response check; both must stay empty so execution falls through
+    # to the async-arrival grace poll (call 3) and its final re-poll
+    # (call 4+).
+    if [ "$calls" -ge 4 ]; then
+      printf '[{"id":227,"created_at":"2026-01-01T00:00:02Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"To use Codex here, create an environment for this repo."}]\n'
+    elif [ "$calls" -eq 3 ]; then
+      printf '[{"id":226,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"If Codex has suggestions, it will comment; otherwise it will react with 👍 on this comment."}]\n'
+    else
+      printf '[]\n'
+    fi
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_ACK_REPOLL_ENV_THEN_REACTION_GH
+chmod +x "$_codex_ack_repoll_env_then_reaction_mock_dir/gh"
+
+_codex_ack_repoll_env_then_reaction_output=""
+_codex_ack_repoll_env_then_reaction_exit=0
+PATH="$_codex_ack_repoll_env_then_reaction_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_ack_repoll_env_then_reaction_mock_dir/output.txt" 2>&1 || _codex_ack_repoll_env_then_reaction_exit=$?
+_codex_ack_repoll_env_then_reaction_output="$(cat "$_codex_ack_repoll_env_then_reaction_mock_dir/output.txt")"
+run_test "codex_ack_repoll_env_then_reaction_exit_unavailable" "2" "$_codex_ack_repoll_env_then_reaction_exit"
+run_test "codex_ack_repoll_env_then_reaction_reason" "REASON=codex-github-environment-missing" \
+  "$(printf '%s\n' "$_codex_ack_repoll_env_then_reaction_output" | grep "^REASON=")"
+rm -rf "$_codex_ack_repoll_env_then_reaction_mock_dir"
+unset _codex_ack_repoll_env_then_reaction_mock_dir _codex_ack_repoll_env_then_reaction_output _codex_ack_repoll_env_then_reaction_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -6288,6 +6288,106 @@ run_test "codex_do_not_merge_blocking_root_comment_verdict" "VERDICT: NEEDS_REVI
 rm -rf "$_codex_do_not_merge_blocking_root_comment_mock_dir"
 unset _codex_do_not_merge_blocking_root_comment_mock_dir _codex_do_not_merge_blocking_root_comment_output _codex_do_not_merge_blocking_root_comment_exit
 
+# Manually enumerating merge-refusal phrasings one at a time in
+# CODEX_BLOCKING_PATTERN ("should/must not be merged", then "do not
+# merge"/"don't merge") kept surfacing the next unenumerated synonym —
+# "cannot be merged" was the third sibling finding in a row (fresh
+# evidence from PR #1490 finding 3799159335, a followup to 3798999561
+# and 3798880969). Rather than add yet another one-off alternative,
+# CODEX_BLOCKING_PATTERN now includes a generalized
+# CODEX_MERGE_REFUSAL_PATTERN built from the existing CODEX_NEGATION_WORDS
+# list (the same construction CODEX_NEGATED_APPROVAL_PATTERN already
+# uses), so any negation word already known to this file — including
+# future additions — automatically covers merge refusals too, without
+# needing its own enumeration round-trip.
+_codex_cannot_be_merged_blocking_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_cannot_be_merged_blocking_root_comment_mock_dir/gh" <<'CODEX_CANNOT_BE_MERGED_BLOCKING_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'face44441234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":320,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":321,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"This looks good at first glance, but this cannot be merged until tests pass.\\n\\n**Reviewed commit:** `face4444`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_CANNOT_BE_MERGED_BLOCKING_ROOT_COMMENT_GH
+chmod +x "$_codex_cannot_be_merged_blocking_root_comment_mock_dir/gh"
+
+_codex_cannot_be_merged_blocking_root_comment_output=""
+_codex_cannot_be_merged_blocking_root_comment_exit=0
+PATH="$_codex_cannot_be_merged_blocking_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_cannot_be_merged_blocking_root_comment_mock_dir/output.txt" 2>&1 || _codex_cannot_be_merged_blocking_root_comment_exit=$?
+_codex_cannot_be_merged_blocking_root_comment_output="$(cat "$_codex_cannot_be_merged_blocking_root_comment_mock_dir/output.txt")"
+run_test "codex_cannot_be_merged_blocking_root_comment_exit_needs_revision" "1" "$_codex_cannot_be_merged_blocking_root_comment_exit"
+run_test "codex_cannot_be_merged_blocking_root_comment_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_cannot_be_merged_blocking_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_cannot_be_merged_blocking_root_comment_mock_dir"
+unset _codex_cannot_be_merged_blocking_root_comment_mock_dir _codex_cannot_be_merged_blocking_root_comment_output _codex_cannot_be_merged_blocking_root_comment_exit
+
+# The generalized CODEX_MERGE_REFUSAL_PATTERN reuses CODEX_NEGATION_WORDS'
+# bare "not" alternative combined with an unbounded (except for
+# sentence/clause terminators) span before "merge(d)" — the same
+# clause-scoping already used by CODEX_NEGATED_APPROVAL_PATTERN protects
+# against an unrelated EARLIER negation in a different clause being
+# misread as targeting a LATER, unrelated mention of "merge": a genuinely
+# clean review that discusses an unrelated negation before a separate
+# instruction to merge must still classify as approved.
+_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir/gh" <<'CODEX_UNRELATED_NEGATION_BEFORE_MERGE_STAYS_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'face55551234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":322,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":323,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"This is not a blocker; looks good, please merge.\\n\\n**Reviewed commit:** `face5555`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_UNRELATED_NEGATION_BEFORE_MERGE_STAYS_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir/gh"
+
+_codex_unrelated_negation_before_merge_stays_approved_root_comment_output=""
+_codex_unrelated_negation_before_merge_stays_approved_root_comment_exit=0
+PATH="$_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_unrelated_negation_before_merge_stays_approved_root_comment_exit=$?
+_codex_unrelated_negation_before_merge_stays_approved_root_comment_output="$(cat "$_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_unrelated_negation_before_merge_stays_approved_root_comment_exit_clean" "0" "$_codex_unrelated_negation_before_merge_stays_approved_root_comment_exit"
+run_test "codex_unrelated_negation_before_merge_stays_approved_root_comment_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_unrelated_negation_before_merge_stays_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir"
+unset _codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir _codex_unrelated_negation_before_merge_stays_approved_root_comment_output _codex_unrelated_negation_before_merge_stays_approved_root_comment_exit
+
 # codex_strip_quoted_spans handled straight-double-quotes, backticks, and
 # blockquotes, but not single-quoted spans — the fourth quoting style
 # found unprotected — so a review discussing a quoted clean phrase in

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4987,6 +4987,104 @@ run_test "codex_terminal_comment_quotes_env_error_not_ancillary_verdict" "VERDIC
 rm -rf "$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir"
 unset _codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir _codex_terminal_comment_quotes_env_error_not_ancillary_output _codex_terminal_comment_quotes_env_error_not_ancillary_exit
 
+# Positive control for the reverse-order negation alternative that was
+# added for finding 3790023141 and then REMOVED for being over-broad: it
+# matched ANY later negation word in the same sentence regardless of what
+# it actually negated, so a genuinely clean response like "Looks good
+# overall; tests were not run." (the "not" refers to the unrelated "tests
+# were not run" clause, not to the approval) was incorrectly flagged as
+# negated and returned NEEDS_REVISION instead of APPROVED (fresh evidence
+# from PR #1490 finding 3790062089).
+_codex_unrelated_later_negation_stays_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_unrelated_later_negation_stays_approved_root_comment_mock_dir/gh" <<'CODEX_UNRELATED_LATER_NEGATION_STAYS_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade00ff1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":276,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":277,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Looks good overall; tests were not run.\\n\\n**Reviewed commit:** `facade00ff`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_UNRELATED_LATER_NEGATION_STAYS_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_unrelated_later_negation_stays_approved_root_comment_mock_dir/gh"
+
+_codex_unrelated_later_negation_stays_approved_root_comment_output=""
+_codex_unrelated_later_negation_stays_approved_root_comment_exit=0
+PATH="$_codex_unrelated_later_negation_stays_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_unrelated_later_negation_stays_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_unrelated_later_negation_stays_approved_root_comment_exit=$?
+_codex_unrelated_later_negation_stays_approved_root_comment_output="$(cat "$_codex_unrelated_later_negation_stays_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_unrelated_later_negation_stays_approved_root_comment_exit_clean" "0" "$_codex_unrelated_later_negation_stays_approved_root_comment_exit"
+run_test "codex_unrelated_later_negation_stays_approved_root_comment_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_unrelated_later_negation_stays_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_unrelated_later_negation_stays_approved_root_comment_mock_dir"
+unset _codex_unrelated_later_negation_stays_approved_root_comment_mock_dir _codex_unrelated_later_negation_stays_approved_root_comment_output _codex_unrelated_later_negation_stays_approved_root_comment_exit
+
+# codex_combine_terminal_evidence previously applied the SAME newest-wins
+# comparison to a usage-limit ancillary comment as it does to an
+# environment-setup error, so a clean current-head review returned in the
+# SAME fetch as (and strictly newer than) a usage-limit notice let the
+# review win, and the quota body never reached codex_return_usage_limit —
+# contradicting the documented immediate-termination contract for
+# usage-limit (fresh evidence from PR #1490 finding 3790062091). Fixture:
+# an ancillary (non-terminal) usage-limit comment at T1 and a clean
+# current-head review at T2 > T1, both in the same poll fetch.
+_codex_usage_limit_beats_same_fetch_newer_review_mock_dir="$(mktemp -d)"
+cat > "$_codex_usage_limit_beats_same_fetch_newer_review_mock_dir/gh" <<'CODEX_USAGE_LIMIT_BEATS_SAME_FETCH_NEWER_REVIEW_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade01001234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":278,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:02Z","commit_id":"facade01001234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":279,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"You have reached your Codex usage limits for code reviews."}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_USAGE_LIMIT_BEATS_SAME_FETCH_NEWER_REVIEW_GH
+chmod +x "$_codex_usage_limit_beats_same_fetch_newer_review_mock_dir/gh"
+
+_codex_usage_limit_beats_same_fetch_newer_review_output=""
+_codex_usage_limit_beats_same_fetch_newer_review_exit=0
+PATH="$_codex_usage_limit_beats_same_fetch_newer_review_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_usage_limit_beats_same_fetch_newer_review_mock_dir/output.txt" 2>&1 || _codex_usage_limit_beats_same_fetch_newer_review_exit=$?
+_codex_usage_limit_beats_same_fetch_newer_review_output="$(cat "$_codex_usage_limit_beats_same_fetch_newer_review_mock_dir/output.txt")"
+run_test "codex_usage_limit_beats_same_fetch_newer_review_exit_unavailable" "3" "$_codex_usage_limit_beats_same_fetch_newer_review_exit"
+run_test "codex_usage_limit_beats_same_fetch_newer_review_verdict" "VERDICT: UNAVAILABLE — Codex GitHub review usage limit reached" \
+  "$(printf '%s\n' "$_codex_usage_limit_beats_same_fetch_newer_review_output" | grep "^VERDICT:")"
+rm -rf "$_codex_usage_limit_beats_same_fetch_newer_review_mock_dir"
+unset _codex_usage_limit_beats_same_fetch_newer_review_mock_dir _codex_usage_limit_beats_same_fetch_newer_review_output _codex_usage_limit_beats_same_fetch_newer_review_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5998,6 +5998,61 @@ run_test "codex_inline_backtick_pair_stays_approved_root_comment_verdict" "VERDI
 rm -rf "$_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir"
 unset _codex_inline_backtick_pair_stays_approved_root_comment_mock_dir _codex_inline_backtick_pair_stays_approved_root_comment_output _codex_inline_backtick_pair_stays_approved_root_comment_exit
 
+# The fence-marker guard was added to codex_response_is_approved only,
+# but codex_response_is_usage_limit's own callers (the 4 top-level
+# verdict-parsing elif chains) were left unguarded — so a clean SHA-
+# pinned review that quotes a REAL quota notice inside a fenced example
+# (e.g. "No blocking issues found" followed by a ~~~ block containing
+# "You have reached your Codex usage limits") still matched the
+# usage-limit pattern on the unstripped fence content and returned
+# UNAVAILABLE (exit 3) instead of the safe-fail NEEDS_REVISION a fenced
+# response should produce (fresh evidence from PR #1490 finding
+# 3796042503, a followup to 3795661290). The fence-marker guard is now
+# embedded directly inside codex_response_has_fence_marker's callers
+# (usage-limit, environment-error, blocking, approved) rather than at
+# each call site, so every current and future caller benefits
+# automatically — the exact lesson codex_response_is_blocking already
+# taught for quote-stripping (finding 3793367887).
+_codex_fenced_quota_example_not_unavailable_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_fenced_quota_example_not_unavailable_root_comment_mock_dir/gh" <<'CODEX_FENCED_QUOTA_EXAMPLE_NOT_UNAVAILABLE_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade03001234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":318,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:319,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("No blocking issues found\n~~~\nYou have reached your Codex usage limits.\n~~~\n\n**Reviewed commit:** `facade03001`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FENCED_QUOTA_EXAMPLE_NOT_UNAVAILABLE_ROOT_COMMENT_GH
+chmod +x "$_codex_fenced_quota_example_not_unavailable_root_comment_mock_dir/gh"
+
+_codex_fenced_quota_example_not_unavailable_root_comment_output=""
+_codex_fenced_quota_example_not_unavailable_root_comment_exit=0
+PATH="$_codex_fenced_quota_example_not_unavailable_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_fenced_quota_example_not_unavailable_root_comment_mock_dir/output.txt" 2>&1 || _codex_fenced_quota_example_not_unavailable_root_comment_exit=$?
+_codex_fenced_quota_example_not_unavailable_root_comment_output="$(cat "$_codex_fenced_quota_example_not_unavailable_root_comment_mock_dir/output.txt")"
+run_test "codex_fenced_quota_example_not_unavailable_root_comment_exit_needs_revision" "1" "$_codex_fenced_quota_example_not_unavailable_root_comment_exit"
+run_test "codex_fenced_quota_example_not_unavailable_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_fenced_quota_example_not_unavailable_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_fenced_quota_example_not_unavailable_root_comment_mock_dir"
+unset _codex_fenced_quota_example_not_unavailable_root_comment_mock_dir _codex_fenced_quota_example_not_unavailable_root_comment_output _codex_fenced_quota_example_not_unavailable_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4406,6 +4406,56 @@ run_test "codex_long_root_review_blocker_past_cutoff_verdict" "VERDICT: NEEDS_RE
 rm -rf "$_codex_long_root_review_blocker_past_cutoff_mock_dir"
 unset _codex_long_root_review_blocker_past_cutoff_mock_dir _codex_long_root_review_blocker_past_cutoff_output _codex_long_root_review_blocker_past_cutoff_exit
 
+# Same class of bug as codex_long_root_review_blocker_past_cutoff, but one
+# layer further upstream: the reviews-endpoint jq QUERY itself used to slice
+# the body to 5000 chars (`.[0:5000]`) before the result ever reached
+# BOT_RESPONSE_FULL, so a submitted review with an approval phrase before
+# the cutoff and a blocking marker past it was misclassified as APPROVED
+# even though the shell-level classify-full/truncate-only-for-display fix
+# was already in place (fresh evidence from PR #1490 finding 3789679344).
+# Fixture: a single submitted review whose body is a clean "no blocking
+# issues found" phrase followed by 5000+ chars of padding and then a
+# blocking marker.
+_codex_long_review_blocker_past_query_cutoff_mock_dir="$(mktemp -d)"
+cat > "$_codex_long_review_blocker_past_query_cutoff_mock_dir/gh" <<'CODEX_LONG_REVIEW_BLOCKER_PAST_QUERY_CUTOFF_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade001234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":251,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"facade001234567890",user:{login:"chatgpt-codex-connector[bot]"},body:("No blocking issues found.\n\n" + ("x" * 5200) + "\n\nBlocking issues: must fix the leak past the query-level cutoff.")}]'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_LONG_REVIEW_BLOCKER_PAST_QUERY_CUTOFF_GH
+chmod +x "$_codex_long_review_blocker_past_query_cutoff_mock_dir/gh"
+
+_codex_long_review_blocker_past_query_cutoff_output=""
+_codex_long_review_blocker_past_query_cutoff_exit=0
+PATH="$_codex_long_review_blocker_past_query_cutoff_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_long_review_blocker_past_query_cutoff_mock_dir/output.txt" 2>&1 || _codex_long_review_blocker_past_query_cutoff_exit=$?
+_codex_long_review_blocker_past_query_cutoff_output="$(cat "$_codex_long_review_blocker_past_query_cutoff_mock_dir/output.txt")"
+run_test "codex_long_review_blocker_past_query_cutoff_exit_needs_revision" "1" "$_codex_long_review_blocker_past_query_cutoff_exit"
+run_test "codex_long_review_blocker_past_query_cutoff_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_long_review_blocker_past_query_cutoff_output" | grep "^VERDICT:")"
+rm -rf "$_codex_long_review_blocker_past_query_cutoff_mock_dir"
+unset _codex_long_review_blocker_past_query_cutoff_mock_dir _codex_long_review_blocker_past_query_cutoff_output _codex_long_review_blocker_past_query_cutoff_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5423,6 +5423,54 @@ run_test "codex_terminal_review_quotes_quota_message_verdict" "VERDICT: APPROVED
 rm -rf "$_codex_terminal_review_quotes_quota_message_mock_dir"
 unset _codex_terminal_review_quotes_quota_message_mock_dir _codex_terminal_review_quotes_quota_message_output _codex_terminal_review_quotes_quota_message_exit
 
+# "Not only X, (but) Y" is an AFFIRMATIVE intensifier construction (BOTH
+# X and Y are being asserted, not negated), not a negation of X, so
+# CODEX_NEGATION_WORDS' bare "not" alternative — which has no way to
+# distinguish this idiom from a genuine negation — misclassified "Not
+# only does this look good, it is approved" as negated even though both
+# phrases are affirmative (fresh evidence from PR #1490 finding
+# 3793299512). codex_response_is_approved now strips the "not only" idiom
+# before running the negation check.
+_codex_not_only_idiom_stays_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_not_only_idiom_stays_approved_root_comment_mock_dir/gh" <<'CODEX_NOT_ONLY_IDIOM_STAYS_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade01881234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":295,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":296,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Not only does this look good, it is approved.\\n\\n**Reviewed commit:** `facade01881`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_NOT_ONLY_IDIOM_STAYS_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_not_only_idiom_stays_approved_root_comment_mock_dir/gh"
+
+_codex_not_only_idiom_stays_approved_root_comment_output=""
+_codex_not_only_idiom_stays_approved_root_comment_exit=0
+PATH="$_codex_not_only_idiom_stays_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_not_only_idiom_stays_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_not_only_idiom_stays_approved_root_comment_exit=$?
+_codex_not_only_idiom_stays_approved_root_comment_output="$(cat "$_codex_not_only_idiom_stays_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_not_only_idiom_stays_approved_root_comment_exit_clean" "0" "$_codex_not_only_idiom_stays_approved_root_comment_exit"
+run_test "codex_not_only_idiom_stays_approved_root_comment_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_not_only_idiom_stays_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_not_only_idiom_stays_approved_root_comment_mock_dir"
+unset _codex_not_only_idiom_stays_approved_root_comment_mock_dir _codex_not_only_idiom_stays_approved_root_comment_output _codex_not_only_idiom_stays_approved_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3711,6 +3711,102 @@ run_test "codex_long_root_comment_no_sigpipe_verdict" "VERDICT: APPROVED" \
 rm -rf "$_codex_long_root_comment_no_sigpipe_mock_dir"
 unset _codex_long_root_comment_no_sigpipe_mock_dir _codex_long_root_comment_no_sigpipe_output _codex_long_root_comment_no_sigpipe_exit
 
+# Reproduces Codex finding on PR #1490 (P1, comment id 3787943162): a
+# SHA-pinned terminal root comment reporting a blocking finding at T1,
+# followed by a non-terminal environment-setup comment at T2 in the same
+# fetch. codex_combine_terminal_evidence's final environment-error override
+# previously replaced the blocking COMBINED_BODY whenever it was not
+# strictly newer than the environment-error comment, silently hiding the
+# blocking finding behind an "unavailable" verdict. Blocking terminal
+# evidence must now win outright, regardless of timing. No review from the
+# reviews endpoint -> expect NEEDS_REVISION, not environment-missing.
+_codex_blocking_terminal_beats_env_error_mock_dir="$(mktemp -d)"
+cat > "$_codex_blocking_terminal_beats_env_error_mock_dir/gh" <<'CODEX_BLOCKING_TERMINAL_BEATS_ENV_ERROR_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'beadf00d1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":160,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":270,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: must fix the null check.\\n\\n**Reviewed commit:** `beadf00d1234`"},{"id":271,"created_at":"2026-01-01T00:00:02Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"To use Codex here, create an environment for this repo."}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_BLOCKING_TERMINAL_BEATS_ENV_ERROR_GH
+chmod +x "$_codex_blocking_terminal_beats_env_error_mock_dir/gh"
+
+_codex_blocking_terminal_beats_env_error_output=""
+_codex_blocking_terminal_beats_env_error_exit=0
+PATH="$_codex_blocking_terminal_beats_env_error_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_blocking_terminal_beats_env_error_mock_dir/output.txt" 2>&1 || _codex_blocking_terminal_beats_env_error_exit=$?
+_codex_blocking_terminal_beats_env_error_output="$(cat "$_codex_blocking_terminal_beats_env_error_mock_dir/output.txt")"
+run_test "codex_blocking_terminal_beats_env_error_exit_needs_revision" "1" "$_codex_blocking_terminal_beats_env_error_exit"
+run_test "codex_blocking_terminal_beats_env_error_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_blocking_terminal_beats_env_error_output" | grep "^VERDICT:")"
+rm -rf "$_codex_blocking_terminal_beats_env_error_mock_dir"
+unset _codex_blocking_terminal_beats_env_error_mock_dir _codex_blocking_terminal_beats_env_error_output _codex_blocking_terminal_beats_env_error_exit
+
+# Reproduces Codex finding on PR #1490 (P2, comment id 3787943163): a
+# SHA-pinned terminal root review whose blocking finding text quotes the
+# environment-setup sentence verbatim (e.g. flagging stale docs that
+# reproduce it) was misclassified as an environment-setup error by the
+# unanchored substring matcher, suppressing NEEDS_REVISION. A SHA-pinned
+# TERMINAL comment is now never classified as an environment error,
+# regardless of its text content -> expect NEEDS_REVISION.
+_codex_quoted_setup_sentence_in_blocking_finding_mock_dir="$(mktemp -d)"
+cat > "$_codex_quoted_setup_sentence_in_blocking_finding_mock_dir/gh" <<'CODEX_QUOTED_SETUP_SENTENCE_IN_BLOCKING_FINDING_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'cafebabe1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":161,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":280,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: docs must not claim: To use Codex here, create an environment for this repo.\\n\\n**Reviewed commit:** `cafebabe1234`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_QUOTED_SETUP_SENTENCE_IN_BLOCKING_FINDING_GH
+chmod +x "$_codex_quoted_setup_sentence_in_blocking_finding_mock_dir/gh"
+
+_codex_quoted_setup_sentence_in_blocking_finding_output=""
+_codex_quoted_setup_sentence_in_blocking_finding_exit=0
+PATH="$_codex_quoted_setup_sentence_in_blocking_finding_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_quoted_setup_sentence_in_blocking_finding_mock_dir/output.txt" 2>&1 || _codex_quoted_setup_sentence_in_blocking_finding_exit=$?
+_codex_quoted_setup_sentence_in_blocking_finding_output="$(cat "$_codex_quoted_setup_sentence_in_blocking_finding_mock_dir/output.txt")"
+run_test "codex_quoted_setup_sentence_in_blocking_finding_exit_needs_revision" "1" "$_codex_quoted_setup_sentence_in_blocking_finding_exit"
+run_test "codex_quoted_setup_sentence_in_blocking_finding_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_quoted_setup_sentence_in_blocking_finding_output" | grep "^VERDICT:")"
+rm -rf "$_codex_quoted_setup_sentence_in_blocking_finding_mock_dir"
+unset _codex_quoted_setup_sentence_in_blocking_finding_mock_dir _codex_quoted_setup_sentence_in_blocking_finding_output _codex_quoted_setup_sentence_in_blocking_finding_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5709,6 +5709,59 @@ run_test "codex_fenced_example_outside_blocker_stays_blocking_root_comment_verdi
 rm -rf "$_codex_fenced_example_outside_blocker_stays_blocking_root_comment_mock_dir"
 unset _codex_fenced_example_outside_blocker_stays_blocking_root_comment_mock_dir _codex_fenced_example_outside_blocker_stays_blocking_root_comment_output _codex_fenced_example_outside_blocker_stays_blocking_root_comment_exit
 
+# The reviewer script relied entirely on free-text body parsing
+# (codex_response_is_blocking/is_approved) and never consulted GitHub's
+# own structured review `state` field (APPROVED/CHANGES_REQUESTED/
+# COMMENTED/PENDING/DISMISSED), even though the reviews-endpoint response
+# carries it directly. A submitted review with state CHANGES_REQUESTED
+# but a clean-sounding or ambiguous body ("Looks good overall, but see
+# the note below.") fell through to the unrecognized-format safe-fail
+# instead of being recognized as blocking on GitHub's own authoritative
+# signal (fresh evidence from PR #1490 finding 3796396391).
+# codex_combine_terminal_evidence now threads the review's state through
+# as COMBINED_REVIEW_STATE, and the verdict-parsing chain short-circuits
+# to blocking whenever a winning review's state is CHANGES_REQUESTED,
+# ahead of free-text classification.
+_codex_changes_requested_state_forces_blocking_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_changes_requested_state_forces_blocking_root_comment_mock_dir/gh" <<'CODEX_CHANGES_REQUESTED_STATE_FORCES_BLOCKING_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade02221234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":303,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"facade02221234567890","state":"CHANGES_REQUESTED","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Looks good overall, but see the note below."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_CHANGES_REQUESTED_STATE_FORCES_BLOCKING_ROOT_COMMENT_GH
+chmod +x "$_codex_changes_requested_state_forces_blocking_root_comment_mock_dir/gh"
+
+_codex_changes_requested_state_forces_blocking_root_comment_output=""
+_codex_changes_requested_state_forces_blocking_root_comment_exit=0
+PATH="$_codex_changes_requested_state_forces_blocking_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_changes_requested_state_forces_blocking_root_comment_mock_dir/output.txt" 2>&1 || _codex_changes_requested_state_forces_blocking_root_comment_exit=$?
+_codex_changes_requested_state_forces_blocking_root_comment_output="$(cat "$_codex_changes_requested_state_forces_blocking_root_comment_mock_dir/output.txt")"
+run_test "codex_changes_requested_state_forces_blocking_root_comment_exit_needs_revision" "1" "$_codex_changes_requested_state_forces_blocking_root_comment_exit"
+run_test "codex_changes_requested_state_forces_blocking_root_comment_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_changes_requested_state_forces_blocking_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_changes_requested_state_forces_blocking_root_comment_mock_dir"
+unset _codex_changes_requested_state_forces_blocking_root_comment_mock_dir _codex_changes_requested_state_forces_blocking_root_comment_output _codex_changes_requested_state_forces_blocking_root_comment_exit
+
 # codex_strip_quoted_spans handled straight-double-quotes, backticks, and
 # blockquotes, but not single-quoted spans — the fourth quoting style
 # found unprotected — so a review discussing a quoted clean phrase in

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4107,6 +4107,55 @@ run_test "codex_bodyless_tied_review_needs_revision_verdict" "VERDICT: NEEDS_REV
 rm -rf "$_codex_bodyless_tied_review_needs_revision_mock_dir"
 unset _codex_bodyless_tied_review_needs_revision_mock_dir _codex_bodyless_tied_review_needs_revision_output _codex_bodyless_tied_review_needs_revision_exit
 
+# Reproduces Codex finding on PR #1490 (P1, comment id 3789477520):
+# codex_select_review_evidence's scan stopped at the FIRST tied review
+# that merely "requires attention" (which includes non-blocking types
+# like usage-limit text), so a usage-limit review returned before a
+# blocking review in the same tied timestamp silently discarded the
+# blocker and the script emitted UNAVAILABLE instead of NEEDS_REVISION.
+# Blocking is now scanned and prioritized independently of other
+# attention-requiring types. Fixture: usage-limit review first in the
+# array, blocking review second, both tied at the same timestamp.
+_codex_tied_reviews_blocking_beats_usage_limit_mock_dir="$(mktemp -d)"
+cat > "$_codex_tied_reviews_blocking_beats_usage_limit_mock_dir/gh" <<'CODEX_TIED_REVIEWS_BLOCKING_BEATS_USAGE_LIMIT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'deadc0de1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":210,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"deadc0de1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"You have reached your Codex usage limits for code reviews."},{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"deadc0de1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: must fix the null check."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TIED_REVIEWS_BLOCKING_BEATS_USAGE_LIMIT_GH
+chmod +x "$_codex_tied_reviews_blocking_beats_usage_limit_mock_dir/gh"
+
+_codex_tied_reviews_blocking_beats_usage_limit_output=""
+_codex_tied_reviews_blocking_beats_usage_limit_exit=0
+PATH="$_codex_tied_reviews_blocking_beats_usage_limit_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_tied_reviews_blocking_beats_usage_limit_mock_dir/output.txt" 2>&1 || _codex_tied_reviews_blocking_beats_usage_limit_exit=$?
+_codex_tied_reviews_blocking_beats_usage_limit_output="$(cat "$_codex_tied_reviews_blocking_beats_usage_limit_mock_dir/output.txt")"
+run_test "codex_tied_reviews_blocking_beats_usage_limit_exit_needs_revision" "1" "$_codex_tied_reviews_blocking_beats_usage_limit_exit"
+run_test "codex_tied_reviews_blocking_beats_usage_limit_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_tied_reviews_blocking_beats_usage_limit_output" | grep "^VERDICT:")"
+rm -rf "$_codex_tied_reviews_blocking_beats_usage_limit_mock_dir"
+unset _codex_tied_reviews_blocking_beats_usage_limit_mock_dir _codex_tied_reviews_blocking_beats_usage_limit_output _codex_tied_reviews_blocking_beats_usage_limit_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3614,6 +3614,103 @@ run_test "codex_env_error_survives_later_ack_reason" "REASON=codex-github-enviro
 rm -rf "$_codex_env_error_survives_later_ack_mock_dir"
 unset _codex_env_error_survives_later_ack_mock_dir _codex_env_error_survives_later_ack_output _codex_env_error_survives_later_ack_exit
 
+# Reproduces Codex finding on PR #1490 (P1, comment id 3787868727): a clean
+# SHA-pinned terminal root comment at T1 and a strictly newer
+# environment-setup-error comment at T2, both present in the same comments
+# fetch. codex_combine_terminal_evidence previously chose the terminal
+# comment unconditionally whenever no submitted review was present,
+# discarding the newer environment error entirely (that branch never
+# considered it). No review from the reviews endpoint -> expect
+# codex-github-environment-missing, not APPROVED.
+_codex_terminal_comment_vs_newer_env_error_mock_dir="$(mktemp -d)"
+cat > "$_codex_terminal_comment_vs_newer_env_error_mock_dir/gh" <<'CODEX_TERMINAL_COMMENT_VS_NEWER_ENV_ERROR_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'deadf00d12345678\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":150,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":250,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex Review: Didn'\''t find any major issues.\\n\\n**Reviewed commit:** `deadf00d1234`"},{"id":251,"created_at":"2026-01-01T00:00:02Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"To use Codex here, create an environment for this repo."}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TERMINAL_COMMENT_VS_NEWER_ENV_ERROR_GH
+chmod +x "$_codex_terminal_comment_vs_newer_env_error_mock_dir/gh"
+
+_codex_terminal_comment_vs_newer_env_error_output=""
+_codex_terminal_comment_vs_newer_env_error_exit=0
+PATH="$_codex_terminal_comment_vs_newer_env_error_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_terminal_comment_vs_newer_env_error_mock_dir/output.txt" 2>&1 || _codex_terminal_comment_vs_newer_env_error_exit=$?
+_codex_terminal_comment_vs_newer_env_error_output="$(cat "$_codex_terminal_comment_vs_newer_env_error_mock_dir/output.txt")"
+run_test "codex_terminal_comment_vs_newer_env_error_exit_unavailable" "2" "$_codex_terminal_comment_vs_newer_env_error_exit"
+run_test "codex_terminal_comment_vs_newer_env_error_reason" "REASON=codex-github-environment-missing" \
+  "$(printf '%s\n' "$_codex_terminal_comment_vs_newer_env_error_output" | grep "^REASON=")"
+rm -rf "$_codex_terminal_comment_vs_newer_env_error_mock_dir"
+unset _codex_terminal_comment_vs_newer_env_error_mock_dir _codex_terminal_comment_vs_newer_env_error_output _codex_terminal_comment_vs_newer_env_error_exit
+
+# Reproduces Codex finding on PR #1490 (P1, comment id 3787868733): only
+# submitted review bodies were sliced inside jq; a SHA-pinned root-comment
+# body large enough to exceed a pipe buffer's capacity (well within
+# GitHub's ~64KB per-comment limit) still passed through
+# `printf | head -c 10000` in the main loop and all 3 async paths,
+# triggering the same SIGPIPE/exit-141 crash under `set -euo pipefail`.
+# All 4 sites now truncate via `jq -Rrs '.[0:10000]'`, which slurps its
+# entire stdin before producing output so the writer can never receive
+# SIGPIPE regardless of input size.
+_codex_long_root_comment_no_sigpipe_mock_dir="$(mktemp -d)"
+cat > "$_codex_long_root_comment_no_sigpipe_mock_dir/gh" <<'CODEX_LONG_ROOT_COMMENT_NO_SIGPIPE_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'deadf00d12345678\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":151,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:260,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'"'"'t find any major issues.\n\n" + ("x" * 200000) + "\n\n**Reviewed commit:** `deadf00d1234`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_LONG_ROOT_COMMENT_NO_SIGPIPE_GH
+chmod +x "$_codex_long_root_comment_no_sigpipe_mock_dir/gh"
+
+_codex_long_root_comment_no_sigpipe_output=""
+_codex_long_root_comment_no_sigpipe_exit=0
+PATH="$_codex_long_root_comment_no_sigpipe_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_long_root_comment_no_sigpipe_mock_dir/output.txt" 2>&1 || _codex_long_root_comment_no_sigpipe_exit=$?
+_codex_long_root_comment_no_sigpipe_output="$(cat "$_codex_long_root_comment_no_sigpipe_mock_dir/output.txt")"
+run_test "codex_long_root_comment_no_sigpipe_exit_clean" "0" "$_codex_long_root_comment_no_sigpipe_exit"
+run_test "codex_long_root_comment_no_sigpipe_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_long_root_comment_no_sigpipe_output" | grep "^VERDICT:")"
+rm -rf "$_codex_long_root_comment_no_sigpipe_mock_dir"
+unset _codex_long_root_comment_no_sigpipe_mock_dir _codex_long_root_comment_no_sigpipe_output _codex_long_root_comment_no_sigpipe_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5372,6 +5372,57 @@ run_test "codex_comma_scoped_negation_root_comment_verdict" "VERDICT: APPROVED" 
 rm -rf "$_codex_comma_scoped_negation_root_comment_mock_dir"
 unset _codex_comma_scoped_negation_root_comment_mock_dir _codex_comma_scoped_negation_root_comment_output _codex_comma_scoped_negation_root_comment_exit
 
+# The top-level verdict-parsing elif chain's usage-limit check has no
+# source gate (unlike the environment-error check, already safe because
+# it's gated on source == "comment", and a terminal SHA-pinned review
+# always has source == "review" by construction) and was not
+# quote-stripped, so a clean terminal review that merely QUOTES an actual
+# quota message (e.g. "No blocking issues found. The docs accurately
+# quote: You have reached your Codex usage limits.") was reclassified as
+# UNAVAILABLE instead of APPROVED — a case COMMENT_LATEST_IS_TERMINAL
+# does not cover, since that guard only protects the ancillary-evidence
+# combination stage, not this separate final verdict check (fresh
+# evidence from PR #1490 finding 3793259351).
+_codex_terminal_review_quotes_quota_message_mock_dir="$(mktemp -d)"
+cat > "$_codex_terminal_review_quotes_quota_message_mock_dir/gh" <<'CODEX_TERMINAL_REVIEW_QUOTES_QUOTA_MESSAGE_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade01771234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":293,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":294,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found. The docs accurately quote: `You have reached your Codex usage limits.`\\n\\n**Reviewed commit:** `facade01771`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TERMINAL_REVIEW_QUOTES_QUOTA_MESSAGE_GH
+chmod +x "$_codex_terminal_review_quotes_quota_message_mock_dir/gh"
+
+_codex_terminal_review_quotes_quota_message_output=""
+_codex_terminal_review_quotes_quota_message_exit=0
+PATH="$_codex_terminal_review_quotes_quota_message_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_terminal_review_quotes_quota_message_mock_dir/output.txt" 2>&1 || _codex_terminal_review_quotes_quota_message_exit=$?
+_codex_terminal_review_quotes_quota_message_output="$(cat "$_codex_terminal_review_quotes_quota_message_mock_dir/output.txt")"
+run_test "codex_terminal_review_quotes_quota_message_exit_clean" "0" "$_codex_terminal_review_quotes_quota_message_exit"
+run_test "codex_terminal_review_quotes_quota_message_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_terminal_review_quotes_quota_message_output" | grep "^VERDICT:")"
+rm -rf "$_codex_terminal_review_quotes_quota_message_mock_dir"
+unset _codex_terminal_review_quotes_quota_message_mock_dir _codex_terminal_review_quotes_quota_message_output _codex_terminal_review_quotes_quota_message_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2572,7 +2572,7 @@ case "$*" in
   *"pulls/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/reviews"*)
-    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"abcreviewok1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    printf '[{"submitted_at":"2026-01-01T00:00:00Z","commit_id":"abcreviewok1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
     exit 0 ;;
   *"issues/"*"/comments"*)
     printf '[{"id":206,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector"},"body":"If Codex has suggestions, it will comment; otherwise it will react with thumbs up."}]\n'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4456,6 +4456,106 @@ run_test "codex_long_review_blocker_past_query_cutoff_verdict" "VERDICT: NEEDS_R
 rm -rf "$_codex_long_review_blocker_past_query_cutoff_mock_dir"
 unset _codex_long_review_blocker_past_query_cutoff_mock_dir _codex_long_review_blocker_past_query_cutoff_output _codex_long_review_blocker_past_query_cutoff_exit
 
+# CODEX_APPROVAL_PATTERN's "approved" alternative is an unbounded substring
+# match, so a SHA-pinned terminal response REJECTING the change by saying
+# "This change is not approved" used to match it unconditionally and get
+# reported as APPROVED instead of falling through to the documented
+# unrecognized-format safe-fail (fresh evidence from PR #1490 finding
+# 3789722818).
+_codex_negated_approval_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_negated_approval_root_comment_mock_dir/gh" <<'CODEX_NEGATED_APPROVAL_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade003a1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":252,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":253,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"This change is not approved. Needs more work before it can ship.\\n\\n**Reviewed commit:** `facade003a`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_NEGATED_APPROVAL_ROOT_COMMENT_GH
+chmod +x "$_codex_negated_approval_root_comment_mock_dir/gh"
+
+_codex_negated_approval_root_comment_output=""
+_codex_negated_approval_root_comment_exit=0
+PATH="$_codex_negated_approval_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_negated_approval_root_comment_mock_dir/output.txt" 2>&1 || _codex_negated_approval_root_comment_exit=$?
+_codex_negated_approval_root_comment_output="$(cat "$_codex_negated_approval_root_comment_mock_dir/output.txt")"
+run_test "codex_negated_approval_root_comment_exit_needs_revision" "1" "$_codex_negated_approval_root_comment_exit"
+run_test "codex_negated_approval_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_negated_approval_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_negated_approval_root_comment_mock_dir"
+unset _codex_negated_approval_root_comment_mock_dir _codex_negated_approval_root_comment_output _codex_negated_approval_root_comment_exit
+
+# codex_response_priority ranked an ancillary environment-setup-error
+# comment at the same "unrecognized format" tier (2) as a genuine but
+# unrecognized-format submitted review, instead of at the lower
+# availability tier (1) shared with usage-limit notices. Tied at the same
+# timestamp, the setup-error comment then won the tie-break and replaced
+# the review's safe-fail NEEDS_REVISION with an UNAVAILABLE-style
+# codex-github-environment-missing verdict, silently discarding a review
+# that could have been a real rejection (fresh evidence from PR #1490
+# finding 3789722821). Fixture: an ancillary (non-SHA-pinned) environment-
+# setup-error comment and an unrecognized-format submitted review, both
+# timestamped identically.
+_codex_env_error_vs_unrecognized_review_tie_mock_dir="$(mktemp -d)"
+cat > "$_codex_env_error_vs_unrecognized_review_tie_mock_dir/gh" <<'CODEX_ENV_ERROR_VS_UNRECOGNIZED_REVIEW_TIE_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade004b1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":254,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"facade004b1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Reviewed the changes, nothing further to add at this time."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":255,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"To use Codex here, create an environment for this repo."}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_ENV_ERROR_VS_UNRECOGNIZED_REVIEW_TIE_GH
+chmod +x "$_codex_env_error_vs_unrecognized_review_tie_mock_dir/gh"
+
+_codex_env_error_vs_unrecognized_review_tie_output=""
+_codex_env_error_vs_unrecognized_review_tie_exit=0
+PATH="$_codex_env_error_vs_unrecognized_review_tie_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_env_error_vs_unrecognized_review_tie_mock_dir/output.txt" 2>&1 || _codex_env_error_vs_unrecognized_review_tie_exit=$?
+_codex_env_error_vs_unrecognized_review_tie_output="$(cat "$_codex_env_error_vs_unrecognized_review_tie_mock_dir/output.txt")"
+run_test "codex_env_error_vs_unrecognized_review_tie_exit_needs_revision" "1" "$_codex_env_error_vs_unrecognized_review_tie_exit"
+run_test "codex_env_error_vs_unrecognized_review_tie_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_env_error_vs_unrecognized_review_tie_output" | grep "^VERDICT:")"
+run_test "codex_env_error_vs_unrecognized_review_tie_reason_not_env_missing" "" \
+  "$(printf '%s\n' "$_codex_env_error_vs_unrecognized_review_tie_output" | grep "^REASON=codex-github-environment-missing")"
+rm -rf "$_codex_env_error_vs_unrecognized_review_tie_mock_dir"
+unset _codex_env_error_vs_unrecognized_review_tie_mock_dir _codex_env_error_vs_unrecognized_review_tie_output _codex_env_error_vs_unrecognized_review_tie_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5656,6 +5656,98 @@ run_test "codex_quoted_blocker_token_stays_approved_root_comment_verdict" "VERDI
 rm -rf "$_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir"
 unset _codex_quoted_blocker_token_stays_approved_root_comment_mock_dir _codex_quoted_blocker_token_stays_approved_root_comment_output _codex_quoted_blocker_token_stays_approved_root_comment_exit
 
+# codex_strip_quoted_spans handled straight-double-quotes, backticks, and
+# blockquotes, but not single-quoted spans — the fourth quoting style
+# found unprotected — so a review discussing a quoted clean phrase in
+# single quotes (e.g. "The documented response 'No blocking issues
+# found' is inaccurate and should be corrected") still matched and
+# returned APPROVED (fresh evidence from PR #1490 finding 3793410331).
+_codex_single_quoted_phrase_not_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_single_quoted_phrase_not_approved_root_comment_mock_dir/gh" <<'CODEX_SINGLE_QUOTED_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade02331234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":304,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf "[{\"id\":305,\"created_at\":\"2026-01-01T00:00:01Z\",\"user\":{\"login\":\"chatgpt-codex-connector[bot]\"},\"body\":\"The documented response 'No blocking issues found' is inaccurate and should be corrected.\\\\n\\\\n**Reviewed commit:** \`facade02331\`\"}]\n"
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_SINGLE_QUOTED_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_single_quoted_phrase_not_approved_root_comment_mock_dir/gh"
+
+_codex_single_quoted_phrase_not_approved_root_comment_output=""
+_codex_single_quoted_phrase_not_approved_root_comment_exit=0
+PATH="$_codex_single_quoted_phrase_not_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_single_quoted_phrase_not_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_single_quoted_phrase_not_approved_root_comment_exit=$?
+_codex_single_quoted_phrase_not_approved_root_comment_output="$(cat "$_codex_single_quoted_phrase_not_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_single_quoted_phrase_not_approved_root_comment_exit_needs_revision" "1" "$_codex_single_quoted_phrase_not_approved_root_comment_exit"
+run_test "codex_single_quoted_phrase_not_approved_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_single_quoted_phrase_not_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_single_quoted_phrase_not_approved_root_comment_mock_dir"
+unset _codex_single_quoted_phrase_not_approved_root_comment_mock_dir _codex_single_quoted_phrase_not_approved_root_comment_output _codex_single_quoted_phrase_not_approved_root_comment_exit
+
+# Positive control for the single-quote stripping above: a bare
+# `'[^']*'` pattern would also match the span between two UNRELATED
+# apostrophes in contractions (e.g. the apostrophe in "isn't" and the
+# apostrophe in "it's"), corrupting a genuinely clean review by deleting
+# everything between them. The stricter whitespace/punctuation-boundary
+# requirement must leave contractions untouched.
+_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir/gh" <<'CODEX_CONTRACTION_APOSTROPHES_NOT_MANGLED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade02441234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":306,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":307,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"It'\''s fine, doesn'\''t need changes. No blocking issues found.\\n\\n**Reviewed commit:** `facade02441`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_CONTRACTION_APOSTROPHES_NOT_MANGLED_ROOT_COMMENT_GH
+chmod +x "$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir/gh"
+
+_codex_contraction_apostrophes_not_mangled_root_comment_output=""
+_codex_contraction_apostrophes_not_mangled_root_comment_exit=0
+PATH="$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir/output.txt" 2>&1 || _codex_contraction_apostrophes_not_mangled_root_comment_exit=$?
+_codex_contraction_apostrophes_not_mangled_root_comment_output="$(cat "$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir/output.txt")"
+run_test "codex_contraction_apostrophes_not_mangled_root_comment_exit_clean" "0" "$_codex_contraction_apostrophes_not_mangled_root_comment_exit"
+run_test "codex_contraction_apostrophes_not_mangled_root_comment_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_contraction_apostrophes_not_mangled_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir"
+unset _codex_contraction_apostrophes_not_mangled_root_comment_mock_dir _codex_contraction_apostrophes_not_mangled_root_comment_output _codex_contraction_apostrophes_not_mangled_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3807,6 +3807,104 @@ run_test "codex_quoted_setup_sentence_in_blocking_finding_verdict" "VERDICT: NEE
 rm -rf "$_codex_quoted_setup_sentence_in_blocking_finding_mock_dir"
 unset _codex_quoted_setup_sentence_in_blocking_finding_mock_dir _codex_quoted_setup_sentence_in_blocking_finding_output _codex_quoted_setup_sentence_in_blocking_finding_exit
 
+# Reproduces Codex finding on PR #1490 (P1, comment id 3788008326): when
+# multiple current-head reviews share GitHub's second-resolution
+# submitted_at timestamp, `sort_by(.submitted_at) | last` discarded every
+# response except whichever the API happened to return last, regardless of
+# content. A blocking review returned BEFORE a tied clean review in the
+# array silently produced APPROVED. The review-poll jq queries now select
+# every review tied at the latest timestamp and codex_select_review_evidence
+# picks the one requiring attention, if any. Fixture: blocking review first
+# in the array, clean review second, both tied at the same timestamp.
+_codex_tied_reviews_blocking_first_survives_mock_dir="$(mktemp -d)"
+cat > "$_codex_tied_reviews_blocking_first_survives_mock_dir/gh" <<'CODEX_TIED_REVIEWS_BLOCKING_FIRST_SURVIVES_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'deadbeef1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":170,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"deadbeef1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: must fix the leak."},{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"deadbeef1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TIED_REVIEWS_BLOCKING_FIRST_SURVIVES_GH
+chmod +x "$_codex_tied_reviews_blocking_first_survives_mock_dir/gh"
+
+_codex_tied_reviews_blocking_first_survives_output=""
+_codex_tied_reviews_blocking_first_survives_exit=0
+PATH="$_codex_tied_reviews_blocking_first_survives_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_tied_reviews_blocking_first_survives_mock_dir/output.txt" 2>&1 || _codex_tied_reviews_blocking_first_survives_exit=$?
+_codex_tied_reviews_blocking_first_survives_output="$(cat "$_codex_tied_reviews_blocking_first_survives_mock_dir/output.txt")"
+run_test "codex_tied_reviews_blocking_first_survives_exit_needs_revision" "1" "$_codex_tied_reviews_blocking_first_survives_exit"
+run_test "codex_tied_reviews_blocking_first_survives_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_tied_reviews_blocking_first_survives_output" | grep "^VERDICT:")"
+rm -rf "$_codex_tied_reviews_blocking_first_survives_mock_dir"
+unset _codex_tied_reviews_blocking_first_survives_mock_dir _codex_tied_reviews_blocking_first_survives_output _codex_tied_reviews_blocking_first_survives_exit
+
+# Reproduces Codex finding on PR #1490 (P2, comment id 3788008327): only
+# environment-error ancillary comments were retained/compared independently
+# — usage-limit comments were not, so an older clean current-head review
+# and a newer root comment reporting exhausted Codex usage silently
+# resolved to APPROVED instead of the configured unavailable policy.
+# codex_scan_comment_evidence and the final override in
+# codex_combine_terminal_evidence now treat usage-limit comments the same
+# way as environment-error comments.
+_codex_older_review_vs_newer_usage_limit_mock_dir="$(mktemp -d)"
+cat > "$_codex_older_review_vs_newer_usage_limit_mock_dir/gh" <<'CODEX_OLDER_REVIEW_VS_NEWER_USAGE_LIMIT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facefeed1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":180,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"facefeed1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":290,"created_at":"2026-01-01T00:00:02Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"You have reached your Codex usage limits for code reviews."}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_OLDER_REVIEW_VS_NEWER_USAGE_LIMIT_GH
+chmod +x "$_codex_older_review_vs_newer_usage_limit_mock_dir/gh"
+
+_codex_older_review_vs_newer_usage_limit_output=""
+_codex_older_review_vs_newer_usage_limit_exit=0
+PATH="$_codex_older_review_vs_newer_usage_limit_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_older_review_vs_newer_usage_limit_mock_dir/output.txt" 2>&1 || _codex_older_review_vs_newer_usage_limit_exit=$?
+_codex_older_review_vs_newer_usage_limit_output="$(cat "$_codex_older_review_vs_newer_usage_limit_mock_dir/output.txt")"
+run_test "codex_older_review_vs_newer_usage_limit_exit_unavailable" "3" "$_codex_older_review_vs_newer_usage_limit_exit"
+run_test "codex_older_review_vs_newer_usage_limit_reason" "REASON=codex-github-usage-limit" \
+  "$(printf '%s\n' "$_codex_older_review_vs_newer_usage_limit_output" | grep "^REASON=")"
+rm -rf "$_codex_older_review_vs_newer_usage_limit_mock_dir"
+unset _codex_older_review_vs_newer_usage_limit_mock_dir _codex_older_review_vs_newer_usage_limit_output _codex_older_review_vs_newer_usage_limit_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4304,6 +4304,58 @@ run_test "codex_tied_usage_limit_with_approval_phrase_verdict" "VERDICT: UNAVAIL
 rm -rf "$_codex_tied_usage_limit_with_approval_phrase_mock_dir"
 unset _codex_tied_usage_limit_with_approval_phrase_mock_dir _codex_tied_usage_limit_with_approval_phrase_output _codex_tied_usage_limit_with_approval_phrase_exit
 
+# Reproduces Codex finding on PR #1490 (P1, comment id 3789597796): the
+# binary requires-attention distinction put usage-limit and unrecognized-
+# format responses into the same generic "attention" tier, so scanning
+# stopped at whichever one was seen first — a usage-limit response
+# (matching an approval phrase too) returned before a genuinely
+# unrecognized-format response silently retained the usage-limit response,
+# emitting UNAVAILABLE instead of the documented unrecognized-response
+# NEEDS_REVISION safe-fail. A permissive unavailable policy could
+# therefore hide a potentially rejecting response. codex_response_priority
+# now ranks unrecognized-format (2) above usage-limit (1) explicitly.
+# Fixture: usage-limit+approval-phrase review first in the array,
+# genuinely unrecognized-format review second, both tied.
+_codex_tied_usage_limit_then_unrecognized_mock_dir="$(mktemp -d)"
+cat > "$_codex_tied_usage_limit_then_unrecognized_mock_dir/gh" <<'CODEX_TIED_USAGE_LIMIT_THEN_UNRECOGNIZED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'a1a1a1a1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":240,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"a1a1a1a1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues could be evaluated because you have reached your Codex usage limits."},{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"a1a1a1a1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Something ambiguous happened here."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TIED_USAGE_LIMIT_THEN_UNRECOGNIZED_GH
+chmod +x "$_codex_tied_usage_limit_then_unrecognized_mock_dir/gh"
+
+_codex_tied_usage_limit_then_unrecognized_output=""
+_codex_tied_usage_limit_then_unrecognized_exit=0
+PATH="$_codex_tied_usage_limit_then_unrecognized_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_tied_usage_limit_then_unrecognized_mock_dir/output.txt" 2>&1 || _codex_tied_usage_limit_then_unrecognized_exit=$?
+_codex_tied_usage_limit_then_unrecognized_output="$(cat "$_codex_tied_usage_limit_then_unrecognized_mock_dir/output.txt")"
+run_test "codex_tied_usage_limit_then_unrecognized_exit" "1" "$_codex_tied_usage_limit_then_unrecognized_exit"
+run_test "codex_tied_usage_limit_then_unrecognized_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_tied_usage_limit_then_unrecognized_output" | grep "^VERDICT:")"
+rm -rf "$_codex_tied_usage_limit_then_unrecognized_mock_dir"
+unset _codex_tied_usage_limit_then_unrecognized_mock_dir _codex_tied_usage_limit_then_unrecognized_output _codex_tied_usage_limit_then_unrecognized_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5800,6 +5800,56 @@ run_test "codex_fenced_code_block_phrase_not_approved_root_comment_verdict" "VER
 rm -rf "$_codex_fenced_code_block_phrase_not_approved_root_comment_mock_dir"
 unset _codex_fenced_code_block_phrase_not_approved_root_comment_mock_dir _codex_fenced_code_block_phrase_not_approved_root_comment_output _codex_fenced_code_block_phrase_not_approved_root_comment_exit
 
+# The original fence-stripping awk pass toggled its "inside fence" state
+# on ANY line with 3+ backticks, with no regard for the LENGTH of the
+# opening delimiter. GitHub-flavored Markdown's actual fence semantics
+# require a delimiter of AT LEAST the opening fence's length to close it
+# — a longer outer fence (e.g. four backticks) can safely quote content
+# that itself contains a shorter (three-backtick) fence. The naive
+# implementation incorrectly closed on the inner three-backtick
+# delimiter, re-exposing the rest of the outer-fenced content —
+# including a quoted clean phrase — to classification (fresh evidence
+# from PR #1490 finding 3793497787, a followup to 3793453010).
+_codex_nested_fence_length_phrase_not_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_nested_fence_length_phrase_not_approved_root_comment_mock_dir/gh" <<'CODEX_NESTED_FENCE_LENGTH_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade02661234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":310,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:311,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Response was:\n````\nHere is an example:\n```\nNo blocking issues found\n```\nThat quoted output is inaccurate.\n````\nAfter the fence.\n\n**Reviewed commit:** `facade02661`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_NESTED_FENCE_LENGTH_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_nested_fence_length_phrase_not_approved_root_comment_mock_dir/gh"
+
+_codex_nested_fence_length_phrase_not_approved_root_comment_output=""
+_codex_nested_fence_length_phrase_not_approved_root_comment_exit=0
+PATH="$_codex_nested_fence_length_phrase_not_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_nested_fence_length_phrase_not_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_nested_fence_length_phrase_not_approved_root_comment_exit=$?
+_codex_nested_fence_length_phrase_not_approved_root_comment_output="$(cat "$_codex_nested_fence_length_phrase_not_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_nested_fence_length_phrase_not_approved_root_comment_exit_needs_revision" "1" "$_codex_nested_fence_length_phrase_not_approved_root_comment_exit"
+run_test "codex_nested_fence_length_phrase_not_approved_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_nested_fence_length_phrase_not_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_nested_fence_length_phrase_not_approved_root_comment_mock_dir"
+unset _codex_nested_fence_length_phrase_not_approved_root_comment_mock_dir _codex_nested_fence_length_phrase_not_approved_root_comment_output _codex_nested_fence_length_phrase_not_approved_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4600,6 +4600,53 @@ run_test "codex_markdown_negated_approval_root_comment_verdict" "VERDICT: NEEDS_
 rm -rf "$_codex_markdown_negated_approval_root_comment_mock_dir"
 unset _codex_markdown_negated_approval_root_comment_mock_dir _codex_markdown_negated_approval_root_comment_output _codex_markdown_negated_approval_root_comment_exit
 
+# Followup to the space-separated/concatenated-prefix/Markdown-wrapped
+# negation fixes above: a qualifier word interrupting the negation and
+# the approval word (e.g. "This change is not YET approved") still
+# missed the old rigid negation-immediately-adjacent-to-approval
+# requirement (fresh evidence from PR #1490 finding 3789904716).
+# CODEX_NEGATED_APPROVAL_PATTERN now tolerates up to 3 intervening
+# qualifier words.
+_codex_qualifier_negated_approval_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_qualifier_negated_approval_root_comment_mock_dir/gh" <<'CODEX_QUALIFIER_NEGATED_APPROVAL_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade007e1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":260,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":261,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"This change is not yet approved. Needs more work.\\n\\n**Reviewed commit:** `facade007e`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_QUALIFIER_NEGATED_APPROVAL_ROOT_COMMENT_GH
+chmod +x "$_codex_qualifier_negated_approval_root_comment_mock_dir/gh"
+
+_codex_qualifier_negated_approval_root_comment_output=""
+_codex_qualifier_negated_approval_root_comment_exit=0
+PATH="$_codex_qualifier_negated_approval_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_qualifier_negated_approval_root_comment_mock_dir/output.txt" 2>&1 || _codex_qualifier_negated_approval_root_comment_exit=$?
+_codex_qualifier_negated_approval_root_comment_output="$(cat "$_codex_qualifier_negated_approval_root_comment_mock_dir/output.txt")"
+run_test "codex_qualifier_negated_approval_root_comment_exit_needs_revision" "1" "$_codex_qualifier_negated_approval_root_comment_exit"
+run_test "codex_qualifier_negated_approval_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_qualifier_negated_approval_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_qualifier_negated_approval_root_comment_mock_dir"
+unset _codex_qualifier_negated_approval_root_comment_mock_dir _codex_qualifier_negated_approval_root_comment_output _codex_qualifier_negated_approval_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2598,6 +2598,55 @@ run_test "codex_reaction_with_current_review_approved" "VERDICT: APPROVED" \
 rm -rf "$_codex_reaction_with_review_mock_dir"
 unset _codex_reaction_with_review_mock_dir _codex_reaction_with_review_output _codex_reaction_with_review_exit
 
+_codex_reaction_then_review_mock_dir="$(mktemp -d)"
+printf '0\n' > "$_codex_reaction_then_review_mock_dir/review_calls"
+cat > "$_codex_reaction_then_review_mock_dir/gh" <<'CODEX_REACTION_THEN_REVIEW_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcreactlate1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":117,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[{"content":"+1","user":{"login":"chatgpt-codex-connector[bot]"}}]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    calls_file="$(dirname "$0")/review_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    if [ "$calls" -ge 2 ]; then
+      printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"abcreactlate1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    else
+      printf '[]\n'
+    fi
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_REACTION_THEN_REVIEW_GH
+chmod +x "$_codex_reaction_then_review_mock_dir/gh"
+
+_codex_reaction_then_review_output=""
+_codex_reaction_then_review_exit=0
+PATH="$_codex_reaction_then_review_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 2 --max-retriggers 0 \
+  >"$_codex_reaction_then_review_mock_dir/output.txt" 2>&1 || _codex_reaction_then_review_exit=$?
+_codex_reaction_then_review_output="$(cat "$_codex_reaction_then_review_mock_dir/output.txt")"
+run_test "codex_reaction_then_late_review_exit_clean" "0" "$_codex_reaction_then_review_exit"
+run_test "codex_reaction_then_late_review_approved" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_reaction_then_review_output" | grep "^VERDICT:")"
+rm -rf "$_codex_reaction_then_review_mock_dir"
+unset _codex_reaction_then_review_mock_dir _codex_reaction_then_review_output _codex_reaction_then_review_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5923,6 +5923,62 @@ run_test "codex_tied_changes_requested_review_beats_clean_root_comment_verdict" 
 rm -rf "$_codex_tied_changes_requested_review_beats_clean_root_comment_mock_dir"
 unset _codex_tied_changes_requested_review_beats_clean_root_comment_mock_dir _codex_tied_changes_requested_review_beats_clean_root_comment_output _codex_tied_changes_requested_review_beats_clean_root_comment_exit
 
+# codex_strip_quoted_spans' double-quote stripping ran inside a single sed
+# invocation, which operates per-line by default (each line is its own
+# pattern space) — a straight-double-quote pair that spans a newline (e.g.
+# `The documented response "` / `No blocking issues found` / `" is
+# inaccurate` across three lines) was never stripped at all, since the
+# opening and closing quote are in different sed pattern spaces. The
+# quoted clean phrase reached classification unstripped and matched
+# CODEX_APPROVAL_PATTERN's "no blocking issues" alternative, returning
+# APPROVED instead of the documented unrecognized-format safe-fail (fresh
+# evidence from PR #1490 finding 3797334339, a multi-line followup to the
+# same-line case already covered by codex_quoted_clean_phrase_not_
+# approved_root_comment above). codex_strip_quoted_spans now flattens
+# newlines to a placeholder before the double-/single-quote stripping
+# passes (restoring them immediately after, before the line-oriented
+# backtick pass), so a quote pair can be stripped regardless of how many
+# original lines it spans.
+_codex_multiline_quoted_clean_phrase_not_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_multiline_quoted_clean_phrase_not_approved_root_comment_mock_dir/gh" <<'CODEX_MULTILINE_QUOTED_CLEAN_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'beef00001234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":306,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:307,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("The documented response \"\nNo blocking issues found\n\" is inaccurate and should be corrected.\n\n**Reviewed commit:** `beef0000`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_MULTILINE_QUOTED_CLEAN_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_multiline_quoted_clean_phrase_not_approved_root_comment_mock_dir/gh"
+
+_codex_multiline_quoted_clean_phrase_not_approved_root_comment_output=""
+_codex_multiline_quoted_clean_phrase_not_approved_root_comment_exit=0
+PATH="$_codex_multiline_quoted_clean_phrase_not_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_multiline_quoted_clean_phrase_not_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_multiline_quoted_clean_phrase_not_approved_root_comment_exit=$?
+_codex_multiline_quoted_clean_phrase_not_approved_root_comment_output="$(cat "$_codex_multiline_quoted_clean_phrase_not_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_multiline_quoted_clean_phrase_not_approved_root_comment_exit_needs_revision" "1" "$_codex_multiline_quoted_clean_phrase_not_approved_root_comment_exit"
+run_test "codex_multiline_quoted_clean_phrase_not_approved_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_multiline_quoted_clean_phrase_not_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_multiline_quoted_clean_phrase_not_approved_root_comment_mock_dir"
+unset _codex_multiline_quoted_clean_phrase_not_approved_root_comment_mock_dir _codex_multiline_quoted_clean_phrase_not_approved_root_comment_output _codex_multiline_quoted_clean_phrase_not_approved_root_comment_exit
+
 # codex_strip_quoted_spans handled straight-double-quotes, backticks, and
 # blockquotes, but not single-quoted spans — the fourth quoting style
 # found unprotected — so a review discussing a quoted clean phrase in

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2598,6 +2598,47 @@ run_test "codex_reaction_with_current_review_approved" "VERDICT: APPROVED" \
 rm -rf "$_codex_reaction_with_review_mock_dir"
 unset _codex_reaction_with_review_mock_dir _codex_reaction_with_review_output _codex_reaction_with_review_exit
 
+_codex_latest_review_mock_dir="$(mktemp -d)"
+cat > "$_codex_latest_review_mock_dir/gh" <<'CODEX_LATEST_REVIEW_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abclatestre1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":111,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"abclatestre1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: old finding."}]\n'
+    printf '[{"submitted_at":"2026-01-01T00:00:02Z","commit_id":"abclatestre1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_LATEST_REVIEW_GH
+chmod +x "$_codex_latest_review_mock_dir/gh"
+
+_codex_latest_review_output=""
+_codex_latest_review_exit=0
+PATH="$_codex_latest_review_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_latest_review_mock_dir/output.txt" 2>&1 || _codex_latest_review_exit=$?
+_codex_latest_review_output="$(cat "$_codex_latest_review_mock_dir/output.txt")"
+run_test "codex_latest_current_review_exit_clean" "0" "$_codex_latest_review_exit"
+run_test "codex_latest_current_review_approved" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_latest_review_output" | grep "^VERDICT:")"
+rm -rf "$_codex_latest_review_mock_dir"
+unset _codex_latest_review_mock_dir _codex_latest_review_output _codex_latest_review_exit
+
 _codex_stale_review_mock_dir="$(mktemp -d)"
 cat > "$_codex_stale_review_mock_dir/gh" <<'CODEX_STALE_REVIEW_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5085,6 +5085,56 @@ run_test "codex_usage_limit_beats_same_fetch_newer_review_verdict" "VERDICT: UNA
 rm -rf "$_codex_usage_limit_beats_same_fetch_newer_review_mock_dir"
 unset _codex_usage_limit_beats_same_fetch_newer_review_mock_dir _codex_usage_limit_beats_same_fetch_newer_review_output _codex_usage_limit_beats_same_fetch_newer_review_exit
 
+# Followup to codex_usage_limit_beats_same_fetch_newer_review: the earlier
+# fix only protected usage-limit precedence INSIDE
+# codex_combine_terminal_evidence, but codex_scan_comment_evidence's
+# upstream tracking could already discard a usage-limit comment in favor
+# of a LATER environment-error comment within the SAME fetch, before
+# combine_terminal_evidence is ever reached — both set is_actionable=1,
+# so the unconditional overwrite let the later setup-error body replace
+# the quota body (fresh evidence from PR #1490 finding 3790092216).
+# Fixture: an ancillary usage-limit comment at T1 followed by an
+# ancillary environment-error comment at T2 > T1, in the same fetch.
+_codex_usage_limit_survives_later_env_error_same_fetch_mock_dir="$(mktemp -d)"
+cat > "$_codex_usage_limit_survives_later_env_error_same_fetch_mock_dir/gh" <<'CODEX_USAGE_LIMIT_SURVIVES_LATER_ENV_ERROR_SAME_FETCH_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade01111234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":280,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":281,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"You have reached your Codex usage limits for code reviews."},{"id":282,"created_at":"2026-01-01T00:00:02Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"To use Codex here, create an environment for this repo."}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_USAGE_LIMIT_SURVIVES_LATER_ENV_ERROR_SAME_FETCH_GH
+chmod +x "$_codex_usage_limit_survives_later_env_error_same_fetch_mock_dir/gh"
+
+_codex_usage_limit_survives_later_env_error_same_fetch_output=""
+_codex_usage_limit_survives_later_env_error_same_fetch_exit=0
+PATH="$_codex_usage_limit_survives_later_env_error_same_fetch_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_usage_limit_survives_later_env_error_same_fetch_mock_dir/output.txt" 2>&1 || _codex_usage_limit_survives_later_env_error_same_fetch_exit=$?
+_codex_usage_limit_survives_later_env_error_same_fetch_output="$(cat "$_codex_usage_limit_survives_later_env_error_same_fetch_mock_dir/output.txt")"
+run_test "codex_usage_limit_survives_later_env_error_same_fetch_exit_unavailable" "3" "$_codex_usage_limit_survives_later_env_error_same_fetch_exit"
+run_test "codex_usage_limit_survives_later_env_error_same_fetch_verdict" "VERDICT: UNAVAILABLE — Codex GitHub review usage limit reached" \
+  "$(printf '%s\n' "$_codex_usage_limit_survives_later_env_error_same_fetch_output" | grep "^VERDICT:")"
+rm -rf "$_codex_usage_limit_survives_later_env_error_same_fetch_mock_dir"
+unset _codex_usage_limit_survives_later_env_error_same_fetch_mock_dir _codex_usage_limit_survives_later_env_error_same_fetch_output _codex_usage_limit_survives_later_env_error_same_fetch_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4701,6 +4701,102 @@ run_test "codex_usage_limit_topic_mention_not_quota_verdict" "VERDICT: APPROVED"
 rm -rf "$_codex_usage_limit_topic_mention_not_quota_mock_dir"
 unset _codex_usage_limit_topic_mention_not_quota_mock_dir _codex_usage_limit_topic_mention_not_quota_output _codex_usage_limit_topic_mention_not_quota_exit
 
+# CODEX_NEGATED_APPROVAL_PATTERN's target alternation only covered
+# "approved"/"lgtm"/"looks good", not "no blocking issues"/"didn't find
+# any major issues" — those are approval SIGNALS in CODEX_APPROVAL_PATTERN
+# too, but were left unguarded. A hedged/uncertain response like "I
+# cannot confirm there are no blocking issues" still matched "no blocking
+# issues" and was classified APPROVED instead of the documented
+# unrecognized-format safe-fail (fresh evidence from PR #1490 finding
+# 3789958775).
+_codex_negated_no_blocking_issues_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_negated_no_blocking_issues_root_comment_mock_dir/gh" <<'CODEX_NEGATED_NO_BLOCKING_ISSUES_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade00911234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":264,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":265,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"I cannot confirm there are no blocking issues. Needs deeper review.\\n\\n**Reviewed commit:** `facade0091`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_NEGATED_NO_BLOCKING_ISSUES_ROOT_COMMENT_GH
+chmod +x "$_codex_negated_no_blocking_issues_root_comment_mock_dir/gh"
+
+_codex_negated_no_blocking_issues_root_comment_output=""
+_codex_negated_no_blocking_issues_root_comment_exit=0
+PATH="$_codex_negated_no_blocking_issues_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_negated_no_blocking_issues_root_comment_mock_dir/output.txt" 2>&1 || _codex_negated_no_blocking_issues_root_comment_exit=$?
+_codex_negated_no_blocking_issues_root_comment_output="$(cat "$_codex_negated_no_blocking_issues_root_comment_mock_dir/output.txt")"
+run_test "codex_negated_no_blocking_issues_root_comment_exit_needs_revision" "1" "$_codex_negated_no_blocking_issues_root_comment_exit"
+run_test "codex_negated_no_blocking_issues_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_negated_no_blocking_issues_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_negated_no_blocking_issues_root_comment_mock_dir"
+unset _codex_negated_no_blocking_issues_root_comment_mock_dir _codex_negated_no_blocking_issues_root_comment_output _codex_negated_no_blocking_issues_root_comment_exit
+
+# codex_response_is_usage_limit's second alternative ("codex usage limits
+# for code reviews") had the exact same unguarded-mention gap as the
+# third alternative fixed just above — missed in that first pass since
+# only the third alternative was narrowed. A clean review merely
+# discussing the phrase in the context of docs (e.g. "No blocking issues
+# found. The docs correctly explain Codex usage limits for code
+# reviews.") was itself misclassified as a usage-limit notice (fresh
+# evidence from PR #1490 finding 3789958776).
+_codex_usage_limit_code_reviews_phrase_mention_mock_dir="$(mktemp -d)"
+cat > "$_codex_usage_limit_code_reviews_phrase_mention_mock_dir/gh" <<'CODEX_USAGE_LIMIT_CODE_REVIEWS_PHRASE_MENTION_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade00aa1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":266,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":267,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found. The docs correctly explain Codex usage limits for code reviews.\\n\\n**Reviewed commit:** `facade00aa`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_USAGE_LIMIT_CODE_REVIEWS_PHRASE_MENTION_GH
+chmod +x "$_codex_usage_limit_code_reviews_phrase_mention_mock_dir/gh"
+
+_codex_usage_limit_code_reviews_phrase_mention_output=""
+_codex_usage_limit_code_reviews_phrase_mention_exit=0
+PATH="$_codex_usage_limit_code_reviews_phrase_mention_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_usage_limit_code_reviews_phrase_mention_mock_dir/output.txt" 2>&1 || _codex_usage_limit_code_reviews_phrase_mention_exit=$?
+_codex_usage_limit_code_reviews_phrase_mention_output="$(cat "$_codex_usage_limit_code_reviews_phrase_mention_mock_dir/output.txt")"
+run_test "codex_usage_limit_code_reviews_phrase_mention_exit_clean" "0" "$_codex_usage_limit_code_reviews_phrase_mention_exit"
+run_test "codex_usage_limit_code_reviews_phrase_mention_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_usage_limit_code_reviews_phrase_mention_output" | grep "^VERDICT:")"
+rm -rf "$_codex_usage_limit_code_reviews_phrase_mention_mock_dir"
+unset _codex_usage_limit_code_reviews_phrase_mention_mock_dir _codex_usage_limit_code_reviews_phrase_mention_output _codex_usage_limit_code_reviews_phrase_mention_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2355,7 +2355,7 @@ _docs_is_outdated_filter_count="$(grep -h 'select((.isOutdated // false) == fals
 run_test "manual_readiness_audit_docs_filter_outdated" "5" "$_docs_is_outdated_filter_count"
 unset _manual_audit_fixture _manual_audit_fixture_outdated_only _docs_is_outdated_field_count _docs_is_outdated_filter_count
 
-if grep -q "Codex acknowledgement detected; waiting for current-head review, clean comment, or inline review comments" \
+if grep -q "Codex acknowledgement detected; waiting for current-head review or inline review comments" \
     "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh"; then
   _codex_ack_wait_signal="yes"
 else
@@ -2853,11 +2853,15 @@ PATH="$_codex_environment_then_clean_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_environment_then_clean_comment_mock_dir/output.txt" 2>&1 || _codex_environment_then_clean_comment_exit=$?
 _codex_environment_then_clean_comment_output="$(cat "$_codex_environment_then_clean_comment_mock_dir/output.txt")"
-run_test "codex_environment_then_clean_comment_exit_clean" "0" "$_codex_environment_then_clean_comment_exit"
-run_test "codex_environment_then_clean_comment_approved" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_environment_then_clean_comment_output" | grep "^VERDICT:")"
+run_test "codex_environment_then_clean_comment_exit_unavailable" "2" "$_codex_environment_then_clean_comment_exit"
+if printf '%s\n' "$_codex_environment_then_clean_comment_output" | grep -q "^VERDICT: APPROVED"; then
+  _codex_environment_then_clean_comment_approved="yes"
+else
+  _codex_environment_then_clean_comment_approved="no"
+fi
+run_test "codex_environment_then_clean_comment_not_approved" "no" "$_codex_environment_then_clean_comment_approved"
 rm -rf "$_codex_environment_then_clean_comment_mock_dir"
-unset _codex_environment_then_clean_comment_mock_dir _codex_environment_then_clean_comment_output _codex_environment_then_clean_comment_exit
+unset _codex_environment_then_clean_comment_mock_dir _codex_environment_then_clean_comment_output _codex_environment_then_clean_comment_exit _codex_environment_then_clean_comment_approved
 
 _codex_cloud_environment_finding_mock_dir="$(mktemp -d)"
 cat > "$_codex_cloud_environment_finding_mock_dir/gh" <<'CODEX_CLOUD_ENVIRONMENT_FINDING_GH'
@@ -2982,11 +2986,15 @@ PATH="$_codex_final_ack_clean_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_final_ack_clean_comment_mock_dir/output.txt" 2>&1 || _codex_final_ack_clean_comment_exit=$?
 _codex_final_ack_clean_comment_output="$(cat "$_codex_final_ack_clean_comment_mock_dir/output.txt")"
-run_test "codex_final_ack_clean_comment_exit_clean" "0" "$_codex_final_ack_clean_comment_exit"
-run_test "codex_final_ack_clean_comment_approved" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_final_ack_clean_comment_output" | grep "^VERDICT:")"
+run_test "codex_final_ack_clean_comment_exit_unavailable" "2" "$_codex_final_ack_clean_comment_exit"
+if printf '%s\n' "$_codex_final_ack_clean_comment_output" | grep -q "^VERDICT: APPROVED"; then
+  _codex_final_ack_clean_comment_approved="yes"
+else
+  _codex_final_ack_clean_comment_approved="no"
+fi
+run_test "codex_final_ack_clean_comment_not_approved" "no" "$_codex_final_ack_clean_comment_approved"
 rm -rf "$_codex_final_ack_clean_comment_mock_dir"
-unset _codex_final_ack_clean_comment_mock_dir _codex_final_ack_clean_comment_output _codex_final_ack_clean_comment_exit
+unset _codex_final_ack_clean_comment_mock_dir _codex_final_ack_clean_comment_output _codex_final_ack_clean_comment_exit _codex_final_ack_clean_comment_approved
 
 _codex_environment_mock_dir="$(mktemp -d)"
 cat > "$_codex_environment_mock_dir/gh" <<'CODEX_ENVIRONMENT_GH'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5899,6 +5899,105 @@ run_test "codex_fence_close_requires_whitespace_only_root_comment_verdict" "VERD
 rm -rf "$_codex_fence_close_requires_whitespace_only_root_comment_mock_dir"
 unset _codex_fence_close_requires_whitespace_only_root_comment_mock_dir _codex_fence_close_requires_whitespace_only_root_comment_output _codex_fence_close_requires_whitespace_only_root_comment_exit
 
+# Four consecutive rounds of precisely re-implementing GFM's fenced-code-
+# block semantics (detect, length, close-only-whitespace) still missed
+# GFM's entirely separate TILDE-delimited fence syntax (~~~...~~~), which
+# a backtick-only implementation never recognized at all, so a quoted
+# clean phrase inside a tilde fence stayed fully exposed to classification
+# (fresh evidence from PR #1490 finding 3795661290). Per the project's
+# explicit direction after this fourth round, codex_strip_quoted_spans no
+# longer attempts precise fence parsing at all: codex_response_is_approved
+# now treats the mere PRESENCE of a fence-opener marker (3+ consecutive
+# backticks OR tildes) anywhere in the response as disqualifying for a
+# clean verdict, closing this whole class of bug in one step rather than
+# chasing the next undiscovered fence-syntax edge case.
+_codex_tilde_fence_phrase_not_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_tilde_fence_phrase_not_approved_root_comment_mock_dir/gh" <<'CODEX_TILDE_FENCE_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade02881234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":314,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:315,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Response was:\n~~~text\nNo blocking issues found\n~~~\nThat quoted output is inaccurate.\n\n**Reviewed commit:** `facade02881`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TILDE_FENCE_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_tilde_fence_phrase_not_approved_root_comment_mock_dir/gh"
+
+_codex_tilde_fence_phrase_not_approved_root_comment_output=""
+_codex_tilde_fence_phrase_not_approved_root_comment_exit=0
+PATH="$_codex_tilde_fence_phrase_not_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_tilde_fence_phrase_not_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_tilde_fence_phrase_not_approved_root_comment_exit=$?
+_codex_tilde_fence_phrase_not_approved_root_comment_output="$(cat "$_codex_tilde_fence_phrase_not_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_tilde_fence_phrase_not_approved_root_comment_exit_needs_revision" "1" "$_codex_tilde_fence_phrase_not_approved_root_comment_exit"
+run_test "codex_tilde_fence_phrase_not_approved_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_tilde_fence_phrase_not_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_tilde_fence_phrase_not_approved_root_comment_mock_dir"
+unset _codex_tilde_fence_phrase_not_approved_root_comment_mock_dir _codex_tilde_fence_phrase_not_approved_root_comment_output _codex_tilde_fence_phrase_not_approved_root_comment_exit
+
+# Positive control for the new fence-marker bail-out above: a single
+# INLINE backtick PAIR on one line (e.g. referencing a filename), which is
+# NOT a 3+-backtick fence marker, must still classify a genuinely clean
+# review as APPROVED. Inline code references are extremely common in
+# legitimate review comments and must not be swept up by the new
+# conservative fence heuristic, which is deliberately scoped to
+# multi-backtick/tilde FENCE markers only.
+_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir/gh" <<'CODEX_INLINE_BACKTICK_PAIR_STAYS_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade02991234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":316,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":317,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"The fix looks good. See `foo.py:42` for a minor nit.\\n\\n**Reviewed commit:** `facade02991`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_INLINE_BACKTICK_PAIR_STAYS_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir/gh"
+
+_codex_inline_backtick_pair_stays_approved_root_comment_output=""
+_codex_inline_backtick_pair_stays_approved_root_comment_exit=0
+PATH="$_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_inline_backtick_pair_stays_approved_root_comment_exit=$?
+_codex_inline_backtick_pair_stays_approved_root_comment_output="$(cat "$_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_inline_backtick_pair_stays_approved_root_comment_exit_clean" "0" "$_codex_inline_backtick_pair_stays_approved_root_comment_exit"
+run_test "codex_inline_backtick_pair_stays_approved_root_comment_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_inline_backtick_pair_stays_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir"
+unset _codex_inline_backtick_pair_stays_approved_root_comment_mock_dir _codex_inline_backtick_pair_stays_approved_root_comment_output _codex_inline_backtick_pair_stays_approved_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5748,6 +5748,58 @@ run_test "codex_contraction_apostrophes_not_mangled_root_comment_verdict" "VERDI
 rm -rf "$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir"
 unset _codex_contraction_apostrophes_not_mangled_root_comment_mock_dir _codex_contraction_apostrophes_not_mangled_root_comment_output _codex_contraction_apostrophes_not_mangled_root_comment_exit
 
+# codex_strip_quoted_spans' single-line sed substitutions can't strip a
+# fenced Markdown code block (```...```): a fence marker line has no
+# PAIRED backtick on the same line for the single-backtick-pair
+# substitution to match, and the quoted content between the opening and
+# closing fence spans arbitrarily many separate lines. A review quoting
+# a clean signal inside a fenced block (e.g. "The documented output
+# is:\n```text\nNo blocking issues found\n```\nThat output is
+# inaccurate") was the fifth quoting style found unprotected, after
+# straight-quote, backtick, blockquote, and single-quote (fresh evidence
+# from PR #1490 finding 3793453010). codex_strip_quoted_spans now runs
+# an awk pre-pass that strips entire fenced-code-block regions before
+# the existing single-line substitutions.
+_codex_fenced_code_block_phrase_not_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_fenced_code_block_phrase_not_approved_root_comment_mock_dir/gh" <<'CODEX_FENCED_CODE_BLOCK_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade02551234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":308,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:309,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("The documented output is:\n```text\nNo blocking issues found\n```\nThat output is inaccurate.\n\n**Reviewed commit:** `facade02551`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FENCED_CODE_BLOCK_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_fenced_code_block_phrase_not_approved_root_comment_mock_dir/gh"
+
+_codex_fenced_code_block_phrase_not_approved_root_comment_output=""
+_codex_fenced_code_block_phrase_not_approved_root_comment_exit=0
+PATH="$_codex_fenced_code_block_phrase_not_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_fenced_code_block_phrase_not_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_fenced_code_block_phrase_not_approved_root_comment_exit=$?
+_codex_fenced_code_block_phrase_not_approved_root_comment_output="$(cat "$_codex_fenced_code_block_phrase_not_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_fenced_code_block_phrase_not_approved_root_comment_exit_needs_revision" "1" "$_codex_fenced_code_block_phrase_not_approved_root_comment_exit"
+run_test "codex_fenced_code_block_phrase_not_approved_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_fenced_code_block_phrase_not_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_fenced_code_block_phrase_not_approved_root_comment_mock_dir"
+unset _codex_fenced_code_block_phrase_not_approved_root_comment_mock_dir _codex_fenced_code_block_phrase_not_approved_root_comment_output _codex_fenced_code_block_phrase_not_approved_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -6083,6 +6083,109 @@ run_test "codex_multiline_backtick_span_not_approved_root_comment_verdict" "VERD
 rm -rf "$_codex_multiline_backtick_span_not_approved_root_comment_mock_dir"
 unset _codex_multiline_backtick_span_not_approved_root_comment_mock_dir _codex_multiline_backtick_span_not_approved_root_comment_output _codex_multiline_backtick_span_not_approved_root_comment_exit
 
+# CODEX_NEGATION_WORDS was missing "don't"/"do not" entirely — only the
+# third-person singular form ("does not"/"doesn't") was covered, not the
+# base form. A response like "This looks good at first glance, but I
+# don't approve this change." had the negation word absent from the
+# alternation, so the earlier positive phrase ("looks good") won and the
+# response was classified APPROVED instead of falling through to the
+# negated-approval check (fresh evidence from PR #1490 finding
+# 3798756826). "don't"/"do not" is now included alongside every other
+# verb's contracted and space-separated forms.
+_codex_dont_approve_not_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_dont_approve_not_approved_root_comment_mock_dir/gh" <<'CODEX_DONT_APPROVE_NOT_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'face00001234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":312,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:313,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("This looks good at first glance, but I don'"'"'t approve this change.\n\n**Reviewed commit:** `face0000`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_DONT_APPROVE_NOT_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_dont_approve_not_approved_root_comment_mock_dir/gh"
+
+_codex_dont_approve_not_approved_root_comment_output=""
+_codex_dont_approve_not_approved_root_comment_exit=0
+PATH="$_codex_dont_approve_not_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_dont_approve_not_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_dont_approve_not_approved_root_comment_exit=$?
+_codex_dont_approve_not_approved_root_comment_output="$(cat "$_codex_dont_approve_not_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_dont_approve_not_approved_root_comment_exit_needs_revision" "1" "$_codex_dont_approve_not_approved_root_comment_exit"
+run_test "codex_dont_approve_not_approved_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_dont_approve_not_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_dont_approve_not_approved_root_comment_mock_dir"
+unset _codex_dont_approve_not_approved_root_comment_mock_dir _codex_dont_approve_not_approved_root_comment_output _codex_dont_approve_not_approved_root_comment_exit
+
+# codex_strip_quoted_spans' backtick-pair regex (`[^\`]*\`) mishandles
+# CommonMark's actual code-span delimiter-run matching: a code span CAN
+# be delimited by a run of 2+ backticks (not just a single pair), and the
+# naive regex treats an adjacent 2-backtick run as two separate EMPTY
+# single-backtick pairs (each backtick immediately "closes" against its
+# neighbor with zero content between), stripping only the empty delimiter
+# markers and leaving the actual enclosed content fully exposed — e.g. a
+# double-backtick-quoted `` `` No blocking issues found `` `` survived
+# stripping intact and matched CODEX_APPROVAL_PATTERN, returning APPROVED
+# (fresh evidence from PR #1490 finding 3798756834).
+# codex_response_has_fence_marker's backtick threshold is now 2+ (was
+# 3+), so a 2+-backtick run disqualifies the same way a 3+ run always
+# has; single backtick PAIRS are unaffected and still get precise
+# stripping.
+_codex_double_backtick_span_not_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_double_backtick_span_not_approved_root_comment_mock_dir/gh" <<'CODEX_DOUBLE_BACKTICK_SPAN_NOT_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'face11121234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":314,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:315,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("The documented response ``No blocking issues found`` is inaccurate and should be corrected.\n\n**Reviewed commit:** `face1112`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_DOUBLE_BACKTICK_SPAN_NOT_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_double_backtick_span_not_approved_root_comment_mock_dir/gh"
+
+_codex_double_backtick_span_not_approved_root_comment_output=""
+_codex_double_backtick_span_not_approved_root_comment_exit=0
+PATH="$_codex_double_backtick_span_not_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_double_backtick_span_not_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_double_backtick_span_not_approved_root_comment_exit=$?
+_codex_double_backtick_span_not_approved_root_comment_output="$(cat "$_codex_double_backtick_span_not_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_double_backtick_span_not_approved_root_comment_exit_needs_revision" "1" "$_codex_double_backtick_span_not_approved_root_comment_exit"
+run_test "codex_double_backtick_span_not_approved_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_double_backtick_span_not_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_double_backtick_span_not_approved_root_comment_mock_dir"
+unset _codex_double_backtick_span_not_approved_root_comment_mock_dir _codex_double_backtick_span_not_approved_root_comment_output _codex_double_backtick_span_not_approved_root_comment_exit
+
 # codex_strip_quoted_spans handled straight-double-quotes, backticks, and
 # blockquotes, but not single-quoted spans — the fourth quoting style
 # found unprotected — so a review discussing a quoted clean phrase in

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3279,13 +3279,18 @@ unset _codex_ack_repoll_env_then_reaction_mock_dir _codex_ack_repoll_env_then_re
 
 # Reproduces PR-Agent advisory finding on PR #1490 (main-loop env-error
 # override): the main poll loop recorded an environment setup error on its
-# first iteration (SEEN_ENVIRONMENT_ERROR=1) but a later iteration's clean
-# submitted review still exited APPROVED without checking that flag,
-# silently discarding the recorded environment failure. Sequence: iteration
-# 1 finds an environment-setup root comment -> iteration 2 finds no new
-# comment but a clean current-head review -> expect
-# codex-github-environment-missing, not APPROVED. Covers all four APPROVED
-# exit sites' shared guard, exercised here via the main poll loop.
+# first iteration (SEEN_ENVIRONMENT_ERROR=1) but a later iteration's
+# same-timestamp-or-older submitted review still exited APPROVED without
+# checking that flag, silently discarding the recorded environment failure.
+# Sequence: iteration 1 finds an environment-setup root comment -> iteration
+# 2 finds no new comment but a clean current-head review AT THE SAME
+# TIMESTAMP as the recorded environment error -> expect
+# codex-github-environment-missing, not APPROVED (ties favor the non-clean
+# evidence, per codex_response_requires_attention's tie-break principle).
+# Covers all four APPROVED exit sites' shared guard, exercised here via the
+# main poll loop. A strictly NEWER review is expected to supersede the
+# stale environment error instead — see
+# codex_main_loop_env_then_newer_review_supersedes below.
 _codex_main_loop_env_then_review_mock_dir="$(mktemp -d)"
 printf '0\n' > "$_codex_main_loop_env_then_review_mock_dir/comment_calls"
 printf '0\n' > "$_codex_main_loop_env_then_review_mock_dir/review_calls"
@@ -3308,7 +3313,7 @@ case "$*" in
     calls=$((calls + 1))
     printf '%s\n' "$calls" > "$calls_file"
     if [ "$calls" -ge 2 ]; then
-      printf '[{"submitted_at":"2026-01-01T00:00:03Z","commit_id":"mainloopenv1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+      printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"mainloopenv1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
     else
       printf '[]\n'
     fi
@@ -3344,6 +3349,123 @@ run_test "codex_main_loop_env_then_review_reason" "REASON=codex-github-environme
   "$(printf '%s\n' "$_codex_main_loop_env_then_review_output" | grep "^REASON=")"
 rm -rf "$_codex_main_loop_env_then_review_mock_dir"
 unset _codex_main_loop_env_then_review_mock_dir _codex_main_loop_env_then_review_output _codex_main_loop_env_then_review_exit
+
+# Reproduces Codex finding on PR #1490 (P2, comment id 3787679406): the
+# environment-error guard must not be permanently sticky — a genuinely
+# fresh (strictly newer timestamp) current-head approved review must
+# supersede a now-stale recorded environment error, so an operator fixing
+# the Codex cloud environment mid-poll can recover within the same
+# invocation. Sequence identical to codex_main_loop_env_then_review above,
+# except the review's submitted_at is strictly newer than the env-error
+# comment's created_at -> expect APPROVED, not environment-missing.
+_codex_main_loop_env_then_newer_review_supersedes_mock_dir="$(mktemp -d)"
+printf '0\n' > "$_codex_main_loop_env_then_newer_review_supersedes_mock_dir/comment_calls"
+printf '0\n' > "$_codex_main_loop_env_then_newer_review_supersedes_mock_dir/review_calls"
+cat > "$_codex_main_loop_env_then_newer_review_supersedes_mock_dir/gh" <<'CODEX_MAIN_LOOP_ENV_THEN_NEWER_REVIEW_SUPERSEDES_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'newerreview1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":132,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    calls_file="$(dirname "$0")/review_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    if [ "$calls" -ge 2 ]; then
+      printf '[{"submitted_at":"2026-01-01T00:00:03Z","commit_id":"newerreview1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    else
+      printf '[]\n'
+    fi
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    calls_file="$(dirname "$0")/comment_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    if [ "$calls" -eq 2 ]; then
+      printf '[{"id":230,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"To use Codex here, create an environment for this repo."}]\n'
+    else
+      printf '[]\n'
+    fi
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_MAIN_LOOP_ENV_THEN_NEWER_REVIEW_SUPERSEDES_GH
+chmod +x "$_codex_main_loop_env_then_newer_review_supersedes_mock_dir/gh"
+
+_codex_main_loop_env_then_newer_review_supersedes_output=""
+_codex_main_loop_env_then_newer_review_supersedes_exit=0
+PATH="$_codex_main_loop_env_then_newer_review_supersedes_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 2 --max-retriggers 0 \
+  >"$_codex_main_loop_env_then_newer_review_supersedes_mock_dir/output.txt" 2>&1 || _codex_main_loop_env_then_newer_review_supersedes_exit=$?
+_codex_main_loop_env_then_newer_review_supersedes_output="$(cat "$_codex_main_loop_env_then_newer_review_supersedes_mock_dir/output.txt")"
+run_test "codex_main_loop_env_then_newer_review_supersedes_exit_clean" "0" "$_codex_main_loop_env_then_newer_review_supersedes_exit"
+run_test "codex_main_loop_env_then_newer_review_supersedes_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_main_loop_env_then_newer_review_supersedes_output" | grep "^VERDICT:")"
+rm -rf "$_codex_main_loop_env_then_newer_review_supersedes_mock_dir"
+unset _codex_main_loop_env_then_newer_review_supersedes_mock_dir _codex_main_loop_env_then_newer_review_supersedes_output _codex_main_loop_env_then_newer_review_supersedes_exit
+
+# Reproduces Codex finding on PR #1490 (P1, comment id 3787679402): the
+# codex_response_requires_attention tie-break helper (added in the prior
+# cycle to fix unrecognized-format ties) checked only the approval pattern,
+# so a mixed response containing BOTH an approval phrase and a blocking
+# marker (e.g. "No blocking issues found. Must fix ...") was misclassified
+# as a clean approval and lost the tie-break to a clean root comment,
+# producing APPROVED instead of the classifier's blocking-first
+# NEEDS_REVISION. Root comment is a clean approval; tied review body
+# contains both an approval phrase and a blocking marker.
+_codex_tied_mixed_blocking_review_wins_mock_dir="$(mktemp -d)"
+cat > "$_codex_tied_mixed_blocking_review_wins_mock_dir/gh" <<'CODEX_TIED_MIXED_BLOCKING_REVIEW_WINS_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'deadb00d12345678\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":133,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"deadb00d12345678","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found. Must fix the typo on line 4."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":234,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex Review: Didn'\''t find any major issues.\\n\\n**Reviewed commit:** `deadb00d1234`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TIED_MIXED_BLOCKING_REVIEW_WINS_GH
+chmod +x "$_codex_tied_mixed_blocking_review_wins_mock_dir/gh"
+
+_codex_tied_mixed_blocking_review_wins_output=""
+_codex_tied_mixed_blocking_review_wins_exit=0
+PATH="$_codex_tied_mixed_blocking_review_wins_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_tied_mixed_blocking_review_wins_mock_dir/output.txt" 2>&1 || _codex_tied_mixed_blocking_review_wins_exit=$?
+_codex_tied_mixed_blocking_review_wins_output="$(cat "$_codex_tied_mixed_blocking_review_wins_mock_dir/output.txt")"
+run_test "codex_tied_mixed_blocking_review_wins_exit_needs_revision" "1" "$_codex_tied_mixed_blocking_review_wins_exit"
+run_test "codex_tied_mixed_blocking_review_wins_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_tied_mixed_blocking_review_wins_output" | grep "^VERDICT:")"
+rm -rf "$_codex_tied_mixed_blocking_review_wins_mock_dir"
+unset _codex_tied_mixed_blocking_review_wins_mock_dir _codex_tied_mixed_blocking_review_wins_output _codex_tied_mixed_blocking_review_wins_exit
 
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4001,6 +4001,59 @@ run_test "codex_blocking_text_mentions_usage_limit_verdict" "VERDICT: NEEDS_REVI
 rm -rf "$_codex_blocking_text_mentions_usage_limit_mock_dir"
 unset _codex_blocking_text_mentions_usage_limit_mock_dir _codex_blocking_text_mentions_usage_limit_output _codex_blocking_text_mentions_usage_limit_exit
 
+# Reproduces Codex finding on PR #1490 (P1, comment id 3788118857): when
+# the latest timestamp contains a bodyless submitted review tied with a
+# clean SHA-pinned terminal comment, codex_combine_terminal_evidence's
+# presence check `[ -n "$review_body" ]` treated the empty-bodied review as
+# absent, so the clean terminal comment won by default and the script
+# returned APPROVED — even though codex_response_requires_attention
+# correctly classifies an empty body as unrecognized/requires-attention.
+# Presence is now checked via review_time (guaranteed non-empty for any
+# selected review by the poll query's filter), not review_body. Fixture:
+# clean terminal comment, clean submitted review, and an empty submitted
+# review, all tied at the same timestamp -> expect NOT APPROVED (the empty
+# review participates in the tie-break and the script does not silently
+# approve).
+_codex_bodyless_tied_review_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_bodyless_tied_review_not_approved_mock_dir/gh" <<'CODEX_BODYLESS_TIED_REVIEW_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'c0ffee001234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":200,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"c0ffee001234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."},{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"c0ffee001234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":""}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":310,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex Review: Didn'\''t find any major issues.\\n\\n**Reviewed commit:** `c0ffee001234`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_BODYLESS_TIED_REVIEW_NOT_APPROVED_GH
+chmod +x "$_codex_bodyless_tied_review_not_approved_mock_dir/gh"
+
+_codex_bodyless_tied_review_not_approved_output=""
+_codex_bodyless_tied_review_not_approved_exit=0
+PATH="$_codex_bodyless_tied_review_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_bodyless_tied_review_not_approved_mock_dir/output.txt" 2>&1 || _codex_bodyless_tied_review_not_approved_exit=$?
+_codex_bodyless_tied_review_not_approved_output="$(cat "$_codex_bodyless_tied_review_not_approved_mock_dir/output.txt")"
+run_test "codex_bodyless_tied_review_not_approved_verdict_not_approved" "0" \
+  "$(printf '%s\n' "$_codex_bodyless_tied_review_not_approved_output" | grep -c "^VERDICT: APPROVED$" || true)"
+rm -rf "$_codex_bodyless_tied_review_not_approved_mock_dir"
+unset _codex_bodyless_tied_review_not_approved_mock_dir _codex_bodyless_tied_review_not_approved_output _codex_bodyless_tied_review_not_approved_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2763,6 +2763,98 @@ run_test "codex_tied_root_blocks_review_verdict" "VERDICT: NEEDS_REVISION" \
 rm -rf "$_codex_tied_root_blocks_review_mock_dir"
 unset _codex_tied_root_blocks_review_mock_dir _codex_tied_root_blocks_review_output _codex_tied_root_blocks_review_exit
 
+# Reverse of codex_tied_root_blocks_review: this time the SHA-pinned root
+# comment is CLEAN and the submitted review (same timestamp) is BLOCKING. The
+# tie-break must be symmetric (blocking wins on ties regardless of which
+# source supplied it), so this must also resolve to NEEDS_REVISION.
+_codex_tied_review_blocks_root_mock_dir="$(mktemp -d)"
+cat > "$_codex_tied_review_blocks_root_mock_dir/gh" <<'CODEX_TIED_REVIEW_BLOCKS_ROOT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'beefcafe1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":129,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"beefcafe1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: tied review finding."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":229,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex Review: Didn'\''t find any major issues.\\n\\n**Reviewed commit:** `beefcafe1234`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TIED_REVIEW_BLOCKS_ROOT_GH
+chmod +x "$_codex_tied_review_blocks_root_mock_dir/gh"
+
+_codex_tied_review_blocks_root_output=""
+_codex_tied_review_blocks_root_exit=0
+PATH="$_codex_tied_review_blocks_root_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_tied_review_blocks_root_mock_dir/output.txt" 2>&1 || _codex_tied_review_blocks_root_exit=$?
+_codex_tied_review_blocks_root_output="$(cat "$_codex_tied_review_blocks_root_mock_dir/output.txt")"
+run_test "codex_tied_review_blocks_root_exit_needs_revision" "1" "$_codex_tied_review_blocks_root_exit"
+run_test "codex_tied_review_blocks_root_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_tied_review_blocks_root_output" | grep "^VERDICT:")"
+rm -rf "$_codex_tied_review_blocks_root_mock_dir"
+unset _codex_tied_review_blocks_root_mock_dir _codex_tied_review_blocks_root_output _codex_tied_review_blocks_root_exit
+
+# A clean submitted review arrives first, then a SHA-pinned BLOCKING root
+# comment, then a newer non-terminal acknowledgement comment. Greedily
+# selecting the latest root comment overall (the ack) would discard the
+# blocking root comment and let the earlier clean review win by default. The
+# terminal SHA-pinned comment must be selected independently of the latest
+# ancillary comment.
+_codex_ack_does_not_erase_blocking_root_mock_dir="$(mktemp -d)"
+cat > "$_codex_ack_does_not_erase_blocking_root_mock_dir/gh" <<'CODEX_ACK_DOES_NOT_ERASE_BLOCKING_ROOT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'dead12341234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":130,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"dead12341234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":231,"created_at":"2026-01-01T00:00:02Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: root finding before ack.\\n\\n**Reviewed commit:** `dead12341234`"},{"id":232,"created_at":"2026-01-01T00:00:03Z","user":{"login":"chatgpt-codex-connector"},"body":"If Codex has suggestions, it will comment; otherwise it will react with thumbs up."}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_ACK_DOES_NOT_ERASE_BLOCKING_ROOT_GH
+chmod +x "$_codex_ack_does_not_erase_blocking_root_mock_dir/gh"
+
+_codex_ack_does_not_erase_blocking_root_output=""
+_codex_ack_does_not_erase_blocking_root_exit=0
+PATH="$_codex_ack_does_not_erase_blocking_root_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_ack_does_not_erase_blocking_root_mock_dir/output.txt" 2>&1 || _codex_ack_does_not_erase_blocking_root_exit=$?
+_codex_ack_does_not_erase_blocking_root_output="$(cat "$_codex_ack_does_not_erase_blocking_root_mock_dir/output.txt")"
+run_test "codex_ack_does_not_erase_blocking_root_exit_needs_revision" "1" "$_codex_ack_does_not_erase_blocking_root_exit"
+run_test "codex_ack_does_not_erase_blocking_root_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_ack_does_not_erase_blocking_root_output" | grep "^VERDICT:")"
+rm -rf "$_codex_ack_does_not_erase_blocking_root_mock_dir"
+unset _codex_ack_does_not_erase_blocking_root_mock_dir _codex_ack_does_not_erase_blocking_root_output _codex_ack_does_not_erase_blocking_root_exit
+
 _codex_async_newer_root_blocks_old_review_mock_dir="$(mktemp -d)"
 printf '0\n' > "$_codex_async_newer_root_blocks_old_review_mock_dir/comment_calls"
 printf '0\n' > "$_codex_async_newer_root_blocks_old_review_mock_dir/review_calls"
@@ -2821,6 +2913,79 @@ run_test "codex_async_newer_root_blocks_old_review_verdict" "VERDICT: NEEDS_REVI
   "$(printf '%s\n' "$_codex_async_newer_root_blocks_old_review_output" | grep "^VERDICT:")"
 rm -rf "$_codex_async_newer_root_blocks_old_review_mock_dir"
 unset _codex_async_newer_root_blocks_old_review_mock_dir _codex_async_newer_root_blocks_old_review_output _codex_async_newer_root_blocks_old_review_exit
+
+# Root comments are a terminal evidence source. If the root-comments fetch
+# fails specifically during the async grace period while the reviews fetch
+# succeeds with a clean review, the failure must be treated as unavailable
+# (fail closed) rather than silently falling through to accept the clean
+# review as if no root evidence existed (fail open). Sequence: idempotency
+# check (call 1, empty) and main-loop poll (call 2, empty) succeed normally;
+# the async-grace root-comments fetch (call 3) fails.
+_codex_async_root_fetch_failure_mock_dir="$(mktemp -d)"
+printf '0\n' > "$_codex_async_root_fetch_failure_mock_dir/comment_calls"
+printf '0\n' > "$_codex_async_root_fetch_failure_mock_dir/review_calls"
+cat > "$_codex_async_root_fetch_failure_mock_dir/gh" <<'CODEX_ASYNC_ROOT_FETCH_FAILURE_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'fade12341234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":128,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    calls_file="$(dirname "$0")/review_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    if [ "$calls" -ge 2 ]; then
+      printf '[{"submitted_at":"2026-01-01T00:00:05Z","commit_id":"fade12341234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    else
+      printf '[]\n'
+    fi
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    calls_file="$(dirname "$0")/comment_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    if [ "$calls" -ge 3 ]; then
+      echo "simulated transient API failure" >&2
+      exit 1
+    fi
+    printf '[]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_ASYNC_ROOT_FETCH_FAILURE_GH
+chmod +x "$_codex_async_root_fetch_failure_mock_dir/gh"
+
+_codex_async_root_fetch_failure_output=""
+_codex_async_root_fetch_failure_exit=0
+PATH="$_codex_async_root_fetch_failure_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_async_root_fetch_failure_mock_dir/output.txt" 2>&1 || _codex_async_root_fetch_failure_exit=$?
+_codex_async_root_fetch_failure_output="$(cat "$_codex_async_root_fetch_failure_mock_dir/output.txt")"
+run_test "codex_async_root_fetch_failure_exit_unavailable" "2" "$_codex_async_root_fetch_failure_exit"
+run_test "codex_async_root_fetch_failure_verdict" \
+  "VERDICT: TIMED_OUT — failed to fetch Codex root comments during async grace period (treated as unavailable)" \
+  "$(printf '%s\n' "$_codex_async_root_fetch_failure_output" | grep "^VERDICT:")"
+if printf '%s\n' "$_codex_async_root_fetch_failure_output" | grep -q "^VERDICT: APPROVED"; then
+  _codex_async_root_fetch_failure_approved="yes"
+else
+  _codex_async_root_fetch_failure_approved="no"
+fi
+run_test "codex_async_root_fetch_failure_not_approved" "no" "$_codex_async_root_fetch_failure_approved"
+rm -rf "$_codex_async_root_fetch_failure_mock_dir"
+unset _codex_async_root_fetch_failure_mock_dir _codex_async_root_fetch_failure_output _codex_async_root_fetch_failure_exit _codex_async_root_fetch_failure_approved
 
 _codex_reaction_with_review_mock_dir="$(mktemp -d)"
 cat > "$_codex_reaction_with_review_mock_dir/gh" <<'CODEX_REACTION_WITH_REVIEW_GH'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -6491,6 +6491,105 @@ run_test "codex_not_only_safe_to_merge_stays_approved_root_comment_verdict" "VER
 rm -rf "$_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir"
 unset _codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir _codex_not_only_safe_to_merge_stays_approved_root_comment_output _codex_not_only_safe_to_merge_stays_approved_root_comment_exit
 
+# CODEX_NEGATION_WORDS was missing "would not"/"wouldn't" — the fourth
+# consecutive missing-negation-word finding (don't, should/mustn't, now
+# wouldn't), which prompted a proactive sweep of the remaining common
+# English negation forms (was/were/would/has/have/had, contracted and
+# space-separated) in one pass rather than continuing to fix them one at
+# a time (fresh evidence from PR #1490 finding 3799391883).
+_codex_wouldnt_approve_not_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_wouldnt_approve_not_approved_root_comment_mock_dir/gh" <<'CODEX_WOULDNT_APPROVE_NOT_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'face88881234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":328,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":329,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"This looks good at first glance, but I wouldn'"'"'t approve this change.\\n\\n**Reviewed commit:** `face8888`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_WOULDNT_APPROVE_NOT_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_wouldnt_approve_not_approved_root_comment_mock_dir/gh"
+
+_codex_wouldnt_approve_not_approved_root_comment_output=""
+_codex_wouldnt_approve_not_approved_root_comment_exit=0
+PATH="$_codex_wouldnt_approve_not_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_wouldnt_approve_not_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_wouldnt_approve_not_approved_root_comment_exit=$?
+_codex_wouldnt_approve_not_approved_root_comment_output="$(cat "$_codex_wouldnt_approve_not_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_wouldnt_approve_not_approved_root_comment_exit_needs_revision" "1" "$_codex_wouldnt_approve_not_approved_root_comment_exit"
+run_test "codex_wouldnt_approve_not_approved_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_wouldnt_approve_not_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_wouldnt_approve_not_approved_root_comment_mock_dir"
+unset _codex_wouldnt_approve_not_approved_root_comment_mock_dir _codex_wouldnt_approve_not_approved_root_comment_output _codex_wouldnt_approve_not_approved_root_comment_exit
+
+# "did not"/"didn't" is DELIBERATELY excluded from the negation-word
+# sweep above (see the comment above CODEX_NEGATION_WORDS): it already
+# appears baked into CODEX_NEGATED_APPROVAL_TARGET_WORDS as part of the
+# atomic phrase "didn't find any major issues" (itself a clean signal,
+# not something to negate). Adding bare "didn.t" as a general negation
+# word was verified during this sweep's own development to introduce a
+# genuine false positive — caught and reverted before ever being
+# committed — where a doubly-reinforced clean response ("Codex didn't
+# find any major issues and looks good.") was misclassified as
+# NEEDS_REVISION because "didn't" matched as a bare negation and reached
+# the separate "looks good" target later in the same unpunctuated
+# sentence. This test guards against that specific regression being
+# silently reintroduced by a future negation-word addition.
+_codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir/gh" <<'CODEX_DIDNT_FIND_ISSUES_AND_LOOKS_GOOD_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'face99991234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":330,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":331,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex didn'"'"'t find any major issues and looks good.\\n\\n**Reviewed commit:** `face9999`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_DIDNT_FIND_ISSUES_AND_LOOKS_GOOD_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir/gh"
+
+_codex_didnt_find_issues_and_looks_good_approved_root_comment_output=""
+_codex_didnt_find_issues_and_looks_good_approved_root_comment_exit=0
+PATH="$_codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_didnt_find_issues_and_looks_good_approved_root_comment_exit=$?
+_codex_didnt_find_issues_and_looks_good_approved_root_comment_output="$(cat "$_codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_didnt_find_issues_and_looks_good_approved_root_comment_exit_clean" "0" "$_codex_didnt_find_issues_and_looks_good_approved_root_comment_exit"
+run_test "codex_didnt_find_issues_and_looks_good_approved_root_comment_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_didnt_find_issues_and_looks_good_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir"
+unset _codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir _codex_didnt_find_issues_and_looks_good_approved_root_comment_output _codex_didnt_find_issues_and_looks_good_approved_root_comment_exit
+
 # codex_strip_quoted_spans handled straight-double-quotes, backticks, and
 # blockquotes, but not single-quoted spans — the fourth quoting style
 # found unprotected — so a review discussing a quoted clean phrase in

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5656,6 +5656,59 @@ run_test "codex_quoted_blocker_token_stays_approved_root_comment_verdict" "VERDI
 rm -rf "$_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir"
 unset _codex_quoted_blocker_token_stays_approved_root_comment_mock_dir _codex_quoted_blocker_token_stays_approved_root_comment_output _codex_quoted_blocker_token_stays_approved_root_comment_exit
 
+# codex_response_is_blocking briefly gained the same fence-marker bail-out
+# used by is_usage_limit/is_environment_error/is_approved (applied "for
+# consistency" while fixing finding 3796042503), but that guard is unsafe
+# specifically for this classifier: a genuinely asserted blocking finding
+# OUTSIDE a fence, in a review that also happens to contain an unrelated
+# fenced code example elsewhere, must still be detected — Protocol 93's
+# "blocking always wins" invariant depends on is_blocking correctly
+# reporting TRUE for such a review, and bailing out on fence presence let
+# a real blocker fall through to the unrecognized-format safe-fail instead
+# of being reported as a detected blocking finding (fresh evidence from PR
+# #1490 finding 3796396399, a regression introduced by 3796042503's fix).
+# is_blocking must keep detecting a real blocker even when the review also
+# contains an unrelated fenced example, unlike the other three classifiers.
+_codex_fenced_example_outside_blocker_stays_blocking_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_fenced_example_outside_blocker_stays_blocking_root_comment_mock_dir/gh" <<'CODEX_FENCED_EXAMPLE_OUTSIDE_BLOCKER_STAYS_BLOCKING_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade02221234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":303,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"facade02221234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"This must fix the validation error before merge.\\n\\nExample:\\n```\\nfoo();\\n```"}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FENCED_EXAMPLE_OUTSIDE_BLOCKER_STAYS_BLOCKING_ROOT_COMMENT_GH
+chmod +x "$_codex_fenced_example_outside_blocker_stays_blocking_root_comment_mock_dir/gh"
+
+_codex_fenced_example_outside_blocker_stays_blocking_root_comment_output=""
+_codex_fenced_example_outside_blocker_stays_blocking_root_comment_exit=0
+PATH="$_codex_fenced_example_outside_blocker_stays_blocking_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_fenced_example_outside_blocker_stays_blocking_root_comment_mock_dir/output.txt" 2>&1 || _codex_fenced_example_outside_blocker_stays_blocking_root_comment_exit=$?
+_codex_fenced_example_outside_blocker_stays_blocking_root_comment_output="$(cat "$_codex_fenced_example_outside_blocker_stays_blocking_root_comment_mock_dir/output.txt")"
+run_test "codex_fenced_example_outside_blocker_stays_blocking_root_comment_exit_needs_revision" "1" "$_codex_fenced_example_outside_blocker_stays_blocking_root_comment_exit"
+run_test "codex_fenced_example_outside_blocker_stays_blocking_root_comment_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_fenced_example_outside_blocker_stays_blocking_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_fenced_example_outside_blocker_stays_blocking_root_comment_mock_dir"
+unset _codex_fenced_example_outside_blocker_stays_blocking_root_comment_mock_dir _codex_fenced_example_outside_blocker_stays_blocking_root_comment_output _codex_fenced_example_outside_blocker_stays_blocking_root_comment_exit
+
 # codex_strip_quoted_spans handled straight-double-quotes, backticks, and
 # blockquotes, but not single-quoted spans — the fourth quoting style
 # found unprotected — so a review discussing a quoted clean phrase in

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2983,6 +2983,46 @@ run_test "codex_environment_phrase_finding_verdict" "VERDICT: NEEDS_REVISION" \
 rm -rf "$_codex_environment_phrase_finding_mock_dir"
 unset _codex_environment_phrase_finding_mock_dir _codex_environment_phrase_finding_output _codex_environment_phrase_finding_exit
 
+_codex_quoted_environment_finding_mock_dir="$(mktemp -d)"
+cat > "$_codex_quoted_environment_finding_mock_dir/gh" <<'CODEX_QUOTED_ENVIRONMENT_FINDING_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcenvquote1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":116,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"abcenvquote1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: docs must not claim: To use Codex here, create an environment for this repo."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_QUOTED_ENVIRONMENT_FINDING_GH
+chmod +x "$_codex_quoted_environment_finding_mock_dir/gh"
+
+_codex_quoted_environment_finding_output=""
+_codex_quoted_environment_finding_exit=0
+PATH="$_codex_quoted_environment_finding_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_quoted_environment_finding_mock_dir/output.txt" 2>&1 || _codex_quoted_environment_finding_exit=$?
+_codex_quoted_environment_finding_output="$(cat "$_codex_quoted_environment_finding_mock_dir/output.txt")"
+run_test "codex_quoted_environment_finding_exit_needs_revision" "1" "$_codex_quoted_environment_finding_exit"
+run_test "codex_quoted_environment_finding_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_quoted_environment_finding_output" | grep "^VERDICT:")"
+rm -rf "$_codex_quoted_environment_finding_mock_dir"
+unset _codex_quoted_environment_finding_mock_dir _codex_quoted_environment_finding_output _codex_quoted_environment_finding_exit
+
 _codex_final_ack_clean_comment_mock_dir="$(mktemp -d)"
 printf '0\n' > "$_codex_final_ack_clean_comment_mock_dir/comment_calls"
 cat > "$_codex_final_ack_clean_comment_mock_dir/gh" <<'CODEX_FINAL_ACK_CLEAN_COMMENT_GH'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4889,6 +4889,104 @@ run_test "codex_negation_prior_sentence_does_not_leak_root_comment_verdict" "VER
 rm -rf "$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir"
 unset _codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir _codex_negation_prior_sentence_does_not_leak_root_comment_output _codex_negation_prior_sentence_does_not_leak_root_comment_exit
 
+# Two more negation gaps surfaced once the pattern was unbounded: (a) the
+# target alternation had "approved" but not the bare verb "approve", and
+# (b) the pattern only checked negation-THEN-approval order, so an
+# approval phrase appearing BEFORE the negation in the same sentence
+# ("This looks good at first glance, but I cannot approve this change")
+# wasn't caught (fresh evidence from PR #1490 finding 3790023141). Both
+# alternation orders are now checked, and the target list includes the
+# bare verb.
+_codex_negation_reverse_order_cannot_approve_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_negation_reverse_order_cannot_approve_root_comment_mock_dir/gh" <<'CODEX_NEGATION_REVERSE_ORDER_CANNOT_APPROVE_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade00dd1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":272,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":273,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"This looks good at first glance, but I cannot approve this change.\\n\\n**Reviewed commit:** `facade00dd`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_NEGATION_REVERSE_ORDER_CANNOT_APPROVE_ROOT_COMMENT_GH
+chmod +x "$_codex_negation_reverse_order_cannot_approve_root_comment_mock_dir/gh"
+
+_codex_negation_reverse_order_cannot_approve_root_comment_output=""
+_codex_negation_reverse_order_cannot_approve_root_comment_exit=0
+PATH="$_codex_negation_reverse_order_cannot_approve_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_negation_reverse_order_cannot_approve_root_comment_mock_dir/output.txt" 2>&1 || _codex_negation_reverse_order_cannot_approve_root_comment_exit=$?
+_codex_negation_reverse_order_cannot_approve_root_comment_output="$(cat "$_codex_negation_reverse_order_cannot_approve_root_comment_mock_dir/output.txt")"
+run_test "codex_negation_reverse_order_cannot_approve_root_comment_exit_needs_revision" "1" "$_codex_negation_reverse_order_cannot_approve_root_comment_exit"
+run_test "codex_negation_reverse_order_cannot_approve_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_negation_reverse_order_cannot_approve_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_negation_reverse_order_cannot_approve_root_comment_mock_dir"
+unset _codex_negation_reverse_order_cannot_approve_root_comment_mock_dir _codex_negation_reverse_order_cannot_approve_root_comment_output _codex_negation_reverse_order_cannot_approve_root_comment_exit
+
+# codex_scan_comment_evidence tracked COMMENT_LATEST_BODY without
+# recording whether it was the SAME comment as COMMENT_TERMINAL_BODY. When
+# the only comment is a clean SHA-pinned terminal review whose OWN finding
+# text happens to quote the environment-setup message (e.g. flagging that
+# docs accurately quote it), codex_combine_terminal_evidence's ancillary
+# environment-error/usage-limit override re-classified that SAME terminal
+# comment as if it were a genuinely separate ancillary setup-failure
+# notice, downgrading APPROVED to codex-github-environment-missing (fresh
+# evidence from PR #1490 finding 3790023143). COMMENT_LATEST_IS_TERMINAL
+# now gates that override so it never fires on the terminal comment itself.
+_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir="$(mktemp -d)"
+cat > "$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir/gh" <<'CODEX_TERMINAL_COMMENT_QUOTES_ENV_ERROR_NOT_ANCILLARY_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade00ee1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":274,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":275,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found. The docs accurately quote: To use Codex here, create an environment for this repo.\\n\\n**Reviewed commit:** `facade00ee`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TERMINAL_COMMENT_QUOTES_ENV_ERROR_NOT_ANCILLARY_GH
+chmod +x "$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir/gh"
+
+_codex_terminal_comment_quotes_env_error_not_ancillary_output=""
+_codex_terminal_comment_quotes_env_error_not_ancillary_exit=0
+PATH="$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir/output.txt" 2>&1 || _codex_terminal_comment_quotes_env_error_not_ancillary_exit=$?
+_codex_terminal_comment_quotes_env_error_not_ancillary_output="$(cat "$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir/output.txt")"
+run_test "codex_terminal_comment_quotes_env_error_not_ancillary_exit_clean" "0" "$_codex_terminal_comment_quotes_env_error_not_ancillary_exit"
+run_test "codex_terminal_comment_quotes_env_error_not_ancillary_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_terminal_comment_quotes_env_error_not_ancillary_output" | grep "^VERDICT:")"
+rm -rf "$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir"
+unset _codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir _codex_terminal_comment_quotes_env_error_not_ancillary_output _codex_terminal_comment_quotes_env_error_not_ancillary_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4550,6 +4550,56 @@ run_test "codex_unapproved_prefix_root_comment_verdict" "VERDICT: NEEDS_REVISION
 rm -rf "$_codex_unapproved_prefix_root_comment_mock_dir"
 unset _codex_unapproved_prefix_root_comment_mock_dir _codex_unapproved_prefix_root_comment_output _codex_unapproved_prefix_root_comment_exit
 
+# Followup to codex_negated_approval_root_comment/codex_unapproved_prefix_
+# root_comment: CODEX_NEGATED_APPROVAL_PATTERN required an unbroken
+# [[:space:]]+ directly between the negation word and the approval word,
+# so GitHub's rendered Markdown bold ("This change is **not** approved")
+# — whose raw text has "**" wedged between "not" and the following
+# space — did not match, and the bare \bapproved\b in
+# CODEX_APPROVAL_PATTERN still did, misclassifying the rejection as
+# APPROVED (fresh evidence from PR #1490 finding 3789878264).
+# CODEX_NEGATED_APPROVAL_PATTERN now tolerates optional Markdown emphasis
+# markers between the negation and approval words.
+_codex_markdown_negated_approval_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_markdown_negated_approval_root_comment_mock_dir/gh" <<'CODEX_MARKDOWN_NEGATED_APPROVAL_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade006d1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":258,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":259,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"This change is **not** approved. Needs more work.\\n\\n**Reviewed commit:** `facade006d`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_MARKDOWN_NEGATED_APPROVAL_ROOT_COMMENT_GH
+chmod +x "$_codex_markdown_negated_approval_root_comment_mock_dir/gh"
+
+_codex_markdown_negated_approval_root_comment_output=""
+_codex_markdown_negated_approval_root_comment_exit=0
+PATH="$_codex_markdown_negated_approval_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_markdown_negated_approval_root_comment_mock_dir/output.txt" 2>&1 || _codex_markdown_negated_approval_root_comment_exit=$?
+_codex_markdown_negated_approval_root_comment_output="$(cat "$_codex_markdown_negated_approval_root_comment_mock_dir/output.txt")"
+run_test "codex_markdown_negated_approval_root_comment_exit_needs_revision" "1" "$_codex_markdown_negated_approval_root_comment_exit"
+run_test "codex_markdown_negated_approval_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_markdown_negated_approval_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_markdown_negated_approval_root_comment_mock_dir"
+unset _codex_markdown_negated_approval_root_comment_mock_dir _codex_markdown_negated_approval_root_comment_output _codex_markdown_negated_approval_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2598,6 +2598,46 @@ run_test "codex_reaction_with_current_review_approved" "VERDICT: APPROVED" \
 rm -rf "$_codex_reaction_with_review_mock_dir"
 unset _codex_reaction_with_review_mock_dir _codex_reaction_with_review_output _codex_reaction_with_review_exit
 
+_codex_review_query_failure_mock_dir="$(mktemp -d)"
+cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcreviewfail1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":115,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf 'reviews unavailable\n' >&2
+    exit 1 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_REVIEW_QUERY_FAILURE_GH
+chmod +x "$_codex_review_query_failure_mock_dir/gh"
+
+_codex_review_query_failure_output=""
+_codex_review_query_failure_exit=0
+PATH="$_codex_review_query_failure_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_review_query_failure_mock_dir/output.txt" 2>&1 || _codex_review_query_failure_exit=$?
+_codex_review_query_failure_output="$(cat "$_codex_review_query_failure_mock_dir/output.txt")"
+run_test "codex_review_query_failure_exit_unavailable" "2" "$_codex_review_query_failure_exit"
+run_test "codex_review_query_failure_verdict" "VERDICT: TIMED_OUT — failed to fetch Codex PR reviews (treated as unavailable)" \
+  "$(printf '%s\n' "$_codex_review_query_failure_output" | grep "^VERDICT:")"
+rm -rf "$_codex_review_query_failure_mock_dir"
+unset _codex_review_query_failure_mock_dir _codex_review_query_failure_output _codex_review_query_failure_exit
+
 _codex_latest_review_mock_dir="$(mktemp -d)"
 cat > "$_codex_latest_review_mock_dir/gh" <<'CODEX_LATEST_REVIEW_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4502,6 +4502,54 @@ run_test "codex_negated_approval_root_comment_verdict" "VERDICT: NEEDS_REVISION 
 rm -rf "$_codex_negated_approval_root_comment_mock_dir"
 unset _codex_negated_approval_root_comment_mock_dir _codex_negated_approval_root_comment_output _codex_negated_approval_root_comment_exit
 
+# Followup to codex_negated_approval_root_comment: CODEX_NEGATED_APPROVAL_
+# PATTERN only catches SPACE-separated negations ("not approved"). A
+# CONCATENATED negation prefix like "unapproved" or "disapproved" still
+# matched the bare "approved" substring in CODEX_APPROVAL_PATTERN, so a
+# current-head response saying "This change remains unapproved" was still
+# classified APPROVED (fresh evidence from PR #1490 finding 3789851555).
+# CODEX_APPROVAL_PATTERN's positive alternatives now require \b word
+# boundaries, which "un"/"a" and "dis"/"a" do not form.
+_codex_unapproved_prefix_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_unapproved_prefix_root_comment_mock_dir/gh" <<'CODEX_UNAPPROVED_PREFIX_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade005c1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":256,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":257,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"This change remains unapproved pending further work.\\n\\n**Reviewed commit:** `facade005c`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_UNAPPROVED_PREFIX_ROOT_COMMENT_GH
+chmod +x "$_codex_unapproved_prefix_root_comment_mock_dir/gh"
+
+_codex_unapproved_prefix_root_comment_output=""
+_codex_unapproved_prefix_root_comment_exit=0
+PATH="$_codex_unapproved_prefix_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_unapproved_prefix_root_comment_mock_dir/output.txt" 2>&1 || _codex_unapproved_prefix_root_comment_exit=$?
+_codex_unapproved_prefix_root_comment_output="$(cat "$_codex_unapproved_prefix_root_comment_mock_dir/output.txt")"
+run_test "codex_unapproved_prefix_root_comment_exit_needs_revision" "1" "$_codex_unapproved_prefix_root_comment_exit"
+run_test "codex_unapproved_prefix_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_unapproved_prefix_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_unapproved_prefix_root_comment_mock_dir"
+unset _codex_unapproved_prefix_root_comment_mock_dir _codex_unapproved_prefix_root_comment_output _codex_unapproved_prefix_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5862,6 +5862,67 @@ run_test "codex_dismissed_review_excluded_root_comment_verdict_not_approved" "TI
 rm -rf "$_codex_dismissed_review_excluded_root_comment_mock_dir"
 unset _codex_dismissed_review_excluded_root_comment_mock_dir _codex_dismissed_review_excluded_root_comment_output _codex_dismissed_review_excluded_root_comment_exit
 
+# codex_select_review_evidence's tie-break (finding 3796982553) was fixed
+# to treat a tied CHANGES_REQUESTED review as blocking-tier regardless of
+# body text, but that fix only covers the review-vs-review tie-break. The
+# SEPARATE comment-vs-review tie-break in codex_select_terminal_evidence
+# (used when a SHA-pinned terminal root comment and a current-head review
+# share the same second-resolution timestamp) still called
+# codex_response_priority with body text only, with no state parameter at
+# all. A clean-looking SHA-pinned root comment ("No blocking issues
+# found.") and a same-timestamp CHANGES_REQUESTED review whose body ALSO
+# reads clean ("Looks good overall, but see inline comments.") both
+# scored priority 0 from body text, and since the comment is always
+# CURRENT in this comparison (set by the terminal-comment block before
+# the review is ever considered), the review never outranked it — the
+# review's CHANGES_REQUESTED state was discarded and the run returned
+# APPROVED (fresh evidence from PR #1490 finding 3797160202, a followup
+# to 3796982553 that fixed the review-vs-review tie-break but missed this
+# separate comment-vs-review one). codex_select_terminal_evidence now
+# accepts current/candidate state params and passes the review's state
+# through, so a same-timestamp CHANGES_REQUESTED review beats a
+# clean-looking root comment regardless of which source is "current".
+_codex_tied_changes_requested_review_beats_clean_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_tied_changes_requested_review_beats_clean_root_comment_mock_dir/gh" <<'CODEX_TIED_CHANGES_REQUESTED_REVIEW_BEATS_CLEAN_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'beef00001234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":304,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"beef00001234567890","state":"CHANGES_REQUESTED","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Looks good overall, but see inline comments."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":230,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found.\\n\\n**Reviewed commit:** `beef0000`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TIED_CHANGES_REQUESTED_REVIEW_BEATS_CLEAN_ROOT_COMMENT_GH
+chmod +x "$_codex_tied_changes_requested_review_beats_clean_root_comment_mock_dir/gh"
+
+_codex_tied_changes_requested_review_beats_clean_root_comment_output=""
+_codex_tied_changes_requested_review_beats_clean_root_comment_exit=0
+PATH="$_codex_tied_changes_requested_review_beats_clean_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_tied_changes_requested_review_beats_clean_root_comment_mock_dir/output.txt" 2>&1 || _codex_tied_changes_requested_review_beats_clean_root_comment_exit=$?
+_codex_tied_changes_requested_review_beats_clean_root_comment_output="$(cat "$_codex_tied_changes_requested_review_beats_clean_root_comment_mock_dir/output.txt")"
+run_test "codex_tied_changes_requested_review_beats_clean_root_comment_exit_needs_revision" "1" "$_codex_tied_changes_requested_review_beats_clean_root_comment_exit"
+run_test "codex_tied_changes_requested_review_beats_clean_root_comment_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_tied_changes_requested_review_beats_clean_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_tied_changes_requested_review_beats_clean_root_comment_mock_dir"
+unset _codex_tied_changes_requested_review_beats_clean_root_comment_mock_dir _codex_tied_changes_requested_review_beats_clean_root_comment_output _codex_tied_changes_requested_review_beats_clean_root_comment_exit
+
 # codex_strip_quoted_spans handled straight-double-quotes, backticks, and
 # blockquotes, but not single-quoted spans — the fourth quoting style
 # found unprotected — so a review discussing a quoted clean phrase in

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2731,6 +2731,55 @@ run_test "codex_reaction_then_late_review_approved" "VERDICT: APPROVED" \
 rm -rf "$_codex_reaction_then_review_mock_dir"
 unset _codex_reaction_then_review_mock_dir _codex_reaction_then_review_output _codex_reaction_then_review_exit
 
+_codex_async_reaction_then_review_mock_dir="$(mktemp -d)"
+printf '0\n' > "$_codex_async_reaction_then_review_mock_dir/review_calls"
+cat > "$_codex_async_reaction_then_review_mock_dir/gh" <<'CODEX_ASYNC_REACTION_THEN_REVIEW_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abc456aa1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":122,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[{"content":"+1","user":{"login":"chatgpt-codex-connector[bot]"}}]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    calls_file="$(dirname "$0")/review_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    if [ "$calls" -ge 3 ]; then
+      printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"abc456aa1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    else
+      printf '[]\n'
+    fi
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_ASYNC_REACTION_THEN_REVIEW_GH
+chmod +x "$_codex_async_reaction_then_review_mock_dir/gh"
+
+_codex_async_reaction_then_review_output=""
+_codex_async_reaction_then_review_exit=0
+PATH="$_codex_async_reaction_then_review_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_async_reaction_then_review_mock_dir/output.txt" 2>&1 || _codex_async_reaction_then_review_exit=$?
+_codex_async_reaction_then_review_output="$(cat "$_codex_async_reaction_then_review_mock_dir/output.txt")"
+run_test "codex_async_reaction_then_late_review_exit_clean" "0" "$_codex_async_reaction_then_review_exit"
+run_test "codex_async_reaction_then_late_review_approved" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_async_reaction_then_review_output" | grep "^VERDICT:")"
+rm -rf "$_codex_async_reaction_then_review_mock_dir"
+unset _codex_async_reaction_then_review_mock_dir _codex_async_reaction_then_review_output _codex_async_reaction_then_review_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4253,6 +4253,57 @@ run_test "codex_two_tied_terminal_comments_usage_limit_vs_blocking_verdict" "VER
 rm -rf "$_codex_two_tied_terminal_comments_usage_limit_vs_blocking_mock_dir"
 unset _codex_two_tied_terminal_comments_usage_limit_vs_blocking_mock_dir _codex_two_tied_terminal_comments_usage_limit_vs_blocking_output _codex_two_tied_terminal_comments_usage_limit_vs_blocking_exit
 
+# Reproduces Codex finding on PR #1490 (P1, comment id 3789555934): the
+# earlier mixed-blocking-and-approval fix to codex_response_requires_attention
+# checked only codex_response_is_blocking alongside is_approved, leaving the
+# analogous mixed-usage-limit-and-approval case unguarded. A usage-limit
+# response that ALSO contains an approval phrase (e.g. "No blocking issues
+# could be evaluated because you have reached your Codex usage limits")
+# matched the approval pattern and was classified as NOT requiring
+# attention, so codex_select_review_evidence kept a tied clean review
+# instead, returning APPROVED instead of UNAVAILABLE. requires_attention
+# now also checks codex_response_is_usage_limit. Fixture: clean review
+# first in the array, mixed usage-limit+approval review second, both tied.
+_codex_tied_usage_limit_with_approval_phrase_mock_dir="$(mktemp -d)"
+cat > "$_codex_tied_usage_limit_with_approval_phrase_mock_dir/gh" <<'CODEX_TIED_USAGE_LIMIT_WITH_APPROVAL_PHRASE_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'feedc0de1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":230,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"feedc0de1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."},{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"feedc0de1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues could be evaluated because you have reached your Codex usage limits."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TIED_USAGE_LIMIT_WITH_APPROVAL_PHRASE_GH
+chmod +x "$_codex_tied_usage_limit_with_approval_phrase_mock_dir/gh"
+
+_codex_tied_usage_limit_with_approval_phrase_output=""
+_codex_tied_usage_limit_with_approval_phrase_exit=0
+PATH="$_codex_tied_usage_limit_with_approval_phrase_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_tied_usage_limit_with_approval_phrase_mock_dir/output.txt" 2>&1 || _codex_tied_usage_limit_with_approval_phrase_exit=$?
+_codex_tied_usage_limit_with_approval_phrase_output="$(cat "$_codex_tied_usage_limit_with_approval_phrase_mock_dir/output.txt")"
+run_test "codex_tied_usage_limit_with_approval_phrase_exit_unavailable" "3" "$_codex_tied_usage_limit_with_approval_phrase_exit"
+run_test "codex_tied_usage_limit_with_approval_phrase_verdict" "VERDICT: UNAVAILABLE — Codex GitHub review usage limit reached" \
+  "$(printf '%s\n' "$_codex_tied_usage_limit_with_approval_phrase_output" | grep "^VERDICT:")"
+rm -rf "$_codex_tied_usage_limit_with_approval_phrase_mock_dir"
+unset _codex_tied_usage_limit_with_approval_phrase_mock_dir _codex_tied_usage_limit_with_approval_phrase_output _codex_tied_usage_limit_with_approval_phrase_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2557,6 +2557,90 @@ run_test "codex_reaction_only_reason" "REASON=codex-github-reaction-without-revi
 rm -rf "$_codex_reaction_mock_dir"
 unset _codex_reaction_mock_dir _codex_reaction_output _codex_reaction_exit
 
+_codex_clean_root_review_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_clean_root_review_comment_mock_dir/gh" <<'CODEX_CLEAN_ROOT_REVIEW_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcdefab1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":118,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":218,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex Review: Didn'\''t find any major issues.\\n\\n**Reviewed commit:** `abcdefab12`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_CLEAN_ROOT_REVIEW_COMMENT_GH
+chmod +x "$_codex_clean_root_review_comment_mock_dir/gh"
+
+_codex_clean_root_review_comment_output=""
+_codex_clean_root_review_comment_exit=0
+PATH="$_codex_clean_root_review_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_clean_root_review_comment_mock_dir/output.txt" 2>&1 || _codex_clean_root_review_comment_exit=$?
+_codex_clean_root_review_comment_output="$(cat "$_codex_clean_root_review_comment_mock_dir/output.txt")"
+run_test "codex_clean_root_review_comment_exit_clean" "0" "$_codex_clean_root_review_comment_exit"
+run_test "codex_clean_root_review_comment_approved" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_clean_root_review_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_clean_root_review_comment_mock_dir"
+unset _codex_clean_root_review_comment_mock_dir _codex_clean_root_review_comment_output _codex_clean_root_review_comment_exit
+
+_codex_stale_root_review_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_stale_root_review_comment_mock_dir/gh" <<'CODEX_STALE_ROOT_REVIEW_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abc123aa1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":119,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":219,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex Review: Didn'\''t find any major issues.\\n\\n**Reviewed commit:** `def456bb12`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_STALE_ROOT_REVIEW_COMMENT_GH
+chmod +x "$_codex_stale_root_review_comment_mock_dir/gh"
+
+_codex_stale_root_review_comment_output=""
+_codex_stale_root_review_comment_exit=0
+PATH="$_codex_stale_root_review_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_stale_root_review_comment_mock_dir/output.txt" 2>&1 || _codex_stale_root_review_comment_exit=$?
+_codex_stale_root_review_comment_output="$(cat "$_codex_stale_root_review_comment_mock_dir/output.txt")"
+run_test "codex_stale_root_review_comment_exit_unavailable" "2" "$_codex_stale_root_review_comment_exit"
+if printf '%s\n' "$_codex_stale_root_review_comment_output" | grep -q "^VERDICT: APPROVED"; then
+  _codex_stale_root_review_comment_approved="yes"
+else
+  _codex_stale_root_review_comment_approved="no"
+fi
+run_test "codex_stale_root_review_comment_not_approved" "no" "$_codex_stale_root_review_comment_approved"
+rm -rf "$_codex_stale_root_review_comment_mock_dir"
+unset _codex_stale_root_review_comment_mock_dir _codex_stale_root_review_comment_output _codex_stale_root_review_comment_exit _codex_stale_root_review_comment_approved
+
 _codex_reaction_with_review_mock_dir="$(mktemp -d)"
 cat > "$_codex_reaction_with_review_mock_dir/gh" <<'CODEX_REACTION_WITH_REVIEW_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2597,6 +2597,46 @@ run_test "codex_clean_root_review_comment_approved" "VERDICT: APPROVED" \
 rm -rf "$_codex_clean_root_review_comment_mock_dir"
 unset _codex_clean_root_review_comment_mock_dir _codex_clean_root_review_comment_output _codex_clean_root_review_comment_exit
 
+_codex_full_root_review_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_full_root_review_comment_mock_dir/gh" <<'CODEX_FULL_ROOT_REVIEW_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcabcabcabc1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":126,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":226,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex Review: Didn'\''t find any major issues.\\n\\n**Reviewed commit:** `abcabcabcabc1234567890`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FULL_ROOT_REVIEW_COMMENT_GH
+chmod +x "$_codex_full_root_review_comment_mock_dir/gh"
+
+_codex_full_root_review_comment_output=""
+_codex_full_root_review_comment_exit=0
+PATH="$_codex_full_root_review_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_full_root_review_comment_mock_dir/output.txt" 2>&1 || _codex_full_root_review_comment_exit=$?
+_codex_full_root_review_comment_output="$(cat "$_codex_full_root_review_comment_mock_dir/output.txt")"
+run_test "codex_full_root_review_comment_exit_clean" "0" "$_codex_full_root_review_comment_exit"
+run_test "codex_full_root_review_comment_approved" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_full_root_review_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_full_root_review_comment_mock_dir"
+unset _codex_full_root_review_comment_mock_dir _codex_full_root_review_comment_output _codex_full_root_review_comment_exit
+
 _codex_stale_root_review_comment_mock_dir="$(mktemp -d)"
 cat > "$_codex_stale_root_review_comment_mock_dir/gh" <<'CODEX_STALE_ROOT_REVIEW_COMMENT_GH'
 #!/usr/bin/env bash
@@ -2681,6 +2721,47 @@ run_test "codex_newer_root_blocks_old_review_verdict" "VERDICT: NEEDS_REVISION" 
   "$(printf '%s\n' "$_codex_newer_root_blocks_old_review_output" | grep "^VERDICT:")"
 rm -rf "$_codex_newer_root_blocks_old_review_mock_dir"
 unset _codex_newer_root_blocks_old_review_mock_dir _codex_newer_root_blocks_old_review_output _codex_newer_root_blocks_old_review_exit
+
+_codex_tied_root_blocks_review_mock_dir="$(mktemp -d)"
+cat > "$_codex_tied_root_blocks_review_mock_dir/gh" <<'CODEX_TIED_ROOT_BLOCKS_REVIEW_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'cafe12341234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":127,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"cafe12341234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":227,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: tied root finding.\\n\\n**Reviewed commit:** `cafe1234`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TIED_ROOT_BLOCKS_REVIEW_GH
+chmod +x "$_codex_tied_root_blocks_review_mock_dir/gh"
+
+_codex_tied_root_blocks_review_output=""
+_codex_tied_root_blocks_review_exit=0
+PATH="$_codex_tied_root_blocks_review_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_tied_root_blocks_review_mock_dir/output.txt" 2>&1 || _codex_tied_root_blocks_review_exit=$?
+_codex_tied_root_blocks_review_output="$(cat "$_codex_tied_root_blocks_review_mock_dir/output.txt")"
+run_test "codex_tied_root_blocks_review_exit_needs_revision" "1" "$_codex_tied_root_blocks_review_exit"
+run_test "codex_tied_root_blocks_review_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_tied_root_blocks_review_output" | grep "^VERDICT:")"
+rm -rf "$_codex_tied_root_blocks_review_mock_dir"
+unset _codex_tied_root_blocks_review_mock_dir _codex_tied_root_blocks_review_output _codex_tied_root_blocks_review_exit
 
 _codex_async_newer_root_blocks_old_review_mock_dir="$(mktemp -d)"
 printf '0\n' > "$_codex_async_newer_root_blocks_old_review_mock_dir/comment_calls"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5471,6 +5471,51 @@ run_test "codex_not_only_idiom_stays_approved_root_comment_verdict" "VERDICT: AP
 rm -rf "$_codex_not_only_idiom_stays_approved_root_comment_mock_dir"
 unset _codex_not_only_idiom_stays_approved_root_comment_mock_dir _codex_not_only_idiom_stays_approved_root_comment_output _codex_not_only_idiom_stays_approved_root_comment_exit
 
+# codex_strip_not_only_idiom's [Nn]ot/[Oo]nly form only covered Title-Case
+# and lowercase, not a fully uppercase emphasis form like "NOT ONLY does
+# this look good, it is approved" (fresh evidence from PR #1490 finding
+# 3793330278, a followup to 3793299512). Every letter is now
+# bracket-expanded for both cases.
+_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir/gh" <<'CODEX_NOT_ONLY_IDIOM_UPPERCASE_STAYS_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade01991234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":297,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":298,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"NOT ONLY does this look good, it is approved.\\n\\n**Reviewed commit:** `facade01991`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_NOT_ONLY_IDIOM_UPPERCASE_STAYS_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir/gh"
+
+_codex_not_only_idiom_uppercase_stays_approved_root_comment_output=""
+_codex_not_only_idiom_uppercase_stays_approved_root_comment_exit=0
+PATH="$_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_not_only_idiom_uppercase_stays_approved_root_comment_exit=$?
+_codex_not_only_idiom_uppercase_stays_approved_root_comment_output="$(cat "$_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_not_only_idiom_uppercase_stays_approved_root_comment_exit_clean" "0" "$_codex_not_only_idiom_uppercase_stays_approved_root_comment_exit"
+run_test "codex_not_only_idiom_uppercase_stays_approved_root_comment_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_not_only_idiom_uppercase_stays_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir"
+unset _codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir _codex_not_only_idiom_uppercase_stays_approved_root_comment_output _codex_not_only_idiom_uppercase_stays_approved_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5979,6 +5979,110 @@ run_test "codex_multiline_quoted_clean_phrase_not_approved_root_comment_verdict"
 rm -rf "$_codex_multiline_quoted_clean_phrase_not_approved_root_comment_mock_dir"
 unset _codex_multiline_quoted_clean_phrase_not_approved_root_comment_mock_dir _codex_multiline_quoted_clean_phrase_not_approved_root_comment_output _codex_multiline_quoted_clean_phrase_not_approved_root_comment_exit
 
+# The newline-flattening fix above (codex_multiline_quoted_clean_phrase_
+# not_approved_root_comment) had its own boundary gap: the single-quote
+# pattern's boundary alternatives ((^|[[:space:]]) and
+# ([[:space:].,;:!?]|$)) didn't include the placeholder character, so a
+# single-quoted span occupying an ENTIRE original line by itself (e.g.
+# "The documented response is:" / "'No blocking issues found'" / "That
+# claim is inaccurate" across three lines) has the placeholder — not real
+# whitespace, not true start/end-of-string — immediately before/after the
+# quote once flattened, so neither boundary matched and the span survived
+# unstripped, returning APPROVED (fresh evidence from PR #1490 finding
+# 3798665078). codex_strip_quoted_spans now includes the placeholder as
+# an additional valid boundary character for the single-quote pattern.
+_codex_multiline_single_quoted_whole_line_not_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_multiline_single_quoted_whole_line_not_approved_root_comment_mock_dir/gh" <<'CODEX_MULTILINE_SINGLE_QUOTED_WHOLE_LINE_NOT_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'dead00001234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":308,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:309,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("The documented response is:\n'"'"'No blocking issues found'"'"'\nThat claim is inaccurate.\n\n**Reviewed commit:** `dead0000`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_MULTILINE_SINGLE_QUOTED_WHOLE_LINE_NOT_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_multiline_single_quoted_whole_line_not_approved_root_comment_mock_dir/gh"
+
+_codex_multiline_single_quoted_whole_line_not_approved_root_comment_output=""
+_codex_multiline_single_quoted_whole_line_not_approved_root_comment_exit=0
+PATH="$_codex_multiline_single_quoted_whole_line_not_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_multiline_single_quoted_whole_line_not_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_multiline_single_quoted_whole_line_not_approved_root_comment_exit=$?
+_codex_multiline_single_quoted_whole_line_not_approved_root_comment_output="$(cat "$_codex_multiline_single_quoted_whole_line_not_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_multiline_single_quoted_whole_line_not_approved_root_comment_exit_needs_revision" "1" "$_codex_multiline_single_quoted_whole_line_not_approved_root_comment_exit"
+run_test "codex_multiline_single_quoted_whole_line_not_approved_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_multiline_single_quoted_whole_line_not_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_multiline_single_quoted_whole_line_not_approved_root_comment_mock_dir"
+unset _codex_multiline_single_quoted_whole_line_not_approved_root_comment_mock_dir _codex_multiline_single_quoted_whole_line_not_approved_root_comment_output _codex_multiline_single_quoted_whole_line_not_approved_root_comment_exit
+
+# codex_strip_quoted_spans deliberately kept backtick-pair stripping
+# line-oriented, reasoning that GFM inline code spans never cross a line
+# — that reasoning was WRONG. CommonMark/GFM inline code spans CAN
+# legitimately span multiple lines (line endings inside a code span are
+# normalized to spaces in the rendered output); only FENCED
+# (triple-backtick) code blocks have line-anchored open/close semantics,
+# a different construct. A single-backtick code span split across lines
+# (e.g. "The documented response `" / "No blocking issues found" / "` is
+# inaccurate") was never stripped, letting the coded clean phrase reach
+# classification unstripped and return APPROVED (fresh evidence from PR
+# #1490 finding 3798665086). Backtick-pair stripping now runs on the same
+# newline-flattened body as the double-/single-quote passes.
+_codex_multiline_backtick_span_not_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_multiline_backtick_span_not_approved_root_comment_mock_dir/gh" <<'CODEX_MULTILINE_BACKTICK_SPAN_NOT_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'beef11121234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":310,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:311,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("The documented response `\nNo blocking issues found\n` is inaccurate and should be corrected.\n\n**Reviewed commit:** `beef1112`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_MULTILINE_BACKTICK_SPAN_NOT_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_multiline_backtick_span_not_approved_root_comment_mock_dir/gh"
+
+_codex_multiline_backtick_span_not_approved_root_comment_output=""
+_codex_multiline_backtick_span_not_approved_root_comment_exit=0
+PATH="$_codex_multiline_backtick_span_not_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_multiline_backtick_span_not_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_multiline_backtick_span_not_approved_root_comment_exit=$?
+_codex_multiline_backtick_span_not_approved_root_comment_output="$(cat "$_codex_multiline_backtick_span_not_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_multiline_backtick_span_not_approved_root_comment_exit_needs_revision" "1" "$_codex_multiline_backtick_span_not_approved_root_comment_exit"
+run_test "codex_multiline_backtick_span_not_approved_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_multiline_backtick_span_not_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_multiline_backtick_span_not_approved_root_comment_mock_dir"
+unset _codex_multiline_backtick_span_not_approved_root_comment_mock_dir _codex_multiline_backtick_span_not_approved_root_comment_output _codex_multiline_backtick_span_not_approved_root_comment_exit
+
 # codex_strip_quoted_spans handled straight-double-quotes, backticks, and
 # blockquotes, but not single-quoted spans — the fourth quoting style
 # found unprotected — so a review discussing a quoted clean phrase in

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3116,6 +3116,47 @@ run_test "codex_environment_missing_reason" "REASON=codex-github-environment-mis
 rm -rf "$_codex_environment_mock_dir"
 unset _codex_environment_mock_dir _codex_environment_output _codex_environment_exit
 
+_codex_same_second_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_same_second_root_comment_mock_dir/gh" <<'CODEX_SAME_SECOND_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcsamesecond1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":120,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":119,"created_at":"2026-01-01T00:00:00Z","user":{"login":"chatgpt-codex-connector"},"body":"Older same-second setup response."}]\n'
+    printf '[{"id":121,"created_at":"2026-01-01T00:00:00Z","user":{"login":"chatgpt-codex-connector"},"body":"To use Codex here, create an environment for this repo."}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_SAME_SECOND_ROOT_COMMENT_GH
+chmod +x "$_codex_same_second_root_comment_mock_dir/gh"
+
+_codex_same_second_root_comment_output=""
+_codex_same_second_root_comment_exit=0
+PATH="$_codex_same_second_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_same_second_root_comment_mock_dir/output.txt" 2>&1 || _codex_same_second_root_comment_exit=$?
+_codex_same_second_root_comment_output="$(cat "$_codex_same_second_root_comment_mock_dir/output.txt")"
+run_test "codex_same_second_root_comment_exit_unavailable" "2" "$_codex_same_second_root_comment_exit"
+run_test "codex_same_second_root_comment_reason" "REASON=codex-github-environment-missing" \
+  "$(printf '%s\n' "$_codex_same_second_root_comment_output" | grep "^REASON=")"
+rm -rf "$_codex_same_second_root_comment_mock_dir"
+unset _codex_same_second_root_comment_mock_dir _codex_same_second_root_comment_output _codex_same_second_root_comment_exit
+
 _unlock_pr="80213$$"
 _unlock_lock_dir="/tmp/pr-review-loop-${_unlock_pr}.lockdir"
 rm -rf "$_unlock_lock_dir"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -6388,6 +6388,109 @@ run_test "codex_unrelated_negation_before_merge_stays_approved_root_comment_verd
 rm -rf "$_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir"
 unset _codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir _codex_unrelated_negation_before_merge_stays_approved_root_comment_output _codex_unrelated_negation_before_merge_stays_approved_root_comment_exit
 
+# CODEX_NEGATION_WORDS was missing "shouldn't"/"should not" and
+# "mustn't"/"must not" entirely, so neither the generalized
+# merge-refusal pattern nor the negated-approval pattern recognized a
+# response like "This looks good at first glance, but this shouldn't be
+# merged until tests pass" as a rejection, and the earlier "looks good"
+# phrase alone won, returning APPROVED (fresh evidence from PR #1490
+# finding 3799277919, a followup to the "cannot be merged" fix).
+# "should not"/"shouldn't" and "must not"/"mustn't" are now included in
+# CODEX_NEGATION_WORDS, automatically fixing both the merge-refusal and
+# negated-approval checks at once (the whole point of generalizing
+# merge-refusal detection to reuse this shared word list).
+_codex_shouldnt_be_merged_blocking_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_shouldnt_be_merged_blocking_root_comment_mock_dir/gh" <<'CODEX_SHOULDNT_BE_MERGED_BLOCKING_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'face66661234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":324,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":325,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"This looks good at first glance, but this shouldn'"'"'t be merged until tests pass.\\n\\n**Reviewed commit:** `face6666`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_SHOULDNT_BE_MERGED_BLOCKING_ROOT_COMMENT_GH
+chmod +x "$_codex_shouldnt_be_merged_blocking_root_comment_mock_dir/gh"
+
+_codex_shouldnt_be_merged_blocking_root_comment_output=""
+_codex_shouldnt_be_merged_blocking_root_comment_exit=0
+PATH="$_codex_shouldnt_be_merged_blocking_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_shouldnt_be_merged_blocking_root_comment_mock_dir/output.txt" 2>&1 || _codex_shouldnt_be_merged_blocking_root_comment_exit=$?
+_codex_shouldnt_be_merged_blocking_root_comment_output="$(cat "$_codex_shouldnt_be_merged_blocking_root_comment_mock_dir/output.txt")"
+run_test "codex_shouldnt_be_merged_blocking_root_comment_exit_needs_revision" "1" "$_codex_shouldnt_be_merged_blocking_root_comment_exit"
+run_test "codex_shouldnt_be_merged_blocking_root_comment_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_shouldnt_be_merged_blocking_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_shouldnt_be_merged_blocking_root_comment_mock_dir"
+unset _codex_shouldnt_be_merged_blocking_root_comment_mock_dir _codex_shouldnt_be_merged_blocking_root_comment_output _codex_shouldnt_be_merged_blocking_root_comment_exit
+
+# CODEX_BLOCKING_PATTERN's generalized merge-refusal alternative
+# (CODEX_MERGE_REFUSAL_PATTERN) reuses CODEX_NEGATION_WORDS' bare "not"
+# alternative the same way CODEX_NEGATED_APPROVAL_PATTERN does, so it
+# inherited the exact same "not only X" affirmative-idiom
+# misclassification that motivated codex_strip_not_only_idiom in the
+# first place — "not only" is an intensifier, not a negation, but a
+# clean response like "This is not only safe to merge but looks good"
+# had "not" followed by "merge" within the same clause and was misread
+# as a merge refusal, returning NEEDS_REVISION for a genuinely clean
+# review (fresh evidence from PR #1490 finding 3799277922).
+# codex_response_is_blocking now applies codex_strip_not_only_idiom the
+# same way codex_response_is_approved already does.
+_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir/gh" <<'CODEX_NOT_ONLY_SAFE_TO_MERGE_STAYS_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'face77771234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":326,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":327,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"This is not only safe to merge but looks good.\\n\\n**Reviewed commit:** `face7777`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_NOT_ONLY_SAFE_TO_MERGE_STAYS_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir/gh"
+
+_codex_not_only_safe_to_merge_stays_approved_root_comment_output=""
+_codex_not_only_safe_to_merge_stays_approved_root_comment_exit=0
+PATH="$_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_not_only_safe_to_merge_stays_approved_root_comment_exit=$?
+_codex_not_only_safe_to_merge_stays_approved_root_comment_output="$(cat "$_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_not_only_safe_to_merge_stays_approved_root_comment_exit_clean" "0" "$_codex_not_only_safe_to_merge_stays_approved_root_comment_exit"
+run_test "codex_not_only_safe_to_merge_stays_approved_root_comment_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_not_only_safe_to_merge_stays_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir"
+unset _codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir _codex_not_only_safe_to_merge_stays_approved_root_comment_output _codex_not_only_safe_to_merge_stays_approved_root_comment_exit
+
 # codex_strip_quoted_spans handled straight-double-quotes, backticks, and
 # blockquotes, but not single-quoted spans — the fourth quoting style
 # found unprotected — so a review discussing a quoted clean phrase in

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -6239,6 +6239,55 @@ run_test "codex_should_not_be_merged_blocking_root_comment_verdict" "VERDICT: NE
 rm -rf "$_codex_should_not_be_merged_blocking_root_comment_mock_dir"
 unset _codex_should_not_be_merged_blocking_root_comment_mock_dir _codex_should_not_be_merged_blocking_root_comment_output _codex_should_not_be_merged_blocking_root_comment_exit
 
+# The should/must-not-be-merged fix above only covered the PASSIVE form;
+# the IMPERATIVE form ("do not merge"/"don't merge") is a separate,
+# common phrasing that the same gap applies to for the identical reason
+# — "merge" isn't in CODEX_NEGATED_APPROVAL_TARGET_WORDS either, and
+# unlike the passive form's "not be merged", the imperative form's
+# negation word isn't even adjacent to an approval-vocabulary word at
+# all. A response like "This looks good at first glance, but do not
+# merge until tests pass" still returned APPROVED (fresh evidence from PR
+# #1490 finding 3798999561, a followup to the passive-form fix).
+_codex_do_not_merge_blocking_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_do_not_merge_blocking_root_comment_mock_dir/gh" <<'CODEX_DO_NOT_MERGE_BLOCKING_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'face33331234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":318,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":319,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"This looks good at first glance, but do not merge until tests pass.\\n\\n**Reviewed commit:** `face3333`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_DO_NOT_MERGE_BLOCKING_ROOT_COMMENT_GH
+chmod +x "$_codex_do_not_merge_blocking_root_comment_mock_dir/gh"
+
+_codex_do_not_merge_blocking_root_comment_output=""
+_codex_do_not_merge_blocking_root_comment_exit=0
+PATH="$_codex_do_not_merge_blocking_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_do_not_merge_blocking_root_comment_mock_dir/output.txt" 2>&1 || _codex_do_not_merge_blocking_root_comment_exit=$?
+_codex_do_not_merge_blocking_root_comment_output="$(cat "$_codex_do_not_merge_blocking_root_comment_mock_dir/output.txt")"
+run_test "codex_do_not_merge_blocking_root_comment_exit_needs_revision" "1" "$_codex_do_not_merge_blocking_root_comment_exit"
+run_test "codex_do_not_merge_blocking_root_comment_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_do_not_merge_blocking_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_do_not_merge_blocking_root_comment_mock_dir"
+unset _codex_do_not_merge_blocking_root_comment_mock_dir _codex_do_not_merge_blocking_root_comment_output _codex_do_not_merge_blocking_root_comment_exit
+
 # codex_strip_quoted_spans handled straight-double-quotes, backticks, and
 # blockquotes, but not single-quoted spans — the fourth quoting style
 # found unprotected — so a review discussing a quoted clean phrase in

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3229,6 +3229,74 @@ run_test "codex_ack_repoll_env_then_reaction_reason" "REASON=codex-github-enviro
 rm -rf "$_codex_ack_repoll_env_then_reaction_mock_dir"
 unset _codex_ack_repoll_env_then_reaction_mock_dir _codex_ack_repoll_env_then_reaction_output _codex_ack_repoll_env_then_reaction_exit
 
+# Reproduces PR-Agent advisory finding on PR #1490 (main-loop env-error
+# override): the main poll loop recorded an environment setup error on its
+# first iteration (SEEN_ENVIRONMENT_ERROR=1) but a later iteration's clean
+# submitted review still exited APPROVED without checking that flag,
+# silently discarding the recorded environment failure. Sequence: iteration
+# 1 finds an environment-setup root comment -> iteration 2 finds no new
+# comment but a clean current-head review -> expect
+# codex-github-environment-missing, not APPROVED. Covers all four APPROVED
+# exit sites' shared guard, exercised here via the main poll loop.
+_codex_main_loop_env_then_review_mock_dir="$(mktemp -d)"
+printf '0\n' > "$_codex_main_loop_env_then_review_mock_dir/comment_calls"
+printf '0\n' > "$_codex_main_loop_env_then_review_mock_dir/review_calls"
+cat > "$_codex_main_loop_env_then_review_mock_dir/gh" <<'CODEX_MAIN_LOOP_ENV_THEN_REVIEW_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'mainloopenv1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":130,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    calls_file="$(dirname "$0")/review_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    if [ "$calls" -ge 2 ]; then
+      printf '[{"submitted_at":"2026-01-01T00:00:03Z","commit_id":"mainloopenv1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    else
+      printf '[]\n'
+    fi
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    calls_file="$(dirname "$0")/comment_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    if [ "$calls" -eq 2 ]; then
+      printf '[{"id":230,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"To use Codex here, create an environment for this repo."}]\n'
+    else
+      printf '[]\n'
+    fi
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_MAIN_LOOP_ENV_THEN_REVIEW_GH
+chmod +x "$_codex_main_loop_env_then_review_mock_dir/gh"
+
+_codex_main_loop_env_then_review_output=""
+_codex_main_loop_env_then_review_exit=0
+PATH="$_codex_main_loop_env_then_review_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 2 --max-retriggers 0 \
+  >"$_codex_main_loop_env_then_review_mock_dir/output.txt" 2>&1 || _codex_main_loop_env_then_review_exit=$?
+_codex_main_loop_env_then_review_output="$(cat "$_codex_main_loop_env_then_review_mock_dir/output.txt")"
+run_test "codex_main_loop_env_then_review_exit_unavailable" "2" "$_codex_main_loop_env_then_review_exit"
+run_test "codex_main_loop_env_then_review_reason" "REASON=codex-github-environment-missing" \
+  "$(printf '%s\n' "$_codex_main_loop_env_then_review_output" | grep "^REASON=")"
+rm -rf "$_codex_main_loop_env_then_review_mock_dir"
+unset _codex_main_loop_env_then_review_mock_dir _codex_main_loop_env_then_review_output _codex_main_loop_env_then_review_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5850,6 +5850,55 @@ run_test "codex_nested_fence_length_phrase_not_approved_root_comment_verdict" "V
 rm -rf "$_codex_nested_fence_length_phrase_not_approved_root_comment_mock_dir"
 unset _codex_nested_fence_length_phrase_not_approved_root_comment_mock_dir _codex_nested_fence_length_phrase_not_approved_root_comment_output _codex_nested_fence_length_phrase_not_approved_root_comment_exit
 
+# The delimiter-length fix above checked LENGTH but not the GFM rule that
+# a closing fence must be followed by nothing but optional whitespace: a
+# line like ```` ```not-a-close ```` is, per GFM, a NEW opening fence with
+# an info string, not a close, but a length-only check treated it as
+# closing regardless — re-exposing everything after it, including a
+# quoted clean phrase, to classification (fresh evidence from PR #1490
+# finding following 3793497787/3793453010). This completes GFM's fence
+# spec (open, length, close-only-whitespace) — the awk pass now requires
+# nothing but whitespace after a would-be closing delimiter.
+_codex_fence_close_requires_whitespace_only_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_fence_close_requires_whitespace_only_root_comment_mock_dir/gh" <<'CODEX_FENCE_CLOSE_REQUIRES_WHITESPACE_ONLY_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade02771234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":312,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:313,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Response was:\n```text\nsome intro\n```not-a-close\nNo blocking issues found\n```\nThat quoted output is inaccurate.\n\n**Reviewed commit:** `facade02771`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FENCE_CLOSE_REQUIRES_WHITESPACE_ONLY_ROOT_COMMENT_GH
+chmod +x "$_codex_fence_close_requires_whitespace_only_root_comment_mock_dir/gh"
+
+_codex_fence_close_requires_whitespace_only_root_comment_output=""
+_codex_fence_close_requires_whitespace_only_root_comment_exit=0
+PATH="$_codex_fence_close_requires_whitespace_only_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_fence_close_requires_whitespace_only_root_comment_mock_dir/output.txt" 2>&1 || _codex_fence_close_requires_whitespace_only_root_comment_exit=$?
+_codex_fence_close_requires_whitespace_only_root_comment_output="$(cat "$_codex_fence_close_requires_whitespace_only_root_comment_mock_dir/output.txt")"
+run_test "codex_fence_close_requires_whitespace_only_root_comment_exit_needs_revision" "1" "$_codex_fence_close_requires_whitespace_only_root_comment_exit"
+run_test "codex_fence_close_requires_whitespace_only_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_fence_close_requires_whitespace_only_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_fence_close_requires_whitespace_only_root_comment_mock_dir"
+unset _codex_fence_close_requires_whitespace_only_root_comment_mock_dir _codex_fence_close_requires_whitespace_only_root_comment_output _codex_fence_close_requires_whitespace_only_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3905,6 +3905,102 @@ run_test "codex_older_review_vs_newer_usage_limit_reason" "REASON=codex-github-u
 rm -rf "$_codex_older_review_vs_newer_usage_limit_mock_dir"
 unset _codex_older_review_vs_newer_usage_limit_mock_dir _codex_older_review_vs_newer_usage_limit_output _codex_older_review_vs_newer_usage_limit_exit
 
+# Reproduces Codex finding on PR #1490 (P1, comment id 3788078189): when
+# two current-head terminal root comments share GitHub's second-resolution
+# timestamp, codex_scan_comment_evidence previously overwrote
+# COMMENT_TERMINAL_BODY unconditionally on every terminal comment seen,
+# regardless of content. A blocking terminal comment followed by a tied
+# clean terminal comment silently produced APPROVED. The not-a-clean-
+# approval-first tie-break now decides which tied terminal comment is
+# tracked. Fixture: blocking terminal comment first, clean terminal
+# comment second, both tied at the same timestamp, no review.
+_codex_tied_terminal_comments_blocking_survives_mock_dir="$(mktemp -d)"
+cat > "$_codex_tied_terminal_comments_blocking_survives_mock_dir/gh" <<'CODEX_TIED_TERMINAL_COMMENTS_BLOCKING_SURVIVES_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'aceface1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":190,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":300,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: must fix the leak.\\n\\n**Reviewed commit:** `aceface1234`"},{"id":301,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex Review: Didn'\''t find any major issues.\\n\\n**Reviewed commit:** `aceface1234`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TIED_TERMINAL_COMMENTS_BLOCKING_SURVIVES_GH
+chmod +x "$_codex_tied_terminal_comments_blocking_survives_mock_dir/gh"
+
+_codex_tied_terminal_comments_blocking_survives_output=""
+_codex_tied_terminal_comments_blocking_survives_exit=0
+PATH="$_codex_tied_terminal_comments_blocking_survives_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_tied_terminal_comments_blocking_survives_mock_dir/output.txt" 2>&1 || _codex_tied_terminal_comments_blocking_survives_exit=$?
+_codex_tied_terminal_comments_blocking_survives_output="$(cat "$_codex_tied_terminal_comments_blocking_survives_mock_dir/output.txt")"
+run_test "codex_tied_terminal_comments_blocking_survives_exit_needs_revision" "1" "$_codex_tied_terminal_comments_blocking_survives_exit"
+run_test "codex_tied_terminal_comments_blocking_survives_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_tied_terminal_comments_blocking_survives_output" | grep "^VERDICT:")"
+rm -rf "$_codex_tied_terminal_comments_blocking_survives_mock_dir"
+unset _codex_tied_terminal_comments_blocking_survives_mock_dir _codex_tied_terminal_comments_blocking_survives_output _codex_tied_terminal_comments_blocking_survives_exit
+
+# Reproduces Codex finding on PR #1490 (P2, comment id 3788078191): the
+# usage-limit check ran before the blocking check in every verdict path, so
+# a current-head submitted review whose blocking finding text mentions
+# "usage limit" as part of the finding itself (e.g. flagging stale docs
+# that describe it) was misrouted to an UNAVAILABLE/usage-limit verdict
+# before the blocking classifier could run, hiding the actionable finding.
+# Blocking is now checked first in every verdict path.
+_codex_blocking_text_mentions_usage_limit_mock_dir="$(mktemp -d)"
+cat > "$_codex_blocking_text_mentions_usage_limit_mock_dir/gh" <<'CODEX_BLOCKING_TEXT_MENTIONS_USAGE_LIMIT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'baadf00d1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":191,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"baadf00d1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: docs incorrectly describe the Codex usage limit for code reviews."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_BLOCKING_TEXT_MENTIONS_USAGE_LIMIT_GH
+chmod +x "$_codex_blocking_text_mentions_usage_limit_mock_dir/gh"
+
+_codex_blocking_text_mentions_usage_limit_output=""
+_codex_blocking_text_mentions_usage_limit_exit=0
+PATH="$_codex_blocking_text_mentions_usage_limit_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_blocking_text_mentions_usage_limit_mock_dir/output.txt" 2>&1 || _codex_blocking_text_mentions_usage_limit_exit=$?
+_codex_blocking_text_mentions_usage_limit_output="$(cat "$_codex_blocking_text_mentions_usage_limit_mock_dir/output.txt")"
+run_test "codex_blocking_text_mentions_usage_limit_exit_needs_revision" "1" "$_codex_blocking_text_mentions_usage_limit_exit"
+run_test "codex_blocking_text_mentions_usage_limit_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_blocking_text_mentions_usage_limit_output" | grep "^VERDICT:")"
+rm -rf "$_codex_blocking_text_mentions_usage_limit_mock_dir"
+unset _codex_blocking_text_mentions_usage_limit_mock_dir _codex_blocking_text_mentions_usage_limit_output _codex_blocking_text_mentions_usage_limit_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2355,7 +2355,7 @@ _docs_is_outdated_filter_count="$(grep -h 'select((.isOutdated // false) == fals
 run_test "manual_readiness_audit_docs_filter_outdated" "5" "$_docs_is_outdated_filter_count"
 unset _manual_audit_fixture _manual_audit_fixture_outdated_only _docs_is_outdated_field_count _docs_is_outdated_filter_count
 
-if grep -q "Codex acknowledgement detected; waiting for thumbs-up reaction or inline review comments" \
+if grep -q "Codex acknowledgement detected; waiting for current-head review, clean comment, or inline review comments" \
     "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh"; then
   _codex_ack_wait_signal="yes"
 else
@@ -2484,7 +2484,7 @@ case "$*" in
   *"pulls/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/reviews"*)
-    printf '[{"submitted_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex review capacity exhausted. Please rerun after quota reset."}]\n'
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"abcreview1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex review capacity exhausted. Please rerun after quota reset."}]\n'
     exit 0 ;;
   *"issues/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
@@ -2517,6 +2517,129 @@ run_test "codex_usage_limit_review_suggestion_count" "SUGGESTION_COUNT=0" \
   "$(printf '%s\n' "$_codex_usage_review_output" | grep "^SUGGESTION_COUNT=")"
 rm -rf "$_codex_usage_review_mock_dir"
 unset _codex_usage_review_mock_dir _codex_usage_review_output _codex_usage_review_exit
+
+_codex_reaction_mock_dir="$(mktemp -d)"
+cat > "$_codex_reaction_mock_dir/gh" <<'CODEX_REACTION_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcreact1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":103,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[{"content":"+1","user":{"login":"chatgpt-codex-connector[bot]"}}]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_REACTION_GH
+chmod +x "$_codex_reaction_mock_dir/gh"
+
+_codex_reaction_output=""
+_codex_reaction_exit=0
+PATH="$_codex_reaction_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_reaction_mock_dir/output.txt" 2>&1 || _codex_reaction_exit=$?
+_codex_reaction_output="$(cat "$_codex_reaction_mock_dir/output.txt")"
+run_test "codex_reaction_only_exit_unavailable" "2" "$_codex_reaction_exit"
+run_test "codex_reaction_only_reason" "REASON=codex-github-reaction-without-review" \
+  "$(printf '%s\n' "$_codex_reaction_output" | grep "^REASON=")"
+rm -rf "$_codex_reaction_mock_dir"
+unset _codex_reaction_mock_dir _codex_reaction_output _codex_reaction_exit
+
+_codex_stale_review_mock_dir="$(mktemp -d)"
+cat > "$_codex_stale_review_mock_dir/gh" <<'CODEX_STALE_REVIEW_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcstale1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":104,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"oldstale1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_STALE_REVIEW_GH
+chmod +x "$_codex_stale_review_mock_dir/gh"
+
+_codex_stale_review_output=""
+_codex_stale_review_exit=0
+PATH="$_codex_stale_review_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_stale_review_mock_dir/output.txt" 2>&1 || _codex_stale_review_exit=$?
+_codex_stale_review_output="$(cat "$_codex_stale_review_mock_dir/output.txt")"
+run_test "codex_stale_review_exit_unavailable" "2" "$_codex_stale_review_exit"
+if printf '%s\n' "$_codex_stale_review_output" | grep -q "^VERDICT: APPROVED"; then
+  _codex_stale_review_approved="yes"
+else
+  _codex_stale_review_approved="no"
+fi
+run_test "codex_stale_review_not_approved" "no" "$_codex_stale_review_approved"
+rm -rf "$_codex_stale_review_mock_dir"
+unset _codex_stale_review_mock_dir _codex_stale_review_output _codex_stale_review_exit _codex_stale_review_approved
+
+_codex_environment_mock_dir="$(mktemp -d)"
+cat > "$_codex_environment_mock_dir/gh" <<'CODEX_ENVIRONMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcenv1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":105,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":205,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector"},"body":"To use Codex here, create an environment for this repo."}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_ENVIRONMENT_GH
+chmod +x "$_codex_environment_mock_dir/gh"
+
+_codex_environment_output=""
+_codex_environment_exit=0
+PATH="$_codex_environment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_environment_mock_dir/output.txt" 2>&1 || _codex_environment_exit=$?
+_codex_environment_output="$(cat "$_codex_environment_mock_dir/output.txt")"
+run_test "codex_environment_missing_exit_unavailable" "2" "$_codex_environment_exit"
+run_test "codex_environment_missing_reason" "REASON=codex-github-environment-missing" \
+  "$(printf '%s\n' "$_codex_environment_output" | grep "^REASON=")"
+rm -rf "$_codex_environment_mock_dir"
+unset _codex_environment_mock_dir _codex_environment_output _codex_environment_exit
 
 _unlock_pr="80213$$"
 _unlock_lock_dir="/tmp/pr-review-loop-${_unlock_pr}.lockdir"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -6186,6 +6186,59 @@ run_test "codex_double_backtick_span_not_approved_root_comment_verdict" "VERDICT
 rm -rf "$_codex_double_backtick_span_not_approved_root_comment_mock_dir"
 unset _codex_double_backtick_span_not_approved_root_comment_mock_dir _codex_double_backtick_span_not_approved_root_comment_output _codex_double_backtick_span_not_approved_root_comment_exit
 
+# The negated-approval mechanism (CODEX_NEGATED_APPROVAL_PATTERN) only
+# fires when a negation word is followed by one of a fixed list of
+# approval-vocabulary target words (approve[ds]?, lgtm, looks good, etc.)
+# within the same sentence. A response like "This looks good at first
+# glance, but this should not be merged until tests pass." negates
+# "merged" — a word outside that target list entirely — so the
+# negated-approval check never matches, and the earlier "looks good"
+# phrase alone wins, returning APPROVED (fresh evidence from PR #1490
+# finding 3798880969, a followup to the "don't approve" fix that closed
+# the adjacent-to-an-approval-word case but not this direct-merge-refusal
+# case). CODEX_BLOCKING_PATTERN now recognizes an explicit
+# should/must-not-be-merged verdict outright, checked before approval in
+# the verdict-parsing chain.
+_codex_should_not_be_merged_blocking_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_should_not_be_merged_blocking_root_comment_mock_dir/gh" <<'CODEX_SHOULD_NOT_BE_MERGED_BLOCKING_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'face22221234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":316,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":317,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"This looks good at first glance, but this should not be merged until tests pass.\\n\\n**Reviewed commit:** `face2222`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_SHOULD_NOT_BE_MERGED_BLOCKING_ROOT_COMMENT_GH
+chmod +x "$_codex_should_not_be_merged_blocking_root_comment_mock_dir/gh"
+
+_codex_should_not_be_merged_blocking_root_comment_output=""
+_codex_should_not_be_merged_blocking_root_comment_exit=0
+PATH="$_codex_should_not_be_merged_blocking_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_should_not_be_merged_blocking_root_comment_mock_dir/output.txt" 2>&1 || _codex_should_not_be_merged_blocking_root_comment_exit=$?
+_codex_should_not_be_merged_blocking_root_comment_output="$(cat "$_codex_should_not_be_merged_blocking_root_comment_mock_dir/output.txt")"
+run_test "codex_should_not_be_merged_blocking_root_comment_exit_needs_revision" "1" "$_codex_should_not_be_merged_blocking_root_comment_exit"
+run_test "codex_should_not_be_merged_blocking_root_comment_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_should_not_be_merged_blocking_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_should_not_be_merged_blocking_root_comment_mock_dir"
+unset _codex_should_not_be_merged_blocking_root_comment_mock_dir _codex_should_not_be_merged_blocking_root_comment_output _codex_should_not_be_merged_blocking_root_comment_exit
+
 # codex_strip_quoted_spans handled straight-double-quotes, backticks, and
 # blockquotes, but not single-quoted spans — the fourth quoting style
 # found unprotected — so a review discussing a quoted clean phrase in

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5516,6 +5516,146 @@ run_test "codex_not_only_idiom_uppercase_stays_approved_root_comment_verdict" "V
 rm -rf "$_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir"
 unset _codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir _codex_not_only_idiom_uppercase_stays_approved_root_comment_output _codex_not_only_idiom_uppercase_stays_approved_root_comment_exit
 
+# "unable to" wasn't in CODEX_NEGATION_WORDS at all, so "I am unable to
+# approve this change" wasn't recognized as a rejection while an earlier
+# "looks good" in the same sentence still matched (fresh evidence from PR
+# #1490 finding 3793367883, same class of gap as "cannot approve" fixed
+# for finding 3790023141, just a different inability phrase).
+_codex_unable_to_approve_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_unable_to_approve_root_comment_mock_dir/gh" <<'CODEX_UNABLE_TO_APPROVE_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade02001234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":299,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":300,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"This looks good at first glance, but I am unable to approve this change.\\n\\n**Reviewed commit:** `facade02001`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_UNABLE_TO_APPROVE_ROOT_COMMENT_GH
+chmod +x "$_codex_unable_to_approve_root_comment_mock_dir/gh"
+
+_codex_unable_to_approve_root_comment_output=""
+_codex_unable_to_approve_root_comment_exit=0
+PATH="$_codex_unable_to_approve_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_unable_to_approve_root_comment_mock_dir/output.txt" 2>&1 || _codex_unable_to_approve_root_comment_exit=$?
+_codex_unable_to_approve_root_comment_output="$(cat "$_codex_unable_to_approve_root_comment_mock_dir/output.txt")"
+run_test "codex_unable_to_approve_root_comment_exit_needs_revision" "1" "$_codex_unable_to_approve_root_comment_exit"
+run_test "codex_unable_to_approve_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_unable_to_approve_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_unable_to_approve_root_comment_mock_dir"
+unset _codex_unable_to_approve_root_comment_mock_dir _codex_unable_to_approve_root_comment_output _codex_unable_to_approve_root_comment_exit
+
+# codex_strip_quoted_spans only stripped straight-double-quoted and
+# backtick-quoted spans, not GitHub-flavored Markdown blockquote lines
+# (a line starting with `>`), so a review discussing a quoted clean
+# phrase via blockquote syntax (e.g. "The documentation claims:\n> No
+# blocking issues found\nThat claim is inaccurate") still matched and
+# returned APPROVED (fresh evidence from PR #1490 finding 3793367885).
+# codex_strip_quoted_spans now also deletes blockquote lines.
+_codex_blockquoted_clean_phrase_not_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_blockquoted_clean_phrase_not_approved_root_comment_mock_dir/gh" <<'CODEX_BLOCKQUOTED_CLEAN_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade02111234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":301,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:302,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("The documentation claims:\n> No blocking issues found\nThat claim is inaccurate.\n\n**Reviewed commit:** `facade02111`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_BLOCKQUOTED_CLEAN_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_blockquoted_clean_phrase_not_approved_root_comment_mock_dir/gh"
+
+_codex_blockquoted_clean_phrase_not_approved_root_comment_output=""
+_codex_blockquoted_clean_phrase_not_approved_root_comment_exit=0
+PATH="$_codex_blockquoted_clean_phrase_not_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_blockquoted_clean_phrase_not_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_blockquoted_clean_phrase_not_approved_root_comment_exit=$?
+_codex_blockquoted_clean_phrase_not_approved_root_comment_output="$(cat "$_codex_blockquoted_clean_phrase_not_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_blockquoted_clean_phrase_not_approved_root_comment_exit_needs_revision" "1" "$_codex_blockquoted_clean_phrase_not_approved_root_comment_exit"
+run_test "codex_blockquoted_clean_phrase_not_approved_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_blockquoted_clean_phrase_not_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_blockquoted_clean_phrase_not_approved_root_comment_mock_dir"
+unset _codex_blockquoted_clean_phrase_not_approved_root_comment_mock_dir _codex_blockquoted_clean_phrase_not_approved_root_comment_output _codex_blockquoted_clean_phrase_not_approved_root_comment_exit
+
+# codex_response_is_blocking was never quote-stripped at all — only the
+# approval/negation checks were — so a quoted blocker token in an
+# otherwise clean review (e.g. "No blocking issues found. The tests
+# correctly cover the `must fix` marker.") still matched
+# CODEX_BLOCKING_PATTERN's "must fix" alternative and returned
+# NEEDS_REVISION for an actually-clean review (fresh evidence from PR
+# #1490 finding 3793367887). codex_response_is_blocking now shares the
+# same codex_strip_quoted_spans normalization as the approval checks.
+_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir/gh" <<'CODEX_QUOTED_BLOCKER_TOKEN_STAYS_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade02221234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":303,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"facade02221234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found. The tests correctly cover the `must fix` marker."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_QUOTED_BLOCKER_TOKEN_STAYS_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir/gh"
+
+_codex_quoted_blocker_token_stays_approved_root_comment_output=""
+_codex_quoted_blocker_token_stays_approved_root_comment_exit=0
+PATH="$_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_quoted_blocker_token_stays_approved_root_comment_exit=$?
+_codex_quoted_blocker_token_stays_approved_root_comment_output="$(cat "$_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_quoted_blocker_token_stays_approved_root_comment_exit_clean" "0" "$_codex_quoted_blocker_token_stays_approved_root_comment_exit"
+run_test "codex_quoted_blocker_token_stays_approved_root_comment_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_quoted_blocker_token_stays_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir"
+unset _codex_quoted_blocker_token_stays_approved_root_comment_mock_dir _codex_quoted_blocker_token_stays_approved_root_comment_output _codex_quoted_blocker_token_stays_approved_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2808,6 +2808,54 @@ run_test "codex_tied_review_blocks_root_verdict" "VERDICT: NEEDS_REVISION" \
 rm -rf "$_codex_tied_review_blocks_root_mock_dir"
 unset _codex_tied_review_blocks_root_mock_dir _codex_tied_review_blocks_root_output _codex_tied_review_blocks_root_exit
 
+# Reproduces Codex finding on PR #1490 (P1, comment id 3787623071): the
+# terminal-evidence tie-break only checked codex_response_is_blocking, so an
+# unrecognized-format submitted review tied with a clean SHA-pinned root
+# comment lost the tie-break and the clean root comment won, returning
+# APPROVED instead of the documented safe-fail NEEDS_REVISION for
+# unrecognized responses. Root comment is a clean approval; tied review body
+# matches neither the blocking nor approval pattern.
+_codex_tied_unrecognized_review_safe_fails_mock_dir="$(mktemp -d)"
+cat > "$_codex_tied_unrecognized_review_safe_fails_mock_dir/gh" <<'CODEX_TIED_UNRECOGNIZED_REVIEW_SAFE_FAILS_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'deadfeed1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":131,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"deadfeed1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Some ambiguous status update with no recognized marker."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":231,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex Review: Didn'\''t find any major issues.\\n\\n**Reviewed commit:** `deadfeed1234`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TIED_UNRECOGNIZED_REVIEW_SAFE_FAILS_GH
+chmod +x "$_codex_tied_unrecognized_review_safe_fails_mock_dir/gh"
+
+_codex_tied_unrecognized_review_safe_fails_output=""
+_codex_tied_unrecognized_review_safe_fails_exit=0
+PATH="$_codex_tied_unrecognized_review_safe_fails_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_tied_unrecognized_review_safe_fails_mock_dir/output.txt" 2>&1 || _codex_tied_unrecognized_review_safe_fails_exit=$?
+_codex_tied_unrecognized_review_safe_fails_output="$(cat "$_codex_tied_unrecognized_review_safe_fails_mock_dir/output.txt")"
+run_test "codex_tied_unrecognized_review_safe_fails_exit_needs_revision" "1" "$_codex_tied_unrecognized_review_safe_fails_exit"
+run_test "codex_tied_unrecognized_review_safe_fails_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_tied_unrecognized_review_safe_fails_output" | grep "^VERDICT:")"
+rm -rf "$_codex_tied_unrecognized_review_safe_fails_mock_dir"
+unset _codex_tied_unrecognized_review_safe_fails_mock_dir _codex_tied_unrecognized_review_safe_fails_output _codex_tied_unrecognized_review_safe_fails_exit
+
 # A clean submitted review arrives first, then a SHA-pinned BLOCKING root
 # comment, then a newer non-terminal acknowledgement comment. Greedily
 # selecting the latest root comment overall (the ack) would discard the

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4156,6 +4156,103 @@ run_test "codex_tied_reviews_blocking_beats_usage_limit_verdict" "VERDICT: NEEDS
 rm -rf "$_codex_tied_reviews_blocking_beats_usage_limit_mock_dir"
 unset _codex_tied_reviews_blocking_beats_usage_limit_mock_dir _codex_tied_reviews_blocking_beats_usage_limit_output _codex_tied_reviews_blocking_beats_usage_limit_exit
 
+# Reproduces Codex finding on PR #1490 (P1, comment id 3789521036): the
+# shared codex_select_terminal_evidence tie-break only checked the binary
+# requires-attention distinction, so two tied responses that are BOTH
+# "requires attention" (a usage-limit root comment and a blocking
+# submitted review) kept whichever was CURRENT even when the candidate was
+# strictly more severe (blocking). The prior d149 fix addressed only
+# codex_select_review_evidence's own review-vs-review scan; this shared
+# selector (used for terminal-comment-vs-review and terminal-comment-vs-
+# terminal-comment ties) now checks blocking first. Fixture: a SHA-pinned
+# terminal root comment reporting a usage limit, tied with a submitted
+# blocking review, no acknowledgement.
+_codex_terminal_usage_limit_vs_blocking_review_mock_dir="$(mktemp -d)"
+cat > "$_codex_terminal_usage_limit_vs_blocking_review_mock_dir/gh" <<'CODEX_TERMINAL_USAGE_LIMIT_VS_BLOCKING_REVIEW_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade001234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":220,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"facade001234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: must fix the null check."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":320,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"You have reached your Codex usage limits for code reviews.\\n\\n**Reviewed commit:** `facade001234`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TERMINAL_USAGE_LIMIT_VS_BLOCKING_REVIEW_GH
+chmod +x "$_codex_terminal_usage_limit_vs_blocking_review_mock_dir/gh"
+
+_codex_terminal_usage_limit_vs_blocking_review_output=""
+_codex_terminal_usage_limit_vs_blocking_review_exit=0
+PATH="$_codex_terminal_usage_limit_vs_blocking_review_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_terminal_usage_limit_vs_blocking_review_mock_dir/output.txt" 2>&1 || _codex_terminal_usage_limit_vs_blocking_review_exit=$?
+_codex_terminal_usage_limit_vs_blocking_review_output="$(cat "$_codex_terminal_usage_limit_vs_blocking_review_mock_dir/output.txt")"
+run_test "codex_terminal_usage_limit_vs_blocking_review_exit_needs_revision" "1" "$_codex_terminal_usage_limit_vs_blocking_review_exit"
+run_test "codex_terminal_usage_limit_vs_blocking_review_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_terminal_usage_limit_vs_blocking_review_output" | grep "^VERDICT:")"
+rm -rf "$_codex_terminal_usage_limit_vs_blocking_review_mock_dir"
+unset _codex_terminal_usage_limit_vs_blocking_review_mock_dir _codex_terminal_usage_limit_vs_blocking_review_output _codex_terminal_usage_limit_vs_blocking_review_exit
+
+# Same finding (3789521036), second reproduction scenario explicitly
+# called out in the finding text: "the same loss occurs between two tied
+# root responses". Two SHA-pinned terminal root comments tied at the same
+# timestamp — one reporting a usage limit, one blocking — no submitted
+# review at all.
+_codex_two_tied_terminal_comments_usage_limit_vs_blocking_mock_dir="$(mktemp -d)"
+cat > "$_codex_two_tied_terminal_comments_usage_limit_vs_blocking_mock_dir/gh" <<'CODEX_TWO_TIED_TERMINAL_COMMENTS_USAGE_LIMIT_VS_BLOCKING_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'ba5eba1112345678\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":221,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":330,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"You have reached your Codex usage limits for code reviews.\\n\\n**Reviewed commit:** `ba5eba111234`"},{"id":331,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: must fix the null check.\\n\\n**Reviewed commit:** `ba5eba111234`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TWO_TIED_TERMINAL_COMMENTS_USAGE_LIMIT_VS_BLOCKING_GH
+chmod +x "$_codex_two_tied_terminal_comments_usage_limit_vs_blocking_mock_dir/gh"
+
+_codex_two_tied_terminal_comments_usage_limit_vs_blocking_output=""
+_codex_two_tied_terminal_comments_usage_limit_vs_blocking_exit=0
+PATH="$_codex_two_tied_terminal_comments_usage_limit_vs_blocking_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_two_tied_terminal_comments_usage_limit_vs_blocking_mock_dir/output.txt" 2>&1 || _codex_two_tied_terminal_comments_usage_limit_vs_blocking_exit=$?
+_codex_two_tied_terminal_comments_usage_limit_vs_blocking_output="$(cat "$_codex_two_tied_terminal_comments_usage_limit_vs_blocking_mock_dir/output.txt")"
+run_test "codex_two_tied_terminal_comments_usage_limit_vs_blocking_exit_needs_revision" "1" "$_codex_two_tied_terminal_comments_usage_limit_vs_blocking_exit"
+run_test "codex_two_tied_terminal_comments_usage_limit_vs_blocking_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_two_tied_terminal_comments_usage_limit_vs_blocking_output" | grep "^VERDICT:")"
+rm -rf "$_codex_two_tied_terminal_comments_usage_limit_vs_blocking_mock_dir"
+unset _codex_two_tied_terminal_comments_usage_limit_vs_blocking_mock_dir _codex_two_tied_terminal_comments_usage_limit_vs_blocking_output _codex_two_tied_terminal_comments_usage_limit_vs_blocking_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5762,6 +5762,106 @@ run_test "codex_changes_requested_state_forces_blocking_root_comment_verdict" "V
 rm -rf "$_codex_changes_requested_state_forces_blocking_root_comment_mock_dir"
 unset _codex_changes_requested_state_forces_blocking_root_comment_mock_dir _codex_changes_requested_state_forces_blocking_root_comment_output _codex_changes_requested_state_forces_blocking_root_comment_exit
 
+# codex_select_review_evidence's tie-break ranked tied current-head reviews
+# via codex_response_priority(body) alone, which had no notion of the
+# extracted `state` field. Two reviews tied at the same second — a clean
+# one and a CHANGES_REQUESTED one whose body ALSO happens to contain an
+# approval phrase like "Looks good" — both scored priority 0 from body
+# text, so whichever the API returned FIRST kept the selection (only a
+# STRICTLY greater priority replaces it): the clean review is returned
+# first here, so without the fix the CHANGES_REQUESTED review's state was
+# silently discarded and the run returned APPROVED (fresh evidence from
+# PR #1490 finding 3796982553). codex_response_priority now also treats
+# state CHANGES_REQUESTED as blocking-tier, so the tied CHANGES_REQUESTED
+# review wins regardless of array order.
+_codex_tied_changes_requested_wins_priority_tie_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_tied_changes_requested_wins_priority_tie_root_comment_mock_dir/gh" <<'CODEX_TIED_CHANGES_REQUESTED_WINS_PRIORITY_TIE_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade02221234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":303,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"facade02221234567890","state":"COMMENTED","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Looks good overall."},{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"facade02221234567890","state":"CHANGES_REQUESTED","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Looks good overall, but see inline comments."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_TIED_CHANGES_REQUESTED_WINS_PRIORITY_TIE_ROOT_COMMENT_GH
+chmod +x "$_codex_tied_changes_requested_wins_priority_tie_root_comment_mock_dir/gh"
+
+_codex_tied_changes_requested_wins_priority_tie_root_comment_output=""
+_codex_tied_changes_requested_wins_priority_tie_root_comment_exit=0
+PATH="$_codex_tied_changes_requested_wins_priority_tie_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_tied_changes_requested_wins_priority_tie_root_comment_mock_dir/output.txt" 2>&1 || _codex_tied_changes_requested_wins_priority_tie_root_comment_exit=$?
+_codex_tied_changes_requested_wins_priority_tie_root_comment_output="$(cat "$_codex_tied_changes_requested_wins_priority_tie_root_comment_mock_dir/output.txt")"
+run_test "codex_tied_changes_requested_wins_priority_tie_root_comment_exit_needs_revision" "1" "$_codex_tied_changes_requested_wins_priority_tie_root_comment_exit"
+run_test "codex_tied_changes_requested_wins_priority_tie_root_comment_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_tied_changes_requested_wins_priority_tie_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_tied_changes_requested_wins_priority_tie_root_comment_mock_dir"
+unset _codex_tied_changes_requested_wins_priority_tie_root_comment_mock_dir _codex_tied_changes_requested_wins_priority_tie_root_comment_output _codex_tied_changes_requested_wins_priority_tie_root_comment_exit
+
+# A review with state DISMISSED still matched the SHA/bot/timestamp
+# filters (dismissal doesn't change commit_id or submitted_at), so its
+# now-stale body text (recorded before it was dismissed) could still be
+# selected as fresh terminal approval evidence on an idempotent rerun —
+# GitHub itself no longer treats a dismissed review as active (fresh
+# evidence from PR #1490 finding 3796982554). The reviews-endpoint jq
+# queries now exclude state DISMISSED entirely, so with no other
+# evidence, the run must fail closed to TIMED_OUT rather than APPROVED.
+_codex_dismissed_review_excluded_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_dismissed_review_excluded_root_comment_mock_dir/gh" <<'CODEX_DISMISSED_REVIEW_EXCLUDED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade02221234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":303,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"facade02221234567890","state":"DISMISSED","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_DISMISSED_REVIEW_EXCLUDED_ROOT_COMMENT_GH
+chmod +x "$_codex_dismissed_review_excluded_root_comment_mock_dir/gh"
+
+_codex_dismissed_review_excluded_root_comment_output=""
+_codex_dismissed_review_excluded_root_comment_exit=0
+PATH="$_codex_dismissed_review_excluded_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_dismissed_review_excluded_root_comment_mock_dir/output.txt" 2>&1 || _codex_dismissed_review_excluded_root_comment_exit=$?
+_codex_dismissed_review_excluded_root_comment_output="$(cat "$_codex_dismissed_review_excluded_root_comment_mock_dir/output.txt")"
+run_test "codex_dismissed_review_excluded_root_comment_exit_timed_out" "2" "$_codex_dismissed_review_excluded_root_comment_exit"
+run_test "codex_dismissed_review_excluded_root_comment_verdict_not_approved" "TIMED_OUT" \
+  "$(printf '%s\n' "$_codex_dismissed_review_excluded_root_comment_output" | grep -oE 'VERDICT: (TIMED_OUT|APPROVED)' | grep -oE 'TIMED_OUT|APPROVED')"
+rm -rf "$_codex_dismissed_review_excluded_root_comment_mock_dir"
+unset _codex_dismissed_review_excluded_root_comment_mock_dir _codex_dismissed_review_excluded_root_comment_output _codex_dismissed_review_excluded_root_comment_exit
+
 # codex_strip_quoted_spans handled straight-double-quotes, backticks, and
 # blockquotes, but not single-quoted spans — the fourth quoting style
 # found unprotected — so a review discussing a quoted clean phrase in

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3467,6 +3467,153 @@ run_test "codex_tied_mixed_blocking_review_wins_verdict" "VERDICT: NEEDS_REVISIO
 rm -rf "$_codex_tied_mixed_blocking_review_wins_mock_dir"
 unset _codex_tied_mixed_blocking_review_wins_mock_dir _codex_tied_mixed_blocking_review_wins_output _codex_tied_mixed_blocking_review_wins_exit
 
+# Reproduces Codex finding on PR #1490 (P1, comment id 3787786942): a
+# submitted review body that exceeds a pipe buffer's capacity (well within
+# GitHub's ~64KB per-comment limit) causes `jq ... | head -c 5000` to SIGPIPE
+# jq once `head` closes its read end after 5000 bytes; under `set -euo
+# pipefail` this aborts the whole script with exit 141 before any VERDICT
+# line is emitted. Truncation now happens inside jq (codepoint slice)
+# instead of via a piped `head`, eliminating the SIGPIPE entirely. Body is
+# built via jq's own string-repeat operator (200000 chars) rather than a
+# large literal in this file or a python3 dependency.
+_codex_long_review_body_no_sigpipe_mock_dir="$(mktemp -d)"
+cat > "$_codex_long_review_body_no_sigpipe_mock_dir/gh" <<'CODEX_LONG_REVIEW_BODY_NO_SIGPIPE_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'longbody1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":140,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"longbody1234567890",user:{login:"chatgpt-codex-connector[bot]"},body:("No blocking issues found. " + ("x" * 200000))}]'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_LONG_REVIEW_BODY_NO_SIGPIPE_GH
+chmod +x "$_codex_long_review_body_no_sigpipe_mock_dir/gh"
+
+_codex_long_review_body_no_sigpipe_output=""
+_codex_long_review_body_no_sigpipe_exit=0
+PATH="$_codex_long_review_body_no_sigpipe_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_long_review_body_no_sigpipe_mock_dir/output.txt" 2>&1 || _codex_long_review_body_no_sigpipe_exit=$?
+_codex_long_review_body_no_sigpipe_output="$(cat "$_codex_long_review_body_no_sigpipe_mock_dir/output.txt")"
+run_test "codex_long_review_body_no_sigpipe_exit_clean" "0" "$_codex_long_review_body_no_sigpipe_exit"
+run_test "codex_long_review_body_no_sigpipe_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_long_review_body_no_sigpipe_output" | grep "^VERDICT:")"
+rm -rf "$_codex_long_review_body_no_sigpipe_mock_dir"
+unset _codex_long_review_body_no_sigpipe_mock_dir _codex_long_review_body_no_sigpipe_output _codex_long_review_body_no_sigpipe_exit
+
+# Reproduces Codex finding on PR #1490 (P1, comment id 3787786943): within a
+# single poll, a clean submitted review at T1 and a newer environment-setup
+# root comment at T2 were combined by unconditionally preferring the review
+# (since it wasn't competing against a SHA-pinned terminal comment), so the
+# newer setup failure never had a chance to be recorded as
+# SEEN_ENVIRONMENT_ERROR and the run returned APPROVED. Root comment (env
+# error) is strictly newer than the review in this fixture -> expect
+# codex-github-environment-missing, not APPROVED.
+_codex_same_poll_newer_env_error_wins_mock_dir="$(mktemp -d)"
+cat > "$_codex_same_poll_newer_env_error_wins_mock_dir/gh" <<'CODEX_SAME_POLL_NEWER_ENV_ERROR_WINS_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'samepoll1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":141,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"samepoll1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":242,"created_at":"2026-01-01T00:00:02Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"To use Codex here, create an environment for this repo."}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_SAME_POLL_NEWER_ENV_ERROR_WINS_GH
+chmod +x "$_codex_same_poll_newer_env_error_wins_mock_dir/gh"
+
+_codex_same_poll_newer_env_error_wins_output=""
+_codex_same_poll_newer_env_error_wins_exit=0
+PATH="$_codex_same_poll_newer_env_error_wins_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_same_poll_newer_env_error_wins_mock_dir/output.txt" 2>&1 || _codex_same_poll_newer_env_error_wins_exit=$?
+_codex_same_poll_newer_env_error_wins_output="$(cat "$_codex_same_poll_newer_env_error_wins_mock_dir/output.txt")"
+run_test "codex_same_poll_newer_env_error_wins_exit_unavailable" "2" "$_codex_same_poll_newer_env_error_wins_exit"
+run_test "codex_same_poll_newer_env_error_wins_reason" "REASON=codex-github-environment-missing" \
+  "$(printf '%s\n' "$_codex_same_poll_newer_env_error_wins_output" | grep "^REASON=")"
+rm -rf "$_codex_same_poll_newer_env_error_wins_mock_dir"
+unset _codex_same_poll_newer_env_error_wins_mock_dir _codex_same_poll_newer_env_error_wins_output _codex_same_poll_newer_env_error_wins_exit
+
+# Reproduces Codex finding on PR #1490 (P2, comment id 3787786945): when the
+# same comments fetch contains an environment-setup error at T1 followed by
+# a plain acknowledgement at T2, codex_scan_comment_evidence previously kept
+# only the LATEST comment overall (the acknowledgement), losing the
+# actionable setup-error text. Combined with a thumbs-up reaction, this
+# produced codex-github-reaction-without-review instead of
+# codex-github-environment-missing. Async-arrival grace path: env-error at
+# T1 and acknowledgement at T2 both appear in the same async-arrival poll's
+# comment fetch, plus a thumbs-up reaction on the trigger comment.
+_codex_env_error_survives_later_ack_mock_dir="$(mktemp -d)"
+cat > "$_codex_env_error_survives_later_ack_mock_dir/gh" <<'CODEX_ENV_ERROR_SURVIVES_LATER_ACK_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'ackenverr1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":142,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[{"content":"+1","user":{"login":"chatgpt-codex-connector[bot]"}}]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":243,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"To use Codex here, create an environment for this repo."},{"id":244,"created_at":"2026-01-01T00:00:02Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"If Codex has suggestions, it will comment; otherwise it will react with \xf0\x9f\x91\x8d on this comment."}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_ENV_ERROR_SURVIVES_LATER_ACK_GH
+chmod +x "$_codex_env_error_survives_later_ack_mock_dir/gh"
+
+_codex_env_error_survives_later_ack_output=""
+_codex_env_error_survives_later_ack_exit=0
+PATH="$_codex_env_error_survives_later_ack_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_env_error_survives_later_ack_mock_dir/output.txt" 2>&1 || _codex_env_error_survives_later_ack_exit=$?
+_codex_env_error_survives_later_ack_output="$(cat "$_codex_env_error_survives_later_ack_mock_dir/output.txt")"
+run_test "codex_env_error_survives_later_ack_exit_unavailable" "2" "$_codex_env_error_survives_later_ack_exit"
+run_test "codex_env_error_survives_later_ack_reason" "REASON=codex-github-environment-missing" \
+  "$(printf '%s\n' "$_codex_env_error_survives_later_ack_output" | grep "^REASON=")"
+rm -rf "$_codex_env_error_survives_later_ack_mock_dir"
+unset _codex_env_error_survives_later_ack_mock_dir _codex_env_error_survives_later_ack_output _codex_env_error_survives_later_ack_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5230,6 +5230,148 @@ run_test "codex_semicolon_scoped_negation_root_comment_verdict" "VERDICT: APPROV
 rm -rf "$_codex_semicolon_scoped_negation_root_comment_mock_dir"
 unset _codex_semicolon_scoped_negation_root_comment_mock_dir _codex_semicolon_scoped_negation_root_comment_output _codex_semicolon_scoped_negation_root_comment_exit
 
+# codex_response_is_approved only stripped straight-double-quoted spans,
+# not backtick-quoted (Markdown inline code) ones, so a review that
+# quotes a clean phrase using backticks instead of straight quotes (e.g.
+# "The documented response `No blocking issues found` is inaccurate")
+# still matched and returned APPROVED (fresh evidence from PR #1490
+# finding 3793219190, a followup to 3790122058). The shared
+# codex_strip_quoted_spans helper now strips both quoting styles.
+_codex_backtick_quoted_phrase_not_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_backtick_quoted_phrase_not_approved_root_comment_mock_dir/gh" <<'CODEX_BACKTICK_QUOTED_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade01441234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":287,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":288,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"The documented response `No blocking issues found` is inaccurate and should be corrected.\\n\\n**Reviewed commit:** `facade01441`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_BACKTICK_QUOTED_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_backtick_quoted_phrase_not_approved_root_comment_mock_dir/gh"
+
+_codex_backtick_quoted_phrase_not_approved_root_comment_output=""
+_codex_backtick_quoted_phrase_not_approved_root_comment_exit=0
+PATH="$_codex_backtick_quoted_phrase_not_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_backtick_quoted_phrase_not_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_backtick_quoted_phrase_not_approved_root_comment_exit=$?
+_codex_backtick_quoted_phrase_not_approved_root_comment_output="$(cat "$_codex_backtick_quoted_phrase_not_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_backtick_quoted_phrase_not_approved_root_comment_exit_needs_revision" "1" "$_codex_backtick_quoted_phrase_not_approved_root_comment_exit"
+run_test "codex_backtick_quoted_phrase_not_approved_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_backtick_quoted_phrase_not_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_backtick_quoted_phrase_not_approved_root_comment_mock_dir"
+unset _codex_backtick_quoted_phrase_not_approved_root_comment_mock_dir _codex_backtick_quoted_phrase_not_approved_root_comment_output _codex_backtick_quoted_phrase_not_approved_root_comment_exit
+
+# codex_response_is_approved only quote-stripped before the POSITIVE
+# CODEX_APPROVAL_PATTERN check, not before the NEGATED_APPROVAL_PATTERN
+# check that runs first — so an otherwise-clean response that quotes a
+# rejection phrase from elsewhere (e.g. test/documentation text), such as
+# `No blocking issues found. The tests cover "This change is not
+# approved".`, still tripped the negation check on the unstripped body
+# and safe-failed to NEEDS_REVISION even though the actual review verdict
+# was clean (fresh evidence from PR #1490 finding 3793219192).
+# codex_response_is_approved now strips quoted spans ONCE, before running
+# either check.
+_codex_quoted_rejection_in_clean_review_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir/gh" <<'CODEX_QUOTED_REJECTION_IN_CLEAN_REVIEW_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade01551234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":289,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:290,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("No blocking issues found. The tests cover \"This change is not approved\".\n\n**Reviewed commit:** `facade01551`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_QUOTED_REJECTION_IN_CLEAN_REVIEW_ROOT_COMMENT_GH
+chmod +x "$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir/gh"
+
+_codex_quoted_rejection_in_clean_review_root_comment_output=""
+_codex_quoted_rejection_in_clean_review_root_comment_exit=0
+PATH="$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir/output.txt" 2>&1 || _codex_quoted_rejection_in_clean_review_root_comment_exit=$?
+_codex_quoted_rejection_in_clean_review_root_comment_output="$(cat "$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir/output.txt")"
+run_test "codex_quoted_rejection_in_clean_review_root_comment_exit_clean" "0" "$_codex_quoted_rejection_in_clean_review_root_comment_exit"
+run_test "codex_quoted_rejection_in_clean_review_root_comment_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_quoted_rejection_in_clean_review_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir"
+unset _codex_quoted_rejection_in_clean_review_root_comment_mock_dir _codex_quoted_rejection_in_clean_review_root_comment_output _codex_quoted_rejection_in_clean_review_root_comment_exit
+
+# Followup to codex_semicolon_scoped_negation_root_comment: the semicolon-
+# only exclusion still let a comma-joined clause cross ("Tests are not
+# required, but looks good") the same way the original unbounded span
+# crossed the semicolon (fresh evidence from PR #1490 finding
+# 3793219193). The character class now also excludes `,`.
+_codex_comma_scoped_negation_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_comma_scoped_negation_root_comment_mock_dir/gh" <<'CODEX_COMMA_SCOPED_NEGATION_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade01661234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":291,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":292,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Tests are not required, but looks good.\\n\\n**Reviewed commit:** `facade01661`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_COMMA_SCOPED_NEGATION_ROOT_COMMENT_GH
+chmod +x "$_codex_comma_scoped_negation_root_comment_mock_dir/gh"
+
+_codex_comma_scoped_negation_root_comment_output=""
+_codex_comma_scoped_negation_root_comment_exit=0
+PATH="$_codex_comma_scoped_negation_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_comma_scoped_negation_root_comment_mock_dir/output.txt" 2>&1 || _codex_comma_scoped_negation_root_comment_exit=$?
+_codex_comma_scoped_negation_root_comment_output="$(cat "$_codex_comma_scoped_negation_root_comment_mock_dir/output.txt")"
+run_test "codex_comma_scoped_negation_root_comment_exit_clean" "0" "$_codex_comma_scoped_negation_root_comment_exit"
+run_test "codex_comma_scoped_negation_root_comment_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_comma_scoped_negation_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_comma_scoped_negation_root_comment_mock_dir"
+unset _codex_comma_scoped_negation_root_comment_mock_dir _codex_comma_scoped_negation_root_comment_output _codex_comma_scoped_negation_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4797,6 +4797,98 @@ run_test "codex_usage_limit_code_reviews_phrase_mention_verdict" "VERDICT: APPRO
 rm -rf "$_codex_usage_limit_code_reviews_phrase_mention_mock_dir"
 unset _codex_usage_limit_code_reviews_phrase_mention_mock_dir _codex_usage_limit_code_reviews_phrase_mention_output _codex_usage_limit_code_reviews_phrase_mention_exit
 
+# CODEX_NEGATED_APPROVAL_PATTERN's bounded {0,3} filler-word window (added
+# for finding 3789904716) was itself proven insufficient: 5 intervening
+# words exceed the bound, so the negation went undetected while the
+# approval alternative still matched (fresh evidence from PR #1490
+# finding 3789992792). Replaced with an unbounded same-sentence scope
+# ([^.!?]*) — this is the reviewer's own stated remediation ("avoid
+# relying on a bounded filler-word count").
+_codex_negation_beyond_bounded_window_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_negation_beyond_bounded_window_root_comment_mock_dir/gh" <<'CODEX_NEGATION_BEYOND_BOUNDED_WINDOW_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade00bb1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":268,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":269,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"I cannot confidently confirm that there are no blocking issues.\\n\\n**Reviewed commit:** `facade00bb`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_NEGATION_BEYOND_BOUNDED_WINDOW_ROOT_COMMENT_GH
+chmod +x "$_codex_negation_beyond_bounded_window_root_comment_mock_dir/gh"
+
+_codex_negation_beyond_bounded_window_root_comment_output=""
+_codex_negation_beyond_bounded_window_root_comment_exit=0
+PATH="$_codex_negation_beyond_bounded_window_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_negation_beyond_bounded_window_root_comment_mock_dir/output.txt" 2>&1 || _codex_negation_beyond_bounded_window_root_comment_exit=$?
+_codex_negation_beyond_bounded_window_root_comment_output="$(cat "$_codex_negation_beyond_bounded_window_root_comment_mock_dir/output.txt")"
+run_test "codex_negation_beyond_bounded_window_root_comment_exit_needs_revision" "1" "$_codex_negation_beyond_bounded_window_root_comment_exit"
+run_test "codex_negation_beyond_bounded_window_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_negation_beyond_bounded_window_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_negation_beyond_bounded_window_root_comment_mock_dir"
+unset _codex_negation_beyond_bounded_window_root_comment_mock_dir _codex_negation_beyond_bounded_window_root_comment_output _codex_negation_beyond_bounded_window_root_comment_exit
+
+# Positive control for the unbounded [^.!?]* negation scope above: a
+# negation word in one sentence must NOT suppress a clean approval phrase
+# in a later, unrelated sentence — the sentence-terminator exclusion in
+# the character class is what keeps the unbounded window from
+# over-matching across sentence boundaries.
+_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir/gh" <<'CODEX_NEGATION_PRIOR_SENTENCE_DOES_NOT_LEAK_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade00cc1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":270,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":271,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"The variable name is not great. No blocking issues found.\\n\\n**Reviewed commit:** `facade00cc`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_NEGATION_PRIOR_SENTENCE_DOES_NOT_LEAK_ROOT_COMMENT_GH
+chmod +x "$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir/gh"
+
+_codex_negation_prior_sentence_does_not_leak_root_comment_output=""
+_codex_negation_prior_sentence_does_not_leak_root_comment_exit=0
+PATH="$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir/output.txt" 2>&1 || _codex_negation_prior_sentence_does_not_leak_root_comment_exit=$?
+_codex_negation_prior_sentence_does_not_leak_root_comment_output="$(cat "$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir/output.txt")"
+run_test "codex_negation_prior_sentence_does_not_leak_root_comment_exit_clean" "0" "$_codex_negation_prior_sentence_does_not_leak_root_comment_exit"
+run_test "codex_negation_prior_sentence_does_not_leak_root_comment_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_negation_prior_sentence_does_not_leak_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir"
+unset _codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir _codex_negation_prior_sentence_does_not_leak_root_comment_output _codex_negation_prior_sentence_does_not_leak_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4647,6 +4647,60 @@ run_test "codex_qualifier_negated_approval_root_comment_verdict" "VERDICT: NEEDS
 rm -rf "$_codex_qualifier_negated_approval_root_comment_mock_dir"
 unset _codex_qualifier_negated_approval_root_comment_mock_dir _codex_qualifier_negated_approval_root_comment_output _codex_qualifier_negated_approval_root_comment_exit
 
+# codex_response_is_usage_limit's broad "codex ... usage limit/quota/
+# capacity" alternative matched ANY mention of those words, with no
+# requirement for accompanying exhaustion/unavailability language. A
+# clean submitted review merely discussing this PR's own usage-limit-
+# detection code (e.g. "No blocking issues found. The Codex usage limit
+# handling looks correct.") was itself misclassified as a usage-limit
+# notice — priority 1 instead of the correct clean-approval priority 0.
+# Tied against a clean SHA-pinned terminal comment (priority 0), the
+# higher (buggy) priority won the tie-break, and the unconditional
+# (non-source-gated) usage-limit check in the verdict classifier then
+# emitted UNAVAILABLE instead of APPROVED for an actually-clean PR (fresh
+# evidence from PR #1490 finding 3789928781). The alternative now
+# requires an exhaustion/unavailability word directly after the noun.
+_codex_usage_limit_topic_mention_not_quota_mock_dir="$(mktemp -d)"
+cat > "$_codex_usage_limit_topic_mention_not_quota_mock_dir/gh" <<'CODEX_USAGE_LIMIT_TOPIC_MENTION_NOT_QUOTA_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade008f1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":262,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"facade008f1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found. The Codex usage limit handling looks correct."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":263,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found.\\n\\n**Reviewed commit:** `facade008f`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_USAGE_LIMIT_TOPIC_MENTION_NOT_QUOTA_GH
+chmod +x "$_codex_usage_limit_topic_mention_not_quota_mock_dir/gh"
+
+_codex_usage_limit_topic_mention_not_quota_output=""
+_codex_usage_limit_topic_mention_not_quota_exit=0
+PATH="$_codex_usage_limit_topic_mention_not_quota_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_usage_limit_topic_mention_not_quota_mock_dir/output.txt" 2>&1 || _codex_usage_limit_topic_mention_not_quota_exit=$?
+_codex_usage_limit_topic_mention_not_quota_output="$(cat "$_codex_usage_limit_topic_mention_not_quota_mock_dir/output.txt")"
+run_test "codex_usage_limit_topic_mention_not_quota_exit_clean" "0" "$_codex_usage_limit_topic_mention_not_quota_exit"
+run_test "codex_usage_limit_topic_mention_not_quota_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_usage_limit_topic_mention_not_quota_output" | grep "^VERDICT:")"
+rm -rf "$_codex_usage_limit_topic_mention_not_quota_mock_dir"
+unset _codex_usage_limit_topic_mention_not_quota_mock_dir _codex_usage_limit_topic_mention_not_quota_output _codex_usage_limit_topic_mention_not_quota_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4356,6 +4356,56 @@ run_test "codex_tied_usage_limit_then_unrecognized_verdict" "VERDICT: NEEDS_REVI
 rm -rf "$_codex_tied_usage_limit_then_unrecognized_mock_dir"
 unset _codex_tied_usage_limit_then_unrecognized_mock_dir _codex_tied_usage_limit_then_unrecognized_output _codex_tied_usage_limit_then_unrecognized_exit
 
+# Reproduces Codex finding on PR #1490 (P1, comment id 3789634709): the
+# post-combine truncation to 10000 chars ran BEFORE the verdict-parsing
+# classification checks, so a SHA-pinned root review exceeding 10000
+# characters with an approval phrase before the cutoff and a blocking
+# marker after it had its blocker silently cut off, classifying the
+# truncated (approval-only) text as APPROVED. Classification now runs
+# against BOT_RESPONSE_FULL (untruncated); BOT_RESPONSE (truncated) is
+# used only for the script's own "---BEGIN/END BOT RESPONSE---" display.
+# Fixture: a 15000+ char root comment with a clean approval phrase near
+# the start and a blocking marker well past the 10000-char cutoff.
+_codex_long_root_review_blocker_past_cutoff_mock_dir="$(mktemp -d)"
+cat > "$_codex_long_root_review_blocker_past_cutoff_mock_dir/gh" <<'CODEX_LONG_ROOT_REVIEW_BLOCKER_PAST_CUTOFF_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'deadface1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":250,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:340,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("No blocking issues found.\n\n" + ("x" * 15000) + "\n\nBlocking issues: must fix the leak past the cutoff.\n\n**Reviewed commit:** `deadface1234`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_LONG_ROOT_REVIEW_BLOCKER_PAST_CUTOFF_GH
+chmod +x "$_codex_long_root_review_blocker_past_cutoff_mock_dir/gh"
+
+_codex_long_root_review_blocker_past_cutoff_output=""
+_codex_long_root_review_blocker_past_cutoff_exit=0
+PATH="$_codex_long_root_review_blocker_past_cutoff_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_long_root_review_blocker_past_cutoff_mock_dir/output.txt" 2>&1 || _codex_long_root_review_blocker_past_cutoff_exit=$?
+_codex_long_root_review_blocker_past_cutoff_output="$(cat "$_codex_long_root_review_blocker_past_cutoff_mock_dir/output.txt")"
+run_test "codex_long_root_review_blocker_past_cutoff_exit_needs_revision" "1" "$_codex_long_root_review_blocker_past_cutoff_exit"
+run_test "codex_long_root_review_blocker_past_cutoff_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_long_root_review_blocker_past_cutoff_output" | grep "^VERDICT:")"
+rm -rf "$_codex_long_root_review_blocker_past_cutoff_mock_dir"
+unset _codex_long_root_review_blocker_past_cutoff_mock_dir _codex_long_root_review_blocker_past_cutoff_output _codex_long_root_review_blocker_past_cutoff_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4054,6 +4054,59 @@ run_test "codex_bodyless_tied_review_not_approved_verdict_not_approved" "0" \
 rm -rf "$_codex_bodyless_tied_review_not_approved_mock_dir"
 unset _codex_bodyless_tied_review_not_approved_mock_dir _codex_bodyless_tied_review_not_approved_output _codex_bodyless_tied_review_not_approved_exit
 
+# Reproduces Codex finding on PR #1490 (P1, comment id 3788164224): the
+# prior bodyless-tied-review fix made COMBINED_SOURCE/COMBINED_TIME record
+# an empty-bodied review's presence, but the main-loop and async verdict
+# paths still gated the "if -n $BOT_RESPONSE" verdict-parsing entry on the
+# BODY being non-empty, so a bodyless winning review fell through to
+# TIMED_OUT — a permissive-unavailable-policy consumer could treat that
+# more leniently than the documented unrecognized-response safe-fail
+# NEEDS_REVISION. Verdict-parsing entry is now gated on
+# BOT_RESPONSE_TIME (captured from COMBINED_TIME right after combine)
+# instead of BOT_RESPONSE body content. Same fixture as
+# codex_bodyless_tied_review_not_approved, but asserts the exact expected
+# verdict rather than only "not APPROVED".
+_codex_bodyless_tied_review_needs_revision_mock_dir="$(mktemp -d)"
+cat > "$_codex_bodyless_tied_review_needs_revision_mock_dir/gh" <<'CODEX_BODYLESS_TIED_REVIEW_NEEDS_REVISION_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'c0ffee001234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":200,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"c0ffee001234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."},{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"c0ffee001234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":""}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":310,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex Review: Didn'\''t find any major issues.\\n\\n**Reviewed commit:** `c0ffee001234`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_BODYLESS_TIED_REVIEW_NEEDS_REVISION_GH
+chmod +x "$_codex_bodyless_tied_review_needs_revision_mock_dir/gh"
+
+_codex_bodyless_tied_review_needs_revision_output=""
+_codex_bodyless_tied_review_needs_revision_exit=0
+PATH="$_codex_bodyless_tied_review_needs_revision_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_bodyless_tied_review_needs_revision_mock_dir/output.txt" 2>&1 || _codex_bodyless_tied_review_needs_revision_exit=$?
+_codex_bodyless_tied_review_needs_revision_output="$(cat "$_codex_bodyless_tied_review_needs_revision_mock_dir/output.txt")"
+run_test "codex_bodyless_tied_review_needs_revision_exit" "1" "$_codex_bodyless_tied_review_needs_revision_exit"
+run_test "codex_bodyless_tied_review_needs_revision_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_bodyless_tied_review_needs_revision_output" | grep "^VERDICT:")"
+rm -rf "$_codex_bodyless_tied_review_needs_revision_mock_dir"
+unset _codex_bodyless_tied_review_needs_revision_mock_dir _codex_bodyless_tied_review_needs_revision_output _codex_bodyless_tied_review_needs_revision_exit
+
 _codex_review_query_failure_mock_dir="$(mktemp -d)"
 cat > "$_codex_review_query_failure_mock_dir/gh" <<'CODEX_REVIEW_QUERY_FAILURE_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2899,6 +2899,46 @@ run_test "codex_cloud_environment_finding_verdict" "VERDICT: NEEDS_REVISION" \
 rm -rf "$_codex_cloud_environment_finding_mock_dir"
 unset _codex_cloud_environment_finding_mock_dir _codex_cloud_environment_finding_output _codex_cloud_environment_finding_exit
 
+_codex_environment_phrase_finding_mock_dir="$(mktemp -d)"
+cat > "$_codex_environment_phrase_finding_mock_dir/gh" <<'CODEX_ENVIRONMENT_PHRASE_FINDING_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcenvphrase1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":114,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"abcenvphrase1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Must fix docs that tell users to create an environment for this repo."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_ENVIRONMENT_PHRASE_FINDING_GH
+chmod +x "$_codex_environment_phrase_finding_mock_dir/gh"
+
+_codex_environment_phrase_finding_output=""
+_codex_environment_phrase_finding_exit=0
+PATH="$_codex_environment_phrase_finding_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_environment_phrase_finding_mock_dir/output.txt" 2>&1 || _codex_environment_phrase_finding_exit=$?
+_codex_environment_phrase_finding_output="$(cat "$_codex_environment_phrase_finding_mock_dir/output.txt")"
+run_test "codex_environment_phrase_finding_exit_needs_revision" "1" "$_codex_environment_phrase_finding_exit"
+run_test "codex_environment_phrase_finding_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_environment_phrase_finding_output" | grep "^VERDICT:")"
+rm -rf "$_codex_environment_phrase_finding_mock_dir"
+unset _codex_environment_phrase_finding_mock_dir _codex_environment_phrase_finding_output _codex_environment_phrase_finding_exit
+
 _codex_final_ack_clean_comment_mock_dir="$(mktemp -d)"
 printf '0\n' > "$_codex_final_ack_clean_comment_mock_dir/comment_calls"
 cat > "$_codex_final_ack_clean_comment_mock_dir/gh" <<'CODEX_FINAL_ACK_CLEAN_COMMENT_GH'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2642,6 +2642,50 @@ run_test "codex_stale_review_not_approved" "no" "$_codex_stale_review_approved"
 rm -rf "$_codex_stale_review_mock_dir"
 unset _codex_stale_review_mock_dir _codex_stale_review_output _codex_stale_review_exit _codex_stale_review_approved
 
+_codex_stale_inline_mock_dir="$(mktemp -d)"
+cat > "$_codex_stale_inline_mock_dir/gh" <<'CODEX_STALE_INLINE_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcinline1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":112,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[{"created_at":"2026-01-01T00:00:01Z","commit_id":"oldinline1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issue on old head."}]\n'
+    exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_STALE_INLINE_GH
+chmod +x "$_codex_stale_inline_mock_dir/gh"
+
+_codex_stale_inline_output=""
+_codex_stale_inline_exit=0
+PATH="$_codex_stale_inline_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_stale_inline_mock_dir/output.txt" 2>&1 || _codex_stale_inline_exit=$?
+_codex_stale_inline_output="$(cat "$_codex_stale_inline_mock_dir/output.txt")"
+run_test "codex_stale_inline_exit_unavailable" "2" "$_codex_stale_inline_exit"
+if printf '%s\n' "$_codex_stale_inline_output" | grep -q "^VERDICT: NEEDS_REVISION"; then
+  _codex_stale_inline_needs_revision="yes"
+else
+  _codex_stale_inline_needs_revision="no"
+fi
+run_test "codex_stale_inline_not_needs_revision" "no" "$_codex_stale_inline_needs_revision"
+rm -rf "$_codex_stale_inline_mock_dir"
+unset _codex_stale_inline_mock_dir _codex_stale_inline_output _codex_stale_inline_exit _codex_stale_inline_needs_revision
+
 _codex_head_changed_mock_dir="$(mktemp -d)"
 printf '0\n' > "$_codex_head_changed_mock_dir/head_calls"
 cat > "$_codex_head_changed_mock_dir/gh" <<'CODEX_HEAD_CHANGED_GH'
@@ -2750,7 +2794,8 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    printf '[{"id":208,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector"},"body":"To use Codex here, create an environment for this repo."},{"id":209,"created_at":"2026-01-01T00:00:02Z","user":{"login":"chatgpt-codex-connector"},"body":"No blocking issues found."}]\n'
+    printf '[{"id":208,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector"},"body":"To use Codex here, create an environment for this repo."}]\n'
+    printf '[{"id":209,"created_at":"2026-01-01T00:00:02Z","user":{"login":"chatgpt-codex-connector"},"body":"No blocking issues found."}]\n'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
@@ -2772,6 +2817,46 @@ run_test "codex_environment_then_clean_comment_approved" "VERDICT: APPROVED" \
   "$(printf '%s\n' "$_codex_environment_then_clean_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_environment_then_clean_comment_mock_dir"
 unset _codex_environment_then_clean_comment_mock_dir _codex_environment_then_clean_comment_output _codex_environment_then_clean_comment_exit
+
+_codex_cloud_environment_finding_mock_dir="$(mktemp -d)"
+cat > "$_codex_cloud_environment_finding_mock_dir/gh" <<'CODEX_CLOUD_ENVIRONMENT_FINDING_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abccloudfinding1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":113,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"abccloudfinding1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: the Codex cloud environment is missing required secrets."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_CLOUD_ENVIRONMENT_FINDING_GH
+chmod +x "$_codex_cloud_environment_finding_mock_dir/gh"
+
+_codex_cloud_environment_finding_output=""
+_codex_cloud_environment_finding_exit=0
+PATH="$_codex_cloud_environment_finding_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_cloud_environment_finding_mock_dir/output.txt" 2>&1 || _codex_cloud_environment_finding_exit=$?
+_codex_cloud_environment_finding_output="$(cat "$_codex_cloud_environment_finding_mock_dir/output.txt")"
+run_test "codex_cloud_environment_finding_exit_needs_revision" "1" "$_codex_cloud_environment_finding_exit"
+run_test "codex_cloud_environment_finding_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_cloud_environment_finding_output" | grep "^VERDICT:")"
+rm -rf "$_codex_cloud_environment_finding_mock_dir"
+unset _codex_cloud_environment_finding_mock_dir _codex_cloud_environment_finding_output _codex_cloud_environment_finding_exit
 
 _codex_final_ack_clean_comment_mock_dir="$(mktemp -d)"
 printf '0\n' > "$_codex_final_ack_clean_comment_mock_dir/comment_calls"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2557,6 +2557,46 @@ run_test "codex_reaction_only_reason" "REASON=codex-github-reaction-without-revi
 rm -rf "$_codex_reaction_mock_dir"
 unset _codex_reaction_mock_dir _codex_reaction_output _codex_reaction_exit
 
+_codex_reaction_with_review_mock_dir="$(mktemp -d)"
+cat > "$_codex_reaction_with_review_mock_dir/gh" <<'CODEX_REACTION_WITH_REVIEW_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcreviewok1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":106,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[{"content":"+1","user":{"login":"chatgpt-codex-connector[bot]"}}]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"abcreviewok1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_REACTION_WITH_REVIEW_GH
+chmod +x "$_codex_reaction_with_review_mock_dir/gh"
+
+_codex_reaction_with_review_output=""
+_codex_reaction_with_review_exit=0
+PATH="$_codex_reaction_with_review_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_reaction_with_review_mock_dir/output.txt" 2>&1 || _codex_reaction_with_review_exit=$?
+_codex_reaction_with_review_output="$(cat "$_codex_reaction_with_review_mock_dir/output.txt")"
+run_test "codex_reaction_with_current_review_exit_clean" "0" "$_codex_reaction_with_review_exit"
+run_test "codex_reaction_with_current_review_approved" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_reaction_with_review_output" | grep "^VERDICT:")"
+rm -rf "$_codex_reaction_with_review_mock_dir"
+unset _codex_reaction_with_review_mock_dir _codex_reaction_with_review_output _codex_reaction_with_review_exit
+
 _codex_stale_review_mock_dir="$(mktemp -d)"
 cat > "$_codex_stale_review_mock_dir/gh" <<'CODEX_STALE_REVIEW_GH'
 #!/usr/bin/env bash
@@ -2600,6 +2640,56 @@ fi
 run_test "codex_stale_review_not_approved" "no" "$_codex_stale_review_approved"
 rm -rf "$_codex_stale_review_mock_dir"
 unset _codex_stale_review_mock_dir _codex_stale_review_output _codex_stale_review_exit _codex_stale_review_approved
+
+_codex_head_changed_mock_dir="$(mktemp -d)"
+printf '0\n' > "$_codex_head_changed_mock_dir/head_calls"
+cat > "$_codex_head_changed_mock_dir/gh" <<'CODEX_HEAD_CHANGED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    calls_file="$(dirname "$0")/head_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    if [ "$calls" -eq 1 ]; then
+      printf 'abcheadold1234567890\n'
+    else
+      printf 'abcheadnew1234567890\n'
+    fi
+    exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":107,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"abcheadold1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_HEAD_CHANGED_GH
+chmod +x "$_codex_head_changed_mock_dir/gh"
+
+_codex_head_changed_output=""
+_codex_head_changed_exit=0
+PATH="$_codex_head_changed_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_head_changed_mock_dir/output.txt" 2>&1 || _codex_head_changed_exit=$?
+_codex_head_changed_output="$(cat "$_codex_head_changed_mock_dir/output.txt")"
+run_test "codex_head_changed_exit_unavailable" "2" "$_codex_head_changed_exit"
+run_test "codex_head_changed_reason" "REASON=codex-github-head-changed" \
+  "$(printf '%s\n' "$_codex_head_changed_output" | grep "^REASON=")"
+rm -rf "$_codex_head_changed_mock_dir"
+unset _codex_head_changed_mock_dir _codex_head_changed_output _codex_head_changed_exit
 
 _codex_environment_mock_dir="$(mktemp -d)"
 cat > "$_codex_environment_mock_dir/gh" <<'CODEX_ENVIRONMENT_GH'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2733,6 +2733,95 @@ run_test "codex_environment_with_current_review_approved" "VERDICT: APPROVED" \
 rm -rf "$_codex_environment_with_review_mock_dir"
 unset _codex_environment_with_review_mock_dir _codex_environment_with_review_output _codex_environment_with_review_exit
 
+_codex_environment_then_clean_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_environment_then_clean_comment_mock_dir/gh" <<'CODEX_ENVIRONMENT_THEN_CLEAN_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcenvcomment1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":109,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":208,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector"},"body":"To use Codex here, create an environment for this repo."},{"id":209,"created_at":"2026-01-01T00:00:02Z","user":{"login":"chatgpt-codex-connector"},"body":"No blocking issues found."}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_ENVIRONMENT_THEN_CLEAN_COMMENT_GH
+chmod +x "$_codex_environment_then_clean_comment_mock_dir/gh"
+
+_codex_environment_then_clean_comment_output=""
+_codex_environment_then_clean_comment_exit=0
+PATH="$_codex_environment_then_clean_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_environment_then_clean_comment_mock_dir/output.txt" 2>&1 || _codex_environment_then_clean_comment_exit=$?
+_codex_environment_then_clean_comment_output="$(cat "$_codex_environment_then_clean_comment_mock_dir/output.txt")"
+run_test "codex_environment_then_clean_comment_exit_clean" "0" "$_codex_environment_then_clean_comment_exit"
+run_test "codex_environment_then_clean_comment_approved" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_environment_then_clean_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_environment_then_clean_comment_mock_dir"
+unset _codex_environment_then_clean_comment_mock_dir _codex_environment_then_clean_comment_output _codex_environment_then_clean_comment_exit
+
+_codex_final_ack_clean_comment_mock_dir="$(mktemp -d)"
+printf '0\n' > "$_codex_final_ack_clean_comment_mock_dir/comment_calls"
+cat > "$_codex_final_ack_clean_comment_mock_dir/gh" <<'CODEX_FINAL_ACK_CLEAN_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcfinalcomment1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":110,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    calls_file="$(dirname "$0")/comment_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    if [ "$calls" -lt 3 ]; then
+      printf '[{"id":210,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector"},"body":"If Codex has suggestions, it will comment; otherwise it will react with thumbs up."}]\n'
+    else
+      printf '[{"id":210,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector"},"body":"If Codex has suggestions, it will comment; otherwise it will react with thumbs up."},{"id":211,"created_at":"2026-01-01T00:00:02Z","user":{"login":"chatgpt-codex-connector"},"body":"No blocking issues found."}]\n'
+    fi
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FINAL_ACK_CLEAN_COMMENT_GH
+chmod +x "$_codex_final_ack_clean_comment_mock_dir/gh"
+
+_codex_final_ack_clean_comment_output=""
+_codex_final_ack_clean_comment_exit=0
+PATH="$_codex_final_ack_clean_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_final_ack_clean_comment_mock_dir/output.txt" 2>&1 || _codex_final_ack_clean_comment_exit=$?
+_codex_final_ack_clean_comment_output="$(cat "$_codex_final_ack_clean_comment_mock_dir/output.txt")"
+run_test "codex_final_ack_clean_comment_exit_clean" "0" "$_codex_final_ack_clean_comment_exit"
+run_test "codex_final_ack_clean_comment_approved" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_final_ack_clean_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_final_ack_clean_comment_mock_dir"
+unset _codex_final_ack_clean_comment_mock_dir _codex_final_ack_clean_comment_output _codex_final_ack_clean_comment_exit
+
 _codex_environment_mock_dir="$(mktemp -d)"
 cat > "$_codex_environment_mock_dir/gh" <<'CODEX_ENVIRONMENT_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -5135,6 +5135,101 @@ run_test "codex_usage_limit_survives_later_env_error_same_fetch_verdict" "VERDIC
 rm -rf "$_codex_usage_limit_survives_later_env_error_same_fetch_mock_dir"
 unset _codex_usage_limit_survives_later_env_error_same_fetch_mock_dir _codex_usage_limit_survives_later_env_error_same_fetch_output _codex_usage_limit_survives_later_env_error_same_fetch_exit
 
+# CODEX_APPROVAL_PATTERN's substring match can't distinguish quotation/
+# discussion of a clean phrase from an actual assertion of it: a
+# SHA-pinned review that REJECTS text while QUOTING a clean signal (e.g.
+# `The documented bot response "No blocking issues found" is inaccurate
+# and should be corrected`) still matched and returned APPROVED instead
+# of the documented unrecognized-format safe-fail (fresh evidence from PR
+# #1490 finding 3790122058). codex_response_is_approved now strips
+# quoted spans before matching.
+_codex_quoted_clean_phrase_not_approved_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_quoted_clean_phrase_not_approved_root_comment_mock_dir/gh" <<'CODEX_QUOTED_CLEAN_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade01221234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":283,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:284,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("The documented bot response \"No blocking issues found\" is inaccurate and should be corrected.\n\n**Reviewed commit:** `facade01221`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_QUOTED_CLEAN_PHRASE_NOT_APPROVED_ROOT_COMMENT_GH
+chmod +x "$_codex_quoted_clean_phrase_not_approved_root_comment_mock_dir/gh"
+
+_codex_quoted_clean_phrase_not_approved_root_comment_output=""
+_codex_quoted_clean_phrase_not_approved_root_comment_exit=0
+PATH="$_codex_quoted_clean_phrase_not_approved_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_quoted_clean_phrase_not_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_quoted_clean_phrase_not_approved_root_comment_exit=$?
+_codex_quoted_clean_phrase_not_approved_root_comment_output="$(cat "$_codex_quoted_clean_phrase_not_approved_root_comment_mock_dir/output.txt")"
+run_test "codex_quoted_clean_phrase_not_approved_root_comment_exit_needs_revision" "1" "$_codex_quoted_clean_phrase_not_approved_root_comment_exit"
+run_test "codex_quoted_clean_phrase_not_approved_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_quoted_clean_phrase_not_approved_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_quoted_clean_phrase_not_approved_root_comment_mock_dir"
+unset _codex_quoted_clean_phrase_not_approved_root_comment_mock_dir _codex_quoted_clean_phrase_not_approved_root_comment_output _codex_quoted_clean_phrase_not_approved_root_comment_exit
+
+# The [^.!?]* negation span only excluded sentence terminators, not
+# clause separators, so an unrelated negation in an earlier semicolon-
+# joined clause of the same sentence still spanned into a later, unrelated
+# clean clause (e.g. "Tests are not required for this documentation-only
+# change; looks good") and was incorrectly flagged as negated (fresh
+# evidence from PR #1490 finding 3790122061). The character class now
+# also excludes `;`.
+_codex_semicolon_scoped_negation_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_semicolon_scoped_negation_root_comment_mock_dir/gh" <<'CODEX_SEMICOLON_SCOPED_NEGATION_ROOT_COMMENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'facade01331234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":285,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":286,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Tests are not required for this documentation-only change; looks good.\\n\\n**Reviewed commit:** `facade01331`"}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_SEMICOLON_SCOPED_NEGATION_ROOT_COMMENT_GH
+chmod +x "$_codex_semicolon_scoped_negation_root_comment_mock_dir/gh"
+
+_codex_semicolon_scoped_negation_root_comment_output=""
+_codex_semicolon_scoped_negation_root_comment_exit=0
+PATH="$_codex_semicolon_scoped_negation_root_comment_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_semicolon_scoped_negation_root_comment_mock_dir/output.txt" 2>&1 || _codex_semicolon_scoped_negation_root_comment_exit=$?
+_codex_semicolon_scoped_negation_root_comment_output="$(cat "$_codex_semicolon_scoped_negation_root_comment_mock_dir/output.txt")"
+run_test "codex_semicolon_scoped_negation_root_comment_exit_clean" "0" "$_codex_semicolon_scoped_negation_root_comment_exit"
+run_test "codex_semicolon_scoped_negation_root_comment_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_semicolon_scoped_negation_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_semicolon_scoped_negation_root_comment_mock_dir"
+unset _codex_semicolon_scoped_negation_root_comment_mock_dir _codex_semicolon_scoped_negation_root_comment_output _codex_semicolon_scoped_negation_root_comment_exit
+
 # codex_response_priority ranked an ancillary environment-setup-error
 # comment at the same "unrecognized format" tier (2) as a genuine but
 # unrecognized-format submitted review, instead of at the lower

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2575,7 +2575,8 @@ case "$*" in
     printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"abcreviewok1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
     exit 0 ;;
   *"issues/"*"/comments"*)
-    printf '[]\n'; exit 0 ;;
+    printf '[{"id":206,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector"},"body":"If Codex has suggestions, it will comment; otherwise it will react with thumbs up."}]\n'
+    exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
     printf 'ARGS=%q\n' "$*" >&2
@@ -2690,6 +2691,47 @@ run_test "codex_head_changed_reason" "REASON=codex-github-head-changed" \
   "$(printf '%s\n' "$_codex_head_changed_output" | grep "^REASON=")"
 rm -rf "$_codex_head_changed_mock_dir"
 unset _codex_head_changed_mock_dir _codex_head_changed_output _codex_head_changed_exit
+
+_codex_environment_with_review_mock_dir="$(mktemp -d)"
+cat > "$_codex_environment_with_review_mock_dir/gh" <<'CODEX_ENVIRONMENT_WITH_REVIEW_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcenvok1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":108,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"submitted_at":"2026-01-01T00:00:02Z","commit_id":"abcenvok1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":207,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector"},"body":"To use Codex here, create an environment for this repo."}]\n'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_ENVIRONMENT_WITH_REVIEW_GH
+chmod +x "$_codex_environment_with_review_mock_dir/gh"
+
+_codex_environment_with_review_output=""
+_codex_environment_with_review_exit=0
+PATH="$_codex_environment_with_review_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_environment_with_review_mock_dir/output.txt" 2>&1 || _codex_environment_with_review_exit=$?
+_codex_environment_with_review_output="$(cat "$_codex_environment_with_review_mock_dir/output.txt")"
+run_test "codex_environment_with_current_review_exit_clean" "0" "$_codex_environment_with_review_exit"
+run_test "codex_environment_with_current_review_approved" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_environment_with_review_output" | grep "^VERDICT:")"
+rm -rf "$_codex_environment_with_review_mock_dir"
+unset _codex_environment_with_review_mock_dir _codex_environment_with_review_output _codex_environment_with_review_exit
 
 _codex_environment_mock_dir="$(mktemp -d)"
 cat > "$_codex_environment_mock_dir/gh" <<'CODEX_ENVIRONMENT_GH'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2682,6 +2682,65 @@ run_test "codex_newer_root_blocks_old_review_verdict" "VERDICT: NEEDS_REVISION" 
 rm -rf "$_codex_newer_root_blocks_old_review_mock_dir"
 unset _codex_newer_root_blocks_old_review_mock_dir _codex_newer_root_blocks_old_review_output _codex_newer_root_blocks_old_review_exit
 
+_codex_async_newer_root_blocks_old_review_mock_dir="$(mktemp -d)"
+printf '0\n' > "$_codex_async_newer_root_blocks_old_review_mock_dir/comment_calls"
+printf '0\n' > "$_codex_async_newer_root_blocks_old_review_mock_dir/review_calls"
+cat > "$_codex_async_newer_root_blocks_old_review_mock_dir/gh" <<'CODEX_ASYNC_NEWER_ROOT_BLOCKS_OLD_REVIEW_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'deaf12341234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":125,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    calls_file="$(dirname "$0")/review_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    if [ "$calls" -ge 2 ]; then
+      printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"deaf12341234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    else
+      printf '[]\n'
+    fi
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    calls_file="$(dirname "$0")/comment_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    if [ "$calls" -ge 2 ]; then
+      printf '[{"id":225,"created_at":"2026-01-01T00:00:02Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: newer async root finding.\\n\\n**Reviewed commit:** `deaf1234`"}]\n'
+    else
+      printf '[]\n'
+    fi
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_ASYNC_NEWER_ROOT_BLOCKS_OLD_REVIEW_GH
+chmod +x "$_codex_async_newer_root_blocks_old_review_mock_dir/gh"
+
+_codex_async_newer_root_blocks_old_review_output=""
+_codex_async_newer_root_blocks_old_review_exit=0
+PATH="$_codex_async_newer_root_blocks_old_review_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_async_newer_root_blocks_old_review_mock_dir/output.txt" 2>&1 || _codex_async_newer_root_blocks_old_review_exit=$?
+_codex_async_newer_root_blocks_old_review_output="$(cat "$_codex_async_newer_root_blocks_old_review_mock_dir/output.txt")"
+run_test "codex_async_newer_root_blocks_old_review_exit_needs_revision" "1" "$_codex_async_newer_root_blocks_old_review_exit"
+run_test "codex_async_newer_root_blocks_old_review_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_async_newer_root_blocks_old_review_output" | grep "^VERDICT:")"
+rm -rf "$_codex_async_newer_root_blocks_old_review_mock_dir"
+unset _codex_async_newer_root_blocks_old_review_mock_dir _codex_async_newer_root_blocks_old_review_output _codex_async_newer_root_blocks_old_review_exit
+
 _codex_reaction_with_review_mock_dir="$(mktemp -d)"
 cat > "$_codex_reaction_with_review_mock_dir/gh" <<'CODEX_REACTION_WITH_REVIEW_GH'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary
- require Codex GitHub submitted reviews to match the current PR head SHA before they can produce a clean verdict
- treat thumbs-up-only Codex responses and missing Codex cloud environments as unavailable, not clean
- document the terminal evidence contract and add regression coverage for reaction-only, stale-review, and environment-missing cases

## Validation
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` (421 passed)
- `bash -n scripts/development-workflow/codex-github-reviewer.sh scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 CHANGELOG.md docs/workflow/development-workflow/integrations/codex-github.md docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`

ShellCheck was not available in the Mac Mini environment.
