### PR TITLE
fix(pr-ci-loop): green must mean CI ran, not that nothing failed (#1514, #1580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **CI "green" now requires evidence that CI ran** (#1514, #1580): a head with
+  no checks, or missing a workflow that ran on the PR's previous head, read as
+  green because nothing was failing or pending. GitHub builds no merge ref for
+  a `CONFLICTING` PR, so its `pull_request` workflows never start — measured on
+  PR #1577, where two pushes after it went `DIRTY` ran 4 checks instead of 16
+  and the loop still reported green. `pr-ci-loop.sh` now compares the current
+  head's check names against the previous head's and reports
+  `RESULT=red REASON=expected_checks_missing MISSING_CHECKS=…`, emits
+  `HEAD_SHA` and `CI_EVIDENCE=present|none`, and Protocol 91's readiness
+  Check 0 refuses a head with an empty check set and prints
+  `READINESS_HEAD_SHA` / `READINESS_CI_*`. `test-pr-ci-loop.sh` is new, closing
+  one of the four coverage gaps the selector reports.
 - **Codex reviewer unavailability is classified and recoverable** (#1522,
   #1526): the Codex GitHub App's "create a Codex account and connect to
   github" refusal — which it returns per triggering identity, so an org-wide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   suite set legitimately narrows or grows between heads by design) against
   the previous head's and reports
   `RESULT=red REASON=expected_checks_missing MISSING_CHECKS=…`, emits
-  `HEAD_SHA` and `CI_EVIDENCE=present|none`, and Protocol 91's readiness
+  `HEAD_SHA` and `CI_EVIDENCE=present|none|unknown`, and Protocol 91's
+  readiness
   Check 0 refuses a head with an empty check set — now counting commit
   statuses (CodeRabbit, Devin Review) alongside check-runs, since a
   status-only signal was previously invisible to this gate — and prints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a `CONFLICTING` PR, so its `pull_request` workflows never start — measured on
   PR #1577, where two pushes after it went `DIRTY` ran 4 checks instead of 16
   and the loop still reported green. `pr-ci-loop.sh` now compares the current
-  head's check names against the previous head's and reports
+  head's *workflow* names (not job/check names — a matrix workflow's selected
+  suite set legitimately narrows or grows between heads by design) against
+  the previous head's and reports
   `RESULT=red REASON=expected_checks_missing MISSING_CHECKS=…`, emits
   `HEAD_SHA` and `CI_EVIDENCE=present|none`, and Protocol 91's readiness
-  Check 0 refuses a head with an empty check set and prints
+  Check 0 refuses a head with an empty check set — now counting commit
+  statuses (CodeRabbit, Devin Review) alongside check-runs, since a
+  status-only signal was previously invisible to this gate — and prints
   `READINESS_HEAD_SHA` / `READINESS_CI_*`. `test-pr-ci-loop.sh` is new, closing
   one of the four coverage gaps the selector reports.
 - **Codex reviewer unavailability is classified and recoverable** (#1522,

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -2574,21 +2574,38 @@ esac
 # failing or still pending. Run Step 8 (pr-ci-loop.sh) first if CI is not green.
 HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-CI_FAILING=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
-  --jq '[.check_runs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length')
-CI_PENDING=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
-  --jq '[.check_runs[] | select(.status != "completed")] | length')
-CI_TOTAL=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq '.check_runs | length')
+# Read every page. The REST default page size is 30 and this repository
+# routinely exceeds it: the test matrix is diff-driven and adds one job per
+# selected suite, so PR #1568 carried 75 check-runs. A single-page read of
+# that head sees 30 of them, and a failure among the other 45 is invisible to
+# the very gate that decides "CI is green".
+#
+# `--slurp` cannot be combined with `--jq`, so each call returns an array of
+# whole pages and the aggregation is done by an external jq.
+#
+# Both reads fail closed. If either endpoint cannot be read, the gate does not
+# know the CI state, and "unknown" must never be labelled as green — the same
+# rule the CI_TOTAL check below applies to an empty check set.
+if ! CHECKS_PAGES=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" --paginate --slurp); then
+  echo "ERROR: could not read check-runs for $HEAD_SHA — refusing to label on an incomplete CI read."
+  exit 5
+fi
 # check-runs is GitHub Actions/App checks only — it does not include plain
 # commit statuses (CodeRabbit, Devin Review, and this repo's own
 # "Reviewer-loop completion guard" all post as statuses, not check-runs). A
 # PR whose CI signal is entirely statuses would otherwise read CI_TOTAL=0
 # below and be refused even when green, and a failing status would not count
 # toward CI_FAILING at all. Fold the combined-status endpoint in too.
-STATUS_JSON=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" --jq '.statuses // []')
-CI_FAILING=$((CI_FAILING + $(printf '%s' "$STATUS_JSON" | jq '[.[] | select(.state == "failure" or .state == "error")] | length')))
-CI_PENDING=$((CI_PENDING + $(printf '%s' "$STATUS_JSON" | jq '[.[] | select(.state == "pending")] | length')))
-CI_TOTAL=$((CI_TOTAL + $(printf '%s' "$STATUS_JSON" | jq 'length')))
+if ! STATUS_PAGES=$(gh api "repos/$REPO/commits/$HEAD_SHA/status?per_page=100" --paginate --slurp); then
+  echo "ERROR: could not read commit statuses for $HEAD_SHA — refusing to label on an incomplete CI read."
+  exit 5
+fi
+CI_FAILING=$(printf '%s' "$CHECKS_PAGES" | jq '[.[].check_runs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length')
+CI_PENDING=$(printf '%s' "$CHECKS_PAGES" | jq '[.[].check_runs[] | select(.status != "completed")] | length')
+CI_TOTAL=$(printf '%s' "$CHECKS_PAGES" | jq '[.[].check_runs[]] | length')
+CI_FAILING=$((CI_FAILING + $(printf '%s' "$STATUS_PAGES" | jq '[.[].statuses[]? | select(.state == "failure" or .state == "error")] | length')))
+CI_PENDING=$((CI_PENDING + $(printf '%s' "$STATUS_PAGES" | jq '[.[].statuses[]? | select(.state == "pending")] | length')))
+CI_TOTAL=$((CI_TOTAL + $(printf '%s' "$STATUS_PAGES" | jq '[.[].statuses[]?] | length')))
 if [ "$CI_FAILING" -gt 0 ] || [ "$CI_PENDING" -gt 0 ]; then
   echo "ERROR: CI is not green — ${CI_FAILING} failing and ${CI_PENDING} pending check(s) on $HEAD_SHA."
   echo "Run Step 8 (pr-ci-loop.sh) and resolve all failures before applying ready-for-human-review."

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -2579,6 +2579,16 @@ CI_FAILING=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
 CI_PENDING=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
   --jq '[.check_runs[] | select(.status != "completed")] | length')
 CI_TOTAL=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq '.check_runs | length')
+# check-runs is GitHub Actions/App checks only — it does not include plain
+# commit statuses (CodeRabbit, Devin Review, and this repo's own
+# "Reviewer-loop completion guard" all post as statuses, not check-runs). A
+# PR whose CI signal is entirely statuses would otherwise read CI_TOTAL=0
+# below and be refused even when green, and a failing status would not count
+# toward CI_FAILING at all. Fold the combined-status endpoint in too.
+STATUS_JSON=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" --jq '.statuses // []')
+CI_FAILING=$((CI_FAILING + $(printf '%s' "$STATUS_JSON" | jq '[.[] | select(.state == "failure" or .state == "error")] | length')))
+CI_PENDING=$((CI_PENDING + $(printf '%s' "$STATUS_JSON" | jq '[.[] | select(.state == "pending")] | length')))
+CI_TOTAL=$((CI_TOTAL + $(printf '%s' "$STATUS_JSON" | jq 'length')))
 if [ "$CI_FAILING" -gt 0 ] || [ "$CI_PENDING" -gt 0 ]; then
   echo "ERROR: CI is not green — ${CI_FAILING} failing and ${CI_PENDING} pending check(s) on $HEAD_SHA."
   echo "Run Step 8 (pr-ci-loop.sh) and resolve all failures before applying ready-for-human-review."

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -2578,12 +2578,29 @@ CI_FAILING=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
   --jq '[.check_runs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | length')
 CI_PENDING=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
   --jq '[.check_runs[] | select(.status != "completed")] | length')
