### PR TITLE
refactor(codex-github): whole-body exact-template verdict classifier (#1491)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -572,6 +572,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PR metadata cannot be resolved, and batch merge rechecks preserve explicit
   approvals for unready PRs.
 
+### Changed
+
+- **Conservative Codex verdict classifier** (#1491): `codex-github-reviewer.sh` now requires the response —
+  whitespace-normalized, with no truncation step of any kind — to be an exact match, from its first
+  character to its last, against one of a small set of clean-response templates captured verbatim from real
+  Codex responses (each template including the complete vendor `<details>` footer text), and safe-fails to
+  `NEEDS_REVISION` for anything else, including responses that are plausibly clean but use different
+  wording anywhere in the body. This replaces both the open-ended negated-approval vocabulary enumeration
+  this plan originally targeted and the allow-list/closed-grammar/truncate-then-match designs this plan
+  shipped and then found further false-`APPROVED` gaps in across subsequent review rounds — no vocabulary,
+  grammar, or partial-body match converged, so this revision applies exact literal comparison to the entire
+  response, leaving no discarded byte range for a novel construction to hide in. GitHub's structured
+  `CHANGES_REQUESTED` review-state short-circuit and the blocking classifier are unchanged.
+
 ## [0.42.0] - 2026-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -585,11 +585,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   grammar, or partial-body match converged, so this revision applies exact literal comparison to the entire
   response, leaving no discarded byte range for a novel construction to hide in. GitHub's structured
   `CHANGES_REQUESTED` review-state short-circuit and the blocking classifier are unchanged. The template's one
-  "flavor" slot (the word or phrase directly after "Didn't find any major issues.") is a bounded alternation
-  of every token evidenced from a live Codex response (14 found by a repository-history sweep, including
-  `Swish!` and `:rocket:`), not a single fixed literal — the vendor rotates this slot, confirmed after the
-  shipped single-literal version safe-failed on this feature's own first real-traffic PR. Adding a
-  newly-observed token requires the same live-capture discipline as adding a template.
+  "flavor" slot (the word or phrase directly after "Didn't find any major issues.") is a single bounded
+  placeholder (up to 40 characters, excluding `*`, backtick, and control characters), not a fixed literal —
+  the vendor rotates this slot, confirmed after the shipped single-literal version safe-failed on this
+  feature's own first real-traffic PR. A first fix enumerated every observed token as a literal alternation,
+  but a 14-token discovery rate from under 50 samples showed that vocabulary would not converge by
+  enumeration either, so the bounded placeholder replaced it before merge — the accepted residual is a
+  disclosed, narrow false-`APPROVED` surface (self-contradictory vendor output only), not an enumeration that
+  needs ongoing maintenance.
 
 ## [0.42.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -584,7 +584,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shipped and then found further false-`APPROVED` gaps in across subsequent review rounds — no vocabulary,
   grammar, or partial-body match converged, so this revision applies exact literal comparison to the entire
   response, leaving no discarded byte range for a novel construction to hide in. GitHub's structured
-  `CHANGES_REQUESTED` review-state short-circuit and the blocking classifier are unchanged.
+  `CHANGES_REQUESTED` review-state short-circuit and the blocking classifier are unchanged. The template's one
+  "flavor" slot (the word or phrase directly after "Didn't find any major issues.") is a bounded alternation
+  of every token evidenced from a live Codex response (14 found by a repository-history sweep, including
+  `Swish!` and `:rocket:`), not a single fixed literal — the vendor rotates this slot, confirmed after the
+  shipped single-literal version safe-failed on this feature's own first real-traffic PR. Adding a
+  newly-observed token requires the same live-capture discipline as adding a template.
 
 ## [0.42.0] - 2026-08-13
 

--- a/docs/specs/developments/20260817203204_1491-conservative-verdict-classifier/2_1491-conservative-verdict-classifier_implementation-plan.md
+++ b/docs/specs/developments/20260817203204_1491-conservative-verdict-classifier/2_1491-conservative-verdict-classifier_implementation-plan.md
@@ -1421,6 +1421,59 @@ This is a full design replacement, so the evidence the implementation must produ
     vector still safe-fails once normalization flattens it — confirmed by execution against the real, composed
     chain, not asserted from the pattern's appearance alone.
 
+### Planted-violation proof (REVIEW.md Verification Discipline; PR #1494 review finding `3808305143`)
+
+`REVIEW.md`'s Verification Discipline rule requires, for any PR that materially modifies an automated check —
+this classifier and its Decision 6 gate both qualify — a demonstrated run at a concrete file and line showing
+the check fails with the targeted violation present and passes once it is removed, in both directions, not a
+description. Codex GitHub finding `3808305143` (P1) correctly identified that the evidence posted for this PR
+did not meet that bar: it described gate-revert experiments in prose without naming file:line or pasting both
+runs' actual output. The full transcripts (mutation, failing-run output, restoration, passing-run output) for
+every materially modified check are posted as a PR #1494 comment and are the authoritative record; this section
+indexes what each transcript covers and what it found, so the proof is discoverable from the plan, not only
+from a comment that could scroll out of view.
+
+**Decision 6 acknowledgement gate — all four verdict sites, each with its own full transcript (not one
+transcript generalized to the other three):**
+
+- Main-loop, `codex-github-reviewer.sh:1605` — mutation removes the `[ SOURCE != "review" ]` condition,
+  reverting to the unconditional pre-Decision-6 form. Caught by `codex_footer_near_miss_main_loop_safe_fails`.
+  **This transcript also found and fixed a real, pre-existing test-isolation gap**: the scenario's mock
+  originally returned the near-miss body on every poll call, so a broken main-loop gate was silently rescued by
+  the still-correct async-arrival gate one site later, and the mutation produced no detectable failure at all
+  on first attempt. Fixed by making the mock call-counted (near-miss body only on call 2, the main poll loop's
+  own check; empty on calls 3+), matching the isolation convention the other three sites' mocks already used —
+  after the fix, the same mutation is correctly caught.
+- Async-arrival, `codex-github-reviewer.sh:1823` — same mutation shape. Caught by
+  `codex_footer_near_miss_async_arrival_safe_fails`. **Same rescue gap found and fixed**: the mock originally
+  kept returning the near-miss body from call 3 onward (`-ge 3`), letting async-final rescue a broken
+  async-arrival gate; tightened to `-eq 3` (near-miss body only on call 3; empty on calls 4+).
+- Async-final, `codex-github-reviewer.sh:1929` — mutation removes the `[ SOURCE = "review" ] ||` disjunct from
+  the negated-form gate, reverting to the unconditional `! grep` pre-Decision-6 form. Caught by
+  `codex_footer_near_miss_async_final_safe_fails`. This scenario's mock was already properly isolated (no
+  rescue possible — async-final is the terminal site for its own construction's branch).
+- Async-reaction-final, `codex-github-reviewer.sh:2081` — same negated-form mutation shape. Caught by
+  `codex_footer_near_miss_async_reaction_final_safe_fails`. Also already properly isolated for the same
+  structural reason (terminal site for the reaction-detected branch).
+
+**Whole-body exact-match classifier (`codex_response_is_approved`, the array element cited at
+`codex-github-reviewer.sh:759` in the finding, template literal at `codex-github-reviewer.sh:737`)** — mutation
+removes the trailing `$` anchor from `CODEX_APPROVED_TEMPLATES`' one entry, reopening the "extra trailing
+content" gap Decision 1 exists to close. Caught by `codex_e10_trailing_prose_not_approved`, which produces a
+false `VERDICT: APPROVED` with the violation present.
+
+**Bounded flavor placeholder (`codex-github-reviewer.sh:737`)** — mutation removes `*` from the placeholder's
+excluded-character class (`[^*`[:cntrl:]]{1,40}` → `[^`[:cntrl:]]{1,40}`). Caught by
+`codex_placeholder_asterisk_not_approved`, which also produces a false `VERDICT: APPROVED` with the violation
+present.
+
+**Not re-proven (exemption, `REVIEW.md:324`): the SHA field's `[0-9a-f]{7,40}` bound and the complete footer
+literal.** Neither was modified by this PR's diff — the SHA bound is unchanged from the version this plan's
+E5/E6/E7/E8 scenarios already proved (Decision 2's original implementation), and the footer literal is
+byte-identical to the version E9–E11/E24 already proved. Carrying an already-proven check unmodified is a pure
+refactor with no behavior change on that surface, so re-proof is exempt per `REVIEW.md:324`; this exemption is
+stated explicitly rather than silently omitting the proof.
+
 ---
 
 ## Seed Data

--- a/docs/specs/developments/20260817203204_1491-conservative-verdict-classifier/2_1491-conservative-verdict-classifier_implementation-plan.md
+++ b/docs/specs/developments/20260817203204_1491-conservative-verdict-classifier/2_1491-conservative-verdict-classifier_implementation-plan.md
@@ -292,6 +292,74 @@ truncate-then-match design it would not have. This is the accepted trade the hum
 stated, evidence-derived bound for any variable field — is the same fix this plan has always prescribed for
 its riskiest lever, just now applied to one array instead of several.
 
+### Decision 2 Addendum — PR #1494 live evidence falsified the single-literal flavor assumption; the flavor slot is now a bounded alternation of evidenced tokens
+
+**What happened.** This PR's own first real-world use, PR #1494, received a genuinely clean Codex GitHub
+response on its first ready-phase check. The response read `Codex Review: Didn't find any major issues.
+:rocket:` — not `Swish!`. `CODEX_APPROVED_TEMPLATES`' one entry hardcoded `Swish!` as a literal, so this
+genuinely clean response safe-failed to `NEEDS_REVISION` on the classifier's first real-traffic exercise
+(GitHub comment id `5333550055`, PR #1494, 2026-08-18). This is not an implementation defect — the shipped
+code does exactly what Decision 2 specified — it is the residual gap Decision 2 already disclosed explicitly
+("a vendor phrasing change, a different flavor sentence than `Swish!`... safe-fails") materializing in
+practice, faster than expected.
+
+**Live evidence: the flavor slot is a vendor-rotated pool, not a fixed word.** A sweep of every Codex
+GitHub clean-verdict root comment reachable in this repository's history (issues/comments across PRs #470–#519,
+#683, #869–#872, #1489, #1490, #1492, #1494 — the full set returned by a `commenter:chatgpt-codex-connector[bot]`
+search) found **14 distinct flavor tokens**, not the 1–2 anticipated:
+
+| Token (byte-exact) | Evidenced in |
+| --- | --- |
+| `Swish!` | PR #491 (comment `4381989833`), PR #1489 (comment `5294701769`) |
+| `:rocket:` | PR #1494 (comment `5333550055`) — the finding that triggered this correction |
+| `Nice work!` | PR #490 (`4381534986`), PR #506 (`4391791674`), PR #871 (`4664586913`) |
+| `Chef's kiss.` | PR #503 (`4391484333`), PR #510 (`4392497562`), PR #871 (`4665009816`) |
+| `You're on a roll.` | PR #870 (`4664324795`) |
+| `:tada:` | PR #869 (`4664269616`) |
+| `Another round soon, please!` | PR #500 (`4389724254`), PR #683 (`4500576578`) |
+| `:+1:` | PR #481 (`4374386509`), PR #517 (`4396260443`) |
+| `Bravo.` | PR #514 (`4392864280`) |
+| `Keep it up!` | PR #496 (`4383590778`) |
+| `Delightful!` | PR #493 (`4388320805`) |
+| `Keep them coming!` | PR #488 (`4380098761`), PR #489 (`4380656798`) |
+| `Can't wait for the next one!` | PR #484 (`4374411552`), PR #485 (`4374391710`) |
+| `More of your lovely PRs please.` | PR #476 (`4371879954`) |
+
+Every token above was captured verbatim from a live GitHub API response and re-verified byte-for-byte (apostrophe
+form, trailing punctuation) before being bound into the pattern — none is invented or paraphrased. The literal
+emoji form (`🚀`) was checked for and not found in any capture; every shortcode-style token (`:rocket:`, `:tada:`,
+`:+1:`) appears in its raw GitHub shortcode form in the API response body, never as a rendered unicode emoji, so
+only the shortcode forms are bound.
+
+**This sample is very likely not exhaustive.** 14 distinct, largely unrelated phrases (single words, full
+sentences, GitHub emoji shortcodes, inconsistent trailing punctuation) surfaced from a search covering roughly
+40 clean responses — a token discovery rate this high strongly suggests the vendor draws from a large, possibly
+still-growing pool, not a small fixed set. This changes the operational cost estimate in "Risks & Mitigations"
+below from hypothetical to observed: expect further genuinely clean responses to safe-fail on a
+not-yet-evidenced token, and expect this correction cycle (capture live, add to the alternation) to recur.
+
+**Human decision: enumerate, as a bounded alternation, not a wildcard.** The one slot that was a single literal
+becomes a parenthesized ERE alternation of every evidenced token
+(`(Swish!|:rocket:|Nice work!|Chef's kiss\.|...)`), each token escaped for ERE metacharacters as a literal
+string — never a character class, never an open vocabulary, never a "starts with a flavor word" heuristic.
+**Rationale for why this is safe where the original disqualifier/vocabulary enumeration (see "Background") was
+not**: an incomplete flavor list produces a false `NEEDS_REVISION` — the safe failure direction, identical in
+kind to every other residual gap this design already accepts (Decision 2, Risks & Mitigations) — whereas the
+disqualifier enumeration that failed across this plan's first three designs produced a false `APPROVED` on every
+gap, the unsafe direction. Enumerating the flavor slot is the direct, template-scoped application of the
+"capture the new wording live, add a template entry" escape hatch this plan has always prescribed (Decision 2's
+extension rule; "Operational cost and escape hatch") — it is not a new mechanism, and it does not reopen the
+class of gap the whole-body exact match was designed to close: every character in the body is still either part
+of one of the finite literal strings the alternation can produce, or the match fails.
+
+**Standing rule (extends Decision 2's governing rule to the flavor slot specifically).** Adding a flavor token
+is, alongside adding a whole new template, the only other lever that can widen the approval surface. It requires
+the identical review discipline: a token must come from a **live capture** of a real Codex response, never
+invented or guessed by "plausible enthusiasm," and — because unlike the SHA field this slot has no external
+specification to bound it — there is no narrower bound available than "the literal set evidenced so far."
+Removing a token (if a capture is ever found to be a transcription error) is always safe; adding one requires
+the same review this document's history has required for every prior widening.
+
 ### Decision 3 — Composition with the GitHub review `state` short-circuit from PR #1490
 
 PR #1490 threaded GitHub's structured review `state` through evidence selection. That behavior is **preserved
@@ -655,6 +723,13 @@ See "Documentation Updates" for exactly what changes in each.
 ## Code Samples
 
 <!-- Illustrative — adapt during implementation. -->
+
+**Post-implementation note (Decision 2 Addendum):** the flavor slot below is shown with the single `Swish!`
+literal this plan originally shipped. The shipped code no longer matches this illustration exactly — the flavor
+slot is a bounded alternation of every evidenced token (see Decision 2 Addendum for the full list and
+provenance), not a single literal. This snippet is left as originally illustrative, per its own header, rather
+than rewritten to track every subsequent correction; the shipped `codex-github-reviewer.sh` and Decision 2
+Addendum are authoritative for the current contract.
 
 **This is the fourth design this plan has shipped**, replacing (not extending) the truncate-then-match design
 of the immediately prior revision after Codex GitHub finding `3803545669` showed that design still trusted
@@ -1169,7 +1244,30 @@ Before authoring any of the above, re-check whether an equivalent scenario alrea
 name — do not assume absence without searching the real file first (this document has previously assumed
 scenarios existed, or did not exist, incorrectly in both directions).
 
+### New scenarios addendum — flavor-token enumeration (Decision 2 Addendum, PR #1494 follow-up)
+
+Fourteen new scenarios cover the flavor-token alternation, added after implementation was otherwise complete:
+
+- **`codex_flavor_rocket_real_pr1494_capture_approved`** — the real, live PR #1494 root comment (comment id
+  `5333550055`) that falsified the single-literal assumption, verbatim, same real-capture convention as
+  `codex_e1_real_pr1489_capture_approved`. `APPROVED`.
+- **One scenario per remaining evidenced token** (`Nice work!`, `Chef's kiss.`, `You're on a roll.`, `:tada:`,
+  `Another round soon, please!`, `:+1:`, `Bravo.`, `Keep it up!`, `Delightful!`, `Keep them coming!`, `Can't
+  wait for the next one!`, `More of your lovely PRs please.`) — a synthetic body reproducing that token in the
+  otherwise-exact template, each with its own valid SHA. `APPROVED`. (`Swish!` itself remains covered by
+  `codex_e1_real_pr1489_capture_approved`, unchanged.)
+- **`codex_flavor_unevidenced_token_not_approved`** — a clean-shaped body using an invented, unevidenced token
+  (`Fantastic job!`). `NEEDS_REVISION`. Proves the alternation is closed, not a wildcard, and that the accepted
+  safe-direction failure mode (a genuine future flavor rotation safe-failing until captured and added) is
+  intentional and under test, not an oversight.
+- **Escaping regressions verified directly against the isolated classifier** (not asserted): a mutated `Bravo!`
+  body does not match the `Bravo.` alternative (proves the token's literal period is not acting as an
+  any-character wildcard), and a mutated `::::1:` body does not match the `:+1:` alternative (proves the
+  token's literal `+` is not acting as a one-or-more quantifier) — both confirm the ERE-escaping of
+  metacharacters inside each flavor token is correct, not merely that the happy path passes.
+
 ### Residual verification strategy
+
 
 This is a full design replacement, so the evidence the implementation must produce before
 `ready-for-human-review` is:
@@ -1203,6 +1301,10 @@ This is a full design replacement, so the evidence the implementation must produ
    scenario resolving at one site by default is not evidence the other three copies are correct.
 9. **Before marking any "exists"/"kept"/"unchanged" claim in this document verified, re-derive it by execution
    against the file at implementation time**, not against this document's prose.
+10. **(Decision 2 Addendum, PR #1494 follow-up) Every evidenced flavor token approves, an unevidenced one still
+    safe-fails, and neither escaped metacharacter inside a token (the periods in `Chef's kiss.`/`Bravo.`/etc.,
+    the `+` in `:+1:`) silently reverts to acting as a regex wildcard/quantifier** — confirmed by execution
+    against the real, isolated classifier, not asserted from the pattern's appearance alone.
 
 ---
 
@@ -1248,6 +1350,10 @@ shape recorded in the Cross-Cutting Operational Assumption Check, stop and repor
       `CODEX_CLEAN_SIGNAL_PATTERN` change once required. Note the deliberate, disclosed trade: a genuinely
       clean response using different wording anywhere in the body — including the vendor footer — safe-fails
       to `NEEDS_REVISION` today.
+- [ ] **(Decision 2 Addendum, PR #1494 follow-up)** Update the same section to state that the flavor slot
+      between the verdict sentence and the `Reviewed commit:` marker is a **bounded alternation of every
+      evidenced token** (list them), not a single literal — the vendor rotates this slot — and that adding a
+      newly observed token requires the same live-capture discipline as adding a template.
 - [ ] `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` — in the
       "Codex GitHub terminal evidence" block, state: the response must reproduce, whitespace aside, one of a
       small set of exact captured clean-response templates covering the entire body, footer included, with no
@@ -1267,7 +1373,7 @@ shape recorded in the Cross-Cutting Operational Assumption Check, stop and repor
 
 | Risk | Likelihood | Impact | Mitigation |
 | --- | --- | --- | --- |
-| A genuinely clean Codex response uses wording that does not reproduce any evidenced template, and safe-fails to `NEEDS_REVISION` | **High, by design** | Low–Medium | **This is the central, accepted trade of this design, stated explicitly rather than discovered later.** The failure direction is always safe (never a false `APPROVED`). Recovery is a one-line addition to `CODEX_APPROVED_TEMPLATES`, backed by a live capture of the new wording and held to the same review a `CODEX_CLEAN_SIGNAL_PATTERN` change once required (Decision 2). This risk directly subsumes and replaces every "vendor wording change" risk row every prior revision of this plan carried separately for the clean-signal vocabulary, the flavor-token list, and the footer literal — under this design there is exactly one surface (the template array) where this class of risk lives, not three |
+| A genuinely clean Codex response uses wording that does not reproduce any evidenced template, and safe-fails to `NEEDS_REVISION` | **Confirmed, not hypothetical — materialized on PR #1494, this plan's own first real-traffic exercise** | Low–Medium | **This is the central, accepted trade of this design, stated explicitly rather than discovered later — and now observed directly, not merely anticipated.** The failure direction is always safe (never a false `APPROVED`): PR #1494's Codex review used `:rocket:` instead of the sole evidenced `Swish!` literal and safe-failed, exactly as this row predicted. Recovery is a one-line addition to `CODEX_APPROVED_TEMPLATES` (or, for the flavor slot specifically, to its bounded alternation — see Decision 2 Addendum), backed by a live capture of the new wording and held to the same review a `CODEX_CLEAN_SIGNAL_PATTERN` change once required (Decision 2). A repository-wide sweep triggered by this finding evidenced 14 distinct flavor tokens from roughly 40 historical clean responses — a discovery rate implying the true pool is larger still — so this recovery cycle should be expected to recur, not treated as a one-time correction. This risk directly subsumes and replaces every "vendor wording change" risk row every prior revision of this plan carried separately for the clean-signal vocabulary, the flavor-token list, and the footer literal — under this design there is exactly one surface (the template array, including its one bounded-alternation slot) where this class of risk lives, not three |
 | **The template now binds to vendor-controlled help text (the `<details>` footer), not just the verdict sentence — a purely cosmetic rewording of OpenAI's footer now also produces a false `NEEDS_REVISION`, which it did not under the prior (truncate-then-match) revision.** | **High, by design — an explicit, accepted trade** | Low–Medium | **Recorded explicitly (Decision 5).** The failure direction remains safe (more `NEEDS_REVISION`, never a false `APPROVED`) — this trade is accepted specifically because it closes Codex GitHub finding `3803545669`, which was the opposite (unsafe) failure direction. Recovery is the same as the row above: re-capture the footer live and update the one template entry. This risk did not exist under the prior revision (the footer was discarded before comparison, so its wording was irrelevant to the match) and is a direct, disclosed consequence of removing truncation |
 | Only one template is evidenced today, so the approval surface is intentionally very narrow at ship time | High (by design) | Medium | Accepted, not a defect: the two live sources this plan had access to yield exactly one clean-response shape. Widening it requires a genuinely new live capture, per Decision 2's extension rule — inventing a plausible-looking second template with no current live evidence was explicitly out of scope and must not be done without one |
 | The commit-SHA placeholder's bound (`{7,40}`) is wider than the length every current real capture shows, and could in principle match a SHA-shaped string that is not really a commit reference | Low | Low | The bound is git's own documented abbreviated-to-full SHA-1 range, not an arbitrary guess (Decision 2) — narrowing it to today's observed length would be *safer* in the false-`APPROVED` direction but would fail on the very next legitimate response once this repository's object count crosses git's next auto-lengthening threshold, for a reason unrelated to anything Codex changed. This trade was made deliberately; revisit only with fresh evidence that git's behavior differs from its documented specification |

--- a/docs/specs/developments/20260817203204_1491-conservative-verdict-classifier/2_1491-conservative-verdict-classifier_implementation-plan.md
+++ b/docs/specs/developments/20260817203204_1491-conservative-verdict-classifier/2_1491-conservative-verdict-classifier_implementation-plan.md
@@ -292,7 +292,9 @@ truncate-then-match design it would not have. This is the accepted trade the hum
 stated, evidence-derived bound for any variable field — is the same fix this plan has always prescribed for
 its riskiest lever, just now applied to one array instead of several.
 
-### Decision 2 Addendum — PR #1494 live evidence falsified the single-literal flavor assumption; the flavor slot is now a bounded alternation of evidenced tokens
+### Decision 2 Addendum — PR #1494 live evidence falsified the single-literal flavor assumption (superseded by Decision 2 Second Addendum below; kept for the evidence and history)
+
+**Superseded before merge.** This addendum's own fix — a 14-token literal alternation — was itself replaced by a bounded placeholder (Decision 2 Second Addendum, immediately below) before this PR merged, once the shape of the evidence made clear that enumeration would not converge either. This addendum is kept in full because its evidence-gathering (the 14-token sweep, with full provenance) is exactly what falsified the enumeration approach — it is the record of why the fix below exists, not a stale artifact.
 
 **What happened.** This PR's own first real-world use, PR #1494, received a genuinely clean Codex GitHub
 response on its first ready-phase check. The response read `Codex Review: Didn't find any major issues.
@@ -359,6 +361,90 @@ invented or guessed by "plausible enthusiasm," and — because unlike the SHA fi
 specification to bound it — there is no narrower bound available than "the literal set evidenced so far."
 Removing a token (if a capture is ever found to be a transcription error) is always safe; adding one requires
 the same review this document's history has required for every prior widening.
+
+### Decision 2 Second Addendum — the 14-token alternation was itself replaced by a single bounded placeholder before merge
+
+**Why the first addendum's fix did not survive review.** The enumeration approach (Decision 2 Addendum) was
+implemented, verified, committed, and pushed. Before this PR reached human review, the same evidence that
+motivated it was re-examined and found to falsify it: **14 distinct flavor tokens surfaced from fewer than 50
+historical samples** — single words (`Bravo.`), full sentences (`More of your lovely PRs please.`), GitHub
+emoji shortcodes (`:rocket:`, `:tada:`, `:+1:`), with inconsistent trailing punctuation across all of them. A
+discovery rate that high, from that few samples, is the signature of **LLM-generated variety**, not a fixed,
+enumerable vocabulary. Enumerating it would not converge — this is issue #1491's original complaint (an
+open-ended enumeration that a review cycle keeps finding one more case for) **reappearing on a new axis**: the
+first three designs this plan shipped failed because a disqualifier/vocabulary list could not keep pace with
+negation phrasing; this flavor-token list could not keep pace with the vendor's own enthusiasm phrasing, for
+the identical structural reason. The sweep did exactly what it should: it produced evidence, and the evidence
+falsified the fix before it shipped, rather than after — the intended function of a Protocol 03 verification
+pass, working as designed.
+
+**The fix: one bounded placeholder, not an enumeration.** `CODEX_APPROVED_TEMPLATES`' flavor slot is now:
+
+```text
+[^*`[:cntrl:]]{1,40}
+```
+
+placed in exactly the position the 14-token alternation and, before that, the `Swish!` literal occupied —
+between `Didn't find any major issues. ` and ` **Reviewed commit:**`. Every other character in the template,
+including the SHA field's own `[0-9a-f]{7,40}` bound and the complete footer, is unchanged and remains
+byte-exact.
+
+**Bound derivation, stated explicitly (not asserted):**
+
+- **Length cap `{1,40}`**: the longest evidenced token is `More of your lovely PRs please.` at **31
+  characters**. 40 is 31 rounded up to the nearest 10 with modest headroom — wide enough to admit a somewhat
+  longer genuine flavor phrase than any evidenced so far, without being large enough to admit multi-sentence
+  injected content (an actionable instruction is realistically longer than 40 characters once it says anything
+  concrete).
+- **Excluded characters ``[^*`[:cntrl:]]``**: the class excludes exactly three things, each protecting a specific
+  piece of adjacent template structure, not a general "looks suspicious" filter:
+  - `*` — protects the literal `**Reviewed commit:**` bold-marker syntax immediately following this slot from
+    being partially reproduced or spoofed from inside the placeholder.
+  - `` ` `` (backtick) — protects the backtick-delimited SHA field that follows.
+  - Every control character, via the POSIX `[:cntrl:]` class (covers newline, carriage return, tab, and every
+    other C0/C1 control byte in one portable construct, rather than trying to enumerate `\n`/`\r`/`\t`
+    individually) — defense in depth. `codex_normalize_whitespace` (Decision 1, unchanged) already guarantees no
+    raw control character survives to reach this regex — every whitespace run, including any embedded newline,
+    is collapsed to a single space before matching — so this exclusion is currently unreachable in the composed
+    pipeline. It is kept explicit anyway, rather than relying solely on that upstream guarantee, because a
+    future change to normalization should not silently widen this slot's admitted character set as a side
+    effect.
+  - No other character is excluded. Apostrophes, colons, commas, periods, exclamation marks, and plain spaces
+    are all left admissible, because at least one evidenced token requires each of them (`Chef's kiss.`,
+    `:rocket:`, `Another round soon, please!`, `Bravo.`, `Nice work!`, and every multi-word phrase,
+    respectively).
+
+**This is a genuine placeholder, unlike the alternation it replaces — the residual risk is stated plainly, not
+claimed away.** A false `APPROVED` is now possible if Codex ever emits a response reading `Codex Review: Didn't
+find any major issues.` followed by an actual directive inside this 40-character slot, followed by the complete,
+exact vendor footer. This requires **self-contradictory vendor output** — the same response asserting "no major
+issues" and then, in the same breath, giving an instruction, while still reproducing every other part of the
+template verbatim. This is judged an acceptable, disclosed trade for the same reason every other bounded field
+in this design is: the alternative (continued enumeration) does not converge, and the alternative to that
+(reverting to a vocabulary/grammar scan of the slot's contents) reopens exactly the class of gap this entire
+plan exists to close. See Risks & Mitigations for the same row, updated to state this residual risk rather than
+the enumeration's now-obsolete "recovery is adding a token" framing.
+
+**Why this differs from a generic wildcard, despite superficially looking like one.** A generic wildcard would
+admit the WHOLE body, or an unbounded run, or would sit adjacent to no anchor at all. This placeholder is
+bounded on three independent axes simultaneously: **position** (a single fixed slot between two exact literal
+anchors, `^Codex Review: Didn't find any major issues. ` before it and ` **Reviewed commit:**` after it —
+Decision 1's `^...$` whole-body anchoring is unchanged, so nothing can appear before or after the template as a
+whole either), **length** (`{1,40}`, both bounds enforced), and **content** (excludes exactly the three
+character classes that could let it interact with adjacent structure). No prior design in this plan's history
+had all three properties on the same slot; the SHA field has position and content bounds (git's own hex-length
+specification) but its content bound is far narrower (16 possible characters, not "everything except three
+exclusions").
+
+**Standing rule (supersedes the first addendum's "adding a token requires review" rule for this slot; the
+placeholder is not extended by adding entries).** The two levers that can widen the approval surface for this
+specific slot are now: (1) narrowing the length cap or the excluded-character set — always safe, since it can
+only shrink what is admitted; (2) widening either — the length cap or the excluded-character set — which
+requires the same review discipline as adding a whole new template: a live capture demonstrating the current
+bound is too narrow for genuine vendor output, never a guess about what "might" be needed. Reintroducing a
+closed enumeration (a list of literal tokens) for this slot, after this correction, must be rejected on sight —
+that is precisely the design this second addendum replaced, and re-litigating it requires new evidence that the
+bounded-placeholder approach itself has failed, not merely that the enumeration would have been more precise.
 
 ### Decision 3 — Composition with the GitHub review `state` short-circuit from PR #1490
 
@@ -724,12 +810,13 @@ See "Documentation Updates" for exactly what changes in each.
 
 <!-- Illustrative — adapt during implementation. -->
 
-**Post-implementation note (Decision 2 Addendum):** the flavor slot below is shown with the single `Swish!`
-literal this plan originally shipped. The shipped code no longer matches this illustration exactly — the flavor
-slot is a bounded alternation of every evidenced token (see Decision 2 Addendum for the full list and
-provenance), not a single literal. This snippet is left as originally illustrative, per its own header, rather
-than rewritten to track every subsequent correction; the shipped `codex-github-reviewer.sh` and Decision 2
-Addendum are authoritative for the current contract.
+**Post-implementation note (Decision 2 Second Addendum):** the flavor slot below is shown with the single
+`Swish!` literal this plan originally shipped. The shipped code no longer matches this illustration exactly —
+the flavor slot is a single bounded placeholder, ``[^*`[:cntrl:]]{1,40}`` (see Decision 2 Second Addendum for the
+full derivation of its length cap and excluded-character set), not a single literal and not an enumeration.
+This snippet is left as originally illustrative, per its own header, rather than rewritten to track every
+subsequent correction; the shipped `codex-github-reviewer.sh` and Decision 2 Second Addendum are authoritative
+for the current contract.
 
 **This is the fourth design this plan has shipped**, replacing (not extending) the truncate-then-match design
 of the immediately prior revision after Codex GitHub finding `3803545669` showed that design still trusted
@@ -1244,27 +1331,52 @@ Before authoring any of the above, re-check whether an equivalent scenario alrea
 name — do not assume absence without searching the real file first (this document has previously assumed
 scenarios existed, or did not exist, incorrectly in both directions).
 
-### New scenarios addendum — flavor-token enumeration (Decision 2 Addendum, PR #1494 follow-up)
+### New scenarios addendum — flavor-token enumeration (Decision 2 Addendum, superseded — kept for history)
 
-Fourteen new scenarios cover the flavor-token alternation, added after implementation was otherwise complete:
+**This addendum's own 14 `codex_flavor_*` scenarios no longer exist in the shipped test file** — they were
+deleted along with the alternation they tested, and replaced by the `codex_placeholder_*` scenarios in the next
+addendum below, once the alternation itself was replaced by a bounded placeholder (Decision 2 Second Addendum).
+This section is left in place, unedited, as the historical record of what was tried and superseded; do not
+treat it as a description of the current test file's contents.
 
-- **`codex_flavor_rocket_real_pr1494_capture_approved`** — the real, live PR #1494 root comment (comment id
-  `5333550055`) that falsified the single-literal assumption, verbatim, same real-capture convention as
-  `codex_e1_real_pr1489_capture_approved`. `APPROVED`.
+### New scenarios addendum — bounded flavor placeholder (Decision 2 Second Addendum, PR #1494 follow-up)
+
+Eighteen scenarios (38 assertions) cover the bounded placeholder that replaced the 14-token alternation <!-- markdown-heuristic-disable COUNT001 --> (the count is a direct sum of this list's items — the "one scenario per remaining evidenced token" bullet below represents 12 of the 18, not 1, since listing all 12 individually would duplicate the earlier per-token table in the first addendum):
+
+- **`codex_placeholder_rocket_real_pr1494_capture_approved`** — the real, live PR #1494 root comment (comment
+  id `5333550055`) that originally falsified the single-literal assumption, verbatim, same real-capture
+  convention as `codex_e1_real_pr1489_capture_approved`. `APPROVED`.
 - **One scenario per remaining evidenced token** (`Nice work!`, `Chef's kiss.`, `You're on a roll.`, `:tada:`,
   `Another round soon, please!`, `:+1:`, `Bravo.`, `Keep it up!`, `Delightful!`, `Keep them coming!`, `Can't
   wait for the next one!`, `More of your lovely PRs please.`) — a synthetic body reproducing that token in the
   otherwise-exact template, each with its own valid SHA. `APPROVED`. (`Swish!` itself remains covered by
   `codex_e1_real_pr1489_capture_approved`, unchanged.)
-- **`codex_flavor_unevidenced_token_not_approved`** — a clean-shaped body using an invented, unevidenced token
-  (`Fantastic job!`). `NEEDS_REVISION`. Proves the alternation is closed, not a wildcard, and that the accepted
-  safe-direction failure mode (a genuine future flavor rotation safe-failing until captured and added) is
-  intentional and under test, not an oversight.
-- **Escaping regressions verified directly against the isolated classifier** (not asserted): a mutated `Bravo!`
-  body does not match the `Bravo.` alternative (proves the token's literal period is not acting as an
-  any-character wildcard), and a mutated `::::1:` body does not match the `:+1:` alternative (proves the
-  token's literal `+` is not acting as a one-or-more quantifier) — both confirm the ERE-escaping of
-  metacharacters inside each flavor token is correct, not merely that the happy path passes.
+- **`codex_placeholder_unevidenced_flavor_now_approved`** — the same previously-unevidenced token
+  (`Fantastic job!`) the first addendum's negative test used, now asserting `APPROVED` instead of
+  `NEEDS_REVISION`. This is the direct proof of the design's behavior change, not incidental coverage.
+- **`codex_placeholder_exactly_cap_length_approved`** — a 40-character flavor slot (the cap, inclusive).
+  `APPROVED`. Confirms the upper bound is inclusive, matching the SHA field's own inclusive-bound precedent
+  (`codex_e7_full_length_sha_approved`).
+- **`codex_placeholder_exceeds_length_cap_not_approved`** — a 41-character flavor slot. `NEEDS_REVISION`.
+  Confirms the length cap is enforced, not merely documented.
+- **`codex_placeholder_asterisk_not_approved`** — a flavor slot containing `*`. `NEEDS_REVISION`. Confirms the
+  excluded-character set protects the `**Reviewed commit:**` bold-marker syntax immediately following the slot.
+- **`codex_placeholder_backtick_not_approved`** — a flavor slot containing a backtick. `NEEDS_REVISION`.
+  Confirms the excluded-character set protects the backtick-delimited SHA field that follows.
+- **`codex_placeholder_newline_separated_overflow_not_approved`** — a paragraph break (blank line) inside the
+  flavor position followed by an extra sentence. `NEEDS_REVISION`. Confirms the length cap still catches
+  content smuggled in via a newline-separated injection vector, once whitespace normalization (Decision 1,
+  unchanged) collapses the break to a single space and the flattened text exceeds 40 characters — a distinct
+  injection vector from the same-line overflow case above, not a redundant restatement of it.
+- **A raw-literal-newline check against the regex directly, verified out of band, not shipped as a `run_test`
+  entry**: confirmed the `[:cntrl:]` exclusion rejects a genuine (non-escaped) newline byte in the flavor
+  position when matched against the pattern without whitespace normalization applied first. This is currently
+  unreachable through the composed production pipeline (normalization always runs first inside
+  `codex_response_is_approved`), so it is not added as a shipped end-to-end scenario — doing so would test an
+  isolated regex property, not a reachable composed-chain behavior, and Decision 6's standing rule discourages
+  isolated-function assertions as a substitute for composed-chain verification. It is recorded here as
+  supplementary evidence that the character-class exclusion is correctly encoded, not merely assumed correct
+  because normalization happens to make it unreachable.
 
 ### Residual verification strategy
 
@@ -1301,10 +1413,13 @@ This is a full design replacement, so the evidence the implementation must produ
    scenario resolving at one site by default is not evidence the other three copies are correct.
 9. **Before marking any "exists"/"kept"/"unchanged" claim in this document verified, re-derive it by execution
    against the file at implementation time**, not against this document's prose.
-10. **(Decision 2 Addendum, PR #1494 follow-up) Every evidenced flavor token approves, an unevidenced one still
-    safe-fails, and neither escaped metacharacter inside a token (the periods in `Chef's kiss.`/`Bravo.`/etc.,
-    the `+` in `:+1:`) silently reverts to acting as a regex wildcard/quantifier** — confirmed by execution
-    against the real, isolated classifier, not asserted from the pattern's appearance alone.
+10. **(Decision 2 Second Addendum, PR #1494 follow-up) Every evidenced flavor token still approves under the
+    bounded placeholder, a previously-unevidenced token now approves too (the intended behavior change), and
+    the placeholder's three guards are each independently proven**: a slot containing `*` safe-fails, a slot
+    containing a backtick safe-fails, a slot exceeding the 40-character cap safe-fails (with the boundary case
+    of exactly 40 characters still approving), and a slot exceeding the cap via a newline-separated injection
+    vector still safe-fails once normalization flattens it — confirmed by execution against the real, composed
+    chain, not asserted from the pattern's appearance alone.
 
 ---
 
@@ -1350,10 +1465,14 @@ shape recorded in the Cross-Cutting Operational Assumption Check, stop and repor
       `CODEX_CLEAN_SIGNAL_PATTERN` change once required. Note the deliberate, disclosed trade: a genuinely
       clean response using different wording anywhere in the body — including the vendor footer — safe-fails
       to `NEEDS_REVISION` today.
-- [ ] **(Decision 2 Addendum, PR #1494 follow-up)** Update the same section to state that the flavor slot
-      between the verdict sentence and the `Reviewed commit:` marker is a **bounded alternation of every
-      evidenced token** (list them), not a single literal — the vendor rotates this slot — and that adding a
-      newly observed token requires the same live-capture discipline as adding a template.
+- [ ] **(Decision 2 Second Addendum, PR #1494 follow-up — supersedes the item above)** Update the same
+      section to state that the flavor slot between the verdict sentence and the `Reviewed commit:` marker is
+      a **single bounded placeholder** (``[^*`[:cntrl:]]{1,40}``), not an enumeration and not a single literal —
+      state the length cap's derivation (31-character longest evidenced token, rounded to 40 with headroom)
+      and the excluded-character set's rationale (`*` and backtick protect adjacent template structure;
+      control characters are defense in depth given normalization). State the residual risk plainly: a false
+      `APPROVED` requires self-contradictory vendor output (a clean verdict immediately followed by a directive
+      inside the 40-character slot).
 - [ ] `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` — in the
       "Codex GitHub terminal evidence" block, state: the response must reproduce, whitespace aside, one of a
       small set of exact captured clean-response templates covering the entire body, footer included, with no
@@ -1373,7 +1492,8 @@ shape recorded in the Cross-Cutting Operational Assumption Check, stop and repor
 
 | Risk | Likelihood | Impact | Mitigation |
 | --- | --- | --- | --- |
-| A genuinely clean Codex response uses wording that does not reproduce any evidenced template, and safe-fails to `NEEDS_REVISION` | **Confirmed, not hypothetical — materialized on PR #1494, this plan's own first real-traffic exercise** | Low–Medium | **This is the central, accepted trade of this design, stated explicitly rather than discovered later — and now observed directly, not merely anticipated.** The failure direction is always safe (never a false `APPROVED`): PR #1494's Codex review used `:rocket:` instead of the sole evidenced `Swish!` literal and safe-failed, exactly as this row predicted. Recovery is a one-line addition to `CODEX_APPROVED_TEMPLATES` (or, for the flavor slot specifically, to its bounded alternation — see Decision 2 Addendum), backed by a live capture of the new wording and held to the same review a `CODEX_CLEAN_SIGNAL_PATTERN` change once required (Decision 2). A repository-wide sweep triggered by this finding evidenced 14 distinct flavor tokens from roughly 40 historical clean responses — a discovery rate implying the true pool is larger still — so this recovery cycle should be expected to recur, not treated as a one-time correction. This risk directly subsumes and replaces every "vendor wording change" risk row every prior revision of this plan carried separately for the clean-signal vocabulary, the flavor-token list, and the footer literal — under this design there is exactly one surface (the template array, including its one bounded-alternation slot) where this class of risk lives, not three |
+| A genuinely clean Codex response uses wording that does not reproduce any evidenced template, and safe-fails to `NEEDS_REVISION` | **Confirmed, not hypothetical — materialized on PR #1494, this plan's own first real-traffic exercise** | Low–Medium | **This is the central, accepted trade of this design, stated explicitly rather than discovered later — and now observed directly, not merely anticipated.** The failure direction is always safe (never a false `APPROVED`): PR #1494's Codex review used `:rocket:` instead of the sole evidenced `Swish!` literal and safe-failed, exactly as this row predicted. Recovery for the SHA field or the footer is a one-line addition to `CODEX_APPROVED_TEMPLATES`, backed by a live capture. **For the flavor slot specifically, recovery is no longer adding a token** — a 14-token enumeration was tried and replaced before merge (Decision 2 Addendum, superseded by Decision 2 Second Addendum) because 14 distinct tokens from under 50 samples proved the vocabulary would not converge by enumeration, the same non-convergence failure mode issue #1491 was originally filed against. The flavor slot is now a bounded placeholder (``[^*`[:cntrl:]]{1,40}``), so a genuinely clean response safe-fails on this axis now only if its flavor phrasing exceeds 40 characters or contains `*`/backtick/a control character — narrower and rarer than the enumeration's gap, and recovery for THAT (if a genuine flavor phrase is ever found to exceed the bound) is widening the placeholder's length cap or excluded-character set with live evidence, held to the same review discipline (Decision 2 Second Addendum). This risk directly subsumes and replaces every "vendor wording change" risk row every prior revision of this plan carried separately for the clean-signal vocabulary, the flavor-token list, and the footer literal — under this design there is exactly one surface (the template array, including its one bounded-placeholder slot) where this class of risk lives, not three |
+| **The flavor placeholder (``[^*`[:cntrl:]]{1,40}``) is a genuine bounded placeholder, not a literal — unlike every other part of this template, a false `APPROVED` through this one slot is possible in principle** | Low | Medium | **Stated plainly, not claimed away (Decision 2 Second Addendum).** A false `APPROVED` requires Codex to emit a response reading "Didn't find any major issues." and then place an actual directive inside this 40-character slot, while still reproducing the complete, exact vendor footer verbatim afterward — self-contradictory vendor output (a clean verdict immediately followed by an instruction, inside one otherwise-genuine response). No evidence of this construction has ever been observed from the vendor; the SHA-pinning requirement (terminal evidence only) and the requirement to reproduce the complete real footer verbatim both remain fully load-bearing and unchanged, so this is not an open surface — it is one narrow, bounded, and disclosed slot. Mitigation if evidence of this construction is ever found: narrow the excluded-character set or the length cap further (always safe), never widen either without new live evidence |
 | **The template now binds to vendor-controlled help text (the `<details>` footer), not just the verdict sentence — a purely cosmetic rewording of OpenAI's footer now also produces a false `NEEDS_REVISION`, which it did not under the prior (truncate-then-match) revision.** | **High, by design — an explicit, accepted trade** | Low–Medium | **Recorded explicitly (Decision 5).** The failure direction remains safe (more `NEEDS_REVISION`, never a false `APPROVED`) — this trade is accepted specifically because it closes Codex GitHub finding `3803545669`, which was the opposite (unsafe) failure direction. Recovery is the same as the row above: re-capture the footer live and update the one template entry. This risk did not exist under the prior revision (the footer was discarded before comparison, so its wording was irrelevant to the match) and is a direct, disclosed consequence of removing truncation |
 | Only one template is evidenced today, so the approval surface is intentionally very narrow at ship time | High (by design) | Medium | Accepted, not a defect: the two live sources this plan had access to yield exactly one clean-response shape. Widening it requires a genuinely new live capture, per Decision 2's extension rule — inventing a plausible-looking second template with no current live evidence was explicitly out of scope and must not be done without one |
 | The commit-SHA placeholder's bound (`{7,40}`) is wider than the length every current real capture shows, and could in principle match a SHA-shaped string that is not really a commit reference | Low | Low | The bound is git's own documented abbreviated-to-full SHA-1 range, not an arbitrary guess (Decision 2) — narrowing it to today's observed length would be *safer* in the false-`APPROVED` direction but would fail on the very next legitimate response once this repository's object count crosses git's next auto-lengthening threshold, for a reason unrelated to anything Codex changed. This trade was made deliberately; revisit only with fresh evidence that git's behavior differs from its documented specification |

--- a/docs/testing/workflow/1491-conservative-verdict-classifier.smoke-test.md
+++ b/docs/testing/workflow/1491-conservative-verdict-classifier.smoke-test.md
@@ -531,24 +531,24 @@ design any earlier revision of this plan shipped there).
 
 | Step | Pass / Fail | Notes |
 | --- | --- | --- |
-| 1 | | |
-| 2 | | |
-| 3 | | |
-| 4 | | |
-| 5 | | |
-| 6 | | |
-| 7 | | |
-| 8 | | |
-| 9 | | |
-| 10 | | |
-| 11 | | |
-| 12 | | |
-| 13 | | |
-| 14 | | |
-| 15 | | |
+| 1 | Pass | `bash scripts/development-workflow/tests/test-pr-review-loop.sh` exits 0, `Tests: 684 passed, 0 failed` |
+| 2 | Pass | Comment-filtered deletion-list search returns nothing; `CODEX_APPROVED_TEMPLATES`/`codex_normalize_whitespace` each show one definition; `codex_response_is_approved` shows no footer-strip/fence/quote/not-only-idiom call; five call sites confirmed (`codex_response_priority` plus the four verdict sites) |
+| 3 | Pass | Comment-filtered `codex_strip_not_only_idiom` count = 2 (definition + one call, inside `codex_response_is_blocking`) |
+| 4 | Pass | Merge base `a0b8f8c7d9b63ea0f2ace945f78990579ceca828` resolved; `CODEX_BLOCKING_PATTERN`/`CODEX_MERGE_REFUSAL_PATTERN`/`CODEX_NEGATION_WORDS` diffs empty; full `codex_response_is_blocking` function-range diff empty (byte-identical) |
+| 5 | Pass | All four `codex_footer_near_miss_*_safe_fails` scenarios exit 1 with the unrecognized-format safe-fail, resolving at their named site per `INFO:` trace; independence verified by reverting only the async-final gate in a scratch copy — only that scenario regressed to `TIMED_OUT`, the other three still passed |
+| 6 | Pass | `No blocking issues found.` root comment exits 1, `VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)` |
+| 7 | Pass | Live-refetched PR #1489 root comment (2026-08-18, repo `26b5dada`) still matches the evidenced template verbatim; `codex_e1_real_pr1489_capture_approved` exits 0, `VERDICT: APPROVED` |
+| 8 | Pass | Live-refetched PR #1490 review body still the generic wrapper with no clean-signal text; `codex_e2_real_pr1490_review_not_approved` (review-sourced, state `COMMENTED`) exits 1, safe-fail |
+| 9 | Pass | `codex_e22_refusal_inside_footer_blocking` exits 1 with plain `VERDICT: NEEDS_REVISION` (blocking branch); isolated `codex_response_is_approved` call on the same body also returns non-zero on its own |
+| 10 | Pass | `codex_e23_footer_opening_line_only_not_approved` exits 1, safe-fail — finding `3803545669`'s construction is rejected |
+| 11 | Pass | `codex_e24a/b/c_footer_byte_mutation_*` (mid-sentence, before `</details>`, inside the URL) all exit 1, safe-fail |
+| 12 | Pass | `codex_e21_filler_composed_hedge_not_approved` (`Looks good, or is it?`) exits 1, safe-fail |
+| 13 | Pass | (a) Group APPROVED's two template-anchored members use distinct valid SHAs (`abcdefab12`, `abcabcabcabc1234567890`) and both exit 0/`APPROVED`; `codex_e7_full_length_sha_approved` (40-char) exits 0/`APPROVED`; (b) `codex_e5_short_sha_not_approved` (6-char, review-sourced), (c) `codex_e6_oversized_sha_not_approved` (41-char, review-sourced), and (d) `codex_e8_non_hex_sha_not_approved` (review-sourced) all exit 1, safe-fail |
+| 14 | Pass | `codex-github.md` gained a "Verdict Classification" section stating the whole-body exact-template contract; Protocol 93's "Codex GitHub terminal evidence" block states the template-reproduction requirement; `CHANGELOG.md` `[Unreleased]` → `### Changed` carries the `**Conservative Codex verdict classifier** (#1491):` entry |
+| 15 | Pass | `markdownlint-cli2` (changed docs + this runbook + `CHANGELOG.md`): 0 errors; `markdown-heuristic-lint.py`: exit 0; `workflow-shell-snippet-lint.py --base-ref origin/develop`: exit 0; `shellcheck --severity=warning` on both changed `.sh` files: only pre-existing, untouched warnings at unrelated lines (1699-1700 of the test file, unchanged by this PR) |
 
-**Platform tested**: (macOS/BSD or Linux/GNU)
+**Platform tested**: macOS/BSD (Darwin 25.5.0)
 
-**Tester**:
+**Tester**: developer agent (issue #1491 implementation)
 
-**Date**:
+**Date**: 2026-08-18

--- a/docs/testing/workflow/1491-conservative-verdict-classifier.smoke-test.md
+++ b/docs/testing/workflow/1491-conservative-verdict-classifier.smoke-test.md
@@ -575,6 +575,32 @@ rather than a general wildcard.
 
 ---
 
+### Step 17: Planted-violation proof for every materially modified check (REVIEW.md Verification Discipline; PR #1494 review finding `3808305143`)
+
+**Maps to**: `REVIEW.md` → Verification Discipline / Code Review Checklist → Pass 2 → "PRs that add or modify an
+automated check, guard, lint rule, or CI job". A Codex GitHub review found the PR's original evidence for the
+Decision 6 gate reverts described the experiments in prose without naming file:line or pasting both runs —
+this step is the runbook-side record of the corrected proof. The full transcripts (exact commands, exact
+output, both directions, for every check) are posted as a comment on PR #1494 and indexed in the plan's
+"Planted-violation proof" section; this step's job is to confirm they exist and are reproducible, not to
+duplicate their full output here.
+
+1. For each of the four Decision 6 gate sites (`codex-github-reviewer.sh:1605`, `:1823`, `:1929`, `:2081`),
+   confirm the plan's "Planted-violation proof" section names the exact mutation, the scenario that catches it,
+   and (for main-loop and async-arrival) the pre-existing test-isolation gap found and fixed during this
+   verification.
+2. For the whole-body classifier (`codex-github-reviewer.sh:737`, trailing `$` anchor) and the bounded flavor
+   placeholder (`codex-github-reviewer.sh:737`, `*` exclusion), confirm the same section names the mutation and
+   catching scenario, and that both produced a false `VERDICT: APPROVED` with the violation present.
+3. Spot-check at least one transcript by reproducing it: apply the cited mutation to a scratch copy, run the
+   named scenario in isolation, confirm the failing output matches, restore, confirm the passing output matches.
+
+**Expected result**: every materially modified check has a named file:line, a named catching scenario, and a
+reproducible failing/passing pair; the SHA field and footer literal exemption (`REVIEW.md:324`) is stated
+explicitly with its rationale, not omitted silently.
+
+---
+
 ## Results
 
 | Step | Pass / Fail | Notes |
@@ -595,12 +621,15 @@ rather than a general wildcard.
 | 14 | Pass | `codex-github.md` gained a "Verdict Classification" section stating the whole-body exact-template contract; Protocol 93's "Codex GitHub terminal evidence" block states the template-reproduction requirement; `CHANGELOG.md` `[Unreleased]` → `### Changed` carries the `**Conservative Codex verdict classifier** (#1491):` entry |
 | 15 | Pass | `markdownlint-cli2` (changed docs + this runbook + `CHANGELOG.md`): 0 errors; `markdown-heuristic-lint.py`: exit 0; `workflow-shell-snippet-lint.py --base-ref origin/develop`: exit 0; `shellcheck --severity=warning` on both changed `.sh` files: only pre-existing, untouched warnings at unrelated lines (1699-1700 of the test file, unchanged by this PR) |
 | 16 | Pass | Live-refetched PR #1494 comment `5333550055` still reads `:rocket:`; all 14 evidenced flavor tokens (including the real `:rocket:` and `Swish!` captures) exit 0/`APPROVED` under the bounded placeholder; a previously-unevidenced token (`Fantastic job!`) now exits 0/`APPROVED` (the intended behavior change); `*`-in-slot and backtick-in-slot both exit 1/safe-fail; 40-char slot exits 0/`APPROVED` (boundary inclusive), 41-char slot exits 1/safe-fail; newline-separated overflow exits 1/safe-fail |
+| 17 | Pass | Six planted-violation transcripts produced (4 Decision 6 gates + whole-body classifier + bounded placeholder), each with cited file:line, exact command, failing output, and restored-passing output; posted as a PR #1494 comment and indexed in the plan's "Planted-violation proof" section; main-loop and async-arrival transcripts found and fixed a pre-existing test-isolation gap (sticky mock bodies letting a downstream site's correct gate rescue an upstream broken one) |
 
 **Platform tested**: macOS/BSD (Darwin 25.5.0)
 
 **Tester**: developer agent (issue #1491 implementation; Step 16 added and then revised by the reviewer agent
 after PR #1494's own Codex review falsified the single-flavor-literal assumption during Step 7a review, and
-after a follow-up evidence sweep for that fix falsified the enumeration approach itself)
+after a follow-up evidence sweep for that fix falsified the enumeration approach itself; Step 17 added by the
+reviewer agent after a Codex GitHub review (finding `3808305143`) found the planted-violation evidence for the
+Decision 6 gates was insufficiently specific)
 
 **Date**: 2026-08-18 (original); flavor-token enumeration correction 2026-08-18; bounded-placeholder correction
-2026-08-18
+2026-08-18; planted-violation transcript correction 2026-08-18

--- a/docs/testing/workflow/1491-conservative-verdict-classifier.smoke-test.md
+++ b/docs/testing/workflow/1491-conservative-verdict-classifier.smoke-test.md
@@ -340,9 +340,12 @@ runbook
    `**Reviewed commit:**` marker with a lowercase-hex SHA, followed by the **complete** `<details> <summary>ℹ️
    About Codex in GitHub</summary>…</details>` footer — not just its opening line. Compare the **entire** footer
    text (bulleted list, settings link, acknowledgement sentence, through the closing `</details>`) against the
-   literal baked into `CODEX_APPROVED_TEMPLATES`, not only the opening line. **If any of these components has
-   changed even slightly, anywhere in the body including the footer** (different flavor word, different marker
-   format, different footer wording anywhere in its text), stop and report it — do not proceed to step 3
+   literal baked into `CODEX_APPROVED_TEMPLATES`, not only the opening line. **The flavor word/phrase itself
+   (`Swish!` here) is no longer a fixed literal to compare against (Decision 2 Second Addendum) — it is a
+   bounded placeholder (up to 40 characters, excluding `*`, backtick, and control characters), so any flavor
+   text within that bound is expected and not itself a sign of drift.** If the `**Reviewed commit:**` marker
+   format, the footer's exact wording, or the flavor text's length/character set (exceeds 40 characters, or
+   contains `*`/backtick/a control character) has changed, stop and report it — do not proceed to step 3
    assuming the existing `CODEX_APPROVED_TEMPLATES` entry still applies. This is a stricter check than any
    truncate-then-match revision of this runbook required, because the footer is now part of the literal being
    matched, not discarded before comparison.
@@ -527,11 +530,13 @@ design any earlier revision of this plan shipped there).
 
 ---
 
-### Step 16: The flavor-token alternation approves every evidenced token and rejects an unevidenced one (Decision 2 Addendum, PR #1494 follow-up)
+### Step 16: The bounded flavor placeholder approves every evidenced token, a previously-unevidenced one, and enforces its three guards (Decision 2 Second Addendum, PR #1494 follow-up)
 
-**Maps to**: Decision 2 Addendum — this step exists because PR #1494's own Codex review (comment id
-`5333550055`) safe-failed on its first real-traffic exercise: the response read `:rocket:`, not the sole
-originally-evidenced `Swish!` literal.
+**Maps to**: Decision 2 Second Addendum — this step exists because PR #1494's own Codex review (comment id
+`5333550055`) safe-failed on its first real-traffic exercise (the response read `:rocket:`, not the sole
+originally-evidenced `Swish!` literal), and the enumeration this repository first shipped to fix that (a
+14-token literal alternation) was itself replaced by a bounded placeholder before merge, once a sweep for that
+fix found enough token diversity to prove enumeration would not converge either.
 
 1. Re-fetch the live PR #1494 comment and confirm it still reads `Codex Review: Didn't find any major issues.
    :rocket:` followed by the `**Reviewed commit:**` marker and the complete real footer:
@@ -545,18 +550,28 @@ originally-evidenced `Swish!` literal.
    roll.`, `:tada:`, `Another round soon, please!`, `:+1:`, `Bravo.`, `Keep it up!`, `Delightful!`, `Keep them
    coming!`, `Can't wait for the next one!`, `More of your lovely PRs please.`), build a body reproducing the
    template with that token in place of the flavor slot and run the reviewer against it.
-4. Build a body using an invented, unevidenced token (e.g. `Fantastic job!`) in the flavor slot and run the
-   reviewer against it.
-5. Confirm the escaped metacharacters inside tokens are literal, not wildcards: mutate a dotted token (e.g.
-   `Bravo.` → `Bravo!`) and confirm it does **not** approve; mutate the `+` in `:+1:` (e.g. to `::::1:`) and
-   confirm it does **not** approve.
+4. Build a body using an invented, previously-unevidenced token (e.g. `Fantastic job!`, the same phrase the
+   prior alternation design's negative test used) in the flavor slot and run the reviewer against it. This is
+   the direct proof of the behavior change: under the alternation this exited `NEEDS_REVISION`; under the
+   bounded placeholder it exits `APPROVED`.
+5. Confirm the placeholder's structure guards: build a body with `*` inside the flavor slot (e.g.
+   `Great **job**`) and confirm it does **not** approve; build a body with a backtick inside the flavor slot
+   (e.g. `` Nice `work` ``) and confirm it does **not** approve.
+6. Confirm the length cap: build a body with exactly 40 characters in the flavor slot and confirm it **does**
+   approve (boundary inclusive); build a body with 41 characters and confirm it does **not** approve.
+7. Confirm the length cap is enforced even via a newline-separated injection vector: build a body where a
+   paragraph break (blank line) sits inside the flavor position, followed by an extra sentence long enough
+   that the flattened (post-normalization) flavor text exceeds 40 characters, and confirm it does **not**
+   approve.
 
 **Expected result**: steps 2 and 3 (all 14 evidenced tokens) exit 0 and print `VERDICT: APPROVED`. Step 4
-(unevidenced token) exits 1 and prints `VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)` —
-this is the accepted safe-direction failure mode, not a defect. Step 5's two mutations both exit 1 — if either
-approves, an escaping regression has reintroduced a wildcard/quantifier where a literal token character was
-required, and the finding must be treated as a `blocking` regression on the same footing as a template-level
-escaping bug.
+(previously-unevidenced token) now exits 0 and prints `VERDICT: APPROVED` — this is the intended behavior
+change, not a regression. Step 5's two structure-guard bodies, the step 6 41-character body, and the step 7
+newline-separated body all exit 1 and print `VERDICT: NEEDS_REVISION (unrecognized response format —
+safe-fail)`; the step 6 40-character body exits 0. If any structure/length guard case instead approves, the
+placeholder's character class or length bound has regressed, and the finding must be treated as `blocking` on
+the same footing as a template-level escaping bug — this is the mechanism that keeps the placeholder bounded
+rather than a general wildcard.
 
 ---
 
@@ -564,7 +579,7 @@ escaping bug.
 
 | Step | Pass / Fail | Notes |
 | --- | --- | --- |
-| 1 | Pass | `bash scripts/development-workflow/tests/test-pr-review-loop.sh` exits 0, `Tests: 712 passed, 0 failed` (684 prior to the Step 16 flavor-token addendum; +28 assertions from the 14 new flavor scenarios) |
+| 1 | Pass | `bash scripts/development-workflow/tests/test-pr-review-loop.sh` exits 0, `Tests: 722 passed, 0 failed` (684 baseline; +28 then -28 for the superseded 14-token alternation scenarios; +38 for the 18 bounded-placeholder scenarios) |
 | 2 | Pass | Comment-filtered deletion-list search returns nothing; `CODEX_APPROVED_TEMPLATES`/`codex_normalize_whitespace` each show one definition; `codex_response_is_approved` shows no footer-strip/fence/quote/not-only-idiom call; five call sites confirmed (`codex_response_priority` plus the four verdict sites) |
 | 3 | Pass | Comment-filtered `codex_strip_not_only_idiom` count = 2 (definition + one call, inside `codex_response_is_blocking`) |
 | 4 | Pass | Merge base `a0b8f8c7d9b63ea0f2ace945f78990579ceca828` resolved; `CODEX_BLOCKING_PATTERN`/`CODEX_MERGE_REFUSAL_PATTERN`/`CODEX_NEGATION_WORDS` diffs empty; full `codex_response_is_blocking` function-range diff empty (byte-identical) |
@@ -579,11 +594,13 @@ escaping bug.
 | 13 | Pass | (a) Group APPROVED's two template-anchored members use distinct valid SHAs (`abcdefab12`, `abcabcabcabc1234567890`) and both exit 0/`APPROVED`; `codex_e7_full_length_sha_approved` (40-char) exits 0/`APPROVED`; (b) `codex_e5_short_sha_not_approved` (6-char, review-sourced), (c) `codex_e6_oversized_sha_not_approved` (41-char, review-sourced), and (d) `codex_e8_non_hex_sha_not_approved` (review-sourced) all exit 1, safe-fail |
 | 14 | Pass | `codex-github.md` gained a "Verdict Classification" section stating the whole-body exact-template contract; Protocol 93's "Codex GitHub terminal evidence" block states the template-reproduction requirement; `CHANGELOG.md` `[Unreleased]` → `### Changed` carries the `**Conservative Codex verdict classifier** (#1491):` entry |
 | 15 | Pass | `markdownlint-cli2` (changed docs + this runbook + `CHANGELOG.md`): 0 errors; `markdown-heuristic-lint.py`: exit 0; `workflow-shell-snippet-lint.py --base-ref origin/develop`: exit 0; `shellcheck --severity=warning` on both changed `.sh` files: only pre-existing, untouched warnings at unrelated lines (1699-1700 of the test file, unchanged by this PR) |
-| 16 | Pass | Live-refetched PR #1494 comment `5333550055` still reads `:rocket:`; all 14 evidenced flavor tokens (including the real `:rocket:` and `Swish!` captures) exit 0/`APPROVED`; an unevidenced token (`Fantastic job!`) exits 1/safe-fail; both escaping-regression mutations (`Bravo!`, `::::1:`) exit 1/safe-fail, confirming the alternation's escaped metacharacters remain literal |
+| 16 | Pass | Live-refetched PR #1494 comment `5333550055` still reads `:rocket:`; all 14 evidenced flavor tokens (including the real `:rocket:` and `Swish!` captures) exit 0/`APPROVED` under the bounded placeholder; a previously-unevidenced token (`Fantastic job!`) now exits 0/`APPROVED` (the intended behavior change); `*`-in-slot and backtick-in-slot both exit 1/safe-fail; 40-char slot exits 0/`APPROVED` (boundary inclusive), 41-char slot exits 1/safe-fail; newline-separated overflow exits 1/safe-fail |
 
 **Platform tested**: macOS/BSD (Darwin 25.5.0)
 
-**Tester**: developer agent (issue #1491 implementation; Step 16 added by the reviewer agent after PR #1494's
-own Codex review falsified the single-flavor-literal assumption during Step 7a review)
+**Tester**: developer agent (issue #1491 implementation; Step 16 added and then revised by the reviewer agent
+after PR #1494's own Codex review falsified the single-flavor-literal assumption during Step 7a review, and
+after a follow-up evidence sweep for that fix falsified the enumeration approach itself)
 
-**Date**: 2026-08-18 (original); flavor-token correction 2026-08-18
+**Date**: 2026-08-18 (original); flavor-token enumeration correction 2026-08-18; bounded-placeholder correction
+2026-08-18

--- a/docs/testing/workflow/1491-conservative-verdict-classifier.smoke-test.md
+++ b/docs/testing/workflow/1491-conservative-verdict-classifier.smoke-test.md
@@ -527,11 +527,44 @@ design any earlier revision of this plan shipped there).
 
 ---
 
+### Step 16: The flavor-token alternation approves every evidenced token and rejects an unevidenced one (Decision 2 Addendum, PR #1494 follow-up)
+
+**Maps to**: Decision 2 Addendum — this step exists because PR #1494's own Codex review (comment id
+`5333550055`) safe-failed on its first real-traffic exercise: the response read `:rocket:`, not the sole
+originally-evidenced `Swish!` literal.
+
+1. Re-fetch the live PR #1494 comment and confirm it still reads `Codex Review: Didn't find any major issues.
+   :rocket:` followed by the `**Reviewed commit:**` marker and the complete real footer:
+
+   ```bash
+   gh api repos/lhpaul/ai-dev-framework-template/issues/comments/5333550055 --jq '.body'
+   ```
+
+2. Run the reviewer against that exact body as a SHA-pinned root comment (mock convention from Step 6).
+3. For each of the other 13 evidenced flavor tokens (`Swish!`, `Nice work!`, `Chef's kiss.`, `You're on a
+   roll.`, `:tada:`, `Another round soon, please!`, `:+1:`, `Bravo.`, `Keep it up!`, `Delightful!`, `Keep them
+   coming!`, `Can't wait for the next one!`, `More of your lovely PRs please.`), build a body reproducing the
+   template with that token in place of the flavor slot and run the reviewer against it.
+4. Build a body using an invented, unevidenced token (e.g. `Fantastic job!`) in the flavor slot and run the
+   reviewer against it.
+5. Confirm the escaped metacharacters inside tokens are literal, not wildcards: mutate a dotted token (e.g.
+   `Bravo.` → `Bravo!`) and confirm it does **not** approve; mutate the `+` in `:+1:` (e.g. to `::::1:`) and
+   confirm it does **not** approve.
+
+**Expected result**: steps 2 and 3 (all 14 evidenced tokens) exit 0 and print `VERDICT: APPROVED`. Step 4
+(unevidenced token) exits 1 and prints `VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)` —
+this is the accepted safe-direction failure mode, not a defect. Step 5's two mutations both exit 1 — if either
+approves, an escaping regression has reintroduced a wildcard/quantifier where a literal token character was
+required, and the finding must be treated as a `blocking` regression on the same footing as a template-level
+escaping bug.
+
+---
+
 ## Results
 
 | Step | Pass / Fail | Notes |
 | --- | --- | --- |
-| 1 | Pass | `bash scripts/development-workflow/tests/test-pr-review-loop.sh` exits 0, `Tests: 684 passed, 0 failed` |
+| 1 | Pass | `bash scripts/development-workflow/tests/test-pr-review-loop.sh` exits 0, `Tests: 712 passed, 0 failed` (684 prior to the Step 16 flavor-token addendum; +28 assertions from the 14 new flavor scenarios) |
 | 2 | Pass | Comment-filtered deletion-list search returns nothing; `CODEX_APPROVED_TEMPLATES`/`codex_normalize_whitespace` each show one definition; `codex_response_is_approved` shows no footer-strip/fence/quote/not-only-idiom call; five call sites confirmed (`codex_response_priority` plus the four verdict sites) |
 | 3 | Pass | Comment-filtered `codex_strip_not_only_idiom` count = 2 (definition + one call, inside `codex_response_is_blocking`) |
 | 4 | Pass | Merge base `a0b8f8c7d9b63ea0f2ace945f78990579ceca828` resolved; `CODEX_BLOCKING_PATTERN`/`CODEX_MERGE_REFUSAL_PATTERN`/`CODEX_NEGATION_WORDS` diffs empty; full `codex_response_is_blocking` function-range diff empty (byte-identical) |
@@ -546,9 +579,11 @@ design any earlier revision of this plan shipped there).
 | 13 | Pass | (a) Group APPROVED's two template-anchored members use distinct valid SHAs (`abcdefab12`, `abcabcabcabc1234567890`) and both exit 0/`APPROVED`; `codex_e7_full_length_sha_approved` (40-char) exits 0/`APPROVED`; (b) `codex_e5_short_sha_not_approved` (6-char, review-sourced), (c) `codex_e6_oversized_sha_not_approved` (41-char, review-sourced), and (d) `codex_e8_non_hex_sha_not_approved` (review-sourced) all exit 1, safe-fail |
 | 14 | Pass | `codex-github.md` gained a "Verdict Classification" section stating the whole-body exact-template contract; Protocol 93's "Codex GitHub terminal evidence" block states the template-reproduction requirement; `CHANGELOG.md` `[Unreleased]` → `### Changed` carries the `**Conservative Codex verdict classifier** (#1491):` entry |
 | 15 | Pass | `markdownlint-cli2` (changed docs + this runbook + `CHANGELOG.md`): 0 errors; `markdown-heuristic-lint.py`: exit 0; `workflow-shell-snippet-lint.py --base-ref origin/develop`: exit 0; `shellcheck --severity=warning` on both changed `.sh` files: only pre-existing, untouched warnings at unrelated lines (1699-1700 of the test file, unchanged by this PR) |
+| 16 | Pass | Live-refetched PR #1494 comment `5333550055` still reads `:rocket:`; all 14 evidenced flavor tokens (including the real `:rocket:` and `Swish!` captures) exit 0/`APPROVED`; an unevidenced token (`Fantastic job!`) exits 1/safe-fail; both escaping-regression mutations (`Bravo!`, `::::1:`) exit 1/safe-fail, confirming the alternation's escaped metacharacters remain literal |
 
 **Platform tested**: macOS/BSD (Darwin 25.5.0)
 
-**Tester**: developer agent (issue #1491 implementation)
+**Tester**: developer agent (issue #1491 implementation; Step 16 added by the reviewer agent after PR #1494's
+own Codex review falsified the single-flavor-literal assumption during Step 7a review)
 
-**Date**: 2026-08-18
+**Date**: 2026-08-18 (original); flavor-token correction 2026-08-18

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -31,7 +31,7 @@ whitespace-normalized — to be an **exact** match against one of a small set
 of literal templates captured verbatim from real Codex clean responses, each
 template including the complete vendor `<details>` "About Codex in GitHub"
 footer text. Today exactly one template is evidenced, covering the
-`Codex Review: Didn't find any major issues. Swish!` / `**Reviewed commit:**`
+`Codex Review: Didn't find any major issues. <flavor>` / `**Reviewed commit:**`
 shape plus the complete footer, with a bounded placeholder only for the
 commit SHA (`[0-9a-f]{7,40}`, git's own documented abbreviated-to-full
 SHA-1 hex-length range). There is no vocabulary list, no grammar, no
@@ -42,14 +42,29 @@ the only way to widen the approval surface, and it needs a live capture of
 the new wording plus the same review discipline the classifier's earlier,
 now-deleted vocabulary patterns once required.
 
+**The `<flavor>` slot is a bounded alternation of every evidenced token, not
+a single fixed word.** PR #1494's own Codex review returned `:rocket:`
+instead of the sole originally-evidenced `Swish!`, proving the vendor
+rotates this slot through a pool of phrases. A repository-history sweep
+found 14 distinct tokens evidenced by live GitHub captures: `Swish!`,
+`:rocket:`, `Nice work!`, `Chef's kiss.`, `You're on a roll.`, `:tada:`,
+`Another round soon, please!`, `:+1:`, `Bravo.`, `Keep it up!`,
+`Delightful!`, `Keep them coming!`, `Can't wait for the next one!`, and
+`More of your lovely PRs please.` — each is a literal alternative, never a
+character-class wildcard, so an as-yet-unobserved token still safe-fails
+(the discovery rate suggests the true pool is larger than what has been
+observed so far). Adding a newly observed token requires the identical
+live-capture discipline as adding a whole new template.
+
 The deliberate, disclosed trade of this design: a genuinely clean response
 using different wording anywhere in the body — including a cosmetic vendor
-footer rewording — safe-fails to `NEEDS_REVISION` today rather than being
-approved. This failure direction is always safe (more `NEEDS_REVISION`,
-never a false `APPROVED`); recovery is a live capture of the new wording
-added as a new template entry, never a relaxation of the matching
-technique. See issue #1491's implementation plan for the full design
-history and rationale.
+footer rewording, or a flavor token not yet in the evidenced alternation —
+safe-fails to `NEEDS_REVISION` today rather than being approved. This
+failure direction is always safe (more `NEEDS_REVISION`, never a false
+`APPROVED`); recovery is a live capture of the new wording added as a new
+template entry or alternation token, never a relaxation of the matching
+technique. See issue #1491's implementation plan (Decision 2 and its
+Decision 2 Addendum) for the full design history and rationale.
 
 ## Prerequisites
 

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -24,6 +24,33 @@ during the async grace-period poll — is treated as unavailable, not as
 absence of evidence, so it cannot be silently overridden by a clean
 submitted review.
 
+## Verdict Classification
+
+`APPROVED` requires the response — the **entire, untruncated** body,
+whitespace-normalized — to be an **exact** match against one of a small set
+of literal templates captured verbatim from real Codex clean responses, each
+template including the complete vendor `<details>` "About Codex in GitHub"
+footer text. Today exactly one template is evidenced, covering the
+`Codex Review: Didn't find any major issues. Swish!` / `**Reviewed commit:**`
+shape plus the complete footer, with a bounded placeholder only for the
+commit SHA (`[0-9a-f]{7,40}`, git's own documented abbreviated-to-full
+SHA-1 hex-length range). There is no vocabulary list, no grammar, no
+truncation step, and no case-insensitive or punctuation-tolerant matching —
+whitespace normalization (collapsing whitespace runs to a single space,
+trimming the ends) is the only permitted flexibility. Adding a template is
+the only way to widen the approval surface, and it needs a live capture of
+the new wording plus the same review discipline the classifier's earlier,
+now-deleted vocabulary patterns once required.
+
+The deliberate, disclosed trade of this design: a genuinely clean response
+using different wording anywhere in the body — including a cosmetic vendor
+footer rewording — safe-fails to `NEEDS_REVISION` today rather than being
+approved. This failure direction is always safe (more `NEEDS_REVISION`,
+never a false `APPROVED`); recovery is a live capture of the new wording
+added as a new template entry, never a relaxation of the matching
+technique. See issue #1491's implementation plan for the full design
+history and rationale.
+
 ## Prerequisites
 
 Before a repository keeps `codex-github` in `review.on_ready.github`, verify:

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -32,39 +32,53 @@ of literal templates captured verbatim from real Codex clean responses, each
 template including the complete vendor `<details>` "About Codex in GitHub"
 footer text. Today exactly one template is evidenced, covering the
 `Codex Review: Didn't find any major issues. <flavor>` / `**Reviewed commit:**`
-shape plus the complete footer, with a bounded placeholder only for the
-commit SHA (`[0-9a-f]{7,40}`, git's own documented abbreviated-to-full
-SHA-1 hex-length range). There is no vocabulary list, no grammar, no
+shape plus the complete footer. There is no vocabulary list, no grammar, no
 truncation step, and no case-insensitive or punctuation-tolerant matching —
 whitespace normalization (collapsing whitespace runs to a single space,
-trimming the ends) is the only permitted flexibility. Adding a template is
-the only way to widen the approval surface, and it needs a live capture of
-the new wording plus the same review discipline the classifier's earlier,
-now-deleted vocabulary patterns once required.
+trimming the ends) is the only permitted flexibility.
 
-**The `<flavor>` slot is a bounded alternation of every evidenced token, not
-a single fixed word.** PR #1494's own Codex review returned `:rocket:`
-instead of the sole originally-evidenced `Swish!`, proving the vendor
-rotates this slot through a pool of phrases. A repository-history sweep
-found 14 distinct tokens evidenced by live GitHub captures: `Swish!`,
-`:rocket:`, `Nice work!`, `Chef's kiss.`, `You're on a roll.`, `:tada:`,
-`Another round soon, please!`, `:+1:`, `Bravo.`, `Keep it up!`,
-`Delightful!`, `Keep them coming!`, `Can't wait for the next one!`, and
-`More of your lovely PRs please.` — each is a literal alternative, never a
-character-class wildcard, so an as-yet-unobserved token still safe-fails
-(the discovery rate suggests the true pool is larger than what has been
-observed so far). Adding a newly observed token requires the identical
-live-capture discipline as adding a whole new template.
+**The template has exactly two bounded placeholders, never a general
+wildcard**: the commit SHA (`[0-9a-f]{7,40}`, git's own documented
+abbreviated-to-full SHA-1 hex-length range), and the `<flavor>` slot
+immediately after "Didn't find any major issues. " — a single bounded
+placeholder, ``[^*`[:cntrl:]]{1,40}`` (up to 40 characters, excluding
+asterisk, backtick, and control characters), not a fixed word and not an
+enumerated list.
 
-The deliberate, disclosed trade of this design: a genuinely clean response
-using different wording anywhere in the body — including a cosmetic vendor
-footer rewording, or a flavor token not yet in the evidenced alternation —
-safe-fails to `NEEDS_REVISION` today rather than being approved. This
-failure direction is always safe (more `NEEDS_REVISION`, never a false
-`APPROVED`); recovery is a live capture of the new wording added as a new
-template entry or alternation token, never a relaxation of the matching
-technique. See issue #1491's implementation plan (Decision 2 and its
-Decision 2 Addendum) for the full design history and rationale.
+**Why a placeholder, not an enumeration.** PR #1494's own Codex review
+returned `:rocket:` instead of the originally-shipped `Swish!` literal,
+proving the vendor rotates this slot. The first fix enumerated every
+evidenced token as a literal alternation — but a repository-history sweep
+for that fix found 14 distinct tokens (single words, full sentences, GitHub
+emoji shortcodes, inconsistent trailing punctuation) from under 50 samples,
+a discovery rate indicating LLM-generated variety rather than a fixed,
+enumerable vocabulary. Enumeration would not have converged — the same
+non-convergence failure this classifier's entire design history exists to
+avoid, on a new axis. The bounded placeholder replaced the alternation
+before merge.
+
+**Bound derivation**: the 40-character cap is the longest evidenced token
+(31 characters, "More of your lovely PRs please.") rounded up with modest
+headroom. The excluded characters protect adjacent template structure only:
+asterisk protects the `**Reviewed commit:**` marker that follows, backtick
+protects the SHA field's delimiters, and control characters (including
+newline) are excluded as defense in depth even though whitespace
+normalization already prevents them from reaching this point.
+
+**The deliberate, disclosed trade of this design**: a genuinely clean
+response using different wording anywhere in the body — including a
+cosmetic vendor footer rewording, or a flavor phrase exceeding 40 characters
+or containing an excluded character — safe-fails to `NEEDS_REVISION` today
+rather than being approved. This failure direction is always safe (more
+`NEEDS_REVISION`, never a false `APPROVED`). **The flavor placeholder is the
+one exception to "never a false `APPROVED`" stated plainly, not hidden**: a
+false `APPROVED` through this slot requires Codex to emit self-contradictory
+output — a clean verdict immediately followed by an actual directive inside
+the 40-character slot, while still reproducing the complete, exact footer
+afterward. No evidence of this has ever been observed; recovery if it ever
+is, is narrowing the placeholder's bound, never widening it without new live
+evidence. See issue #1491's implementation plan (Decision 2 and its two
+addenda) for the full design history and rationale.
 
 ## Prerequisites
 

--- a/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+++ b/docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
@@ -149,6 +149,19 @@ acknowledgement, since a bare
 acknowledgement carries no information and is never treated as competing
 evidence.
 
+Once terminal evidence is selected, `APPROVED` requires the response to
+reproduce, whitespace aside, one of a small set of exact captured
+clean-response templates covering the entire body — footer included, with no
+truncation step of any kind. Anything else is treated as `NEEDS_REVISION`
+regardless of how close it reads to a genuine approval, including a response
+that carries the real vendor footer but does not exactly match an evidenced
+template (issue #1491's conservative-verdict-classifier implementation
+plan). A bare, non-terminal acknowledgement comment is still routed to
+wait-for-more-evidence as before; that wait is gated on the evidence being
+non-terminal, so a footer-bearing near-miss on genuinely terminal evidence
+always reaches the `NEEDS_REVISION` safe-fail rather than being misrouted to
+a wait/timeout.
+
 When both a SHA-pinned root comment and a submitted review qualify as terminal
 evidence, the strictly newer one wins. On an exact timestamp tie (GitHub
 timestamps are second-resolution), any response that is not a clean approval

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -676,8 +676,25 @@ codex_normalize_whitespace() {
 # edited; a wildcard there would silently widen the match to any
 # character, which is exactly the kind of unreviewed widening this
 # design forbids.
+#
+# The "flavor" slot immediately after "Didn't find any major issues. " is
+# a bounded, parenthesized alternation of every literal flavor token
+# evidenced by a live Codex response — NOT a single fixed word and NOT a
+# general wildcard/character-class. This was learned the hard way: the
+# single-literal ("Swish!") version of this template shipped on this
+# repository's own PR #1494, whose first Codex review used ":rocket:"
+# instead and safe-failed on real traffic (issue #1491's implementation
+# plan, Decision 2 Addendum). A repository-history sweep of every Codex
+# clean-verdict root comment found 14 distinct tokens; every one is
+# reproduced here as an ERE-escaped literal (note the escaped `.` in
+# "Chef's kiss\." and "Bravo\." and the escaped `+` in ":\+1:" — these
+# MUST stay escaped, or the "." would silently become an any-character
+# wildcard and the "+" a one-or-more quantifier, each exactly the kind of
+# unreviewed widening this design forbids). Extending this alternation
+# with a newly observed token requires the identical live-capture
+# discipline as adding a whole new template — see Decision 2 Addendum.
 CODEX_APPROVED_TEMPLATES=(
-  '^Codex Review: Didn'"'"'t find any major issues\. Swish! \*\*Reviewed commit:\*\* `[0-9a-f]{7,40}` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> \[Your team has set up Codex to review pull requests in this repo\]\(https://chatgpt\.com/codex/cloud/settings/general\)\. Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment "@codex review"\. If Codex has suggestions, it will comment; otherwise it will react with 👍\. Codex can also answer questions or update the PR\. Try commenting "@codex address that feedback"\. </details>$'
+  '^Codex Review: Didn'"'"'t find any major issues\. (Swish!|:rocket:|Nice work!|Chef'"'"'s kiss\.|You'"'"'re on a roll\.|:tada:|Another round soon, please!|:\+1:|Bravo\.|Keep it up!|Delightful!|Keep them coming!|Can'"'"'t wait for the next one!|More of your lovely PRs please\.) \*\*Reviewed commit:\*\* `[0-9a-f]{7,40}` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> \[Your team has set up Codex to review pull requests in this repo\]\(https://chatgpt\.com/codex/cloud/settings/general\)\. Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment "@codex review"\. If Codex has suggestions, it will comment; otherwise it will react with 👍\. Codex can also answer questions or update the PR\. Try commenting "@codex address that feedback"\. </details>$'
 )
 
 # `APPROVED` requires the ENTIRE, untruncated response — whitespace-

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -37,14 +37,27 @@
 #      "required:", "❌"
 #      Note: "blocking issues:" (with colon) disambiguates the list form from
 #      "no blocking issues found"; bare "blocking" excluded (too broad).
-#   2. Approval signals present → APPROVED (exit 0)
-#      Signals (case-insensitive): "approved", "lgtm", "looks good",
-#      "didn't find any major issues", or "no blocking issues" from a
-#      submitted review pinned to the current head, or a root PR comment that
-#      names the current head in a Reviewed commit marker. Other Codex root PR
-#      comments and thumbs-up reactions are acknowledgements only; they are not
-#      SHA-pinned review evidence and must not approve the PR by themselves.
-#   3. Neither found (unrecognized format) → safe-fails to NEEDS_REVISION (exit 1)
+#   2. Whole-body exact template match → APPROVED (exit 0)
+#      The entire, untruncated response — whitespace-normalized, nothing
+#      truncated or discarded — must reproduce, character for character, one
+#      of the small set of clean-response templates in
+#      CODEX_APPROVED_TEMPLATES (captured verbatim from real Codex responses,
+#      each including the complete vendor <details> "About Codex in GitHub"
+#      footer). There is no vocabulary list, no grammar, and no
+#      case-insensitive or punctuation-tolerant matching — see
+#      codex_response_is_approved below and issue #1491's implementation plan
+#      (Decisions 1, 2, 5) for the full rationale. Only a submitted review
+#      pinned to the current head, or a root PR comment that names the
+#      current head in a Reviewed commit marker (terminal evidence), is ever
+#      tested against this match. Other Codex root PR comments and
+#      thumbs-up reactions are acknowledgements only; they are not SHA-pinned
+#      review evidence and must not approve the PR by themselves.
+#   3. Neither found, and evidence is terminal → safe-fails to NEEDS_REVISION
+#      (exit 1). A bare acknowledgement comment on NON-terminal evidence
+#      instead causes the poll loop to keep waiting for real evidence — this
+#      wait is gated on the evidence being non-terminal (Decision 6), so a
+#      footer-bearing near-miss on genuinely terminal evidence always
+#      safe-fails rather than being misrouted to a wait/timeout.
 #
 # Response source detection (two sources polled each cycle):
 #   - issues/{PR}/comments — plain PR comments; matches both BOT_LOGIN and
@@ -245,8 +258,12 @@ codex_inline_review_comment_count_since() {
 
 # Returns true if the response contains a fence-opener marker (2+
 # consecutive backticks, or 3+ consecutive tildes) ANYWHERE. Used by
-# every positive-signal classifier below (usage-limit, environment-error,
-# approved) as a conservative guard: a genuine SHA-pinned clean review
+# codex_response_is_usage_limit and codex_response_is_environment_error
+# below as a conservative guard (no longer by codex_response_is_approved,
+# which — since issue #1491's conservative-verdict-classifier redesign,
+# Decision 1 — is a whole-body exact-template match with no fence-presence
+# check of its own; a fence character inside the body is just extra text
+# that already breaks the exact match): a genuine SHA-pinned clean review
 # can QUOTE example text inside a fenced block (e.g. demonstrating what a
 # usage-limit notice looks like) without that text being a genuine
 # assertion, and after 5 rounds of precisely parsing GFM's fence-open/
@@ -369,88 +386,17 @@ codex_response_reviews_current_head() {
 # is recognized as blocking outright regardless of what an earlier
 # hedge phrase in the same response says.
 CODEX_BLOCKING_PATTERN='(changes[[:space:]]+requested|blocking[[:space:]]+issues?[[:space:]]*:|blocking[[:space:]]+finding|blocking:|must[[:space:]]+fix|action[[:space:]]+required|required:|❌)'
-# \b word boundaries around the positive approval words: without them,
-# "approved" as a bare substring matched inside prefixed negative forms
-# like "unapproved" or "disapproved" (no space/word-break before
-# "approved" in either), so a current-head response saying "This change
-# remains unapproved" was still classified APPROVED instead of falling
-# through to the documented safe-fail (fresh evidence from PR #1490
-# finding 3789851555 — a followup to finding 3789722818, whose fix only
-# handled SPACE-separated negations like "not approved"; \b closes the
-# concatenated-negation-prefix gap that a space-only negation check
-# cannot). Verified portable across BSD grep (macOS default), GNU grep,
-# and ugrep — all treat \b as a GNU-style word-boundary extension in -E
-# mode.
-CODEX_APPROVAL_PATTERN='(\bapproved\b|\blgtm\b|\blooks[[:space:]]+good\b|didn.t find[[:space:]]+any major[[:space:]]+issues|no[[:space:]]+blocking[[:space:]]+issues?)'
-# Negated forms of the approval phrases above. CODEX_APPROVAL_PATTERN's
-# alternatives are unbounded substring matches, so a rejecting response
-# like "This change is not approved" matched them unconditionally and was
-# classified APPROVED instead of falling through to the documented
-# unrecognized-format safe-fail. Checked BEFORE the positive approval
-# pattern in codex_response_is_approved so a negated approval phrase can
-# never be reported as approved.
-#
-# This went through several rounds of narrowly-scoped fixes (PR #1490
-# findings 3789722818, 3789851555, 3789878264, 3789904716, 3789958775):
-# require a negation word directly adjacent to the approval word, then
-# tolerate a concatenated prefix ("unapproved"), then Markdown emphasis
-# markers wedged in the middle ("**not** approved"), then a BOUNDED
-# window of up to 3 intervening qualifier words ("not YET approved").
-# Each fix narrowed one specific adjacency assumption and Codex found the
-# next one, up to and including the bounded-window fix itself: 5
-# intervening words ("I cannot confidently confirm that there are no
-# blocking issues") exceeded the {0,3} bound (fresh evidence from PR
-# #1490 finding 3789992792) — the reviewer's own stated remediation was
-# "avoid relying on a bounded filler-word count".
-#
-# [^.!?]* (any character except a sentence terminator, UNBOUNDED) between
-# the negation word and the approval word closes this whole class of gap
-# at once: it matches a negation and an approval word co-occurring
-# anywhere within the same sentence, regardless of how much text sits
-# between them or how it's formatted (Markdown markers included, since
-# they aren't excluded by the character class), while a period/!/?
-# between them correctly prevents an unrelated LATER sentence's approval
-# phrase from being treated as negated by an EARLIER sentence's negation
-# word (e.g. "The variable name is not great. No blocking issues found."
-# still classifies as approved).
-#
-# The target alternation had "approved" but not the bare verb "approve",
-# so "I cannot approve this change" wasn't recognized (PR #1490 finding
-# 3790023141). This is a forward negation-THEN-approval match: "cannot"
-# precedes "approve" in that sentence, so adding the bare verb to the
-# target list is sufficient on its own — no reverse-order (approval-word
-# ... negation-word) alternative is needed. An earlier version of this
-# fix DID add a reverse-order alternative, reasoning that "looks good"
-# preceded "cannot" in the same example; that reverse check was over-
-# broad in practice — it matched ANY later negation word in the same
-# sentence regardless of what the negation actually referred to, so a
-# genuinely clean response like "Looks good overall; tests were not run."
-# (the negation refers to the unrelated "tests were not run" clause, not
-# to the approval) was incorrectly flagged as negated (PR #1490 finding
-# 3790062089). The reverse-order alternative has been removed; the
-# forward-only match plus the bare-verb addition covers the original
-# "cannot approve" case without this false-positive class.
-#
-# The [^.!?]* span only excluded sentence terminators, not clause
-# separators, so an unrelated negation in an EARLIER clause of the SAME
-# sentence still spanned into a LATER, unrelated clean clause — e.g.
-# "Tests are not required for this documentation-only change; looks
-# good" has "not" in one semicolon-joined clause and "looks good" in a
-# separate one, but the span crossed the semicolon and matched anyway
-# (PR #1490 finding 3790122061, the same class of gap as 3790062089
-# above but on the forward-order side rather than the removed reverse
-# alternative). The character class also excludes `;` and `,`: a comma-
-# joined clause (e.g. "Tests are not required, but looks good") crossed
-# the semicolon-only exclusion the same way the semicolon-crossing case
-# crossed the original unbounded span (fresh evidence from PR #1490
-# finding 3793219193, a followup to 3790122061/3790062089). "unable to"
-# is also included: it wasn't in the negation-word list at all, so "I am
-# unable to approve this change" wasn't recognized as a rejection while
-# an earlier "looks good" in the same sentence still matched (fresh
-# evidence from PR #1490 finding 3793367883, the same class of gap as
-# "cannot approve" fixed for finding 3790023141, just a different
-# inability phrase).
-CODEX_NEGATED_APPROVAL_TARGET_WORDS='(approve[ds]?|lgtm|look(s|ing)?[[:space:]]+good|no[[:space:]]+blocking[[:space:]]+issues?|didn.t find[[:space:]]+any major[[:space:]]+issues)'
+# CODEX_APPROVAL_PATTERN, CODEX_NEGATED_APPROVAL_TARGET_WORDS, and
+# CODEX_NEGATED_APPROVAL_PATTERN (the open-ended approval-vocabulary and
+# negated-approval-vocabulary enumerations that used to live here) are
+# deleted outright, not narrowed further — issue #1491's implementation
+# plan (Decisions 1, 2) replaces this entire class of open-ended-vocabulary
+# matching with codex_response_is_approved's whole-body exact-template
+# match below, which has no vocabulary of its own to enumerate gaps in.
+# CODEX_NEGATION_WORDS (below) is kept — CODEX_MERGE_REFUSAL_PATTERN, part
+# of CODEX_BLOCKING_PATTERN above, still depends on it, and
+# codex_response_is_blocking's failure direction (a false negative there
+# is unsafe) means it keeps its own block-list unchanged (Decision 4).
 # Proactive sweep of the remaining common English negation forms not yet
 # covered (was/were/would/has/have/had, contracted and space-separated),
 # added in one pass after four consecutive findings each surfaced one
@@ -458,20 +404,24 @@ CODEX_NEGATED_APPROVAL_TARGET_WORDS='(approve[ds]?|lgtm|look(s|ing)?[[:space:]]+
 # and finally wouldn't — fresh evidence from PR #1490 finding 3799391883
 # — prompted this sweep rather than continuing to fix them one at a
 # time). "did not"/"didn't" is DELIBERATELY excluded despite being an
-# equally common negation form: it already appears baked into
-# CODEX_NEGATED_APPROVAL_TARGET_WORDS above as part of the atomic phrase
-# "didn't find any major issues" (itself a clean/approval signal, not
-# something to negate). Adding bare "didn.t" here was verified to
-# introduce a genuine false positive: a response like "Codex didn't find
-# any major issues and looks good." — doubly-reinforced clean, not
-# rejected — matched NEGATION_WORDS on "didn't" and then reached the
-# separate "looks good" target later in the same unpunctuated sentence,
-# misclassifying a clean review as NEEDS_REVISION. Caught and reverted
-# during this sweep's own verification before ever being committed;
-# left undocumented here it would be an easy trap for a future sweep to
-# re-introduce.
+# equally common negation form: "didn't find any major issues" is itself
+# a clean-signal phrase, not something to negate, so folding bare
+# "didn.t" into this list would make CODEX_MERGE_REFUSAL_PATTERN below
+# false-positive-match a genuinely clean, unpunctuated sentence like
+# "Codex didn't find any major issues that would block this from being
+# merged." (the "didn't" and "merge" fall in the same clause, with no
+# sentence terminator or comma between them to stop the match). This
+# exclusion originally protected the now-deleted negated-approval
+# pattern (issue #1491's implementation plan, Decision 2: the
+# open-ended approval/negated-approval vocabulary this constant used to
+# feed was replaced by codex_response_is_approved's whole-body
+# exact-template match) — it is kept here because CODEX_NEGATION_WORDS'
+# one remaining consumer, CODEX_MERGE_REFUSAL_PATTERN, has the exact
+# same "didn't find any major issues" adjacency risk. Caught and
+# reverted during this sweep's own verification before ever being
+# committed; left undocumented here it would be an easy trap for a
+# future sweep to re-introduce.
 CODEX_NEGATION_WORDS='(not|isn.t|is[[:space:]]+not|are[[:space:]]+not|aren.t|was[[:space:]]+not|wasn.t|were[[:space:]]+not|weren.t|cannot|can.t|could[[:space:]]+not|couldn.t|will[[:space:]]+not|won.t|would[[:space:]]+not|wouldn.t|does[[:space:]]+not|doesn.t|do[[:space:]]+not|don.t|has[[:space:]]+not|hasn.t|have[[:space:]]+not|haven.t|had[[:space:]]+not|hadn.t|should[[:space:]]+not|shouldn.t|must[[:space:]]+not|mustn.t|never|unable[[:space:]]+to)'
-CODEX_NEGATED_APPROVAL_PATTERN="${CODEX_NEGATION_WORDS}[^.!?;,]*${CODEX_NEGATED_APPROVAL_TARGET_WORDS}"
 # Any CODEX_NEGATION_WORDS alternative, followed within the same clause
 # by "merge"/"merged" (with or without an intervening "be"), is treated
 # as an explicit merge-refusal verdict — see the comment above
@@ -485,8 +435,11 @@ CODEX_BLOCKING_PATTERN="${CODEX_BLOCKING_PATTERN%)}|${CODEX_MERGE_REFUSAL_PATTER
 
 # Strips quoted spans — text between a pair of straight double-quotes
 # ("...") AND text between a pair of backticks (`...`, Markdown inline
-# code) — used by codex_response_is_approved AND codex_response_is_blocking
-# below, never applied to the body before codex_response_reviews_current_
+# code) — used by codex_response_is_blocking below (no longer by
+# codex_response_is_approved, which — since issue #1491's
+# conservative-verdict-classifier redesign, Decision 1 — is a whole-body
+# exact-template match with no quote-stripping step of its own), never
+# applied to the body before codex_response_reviews_current_
 # head's SHA extraction (which itself relies on backtick-delimited
 # `Reviewed commit:` markers and must see the original, unstripped body).
 # A SHA-pinned review can QUOTE a clean OR blocking phrase, in either
@@ -533,11 +486,13 @@ CODEX_BLOCKING_PATTERN="${CODEX_BLOCKING_PATTERN%)}|${CODEX_MERGE_REFUSAL_PATTER
 # 3793453010, 3793497787, a closing-validity followup, and 3795661290).
 # Rather than continue precisely re-implementing GFM's fence grammar one
 # construct at a time, codex_response_has_fence_marker above (used by
-# every positive/actionable classifier: usage-limit, environment-error,
-# blocking, approved) now treats the mere PRESENCE of a fence-opener
-# marker (3+ consecutive backticks or tildes) ANYWHERE in the response as
-# disqualifying, without attempting to determine where it opens or
-# closes. This is a deliberate, explicit tradeoff: a small amount of
+# codex_response_is_usage_limit and codex_response_is_environment_error;
+# no longer by codex_response_is_approved as of issue #1491's
+# conservative-verdict-classifier redesign, Decision 1) now treats the
+# mere PRESENCE of a fence-opener marker (3+ consecutive backticks or
+# tildes) ANYWHERE in the response as disqualifying, without attempting
+# to determine where it opens or closes. This is a deliberate, explicit
+# tradeoff: a small amount of
 # false-NEEDS_REVISION risk (a genuinely clean response that happens to
 # include an example code fence) in exchange for closing the entire class
 # of "quoted/fenced clean phrase misread as an assertion" bug in one
@@ -640,11 +595,15 @@ codex_response_is_blocking() {
   grep -qiE "$CODEX_BLOCKING_PATTERN" <<< "$normalized_body"
 }
 
-# Strips the "not only X" idiom — used by codex_response_is_approved and
-# codex_response_is_blocking below (originally added for approval only,
-# see codex_response_is_blocking's own comment for why the blocking
-# classifier needed it too once its merge-refusal pattern started reusing
-# CODEX_NEGATION_WORDS' bare "not" alternative). "Not only X, (but) Y" is
+# Strips the "not only X" idiom — used by codex_response_is_blocking
+# below (originally added for the old codex_response_is_approved only;
+# no longer called there since issue #1491's conservative-verdict-
+# classifier redesign, Decision 1, replaced that function with a
+# whole-body exact-template match that performs no prose normalization
+# of any kind — see codex_response_is_blocking's own comment for why the
+# blocking classifier needed this idiom-stripping too once its
+# merge-refusal pattern started reusing CODEX_NEGATION_WORDS' bare "not"
+# alternative). "Not only X, (but) Y" is
 # an AFFIRMATIVE intensifier construction (BOTH X and Y are being
 # asserted, not negated: "Not only does this look good, it is approved"
 # means both "looks good" and "is approved" hold), not a negation of X,
@@ -664,21 +623,87 @@ codex_strip_not_only_idiom() {
   sed -E 's/[Nn][Oo][Tt][[:space:]]+[Oo][Nn][Ll][Yy]//g' <<< "$body"
 }
 
+# Collapses every run of whitespace (spaces, tabs, newlines, carriage
+# returns — including blank lines between paragraphs) to a single space,
+# then trims leading/trailing whitespace. This is the ONLY step performed
+# before matching in codex_response_is_approved below, and the ONLY
+# permitted flexibility in template matching (issue #1491's
+# conservative-verdict-classifier implementation plan, Decision 1) — no
+# case folding, no optional clauses, no punctuation tolerance, no
+# synonym alternation, and no truncation of any kind. `tr` first converts
+# every whitespace class this function cares about to a literal space
+# (BSD tr does not support `\s`, hence the explicit newline/tab/
+# carriage-return class), then `tr -s ' '` squeezes runs of spaces to
+# one; `sed` trims the two remaining edges.
+codex_normalize_whitespace() {
+  local text
+  text=$(tr '\n\t\r' '   ' <<< "$1" | tr -s ' ')
+  sed -E 's/^ //; s/ $//' <<< "$text"
+}
+
+# Exact captured clean-response template, covering the ENTIRE body —
+# verdict sentence AND the complete vendor "About Codex in GitHub"
+# footer, with no truncation step anywhere in codex_response_is_approved
+# below. This closes Codex GitHub finding `3803545669` (issue #1491's
+# implementation plan, Decisions 1 and 5): a prior design truncated the
+# body at the footer's opening line and matched only the visible
+# portion, trusting every byte after that line, unseen; a body reading
+# the approved template + the footer's opening line only + an actual
+# instruction (e.g. "Rename the unsafe function.") matched the visible
+# portion exactly and would have been misclassified APPROVED under that
+# design. There is no discarded byte range left for that construction
+# (or any construction) to hide in — the entire body, first character to
+# last, must be part of this one literal.
+#
+# The ONE bounded placeholder this design permits is the commit SHA,
+# bound to git's own documented abbreviated-to-full SHA-1 hex-length
+# range (`[0-9a-f]{7,40}`) — NOT to the single length any one capture
+# happens to show. No other field is a placeholder, anywhere in the
+# verdict sentence or the footer. Extending this array requires a live
+# capture of the new wording and the same review discipline the deleted
+# CODEX_APPROVAL_PATTERN once required — it is the ONLY lever that can
+# widen the approval surface, and reintroducing any truncation step
+# before matching is explicitly forbidden (Decision 2/5).
+#
+# The footer portion of this literal was verified byte-identical (modulo
+# one API-transport-only trailing newline that whitespace normalization
+# already absorbs) across every real capture available at implementation
+# time — the PR #1489 root-comment capture and every PR #1490/#1492
+# review-body capture — so it contributes zero placeholders of its own.
+#
+# The apostrophe in "Didn't" is a literal straight ASCII apostrophe, NOT
+# a regex wildcard — do not replace it with `.` if this pattern is
+# edited; a wildcard there would silently widen the match to any
+# character, which is exactly the kind of unreviewed widening this
+# design forbids.
+CODEX_APPROVED_TEMPLATES=(
+  '^Codex Review: Didn'"'"'t find any major issues\. Swish! \*\*Reviewed commit:\*\* `[0-9a-f]{7,40}` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> \[Your team has set up Codex to review pull requests in this repo\]\(https://chatgpt\.com/codex/cloud/settings/general\)\. Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment "@codex review"\. If Codex has suggestions, it will comment; otherwise it will react with 👍\. Codex can also answer questions or update the PR\. Try commenting "@codex address that feedback"\. </details>$'
+)
+
+# `APPROVED` requires the ENTIRE, untruncated response — whitespace-
+# normalized, nothing else changed — to reproduce one of
+# CODEX_APPROVED_TEMPLATES exactly (issue #1491's conservative-verdict-
+# classifier implementation plan, Decision 1). There is no
+# fence-marker check, no quoted-span stripping, no "not only" idiom
+# stripping, and no vocabulary/negation/grammar scan in this function —
+# each of those existed to compensate for a parsing layer that no longer
+# exists; a stray fence marker, a quoted span, or off-position content
+# is now just "extra text that breaks the exact match," and the match
+# already rejects it without a dedicated check. No stderr diagnostic is
+# emitted on a non-match: under exact-template matching there is exactly
+# one reason a response fails to approve (it does not reproduce an
+# evidenced template), so a diagnostic distinguishing "no reason" would
+# not be useful and would reintroduce a fuzzy-matching concept this
+# design deliberately does not have.
 codex_response_is_approved() {
-  local body="$1"
-  # A fence-opener marker (3+ consecutive backticks or tildes) ANYWHERE
-  # in the response — see codex_response_has_fence_marker above for the
-  # full rationale — disqualifies a clean verdict outright, without
-  # attempting to determine where the fence opens or closes.
-  if codex_response_has_fence_marker "$body"; then
-    return 1
-  fi
-  local normalized_body
-  normalized_body=$(codex_strip_not_only_idiom "$(codex_strip_quoted_spans "$body")")
-  if grep -qiE "$CODEX_NEGATED_APPROVAL_PATTERN" <<< "$normalized_body"; then
-    return 1
-  fi
-  grep -qiE "$CODEX_APPROVAL_PATTERN" <<< "$normalized_body"
+  local body="$1" normalized template
+  normalized=$(codex_normalize_whitespace "$body")
+  for template in "${CODEX_APPROVED_TEMPLATES[@]}"; do
+    if grep -qE "$template" <<< "$normalized"; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 # Ranks a response into one of four priority tiers, highest wins on a
@@ -1449,17 +1474,25 @@ while true; do
     #    found"), "blocking finding", "blocking:", "must fix", "action required",
     #    "required:", "❌"
     #
-    # 2. Explicit approval signals present → APPROVED (exit 0)   [checked second]
-    #    Approval signals: "approved", "lgtm", "looks good",
-    #    "didn't find any major issues", or "no blocking issues" from a
-    #    submitted review pinned to the current head, or a root PR comment that
-    #    names the current head in a Reviewed commit marker. Other Codex root PR
-    #    comments and thumbs-up reactions are unavailable, not clean.
+    # 2. Whole-body exact template match → APPROVED (exit 0)   [checked second,
+    #    terminal (source == "review") evidence only]
+    #    The entire, untruncated response body — whitespace-normalized,
+    #    nothing truncated or discarded — must reproduce one of the
+    #    templates in CODEX_APPROVED_TEMPLATES exactly (see
+    #    codex_response_is_approved above and issue #1491's implementation
+    #    plan, Decisions 1/2/5). There is no vocabulary list, no grammar,
+    #    and no punctuation/case tolerance. Other Codex root PR comments
+    #    and thumbs-up reactions are unavailable, not clean.
     #
-    # 3. Neither found (unrecognized response format) → NEEDS_REVISION (exit 1)
-    #    Safe-fail: default to NEEDS_REVISION when the format is unrecognized to
-    #    avoid incorrectly approving a response that is a rejection in an
-    #    unexpected format (per spec risk mitigation for BR-4).
+    # 3. Neither found, and evidence is terminal → NEEDS_REVISION (exit 1)
+    #    Safe-fail: default to NEEDS_REVISION when a terminal response's
+    #    format is unrecognized, to avoid incorrectly approving a response
+    #    that is a rejection in an unexpected format (per spec risk
+    #    mitigation for BR-4). The acknowledgement branch immediately below
+    #    is gated on the evidence being NON-terminal (source != "review",
+    #    issue #1491's implementation plan, Decision 6), so a
+    #    footer-bearing near-miss on terminal evidence always reaches this
+    #    safe-fail rather than being misrouted to a wait/timeout.
     #
     # Note on "blocking issues" disambiguation: the phrase "blocking issues" appears
     # in both blocking context ("blocking issues: 1. foo") and clean context ("no
@@ -1512,7 +1545,19 @@ while true; do
       echo "$BOT_RESPONSE"
       echo "---END BOT RESPONSE---"
       exit 0
-    elif grep -qi "If Codex has suggestions, it will comment; otherwise it will react with" <<< "$BOT_RESPONSE_FULL"; then
+    elif [ "$BOT_RESPONSE_SOURCE" != "review" ] && grep -qi "If Codex has suggestions, it will comment; otherwise it will react with" <<< "$BOT_RESPONSE_FULL"; then
+      # Gated on non-terminal evidence (source != "review") — issue #1491's
+      # implementation plan, Decision 6. Without this gate, a genuine Codex
+      # response that carries the real footer but does not exactly match
+      # CODEX_APPROVED_TEMPLATES also matches this acknowledgement text
+      # (the footer's opening line), and terminal evidence would be
+      # misrouted here (wait for more evidence) instead of the documented
+      # NEEDS_REVISION safe-fail below, eventually timing out. A bare,
+      # non-terminal acknowledgement-only comment can never have
+      # source == "review" in the first place (codex_response_reviews_
+      # current_head requires an extractable Reviewed-commit SHA), so this
+      # narrowing removes only the one case (terminal evidence) this
+      # branch was never meant to catch.
       echo "INFO: Codex acknowledgement detected; waiting for current-head review or inline review comments"
       continue
     elif [ "$BOT_RESPONSE_SOURCE" = "comment" ]; then
@@ -1718,7 +1763,9 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
     echo "$ASYNC_BOT_RESPONSE"
     echo "---END BOT RESPONSE---"
     exit 0
-  elif grep -qi "If Codex has suggestions, it will comment; otherwise it will react with" <<< "$ASYNC_BOT_RESPONSE_FULL"; then
+  elif [ "$ASYNC_BOT_RESPONSE_SOURCE" != "review" ] && grep -qi "If Codex has suggestions, it will comment; otherwise it will react with" <<< "$ASYNC_BOT_RESPONSE_FULL"; then
+    # Gated on non-terminal evidence — see the main-loop equivalent above
+    # for the rationale (issue #1491's implementation plan, Decision 6).
     echo "INFO: async-arrival Codex acknowledgement detected without current-head review or inline comments"
     echo "INFO: waiting ${POLL_INTERVAL}s for final Codex async signal..."
     sleep "$POLL_INTERVAL"
@@ -1822,7 +1869,18 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
         exit 0
       elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "comment" ]; then
         echo "INFO: final async Codex root comment is not SHA-pinned terminal evidence"
-      elif ! grep -qi "If Codex has suggestions, it will comment; otherwise it will react with" <<< "$ASYNC_FINAL_BOT_RESPONSE_FULL"; then
+      elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "review" ] || ! grep -qi "If Codex has suggestions, it will comment; otherwise it will react with" <<< "$ASYNC_FINAL_BOT_RESPONSE_FULL"; then
+        # Gated on terminal evidence (source == "review") — issue #1491's
+        # implementation plan, Decision 6. This branch is only reachable
+        # for review-sourced (terminal) bodies to begin with (a bare
+        # non-terminal comment is already caught by the `source ==
+        # "comment"` branch immediately above), so the added
+        # `[ SOURCE = "review" ]` condition makes this safe-fail
+        # unconditional for every body that reaches this elif: without it,
+        # a genuine terminal response carrying the real footer but not
+        # exactly matching CODEX_APPROVED_TEMPLATES would silently fall
+        # through to "wait" (no branch taken) instead of the documented
+        # NEEDS_REVISION safe-fail, eventually timing out.
         echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
         echo "---BEGIN BOT RESPONSE---"
         echo "$ASYNC_FINAL_BOT_RESPONSE"
@@ -1963,7 +2021,10 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
       exit 0
     elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "comment" ]; then
       echo "INFO: final async reaction Codex root comment is not SHA-pinned terminal evidence"
-    elif ! grep -qi "If Codex has suggestions, it will comment; otherwise it will react with" <<< "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL"; then
+    elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "review" ] || ! grep -qi "If Codex has suggestions, it will comment; otherwise it will react with" <<< "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL"; then
+      # Gated on terminal evidence (source == "review") — see the
+      # async-final equivalent above for the rationale (issue #1491's
+      # implementation plan, Decision 6).
       echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
       echo "---BEGIN BOT RESPONSE---"
       echo "$ASYNC_REACTION_FINAL_BOT_RESPONSE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -655,15 +655,25 @@ codex_normalize_whitespace() {
 # (or any construction) to hide in — the entire body, first character to
 # last, must be part of this one literal.
 #
-# The ONE bounded placeholder this design permits is the commit SHA,
-# bound to git's own documented abbreviated-to-full SHA-1 hex-length
-# range (`[0-9a-f]{7,40}`) — NOT to the single length any one capture
-# happens to show. No other field is a placeholder, anywhere in the
-# verdict sentence or the footer. Extending this array requires a live
-# capture of the new wording and the same review discipline the deleted
-# CODEX_APPROVAL_PATTERN once required — it is the ONLY lever that can
-# widen the approval surface, and reintroducing any truncation step
-# before matching is explicitly forbidden (Decision 2/5).
+# This template has exactly TWO bounded placeholders, both anchored at a
+# fixed position between exact literal text on either side, never a
+# general wildcard:
+#
+# 1. The commit SHA, bound to git's own documented abbreviated-to-full
+#    SHA-1 hex-length range (`[0-9a-f]{7,40}`) — NOT to the single
+#    length any one capture happens to show.
+# 2. The "flavor" slot immediately after "Didn't find any major issues. "
+#    — see the dedicated comment block below for its full history and
+#    bound derivation (issue #1491's implementation plan, Decision 2
+#    Addendum).
+#
+# No other field is a placeholder, anywhere in the verdict sentence or
+# the footer. Extending either placeholder's bound, or adding a whole new
+# template, requires a live capture of the new evidence and the same
+# review discipline the deleted CODEX_APPROVAL_PATTERN once required —
+# these are the ONLY levers that can widen the approval surface, and
+# reintroducing any truncation step before matching is explicitly
+# forbidden (Decision 2/5).
 #
 # The footer portion of this literal was verified byte-identical (modulo
 # one API-transport-only trailing newline that whitespace normalization
@@ -677,24 +687,54 @@ codex_normalize_whitespace() {
 # character, which is exactly the kind of unreviewed widening this
 # design forbids.
 #
-# The "flavor" slot immediately after "Didn't find any major issues. " is
-# a bounded, parenthesized alternation of every literal flavor token
-# evidenced by a live Codex response — NOT a single fixed word and NOT a
-# general wildcard/character-class. This was learned the hard way: the
-# single-literal ("Swish!") version of this template shipped on this
-# repository's own PR #1494, whose first Codex review used ":rocket:"
-# instead and safe-failed on real traffic (issue #1491's implementation
-# plan, Decision 2 Addendum). A repository-history sweep of every Codex
-# clean-verdict root comment found 14 distinct tokens; every one is
-# reproduced here as an ERE-escaped literal (note the escaped `.` in
-# "Chef's kiss\." and "Bravo\." and the escaped `+` in ":\+1:" — these
-# MUST stay escaped, or the "." would silently become an any-character
-# wildcard and the "+" a one-or-more quantifier, each exactly the kind of
-# unreviewed widening this design forbids). Extending this alternation
-# with a newly observed token requires the identical live-capture
-# discipline as adding a whole new template — see Decision 2 Addendum.
+# The "flavor" slot's placeholder, `[^*`[:cntrl:]]{1,40}`, and why it
+# replaced a 14-token literal alternation (issue #1491's implementation
+# plan, Decision 2 second addendum — supersedes the first addendum's
+# enumeration approach):
+#
+# History: this template originally hardcoded the single literal
+# "Swish!" here. This repository's own PR #1494 falsified that
+# assumption on its first real-traffic exercise — its Codex review used
+# ":rocket:" instead and safe-failed. A repository-history sweep then
+# found 14 distinct evidenced tokens, not the 1-2 anticipated — single
+# words, full sentences, GitHub emoji shortcodes, inconsistent trailing
+# punctuation. That diversity, discovered from fewer than 50 samples, is
+# LLM-generated variety, not a fixed vocabulary: enumerating it would not
+# converge, reopening issue #1491's original complaint (an open-ended
+# enumeration that keeps finding one more case) on a new axis, just as
+# every disqualifier/vocabulary design earlier in this plan's history
+# already failed to converge for the same structural reason. Attempting a
+# 14-token alternation shipped briefly, then was replaced by this bounded
+# placeholder before merge, once that pattern became clear.
+#
+# Bound derivation: `{1,40}` — 40 is the longest evidenced token's length
+# (31 characters, "More of your lovely PRs please.") rounded up to the
+# nearest 10 with modest headroom, wide enough to admit a somewhat longer
+# genuine flavor phrase without being large enough to admit multi-sentence
+# injected content. `[^*`[:cntrl:]]` excludes only the characters that
+# could let this slot swallow adjacent template structure: `*` (protects
+# the literal `**Reviewed commit:**` bold-marker syntax immediately
+# after this slot), backtick (protects the backtick-delimited SHA field
+# that follows), and every control character including newline/carriage
+# return (defense in depth — whitespace normalization, Decision 1,
+# already guarantees no raw control character survives to this point,
+# but the exclusion is kept explicit rather than relying solely on that
+# guarantee). No apostrophe, colon, comma, period, exclamation mark, or
+# plain space is excluded — every one of those appears in at least one
+# evidenced token and the slot must keep admitting ordinary punctuation.
+#
+# Residual risk, stated plainly rather than claimed away: this is now a
+# genuine (bounded) placeholder, not a literal — a false `APPROVED` is
+# possible if Codex ever asserts "Didn't find any major issues." and then
+# places an actual directive inside this 40-character slot while still
+# reproducing the exact, complete footer verbatim afterward. This
+# requires self-contradictory vendor output (a clean verdict immediately
+# followed by an instruction, inside one otherwise-genuine response) and
+# is treated as an accepted, disclosed trade — see Decision 2 second
+# addendum and Risks & Mitigations for the full accounting — not a zero-
+# risk claim.
 CODEX_APPROVED_TEMPLATES=(
-  '^Codex Review: Didn'"'"'t find any major issues\. (Swish!|:rocket:|Nice work!|Chef'"'"'s kiss\.|You'"'"'re on a roll\.|:tada:|Another round soon, please!|:\+1:|Bravo\.|Keep it up!|Delightful!|Keep them coming!|Can'"'"'t wait for the next one!|More of your lovely PRs please\.) \*\*Reviewed commit:\*\* `[0-9a-f]{7,40}` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> \[Your team has set up Codex to review pull requests in this repo\]\(https://chatgpt\.com/codex/cloud/settings/general\)\. Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment "@codex review"\. If Codex has suggestions, it will comment; otherwise it will react with 👍\. Codex can also answer questions or update the PR\. Try commenting "@codex address that feedback"\. </details>$'
+  '^Codex Review: Didn'"'"'t find any major issues\. [^*`[:cntrl:]]{1,40} \*\*Reviewed commit:\*\* `[0-9a-f]{7,40}` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> \[Your team has set up Codex to review pull requests in this repo\]\(https://chatgpt\.com/codex/cloud/settings/general\)\. Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment "@codex review"\. If Codex has suggestions, it will comment; otherwise it will react with 👍\. Codex can also answer questions or update the PR\. Try commenting "@codex address that feedback"\. </details>$'
 )
 
 # `APPROVED` requires the ENTIRE, untruncated response — whitespace-

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -9220,6 +9220,621 @@ rm -rf "$_codex_footer_near_miss_async_reaction_final_safe_fails_mock_dir"
 unset _codex_footer_near_miss_async_reaction_final_safe_fails_mock_dir _codex_footer_near_miss_async_reaction_final_safe_fails_output _codex_footer_near_miss_async_reaction_final_safe_fails_exit _codex_footer_near_miss_async_reaction_final_safe_fails_site
 
 
+# ---------------------------------------------------------------------------
+# Flavor-token enumeration (issue #1491 follow-up, live-evidence correction
+# after PR #1494's own Codex review returned a clean response using
+# ":rocket:" instead of the single "Swish!" literal the shipped template
+# hardcoded — the vendor rotates this one slot through a pool of tokens, not
+# a fixed word. CODEX_APPROVED_TEMPLATES' flavor slot is now a bounded
+# alternation of every token evidenced by a live GitHub capture (comment
+# ids and PR numbers recorded in the implementation plan's Decision 2
+# addendum and the smoke-test runbook) — never an invented token, never a
+# general wildcard. Adding a token here requires the same review discipline
+# as adding a template. codex_e1_real_pr1489_capture_approved above already
+# covers "Swish!" end to end; this block covers every other evidenced token.
+# ---------------------------------------------------------------------------
+# Flavor token: 'Nice work!' (issue #1491 follow-up; live evidence swept from repo history)
+_codex_flavor_nice_work_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_flavor_nice_work_approved_mock_dir/gh" <<'CODEX_FLAVOR_NICE_WORK_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'f1a00000011234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":901,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:951,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Nice work! **Reviewed commit:** `f1a0000001` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FLAVOR_NICE_WORK_APPROVED_GH
+chmod +x "$_codex_flavor_nice_work_approved_mock_dir/gh"
+
+_codex_flavor_nice_work_approved_output=""
+_codex_flavor_nice_work_approved_exit=0
+PATH="$_codex_flavor_nice_work_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_flavor_nice_work_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_nice_work_approved_exit=$?
+_codex_flavor_nice_work_approved_output="$(cat "$_codex_flavor_nice_work_approved_mock_dir/output.txt")"
+run_test "codex_flavor_nice_work_approved_exit_clean" "0" "$_codex_flavor_nice_work_approved_exit"
+run_test "codex_flavor_nice_work_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_flavor_nice_work_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_flavor_nice_work_approved_mock_dir"
+unset _codex_flavor_nice_work_approved_mock_dir _codex_flavor_nice_work_approved_output _codex_flavor_nice_work_approved_exit
+
+# Flavor token: "Chef's kiss." (issue #1491 follow-up; live evidence swept from repo history)
+_codex_flavor_chefs_kiss_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_flavor_chefs_kiss_approved_mock_dir/gh" <<'CODEX_FLAVOR_CHEFS_KISS_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'f1a00000021234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":902,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:952,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Chef'\''s kiss. **Reviewed commit:** `f1a0000002` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FLAVOR_CHEFS_KISS_APPROVED_GH
+chmod +x "$_codex_flavor_chefs_kiss_approved_mock_dir/gh"
+
+_codex_flavor_chefs_kiss_approved_output=""
+_codex_flavor_chefs_kiss_approved_exit=0
+PATH="$_codex_flavor_chefs_kiss_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_flavor_chefs_kiss_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_chefs_kiss_approved_exit=$?
+_codex_flavor_chefs_kiss_approved_output="$(cat "$_codex_flavor_chefs_kiss_approved_mock_dir/output.txt")"
+run_test "codex_flavor_chefs_kiss_approved_exit_clean" "0" "$_codex_flavor_chefs_kiss_approved_exit"
+run_test "codex_flavor_chefs_kiss_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_flavor_chefs_kiss_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_flavor_chefs_kiss_approved_mock_dir"
+unset _codex_flavor_chefs_kiss_approved_mock_dir _codex_flavor_chefs_kiss_approved_output _codex_flavor_chefs_kiss_approved_exit
+
+# Flavor token: "You're on a roll." (issue #1491 follow-up; live evidence swept from repo history)
+_codex_flavor_youre_on_a_roll_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_flavor_youre_on_a_roll_approved_mock_dir/gh" <<'CODEX_FLAVOR_YOURE_ON_A_ROLL_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'f1a00000031234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":903,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:953,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. You'\''re on a roll. **Reviewed commit:** `f1a0000003` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FLAVOR_YOURE_ON_A_ROLL_APPROVED_GH
+chmod +x "$_codex_flavor_youre_on_a_roll_approved_mock_dir/gh"
+
+_codex_flavor_youre_on_a_roll_approved_output=""
+_codex_flavor_youre_on_a_roll_approved_exit=0
+PATH="$_codex_flavor_youre_on_a_roll_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_flavor_youre_on_a_roll_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_youre_on_a_roll_approved_exit=$?
+_codex_flavor_youre_on_a_roll_approved_output="$(cat "$_codex_flavor_youre_on_a_roll_approved_mock_dir/output.txt")"
+run_test "codex_flavor_youre_on_a_roll_approved_exit_clean" "0" "$_codex_flavor_youre_on_a_roll_approved_exit"
+run_test "codex_flavor_youre_on_a_roll_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_flavor_youre_on_a_roll_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_flavor_youre_on_a_roll_approved_mock_dir"
+unset _codex_flavor_youre_on_a_roll_approved_mock_dir _codex_flavor_youre_on_a_roll_approved_output _codex_flavor_youre_on_a_roll_approved_exit
+
+# Flavor token: ':tada:' (issue #1491 follow-up; live evidence swept from repo history)
+_codex_flavor_tada_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_flavor_tada_approved_mock_dir/gh" <<'CODEX_FLAVOR_TADA_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'f1a00000041234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":904,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:954,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. :tada: **Reviewed commit:** `f1a0000004` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FLAVOR_TADA_APPROVED_GH
+chmod +x "$_codex_flavor_tada_approved_mock_dir/gh"
+
+_codex_flavor_tada_approved_output=""
+_codex_flavor_tada_approved_exit=0
+PATH="$_codex_flavor_tada_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_flavor_tada_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_tada_approved_exit=$?
+_codex_flavor_tada_approved_output="$(cat "$_codex_flavor_tada_approved_mock_dir/output.txt")"
+run_test "codex_flavor_tada_approved_exit_clean" "0" "$_codex_flavor_tada_approved_exit"
+run_test "codex_flavor_tada_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_flavor_tada_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_flavor_tada_approved_mock_dir"
+unset _codex_flavor_tada_approved_mock_dir _codex_flavor_tada_approved_output _codex_flavor_tada_approved_exit
+
+# Flavor token: 'Another round soon, please!' (issue #1491 follow-up; live evidence swept from repo history)
+_codex_flavor_another_round_soon_please_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_flavor_another_round_soon_please_approved_mock_dir/gh" <<'CODEX_FLAVOR_ANOTHER_ROUND_SOON_PLEASE_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'f1a00000051234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":905,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:955,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Another round soon, please! **Reviewed commit:** `f1a0000005` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FLAVOR_ANOTHER_ROUND_SOON_PLEASE_APPROVED_GH
+chmod +x "$_codex_flavor_another_round_soon_please_approved_mock_dir/gh"
+
+_codex_flavor_another_round_soon_please_approved_output=""
+_codex_flavor_another_round_soon_please_approved_exit=0
+PATH="$_codex_flavor_another_round_soon_please_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_flavor_another_round_soon_please_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_another_round_soon_please_approved_exit=$?
+_codex_flavor_another_round_soon_please_approved_output="$(cat "$_codex_flavor_another_round_soon_please_approved_mock_dir/output.txt")"
+run_test "codex_flavor_another_round_soon_please_approved_exit_clean" "0" "$_codex_flavor_another_round_soon_please_approved_exit"
+run_test "codex_flavor_another_round_soon_please_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_flavor_another_round_soon_please_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_flavor_another_round_soon_please_approved_mock_dir"
+unset _codex_flavor_another_round_soon_please_approved_mock_dir _codex_flavor_another_round_soon_please_approved_output _codex_flavor_another_round_soon_please_approved_exit
+
+# Flavor token: ':+1:' (issue #1491 follow-up; live evidence swept from repo history)
+_codex_flavor_plus_one_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_flavor_plus_one_approved_mock_dir/gh" <<'CODEX_FLAVOR_PLUS_ONE_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'f1a00000061234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":906,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:956,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. :+1: **Reviewed commit:** `f1a0000006` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FLAVOR_PLUS_ONE_APPROVED_GH
+chmod +x "$_codex_flavor_plus_one_approved_mock_dir/gh"
+
+_codex_flavor_plus_one_approved_output=""
+_codex_flavor_plus_one_approved_exit=0
+PATH="$_codex_flavor_plus_one_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_flavor_plus_one_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_plus_one_approved_exit=$?
+_codex_flavor_plus_one_approved_output="$(cat "$_codex_flavor_plus_one_approved_mock_dir/output.txt")"
+run_test "codex_flavor_plus_one_approved_exit_clean" "0" "$_codex_flavor_plus_one_approved_exit"
+run_test "codex_flavor_plus_one_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_flavor_plus_one_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_flavor_plus_one_approved_mock_dir"
+unset _codex_flavor_plus_one_approved_mock_dir _codex_flavor_plus_one_approved_output _codex_flavor_plus_one_approved_exit
+
+# Flavor token: 'Bravo.' (issue #1491 follow-up; live evidence swept from repo history)
+_codex_flavor_bravo_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_flavor_bravo_approved_mock_dir/gh" <<'CODEX_FLAVOR_BRAVO_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'f1a00000071234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":907,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:957,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Bravo. **Reviewed commit:** `f1a0000007` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FLAVOR_BRAVO_APPROVED_GH
+chmod +x "$_codex_flavor_bravo_approved_mock_dir/gh"
+
+_codex_flavor_bravo_approved_output=""
+_codex_flavor_bravo_approved_exit=0
+PATH="$_codex_flavor_bravo_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_flavor_bravo_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_bravo_approved_exit=$?
+_codex_flavor_bravo_approved_output="$(cat "$_codex_flavor_bravo_approved_mock_dir/output.txt")"
+run_test "codex_flavor_bravo_approved_exit_clean" "0" "$_codex_flavor_bravo_approved_exit"
+run_test "codex_flavor_bravo_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_flavor_bravo_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_flavor_bravo_approved_mock_dir"
+unset _codex_flavor_bravo_approved_mock_dir _codex_flavor_bravo_approved_output _codex_flavor_bravo_approved_exit
+
+# Flavor token: 'Keep it up!' (issue #1491 follow-up; live evidence swept from repo history)
+_codex_flavor_keep_it_up_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_flavor_keep_it_up_approved_mock_dir/gh" <<'CODEX_FLAVOR_KEEP_IT_UP_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'f1a00000081234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":908,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:958,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Keep it up! **Reviewed commit:** `f1a0000008` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FLAVOR_KEEP_IT_UP_APPROVED_GH
+chmod +x "$_codex_flavor_keep_it_up_approved_mock_dir/gh"
+
+_codex_flavor_keep_it_up_approved_output=""
+_codex_flavor_keep_it_up_approved_exit=0
+PATH="$_codex_flavor_keep_it_up_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_flavor_keep_it_up_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_keep_it_up_approved_exit=$?
+_codex_flavor_keep_it_up_approved_output="$(cat "$_codex_flavor_keep_it_up_approved_mock_dir/output.txt")"
+run_test "codex_flavor_keep_it_up_approved_exit_clean" "0" "$_codex_flavor_keep_it_up_approved_exit"
+run_test "codex_flavor_keep_it_up_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_flavor_keep_it_up_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_flavor_keep_it_up_approved_mock_dir"
+unset _codex_flavor_keep_it_up_approved_mock_dir _codex_flavor_keep_it_up_approved_output _codex_flavor_keep_it_up_approved_exit
+
+# Flavor token: 'Delightful!' (issue #1491 follow-up; live evidence swept from repo history)
+_codex_flavor_delightful_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_flavor_delightful_approved_mock_dir/gh" <<'CODEX_FLAVOR_DELIGHTFUL_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'f1a00000091234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":909,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:959,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Delightful! **Reviewed commit:** `f1a0000009` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FLAVOR_DELIGHTFUL_APPROVED_GH
+chmod +x "$_codex_flavor_delightful_approved_mock_dir/gh"
+
+_codex_flavor_delightful_approved_output=""
+_codex_flavor_delightful_approved_exit=0
+PATH="$_codex_flavor_delightful_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_flavor_delightful_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_delightful_approved_exit=$?
+_codex_flavor_delightful_approved_output="$(cat "$_codex_flavor_delightful_approved_mock_dir/output.txt")"
+run_test "codex_flavor_delightful_approved_exit_clean" "0" "$_codex_flavor_delightful_approved_exit"
+run_test "codex_flavor_delightful_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_flavor_delightful_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_flavor_delightful_approved_mock_dir"
+unset _codex_flavor_delightful_approved_mock_dir _codex_flavor_delightful_approved_output _codex_flavor_delightful_approved_exit
+
+# Flavor token: 'Keep them coming!' (issue #1491 follow-up; live evidence swept from repo history)
+_codex_flavor_keep_them_coming_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_flavor_keep_them_coming_approved_mock_dir/gh" <<'CODEX_FLAVOR_KEEP_THEM_COMING_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'f1a000000a1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":910,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:960,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Keep them coming! **Reviewed commit:** `f1a000000a` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FLAVOR_KEEP_THEM_COMING_APPROVED_GH
+chmod +x "$_codex_flavor_keep_them_coming_approved_mock_dir/gh"
+
+_codex_flavor_keep_them_coming_approved_output=""
+_codex_flavor_keep_them_coming_approved_exit=0
+PATH="$_codex_flavor_keep_them_coming_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_flavor_keep_them_coming_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_keep_them_coming_approved_exit=$?
+_codex_flavor_keep_them_coming_approved_output="$(cat "$_codex_flavor_keep_them_coming_approved_mock_dir/output.txt")"
+run_test "codex_flavor_keep_them_coming_approved_exit_clean" "0" "$_codex_flavor_keep_them_coming_approved_exit"
+run_test "codex_flavor_keep_them_coming_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_flavor_keep_them_coming_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_flavor_keep_them_coming_approved_mock_dir"
+unset _codex_flavor_keep_them_coming_approved_mock_dir _codex_flavor_keep_them_coming_approved_output _codex_flavor_keep_them_coming_approved_exit
+
+# Flavor token: "Can't wait for the next one!" (issue #1491 follow-up; live evidence swept from repo history)
+_codex_flavor_cant_wait_for_next_one_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_flavor_cant_wait_for_next_one_approved_mock_dir/gh" <<'CODEX_FLAVOR_CANT_WAIT_FOR_NEXT_ONE_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'f1a000000b1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":911,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:961,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Can'\''t wait for the next one! **Reviewed commit:** `f1a000000b` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FLAVOR_CANT_WAIT_FOR_NEXT_ONE_APPROVED_GH
+chmod +x "$_codex_flavor_cant_wait_for_next_one_approved_mock_dir/gh"
+
+_codex_flavor_cant_wait_for_next_one_approved_output=""
+_codex_flavor_cant_wait_for_next_one_approved_exit=0
+PATH="$_codex_flavor_cant_wait_for_next_one_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_flavor_cant_wait_for_next_one_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_cant_wait_for_next_one_approved_exit=$?
+_codex_flavor_cant_wait_for_next_one_approved_output="$(cat "$_codex_flavor_cant_wait_for_next_one_approved_mock_dir/output.txt")"
+run_test "codex_flavor_cant_wait_for_next_one_approved_exit_clean" "0" "$_codex_flavor_cant_wait_for_next_one_approved_exit"
+run_test "codex_flavor_cant_wait_for_next_one_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_flavor_cant_wait_for_next_one_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_flavor_cant_wait_for_next_one_approved_mock_dir"
+unset _codex_flavor_cant_wait_for_next_one_approved_mock_dir _codex_flavor_cant_wait_for_next_one_approved_output _codex_flavor_cant_wait_for_next_one_approved_exit
+
+# Flavor token: 'More of your lovely PRs please.' (issue #1491 follow-up; live evidence swept from repo history)
+_codex_flavor_more_lovely_prs_please_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_flavor_more_lovely_prs_please_approved_mock_dir/gh" <<'CODEX_FLAVOR_MORE_LOVELY_PRS_PLEASE_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'f1a000000c1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":912,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:962,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. More of your lovely PRs please. **Reviewed commit:** `f1a000000c` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FLAVOR_MORE_LOVELY_PRS_PLEASE_APPROVED_GH
+chmod +x "$_codex_flavor_more_lovely_prs_please_approved_mock_dir/gh"
+
+_codex_flavor_more_lovely_prs_please_approved_output=""
+_codex_flavor_more_lovely_prs_please_approved_exit=0
+PATH="$_codex_flavor_more_lovely_prs_please_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_flavor_more_lovely_prs_please_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_more_lovely_prs_please_approved_exit=$?
+_codex_flavor_more_lovely_prs_please_approved_output="$(cat "$_codex_flavor_more_lovely_prs_please_approved_mock_dir/output.txt")"
+run_test "codex_flavor_more_lovely_prs_please_approved_exit_clean" "0" "$_codex_flavor_more_lovely_prs_please_approved_exit"
+run_test "codex_flavor_more_lovely_prs_please_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_flavor_more_lovely_prs_please_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_flavor_more_lovely_prs_please_approved_mock_dir"
+unset _codex_flavor_more_lovely_prs_please_approved_mock_dir _codex_flavor_more_lovely_prs_please_approved_output _codex_flavor_more_lovely_prs_please_approved_exit
+
+# Flavor token: ":rocket:" — the real, live PR #1494 root comment capture
+# (comment id 5333550055, 2026-08-18) that falsified the single-token
+# assumption in the first place. Verbatim, including its real footer,
+# matching codex_e1_real_pr1489_capture_approved's real-capture style.
+_codex_flavor_rocket_real_pr1494_capture_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_flavor_rocket_real_pr1494_capture_approved_mock_dir/gh" <<'CODEX_FLAVOR_ROCKET_REAL_PR1494_CAPTURE_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'a2a20e7b4836cfb5d20b75e39e01447757434e34\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":999,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:998,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. :rocket:
+
+**Reviewed commit:** `a2a20e7b48`
+
+<details> <summary>ℹ️ About Codex in GitHub</summary>
+<br/>
+
+[Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you
+- Open a pull request for review
+- Mark a draft as ready
+- Comment \"@codex review\".
+
+If Codex has suggestions, it will comment; otherwise it will react with 👍.
+
+
+
+
+Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\".
+            
+</details>
+")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FLAVOR_ROCKET_REAL_PR1494_CAPTURE_APPROVED_GH
+chmod +x "$_codex_flavor_rocket_real_pr1494_capture_approved_mock_dir/gh"
+
+_codex_flavor_rocket_real_pr1494_capture_approved_output=""
+_codex_flavor_rocket_real_pr1494_capture_approved_exit=0
+PATH="$_codex_flavor_rocket_real_pr1494_capture_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_flavor_rocket_real_pr1494_capture_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_rocket_real_pr1494_capture_approved_exit=$?
+_codex_flavor_rocket_real_pr1494_capture_approved_output="$(cat "$_codex_flavor_rocket_real_pr1494_capture_approved_mock_dir/output.txt")"
+run_test "codex_flavor_rocket_real_pr1494_capture_approved_exit_clean" "0" "$_codex_flavor_rocket_real_pr1494_capture_approved_exit"
+run_test "codex_flavor_rocket_real_pr1494_capture_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_flavor_rocket_real_pr1494_capture_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_flavor_rocket_real_pr1494_capture_approved_mock_dir"
+unset _codex_flavor_rocket_real_pr1494_capture_approved_mock_dir _codex_flavor_rocket_real_pr1494_capture_approved_output _codex_flavor_rocket_real_pr1494_capture_approved_exit
+
+# Flavor token regression: an unevidenced flavor phrase ("Fantastic job!")
+# must still safe-fail. Proves the alternation is closed (does not admit
+# arbitrary text in the flavor slot) and that the safe-direction failure
+# (false NEEDS_REVISION on an as-yet-unobserved genuine flavor rotation) is
+# intentional and tested, per the human decision recorded in the plan.
+_codex_flavor_unevidenced_token_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_flavor_unevidenced_token_not_approved_mock_dir/gh" <<'CODEX_FLAVOR_UNEVIDENCED_TOKEN_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'f1a000000d1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":913,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:963,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Fantastic job! **Reviewed commit:** `f1a000000d` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FLAVOR_UNEVIDENCED_TOKEN_NOT_APPROVED_GH
+chmod +x "$_codex_flavor_unevidenced_token_not_approved_mock_dir/gh"
+
+_codex_flavor_unevidenced_token_not_approved_output=""
+_codex_flavor_unevidenced_token_not_approved_exit=0
+PATH="$_codex_flavor_unevidenced_token_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_flavor_unevidenced_token_not_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_unevidenced_token_not_approved_exit=$?
+_codex_flavor_unevidenced_token_not_approved_output="$(cat "$_codex_flavor_unevidenced_token_not_approved_mock_dir/output.txt")"
+run_test "codex_flavor_unevidenced_token_not_approved_exit_needs_revision" "1" "$_codex_flavor_unevidenced_token_not_approved_exit"
+run_test "codex_flavor_unevidenced_token_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_flavor_unevidenced_token_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_flavor_unevidenced_token_not_approved_mock_dir"
+unset _codex_flavor_unevidenced_token_not_approved_mock_dir _codex_flavor_unevidenced_token_not_approved_output _codex_flavor_unevidenced_token_not_approved_exit
+
+
 _unlock_pr="80213$$"
 _unlock_lock_dir="/tmp/pr-review-loop-${_unlock_pr}.lockdir"
 rm -rf "$_unlock_lock_dir"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3529,7 +3529,7 @@ PATH="$_codex_long_review_body_no_sigpipe_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_long_review_body_no_sigpipe_mock_dir/output.txt" 2>&1 || _codex_long_review_body_no_sigpipe_exit=$?
 _codex_long_review_body_no_sigpipe_output="$(cat "$_codex_long_review_body_no_sigpipe_mock_dir/output.txt")"
-run_test "codex_long_review_body_no_sigpipe_exit_clean" "1" "$_codex_long_review_body_no_sigpipe_exit"
+run_test "codex_long_review_body_no_sigpipe_exit_needs_revision" "1" "$_codex_long_review_body_no_sigpipe_exit"
 run_test "codex_long_review_body_no_sigpipe_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_long_review_body_no_sigpipe_output" | grep "^VERDICT:")"
 rm -rf "$_codex_long_review_body_no_sigpipe_mock_dir"
@@ -3732,7 +3732,7 @@ PATH="$_codex_long_root_comment_no_sigpipe_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_long_root_comment_no_sigpipe_mock_dir/output.txt" 2>&1 || _codex_long_root_comment_no_sigpipe_exit=$?
 _codex_long_root_comment_no_sigpipe_output="$(cat "$_codex_long_root_comment_no_sigpipe_mock_dir/output.txt")"
-run_test "codex_long_root_comment_no_sigpipe_exit_clean" "1" "$_codex_long_root_comment_no_sigpipe_exit"
+run_test "codex_long_root_comment_no_sigpipe_exit_needs_revision" "1" "$_codex_long_root_comment_no_sigpipe_exit"
 run_test "codex_long_root_comment_no_sigpipe_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_long_root_comment_no_sigpipe_output" | grep "^VERDICT:")"
 rm -rf "$_codex_long_root_comment_no_sigpipe_mock_dir"
@@ -4752,7 +4752,7 @@ PATH="$_codex_usage_limit_topic_mention_not_quota_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_usage_limit_topic_mention_not_quota_mock_dir/output.txt" 2>&1 || _codex_usage_limit_topic_mention_not_quota_exit=$?
 _codex_usage_limit_topic_mention_not_quota_output="$(cat "$_codex_usage_limit_topic_mention_not_quota_mock_dir/output.txt")"
-run_test "codex_usage_limit_topic_mention_not_quota_exit_clean" "1" "$_codex_usage_limit_topic_mention_not_quota_exit"
+run_test "codex_usage_limit_topic_mention_not_quota_exit_needs_revision" "1" "$_codex_usage_limit_topic_mention_not_quota_exit"
 run_test "codex_usage_limit_topic_mention_not_quota_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_usage_limit_topic_mention_not_quota_output" | grep "^VERDICT:")"
 rm -rf "$_codex_usage_limit_topic_mention_not_quota_mock_dir"
@@ -4855,7 +4855,7 @@ PATH="$_codex_usage_limit_code_reviews_phrase_mention_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_usage_limit_code_reviews_phrase_mention_mock_dir/output.txt" 2>&1 || _codex_usage_limit_code_reviews_phrase_mention_exit=$?
 _codex_usage_limit_code_reviews_phrase_mention_output="$(cat "$_codex_usage_limit_code_reviews_phrase_mention_mock_dir/output.txt")"
-run_test "codex_usage_limit_code_reviews_phrase_mention_exit_clean" "1" "$_codex_usage_limit_code_reviews_phrase_mention_exit"
+run_test "codex_usage_limit_code_reviews_phrase_mention_exit_needs_revision" "1" "$_codex_usage_limit_code_reviews_phrase_mention_exit"
 run_test "codex_usage_limit_code_reviews_phrase_mention_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_usage_limit_code_reviews_phrase_mention_output" | grep "^VERDICT:")"
 rm -rf "$_codex_usage_limit_code_reviews_phrase_mention_mock_dir"
@@ -4954,7 +4954,7 @@ PATH="$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir:$PATH"
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir/output.txt" 2>&1 || _codex_negation_prior_sentence_does_not_leak_root_comment_exit=$?
 _codex_negation_prior_sentence_does_not_leak_root_comment_output="$(cat "$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir/output.txt")"
-run_test "codex_negation_prior_sentence_does_not_leak_root_comment_exit_clean" "1" "$_codex_negation_prior_sentence_does_not_leak_root_comment_exit"
+run_test "codex_negation_prior_sentence_does_not_leak_root_comment_exit_needs_revision" "1" "$_codex_negation_prior_sentence_does_not_leak_root_comment_exit"
 run_test "codex_negation_prior_sentence_does_not_leak_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_negation_prior_sentence_does_not_leak_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir"
@@ -5061,7 +5061,7 @@ PATH="$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir/output.txt" 2>&1 || _codex_terminal_comment_quotes_env_error_not_ancillary_exit=$?
 _codex_terminal_comment_quotes_env_error_not_ancillary_output="$(cat "$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir/output.txt")"
-run_test "codex_terminal_comment_quotes_env_error_not_ancillary_exit_clean" "1" "$_codex_terminal_comment_quotes_env_error_not_ancillary_exit"
+run_test "codex_terminal_comment_quotes_env_error_not_ancillary_exit_needs_revision" "1" "$_codex_terminal_comment_quotes_env_error_not_ancillary_exit"
 run_test "codex_terminal_comment_quotes_env_error_not_ancillary_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_terminal_comment_quotes_env_error_not_ancillary_output" | grep "^VERDICT:")"
 rm -rf "$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir"
@@ -5117,7 +5117,7 @@ PATH="$_codex_unrelated_later_negation_safe_fails_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_unrelated_later_negation_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_unrelated_later_negation_safe_fails_root_comment_exit=$?
 _codex_unrelated_later_negation_safe_fails_root_comment_output="$(cat "$_codex_unrelated_later_negation_safe_fails_root_comment_mock_dir/output.txt")"
-run_test "codex_unrelated_later_negation_safe_fails_root_comment_exit_clean" "1" "$_codex_unrelated_later_negation_safe_fails_root_comment_exit"
+run_test "codex_unrelated_later_negation_safe_fails_root_comment_exit_needs_revision" "1" "$_codex_unrelated_later_negation_safe_fails_root_comment_exit"
 run_test "codex_unrelated_later_negation_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_unrelated_later_negation_safe_fails_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_unrelated_later_negation_safe_fails_root_comment_mock_dir"
@@ -5318,7 +5318,7 @@ PATH="$_codex_semicolon_scoped_negation_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_semicolon_scoped_negation_root_comment_mock_dir/output.txt" 2>&1 || _codex_semicolon_scoped_negation_root_comment_exit=$?
 _codex_semicolon_scoped_negation_root_comment_output="$(cat "$_codex_semicolon_scoped_negation_root_comment_mock_dir/output.txt")"
-run_test "codex_semicolon_scoped_negation_root_comment_exit_clean" "1" "$_codex_semicolon_scoped_negation_root_comment_exit"
+run_test "codex_semicolon_scoped_negation_root_comment_exit_needs_revision" "1" "$_codex_semicolon_scoped_negation_root_comment_exit"
 run_test "codex_semicolon_scoped_negation_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_semicolon_scoped_negation_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_semicolon_scoped_negation_root_comment_mock_dir"
@@ -5422,7 +5422,7 @@ PATH="$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir/output.txt" 2>&1 || _codex_quoted_rejection_in_clean_review_root_comment_exit=$?
 _codex_quoted_rejection_in_clean_review_root_comment_output="$(cat "$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir/output.txt")"
-run_test "codex_quoted_rejection_in_clean_review_root_comment_exit_clean" "1" "$_codex_quoted_rejection_in_clean_review_root_comment_exit"
+run_test "codex_quoted_rejection_in_clean_review_root_comment_exit_needs_revision" "1" "$_codex_quoted_rejection_in_clean_review_root_comment_exit"
 run_test "codex_quoted_rejection_in_clean_review_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_quoted_rejection_in_clean_review_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir"
@@ -5473,7 +5473,7 @@ PATH="$_codex_comma_scoped_negation_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_comma_scoped_negation_root_comment_mock_dir/output.txt" 2>&1 || _codex_comma_scoped_negation_root_comment_exit=$?
 _codex_comma_scoped_negation_root_comment_output="$(cat "$_codex_comma_scoped_negation_root_comment_mock_dir/output.txt")"
-run_test "codex_comma_scoped_negation_root_comment_exit_clean" "1" "$_codex_comma_scoped_negation_root_comment_exit"
+run_test "codex_comma_scoped_negation_root_comment_exit_needs_revision" "1" "$_codex_comma_scoped_negation_root_comment_exit"
 run_test "codex_comma_scoped_negation_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_comma_scoped_negation_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_comma_scoped_negation_root_comment_mock_dir"
@@ -5533,7 +5533,7 @@ PATH="$_codex_terminal_review_quotes_quota_message_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_terminal_review_quotes_quota_message_mock_dir/output.txt" 2>&1 || _codex_terminal_review_quotes_quota_message_exit=$?
 _codex_terminal_review_quotes_quota_message_output="$(cat "$_codex_terminal_review_quotes_quota_message_mock_dir/output.txt")"
-run_test "codex_terminal_review_quotes_quota_message_exit_clean" "1" "$_codex_terminal_review_quotes_quota_message_exit"
+run_test "codex_terminal_review_quotes_quota_message_exit_needs_revision" "1" "$_codex_terminal_review_quotes_quota_message_exit"
 run_test "codex_terminal_review_quotes_quota_message_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_terminal_review_quotes_quota_message_output" | grep "^VERDICT:")"
 rm -rf "$_codex_terminal_review_quotes_quota_message_mock_dir"
@@ -5590,7 +5590,7 @@ PATH="$_codex_not_only_idiom_safe_fails_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_not_only_idiom_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_not_only_idiom_safe_fails_root_comment_exit=$?
 _codex_not_only_idiom_safe_fails_root_comment_output="$(cat "$_codex_not_only_idiom_safe_fails_root_comment_mock_dir/output.txt")"
-run_test "codex_not_only_idiom_safe_fails_root_comment_exit_clean" "1" "$_codex_not_only_idiom_safe_fails_root_comment_exit"
+run_test "codex_not_only_idiom_safe_fails_root_comment_exit_needs_revision" "1" "$_codex_not_only_idiom_safe_fails_root_comment_exit"
 run_test "codex_not_only_idiom_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_not_only_idiom_safe_fails_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_not_only_idiom_safe_fails_root_comment_mock_dir"
@@ -5642,7 +5642,7 @@ PATH="$_codex_not_only_idiom_uppercase_safe_fails_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_not_only_idiom_uppercase_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_not_only_idiom_uppercase_safe_fails_root_comment_exit=$?
 _codex_not_only_idiom_uppercase_safe_fails_root_comment_output="$(cat "$_codex_not_only_idiom_uppercase_safe_fails_root_comment_mock_dir/output.txt")"
-run_test "codex_not_only_idiom_uppercase_safe_fails_root_comment_exit_clean" "1" "$_codex_not_only_idiom_uppercase_safe_fails_root_comment_exit"
+run_test "codex_not_only_idiom_uppercase_safe_fails_root_comment_exit_needs_revision" "1" "$_codex_not_only_idiom_uppercase_safe_fails_root_comment_exit"
 run_test "codex_not_only_idiom_uppercase_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_not_only_idiom_uppercase_safe_fails_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_not_only_idiom_uppercase_safe_fails_root_comment_mock_dir"
@@ -5793,7 +5793,7 @@ PATH="$_codex_quoted_blocker_token_safe_fails_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_quoted_blocker_token_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_quoted_blocker_token_safe_fails_root_comment_exit=$?
 _codex_quoted_blocker_token_safe_fails_root_comment_output="$(cat "$_codex_quoted_blocker_token_safe_fails_root_comment_mock_dir/output.txt")"
-run_test "codex_quoted_blocker_token_safe_fails_root_comment_exit_clean" "1" "$_codex_quoted_blocker_token_safe_fails_root_comment_exit"
+run_test "codex_quoted_blocker_token_safe_fails_root_comment_exit_needs_revision" "1" "$_codex_quoted_blocker_token_safe_fails_root_comment_exit"
 run_test "codex_quoted_blocker_token_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_quoted_blocker_token_safe_fails_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_quoted_blocker_token_safe_fails_root_comment_mock_dir"
@@ -6536,7 +6536,7 @@ PATH="$_codex_unrelated_negation_before_merge_safe_fails_root_comment_mock_dir:$
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_unrelated_negation_before_merge_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_unrelated_negation_before_merge_safe_fails_root_comment_exit=$?
 _codex_unrelated_negation_before_merge_safe_fails_root_comment_output="$(cat "$_codex_unrelated_negation_before_merge_safe_fails_root_comment_mock_dir/output.txt")"
-run_test "codex_unrelated_negation_before_merge_safe_fails_root_comment_exit_clean" "1" "$_codex_unrelated_negation_before_merge_safe_fails_root_comment_exit"
+run_test "codex_unrelated_negation_before_merge_safe_fails_root_comment_exit_needs_revision" "1" "$_codex_unrelated_negation_before_merge_safe_fails_root_comment_exit"
 run_test "codex_unrelated_negation_before_merge_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_unrelated_negation_before_merge_safe_fails_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_unrelated_negation_before_merge_safe_fails_root_comment_mock_dir"
@@ -6652,7 +6652,7 @@ PATH="$_codex_not_only_safe_to_merge_safe_fails_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_not_only_safe_to_merge_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_not_only_safe_to_merge_safe_fails_root_comment_exit=$?
 _codex_not_only_safe_to_merge_safe_fails_root_comment_output="$(cat "$_codex_not_only_safe_to_merge_safe_fails_root_comment_mock_dir/output.txt")"
-run_test "codex_not_only_safe_to_merge_safe_fails_root_comment_exit_clean" "1" "$_codex_not_only_safe_to_merge_safe_fails_root_comment_exit"
+run_test "codex_not_only_safe_to_merge_safe_fails_root_comment_exit_needs_revision" "1" "$_codex_not_only_safe_to_merge_safe_fails_root_comment_exit"
 run_test "codex_not_only_safe_to_merge_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_not_only_safe_to_merge_safe_fails_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_not_only_safe_to_merge_safe_fails_root_comment_mock_dir"
@@ -6762,7 +6762,7 @@ PATH="$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_mock_dir:
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_exit=$?
 _codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_output="$(cat "$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_mock_dir/output.txt")"
-run_test "codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_exit_clean" "1" "$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_exit"
+run_test "codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_exit_needs_revision" "1" "$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_exit"
 run_test "codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_mock_dir"
@@ -6862,7 +6862,7 @@ PATH="$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir/output.txt" 2>&1 || _codex_contraction_apostrophes_not_mangled_root_comment_exit=$?
 _codex_contraction_apostrophes_not_mangled_root_comment_output="$(cat "$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir/output.txt")"
-run_test "codex_contraction_apostrophes_not_mangled_root_comment_exit_clean" "1" "$_codex_contraction_apostrophes_not_mangled_root_comment_exit"
+run_test "codex_contraction_apostrophes_not_mangled_root_comment_exit_needs_revision" "1" "$_codex_contraction_apostrophes_not_mangled_root_comment_exit"
 run_test "codex_contraction_apostrophes_not_mangled_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_contraction_apostrophes_not_mangled_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir"
@@ -7123,7 +7123,7 @@ PATH="$_codex_inline_backtick_pair_safe_fails_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_inline_backtick_pair_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_inline_backtick_pair_safe_fails_root_comment_exit=$?
 _codex_inline_backtick_pair_safe_fails_root_comment_output="$(cat "$_codex_inline_backtick_pair_safe_fails_root_comment_mock_dir/output.txt")"
-run_test "codex_inline_backtick_pair_safe_fails_root_comment_exit_clean" "1" "$_codex_inline_backtick_pair_safe_fails_root_comment_exit"
+run_test "codex_inline_backtick_pair_safe_fails_root_comment_exit_needs_revision" "1" "$_codex_inline_backtick_pair_safe_fails_root_comment_exit"
 run_test "codex_inline_backtick_pair_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_inline_backtick_pair_safe_fails_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_inline_backtick_pair_safe_fails_root_comment_mock_dir"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2574,7 +2574,7 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    printf '[{"id":218,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex Review: Didn'\''t find any major issues.\\n\\n**Reviewed commit:** `abcdefab12`"}]\n'
+    jq -nc '[{id:218,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `abcdefab12` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
@@ -2614,7 +2614,7 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    printf '[{"id":226,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Codex Review: Didn'\''t find any major issues.\\n\\n**Reviewed commit:** `abcabcabcabc1234567890`"}]\n'
+    jq -nc '[{id:226,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `abcabcabcabc1234567890` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
@@ -3050,7 +3050,7 @@ case "$*" in
   *"pulls/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/reviews"*)
-    printf '[{"submitted_at":"2026-01-01T00:00:00Z","commit_id":"abcreviewok1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    jq -nc '[{submitted_at:"2026-01-01T00:00:00Z",commit_id:"abcreviewok1234567890",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `aaaaaaaaaa` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *"issues/"*"/comments"*)
     printf '[{"id":206,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector"},"body":"If Codex has suggestions, it will comment; otherwise it will react with thumbs up."}]\n'
@@ -3097,7 +3097,7 @@ case "$*" in
     calls=$((calls + 1))
     printf '%s\n' "$calls" > "$calls_file"
     if [ "$calls" -ge 2 ]; then
-      printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"abcreactlate1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+      jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"abcreactlate1234567890",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `bbbbbbbbbb` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     else
       printf '[]\n'
     fi
@@ -3146,7 +3146,7 @@ case "$*" in
     calls=$((calls + 1))
     printf '%s\n' "$calls" > "$calls_file"
     if [ "$calls" -ge 3 ]; then
-      printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"abc456aa1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+      jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"abc456aa1234567890",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `cccccccccc` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     else
       printf '[]\n'
     fi
@@ -3291,6 +3291,17 @@ unset _codex_ack_repoll_env_then_reaction_mock_dir _codex_ack_repoll_env_then_re
 # main poll loop. A strictly NEWER review is expected to supersede the
 # stale environment error instead — see
 # codex_main_loop_env_then_newer_review_supersedes below.
+#
+# The review body must reproduce a real CODEX_APPROVED_TEMPLATES entry
+# (issue #1491's conservative-verdict-classifier implementation plan): the
+# SEEN_ENVIRONMENT_ERROR-supersede check this scenario exercises lives
+# INSIDE the `source == "review" && codex_response_is_approved` branch, so
+# a body that does not exactly reproduce the template never reaches that
+# check at all (it falls through to the unrecognized-format safe-fail
+# instead) — silently defeating this scenario's own coverage rather than
+# failing loudly, which is exactly why this fixture needed updating
+# alongside the classifier redesign even though its own assertion never
+# mentions "APPROVED".
 _codex_main_loop_env_then_review_mock_dir="$(mktemp -d)"
 printf '0\n' > "$_codex_main_loop_env_then_review_mock_dir/comment_calls"
 printf '0\n' > "$_codex_main_loop_env_then_review_mock_dir/review_calls"
@@ -3313,7 +3324,7 @@ case "$*" in
     calls=$((calls + 1))
     printf '%s\n' "$calls" > "$calls_file"
     if [ "$calls" -ge 2 ]; then
-      printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"mainloopenv1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+      jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"mainloopenv1234567890",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `1111111111` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     else
       printf '[]\n'
     fi
@@ -3380,7 +3391,7 @@ case "$*" in
     calls=$((calls + 1))
     printf '%s\n' "$calls" > "$calls_file"
     if [ "$calls" -ge 2 ]; then
-      printf '[{"submitted_at":"2026-01-01T00:00:03Z","commit_id":"newerreview1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+      jq -nc '[{submitted_at:"2026-01-01T00:00:03Z",commit_id:"newerreview1234567890",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `dddddddddd` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     else
       printf '[]\n'
     fi
@@ -3476,6 +3487,14 @@ unset _codex_tied_mixed_blocking_review_wins_mock_dir _codex_tied_mixed_blocking
 # instead of via a piped `head`, eliminating the SIGPIPE entirely. Body is
 # built via jq's own string-repeat operator (200000 chars) rather than a
 # large literal in this file or a python3 dependency.
+#
+# Retargeted for issue #1491's conservative-verdict-classifier redesign:
+# this body's leading "No blocking issues found." prefix was a pre-plan
+# block-list vocabulary artifact, not a reproduction of
+# CODEX_APPROVED_TEMPLATES' whole-body exact template, so it now correctly
+# safe-fails to NEEDS_REVISION. The scenario's actual purpose — proving a
+# large (~200,000-character) response completes without a SIGPIPE crash —
+# is unaffected by the verdict changing; only the disposition changes.
 _codex_long_review_body_no_sigpipe_mock_dir="$(mktemp -d)"
 cat > "$_codex_long_review_body_no_sigpipe_mock_dir/gh" <<'CODEX_LONG_REVIEW_BODY_NO_SIGPIPE_GH'
 #!/usr/bin/env bash
@@ -3510,8 +3529,8 @@ PATH="$_codex_long_review_body_no_sigpipe_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_long_review_body_no_sigpipe_mock_dir/output.txt" 2>&1 || _codex_long_review_body_no_sigpipe_exit=$?
 _codex_long_review_body_no_sigpipe_output="$(cat "$_codex_long_review_body_no_sigpipe_mock_dir/output.txt")"
-run_test "codex_long_review_body_no_sigpipe_exit_clean" "0" "$_codex_long_review_body_no_sigpipe_exit"
-run_test "codex_long_review_body_no_sigpipe_verdict" "VERDICT: APPROVED" \
+run_test "codex_long_review_body_no_sigpipe_exit_clean" "1" "$_codex_long_review_body_no_sigpipe_exit"
+run_test "codex_long_review_body_no_sigpipe_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_long_review_body_no_sigpipe_output" | grep "^VERDICT:")"
 rm -rf "$_codex_long_review_body_no_sigpipe_mock_dir"
 unset _codex_long_review_body_no_sigpipe_mock_dir _codex_long_review_body_no_sigpipe_output _codex_long_review_body_no_sigpipe_exit
@@ -3671,6 +3690,14 @@ unset _codex_terminal_comment_vs_newer_env_error_mock_dir _codex_terminal_commen
 # All 4 sites now truncate via `jq -Rrs '.[0:10000]'`, which slurps its
 # entire stdin before producing output so the writer can never receive
 # SIGPIPE regardless of input size.
+#
+# Retargeted for issue #1491's conservative-verdict-classifier redesign:
+# this body (verdict sentence + 200,000 filler characters + Reviewed-commit
+# marker, no footer) does not reproduce CODEX_APPROVED_TEMPLATES' whole-body
+# exact template, so it now correctly safe-fails to NEEDS_REVISION. The
+# scenario's actual purpose — proving a large root-comment body completes
+# without a SIGPIPE crash — is unaffected by the verdict changing; only the
+# disposition changes.
 _codex_long_root_comment_no_sigpipe_mock_dir="$(mktemp -d)"
 cat > "$_codex_long_root_comment_no_sigpipe_mock_dir/gh" <<'CODEX_LONG_ROOT_COMMENT_NO_SIGPIPE_GH'
 #!/usr/bin/env bash
@@ -3705,8 +3732,8 @@ PATH="$_codex_long_root_comment_no_sigpipe_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_long_root_comment_no_sigpipe_mock_dir/output.txt" 2>&1 || _codex_long_root_comment_no_sigpipe_exit=$?
 _codex_long_root_comment_no_sigpipe_output="$(cat "$_codex_long_root_comment_no_sigpipe_mock_dir/output.txt")"
-run_test "codex_long_root_comment_no_sigpipe_exit_clean" "0" "$_codex_long_root_comment_no_sigpipe_exit"
-run_test "codex_long_root_comment_no_sigpipe_verdict" "VERDICT: APPROVED" \
+run_test "codex_long_root_comment_no_sigpipe_exit_clean" "1" "$_codex_long_root_comment_no_sigpipe_exit"
+run_test "codex_long_root_comment_no_sigpipe_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_long_root_comment_no_sigpipe_output" | grep "^VERDICT:")"
 rm -rf "$_codex_long_root_comment_no_sigpipe_mock_dir"
 unset _codex_long_root_comment_no_sigpipe_mock_dir _codex_long_root_comment_no_sigpipe_output _codex_long_root_comment_no_sigpipe_exit
@@ -4264,6 +4291,17 @@ unset _codex_two_tied_terminal_comments_usage_limit_vs_blocking_mock_dir _codex_
 # instead, returning APPROVED instead of UNAVAILABLE. requires_attention
 # now also checks codex_response_is_usage_limit. Fixture: clean review
 # first in the array, mixed usage-limit+approval review second, both tied.
+#
+# The clean review's body must reproduce a real CODEX_APPROVED_TEMPLATES
+# entry (issue #1491's conservative-verdict-classifier implementation
+# plan): codex_response_priority ranks an unrecognized body (2) ABOVE
+# usage-limit (1), so once this fixture's clean-review body stopped
+# reproducing a template it would rank as "unrecognized" and win the tie
+# against the usage-limit review by coincidence of tier ordering, not
+# because the usage-limit review was correctly classified — silently
+# absorbing the exact regression this scenario exists to catch (the same
+# failure mode Codex GitHub finding `3805611400` identified for
+# codex_usage_limit_topic_mention_not_quota's competing fixture).
 _codex_tied_usage_limit_with_approval_phrase_mock_dir="$(mktemp -d)"
 cat > "$_codex_tied_usage_limit_with_approval_phrase_mock_dir/gh" <<'CODEX_TIED_USAGE_LIMIT_WITH_APPROVAL_PHRASE_GH'
 #!/usr/bin/env bash
@@ -4279,7 +4317,7 @@ case "$*" in
   *"pulls/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/reviews"*)
-    printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"feedc0de1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."},{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"feedc0de1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues could be evaluated because you have reached your Codex usage limits."}]\n'
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"feedc0de1234567890",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `2222222222` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")},{submitted_at:"2026-01-01T00:00:01Z",commit_id:"feedc0de1234567890",user:{login:"chatgpt-codex-connector[bot]"},body:"No blocking issues could be evaluated because you have reached your Codex usage limits."}]'
     exit 0 ;;
   *"issues/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
@@ -4660,6 +4698,25 @@ unset _codex_qualifier_negated_approval_root_comment_mock_dir _codex_qualifier_n
 # emitted UNAVAILABLE instead of APPROVED for an actually-clean PR (fresh
 # evidence from PR #1490 finding 3789928781). The alternative now
 # requires an exhaustion/unavailability word directly after the noun.
+#
+# Retargeted for issue #1491's conservative-verdict-classifier redesign
+# (Codex GitHub finding `3805611400`, P2): the review's own body still
+# does not reproduce CODEX_APPROVED_TEMPLATES (it never did — this
+# scenario relies on codex_response_priority ranking an unrecognized body
+# ABOVE usage-limit, priority 2 vs 1, so the review correctly wins the tie
+# and the composed verdict now safe-fails to NEEDS_REVISION instead of
+# APPROVED). The competing SHA-pinned ROOT COMMENT body, however, is
+# updated to the exact new template (not merely left as-is): if it were
+# left at its old "No blocking issues found." vocabulary body, it would
+# also collapse to the same unrecognized priority tier (2) as the review,
+# and the tie would then be decided by array order rather than by whether
+# the review's usage-limit-topic-mention is correctly classified —
+# silently absorbing the exact regression this scenario exists to catch.
+# Keeping the root comment as a real template (priority 0) preserves the
+# scenario's actual test: the review (priority 2, correctly NOT
+# usage-limit) still wins the tie over the clean root comment
+# (priority 0), and the composed verdict safe-fails on the review's own
+# unrecognized wording — never misrouted to UNAVAILABLE.
 _codex_usage_limit_topic_mention_not_quota_mock_dir="$(mktemp -d)"
 cat > "$_codex_usage_limit_topic_mention_not_quota_mock_dir/gh" <<'CODEX_USAGE_LIMIT_TOPIC_MENTION_NOT_QUOTA_GH'
 #!/usr/bin/env bash
@@ -4678,7 +4735,7 @@ case "$*" in
     printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"facade008f1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found. The Codex usage limit handling looks correct."}]\n'
     exit 0 ;;
   *"issues/"*"/comments"*)
-    printf '[{"id":263,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found.\\n\\n**Reviewed commit:** `facade008f`"}]\n'
+    jq -nc '[{id:263,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `facade008f` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
@@ -4695,8 +4752,8 @@ PATH="$_codex_usage_limit_topic_mention_not_quota_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_usage_limit_topic_mention_not_quota_mock_dir/output.txt" 2>&1 || _codex_usage_limit_topic_mention_not_quota_exit=$?
 _codex_usage_limit_topic_mention_not_quota_output="$(cat "$_codex_usage_limit_topic_mention_not_quota_mock_dir/output.txt")"
-run_test "codex_usage_limit_topic_mention_not_quota_exit_clean" "0" "$_codex_usage_limit_topic_mention_not_quota_exit"
-run_test "codex_usage_limit_topic_mention_not_quota_verdict" "VERDICT: APPROVED" \
+run_test "codex_usage_limit_topic_mention_not_quota_exit_clean" "1" "$_codex_usage_limit_topic_mention_not_quota_exit"
+run_test "codex_usage_limit_topic_mention_not_quota_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_usage_limit_topic_mention_not_quota_output" | grep "^VERDICT:")"
 rm -rf "$_codex_usage_limit_topic_mention_not_quota_mock_dir"
 unset _codex_usage_limit_topic_mention_not_quota_mock_dir _codex_usage_limit_topic_mention_not_quota_output _codex_usage_limit_topic_mention_not_quota_exit
@@ -4757,6 +4814,13 @@ unset _codex_negated_no_blocking_issues_root_comment_mock_dir _codex_negated_no_
 # found. The docs correctly explain Codex usage limits for code
 # reviews.") was itself misclassified as a usage-limit notice (fresh
 # evidence from PR #1490 finding 3789958776).
+#
+# Retargeted for issue #1491's conservative-verdict-classifier redesign:
+# this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-body exact
+# template, so it now correctly safe-fails to NEEDS_REVISION. This is a
+# single-evidence-source fixture (no competing tied evidence), so the
+# retarget is a plain disposition change — is_usage_limit's own guard
+# (unaffected by this plan) is still what is under test here.
 _codex_usage_limit_code_reviews_phrase_mention_mock_dir="$(mktemp -d)"
 cat > "$_codex_usage_limit_code_reviews_phrase_mention_mock_dir/gh" <<'CODEX_USAGE_LIMIT_CODE_REVIEWS_PHRASE_MENTION_GH'
 #!/usr/bin/env bash
@@ -4791,8 +4855,8 @@ PATH="$_codex_usage_limit_code_reviews_phrase_mention_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_usage_limit_code_reviews_phrase_mention_mock_dir/output.txt" 2>&1 || _codex_usage_limit_code_reviews_phrase_mention_exit=$?
 _codex_usage_limit_code_reviews_phrase_mention_output="$(cat "$_codex_usage_limit_code_reviews_phrase_mention_mock_dir/output.txt")"
-run_test "codex_usage_limit_code_reviews_phrase_mention_exit_clean" "0" "$_codex_usage_limit_code_reviews_phrase_mention_exit"
-run_test "codex_usage_limit_code_reviews_phrase_mention_verdict" "VERDICT: APPROVED" \
+run_test "codex_usage_limit_code_reviews_phrase_mention_exit_clean" "1" "$_codex_usage_limit_code_reviews_phrase_mention_exit"
+run_test "codex_usage_limit_code_reviews_phrase_mention_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_usage_limit_code_reviews_phrase_mention_output" | grep "^VERDICT:")"
 rm -rf "$_codex_usage_limit_code_reviews_phrase_mention_mock_dir"
 unset _codex_usage_limit_code_reviews_phrase_mention_mock_dir _codex_usage_limit_code_reviews_phrase_mention_output _codex_usage_limit_code_reviews_phrase_mention_exit
@@ -4849,6 +4913,13 @@ unset _codex_negation_beyond_bounded_window_root_comment_mock_dir _codex_negatio
 # in a later, unrelated sentence — the sentence-terminator exclusion in
 # the character class is what keeps the unbounded window from
 # over-matching across sentence boundaries.
+#
+# Retargeted for issue #1491's conservative-verdict-classifier redesign:
+# this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-body exact
+# template, so it now correctly safe-fails to NEEDS_REVISION regardless of
+# the (now-deleted) negation-leak mechanism this scenario originally
+# regression-tested; the construction remains valid coverage confirming it
+# is trivially rejected under the new design.
 _codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir="$(mktemp -d)"
 cat > "$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir/gh" <<'CODEX_NEGATION_PRIOR_SENTENCE_DOES_NOT_LEAK_ROOT_COMMENT_GH'
 #!/usr/bin/env bash
@@ -4883,8 +4954,8 @@ PATH="$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir:$PATH"
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir/output.txt" 2>&1 || _codex_negation_prior_sentence_does_not_leak_root_comment_exit=$?
 _codex_negation_prior_sentence_does_not_leak_root_comment_output="$(cat "$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir/output.txt")"
-run_test "codex_negation_prior_sentence_does_not_leak_root_comment_exit_clean" "0" "$_codex_negation_prior_sentence_does_not_leak_root_comment_exit"
-run_test "codex_negation_prior_sentence_does_not_leak_root_comment_verdict" "VERDICT: APPROVED" \
+run_test "codex_negation_prior_sentence_does_not_leak_root_comment_exit_clean" "1" "$_codex_negation_prior_sentence_does_not_leak_root_comment_exit"
+run_test "codex_negation_prior_sentence_does_not_leak_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_negation_prior_sentence_does_not_leak_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir"
 unset _codex_negation_prior_sentence_does_not_leak_root_comment_mock_dir _codex_negation_prior_sentence_does_not_leak_root_comment_output _codex_negation_prior_sentence_does_not_leak_root_comment_exit
@@ -4947,6 +5018,15 @@ unset _codex_negation_reverse_order_cannot_approve_root_comment_mock_dir _codex_
 # notice, downgrading APPROVED to codex-github-environment-missing (fresh
 # evidence from PR #1490 finding 3790023143). COMMENT_LATEST_IS_TERMINAL
 # now gates that override so it never fires on the terminal comment itself.
+#
+# Retargeted for issue #1491's conservative-verdict-classifier redesign:
+# this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-body exact
+# template, so it now correctly safe-fails to NEEDS_REVISION instead of
+# APPROVED. The property this scenario actually tests — that the terminal
+# comment is never re-classified as a separate ancillary environment-error
+# notice — is unaffected: COMMENT_LATEST_IS_TERMINAL's gate is independent
+# of codex_response_is_approved and still correctly prevents the downgrade
+# to codex-github-environment-missing.
 _codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir="$(mktemp -d)"
 cat > "$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir/gh" <<'CODEX_TERMINAL_COMMENT_QUOTES_ENV_ERROR_NOT_ANCILLARY_GH'
 #!/usr/bin/env bash
@@ -4981,8 +5061,8 @@ PATH="$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir/output.txt" 2>&1 || _codex_terminal_comment_quotes_env_error_not_ancillary_exit=$?
 _codex_terminal_comment_quotes_env_error_not_ancillary_output="$(cat "$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir/output.txt")"
-run_test "codex_terminal_comment_quotes_env_error_not_ancillary_exit_clean" "0" "$_codex_terminal_comment_quotes_env_error_not_ancillary_exit"
-run_test "codex_terminal_comment_quotes_env_error_not_ancillary_verdict" "VERDICT: APPROVED" \
+run_test "codex_terminal_comment_quotes_env_error_not_ancillary_exit_clean" "1" "$_codex_terminal_comment_quotes_env_error_not_ancillary_exit"
+run_test "codex_terminal_comment_quotes_env_error_not_ancillary_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_terminal_comment_quotes_env_error_not_ancillary_output" | grep "^VERDICT:")"
 rm -rf "$_codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir"
 unset _codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir _codex_terminal_comment_quotes_env_error_not_ancillary_output _codex_terminal_comment_quotes_env_error_not_ancillary_exit
@@ -4995,8 +5075,16 @@ unset _codex_terminal_comment_quotes_env_error_not_ancillary_mock_dir _codex_ter
 # were not run" clause, not to the approval) was incorrectly flagged as
 # negated and returned NEEDS_REVISION instead of APPROVED (fresh evidence
 # from PR #1490 finding 3790062089).
-_codex_unrelated_later_negation_stays_approved_root_comment_mock_dir="$(mktemp -d)"
-cat > "$_codex_unrelated_later_negation_stays_approved_root_comment_mock_dir/gh" <<'CODEX_UNRELATED_LATER_NEGATION_STAYS_APPROVED_ROOT_COMMENT_GH'
+#
+# Retargeted and renamed for issue #1491's conservative-verdict-classifier
+# redesign: this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-
+# body exact template, so it now correctly safe-fails to NEEDS_REVISION —
+# the (now-deleted) reverse-order negation mechanism this scenario
+# originally regression-tested no longer exists to have a gap in. Renamed
+# from "...stays_approved_..." per the plan's naming standing rule (a
+# scenario name must never assert the opposite of its expectation).
+_codex_unrelated_later_negation_safe_fails_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_unrelated_later_negation_safe_fails_root_comment_mock_dir/gh" <<'CODEX_UNRELATED_LATER_NEGATION_SAFE_FAILS_ROOT_COMMENT_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
@@ -5019,21 +5107,21 @@ case "$*" in
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_UNRELATED_LATER_NEGATION_STAYS_APPROVED_ROOT_COMMENT_GH
-chmod +x "$_codex_unrelated_later_negation_stays_approved_root_comment_mock_dir/gh"
+CODEX_UNRELATED_LATER_NEGATION_SAFE_FAILS_ROOT_COMMENT_GH
+chmod +x "$_codex_unrelated_later_negation_safe_fails_root_comment_mock_dir/gh"
 
-_codex_unrelated_later_negation_stays_approved_root_comment_output=""
-_codex_unrelated_later_negation_stays_approved_root_comment_exit=0
-PATH="$_codex_unrelated_later_negation_stays_approved_root_comment_mock_dir:$PATH" \
+_codex_unrelated_later_negation_safe_fails_root_comment_output=""
+_codex_unrelated_later_negation_safe_fails_root_comment_exit=0
+PATH="$_codex_unrelated_later_negation_safe_fails_root_comment_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_unrelated_later_negation_stays_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_unrelated_later_negation_stays_approved_root_comment_exit=$?
-_codex_unrelated_later_negation_stays_approved_root_comment_output="$(cat "$_codex_unrelated_later_negation_stays_approved_root_comment_mock_dir/output.txt")"
-run_test "codex_unrelated_later_negation_stays_approved_root_comment_exit_clean" "0" "$_codex_unrelated_later_negation_stays_approved_root_comment_exit"
-run_test "codex_unrelated_later_negation_stays_approved_root_comment_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_unrelated_later_negation_stays_approved_root_comment_output" | grep "^VERDICT:")"
-rm -rf "$_codex_unrelated_later_negation_stays_approved_root_comment_mock_dir"
-unset _codex_unrelated_later_negation_stays_approved_root_comment_mock_dir _codex_unrelated_later_negation_stays_approved_root_comment_output _codex_unrelated_later_negation_stays_approved_root_comment_exit
+  >"$_codex_unrelated_later_negation_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_unrelated_later_negation_safe_fails_root_comment_exit=$?
+_codex_unrelated_later_negation_safe_fails_root_comment_output="$(cat "$_codex_unrelated_later_negation_safe_fails_root_comment_mock_dir/output.txt")"
+run_test "codex_unrelated_later_negation_safe_fails_root_comment_exit_clean" "1" "$_codex_unrelated_later_negation_safe_fails_root_comment_exit"
+run_test "codex_unrelated_later_negation_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_unrelated_later_negation_safe_fails_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_unrelated_later_negation_safe_fails_root_comment_mock_dir"
+unset _codex_unrelated_later_negation_safe_fails_root_comment_mock_dir _codex_unrelated_later_negation_safe_fails_root_comment_output _codex_unrelated_later_negation_safe_fails_root_comment_exit
 
 # codex_combine_terminal_evidence previously applied the SAME newest-wins
 # comparison to a usage-limit ancillary comment as it does to an
@@ -5190,6 +5278,12 @@ unset _codex_quoted_clean_phrase_not_approved_root_comment_mock_dir _codex_quote
 # change; looks good") and was incorrectly flagged as negated (fresh
 # evidence from PR #1490 finding 3790122061). The character class now
 # also excludes `;`.
+#
+# Retargeted for issue #1491's conservative-verdict-classifier redesign:
+# this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-body exact
+# template, so it now correctly safe-fails to NEEDS_REVISION regardless of
+# the (now-deleted) semicolon-scoping mechanism this scenario originally
+# regression-tested.
 _codex_semicolon_scoped_negation_root_comment_mock_dir="$(mktemp -d)"
 cat > "$_codex_semicolon_scoped_negation_root_comment_mock_dir/gh" <<'CODEX_SEMICOLON_SCOPED_NEGATION_ROOT_COMMENT_GH'
 #!/usr/bin/env bash
@@ -5224,8 +5318,8 @@ PATH="$_codex_semicolon_scoped_negation_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_semicolon_scoped_negation_root_comment_mock_dir/output.txt" 2>&1 || _codex_semicolon_scoped_negation_root_comment_exit=$?
 _codex_semicolon_scoped_negation_root_comment_output="$(cat "$_codex_semicolon_scoped_negation_root_comment_mock_dir/output.txt")"
-run_test "codex_semicolon_scoped_negation_root_comment_exit_clean" "0" "$_codex_semicolon_scoped_negation_root_comment_exit"
-run_test "codex_semicolon_scoped_negation_root_comment_verdict" "VERDICT: APPROVED" \
+run_test "codex_semicolon_scoped_negation_root_comment_exit_clean" "1" "$_codex_semicolon_scoped_negation_root_comment_exit"
+run_test "codex_semicolon_scoped_negation_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_semicolon_scoped_negation_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_semicolon_scoped_negation_root_comment_mock_dir"
 unset _codex_semicolon_scoped_negation_root_comment_mock_dir _codex_semicolon_scoped_negation_root_comment_output _codex_semicolon_scoped_negation_root_comment_exit
@@ -5287,6 +5381,13 @@ unset _codex_backtick_quoted_phrase_not_approved_root_comment_mock_dir _codex_ba
 # was clean (fresh evidence from PR #1490 finding 3793219192).
 # codex_response_is_approved now strips quoted spans ONCE, before running
 # either check.
+#
+# Retargeted for issue #1491's conservative-verdict-classifier redesign:
+# this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-body exact
+# template, so it now correctly safe-fails to NEEDS_REVISION regardless of
+# the (now-deleted) quote-stripping-order mechanism this scenario
+# originally regression-tested for the approval path (codex_strip_quoted_
+# spans itself is unchanged, and is_approved no longer calls it at all).
 _codex_quoted_rejection_in_clean_review_root_comment_mock_dir="$(mktemp -d)"
 cat > "$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir/gh" <<'CODEX_QUOTED_REJECTION_IN_CLEAN_REVIEW_ROOT_COMMENT_GH'
 #!/usr/bin/env bash
@@ -5321,8 +5422,8 @@ PATH="$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir/output.txt" 2>&1 || _codex_quoted_rejection_in_clean_review_root_comment_exit=$?
 _codex_quoted_rejection_in_clean_review_root_comment_output="$(cat "$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir/output.txt")"
-run_test "codex_quoted_rejection_in_clean_review_root_comment_exit_clean" "0" "$_codex_quoted_rejection_in_clean_review_root_comment_exit"
-run_test "codex_quoted_rejection_in_clean_review_root_comment_verdict" "VERDICT: APPROVED" \
+run_test "codex_quoted_rejection_in_clean_review_root_comment_exit_clean" "1" "$_codex_quoted_rejection_in_clean_review_root_comment_exit"
+run_test "codex_quoted_rejection_in_clean_review_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_quoted_rejection_in_clean_review_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_quoted_rejection_in_clean_review_root_comment_mock_dir"
 unset _codex_quoted_rejection_in_clean_review_root_comment_mock_dir _codex_quoted_rejection_in_clean_review_root_comment_output _codex_quoted_rejection_in_clean_review_root_comment_exit
@@ -5332,6 +5433,12 @@ unset _codex_quoted_rejection_in_clean_review_root_comment_mock_dir _codex_quote
 # required, but looks good") the same way the original unbounded span
 # crossed the semicolon (fresh evidence from PR #1490 finding
 # 3793219193). The character class now also excludes `,`.
+#
+# Retargeted for issue #1491's conservative-verdict-classifier redesign:
+# this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-body exact
+# template, so it now correctly safe-fails to NEEDS_REVISION regardless of
+# the (now-deleted) comma-scoping mechanism this scenario originally
+# regression-tested.
 _codex_comma_scoped_negation_root_comment_mock_dir="$(mktemp -d)"
 cat > "$_codex_comma_scoped_negation_root_comment_mock_dir/gh" <<'CODEX_COMMA_SCOPED_NEGATION_ROOT_COMMENT_GH'
 #!/usr/bin/env bash
@@ -5366,8 +5473,8 @@ PATH="$_codex_comma_scoped_negation_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_comma_scoped_negation_root_comment_mock_dir/output.txt" 2>&1 || _codex_comma_scoped_negation_root_comment_exit=$?
 _codex_comma_scoped_negation_root_comment_output="$(cat "$_codex_comma_scoped_negation_root_comment_mock_dir/output.txt")"
-run_test "codex_comma_scoped_negation_root_comment_exit_clean" "0" "$_codex_comma_scoped_negation_root_comment_exit"
-run_test "codex_comma_scoped_negation_root_comment_verdict" "VERDICT: APPROVED" \
+run_test "codex_comma_scoped_negation_root_comment_exit_clean" "1" "$_codex_comma_scoped_negation_root_comment_exit"
+run_test "codex_comma_scoped_negation_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_comma_scoped_negation_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_comma_scoped_negation_root_comment_mock_dir"
 unset _codex_comma_scoped_negation_root_comment_mock_dir _codex_comma_scoped_negation_root_comment_output _codex_comma_scoped_negation_root_comment_exit
@@ -5383,6 +5490,15 @@ unset _codex_comma_scoped_negation_root_comment_mock_dir _codex_comma_scoped_neg
 # does not cover, since that guard only protects the ancillary-evidence
 # combination stage, not this separate final verdict check (fresh
 # evidence from PR #1490 finding 3793259351).
+#
+# Retargeted for issue #1491's conservative-verdict-classifier redesign:
+# this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-body exact
+# template, so it now correctly safe-fails to NEEDS_REVISION. The property
+# this scenario actually tests — that the quoted quota message does not
+# trigger a false UNAVAILABLE — is unaffected: codex_response_is_usage_
+# limit is still called on the quote-stripped body at this verdict site
+# (unchanged by this plan), so the quoted quota wording is still correctly
+# never treated as a genuine usage-limit notice.
 _codex_terminal_review_quotes_quota_message_mock_dir="$(mktemp -d)"
 cat > "$_codex_terminal_review_quotes_quota_message_mock_dir/gh" <<'CODEX_TERMINAL_REVIEW_QUOTES_QUOTA_MESSAGE_GH'
 #!/usr/bin/env bash
@@ -5417,8 +5533,8 @@ PATH="$_codex_terminal_review_quotes_quota_message_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_terminal_review_quotes_quota_message_mock_dir/output.txt" 2>&1 || _codex_terminal_review_quotes_quota_message_exit=$?
 _codex_terminal_review_quotes_quota_message_output="$(cat "$_codex_terminal_review_quotes_quota_message_mock_dir/output.txt")"
-run_test "codex_terminal_review_quotes_quota_message_exit_clean" "0" "$_codex_terminal_review_quotes_quota_message_exit"
-run_test "codex_terminal_review_quotes_quota_message_verdict" "VERDICT: APPROVED" \
+run_test "codex_terminal_review_quotes_quota_message_exit_clean" "1" "$_codex_terminal_review_quotes_quota_message_exit"
+run_test "codex_terminal_review_quotes_quota_message_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_terminal_review_quotes_quota_message_output" | grep "^VERDICT:")"
 rm -rf "$_codex_terminal_review_quotes_quota_message_mock_dir"
 unset _codex_terminal_review_quotes_quota_message_mock_dir _codex_terminal_review_quotes_quota_message_output _codex_terminal_review_quotes_quota_message_exit
@@ -5431,8 +5547,17 @@ unset _codex_terminal_review_quotes_quota_message_mock_dir _codex_terminal_revie
 # phrases are affirmative (fresh evidence from PR #1490 finding
 # 3793299512). codex_response_is_approved now strips the "not only" idiom
 # before running the negation check.
-_codex_not_only_idiom_stays_approved_root_comment_mock_dir="$(mktemp -d)"
-cat > "$_codex_not_only_idiom_stays_approved_root_comment_mock_dir/gh" <<'CODEX_NOT_ONLY_IDIOM_STAYS_APPROVED_ROOT_COMMENT_GH'
+#
+# Retargeted and renamed for issue #1491's conservative-verdict-classifier
+# redesign: this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-
+# body exact template, so it now correctly safe-fails to NEEDS_REVISION.
+# codex_strip_not_only_idiom itself is unchanged, but is_approved no
+# longer calls it (only codex_response_is_blocking does, Decision 4) — the
+# idiom-stripping-before-negation-check mechanism this scenario originally
+# regression-tested no longer applies to the approval path. Renamed from
+# "...stays_approved_..." per the plan's naming standing rule.
+_codex_not_only_idiom_safe_fails_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_not_only_idiom_safe_fails_root_comment_mock_dir/gh" <<'CODEX_NOT_ONLY_IDIOM_SAFE_FAILS_ROOT_COMMENT_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
@@ -5455,29 +5580,36 @@ case "$*" in
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_NOT_ONLY_IDIOM_STAYS_APPROVED_ROOT_COMMENT_GH
-chmod +x "$_codex_not_only_idiom_stays_approved_root_comment_mock_dir/gh"
+CODEX_NOT_ONLY_IDIOM_SAFE_FAILS_ROOT_COMMENT_GH
+chmod +x "$_codex_not_only_idiom_safe_fails_root_comment_mock_dir/gh"
 
-_codex_not_only_idiom_stays_approved_root_comment_output=""
-_codex_not_only_idiom_stays_approved_root_comment_exit=0
-PATH="$_codex_not_only_idiom_stays_approved_root_comment_mock_dir:$PATH" \
+_codex_not_only_idiom_safe_fails_root_comment_output=""
+_codex_not_only_idiom_safe_fails_root_comment_exit=0
+PATH="$_codex_not_only_idiom_safe_fails_root_comment_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_not_only_idiom_stays_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_not_only_idiom_stays_approved_root_comment_exit=$?
-_codex_not_only_idiom_stays_approved_root_comment_output="$(cat "$_codex_not_only_idiom_stays_approved_root_comment_mock_dir/output.txt")"
-run_test "codex_not_only_idiom_stays_approved_root_comment_exit_clean" "0" "$_codex_not_only_idiom_stays_approved_root_comment_exit"
-run_test "codex_not_only_idiom_stays_approved_root_comment_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_not_only_idiom_stays_approved_root_comment_output" | grep "^VERDICT:")"
-rm -rf "$_codex_not_only_idiom_stays_approved_root_comment_mock_dir"
-unset _codex_not_only_idiom_stays_approved_root_comment_mock_dir _codex_not_only_idiom_stays_approved_root_comment_output _codex_not_only_idiom_stays_approved_root_comment_exit
+  >"$_codex_not_only_idiom_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_not_only_idiom_safe_fails_root_comment_exit=$?
+_codex_not_only_idiom_safe_fails_root_comment_output="$(cat "$_codex_not_only_idiom_safe_fails_root_comment_mock_dir/output.txt")"
+run_test "codex_not_only_idiom_safe_fails_root_comment_exit_clean" "1" "$_codex_not_only_idiom_safe_fails_root_comment_exit"
+run_test "codex_not_only_idiom_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_not_only_idiom_safe_fails_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_not_only_idiom_safe_fails_root_comment_mock_dir"
+unset _codex_not_only_idiom_safe_fails_root_comment_mock_dir _codex_not_only_idiom_safe_fails_root_comment_output _codex_not_only_idiom_safe_fails_root_comment_exit
 
 # codex_strip_not_only_idiom's [Nn]ot/[Oo]nly form only covered Title-Case
 # and lowercase, not a fully uppercase emphasis form like "NOT ONLY does
 # this look good, it is approved" (fresh evidence from PR #1490 finding
 # 3793330278, a followup to 3793299512). Every letter is now
 # bracket-expanded for both cases.
-_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir="$(mktemp -d)"
-cat > "$_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir/gh" <<'CODEX_NOT_ONLY_IDIOM_UPPERCASE_STAYS_APPROVED_ROOT_COMMENT_GH'
+#
+# Retargeted and renamed for issue #1491's conservative-verdict-classifier
+# redesign: this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-
+# body exact template, so it now correctly safe-fails to NEEDS_REVISION,
+# for the same reason as codex_not_only_idiom_safe_fails_root_comment
+# above. Renamed from "...stays_approved_..." per the plan's naming
+# standing rule.
+_codex_not_only_idiom_uppercase_safe_fails_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_not_only_idiom_uppercase_safe_fails_root_comment_mock_dir/gh" <<'CODEX_NOT_ONLY_IDIOM_UPPERCASE_SAFE_FAILS_ROOT_COMMENT_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
@@ -5500,21 +5632,21 @@ case "$*" in
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_NOT_ONLY_IDIOM_UPPERCASE_STAYS_APPROVED_ROOT_COMMENT_GH
-chmod +x "$_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir/gh"
+CODEX_NOT_ONLY_IDIOM_UPPERCASE_SAFE_FAILS_ROOT_COMMENT_GH
+chmod +x "$_codex_not_only_idiom_uppercase_safe_fails_root_comment_mock_dir/gh"
 
-_codex_not_only_idiom_uppercase_stays_approved_root_comment_output=""
-_codex_not_only_idiom_uppercase_stays_approved_root_comment_exit=0
-PATH="$_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir:$PATH" \
+_codex_not_only_idiom_uppercase_safe_fails_root_comment_output=""
+_codex_not_only_idiom_uppercase_safe_fails_root_comment_exit=0
+PATH="$_codex_not_only_idiom_uppercase_safe_fails_root_comment_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_not_only_idiom_uppercase_stays_approved_root_comment_exit=$?
-_codex_not_only_idiom_uppercase_stays_approved_root_comment_output="$(cat "$_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir/output.txt")"
-run_test "codex_not_only_idiom_uppercase_stays_approved_root_comment_exit_clean" "0" "$_codex_not_only_idiom_uppercase_stays_approved_root_comment_exit"
-run_test "codex_not_only_idiom_uppercase_stays_approved_root_comment_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_not_only_idiom_uppercase_stays_approved_root_comment_output" | grep "^VERDICT:")"
-rm -rf "$_codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir"
-unset _codex_not_only_idiom_uppercase_stays_approved_root_comment_mock_dir _codex_not_only_idiom_uppercase_stays_approved_root_comment_output _codex_not_only_idiom_uppercase_stays_approved_root_comment_exit
+  >"$_codex_not_only_idiom_uppercase_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_not_only_idiom_uppercase_safe_fails_root_comment_exit=$?
+_codex_not_only_idiom_uppercase_safe_fails_root_comment_output="$(cat "$_codex_not_only_idiom_uppercase_safe_fails_root_comment_mock_dir/output.txt")"
+run_test "codex_not_only_idiom_uppercase_safe_fails_root_comment_exit_clean" "1" "$_codex_not_only_idiom_uppercase_safe_fails_root_comment_exit"
+run_test "codex_not_only_idiom_uppercase_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_not_only_idiom_uppercase_safe_fails_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_not_only_idiom_uppercase_safe_fails_root_comment_mock_dir"
+unset _codex_not_only_idiom_uppercase_safe_fails_root_comment_mock_dir _codex_not_only_idiom_uppercase_safe_fails_root_comment_output _codex_not_only_idiom_uppercase_safe_fails_root_comment_exit
 
 # "unable to" wasn't in CODEX_NEGATION_WORDS at all, so "I am unable to
 # approve this change" wasn't recognized as a rejection while an earlier
@@ -5616,8 +5748,19 @@ unset _codex_blockquoted_clean_phrase_not_approved_root_comment_mock_dir _codex_
 # NEEDS_REVISION for an actually-clean review (fresh evidence from PR
 # #1490 finding 3793367887). codex_response_is_blocking now shares the
 # same codex_strip_quoted_spans normalization as the approval checks.
-_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir="$(mktemp -d)"
-cat > "$_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir/gh" <<'CODEX_QUOTED_BLOCKER_TOKEN_STAYS_APPROVED_ROOT_COMMENT_GH'
+#
+# Retargeted and renamed for issue #1491's conservative-verdict-classifier
+# redesign: this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-
+# body exact template, so it now correctly safe-fails to NEEDS_REVISION.
+# The property this scenario actually tests — that the quoted "must fix"
+# token does not cause a false blocking verdict — is unaffected:
+# codex_response_is_blocking (Decision 4, unchanged) still quote-strips
+# before matching and still correctly does not classify this body as
+# blocking; the composed verdict now reaches the unrecognized-format
+# safe-fail instead of APPROVED, never the blocking branch. Renamed from
+# "...stays_approved_..." per the plan's naming standing rule.
+_codex_quoted_blocker_token_safe_fails_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_quoted_blocker_token_safe_fails_root_comment_mock_dir/gh" <<'CODEX_QUOTED_BLOCKER_TOKEN_SAFE_FAILS_ROOT_COMMENT_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
@@ -5640,21 +5783,21 @@ case "$*" in
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_QUOTED_BLOCKER_TOKEN_STAYS_APPROVED_ROOT_COMMENT_GH
-chmod +x "$_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir/gh"
+CODEX_QUOTED_BLOCKER_TOKEN_SAFE_FAILS_ROOT_COMMENT_GH
+chmod +x "$_codex_quoted_blocker_token_safe_fails_root_comment_mock_dir/gh"
 
-_codex_quoted_blocker_token_stays_approved_root_comment_output=""
-_codex_quoted_blocker_token_stays_approved_root_comment_exit=0
-PATH="$_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir:$PATH" \
+_codex_quoted_blocker_token_safe_fails_root_comment_output=""
+_codex_quoted_blocker_token_safe_fails_root_comment_exit=0
+PATH="$_codex_quoted_blocker_token_safe_fails_root_comment_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_quoted_blocker_token_stays_approved_root_comment_exit=$?
-_codex_quoted_blocker_token_stays_approved_root_comment_output="$(cat "$_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir/output.txt")"
-run_test "codex_quoted_blocker_token_stays_approved_root_comment_exit_clean" "0" "$_codex_quoted_blocker_token_stays_approved_root_comment_exit"
-run_test "codex_quoted_blocker_token_stays_approved_root_comment_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_quoted_blocker_token_stays_approved_root_comment_output" | grep "^VERDICT:")"
-rm -rf "$_codex_quoted_blocker_token_stays_approved_root_comment_mock_dir"
-unset _codex_quoted_blocker_token_stays_approved_root_comment_mock_dir _codex_quoted_blocker_token_stays_approved_root_comment_output _codex_quoted_blocker_token_stays_approved_root_comment_exit
+  >"$_codex_quoted_blocker_token_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_quoted_blocker_token_safe_fails_root_comment_exit=$?
+_codex_quoted_blocker_token_safe_fails_root_comment_output="$(cat "$_codex_quoted_blocker_token_safe_fails_root_comment_mock_dir/output.txt")"
+run_test "codex_quoted_blocker_token_safe_fails_root_comment_exit_clean" "1" "$_codex_quoted_blocker_token_safe_fails_root_comment_exit"
+run_test "codex_quoted_blocker_token_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_quoted_blocker_token_safe_fails_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_quoted_blocker_token_safe_fails_root_comment_mock_dir"
+unset _codex_quoted_blocker_token_safe_fails_root_comment_mock_dir _codex_quoted_blocker_token_safe_fails_root_comment_output _codex_quoted_blocker_token_safe_fails_root_comment_exit
 
 # codex_response_is_blocking briefly gained the same fence-marker bail-out
 # used by is_usage_limit/is_environment_error/is_approved (applied "for
@@ -6348,8 +6491,19 @@ unset _codex_cannot_be_merged_blocking_root_comment_mock_dir _codex_cannot_be_me
 # misread as targeting a LATER, unrelated mention of "merge": a genuinely
 # clean review that discusses an unrelated negation before a separate
 # instruction to merge must still classify as approved.
-_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir="$(mktemp -d)"
-cat > "$_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir/gh" <<'CODEX_UNRELATED_NEGATION_BEFORE_MERGE_STAYS_APPROVED_ROOT_COMMENT_GH'
+#
+# Retargeted and renamed for issue #1491's conservative-verdict-classifier
+# redesign: this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-
+# body exact template, so it now correctly safe-fails to NEEDS_REVISION.
+# The property this scenario actually tests — that the unrelated earlier
+# negation does not cause a false merge-refusal blocking verdict — is
+# unaffected: CODEX_MERGE_REFUSAL_PATTERN and codex_response_is_blocking
+# (Decision 4, unchanged) still correctly do not classify this body as
+# blocking; the composed verdict now reaches the unrecognized-format
+# safe-fail instead of APPROVED, never the blocking branch. Renamed from
+# "...stays_approved_..." per the plan's naming standing rule.
+_codex_unrelated_negation_before_merge_safe_fails_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_unrelated_negation_before_merge_safe_fails_root_comment_mock_dir/gh" <<'CODEX_UNRELATED_NEGATION_BEFORE_MERGE_SAFE_FAILS_ROOT_COMMENT_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
@@ -6372,21 +6526,21 @@ case "$*" in
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_UNRELATED_NEGATION_BEFORE_MERGE_STAYS_APPROVED_ROOT_COMMENT_GH
-chmod +x "$_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir/gh"
+CODEX_UNRELATED_NEGATION_BEFORE_MERGE_SAFE_FAILS_ROOT_COMMENT_GH
+chmod +x "$_codex_unrelated_negation_before_merge_safe_fails_root_comment_mock_dir/gh"
 
-_codex_unrelated_negation_before_merge_stays_approved_root_comment_output=""
-_codex_unrelated_negation_before_merge_stays_approved_root_comment_exit=0
-PATH="$_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir:$PATH" \
+_codex_unrelated_negation_before_merge_safe_fails_root_comment_output=""
+_codex_unrelated_negation_before_merge_safe_fails_root_comment_exit=0
+PATH="$_codex_unrelated_negation_before_merge_safe_fails_root_comment_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_unrelated_negation_before_merge_stays_approved_root_comment_exit=$?
-_codex_unrelated_negation_before_merge_stays_approved_root_comment_output="$(cat "$_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir/output.txt")"
-run_test "codex_unrelated_negation_before_merge_stays_approved_root_comment_exit_clean" "0" "$_codex_unrelated_negation_before_merge_stays_approved_root_comment_exit"
-run_test "codex_unrelated_negation_before_merge_stays_approved_root_comment_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_unrelated_negation_before_merge_stays_approved_root_comment_output" | grep "^VERDICT:")"
-rm -rf "$_codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir"
-unset _codex_unrelated_negation_before_merge_stays_approved_root_comment_mock_dir _codex_unrelated_negation_before_merge_stays_approved_root_comment_output _codex_unrelated_negation_before_merge_stays_approved_root_comment_exit
+  >"$_codex_unrelated_negation_before_merge_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_unrelated_negation_before_merge_safe_fails_root_comment_exit=$?
+_codex_unrelated_negation_before_merge_safe_fails_root_comment_output="$(cat "$_codex_unrelated_negation_before_merge_safe_fails_root_comment_mock_dir/output.txt")"
+run_test "codex_unrelated_negation_before_merge_safe_fails_root_comment_exit_clean" "1" "$_codex_unrelated_negation_before_merge_safe_fails_root_comment_exit"
+run_test "codex_unrelated_negation_before_merge_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_unrelated_negation_before_merge_safe_fails_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_unrelated_negation_before_merge_safe_fails_root_comment_mock_dir"
+unset _codex_unrelated_negation_before_merge_safe_fails_root_comment_mock_dir _codex_unrelated_negation_before_merge_safe_fails_root_comment_output _codex_unrelated_negation_before_merge_safe_fails_root_comment_exit
 
 # CODEX_NEGATION_WORDS was missing "shouldn't"/"should not" and
 # "mustn't"/"must not" entirely, so neither the generalized
@@ -6451,8 +6605,21 @@ unset _codex_shouldnt_be_merged_blocking_root_comment_mock_dir _codex_shouldnt_b
 # review (fresh evidence from PR #1490 finding 3799277922).
 # codex_response_is_blocking now applies codex_strip_not_only_idiom the
 # same way codex_response_is_approved already does.
-_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir="$(mktemp -d)"
-cat > "$_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir/gh" <<'CODEX_NOT_ONLY_SAFE_TO_MERGE_STAYS_APPROVED_ROOT_COMMENT_GH'
+#
+# Retargeted and renamed for issue #1491's conservative-verdict-classifier
+# redesign: this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-
+# body exact template, so it now correctly safe-fails to NEEDS_REVISION.
+# This scenario's real coverage — that codex_strip_not_only_idiom's call
+# inside codex_response_is_blocking is load-bearing (Decision 4) and still
+# correctly prevents this "not only ... merge" idiom from being misread as
+# a merge refusal — is unaffected: is_blocking is unchanged by this plan
+# and codex_strip_not_only_idiom keeps both its definition and its one
+# real call site there. The composed verdict now reaches the
+# unrecognized-format safe-fail instead of APPROVED, never the blocking
+# branch. Renamed from "...stays_approved_..." per the plan's naming
+# standing rule.
+_codex_not_only_safe_to_merge_safe_fails_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_not_only_safe_to_merge_safe_fails_root_comment_mock_dir/gh" <<'CODEX_NOT_ONLY_SAFE_TO_MERGE_SAFE_FAILS_ROOT_COMMENT_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
@@ -6475,21 +6642,21 @@ case "$*" in
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_NOT_ONLY_SAFE_TO_MERGE_STAYS_APPROVED_ROOT_COMMENT_GH
-chmod +x "$_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir/gh"
+CODEX_NOT_ONLY_SAFE_TO_MERGE_SAFE_FAILS_ROOT_COMMENT_GH
+chmod +x "$_codex_not_only_safe_to_merge_safe_fails_root_comment_mock_dir/gh"
 
-_codex_not_only_safe_to_merge_stays_approved_root_comment_output=""
-_codex_not_only_safe_to_merge_stays_approved_root_comment_exit=0
-PATH="$_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir:$PATH" \
+_codex_not_only_safe_to_merge_safe_fails_root_comment_output=""
+_codex_not_only_safe_to_merge_safe_fails_root_comment_exit=0
+PATH="$_codex_not_only_safe_to_merge_safe_fails_root_comment_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_not_only_safe_to_merge_stays_approved_root_comment_exit=$?
-_codex_not_only_safe_to_merge_stays_approved_root_comment_output="$(cat "$_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir/output.txt")"
-run_test "codex_not_only_safe_to_merge_stays_approved_root_comment_exit_clean" "0" "$_codex_not_only_safe_to_merge_stays_approved_root_comment_exit"
-run_test "codex_not_only_safe_to_merge_stays_approved_root_comment_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_not_only_safe_to_merge_stays_approved_root_comment_output" | grep "^VERDICT:")"
-rm -rf "$_codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir"
-unset _codex_not_only_safe_to_merge_stays_approved_root_comment_mock_dir _codex_not_only_safe_to_merge_stays_approved_root_comment_output _codex_not_only_safe_to_merge_stays_approved_root_comment_exit
+  >"$_codex_not_only_safe_to_merge_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_not_only_safe_to_merge_safe_fails_root_comment_exit=$?
+_codex_not_only_safe_to_merge_safe_fails_root_comment_output="$(cat "$_codex_not_only_safe_to_merge_safe_fails_root_comment_mock_dir/output.txt")"
+run_test "codex_not_only_safe_to_merge_safe_fails_root_comment_exit_clean" "1" "$_codex_not_only_safe_to_merge_safe_fails_root_comment_exit"
+run_test "codex_not_only_safe_to_merge_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_not_only_safe_to_merge_safe_fails_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_not_only_safe_to_merge_safe_fails_root_comment_mock_dir"
+unset _codex_not_only_safe_to_merge_safe_fails_root_comment_mock_dir _codex_not_only_safe_to_merge_safe_fails_root_comment_output _codex_not_only_safe_to_merge_safe_fails_root_comment_exit
 
 # CODEX_NEGATION_WORDS was missing "would not"/"wouldn't" — the fourth
 # consecutive missing-negation-word finding (don't, should/mustn't, now
@@ -6550,8 +6717,19 @@ unset _codex_wouldnt_approve_not_approved_root_comment_mock_dir _codex_wouldnt_a
 # the separate "looks good" target later in the same unpunctuated
 # sentence. This test guards against that specific regression being
 # silently reintroduced by a future negation-word addition.
-_codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir="$(mktemp -d)"
-cat > "$_codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir/gh" <<'CODEX_DIDNT_FIND_ISSUES_AND_LOOKS_GOOD_APPROVED_ROOT_COMMENT_GH'
+#
+# Retargeted and renamed for issue #1491's conservative-verdict-classifier
+# redesign: this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-
+# body exact template (it has no "Swish!" sentence and no vendor footer),
+# so it now correctly safe-fails to NEEDS_REVISION. CODEX_NEGATION_WORDS'
+# "didn't"-exclusion property this scenario originally regression-tested
+# is unaffected — CODEX_NEGATION_WORDS is kept unchanged (Decision 4) and
+# still excludes "didn't" for the same reason, now guarding
+# CODEX_MERGE_REFUSAL_PATTERN inside codex_response_is_blocking instead of
+# the deleted negated-approval pattern. Renamed from "..._approved_..."
+# per the plan's naming standing rule.
+_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_mock_dir/gh" <<'CODEX_DIDNT_FIND_ISSUES_AND_LOOKS_GOOD_SAFE_FAILS_ROOT_COMMENT_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
@@ -6574,21 +6752,21 @@ case "$*" in
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_DIDNT_FIND_ISSUES_AND_LOOKS_GOOD_APPROVED_ROOT_COMMENT_GH
-chmod +x "$_codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir/gh"
+CODEX_DIDNT_FIND_ISSUES_AND_LOOKS_GOOD_SAFE_FAILS_ROOT_COMMENT_GH
+chmod +x "$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_mock_dir/gh"
 
-_codex_didnt_find_issues_and_looks_good_approved_root_comment_output=""
-_codex_didnt_find_issues_and_looks_good_approved_root_comment_exit=0
-PATH="$_codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir:$PATH" \
+_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_output=""
+_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_exit=0
+PATH="$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_didnt_find_issues_and_looks_good_approved_root_comment_exit=$?
-_codex_didnt_find_issues_and_looks_good_approved_root_comment_output="$(cat "$_codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir/output.txt")"
-run_test "codex_didnt_find_issues_and_looks_good_approved_root_comment_exit_clean" "0" "$_codex_didnt_find_issues_and_looks_good_approved_root_comment_exit"
-run_test "codex_didnt_find_issues_and_looks_good_approved_root_comment_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_didnt_find_issues_and_looks_good_approved_root_comment_output" | grep "^VERDICT:")"
-rm -rf "$_codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir"
-unset _codex_didnt_find_issues_and_looks_good_approved_root_comment_mock_dir _codex_didnt_find_issues_and_looks_good_approved_root_comment_output _codex_didnt_find_issues_and_looks_good_approved_root_comment_exit
+  >"$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_exit=$?
+_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_output="$(cat "$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_mock_dir/output.txt")"
+run_test "codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_exit_clean" "1" "$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_exit"
+run_test "codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_mock_dir"
+unset _codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_mock_dir _codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_output _codex_didnt_find_issues_and_looks_good_safe_fails_root_comment_exit
 
 # codex_strip_quoted_spans handled straight-double-quotes, backticks, and
 # blockquotes, but not single-quoted spans — the fourth quoting style
@@ -6642,6 +6820,14 @@ unset _codex_single_quoted_phrase_not_approved_root_comment_mock_dir _codex_sing
 # apostrophe in "it's"), corrupting a genuinely clean review by deleting
 # everything between them. The stricter whitespace/punctuation-boundary
 # requirement must leave contractions untouched.
+#
+# Retargeted for issue #1491's conservative-verdict-classifier redesign:
+# this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-body exact
+# template, so it now correctly safe-fails to NEEDS_REVISION. is_approved
+# no longer calls codex_strip_quoted_spans at all (Decision 1), so this
+# scenario no longer has a live approval-path mechanism to regression-test
+# for contraction-mangling; codex_strip_quoted_spans itself is unchanged
+# and still used by codex_response_is_blocking.
 _codex_contraction_apostrophes_not_mangled_root_comment_mock_dir="$(mktemp -d)"
 cat > "$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir/gh" <<'CODEX_CONTRACTION_APOSTROPHES_NOT_MANGLED_ROOT_COMMENT_GH'
 #!/usr/bin/env bash
@@ -6676,8 +6862,8 @@ PATH="$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir/output.txt" 2>&1 || _codex_contraction_apostrophes_not_mangled_root_comment_exit=$?
 _codex_contraction_apostrophes_not_mangled_root_comment_output="$(cat "$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir/output.txt")"
-run_test "codex_contraction_apostrophes_not_mangled_root_comment_exit_clean" "0" "$_codex_contraction_apostrophes_not_mangled_root_comment_exit"
-run_test "codex_contraction_apostrophes_not_mangled_root_comment_verdict" "VERDICT: APPROVED" \
+run_test "codex_contraction_apostrophes_not_mangled_root_comment_exit_clean" "1" "$_codex_contraction_apostrophes_not_mangled_root_comment_exit"
+run_test "codex_contraction_apostrophes_not_mangled_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
   "$(printf '%s\n' "$_codex_contraction_apostrophes_not_mangled_root_comment_output" | grep "^VERDICT:")"
 rm -rf "$_codex_contraction_apostrophes_not_mangled_root_comment_mock_dir"
 unset _codex_contraction_apostrophes_not_mangled_root_comment_mock_dir _codex_contraction_apostrophes_not_mangled_root_comment_output _codex_contraction_apostrophes_not_mangled_root_comment_exit
@@ -6892,8 +7078,19 @@ unset _codex_tilde_fence_phrase_not_approved_root_comment_mock_dir _codex_tilde_
 # legitimate review comments and must not be swept up by the new
 # conservative fence heuristic, which is deliberately scoped to
 # multi-backtick/tilde FENCE markers only.
-_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir="$(mktemp -d)"
-cat > "$_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir/gh" <<'CODEX_INLINE_BACKTICK_PAIR_STAYS_APPROVED_ROOT_COMMENT_GH'
+#
+# Retargeted and renamed for issue #1491's conservative-verdict-classifier
+# redesign: this body does not reproduce CODEX_APPROVED_TEMPLATES' whole-
+# body exact template, so it now correctly safe-fails to NEEDS_REVISION.
+# is_approved no longer calls codex_response_has_fence_marker at all
+# (Decision 1), so this scenario no longer has a live approval-path
+# mechanism to regression-test for inline-backtick-pair false rejection;
+# codex_response_has_fence_marker itself is unchanged and still used by
+# codex_response_is_usage_limit and codex_response_is_environment_error.
+# Renamed from "...stays_approved_..." per the plan's naming standing
+# rule.
+_codex_inline_backtick_pair_safe_fails_root_comment_mock_dir="$(mktemp -d)"
+cat > "$_codex_inline_backtick_pair_safe_fails_root_comment_mock_dir/gh" <<'CODEX_INLINE_BACKTICK_PAIR_SAFE_FAILS_ROOT_COMMENT_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
@@ -6916,21 +7113,21 @@ case "$*" in
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_INLINE_BACKTICK_PAIR_STAYS_APPROVED_ROOT_COMMENT_GH
-chmod +x "$_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir/gh"
+CODEX_INLINE_BACKTICK_PAIR_SAFE_FAILS_ROOT_COMMENT_GH
+chmod +x "$_codex_inline_backtick_pair_safe_fails_root_comment_mock_dir/gh"
 
-_codex_inline_backtick_pair_stays_approved_root_comment_output=""
-_codex_inline_backtick_pair_stays_approved_root_comment_exit=0
-PATH="$_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir:$PATH" \
+_codex_inline_backtick_pair_safe_fails_root_comment_output=""
+_codex_inline_backtick_pair_safe_fails_root_comment_exit=0
+PATH="$_codex_inline_backtick_pair_safe_fails_root_comment_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir/output.txt" 2>&1 || _codex_inline_backtick_pair_stays_approved_root_comment_exit=$?
-_codex_inline_backtick_pair_stays_approved_root_comment_output="$(cat "$_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir/output.txt")"
-run_test "codex_inline_backtick_pair_stays_approved_root_comment_exit_clean" "0" "$_codex_inline_backtick_pair_stays_approved_root_comment_exit"
-run_test "codex_inline_backtick_pair_stays_approved_root_comment_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_inline_backtick_pair_stays_approved_root_comment_output" | grep "^VERDICT:")"
-rm -rf "$_codex_inline_backtick_pair_stays_approved_root_comment_mock_dir"
-unset _codex_inline_backtick_pair_stays_approved_root_comment_mock_dir _codex_inline_backtick_pair_stays_approved_root_comment_output _codex_inline_backtick_pair_stays_approved_root_comment_exit
+  >"$_codex_inline_backtick_pair_safe_fails_root_comment_mock_dir/output.txt" 2>&1 || _codex_inline_backtick_pair_safe_fails_root_comment_exit=$?
+_codex_inline_backtick_pair_safe_fails_root_comment_output="$(cat "$_codex_inline_backtick_pair_safe_fails_root_comment_mock_dir/output.txt")"
+run_test "codex_inline_backtick_pair_safe_fails_root_comment_exit_clean" "1" "$_codex_inline_backtick_pair_safe_fails_root_comment_exit"
+run_test "codex_inline_backtick_pair_safe_fails_root_comment_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_inline_backtick_pair_safe_fails_root_comment_output" | grep "^VERDICT:")"
+rm -rf "$_codex_inline_backtick_pair_safe_fails_root_comment_mock_dir"
+unset _codex_inline_backtick_pair_safe_fails_root_comment_mock_dir _codex_inline_backtick_pair_safe_fails_root_comment_output _codex_inline_backtick_pair_safe_fails_root_comment_exit
 
 # The fence-marker guard was added to codex_response_is_approved only,
 # but codex_response_is_usage_limit's own callers (the 4 top-level
@@ -7097,7 +7294,7 @@ case "$*" in
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/reviews"*)
     printf '[{"submitted_at":"2026-01-01T00:00:01Z","commit_id":"abclatestre1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"Blocking issues: old finding."}]\n'
-    printf '[{"submitted_at":"2026-01-01T00:00:02Z","commit_id":"abclatestre1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    jq -nc '[{submitted_at:"2026-01-01T00:00:02Z",commit_id:"abclatestre1234567890",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `eeeeeeeeee` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *"issues/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
@@ -7275,7 +7472,7 @@ case "$*" in
   *"pulls/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/reviews"*)
-    printf '[{"submitted_at":"2026-01-01T00:00:02Z","commit_id":"abcenvok1234567890","user":{"login":"chatgpt-codex-connector[bot]"},"body":"No blocking issues found."}]\n'
+    jq -nc '[{submitted_at:"2026-01-01T00:00:02Z",commit_id:"abcenvok1234567890",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `ffffffffff` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *"issues/"*"/comments"*)
     printf '[{"id":207,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector"},"body":"To use Codex here, create an environment for this repo."}]\n'
@@ -7599,6 +7796,1429 @@ run_test "codex_same_second_root_comment_reason" "REASON=codex-github-environmen
   "$(printf '%s\n' "$_codex_same_second_root_comment_output" | grep "^REASON=")"
 rm -rf "$_codex_same_second_root_comment_mock_dir"
 unset _codex_same_second_root_comment_mock_dir _codex_same_second_root_comment_output _codex_same_second_root_comment_exit
+
+# ---------------------------------------------------------------------------
+# New scenarios for issue #1491's conservative-verdict-classifier
+# implementation plan — Parser-risk addendum edge cases E1-E24 (E4 and E14
+# already covered: E4 by the two Group APPROVED template-anchored members'
+# distinct SHAs; E14 by the pre-existing codex_unapproved_prefix_root_comment
+# above) — plus the four Decision-6 verdict-site near-miss scenarios.
+# ---------------------------------------------------------------------------
+# Parser-risk addendum E1 (issue #1491's implementation plan): the real
+# captured PR #1489 root comment, in full, including its real <details>
+# footer, verbatim. The anchor case for the classifier's primary
+# real-response template.
+_codex_e1_real_pr1489_capture_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e1_real_pr1489_capture_approved_mock_dir/gh" <<'CODEX_E1_REAL_PR1489_CAPTURE_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf '87aaefceff1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":400,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:401,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish!
+
+**Reviewed commit:** `87aaefceff`
+
+<details> <summary>ℹ️ About Codex in GitHub</summary>
+<br/>
+
+[Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you
+- Open a pull request for review
+- Mark a draft as ready
+- Comment \"@codex review\".
+
+If Codex has suggestions, it will comment; otherwise it will react with 👍.
+
+
+
+
+Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\".
+            
+</details>
+")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E1_REAL_PR1489_CAPTURE_APPROVED_GH
+chmod +x "$_codex_e1_real_pr1489_capture_approved_mock_dir/gh"
+
+_codex_e1_real_pr1489_capture_approved_output=""
+_codex_e1_real_pr1489_capture_approved_exit=0
+PATH="$_codex_e1_real_pr1489_capture_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e1_real_pr1489_capture_approved_mock_dir/output.txt" 2>&1 || _codex_e1_real_pr1489_capture_approved_exit=$?
+_codex_e1_real_pr1489_capture_approved_output="$(cat "$_codex_e1_real_pr1489_capture_approved_mock_dir/output.txt")"
+run_test "codex_e1_real_pr1489_capture_approved_exit_clean" "0" "$_codex_e1_real_pr1489_capture_approved_exit"
+run_test "codex_e1_real_pr1489_capture_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_e1_real_pr1489_capture_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e1_real_pr1489_capture_approved_mock_dir"
+unset _codex_e1_real_pr1489_capture_approved_mock_dir _codex_e1_real_pr1489_capture_approved_output _codex_e1_real_pr1489_capture_approved_exit
+
+# Parser-risk addendum E2 (issue #1491's implementation plan): a real
+# captured PR #1490 review body, in full, verbatim. Confirms the generic
+# review-submission wrapper — no clean-signal text — correctly never
+# matches; verdict is driven by review `state`, not this function
+# (Decision 3). Review-sourced: always terminal by construction.
+_codex_e2_real_pr1490_review_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e2_real_pr1490_review_not_approved_mock_dir/gh" <<'CODEX_E2_REAL_PR1490_REVIEW_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e2e2e2e2e2e2\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":401,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"e2e2e2e2e2e2",user:{login:"chatgpt-codex-connector[bot]"},state:"COMMENTED",body:("### 💡 Codex Review
+
+Here are some automated review suggestions for this pull request.
+
+**Reviewed commit:** `6b70f9b229`
+    
+
+<details> <summary>ℹ️ About Codex in GitHub</summary>
+<br/>
+
+[Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you
+- Open a pull request for review
+- Mark a draft as ready
+- Comment \"@codex review\".
+
+If Codex has suggestions, it will comment; otherwise it will react with 👍.
+
+
+
+
+Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\".
+            
+</details>")}]'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E2_REAL_PR1490_REVIEW_NOT_APPROVED_GH
+chmod +x "$_codex_e2_real_pr1490_review_not_approved_mock_dir/gh"
+
+_codex_e2_real_pr1490_review_not_approved_output=""
+_codex_e2_real_pr1490_review_not_approved_exit=0
+PATH="$_codex_e2_real_pr1490_review_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e2_real_pr1490_review_not_approved_mock_dir/output.txt" 2>&1 || _codex_e2_real_pr1490_review_not_approved_exit=$?
+_codex_e2_real_pr1490_review_not_approved_output="$(cat "$_codex_e2_real_pr1490_review_not_approved_mock_dir/output.txt")"
+run_test "codex_e2_real_pr1490_review_not_approved_exit_needs_revision" "1" "$_codex_e2_real_pr1490_review_not_approved_exit"
+run_test "codex_e2_real_pr1490_review_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e2_real_pr1490_review_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e2_real_pr1490_review_not_approved_mock_dir"
+unset _codex_e2_real_pr1490_review_not_approved_mock_dir _codex_e2_real_pr1490_review_not_approved_output _codex_e2_real_pr1490_review_not_approved_exit
+
+# Parser-risk addendum E3 (issue #1491's implementation plan): the real
+# template's opening sentence, Reviewed-commit marker, and complete real
+# footer, but WITHOUT "Swish!". The template has no optional clauses —
+# a response missing the evidenced flavor sentence does not reproduce it,
+# however close it looks, including when the rest of the body (footer
+# included) is otherwise exact.
+_codex_e3_missing_swish_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e3_missing_swish_not_approved_mock_dir/gh" <<'CODEX_E3_MISSING_SWISH_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e3e3e3e3e3e3\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":402,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:403,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. **Reviewed commit:** `e3e3e3e3e3` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E3_MISSING_SWISH_NOT_APPROVED_GH
+chmod +x "$_codex_e3_missing_swish_not_approved_mock_dir/gh"
+
+_codex_e3_missing_swish_not_approved_output=""
+_codex_e3_missing_swish_not_approved_exit=0
+PATH="$_codex_e3_missing_swish_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e3_missing_swish_not_approved_mock_dir/output.txt" 2>&1 || _codex_e3_missing_swish_not_approved_exit=$?
+_codex_e3_missing_swish_not_approved_output="$(cat "$_codex_e3_missing_swish_not_approved_mock_dir/output.txt")"
+run_test "codex_e3_missing_swish_not_approved_exit_needs_revision" "1" "$_codex_e3_missing_swish_not_approved_exit"
+run_test "codex_e3_missing_swish_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e3_missing_swish_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e3_missing_swish_not_approved_mock_dir"
+unset _codex_e3_missing_swish_not_approved_mock_dir _codex_e3_missing_swish_not_approved_output _codex_e3_missing_swish_not_approved_exit
+
+# Parser-risk addendum E5 (issue #1491's implementation plan): the real
+# template with a 6-character SHA plus the complete real footer — below
+# the {7,40} bound. Review-sourced: a malformed SHA never becomes
+# terminal evidence via the root-comment extraction path, so this case
+# is constructed as a review (pinned via the API's own commit_id field,
+# independent of the body text) to isolate what the classifier itself
+# does with the malformed value.
+_codex_e5_short_sha_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e5_short_sha_not_approved_mock_dir/gh" <<'CODEX_E5_SHORT_SHA_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e5e5e5e5e5e5\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":403,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"e5e5e5e5e5e5",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `abcdef` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E5_SHORT_SHA_NOT_APPROVED_GH
+chmod +x "$_codex_e5_short_sha_not_approved_mock_dir/gh"
+
+_codex_e5_short_sha_not_approved_output=""
+_codex_e5_short_sha_not_approved_exit=0
+PATH="$_codex_e5_short_sha_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e5_short_sha_not_approved_mock_dir/output.txt" 2>&1 || _codex_e5_short_sha_not_approved_exit=$?
+_codex_e5_short_sha_not_approved_output="$(cat "$_codex_e5_short_sha_not_approved_mock_dir/output.txt")"
+run_test "codex_e5_short_sha_not_approved_exit_needs_revision" "1" "$_codex_e5_short_sha_not_approved_exit"
+run_test "codex_e5_short_sha_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e5_short_sha_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e5_short_sha_not_approved_mock_dir"
+unset _codex_e5_short_sha_not_approved_mock_dir _codex_e5_short_sha_not_approved_output _codex_e5_short_sha_not_approved_exit
+
+# Parser-risk addendum E6 (issue #1491's implementation plan): the real
+# template with a 41-character SHA plus the complete real footer — above
+# the {7,40} bound (one past a full SHA-1). Review-sourced, same reason
+# as E5.
+_codex_e6_oversized_sha_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e6_oversized_sha_not_approved_mock_dir/gh" <<'CODEX_E6_OVERSIZED_SHA_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e6e6e6e6e6e6\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":404,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"e6e6e6e6e6e6",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E6_OVERSIZED_SHA_NOT_APPROVED_GH
+chmod +x "$_codex_e6_oversized_sha_not_approved_mock_dir/gh"
+
+_codex_e6_oversized_sha_not_approved_output=""
+_codex_e6_oversized_sha_not_approved_exit=0
+PATH="$_codex_e6_oversized_sha_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e6_oversized_sha_not_approved_mock_dir/output.txt" 2>&1 || _codex_e6_oversized_sha_not_approved_exit=$?
+_codex_e6_oversized_sha_not_approved_output="$(cat "$_codex_e6_oversized_sha_not_approved_mock_dir/output.txt")"
+run_test "codex_e6_oversized_sha_not_approved_exit_needs_revision" "1" "$_codex_e6_oversized_sha_not_approved_exit"
+run_test "codex_e6_oversized_sha_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e6_oversized_sha_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e6_oversized_sha_not_approved_mock_dir"
+unset _codex_e6_oversized_sha_not_approved_mock_dir _codex_e6_oversized_sha_not_approved_output _codex_e6_oversized_sha_not_approved_exit
+
+# Parser-risk addendum E7 (issue #1491's implementation plan): the real
+# template with a full-length (40-character) SHA plus the complete real
+# footer. Confirms the upper bound is inclusive, not an off-by-one
+# exclusion of legitimate full-length SHAs.
+_codex_e7_full_length_sha_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e7_full_length_sha_approved_mock_dir/gh" <<'CODEX_E7_FULL_LENGTH_SHA_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abababababababababababababababababababab\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":405,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:406,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `abababababababababababababababababababab` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E7_FULL_LENGTH_SHA_APPROVED_GH
+chmod +x "$_codex_e7_full_length_sha_approved_mock_dir/gh"
+
+_codex_e7_full_length_sha_approved_output=""
+_codex_e7_full_length_sha_approved_exit=0
+PATH="$_codex_e7_full_length_sha_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e7_full_length_sha_approved_mock_dir/output.txt" 2>&1 || _codex_e7_full_length_sha_approved_exit=$?
+_codex_e7_full_length_sha_approved_output="$(cat "$_codex_e7_full_length_sha_approved_mock_dir/output.txt")"
+run_test "codex_e7_full_length_sha_approved_exit_clean" "0" "$_codex_e7_full_length_sha_approved_exit"
+run_test "codex_e7_full_length_sha_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_e7_full_length_sha_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e7_full_length_sha_approved_mock_dir"
+unset _codex_e7_full_length_sha_approved_mock_dir _codex_e7_full_length_sha_approved_output _codex_e7_full_length_sha_approved_exit
+
+# Parser-risk addendum E8 (issue #1491's implementation plan): the real
+# template with a non-hex "SHA" plus the complete real footer. The
+# placeholder accepts hex digits only. Review-sourced, same reason as E5.
+_codex_e8_non_hex_sha_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e8_non_hex_sha_not_approved_mock_dir/gh" <<'CODEX_E8_NON_HEX_SHA_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e8e8e8e8e8e8\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":406,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"e8e8e8e8e8e8",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `not-a-sha!` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E8_NON_HEX_SHA_NOT_APPROVED_GH
+chmod +x "$_codex_e8_non_hex_sha_not_approved_mock_dir/gh"
+
+_codex_e8_non_hex_sha_not_approved_output=""
+_codex_e8_non_hex_sha_not_approved_exit=0
+PATH="$_codex_e8_non_hex_sha_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e8_non_hex_sha_not_approved_mock_dir/output.txt" 2>&1 || _codex_e8_non_hex_sha_not_approved_exit=$?
+_codex_e8_non_hex_sha_not_approved_output="$(cat "$_codex_e8_non_hex_sha_not_approved_mock_dir/output.txt")"
+run_test "codex_e8_non_hex_sha_not_approved_exit_needs_revision" "1" "$_codex_e8_non_hex_sha_not_approved_exit"
+run_test "codex_e8_non_hex_sha_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e8_non_hex_sha_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e8_non_hex_sha_not_approved_mock_dir"
+unset _codex_e8_non_hex_sha_not_approved_mock_dir _codex_e8_non_hex_sha_not_approved_output _codex_e8_non_hex_sha_not_approved_exit
+
+# Parser-risk addendum E9 (issue #1491's implementation plan): the real
+# template plus complete real footer, with unrelated prose immediately
+# BEFORE the verdict sentence. Exact match is whole-body, not a
+# substring/prefix test — extra leading text breaks the match.
+_codex_e9_leading_prose_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e9_leading_prose_not_approved_mock_dir/gh" <<'CODEX_E9_LEADING_PROSE_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e9e9e9e9e9e9\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":407,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:408,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("FYI: Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `e9e9e9e9e9` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E9_LEADING_PROSE_NOT_APPROVED_GH
+chmod +x "$_codex_e9_leading_prose_not_approved_mock_dir/gh"
+
+_codex_e9_leading_prose_not_approved_output=""
+_codex_e9_leading_prose_not_approved_exit=0
+PATH="$_codex_e9_leading_prose_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e9_leading_prose_not_approved_mock_dir/output.txt" 2>&1 || _codex_e9_leading_prose_not_approved_exit=$?
+_codex_e9_leading_prose_not_approved_output="$(cat "$_codex_e9_leading_prose_not_approved_mock_dir/output.txt")"
+run_test "codex_e9_leading_prose_not_approved_exit_needs_revision" "1" "$_codex_e9_leading_prose_not_approved_exit"
+run_test "codex_e9_leading_prose_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e9_leading_prose_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e9_leading_prose_not_approved_mock_dir"
+unset _codex_e9_leading_prose_not_approved_mock_dir _codex_e9_leading_prose_not_approved_output _codex_e9_leading_prose_not_approved_exit
+
+# Parser-risk addendum E10 (issue #1491's implementation plan): the real
+# template plus complete real footer, with unrelated prose immediately
+# AFTER </details>. Confirms no trailing-clause exploit of any kind can
+# reach APPROVED: any trailing content at all breaks the whole-body
+# match, regardless of wording or how much of the footer precedes it.
+_codex_e10_trailing_prose_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e10_trailing_prose_not_approved_mock_dir/gh" <<'CODEX_E10_TRAILING_PROSE_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e1010101010a\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":408,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:409,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `e1010101010` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details> Rename the unsafe function.")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E10_TRAILING_PROSE_NOT_APPROVED_GH
+chmod +x "$_codex_e10_trailing_prose_not_approved_mock_dir/gh"
+
+_codex_e10_trailing_prose_not_approved_output=""
+_codex_e10_trailing_prose_not_approved_exit=0
+PATH="$_codex_e10_trailing_prose_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e10_trailing_prose_not_approved_mock_dir/output.txt" 2>&1 || _codex_e10_trailing_prose_not_approved_exit=$?
+_codex_e10_trailing_prose_not_approved_output="$(cat "$_codex_e10_trailing_prose_not_approved_mock_dir/output.txt")"
+run_test "codex_e10_trailing_prose_not_approved_exit_needs_revision" "1" "$_codex_e10_trailing_prose_not_approved_exit"
+run_test "codex_e10_trailing_prose_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e10_trailing_prose_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e10_trailing_prose_not_approved_mock_dir"
+unset _codex_e10_trailing_prose_not_approved_mock_dir _codex_e10_trailing_prose_not_approved_output _codex_e10_trailing_prose_not_approved_exit
+
+# Parser-risk addendum E11 (issue #1491's implementation plan): the real
+# template plus complete real footer, wrapped in a fenced code block.
+# Confirms no dedicated fence-marker check is needed (Decision 1): the
+# fence characters are literal extra text the template does not
+# contain, so the match fails on its own.
+_codex_e11_fenced_wrapper_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e11_fenced_wrapper_not_approved_mock_dir/gh" <<'CODEX_E11_FENCED_WRAPPER_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e11e11e11e1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":409,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:410,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("```
+Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `e11e11e11e` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>
+```")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E11_FENCED_WRAPPER_NOT_APPROVED_GH
+chmod +x "$_codex_e11_fenced_wrapper_not_approved_mock_dir/gh"
+
+_codex_e11_fenced_wrapper_not_approved_output=""
+_codex_e11_fenced_wrapper_not_approved_exit=0
+PATH="$_codex_e11_fenced_wrapper_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e11_fenced_wrapper_not_approved_mock_dir/output.txt" 2>&1 || _codex_e11_fenced_wrapper_not_approved_exit=$?
+_codex_e11_fenced_wrapper_not_approved_output="$(cat "$_codex_e11_fenced_wrapper_not_approved_mock_dir/output.txt")"
+run_test "codex_e11_fenced_wrapper_not_approved_exit_needs_revision" "1" "$_codex_e11_fenced_wrapper_not_approved_exit"
+run_test "codex_e11_fenced_wrapper_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e11_fenced_wrapper_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e11_fenced_wrapper_not_approved_mock_dir"
+unset _codex_e11_fenced_wrapper_not_approved_mock_dir _codex_e11_fenced_wrapper_not_approved_output _codex_e11_fenced_wrapper_not_approved_exit
+
+# Parser-risk addendum E12 (issue #1491's implementation plan): the real
+# template with extra/irregular whitespace (extra spaces, tabs, multiple
+# blank lines, trailing spaces, extra whitespace around the footer).
+# Confirms codex_normalize_whitespace provides exactly the permitted
+# flexibility (Decision 1) and nothing more, across the entire body
+# including the footer.
+_codex_e12_irregular_whitespace_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e12_irregular_whitespace_approved_mock_dir/gh" <<'CODEX_E12_IRREGULAR_WHITESPACE_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e12e12e12e1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":410,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:411,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("  Codex Review:   Didn'\''t find any major issues.	 Swish!
+
+**Reviewed commit:**  `e12e12e12e`  <details>   <summary>ℹ️ About Codex in GitHub</summary>
+
+
+<br/>		[Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general).   Reviews are triggered when you
+  - Open a pull request for review
+  - Mark a draft as ready
+  - Comment \"@codex review\".
+
+
+If Codex has suggestions, it will comment; otherwise it will react with 👍.
+
+
+
+Codex can also answer questions or update the PR.   Try commenting
+\"@codex address that feedback\".   
+
+</details>   ")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E12_IRREGULAR_WHITESPACE_APPROVED_GH
+chmod +x "$_codex_e12_irregular_whitespace_approved_mock_dir/gh"
+
+_codex_e12_irregular_whitespace_approved_output=""
+_codex_e12_irregular_whitespace_approved_exit=0
+PATH="$_codex_e12_irregular_whitespace_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e12_irregular_whitespace_approved_mock_dir/output.txt" 2>&1 || _codex_e12_irregular_whitespace_approved_exit=$?
+_codex_e12_irregular_whitespace_approved_output="$(cat "$_codex_e12_irregular_whitespace_approved_mock_dir/output.txt")"
+run_test "codex_e12_irregular_whitespace_approved_exit_clean" "0" "$_codex_e12_irregular_whitespace_approved_exit"
+run_test "codex_e12_irregular_whitespace_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_e12_irregular_whitespace_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e12_irregular_whitespace_approved_mock_dir"
+unset _codex_e12_irregular_whitespace_approved_mock_dir _codex_e12_irregular_whitespace_approved_output _codex_e12_irregular_whitespace_approved_exit
+
+# Parser-risk addendum E13 (issue #1491's implementation plan): the real
+# template plus complete real footer, case-altered (lower-cased verdict
+# sentence and footer text). Confirms there is no case-insensitive
+# matching beyond what the captures themselves show (Decision 1),
+# for the footer as much as for the verdict sentence. Review-sourced,
+# same reason as E5 (a case-folded SHA is never extracted by the
+# case-sensitive root-comment path).
+_codex_e13_case_altered_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e13_case_altered_not_approved_mock_dir/gh" <<'CODEX_E13_CASE_ALTERED_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e13e13e13e1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":411,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"e13e13e13e1",user:{login:"chatgpt-codex-connector[bot]"},body:("codex review: didn'\''t find any major issues. swish! **reviewed commit:** `e13e13e13e` <details> <summary>ℹ️ about codex in github</summary> <br/> [your team has set up codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). reviews are triggered when you - open a pull request for review - mark a draft as ready - comment \"@codex review\". if codex has suggestions, it will comment; otherwise it will react with 👍. codex can also answer questions or update the pr. try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E13_CASE_ALTERED_NOT_APPROVED_GH
+chmod +x "$_codex_e13_case_altered_not_approved_mock_dir/gh"
+
+_codex_e13_case_altered_not_approved_output=""
+_codex_e13_case_altered_not_approved_exit=0
+PATH="$_codex_e13_case_altered_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e13_case_altered_not_approved_mock_dir/output.txt" 2>&1 || _codex_e13_case_altered_not_approved_exit=$?
+_codex_e13_case_altered_not_approved_output="$(cat "$_codex_e13_case_altered_not_approved_mock_dir/output.txt")"
+run_test "codex_e13_case_altered_not_approved_exit_needs_revision" "1" "$_codex_e13_case_altered_not_approved_exit"
+run_test "codex_e13_case_altered_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e13_case_altered_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e13_case_altered_not_approved_mock_dir"
+unset _codex_e13_case_altered_not_approved_mock_dir _codex_e13_case_altered_not_approved_output _codex_e13_case_altered_not_approved_exit
+
+# Parser-risk addendum E15 (issue #1491's implementation plan): an
+# underscore-variant boundary-lookalike construction — trivially
+# rejected under this design because it is not a reproduction of any
+# template.
+_codex_e15_underscore_variant_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e15_underscore_variant_not_approved_mock_dir/gh" <<'CODEX_E15_UNDERSCORE_VARIANT_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e15e15e15e1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":412,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:413,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("This remains un_approved.
+
+**Reviewed commit:** `e15e15e15e`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E15_UNDERSCORE_VARIANT_NOT_APPROVED_GH
+chmod +x "$_codex_e15_underscore_variant_not_approved_mock_dir/gh"
+
+_codex_e15_underscore_variant_not_approved_output=""
+_codex_e15_underscore_variant_not_approved_exit=0
+PATH="$_codex_e15_underscore_variant_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e15_underscore_variant_not_approved_mock_dir/output.txt" 2>&1 || _codex_e15_underscore_variant_not_approved_exit=$?
+_codex_e15_underscore_variant_not_approved_output="$(cat "$_codex_e15_underscore_variant_not_approved_mock_dir/output.txt")"
+run_test "codex_e15_underscore_variant_not_approved_exit_needs_revision" "1" "$_codex_e15_underscore_variant_not_approved_exit"
+run_test "codex_e15_underscore_variant_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e15_underscore_variant_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e15_underscore_variant_not_approved_mock_dir"
+unset _codex_e15_underscore_variant_not_approved_mock_dir _codex_e15_underscore_variant_not_approved_output _codex_e15_underscore_variant_not_approved_exit
+
+# Parser-risk addendum E16 (issue #1491's implementation plan):
+# disqualifier-list gap under an earlier design (Codex GitHub finding
+# `3800167486`) — now genuinely closed, because it was never a
+# reproduction of any template to begin with.
+_codex_e16_disqualifier_gap_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e16_disqualifier_gap_not_approved_mock_dir/gh" <<'CODEX_E16_DISQUALIFIER_GAP_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e16e16e16e1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":413,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:414,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Looks good. Remove the authentication check.
+
+**Reviewed commit:** `e16e16e16e`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E16_DISQUALIFIER_GAP_NOT_APPROVED_GH
+chmod +x "$_codex_e16_disqualifier_gap_not_approved_mock_dir/gh"
+
+_codex_e16_disqualifier_gap_not_approved_output=""
+_codex_e16_disqualifier_gap_not_approved_exit=0
+PATH="$_codex_e16_disqualifier_gap_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e16_disqualifier_gap_not_approved_mock_dir/output.txt" 2>&1 || _codex_e16_disqualifier_gap_not_approved_exit=$?
+_codex_e16_disqualifier_gap_not_approved_output="$(cat "$_codex_e16_disqualifier_gap_not_approved_mock_dir/output.txt")"
+run_test "codex_e16_disqualifier_gap_not_approved_exit_needs_revision" "1" "$_codex_e16_disqualifier_gap_not_approved_exit"
+run_test "codex_e16_disqualifier_gap_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e16_disqualifier_gap_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e16_disqualifier_gap_not_approved_mock_dir"
+unset _codex_e16_disqualifier_gap_not_approved_mock_dir _codex_e16_disqualifier_gap_not_approved_output _codex_e16_disqualifier_gap_not_approved_exit
+
+# Parser-risk addendum E17 (issue #1491's implementation plan): the
+# residual gap an earlier zero-tolerance-grammar design disclosed but
+# could not close — now genuinely closed, because it was never a
+# reproduction of any template to begin with.
+_codex_e17_zero_tolerance_gap_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e17_zero_tolerance_gap_not_approved_mock_dir/gh" <<'CODEX_E17_ZERO_TOLERANCE_GAP_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e17e17e17e1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":414,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:415,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Approved. Revert.
+
+**Reviewed commit:** `e17e17e17e`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E17_ZERO_TOLERANCE_GAP_NOT_APPROVED_GH
+chmod +x "$_codex_e17_zero_tolerance_gap_not_approved_mock_dir/gh"
+
+_codex_e17_zero_tolerance_gap_not_approved_output=""
+_codex_e17_zero_tolerance_gap_not_approved_exit=0
+PATH="$_codex_e17_zero_tolerance_gap_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e17_zero_tolerance_gap_not_approved_mock_dir/output.txt" 2>&1 || _codex_e17_zero_tolerance_gap_not_approved_exit=$?
+_codex_e17_zero_tolerance_gap_not_approved_output="$(cat "$_codex_e17_zero_tolerance_gap_not_approved_mock_dir/output.txt")"
+run_test "codex_e17_zero_tolerance_gap_not_approved_exit_needs_revision" "1" "$_codex_e17_zero_tolerance_gap_not_approved_exit"
+run_test "codex_e17_zero_tolerance_gap_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e17_zero_tolerance_gap_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e17_zero_tolerance_gap_not_approved_mock_dir"
+unset _codex_e17_zero_tolerance_gap_not_approved_mock_dir _codex_e17_zero_tolerance_gap_not_approved_output _codex_e17_zero_tolerance_gap_not_approved_exit
+
+# Parser-risk addendum E18 (issue #1491's implementation plan):
+# vendor-metadata-token gap under an earlier design (Codex GitHub
+# finding `3803050745`) — now genuinely closed, because it was never a
+# reproduction of any template to begin with.
+_codex_e18_vendor_flavor_token_gap_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e18_vendor_flavor_token_gap_not_approved_mock_dir/gh" <<'CODEX_E18_VENDOR_FLAVOR_TOKEN_GAP_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e18e18e18e1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":415,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:416,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Looks good. Commit this.
+
+**Reviewed commit:** `e18e18e18e`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E18_VENDOR_FLAVOR_TOKEN_GAP_NOT_APPROVED_GH
+chmod +x "$_codex_e18_vendor_flavor_token_gap_not_approved_mock_dir/gh"
+
+_codex_e18_vendor_flavor_token_gap_not_approved_output=""
+_codex_e18_vendor_flavor_token_gap_not_approved_exit=0
+PATH="$_codex_e18_vendor_flavor_token_gap_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e18_vendor_flavor_token_gap_not_approved_mock_dir/output.txt" 2>&1 || _codex_e18_vendor_flavor_token_gap_not_approved_exit=$?
+_codex_e18_vendor_flavor_token_gap_not_approved_output="$(cat "$_codex_e18_vendor_flavor_token_gap_not_approved_mock_dir/output.txt")"
+run_test "codex_e18_vendor_flavor_token_gap_not_approved_exit_needs_revision" "1" "$_codex_e18_vendor_flavor_token_gap_not_approved_exit"
+run_test "codex_e18_vendor_flavor_token_gap_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e18_vendor_flavor_token_gap_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e18_vendor_flavor_token_gap_not_approved_mock_dir"
+unset _codex_e18_vendor_flavor_token_gap_not_approved_mock_dir _codex_e18_vendor_flavor_token_gap_not_approved_output _codex_e18_vendor_flavor_token_gap_not_approved_exit
+
+# Parser-risk addendum E19 (issue #1491's implementation plan):
+# over-broad footer-truncation-regex gap under an earlier design
+# (Codex GitHub finding `3800167489`) — under this revision there is no
+# truncation step at all to over-match; the body simply does not
+# reproduce the one evidenced literal, regardless of what any
+# <details>-shaped text inside it says. Includes an explicit
+# **Reviewed commit:** marker (needed to reach terminal evidence).
+_codex_e19_non_vendor_details_block_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e19_non_vendor_details_block_not_approved_mock_dir/gh" <<'CODEX_E19_NON_VENDOR_DETAILS_BLOCK_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e19e19e19e1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":416,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:417,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Looks good. <details><summary>Notes</summary>Rename the unsafe function.</details>
+
+**Reviewed commit:** `e19e19e19e`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E19_NON_VENDOR_DETAILS_BLOCK_NOT_APPROVED_GH
+chmod +x "$_codex_e19_non_vendor_details_block_not_approved_mock_dir/gh"
+
+_codex_e19_non_vendor_details_block_not_approved_output=""
+_codex_e19_non_vendor_details_block_not_approved_exit=0
+PATH="$_codex_e19_non_vendor_details_block_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e19_non_vendor_details_block_not_approved_mock_dir/output.txt" 2>&1 || _codex_e19_non_vendor_details_block_not_approved_exit=$?
+_codex_e19_non_vendor_details_block_not_approved_output="$(cat "$_codex_e19_non_vendor_details_block_not_approved_mock_dir/output.txt")"
+run_test "codex_e19_non_vendor_details_block_not_approved_exit_needs_revision" "1" "$_codex_e19_non_vendor_details_block_not_approved_exit"
+run_test "codex_e19_non_vendor_details_block_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e19_non_vendor_details_block_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e19_non_vendor_details_block_not_approved_mock_dir"
+unset _codex_e19_non_vendor_details_block_not_approved_mock_dir _codex_e19_non_vendor_details_block_not_approved_output _codex_e19_non_vendor_details_block_not_approved_exit
+
+# Parser-risk addendum E20 (issue #1491's implementation plan):
+# tag-name-flexible footer-truncation-regex gap under an earlier design
+# (Codex GitHub finding `3803189273`) — same reason as E19: no
+# truncation step left to apply a tag-name pattern to. Includes an
+# explicit **Reviewed commit:** marker (needed to reach terminal
+# evidence).
+_codex_e20_tag_flexible_variant_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e20_tag_flexible_variant_not_approved_mock_dir/gh" <<'CODEX_E20_TAG_FLEXIBLE_VARIANT_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e20e20e20e1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":417,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:418,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Looks good. <details-not-footer><summary-note>About Codex in GitHub</summary-note>Rename the unsafe function.</details-not-footer>
+
+**Reviewed commit:** `e20e20e20e`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E20_TAG_FLEXIBLE_VARIANT_NOT_APPROVED_GH
+chmod +x "$_codex_e20_tag_flexible_variant_not_approved_mock_dir/gh"
+
+_codex_e20_tag_flexible_variant_not_approved_output=""
+_codex_e20_tag_flexible_variant_not_approved_exit=0
+PATH="$_codex_e20_tag_flexible_variant_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e20_tag_flexible_variant_not_approved_mock_dir/output.txt" 2>&1 || _codex_e20_tag_flexible_variant_not_approved_exit=$?
+_codex_e20_tag_flexible_variant_not_approved_output="$(cat "$_codex_e20_tag_flexible_variant_not_approved_mock_dir/output.txt")"
+run_test "codex_e20_tag_flexible_variant_not_approved_exit_needs_revision" "1" "$_codex_e20_tag_flexible_variant_not_approved_exit"
+run_test "codex_e20_tag_flexible_variant_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e20_tag_flexible_variant_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e20_tag_flexible_variant_not_approved_mock_dir"
+unset _codex_e20_tag_flexible_variant_not_approved_mock_dir _codex_e20_tag_flexible_variant_not_approved_output _codex_e20_tag_flexible_variant_not_approved_exit
+
+# Parser-risk addendum E21 (issue #1491's implementation plan):
+# filler-composed-hedge construction (Codex GitHub finding
+# `3803306915`) that motivated the third design of this classifier —
+# trivially rejected under this design because it is not a
+# reproduction of any template.
+_codex_e21_filler_composed_hedge_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e21_filler_composed_hedge_not_approved_mock_dir/gh" <<'CODEX_E21_FILLER_COMPOSED_HEDGE_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e21e21e21e1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":418,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:419,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Looks good, or is it?
+
+**Reviewed commit:** `e21e21e21e`")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E21_FILLER_COMPOSED_HEDGE_NOT_APPROVED_GH
+chmod +x "$_codex_e21_filler_composed_hedge_not_approved_mock_dir/gh"
+
+_codex_e21_filler_composed_hedge_not_approved_output=""
+_codex_e21_filler_composed_hedge_not_approved_exit=0
+PATH="$_codex_e21_filler_composed_hedge_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e21_filler_composed_hedge_not_approved_mock_dir/output.txt" 2>&1 || _codex_e21_filler_composed_hedge_not_approved_exit=$?
+_codex_e21_filler_composed_hedge_not_approved_output="$(cat "$_codex_e21_filler_composed_hedge_not_approved_mock_dir/output.txt")"
+run_test "codex_e21_filler_composed_hedge_not_approved_exit_needs_revision" "1" "$_codex_e21_filler_composed_hedge_not_approved_exit"
+run_test "codex_e21_filler_composed_hedge_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e21_filler_composed_hedge_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e21_filler_composed_hedge_not_approved_mock_dir"
+unset _codex_e21_filler_composed_hedge_not_approved_mock_dir _codex_e21_filler_composed_hedge_not_approved_output _codex_e21_filler_composed_hedge_not_approved_exit
+
+# Parser-risk addendum E22 (issue #1491's implementation plan): the real
+# template plus complete real footer, with "This must not be merged."
+# inserted inside the footer (immediately after </summary>). Under this
+# revision, is_approved ALONE already returns NEEDS_REVISION for this
+# body — inserting any text inside the footer breaks the whole-body
+# exact match on its own. codex_response_is_blocking (unchanged,
+# Decision 4) still runs first at every verdict site and still
+# independently recognizes the refusal, so the COMPOSED verdict is
+# still the more specific blocking branch (plain "VERDICT:
+# NEEDS_REVISION", not the "(unrecognized...)" safe-fail suffix) — the
+# structural relationship between is_approved and is_blocking
+# described in Decision 4/5.
+_codex_e22_refusal_inside_footer_blocking_mock_dir="$(mktemp -d)"
+cat > "$_codex_e22_refusal_inside_footer_blocking_mock_dir/gh" <<'CODEX_E22_REFUSAL_INSIDE_FOOTER_BLOCKING_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e22e22e22e1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":419,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:420,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `e22e22e22e` <details> <summary>ℹ️ About Codex in GitHub</summary> This must not be merged. <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E22_REFUSAL_INSIDE_FOOTER_BLOCKING_GH
+chmod +x "$_codex_e22_refusal_inside_footer_blocking_mock_dir/gh"
+
+_codex_e22_refusal_inside_footer_blocking_output=""
+_codex_e22_refusal_inside_footer_blocking_exit=0
+PATH="$_codex_e22_refusal_inside_footer_blocking_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e22_refusal_inside_footer_blocking_mock_dir/output.txt" 2>&1 || _codex_e22_refusal_inside_footer_blocking_exit=$?
+_codex_e22_refusal_inside_footer_blocking_output="$(cat "$_codex_e22_refusal_inside_footer_blocking_mock_dir/output.txt")"
+run_test "codex_e22_refusal_inside_footer_blocking_exit_needs_revision" "1" "$_codex_e22_refusal_inside_footer_blocking_exit"
+run_test "codex_e22_refusal_inside_footer_blocking_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_e22_refusal_inside_footer_blocking_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e22_refusal_inside_footer_blocking_mock_dir"
+unset _codex_e22_refusal_inside_footer_blocking_mock_dir _codex_e22_refusal_inside_footer_blocking_output _codex_e22_refusal_inside_footer_blocking_exit
+
+# Parser-risk addendum E23 (issue #1491's implementation plan): the real
+# template, followed by the footer's OPENING LINE ONLY (not its
+# complete text), followed by "Rename the unsafe function." — the exact
+# construction from Codex GitHub finding `3803545669` that motivated
+# this revision. The required literal is the COMPLETE footer text, so a
+# body carrying only its opening line does not reproduce that literal.
+# The direct regression test for finding `3803545669`.
+_codex_e23_footer_opening_line_only_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e23_footer_opening_line_only_not_approved_mock_dir/gh" <<'CODEX_E23_FOOTER_OPENING_LINE_ONLY_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e23e23e23e1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":420,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:421,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `e23e23e23e` <details> <summary>ℹ️ About Codex in GitHub</summary> Rename the unsafe function.")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E23_FOOTER_OPENING_LINE_ONLY_NOT_APPROVED_GH
+chmod +x "$_codex_e23_footer_opening_line_only_not_approved_mock_dir/gh"
+
+_codex_e23_footer_opening_line_only_not_approved_output=""
+_codex_e23_footer_opening_line_only_not_approved_exit=0
+PATH="$_codex_e23_footer_opening_line_only_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e23_footer_opening_line_only_not_approved_mock_dir/output.txt" 2>&1 || _codex_e23_footer_opening_line_only_not_approved_exit=$?
+_codex_e23_footer_opening_line_only_not_approved_output="$(cat "$_codex_e23_footer_opening_line_only_not_approved_mock_dir/output.txt")"
+run_test "codex_e23_footer_opening_line_only_not_approved_exit_needs_revision" "1" "$_codex_e23_footer_opening_line_only_not_approved_exit"
+run_test "codex_e23_footer_opening_line_only_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e23_footer_opening_line_only_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e23_footer_opening_line_only_not_approved_mock_dir"
+unset _codex_e23_footer_opening_line_only_not_approved_mock_dir _codex_e23_footer_opening_line_only_not_approved_output _codex_e23_footer_opening_line_only_not_approved_exit
+
+# Parser-risk addendum E24a (issue #1491's implementation plan): the
+# real template plus complete real footer, with a single byte changed
+# MID-SENTENCE inside the footer body ("this repo" -> "thXs repo").
+# Confirms the entire footer is load-bearing for the match, not merely
+# its opening line.
+_codex_e24a_footer_byte_mutation_mid_sentence_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e24a_footer_byte_mutation_mid_sentence_not_approved_mock_dir/gh" <<'CODEX_E24A_FOOTER_BYTE_MUTATION_MID_SENTENCE_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e24a24a24a1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":421,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:422,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `e24a24a24a` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in thXs repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E24A_FOOTER_BYTE_MUTATION_MID_SENTENCE_NOT_APPROVED_GH
+chmod +x "$_codex_e24a_footer_byte_mutation_mid_sentence_not_approved_mock_dir/gh"
+
+_codex_e24a_footer_byte_mutation_mid_sentence_not_approved_output=""
+_codex_e24a_footer_byte_mutation_mid_sentence_not_approved_exit=0
+PATH="$_codex_e24a_footer_byte_mutation_mid_sentence_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e24a_footer_byte_mutation_mid_sentence_not_approved_mock_dir/output.txt" 2>&1 || _codex_e24a_footer_byte_mutation_mid_sentence_not_approved_exit=$?
+_codex_e24a_footer_byte_mutation_mid_sentence_not_approved_output="$(cat "$_codex_e24a_footer_byte_mutation_mid_sentence_not_approved_mock_dir/output.txt")"
+run_test "codex_e24a_footer_byte_mutation_mid_sentence_not_approved_exit_needs_revision" "1" "$_codex_e24a_footer_byte_mutation_mid_sentence_not_approved_exit"
+run_test "codex_e24a_footer_byte_mutation_mid_sentence_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e24a_footer_byte_mutation_mid_sentence_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e24a_footer_byte_mutation_mid_sentence_not_approved_mock_dir"
+unset _codex_e24a_footer_byte_mutation_mid_sentence_not_approved_mock_dir _codex_e24a_footer_byte_mutation_mid_sentence_not_approved_output _codex_e24a_footer_byte_mutation_mid_sentence_not_approved_exit
+
+# Parser-risk addendum E24b (issue #1491's implementation plan): the
+# real template plus complete real footer, with a single byte changed
+# IMMEDIATELY BEFORE </details> (the final "." -> "!"). Confirms the
+# footer's closing text is load-bearing, not just its opening line.
+_codex_e24b_footer_byte_mutation_before_details_close_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e24b_footer_byte_mutation_before_details_close_not_approved_mock_dir/gh" <<'CODEX_E24B_FOOTER_BYTE_MUTATION_BEFORE_DETAILS_CLOSE_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e24b24b24b1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":422,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:423,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `e24b24b24b` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\"! </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E24B_FOOTER_BYTE_MUTATION_BEFORE_DETAILS_CLOSE_NOT_APPROVED_GH
+chmod +x "$_codex_e24b_footer_byte_mutation_before_details_close_not_approved_mock_dir/gh"
+
+_codex_e24b_footer_byte_mutation_before_details_close_not_approved_output=""
+_codex_e24b_footer_byte_mutation_before_details_close_not_approved_exit=0
+PATH="$_codex_e24b_footer_byte_mutation_before_details_close_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e24b_footer_byte_mutation_before_details_close_not_approved_mock_dir/output.txt" 2>&1 || _codex_e24b_footer_byte_mutation_before_details_close_not_approved_exit=$?
+_codex_e24b_footer_byte_mutation_before_details_close_not_approved_output="$(cat "$_codex_e24b_footer_byte_mutation_before_details_close_not_approved_mock_dir/output.txt")"
+run_test "codex_e24b_footer_byte_mutation_before_details_close_not_approved_exit_needs_revision" "1" "$_codex_e24b_footer_byte_mutation_before_details_close_not_approved_exit"
+run_test "codex_e24b_footer_byte_mutation_before_details_close_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e24b_footer_byte_mutation_before_details_close_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e24b_footer_byte_mutation_before_details_close_not_approved_mock_dir"
+unset _codex_e24b_footer_byte_mutation_before_details_close_not_approved_mock_dir _codex_e24b_footer_byte_mutation_before_details_close_not_approved_output _codex_e24b_footer_byte_mutation_before_details_close_not_approved_exit
+
+# Parser-risk addendum E24c (issue #1491's implementation plan): the
+# real template plus complete real footer, with a single byte changed
+# INSIDE the settings URL ("general" -> "genera1"). Confirms the
+# footer's URL text is load-bearing, not just its opening line.
+_codex_e24c_footer_byte_mutation_in_url_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_e24c_footer_byte_mutation_in_url_not_approved_mock_dir/gh" <<'CODEX_E24C_FOOTER_BYTE_MUTATION_IN_URL_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'e24c24c24c1\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":423,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:424,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `e24c24c24c` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/genera1). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_E24C_FOOTER_BYTE_MUTATION_IN_URL_NOT_APPROVED_GH
+chmod +x "$_codex_e24c_footer_byte_mutation_in_url_not_approved_mock_dir/gh"
+
+_codex_e24c_footer_byte_mutation_in_url_not_approved_output=""
+_codex_e24c_footer_byte_mutation_in_url_not_approved_exit=0
+PATH="$_codex_e24c_footer_byte_mutation_in_url_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_e24c_footer_byte_mutation_in_url_not_approved_mock_dir/output.txt" 2>&1 || _codex_e24c_footer_byte_mutation_in_url_not_approved_exit=$?
+_codex_e24c_footer_byte_mutation_in_url_not_approved_output="$(cat "$_codex_e24c_footer_byte_mutation_in_url_not_approved_mock_dir/output.txt")"
+run_test "codex_e24c_footer_byte_mutation_in_url_not_approved_exit_needs_revision" "1" "$_codex_e24c_footer_byte_mutation_in_url_not_approved_exit"
+run_test "codex_e24c_footer_byte_mutation_in_url_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_e24c_footer_byte_mutation_in_url_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_e24c_footer_byte_mutation_in_url_not_approved_mock_dir"
+unset _codex_e24c_footer_byte_mutation_in_url_not_approved_mock_dir _codex_e24c_footer_byte_mutation_in_url_not_approved_output _codex_e24c_footer_byte_mutation_in_url_not_approved_exit
+# Decision-6 verdict-site near-miss #1 of 4 (issue #1491's implementation
+# plan, Codex GitHub finding `3805277351`, P2): the E3 near-miss body
+# (missing "Swish!", complete real footer, SHA-pinned) present on the
+# first poll. Resolves at the MAIN-LOOP verdict site. NEEDS_REVISION,
+# exit 1 — never VERDICT: TIMED_OUT. Each of the four Decision-6
+# verdict-site gates must be exercised by its own scenario, not inferred
+# from the others: a missing/mistyped gate at any one site still lets
+# this construction pass if it resolves at a different site.
+_codex_footer_near_miss_main_loop_safe_fails_mock_dir="$(mktemp -d)"
+cat > "$_codex_footer_near_miss_main_loop_safe_fails_mock_dir/gh" <<'CODEX_FOOTER_NEAR_MISS_MAIN_LOOP_SAFE_FAILS_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'face0000011234567\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":450,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:451,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. **Reviewed commit:** `face000001` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FOOTER_NEAR_MISS_MAIN_LOOP_SAFE_FAILS_GH
+chmod +x "$_codex_footer_near_miss_main_loop_safe_fails_mock_dir/gh"
+
+_codex_footer_near_miss_main_loop_safe_fails_output=""
+_codex_footer_near_miss_main_loop_safe_fails_exit=0
+PATH="$_codex_footer_near_miss_main_loop_safe_fails_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_footer_near_miss_main_loop_safe_fails_mock_dir/output.txt" 2>&1 || _codex_footer_near_miss_main_loop_safe_fails_exit=$?
+_codex_footer_near_miss_main_loop_safe_fails_output="$(cat "$_codex_footer_near_miss_main_loop_safe_fails_mock_dir/output.txt")"
+run_test "codex_footer_near_miss_main_loop_safe_fails_exit_needs_revision" "1" "$_codex_footer_near_miss_main_loop_safe_fails_exit"
+run_test "codex_footer_near_miss_main_loop_safe_fails_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_footer_near_miss_main_loop_safe_fails_output" | grep "^VERDICT:")"
+if printf '%s\n' "$_codex_footer_near_miss_main_loop_safe_fails_output" | grep -q "^INFO: bot response detected"; then
+  _codex_footer_near_miss_main_loop_safe_fails_site="main_loop"
+else
+  _codex_footer_near_miss_main_loop_safe_fails_site="other"
+fi
+run_test "codex_footer_near_miss_main_loop_safe_fails_resolves_at_main_loop" "main_loop" "$_codex_footer_near_miss_main_loop_safe_fails_site"
+rm -rf "$_codex_footer_near_miss_main_loop_safe_fails_mock_dir"
+unset _codex_footer_near_miss_main_loop_safe_fails_mock_dir _codex_footer_near_miss_main_loop_safe_fails_output _codex_footer_near_miss_main_loop_safe_fails_exit _codex_footer_near_miss_main_loop_safe_fails_site
+# Decision-6 verdict-site near-miss #2 of 4 (issue #1491's implementation
+# plan, Codex GitHub finding `3805277351`, P2): the main poll loop's own
+# comment fetches return empty for its entire budget; the near-miss body
+# appears only on the single async-grace poll that follows. Resolves at
+# the ASYNC-ARRIVAL verdict site. NEEDS_REVISION, exit 1 — never
+# VERDICT: TIMED_OUT.
+_codex_footer_near_miss_async_arrival_safe_fails_mock_dir="$(mktemp -d)"
+printf '0\n' > "$_codex_footer_near_miss_async_arrival_safe_fails_mock_dir/comment_calls"
+cat > "$_codex_footer_near_miss_async_arrival_safe_fails_mock_dir/gh" <<'CODEX_FOOTER_NEAR_MISS_ASYNC_ARRIVAL_SAFE_FAILS_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'face0000021234567\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":460,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    calls_file="$(dirname "$0")/comment_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    # Calls 1-2 are the pre-trigger dedup check and the main poll-loop's
+    # bot-response check; both stay empty so execution falls through to
+    # the async-arrival grace poll (call 3), which returns the near-miss
+    # body directly as SHA-pinned terminal evidence.
+    if [ "$calls" -ge 3 ]; then
+      jq -nc '[{id:461,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. **Reviewed commit:** `face000002` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    else
+      printf '[]\n'
+    fi
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FOOTER_NEAR_MISS_ASYNC_ARRIVAL_SAFE_FAILS_GH
+chmod +x "$_codex_footer_near_miss_async_arrival_safe_fails_mock_dir/gh"
+
+_codex_footer_near_miss_async_arrival_safe_fails_output=""
+_codex_footer_near_miss_async_arrival_safe_fails_exit=0
+PATH="$_codex_footer_near_miss_async_arrival_safe_fails_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_footer_near_miss_async_arrival_safe_fails_mock_dir/output.txt" 2>&1 || _codex_footer_near_miss_async_arrival_safe_fails_exit=$?
+_codex_footer_near_miss_async_arrival_safe_fails_output="$(cat "$_codex_footer_near_miss_async_arrival_safe_fails_mock_dir/output.txt")"
+run_test "codex_footer_near_miss_async_arrival_safe_fails_exit_needs_revision" "1" "$_codex_footer_near_miss_async_arrival_safe_fails_exit"
+run_test "codex_footer_near_miss_async_arrival_safe_fails_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_footer_near_miss_async_arrival_safe_fails_output" | grep "^VERDICT:")"
+if printf '%s\n' "$_codex_footer_near_miss_async_arrival_safe_fails_output" | grep -q "^INFO: async-arrival bot response detected during grace period"; then
+  _codex_footer_near_miss_async_arrival_safe_fails_site="async_arrival"
+else
+  _codex_footer_near_miss_async_arrival_safe_fails_site="other"
+fi
+run_test "codex_footer_near_miss_async_arrival_safe_fails_resolves_at_async_arrival" "async_arrival" "$_codex_footer_near_miss_async_arrival_safe_fails_site"
+rm -rf "$_codex_footer_near_miss_async_arrival_safe_fails_mock_dir"
+unset _codex_footer_near_miss_async_arrival_safe_fails_mock_dir _codex_footer_near_miss_async_arrival_safe_fails_output _codex_footer_near_miss_async_arrival_safe_fails_exit _codex_footer_near_miss_async_arrival_safe_fails_site
+# Decision-6 verdict-site near-miss #3 of 4 (issue #1491's implementation
+# plan, Codex GitHub finding `3805277351`, P2): the main poll loop returns
+# empty; the first async-grace poll finds only a bare acknowledgement
+# comment (the footer's acknowledgement sentence alone, no
+# **Reviewed commit:** marker — non-terminal, so it cannot resolve the
+# verdict on its own); this triggers the one-shot sleep-and-recheck, and
+# the near-miss body appears only on that second check. Resolves at the
+# ASYNC-FINAL verdict site. NEEDS_REVISION, exit 1 — never
+# VERDICT: TIMED_OUT.
+_codex_footer_near_miss_async_final_safe_fails_mock_dir="$(mktemp -d)"
+printf '0\n' > "$_codex_footer_near_miss_async_final_safe_fails_mock_dir/comment_calls"
+cat > "$_codex_footer_near_miss_async_final_safe_fails_mock_dir/gh" <<'CODEX_FOOTER_NEAR_MISS_ASYNC_FINAL_SAFE_FAILS_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'face0000031234567\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":470,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    calls_file="$(dirname "$0")/comment_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    # Calls 1-2 are the pre-trigger dedup check and the main poll-loop's
+    # bot-response check; both stay empty. Call 3 is the async-arrival
+    # grace poll: a bare, non-terminal acknowledgement comment (gated on
+    # source != "review", Decision 6, so it correctly triggers the
+    # sleep-and-recheck instead of safe-failing here). Call 4+ is the
+    # async-final re-poll: the near-miss body, SHA-pinned terminal
+    # evidence that does not reproduce CODEX_APPROVED_TEMPLATES.
+    if [ "$calls" -ge 4 ]; then
+      jq -nc '[{id:471,created_at:"2026-01-01T00:00:02Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. **Reviewed commit:** `face000003` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    elif [ "$calls" -eq 3 ]; then
+      jq -nc '[{id:472,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\".")}]'
+    else
+      printf '[]\n'
+    fi
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FOOTER_NEAR_MISS_ASYNC_FINAL_SAFE_FAILS_GH
+chmod +x "$_codex_footer_near_miss_async_final_safe_fails_mock_dir/gh"
+
+_codex_footer_near_miss_async_final_safe_fails_output=""
+_codex_footer_near_miss_async_final_safe_fails_exit=0
+PATH="$_codex_footer_near_miss_async_final_safe_fails_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_footer_near_miss_async_final_safe_fails_mock_dir/output.txt" 2>&1 || _codex_footer_near_miss_async_final_safe_fails_exit=$?
+_codex_footer_near_miss_async_final_safe_fails_output="$(cat "$_codex_footer_near_miss_async_final_safe_fails_mock_dir/output.txt")"
+run_test "codex_footer_near_miss_async_final_safe_fails_exit_needs_revision" "1" "$_codex_footer_near_miss_async_final_safe_fails_exit"
+run_test "codex_footer_near_miss_async_final_safe_fails_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_footer_near_miss_async_final_safe_fails_output" | grep "^VERDICT:")"
+if printf '%s\n' "$_codex_footer_near_miss_async_final_safe_fails_output" | grep -q "^INFO: final async bot response detected after acknowledgement wait"; then
+  _codex_footer_near_miss_async_final_safe_fails_site="async_final"
+else
+  _codex_footer_near_miss_async_final_safe_fails_site="other"
+fi
+run_test "codex_footer_near_miss_async_final_safe_fails_resolves_at_async_final" "async_final" "$_codex_footer_near_miss_async_final_safe_fails_site"
+rm -rf "$_codex_footer_near_miss_async_final_safe_fails_mock_dir"
+unset _codex_footer_near_miss_async_final_safe_fails_mock_dir _codex_footer_near_miss_async_final_safe_fails_output _codex_footer_near_miss_async_final_safe_fails_exit _codex_footer_near_miss_async_final_safe_fails_site
+# Decision-6 verdict-site near-miss #4 of 4 (issue #1491's implementation
+# plan, Codex GitHub finding `3805277351`, P2): a thumbs-up reaction is
+# present on the trigger comment from the first poll onward, and every
+# comment fetch returns empty until the final check that follows the
+# reaction-triggered sleep, where the near-miss body appears (as a
+# current-head review, mirroring codex_async_reaction_then_late_review's
+# proven mock sequencing for this same site's positive path). Resolves at
+# the ASYNC-REACTION-FINAL verdict site — this scenario is the negative-
+# path counterpart to codex_async_reaction_then_late_review (Group
+# APPROVED). NEEDS_REVISION, exit 1 — never VERDICT: TIMED_OUT.
+_codex_footer_near_miss_async_reaction_final_safe_fails_mock_dir="$(mktemp -d)"
+printf '0\n' > "$_codex_footer_near_miss_async_reaction_final_safe_fails_mock_dir/review_calls"
+cat > "$_codex_footer_near_miss_async_reaction_final_safe_fails_mock_dir/gh" <<'CODEX_FOOTER_NEAR_MISS_ASYNC_REACTION_FINAL_SAFE_FAILS_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'face0000041234567\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":480,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[{"content":"+1","user":{"login":"chatgpt-codex-connector[bot]"}}]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    calls_file="$(dirname "$0")/review_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    if [ "$calls" -ge 3 ]; then
+      jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"face0000041234567",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. **Reviewed commit:** `face000004` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    else
+      printf '[]\n'
+    fi
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_FOOTER_NEAR_MISS_ASYNC_REACTION_FINAL_SAFE_FAILS_GH
+chmod +x "$_codex_footer_near_miss_async_reaction_final_safe_fails_mock_dir/gh"
+
+_codex_footer_near_miss_async_reaction_final_safe_fails_output=""
+_codex_footer_near_miss_async_reaction_final_safe_fails_exit=0
+PATH="$_codex_footer_near_miss_async_reaction_final_safe_fails_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_footer_near_miss_async_reaction_final_safe_fails_mock_dir/output.txt" 2>&1 || _codex_footer_near_miss_async_reaction_final_safe_fails_exit=$?
+_codex_footer_near_miss_async_reaction_final_safe_fails_output="$(cat "$_codex_footer_near_miss_async_reaction_final_safe_fails_mock_dir/output.txt")"
+run_test "codex_footer_near_miss_async_reaction_final_safe_fails_exit_needs_revision" "1" "$_codex_footer_near_miss_async_reaction_final_safe_fails_exit"
+run_test "codex_footer_near_miss_async_reaction_final_safe_fails_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_footer_near_miss_async_reaction_final_safe_fails_output" | grep "^VERDICT:")"
+if printf '%s\n' "$_codex_footer_near_miss_async_reaction_final_safe_fails_output" | grep -q "^INFO: final async reaction bot response detected via PR reviews endpoint"; then
+  _codex_footer_near_miss_async_reaction_final_safe_fails_site="async_reaction_final"
+else
+  _codex_footer_near_miss_async_reaction_final_safe_fails_site="other"
+fi
+run_test "codex_footer_near_miss_async_reaction_final_safe_fails_resolves_at_async_reaction_final" "async_reaction_final" "$_codex_footer_near_miss_async_reaction_final_safe_fails_site"
+rm -rf "$_codex_footer_near_miss_async_reaction_final_safe_fails_mock_dir"
+unset _codex_footer_near_miss_async_reaction_final_safe_fails_mock_dir _codex_footer_near_miss_async_reaction_final_safe_fails_output _codex_footer_near_miss_async_reaction_final_safe_fails_exit _codex_footer_near_miss_async_reaction_final_safe_fails_site
+
 
 _unlock_pr="80213$$"
 _unlock_lock_dir="/tmp/pr-review-loop-${_unlock_pr}.lockdir"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -9221,29 +9221,32 @@ unset _codex_footer_near_miss_async_reaction_final_safe_fails_mock_dir _codex_fo
 
 
 # ---------------------------------------------------------------------------
-# Flavor-token enumeration (issue #1491 follow-up, live-evidence correction
-# after PR #1494's own Codex review returned a clean response using
-# ":rocket:" instead of the single "Swish!" literal the shipped template
-# hardcoded — the vendor rotates this one slot through a pool of tokens, not
-# a fixed word. CODEX_APPROVED_TEMPLATES' flavor slot is now a bounded
-# alternation of every token evidenced by a live GitHub capture (comment
-# ids and PR numbers recorded in the implementation plan's Decision 2
-# addendum and the smoke-test runbook) — never an invented token, never a
-# general wildcard. Adding a token here requires the same review discipline
-# as adding a template. codex_e1_real_pr1489_capture_approved above already
-# covers "Swish!" end to end; this block covers every other evidenced token.
+# Bounded flavor-slot placeholder (issue #1491 follow-up, second correction).
+# The first correction (a 14-token literal alternation) was itself replaced
+# before merge: 14 distinct tokens from under 50 samples — single words,
+# full sentences, GitHub emoji shortcodes, inconsistent trailing punctuation
+# — is LLM-generated variety, not a fixed vocabulary, and enumerating it
+# would not converge (issue #1491's original complaint reappearing on a new
+# axis). CODEX_APPROVED_TEMPLATES' flavor slot is now the single bounded
+# placeholder `[^*`[:cntrl:]]{1,40}` — see the production script's own
+# comment above CODEX_APPROVED_TEMPLATES and the implementation plan's
+# Decision 2 second addendum for the full derivation of both the length
+# cap and the excluded-character set. codex_e1_real_pr1489_capture_approved
+# above already covers "Swish!" end to end and is unchanged; this block
+# covers the remaining evidenced tokens plus the placeholder's own
+# structure/length guards.
 # ---------------------------------------------------------------------------
-# Flavor token: 'Nice work!' (issue #1491 follow-up; live evidence swept from repo history)
-_codex_flavor_nice_work_approved_mock_dir="$(mktemp -d)"
-cat > "$_codex_flavor_nice_work_approved_mock_dir/gh" <<'CODEX_FLAVOR_NICE_WORK_APPROVED_GH'
+# Evidenced flavor token: 'Nice work!' (issue #1491 follow-up; approved by the bounded placeholder)
+_codex_placeholder_nice_work_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_nice_work_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_NICE_WORK_APPROVED_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
     exit 0 ;;
   *"pr view"*headRefOid*)
-    printf 'f1a00000011234567890\n'; exit 0 ;;
+    printf 'fa00000011234567890\n'; exit 0 ;;
   *"--method POST"*)
-    printf '{"id":901,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+    printf '{"id":701,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
   *"issues/comments/"*"/reactions"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/comments"*)
@@ -9251,40 +9254,40 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:951,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Nice work! **Reviewed commit:** `f1a0000001` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    jq -nc '[{id:751,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Nice work! **Reviewed commit:** `fa0000001` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_FLAVOR_NICE_WORK_APPROVED_GH
-chmod +x "$_codex_flavor_nice_work_approved_mock_dir/gh"
+CODEX_PLACEHOLDER_NICE_WORK_APPROVED_GH
+chmod +x "$_codex_placeholder_nice_work_approved_mock_dir/gh"
 
-_codex_flavor_nice_work_approved_output=""
-_codex_flavor_nice_work_approved_exit=0
-PATH="$_codex_flavor_nice_work_approved_mock_dir:$PATH" \
+_codex_placeholder_nice_work_approved_output=""
+_codex_placeholder_nice_work_approved_exit=0
+PATH="$_codex_placeholder_nice_work_approved_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_flavor_nice_work_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_nice_work_approved_exit=$?
-_codex_flavor_nice_work_approved_output="$(cat "$_codex_flavor_nice_work_approved_mock_dir/output.txt")"
-run_test "codex_flavor_nice_work_approved_exit_clean" "0" "$_codex_flavor_nice_work_approved_exit"
-run_test "codex_flavor_nice_work_approved_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_flavor_nice_work_approved_output" | grep "^VERDICT:")"
-rm -rf "$_codex_flavor_nice_work_approved_mock_dir"
-unset _codex_flavor_nice_work_approved_mock_dir _codex_flavor_nice_work_approved_output _codex_flavor_nice_work_approved_exit
+  >"$_codex_placeholder_nice_work_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_nice_work_approved_exit=$?
+_codex_placeholder_nice_work_approved_output="$(cat "$_codex_placeholder_nice_work_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_nice_work_approved_exit_clean" "0" "$_codex_placeholder_nice_work_approved_exit"
+run_test "codex_placeholder_nice_work_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_nice_work_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_nice_work_approved_mock_dir"
+unset _codex_placeholder_nice_work_approved_mock_dir _codex_placeholder_nice_work_approved_output _codex_placeholder_nice_work_approved_exit
 
-# Flavor token: "Chef's kiss." (issue #1491 follow-up; live evidence swept from repo history)
-_codex_flavor_chefs_kiss_approved_mock_dir="$(mktemp -d)"
-cat > "$_codex_flavor_chefs_kiss_approved_mock_dir/gh" <<'CODEX_FLAVOR_CHEFS_KISS_APPROVED_GH'
+# Evidenced flavor token: "Chef's kiss." (issue #1491 follow-up; approved by the bounded placeholder)
+_codex_placeholder_chefs_kiss_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_chefs_kiss_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_CHEFS_KISS_APPROVED_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
     exit 0 ;;
   *"pr view"*headRefOid*)
-    printf 'f1a00000021234567890\n'; exit 0 ;;
+    printf 'fa00000021234567890\n'; exit 0 ;;
   *"--method POST"*)
-    printf '{"id":902,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+    printf '{"id":702,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
   *"issues/comments/"*"/reactions"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/comments"*)
@@ -9292,40 +9295,40 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:952,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Chef'\''s kiss. **Reviewed commit:** `f1a0000002` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    jq -nc '[{id:752,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Chef'\''s kiss. **Reviewed commit:** `fa0000002` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_FLAVOR_CHEFS_KISS_APPROVED_GH
-chmod +x "$_codex_flavor_chefs_kiss_approved_mock_dir/gh"
+CODEX_PLACEHOLDER_CHEFS_KISS_APPROVED_GH
+chmod +x "$_codex_placeholder_chefs_kiss_approved_mock_dir/gh"
 
-_codex_flavor_chefs_kiss_approved_output=""
-_codex_flavor_chefs_kiss_approved_exit=0
-PATH="$_codex_flavor_chefs_kiss_approved_mock_dir:$PATH" \
+_codex_placeholder_chefs_kiss_approved_output=""
+_codex_placeholder_chefs_kiss_approved_exit=0
+PATH="$_codex_placeholder_chefs_kiss_approved_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_flavor_chefs_kiss_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_chefs_kiss_approved_exit=$?
-_codex_flavor_chefs_kiss_approved_output="$(cat "$_codex_flavor_chefs_kiss_approved_mock_dir/output.txt")"
-run_test "codex_flavor_chefs_kiss_approved_exit_clean" "0" "$_codex_flavor_chefs_kiss_approved_exit"
-run_test "codex_flavor_chefs_kiss_approved_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_flavor_chefs_kiss_approved_output" | grep "^VERDICT:")"
-rm -rf "$_codex_flavor_chefs_kiss_approved_mock_dir"
-unset _codex_flavor_chefs_kiss_approved_mock_dir _codex_flavor_chefs_kiss_approved_output _codex_flavor_chefs_kiss_approved_exit
+  >"$_codex_placeholder_chefs_kiss_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_chefs_kiss_approved_exit=$?
+_codex_placeholder_chefs_kiss_approved_output="$(cat "$_codex_placeholder_chefs_kiss_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_chefs_kiss_approved_exit_clean" "0" "$_codex_placeholder_chefs_kiss_approved_exit"
+run_test "codex_placeholder_chefs_kiss_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_chefs_kiss_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_chefs_kiss_approved_mock_dir"
+unset _codex_placeholder_chefs_kiss_approved_mock_dir _codex_placeholder_chefs_kiss_approved_output _codex_placeholder_chefs_kiss_approved_exit
 
-# Flavor token: "You're on a roll." (issue #1491 follow-up; live evidence swept from repo history)
-_codex_flavor_youre_on_a_roll_approved_mock_dir="$(mktemp -d)"
-cat > "$_codex_flavor_youre_on_a_roll_approved_mock_dir/gh" <<'CODEX_FLAVOR_YOURE_ON_A_ROLL_APPROVED_GH'
+# Evidenced flavor token: "You're on a roll." (issue #1491 follow-up; approved by the bounded placeholder)
+_codex_placeholder_youre_on_a_roll_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_youre_on_a_roll_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_YOURE_ON_A_ROLL_APPROVED_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
     exit 0 ;;
   *"pr view"*headRefOid*)
-    printf 'f1a00000031234567890\n'; exit 0 ;;
+    printf 'fa00000031234567890\n'; exit 0 ;;
   *"--method POST"*)
-    printf '{"id":903,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+    printf '{"id":703,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
   *"issues/comments/"*"/reactions"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/comments"*)
@@ -9333,40 +9336,40 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:953,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. You'\''re on a roll. **Reviewed commit:** `f1a0000003` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    jq -nc '[{id:753,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. You'\''re on a roll. **Reviewed commit:** `fa0000003` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_FLAVOR_YOURE_ON_A_ROLL_APPROVED_GH
-chmod +x "$_codex_flavor_youre_on_a_roll_approved_mock_dir/gh"
+CODEX_PLACEHOLDER_YOURE_ON_A_ROLL_APPROVED_GH
+chmod +x "$_codex_placeholder_youre_on_a_roll_approved_mock_dir/gh"
 
-_codex_flavor_youre_on_a_roll_approved_output=""
-_codex_flavor_youre_on_a_roll_approved_exit=0
-PATH="$_codex_flavor_youre_on_a_roll_approved_mock_dir:$PATH" \
+_codex_placeholder_youre_on_a_roll_approved_output=""
+_codex_placeholder_youre_on_a_roll_approved_exit=0
+PATH="$_codex_placeholder_youre_on_a_roll_approved_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_flavor_youre_on_a_roll_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_youre_on_a_roll_approved_exit=$?
-_codex_flavor_youre_on_a_roll_approved_output="$(cat "$_codex_flavor_youre_on_a_roll_approved_mock_dir/output.txt")"
-run_test "codex_flavor_youre_on_a_roll_approved_exit_clean" "0" "$_codex_flavor_youre_on_a_roll_approved_exit"
-run_test "codex_flavor_youre_on_a_roll_approved_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_flavor_youre_on_a_roll_approved_output" | grep "^VERDICT:")"
-rm -rf "$_codex_flavor_youre_on_a_roll_approved_mock_dir"
-unset _codex_flavor_youre_on_a_roll_approved_mock_dir _codex_flavor_youre_on_a_roll_approved_output _codex_flavor_youre_on_a_roll_approved_exit
+  >"$_codex_placeholder_youre_on_a_roll_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_youre_on_a_roll_approved_exit=$?
+_codex_placeholder_youre_on_a_roll_approved_output="$(cat "$_codex_placeholder_youre_on_a_roll_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_youre_on_a_roll_approved_exit_clean" "0" "$_codex_placeholder_youre_on_a_roll_approved_exit"
+run_test "codex_placeholder_youre_on_a_roll_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_youre_on_a_roll_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_youre_on_a_roll_approved_mock_dir"
+unset _codex_placeholder_youre_on_a_roll_approved_mock_dir _codex_placeholder_youre_on_a_roll_approved_output _codex_placeholder_youre_on_a_roll_approved_exit
 
-# Flavor token: ':tada:' (issue #1491 follow-up; live evidence swept from repo history)
-_codex_flavor_tada_approved_mock_dir="$(mktemp -d)"
-cat > "$_codex_flavor_tada_approved_mock_dir/gh" <<'CODEX_FLAVOR_TADA_APPROVED_GH'
+# Evidenced flavor token: ':tada:' (issue #1491 follow-up; approved by the bounded placeholder)
+_codex_placeholder_tada_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_tada_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_TADA_APPROVED_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
     exit 0 ;;
   *"pr view"*headRefOid*)
-    printf 'f1a00000041234567890\n'; exit 0 ;;
+    printf 'fa00000041234567890\n'; exit 0 ;;
   *"--method POST"*)
-    printf '{"id":904,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+    printf '{"id":704,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
   *"issues/comments/"*"/reactions"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/comments"*)
@@ -9374,40 +9377,40 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:954,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. :tada: **Reviewed commit:** `f1a0000004` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    jq -nc '[{id:754,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. :tada: **Reviewed commit:** `fa0000004` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_FLAVOR_TADA_APPROVED_GH
-chmod +x "$_codex_flavor_tada_approved_mock_dir/gh"
+CODEX_PLACEHOLDER_TADA_APPROVED_GH
+chmod +x "$_codex_placeholder_tada_approved_mock_dir/gh"
 
-_codex_flavor_tada_approved_output=""
-_codex_flavor_tada_approved_exit=0
-PATH="$_codex_flavor_tada_approved_mock_dir:$PATH" \
+_codex_placeholder_tada_approved_output=""
+_codex_placeholder_tada_approved_exit=0
+PATH="$_codex_placeholder_tada_approved_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_flavor_tada_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_tada_approved_exit=$?
-_codex_flavor_tada_approved_output="$(cat "$_codex_flavor_tada_approved_mock_dir/output.txt")"
-run_test "codex_flavor_tada_approved_exit_clean" "0" "$_codex_flavor_tada_approved_exit"
-run_test "codex_flavor_tada_approved_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_flavor_tada_approved_output" | grep "^VERDICT:")"
-rm -rf "$_codex_flavor_tada_approved_mock_dir"
-unset _codex_flavor_tada_approved_mock_dir _codex_flavor_tada_approved_output _codex_flavor_tada_approved_exit
+  >"$_codex_placeholder_tada_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_tada_approved_exit=$?
+_codex_placeholder_tada_approved_output="$(cat "$_codex_placeholder_tada_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_tada_approved_exit_clean" "0" "$_codex_placeholder_tada_approved_exit"
+run_test "codex_placeholder_tada_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_tada_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_tada_approved_mock_dir"
+unset _codex_placeholder_tada_approved_mock_dir _codex_placeholder_tada_approved_output _codex_placeholder_tada_approved_exit
 
-# Flavor token: 'Another round soon, please!' (issue #1491 follow-up; live evidence swept from repo history)
-_codex_flavor_another_round_soon_please_approved_mock_dir="$(mktemp -d)"
-cat > "$_codex_flavor_another_round_soon_please_approved_mock_dir/gh" <<'CODEX_FLAVOR_ANOTHER_ROUND_SOON_PLEASE_APPROVED_GH'
+# Evidenced flavor token: 'Another round soon, please!' (issue #1491 follow-up; approved by the bounded placeholder)
+_codex_placeholder_another_round_soon_please_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_another_round_soon_please_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_ANOTHER_ROUND_SOON_PLEASE_APPROVED_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
     exit 0 ;;
   *"pr view"*headRefOid*)
-    printf 'f1a00000051234567890\n'; exit 0 ;;
+    printf 'fa00000051234567890\n'; exit 0 ;;
   *"--method POST"*)
-    printf '{"id":905,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+    printf '{"id":705,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
   *"issues/comments/"*"/reactions"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/comments"*)
@@ -9415,40 +9418,40 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:955,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Another round soon, please! **Reviewed commit:** `f1a0000005` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    jq -nc '[{id:755,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Another round soon, please! **Reviewed commit:** `fa0000005` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_FLAVOR_ANOTHER_ROUND_SOON_PLEASE_APPROVED_GH
-chmod +x "$_codex_flavor_another_round_soon_please_approved_mock_dir/gh"
+CODEX_PLACEHOLDER_ANOTHER_ROUND_SOON_PLEASE_APPROVED_GH
+chmod +x "$_codex_placeholder_another_round_soon_please_approved_mock_dir/gh"
 
-_codex_flavor_another_round_soon_please_approved_output=""
-_codex_flavor_another_round_soon_please_approved_exit=0
-PATH="$_codex_flavor_another_round_soon_please_approved_mock_dir:$PATH" \
+_codex_placeholder_another_round_soon_please_approved_output=""
+_codex_placeholder_another_round_soon_please_approved_exit=0
+PATH="$_codex_placeholder_another_round_soon_please_approved_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_flavor_another_round_soon_please_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_another_round_soon_please_approved_exit=$?
-_codex_flavor_another_round_soon_please_approved_output="$(cat "$_codex_flavor_another_round_soon_please_approved_mock_dir/output.txt")"
-run_test "codex_flavor_another_round_soon_please_approved_exit_clean" "0" "$_codex_flavor_another_round_soon_please_approved_exit"
-run_test "codex_flavor_another_round_soon_please_approved_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_flavor_another_round_soon_please_approved_output" | grep "^VERDICT:")"
-rm -rf "$_codex_flavor_another_round_soon_please_approved_mock_dir"
-unset _codex_flavor_another_round_soon_please_approved_mock_dir _codex_flavor_another_round_soon_please_approved_output _codex_flavor_another_round_soon_please_approved_exit
+  >"$_codex_placeholder_another_round_soon_please_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_another_round_soon_please_approved_exit=$?
+_codex_placeholder_another_round_soon_please_approved_output="$(cat "$_codex_placeholder_another_round_soon_please_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_another_round_soon_please_approved_exit_clean" "0" "$_codex_placeholder_another_round_soon_please_approved_exit"
+run_test "codex_placeholder_another_round_soon_please_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_another_round_soon_please_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_another_round_soon_please_approved_mock_dir"
+unset _codex_placeholder_another_round_soon_please_approved_mock_dir _codex_placeholder_another_round_soon_please_approved_output _codex_placeholder_another_round_soon_please_approved_exit
 
-# Flavor token: ':+1:' (issue #1491 follow-up; live evidence swept from repo history)
-_codex_flavor_plus_one_approved_mock_dir="$(mktemp -d)"
-cat > "$_codex_flavor_plus_one_approved_mock_dir/gh" <<'CODEX_FLAVOR_PLUS_ONE_APPROVED_GH'
+# Evidenced flavor token: ':+1:' (issue #1491 follow-up; approved by the bounded placeholder)
+_codex_placeholder_plus_one_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_plus_one_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_PLUS_ONE_APPROVED_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
     exit 0 ;;
   *"pr view"*headRefOid*)
-    printf 'f1a00000061234567890\n'; exit 0 ;;
+    printf 'fa00000061234567890\n'; exit 0 ;;
   *"--method POST"*)
-    printf '{"id":906,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+    printf '{"id":706,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
   *"issues/comments/"*"/reactions"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/comments"*)
@@ -9456,40 +9459,40 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:956,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. :+1: **Reviewed commit:** `f1a0000006` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    jq -nc '[{id:756,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. :+1: **Reviewed commit:** `fa0000006` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_FLAVOR_PLUS_ONE_APPROVED_GH
-chmod +x "$_codex_flavor_plus_one_approved_mock_dir/gh"
+CODEX_PLACEHOLDER_PLUS_ONE_APPROVED_GH
+chmod +x "$_codex_placeholder_plus_one_approved_mock_dir/gh"
 
-_codex_flavor_plus_one_approved_output=""
-_codex_flavor_plus_one_approved_exit=0
-PATH="$_codex_flavor_plus_one_approved_mock_dir:$PATH" \
+_codex_placeholder_plus_one_approved_output=""
+_codex_placeholder_plus_one_approved_exit=0
+PATH="$_codex_placeholder_plus_one_approved_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_flavor_plus_one_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_plus_one_approved_exit=$?
-_codex_flavor_plus_one_approved_output="$(cat "$_codex_flavor_plus_one_approved_mock_dir/output.txt")"
-run_test "codex_flavor_plus_one_approved_exit_clean" "0" "$_codex_flavor_plus_one_approved_exit"
-run_test "codex_flavor_plus_one_approved_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_flavor_plus_one_approved_output" | grep "^VERDICT:")"
-rm -rf "$_codex_flavor_plus_one_approved_mock_dir"
-unset _codex_flavor_plus_one_approved_mock_dir _codex_flavor_plus_one_approved_output _codex_flavor_plus_one_approved_exit
+  >"$_codex_placeholder_plus_one_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_plus_one_approved_exit=$?
+_codex_placeholder_plus_one_approved_output="$(cat "$_codex_placeholder_plus_one_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_plus_one_approved_exit_clean" "0" "$_codex_placeholder_plus_one_approved_exit"
+run_test "codex_placeholder_plus_one_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_plus_one_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_plus_one_approved_mock_dir"
+unset _codex_placeholder_plus_one_approved_mock_dir _codex_placeholder_plus_one_approved_output _codex_placeholder_plus_one_approved_exit
 
-# Flavor token: 'Bravo.' (issue #1491 follow-up; live evidence swept from repo history)
-_codex_flavor_bravo_approved_mock_dir="$(mktemp -d)"
-cat > "$_codex_flavor_bravo_approved_mock_dir/gh" <<'CODEX_FLAVOR_BRAVO_APPROVED_GH'
+# Evidenced flavor token: 'Bravo.' (issue #1491 follow-up; approved by the bounded placeholder)
+_codex_placeholder_bravo_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_bravo_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_BRAVO_APPROVED_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
     exit 0 ;;
   *"pr view"*headRefOid*)
-    printf 'f1a00000071234567890\n'; exit 0 ;;
+    printf 'fa00000071234567890\n'; exit 0 ;;
   *"--method POST"*)
-    printf '{"id":907,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+    printf '{"id":707,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
   *"issues/comments/"*"/reactions"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/comments"*)
@@ -9497,40 +9500,40 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:957,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Bravo. **Reviewed commit:** `f1a0000007` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    jq -nc '[{id:757,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Bravo. **Reviewed commit:** `fa0000007` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_FLAVOR_BRAVO_APPROVED_GH
-chmod +x "$_codex_flavor_bravo_approved_mock_dir/gh"
+CODEX_PLACEHOLDER_BRAVO_APPROVED_GH
+chmod +x "$_codex_placeholder_bravo_approved_mock_dir/gh"
 
-_codex_flavor_bravo_approved_output=""
-_codex_flavor_bravo_approved_exit=0
-PATH="$_codex_flavor_bravo_approved_mock_dir:$PATH" \
+_codex_placeholder_bravo_approved_output=""
+_codex_placeholder_bravo_approved_exit=0
+PATH="$_codex_placeholder_bravo_approved_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_flavor_bravo_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_bravo_approved_exit=$?
-_codex_flavor_bravo_approved_output="$(cat "$_codex_flavor_bravo_approved_mock_dir/output.txt")"
-run_test "codex_flavor_bravo_approved_exit_clean" "0" "$_codex_flavor_bravo_approved_exit"
-run_test "codex_flavor_bravo_approved_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_flavor_bravo_approved_output" | grep "^VERDICT:")"
-rm -rf "$_codex_flavor_bravo_approved_mock_dir"
-unset _codex_flavor_bravo_approved_mock_dir _codex_flavor_bravo_approved_output _codex_flavor_bravo_approved_exit
+  >"$_codex_placeholder_bravo_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_bravo_approved_exit=$?
+_codex_placeholder_bravo_approved_output="$(cat "$_codex_placeholder_bravo_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_bravo_approved_exit_clean" "0" "$_codex_placeholder_bravo_approved_exit"
+run_test "codex_placeholder_bravo_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_bravo_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_bravo_approved_mock_dir"
+unset _codex_placeholder_bravo_approved_mock_dir _codex_placeholder_bravo_approved_output _codex_placeholder_bravo_approved_exit
 
-# Flavor token: 'Keep it up!' (issue #1491 follow-up; live evidence swept from repo history)
-_codex_flavor_keep_it_up_approved_mock_dir="$(mktemp -d)"
-cat > "$_codex_flavor_keep_it_up_approved_mock_dir/gh" <<'CODEX_FLAVOR_KEEP_IT_UP_APPROVED_GH'
+# Evidenced flavor token: 'Keep it up!' (issue #1491 follow-up; approved by the bounded placeholder)
+_codex_placeholder_keep_it_up_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_keep_it_up_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_KEEP_IT_UP_APPROVED_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
     exit 0 ;;
   *"pr view"*headRefOid*)
-    printf 'f1a00000081234567890\n'; exit 0 ;;
+    printf 'fa00000081234567890\n'; exit 0 ;;
   *"--method POST"*)
-    printf '{"id":908,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+    printf '{"id":708,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
   *"issues/comments/"*"/reactions"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/comments"*)
@@ -9538,40 +9541,40 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:958,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Keep it up! **Reviewed commit:** `f1a0000008` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    jq -nc '[{id:758,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Keep it up! **Reviewed commit:** `fa0000008` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_FLAVOR_KEEP_IT_UP_APPROVED_GH
-chmod +x "$_codex_flavor_keep_it_up_approved_mock_dir/gh"
+CODEX_PLACEHOLDER_KEEP_IT_UP_APPROVED_GH
+chmod +x "$_codex_placeholder_keep_it_up_approved_mock_dir/gh"
 
-_codex_flavor_keep_it_up_approved_output=""
-_codex_flavor_keep_it_up_approved_exit=0
-PATH="$_codex_flavor_keep_it_up_approved_mock_dir:$PATH" \
+_codex_placeholder_keep_it_up_approved_output=""
+_codex_placeholder_keep_it_up_approved_exit=0
+PATH="$_codex_placeholder_keep_it_up_approved_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_flavor_keep_it_up_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_keep_it_up_approved_exit=$?
-_codex_flavor_keep_it_up_approved_output="$(cat "$_codex_flavor_keep_it_up_approved_mock_dir/output.txt")"
-run_test "codex_flavor_keep_it_up_approved_exit_clean" "0" "$_codex_flavor_keep_it_up_approved_exit"
-run_test "codex_flavor_keep_it_up_approved_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_flavor_keep_it_up_approved_output" | grep "^VERDICT:")"
-rm -rf "$_codex_flavor_keep_it_up_approved_mock_dir"
-unset _codex_flavor_keep_it_up_approved_mock_dir _codex_flavor_keep_it_up_approved_output _codex_flavor_keep_it_up_approved_exit
+  >"$_codex_placeholder_keep_it_up_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_keep_it_up_approved_exit=$?
+_codex_placeholder_keep_it_up_approved_output="$(cat "$_codex_placeholder_keep_it_up_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_keep_it_up_approved_exit_clean" "0" "$_codex_placeholder_keep_it_up_approved_exit"
+run_test "codex_placeholder_keep_it_up_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_keep_it_up_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_keep_it_up_approved_mock_dir"
+unset _codex_placeholder_keep_it_up_approved_mock_dir _codex_placeholder_keep_it_up_approved_output _codex_placeholder_keep_it_up_approved_exit
 
-# Flavor token: 'Delightful!' (issue #1491 follow-up; live evidence swept from repo history)
-_codex_flavor_delightful_approved_mock_dir="$(mktemp -d)"
-cat > "$_codex_flavor_delightful_approved_mock_dir/gh" <<'CODEX_FLAVOR_DELIGHTFUL_APPROVED_GH'
+# Evidenced flavor token: 'Delightful!' (issue #1491 follow-up; approved by the bounded placeholder)
+_codex_placeholder_delightful_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_delightful_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_DELIGHTFUL_APPROVED_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
     exit 0 ;;
   *"pr view"*headRefOid*)
-    printf 'f1a00000091234567890\n'; exit 0 ;;
+    printf 'fa00000091234567890\n'; exit 0 ;;
   *"--method POST"*)
-    printf '{"id":909,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+    printf '{"id":709,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
   *"issues/comments/"*"/reactions"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/comments"*)
@@ -9579,40 +9582,40 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:959,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Delightful! **Reviewed commit:** `f1a0000009` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    jq -nc '[{id:759,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Delightful! **Reviewed commit:** `fa0000009` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_FLAVOR_DELIGHTFUL_APPROVED_GH
-chmod +x "$_codex_flavor_delightful_approved_mock_dir/gh"
+CODEX_PLACEHOLDER_DELIGHTFUL_APPROVED_GH
+chmod +x "$_codex_placeholder_delightful_approved_mock_dir/gh"
 
-_codex_flavor_delightful_approved_output=""
-_codex_flavor_delightful_approved_exit=0
-PATH="$_codex_flavor_delightful_approved_mock_dir:$PATH" \
+_codex_placeholder_delightful_approved_output=""
+_codex_placeholder_delightful_approved_exit=0
+PATH="$_codex_placeholder_delightful_approved_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_flavor_delightful_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_delightful_approved_exit=$?
-_codex_flavor_delightful_approved_output="$(cat "$_codex_flavor_delightful_approved_mock_dir/output.txt")"
-run_test "codex_flavor_delightful_approved_exit_clean" "0" "$_codex_flavor_delightful_approved_exit"
-run_test "codex_flavor_delightful_approved_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_flavor_delightful_approved_output" | grep "^VERDICT:")"
-rm -rf "$_codex_flavor_delightful_approved_mock_dir"
-unset _codex_flavor_delightful_approved_mock_dir _codex_flavor_delightful_approved_output _codex_flavor_delightful_approved_exit
+  >"$_codex_placeholder_delightful_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_delightful_approved_exit=$?
+_codex_placeholder_delightful_approved_output="$(cat "$_codex_placeholder_delightful_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_delightful_approved_exit_clean" "0" "$_codex_placeholder_delightful_approved_exit"
+run_test "codex_placeholder_delightful_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_delightful_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_delightful_approved_mock_dir"
+unset _codex_placeholder_delightful_approved_mock_dir _codex_placeholder_delightful_approved_output _codex_placeholder_delightful_approved_exit
 
-# Flavor token: 'Keep them coming!' (issue #1491 follow-up; live evidence swept from repo history)
-_codex_flavor_keep_them_coming_approved_mock_dir="$(mktemp -d)"
-cat > "$_codex_flavor_keep_them_coming_approved_mock_dir/gh" <<'CODEX_FLAVOR_KEEP_THEM_COMING_APPROVED_GH'
+# Evidenced flavor token: 'Keep them coming!' (issue #1491 follow-up; approved by the bounded placeholder)
+_codex_placeholder_keep_them_coming_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_keep_them_coming_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_KEEP_THEM_COMING_APPROVED_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
     exit 0 ;;
   *"pr view"*headRefOid*)
-    printf 'f1a000000a1234567890\n'; exit 0 ;;
+    printf 'fa000000a1234567890\n'; exit 0 ;;
   *"--method POST"*)
-    printf '{"id":910,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+    printf '{"id":710,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
   *"issues/comments/"*"/reactions"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/comments"*)
@@ -9620,40 +9623,40 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:960,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Keep them coming! **Reviewed commit:** `f1a000000a` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    jq -nc '[{id:760,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Keep them coming! **Reviewed commit:** `fa000000a` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_FLAVOR_KEEP_THEM_COMING_APPROVED_GH
-chmod +x "$_codex_flavor_keep_them_coming_approved_mock_dir/gh"
+CODEX_PLACEHOLDER_KEEP_THEM_COMING_APPROVED_GH
+chmod +x "$_codex_placeholder_keep_them_coming_approved_mock_dir/gh"
 
-_codex_flavor_keep_them_coming_approved_output=""
-_codex_flavor_keep_them_coming_approved_exit=0
-PATH="$_codex_flavor_keep_them_coming_approved_mock_dir:$PATH" \
+_codex_placeholder_keep_them_coming_approved_output=""
+_codex_placeholder_keep_them_coming_approved_exit=0
+PATH="$_codex_placeholder_keep_them_coming_approved_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_flavor_keep_them_coming_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_keep_them_coming_approved_exit=$?
-_codex_flavor_keep_them_coming_approved_output="$(cat "$_codex_flavor_keep_them_coming_approved_mock_dir/output.txt")"
-run_test "codex_flavor_keep_them_coming_approved_exit_clean" "0" "$_codex_flavor_keep_them_coming_approved_exit"
-run_test "codex_flavor_keep_them_coming_approved_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_flavor_keep_them_coming_approved_output" | grep "^VERDICT:")"
-rm -rf "$_codex_flavor_keep_them_coming_approved_mock_dir"
-unset _codex_flavor_keep_them_coming_approved_mock_dir _codex_flavor_keep_them_coming_approved_output _codex_flavor_keep_them_coming_approved_exit
+  >"$_codex_placeholder_keep_them_coming_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_keep_them_coming_approved_exit=$?
+_codex_placeholder_keep_them_coming_approved_output="$(cat "$_codex_placeholder_keep_them_coming_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_keep_them_coming_approved_exit_clean" "0" "$_codex_placeholder_keep_them_coming_approved_exit"
+run_test "codex_placeholder_keep_them_coming_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_keep_them_coming_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_keep_them_coming_approved_mock_dir"
+unset _codex_placeholder_keep_them_coming_approved_mock_dir _codex_placeholder_keep_them_coming_approved_output _codex_placeholder_keep_them_coming_approved_exit
 
-# Flavor token: "Can't wait for the next one!" (issue #1491 follow-up; live evidence swept from repo history)
-_codex_flavor_cant_wait_for_next_one_approved_mock_dir="$(mktemp -d)"
-cat > "$_codex_flavor_cant_wait_for_next_one_approved_mock_dir/gh" <<'CODEX_FLAVOR_CANT_WAIT_FOR_NEXT_ONE_APPROVED_GH'
+# Evidenced flavor token: "Can't wait for the next one!" (issue #1491 follow-up; approved by the bounded placeholder)
+_codex_placeholder_cant_wait_for_next_one_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_cant_wait_for_next_one_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_CANT_WAIT_FOR_NEXT_ONE_APPROVED_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
     exit 0 ;;
   *"pr view"*headRefOid*)
-    printf 'f1a000000b1234567890\n'; exit 0 ;;
+    printf 'fa000000b1234567890\n'; exit 0 ;;
   *"--method POST"*)
-    printf '{"id":911,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+    printf '{"id":711,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
   *"issues/comments/"*"/reactions"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/comments"*)
@@ -9661,40 +9664,40 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:961,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Can'\''t wait for the next one! **Reviewed commit:** `f1a000000b` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    jq -nc '[{id:761,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Can'\''t wait for the next one! **Reviewed commit:** `fa000000b` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_FLAVOR_CANT_WAIT_FOR_NEXT_ONE_APPROVED_GH
-chmod +x "$_codex_flavor_cant_wait_for_next_one_approved_mock_dir/gh"
+CODEX_PLACEHOLDER_CANT_WAIT_FOR_NEXT_ONE_APPROVED_GH
+chmod +x "$_codex_placeholder_cant_wait_for_next_one_approved_mock_dir/gh"
 
-_codex_flavor_cant_wait_for_next_one_approved_output=""
-_codex_flavor_cant_wait_for_next_one_approved_exit=0
-PATH="$_codex_flavor_cant_wait_for_next_one_approved_mock_dir:$PATH" \
+_codex_placeholder_cant_wait_for_next_one_approved_output=""
+_codex_placeholder_cant_wait_for_next_one_approved_exit=0
+PATH="$_codex_placeholder_cant_wait_for_next_one_approved_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_flavor_cant_wait_for_next_one_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_cant_wait_for_next_one_approved_exit=$?
-_codex_flavor_cant_wait_for_next_one_approved_output="$(cat "$_codex_flavor_cant_wait_for_next_one_approved_mock_dir/output.txt")"
-run_test "codex_flavor_cant_wait_for_next_one_approved_exit_clean" "0" "$_codex_flavor_cant_wait_for_next_one_approved_exit"
-run_test "codex_flavor_cant_wait_for_next_one_approved_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_flavor_cant_wait_for_next_one_approved_output" | grep "^VERDICT:")"
-rm -rf "$_codex_flavor_cant_wait_for_next_one_approved_mock_dir"
-unset _codex_flavor_cant_wait_for_next_one_approved_mock_dir _codex_flavor_cant_wait_for_next_one_approved_output _codex_flavor_cant_wait_for_next_one_approved_exit
+  >"$_codex_placeholder_cant_wait_for_next_one_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_cant_wait_for_next_one_approved_exit=$?
+_codex_placeholder_cant_wait_for_next_one_approved_output="$(cat "$_codex_placeholder_cant_wait_for_next_one_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_cant_wait_for_next_one_approved_exit_clean" "0" "$_codex_placeholder_cant_wait_for_next_one_approved_exit"
+run_test "codex_placeholder_cant_wait_for_next_one_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_cant_wait_for_next_one_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_cant_wait_for_next_one_approved_mock_dir"
+unset _codex_placeholder_cant_wait_for_next_one_approved_mock_dir _codex_placeholder_cant_wait_for_next_one_approved_output _codex_placeholder_cant_wait_for_next_one_approved_exit
 
-# Flavor token: 'More of your lovely PRs please.' (issue #1491 follow-up; live evidence swept from repo history)
-_codex_flavor_more_lovely_prs_please_approved_mock_dir="$(mktemp -d)"
-cat > "$_codex_flavor_more_lovely_prs_please_approved_mock_dir/gh" <<'CODEX_FLAVOR_MORE_LOVELY_PRS_PLEASE_APPROVED_GH'
+# Evidenced flavor token: 'More of your lovely PRs please.' (issue #1491 follow-up; approved by the bounded placeholder)
+_codex_placeholder_more_lovely_prs_please_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_more_lovely_prs_please_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_MORE_LOVELY_PRS_PLEASE_APPROVED_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
     exit 0 ;;
   *"pr view"*headRefOid*)
-    printf 'f1a000000c1234567890\n'; exit 0 ;;
+    printf 'fa000000c1234567890\n'; exit 0 ;;
   *"--method POST"*)
-    printf '{"id":912,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+    printf '{"id":712,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
   *"issues/comments/"*"/reactions"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/comments"*)
@@ -9702,35 +9705,35 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:962,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. More of your lovely PRs please. **Reviewed commit:** `f1a000000c` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    jq -nc '[{id:762,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. More of your lovely PRs please. **Reviewed commit:** `fa000000c` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_FLAVOR_MORE_LOVELY_PRS_PLEASE_APPROVED_GH
-chmod +x "$_codex_flavor_more_lovely_prs_please_approved_mock_dir/gh"
+CODEX_PLACEHOLDER_MORE_LOVELY_PRS_PLEASE_APPROVED_GH
+chmod +x "$_codex_placeholder_more_lovely_prs_please_approved_mock_dir/gh"
 
-_codex_flavor_more_lovely_prs_please_approved_output=""
-_codex_flavor_more_lovely_prs_please_approved_exit=0
-PATH="$_codex_flavor_more_lovely_prs_please_approved_mock_dir:$PATH" \
+_codex_placeholder_more_lovely_prs_please_approved_output=""
+_codex_placeholder_more_lovely_prs_please_approved_exit=0
+PATH="$_codex_placeholder_more_lovely_prs_please_approved_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_flavor_more_lovely_prs_please_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_more_lovely_prs_please_approved_exit=$?
-_codex_flavor_more_lovely_prs_please_approved_output="$(cat "$_codex_flavor_more_lovely_prs_please_approved_mock_dir/output.txt")"
-run_test "codex_flavor_more_lovely_prs_please_approved_exit_clean" "0" "$_codex_flavor_more_lovely_prs_please_approved_exit"
-run_test "codex_flavor_more_lovely_prs_please_approved_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_flavor_more_lovely_prs_please_approved_output" | grep "^VERDICT:")"
-rm -rf "$_codex_flavor_more_lovely_prs_please_approved_mock_dir"
-unset _codex_flavor_more_lovely_prs_please_approved_mock_dir _codex_flavor_more_lovely_prs_please_approved_output _codex_flavor_more_lovely_prs_please_approved_exit
+  >"$_codex_placeholder_more_lovely_prs_please_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_more_lovely_prs_please_approved_exit=$?
+_codex_placeholder_more_lovely_prs_please_approved_output="$(cat "$_codex_placeholder_more_lovely_prs_please_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_more_lovely_prs_please_approved_exit_clean" "0" "$_codex_placeholder_more_lovely_prs_please_approved_exit"
+run_test "codex_placeholder_more_lovely_prs_please_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_more_lovely_prs_please_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_more_lovely_prs_please_approved_mock_dir"
+unset _codex_placeholder_more_lovely_prs_please_approved_mock_dir _codex_placeholder_more_lovely_prs_please_approved_output _codex_placeholder_more_lovely_prs_please_approved_exit
 
-# Flavor token: ":rocket:" — the real, live PR #1494 root comment capture
-# (comment id 5333550055, 2026-08-18) that falsified the single-token
-# assumption in the first place. Verbatim, including its real footer,
-# matching codex_e1_real_pr1489_capture_approved's real-capture style.
-_codex_flavor_rocket_real_pr1494_capture_approved_mock_dir="$(mktemp -d)"
-cat > "$_codex_flavor_rocket_real_pr1494_capture_approved_mock_dir/gh" <<'CODEX_FLAVOR_ROCKET_REAL_PR1494_CAPTURE_APPROVED_GH'
+# Evidenced flavor token: ":rocket:" — the real, live PR #1494 root comment
+# capture (comment id 5333550055, 2026-08-18) that falsified the original
+# single-literal assumption. Verbatim, including its real footer, matching
+# codex_e1_real_pr1489_capture_approved's real-capture style.
+_codex_placeholder_rocket_real_pr1494_capture_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_rocket_real_pr1494_capture_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_ROCKET_REAL_PR1494_CAPTURE_APPROVED_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
@@ -9738,7 +9741,7 @@ case "$*" in
   *"pr view"*headRefOid*)
     printf 'a2a20e7b4836cfb5d20b75e39e01447757434e34\n'; exit 0 ;;
   *"--method POST"*)
-    printf '{"id":999,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+    printf '{"id":799,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
   *"issues/comments/"*"/reactions"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/comments"*)
@@ -9746,7 +9749,7 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:998,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. :rocket:
+    jq -nc '[{id:798,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. :rocket:
 
 **Reviewed commit:** `a2a20e7b48`
 
@@ -9773,37 +9776,36 @@ Codex can also answer questions or update the PR. Try commenting \"@codex addres
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_FLAVOR_ROCKET_REAL_PR1494_CAPTURE_APPROVED_GH
-chmod +x "$_codex_flavor_rocket_real_pr1494_capture_approved_mock_dir/gh"
+CODEX_PLACEHOLDER_ROCKET_REAL_PR1494_CAPTURE_APPROVED_GH
+chmod +x "$_codex_placeholder_rocket_real_pr1494_capture_approved_mock_dir/gh"
 
-_codex_flavor_rocket_real_pr1494_capture_approved_output=""
-_codex_flavor_rocket_real_pr1494_capture_approved_exit=0
-PATH="$_codex_flavor_rocket_real_pr1494_capture_approved_mock_dir:$PATH" \
+_codex_placeholder_rocket_real_pr1494_capture_approved_output=""
+_codex_placeholder_rocket_real_pr1494_capture_approved_exit=0
+PATH="$_codex_placeholder_rocket_real_pr1494_capture_approved_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_flavor_rocket_real_pr1494_capture_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_rocket_real_pr1494_capture_approved_exit=$?
-_codex_flavor_rocket_real_pr1494_capture_approved_output="$(cat "$_codex_flavor_rocket_real_pr1494_capture_approved_mock_dir/output.txt")"
-run_test "codex_flavor_rocket_real_pr1494_capture_approved_exit_clean" "0" "$_codex_flavor_rocket_real_pr1494_capture_approved_exit"
-run_test "codex_flavor_rocket_real_pr1494_capture_approved_verdict" "VERDICT: APPROVED" \
-  "$(printf '%s\n' "$_codex_flavor_rocket_real_pr1494_capture_approved_output" | grep "^VERDICT:")"
-rm -rf "$_codex_flavor_rocket_real_pr1494_capture_approved_mock_dir"
-unset _codex_flavor_rocket_real_pr1494_capture_approved_mock_dir _codex_flavor_rocket_real_pr1494_capture_approved_output _codex_flavor_rocket_real_pr1494_capture_approved_exit
+  >"$_codex_placeholder_rocket_real_pr1494_capture_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_rocket_real_pr1494_capture_approved_exit=$?
+_codex_placeholder_rocket_real_pr1494_capture_approved_output="$(cat "$_codex_placeholder_rocket_real_pr1494_capture_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_rocket_real_pr1494_capture_approved_exit_clean" "0" "$_codex_placeholder_rocket_real_pr1494_capture_approved_exit"
+run_test "codex_placeholder_rocket_real_pr1494_capture_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_rocket_real_pr1494_capture_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_rocket_real_pr1494_capture_approved_mock_dir"
+unset _codex_placeholder_rocket_real_pr1494_capture_approved_mock_dir _codex_placeholder_rocket_real_pr1494_capture_approved_output _codex_placeholder_rocket_real_pr1494_capture_approved_exit
 
-# Flavor token regression: an unevidenced flavor phrase ("Fantastic job!")
-# must still safe-fail. Proves the alternation is closed (does not admit
-# arbitrary text in the flavor slot) and that the safe-direction failure
-# (false NEEDS_REVISION on an as-yet-unobserved genuine flavor rotation) is
-# intentional and tested, per the human decision recorded in the plan.
-_codex_flavor_unevidenced_token_not_approved_mock_dir="$(mktemp -d)"
-cat > "$_codex_flavor_unevidenced_token_not_approved_mock_dir/gh" <<'CODEX_FLAVOR_UNEVIDENCED_TOKEN_NOT_APPROVED_GH'
+# Behavior change (the whole point of this correction): a previously
+# unevidenced flavor phrase now APPROVES, because the flavor slot is a
+# bounded placeholder, not a closed enumeration. Proves the design change
+# directly rather than asserting it.
+_codex_placeholder_unevidenced_flavor_now_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_unevidenced_flavor_now_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_UNEVIDENCED_FLAVOR_NOW_APPROVED_GH'
 #!/usr/bin/env bash
 case "$*" in
   *"auth status"*)
     exit 0 ;;
   *"pr view"*headRefOid*)
-    printf 'f1a000000d1234567890\n'; exit 0 ;;
+    printf 'fa000000d1234567890\n'; exit 0 ;;
   *"--method POST"*)
-    printf '{"id":913,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+    printf '{"id":713,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
   *"issues/comments/"*"/reactions"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/comments"*)
@@ -9811,28 +9813,253 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:963,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Fantastic job! **Reviewed commit:** `f1a000000d` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    jq -nc '[{id:763,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Fantastic job! **Reviewed commit:** `fa000000d` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
     printf 'ARGS=%q\n' "$*" >&2
     exit 64 ;;
 esac
-CODEX_FLAVOR_UNEVIDENCED_TOKEN_NOT_APPROVED_GH
-chmod +x "$_codex_flavor_unevidenced_token_not_approved_mock_dir/gh"
+CODEX_PLACEHOLDER_UNEVIDENCED_FLAVOR_NOW_APPROVED_GH
+chmod +x "$_codex_placeholder_unevidenced_flavor_now_approved_mock_dir/gh"
 
-_codex_flavor_unevidenced_token_not_approved_output=""
-_codex_flavor_unevidenced_token_not_approved_exit=0
-PATH="$_codex_flavor_unevidenced_token_not_approved_mock_dir:$PATH" \
+_codex_placeholder_unevidenced_flavor_now_approved_output=""
+_codex_placeholder_unevidenced_flavor_now_approved_exit=0
+PATH="$_codex_placeholder_unevidenced_flavor_now_approved_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
-  >"$_codex_flavor_unevidenced_token_not_approved_mock_dir/output.txt" 2>&1 || _codex_flavor_unevidenced_token_not_approved_exit=$?
-_codex_flavor_unevidenced_token_not_approved_output="$(cat "$_codex_flavor_unevidenced_token_not_approved_mock_dir/output.txt")"
-run_test "codex_flavor_unevidenced_token_not_approved_exit_needs_revision" "1" "$_codex_flavor_unevidenced_token_not_approved_exit"
-run_test "codex_flavor_unevidenced_token_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
-  "$(printf '%s\n' "$_codex_flavor_unevidenced_token_not_approved_output" | grep "^VERDICT:")"
-rm -rf "$_codex_flavor_unevidenced_token_not_approved_mock_dir"
-unset _codex_flavor_unevidenced_token_not_approved_mock_dir _codex_flavor_unevidenced_token_not_approved_output _codex_flavor_unevidenced_token_not_approved_exit
+  >"$_codex_placeholder_unevidenced_flavor_now_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_unevidenced_flavor_now_approved_exit=$?
+_codex_placeholder_unevidenced_flavor_now_approved_output="$(cat "$_codex_placeholder_unevidenced_flavor_now_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_unevidenced_flavor_now_approved_exit_clean" "0" "$_codex_placeholder_unevidenced_flavor_now_approved_exit"
+run_test "codex_placeholder_unevidenced_flavor_now_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_unevidenced_flavor_now_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_unevidenced_flavor_now_approved_mock_dir"
+unset _codex_placeholder_unevidenced_flavor_now_approved_mock_dir _codex_placeholder_unevidenced_flavor_now_approved_output _codex_placeholder_unevidenced_flavor_now_approved_exit
+
+# Boundary: a flavor slot of exactly 40 characters (the cap, inclusive)
+# still APPROVES — confirms the upper bound is inclusive, not an off-by-one
+# exclusion, matching the SHA field's own inclusive-upper-bound precedent
+# (codex_e7_full_length_sha_approved).
+_codex_placeholder_exactly_cap_length_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_exactly_cap_length_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_EXACTLY_CAP_LENGTH_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'fa000000e1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":714,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:764,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx **Reviewed commit:** `fa000000e` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_PLACEHOLDER_EXACTLY_CAP_LENGTH_APPROVED_GH
+chmod +x "$_codex_placeholder_exactly_cap_length_approved_mock_dir/gh"
+
+_codex_placeholder_exactly_cap_length_approved_output=""
+_codex_placeholder_exactly_cap_length_approved_exit=0
+PATH="$_codex_placeholder_exactly_cap_length_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_placeholder_exactly_cap_length_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_exactly_cap_length_approved_exit=$?
+_codex_placeholder_exactly_cap_length_approved_output="$(cat "$_codex_placeholder_exactly_cap_length_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_exactly_cap_length_approved_exit_clean" "0" "$_codex_placeholder_exactly_cap_length_approved_exit"
+run_test "codex_placeholder_exactly_cap_length_approved_verdict" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_placeholder_exactly_cap_length_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_exactly_cap_length_approved_mock_dir"
+unset _codex_placeholder_exactly_cap_length_approved_mock_dir _codex_placeholder_exactly_cap_length_approved_output _codex_placeholder_exactly_cap_length_approved_exit
+
+# Structure/length guard: a flavor slot of 41 characters (one past the cap)
+# safe-fails. Confirms the length cap is enforced, not merely documented.
+_codex_placeholder_exceeds_length_cap_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_exceeds_length_cap_not_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_EXCEEDS_LENGTH_CAP_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'fa000000f1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":715,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:765,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx **Reviewed commit:** `fa000000f` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_PLACEHOLDER_EXCEEDS_LENGTH_CAP_NOT_APPROVED_GH
+chmod +x "$_codex_placeholder_exceeds_length_cap_not_approved_mock_dir/gh"
+
+_codex_placeholder_exceeds_length_cap_not_approved_output=""
+_codex_placeholder_exceeds_length_cap_not_approved_exit=0
+PATH="$_codex_placeholder_exceeds_length_cap_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_placeholder_exceeds_length_cap_not_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_exceeds_length_cap_not_approved_exit=$?
+_codex_placeholder_exceeds_length_cap_not_approved_output="$(cat "$_codex_placeholder_exceeds_length_cap_not_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_exceeds_length_cap_not_approved_exit_needs_revision" "1" "$_codex_placeholder_exceeds_length_cap_not_approved_exit"
+run_test "codex_placeholder_exceeds_length_cap_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_placeholder_exceeds_length_cap_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_exceeds_length_cap_not_approved_mock_dir"
+unset _codex_placeholder_exceeds_length_cap_not_approved_mock_dir _codex_placeholder_exceeds_length_cap_not_approved_output _codex_placeholder_exceeds_length_cap_not_approved_exit
+
+# Structure guard: a flavor slot containing "*" safe-fails. Confirms the
+# excluded-character set protects the literal "**Reviewed commit:**"
+# bold-marker syntax immediately after this slot from being spoofed or
+# absorbed by an overly permissive placeholder.
+_codex_placeholder_asterisk_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_asterisk_not_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_ASTERISK_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'fa00000101234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":716,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:766,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Great **job** **Reviewed commit:** `fa0000010` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_PLACEHOLDER_ASTERISK_NOT_APPROVED_GH
+chmod +x "$_codex_placeholder_asterisk_not_approved_mock_dir/gh"
+
+_codex_placeholder_asterisk_not_approved_output=""
+_codex_placeholder_asterisk_not_approved_exit=0
+PATH="$_codex_placeholder_asterisk_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_placeholder_asterisk_not_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_asterisk_not_approved_exit=$?
+_codex_placeholder_asterisk_not_approved_output="$(cat "$_codex_placeholder_asterisk_not_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_asterisk_not_approved_exit_needs_revision" "1" "$_codex_placeholder_asterisk_not_approved_exit"
+run_test "codex_placeholder_asterisk_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_placeholder_asterisk_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_asterisk_not_approved_mock_dir"
+unset _codex_placeholder_asterisk_not_approved_mock_dir _codex_placeholder_asterisk_not_approved_output _codex_placeholder_asterisk_not_approved_exit
+
+# Structure guard: a flavor slot containing a backtick safe-fails. Confirms
+# the excluded-character set protects the backtick-delimited SHA field that
+# immediately follows this slot.
+_codex_placeholder_backtick_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_backtick_not_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_BACKTICK_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'fa00000111234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":717,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:767,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Nice `work` **Reviewed commit:** `fa0000011` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_PLACEHOLDER_BACKTICK_NOT_APPROVED_GH
+chmod +x "$_codex_placeholder_backtick_not_approved_mock_dir/gh"
+
+_codex_placeholder_backtick_not_approved_output=""
+_codex_placeholder_backtick_not_approved_exit=0
+PATH="$_codex_placeholder_backtick_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_placeholder_backtick_not_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_backtick_not_approved_exit=$?
+_codex_placeholder_backtick_not_approved_output="$(cat "$_codex_placeholder_backtick_not_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_backtick_not_approved_exit_needs_revision" "1" "$_codex_placeholder_backtick_not_approved_exit"
+run_test "codex_placeholder_backtick_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_placeholder_backtick_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_backtick_not_approved_mock_dir"
+unset _codex_placeholder_backtick_not_approved_mock_dir _codex_placeholder_backtick_not_approved_output _codex_placeholder_backtick_not_approved_exit
+
+# Structure/length guard via a distinct injection vector: a paragraph break
+# (blank line) inside the flavor position, followed by an extra sentence,
+# safe-fails once whitespace normalization (Decision 1, unchanged) collapses
+# the break to a single space and the flattened flavor text exceeds the
+# 40-character cap. Proves the length cap still catches injected content
+# smuggled in via a newline-separated paragraph, not only content appended
+# on the same line.
+_codex_placeholder_newline_separated_overflow_not_approved_mock_dir="$(mktemp -d)"
+cat > "$_codex_placeholder_newline_separated_overflow_not_approved_mock_dir/gh" <<'CODEX_PLACEHOLDER_NEWLINE_SEPARATED_OVERFLOW_NOT_APPROVED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'fa00000121234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf '{"id":718,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:768,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues.
+
+Rename the unsafe function immediately before merging this pull request please.
+
+**Reviewed commit:** `fa0000012` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_PLACEHOLDER_NEWLINE_SEPARATED_OVERFLOW_NOT_APPROVED_GH
+chmod +x "$_codex_placeholder_newline_separated_overflow_not_approved_mock_dir/gh"
+
+_codex_placeholder_newline_separated_overflow_not_approved_output=""
+_codex_placeholder_newline_separated_overflow_not_approved_exit=0
+PATH="$_codex_placeholder_newline_separated_overflow_not_approved_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_placeholder_newline_separated_overflow_not_approved_mock_dir/output.txt" 2>&1 || _codex_placeholder_newline_separated_overflow_not_approved_exit=$?
+_codex_placeholder_newline_separated_overflow_not_approved_output="$(cat "$_codex_placeholder_newline_separated_overflow_not_approved_mock_dir/output.txt")"
+run_test "codex_placeholder_newline_separated_overflow_not_approved_exit_needs_revision" "1" "$_codex_placeholder_newline_separated_overflow_not_approved_exit"
+run_test "codex_placeholder_newline_separated_overflow_not_approved_verdict" "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)" \
+  "$(printf '%s\n' "$_codex_placeholder_newline_separated_overflow_not_approved_output" | grep "^VERDICT:")"
+rm -rf "$_codex_placeholder_newline_separated_overflow_not_approved_mock_dir"
+unset _codex_placeholder_newline_separated_overflow_not_approved_mock_dir _codex_placeholder_newline_separated_overflow_not_approved_output _codex_placeholder_newline_separated_overflow_not_approved_exit
+
 
 
 _unlock_pr="80213$$"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -8974,6 +8974,7 @@ unset _codex_e24c_footer_byte_mutation_in_url_not_approved_mock_dir _codex_e24c_
 # from the others: a missing/mistyped gate at any one site still lets
 # this construction pass if it resolves at a different site.
 _codex_footer_near_miss_main_loop_safe_fails_mock_dir="$(mktemp -d)"
+printf '0\n' > "$_codex_footer_near_miss_main_loop_safe_fails_mock_dir/comment_calls"
 cat > "$_codex_footer_near_miss_main_loop_safe_fails_mock_dir/gh" <<'CODEX_FOOTER_NEAR_MISS_MAIN_LOOP_SAFE_FAILS_GH'
 #!/usr/bin/env bash
 case "$*" in
@@ -8990,7 +8991,26 @@ case "$*" in
   *"pulls/"*"/reviews"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    jq -nc '[{id:451,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. **Reviewed commit:** `face000001` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    calls_file="$(dirname "$0")/comment_calls"
+    calls="$(cat "$calls_file")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$calls_file"
+    # Call 1 is the pre-trigger dedup check (stays empty). Call 2 is the
+    # main poll loop's own bot-response check -- this is the ONLY call
+    # that returns the near-miss body, so this scenario genuinely
+    # isolates the main-loop verdict site: if main-loop's own gate is
+    # broken, no LATER site (async-arrival, async-final) ever sees this
+    # body again to independently rescue the correct verdict, since
+    # calls 3+ return empty and the run legitimately times out instead
+    # (issue #1491 implementation plan follow-up, PR #1494 review
+    # finding 3808305143: the original construction returned the
+    # near-miss body on every call, which let a still-correct
+    # async-arrival gate silently rescue a broken main-loop gate).
+    if [ "$calls" -eq 2 ]; then
+      jq -nc '[{id:451,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. **Reviewed commit:** `face000001` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    else
+      printf '[]\n'
+    fi
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
@@ -9049,8 +9069,13 @@ case "$*" in
     # Calls 1-2 are the pre-trigger dedup check and the main poll-loop's
     # bot-response check; both stay empty so execution falls through to
     # the async-arrival grace poll (call 3), which returns the near-miss
-    # body directly as SHA-pinned terminal evidence.
-    if [ "$calls" -ge 3 ]; then
+    # body directly as SHA-pinned terminal evidence. Calls 4+ return
+    # empty, so this scenario genuinely isolates the async-arrival
+    # verdict site rather than letting a later site (async-final)
+    # independently rediscover the same body and rescue a broken
+    # async-arrival gate (issue #1491 implementation plan follow-up,
+    # PR #1494 review finding 3808305143).
+    if [ "$calls" -eq 3 ]; then
       jq -nc '[{id:461,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. **Reviewed commit:** `face000002` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
     else
       printf '[]\n'


### PR DESCRIPTION
## Summary

Implements issue #1491's implementation plan (`docs/specs/developments/20260817203204_1491-conservative-verdict-classifier/2_1491-conservative-verdict-classifier_implementation-plan.md`, merged `a0b8f8c7`).

`codex_response_is_approved` in `codex-github-reviewer.sh` is rewritten from an open-ended negated-approval-vocabulary block-list to a whole-body, whitespace-normalized **exact match** against `CODEX_APPROVED_TEMPLATES` — a small set of clean-response templates captured verbatim from real Codex responses, each including the complete vendor `<details>` "About Codex in GitHub" footer. There is no truncation step: the footer is part of the literal being matched, not discarded before comparison, closing Codex GitHub finding `3803545669` (the finding that motivated this revision).

`codex_response_is_blocking` is unchanged (confirmed byte-identical to the merge base by function-range diff). Decision 6 gates the acknowledgement branch at all four verdict sites (main loop, async-arrival, async-final, async-reaction-final) on the evidence being non-terminal, so a footer-bearing near-miss on terminal evidence always safe-fails instead of being misrouted to a wait/timeout.

## Wire-format re-verification (Protocol 02 implementation-start check, mandated by the plan)

Re-fetched live Codex responses from PRs #1489, #1490, and #1492 before any edit:

- **Clean-response verdict sentence**: PR #1489's root comment still matches `CODEX_APPROVED_TEMPLATES`' entry exactly (verified by running the actual regex against the live capture).
- **Vendor `<details>` footer**: byte-identical (modulo one API-transport-only trailing newline, absorbed by whitespace normalization) across the PR #1489 root comment and every PR #1490/#1492 review body.

**Result: matched, no drift.** No stop-and-report was needed.

## Test disposition (derived fresh against the file, not carried forward from any prior revision)

- **Group APPROVED** (8 members): full body replacement with the exact template, preserving each scenario's distinguishing mock sequencing (2 template-anchored + 6 routing-testing scenarios: `codex_reaction_with_current_review`, `codex_reaction_then_late_review`, `codex_async_reaction_then_late_review`, `codex_main_loop_env_then_newer_review_supersedes`, `codex_latest_current_review`, `codex_environment_with_current_review`).
- **Group RETARGETED** (19 members): `VERDICT: APPROVED` → `VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)`, paired `exit_clean` `0` → `1`. 8 scenarios whose names asserted `stays_approved`/`_approved_` were renamed to `_safe_fails_` so the name never disagrees with the expectation. `codex_usage_limit_topic_mention_not_quota`'s competing root-comment fixture was also updated to the new exact template (Codex GitHub finding `3805611400`) so the tie-break still isolates whether the review is correctly classified rather than both sides collapsing into the same "unrecognized" tier.
- **Two additional fixtures found by executing the full suite** (outside the 27 `VERDICT: APPROVED`-asserting scenarios, so not caught by that enumeration): `codex_main_loop_env_then_review` (the `SEEN_ENVIRONMENT_ERROR`-supersede check lives inside the `is_approved` branch) and `codex_tied_usage_limit_with_approval_phrase` (an unrecognized body now outranks usage-limit in `codex_response_priority`, so the clean side of the tie must stay a real template).
- **New scenarios**: Parser-risk addendum E1, E2, E3, E5–E13, E15–E24 (E4 and E14 already covered by existing fixtures), including the real, live-fetched PR #1489/#1490 bodies, plus four `codex_footer_near_miss_*_safe_fails` scenarios — one per verdict site — proving Decision 6's gate is independently correct at each of its four hand-edited copies (verified by reverting only one site's gate in a scratch copy of the script and confirming only that scenario regressed to `TIMED_OUT`, the other three still passed).

## Verification

- `bash scripts/development-workflow/tests/test-pr-review-loop.sh`: **684 passed, 0 failed**.
- Comment-filtered deletion-list search for every symbol this plan or its prior revisions ever introduced: returns nothing.
- Five (not four) real call sites of `codex_response_is_approved` confirmed (the four verdict sites plus one inside `codex_response_priority`).
- `codex_strip_not_only_idiom`: comment-filtered count = 2 (definition + one call, inside `codex_response_is_blocking`).
- Merge-base (`a0b8f8c7d9b63ea0f2ace945f78990579ceca828`) function-range diff of `codex_response_is_blocking`, plus the `CODEX_BLOCKING_PATTERN`/`CODEX_MERGE_REFUSAL_PATTERN`/`CODEX_NEGATION_WORDS` definitions: **empty (byte-identical)**.
- Live-refetched PR #1489 body approves end-to-end through the real script; live-refetched PR #1490 review still safe-fails.
- All Parser-risk addendum edge cases (E14–E24) verified against the real script.
- Smoke test runbook (`docs/testing/workflow/1491-conservative-verdict-classifier.smoke-test.md`) walked in full — all 15 steps Pass, results recorded in the runbook.
- Lint: `markdownlint-cli2` (0 errors), `markdown-heuristic-lint.py` (exit 0), `check-changelog-duplicate-headers.sh` (passed), `workflow-shell-snippet-lint.py --base-ref origin/develop` (exit 0), `workflow-shell-guard-lint.py --base-ref origin/develop` (exit 0), `shellcheck --severity=warning` on both changed `.sh` files (only pre-existing, untouched warnings at unrelated lines).

## Self-review

Reviewed `git diff develop...HEAD`: no stale markers, no debug/TODO leftovers, no orphaned "stays_approved" variable-name remnants after the 8 scenario renames, no duplicate symbol definitions. `pr-review-loop.sh`, `AGENTS.md`, and `REVIEW.md` are untouched, matching the plan's explicit "no change" calls. The plan's own Decision-gate matrix (verdict strings, exit codes) is unchanged by this implementation — no new gate outcomes were introduced.

## Scope

Everything the plan specifies, nothing more. No changes to `pr-review-loop.sh` beyond what the classifier redesign strictly required (none were required — the redesign is entirely inside `codex-github-reviewer.sh`).

Closes #1491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
