### PR TITLE
fix(workflow): fail fast on missing --pr, document test harness timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -573,11 +573,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   approvals for unready PRs.
 - **`post-merge-cleanup.sh` fails fast on missing `--pr`**: the `--pr <merged-pr-number>`
   requirement for cleaning up an implementation branch's remote copy is now
-  checked immediately after the branch's ownership kind is resolved, before any
-  fetch/checkout/pull/delete work runs, instead of surfacing only after the rest
-  of cleanup had already mutated local state. The structured
-  `REMOTE_DELETE_RESULT`/`REMOTE_DELETE_REASON`/`ERROR_MESSAGE` output contract
-  is unchanged.
+  checked immediately after the branch's ownership kind is resolved (and after
+  the existing `workflow_hub` product-repo-selection check, preserving that
+  check's original priority), before any fetch/checkout/pull/delete work runs,
+  instead of surfacing only after the rest of cleanup had already mutated
+  local state. The structured `REMOTE_DELETE_RESULT`/`REMOTE_DELETE_REASON`/
+  `ERROR_MESSAGE` output is emitted from a single shared helper used by both
+  the new early guard and the pre-existing (now defensive, unreachable via
+  the main flow) check inside `cleanup_remote_implementation_branch()`, so the
+  message text can't drift between the two call sites. The early guard exits
+  with status 64, this script's usage-error convention shared by every other
+  argument-validation check, rather than the incidental status 1 that used to
+  result from `set -e` propagating the deep check's generic `return 1`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -584,7 +584,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   message text can't drift between the two call sites. The early guard exits
   with status 64, this script's usage-error convention shared by every other
   argument-validation check, rather than the incidental status 1 that used to
-  result from `set -e` propagating the deep check's generic `return 1`.
+  result from `set -e` propagating the deep check's generic `return 1`. A
+  planted-violation proof (both directions, including before/after
+  `git rev-parse HEAD` / `git branch --show-current` / `git for-each-ref` /
+  `git ls-remote` evidence that nothing mutates before the guard fires) and a
+  regression test proving a reverted guard placement turns the suite red are
+  recorded in [PR #1500](https://github.com/lhpaul/ai-dev-framework-template/pull/1500#issuecomment-5335650280).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -571,6 +571,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   against the current PR head, CodeRabbit CLI review evidence fails closed when
   PR metadata cannot be resolved, and batch merge rechecks preserve explicit
   approvals for unready PRs.
+- **`post-merge-cleanup.sh` fails fast on missing `--pr`**: the `--pr <merged-pr-number>`
+  requirement for cleaning up an implementation branch's remote copy is now
+  checked immediately after the branch's ownership kind is resolved, before any
+  fetch/checkout/pull/delete work runs, instead of surfacing only after the rest
+  of cleanup had already mutated local state. The structured
+  `REMOTE_DELETE_RESULT`/`REMOTE_DELETE_REASON`/`ERROR_MESSAGE` output contract
+  is unchanged.
 
 ### Changed
 

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -2,6 +2,21 @@
 
 Scripts used by the staged AI development workflow. Referenced by `docs/workflow/development-workflow/` and by the Codex skills in `.agents/skills/` and `.codex/skills/`. Run from the repository root.
 
+## Running the test suite
+
+Each script's tests live alongside it in `scripts/development-workflow/tests/` as
+`test-<script-name>.sh`. To run the full harness (every `test-*.sh` file in that
+directory), expect it to take **more than 2 minutes** as of this writing — invoke
+it with a longer explicit timeout, or in the background, rather than relying on
+a tool's default foreground command timeout:
+
+```bash
+for f in scripts/development-workflow/tests/test-*.sh; do bash "$f" || echo "FAILED: $f"; done
+```
+
+Individual `test-*.sh` files typically run in a few seconds each and are safe to
+invoke with a default foreground timeout.
+
 ## `install-codex-skills.sh`
 
 Installs the repository's bundled Codex skills into the local Codex skill directories by creating symlinks.

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -10,6 +10,8 @@ directory), expect it to take **more than 2 minutes** as of this writing — inv
 it with a longer explicit timeout, or in the background, rather than relying on
 a tool's default foreground command timeout:
 