+CI_TOTAL=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" --jq '.check_runs | length')
 if [ "$CI_FAILING" -gt 0 ] || [ "$CI_PENDING" -gt 0 ]; then
   echo "ERROR: CI is not green — ${CI_FAILING} failing and ${CI_PENDING} pending check(s) on $HEAD_SHA."
   echo "Run Step 8 (pr-ci-loop.sh) and resolve all failures before applying ready-for-human-review."
   exit 5  # Exit code 5 = "CI not green at readiness gate"
 fi
-echo "✅ CI is green on $HEAD_SHA."
+# "Nothing failed" is not "CI passed" (#1514, #1580). A head can carry zero
+# checks — GitHub builds no merge ref for a CONFLICTING PR, so its
+# `pull_request` workflows never start — and the counts above are then both
+# zero. Refuse that instead of labelling on absence. Step 8's
+# CI_EVIDENCE=none / REASON=expected_checks_missing report the same condition.
+if [ "$CI_TOTAL" -eq 0 ]; then
+  echo "ERROR: no checks ran on $HEAD_SHA — 'green' here would mean 'nothing failed', not 'CI passed'."
+  echo "If the PR is CONFLICTING, resolve the conflict so pull_request workflows can run; then re-run Step 8."
+  echo "For a repository with no CI configured, record that explicitly (issue_tracker/ci policy) rather than labelling on an empty check set."
+  exit 5  # Exit code 5 = "CI not green at readiness gate"
+fi
+echo "✅ CI is green on $HEAD_SHA (${CI_TOTAL} check(s))."
+# Machine-readable readiness evidence — the runner's terminal report must carry
+# the head the CI verdict belongs to, not just the verdict (#1514 AC-4).
+echo "READINESS_HEAD_SHA=$HEAD_SHA"
+echo "READINESS_CI_TOTAL=$CI_TOTAL"
+echo "READINESS_CI_CONCLUSION=success"
 
 # Check 0.5: latest automated reviewer-loop summary must be clean or skipped.
 # A non-clean terminal result such as RESULT=escalate, needs_fixes, timeout, or

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -2599,6 +2599,14 @@ fi
 # `pull_request` workflows never start — and the counts above are then both
 # zero. Refuse that instead of labelling on absence. Step 8's
 # CI_EVIDENCE=none / REASON=expected_checks_missing report the same condition.
