### PR TITLE
fix(run-work-router): distinguish gh probe failure from not-found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -961,7 +961,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of being silently treated as not-found. gh's own "no default
   remote repository has been set" message (a local repo-configuration
   error, not evidence the target doesn't exist) is likewise never
-  classified as `not_found`. `gh_probe()` also now guards its own
+  classified as `not_found`, and gets its own `local_config_error`
+  classification distinct from `github_unavailable` since the operator fix
+  is running `gh repo set-default` locally, not waiting out an outage.
+  `gh_probe()` also now guards its own
   temp-file setup and stderr capture: a failing `mktemp` or `cat` reports a
   diagnostic `PROBE_ERR` at a dedicated internal exit code instead of
   silently producing an empty stderr that could otherwise be misread as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -954,11 +954,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and classifies a non-zero exit's stderr (`classify_gh_probe_error`) into
   `rate_limited`, `auth_failed`, `network_error`, or `github_unavailable`
   before falling back to `not_found` for gh's own "could not resolve to a
-  PullRequest/Issue" message or an empty stderr — preserving current behavior
-  for a genuine not-found. A probe failure now stops with the distinct
+  PullRequest/Issue" message, or for an empty stderr **only** when the exit
+  code is gh's normal API-error code (`1`) — preserving current behavior for
+  a genuine not-found while an empty stderr at any other exit code (a
+  signal death, an OOM kill) still falls back to `github_unavailable`
+  instead of being silently treated as not-found. gh's own "no default
+  remote repository has been set" message (a local repo-configuration
+  error, not evidence the target doesn't exist) is likewise never
+  classified as `not_found`. `gh_probe()` also now guards its own
+  temp-file setup and stderr capture: a failing `mktemp` or `cat` reports a
+  diagnostic `PROBE_ERR` at a dedicated internal exit code instead of
+  silently producing an empty stderr that could otherwise be misread as a
+  not-found. A probe failure now stops with the distinct
   `MODE=tracker_unavailable` (not `ambiguous`) and a `STOP_REASON` naming the
   cause; a rate-limited probe additionally reports the GraphQL quota reset
   time from `gh api rate_limit` when available.
+  `docs/workflow/development-workflow/protocols/96-run-work-routing-protocol.md`
+  (the canonical routing specification) is updated to document the new
+  `tracker_unavailable` mode, its decision-table row, edge cases, and handoff
+  mapping (routing layer version 1.0 → 1.1).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -940,6 +940,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   directory instead of the product checkout's, so two cleanup runs that
   resolve the product repository to different local checkouts of the same
   hub no longer both proceed for the same release.
+- **`run-work-router.sh` no longer treats a `gh` probe failure as "target not
+  found"** (#1503): `resolve_token()` probed `gh pr view`/`gh issue view` with
+  `2>/dev/null || true` and treated any empty result as unresolved, so a rate
+  limit, auth failure, network error, or GitHub outage was indistinguishable
+  from the target genuinely not existing — both produced `MODE=ambiguous`,
+  which every bounded command (`/run-item`, `/run-items`, `/run-epic`) treats
+  as a hard stop with a misdirecting reason. Live reproduction: `/run-items
+  1502 1501` stopped reporting both issues unresolvable immediately after a
+  `/run-work` scan exhausted the hourly GraphQL quota, even though both were
+  open and had resolved successfully minutes earlier. `resolve_token()` now
+  captures each probe's stdout, stderr, and exit code separately (`gh_probe`)
+  and classifies a non-zero exit's stderr (`classify_gh_probe_error`) into
+  `rate_limited`, `auth_failed`, `network_error`, or `github_unavailable`
+  before falling back to `not_found` for gh's own "could not resolve to a
+  PullRequest/Issue" message or an empty stderr — preserving current behavior
+  for a genuine not-found. A probe failure now stops with the distinct
+  `MODE=tracker_unavailable` (not `ambiguous`) and a `STOP_REASON` naming the
+  cause; a rate-limited probe additionally reports the GraphQL quota reset
+  time from `gh api rate_limit` when available.
 
 ### Changed
 

--- a/docs/workflow/development-workflow/protocols/96-run-work-routing-protocol.md
+++ b/docs/workflow/development-workflow/protocols/96-run-work-routing-protocol.md
@@ -44,7 +44,7 @@ This protocol defines:
 | `redirect_item`   | Redirect (item)    | Single non-epic target resolved; `/run-work` performs **no mutation** and emits redirect to `/run-item`.                                               |
 | `redirect_epic`   | Redirect (epic)    | Epic-like or `--epic` target; `/run-work` performs **no mutation** and emits redirect to `/run-epic`.                                                   |
 | `ambiguous`       | Ambiguous          | Cannot resolve deterministically; records stop reason and performs no mutation.                                                                         |
-| `tracker_unavailable` | Tracker unavailable | A `gh` probe used to resolve a target failed (rate limit, auth, network, or a GitHub outage) rather than confirming the target does not exist; records a cause-specific stop reason and performs no mutation. Distinct from `ambiguous`, which means the input itself could not be resolved, not that the resolution attempt errored. |
+| `tracker_unavailable` | Tracker unavailable | A `gh` probe used to resolve a target failed (rate limit, auth, network, GitHub outage, or a local repository-configuration error) rather than confirming the target does not exist; records a cause-specific stop reason and performs no mutation. Distinct from `ambiguous`, which means the input itself could not be resolved, not that the resolution attempt errored. |
 
 **Valid transitions**:
 
@@ -55,9 +55,16 @@ This protocol defines:
 - Any unresolved input → `ambiguous`.
 - Any input whose resolution could not be determined because the underlying
   `gh` probe itself failed (rate limit, auth failure, network error, GitHub
-  outage) → `tracker_unavailable`, not `ambiguous`. A genuine not-found result
-  (the probe succeeded and confirmed no matching target) still resolves to
-  `ambiguous`.
+  outage, or a local repository-configuration error such as gh having no
+  default remote repository configured) → `tracker_unavailable`, not
+  `ambiguous`. A genuine not-found result (the probe succeeded and confirmed
+  no matching target) still resolves to `ambiguous`. The `STOP_REASON` and
+  operator guidance differ by sub-cause: a rate limit, auth failure, network
+  error, or outage all recommend retrying (immediately, or after the
+  reported quota reset time for a rate limit); a local repository-
+  configuration error instead recommends running `gh repo set-default` in
+  the checkout, since retrying will not help until the default repository is
+  configured.
 
 ---
 
@@ -76,6 +83,7 @@ encodes the same rows. Every row maps to at least one automated test in
 | Two or more explicit target tokens (after duplicate collapse) that each resolve to a concrete target | `redirect_items` | UC3, BR5, AC3 |
 | Any input that cannot be deterministically resolved: unresolvable lookalike token, mixed list with at least one unresolvable token, or a single token matching two different concrete artifacts (conflicting signal) | `ambiguous` | BR2, BR10, AC11 |
 | A `gh` probe used to resolve a token failed with a rate limit, auth failure, network error, or GitHub outage — the probe itself errored rather than confirming the target does not exist (single token, or the first such failure encountered in a multi-token list) | `tracker_unavailable` | #1503 |
+| A `gh` probe used to resolve a token failed with a local repository-configuration error (gh has no default remote repository configured for this checkout) — a local environment problem, not evidence the target does not exist and not a transient outage | `tracker_unavailable` (with `STOP_REASON` recommending `gh repo set-default`, not a retry) | #1503 |
 
 **Edge cases** (all must be covered by automated tests):
 
@@ -98,6 +106,7 @@ encodes the same rows. Every row maps to at least one automated test in
 | `gh pr view`/`gh issue view` probe fails with an authentication error while resolving a token | `tracker_unavailable` |
 | `gh pr view`/`gh issue view` probe fails with a network error while resolving a token | `tracker_unavailable` |
 | `gh pr view`/`gh issue view` probe fails with an unrecognized/opaque error (GitHub outage) while resolving a token | `tracker_unavailable` |
