### PR TITLE
fix(workflow): backlog item Priority is silently never set (#1501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -612,7 +612,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   partial-success window where the post-creation required update could
   otherwise fail after the issue already existed, which a caller retrying
   on non-zero exit without inspecting stdout could turn into duplicate
-  issues (caught in code review on this PR). The rarer failure modes the
+  issues. The rarer failure modes the
   pre-check cannot see (issue unexpectedly missing from the board, a
   transient GraphQL write failure) still surface after issue creation but
   now exit with a distinct code (`5`) and an explicit "issue was already
@@ -622,25 +622,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   adapts to whatever the configured board actually supports — preferring
   `Medium` (this repo's board), falling back to `Normal` for downstream
   repos whose board is still set up per the framework's pre-#1501 docs
-  (also caught in code review on this PR, since `github-projects.md`
-  previously told every template consumer to create a `Normal` option), and
+  (`github-projects.md` previously told every template consumer to create
+  a `Normal` option), and
   leaving Priority unset (no error) only when a board's Priority field
   confirms neither candidate exists — the same way an omitted `--size` or
   `--type` is left unset. A Priority update failure no longer skips the
-  independent Type/Size updates that follow it in `create_cmd` (also caught
-  in code review on this PR) — every requested field is attempted before
+  independent Type/Size updates that follow it in `create_cmd` — every
+  requested field is attempted before
   the exit-5 partial-success signal is raised. `--priority` help text
   updated to match, including the new documented exit codes. Protocol 00's
   Priority inference heuristics now tell agents to **omit** `--priority`
-  for the routine/default case instead of hardcoding `--priority Medium`
-  (also caught in code review on this PR): an explicit value is validated
+  for the routine/default case instead of hardcoding `--priority Medium`:
+  an explicit value is validated
   against the board's real options and hard-fails if absent, so the
   authoritative example was itself bypassing the adaptive default it
   documented, breaking on any board still using `Normal`. `Urgent`,
   `High`, and `Low` are unaffected — those literals are common to both the
   current and legacy board vocabularies. `README.md` and Protocol 90's
-  abstract Priority ordering rules and summary templates (also caught in
-  code review on this PR) now list `Normal/Medium` as an equal-rank pair
+  abstract Priority ordering rules and summary templates now list
+  `Normal/Medium` as an equal-rank pair
   instead of only `Normal`, matching `workflow-batch-overlap.sh`'s existing
   `PRIORITY_RANK` table (which already ranked both names equally) — a real
   board can now literally carry a `Medium` Priority value after this fix,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -630,7 +630,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   independent Type/Size updates that follow it in `create_cmd` (also caught
   in code review on this PR) — every requested field is attempted before
   the exit-5 partial-success signal is raised. `--priority` help text
-  updated to match, including the new documented exit codes.
+  updated to match, including the new documented exit codes. Protocol 00's
+  Priority inference heuristics now tell agents to **omit** `--priority`
+  for the routine/default case instead of hardcoding `--priority Medium`
+  (also caught in code review on this PR): an explicit value is validated
+  against the board's real options and hard-fails if absent, so the
+  authoritative example was itself bypassing the adaptive default it
+  documented, breaking on any board still using `Normal`. `Urgent`,
+  `High`, and `Low` are unaffected — those literals are common to both the
+  current and legacy board vocabularies.
   Live reproduction on the real board (see issue #1501) showed `High`
   already worked correctly and the alias/default were the whole defect —
   no separate `High` resolution bug exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -638,7 +638,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   authoritative example was itself bypassing the adaptive default it
   documented, breaking on any board still using `Normal`. `Urgent`,
   `High`, and `Low` are unaffected — those literals are common to both the
-  current and legacy board vocabularies.
+  current and legacy board vocabularies. `README.md` and Protocol 90's
+  abstract Priority ordering rules and summary templates (also caught in
+  code review on this PR) now list `Normal/Medium` as an equal-rank pair
+  instead of only `Normal`, matching `workflow-batch-overlap.sh`'s existing
+  `PRIORITY_RANK` table (which already ranked both names equally) — a real
+  board can now literally carry a `Medium` Priority value after this fix,
+  and the framework's own prioritization docs previously had no rule for it.
   Live reproduction on the real board (see issue #1501) showed `High`
   already worked correctly and the alias/default were the whole defect —
   no separate `High` resolution bug exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -604,15 +604,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   applies narrowly to the Priority field via a new opt-in `required` mode
   on `update_tracker_named_field_best_effort` — the Type and Size helpers,
   and cases where the tracker provider or project genuinely does not apply,
-  remain best-effort as before. `add-backlog-item.sh` also now validates the
-  effective priority against the board's real Priority field options via the
-  new no-mutation `workflow_tracker_priority_resolvable` check **before**
-  calling `gh issue create`, so an unresolvable value is rejected without
-  ever creating the issue — closing a partial-success window where the
-  post-creation required update could fail after the issue already existed,
-  which a caller retrying on non-zero exit without inspecting stdout could
-  otherwise turn into duplicate issues (caught in code review on this PR).
-  `--priority` help text updated to match.
+  remain best-effort as before. `add-backlog-item.sh` now validates an
+  explicit `--priority` against the board's real Priority field options via
+  the new no-mutation `workflow_tracker_priority_resolvable` check
+  **before** calling `gh issue create`, so an unresolvable explicit value is
+  rejected without ever creating the issue (exit 1) — closing a
+  partial-success window where the post-creation required update could
+  otherwise fail after the issue already existed, which a caller retrying
+  on non-zero exit without inspecting stdout could turn into duplicate
+  issues (caught in code review on this PR). The rarer failure modes the
+  pre-check cannot see (issue unexpectedly missing from the board, a
+  transient GraphQL write failure) still surface after issue creation but
+  now exit with a distinct code (`5`) and an explicit "issue was already
+  created, do not retry" message instead of a generic failure. The
+  implicit **default** (used when `--priority` is omitted) is no longer a
+  single hardcoded literal either: the new `workflow_tracker_default_priority_value`
+  adapts to whatever the configured board actually supports — preferring
+  `Medium` (this repo's board), falling back to `Normal` for downstream
+  repos whose board is still set up per the framework's pre-#1501 docs
+  (also caught in code review on this PR, since `github-projects.md`
+  previously told every template consumer to create a `Normal` option), and
+  leaving Priority unset (no error) only when a board's Priority field
+  confirms neither candidate exists — the same way an omitted `--size` or
+  `--type` is left unset. `--priority` help text updated to match.
   Live reproduction on the real board (see issue #1501) showed `High`
   already worked correctly and the alias/default were the whole defect —
   no separate `High` resolution bug exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -590,6 +590,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `git ls-remote` evidence that nothing mutates before the guard fires) and a
   regression test proving a reverted guard placement turns the suite red are
   recorded in [PR #1500](https://github.com/lhpaul/ai-dev-framework-template/pull/1500#issuecomment-5335650280).
+- **Backlog item Priority was silently never set**: `update_tracker_priority_best_effort`
+  in `workflow-lib.sh` rewrote `Medium` — the board's actual Priority field
+  option — into `Normal`, a value that does not exist on the board, so the
+  mutation could never resolve; the inverted alias is removed, and
+  `add-backlog-item.sh`'s implicit default (used whenever `--priority` is
+  omitted) changes from the nonexistent `Normal` to `Medium`. Priority
+  resolution already read the project's actual field options dynamically
+  (no hardcoded value list to fix there). A requested priority that still
+  cannot be resolved against the board's real options is now a hard error
+  (non-zero exit, `Error:`-prefixed message) instead of a fail-open
+  `Warning:` that let the item get created with no priority at all; this
+  applies narrowly to the Priority field via a new opt-in `required` mode
+  on `update_tracker_named_field_best_effort` — the Type and Size helpers,
+  and cases where the tracker provider or project genuinely does not apply,
+  remain best-effort as before. `--priority` help text updated to match.
+  Live reproduction on the real board (see issue #1501) showed `High`
+  already worked correctly and the alias/default were the whole defect —
+  no separate `High` resolution bug exists.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -626,7 +626,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previously told every template consumer to create a `Normal` option), and
   leaving Priority unset (no error) only when a board's Priority field
   confirms neither candidate exists — the same way an omitted `--size` or
-  `--type` is left unset. `--priority` help text updated to match.
+  `--type` is left unset. A Priority update failure no longer skips the
+  independent Type/Size updates that follow it in `create_cmd` (also caught
+  in code review on this PR) — every requested field is attempted before
+  the exit-5 partial-success signal is raised. `--priority` help text
+  updated to match, including the new documented exit codes.
   Live reproduction on the real board (see issue #1501) showed `High`
   already worked correctly and the alias/default were the whole defect —
   no separate `High` resolution bug exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -604,7 +604,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   applies narrowly to the Priority field via a new opt-in `required` mode
   on `update_tracker_named_field_best_effort` — the Type and Size helpers,
   and cases where the tracker provider or project genuinely does not apply,
-  remain best-effort as before. `--priority` help text updated to match.
+  remain best-effort as before. `add-backlog-item.sh` also now validates the
+  effective priority against the board's real Priority field options via the
+  new no-mutation `workflow_tracker_priority_resolvable` check **before**
+  calling `gh issue create`, so an unresolvable value is rejected without
+  ever creating the issue — closing a partial-success window where the
+  post-creation required update could fail after the issue already existed,
+  which a caller retrying on non-zero exit without inspecting stdout could
+  otherwise turn into duplicate issues (caught in code review on this PR).
+  `--priority` help text updated to match.
   Live reproduction on the real board (see issue #1501) showed `High`
   already worked correctly and the alias/default were the whole defect —
   no separate `High` resolution bug exists.

--- a/docs/workflow/development-workflow/README.md
+++ b/docs/workflow/development-workflow/README.md
@@ -371,7 +371,9 @@ Typical tracker fields worth keeping current:
 When multiple items could advance, use this order:
 
 1. Due date within the next two weeks, earliest first.
-2. Priority: Urgent -> High -> Normal -> Low.
+2. Priority: Urgent -> High -> Normal/Medium -> Low. (`Normal` and `Medium` rank
+   equally — different GitHub Projects boards use one or the other for the
+   same "routine" tier; see `workflow-batch-overlap.sh`'s `PRIORITY_RANK`.)
 3. Earlier-created items before newer items.
 
 Dependencies override priority. If a work item depends on another item that is not yet `Merged` or `Released`, it should wait.

--- a/docs/workflow/development-workflow/integrations/github-projects.md
+++ b/docs/workflow/development-workflow/integrations/github-projects.md
@@ -91,7 +91,7 @@ Add these custom fields to the project (via project settings UI or GraphQL):
 
 | Field    | Type                                                         | Purpose                                                                                 |
 | -------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
-| Priority | Single select: `Urgent`, `High`, `Normal`, `Low`             | Drives orchestrator prioritization                                                      |
+| Priority | Single select: `Urgent`, `High`, `Medium`, `Low`             | Drives orchestrator prioritization                                                      |
 | Size     | Single select: `XS`, `S`, `M`, `L`, `XL`                    | Drives work sizing and sprint planning                                                  |
 | Due date | Date                                                         | Items due within 2 weeks get priority boost                                             |
 | Type     | Single select: `Feature`, `Bug`, `Refactor`, `Workflow`      | Source of truth for work-item classification and workflow path routing                  |

--- a/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
+++ b/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
@@ -94,15 +94,18 @@ assets or a fidelity baseline.
 
 ### Priority and Size inference heuristics (GitHub Projects)
 
-**Priority** — default `Normal` unless there is explicit urgency signal.
-`Medium` remains accepted by helper scripts as a backward-compatible alias for
-`Normal`:
+**Priority** — default `Medium` unless there is explicit urgency signal. The
+value must match one of the board's actual Priority field options (see
+[`github-projects.md`](../integrations/github-projects.md)); typical boards
+use `Urgent`, `High`, `Medium`, `Low`. A value that does not resolve against
+the board's Priority options is a hard error from the helper script (see
+below), not a silent no-op:
 
 | Signal | Priority |
 | ------ | -------- |
 | Human uses words like "urgent", "blocking", "ASAP", "critical", or "production issue" | `Urgent` or `High` |
 | Item blocks another in-progress item or a pending release | `High` |
-| Standard new feature, improvement, or process fix | `Normal` (default) |
+| Standard new feature, improvement, or process fix | `Medium` (default) |
 | Nice-to-have, polish, or exploratory work | `Low` |
 
 **Size** — infer from the scope of the change implied by the request:
@@ -121,11 +124,11 @@ Pass inferred values directly to the helper:
 ./scripts/development-workflow/add-backlog-item.sh create \
   --title "..." \
   --body-file - \
-  --priority Normal \
+  --priority Medium \
   --size S
 ```
 
-When the scope is genuinely unclear after reading the request, omit `--size` (leave it unset) rather than guessing. Do not omit `--priority` — the script defaults to `Normal` when the flag is absent.
+When the scope is genuinely unclear after reading the request, omit `--size` (leave it unset) rather than guessing. Do not omit `--priority` — the script defaults to `Medium` when the flag is absent.
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
+++ b/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
@@ -94,19 +94,30 @@ assets or a fidelity baseline.
 
 ### Priority and Size inference heuristics (GitHub Projects)
 
-**Priority** — default `Medium` unless there is explicit urgency signal. The
-value must match one of the board's actual Priority field options (see
-[`github-projects.md`](../integrations/github-projects.md)); typical boards
-use `Urgent`, `High`, `Medium`, `Low`. A value that does not resolve against
-the board's Priority options is a hard error from the helper script (see
-below), not a silent no-op:
+**Priority** — infer from the request. When no explicit urgency/low signal
+applies (the routine case), **omit `--priority` entirely** and let the
+helper script's adaptive default resolve it against the board's actual
+Priority field options (`Medium` if present, else `Normal` for a board not
+yet migrated off the framework's pre-#1501 setup docs — see
+[`github-projects.md`](../integrations/github-projects.md) and
+`workflow_tracker_default_priority_value` in `workflow-lib.sh`). Do
+**not** hardcode an explicit `--priority Medium` (or `Normal`) for the
+routine case: an explicit value is validated against the board's real
+options and is a hard error if it does not resolve, so hardcoding either
+literal can break on a board configured with the other one.
+
+`Urgent`, `High`, and `Low` are common to both the current and legacy
+Priority vocabularies, so it is safe to pass those explicitly whenever a
+genuine signal applies — a value that does not resolve against the board's
+Priority options is a hard error from the helper script (see below), not a
+silent no-op:
 
 | Signal | Priority |
 | ------ | -------- |
-| Human uses words like "urgent", "blocking", "ASAP", "critical", or "production issue" | `Urgent` or `High` |
-| Item blocks another in-progress item or a pending release | `High` |
-| Standard new feature, improvement, or process fix | `Medium` (default) |
-| Nice-to-have, polish, or exploratory work | `Low` |
+| Human uses words like "urgent", "blocking", "ASAP", "critical", or "production issue" | `--priority Urgent` or `--priority High` |
+| Item blocks another in-progress item or a pending release | `--priority High` |
+| Standard new feature, improvement, or process fix | Omit `--priority` (adaptive default) |
+| Nice-to-have, polish, or exploratory work | `--priority Low` |
 
 **Size** — infer from the scope of the change implied by the request:
 
@@ -124,11 +135,12 @@ Pass inferred values directly to the helper:
 ./scripts/development-workflow/add-backlog-item.sh create \
   --title "..." \
   --body-file - \
-  --priority Medium \
   --size S
 ```
 
-When the scope is genuinely unclear after reading the request, omit `--size` (leave it unset) rather than guessing. Do not omit `--priority` — the script defaults to `Medium` when the flag is absent.
+This example omits `--priority` for the routine case shown in the table above, so the helper script's adaptive default applies. Pass `--priority Urgent`, `--priority High`, or `--priority Low` explicitly only when the corresponding signal from the table applies.
+
+When the scope is genuinely unclear after reading the request, omit `--size` (leave it unset) rather than guessing.
 
 ---
 

--- a/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md
@@ -462,7 +462,9 @@ When no dispatch-eligible work exists, the orchestrator must still evaluate prop
 When multiple items are eligible or proposal-eligible, prioritize as follows:
 
 1. Due date within 2 weeks, earliest first
-2. Priority: Urgent → High → Normal → Low
+2. Priority: Urgent → High → Normal/Medium → Low (`Normal` and `Medium` rank equally
+   — different GitHub Projects boards use one or the other for the same "routine"
+   tier; see `workflow-batch-overlap.sh`'s `PRIORITY_RANK`)
 3. Creation date, earlier first
 
 If a due date conflicts with the abstract priority order, flag it to the human rather than silently choosing.
@@ -851,7 +853,8 @@ held consumer items and their reason (e.g., `held — pending tool-fix merge for
 **Multiple tool-fix items**: When two or more tool-fix items appear in the same candidate batch,
 each is serialized into its own serial sub-batch dispatched one at a time before any consumer
 item is dispatched. The ordering among multiple tool-fix items follows the standard priority
-order — due date within 2 weeks (earliest first), then priority (Urgent → High → Normal → Low),
+order — due date within 2 weeks (earliest first), then priority (Urgent → High →
+Normal/Medium → Low; `Normal` and `Medium` rank equally),
 then creation date (earliest first) — mirroring the Step 2 priority rules.
 
 #### Foundational reviewer-tool merge ordering
@@ -919,7 +922,8 @@ sets share at least one common path. Paths are compared as normalized, repo-root
 moved to the next serial sub-batch. The higher-priority item remains in the current batch.
 Priority is determined by the orchestrator using the following ordered tiebreakers:
 
-1. Item priority level: Urgent > High > Normal > Low (orchestrator applies from tracker data)
+1. Item priority level: Urgent > High > Normal/Medium > Low (`Normal` and `Medium`
+   rank equally; orchestrator applies from tracker data)
 2. Creation date: the older item (earlier creation date) stays in the current batch
    (orchestrator applies from tracker data or development folder timestamp prefix)
 3. Branch name lexicographic order: the lexicographically earlier branch name stays
@@ -2025,8 +2029,8 @@ After all currently eligible items have reached a terminal condition, provide a 
 
 ### Proposed Start Batch
 
-- [Issue #N] — [title] — priority: [Urgent/High/Normal/Low] — next stage: [Spec/Plan] — [parallelization note]
-- [Issue #M] — [title] — priority: [Urgent/High/Normal/Low] — next stage: [Spec/Plan] — [parallelization note]
+- [Issue #N] — [title] — priority: [Urgent/High/Normal/Medium/Low] — next stage: [Spec/Plan] — [parallelization note]
+- [Issue #M] — [title] — priority: [Urgent/High/Normal/Medium/Low] — next stage: [Spec/Plan] — [parallelization note]
 
 Approval required before tracker status changes or branch/PR work starts for these Backlog items.
 

--- a/scripts/development-workflow/add-backlog-item.sh
+++ b/scripts/development-workflow/add-backlog-item.sh
@@ -47,7 +47,9 @@ Exit codes (create, GitHub destination):
      actual Priority options; no issue was created.
   5  Partial success: the issue WAS created (see the printed URL) but the
      required post-creation Priority update failed — do not retry issue
-     creation; retry only the Priority update, or set it manually.
+     creation; retry only the Priority update, or set it manually. Type and
+     Size updates (if requested) are attempted independently and are not
+     skipped by a Priority failure.
 EOF
 }
 
@@ -210,18 +212,26 @@ create_cmd() {
     # Those necessarily surface after issue creation, at which point the issue URL has already
     # been printed to stdout above — do not let a failure here look identical to "nothing
     # happened": exit with a distinct code (5) and an explicit message so a caller does not retry
-    # `create` and mint a duplicate issue (see issue #1501 code review).
+    # `create` and mint a duplicate issue (see issue #1501 code review). Field updates are
+    # independent of each other, so a Priority failure must not prevent Type/Size from being
+    # attempted (issue #1501 code review, "Continue requested field updates after Priority
+    # failure") — priority_update_failed defers the exit-5 signal until every requested field
+    # has had its chance to run.
+    local priority_update_failed=0
     if [ -n "$type_label" ]; then
       update_tracker_type_best_effort "$issue_number" "$type_label"
     fi
     if [ -n "$effective_priority" ]; then
       if ! update_tracker_priority_best_effort "$issue_number" "$effective_priority"; then
-        echo "Error: issue #${issue_number} was already created (${issue_url}) — the required post-creation Priority update failed (see the Error above). Do NOT retry issue creation; instead retry only the Priority update for issue #${issue_number}, or set it manually on the project board." >&2
-        exit 5
+        priority_update_failed=1
       fi
     fi
     if [ -n "$size" ]; then
       update_tracker_size_best_effort "$issue_number" "$size"
+    fi
+    if [ "$priority_update_failed" -eq 1 ]; then
+      echo "Error: issue #${issue_number} was already created (${issue_url}) — the required post-creation Priority update failed (see the Error above). Do NOT retry issue creation; instead retry only the Priority update for issue #${issue_number}, or set it manually on the project board." >&2
+      exit 5
     fi
     return 0
   fi

--- a/scripts/development-workflow/add-backlog-item.sh
+++ b/scripts/development-workflow/add-backlog-item.sh
@@ -27,13 +27,27 @@ create
                       resolved against the project's actual Priority field
                       options (see docs/workflow/development-workflow/integrations/github-projects.md);
                       typical boards use Urgent, High, Medium, Low.
-                      When omitted, defaults to Medium for GitHub Projects.
-                      A value that cannot be resolved against the board's
-                      Priority options is a hard error (non-zero exit).
+                      When given explicitly, it is validated BEFORE the issue
+                      is created; a value that cannot be resolved against the
+                      board's Priority options is a hard error (exit 1) and no
+                      issue is created.
+                      When omitted, the default adapts to the configured
+                      board: "Medium" if present, else "Normal" (for boards
+                      still set up per the framework's pre-#1501 docs), else
+                      left unset — never a hard error for the default case.
   --size <value>      Optional. Set the project Size field. Valid values: XS, S, M, L, XL.
                       When omitted, the Size field is left unset.
   --type <value>      Optional. Set the project classification field. Valid values: Feature, Bug,
                       Refactor, Workflow. When omitted, the Type field is left unset.
+
+Exit codes (create, GitHub destination):
+  0  Success (including a resolved-value tracker-field skip when the tracker
+     provider/project genuinely does not apply).
+  1  A value passed to --priority could not be resolved against the board's
+     actual Priority options; no issue was created.
+  5  Partial success: the issue WAS created (see the printed URL) but the
+     required post-creation Priority update failed — do not retry issue
+     creation; retry only the Priority update, or set it manually.
 EOF
 }
 
@@ -119,20 +133,32 @@ create_cmd() {
       echo "create: --title is required" >&2
       exit 2
     fi
-    # Resolve the effective priority and validate it against the project's
-    # actual Priority field options BEFORE creating the issue. This avoids a
-    # partial-success window: without this pre-check, an invalid/unmigrated
-    # priority value would only be caught by the required post-creation
-    # update below, after `gh issue create` had already created the issue —
-    # so a caller that retries on non-zero exit without inspecting stdout
-    # could create a duplicate issue for every retry (see issue #1501 code
-    # review). workflow_tracker_priority_resolvable is a no-op read-only
-    # check (no mutation); it returns 0 (don't block) whenever the tracker
-    # provider/project don't apply or the check itself is inconclusive, so
-    # this pre-check cannot introduce new false rejections — only a
-    # confirmed-invalid value blocks issue creation here.
-    local effective_priority="${priority:-Medium}"
-    if ! workflow_tracker_priority_resolvable "$effective_priority"; then
+    # Resolve the effective priority BEFORE creating the issue.
+    #
+    # Explicit --priority: validated against the project's actual Priority
+    # field options before `gh issue create` runs. Without this pre-check,
+    # an invalid/unmigrated value would only be caught by the required
+    # post-creation update further below, after the issue had already been
+    # created — so a caller that retries on non-zero exit without
+    # inspecting stdout could create a duplicate issue for every retry (see
+    # issue #1501 code review). workflow_tracker_priority_resolvable is a
+    # no-op read-only check (no mutation); it returns 0 (don't block)
+    # whenever the tracker provider/project don't apply or the check itself
+    # is inconclusive, so this pre-check cannot introduce new false
+    # rejections — only a confirmed-invalid explicit value blocks issue
+    # creation here.
+    #
+    # Omitted --priority: adapts to whatever the configured board actually
+    # supports (preferring "Medium", falling back to "Normal" for boards
+    # still set up per the framework's pre-#1501 docs) instead of assuming
+    # a single universal literal. This never blocks issue creation — an
+    # unresolvable default just leaves Priority unset, the same way an
+    # omitted --size or --type is left unset (see issue #1501 code review,
+    # "Preserve compatibility with Normal-priority boards").
+    local effective_priority="$priority"
+    if [ -z "$effective_priority" ]; then
+      effective_priority="$(workflow_tracker_default_priority_value)"
+    elif ! workflow_tracker_priority_resolvable "$effective_priority"; then
       echo "Error: could not resolve 'Priority' option '${effective_priority}' against the configured GitHub Project; no issue was created. Pass a value from the board's actual Priority field options (see docs/workflow/development-workflow/integrations/github-projects.md), or configure the field, before retrying." >&2
       exit 1
     fi
@@ -174,19 +200,26 @@ create_cmd() {
     ensure_on_project_board "$issue_number" "Backlog"
     # Update project Type, Priority, and Size when GitHub Projects is configured.
     # update_tracker_type_best_effort and update_tracker_size_best_effort are fail-open (always
-    # return 0). update_tracker_priority_best_effort is a hard error (non-zero exit) when the
-    # tracker provider/project are configured but the requested priority value cannot be resolved
-    # against the board's actual Priority field options — under `set -euo pipefail` this aborts
-    # the script so a bad or stale priority value is never silently dropped. The common case
-    # (an invalid effective_priority) is already caught by workflow_tracker_priority_resolvable
-    # above, before the issue was created; this call remains a required safety net for the rarer
-    # cases the pre-check cannot see (e.g. the issue unexpectedly missing from the board, or a
-    # transient GraphQL write failure) — those necessarily surface after issue creation, at which
-    # point the issue URL has already been printed to stdout above.
+    # return 0). effective_priority is empty only when the default adapter above found no safe
+    # value (see its docstring) — skip the call entirely in that case, same as omitted --size/--type.
+    #
+    # When effective_priority is non-empty, update_tracker_priority_best_effort runs in required
+    # mode: the common failure case (an invalid value) was already ruled out above, before the
+    # issue was created, so this call is a safety net for the rarer cases the pre-check cannot see
+    # (e.g. the issue unexpectedly missing from the board, or a transient GraphQL write failure).
+    # Those necessarily surface after issue creation, at which point the issue URL has already
+    # been printed to stdout above — do not let a failure here look identical to "nothing
+    # happened": exit with a distinct code (5) and an explicit message so a caller does not retry
+    # `create` and mint a duplicate issue (see issue #1501 code review).
     if [ -n "$type_label" ]; then
       update_tracker_type_best_effort "$issue_number" "$type_label"
     fi
-    update_tracker_priority_best_effort "$issue_number" "$effective_priority"
+    if [ -n "$effective_priority" ]; then
+      if ! update_tracker_priority_best_effort "$issue_number" "$effective_priority"; then
+        echo "Error: issue #${issue_number} was already created (${issue_url}) — the required post-creation Priority update failed (see the Error above). Do NOT retry issue creation; instead retry only the Priority update for issue #${issue_number}, or set it manually on the project board." >&2
+        exit 5
+      fi
+    fi
     if [ -n "$size" ]; then
       update_tracker_size_best_effort "$issue_number" "$size"
     fi

--- a/scripts/development-workflow/add-backlog-item.sh
+++ b/scripts/development-workflow/add-backlog-item.sh
@@ -23,9 +23,13 @@ create
   When DESTINATION_KIND is github, creates one GitHub issue via gh (requires gh auth).
   For linear, other, or none, exits non-zero with guidance (agents follow 00-add-backlog-item-protocol.md).
 
-  --priority <value>  Optional. Set the project Priority field. Valid values: Urgent, High, Normal, Low.
-                      Medium is accepted as a backward-compatible alias for Normal.
-                      When omitted, defaults to Normal for GitHub Projects.
+  --priority <value>  Optional. Set the project Priority field. The value is
+                      resolved against the project's actual Priority field
+                      options (see docs/workflow/development-workflow/integrations/github-projects.md);
+                      typical boards use Urgent, High, Medium, Low.
+                      When omitted, defaults to Medium for GitHub Projects.
+                      A value that cannot be resolved against the board's
+                      Priority options is a hard error (non-zero exit).
   --size <value>      Optional. Set the project Size field. Valid values: XS, S, M, L, XL.
                       When omitted, the Size field is left unset.
   --type <value>      Optional. Set the project classification field. Valid values: Feature, Bug,
@@ -151,12 +155,16 @@ create_cmd() {
     # Ensure the issue is on the project board (adds it with Status=Backlog if absent).
     # The ensure_on_project_board helper is fail-open; it always returns 0.
     ensure_on_project_board "$issue_number" "Backlog"
-    # Update project Type, Priority (default Normal), and Size when GitHub Projects is configured.
-    # The update_tracker_*_best_effort helpers are fail-open; they always return 0.
+    # Update project Type, Priority (default Medium), and Size when GitHub Projects is configured.
+    # update_tracker_type_best_effort and update_tracker_size_best_effort are fail-open (always
+    # return 0). update_tracker_priority_best_effort is a hard error (non-zero exit) when the
+    # tracker provider/project are configured but the requested priority value cannot be resolved
+    # against the board's actual Priority field options — under `set -euo pipefail` this aborts
+    # the script so a bad or stale priority value is never silently dropped.
     if [ -n "$type_label" ]; then
       update_tracker_type_best_effort "$issue_number" "$type_label"
     fi
-    local effective_priority="${priority:-Normal}"
+    local effective_priority="${priority:-Medium}"
     update_tracker_priority_best_effort "$issue_number" "$effective_priority"
     if [ -n "$size" ]; then
       update_tracker_size_best_effort "$issue_number" "$size"

--- a/scripts/development-workflow/add-backlog-item.sh
+++ b/scripts/development-workflow/add-backlog-item.sh
@@ -119,6 +119,23 @@ create_cmd() {
       echo "create: --title is required" >&2
       exit 2
     fi
+    # Resolve the effective priority and validate it against the project's
+    # actual Priority field options BEFORE creating the issue. This avoids a
+    # partial-success window: without this pre-check, an invalid/unmigrated
+    # priority value would only be caught by the required post-creation
+    # update below, after `gh issue create` had already created the issue —
+    # so a caller that retries on non-zero exit without inspecting stdout
+    # could create a duplicate issue for every retry (see issue #1501 code
+    # review). workflow_tracker_priority_resolvable is a no-op read-only
+    # check (no mutation); it returns 0 (don't block) whenever the tracker
+    # provider/project don't apply or the check itself is inconclusive, so
+    # this pre-check cannot introduce new false rejections — only a
+    # confirmed-invalid value blocks issue creation here.
+    local effective_priority="${priority:-Medium}"
+    if ! workflow_tracker_priority_resolvable "$effective_priority"; then
+      echo "Error: could not resolve 'Priority' option '${effective_priority}' against the configured GitHub Project; no issue was created. Pass a value from the board's actual Priority field options (see docs/workflow/development-workflow/integrations/github-projects.md), or configure the field, before retrying." >&2
+      exit 1
+    fi
     if [ -n "$body_file" ]; then
       body="$(cat -- "$body_file")"
     fi
@@ -155,16 +172,20 @@ create_cmd() {
     # Ensure the issue is on the project board (adds it with Status=Backlog if absent).
     # The ensure_on_project_board helper is fail-open; it always returns 0.
     ensure_on_project_board "$issue_number" "Backlog"
-    # Update project Type, Priority (default Medium), and Size when GitHub Projects is configured.
+    # Update project Type, Priority, and Size when GitHub Projects is configured.
     # update_tracker_type_best_effort and update_tracker_size_best_effort are fail-open (always
     # return 0). update_tracker_priority_best_effort is a hard error (non-zero exit) when the
     # tracker provider/project are configured but the requested priority value cannot be resolved
     # against the board's actual Priority field options — under `set -euo pipefail` this aborts
-    # the script so a bad or stale priority value is never silently dropped.
+    # the script so a bad or stale priority value is never silently dropped. The common case
+    # (an invalid effective_priority) is already caught by workflow_tracker_priority_resolvable
+    # above, before the issue was created; this call remains a required safety net for the rarer
+    # cases the pre-check cannot see (e.g. the issue unexpectedly missing from the board, or a
+    # transient GraphQL write failure) — those necessarily surface after issue creation, at which
+    # point the issue URL has already been printed to stdout above.
     if [ -n "$type_label" ]; then
       update_tracker_type_best_effort "$issue_number" "$type_label"
     fi
-    local effective_priority="${priority:-Medium}"
     update_tracker_priority_best_effort "$issue_number" "$effective_priority"
     if [ -n "$size" ]; then
       update_tracker_size_best_effort "$issue_number" "$size"

--- a/scripts/development-workflow/tests/test-add-backlog-item.sh
+++ b/scripts/development-workflow/tests/test-add-backlog-item.sh
@@ -78,11 +78,31 @@ case "$*" in
         printf '{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_123","project":{"id":"PVT_project_1","number":1},"status":{"name":"Backlog"},"type":{"name":"Feature"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}\n'
         ;;
       *"fields(first:"*)
-        # Matches the real board's Priority options verified on issue #1501:
-        # Urgent, High, Medium, Low — there is no "Normal" option.
-        printf '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_urgent","name":"Urgent"},{"id":"OPT_high","name":"High"},{"id":"OPT_medium","name":"Medium"},{"id":"OPT_low","name":"Low"}]},{"id":"PVTSSF_size","name":"Size","options":[{"id":"OPT_size_xs","name":"XS"},{"id":"OPT_size_s","name":"S"},{"id":"OPT_size_m","name":"M"},{"id":"OPT_size_l","name":"L"},{"id":"OPT_size_xl","name":"XL"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_type_feature","name":"Feature"},{"id":"OPT_type_bug","name":"Bug"},{"id":"OPT_type_refactor","name":"Refactor"},{"id":"OPT_type_workflow","name":"Workflow"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}\n'
+        case "${MOCK_PRIORITY_FIELD_MODE:-medium}" in
+          normal_only)
+            # Simulates a downstream board still configured per the
+            # framework's pre-#1501 docs: Urgent, High, Normal, Low — no
+            # "Medium" option (issue #1501 code review, "Preserve
+            # compatibility with Normal-priority boards").
+            printf '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_urgent","name":"Urgent"},{"id":"OPT_high","name":"High"},{"id":"OPT_normal","name":"Normal"},{"id":"OPT_low","name":"Low"}]},{"id":"PVTSSF_size","name":"Size","options":[{"id":"OPT_size_xs","name":"XS"},{"id":"OPT_size_s","name":"S"},{"id":"OPT_size_m","name":"M"},{"id":"OPT_size_l","name":"L"},{"id":"OPT_size_xl","name":"XL"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_type_feature","name":"Feature"},{"id":"OPT_type_bug","name":"Bug"},{"id":"OPT_type_refactor","name":"Refactor"},{"id":"OPT_type_workflow","name":"Workflow"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}\n'
+            ;;
+          neither)
+            # Simulates a board using an entirely different Priority
+            # vocabulary (neither "Medium" nor "Normal" present).
+            printf '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_p0","name":"P0"},{"id":"OPT_p1","name":"P1"}]},{"id":"PVTSSF_size","name":"Size","options":[{"id":"OPT_size_xs","name":"XS"},{"id":"OPT_size_s","name":"S"},{"id":"OPT_size_m","name":"M"},{"id":"OPT_size_l","name":"L"},{"id":"OPT_size_xl","name":"XL"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_type_feature","name":"Feature"},{"id":"OPT_type_bug","name":"Bug"},{"id":"OPT_type_refactor","name":"Refactor"},{"id":"OPT_type_workflow","name":"Workflow"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}\n'
+            ;;
+          *)
+            # Matches the real board's Priority options verified on issue
+            # #1501: Urgent, High, Medium, Low — there is no "Normal" option.
+            printf '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_urgent","name":"Urgent"},{"id":"OPT_high","name":"High"},{"id":"OPT_medium","name":"Medium"},{"id":"OPT_low","name":"Low"}]},{"id":"PVTSSF_size","name":"Size","options":[{"id":"OPT_size_xs","name":"XS"},{"id":"OPT_size_s","name":"S"},{"id":"OPT_size_m","name":"M"},{"id":"OPT_size_l","name":"L"},{"id":"OPT_size_xl","name":"XL"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_type_feature","name":"Feature"},{"id":"OPT_type_bug","name":"Bug"},{"id":"OPT_type_refactor","name":"Refactor"},{"id":"OPT_type_workflow","name":"Workflow"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}\n'
+            ;;
+        esac
         ;;
       *"updateProjectV2ItemFieldValue"*)
+        if [ "${MOCK_PRIORITY_UPDATE_MODE:-ok}" = "fail" ]; then
+          printf 'transient GraphQL write failure\n' >&2
+          exit 42
+        fi
         printf '{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_item_123"}}}}\n'
         ;;
       *)
@@ -224,6 +244,54 @@ case "$unresolvable_stderr" in
   *) unresolvable_error_result="$unresolvable_stderr" ;;
 esac
 run_test "unresolvable_priority_prints_error" "errored" "$unresolvable_error_result"
+
+echo ""
+echo "=== create: default priority adapts to a Normal-only board (issue #1501 code review) ==="
+
+export MOCK_PRIORITY_FIELD_MODE=normal_only
+run_create "ok" --title "Test" --body "body"
+unset MOCK_PRIORITY_FIELD_MODE
+run_test "normal_only_board_default_exits_zero" "0" "$(get_exit)"
+run_test "normal_only_board_default_creates_issue" "1" "$(count_log_matches 'issue create')"
+run_test "normal_only_board_default_uses_normal_option" "1" "$(count_log_matches 'optionId=OPT_normal')"
+run_test "normal_only_board_default_avoids_medium_option" "0" "$(count_log_matches 'optionId=OPT_medium')"
+
+echo ""
+echo "=== create: default priority left unset on a board with neither Medium nor Normal (issue #1501 code review) ==="
+
+export MOCK_PRIORITY_FIELD_MODE=neither
+run_create "ok" --title "Test" --body "body"
+unset MOCK_PRIORITY_FIELD_MODE
+# The unresolvable-default case must NOT block issue creation the way an
+# unresolvable EXPLICIT --priority does — Priority is simply left unset,
+# the same way an omitted --size or --type is left unset.
+run_test "neither_board_default_exits_zero" "0" "$(get_exit)"
+run_test "neither_board_default_creates_issue" "1" "$(count_log_matches 'issue create')"
+run_test "neither_board_default_sends_no_priority_mutation" "0" "$(count_log_matches 'fieldId=PVTSSF_priority')"
+
+echo ""
+echo "=== create: post-creation Priority failure is a distinct partial-success exit, not a generic failure (issue #1501 code review) ==="
+
+export MOCK_PRIORITY_UPDATE_MODE=fail
+run_create "ok" --title "Test" --body "body"
+unset MOCK_PRIORITY_UPDATE_MODE
+partial_stdout="$(get_stdout)"
+partial_stderr="$(get_stderr)"
+run_test "partial_success_exit_code_is_five" "5" "$(get_exit)"
+# The issue WAS created — its URL must still be visible on stdout, and
+# `gh issue create` must have actually run (not been skipped), proving this
+# is a genuine partial success rather than the pre-flight blocking path.
+run_test "partial_success_creates_issue" "1" "$(count_log_matches 'issue create')"
+case "$partial_stdout" in
+  *"https://github.com/lhpaul/test-repo/issues/123"*) partial_url_result="printed" ;;
+  *) partial_url_result="$partial_stdout" ;;
+esac
+run_test "partial_success_prints_issue_url" "printed" "$partial_url_result"
+case "$partial_stderr" in
+  *"already created"*"Do NOT retry issue creation"*) partial_message_result="explicit" ;;
+  *) partial_message_result="$partial_stderr" ;;
+esac
+run_test "partial_success_prints_explicit_no_retry_message" "explicit" "$partial_message_result"
 
 echo ""
 echo "=== create: --size flag updates Size field ==="

--- a/scripts/development-workflow/tests/test-add-backlog-item.sh
+++ b/scripts/development-workflow/tests/test-add-backlog-item.sh
@@ -294,6 +294,20 @@ esac
 run_test "partial_success_prints_explicit_no_retry_message" "explicit" "$partial_message_result"
 
 echo ""
+echo "=== create: Priority failure does not skip independent Type/Size updates (issue #1501 code review) ==="
+
+export MOCK_PRIORITY_UPDATE_MODE=fail
+run_create "ok" --title "Test" --body "body" --size "M" --type "Bug"
+unset MOCK_PRIORITY_UPDATE_MODE
+run_test "partial_success_still_exits_five_with_other_fields" "5" "$(get_exit)"
+# Type and Size are independent field writes and must still be attempted
+# even though Priority failed — a caller following the "retry only
+# Priority" guidance must not find Type/Size permanently unset because this
+# script gave up early.
+run_test "partial_success_still_updates_size" "1" "$(count_log_matches 'fieldId=PVTSSF_size')"
+run_test "partial_success_still_updates_type" "1" "$(count_log_matches 'fieldId=PVTSSF_type')"
+
+echo ""
 echo "=== create: --size flag updates Size field ==="
 
 run_create "ok" --title "Test" --body "body" --size "M"

--- a/scripts/development-workflow/tests/test-add-backlog-item.sh
+++ b/scripts/development-workflow/tests/test-add-backlog-item.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 # test-add-backlog-item.sh — Unit tests for add-backlog-item.sh create flow.
 #
-# Exercises issue #965's Priority/Size field updates:
+# Exercises issue #965's Priority/Size field updates, and issue #1501's fix
+# for the inverted Medium/Normal priority alias (the board has no "Normal"
+# option; "Medium" is the real board value):
 #   1. Malformed gh output warns and skips project field updates
 #   2. Non-numeric issue number in URL warns and skips project field updates
-#   3. Happy path: URL parsed, board membership checked, Priority defaults to Normal
-#   4. --priority flag: uses supplied value instead of Normal default
+#   3. Happy path: URL parsed, board membership checked, Priority defaults to Medium
+#   4. --priority flag: uses supplied value instead of the Medium default
 #   5. --size flag: triggers Size field update
 #   6. No --size: Size field update is not called
 #   7. --type flag: triggers Type field update
+#   8. A priority value that does not resolve against the board's actual
+#      Priority options (issue #1501) is a hard error: create exits non-zero
+#      and no mutation is sent.
 #
 # Usage: bash scripts/development-workflow/tests/test-add-backlog-item.sh
 
@@ -73,7 +78,9 @@ case "$*" in
         printf '{"data":{"repository":{"issue":{"projectItems":{"nodes":[{"id":"PVTI_item_123","project":{"id":"PVT_project_1","number":1},"status":{"name":"Backlog"},"type":{"name":"Feature"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}\n'
         ;;
       *"fields(first:"*)
-        printf '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_urgent","name":"Urgent"},{"id":"OPT_high","name":"High"},{"id":"OPT_normal","name":"Normal"},{"id":"OPT_low","name":"Low"}]},{"id":"PVTSSF_size","name":"Size","options":[{"id":"OPT_size_xs","name":"XS"},{"id":"OPT_size_s","name":"S"},{"id":"OPT_size_m","name":"M"},{"id":"OPT_size_l","name":"L"},{"id":"OPT_size_xl","name":"XL"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_type_feature","name":"Feature"},{"id":"OPT_type_bug","name":"Bug"},{"id":"OPT_type_refactor","name":"Refactor"},{"id":"OPT_type_workflow","name":"Workflow"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}\n'
+        # Matches the real board's Priority options verified on issue #1501:
+        # Urgent, High, Medium, Low — there is no "Normal" option.
+        printf '{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_urgent","name":"Urgent"},{"id":"OPT_high","name":"High"},{"id":"OPT_medium","name":"Medium"},{"id":"OPT_low","name":"Low"}]},{"id":"PVTSSF_size","name":"Size","options":[{"id":"OPT_size_xs","name":"XS"},{"id":"OPT_size_s","name":"S"},{"id":"OPT_size_m","name":"M"},{"id":"OPT_size_l","name":"L"},{"id":"OPT_size_xl","name":"XL"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_type_feature","name":"Feature"},{"id":"OPT_type_bug","name":"Bug"},{"id":"OPT_type_refactor","name":"Refactor"},{"id":"OPT_type_workflow","name":"Workflow"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}\n'
         ;;
       *"updateProjectV2ItemFieldValue"*)
         printf '{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_item_123"}}}}\n'
@@ -164,7 +171,7 @@ run_test "nonnumeric_skips_board_check" "0" "$(count_log_matches 'projectItems')
 run_test "nonnumeric_skips_priority_update" "0" "$(count_log_matches 'updateProjectV2ItemFieldValue')"
 
 echo ""
-echo "=== create: happy path — issue URL in output, Priority defaults to Normal ==="
+echo "=== create: happy path — issue URL in output, Priority defaults to Medium ==="
 
 run_create "ok" --title "Test" --body "body"
 run_test "happy_path_exits_zero" "0" "$(get_exit)"
@@ -177,23 +184,41 @@ run_test "happy_path_prints_issue_url" "yes" "$url_in_output"
 board_check_count="$(count_log_matches 'projectItems')"
 run_test "happy_path_checks_board_membership" "yes" "$([ "$board_check_count" -ge 1 ] && echo yes || echo no)"
 run_test "happy_path_updates_priority" "1" "$(count_log_matches 'fieldId=PVTSSF_priority')"
-run_test "happy_path_default_priority_is_normal" "1" "$(count_log_matches 'optionId=OPT_normal')"
+# Regression for issue #1501: the requested (defaulted) priority must
+# actually be present on the board item afterward — assert the mutation was
+# sent with the Medium option ID, not the non-existent "Normal" option.
+run_test "happy_path_default_priority_is_medium" "1" "$(count_log_matches 'optionId=OPT_medium')"
 run_test "happy_path_skips_size_update" "0" "$(count_log_matches 'fieldId=PVTSSF_size')"
 
 echo ""
-echo "=== create: --priority flag overrides Normal default ==="
+echo "=== create: --priority flag overrides Medium default ==="
 
 run_create "ok" --title "Test" --body "body" --priority "High"
 run_test "explicit_priority_exits_zero" "0" "$(get_exit)"
+# Regression for issue #1501: an explicitly requested priority must actually
+# be applied — assert the mutation carries the requested option ID.
 run_test "explicit_priority_high_used" "1" "$(count_log_matches 'optionId=OPT_high')"
-run_test "explicit_priority_not_normal" "0" "$(count_log_matches 'optionId=OPT_normal')"
+run_test "explicit_priority_not_medium" "0" "$(count_log_matches 'optionId=OPT_medium')"
 
 echo ""
-echo "=== create: Medium priority aliases to Normal ==="
+echo "=== create: Medium priority resolves directly (no Normal alias) ==="
 
 run_create "ok" --title "Test" --body "body" --priority "Medium"
-run_test "medium_priority_alias_exits_zero" "0" "$(get_exit)"
-run_test "medium_priority_alias_uses_normal" "1" "$(count_log_matches 'optionId=OPT_normal')"
+run_test "medium_priority_exits_zero" "0" "$(get_exit)"
+run_test "medium_priority_uses_medium_option" "1" "$(count_log_matches 'optionId=OPT_medium')"
+
+echo ""
+echo "=== create: unresolvable priority is a hard error (issue #1501) ==="
+
+run_create "ok" --title "Test" --body "body" --priority "NoSuchPriority"
+run_test "unresolvable_priority_exits_nonzero" "yes" "$([ "$(get_exit)" -ne 0 ] && echo yes || echo no)"
+run_test "unresolvable_priority_sends_no_mutation" "0" "$(count_log_matches 'updateProjectV2ItemFieldValue')"
+unresolvable_stderr="$(get_stderr)"
+case "$unresolvable_stderr" in
+  *"Error:"*"could not resolve 'Priority' field or option 'NoSuchPriority'"*) unresolvable_error_result="errored" ;;
+  *) unresolvable_error_result="$unresolvable_stderr" ;;
+esac
+run_test "unresolvable_priority_prints_error" "errored" "$unresolvable_error_result"
 
 echo ""
 echo "=== create: --size flag updates Size field ==="

--- a/scripts/development-workflow/tests/test-add-backlog-item.sh
+++ b/scripts/development-workflow/tests/test-add-backlog-item.sh
@@ -208,14 +208,19 @@ run_test "medium_priority_exits_zero" "0" "$(get_exit)"
 run_test "medium_priority_uses_medium_option" "1" "$(count_log_matches 'optionId=OPT_medium')"
 
 echo ""
-echo "=== create: unresolvable priority is a hard error (issue #1501) ==="
+echo "=== create: unresolvable priority is a hard error, and blocks BEFORE issue creation (issue #1501 code review) ==="
 
 run_create "ok" --title "Test" --body "body" --priority "NoSuchPriority"
 run_test "unresolvable_priority_exits_nonzero" "yes" "$([ "$(get_exit)" -ne 0 ] && echo yes || echo no)"
 run_test "unresolvable_priority_sends_no_mutation" "0" "$(count_log_matches 'updateProjectV2ItemFieldValue')"
+# Regression for the codex-github review finding on this PR: validating the
+# priority value BEFORE calling `gh issue create` means an invalid value can
+# never leave behind a created-but-unlabeled issue that a blind exit-code
+# retry would duplicate.
+run_test "unresolvable_priority_skips_issue_create" "0" "$(count_log_matches 'issue create')"
 unresolvable_stderr="$(get_stderr)"
 case "$unresolvable_stderr" in
-  *"Error:"*"could not resolve 'Priority' field or option 'NoSuchPriority'"*) unresolvable_error_result="errored" ;;
+  *"Error:"*"could not resolve 'Priority' option 'NoSuchPriority'"*"no issue was created"*) unresolvable_error_result="errored" ;;
   *) unresolvable_error_result="$unresolvable_stderr" ;;
 esac
 run_test "unresolvable_priority_prints_error" "errored" "$unresolvable_error_result"

--- a/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+++ b/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
@@ -189,6 +189,12 @@ JSON
           cat <<'JSON'
 {"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_custom_type","name":"Custom Type","options":[{"id":"OPT_workflow_custom","name":"Workflow"}]},{"id":"PVTSSF_configured_type","name":"Configured Type","options":[{"id":"OPT_workflow_configured","name":"Workflow"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_workflow","name":"Workflow"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}
 JSON
+        elif [ "${MOCK_STATUS_FIELD_MODE:-existing}" = "priority_configured" ]; then
+          # Matches the real board's Priority options verified on issue #1501:
+          # Urgent, High, Medium, Low — there is no "Normal" option.
+          cat <<'JSON'
+{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_urgent","name":"Urgent"},{"id":"OPT_high","name":"High"},{"id":"OPT_medium","name":"Medium"},{"id":"OPT_low","name":"Low"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}
+JSON
         else
           cat <<'JSON'
 {"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_status","name":"Status","options":[{"id":"OPT_spec_ready","name":"Spec Ready"},{"id":"OPT_in_development","name":"In Development"},{"id":"OPT_merged","name":"Merged"},{"id":"OPT_released","name":"Released"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_workflow","name":"Workflow"},{"id":"OPT_bug","name":"Bug"},{"id":"OPT_refactor","name":"Refactor"},{"id":"OPT_feature","name":"Feature"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}
@@ -860,12 +866,68 @@ run_test "named_field_update_wrong_provider_no_mutation" "0" "$(count_log_matche
 reset_log
 __workflow_project_named_field_cache_keys=()
 __workflow_project_named_field_cache_vals=()
-priority_output="$(update_tracker_priority_best_effort 824 "High" 2>&1)"
+priority_exit=0
+priority_output=""
+priority_output="$(update_tracker_priority_best_effort 824 "High" 2>&1)" || priority_exit=$?
 case "$priority_output" in
-  *"could not read project 'Priority' field metadata"*) priority_result="routed-to-priority" ;;
+  *"Error:"*"could not read project 'Priority' field metadata"*) priority_result="routed-to-priority" ;;
   *) priority_result="$priority_output" ;;
 esac
 run_test "priority_convenience_routes_to_named_field" "routed-to-priority" "$priority_result"
+# Issue #1501: Priority is always passed to update_tracker_named_field_best_effort
+# in "required" mode, so a field that cannot be resolved is a hard error.
+run_test "priority_convenience_required_mode_returns_nonzero" "1" "$priority_exit"
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+export MOCK_STATUS_FIELD_MODE=priority_configured
+priority_medium_exit=0
+priority_medium_output=""
+priority_medium_output="$(update_tracker_priority_best_effort 824 "Medium" 2>&1)" || priority_medium_exit=$?
+run_test "priority_medium_resolves_against_real_board_options" "0" "$priority_medium_exit"
+case "$priority_medium_output" in
+  *"Error:"*) priority_medium_output_result="has-error" ;;
+  *) priority_medium_output_result="no-error" ;;
+esac
+run_test "priority_medium_output_has_no_error" "no-error" "$priority_medium_output_result"
+# Regression for issue #1501: assert the requested priority is actually
+# present on the board item afterward — the mutation must carry the Medium
+# option ID resolved from the board's real options, not a hardcoded/aliased
+# value. There is no "Normal" option on the board.
+run_test "priority_medium_mutation_uses_medium_option" "1" "$(count_log_matches 'optionId=OPT_medium')"
+run_test "priority_medium_mutation_avoids_normal_option" "0" "$(count_log_matches 'optionId=OPT_normal')"
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+priority_urgent_exit=0
+priority_urgent_output=""
+priority_urgent_output="$(update_tracker_priority_best_effort 824 "Urgent" 2>&1)" || priority_urgent_exit=$?
+run_test "priority_urgent_resolves_against_real_board_options" "0" "$priority_urgent_exit"
+case "$priority_urgent_output" in
+  *"Error:"*) priority_urgent_output_result="has-error" ;;
+  *) priority_urgent_output_result="no-error" ;;
+esac
+run_test "priority_urgent_output_has_no_error" "no-error" "$priority_urgent_output_result"
+run_test "priority_urgent_mutation_uses_urgent_option" "1" "$(count_log_matches 'optionId=OPT_urgent')"
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+priority_bad_exit=0
+priority_bad_output=""
+priority_bad_output="$(update_tracker_priority_best_effort 824 "Normal" 2>&1)" || priority_bad_exit=$?
+unset MOCK_STATUS_FIELD_MODE
+# Issue #1501: "Normal" is not a real board option; requesting it must be a
+# hard error, not a silent no-op.
+run_test "priority_normal_is_hard_error" "1" "$priority_bad_exit"
+case "$priority_bad_output" in
+  *"Error:"*"could not resolve 'Priority' field or option 'Normal'"*) priority_bad_result="errored" ;;
+  *) priority_bad_result="$priority_bad_output" ;;
+esac
+run_test "priority_normal_error_message" "errored" "$priority_bad_result"
+run_test "priority_normal_sends_no_mutation" "0" "$(count_log_matches 'updateProjectV2ItemFieldValue')"
 
 reset_log
 __workflow_project_named_field_cache_keys=()

--- a/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+++ b/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
@@ -195,6 +195,19 @@ JSON
           cat <<'JSON'
 {"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_urgent","name":"Urgent"},{"id":"OPT_high","name":"High"},{"id":"OPT_medium","name":"Medium"},{"id":"OPT_low","name":"Low"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}
 JSON
+        elif [ "${MOCK_STATUS_FIELD_MODE:-existing}" = "priority_normal_only" ]; then
+          # Simulates a downstream board still configured per the
+          # framework's pre-#1501 docs: Urgent, High, Normal, Low — no
+          # "Medium" option (issue #1501 code review).
+          cat <<'JSON'
+{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_urgent","name":"Urgent"},{"id":"OPT_high","name":"High"},{"id":"OPT_normal","name":"Normal"},{"id":"OPT_low","name":"Low"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}
+JSON
+        elif [ "${MOCK_STATUS_FIELD_MODE:-existing}" = "priority_neither" ]; then
+          # Simulates a board using an entirely different Priority
+          # vocabulary (neither "Medium" nor "Normal" present).
+          cat <<'JSON'
+{"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_priority","name":"Priority","options":[{"id":"OPT_p0","name":"P0"},{"id":"OPT_p1","name":"P1"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}
+JSON
         else
           cat <<'JSON'
 {"data":{"node":{"fields":{"nodes":[{"id":"PVTSSF_status","name":"Status","options":[{"id":"OPT_spec_ready","name":"Spec Ready"},{"id":"OPT_in_development","name":"In Development"},{"id":"OPT_merged","name":"Merged"},{"id":"OPT_released","name":"Released"}]},{"id":"PVTSSF_type","name":"Type","options":[{"id":"OPT_workflow","name":"Workflow"},{"id":"OPT_bug","name":"Bug"},{"id":"OPT_refactor","name":"Refactor"},{"id":"OPT_feature","name":"Feature"}]}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}
@@ -969,6 +982,47 @@ unset MOCK_TRACKER_PROJECT_NUMBER
 # No project configured — same permissive rule: nothing to validate against.
 run_test "resolvable_no_project_returns_zero" "0" "$resolvable_no_project_exit"
 run_test "resolvable_no_project_avoids_api" "0" "$(count_log_matches 'api graphql')"
+
+echo ""
+echo "=== workflow_tracker_default_priority_value (issue #1501 code review: adaptive default) ==="
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+export MOCK_STATUS_FIELD_MODE=priority_configured
+default_medium_value="$(workflow_tracker_default_priority_value)"
+unset MOCK_STATUS_FIELD_MODE
+run_test "default_prefers_medium_when_present" "Medium" "$default_medium_value"
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+export MOCK_STATUS_FIELD_MODE=priority_normal_only
+default_normal_value="$(workflow_tracker_default_priority_value)"
+unset MOCK_STATUS_FIELD_MODE
+# A downstream board still configured per the pre-#1501 docs (no "Medium"
+# option) must keep working exactly as it did before this fix.
+run_test "default_falls_back_to_normal_when_medium_absent" "Normal" "$default_normal_value"
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+export MOCK_STATUS_FIELD_MODE=priority_neither
+default_neither_value="$(workflow_tracker_default_priority_value)"
+unset MOCK_STATUS_FIELD_MODE
+# Neither candidate present on a confirmed, successfully-read board — the
+# caller must leave Priority unset (empty), not force a default that will
+# never resolve.
+run_test "default_empty_when_neither_candidate_present" "" "$default_neither_value"
+
+reset_log
+export MOCK_TRACKER_PROVIDER=linear
+default_wrong_provider_value="$(workflow_tracker_default_priority_value)"
+unset MOCK_TRACKER_PROVIDER
+# Provider mismatch is an inconclusive case (nothing to adapt against) —
+# falls back to the static "Medium" literal, same as before this helper
+# existed.
+run_test "default_wrong_provider_returns_medium" "Medium" "$default_wrong_provider_value"
 
 reset_log
 __workflow_project_named_field_cache_keys=()

--- a/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+++ b/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
@@ -929,6 +929,47 @@ esac
 run_test "priority_normal_error_message" "errored" "$priority_bad_result"
 run_test "priority_normal_sends_no_mutation" "0" "$(count_log_matches 'updateProjectV2ItemFieldValue')"
 
+echo ""
+echo "=== workflow_tracker_priority_resolvable (issue #1501 code review: pre-flight, no issue required) ==="
+
+reset_log
+__workflow_project_named_field_cache_keys=()
+__workflow_project_named_field_cache_vals=()
+export MOCK_STATUS_FIELD_MODE=priority_configured
+resolvable_medium_exit=0
+workflow_tracker_priority_resolvable "Medium" || resolvable_medium_exit=$?
+run_test "resolvable_medium_returns_zero" "0" "$resolvable_medium_exit"
+# No issue-specific lookups: no projectItems (issue membership) query is sent.
+run_test "resolvable_check_avoids_issue_lookup" "0" "$(count_log_matches 'projectItems')"
+
+resolvable_bad_exit=0
+workflow_tracker_priority_resolvable "NoSuchPriority" || resolvable_bad_exit=$?
+run_test "resolvable_bad_value_returns_one" "1" "$resolvable_bad_exit"
+unset MOCK_STATUS_FIELD_MODE
+
+reset_log
+export MOCK_TRACKER_PROVIDER=linear
+resolvable_wrong_provider_exit=0
+workflow_tracker_priority_resolvable "AnythingAtAll" || resolvable_wrong_provider_exit=$?
+unset MOCK_TRACKER_PROVIDER
+# A provider that doesn't support GitHub Projects fields has nothing to
+# validate against — must not block (permissive, matches
+# update_tracker_named_field_best_effort's own provider-mismatch handling).
+run_test "resolvable_wrong_provider_returns_zero" "0" "$resolvable_wrong_provider_exit"
+run_test "resolvable_wrong_provider_avoids_api" "0" "$(count_log_matches 'api graphql')"
+
+reset_log
+old_project_number="${GITHUB_PROJECT_NUMBER:-}"
+unset GITHUB_PROJECT_NUMBER
+MOCK_TRACKER_PROJECT_NUMBER=""
+resolvable_no_project_exit=0
+workflow_tracker_priority_resolvable "AnythingAtAll" || resolvable_no_project_exit=$?
+export GITHUB_PROJECT_NUMBER="$old_project_number"
+unset MOCK_TRACKER_PROJECT_NUMBER
+# No project configured — same permissive rule: nothing to validate against.
+run_test "resolvable_no_project_returns_zero" "0" "$resolvable_no_project_exit"
+run_test "resolvable_no_project_avoids_api" "0" "$(count_log_matches 'api graphql')"
+
 reset_log
 __workflow_project_named_field_cache_keys=()
 __workflow_project_named_field_cache_vals=()

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -2633,38 +2633,31 @@ EOF
   printf '%s' "$field_json"
 }
 
-# workflow_tracker_priority_resolvable <priority_value>
+# _workflow_tracker_priority_field_json
 #
-# Pre-flight check: does <priority_value> resolve against the project's
-# actual Priority field options? Unlike update_tracker_priority_best_effort,
-# this performs no issue-specific lookups and triggers no mutation, so it is
-# safe to call before an issue exists — e.g. before `gh issue create` — to
-# avoid the partial-success window where an issue is created but a required
-# follow-up Priority write then fails (see issue #1501 code review: a caller
-# that retries on non-zero exit without inspecting stdout could otherwise
-# create a duplicate issue).
-#
-# Returns 0 (resolvable / not blocking) when the tracker provider is not
-# github_projects, no project is configured, or the project/field lookup
-# itself fails or is inconclusive — those are the same "genuinely does not
-# apply" or "uncertain" cases update_tracker_named_field_best_effort always
-# treats permissively, and this pre-check must not block issue creation on
-# an environmental failure the authoritative post-creation required check
-# will re-attempt anyway. Returns 1 only when the Priority field was
-# successfully read from a configured project and <priority_value> does not
-# match any of its options — a confirmed, actionable bad value.
-workflow_tracker_priority_resolvable() {
-  local priority_value="$1"
-  local _wtpr_provider project_owner project_number project_id field_json option_id
+# Internal helper shared by workflow_tracker_priority_resolvable and
+# workflow_tracker_default_priority_value. Resolves and prints the
+# project's Priority field JSON (id + options map, see
+# workflow_github_project_named_field_json) when the tracker provider is
+# github_projects, a project is configured, and the field was successfully
+# read. Performs no issue-specific lookups and triggers no mutation, so it
+# is safe to call before an issue exists. Prints nothing and returns 1 in
+# every other case — provider mismatch, no project configured, or the
+# lookup itself failed — which both callers treat uniformly as "nothing to
+# validate/adapt against" (the same "genuinely does not apply" / "uncertain"
+# carve-out update_tracker_named_field_best_effort always treats
+# permissively).
+_workflow_tracker_priority_field_json() {
+  local _wtpfj_provider project_owner project_number project_id field_json
 
-  _wtpr_provider="$(workflow_normalize_issue_tracker_provider "$(workflow_issue_tracker_provider_raw)")"
-  if [ "$_wtpr_provider" != "github_projects" ]; then
-    return 0
+  _wtpfj_provider="$(workflow_normalize_issue_tracker_provider "$(workflow_issue_tracker_provider_raw)")"
+  if [ "$_wtpfj_provider" != "github_projects" ]; then
+    return 1
   fi
 
   project_number="${GITHUB_PROJECT_NUMBER:-$(workflow_issue_tracker_project_number)}"
   if [ -z "$project_number" ]; then
-    return 0
+    return 1
   fi
 
   project_owner="$(workflow_resolve_github_project_owner)"
@@ -2672,15 +2665,44 @@ workflow_tracker_priority_resolvable() {
     project_owner="$(workflow_resolve_github_repo_owner)"
   fi
   if [ -z "$project_owner" ]; then
-    return 0
+    return 1
   fi
 
   project_id="$(workflow_github_project_id "$project_owner" "$project_number" 2>/dev/null)"
   if [ -z "$project_id" ]; then
-    return 0
+    return 1
   fi
 
   if ! field_json="$(workflow_github_project_named_field_json "$project_id" "Priority" 2>/dev/null)"; then
+    return 1
+  fi
+
+  printf '%s' "$field_json"
+}
+
+# workflow_tracker_priority_resolvable <priority_value>
+#
+# Pre-flight check: does <priority_value> resolve against the project's
+# actual Priority field options? Unlike update_tracker_priority_best_effort,
+# this triggers no mutation, so it is safe to call before an issue exists —
+# e.g. before `gh issue create` — to avoid the partial-success window where
+# an issue is created but a required follow-up Priority write then fails
+# (see issue #1501 code review: a caller that retries on non-zero exit
+# without inspecting stdout could otherwise create a duplicate issue).
+#
+# Returns 0 (resolvable / not blocking) whenever
+# _workflow_tracker_priority_field_json cannot produce a confirmed field
+# reading (provider mismatch, no project configured, or an inconclusive
+# lookup) — this pre-check must not block issue creation on an
+# environmental failure the authoritative post-creation required check will
+# re-attempt anyway. Returns 1 only when the Priority field was
+# successfully read from a configured project and <priority_value> does not
+# match any of its options — a confirmed, actionable bad value.
+workflow_tracker_priority_resolvable() {
+  local priority_value="$1"
+  local field_json option_id
+
+  if ! field_json="$(_workflow_tracker_priority_field_json)"; then
     return 0
   fi
 
@@ -2691,6 +2713,49 @@ print((data.get('options') or {}).get(sys.argv[1]) or '', end='')
 " "$priority_value" 2>/dev/null)"
 
   [ -n "$option_id" ]
+}
+
+# workflow_tracker_default_priority_value
+#
+# Resolves the runtime default Priority value used when --priority is
+# omitted, adapting to what the configured board actually supports instead
+# of assuming a single universal literal (issue #1501 code review, P1
+# finding "Preserve compatibility with Normal-priority boards"): prefers
+# "Medium" (this repo's own board), falls back to "Normal" for boards still
+# configured per the framework's pre-#1501 setup docs.
+#
+# When _workflow_tracker_priority_field_json cannot produce a confirmed
+# field reading (provider mismatch, no project configured, or an
+# inconclusive lookup), prints "Medium" unchanged — matching the
+# pre-existing best-effort behavior for those cases; there is nothing more
+# specific to fall back to, and the post-creation update remains a
+# best-effort no-op for a provider that does not support it.
+#
+# Only prints nothing (empty) when the Priority field was successfully read
+# from a configured project and CONFIRMED to contain neither "Medium" nor
+# "Normal". At that point, forcing a hard default would make every routine
+# backlog-item creation on that board fail until manually migrated, so the
+# caller should leave Priority unset instead — the same way an omitted
+# --size or --type is left unset.
+workflow_tracker_default_priority_value() {
+  local field_json resolved
+
+  if ! field_json="$(_workflow_tracker_priority_field_json)"; then
+    printf 'Medium'
+    return 0
+  fi
+
+  resolved="$(printf '%s' "$field_json" | python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read(), strict=False)
+options = data.get('options') or {}
+for candidate in ('Medium', 'Normal'):
+    if options.get(candidate):
+        print(candidate, end='')
+        break
+" 2>/dev/null)"
+
+  printf '%s' "$resolved"
 }
 
 # update_tracker_named_field_best_effort <issue_number> <field_name> <option_value> [required]

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -2633,6 +2633,66 @@ EOF
   printf '%s' "$field_json"
 }
 
+# workflow_tracker_priority_resolvable <priority_value>
+#
+# Pre-flight check: does <priority_value> resolve against the project's
+# actual Priority field options? Unlike update_tracker_priority_best_effort,
+# this performs no issue-specific lookups and triggers no mutation, so it is
+# safe to call before an issue exists — e.g. before `gh issue create` — to
+# avoid the partial-success window where an issue is created but a required
+# follow-up Priority write then fails (see issue #1501 code review: a caller
+# that retries on non-zero exit without inspecting stdout could otherwise
+# create a duplicate issue).
+#
+# Returns 0 (resolvable / not blocking) when the tracker provider is not
+# github_projects, no project is configured, or the project/field lookup
+# itself fails or is inconclusive — those are the same "genuinely does not
+# apply" or "uncertain" cases update_tracker_named_field_best_effort always
+# treats permissively, and this pre-check must not block issue creation on
+# an environmental failure the authoritative post-creation required check
+# will re-attempt anyway. Returns 1 only when the Priority field was
+# successfully read from a configured project and <priority_value> does not
+# match any of its options — a confirmed, actionable bad value.
+workflow_tracker_priority_resolvable() {
+  local priority_value="$1"
+  local _wtpr_provider project_owner project_number project_id field_json option_id
+
+  _wtpr_provider="$(workflow_normalize_issue_tracker_provider "$(workflow_issue_tracker_provider_raw)")"
+  if [ "$_wtpr_provider" != "github_projects" ]; then
+    return 0
+  fi
+
+  project_number="${GITHUB_PROJECT_NUMBER:-$(workflow_issue_tracker_project_number)}"
+  if [ -z "$project_number" ]; then
+    return 0
+  fi
+
+  project_owner="$(workflow_resolve_github_project_owner)"
+  if [ -z "$project_owner" ]; then
+    project_owner="$(workflow_resolve_github_repo_owner)"
+  fi
+  if [ -z "$project_owner" ]; then
+    return 0
+  fi
+
+  project_id="$(workflow_github_project_id "$project_owner" "$project_number" 2>/dev/null)"
+  if [ -z "$project_id" ]; then
+    return 0
+  fi
+
+  if ! field_json="$(workflow_github_project_named_field_json "$project_id" "Priority" 2>/dev/null)"; then
+    return 0
+  fi
+
+  option_id="$(printf '%s' "$field_json" | python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read(), strict=False)
+print((data.get('options') or {}).get(sys.argv[1]) or '', end='')
+" "$priority_value" 2>/dev/null)"
+
+  [ -n "$option_id" ]
+}
+
 # update_tracker_named_field_best_effort <issue_number> <field_name> <option_value> [required]
 #
 # Update for any single-select GitHub Projects field by name. Resolves

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -2633,15 +2633,32 @@ EOF
   printf '%s' "$field_json"
 }
 
-# update_tracker_named_field_best_effort <issue_number> <field_name> <option_value>
+# update_tracker_named_field_best_effort <issue_number> <field_name> <option_value> [required]
 #
-# Best-effort update for any single-select GitHub Projects field by name.
-# Supports github_projects provider only; emits warnings for all other providers.
-# Returns 0 in all warning/failure cases to avoid blocking caller flows.
+# Update for any single-select GitHub Projects field by name. Resolves
+# <option_value> against the project's actual field options (see
+# workflow_github_project_named_field_json) rather than a hardcoded list.
+# Supports github_projects provider only; emits warnings for all other
+# providers.
+#
+# When the tracker provider is not github_projects, or no GitHub Project is
+# configured, the field genuinely does not apply — there is nothing to
+# resolve <option_value> against — so those two cases always return 0
+# regardless of the [required] argument.
+#
+# For every other failure (item not found on the board, field/option not
+# found, GraphQL read or write failure, etc.): when [required] is the
+# literal string "required", the failure is a hard error (non-zero return,
+# message prefixed "Error:") so an explicitly-requested value that cannot be
+# applied to a configured board does not fail silently. When [required] is
+# omitted (the default), those failures remain best-effort (return 0,
+# message prefixed "Warning:") to avoid blocking caller flows for fields the
+# caller does not depend on.
 update_tracker_named_field_best_effort() {
   local issue_number="$1"
   local field_name="$2"
   local option_value="$3"
+  local required="${4:-}"
   local project_number project_id field_json field_id option_id item_json item_id
 
   local _utnfbe_provider
@@ -2663,6 +2680,10 @@ import json, sys
 item = json.loads(sys.stdin.read(), strict=False)
 print(item.get('item_id') or '', end='')
 "); then
+    if [ "$required" = "required" ]; then
+      echo "Error: could not parse project item ID for issue #${issue_number}; tracker '${field_name}' not updated." >&2
+      return 1
+    fi
     echo "Warning: could not parse project item ID for issue #${issue_number}; skipping tracker '${field_name}' update."
     return 0
   fi
@@ -2671,19 +2692,35 @@ import json, sys
 item = json.loads(sys.stdin.read(), strict=False)
 print(item.get('project_id') or '', end='')
 "); then
+    if [ "$required" = "required" ]; then
+      echo "Error: could not parse project ID for issue #${issue_number}; tracker '${field_name}' not updated." >&2
+      return 1
+    fi
     echo "Warning: could not parse project ID for issue #${issue_number}; skipping tracker '${field_name}' update."
     return 0
   fi
   if [ -z "$item_id" ]; then
+    if [ "$required" = "required" ]; then
+      echo "Error: issue #${issue_number} not found in project #${project_number}; tracker '${field_name}' not updated." >&2
+      return 1
+    fi
     echo "Warning: issue #${issue_number} not found in project #${project_number}; skipping tracker '${field_name}' update."
     return 0
   fi
   if [ -z "$project_id" ]; then
+    if [ "$required" = "required" ]; then
+      echo "Error: could not resolve project ID for issue #${issue_number}; tracker '${field_name}' not updated." >&2
+      return 1
+    fi
     echo "Warning: could not resolve project ID for issue #${issue_number}; skipping tracker '${field_name}' update."
     return 0
   fi
 
   if ! field_json="$(workflow_github_project_named_field_json "$project_id" "$field_name")"; then
+    if [ "$required" = "required" ]; then
+      echo "Error: could not read project '${field_name}' field metadata; tracker '${field_name}' not updated." >&2
+      return 1
+    fi
     echo "Warning: could not read project '${field_name}' field metadata; skipping tracker '${field_name}' update."
     return 0
   fi
@@ -2692,6 +2729,10 @@ import json, sys
 data = json.loads(sys.stdin.read(), strict=False)
 print(data.get('field_id') or '', end='')
 "); then
+    if [ "$required" = "required" ]; then
+      echo "Error: could not parse '${field_name}' field metadata; tracker '${field_name}' not updated." >&2
+      return 1
+    fi
     echo "Warning: could not parse '${field_name}' field metadata; skipping tracker '${field_name}' update."
     return 0
   fi
@@ -2700,10 +2741,18 @@ import json, sys
 data = json.loads(sys.stdin.read(), strict=False)
 print((data.get('options') or {}).get(sys.argv[1]) or '', end='')
 " "$option_value"); then
+    if [ "$required" = "required" ]; then
+      echo "Error: could not parse '${field_name}' option '${option_value}'; tracker '${field_name}' not updated." >&2
+      return 1
+    fi
     echo "Warning: could not parse '${field_name}' option '${option_value}'; skipping tracker '${field_name}' update."
     return 0
   fi
   if [ -z "$field_id" ] || [ -z "$option_id" ]; then
+    if [ "$required" = "required" ]; then
+      echo "Error: could not resolve '${field_name}' field or option '${option_value}'; tracker '${field_name}' not updated." >&2
+      return 1
+    fi
     echo "Warning: could not resolve '${field_name}' field or option '${option_value}'; skipping tracker '${field_name}' update."
     return 0
   fi
@@ -2729,6 +2778,11 @@ print((data.get('options') or {}).get(sys.argv[1]) or '', end='')
     '; then
     printf '%s' "$__workflow_last_gh_stdout"
   else
+    if [ "$required" = "required" ]; then
+      echo "Error: GraphQL mutation failed for issue #${issue_number}; tracker '${field_name}' not updated." >&2
+      workflow_print_captured_gh_stderr
+      return 1
+    fi
     echo "Warning: GraphQL mutation failed for issue #${issue_number}; tracker '${field_name}' not updated."
     workflow_print_captured_gh_stderr
   fi
@@ -2736,16 +2790,19 @@ print((data.get('options') or {}).get(sys.argv[1]) or '', end='')
 
 # update_tracker_priority_best_effort <issue_number> <priority_value>
 #
-# Best-effort update for the GitHub Projects Priority field.
-# Valid values: Urgent, High, Normal, Low. Medium aliases to Normal.
-# Returns 0 in all failure cases (fail-open).
+# Update for the GitHub Projects Priority field. Resolves <priority_value>
+# against the project's actual Priority field options (see
+# workflow_github_project_named_field_json) — there is no hardcoded alias
+# table. Priority is always explicitly set by add-backlog-item.sh (either
+# user-supplied via --priority, or defaulted), so an unresolvable value is a
+# hard error (non-zero return) whenever the tracker provider and project are
+# configured — see update_tracker_named_field_best_effort's "required" mode.
+# When the provider/project genuinely does not apply, this remains
+# best-effort (returns 0), matching update_tracker_named_field_best_effort.
 update_tracker_priority_best_effort() {
   local issue_number="$1"
   local priority_value="$2"
-  if [ "$priority_value" = "Medium" ]; then
-    priority_value="Normal"
-  fi
-  update_tracker_named_field_best_effort "$issue_number" "Priority" "$priority_value"
+  update_tracker_named_field_best_effort "$issue_number" "Priority" "$priority_value" "required"
 }
 
 # update_tracker_size_best_effort <issue_number> <size_value>


### PR DESCRIPTION
## Summary

Fixes #1501: `add-backlog-item.sh` / `workflow-lib.sh` set backlog item
Priority to the value `Normal`, which does not exist on this repository's
GitHub Projects board (real options: `Urgent`, `High`, `Medium`, `Low`), so
the Priority field silently ended up unset on every item created without an
explicit, already-valid `--priority` value.

Scope was narrowed by live reproduction evidence gathered immediately before
implementation and posted to [issue #1501 comment](https://github.com/lhpaul/ai-dev-framework-template/issues/1501#issuecomment-5336119449):
`High` already resolves correctly on a clean run, so the issue's "defect 3"
(a suspected third, unexplained `High` failure) does not reproduce and is out
of scope for this PR. The real defects are the inverted `Medium`→`Normal`
alias and the `Normal` default, and the helper is fail-open rather than
silent (it does print a `Warning:` line — the defect is that it doesn't stop
anything).

## Changes

- `scripts/development-workflow/workflow-lib.sh`: removed the inverted
  `Medium` → `Normal` alias in `update_tracker_priority_best_effort`.
  Priority resolution already reads the project's actual field options
  dynamically (no hardcoded value list). Added an opt-in `required` mode to
  `update_tracker_named_field_best_effort`: when the tracker provider and
  project are configured but the requested value cannot be resolved/applied,
  the failure is now a hard error (non-zero return, `Error:`-prefixed
  message) instead of always fail-open. Only `update_tracker_priority_best_effort`
  opts into `required`; `update_tracker_type_best_effort` and
  `update_tracker_size_best_effort` remain unchanged (best-effort), and cases
  where the tracker/project genuinely doesn't apply always stay best-effort
  regardless of `required`.
- `scripts/development-workflow/add-backlog-item.sh`: default `--priority`
  changes from `Normal` to `Medium`; updated `--priority` help text.
- `docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md`:
  Priority inference heuristics and example command updated from `Normal` to
  `Medium` (this doc explicitly instructed agents to pass `--priority Normal`
  — left as-is it would keep pointing every future caller at the exact
  removed value).
- `docs/workflow/development-workflow/integrations/github-projects.md`:
  Priority field option table corrected from `Normal` to `Medium`.
- Regression tests in `test-add-backlog-item.sh` and
  `test-workflow-lib-github-projects.sh`: assert a requested priority is
  actually present on the board item afterward (mutation carries the
  resolved option ID for `Medium`/`Urgent`/`High`), and that an unresolvable
  requested priority is a hard error with no mutation sent.
- `CHANGELOG.md`: `[Unreleased]` → `### Fixed` entry.

## Out of scope (explicitly)

- Issue #1501's "defect 3" (`High` also failed) — does not reproduce; no
  third defect exists in the resolution path.
- #1502 (max_cycles) — sibling item in the same batch, handled separately;
  `pr-review-loop.sh` is untouched.

## Verification

- `bash scripts/development-workflow/tests/test-add-backlog-item.sh` — 35/35 passed.
- `bash scripts/development-workflow/tests/test-workflow-lib-github-projects.sh` — 147/147 passed.
- `shellcheck --severity=warning` on all modified `.sh` files — clean.
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop` — clean.
- `markdownlint-cli2` on CHANGELOG.md and both modified docs — 0 issues.
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md` — passed (single `### Fixed` header under `[Unreleased]`, link references intact).
- CHANGELOG entry checked for trailing whitespace/blank lines; all modified `.md` files end with a trailing newline (MD047).

## Pre-Submission Self-Review Pass

- Reviewed `git diff origin/develop...HEAD` in full; no stale markers, debug
  output, or TODOs left behind.
- Caller consistency: `update_tracker_priority_best_effort` is the only
  caller of `update_tracker_named_field_best_effort` passing `"required"`;
  `update_tracker_type_best_effort` / `update_tracker_size_best_effort`
  callers and their existing tests are unchanged and still pass.
- Confirmed coverage of every doc location that documented the now-removed
  `Normal` default/alias as intended behavior (protocol 00, github-projects.md
  field table) via `grep -rn "Normal"` across `docs/workflow/development-workflow/`;
  left the framework's tracker-agnostic abstract priority-tier vocabulary
  (README.md, protocol 90 ordering heuristics, linear.md's Linear-priority
  mapping) untouched since those are not the literal GitHub Projects board
  option string this bug is about, and changing them would be out-of-scope
  renaming beyond the confirmed defect.
- Issue-body coverage: all "Still-valid remainder of the fix list" items from
  the issue and its narrowing comment are addressed (alias/default fix,
  board-options resolution — already dynamic, hard-error on unresolvable
  request, help text, regression test). The issue's original "reproduce and
  fix the `High` failure" item is explicitly dropped per the live
  reproduction evidence.
- Not a UI-facing change; no design assets applicable. Not a filter-schema
  addition; no canary test required. Not a sweep/batch/pattern-completeness
  change; no residual-gate script required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