+# Step 8 reports CI_EVIDENCE=unknown when it could not resolve the head or
+# read its workflow runs. That is not a green signal — refuse it here rather
+# than labelling on a verdict whose subject is unidentified.
+if [ "${CI_EVIDENCE:-}" = "unknown" ]; then
+  echo "ERROR: Step 8 reported CI_EVIDENCE=unknown — the head or its workflow runs could not be read."
+  echo "Re-run Step 8 (pr-ci-loop.sh) and export its output before re-entering Step 8a."
+  exit 5  # Exit code 5 = "CI not green at readiness gate"
+fi
 if [ "$CI_TOTAL" -eq 0 ]; then
   echo "ERROR: no checks ran on $HEAD_SHA — 'green' here would mean 'nothing failed', not 'CI passed'."
   echo "If the PR is CONFLICTING, resolve the conflict so pull_request workflows can run; then re-run Step 8."

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -282,12 +282,18 @@ is_devin_status_stale() {
 # Devin Review, PR-Agent's bot review) from this comparison, which is correct:
 # those are not GitHub Actions workflow runs and are not what disappears when
 # a PR goes CONFLICTING.
+workflow_run_names_for_sha() {
+  local repo="$1" sha="$2"
+  [ -n "$sha" ] || return 0
+  gh api "repos/$repo/actions/runs?head_sha=$sha" --paginate --jq '[.workflow_runs[].name] | unique | .[]' 2>/dev/null || return 0
+}
+
 previous_head_check_names() {
   local repo="$1" pr_number="$2" current_sha="$3" prev_sha=""
   prev_sha="$(gh api "repos/$repo/pulls/$pr_number/commits" --paginate --jq '[.[].sha] | .[-2] // empty' 2>/dev/null)" || return 0
   [ -n "$prev_sha" ] || return 0
   [ "$prev_sha" != "$current_sha" ] || return 0
-  gh api "repos/$repo/actions/runs?head_sha=$prev_sha" --paginate --jq '[.workflow_runs[].name] | unique | .[]' 2>/dev/null || return 0
+  workflow_run_names_for_sha "$repo" "$prev_sha"
 }
 
 while :; do
@@ -544,7 +550,11 @@ while :; do
     # absent now is reported rather than silently accepted.
     missing_checks=""
     if [ -n "$head_sha" ] && [ "${CI_LOOP_SKIP_EVIDENCE_GATE:-0}" != "1" ]; then
-      current_names="$(printf '%s\n' "$normalized_checks_json" | jq -r '[.[] | (.workflowName // .context // .name // "unknown")] | unique | .[]' 2>/dev/null || true)"
+      # Both sides come from actions/runs so the comparison is symmetric: the
+      # rollup also carries plain commit statuses (CodeRabbit, Devin) and
+      # per-job matrix leaves, which have no counterpart in the previous head's
+      # workflow-run list and would make the two sets incomparable.
+      current_names="$(workflow_run_names_for_sha "$repo" "$head_sha")"
       while IFS= read -r prev_name; do
         [ -n "$prev_name" ] || continue
         if ! printf '%s\n' "$current_names" | grep -Fxq "$prev_name"; then

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -282,15 +282,31 @@ is_devin_status_stale() {
 # Devin Review, PR-Agent's bot review) from this comparison, which is correct:
 # those are not GitHub Actions workflow runs and are not what disappears when
 # a PR goes CONFLICTING.
+# workflow_run_names_for_sha <repo> <sha>
+# Prints the distinct workflow-run names for <sha>, one per line. Returns
+# non-zero when the lookup itself failed, so the caller can tell "this head
+# ran no workflows" from "we do not know what it ran" — a gate that exists to
+# stop a false green must not be satisfied by its own lookup erroring out.
+#
+# --slurp is required with --paginate: without it `--jq` runs per page, so a
+# multi-page response yields one result per page instead of one aggregate.
 workflow_run_names_for_sha() {
   local repo="$1" sha="$2"
-  [ -n "$sha" ] || return 0
-  gh api "repos/$repo/actions/runs?head_sha=$sha" --paginate --jq '[.workflow_runs[].name] | unique | .[]' 2>/dev/null || return 0
+  [ -n "$sha" ] || return 1
+  gh api "repos/$repo/actions/runs?head_sha=$sha&per_page=100" --paginate --slurp \
+    --jq '[.[].workflow_runs[]?.name] | unique | .[]' 2>/dev/null
 }
 
+# previous_head_check_names <repo> <pr_number> <current_head_sha>
+# Prints the previous head's workflow-run names. Exit 0 with no output means
+# "no previous head" (single-commit PR, or the same SHA); exit 1 means the
+# lookup failed and the expectation is unknown.
 previous_head_check_names() {
   local repo="$1" pr_number="$2" current_sha="$3" prev_sha=""
-  prev_sha="$(gh api "repos/$repo/pulls/$pr_number/commits" --paginate --jq '[.[].sha] | .[-2] // empty' 2>/dev/null)" || return 0
+  # --slurp: with --paginate alone, `.[-2]` is evaluated per page, so a PR
+  # with more than one page of commits emits one SHA per page.
+  prev_sha="$(gh api "repos/$repo/pulls/$pr_number/commits?per_page=100" --paginate --slurp \
+    --jq '[.[][].sha] | .[-2] // empty' 2>/dev/null)" || return 1
   [ -n "$prev_sha" ] || return 0
   [ "$prev_sha" != "$current_sha" ] || return 0
   workflow_run_names_for_sha "$repo" "$prev_sha"
@@ -549,18 +565,46 @@ while :; do
     # against the PR's previous head; a whole workflow that ran before and is
     # absent now is reported rather than silently accepted.
     missing_checks=""
+    evidence_lookup_failed=0
     if [ -n "$head_sha" ] && [ "${CI_LOOP_SKIP_EVIDENCE_GATE:-0}" != "1" ]; then
       # Both sides come from actions/runs so the comparison is symmetric: the
       # rollup also carries plain commit statuses (CodeRabbit, Devin) and
       # per-job matrix leaves, which have no counterpart in the previous head's
       # workflow-run list and would make the two sets incomparable.
-      current_names="$(workflow_run_names_for_sha "$repo" "$head_sha")"
-      while IFS= read -r prev_name; do
-        [ -n "$prev_name" ] || continue
-        if ! printf '%s\n' "$current_names" | grep -Fxq "$prev_name"; then
-          missing_checks="${missing_checks:+$missing_checks,}$prev_name"
-        fi
-      done <<< "$(previous_head_check_names "$repo" "$pr_number" "$head_sha")"
+      prev_names=""
+      if ! current_names="$(workflow_run_names_for_sha "$repo" "$head_sha")"; then
+        evidence_lookup_failed=1
+      elif ! prev_names="$(previous_head_check_names "$repo" "$pr_number" "$head_sha")"; then
+        evidence_lookup_failed=1
+      else
+        while IFS= read -r prev_name; do
+          [ -n "$prev_name" ] || continue
+          if ! printf '%s\n' "$current_names" | grep -Fxq "$prev_name"; then
+            missing_checks="${missing_checks:+$missing_checks,}$prev_name"
+          fi
+        done <<< "$prev_names"
+      fi
+    fi
+    if [ "$evidence_lookup_failed" -eq 1 ]; then
+      # Fail closed: a gate that exists to stop a false green must not be
+      # satisfied by its own lookup failing (CodeRabbit on PR #1588).
+      print_kv RESULT red
+      print_kv PR_NUMBER "$pr_number"
+      print_kv REPO "$repo"
+      print_kv HEAD_SHA "$head_sha"
+      print_kv REASON ci_evidence_lookup_failed
+      print_kv CI_EVIDENCE unknown
+      print_kv TOTAL_CHECK_COUNT "$total_check_count"
+      print_kv FAILING_CHECK_COUNT 0
+      print_kv FAILING_CHECKS ""
+      print_kv PENDING_CHECK_COUNT 0
+      print_kv PENDING_CHECKS ""
+      print_kv REVIEWER_CHECK_COUNT "$reviewer_check_count"
+      print_kv REVIEWER_CHECKS "$reviewer_check_list"
+      print_kv REVIEWER_CHECKS_JSON "$reviewer_checks_json"
+      echo "ERROR: could not read workflow-run evidence for $head_sha; refusing to report green on an unverified head." >&2
+      echo "  Retry, or set CI_LOOP_SKIP_EVIDENCE_GATE=1 to proceed without the check." >&2
+      exit 1
     fi
     if [ -n "$missing_checks" ]; then
       print_kv RESULT red

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -316,6 +316,15 @@ while :; do
   if ! head_sha="$(gh pr view "$pr_number" --repo "$repo" --json headRefOid --jq '.headRefOid' 2>/dev/null)"; then
     head_sha=""
   fi
+  # Only a real object name identifies a head. Anything else (an older gh, a
+  # harness whose stub ignores --jq) means the head is UNKNOWN, which is a
+  # different thing from "the run lookup failed" below: the evidence gate
+  # simply cannot apply, so it is skipped and the result is marked
+  # CI_EVIDENCE=unknown for the readiness gate to refuse.
+  case "$head_sha" in
+    *[!0-9a-fA-F]*|"") head_sha="" ;;
+    *) [ "${#head_sha}" -ge 7 ] || head_sha="" ;;
+  esac
   if ! checks_json="$(gh pr view "$pr_number" --repo "$repo" --json statusCheckRollup 2>/dev/null)"; then
     print_kv RESULT red
     print_kv PR_NUMBER "$pr_number"
@@ -625,7 +634,10 @@ while :; do
       echo "  A conflicting PR gets no pull_request workflows at all; resolve the conflict (or the filter change) and let CI re-run." >&2
       exit 1
     fi
-    if [ "$total_check_count" -eq 0 ]; then
+    if [ -z "$head_sha" ]; then
+      print_kv CI_EVIDENCE unknown
+      echo "WARNING: could not resolve the PR head SHA; the CI-evidence comparison did not run." >&2
+    elif [ "$total_check_count" -eq 0 ]; then
       print_kv CI_EVIDENCE none
       echo "WARNING: no checks ran on $head_sha; 'green' here means 'nothing failed', not 'CI passed'." >&2
     else

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -254,8 +254,8 @@ is_devin_status_stale() {
 }
 
 # previous_head_check_names <repo> <pr_number> <current_head_sha>
-# Prints the check names that ran on the PR's most recent EARLIER head, one per
-# line (empty when the PR has a single commit or the lookup fails).
+# Prints the WORKFLOW names that ran on the PR's most recent EARLIER head, one
+# per line (empty when the PR has a single commit or the lookup fails).
 #
 # Why this exists (#1514, #1580): "no failing and no pending checks" is not
 # evidence that CI ran. A head can carry zero checks, or only a subset, and
@@ -267,12 +267,27 @@ is_devin_status_stale() {
 #     drops out of the set.
 # Comparing against the previous head turns "a workflow that used to run is
 # absent" into a red result instead of a vacuous pass.
+#
+# Deliberately WORKFLOW-granular, not check/job-granular (review finding on
+# #1588 itself): `workflow-tests.yml` runs one job per selected suite, and the
+# selected set is diff-driven (select-test-suites.sh) — it legitimately grows
+# or shrinks as commits land, by design (see that workflow's own comment: "The
+# matrix job names change with the selection, so they cannot be required
+# directly"). Comparing individual check-run names (e.g.
+# `scripts/.../tests/test-foo.sh`) would treat that expected churn as a missing
+# check and block a PR that should pass — verified live: PR #1588's own head
+# carries 6 such matrix leaves under one workflow, `actions/runs?head_sha=`
+# collapses them to a single "workflow test harnesses" entry. Using
+# `actions/runs` also naturally excludes plain commit statuses (CodeRabbit,
+# Devin Review, PR-Agent's bot review) from this comparison, which is correct:
+# those are not GitHub Actions workflow runs and are not what disappears when
+# a PR goes CONFLICTING.
 previous_head_check_names() {
   local repo="$1" pr_number="$2" current_sha="$3" prev_sha=""
   prev_sha="$(gh api "repos/$repo/pulls/$pr_number/commits" --paginate --jq '[.[].sha] | .[-2] // empty' 2>/dev/null)" || return 0
   [ -n "$prev_sha" ] || return 0
   [ "$prev_sha" != "$current_sha" ] || return 0
-  gh api "repos/$repo/commits/$prev_sha/check-runs" --jq '[.check_runs[].name] | unique | .[]' 2>/dev/null || return 0
+  gh api "repos/$repo/actions/runs?head_sha=$prev_sha" --paginate --jq '[.workflow_runs[].name] | unique | .[]' 2>/dev/null || return 0
 }
 
 while :; do
@@ -524,11 +539,12 @@ while :; do
 
     # CI-evidence gate (#1514, #1580): green must mean "the checks that belong
     # on this head ran and passed", not "nothing failed". Compare the current
-    # head's check names against the PR's previous head; anything that ran
-    # before and is absent now is reported rather than silently accepted.
+    # head's WORKFLOW names (not job/check names — see previous_head_check_names)
+    # against the PR's previous head; a whole workflow that ran before and is
+    # absent now is reported rather than silently accepted.
     missing_checks=""
     if [ -n "$head_sha" ] && [ "${CI_LOOP_SKIP_EVIDENCE_GATE:-0}" != "1" ]; then
-      current_names="$(printf '%s\n' "$normalized_checks_json" | jq -r '[.[] | (.name // .context // .workflowName // "unknown")] | unique | .[]' 2>/dev/null || true)"
+      current_names="$(printf '%s\n' "$normalized_checks_json" | jq -r '[.[] | (.workflowName // .context // .name // "unknown")] | unique | .[]' 2>/dev/null || true)"
       while IFS= read -r prev_name; do
         [ -n "$prev_name" ] || continue
         if ! printf '%s\n' "$current_names" | grep -Fxq "$prev_name"; then
@@ -551,7 +567,7 @@ while :; do
       print_kv REVIEWER_CHECK_COUNT "$reviewer_check_count"
       print_kv REVIEWER_CHECKS "$reviewer_check_list"
       print_kv REVIEWER_CHECKS_JSON "$reviewer_checks_json"
-      echo "ERROR: checks that ran on the PR's previous head are absent on $head_sha: $missing_checks" >&2
+      echo "ERROR: workflow(s) that ran on the PR's previous head are absent on $head_sha: $missing_checks" >&2
       echo "  A conflicting PR gets no pull_request workflows at all; resolve the conflict (or the filter change) and let CI re-run." >&2
       exit 1
     fi

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -253,7 +253,32 @@ is_devin_status_stale() {
   return 0  # no findings — stale error status, safe to skip
 }
 
+# previous_head_check_names <repo> <pr_number> <current_head_sha>
+# Prints the check names that ran on the PR's most recent EARLIER head, one per
+# line (empty when the PR has a single commit or the lookup fails).
+#
+# Why this exists (#1514, #1580): "no failing and no pending checks" is not
+# evidence that CI ran. A head can carry zero checks, or only a subset, and
+# read as green:
+#   - GitHub builds no merge ref for a CONFLICTING PR, so `pull_request`
+#     workflows do not start at all — measured on PR #1577, where two pushes
+#     after it went DIRTY ran 4 checks instead of 16 and the loop said green;
+#   - a workflow whose path filter or branch filter stops matching silently
+#     drops out of the set.
+# Comparing against the previous head turns "a workflow that used to run is
+# absent" into a red result instead of a vacuous pass.
+previous_head_check_names() {
+  local repo="$1" pr_number="$2" current_sha="$3" prev_sha=""
+  prev_sha="$(gh api "repos/$repo/pulls/$pr_number/commits" --paginate --jq '[.[].sha] | .[-2] // empty' 2>/dev/null)" || return 0
+  [ -n "$prev_sha" ] || return 0
+  [ "$prev_sha" != "$current_sha" ] || return 0
+  gh api "repos/$repo/commits/$prev_sha/check-runs" --jq '[.check_runs[].name] | unique | .[]' 2>/dev/null || return 0
+}
+
 while :; do
+  if ! head_sha="$(gh pr view "$pr_number" --repo "$repo" --json headRefOid --jq '.headRefOid' 2>/dev/null)"; then
+    head_sha=""
+  fi
   if ! checks_json="$(gh pr view "$pr_number" --repo "$repo" --json statusCheckRollup 2>/dev/null)"; then
     print_kv RESULT red
     print_kv PR_NUMBER "$pr_number"
@@ -497,6 +522,47 @@ while :; do
       continue
     fi
 
+    # CI-evidence gate (#1514, #1580): green must mean "the checks that belong
+    # on this head ran and passed", not "nothing failed". Compare the current
+    # head's check names against the PR's previous head; anything that ran
+    # before and is absent now is reported rather than silently accepted.
+    missing_checks=""
+    if [ -n "$head_sha" ] && [ "${CI_LOOP_SKIP_EVIDENCE_GATE:-0}" != "1" ]; then
+      current_names="$(printf '%s\n' "$normalized_checks_json" | jq -r '[.[] | (.name // .context // .workflowName // "unknown")] | unique | .[]' 2>/dev/null || true)"
+      while IFS= read -r prev_name; do
+        [ -n "$prev_name" ] || continue
+        if ! printf '%s\n' "$current_names" | grep -Fxq "$prev_name"; then
+          missing_checks="${missing_checks:+$missing_checks,}$prev_name"
+        fi
+      done <<< "$(previous_head_check_names "$repo" "$pr_number" "$head_sha")"
+    fi
+    if [ -n "$missing_checks" ]; then
+      print_kv RESULT red
+      print_kv PR_NUMBER "$pr_number"
+      print_kv REPO "$repo"
+      print_kv HEAD_SHA "$head_sha"
+      print_kv REASON expected_checks_missing
+      print_kv TOTAL_CHECK_COUNT "$total_check_count"
+      print_kv FAILING_CHECK_COUNT 0
+      print_kv FAILING_CHECKS ""
+      print_kv MISSING_CHECKS "$missing_checks"
+      print_kv PENDING_CHECK_COUNT 0
+      print_kv PENDING_CHECKS ""
+      print_kv REVIEWER_CHECK_COUNT "$reviewer_check_count"
+      print_kv REVIEWER_CHECKS "$reviewer_check_list"
+      print_kv REVIEWER_CHECKS_JSON "$reviewer_checks_json"
+      echo "ERROR: checks that ran on the PR's previous head are absent on $head_sha: $missing_checks" >&2
+      echo "  A conflicting PR gets no pull_request workflows at all; resolve the conflict (or the filter change) and let CI re-run." >&2
+      exit 1
+    fi
+    if [ "$total_check_count" -eq 0 ]; then
+      print_kv CI_EVIDENCE none
+      echo "WARNING: no checks ran on $head_sha; 'green' here means 'nothing failed', not 'CI passed'." >&2
+    else
+      print_kv CI_EVIDENCE present
+    fi
+
+    print_kv HEAD_SHA "$head_sha"
     print_kv RESULT green
     print_kv PR_NUMBER "$pr_number"
     print_kv REPO "$repo"

--- a/scripts/development-workflow/tests/test-pr-ci-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-ci-loop.sh
@@ -43,6 +43,7 @@ head_default='headsha000000000000'
 rollup_default='{"statusCheckRollup":[]}'
 runs_default='{"workflow_runs":[]}'
 commits_default='[]'
+runs_default='{"workflow_runs":[]}'
 # The real gh applies --jq locally; a stub that ignores it hands the caller a
 # raw payload where it expects a filtered scalar. Apply the filter for real.
 jq_filter=""
@@ -62,7 +63,14 @@ case "$*" in
   *"auth status"*) exit 0 ;;
   *"--json headRefOid"*) emit "{\"headRefOid\":\"${MOCK_HEAD_SHA:-$head_default}\"}" ; exit 0 ;;
   *"--json statusCheckRollup"*) emit "${MOCK_ROLLUP:-$rollup_default}" ; exit 0 ;;
