### PR TITLE
fix(workflow-lib): resolve gh project item-list Type key by field name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,14 +39,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolves the same field-name order as
   `workflow_github_project_type_field_json`:
   `issue_tracker.custom_fields.type_field`, then `Custom Type`, `CustomType`,
-  then `Type`, each converted to its gh item-list key. When none of those
-  keys are present anywhere in the item-list payload, the function now emits
-  a distinct stderr warning so a genuinely empty result ("no open Workflow
-  items") is no longer indistinguishable from an unreadable Type field. The
+  then `Type`, each converted to its gh item-list key. When the item-list
+  payload has at least one item and none of those keys are present on any of
+  them, the function now emits a distinct stderr warning so a genuinely
+  unreadable Type field is no longer indistinguishable from a clean "no open
+  Workflow items" result — an empty board (zero items on the project, e.g.
+  open issues not yet triaged onto it) is left alone and does not trigger the
+  warning, since there is nothing to judge the candidate keys against. The
   shipped regression test's fixture previously mocked a `"type":"Workflow"`
   key that real `gh` cannot produce; it now uses `"custom Type"`, matching a
-  real board, plus new cases for a configured `type_field` override and the
-  unreadable-field warning.
+  real board, plus new cases for a configured `type_field` override, the
+  unreadable-field warning, and the empty-board non-warning case.
 - **`post-merge-cleanup.sh` no longer closes the wrong issue for team-prefixed
   branch slugs** (#1511): the team-prefixed identifier pattern
   (`^(fix|feature|hotfix|refactor)/([a-zA-Z]{2,6}-([0-9]+))($|-)`) matches any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **`list_open_workflow_type_issues` no longer hardcodes a `.type` field key**
+  (#1400): `gh project item-list --format json` derives each item's field key
+  from the field's display name, lowercasing only its first character (for
+  example `Custom Type` -> `custom Type`). Because `Type` is a reserved
+  GitHub Projects field name, no conforming board can actually name its
+  classification field `Type`, so the hardcoded `select((.type // "") ==
+  "Workflow")` never matched anything on a real board — release protocol
+  §7.2's "downstream script-bug review" gate silently returned `[]` on every
+  release regardless of how many open Workflow items existed. The lookup now
+  resolves the same field-name order as
+  `workflow_github_project_type_field_json`:
+  `issue_tracker.custom_fields.type_field`, then `Custom Type`, `CustomType`,
+  then `Type`, each converted to its gh item-list key. When none of those
+  keys are present anywhere in the item-list payload, the function now emits
+  a distinct stderr warning so a genuinely empty result ("no open Workflow
+  items") is no longer indistinguishable from an unreadable Type field. The
+  shipped regression test's fixture previously mocked a `"type":"Workflow"`
+  key that real `gh` cannot produce; it now uses `"custom Type"`, matching a
+  real board, plus new cases for a configured `type_field` override and the
+  unreadable-field warning.
 - **`post-merge-cleanup.sh` no longer closes the wrong issue for team-prefixed
   branch slugs** (#1511): the team-prefixed identifier pattern
   (`^(fix|feature|hotfix|refactor)/([a-zA-Z]{2,6}-([0-9]+))($|-)`) matches any

--- a/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+++ b/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
@@ -252,6 +252,14 @@ JSON
       cat <<'JSON'
 {"items":[{"content":{"number":824},"status":"Backlog","priority":"High","title":"Workflow helper issue"}]}
 JSON
+    elif [ "${MOCK_ITEM_LIST_MODE:-default}" = "empty_board" ]; then
+      # Project board has zero items yet (e.g. open issues not triaged onto
+      # the board). This must be a clean "no open Workflow items" result, not
+      # an unreadable-Type-field warning — there is nothing to judge the
+      # field keys against.
+      cat <<'JSON'
+{"items":[]}
+JSON
     else
       cat <<'JSON'
 {"items":[{"content":{"number":824},"status":"Backlog","priority":"High","custom Type":"Workflow","title":"Workflow helper issue"},{"content":{"number":825},"status":"Backlog","priority":"High","custom Type":"Bug","title":"Bug helper issue"},{"content":{"number":826},"status":"Done","priority":"High","custom Type":"Workflow","title":"Done workflow helper issue"},{"content":{"number":827},"status":"Merged","priority":"High","custom Type":"Workflow","title":"Merged workflow helper issue"},{"content":{"number":828},"status":"Released","priority":"High","custom Type":"Workflow","title":"Released workflow helper issue"},{"content":{"number":829},"status":"Cancelled","priority":"High","custom Type":"Workflow","title":"Cancelled workflow helper issue"}]}
@@ -681,6 +689,23 @@ case "$workflow_issues_stderr" in
   *) unreadable_warning_result="$workflow_issues_stderr" ;;
 esac
 run_test "workflow_type_discovery_unreadable_field_warns_distinctly" "warned" "$unreadable_warning_result"
+
+# Regression (issue #1400 follow-up): an empty project board (zero items —
+# e.g. open issues not yet triaged onto the board) must not be confused with
+# an unreadable Type field. There is nothing to judge the candidate keys
+# against, so no warning should fire and the result must stay a clean [].
+reset_log
+export MOCK_ITEM_LIST_MODE=empty_board
+workflow_issues_empty_board_stderr=""
+workflow_issues_empty_board_stderr="$(list_open_workflow_type_issues 2>&1 >/dev/null)"
+workflow_issues_empty_board="$(list_open_workflow_type_issues 2>/dev/null)"
+unset MOCK_ITEM_LIST_MODE
+run_test "workflow_type_discovery_empty_board_returns_empty" "[]" "$(printf '%s' "$workflow_issues_empty_board" | jq -c '.')"
+case "$workflow_issues_empty_board_stderr" in
+  *"Cannot distinguish"*) empty_board_warning_result="$workflow_issues_empty_board_stderr" ;;
+  *) empty_board_warning_result="no-warning" ;;
+esac
+run_test "workflow_type_discovery_empty_board_no_false_warning" "no-warning" "$empty_board_warning_result"
 
 reset_log
 export MOCK_TRACKER_PROVIDER=linear

