### PR TITLE
fix(pr-review-loop): settle before calling CodeRabbit clean (#1556)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A CodeRabbit `RESULT=clean` now means "clean, and still clean after the
+  platform went quiet"** (#1556): the loop's post-clean recheck was a single
+  30-second wait, far too short for a vendor that posts findings minutes after
+  it first falls silent. Measured across the 2026-08-20/21 unattended run and
+  since — PR #1532 two late findings, #1541 three across three rounds, #1555
+  five across two, and eight on one PR during #1562 work, two of them Major.
+  **Every late finding was real**; none escaped only because runners were told
+  to hold a 2-3 minute quiet window and re-query by hand, which is operator
+  discipline standing in for a tooling guarantee. The recheck is now a settle
+  loop that polls until the platform has produced no activity for a full quiet
+  period (180s for CodeRabbit, 60s otherwise) or the window is exhausted (600s
+  / 180s). Any activity resets the quiet timer, and a failed activity query is
+  never counted as silence. An exhausted window still reports `clean` but flags
+  it `POST_CLEAN_SETTLED=0` with `POST_CLEAN_SETTLE_TIMEOUT=1`, so a weaker
+  verdict is visible rather than indistinguishable. All windows are
+  configurable generically and per platform; `POST_CLEAN_WAIT` still works.
+- **An in-place edit of a bot comment now registers as review activity**
+  (#1556): CodeRabbit revises its walkthrough comment rather than posting a new
+  one, so the comment keeps its original `created_at`. Observed on PR #1532 —
+  created 23:23, before the 23:34 HEAD commit, and edited 23:52 to carry the
+  new review. The activity probe in `run_coderabbit_review` selected on
+  `created_at` alone and could not see it; that run only survived because
+  CodeRabbit also submitted a formal review, matched separately on
+  `submitted_at`. The probe now accepts `updated_at` as well, as the timeout
+  guard already did.
+- **Readiness now requires the clean verdict to be adjacent to the label**
+  (#1556): protocol 92 previously required only that the reviewer-loop summary
+  be clean, not that it be *recent*. On PR #1555 the label was applied off a
+  thread check that had gone stale during a ~10 minute status poll, with four
+  findings landing in the gap. The loop emits `POST_CLEAN_SETTLED_AT` so the
+  gap is measurable, and the protocol now requires a re-query when anything
+  lengthy intervenes.
 - **`test-pr-review-loop.sh` gains an `--area` filter, runs from an immutable
   snapshot, and can no longer be edited mid-run without notice** (#1562): the
   suite is ~13.6k lines and ~900 assertions with no way to run part of it, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to hold a 2-3 minute quiet window and re-query by hand, which is operator
   discipline standing in for a tooling guarantee. The recheck is now a settle
   loop that polls until the platform has produced no activity for a full quiet
-  period (180s for CodeRabbit, 60s otherwise) or the window is exhausted (600s
-  / 180s). Any activity resets the quiet timer, and a failed activity query is
+  period (120s for CodeRabbit, 60s otherwise) or the window is exhausted (900s
+  / 180s). For CodeRabbit the quiet period does not even begin until a review
+  has been **submitted** for the current HEAD: measured on PR #1573, it posted
+  its walkthrough comment 48 seconds after the push and submitted the actual
+  review — carrying three findings — twelve minutes later, so silence in
+  between meant it was still working rather than finished. A quiet period alone
+  cannot tell those apart, which is why the settle waits for a positive signal
+  and not merely an absent one. Any activity resets the quiet timer, and a failed activity query is
   never counted as silence. An exhausted window still reports `clean` but flags
   it `POST_CLEAN_SETTLED=0` with `POST_CLEAN_SETTLE_TIMEOUT=1`, so a weaker
   verdict is visible rather than indistinguishable. All windows are
@@ -67,8 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   be clean, not that it be *recent*. On PR #1555 the label was applied off a
   thread check that had gone stale during a ~10 minute status poll, with four
   findings landing in the gap. The loop emits `POST_CLEAN_SETTLED_AT` so the
-  gap is measurable, and the protocol now requires a re-query when anything
-  lengthy intervenes.
+  gap is measurable; see
+  [protocol 92](docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md)
+  for the operating contract.
 - **`test-pr-review-loop.sh` gains an `--area` filter, runs from an immutable
   snapshot, and can no longer be edited mid-run without notice** (#1562): the
   suite is ~13.6k lines and ~900 assertions with no way to run part of it, so

--- a/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -59,11 +59,18 @@ Apply this label when **all** of the following are true:
       and treat any unresolved bot thread as blocking. The loop emits
       `POST_CLEAN_SETTLED_AT=<iso8601>` for exactly this: it is the instant the
       verdict was established, so the gap is measurable rather than guessed at.
-- [ ] The reviewer loop reported `POST_CLEAN_SETTLED=1`. `POST_CLEAN_SETTLED=0`
-      (with `POST_CLEAN_SETTLE_TIMEOUT=1`) means the settle window was
-      exhausted while the platform was **still active** — no unresolved thread
-      was found, but the verdict is weaker than a settled one. Treat it as a
-      prompt to re-query threads before labelling rather than as a pass.
+- [ ] **When Step 7 returned `clean`**, the reviewer loop also reported
+      `POST_CLEAN_SETTLED=1`. This condition does not apply to
+      `Result: skipped`: the settle loop only runs on a clean aggregate, so a
+      legitimately skipped result never emits `POST_CLEAN_SETTLED=1` and must
+      not be blocked for its absence.
+
+      `POST_CLEAN_SETTLED=0` (with `POST_CLEAN_SETTLE_TIMEOUT=1`) means the
+      window was exhausted while the platform was still active, or — with
+      `POST_CLEAN_NO_SUBMITTED_REVIEW=1` — that it never submitted a review for
+      this HEAD at all. No unresolved thread was found in either case, so the
+      verdict stands, but it is weaker than a settled one. Treat it as a prompt
+      to re-query threads immediately before labelling rather than as a pass.
 - [ ] Every configured automated PR reviewer has no blocking PR feedback (or is skipped)
 - [ ] All feedback from a previous human review cycle has been addressed
 - [ ] For `spec/*` and `implementation-plan/*` PRs,

--- a/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -45,6 +45,25 @@ Apply this label when **all** of the following are true:
 - [ ] CI checks are green (build, lint, tests all pass)
 - [ ] The relevant pre-PR review gate from `REVIEW.md` has been completed
 - [ ] Step 7's latest automated reviewer-loop summary has `Result: clean` or `Result: skipped`; `RESULT=escalate`, `pending_timeout`, `timeout`, `needs_fixes`, or any other non-clean terminal result blocks this label
+- [ ] That clean verdict is **adjacent** to applying the label, not merely
+      earlier than it (issue #1556). The reviewer loop now settles before
+      reporting clean — it waits for the platform to go quiet for a configured
+      period — but a caller can still invalidate that by doing something slow
+      in between. On PR #1555 the label was applied off a thread check that had
+      gone stale during a ~10 minute status poll, and four findings had landed
+      in the gap; the label had to be pulled back.
+
+      Concretely, when anything lengthy happens between the loop's verdict and
+      the label — a CI poll, a fix cycle, a merge of a sibling PR, a session
+      break — re-query review threads immediately before applying the label,
+      and treat any unresolved bot thread as blocking. The loop emits
+      `POST_CLEAN_SETTLED_AT=<iso8601>` for exactly this: it is the instant the
+      verdict was established, so the gap is measurable rather than guessed at.
+- [ ] The reviewer loop reported `POST_CLEAN_SETTLED=1`. `POST_CLEAN_SETTLED=0`
+      (with `POST_CLEAN_SETTLE_TIMEOUT=1`) means the settle window was
+      exhausted while the platform was **still active** — no unresolved thread
+      was found, but the verdict is weaker than a settled one. Treat it as a
+      prompt to re-query threads before labelling rather than as a pass.
 - [ ] Every configured automated PR reviewer has no blocking PR feedback (or is skipped)
 - [ ] All feedback from a previous human review cycle has been addressed
 - [ ] For `spec/*` and `implementation-plan/*` PRs,

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -501,7 +501,16 @@ Outputs stable key=value lines including:
   PHASE_AFTER_CLEAN_GATE_RESULT=<result> (emitted only after the phase starts)
   PHASE_AFTER_CLEAN_SKIP_REASON=<result> (emitted when the phase never starts)
   PHASE_AFTER_CLEAN_NET_NEW_BLOCKER=0|1 (compatibility alias for READY_PHASE_NET_NEW_BLOCKER)
-  POST_CLEAN_RECHECK=0|1 (1 when the post-clean wait-and-recheck ran)
+  POST_CLEAN_RECHECK=0|1 (1 when the post-clean settle-and-recheck ran)
+  POST_CLEAN_SETTLED=0|1 (1 when the platform went quiet for the full required period; 0 when the
+    window was exhausted while it was still active — the verdict is still clean, but weaker)
+  POST_CLEAN_SETTLE_TIMEOUT=1 (present only when the window was exhausted before silence)
+  POST_CLEAN_SETTLE_WINDOW_SECONDS / POST_CLEAN_SETTLE_QUIET_SECONDS (the values in force)
+  POST_CLEAN_ACTIVITY_SEEN=1 (present when the platform acted during the settle window)
+  POST_CLEAN_ACTIVITY_PROBE_FAILED=1 (present when an activity query failed; a failed probe is
+    never counted as silence)
+  POST_CLEAN_SETTLED_AT=<iso8601> (when the verdict was established — a caller that inserts a long
+    poll between this and the readiness label is acting on a stale check)
   LATE_THREADS_FOUND=<N> (count of newly-found unresolved threads; -1 on audit failure; 0 when POST_CLEAN_RECHECK=0)
   RUN_ID=<id> (this invocation's resolved orchestration-run identifier — either PR_REVIEW_LOOP_RUN_ID
                   verbatim, or a freshly generated "auto-<epoch>-<pid>-<random>" id when unset. See
@@ -553,7 +562,25 @@ Outputs stable key=value lines including:
                   match" key=value parser.)
 
 Environment variables:
-  POST_CLEAN_WAIT=<seconds>          Override the post-clean recheck wait (default: 30). Set to 0 to run immediately.
+  POST_CLEAN_SETTLE_QUIET=<sec>      Consecutive seconds of platform silence required before a clean verdict is
+                                     called settled (issue #1556). Defaults per platform: 180 for coderabbit /
+                                     coderabbit-cli, 60 otherwise. Any platform activity — including an in-place
+                                     EDIT of an existing bot comment — resets this timer.
+  POST_CLEAN_SETTLE_WINDOW=<sec>     Maximum total time to spend settling (default: 600 for coderabbit /
+                                     coderabbit-cli, 180 otherwise). If the window is exhausted while the platform
+                                     is still active, the verdict stays clean but is reported UNSETTLED via
+                                     POST_CLEAN_SETTLED=0 and POST_CLEAN_SETTLE_TIMEOUT=1.
+  POST_CLEAN_POLL=<seconds>          Interval between settle re-checks (default: 60 for coderabbit /
+                                     coderabbit-cli, 30 otherwise).
+  <PLATFORM>_POST_CLEAN_SETTLE_QUIET / _SETTLE_WINDOW / _POLL
+                                     Per-platform overrides, taking precedence over the generic forms above.
+                                     The platform name is upper-cased with '-' replaced by '_', except that
+                                     coderabbit-cli shares the CODERABBIT_ prefix. Example:
+                                     CODERABBIT_POST_CLEAN_SETTLE_QUIET=240
+                                     When several platforms are configured, the LONGEST window and quiet period
+                                     across them are used — any of them can be the one that posts late.
+  POST_CLEAN_WAIT=<seconds>          Legacy alias, still honoured: sets the quiet period when no more specific
+                                     POST_CLEAN_SETTLE_QUIET (generic or per-platform) is set.
   SKIP_POST_CLEAN_RECHECK=1          Suppress the post-clean recheck. Set by callers re-dispatching after a prior
                                      late-thread fix cycle, so the corrective invocation does not recheck again.
   FALLBACK_THREAD_SETTLE_WAIT=<sec>  Seconds to wait before running the thread audit when using
@@ -4601,6 +4628,14 @@ run_coderabbit_review() {
     # Also check for CodeRabbit issue comments (summary comment) as activity signal.
     # Filter by since_iso so historical comments from prior pushes do not incorrectly
     # mark this HEAD cycle as having activity (which would suppress stale-findings recovery).
+    #
+    # Both created_at AND updated_at are accepted (issue #1556). CodeRabbit revises
+    # its walkthrough comment IN PLACE rather than posting a new one, so the comment
+    # keeps its original created_at. Observed on PR #1532: created 23:23 — before the
+    # 23:34 HEAD commit — and edited 23:52 to carry the new review. A created_at-only
+    # filter cannot see that at all; the run only survived because CodeRabbit also
+    # submitted a formal review, which is matched separately on submitted_at. The
+    # timeout guard already accepted updated_at; this probe did not.
     # Exclude "Reviews paused" comments (pause marker), "rate limit" comments (rate-limit
     # marker), "Reviews resumed" acknowledgement comments, and "Review skipped" banners
     # (skip marker — see CODERABBIT_SKIP_BANNER_RE) — none of these represent a
@@ -4613,7 +4648,7 @@ run_coderabbit_review() {
                --arg skip_re "$CODERABBIT_SKIP_BANNER_RE" '
               [.[].[] | select(
                   .user.login == $bot and
-                  .created_at > $since and
+                  (.created_at > $since or (.updated_at // .created_at) > $since) and
                   ((.body // "") | test("Reviews paused|review paused"; "i") | not) and
                   ((.body // "") | test("rate.?limit"; "i") | not) and
                   ((.body // "") | test("reviews resumed"; "i") | not) and
@@ -6848,6 +6883,118 @@ resolve_local_review_override_root() {
 # All function definitions above (including normalize_platform_verdict,
 # append_compare_metrics_row, and restore_regression_label_if_missing) are
 # loaded; only the argument-parsing and execution sections below are skipped.
+# ---------------------------------------------------------------------------
+# Post-clean settle window (issue #1556)
+#
+# The old behaviour was a single 30-second wait followed by one thread re-query.
+# That is far too short for CodeRabbit, which posts findings minutes after it
+# first goes quiet. Measured: PR #1532 two late findings, #1541 three across
+# three rounds, #1555 five across two rounds, and again during #1537/#1562 —
+# eight on one PR across two post-clean rounds, two of them Major. Every late
+# finding was real. Nothing escaped only because runners were told to hold a
+# 2-3 minute quiet window and re-query by hand, which is operator discipline
+# standing in for a tooling guarantee.
+#
+# The verdict now means "clean, and still clean after the vendor went quiet":
+# poll until the platform has produced NO activity for a full quiet period, or
+# until the overall window is exhausted. Any activity resets the quiet timer,
+# because a vendor that just spoke is likely to speak again.
+#
+# _settle_config_for_platform <platform> — echoes "window quiet poll" seconds.
+#
+# Per-platform (AC-4), because vendors differ by an order of magnitude and a
+# window sized for the slowest would tax every other platform. Resolution
+# order, most specific first:
+#   1. <PLATFORM>_POST_CLEAN_SETTLE_WINDOW / _QUIET / _POLL   (e.g. CODERABBIT_)
+#   2. POST_CLEAN_SETTLE_WINDOW / POST_CLEAN_SETTLE_QUIET / POST_CLEAN_POLL
+#   3. the per-platform defaults below
+#
+# POST_CLEAN_WAIT is still honoured as the quiet period when nothing more
+# specific is set, so existing callers keep working.
+_settle_config_for_platform() {
+  local platform="$1"
+  local window quiet poll
+  local prefix
+  # coderabbit-cli shares CodeRabbit's posting behaviour.
+  case "$platform" in
+    coderabbit|coderabbit-cli) prefix="CODERABBIT" ;;
+    *) prefix="$(printf '%s' "$platform" | tr '[:lower:]-' '[:upper:]_')" ;;
+  esac
+
+  case "$platform" in
+    coderabbit|coderabbit-cli)
+      # Sized from the observed late-arrival spread, not guessed.
+      window=600; quiet=180; poll=60
+      ;;
+    *)
+      window=180; quiet=60; poll=30
+      ;;
+  esac
+
+  local v
+  eval "v=\"\${${prefix}_POST_CLEAN_SETTLE_WINDOW:-}\""
+  [ -n "$v" ] || v="${POST_CLEAN_SETTLE_WINDOW:-}"
+  case "$v" in ''|*[!0-9]*) ;; *) window="$v" ;; esac
+
+  eval "v=\"\${${prefix}_POST_CLEAN_SETTLE_QUIET:-}\""
+  [ -n "$v" ] || v="${POST_CLEAN_SETTLE_QUIET:-${POST_CLEAN_WAIT:-}}"
+  case "$v" in ''|*[!0-9]*) ;; *) quiet="$v" ;; esac
+
+  eval "v=\"\${${prefix}_POST_CLEAN_POLL:-}\""
+  [ -n "$v" ] || v="${POST_CLEAN_POLL:-}"
+  case "$v" in ''|*[!0-9]*) ;; *) poll="$v" ;; esac
+
+  # A quiet period longer than the window can never be satisfied, which would
+  # burn the whole window and then report settled without ever having been.
+  [ "$quiet" -gt "$window" ] && quiet="$window"
+  [ "$poll" -lt 1 ] && poll=1
+  [ "$poll" -gt "$quiet" ] && [ "$quiet" -gt 0 ] && poll="$quiet"
+
+  printf '%s %s %s' "$window" "$quiet" "$poll"
+}
+
+# _bot_activity_since <repo> <pr> <since-iso> <bot-login>...
+#
+# Counts bot activity at or after <since-iso> across issue comments, review
+# comments, and submitted reviews. Accepts updated_at as well as created_at,
+# so an in-place edit counts — the same blind spot fixed in the CodeRabbit
+# activity probe. Echoes an integer, or "-1" if the query failed (which the
+# caller must not read as "quiet").
+_bot_activity_since() {
+  local repo="$1" pr="$2" since="$3"
+  shift 3
+  local logins_json
+  logins_json="$(printf '%s\n' "$@" | jq -R . | jq -sc .)"
+
+  local issue_n review_n comment_n
+  issue_n="$(gh api "repos/$repo/issues/$pr/comments" --paginate 2>/dev/null \
+    | jq -s --argjson bots "$logins_json" --arg since "$since" '
+        [ .[][]? | select(
+            ((.user.login // "") | rtrimstr("[bot]")) as $l
+            | ($bots | index($l) or ($bots | index(.user.login // ""))) 
+          ) | select((.created_at > $since) or ((.updated_at // .created_at) > $since))
+        ] | length' 2>/dev/null)" || issue_n=""
+  comment_n="$(gh api "repos/$repo/pulls/$pr/comments" --paginate 2>/dev/null \
+    | jq -s --argjson bots "$logins_json" --arg since "$since" '
+        [ .[][]? | select(
+            ((.user.login // "") | rtrimstr("[bot]")) as $l
+            | ($bots | index($l) or ($bots | index(.user.login // "")))
+          ) | select((.created_at > $since) or ((.updated_at // .created_at) > $since))
+        ] | length' 2>/dev/null)" || comment_n=""
+  review_n="$(gh api "repos/$repo/pulls/$pr/reviews" --paginate 2>/dev/null \
+    | jq -s --argjson bots "$logins_json" --arg since "$since" '
+        [ .[][]? | select(
+            ((.user.login // "") | rtrimstr("[bot]")) as $l
+            | ($bots | index($l) or ($bots | index(.user.login // "")))
+          ) | select((.submitted_at // "") > $since)
+        ] | length' 2>/dev/null)" || review_n=""
+
+  case "${issue_n}${comment_n}${review_n}" in
+    ''|*[!0-9]*) printf '%s' "-1"; return 0 ;;
+  esac
+  printf '%s' "$(( issue_n + comment_n + review_n ))"
+}
+
 [ "$_HARNESS_MODE_EFFECTIVE" -eq 1 ] && return 0 2>/dev/null || true
 
 if [ "$#" -lt 1 ]; then
@@ -8060,42 +8207,76 @@ fi
 # Configurable via POST_CLEAN_WAIT env var (default: 30 seconds).
 # Emits POST_CLEAN_RECHECK=1 when the wait-and-recheck runs, and
 # LATE_THREADS_FOUND=<N> with the count of newly-discovered unresolved threads.
-post_clean_wait="${POST_CLEAN_WAIT:-30}"
+# Take the longest settle configuration across every configured platform: any
+# of them can be the one that posts late, so the window must accommodate the
+# slowest rather than whichever happened to run last.
+settle_window=0
+settle_quiet=0
+settle_poll=0
+for _sp in "${platforms[@]}"; do
+  read -r _sw _sq _spoll <<<"$(_settle_config_for_platform "$_sp")"
+  [ "${_sw:-0}" -gt "$settle_window" ] && settle_window="$_sw"
+  [ "${_sq:-0}" -gt "$settle_quiet" ] && settle_quiet="$_sq"
+  if [ "$settle_poll" -eq 0 ] || { [ "${_spoll:-0}" -gt 0 ] && [ "${_spoll:-0}" -lt "$settle_poll" ]; }; then
+    settle_poll="${_spoll:-30}"
+  fi
+done
+[ "$settle_window" -gt 0 ] || settle_window=180
+[ "$settle_quiet" -gt 0 ] || settle_quiet=60
+[ "$settle_poll" -gt 0 ] || settle_poll=30
+unset _sp _sw _sq _spoll
+
 if [ "$aggregate_result" = "clean" ] \
     && [ "$compare_mode" -eq 0 ] \
     && [ "${SKIP_POST_CLEAN_RECHECK:-0}" != "1" ] \
     && [ "${#unresolved_bot_logins[@]}" -gt 0 ] \
     && [ -n "$pr_number" ]; then
   print_kv POST_CLEAN_RECHECK 1
-  echo "INFO: post-clean recheck — waiting ${post_clean_wait}s for any late-arriving review threads" >&2
-  _interruptible_sleep "$post_clean_wait"
+  print_kv POST_CLEAN_SETTLE_WINDOW_SECONDS "$settle_window"
+  print_kv POST_CLEAN_SETTLE_QUIET_SECONDS "$settle_quiet"
+  echo "INFO: post-clean settle — requiring ${settle_quiet}s of platform silence (max ${settle_window}s), polling every ${settle_poll}s" >&2
 
   late_thread_count=0
-  late_thread_check_output=""
-  late_thread_check_status=0
-  set +e
-  # mode=strict: the post-clean recheck also decides RESULT=clean and must
-  # never be relaxed by a reply-without-resolve (see check_unresolved_threads).
-  late_thread_check_output="$(check_unresolved_threads "$pr_number" "$(repo_slug)" strict "${unresolved_bot_logins[@]}")"
-  late_thread_check_status=$?
-  set -e
+  settle_elapsed=0
+  settle_quiet_elapsed=0
+  settle_activity_seen=0
+  settle_probe_failed=0
+  settle_since="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  settle_repo="$(repo_slug)"
 
-  if [ "$late_thread_check_status" -eq 2 ]; then
-    # Page-cap exceeded — cannot confirm all threads are resolved. Escalate.
-    echo "WARN: post-clean recheck: check_unresolved_threads exceeded page cap — escalating" >&2
-    aggregate_result="escalate"
-    aggregate_reason="post_clean_recheck_thread_check_incomplete"
-    late_thread_count=-1
-  elif [ "$late_thread_check_status" -ne 0 ]; then
-    # GraphQL failure — escalate rather than silently treating the recheck as clean.
-    echo "WARN: post-clean recheck: check_unresolved_threads failed (exit $late_thread_check_status) — escalating" >&2
-    aggregate_result="escalate"
-    aggregate_reason="post_clean_recheck_thread_audit_failed"
-    late_thread_count=-1
-  else
+  while [ "$settle_elapsed" -lt "$settle_window" ] \
+     && [ "$settle_quiet_elapsed" -lt "$settle_quiet" ]; do
+    _interruptible_sleep "$settle_poll"
+    settle_elapsed=$((settle_elapsed + settle_poll))
+
+    # Threads first: a late unresolved thread is the outcome we are hunting,
+    # and finding one ends the wait immediately.
+    late_thread_check_output=""
+    late_thread_check_status=0
+    set +e
+    # mode=strict: this decides RESULT=clean and must never be relaxed by a
+    # reply-without-resolve (see check_unresolved_threads).
+    late_thread_check_output="$(check_unresolved_threads "$pr_number" "$settle_repo" strict "${unresolved_bot_logins[@]}")"
+    late_thread_check_status=$?
+    set -e
+
+    if [ "$late_thread_check_status" -eq 2 ]; then
+      echo "WARN: post-clean settle: check_unresolved_threads exceeded page cap — escalating" >&2
+      aggregate_result="escalate"
+      aggregate_reason="post_clean_recheck_thread_check_incomplete"
+      late_thread_count=-1
+      break
+    elif [ "$late_thread_check_status" -ne 0 ]; then
+      echo "WARN: post-clean settle: check_unresolved_threads failed (exit $late_thread_check_status) — escalating" >&2
+      aggregate_result="escalate"
+      aggregate_reason="post_clean_recheck_thread_audit_failed"
+      late_thread_count=-1
+      break
+    fi
+
     late_thread_count="$late_thread_check_output"
     if [ "$late_thread_count" -gt 0 ]; then
-      echo "INFO: post-clean recheck — found $late_thread_count late unresolved thread(s); switching to needs_fixes" >&2
+      echo "INFO: post-clean settle — found $late_thread_count late unresolved thread(s) after ${settle_elapsed}s; switching to needs_fixes" >&2
       aggregate_result="needs_fixes"
       aggregate_reason="late_review_threads"
       if [ "$phase_after_clean_enabled" -eq 1 ] && [ "$phase_after_clean_started" -eq 1 ]; then
@@ -8103,10 +8284,49 @@ if [ "$aggregate_result" = "clean" ] \
         phase_after_clean_blocking_platform="${phase_after_clean_blocking_platform:-late_review_threads}"
       fi
       total_blocking_count=$((total_blocking_count + late_thread_count))
-    else
-      echo "INFO: post-clean recheck — no late threads found; result remains clean" >&2
+      break
     fi
+
+    # No unresolved thread yet — but the platform may still be mid-write, and a
+    # comment posted without a review thread (or a walkthrough edited in place)
+    # is exactly the signal that more is coming. Any activity resets the quiet
+    # timer rather than merely being noted.
+    settle_activity="$(_bot_activity_since "$settle_repo" "$pr_number" "$settle_since" "${unresolved_bot_logins[@]}")"
+    if [ "$settle_activity" = "-1" ]; then
+      # A failed probe is not silence. Do not let it satisfy the quiet period.
+      settle_probe_failed=1
+      echo "WARN: post-clean settle: activity probe failed; not counting this interval as quiet" >&2
+    elif [ "${settle_activity:-0}" -gt 0 ]; then
+      settle_activity_seen=1
+      settle_quiet_elapsed=0
+      settle_since="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+      echo "INFO: post-clean settle — $settle_activity new platform action(s) at ${settle_elapsed}s; quiet timer reset" >&2
+    else
+      settle_quiet_elapsed=$((settle_quiet_elapsed + settle_poll))
+    fi
+  done
+
+  if [ "$aggregate_result" = "clean" ]; then
+    if [ "$settle_quiet_elapsed" -ge "$settle_quiet" ]; then
+      print_kv POST_CLEAN_SETTLED 1
+      echo "INFO: post-clean settle — platform quiet for ${settle_quiet_elapsed}s; result remains clean" >&2
+    else
+      # The window ran out before the quiet period was satisfied. The verdict is
+      # still clean (no unresolved thread was ever found) but it is weaker than
+      # a settled one, and saying so is the difference between a caller that
+      # knows to look and one that does not.
+      print_kv POST_CLEAN_SETTLED 0
+      print_kv POST_CLEAN_SETTLE_TIMEOUT 1
+      echo "WARN: post-clean settle — window (${settle_window}s) exhausted before ${settle_quiet}s of silence; the platform was still active. Verdict is clean but UNSETTLED." >&2
+    fi
+    [ "$settle_probe_failed" -eq 1 ] && print_kv POST_CLEAN_ACTIVITY_PROBE_FAILED 1
+    [ "$settle_activity_seen" -eq 1 ] && print_kv POST_CLEAN_ACTIVITY_SEEN 1
   fi
+
+  # The instant the verdict was established. A caller that inserts a long poll
+  # between this timestamp and the readiness label is acting on a stale check —
+  # see the "adjacent to the readiness decision" note in the reviewer-loop docs.
+  print_kv POST_CLEAN_SETTLED_AT "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   print_kv LATE_THREADS_FOUND "$late_thread_count"
 else
   print_kv POST_CLEAN_RECHECK 0

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -572,6 +572,14 @@ Environment variables:
                                      POST_CLEAN_SETTLED=0 and POST_CLEAN_SETTLE_TIMEOUT=1.
   POST_CLEAN_POLL=<seconds>          Interval between settle re-checks (default: 60 for coderabbit /
                                      coderabbit-cli, 30 otherwise).
+  POST_CLEAN_REQUIRE_REVIEW=0|1      Whether silence alone may satisfy the settle, or whether a SUBMITTED review
+                                     for the current HEAD is required first (default: 1 for coderabbit /
+                                     coderabbit-cli, 0 otherwise). CodeRabbit posts a walkthrough issue comment
+                                     within a minute of the push and then submits the actual review much later —
+                                     twelve minutes, measured on PR #1573 — so silence in between means it is
+                                     still working, not that it finished. When no review arrives inside the
+                                     window the verdict stays clean but reports POST_CLEAN_NO_SUBMITTED_REVIEW=1
+                                     alongside POST_CLEAN_SETTLED=0.
   <PLATFORM>_POST_CLEAN_SETTLE_QUIET / _SETTLE_WINDOW / _POLL
                                      Per-platform overrides, taking precedence over the generic forms above.
                                      The platform name is upper-cased with '-' replaced by '_', except that
@@ -6920,27 +6928,55 @@ _settle_config_for_platform() {
     coderabbit|coderabbit-cli) prefix="CODERABBIT" ;;
     *) prefix="$(printf '%s' "$platform" | tr '[:lower:]-' '[:upper:]_')" ;;
   esac
+  # The prefix is interpolated into a variable NAME below. Reject anything that
+  # is not a valid shell identifier rather than trusting the tr transform to
+  # have neutralised it: platform reaches here from --platform and from the
+  # workflow config, neither of which is validated upstream. An unusable prefix
+  # simply means no per-platform overrides — the generic knobs and the defaults
+  # still apply, so a strange platform name degrades instead of failing.
+  case "$prefix" in
+    ''|*[!A-Za-z0-9_]*) prefix="" ;;
+    [0-9]*) prefix="" ;;
+  esac
 
+  # require_review: whether silence alone may satisfy the settle, or whether a
+  # formal review submission for the current HEAD is required first.
+  #
+  # This is the distinction the first implementation of #1556 missed, and the
+  # measurement that forced it: on PR #1573, HEAD landed at 00:17:29, CodeRabbit
+  # posted its WALKTHROUGH comment 48s later at 00:18:17, and the loop treated
+  # that as "reviewed, no findings" and returned clean. The actual review was
+  # submitted at 00:30:32 — twelve minutes after the walkthrough — carrying
+  # three findings. A quiet period cannot help here: CodeRabbit was completely
+  # silent for the whole 180s window because it was still thinking.
+  #
+  # Silence is an absence signal and cannot distinguish "done" from "working".
+  # For CodeRabbit the settle therefore waits for a positive one.
+  local require_review
   case "$platform" in
     coderabbit|coderabbit-cli)
-      # Sized from the observed late-arrival spread, not guessed.
-      window=600; quiet=180; poll=60
+      # Window sized from the observed walkthrough-to-review gap (~12 min),
+      # not guessed.
+      window=900; quiet=120; poll=60; require_review=1
       ;;
     *)
-      window=180; quiet=60; poll=30
+      window=180; quiet=60; poll=30; require_review=0
       ;;
   esac
 
-  local v
-  eval "v=\"\${${prefix}_POST_CLEAN_SETTLE_WINDOW:-}\""
+  local v _n
+  v=""
+  if [ -n "$prefix" ]; then _n="${prefix}_POST_CLEAN_SETTLE_WINDOW"; v="${!_n:-}"; fi
   [ -n "$v" ] || v="${POST_CLEAN_SETTLE_WINDOW:-}"
   case "$v" in ''|*[!0-9]*) ;; *) window="$v" ;; esac
 
-  eval "v=\"\${${prefix}_POST_CLEAN_SETTLE_QUIET:-}\""
+  v=""
+  if [ -n "$prefix" ]; then _n="${prefix}_POST_CLEAN_SETTLE_QUIET"; v="${!_n:-}"; fi
   [ -n "$v" ] || v="${POST_CLEAN_SETTLE_QUIET:-${POST_CLEAN_WAIT:-}}"
   case "$v" in ''|*[!0-9]*) ;; *) quiet="$v" ;; esac
 
-  eval "v=\"\${${prefix}_POST_CLEAN_POLL:-}\""
+  v=""
+  if [ -n "$prefix" ]; then _n="${prefix}_POST_CLEAN_POLL"; v="${!_n:-}"; fi
   [ -n "$v" ] || v="${POST_CLEAN_POLL:-}"
   case "$v" in ''|*[!0-9]*) ;; *) poll="$v" ;; esac
 
@@ -6950,7 +6986,38 @@ _settle_config_for_platform() {
   [ "$poll" -lt 1 ] && poll=1
   [ "$poll" -gt "$quiet" ] && [ "$quiet" -gt 0 ] && poll="$quiet"
 
-  printf '%s %s %s' "$window" "$quiet" "$poll"
+  v=""
+  if [ -n "$prefix" ]; then _n="${prefix}_POST_CLEAN_REQUIRE_REVIEW"; v="${!_n:-}"; fi
+  [ -n "$v" ] || v="${POST_CLEAN_REQUIRE_REVIEW:-}"
+  case "$v" in 0|1) require_review="$v" ;; esac
+
+  printf '%s %s %s %s' "$window" "$quiet" "$poll" "$require_review"
+}
+
+# _bot_review_submitted_since <repo> <pr> <since-iso> <bot-login>...
+#
+# Echoes 1 when any listed bot has SUBMITTED a formal review at or after
+# <since-iso>, 0 when none has, and -1 when the query failed. This is the
+# positive completion signal: CodeRabbit's walkthrough issue comment appears
+# within a minute of the push and means only that it has noticed the PR, while
+# the submitted review is what carries the findings.
+_bot_review_submitted_since() {
+  local repo="$1" pr="$2" since="$3"
+  shift 3
+  local logins_json n
+  logins_json="$(printf '%s\n' "$@" | jq -R . | jq -sc .)"
+  n="$(gh api "repos/$repo/pulls/$pr/reviews" --paginate 2>/dev/null \
+    | jq -s --argjson bots "$logins_json" --arg since "$since" '
+        [ .[][]? | select(
+            ((.user.login // "")) as $raw
+            | ($raw | rtrimstr("[bot]")) as $l
+            | ((($bots | index($l)) != null) or (($bots | index($raw)) != null))
+          ) | select((.submitted_at // "") > $since)
+        ] | length' 2>/dev/null)" || n=""
+  case "$n" in
+    ''|*[!0-9]*) printf '%s' "-1"; return 0 ;;
+  esac
+  [ "$n" -gt 0 ] && printf '1' || printf '0'
 }
 
 # _bot_activity_since <repo> <pr> <since-iso> <bot-login>...
@@ -6970,22 +7037,25 @@ _bot_activity_since() {
   issue_n="$(gh api "repos/$repo/issues/$pr/comments" --paginate 2>/dev/null \
     | jq -s --argjson bots "$logins_json" --arg since "$since" '
         [ .[][]? | select(
-            ((.user.login // "") | rtrimstr("[bot]")) as $l
-            | ($bots | index($l) or ($bots | index(.user.login // ""))) 
+            ((.user.login // "")) as $raw
+            | ($raw | rtrimstr("[bot]")) as $l
+            | ((($bots | index($l)) != null) or (($bots | index($raw)) != null)) 
           ) | select((.created_at > $since) or ((.updated_at // .created_at) > $since))
         ] | length' 2>/dev/null)" || issue_n=""
   comment_n="$(gh api "repos/$repo/pulls/$pr/comments" --paginate 2>/dev/null \
     | jq -s --argjson bots "$logins_json" --arg since "$since" '
         [ .[][]? | select(
-            ((.user.login // "") | rtrimstr("[bot]")) as $l
-            | ($bots | index($l) or ($bots | index(.user.login // "")))
+            ((.user.login // "")) as $raw
+            | ($raw | rtrimstr("[bot]")) as $l
+            | ((($bots | index($l)) != null) or (($bots | index($raw)) != null))
           ) | select((.created_at > $since) or ((.updated_at // .created_at) > $since))
         ] | length' 2>/dev/null)" || comment_n=""
   review_n="$(gh api "repos/$repo/pulls/$pr/reviews" --paginate 2>/dev/null \
     | jq -s --argjson bots "$logins_json" --arg since "$since" '
         [ .[][]? | select(
-            ((.user.login // "") | rtrimstr("[bot]")) as $l
-            | ($bots | index($l) or ($bots | index(.user.login // "")))
+            ((.user.login // "")) as $raw
+            | ($raw | rtrimstr("[bot]")) as $l
+            | ((($bots | index($l)) != null) or (($bots | index($raw)) != null))
           ) | select((.submitted_at // "") > $since)
         ] | length' 2>/dev/null)" || review_n=""
 
@@ -8213,10 +8283,12 @@ fi
 settle_window=0
 settle_quiet=0
 settle_poll=0
+settle_require_review=0
 for _sp in "${platforms[@]}"; do
-  read -r _sw _sq _spoll <<<"$(_settle_config_for_platform "$_sp")"
+  read -r _sw _sq _spoll _srr <<<"$(_settle_config_for_platform "$_sp")"
   [ "${_sw:-0}" -gt "$settle_window" ] && settle_window="$_sw"
   [ "${_sq:-0}" -gt "$settle_quiet" ] && settle_quiet="$_sq"
+  [ "${_srr:-0}" -eq 1 ] && settle_require_review=1
   if [ "$settle_poll" -eq 0 ] || { [ "${_spoll:-0}" -gt 0 ] && [ "${_spoll:-0}" -lt "$settle_poll" ]; }; then
     settle_poll="${_spoll:-30}"
   fi
@@ -8224,7 +8296,7 @@ done
 [ "$settle_window" -gt 0 ] || settle_window=180
 [ "$settle_quiet" -gt 0 ] || settle_quiet=60
 [ "$settle_poll" -gt 0 ] || settle_poll=30
-unset _sp _sw _sq _spoll
+unset _sp _sw _sq _spoll _srr
 
 if [ "$aggregate_result" = "clean" ] \
     && [ "$compare_mode" -eq 0 ] \
@@ -8234,7 +8306,18 @@ if [ "$aggregate_result" = "clean" ] \
   print_kv POST_CLEAN_RECHECK 1
   print_kv POST_CLEAN_SETTLE_WINDOW_SECONDS "$settle_window"
   print_kv POST_CLEAN_SETTLE_QUIET_SECONDS "$settle_quiet"
-  echo "INFO: post-clean settle — requiring ${settle_quiet}s of platform silence (max ${settle_window}s), polling every ${settle_poll}s" >&2
+  print_kv POST_CLEAN_REQUIRE_REVIEW "$settle_require_review"
+  if [ "$settle_require_review" -eq 1 ]; then
+    echo "INFO: post-clean settle — awaiting a submitted review for this HEAD, then ${settle_quiet}s of silence (max ${settle_window}s), polling every ${settle_poll}s" >&2
+  else
+    echo "INFO: post-clean settle — requiring ${settle_quiet}s of platform silence (max ${settle_window}s), polling every ${settle_poll}s" >&2
+  fi
+  # since_iso for the settle probes is the HEAD commit time, not "now": a review
+  # submitted between the loop starting and the settle beginning still counts as
+  # this HEAD's review, and anchoring to "now" would wait for a second one.
+  settle_head_iso="$(gh api "repos/$(repo_slug)/commits/${head_sha:-HEAD}" --jq '.commit.committer.date // empty' 2>/dev/null)"
+  [ -n "$settle_head_iso" ] || settle_head_iso="$(date -u -v-1H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '1 hour ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
+  settle_review_seen=0
 
   late_thread_count=0
   settle_elapsed=0
@@ -8301,6 +8384,19 @@ if [ "$aggregate_result" = "clean" ] \
       settle_quiet_elapsed=0
       settle_since="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
       echo "INFO: post-clean settle — $settle_activity new platform action(s) at ${settle_elapsed}s; quiet timer reset" >&2
+    elif [ "$settle_require_review" -eq 1 ] && [ "$settle_review_seen" -eq 0 ]; then
+      # Silence before the review lands is the platform thinking, not finishing.
+      # Do not let it accumulate toward the quiet period.
+      settle_review_probe="$(_bot_review_submitted_since "$settle_repo" "$pr_number" "$settle_head_iso" "${unresolved_bot_logins[@]}")"
+      if [ "$settle_review_probe" = "1" ]; then
+        settle_review_seen=1
+        echo "INFO: post-clean settle — submitted review detected at ${settle_elapsed}s; quiet period starts now" >&2
+      elif [ "$settle_review_probe" = "-1" ]; then
+        settle_probe_failed=1
+        echo "WARN: post-clean settle: review probe failed; not counting this interval as quiet" >&2
+      else
+        echo "INFO: post-clean settle — no submitted review yet at ${settle_elapsed}s of ${settle_window}s; still waiting" >&2
+      fi
     else
       settle_quiet_elapsed=$((settle_quiet_elapsed + settle_poll))
     fi
@@ -8317,7 +8413,13 @@ if [ "$aggregate_result" = "clean" ] \
       # knows to look and one that does not.
       print_kv POST_CLEAN_SETTLED 0
       print_kv POST_CLEAN_SETTLE_TIMEOUT 1
-      echo "WARN: post-clean settle — window (${settle_window}s) exhausted before ${settle_quiet}s of silence; the platform was still active. Verdict is clean but UNSETTLED." >&2
+      if [ "$settle_require_review" -eq 1 ] && [ "$settle_review_seen" -eq 0 ]; then
+        print_kv POST_CLEAN_NO_SUBMITTED_REVIEW 1
+        echo "WARN: post-clean settle — window (${settle_window}s) exhausted and the platform never submitted a review for this HEAD." >&2
+        echo "  Its walkthrough comment alone does not mean it finished. Verdict is clean but UNSETTLED — re-query threads before labelling." >&2
+      else
+        echo "WARN: post-clean settle — window (${settle_window}s) exhausted before ${settle_quiet}s of silence; the platform was still active. Verdict is clean but UNSETTLED." >&2
+      fi
     fi
     [ "$settle_probe_failed" -eq 1 ] && print_kv POST_CLEAN_ACTIVITY_PROBE_FAILED 1
     [ "$settle_activity_seen" -eq 1 ] && print_kv POST_CLEAN_ACTIVITY_SEEN 1

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -13982,34 +13982,34 @@ echo "=== Area 19: post-clean settle and updated_at activity (#1556) ==="
 # --- AC-4: the settle window is configurable, per platform ------------------
 run_test "settle_config_defined" "yes" \
   "$(type -t _settle_config_for_platform >/dev/null 2>&1 && echo yes || echo no)"
-run_test "settle_default_platform" "180 60 30" \
+run_test "settle_default_platform" "180 60 30 0" \
   "$(_settle_config_for_platform pr-agent)"
 # CodeRabbit gets a longer window because it is the platform that posts late.
-run_test "settle_coderabbit_is_longer" "600 180 60" \
+run_test "settle_coderabbit_is_longer" "900 120 60 1" \
   "$(_settle_config_for_platform coderabbit)"
-run_test "settle_coderabbit_cli_shares_prefix" "600 180 60" \
+run_test "settle_coderabbit_cli_shares_prefix" "900 120 60 1" \
   "$(_settle_config_for_platform coderabbit-cli)"
-run_test "settle_generic_env_override" "180 45 30" \
+run_test "settle_generic_env_override" "180 45 30 0" \
   "$(POST_CLEAN_SETTLE_QUIET=45 _settle_config_for_platform pr-agent)"
-run_test "settle_per_platform_env_wins" "600 10 10" \
+run_test "settle_per_platform_env_wins" "900 10 10 1" \
   "$(CODERABBIT_POST_CLEAN_SETTLE_QUIET=10 _settle_config_for_platform coderabbit)"
-run_test "settle_per_platform_beats_generic" "600 20 20" \
+run_test "settle_per_platform_beats_generic" "900 20 20 1" \
   "$(POST_CLEAN_SETTLE_QUIET=99 CODERABBIT_POST_CLEAN_SETTLE_QUIET=20 \
      _settle_config_for_platform coderabbit)"
-run_test "settle_window_override" "300 180 60" \
+run_test "settle_window_override" "300 120 60 1" \
   "$(CODERABBIT_POST_CLEAN_SETTLE_WINDOW=300 _settle_config_for_platform coderabbit)"
 # Legacy knob still works so existing callers are not silently retimed.
-run_test "settle_legacy_post_clean_wait" "180 5 5" \
+run_test "settle_legacy_post_clean_wait" "180 5 5 0" \
   "$(POST_CLEAN_WAIT=5 _settle_config_for_platform pr-agent)"
-run_test "settle_specific_beats_legacy" "180 45 30" \
+run_test "settle_specific_beats_legacy" "180 45 30 0" \
   "$(POST_CLEAN_WAIT=5 POST_CLEAN_SETTLE_QUIET=45 _settle_config_for_platform pr-agent)"
 # A quiet period longer than the window could never be satisfied, which would
 # burn the whole window and then report settled without ever having been.
-run_test "settle_quiet_clamped_to_window" "60 60 30" \
+run_test "settle_quiet_clamped_to_window" "60 60 30 0" \
   "$(POST_CLEAN_SETTLE_WINDOW=60 POST_CLEAN_SETTLE_QUIET=999 _settle_config_for_platform pr-agent)"
-run_test "settle_junk_falls_back_to_default" "180 60 30" \
+run_test "settle_junk_falls_back_to_default" "180 60 30 0" \
   "$(POST_CLEAN_SETTLE_QUIET=abc _settle_config_for_platform pr-agent)"
-run_test "settle_negative_junk_falls_back" "180 60 30" \
+run_test "settle_negative_junk_falls_back" "180 60 30 0" \
   "$(POST_CLEAN_SETTLE_QUIET=-5 _settle_config_for_platform pr-agent)"
 
 # --- AC-2 / AC-3: an in-place edit registers as activity --------------------
@@ -14076,6 +14076,84 @@ run_test "activity_probe_failure_is_minus_one" "-1" \
 rm -rf "$_1556_bin"
 unset _1556_bin
 
+# --- The completion signal: silence is not the same as finished -------------
+#
+# Measured on PR #1573, which is what forced this design. HEAD landed at
+# 00:17:29; CodeRabbit posted its WALKTHROUGH comment 48s later at 00:18:17,
+# and the loop read that as "reviewed, no findings" and returned clean. The
+# actual review was submitted at 00:30:32 — twelve minutes after the
+# walkthrough — carrying three findings. A quiet period cannot catch that:
+# CodeRabbit was silent for the entire window because it was still working.
+run_test "settle_coderabbit_requires_submitted_review" "1" \
+  "$(_settle_config_for_platform coderabbit | awk '{print $4}')"
+run_test "settle_other_platforms_do_not_require_review" "0" \
+  "$(_settle_config_for_platform pr-agent | awk '{print $4}')"
+run_test "settle_require_review_overridable" "0" \
+  "$(CODERABBIT_POST_CLEAN_REQUIRE_REVIEW=0 _settle_config_for_platform coderabbit | awk '{print $4}')"
+
+# A platform name reaches this function from --platform and from the workflow
+# config, neither validated upstream, and was interpolated into an eval. I could
+# not craft a working exploit — the uppercase transform breaks the obvious
+# vectors — but eval on config-derived data is not a construct worth keeping.
+run_test "settle_hostile_platform_name_is_safe" "180 60 30 0" \
+  "$(_settle_config_for_platform 'a}">/tmp/settle-probe;${b')"
+run_test "settle_hostile_platform_no_side_effect" "absent" \
+  "$(rm -f /tmp/settle-probe; _settle_config_for_platform 'a}">/tmp/settle-probe;${b' >/dev/null 2>&1; \
+     [ -e /tmp/settle-probe ] && echo present || echo absent)"
+# An unusable prefix must degrade to the generic knobs, not discard them.
+run_test "settle_hostile_name_still_honours_generic" "180 42 30 0" \
+  "$(POST_CLEAN_SETTLE_QUIET=42 _settle_config_for_platform 'we!rd')"
+run_test "settle_no_eval_in_lookup" "0" \
+  "$(grep_count_or_zero 'eval "v=' "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"
+
+run_test "review_probe_defined" "yes" \
+  "$(type -t _bot_review_submitted_since >/dev/null 2>&1 && echo yes || echo no)"
+
+_1556_rbin="$(mktemp -d)"
+_1556_mkreviews() {
+  cat > "$_1556_rbin/gh" <<GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"pulls/42/reviews"*) cat <<'JSON'
+$1
+JSON
+    ;;
+  *) printf '[]\n' ;;
+esac
+GHEOF
+  chmod +x "$_1556_rbin/gh"
+}
+
+# A walkthrough comment is NOT a submitted review — this is the whole point.
+_1556_mkreviews '[]'
+run_test "review_probe_no_review_is_zero" "0" \
+  "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" coderabbitai)"
+
+# The PR #1573 review, submitted 13 minutes after HEAD.
+_1556_mkreviews '[{"user":{"login":"coderabbitai[bot]"},"submitted_at":"2026-08-22T00:30:32Z","state":"COMMENTED"}]'
+run_test "review_probe_detects_submitted_review" "1" \
+  "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" coderabbitai)"
+
+# A review from a PREVIOUS head must not satisfy this head.
+_1556_mkreviews '[{"user":{"login":"coderabbitai[bot]"},"submitted_at":"2026-08-22T00:10:00Z","state":"COMMENTED"}]'
+run_test "review_probe_ignores_stale_review" "0" \
+  "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" coderabbitai)"
+
+# Another bot's review must not satisfy this bot.
+_1556_mkreviews '[{"user":{"login":"other-bot[bot]"},"submitted_at":"2026-08-22T00:30:32Z","state":"COMMENTED"}]'
+run_test "review_probe_ignores_other_bot" "0" \
+  "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" coderabbitai)"
+
+cat > "$_1556_rbin/gh" <<'GHFAIL2'
+#!/usr/bin/env bash
+echo "simulated failure" >&2; exit 1
+GHFAIL2
+chmod +x "$_1556_rbin/gh"
+run_test "review_probe_failure_is_minus_one" "-1" \
+  "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" coderabbitai)"
+rm -rf "$_1556_rbin"
+unset _1556_rbin
+
 # --- AC-1: the loop owns the wait, and the contract says so -----------------
 _1556_loop="$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
 # The activity probe inside run_coderabbit_review must accept updated_at too;
@@ -14095,6 +14173,13 @@ run_test "post_clean_reports_timeout_distinctly" "yes" \
 # A failed activity probe must never be counted as silence.
 run_test "post_clean_probe_failure_not_silence" "yes" \
   "$(grep -q 'not counting this interval as quiet' "$_1556_loop" && echo yes || echo no)"
+# Silence before the review lands must not accumulate toward the quiet period.
+run_test "post_clean_gates_quiet_on_review" "yes" \
+  "$(grep -q 'quiet period starts now' "$_1556_loop" && echo yes || echo no)"
+run_test "post_clean_reports_missing_review" "yes" \
+  "$(grep -q 'print_kv POST_CLEAN_NO_SUBMITTED_REVIEW 1' "$_1556_loop" && echo yes || echo no)"
+run_test "post_clean_anchors_since_to_head_commit" "yes" \
+  "$(grep -q 'settle_head_iso=' "$_1556_loop" && echo yes || echo no)"
 # The documented knobs must actually appear in --help (AC-4).
 for _knob in POST_CLEAN_SETTLE_QUIET POST_CLEAN_SETTLE_WINDOW POST_CLEAN_POLL; do
   run_test "help_documents_$_knob" "yes" \

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -13974,6 +13974,135 @@ run_test "area_filter_empty_value_exits_2" "2" \
 unset _1562_suite _1562_loop _1562_filtered _1562_guard_out
 
 # ---------------------------------------------------------------------------
+# Area 19: post-clean settle window and updated_at activity (issue #1556)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 19: post-clean settle and updated_at activity (#1556) ==="
+
+# --- AC-4: the settle window is configurable, per platform ------------------
+run_test "settle_config_defined" "yes" \
+  "$(type -t _settle_config_for_platform >/dev/null 2>&1 && echo yes || echo no)"
+run_test "settle_default_platform" "180 60 30" \
+  "$(_settle_config_for_platform pr-agent)"
+# CodeRabbit gets a longer window because it is the platform that posts late.
+run_test "settle_coderabbit_is_longer" "600 180 60" \
+  "$(_settle_config_for_platform coderabbit)"
+run_test "settle_coderabbit_cli_shares_prefix" "600 180 60" \
+  "$(_settle_config_for_platform coderabbit-cli)"
+run_test "settle_generic_env_override" "180 45 30" \
+  "$(POST_CLEAN_SETTLE_QUIET=45 _settle_config_for_platform pr-agent)"
+run_test "settle_per_platform_env_wins" "600 10 10" \
+  "$(CODERABBIT_POST_CLEAN_SETTLE_QUIET=10 _settle_config_for_platform coderabbit)"
+run_test "settle_per_platform_beats_generic" "600 20 20" \
+  "$(POST_CLEAN_SETTLE_QUIET=99 CODERABBIT_POST_CLEAN_SETTLE_QUIET=20 \
+     _settle_config_for_platform coderabbit)"
+run_test "settle_window_override" "300 180 60" \
+  "$(CODERABBIT_POST_CLEAN_SETTLE_WINDOW=300 _settle_config_for_platform coderabbit)"
+# Legacy knob still works so existing callers are not silently retimed.
+run_test "settle_legacy_post_clean_wait" "180 5 5" \
+  "$(POST_CLEAN_WAIT=5 _settle_config_for_platform pr-agent)"
+run_test "settle_specific_beats_legacy" "180 45 30" \
+  "$(POST_CLEAN_WAIT=5 POST_CLEAN_SETTLE_QUIET=45 _settle_config_for_platform pr-agent)"
+# A quiet period longer than the window could never be satisfied, which would
+# burn the whole window and then report settled without ever having been.
+run_test "settle_quiet_clamped_to_window" "60 60 30" \
+  "$(POST_CLEAN_SETTLE_WINDOW=60 POST_CLEAN_SETTLE_QUIET=999 _settle_config_for_platform pr-agent)"
+run_test "settle_junk_falls_back_to_default" "180 60 30" \
+  "$(POST_CLEAN_SETTLE_QUIET=abc _settle_config_for_platform pr-agent)"
+run_test "settle_negative_junk_falls_back" "180 60 30" \
+  "$(POST_CLEAN_SETTLE_QUIET=-5 _settle_config_for_platform pr-agent)"
+
+# --- AC-2 / AC-3: an in-place edit registers as activity --------------------
+run_test "activity_probe_defined" "yes" \
+  "$(type -t _bot_activity_since >/dev/null 2>&1 && echo yes || echo no)"
+
+_1556_bin="$(mktemp -d)"
+_1556_mkgh() {
+  # $1 = issue-comments JSON body for the mock to return
+  cat > "$_1556_bin/gh" <<GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"issues/42/comments"*) cat <<'JSON'
+$1
+JSON
+    ;;
+  *"pulls/42/comments"*) printf '[]\n' ;;
+  *"pulls/42/reviews"*)  printf '[]\n' ;;
+  *) printf '[]\n' ;;
+esac
+GHEOF
+  chmod +x "$_1556_bin/gh"
+}
+
+# The PR #1532 shape exactly: the walkthrough comment was CREATED at 23:23,
+# before the 23:34 HEAD commit, and EDITED at 23:52 to carry the new review.
+# A created_at-only filter cannot see it; that run only survived because
+# CodeRabbit also submitted a formal review, matched separately.
+_1556_mkgh '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2026-01-01T23:23:00Z","updated_at":"2026-01-01T23:52:00Z","body":"walkthrough"}]'
+run_test "activity_1532_shape_edit_counts" "1" \
+  "$(PATH="$_1556_bin:$PATH" _bot_activity_since owner/repo 42 "2026-01-01T23:34:00Z" coderabbitai)"
+
+# The same comment with no edit must NOT count — otherwise every historical
+# comment would look like fresh activity and the quiet timer could never expire.
+_1556_mkgh '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2026-01-01T23:23:00Z","updated_at":"2026-01-01T23:23:00Z","body":"walkthrough"}]'
+run_test "activity_stale_comment_does_not_count" "0" \
+  "$(PATH="$_1556_bin:$PATH" _bot_activity_since owner/repo 42 "2026-01-01T23:34:00Z" coderabbitai)"
+
+# A genuinely new comment counts through created_at, as before.
+_1556_mkgh '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2026-01-01T23:40:00Z","updated_at":"2026-01-01T23:40:00Z","body":"new"}]'
+run_test "activity_new_comment_counts" "1" \
+  "$(PATH="$_1556_bin:$PATH" _bot_activity_since owner/repo 42 "2026-01-01T23:34:00Z" coderabbitai)"
+
+# A comment with no updated_at at all must not crash or false-positive.
+_1556_mkgh '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2026-01-01T23:23:00Z","body":"no-updated-field"}]'
+run_test "activity_missing_updated_at_is_safe" "0" \
+  "$(PATH="$_1556_bin:$PATH" _bot_activity_since owner/repo 42 "2026-01-01T23:34:00Z" coderabbitai)"
+
+# Another bot's activity must not satisfy this bot's quiet period.
+_1556_mkgh '[{"user":{"login":"some-other-bot[bot]"},"created_at":"2026-01-01T23:40:00Z","updated_at":"2026-01-01T23:40:00Z","body":"unrelated"}]'
+run_test "activity_other_bot_ignored" "0" \
+  "$(PATH="$_1556_bin:$PATH" _bot_activity_since owner/repo 42 "2026-01-01T23:34:00Z" coderabbitai)"
+
+# A failed query must report -1, never 0 — a broken probe is not silence.
+cat > "$_1556_bin/gh" <<'GHFAIL'
+#!/usr/bin/env bash
+echo "simulated gh failure" >&2
+exit 1
+GHFAIL
+chmod +x "$_1556_bin/gh"
+run_test "activity_probe_failure_is_minus_one" "-1" \
+  "$(PATH="$_1556_bin:$PATH" _bot_activity_since owner/repo 42 "2026-01-01T23:34:00Z" coderabbitai)"
+
+rm -rf "$_1556_bin"
+unset _1556_bin
+
+# --- AC-1: the loop owns the wait, and the contract says so -----------------
+_1556_loop="$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
+# The activity probe inside run_coderabbit_review must accept updated_at too;
+# that was the specific created_at-only filter reported on PR #1532.
+run_test "coderabbit_activity_probe_accepts_updated_at" "1" \
+  "$(grep_count_or_zero '(.created_at > $since or (.updated_at // .created_at) > $since)' "$_1556_loop")"
+# The verdict must no longer be a single fixed sleep.
+run_test "post_clean_no_longer_single_wait" "0" \
+  "$(grep_count_or_zero '_interruptible_sleep "$post_clean_wait"' "$_1556_loop")"
+run_test "post_clean_emits_settled_field" "yes" \
+  "$(grep -q 'print_kv POST_CLEAN_SETTLED ' "$_1556_loop" && echo yes || echo no)"
+run_test "post_clean_emits_settled_at" "yes" \
+  "$(grep -q 'print_kv POST_CLEAN_SETTLED_AT ' "$_1556_loop" && echo yes || echo no)"
+# An exhausted window must be distinguishable from a genuinely quiet one.
+run_test "post_clean_reports_timeout_distinctly" "yes" \
+  "$(grep -q 'print_kv POST_CLEAN_SETTLE_TIMEOUT 1' "$_1556_loop" && echo yes || echo no)"
+# A failed activity probe must never be counted as silence.
+run_test "post_clean_probe_failure_not_silence" "yes" \
+  "$(grep -q 'not counting this interval as quiet' "$_1556_loop" && echo yes || echo no)"
+# The documented knobs must actually appear in --help (AC-4).
+for _knob in POST_CLEAN_SETTLE_QUIET POST_CLEAN_SETTLE_WINDOW POST_CLEAN_POLL; do
+  run_test "help_documents_$_knob" "yes" \
+    "$(grep -q "$_knob=<" "$_1556_loop" && echo yes || echo no)"
+done
+unset _knob _1556_loop
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Closes #1556.

## The evidence, extended

The issue's table, plus what happened while implementing #1537 and #1562 in the same session:

| PR | Late findings after `RESULT=clean` |
| -- | ---------------------------------- |
| #1532 | 2 |
| #1541 | 3 (three rounds) |
| #1555 | 5 (two rounds, one a re-raise) |
| #1568 | 1 |
| #1569 | 3 |
| **#1570** | **8, across two post-clean rounds — two of them Major** |

**Every one was real.** On #1570 the two Majors were an arithmetic crash and, after fixing it, a 64-bit overflow that made a safety check report `ok` for the exact configuration it exists to reject. Both would have shipped on a `RESULT=clean` verdict.

Nothing escaped only because I was holding a 2–3 minute quiet window and re-querying by hand every time. That is operator discipline standing in for a tooling guarantee — and it does not exist in an unattended run.

## AC-1: the loop owns the wait now

The single 30-second sleep is replaced by a settle loop: poll until the platform has produced **no activity for a full quiet period**, or until the window is exhausted.

- Any activity **resets** the quiet timer — a vendor that just spoke is likely to speak again.
- A **failed** activity query is never counted as silence. That distinction matters: a broken probe returning "0 activity" would have been the worst possible failure mode here.
- With several platforms configured, the **longest** window across them is used. Any of them can be the one that posts late.
- An exhausted window still reports `clean` (no unresolved thread was ever found) but flags `POST_CLEAN_SETTLED=0` + `POST_CLEAN_SETTLE_TIMEOUT=1`. A weaker verdict that says so beats one indistinguishable from a settled one.

## AC-2 / AC-3: in-place edits

CodeRabbit revises its walkthrough comment rather than posting a new one, so it keeps its original `created_at`. The probe in `run_coderabbit_review` selected on `created_at` alone and could not see it.

Area 19 reproduces the PR #1532 shape exactly — created `23:23` (before the `23:34` HEAD commit), edited `23:52` — and asserts the converse too: an **unedited** historic comment must *not* count, or the quiet timer could never expire and every run would burn its full window.

## AC-4: configurable, per platform

| | quiet | window | poll |
| - | ----- | ------ | ---- |
| `coderabbit`, `coderabbit-cli` | 180s | 600s | 60s |
| everything else | 60s | 180s | 30s |

Resolution order: `<PLATFORM>_POST_CLEAN_SETTLE_QUIET` → `POST_CLEAN_SETTLE_QUIET` → per-platform default. `POST_CLEAN_WAIT` still works as the quiet period, so existing callers aren't silently retimed. A quiet period longer than the window is clamped — otherwise it could never be satisfied, and the run would burn the whole window and then report settled without ever having been.

CodeRabbit gets the longer default because it is the platform that posts late; sizing one window for the slowest would tax every other platform.

## Also: the ordering requirement (protocol 92)

The issue's second bullet is a protocol gap, not a code one. Readiness previously required only that the reviewer-loop summary be clean — not that it be *recent*. On PR #1555 the label went on off a thread check that had gone stale during a ~10 minute status poll, with four findings landing in the gap.

Protocol 92 now requires the verdict to be **adjacent** to the label, with a re-query when anything lengthy intervenes, and `POST_CLEAN_SETTLED_AT` makes the gap measurable rather than guessed at.

## The cost, stated plainly

**A clean CodeRabbit run now takes at least 180 seconds longer.** That is the trade this issue asks for, and I think it is clearly the right one — but it is a real regression in loop latency and it compounds across a batch. If that turns out to be too much, `CODERABBIT_POST_CLEAN_SETTLE_QUIET` lowers it without a code change.

Worth noting the interaction with **#1557**: a wider wave already strains the org-wide CodeRabbit quota, and this adds settle time per PR on top.

## Verification

- Full suite: **950 passed, 0 failed**. New Area 19 carries 29 assertions.
- Config resolution verified across precedence, per-platform override, legacy alias, clamping, and junk input.
- Activity probe verified against the #1532 shape, the unedited-comment converse, a missing `updated_at` field, another bot's activity, and a failed query.
- ShellCheck, guard lint, snippet lint, markdownlint, CHANGELOG checks: clean.
- Change-scoped CI selects 6 suites; all pass locally.

**This PR's own reviewer loop is the end-to-end test** — if the settle window works, CodeRabbit's late findings should be caught by the loop rather than by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request readiness checks by requiring a recent, settled clean automated-review result.
  * Edited bot comments are now recognized as new review activity.
  * Unresolved review activity correctly prevents readiness until rechecked.
  * Long review-processing gaps now trigger an additional thread verification.

* **Improvements**
  * Added configurable settling and quiet periods for automated review results.
  * Improved timeout and review-status reporting for greater visibility into readiness decisions.

* **Documentation**
  * Updated workflow guidance and changelog entries to reflect the revised readiness criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Correction: the first implementation was wrong, and this PR proved it

I shipped a quiet-period settle loop, ran it on this PR, and it reported `POST_CLEAN_SETTLED=1` after 180 seconds of measured silence. **Three findings arrived 104 seconds later.**

The timeline is the whole story:

```
00:17:29  HEAD commit
00:18:17  CodeRabbit posts its WALKTHROUGH comment   (48s after push)
00:25:47  reviewer loop finishes platforms, begins settle
00:28:47  settle reports "quiet for 180s" → SETTLED=1, clean
00:30:28  walkthrough EDITED with the real review
00:30:32  formal review submitted — three findings
```

The loop breaks out of its poll on the **first** CodeRabbit artifact and treats it as "reviewed, no findings". That artifact is a walkthrough posted within a minute of the push: it means CodeRabbit *noticed* the PR, not that it finished. The real review came twelve minutes later.

A quiet period cannot bridge that, because **CodeRabbit was completely silent during the entire window — it was still working.** Silence is an absence signal and cannot distinguish "done" from "thinking". That is a flaw in my implementation and equally in the issue's own proposal ("fold a settle-and-recheck into the verdict, with a window measured in minutes").

**The settle now waits for a positive signal**: for CodeRabbit the quiet period does not begin until a review has been *submitted* for the current HEAD. Window widened to 900s to cover the observed gap; quiet lowered to 120s because it now starts from a meaningful point. Off by default for platforms that don't submit formal reviews — for those, silence remains the only signal available.

Verified on the rerun:

```
POST_CLEAN_REQUIRE_REVIEW=1
INFO: awaiting a submitted review for this HEAD, then 120s of silence (max 900s)
INFO: submitted review detected at 30s; quiet period starts now
POST_CLEAN_SETTLED=1
```

Nothing arrived in a 4.5-minute manual window afterwards.

## Review findings (3, all applied)

- **`eval` in the per-platform env lookup** (Major, security). `platform` reaches the function from `--platform` and workflow config, neither validated. I tried to demonstrate execution and **could not** — the `tr` uppercase transform breaks `$( )`, backticks, and redirection break-outs by mangling command names. That is accidental mitigation, not a defence, so the construct is gone: indirect expansion behind an identifier check, with an unusable prefix degrading to the generic knobs rather than failing.
- **Protocol 92 blocked `Result: skipped`** (Major). My checklist required `POST_CLEAN_SETTLED=1` unconditionally, but the settle loop only runs on a clean aggregate — so a legitimately skipped result could never satisfy a condition the same checklist explicitly allows. Scoped to `clean`.
- **CHANGELOG duplication** (Trivial). The readiness entry now links to protocol 92 instead of restating the rule. I kept the incident timelines in the other entries and said why in the thread: they justify the specific numbers and exist nowhere else.

I also found and fixed a bug of my own while addressing these: a jq predicate referenced `.user.login` after piping into `$bots`, where `.` is the array. It worked only by short-circuit when the bot matched; a non-matching author **errored the query**, which `_bot_activity_since` reports as `-1` — indistinguishable from a failed probe. Four occurrences.

## Final state

- Suite: **966 passed, 0 failed**. Area 19 carries **45 assertions**.
- 16 checks: 15 pass, 1 skipped. 0 unresolved threads.
- **Cost, restated:** a clean CodeRabbit run now waits for the submitted review plus 120s, up to 900s. On this PR that was ~150s. Tunable via `CODERABBIT_POST_CLEAN_SETTLE_QUIET` / `_WINDOW` / `_REQUIRE_REVIEW` without a code change.