### PR TITLE
fix(pr-review-loop): distinguish GitHub rate limit from review verdict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/best-practices/2-version-control.md` now states that CHANGELOG entries
   describe shipped behavior rather than the review history of the PR that produced
   them — a content rule, not a length rule. No behavior change.
+- **`pr-review-loop.sh` ready-phase gate no longer reports a GitHub API
+  rate-limit outage as a review verdict** (#1509): `ensure_pr_ready_for_ready_phase`
+  converted any `gh pr view`/`gh pr ready` failure into `RESULT=escalate
+  REASON=ready_for_review_failed` and the `reviewer-failed` label, with no
+  distinction between an actual review-gate failure and a transient GitHub
+  API/rate-limit outage — observed live as a run that hit
+  `GraphQL: API rate limit already exceeded`, escalated an already-ready,
+  all-green PR, and applied `reviewer-failed` to it. The gate now probes
+  `gh api rate_limit` (a call GitHub exempts from consuming its own quota)
+  whenever `gh pr view`/`gh pr ready` fails; a confirmed core/graphql
+  exhaustion now reports `REASON=rate_limited` with the reset timestamp
+  instead of the generic reason, and `reviewer_failed_label_required_for_result`
+  no longer applies `reviewer-failed` for that reason — the same
+  distinct-REASON-per-distinct-cause pattern `review_skipped_banner` (#1531)
+  established for CodeRabbit's own skip banner. An unexplained `gh` failure
+  (rate limit not confirmed exhausted) keeps the original
+  `REASON=ready_for_review_failed` behavior unchanged.
 
 - **Codex GitHub terminal evidence**: `codex-github-reviewer.sh` no longer
   treats a thumbs-up reaction on the trigger comment as a clean review result,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,22 +117,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   describe shipped behavior rather than the review history of the PR that produced
   them — a content rule, not a length rule. No behavior change.
 - **`pr-review-loop.sh` ready-phase gate no longer reports a GitHub API
-  rate-limit outage as a review verdict** (#1509): `ensure_pr_ready_for_ready_phase`
-  converted any `gh pr view`/`gh pr ready` failure into `RESULT=escalate
-  REASON=ready_for_review_failed` and the `reviewer-failed` label, with no
-  distinction between an actual review-gate failure and a transient GitHub
-  API/rate-limit outage — observed live as a run that hit
-  `GraphQL: API rate limit already exceeded`, escalated an already-ready,
-  all-green PR, and applied `reviewer-failed` to it. The gate now probes
-  `gh api rate_limit` (a call GitHub exempts from consuming its own quota)
-  whenever `gh pr view`/`gh pr ready` fails; a confirmed core/graphql
-  exhaustion now reports `REASON=rate_limited` with the reset timestamp
-  instead of the generic reason, and `reviewer_failed_label_required_for_result`
-  no longer applies `reviewer-failed` for that reason — the same
-  distinct-REASON-per-distinct-cause pattern `review_skipped_banner` (#1531)
-  established for CodeRabbit's own skip banner. An unexplained `gh` failure
-  (rate limit not confirmed exhausted) keeps the original
-  `REASON=ready_for_review_failed` behavior unchanged.
+  rate-limit outage as a review verdict** (#1509): a `gh pr view`/`gh pr ready`
+  failure in `ensure_pr_ready_for_ready_phase` previously always produced
+  `RESULT=escalate REASON=ready_for_review_failed` plus the `reviewer-failed`
+  label, with no distinction from a genuine review-gate failure. The gate now
+  probes `gh api rate_limit` on that failure; a confirmed core/graphql
+  exhaustion reports `REASON=rate_limited` with the reset timestamp instead,
+  and `reviewer_failed_label_required_for_result` no longer applies
+  `reviewer-failed` for that reason. An unexplained `gh` failure keeps the
+  original `REASON=ready_for_review_failed` behavior.
 
 - **Codex GitHub terminal evidence**: `codex-github-reviewer.sh` no longer
   treats a thumbs-up reaction on the trigger comment as a clean review result,

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -5139,6 +5139,59 @@ run_platform_review() {
   esac
 }
 
+# gh_rate_limit_exhausted_reset
+#
+# Probes `gh api rate_limit` (a check that GitHub explicitly exempts from
+# consuming the very quota it reports, so it remains reliable to call even
+# when a run has just exhausted its core or graphql budget) and prints the
+# epoch reset timestamp of whichever of those two resources currently has
+# zero remaining calls. Prints nothing and returns 1 when neither resource
+# is exhausted, the probe call itself fails, or the response cannot be
+# parsed — a probe failure carries no information either way, so callers
+# must treat it the same as "not (confirmably) rate limited", not as proof
+# the original failure had some other cause.
+#
+# Used by ensure_pr_ready_for_ready_phase (issue #1509) to distinguish a
+# transient GitHub API/rate-limit outage from a genuine review-gate failure,
+# the same way CODERABBIT_SKIP_BANNER_RE (issue #1531) gives a distinct,
+# actionable REASON to a distinct failure cause instead of overloading a
+# single generic escalation.
+gh_rate_limit_exhausted_reset() {
+  local rl_json
+  if ! rl_json="$(gh api rate_limit 2>/dev/null)"; then
+    return 1
+  fi
+
+  # The `|| reset=""` guard is load-bearing under `set -e`: this is a plain
+  # (unguarded-by-if) assignment, so if jq exits non-zero (e.g. malformed
+  # JSON from the probe), the assignment statement's own exit status would
+  # otherwise propagate and abort the whole script instead of letting this
+  # function fail closed and return 1 like every other parse-failure path
+  # here.
+  local reset
+  reset="$(printf '%s\n' "$rl_json" | jq -r '
+      [.resources.core, .resources.graphql]
+      | map(select(. != null and .remaining == 0))
+      | sort_by(.reset)
+      | .[0].reset // empty
+    ' 2>/dev/null)" || reset=""
+
+  if [ -z "$reset" ]; then
+    return 1
+  fi
+
+  printf '%s\n' "$reset"
+  return 0
+}
+
+# READY_PHASE_GATE_RATE_LIMIT_RESET is set by ensure_pr_ready_for_ready_phase
+# (as a plain global, since the function's only current callers use its exit
+# code directly rather than command-substituting its stdout) whenever it
+# returns 3, carrying the GitHub API rate-limit reset epoch so the caller can
+# report it. Cleared at the start of every call so a stale value from a prior
+# cycle is never mistaken for this cycle's cause.
+READY_PHASE_GATE_RATE_LIMIT_RESET=""
+
 ensure_pr_ready_for_ready_phase() {
   # Ready-phase platforms are intended to run only once draft-compatible GitHub
   # reviewers have cleared. Some external reviewers, including Haystack triage,
@@ -5147,7 +5200,23 @@ ensure_pr_ready_for_ready_phase() {
   local pr_number="$1"
   local is_draft
 
+  READY_PHASE_GATE_RATE_LIMIT_RESET=""
+
   if ! is_draft="$(gh pr view "$pr_number" --json isDraft --jq '.isDraft' 2>/dev/null)"; then
+    # Distinguish "GitHub's API was temporarily unavailable/rate-limited" from
+    # "this PR genuinely could not be prepared for the ready phase" (issue
+    # #1509): probe the rate-limit endpoint before concluding this is an
+    # unexplained failure. A confirmed exhaustion returns exit 3 so the caller
+    # can report REASON=rate_limited instead of the generic
+    # ready_for_review_failed, and skip the reviewer-failed label — the same
+    # distinction CODERABBIT_RATE_LIMIT_WAIT/CODERABBIT_SKIP_BANNER_RE draw
+    # between an acknowledged vendor quota block and a silent reviewer.
+    local rl_reset
+    if rl_reset="$(gh_rate_limit_exhausted_reset)"; then
+      READY_PHASE_GATE_RATE_LIMIT_RESET="$rl_reset"
+      echo "WARN: could not determine draft state for PR #$pr_number before ready phase — GitHub API rate limit exhausted (resets $rl_reset)" >&2
+      return 3
+    fi
     echo "WARN: could not determine draft state for PR #$pr_number before ready phase" >&2
     return 2
   fi
@@ -5155,6 +5224,12 @@ ensure_pr_ready_for_ready_phase() {
   if [ "$is_draft" = "true" ]; then
     echo "INFO: converting PR #$pr_number to ready before ready-phase reviewers" >&2
     if ! gh pr ready "$pr_number" >/dev/null 2>&1; then
+      local rl_reset_ready
+      if rl_reset_ready="$(gh_rate_limit_exhausted_reset)"; then
+        READY_PHASE_GATE_RATE_LIMIT_RESET="$rl_reset_ready"
+        echo "WARN: failed to mark PR #$pr_number ready before ready phase — GitHub API rate limit exhausted (resets $rl_reset_ready)" >&2
+        return 3
+      fi
       echo "WARN: failed to mark PR #$pr_number ready before ready phase" >&2
       return 2
     fi
@@ -5234,6 +5309,15 @@ reviewer_failed_label_required_for_result() {
 
   case "$result" in
     escalate)
+      case "$reason" in
+        # rate_limited (issue #1509) means the ready-phase gate confirmed a
+        # GitHub API rate-limit exhaustion, not a genuine review verdict on
+        # the PR — applying reviewer-failed here would blame the PR (and its
+        # author) for transient vendor/infrastructure unavailability.
+        rate_limited)
+          return 1
+          ;;
+      esac
       return 0
       ;;
     skipped)
@@ -7075,8 +7159,22 @@ for index in "${!platforms[@]}"; do
         phase_after_clean_net_new_blocker=1
         phase_after_clean_blocking_platform="ready_for_review"
         aggregate_result="escalate"
-        aggregate_reason="ready_for_review_failed"
-        aggregate_output="$(printf 'RESULT=escalate\nREASON=ready_for_review_failed\nCOMMENT_COUNT=0\nBLOCKING_COUNT=0\nSUGGESTION_COUNT=0\n')"
+        # Exit 3 means ensure_pr_ready_for_ready_phase confirmed (via
+        # gh_rate_limit_exhausted_reset) that the underlying `gh` failure was a
+        # GitHub API rate-limit exhaustion rather than a genuine review-gate
+        # failure (issue #1509). Give it a distinct, actionable REASON instead
+        # of the generic ready_for_review_failed, and carry the reset
+        # timestamp so a human/supervisor knows when it is safe to retry.
+        # reviewer_failed_label_required_for_result() excludes this REASON
+        # from the reviewer-failed label — vendor/infrastructure unavailability
+        # is not a review verdict on the PR.
+        if [ "$ready_status" -eq 3 ]; then
+          aggregate_reason="rate_limited"
+          aggregate_output="$(printf 'RESULT=escalate\nREASON=rate_limited\nRATE_LIMIT_RESET=%s\nCOMMENT_COUNT=0\nBLOCKING_COUNT=0\nSUGGESTION_COUNT=0\n' "$READY_PHASE_GATE_RATE_LIMIT_RESET")"
+        else
+          aggregate_reason="ready_for_review_failed"
+          aggregate_output="$(printf 'RESULT=escalate\nREASON=ready_for_review_failed\nCOMMENT_COUNT=0\nBLOCKING_COUNT=0\nSUGGESTION_COUNT=0\n')"
+        fi
         aggregate_status=2
         break
       fi

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2943,9 +2943,17 @@ echo "=== Area 12b: rate-limit-aware ready-phase gate (issue #1509) ==="
 
 _1509_mkmock() {
   # $1 = mock dir, $2 = case body (bash `case "$*" in ... esac` arms)
+  if [ "$#" -ne 2 ]; then
+    echo "ERROR: _1509_mkmock requires exactly 2 arguments (dir, arms), got $#" >&2
+    return 1
+  fi
   local dir="$1"
   local arms="$2"
-  cat > "$dir/gh" <<EOF
+  if [ -z "$dir" ] || [ ! -d "$dir" ]; then
+    echo "ERROR: _1509_mkmock: '$dir' is not a valid directory" >&2
+    return 1
+  fi
+  if ! cat > "$dir/gh" <<EOF
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "\$RL1509_CALL_LOG"
 case "\$*" in
@@ -2956,7 +2964,14 @@ $arms
     ;;
 esac
 EOF
-  chmod +x "$dir/gh"
+  then
+    echo "ERROR: _1509_mkmock: failed to write $dir/gh" >&2
+    return 1
+  fi
+  if ! chmod +x "$dir/gh"; then
+    echo "ERROR: _1509_mkmock: failed to chmod +x $dir/gh" >&2
+    return 1
+  fi
 }
 
 # --- gh_rate_limit_exhausted_reset: core exhausted -------------------------

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -2924,6 +2924,218 @@ unset _reviewer_failed_required _reviewer_failed_fn_line _sync_fn_line _harness_
 unset MOCK_GH_EXIT MOCK_GH_LABEL_VIEW_EXIT MOCK_GH_LABEL_CREATE_EXIT MOCK_GH_PR_EDIT_EXIT
 
 # ---------------------------------------------------------------------------
+# Area 12b: ready-phase gate distinguishes GitHub API rate-limit exhaustion
+# from a genuine review-gate failure (issue #1509)
+#
+# gh_rate_limit_exhausted_reset() and ensure_pr_ready_for_ready_phase() are
+# defined before the HARNESS_MODE return point and are therefore callable
+# directly from the test harness.
+#
+# Uses the strict-mock pattern established for issue #1531 (a PATH-installed
+# `gh` script that enumerates every invocation the code under test legitimately
+# makes and hard-errors on anything else) rather than the permissive global
+# MOCK_GH_* fallback used elsewhere in this file — a renamed or dropped
+# `gh api rate_limit` call must fail the test, not silently return an empty
+# default that happens to still satisfy the assertion.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 12b: rate-limit-aware ready-phase gate (issue #1509) ==="
+
+_1509_mkmock() {
+  # $1 = mock dir, $2 = case body (bash `case "$*" in ... esac` arms)
+  local dir="$1"
+  local arms="$2"
+  cat > "$dir/gh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "\$RL1509_CALL_LOG"
+case "\$*" in
+$arms
+  *)
+    printf 'UNEXPECTED gh invocation in 1509 mock: %s\n' "\$*" >&2
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$dir/gh"
+}
+
+# --- gh_rate_limit_exhausted_reset: core exhausted -------------------------
+_1509_dir="$(mktemp -d)"
+_1509_log="$_1509_dir/calls.log"
+_1509_mkmock "$_1509_dir" '  "api rate_limit")
+    printf '"'"'{"resources":{"core":{"limit":5000,"remaining":0,"reset":1700000100},"graphql":{"limit":5000,"remaining":5000,"reset":1700009999}}}\n'"'"'
+    exit 0 ;;'
+_1509_out="$(PATH="$_1509_dir:$PATH" RL1509_CALL_LOG="$_1509_log" gh_rate_limit_exhausted_reset)"
+_1509_rc=$?
+run_test "rl1509_core_exhausted_prints_reset" "1700000100" "$_1509_out"
+run_test "rl1509_core_exhausted_exit_0" "0" "$_1509_rc"
+run_test "rl1509_core_exhausted_probed_rate_limit" "yes" \
+  "$([ "$(grep -c -- 'api rate_limit' "$_1509_log" 2>/dev/null || true)" -ge 1 ] && echo yes || echo no)"
+rm -rf "$_1509_dir"
+unset _1509_dir _1509_log _1509_out _1509_rc
+
+# --- gh_rate_limit_exhausted_reset: graphql exhausted -----------------------
+_1509_dir="$(mktemp -d)"
+_1509_log="$_1509_dir/calls.log"
+_1509_mkmock "$_1509_dir" '  "api rate_limit")
+    printf '"'"'{"resources":{"core":{"limit":5000,"remaining":5000,"reset":1700009999},"graphql":{"limit":5000,"remaining":0,"reset":1700000200}}}\n'"'"'
+    exit 0 ;;'
+_1509_out="$(PATH="$_1509_dir:$PATH" RL1509_CALL_LOG="$_1509_log" gh_rate_limit_exhausted_reset)"
+run_test "rl1509_graphql_exhausted_prints_reset" "1700000200" "$_1509_out"
+rm -rf "$_1509_dir"
+unset _1509_dir _1509_log _1509_out
+
+# --- gh_rate_limit_exhausted_reset: both exhausted -> earliest reset wins --
+_1509_dir="$(mktemp -d)"
+_1509_log="$_1509_dir/calls.log"
+_1509_mkmock "$_1509_dir" '  "api rate_limit")
+    printf '"'"'{"resources":{"core":{"limit":5000,"remaining":0,"reset":1700000500},"graphql":{"limit":5000,"remaining":0,"reset":1700000300}}}\n'"'"'
+    exit 0 ;;'
+_1509_out="$(PATH="$_1509_dir:$PATH" RL1509_CALL_LOG="$_1509_log" gh_rate_limit_exhausted_reset)"
+run_test "rl1509_both_exhausted_earliest_reset" "1700000300" "$_1509_out"
+rm -rf "$_1509_dir"
+unset _1509_dir _1509_log _1509_out
+
+# --- gh_rate_limit_exhausted_reset: neither exhausted -> empty, exit 1 -----
+_1509_dir="$(mktemp -d)"
+_1509_log="$_1509_dir/calls.log"
+_1509_mkmock "$_1509_dir" '  "api rate_limit")
+    printf '"'"'{"resources":{"core":{"limit":5000,"remaining":4999,"reset":1700009999},"graphql":{"limit":5000,"remaining":5000,"reset":1700009999}}}\n'"'"'
+    exit 0 ;;'
+set +e
+_1509_out="$(PATH="$_1509_dir:$PATH" RL1509_CALL_LOG="$_1509_log" gh_rate_limit_exhausted_reset)"
+_1509_rc=$?
+set -e
+run_test "rl1509_not_exhausted_empty_output" "" "$_1509_out"
+run_test "rl1509_not_exhausted_exit_1" "1" "$_1509_rc"
+rm -rf "$_1509_dir"
+unset _1509_dir _1509_log _1509_out _1509_rc
+
+# --- gh_rate_limit_exhausted_reset: probe call itself fails -> exit 1 ------
+_1509_dir="$(mktemp -d)"
+_1509_log="$_1509_dir/calls.log"
+_1509_mkmock "$_1509_dir" '  "api rate_limit")
+    exit 1 ;;'
+set +e
+_1509_out="$(PATH="$_1509_dir:$PATH" RL1509_CALL_LOG="$_1509_log" gh_rate_limit_exhausted_reset)"
+_1509_rc=$?
+set -e
+run_test "rl1509_probe_failure_empty_output" "" "$_1509_out"
+run_test "rl1509_probe_failure_exit_1" "1" "$_1509_rc"
+rm -rf "$_1509_dir"
+unset _1509_dir _1509_log _1509_out _1509_rc
+
+# --- gh_rate_limit_exhausted_reset: malformed JSON does not abort the caller
+# under `set -e` (regression guard for the unguarded-assignment failure mode) --
+_1509_dir="$(mktemp -d)"
+_1509_log="$_1509_dir/calls.log"
+_1509_mkmock "$_1509_dir" '  "api rate_limit")
+    printf '"'"'not-json\n'"'"'
+    exit 0 ;;'
+set +e
+_1509_out="$(PATH="$_1509_dir:$PATH" RL1509_CALL_LOG="$_1509_log" gh_rate_limit_exhausted_reset)"
+_1509_rc=$?
+set -e
+run_test "rl1509_malformed_json_empty_output" "" "$_1509_out"
+run_test "rl1509_malformed_json_exit_1" "1" "$_1509_rc"
+rm -rf "$_1509_dir"
+unset _1509_dir _1509_log _1509_out _1509_rc
+
+# --- ensure_pr_ready_for_ready_phase: gh pr view failure + confirmed rate
+# limit exhaustion -> exit 3, distinct from the generic exit 2, and
+# READY_PHASE_GATE_RATE_LIMIT_RESET carries the reset timestamp -------------
+_1509_dir="$(mktemp -d)"
+_1509_log="$_1509_dir/calls.log"
+_1509_mkmock "$_1509_dir" '  "pr view 999 --json isDraft --jq .isDraft")
+    exit 1 ;;
+  "api rate_limit")
+    printf '"'"'{"resources":{"core":{"limit":5000,"remaining":0,"reset":1700000777},"graphql":{"limit":5000,"remaining":5000,"reset":1700009999}}}\n'"'"'
+    exit 0 ;;'
+set +e
+PATH="$_1509_dir:$PATH" RL1509_CALL_LOG="$_1509_log" \
+  ensure_pr_ready_for_ready_phase "999" >/dev/null 2>&1
+_1509_rc=$?
+set -e
+run_test "rl1509_gate_draft_state_rate_limited_exit_3" "3" "$_1509_rc"
+run_test "rl1509_gate_draft_state_rate_limited_reset_captured" "1700000777" \
+  "$READY_PHASE_GATE_RATE_LIMIT_RESET"
+run_test "rl1509_gate_draft_state_rate_limited_probed" "yes" \
+  "$([ "$(grep -c -- 'api rate_limit' "$_1509_log" 2>/dev/null || true)" -ge 1 ] && echo yes || echo no)"
+run_test "rl1509_gate_draft_state_rate_limited_did_not_call_pr_ready" "0" \
+  "$(grep -c -- 'pr ready 999' "$_1509_log" 2>/dev/null || true)"
+rm -rf "$_1509_dir"
+unset _1509_dir _1509_log _1509_rc
+
+# --- ensure_pr_ready_for_ready_phase: gh pr view failure WITHOUT confirmed
+# rate-limit exhaustion still returns the original exit 2 (unchanged
+# behavior — an unexplained failure is not asserted to be a rate limit) -----
+_1509_dir="$(mktemp -d)"
+_1509_log="$_1509_dir/calls.log"
+_1509_mkmock "$_1509_dir" '  "pr view 999 --json isDraft --jq .isDraft")
+    exit 1 ;;
+  "api rate_limit")
+    printf '"'"'{"resources":{"core":{"limit":5000,"remaining":4999,"reset":1700009999},"graphql":{"limit":5000,"remaining":5000,"reset":1700009999}}}\n'"'"'
+    exit 0 ;;'
+READY_PHASE_GATE_RATE_LIMIT_RESET="stale-from-prior-cycle"
+set +e
+PATH="$_1509_dir:$PATH" RL1509_CALL_LOG="$_1509_log" \
+  ensure_pr_ready_for_ready_phase "999" >/dev/null 2>&1
+_1509_rc=$?
+set -e
+run_test "rl1509_gate_draft_state_unexplained_failure_exit_2" "2" "$_1509_rc"
+run_test "rl1509_gate_unexplained_failure_clears_stale_reset" "" \
+  "$READY_PHASE_GATE_RATE_LIMIT_RESET"
+rm -rf "$_1509_dir"
+unset _1509_dir _1509_log _1509_rc
+
+# --- ensure_pr_ready_for_ready_phase: `gh pr ready` failure (after a
+# successful draft-state read) + confirmed rate-limit exhaustion -> exit 3 --
+_1509_dir="$(mktemp -d)"
+_1509_log="$_1509_dir/calls.log"
+_1509_mkmock "$_1509_dir" '  "pr view 999 --json isDraft --jq .isDraft")
+    printf '"'"'true\n'"'"'
+    exit 0 ;;
+  "pr ready 999")
+    exit 1 ;;
+  "api rate_limit")
+    printf '"'"'{"resources":{"core":{"limit":5000,"remaining":0,"reset":1700000888},"graphql":{"limit":5000,"remaining":5000,"reset":1700009999}}}\n'"'"'
+    exit 0 ;;'
+set +e
+PATH="$_1509_dir:$PATH" RL1509_CALL_LOG="$_1509_log" \
+  ensure_pr_ready_for_ready_phase "999" >/dev/null 2>&1
+_1509_rc=$?
+set -e
+run_test "rl1509_gate_pr_ready_rate_limited_exit_3" "3" "$_1509_rc"
+run_test "rl1509_gate_pr_ready_rate_limited_reset_captured" "1700000888" \
+  "$READY_PHASE_GATE_RATE_LIMIT_RESET"
+rm -rf "$_1509_dir"
+unset _1509_dir _1509_log _1509_rc
+unset -f _1509_mkmock
+READY_PHASE_GATE_RATE_LIMIT_RESET=""
+
+# --- reviewer_failed_label_required_for_result: rate_limited escalation is
+# infrastructure unavailability, not a review verdict — no label -----------
+#
+# Defined locally (not reusing Area 12's _reviewer_failed_required) because
+# Area 12 ends by `unset`-ing that name — with neither -f nor -v given, bash
+# falls back to unsetting the FUNCTION when no variable by that name exists,
+# so the Area 12 helper is gone by the time this block runs.
+_1509_reviewer_failed_required() {
+  if reviewer_failed_label_required_for_result "$1" "${2:-}"; then
+    printf 'yes'
+  else
+    printf 'no'
+  fi
+}
+run_test "reviewer_failed_escalate_rate_limited_no_label" "no" \
+  "$(_1509_reviewer_failed_required escalate rate_limited)"
+# Sibling REASON tokens must be unaffected by the new exception (regression
+# guard against an over-broad case match swallowing other escalate reasons).
+run_test "reviewer_failed_escalate_ready_for_review_failed_still_label" "yes" \
+  "$(_1509_reviewer_failed_required escalate ready_for_review_failed)"
+unset -f _1509_reviewer_failed_required
+
+# ---------------------------------------------------------------------------
 # Area 13: PR #801 follow-up coverage for reviewer-loop failure paths
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

`ensure_pr_ready_for_ready_phase` in `scripts/development-workflow/pr-review-loop.sh` converted any `gh pr view`/`gh pr ready` failure into `RESULT=escalate REASON=ready_for_review_failed`, applying the `reviewer-failed` label — with no distinction between a genuine review-gate failure and a transient GitHub API/rate-limit outage. A live run hit `GraphQL: API rate limit already exceeded`, escalated an already-ready, all-green PR, and applied `reviewer-failed` to it (observed live via a downstream report from `zeki-cl/zeki-platform`).

## Change

- Added `gh_rate_limit_exhausted_reset` (`scripts/development-workflow/pr-review-loop.sh:5159`), which probes `gh api rate_limit` (a call GitHub explicitly exempts from consuming its own quota, so it stays reliable even when the run just exhausted its budget) whenever the ready-phase gate's `gh pr view`/`gh pr ready` call fails.
- A confirmed core/graphql exhaustion now returns a distinct exit code (`3`, `ensure_pr_ready_for_ready_phase` at `pr-review-loop.sh:5195`, exit points at `:5218` and `:5231`) carrying the reset timestamp via `READY_PHASE_GATE_RATE_LIMIT_RESET` (`:5187`); the caller (`:7173`) reports `REASON=rate_limited` (with `RATE_LIMIT_RESET`) instead of the generic `ready_for_review_failed`.
- `reviewer_failed_label_required_for_result` (`:5317`) no longer applies the `reviewer-failed` label for `REASON=rate_limited` — infrastructure unavailability is not a review verdict on the PR.
- An unexplained `gh` failure (rate limit not confirmed exhausted) keeps the original `REASON=ready_for_review_failed` behavior unchanged — this fix only distinguishes the *confirmed* case, it doesn't assume every gate failure is a rate limit.

This follows the same distinct-REASON-per-distinct-cause pattern `CODERABBIT_SKIP_BANNER_RE`/`REASON=review_skipped_banner` established tonight (#1531) for CodeRabbit's own "Review skipped" banner vs. its rate limit.

## Out of scope

The issue's third proposal item — persisting the reviewer-loop-summary run record via a path that doesn't depend on the same exhausted quota, or retrying the summary post after reset — is a separate structural concern (the issue itself frames it as "a secondary effect") and is not addressed here to keep this change focused and reviewable.

## Testing (planted-violation proof)

21 new regression tests in `scripts/development-workflow/tests/test-pr-review-loop.sh` ("Area 12b", starting at line 2941), using the strict-mock pattern established for #1531 (a PATH-installed `gh` script enumerating every invocation legitimately made, hard-erroring on anything else) rather than the permissive global `MOCK_GH_*` mock:

- `gh_rate_limit_exhausted_reset`: core exhausted, graphql exhausted, both exhausted (earliest reset wins), neither exhausted, probe call itself fails, malformed JSON response (regression guard for a `set -e`-unsafe unguarded assignment; test `rl1509_malformed_json_exit_1` at `test-pr-review-loop.sh:3040`).
- `ensure_pr_ready_for_ready_phase`: exit 3 + reset capture on confirmed rate limit at both the `gh pr view` failure path (`rl1509_gate_draft_state_rate_limited_exit_3` at `:3059`) and the `gh pr ready` failure path (`rl1509_gate_pr_ready_rate_limited_exit_3` at `:3108`); exit 2 unchanged on an unexplained failure (`rl1509_gate_draft_state_unexplained_failure_exit_2` at `:3085`); stale-reset-global cleared each call (`rl1509_gate_unexplained_failure_clears_stale_reset` at `:3086`).
- `reviewer_failed_label_required_for_result`: `escalate`/`rate_limited` → no label (`reviewer_failed_escalate_rate_limited_no_label` at `test-pr-review-loop.sh:3130`); sibling `escalate`/`ready_for_review_failed` → label unaffected (`reviewer_failed_escalate_ready_for_review_failed_still_label` at `:3134`, regression guard against an over-broad case match).

**Demonstrated failing/passing run** (both directions, per `REVIEW.md`'s Planted-Violation Proof rule — this repo's own test harness, not a hypothetical):

- Pre-fix (`git checkout HEAD~1 -- scripts/development-workflow/pr-review-loop.sh`, confirmed via `grep -c gh_rate_limit_exhausted_reset` returning `0`, leaving the new tests from this PR's commit in place): the full suite aborts at exactly —
  `scripts/development-workflow/tests/test-pr-review-loop.sh: line 2968: gh_rate_limit_exhausted_reset: command not found` (`EXIT:127`) — the function does not exist on `develop`.
- Post-fix (`git checkout HEAD -- scripts/development-workflow/pr-review-loop.sh`, confirmed restored via `bash -n`): all 21 new tests pass, and the full suite (`bash scripts/development-workflow/tests/test-pr-review-loop.sh`) reports **861 passed, 0 failed** — no regressions in the other 840 pre-existing tests.

## Other verification

- `bash -n`, `shellcheck --severity=warning` (clean, no findings), `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop` (clean) on both modified shell files.
- `npx markdownlint-cli2`, the heuristic lint, and the duplicate-header check all pass on `CHANGELOG.md`.

Fixes #1509

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of GitHub API rate-limit failures during pull request readiness checks.
  * Rate-limited failures now report the reset time and avoid applying an incorrect failure label.
  * Other readiness failures continue to receive the appropriate failure status.
  * Readiness checks no longer proceed when draft-state verification fails.

* **Tests**
  * Added coverage for rate-limit detection, reset-time reporting, malformed responses, and related readiness scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->