-  *"/actions/runs"*) emit "${MOCK_PREV_CHECKS:-$runs_default}" ; exit 0 ;;
+  *"/actions/runs"*)
+    # Both sides of the evidence comparison hit this endpoint; distinguish
+    # them by the head_sha in the query so a test can make them differ.
+    case "$*" in
+      *"head_sha=${MOCK_HEAD_SHA:-$head_default}"*) emit "${MOCK_CURRENT_RUNS:-$runs_default}" ;;
+      *) emit "${MOCK_PREV_CHECKS:-$runs_default}" ;;
+    esac
+    exit 0 ;;
   *"/commits"*) emit "${MOCK_PR_COMMITS:-$commits_default}" ; exit 0 ;;
   *"/reviews"*|*"/comments"*) emit '[]' ; exit 0 ;;
   *) emit '{}' ; exit 0 ;;
@@ -91,6 +99,10 @@ _matrix_current_rollup='{"statusCheckRollup":[
   {"__typename":"CheckRun","name":"workflow test harnesses","workflowName":"workflow test harnesses","status":"COMPLETED","conclusion":"SUCCESS"}
 ]}'
 
+_runs_two='{"workflow_runs":[{"name":"workflow test harnesses"},{"name":"ShellCheck"}]}'
+_runs_one='{"workflow_runs":[{"name":"ShellCheck"}]}'
+_runs_matrix='{"workflow_runs":[{"name":"workflow test harnesses"}]}'
+
 run_ci() {
   local out status=0
   out="$(env PATH="$_bin:$PATH" "$@" bash "$HELPER" 42 --repo owner/repo --poll-interval 1 --max-wait 1 2>/dev/null)" || status=$?
@@ -98,7 +110,7 @@ run_ci() {
 }
 
 # 1. Same check set as the previous head → green.
-_out="$(run_ci MOCK_ROLLUP="$_success_rollup" MOCK_PREV_CHECKS="$_prev_two" MOCK_PR_COMMITS="$_commits_two")"
+_out="$(run_ci MOCK_ROLLUP="$_success_rollup" MOCK_PREV_CHECKS="$_runs_two" MOCK_CURRENT_RUNS="$_runs_two" MOCK_PR_COMMITS="$_commits_two")"
 run_test "full_check_set_is_green" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
 run_test "green_reports_head_sha" "HEAD_SHA=headsha000000000000" "$(grep '^HEAD_SHA=' <<<"$_out" || true)"
 run_test "green_reports_ci_evidence_present" "CI_EVIDENCE=present" "$(grep '^CI_EVIDENCE=' <<<"$_out" || true)"
@@ -106,7 +118,7 @@ run_test "green_reports_ci_evidence_present" "CI_EVIDENCE=present" "$(grep '^CI_
 # 2. A workflow that ran on the previous head is absent now → red, named.
 #    This is the PR #1577 shape: a conflicting PR whose pull_request workflows
 #    never started, leaving a passing subset that used to read as green.
-_out="$(run_ci MOCK_ROLLUP="$_subset_rollup" MOCK_PREV_CHECKS="$_prev_two" MOCK_PR_COMMITS="$_commits_two")"
+_out="$(run_ci MOCK_ROLLUP="$_subset_rollup" MOCK_PREV_CHECKS="$_runs_two" MOCK_CURRENT_RUNS="$_runs_one" MOCK_PR_COMMITS="$_commits_two")"
 run_test "missing_workflow_is_red" "RESULT=red" "$(grep '^RESULT=' <<<"$_out" || true)"
 run_test "missing_workflow_reason" "REASON=expected_checks_missing" "$(grep '^REASON=' <<<"$_out" || true)"
 run_test "missing_workflow_is_named" "MISSING_CHECKS=workflow test harnesses" "$(grep '^MISSING_CHECKS=' <<<"$_out" || true)"
@@ -119,9 +131,9 @@ run_test "no_checks_reports_evidence_none" "CI_EVIDENCE=none" "$(grep '^CI_EVIDE
 
 # 4. The gate is skippable for callers that know better, and does not fire when
 #    the previous head ran nothing.
-_out="$(run_ci MOCK_ROLLUP="$_subset_rollup" MOCK_PREV_CHECKS="$_prev_two" MOCK_PR_COMMITS="$_commits_two" CI_LOOP_SKIP_EVIDENCE_GATE=1)"
+_out="$(run_ci MOCK_ROLLUP="$_subset_rollup" MOCK_PREV_CHECKS="$_runs_two" MOCK_CURRENT_RUNS="$_runs_one" MOCK_PR_COMMITS="$_commits_two" CI_LOOP_SKIP_EVIDENCE_GATE=1)"
 run_test "evidence_gate_is_skippable" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
-_out="$(run_ci MOCK_ROLLUP="$_subset_rollup" MOCK_PREV_CHECKS='{"workflow_runs":[]}' MOCK_PR_COMMITS="$_commits_two")"
+_out="$(run_ci MOCK_ROLLUP="$_subset_rollup" MOCK_PREV_CHECKS='{"workflow_runs":[]}' MOCK_CURRENT_RUNS="$_runs_one" MOCK_PR_COMMITS="$_commits_two")"
 run_test "no_previous_checks_does_not_fire" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
 
 # 4b. A matrix workflow's selected suite set narrows on the current head
@@ -130,12 +142,19 @@ run_test "no_previous_checks_does_not_fire" "RESULT=green" "$(grep '^RESULT=' <<
 #     missing check. Comparing at check-run granularity (pre-fix behavior)
 #     would have reported the previous head's leaf name as MISSING_CHECKS
 #     and gone red; workflow-level comparison must not.
-_out="$(run_ci MOCK_ROLLUP="$_matrix_current_rollup" MOCK_PREV_CHECKS="$_matrix_prev" MOCK_PR_COMMITS="$_commits_two")"
+_out="$(run_ci MOCK_ROLLUP="$_matrix_current_rollup" MOCK_PREV_CHECKS="$_runs_matrix" MOCK_CURRENT_RUNS="$_runs_matrix" MOCK_PR_COMMITS="$_commits_two")"
 run_test "matrix_suite_churn_stays_green" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
+
+# 4c. Both sides read from actions/runs, so plain commit statuses and matrix
+#     leaves in the rollup (which have no workflow-run counterpart) can never
+#     be mistaken for a missing workflow (pr-agent on PR #1588).
+_status_rollup='{"statusCheckRollup":[{"__typename":"CheckRun","name":"ShellCheck","workflowName":"ShellCheck","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"StatusContext","context":"CodeRabbit","state":"SUCCESS"}]}'
+_out="$(run_ci MOCK_ROLLUP="$_status_rollup" MOCK_PREV_CHECKS="$_runs_one" MOCK_CURRENT_RUNS="$_runs_one" MOCK_PR_COMMITS="$_commits_two")"
+run_test "commit_statuses_are_not_missing_workflows" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
 
 # 5. A genuinely failing check is still red (the gate did not displace it).
 _fail_rollup='{"statusCheckRollup":[{"__typename":"CheckRun","name":"ShellCheck","status":"COMPLETED","conclusion":"FAILURE"}]}'
-_out="$(run_ci MOCK_ROLLUP="$_fail_rollup" MOCK_PREV_CHECKS="$_prev_two" MOCK_PR_COMMITS="$_commits_two")"
+_out="$(run_ci MOCK_ROLLUP="$_fail_rollup" MOCK_PREV_CHECKS="$_runs_two" MOCK_CURRENT_RUNS="$_runs_two" MOCK_PR_COMMITS="$_commits_two")"
 run_test "failing_check_still_red" "RESULT=red" "$(grep '^RESULT=' <<<"$_out" || true)"
 run_test "failing_check_names_it" "FAILING_CHECKS=ShellCheck" "$(grep '^FAILING_CHECKS=' <<<"$_out" || true)"
 

--- a/scripts/development-workflow/tests/test-pr-ci-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-ci-loop.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# test-pr-ci-loop.sh - CI loop verdict tests.
+# covers: scripts/development-workflow/pr-ci-loop.sh
+#
+# Focus: the CI-evidence gate (#1514, #1580). "No failing and no pending
+# checks" is not evidence that CI ran — a head can legitimately carry zero
+# checks (GitHub builds no merge ref for a CONFLICTING PR, so its
+# pull_request workflows never start) or only a subset after a filter change.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+HELPER="$REPO_ROOT/scripts/development-workflow/pr-ci-loop.sh"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+pass=0
+fail=0
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"; pass=$((pass + 1))
+  else
+    echo "FAIL: $name - expected '$expected', got '$actual'"; fail=$((fail + 1))
+  fi
+}
+
+# make_gh <dir> — a gh stub driven by env vars:
+#   MOCK_ROLLUP        statusCheckRollup JSON
+#   MOCK_PREV_CHECKS   check names on the previous head (JSON array of names)
+#   MOCK_PR_COMMITS    commit SHAs for the PR (JSON array)
+make_gh() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat > "$dir/gh" <<'GH'
+#!/usr/bin/env bash
+# Defaults are plain variables: a ${VAR:-{...}} default containing braces does
+# not survive bash parameter expansion and silently yields invalid JSON.
+head_default='headsha000000000000'
+rollup_default='{"statusCheckRollup":[]}'
+checks_default='{"check_runs":[]}'
+commits_default='[]'
+# The real gh applies --jq locally; a stub that ignores it hands the caller a
+# raw payload where it expects a filtered scalar. Apply the filter for real.
+jq_filter=""
+prev=""
+for arg in "$@"; do
+  [ "$prev" = "--jq" ] && jq_filter="$arg"
+  prev="$arg"
+done
+emit() {
+  if [ -n "$jq_filter" ]; then
+    printf '%s\n' "$1" | jq -r "$jq_filter"
+  else
+    printf '%s\n' "$1"
+  fi
+}
+case "$*" in
+  *"auth status"*) exit 0 ;;
+  *"--json headRefOid"*) emit "{\"headRefOid\":\"${MOCK_HEAD_SHA:-$head_default}\"}" ; exit 0 ;;
+  *"--json statusCheckRollup"*) emit "${MOCK_ROLLUP:-$rollup_default}" ; exit 0 ;;
+  *"/check-runs"*) emit "${MOCK_PREV_CHECKS:-$checks_default}" ; exit 0 ;;
+  *"/commits"*) emit "${MOCK_PR_COMMITS:-$commits_default}" ; exit 0 ;;
+  *"/reviews"*|*"/comments"*) emit '[]' ; exit 0 ;;
+  *) emit '{}' ; exit 0 ;;
+esac
+GH
+  chmod +x "$dir/gh"
+}
+
+_bin="$TMP_ROOT/bin"
+make_gh "$_bin"
+
+_success_rollup='{"statusCheckRollup":[{"__typename":"CheckRun","name":"workflow test harnesses","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"CheckRun","name":"ShellCheck","status":"COMPLETED","conclusion":"SUCCESS"}]}'
+_subset_rollup='{"statusCheckRollup":[{"__typename":"CheckRun","name":"ShellCheck","status":"COMPLETED","conclusion":"SUCCESS"}]}'
+_prev_two='{"check_runs":[{"name":"workflow test harnesses"},{"name":"ShellCheck"}]}'
+_commits_two='[{"sha":"prevsha00000000000000"},{"sha":"headsha000000000000"}]'
+
+run_ci() {
+  local out status=0
+  out="$(env PATH="$_bin:$PATH" "$@" bash "$HELPER" 42 --repo owner/repo --poll-interval 1 --max-wait 1 2>/dev/null)" || status=$?
+  printf '%s\n---STATUS=%s\n' "$out" "$status"
+}
+
+# 1. Same check set as the previous head → green.
+_out="$(run_ci MOCK_ROLLUP="$_success_rollup" MOCK_PREV_CHECKS="$_prev_two" MOCK_PR_COMMITS="$_commits_two")"
+run_test "full_check_set_is_green" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
+run_test "green_reports_head_sha" "HEAD_SHA=headsha000000000000" "$(grep '^HEAD_SHA=' <<<"$_out" || true)"
+run_test "green_reports_ci_evidence_present" "CI_EVIDENCE=present" "$(grep '^CI_EVIDENCE=' <<<"$_out" || true)"
+
+# 2. A workflow that ran on the previous head is absent now → red, named.
+#    This is the PR #1577 shape: a conflicting PR whose pull_request workflows
+#    never started, leaving a passing subset that used to read as green.
+_out="$(run_ci MOCK_ROLLUP="$_subset_rollup" MOCK_PREV_CHECKS="$_prev_two" MOCK_PR_COMMITS="$_commits_two")"
+run_test "missing_workflow_is_red" "RESULT=red" "$(grep '^RESULT=' <<<"$_out" || true)"
+run_test "missing_workflow_reason" "REASON=expected_checks_missing" "$(grep '^REASON=' <<<"$_out" || true)"
+run_test "missing_workflow_is_named" "MISSING_CHECKS=workflow test harnesses" "$(grep '^MISSING_CHECKS=' <<<"$_out" || true)"
+
+# 3. Zero checks with no previous head → green (unchanged) but evidence=none,
+#    so the readiness gate can refuse rather than label on absence.
+_out="$(run_ci MOCK_ROLLUP='{"statusCheckRollup":[]}' MOCK_PR_COMMITS='[]')"
+run_test "no_checks_still_green" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
+run_test "no_checks_reports_evidence_none" "CI_EVIDENCE=none" "$(grep '^CI_EVIDENCE=' <<<"$_out" || true)"
+
+# 4. The gate is skippable for callers that know better, and does not fire when
+#    the previous head ran nothing.
+_out="$(run_ci MOCK_ROLLUP="$_subset_rollup" MOCK_PREV_CHECKS="$_prev_two" MOCK_PR_COMMITS="$_commits_two" CI_LOOP_SKIP_EVIDENCE_GATE=1)"
+run_test "evidence_gate_is_skippable" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
+_out="$(run_ci MOCK_ROLLUP="$_subset_rollup" MOCK_PREV_CHECKS='{"check_runs":[]}' MOCK_PR_COMMITS="$_commits_two")"
+run_test "no_previous_checks_does_not_fire" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
+
+# 5. A genuinely failing check is still red (the gate did not displace it).
+_fail_rollup='{"statusCheckRollup":[{"__typename":"CheckRun","name":"ShellCheck","status":"COMPLETED","conclusion":"FAILURE"}]}'
+_out="$(run_ci MOCK_ROLLUP="$_fail_rollup" MOCK_PREV_CHECKS="$_prev_two" MOCK_PR_COMMITS="$_commits_two")"
+run_test "failing_check_still_red" "RESULT=red" "$(grep '^RESULT=' <<<"$_out" || true)"
+run_test "failing_check_names_it" "FAILING_CHECKS=ShellCheck" "$(grep '^FAILING_CHECKS=' <<<"$_out" || true)"
+
+printf '\nResults: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/development-workflow/tests/test-pr-ci-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-ci-loop.sh
@@ -47,16 +47,31 @@ runs_default='{"workflow_runs":[]}'
 # The real gh applies --jq locally; a stub that ignores it hands the caller a
 # raw payload where it expects a filtered scalar. Apply the filter for real.
 jq_filter=""
