### PR TITLE
fix(item-completion-self-check): flag wrong --worktree-path distinctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -986,6 +986,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (the canonical routing specification) is updated to document the new
   `tracker_unavailable` mode, its decision-table row, edge cases, and handoff
   mapping (routing layer version 1.0 → 1.1).
+- **`item-completion-self-check.sh` no longer reports an indistinguishable
+  false discrepancy when the caller's `--worktree-path` is the main clone
+  (or the wrong sibling worktree)** (#1333): when `--worktree-path` resolves
+  to a path other than the item's actual worktree, `repository.branch`
+  reported a generic `discrepancy` (`HEAD` was the trunk branch checked out
+  in the main clone rather than the item branch) that looked identical to
+  genuine branch contamination — a downstream 5-sub-item epic run hit this
+  in every runner completion report and had to be manually triaged. The
+  script now also inspects `git worktree list --porcelain` (which enumerates
+  every linked worktree regardless of which one it is invoked from) for the
+  path where the expected branch is actually checked out. When that path
+  differs from the supplied `--worktree-path`, a new, distinct
+  `caller.worktree_path` diagnostic row is added alongside the existing
+  `repository.branch` row, naming the actual worktree path and the correct
+  `--worktree-path` to re-run with. This is strictly additive: the
+  pre-existing `repository.branch`/`workspace.worktrees` rows and their
+  `discrepancy` outcome are unchanged, so a genuine contamination case
+  (the expected branch not checked out anywhere) still reports a plain,
+  unexplained discrepancy with no caller-error row and no change to the
+  non-zero exit code.
 
 ### Changed
 

--- a/scripts/development-workflow/item-completion-self-check.sh
+++ b/scripts/development-workflow/item-completion-self-check.sh
@@ -447,7 +447,51 @@ reviewer_check_names_json() {
   printf '%s\n' "${check_names[@]}" | jq -R . | jq -s 'unique'
 }
 
+# worktree_path_for_branch <branch> <git-worktree-list---porcelain-output>
+#
+# Parses `git worktree list --porcelain` output and prints the worktree path
+# whose checked-out branch is <branch>, or nothing if no linked worktree has
+# that branch checked out. `git worktree list` enumerates every worktree
+# linked to the repository regardless of which one it is invoked from, so
+# this works even when $repo_root/$worktree_path is the wrong path.
+worktree_path_for_branch() {
+  local branch="$1"
+  local list_output="$2"
+  printf '%s\n' "$list_output" | awk -v want="refs/heads/$branch" '
+    /^worktree / { path = substr($0, 10) }
+    /^branch / { if ($0 == "branch " want) { print path; exit } }
+  '
+}
+
 cd "$repo_root"
+
+resolved_repo_root="$(pwd -P)"
+
+worktree_list=""
+worktree_list_available="true"
+if ! worktree_list="$(git worktree list --porcelain 2>&1)"; then
+  worktree_list_available="false"
+fi
+
+# Detect the "caller passed the wrong --worktree-path" pattern: the expected
+# branch IS checked out somewhere in this repository's worktrees, just not at
+# the path the caller supplied (e.g. the main clone instead of the actual
+# item worktree, or a sibling item's worktree). When true, a branch mismatch
+# below is a caller path error, not evidence of branch contamination, and
+# gets its own distinct diagnostic row instead of being folded into the
+# generic repository.branch discrepancy.
+expected_branch_worktree_path=""
+resolved_expected_branch_worktree_path=""
+caller_worktree_path_mismatch="false"
+if [ "$worktree_list_available" = "true" ]; then
+  expected_branch_worktree_path="$(worktree_path_for_branch "$expected_branch" "$worktree_list")"
+  if [ -n "$expected_branch_worktree_path" ]; then
+    resolved_expected_branch_worktree_path="$(CDPATH='' cd -- "$expected_branch_worktree_path" 2>/dev/null && pwd -P || printf '%s' "$expected_branch_worktree_path")"
+    if [ "$resolved_expected_branch_worktree_path" != "$resolved_repo_root" ]; then
+      caller_worktree_path_mismatch="true"
+    fi
+  fi
+fi
 
 current_branch=""
 returned_to_expected_base="false"
@@ -461,6 +505,9 @@ if current_branch="$(git rev-parse --abbrev-ref HEAD 2>&1)"; then
     add_row "repository.branch" "verified" "$current_branch" "local checkout returned to expected base; PR head check verifies item branch"
   else
     add_row "repository.branch" "discrepancy" "expected=$expected_branch observed=$current_branch" "git rev-parse --abbrev-ref HEAD"
+    if [ "$caller_worktree_path_mismatch" = "true" ]; then
+      add_row "caller.worktree_path" "discrepancy" "expected branch $expected_branch is checked out at $resolved_expected_branch_worktree_path, not the supplied --worktree-path $resolved_repo_root; re-run this check with --worktree-path $resolved_expected_branch_worktree_path" "git worktree list --porcelain"
+    fi
   fi
 else
   add_row "repository.branch" "unavailable_required" "$current_branch" "git rev-parse --abbrev-ref HEAD"
@@ -473,7 +520,6 @@ else
   add_row "repository.head" "unavailable_required" "unable to read HEAD" "$head_sha"
 fi
 
-resolved_repo_root="$(pwd -P)"
 resolved_worktree_path="$(CDPATH='' cd -- "$worktree_path" 2>/dev/null && pwd -P || printf '%s' "$worktree_path")"
 if [ "$resolved_repo_root" = "$resolved_worktree_path" ]; then
   add_row "workspace.path" "verified" "$resolved_worktree_path" "pwd -P"
@@ -494,8 +540,7 @@ else
   add_row "workspace.status" "unavailable_required" "$status_short" "git status --short"
 fi
 
-worktree_list=""
-if worktree_list="$(git worktree list --porcelain 2>&1)"; then
+if [ "$worktree_list_available" = "true" ]; then
   if printf '%s\n' "$worktree_list" | grep -Fq "branch refs/heads/$expected_branch"; then
     add_row "workspace.worktrees" "verified" "expected branch present; path=$resolved_worktree_path" "git worktree list --porcelain"
   elif is_true "$returned_to_expected_base"; then

--- a/scripts/development-workflow/item-completion-self-check.sh
+++ b/scripts/development-workflow/item-completion-self-check.sh
@@ -466,6 +466,7 @@ worktree_path_for_branch() {
 cd "$repo_root"
 
 resolved_repo_root="$(pwd -P)"
+resolved_worktree_path="$(CDPATH='' cd -- "$worktree_path" 2>/dev/null && pwd -P || printf '%s' "$worktree_path")"
 
 worktree_list=""
 worktree_list_available="true"
@@ -487,7 +488,7 @@ if [ "$worktree_list_available" = "true" ]; then
   expected_branch_worktree_path="$(worktree_path_for_branch "$expected_branch" "$worktree_list")"
   if [ -n "$expected_branch_worktree_path" ]; then
     resolved_expected_branch_worktree_path="$(CDPATH='' cd -- "$expected_branch_worktree_path" 2>/dev/null && pwd -P || printf '%s' "$expected_branch_worktree_path")"
-    if [ "$resolved_expected_branch_worktree_path" != "$resolved_repo_root" ]; then
+    if [ "$resolved_expected_branch_worktree_path" != "$resolved_worktree_path" ]; then
       caller_worktree_path_mismatch="true"
     fi
   fi
@@ -506,7 +507,7 @@ if current_branch="$(git rev-parse --abbrev-ref HEAD 2>&1)"; then
   else
     add_row "repository.branch" "discrepancy" "expected=$expected_branch observed=$current_branch" "git rev-parse --abbrev-ref HEAD"
     if [ "$caller_worktree_path_mismatch" = "true" ]; then
-      add_row "caller.worktree_path" "discrepancy" "expected branch $expected_branch is checked out at $resolved_expected_branch_worktree_path, not the supplied --worktree-path $resolved_repo_root; re-run this check with --worktree-path $resolved_expected_branch_worktree_path" "git worktree list --porcelain"
+      add_row "caller.worktree_path" "discrepancy" "expected branch $expected_branch is checked out at $resolved_expected_branch_worktree_path, not the supplied --worktree-path $resolved_worktree_path; re-run this check with --worktree-path $resolved_expected_branch_worktree_path" "git worktree list --porcelain"
     fi
   fi
 else
@@ -520,7 +521,6 @@ else
   add_row "repository.head" "unavailable_required" "unable to read HEAD" "$head_sha"
 fi
 
-resolved_worktree_path="$(CDPATH='' cd -- "$worktree_path" 2>/dev/null && pwd -P || printf '%s' "$worktree_path")"
 if [ "$resolved_repo_root" = "$resolved_worktree_path" ]; then
   add_row "workspace.path" "verified" "$resolved_worktree_path" "pwd -P"
 else

--- a/scripts/development-workflow/tests/test-item-completion-self-check.sh
+++ b/scripts/development-workflow/tests/test-item-completion-self-check.sh
@@ -231,6 +231,18 @@ run_contains() {
   fi
 }
 
+run_not_contains() {
+  local name="$1" unexpected="$2" actual="$3"
+  if grep -Fq -- "$unexpected" <<< "$actual"; then
+    echo "FAIL: $name - expected output NOT to contain '${unexpected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  else
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  fi
+}
+
 run_test() {
   local name="$1" expected="$2" actual="$3"
   if [ "$actual" = "$expected" ]; then
@@ -344,6 +356,72 @@ out="$(self_check_output \
 run_test "parallel_worktree_exit_zero" "0" "$(status_code "$out")"
 run_contains "parallel_worktree_path" "$worktree_path" "$(body "$out")"
 run_contains "parallel_worktree_evidence" "| workspace.worktrees | verified |" "$(body "$out")"
+
+# Regression coverage for issue #1333: item-completion-self-check.sh must not
+# emit an indistinguishable-from-contamination discrepancy when the caller
+# passes the main clone (or any wrong sibling worktree) as --worktree-path
+# instead of the actual item worktree. The three cases below establish: (1)
+# the false-positive scenario now surfaces a distinct caller.worktree_path
+# diagnostic row rather than only a generic repository.branch discrepancy,
+# (2) passing the correct worktree path never produces that diagnostic row,
+# and (3) genuine branch contamination (the expected branch is not checked
+# out anywhere at all) still reports a plain discrepancy with no diagnostic
+# row suppressing or explaining it away — the fix must not become more
+# permissive.
+
+repo="$(make_repo caller-passed-main-clone)"
+worktree_path="$TMP_ROOT/caller-passed-main-clone-actual-worktree"
+git -C "$repo" switch -q develop
+git -C "$repo" branch -D feature/1202-self-check >/dev/null
+git -C "$repo" worktree add -q -b feature/1202-self-check "$worktree_path"
+worktree_path="$(CDPATH='' cd -- "$worktree_path" && pwd -P)"
+export WORKFLOW_SELF_CHECK_TRACKER_STATUS="Development in Review"
+out="$(self_check_output \
+  --repo-root "$repo" \
+  --issue 1202 \
+  --branch feature/1202-self-check \
+  --stage implementation \
+  --worktree-path "$repo" \
+  --require-ci-green false \
+  --tracker-required false)"
+run_test "caller_wrong_path_exit_one" "1" "$(status_code "$out")"
+run_contains "caller_wrong_path_branch_discrepancy" "| repository.branch | discrepancy | expected=feature/1202-self-check observed=develop |" "$(body "$out")"
+run_contains "caller_wrong_path_hint_row_actual" "| caller.worktree_path | discrepancy | expected branch feature/1202-self-check is checked out at $worktree_path" "$(body "$out")"
+run_contains "caller_wrong_path_hint_row_supplied" "not the supplied --worktree-path $repo" "$(body "$out")"
+
+repo="$(make_repo caller-passed-correct-path)"
+worktree_path="$TMP_ROOT/caller-passed-correct-path-actual-worktree"
+git -C "$repo" switch -q develop
+git -C "$repo" branch -D feature/1202-self-check >/dev/null
+git -C "$repo" worktree add -q -b feature/1202-self-check "$worktree_path"
+worktree_path="$(CDPATH='' cd -- "$worktree_path" && pwd -P)"
+export WORKFLOW_SELF_CHECK_TRACKER_STATUS="Development in Review"
+out="$(self_check_output \
+  --repo-root "$worktree_path" \
+  --issue 1202 \
+  --branch feature/1202-self-check \
+  --stage implementation \
+  --worktree-path "$worktree_path" \
+  --require-ci-green false \
+  --tracker-required false)"
+run_test "caller_correct_path_exit_zero" "0" "$(status_code "$out")"
+run_contains "caller_correct_path_branch_verified" "| repository.branch | verified | feature/1202-self-check |" "$(body "$out")"
+run_not_contains "caller_correct_path_no_hint_row" "caller.worktree_path" "$(body "$out")"
+
+repo="$(make_repo true-branch-contamination)"
+git -C "$repo" switch -q -c totally-unrelated-branch
+export WORKFLOW_SELF_CHECK_TRACKER_STATUS="Development in Review"
+out="$(self_check_output \
+  --repo-root "$repo" \
+  --issue 1202 \
+  --branch feature/1202-self-check \
+  --stage implementation \
+  --worktree-path "$repo" \
+  --require-ci-green false \
+  --tracker-required false)"
+run_test "true_contamination_exit_one" "1" "$(status_code "$out")"
+run_contains "true_contamination_branch_discrepancy" "| repository.branch | discrepancy | expected=feature/1202-self-check observed=totally-unrelated-branch |" "$(body "$out")"
+run_not_contains "true_contamination_no_hint_row" "caller.worktree_path" "$(body "$out")"
 
 repo="$(make_repo returned-to-base)"
 git -C "$repo" switch -q develop

--- a/scripts/development-workflow/tests/test-item-completion-self-check.sh
+++ b/scripts/development-workflow/tests/test-item-completion-self-check.sh
@@ -423,6 +423,33 @@ run_test "true_contamination_exit_one" "1" "$(status_code "$out")"
 run_contains "true_contamination_branch_discrepancy" "| repository.branch | discrepancy | expected=feature/1202-self-check observed=totally-unrelated-branch |" "$(body "$out")"
 run_not_contains "true_contamination_no_hint_row" "caller.worktree_path" "$(body "$out")"
 
+# Regression coverage for a CodeRabbit finding on PR #1546: when --repo-root
+# and --worktree-path are supplied as two different paths, the
+# caller.worktree_path diagnostic must compare against the actual
+# --worktree-path value, not against the (possibly different) --repo-root
+# value it happens to land in after `cd`. Otherwise a wrong --repo-root with
+# an already-correct --worktree-path produces a false caller.worktree_path
+# row that tells the caller to "fix" the one flag that was already right.
+repo="$(make_repo repo-root-worktree-path-differ)"
+worktree_path="$TMP_ROOT/repo-root-worktree-path-differ-actual-worktree"
+git -C "$repo" switch -q develop
+git -C "$repo" branch -D feature/1202-self-check >/dev/null
+git -C "$repo" worktree add -q -b feature/1202-self-check "$worktree_path"
+worktree_path="$(CDPATH='' cd -- "$worktree_path" && pwd -P)"
+export WORKFLOW_SELF_CHECK_TRACKER_STATUS="Development in Review"
+out="$(self_check_output \
+  --repo-root "$repo" \
+  --issue 1202 \
+  --branch feature/1202-self-check \
+  --stage implementation \
+  --worktree-path "$worktree_path" \
+  --require-ci-green false \
+  --tracker-required false)"
+run_test "repo_root_worktree_path_differ_exit_one" "1" "$(status_code "$out")"
+run_contains "repo_root_worktree_path_differ_branch_discrepancy" "| repository.branch | discrepancy | expected=feature/1202-self-check observed=develop |" "$(body "$out")"
+run_not_contains "repo_root_worktree_path_differ_no_hint_row" "caller.worktree_path" "$(body "$out")"
+run_contains "repo_root_worktree_path_differ_workspace_path_discrepancy" "| workspace.path | discrepancy |" "$(body "$out")"
+
 repo="$(make_repo returned-to-base)"
 git -C "$repo" switch -q develop
 export WORKFLOW_SELF_CHECK_TRACKER_STATUS="Development in Review"


### PR DESCRIPTION
## Summary

`item-completion-self-check.sh` reported a generic `repository.branch` discrepancy — indistinguishable from real branch contamination — whenever the caller passed the wrong `--worktree-path` (e.g. the main clone or a sibling item's worktree) instead of the actual item worktree. A downstream 5-sub-item epic run hit this in every runner completion report and had to be manually triaged and dismissed (see issue #1333 for the full report).

## Root cause (established before any change)

- The documented call pattern (Protocol 91) passes only `--worktree-path`; `--repo-root` defaults to it, so `cd "$repo_root"` lands in whatever the caller passed.
- When that path is the main clone, `git rev-parse --abbrev-ref HEAD` there reports the trunk branch (e.g. `develop`), which mismatches `expected_branch` → `repository.branch: discrepancy`, with no way to tell this apart from genuine contamination.
- `workspace.worktrees` was already correct in this scenario (it lists all linked worktrees regardless of cwd), and `workspace.path` is a tautological self-comparison under this call pattern (repo_root always equals worktree_path by default), so it never actually fires — contrary to my initial reading of the issue text, only `repository.branch` reproduces.
- Confirmed empirically against `develop` HEAD with a live repro (main clone path passed for this very item, expected branch checked out in `.worktrees/item-1333`).

## Fix

Adds a `worktree_path_for_branch()` helper that parses `git worktree list --porcelain` (already fetched once, now shared instead of re-fetched) to find the actual path where `expected_branch` is checked out. When that path differs from the resolved `--worktree-path` **and** the branch check would otherwise fire a discrepancy, a new, distinct `caller.worktree_path` row is added alongside the existing `repository.branch` row, naming the real path and the correct `--worktree-path` to re-run with.

This is strictly additive:
- The `repository.branch` row and its `discrepancy` result, the exit code, and `workspace.worktrees` are all unchanged.
- Genuine branch contamination (expected branch not checked out **anywhere**) still reports a plain `repository.branch: discrepancy` with **no** `caller.worktree_path` row and no change in exit code — the check does not become more permissive.

## Tests

10 new regression assertions in `scripts/development-workflow/tests/test-item-completion-self-check.sh`:
- **Main-clone-path case**: caller passes the main clone path while the item worktree exists elsewhere → `repository.branch: discrepancy` (unchanged) + new `caller.worktree_path: discrepancy` row naming the real path.
- **Genuine worktree path case**: caller passes the correct worktree path → `repository.branch: verified`, no `caller.worktree_path` row.
- **Real discrepancy case**: expected branch genuinely not checked out anywhere → `repository.branch: discrepancy` fires, no `caller.worktree_path` row (nothing to point to) — confirms the fix cannot pass by suppressing genuine findings.

All 10 new assertions confirmed to fail against the pre-fix script (via manual revert check) and pass after the fix. Full local suite: 79 passed / 12 failed — the 12 failures are **pre-existing** on unmodified `develop` HEAD (confirmed by baseline run before touching the script) and unrelated (reviewer-check-name exclusion + review-thread test fixtures assume a `bugbot`/legacy config shape that no longer matches this repo's committed `.ai-dev-workflow.yaml`; consistent with issue #1537 noting this suite isn't CI-exercised). Not in scope for #1333; same failure set before and after this change.

## Note

`test-item-completion-self-check.sh` is not executed by CI (issue #1537), so this local run is the only verification this change receives.

Closes #1333

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree validation to detect when the supplied path does not match the worktree containing the expected branch.
  * Added clear diagnostics showing the actual and expected worktree paths.
  * Preserved existing branch and worktree discrepancy reporting and exit behavior.

* **Documentation**
  * Added an Unreleased changelog entry describing the enhanced validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->