--- a/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
+++ b/scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
@@ -6,6 +6,9 @@
 #   2. ensure_on_project_board checks membership without full-board pagination
 #   3. update_tracker_status_best_effort resolves item/status IDs without item-list
 #   4. Type helpers read/update project Type and discover open Workflow items
+#   5. list_open_workflow_type_issues resolves the real gh item-list key
+#      ("custom Type"/configured field), not a hardcoded ".type", and
+#      distinguishes an unreadable Type field from a clean [] (issue #1400)
 #
 # Usage: bash scripts/development-workflow/tests/test-workflow-lib-github-projects.sh
 
@@ -230,9 +233,30 @@ JSON
 JSON
     ;;
   "project item-list 1 --owner lhpaul --limit 1000 --format json")
-    cat <<'JSON'
-{"items":[{"content":{"number":824},"status":"Backlog","priority":"High","type":"Workflow","title":"Workflow helper issue"},{"content":{"number":825},"status":"Backlog","priority":"High","type":"Bug","title":"Bug helper issue"},{"content":{"number":826},"status":"Done","priority":"High","type":"Workflow","title":"Done workflow helper issue"},{"content":{"number":827},"status":"Merged","priority":"High","type":"Workflow","title":"Merged workflow helper issue"},{"content":{"number":828},"status":"Released","priority":"High","type":"Workflow","title":"Released workflow helper issue"},{"content":{"number":829},"status":"Cancelled","priority":"High","type":"Workflow","title":"Cancelled workflow helper issue"}]}
+    # Real `gh project item-list --format json` derives each item's field
+    # key from the field's display name, lowercasing only the first
+    # character. "Type" is a reserved GitHub Projects field name, so no
+    # conforming board can name its classification field "Type" — the
+    # fixture below uses "custom Type" (from a field literally named
+    # "Custom Type"), the key a real board actually emits (issue #1400).
+    if [ "${MOCK_ITEM_LIST_MODE:-default}" = "configured_field" ]; then
+      # Board configured with issue_tracker.custom_fields.type_field:
+      # "Classification" — key is "classification".
+      cat <<'JSON'
+{"items":[{"content":{"number":824},"status":"Backlog","priority":"High","classification":"Workflow","custom Type":"Bug","title":"Workflow helper issue"}]}
 JSON