+<!-- workflow-shell-contract: bash-zsh -->
+
 ```bash
 for f in scripts/development-workflow/tests/test-*.sh; do bash "$f" || echo "FAILED: $f"; done
 ```

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -13,11 +13,19 @@ a tool's default foreground command timeout:
 <!-- workflow-shell-contract: bash-zsh -->
 
 ```bash
-for f in scripts/development-workflow/tests/test-*.sh; do bash "$f" || echo "FAILED: $f"; done
+( harness_status=0
+  for f in scripts/development-workflow/tests/test-*.sh; do
+    bash "$f" || { echo "FAILED: $f"; harness_status=1; }
+  done
+  exit "$harness_status"
+)
 ```
 
-Individual `test-*.sh` files typically run in a few seconds each and are safe to
-invoke with a default foreground timeout.
+The subshell's exit status reflects the harness as a whole (0 only if every
+`test-*.sh` passed) — checking `$?` after the loop, or running it in CI, is
+enough to detect a failure even though each script's own PASS/FAIL lines keep
+scrolling past. Individual `test-*.sh` files typically run in a few seconds
+each and are safe to invoke with a default foreground timeout.
 
 ## `install-codex-skills.sh`
 

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -150,6 +150,14 @@ fi
 # argument-validation check above) rather than the incidental exit 1 that
 # resulted from cleanup_remote_implementation_branch()'s `return 1` plus
 # `set -e` when this condition was only checked there.
+#
+# Planted-violation proof (both directions, plus no-mutation evidence:
+# git rev-parse HEAD / git branch --show-current / git for-each-ref /
+# git ls-remote identical before and after the failing invocation) is
+# recorded at https://github.com/lhpaul/ai-dev-framework-template/pull/1500#issuecomment-5335650280
+# Regression coverage lives in
+# scripts/development-workflow/tests/test-post-merge-cleanup.sh
+# (unmerged_guard_fires_before_fetch and friends).
 if [ "$branch_owner_kind" = "implementation" ] && [ -z "$merged_pr_number" ]; then
   emit_pr_number_required_skip "$TO_DELETE"
   exit 64

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -123,23 +123,35 @@ case "$(branch_prefix "$TO_DELETE")" in
     ;;
 esac
 
-# Fail fast: --pr is required to clean up the remote copy of an implementation
-# branch (see cleanup_remote_implementation_branch() below). Check this before
-# any fetch/checkout/pull/delete work runs, so the error surfaces immediately
-# instead of after the rest of cleanup has already mutated local state. Emits
-# the same structured REMOTE_DELETE_* contract as the (now unreachable for
-# this specific case) check inside cleanup_remote_implementation_branch(), so
-# existing consumers of that output are unaffected.
-if [ "$branch_owner_kind" = "implementation" ] && [ -z "$merged_pr_number" ]; then
+# Shared with cleanup_remote_implementation_branch() below, which emits the
+# identical REMOTE_DELETE_* contract for the same condition when reached via
+# a different call path, so the two checks can't drift apart in wording.
+emit_pr_number_required_skip() {
+  local branch="$1"
   print_kv REMOTE_DELETE_RESULT "skipped"
   print_kv REMOTE_DELETE_REASON "pr_number_required"
-  print_kv_escaped ERROR_MESSAGE "Remote implementation branch '${TO_DELETE}' was not deleted because --pr <merged-pr-number> is required to bind cleanup to the exact merged PR."
-  echo "ERROR: remote implementation branch '$TO_DELETE' was not deleted because --pr <merged-pr-number> is required." >&2
-  exit 64
-fi
+  print_kv_escaped ERROR_MESSAGE "Remote implementation branch '${branch}' was not deleted because --pr <merged-pr-number> is required to bind cleanup to the exact merged PR."
+  echo "ERROR: remote implementation branch '$branch' was not deleted because --pr <merged-pr-number> is required." >&2
+}
 
 if [ "$workflow_mode" = "workflow_hub" ] && [ "$branch_owner_kind" = "implementation" ] && [ -z "$target_repo" ]; then
   echo "ERROR: product repository selection is required for implementation branch cleanup in workflow_hub mode; pass --repo <name>." >&2