+| `gh pr view`/`gh issue view` probe fails with "no default remote repository has been set" while resolving a token | `tracker_unavailable` (`STOP_REASON` recommends `gh repo set-default`, distinct from the outage/retry wording) |
 | `gh pr view`/`gh issue view` probe returns gh's own "could not resolve to a PullRequest/Issue" not-found message, or a bare non-zero exit with empty stderr at gh's normal API-error exit code (`1`) | `ambiguous` (genuine not-found, unchanged) |
 | A probe failure occurs partway through a multi-token list (after at least one token already resolved successfully) | `tracker_unavailable` (not masked by the earlier successful resolution) |
 
@@ -145,7 +154,7 @@ RESOLVED_SCOPE=<comma-separated list of resolved concrete targets, or "(none)" f
 ```
 HELD_BACK=<comma-separated list of items held back with reason, or "(none)">
 OUT_OF_SCOPE=<comma-separated list of out-of-scope items encountered, or "(none)">
-STOP_REASON=<human-readable stop reason when mode is ambiguous or tracker_unavailable, or run does not advance; for tracker_unavailable this names the probe-failure cause (rate limit, auth, network, or GitHub outage) and, for a rate limit, the quota reset time when available>
+STOP_REASON=<human-readable stop reason when mode is ambiguous or tracker_unavailable, or run does not advance; for tracker_unavailable this names the probe-failure cause (rate limit, auth, network, GitHub outage, or local repository-configuration error) and, for a rate limit, the quota reset time when available; a local repository-configuration error recommends running gh repo set-default instead of retrying>
 REDIRECT_COMMAND=<recommended /run-items, /run-item, or /run-epic command when mode is redirect_items, redirect_item, or redirect_epic>
 GUARDRAILS_MODE=<mode value from .ai-dev-workflow.yaml or "manual" (default)>
 GUARDRAILS_BACKLOG_START=<true|false (default: false)>
@@ -189,7 +198,7 @@ After the routing-decision record is emitted, `/run-work` hands off as follows:
 | `redirect_item`   | **No handoff** — emit `REDIRECT_COMMAND` (e.g. `/run-item <target>`); operator re-invokes `/run-item`                              |
 | `redirect_epic`   | **No handoff** — emit `REDIRECT_COMMAND` (e.g. `/run-epic --epic <n>`); operator re-invokes `/run-epic`                           |
 | `ambiguous`       | **No handoff** — record stop reason, perform no mutation, stop for a human decision                                                 |
-| `tracker_unavailable` | **No handoff** — record the cause-specific stop reason, perform no mutation, and recommend the operator retry once the underlying `gh` failure clears (immediately for auth/network fixes, or after the reported quota reset time for a rate limit) rather than treating the target as unresolved |
+| `tracker_unavailable` | **No handoff** — record the cause-specific stop reason, perform no mutation, and recommend the operator retry once the underlying `gh` failure clears (immediately for auth/network fixes, or after the reported quota reset time for a rate limit) rather than treating the target as unresolved. For a local repository-configuration error (no default remote configured), the recommendation is `gh repo set-default`, not a retry — retrying will not change the outcome. |
 
 The routing layer does not replace Protocols 90, 91, or 95. `/run-work` is a
 proposal surface only. Execution is delegated to `/run-items`, `/run-item`, or

--- a/docs/workflow/development-workflow/protocols/96-run-work-routing-protocol.md
+++ b/docs/workflow/development-workflow/protocols/96-run-work-routing-protocol.md
@@ -1,6 +1,6 @@
 # Protocol 96: /run-work Routing
 
-**Routing layer version**: 1.0
+**Routing layer version**: 1.1
 **Status**: Active
 
 This protocol is the canonical specification for how `/run-work` classifies an
@@ -27,7 +27,7 @@ redirect to `/run-items`. The human then executes the recommended command.
 This protocol defines:
 
 1. The **routing modes** and their code values (`no_target_scan`, `redirect_items`,
-   `redirect_item`, `redirect_epic`, `ambiguous`).
+   `redirect_item`, `redirect_epic`, `ambiguous`, `tracker_unavailable`).
 2. The **deterministic routing decision table** that maps (input + discovered state
    + configuration) → routing mode.
 3. The **routing-decision record** format every invocation must emit.
@@ -44,6 +44,7 @@ This protocol defines:
 | `redirect_item`   | Redirect (item)    | Single non-epic target resolved; `/run-work` performs **no mutation** and emits redirect to `/run-item`.                                               |
 | `redirect_epic`   | Redirect (epic)    | Epic-like or `--epic` target; `/run-work` performs **no mutation** and emits redirect to `/run-epic`.                                                   |
 | `ambiguous`       | Ambiguous          | Cannot resolve deterministically; records stop reason and performs no mutation.                                                                         |
+| `tracker_unavailable` | Tracker unavailable | A `gh` probe used to resolve a target failed (rate limit, auth, network, or a GitHub outage) rather than confirming the target does not exist; records a cause-specific stop reason and performs no mutation. Distinct from `ambiguous`, which means the input itself could not be resolved, not that the resolution attempt errored. |
 
 **Valid transitions**:
 
@@ -52,6 +53,11 @@ This protocol defines:
 - Single non-epic targets resolve to `redirect_item` (not Protocol 91 under `/run-work`).
 - Single epic-like targets and `--epic` resolve to `redirect_epic` (not Protocol 95 under `/run-work`).
 - Any unresolved input → `ambiguous`.
+- Any input whose resolution could not be determined because the underlying
+  `gh` probe itself failed (rate limit, auth failure, network error, GitHub
+  outage) → `tracker_unavailable`, not `ambiguous`. A genuine not-found result
+  (the probe succeeded and confirmed no matching target) still resolves to
+  `ambiguous`.
 
 ---
 
@@ -69,6 +75,7 @@ encodes the same rows. Every row maps to at least one automated test in
 | Exactly one target token that is explicitly marked as an epic (e.g., `--epic <n>` flag) | `redirect_epic` | UC5, BR6, AC6 |
 | Two or more explicit target tokens (after duplicate collapse) that each resolve to a concrete target | `redirect_items` | UC3, BR5, AC3 |
 | Any input that cannot be deterministically resolved: unresolvable lookalike token, mixed list with at least one unresolvable token, or a single token matching two different concrete artifacts (conflicting signal) | `ambiguous` | BR2, BR10, AC11 |
+| A `gh` probe used to resolve a token failed with a rate limit, auth failure, network error, or GitHub outage — the probe itself errored rather than confirming the target does not exist (single token, or the first such failure encountered in a multi-token list) | `tracker_unavailable` | #1503 |
 
 **Edge cases** (all must be covered by automated tests):
 
@@ -87,6 +94,12 @@ encodes the same rows. Every row maps to at least one automated test in
 | Unresolvable lookalike (e.g., `999999` with no matching artifact) | `ambiguous` |
 | Mixed list with one unresolvable token (`42 not-a-target`) | `ambiguous` |
 | Single token matching two different artifacts (branch + issue collision) | `ambiguous` |
+| `gh pr view`/`gh issue view` probe fails with a rate-limit error while resolving a token | `tracker_unavailable` |
+| `gh pr view`/`gh issue view` probe fails with an authentication error while resolving a token | `tracker_unavailable` |
+| `gh pr view`/`gh issue view` probe fails with a network error while resolving a token | `tracker_unavailable` |
+| `gh pr view`/`gh issue view` probe fails with an unrecognized/opaque error (GitHub outage) while resolving a token | `tracker_unavailable` |
+| `gh pr view`/`gh issue view` probe returns gh's own "could not resolve to a PullRequest/Issue" not-found message, or a bare non-zero exit with empty stderr at gh's normal API-error exit code (`1`) | `ambiguous` (genuine not-found, unchanged) |
+| A probe failure occurs partway through a multi-token list (after at least one token already resolved successfully) | `tracker_unavailable` (not masked by the earlier successful resolution) |
 
 ---
 
@@ -132,7 +145,7 @@ RESOLVED_SCOPE=<comma-separated list of resolved concrete targets, or "(none)" f
 ```
 HELD_BACK=<comma-separated list of items held back with reason, or "(none)">
 OUT_OF_SCOPE=<comma-separated list of out-of-scope items encountered, or "(none)">