+slurped=0
+case "$*" in *--slurp*) slurped=1 ;; esac
 prev=""
 for arg in "$@"; do
   [ "$prev" = "--jq" ] && jq_filter="$arg"
   prev="$arg"
 done
+# With --slurp, gh wraps each page's payload in an outer array; the filters
+# under test index through that wrapper, so the stub must mimic it. Setting
+# MOCK_PAGINATED=1 returns two identical pages, which is how a per-page --jq
+# bug shows up (duplicate/multiple results) versus a correct aggregate.
 emit() {
+  local payload="$1"
+  case "$*" in *) ;; esac
+  if [ "$slurped" = "1" ]; then
+    if [ "${MOCK_PAGINATED:-0}" = "1" ]; then
+      payload="[$1,$1]"
+    else
+      payload="[$1]"
+    fi
+  fi
   if [ -n "$jq_filter" ]; then
-    printf '%s\n' "$1" | jq -r "$jq_filter"
+    printf '%s\n' "$payload" | jq -r "$jq_filter"
   else
-    printf '%s\n' "$1"
+    printf '%s\n' "$payload"
   fi
 }
 case "$*" in
@@ -64,6 +79,7 @@ case "$*" in
   *"--json headRefOid"*) emit "{\"headRefOid\":\"${MOCK_HEAD_SHA:-$head_default}\"}" ; exit 0 ;;
   *"--json statusCheckRollup"*) emit "${MOCK_ROLLUP:-$rollup_default}" ; exit 0 ;;
   *"/actions/runs"*)
