### PR TITLE
fix(pr-review-loop): CodeRabbit skip banner is not a review (#1531)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,11 +3,15 @@
 # This file controls CodeRabbit's behavior for this repository.
 # Docs: https://docs.coderabbit.ai/reference/configuration
 #
-# CodeRabbit is disabled by default so repository review policy remains
-# explicit in .ai-dev-workflow.yaml. To opt in to CodeRabbit GitHub App review:
-# - set reviews.auto_review.enabled to true
-# - add "coderabbit" to review.on_draft.github or review.on_ready.github
-# - keep drafts false unless the repository intentionally wants draft PR review
+# This repository has OPTED IN to CodeRabbit GitHub App review (issue #1531).
+# CodeRabbit runs as the ready-phase reviewer via review.on_ready.github in
+# .ai-dev-workflow.yaml (or .ai-dev-workflow.local.yaml). The two files must stay
+# consistent: listing "coderabbit" in a lifecycle bucket that auto_review below
+# does not cover makes CodeRabbit post a "Review skipped" banner instead of a
+# review, which pr-review-loop.sh escalates as REASON=review_skipped_banner.
+#
+# This file is NOT in sync-manifest.yaml, so it is repository-local and does not
+# change the CodeRabbit defaults inherited by projects created from this template.
 
 reviews:
   tools:
@@ -15,11 +19,24 @@ reviews:
       enabled: true
       timeout_ms: 600000
   auto_review:
-    enabled: false
+    enabled: true
+    # drafts stays false on purpose: CodeRabbit is configured as the *ready-phase*
+    # reviewer only (review.on_ready.github), and pr-agent covers the draft phase.
+    # Reviewing drafts would spend hourly quota on revisions that are still moving.
     drafts: false
-    auto_pause_after_reviewed_commits: 1
+    # Raised from 1. CodeRabbit pauses auto review after this many reviewed commits
+    # arrive without human interaction; at 1, every reviewer-loop fix commit tripped
+    # the pause banner and cost a full poll cycle for pr-review-loop.sh to post
+    # "@coderabbitai resume". Reviewer-loop convergence routinely needs several fix
+    # rounds, so the cap has to sit above a normal round count.
+    auto_pause_after_reviewed_commits: 10
+    # Both the integration branch (develop) and epic integration branches
+    # (develop-<slug>, per protocol 05b) must be listed. A sub-item PR whose base is
+    # absent here gets a "Review skipped" banner rather than a review — the exact
+    # false-clean that issue #1531 fixed the loop to catch. Entries are regexes.
     base_branches:
       - develop
+      - develop-.*
   path_filters:
     - "!dist/**"
     - "!**/*.generated.*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **CodeRabbit "Review skipped" banner no longer reports an unreviewed PR as
+  clean** (#1531): `run_coderabbit_review` in
+  `scripts/development-workflow/pr-review-loop.sh` counted any CodeRabbit issue
+  comment as evidence of a completed review, excluding only the pause,
+  rate-limit, and resume markers. CodeRabbit's fourth non-review banner —
+  `Review skipped`, posted whenever it declines by configuration rather than by
+  capacity (`auto_review.enabled: false`, `drafts: false` on a draft PR, or an
+  `auto_review.base_branches` list that omits the PR's base) — satisfied that
+  check, broke the poll loop into Phase 3, and returned `RESULT=clean` after
+  collecting zero inline comments. The banner is now matched by
+  `CODERABBIT_SKIP_BANNER_RE`, excluded from the activity probe so the existing
+  silent-non-trigger path nudges CodeRabbit with an explicit
+  `@coderabbitai review` (which works even when auto review is disabled), and
+  escalated as `REASON=review_skipped_banner` if it is still standing when the
+  poll window closes — a distinct reason from `rate_limit_max_retries`, since
+  the operator fix is a `.coderabbit.yaml` change rather than waiting out vendor
+  quota. Same false-clean class as #1437 and the PR #650 pause-banner incident.
+- **CodeRabbit rate-limit tolerance now spans an hourly quota reset** (#1531):
+  `CODERABBIT_RATE_LIMIT_MAX_RETRIES` and `CODERABBIT_RATE_LIMIT_WAIT` defaulted
+  to `2` and `180`, giving roughly six minutes of tolerance against a vendor
+  whose quota resets hourly — so a loop that hit the cap exhausted its retries
+  about 54 minutes before CodeRabbit could possibly answer, then escalated a PR
+  with nothing wrong with it. Defaults are now `4` and `900`, covering a full
+  60-minute reset window; both env vars still override.
 - **ShellCheck CI no longer hangs indefinitely installing zsh** (#1517):
   the `Install zsh for cross-shell snippet tests` step in
   `.github/workflows/shellcheck.yml` was observed hanging on three PRs, and

--- a/docs/workflow/development-workflow/integrations/coderabbit.md
+++ b/docs/workflow/development-workflow/integrations/coderabbit.md
@@ -182,7 +182,27 @@ Go to [coderabbit.ai](https://www.coderabbit.ai) and install the GitHub App on y
 reviews:
   auto_review:
     enabled: true
+    # true only if you list coderabbit in review.on_draft.github
+    drafts: false
+    # must include every base branch your PRs target, including develop-<slug>
+    base_branches:
+      - develop
+      - develop-.*
+    # 1 makes CodeRabbit pause after each reviewer-loop fix commit
+    auto_pause_after_reviewed_commits: 10
 ```
+
+`.coderabbit.yaml` must agree with the lifecycle bucket you pick in step 3. CodeRabbit declines to review — and posts a **"Review skipped" banner** instead — in three configurations that are easy to create by accident:
+
+| Configuration                                                       | When it bites                                                    |
+| ------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `auto_review.enabled: false`                                        | Every PR. This is the template's shipped default.                |
+| `auto_review.drafts: false` with `coderabbit` in `on_draft.github`  | Every draft PR, i.e. the entire draft gate.                      |
+| `auto_review.base_branches` missing the PR's base                   | Sub-item PRs into a `develop-<slug>` integration branch.         |
+
+`pr-review-loop.sh` treats that banner as **no review**, not as a completed review: it keeps polling, posts an explicit `@coderabbitai review` nudge (which works even when auto review is off), and if the banner is still standing when the poll window closes it exits `RESULT=escalate` with `REASON=review_skipped_banner`. That reason string is deliberately distinct from `rate_limit_max_retries` — it means "fix `.coderabbit.yaml`", not "wait for vendor quota".
+
+`auto_pause_after_reviewed_commits` deserves its own attention. It pauses auto review once that many reviewed commits arrive without human interaction. At `1`, every reviewer-loop fix commit trips the pause banner and costs a full poll cycle while the loop posts `@coderabbitai resume`. Convergence routinely takes several fix rounds, so set the cap above a normal round count.
 
 ### 3. Add to `.ai-dev-workflow.yaml`
 
@@ -193,9 +213,17 @@ review:
       - coderabbit
 ```
 
+Use `on_ready.github` instead when CodeRabbit should review the finished PR rather than the draft. That is the cheaper placement against an hourly quota: draft revisions are still moving, so reviewing them spends quota on code that is about to change.
+
 ### 4. Verify Auto-Review Is Active and Configured in the Workflow
 
 Push a commit to an open PR and confirm that CodeRabbit posts review comments. The bot posts as `coderabbitai[bot]`. CodeRabbit should also be listed in `.ai-dev-workflow.yaml`; otherwise the App may post findings that the workflow loop does not wait for.
+
+If the first comment CodeRabbit posts is a "Review skipped" banner rather than a walkthrough, the App is installed correctly but the configuration in step 2 does not cover this PR — re-check it against the table above before assuming the integration is broken.
+
+### 5. Size the rate-limit tolerance for your plan
+
+CodeRabbit's quota resets on an **hourly** boundary. The loop waits `CODERABBIT_RATE_LIMIT_WAIT` seconds (default `900`) and retries up to `CODERABBIT_RATE_LIMIT_MAX_RETRIES` times (default `4`), so the shipped defaults cover a full 60-minute reset window before escalating. Lower them only if you would rather escalate quickly than wait; raising them past an hour buys nothing, since a quota that has not reset in an hour indicates a spending cap rather than a rate limit.
 
 ---
 
@@ -229,10 +257,14 @@ The helper script checks for a CodeRabbit review on each poll iteration. If a re
 
 As a secondary signal, the script also checks for CodeRabbit issue comments (e.g., the PR summary comment) as an **activity indicator** — this is used only to distinguish "CodeRabbit is active but hasn't finished" from "CodeRabbit didn't review this HEAD at all" when the timeout is reached.
 
+Four kinds of CodeRabbit comment are explicitly **excluded** from that activity signal, because each one is CodeRabbit announcing that it did *not* review: the `Reviews paused` banner, a `rate limit` notice, a `Reviews resumed` acknowledgement, and the `Review skipped` banner (`CODERABBIT_SKIP_BANNER_RE`). Counting any of them as activity would break the poll loop into Phase 3, which would then collect zero inline comments and report the PR clean.
+
 | Result                                                     | Action                                                          |
 | ---------------------------------------------------------- | --------------------------------------------------------------- |
 | CodeRabbit review found after HEAD commit                  | Review complete — proceed to Step 7.3                           |
 | No review yet and `elapsed < max_wait`                     | Not finished yet — wait another `poll_interval` and poll again  |
+| `elapsed >= max_wait` and only a `Review skipped` banner   | Escalate — `REASON=review_skipped_banner` (fix `.coderabbit.yaml`) |
+| `elapsed >= max_wait` and a pause or rate-limit banner     | Escalate — `REASON=rate_limit_max_retries`                      |
 | `elapsed >= max_wait` and no CodeRabbit activity detected  | Stale findings recovery, then skip as `no_review` if none found |
 | `elapsed >= max_wait` and CodeRabbit activity was detected | Timeout — escalate to human                                     |
 

--- a/docs/workflow/development-workflow/integrations/coderabbit.md
+++ b/docs/workflow/development-workflow/integrations/coderabbit.md
@@ -192,7 +192,7 @@ reviews:
     auto_pause_after_reviewed_commits: 10
 ```
 
-`.coderabbit.yaml` must agree with the lifecycle bucket you pick in step 3. CodeRabbit declines to review — and posts a **"Review skipped" banner** instead — in three configurations that are easy to create by accident:
+`.coderabbit.yaml` must agree with the lifecycle bucket you pick in step 3. CodeRabbit declines to review — and posts a **"Review skipped" banner** instead — in three configurations that are easy to create unintentionally:
 
 | Configuration                                                       | When it bites                                                    |
 | ------------------------------------------------------------------- | ---------------------------------------------------------------- |
@@ -247,7 +247,9 @@ CodeRabbit posts as `coderabbitai[bot]`. Use this login to filter its comments a
 
 ### Step 7.1 — Trigger a re-review
 
-**No trigger needed.** CodeRabbit auto-reviews on every push when `auto_review.enabled` is `true` in `.coderabbit.yaml`. There is no trigger comment and therefore no `REVIEW_COMMENT_ID`.
+**No routine trigger needed.** CodeRabbit auto-reviews on every push when `auto_review.enabled` is `true` in `.coderabbit.yaml`, so the normal path posts nothing and there is no `REVIEW_COMMENT_ID`.
+
+The helper does post one **conditional** trigger. When no CodeRabbit activity has appeared after `CODERABBIT_NO_TRIGGER_TIMEOUT` seconds — because CodeRabbit stayed silent after a push, or because it declined with a `Review skipped` banner — the loop posts `@coderabbitai review`, which works even when auto review is disabled. This is bounded by `CODERABBIT_RATE_LIMIT_MAX_RETRIES`, shared with the rate-limit retry path so there is a single knob for total nudge attempts. A separate `@coderabbitai resume` is posted for the pause banner.
 
 ### Step 7.2 — Detect review completion
 

--- a/docs/workflow/development-workflow/integrations/coderabbit.md
+++ b/docs/workflow/development-workflow/integrations/coderabbit.md
@@ -257,7 +257,7 @@ The helper script checks for a CodeRabbit review on each poll iteration. If a re
 
 As a secondary signal, the script also checks for CodeRabbit issue comments (e.g., the PR summary comment) as an **activity indicator** — this is used only to distinguish "CodeRabbit is active but hasn't finished" from "CodeRabbit didn't review this HEAD at all" when the timeout is reached.
 
-Four kinds of CodeRabbit comment are explicitly **excluded** from that activity signal, because each one is CodeRabbit announcing that it did *not* review: the `Reviews paused` banner, a `rate limit` notice, a `Reviews resumed` acknowledgement, and the `Review skipped` banner (`CODERABBIT_SKIP_BANNER_RE`). Counting any of them as activity would break the poll loop into Phase 3, which would then collect zero inline comments and report the PR clean.
+Four kinds of CodeRabbit comment are explicitly **excluded** from that activity signal, because each one is CodeRabbit announcing that it did *not* review: the `Reviews paused` banner, a `rate limit` notice, a `Reviews resumed` acknowledgement, and the `Review skipped` banner (`CODERABBIT_SKIP_BANNER_RE`, which keys on the `skip review by coderabbit.ai` HTML marker and the banner's markdown heading rather than a bare "review skipped" substring, so a walkthrough using that phrase in prose is not mistaken for a banner). Counting any of them as activity would break the poll loop into Phase 3, which would then collect zero inline comments and report the PR clean.
 
 | Result                                                     | Action                                                          |
 | ---------------------------------------------------------- | --------------------------------------------------------------- |

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4768,6 +4768,14 @@ run_coderabbit_review() {
         # rate-limit handlers below whenever CodeRabbit has since said something more
         # specific. updated_at is accepted alongside created_at because CodeRabbit
         # revises its existing comment in place rather than always posting a new one.
+        #
+        # For the same reason the sort key is the EFFECTIVE event time,
+        # updated_at // created_at, not created_at. Admitting a comment on updated_at
+        # and then ordering on created_at contradicts itself: an older comment that
+        # CodeRabbit edited a moment ago is genuinely the most recent thing it said,
+        # but a created_at sort would rank a banner posted in between above it. That is
+        # not hypothetical — on PR #1532 the walkthrough comment was created at 23:23
+        # and revised at 23:52, straddling later comments.
         local timeout_latest_cr_body
         timeout_latest_cr_body="$(
           gh api "repos/$repo/issues/$pr_number/comments" --paginate \
@@ -4777,7 +4785,7 @@ run_coderabbit_review() {
                     .user.login == $bot and
                     (.created_at > $since or .updated_at > $since)
                   ))
-                | sort_by(.created_at)
+                | sort_by(.updated_at // .created_at)
                 | last
                 | .body // ""
               '

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -20,6 +20,27 @@ fi
 
 BUGBOT_HANDLED_SKIP_RC=3
 
+# CODERABBIT_SKIP_BANNER_RE — matches the CodeRabbit "Review skipped" banner.
+#
+# CodeRabbit posts this banner instead of a review whenever it declines to review a
+# PR by configuration rather than by capacity: `reviews.auto_review.enabled: false`
+# ("Auto reviews are disabled on this repository"), `auto_review.drafts: false` on a
+# draft PR, or an `auto_review.base_branches` list that does not match the PR base
+# (e.g. only `develop` listed while the PR targets a `develop-<slug>` integration
+# branch).
+#
+# It must never be counted as review activity. Before this constant existed, the
+# activity probe in run_coderabbit_review excluded only the pause, rate-limit, and
+# resume markers, so the skip banner satisfied "CodeRabbit posted something" and
+# broke the poll loop into Phase 3 — which then collected zero inline comments and
+# zero CHANGES_REQUESTED reviews and returned RESULT=clean for a PR CodeRabbit had
+# never looked at. Same false-clean class as #1437 (rate-limited SUCCESS status) and
+# the PR #650 pause-banner incident, both already fixed for their own banner shapes.
+#
+# Passed into jq as --arg skip_re and applied with test($skip_re; "i"), so it must
+# stay a case-insensitive-safe Oniguruma alternation with no anchors.
+CODERABBIT_SKIP_BANNER_RE='review skipped|auto reviews are disabled'
+
 # --- unlock subcommand ---
 # Must run before the single-instance lock guard so stale-lock recovery always
 # works: if a previous invocation crashed, the lock guard would re-acquire the
@@ -4048,9 +4069,13 @@ coderabbit_success_status_count() {
 # loop, so the silent-non-trigger safety net never had a chance to fire at
 # all on those branches.
 #
-# Fix: default to 180 s — the same already-vetted "give CodeRabbit time,
-# then nudge" cadence CODERABBIT_RATE_LIMIT_WAIT already uses elsewhere in
-# this script for the analogous rate-limit retry path.
+# Fix: default to 180 s — the "give CodeRabbit time, then nudge" cadence
+# CODERABBIT_RATE_LIMIT_WAIT originally shared. The two knobs have since
+# diverged deliberately and must not be re-coupled: this one waits out a
+# *silent* CodeRabbit (nothing posted at all), where 3 minutes is ample and a
+# longer wait is pure idle latency, while CODERABBIT_RATE_LIMIT_WAIT waits out
+# an *acknowledged* vendor quota block whose reset is hourly, so it is now
+# sized in quarter-hours (see its declaration in run_coderabbit_review).
 #
 # Effective-timeout rule (piecewise, by max_wait):
 #   - max_wait >= 360 s: effective = 180 s (the hardcoded default; the half-
@@ -4325,8 +4350,14 @@ run_coderabbit_review() {
   # Initialize retrigger flag from Phase 0 so Phase 2 does not double-post a resume.
   local coderabbit_retrigger_attempted=$coderabbit_phase0_retrigger
   local coderabbit_rate_limit_retries=0
-  local coderabbit_rate_limit_max_retries="${CODERABBIT_RATE_LIMIT_MAX_RETRIES:-2}"
-  local coderabbit_rate_limit_wait="${CODERABBIT_RATE_LIMIT_WAIT:-180}"
+  # Defaults are sized against CodeRabbit's *hourly* quota reset: 4 retries x 900 s
+  # covers 60 minutes of waiting, so a loop that hits the cap early in an hour can
+  # still succeed once the vendor window rolls over. The previous 2 x 180 s (~6 min)
+  # exhausted its retries roughly 54 minutes before the vendor could possibly answer
+  # and escalated PRs that had nothing wrong with them — the dominant failure mode
+  # for unattended overnight runs. Both env vars still override.
+  local coderabbit_rate_limit_max_retries="${CODERABBIT_RATE_LIMIT_MAX_RETRIES:-4}"
+  local coderabbit_rate_limit_wait="${CODERABBIT_RATE_LIMIT_WAIT:-900}"
   # See coderabbit_resolve_no_trigger_timeout / coderabbit_no_trigger_timeout_default
   # (issue #1433) for why the default is computed from max_wait rather than a
   # fixed constant, and for env var override / validation-fallback handling
@@ -4335,12 +4366,12 @@ run_coderabbit_review() {
   coderabbit_no_trigger_timeout="$(coderabbit_resolve_no_trigger_timeout "$max_wait")"
   local coderabbit_no_trigger_retriggers=0
   if ! [[ "$coderabbit_rate_limit_max_retries" =~ ^[0-9]+$ ]]; then
-    echo "WARN: CODERABBIT_RATE_LIMIT_MAX_RETRIES must be a non-negative integer; defaulting to 2" >&2
-    coderabbit_rate_limit_max_retries=2
+    echo "WARN: CODERABBIT_RATE_LIMIT_MAX_RETRIES must be a non-negative integer; defaulting to 4" >&2
+    coderabbit_rate_limit_max_retries=4
   fi
   if ! [[ "$coderabbit_rate_limit_wait" =~ ^[0-9]+$ ]] || [ "$coderabbit_rate_limit_wait" -le 0 ]; then
-    echo "WARN: CODERABBIT_RATE_LIMIT_WAIT must be a positive integer; defaulting to 180" >&2
-    coderabbit_rate_limit_wait=180
+    echo "WARN: CODERABBIT_RATE_LIMIT_WAIT must be a positive integer; defaulting to 900" >&2
+    coderabbit_rate_limit_wait=900
   fi
 
   while :; do
@@ -4367,19 +4398,22 @@ run_coderabbit_review() {
     # Filter by since_iso so historical comments from prior pushes do not incorrectly
     # mark this HEAD cycle as having activity (which would suppress stale-findings recovery).
     # Exclude "Reviews paused" comments (pause marker), "rate limit" comments (rate-limit
-    # marker), and "Reviews resumed" acknowledgement comments — none of these represent a
+    # marker), "Reviews resumed" acknowledgement comments, and "Review skipped" banners
+    # (skip marker — see CODERABBIT_SKIP_BANNER_RE) — none of these represent a
     # completed review and must not trigger an early break from the poll loop.
     if [ "$coderabbit_any_activity" -eq 0 ]; then
       local activity_count
       activity_count="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq -s --arg bot "$bot_login" --arg since "$since_iso" '
+          | jq -s --arg bot "$bot_login" --arg since "$since_iso" \
+               --arg skip_re "$CODERABBIT_SKIP_BANNER_RE" '
               [.[].[] | select(
                   .user.login == $bot and
                   .created_at > $since and
                   ((.body // "") | test("Reviews paused|review paused"; "i") | not) and
                   ((.body // "") | test("rate.?limit"; "i") | not) and
-                  ((.body // "") | test("reviews resumed"; "i") | not)
+                  ((.body // "") | test("reviews resumed"; "i") | not) and
+                  ((.body // "") | test($skip_re; "i") | not)
               )] | length
             '
       )"
@@ -4689,6 +4723,38 @@ run_coderabbit_review() {
                 )] | length
               '
         )"
+        # A "Review skipped" banner is a distinct terminal non-review outcome from a
+        # rate limit or a pause: CodeRabbit consciously declined to review this PR
+        # (auto_review disabled, drafts excluded, or base_branches not matching) rather
+        # than being unable to. It is counted separately so the escalation REASON tells
+        # the operator which knob to turn — review_skipped_banner points at
+        # .coderabbit.yaml, rate_limit_max_retries points at vendor quota.
+        local timeout_skip_banner_count
+        timeout_skip_banner_count="$(
+          gh api "repos/$repo/issues/$pr_number/comments" --paginate \
+            | jq -s --arg bot "$bot_login" --arg since "$since_iso" \
+                 --arg skip_re "$CODERABBIT_SKIP_BANNER_RE" '
+                [.[].[] | select(
+                    .user.login == $bot and
+                    (.created_at > $since or .updated_at > $since) and
+                    ((.body // "") | test($skip_re; "i"))
+                )] | length
+              '
+        )"
+        if [ "${timeout_skip_banner_count:-0}" -gt 0 ]; then
+          echo "ERROR: CodeRabbit posted a 'Review skipped' banner and never reviewed HEAD $head_sha — escalating instead of returning clean. Check reviews.auto_review.enabled / .drafts / .base_branches in .coderabbit.yaml against this PR's draft state and base branch." >&2
+          print_kv RESULT escalate
+          print_kv REASON review_skipped_banner
+          print_kv PLATFORM "$platform"
+          print_kv PR_NUMBER "$pr_number"
+          print_kv BRANCH "$branch_name"
+          print_kv REVIEW_COMMENT_ID ""
+          print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+          print_kv COMMENT_COUNT 0
+          print_kv BLOCKING_COUNT 0
+          print_kv SUGGESTION_COUNT 0
+          return 2
+        fi
         if [ "${timeout_incomplete_count:-0}" -gt 0 ] || [ "$coderabbit_phase0_retrigger" -eq 1 ]; then
           echo "INFO: CodeRabbit rate-limit or pause still unresolved at timeout (incomplete_count=${timeout_incomplete_count:-0}, phase0_retrigger=$coderabbit_phase0_retrigger) — escalating instead of returning clean" >&2
           print_kv RESULT escalate

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -43,14 +43,20 @@ BUGBOT_HANDLED_SKIP_RC=3
 # failure: the loop would ignore an actual review, poll to timeout, and escalate.
 # The three alternatives are ordered most to least machine-specific:
 #   1. the HTML marker CodeRabbit stamps on skip comments and on no other kind;
-#   2. the banner's markdown heading, which prose cannot produce accidentally
-#      (the banner renders inside a blockquote, so "> ## Review skipped" matches);
+#   2. the banner's markdown heading, REQUIRED to carry the blockquote prefix
+#      CodeRabbit always renders it with (the banner lives inside a
+#      "> [!IMPORTANT]" callout, so the body contains "> ## Review skipped").
+#      A bare "## Review skipped" heading is deliberately NOT matched: a genuine
+#      comment is free to use that heading, and misclassifying a real review as a
+#      banner is the mirror-image failure — the review would be dropped from the
+#      activity probe, polled to timeout, and escalated. If the vendor ever drops
+#      the callout wrapper, alternative 1 still covers the banner;
 #   3. the auto-review-disabled sentence, as a belt-and-braces fallback.
 #
 # Passed into jq as --arg skip_re with test($skip_re; "i") and to grep -qiE, so it
 # must stay an alternation valid in both Oniguruma and POSIX ERE, with no anchors
 # and no backslash escapes that differ between the two.
-CODERABBIT_SKIP_BANNER_RE='skip review by coderabbit|#{1,6} *review skipped|auto reviews are disabled'
+CODERABBIT_SKIP_BANNER_RE='skip review by coderabbit|> *#{1,6} *review skipped|auto reviews are disabled'
 
 # --- unlock subcommand ---
 # Must run before the single-instance lock guard so stale-lock recovery always
@@ -4741,21 +4747,36 @@ run_coderabbit_review() {
         # the operator which knob to turn — review_skipped_banner points at
         # .coderabbit.yaml, rate_limit_max_retries points at vendor quota.
         #
-        # Matched on the MOST RECENT CodeRabbit comment only, not on "any banner inside
-        # the since_iso window". A repository that sets auto_review.drafts to false —
-        # the recommended setting when coderabbit runs in on_ready.github — collects a
-        # "Review skipped / Draft detected" banner on every PR while it is still a
-        # draft. That banner is newer than the HEAD commit, so a window-wide match would
-        # attribute every later ready-phase timeout to a stale draft banner and report
-        # review_skipped_banner for what is really a slow or silent CodeRabbit. Taking
-        # only the latest comment also yields correctly to the pause and rate-limit
-        # handlers below whenever CodeRabbit has since said something more specific.
+        # Matched on the LATEST CodeRabbit comment WITHIN the current HEAD window.
+        # Both halves of that are load-bearing, and each one alone misattributes in the
+        # opposite direction:
+        #
+        #   - "Any banner in the window" (no latest constraint) blames a stale banner
+        #     for a later outcome. A repository that sets auto_review.drafts to false —
+        #     the recommended setting when coderabbit runs in on_ready.github — collects
+        #     a "Review skipped / Draft detected" banner on every PR while it is still a
+        #     draft, timestamped after the HEAD commit. Without the latest constraint,
+        #     every subsequent ready-phase timeout would report review_skipped_banner
+        #     even when CodeRabbit had since posted a pause or rate-limit notice.
+        #
+        #   - "Latest comment overall" (no window constraint) blames a banner from a
+        #     PREVIOUS HEAD. Push a new commit after a draft-phase banner and that
+        #     banner is still the newest comment on the PR, so a silent or rate-limited
+        #     review of the *current* HEAD would be reported as a configuration problem.
+        #
+        # Taking the latest in-window comment also yields correctly to the pause and
+        # rate-limit handlers below whenever CodeRabbit has since said something more
+        # specific. updated_at is accepted alongside created_at because CodeRabbit
+        # revises its existing comment in place rather than always posting a new one.
         local timeout_latest_cr_body
         timeout_latest_cr_body="$(
           gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-            | jq -rs --arg bot "$bot_login" '
+            | jq -rs --arg bot "$bot_login" --arg since "$since_iso" '
                 add // []
-                | map(select(.user.login == $bot))
+                | map(select(
+                    .user.login == $bot and
+                    (.created_at > $since or .updated_at > $since)
+                  ))
                 | sort_by(.created_at)
                 | last
                 | .body // ""

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -37,9 +37,20 @@ BUGBOT_HANDLED_SKIP_RC=3
 # never looked at. Same false-clean class as #1437 (rate-limited SUCCESS status) and
 # the PR #650 pause-banner incident, both already fixed for their own banner shapes.
 #
-# Passed into jq as --arg skip_re and applied with test($skip_re; "i"), so it must
-# stay a case-insensitive-safe Oniguruma alternation with no anchors.
-CODERABBIT_SKIP_BANNER_RE='review skipped|auto reviews are disabled'
+# Deliberately NOT a bare "review skipped" substring match. A genuine walkthrough
+# is free to contain that phrase in prose ("this review skipped the generated
+# files"), and misclassifying a real review as a banner is the mirror-image
+# failure: the loop would ignore an actual review, poll to timeout, and escalate.
+# The three alternatives are ordered most to least machine-specific:
+#   1. the HTML marker CodeRabbit stamps on skip comments and on no other kind;
+#   2. the banner's markdown heading, which prose cannot produce accidentally
+#      (the banner renders inside a blockquote, so "> ## Review skipped" matches);
+#   3. the auto-review-disabled sentence, as a belt-and-braces fallback.
+#
+# Passed into jq as --arg skip_re with test($skip_re; "i") and to grep -qiE, so it
+# must stay an alternation valid in both Oniguruma and POSIX ERE, with no anchors
+# and no backslash escapes that differ between the two.
+CODERABBIT_SKIP_BANNER_RE='skip review by coderabbit|#{1,6} *review skipped|auto reviews are disabled'
 
 # --- unlock subcommand ---
 # Must run before the single-instance lock guard so stale-lock recovery always
@@ -4726,21 +4737,35 @@ run_coderabbit_review() {
         # A "Review skipped" banner is a distinct terminal non-review outcome from a
         # rate limit or a pause: CodeRabbit consciously declined to review this PR
         # (auto_review disabled, drafts excluded, or base_branches not matching) rather
-        # than being unable to. It is counted separately so the escalation REASON tells
+        # than being unable to. It is detected separately so the escalation REASON tells
         # the operator which knob to turn — review_skipped_banner points at
         # .coderabbit.yaml, rate_limit_max_retries points at vendor quota.
-        local timeout_skip_banner_count
-        timeout_skip_banner_count="$(
+        #
+        # Matched on the MOST RECENT CodeRabbit comment only, not on "any banner inside
+        # the since_iso window". A repository that sets auto_review.drafts to false —
+        # the recommended setting when coderabbit runs in on_ready.github — collects a
+        # "Review skipped / Draft detected" banner on every PR while it is still a
+        # draft. That banner is newer than the HEAD commit, so a window-wide match would
+        # attribute every later ready-phase timeout to a stale draft banner and report
+        # review_skipped_banner for what is really a slow or silent CodeRabbit. Taking
+        # only the latest comment also yields correctly to the pause and rate-limit
+        # handlers below whenever CodeRabbit has since said something more specific.
+        local timeout_latest_cr_body
+        timeout_latest_cr_body="$(
           gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-            | jq -s --arg bot "$bot_login" --arg since "$since_iso" \
-                 --arg skip_re "$CODERABBIT_SKIP_BANNER_RE" '
-                [.[].[] | select(
-                    .user.login == $bot and
-                    (.created_at > $since or .updated_at > $since) and
-                    ((.body // "") | test($skip_re; "i"))
-                )] | length
+            | jq -rs --arg bot "$bot_login" '
+                add // []
+                | map(select(.user.login == $bot))
+                | sort_by(.created_at)
+                | last
+                | .body // ""
               '
         )"
+        local timeout_skip_banner_count=0
+        if printf '%s\n' "$timeout_latest_cr_body" \
+             | grep -qiE "$CODERABBIT_SKIP_BANNER_RE"; then
+          timeout_skip_banner_count=1
+        fi
         if [ "${timeout_skip_banner_count:-0}" -gt 0 ]; then
           echo "ERROR: CodeRabbit posted a 'Review skipped' banner and never reviewed HEAD $head_sha — escalating instead of returning clean. Check reviews.auto_review.enabled / .drafts / .base_branches in .coderabbit.yaml against this PR's draft state and base branch." >&2
           print_kv RESULT escalate

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -13005,24 +13005,30 @@ _cr_mock_dir_1531="$(mktemp -d)"
 _cr_call_log_1531="$_cr_mock_dir_1531/calls.log"
 cat > "$_cr_mock_dir_1531/gh" <<'CR_GH_1531'
 #!/usr/bin/env bash
+# Strict mock: every gh invocation run_coderabbit_review legitimately makes is
+# enumerated, and anything else is a hard error. A permissive "*) echo []" fallback
+# would let these cases pass for the wrong reason — a renamed or dropped comments
+# request would silently return an empty array and still produce the expected
+# REASON, proving nothing.
 printf '%s\n' "$*" >> "$CR_CALL_LOG"
 case "$*" in
-  *"--jq .head.sha"*)
-    printf 'abc1531sha\n'; exit 0 ;;
-  *"--jq .commit.committer.date"*)
-    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
-  # An empty, successful thread audit. Without this the audit errors against the
-  # default "[]" and the run escalates as review_thread_audit_failed — which would
-  # make the RESULT=escalate assertion below pass for the wrong reason, and hide
-  # the fact that the unfixed code returns RESULT=clean here.
-  *"api graphql"*)
-    printf '%s\n' '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}'
-    exit 0 ;;
+  "auth status") exit 0 ;;
+  *"repo view"*"nameWithOwner"*) printf 'owner/repo\n'; exit 0 ;;
+  *"pulls/42 --jq .head.sha"*) printf 'abc1531sha\n'; exit 0 ;;
+  *"commits/abc1531sha --jq .commit.committer.date"*) printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"commits/abc1531sha/statuses"*) printf '[]\n'; exit 0 ;;
+  *"pulls/42/comments"*) printf '[]\n'; exit 0 ;;
+  *"pulls/42/reviews"*) printf '[]\n'; exit 0 ;;
   *"issues/42/comments"*)
     printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:00:01Z","updated_at":"2020-01-01T00:00:01Z","body":"<!-- This is an auto-generated comment: skip review by coderabbit.ai -->\n\n> [!IMPORTANT]\n> ## Review skipped\n>\n> Auto reviews are disabled on this repository."}]'
     exit 0 ;;
+  *"api graphql"*)
+    printf '%s\n' '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}'
+    exit 0 ;;
+  *"pr comment 42"*) exit 0 ;;
   *)
-    printf '[]\n'; exit 0 ;;
+    printf 'UNEXPECTED gh invocation in 1531 mock: %s\n' "$*" >&2
+    exit 1 ;;
 esac
 CR_GH_1531
 chmod +x "$_cr_mock_dir_1531/gh"
@@ -13041,6 +13047,11 @@ run_test "cr_skip_banner_escalates_not_clean" "RESULT=escalate" \
 # .coderabbit.yaml change, not waiting out a vendor quota.
 run_test "cr_skip_banner_reason_is_review_skipped_banner" "REASON=review_skipped_banner" \
   "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+
+# The mock errors on any unenumerated call, but silence is not proof the RIGHT
+# call happened — assert the comments endpoint was actually requested.
+run_test "cr_skip_banner_queried_issue_comments" "yes" \
+  "$([ "$(grep_count_or_zero "issues/42/comments" "$_cr_call_log_1531")" -ge 1 ] && echo yes || echo no)"
 
 # AC-2: the loop must still have nudged CodeRabbit with an explicit trigger
 # before giving up, since "@coderabbitai review" works even when auto review is
@@ -13071,20 +13082,30 @@ _cr_mock_dir_1531b="$(mktemp -d)"
 _cr_call_log_1531b="$_cr_mock_dir_1531b/calls.log"
 cat > "$_cr_mock_dir_1531b/gh" <<'CR_GH_1531B'
 #!/usr/bin/env bash
+# Strict mock: every gh invocation run_coderabbit_review legitimately makes is
+# enumerated, and anything else is a hard error. A permissive "*) echo []" fallback
+# would let these cases pass for the wrong reason — a renamed or dropped comments
+# request would silently return an empty array and still produce the expected
+# REASON, proving nothing.
 printf '%s\n' "$*" >> "$CR_CALL_LOG"
 case "$*" in
-  *"--jq .head.sha"*)
-    printf 'abc1531bsha\n'; exit 0 ;;
-  *"--jq .commit.committer.date"*)
-    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
-  *"api graphql"*)
-    printf '%s\n' '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}'
-    exit 0 ;;
+  "auth status") exit 0 ;;
+  *"repo view"*"nameWithOwner"*) printf 'owner/repo\n'; exit 0 ;;
+  *"pulls/42 --jq .head.sha"*) printf 'abc1531bsha\n'; exit 0 ;;
+  *"commits/abc1531bsha --jq .commit.committer.date"*) printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"commits/abc1531bsha/statuses"*) printf '[]\n'; exit 0 ;;
+  *"pulls/42/comments"*) printf '[]\n'; exit 0 ;;
+  *"pulls/42/reviews"*) printf '[]\n'; exit 0 ;;
   *"issues/42/comments"*)
     printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:00:01Z","updated_at":"2020-01-01T00:00:01Z","body":"<!-- This is an auto-generated comment: skip review by coderabbit.ai -->\n\n> [!IMPORTANT]\n> ## Review skipped\n>\n> Draft detected."},{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:05:00Z","updated_at":"2020-01-01T00:05:00Z","body":"Review limit reached — rate limit in effect."}]'
     exit 0 ;;
+  *"api graphql"*)
+    printf '%s\n' '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}'
+    exit 0 ;;
+  *"pr comment 42"*) exit 0 ;;
   *)
-    printf '[]\n'; exit 0 ;;
+    printf 'UNEXPECTED gh invocation in 1531B mock: %s\n' "$*" >&2
+    exit 1 ;;
 esac
 CR_GH_1531B
 chmod +x "$_cr_mock_dir_1531b/gh"
@@ -13100,6 +13121,8 @@ run_test "cr_stale_draft_banner_does_not_shadow_rate_limit" "REASON=rate_limit_m
   "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
 run_test "cr_stale_draft_banner_still_escalates" "RESULT=escalate" \
   "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "cr_stale_draft_banner_queried_issue_comments" "yes" \
+  "$([ "$(grep_count_or_zero "issues/42/comments" "$_cr_call_log_1531b")" -ge 1 ] && echo yes || echo no)"
 
 rm -rf "$_cr_mock_dir_1531b"
 unset _cr_mock_dir_1531b _cr_call_log_1531b actual_output
@@ -13115,20 +13138,30 @@ _cr_mock_dir_1531c="$(mktemp -d)"
 _cr_call_log_1531c="$_cr_mock_dir_1531c/calls.log"
 cat > "$_cr_mock_dir_1531c/gh" <<'CR_GH_1531C'
 #!/usr/bin/env bash
+# Strict mock: every gh invocation run_coderabbit_review legitimately makes is
+# enumerated, and anything else is a hard error. A permissive "*) echo []" fallback
+# would let these cases pass for the wrong reason — a renamed or dropped comments
+# request would silently return an empty array and still produce the expected
+# REASON, proving nothing.
 printf '%s\n' "$*" >> "$CR_CALL_LOG"
 case "$*" in
-  *"--jq .head.sha"*)
-    printf 'abc1531csha\n'; exit 0 ;;
-  *"--jq .commit.committer.date"*)
-    printf '2020-01-02T00:00:00Z\n'; exit 0 ;;
-  *"api graphql"*)
-    printf '%s\n' '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}'
-    exit 0 ;;
+  "auth status") exit 0 ;;
+  *"repo view"*"nameWithOwner"*) printf 'owner/repo\n'; exit 0 ;;
+  *"pulls/42 --jq .head.sha"*) printf 'abc1531csha\n'; exit 0 ;;
+  *"commits/abc1531csha --jq .commit.committer.date"*) printf '2020-01-02T00:00:00Z\n'; exit 0 ;;
+  *"commits/abc1531csha/statuses"*) printf '[]\n'; exit 0 ;;
+  *"pulls/42/comments"*) printf '[]\n'; exit 0 ;;
+  *"pulls/42/reviews"*) printf '[]\n'; exit 0 ;;
   *"issues/42/comments"*)
     printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:00:01Z","updated_at":"2020-01-01T00:00:01Z","body":"<!-- This is an auto-generated comment: skip review by coderabbit.ai -->\n\n> [!IMPORTANT]\n> ## Review skipped\n>\n> Draft detected."}]'
     exit 0 ;;
+  *"api graphql"*)
+    printf '%s\n' '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}'
+    exit 0 ;;
+  *"pr comment 42"*) exit 0 ;;
   *)
-    printf '[]\n'; exit 0 ;;
+    printf 'UNEXPECTED gh invocation in 1531C mock: %s\n' "$*" >&2
+    exit 1 ;;
 esac
 CR_GH_1531C
 chmod +x "$_cr_mock_dir_1531c/gh"
@@ -13141,9 +13174,99 @@ actual_output="$(
 
 run_test "cr_banner_from_previous_head_not_attributed" "REASON=no_review" \
   "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+run_test "cr_banner_from_previous_head_queried_issue_comments" "yes" \
+  "$([ "$(grep_count_or_zero "issues/42/comments" "$_cr_call_log_1531c")" -ge 1 ] && echo yes || echo no)"
 
 rm -rf "$_cr_mock_dir_1531c"
 unset _cr_mock_dir_1531c _cr_call_log_1531c actual_output
+
+# --- The "latest" comment is ordered by EFFECTIVE event time -----------------
+# Admitting comments on `updated_at` and then ordering them on `created_at`
+# contradicts itself: an older comment CodeRabbit edited a moment ago is the most
+# recent thing it said, but a created_at sort ranks anything posted in between
+# above it. Both permutations below are non-activity comments (a skip banner and
+# a rate-limit notice), so both reach the timeout guard, and each one flips its
+# verdict if the sort key regresses to created_at.
+
+# Permutation 1 — banner created last, rate-limit notice UPDATED last.
+# Effective latest is the rate-limit notice, so this is a quota problem.
+_cr_mock_dir_1531d="$(mktemp -d)"
+_cr_call_log_1531d="$_cr_mock_dir_1531d/calls.log"
+cat > "$_cr_mock_dir_1531d/gh" <<'CR_GH_1531D'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CR_CALL_LOG"
+case "$*" in
+  "auth status") exit 0 ;;
+  *"repo view"*"nameWithOwner"*) printf 'owner/repo\n'; exit 0 ;;
+  *"pulls/42 --jq .head.sha"*) printf 'abc1531dsha\n'; exit 0 ;;
+  *"commits/abc1531dsha --jq .commit.committer.date"*) printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"commits/abc1531dsha/statuses"*) printf '[]\n'; exit 0 ;;
+  *"pulls/42/comments"*) printf '[]\n'; exit 0 ;;
+  *"pulls/42/reviews"*) printf '[]\n'; exit 0 ;;
+  *"issues/42/comments"*)
+    printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:00:30Z","updated_at":"2020-01-01T00:00:30Z","body":"<!-- This is an auto-generated comment: skip review by coderabbit.ai -->\n\n> [!IMPORTANT]\n> ## Review skipped\n>\n> Draft detected."},{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:00:10Z","updated_at":"2020-01-01T00:01:00Z","body":"Review limit reached — rate limit in effect."}]'
+    exit 0 ;;
+  *"api graphql"*)
+    printf '%s\n' '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}'
+    exit 0 ;;
+  *"pr comment 42"*) exit 0 ;;
+  *)
+    printf 'UNEXPECTED gh invocation in abc1531d mock: %s\n' "$*" >&2
+    exit 1 ;;
+esac
+CR_GH_1531D
+chmod +x "$_cr_mock_dir_1531d/gh"
+
+actual_output="$(
+  PATH="$_cr_mock_dir_1531d:$PATH" CR_CALL_LOG="$_cr_call_log_1531d" \
+    CODERABBIT_NO_TRIGGER_TIMEOUT=1 CODERABBIT_RATE_LIMIT_WAIT=1 \
+    CODERABBIT_RATE_LIMIT_MAX_RETRIES=1 \
+    run_coderabbit_review "42" "fix/42-test" "1" "3" 2>/dev/null || true
+)"
+run_test "cr_latest_by_effective_time_prefers_updated_rate_limit" "REASON=rate_limit_max_retries" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+rm -rf "$_cr_mock_dir_1531d"
+unset _cr_mock_dir_1531d _cr_call_log_1531d actual_output
+
+# Permutation 2 — rate-limit notice created last, banner UPDATED last.
+# Effective latest is the banner, so this is a configuration problem.
+_cr_mock_dir_1531e="$(mktemp -d)"
+_cr_call_log_1531e="$_cr_mock_dir_1531e/calls.log"
+cat > "$_cr_mock_dir_1531e/gh" <<'CR_GH_1531E'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CR_CALL_LOG"
+case "$*" in
+  "auth status") exit 0 ;;
+  *"repo view"*"nameWithOwner"*) printf 'owner/repo\n'; exit 0 ;;
+  *"pulls/42 --jq .head.sha"*) printf 'abc1531esha\n'; exit 0 ;;
+  *"commits/abc1531esha --jq .commit.committer.date"*) printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"commits/abc1531esha/statuses"*) printf '[]\n'; exit 0 ;;
+  *"pulls/42/comments"*) printf '[]\n'; exit 0 ;;
+  *"pulls/42/reviews"*) printf '[]\n'; exit 0 ;;
+  *"issues/42/comments"*)
+    printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:00:30Z","updated_at":"2020-01-01T00:00:30Z","body":"Review limit reached — rate limit in effect."},{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:00:10Z","updated_at":"2020-01-01T00:01:00Z","body":"<!-- This is an auto-generated comment: skip review by coderabbit.ai -->\n\n> [!IMPORTANT]\n> ## Review skipped\n>\n> Draft detected."}]'
+    exit 0 ;;
+  *"api graphql"*)
+    printf '%s\n' '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}'
+    exit 0 ;;
+  *"pr comment 42"*) exit 0 ;;
+  *)
+    printf 'UNEXPECTED gh invocation in abc1531e mock: %s\n' "$*" >&2
+    exit 1 ;;
+esac
+CR_GH_1531E
+chmod +x "$_cr_mock_dir_1531e/gh"
+
+actual_output="$(
+  PATH="$_cr_mock_dir_1531e:$PATH" CR_CALL_LOG="$_cr_call_log_1531e" \
+    CODERABBIT_NO_TRIGGER_TIMEOUT=1 CODERABBIT_RATE_LIMIT_WAIT=1 \
+    CODERABBIT_RATE_LIMIT_MAX_RETRIES=1 \
+    run_coderabbit_review "42" "fix/42-test" "1" "3" 2>/dev/null || true
+)"
+run_test "cr_latest_by_effective_time_prefers_updated_banner" "REASON=review_skipped_banner" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+rm -rf "$_cr_mock_dir_1531e"
+unset _cr_mock_dir_1531e _cr_call_log_1531e actual_output
 
 # --- AC-4: rate-limit tolerance spans an hourly vendor quota reset ------------
 # Asserted against the script source: the defaults are function-locals, so there

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -12908,7 +12908,7 @@ unset MOCK_GH_OUTPUT MOCK_GH_POST_EXIT MOCK_GH_POST_OUTPUT MOCK_GH_CALL_LOG MOCK
 
 # The exact banner CodeRabbit posts when reviews.auto_review.enabled is false,
 # quoted from an observed comment on this repository (PR #1527).
-_CR_SKIP_BANNER_1531='> [!IMPORTANT]\n> ## Review skipped\n> \n> Auto reviews are disabled on this repository. Please check the settings in the CodeRabbit UI or the `.coderabbit.yaml` file in this repository. To trigger a single review, invoke the `@coderabbitai review` command.'
+_CR_SKIP_BANNER_1531='<!-- This is an auto-generated comment: skip review by coderabbit.ai -->\n\n> [!IMPORTANT]\n> ## Review skipped\n> \n> Auto reviews are disabled on this repository. Please check the settings in the CodeRabbit UI or the `.coderabbit.yaml` file in this repository. To trigger a single review, invoke the `@coderabbitai review` command.'
 
 # --- AC-1: the regex classifies banners, not genuine reviews ------------------
 _cr_re_matches_1531() {
@@ -12924,9 +12924,18 @@ run_test "cr_skip_banner_re_matches_auto_reviews_disabled" "yes" \
 # heading for the drafts-excluded and base-branch-mismatch variants, whose
 # bodies never contain the "auto reviews are disabled" sentence.
 run_test "cr_skip_banner_re_matches_review_skipped_alone" "yes" \
+  "$(_cr_re_matches_1531 '> [!IMPORTANT]
+> ## Review skipped
+>
+> Draft detected. Set `reviews.auto_review.drafts` to true to review draft PRs.')"
+
+# CONTROL: a BARE "## Review skipped" heading, with no blockquote prefix, is not
+# a banner. A genuine CodeRabbit comment may legitimately use that heading, and
+# classifying it as a banner would drop a real review from the activity probe.
+run_test "cr_skip_banner_re_ignores_bare_heading" "no" \
   "$(_cr_re_matches_1531 '## Review skipped
 
-Draft detected. Set `reviews.auto_review.drafts` to true to review draft PRs.')"
+This section explains when the reviewer skips generated files.')"
 
 # CONTROL: a genuine CodeRabbit walkthrough must NOT match, or the fix would
 # suppress real reviews and hang every loop until timeout.
@@ -12960,6 +12969,8 @@ _cr_grep_matches_1531() {
 }
 run_test "cr_skip_banner_re_grep_agrees_on_banner" "yes" \
   "$(_cr_grep_matches_1531 '> ## Review skipped')"
+run_test "cr_skip_banner_re_grep_agrees_on_bare_heading" "no" \
+  "$(_cr_grep_matches_1531 '## Review skipped')"
 run_test "cr_skip_banner_re_grep_agrees_on_prose" "no" \
   "$(_cr_grep_matches_1531 'The walkthrough notes that this review skipped the generated files.')"
 
@@ -13008,7 +13019,7 @@ case "$*" in
     printf '%s\n' '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}'
     exit 0 ;;
   *"issues/42/comments"*)
-    printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:00:01Z","updated_at":"2020-01-01T00:00:01Z","body":"## Review skipped — Auto reviews are disabled on this repository."}]'
+    printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:00:01Z","updated_at":"2020-01-01T00:00:01Z","body":"<!-- This is an auto-generated comment: skip review by coderabbit.ai -->\n\n> [!IMPORTANT]\n> ## Review skipped\n>\n> Auto reviews are disabled on this repository."}]'
     exit 0 ;;
   *)
     printf '[]\n'; exit 0 ;;
@@ -13070,7 +13081,7 @@ case "$*" in
     printf '%s\n' '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}'
     exit 0 ;;
   *"issues/42/comments"*)
-    printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:00:01Z","updated_at":"2020-01-01T00:00:01Z","body":"## Review skipped — Draft detected."},{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:05:00Z","updated_at":"2020-01-01T00:05:00Z","body":"Review limit reached — rate limit in effect."}]'
+    printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:00:01Z","updated_at":"2020-01-01T00:00:01Z","body":"<!-- This is an auto-generated comment: skip review by coderabbit.ai -->\n\n> [!IMPORTANT]\n> ## Review skipped\n>\n> Draft detected."},{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:05:00Z","updated_at":"2020-01-01T00:05:00Z","body":"Review limit reached — rate limit in effect."}]'
     exit 0 ;;
   *)
     printf '[]\n'; exit 0 ;;
@@ -13092,6 +13103,47 @@ run_test "cr_stale_draft_banner_still_escalates" "RESULT=escalate" \
 
 rm -rf "$_cr_mock_dir_1531b"
 unset _cr_mock_dir_1531b _cr_call_log_1531b actual_output
+
+# --- A banner from a PREVIOUS HEAD must not be attributed to this one --------
+# Mirror of the stale-draft case above. Here the only CodeRabbit comment is a
+# skip banner that PREDATES the HEAD commit — the shape produced by pushing a
+# new commit after a draft-phase banner. CodeRabbit has said nothing about the
+# current HEAD, so the outcome is "did not review this HEAD" (no_review), not a
+# configuration problem. Reporting review_skipped_banner here would send the
+# operator to .coderabbit.yaml for what is really a silent or rate-limited review.
+_cr_mock_dir_1531c="$(mktemp -d)"
+_cr_call_log_1531c="$_cr_mock_dir_1531c/calls.log"
+cat > "$_cr_mock_dir_1531c/gh" <<'CR_GH_1531C'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CR_CALL_LOG"
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc1531csha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-02T00:00:00Z\n'; exit 0 ;;
+  *"api graphql"*)
+    printf '%s\n' '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}'
+    exit 0 ;;
+  *"issues/42/comments"*)
+    printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:00:01Z","updated_at":"2020-01-01T00:00:01Z","body":"<!-- This is an auto-generated comment: skip review by coderabbit.ai -->\n\n> [!IMPORTANT]\n> ## Review skipped\n>\n> Draft detected."}]'
+    exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+CR_GH_1531C
+chmod +x "$_cr_mock_dir_1531c/gh"
+
+actual_output="$(
+  PATH="$_cr_mock_dir_1531c:$PATH" CR_CALL_LOG="$_cr_call_log_1531c" \
+    CODERABBIT_NO_TRIGGER_TIMEOUT=1 \
+    run_coderabbit_review "42" "fix/42-test" "1" "3" 2>/dev/null || true
+)"
+
+run_test "cr_banner_from_previous_head_not_attributed" "REASON=no_review" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+
+rm -rf "$_cr_mock_dir_1531c"
+unset _cr_mock_dir_1531c _cr_call_log_1531c actual_output
 
 # --- AC-4: rate-limit tolerance spans an hourly vendor quota reset ------------
 # Asserted against the script source: the defaults are function-locals, so there

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -12939,6 +12939,30 @@ The changes update the reviewer loop. Estimated code review effort: 3.')"
 run_test "cr_skip_banner_re_ignores_prose_use_of_skipped" "no" \
   "$(_cr_re_matches_1531 'Nitpick: this branch is skipped when the list is empty.')"
 
+# CONTROL, and the reason the pattern is not a bare "review skipped" substring:
+# a genuine walkthrough may use that exact phrase in prose. Matching it would be
+# the mirror-image failure — a real review classified as a banner, ignored by the
+# activity probe, polled to timeout, and escalated.
+run_test "cr_skip_banner_re_ignores_exact_phrase_in_prose" "no" \
+  "$(_cr_re_matches_1531 'The walkthrough notes that this review skipped the generated files.')"
+
+# The HTML marker CodeRabbit stamps on skip comments (and on no other kind) is
+# the most reliable signal, and must match on its own even if the rendered
+# heading text is reworded by the vendor.
+run_test "cr_skip_banner_re_matches_html_marker_alone" "yes" \
+  "$(_cr_re_matches_1531 '<!-- This is an auto-generated comment: skip review by coderabbit.ai -->')"
+
+# The pattern is consumed by BOTH jq (test(); Oniguruma) and grep -qiE (POSIX
+# ERE). A pattern valid in only one engine would silently stop matching at one of
+# the two call sites, so the engines are asserted to agree.
+_cr_grep_matches_1531() {
+  if printf '%s' "$1" | grep -qiE "$CODERABBIT_SKIP_BANNER_RE"; then echo yes; else echo no; fi
+}
+run_test "cr_skip_banner_re_grep_agrees_on_banner" "yes" \
+  "$(_cr_grep_matches_1531 '> ## Review skipped')"
+run_test "cr_skip_banner_re_grep_agrees_on_prose" "no" \
+  "$(_cr_grep_matches_1531 'The walkthrough notes that this review skipped the generated files.')"
+
 # --- AC-1: the activity probe returns 0 for a banner-only comment set ---------
 # Mirrors the production jq expression in run_coderabbit_review so a future edit
 # that drops the $skip_re clause is caught here.
@@ -13024,6 +13048,50 @@ unset _cr_trigger_count_1531
 
 rm -rf "$_cr_mock_dir_1531"
 unset _cr_mock_dir_1531 _cr_call_log_1531 actual_output _CR_SKIP_BANNER_1531
+
+# --- Stale draft banner must not shadow a newer, more specific outcome --------
+# A repository that runs coderabbit in on_ready.github keeps auto_review.drafts
+# false, so EVERY PR collects a "Review skipped / Draft detected" banner while it
+# is still a draft. That banner is newer than the HEAD commit, so a guard that
+# matched any banner inside the since_iso window would blame it for every later
+# ready-phase timeout. Here the newest CodeRabbit comment is a rate-limit notice:
+# the run must escalate as rate_limit_max_retries, not review_skipped_banner.
+_cr_mock_dir_1531b="$(mktemp -d)"
+_cr_call_log_1531b="$_cr_mock_dir_1531b/calls.log"
+cat > "$_cr_mock_dir_1531b/gh" <<'CR_GH_1531B'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CR_CALL_LOG"
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc1531bsha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  *"api graphql"*)
+    printf '%s\n' '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}'
+    exit 0 ;;
+  *"issues/42/comments"*)
+    printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:00:01Z","updated_at":"2020-01-01T00:00:01Z","body":"## Review skipped — Draft detected."},{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:05:00Z","updated_at":"2020-01-01T00:05:00Z","body":"Review limit reached — rate limit in effect."}]'
+    exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+CR_GH_1531B
+chmod +x "$_cr_mock_dir_1531b/gh"
+
+actual_output="$(
+  PATH="$_cr_mock_dir_1531b:$PATH" CR_CALL_LOG="$_cr_call_log_1531b" \
+    CODERABBIT_NO_TRIGGER_TIMEOUT=1 CODERABBIT_RATE_LIMIT_WAIT=1 \
+    CODERABBIT_RATE_LIMIT_MAX_RETRIES=1 \
+    run_coderabbit_review "42" "fix/42-test" "1" "3" 2>/dev/null || true
+)"
+
+run_test "cr_stale_draft_banner_does_not_shadow_rate_limit" "REASON=rate_limit_max_retries" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+run_test "cr_stale_draft_banner_still_escalates" "RESULT=escalate" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+
+rm -rf "$_cr_mock_dir_1531b"
+unset _cr_mock_dir_1531b _cr_call_log_1531b actual_output
 
 # --- AC-4: rate-limit tolerance spans an hourly vendor quota reset ------------
 # Asserted against the script source: the defaults are function-locals, so there

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -12885,6 +12885,156 @@ run_test "no_trigger_resolve_zero_override_falls_back_to_default" "180" "$actual
 unset CODERABBIT_NO_TRIGGER_TIMEOUT
 
 # ---------------------------------------------------------------------------
+# Area: CodeRabbit "Review skipped" banner is not review activity (issue #1531)
+#
+# CodeRabbit posts a "Review skipped" banner instead of a review whenever it
+# declines by configuration rather than by capacity (auto_review.enabled false,
+# drafts excluded, or base_branches not matching the PR base). Before this fix
+# the activity probe in run_coderabbit_review excluded only the pause,
+# rate-limit, and resume markers, so the skip banner read as "CodeRabbit posted
+# something", broke the poll loop into Phase 3, and Phase 3 returned
+# RESULT=clean after collecting zero inline comments — a clean verdict on a PR
+# CodeRabbit never looked at.
+#
+# The end-to-end case runs with poll_interval=1, max_wait=3 and
+# CODERABBIT_NO_TRIGGER_TIMEOUT=1 so the loop exercises the explicit-nudge path
+# and then its timeout branch — where the skip-banner guard lives — within a few
+# seconds of real sleep.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area: CodeRabbit skip-banner false-clean (issue #1531) ==="
+
+unset MOCK_GH_OUTPUT MOCK_GH_POST_EXIT MOCK_GH_POST_OUTPUT MOCK_GH_CALL_LOG MOCK_GH_EXIT
+
+# The exact banner CodeRabbit posts when reviews.auto_review.enabled is false,
+# quoted from an observed comment on this repository (PR #1527).
+_CR_SKIP_BANNER_1531='> [!IMPORTANT]\n> ## Review skipped\n> \n> Auto reviews are disabled on this repository. Please check the settings in the CodeRabbit UI or the `.coderabbit.yaml` file in this repository. To trigger a single review, invoke the `@coderabbitai review` command.'
+
+# --- AC-1: the regex classifies banners, not genuine reviews ------------------
+_cr_re_matches_1531() {
+  printf '%s' "$1" \
+    | jq -Rs --arg skip_re "$CODERABBIT_SKIP_BANNER_RE" \
+        'if test($skip_re; "i") then "yes" else "no" end' -r
+}
+
+run_test "cr_skip_banner_re_matches_auto_reviews_disabled" "yes" \
+  "$(_cr_re_matches_1531 "$_CR_SKIP_BANNER_1531")"
+
+# The "Review skipped" half must match on its own: CodeRabbit uses the same
+# heading for the drafts-excluded and base-branch-mismatch variants, whose
+# bodies never contain the "auto reviews are disabled" sentence.
+run_test "cr_skip_banner_re_matches_review_skipped_alone" "yes" \
+  "$(_cr_re_matches_1531 '## Review skipped
+
+Draft detected. Set `reviews.auto_review.drafts` to true to review draft PRs.')"
+
+# CONTROL: a genuine CodeRabbit walkthrough must NOT match, or the fix would
+# suppress real reviews and hang every loop until timeout.
+run_test "cr_skip_banner_re_ignores_genuine_walkthrough" "no" \
+  "$(_cr_re_matches_1531 '## Walkthrough
+
+The changes update the reviewer loop. Estimated code review effort: 3.')"
+
+# CONTROL: the word "skipped" in ordinary review prose must not match either.
+run_test "cr_skip_banner_re_ignores_prose_use_of_skipped" "no" \
+  "$(_cr_re_matches_1531 'Nitpick: this branch is skipped when the list is empty.')"
+
+# --- AC-1: the activity probe returns 0 for a banner-only comment set ---------
+# Mirrors the production jq expression in run_coderabbit_review so a future edit
+# that drops the $skip_re clause is caught here.
+_cr_activity_count_1531() {
+  printf '%s' "$1" \
+    | jq -s --arg bot "coderabbitai[bot]" --arg since "2020-01-01T00:00:00Z" \
+         --arg skip_re "$CODERABBIT_SKIP_BANNER_RE" '
+        [.[].[] | select(
+            .user.login == $bot and
+            .created_at > $since and
+            ((.body // "") | test("Reviews paused|review paused"; "i") | not) and
+            ((.body // "") | test("rate.?limit"; "i") | not) and
+            ((.body // "") | test("reviews resumed"; "i") | not) and
+            ((.body // "") | test($skip_re; "i") | not)
+        )] | length
+      '
+}
+
+run_test "cr_activity_probe_skip_banner_not_activity" "0" \
+  "$(_cr_activity_count_1531 "$(jq -cn --arg b "$_CR_SKIP_BANNER_1531" \
+       '[{user:{login:"coderabbitai[bot]"},created_at:"2020-01-01T00:00:01Z",body:$b}]')")"
+
+run_test "cr_activity_probe_genuine_review_is_activity" "1" \
+  "$(_cr_activity_count_1531 "$(jq -cn \
+       '[{user:{login:"coderabbitai[bot]"},created_at:"2020-01-01T00:00:01Z",body:"## Walkthrough\n\nLGTM."}]')")"
+
+# --- AC-2 / AC-3: end-to-end escalation instead of a clean verdict ------------
+_cr_mock_dir_1531="$(mktemp -d)"
+_cr_call_log_1531="$_cr_mock_dir_1531/calls.log"
+cat > "$_cr_mock_dir_1531/gh" <<'CR_GH_1531'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CR_CALL_LOG"
+case "$*" in
+  *"--jq .head.sha"*)
+    printf 'abc1531sha\n'; exit 0 ;;
+  *"--jq .commit.committer.date"*)
+    printf '2020-01-01T00:00:00Z\n'; exit 0 ;;
+  # An empty, successful thread audit. Without this the audit errors against the
+  # default "[]" and the run escalates as review_thread_audit_failed — which would
+  # make the RESULT=escalate assertion below pass for the wrong reason, and hide
+  # the fact that the unfixed code returns RESULT=clean here.
+  *"api graphql"*)
+    printf '%s\n' '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}'
+    exit 0 ;;
+  *"issues/42/comments"*)
+    printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2020-01-01T00:00:01Z","updated_at":"2020-01-01T00:00:01Z","body":"## Review skipped — Auto reviews are disabled on this repository."}]'
+    exit 0 ;;
+  *)
+    printf '[]\n'; exit 0 ;;
+esac
+CR_GH_1531
+chmod +x "$_cr_mock_dir_1531/gh"
+
+actual_output="$(
+  PATH="$_cr_mock_dir_1531:$PATH" CR_CALL_LOG="$_cr_call_log_1531" \
+    CODERABBIT_NO_TRIGGER_TIMEOUT=1 \
+    run_coderabbit_review "42" "fix/42-test" "1" "3" 2>/dev/null || true
+)"
+
+# The planted violation: before the fix this asserted RESULT=clean.
+run_test "cr_skip_banner_escalates_not_clean" "RESULT=escalate" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+
+# A distinct REASON from rate_limit_max_retries — the operator fix is a
+# .coderabbit.yaml change, not waiting out a vendor quota.
+run_test "cr_skip_banner_reason_is_review_skipped_banner" "REASON=review_skipped_banner" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+
+# AC-2: the loop must still have nudged CodeRabbit with an explicit trigger
+# before giving up, since "@coderabbitai review" works even when auto review is
+# disabled. Without the activity-probe fix the loop broke out immediately and
+# never reached the retrigger path.
+_cr_trigger_count_1531="$(grep_count_or_zero "pr comment 42 --body @coderabbitai review" "$_cr_call_log_1531")"
+run_test "cr_skip_banner_posts_explicit_review_trigger" "yes" \
+  "$([ "$_cr_trigger_count_1531" -ge 1 ] && echo yes || echo no)"
+
+# The nudge must stay bounded by CODERABBIT_RATE_LIMIT_MAX_RETRIES rather than
+# firing on every poll iteration — an unbounded nudge would spam the PR and burn
+# vendor quota on a PR CodeRabbit is configured never to review.
+run_test "cr_skip_banner_trigger_is_capped" "yes" \
+  "$([ "$_cr_trigger_count_1531" -le 4 ] && echo yes || echo no)"
+unset _cr_trigger_count_1531
+
+rm -rf "$_cr_mock_dir_1531"
+unset _cr_mock_dir_1531 _cr_call_log_1531 actual_output _CR_SKIP_BANNER_1531
+
+# --- AC-4: rate-limit tolerance spans an hourly vendor quota reset ------------
+# Asserted against the script source: the defaults are function-locals, so there
+# is no accessor to read them from, and the whole point of the change is that
+# the shipped numbers (not just the env overrides) are large enough.
+run_test "cr_rate_limit_default_retries_is_four" "1" \
+  "$(grep_count_or_zero 'CODERABBIT_RATE_LIMIT_MAX_RETRIES:-4' "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"
+run_test "cr_rate_limit_default_wait_is_900" "1" \
+  "$(grep_count_or_zero 'CODERABBIT_RATE_LIMIT_WAIT:-900' "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Closes #1531

## Problem

`run_coderabbit_review` treated **any** CodeRabbit issue comment posted after the HEAD commit as evidence that CodeRabbit had completed a review. Only three markers were excluded: `Reviews paused`, `rate limit`, and `reviews resumed`.

CodeRabbit has a fourth non-review banner:

> **Review skipped** — Auto reviews are disabled on this repository. […] To trigger a single review, invoke the `@coderabbitai review` command.

It posts this whenever it declines by **configuration** rather than by capacity: `auto_review.enabled: false`, `auto_review.drafts: false` on a draft PR, or an `auto_review.base_branches` list that omits the PR's base (e.g. only `develop` while the PR targets `develop-<slug>`).

That banner satisfied the activity check, so the poll loop broke into Phase 3, Phase 3 collected zero inline comments and zero `CHANGES_REQUESTED` reviews, and the loop returned **`RESULT=clean` for a PR CodeRabbit never looked at**. Same false-clean class as #1437 (rate-limited SUCCESS status) and the PR #650 pause-banner incident, each already fixed for its own banner shape.

This repository shipped `.coderabbit.yaml` with `auto_review.enabled: false`, so *every* PR received the banner — any run with `coderabbit` configured in a lifecycle bucket silently no-opped.

## Changes

- **`CODERABBIT_SKIP_BANNER_RE`** — new constant matching the banner.
- **Activity probe** excludes it, so the loop keeps polling and the existing silent-non-trigger path posts an explicit `@coderabbitai review` (which works even when auto review is disabled), bounded by `CODERABBIT_RATE_LIMIT_MAX_RETRIES`.
- **Timeout guard** escalates with `REASON=review_skipped_banner` if the banner is still standing when the poll window closes. Deliberately distinct from `rate_limit_max_retries`: the operator fix is a `.coderabbit.yaml` edit, not waiting out vendor quota.
- **Rate-limit defaults** raised from `2 x 180s` (~6 min) to `4 x 900s`. CodeRabbit's quota resets **hourly**, so the old defaults exhausted their retries ~54 minutes before the vendor could possibly answer, then escalated PRs with nothing wrong with them. Both env vars still override.
- **`.coderabbit.yaml`** opts this repository in: `auto_review.enabled: true`, `base_branches` covering `develop` and `develop-.*`, and `auto_pause_after_reviewed_commits` raised from `1` (which tripped the pause banner after *every* reviewer-loop fix commit) to `10`. This file is **not** in `sync-manifest.yaml`, so downstream projects created from this template keep their existing defaults.
- **Docs** — `integrations/coderabbit.md` gains the three misconfigurations that produce the banner, the new escalation reason, the `auto_pause_after_reviewed_commits` trap, and rate-limit sizing guidance.

## Verification

Full suite: **826 passed, 0 failed** (`scripts/development-workflow/tests/test-pr-review-loop.sh`).

Planted-violation check — the same end-to-end case run against the script with only the two behavioral changes reverted:

| Variant | RESULT | REASON | `@coderabbitai review` nudges |
| ------- | ------ | ------ | ----------------------------- |
| unfixed | `clean` | — | 0 |
| fixed   | `escalate` | `review_skipped_banner` | 4 (capped) |

The mock returns a successful, empty thread audit on purpose — without it the unfixed run escalates as `review_thread_audit_failed`, which would make the `RESULT=escalate` assertion pass for the wrong reason and hide the actual false-clean.

## Acceptance criteria

- [x] AC-1 — skip banner does not set `coderabbit_any_activity`
- [x] AC-2 — loop posts `@coderabbitai review` via the silent-non-trigger path
- [x] AC-3 — banner at timeout yields `RESULT=escalate`, never clean or `no_review`
- [x] AC-4 — default rate-limit tolerance spans an hourly quota reset; env overrides intact
- [x] AC-5 — regression tests cover AC-1..AC-3 (plus a cap assertion on the nudge)
- [x] AC-6 — integration doc updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of skipped automated code reviews with explicit nudges and escalation.
  * Prevented skipped-review notices from being treated as completed reviews.
  * Increased rate-limit retry capacity for more reliable review processing.

* **Documentation**
  * Expanded guidance for review behavior, supported branches, skipped reviews, and rate limits.

* **Tests**
  * Added coverage for skipped-review detection, escalation, retry limits, and tooling compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->