-STOP_REASON=<human-readable stop reason when mode is ambiguous or run does not advance>
+STOP_REASON=<human-readable stop reason when mode is ambiguous or tracker_unavailable, or run does not advance; for tracker_unavailable this names the probe-failure cause (rate limit, auth, network, or GitHub outage) and, for a rate limit, the quota reset time when available>
 REDIRECT_COMMAND=<recommended /run-items, /run-item, or /run-epic command when mode is redirect_items, redirect_item, or redirect_epic>
 GUARDRAILS_MODE=<mode value from .ai-dev-workflow.yaml or "manual" (default)>
 GUARDRAILS_BACKLOG_START=<true|false (default: false)>
@@ -176,6 +189,7 @@ After the routing-decision record is emitted, `/run-work` hands off as follows:
 | `redirect_item`   | **No handoff** — emit `REDIRECT_COMMAND` (e.g. `/run-item <target>`); operator re-invokes `/run-item`                              |
 | `redirect_epic`   | **No handoff** — emit `REDIRECT_COMMAND` (e.g. `/run-epic --epic <n>`); operator re-invokes `/run-epic`                           |
 | `ambiguous`       | **No handoff** — record stop reason, perform no mutation, stop for a human decision                                                 |
+| `tracker_unavailable` | **No handoff** — record the cause-specific stop reason, perform no mutation, and recommend the operator retry once the underlying `gh` failure clears (immediately for auth/network fixes, or after the reported quota reset time for a rate limit) rather than treating the target as unresolved |
 
 The routing layer does not replace Protocols 90, 91, or 95. `/run-work` is a
 proposal surface only. Execution is delegated to `/run-items`, `/run-item`, or

--- a/scripts/development-workflow/run-work-router.sh
+++ b/scripts/development-workflow/run-work-router.sh
@@ -3,6 +3,7 @@
 #
 # Classifies a /run-work invocation into one routing mode:
 #   no_target_scan | redirect_items | redirect_item | redirect_epic | ambiguous
+#   | tracker_unavailable
 #
 # The script is READ-ONLY: it must not update tracker status, create branches,
 # open/edit/merge PRs, close issues, delete branches, or post comments.
@@ -34,12 +35,14 @@ MODE_REDIRECT_ITEM="redirect_item"
 MODE_REDIRECT_ITEMS="redirect_items"
 MODE_REDIRECT_EPIC="redirect_epic"
 MODE_AMBIGUOUS="ambiguous"
+MODE_TRACKER_UNAVAILABLE="tracker_unavailable"
 
 LABEL_NO_TARGET="No-target scan"
 LABEL_REDIRECT_ITEM="Redirect (item)"
 LABEL_REDIRECT_ITEMS="Redirect (items)"
 LABEL_REDIRECT_EPIC="Redirect (epic)"
 LABEL_AMBIGUOUS="Ambiguous"
+LABEL_TRACKER_UNAVAILABLE="Tracker unavailable"
 
 # ---------------------------------------------------------------------------
 # Usage
@@ -57,6 +60,10 @@ Classifies a /run-work invocation into one routing mode:
   redirect_item    Single non-epic target; redirect to /run-item (no mutation).
   redirect_epic    Epic-like target; redirect to /run-epic (no mutation).
   ambiguous        Cannot deterministically resolve; no mutation allowed.
+  tracker_unavailable
+                   A gh probe failed (rate limit, auth, network, or GitHub
+                   outage) rather than confirming the target does not exist;
+                   retry once the underlying cause clears. No mutation allowed.
 
 Flags:
   --epic <n>   Treat <n> as an explicit epic target (skips is_epic_issue check).
@@ -266,6 +273,159 @@ RESOLVED_KIND=""
 # Caller should use this to populate STOP_REASON when the generic message is
 # insufficient (e.g., gh CLI missing vs. item not found).
 RESOLVE_FAIL_REASON=""