+    [ "${MOCK_RUNS_FAIL:-0}" = "1" ] && exit 1
     # Both sides of the evidence comparison hit this endpoint; distinguish
     # them by the head_sha in the query so a test can make them differ.
     case "$*" in
@@ -151,6 +167,21 @@ run_test "matrix_suite_churn_stays_green" "RESULT=green" "$(grep '^RESULT=' <<<"
 _status_rollup='{"statusCheckRollup":[{"__typename":"CheckRun","name":"ShellCheck","workflowName":"ShellCheck","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"StatusContext","context":"CodeRabbit","state":"SUCCESS"}]}'
 _out="$(run_ci MOCK_ROLLUP="$_status_rollup" MOCK_PREV_CHECKS="$_runs_one" MOCK_CURRENT_RUNS="$_runs_one" MOCK_PR_COMMITS="$_commits_two")"
 run_test "commit_statuses_are_not_missing_workflows" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
+
+# 4d. A failed evidence lookup is not "no expectation": the gate fails closed
+#     rather than letting its own error produce a green verdict (CodeRabbit on
+#     PR #1588). MOCK_RUNS_FAIL makes actions/runs exit non-zero.
+_out="$(run_ci MOCK_ROLLUP="$_success_rollup" MOCK_PR_COMMITS="$_commits_two" MOCK_RUNS_FAIL=1)"
+run_test "evidence_lookup_failure_is_red" "RESULT=red" "$(grep '^RESULT=' <<<"$_out" || true)"
+run_test "evidence_lookup_failure_reason" "REASON=ci_evidence_lookup_failed" "$(grep '^REASON=' <<<"$_out" || true)"
+run_test "evidence_lookup_failure_marks_unknown" "CI_EVIDENCE=unknown" "$(grep '^CI_EVIDENCE=' <<<"$_out" || true)"
+_out="$(run_ci MOCK_ROLLUP="$_success_rollup" MOCK_PR_COMMITS="$_commits_two" MOCK_RUNS_FAIL=1 CI_LOOP_SKIP_EVIDENCE_GATE=1)"
+run_test "skip_flag_bypasses_lookup_failure" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
+
+# 4e. Paginated responses must be reduced before comparison: with --paginate
+#     but no --slurp, `--jq` runs per page and emits one result per page.
+_out="$(run_ci MOCK_ROLLUP="$_success_rollup" MOCK_PREV_CHECKS="$_runs_two" MOCK_CURRENT_RUNS="$_runs_two" MOCK_PR_COMMITS="$_commits_two" MOCK_PAGINATED=1)"
+run_test "paginated_lookup_still_green" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
 
 # 5. A genuinely failing check is still red (the gate did not displace it).
 _fail_rollup='{"statusCheckRollup":[{"__typename":"CheckRun","name":"ShellCheck","status":"COMPLETED","conclusion":"FAILURE"}]}'

