### PR TITLE
fix(risk-classifier): score test CI workflows below deployment (#1565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,14 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PR to `high`, so a PR that wires a test suite into CI exceeded a `medium`
   ceiling and could not merge under delegated policy — the risk model penalised
   closing a test-coverage gap, which is what #1537 asked for. Recognised test
-  and lint workflows (`test-*.yml`, `*-tests.yml`, `*lint*.yml`,
-  `shellcheck.yml`) now score `medium` with a distinct
+  and lint workflows now score `medium` with a distinct
   `test or lint CI workflow change:` reason; deployment, release, and permission
-  behavior still score `high`. The classifier only ever receives changed paths,
-  never file contents, so this is judged by filename — deliberately an allowlist
-  that yields to a deny-list (`deploy`, `release`, `publish`, `tag`, `secret`,
-  `credential`, `permission`, `policy`, `token`), leaving an unrecognised
-  workflow at `high`.
+  behavior still score `high`, as does any unrecognised workflow. The classifier
+  only ever receives changed paths, never file contents, so this is judged by
+  filename — see the authoritative pattern table under "Known Heuristic Limits"
+  in
+  [guardrails-enforcement.md](docs/workflow/development-workflow/guardrails-enforcement.md).
 - **Every test suite is now reachable from CI, so a green check rollup means
   the changed script's own tests ran** (#1537): CI ran a hard-coded list of six
   suites behind a path filter, leaving 59 of 65 suites never executed by any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **Adding a test job to a CI workflow no longer scores the same risk as
+  changing deployment behavior** (#1565): `run-epic-risk-classifier.sh` treated
+  every `.github/workflows/**` change as a sensitive category and escalated the
+  PR to `high`, so a PR that wires a test suite into CI exceeded a `medium`
+  ceiling and could not merge under delegated policy — the risk model penalised
+  closing a test-coverage gap, which is what #1537 asked for. Recognised test
+  and lint workflows (`test-*.yml`, `*-tests.yml`, `*lint*.yml`,
+  `shellcheck.yml`) now score `medium` with a distinct
+  `test or lint CI workflow change:` reason; deployment, release, and permission
+  behavior still score `high`. The classifier only ever receives changed paths,
+  never file contents, so this is judged by filename — deliberately an allowlist
+  that yields to a deny-list (`deploy`, `release`, `publish`, `tag`, `secret`,
+  `credential`, `permission`, `policy`, `token`), leaving an unrecognised
+  workflow at `high`.
 - **Every test suite is now reachable from CI, so a green check rollup means
   the changed script's own tests ran** (#1537): CI ran a hard-coded list of six
   suites behind a path filter, leaving 59 of 65 suites never executed by any

--- a/docs/workflow/development-workflow/guardrails-enforcement.md
+++ b/docs/workflow/development-workflow/guardrails-enforcement.md
@@ -441,11 +441,22 @@ mode worth recognising rather than rediscovering.
 
 `run-epic-risk-classifier.sh` is handed a list of changed paths and never the
 file contents, so it cannot inspect what a workflow actually does. It therefore
-scores `.github/workflows/**` by filename: recognised test and lint workflows
-(`test-*.yml`, `*-tests.yml`, `*lint*.yml`, `shellcheck.yml`) score `medium`,
-and everything else — including any name containing `deploy`, `release`,
-`publish`, `tag`, `secret`, `credential`, `permission`, `policy`, or `token` —
-scores `high`.
+scores `.github/workflows/**` by filename.
+
+This table is the authoritative rule; it is matched against the **basename**,
+and the deny-list is checked first.
+
+| Order | Rule | Patterns | Risk |
+| ----- | ---- | -------- | ---- |
+| 1 | Deny-list (checked first, wins over any allowlist match) | basename containing `deploy`, `release`, `publish`, `tag`, `secret`, `credential`, `permission`, `policy`, or `token` | `high` |
+| 2 | Test workflows | `test-*.yml`, `test-*.yaml`, `*-test.yml`, `*-test.yaml`, `*-tests.yml`, `*-tests.yaml` | `medium` |
+| 3 | Lint workflows | `*lint*.yml`, `*lint*.yaml`, `shellcheck.yml`, `shellcheck.yaml` | `medium` |
+| 4 | Anything else under `.github/workflows/**` | — | `high` |
+
+So `workflow-tests.yml` and `markdown-lint.yml` are `medium`, while
+`deploy.yml`, `auto-tag-release.yml`, `pr-policy.yml`, and `e2e-regression.yml`
+are `high`. A name matching both lists (`test-release.yml`) is `high`: rule 1
+wins.
 
 This is deliberately an allowlist that yields to that deny-list: an
 unrecognised workflow stays `high`. Before issue #1565 every workflow change

--- a/docs/workflow/development-workflow/guardrails-enforcement.md
+++ b/docs/workflow/development-workflow/guardrails-enforcement.md
@@ -429,3 +429,49 @@ only — they do not by themselves grant merge authority.
 
 **When a parent/epic does not exist**: the work-item ledger record is not
 applicable. Record "not applicable — no parent/epic exists" for that field.
+
+---
+
+## 7. Known Heuristic Limits
+
+Two of the signals used above are keyword- or path-driven. Both have a failure
+mode worth recognising rather than rediscovering.
+
+### CI workflow risk is judged by filename
+
+`run-epic-risk-classifier.sh` is handed a list of changed paths and never the
+file contents, so it cannot inspect what a workflow actually does. It therefore
+scores `.github/workflows/**` by filename: recognised test and lint workflows
+(`test-*.yml`, `*-tests.yml`, `*lint*.yml`, `shellcheck.yml`) score `medium`,
+and everything else — including any name containing `deploy`, `release`,
+`publish`, `tag`, `secret`, `credential`, `permission`, `policy`, or `token` —
+scores `high`.
+
+This is deliberately an allowlist that yields to that deny-list: an
+unrecognised workflow stays `high`. Before issue #1565 every workflow change
+scored `high`, which meant a PR that wired a test suite into CI exceeded a
+`medium` ceiling and could not merge under delegated policy — the risk model
+penalised closing a test-coverage gap.
+
+**Consequence for authors**: name a new test or lint workflow conventionally,
+or expect it to be classified `high` and to need explicit human merge
+authorization. That is the intended trade — misjudging a deployment workflow as
+a test job is far worse than making someone rename a file.
+
+### A bug report about a heuristic will trip that heuristic
+
+A bug report has to name its trigger in order to explain it, so any
+keyword-driven gate in this framework mishandles its own bug reports. Observed
+twice on one run:
+
+- The policy recommender flagged the issue reporting that its keyword test
+  over-matches, because the body quotes the keyword list.
+- The overlap classifier serialized the issue reporting that it over-serializes,
+  because the brief necessarily contains the triggering vocabulary.
+
+This is a property of keyword matching, not a defect in those specific lists,
+and it bites exactly when correct handling matters most. **Operators should
+expect it** and treat a heuristic's verdict on an item filed *against* that
+heuristic as uninformative — re-read the item and decide directly rather than
+deferring to the signal. Do not "fix" it by broadening the keyword list, which
+makes over-matching worse everywhere else.

--- a/scripts/development-workflow/run-epic-risk-classifier.sh
+++ b/scripts/development-workflow/run-epic-risk-classifier.sh
@@ -332,6 +332,8 @@ base64_decode() {
 # unrecognised workflow stays `high`. Misjudging a deployment workflow as a
 # test job is far worse than making someone name a test workflow conventionally.
 ci_workflow_is_test_or_lint() {
+  [ "$#" -eq 1 ] && [ -n "${1:-}" ] \
+    || error_exit "ci_workflow_is_test_or_lint requires exactly one workflow path"
   local base="${1##*/}"
 
   # Deny-list wins. A name claiming both ("test-release.yml") is not a test job

--- a/scripts/development-workflow/run-epic-risk-classifier.sh
+++ b/scripts/development-workflow/run-epic-risk-classifier.sh
@@ -316,6 +316,43 @@ base64_decode() {
   fi
 }
 
+# ci_workflow_is_test_or_lint <path> — true when a .github/workflows file only
+# carries a test or lint job, judged by filename.
+#
+# Issue #1565: every .github/workflows change scored `high`, so a PR that wires
+# a test suite into CI exceeded a medium ceiling and could not be merged under
+# delegated policy — the risk model penalised closing a test-coverage gap.
+# Adding a test or lint job is close to the safest workflow edit there is;
+# changing deployment, release, or permission behavior is not.
+#
+# Filename is the only signal available: the classifier is handed a list of
+# changed paths (--input carries `changed_files` and nothing else), never file
+# contents, so it cannot inspect what a workflow actually does. That makes this
+# deliberately an allowlist, and one that yields to the deny-list below — an
+# unrecognised workflow stays `high`. Misjudging a deployment workflow as a
+# test job is far worse than making someone name a test workflow conventionally.
+ci_workflow_is_test_or_lint() {
+  local base="${1##*/}"
+
+  # Deny-list wins. A name claiming both ("test-release.yml") is not a test job
+  # for this purpose.
+  case "$base" in
+    *deploy*|*release*|*publish*|*tag*|*secret*|*credential*|*permission*|*policy*|*token*)
+      return 1
+      ;;
+  esac
+
+  case "$base" in
+    test-*.yml|test-*.yaml|\
+    *-test.yml|*-test.yaml|*-tests.yml|*-tests.yaml|\
+    *lint*.yml|*lint*.yaml|\
+    shellcheck.yml|shellcheck.yaml)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 changed_file_risk() {
   local state_json="$1"
   local risk="low"
@@ -325,7 +362,20 @@ changed_file_risk() {
   while IFS= read -r file; do
     [ -n "$file" ] || continue
     case "$file" in
-      .github/workflows/*|*release*|*branch-deletion*|*delete-branch*|\
+      .github/workflows/*)
+        # Split before the sensitive category below, which would otherwise
+        # collapse every workflow edit into `high` (issue #1565).
+        if ci_workflow_is_test_or_lint "$file"; then
+          if [ "$risk" != "high" ]; then
+            risk="medium"
+          fi
+          reasons="$(append_json_array_string "$reasons" "test or lint CI workflow change: ${file}")"
+        else
+          risk="high"
+          reasons="$(append_json_array_string "$reasons" "sensitive or broad file category: ${file}")"
+        fi
+        ;;
+      *release*|*branch-deletion*|*delete-branch*|\
       auth/*|*/auth/*|*/auth|\
       authentication/*|*/authentication/*|*/authentication|\
       secret/*|*/secret/*|*/secret|\

--- a/scripts/development-workflow/tests/test-run-epic-risk-classifier.sh
+++ b/scripts/development-workflow/tests/test-run-epic-risk-classifier.sh
@@ -356,6 +356,89 @@ medium_missing_output="$(classify_fixture "$medium_missing_fixture" medium)"
 run_test "blocks_medium_without_evidence" "blocked" "$(printf '%s\n' "$medium_missing_output" | jq -r '.risk')"
 run_test "missing_evidence_blocks_merge" "false" "$(printf '%s\n' "$medium_missing_output" | jq -r '.merge_permitted')"
 
+# ---------------------------------------------------------------------------
+# CI workflow granularity (issue #1565)
+#
+# Every .github/workflows change used to score `high`, so a PR that wires a
+# test suite into CI exceeded a medium ceiling and could not merge under
+# delegated policy — the risk model penalised closing a test-coverage gap.
+# Adding a test or lint job now scores medium; deployment, release, and
+# permission behavior still score high.
+# ---------------------------------------------------------------------------
+
+# ci_workflow_fixture <name> <changed-files-json> — a clean PR differing only
+# in which files it touches, with why_safe_to_merge evidence supplied so the
+# result reflects file risk rather than the separate evidence blocker.
+ci_workflow_fixture() {
+  write_fixture "$1" '{
+  "pr_number": 30,
+  "merge_state": "CLEAN",
+  "labels": ["ready-for-human-review"],
+  "status_checks": [{"name": "guard", "status": "COMPLETED", "conclusion": "SUCCESS"}],
+  "changed_files": '"$2"',
+  "reviewer": {"status": "clean", "blocking_count": 0, "unresolved_blocking_threads": 0},
+  "why_safe_to_merge": {
+    "scope": "ci workflow classification fixture",
+    "tests": "fixture tests cover risk classes",
+    "reviewer_outcome": "reviewer loop clean",
+    "ci_outcome": "CI green",
+    "rollback_or_cleanup_risk": "revert the workflow file"
+  }
+}'
+}
+
+ci_workflow_risk() {
+  classify_fixture "$(ci_workflow_fixture "$1" "$2")" medium | jq -r '.risk'
+}
+
+ci_workflow_merge() {
+  classify_fixture "$(ci_workflow_fixture "$1" "$2")" medium | jq -r '.merge_permitted'
+}
+
+# AC-1 / AC-2: the diff shape from PR #1536 — a test workflow plus the workflow
+# script it covers — must fit inside a medium ceiling.
+run_test "ci_test_workflow_is_medium" "medium" \
+  "$(ci_workflow_risk wf-test '[".github/workflows/workflow-tests.yml","scripts/development-workflow/batch-merge.sh"]')"
+
+run_test "ci_test_workflow_alone_is_medium" "medium" \
+  "$(ci_workflow_risk wf-test-alone '[".github/workflows/test-pr-review-loop.yml"]')"
+run_test "ci_test_workflow_merge_permitted" "true" \
+  "$(ci_workflow_merge wf-test-merge '[".github/workflows/test-pr-review-loop.yml"]')"
+run_test "ci_lint_workflow_is_medium" "medium" \
+  "$(ci_workflow_risk wf-lint '[".github/workflows/markdown-lint.yml"]')"
+run_test "ci_shellcheck_workflow_is_medium" "medium" \
+  "$(ci_workflow_risk wf-shellcheck '[".github/workflows/shellcheck.yml"]')"
+
+# AC-3: deployment, release, and permission behavior stay high.
+run_test "ci_deploy_workflow_is_high" "high" \
+  "$(ci_workflow_risk wf-deploy '[".github/workflows/deploy.yml"]')"
+run_test "ci_deploy_workflow_blocked_at_medium" "false" \
+  "$(ci_workflow_merge wf-deploy-merge '[".github/workflows/deploy.yml"]')"
+run_test "ci_release_workflow_is_high" "high" \
+  "$(ci_workflow_risk wf-release '[".github/workflows/auto-tag-release.yml"]')"
+run_test "ci_policy_workflow_is_high" "high" \
+  "$(ci_workflow_risk wf-policy '[".github/workflows/pr-policy.yml"]')"
+
+# An unrecognised workflow name is not assumed safe.
+run_test "ci_unknown_workflow_is_high" "high" \
+  "$(ci_workflow_risk wf-unknown '[".github/workflows/e2e-regression.yml"]')"
+
+# The deny-list beats the allowlist: a name claiming both is not a test job.
+run_test "ci_test_named_release_workflow_is_high" "high" \
+  "$(ci_workflow_risk wf-test-release '[".github/workflows/test-release.yml"]')"
+
+# A test workflow alongside a genuinely sensitive path stays high.
+run_test "ci_test_workflow_with_auth_path_is_high" "high" \
+  "$(ci_workflow_risk wf-test-auth '[".github/workflows/workflow-tests.yml","auth/token.sh"]')"
+
+# The reason string distinguishes the two categories rather than reusing one.
+run_test "ci_test_workflow_reason_is_specific" "yes" \
+  "$(classify_fixture "$(ci_workflow_fixture wf-reason '[".github/workflows/test-pr-review-loop.yml"]')" medium \
+     | jq -e '.reasons | any(startswith("test or lint CI workflow change:"))' >/dev/null && echo yes || echo no)"
+run_test "ci_deploy_workflow_reason_is_sensitive" "yes" \
+  "$(classify_fixture "$(ci_workflow_fixture wf-reason-deploy '[".github/workflows/deploy.yml"]')" medium \
+     | jq -e '.reasons | any(startswith("sensitive or broad file category:"))' >/dev/null && echo yes || echo no)"
+
 high_fixture="$(write_fixture high '{
   "pr_number": 4,
   "merge_state": "CLEAN",

--- a/scripts/development-workflow/tests/test-run-epic-risk-classifier.sh
+++ b/scripts/development-workflow/tests/test-run-epic-risk-classifier.sh
@@ -370,6 +370,10 @@ run_test "missing_evidence_blocks_merge" "false" "$(printf '%s\n' "$medium_missi
 # in which files it touches, with why_safe_to_merge evidence supplied so the
 # result reflects file risk rather than the separate evidence blocker.
 ci_workflow_fixture() {
+  if [ "$#" -ne 2 ] || [ -z "${1:-}" ] || [ -z "${2:-}" ]; then
+    printf 'ERROR: ci_workflow_fixture requires <name> <changed-files-json>\n' >&2
+    exit 2
+  fi
   write_fixture "$1" '{
   "pr_number": 30,
   "merge_state": "CLEAN",
@@ -388,10 +392,12 @@ ci_workflow_fixture() {
 }
 
 ci_workflow_risk() {
+  [ "$#" -eq 2 ] || { printf 'ERROR: ci_workflow_risk requires <name> <changed-files-json>\n' >&2; exit 2; }
   classify_fixture "$(ci_workflow_fixture "$1" "$2")" medium | jq -r '.risk'
 }
 
 ci_workflow_merge() {
+  [ "$#" -eq 2 ] || { printf 'ERROR: ci_workflow_merge requires <name> <changed-files-json>\n' >&2; exit 2; }
   classify_fixture "$(ci_workflow_fixture "$1" "$2")" medium | jq -r '.merge_permitted'
 }
 
@@ -418,6 +424,18 @@ run_test "ci_release_workflow_is_high" "high" \
   "$(ci_workflow_risk wf-release '[".github/workflows/auto-tag-release.yml"]')"
 run_test "ci_policy_workflow_is_high" "high" \
   "$(ci_workflow_risk wf-policy '[".github/workflows/pr-policy.yml"]')"
+run_test "ci_permissions_workflow_is_high" "high" \
+  "$(ci_workflow_risk wf-permissions '[".github/workflows/permissions.yml"]')"
+run_test "ci_permission_workflow_is_high" "high" \
+  "$(ci_workflow_risk wf-permission '[".github/workflows/permission-sync.yml"]')"
+run_test "ci_token_workflow_is_high" "high" \
+  "$(ci_workflow_risk wf-token '[".github/workflows/token-refresh.yml"]')"
+
+# .yaml variants of the allowlist are accepted too.
+run_test "ci_test_workflow_yaml_ext_is_medium" "medium" \
+  "$(ci_workflow_risk wf-yaml '[".github/workflows/test-thing.yaml"]')"
+run_test "ci_singular_test_suffix_is_medium" "medium" \
+  "$(ci_workflow_risk wf-singular '[".github/workflows/smoke-test.yml"]')"
 
 # An unrecognised workflow name is not assumed safe.
 run_test "ci_unknown_workflow_is_high" "high" \


### PR DESCRIPTION
Closes #1565.

## What changed

`run-epic-risk-classifier.sh` treated every `.github/workflows/**` change as a sensitive category and escalated the PR to `high`. So a PR that wires a test suite into CI exceeded a `medium` ceiling and couldn't merge under delegated policy — **the risk model penalised closing a test-coverage gap**, which is exactly what #1537 asked for.

This wasn't hypothetical twice over: PR #1536, and then PR #1568 implementing #1537, which needed explicit owner authorization to merge for this reason alone.

Recognised test and lint workflows now score `medium` with their own reason string; deployment, release, and permission behavior still score `high`.

## Why filename, not content

The classifier is handed a list of changed **paths** and never file contents — `--input` carries `changed_files` and nothing else — so it cannot inspect what a workflow actually does.

That makes this deliberately an **allowlist that yields to a deny-list**:

- Allowed to `medium`: `test-*.yml`, `*-test(s).yml`, `*lint*.yml`, `shellcheck.yml`
- Forced to `high` regardless: any name containing `deploy`, `release`, `publish`, `tag`, `secret`, `credential`, `permission`, `policy`, `token`
- Anything unrecognised: stays `high`

Misjudging a deployment workflow as a test job is far worse than making someone name a test workflow conventionally. That trade is now documented for authors in `guardrails-enforcement.md`.

## Acceptance criteria

| AC | Result |
| -- | ------ |
| **AC-1** test/lint below deployment/release/permission | `medium` vs `high` |
| **AC-2** PR #1536's diff shape fits a `medium` ceiling | `medium`, `merge_permitted=true` |
| **AC-3** deployment change still `high` | `deploy.yml`, `auto-tag-release.yml` → `high` |
| **AC-4** self-describing-report interaction | Documented — see below |

Verified across the boundary cases:

| Change set | Risk |
| ---------- | ---- |
| `workflow-tests.yml` + `batch-merge.sh` + a test (the #1536/#1568 shape) | `medium` ✅ |
| `test-pr-review-loop.yml` alone | `medium` |
| `markdown-lint.yml`, `shellcheck.yml` | `medium` |
| `deploy.yml`, `auto-tag-release.yml`, `pr-policy.yml` | `high` |
| `e2e-regression.yml` (unrecognised) | `high` |
| `test-release.yml` (deny-list beats allowlist) | `high` |
| `workflow-tests.yml` + `auth/token.sh` | `high` |

## AC-4: documented, not guarded

A bug report must name its trigger to explain it, so **any keyword-driven gate in this framework mishandles its own bug reports** — which is precisely when correct handling matters most. You observed it twice on one run (the policy recommender on #1504, the overlap classifier on #1540).

I documented it as a known heuristic limit rather than building a guard, because a guard would need to know an item was filed *against* the heuristic it's about to run — that determination is the same keyword problem one level up. The guidance is to treat such a verdict as uninformative and read the item directly, and explicitly **not** to broaden the keyword list, which makes over-matching worse everywhere else.

If you'd rather have a mechanical guard (e.g. an opt-out label on the item), say so and I'll add it — I judged documentation the better trade, but it is a judgment call.

## Verification

- `test-run-epic-risk-classifier.sh`: **100 assertions passing**, 14 new
- ShellCheck clean; markdownlint, heuristic lint, CHANGELOG checks, snippet lint all clean
- **First real use of change-scoped CI** (merged in #1568): this change set selects **2 suites, not 66** — `test-run-epic-risk-classifier.sh` by naming convention and `test-may-merge-terminal-contract.sh` via its `# covers:` header on `guardrails-enforcement.md`. Both pass.

## Note on merging

Under its own new rule this PR is `medium` — it touches no workflow file at all, only the classifier and its tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow risk classification: test and lint workflow changes now receive medium risk.
  * Deployment, release, publishing, security, permission, policy, and authentication-related workflow changes remain high risk.
  * Risk explanations now clearly reflect changed file paths and classification rules.

* **Documentation**
  * Documented filename-based classification limits and potential keyword-related false positives.

* **Tests**
  * Added coverage for workflow risk levels, merge thresholds, sensitive changes, and classification precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->