+# Set by resolve_token alongside RESOLVE_FAIL_REASON when the failure is a
+# probe failure (gh call errored) rather than a confirmed not-found. Callers
+# use this to route to MODE_TRACKER_UNAVAILABLE instead of MODE_AMBIGUOUS.
+# Values: "" (default — genuine not-found / other unresolvable) |
+#         "tracker_unavailable"
+RESOLVE_FAIL_KIND=""
+
+# ---------------------------------------------------------------------------
+# Helper: run a gh probe capturing stdout, stderr, and exit code separately.
+#
+# Unlike `gh ... 2>/dev/null || true`, this lets callers distinguish a probe
+# failure (rate limit, auth, network, GitHub outage) from a successful call
+# that simply found nothing. Sets PROBE_OUT, PROBE_ERR, PROBE_EXIT. Never
+# triggers `set -e` regardless of the underlying gh exit status, and restores
+# the caller's original errexit state on return rather than forcing it back
+# on — callers (resolve_token's call sites) rely on `set +e` remaining in
+# effect around the whole resolve_token() call, and unconditionally
+# re-enabling errexit here would make a later `return 1` from resolve_token
+# terminate the script immediately instead of letting the caller inspect $?.
+# ---------------------------------------------------------------------------
+
+PROBE_OUT=""
+PROBE_ERR=""
+PROBE_EXIT=0
+
+gh_probe() {
+  local err_file errexit_was_set
+  errexit_was_set=0
+  case "$-" in *e*) errexit_was_set=1 ;; esac
+  err_file="$(mktemp)"
+  set +e
+  PROBE_OUT="$(gh "$@" 2>"$err_file")"
+  PROBE_EXIT=$?
+  if [ "$errexit_was_set" -eq 1 ]; then
+    set -e
+  fi
+  PROBE_ERR="$(cat "$err_file" 2>/dev/null)"
+  rm -f "$err_file"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: classify a gh probe's stderr into a failure cause.
+#
+# Echoes one of: not_found | rate_limited | auth_failed | network_error |
+# github_unavailable
+#
+# A confirmed "not found" response (gh's own "could not resolve to a
+# PullRequest/Issue" message, or an empty stderr — gh's historical behavior
+# for this repo's probes) is classified as not_found so genuinely unknown
+# targets keep resolving to MODE_AMBIGUOUS exactly as before. Anything else
+# non-empty and unrecognized falls back to github_unavailable so opaque
+# outages are treated as probe failures rather than silently swallowed as
+# not-found.
+# ---------------------------------------------------------------------------
+
+classify_gh_probe_error() {
+  local err="$1"
+  local err_lc
+  err_lc="$(printf '%s' "$err" | tr '[:upper:]' '[:lower:]')"
+
+  if [ -z "$err_lc" ]; then
+    echo "not_found"
+    return 0
+  fi
+
+  case "$err_lc" in
+    *"could not resolve to a pullrequest"*|*"could not resolve to an issue"*|*"no pull requests found"*|*"no default remote repository has been set"*)
+      echo "not_found"
+      return 0
+      ;;
+  esac
+
+  case "$err_lc" in
+    *"api rate limit"*|*"rate limit exceeded"*|*"secondary rate limit"*)
+      echo "rate_limited"
+      return 0
+      ;;
+  esac
+
+  case "$err_lc" in
+    *"gh auth login"*|*"gh auth refresh"*|*"not logged into"*|*"bad credentials"*|*"requires authentication"*|*"http 401"*|*"401 unauthorized"*|*"authentication required"*)
+      echo "auth_failed"
+      return 0
+      ;;
+  esac
+
+  case "$err_lc" in
+    *"could not resolve host"*|*"connection refused"*|*"connection reset"*|*"network is unreachable"*|*"no such host"*|*"context deadline exceeded"*|*"timed out"*|*"dial tcp"*)
+      echo "network_error"
+      return 0
+      ;;
+  esac
+
+  echo "github_unavailable"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: best-effort rate-limit reset time for the reason string.
+#
+# Queries `gh api rate_limit` for the GraphQL quota reset epoch and formats
+# it as UTC. Never fails the caller — an unavailable/erroring rate_limit call
+# just omits the timestamp from the reason string.
+# ---------------------------------------------------------------------------
+
+gh_rate_limit_reset_info() {
+  local reset_epoch
+  reset_epoch="$(gh api rate_limit --jq '.resources.graphql.reset' 2>/dev/null)" || reset_epoch="" # workflow-shell-guard: allow SH001 - best-effort diagnostic lookup, failure just omits the reset timestamp
+  case "${reset_epoch:-}" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+
+  local reset_human=""
+  if date -u -d "@$reset_epoch" '+%Y-%m-%dT%H:%M:%SZ' >/dev/null 2>&1; then
+    reset_human="$(date -u -d "@$reset_epoch" '+%Y-%m-%dT%H:%M:%SZ')"
+  elif date -u -r "$reset_epoch" '+%Y-%m-%dT%H:%M:%SZ' >/dev/null 2>&1; then
+    reset_human="$(date -u -r "$reset_epoch" '+%Y-%m-%dT%H:%M:%SZ')"
+  fi
+
+  if [ -n "$reset_human" ]; then
+    printf 'retry after %s UTC (rate limit resets then)' "$reset_human"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: build the RESOLVE_FAIL_REASON text for a classified probe failure.
+# ---------------------------------------------------------------------------
+
+build_probe_fail_reason() {
+  local kind="$1" token="$2" err="$3"
+  case "$kind" in
+    rate_limited)
+      local reset_info
+      reset_info="$(gh_rate_limit_reset_info)"
+      if [ -n "$reset_info" ]; then
+        printf "GitHub API rate limit exceeded while resolving target '%s'; %s" "$token" "$reset_info"
+      else
+        printf "GitHub API rate limit exceeded while resolving target '%s'; retry after the rate limit resets" "$token"
+      fi
+      ;;
+    auth_failed)
+      printf "GitHub authentication failed while resolving target '%s'; run 'gh auth login' (or 'gh auth refresh') and retry" "$token"
+      ;;
+    network_error)
+      printf "Network error contacting GitHub while resolving target '%s'; check connectivity and retry" "$token"
+      ;;
+    github_unavailable)
+      printf "GitHub appears unavailable while resolving target '%s' (gh reported: %s); retry shortly" "$token" "$(printf '%s' "$err" | head -n1)"
+      ;;
+    *)
+      printf "gh probe failed while resolving target '%s'" "$token"
+      ;;
+  esac
+}
 
 resolve_token() {
   local token="$1"
@@ -273,6 +433,7 @@ resolve_token() {
   REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
   RESOLVED_KIND="none"
   RESOLVE_FAIL_REASON=""
+  RESOLVE_FAIL_KIND=""
 
   # Normalize: strip leading ./ so ./docs/specs/developments/... matches correctly
   token="${token#./}"
@@ -290,20 +451,44 @@ resolve_token() {
   if is_positive_int "$pr_num"; then
     # Try as a PR first; if that fails, try as an issue
     if have_cmd gh; then
-      local pr_state
-      pr_state="$(gh pr view "$pr_num" --json state --jq '.state' 2>/dev/null)" || true # workflow-shell-guard: allow SH001 - type probe; failure expected when target is not a PR, result checked by caller
-      if [ -n "$pr_state" ]; then
+      local pr_class issue_class
+
+      gh_probe pr view "$pr_num" --json state --jq '.state'
+      if [ "$PROBE_EXIT" -eq 0 ] && [ -n "$PROBE_OUT" ]; then
         RESOLVED_KIND="pr"
         return 0
       fi
+      if [ "$PROBE_EXIT" -ne 0 ]; then
+        pr_class="$(classify_gh_probe_error "$PROBE_ERR")"
+        if [ "$pr_class" != "not_found" ]; then
+          # gh call itself failed (rate limit, auth, network, outage) rather
+          # than confirming the target is not a PR — do not fall through to
+          # the issue probe and do not treat this as a genuine not-found.
+          RESOLVE_FAIL_KIND="tracker_unavailable"
+          RESOLVE_FAIL_REASON="$(build_probe_fail_reason "$pr_class" "$token" "$PROBE_ERR")"
+          RESOLVED_KIND="none"
+          return 1
+        fi
+      fi
+
       # Try as issue
-      local issue_state
-      issue_state="$(gh issue view "$pr_num" --json state --jq '.state' 2>/dev/null)" || true # workflow-shell-guard: allow SH001 - type probe; failure expected when target is not an issue, result checked by caller
-      if [ -n "$issue_state" ]; then
+      gh_probe issue view "$pr_num" --json state --jq '.state'
+      if [ "$PROBE_EXIT" -eq 0 ] && [ -n "$PROBE_OUT" ]; then
         RESOLVED_KIND="issue"
         return 0
       fi
-      # gh available but token is neither an open PR nor an open issue.
+      if [ "$PROBE_EXIT" -ne 0 ]; then
+        issue_class="$(classify_gh_probe_error "$PROBE_ERR")"
+        if [ "$issue_class" != "not_found" ]; then
+          RESOLVE_FAIL_KIND="tracker_unavailable"
+          RESOLVE_FAIL_REASON="$(build_probe_fail_reason "$issue_class" "$token" "$PROBE_ERR")"
+          RESOLVED_KIND="none"
+          return 1
+        fi
+      fi
+
+      # gh available, both probes succeeded, and token is neither an open PR
+      # nor an open issue — a genuine not-found.
       RESOLVED_KIND="none"
       return 1
     else
@@ -443,9 +628,16 @@ elif [ "${#deduped_tokens[@]}" -eq 1 ]; then
   set -e
 
   if [ "$resolve_exit" -ne 0 ]; then
-    # Unresolvable token → ambiguous
-    MODE="$MODE_AMBIGUOUS"
-    MODE_LABEL="$LABEL_AMBIGUOUS"
+    # Unresolvable token → ambiguous, unless the failure was a gh probe
+    # failure (rate limit, auth, network, outage) rather than a confirmed
+    # not-found, in which case it is distinctly tracker_unavailable.
+    if [ "${RESOLVE_FAIL_KIND:-}" = "tracker_unavailable" ]; then
+      MODE="$MODE_TRACKER_UNAVAILABLE"
+      MODE_LABEL="$LABEL_TRACKER_UNAVAILABLE"
+    else
+      MODE="$MODE_AMBIGUOUS"
+      MODE_LABEL="$LABEL_AMBIGUOUS"
+    fi
     if [ -n "${RESOLVE_FAIL_REASON:-}" ]; then
       STOP_REASON="$RESOLVE_FAIL_REASON"
     else
@@ -484,6 +676,7 @@ else
   all_resolved=1
   resolved_list=()
   first_unresolvable=""
+  first_unresolvable_fail_kind=""
 
   for t in "${deduped_tokens[@]}"; do
     set +e
@@ -494,14 +687,23 @@ else
     if [ "$res_exit" -ne 0 ]; then
       all_resolved=0
       first_unresolvable="$t"
+      first_unresolvable_fail_kind="${RESOLVE_FAIL_KIND:-}"
       break
     fi
     resolved_list+=("$t")
   done
 
   if [ "$all_resolved" -eq 0 ]; then
-    MODE="$MODE_AMBIGUOUS"
-    MODE_LABEL="$LABEL_AMBIGUOUS"
+    # Unresolvable token → ambiguous, unless the failure was a gh probe
+    # failure (rate limit, auth, network, outage) rather than a confirmed
+    # not-found, in which case it is distinctly tracker_unavailable.
+    if [ "$first_unresolvable_fail_kind" = "tracker_unavailable" ]; then
+      MODE="$MODE_TRACKER_UNAVAILABLE"
+      MODE_LABEL="$LABEL_TRACKER_UNAVAILABLE"
+    else
+      MODE="$MODE_AMBIGUOUS"
+      MODE_LABEL="$LABEL_AMBIGUOUS"
+    fi
     if [ -n "${RESOLVE_FAIL_REASON:-}" ]; then
       STOP_REASON="$RESOLVE_FAIL_REASON"
     else

--- a/scripts/development-workflow/run-work-router.sh
+++ b/scripts/development-workflow/run-work-router.sh
@@ -306,35 +306,48 @@ gh_probe() {
   set +e
   PROBE_OUT="$(gh "$@" 2>"$err_file")"
   PROBE_EXIT=$?
+  # Capture stderr and clean up the temp file while errexit is still
+  # disabled — a failing `cat` (e.g. the temp file became unreadable) must
+  # not itself trigger `set -e` and terminate the script ahead of the
+  # caller's own `$?` check, once errexit is restored below.
+  PROBE_ERR="$(cat "$err_file" 2>/dev/null)"
+  rm -f "$err_file" 2>/dev/null
   if [ "$errexit_was_set" -eq 1 ]; then
     set -e
   fi
-  PROBE_ERR="$(cat "$err_file" 2>/dev/null)"
-  rm -f "$err_file"
 }
 
 # ---------------------------------------------------------------------------
-# Helper: classify a gh probe's stderr into a failure cause.
+# Helper: classify a gh probe's stderr (and exit code) into a failure cause.
 #
 # Echoes one of: not_found | rate_limited | auth_failed | network_error |
 # github_unavailable
 #
 # A confirmed "not found" response (gh's own "could not resolve to a
-# PullRequest/Issue" message, or an empty stderr — gh's historical behavior
-# for this repo's probes) is classified as not_found so genuinely unknown
-# targets keep resolving to MODE_AMBIGUOUS exactly as before. Anything else
-# non-empty and unrecognized falls back to github_unavailable so opaque
-# outages are treated as probe failures rather than silently swallowed as
-# not-found.
+# PullRequest/Issue" message) is classified as not_found so genuinely unknown
+# targets keep resolving to MODE_AMBIGUOUS exactly as before. An empty stderr
+# is only treated as not_found when the exit code is gh's normal API-error
+# exit code (1) — this repo's probes have historically seen exit 1 with no
+# captured stderr for a genuine not-found. An empty stderr paired with any
+# other exit code (a signal death, an OOM kill, a shell-level launch failure,
+# etc.) is NOT assumed to be a not-found — it falls back to
+# github_unavailable, since gh crashing or being killed is a probe failure,
+# not evidence the target doesn't exist. Any other non-empty, unrecognized
+# stderr also falls back to github_unavailable so opaque outages are treated
+# as probe failures rather than silently swallowed as not-found.
 # ---------------------------------------------------------------------------
 
 classify_gh_probe_error() {
-  local err="$1"
+  local err="$1" exit_code="${2:-1}"
   local err_lc
   err_lc="$(printf '%s' "$err" | tr '[:upper:]' '[:lower:]')"
 
   if [ -z "$err_lc" ]; then
-    echo "not_found"
+    if [ "$exit_code" = "1" ]; then
+      echo "not_found"
+    else
+      echo "github_unavailable"
+    fi
     return 0
   fi
 
@@ -459,7 +472,7 @@ resolve_token() {
         return 0
       fi
       if [ "$PROBE_EXIT" -ne 0 ]; then
-        pr_class="$(classify_gh_probe_error "$PROBE_ERR")"
+        pr_class="$(classify_gh_probe_error "$PROBE_ERR" "$PROBE_EXIT")"
         if [ "$pr_class" != "not_found" ]; then
           # gh call itself failed (rate limit, auth, network, outage) rather
           # than confirming the target is not a PR — do not fall through to
@@ -478,7 +491,7 @@ resolve_token() {
         return 0
       fi
       if [ "$PROBE_EXIT" -ne 0 ]; then
-        issue_class="$(classify_gh_probe_error "$PROBE_ERR")"
+        issue_class="$(classify_gh_probe_error "$PROBE_ERR" "$PROBE_EXIT")"
         if [ "$issue_class" != "not_found" ]; then
           RESOLVE_FAIL_KIND="tracker_unavailable"
           RESOLVE_FAIL_REASON="$(build_probe_fail_reason "$issue_class" "$token" "$PROBE_ERR")"

--- a/scripts/development-workflow/run-work-router.sh
+++ b/scripts/development-workflow/run-work-router.sh
@@ -302,15 +302,32 @@ gh_probe() {
   local err_file errexit_was_set
   errexit_was_set=0
   case "$-" in *e*) errexit_was_set=1 ;; esac
-  err_file="$(mktemp)"
   set +e
+  # If temp-file setup itself fails, do not let a resulting empty PROBE_ERR
+  # be misread downstream as gh's own empty-stderr not-found case (exit 1).
+  # Use exit code 125 (a value gh itself never returns) with a diagnostic
+  # PROBE_ERR so classify_gh_probe_error() correctly treats this as an
+  # infrastructure failure (github_unavailable), not a not-found.
+  if ! err_file="$(mktemp)"; then
+    PROBE_OUT=""
+    PROBE_ERR="gh_probe: mktemp failed while preparing to capture gh stderr"
+    PROBE_EXIT=125
+    if [ "$errexit_was_set" -eq 1 ]; then
+      set -e
+    fi
+    return 0
+  fi
   PROBE_OUT="$(gh "$@" 2>"$err_file")"
   PROBE_EXIT=$?
   # Capture stderr and clean up the temp file while errexit is still
   # disabled — a failing `cat` (e.g. the temp file became unreadable) must
   # not itself trigger `set -e` and terminate the script ahead of the
   # caller's own `$?` check, once errexit is restored below.
-  PROBE_ERR="$(cat "$err_file" 2>/dev/null)"
+  if ! PROBE_ERR="$(cat "$err_file")"; then
+    PROBE_OUT=""
+    PROBE_ERR="gh_probe: failed to read captured gh stderr"
+    PROBE_EXIT=125
+  fi
   rm -f "$err_file" 2>/dev/null
   if [ "$errexit_was_set" -eq 1 ]; then
     set -e
@@ -334,7 +351,11 @@ gh_probe() {
 # github_unavailable, since gh crashing or being killed is a probe failure,
 # not evidence the target doesn't exist. Any other non-empty, unrecognized
 # stderr also falls back to github_unavailable so opaque outages are treated
-# as probe failures rather than silently swallowed as not-found.
+# as probe failures rather than silently swallowed as not-found. This
+# deliberately includes gh's "no default remote repository has been set"
+# message — that is a local repository-configuration error (gh cannot
+# determine which repository to query), not confirmation that the PR or
+# issue does not exist, so it must NOT be classified as not_found.
 # ---------------------------------------------------------------------------
 
 classify_gh_probe_error() {
@@ -352,7 +373,7 @@ classify_gh_probe_error() {
   fi
 
   case "$err_lc" in
-    *"could not resolve to a pullrequest"*|*"could not resolve to an issue"*|*"no pull requests found"*|*"no default remote repository has been set"*)
+    *"could not resolve to a pullrequest"*|*"could not resolve to an issue"*|*"no pull requests found"*)
       echo "not_found"
       return 0
       ;;

--- a/scripts/development-workflow/run-work-router.sh
+++ b/scripts/development-workflow/run-work-router.sh
@@ -338,7 +338,7 @@ gh_probe() {
 # Helper: classify a gh probe's stderr (and exit code) into a failure cause.
 #
 # Echoes one of: not_found | rate_limited | auth_failed | network_error |
-# github_unavailable
+# local_config_error | github_unavailable
 #
 # A confirmed "not found" response (gh's own "could not resolve to a
 # PullRequest/Issue" message) is classified as not_found so genuinely unknown
@@ -349,13 +349,15 @@ gh_probe() {
 # other exit code (a signal death, an OOM kill, a shell-level launch failure,
 # etc.) is NOT assumed to be a not-found — it falls back to
 # github_unavailable, since gh crashing or being killed is a probe failure,
-# not evidence the target doesn't exist. Any other non-empty, unrecognized
-# stderr also falls back to github_unavailable so opaque outages are treated
-# as probe failures rather than silently swallowed as not-found. This
-# deliberately includes gh's "no default remote repository has been set"
-# message — that is a local repository-configuration error (gh cannot
-# determine which repository to query), not confirmation that the PR or
-# issue does not exist, so it must NOT be classified as not_found.
+# not evidence the target doesn't exist. gh's "no default remote repository
+# has been set" message is a local repository-configuration error (gh
+# cannot determine which repository to query, independent of GitHub's
+# availability) — it must NOT be classified as not_found, and is kept
+# distinct from github_unavailable because the operator fix is local
+# ("gh repo set-default"), not "wait and retry". Any other non-empty,
+# unrecognized stderr falls back to github_unavailable so opaque outages
+# are treated as probe failures rather than silently swallowed as
+# not-found.
 # ---------------------------------------------------------------------------
 
 classify_gh_probe_error() {
@@ -396,6 +398,13 @@ classify_gh_probe_error() {
   case "$err_lc" in
     *"could not resolve host"*|*"connection refused"*|*"connection reset"*|*"network is unreachable"*|*"no such host"*|*"context deadline exceeded"*|*"timed out"*|*"dial tcp"*)
       echo "network_error"
+      return 0
+      ;;
+  esac
+
+  case "$err_lc" in
+    *"no default remote repository has been set"*|*"could not determine base repo"*)
+      echo "local_config_error"
       return 0
       ;;
   esac
@@ -451,6 +460,9 @@ build_probe_fail_reason() {
       ;;
     network_error)
       printf "Network error contacting GitHub while resolving target '%s'; check connectivity and retry" "$token"
+      ;;
+    local_config_error)
+      printf "gh could not determine which repository to query while resolving target '%s' (gh reported: %s); run 'gh repo set-default' in this checkout — retrying will not help until the default repository is configured" "$token" "$(printf '%s' "$err" | head -n1)"
       ;;
     github_unavailable)
       printf "GitHub appears unavailable while resolving target '%s' (gh reported: %s); retry shortly" "$token" "$(printf '%s' "$err" | head -n1)"

--- a/scripts/development-workflow/run-work-router.sh
+++ b/scripts/development-workflow/run-work-router.sh
@@ -335,8 +335,12 @@ gh_probe() {
   # result (e.g. a PR that was actually found) and misreport it as a probe
   # failure over a benign filesystem cleanup blip, unrelated to whether gh
   # itself succeeded. `--` guards against a pathological temp path starting
-  # with `-`, though mktemp never generates one.
-  rm -f -- "$err_file" 2>/dev/null
+  # with `-`, though mktemp never generates one. A cleanup failure is still
+  # reported (rather than silently swallowed) so a stray leftover temp file
+  # is visible for diagnosis, without affecting the routing decision.
+  if ! rm -f -- "$err_file" 2>/dev/null; then
+    echo "run-work-router: warning: failed to remove temp file '$err_file' used to capture gh stderr" >&2
+  fi
   if [ "$errexit_was_set" -eq 1 ]; then
     set -e
   fi

--- a/scripts/development-workflow/run-work-router.sh
+++ b/scripts/development-workflow/run-work-router.sh
@@ -328,7 +328,15 @@ gh_probe() {
     PROBE_ERR="gh_probe: failed to read captured gh stderr"
     PROBE_EXIT=125
   fi
-  rm -f "$err_file" 2>/dev/null
+  # Best-effort cleanup only. PROBE_OUT/PROBE_ERR/PROBE_EXIT above already
+  # correctly reflect gh's own result (including a genuine successful
+  # resolution) — a failure to delete the now-fully-read temp file must NOT
+  # overwrite them: doing so would discard an already-valid successful probe
+  # result (e.g. a PR that was actually found) and misreport it as a probe
+  # failure over a benign filesystem cleanup blip, unrelated to whether gh
+  # itself succeeded. `--` guards against a pathological temp path starting
+  # with `-`, though mktemp never generates one.
+  rm -f -- "$err_file" 2>/dev/null
   if [ "$errexit_was_set" -eq 1 ]; then
     set -e
   fi

--- a/scripts/development-workflow/tests/test-run-work-router.sh
+++ b/scripts/development-workflow/tests/test-run-work-router.sh
@@ -119,6 +119,9 @@ esac
 #   888886 — gh probe fails with empty stderr and a non-1 exit code (e.g. the
 #            gh binary itself crashed or was signal-killed) — must NOT be
 #            misclassified as not_found the way a bare exit-1/empty-stderr is
+#   888887 — gh probe fails with "no default remote repository has been set"
+#            (a local repo-configuration error) — must NOT be classified as
+#            not_found; it is not confirmation the target doesn't exist
 case "$*" in
   pr\ view\ 888881\ --json\ state\ --jq\ .state)
     printf 'API rate limit exceeded for user ID 1148259 (https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting)\n' >&2
@@ -154,6 +157,14 @@ case "$*" in
     ;;
   issue\ view\ 888886\ --json\ state\ --jq\ .state)
     exit 137
+    ;;
+  pr\ view\ 888887\ --json\ state\ --jq\ .state)
+    printf 'no default remote repository has been set\n' >&2
+    exit 1
+    ;;
+  issue\ view\ 888887\ --json\ state\ --jq\ .state)
+    printf 'no default remote repository has been set\n' >&2
+    exit 1
     ;;
 esac
 
@@ -613,6 +624,15 @@ run_test "crash_empty_stderr_nonone_exit_mode" "tracker_unavailable" \
   "$(printf '%s\n' "$output_crash_empty_stderr" | grep '^MODE=' | cut -d= -f2-)"
 run_test_contains "crash_empty_stderr_nonone_exit_stop_reason" "unavailable" \
   "$(printf '%s\n' "$output_crash_empty_stderr" | grep '^STOP_REASON=' | cut -d= -f2-)"
+
+# "no default remote repository has been set" is a local repo-configuration
+# error, not confirmation that the target doesn't exist — must NOT be
+# classified as not_found (CodeRabbit finding on PR #1541).
+output_no_default_remote="$(router_output "888887")"
+run_test "no_default_remote_probe_mode" "tracker_unavailable" \
+  "$(printf '%s\n' "$output_no_default_remote" | grep '^MODE=' | cut -d= -f2-)"
+run_test_contains "no_default_remote_probe_stop_reason" "unavailable" \
+  "$(printf '%s\n' "$output_no_default_remote" | grep '^STOP_REASON=' | cut -d= -f2-)"
 
 # Multi-target list: a probe failure partway through the list must still
 # surface as tracker_unavailable, not ambiguous, and must not be masked by

--- a/scripts/development-workflow/tests/test-run-work-router.sh
+++ b/scripts/development-workflow/tests/test-run-work-router.sh
@@ -627,11 +627,15 @@ run_test_contains "crash_empty_stderr_nonone_exit_stop_reason" "unavailable" \
 
 # "no default remote repository has been set" is a local repo-configuration
 # error, not confirmation that the target doesn't exist — must NOT be
-# classified as not_found (CodeRabbit finding on PR #1541).
+# classified as not_found (CodeRabbit finding on PR #1541), and gets its own
+# distinct, actionable STOP_REASON (local_config_error) instead of the
+# generic "retry shortly" github_unavailable message, since the operator fix
+# here is local configuration, not waiting out an outage (CodeRabbit
+# late-arriving finding on the same PR).
 output_no_default_remote="$(router_output "888887")"
 run_test "no_default_remote_probe_mode" "tracker_unavailable" \
   "$(printf '%s\n' "$output_no_default_remote" | grep '^MODE=' | cut -d= -f2-)"
-run_test_contains "no_default_remote_probe_stop_reason" "unavailable" \
+run_test_contains "no_default_remote_probe_stop_reason" "gh repo set-default" \
   "$(printf '%s\n' "$output_no_default_remote" | grep '^STOP_REASON=' | cut -d= -f2-)"
 
 # Multi-target list: a probe failure partway through the list must still

--- a/scripts/development-workflow/tests/test-run-work-router.sh
+++ b/scripts/development-workflow/tests/test-run-work-router.sh
@@ -100,6 +100,47 @@ case "$*" in
     printf 'lhpaul/ai-dev-framework-template\n'
     exit 0
     ;;
+  api\ rate_limit\ --jq\ '.resources.graphql.reset')
+    # Fixed far-future epoch (2100-01-01T00:00:00Z) so reset-time messages
+    # are deterministic without depending on wall-clock time.
+    printf '4102444800\n'
+    exit 0
+    ;;
+esac
+
+# ---- gh probe failures: rate limit / auth / network / outage ----
+# Issue numbers reserved for probe-failure regression tests (see issue #1503):
+#   888881 — gh probe fails with an API rate limit error
+#   888882 — gh probe fails with an authentication error
+#   888883 — gh probe fails with a network error
+#   888884 — gh probe fails with an unrecognized/opaque error (outage-style)
+#   888885 — gh probe fails with a genuine "could not resolve" not-found error
+#            (explicit not-found stderr text, not just a bare non-zero exit)
+case "$*" in
+  pr\ view\ 888881\ --json\ state\ --jq\ .state)
+    printf 'API rate limit exceeded for user ID 1148259 (https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting)\n' >&2
+    exit 1
+    ;;
+  pr\ view\ 888882\ --json\ state\ --jq\ .state)
+    printf 'gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.\nerror: not logged into any GitHub hosts. Run gh auth login\n' >&2
+    exit 1
+    ;;
+  pr\ view\ 888883\ --json\ state\ --jq\ .state)
+    printf 'error connecting to api.github.com\ndial tcp: lookup api.github.com: no such host\n' >&2
+    exit 1
+    ;;
+  pr\ view\ 888884\ --json\ state\ --jq\ .state)
+    printf 'HTTP 502: Bad Gateway\nSomething went wrong while executing your query. Unicorn! ...ready.\n' >&2
+    exit 1
+    ;;
+  pr\ view\ 888885\ --json\ state\ --jq\ .state)
+    printf 'GraphQL: Could not resolve to a PullRequest with the number of 888885. (repository.pullRequest)\n' >&2
+    exit 1
+    ;;
+  issue\ view\ 888885\ --json\ state\ --jq\ .state)
+    printf 'GraphQL: Could not resolve to an Issue with the number of 888885. (repository.issue)\n' >&2
+    exit 1
+    ;;
 esac
 
 emit_issue_subissues() {
@@ -492,6 +533,78 @@ run_test "mixed_list_mode" "ambiguous" \
   "$(printf '%s\n' "$output_mixed" | grep '^MODE=' | cut -d= -f2-)"
 run_test_contains "mixed_list_stop_reason" "999999" \
   "$(printf '%s\n' "$output_mixed" | grep '^STOP_REASON=' | cut -d= -f2-)"
+
+# --- gh probe failure classification (issue #1503) --------------------------
+#
+# resolve_token() must distinguish a gh probe failure (rate limit, auth,
+# network, GitHub outage) from a successful "not found" result. A probe
+# failure must route to MODE=tracker_unavailable with a distinct, actionable
+# STOP_REASON — not MODE=ambiguous, which tells the operator their target is
+# unrecognized when it is actually gh that failed.
+
+# Rate-limited probe → tracker_unavailable, reason names the cause and
+# includes the rate-limit reset time.
+output_rate_limited="$(router_output "888881")"
+run_test "rate_limited_probe_mode" "tracker_unavailable" \
+  "$(printf '%s\n' "$output_rate_limited" | grep '^MODE=' | cut -d= -f2-)"
+run_test_contains "rate_limited_probe_stop_reason_names_cause" "rate limit" \
+  "$(printf '%s\n' "$output_rate_limited" | grep '^STOP_REASON=' | cut -d= -f2-)"
+run_test_contains "rate_limited_probe_stop_reason_has_reset_time" "retry after" \
+  "$(printf '%s\n' "$output_rate_limited" | grep '^STOP_REASON=' | cut -d= -f2-)"
+
+# Auth-failed probe → tracker_unavailable, reason is actionable (gh auth login).
+output_auth_failed="$(router_output "888882")"
+run_test "auth_failed_probe_mode" "tracker_unavailable" \
+  "$(printf '%s\n' "$output_auth_failed" | grep '^MODE=' | cut -d= -f2-)"
+run_test_contains "auth_failed_probe_stop_reason" "gh auth login" \
+  "$(printf '%s\n' "$output_auth_failed" | grep '^STOP_REASON=' | cut -d= -f2-)"
+
+# Network-error probe → tracker_unavailable, distinct reason from auth/rate-limit.
+output_network_error="$(router_output "888883")"
+run_test "network_error_probe_mode" "tracker_unavailable" \
+  "$(printf '%s\n' "$output_network_error" | grep '^MODE=' | cut -d= -f2-)"
+run_test_contains "network_error_probe_stop_reason" "Network error" \
+  "$(printf '%s\n' "$output_network_error" | grep '^STOP_REASON=' | cut -d= -f2-)"
+
+# Opaque/outage probe (unrecognized gh error, not the specific not-found
+# message) → tracker_unavailable, falls back to github_unavailable framing.
+output_github_unavailable="$(router_output "888884")"
+run_test "github_unavailable_probe_mode" "tracker_unavailable" \
+  "$(printf '%s\n' "$output_github_unavailable" | grep '^MODE=' | cut -d= -f2-)"
+run_test_contains "github_unavailable_probe_stop_reason" "unavailable" \
+  "$(printf '%s\n' "$output_github_unavailable" | grep '^STOP_REASON=' | cut -d= -f2-)"
+
+# Genuine not-found with an explicit gh "could not resolve" error on BOTH
+# probes must still classify as not_found → MODE=ambiguous (unchanged
+# behavior), proving the fix does not turn every non-zero gh exit into
+# tracker_unavailable.
+output_explicit_not_found="$(router_output "888885")"
+run_test "explicit_not_found_probe_mode" "ambiguous" \
+  "$(printf '%s\n' "$output_explicit_not_found" | grep '^MODE=' | cut -d= -f2-)"
+run_test_contains "explicit_not_found_probe_stop_reason" "could not be resolved" \
+  "$(printf '%s\n' "$output_explicit_not_found" | grep '^STOP_REASON=' | cut -d= -f2-)"
+
+# Genuine not-found via a bare non-zero exit with no stderr (999999, existing
+# fixture) must also still classify as not_found → MODE=ambiguous. Re-asserted
+# here explicitly as part of the #1503 regression coverage.
+run_test "bare_exit_not_found_probe_mode_regression" "ambiguous" \
+  "$(printf '%s\n' "$output_noresol" | grep '^MODE=' | cut -d= -f2-)"
+
+# Multi-target list: a probe failure partway through the list must still
+# surface as tracker_unavailable, not ambiguous, and must not be masked by
+# an earlier successfully-resolved token.
+output_list_rate_limited="$(router_output "978" "888881")"
+run_test "list_rate_limited_mode" "tracker_unavailable" \
+  "$(printf '%s\n' "$output_list_rate_limited" | grep '^MODE=' | cut -d= -f2-)"
+run_test_contains "list_rate_limited_stop_reason" "rate limit" \
+  "$(printf '%s\n' "$output_list_rate_limited" | grep '^STOP_REASON=' | cut -d= -f2-)"
+
+# Happy path: a successful resolution (no probe failure at all) must be
+# entirely unaffected by the new probe-capturing path — reconfirmed here
+# alongside the failure-classification tests so the two are visibly compared
+# in the same regression block.
+run_test "happy_path_probe_regression" "redirect_item" \
+  "$(printf '%s\n' "$output_978" | grep '^MODE=' | cut -d= -f2-)"
 
 # --- Routing-decision record fields present (AC10) -------------------------
 

--- a/scripts/development-workflow/tests/test-run-work-router.sh
+++ b/scripts/development-workflow/tests/test-run-work-router.sh
@@ -116,6 +116,9 @@ esac
 #   888884 — gh probe fails with an unrecognized/opaque error (outage-style)
 #   888885 — gh probe fails with a genuine "could not resolve" not-found error
 #            (explicit not-found stderr text, not just a bare non-zero exit)
+#   888886 — gh probe fails with empty stderr and a non-1 exit code (e.g. the
+#            gh binary itself crashed or was signal-killed) — must NOT be
+#            misclassified as not_found the way a bare exit-1/empty-stderr is
 case "$*" in
   pr\ view\ 888881\ --json\ state\ --jq\ .state)
     printf 'API rate limit exceeded for user ID 1148259 (https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting)\n' >&2