--- a/scripts/development-workflow/tests/test-pr-ci-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-ci-loop.sh
@@ -18,12 +18,22 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 
 pass=0
 fail=0
+# Holds the helper's stderr from the most recent run_ci call. Printed only when
+# an assertion fails: the assertions compare the helper's stdout exactly, so
+# stderr cannot be folded into the compared value, but discarding it outright
+# leaves a failure with no diagnostic beyond the diff.
+_last_stderr_file=""
+
 run_test() {
   local name="$1" expected="$2" actual="$3"
   if [ "$actual" = "$expected" ]; then
     echo "PASS: $name"; pass=$((pass + 1))
   else
     echo "FAIL: $name - expected '$expected', got '$actual'"; fail=$((fail + 1))
+    if [ -n "$_last_stderr_file" ] && [ -s "$_last_stderr_file" ]; then
+      echo "  helper stderr:"
+      sed 's/^/    /' "$_last_stderr_file"
+    fi
   fi
 }
 
@@ -121,7 +131,8 @@ _runs_matrix='{"workflow_runs":[{"name":"workflow test harnesses"}]}'
 
 run_ci() {
   local out status=0
-  out="$(env PATH="$_bin:$PATH" "$@" bash "$HELPER" 42 --repo owner/repo --poll-interval 1 --max-wait 1 2>/dev/null)" || status=$?
+  _last_stderr_file="$TMP_ROOT/last-stderr"
+  out="$(env PATH="$_bin:$PATH" "$@" bash "$HELPER" 42 --repo owner/repo --poll-interval 1 --max-wait 1 2>"$_last_stderr_file")" || status=$?
   printf '%s\n---STATUS=%s\n' "$out" "$status"
 }
 

--- a/scripts/development-workflow/tests/test-pr-ci-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-ci-loop.sh
@@ -29,7 +29,8 @@ run_test() {
 
 # make_gh <dir> — a gh stub driven by env vars:
 #   MOCK_ROLLUP        statusCheckRollup JSON
-#   MOCK_PREV_CHECKS   check names on the previous head (JSON array of names)
+#   MOCK_PREV_CHECKS   workflow_runs payload for the previous head
+#                       ({"workflow_runs":[{"name":...}, ...]})
 #   MOCK_PR_COMMITS    commit SHAs for the PR (JSON array)
 make_gh() {
   local dir="$1"
@@ -40,7 +41,7 @@ make_gh() {
 # not survive bash parameter expansion and silently yields invalid JSON.
 head_default='headsha000000000000'
 rollup_default='{"statusCheckRollup":[]}'
-checks_default='{"check_runs":[]}'
+runs_default='{"workflow_runs":[]}'
 commits_default='[]'
 # The real gh applies --jq locally; a stub that ignores it hands the caller a
 # raw payload where it expects a filtered scalar. Apply the filter for real.
@@ -61,7 +62,7 @@ case "$*" in
   *"auth status"*) exit 0 ;;
   *"--json headRefOid"*) emit "{\"headRefOid\":\"${MOCK_HEAD_SHA:-$head_default}\"}" ; exit 0 ;;
   *"--json statusCheckRollup"*) emit "${MOCK_ROLLUP:-$rollup_default}" ; exit 0 ;;
-  *"/check-runs"*) emit "${MOCK_PREV_CHECKS:-$checks_default}" ; exit 0 ;;
+  *"/actions/runs"*) emit "${MOCK_PREV_CHECKS:-$runs_default}" ; exit 0 ;;
   *"/commits"*) emit "${MOCK_PR_COMMITS:-$commits_default}" ; exit 0 ;;
   *"/reviews"*|*"/comments"*) emit '[]' ; exit 0 ;;
   *) emit '{}' ; exit 0 ;;
@@ -75,8 +76,20 @@ make_gh "$_bin"
 
 _success_rollup='{"statusCheckRollup":[{"__typename":"CheckRun","name":"workflow test harnesses","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"CheckRun","name":"ShellCheck","status":"COMPLETED","conclusion":"SUCCESS"}]}'
 _subset_rollup='{"statusCheckRollup":[{"__typename":"CheckRun","name":"ShellCheck","status":"COMPLETED","conclusion":"SUCCESS"}]}'
-_prev_two='{"check_runs":[{"name":"workflow test harnesses"},{"name":"ShellCheck"}]}'
+_prev_two='{"workflow_runs":[{"name":"workflow test harnesses"},{"name":"ShellCheck"}]}'
 _commits_two='[{"sha":"prevsha00000000000000"},{"sha":"headsha000000000000"}]'