+  exit 64
+fi
+
+# Fail fast: --pr is required to clean up the remote copy of an implementation
+# branch (see cleanup_remote_implementation_branch() below). Check this before
+# any fetch/checkout/pull/delete work runs, so the error surfaces immediately
+# instead of after the rest of cleanup has already mutated local state. Kept
+# after the workflow_hub product-repo-selection check above so the original
+# relative check priority (and therefore which error a caller sees first when
+# both --repo and --pr are missing in workflow_hub mode) is preserved exactly.
+# Uses exit 64 (this script's usage-error convention, matching every other
+# argument-validation check above) rather than the incidental exit 1 that
+# resulted from cleanup_remote_implementation_branch()'s `return 1` plus
+# `set -e` when this condition was only checked there.
+if [ "$branch_owner_kind" = "implementation" ] && [ -z "$merged_pr_number" ]; then
+  emit_pr_number_required_skip "$TO_DELETE"
   exit 64
 fi
 
@@ -285,10 +297,10 @@ cleanup_remote_implementation_branch() {
   fi
 
   if [ -z "$merged_pr_number" ]; then
-    print_kv REMOTE_DELETE_RESULT "skipped"
-    print_kv REMOTE_DELETE_REASON "pr_number_required"
-    print_kv_escaped ERROR_MESSAGE "Remote implementation branch '${branch}' was not deleted because --pr <merged-pr-number> is required to bind cleanup to the exact merged PR."
-    echo "ERROR: remote implementation branch '$branch' was not deleted because --pr <merged-pr-number> is required." >&2
+    # Unreachable via the main script flow above (the early guard near the
+    # top exits first), kept as a defensive check in case this function is
+    # ever called from another path in the future.
+    emit_pr_number_required_skip "$branch"
     return 1
   fi
 

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -123,6 +123,21 @@ case "$(branch_prefix "$TO_DELETE")" in
     ;;
 esac
 
+# Fail fast: --pr is required to clean up the remote copy of an implementation
+# branch (see cleanup_remote_implementation_branch() below). Check this before
+# any fetch/checkout/pull/delete work runs, so the error surfaces immediately
+# instead of after the rest of cleanup has already mutated local state. Emits
+# the same structured REMOTE_DELETE_* contract as the (now unreachable for
+# this specific case) check inside cleanup_remote_implementation_branch(), so
+# existing consumers of that output are unaffected.
+if [ "$branch_owner_kind" = "implementation" ] && [ -z "$merged_pr_number" ]; then
+  print_kv REMOTE_DELETE_RESULT "skipped"
+  print_kv REMOTE_DELETE_REASON "pr_number_required"
+  print_kv_escaped ERROR_MESSAGE "Remote implementation branch '${TO_DELETE}' was not deleted because --pr <merged-pr-number> is required to bind cleanup to the exact merged PR."
+  echo "ERROR: remote implementation branch '$TO_DELETE' was not deleted because --pr <merged-pr-number> is required." >&2
+  exit 64
+fi
+
 if [ "$workflow_mode" = "workflow_hub" ] && [ "$branch_owner_kind" = "implementation" ] && [ -z "$target_repo" ]; then
   echo "ERROR: product repository selection is required for implementation branch cleanup in workflow_hub mode; pass --repo <name>." >&2
   exit 64

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -246,6 +246,35 @@ run_test "unmerged_remote_ref_still_exists" "yes" "$(
   fi
 )"
 
+unmerged_before_local_head="$("$REAL_GIT" -C "$unmerged_repo" rev-parse HEAD)"
+unmerged_before_branch_sha="$("$REAL_GIT" -C "$unmerged_repo" rev-parse "refs/heads/$unmerged_branch")"
+set +e
+unmerged_no_mutation_output="$(
+  env WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+    PATH="$stub_bin:$PATH" \
+    "$HELPER" --repo-root "$unmerged_repo" --base develop "$unmerged_branch" 2>&1
+)"
+set -e
+unmerged_after_local_head="$("$REAL_GIT" -C "$unmerged_repo" rev-parse HEAD)"
+unmerged_after_branch_sha="$("$REAL_GIT" -C "$unmerged_repo" rev-parse "refs/heads/$unmerged_branch")"
+
+# Regression coverage for the no-mutation property: the pr_number_required
+# guard must fire before any fetch/checkout/pull/local-delete runs. Asserts
+# both that the "Fetching origin..." banner (printed immediately before the
+# first mutating git command) never appears, and that the local develop HEAD
+# and the target branch's local ref are byte-identical before and after the
+# failing invocation. A future refactor that moved the guard back below the
+# mutating work would make this fail.
+run_test "unmerged_guard_fires_before_fetch" "no" "$(
+  if grep -Fq "Fetching origin..." <<<"$unmerged_no_mutation_output"; then
+    printf 'yes'
+  else
+    printf 'no'
+  fi
+)"
+run_test "unmerged_guard_local_develop_head_unchanged" "$unmerged_before_local_head" "$unmerged_after_local_head"
+run_test "unmerged_guard_local_branch_ref_unchanged" "$unmerged_before_branch_sha" "$unmerged_after_branch_sha"
+
 fork_branch="feature/noissue-fork-pr"
 fork_repo="$(make_repo fork "$fork_branch" yes)"
 fork_output="$(