@@ -140,6 +143,17 @@ case "$*" in
   issue\ view\ 888885\ --json\ state\ --jq\ .state)
     printf 'GraphQL: Could not resolve to an Issue with the number of 888885. (repository.issue)\n' >&2
     exit 1
+    ;;
+  pr\ view\ 888886\ --json\ state\ --jq\ .state)
+    # Empty stderr, non-1 exit code (simulates a signal-killed gh process,
+    # e.g. exit 137 = 128 + SIGKILL(9)). The issue-view probe below mirrors
+    # this so the test isolates classify_gh_probe_error's own empty-stderr
+    # exit-code handling rather than accidentally passing via the generic
+    # "unexpected gh invocation" catch-all if only the PR probe were mocked.
+    exit 137
+    ;;
+  issue\ view\ 888886\ --json\ state\ --jq\ .state)
+    exit 137
     ;;
 esac
 
@@ -589,6 +603,16 @@ run_test_contains "explicit_not_found_probe_stop_reason" "could not be resolved"
 # here explicitly as part of the #1503 regression coverage.
 run_test "bare_exit_not_found_probe_mode_regression" "ambiguous" \
   "$(printf '%s\n' "$output_noresol" | grep '^MODE=' | cut -d= -f2-)"
+
+# A bare non-zero exit with EMPTY stderr and a non-1 exit code (simulating a
+# crashed/signal-killed gh process) must NOT be misclassified as not_found —
+# only gh's normal exit-1/empty-stderr not-found path keeps that
+# classification. This must resolve as tracker_unavailable.
+output_crash_empty_stderr="$(router_output "888886")"
+run_test "crash_empty_stderr_nonone_exit_mode" "tracker_unavailable" \
+  "$(printf '%s\n' "$output_crash_empty_stderr" | grep '^MODE=' | cut -d= -f2-)"
+run_test_contains "crash_empty_stderr_nonone_exit_stop_reason" "unavailable" \
+  "$(printf '%s\n' "$output_crash_empty_stderr" | grep '^STOP_REASON=' | cut -d= -f2-)"
 
 # Multi-target list: a probe failure partway through the list must still
 # surface as tracker_unavailable, not ambiguous, and must not be masked by