+    elif [ "${MOCK_ITEM_LIST_MODE:-default}" = "unreadable" ]; then
+      # No key matching any candidate (preferred/"Custom Type"/"CustomType"/
+      # "Type") is present anywhere in the payload — simulates a
+      # misconfigured or unreadable Type field.
+      cat <<'JSON'
+{"items":[{"content":{"number":824},"status":"Backlog","priority":"High","title":"Workflow helper issue"}]}
+JSON
+    else
+      cat <<'JSON'
+{"items":[{"content":{"number":824},"status":"Backlog","priority":"High","custom Type":"Workflow","title":"Workflow helper issue"},{"content":{"number":825},"status":"Backlog","priority":"High","custom Type":"Bug","title":"Bug helper issue"},{"content":{"number":826},"status":"Done","priority":"High","custom Type":"Workflow","title":"Done workflow helper issue"},{"content":{"number":827},"status":"Merged","priority":"High","custom Type":"Workflow","title":"Merged workflow helper issue"},{"content":{"number":828},"status":"Released","priority":"High","custom Type":"Workflow","title":"Released workflow helper issue"},{"content":{"number":829},"status":"Cancelled","priority":"High","custom Type":"Workflow","title":"Cancelled workflow helper issue"}]}
+JSON
+    fi
     ;;
   "project item-add "*)
     printf 'PVTI_added\n'
@@ -599,6 +623,64 @@ workflow_issue_numbers="$(printf '%s' "$workflow_issues" | jq -r '.[].number' | 
 run_test "workflow_type_discovery_filters_open_type" "824" "$workflow_issue_numbers"
 run_test "workflow_type_discovery_filters_terminal_statuses" "824" "$workflow_issue_numbers"
 run_test "workflow_type_discovery_uses_single_board_scan" "1" "$(count_log_matches 'project item-list')"
