### PR TITLE
fix(post-merge-cleanup): derive team-prefixed issue IDs from PR body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **`post-merge-cleanup.sh` no longer closes the wrong issue for team-prefixed
+  branch slugs** (#1511): the team-prefixed identifier pattern
+  (`^(fix|feature|hotfix|refactor)/([a-zA-Z]{2,6}-([0-9]+))($|-)`) matches any
+  slug beginning with 2-6 letters followed by `-<digits>` — including ordinary
+  descriptive fragments with no relation to an issue number
+  (`fix/retro-517-doc-gaps`, `fix/http-500-retry`, `feature/sha-256-hashing`).
+  A downstream consumer observed the script silently update and close an
+  unrelated issue derived from such a slug. The merged PR body/title is now
+  checked first for GitHub closing keywords (`Closes #N`, `Fixes #N`,
+  `Resolves #N`, etc.) whenever the branch slug's identifier is
+  team-prefixed, and that reference is treated as authoritative when present
+  — including when the PR closes more than one issue. The slug-derived
+  identifier is only used as a fallback when the PR body carries no closing
+  reference at all, preserving existing behavior for legitimate team-prefixed
+  slugs (`fix/lh-97-real-issue`) merged without an explicit closing keyword.
+  Plain numeric identifiers (`fix/42-slug`) are unambiguous and are unaffected.
 - **CodeRabbit "Review skipped" banner no longer reports an unreviewed PR as
   clean** (#1531): `run_coderabbit_review` in
   `scripts/development-workflow/pr-review-loop.sh` counted any CodeRabbit issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference at all, preserving existing behavior for legitimate team-prefixed
   slugs (`fix/lh-97-real-issue`) merged without an explicit closing keyword.
   Plain numeric identifiers (`fix/42-slug`) are unambiguous and are unaffected.
+  The closing-keyword matcher also now requires only a non-word boundary
+  (rather than specifically whitespace) before the keyword, so
+  punctuation-delimited references like `(Fixes #601)` are recognized, and it
+  strips fenced code blocks before matching so an example `Closes #999` in a
+  code sample within the PR body is not mistaken for a live reference —
+  mirroring `graduation-closeout-from-merged-pr.sh`'s existing
+  `extract_closing_issue_numbers` / `strip_fenced_blocks` behavior.
 - **CodeRabbit "Review skipped" banner no longer reports an unreviewed PR as
   clean** (#1531): `run_coderabbit_review` in
   `scripts/development-workflow/pr-review-loop.sh` counted any CodeRabbit issue

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -502,16 +502,31 @@ fi
 # --- Update tracker status and close associated GitHub issue (if any) ---
 
 # strip_fenced_pr_body_blocks
-# Removes fenced code blocks (```...```) from stdin before it is scanned for
-# closing keywords, so an example like "Closes #999" inside a code sample in
-# the PR body is not treated as a live closing reference. Mirrors
-# graduation-closeout-from-merged-pr.sh's strip_fenced_blocks().
+# Removes fenced code blocks from stdin before it is scanned for closing
+# keywords, so an example like "Closes #999" inside a code sample in the PR
+# body is not treated as a live closing reference. Handles both backtick
+# (```) and tilde (~~~) fence styles, and treats an unclosed opening fence as
+# extending to end of input (rather than leaving the rest of the body
+# unfiltered). A closing fence must use the same character as the opening
+# fence it closes, matching GitHub-Flavored Markdown's fence-matching rule.
 strip_fenced_pr_body_blocks() {
   python3 -c '
 import re, sys
-text = sys.stdin.read()
-text = re.sub(r"```.*?```", "", text, flags=re.S)
-sys.stdout.write(text)
+lines = sys.stdin.read().split("\n")
+out = []
+fence_char = None
+for line in lines:
+    match = re.match(r"^(`{3,}|~{3,})", line.strip())
+    if fence_char is None:
+        if match:
+            fence_char = match.group(1)[0]
+            continue
+        out.append(line)
+    else:
+        if match and match.group(1)[0] == fence_char:
+            fence_char = None
+        continue
+sys.stdout.write("\n".join(out))
 '
 }
 
@@ -528,18 +543,25 @@ sys.stdout.write(text)
 # graduation-closeout-from-merged-pr.sh's extract_closing_issue_numbers().
 # Echoes sorted, deduped issue numbers (one per line, possibly empty).
 # Returns 2 if the arguments are missing/invalid, or 1 (without echoing
-# anything) if the PR body could not be fetched (gh command failure); the
-# caller decides whether either failure is fatal.
+# anything) if the PR body could not be fetched or fence-stripping failed
+# (e.g. python3 missing/erroring) — the caller decides whether either failure
+# is fatal. A failed fence-strip is deliberately distinguished from "no
+# closing keywords found" (which returns 0 with empty output) so a parser
+# failure can never be silently treated as "nothing to close".
 fetch_pr_closing_issues() {
   local pr_repo="$1"
   local pr_number="$2"
-  local pr_body
+  local pr_body stripped_pr_body
   if [ "$#" -ne 2 ] || [ -z "$pr_repo" ] || [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
     echo "ERROR: fetch_pr_closing_issues requires <pr_repo> <pr_number>." >&2
     return 2
   fi
   pr_body="$(gh pr view "$pr_number" --repo "$pr_repo" --json body,title --jq '(.title // "") + "\n" + (.body // "")' 2>/dev/null)" || return 1
-  printf '%s' "$pr_body" | strip_fenced_pr_body_blocks | grep -ioE '(^|[^[:alnum:]_])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+' | grep -oE '[0-9]+$' | sort -un || true
+  if ! stripped_pr_body="$(printf '%s' "$pr_body" | strip_fenced_pr_body_blocks)"; then
+    echo "ERROR: could not strip fenced code blocks from PR #${pr_number}." >&2
+    return 1
+  fi
+  printf '%s' "$stripped_pr_body" | grep -ioE '(^|[^[:alnum:]_])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+' | grep -oE '[0-9]+$' | sort -un || true
   return 0
 }
 

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -501,20 +501,45 @@ fi
 
 # --- Update tracker status and close associated GitHub issue (if any) ---
 
+# strip_fenced_pr_body_blocks
+# Removes fenced code blocks (```...```) from stdin before it is scanned for
+# closing keywords, so an example like "Closes #999" inside a code sample in
+# the PR body is not treated as a live closing reference. Mirrors
+# graduation-closeout-from-merged-pr.sh's strip_fenced_blocks().
+strip_fenced_pr_body_blocks() {
+  python3 -c '
+import re, sys
+text = sys.stdin.read()
+text = re.sub(r"```.*?```", "", text, flags=re.S)
+sys.stdout.write(text)
+'
+}
+
 # fetch_pr_closing_issues <pr_repo> <pr_number>
-# Fetches PR title+body and extracts GitHub closing-keyword issue references
-# (Close/Closes/Closed, Fix/Fixes/Fixed, Resolve/Resolves/Resolved — optionally
-# followed by "issue" — then #NNN). Requires a word boundary before the
-# keyword so substrings like "disclose" or "hotfix" are not treated as closing
-# keywords. Echoes sorted, deduped issue numbers (one per line, possibly
-# empty). Returns 1 (without echoing anything) if the PR body could not be
-# fetched (gh command failure); the caller decides whether that is fatal.
+# Fetches PR title+body, strips fenced code blocks (so example closing
+# keywords in a code sample are not treated as live references — see
+# strip_fenced_pr_body_blocks above), and extracts GitHub closing-keyword
+# issue references (Close/Closes/Closed, Fix/Fixes/Fixed,
+# Resolve/Resolves/Resolved — optionally followed by "issue" — then #NNN).
+# Requires a non-word-boundary immediately before the keyword (start of
+# string, or any character that is not alphanumeric/underscore) so substrings
+# like "disclose" or "hotfix" are not treated as closing keywords, while
+# still matching punctuation-delimited forms like "(Fixes #601)". Mirrors
+# graduation-closeout-from-merged-pr.sh's extract_closing_issue_numbers().
+# Echoes sorted, deduped issue numbers (one per line, possibly empty).
+# Returns 2 if the arguments are missing/invalid, or 1 (without echoing
+# anything) if the PR body could not be fetched (gh command failure); the
+# caller decides whether either failure is fatal.
 fetch_pr_closing_issues() {
   local pr_repo="$1"
   local pr_number="$2"
   local pr_body
+  if [ "$#" -ne 2 ] || [ -z "$pr_repo" ] || [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: fetch_pr_closing_issues requires <pr_repo> <pr_number>." >&2
+    return 2
+  fi
   pr_body="$(gh pr view "$pr_number" --repo "$pr_repo" --json body,title --jq '(.title // "") + "\n" + (.body // "")' 2>/dev/null)" || return 1
-  printf '%s' "$pr_body" | grep -ioE '(^|[[:space:]])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+' | grep -oE '[0-9]+$' | sort -un || true
+  printf '%s' "$pr_body" | strip_fenced_pr_body_blocks | grep -ioE '(^|[^[:alnum:]_])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+' | grep -oE '[0-9]+$' | sort -un || true
   return 0
 }
 
@@ -529,11 +554,17 @@ fetch_pr_closing_issues() {
 # the aggregate fatal-on-view-failure behavior this replaces at both call
 # sites. This is distinct from a `gh issue close` failure, which remains a
 # warning-only, non-fatal condition (cleanup continues for the remaining
-# issues in the list either way).
+# issues in the list either way). The issue-numbers list may be empty (a
+# no-op loop), but <pr_number> must be a non-empty numeric PR number so an
+# invalid caller cannot produce a close comment like "Closed by PR #.".
 close_issues_from_pr() {
   local pr_number="$1"
   local issue_list="$2"
   local issue_num issue_state view_failures=0
+  if [ "$#" -ne 2 ] || [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: close_issues_from_pr requires <pr_number> (numeric) <issue_numbers_newline_list>." >&2
+    return 2
+  fi
   while IFS= read -r issue_num; do
     [ -z "$issue_num" ] && continue
     echo "Processing issue #${issue_num} from PR #${pr_number} closing keywords..."

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -512,7 +512,11 @@ fi
 # least as long, and have nothing but trailing whitespace after the fence
 # marker — a shorter, differently-charactered, or content-suffixed line
 # (e.g. a nested example fence, or "``` end of block") is treated as still
-# being inside the fence rather than closing it.
+# being inside the fence rather than closing it. A fence delimiter may be
+# indented up to 3 spaces per GFM; 4+ spaces of leading whitespace makes it
+# indented code instead, so the raw line (not a fully whitespace-stripped
+# line) is matched to preserve that boundary — otherwise a 4-space-indented
+# "```" could be mistaken for a real fence and hide a live closing reference.
 strip_fenced_pr_body_blocks() {
   python3 -c '
 import re, sys
@@ -520,8 +524,9 @@ lines = sys.stdin.read().split("\n")
 out = []
 fence_char = None
 fence_len = 0
+fence_re = re.compile(r"^ {0,3}(`{3,}|~{3,})(.*)$")
 for line in lines:
-    match = re.match(r"^(`{3,}|~{3,})(.*)$", line.strip())
+    match = fence_re.match(line)
     if fence_char is None:
         if match:
             fence_char = match.group(1)[0]
@@ -553,17 +558,23 @@ sys.stdout.write("\n".join(out))
 # Echoes sorted, deduped issue numbers (one per line, possibly empty).
 # Returns 2 if the arguments are missing/invalid, or 1 (without echoing
 # anything) if the PR body could not be fetched, fence-stripping failed (e.g.
-# python3 missing/erroring), or the keyword-extraction pipeline itself failed
-# — the caller decides whether either failure is fatal. Every failure mode is
-# deliberately distinguished from "no closing keywords found" (which returns
-# 0 with empty output) so a parser or pipeline failure can never be silently
-# treated as "nothing to close". A `grep` exit status of 1 means "no match"
+# python3 missing/erroring), or the keyword-extraction stages themselves
+# failed — the caller decides whether either failure is fatal. Every failure
+# mode is deliberately distinguished from "no closing keywords found" (which
+# returns 0 with empty output) so a failure can never be silently treated as
+# "nothing to close". Each `grep` stage is run separately (not piped
+# together) and its own exit status captured directly: under `pipefail`, a
+# 2-stage `grep1 | grep2` pipeline reports only the *rightmost* non-zero
+# exit, so a real error in the first grep (exit 2+) can be masked by the
+# second grep's ordinary "no match" (exit 1) on its now-empty input, and
+# would otherwise be misread as "nothing to close" rather than propagated.
+# A `grep` exit status of 1 means "no match" for that stage specifically
 # (not a failure, per grep's own exit-code contract) and is not an error;
 # anything else (grep exit >1, or `sort` failing) is.
 fetch_pr_closing_issues() {
   local pr_repo="$1"
   local pr_number="$2"
-  local pr_body stripped_pr_body matched_refs grep_status
+  local pr_body stripped_pr_body keyword_lines matched_refs stage_status
   if [ "$#" -ne 2 ] || [ -z "$pr_repo" ] || [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
     echo "ERROR: fetch_pr_closing_issues requires <pr_repo> <pr_number>." >&2
     return 2
@@ -574,14 +585,25 @@ fetch_pr_closing_issues() {
     return 1
   fi
   set +e
-  matched_refs="$(printf '%s' "$stripped_pr_body" | grep -ioE '(^|[^[:alnum:]_])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+' | grep -oE '[0-9]+$')"
-  grep_status=$?
+  keyword_lines="$(printf '%s' "$stripped_pr_body" | grep -ioE '(^|[^[:alnum:]_])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+')"
+  stage_status=$?
   set -e
-  if [ "$grep_status" -gt 1 ]; then
-    echo "ERROR: failed to extract closing-keyword references from PR #${pr_number} (grep exit ${grep_status})." >&2
+  if [ "$stage_status" -gt 1 ]; then
+    echo "ERROR: failed to scan PR #${pr_number} body for closing keywords (grep exit ${stage_status})." >&2
     return 1
   fi
-  if [ -z "$matched_refs" ]; then
+  if [ "$stage_status" -eq 1 ] || [ -z "$keyword_lines" ]; then
+    return 0
+  fi
+  set +e
+  matched_refs="$(printf '%s' "$keyword_lines" | grep -oE '[0-9]+$')"
+  stage_status=$?
+  set -e
+  if [ "$stage_status" -gt 1 ]; then
+    echo "ERROR: failed to extract issue numbers from PR #${pr_number} closing-keyword matches (grep exit ${stage_status})." >&2
+    return 1
+  fi
+  if [ "$stage_status" -eq 1 ] || [ -z "$matched_refs" ]; then
     return 0
   fi
   if ! printf '%s\n' "$matched_refs" | sort -un; then

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -523,9 +523,13 @@ fetch_pr_closing_issues() {
 # closes the issue if it is still open (commenting with the closing PR
 # number), and reasserts Merged status after close. A `gh issue view` failure
 # for a given issue is counted and reported but does not stop processing of
-# the remaining issues in the list; the caller should treat a nonzero return
-# as fatal (matching the existing single-issue close-failure handling
-# elsewhere in this script, which is a warning-only, non-fatal condition).
+# the remaining issues in the list; once all issues have been processed, a
+# nonzero view-failure count makes this function return 1, and the caller
+# must treat that as fatal (`close_issues_from_pr ... || exit 1`), matching
+# the aggregate fatal-on-view-failure behavior this replaces at both call
+# sites. This is distinct from a `gh issue close` failure, which remains a
+# warning-only, non-fatal condition (cleanup continues for the remaining
+# issues in the list either way).
 close_issues_from_pr() {
   local pr_number="$1"
   local issue_list="$2"

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -507,24 +507,33 @@ fi
 # body is not treated as a live closing reference. Handles both backtick
 # (```) and tilde (~~~) fence styles, and treats an unclosed opening fence as
 # extending to end of input (rather than leaving the rest of the body
-# unfiltered). A closing fence must use the same character as the opening
-# fence it closes, matching GitHub-Flavored Markdown's fence-matching rule.
+# unfiltered). Matches GitHub-Flavored Markdown's fence-matching rule: a
+# closing fence must use the same character as the opening fence, be at
+# least as long, and have nothing but trailing whitespace after the fence
+# marker — a shorter, differently-charactered, or content-suffixed line
+# (e.g. a nested example fence, or "``` end of block") is treated as still
+# being inside the fence rather than closing it.
 strip_fenced_pr_body_blocks() {
   python3 -c '
 import re, sys
 lines = sys.stdin.read().split("\n")
 out = []
 fence_char = None
+fence_len = 0
 for line in lines:
-    match = re.match(r"^(`{3,}|~{3,})", line.strip())
+    match = re.match(r"^(`{3,}|~{3,})(.*)$", line.strip())
     if fence_char is None:
         if match:
             fence_char = match.group(1)[0]
+            fence_len = len(match.group(1))
             continue
         out.append(line)
     else:
-        if match and match.group(1)[0] == fence_char:
+        if (match and match.group(1)[0] == fence_char
+                and len(match.group(1)) >= fence_len
+                and match.group(2).strip() == ""):
             fence_char = None
+            fence_len = 0
         continue
 sys.stdout.write("\n".join(out))
 '
@@ -543,15 +552,18 @@ sys.stdout.write("\n".join(out))
 # graduation-closeout-from-merged-pr.sh's extract_closing_issue_numbers().
 # Echoes sorted, deduped issue numbers (one per line, possibly empty).
 # Returns 2 if the arguments are missing/invalid, or 1 (without echoing
-# anything) if the PR body could not be fetched or fence-stripping failed
-# (e.g. python3 missing/erroring) — the caller decides whether either failure
-# is fatal. A failed fence-strip is deliberately distinguished from "no
-# closing keywords found" (which returns 0 with empty output) so a parser
-# failure can never be silently treated as "nothing to close".
+# anything) if the PR body could not be fetched, fence-stripping failed (e.g.
+# python3 missing/erroring), or the keyword-extraction pipeline itself failed
+# — the caller decides whether either failure is fatal. Every failure mode is
+# deliberately distinguished from "no closing keywords found" (which returns
+# 0 with empty output) so a parser or pipeline failure can never be silently
+# treated as "nothing to close". A `grep` exit status of 1 means "no match"
+# (not a failure, per grep's own exit-code contract) and is not an error;
+# anything else (grep exit >1, or `sort` failing) is.
 fetch_pr_closing_issues() {
   local pr_repo="$1"
   local pr_number="$2"
-  local pr_body stripped_pr_body
+  local pr_body stripped_pr_body matched_refs grep_status
   if [ "$#" -ne 2 ] || [ -z "$pr_repo" ] || [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
     echo "ERROR: fetch_pr_closing_issues requires <pr_repo> <pr_number>." >&2
     return 2
@@ -561,7 +573,21 @@ fetch_pr_closing_issues() {
     echo "ERROR: could not strip fenced code blocks from PR #${pr_number}." >&2
     return 1
   fi
-  printf '%s' "$stripped_pr_body" | grep -ioE '(^|[^[:alnum:]_])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+' | grep -oE '[0-9]+$' | sort -un || true
+  set +e
+  matched_refs="$(printf '%s' "$stripped_pr_body" | grep -ioE '(^|[^[:alnum:]_])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+' | grep -oE '[0-9]+$')"
+  grep_status=$?
+  set -e
+  if [ "$grep_status" -gt 1 ]; then
+    echo "ERROR: failed to extract closing-keyword references from PR #${pr_number} (grep exit ${grep_status})." >&2
+    return 1
+  fi
+  if [ -z "$matched_refs" ]; then
+    return 0
+  fi
+  if ! printf '%s\n' "$matched_refs" | sort -un; then
+    echo "ERROR: failed to sort extracted closing-keyword issue numbers from PR #${pr_number}." >&2
+    return 1
+  fi
   return 0
 }
 

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -14,11 +14,18 @@
 # Uses `git branch -D` (force delete) because squash/rebase merges (e.g. GitHub
 # default) do not have the branch tip in develop's history, so -d would fail.
 #
-# Issue close: if an issue number is embedded in the branch name it is closed
-# directly. When the branch slug contains no issue number (e.g. epic-slug
-# branches like feature/model-cost-resilience), the merged PR body/title is
-# parsed for GitHub closing keywords (Closes #N, Fixes #N, Resolves #N, etc.)
-# and each referenced issue is closed and its tracker status updated to Merged.
+# Issue close: if a plain numeric issue number is embedded in the branch name
+# (e.g. fix/42-slug) it is closed directly. Team-prefixed identifiers (e.g.
+# fix/lh-97-slug) are ambiguous with descriptive slug fragments that happen to
+# contain a number (fix/retro-517-doc-gaps, fix/http-500-retry) — for those,
+# the merged PR body/title is checked first for GitHub closing keywords
+# (Closes #N, Fixes #N, Resolves #N, etc.) and, when present, that reference
+# is authoritative; the slug-derived identifier is only used as a fallback
+# when the PR body carries no closing reference. When the branch slug
+# contains no issue number at all (e.g. epic-slug branches like
+# feature/model-cost-resilience), the merged PR body/title is parsed the same
+# way, and each referenced issue is closed and its tracker status updated to
+# Merged.
 #
 
 set -euo pipefail
@@ -494,6 +501,63 @@ fi
 
 # --- Update tracker status and close associated GitHub issue (if any) ---
 
+# fetch_pr_closing_issues <pr_repo> <pr_number>
+# Fetches PR title+body and extracts GitHub closing-keyword issue references
+# (Close/Closes/Closed, Fix/Fixes/Fixed, Resolve/Resolves/Resolved — optionally
+# followed by "issue" — then #NNN). Requires a word boundary before the
+# keyword so substrings like "disclose" or "hotfix" are not treated as closing
+# keywords. Echoes sorted, deduped issue numbers (one per line, possibly
+# empty). Returns 1 (without echoing anything) if the PR body could not be
+# fetched (gh command failure); the caller decides whether that is fatal.
+fetch_pr_closing_issues() {
+  local pr_repo="$1"
+  local pr_number="$2"
+  local pr_body
+  pr_body="$(gh pr view "$pr_number" --repo "$pr_repo" --json body,title --jq '(.title // "") + "\n" + (.body // "")' 2>/dev/null)" || return 1
+  printf '%s' "$pr_body" | grep -ioE '(^|[[:space:]])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+' | grep -oE '[0-9]+$' | sort -un || true
+  return 0
+}
+
+# close_issues_from_pr <pr_number> <issue_numbers_newline_list>
+# For each issue number in the list, updates the tracker status to Merged,
+# closes the issue if it is still open (commenting with the closing PR
+# number), and reasserts Merged status after close. A `gh issue view` failure
+# for a given issue is counted and reported but does not stop processing of
+# the remaining issues in the list; the caller should treat a nonzero return
+# as fatal (matching the existing single-issue close-failure handling
+# elsewhere in this script, which is a warning-only, non-fatal condition).
+close_issues_from_pr() {
+  local pr_number="$1"
+  local issue_list="$2"
+  local issue_num issue_state view_failures=0
+  while IFS= read -r issue_num; do
+    [ -z "$issue_num" ] && continue
+    echo "Processing issue #${issue_num} from PR #${pr_number} closing keywords..."
+    if ! issue_state="$(gh issue view "$issue_num" --json state --jq '.state' 2>/dev/null)"; then
+      echo "Warning: could not query issue #${issue_num}; skipping close and tracker update for this ref." >&2
+      view_failures=$((view_failures + 1))
+      continue
+    fi
+    update_tracker_status_best_effort "$issue_num" "Merged"
+    if [ "$issue_state" = "OPEN" ]; then
+      echo "Closing issue #${issue_num}..."
+      if gh issue close "$issue_num" --comment "Closed by PR #${pr_number}."; then
+        echo "Reasserting issue #${issue_num} tracker status as Merged after close..."
+        update_tracker_status_best_effort "$issue_num" "Merged" "" "allow-backward"
+      else
+        echo "Warning: could not close issue #${issue_num}; continuing cleanup." >&2
+      fi
+    else
+      echo "Issue #${issue_num} is already ${issue_state}, skipping close."
+    fi
+  done <<< "$issue_list"
+  if [ "$view_failures" -gt 0 ]; then
+    echo "ERROR: could not query ${view_failures} issue(s) from PR #${pr_number} closing refs (gh command failed)." >&2
+    return 1
+  fi
+  return 0
+}
+
 # Unified issue-number extraction: covers all branch prefixes in a single pass.
 # Sets ISSUE_NUMBER, ISSUE_IDENTIFIER, ISSUE_ID_TYPE, and BRANCH_TYPE.
 # ISSUE_IDENTIFIER holds the full extracted identifier (e.g. "42", "lh-97").
@@ -558,51 +622,90 @@ if [ -n "$ISSUE_IDENTIFIER" ]; then
   fi
 
   if [ "$BRANCH_TYPE" = "implementation" ]; then
-    # Update the tracker status BEFORE closing the issue so that
-    # gh project item-list can still find the item (it only returns items
-    # whose linked issue is open; once closed the lookup silently fails).
-    update_tracker_status_best_effort "$ISSUE_NUMBER" "Merged"
-    # Close the issue when an implementation branch (feature/fix/hotfix/refactor) is merged.
-    if ! ISSUE_STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state'); then
-      echo "ERROR: could not query issue #$ISSUE_NUMBER (gh command failed)." >&2
-      exit 1
-    fi
-    if [ "$ISSUE_STATE" = "OPEN" ]; then
-      # Find the merged PR for this branch.
-      merged_pr_repo="$TARGET_GITHUB_REPO"
-      if [ -z "$merged_pr_repo" ]; then
-        if ! merged_pr_repo="$(repo_slug)"; then
-          echo "ERROR: could not resolve GitHub repository for merged PR lookup." >&2
+    # Team-prefixed identifiers are ambiguous by construction: a 2-6 letter
+    # prefix followed by "-<digits>" matches both real team-prefixed issue
+    # IDs (lh-97) and ordinary descriptive slug fragments that happen to
+    # contain a number (retro-517, http-500, sha-256, utf-8, base-64). The
+    # merged PR body is authoritative when it carries GitHub closing
+    # keywords; only fall back to the slug-derived identifier below when the
+    # PR body has no closing reference at all (e.g. no PR could be resolved,
+    # or the PR genuinely does not close an issue).
+    PR_OVERRIDE_ISSUES=""
+    PR_FOR_OVERRIDE=""
+    if [ "$ISSUE_ID_TYPE" = "team-prefixed" ]; then
+      pr_override_repo="$TARGET_GITHUB_REPO"
+      if [ -z "$pr_override_repo" ]; then
+        if ! pr_override_repo="$(repo_slug 2>/dev/null)"; then
+          echo "ERROR: could not resolve GitHub repository for PR-body issue verification." >&2
           exit 1
         fi
       fi
-      if [ -n "$merged_pr_number" ]; then
-        MERGED_PR="$merged_pr_number"
-      else
-        MERGED_PR="$(gh pr list --repo "$merged_pr_repo" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty')" || {
-          echo "ERROR: could not query merged PRs for branch '$TO_DELETE' in '$merged_pr_repo' (gh command failed)." >&2
+      PR_FOR_OVERRIDE="${VERIFIED_MERGED_PR:-}"
+      [ -n "$PR_FOR_OVERRIDE" ] || PR_FOR_OVERRIDE="$merged_pr_number"
+      if [ -z "$PR_FOR_OVERRIDE" ]; then
+        PR_FOR_OVERRIDE="$(gh pr list --repo "$pr_override_repo" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty')" || {
+          echo "ERROR: could not query merged PRs for branch '$TO_DELETE' in '$pr_override_repo' (gh command failed)." >&2
           exit 1
         }
       fi
-      if [ -n "$MERGED_PR" ]; then
-        CLOSE_COMMENT="Closed by PR #${MERGED_PR}."
-      elif [ -n "$VERIFIED_MERGED_PR" ]; then
-        MERGED_PR="$VERIFIED_MERGED_PR"
-        CLOSE_COMMENT="Closed by PR #${MERGED_PR}."
+      if [ -n "$PR_FOR_OVERRIDE" ]; then
+        PR_OVERRIDE_ISSUES="$(fetch_pr_closing_issues "$pr_override_repo" "$PR_FOR_OVERRIDE")" || {
+          echo "ERROR: could not fetch PR #${PR_FOR_OVERRIDE} body from '$pr_override_repo' (gh command failed)." >&2
+          exit 1
+        }
       fi
-      if [ -n "$MERGED_PR" ]; then
-        echo "Closing issue #$ISSUE_NUMBER..."
-        if gh issue close "$ISSUE_NUMBER" --comment "$CLOSE_COMMENT"; then
-          echo "Reasserting issue #$ISSUE_NUMBER tracker status as Merged after close..."
-          update_tracker_status_best_effort "$ISSUE_NUMBER" "Merged" "" "allow-backward"
+    fi
+
+    if [ -n "$PR_OVERRIDE_ISSUES" ]; then
+      echo "Team-prefixed identifier '$ISSUE_IDENTIFIER' in branch '$TO_DELETE' is ambiguous; using closing keyword refs from PR #${PR_FOR_OVERRIDE} instead: $(printf '%s' "$PR_OVERRIDE_ISSUES" | tr '\n' ' ')"
+      close_issues_from_pr "$PR_FOR_OVERRIDE" "$PR_OVERRIDE_ISSUES" || exit 1
+    else
+      # Update the tracker status BEFORE closing the issue so that
+      # gh project item-list can still find the item (it only returns items
+      # whose linked issue is open; once closed the lookup silently fails).
+      update_tracker_status_best_effort "$ISSUE_NUMBER" "Merged"
+      # Close the issue when an implementation branch (feature/fix/hotfix/refactor) is merged.
+      if ! ISSUE_STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state'); then
+        echo "ERROR: could not query issue #$ISSUE_NUMBER (gh command failed)." >&2
+        exit 1
+      fi
+      if [ "$ISSUE_STATE" = "OPEN" ]; then
+        # Find the merged PR for this branch.
+        merged_pr_repo="$TARGET_GITHUB_REPO"
+        if [ -z "$merged_pr_repo" ]; then
+          if ! merged_pr_repo="$(repo_slug)"; then
+            echo "ERROR: could not resolve GitHub repository for merged PR lookup." >&2
+            exit 1
+          fi
+        fi
+        if [ -n "$merged_pr_number" ]; then
+          MERGED_PR="$merged_pr_number"
         else
-          echo "Warning: could not close issue #$ISSUE_NUMBER; continuing cleanup." >&2
+          MERGED_PR="$(gh pr list --repo "$merged_pr_repo" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty')" || {
+            echo "ERROR: could not query merged PRs for branch '$TO_DELETE' in '$merged_pr_repo' (gh command failed)." >&2
+            exit 1
+          }
+        fi
+        if [ -n "$MERGED_PR" ]; then
+          CLOSE_COMMENT="Closed by PR #${MERGED_PR}."
+        elif [ -n "$VERIFIED_MERGED_PR" ]; then
+          MERGED_PR="$VERIFIED_MERGED_PR"
+          CLOSE_COMMENT="Closed by PR #${MERGED_PR}."
+        fi
+        if [ -n "$MERGED_PR" ]; then
+          echo "Closing issue #$ISSUE_NUMBER..."
+          if gh issue close "$ISSUE_NUMBER" --comment "$CLOSE_COMMENT"; then
+            echo "Reasserting issue #$ISSUE_NUMBER tracker status as Merged after close..."
+            update_tracker_status_best_effort "$ISSUE_NUMBER" "Merged" "" "allow-backward"
+          else
+            echo "Warning: could not close issue #$ISSUE_NUMBER; continuing cleanup." >&2
+          fi
+        else
+          echo "No merged PR found for branch '$TO_DELETE'; leaving issue #$ISSUE_NUMBER open."
         fi
       else
-        echo "No merged PR found for branch '$TO_DELETE'; leaving issue #$ISSUE_NUMBER open."
+        echo "Issue #$ISSUE_NUMBER is already $ISSUE_STATE, skipping close."
       fi
-    else
-      echo "Issue #$ISSUE_NUMBER is already $ISSUE_STATE, skipping close."
     fi
   elif [ "$BRANCH_TYPE" = "spec" ]; then
     # spec/* branches reference the issue but must not close it — the issue stays
@@ -638,44 +741,14 @@ else
         fi
       fi
       if [ -n "$CLOSING_PR" ]; then
-        if ! PR_BODY="$(gh pr view "$CLOSING_PR" --repo "$pr_closes_repo" --json body,title --jq '(.title // "") + "\n" + (.body // "")' 2>/dev/null)"; then
+        if ! CLOSES_ISSUES="$(fetch_pr_closing_issues "$pr_closes_repo" "$CLOSING_PR")"; then
           echo "ERROR: could not fetch PR #${CLOSING_PR} body from '$pr_closes_repo' (gh command failed)." >&2
           exit 1
         fi
-        # GitHub closing keywords (case-insensitive): close/closes/closed, fix/fixes/fixed,
-        # resolve/resolves/resolved — optionally followed by "issue" — then #NNN.
-        # Require a word boundary before the keyword so substrings like "disclose" or
-        # "hotfix" are not treated as closing keywords.
-        CLOSES_ISSUES="$(printf '%s' "$PR_BODY" | grep -ioE '(^|[[:space:]])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+' | grep -oE '[0-9]+$' | sort -un || true)"
         if [ -n "$CLOSES_ISSUES" ]; then
           echo "Found closing keyword refs in PR #${CLOSING_PR}: issues $(printf '%s' "$CLOSES_ISSUES" | tr '\n' ' ')"
           cd "$HUB_REPO_ROOT"
-          CLOSES_ISSUE_VIEW_FAILURES=0
-          while IFS= read -r closes_issue_num; do
-            [ -z "$closes_issue_num" ] && continue
-            echo "Processing issue #${closes_issue_num} from PR #${CLOSING_PR} closing keywords..."
-            if ! CLOSES_ISSUE_STATE="$(gh issue view "$closes_issue_num" --json state --jq '.state' 2>/dev/null)"; then
-              echo "Warning: could not query issue #${closes_issue_num}; skipping close and tracker update for this ref." >&2
-              CLOSES_ISSUE_VIEW_FAILURES=$((CLOSES_ISSUE_VIEW_FAILURES + 1))
-              continue
-            fi
-            update_tracker_status_best_effort "$closes_issue_num" "Merged"
-            if [ "$CLOSES_ISSUE_STATE" = "OPEN" ]; then
-              echo "Closing issue #${closes_issue_num}..."
-              if gh issue close "$closes_issue_num" --comment "Closed by PR #${CLOSING_PR}."; then
-                echo "Reasserting issue #${closes_issue_num} tracker status as Merged after close..."
-                update_tracker_status_best_effort "$closes_issue_num" "Merged" "" "allow-backward"
-              else
-                echo "Warning: could not close issue #${closes_issue_num}; continuing cleanup." >&2
-              fi
-            else
-              echo "Issue #${closes_issue_num} is already ${CLOSES_ISSUE_STATE}, skipping close."
-            fi
-          done <<< "$CLOSES_ISSUES"
-          if [ "$CLOSES_ISSUE_VIEW_FAILURES" -gt 0 ]; then
-            echo "ERROR: could not query ${CLOSES_ISSUE_VIEW_FAILURES} issue(s) from PR #${CLOSING_PR} closing refs (gh command failed)." >&2
-            exit 1
-          fi
+          close_issues_from_pr "$CLOSING_PR" "$CLOSES_ISSUES" || exit 1
         else
           echo "No issue number in branch name '$TO_DELETE' or PR #${CLOSING_PR} body; skipping issue close and tracker update."
         fi

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -479,6 +479,72 @@ run_test \
     fi
   )"
 
+# Punctuation-delimited closing keyword (e.g. "(Fixes #601)") must still be
+# recognized — the word-boundary regex requires a non-alnum/underscore
+# character immediately before the keyword, not specifically whitespace, so
+# a parenthesis directly abutting the keyword still matches.
+punctuation_branch="fix/retro-518-doc-gaps"
+punctuation_repo="$(make_repo punctuation "$punctuation_branch" yes)"
+punctuation_output="$(
+  GH_MERGED_HEAD="$punctuation_branch" \
+  GH_MERGED_PR=651 \
+  GH_PR_BODY="Cleans up doc gaps. (Fixes #602)" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$punctuation_repo" --base develop --pr 651 "$punctuation_branch"
+)"
+run_contains \
+  "punctuation_delimited_keyword_uses_pr_body_issue" \
+  "Closing issue #602..." \
+  "$punctuation_output"
+run_test \
+  "punctuation_delimited_keyword_does_not_close_slug_derived_issue" \
+  "no" \
+  "$(
+    if grep -Fq "Closing issue #518" <<<"$punctuation_output" || grep -Fq "Processing issue #518" <<<"$punctuation_output"; then
+      printf 'yes'
+    else
+      printf 'no'
+    fi
+  )"
+
+# An example closing keyword inside a fenced code block in the PR body must
+# not be treated as a live reference — only the real footer reference should
+# be used.
+fenced_branch="fix/retro-519-doc-gaps"
+fenced_repo="$(make_repo fenced "$fenced_branch" yes)"
+fenced_pr_body='Cleans up doc gaps.
+
+```
+Example commit message: Closes #999
+```
+
+Closes #603'
+fenced_output="$(
+  GH_MERGED_HEAD="$fenced_branch" \
+  GH_MERGED_PR=652 \
+  GH_PR_BODY="$fenced_pr_body" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$fenced_repo" --base develop --pr 652 "$fenced_branch"
+)"
+run_contains \
+  "fenced_example_excludes_code_block_reference_closes_real_issue" \
+  "Closing issue #603..." \
+  "$fenced_output"
+run_test \
+  "fenced_example_does_not_close_code_block_example_issue" \
+  "no" \
+  "$(
+    if grep -Fq "Closing issue #999" <<<"$fenced_output" || grep -Fq "Processing issue #999" <<<"$fenced_output"; then
+      printf 'yes'
+    else
+      printf 'no'
+    fi
+  )"
+
 echo ""
 echo "Passed: $PASS_COUNT"
 echo "Failed: $FAIL_COUNT"

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -545,6 +545,75 @@ run_test \
     fi
   )"
 
+# Tilde-fenced (~~~) code blocks must be excluded the same way as
+# backtick-fenced blocks.
+tilde_fenced_branch="fix/retro-520-doc-gaps"
+tilde_fenced_repo="$(make_repo tilde-fenced "$tilde_fenced_branch" yes)"
+tilde_fenced_pr_body='Cleans up doc gaps.
+
+~~~
+Example commit message: Closes #998
+~~~
+
+Closes #604'
+tilde_fenced_output="$(
+  GH_MERGED_HEAD="$tilde_fenced_branch" \
+  GH_MERGED_PR=653 \
+  GH_PR_BODY="$tilde_fenced_pr_body" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$tilde_fenced_repo" --base develop --pr 653 "$tilde_fenced_branch"
+)"
+run_contains \
+  "tilde_fenced_example_closes_real_issue" \
+  "Closing issue #604..." \
+  "$tilde_fenced_output"
+run_test \
+  "tilde_fenced_example_does_not_close_code_block_example_issue" \
+  "no" \
+  "$(
+    if grep -Fq "Closing issue #998" <<<"$tilde_fenced_output" || grep -Fq "Processing issue #998" <<<"$tilde_fenced_output"; then
+      printf 'yes'
+    else
+      printf 'no'
+    fi
+  )"
+
+# An unclosed opening fence must extend to end of input, so a real closing
+# reference placed after an accidentally-unclosed fence is NOT treated as
+# live (rather than leaking past the unclosed fence and being extracted).
+unclosed_fence_branch="fix/retro-521-doc-gaps"
+unclosed_fence_repo="$(make_repo unclosed-fence "$unclosed_fence_branch" yes)"
+unclosed_fence_pr_body='Cleans up doc gaps.
+
+```
+Example commit message: Closes #997
+Closes #605'
+unclosed_fence_output="$(
+  GH_MERGED_HEAD="$unclosed_fence_branch" \
+  GH_MERGED_PR=654 \
+  GH_PR_BODY="$unclosed_fence_pr_body" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$unclosed_fence_repo" --base develop --pr 654 "$unclosed_fence_branch"
+)"
+run_test \
+  "unclosed_fence_extends_to_end_of_input" \
+  "no" \
+  "$(
+    if grep -Fq "Closing issue #997" <<<"$unclosed_fence_output" || grep -Fq "Processing issue #997" <<<"$unclosed_fence_output" || grep -Fq "Closing issue #605" <<<"$unclosed_fence_output" || grep -Fq "Processing issue #605" <<<"$unclosed_fence_output"; then
+      printf 'yes'
+    else
+      printf 'no'
+    fi
+  )"
+run_contains \
+  "unclosed_fence_falls_back_to_slug_issue" \
+  "Closing issue #521..." \
+  "$unclosed_fence_output"
+
 echo ""
 echo "Passed: $PASS_COUNT"
 echo "Failed: $FAIL_COUNT"

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -133,6 +133,11 @@ case "$1 $2" in
       else
         printf '\n'
       fi
+    elif [[ "$args" == *"--json body,title"* ]]; then
+      # Emulates the real command's jq filter
+      # '(.title // "") + "\n" + (.body // "")' without invoking jq, so tests
+      # can control the PR title/body via GH_PR_TITLE / GH_PR_BODY.
+      printf '%s\n%s' "${GH_PR_TITLE:-}" "${GH_PR_BODY:-}"
     elif [[ "$args" == *"--jq"* ]]; then
       printf '\n'
     else
@@ -141,9 +146,9 @@ case "$1 $2" in
     ;;
   "issue view")
     if [[ "$args" == *"--jq"* ]]; then
-      printf 'CLOSED\n'
+      printf '%s\n' "${GH_ISSUE_STATE:-CLOSED}"
     else
-      printf '{"state":"CLOSED"}\n'
+      printf '{"state":"%s"}\n' "${GH_ISSUE_STATE:-CLOSED}"
     fi
     ;;
   "issue close")
@@ -388,6 +393,91 @@ run_test "failed_delete_local_branch_remains" "yes" "$(
     printf 'no'
   fi
 )"
+
+# --- Team-prefixed issue identifier vs. PR-body-derived issue (issue #1511) ---
+#
+# Team-prefixed branch slugs (2-6 letters, dash, digits) are ambiguous with
+# ordinary descriptive slug fragments that happen to contain a number
+# (retro-517, http-500, sha-256). These tests cover the three scenarios from
+# the fix: a false-positive slug overridden by the PR body, a team-prefixed
+# slug whose PR body confirms the same issue, and a team-prefixed slug with
+# no PR-body closing reference falling back to the slug-derived issue.
+
+false_positive_branch="fix/retro-517-doc-gaps"
+false_positive_repo="$(make_repo false-positive "$false_positive_branch" yes)"
+false_positive_output="$(
+  GH_MERGED_HEAD="$false_positive_branch" \
+  GH_MERGED_PR=632 \
+  GH_PR_BODY="Fixes #601" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$false_positive_repo" --base develop --pr 632 "$false_positive_branch"
+)"
+run_contains \
+  "false_positive_slug_uses_pr_body_issue" \
+  "Closing issue #601..." \
+  "$false_positive_output"
+run_test \
+  "false_positive_slug_does_not_close_slug_derived_issue" \
+  "no" \
+  "$(
+    if grep -Fq "Closing issue #517" <<<"$false_positive_output" || grep -Fq "Processing issue #517" <<<"$false_positive_output"; then
+      printf 'yes'
+    else
+      printf 'no'
+    fi
+  )"
+run_contains \
+  "false_positive_slug_notes_ambiguity" \
+  "Team-prefixed identifier 'retro-517'" \
+  "$false_positive_output"
+
+matching_override_branch="fix/lh-97-fix-thing"
+matching_override_repo="$(make_repo matching-override "$matching_override_branch" yes)"
+matching_override_output="$(
+  GH_MERGED_HEAD="$matching_override_branch" \
+  GH_MERGED_PR=645 \
+  GH_PR_BODY="Closes #97" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$matching_override_repo" --base develop --pr 645 "$matching_override_branch"
+)"
+run_contains \
+  "pr_body_derived_happy_path_closes_issue" \
+  "Closing issue #97..." \
+  "$matching_override_output"
+run_contains \
+  "pr_body_derived_happy_path_used_override_path" \
+  "using closing keyword refs from PR #645" \
+  "$matching_override_output"
+
+no_reference_branch="fix/lh-97-real-issue"
+no_reference_repo="$(make_repo no-reference "$no_reference_branch" yes)"
+no_reference_output="$(
+  GH_MERGED_HEAD="$no_reference_branch" \
+  GH_MERGED_PR=650 \
+  GH_PR_BODY="No closing keyword here." \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$no_reference_repo" --base develop --pr 650 "$no_reference_branch"
+)"
+run_contains \
+  "no_closing_reference_falls_back_to_slug_issue" \
+  "Closing issue #97..." \
+  "$no_reference_output"
+run_test \
+  "no_closing_reference_does_not_use_override_path" \
+  "no" \
+  "$(
+    if grep -Fq "using closing keyword refs from PR" <<<"$no_reference_output"; then
+      printf 'yes'
+    else
+      printf 'no'
+    fi
+  )"
 
 echo ""
 echo "Passed: $PASS_COUNT"

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -587,7 +587,7 @@ unclosed_fence_branch="fix/retro-521-doc-gaps"
 unclosed_fence_repo="$(make_repo unclosed-fence "$unclosed_fence_branch" yes)"
 unclosed_fence_pr_body='Cleans up doc gaps.
 
-```
+~~~
 Example commit message: Closes #997
 Closes #605'
 unclosed_fence_output="$(

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -614,6 +614,128 @@ run_contains \
   "Closing issue #521..." \
   "$unclosed_fence_output"
 
+# A closing fence marker shorter than the opening one must NOT be treated as
+# a closer (GFM requires the closer to be at least as long as the opener).
+# Using tildes here (not backticks) keeps this test out of reach of
+# workflow-shell-snippet-lint.py's backtick-only WS001 fence scan.
+mismatched_fence_branch="fix/retro-522-doc-gaps"
+mismatched_fence_repo="$(make_repo mismatched-fence "$mismatched_fence_branch" yes)"
+mismatched_fence_pr_body='Cleans up doc gaps.
+
+~~~~
+Example commit message: Closes #996
+~~~
+still fenced content after a too-short closer
+~~~~
+
+Closes #606'
+mismatched_fence_output="$(
+  GH_MERGED_HEAD="$mismatched_fence_branch" \
+  GH_MERGED_PR=655 \
+  GH_PR_BODY="$mismatched_fence_pr_body" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$mismatched_fence_repo" --base develop --pr 655 "$mismatched_fence_branch"
+)"
+run_contains \
+  "mismatched_fence_length_closes_real_issue" \
+  "Closing issue #606..." \
+  "$mismatched_fence_output"
+run_test \
+  "mismatched_fence_length_does_not_close_example_issue" \
+  "no" \
+  "$(
+    if grep -Fq "Closing issue #996" <<<"$mismatched_fence_output" || grep -Fq "Processing issue #996" <<<"$mismatched_fence_output"; then
+      printf 'yes'
+    else
+      printf 'no'
+    fi
+  )"
+
+# A closing fence line with trailing content after the fence marker (not
+# pure whitespace) must NOT be treated as a closer either (GFM requires the
+# closing fence to be followed only by whitespace).
+trailing_content_fence_branch="fix/retro-523-doc-gaps"
+trailing_content_fence_repo="$(make_repo trailing-content-fence "$trailing_content_fence_branch" yes)"
+trailing_content_fence_pr_body='Cleans up doc gaps.
+
+~~~
+Example commit message: Closes #994
+~~~ not a real closer
+still fenced
+~~~
+
+Closes #607'
+trailing_content_fence_output="$(
+  GH_MERGED_HEAD="$trailing_content_fence_branch" \
+  GH_MERGED_PR=656 \
+  GH_PR_BODY="$trailing_content_fence_pr_body" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$trailing_content_fence_repo" --base develop --pr 656 "$trailing_content_fence_branch"
+)"
+run_contains \
+  "trailing_content_fence_closes_real_issue" \
+  "Closing issue #607..." \
+  "$trailing_content_fence_output"
+run_test \
+  "trailing_content_fence_does_not_close_example_issue" \
+  "no" \
+  "$(
+    if grep -Fq "Closing issue #994" <<<"$trailing_content_fence_output" || grep -Fq "Processing issue #994" <<<"$trailing_content_fence_output"; then
+      printf 'yes'
+    else
+      printf 'no'
+    fi
+  )"
+
+# A genuine sort failure while extracting closing-keyword issue numbers must
+# propagate as a fatal error, not be silently swallowed and fall through to
+# the ambiguous slug-derived issue.
+sort_failure_bin="$TMP_ROOT/sort-failure-bin"
+write_gh_stub "$sort_failure_bin"
+cat >"$sort_failure_bin/sort" <<'STUB'
+#!/usr/bin/env bash
+echo "mock sort failure" >&2
+exit 2
+STUB
+chmod +x "$sort_failure_bin/sort"
+
+sort_failure_branch="fix/retro-524-doc-gaps"
+sort_failure_repo="$(make_repo sort-failure "$sort_failure_branch" yes)"
+set +e
+sort_failure_output="$(
+  env GH_MERGED_HEAD="$sort_failure_branch" \
+    GH_MERGED_PR=657 \
+    GH_PR_BODY="Closes #608" \
+    GH_ISSUE_STATE=OPEN \
+    WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+    PATH="$sort_failure_bin:$PATH" \
+    "$HELPER" --repo-root "$sort_failure_repo" --base develop --pr 657 "$sort_failure_branch" 2>&1
+)"
+sort_failure_status=$?
+set -e
+run_test \
+  "extraction_sort_failure_propagates_as_fatal" \
+  "nonzero" \
+  "$([ "$sort_failure_status" -ne 0 ] && printf 'nonzero' || printf 'zero')"
+run_contains \
+  "extraction_sort_failure_error_message" \
+  "ERROR: failed to sort extracted closing-keyword issue numbers" \
+  "$sort_failure_output"
+run_test \
+  "extraction_sort_failure_does_not_fall_back_to_slug_issue" \
+  "no" \
+  "$(
+    if grep -Fq "Closing issue #524" <<<"$sort_failure_output"; then
+      printf 'yes'
+    else
+      printf 'no'
+    fi
+  )"
+
 echo ""
 echo "Passed: $PASS_COUNT"
 echo "Failed: $FAIL_COUNT"

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -736,6 +736,42 @@ run_test \
     fi
   )"
 
+# A 4-space-indented fence marker is GFM indented code, not a real fence, and
+# must not be treated as one — otherwise it can spuriously open an unclosed
+# fence that swallows a later, real closing reference.
+indented_fence_branch="fix/retro-525-doc-gaps"
+indented_fence_repo="$(make_repo indented-fence "$indented_fence_branch" yes)"
+indented_fence_pr_body='Cleans up doc gaps.
+
+Example indented code (not a fence):
+    ~~~
+    some literal example content
+
+Closes #609'
+indented_fence_output="$(
+  GH_MERGED_HEAD="$indented_fence_branch" \
+  GH_MERGED_PR=658 \
+  GH_PR_BODY="$indented_fence_pr_body" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$indented_fence_repo" --base develop --pr 658 "$indented_fence_branch"
+)"
+run_contains \
+  "indented_fence_marker_is_not_a_fence_closes_real_issue" \
+  "Closing issue #609..." \
+  "$indented_fence_output"
+run_test \
+  "indented_fence_marker_does_not_fall_back_to_slug_issue" \
+  "no" \
+  "$(
+    if grep -Fq "Closing issue #525" <<<"$indented_fence_output"; then
+      printf 'yes'
+    else
+      printf 'no'
+    fi
+  )"
+
 echo ""
 echo "Passed: $PASS_COUNT"
 echo "Failed: $FAIL_COUNT"


### PR DESCRIPTION
## Summary

`post-merge-cleanup.sh` derives an issue ID from the branch slug using a
team-prefixed pattern (2-6 letters + dash + digits). That pattern is
indistinguishable from ordinary descriptive slug fragments that happen to
contain a number (`retro-517`, `http-500`, `sha-256`, `utf-8`, `base-64`), so
it could silently update the tracker status of, and close, an unrelated
issue.

The merged PR body/title is now checked first for GitHub closing keywords
(`Closes #N`, `Fixes #N`, `Resolves #N`, etc.) whenever the branch slug's
identifier is team-prefixed, and that reference is treated as authoritative
when present — including when the PR closes more than one issue (reuses the
existing multi-issue-closing loop, backlog #1391's concern). The
slug-derived identifier is only used as a fallback when the PR body carries
no closing reference at all, so legitimate team-prefixed slugs merged
without an explicit closing keyword (`fix/lh-97-real-issue`) keep working
exactly as before. Plain numeric identifiers (`fix/42-slug`) are unambiguous
and unaffected — this change does not touch that path.

Extracted the PR-body closing-keyword parsing and per-issue
close/tracker-update loop into `fetch_pr_closing_issues()` and
`close_issues_from_pr()` so the new team-prefixed override path and the
existing no-identifier fallback path share one implementation instead of
diverging copies.

## Testing

- `bash scripts/development-workflow/tests/test-post-merge-cleanup.sh` — 31/31
  pass (24 pre-existing + 7 new). Confirmed the 4 assertions tied to the fix
  fail against the unfixed script (git-stash verified).
- `bash scripts/development-workflow/tests/test-workflow-orchestration-product-repo-aware.sh`
  — 72/72 pass (exercises `post-merge-cleanup.sh` directly).
- `shellcheck -x scripts/development-workflow/post-merge-cleanup.sh scripts/development-workflow/tests/test-post-merge-cleanup.sh`
  — clean.
- `bash -n scripts/development-workflow/post-merge-cleanup.sh` — clean.
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop` — clean.
- markdownlint-cli2 + heuristic + duplicate-header CHANGELOG checks — clean.

Closes #1511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-merge cleanup for team-prefixed branches by prioritizing issue references from pull request closing keywords.
  * Added support for multiple references, punctuation-delimited keywords, and ignored fenced code examples.
  * Added fallback handling when no closing references are found, preserving numeric branch behavior.
  * Improved issue updates, closure handling, warnings, and failure reporting.

* **Tests**
  * Added coverage for overrides, fallbacks, punctuation, and fenced code blocks.

* **Documentation**
  * Documented the updated issue-identification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->