### PR TITLE
docs(spec): changelog fragments to end parallel-batch conflicts (#1554)

### DIFF
--- a/docs/specs/developments/20260821080421_1554-changelog-fragments/1_1554-changelog-fragments_specs.md
+++ b/docs/specs/developments/20260821080421_1554-changelog-fragments/1_1554-changelog-fragments_specs.md
@@ -1,0 +1,133 @@
+# Changelog Fragments — Spec
+
+---
+
+## Overview
+
+Today every work item records its release note in one shared block at the top of the changelog. When several items are worked in parallel, they all edit the same few lines, so each one collides with the ones merged before it. Resolving a collision is quick; what follows is not — the resolution changes the branch, and every approval that was granted against the previous version of that branch is discarded and has to be earned again.
+
+This feature gives each work item its own changelog file. Two items worked at the same time no longer touch the same place, so the collisions stop happening rather than being resolved more cleverly. At release time the individual files are gathered into the changelog as a draft section, which the person cutting the release edits before publishing, exactly as they do today.
+
+---
+
+## Use Cases
+
+### Use Case 1: Recording a release note while working an item
+
+**Actor**: Anyone completing a work item — a person or an AI agent
+**Preconditions**: The item has changes worth telling users about, and a work branch exists.
+
+**Steps**:
+
+1. The author writes their release note in a new file that belongs to their item alone.
+2. The author states which kind of change it is, using the same kinds the changelog already uses (Added, Changed, Deprecated, Removed, Fixed, Security).
+3. The author opens the pull request as usual.
+
+**Postconditions**: The item carries its own release note. No other in-flight item is affected by it.
+
+**Information shown**:
+
+- Readiness checks confirm the item carries a release note, without requiring the shared changelog to have been edited.
+
+**Actions available**:
+
+- Edit the note at any time before release, without affecting other items.
+- Omit the note deliberately for changes that need no release note, as is permitted today.
+
+**Considerations**:
+
+- Two items completed on the same day must never be able to claim the same file.
+- An author must not have to know what any other in-flight item is doing.
+
+---
+
+### Use Case 2: Cutting a release
+
+**Actor**: The person preparing a release
+**Preconditions**: One or more merged items carry release notes that have not yet been released.
+
+**Steps**:
+
+1. The releaser starts release preparation as they do today.
+2. Every unreleased note is gathered into a single draft section for the new version, grouped by kind of change.
+3. The releaser reads the draft as a whole and edits it — tightening wording, merging duplicates, cutting implementation detail — which is the same editorial pass performed today.
+4. The releaser publishes the release.
+
+**Postconditions**: The changelog contains a finished section for the new version. The individual notes that fed it are gone, so nothing can be released twice.
+
+**Information shown**:
+
+- The assembled draft, grouped by kind of change, with every unreleased note present.
+
+**Actions available**:
+
+- Edit any part of the draft before publishing.
+- Re-run the gathering step safely if the first attempt was interrupted.
+
+**Considerations**:
+
+- The releaser sees the whole release at once. This is the point of the step, and it is why gathering produces a draft rather than a finished section.
+- For one release only, notes may exist in both the old shared block and the new per-item files. Both must appear in the draft.
+
+---
+
+### Use Case 3: Shipping an urgent fix to production
+
+**Actor**: Anyone completing an urgent production fix
+**Preconditions**: A defect in released software needs to ship immediately, outside the normal release cycle.
+
+**Steps**:
+
+1. The author writes the release note directly into the changelog as a finished, versioned section, as they do today.
+
+**Postconditions**: The changelog carries the new version. Nothing about the urgent path changes.
+
+**Considerations**:
+
+- Urgent fixes release on merge, so there is no later gathering step for them to feed. Routing them through per-item files would add a step that never pays off.
+
+---
+
+## Business Rules
+
+- A work item's release note belongs to that item alone. No two in-flight items may need to edit the same content to record their notes.
+- Every release note carries one kind of change, drawn from the set the changelog already uses.
+- A release note is written once and survives unchanged until a release consumes it, unless its author edits it.
+- Gathering consumes notes: once a note has been released it cannot be gathered again, and no unreleased note may be silently left behind.
+- Gathering is repeatable. Running it twice in a row must leave the same result as running it once.
+- The changelog remains the permanent record of everything released. This feature changes only how notes accumulate before a release, never the released history.
+- Readiness checks that today confirm an item recorded a release note must accept a per-item note as satisfying that requirement.
+- Urgent production fixes keep writing finished versioned sections directly, and are never gathered.
+- For the single release that spans the transition, notes already recorded in the shared block are released alongside per-item notes, with nothing lost or duplicated.
+
+---
+
+## Operational Visibility
+
+- **Logs**: The gathering step reports how many notes it consumed and which items they came from, so a releaser can confirm nothing was missed.
+- **Audit trail**: Consumed notes are removed as part of the release, making "released" and "not yet released" visible from the repository state rather than inferred.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Two work items completed at the same time, both recording release notes, merge one after the other without either needing a conflict resolved, and both notes are present afterwards.
+- [ ] A pull request that records a release note the new way passes the readiness check that confirms a release note exists, without editing the shared changelog.
+- [ ] Preparing a release gathers every unreleased note into a draft section for the new version, grouped by kind of change, with no note missing.
+- [ ] The releaser can edit the assembled draft before publishing, and the published section reflects their edits.
+- [ ] After a release, no consumed note remains, and running the gathering step again produces no duplicate entries.
+- [ ] A release cut during the transition includes both the notes already in the shared block and the per-item notes, each appearing exactly once.
+- [ ] An urgent production fix still writes its own finished versioned section and is unaffected by gathering.
+- [ ] A project created from this template records release notes the new way without additional setup.
+- [ ] The changelog's existing published history is unchanged by adopting this feature.
+
+---
+
+## Out of Scope (MVP)
+
+- Converting the release notes already sitting in the shared block into per-item files. They stay where they are and are released from there once.
+- Any change to how urgent production fixes are recorded.
+- Automatic generation of release notes from commits, pull request titles, or issue text. Notes stay author-written.
+- Changing which kinds of change the changelog recognises, or the format of published version sections.
+- A migration tool for projects already created from this template that want to convert existing shared-block entries.
+- Enforcing a quality bar on individual notes at the time they are written. The release editorial pass remains where quality is set.

--- a/docs/specs/developments/20260821080421_1554-changelog-fragments/1_1554-changelog-fragments_specs.md
+++ b/docs/specs/developments/20260821080421_1554-changelog-fragments/1_1554-changelog-fragments_specs.md
@@ -53,7 +53,7 @@ This feature gives each work item its own changelog file. Two items worked at th
 3. The releaser reads the draft as a whole and edits it — tightening wording, merging duplicates, cutting implementation detail — which is the same editorial pass performed today.
 4. The releaser publishes the release.
 
-**Postconditions**: The changelog contains a finished section for the new version. The individual notes that fed it are gone, so nothing can be released twice.
+**Postconditions**: The changelog contains a finished section for the new version. The notes that fed it are consumed, so nothing can be released twice. The changelog is left ready to accumulate the next release's notes, and its version links continue to work.
 
 **Information shown**:
 
@@ -62,11 +62,13 @@ This feature gives each work item its own changelog file. Two items worked at th
 **Actions available**:
 
 - Edit any part of the draft before publishing.
-- Re-run the gathering step safely if the first attempt was interrupted.
+- Resume an interrupted release preparation without losing notes or prior edits.
 
 **Considerations**:
 
 - The releaser sees the whole release at once. This is the point of the step, and it is why gathering produces a draft rather than a finished section.
+- Notes are consumed when the release is **published**, not when the draft is assembled. Until publication succeeds, every note still exists — so an interrupted preparation loses nothing.
+- A note recorded after the draft was assembled belongs to the **next** release, not the one being prepared. Otherwise a note could be silently swept into a release nobody reviewed it for.
 - For one release only, notes may exist in both the old shared block and the new per-item files. Both must appear in the draft.
 
 ---
@@ -93,8 +95,11 @@ This feature gives each work item its own changelog file. Two items worked at th
 - A work item's release note belongs to that item alone. No two in-flight items may need to edit the same content to record their notes.
 - Every release note carries one kind of change, drawn from the set the changelog already uses.
 - A release note is written once and survives unchanged until a release consumes it, unless its author edits it.
-- Gathering consumes notes: once a note has been released it cannot be gathered again, and no unreleased note may be silently left behind.
+- A note is consumed only when the release that contains it is published. Assembling a draft never destroys anything, so an interrupted release preparation loses neither notes nor the releaser's edits.
+- Once a note has been released it cannot be gathered again, and no unreleased note may be silently left behind.
+- The set of notes in a release is fixed when its draft is assembled. A note recorded afterward belongs to the next release, never retroactively to the one being prepared.
 - Gathering is repeatable. Running it twice in a row must leave the same result as running it once.
+- Publishing a release leaves the changelog ready to accumulate the next release's notes, and every version link in it continues to resolve.
 - The changelog remains the permanent record of everything released. This feature changes only how notes accumulate before a release, never the released history.
 - Readiness checks that today confirm an item recorded a release note must accept a per-item note as satisfying that requirement.
 - Urgent production fixes keep writing finished versioned sections directly, and are never gathered.
@@ -104,18 +109,22 @@ This feature gives each work item its own changelog file. Two items worked at th
 
 ## Operational Visibility
 
-- **Logs**: The gathering step reports how many notes it consumed and which items they came from, so a releaser can confirm nothing was missed.
+- **Logs**: The gathering step reports how many notes it gathered and which items they came from, so a releaser can confirm nothing was missed. Notes carried over from the old shared block have no owning item, and are reported as a single group rather than attributed individually.
 - **Audit trail**: Consumed notes are removed as part of the release, making "released" and "not yet released" visible from the repository state rather than inferred.
 
 ---
 
 ## Acceptance Criteria
 
-- [ ] Two work items completed at the same time, both recording release notes, merge one after the other without either needing a conflict resolved, and both notes are present afterwards.
+- [ ] Two work items completed at the same time, both recording release notes, merge one after the other without either needing a conflict resolved, and both notes are present afterward.
 - [ ] A pull request that records a release note the new way passes the readiness check that confirms a release note exists, without editing the shared changelog.
 - [ ] Preparing a release gathers every unreleased note into a draft section for the new version, grouped by kind of change, with no note missing.
 - [ ] The releaser can edit the assembled draft before publishing, and the published section reflects their edits.
+- [ ] A release preparation interrupted after the draft is assembled can be resumed with no note lost and the releaser's edits intact.
+- [ ] A note recorded after a draft is assembled does not appear in that release, and is still available for the next one.
 - [ ] After a release, no consumed note remains, and running the gathering step again produces no duplicate entries.
+- [ ] After publishing, the changelog is ready to accumulate the next release's notes, and every version link in it resolves to the right comparison.
+- [ ] The published version section is well-formed changelog content that passes the repository's existing document checks.
 - [ ] A release cut during the transition includes both the notes already in the shared block and the per-item notes, each appearing exactly once.
 - [ ] An urgent production fix still writes its own finished versioned section and is unaffected by gathering.
 - [ ] A project created from this template records release notes the new way without additional setup.


### PR DESCRIPTION
Closes #1554

## Why

Every work item currently adds its release note to the same `[Unreleased]` block, so a parallel batch produces **N−1 conflicts by construction**. The conflict is cheap; what it drags behind it is not — resolution changes the head SHA, which invalidates the reviewer verdict, CI, **and** both Gate 5 decisions, all of which must then be re-earned.

Measured across the 2026-08-20/21 unattended run (14 items, 5 waves): every multi-item wave hit it. PR #1534's merge dirtied #1535; PRs #1544 and #1547 dirtied #1546 **and** #1543 simultaneously; #1552's merge dirtied #1553. Two of those additionally required the parent to notify the runner, because a runner has no way to learn its PR was invalidated from outside — both would otherwise have declared terminal on an unmergeable PR.

Rework grows quadratically while the benefit of parallelism grows linearly, which caps useful wave width well below what the isolation machinery supports.

## Alignment decisions

Three product questions were open; all were settled with the repository owner and are reflected in the spec:

| Question | Decision |
| --- | --- |
| Where does the release editorial pass live? | **Gathering produces a draft**, and Protocol 05's polish pass continues as today. Mechanical concatenation would quietly delete the step that makes releases readable. |
| The 36 entries already in `[Unreleased]`? | **Not migrated.** Released from where they are, once. The spec requires the transition release to carry both sources, each entry exactly once. |
| Downstream propagation? | **Default for projects created from this template.** |

## Scope boundary

Per Protocol 01's product-first rule, the spec deliberately contains no technical design. Fragment file naming, how the change-category is carried, the assembly mechanism, and which of the ten affected consumers change how — all deferred to the implementation plan.

## Document Quality Gate

- **Brief coverage**: Checked — see the objective matrix below.
- **Internal consistency**: Checked — terminology is consistent throughout ("release note", "gathering", "kind of change", "draft"); no synonym drift; no code identifiers in the spec body.
- **Behavioral guarantees**: Checked — idempotent gathering, no orphaned notes, and unchanged published history are each stated as a business rule *and* carry a matching acceptance criterion.
- **Complex workflow decision-gate matrix**: Not applicable — this spec introduces no decision-gate branching or new outcomes; gathering has a single path, and the hotfix path is explicitly unchanged.
- **Reviewer-risk categories**: Checked — the risk here is data loss at the transition release (covered by BR9/AC-6), double-release of a consumed note (BR5/AC-5), and silent orphaning (BR4/AC-3). No API surface, concurrency, or snapshot semantics are introduced.

### Brief objective coverage matrix

| #1554 objective | Where it lands in the spec |
| --- | --- |
| AC-1 — two same-wave items merge with no conflict, demonstrated end to end | Use Case 1; spec AC-1 (stated as a demonstration, not an assertion) |
| AC-2 — release assembles fragments; Step-249 editorial pass survives | Use Case 2 steps 2–3; spec AC-3 and AC-4. Link-reference mechanics omitted as technical. |
| AC-3 — every consumer updated; fragment satisfies the readiness check | Readiness half → spec AC-2. **Consumer list deferred to plan** — updating ten named scripts and workflows is implementation completeness, not a product guarantee. |
| AC-4 — fragments consumed on release; assembly idempotent | Business rules "Gathering consumes notes" and "Gathering is repeatable"; spec AC-5 |
| AC-5 — the 36 existing entries handled with nothing lost | Business rule on the transition release; spec AC-6; Out of Scope (they are not migrated) |
| AC-6 — hotfix behavior unchanged, with a regression test | Use Case 3; business rule 8; spec AC-7. **Regression test deferred** — a test instruction is test-stage, not spec content. |
| AC-7 — lints pass on fragments and assembled output | **Deferred to plan** — a specific instance of AC-3's consumer updates (two of the ten are the changelog lints), not a separate product-level guarantee. |

## Step 7a — Internal review gate

Verdict: **Approved**, no blocking findings, no commits required.

The reviewer independently rebuilt the objective matrix above and confirmed the deferral reasoning for AC-3, AC-6 and AC-7. It also checked the product-first boundary in both directions — no leaked technical identifiers, and no requirement abstracted into untestability — and confirmed the transition-release rule is phrased time-independently, so it holds even if a late in-flight PR lands an old-style entry before the transition release is cut.

Its one important finding was against this PR description, not the spec: the previous Document Quality Gate log used narrative assertions where `REVIEW.md:88` requires a visible matrix, and substituted three rows of its own for two the Protocol 01 template requires. Both are corrected above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a specification for managing release notes as individual, typed changelog fragments.
  - Documented how unreleased notes are collected into an editable, grouped release draft.
  - Defined safe, repeatable consumption of published notes without duplication.
  - Preserved support for direct versioned entries for urgent fixes.
  - Documented migration from the shared changelog format, operational visibility, acceptance criteria, and MVP exclusions.
  - Clarified the workflow for preparing and publishing release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->