+
+# Regression (issue #1400): the payload above uses "custom Type" — the key
+# real `gh project item-list --format json` derives from a field literally
+# named "Custom Type" (lowercasing only the first character). A hardcoded
+# `.type` lookup cannot match this key and silently returns []. Confirm the
+# discovered item's reported type reflects the resolved field value.
+workflow_issue_types="$(printf '%s' "$workflow_issues" | jq -r '.[].type' | tr '\n' ' ' | sed 's/ $//')"
+run_test "workflow_type_discovery_resolves_custom_type_key" "Workflow" "$workflow_issue_types"
+
+# Regression (issue #1400): issue_tracker.custom_fields.type_field names a
+# board's classification field something other than "Custom Type"/"Type".
+# The configured field must be honored (and preferred over a stray
+# "custom Type" key present on the same item, e.g. an unrelated field with
+# that literal name).
+reset_log
+# NOTE: an earlier section (workflow_github_project_type_field_json tests)
+# permanently redefines workflow_issue_tracker_custom_field to always
+# return "Configured Type", ignoring $MOCK_TRACKER_TYPE_FIELD from here on.
+# Restore the $MOCK_TRACKER_TYPE_FIELD-driven stub for this test, then put
+# the hardcoded "Configured Type" stub back so later tests are unaffected.
+workflow_issue_tracker_custom_field() {
+  case "$1" in
+    type_field) printf '%s\n' "${MOCK_TRACKER_TYPE_FIELD:-}" ;;
+    *) printf '\n' ;;
+  esac
+}
+export MOCK_ITEM_LIST_MODE=configured_field
+export MOCK_TRACKER_TYPE_FIELD="Classification"
+workflow_issues="$(list_open_workflow_type_issues)"
+unset MOCK_ITEM_LIST_MODE
+unset MOCK_TRACKER_TYPE_FIELD
+workflow_issue_tracker_custom_field() {
+  case "$1" in
+    type_field) printf 'Configured Type\n' ;;
+    *) printf '\n' ;;
+  esac
+}
+workflow_issue_numbers="$(printf '%s' "$workflow_issues" | jq -r '.[].number' | tr '\n' ' ' | sed 's/ $//')"
+run_test "workflow_type_discovery_honors_configured_type_field" "824" "$workflow_issue_numbers"
+
+# Regression (issue #1400): when none of the configured/default candidate
+# keys (preferred, "Custom Type", "CustomType", "Type") are present
+# anywhere in the item-list payload, the empty result must be distinguished
+# from a clean "no open Workflow items" scan via a distinct stderr warning
+# — otherwise a false-green [] is indistinguishable from an unreadable
+# field (the exact silent failure mode this issue reports).
+reset_log
+export MOCK_ITEM_LIST_MODE=unreadable
+workflow_issues_stderr=""
+workflow_issues_stderr="$(list_open_workflow_type_issues 2>&1 >/dev/null)"
+workflow_issues_unreadable="$(list_open_workflow_type_issues 2>/dev/null)"
+unset MOCK_ITEM_LIST_MODE
+run_test "workflow_type_discovery_unreadable_field_returns_empty" "[]" "$(printf '%s' "$workflow_issues_unreadable" | jq -c '.')"
+case "$workflow_issues_stderr" in
+  *"Cannot distinguish 'no open Workflow items' from 'Type field unreadable'"*) unreadable_warning_result="warned" ;;
+  *) unreadable_warning_result="$workflow_issues_stderr" ;;
+esac
+run_test "workflow_type_discovery_unreadable_field_warns_distinctly" "warned" "$unreadable_warning_result"
 
 reset_log
 export MOCK_TRACKER_PROVIDER=linear

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -3021,8 +3021,25 @@ update_tracker_size_best_effort() {
 # Prints a JSON array of open GitHub issues whose project Type is Workflow.
 # Discovery is intentionally open-issues-first, then one project item-list
 # cross-reference, so callers avoid per-item full-board scans.
+#
+# `gh project item-list --format json` derives each item's field keys from
+# the field's display name, lowercasing only the first character (for
+# example "Custom Type" -> "custom Type", "Type" -> "type"). Because "Type"
+# is a reserved GitHub Projects field name, no conforming board can actually
+# name its classification field "Type" — so this resolves the same lookup
+# order as workflow_github_project_type_field_json:
+# issue_tracker.custom_fields.type_field, then "Custom Type", "CustomType",
+# then "Type", each converted to its gh item-list key.
+#
+# When none of those keys appear anywhere in the item-list payload, an
+# empty result is indistinguishable from "nothing open" versus "the Type
+# field could not be read" — this prints a distinct stderr warning for that
+# case so callers (and humans reading release-gate output) are not silently
+# fooled by a false-green `[]`.
 list_open_workflow_type_issues() {
   local project_number owner open_issues project_items repo_owner repo_name repo_slug
+  local _lowti_preferred_field _lowti_candidate_keys_json _lowti_result_json
+  local _lowti_matched_keys _lowti_results _lowti_item_keys_display _lowti_candidate_display
 
   local _lowti_provider
   _lowti_provider="$(workflow_normalize_issue_tracker_provider "$(workflow_issue_tracker_provider_raw)")"
@@ -3080,28 +3097,88 @@ list_open_workflow_type_issues() {
     return 0
   fi
 
-  if ! printf '%s' "$project_items" | jq --argjson open "$open_issues" '
+  _lowti_preferred_field="$(workflow_issue_tracker_custom_field type_field "$(workflow_effective_config_file || true)")"
+  _lowti_candidate_keys_json="$(_workflow_lowti_candidate_keys_json "$_lowti_preferred_field")"
+
+  if ! _lowti_result_json="$(printf '%s' "$project_items" | jq --argjson open "$open_issues" --argjson candidate_keys "$_lowti_candidate_keys_json" '
     def terminal($status):
       ($status // "") as $s
       | ($s == "Done" or $s == "Merged" or $s == "Released" or $s == "Cancelled");
 
-    [ .items[]
-      | select((.type // "") == "Workflow")
-      | . as $item
-      | ($open[] | select(.number == $item.content.number)) as $issue
-      | select(terminal($item.status) | not)
-      | {
-          number: $issue.number,
-          title: $issue.title,
-          url: $issue.url,
-          createdAt: $issue.createdAt,
-          status: ($item.status // ""),
-          priority: ($item.priority // ""),
-          type: ($item.type // "")
-        }
-    ]
-  ' 2>/dev/null; then
+    def item_type($item):
+      ( [ $candidate_keys[] as $k | ($item[$k] // "") ] | map(select(. != "")) | first ) // "";
+
+    ( [ .items[] | keys[] ] | unique ) as $item_keys
+    | ( [ $candidate_keys[] | select(. as $k | $item_keys | index($k) != null) ] ) as $matched_keys
+    | {
+        matched_keys: $matched_keys,
+        item_keys: $item_keys,
+        results: [ .items[]
+          | select(item_type(.) == "Workflow")
+          | . as $item
+          | ($open[] | select(.number == $item.content.number)) as $issue
+          | select(terminal($item.status) | not)
+          | {
+              number: $issue.number,
+              title: $issue.title,
+              url: $issue.url,
+              createdAt: $issue.createdAt,
+              status: ($item.status // ""),
+              priority: ($item.priority // ""),
+              type: (item_type($item))
+            }
+        ]
+      }
+  ' 2>/dev/null)"; then
     echo "Warning: failed to parse GitHub Project items while discovering Workflow Type issues." >&2
     printf '[]\n'
+    return 0
   fi
+
+  _lowti_matched_keys="$(printf '%s' "$_lowti_result_json" | jq -c '.matched_keys' 2>/dev/null)"
+  _lowti_results="$(printf '%s' "$_lowti_result_json" | jq -c '.results' 2>/dev/null)"
+
+  if [ "$_lowti_matched_keys" = "[]" ]; then
+    _lowti_item_keys_display="$(printf '%s' "$_lowti_result_json" | jq -r '.item_keys | join(", ")' 2>/dev/null)"
+    _lowti_candidate_display="$(printf '%s' "$_lowti_candidate_keys_json" | jq -r 'join(", ")' 2>/dev/null)"
+    echo "Warning: none of the expected Type field keys (${_lowti_candidate_display}) were found on gh project item-list items (keys present: ${_lowti_item_keys_display}). Cannot distinguish 'no open Workflow items' from 'Type field unreadable' — verify issue_tracker.custom_fields.type_field or the project's Custom Type / Type field name." >&2
+  fi
+
+  printf '%s\n' "${_lowti_results:-[]}"
+}
+
+# _workflow_lowti_candidate_keys_json <preferred_field_name>
+#
+# Builds the ordered, de-duplicated JSON array of gh project item-list keys
+# to check for the Type field value, honoring the same lookup order as
+# workflow_github_project_type_field_json: preferred field name (from
+# issue_tracker.custom_fields.type_field), then "Custom Type", "CustomType",
+# then "Type". Each field display name is converted to its gh item-list key
+# by lowercasing only the first character.
+_workflow_lowti_candidate_keys_json() {
+  local preferred_field="$1"
+  local -a names=("$preferred_field" "Custom Type" "CustomType" "Type")
+  local -a keys=()
+  local name key first rest existing dup
+
+  for name in "${names[@]}"; do
+    [ -z "$name" ] && continue
+    first="$(printf '%s' "${name:0:1}" | tr '[:upper:]' '[:lower:]')"
+    rest="${name:1}"
+    key="${first}${rest}"
+    dup=0
+    for existing in "${keys[@]:-}"; do
+      if [ "$existing" = "$key" ]; then
+        dup=1
+        break
+      fi
+    done
+    [ "$dup" -eq 0 ] && keys+=("$key")
+  done
+
+  if [ "${#keys[@]}" -eq 0 ]; then
+    printf '[]'
+    return 0
+  fi
+  printf '%s\n' "${keys[@]}" | jq -R . | jq -sc .
 }

--- a/scripts/development-workflow/workflow-lib.sh
+++ b/scripts/development-workflow/workflow-lib.sh
@@ -3040,6 +3040,7 @@ list_open_workflow_type_issues() {
   local project_number owner open_issues project_items repo_owner repo_name repo_slug
   local _lowti_preferred_field _lowti_candidate_keys_json _lowti_result_json
   local _lowti_matched_keys _lowti_results _lowti_item_keys_display _lowti_candidate_display
+  local _lowti_item_count
 
   local _lowti_provider
   _lowti_provider="$(workflow_normalize_issue_tracker_provider "$(workflow_issue_tracker_provider_raw)")"
@@ -3113,6 +3114,7 @@ list_open_workflow_type_issues() {
     | {
         matched_keys: $matched_keys,
         item_keys: $item_keys,
+        item_count: (.items | length),
         results: [ .items[]
           | select(item_type(.) == "Workflow")
           | . as $item
@@ -3137,8 +3139,9 @@ list_open_workflow_type_issues() {
 
   _lowti_matched_keys="$(printf '%s' "$_lowti_result_json" | jq -c '.matched_keys' 2>/dev/null)"
   _lowti_results="$(printf '%s' "$_lowti_result_json" | jq -c '.results' 2>/dev/null)"
+  _lowti_item_count="$(printf '%s' "$_lowti_result_json" | jq -r '.item_count' 2>/dev/null)"
 
-  if [ "$_lowti_matched_keys" = "[]" ]; then
+  if [ "$_lowti_matched_keys" = "[]" ] && [ "${_lowti_item_count:-0}" -gt 0 ] 2>/dev/null; then
     _lowti_item_keys_display="$(printf '%s' "$_lowti_result_json" | jq -r '.item_keys | join(", ")' 2>/dev/null)"
     _lowti_candidate_display="$(printf '%s' "$_lowti_candidate_keys_json" | jq -r 'join(", ")' 2>/dev/null)"
     echo "Warning: none of the expected Type field keys (${_lowti_candidate_display}) were found on gh project item-list items (keys present: ${_lowti_item_keys_display}). Cannot distinguish 'no open Workflow items' from 'Type field unreadable' — verify issue_tracker.custom_fields.type_field or the project's Custom Type / Type field name." >&2


### PR DESCRIPTION
## Summary

`list_open_workflow_type_issues` in `scripts/development-workflow/workflow-lib.sh` hardcoded a `.type` field-key lookup against `gh project item-list --format json` output. Because `gh` derives each item's field key from the field's **display name** (lowercasing only the first character — e.g. `Custom Type` -> `custom Type`), and because `Type` is a reserved GitHub Projects field name that no conforming board can actually use for its classification field, the hardcoded `.type` selector never matched anything on a real board. The release protocol's §7.2 "downstream script-bug review" gate consumed this helper and silently returned `[]` on every release, indistinguishable from "nothing open."

## Fix

- Resolve the field by name using the same lookup order as `workflow_github_project_type_field_json`: `issue_tracker.custom_fields.type_field` (if configured), then `Custom Type`, then `CustomType`, then `Type` — each converted to its `gh` item-list key.
- When none of those keys are present anywhere in the item-list payload, emit a distinct stderr warning so a genuinely empty result ("no open Workflow items") is no longer indistinguishable from an unreadable Type field.
- Fixed the shipped test fixture, which mocked an impossible `"type":"Workflow"` key; it now uses `"custom Type"` (the key a field literally named `Custom Type` actually produces).
- Added regression tests for: the default `Custom Type` field, a board using `issue_tracker.custom_fields.type_field`, and the unreadable/missing-field warning case.
- Added a `CHANGELOG.md` entry under `[Unreleased]` → `### Fixed`.

## Testing

- `bash scripts/development-workflow/tests/test-workflow-lib-github-projects.sh` — 162 passed, 0 failed.
- Confirmed the new/updated tests fail against the pre-fix helper (5 failures) before applying the fix.
- `shellcheck scripts/development-workflow/workflow-lib.sh` — only a pre-existing unrelated SC2016 info-level finding at line 487.
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop` — clean.
- `npx markdownlint-cli2 "CHANGELOG.md"` — 0 errors.
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md` — passed.

## Scope note

Issue #1400 reported two defects sharing one wrong assumption (that the classification field is reachable as `Type`/`.type`), in two different files. This PR fixes Defect 1 only (`list_open_workflow_type_issues` hardcoding `.type`, the release §7.2 gate false-green). Defect 2 (`00-add-backlog-item-protocol.md` never documents `add-backlog-item.sh --type`) is unrelated code (a different file, no shared logic) and is tracked separately as #1545 so it is not silently dropped when this PR closes #1400. The issue's "Side note" about test suites not running in CI is already tracked as #1537.

Fixes #1400

Related: #1545 (Defect 2 follow-up), #1537 (CI coverage side note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workflow issue discovery across GitHub Projects by recognizing configured and custom Type field names.
  - Preserved filtering of completed or terminal-status items.
  - Added a clear warning when Type information cannot be read from a populated project board.
  - Empty project boards no longer produce unnecessary warnings.

- **Tests**
  - Expanded regression coverage for custom fields, configured field names, unreadable fields, and empty boards.

- **Documentation**
  - Added a changelog entry describing the GitHub Projects Type-field improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->