### PR TITLE
fix(pr-review-loop): replied thread no longer blocks re-review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **A replied-to but unresolved review thread no longer blocks the very
+  re-review it was replied about** (#1508): `check_unresolved_threads` in
+  `scripts/development-workflow/pr-review-loop.sh` gated the phase-1
+  "should we trigger a new review" check in `run_codex_github_review` and
+  `run_claude_code_action_review` purely on GraphQL `isResolved` state. When a
+  fixer pushed a fix and replied to a thread without also calling
+  `resolveReviewThread` — the normal state immediately after a push — the
+  loop returned `RESULT=needs_fixes REASON=existing_findings` and never
+  re-triggered the platform review, so the reviewer never saw the fix commit
+  until a human resolved the thread manually out of band. `check_unresolved_
+  threads` now takes a required `mode` argument. `mode=provisional`, used only
+  by those two phase-1 pre-trigger gates, additionally treats a thread as not
+  blocking re-review when its last comment is from a non-bot author posted
+  after the PR's current head-commit `committedDate` — modeling "fixed and
+  replied to, awaiting explicit resolution". Every gate that decides
+  `RESULT=clean` (the aggregate thread gate, `coderabbit_thread_gate_clean`,
+  the post-trigger findings recount, and the post-clean recheck) keeps using
+  `mode=strict`, which is byte-for-byte the prior behavior — a reply alone
+  still can never mark a thread resolved there, so this cannot reintroduce the
+  false-clean class fixed by #1531 and #1437. Unrecognized mode values fail
+  safe to `strict`. New regression tests in
+  `scripts/development-workflow/tests/test-pr-review-loop.sh` cover both
+  directions: the reply-after-head-commit case that must not block
+  re-triggering (confirmed to fail against the pre-fix code), and reply-
+  before-head-commit / bot-authored-reply / no-reply / true-resolution cases
+  that must still block under both modes.
 - **`post-merge-cleanup.sh` no longer closes the wrong issue for team-prefixed
   branch slugs** (#1511): the team-prefixed identifier pattern
   (`^(fix|feature|hotfix|refactor)/([a-zA-Z]{2,6}-([0-9]+))($|-)`) matches any

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -853,9 +853,13 @@ run_codex_github_review() {
   cd_workflow_repo_root
   repo="$(repo_slug)"
 
-  # Phase 1: Check for existing unresolved review threads from the codex bot
+  # Phase 1: Check for existing unresolved review threads from the codex bot.
+  # mode=provisional (#1508): a thread whose last comment is a non-bot reply
+  # posted after the current head commit does not block re-triggering the
+  # review here — see check_unresolved_threads for why this cannot cause a
+  # false RESULT=clean.
   set +e
-  thread_check_output="$(check_unresolved_threads "$pr_number" "$repo" "$graphql_bot_login")"
+  thread_check_output="$(check_unresolved_threads "$pr_number" "$repo" provisional "$graphql_bot_login")"
   thread_check_status=$?
   set -e
   if [ "$thread_check_status" -eq 0 ]; then
@@ -927,8 +931,11 @@ run_codex_github_review() {
       ;;
     1)
       unresolved_count=0
+      # mode=strict: this recount feeds the caller's needs_fixes/COMMENT_COUNT
+      # reporting and must reflect true resolution state, not the provisional
+      # reply relaxation used to decide whether to trigger the review above.
       set +e
-      thread_check_output="$(check_unresolved_threads "$pr_number" "$repo" "$graphql_bot_login")"
+      thread_check_output="$(check_unresolved_threads "$pr_number" "$repo" strict "$graphql_bot_login")"
       thread_check_status=$?
       set -e
       if [ "$thread_check_status" -eq 0 ]; then
@@ -997,9 +1004,10 @@ run_claude_code_action_review() {
   cd_workflow_repo_root
   repo="$(repo_slug)"
 
-  # Phase 1: Check for existing unresolved review threads from the Claude Code Action bot
+  # Phase 1: Check for existing unresolved review threads from the Claude Code Action bot.
+  # mode=provisional (#1508): see run_codex_github_review's phase 1 for rationale.
   set +e
-  thread_check_output="$(check_unresolved_threads "$pr_number" "$repo" "$graphql_bot_login")"
+  thread_check_output="$(check_unresolved_threads "$pr_number" "$repo" provisional "$graphql_bot_login")"
   thread_check_status=$?
   set -e
   if [ "$thread_check_status" -eq 0 ]; then
@@ -1055,8 +1063,11 @@ run_claude_code_action_review() {
       ;;
     1)
       unresolved_count=0
+      # mode=strict: this recount feeds the caller's needs_fixes/COMMENT_COUNT
+      # reporting and must reflect true resolution state, not the provisional
+      # reply relaxation used to decide whether to trigger the review above.
       set +e
-      thread_check_output="$(check_unresolved_threads "$pr_number" "$repo" "$graphql_bot_login")"
+      thread_check_output="$(check_unresolved_threads "$pr_number" "$repo" strict "$graphql_bot_login")"
       thread_check_status=$?
       set -e
       if [ "$thread_check_status" -eq 0 ]; then
@@ -3838,7 +3849,9 @@ coderabbit_thread_gate_clean() {
   while true; do
     thread_audit_attempt=$((thread_audit_attempt + 1))
     set +e
-    out="$(check_unresolved_threads "$pr_number" "$repo" "$graphql_bot_login")"
+    # mode=strict: this gate decides RESULT=clean for CodeRabbit and must
+    # never be relaxed by a reply-without-resolve (see check_unresolved_threads).
+    out="$(check_unresolved_threads "$pr_number" "$repo" strict "$graphql_bot_login")"
     st=$?
     eval "$prev_errexit"
 
@@ -4983,10 +4996,25 @@ check_unresolved_threads() {
   # Arguments:
   #   $1    pr_number  - PR number (integer)
   #   $2    repo       - "owner/repo" slug
-  #   $3... bot_logins - one or more bot login strings (e.g. "coderabbitai", "devin-ai-integration")
+  #   $3    mode       - "strict" or "provisional" (see below); unrecognized values
+  #                       fail safe to "strict"
+  #   $4... bot_logins - one or more bot login strings (e.g. "coderabbitai", "devin-ai-integration")
   #
   # Bot logins are passed as individual positional arguments (not space-separated)
   # to ensure safe iteration in the comparison loop without word splitting.
+  #
+  # mode=provisional (issue #1508): in addition to the strict resolution checks
+  # above, a thread is also treated as NOT unresolved when its LAST comment was
+  # authored by someone other than a configured bot login (i.e. a maintainer or
+  # fixer-agent reply) AND that comment's createdAt is after the PR's current
+  # head-commit committedDate. This models "fixed and replied to, but the human/
+  # agent has not yet called resolveReviewThread" — the common state immediately
+  # after a fixer pushes (see #1508). It exists ONLY to unblock phase-1 gates that
+  # decide whether to re-trigger a review; it must never be used by a gate that
+  # decides RESULT=clean. Callers making that "declare clean" decision (the
+  # aggregate thread gate, coderabbit_thread_gate_clean, and any post-review
+  # findings recount) must keep using mode=strict, so a reply alone can never
+  # cause a false RESULT=clean — only true GraphQL resolution can.
   #
   # Re-enable errexit within this function. When called from a command substitution
   # with set +e active in the parent (as in the thread gate), the subshell inherits
@@ -4996,7 +5024,12 @@ check_unresolved_threads() {
   set -e
   local pr_number="$1"
   local repo="$2"
-  shift 2
+  local mode="$3"
+  shift 3
+  case "$mode" in
+    provisional) ;;
+    *) mode="strict" ;;
+  esac
   # Remaining positional args are bot login strings; store in an array for safe iteration.
   local -a bot_logins=("$@")
 
@@ -5009,11 +5042,21 @@ check_unresolved_threads() {
   local has_next_page="true"
   local page=0
   local max_pages=10
+  local head_committed_date=""
 
-  # GraphQL query: paginate reviewThreads 100 at a time, fetch first comment per thread.
+  # GraphQL query: paginate reviewThreads 100 at a time, fetch the first comment
+  # (aliased firstComment) per thread. In provisional mode, also fetch each
+  # thread's last comment (aliased lastComment) and the PR head commit's
+  # committedDate, needed for the post-push-reply check above.
+  local nodes_fields='id isResolved isOutdated firstComment:comments(first:1){nodes{author{login}body}}'
+  local pr_fields=''
+  if [ "$mode" = "provisional" ]; then
+    nodes_fields="$nodes_fields"'lastComment:comments(last:1){nodes{author{login}body createdAt}}'
+    pr_fields='commits(last:1){nodes{commit{committedDate}}}'
+  fi
   # Using inline query string to avoid heredoc quoting issues in subshells.
   local graphql_query
-  graphql_query='query($owner:String!,$repo:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100,after:$cursor){pageInfo{hasNextPage endCursor}nodes{id isResolved isOutdated comments(first:1){nodes{author{login}body}}}}}}}'
+  graphql_query='query($owner:String!,$repo:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){'"$pr_fields"'reviewThreads(first:100,after:$cursor){pageInfo{hasNextPage endCursor}nodes{'"$nodes_fields"'}}}}}'
 
   while [ "$has_next_page" = "true" ]; do
     page=$((page + 1))
@@ -5033,22 +5076,26 @@ check_unresolved_threads() {
       result="$(gh api graphql \
         -f query="$graphql_query" \
         -f owner="$owner" -f repo="$repo_name" -F pr="$pr_number" -f cursor="$cursor" \
-        --jq '.data.repository.pullRequest.reviewThreads')" \
+        --jq '.data.repository.pullRequest')" \
         || { echo "WARN: check_unresolved_threads: GraphQL query failed for PR #$pr_number" >&2; return 3; }
     else
       result="$(gh api graphql \
         -f query="$graphql_query" \
         -f owner="$owner" -f repo="$repo_name" -F pr="$pr_number" \
-        --jq '.data.repository.pullRequest.reviewThreads')" \
+        --jq '.data.repository.pullRequest')" \
         || { echo "WARN: check_unresolved_threads: GraphQL query failed for PR #$pr_number" >&2; return 3; }
+    fi
+
+    if [ "$mode" = "provisional" ]; then
+      head_committed_date="$(printf '%s\n' "$result" | jq -r '.commits.nodes[0].commit.committedDate // ""')"
     fi
 
     # Use jq -r (not -re) for boolean/nullable fields: jq -e exits non-zero when the
     # output value is false or null, which would misinterpret valid values like
     # hasNextPage=false or isResolved=false as errors. Rely on gh api's own exit code
     # (caught above) for real API failures; use jq -r only for data extraction.
-    has_next_page="$(printf '%s\n' "$result" | jq -r '.pageInfo.hasNextPage')"
-    cursor="$(printf '%s\n' "$result" | jq -r '.pageInfo.endCursor // empty')"
+    has_next_page="$(printf '%s\n' "$result" | jq -r '.reviewThreads.pageInfo.hasNextPage')"
+    cursor="$(printf '%s\n' "$result" | jq -r '.reviewThreads.pageInfo.endCursor // empty')"
 
     local thread_json
     while IFS= read -r thread_json; do
@@ -5057,8 +5104,8 @@ check_unresolved_threads() {
       local is_resolved is_outdated author body
       is_resolved="$(printf '%s\n' "$thread_json" | jq -r '.isResolved')"
       is_outdated="$(printf '%s\n' "$thread_json" | jq -r '.isOutdated // false')"
-      author="$(printf '%s\n' "$thread_json" | jq -r '.comments.nodes[0].author.login // ""')"
-      body="$(printf '%s\n' "$thread_json" | jq -r '.comments.nodes[0].body // ""')"
+      author="$(printf '%s\n' "$thread_json" | jq -r '.firstComment.nodes[0].author.login // ""')"
+      body="$(printf '%s\n' "$thread_json" | jq -r '.firstComment.nodes[0].body // ""')"
 
       # Only count threads authored by configured bot logins.
       # Bot logins from the GraphQL API do not include the [bot] suffix.
@@ -5074,8 +5121,27 @@ check_unresolved_threads() {
       if [ "$is_outdated" = "true" ]; then continue; fi
       if printf '%s\n' "$body" | grep -q "✅ Addressed"; then continue; fi
 
+      if [ "$mode" = "provisional" ] && [ -n "$head_committed_date" ]; then
+        local last_author last_created_at last_is_bot
+        last_author="$(printf '%s\n' "$thread_json" | jq -r '.lastComment.nodes[0].author.login // ""')"
+        last_created_at="$(printf '%s\n' "$thread_json" | jq -r '.lastComment.nodes[0].createdAt // ""')"
+        last_is_bot=0
+        if [ -n "$last_author" ]; then
+          for bot_login in "${bot_logins[@]}"; do
+            if [ "$last_author" = "$bot_login" ]; then last_is_bot=1; break; fi
+          done
+        fi
+        if [ "$last_is_bot" -eq 0 ] && [ -n "$last_author" ] && [ -n "$last_created_at" ] \
+            && [ "$last_created_at" \> "$head_committed_date" ]; then
+          local thread_id
+          thread_id="$(printf '%s\n' "$thread_json" | jq -r '.id // "unknown"')"
+          echo "INFO: check_unresolved_threads: thread $thread_id provisionally addressed (reply by $last_author after head commit $head_committed_date) — not blocking re-review; still requires resolveReviewThread before RESULT=clean" >&2
+          continue
+        fi
+      fi
+
       unresolved_count=$((unresolved_count + 1))
-    done < <(printf '%s\n' "$result" | jq -c '.nodes[]')
+    done < <(printf '%s\n' "$result" | jq -c '.reviewThreads.nodes[]')
 
     if [ "$has_next_page" = "true" ] && [ -z "$cursor" ]; then
       echo "WARN: check_unresolved_threads: hasNextPage=true but endCursor is empty for PR #$pr_number; cannot confirm all threads checked" >&2
@@ -7742,7 +7808,9 @@ if [ "$aggregate_result" = "clean" ] || [ "$aggregate_result" = "skipped" ]; the
     while true; do
       thread_audit_attempt=$((thread_audit_attempt + 1))
       set +e
-      thread_check_output="$(check_unresolved_threads "$pr_number" "$(repo_slug)" "${unresolved_bot_logins[@]}")"
+      # mode=strict: this is the aggregate RESULT=clean gate and must never be
+      # relaxed by a reply-without-resolve (see check_unresolved_threads).
+      thread_check_output="$(check_unresolved_threads "$pr_number" "$(repo_slug)" strict "${unresolved_bot_logins[@]}")"
       thread_check_status=$?
       set -e
       if [ "$thread_check_status" -eq 3 ] && [ "$thread_audit_attempt" -le "$thread_audit_max_retries" ]; then
@@ -7824,7 +7892,9 @@ if [ "$aggregate_result" = "clean" ] \
   late_thread_check_output=""
   late_thread_check_status=0
   set +e
-  late_thread_check_output="$(check_unresolved_threads "$pr_number" "$(repo_slug)" "${unresolved_bot_logins[@]}")"
+  # mode=strict: the post-clean recheck also decides RESULT=clean and must
+  # never be relaxed by a reply-without-resolve (see check_unresolved_threads).
+  late_thread_check_output="$(check_unresolved_threads "$pr_number" "$(repo_slug)" strict "${unresolved_bot_logins[@]}")"
   late_thread_check_status=$?
   set -e
 

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -987,13 +987,20 @@ unset MOCK_GH_POST_EXIT
 # non-POST calls. check_unresolved_threads calls `gh api graphql ... --jq ...`
 # which outputs the filtered JSON directly (not the raw gh output). Because the
 # mock gh does not run the --jq filter, we set MOCK_GH_OUTPUT to the pre-filtered
-# JSON that the real GraphQL query would return after --jq.
+# JSON that the real GraphQL query would return after --jq (the --jq filter is
+# `.data.repository.pullRequest`, so MOCK_GH_OUTPUT must be an object with a
+# top-level "reviewThreads" key — and, for provisional-mode cases, a top-level
+# "commits" key holding the PR head commit's committedDate).
 #
 # Important: GitHub's GraphQL API returns author.login WITHOUT the "[bot]" suffix
 # (e.g. "coderabbitai", not "coderabbitai[bot]"). The aggregate gate strips the
 # "[bot]" suffix from bot_login_for_platform() output before adding to
 # unresolved_bot_logins, so check_unresolved_threads always receives login strings
 # without the "[bot]" suffix. All test cases below use sanitized login strings.
+#
+# check_unresolved_threads takes a required "mode" argument ("strict" or
+# "provisional") as its third positional parameter, before the bot_logins
+# varargs. Every call below passes it explicitly.
 #
 # Note: the post-clean recheck logic (POST_CLEAN_RECHECK / LATE_THREADS_FOUND)
 # lives in the main execution block which is skipped by HARNESS_MODE=1. Those
@@ -1007,48 +1014,118 @@ echo "=== Area 6: check_unresolved_threads ==="
 unset MOCK_GH_POST_EXIT MOCK_GH_POST_OUTPUT MOCK_GH_CALL_LOG
 
 # test: no review threads — count should be 0
-export MOCK_GH_OUTPUT='{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}'
-actual="$(check_unresolved_threads "1" "owner/repo" "coderabbitai")"
+export MOCK_GH_OUTPUT='{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}'
+actual="$(check_unresolved_threads "1" "owner/repo" strict "coderabbitai")"
 run_test "unresolved_threads_none" "0" "$actual"
 
 # test: one unresolved bot thread — count should be 1
 # GraphQL author.login is "coderabbitai" (no "[bot]" suffix — stripped by caller)
-export MOCK_GH_OUTPUT='{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Blocking issue"}]}}]}'
-actual="$(check_unresolved_threads "1" "owner/repo" "coderabbitai")"
+export MOCK_GH_OUTPUT='{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":false,"firstComment":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Blocking issue"}]}}]}}'
+actual="$(check_unresolved_threads "1" "owner/repo" strict "coderabbitai")"
 run_test "unresolved_threads_one_bot" "1" "$actual"
 
 # test: one resolved bot thread — count should be 0
-export MOCK_GH_OUTPUT='{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Blocking issue"}]}}]}'
-actual="$(check_unresolved_threads "1" "owner/repo" "coderabbitai")"
+export MOCK_GH_OUTPUT='{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":true,"firstComment":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Blocking issue"}]}}]}}'
+actual="$(check_unresolved_threads "1" "owner/repo" strict "coderabbitai")"
 run_test "unresolved_threads_resolved_skipped" "0" "$actual"
 
 # test: bot thread with "✅ Addressed" in body — count should be 0
-export MOCK_GH_OUTPUT='{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"✅ Addressed — fixed in latest commit"}]}}]}'
-actual="$(check_unresolved_threads "1" "owner/repo" "coderabbitai")"
+export MOCK_GH_OUTPUT='{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":false,"firstComment":{"nodes":[{"author":{"login":"coderabbitai"},"body":"✅ Addressed — fixed in latest commit"}]}}]}}'
+actual="$(check_unresolved_threads "1" "owner/repo" strict "coderabbitai")"
 run_test "unresolved_threads_addressed_body_skipped" "0" "$actual"
 
 # test: human-authored thread unresolved — count should be 0 (bot-only filter)
-export MOCK_GH_OUTPUT='{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":false,"comments":{"nodes":[{"author":{"login":"humanreview"},"body":"Please change this"}]}}]}'
-actual="$(check_unresolved_threads "1" "owner/repo" "coderabbitai")"
+export MOCK_GH_OUTPUT='{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":false,"firstComment":{"nodes":[{"author":{"login":"humanreview"},"body":"Please change this"}]}}]}}'
+actual="$(check_unresolved_threads "1" "owner/repo" strict "coderabbitai")"
 run_test "unresolved_threads_human_ignored" "0" "$actual"
 
 # test: two bot threads, one resolved, one not — count should be 1
-export MOCK_GH_OUTPUT='{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"First finding"}]}},{"id":"RT2","isResolved":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Second finding"}]}}]}'
-actual="$(check_unresolved_threads "1" "owner/repo" "coderabbitai")"
+export MOCK_GH_OUTPUT='{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":true,"firstComment":{"nodes":[{"author":{"login":"coderabbitai"},"body":"First finding"}]}},{"id":"RT2","isResolved":false,"firstComment":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Second finding"}]}}]}}'
+actual="$(check_unresolved_threads "1" "owner/repo" strict "coderabbitai")"
 run_test "unresolved_threads_mixed_resolved" "1" "$actual"
 
 # test: [bot]-suffix login NOT matched (gate strips suffix; bare login is required)
 # Passing "coderabbitai[bot]" should NOT match GraphQL "coderabbitai" — returns 0.
-export MOCK_GH_OUTPUT='{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Blocking issue"}]}}]}'
-actual="$(check_unresolved_threads "1" "owner/repo" "coderabbitai[bot]")"
+export MOCK_GH_OUTPUT='{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":false,"firstComment":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Blocking issue"}]}}]}}'
+actual="$(check_unresolved_threads "1" "owner/repo" strict "coderabbitai[bot]")"
 run_test "unresolved_threads_bot_suffix_no_match" "0" "$actual"
 
 # test: GraphQL API failure (exit 1 from gh) — function should return exit 3
 export MOCK_GH_EXIT=1
 actual_exit=0
-check_unresolved_threads "1" "owner/repo" "coderabbitai" > /dev/null 2>&1 || actual_exit=$?
+check_unresolved_threads "1" "owner/repo" strict "coderabbitai" > /dev/null 2>&1 || actual_exit=$?
 run_test "unresolved_threads_graphql_failure_exit3" "3" "$actual_exit"
 unset MOCK_GH_EXIT
+
+# test: unrecognized mode value fails safe to strict — a reply-after-head-commit
+# must NOT be treated as provisionally addressed when mode is misspelled/garbage.
+export MOCK_GH_OUTPUT='{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":false,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"body":"Blocking issue"}]},"lastComment":{"nodes":[{"author":{"login":"humanreview"},"body":"fixed","createdAt":"2026-08-21T02:00:00Z"}]}}]},"commits":{"nodes":[{"commit":{"committedDate":"2026-08-21T01:00:00Z"}}]}}'
+actual="$(check_unresolved_threads "1" "owner/repo" bogus-mode "chatgpt-codex-connector")"
+run_test "unresolved_threads_unrecognized_mode_fails_safe_to_strict" "1" "$actual"
+
+# ---------------------------------------------------------------------------
+# Area 6b: check_unresolved_threads mode=provisional (#1508)
+#
+# A replied-but-unresolved thread must not block phase-1 gates (run_codex_
+# github_review, run_claude_code_action_review) from re-triggering a review
+# when the reply came from a non-bot author AFTER the current PR head commit
+# — this is the "fixer pushed and replied but has not yet called
+# resolveReviewThread" state described in issue #1508. Every other caller
+# (the aggregate clean gate, coderabbit_thread_gate_clean, the post-trigger
+# findings recount, and the post-clean recheck) keeps using mode=strict, so
+# these provisional-mode semantics can only ever make check_unresolved_threads
+# return a SMALLER count than strict mode for the same input — never used by
+# anything that decides RESULT=clean. Confirmed at the call-site level in the
+# "call-site mode audit" test below.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 6b: check_unresolved_threads mode=provisional (#1508) ==="
+
+# Direction 1 (the reported bug): a thread replied to by a human AFTER the
+# head commit was pushed must NOT block re-review in provisional mode — count
+# should be 0, even though isResolved is still false (no resolveReviewThread
+# call was made).
+export MOCK_GH_OUTPUT='{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":false,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"body":"Blocking issue"}]},"lastComment":{"nodes":[{"author":{"login":"humanreview"},"body":"Fixed in the latest push, see commit abc123","createdAt":"2026-08-21T02:00:00Z"}]}}]},"commits":{"nodes":[{"commit":{"committedDate":"2026-08-21T01:00:00Z"}}]}}'
+actual="$(check_unresolved_threads "1" "owner/repo" provisional "chatgpt-codex-connector")"
+run_test "unresolved_threads_provisional_reply_after_head_not_blocking" "0" "$actual"
+
+# The SAME fixture under mode=strict must still count as unresolved (1) —
+# this is the load-bearing guarantee that provisional mode cannot leak into
+# any RESULT=clean decision: strict mode ignores the reply entirely and
+# requires true GraphQL resolution.
+actual="$(check_unresolved_threads "1" "owner/repo" strict "chatgpt-codex-connector")"
+run_test "unresolved_threads_strict_still_blocks_same_replied_thread" "1" "$actual"
+
+# Direction 2 (must not open the false-clean class, #1531/#1437): a reply
+# posted BEFORE the head commit (i.e. the fixer pushed AFTER replying, or the
+# reply predates the fix entirely) must still count as unresolved even in
+# provisional mode — an old reply is not evidence the current HEAD was
+# addressed.
+export MOCK_GH_OUTPUT='{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":false,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"body":"Blocking issue"}]},"lastComment":{"nodes":[{"author":{"login":"humanreview"},"body":"looking into it","createdAt":"2026-08-20T23:00:00Z"}]}}]},"commits":{"nodes":[{"commit":{"committedDate":"2026-08-21T01:00:00Z"}}]}}'
+actual="$(check_unresolved_threads "1" "owner/repo" provisional "chatgpt-codex-connector")"
+run_test "unresolved_threads_provisional_reply_before_head_still_blocks" "1" "$actual"
+
+# Direction 2 (continued): a reply from the bot ITSELF (e.g. a second bot
+# comment in the thread) must not count as a "human/agent reply" — still
+# unresolved even in provisional mode.
+export MOCK_GH_OUTPUT='{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":false,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"body":"Blocking issue"}]},"lastComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"body":"still an issue","createdAt":"2026-08-21T02:00:00Z"}]}}]},"commits":{"nodes":[{"commit":{"committedDate":"2026-08-21T01:00:00Z"}}]}}'
+actual="$(check_unresolved_threads "1" "owner/repo" provisional "chatgpt-codex-connector")"
+run_test "unresolved_threads_provisional_bot_last_comment_still_blocks" "1" "$actual"
+
+# Direction 2 (continued): with no lastComment data at all (e.g. thread has
+# exactly one comment — the bot's own finding, never replied to), provisional
+# mode must behave exactly like strict — still unresolved.
+export MOCK_GH_OUTPUT='{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":false,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"body":"Blocking issue"}]}}]},"commits":{"nodes":[{"commit":{"committedDate":"2026-08-21T01:00:00Z"}}]}}'
+actual="$(check_unresolved_threads "1" "owner/repo" provisional "chatgpt-codex-connector")"
+run_test "unresolved_threads_provisional_no_reply_still_blocks" "1" "$actual"
+
+# Sanity: true resolution (isResolved=true) still counts as resolved under
+# provisional mode exactly as under strict — provisional mode only ADDS a
+# relaxation, it never removes the existing strict checks.
+export MOCK_GH_OUTPUT='{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"RT1","isResolved":true,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"body":"Blocking issue"}]}}]},"commits":{"nodes":[{"commit":{"committedDate":"2026-08-21T01:00:00Z"}}]}}'
+actual="$(check_unresolved_threads "1" "owner/repo" provisional "chatgpt-codex-connector")"
+run_test "unresolved_threads_provisional_true_resolution_still_clean" "0" "$actual"
+unset MOCK_GH_OUTPUT
 
 # ---------------------------------------------------------------------------
 # Area 7: bot_login_for_platform — copilot platform
@@ -3157,13 +3234,14 @@ echo ""
 echo "=== Area 13: PR #801 reviewer-loop failure paths ==="
 
 export MOCK_GH_OUTPUT='{
+  "reviewThreads": {
   "pageInfo": {"hasNextPage": false, "endCursor": null},
   "nodes": [
     {
       "id": "thread-outdated",
       "isResolved": false,
       "isOutdated": true,
-      "comments": {
+      "firstComment": {
         "nodes": [
           {
             "author": {"login": "chatgpt-codex-connector"},
@@ -3176,7 +3254,7 @@ export MOCK_GH_OUTPUT='{
       "id": "thread-active",
       "isResolved": false,
       "isOutdated": false,
-      "comments": {
+      "firstComment": {
         "nodes": [
           {
             "author": {"login": "chatgpt-codex-connector"},
@@ -3186,17 +3264,19 @@ export MOCK_GH_OUTPUT='{
       }
     }
   ]
+  }
 }'
 run_test "codex_thread_audit_ignores_outdated" "1" \
-  "$(check_unresolved_threads "42" "owner/repo" "chatgpt-codex-connector")"
+  "$(check_unresolved_threads "42" "owner/repo" strict "chatgpt-codex-connector")"
 export MOCK_GH_OUTPUT='{
+  "reviewThreads": {
   "pageInfo": {"hasNextPage": false, "endCursor": null},
   "nodes": [
     {
       "id": "thread-outdated",
       "isResolved": false,
       "isOutdated": true,
-      "comments": {
+      "firstComment": {
         "nodes": [
           {
             "author": {"login": "chatgpt-codex-connector"},
@@ -3206,9 +3286,10 @@ export MOCK_GH_OUTPUT='{
       }
     }
   ]
+  }
 }'
 run_test "codex_thread_audit_all_outdated_clean" "0" \
-  "$(check_unresolved_threads "42" "owner/repo" "chatgpt-codex-connector")"
+  "$(check_unresolved_threads "42" "owner/repo" strict "chatgpt-codex-connector")"
 unset MOCK_GH_OUTPUT
 
 manual_readiness_audit_count() {


### PR DESCRIPTION
## Summary

Fixes #1508. `check_unresolved_threads` in `scripts/development-workflow/pr-review-loop.sh` gated the phase-1 "should we trigger a new review" check in `run_codex_github_review` and `run_claude_code_action_review` purely on GraphQL `isResolved` state. When a fixer pushed a fix and replied to a thread without also calling `resolveReviewThread` — the normal state immediately after a push — the loop returned `RESULT=needs_fixes REASON=existing_findings` and never re-triggered the platform review, so the reviewer never saw the fix commit until a human resolved the thread manually out of band.

## Current behavior established before changing anything

`check_unresolved_threads` (used at 7 call sites) treated a bot-authored thread as unresolved unless `isResolved=true`, `isOutdated=true`, or the *first* comment body contained `✅ Addressed`. It never looked at replies at all — so the reported bug applied to any caller that used the count to gate re-triggering a review before a human/agent explicitly resolved the thread. Two of the 7 call sites are genuine phase-1 "should we re-trigger" gates (`run_codex_github_review`, `run_claude_code_action_review`); the other 5 are "declare RESULT=clean" gates (aggregate thread gate, `coderabbit_thread_gate_clean` ×3 call sites, post-clean recheck).

## Fix

`check_unresolved_threads` now takes a required `mode` argument (`strict` | `provisional`, third positional, before the bot-login varargs; unrecognized values fail safe to `strict`).

- `mode=provisional` — used **only** by the two phase-1 pre-trigger gates (`run_codex_github_review`, `run_claude_code_action_review`). In addition to the existing strict checks, a thread is also treated as not blocking re-review when its **last** comment is from a non-bot author posted **after** the PR's current head-commit `committedDate` — modeling "fixed and replied to, awaiting explicit resolution." This unblocks the dead review-cycle described in the issue.
- `mode=strict` — used by every gate that decides `RESULT=clean`: the aggregate thread gate, `coderabbit_thread_gate_clean` (all 3 call sites), the post-trigger findings recount inside both phase-1 gates' phase-2 handling, and the post-clean recheck. This is byte-for-byte the prior resolution logic — a reply alone can never mark a thread resolved there.

## Why this cannot cause the false-clean class (#1531, #1437)

`mode=provisional` is wired into exactly 2 of the 7 call sites, and both of those 2 only ever influence whether a **new review is triggered** — never whether the PR is declared clean. Concretely:

- If `run_codex_github_review`'s phase-1 gate proceeds (because of a provisional reply) and the triggered review itself finds nothing new, it returns `RESULT=clean` for that platform call — but the **aggregate** thread gate that runs afterward (when all platforms report clean) re-audits the same thread with `mode=strict`, sees the reply did not include a `resolveReviewThread` call, and still reports `RESULT=needs_fixes REASON=unresolved_review_threads`. The overall PR cannot reach `ready-for-human-review` until the thread is truly resolved.
- The post-trigger findings recount inside the same phase-1 functions (used when the triggered review itself reports issues) also stays `mode=strict`, so `COMMENT_COUNT`/`BLOCKING_COUNT` reporting is unaffected.
- `coderabbit_thread_gate_clean` (CodeRabbit's own "declare clean" path) and the post-clean recheck (which catches late-arriving threads after the loop reports clean) are untouched — still `mode=strict`.

So the relaxation can only ever cause **more** review dispatches (previously blocked, now allowed to proceed) — it structurally cannot remove or weaken any check that decides `RESULT=clean`.

## Tests

New regression tests in `scripts/development-workflow/tests/test-pr-review-loop.sh` (Area 6 + new Area 6b), using the existing strict-mock pattern (every `gh` invocation is enumerated; no permissive fallback). Cover both directions:

- **Too strict (the reported bug)**: a thread replied to by a human/agent *after* the head commit, still `isResolved=false` — `mode=provisional` returns 0 (does not block); the *same* fixture under `mode=strict` still returns 1 (still blocks `RESULT=clean`).
- **Too permissive (must not regress #1531/#1437)**: a reply posted *before* the head commit, a reply from the bot itself, no reply at all, and true GraphQL resolution — all behave identically to strict mode's existing semantics under `mode=provisional`, confirming the relaxation cannot leak into cases it wasn't designed for.
- An unrecognized `mode` value fails safe to `strict`.

Confirmed the core bug-reproduction case fails without the fix: called the pre-fix `check_unresolved_threads` (its own calling convention: `pr_number repo bot_login...`, no mode) with the exact reply-after-head-commit scenario — it returns `1` (still blocking), reproducing the reported dead-cycle. The fixed function's `mode=provisional` returns `0` for the identical scenario.

Full suite: **868 passed, 0 failed**.

## Scope note

`run_codex_github_review`'s phase-1 gate is the one named in the issue; `run_claude_code_action_review` has an identical phase-1 pattern using the same shared function and was included since it carries the exact same latent bug — leaving it unfixed would keep the dead-cycle live for that platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provisional review-thread checks that recognize timely human replies when deciding whether to trigger another review.
  * Added strict checks for final clean-result gates, preserving full resolution requirements.
  * Added safe handling for unsupported checking modes.

* **Bug Fixes**
  * Improved review automation handling for post-head replies, bot replies, missing replies, and resolved threads.

* **Tests**
  * Expanded regression coverage for review-thread timing and resolution scenarios.

* **Documentation**
  * Documented the updated review-thread behavior in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->