### PR TITLE
fix(batch-overlap): drop verb-as-module signals, fix one-sided suspect (#1540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,40 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **`workflow-batch-overlap.sh` no longer treats ordinary prose as a module
-  collision or serializes provably independent pairs** (#1540): two
-  compounding defects collapsed parallel batches. First, the unquoted
-  module-cue extractor (`module|package|component|helper|script|service
-  <token>`) captured whatever word followed the cue with no validation, so
-  brief text like "the helper **emits** false rows" or "the **script**
-  **hardcodes** a path" produced fake `module` signals from ordinary English
-  verbs. It now requires the candidate to look like an identifier or path
-  fragment — a dot-extension, an underscore/hyphen separator, or mixed/upper
-  case — via a new `looks_like_module_identifier` check; the quoted variant
-  (`` helper `name` ``) is unaffected. Second, the `has_plan_evidence and
-  (left_signals or right_signals)` branch classified a pair `suspected`
-  (defaulting to serial) whenever **one** side carried a signal and the other
-  carried none, even with disjoint file sets and nothing shared or related —
-  which is close to the strongest evidence of independence the helper can
-  produce, and meant the more specific a brief was, the more likely its item
-  got serialized. The condition now requires signals on **both** sides
-  (`left_signals and right_signals`) before treating the pair as ambiguous;
-  a one-sided signal set with no other evidence now falls through to
-  `no_actionable_overlap`. `suspected` explanations for both the "related"
-  and the plan/brief-mismatch branches now name the specific triggering
-  signal(s) instead of a generic identical string for every pair. Genuinely
-  overlapping pairs (shared files, shared signals, or an unquoted
-  identifier-shaped module name matching on both sides) still classify
-  `concrete`, per a new control fixture. Added regression tests in
-  `scripts/development-workflow/tests/test-workflow-batch-overlap.sh`
-  covering the issue's minimal reproduction, the verb-capture fixtures
-  ("helper emits", "script hardcodes", "component returns"), the concrete
-  control, and the two real overnight-batch wave sets named in the issue
-  (previously collapsed into one serial group of 4 each, now fully
-  parallel-eligible). `looks_like_module_identifier` also now strips trailing
-  sentence punctuation before its shape check, so a verb immediately followed
-  by terminal punctuation (e.g. "the script **fails**.") is no longer
-  misread as having a dot-extension and does not slip through as a fake
-  module signal either.
+  collision or serializes provably independent pairs** (#1540): brief text
+  like "the helper **emits** false rows" no longer produces a fake `module`
+  signal, and a pair with a signal on only one side (nothing shared or
+  related) no longer defaults to `suspected`/serial — it now requires
+  independence-defeating evidence on **both** sides. Genuinely overlapping
+  pairs still classify `concrete`. `suspected` explanations now name the
+  specific triggering signal(s). Regression tests cover the issue's
+  reproduction, verb-capture fixtures, a concrete-overlap control, and the
+  two real overnight-batch wave sets from the issue (previously one serial
+  group of 4 each, now fully parallel-eligible).
 - **Item runners no longer park permanently after backgrounding a long step
   and ending the turn to wait for it** (#1548): three of four Work Item
   Runners in one overnight wave backgrounded a step (`test-pr-review-loop.sh`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ("helper emits", "script hardcodes", "component returns"), the concrete
   control, and the two real overnight-batch wave sets named in the issue
   (previously collapsed into one serial group of 4 each, now fully
-  parallel-eligible).
+  parallel-eligible). `looks_like_module_identifier` also now strips trailing
+  sentence punctuation before its shape check, so a verb immediately followed
+  by terminal punctuation (e.g. "the script **fails**.") is no longer
+  misread as having a dot-extension and does not slip through as a fake
+  module signal either.
 - **Item runners no longer park permanently after backgrounding a long step
   and ending the turn to wait for it** (#1548): three of four Work Item
   Runners in one overnight wave backgrounded a step (`test-pr-review-loop.sh`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **`workflow-batch-overlap.sh` no longer treats ordinary prose as a module
+  collision or serializes provably independent pairs** (#1540): two
+  compounding defects collapsed parallel batches. First, the unquoted
+  module-cue extractor (`module|package|component|helper|script|service
+  <token>`) captured whatever word followed the cue with no validation, so
+  brief text like "the helper **emits** false rows" or "the **script**
+  **hardcodes** a path" produced fake `module` signals from ordinary English
+  verbs. It now requires the candidate to look like an identifier or path
+  fragment — a dot-extension, an underscore/hyphen separator, or mixed/upper
+  case — via a new `looks_like_module_identifier` check; the quoted variant
+  (`` helper `name` ``) is unaffected. Second, the `has_plan_evidence and
+  (left_signals or right_signals)` branch classified a pair `suspected`
+  (defaulting to serial) whenever **one** side carried a signal and the other
+  carried none, even with disjoint file sets and nothing shared or related —
+  which is close to the strongest evidence of independence the helper can
+  produce, and meant the more specific a brief was, the more likely its item
+  got serialized. The condition now requires signals on **both** sides
+  (`left_signals and right_signals`) before treating the pair as ambiguous;
+  a one-sided signal set with no other evidence now falls through to
+  `no_actionable_overlap`. `suspected` explanations for both the "related"
+  and the plan/brief-mismatch branches now name the specific triggering
+  signal(s) instead of a generic identical string for every pair. Genuinely
+  overlapping pairs (shared files, shared signals, or an unquoted
+  identifier-shaped module name matching on both sides) still classify
+  `concrete`, per a new control fixture. Added regression tests in
+  `scripts/development-workflow/tests/test-workflow-batch-overlap.sh`
+  covering the issue's minimal reproduction, the verb-capture fixtures
+  ("helper emits", "script hardcodes", "component returns"), the concrete
+  control, and the two real overnight-batch wave sets named in the issue
+  (previously collapsed into one serial group of 4 each, now fully
+  parallel-eligible).
 - **Item runners no longer park permanently after backgrounding a long step
   and ending the turn to wait for it** (#1548): three of four Work Item
   Runners in one overnight wave backgrounded a step (`test-pr-review-loop.sh`,

--- a/scripts/development-workflow/tests/test-workflow-batch-overlap.sh
+++ b/scripts/development-workflow/tests/test-workflow-batch-overlap.sh
@@ -283,6 +283,17 @@ write_items "$one_sided" \
 run_test "one_sided_evidence_is_no_actionable_overlap" "no_actionable_overlap" "$(class_for "$one_sided")"
 run_test "one_sided_evidence_dispatch_is_parallel" "parallel_eligible" "$(dispatch_for "$one_sided")"
 
+# Defect 1 residual: an English verb immediately followed by terminal
+# punctuation (no words after it) must not become a module signal either.
+# The unquoted-cue capture group includes "." in its character class, so a
+# trailing sentence period was previously mistaken for a dot-extension.
+verb_terminal_period="$TMP_ROOT/verb-terminal-period.json"
+write_items "$verb_terminal_period" \
+  "$(item_json vtp-a "A" "the script fails." "scripts/x/period-a.sh")" \
+  "$(item_json vtp-b "B" "resolveBeta() has a bug." "scripts/x/period-b.sh")"
+run_test "verb_terminal_period_not_captured" "no_actionable_overlap" "$(class_for "$verb_terminal_period")"
+run_test "verb_terminal_period_drops_bogus_module_signal" "0" "$(pair_value "$verb_terminal_period" '[.pairs[0].signals.leftSignals[] | select(.type=="module")] | length')"
+
 echo ""
 echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
 [ "$FAIL_COUNT" -eq 0 ]

--- a/scripts/development-workflow/tests/test-workflow-batch-overlap.sh
+++ b/scripts/development-workflow/tests/test-workflow-batch-overlap.sh
@@ -217,18 +217,21 @@ write_items "$verb_emits" \
   "$(item_json ve-a "A" "the helper emits false discrepancy rows" "scripts/x/emits-a.sh")" \
   "$(item_json ve-b "B" "an unrelated brief with no cues" "scripts/x/emits-b.sh")"
 run_test "verb_emits_not_captured" "no_actionable_overlap" "$(class_for "$verb_emits")"
+run_test "verb_emits_drops_bogus_module_signal" "0" "$(pair_value "$verb_emits" '[.pairs[0].signals.leftSignals[] | select(.type=="module")] | length')"
 
 verb_hardcodes="$TMP_ROOT/verb-hardcodes.json"
 write_items "$verb_hardcodes" \
   "$(item_json vh-a "A" "the script hardcodes a type field path" "scripts/x/hardcodes-a.sh")" \
   "$(item_json vh-b "B" "an unrelated brief with no cues" "scripts/x/hardcodes-b.sh")"
 run_test "verb_hardcodes_not_captured" "no_actionable_overlap" "$(class_for "$verb_hardcodes")"
+run_test "verb_hardcodes_drops_bogus_module_signal" "0" "$(pair_value "$verb_hardcodes" '[.pairs[0].signals.leftSignals[] | select(.type=="module")] | length')"
 
 verb_returns="$TMP_ROOT/verb-returns.json"
 write_items "$verb_returns" \
   "$(item_json vr-a "A" "the component returns unrelated data" "scripts/x/returns-a.sh")" \
   "$(item_json vr-b "B" "an unrelated brief with no cues" "scripts/x/returns-b.sh")"
 run_test "verb_returns_not_captured" "no_actionable_overlap" "$(class_for "$verb_returns")"
+run_test "verb_returns_drops_bogus_module_signal" "0" "$(pair_value "$verb_returns" '[.pairs[0].signals.leftSignals[] | select(.type=="module")] | length')"
 
 # AC-3 control: genuinely overlapping pairs must still classify concrete, including
 # via an unquoted-but-identifier-shaped module name (proves the validator does not

--- a/scripts/development-workflow/tests/test-workflow-batch-overlap.sh
+++ b/scripts/development-workflow/tests/test-workflow-batch-overlap.sh
@@ -199,6 +199,90 @@ write_items "$reordered" \
   "$(item_json route-a "Users endpoint" "Update GET /api/users/:id validation.")"
 run_test "input_order_is_stable" "$(pair_value "$same_route" '.pairs[0].pairId')" "$(pair_value "$reordered" '.pairs[0].pairId')"
 
+# --- Issue #1540: verb-capture module signals + one-sided-evidence false serialization ---
+
+# AC-1: minimal reproduction from the issue must classify as fully independent.
+minimal_repro="$TMP_ROOT/minimal-repro-1540.json"
+write_items "$minimal_repro" \
+  "$(item_json A "Alpha" "the helper emits false rows" "scripts/alpha.sh")" \
+  "$(item_json B "Beta" "completely unrelated change" "scripts/beta.sh")"
+run_test "minimal_repro_is_no_actionable_overlap" "no_actionable_overlap" "$(class_for "$minimal_repro")"
+run_test "minimal_repro_dispatch_is_parallel" "parallel_eligible" "$(dispatch_for "$minimal_repro")"
+run_test "minimal_repro_drops_bogus_module_signal" "0" "$(pair_value "$minimal_repro" '[.pairs[0].signals.leftSignals[] | select(.type=="module")] | length')"
+
+# AC-2: an English verb following a module cue must not become a "module" signal,
+# for each of the three fixtures named in the issue's acceptance criteria.
+verb_emits="$TMP_ROOT/verb-emits.json"
+write_items "$verb_emits" \
+  "$(item_json ve-a "A" "the helper emits false discrepancy rows" "scripts/x/emits-a.sh")" \
+  "$(item_json ve-b "B" "an unrelated brief with no cues" "scripts/x/emits-b.sh")"
+run_test "verb_emits_not_captured" "no_actionable_overlap" "$(class_for "$verb_emits")"
+
+verb_hardcodes="$TMP_ROOT/verb-hardcodes.json"
+write_items "$verb_hardcodes" \
+  "$(item_json vh-a "A" "the script hardcodes a type field path" "scripts/x/hardcodes-a.sh")" \
+  "$(item_json vh-b "B" "an unrelated brief with no cues" "scripts/x/hardcodes-b.sh")"
+run_test "verb_hardcodes_not_captured" "no_actionable_overlap" "$(class_for "$verb_hardcodes")"
+
+verb_returns="$TMP_ROOT/verb-returns.json"
+write_items "$verb_returns" \
+  "$(item_json vr-a "A" "the component returns unrelated data" "scripts/x/returns-a.sh")" \
+  "$(item_json vr-b "B" "an unrelated brief with no cues" "scripts/x/returns-b.sh")"
+run_test "verb_returns_not_captured" "no_actionable_overlap" "$(class_for "$verb_returns")"
+
+# AC-3 control: genuinely overlapping pairs must still classify concrete, including
+# via an unquoted-but-identifier-shaped module name (proves the validator does not
+# reject real module names, only bare English words).
+overlapping_module="$TMP_ROOT/overlapping-module.json"
+write_items "$overlapping_module" \
+  "$(item_json om-a "A" "Change helper token-resolver for consistency.")" \
+  "$(item_json om-b "B" "Update script token-resolver to match.")"
+run_test "overlapping_unquoted_module_stays_concrete" "concrete" "$(class_for "$overlapping_module")"
+run_test "overlapping_unquoted_module_source" "brief" "$(source_for "$overlapping_module")"
+
+# AC-4: the wave-1 and wave-2 sets from the issue's observed-impact section must
+# be fully parallel-eligible (no serial groups) after the fix.
+wave1="$TMP_ROOT/wave1.json"
+write_items "$wave1" \
+  "$(item_json i1503 "Fix token resolution bug" "resolve_token() returns a stale token under load." "scripts/development-workflow/resolve-token.sh")" \
+  "$(item_json i1504 "Improve report formatting" "Report rows misalign in the summary table." "scripts/development-workflow/report-format.sh")" \
+  "$(item_json i1511 "Add edge case fixture" "Add coverage for an edge case scenario." "scripts/development-workflow/tests/test-edge-case.sh")" \
+  "$(item_json i1516 "Tidy up dead code" "Remove an unused variable in the reporting flow." "scripts/development-workflow/cleanup.sh")"
+run_test "wave1_has_no_serial_groups" "0" "$(pair_value "$wave1" '.serialGroups | length')"
+run_test "wave1_all_pairs_parallel_eligible" "6" "$(pair_value "$wave1" '[.pairs[] | select(.defaultDispatch=="parallel_eligible")] | length')"
+
+wave2="$TMP_ROOT/wave2.json"
+write_items "$wave2" \
+  "$(item_json i1333 "Alpha work" "the helper emits false rows in the report." "scripts/x/alpha.sh")" \
+  "$(item_json i1400 "Beta work" "the script hardcodes a path that should be configurable." "scripts/x/beta.sh")" \
+  "$(item_json i1503b "Gamma work" "Improve token handling reliability." "scripts/x/gamma.sh")" \
+  "$(item_json i1509 "Delta work" "Add coverage for token edge cases." "scripts/x/delta.sh")"
+run_test "wave2_has_no_serial_groups" "0" "$(pair_value "$wave2" '.serialGroups | length')"
+run_test "wave2_all_pairs_parallel_eligible" "6" "$(pair_value "$wave2" '[.pairs[] | select(.defaultDispatch=="parallel_eligible")] | length')"
+
+# AC-5: "suspected" explanations must name the specific triggering signal, not a
+# generic identical string for every pair.
+related_explanation="$(pair_value "$parent_route" '.pairs[0].explanation')"
+run_test "related_explanation_names_routes" "yes" "$(printf '%s' "$related_explanation" | grep -q "/api/users" && echo yes || echo no)"
+
+two_sided_mismatch="$TMP_ROOT/two-sided-mismatch.json"
+write_items "$two_sided_mismatch" \
+  "$(item_json tsm-a "A" "resolveAlpha() has a bug." "a.ts")" \
+  "$(item_json tsm-b "B" "resolveBeta() has a bug." "b.ts")"
+run_test "two_sided_mismatch_is_suspected" "suspected" "$(class_for "$two_sided_mismatch")"
+mismatch_explanation="$(pair_value "$two_sided_mismatch" '.pairs[0].explanation')"
+run_test "mismatch_explanation_names_signals" "yes" "$(printf '%s' "$mismatch_explanation" | grep -q "resolvealpha" && printf '%s' "$mismatch_explanation" | grep -q "resolvebeta" && echo yes || echo no)"
+
+# Defect 2 regression: one side having signals while the other has none (with
+# shared_files already ruled out) must fall through to no_actionable_overlap
+# instead of defaulting to suspected/serial.
+one_sided="$TMP_ROOT/one-sided.json"
+write_items "$one_sided" \
+  "$(item_json os-a "A" "resolveGamma() has a bug." "gamma.ts")" \
+  "$(item_json os-b "B" "an unrelated brief with no signals." "delta.ts")"
+run_test "one_sided_evidence_is_no_actionable_overlap" "no_actionable_overlap" "$(class_for "$one_sided")"
+run_test "one_sided_evidence_dispatch_is_parallel" "parallel_eligible" "$(dispatch_for "$one_sided")"
+
 echo ""
 echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
 [ "$FAIL_COUNT" -eq 0 ]

--- a/scripts/development-workflow/workflow-batch-overlap.sh
+++ b/scripts/development-workflow/workflow-batch-overlap.sh
@@ -176,6 +176,21 @@ def add_signal(signals: set[tuple[str, str]], kind: str, value: str) -> None:
     signals.add((kind, value))
 
 
+def looks_like_module_identifier(value: str) -> bool:
+    """Reject bare English words captured after an unquoted module cue.
+
+    The unquoted variant of the module-cue extraction has no delimiter to
+    anchor on, so it must accept only candidates that look like an
+    identifier or path fragment rather than the next word of a sentence: a
+    dot-extension, an underscore/hyphen separator, or mixed/upper case (a
+    proper noun or identifier shape). A plain lowercase word (e.g. "emits",
+    "hardcodes", "returns") is ordinary English prose, not a module name.
+    """
+    if re.search(r"[._-]", value):
+        return True
+    return value != value.lower()
+
+
 def extract_signals(title: str, brief: str) -> list[dict]:
     text = f"{title or ''}\n{brief or ''}"
     signals: set[tuple[str, str]] = set()
@@ -199,7 +214,10 @@ def extract_signals(title: str, brief: str) -> list[dict]:
     for match in re.finditer(rf"\b{module_cue}\s+[`'\"]([^`'\"\n]+)[`'\"]", text, re.I):
         add_signal(signals, "module", match.group(1))
     for match in re.finditer(rf"\b{module_cue}\s+([A-Za-z][A-Za-z0-9_.-]{{2,}})", text, re.I):
-        add_signal(signals, "module", match.group(1))
+        candidate = match.group(1)
+        if not looks_like_module_identifier(candidate):
+            continue
+        add_signal(signals, "module", candidate)
 
     return [{"type": kind, "value": value} for kind, value in sorted(signals)]
 
@@ -237,6 +255,16 @@ def pair_id(left_id: str, right_id: str) -> str:
     return "--".join(sorted([left_id, right_id]))
 
 
+def describe_signal(signal: dict) -> str:
+    return f"{signal['type']}:{signal['value']}"
+
+
+def describe_signal_list(signals: list[dict]) -> str:
+    if not signals:
+        return "none"
+    return ", ".join(describe_signal(signal) for signal in signals)
+
+
 def item_sort_key(item: dict):
     priority = PRIORITY_RANK.get(str(item.get("priority", "")).lower(), 2)
     created = str(item.get("createdAt") or item.get("created_at") or "")
@@ -266,12 +294,23 @@ def classify_pair(left: dict, right: dict) -> dict:
     elif related:
         classification = "suspected"
         source = "mixed" if has_plan_evidence else "brief"
-        explanation = "Brief-derived targets are related but not identical."
+        first = related[0]
+        more = f" (+{len(related) - 1} more)" if len(related) > 1 else ""
+        explanation = (
+            "Brief-derived targets are related but not identical: "
+            f"{describe_signal(first['left'])} vs {describe_signal(first['right'])} "
+            f"({first['reason']}){more}."
+        )
         evidence = {"relatedSignals": related}
-    elif has_plan_evidence and (left_signals or right_signals):
+    elif has_plan_evidence and (left_signals and right_signals):
         classification = "suspected"
         source = "mixed"
-        explanation = "Plan-derived and brief-derived evidence do not prove independence; require pair-scoped disposition."
+        explanation = (
+            "Plan-derived evidence exists but brief-derived signals neither match nor relate, so "
+            "independence is not proven; require pair-scoped disposition. "
+            f"Left signals: {describe_signal_list(left_signals)}. "
+            f"Right signals: {describe_signal_list(right_signals)}."
+        )
         evidence = {"leftSignals": left_signals, "rightSignals": right_signals}
     else:
         classification = "no_actionable_overlap"

--- a/scripts/development-workflow/workflow-batch-overlap.sh
+++ b/scripts/development-workflow/workflow-batch-overlap.sh
@@ -185,10 +185,19 @@ def looks_like_module_identifier(value: str) -> bool:
     dot-extension, an underscore/hyphen separator, or mixed/upper case (a
     proper noun or identifier shape). A plain lowercase word (e.g. "emits",
     "hardcodes", "returns") is ordinary English prose, not a module name.
+
+    Trailing sentence punctuation (e.g. the "." that ends "the script
+    fails.") is stripped before the shape check, matching the punctuation
+    `normalize_identifier` strips later. Without this, a verb immediately
+    followed by terminal punctuation would be misread as having a
+    dot-extension and slip through as a fabricated module signal.
     """
-    if re.search(r"[._-]", value):
+    trimmed = value.strip("`'\"“”‘’.,;:)(")
+    if not trimmed:
+        return False
+    if re.search(r"[._-]", trimmed):
         return True
-    return value != value.lower()
+    return trimmed != trimmed.lower()
 
 
 def extract_signals(title: str, brief: str) -> list[dict]:


### PR DESCRIPTION
## Summary

Fixes #1540. Two compounding defects in `workflow-batch-overlap.sh` collapsed provably independent batch items into serial groups.

1. **Verb-as-module signal**: the unquoted module-cue extractor (`module|package|component|helper|script|service <token>`) captured whatever token followed the cue word, unvalidated, so ordinary English prose produced fake `module` signals ("the helper **emits** false rows" -> module `emits`). Added a `looks_like_module_identifier()` check requiring a dot-extension, underscore/hyphen separator, or mixed/upper case before an unquoted candidate is accepted. The quoted variant (`` helper `name` ``) is unaffected and unchanged.
2. **One-sided evidence defaults to serialize**: the `has_plan_evidence and (left_signals or right_signals)` branch classified a pair `suspected` (default `serial`) whenever *one* side had a signal and the other had none — even with disjoint file sets and nothing shared or related, which is close to the strongest evidence of independence this helper can produce. Changed the condition to require signals on **both** sides (`left_signals and right_signals`); a one-sided signal set with no other evidence now falls through to `no_actionable_overlap`.

Also: `suspected` explanations for both the related-signals branch and the plan/brief-mismatch branch now name the specific triggering signal(s) instead of an identical generic string for every pair (AC-5).

**Update (Step 7a internal review):** found and fixed a residual defect-1 gap. `looks_like_module_identifier` still accepted a bare English verb when it was the last word before terminal punctuation (e.g. "the script **fails**.") — the unquoted-cue capture regex includes `.` in its character class, so the trailing sentence period was misread as a dot-extension. The check now strips trailing sentence punctuation before the shape check (matching what `normalize_identifier` strips later), so this collapses back to the plain-lowercase-word rejection path. Confirmed end-to-end that this previously forced a false `suspected`/`serial` classification between two genuinely independent items.

## Verification

Genuinely overlapping pairs (shared files, shared signals, and an unquoted identifier-shaped module name matching on both sides) still classify `concrete` — verified with a new control fixture, so the fix does not make the classifier permissive.

Regression tests added to `scripts/development-workflow/tests/test-workflow-batch-overlap.sh`:
- the issue's minimal reproduction (AC-1)
- the three verb-capture fixtures: "helper emits", "script hardcodes", "component returns" (AC-2)
- a concrete-overlap control fixture (AC-3)
- the two real overnight-batch wave sets named in the issue's impact section — previously each collapsed into one serial group of 4, now fully parallel-eligible (AC-4)
- explanation-naming assertions for both suspected branches (AC-5)
- a direct defect-2 regression (one-sided signals -> `no_actionable_overlap`)
- a defect-1 residual regression: a verb immediately followed by terminal punctuation (no words after it) must not become a module signal either

Confirmed all new tests **fail** against the unfixed script before applying the fix (14 of 17 original new assertions failed; the 3 control/AC-3 assertions correctly passed under both old and new code; the follow-up trailing-punctuation test also confirmed to fail against the pre-follow-up-fix validator and pass after). Full suite: 50/50 passing after both fixes (31 pre-existing + 19 new).

Note: this test suite is one of the ~57 not executed by CI (issue #1537) — the local run above is the only verification.

## Test plan

- [x] `bash scripts/development-workflow/tests/test-workflow-batch-overlap.sh` — 50 passed, 0 failed
- [x] `markdownlint-cli2 CHANGELOG.md` — 0 errors
- [x] `markdown-heuristic-lint.py CHANGELOG.md` — clean
- [x] `check-changelog-duplicate-headers.sh CHANGELOG.md` — passed
- [x] `workflow-shell-snippet-lint.py --base-ref origin/develop` — clean
- [x] `bash -n` on both modified shell scripts; `python3 -m py_compile` on the embedded Python body

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow overlap detection to ignore ordinary prose and trailing punctuation that could be mistaken for module names.
  * Corrected one-sided overlap signals so they no longer produce actionable overlap classifications.
  * Preserved detection of genuine module overlaps and parallel batch execution scenarios.
  * Improved overlap explanations by identifying the specific signals that triggered them.

* **Tests**
  * Added regression coverage for false positives, concrete overlaps, evidence validation, and parallel batch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->