### PR TITLE
fix(post-merge-cleanup): process every issue a PR resolves (#1391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **`post-merge-cleanup.sh` now processes every issue a PR resolves**
+  (#1391): a numeric branch (`fix/1520-…`) previously routed cleanup through
+  the branch-derived issue alone, silently ignoring `Closes #N` references in
+  the PR body — and commit-message references were never scanned at all
+  (GitHub only honours them on default-branch merges, and this repo merges to
+  `develop`). Closing references from the PR title, body, and commit messages
+  are now processed in addition to the branch issue, and bare `#N` title
+  references without a closing keyword (e.g. `fix(#2053,#2055): …`) produce a
+  loud warning naming what was not processed. Protocols 91 and 95 now state
+  that post-merge verification is per referenced item.
 - **`/run-epic` helpers no longer bind the jq-reserved identifier `label`**
   (#1523): on jq 1.6 (Ubuntu 22.04 LTS and peers) `label` is a reserved
   keyword, so `run-epic-policy-recommender.sh`, `run-bounded-prelude.sh`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,15 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **`post-merge-cleanup.sh` now processes every issue a PR resolves**
-  (#1391): a numeric branch (`fix/1520-…`) previously routed cleanup through
-  the branch-derived issue alone, silently ignoring `Closes #N` references in
-  the PR body — and commit-message references were never scanned at all
-  (GitHub only honours them on default-branch merges, and this repo merges to
-  `develop`). Closing references from the PR title, body, and commit messages
-  are now processed in addition to the branch issue, and bare `#N` title
-  references without a closing keyword (e.g. `fix(#2053,#2055): …`) produce a
-  loud warning naming what was not processed. Protocols 91 and 95 now state
-  that post-merge verification is per referenced item.
+  (#1391): closing references in the PR title, body, and commit messages are
+  processed in addition to the branch-derived issue, and bare `#N` title
+  references without a closing keyword produce a warning naming what was not
+  processed. Post-merge verification is per referenced item and an
+  unprocessed-reference warning is non-terminal — see Protocol 91 Step 10 and
+  Protocol 95 Step 11.
 - **`/run-epic` helpers no longer bind the jq-reserved identifier `label`**
   (#1523): on jq 1.6 (Ubuntu 22.04 LTS and peers) `label` is a reserved
   keyword, so `run-epic-policy-recommender.sh`, `run-bounded-prelude.sh`, and

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -3184,6 +3184,13 @@ state according to this table:
 | `implementation-plan/*`                           | Plan Ready            |
 | `feature/*` / `fix/*` / `refactor/*` / `hotfix/*` | Merged                |
 
+**A PR may resolve more than one item** (#1391). `post-merge-cleanup.sh`
+processes the branch-derived issue plus every closing-keyword reference in the
+PR title, body, and commit messages, and warns about bare `#N` title
+references it did not process. Verify the transition for **each** referenced
+item — do not stop after the first — and act on any "references issue(s) …
+without a closing keyword" warning before reporting cleanup complete.
+
 **Key rules:**
 
 - When a spec or plan PR is merged, set the tracker status to the corresponding **Ready** status (`Spec Ready` or `Plan Ready`) — **not** `Merged`. Only implementation PRs (feature, fix, refactor, hotfix) go to `Merged`.

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -3188,8 +3188,10 @@ state according to this table:
 processes the branch-derived issue plus every closing-keyword reference in the
 PR title, body, and commit messages, and warns about bare `#N` title
 references it did not process. Verify the transition for **each** referenced
-item — do not stop after the first — and act on any "references issue(s) …
-without a closing keyword" warning before reporting cleanup complete.
+item — do not stop after the first. A "references issue(s) … without a closing
+keyword" warning is **non-terminal**: cleanup stays incomplete until every
+named issue has an explicit disposition — processed (closed and
+status-updated) or confirmed non-closing — recorded in the item report.
 
 **Key rules:**
 

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -741,8 +741,12 @@ When all gates permit merge:
 3. Delete or prune the merged branch as appropriate.
 4. Run post-merge cleanup for the correct base branch. A PR may resolve
    more than one item (#1391): verify tracker state for every issue the PR
-   references, not only the branch-derived one, and act on the cleanup
-   helper's unprocessed-title-reference warning when it appears. For direct single-PR
+   references, not only the branch-derived one. An unprocessed-title-reference
+   warning from the cleanup helper is **non-terminal** — cleanup is not
+   complete until every named issue has an explicit recorded disposition:
+   processed (closed and status-updated), or confirmed non-closing (the PR
+   mentions it but does not resolve it). Record that disposition in the run
+   summary before closeout; acknowledging the warning is not a disposition. For direct single-PR
    merges, use the cleanup helper after merge verification. In `workflow_hub`
    mode, pass `--repo <product-repo>` for product-owned implementation branches:
 

--- a/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
+++ b/docs/workflow/development-workflow/protocols/95-run-epic-protocol.md
@@ -739,7 +739,10 @@ When all gates permit merge:
    approval evidence described in the delegated gate checklist is present.
 2. Verify GitHub reports the PR state as `MERGED`.
 3. Delete or prune the merged branch as appropriate.
-4. Run post-merge cleanup for the correct base branch. For direct single-PR
+4. Run post-merge cleanup for the correct base branch. A PR may resolve
+   more than one item (#1391): verify tracker state for every issue the PR
+   references, not only the branch-derived one, and act on the cleanup
+   helper's unprocessed-title-reference warning when it appears. For direct single-PR
    merges, use the cleanup helper after merge verification. In `workflow_hub`
    mode, pass `--repo <product-repo>` for product-owned implementation branches:
 

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -584,14 +584,26 @@ fetch_pr_closing_issues() {
   # natively on default-branch merges — this repo merges to develop, so the
   # script must read them itself (#1391, second confirmation: a `Closes #N`
   # in a commit body was silently ignored).
-  local pr_commit_text
+  local pr_commit_text stripped_pr_commit_text
   pr_commit_text="$(gh pr view "$pr_number" --repo "$pr_repo" --json commits --jq '[.commits[] | ((.messageHeadline // "") + "\n" + (.messageBody // ""))] | join("\n")' 2>/dev/null)" || return 1
-  pr_body="${pr_body}
-${pr_commit_text}"
+  # Strip the title/body and the commit text SEPARATELY, then combine the
+  # already-stripped results. strip_fenced_pr_body_blocks deliberately treats
+  # an unclosed opening fence as extending to end of input; if the raw body
+  # and commit text were concatenated *before* stripping, an unclosed (e.g.
+  # accidentally malformed) fence in the PR body would swallow every commit
+  # message that follows it — including a live `Closes #N` reference — as
+  # collateral damage. Each source's fence state must not leak into the
+  # other's.
   if ! stripped_pr_body="$(printf '%s' "$pr_body" | strip_fenced_pr_body_blocks)"; then
-    echo "ERROR: could not strip fenced code blocks from PR #${pr_number}." >&2
+    echo "ERROR: could not strip fenced code blocks from PR #${pr_number} body." >&2
     return 1
   fi
+  if ! stripped_pr_commit_text="$(printf '%s' "$pr_commit_text" | strip_fenced_pr_body_blocks)"; then
+    echo "ERROR: could not strip fenced code blocks from PR #${pr_number} commit messages." >&2
+    return 1
+  fi
+  stripped_pr_body="${stripped_pr_body}
+${stripped_pr_commit_text}"
   set +e
   keyword_lines="$(printf '%s' "$stripped_pr_body" | grep -ioE '(^|[^[:alnum:]_])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+(issue[[:space:]]+)?#[0-9]+')"
   stage_status=$?
@@ -675,11 +687,18 @@ close_issues_from_pr() {
 # A PR title like "fix(#2053,#2055): ..." references issues without a closing
 # keyword; neither GitHub nor this script closes them. Say so loudly instead
 # of silently processing a subset (#1391): list every #N in the title that is
-# not in the processed list.
+# not in the processed list. Best-effort by design (a failure here must never
+# fail the overall cleanup), but a failure to fetch the title is itself
+# announced on stderr rather than returning silently — otherwise the one
+# helper whose whole purpose is avoiding a silent gap could itself go silent
+# on a transient `gh` failure, indistinguishable from "no bare refs found".
 warn_unprocessed_title_refs() {
   local pr_repo="$1" pr_number="$2" processed="$3"
   local title refs ref unprocessed=""
-  title="$(gh pr view "$pr_number" --repo "$pr_repo" --json title --jq '.title // ""' 2>/dev/null)" || return 0
+  title="$(gh pr view "$pr_number" --repo "$pr_repo" --json title --jq '.title // ""' 2>/dev/null)" || {
+    echo "Warning: could not fetch PR #${pr_number} title to check for unprocessed bare issue references; skipping this check." >&2
+    return 0
+  }
   refs="$(printf '%s' "$title" | grep -oE '#[0-9]+' | tr -d '#' | sort -un)" || return 0
   [ -n "$refs" ] || return 0
   while IFS= read -r ref; do

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -580,6 +580,14 @@ fetch_pr_closing_issues() {
     return 2
   fi
   pr_body="$(gh pr view "$pr_number" --repo "$pr_repo" --json body,title --jq '(.title // "") + "\n" + (.body // "")' 2>/dev/null)" || return 1
+  # Commit messages carry closing keywords too, and GitHub only honours them
+  # natively on default-branch merges — this repo merges to develop, so the
+  # script must read them itself (#1391, second confirmation: a `Closes #N`
+  # in a commit body was silently ignored).
+  local pr_commit_text
+  pr_commit_text="$(gh pr view "$pr_number" --repo "$pr_repo" --json commits --jq '[.commits[] | ((.messageHeadline // "") + "\n" + (.messageBody // ""))] | join("\n")' 2>/dev/null)" || return 1
+  pr_body="${pr_body}
+${pr_commit_text}"
   if ! stripped_pr_body="$(printf '%s' "$pr_body" | strip_fenced_pr_body_blocks)"; then
     echo "ERROR: could not strip fenced code blocks from PR #${pr_number}." >&2
     return 1
@@ -659,6 +667,30 @@ close_issues_from_pr() {
   if [ "$view_failures" -gt 0 ]; then
     echo "ERROR: could not query ${view_failures} issue(s) from PR #${pr_number} closing refs (gh command failed)." >&2
     return 1
+  fi
+  return 0
+}
+
+# warn_unprocessed_title_refs <pr_repo> <pr_number> <processed_newline_list>
+# A PR title like "fix(#2053,#2055): ..." references issues without a closing
+# keyword; neither GitHub nor this script closes them. Say so loudly instead
+# of silently processing a subset (#1391): list every #N in the title that is
+# not in the processed list.
+warn_unprocessed_title_refs() {
+  local pr_repo="$1" pr_number="$2" processed="$3"
+  local title refs ref unprocessed=""
+  title="$(gh pr view "$pr_number" --repo "$pr_repo" --json title --jq '.title // ""' 2>/dev/null)" || return 0
+  refs="$(printf '%s' "$title" | grep -oE '#[0-9]+' | tr -d '#' | sort -un)" || return 0
+  [ -n "$refs" ] || return 0
+  while IFS= read -r ref; do
+    [ -z "$ref" ] && continue
+    if ! printf '%s
+' "$processed" | grep -qx "$ref"; then
+      unprocessed="${unprocessed} #${ref}"
+    fi
+  done <<< "$refs"
+  if [ -n "$unprocessed" ]; then
+    echo "WARNING: PR #${pr_number} title references issue(s)${unprocessed} without a closing keyword; they were NOT closed or status-updated. If this PR resolved them, update them manually or add closing keywords next time." >&2
   fi
   return 0
 }
@@ -764,6 +796,7 @@ if [ -n "$ISSUE_IDENTIFIER" ]; then
     if [ -n "$PR_OVERRIDE_ISSUES" ]; then
       echo "Team-prefixed identifier '$ISSUE_IDENTIFIER' in branch '$TO_DELETE' is ambiguous; using closing keyword refs from PR #${PR_FOR_OVERRIDE} instead: $(printf '%s' "$PR_OVERRIDE_ISSUES" | tr '\n' ' ')"
       close_issues_from_pr "$PR_FOR_OVERRIDE" "$PR_OVERRIDE_ISSUES" || exit 1
+      warn_unprocessed_title_refs "$pr_override_repo" "$PR_FOR_OVERRIDE" "$PR_OVERRIDE_ISSUES"
     else
       # Update the tracker status BEFORE closing the issue so that
       # gh project item-list can still find the item (it only returns items
@@ -774,23 +807,25 @@ if [ -n "$ISSUE_IDENTIFIER" ]; then
         echo "ERROR: could not query issue #$ISSUE_NUMBER (gh command failed)." >&2
         exit 1
       fi
+      # Resolve the merged PR up front: the branch-derived issue needs it for
+      # the close comment, and the PR's own closing refs (#1391) need it even
+      # when the branch issue is already closed.
+      merged_pr_repo="$TARGET_GITHUB_REPO"
+      if [ -z "$merged_pr_repo" ]; then
+        if ! merged_pr_repo="$(repo_slug)"; then
+          echo "ERROR: could not resolve GitHub repository for merged PR lookup." >&2
+          exit 1
+        fi
+      fi
+      if [ -n "$merged_pr_number" ]; then
+        MERGED_PR="$merged_pr_number"
+      else
+        MERGED_PR="$(gh pr list --repo "$merged_pr_repo" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty')" || {
+          echo "ERROR: could not query merged PRs for branch '$TO_DELETE' in '$merged_pr_repo' (gh command failed)." >&2
+          exit 1
+        }
+      fi
       if [ "$ISSUE_STATE" = "OPEN" ]; then
-        # Find the merged PR for this branch.
-        merged_pr_repo="$TARGET_GITHUB_REPO"
-        if [ -z "$merged_pr_repo" ]; then
-          if ! merged_pr_repo="$(repo_slug)"; then
-            echo "ERROR: could not resolve GitHub repository for merged PR lookup." >&2
-            exit 1
-          fi
-        fi
-        if [ -n "$merged_pr_number" ]; then
-          MERGED_PR="$merged_pr_number"
-        else
-          MERGED_PR="$(gh pr list --repo "$merged_pr_repo" --state merged --head "$TO_DELETE" --limit 1 --json number --jq '.[0].number // empty')" || {
-            echo "ERROR: could not query merged PRs for branch '$TO_DELETE' in '$merged_pr_repo' (gh command failed)." >&2
-            exit 1
-          }
-        fi
         if [ -n "$MERGED_PR" ]; then
           CLOSE_COMMENT="Closed by PR #${MERGED_PR}."
         elif [ -n "$VERIFIED_MERGED_PR" ]; then
@@ -810,6 +845,21 @@ if [ -n "$ISSUE_IDENTIFIER" ]; then
         fi
       else
         echo "Issue #$ISSUE_NUMBER is already $ISSUE_STATE, skipping close."
+      fi
+      # The branch names one issue; the PR may resolve more (#1391). Process
+      # every closing reference from the PR title, body, and commit messages
+      # that is not the branch-derived issue, and warn about bare title refs.
+      if [ -n "${MERGED_PR:-}" ]; then
+        if ! EXTRA_CLOSES="$(fetch_pr_closing_issues "$merged_pr_repo" "$MERGED_PR")"; then
+          echo "ERROR: could not fetch PR #${MERGED_PR} closing refs from '$merged_pr_repo' (gh command failed)." >&2
+          exit 1
+        fi
+        EXTRA_CLOSES="$(printf '%s\n' "$EXTRA_CLOSES" | grep -vx "$ISSUE_NUMBER" || true)"
+        if [ -n "$EXTRA_CLOSES" ]; then
+          echo "PR #${MERGED_PR} also closes: $(printf '%s' "$EXTRA_CLOSES" | tr '\n' ' ')"
+          close_issues_from_pr "$MERGED_PR" "$EXTRA_CLOSES" || exit 1
+        fi
+        warn_unprocessed_title_refs "$merged_pr_repo" "$MERGED_PR" "$(printf '%s\n%s' "$ISSUE_NUMBER" "$EXTRA_CLOSES")"
       fi
     fi
   elif [ "$BRANCH_TYPE" = "spec" ]; then
@@ -854,6 +904,7 @@ else
           echo "Found closing keyword refs in PR #${CLOSING_PR}: issues $(printf '%s' "$CLOSES_ISSUES" | tr '\n' ' ')"
           cd "$HUB_REPO_ROOT"
           close_issues_from_pr "$CLOSING_PR" "$CLOSES_ISSUES" || exit 1
+          warn_unprocessed_title_refs "$pr_closes_repo" "$CLOSING_PR" "$CLOSES_ISSUES"
         else
           echo "No issue number in branch name '$TO_DELETE' or PR #${CLOSING_PR} body; skipping issue close and tracker update."
         fi

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -693,6 +693,10 @@ close_issues_from_pr() {
 # helper whose whole purpose is avoiding a silent gap could itself go silent
 # on a transient `gh` failure, indistinguishable from "no bare refs found".
 warn_unprocessed_title_refs() {
+  if [ "$#" -ne 3 ] || [ -z "${1:-}" ] || [[ ! "${2:-}" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: warn_unprocessed_title_refs requires <pr_repo> (non-empty) <pr_number> (numeric) <processed_newline_list>." >&2
+    return 2
+  fi
   local pr_repo="$1" pr_number="$2" processed="$3"
   local title refs ref unprocessed=""
   title="$(gh pr view "$pr_number" --repo "$pr_repo" --json title --jq '.title // ""' 2>/dev/null)" || {

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -133,6 +133,12 @@ case "$1 $2" in
       else
         printf '\n'
       fi
+    elif [[ "$args" == *"--json commits"* ]]; then
+      # Emulates '[.commits[] | ...] | join("\n")' — tests control it via
+      # GH_PR_COMMITS_TEXT (already-joined text, may be empty).
+      printf '%s\n' "${GH_PR_COMMITS_TEXT:-}"
+    elif [[ "$args" == *"--json title "* || "$args" == *'--json title'* ]]; then
+      printf '%s\n' "${GH_PR_TITLE:-}"
     elif [[ "$args" == *"--json body,title"* ]]; then
       # Emulates the real command's jq filter
       # '(.title // "") + "\n" + (.body // "")' without invoking jq, so tests
@@ -402,6 +408,56 @@ run_test "failed_delete_local_branch_remains" "yes" "$(
 # the fix: a false-positive slug overridden by the PR body, a team-prefixed
 # slug whose PR body confirms the same issue, and a team-prefixed slug with
 # no PR-body closing reference falling back to the slug-derived issue.
+
+# #1391: a numeric branch names one issue; the PR may resolve more. Closing
+# refs from body/commits are processed as extras, and bare title refs warn.
+multi_branch="fix/1520-retro-followups"
+multi_repo="$(make_repo multi-close "$multi_branch" yes)"
+multi_output="$(
+  GH_MERGED_HEAD="$multi_branch" \
+  GH_MERGED_PR=1521 \
+  GH_PR_TITLE="fix(#1520): retro followups" \
+  GH_PR_BODY="Also resolves the report tracked separately. Closes #1517" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$multi_repo" --base develop --pr 1521 "$multi_branch"
+)"
+run_contains "branch_issue_still_closed" "Closing issue #1520..." "$multi_output"
+run_contains "body_extra_ref_processed" "Processing issue #1517 from PR #1521" "$multi_output"
+run_contains "extras_announced" "PR #1521 also closes: 1517" "$multi_output"
+
+commitmsg_branch="fix/1600-commit-ref"
+commitmsg_repo="$(make_repo commitmsg-close "$commitmsg_branch" yes)"
+commitmsg_output="$(
+  GH_MERGED_HEAD="$commitmsg_branch" \
+  GH_MERGED_PR=1601 \
+  GH_PR_TITLE="fix(#1600): thing" \
+  GH_PR_BODY="No closing keyword in the body." \
+  GH_PR_COMMITS_TEXT="fix: the thing
+Closes #1602" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$commitmsg_repo" --base develop --pr 1601 "$commitmsg_branch"
+)"
+run_contains "commit_message_ref_processed" "Processing issue #1602 from PR #1601" "$commitmsg_output"
+
+bare_branch="fix/2053-first-of-two"
+bare_repo="$(make_repo bare-title "$bare_branch" yes)"
+bare_output="$(
+  GH_MERGED_HEAD="$bare_branch" \
+  GH_MERGED_PR=2060 \
+  GH_PR_TITLE="fix(#2053,#2055): shared component edits" \
+  GH_PR_BODY="No closing keywords." \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$bare_repo" --base develop --pr 2060 "$bare_branch" 2>&1
+)"
+run_contains "bare_title_ref_warns_loudly" "title references issue(s) #2055 without a closing keyword" "$bare_output"
+run_test "bare_title_ref_branch_issue_not_warned" "no" \
+  "$(if grep -Fq "#2053 without" <<<"$bare_output"; then printf yes; else printf no; fi)"
 
 false_positive_branch="fix/retro-517-doc-gaps"
 false_positive_repo="$(make_repo false-positive "$false_positive_branch" yes)"

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -438,8 +438,7 @@ commitmsg_output="$(
   GH_MERGED_PR=1601 \
   GH_PR_TITLE="fix(#1600): thing" \
   GH_PR_BODY="No closing keyword in the body." \
-  GH_PR_COMMITS_TEXT="fix: the thing
-Closes #1602" \
+  GH_PR_COMMITS_TEXT=$'fix: the thing\nCloses #1602' \
   GH_ISSUE_STATE=OPEN \
   WORKFLOW_TARGET_GITHUB_REPO=example/repo \
   PATH="$stub_bin:$PATH" \

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -138,6 +138,10 @@ case "$1 $2" in
       # GH_PR_COMMITS_TEXT (already-joined text, may be empty).
       printf '%s\n' "${GH_PR_COMMITS_TEXT:-}"
     elif [[ "$args" == *"--json title "* || "$args" == *'--json title'* ]]; then
+      if [ -n "${GH_PR_TITLE_FETCH_FAIL:-}" ]; then
+        echo "mock pr view --json title failure" >&2
+        exit 1
+      fi
       printf '%s\n' "${GH_PR_TITLE:-}"
     elif [[ "$args" == *"--json body,title"* ]]; then
       # Emulates the real command's jq filter
@@ -443,6 +447,33 @@ Closes #1602" \
 )"
 run_contains "commit_message_ref_processed" "Processing issue #1602 from PR #1601" "$commitmsg_output"
 
+# #1391: title/body and commit text must be fence-stripped SEPARATELY. An
+# unclosed fence in the PR body extends "to end of input" by design (see the
+# unclosed_fence_extends_to_end_of_input test above); if body and commit text
+# were combined before stripping, that same unclosed-fence rule would treat
+# every commit message as inside the fence too and silently drop a live
+# commit-message closing reference as collateral damage.
+unclosed_body_fence_branch="fix/1610-unclosed-body-fence"
+unclosed_body_fence_repo="$(make_repo unclosed-body-fence "$unclosed_body_fence_branch" yes)"
+unclosed_body_fence_output="$(
+  GH_MERGED_HEAD="$unclosed_body_fence_branch" \
+  GH_MERGED_PR=1611 \
+  GH_PR_TITLE="fix(#1610): thing" \
+  GH_PR_BODY='Accidentally unclosed fence below.
+
+```
+some example text' \
+  GH_PR_COMMITS_TEXT="fix: the thing
+Closes #1612" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$unclosed_body_fence_repo" --base develop --pr 1611 "$unclosed_body_fence_branch"
+)"
+run_contains "unclosed_body_fence_does_not_swallow_commit_ref" \
+  "Processing issue #1612 from PR #1611" \
+  "$unclosed_body_fence_output"
+
 bare_branch="fix/2053-first-of-two"
 bare_repo="$(make_repo bare-title "$bare_branch" yes)"
 bare_output="$(
@@ -458,6 +489,45 @@ bare_output="$(
 run_contains "bare_title_ref_warns_loudly" "title references issue(s) #2055 without a closing keyword" "$bare_output"
 run_test "bare_title_ref_branch_issue_not_warned" "no" \
   "$(if grep -Fq "#2053 without" <<<"$bare_output"; then printf yes; else printf no; fi)"
+
+# #1391: the branch-derived issue may already be closed (e.g. a re-run, or an
+# issue closed by hand before cleanup ran) — extras from the PR body/commits
+# must still be processed rather than being skipped along with the branch
+# issue's own (redundant) close step.
+already_closed_branch="fix/1800-already-closed-with-extra"
+already_closed_repo="$(make_repo already-closed-extra "$already_closed_branch" yes)"
+already_closed_output="$(
+  GH_MERGED_HEAD="$already_closed_branch" \
+  GH_MERGED_PR=1801 \
+  GH_PR_TITLE="fix(#1800): thing" \
+  GH_PR_BODY="Also closes #1802" \
+  GH_ISSUE_STATE=CLOSED \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$already_closed_repo" --base develop --pr 1801 "$already_closed_branch"
+)"
+run_contains "already_closed_branch_issue_skips_close" "Issue #1800 is already CLOSED, skipping close." "$already_closed_output"
+run_contains "already_closed_branch_extra_still_processed" "Processing issue #1802 from PR #1801" "$already_closed_output"
+
+# #1391: a transient failure fetching the PR title for the bare-ref check
+# must not go completely silent — it is the one helper whose purpose is
+# avoiding exactly that kind of silent gap.
+title_fetch_fail_branch="fix/1900-title-fetch-fails"
+title_fetch_fail_repo="$(make_repo title-fetch-fail "$title_fetch_fail_branch" yes)"
+title_fetch_fail_output="$(
+  GH_MERGED_HEAD="$title_fetch_fail_branch" \
+  GH_MERGED_PR=1901 \
+  GH_PR_TITLE="fix(#1900): thing" \
+  GH_PR_BODY="No closing keywords." \
+  GH_ISSUE_STATE=OPEN \
+  GH_PR_TITLE_FETCH_FAIL=1 \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$title_fetch_fail_repo" --base develop --pr 1901 "$title_fetch_fail_branch" 2>&1
+)"
+run_contains "title_fetch_failure_warns_instead_of_silent" \
+  "could not fetch PR #1901 title to check for unprocessed bare issue references" \
+  "$title_fetch_fail_output"
 
 false_positive_branch="fix/retro-517-doc-gaps"
 false_positive_repo="$(make_repo false-positive "$false_positive_branch" yes)"

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -458,10 +458,7 @@ unclosed_body_fence_output="$(
   GH_MERGED_HEAD="$unclosed_body_fence_branch" \
   GH_MERGED_PR=1611 \
   GH_PR_TITLE="fix(#1610): thing" \
-  GH_PR_BODY='Accidentally unclosed fence below.
-
-```
-some example text' \
+  GH_PR_BODY=$'Accidentally unclosed fence below.\n\n```\nsome example text' \
   GH_PR_COMMITS_TEXT="fix: the thing
 Closes #1612" \
   GH_ISSUE_STATE=OPEN \


### PR DESCRIPTION
Closes #1391.

## Problem
When a PR resolves more than one item, `post-merge-cleanup.sh` updated only the branch-derived issue. Both reported reproductions are covered: `Closes #1517` in a PR whose branch named #1520 was ignored (the numeric-branch path never consulted closing refs), and commit-message references were never scanned anywhere — GitHub only honours them on default-branch merges, and this repo merges to `develop`.

## Fix
- `fetch_pr_closing_issues` scans commit messages (`--json commits`) in addition to the PR title and body (fence-stripping applies to the combined text).
- The numeric-branch path resolves the merged PR up front and, after the branch issue, runs `close_issues_from_pr` over every closing reference that is not the branch issue (`PR #N also closes: …`); a fetch failure is fatal, matching the other call sites.
- Bare `#N` title references without a closing keyword (`fix(#2053,#2055): …`) produce a loud warning at all three call sites naming exactly what was not processed — the "warn loudly" option from the issue, applied to the one form that is semantically ambiguous.
- Protocol 91 Step 10 and Protocol 95 Step 11 now state that post-merge verification is per referenced item.

## Verification
- `test-post-merge-cleanup.sh`: 54/0 (was 48) — new: `body_extra_ref_processed` / `extras_announced` (the #1521 shape), `commit_message_ref_processed`, `bare_title_ref_warns_loudly` (+ branch issue excluded from the warning); all pre-existing paths unchanged.
- guard lint, snippet lint (committed diff), shellcheck `--severity=warning`, markdownlint, CHANGELOG heuristic + duplicate-header: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Post-merge cleanup now processes all issues referenced by a pull request’s branch, title, body, and commit messages.
  - Added warnings for issue references in titles that lack closing keywords.
  - Cleanup verification now confirms tracker transitions for every referenced issue.

- **Documentation**
  - Updated workflow guidance to cover multiple issue references and per-item post-merge verification.

- **Bug Fixes**
  - Improved handling of fenced content and already-closed issues during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->