### PR TITLE
fix(protocol-91): re-check wait comes from the loop settle (#1574)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   settle window exhausted while the platform was active (re-run Step 7; a
   second consecutive timeout escalates as `settle_never_quiet`) — and Step 7
   tells the runner to export the fields (the label is re-validated against
-  the live head one last time before it is applied); the loop emits
+  the live head one last time before it is applied). The settle's "submitted
+  review for this HEAD" anchor read a function-local variable and fell back
+  to `commits/HEAD`, which the GitHub API resolves to the default branch —
+  nine days old on PR #1575 — so any past review satisfied it; it is now the
+  pre-dispatch head. The loop emits
   `POST_CLEAN_HEAD_SHA`
   and Check 0.6 refuses telemetry for a head the PR has moved past, flipping
   the verdict to `RESULT=needs_fixes REASON=head_moved_during_run` with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `pr-review-loop.sh`; Protocol 91 still described the old contract. Step 8a.1
   now consumes the loop's `POST_CLEAN_*` settle fields instead of carrying a
   number, a new readiness Check 0.6 (exit 12) refuses a clean verdict that was
-  never settled or whose platform never submitted a review for the HEAD, and
-  Step 7 tells the runner to export the fields. The loop reports
+  never settled — recheck suppressed, no submitted review for the HEAD, or
+  settle window exhausted while the platform was active (re-run Step 7; a
+  second consecutive timeout escalates as `settle_never_quiet`) — and Step 7
+  tells the runner to export the fields. Area 20 executes the gate with a
+  stubbed `gh` across every state, including a planted inversion — which is
+  how it surfaced that the Check 0.5 fence had carried an unterminated quote
+  on its jq filter since it was written, so the checklist as printed could
+  not have parsed in bash or zsh; fixed here. The loop reports
   `POST_CLEAN_RECHECK_SKIP_REASON` so "nothing can arrive late" is
   distinguishable from "settling was suppressed", and its `--help` now states
   the CodeRabbit defaults the code actually uses (900s window / 120s quiet,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never settled — recheck suppressed, no submitted review for the HEAD, or
   settle window exhausted while the platform was active (re-run Step 7; a
   second consecutive timeout escalates as `settle_never_quiet`) — and Step 7
-  tells the runner to export the fields. Area 20 executes the gate with a
+  tells the runner to export the fields; the loop emits `POST_CLEAN_HEAD_SHA`
+  and Check 0.6 refuses telemetry for a head the PR has moved past. Area 20
+  executes the gate with a
   stubbed `gh` across every state, including a planted inversion — which is
   how it surfaced that the Check 0.5 fence had carried an unterminated quote
   on its jq filter since it was written, so the checklist as printed could

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never settled — recheck suppressed, no submitted review for the HEAD, or
   settle window exhausted while the platform was active (re-run Step 7; a
   second consecutive timeout escalates as `settle_never_quiet`) — and Step 7
-  tells the runner to export the fields; the loop emits `POST_CLEAN_HEAD_SHA`
+  tells the runner to export the fields (the label is re-validated against
+  the live head one last time before it is applied); the loop emits
+  `POST_CLEAN_HEAD_SHA`
   and Check 0.6 refuses telemetry for a head the PR has moved past, flipping
   the verdict to `RESULT=needs_fixes REASON=head_moved_during_run` with a
   named message in the PR summary comment rather than a bare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,37 +38,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Protocol 91's late-thread re-check no longer waits a fixed 10 seconds**
-  (#1574): Step 8a.1 was sized for a `codex-github` posting race, two orders
-  of magnitude short of CodeRabbit, whose findings arrive minutes after the
-  loop goes quiet (12 minutes walkthrough-to-review on PR #1573; 2, 3, 5, 1,
-  3 and 8 late findings across six PRs, all real). #1556 put the wait in
-  `pr-review-loop.sh`; Protocol 91 still described the old contract. Step 8a.1
-  now consumes the loop's `POST_CLEAN_*` settle fields instead of carrying a
-  number, a new readiness Check 0.6 (exit 12) refuses a clean verdict that was
-  never settled — recheck suppressed, no submitted review for the HEAD, or
-  settle window exhausted while the platform was active (re-run Step 7; a
-  second consecutive timeout escalates as `settle_never_quiet`) — and Step 7
-  tells the runner to export the fields (the label is re-validated against
-  the live head one last time before it is applied). The settle's "submitted
-  review for this HEAD" anchor read a function-local variable and fell back
-  to `commits/HEAD`, which the GitHub API resolves to the default branch —
-  nine days old on PR #1575 — so any past review satisfied it; it is now the
-  pre-dispatch head. The loop emits
-  `POST_CLEAN_HEAD_SHA`
-  and Check 0.6 refuses telemetry for a head the PR has moved past, flipping
-  the verdict to `RESULT=needs_fixes REASON=head_moved_during_run` with a
-  named message in the PR summary comment rather than a bare
-  "0 blocking finding(s)". Area 20
-  executes the gate with a
-  stubbed `gh` across every state, including a planted inversion — which is
-  how it surfaced that the Check 0.5 fence had carried an unterminated quote
-  on its jq filter since it was written, so the checklist as printed could
-  not have parsed in bash or zsh; fixed here. The loop reports
-  `POST_CLEAN_RECHECK_SKIP_REASON` so "nothing can arrive late" is
-  distinguishable from "settling was suppressed", and its `--help` now states
-  the CodeRabbit defaults the code actually uses (900s window / 120s quiet,
-  not 600/180). Area 20 of `test-pr-review-loop.sh` pins help-to-code and
-  protocol-to-loop agreement.
+  (#1574): the readiness checklist now consumes `pr-review-loop.sh`'s
+  `POST_CLEAN_*` settle fields instead of carrying a wait of its own. A new
+  Check 0.6 (exit 12) refuses a clean verdict that was never settled — recheck
+  suppressed, no submitted review for the HEAD, settle window exhausted, or
+  `POST_CLEAN_HEAD_SHA` not the live head — and Check 4 re-validates the head
+  immediately before applying `ready-for-human-review`; Step 8a.1 is only the
+  adjacency re-query. The loop reads the PR head before dispatching reviewers,
+  emits `POST_CLEAN_HEAD_SHA` and `POST_CLEAN_RECHECK_SKIP_REASON`, anchors
+  the require-review settle to that head (it previously resolved to the
+  default-branch head, so any past review satisfied it), and reports a head
+  that moved during a clean run as `needs_fixes` / `head_moved_during_run`
+  without counting a fixer cycle. Protocol 92 names the same contract; the
+  loop's `--help` defaults now match its code. The Check 0.5 jq filter's
+  unterminated quote (since `559c5402`) is fixed. Details and measurements:
+  Protocol 91 Step 7 / Check 0.6 / Step 8a.1 and `test-pr-review-loop.sh`
+  Area 20.
 - **A CodeRabbit `RESULT=clean` now means "clean, and still clean after the
   platform went quiet"** (#1556): the loop's post-clean recheck was a single
   30-second wait, far too short for a vendor that posts findings minutes after

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   settle window exhausted while the platform was active (re-run Step 7; a
   second consecutive timeout escalates as `settle_never_quiet`) — and Step 7
   tells the runner to export the fields; the loop emits `POST_CLEAN_HEAD_SHA`
-  and Check 0.6 refuses telemetry for a head the PR has moved past. Area 20
+  and Check 0.6 refuses telemetry for a head the PR has moved past, flipping
+  the verdict to `RESULT=needs_fixes REASON=head_moved_during_run` with a
+  named message in the PR summary comment rather than a bare
+  "0 blocking finding(s)". Area 20
   executes the gate with a
   stubbed `gh` across every state, including a planted inversion — which is
   how it surfaced that the Check 0.5 fence had carried an unterminated quote

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Protocol 91's late-thread re-check no longer waits a fixed 10 seconds**
+  (#1574): Step 8a.1 was sized for a `codex-github` posting race, two orders
+  of magnitude short of CodeRabbit, whose findings arrive minutes after the
+  loop goes quiet (12 minutes walkthrough-to-review on PR #1573; 2, 3, 5, 1,
+  3 and 8 late findings across six PRs, all real). #1556 put the wait in
+  `pr-review-loop.sh`; Protocol 91 still described the old contract. Step 8a.1
+  now consumes the loop's `POST_CLEAN_*` settle fields instead of carrying a
+  number, a new readiness Check 0.6 (exit 12) refuses a clean verdict that was
+  never settled or whose platform never submitted a review for the HEAD, and
+  Step 7 tells the runner to export the fields. The loop reports
+  `POST_CLEAN_RECHECK_SKIP_REASON` so "nothing can arrive late" is
+  distinguishable from "settling was suppressed", and its `--help` now states
+  the CodeRabbit defaults the code actually uses (900s window / 120s quiet,
+  not 600/180). Area 20 of `test-pr-review-loop.sh` pins help-to-code and
+  protocol-to-loop agreement.
 - **A CodeRabbit `RESULT=clean` now means "clean, and still clean after the
   platform went quiet"** (#1556): the loop's post-clean recheck was a single
   30-second wait, far too short for a vendor that posts findings minutes after

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -2319,7 +2319,7 @@ Interpret the result as follows:
 | 9         | Residual gate missing, blocked, or escalated for broad-scope work                                | Keep out of readiness; fix residuals, add `needs-fixes`, or escalate |
 | 10        | Documentation-stage alignment checker infrastructure failure                                     | Retry checker or resolve GitHub/diff read failure |
 | 11        | Complex workflow decision-gate matrix evidence missing or contradictory when applicable          | Keep out of readiness; add `needs-fixes`, complete matrix evidence, and re-run review |
-| 12        | Reviewer-loop clean verdict not settled (Check 0.6): `POST_CLEAN_*` fields absent, recheck suppressed, or platform never submitted a review | Do not label ready; re-run Step 7, export its `POST_CLEAN_*` fields, and re-enter Step 8a |
+| 12        | Reviewer-loop clean verdict not settled (Check 0.6): `POST_CLEAN_*` fields absent, recheck suppressed, platform never submitted a review, or settle window exhausted while the platform was active | Do not label ready; re-run Step 7, export its `POST_CLEAN_*` fields, and re-enter Step 8a; a second consecutive `POST_CLEAN_SETTLE_TIMEOUT=1` escalates (`settle_never_quiet`) |
 
 When adding a new gate to this checklist, allocate the next unused exit code and update this table. Exit codes must not collide.
 
@@ -2519,7 +2519,7 @@ if ! LOOP_SUMMARY_BODY=$(gh pr view "$PR_NUMBER" --json comments --jq '
    | select(.body | test("Automated Reviewer Loop Summary|Reviewer Loop Summary|No blocking PR feedback"))]
   | sort_by(.createdAt)
   | last
-  | .body // ""); then
+  | .body // ""'); then
   echo "ERROR: Cannot verify automated reviewer-loop result — gh pr view failed."
   echo "Retry the GitHub query or resolve the CLI/API failure before applying ready-for-human-review."
   exit 7  # Exit code 7 = "reviewer-loop summary missing or non-clean"
@@ -2571,10 +2571,12 @@ elif [ "${POST_CLEAN_NO_SUBMITTED_REVIEW:-0}" = "1" ]; then
   exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
 else
   # POST_CLEAN_SETTLE_TIMEOUT=1: the platform was still active when the window
-  # ran out. No unresolved thread was found, so the verdict stands, but Step
-  # 8a.1 must wait out one more quiet period before its re-query.
-  echo "⚠️ Settle-state check: verdict is clean but UNSETTLED (window exhausted while the platform was active)."
-  echo "Step 8a.1 will wait ${POST_CLEAN_SETTLE_QUIET_SECONDS:-60}s of quiet before re-querying threads."
+  # ran out. Elapsed time is not quiet time — only the loop's activity-aware
+  # settle can tell the two apart — so this is refused like the other unsettled
+  # states, not re-checked after a sleep of this script's own.
+  echo "ERROR: The reviewer loop reported clean but UNSETTLED: the settle window ran out while the platform was still active (POST_CLEAN_SETTLE_TIMEOUT=1)."
+  echo "Re-run Step 7 so the loop settles again for this HEAD. If that run also reports POST_CLEAN_SETTLE_TIMEOUT=1, escalate to the human with reason settle_never_quiet instead of re-running a third time."
+  exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
 fi
 
 # Check 1: PR is non-draft
@@ -2821,29 +2823,24 @@ a wait of its own (issue #1574).
 
 **Procedure:**
 
-1. **Size the wait from the loop's settle result — never from a fixed number**:
+1. **Do not wait here — the loop already did, or the checklist already sent you back**:
 
-   Check 0.6 already refused the states that cannot be re-checked into safety
-   (`POST_CLEAN_RECHECK` unset or suppressed; `POST_CLEAN_NO_SUBMITTED_REVIEW=1`).
-   What reaches this substep is one of:
+   Check 0.6 refused every unsettled state before the label was applied:
+   `POST_CLEAN_RECHECK` unset or suppressed, `POST_CLEAN_NO_SUBMITTED_REVIEW=1`,
+   and `POST_CLEAN_SETTLE_TIMEOUT=1`. Elapsed time is not quiet time — a bot
+   that edits its walkthrough mid-sleep and posts threads afterwards defeats any
+   fixed sleep — and only the loop's activity-aware settle (quiet timer reset on
+   every platform action) can tell the two apart. So what reaches this substep
+   is one of:
 
-   | Step 7 settle fields                                                 | Wait before the re-query                                                                                                                                             |
-   | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-   | `POST_CLEAN_SETTLED=1`                                               | None. The loop already held the platform's quiet period after a submitted review; the re-query below is the adjacency check Protocol 92 requires, not another wait. |
-   | `POST_CLEAN_SETTLED=0` with `POST_CLEAN_SETTLE_TIMEOUT=1`            | One quiet period: `POST_CLEAN_SETTLE_QUIET_SECONDS` from the same output (the platform was still active when the window ran out).                                   |
-   | `POST_CLEAN_RECHECK=0` with `POST_CLEAN_RECHECK_SKIP_REASON=no_thread_posting_platforms` | Not applicable — no configured platform posts threads. Skip 8a.1.                                                                                                   |
+   | Step 7 settle fields                                                                      | Action                                                                                                                                            |
+   | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | `POST_CLEAN_SETTLED=1`                                                                   | Re-query now. The loop held the platform's quiet period after a submitted review; this re-query is the adjacency check Protocol 92 requires.       |
+   | `POST_CLEAN_RECHECK=0` with `POST_CLEAN_RECHECK_SKIP_REASON=no_thread_posting_platforms` | Not applicable — no configured platform posts threads. Skip 8a.1.                                                                                 |
 
-   <!-- workflow-shell-contract: bash-zsh -->
-   ```bash
-   if [ "${POST_CLEAN_SETTLED:-0}" != "1" ] && [ "${POST_CLEAN_SETTLE_TIMEOUT:-0}" = "1" ]; then
-     echo "Unsettled clean verdict: waiting ${POST_CLEAN_SETTLE_QUIET_SECONDS:-60}s of platform quiet before re-querying threads..."
-     sleep "${POST_CLEAN_SETTLE_QUIET_SECONDS:-60}"
-   fi
-   ```
-
-   The only number in this substep is the one the loop printed. If the loop
-   output is not available in this session, the answer is to re-run Step 7
-   (Check 0.6 enforces that), not to pick a wait.
+   This substep carries no wait and no number. If the loop output is not
+   available in this session, the answer is to re-run Step 7 (Check 0.6
+   enforces that), not to pick a wait.
 
 2. **Re-query review threads**:
 
@@ -2900,7 +2897,7 @@ a wait of its own (issue #1574).
   - If `ready-for-regression not verified` on implementation PR (exit 3 from pre-Check-4 gate): Step 7b was not completed. Apply the label via Step 7b, run Step 8 (CI loop), and re-enter Step 8a from the beginning. This gate is a hard block — `ready-for-human-review` cannot be applied until `ready-for-regression` is verified present.
   - If `unresolved review threads found` (exit 4 from GraphQL pre-Check-4 gate): The GraphQL query returned unresolved bot-authored review threads. Address the findings, push fixes, and re-enter Step 8a from the beginning. This gate is a hard block — `ready-for-human-review` cannot be applied until the GraphQL query confirms all threads are resolved. **Do not rely on self-tracked thread state** — the GraphQL query is the authoritative check.
   - If `late-arriving review threads detected` (exit 6 from Step 8a.1 re-check): Unresolved review threads were discovered after the pre-Check-4 gate — a platform posted after the loop's verdict. Remove `ready-for-human-review`, add `needs-fixes`, and return to Step 7a.
-  - If `reviewer-loop verdict not settled` (exit 12 from Check 0.6): the latest Step 7 output is not in this environment, the loop's recheck was suppressed (`SKIP_POST_CLEAN_RECHECK`, `--compare`), or the platform never submitted a review for this HEAD (`POST_CLEAN_NO_SUBMITTED_REVIEW=1`). Do not apply `ready-for-human-review`. Re-run Step 7 for the current HEAD, export its `POST_CLEAN_*` fields, and re-enter Step 8a from the beginning.
+  - If `reviewer-loop verdict not settled` (exit 12 from Check 0.6): the latest Step 7 output is not in this environment, the loop's recheck was suppressed (`SKIP_POST_CLEAN_RECHECK`, `--compare`), the platform never submitted a review for this HEAD (`POST_CLEAN_NO_SUBMITTED_REVIEW=1`), or the settle window ran out while the platform was still active (`POST_CLEAN_SETTLE_TIMEOUT=1`). Do not apply `ready-for-human-review`. Re-run Step 7 for the current HEAD, export its `POST_CLEAN_*` fields, and re-enter Step 8a from the beginning. If a second consecutive run reports `POST_CLEAN_SETTLE_TIMEOUT=1`, escalate to the human with reason `settle_never_quiet` rather than re-running again.
   - If `reviewer-loop summary missing or non-clean` (exit 7 from Check 0.5): The latest automated reviewer-loop summary comment is absent or its `Result:` line is not `clean`/`skipped`. Do not apply `ready-for-human-review`. For `RESULT=escalate`, `pending_timeout`, `timeout`, `needs_fixes`, or any other non-clean terminal result, escalate or re-enter Step 7 according to the reviewer-loop result.
   - If `documentation-stage alignment mismatch` (exit 8 from Check 3.6):
     the PR is on `spec/*` or `implementation-plan/*` but includes files outside

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1956,12 +1956,13 @@ ISO-8601 timestamp, or a reason word); the pattern below admits nothing else:
 <!-- workflow-shell-contract: bash-zsh -->
 ```bash
 loop_out="$(mktemp)"
+settle_kv="$(mktemp)"
 ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch_name> > "$loop_out" 2>&1
-loop_status=$?
 cat "$loop_out"
+grep -E '^POST_CLEAN_[A-Z_]+=[A-Za-z0-9:_-]*$' "$loop_out" > "$settle_kv" || true
 while IFS='=' read -r key value; do
   export "$key=$value"
-done < <(grep -E '^POST_CLEAN_[A-Z_]+=[A-Za-z0-9:_-]*$' "$loop_out")
+done < "$settle_kv"
 ```
 
 Re-export after every invocation: a fixer cycle re-runs the loop, and the
@@ -2312,12 +2313,13 @@ Interpret the result as follows:
 | 3         | `ready-for-regression` label missing at pre-Check-4 gate                                         | Apply label, re-run Step 8                          |
 | 4         | Unresolved review threads at pre-Check-4 gate                                                    | Resolve threads, push fixes, re-run checklist       |
 | 5         | CI not green at readiness gate                                                                    | Run Step 8 (pr-ci-loop.sh) and fix failing checks   |
-| 6         | Late-arriving async bot threads detected after label application                                  | Remove `ready-for-human-review`, add `needs-fixes`, return to Step 7a |
+| 6         | Late-arriving review threads detected after label application                                     | Remove `ready-for-human-review`, add `needs-fixes`, return to Step 7a |
 | 7         | Latest reviewer-loop summary is missing or has a non-clean terminal result                       | Do not label ready; escalate or return to reviewer loop |
 | 8         | Documentation-stage alignment mismatch on `spec/*` or `implementation-plan/*` PR                 | Remove stale readiness, add/update warning, add `needs-fixes`, correct or escalate |
 | 9         | Residual gate missing, blocked, or escalated for broad-scope work                                | Keep out of readiness; fix residuals, add `needs-fixes`, or escalate |
 | 10        | Documentation-stage alignment checker infrastructure failure                                     | Retry checker or resolve GitHub/diff read failure |
 | 11        | Complex workflow decision-gate matrix evidence missing or contradictory when applicable          | Keep out of readiness; add `needs-fixes`, complete matrix evidence, and re-run review |
+| 12        | Reviewer-loop clean verdict not settled (Check 0.6): `POST_CLEAN_*` fields absent, recheck suppressed, or platform never submitted a review | Do not label ready; re-run Step 7, export its `POST_CLEAN_*` fields, and re-enter Step 8a |
 
 When adding a new gate to this checklist, allocate the next unused exit code and update this table. Exit codes must not collide.
 
@@ -2471,6 +2473,7 @@ application) in the readiness checklist. This sync step never applies
 
 Run this checklist for **every PR**:
 
+<!-- workflow-shell-contract: bash-zsh -->
 ```bash
 PR_NUMBER=<pr_number>
 BRANCH=<branch_name>  # e.g., feature/foo, spec/bar, fix/baz
@@ -2530,7 +2533,7 @@ if [ -z "$LOOP_SUMMARY_BODY" ]; then
     exit 7  # Exit code 7 = "reviewer-loop summary missing or non-clean"
   fi
 fi
-if [ -n "$LOOP_SUMMARY_BODY" ] && echo "$LOOP_SUMMARY_BODY" | grep -Eiq '(^|[*[:space:]])Result:([*[:space:]])*(clean|skipped)([[:space:]—.,;:)]|$)|No blocking PR feedback'; then
+if [ -n "$LOOP_SUMMARY_BODY" ] && echo "$LOOP_SUMMARY_BODY" | grep -Eiq '(^|[ *[:space:]])Result:([ *[:space:]])*(clean|skipped)([ [:space:]—.,;:)]|$)|No blocking PR feedback'; then
   echo "✅ Automated reviewer-loop summary result is clean/skipped."
 elif [ -n "$LOOP_SUMMARY_BODY" ]; then
   echo "ERROR: Latest automated reviewer-loop summary is not clean/skipped."
@@ -2546,7 +2549,7 @@ fi
 # #1555, #1568, #1569 and #1570, every one real — so a clean verdict that was
 # never settled, or whose platform never submitted a review for this HEAD, is
 # refused here rather than re-checked with a wait of this script's own.
-if [ "${REVIEWER_LOOP_SKIPPED_NO_PLATFORMS:-false}" = "true" ]   || { [ -n "$LOOP_SUMMARY_BODY" ] && echo "$LOOP_SUMMARY_BODY" | grep -Eiq '(^|[*[:space:]])Result:([*[:space:]])*skipped([[:space:]—.,;:)]|$)'; }; then
+if [ "${REVIEWER_LOOP_SKIPPED_NO_PLATFORMS:-false}" = "true" ]   || { [ -n "$LOOP_SUMMARY_BODY" ] && echo "$LOOP_SUMMARY_BODY" | grep -Eiq '(^|[ *[:space:]])Result:([ *[:space:]])*skipped([ [:space:]—.,;:)]|$)'; }; then
   echo "✅ Settle-state check not applicable: Step 7 was skipped."
 elif [ -z "${POST_CLEAN_RECHECK:-}" ]; then
   echo "ERROR: Settle state unknown — POST_CLEAN_RECHECK is not set in this environment."
@@ -2677,7 +2680,7 @@ if [ "${COMPLEX_GATE_MATRIX_REQUIRED:-false}" = "true" ]; then
     gh pr edit "$PR_NUMBER" --add-label "needs-fixes"
     exit 11
   fi
-  if printf '%s\n' "$PR_BODY" | grep -Eiq 'complex workflow decision-gate matrix:[[:space:]]*not applicable|complex gate matrix[[:space:]-]+not applicable'; then
+  if printf '%s\n' "$PR_BODY" | grep -Eiq 'complex workflow decision-gate matrix:[ [:space:]]*not applicable|complex gate matrix[ [:space:]-]+not applicable'; then
     echo "ERROR: Complex workflow decision-gate matrix was required, but the PR body says not applicable."
     gh pr edit "$PR_NUMBER" --add-label "needs-fixes"
     exit 11
@@ -2873,6 +2876,7 @@ a wait of its own (issue #1574).
 
 3. **Handle late-arriving threads**:
    - If `$UNRESOLVED_RECHECK -gt 0`: New unresolved threads were discovered. Remove `ready-for-human-review`, add `needs-fixes`, and return to Step 7a to address them:
+     <!-- workflow-shell-contract: bash-zsh -->
      ```bash
      if [ "$UNRESOLVED_RECHECK" -gt 0 ]; then
        echo "⚠️ LATE-ARRIVING THREADS: Re-check detected $UNRESOLVED_RECHECK new unresolved review thread(s)."

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1955,6 +1955,7 @@ ISO-8601 timestamp, or a reason word); the pattern below admits nothing else:
 
 <!-- workflow-shell-contract: bash-zsh -->
 ```bash
+set -euo pipefail
 # Drop settle telemetry from any earlier invocation first. A loop that exits
 # before emitting POST_CLEAN_* (outer timeout, interruption, API failure)
 # must leave Check 0.6 with nothing — not with the previous HEAD's verdict.
@@ -2822,16 +2823,21 @@ fi
 
 # Check 4: ready-for-human-review label NOT yet applied (we are about to apply it)
 HAS_HUMAN_REVIEW_LABEL=$(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" --json labels --jq '.labels[].name' | grep -c "^ready-for-human-review$" || true)
+# Last look before the label (issue #1574): several API-backed gates ran since
+# Check 0.6, and a push during any of them leaves the settled verdict
+# describing a head the PR has left. The label stays on — or goes on — the
+# commit that was reviewed, or not at all; a label already present for a head
+# that has since moved is pulled back.
+if [ "${SETTLE_APPLIES:-1}" -eq 1 ] && ! settle_head_ok; then
+  if [ "$HAS_HUMAN_REVIEW_LABEL" -gt 0 ]; then
+    echo "Removing 'ready-for-human-review': it covers a head that is no longer the PR head."
+    gh pr edit "$PR_NUMBER" --repo "$TARGET_REPO" --remove-label "ready-for-human-review"
+  fi
+  exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
+fi
 if [ "$HAS_HUMAN_REVIEW_LABEL" -gt 0 ]; then
   echo "INFO: PR already has 'ready-for-human-review' label. Skipping re-application."
 else
-  # Last look before the label (issue #1574): several API-backed gates ran
-  # since Check 0.6, and a push during any of them leaves the settled verdict
-  # describing a head the PR has left. The label goes on the commit that was
-  # reviewed or not at all.
-  if [ "${SETTLE_APPLIES:-1}" -eq 1 ]; then
-    settle_head_ok || exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
-  fi
   echo "Applying 'ready-for-human-review' label..."
   gh pr edit "$PR_NUMBER" --repo "$TARGET_REPO" --add-label "ready-for-human-review"
 fi
@@ -2889,6 +2895,7 @@ a wait of its own (issue #1574).
 
    Before running the query, resolve the Codex bot login. Use the value of `CODEX_GITHUB_BOT_LOGIN` if set; otherwise default to `"chatgpt-codex-connector[bot]"` (the default used by `codex-github-reviewer.sh`). Strip the `[bot]` suffix because GraphQL `author.login` values omit it:
 
+   <!-- workflow-shell-contract: bash-zsh -->
    ```bash
    CODEX_BOT_LOGIN="${CODEX_GITHUB_BOT_LOGIN:-chatgpt-codex-connector[bot]}"
    # GraphQL author.login omits the "[bot]" suffix present in REST API logins; strip it.

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1900,7 +1900,11 @@ the PR. The only valid path to `ready-for-human-review` is:
    allowed `skipped` result. When Step 7 is not skipped, it leaves the automated
    reviewer loop summary comment on the PR. When Step 7 is skipped because no
    review platforms are configured, carry `REVIEWER_LOOP_SKIPPED_NO_PLATFORMS=true`
-   into Step 8a so the summary check can verify the explicit skip reason.
+   into Step 8a so the summary check can verify the explicit skip reason. When
+   Step 7 ran, carry its `POST_CLEAN_*` settle fields into Step 8a as well (see
+   "Carry the settle verdict forward" in Step 7): Check 0.6 refuses a clean
+   verdict that was never settled, and Step 8a.1 sizes its re-check from those
+   fields instead of from a number of its own (issue #1574).
 3. When Step 7 followed a fixer push or review-feedback cycle, the runner
    re-issues the GraphQL `reviewThreads` query before Step 7b, as described in
    "Re-query reviewThreads after each push" below.
@@ -1940,6 +1944,29 @@ After running the helper script (it reads `.ai-dev-workflow.yaml` for the platfo
 ```bash
 ./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch_name>
 ```
+
+**Carry the settle verdict forward.** The loop does not merely report `clean`;
+since issue #1556 it settles first — for CodeRabbit it waits for a *submitted*
+review for the current HEAD and then for a quiet period — and reports how that
+went in `POST_CLEAN_*` key=value lines. Step 8a consumes them (Check 0.6 and
+Step 8a.1), so keep the loop output and export those lines into the
+environment the checklist runs in. The values are plain tokens (digits, an
+ISO-8601 timestamp, or a reason word); the pattern below admits nothing else:
+
+<!-- workflow-shell-contract: bash-zsh -->
+```bash
+loop_out="$(mktemp)"
+./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch_name> > "$loop_out" 2>&1
+loop_status=$?
+cat "$loop_out"
+while IFS='=' read -r key value; do
+  export "$key=$value"
+done < <(grep -E '^POST_CLEAN_[A-Z_]+=[A-Za-z0-9:_-]*$' "$loop_out")
+```
+
+Re-export after every invocation: a fixer cycle re-runs the loop, and the
+settle fields belong to the latest HEAD only. A new session that cannot produce
+them re-runs Step 7 rather than guessing (Check 0.6 fails closed).
 
 Interpret the result as follows:
 
@@ -2512,6 +2539,41 @@ elif [ -n "$LOOP_SUMMARY_BODY" ]; then
   exit 7  # Exit code 7 = "reviewer-loop summary missing or non-clean"
 fi
 
+# Check 0.6: a clean verdict must be a SETTLED one (issues #1556 / #1574).
+# The loop's POST_CLEAN_* fields are exported from the latest Step 7 output
+# ("Carry the settle verdict forward"). CodeRabbit posts findings minutes after
+# it first goes quiet — 2, 3, 5, 1, 3 and 8 late findings on PRs #1532, #1541,
+# #1555, #1568, #1569 and #1570, every one real — so a clean verdict that was
+# never settled, or whose platform never submitted a review for this HEAD, is
+# refused here rather than re-checked with a wait of this script's own.
+if [ "${REVIEWER_LOOP_SKIPPED_NO_PLATFORMS:-false}" = "true" ]   || { [ -n "$LOOP_SUMMARY_BODY" ] && echo "$LOOP_SUMMARY_BODY" | grep -Eiq '(^|[*[:space:]])Result:([*[:space:]])*skipped([[:space:]—.,;:)]|$)'; }; then
+  echo "✅ Settle-state check not applicable: Step 7 was skipped."
+elif [ -z "${POST_CLEAN_RECHECK:-}" ]; then
+  echo "ERROR: Settle state unknown — POST_CLEAN_RECHECK is not set in this environment."
+  echo "Re-run Step 7 (pr-review-loop.sh) for the current HEAD and export its POST_CLEAN_* fields before re-entering Step 8a."
+  exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
+elif [ "$POST_CLEAN_RECHECK" = "0" ]; then
+  if [ "${POST_CLEAN_RECHECK_SKIP_REASON:-}" = "no_thread_posting_platforms" ]; then
+    echo "✅ Settle-state check: no configured platform posts review threads; nothing can arrive late."
+  else
+    echo "ERROR: The reviewer loop did not settle its clean verdict (POST_CLEAN_RECHECK_SKIP_REASON=${POST_CLEAN_RECHECK_SKIP_REASON:-unknown})."
+    echo "Re-run Step 7 without SKIP_POST_CLEAN_RECHECK / --compare so the loop settles, then re-enter Step 8a."
+    exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
+  fi
+elif [ "${POST_CLEAN_SETTLED:-0}" = "1" ]; then
+  echo "✅ Settle-state check: verdict settled at ${POST_CLEAN_SETTLED_AT:-<unknown>}."
+elif [ "${POST_CLEAN_NO_SUBMITTED_REVIEW:-0}" = "1" ]; then
+  echo "ERROR: The reviewer loop reported clean, but the platform never submitted a review for this HEAD (POST_CLEAN_NO_SUBMITTED_REVIEW=1)."
+  echo "Its walkthrough comment is not its review. Re-run Step 7 so the loop waits for the submitted review; do not apply ready-for-human-review on this state."
+  exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
+else
+  # POST_CLEAN_SETTLE_TIMEOUT=1: the platform was still active when the window
+  # ran out. No unresolved thread was found, so the verdict stands, but Step
+  # 8a.1 must wait out one more quiet period before its re-query.
+  echo "⚠️ Settle-state check: verdict is clean but UNSETTLED (window exhausted while the platform was active)."
+  echo "Step 8a.1 will wait ${POST_CLEAN_SETTLE_QUIET_SECONDS:-60}s of quiet before re-querying threads."
+fi
+
 # Check 1: PR is non-draft
 DRAFT=$(gh pr view "$PR_NUMBER" --json isDraft --jq '.isDraft')
 if [ "$DRAFT" = "true" ]; then
@@ -2729,26 +2791,56 @@ fi
 echo "✅ Label readiness checklist passed. PR is ready for human review."
 ```
 
-### 8a.1: Async Bot Thread Re-check (Mandatory for async review platforms)
+### 8a.1: Late-Arriving Review Thread Re-check (Mandatory whenever a GitHub review platform is configured)
 
 **When to run this substep:**
 
 - After the label readiness checklist passes (all checks = exit 0)
 - Before proceeding to Step 8b
-- Only when `review.on_draft.github` or `review.on_ready.github` in `.ai-dev-workflow.yaml` includes `codex-github` or any other known async-posting review bot
+- Whenever the effective `review.on_draft.github` or `review.on_ready.github`
+  list (after any `.ai-dev-workflow.local.yaml` override) is non-empty. Skip
+  it only when Step 7 was `skipped` because no platform is configured, or
+  when Check 0.6 reported `no_thread_posting_platforms`.
 
 **Why this substep exists:**
-Review bots like the Codex GitHub App (`codex-github`) post `reviewThreads` asynchronously. A thread can arrive **after** the Step 8a pre-Check-4 GraphQL verification described in the label readiness checklist but **before** or **during** the Step 8c post-label verification. Without an explicit re-check, these late-arriving threads slip through as unresolved and cause the orchestrator's Step 5.1 to redispatch the agent.
+Every GitHub review platform posts `reviewThreads` asynchronously, and not on
+the same clock. The original race — `codex-github` posting a thread that was
+already in flight when the checklist ran — is measured in seconds. CodeRabbit's
+findings do not race the checklist at all; they arrive minutes later. Measured
+on PR #1573: HEAD at 00:17:29, walkthrough comment at 00:18:17, formal review
+with three findings at 00:30:32 — twelve minutes after the walkthrough. Across
+PRs #1532, #1541, #1555, #1568, #1569 and #1570 the same pattern produced 2, 3,
+5, 1, 3 and 8 late findings; every one was real, and on #1570 two were Major.
+A fixed ten-second wait would have caught none of them. The wait therefore
+belongs to the tool: `pr-review-loop.sh` settles before it reports `clean`
+(issue #1556), and this substep reads that result rather than re-implementing
+a wait of its own (issue #1574).
 
 **Procedure:**
 
-1. **Wait for async bot threads**:
+1. **Size the wait from the loop's settle result — never from a fixed number**:
 
+   Check 0.6 already refused the states that cannot be re-checked into safety
+   (`POST_CLEAN_RECHECK` unset or suppressed; `POST_CLEAN_NO_SUBMITTED_REVIEW=1`).
+   What reaches this substep is one of:
+
+   | Step 7 settle fields                                                 | Wait before the re-query                                                                                                                                             |
+   | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | `POST_CLEAN_SETTLED=1`                                               | None. The loop already held the platform's quiet period after a submitted review; the re-query below is the adjacency check Protocol 92 requires, not another wait. |
+   | `POST_CLEAN_SETTLED=0` with `POST_CLEAN_SETTLE_TIMEOUT=1`            | One quiet period: `POST_CLEAN_SETTLE_QUIET_SECONDS` from the same output (the platform was still active when the window ran out).                                   |
+   | `POST_CLEAN_RECHECK=0` with `POST_CLEAN_RECHECK_SKIP_REASON=no_thread_posting_platforms` | Not applicable — no configured platform posts threads. Skip 8a.1.                                                                                                   |
+
+   <!-- workflow-shell-contract: bash-zsh -->
    ```bash
-   # Sleep to allow async bots time to post new threads after the agent's pre-Check-4 query
-   echo "Waiting 10 seconds for async-posting review bots (e.g., codex-github) to post any new threads..."
-   sleep 10
+   if [ "${POST_CLEAN_SETTLED:-0}" != "1" ] && [ "${POST_CLEAN_SETTLE_TIMEOUT:-0}" = "1" ]; then
+     echo "Unsettled clean verdict: waiting ${POST_CLEAN_SETTLE_QUIET_SECONDS:-60}s of platform quiet before re-querying threads..."
+     sleep "${POST_CLEAN_SETTLE_QUIET_SECONDS:-60}"
+   fi
    ```
+
+   The only number in this substep is the one the loop printed. If the loop
+   output is not available in this session, the answer is to re-run Step 7
+   (Check 0.6 enforces that), not to pick a wait.
 
 2. **Re-query review threads**:
 
@@ -2783,17 +2875,17 @@ Review bots like the Codex GitHub App (`codex-github`) post `reviewThreads` asyn
    - If `$UNRESOLVED_RECHECK -gt 0`: New unresolved threads were discovered. Remove `ready-for-human-review`, add `needs-fixes`, and return to Step 7a to address them:
      ```bash
      if [ "$UNRESOLVED_RECHECK" -gt 0 ]; then
-       echo "⚠️ LATE-ARRIVING THREADS: Re-check detected $UNRESOLVED_RECHECK new unresolved thread(s) from async bots."
+       echo "⚠️ LATE-ARRIVING THREADS: Re-check detected $UNRESOLVED_RECHECK new unresolved review thread(s)."
        echo "Removing ready-for-human-review label and returning to Step 7a."
        gh pr edit "$PR_NUMBER" --remove-label "ready-for-human-review"
        gh pr edit "$PR_NUMBER" --add-label "needs-fixes"
        echo "Return to Step 7a to address the newly-discovered threads."
-       exit 6  # Exit code 6 = "late-arriving async bot threads detected"
+       exit 6  # Exit code 6 = "late-arriving review threads detected"
      fi
      ```
    - If `$UNRESOLVED_RECHECK -eq 0`: No new threads found. Continue to Step 8b.
 
-**Note**: This re-check is especially important when `codex-github` is a configured Step 7 review platform. The Codex GitHub App bot response is inherently asynchronous — the re-check adds a safety net to catch race conditions without requiring orchestrator intervention.
+**Note**: The re-query is cheap and is always the last thing before Step 8b. Anything lengthy between the loop's verdict and the label — a CI poll, a sibling merge, a session break — makes it the only check that is still current (`POST_CLEAN_SETTLED_AT` is the instant the verdict was established; the gap is measurable, not guessed). The author allowlist in the query already includes `coderabbitai`; the mechanism was never blind to CodeRabbit — only the fixed wait was mis-sized.
 
 **Interpretation**:
 
@@ -2803,7 +2895,8 @@ Review bots like the Codex GitHub App (`codex-github`) post `reviewThreads` asyn
   - If `missing ready-for-regression` on implementation PR (exit 2 from Check 2): The label has been applied by Check 2. **Do not continue to Check 3/4.** Re-run `pr-ci-loop.sh` (Step 8) first to wait for the e2e/regression workflow triggered by the label. Only re-enter Step 8a after CI is green again. This ensures the e2e/regression check completes before the PR is marked ready.
   - If `ready-for-regression not verified` on implementation PR (exit 3 from pre-Check-4 gate): Step 7b was not completed. Apply the label via Step 7b, run Step 8 (CI loop), and re-enter Step 8a from the beginning. This gate is a hard block — `ready-for-human-review` cannot be applied until `ready-for-regression` is verified present.
   - If `unresolved review threads found` (exit 4 from GraphQL pre-Check-4 gate): The GraphQL query returned unresolved bot-authored review threads. Address the findings, push fixes, and re-enter Step 8a from the beginning. This gate is a hard block — `ready-for-human-review` cannot be applied until the GraphQL query confirms all threads are resolved. **Do not rely on self-tracked thread state** — the GraphQL query is the authoritative check.
-  - If `late-arriving async bot threads detected` (exit 6 from Step 8a.1 re-check): Late-arriving threads from async bots (e.g., `codex-github`) were discovered after the pre-Check-4 gate. Remove `ready-for-human-review`, add `needs-fixes`, and return to Step 7a. This indicates a race condition where the bot posted its thread after the initial verification but before the label was applied.
+  - If `late-arriving review threads detected` (exit 6 from Step 8a.1 re-check): Unresolved review threads were discovered after the pre-Check-4 gate — a platform posted after the loop's verdict. Remove `ready-for-human-review`, add `needs-fixes`, and return to Step 7a.
+  - If `reviewer-loop verdict not settled` (exit 12 from Check 0.6): the latest Step 7 output is not in this environment, the loop's recheck was suppressed (`SKIP_POST_CLEAN_RECHECK`, `--compare`), or the platform never submitted a review for this HEAD (`POST_CLEAN_NO_SUBMITTED_REVIEW=1`). Do not apply `ready-for-human-review`. Re-run Step 7 for the current HEAD, export its `POST_CLEAN_*` fields, and re-enter Step 8a from the beginning.
   - If `reviewer-loop summary missing or non-clean` (exit 7 from Check 0.5): The latest automated reviewer-loop summary comment is absent or its `Result:` line is not `clean`/`skipped`. Do not apply `ready-for-human-review`. For `RESULT=escalate`, `pending_timeout`, `timeout`, `needs_fixes`, or any other non-clean terminal result, escalate or re-enter Step 7 according to the reviewer-loop result.
   - If `documentation-stage alignment mismatch` (exit 8 from Check 3.6):
     the PR is on `spec/*` or `implementation-plan/*` but includes files outside

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -2332,7 +2332,7 @@ Interpret the result as follows:
 | 9         | Residual gate missing, blocked, or escalated for broad-scope work                                | Keep out of readiness; fix residuals, add `needs-fixes`, or escalate |
 | 10        | Documentation-stage alignment checker infrastructure failure                                     | Retry checker or resolve GitHub/diff read failure |
 | 11        | Complex workflow decision-gate matrix evidence missing or contradictory when applicable          | Keep out of readiness; add `needs-fixes`, complete matrix evidence, and re-run review |
-| 12        | Reviewer-loop clean verdict not settled (Check 0.6): `POST_CLEAN_*` fields absent, recheck suppressed, platform never submitted a review, or settle window exhausted while the platform was active | Do not label ready; re-run Step 7, export its `POST_CLEAN_*` fields, and re-enter Step 8a; a second consecutive `POST_CLEAN_SETTLE_TIMEOUT=1` escalates (`settle_never_quiet`) |
+| 12        | Reviewer-loop clean verdict not settled (Check 0.6): `POST_CLEAN_*` fields absent, recheck suppressed, platform never submitted a review, settle window exhausted while the platform was active, or `POST_CLEAN_HEAD_SHA` differs from the live PR head | Do not label ready; re-run Step 7, export its `POST_CLEAN_*` fields, and re-enter Step 8a; a second consecutive `POST_CLEAN_SETTLE_TIMEOUT=1` escalates (`settle_never_quiet`) |
 
 When adding a new gate to this checklist, allocate the next unused exit code and update this table. Exit codes must not collide.
 
@@ -2577,7 +2577,20 @@ elif [ "$POST_CLEAN_RECHECK" = "0" ]; then
     exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
   fi
 elif [ "${POST_CLEAN_SETTLED:-0}" = "1" ]; then
-  echo "✅ Settle-state check: verdict settled at ${POST_CLEAN_SETTLED_AT:-<unknown>}."
+  # A settled verdict is about one head. Anything pushed after Step 7 — a
+  # fixer, another automation, a sibling-merge conflict resolution — leaves
+  # these fields describing a commit the PR has moved past.
+  LIVE_HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" --json headRefOid --jq '.headRefOid')
+  if [ -z "${POST_CLEAN_HEAD_SHA:-}" ]; then
+    echo "ERROR: Settle telemetry is not bound to a head (POST_CLEAN_HEAD_SHA is not set)."
+    echo "Re-run Step 7 with the current pr-review-loop.sh and export its POST_CLEAN_* fields before re-entering Step 8a."
+    exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
+  elif [ "$POST_CLEAN_HEAD_SHA" != "$LIVE_HEAD_SHA" ]; then
+    echo "ERROR: The settled verdict is for head ${POST_CLEAN_HEAD_SHA}, but the PR head is now ${LIVE_HEAD_SHA:-unknown}."
+    echo "Something was pushed after Step 7. Re-run Step 7 for the current HEAD, export its POST_CLEAN_* fields, and re-enter Step 8a."
+    exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
+  fi
+  echo "✅ Settle-state check: verdict settled at ${POST_CLEAN_SETTLED_AT:-<unknown>} for head ${POST_CLEAN_HEAD_SHA}."
 elif [ "${POST_CLEAN_NO_SUBMITTED_REVIEW:-0}" = "1" ]; then
   echo "ERROR: The reviewer loop reported clean, but the platform never submitted a review for this HEAD (POST_CLEAN_NO_SUBMITTED_REVIEW=1)."
   echo "Its walkthrough comment is not its review. Re-run Step 7 so the loop waits for the submitted review; do not apply ready-for-human-review on this state."
@@ -2910,7 +2923,7 @@ a wait of its own (issue #1574).
   - If `ready-for-regression not verified` on implementation PR (exit 3 from pre-Check-4 gate): Step 7b was not completed. Apply the label via Step 7b, run Step 8 (CI loop), and re-enter Step 8a from the beginning. This gate is a hard block — `ready-for-human-review` cannot be applied until `ready-for-regression` is verified present.
   - If `unresolved review threads found` (exit 4 from GraphQL pre-Check-4 gate): The GraphQL query returned unresolved bot-authored review threads. Address the findings, push fixes, and re-enter Step 8a from the beginning. This gate is a hard block — `ready-for-human-review` cannot be applied until the GraphQL query confirms all threads are resolved. **Do not rely on self-tracked thread state** — the GraphQL query is the authoritative check.
   - If `late-arriving review threads detected` (exit 6 from Step 8a.1 re-check): Unresolved review threads were discovered after the pre-Check-4 gate — a platform posted after the loop's verdict. Remove `ready-for-human-review`, add `needs-fixes`, and return to Step 7a.
-  - If `reviewer-loop verdict not settled` (exit 12 from Check 0.6): the latest Step 7 output is not in this environment, the loop's recheck was suppressed (`SKIP_POST_CLEAN_RECHECK`, `--compare`), the platform never submitted a review for this HEAD (`POST_CLEAN_NO_SUBMITTED_REVIEW=1`), or the settle window ran out while the platform was still active (`POST_CLEAN_SETTLE_TIMEOUT=1`). Do not apply `ready-for-human-review`. Re-run Step 7 for the current HEAD, export its `POST_CLEAN_*` fields, and re-enter Step 8a from the beginning. If a second consecutive run reports `POST_CLEAN_SETTLE_TIMEOUT=1`, escalate to the human with reason `settle_never_quiet` rather than re-running again.
+  - If `reviewer-loop verdict not settled` (exit 12 from Check 0.6): the latest Step 7 output is not in this environment, the loop's recheck was suppressed (`SKIP_POST_CLEAN_RECHECK`, `--compare`), the platform never submitted a review for this HEAD (`POST_CLEAN_NO_SUBMITTED_REVIEW=1`), the settle window ran out while the platform was still active (`POST_CLEAN_SETTLE_TIMEOUT=1`), or the verdict describes a head the PR has moved past (`POST_CLEAN_HEAD_SHA` differs from the live head). Do not apply `ready-for-human-review`. Re-run Step 7 for the current HEAD, export its `POST_CLEAN_*` fields, and re-enter Step 8a from the beginning. If a second consecutive run reports `POST_CLEAN_SETTLE_TIMEOUT=1`, escalate to the human with reason `settle_never_quiet` rather than re-running again.
   - If `reviewer-loop summary missing or non-clean` (exit 7 from Check 0.5): The latest automated reviewer-loop summary comment is absent or its `Result:` line is not `clean`/`skipped`. Do not apply `ready-for-human-review`. For `RESULT=escalate`, `pending_timeout`, `timeout`, `needs_fixes`, or any other non-clean terminal result, escalate or re-enter Step 7 according to the reviewer-loop result.
   - If `documentation-stage alignment mismatch` (exit 8 from Check 3.6):
     the PR is on `spec/*` or `implementation-plan/*` but includes files outside

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1955,19 +1955,32 @@ ISO-8601 timestamp, or a reason word); the pattern below admits nothing else:
 
 <!-- workflow-shell-contract: bash-zsh -->
 ```bash
+# Drop settle telemetry from any earlier invocation first. A loop that exits
+# before emitting POST_CLEAN_* (outer timeout, interruption, API failure)
+# must leave Check 0.6 with nothing — not with the previous HEAD's verdict.
+for settle_var in $(env | grep -o '^POST_CLEAN_[A-Z_]*' || true); do
+  unset "$settle_var"
+done
 loop_out="$(mktemp)"
-settle_kv="$(mktemp)"
-./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch_name> > "$loop_out" 2>&1
+loop_status=0
+./scripts/development-workflow/pr-review-loop.sh <pr_number> --branch <branch_name> > "$loop_out" 2>&1 || loop_status=$?
 cat "$loop_out"
-grep -E '^POST_CLEAN_[A-Z_]+=[A-Za-z0-9:_-]*$' "$loop_out" > "$settle_kv" || true
-while IFS='=' read -r key value; do
-  export "$key=$value"
-done < "$settle_kv"
+if [ "$loop_status" -ne 0 ]; then
+  echo "Reviewer loop exited ${loop_status}: act on its RESULT=/REASON= lines (needs_fixes, escalate, ...). Do not enter Step 8a on this run."
+else
+  settle_kv="$(mktemp)"
+  grep -E '^POST_CLEAN_[A-Z_]+=[A-Za-z0-9:_-]*$' "$loop_out" > "$settle_kv" || true
+  while IFS='=' read -r key value; do
+    export "$key=$value"
+  done < "$settle_kv"
+fi
 ```
 
 Re-export after every invocation: a fixer cycle re-runs the loop, and the
-settle fields belong to the latest HEAD only. A new session that cannot produce
-them re-runs Step 7 rather than guessing (Check 0.6 fails closed).
+settle fields belong to the latest HEAD only — which is why the block clears
+them before running and exports nothing on a non-zero exit. A new session that
+cannot produce them re-runs Step 7 rather than guessing (Check 0.6 fails
+closed).
 
 Interpret the result as follows:
 

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -2929,8 +2929,8 @@ a wait of its own (issue #1574).
      if [ "$UNRESOLVED_RECHECK" -gt 0 ]; then
        echo "⚠️ LATE-ARRIVING THREADS: Re-check detected $UNRESOLVED_RECHECK new unresolved review thread(s)."
        echo "Removing ready-for-human-review label and returning to Step 7a."
-       gh pr edit "$PR_NUMBER" --remove-label "ready-for-human-review"
-       gh pr edit "$PR_NUMBER" --add-label "needs-fixes"
+       gh pr edit "$PR_NUMBER" --repo "$TARGET_REPO" --remove-label "ready-for-human-review"
+       gh pr edit "$PR_NUMBER" --repo "$TARGET_REPO" --add-label "needs-fixes"
        echo "Return to Step 7a to address the newly-discovered threads."
        exit 6  # Exit code 6 = "late-arriving review threads detected"
      fi

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1988,6 +1988,7 @@ Interpret the result as follows:
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `clean`                                 | Summary comment posted automatically by the script. If `ADVISORY_LABELS` is non-empty, document a disposition for each advisory finding and update the summary comment before proceeding — see "Advisory finding dispositions" in `93-automated-reviewer-loop-protocol.md`. Then continue to Step 7b (implementation PRs) → Step 8 → **Step 8a** (which contains the mandatory GraphQL `reviewThreads` pre-Check-4 gate). **Do NOT apply `ready-for-human-review` directly from this step** — `clean` from the script only means no blocking inline comments or `CHANGES_REQUESTED` reviews were found; it does NOT mean all review threads are resolved. The GraphQL check in Step 8a is the authoritative gate. |
 | `skipped`                               | Continue to Step 7b (implementation PRs) then Step 8 (no summary comment posted — Step 8c skips the check)                                                                                                                                                                                                                                                                                 |
+| `needs_fixes` with `REASON=head_moved_during_run` | The PR head changed while the reviewers ran, so the clean verdict describes a commit the PR has left. Nothing to fix and no fixer to dispatch: run Step 7 again for the current HEAD. Does not count toward `cycle`.                                                                                                                                                                           |
 | `needs_fixes` and `cycle < max_cycles`  | Summary comment posted or updated automatically by the script. Increment `cycle`, dispatch the matching fixer agent, wait for a push, then run Step 7 again                                                                                                                                                                                                                                |
 | `needs_fixes` and `cycle >= max_cycles` | Summary comment posted or updated automatically by the script. Escalate to human                                                                                                                                                                                                                                                                                                          |
 | `needs_rerun` (exit code 3)             | (Reserved — not currently emitted.) Treat as `escalate` if encountered unexpectedly.                                                                                                                                                                                                                                                                                                      |
@@ -2556,6 +2557,24 @@ elif [ -n "$LOOP_SUMMARY_BODY" ]; then
 fi
 
 # Check 0.6: a clean verdict must be a SETTLED one (issues #1556 / #1574).
+# Every clean verdict is about one head — the one the loop read before it
+# dispatched any reviewer and emitted as POST_CLEAN_HEAD_SHA. Anything pushed
+# after Step 7 — a fixer, another automation, a sibling-merge conflict
+# resolution — leaves the fields describing a commit the PR has moved past.
+settle_head_ok() {
+  LIVE_HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" --json headRefOid --jq '.headRefOid')
+  if [ -z "${POST_CLEAN_HEAD_SHA:-}" ]; then
+    echo "ERROR: Reviewer-loop telemetry is not bound to a head (POST_CLEAN_HEAD_SHA is not set)."
+    echo "Re-run Step 7 with the current pr-review-loop.sh and export its POST_CLEAN_* fields before re-entering Step 8a."
+    return 1
+  fi
+  if [ "$POST_CLEAN_HEAD_SHA" != "$LIVE_HEAD_SHA" ]; then
+    echo "ERROR: The reviewer-loop verdict is for head ${POST_CLEAN_HEAD_SHA}, but the PR head is now ${LIVE_HEAD_SHA:-unknown}."
+    echo "Something was pushed after Step 7. Re-run Step 7 for the current HEAD, export its POST_CLEAN_* fields, and re-enter Step 8a."
+    return 1
+  fi
+  return 0
+}
 # The loop's POST_CLEAN_* fields are exported from the latest Step 7 output
 # ("Carry the settle verdict forward"). CodeRabbit posts findings minutes after
 # it first goes quiet — 2, 3, 5, 1, 3 and 8 late findings on PRs #1532, #1541,
@@ -2570,26 +2589,15 @@ elif [ -z "${POST_CLEAN_RECHECK:-}" ]; then
   exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
 elif [ "$POST_CLEAN_RECHECK" = "0" ]; then
   if [ "${POST_CLEAN_RECHECK_SKIP_REASON:-}" = "no_thread_posting_platforms" ]; then
-    echo "✅ Settle-state check: no configured platform posts review threads; nothing can arrive late."
+    settle_head_ok || exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
+    echo "✅ Settle-state check: no configured platform posts review threads; nothing can arrive late (verdict for head ${POST_CLEAN_HEAD_SHA})."
   else
     echo "ERROR: The reviewer loop did not settle its clean verdict (POST_CLEAN_RECHECK_SKIP_REASON=${POST_CLEAN_RECHECK_SKIP_REASON:-unknown})."
     echo "Re-run Step 7 without SKIP_POST_CLEAN_RECHECK / --compare so the loop settles, then re-enter Step 8a."
     exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
   fi
 elif [ "${POST_CLEAN_SETTLED:-0}" = "1" ]; then
-  # A settled verdict is about one head. Anything pushed after Step 7 — a
-  # fixer, another automation, a sibling-merge conflict resolution — leaves
-  # these fields describing a commit the PR has moved past.
-  LIVE_HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" --json headRefOid --jq '.headRefOid')
-  if [ -z "${POST_CLEAN_HEAD_SHA:-}" ]; then
-    echo "ERROR: Settle telemetry is not bound to a head (POST_CLEAN_HEAD_SHA is not set)."
-    echo "Re-run Step 7 with the current pr-review-loop.sh and export its POST_CLEAN_* fields before re-entering Step 8a."
-    exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
-  elif [ "$POST_CLEAN_HEAD_SHA" != "$LIVE_HEAD_SHA" ]; then
-    echo "ERROR: The settled verdict is for head ${POST_CLEAN_HEAD_SHA}, but the PR head is now ${LIVE_HEAD_SHA:-unknown}."
-    echo "Something was pushed after Step 7. Re-run Step 7 for the current HEAD, export its POST_CLEAN_* fields, and re-enter Step 8a."
-    exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
-  fi
+  settle_head_ok || exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
   echo "✅ Settle-state check: verdict settled at ${POST_CLEAN_SETTLED_AT:-<unknown>} for head ${POST_CLEAN_HEAD_SHA}."
 elif [ "${POST_CLEAN_NO_SUBMITTED_REVIEW:-0}" = "1" ]; then
   echo "ERROR: The reviewer loop reported clean, but the platform never submitted a review for this HEAD (POST_CLEAN_NO_SUBMITTED_REVIEW=1)."
@@ -2878,6 +2886,7 @@ a wait of its own (issue #1574).
    CODEX_BOT_LOGIN="${CODEX_BOT_LOGIN%\[bot\]}"
    ```
 
+   <!-- workflow-shell-contract: bash-zsh -->
    ```bash
    JQ_FILTER="[.data.repository.pullRequest.reviewThreads.nodes[]
          | select(.isResolved == false)

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -2581,7 +2581,9 @@ settle_head_ok() {
 # #1555, #1568, #1569 and #1570, every one real — so a clean verdict that was
 # never settled, or whose platform never submitted a review for this HEAD, is
 # refused here rather than re-checked with a wait of this script's own.
+SETTLE_APPLIES=1
 if [ "${REVIEWER_LOOP_SKIPPED_NO_PLATFORMS:-false}" = "true" ]   || { [ -n "$LOOP_SUMMARY_BODY" ] && echo "$LOOP_SUMMARY_BODY" | grep -Eiq '(^|[ *[:space:]])Result:([ *[:space:]])*skipped([ [:space:]—.,;:)]|$)'; }; then
+  SETTLE_APPLIES=0
   echo "✅ Settle-state check not applicable: Step 7 was skipped."
 elif [ -z "${POST_CLEAN_RECHECK:-}" ]; then
   echo "ERROR: Settle state unknown — POST_CLEAN_RECHECK is not set in this environment."
@@ -2823,6 +2825,13 @@ HAS_HUMAN_REVIEW_LABEL=$(gh pr view "$PR_NUMBER" --repo "$TARGET_REPO" --json la
 if [ "$HAS_HUMAN_REVIEW_LABEL" -gt 0 ]; then
   echo "INFO: PR already has 'ready-for-human-review' label. Skipping re-application."
 else
+  # Last look before the label (issue #1574): several API-backed gates ran
+  # since Check 0.6, and a push during any of them leaves the settled verdict
+  # describing a head the PR has left. The label goes on the commit that was
+  # reviewed or not at all.
+  if [ "${SETTLE_APPLIES:-1}" -eq 1 ]; then
+    settle_head_ok || exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
+  fi
   echo "Applying 'ready-for-human-review' label..."
   gh pr edit "$PR_NUMBER" --repo "$TARGET_REPO" --add-label "ready-for-human-review"
 fi

--- a/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -60,10 +60,14 @@ Apply this label when **all** of the following are true:
       `POST_CLEAN_SETTLED_AT=<iso8601>` for exactly this: it is the instant the
       verdict was established, so the gap is measurable rather than guessed at.
 - [ ] **When Step 7 returned `clean`**, the reviewer loop also reported
-      `POST_CLEAN_SETTLED=1`. This condition does not apply to
-      `Result: skipped`: the settle loop only runs on a clean aggregate, so a
-      legitimately skipped result never emits `POST_CLEAN_SETTLED=1` and must
-      not be blocked for its absence.
+      `POST_CLEAN_SETTLED=1` — or, when no configured platform posts review
+      threads (PR-Agent, Haystack), `POST_CLEAN_RECHECK=0` with
+      `POST_CLEAN_RECHECK_SKIP_REASON=no_thread_posting_platforms`, since
+      there is nothing that can arrive late to settle. In both cases
+      `POST_CLEAN_HEAD_SHA` must equal the live PR head. This condition does
+      not apply to `Result: skipped`: the settle loop only runs on a clean
+      aggregate, so a legitimately skipped result never emits
+      `POST_CLEAN_SETTLED=1` and must not be blocked for its absence.
 
       `POST_CLEAN_SETTLED=0` (with `POST_CLEAN_SETTLE_TIMEOUT=1`) means the
       window was exhausted while the platform was still active, or — with

--- a/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -78,8 +78,9 @@ Apply this label when **all** of the following are true:
       unset or suppressed (`POST_CLEAN_RECHECK_SKIP_REASON` other than
       `no_thread_posting_platforms`), whose platform never submitted a review
       (`POST_CLEAN_NO_SUBMITTED_REVIEW=1`), or whose settle window ran out
-      (`POST_CLEAN_SETTLE_TIMEOUT=1`); the runner re-runs Step 7, and a second
-      consecutive timeout escalates as `settle_never_quiet`. Step 8a.1 is then
+      (`POST_CLEAN_SETTLE_TIMEOUT=1`), or whose `POST_CLEAN_HEAD_SHA` is not
+      the live PR head; the runner re-runs Step 7, and a second consecutive
+      timeout escalates as `settle_never_quiet`. Step 8a.1 is then
       only the adjacency re-query, timed by `POST_CLEAN_SETTLED_AT`. The loop's
       `--help` lists the per-platform defaults; the protocols do not repeat
       them.

--- a/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -68,19 +68,21 @@ Apply this label when **all** of the following are true:
       `POST_CLEAN_SETTLED=0` (with `POST_CLEAN_SETTLE_TIMEOUT=1`) means the
       window was exhausted while the platform was still active, or — with
       `POST_CLEAN_NO_SUBMITTED_REVIEW=1` — that it never submitted a review for
-      this HEAD at all. No unresolved thread was found in either case, so the
-      verdict stands, but it is weaker than a settled one. Treat it as a prompt
-      to re-query threads immediately before labelling rather than as a pass.
+      this HEAD at all. No unresolved thread was found in either case, but
+      neither is a pass: the verdict is not usable for this label until a
+      re-run of Step 7 reports `POST_CLEAN_SETTLED=1`.
 
-      Protocol 91 is the only place this is enforced, and it carries no number
-      of its own (issue #1574): Check 0.6 of the readiness checklist refuses a
-      clean verdict whose `POST_CLEAN_RECHECK` is unset or suppressed
-      (`POST_CLEAN_RECHECK_SKIP_REASON` other than
-      `no_thread_posting_platforms`) or whose platform never submitted a
-      review (`POST_CLEAN_NO_SUBMITTED_REVIEW=1`), and Step 8a.1 sizes its
-      final re-query wait from `POST_CLEAN_SETTLE_TIMEOUT` and
-      `POST_CLEAN_SETTLE_QUIET_SECONDS`. The loop's `--help` lists the
-      per-platform defaults; the protocols do not repeat them.
+      Protocol 91 is the only place this is enforced, and it carries no wait
+      and no number of its own (issue #1574): Check 0.6 of the readiness
+      checklist (exit 12) refuses a clean verdict whose `POST_CLEAN_RECHECK` is
+      unset or suppressed (`POST_CLEAN_RECHECK_SKIP_REASON` other than
+      `no_thread_posting_platforms`), whose platform never submitted a review
+      (`POST_CLEAN_NO_SUBMITTED_REVIEW=1`), or whose settle window ran out
+      (`POST_CLEAN_SETTLE_TIMEOUT=1`); the runner re-runs Step 7, and a second
+      consecutive timeout escalates as `settle_never_quiet`. Step 8a.1 is then
+      only the adjacency re-query, timed by `POST_CLEAN_SETTLED_AT`. The loop's
+      `--help` lists the per-platform defaults; the protocols do not repeat
+      them.
 - [ ] Every configured automated PR reviewer has no blocking PR feedback (or is skipped)
 - [ ] All feedback from a previous human review cycle has been addressed
 - [ ] For `spec/*` and `implementation-plan/*` PRs,

--- a/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -71,6 +71,16 @@ Apply this label when **all** of the following are true:
       this HEAD at all. No unresolved thread was found in either case, so the
       verdict stands, but it is weaker than a settled one. Treat it as a prompt
       to re-query threads immediately before labelling rather than as a pass.
+
+      Protocol 91 is the only place this is enforced, and it carries no number
+      of its own (issue #1574): Check 0.6 of the readiness checklist refuses a
+      clean verdict whose `POST_CLEAN_RECHECK` is unset or suppressed
+      (`POST_CLEAN_RECHECK_SKIP_REASON` other than
+      `no_thread_posting_platforms`) or whose platform never submitted a
+      review (`POST_CLEAN_NO_SUBMITTED_REVIEW=1`), and Step 8a.1 sizes its
+      final re-query wait from `POST_CLEAN_SETTLE_TIMEOUT` and
+      `POST_CLEAN_SETTLE_QUIET_SECONDS`. The loop's `--help` lists the
+      per-platform defaults; the protocols do not repeat them.
 - [ ] Every configured automated PR reviewer has no blocking PR feedback (or is skipped)
 - [ ] All feedback from a previous human review cycle has been addressed
 - [ ] For `spec/*` and `implementation-plan/*` PRs,

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -7870,7 +7870,18 @@ _post_review_summary() {
       fi
       ;;
     needs_fixes)
-      result_line="${blocking} blocking finding(s) require fixes"
+      case "$reason" in
+        head_moved_during_run)
+          # This is the only needs_fixes reason with a zero blocking count
+          # (issue #1574): every reviewer was clean, but the PR head moved
+          # while they ran, so "N blocking finding(s)" would misreport why
+          # this cycle is not clean. Name the reason explicitly instead.
+          result_line="needs_fixes (head_moved_during_run) — the clean verdict was for a HEAD the PR has since moved past; nothing to fix, re-run Step 7 for the current HEAD"
+          ;;
+        *)
+          result_line="${blocking} blocking finding(s) require fixes"
+          ;;
+      esac
       ;;
     escalate)
       result_line="escalated (${reason:-unknown})"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -6698,11 +6698,17 @@ reviewer_loop_cycle_count_unavailable_should_escalate() {
 reviewer_loop_persist_failure_should_escalate() {
   local post_summary_exit_code="$1"
   local result="$2"
+  local reason="${3:-}"
 
   case "$result" in
     needs_fixes|needs_rerun) : ;;
     *) return 1 ;;
   esac
+  # A head that moved during a clean run dispatches no fixer and is not
+  # counted as a cycle, so an unpersisted ledger cannot let an unbounded
+  # dispatch through; a transient comment failure there is not a reason to
+  # pull a human in (issue #1574).
+  [ "$reason" != "head_moved_during_run" ] || return 1
 
   [ "$post_summary_exit_code" -ne 0 ]
 }
@@ -8622,7 +8628,7 @@ if [ "$aggregate_result" != "skipped" ]; then
     "$phase_after_clean_started" "$phase_after_clean_net_new_blocker" \
     "$phase_after_clean_blocking_platform" "$pre_after_clean_only" \
     "$advisory_checks_section" || _post_summary_exit=$?
-  if reviewer_loop_persist_failure_should_escalate "$_post_summary_exit" "$aggregate_result"; then
+  if reviewer_loop_persist_failure_should_escalate "$_post_summary_exit" "$aggregate_result" "$aggregate_reason"; then
     echo "WARN: reviewer-loop summary comment could not be persisted for a dispatch-triggering result ($aggregate_result) — escalating (ledger_persist_failed) rather than letting an uncounted fixer/retry dispatch happen" >&2
     aggregate_result="escalate"
     aggregate_reason="ledger_persist_failed"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -6531,6 +6531,9 @@ reviewer_loop_history_entries_count() {
         [
           .entries[]?
           | select((.result // "") == "needs_fixes" or (.result // "") == "needs_rerun")
+          # A head that moved during an otherwise clean run dispatches no
+          # fixer; it is a re-run, not a cycle (issue #1574).
+          | select((.reason // "") != "head_moved_during_run")
         ] as $qualifying
         | ($qualifying
             | [.[] | select((.head_sha // "") | length > 0) | ((.head_sha // "") + "|" + (.result // ""))]
@@ -8547,7 +8550,12 @@ fi
 # then the lifetime ceiling (max_total_cycles_exceeded — the structural
 # backstop). Both counts fail together (-1/-1) when the ledger could not be
 # read, so the unavailable check only needs to inspect one of them.
-if reviewer_loop_cycle_count_unavailable_should_escalate "$lifetime_cycle_count" "$aggregate_result"; then
+if [ "$aggregate_reason" = "head_moved_during_run" ]; then
+  # Not a fixer cycle: the reviewers were clean, the PR simply moved. The
+  # caller re-runs the loop; neither cap applies and the ledger does not
+  # count it (reviewer_loop_history_entries_count excludes this reason).
+  :
+elif reviewer_loop_cycle_count_unavailable_should_escalate "$lifetime_cycle_count" "$aggregate_result"; then
   echo "WARN: reviewer cycle counts could not be read (ledger unavailable after retries) with aggregate_result=$aggregate_result — escalating (cycle_count_unavailable) rather than allowing an unbounded number of unverifiable retries" >&2
   aggregate_result="escalate"
   aggregate_reason="cycle_count_unavailable"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -502,6 +502,9 @@ Outputs stable key=value lines including:
   PHASE_AFTER_CLEAN_SKIP_REASON=<result> (emitted when the phase never starts)
   PHASE_AFTER_CLEAN_NET_NEW_BLOCKER=0|1 (compatibility alias for READY_PHASE_NET_NEW_BLOCKER)
   POST_CLEAN_RECHECK=0|1 (1 when the post-clean settle-and-recheck ran)
+  POST_CLEAN_RECHECK_SKIP_REASON=<reason> (present only when POST_CLEAN_RECHECK=0: not_clean,
+    compare_mode, skip_env, no_thread_posting_platforms, or no_pr_number — so a caller can tell
+    "nothing to settle" from "settling was suppressed" (issue #1574))
   POST_CLEAN_SETTLED=0|1 (1 when the platform went quiet for the full required period; 0 when the
     window was exhausted while it was still active — the verdict is still clean, but weaker)
   POST_CLEAN_SETTLE_TIMEOUT=1 (present only when the window was exhausted before silence)
@@ -563,11 +566,12 @@ Outputs stable key=value lines including:
 
 Environment variables:
   POST_CLEAN_SETTLE_QUIET=<sec>      Consecutive seconds of platform silence required before a clean verdict is
-                                     called settled (issue #1556). Defaults per platform: 180 for coderabbit /
+                                     called settled (issue #1556). Defaults per platform: 120 for coderabbit /
                                      coderabbit-cli, 60 otherwise. Any platform activity — including an in-place
                                      EDIT of an existing bot comment — resets this timer.
-  POST_CLEAN_SETTLE_WINDOW=<sec>     Maximum total time to spend settling (default: 600 for coderabbit /
-                                     coderabbit-cli, 180 otherwise). If the window is exhausted while the platform
+  POST_CLEAN_SETTLE_WINDOW=<sec>     Maximum total time to spend settling (default: 900 for coderabbit /
+                                     coderabbit-cli, 180 otherwise — sized from the measured ~12 min
+                                     walkthrough-to-review gap on PR #1573). If the window is exhausted while the platform
                                      is still active, the verdict stays clean but is reported UNSETTLED via
                                      POST_CLEAN_SETTLED=0 and POST_CLEAN_SETTLE_TIMEOUT=1.
   POST_CLEAN_POLL=<seconds>          Interval between settle re-checks (default: 60 for coderabbit /
@@ -8432,6 +8436,20 @@ if [ "$aggregate_result" = "clean" ] \
   print_kv LATE_THREADS_FOUND "$late_thread_count"
 else
   print_kv POST_CLEAN_RECHECK 0
+  # Say WHY the recheck did not run (issue #1574). Protocol 91's readiness
+  # checklist treats no_thread_posting_platforms as "nothing could arrive late"
+  # and every other reason as "the verdict was never settled — re-run Step 7".
+  if [ "$aggregate_result" != "clean" ]; then
+    print_kv POST_CLEAN_RECHECK_SKIP_REASON not_clean
+  elif [ "$compare_mode" -ne 0 ]; then
+    print_kv POST_CLEAN_RECHECK_SKIP_REASON compare_mode
+  elif [ "${SKIP_POST_CLEAN_RECHECK:-0}" = "1" ]; then
+    print_kv POST_CLEAN_RECHECK_SKIP_REASON skip_env
+  elif [ "${#unresolved_bot_logins[@]}" -eq 0 ]; then
+    print_kv POST_CLEAN_RECHECK_SKIP_REASON no_thread_posting_platforms
+  else
+    print_kv POST_CLEAN_RECHECK_SKIP_REASON no_pr_number
+  fi
   # Emit LATE_THREADS_FOUND=0 on skipped paths so consumers can always rely on
   # the field being present, regardless of whether the recheck ran.
   print_kv LATE_THREADS_FOUND 0

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -514,6 +514,8 @@ Outputs stable key=value lines including:
     never counted as silence)
   POST_CLEAN_SETTLED_AT=<iso8601> (when the verdict was established — a caller that inserts a long
     poll between this and the readiness label is acting on a stale check)
+  POST_CLEAN_HEAD_SHA=<sha> (the PR head the settle describes; Protocol 91 Check 0.6 refuses the
+    verdict when the live head differs — a push after Step 7 voids it — issue #1574)
   LATE_THREADS_FOUND=<N> (count of newly-found unresolved threads; -1 on audit failure; 0 when POST_CLEAN_RECHECK=0)
   RUN_ID=<id> (this invocation's resolved orchestration-run identifier — either PR_REVIEW_LOOP_RUN_ID
                   verbatim, or a freshly generated "auto-<epoch>-<pid>-<random>" id when unset. See
@@ -8322,6 +8324,10 @@ if [ "$aggregate_result" = "clean" ] \
   settle_head_iso="$(gh api "repos/$(repo_slug)/commits/${head_sha:-HEAD}" --jq '.commit.committer.date // empty' 2>/dev/null)"
   [ -n "$settle_head_iso" ] || settle_head_iso="$(date -u -v-1H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '1 hour ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
   settle_review_seen=0
+  # The head this settle is about. Emitted as POST_CLEAN_HEAD_SHA so Protocol
+  # 91 Check 0.6 can refuse telemetry that describes a commit the PR has since
+  # moved past (a fix pushed between Step 7 and Step 8a) — issue #1574.
+  settle_head_sha="$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)"
 
   late_thread_count=0
   settle_elapsed=0
@@ -8433,6 +8439,7 @@ if [ "$aggregate_result" = "clean" ] \
   # between this timestamp and the readiness label is acting on a stale check —
   # see the "adjacent to the readiness decision" note in the reviewer-loop docs.
   print_kv POST_CLEAN_SETTLED_AT "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  print_kv POST_CLEAN_HEAD_SHA "$settle_head_sha"
   print_kv LATE_THREADS_FOUND "$late_thread_count"
 else
   print_kv POST_CLEAN_RECHECK 0

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -514,8 +514,12 @@ Outputs stable key=value lines including:
     never counted as silence)
   POST_CLEAN_SETTLED_AT=<iso8601> (when the verdict was established — a caller that inserts a long
     poll between this and the readiness label is acting on a stale check)
-  POST_CLEAN_HEAD_SHA=<sha> (the PR head the settle describes; Protocol 91 Check 0.6 refuses the
-    verdict when the live head differs — a push after Step 7 voids it — issue #1574)
+  POST_CLEAN_HEAD_SHA=<sha> (the PR head this run reviewed, read BEFORE any reviewer was dispatched and
+    emitted on every clean path; Protocol 91 Check 0.6 refuses the verdict when the live head differs —
+    a push after Step 7 voids it — issue #1574)
+  RESULT=needs_fixes REASON=head_moved_during_run (the PR head changed while the reviewers ran, so
+    the clean verdict describes a commit the PR has left; nothing to fix — re-run the loop for the
+    current HEAD)
   LATE_THREADS_FOUND=<N> (count of newly-found unresolved threads; -1 on audit failure; 0 when POST_CLEAN_RECHECK=0)
   RUN_ID=<id> (this invocation's resolved orchestration-run identifier — either PR_REVIEW_LOOP_RUN_ID
                   verbatim, or a freshly generated "auto-<epoch>-<pid>-<random>" id when unset. See
@@ -7558,6 +7562,19 @@ total_suggestion_count=0
 aggregate_advisory_labels=""
 reviewer_failed_required=0
 declare -a compare_verdicts=()
+# The head this run reviews, captured BEFORE any reviewer is dispatched
+# (issue #1574). Every verdict below describes this commit; the settle emits it
+# as POST_CLEAN_HEAD_SHA, and the head-move guard after the settle turns a
+# clean verdict into needs_fixes/head_moved_during_run if the PR moved away
+# from it while the loop ran. Reading it later would bind the verdict to
+# whatever was pushed in the meantime.
+loop_head_sha=""
+if [ -n "$pr_number" ]; then
+  if ! loop_head_sha="$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid' 2>/dev/null)"; then
+    loop_head_sha=""
+    echo "WARN: could not read the PR head before dispatching reviewers; POST_CLEAN_HEAD_SHA will be empty and Protocol 91 Check 0.6 will refuse this verdict" >&2
+  fi
+fi
 # Per-platform result tokens for the PR summary comment.
 # Each entry is "platform_name:display_token" (e.g. "haystack:unavailable").
 declare -a platform_result_tokens=()
@@ -8327,12 +8344,7 @@ if [ "$aggregate_result" = "clean" ] \
   # The head this settle is about. Emitted as POST_CLEAN_HEAD_SHA so Protocol
   # 91 Check 0.6 can refuse telemetry that describes a commit the PR has since
   # moved past (a fix pushed between Step 7 and Step 8a) — issue #1574.
-  if ! settle_head_sha="$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid' 2>/dev/null)"; then
-    # An unbound settle is refused by Check 0.6 (fail-closed); say so here
-    # rather than letting an empty field pass silently.
-    settle_head_sha=""
-    echo "WARN: post-clean settle — could not read the PR head; POST_CLEAN_HEAD_SHA will be empty and Protocol 91 Check 0.6 will refuse this verdict" >&2
-  fi
+  settle_head_sha="$loop_head_sha"
 
   late_thread_count=0
   settle_elapsed=0
@@ -8465,6 +8477,23 @@ else
   # Emit LATE_THREADS_FOUND=0 on skipped paths so consumers can always rely on
   # the field being present, regardless of whether the recheck ran.
   print_kv LATE_THREADS_FOUND 0
+  # The head binding applies to every clean verdict, not only settled ones:
+  # a no-thread-platform run is just as stale once the PR moves.
+  print_kv POST_CLEAN_HEAD_SHA "$loop_head_sha"
+fi
+
+# Head-move guard (#1574): a push that lands while the reviewers run leaves
+# the clean verdict describing a commit the PR no longer sits on. Refuse it
+# here, before the summary records it, rather than letting Check 0.6 compare
+# a head that was read after the fact.
+if [ "$aggregate_result" = "clean" ] && [ -n "$pr_number" ] && [ -n "$loop_head_sha" ]; then
+  live_head_sha=""
+  if live_head_sha="$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid' 2>/dev/null)" \
+    && [ -n "$live_head_sha" ] && [ "$live_head_sha" != "$loop_head_sha" ]; then
+    echo "WARN: PR head moved from ${loop_head_sha} to ${live_head_sha} while this loop ran; the clean verdict describes the old head — re-run the loop for the current HEAD" >&2
+    aggregate_result="needs_fixes"
+    aggregate_reason="head_moved_during_run"
+  fi
 fi
 
 if [ "$phase_after_clean_enabled" -eq 1 ] && [ "$phase_after_clean_started" -eq 0 ]; then

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -8327,7 +8327,12 @@ if [ "$aggregate_result" = "clean" ] \
   # The head this settle is about. Emitted as POST_CLEAN_HEAD_SHA so Protocol
   # 91 Check 0.6 can refuse telemetry that describes a commit the PR has since
   # moved past (a fix pushed between Step 7 and Step 8a) — issue #1574.
-  settle_head_sha="$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)"
+  if ! settle_head_sha="$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid' 2>/dev/null)"; then
+    # An unbound settle is refused by Check 0.6 (fail-closed); say so here
+    # rather than letting an empty field pass silently.
+    settle_head_sha=""
+    echo "WARN: post-clean settle — could not read the PR head; POST_CLEAN_HEAD_SHA will be empty and Protocol 91 Check 0.6 will refuse this verdict" >&2
+  fi
 
   late_thread_count=0
   settle_elapsed=0

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -8358,8 +8358,23 @@ if [ "$aggregate_result" = "clean" ] \
   # since_iso for the settle probes is the HEAD commit time, not "now": a review
   # submitted between the loop starting and the settle beginning still counts as
   # this HEAD's review, and anchoring to "now" would wait for a second one.
-  settle_head_iso="$(gh api "repos/$(repo_slug)/commits/${head_sha:-HEAD}" --jq '.commit.committer.date // empty' 2>/dev/null)"
-  [ -n "$settle_head_iso" ] || settle_head_iso="$(date -u -v-1H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '1 hour ago' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo '1970-01-01T00:00:00Z')"
+  # Anchor to the head this run reviewed, captured before dispatch. The
+  # previous form, commits/${head_sha:-HEAD}, read a variable that is only
+  # ever function-local, so at this scope it asked the API for commits/HEAD —
+  # which GitHub resolves to the DEFAULT BRANCH head. Measured on PR #1575:
+  # that anchor was nine days old, so any review CodeRabbit had ever
+  # submitted satisfied "a submitted review for this HEAD" and the
+  # require-review settle waited for nothing. When the head is unknown, the
+  # anchor is now: a review must land after this point (conservative —
+  # Check 0.6 refuses the unbound verdict anyway).
+  settle_head_iso=""
+  if [ -n "$loop_head_sha" ]; then
+    settle_head_iso="$(gh api "repos/$(repo_slug)/commits/${loop_head_sha}" --jq '.commit.committer.date // empty' 2>/dev/null)" || settle_head_iso=""
+  fi
+  if [ -z "$settle_head_iso" ]; then
+    settle_head_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    echo "WARN: post-clean settle — head commit time unavailable; a submitted review must land after ${settle_head_iso} to count" >&2
+  fi
   settle_review_seen=0
   # The head this settle is about. Emitted as POST_CLEAN_HEAD_SHA so Protocol
   # 91 Check 0.6 can refuse telemetry that describes a commit the PR has since

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -8359,7 +8359,7 @@ if [ "$aggregate_result" = "clean" ] \
   # submitted between the loop starting and the settle beginning still counts as
   # this HEAD's review, and anchoring to "now" would wait for a second one.
   # Anchor to the head this run reviewed, captured before dispatch. The
-  # previous form, commits/${head_sha:-HEAD}, read a variable that is only
+  # previous form read head_sha with a HEAD fallback, and head_sha is only
   # ever function-local, so at this scope it asked the API for commits/HEAD —
   # which GitHub resolves to the DEFAULT BRANCH head. Measured on PR #1575:
   # that anchor was nine days old, so any review CodeRabbit had ever

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14231,6 +14231,55 @@ done
 # the label, not merely discouraged after it.
 run_test "p91_checklist_refuses_no_submitted_review" "yes" \
   "$(grep -q 'POST_CLEAN_NO_SUBMITTED_REVIEW:-0}" = "1"' "$_1574_p91" && echo yes || echo no)"
+# Protocol 91 carries no wait at all any more: the only sleep in 8a.1 was the
+# fixed one this issue removes, and the timeout path now goes back to Step 7.
+run_test "p91_8a1_has_no_sleep" "0" \
+  "$(awk '/^### 8a\.1:/,/^## Step 8b/' "$_1574_p91" | grep -cE '^[[:space:]]*sleep ' || true)"
+
+
+# Execute the gate, not just grep it: extract Check 0.5 + 0.6 from the
+# readiness checklist fence and run them with a stubbed gh.
+_1574_gate="$(mktemp)"
+{
+  printf 'set -euo pipefail\nPR_NUMBER=42\nTARGET_REPO=owner/repo\ngh() { printf "%%s\\n" "${MOCK_SUMMARY:-}"; }\n'
+  awk '/^# Check 0\.5:/{p=1} /^# Check 1:/{p=0} p' "$_1574_p91"
+} > "$_1574_gate"
+run_test "gate_extracted_has_check_0_6" "yes" "$(grep -q '^# Check 0.6' "$_1574_gate" && echo yes || echo no)"
+# The extracted gate must parse in every shell the fence's contract names;
+# the Check 0.5 jq filter had an unterminated quote until this PR.
+run_test "gate_parses_in_bash" "yes" "$(bash -n "$_1574_gate" 2>/dev/null && echo yes || echo no)"
+run_test "gate_parses_in_zsh" "yes" "$(if command -v zsh >/dev/null 2>&1; then zsh -n "$_1574_gate" 2>/dev/null && echo yes || echo no; else echo yes; fi)"
+_1574_clean='### Automated Reviewer Loop Summary
+
+**Result:** clean — no blocking findings'
+_1574_skipped='### Automated Reviewer Loop Summary
+
+**Result:** skipped — no review platforms configured'
+_1574_run_gate() {
+  # $@ = VAR=value assignments; prints the exit status
+  local status=0
+  env -i PATH="$PATH" MOCK_SUMMARY="$_1574_clean" "$@" bash "$_1574_gate" >/dev/null 2>&1 || status=$?
+  printf '%s' "$status"
+}
+run_test "gate_skipped_flag_passes" "0" "$(_1574_run_gate REVIEWER_LOOP_SKIPPED_NO_PLATFORMS=true)"
+run_test "gate_skipped_summary_passes" "0" "$(_1574_run_gate MOCK_SUMMARY="$_1574_skipped")"
+run_test "gate_missing_fields_refused" "12" "$(_1574_run_gate)"
+run_test "gate_no_thread_platforms_passes" "0" "$(_1574_run_gate POST_CLEAN_RECHECK=0 POST_CLEAN_RECHECK_SKIP_REASON=no_thread_posting_platforms)"
+run_test "gate_suppressed_recheck_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=0 POST_CLEAN_RECHECK_SKIP_REASON=skip_env)"
+run_test "gate_recheck_without_reason_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=0)"
+run_test "gate_settled_passes" "0" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 POST_CLEAN_SETTLED_AT=2026-08-22T13:49:18Z)"
+run_test "gate_no_submitted_review_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=0 POST_CLEAN_SETTLE_TIMEOUT=1 POST_CLEAN_NO_SUBMITTED_REVIEW=1)"
+run_test "gate_settle_timeout_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=0 POST_CLEAN_SETTLE_TIMEOUT=1)"
+run_test "gate_unsettled_without_flags_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=0)"
+# Planted violation: invert the settled comparison and the matrix must notice.
+_1574_gate_bad="$(mktemp)"
+sed 's/POST_CLEAN_SETTLED:-0}" = "1"/POST_CLEAN_SETTLED:-0}" = "0"/' "$_1574_gate" > "$_1574_gate_bad"
+_1574_bad_status=0
+env -i PATH="$PATH" MOCK_SUMMARY="$_1574_clean" POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 bash "$_1574_gate_bad" >/dev/null 2>&1 || _1574_bad_status=$?
+run_test "gate_planted_inversion_is_caught" "12" "$_1574_bad_status"
+rm -f "$_1574_gate" "$_1574_gate_bad"
+unset -f _1574_run_gate
+unset _1574_gate _1574_gate_bad _1574_clean _1574_skipped _1574_bad_status
 unset _1574_loop _1574_p91 _1574_p92 _1574_cw _1574_cq _1574_help _reason _field
 
 # ---------------------------------------------------------------------------

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14241,9 +14241,20 @@ run_test "ledger_excludes_head_moved_reruns" "1 1 available" \
   "$(reviewer_loop_history_entries_count "$_1574_ledger_body" r1)"
 run_test "cap_skipped_for_head_moved" "yes" \
   "$(grep -q 'if \[ "\$aggregate_reason" = "head_moved_during_run" \]; then' "$_1574_loop" && echo yes || echo no)"
-# The label is applied only after a final head re-validation (Check 4).
+# The head is re-validated in Check 4 on BOTH paths — before the
+# label-present/absent branch — and a stale existing label is pulled back.
 run_test "p91_revalidates_head_before_label" "yes" \
-  "$(awk '/^# Check 4:/{p=1} p && /settle_head_ok \|\| exit 12/{found=1} END{exit !found}' "$_1574_p91" && echo yes || echo no)"
+  "$(awk '/^# Check 4:/{p=1} p && /SETTLE_APPLIES:-1}" -eq 1 \] && ! settle_head_ok/{found=1} p && /^if \[ "\$HAS_HUMAN_REVIEW_LABEL" -gt 0 \]; then/{ if (found) ok=1 } END{exit !ok}' "$_1574_p91" && echo yes || echo no)"
+run_test "p91_pulls_stale_label_back" "yes" \
+  "$(grep -q 'it covers a head that is no longer the PR head' "$_1574_p91" && echo yes || echo no)"
+# A head-move rerun never escalates on a failed ledger persist: no fixer is
+# dispatched, so there is nothing for the ledger to bound.
+run_test "persist_failure_ignores_head_moved" "1" \
+  "$(reviewer_loop_persist_failure_should_escalate 1 needs_fixes head_moved_during_run; echo $?)"
+run_test "persist_failure_still_escalates_real_needs_fixes" "0" \
+  "$(reviewer_loop_persist_failure_should_escalate 1 needs_fixes unresolved_review_threads; echo $?)"
+run_test "p91_step7_snippet_fails_fast" "yes" \
+  "$(awk '/^set -euo pipefail$/{s=NR} /^# Drop settle telemetry from any earlier invocation first/{ if (s==NR-1) ok=1 } END{exit !ok}' "$_1574_p91" && echo yes || echo no)"
 unset _1574_ledger_body
 for _field in POST_CLEAN_SETTLED POST_CLEAN_SETTLE_TIMEOUT POST_CLEAN_NO_SUBMITTED_REVIEW POST_CLEAN_SETTLED_AT POST_CLEAN_RECHECK_SKIP_REASON POST_CLEAN_HEAD_SHA; do
   run_test "p91_consumes_$_field" "yes" \

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14221,7 +14221,9 @@ run_test "help_documents_skip_reason" "yes" \
 # of its own (AC-2), and Protocols 91/92 must describe one contract (AC-3).
 run_test "p91_has_no_fixed_recheck_sleep" "0" \
   "$(grep_count_or_zero 'sleep 10' "$_1574_p91")"
-for _field in POST_CLEAN_SETTLED POST_CLEAN_SETTLE_TIMEOUT POST_CLEAN_NO_SUBMITTED_REVIEW POST_CLEAN_SETTLED_AT POST_CLEAN_RECHECK_SKIP_REASON; do
+run_test "loop_emits_settle_head_sha" "yes" \
+  "$(grep -q 'print_kv POST_CLEAN_HEAD_SHA' "$_1574_loop" && echo yes || echo no)"
+for _field in POST_CLEAN_SETTLED POST_CLEAN_SETTLE_TIMEOUT POST_CLEAN_NO_SUBMITTED_REVIEW POST_CLEAN_SETTLED_AT POST_CLEAN_RECHECK_SKIP_REASON POST_CLEAN_HEAD_SHA; do
   run_test "p91_consumes_$_field" "yes" \
     "$(grep -q "$_field" "$_1574_p91" && echo yes || echo no)"
   run_test "p92_names_$_field" "yes" \
@@ -14248,7 +14250,17 @@ run_test "p91_8a1_has_no_sleep" "0" \
 # readiness checklist fence and run them with a stubbed gh.
 _1574_gate="$(mktemp)"
 {
-  printf 'set -euo pipefail\nPR_NUMBER=42\nTARGET_REPO=owner/repo\ngh() { printf "%%s\\n" "${MOCK_SUMMARY:-}"; }\n'
+  cat <<'STUB'
+set -euo pipefail
+PR_NUMBER=42
+TARGET_REPO=owner/repo
+gh() {
+  case "$*" in
+    *headRefOid*) printf '%s\n' "${MOCK_HEAD:-}" ;;
+    *) printf '%s\n' "${MOCK_SUMMARY:-}" ;;
+  esac
+}
+STUB
   awk '/^# Check 0\.5:/{p=1} /^# Check 1:/{p=0} p' "$_1574_p91"
 } > "$_1574_gate"
 run_test "gate_extracted_has_check_0_6" "yes" "$(grep -q '^# Check 0.6' "$_1574_gate" && echo yes || echo no)"
@@ -14262,10 +14274,11 @@ _1574_clean='### Automated Reviewer Loop Summary
 _1574_skipped='### Automated Reviewer Loop Summary
 
 **Result:** skipped — no review platforms configured'
+_1574_head="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 _1574_run_gate() {
   # $@ = VAR=value assignments; prints the exit status
   local status=0
-  env -i PATH="$PATH" MOCK_SUMMARY="$_1574_clean" "$@" bash "$_1574_gate" >/dev/null 2>&1 || status=$?
+  env -i PATH="$PATH" MOCK_SUMMARY="$_1574_clean" MOCK_HEAD="$_1574_head" "$@" bash "$_1574_gate" >/dev/null 2>&1 || status=$?
   printf '%s' "$status"
 }
 run_test "gate_skipped_flag_passes" "0" "$(_1574_run_gate REVIEWER_LOOP_SKIPPED_NO_PLATFORMS=true)"
@@ -14274,7 +14287,11 @@ run_test "gate_missing_fields_refused" "12" "$(_1574_run_gate)"
 run_test "gate_no_thread_platforms_passes" "0" "$(_1574_run_gate POST_CLEAN_RECHECK=0 POST_CLEAN_RECHECK_SKIP_REASON=no_thread_posting_platforms)"
 run_test "gate_suppressed_recheck_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=0 POST_CLEAN_RECHECK_SKIP_REASON=skip_env)"
 run_test "gate_recheck_without_reason_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=0)"
-run_test "gate_settled_passes" "0" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 POST_CLEAN_SETTLED_AT=2026-08-22T13:49:18Z)"
+run_test "gate_settled_passes" "0" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 POST_CLEAN_SETTLED_AT=2026-08-22T13:49:18Z POST_CLEAN_HEAD_SHA="$_1574_head")"
+# A settled verdict is bound to one head: telemetry without a head, or for a
+# head the PR has moved past, is refused.
+run_test "gate_settled_without_head_binding_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1)"
+run_test "gate_settled_for_other_head_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 POST_CLEAN_HEAD_SHA=0123456789012345678901234567890123456789)"
 run_test "gate_no_submitted_review_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=0 POST_CLEAN_SETTLE_TIMEOUT=1 POST_CLEAN_NO_SUBMITTED_REVIEW=1)"
 run_test "gate_settle_timeout_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=0 POST_CLEAN_SETTLE_TIMEOUT=1)"
 run_test "gate_unsettled_without_flags_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=0)"
@@ -14282,11 +14299,11 @@ run_test "gate_unsettled_without_flags_refused" "12" "$(_1574_run_gate POST_CLEA
 _1574_gate_bad="$(mktemp)"
 sed 's/POST_CLEAN_SETTLED:-0}" = "1"/POST_CLEAN_SETTLED:-0}" = "0"/' "$_1574_gate" > "$_1574_gate_bad"
 _1574_bad_status=0
-env -i PATH="$PATH" MOCK_SUMMARY="$_1574_clean" POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 bash "$_1574_gate_bad" >/dev/null 2>&1 || _1574_bad_status=$?
+env -i PATH="$PATH" MOCK_SUMMARY="$_1574_clean" MOCK_HEAD="$_1574_head" POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 POST_CLEAN_HEAD_SHA="$_1574_head" bash "$_1574_gate_bad" >/dev/null 2>&1 || _1574_bad_status=$?
 run_test "gate_planted_inversion_is_caught" "12" "$_1574_bad_status"
 rm -f "$_1574_gate" "$_1574_gate_bad"
 unset -f _1574_run_gate
-unset _1574_gate _1574_gate_bad _1574_clean _1574_skipped _1574_bad_status
+unset _1574_gate _1574_gate_bad _1574_clean _1574_skipped _1574_bad_status _1574_head
 unset _1574_loop _1574_p91 _1574_p92 _1574_cw _1574_cq _1574_help _reason _field
 
 # ---------------------------------------------------------------------------

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14231,6 +14231,20 @@ run_test "loop_refuses_head_moved_during_run" "yes" \
   "$(grep -q 'aggregate_reason="head_moved_during_run"' "$_1574_loop" && echo yes || echo no)"
 run_test "p91_names_head_moved_during_run" "yes" \
   "$(grep -q 'head_moved_during_run' "$_1574_p91" && echo yes || echo no)"
+# A head that moved during a clean run is a re-run, not a fixer cycle: the
+# ledger does not count it and neither cap fires on it.
+_1574_ledger_body="$(jq -nc '{schema:"reviewer_loop_history.v1",pr_number:42,history_status:"available",entries:[
+  {iteration:1,head_sha:"a1",run_id:"r1",result:"needs_fixes",reason:"head_moved_during_run"},
+  {iteration:2,head_sha:"a2",run_id:"r1",result:"needs_fixes",reason:"unresolved_review_threads"}]}' \
+  | { printf '%s\n' "$REVIEWER_LOOP_HISTORY_MARKER" '```json'; cat; printf '```\n'; })"
+run_test "ledger_excludes_head_moved_reruns" "1 1 available" \
+  "$(reviewer_loop_history_entries_count "$_1574_ledger_body" r1)"
+run_test "cap_skipped_for_head_moved" "yes" \
+  "$(grep -q 'if \[ "\$aggregate_reason" = "head_moved_during_run" \]; then' "$_1574_loop" && echo yes || echo no)"
+# The label is applied only after a final head re-validation (Check 4).
+run_test "p91_revalidates_head_before_label" "yes" \
+  "$(awk '/^# Check 4:/{p=1} p && /settle_head_ok \|\| exit 12/{found=1} END{exit !found}' "$_1574_p91" && echo yes || echo no)"
+unset _1574_ledger_body
 for _field in POST_CLEAN_SETTLED POST_CLEAN_SETTLE_TIMEOUT POST_CLEAN_NO_SUBMITTED_REVIEW POST_CLEAN_SETTLED_AT POST_CLEAN_RECHECK_SKIP_REASON POST_CLEAN_HEAD_SHA; do
   run_test "p91_consumes_$_field" "yes" \
     "$(grep -q "$_field" "$_1574_p91" && echo yes || echo no)"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14188,6 +14188,52 @@ done
 unset _knob _1556_loop
 
 # ---------------------------------------------------------------------------
+# Area 20: the late-thread re-check is one contract, owned by the loop (#1574)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 20: late-thread re-check contract (#1574) ==="
+
+_1574_loop="$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
+_1574_p91="$REPO_ROOT/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md"
+_1574_p92="$REPO_ROOT/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md"
+
+# The --help text carried 600/180 for CodeRabbit while the code used 900/120.
+# Read both and compare, so the numbers cannot drift apart again.
+read -r _1574_cw _1574_cq _ _ <<<"$(_settle_config_for_platform coderabbit)"
+_1574_help="$(bash "$_1574_loop" --help 2>&1 || true)"
+run_test "help_window_default_matches_code" "$_1574_cw" \
+  "$(printf '%s\n' "$_1574_help" | grep -oE 'Maximum total time to spend settling \(default: [0-9]+' | grep -oE '[0-9]+$')"
+run_test "help_quiet_default_matches_code" "$_1574_cq" \
+  "$(printf '%s\n' "$_1574_help" | grep -oE 'Defaults per platform: [0-9]+ for coderabbit' | grep -oE '[0-9]+')"
+
+# A skipped recheck must say why, so the checklist can tell "nothing could
+# arrive late" from "settling was suppressed".
+run_test "recheck_skip_reason_emitted" "yes" \
+  "$(grep -q 'print_kv POST_CLEAN_RECHECK_SKIP_REASON' "$_1574_loop" && echo yes || echo no)"
+for _reason in not_clean compare_mode skip_env no_thread_posting_platforms no_pr_number; do
+  run_test "recheck_skip_reason_$_reason" "yes" \
+    "$(grep -q "POST_CLEAN_RECHECK_SKIP_REASON $_reason" "$_1574_loop" && echo yes || echo no)"
+done
+run_test "help_documents_skip_reason" "yes" \
+  "$(printf '%s\n' "$_1574_help" | grep -q 'POST_CLEAN_RECHECK_SKIP_REASON=' && echo yes || echo no)"
+
+# Protocol 91 must defer to the loop's settle fields rather than carry a wait
+# of its own (AC-2), and Protocols 91/92 must describe one contract (AC-3).
+run_test "p91_has_no_fixed_recheck_sleep" "0" \
+  "$(grep_count_or_zero 'sleep 10' "$_1574_p91")"
+for _field in POST_CLEAN_SETTLED POST_CLEAN_SETTLE_TIMEOUT POST_CLEAN_NO_SUBMITTED_REVIEW POST_CLEAN_SETTLED_AT POST_CLEAN_RECHECK_SKIP_REASON; do
+  run_test "p91_consumes_$_field" "yes" \
+    "$(grep -q "$_field" "$_1574_p91" && echo yes || echo no)"
+  run_test "p92_names_$_field" "yes" \
+    "$(grep -q "$_field" "$_1574_p92" && echo yes || echo no)"
+done
+# AC-4: an unsettled clean verdict without a submitted review is refused before
+# the label, not merely discouraged after it.
+run_test "p91_checklist_refuses_no_submitted_review" "yes" \
+  "$(grep -q 'POST_CLEAN_NO_SUBMITTED_REVIEW:-0}" = "1"' "$_1574_p91" && echo yes || echo no)"
+unset _1574_loop _1574_p91 _1574_p92 _1574_cw _1574_cq _1574_help _reason _field
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14180,6 +14180,13 @@ run_test "post_clean_reports_missing_review" "yes" \
   "$(grep -q 'print_kv POST_CLEAN_NO_SUBMITTED_REVIEW 1' "$_1556_loop" && echo yes || echo no)"
 run_test "post_clean_anchors_since_to_head_commit" "yes" \
   "$(grep -q 'settle_head_iso=' "$_1556_loop" && echo yes || echo no)"
+# The anchor must be the pre-dispatch head, never commits/HEAD: the API
+# resolves HEAD to the default branch, which on PR #1575 was nine days old,
+# so any past review satisfied the require-review settle (issue #1574).
+run_test "post_clean_anchor_uses_pre_dispatch_head" "yes" \
+  "$(grep -q 'commits/${loop_head_sha}' "$_1556_loop" && echo yes || echo no)"
+run_test "post_clean_anchor_never_commits_HEAD" "0" \
+  "$(grep_count_or_zero 'commits/${head_sha:-HEAD}' "$_1556_loop")"
 # The documented knobs must actually appear in --help (AC-4).
 for _knob in POST_CLEAN_SETTLE_QUIET POST_CLEAN_SETTLE_WINDOW POST_CLEAN_POLL; do
   run_test "help_documents_$_knob" "yes" \

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14231,6 +14231,13 @@ done
 # the label, not merely discouraged after it.
 run_test "p91_checklist_refuses_no_submitted_review" "yes" \
   "$(grep -q 'POST_CLEAN_NO_SUBMITTED_REVIEW:-0}" = "1"' "$_1574_p91" && echo yes || echo no)"
+# Stale telemetry from a previous invocation must never survive into Check 0.6:
+# the Step 7 block clears POST_CLEAN_* before the loop runs and exports nothing
+# when the loop exits non-zero.
+run_test "p91_step7_clears_stale_settle_vars" "yes" \
+  "$(grep -q "grep -o '^POST_CLEAN_\[A-Z_\]\*'" "$_1574_p91" && echo yes || echo no)"
+run_test "p91_step7_exports_only_on_zero_exit" "yes" \
+  "$(grep -q 'Do not enter Step 8a on this run' "$_1574_p91" && echo yes || echo no)"
 # Protocol 91 carries no wait at all any more: the only sleep in 8a.1 was the
 # fixed one this issue removes, and the timeout path now goes back to Step 7.
 run_test "p91_8a1_has_no_sleep" "0" \

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14221,8 +14221,16 @@ run_test "help_documents_skip_reason" "yes" \
 # of its own (AC-2), and Protocols 91/92 must describe one contract (AC-3).
 run_test "p91_has_no_fixed_recheck_sleep" "0" \
   "$(grep_count_or_zero 'sleep 10' "$_1574_p91")"
-run_test "loop_emits_settle_head_sha" "yes" \
-  "$(grep -q 'print_kv POST_CLEAN_HEAD_SHA' "$_1574_loop" && echo yes || echo no)"
+# Both clean paths — settled and no-thread-platforms — emit the head binding,
+# and the head is read before any reviewer is dispatched, then compared after.
+run_test "loop_emits_head_sha_on_both_clean_paths" "2" \
+  "$(grep_count_or_zero 'print_kv POST_CLEAN_HEAD_SHA' "$_1574_loop")"
+run_test "loop_reads_head_before_dispatch" "yes" \
+  "$(awk '/^loop_head_sha=""/{h=NR} /^aggregate_result="skipped"/{a=NR} END{exit !(h>0 && a>0 && h>a)}' "$_1574_loop" && echo yes || echo no)"
+run_test "loop_refuses_head_moved_during_run" "yes" \
+  "$(grep -q 'aggregate_reason="head_moved_during_run"' "$_1574_loop" && echo yes || echo no)"
+run_test "p91_names_head_moved_during_run" "yes" \
+  "$(grep -q 'head_moved_during_run' "$_1574_p91" && echo yes || echo no)"
 for _field in POST_CLEAN_SETTLED POST_CLEAN_SETTLE_TIMEOUT POST_CLEAN_NO_SUBMITTED_REVIEW POST_CLEAN_SETTLED_AT POST_CLEAN_RECHECK_SKIP_REASON POST_CLEAN_HEAD_SHA; do
   run_test "p91_consumes_$_field" "yes" \
     "$(grep -q "$_field" "$_1574_p91" && echo yes || echo no)"
@@ -14284,7 +14292,10 @@ _1574_run_gate() {
 run_test "gate_skipped_flag_passes" "0" "$(_1574_run_gate REVIEWER_LOOP_SKIPPED_NO_PLATFORMS=true)"
 run_test "gate_skipped_summary_passes" "0" "$(_1574_run_gate MOCK_SUMMARY="$_1574_skipped")"
 run_test "gate_missing_fields_refused" "12" "$(_1574_run_gate)"
-run_test "gate_no_thread_platforms_passes" "0" "$(_1574_run_gate POST_CLEAN_RECHECK=0 POST_CLEAN_RECHECK_SKIP_REASON=no_thread_posting_platforms)"
+run_test "gate_no_thread_platforms_passes" "0" "$(_1574_run_gate POST_CLEAN_RECHECK=0 POST_CLEAN_RECHECK_SKIP_REASON=no_thread_posting_platforms POST_CLEAN_HEAD_SHA="$_1574_head")"
+# The no-thread path is bound to a head too: a push after Step 7 voids it.
+run_test "gate_no_thread_platforms_unbound_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=0 POST_CLEAN_RECHECK_SKIP_REASON=no_thread_posting_platforms)"
+run_test "gate_no_thread_platforms_other_head_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=0 POST_CLEAN_RECHECK_SKIP_REASON=no_thread_posting_platforms POST_CLEAN_HEAD_SHA=0123456789012345678901234567890123456789)"
 run_test "gate_suppressed_recheck_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=0 POST_CLEAN_RECHECK_SKIP_REASON=skip_env)"
 run_test "gate_recheck_without_reason_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=0)"
 run_test "gate_settled_passes" "0" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 POST_CLEAN_SETTLED_AT=2026-08-22T13:49:18Z POST_CLEAN_HEAD_SHA="$_1574_head")"


### PR DESCRIPTION
Closes #1574. Agent-facing half of #1556 (merged as #1573).

## Problem

Protocol 91 Step 8a.1 waited a fixed `sleep 10`, sized for a `codex-github` posting race. CodeRabbit's findings do not race the checklist; they arrive minutes later (12 min walkthrough-to-review on PR #1573; 2, 3, 5, 1, 3 and 8 late findings on #1532/#1541/#1555/#1568/#1569/#1570, all real, two Major). #1556 put the wait in `pr-review-loop.sh`; Protocol 91 still described the old contract, so an agent following 91 step-by-step got the old number.

While doing this I found the same drift *inside the loop*: `--help` says CodeRabbit settles with a 600s window / 180s quiet; the code and Area 19 tests use 900 / 120.

## Fix

- **Protocol 91 Step 7** — "Carry the settle verdict forward": export the loop's `POST_CLEAN_*` lines into the checklist environment (pattern admits only digits / ISO timestamp / reason tokens).
- **Protocol 91 Check 0.6 (exit 12)** — refuses a clean verdict whose `POST_CLEAN_RECHECK` is unset or suppressed (`SKIP_POST_CLEAN_RECHECK`, `--compare`) or whose platform never submitted a review for this HEAD (`POST_CLEAN_NO_SUBMITTED_REVIEW=1`). This runs before the label is applied (AC-4).
- **Protocol 91 Step 8a.1** — retitled "Late-Arriving Review Thread Re-check", runs for every configured GitHub review platform, and carries no number of its own: `POST_CLEAN_SETTLED=1` → re-query immediately; `POST_CLEAN_SETTLE_TIMEOUT=1` → wait `POST_CLEAN_SETTLE_QUIET_SECONDS` from the loop output, then re-query; `no_thread_posting_platforms` → not applicable (AC-1, AC-2).
- **Protocol 92** — names Check 0.6 / 8a.1 as the single enforcement point and states the protocols do not repeat the loop's defaults (AC-3).
- **`pr-review-loop.sh`** — new `POST_CLEAN_RECHECK_SKIP_REASON` (`not_clean` / `compare_mode` / `skip_env` / `no_thread_posting_platforms` / `no_pr_number`) so "nothing can arrive late" is distinguishable from "settling was suppressed"; `--help` defaults corrected to 900 / 120.
- **Tests** — Area 20 of `test-pr-review-loop.sh` reads the defaults from `_settle_config_for_platform` and from `--help` and asserts they match; asserts Protocol 91 has no `sleep 10`, consumes every settle field, and refuses `POST_CLEAN_NO_SUBMITTED_REVIEW=1`; asserts Protocol 92 names the same fields.

## Found while running this PR's own loop (fixed here)

- **The settle anchor was the default-branch head.** `settle_head_iso` read `commits/${head_sha:-HEAD}`; `head_sha` is only ever function-local, so at main scope the API was asked for `commits/HEAD` = the default branch head (`bcba16ff`, 2026-08-13). Any CodeRabbit review from the last nine days satisfied "a submitted review for this HEAD": on PR #1575 the loop reported `POST_CLEAN_SETTLED=1` at 16:03 for HEAD `8cb99966` (15:58) while CodeRabbit's last review was 15:48 for `49fa11f4`. Now anchored to `loop_head_sha`, captured before dispatch; an unknown head anchors to "now". Pinned by `post_clean_anchor_uses_pre_dispatch_head` / `post_clean_anchor_never_commits_HEAD`.
- Six Codex GitHub App fix rounds, all real, all the same theme — bind the verdict to a head: clear stale telemetry before a re-run; read the head before dispatch; bind the no-thread path; re-validate in Check 4 on both label paths (and pull a stale label back); `head_moved_during_run` is a re-run, not a cycle (excluded from caps, ledger, and persistence escalation); fail-fast prelude on the Step 7 snippet; Protocol 92 names the no-thread exception.
- The executable Check 0.5/0.6 test found that the Check 0.5 jq filter had an unterminated quote since `559c5402` (2026-06-06) — the checklist fence could not have parsed in bash or zsh as printed.

## Mirror surfaces

None: `sleep 10` / Step 8a.1 / Check 0.5 appear only in Protocol 91 (grepped across `.claude`, `.cursor`, `.codex`, `.agents`, `docs`).

## Verification

- `test-pr-review-loop.sh --area 19`: 45/0; `--area 20`: 21/0 (new)
- guard lint, snippet lint, markdownlint, CHANGELOG heuristic + duplicate-header checks: clean; shellcheck `--severity=warning`: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-review checks to detect unsettled, stale, missing, or timed-out review results.
  * Clean results are now verified against the latest pull request revision.
  * Clearly reports when the pull request changes during review and requires another review cycle.
  * Improved handling and messaging for skipped late-thread checks.

* **Documentation**
  * Updated workflow guidance, recovery steps, timeout defaults, and readiness criteria.

* **Tests**
  * Added coverage for review states, revision changes, skipped checks, telemetry, and readiness validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->