### PR TITLE
fix(tests): area filter, snapshots, and a truncation guard (#1562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+
 - **`test-pr-review-loop.sh` gains an `--area` filter, runs from an immutable
   snapshot, and can no longer be edited mid-run without notice** (#1562): the
   suite is ~13.6k lines and ~900 assertions with no way to run part of it, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **`test-pr-review-loop.sh` gains an `--area` filter, runs from an immutable
+  snapshot, and can no longer be edited mid-run without notice** (#1562): the
+  suite is ~13.6k lines and ~900 assertions with no way to run part of it, so
+  every reviewer fix cycle paid the whole thing. Measured on a clean tree, the
+  runtime is extremely lopsided — **Area 13 is ~94% of it** (156
+  `codex-github-reviewer.sh` invocations that each really sleep), while the
+  other 27 areas together take about 13 seconds. `--area <name>` matches an
+  area number exactly or any substring of its title, `--list-areas` prints
+  them, and a filtered run still prints the summary and still exits non-zero on
+  failure. Separately, bash reads a script incrementally, so editing the suite
+  while a run was in flight made the running shell pick up part of the new
+  text; during the #1531 work that produced a run whose pass/fail counts
+  matched neither version of the file. The harness now re-executes from a temp
+  snapshot, which also makes an out-of-tree copy work via
+  `TEST_PR_REVIEW_LOOP_ORIGIN` rather than failing with "fatal: not a git
+  repository".
+- **A truncated `pr-review-loop.sh` run can no longer be mistaken for a clean
+  one** (#1562): a run killed part-way — by an outer `timeout` shorter than a
+  legitimate rate-limit wait, or by an operator — produced no terminal
+  `RESULT=` line at all, so a caller grepping for one found nothing, and "no
+  blocking findings were reported" reads uncomfortably like "no blocking
+  findings exist". Every exit now carries a verdict: `print_kv` records that a
+  `RESULT` was emitted, and the `EXIT` trap emits `RESULT=escalate` /
+  `REASON=truncated_run` / `TRUNCATED=1` when none ever was, forcing a non-zero
+  status. Verified end to end by killing a live run: exit 143 with the
+  truncated verdict present.
+- **The CodeRabbit rate-limit ceiling is reconciled with an execution budget**
+  (#1562): the worst-case legitimate wait (4 x 900s = 3600s) sat within minutes
+  of the ~65-minute point at which a run was observed being killed, and two
+  runners had wrapped the loop in an outer `timeout` shorter than a single
+  900s wait. `PR_REVIEW_LOOP_EXECUTION_BUDGET` (default 5400s) now declares the
+  wall clock a caller must allow, and startup fails with
+  `REASON=execution_budget_misconfigured` when the worst-case wait is not
+  strictly less than it — a second of setup instead of an hour of waiting
+  followed by nothing. The two rate-limit defaults were restated in two places
+  once the budget check needed them; they are now declared once.
 - **Adding a test job to a CI workflow no longer scores the same risk as
   changing deployment behavior** (#1565): `run-epic-risk-classifier.sh` treated
   every `.github/workflows/**` change as a sensitive category and escalated the

--- a/scripts/development-workflow/README.md
+++ b/scripts/development-workflow/README.md
@@ -31,6 +31,34 @@ Note that the full harness is heavily lopsided: `test-pr-review-loop.sh` alone
 is roughly half the total wall clock (~13 minutes of ~27), while the median
 suite finishes in a few seconds.
 
+### Iterating on `test-pr-review-loop.sh`
+
+That suite is ~13.6k lines and ~900 assertions, and its runtime is extremely
+lopsided (issue #1562): **Area 13 is ~94% of it** — 156 `codex-github-reviewer.sh`
+invocations that each really sleep — while the other 27 areas together take
+about 13 seconds. Use `--area` when you are not working on Area 13:
+
+<!-- workflow-shell-contract: bash-zsh -->
+
+```bash
+# What areas are there?
+bash scripts/development-workflow/tests/test-pr-review-loop.sh --list-areas
+
+# Run one area (matches an area number exactly, or any substring of its title)
+bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 1
+bash scripts/development-workflow/tests/test-pr-review-loop.sh --area haystack
+bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 0a --area 12b
+```
+
+A filtered run still prints the summary and still exits non-zero if anything in
+the selected areas failed.
+
+The suite re-executes itself from a temp-file snapshot. Bash reads a script
+incrementally, so editing this file mid-run used to make the running shell pick
+up part of the new text — during the #1531 work that produced a run whose
+pass/fail counts matched neither version of the file, with nothing to indicate
+it. You can now edit it freely while a run is in flight.
+
 ### How CI decides which suites to run
 
 `.github/workflows/workflow-tests.yml` does not contain a list of suites. It

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -125,7 +125,8 @@ _check_execution_budget() {
   case "$wait_s" in ''|*[!0-9]*) wait_s="$CODERABBIT_RATE_LIMIT_WAIT_DEFAULT" ;; esac
   case "$budget" in ''|*[!0-9]*) budget=5400 ;; esac
 
-  local worst=$(( retries * wait_s ))
+  local worst
+  worst=$(( retries * wait_s ))
   print_kv BUDGET_EXECUTION_SECONDS "$budget"
   print_kv BUDGET_WORST_CASE_RATE_LIMIT_WAIT_SECONDS "$worst"
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -18,7 +18,131 @@ if [ "${HARNESS_MODE:-0}" -eq 1 ] && [ "${BASH_SOURCE[0]}" != "$0" ]; then
   _HARNESS_MODE_EFFECTIVE=1
 fi
 
+# ---------------------------------------------------------------------------
+# Truncated-run detection (issue #1562)
+#
+# A run killed part-way through — by an outer `timeout` shorter than a
+# legitimate rate-limit wait, or by an operator, or by a session ending —
+# used to produce output with no terminal RESULT= line at all. A caller
+# grepping for RESULT= finds nothing, and "no blocking findings were reported"
+# reads uncomfortably like "no blocking findings exist". The exit code is
+# non-zero in that case (124 from timeout, 143 from SIGTERM), but the exit code
+# is precisely what an orchestrator loses when it captures stdout through a
+# pipeline or a log file.
+#
+# So every exit is made to carry a terminal RESULT=. print_kv is wrapped here
+# to record that a RESULT line was emitted, and the EXIT trap below emits
+# RESULT=escalate / REASON=truncated_run when none ever was.
+_RESULT_EMITTED=0
+
+# Overrides the definition sourced from workflow-lib.sh, deliberately: wrapping
+# the single choke point every RESULT line already passes through is what makes
+# this cover all ~100 emission sites without annotating each one.
+print_kv() {
+  if [ "$1" = "RESULT" ]; then
+    _RESULT_EMITTED=1
+  fi
+  printf '%s=%s\n' "$1" "$2"
+}
+
+# _emit_truncation_guard <exit-status>
+#
+# Emits a terminal RESULT for a run that produced none. The status the caller
+# should exit with is the function's RETURN CODE, not stdout: stdout is where
+# the RESULT lines go, so returning the status there would have made
+# `status="$(_emit_truncation_guard "$status")"` capture the RESULT lines into
+# the status and hand `exit` a multi-line string.
+_emit_truncation_guard() {
+  local status="$1"
+  if [ "$_RESULT_EMITTED" -eq 1 ]; then
+    return "$status"
+  fi
+  print_kv RESULT escalate
+  print_kv REASON truncated_run
+  print_kv TRUNCATED 1
+  print_kv TRUNCATED_EXIT_STATUS "$status"
+  echo "ERROR: pr-review-loop.sh exited without reaching a verdict (status ${status})." >&2
+  echo "  This run was truncated — treat it as NOT reviewed, not as clean." >&2
+  echo "  Common cause: an outer 'timeout' shorter than a single rate-limit wait." >&2
+  echo "  See PR_REVIEW_LOOP_EXECUTION_BUDGET in this script's header for the" >&2
+  echo "  wall clock a caller must allow." >&2
+  # A truncated run must never look successful, whatever killed it.
+  if [ "$status" -eq 0 ]; then
+    status=2
+  fi
+  return "$status"
+}
+
 BUGBOT_HANDLED_SKIP_RC=3
+
+# ---------------------------------------------------------------------------
+# Execution budget vs. rate-limit ceiling (issue #1562)
+#
+# These two numbers were in direct tension and nothing reconciled them:
+#
+#   - The worst-case legitimate CodeRabbit rate-limit wait is
+#     CODERABBIT_RATE_LIMIT_MAX_RETRIES x CODERABBIT_RATE_LIMIT_WAIT, which at
+#     the defaults (4 x 900s) is 3600s — a full hour in which the loop is
+#     working correctly and has nothing to report.
+#   - A run was killed at roughly 65 minutes of foreground polling during the
+#     #1503 work. So the maximum legitimate wait sat within a few minutes of
+#     the observed kill threshold.
+#
+# Two runners then made it worse by wrapping the loop in an outer `timeout`
+# SHORTER than a single 900s rate-limit wait, guaranteeing truncation on any
+# rate-limited PR.
+#
+# PR_REVIEW_LOOP_EXECUTION_BUDGET is the wall clock a caller must allow for
+# this script. The invariant is checked at startup: the worst-case rate-limit
+# wait must be strictly less than the budget, so a correctly-configured run can
+# always finish waiting before the budget it declares. Raising the retry count
+# or the per-retry wait without also raising the budget is a configuration
+# error, and is reported as one rather than discovered as a truncated run an
+# hour later.
+#
+# Callers: allow at least this many seconds. Do NOT wrap this script in a
+# `timeout` shorter than it. If you must bound it more tightly, lower
+# CODERABBIT_RATE_LIMIT_MAX_RETRIES or CODERABBIT_RATE_LIMIT_WAIT and lower the
+# budget to match, so the invariant still holds.
+# The shipped CodeRabbit rate-limit defaults, declared once. Both the review
+# path and the budget invariant below read them from here: the two must agree,
+# and they previously restated 4 and 900 independently, which is precisely the
+# drift that lets a budget check pass while the real wait is something else.
+# Raised to span an hourly vendor quota reset by issue #1509.
+CODERABBIT_RATE_LIMIT_MAX_RETRIES_DEFAULT=4
+CODERABBIT_RATE_LIMIT_WAIT_DEFAULT=900
+
+PR_REVIEW_LOOP_EXECUTION_BUDGET="${PR_REVIEW_LOOP_EXECUTION_BUDGET:-5400}"
+
+# _check_execution_budget — verify worst-case rate-limit wait < execution budget.
+# Emits BUDGET_* key/value lines so a caller can record what it must allow.
+_check_execution_budget() {
+  local retries="${CODERABBIT_RATE_LIMIT_MAX_RETRIES:-$CODERABBIT_RATE_LIMIT_MAX_RETRIES_DEFAULT}"
+  local wait_s="${CODERABBIT_RATE_LIMIT_WAIT:-$CODERABBIT_RATE_LIMIT_WAIT_DEFAULT}"
+  local budget="$PR_REVIEW_LOOP_EXECUTION_BUDGET"
+
+  case "$retries" in ''|*[!0-9]*) retries="$CODERABBIT_RATE_LIMIT_MAX_RETRIES_DEFAULT" ;; esac
+  case "$wait_s" in ''|*[!0-9]*) wait_s="$CODERABBIT_RATE_LIMIT_WAIT_DEFAULT" ;; esac
+  case "$budget" in ''|*[!0-9]*) budget=5400 ;; esac
+
+  local worst=$(( retries * wait_s ))
+  print_kv BUDGET_EXECUTION_SECONDS "$budget"
+  print_kv BUDGET_WORST_CASE_RATE_LIMIT_WAIT_SECONDS "$worst"
+
+  if [ "$worst" -ge "$budget" ]; then
+    print_kv BUDGET_INVARIANT violated
+    echo "ERROR: worst-case rate-limit wait (${retries} x ${wait_s}s = ${worst}s) is not less than" >&2
+    echo "  the execution budget (${budget}s). A rate-limited PR could not finish waiting" >&2
+    echo "  inside the budget this run declares, so it would be truncated rather than" >&2
+    echo "  reviewed. Raise PR_REVIEW_LOOP_EXECUTION_BUDGET, or lower" >&2
+    echo "  CODERABBIT_RATE_LIMIT_MAX_RETRIES / CODERABBIT_RATE_LIMIT_WAIT." >&2
+    print_kv RESULT escalate
+    print_kv REASON execution_budget_misconfigured
+    return 1
+  fi
+  print_kv BUDGET_INVARIANT ok
+  return 0
+}
 
 # CODERABBIT_SKIP_BANNER_RE — matches the CodeRabbit "Review skipped" banner.
 #
@@ -181,7 +305,17 @@ else
     exit 75
   fi
 fi
-trap '[ "$_OWN_LOCK" -eq 1 ] && rm -rf "$_LOCK_DIR"; [ -n "$_PR_CONFIG_TMPFILE" ] && rm -f "$_PR_CONFIG_TMPFILE"' EXIT
+_on_exit() {
+  local status=$?
+  [ "$_OWN_LOCK" -eq 1 ] && rm -rf "$_LOCK_DIR"
+  [ -n "$_PR_CONFIG_TMPFILE" ] && rm -f "$_PR_CONFIG_TMPFILE"
+  # Runs on death-by-signal too: the TERM/INT handlers below re-raise, and bash
+  # still runs the EXIT trap on the way out (verified for both `timeout` and a
+  # direct SIGTERM), which is what lets a killed run report itself.
+  _emit_truncation_guard "$status" || status=$?
+  exit "$status"
+}
+trap _on_exit EXIT
 # SIGTERM/SIGINT handlers: kill the current background child (if any) so the
 # handler fires promptly even while a foreground sleep or gh api call is
 # running, then clean up the lock dir and re-raise the signal so the parent
@@ -4386,8 +4520,8 @@ run_coderabbit_review() {
   # exhausted its retries roughly 54 minutes before the vendor could possibly answer
   # and escalated PRs that had nothing wrong with them — the dominant failure mode
   # for unattended overnight runs. Both env vars still override.
-  local coderabbit_rate_limit_max_retries="${CODERABBIT_RATE_LIMIT_MAX_RETRIES:-4}"
-  local coderabbit_rate_limit_wait="${CODERABBIT_RATE_LIMIT_WAIT:-900}"
+  local coderabbit_rate_limit_max_retries="${CODERABBIT_RATE_LIMIT_MAX_RETRIES:-$CODERABBIT_RATE_LIMIT_MAX_RETRIES_DEFAULT}"
+  local coderabbit_rate_limit_wait="${CODERABBIT_RATE_LIMIT_WAIT:-$CODERABBIT_RATE_LIMIT_WAIT_DEFAULT}"
   # See coderabbit_resolve_no_trigger_timeout / coderabbit_no_trigger_timeout_default
   # (issue #1433) for why the default is computed from max_wait rather than a
   # fixed constant, and for env var override / validation-fallback handling
@@ -6833,6 +6967,14 @@ fi
 # per-invocation id).
 current_run_id="$(reviewer_loop_resolve_run_id)"
 print_kv RUN_ID "$current_run_id"
+
+# Reconcile the rate-limit ceiling against the declared execution budget before
+# any waiting starts (issue #1562). Failing here costs a second; discovering the
+# same misconfiguration by being killed mid-wait costs an hour and reports
+# nothing.
+if ! _check_execution_budget; then
+  exit 2
+fi
 
 # --- Release PR early-exit guard ---
 # Release PRs (release/* -> main) and hotfix PRs (hotfix/* -> main) carry

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -112,7 +112,8 @@ BUGBOT_HANDLED_SKIP_RC=3
 CODERABBIT_RATE_LIMIT_MAX_RETRIES_DEFAULT=4
 CODERABBIT_RATE_LIMIT_WAIT_DEFAULT=900
 
-PR_REVIEW_LOOP_EXECUTION_BUDGET="${PR_REVIEW_LOOP_EXECUTION_BUDGET:-5400}"
+PR_REVIEW_LOOP_EXECUTION_BUDGET_DEFAULT=5400
+PR_REVIEW_LOOP_EXECUTION_BUDGET="${PR_REVIEW_LOOP_EXECUTION_BUDGET:-$PR_REVIEW_LOOP_EXECUTION_BUDGET_DEFAULT}"
 
 # _check_execution_budget — verify worst-case rate-limit wait < execution budget.
 # Emits BUDGET_* key/value lines so a caller can record what it must allow.
@@ -123,10 +124,16 @@ _check_execution_budget() {
 
   case "$retries" in ''|*[!0-9]*) retries="$CODERABBIT_RATE_LIMIT_MAX_RETRIES_DEFAULT" ;; esac
   case "$wait_s" in ''|*[!0-9]*) wait_s="$CODERABBIT_RATE_LIMIT_WAIT_DEFAULT" ;; esac
-  case "$budget" in ''|*[!0-9]*) budget=5400 ;; esac
+  case "$budget" in ''|*[!0-9]*) budget="$PR_REVIEW_LOOP_EXECUTION_BUDGET_DEFAULT" ;; esac
 
+  # 10# forces base 10. The guards above accept any all-digit string, including
+  # a zero-padded one, and bash reads a leading-zero operand inside $(( )) as
+  # octal — so CODERABBIT_RATE_LIMIT_MAX_RETRIES=08 passed the guard and then
+  # died with "value too great for base", crashing the very check that exists
+  # to turn a misconfiguration into a clean escalation.
   local worst
-  worst=$(( retries * wait_s ))
+  worst=$(( 10#$retries * 10#$wait_s ))
+  budget=$(( 10#$budget ))
   print_kv BUDGET_EXECUTION_SECONDS "$budget"
   print_kv BUDGET_WORST_CASE_RATE_LIMIT_WAIT_SECONDS "$worst"
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -126,6 +126,38 @@ _check_execution_budget() {
   case "$wait_s" in ''|*[!0-9]*) wait_s="$CODERABBIT_RATE_LIMIT_WAIT_DEFAULT" ;; esac
   case "$budget" in ''|*[!0-9]*) budget="$PR_REVIEW_LOOP_EXECUTION_BUDGET_DEFAULT" ;; esac
 
+  # Upper bounds, checked BEFORE any arithmetic. Bash integers are 64-bit and
+  # wrap silently: retries=99999999999999999 multiplied out to a NEGATIVE worst
+  # case, which then compared as comfortably under budget and reported the
+  # invariant satisfied — the check accepting exactly the unsafe configuration
+  # it exists to reject. Bounding the inputs is what makes the comparison
+  # below meaningful; a digit string beyond these is a misconfiguration, not a
+  # value to clamp silently.
+  #
+  # The limits are deliberately generous — far past anything operationally
+  # sensible — because their job is to keep the arithmetic honest, not to
+  # express policy.
+  local max_retries=1000        # 1000 retries at any sane wait is already days
+  local max_wait=86400          # one day per retry
+  local max_budget=604800       # one week of wall clock
+  local bound_error=""
+  if [ "${#retries}" -gt 10 ] || [ "$(( 10#$retries ))" -gt "$max_retries" ]; then
+    bound_error="CODERABBIT_RATE_LIMIT_MAX_RETRIES=$retries exceeds the maximum of $max_retries"
+  elif [ "${#wait_s}" -gt 10 ] || [ "$(( 10#$wait_s ))" -gt "$max_wait" ]; then
+    bound_error="CODERABBIT_RATE_LIMIT_WAIT=$wait_s exceeds the maximum of $max_wait"
+  elif [ "${#budget}" -gt 10 ] || [ "$(( 10#$budget ))" -gt "$max_budget" ]; then
+    bound_error="PR_REVIEW_LOOP_EXECUTION_BUDGET=$budget exceeds the maximum of $max_budget"
+  fi
+  if [ -n "$bound_error" ]; then
+    print_kv BUDGET_INVARIANT violated
+    echo "ERROR: $bound_error." >&2
+    echo "  Values beyond these bounds overflow 64-bit arithmetic and would make" >&2
+    echo "  the budget comparison meaningless." >&2
+    print_kv RESULT escalate
+    print_kv REASON execution_budget_misconfigured
+    return 1
+  fi
+
   # 10# forces base 10. The guards above accept any all-digit string, including
   # a zero-padded one, and bash reads a leading-zero operand inside $(( )) as
   # octal — so CODERABBIT_RATE_LIMIT_MAX_RETRIES=08 passed the guard and then

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -56,10 +56,18 @@ if [ "${TEST_PR_REVIEW_LOOP_SNAPSHOT:-0}" != "1" ]; then
     case "$1" in
       --area)
         [ $# -ge 2 ] || { echo "ERROR: --area requires a value" >&2; exit 2; }
+        [ -n "$2" ] || { echo "ERROR: --area requires a non-empty value" >&2; exit 2; }
         _area_filter="${_area_filter}${_area_filter:+,}$2"
         shift 2
         ;;
       --area=*)
+        # Reject an empty value. Appending an empty token left _area_filter
+        # empty, which the snapshot step reads as "unfiltered" — so `--area=`
+        # asked for a filter and silently got the full run instead.
+        if [ -z "${1#--area=}" ]; then
+          echo "ERROR: --area= requires a value" >&2
+          exit 2
+        fi
         _area_filter="${_area_filter}${_area_filter:+,}${1#--area=}"
         shift
         ;;
@@ -122,6 +130,10 @@ USAGE
       exit 2
     fi
   else
+    # mktemp rather than a $$-derived name: /tmp is world-writable, so a
+    # predictable path can be pre-created as a symlink and redirect this write
+    # to a file of someone else's choosing. PIDs also recur.
+    _filter_err="$(mktemp -t test-pr-review-loop-filter.XXXXXX)"
     # Preamble (everything before the first area) + selected areas + footer.
     if ! awk -v filter="$_area_filter" '
       function selected(title,   n, i, pat, lt) {
@@ -163,16 +175,16 @@ USAGE
           exit 3
         }
       }
-    ' "$_self" > "$_snapshot" 2>/tmp/.area-filter-err.$$; then
+    ' "$_self" > "$_snapshot" 2>"$_filter_err"; then
       rm -f "$_snapshot"
-      if grep -q NO_AREA_MATCHED "/tmp/.area-filter-err.$$" 2>/dev/null; then
+      if grep -q NO_AREA_MATCHED "$_filter_err" 2>/dev/null; then
         echo "ERROR: no area matched '--area $_area_filter'." >&2
         echo "  Run with --list-areas to see the available areas." >&2
       fi
-      rm -f "/tmp/.area-filter-err.$$"
+      rm -f "$_filter_err"
       exit 2
     fi
-    rm -f "/tmp/.area-filter-err.$$"
+    rm -f "$_filter_err"
     echo "INFO: running filtered areas: $_area_filter" >&2
   fi
 
@@ -13905,8 +13917,32 @@ run_test "budget_lowered_ceiling_is_ok" "BUDGET_INVARIANT=ok" \
      CODERABBIT_RATE_LIMIT_WAIT=300 _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
 # Non-numeric input falls back to the shipped defaults rather than doing
 # arithmetic on a string.
-run_test "budget_non_numeric_falls_back" "BUDGET_INVARIANT=ok" \
+run_test "budget_non_numeric_retries_falls_back" "BUDGET_INVARIANT=ok" \
   "$(CODERABBIT_RATE_LIMIT_MAX_RETRIES=abc _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
+run_test "budget_non_numeric_wait_falls_back" "BUDGET_INVARIANT=ok" \
+  "$(CODERABBIT_RATE_LIMIT_WAIT=abc _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
+run_test "budget_non_numeric_budget_falls_back" "BUDGET_INVARIANT=ok" \
+  "$(PR_REVIEW_LOOP_EXECUTION_BUDGET=abc _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
+
+# Zero-padded values pass the all-digit guards, and bash reads a leading-zero
+# operand inside $(( )) as octal. Before the 10# prefix these crashed the check
+# that exists to replace a crash with a clean escalation.
+run_test "budget_octal_retries_does_not_crash" "BUDGET_INVARIANT=violated" \
+  "$(CODERABBIT_RATE_LIMIT_MAX_RETRIES=08 _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
+run_test "budget_octal_retries_no_arith_error" "" \
+  "$(CODERABBIT_RATE_LIMIT_MAX_RETRIES=08 _check_execution_budget 2>&1 >/dev/null | grep 'error token' || true)"
+run_test "budget_octal_wait_is_base_10" "BUDGET_WORST_CASE_RATE_LIMIT_WAIT_SECONDS=3600" \
+  "$(CODERABBIT_RATE_LIMIT_WAIT=0900 _check_execution_budget 2>/dev/null | grep '^BUDGET_WORST_CASE' || true)"
+run_test "budget_octal_budget_is_base_10" "BUDGET_EXECUTION_SECONDS=9000" \
+  "$(PR_REVIEW_LOOP_EXECUTION_BUDGET=09000 _check_execution_budget 2>/dev/null | grep '^BUDGET_EXECUTION_SECONDS=' || true)"
+
+# --area= with no value must not silently degrade to a full run.
+run_test "area_filter_empty_equals_value_exits_2" "2" \
+  "$(env -u TEST_PR_REVIEW_LOOP_SNAPSHOT PATH="$TEST_PR_REVIEW_LOOP_REAL_PATH" \
+      bash "$_1562_suite" --area= >/dev/null 2>&1; echo $?)"
+run_test "area_filter_empty_value_exits_2" "2" \
+  "$(env -u TEST_PR_REVIEW_LOOP_SNAPSHOT PATH="$TEST_PR_REVIEW_LOOP_REAL_PATH" \
+      bash "$_1562_suite" --area "" >/dev/null 2>&1; echo $?)"
 
 unset _1562_suite _1562_loop _1562_filtered _1562_guard_out
 

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -133,7 +133,11 @@ USAGE
     # mktemp rather than a $$-derived name: /tmp is world-writable, so a
     # predictable path can be pre-created as a symlink and redirect this write
     # to a file of someone else's choosing. PIDs also recur.
-    _filter_err="$(mktemp -t test-pr-review-loop-filter.XXXXXX)"
+    if ! _filter_err="$(mktemp -t test-pr-review-loop-filter.XXXXXX)" \
+       || [ -z "$_filter_err" ]; then
+      echo "ERROR: could not create a temp file for the area-filter diagnostics" >&2
+      exit 2
+    fi
     # Preamble (everything before the first area) + selected areas + footer.
     if ! awk -v filter="$_area_filter" '
       function selected(title,   n, i, pat, lt) {
@@ -13935,6 +13939,29 @@ run_test "budget_octal_wait_is_base_10" "BUDGET_WORST_CASE_RATE_LIMIT_WAIT_SECON
   "$(CODERABBIT_RATE_LIMIT_WAIT=0900 _check_execution_budget 2>/dev/null | grep '^BUDGET_WORST_CASE' || true)"
 run_test "budget_octal_budget_is_base_10" "BUDGET_EXECUTION_SECONDS=9000" \
   "$(PR_REVIEW_LOOP_EXECUTION_BUDGET=09000 _check_execution_budget 2>/dev/null | grep '^BUDGET_EXECUTION_SECONDS=' || true)"
+
+# Oversized digit strings wrap 64-bit arithmetic. retries=99999999999999999
+# multiplied out NEGATIVE, which compared as under budget and reported the
+# invariant satisfied — the check accepting the unsafe configuration it exists
+# to reject. Bounds are enforced before any arithmetic now.
+run_test "budget_overflow_retries_rejected" "BUDGET_INVARIANT=violated" \
+  "$(CODERABBIT_RATE_LIMIT_MAX_RETRIES=99999999999999999 _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
+run_test "budget_overflow_retries_not_negative" "" \
+  "$(CODERABBIT_RATE_LIMIT_MAX_RETRIES=99999999999999999 _check_execution_budget 2>/dev/null | grep -- '-[0-9]' || true)"
+run_test "budget_overflow_huge_digit_string_rejected" "BUDGET_INVARIANT=violated" \
+  "$(CODERABBIT_RATE_LIMIT_MAX_RETRIES=999999999999999999999 _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
+run_test "budget_overflow_wait_rejected" "BUDGET_INVARIANT=violated" \
+  "$(CODERABBIT_RATE_LIMIT_WAIT=99999999999999999 _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
+run_test "budget_overflow_budget_rejected" "BUDGET_INVARIANT=violated" \
+  "$(PR_REVIEW_LOOP_EXECUTION_BUDGET=99999999999999999 _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
+run_test "budget_overflow_escalates" "REASON=execution_budget_misconfigured" \
+  "$(CODERABBIT_RATE_LIMIT_MAX_RETRIES=99999999999999999 _check_execution_budget 2>/dev/null | grep '^REASON=' || true)"
+run_test "budget_overflow_exits_nonzero" "1" \
+  "$(CODERABBIT_RATE_LIMIT_MAX_RETRIES=99999999999999999 _check_execution_budget >/dev/null 2>&1; echo $?)"
+# The bound must not reject values that are merely large but legitimate.
+run_test "budget_large_but_valid_is_ok" "BUDGET_INVARIANT=ok" \
+  "$(PR_REVIEW_LOOP_EXECUTION_BUDGET=604800 CODERABBIT_RATE_LIMIT_MAX_RETRIES=1000 \
+     CODERABBIT_RATE_LIMIT_WAIT=600 _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
 
 # --area= with no value must not silently degrade to a full run.
 run_test "area_filter_empty_equals_value_exits_2" "2" \

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -17,9 +17,184 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
+# Run from an immutable snapshot (issue #1562)
+# ---------------------------------------------------------------------------
+#
+# Bash reads a script incrementally rather than loading it whole, so editing
+# this file while a run is in flight makes the running shell pick up part of
+# the new text at whatever offset it has reached. During the #1531 work that
+# produced a run reporting a pass/fail count matching neither the old file nor
+# the new one, with nothing to indicate anything had happened. At ~13 minutes
+# per run the temptation to edit while waiting is constant, which makes this a
+# question of when rather than whether.
+#
+# So the harness copies itself to a temp file and re-executes from there. The
+# copy is a single atomic-enough read at startup; once running, edits to the
+# working-tree file cannot reach it.
+#
+# The obvious manual workaround — copy it somewhere immutable and run that —
+# does not work on its own, because the repo root is resolved via git from the
+# script's own location. TEST_PR_REVIEW_LOOP_ORIGIN carries the original path
+# across the re-exec so root resolution still anchors to the real checkout.
+#
+# --area composes with the snapshot rather than needing its own machinery: the
+# areas are contiguous line ranges in a linear script, so a filtered run is
+# just a snapshot built from the shared preamble, the selected ranges, and the
+# summary footer. Nothing in the 13k-line body has to be restructured or
+# wrapped in conditionals.
+#
+# Why it is worth having (measured on a clean tree):
+#   * whole suite            210s
+#   * Area 13 alone          197s  — 94%, from 156 codex-github-reviewer.sh
+#                                    invocations that each really sleep
+#   * all 27 other areas     ~13s
+# So iterating on anything other than Area 13 goes from minutes to seconds.
+if [ "${TEST_PR_REVIEW_LOOP_SNAPSHOT:-0}" != "1" ]; then
+  _area_filter=""
+  _list_areas=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --area)
+        [ $# -ge 2 ] || { echo "ERROR: --area requires a value" >&2; exit 2; }
+        _area_filter="${_area_filter}${_area_filter:+,}$2"
+        shift 2
+        ;;
+      --area=*)
+        _area_filter="${_area_filter}${_area_filter:+,}${1#--area=}"
+        shift
+        ;;
+      --list-areas) _list_areas=1; shift ;;
+      -h|--help)
+        cat <<'USAGE'
+Usage: bash test-pr-review-loop.sh [--area <name>]... [--list-areas]
+
+  --area <name>   Run only matching areas. Matches the area's number or any
+                  substring of its title, case-insensitively; repeatable, and
+                  a comma-separated list is accepted. Examples:
+                    --area 13
+                    --area haystack
+                    --area 0a --area 1
+  --list-areas    Print the area names with their line ranges and exit.
+
+With no arguments the whole suite runs.
+USAGE
+        exit 0
+        ;;
+      *) echo "ERROR: unknown argument '$1'" >&2; exit 2 ;;
+    esac
+  done
+
+  # Honour a pre-set origin so a copy of this file placed outside the checkout
+  # still resolves the repo root — the workaround issue #1562 records as not
+  # working. The snapshot below makes the copy unnecessary, but someone holding
+  # an out-of-tree copy should not be met with "fatal: not a git repository".
+  if [ -n "${TEST_PR_REVIEW_LOOP_ORIGIN:-}" ]; then
+    if [ ! -f "$TEST_PR_REVIEW_LOOP_ORIGIN" ]; then
+      echo "ERROR: TEST_PR_REVIEW_LOOP_ORIGIN does not exist: $TEST_PR_REVIEW_LOOP_ORIGIN" >&2
+      exit 2
+    fi
+    _origin_dir="$(CDPATH='' cd -- "$(dirname -- "$TEST_PR_REVIEW_LOOP_ORIGIN")" && pwd)"
+    _self="$_origin_dir/$(basename "$TEST_PR_REVIEW_LOOP_ORIGIN")"
+  else
+    _origin_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+    _self="$_origin_dir/$(basename "$0")"
+  fi
+
+  if [ "$_list_areas" -eq 1 ]; then
+    awk '
+      /^echo "=== / {
+        line=$0
+        sub(/^echo "=== /, "", line)
+        sub(/ ==="$/, "", line)
+        if (prev != "") printf "  %-70s lines %d-%d\n", prev, pstart, NR-1
+        prev=line; pstart=NR
+      }
+      END { if (prev != "") printf "  %-70s lines %d-%d\n", prev, pstart, NR }
+    ' "$_self"
+    exit 0
+  fi
+
+  _snapshot="$(mktemp -t test-pr-review-loop.XXXXXX)"
+  if [ -z "$_area_filter" ]; then
+    if ! cat "$_self" > "$_snapshot"; then
+      rm -f "$_snapshot"
+      echo "ERROR: could not snapshot the test harness for execution" >&2
+      exit 2
+    fi
+  else
+    # Preamble (everything before the first area) + selected areas + footer.
+    if ! awk -v filter="$_area_filter" '
+      function selected(title,   n, i, pat, lt) {
+        n = split(filter, pats, ",")
+        lt = tolower(title)
+        for (i = 1; i <= n; i++) {
+          pat = tolower(pats[i])
+          gsub(/^[ \t]+|[ \t]+$/, "", pat)
+          if (pat == "") continue
+          # A bare number must match the area number exactly, so --area 1 does
+          # not also drag in 10, 10b, 12, and 13.
+          if (pat ~ /^[0-9]+[a-z]?$/) {
+            if (tolower(title) ~ ("^area " pat ":")) return 1
+          } else if (index(lt, pat) > 0) {
+            return 1
+          }
+        }
+        return 0
+      }
+      BEGIN { emit = 1; matched = 0; footer = 0 }
+      # The summary block must survive every filter: it prints the counts and
+      # carries the [ "$FAIL_COUNT" -eq 0 ] test that gives the run its exit
+      # status. Dropping it made a filtered run with failures still exit 0.
+      /^# Summary$/ { footer = 1 }
+      footer { print; next }
+      /^echo "=== / {
+        title = $0
+        sub(/^echo "=== /, "", title)
+        sub(/ ==="$/, "", title)
+        emit = selected(title)
+        if (emit) matched = 1
+        seen_area = 1
+      }
+      /^# -+$/ && seen_area && !emit { next }
+      { if (emit) print }
+      END {
+        if (!matched) {
+          print "NO_AREA_MATCHED" > "/dev/stderr"
+          exit 3
+        }
+      }
+    ' "$_self" > "$_snapshot" 2>/tmp/.area-filter-err.$$; then
+      rm -f "$_snapshot"
+      if grep -q NO_AREA_MATCHED "/tmp/.area-filter-err.$$" 2>/dev/null; then
+        echo "ERROR: no area matched '--area $_area_filter'." >&2
+        echo "  Run with --list-areas to see the available areas." >&2
+      fi
+      rm -f "/tmp/.area-filter-err.$$"
+      exit 2
+    fi
+    rm -f "/tmp/.area-filter-err.$$"
+    echo "INFO: running filtered areas: $_area_filter" >&2
+  fi
+
+  TEST_PR_REVIEW_LOOP_SNAPSHOT=1 \
+  TEST_PR_REVIEW_LOOP_ORIGIN="$_self" \
+  TEST_PR_REVIEW_LOOP_AREA_FILTER="$_area_filter" \
+    bash "$_snapshot" 
+  _rc=$?
+  rm -f "$_snapshot"
+  exit "$_rc"
+fi
+
+# ---------------------------------------------------------------------------
 # Locate repository root (works inside worktrees and normal checkouts).
 # ---------------------------------------------------------------------------
-SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+# Prefer the pre-re-exec origin: $0 is the snapshot in a temp directory, which
+# is not inside any checkout.
+if [ -n "${TEST_PR_REVIEW_LOOP_ORIGIN:-}" ]; then
+  SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$TEST_PR_REVIEW_LOOP_ORIGIN")" && pwd)"
+else
+  SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+fi
 # Locate repo root from the script's directory.
 # Use --show-toplevel so the path resolves to the current worktree root
 # (correct when the harness runs inside a linked worktree).
@@ -147,6 +322,10 @@ esac
 MOCK_GIT
 chmod +x "$MOCK_BIN/git"
 
+# Preserved before the mocks are prepended, so a test that needs to invoke a
+# real tool (or re-enter this harness) can do so with the genuine PATH. Without
+# it, a nested run picks up the mock git and cannot resolve the repo root.
+TEST_PR_REVIEW_LOOP_REAL_PATH="$PATH"
 export PATH="$MOCK_BIN:$PATH"
 
 # ---------------------------------------------------------------------------
@@ -13577,13 +13756,159 @@ rm -rf "$_cr_mock_dir_1531e"
 unset _cr_mock_dir_1531e _cr_call_log_1531e actual_output
 
 # --- AC-4: rate-limit tolerance spans an hourly vendor quota reset ------------
-# Asserted against the script source: the defaults are function-locals, so there
-# is no accessor to read them from, and the whole point of the change is that
-# the shipped numbers (not just the env overrides) are large enough.
+# Asserted against the script source: the whole point of the change is that the
+# shipped numbers (not just the env overrides) are large enough.
+#
+# These greps used to target the inline "${VAR:-4}" / "${VAR:-900}" expansions
+# inside run_coderabbit_review. Issue #1562 gave the same two numbers a second
+# reader — the execution-budget invariant — so they were hoisted to a single
+# declaration rather than restated, which is what these now pin.
 run_test "cr_rate_limit_default_retries_is_four" "1" \
-  "$(grep_count_or_zero 'CODERABBIT_RATE_LIMIT_MAX_RETRIES:-4' "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"
+  "$(grep_count_or_zero 'CODERABBIT_RATE_LIMIT_MAX_RETRIES_DEFAULT=4' "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"
 run_test "cr_rate_limit_default_wait_is_900" "1" \
-  "$(grep_count_or_zero 'CODERABBIT_RATE_LIMIT_WAIT:-900' "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"
+  "$(grep_count_or_zero 'CODERABBIT_RATE_LIMIT_WAIT_DEFAULT=900' "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"
+# And the review path must actually consume that declaration, so hoisting the
+# numbers out cannot leave the wait reading a stale literal.
+run_test "cr_rate_limit_review_path_uses_default_consts" "2" \
+  "$(grep_count_or_zero 'CODERABBIT_RATE_LIMIT_MAX_RETRIES:-$CODERABBIT_RATE_LIMIT_MAX_RETRIES_DEFAULT' "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"
+
+# ---------------------------------------------------------------------------
+# Area 18: suite ergonomics and execution budget (issue #1562)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 18: suite ergonomics and execution budget (#1562) ==="
+
+_1562_suite="$REPO_ROOT/scripts/development-workflow/tests/test-pr-review-loop.sh"
+_1562_loop="$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
+
+# --- AC-1: a single area can be run without the full suite -------------------
+run_test "area_filter_list_areas_lists_this_area" "yes" \
+  "$(env -u TEST_PR_REVIEW_LOOP_SNAPSHOT PATH="$TEST_PR_REVIEW_LOOP_REAL_PATH" bash "$_1562_suite" --list-areas 2>/dev/null | grep -q 'Area 18:' && echo yes || echo no)"
+
+_1562_filtered="$(env -u TEST_PR_REVIEW_LOOP_SNAPSHOT PATH="$TEST_PR_REVIEW_LOOP_REAL_PATH" bash "$_1562_suite" --area 1 2>/dev/null || true)"
+run_test "area_filter_runs_selected_area" "yes" \
+  "$(printf '%s\n' "$_1562_filtered" | grep -q 'normalize_platform_verdict' && echo yes || echo no)"
+# The point of the filter: Area 13 is ~94% of the runtime, so it must be absent.
+run_test "area_filter_excludes_other_areas" "yes" \
+  "$(printf '%s\n' "$_1562_filtered" | grep -q 'PR #801 reviewer-loop failure paths' && echo no || echo yes)"
+# The summary footer carries the exit status and must survive every filter.
+run_test "area_filter_keeps_summary_footer" "yes" \
+  "$(printf '%s\n' "$_1562_filtered" | grep -q '^Tests: ' && echo yes || echo no)"
+
+run_test "area_filter_unknown_area_exits_2" "2" \
+  "$(env -u TEST_PR_REVIEW_LOOP_SNAPSHOT PATH="$TEST_PR_REVIEW_LOOP_REAL_PATH" bash "$_1562_suite" --area definitely-not-an-area >/dev/null 2>&1; echo $?)"
+run_test "area_filter_missing_value_exits_2" "2" \
+  "$(env -u TEST_PR_REVIEW_LOOP_SNAPSHOT PATH="$TEST_PR_REVIEW_LOOP_REAL_PATH" bash "$_1562_suite" --area >/dev/null 2>&1; echo $?)"
+run_test "area_filter_unknown_flag_exits_2" "2" \
+  "$(env -u TEST_PR_REVIEW_LOOP_SNAPSHOT PATH="$TEST_PR_REVIEW_LOOP_REAL_PATH" bash "$_1562_suite" --not-a-flag >/dev/null 2>&1; echo $?)"
+# A bare number selects that area exactly, not every area containing the digit.
+run_test "area_filter_bare_number_is_exact" "yes" \
+  "$(printf '%s\n' "$_1562_filtered" | grep -q 'max_cycles' && echo no || echo yes)"
+
+# --- AC-2: a mid-run edit cannot silently alter the result -------------------
+run_test "suite_reexecs_from_snapshot" "yes" \
+  "$(grep -q 'TEST_PR_REVIEW_LOOP_SNAPSHOT' "$_1562_suite" && echo yes || echo no)"
+run_test "suite_snapshot_preserves_origin_for_repo_root" "yes" \
+  "$(grep -q 'TEST_PR_REVIEW_LOOP_ORIGIN' "$_1562_suite" && echo yes || echo no)"
+# The snapshot must be what actually runs. This process IS a snapshot run, so
+# $0 is the temp copy rather than the checked-in path — which is also what
+# makes running the harness from outside the repo work, since repo-root
+# resolution follows TEST_PR_REVIEW_LOOP_ORIGIN instead of $0.
+run_test "suite_runs_from_a_copy_not_the_original" "yes" \
+  "$([ "$0" != "$_1562_suite" ] && echo yes || echo no)"
+run_test "suite_origin_points_at_the_checked_in_file" "yes" \
+  "$([ "${TEST_PR_REVIEW_LOOP_ORIGIN:-}" = "$_1562_suite" ] && echo yes || echo no)"
+run_test "suite_repo_root_resolved_despite_snapshot" "yes" \
+  "$([ -d "$REPO_ROOT/scripts/development-workflow" ] && echo yes || echo no)"
+# Issue #1562 consequence 3: an out-of-tree copy used to fail with "fatal: not
+# a git repository" because the root was resolved from the copy's location.
+# A pre-set origin now makes that work.
+_1562_copy="$(mktemp -t test-pr-review-loop-copy.XXXXXX)"
+cat "$_1562_suite" > "$_1562_copy"
+run_test "out_of_tree_copy_resolves_repo_root" "yes" \
+  "$(env -u TEST_PR_REVIEW_LOOP_SNAPSHOT PATH="$TEST_PR_REVIEW_LOOP_REAL_PATH" \
+      TEST_PR_REVIEW_LOOP_ORIGIN="$_1562_suite" \
+      bash "$_1562_copy" --area 1 2>/dev/null | grep -q '^Tests: ' && echo yes || echo no)"
+run_test "out_of_tree_copy_bad_origin_exits_2" "2" \
+  "$(env -u TEST_PR_REVIEW_LOOP_SNAPSHOT PATH="$TEST_PR_REVIEW_LOOP_REAL_PATH" \
+      TEST_PR_REVIEW_LOOP_ORIGIN=/nonexistent/suite.sh \
+      bash "$_1562_copy" --area 1 >/dev/null 2>&1; echo $?)"
+rm -f "$_1562_copy"
+unset _1562_copy
+
+# --- AC-3: a truncated run is never mistaken for a clean one ----------------
+run_test "truncation_guard_defined" "yes" \
+  "$(type -t _emit_truncation_guard >/dev/null 2>&1 && echo yes || echo no)"
+
+# With no RESULT emitted, the guard supplies a terminal one and forces non-zero.
+_RESULT_EMITTED=0
+run_test "truncation_guard_forces_nonzero_from_success" "2" \
+  "$(_emit_truncation_guard 0 >/dev/null 2>&1; echo $?)"
+_RESULT_EMITTED=0
+run_test "truncation_guard_emits_result_escalate" "RESULT=escalate" \
+  "$(_emit_truncation_guard 0 2>/dev/null | grep '^RESULT=' || true)"
+_RESULT_EMITTED=0
+run_test "truncation_guard_emits_truncated_reason" "REASON=truncated_run" \
+  "$(_emit_truncation_guard 0 2>/dev/null | grep '^REASON=' || true)"
+_RESULT_EMITTED=0
+run_test "truncation_guard_preserves_kill_status" "143" \
+  "$(_emit_truncation_guard 143 >/dev/null 2>&1; echo $?)"
+
+# When a verdict was reached, the guard must not add a second RESULT line.
+_RESULT_EMITTED=1
+run_test "truncation_guard_silent_after_a_verdict" "" \
+  "$(_emit_truncation_guard 0 2>/dev/null | grep '^RESULT=' || true)"
+_RESULT_EMITTED=1
+run_test "truncation_guard_passes_status_through" "1" \
+  "$(_emit_truncation_guard 1 >/dev/null 2>&1; echo $?)"
+
+# print_kv is the choke point that sets the flag, covering all emission sites.
+_RESULT_EMITTED=0
+print_kv RESULT clean >/dev/null
+run_test "print_kv_records_result_emission" "1" "$_RESULT_EMITTED"
+_RESULT_EMITTED=0
+print_kv REASON something >/dev/null
+run_test "print_kv_ignores_non_result_keys" "0" "$_RESULT_EMITTED"
+_RESULT_EMITTED=0
+
+# --- AC-4: rate-limit ceiling reconciled with the execution budget ----------
+run_test "budget_check_defined" "yes" \
+  "$(type -t _check_execution_budget >/dev/null 2>&1 && echo yes || echo no)"
+
+# Shipped defaults must satisfy the invariant: 4 x 900 = 3600 < 5400.
+run_test "budget_defaults_satisfy_invariant" "BUDGET_INVARIANT=ok" \
+  "$(_check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
+run_test "budget_default_worst_case_is_3600" "BUDGET_WORST_CASE_RATE_LIMIT_WAIT_SECONDS=3600" \
+  "$(_check_execution_budget 2>/dev/null | grep '^BUDGET_WORST_CASE' || true)"
+run_test "budget_default_budget_is_5400" "BUDGET_EXECUTION_SECONDS=5400" \
+  "$(_check_execution_budget 2>/dev/null | grep '^BUDGET_EXECUTION_SECONDS=' || true)"
+run_test "budget_defaults_exit_zero" "0" \
+  "$(_check_execution_budget >/dev/null 2>&1; echo $?)"
+
+# A budget below the worst-case wait is a configuration error, reported before
+# any waiting rather than discovered as a truncated run an hour later.
+run_test "budget_too_small_is_violation" "BUDGET_INVARIANT=violated" \
+  "$(PR_REVIEW_LOOP_EXECUTION_BUDGET=600 _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
+run_test "budget_too_small_exits_nonzero" "1" \
+  "$(PR_REVIEW_LOOP_EXECUTION_BUDGET=600 _check_execution_budget >/dev/null 2>&1; echo $?)"
+run_test "budget_too_small_escalates" "REASON=execution_budget_misconfigured" \
+  "$(PR_REVIEW_LOOP_EXECUTION_BUDGET=600 _check_execution_budget 2>/dev/null | grep '^REASON=' || true)"
+# Equality is a violation too: the wait must fit strictly inside the budget.
+run_test "budget_equal_to_worst_case_is_violation" "BUDGET_INVARIANT=violated" \
+  "$(PR_REVIEW_LOOP_EXECUTION_BUDGET=3600 _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
+# Raising the retries without raising the budget is caught.
+run_test "budget_raised_retries_violates" "BUDGET_INVARIANT=violated" \
+  "$(CODERABBIT_RATE_LIMIT_MAX_RETRIES=8 _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
+# Lowering the ceiling to match a tighter budget is the supported escape hatch.
+run_test "budget_lowered_ceiling_is_ok" "BUDGET_INVARIANT=ok" \
+  "$(PR_REVIEW_LOOP_EXECUTION_BUDGET=600 CODERABBIT_RATE_LIMIT_MAX_RETRIES=1 \
+     CODERABBIT_RATE_LIMIT_WAIT=300 _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
+# Non-numeric input falls back to the shipped defaults rather than doing
+# arithmetic on a string.
+run_test "budget_non_numeric_falls_back" "BUDGET_INVARIANT=ok" \
+  "$(CODERABBIT_RATE_LIMIT_MAX_RETRIES=abc _check_execution_budget 2>/dev/null | grep '^BUDGET_INVARIANT=' || true)"
+
+unset _1562_suite _1562_loop _1562_filtered _1562_guard_out
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
Closes #1562.

## Where the 13 minutes actually goes

Measured on a clean tree before changing anything — the runtime is far more lopsided than "big suite" suggests:

| | Time | Share |
| - | ---- | ----- |
| **Area 13** (PR #801 reviewer-loop failure paths) | **197s** | **94%** |
| All 27 other areas combined | ~13s | 6% |
| Total | 210s | |

Area 13's cost is **156 invocations of `codex-github-reviewer.sh`, every one with `--poll-interval 1 --max-wait 1`** — each really sleeps, at ~1.26s apiece. Nothing else in the suite is slow.

So an area filter is worth a lot for the 27 cheap areas (seconds instead of minutes) and worth nothing if you're working on Area 13. That's a real limit of this change, and it points at the follow-up: making those sleeps injectable would be the thing that actually shortens Area 13.

## AC-1: `--area`

```bash
bash scripts/development-workflow/tests/test-pr-review-loop.sh --list-areas
bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 1
bash scripts/development-workflow/tests/test-pr-review-loop.sh --area haystack
bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 0a --area 12b
```

A bare number matches that area **exactly**, so `--area 1` doesn't also drag in 10, 10b, 12, and 13. Anything else is a case-insensitive substring of the title.

Implemented by **filtering the snapshot**, not by wrapping 13.6k lines in conditionals: the areas are contiguous line ranges, so a filtered run is the shared preamble + the selected ranges + the summary footer. Nothing in the body had to be restructured.

I verified all **28 areas pass in isolation**, which is also what establishes there's no cross-area state to break.

One bug worth flagging, caught by deliberately breaking an assertion: my first version dropped the summary footer when the last area wasn't selected — which meant **a filtered run with failures still exited 0**. The footer is now unconditionally preserved, and there's a test for it.

## AC-2: mid-run edits

Bash reads a script incrementally, so editing this file while a run is in flight makes the running shell pick up part of the new text. The harness now re-executes from a temp snapshot, so edits can't reach a running copy.

That also fixes the issue's third consequence — an out-of-tree copy used to fail with `fatal: not a git repository` because the root is resolved from the script's own location. `TEST_PR_REVIEW_LOOP_ORIGIN` now carries the real path across, and a bad value is a clean exit 2.

## AC-3: truncated runs

A run killed part-way emitted **no terminal `RESULT=` at all**. The exit code was already non-zero (124 from `timeout`, 143 from SIGTERM), but the exit code is exactly what an orchestrator loses when it captures stdout through a pipeline — and "no blocking findings were reported" reads uncomfortably like "no blocking findings exist".

`print_kv` is wrapped to record that a `RESULT` was emitted — one choke point covering all ~100 emission sites — and the `EXIT` trap emits `RESULT=escalate` / `REASON=truncated_run` / `TRUNCATED=1` when none ever was, forcing non-zero.

I confirmed the EXIT trap does run on death-by-signal before relying on it, then verified end to end against a live run:

```
exit=143
RESULT=escalate
REASON=truncated_run
TRUNCATED=1
TRUNCATED_EXIT_STATUS=1
```

My own new tests caught a genuine bug here: the first version returned the status on **stdout** alongside the RESULT lines, so `_on_exit` would have captured all of it and handed `exit` a multi-line string. The status is now the return code.

## AC-4: budget vs. ceiling

The worst-case legitimate wait (`4 × 900s = 3600s`) sat within minutes of the ~65-minute point at which a run was observed being killed. `PR_REVIEW_LOOP_EXECUTION_BUDGET` (default 5400s) now declares the wall clock a caller must allow, and startup fails with `REASON=execution_budget_misconfigured` unless the worst-case wait is **strictly** less than it. Raising the retry count without raising the budget is now a configuration error reported in a second, rather than discovered as a truncated run an hour later.

Every run also emits `BUDGET_EXECUTION_SECONDS` and `BUDGET_WORST_CASE_RATE_LIMIT_WAIT_SECONDS`, so a caller can record what it needs to allow.

## One thing I changed beyond the ACs

The budget check needs the same two rate-limit defaults that `run_coderabbit_review` stated inline, and my first version restated them — which broke two #1509 assertions that pin those literals to exactly one occurrence. Rather than work around the greps, I hoisted the defaults to a single declaration and updated those assertions to pin it, plus added one proving the review path consumes it. The numbers are unchanged (4 and 900).

## Verification

- Full suite: **903 passed, 0 failed**. New Area 18 carries 36 assertions across all four ACs.
- All 28 areas pass individually.
- Filtered run with an injected failure exits 1 and reports it.
- Live SIGTERM test as above.
- ShellCheck clean; markdownlint, heuristic lint, CHANGELOG checks, snippet lint clean.
- Change-scoped CI selects 3 suites here, all passing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review-loop handling for interrupted or truncated runs, including clearer escalation results.
  * Added safeguards to prevent execution when configured time limits cannot accommodate worst-case rate-limit delays.
  * Improved area filtering and snapshot-based test execution for more reliable validation.

* **Documentation**
  * Added guidance for running selected test areas, understanding runtime considerations, and working with immutable test snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->