### PR DESCRIPTION
## Summary

`resolve_token()` in `scripts/development-workflow/run-work-router.sh` probed `gh pr view` and `gh issue view` with `2>/dev/null || true` and treated any empty result as "not found". Any `gh` failure — rate limit, auth expiry, network, GitHub outage — was therefore indistinguishable from a genuinely missing target, and both produced `MODE=ambiguous`, which every bounded command (`/run-item`, `/run-items`, `/run-epic`) treats as a hard stop.

Live reproduction from the issue: `/run-items 1502 1501` stopped reporting both issues unresolvable immediately after a `/run-work` scan exhausted the hourly GraphQL quota, even though both issues were open and had resolved successfully minutes earlier.

## Changes

- `gh_probe()`: captures a gh probe's stdout, stderr, and exit code separately instead of discarding stderr and swallowing the exit code. Restores the caller's original errexit state on return (rather than unconditionally re-enabling `set -e`) so `resolve_token()`'s callers, which wrap the call in `set +e` / `set -e` to inspect `$?`, are not broken by an internal helper silently flipping shell options back on.
- `classify_gh_probe_error()`: classifies a failed probe's stderr into `not_found | rate_limited | auth_failed | network_error | github_unavailable`. Falls back to `not_found` only for gh's own explicit "could not resolve to a PullRequest/Issue" message or an empty stderr (gh's historical behavior for these probes), preserving current behavior for a genuine not-found target.
- `build_probe_fail_reason()` / `gh_rate_limit_reset_info()`: build an actionable `RESOLVE_FAIL_REASON` per failure cause; a rate-limited failure includes the GraphQL quota reset time from `gh api rate_limit` when available.
- New routing mode `MODE_TRACKER_UNAVAILABLE` (`tracker_unavailable`), distinct from `ambiguous`, applied via a new `RESOLVE_FAIL_KIND` at both the single-token and multi-token resolution call sites.

## Testing

New regression tests in `scripts/development-workflow/tests/test-run-work-router.sh` cover:
- Rate-limited probe → `tracker_unavailable`, reason names the cause and includes a reset-time hint.
- Auth-failed probe → `tracker_unavailable`, reason points at `gh auth login`.
- Network-error probe → `tracker_unavailable`.
- Opaque/unrecognized-error (outage-style) probe → `tracker_unavailable` (`github_unavailable` fallback).
- Explicit gh "could not resolve" not-found message on both probes → still `ambiguous` (unchanged).
- Bare non-zero exit with no stderr (pre-existing `999999` fixture) → still `ambiguous` (unchanged).
- A probe failure partway through a multi-token list → `tracker_unavailable`, not masked by an earlier successful resolution.
- Happy path (no probe failure) → unaffected.

All 11 new assertions were confirmed to fail against the pre-fix script (verified via `git stash` of the router change only, keeping the new tests) before the fix was applied. Full local suite: **73/73 passing** (was 58/58 pre-change).

Note: `test-run-work-router.sh` is one of the suites CI does not currently execute (tracked separately in #1537), so this local run is the primary verification.

Fixes #1503

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Tracker unavailable” routing status for rate limits, authentication failures, network issues, outages, and configuration problems.
  - Added actionable stop reasons, including rate-limit reset timing when available.
  - Distinguished genuine missing targets from tracker failures.

- **Bug Fixes**
  - Prevented probe failures from being reported as ambiguous targets.
  - Preserved successful routing for single and multiple targets.

- **Documentation**
  - Updated routing guidance and changelog with the new status, diagnostics, and retry recommendations.

- **Tests**
  - Added coverage for tracker failures, missing targets, multi-target resolution, and successful routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->