### PR TITLE
fix(codex-reviewer): classify not-connected; recover after refusal (#1522, #1526)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trigger-comment idempotency guard, which keys only on the head SHA, made
   any unavailability terminal: once Codex answered a trigger with a refusal,
   every later run for that commit skipped the post and re-read the stale
-  reply. When the newest bot reply to an existing trigger is a refusal, the
-  trigger is now treated as spent and a fresh one is posted.
+  reply. When the newest bot reply to an existing trigger is any refusal —
+  usage limit, account not connected, or missing environment — the trigger is
+  now treated as spent and a fresh one is posted.
 - **`post-merge-cleanup.sh` now processes every issue a PR resolves**
   (#1391): closing references in the PR title, body, and commit messages are
   processed in addition to the branch-derived issue, and bare `#N` title

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **Codex reviewer unavailability is classified and recoverable** (#1522,
+  #1526): the Codex GitHub App's "create a Codex account and connect to
+  github" refusal — which it returns per triggering identity, so an org-wide
+  install can work for one developer and refuse for another — was not matched
+  at all and fell through to the safe-fail blocking verdict. It now returns
+  `VERDICT: UNAVAILABLE` / `REASON=codex-github-account-not-connected`
+  (exit 3), quote-stripped and fence-guarded like the usage-limit check. The
+  trigger-comment idempotency guard, which keys only on the head SHA, made
+  any unavailability terminal: once Codex answered a trigger with a refusal,
+  every later run for that commit skipped the post and re-read the stale
+  reply. When the newest bot reply to an existing trigger is a refusal, the
+  trigger is now treated as spent and a fresh one is posted.
 - **`post-merge-cleanup.sh` now processes every issue a PR resolves**
   (#1391): closing references in the PR title, body, and commit messages are
   processed in addition to the branch-derived issue, and bare `#N` title

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -346,6 +346,23 @@ codex_response_is_environment_error() {
   grep -qiE "to[[:space:]]+use[[:space:]]+codex[[:space:]]+here,[[:space:]]+create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo" <<< "$response"
 }
 
+# codex_response_is_account_not_connected <response>
+# The Codex GitHub App refuses with an account-connection prompt when the
+# triggering GitHub identity has no linked Codex account (Codex attributes
+# reviews per triggering identity, so an org-wide install can work for one
+# developer and refuse for another). That is reviewer unavailability, not a
+# code-review finding (#1522) — without this it fell to the safe-fail
+# NEEDS_REVISION path and reported a blocking finding with nothing to fix.
+# Fence-guarded and quote-stripped by the caller, like the usage-limit check,
+# so a review that merely quotes the refusal text is not misclassified.
+codex_response_is_account_not_connected() {
+  local response="$1"
+  if codex_response_has_fence_marker "$response"; then
+    return 1
+  fi
+  grep -qiE "to[[:space:]]+use[[:space:]]+codex[[:space:]]+here,[[:space:]]+(\[)?create[[:space:]]+a[[:space:]]+codex[[:space:]]+account[[:space:]]+and[[:space:]]+connect" <<< "$response"
+}
+
 codex_response_reviews_current_head() {
   local response="$1"
   local reviewed_sha
@@ -1225,6 +1242,18 @@ codex_return_environment_error() {
   exit 2
 }
 
+codex_return_account_not_connected() {
+  echo "VERDICT: UNAVAILABLE — Codex GitHub account is not connected for the triggering identity"
+  echo "REASON=codex-github-account-not-connected"
+  echo "COMMENT_COUNT=0"
+  echo "BLOCKING_COUNT=0"
+  echo "SUGGESTION_COUNT=0"
+  echo "---BEGIN BOT RESPONSE---"
+  echo "$1"
+  echo "---END BOT RESPONSE---"
+  exit 3
+}
+
 codex_return_reaction_without_review() {
   echo "VERDICT: TIMED_OUT — Codex thumbs-up reaction is not SHA-pinned review evidence (treated as unavailable)"
   echo "REASON=codex-github-reaction-without-review"
@@ -1302,6 +1331,30 @@ if [ -n "$TRIGGER_COMMENT_INFO" ]; then
     echo "ERROR: existing trigger comment payload missing created_at" >&2
     echo "VERDICT: TIMED_OUT — malformed trigger comment payload (treated as unavailable)"
     exit 2
+  fi
+  if [ -n "$TRIGGER_TIME" ]; then
+    # Recovery after an unavailability reply (#1526). The guard keys only on
+    # the head SHA, so once Codex answered a trigger with a usage-limit or
+    # account-connection refusal, every later run for that same commit found
+    # the old trigger, skipped posting, and re-read the stale refusal — the
+    # commit could never be reviewed again without a new push. If the bot's
+    # newest reply after that trigger is a refusal (not a review), treat the
+    # trigger as spent and post a fresh one.
+    CODEX_LAST_REPLY=""
+    if CODEX_LAST_REPLY=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate 2>/dev/null \
+      | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg since "$TRIGGER_TIME" \
+        '[.[][] | select((.user.login == $bot or .user.login == $bot_plain) and .created_at >= $since)]
+         | sort_by(.created_at) | last | .body // ""'); then
+      if [ -n "$CODEX_LAST_REPLY" ] && \
+        { codex_response_is_usage_limit "$(codex_strip_quoted_spans "$CODEX_LAST_REPLY")" || \
+          codex_response_is_account_not_connected "$(codex_strip_quoted_spans "$CODEX_LAST_REPLY")"; }; then
+        echo "INFO: previous trigger for commit $CURRENT_SHA was answered with a reviewer-unavailability refusal — re-triggering so a restored quota/connection can review this commit"
+        TRIGGER_TIME=""
+        TRIGGER_COMMENT_ID=""
+      fi
+    else
+      echo "WARNING: could not read bot replies to check whether the existing trigger was refused; keeping the existing trigger" >&2
+    fi
   fi
   if [ -n "$TRIGGER_TIME" ]; then
     echo "INFO: trigger comment already posted for commit $CURRENT_SHA (at $TRIGGER_TIME) — skipping duplicate post"
@@ -1587,6 +1640,10 @@ while true; do
       # (fresh evidence from PR #1490 finding 3793259351, a followup to
       # 3790122058/3793219190/3793219192).
       codex_return_usage_limit "$BOT_RESPONSE"
+    elif codex_response_is_account_not_connected "$(codex_strip_quoted_spans "$BOT_RESPONSE_FULL")"; then
+      # Same shape as the usage-limit branch: no source gate (the refusal can
+      # arrive as a comment or a review) and quote-stripped first (#1522).
+      codex_return_account_not_connected "$BOT_RESPONSE"
     elif [ "$BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$BOT_RESPONSE_FULL"; then
       SEEN_ENVIRONMENT_ERROR=1
       SEEN_ENVIRONMENT_RESPONSE="$BOT_RESPONSE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -837,7 +837,7 @@ codex_response_priority() {
   # APPROVED (fresh evidence from PR #1490 finding 3796982553).
   if [ "$state" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$body"; then
     printf '3\n'
-  elif codex_response_is_usage_limit "$body" || codex_response_is_environment_error "$body"; then
+  elif codex_response_is_usage_limit "$body" || codex_response_is_environment_error "$body" || codex_response_is_account_not_connected "$body"; then
     printf '1\n'
   elif codex_response_is_approved "$body"; then
     printf '0\n'
@@ -958,7 +958,7 @@ codex_scan_comment_evidence() {
     is_usage_limit=0
     if [ "$is_terminal" -eq 0 ]; then
       codex_response_is_usage_limit "$body" && is_usage_limit=1
-      if [ "$is_usage_limit" -eq 1 ] || codex_response_is_environment_error "$body"; then
+      if [ "$is_usage_limit" -eq 1 ] || codex_response_is_environment_error "$body" || codex_response_is_account_not_connected "$body"; then
         is_actionable=1
       fi
     fi
@@ -1863,6 +1863,9 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
     # Quote-stripped before checking — see the main-loop equivalent above
     # for the rationale (PR #1490 finding 3793259351).
     codex_return_usage_limit "$ASYNC_BOT_RESPONSE"
+  elif codex_response_is_account_not_connected "$(codex_strip_quoted_spans "$ASYNC_BOT_RESPONSE_FULL")"; then
+    # Same shape as the usage-limit branch above (#1522).
+    codex_return_account_not_connected "$ASYNC_BOT_RESPONSE"
   elif [ "$ASYNC_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_BOT_RESPONSE_FULL"; then
     SEEN_ENVIRONMENT_ERROR=1
     SEEN_ENVIRONMENT_RESPONSE="$ASYNC_BOT_RESPONSE"
@@ -1967,6 +1970,9 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
         # Quote-stripped before checking — see the main-loop equivalent
         # above for the rationale (PR #1490 finding 3793259351).
         codex_return_usage_limit "$ASYNC_FINAL_BOT_RESPONSE"
+      elif codex_response_is_account_not_connected "$(codex_strip_quoted_spans "$ASYNC_FINAL_BOT_RESPONSE_FULL")"; then
+        # Same shape as the usage-limit branch above (#1522).
+        codex_return_account_not_connected "$ASYNC_FINAL_BOT_RESPONSE"
       elif [ "$ASYNC_FINAL_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_FINAL_BOT_RESPONSE_FULL"; then
         SEEN_ENVIRONMENT_ERROR=1
         SEEN_ENVIRONMENT_RESPONSE="$ASYNC_FINAL_BOT_RESPONSE"
@@ -2119,6 +2125,9 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
       # Quote-stripped before checking — see the main-loop equivalent
       # above for the rationale (PR #1490 finding 3793259351).
       codex_return_usage_limit "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
+    elif codex_response_is_account_not_connected "$(codex_strip_quoted_spans "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL")"; then
+      # Same shape as the usage-limit branch above (#1522).
+      codex_return_account_not_connected "$ASYNC_REACTION_FINAL_BOT_RESPONSE"
     elif [ "$ASYNC_REACTION_FINAL_BOT_RESPONSE_SOURCE" = "comment" ] && codex_response_is_environment_error "$ASYNC_REACTION_FINAL_BOT_RESPONSE_FULL"; then
       SEEN_ENVIRONMENT_ERROR=1
       SEEN_ENVIRONMENT_RESPONSE="$ASYNC_REACTION_FINAL_BOT_RESPONSE"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -1197,6 +1197,18 @@ codex_combine_terminal_evidence() {
       COMBINED_REVIEW_STATE=""
       echo "INFO: $label usage-limit notice takes immediate precedence over terminal/review evidence, including same-fetch evidence"
     fi
+  elif [ "$comment_latest_is_terminal" -eq 0 ] && [ -n "$comment_latest_body" ] && codex_response_is_account_not_connected "$comment_latest_body"; then
+    if [ -n "$COMBINED_SOURCE" ] && { [ "$COMBINED_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$COMBINED_BODY"; }; then
+      # Same contract as the usage-limit block above: blocking evidence is
+      # never discarded by an unavailability notice (CodeRabbit on PR #1586).
+      :
+    else
+      COMBINED_BODY="$comment_latest_body"
+      COMBINED_TIME="$comment_latest_time"
+      COMBINED_SOURCE="comment"
+      COMBINED_REVIEW_STATE=""
+      echo "INFO: $label account-connection refusal takes immediate precedence over terminal/review evidence, including same-fetch evidence"
+    fi
   elif [ "$comment_latest_is_terminal" -eq 0 ] && [ -n "$comment_latest_body" ] && codex_response_is_environment_error "$comment_latest_body"; then
     if [ -n "$COMBINED_SOURCE" ] && { [ "$COMBINED_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$COMBINED_BODY"; }; then
       # Blocking terminal/review evidence always wins outright — it is

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -1347,7 +1347,8 @@ if [ -n "$TRIGGER_COMMENT_INFO" ]; then
          | sort_by(.created_at) | last | .body // ""'); then
       if [ -n "$CODEX_LAST_REPLY" ] && \
         { codex_response_is_usage_limit "$(codex_strip_quoted_spans "$CODEX_LAST_REPLY")" || \
-          codex_response_is_account_not_connected "$(codex_strip_quoted_spans "$CODEX_LAST_REPLY")"; }; then
+          codex_response_is_account_not_connected "$(codex_strip_quoted_spans "$CODEX_LAST_REPLY")" || \
+          codex_response_is_environment_error "$(codex_strip_quoted_spans "$CODEX_LAST_REPLY")"; }; then
         echo "INFO: previous trigger for commit $CURRENT_SHA was answered with a reviewer-unavailability refusal — re-triggering so a restored quota/connection can review this commit"
         TRIGGER_TIME=""
         TRIGGER_COMMENT_ID=""

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3856,6 +3856,41 @@ run_test "codex_refused_trigger_does_not_skip_as_duplicate" "no" \
 rm -rf "$_codex_retrig_dir"
 unset _codex_retrig_dir _codex_retrig_output
 
+# The environment-error refusal is the third unavailability form and must be
+# recovered from identically (pr-agent on PR #1586).
+_codex_envretrig_dir="$(mktemp -d)"
+cat > "$_codex_envretrig_dir/gh" <<'CODEX_ENVRETRIG_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+case "$*" in
+  *"auth status"*) exit 0 ;;
+  *"pr view"*headRefOid*) printf 'abcenvretrig123456\n'; exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":301,"created_at":"2026-01-01T00:10:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*) printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*) printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*) printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":200,"created_at":"2026-01-01T00:00:00Z","user":{"login":"runner"},"body":"Review triggered by workflow runner for abcenvretrig123456"},{"id":201,"created_at":"2026-01-01T00:00:05Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"To use Codex here, create an environment for this repo."}]\n'
+    exit 0 ;;
+  *) printf 'ERROR=unexpected-gh-invocation\n' >&2; exit 64 ;;
+esac
+CODEX_ENVRETRIG_GH
+chmod +x "$_codex_envretrig_dir/gh"
+: > "$_codex_envretrig_dir/posts.log"
+MOCK_POST_LOG="$_codex_envretrig_dir/posts.log" PATH="$_codex_envretrig_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_envretrig_dir/output.txt" 2>&1 || true
+_codex_envretrig_output="$(cat "$_codex_envretrig_dir/output.txt")"
+run_test "codex_env_error_trigger_is_retriggered" "yes" \
+  "$(if grep -Fq "re-triggering so a restored quota/connection can review this commit" <<<"$_codex_envretrig_output"; then printf yes; else printf no; fi)"
+run_test "codex_env_error_trigger_posts_new_comment" "yes" \
+  "$(if grep -Fq POST "$_codex_envretrig_dir/posts.log"; then printf yes; else printf no; fi)"
+rm -rf "$_codex_envretrig_dir"
+unset _codex_envretrig_dir _codex_envretrig_output
+
 # --- #1522 (async-arrival path): the not-connected refusal must still be
 # classified as UNAVAILABLE when it only arrives during the post-poll-window
 # "async grace period" check, not just during the main poll loop. This

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3856,6 +3856,60 @@ run_test "codex_refused_trigger_does_not_skip_as_duplicate" "no" \
 rm -rf "$_codex_retrig_dir"
 unset _codex_retrig_dir _codex_retrig_output
 
+# --- #1522 (async-arrival path): the not-connected refusal must still be
+# classified as UNAVAILABLE when it only arrives during the post-poll-window
+# "async grace period" check, not just during the main poll loop. This
+# exercises a SEPARATE duplicate three-path classification chain in the
+# script (ASYNC_BOT_RESPONSE) that has its own usage-limit/environment-error
+# branches; without the account-not-connected branch mirrored there too, a
+# refusal seen only during the grace poll fell through to a generic
+# TIMED_OUT instead of the specific UNAVAILABLE/REASON verdict.
+_codex_notconn_async_dir="$(mktemp -d)"
+: > "$_codex_notconn_async_dir/calls.log"
+cat > "$_codex_notconn_async_dir/gh" <<'CODEX_NOTCONN_ASYNC_GH'
+#!/usr/bin/env bash
+log="$MOCK_CALL_LOG"
+case "$*" in
+  *"auth status"*) exit 0 ;;
+  *"pr view"*headRefOid*) printf 'abcnotconnasync1234\n'; exit 0 ;;
+  *"--method POST"*) printf '{"id":901,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*) printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*) printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*) printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    n=0
+    [ -f "$log" ] && n=$(cat "$log")
+    n=$((n + 1))
+    echo "$n" > "$log"
+    # First two reads (idempotency check + the single main-loop poll) see no
+    # reply yet; only the async-grace-period read sees the refusal, so the
+    # main poll loop's own (already-present) classification cannot be what
+    # catches this case.
+    if [ "$n" -le 2 ]; then
+      printf '[]\n'
+    else
+      printf '[{"id":902,"created_at":"2026-01-01T00:00:05Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"To use Codex here, [create a Codex account and connect to github](https://chatgpt.com/codex/cloud/settings/connectors)."}]\n'
+    fi
+    exit 0 ;;
+  *) printf 'ERROR=unexpected-gh-invocation\n' >&2; exit 64 ;;
+esac
+CODEX_NOTCONN_ASYNC_GH
+chmod +x "$_codex_notconn_async_dir/gh"
+_codex_notconn_async_exit=0
+MOCK_CALL_LOG="$_codex_notconn_async_dir/calls.log" PATH="$_codex_notconn_async_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_notconn_async_dir/output.txt" 2>&1 || _codex_notconn_async_exit=$?
+_codex_notconn_async_output="$(cat "$_codex_notconn_async_dir/output.txt")"
+run_test "codex_account_not_connected_async_exit_unavailable" "3" "$_codex_notconn_async_exit"
+run_test "codex_account_not_connected_async_verdict" \
+  "VERDICT: UNAVAILABLE — Codex GitHub account is not connected for the triggering identity" \
+  "$(printf '%s\n' "$_codex_notconn_async_output" | grep "^VERDICT:")"
+run_test "codex_account_not_connected_async_reason" "REASON=codex-github-account-not-connected" \
+  "$(printf '%s\n' "$_codex_notconn_async_output" | grep "^REASON=")"
+rm -rf "$_codex_notconn_async_dir"
+unset _codex_notconn_async_dir _codex_notconn_async_exit _codex_notconn_async_output
+
 _codex_usage_comment_mock_dir="$(mktemp -d)"
 cat > "$_codex_usage_comment_mock_dir/gh" <<'CODEX_USAGE_COMMENT_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3783,6 +3783,79 @@ run_test "codex_trigger_idempotency_paginated_single_object" "1" \
   "$(printf '%s\n' "$_codex_paginated_selected_trigger" | wc -l | tr -d ' ')"
 unset _codex_trigger_comments _codex_selected_trigger _codex_paginated_trigger_comments _codex_paginated_selected_trigger
 
+# --- #1522: the account-not-connected refusal is unavailability, not a finding
+_codex_notconn_dir="$(mktemp -d)"
+cat > "$_codex_notconn_dir/gh" <<'CODEX_NOTCONN_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*) exit 0 ;;
+  *"pr view"*headRefOid*) printf 'abcnotconn1234567890\n'; exit 0 ;;
+  *"--method POST"*) printf '{"id":101,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*) printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*) printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*) printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":201,"created_at":"2026-01-01T00:00:01Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"To use Codex here, [create a Codex account and connect to github](https://chatgpt.com/codex/cloud/settings/connectors)."}]\n'
+    exit 0 ;;
+  *) printf 'ERROR=unexpected-gh-invocation\n' >&2; exit 64 ;;
+esac
+CODEX_NOTCONN_GH
+chmod +x "$_codex_notconn_dir/gh"
+_codex_notconn_exit=0
+PATH="$_codex_notconn_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_notconn_dir/output.txt" 2>&1 || _codex_notconn_exit=$?
+_codex_notconn_output="$(cat "$_codex_notconn_dir/output.txt")"
+run_test "codex_account_not_connected_exit_unavailable" "3" "$_codex_notconn_exit"
+run_test "codex_account_not_connected_verdict" \
+  "VERDICT: UNAVAILABLE — Codex GitHub account is not connected for the triggering identity" \
+  "$(printf '%s\n' "$_codex_notconn_output" | grep "^VERDICT:")"
+run_test "codex_account_not_connected_reason" "REASON=codex-github-account-not-connected" \
+  "$(printf '%s\n' "$_codex_notconn_output" | grep "^REASON=")"
+run_test "codex_account_not_connected_blocking_count" "BLOCKING_COUNT=0" \
+  "$(printf '%s\n' "$_codex_notconn_output" | grep "^BLOCKING_COUNT=")"
+rm -rf "$_codex_notconn_dir"
+unset _codex_notconn_dir _codex_notconn_exit _codex_notconn_output
+
+# --- #1526: a trigger already answered with a refusal must be re-triggered,
+# so a restored quota/connection can review the same commit. Without the fix
+# the guard skipped the post and re-read the stale refusal forever.
+_codex_retrig_dir="$(mktemp -d)"
+cat > "$_codex_retrig_dir/gh" <<'CODEX_RETRIG_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+case "$*" in
+  *"auth status"*) exit 0 ;;
+  *"pr view"*headRefOid*) printf 'abcretrig1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":301,"created_at":"2026-01-01T00:10:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*) printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*) printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*) printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":200,"created_at":"2026-01-01T00:00:00Z","user":{"login":"runner"},"body":"Review triggered by workflow runner for abcretrig1234567890"},{"id":201,"created_at":"2026-01-01T00:00:05Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"You have reached your Codex usage limits for code reviews."}]\n'
+    exit 0 ;;
+  *) printf 'ERROR=unexpected-gh-invocation\n' >&2; exit 64 ;;
+esac
+CODEX_RETRIG_GH
+chmod +x "$_codex_retrig_dir/gh"
+: > "$_codex_retrig_dir/posts.log"
+MOCK_POST_LOG="$_codex_retrig_dir/posts.log" PATH="$_codex_retrig_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_retrig_dir/output.txt" 2>&1 || true
+_codex_retrig_output="$(cat "$_codex_retrig_dir/output.txt")"
+run_test "codex_refused_trigger_is_retriggered" "yes" \
+  "$(if grep -Fq "re-triggering so a restored quota/connection can review this commit" <<<"$_codex_retrig_output"; then printf yes; else printf no; fi)"
+run_test "codex_refused_trigger_posts_new_comment" "yes" \
+  "$(if grep -Fq POST "$_codex_retrig_dir/posts.log"; then printf yes; else printf no; fi)"
+run_test "codex_refused_trigger_does_not_skip_as_duplicate" "no" \
+  "$(if grep -Fq "skipping duplicate post" <<<"$_codex_retrig_output"; then printf yes; else printf no; fi)"
+rm -rf "$_codex_retrig_dir"
+unset _codex_retrig_dir _codex_retrig_output
+
 _codex_usage_comment_mock_dir="$(mktemp -d)"
 cat > "$_codex_usage_comment_mock_dir/gh" <<'CODEX_USAGE_COMMENT_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3818,6 +3818,59 @@ run_test "codex_account_not_connected_blocking_count" "BLOCKING_COUNT=0" \
 rm -rf "$_codex_notconn_dir"
 unset _codex_notconn_dir _codex_notconn_exit _codex_notconn_output
 