### PR DESCRIPTION
## Summary

Two small fixes from the item #1491 retrospective (findings 8a and 8c).

**8a — `post-merge-cleanup.sh` fails fast on missing `--pr`.** Previously the `--pr`-required check for implementation-branch remote cleanup ran *inside* `cleanup_remote_implementation_branch()`, i.e. after fetch, checkout, pull and local-branch delete had already executed. The operator saw the error only after local state had been mutated, and had to re-run the whole command. This bit during #1491's own post-merge cleanup.

**8c — harness runtime note.** `scripts/development-workflow/README.md` now documents that the full test harness runs >2 minutes and should be invoked with an extended timeout or in the background.

## Correction: the exemption claim in the original PR body was wrong

The first version of this description claimed the `REVIEW.md:324` planted-violation exemption (pure relocation, no behavior change). **The Step 7a review disproved that**, and the issue is fixed in `8448e88e`:

- **Ordering bug (real behavior change, fixed).** The early guard originally ran *before* the existing `workflow_hub` product-repo-selection check. For `workflow_hub` mode + implementation branch + missing **both** `--repo` and `--pr`, that flipped which error surfaced first (was: "product repository selection is required…"; became: `pr_number_required`). Verified by running the pre-PR script against the PR script in scratch repos. The guard now runs *after* the product-repo check, restoring the original priority while still firing before any mutating work.
- **Exit code (disclosed, deliberate).** In single-repo mode the old deep check returned exit 1 only as an incidental effect of `set -e` plus a generically-reused `return 1`; it was not a documented contract value. The new guard uses `exit 64`, this script's usage-error convention, matching every sibling argument-validation check. All in-repo callers (`prepare-release-post-merge-cleanup.sh`, `workflow-batch-plan.sh`, protocol and skill docs) branch on nonzero-vs-zero only, never the numeric value. Disclosed rather than claimed as byte-identical parity.

With the ordering fixed, the `REMOTE_DELETE_RESULT` / `REMOTE_DELETE_REASON` / `ERROR_MESSAGE` output contract is byte-identical to the pre-PR script for every input tested.

## Duplication question — resolved

The first version left the `pr_number_required` contract in two places. The review extracted the literals into a single `emit_pr_number_required_skip()` helper shared by both call sites, keeping the inner check as a defensive guard for other entry paths while eliminating string drift. The literal `"pr_number_required"` now appears exactly once (line 132).

## Verification

- `bash scripts/development-workflow/tests/test-post-merge-cleanup.sh` — **21 passed, 0 failed** (independently re-run).
- Guard exercised directly in single-repo mode without `--pr`: fails immediately with exit 64; `git rev-parse HEAD` and `git branch --show-current` unchanged, confirming no fetch/checkout/pull ran.
- `workflow_hub` mode missing both `--repo` and `--pr`: output now matches the pre-PR script byte-for-byte.
- Non-implementation branch kinds unaffected — guard requires `branch_owner_kind = "implementation"`; `spec_branch_expected_persistent` and `hub_sync_branch_skips_product_repo_requirement` still pass.
- `shellcheck`: clean (pre-existing SC1091 info only). `markdownlint-cli2`: 0 errors. `workflow-shell-snippet-lint.py`: clean after adding the required `bash-zsh` contract marker to the new README snippet. CHANGELOG duplicate-header and link-reference checks pass.

Retrospective source: item #1491 (PRs #1492, #1494). Sibling backlog items: #1495, #1496, #1497, #1498, #1499, #1501.