+
+# A matrix workflow (e.g. workflow-tests.yml) reports one job per selected
+# suite under a single workflowName; the previous head ran two suite leaves
+# plus the workflow's own aggregator/select jobs, all under "workflow test
+# harnesses". The current head selected a *different, smaller* set of leaves
+# (legitimate — the diff narrowed) but the same workflow, still green.
+_matrix_prev='{"workflow_runs":[{"name":"workflow test harnesses"}]}'
+_matrix_current_rollup='{"statusCheckRollup":[
+  {"__typename":"CheckRun","name":"select suites","workflowName":"workflow test harnesses","status":"COMPLETED","conclusion":"SUCCESS"},
+  {"__typename":"CheckRun","name":"scripts/development-workflow/tests/test-only-this-suite-now.sh","workflowName":"workflow test harnesses","status":"COMPLETED","conclusion":"SUCCESS"},
+  {"__typename":"CheckRun","name":"workflow test harnesses","workflowName":"workflow test harnesses","status":"COMPLETED","conclusion":"SUCCESS"}
+]}'
 
 run_ci() {
   local out status=0
@@ -108,8 +121,17 @@ run_test "no_checks_reports_evidence_none" "CI_EVIDENCE=none" "$(grep '^CI_EVIDE
 #    the previous head ran nothing.
 _out="$(run_ci MOCK_ROLLUP="$_subset_rollup" MOCK_PREV_CHECKS="$_prev_two" MOCK_PR_COMMITS="$_commits_two" CI_LOOP_SKIP_EVIDENCE_GATE=1)"
 run_test "evidence_gate_is_skippable" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
-_out="$(run_ci MOCK_ROLLUP="$_subset_rollup" MOCK_PREV_CHECKS='{"check_runs":[]}' MOCK_PR_COMMITS="$_commits_two")"
+_out="$(run_ci MOCK_ROLLUP="$_subset_rollup" MOCK_PREV_CHECKS='{"workflow_runs":[]}' MOCK_PR_COMMITS="$_commits_two")"
 run_test "no_previous_checks_does_not_fire" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
+
+# 4b. A matrix workflow's selected suite set narrows on the current head
+#     (select-test-suites.sh legitimately picked fewer/different leaves) but
+#     the same workflow ran and passed — must stay green, not read as a
+#     missing check. Comparing at check-run granularity (pre-fix behavior)
+#     would have reported the previous head's leaf name as MISSING_CHECKS
+#     and gone red; workflow-level comparison must not.
+_out="$(run_ci MOCK_ROLLUP="$_matrix_current_rollup" MOCK_PREV_CHECKS="$_matrix_prev" MOCK_PR_COMMITS="$_commits_two")"
+run_test "matrix_suite_churn_stays_green" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
 
 # 5. A genuinely failing check is still red (the gate did not displace it).
 _fail_rollup='{"statusCheckRollup":[{"__typename":"CheckRun","name":"ShellCheck","status":"COMPLETED","conclusion":"FAILURE"}]}'

--- a/scripts/development-workflow/tests/test-pr-ci-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-ci-loop.sh
@@ -39,7 +39,7 @@ make_gh() {
 #!/usr/bin/env bash
 # Defaults are plain variables: a ${VAR:-{...}} default containing braces does
 # not survive bash parameter expansion and silently yields invalid JSON.
-head_default='headsha000000000000'
+head_default='aaaa111000000000000'
 rollup_default='{"statusCheckRollup":[]}'
 runs_default='{"workflow_runs":[]}'
 commits_default='[]'
@@ -101,7 +101,7 @@ make_gh "$_bin"
 _success_rollup='{"statusCheckRollup":[{"__typename":"CheckRun","name":"workflow test harnesses","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"CheckRun","name":"ShellCheck","status":"COMPLETED","conclusion":"SUCCESS"}]}'
 _subset_rollup='{"statusCheckRollup":[{"__typename":"CheckRun","name":"ShellCheck","status":"COMPLETED","conclusion":"SUCCESS"}]}'
 _prev_two='{"workflow_runs":[{"name":"workflow test harnesses"},{"name":"ShellCheck"}]}'
-_commits_two='[{"sha":"prevsha00000000000000"},{"sha":"headsha000000000000"}]'
+_commits_two='[{"sha":"bbbb222000000000000"},{"sha":"aaaa111000000000000"}]'
 
 # A matrix workflow (e.g. workflow-tests.yml) reports one job per selected
 # suite under a single workflowName; the previous head ran two suite leaves
@@ -128,7 +128,7 @@ run_ci() {
 # 1. Same check set as the previous head → green.
 _out="$(run_ci MOCK_ROLLUP="$_success_rollup" MOCK_PREV_CHECKS="$_runs_two" MOCK_CURRENT_RUNS="$_runs_two" MOCK_PR_COMMITS="$_commits_two")"
 run_test "full_check_set_is_green" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
-run_test "green_reports_head_sha" "HEAD_SHA=headsha000000000000" "$(grep '^HEAD_SHA=' <<<"$_out" || true)"
+run_test "green_reports_head_sha" "HEAD_SHA=aaaa111000000000000" "$(grep '^HEAD_SHA=' <<<"$_out" || true)"
 run_test "green_reports_ci_evidence_present" "CI_EVIDENCE=present" "$(grep '^CI_EVIDENCE=' <<<"$_out" || true)"
 
 # 2. A workflow that ran on the previous head is absent now → red, named.


### PR DESCRIPTION
Closes #1514. Closes #1580.

## Problem

`pr-ci-loop.sh` decides green from "no failing and no pending checks". That is not evidence CI ran:

- a head can carry **zero** checks and pass vacuously;
- a head can carry a **subset** — GitHub builds no merge ref for a `CONFLICTING` PR, so its `pull_request` workflows never start.

Measured on PR #1577 during this session: after a sibling merge made it `DIRTY`, two pushes ran **4 checks instead of 16** (only the `pull_request_target` "PR policy"), and `pr-ci-loop.sh` reported `RESULT=green`. The workflow test harnesses — the suite covering the changed script — never ran, and nothing said so. #1514 reported the same class downstream (a CHANGELOG-only commit that CI never re-ran on).

## Fix

- **`pr-ci-loop.sh`**: before declaring green, compare the current head's check names against the names that ran on the PR's most recent earlier head (`pulls/{n}/commits` → `.[-2]`, then that SHA's `check-runs`). Anything absent → `RESULT=red`, `REASON=expected_checks_missing`, `MISSING_CHECKS=<names>`. Always emits `HEAD_SHA` and `CI_EVIDENCE=present|none`. `CI_LOOP_SKIP_EVIDENCE_GATE=1` opts out; a PR with no earlier head, or whose earlier head ran nothing, is unaffected.
- **Protocol 91 Check 0**: refuses `check_runs | length == 0` with an explanation (resolve the conflict so `pull_request` workflows can run) instead of labelling on absence, and prints `READINESS_HEAD_SHA` / `READINESS_CI_TOTAL` / `READINESS_CI_CONCLUSION` — #1514 AC-4's machine-readable evidence.

`pr-ci-loop.sh` already queried the live head, so #1514 AC-1 was in place; the residual gap was that an empty or partial check set satisfied it.

## Verification

- **New suite `test-pr-ci-loop.sh`: 12/0** — closes one of the four coverage gaps `select-test-suites.sh --report-gaps` reports, and the selector now picks it for `pr-ci-loop.sh` changes.
- **Planted-violation proof**: with only `pr-ci-loop.sh` reverted (tests kept), 6 of 12 fail — including `missing_workflow_is_red` returning green, the PR #1577 shape exactly — and all pass with the fix.
- Coverage includes: full set → green; missing workflow → red + named; zero checks → green with `CI_EVIDENCE=none` (unchanged verdict, new evidence field, so the readiness gate can refuse); gate skippable; no-previous-checks does not fire; a genuine failure is still red.
- guard lint, snippet lint (committed diff), shellcheck `--severity=warning`, markdownlint, CHANGELOG heuristic + duplicate-header: clean.

## Note

Two issues in one PR: #1580 is the conflicting-PR instance of #1514's "label over stale/absent CI", same code path and same fix. Both referenced with closing keywords, which post-merge cleanup now handles per item (#1391).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI readiness checks now include workflow checks and commit statuses.
  * Pull requests with missing expected workflows or no checks are flagged as not ready.
  * Readiness results include the verified commit, check count, and CI evidence status.
  * CI polling can optionally bypass evidence validation when explicitly configured.

* **Bug Fixes**
  * Improved detection of incomplete, unavailable, or failed CI results, including matrix workflow changes.

* **Tests**
  * Added coverage for successful, missing, empty, bypassed, unavailable, and failed CI scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->