### PR TITLE
fix: Gate 5 why-safe-file evidence path + distinct schema-mismatch reasons (#1497)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   since the gate cannot safely default an authority/CI verdict either way)
   naming exactly which required shape is missing, with `nextAction` text that
   explicitly says this is not a policy or CI-state blocker. A present-but-
-  empty `.statusChecks: []` (a genuine "no CI has run" state, or any state
-  when `ciPolicy`/`ci_policy` is `none`) keeps its original wording and
-  `blocked` decision unchanged — only the schema-shaped absence is new. A
+  empty `.statusChecks: []` (a genuine "no CI has run" state) keeps its
+  original wording and `blocked` decision unchanged — only the schema-shaped
+  absence is new. When `ciPolicy`/`ci_policy` is `none`, no CI reason is
+  added at all (as before this PR); the overall decision then depends only
+  on other evidence and is not necessarily `blocked`. A
   CodeRabbit review on the PR caught a sharper variant of the same bug: a
   key-existence check alone (`has("statusChecks")`) accepted `null`, an
   object, or a scalar for `.statusChecks`, none of which are the array the
@@ -65,7 +67,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `merge_allowed` verdict for malformed input rather than merely an unclear
   message; a scalar aborted the whole jq program. `.statusChecks` is now
   required to literally be an array before any CI evaluation runs against
-  it. Also fixed: a `.pr.mergeable` value defaulted to `""` by a
+  it, and (per a CodeRabbit follow-up finding) every array member must
+  itself be an object — a string or number member reached the same field
+  accessors and crashed the same way a non-array top-level value did, and a
+  `null` member silently read as a generic CI failure instead of the more
+  legible schema-mismatch reason. Also fixed: a `.pr.mergeable` value
+  defaulted to `""` by a
   caller that omitted `mergeable` from its `gh pr view --json` field list
   used to be read as a real "PR is not mergeable" verdict for a PR GitHub
   reports as `MERGEABLE`; a blank/whitespace-only `mergeable` string is now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **`run-epic-risk-classifier.sh --pr` can now attach `why_safe_to_merge`
+  evidence, and Gate 5 evidence-schema mismatches no longer read as a denied
+  merge authority** (#1497): a medium-risk PR classified via `--pr` always
+  reached `blocked` ("medium-risk PR is missing complete why_safe_to_merge
+  evidence") because `--pr` had no way to attach that evidence — only
+  `--input`'s undocumented, hand-normalized shape could carry it. A new
+  `--why-safe-file <file>` flag merges a `why_safe_to_merge` object into the
+  classified state for either `--pr` or `--input` mode, and `--help` on both
+  `run-epic-risk-classifier.sh` and `run-epic-delegated-gate.sh` now
+  documents each script's evidence schema with a worked example, including
+  that the two schemas are different and must not be fed into one another
+  directly (nest the classifier's result under a top-level `risk` key
+  instead). Separately, `run-epic-delegated-gate.sh` used to report a
+  malformed or incompatible evidence file (e.g. one built from the risk
+  classifier's own flat output) as `delegated review authority is missing`,
+  `delegated merge authority is missing`, or `required CI state is missing`
+  — three reasons that read as a policy or CI verdict when the real problem
+  was a missing `.policy` object or an entirely absent `.statusChecks[]` key,
+  risking an operator concluding they lack merge permission when they
+  actually have a JSON shape bug. Both cases now report a distinct
+  `evidence_schema_mismatch: ...` reason (still routed to `human_required`,
+  since the gate cannot safely default an authority/CI verdict either way)
+  naming exactly which required shape is missing, with `nextAction` text that
+  explicitly says this is not a policy or CI-state blocker. A present-but-
+  empty `.statusChecks: []` (a genuine "no CI has run" state) keeps its
+  original wording and `blocked` decision unchanged — only the schema-shaped
+  absence is new. Also fixed: a `.pr.mergeable` value defaulted to `""` by a
+  caller that omitted `mergeable` from its `gh pr view --json` field list
+  used to be read as a real "PR is not mergeable" verdict for a PR GitHub
+  reports as `MERGEABLE`; a blank/whitespace-only `mergeable` string is now
+  treated exactly like an absent field (not blocked), while a genuine
+  non-mergeable state (e.g. `CONFLICTING`) still blocks. `guardrails-
+  enforcement.md`'s Gate 5 section documents the evidence schemas, the
+  `--why-safe-file` flag, and both pitfalls. New regression coverage in
+  `scripts/development-workflow/tests/test-run-epic-risk-classifier.sh` and
+  `scripts/development-workflow/tests/test-run-epic-delegated-gate.sh`
+  reproduces all three failure modes against the unfixed scripts before
+  confirming the fix.
 - **Item runners no longer park permanently after backgrounding a long step
   and ending the turn to wait for it** (#1548): three of four Work Item
   Runners in one overnight wave backgrounded a step (`test-pr-review-loop.sh`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   since the gate cannot safely default an authority/CI verdict either way)
   naming exactly which required shape is missing, with `nextAction` text that
   explicitly says this is not a policy or CI-state blocker. A present-but-
-  empty `.statusChecks: []` (a genuine "no CI has run" state) keeps its
-  original wording and `blocked` decision unchanged — only the schema-shaped
-  absence is new. Also fixed: a `.pr.mergeable` value defaulted to `""` by a
+  empty `.statusChecks: []` (a genuine "no CI has run" state, or any state
+  when `ciPolicy`/`ci_policy` is `none`) keeps its original wording and
+  `blocked` decision unchanged — only the schema-shaped absence is new. A
+  CodeRabbit review on the PR caught a sharper variant of the same bug: a
+  key-existence check alone (`has("statusChecks")`) accepted `null`, an
+  object, or a scalar for `.statusChecks`, none of which are the array the
+  gate actually expects — a `null` silently defaulted to `[]` and reported
+  the old generic message instead of a schema mismatch; an **object** had its
+  *values* iterated as individual check entries (jq's `map`/`.[]` accept
+  objects), so a single well-formed-looking check value one level too deep
+  could read as CI having passed, silently producing a false
+  `merge_allowed` verdict for malformed input rather than merely an unclear
+  message; a scalar aborted the whole jq program. `.statusChecks` is now
+  required to literally be an array before any CI evaluation runs against
+  it. Also fixed: a `.pr.mergeable` value defaulted to `""` by a
   caller that omitted `mergeable` from its `gh pr view --json` field list
   used to be read as a real "PR is not mergeable" verdict for a PR GitHub
   reports as `MERGEABLE`; a blank/whitespace-only `mergeable` string is now

--- a/docs/workflow/development-workflow/guardrails-enforcement.md
+++ b/docs/workflow/development-workflow/guardrails-enforcement.md
@@ -327,6 +327,7 @@ table is required for consistent stop reporting.
 | `missing_required_secret_or_permission` | A required credential, GitHub permission, or access token is absent. |
 | `guardrails_config_unreadable` | The `guardrails` block in `.ai-dev-workflow.yaml` is missing required fields, uses invalid values, or is internally contradictory. |
 | `missing_audit_evidence` | A delegated decision required an audit record but the record could not be produced or verified. |
+| `evidence_schema_mismatch` | `run-epic-delegated-gate.sh` evidence is missing a required object or array key entirely (for example `.policy` or `.statusChecks[]`), which cannot be distinguished from a genuine authority denial or a genuine "no CI has run" state; fix the evidence file's shape before treating the result as a real denial or CI verdict. |
 
 **Additive rule**: These stop conditions may **add** to but may **never remove**
 the framework's baseline human-stop conditions. The baseline stops

--- a/docs/workflow/development-workflow/guardrails-enforcement.md
+++ b/docs/workflow/development-workflow/guardrails-enforcement.md
@@ -174,6 +174,7 @@ At the Step 8/8a readiness handoff, when merge authority is granted for the
 stage (`stages.<stage>.may_merge_pr` is `true`), assemble the evidence object
 and run the existing helpers:
 
+<!-- workflow-shell-contract: bash-zsh -->
 ```bash
 # 1. Classify PR risk against the stage max_merge_risk. A medium-risk PR only
 #    ever reaches a mergeable verdict if why_safe_to_merge evidence is

--- a/docs/workflow/development-workflow/guardrails-enforcement.md
+++ b/docs/workflow/development-workflow/guardrails-enforcement.md
@@ -175,13 +175,31 @@ stage (`stages.<stage>.may_merge_pr` is `true`), assemble the evidence object
 and run the existing helpers:
 
 ```bash
-# 1. Classify PR risk against the stage max_merge_risk
+# 1. Classify PR risk against the stage max_merge_risk. A medium-risk PR only
+#    ever reaches a mergeable verdict if why_safe_to_merge evidence is
+#    attached; --why-safe-file lets --pr carry that evidence directly instead
+#    of switching to --input:
 ./scripts/development-workflow/run-epic-risk-classifier.sh \
-  --pr <pr-number> --max-risk <stages.<stage>.max_merge_risk>
+  --pr <pr-number> --why-safe-file <why-safe-file> \
+  --max-risk <stages.<stage>.max_merge_risk>
 
 # 2. Run the delegated gate with the assembled evidence
 ./scripts/development-workflow/run-epic-delegated-gate.sh --input <evidence-file>
 ```
+
+**These two helpers use different, independently documented evidence
+schemas** — see `--help` on each script for the exact shape and a worked
+example. Do not feed one script's output directly into the other's `--input`;
+nest `run-epic-risk-classifier.sh`'s result under a top-level `"risk"` key when
+assembling the delegated gate's `<evidence-file>` instead. Feeding the wrong
+shape in does not always fail loudly: the delegated gate reports an
+`evidence_schema_mismatch: ...` reason (rather than a generic
+`delegated review/merge authority is missing` or `required CI state is
+missing` reason) whenever a required object (`.policy`) or array key
+(`.statusChecks`) is entirely absent, precisely because that absence is
+otherwise indistinguishable from a real denial or a real "no CI has run"
+state. Treat that reason as an instruction to fix the evidence file's shape,
+not as a policy or CI verdict.
 
 The evidence file's `pr.inScope` field is meaningful only when the runner has
 a resolved `/run-epic` scope to check the candidate PR against. Protocol 90 and
@@ -191,6 +209,13 @@ scope check when the field is absent rather than defaulting to out-of-scope.
 Only set `pr.inScope: false` when scope resolution genuinely excluded the
 candidate PR; the gate then short-circuits with `decision: "not_applicable"`
 instead of piling the mismatch in among unrelated reasons.
+
+Similarly, `pr.mergeable` should be **omitted entirely** when that data is not
+available — never defaulted to `""`. The gate treats a blank/whitespace-only
+value exactly like an absent field (not blocked), but a caller-side default of
+`""` for a field that was simply never requested from `gh pr view --json` used
+to read as a real "PR is not mergeable" verdict for a PR GitHub reports as
+`MERGEABLE`.
 
 Merge through the repository-approved merge path **only when all of the
 following are satisfied**:

--- a/docs/workflow/development-workflow/guardrails-enforcement.md
+++ b/docs/workflow/development-workflow/guardrails-enforcement.md
@@ -196,11 +196,14 @@ assembling the delegated gate's `<evidence-file>` instead. Feeding the wrong
 shape in does not always fail loudly: the delegated gate reports an
 `evidence_schema_mismatch: ...` reason (rather than a generic
 `delegated review/merge authority is missing` or `required CI state is
-missing` reason) whenever a required object (`.policy`) or array key
-(`.statusChecks`) is entirely absent, precisely because that absence is
-otherwise indistinguishable from a real denial or a real "no CI has run"
-state. Treat that reason as an instruction to fix the evidence file's shape,
-not as a policy or CI verdict.
+missing` reason) whenever `.policy` is missing or not an object, or
+`.statusChecks` is missing, `null`, or not an array — precisely because that
+absence/malformation is otherwise indistinguishable from a real denial or a
+real "no CI has run" state. The `.statusChecks` check is skipped when
+`ciPolicy`/`ci_policy` resolves to `none` (no CI configured for this
+repository/product), since CI-disabled evidence is never expected to carry
+`.statusChecks` at all. Treat that reason as an instruction to fix the
+evidence file's shape, not as a policy or CI verdict.
 
 The evidence file's `pr.inScope` field is meaningful only when the runner has
 a resolved `/run-epic` scope to check the candidate PR against. Protocol 90 and
@@ -327,7 +330,7 @@ table is required for consistent stop reporting.
 | `missing_required_secret_or_permission` | A required credential, GitHub permission, or access token is absent. |
 | `guardrails_config_unreadable` | The `guardrails` block in `.ai-dev-workflow.yaml` is missing required fields, uses invalid values, or is internally contradictory. |
 | `missing_audit_evidence` | A delegated decision required an audit record but the record could not be produced or verified. |
-| `evidence_schema_mismatch` | `run-epic-delegated-gate.sh` evidence is missing a required object or array key entirely (for example `.policy` or `.statusChecks[]`), which cannot be distinguished from a genuine authority denial or a genuine "no CI has run" state; fix the evidence file's shape before treating the result as a real denial or CI verdict. |
+| `evidence_schema_mismatch` | `run-epic-delegated-gate.sh` evidence is missing a required object (`.policy`), or `.statusChecks` is missing, `null`, or not an array — which cannot be distinguished from a genuine authority denial or a genuine "no CI has run" state (unless `ciPolicy`/`ci_policy` is `none`, where `.statusChecks` is not required at all); fix the evidence file's shape before treating the result as a real denial or CI verdict. |
 
 **Additive rule**: These stop conditions may **add** to but may **never remove**
 the framework's baseline human-stop conditions. The baseline stops

--- a/scripts/development-workflow/run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/run-epic-delegated-gate.sh
@@ -74,12 +74,17 @@ scope; omit it entirely for /run-item or /run-items evidence -- the gate skips
 the scope check when the field is absent rather than defaulting to
 out-of-scope.
 
-.policy being missing or not an object, or .statusChecks being missing
-entirely (as opposed to present-but-empty), cannot be told apart from a
-genuine denial or a genuine "no CI has run" state -- the gate reports an
-"evidence_schema_mismatch: ..." reason naming exactly which required shape is
-absent instead of guessing. Treat that reason as an instruction to fix the
-evidence file, not as a policy or CI verdict.
+.policy being missing or not an object, or .statusChecks being missing, null,
+or not an array (as opposed to present as an array, even an empty one),
+cannot be told apart from a genuine denial or a genuine "no CI has run"
+state -- the gate reports an "evidence_schema_mismatch: ..." reason naming
+exactly which required shape is absent instead of guessing. This
+.statusChecks check does not apply when ciPolicy/ci_policy resolves to
+"none" (no CI is configured for this repository/product) -- CI-disabled
+evidence is never expected to carry .statusChecks at all, so its absence is
+not a schema mismatch in that case. Treat the evidence_schema_mismatch
+reason as an instruction to fix the evidence file, not as a policy or CI
+verdict.
 
 When --repo-root and --product-repo are supplied (or productRepo.name is present
 in the evidence file), workflow_hub product repository ci_policy is loaded from
@@ -742,7 +747,20 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
   def policy: if (.policy | type) == "object" then .policy else {} end;
   def policy_object_present: (.policy | type) == "object";
   def ci_policy: (.ciPolicy // .ci_policy // "required");
-  def status_checks_key_present: has("statusChecks");
+  # A key-existence check alone (`has("statusChecks")`) is not sufficient: it
+  # returns true for `.statusChecks: null`, an object, or a scalar, none of
+  # which are the array `ci_status_checks` below actually expects. `null`
+  # would silently default to `[]` via `// []` (reported as the generic
+  # "required CI state is missing" rather than a schema mismatch); an object
+  # would iterate its *values* as if they were individual check entries
+  # (jq map/.[] accept objects), so a single well-formed-looking check
+  # value nested one level too deep could silently read as CI having passed
+  # -- exactly the "malformed input rendered as a substantive verdict"
+  # failure class this evidence_schema_mismatch reason exists to prevent; a
+  # scalar would abort the whole jq program with an uncaught type error. This
+  # predicate instead requires `.statusChecks` to literally be an array
+  # (present-but-empty `[]` still counts, matching existing behavior).
+  def status_checks_key_present: ((.statusChecks // null) | type) == "array";
   def labels: (.pr.labels // []);
   def risk_blockers: (.risk.blockers // []);
   def risk_ci_only_blockers:
@@ -927,8 +945,15 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     " on PR #" + (($prNumber // "unknown") | tostring) +
     " requires a fixed commit or a verified human accept/reject decision at head " + ($entry.headSha // "unknown");
   def ci_status_checks:
+    # Coerce defensively to [] for any non-array .statusChecks (missing,
+    # null, object, or scalar) so this helper -- called unconditionally from
+    # reviewer_access_classification below, not only from the guarded reasons
+    # branch that reports evidence_schema_mismatch -- can never abort the
+    # whole jq program on malformed input. The schema-mismatch diagnosis
+    # itself is reported separately via status_checks_key_present, which
+    # remains the single source of truth for "is .statusChecks well-formed".
     (reviewer_check_keys) as $reviewerKeys |
-    (.statusChecks // [])
+    ((.statusChecks // null) | if type == "array" then . else [] end)
     | map(. as $check | select(($reviewerKeys | index(reviewer_check_key($check)) | not)));
   def current_ci_blocker:
     if ci_policy == "none" then
@@ -1155,7 +1180,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
 	  (if (ci_policy == "none")
 	   then $reasons
 	   elif (status_checks_key_present | not)
-	   then add_reason($reasons; "evidence_schema_mismatch: .statusChecks[] is missing from the evidence file; an absent key cannot be distinguished from a genuine \"no CI has run\" state, so the gate reports it distinctly instead of guessing. Populate .statusChecks as an array (even an empty one) built from a live PR read -- see --help for the evidence schema -- rather than substituting the output of a different script (e.g. the result produced by run-epic-risk-classifier.sh belongs nested under a top-level \"risk\" key, not here).")
+	   then add_reason($reasons; "evidence_schema_mismatch: .statusChecks is missing, null, or not an array in the evidence file; an absent or malformed value cannot be distinguished from a genuine \"no CI has run\" state, so the gate reports it distinctly instead of guessing. Populate .statusChecks as an array (even an empty one) built from a live PR read -- see --help for the evidence schema -- rather than substituting the output of a different script (e.g. the result produced by run-epic-risk-classifier.sh belongs nested under a top-level \"risk\" key, not here).")
 	   elif (ci_status_checks | length) == 0
 	   then add_reason($reasons; "required CI state is missing")
 	   else $reasons end) as $reasons |

--- a/scripts/development-workflow/run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/run-epic-delegated-gate.sh
@@ -17,6 +17,70 @@ repository merge protocol. The gate is read-only: it does not run reviewers,
 poll CI, edit labels, update trackers, create comments, merge PRs, close
 issues, or delete branches.
 
+--input <file> expects the evidence schema below. This is a DIFFERENT schema
+than run-epic-risk-classifier.sh's --pr/--input/--json shape -- do not feed
+that script's output directly into this one's --input. Nest its result under
+a top-level "risk" key instead (see the worked example). Feeding the wrong
+shape in does not always fail loudly: some required fields being entirely
+absent reads as an "evidence_schema_mismatch" reason (see below); assemble
+each evidence file to its own documented shape.
+
+Minimal worked example. Only .pr.number, .pr.headRefName, and .pr.baseRefName
+are hard-required (the gate refuses to evaluate without them); every other key
+is optional and defaults per the rules noted inline below:
+
+  {
+    "policy": {
+      "delegateReview": true,
+      "mayMerge": true,
+      "mayStartBacklog": true
+    },
+    "item": {
+      "number": 918,
+      "status": "In Development"
+    },
+    "pr": {
+      "number": 42,
+      "headRefName": "fix/42-example",
+      "baseRefName": "develop",
+      "headSha": "<40-char-sha>",
+      "isDraft": false,
+      "mergeStateStatus": "CLEAN",
+      "mergeable": "MERGEABLE",
+      "labels": ["ready-for-human-review", "ready-for-regression"],
+      "unresolvedBlockingThreads": 0,
+      "auditDispositionPresent": true
+    },
+    "reviewer": {
+      "status": "clean",
+      "blockingCount": 0
+    },
+    "risk": {
+      "mergePermitted": true,
+      "blockers": []
+    },
+    "statusChecks": [
+      {"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"}
+    ]
+  }
+
+.pr.mergeable follows GitHub's mergeable enum (e.g. MERGEABLE, CONFLICTING,
+UNKNOWN). Omit the field entirely when you don't have this data -- do not
+default it to "" (an empty string is treated the same as omitted, never as a
+"not mergeable" verdict).
+
+.pr.inScope is meaningful only when checking against a resolved /run-epic
+scope; omit it entirely for /run-item or /run-items evidence -- the gate skips
+the scope check when the field is absent rather than defaulting to
+out-of-scope.
+
+.policy being missing or not an object, or .statusChecks being missing
+entirely (as opposed to present-but-empty), cannot be told apart from a
+genuine denial or a genuine "no CI has run" state -- the gate reports an
+"evidence_schema_mismatch: ..." reason naming exactly which required shape is
+absent instead of guessing. Treat that reason as an instruction to fix the
+evidence file, not as a policy or CI verdict.
+
 When --repo-root and --product-repo are supplied (or productRepo.name is present
 in the evidence file), workflow_hub product repository ci_policy is loaded from
 the resolver and applied when the evidence file omits ciPolicy/ci_policy.
@@ -676,7 +740,9 @@ state_json="$(printf '%s\n' "$state_json" | jq --argjson fixes "$verified_securi
 
 decision_json="$(printf '%s\n' "$state_json" | jq '
   def policy: if (.policy | type) == "object" then .policy else {} end;
+  def policy_object_present: (.policy | type) == "object";
   def ci_policy: (.ciPolicy // .ci_policy // "required");
+  def status_checks_key_present: has("statusChecks");
   def labels: (.pr.labels // []);
   def risk_blockers: (.risk.blockers // []);
   def risk_ci_only_blockers:
@@ -872,9 +938,20 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
       | any(.[]?; (success_check | not))
     end;
   def pr_mergeable_ok:
-    (.pr.mergeable // .pr.mergeableState // null) as $mergeable |
-    if $mergeable == null then true
-    else (($mergeable | tostring | ascii_downcase) | IN("mergeable", "true"))
+    # A blank/whitespace-only string is treated exactly like an absent field
+    # (unknown mergeable state -> not blocked), not like a real GitHub
+    # mergeable-enum value. Evidence assembled by hand from a `gh pr view
+    # --json` call that omitted the `mergeable` field can easily default the
+    # missing key to "" (e.g. via `.mergeable // ""`) rather than leaving it
+    # null; without this normalization that "" would fall through to the
+    # `else` branch below and be reported as a real "not mergeable" verdict
+    # for a PR GitHub actually reports as MERGEABLE -- missing input rendered
+    # as a substantive verdict, the same failure class pr_identity_gaps
+    # already guards against for .pr identity fields above.
+    ((.pr.mergeable // .pr.mergeableState // null) |
+      if . == null then null else (tostring | gsub("^\\s+|\\s+$"; "")) end) as $mergeable |
+    if ($mergeable == null or $mergeable == "") then true
+    else (($mergeable | ascii_downcase) | IN("mergeable", "true"))
     end;
   def access_obj: (.accessRestriction // .access_restriction // {});
   def access_obj_present:
@@ -1029,10 +1106,25 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
   (if ($invalidCheckpointStates | length) > 0
    then add_reason($reasons; "human_checkpoint_required: invalid checkpoint satisfaction_state; expected pending, satisfied, or waived")
    else $reasons end) as $reasons |
-  (if (policy.delegateReview // false) != true
+  # A .policy that is entirely absent or not an object is indistinguishable,
+  # field-by-field, from an explicit denial of every individual authority flag
+  # once `policy` above defaults it to {} -- exactly the same conflation
+  # pr_identity_gaps already guards against for .pr identity above. Report it
+  # as one named, actionable evidence_schema_mismatch reason instead of the
+  # two generic authority-denial reasons below, so an operator debugging a
+  # malformed evidence file (e.g. one assembled from the output of a
+  # different script, such as the --json result produced by
+  # run-epic-risk-classifier.sh, which has no .policy at all) is not misled
+  # into concluding they lack merge
+  # permission when the real problem is the input shape.
+  (if (policy_object_present | not) then
+     add_reason($reasons; "evidence_schema_mismatch: .policy object is missing or is not an object in the evidence file; this cannot be distinguished from an explicit denial of delegated review/merge authority, so the gate reports it distinctly instead of guessing. Supply .policy as an object with explicit delegateReview and mayMerge booleans (see --help for the evidence schema) before concluding authority is denied.")
+   elif (policy.delegateReview // false) != true
    then add_reason($reasons; "delegated review authority is missing")
    else $reasons end) as $reasons |
-  (if (policy.mayMerge // false) != true
+  (if (policy_object_present | not) then
+     $reasons
+   elif (policy.mayMerge // false) != true
    then add_reason($reasons; "delegated merge authority is missing")
    else $reasons end) as $reasons |
   (if graduation_pr and (graduation_approved | not)
@@ -1062,6 +1154,8 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
    else $reasons end) as $reasons |
 	  (if (ci_policy == "none")
 	   then $reasons
+	   elif (status_checks_key_present | not)
+	   then add_reason($reasons; "evidence_schema_mismatch: .statusChecks[] is missing from the evidence file; an absent key cannot be distinguished from a genuine \"no CI has run\" state, so the gate reports it distinctly instead of guessing. Populate .statusChecks as an array (even an empty one) built from a live PR read -- see --help for the evidence schema -- rather than substituting the output of a different script (e.g. the result produced by run-epic-risk-classifier.sh belongs nested under a top-level \"risk\" key, not here).")
 	   elif (ci_status_checks | length) == 0
 	   then add_reason($reasons; "required CI state is missing")
 	   else $reasons end) as $reasons |
@@ -1114,7 +1208,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
       elif ($reviewerAccessClassification | IN("access_restricted", "authorization_required", "authorization_stale", "audit_required")) then "human_required"
       elif $count == 0 then "merge_allowed"
       elif ($reasons | any(test("reviewer blocking|CI checks|unresolved blocking|advisories"))) then "fix_required"
-      elif ($reasons | any(test("authority|risk gate|needs-setup|Backlog|human_checkpoint_required|human-checkpoint|graduation_approval_required|security_sensitive_advisory_pending"))) then "human_required"
+      elif ($reasons | any(test("authority|risk gate|needs-setup|Backlog|human_checkpoint_required|human-checkpoint|graduation_approval_required|security_sensitive_advisory_pending|evidence_schema_mismatch"))) then "human_required"
       else "blocked"
       end
     ),
@@ -1130,6 +1224,7 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
       elif ($reasons | any(test("human_checkpoint_required|human-checkpoint"))) then "stop for the named human checkpoint action, record satisfied or waived evidence, sync labels, and rerun this gate"
       elif ($reasons | any(test("graduation_approval_required"))) then "stop for explicit graduation approval via /graduate-development before mutating"
       elif ($reasons | any(test("security_sensitive_advisory_pending"))) then "record a fixed commit or obtain a verified human accept/reject decision for each pending security-sensitive advisory finding (never a delegated-agent-recorded acceptance/rejection), then rerun this gate"
+      elif ($reasons | any(test("evidence_schema_mismatch"))) then "fix the evidence file to match the delegated-gate schema (see --help) before concluding this is a denied authority or a real missing-CI-state verdict -- an absent or malformed required field cannot be distinguished from a genuine blocker, so verify the JSON shape first, then rerun this gate"
       elif ($reasons | any(test("authority|risk gate|needs-setup|Backlog"))) then "stop for human authority or setup before mutating"
       else "block until required state is available"
       end

--- a/scripts/development-workflow/run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/run-epic-delegated-gate.sh
@@ -759,8 +759,16 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
   # failure class this evidence_schema_mismatch reason exists to prevent; a
   # scalar would abort the whole jq program with an uncaught type error. This
   # predicate instead requires `.statusChecks` to literally be an array
-  # (present-but-empty `[]` still counts, matching existing behavior).
-  def status_checks_key_present: ((.statusChecks // null) | type) == "array";
+  # (present-but-empty `[]` still counts, matching existing behavior). It
+  # also requires every array member to itself be an object: a string or
+  # number member reaches the reviewer_check_key field accessors (`.name`,
+  # `.context`, ...) and aborts the whole jq program the same way a
+  # non-array top-level value did; a `null` member does not crash but
+  # silently reads as an unnamed, all-fields-absent check that reports a
+  # generic CI failure instead of the more legible schema-mismatch reason.
+  def status_checks_key_present:
+    ((.statusChecks // null) | type) == "array" and
+    ((.statusChecks // []) | all(type == "object"));
   def labels: (.pr.labels // []);
   def risk_blockers: (.risk.blockers // []);
   def risk_ci_only_blockers:
@@ -946,14 +954,18 @@ decision_json="$(printf '%s\n' "$state_json" | jq '
     " requires a fixed commit or a verified human accept/reject decision at head " + ($entry.headSha // "unknown");
   def ci_status_checks:
     # Coerce defensively to [] for any non-array .statusChecks (missing,
-    # null, object, or scalar) so this helper -- called unconditionally from
-    # reviewer_access_classification below, not only from the guarded reasons
-    # branch that reports evidence_schema_mismatch -- can never abort the
-    # whole jq program on malformed input. The schema-mismatch diagnosis
-    # itself is reported separately via status_checks_key_present, which
-    # remains the single source of truth for "is .statusChecks well-formed".
+    # null, object, or scalar), and drop any non-object array member, so
+    # this helper -- called unconditionally from reviewer_access_classification
+    # below, not only from the guarded reasons branch that reports
+    # evidence_schema_mismatch -- can never abort the whole jq program on
+    # malformed input (a string/number member would otherwise reach the
+    # reviewer_check_key field accessors and crash). The schema-mismatch
+    # diagnosis itself is reported separately via status_checks_key_present,
+    # which remains the single source of truth for "is .statusChecks
+    # well-formed" (array-typed, every member an object).
     (reviewer_check_keys) as $reviewerKeys |
     ((.statusChecks // null) | if type == "array" then . else [] end)
+    | map(select(type == "object"))
     | map(. as $check | select(($reviewerKeys | index(reviewer_check_key($check)) | not)));
   def current_ci_blocker:
     if ci_policy == "none" then

--- a/scripts/development-workflow/run-epic-risk-classifier.sh
+++ b/scripts/development-workflow/run-epic-risk-classifier.sh
@@ -9,8 +9,8 @@ source "$SCRIPT_DIR/workflow-lib.sh"
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/development-workflow/run-epic-risk-classifier.sh --pr <number> [--max-risk <low|medium|high>] [--repo-root <path>] [--product-repo <name>] [--json]
-  ./scripts/development-workflow/run-epic-risk-classifier.sh --input <file> [--max-risk <low|medium|high>] [--repo-root <path>] [--product-repo <name>] [--json]
+  ./scripts/development-workflow/run-epic-risk-classifier.sh --pr <number> [--why-safe-file <file>] [--max-risk <low|medium|high>] [--repo-root <path>] [--product-repo <name>] [--json]
+  ./scripts/development-workflow/run-epic-risk-classifier.sh --input <file> [--why-safe-file <file>] [--max-risk <low|medium|high>] [--repo-root <path>] [--product-repo <name>] [--json]
 
 Classifies delegated /run-epic PR merge risk. The classifier is read-only: it
 does not run reviewers, poll CI, edit labels, update trackers, merge PRs, close
@@ -19,11 +19,64 @@ issues, post comments, or delete branches.
 In workflow_hub mode, pass --repo-root and --product-repo (or include
 productRepo.name / github_repo in the evidence) so hub ci_policy is applied when
 the evidence omits ciPolicy / ci_policy.
+
+--pr <number> reads live PR state via `gh pr view` / `gh pr diff`. On its own
+it has no way to attach why_safe_to_merge evidence, so a PR that classifies as
+medium risk will always end up "blocked" ("medium-risk PR is missing complete
+why_safe_to_merge evidence") unless you also pass --why-safe-file.
+
+--why-safe-file <file> merges a why_safe_to_merge object into the classified
+state before evaluation, for either --pr or --input mode (it overrides any
+why_safe_to_merge already present in an --input file's contents). Required
+shape -- all five fields are required, non-blank strings:
+
+  {
+    "scope": "what changed and why, in one or two sentences",
+    "tests": "what was run/verified locally and what it showed",
+    "reviewer_outcome": "delegated review disposition (e.g. clean / advisories accepted with rationale)",
+    "ci_outcome": "CI state summary (e.g. all required checks green)",
+    "rollback_or_cleanup_risk": "what happens if this needs to be reverted"
+  }
+
+--input <file> expects the SAME normalized shape --pr builds internally, not
+raw `gh pr view` JSON. Worked example (only pr_number is required; every other
+field is optional and defaults per classify_state's rules):
+
+  {
+    "pr_number": 42,
+    "title": "fix: example change",
+    "base": "develop",
+    "head": "fix/42-example",
+    "github_repo": "owner/repo",
+    "merge_state": "CLEAN",
+    "is_draft": false,
+    "labels": ["ready-for-human-review"],
+    "review_decision": "APPROVED",
+    "status_checks": [
+      {"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS", "completed_at": "2026-08-20T12:00:00Z"}
+    ],
+    "changed_files": ["scripts/development-workflow/run-epic-risk-classifier.sh"],
+    "why_safe_to_merge": {
+      "scope": "...",
+      "tests": "...",
+      "reviewer_outcome": "...",
+      "ci_outcome": "...",
+      "rollback_or_cleanup_risk": "..."
+    }
+  }
+
+This is NOT the same schema run-epic-delegated-gate.sh --input expects (that
+gate needs a top-level .pr{} identity object, top-level .statusChecks[], and a
+top-level .policy{} -- see that script's --help for its worked example). Do
+not feed this script's --json output directly into that gate's --input;
+assemble each evidence file to its own documented shape (nest this script's
+result under a top-level "risk" key for the delegated gate instead).
 EOF
 }
 
 pr_number=""
 input_file=""
+why_safe_file=""
 repo_root=""
 product_repo=""
 max_risk="low"
@@ -503,6 +556,11 @@ while [ "$#" -gt 0 ]; do
       input_file="$2"
       shift 2
       ;;
+    --why-safe-file)
+      require_value "$@"
+      why_safe_file="$2"
+      shift 2
+      ;;
     --max-risk)
       require_value "$@"
       max_risk="$2"
@@ -556,6 +614,16 @@ if [ -n "$input_file" ]; then
   state_json="$(normalize_fixture "$input_file")"
 else
   state_json="$(live_pr_state "$pr_number")"
+fi
+
+if [ -n "$why_safe_file" ]; then
+  why_safe_json="$(normalize_fixture "$why_safe_file")"
+  if ! printf '%s\n' "$why_safe_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
+    error_exit "--why-safe-file must contain a JSON object: $why_safe_file"
+  fi
+  if ! state_json="$(printf '%s\n' "$state_json" | jq --argjson why "$why_safe_json" '.why_safe_to_merge = $why')"; then
+    error_exit "failed to merge --why-safe-file into classified state"
+  fi
 fi
 
 effective_root="${repo_root:-$(workflow_repo_root)}"

--- a/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
@@ -410,12 +410,48 @@ run_test "missing_delegate_review_reason" "true" "$(reason_match_for "$no_review
 
 null_policy_fixture="$(write_fixture null-policy '.policy = null')"
 run_test "null_policy_requires_human" "human_required" "$(decision_for "$null_policy_fixture")"
+run_test "null_policy_reports_schema_mismatch_not_authority_denial" "true" "$(reason_match_for "$null_policy_fixture" "^evidence_schema_mismatch: \.policy object is missing")"
 
 string_policy_fixture="$(write_fixture string-policy '.policy = "delegate"')"
 run_test "non_object_policy_requires_human" "human_required" "$(decision_for "$string_policy_fixture")"
+run_test "non_object_policy_reports_schema_mismatch_not_authority_denial" "true" "$(reason_match_for "$string_policy_fixture" "^evidence_schema_mismatch: \.policy object is missing")"
 
 no_merge_fixture="$(write_fixture no-merge '.policy.mayMerge = false')"
 run_test "missing_merge_authority_requires_human" "human_required" "$(decision_for "$no_merge_fixture")"
+
+# --- issue #1497: feeding a hand-assembled hybrid evidence file that has a
+# --- well-formed .pr identity (so it clears pr_identity_gaps) but omits
+# --- .policy and .statusChecks entirely -- exactly what happens when an
+# --- operator wraps run-epic-risk-classifier.sh's flat output instead of
+# --- building the delegated-gate's own documented shape -- must report a
+# --- distinct evidence_schema_mismatch reason, never the generic
+# --- "delegated review/merge authority is missing" or "required CI state is
+# --- missing" wording that reads as a policy/CI verdict rather than a
+# --- malformed-input problem. ---
+schema_mismatch_hybrid_fixture="$(write_fixture schema-mismatch-hybrid 'del(.policy) | del(.statusChecks) | del(.risk)')"
+run_test "schema_mismatch_hybrid_requires_human" "human_required" "$(decision_for "$schema_mismatch_hybrid_fixture")"
+run_test "schema_mismatch_hybrid_reports_policy_schema_mismatch" "true" "$(reason_match_for "$schema_mismatch_hybrid_fixture" "^evidence_schema_mismatch: \.policy object is missing")"
+run_test "schema_mismatch_hybrid_reports_statuschecks_schema_mismatch" "true" "$(reason_match_for "$schema_mismatch_hybrid_fixture" "^evidence_schema_mismatch: \.statusChecks\[\] is missing")"
+run_test "schema_mismatch_hybrid_does_not_report_generic_authority_denial" "false" "$(reason_match_for "$schema_mismatch_hybrid_fixture" "^delegated review authority is missing\$")"
+run_test "schema_mismatch_hybrid_does_not_report_generic_merge_denial" "false" "$(reason_match_for "$schema_mismatch_hybrid_fixture" "^delegated merge authority is missing\$")"
+run_test "schema_mismatch_hybrid_does_not_report_generic_ci_missing" "false" "$(reason_match_for "$schema_mismatch_hybrid_fixture" "^required CI state is missing\$")"
+run_test "schema_mismatch_hybrid_next_action_names_schema_not_policy" "true" "$(
+  "$GATE" --input "$schema_mismatch_hybrid_fixture" --json |
+    jq -r '.nextAction | test("schema") and test("denied authority or a real missing-CI-state verdict")'
+)"
+
+missing_statuschecks_only_fixture="$(write_fixture missing-statuschecks-only 'del(.statusChecks)')"
+run_test "missing_statuschecks_key_requires_human" "human_required" "$(decision_for "$missing_statuschecks_only_fixture")"
+run_test "missing_statuschecks_key_reports_schema_mismatch" "true" "$(reason_match_for "$missing_statuschecks_only_fixture" "^evidence_schema_mismatch: \.statusChecks\[\] is missing")"
+run_test "missing_statuschecks_key_does_not_report_generic_ci_missing" "false" "$(reason_match_for "$missing_statuschecks_only_fixture" "^required CI state is missing\$")"
+
+# present-but-empty .statusChecks (genuinely no CI has run / no CI configured
+# without an explicit ciPolicy: none) must keep the existing wording and
+# "blocked" decision unchanged -- only the entirely-absent key case above is
+# new/distinct.
+present_empty_statuschecks_fixture="$(write_fixture present-empty-statuschecks '.statusChecks = []')"
+run_test "present_empty_statuschecks_still_blocked" "blocked" "$(decision_for "$present_empty_statuschecks_fixture")"
+run_test "present_empty_statuschecks_keeps_original_wording" "true" "$(reason_match_for "$present_empty_statuschecks_fixture" "^required CI state is missing\$")"
 
 policy_override_file="$TMP_ROOT/policy-override.json"
 jq '.policy' "$base_fixture" > "$policy_override_file"
@@ -519,6 +555,22 @@ run_test "missing_ci_blocks" "blocked" "$(decision_for "$missing_ci_fixture")"
 
 dirty_merge_fixture="$(write_fixture dirty-merge '.pr.mergeStateStatus = "DIRTY"')"
 run_test "dirty_merge_blocks" "blocked" "$(decision_for "$dirty_merge_fixture")"
+
+# --- issue #1497: a caller-side gh pr view --json field list that omitted
+# --- `mergeable` (or that defaulted it to "" instead of leaving it null) must
+# --- not be reported as a substantive "PR is not mergeable" verdict for a PR
+# --- GitHub actually reports as MERGEABLE. A real non-mergeable state (e.g.
+# --- CONFLICTING) must still block. ---
+not_mergeable_fixture="$(write_fixture not-mergeable '.pr.mergeable = "CONFLICTING"')"
+run_test "real_conflicting_mergeable_blocks" "blocked" "$(decision_for "$not_mergeable_fixture")"
+run_test "real_conflicting_mergeable_reason" "true" "$(reason_match_for "$not_mergeable_fixture" "^PR is not mergeable\$")"
+
+blank_mergeable_fixture="$(write_fixture blank-mergeable '.pr.mergeable = ""')"
+run_test "blank_mergeable_string_allows_merge" "merge_allowed" "$(decision_for "$blank_mergeable_fixture")"
+run_test "blank_mergeable_string_no_false_verdict" "false" "$(reason_match_for "$blank_mergeable_fixture" "^PR is not mergeable\$")"
+
+whitespace_mergeable_fixture="$(write_fixture whitespace-mergeable '.pr.mergeable = "   "')"
+run_test "whitespace_only_mergeable_string_allows_merge" "merge_allowed" "$(decision_for "$whitespace_mergeable_fixture")"
 
 thread_fixture="$(write_fixture unresolved-thread '.pr.unresolvedBlockingThreads = 1')"
 run_test "unresolved_thread_requires_fix" "fix_required" "$(decision_for "$thread_fixture")"

--- a/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
@@ -431,7 +431,7 @@ run_test "missing_merge_authority_requires_human" "human_required" "$(decision_f
 schema_mismatch_hybrid_fixture="$(write_fixture schema-mismatch-hybrid 'del(.policy) | del(.statusChecks) | del(.risk)')"
 run_test "schema_mismatch_hybrid_requires_human" "human_required" "$(decision_for "$schema_mismatch_hybrid_fixture")"
 run_test "schema_mismatch_hybrid_reports_policy_schema_mismatch" "true" "$(reason_match_for "$schema_mismatch_hybrid_fixture" "^evidence_schema_mismatch: \.policy object is missing")"
-run_test "schema_mismatch_hybrid_reports_statuschecks_schema_mismatch" "true" "$(reason_match_for "$schema_mismatch_hybrid_fixture" "^evidence_schema_mismatch: \.statusChecks\[\] is missing")"
+run_test "schema_mismatch_hybrid_reports_statuschecks_schema_mismatch" "true" "$(reason_match_for "$schema_mismatch_hybrid_fixture" "^evidence_schema_mismatch: \.statusChecks is missing")"
 run_test "schema_mismatch_hybrid_does_not_report_generic_authority_denial" "false" "$(reason_match_for "$schema_mismatch_hybrid_fixture" "^delegated review authority is missing\$")"
 run_test "schema_mismatch_hybrid_does_not_report_generic_merge_denial" "false" "$(reason_match_for "$schema_mismatch_hybrid_fixture" "^delegated merge authority is missing\$")"
 run_test "schema_mismatch_hybrid_does_not_report_generic_ci_missing" "false" "$(reason_match_for "$schema_mismatch_hybrid_fixture" "^required CI state is missing\$")"
@@ -442,8 +442,36 @@ run_test "schema_mismatch_hybrid_next_action_names_schema_not_policy" "true" "$(
 
 missing_statuschecks_only_fixture="$(write_fixture missing-statuschecks-only 'del(.statusChecks)')"
 run_test "missing_statuschecks_key_requires_human" "human_required" "$(decision_for "$missing_statuschecks_only_fixture")"
-run_test "missing_statuschecks_key_reports_schema_mismatch" "true" "$(reason_match_for "$missing_statuschecks_only_fixture" "^evidence_schema_mismatch: \.statusChecks\[\] is missing")"
+run_test "missing_statuschecks_key_reports_schema_mismatch" "true" "$(reason_match_for "$missing_statuschecks_only_fixture" "^evidence_schema_mismatch: \.statusChecks is missing")"
 run_test "missing_statuschecks_key_does_not_report_generic_ci_missing" "false" "$(reason_match_for "$missing_statuschecks_only_fixture" "^required CI state is missing\$")"
+
+# --- CodeRabbit finding on PR #1553: has("statusChecks") alone accepted null,
+# --- object, and scalar values for .statusChecks (all of which are not the
+# --- array ci_status_checks expects). A null silently defaulted to [] and
+# --- read as the generic "required CI state is missing" instead of a schema
+# --- mismatch; an object had its *values* iterated as if they were
+# --- individual check entries (jq map/.[] accept objects), so a
+# --- well-formed-looking single check value one level too deep could read
+# --- as CI having passed -- a real false "merge_allowed" for malformed
+# --- input, not just an unclear message; a scalar aborted the whole jq
+# --- program. All three must now report evidence_schema_mismatch, never
+# --- crash, and never silently permit merge. ---
+null_statuschecks_fixture="$(write_fixture null-statuschecks '.statusChecks = null')"
+run_test "null_statuschecks_reports_schema_mismatch" "true" "$(reason_match_for "$null_statuschecks_fixture" "^evidence_schema_mismatch: \.statusChecks is missing")"
+run_test "null_statuschecks_does_not_report_generic_ci_missing" "false" "$(reason_match_for "$null_statuschecks_fixture" "^required CI state is missing\$")"
+
+object_statuschecks_fixture="$(write_fixture object-statuschecks '.statusChecks = {"ci": {"status": "COMPLETED", "conclusion": "SUCCESS"}}')"
+run_test "object_statuschecks_does_not_silently_merge_allow" "human_required" "$(decision_for "$object_statuschecks_fixture")"
+run_test "object_statuschecks_reports_schema_mismatch" "true" "$(reason_match_for "$object_statuschecks_fixture" "^evidence_schema_mismatch: \.statusChecks is missing")"
+
+scalar_statuschecks_fixture="$(write_fixture scalar-statuschecks '.statusChecks = "SUCCESS"')"
+run_test "scalar_statuschecks_does_not_crash" "true" "$(
+  "$GATE" --input "$scalar_statuschecks_fixture" --json >/dev/null 2>&1 && echo true || echo false
+)"
+run_test "scalar_statuschecks_reports_schema_mismatch" "true" "$(reason_match_for "$scalar_statuschecks_fixture" "^evidence_schema_mismatch: \.statusChecks is missing")"
+
+boolean_statuschecks_fixture="$(write_fixture boolean-statuschecks '.statusChecks = true')"
+run_test "boolean_statuschecks_reports_schema_mismatch" "true" "$(reason_match_for "$boolean_statuschecks_fixture" "^evidence_schema_mismatch: \.statusChecks is missing")"
 
 # present-but-empty .statusChecks (genuinely no CI has run / no CI configured
 # without an explicit ciPolicy: none) must keep the existing wording and

--- a/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
+++ b/scripts/development-workflow/tests/test-run-epic-delegated-gate.sh
@@ -459,6 +459,7 @@ run_test "missing_statuschecks_key_does_not_report_generic_ci_missing" "false" "
 null_statuschecks_fixture="$(write_fixture null-statuschecks '.statusChecks = null')"
 run_test "null_statuschecks_reports_schema_mismatch" "true" "$(reason_match_for "$null_statuschecks_fixture" "^evidence_schema_mismatch: \.statusChecks is missing")"
 run_test "null_statuschecks_does_not_report_generic_ci_missing" "false" "$(reason_match_for "$null_statuschecks_fixture" "^required CI state is missing\$")"
+run_test "null_statuschecks_fails_closed" "human_required" "$(decision_for "$null_statuschecks_fixture")"
 
 object_statuschecks_fixture="$(write_fixture object-statuschecks '.statusChecks = {"ci": {"status": "COMPLETED", "conclusion": "SUCCESS"}}')"
 run_test "object_statuschecks_does_not_silently_merge_allow" "human_required" "$(decision_for "$object_statuschecks_fixture")"
@@ -469,9 +470,42 @@ run_test "scalar_statuschecks_does_not_crash" "true" "$(
   "$GATE" --input "$scalar_statuschecks_fixture" --json >/dev/null 2>&1 && echo true || echo false
 )"
 run_test "scalar_statuschecks_reports_schema_mismatch" "true" "$(reason_match_for "$scalar_statuschecks_fixture" "^evidence_schema_mismatch: \.statusChecks is missing")"
+run_test "scalar_statuschecks_fails_closed" "human_required" "$(decision_for "$scalar_statuschecks_fixture")"
 
 boolean_statuschecks_fixture="$(write_fixture boolean-statuschecks '.statusChecks = true')"
 run_test "boolean_statuschecks_reports_schema_mismatch" "true" "$(reason_match_for "$boolean_statuschecks_fixture" "^evidence_schema_mismatch: \.statusChecks is missing")"
+run_test "boolean_statuschecks_fails_closed" "human_required" "$(decision_for "$boolean_statuschecks_fixture")"
+
+# --- CodeRabbit follow-up finding on the same PR: the array-type check above
+# --- does not validate individual array *members*. A string or number member
+# --- reaches reviewer_check_key's field accessors and aborts the whole jq
+# --- program the same way a non-array top-level value did; a null member does
+# --- not crash but silently reads as an unnamed, all-fields-absent check
+# --- (a generic CI failure) rather than the more legible schema-mismatch
+# --- reason. Every array member must now itself be an object. ---
+string_member_statuschecks_fixture="$(write_fixture string-member-statuschecks '.statusChecks = ["SUCCESS"]')"
+run_test "string_member_statuschecks_does_not_crash" "true" "$(
+  "$GATE" --input "$string_member_statuschecks_fixture" --json >/dev/null 2>&1 && echo true || echo false
+)"
+run_test "string_member_statuschecks_reports_schema_mismatch" "true" "$(reason_match_for "$string_member_statuschecks_fixture" "^evidence_schema_mismatch: \.statusChecks is missing")"
+run_test "string_member_statuschecks_fails_closed" "human_required" "$(decision_for "$string_member_statuschecks_fixture")"
+
+number_member_statuschecks_fixture="$(write_fixture number-member-statuschecks '.statusChecks = [42]')"
+run_test "number_member_statuschecks_does_not_crash" "true" "$(
+  "$GATE" --input "$number_member_statuschecks_fixture" --json >/dev/null 2>&1 && echo true || echo false
+)"
+run_test "number_member_statuschecks_reports_schema_mismatch" "true" "$(reason_match_for "$number_member_statuschecks_fixture" "^evidence_schema_mismatch: \.statusChecks is missing")"
+
+null_member_statuschecks_fixture="$(write_fixture null-member-statuschecks '.statusChecks = [null]')"
+run_test "null_member_statuschecks_reports_schema_mismatch" "true" "$(reason_match_for "$null_member_statuschecks_fixture" "^evidence_schema_mismatch: \.statusChecks is missing")"
+run_test "null_member_statuschecks_fails_closed" "human_required" "$(decision_for "$null_member_statuschecks_fixture")"
+
+mixed_member_statuschecks_fixture="$(write_fixture mixed-member-statuschecks '.statusChecks = [{"name": "guard", "status": "COMPLETED", "conclusion": "SUCCESS"}, "SUCCESS"]')"
+run_test "mixed_member_statuschecks_reports_schema_mismatch" "true" "$(reason_match_for "$mixed_member_statuschecks_fixture" "^evidence_schema_mismatch: \.statusChecks is missing")"
+run_test "mixed_member_statuschecks_does_not_silently_merge_allow" "human_required" "$(decision_for "$mixed_member_statuschecks_fixture")"
+
+well_formed_statuschecks_fixture="$(write_fixture well-formed-statuschecks '.statusChecks = [{"name": "guard", "status": "COMPLETED", "conclusion": "SUCCESS"}]')"
+run_test "well_formed_statuschecks_still_merge_allowed" "merge_allowed" "$(decision_for "$well_formed_statuschecks_fixture")"
 
 # present-but-empty .statusChecks (genuinely no CI has run / no CI configured
 # without an explicit ciPolicy: none) must keep the existing wording and

--- a/scripts/development-workflow/tests/test-run-epic-risk-classifier.sh
+++ b/scripts/development-workflow/tests/test-run-epic-risk-classifier.sh
@@ -67,6 +67,27 @@ JSON
     fi
     printf '%s\n' 'docs/workflow/development-workflow/protocols/95-run-epic-protocol.md'
     ;;
+  pr\ view\ 43\ --json*)
+    cat <<'JSON'
+{
+  "number": 43,
+  "title": "Live medium risk",
+  "baseRefName": "develop",
+  "headRefName": "fix/43-live-medium",
+  "headRepository": {"name": "ai-dev-framework-template", "owner": {"login": "lhpaul"}},
+  "mergeStateStatus": "CLEAN",
+  "isDraft": false,
+  "reviewDecision": "APPROVED",
+  "labels": [{"name": "ready-for-human-review"}],
+  "statusCheckRollup": [
+    {"__typename": "CheckRun", "name": "guard", "status": "COMPLETED", "conclusion": "SUCCESS"}
+  ]
+}
+JSON
+    ;;
+  pr\ diff\ 43\ --name-only)
+    printf '%s\n' 'scripts/development-workflow/run-epic-risk-classifier.sh'
+    ;;
   issue\ edit*|pr\ create*|pr\ merge*|project\ item-edit*|project\ item-add*|pr\ comment*|pr\ close*|pr\ edit*)
     printf 'mutating gh command was called: gh %s\n' "$*" >&2
     exit 99
@@ -593,6 +614,44 @@ run_test "json_read_only_guarantee" "yes" "$(printf '%s\n' "$live_output" | jq -
 run_fails_contains "live_pr_view_failure_errors" "failed to read PR #42" env MOCK_GH_MODE=view-fail "$CLASSIFIER" --pr 42 --json
 run_fails_contains "live_pr_empty_response_errors" "empty PR response for #42" env MOCK_GH_MODE=view-empty "$CLASSIFIER" --pr 42 --json
 run_fails_contains "live_pr_diff_failure_errors" "failed to read changed files for PR #42" env MOCK_GH_MODE=diff-fail "$CLASSIFIER" --pr 42 --json
+
+# --- issue #1497: --pr cannot attach why_safe_to_merge, so a medium-risk PR
+# --- classified via --pr always ends up "blocked" without --why-safe-file ---
+live_medium_no_evidence_output="$("$CLASSIFIER" --pr 43 --max-risk medium --json)"
+run_test "live_pr_medium_risk_without_why_safe_file_is_blocked" "blocked" "$(printf '%s\n' "$live_medium_no_evidence_output" | jq -r '.risk')"
+run_test "live_pr_medium_risk_without_why_safe_file_reason" "yes" "$(printf '%s\n' "$live_medium_no_evidence_output" | jq -e '.blockers[] | select(test("why_safe_to_merge"))' >/dev/null && echo yes || echo no)"
+
+why_safe_fixture="$(write_fixture why-safe '{
+  "scope": "single read-only classifier helper",
+  "tests": "fixture tests cover risk classes",
+  "reviewer_outcome": "reviewer loop clean",
+  "ci_outcome": "CI green",
+  "rollback_or_cleanup_risk": "remove helper and docs if needed"
+}')"
+live_medium_with_evidence_output="$("$CLASSIFIER" --pr 43 --why-safe-file "$why_safe_fixture" --max-risk medium --json)"
+run_test "live_pr_medium_risk_with_why_safe_file_reaches_medium" "medium" "$(printf '%s\n' "$live_medium_with_evidence_output" | jq -r '.risk')"
+run_test "live_pr_medium_risk_with_why_safe_file_merge_permitted" "true" "$(printf '%s\n' "$live_medium_with_evidence_output" | jq -r '.merge_permitted')"
+run_test "live_pr_why_safe_file_carried_through" "single read-only classifier helper" "$(printf '%s\n' "$live_medium_with_evidence_output" | jq -r '.why_safe_to_merge.scope')"
+
+# --why-safe-file also works with --input mode, and overrides any
+# why_safe_to_merge already embedded in the --input file's contents.
+why_safe_override_fixture="$(write_fixture why-safe-override '{
+  "scope": "overridden via --why-safe-file",
+  "tests": "overridden",
+  "reviewer_outcome": "overridden",
+  "ci_outcome": "overridden",
+  "rollback_or_cleanup_risk": "overridden"
+}')"
+input_with_why_safe_override_output="$("$CLASSIFIER" --input "$medium_fixture" --why-safe-file "$why_safe_override_fixture" --max-risk medium --json)"
+run_test "why_safe_file_overrides_input_why_safe" "overridden via --why-safe-file" "$(printf '%s\n' "$input_with_why_safe_override_output" | jq -r '.why_safe_to_merge.scope')"
+
+non_object_why_safe_fixture="$(write_fixture why-safe-non-object '["not", "an", "object"]')"
+run_fails_contains "rejects_non_object_why_safe_file" "--why-safe-file must contain a JSON object" \
+  "$CLASSIFIER" --pr 43 --why-safe-file "$non_object_why_safe_fixture" --max-risk medium --json
+run_fails_contains "rejects_missing_why_safe_file" "input file not found" \
+  "$CLASSIFIER" --pr 43 --why-safe-file "$TMP_ROOT/missing-why-safe.json" --max-risk medium --json
+run_fails_contains "rejects_flag_as_why_safe_file_value" "--why-safe-file requires a value" \
+  "$CLASSIFIER" --pr 43 --why-safe-file --max-risk medium --json
 
 run_test "no_mutating_gh_commands" "no" "$(
   grep -Eq '(^issue edit|^pr create|^pr merge|^project item-edit|^project item-add|^pr comment|^pr close|^pr edit|mutation)' "$CALL_LOG" && echo yes || echo no


### PR DESCRIPTION
## Summary

Fixes #1497.

- `run-epic-risk-classifier.sh --pr` had no way to attach `why_safe_to_merge` evidence, so every medium-risk PR classified this way always ended up `blocked`. Added `--why-safe-file <file>` to merge that evidence into the classified state for either `--pr` or `--input` mode.
- Documented both scripts' evidence schemas with a worked example in `--help` (they are different schemas; the docs and help text now explicitly warn against feeding one script's output directly into the other's `--input`, and explain nesting the classifier's result under a top-level `risk` key instead).
- `run-epic-delegated-gate.sh` used to report a malformed/incompatible evidence file (e.g. one built from the risk classifier's own flat output) as `delegated review authority is missing` / `delegated merge authority is missing` / `required CI state is missing` — reading as a policy or CI verdict when the real problem was a missing `.policy` object or an entirely absent `.statusChecks[]` key. Both cases now report a distinct `evidence_schema_mismatch: ...` reason naming exactly what is missing, with `nextAction` text that explicitly says this is not a policy or CI-state blocker. Decision stays `human_required` for `.policy` (unchanged for existing fixtures); present-but-empty `.statusChecks` keeps its original wording/decision (`blocked`).
- Fixed `.pr.mergeable` defaulting to `""` (from a `gh pr view --json` call that omitted the field) reading as a real "PR is not mergeable" verdict for a PR GitHub reports as `MERGEABLE`. Blank/whitespace-only is now treated exactly like an absent field (not blocked); a genuine non-mergeable state (e.g. `CONFLICTING`) still blocks.
- Updated `guardrails-enforcement.md`'s Gate 5 section to document the evidence schemas, the `--why-safe-file` flag, and both pitfalls.
- Added a `CHANGELOG.md` entry under `[Unreleased]` → `### Fixed`.

## Testing

New regression coverage in both test suites, verified to fail against the unfixed scripts before the fix (confirmed via `git stash`):

- `scripts/development-workflow/tests/test-run-epic-risk-classifier.sh` (86 passing): `--why-safe-file` on `--pr`/`--input`, override behavior, validation errors (non-object file, missing file, missing value).
- `scripts/development-workflow/tests/test-run-epic-delegated-gate.sh` (190 passing): schema-mismatch hybrid fixture (matches the issue's exact repro), `.policy` absent/non-object, `.statusChecks` entirely absent vs present-empty, `.pr.mergeable` blank/whitespace vs a real non-mergeable value.

Both suites are among the ~57 CI does not execute (#1537); the above local runs are the only verification for this PR.

```
docs lint: markdownlint-cli2 CHANGELOG.md -- 0 errors
docs lint: markdown-heuristic-lint.py CHANGELOG.md -- clean
docs lint: check-changelog-duplicate-headers.sh CHANGELOG.md -- passed
shell-snippet lint (workflow-shell-snippet-lint.py) -- clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--why-safe-file` support for risk classification in pull request and input-file modes.
  * Expanded help text and documentation for evidence formats, required fields, and validation outcomes.
* **Bug Fixes**
  * Malformed evidence now reports `evidence_schema_mismatch` and requires human review.
  * Blank mergeability values no longer incorrectly block merges, while genuine conflicts remain blocked.
  * Empty CI results retain their existing blocking behavior.
* **Tests**
  * Added regression coverage for evidence validation, mergeability handling, and evidence propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->