### PR TITLE
fix(policy-recommender): word-boundary security checkpoint keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **Security-checkpoint keyword test no longer matches substrings** (#1504):
+  `recommend_checkpoints_for_item` in
+  `scripts/development-workflow/run-epic-policy-recommender.sh` matched the
+  security/auth checkpoint keywords (`auth|security|secret|permission|
+  credential|sensitive`) with a bare, unanchored alternation, so ordinary
+  vocabulary containing those substrings tripped a pending human checkpoint:
+  "authoring", "author", "authority", and "insensitive" all matched. Because a
+  pending checkpoint sets `requiresConfirmation: true`, a single incidental
+  word — such as `auth` inside a `Related: #1496 (... plan-authoring rigor)`
+  cross-reference — halted an otherwise fully delegated `/run-epic`/`/run-items`
+  run and demanded human input on an issue with no actual security content
+  (live reproduction on `/run-items 1502 1501`). The keyword regex now uses
+  `\b`-anchored full-term alternatives (`authenticat\w*`, `authoriz\w*`,
+  `security`, `secrets?`, `permissions?`, `credentials?`, `sensitive`, `auth`)
+  so `authentication`, `authorization`, `secret`, `credential`, `permission`,
+  `security`, `sensitive`, and the bare word `auth` still match while
+  `authoring`, `author`, `authority`, and `insensitive` no longer do. The
+  checkpoint `reason` now names the matched term and quotes the source line
+  instead of a generic static message, so an operator can judge relevance
+  without grepping the issue by hand. The sibling unresolved-product classifier
+  (`ambiguous|unclear|...`) shared the same defect — "unambiguous" matched
+  "ambiguous" as a substring — and is now `\b`-anchored too, along with the
+  trade-off/architecture classifier. 11 new regression tests cover both the
+  false-positive corpus (confirmed to fail against the pre-fix regex) and the
+  true-positive corpus.
 - **CodeRabbit "Review skipped" banner no longer reports an unreviewed PR as
   clean** (#1531): `run_coderabbit_review` in
   `scripts/development-workflow/pr-review-loop.sh` counted any CodeRabbit issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,31 +30,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security-checkpoint keyword test no longer matches substrings** (#1504):
   `recommend_checkpoints_for_item` in
   `scripts/development-workflow/run-epic-policy-recommender.sh` matched the
-  security/auth checkpoint keywords (`auth|security|secret|permission|
-  credential|sensitive`) with a bare, unanchored alternation, so ordinary
-  vocabulary containing those substrings tripped a pending human checkpoint:
-  "authoring", "author", "authority", and "insensitive" all matched. Because a
-  pending checkpoint sets `requiresConfirmation: true`, a single incidental
-  word — such as `auth` inside a `Related: #1496 (... plan-authoring rigor)`
-  cross-reference — halted an otherwise fully delegated `/run-epic`/`/run-items`
-  run and demanded human input on an issue with no actual security content
-  (live reproduction on `/run-items 1502 1501`). The keyword regex now uses
-  `\b`-anchored full-term alternatives (`unauthenticat\w*`, `unauthoriz\w*`,
-  `authenticat\w*`, `authoriz\w*`, `security`, `secrets?`, `permissions?`,
-  `credentials?`, `sensitive`, `auth`) so `authentication`, `authorization`,
-  `secret`, `credential`, `permission`, `security`, `sensitive`, the bare word
-  `auth`, and negated forms like `unauthorized`/`unauthenticated` still match
-  (the pre-fix regex also matched these via bare substring, so the fix must not
-  silently drop them) while `authoring`, `author`, `authority`, and
-  `insensitive` no longer do. The checkpoint `reason` now names the matched
-  term and quotes the source line instead of a generic static message, so an
-  operator can judge relevance without grepping the issue by hand. The sibling
-  unresolved-product classifier (`ambiguous|unclear|...`) shared the same
-  defect — "unambiguous" matched "ambiguous" as a substring — and is now
-  `\b`-anchored too, along with the trade-off/architecture classifier. 13 new
-  regression tests cover both the false-positive corpus (confirmed to fail
-  against the pre-fix regex) and the true-positive corpus, including the
-  `unauthorized`/`unauthenticated` negated forms.
+  security/auth checkpoint keywords with a bare, unanchored alternation, so
+  ordinary vocabulary ("authoring", "author", "authority", "insensitive")
+  tripped a pending human checkpoint and halted an otherwise fully delegated
+  `/run-epic`/`/run-items` run on issues with no actual security content (live
+  reproduction on `/run-items 1502 1501`). The keyword regex is now
+  `\b`-anchored so real security/auth terms — including negated forms like
+  `unauthorized`/`unauthenticated` — still match while incidental substrings no
+  longer do. The checkpoint `reason` now names the matched term and quotes the
+  source line instead of a generic static message. The sibling unresolved-
+  product and trade-off/architecture classifiers shared the same
+  bare-alternation defect and are now `\b`-anchored too. 13 new regression
+  tests cover the false-positive corpus (confirmed to fail against the pre-fix
+  regex) and the true-positive corpus.
 - **CodeRabbit "Review skipped" banner no longer reports an unreviewed PR as
   clean** (#1531): `run_coderabbit_review` in
   `scripts/development-workflow/pr-review-loop.sh` counted any CodeRabbit issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,19 +39,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cross-reference — halted an otherwise fully delegated `/run-epic`/`/run-items`
   run and demanded human input on an issue with no actual security content
   (live reproduction on `/run-items 1502 1501`). The keyword regex now uses
-  `\b`-anchored full-term alternatives (`authenticat\w*`, `authoriz\w*`,
-  `security`, `secrets?`, `permissions?`, `credentials?`, `sensitive`, `auth`)
-  so `authentication`, `authorization`, `secret`, `credential`, `permission`,
-  `security`, `sensitive`, and the bare word `auth` still match while
-  `authoring`, `author`, `authority`, and `insensitive` no longer do. The
-  checkpoint `reason` now names the matched term and quotes the source line
-  instead of a generic static message, so an operator can judge relevance
-  without grepping the issue by hand. The sibling unresolved-product classifier
-  (`ambiguous|unclear|...`) shared the same defect — "unambiguous" matched
-  "ambiguous" as a substring — and is now `\b`-anchored too, along with the
-  trade-off/architecture classifier. 11 new regression tests cover both the
-  false-positive corpus (confirmed to fail against the pre-fix regex) and the
-  true-positive corpus.
+  `\b`-anchored full-term alternatives (`unauthenticat\w*`, `unauthoriz\w*`,
+  `authenticat\w*`, `authoriz\w*`, `security`, `secrets?`, `permissions?`,
+  `credentials?`, `sensitive`, `auth`) so `authentication`, `authorization`,
+  `secret`, `credential`, `permission`, `security`, `sensitive`, the bare word
+  `auth`, and negated forms like `unauthorized`/`unauthenticated` still match
+  (the pre-fix regex also matched these via bare substring, so the fix must not
+  silently drop them) while `authoring`, `author`, `authority`, and
+  `insensitive` no longer do. The checkpoint `reason` now names the matched
+  term and quotes the source line instead of a generic static message, so an
+  operator can judge relevance without grepping the issue by hand. The sibling
+  unresolved-product classifier (`ambiguous|unclear|...`) shared the same
+  defect — "unambiguous" matched "ambiguous" as a substring — and is now
+  `\b`-anchored too, along with the trade-off/architecture classifier. 13 new
+  regression tests cover both the false-positive corpus (confirmed to fail
+  against the pre-fix regex) and the true-positive corpus, including the
+  `unauthorized`/`unauthenticated` negated forms.
 - **CodeRabbit "Review skipped" banner no longer reports an unreviewed PR as
   clean** (#1531): `run_coderabbit_review` in
   `scripts/development-workflow/pr-review-loop.sh` counted any CodeRabbit issue

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -330,7 +330,7 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
       else .
       end;
   def security_keyword_regex:
-    "\\b(authenticat\\w*|authoriz\\w*|security|secrets?|permissions?|credentials?|sensitive|auth)\\b";
+    "\\b(unauthenticat\\w*|unauthoriz\\w*|authenticat\\w*|authoriz\\w*|security|secrets?|permissions?|credentials?|sensitive|auth)\\b";
   def matched_regex_terms($text; $regex):
     [$text | match($regex; "g").string] | stable_unique;
   def security_signal_details($item):

--- a/scripts/development-workflow/run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/run-epic-policy-recommender.sh
@@ -329,12 +329,36 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
         error("waived checkpoints require waiver_rationale")
       else .
       end;
+  def security_keyword_regex:
+    "\\b(authenticat\\w*|authoriz\\w*|security|secrets?|permissions?|credentials?|sensitive|auth)\\b";
+  def matched_regex_terms($text; $regex):
+    [$text | match($regex; "g").string] | stable_unique;
+  def security_signal_details($item):
+    (
+      ($item.title // "") + "\n" +
+      ($item.body // "") + "\n" +
+      (($item.labels // []) | join(" ")) + "\n" +
+      ($item.type // "") + "\n" +
+      ($item.integrationBranchLabel // "")
+    ) as $combined
+    | ($combined | gsub("\r\n"; "\n") | split("\n")) as $lines
+    | [
+        $lines[]
+        | select(length > 0)
+        | . as $line
+        | ($line | ascii_downcase) as $lower
+        | select($lower | test(security_keyword_regex))
+        | matched_regex_terms($lower; security_keyword_regex)[] as $term
+        | ("keyword '\''" + $term + "'\'' in line: \"" + $line + "\"")
+      ]
+    | stable_unique;
   def recommend_checkpoints_for_item($item):
     item_signal_text($item) as $text |
     data_model_signals($item) as $data_model_signals |
+    security_signal_details($item) as $security_signals |
     infer_workflow_stage($item) as $stage |
     acceptance_criteria_problem($item) as $criteria_problem |
-    ($text | test("ambiguous|unclear|\\btbd\\b|open question|unresolved product")) as $unresolved_product_signal |
+    ($text | test("\\bambiguous\\b|\\bunclear\\b|\\btbd\\b|\\bopen question\\b|\\bunresolved product\\b")) as $unresolved_product_signal |
     ($item.number) as $num |
     (
       []
@@ -359,7 +383,7 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
             satisfaction_state: "pending"
           }]
         else . end
-      | if $text | test("trade[- ]?off|architecture.{0,30}product|product.{0,30}technical|ambiguous.{0,40}(architecture|product|technical)") then
+      | if $text | test("\\btrade[- ]?offs?\\b|\\barchitecture\\b.{0,30}\\bproduct\\b|\\bproduct\\b.{0,30}\\btechnical\\b|\\bambiguous\\b.{0,40}\\b(architecture|product|technical)\\b") then
           . + [{
             item_number: $num,
             stage: (if $stage == "spec" then "plan" else $stage end),
@@ -369,12 +393,12 @@ recommendation_json="$(printf '%s\n' "$scope_json" | jq -c \
             satisfaction_state: "pending"
           }]
         else . end
-      | if $text | test("auth|security|secret|permission|credential|sensitive") then
+      | if ($security_signals | length) > 0 then
           . + [{
             item_number: $num,
             stage: "implementation",
             domain: "technical",
-            reason: "issue signals security, auth, or other sensitive implementation changes",
+            reason: ("issue signals security, auth, or other sensitive implementation changes: " + ($security_signals | join("; "))),
             required_human_action: "review security-sensitive implementation approach before delegated merge",
             satisfaction_state: "pending"
           }]

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -503,6 +503,16 @@ credential_fixture="$(security_case_fixture credential-tp 327 "Store credential 
 run_test "credential_word_still_checkpoints" "1" "$(security_case_checkpoint_count "$credential_fixture" 327)"
 run_test "security_checkpoint_reason_names_matched_term_and_line" "yes" "$(security_case_checkpoint_reason "$credential_fixture" 327 | grep -Fq "keyword 'credential' in line: \"The credential should be stored in a secrets vault.\"" && echo yes || echo no)"
 
+# "un-" negated auth terms are real security vocabulary ("unauthorized access",
+# "unauthenticated request") that the pre-fix bare-substring regex also matched
+# (via "auth" inside them). The word-boundary fix must not introduce a false
+# negative here just because "un" glues directly onto the stem.
+unauthorized_fixture="$(security_case_fixture unauthorized-tp 328 "Reject unauthorized requests" "Return 403 for unauthorized access to the admin API.")"
+run_test "unauthorized_word_still_checkpoints" "1" "$(security_case_checkpoint_count "$unauthorized_fixture" 328)"
+
+unauthenticated_fixture="$(security_case_fixture unauthenticated-tp 329 "Block unauthenticated calls" "Middleware should reject unauthenticated requests before hitting the handler.")"
+run_test "unauthenticated_word_still_checkpoints" "1" "$(security_case_checkpoint_count "$unauthenticated_fixture" 329)"
+
 run_test "docs_scope_has_no_checkpoints" "0" "$(printf '%s\n' "$docs_output" | jq -r '.recommendedPolicy.checkpoints | length')"
 
 complete_criteria_fixture="$(write_fixture complete-criteria '{

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -447,6 +447,62 @@ sensitive_backlog_fixture="$(write_fixture sensitive-backlog '{
 sensitive_backlog_output="$(recommend_json "$sensitive_backlog_fixture" "\$run-epic --items 301")"
 run_test "sensitive_backlog_recommends_implementation_checkpoint" "implementation:technical" "$(printf '%s\n' "$sensitive_backlog_output" | jq -r '.recommendedPolicy.checkpoints[0] | .stage + ":" + .domain')"
 
+# Regression coverage for issue #1504: the security-checkpoint keyword test must
+# use word boundaries so ordinary vocabulary ("authoring", "author", "authority",
+# "insensitive") no longer trips a spurious implementation checkpoint, while real
+# security/auth terms still do. security_case_fixture derives each case from the
+# in_review "sensitive_fixture" so only the implementation/technical checkpoint is
+# exercised.
+security_case_fixture() {
+  local name="$1" number="$2" title="$3" body="$4"
+  write_fixture "$name" "$(jq --argjson number "$number" --arg title "$title" --arg body "$body" '
+    .groups.in_review[0].number = $number
+    | .groups.in_review[0].title = $title
+    | .groups.in_review[0].body = $body
+    | .items[0] = .groups.in_review[0]
+  ' "$sensitive_fixture")"
+}
+security_case_checkpoint_count() {
+  local fixture="$1" number="$2"
+  recommend_json "$fixture" "\$run-epic --items $number" \
+    | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "implementation" and .domain == "technical")] | length'
+}
+security_case_checkpoint_reason() {
+  local fixture="$1" number="$2"
+  recommend_json "$fixture" "\$run-epic --items $number" \
+    | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "implementation" and .domain == "technical") | .reason'
+}
+
+# False-positive corpus: must NOT trigger the security checkpoint. Confirmed
+# against the unfixed regex (test("auth|security|secret|permission|credential|
+# sensitive")) that every one of these words matches as a bare substring before
+# this fix, which is exactly the defect being regression-tested here.
+authoring_fixture="$(security_case_fixture authoring-fp 320 "Improve plan-authoring guidance" "Related: #1496 (Protocol 02 plan-authoring rigor) has no bearing here.")"
+run_test "authoring_word_does_not_checkpoint" "0" "$(security_case_checkpoint_count "$authoring_fixture" 320)"
+
+author_fixture="$(security_case_fixture author-fp 321 "Credit the documentation author" "The author of this guide should be listed in the footer.")"
+run_test "author_word_does_not_checkpoint" "0" "$(security_case_checkpoint_count "$author_fixture" 321)"
+
+authority_fixture="$(security_case_fixture authority-fp 322 "Clarify service authority boundaries" "This service has no authority over billing decisions.")"
+run_test "authority_word_does_not_checkpoint" "0" "$(security_case_checkpoint_count "$authority_fixture" 322)"
+
+insensitive_fixture="$(security_case_fixture insensitive-fp 323 "Make string comparison case insensitive" "The comparison should be case insensitive for usernames.")"
+run_test "insensitive_word_does_not_checkpoint" "0" "$(security_case_checkpoint_count "$insensitive_fixture" 323)"
+
+# True-positive corpus: must still trigger the security checkpoint.
+authentication_fixture="$(security_case_fixture authentication-tp 324 "Add authentication to login flow" "Users must authenticate before accessing the dashboard.")"
+run_test "authentication_word_still_checkpoints" "1" "$(security_case_checkpoint_count "$authentication_fixture" 324)"
+
+authorization_fixture="$(security_case_fixture authorization-tp 325 "Fix authorization checks" "The authorization check for admin routes is missing.")"
+run_test "authorization_word_still_checkpoints" "1" "$(security_case_checkpoint_count "$authorization_fixture" 325)"
+
+secret_fixture="$(security_case_fixture secret-tp 326 "Rotate leaked secret" "The leaked secret must be rotated immediately.")"
+run_test "secret_word_still_checkpoints" "1" "$(security_case_checkpoint_count "$secret_fixture" 326)"
+
+credential_fixture="$(security_case_fixture credential-tp 327 "Store credential in vault" "The credential should be stored in a secrets vault.")"
+run_test "credential_word_still_checkpoints" "1" "$(security_case_checkpoint_count "$credential_fixture" 327)"
+run_test "security_checkpoint_reason_names_matched_term_and_line" "yes" "$(security_case_checkpoint_reason "$credential_fixture" 327 | grep -Fq "keyword 'credential' in line: \"The credential should be stored in a secrets vault.\"" && echo yes || echo no)"
+
 run_test "docs_scope_has_no_checkpoints" "0" "$(printf '%s\n' "$docs_output" | jq -r '.recommendedPolicy.checkpoints | length')"
 
 complete_criteria_fixture="$(write_fixture complete-criteria '{
@@ -470,6 +526,24 @@ complete_criteria_fixture="$(write_fixture complete-criteria '{
 }')"
 complete_criteria_output="$(recommend_json "$complete_criteria_fixture" "\$run-epic --items 401")"
 run_test "complete_acceptance_criteria_has_no_product_checkpoint" "0" "$(printf '%s\n' "$complete_criteria_output" | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "spec" and .domain == "product")] | length')"
+
+# Sibling classifier audit (issue #1504): the unresolved-product signal shared the
+# same bare-alternation defect as the security test ("ambiguous" is a substring of
+# "unambiguous"). "unambiguous" must not trigger the spec/product checkpoint,
+# while a genuine "ambiguous" reference still does.
+unambiguous_fixture="$(write_fixture unambiguous "$(jq '
+  .groups.eligible[0].body = "## Problem\nThis flow is unambiguous and fully specified.\n\n## Acceptance Criteria\n- The report labels each proposed item.\n- The report names held items.\n"
+  | .items[0].body = .groups.eligible[0].body
+' "$complete_criteria_fixture")")"
+unambiguous_output="$(recommend_json "$unambiguous_fixture" "\$run-epic --items 401")"
+run_test "unambiguous_word_does_not_recommend_product_checkpoint" "0" "$(printf '%s\n' "$unambiguous_output" | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "spec" and .domain == "product")] | length')"
+
+ambiguous_fixture_word="$(write_fixture ambiguous-word "$(jq '
+  .groups.eligible[0].body = "## Problem\nThis flow is ambiguous in edge cases.\n\n## Acceptance Criteria\n- The report labels each proposed item.\n- The report names held items.\n"
+  | .items[0].body = .groups.eligible[0].body
+' "$complete_criteria_fixture")")"
+ambiguous_output_word="$(recommend_json "$ambiguous_fixture_word" "\$run-epic --items 401")"
+run_test "ambiguous_word_still_recommends_product_checkpoint" "issue signals unresolved product requirements or acceptance-criteria ambiguity" "$(printf '%s\n' "$ambiguous_output_word" | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "spec" and .domain == "product") | .reason')"
 
 case_variant_fixture="$(write_fixture case-variant "$(jq '.groups.eligible[0].body = "## ACCEPTANCE CRITERIA\n- The heading case is normalized.\n" | .items[0].body = .groups.eligible[0].body' "$complete_criteria_fixture")")"
 case_variant_output="$(recommend_json "$case_variant_fixture" "\$run-epic --items 401")"

--- a/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
+++ b/scripts/development-workflow/tests/test-run-epic-policy-recommender.sh
@@ -454,6 +454,10 @@ run_test "sensitive_backlog_recommends_implementation_checkpoint" "implementatio
 # in_review "sensitive_fixture" so only the implementation/technical checkpoint is
 # exercised.
 security_case_fixture() {
+  if [ "$#" -ne 4 ]; then
+    printf 'ERROR: security_case_fixture requires exactly 4 arguments; got %s\n' "$#" >&2
+    return 2
+  fi
   local name="$1" number="$2" title="$3" body="$4"
   write_fixture "$name" "$(jq --argjson number "$number" --arg title "$title" --arg body "$body" '
     .groups.in_review[0].number = $number
@@ -463,11 +467,19 @@ security_case_fixture() {
   ' "$sensitive_fixture")"
 }
 security_case_checkpoint_count() {
+  if [ "$#" -ne 2 ]; then
+    printf 'ERROR: security_case_checkpoint_count requires exactly 2 arguments; got %s\n' "$#" >&2
+    return 2
+  fi
   local fixture="$1" number="$2"
   recommend_json "$fixture" "\$run-epic --items $number" \
     | jq -r '[.recommendedPolicy.checkpoints[]? | select(.stage == "implementation" and .domain == "technical")] | length'
 }
 security_case_checkpoint_reason() {
+  if [ "$#" -ne 2 ]; then
+    printf 'ERROR: security_case_checkpoint_reason requires exactly 2 arguments; got %s\n' "$#" >&2
+    return 2
+  fi
   local fixture="$1" number="$2"
   recommend_json "$fixture" "\$run-epic --items $number" \
     | jq -r '.recommendedPolicy.checkpoints[] | select(.stage == "implementation" and .domain == "technical") | .reason'


### PR DESCRIPTION
## Summary

`recommend_checkpoints_for_item()` in `scripts/development-workflow/run-epic-policy-recommender.sh`
matched the security/auth checkpoint keywords (`auth|security|secret|permission|credential|sensitive`)
with a bare, unanchored `test()` alternation, so ordinary vocabulary containing those substrings
tripped a pending human checkpoint: **authoring**, **author**, **authority**, and **insensitive**
all matched. Because a pending checkpoint sets `requiresConfirmation: true`, a single incidental
word — e.g. `auth` inside a `Related: #1496 (... plan-authoring rigor)` cross-reference — halted an
otherwise fully delegated `/run-epic`/`/run-items` run and demanded human input on an issue with no
actual security content. This was live-reproduced on `/run-items 1502 1501`.

## Changes

- Anchor the security keyword regex with `\b` so `authentication`, `authorization`, `secret`,
  `credential`, `permission`, `security`, `sensitive`, and the bare word `auth` still match, while
  `authoring`, `author`, `authority`, and `insensitive` no longer do.
- New `security_signal_details($item)` helper emits the matched term and the quoted source line in
  the checkpoint `reason`, instead of a static message — so an operator can judge relevance without
  grepping the issue by hand.
- Audited the sibling classifiers per the issue's request:
  - The unresolved-product classifier (`ambiguous|unclear|...`) shared the same defect
    (`"unambiguous"` matched `"ambiguous"` as a substring) — now `\b`-anchored.
  - The trade-off/architecture classifier — now `\b`-anchored too.
  - The data-model classifiers were already `\b`-anchored; no change needed there.
- 13 new regression tests: false-positive corpus (`authoring`/`author`/`authority`/`insensitive`,
  plus `unambiguous`), true-positive corpus (`authentication`/`authorization`/`secret`/`credential`,
  `unauthorized`/`unauthenticated`, plus `ambiguous` and the existing `auth`+`permission` fixtures),
  and a reason-text format check.

## Verification

- Confirmed the 6 new false-positive-detecting tests **fail** against the pre-fix regex (stashed the
  helper script only, kept the new test file, reran — 6 failures, exactly the words the issue lists),
  and pass again after restoring the fix. This rules out a tautological test.
- `bash scripts/development-workflow/tests/test-run-epic-policy-recommender.sh` → 95/95 pass.
- Full sibling `run-epic` test suite also green: audit-trail (113), checkpoint-lifecycle (26),
  delegated-gate (171), risk-classifier (77), scope-resolver (129).
- `markdownlint-cli2`, the heuristic lint, the duplicate-header check, and `shellcheck` are all clean
  on the changed files.

## Acceptance criteria (from #1504)

- [x] `authoring`, `author`, `authority`, and `insensitive` do not trigger the security checkpoint.
- [x] `authentication`, `authorization`, `secret`, `credential`, and `permission` (as real words) still do.
- [x] The checkpoint `reason` names the matched term and quotes its line.
- [x] Sibling keyword classifiers in the same chain are audited and fixed if they share the defect.
- [x] Tests cover both the false-positive corpus and the true-positive corpus.

Fixes #1504

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Update (Step 7a Pass 1 review)

Pass 1 review flagged that `unauthorized`/`unauthenticated` — real security terms the pre-fix bare-substring regex also matched (via `auth` inside them) — no longer matched under the `\b`-anchored fix, since `un` glues directly onto the stem with no boundary. Added `unauthoriz\w*`/`unauthenticat\w*` alternatives plus 2 regression tests to close that gap. Both Step 7a passes (Spec Compliance, Code Quality) are now APPROVED at HEAD `340c84da`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security checkpoint detection to recognize valid security terms while avoiding false positives from incidental word matches.
  * Checkpoint explanations now identify the matched security term and its source line for clearer review.
  * Improved product ambiguity and architecture trade-off detection by reducing partial-word matches.
  * Added regression coverage to help preserve accurate matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->