+# A same-fetch mix of a non-blocking review and an account-connection refusal
+# must classify as UNAVAILABLE, not as the review (CodeRabbit on PR #1586);
+# a BLOCKING review still wins outright, as for usage-limit.
+_codex_mixed_dir="$(mktemp -d)"
+cat > "$_codex_mixed_dir/gh" <<'CODEX_MIXED_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*) exit 0 ;;
+  *"pr view"*headRefOid*) printf 'abcmixed1234567890\n'; exit 0 ;;
+  *"--method POST"*) printf '{"id":101,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*) printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*) printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[{"id":401,"submitted_at":"2026-01-01T00:00:02Z","state":"COMMENTED","user":{"login":"chatgpt-codex-connector[bot]"},"body":"%s"}]\n' "${MOCK_REVIEW_BODY:-No blocking issues found. Reviewed commit: \`abcmixed1234567890\`}"
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":201,"created_at":"2026-01-01T00:00:03Z","user":{"login":"chatgpt-codex-connector[bot]"},"body":"%s"}]\n' "${MOCK_REFUSAL_OVERRIDE:-To use Codex here, [create a Codex account and connect to github](https://chatgpt.com/codex/cloud/settings/connectors).}"
+    exit 0 ;;
+  *) printf 'ERROR=unexpected-gh-invocation\n' >&2; exit 64 ;;
+esac
+CODEX_MIXED_GH
+chmod +x "$_codex_mixed_dir/gh"
+_codex_mixed_exit=0
+PATH="$_codex_mixed_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_mixed_dir/output.txt" 2>&1 || _codex_mixed_exit=$?
+run_test "codex_mixed_fetch_refusal_wins_over_clean_review" "3" "$_codex_mixed_exit"
+run_test "codex_mixed_fetch_refusal_reason" "REASON=codex-github-account-not-connected" \
+  "$(grep "^REASON=" "$_codex_mixed_dir/output.txt" || true)"
+_codex_mixed_blocking_exit=0
+MOCK_REVIEW_BODY="Changes requested: must fix the null deref. Reviewed commit: \`abcmixed1234567890\`" \
+PATH="$_codex_mixed_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_mixed_dir/blocking.txt" 2>&1 || _codex_mixed_blocking_exit=$?
+# Parity, not an independent guarantee: with a blocking review in the SAME
+# fetch, the pre-existing usage-limit path also returns UNAVAILABLE (measured
+# on develop: usage-limit → 3, environment-error → 2). The not-connected block
+# must behave identically to usage-limit rather than inventing a stricter
+# contract; the shared blocking-evidence gap is tracked separately.
+_codex_mixed_usage_exit=0
+MOCK_REVIEW_BODY="Changes requested: must fix the null deref. Reviewed commit: \`abcmixed1234567890\`" \
+MOCK_REFUSAL_OVERRIDE="You have reached your Codex usage limits for code reviews." \
+PATH="$_codex_mixed_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
+  >"$_codex_mixed_dir/usage.txt" 2>&1 || _codex_mixed_usage_exit=$?
+run_test "codex_mixed_fetch_not_connected_matches_usage_limit" \
+  "$_codex_mixed_usage_exit" "$_codex_mixed_blocking_exit"
+rm -rf "$_codex_mixed_dir"
+unset _codex_mixed_dir _codex_mixed_exit _codex_mixed_blocking_exit _codex_mixed_usage_exit
+
 # --- #1526: a trigger already answered with a refusal must be re-triggered,
 # so a restored quota/connection can review the same commit. Without the fix
 # the guard skipped the post and re-read the stale refusal forever.


### PR DESCRIPTION
Closes #1522. Closes #1526. (#1528 was verified already fixed on `develop` and closed with the measurement.)

## Problem

Two gaps in `codex-github-reviewer.sh`, both about reviewer *unavailability* being handled as something else:

1. **#1522** — the App's per-identity refusal, `To use Codex here, [create a Codex account and connect to github](…)`, matched no classifier. Measured against `develop` @ `1013dc67`: `codex_response_is_account_not_connected` did not exist and `codex_response_is_usage_limit` returns NOMATCH for it, so it fell to the documented safe-fail path and reported a blocking finding with nothing to fix (8 occurrences across 4 downstream PRs in the report).
2. **#1526** — the trigger-comment idempotency guard keys only on the head SHA. Once Codex answered a trigger with *any* refusal, every later run for that commit found the trigger, printed `skipping duplicate post`, and re-read the stale refusal. A restored quota could never review that commit without a new push.

## Fix

- `codex_response_is_account_not_connected` + `codex_return_account_not_connected` → `VERDICT: UNAVAILABLE`, `REASON=codex-github-account-not-connected`, exit 3. Placed directly after the usage-limit branch, with the same shape: no source gate (the refusal arrives as a comment or a review) and quote-stripped first, so a review that merely quotes the refusal is not misclassified.
- After the idempotency guard finds an existing trigger, it reads the newest bot reply since that trigger; if it is a usage-limit or connection refusal, the trigger is treated as spent (`TRIGGER_TIME=""`) and a fresh one is posted. A failure to read the replies keeps the existing trigger and warns, rather than posting duplicates blindly.

## Verification

- `test-pr-review-loop.sh --area 13`: **358/0** (was 351). 7 new cases.
- **Planted-violation proof**: with only `codex-github-reviewer.sh` reverted (tests kept), all 7 fail — 4 not-connected cases and 3 re-trigger cases — and pass with the fix. Note the reverted not-connected case reports `TIMED_OUT` under the test's 1s budget rather than the `NEEDS_REVISION` the downstream report saw; both are the same defect (no classifier), and the fix produces `UNAVAILABLE` either way.
- Matcher cross-checks: the quota phrase does not match the not-connected matcher and vice versa.
- guard lint, snippet lint (committed diff), shellcheck `--severity=warning`, markdownlint, CHANGELOG heuristic + duplicate-header: clean.

## Note on scope

Two issues in one PR: they are the same failure path in the same file (classify unavailability → recover from it), and #1526's recovery is what makes #1522's new classification actionable. Both are referenced with closing keywords, which the cleanup helper now handles per item (#1391, merged today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear handling when the Codex reviewer is unavailable because an account is not connected.
  * Unavailable reviews now report a specific reason and status, with no blocking findings.
  * Review attempts affected by usage limits, missing accounts, or missing environments can be retried automatically.

* **Bug Fixes**
  * Improved recognition of unavailable reviewer responses across standard and asynchronous review flows.

* **Tests**
  * Added coverage for unavailable statuses, retry behavior, and asynchronous response handling.

* **Documentation**
  * Documented the updated unavailable-review behavior in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->