### PR TITLE
fix(ci): run checks on integration-branch PRs (#1525)

### DIFF
--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -5,6 +5,10 @@ on:
     types: [labeled, synchronize, reopened]
     branches:
       - develop
+      # Integration branches (develop-<slug>, protocol 05b). Without this, an
+      # epic's sub-item PRs run zero checks and the whole implementation
+      # reaches the graduation PR untested (#1525).
+      - develop-**
       - main
 
 concurrency:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - develop
+      # Integration branches (develop-<slug>, protocol 05b). Without this, an
+      # epic's sub-item PRs run zero checks and the whole implementation
+      # reaches the graduation PR untested (#1525).
+      - develop-**
       - main
     paths:
       - 'docs/specs/developments/**'

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - develop
+      # Integration branches (develop-<slug>, protocol 05b). Without this, an
+      # epic's sub-item PRs run zero checks and the whole implementation
+      # reaches the graduation PR untested (#1525).
+      - develop-**
       - main
     paths:
       - 'scripts/development-workflow/**/*.sh'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,16 +55,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one of the four coverage gaps the selector reports.
 - **Integration-branch PRs now run CI** (#1525): `e2e-regression.yml`,
   `markdown-lint.yml`, and `shellcheck.yml` gated on `develop` and `main`
-  only, so an epic's sub-item PRs into `develop-<slug>` ran zero checks and
-  the whole implementation reached the graduation PR untested — measured
-  downstream at 4 checks on a sub-item PR versus 13 on the graduation PR,
-  which then surfaced four real defects in already-merged code. All three now
-  include `develop-**` (as `workflow-tests.yml` already did), Protocol 05b
-  states the requirement for projects that add their own workflows, and
-  `test-workflow-branch-filters.sh` fails when a `develop`-gated workflow
-  omits the glob or hardcodes a slug — a stale
-  `develop-<old-slug>` entry reads as coverage while the current integration
-  branch is absent.
+  only, so an epic's sub-item PRs into `develop-<slug>` ran zero checks —
+  measured downstream at 4 checks on a sub-item PR versus 13 on the
+  graduation PR, which then surfaced four real defects in already-merged
+  code. All three now include `develop-**`, as `workflow-tests.yml` already
+  did, and `test-workflow-branch-filters.sh` enforces it per trigger. The
+  requirement for projects that add their own workflows is stated in
+  [Protocol 05b](docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md).
 - **Codex reviewer unavailability is classified and recoverable** (#1522,
   #1526): the Codex GitHub App's "create a Codex account and connect to
   github" refusal — which it returns per triggering identity, so an org-wide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **Integration-branch PRs now run CI** (#1525): `e2e-regression.yml`,
+  `markdown-lint.yml`, and `shellcheck.yml` gated on `develop` and `main`
+  only, so an epic's sub-item PRs into `develop-<slug>` ran zero checks and
+  the whole implementation reached the graduation PR untested — measured
+  downstream at 4 checks on a sub-item PR versus 13 on the graduation PR,
+  which then surfaced four real defects in already-merged code. All three now
+  include `develop-**` (as `workflow-tests.yml` already did), Protocol 05b
+  states the requirement for projects that add their own workflows, and
+  `test-workflow-branch-filters.sh` fails when a `develop`-gated workflow
+  omits the glob or hardcodes a slug — a stale
+  `develop-<old-slug>` entry reads as coverage while the current integration
+  branch is absent.
 - **Codex reviewer unavailability is classified and recoverable** (#1522,
   #1526): the Codex GitHub App's "create a Codex account and connect to
   github" refusal — which it returns per triggering identity, so an org-wide

--- a/docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md
@@ -17,7 +17,7 @@ PR, which then surfaced four real defects in already-merged code).
 
 Use the `develop-**` glob, never a hardcoded slug: a stale
 `develop-<old-slug>` entry reads as coverage while the current integration
-branch is absent. `scripts/development-workflow/tests/test-workflow-branch-filters.sh`
+branch is absent. [`scripts/development-workflow/tests/test-workflow-branch-filters.sh`](../../../../scripts/development-workflow/tests/test-workflow-branch-filters.sh)
 enforces both rules for the workflows this template ships.
 
 ## Release Evidence Ownership

--- a/docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md
+++ b/docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md
@@ -5,6 +5,21 @@
 
 ---
 
+## CI coverage for integration branches
+
+A project's own CI workflows must include `develop-**` in their
+`pull_request` branch filters, alongside `develop`. Sub-item PRs in an epic
+target `develop-<slug>`; a workflow that gates only on `develop` runs **zero
+checks** on them, and the epic's entire implementation reaches this
+graduation PR having never been tested, linted, or typechecked (#1525 —
+measured downstream at 4 checks on a sub-item PR versus 13 on the graduation
+PR, which then surfaced four real defects in already-merged code).
+
+Use the `develop-**` glob, never a hardcoded slug: a stale
+`develop-<old-slug>` entry reads as coverage while the current integration
+branch is absent. `scripts/development-workflow/tests/test-workflow-branch-filters.sh`
+enforces both rules for the workflows this template ships.
+
 ## Release Evidence Ownership
 
 For workflow-hub product releases, graduation evidence must preserve the

--- a/scripts/development-workflow/tests/test-workflow-branch-filters.sh
+++ b/scripts/development-workflow/tests/test-workflow-branch-filters.sh
@@ -141,22 +141,79 @@ branch_filter_block() {
 # `develop` exclusion (which leaves develop-<slug> covered), and `^develop-`
 # then missed `develop*` and `dev*`, both of which genuinely do exclude it.
 # GitHub's branch filters are globs, so ask the glob.
-ignores_integration_branch() {
-  local sample="develop-example" pat
+# GitHub evaluates a branch-filter list in order, and a later `!pattern`
+# overrides an earlier match. So `branches: [develop-**, '!develop-old']`
+# advertises integration-branch coverage while leaving develop-old with none.
+# Both helpers below therefore replay the list in order rather than asking
+# whether any single entry matches.
+#
+# Samples: one ordinary integration branch, plus one that a negation is likely
+# to name. A filter must cover BOTH to count as covering integration branches.
+BF_SAMPLES="develop-example
+develop-old"
+
+# Is <sample> included by a positive `branches:` list?
+filter_includes() {
+  local sample="$1" list="$2" pat neg included has_positive=0
   while IFS= read -r pat; do
     [ -n "$pat" ] || continue
-    # Shell pattern matching treats `**` as `*`, which is the same answer here:
-    # integration branch names carry no `/`, the only character the two forms
-    # differ on in GitHub's syntax.
-    # shellcheck disable=SC2254  # unquoted on purpose: $pat IS a glob, and
-    # interpreting it as one is the whole point of this check. Quoting it would
-    # make every pattern an exact-match test and the guard would stop working.
-    case "$sample" in
-      $pat) return 0 ;;
+    case "$pat" in '!'*) : ;; *) has_positive=1 ;; esac
+  done <<< "$list"
+  # With no positive pattern the list only subtracts, so everything starts in.
+  if [ "$has_positive" -eq 1 ]; then included=0; else included=1; fi
+  while IFS= read -r pat; do
+    [ -n "$pat" ] || continue
+    case "$pat" in
+      '!'*)
+        neg="${pat#!}"
+        # shellcheck disable=SC2254  # $neg is a glob by design
+        case "$sample" in $neg) included=0 ;; esac
+        ;;
+      *)
+        # shellcheck disable=SC2254  # $pat is a glob by design
+        case "$sample" in $pat) included=1 ;; esac
+        ;;
     esac
-  done <<< "$1"
+  done <<< "$list"
+  [ "$included" -eq 1 ]
+}
+
+# Does a positive `branches:` list cover every integration-branch sample?
+covers_integration_branches() {
+  local sample
+  while IFS= read -r sample; do
+    [ -n "$sample" ] || continue
+    filter_includes "$sample" "$1" || return 1
+  done <<< "$BF_SAMPLES"
+  return 0
+}
+
+# Does a `branches-ignore:` list exclude any integration-branch sample? Same
+# ordered replay; here a match means excluded, and `!` un-excludes.
+ignores_integration_branch() {
+  local sample pat neg excluded
+  while IFS= read -r sample; do
+    [ -n "$sample" ] || continue
+    excluded=0
+    while IFS= read -r pat; do
+      [ -n "$pat" ] || continue
+      case "$pat" in
+        '!'*)
+          neg="${pat#!}"
+          # shellcheck disable=SC2254  # glob by design
+          case "$sample" in $neg) excluded=0 ;; esac
+          ;;
+        *)
+          # shellcheck disable=SC2254  # glob by design
+          case "$sample" in $pat) excluded=1 ;; esac
+          ;;
+      esac
+    done <<< "$1"
+    [ "$excluded" -eq 1 ] && return 0
+  done <<< "$BF_SAMPLES"
   return 1
 }
+
 
 if ! python3 -c 'import yaml' 2>/dev/null; then
   echo "FAIL: pyyaml_available - PyYAML is required to parse workflow triggers"
@@ -213,7 +270,10 @@ for wf in "$WF_DIR"/*.yml "$WF_DIR"/*.yaml; do
     update-tracker-on-merge.yml) continue ;;
   esac
   checked=$((checked + 1))
-  if ! printf '%s\n' "$block" | grep -qx "develop-\*\*"; then
+  # Replay the list the way GitHub does rather than looking for a literal
+  # `develop-**` entry: an ordered filter can advertise the glob and then
+  # withdraw part of it with a later negation.
+  if ! covers_integration_branches "$block"; then
     missing="${missing:+$missing }$(basename "$wf"):$trigger"
   fi
 done
@@ -357,6 +417,19 @@ run_test "guard_predicate_ignores_unrelated_exclusion" "no" \
 # develop-<slug> covered, while `develop*` and `dev*` genuinely exclude it even
 # though neither starts with the literal `develop-`.
 _bf_excl() { if ignores_integration_branch "$1"; then printf 'excludes\n'; else printf 'no\n'; fi; }
+# GitHub replays a branch-filter list in order and a later `!pattern` overrides
+# an earlier match. A literal search for `develop-**` therefore passes a filter
+# that advertises the glob and then withdraws part of it.
+_bf_cov() { if covers_integration_branches "$1"; then printf 'covers\n'; else printf 'gap\n'; fi; }
+run_test "guard_ordered_plain_glob_covers" "covers" "$(_bf_cov "$(printf 'develop\ndevelop-**\nmain')")"
+run_test "guard_ordered_negation_withdraws_coverage" "gap" "$(_bf_cov "$(printf 'develop\ndevelop-**\n!develop-old')")"
+run_test "guard_ordered_no_glob_is_a_gap" "gap" "$(_bf_cov "$(printf 'develop\nmain')")"
+run_test "guard_ordered_develop_star_covers" "covers" "$(_bf_cov 'develop*')"
+# Negation in an ignore list un-excludes, but only for what it names: the other
+# integration-branch sample stays excluded, so the workflow is still short.
+run_test "guard_ignore_negation_still_excludes_others" "excludes" \
+  "$(if ignores_integration_branch "$(printf 'develop-**\n!develop-old')"; then printf 'excludes\n'; else printf 'no\n'; fi)"
+
 run_test "guard_glob_develop_star_excludes" "excludes" "$(_bf_excl 'develop*')"
 run_test "guard_glob_dev_star_excludes" "excludes" "$(_bf_excl 'dev*')"
 run_test "guard_glob_double_star_excludes" "excludes" "$(_bf_excl '**')"

--- a/scripts/development-workflow/tests/test-workflow-branch-filters.sh
+++ b/scripts/development-workflow/tests/test-workflow-branch-filters.sh
@@ -127,10 +127,16 @@ fi
 missing=""
 checked=0
 for wf in "$WF_DIR"/*.yml; do
-  # Each trigger is judged on its own filter list. A workflow can gate on
-  # develop under one trigger and not another, and only the trigger that
-  # actually gates PR checks decides whether a PR into develop-<slug> runs.
-  for trigger in pull_request pull_request_target; do
+  # Scoped to `pull_request` deliberately. Protocol 05b states the requirement
+  # as "must include develop-** in their `pull_request` branch filters", and
+  # that is the trigger whose checks a sub-item PR into develop-<slug> needs.
+  # Enforcing it on `pull_request_target` too would fail a workflow whose PR
+  # checks are fully covered but which deliberately gates its target-context
+  # job on develop and main only — a finding the documented rule does not make.
+  # The parser stays trigger-aware regardless: that is what stops a develop-**
+  # under one trigger from vouching for another (see the pr-vs-pr-target
+  # fixture below).
+  trigger=pull_request
   block="$(branches_for_trigger "$wf" "$trigger")"
   # No filter at all → runs everywhere → nothing to assert.
   [ -n "$block" ] || continue
@@ -148,7 +154,6 @@ for wf in "$WF_DIR"/*.yml; do
   if ! printf '%s\n' "$block" | grep -qx "develop-\*\*"; then
     missing="${missing:+$missing }$(basename "$wf"):$trigger"
   fi
-  done
 done
 
 run_test "some_workflows_gate_on_develop" "yes" "$([ "$checked" -gt 0 ] && echo yes || echo no)"
@@ -158,12 +163,14 @@ run_test "develop_gated_workflows_cover_integration_branches" "" "$missing"
 # integration branch is absent (the zeki-cl/zeki-platform trap in #1525).
 hardcoded=""
 for wf in "$WF_DIR"/*.yml; do
+  # Same scope as the coverage scan above: the rule Protocol 05b states is
+  # about `pull_request` filters, so a stale slug is judged there.
   while IFS= read -r entry; do
     case "$entry" in
       develop-\*\*|develop-\*) continue ;;
       develop-?*) hardcoded="${hardcoded:+$hardcoded }$(basename "$wf"):$entry" ;;
     esac
-  done <<< "$(branch_filter_block "$wf")"
+  done <<< "$(branches_for_trigger "$wf" pull_request)"
 done
 run_test "no_hardcoded_integration_branch_slugs" "" "$hardcoded"
 

--- a/scripts/development-workflow/tests/test-workflow-branch-filters.sh
+++ b/scripts/development-workflow/tests/test-workflow-branch-filters.sh
@@ -29,13 +29,36 @@ run_test() {
   fi
 }
 
-# branch_filter_block <file> — the `branches:` list under `on:`, one entry per
-# line, empty when the workflow has no branch filter (runs on every branch).
+# branch_filter_block <file> — the `branches:` list under `on: pull_request`
+# (or `pull_request_target`), one entry per line, empty when the workflow has
+# no PR-triggered branch filter (runs on every branch, or has no PR trigger).
+#
+# A `push:` trigger can carry its own unrelated `branches:` list in the same
+# `on:` block; PR checks are gated by the `pull_request(_target)` filter, not
+# `push`, so a `push:` list must not be folded into this result. `trigger`
+# tracks which direct child of `on:` the parser is currently inside, and only
+# `branches:` seen while `trigger` is `pull_request`/`pull_request_target` is
+# collected.
+#
+# Known limits (not hit by any workflow this template ships, so left
+# undetected rather than over-engineered): a flow-style `branches: [a, b]`
+# list is not parsed (the workflow is treated as having no filter and is
+# skipped rather than flagged); a quoted `"on":` top-level key is not
+# recognized. Both assume this repo's own convention of a block-style list
+# under a bare `on:` key, two-space YAML indentation per level.
 branch_filter_block() {
   awk '
-    /^on:/ { in_on = 1; next }
-    /^[^[:space:]#]/ { in_on = 0 }
-    in_on && /^[[:space:]]+branches:[[:space:]]*$/ { in_br = 1; next }
+    /^on:/ { in_on = 1; trigger = ""; next }
+    /^[^[:space:]#]/ { in_on = 0; trigger = "" }
+    in_on && /^[[:space:]]{2}[A-Za-z_]+:[[:space:]]*$/ {
+      key = $0
+      sub(/^[[:space:]]*/, "", key)
+      sub(/:.*$/, "", key)
+      trigger = (key == "pull_request" || key == "pull_request_target") ? key : ""
+      in_br = 0
+      next
+    }
+    in_on && trigger != "" && /^[[:space:]]+branches:[[:space:]]*$/ { in_br = 1; next }
     in_br && /^[[:space:]]+-[[:space:]]/ { sub(/^[[:space:]]*-[[:space:]]*/, ""); gsub(/[\047"]/, ""); print; next }
     # Comments and blank lines sit inside the list without ending it.
     in_br && /^[[:space:]]*#/ { next }
@@ -81,6 +104,34 @@ for wf in "$WF_DIR"/*.yml; do
   done <<< "$(branch_filter_block "$wf")"
 done
 run_test "no_hardcoded_integration_branch_slugs" "" "$hardcoded"
+
+# A `push:` filter's `branches:` list is a different trigger than
+# `pull_request:` — PR checks are not gated by it. A parser that folds both
+# lists together would report a workflow as covering integration branches
+# because `develop-**` sits under `push:`, while its actual `pull_request:`
+# filter still omits it and PRs into develop-<slug> still run zero checks.
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+cat > "$FIXTURE_DIR/push-vs-pull-request.yml" <<'FIXTURE'
+name: fixture
+on:
+  push:
+    branches:
+      - develop
+      - develop-**
+      - main
+  pull_request:
+    branches:
+      - develop
+      - main
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+FIXTURE
+fixture_block="$(branch_filter_block "$FIXTURE_DIR/push-vs-pull-request.yml")"
+run_test "branch_filter_block_ignores_push_trigger" "$(printf 'develop\nmain')" "$fixture_block"
 
 printf '\nResults: %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/development-workflow/tests/test-workflow-branch-filters.sh
+++ b/scripts/development-workflow/tests/test-workflow-branch-filters.sh
@@ -89,6 +89,14 @@ except (OSError, yaml.YAMLError) as exc:
 
 # YAML 1.1 parses a bare `on:` key as the boolean True; PyYAML keeps `"on"`
 # quoted as the string. Accept either spelling.
+# A workflow file is a mapping. A top-level list or scalar would make the
+# .get() below raise AttributeError outside the try, producing a traceback
+# rather than the structured error every other malformed input gets — and a
+# traceback is harder to act on and easier to mistake for a harness bug.
+if not isinstance(doc, dict):
+    print("ERROR: %s is not a YAML mapping (got %s)" % (sys.argv[1], type(doc).__name__), file=sys.stderr)
+    sys.exit(4)
+
 triggers = doc.get("on", doc.get(True, {}))
 if not isinstance(triggers, dict):
     sys.exit(0)
@@ -308,7 +316,16 @@ hardcoded=""
 for wf in "$WF_DIR"/*.yml "$WF_DIR"/*.yaml; do
   [ -e "$wf" ] || continue
   # Same scope as the coverage scan above: the rule Protocol 05b states is
-  # about `pull_request` filters, so a stale slug is judged there.
+  # about `pull_request` filters, so a stale slug is judged there — in the
+  # exclusion list as well as the positive one. `branches-ignore:
+  # [develop-oldslug]` is a hardcoded integration-branch reference exactly as
+  # a positive `develop-oldslug` entry is, and rots the same way.
+  while IFS= read -r entry; do
+    case "$entry" in
+      develop-\*\*|develop-\*) continue ;;
+      develop-?*) hardcoded="${hardcoded:+$hardcoded }$(basename "$wf"):ignore:$entry" ;;
+    esac
+  done <<< "$(branches_for_trigger "$wf" pull_request-ignore)"
   while IFS= read -r entry; do
     case "$entry" in
       develop-\*\*|develop-\*) continue ;;
@@ -475,6 +492,43 @@ jobs:
     steps:
       - run: echo hi
 FIXTURE
+# A top-level list or scalar is not a workflow. It must produce the structured
+# parser error, not an AttributeError traceback that reads like a harness bug.
+printf -- '- a\n- b\n' > "$FIXTURE_DIR/toplevel-list.yml"
+printf 'just-a-scalar\n' > "$FIXTURE_DIR/toplevel-scalar.yml"
+_bf_status() { local st=0; branch_filter_entries "$1" >/dev/null 2>&1 || st=$?; printf '%s\n' "$st"; }
+run_test "toplevel_list_is_a_parser_error" "4" "$(_bf_status "$FIXTURE_DIR/toplevel-list.yml")"
+run_test "toplevel_scalar_is_a_parser_error" "4" "$(_bf_status "$FIXTURE_DIR/toplevel-scalar.yml")"
+# stderr captured to a variable first: the suite runs with `pipefail`, so
+# piping straight from a function that exits non-zero makes the pipeline
+# inherit that status and the assertion would measure the exit code instead of
+# the message it claims to check.
+_bf_says_not_mapping() {
+  local out
+  out="$(branch_filter_entries "$1" 2>&1 >/dev/null || true)"
+  case "$out" in
+    *"not a YAML mapping"*) printf 'yes\n' ;;
+    *) printf 'no\n' ;;
+  esac
+}
+run_test "toplevel_list_reports_on_stderr" "yes" \
+  "$(_bf_says_not_mapping "$FIXTURE_DIR/toplevel-list.yml")"
+# A hardcoded slug in an EXCLUSION rots exactly as one in a positive list does.
+cat > "$FIXTURE_DIR/hardcoded-ignore-slug.yml" <<'FIXTURE'
+name: fixture
+on:
+  pull_request:
+    branches-ignore:
+      - develop-oldslug
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+FIXTURE
+run_test "hardcoded_slug_in_ignore_list_is_visible" "develop-oldslug" \
+  "$(branches_for_trigger "$FIXTURE_DIR/hardcoded-ignore-slug.yml" pull_request-ignore)"
+
 run_test "yaml_extension_is_parsed" "$(printf 'develop\nmain')" \
   "$(branches_for_trigger "$FIXTURE_DIR/dot-yaml-extension.yaml" pull_request)"
 

--- a/scripts/development-workflow/tests/test-workflow-branch-filters.sh
+++ b/scripts/development-workflow/tests/test-workflow-branch-filters.sh
@@ -39,7 +39,38 @@ run_test() {
 # of those guesses fails OPEN, reporting "no filter" for a workflow that has
 # one. Downstream repos copy these workflows and reformat them, so a parser
 # that silently skips a differently-indented file defeats the guard.
-branch_filter_block() {
+# Emits one "<trigger>\t<branch>" line per configured branch filter.
+#
+# Keeping the trigger name attached matters: `pull_request` and
+# `pull_request_target` are different triggers and only the former gates the
+# PR checks #1525 is about. Flattening them into one list lets a workflow with
+#   pull_request:        branches: [develop, main]
+#   pull_request_target: branches: [develop, develop-**]
+# read as covered, because `develop-**` appears *somewhere*, while its actual
+# `pull_request` filter still omits it and PRs into develop-<slug> still run
+# zero checks. That is precisely the gap this suite exists to catch, so the
+# parser must not erase the distinction.
+# Bash keeps only the most recently registered EXIT trap, so registering one
+# per temp directory silently leaks every directory but the last. Both are
+# declared and cleaned by a single handler instead.
+FIXTURE_DIR=""
+_fx=""
+_bf_cleanup() {
+  [ -n "${FIXTURE_DIR:-}" ] && rm -rf "$FIXTURE_DIR"
+  [ -n "${_fx:-}" ] && rm -rf "$_fx"
+  return 0
+}
+trap _bf_cleanup EXIT
+
+branch_filter_entries() {
+  if [ "$#" -ne 1 ]; then
+    echo "ERROR: branch_filter_entries requires exactly 1 argument (workflow file), got $#" >&2
+    return 2
+  fi
+  if [ ! -r "$1" ]; then
+    echo "ERROR: branch_filter_entries: '$1' is not a readable file" >&2
+    return 2
+  fi
   python3 - "$1" <<'PYBF'
 import sys
 try:
@@ -47,8 +78,14 @@ try:
 except ImportError:  # pragma: no cover - PyYAML absent
     sys.exit(3)
 
-with open(sys.argv[1], encoding="utf-8") as fh:
-    doc = yaml.safe_load(fh) or {}
+try:
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh) or {}
+except (OSError, yaml.YAMLError) as exc:
+    # Report rather than emit a traceback: an unparseable workflow must fail
+    # the guard loudly, not read as "no filter" and be skipped.
+    print("ERROR: could not parse %s: %s" % (sys.argv[1], exc), file=sys.stderr)
+    sys.exit(4)
 
 # YAML 1.1 parses a bare `on:` key as the boolean True; PyYAML keeps `"on"`
 # quoted as the string. Accept either spelling.
@@ -61,8 +98,23 @@ for key in ("pull_request", "pull_request_target"):
     if not isinstance(block, dict):
         continue
     for entry in block.get("branches", []) or []:
-        print(entry)
+        print("%s\t%s" % (key, entry))
 PYBF
+}
+
+# Branches configured for one specific trigger.
+branches_for_trigger() {
+  if [ "$#" -ne 2 ]; then
+    echo "ERROR: branches_for_trigger requires 2 arguments (workflow file, trigger), got $#" >&2
+    return 2
+  fi
+  branch_filter_entries "$1" | awk -F'\t' -v t="$2" '$1 == t { print $2 }'
+}
+
+# Every configured branch, regardless of trigger. Used only where the question
+# is genuinely trigger-agnostic (the hardcoded-slug scan).
+branch_filter_block() {
+  branch_filter_entries "$1" | awk -F'\t' '{ print $2 }'
 }
 
 if ! python3 -c 'import yaml' 2>/dev/null; then
@@ -75,7 +127,11 @@ fi
 missing=""
 checked=0
 for wf in "$WF_DIR"/*.yml; do
-  block="$(branch_filter_block "$wf")"
+  # Each trigger is judged on its own filter list. A workflow can gate on
+  # develop under one trigger and not another, and only the trigger that
+  # actually gates PR checks decides whether a PR into develop-<slug> runs.
+  for trigger in pull_request pull_request_target; do
+  block="$(branches_for_trigger "$wf" "$trigger")"
   # No filter at all → runs everywhere → nothing to assert.
   [ -n "$block" ] || continue
   # Only workflows that gate on `develop` are in scope; a main-only workflow
@@ -90,8 +146,9 @@ for wf in "$WF_DIR"/*.yml; do
   esac
   checked=$((checked + 1))
   if ! printf '%s\n' "$block" | grep -qx "develop-\*\*"; then
-    missing="${missing:+$missing }$(basename "$wf")"
+    missing="${missing:+$missing }$(basename "$wf"):$trigger"
   fi
+  done
 done
 
 run_test "some_workflows_gate_on_develop" "yes" "$([ "$checked" -gt 0 ] && echo yes || echo no)"
@@ -116,7 +173,6 @@ run_test "no_hardcoded_integration_branch_slugs" "" "$hardcoded"
 # because `develop-**` sits under `push:`, while its actual `pull_request:`
 # filter still omits it and PRs into develop-<slug> still run zero checks.
 FIXTURE_DIR="$(mktemp -d)"
-trap 'rm -rf "$FIXTURE_DIR"' EXIT
 cat > "$FIXTURE_DIR/push-vs-pull-request.yml" <<'FIXTURE'
 name: fixture
 on:
@@ -138,11 +194,52 @@ FIXTURE
 fixture_block="$(branch_filter_block "$FIXTURE_DIR/push-vs-pull-request.yml")"
 run_test "branch_filter_block_ignores_push_trigger" "$(printf 'develop\nmain')" "$fixture_block"
 
+# The same confusion one level in: `pull_request` and `pull_request_target` are
+# also different triggers. Flattening them lets this workflow read as covered
+# because `develop-**` appears under pull_request_target, while the trigger
+# that actually gates PR checks still omits it — the exact #1525 gap, passing
+# the guard meant to catch it.
+cat > "$FIXTURE_DIR/pr-vs-pr-target.yml" <<'FIXTURE'
+name: fixture
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  pull_request_target:
+    branches:
+      - develop
+      - develop-**
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+FIXTURE
+run_test "pull_request_branches_are_trigger_scoped" "$(printf 'develop\nmain')" \
+  "$(branches_for_trigger "$FIXTURE_DIR/pr-vs-pr-target.yml" pull_request)"
+run_test "pull_request_target_branches_are_trigger_scoped" "$(printf 'develop\ndevelop-**')" \
+  "$(branches_for_trigger "$FIXTURE_DIR/pr-vs-pr-target.yml" pull_request_target)"
+# Planted violation: the flattened view is what used to be checked, and it
+# contains develop-**, so the old logic passed this workflow.
+run_test "flattened_view_would_have_passed_this" "yes" \
+  "$(branch_filter_block "$FIXTURE_DIR/pr-vs-pr-target.yml" | grep -qx 'develop-\*\*' && echo yes || echo no)"
+# Trigger-scoped, the pull_request filter is correctly seen as missing it.
+run_test "trigger_scoped_view_catches_the_gap" "no" \
+  "$(branches_for_trigger "$FIXTURE_DIR/pr-vs-pr-target.yml" pull_request | grep -qx 'develop-\*\*' && echo yes || echo no)"
+
+# Argument validation: a missing or unreadable file must be a reported error,
+# not a shell failure or a Python traceback, and must not read as "no filter".
+_bf_status() { local st=0; "$@" >/dev/null 2>&1 || st=$?; printf '%s\n' "$st"; }
+run_test "branch_filter_entries_no_args" "2" "$(_bf_status branch_filter_entries)"
+run_test "branch_filter_entries_two_args" "2" "$(_bf_status branch_filter_entries a b)"
+run_test "branch_filter_entries_unreadable" "2" "$(_bf_status branch_filter_entries "$FIXTURE_DIR/does-not-exist.yml")"
+run_test "branches_for_trigger_wrong_arity" "2" "$(_bf_status branches_for_trigger "$FIXTURE_DIR/pr-vs-pr-target.yml")"
+
 # Formats a hand-rolled parser would miss, each failing OPEN (reporting "no
 # filter" for a workflow that has one). Downstream repos reformat what they
 # copy, so these are the realistic shapes, not exotica.
 _fx="$(mktemp -d)"
-trap 'rm -rf "$_fx"' EXIT
 cat > "$_fx/four-space.yml" <<'YFX'
 name: Four Space
 on:

--- a/scripts/development-workflow/tests/test-workflow-branch-filters.sh
+++ b/scripts/development-workflow/tests/test-workflow-branch-filters.sh
@@ -150,7 +150,30 @@ branch_filter_block() {
 # Samples: one ordinary integration branch, plus one that a negation is likely
 # to name. A filter must cover BOTH to count as covering integration branches.
 BF_SAMPLES="develop-example
-develop-old"
+develop-old
+develop-team/thing"
+
+# GitHub's branch-filter globs are not shell globs: `*` does not cross `/`,
+# `**` does, and `?` matches one non-`/` character. Shell `case` crosses `/`
+# for both stars, so it reports `develop-*` as covering `develop-team/thing`
+# when GitHub would not. Translate to an anchored regex instead of asking the
+# shell, so the guard answers the question GitHub actually asks.
+bf_glob_matches() {
+  local sample="$1" pat="$2" re="" i=0 c n
+  while [ "$i" -lt "${#pat}" ]; do
+    c="${pat:i:1}"; n="${pat:i+1:1}"
+    case "$c" in
+      '*')
+        if [ "$n" = '*' ]; then re="${re}.*"; i=$((i+2)); continue; fi
+        re="${re}[^/]*"; i=$((i+1)); continue ;;
+      '?') re="${re}[^/]" ;;
+      '.'|'['|']'|'('|')'|'{'|'}'|'+'|'^'|'$'|'|'|'\\') re="${re}\\$c" ;;
+      *) re="${re}${c}" ;;
+    esac
+    i=$((i+1))
+  done
+  printf '%s' "$sample" | grep -qE "^${re}\$"
+}
 
 # Is <sample> included by a positive `branches:` list?
 filter_includes() {
@@ -166,12 +189,10 @@ filter_includes() {
     case "$pat" in
       '!'*)
         neg="${pat#!}"
-        # shellcheck disable=SC2254  # $neg is a glob by design
-        case "$sample" in $neg) included=0 ;; esac
+        bf_glob_matches "$sample" "$neg" && included=0
         ;;
       *)
-        # shellcheck disable=SC2254  # $pat is a glob by design
-        case "$sample" in $pat) included=1 ;; esac
+        bf_glob_matches "$sample" "$pat" && included=1
         ;;
     esac
   done <<< "$list"
@@ -200,12 +221,10 @@ ignores_integration_branch() {
       case "$pat" in
         '!'*)
           neg="${pat#!}"
-          # shellcheck disable=SC2254  # glob by design
-          case "$sample" in $neg) excluded=0 ;; esac
+          bf_glob_matches "$sample" "$neg" && excluded=0
           ;;
         *)
-          # shellcheck disable=SC2254  # glob by design
-          case "$sample" in $pat) excluded=1 ;; esac
+          bf_glob_matches "$sample" "$pat" && excluded=1
           ;;
       esac
     done <<< "$1"
@@ -424,12 +443,19 @@ _bf_cov() { if covers_integration_branches "$1"; then printf 'covers\n'; else pr
 run_test "guard_ordered_plain_glob_covers" "covers" "$(_bf_cov "$(printf 'develop\ndevelop-**\nmain')")"
 run_test "guard_ordered_negation_withdraws_coverage" "gap" "$(_bf_cov "$(printf 'develop\ndevelop-**\n!develop-old')")"
 run_test "guard_ordered_no_glob_is_a_gap" "gap" "$(_bf_cov "$(printf 'develop\nmain')")"
-run_test "guard_ordered_develop_star_covers" "covers" "$(_bf_cov 'develop*')"
+# Under GitHub's semantics a single star does not cross `/`, so `develop*`
+# covers develop-example but NOT develop-team/thing. Only the double-star form
+# covers a nested integration branch — which is exactly why Protocol 05b
+# specifies `develop-**` rather than any glob that happens to match.
+run_test "guard_ordered_develop_star_misses_nested" "gap" "$(_bf_cov 'develop*')"
+run_test "guard_ordered_double_star_covers_nested" "covers" "$(_bf_cov "$(printf 'develop\ndevelop-**')")"
 # Negation in an ignore list un-excludes, but only for what it names: the other
 # integration-branch sample stays excluded, so the workflow is still short.
 run_test "guard_ignore_negation_still_excludes_others" "excludes" \
   "$(if ignores_integration_branch "$(printf 'develop-**\n!develop-old')"; then printf 'excludes\n'; else printf 'no\n'; fi)"
 
+# Still an exclusion: it matches develop-example even though it misses the
+# nested sample, and excluding any integration branch is a coverage gap.
 run_test "guard_glob_develop_star_excludes" "excludes" "$(_bf_excl 'develop*')"
 run_test "guard_glob_dev_star_excludes" "excludes" "$(_bf_excl 'dev*')"
 run_test "guard_glob_double_star_excludes" "excludes" "$(_bf_excl '**')"

--- a/scripts/development-workflow/tests/test-workflow-branch-filters.sh
+++ b/scripts/development-workflow/tests/test-workflow-branch-filters.sh
@@ -99,6 +99,14 @@ for key in ("pull_request", "pull_request_target"):
         continue
     for entry in block.get("branches", []) or []:
         print("%s\t%s" % (key, entry))
+    # branches-ignore is the restrictive form of the same filter, and GitHub
+    # treats it as mutually exclusive with branches. Emitting it under a
+    # distinct pseudo-trigger keeps every existing caller untouched while
+    # making exclusions queryable: a workflow that excludes develop-** has no
+    # integration-branch coverage, yet reports "no filter" to a reader that
+    # only looks at branches.
+    for entry in block.get("branches-ignore", []) or []:
+        print("%s-ignore\t%s" % (key, entry))
 PYBF
 }
 
@@ -138,6 +146,24 @@ for wf in "$WF_DIR"/*.yml; do
   # fixture below).
   trigger=pull_request
   block="$(branches_for_trigger "$wf" "$trigger")"
+  ignores="$(branches_for_trigger "$wf" "${trigger}-ignore")"
+  # An exclusion that names an integration branch removes coverage exactly as
+  # an omission from a positive list does — a workflow with only
+  # `branches-ignore: [develop-**]` runs on every base branch EXCEPT the one
+  # #1525 is about. Judge it before the "no positive filter" early return,
+  # which would otherwise let it through as "runs everywhere".
+  if [ -n "$ignores" ]; then
+    case "$(basename "$wf")" in
+      update-tracker-on-merge.yml) : ;;
+      *)
+        if printf '%s\n' "$ignores" | grep -qE '^develop(-|$)'; then
+          checked=$((checked + 1))
+          missing="${missing:+$missing }$(basename "$wf"):${trigger}-ignore"
+          continue
+        fi
+        ;;
+    esac
+  fi
   # No filter at all → runs everywhere → nothing to assert.
   [ -n "$block" ] || continue
   # Only workflows that gate on `develop` are in scope; a main-only workflow
@@ -223,6 +249,44 @@ jobs:
     steps:
       - run: echo hi
 FIXTURE
+# branches-ignore is the restrictive form of the same filter. A workflow using
+# it to exclude integration branches has no coverage there, but a parser that
+# reads only `branches:` sees nothing and reports "runs everywhere" — so the
+# exclusion escapes the guard entirely.
+cat > "$FIXTURE_DIR/branches-ignore-excludes-integration.yml" <<'FIXTURE'
+name: fixture
+on:
+  pull_request:
+    branches-ignore:
+      - develop-**
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+FIXTURE
+run_test "branches_ignore_is_parsed_under_its_own_trigger" "develop-**" \
+  "$(branches_for_trigger "$FIXTURE_DIR/branches-ignore-excludes-integration.yml" pull_request-ignore)"
+# The positive list is empty, which is exactly why the old parser saw nothing.
+run_test "branches_ignore_leaves_positive_list_empty" "" \
+  "$(branches_for_trigger "$FIXTURE_DIR/branches-ignore-excludes-integration.yml" pull_request)"
+# An exclusion that does not name an integration branch is fine: the workflow
+# still runs on develop-<slug>.
+cat > "$FIXTURE_DIR/branches-ignore-unrelated.yml" <<'FIXTURE'
+name: fixture
+on:
+  pull_request:
+    branches-ignore:
+      - gh-pages
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+FIXTURE
+run_test "branches_ignore_unrelated_exclusion_parsed" "gh-pages" \
+  "$(branches_for_trigger "$FIXTURE_DIR/branches-ignore-unrelated.yml" pull_request-ignore)"
+
 run_test "pull_request_branches_are_trigger_scoped" "$(printf 'develop\nmain')" \
   "$(branches_for_trigger "$FIXTURE_DIR/pr-vs-pr-target.yml" pull_request)"
 run_test "pull_request_target_branches_are_trigger_scoped" "$(printf 'develop\ndevelop-**')" \

--- a/scripts/development-workflow/tests/test-workflow-branch-filters.sh
+++ b/scripts/development-workflow/tests/test-workflow-branch-filters.sh
@@ -134,8 +134,28 @@ branch_filter_block() {
 # literal `develop-<slug>` all do exclude integration-branch coverage and must
 # be flagged. `developer-branch` must not match either: the dash anchors the
 # boundary so `develop` cannot match as a prefix of an unrelated branch name.
+# Does any of these branches-ignore patterns actually exclude an integration
+# branch? Decided by *matching a representative branch name against the glob*
+# rather than by inspecting the pattern's text. Pattern-shape matching kept
+# getting this wrong in both directions: `^develop(-|$)` wrongly flagged a bare
+# `develop` exclusion (which leaves develop-<slug> covered), and `^develop-`
+# then missed `develop*` and `dev*`, both of which genuinely do exclude it.
+# GitHub's branch filters are globs, so ask the glob.
 ignores_integration_branch() {
-  printf '%s\n' "$1" | grep -qE '^develop-'
+  local sample="develop-example" pat
+  while IFS= read -r pat; do
+    [ -n "$pat" ] || continue
+    # Shell pattern matching treats `**` as `*`, which is the same answer here:
+    # integration branch names carry no `/`, the only character the two forms
+    # differ on in GitHub's syntax.
+    # shellcheck disable=SC2254  # unquoted on purpose: $pat IS a glob, and
+    # interpreting it as one is the whole point of this check. Quoting it would
+    # make every pattern an exact-match test and the guard would stop working.
+    case "$sample" in
+      $pat) return 0 ;;
+    esac
+  done <<< "$1"
+  return 1
 }
 
 if ! python3 -c 'import yaml' 2>/dev/null; then
@@ -147,7 +167,10 @@ fi
 
 missing=""
 checked=0
-for wf in "$WF_DIR"/*.yml; do
+# Both extensions: GitHub honours .yaml as well as .yml, so a *.yml-only
+# glob would let a .yaml workflow escape this guard entirely.
+for wf in "$WF_DIR"/*.yml "$WF_DIR"/*.yaml; do
+  [ -e "$wf" ] || continue
   # Scoped to `pull_request` deliberately. Protocol 05b states the requirement
   # as "must include develop-** in their `pull_request` branch filters", and
   # that is the trigger whose checks a sub-item PR into develop-<slug> needs.
@@ -201,7 +224,10 @@ run_test "develop_gated_workflows_cover_integration_branches" "" "$missing"
 # A hardcoded slug is not coverage: it reads as covered while the current
 # integration branch is absent (the zeki-cl/zeki-platform trap in #1525).
 hardcoded=""
-for wf in "$WF_DIR"/*.yml; do
+# Both extensions: GitHub honours .yaml as well as .yml, so a *.yml-only
+# glob would let a .yaml workflow escape this guard entirely.
+for wf in "$WF_DIR"/*.yml "$WF_DIR"/*.yaml; do
+  [ -e "$wf" ] || continue
   # Same scope as the coverage scan above: the rule Protocol 05b states is
   # about `pull_request` filters, so a stale slug is judged there.
   while IFS= read -r entry; do
@@ -326,6 +352,33 @@ run_test "guard_predicate_ignores_unrelated_exclusion" "no" \
   "$(ignores_integration_branch "$(branches_for_trigger "$FIXTURE_DIR/branches-ignore-unrelated.yml" pull_request-ignore)" && echo yes || echo no)"
 # A different branch that merely starts with the same letters must not match:
 # the dash anchors the boundary.
+# The predicate asks the glob, not the pattern's shape. These are the cases
+# that pattern-matching got wrong in both directions: `develop` alone leaves
+# develop-<slug> covered, while `develop*` and `dev*` genuinely exclude it even
+# though neither starts with the literal `develop-`.
+_bf_excl() { if ignores_integration_branch "$1"; then printf 'excludes\n'; else printf 'no\n'; fi; }
+run_test "guard_glob_develop_star_excludes" "excludes" "$(_bf_excl 'develop*')"
+run_test "guard_glob_dev_star_excludes" "excludes" "$(_bf_excl 'dev*')"
+run_test "guard_glob_double_star_excludes" "excludes" "$(_bf_excl '**')"
+run_test "guard_glob_bare_develop_does_not_exclude" "no" "$(_bf_excl 'develop')"
+run_test "guard_glob_release_prefix_does_not_exclude" "no" "$(_bf_excl 'release/*')"
+# A .yaml workflow must not escape the scan; GitHub honours both extensions.
+cat > "$FIXTURE_DIR/dot-yaml-extension.yaml" <<'FIXTURE'
+name: fixture
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+FIXTURE
+run_test "yaml_extension_is_parsed" "$(printf 'develop\nmain')" \
+  "$(branches_for_trigger "$FIXTURE_DIR/dot-yaml-extension.yaml" pull_request)"
+
 run_test "guard_predicate_does_not_match_developer_branch" "no" \
   "$(ignores_integration_branch "developer-branch" && echo yes || echo no)"
 

--- a/scripts/development-workflow/tests/test-workflow-branch-filters.sh
+++ b/scripts/development-workflow/tests/test-workflow-branch-filters.sh
@@ -29,43 +29,48 @@ run_test() {
   fi
 }
 
-# branch_filter_block <file> — the `branches:` list under `on: pull_request`
-# (or `pull_request_target`), one entry per line, empty when the workflow has
-# no PR-triggered branch filter (runs on every branch, or has no PR trigger).
+# branch_filter_block <file> — the pull_request / pull_request_target branch
+# filter, one entry per line; empty when the workflow has no such filter (it
+# then runs on every branch and there is nothing to assert).
 #
-# A `push:` trigger can carry its own unrelated `branches:` list in the same
-# `on:` block; PR checks are gated by the `pull_request(_target)` filter, not
-# `push`, so a `push:` list must not be folded into this result. `trigger`
-# tracks which direct child of `on:` the parser is currently inside, and only
-# `branches:` seen while `trigger` is `pull_request`/`pull_request_target` is
-# collected.
-#
-# Known limits (not hit by any workflow this template ships, so left
-# undetected rather than over-engineered): a flow-style `branches: [a, b]`
-# list is not parsed (the workflow is treated as having no filter and is
-# skipped rather than flagged); a quoted `"on":` top-level key is not
-# recognized. Both assume this repo's own convention of a block-style list
-# under a bare `on:` key, two-space YAML indentation per level.
+# Uses a real YAML parse rather than line matching. A hand-rolled parser has to
+# guess at indentation, flow-style lists (`branches: [a, b]`), and the quoted
+# `"on":` key that YAML 1.1 loaders produce for the `on` token — and every one
+# of those guesses fails OPEN, reporting "no filter" for a workflow that has
+# one. Downstream repos copy these workflows and reformat them, so a parser
+# that silently skips a differently-indented file defeats the guard.
 branch_filter_block() {
-  awk '
-    /^on:/ { in_on = 1; trigger = ""; next }
-    /^[^[:space:]#]/ { in_on = 0; trigger = "" }
-    in_on && /^[[:space:]]{2}[A-Za-z_]+:[[:space:]]*$/ {
-      key = $0
-      sub(/^[[:space:]]*/, "", key)
-      sub(/:.*$/, "", key)
-      trigger = (key == "pull_request" || key == "pull_request_target") ? key : ""
-      in_br = 0
-      next
-    }
-    in_on && trigger != "" && /^[[:space:]]+branches:[[:space:]]*$/ { in_br = 1; next }
-    in_br && /^[[:space:]]+-[[:space:]]/ { sub(/^[[:space:]]*-[[:space:]]*/, ""); gsub(/[\047"]/, ""); print; next }
-    # Comments and blank lines sit inside the list without ending it.
-    in_br && /^[[:space:]]*#/ { next }
-    in_br && /^[[:space:]]*$/ { next }
-    in_br { in_br = 0 }
-  ' "$1"
+  python3 - "$1" <<'PYBF'
+import sys
+try:
+    import yaml
+except ImportError:  # pragma: no cover - PyYAML absent
+    sys.exit(3)
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    doc = yaml.safe_load(fh) or {}
+
+# YAML 1.1 parses a bare `on:` key as the boolean True; PyYAML keeps `"on"`
+# quoted as the string. Accept either spelling.
+triggers = doc.get("on", doc.get(True, {}))
+if not isinstance(triggers, dict):
+    sys.exit(0)
+
+for key in ("pull_request", "pull_request_target"):
+    block = triggers.get(key)
+    if not isinstance(block, dict):
+        continue
+    for entry in block.get("branches", []) or []:
+        print(entry)
+PYBF
 }
+
+if ! python3 -c 'import yaml' 2>/dev/null; then
+  echo "FAIL: pyyaml_available - PyYAML is required to parse workflow triggers"
+  fail=$((fail + 1))
+  printf '\nResults: %d passed, %d failed\n' "$pass" "$fail"
+  exit 1
+fi
 
 missing=""
 checked=0
@@ -132,6 +137,39 @@ jobs:
 FIXTURE
 fixture_block="$(branch_filter_block "$FIXTURE_DIR/push-vs-pull-request.yml")"
 run_test "branch_filter_block_ignores_push_trigger" "$(printf 'develop\nmain')" "$fixture_block"
+
+# Formats a hand-rolled parser would miss, each failing OPEN (reporting "no
+# filter" for a workflow that has one). Downstream repos reformat what they
+# copy, so these are the realistic shapes, not exotica.
+_fx="$(mktemp -d)"
+trap 'rm -rf "$_fx"' EXIT
+cat > "$_fx/four-space.yml" <<'YFX'
+name: Four Space
+on:
+    pull_request:
+        branches:
+            - develop
+            - main
+YFX
+cat > "$_fx/flow-style.yml" <<'YFX'
+name: Flow Style
+on:
+  pull_request:
+    branches: [develop, "develop-**", 'main']
+YFX
+cat > "$_fx/quoted-on.yml" <<'YFX'
+name: Quoted On
+"on":
+  pull_request_target:
+    branches:
+      - develop
+YFX
+run_test "parses_four_space_indentation" "develop main" \
+  "$(branch_filter_block "$_fx/four-space.yml" | tr '\n' ' ' | sed 's/ $//')"
+run_test "parses_flow_style_list" "develop develop-** main" \
+  "$(branch_filter_block "$_fx/flow-style.yml" | tr '\n' ' ' | sed 's/ $//')"
+run_test "parses_quoted_on_key" "develop" \
+  "$(branch_filter_block "$_fx/quoted-on.yml" | tr '\n' ' ' | sed 's/ $//')"
 
 printf '\nResults: %d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/development-workflow/tests/test-workflow-branch-filters.sh
+++ b/scripts/development-workflow/tests/test-workflow-branch-filters.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# test-workflow-branch-filters.sh - integration-branch CI coverage.
+# covers: .github/workflows/e2e-regression.yml
+# covers: .github/workflows/markdown-lint.yml
+# covers: .github/workflows/shellcheck.yml
+# covers: .github/workflows/workflow-tests.yml
+#
+# Protocol 05b defines integration branches (develop-<slug>); an epic's
+# sub-item PRs target them. A workflow whose pull_request filter lists
+# `develop` but not `develop-**` therefore runs zero checks on that work, and
+# the entire epic reaches its graduation PR untested (#1525). Downstream repos
+# copy these files, so the gap propagates — and hardcoding one slug reads as
+# coverage while the current integration branch is absent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../../.." && pwd)"
+WF_DIR="$REPO_ROOT/.github/workflows"
+
+pass=0
+fail=0
+run_test() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"; pass=$((pass + 1))
+  else
+    echo "FAIL: $name - expected '$expected', got '$actual'"; fail=$((fail + 1))
+  fi
+}
+
+# branch_filter_block <file> — the `branches:` list under `on:`, one entry per
+# line, empty when the workflow has no branch filter (runs on every branch).
+branch_filter_block() {
+  awk '
+    /^on:/ { in_on = 1; next }
+    /^[^[:space:]#]/ { in_on = 0 }
+    in_on && /^[[:space:]]+branches:[[:space:]]*$/ { in_br = 1; next }
+    in_br && /^[[:space:]]+-[[:space:]]/ { sub(/^[[:space:]]*-[[:space:]]*/, ""); gsub(/[\047"]/, ""); print; next }
+    # Comments and blank lines sit inside the list without ending it.
+    in_br && /^[[:space:]]*#/ { next }
+    in_br && /^[[:space:]]*$/ { next }
+    in_br { in_br = 0 }
+  ' "$1"
+}
+
+missing=""
+checked=0
+for wf in "$WF_DIR"/*.yml; do
+  block="$(branch_filter_block "$wf")"
+  # No filter at all → runs everywhere → nothing to assert.
+  [ -n "$block" ] || continue
+  # Only workflows that gate on `develop` are in scope; a main-only workflow
+  # (release tagging) legitimately never runs on an integration branch.
+  printf '%s\n' "$block" | grep -qx "develop" || continue
+  # update-tracker-on-merge.yml is deliberately out of scope: it closes issues
+  # and writes tracker status on merge, so extending it to integration branches
+  # is a tracker-lifecycle decision (does a sub-item merged into develop-<slug>
+  # close before the epic graduates?), not the CI-coverage gap #1525 reports.
+  case "$(basename "$wf")" in
+    update-tracker-on-merge.yml) continue ;;
+  esac
+  checked=$((checked + 1))
+  if ! printf '%s\n' "$block" | grep -qx "develop-\*\*"; then
+    missing="${missing:+$missing }$(basename "$wf")"
+  fi
+done
+
+run_test "some_workflows_gate_on_develop" "yes" "$([ "$checked" -gt 0 ] && echo yes || echo no)"
+run_test "develop_gated_workflows_cover_integration_branches" "" "$missing"
+
+# A hardcoded slug is not coverage: it reads as covered while the current
+# integration branch is absent (the zeki-cl/zeki-platform trap in #1525).
+hardcoded=""
+for wf in "$WF_DIR"/*.yml; do
+  while IFS= read -r entry; do
+    case "$entry" in
+      develop-\*\*|develop-\*) continue ;;
+      develop-?*) hardcoded="${hardcoded:+$hardcoded }$(basename "$wf"):$entry" ;;
+    esac
+  done <<< "$(branch_filter_block "$wf")"
+done
+run_test "no_hardcoded_integration_branch_slugs" "" "$hardcoded"
+
+printf '\nResults: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/development-workflow/tests/test-workflow-branch-filters.sh
+++ b/scripts/development-workflow/tests/test-workflow-branch-filters.sh
@@ -125,6 +125,19 @@ branch_filter_block() {
   branch_filter_entries "$1" | awk -F'\t' '{ print $2 }'
 }
 
+# True when a branches-ignore list (one entry per line, as returned by
+# branches_for_trigger with a "-ignore" pseudo-trigger) excludes an
+# integration branch. Requires the dash: branches-ignore matches each entry
+# exactly, with no implicit wildcard, so `branches-ignore: [develop]` excludes
+# only the literal `develop` branch — the workflow still runs on
+# `develop-<slug>` — and must NOT be flagged. `develop-**`, `develop-*`, and a
+# literal `develop-<slug>` all do exclude integration-branch coverage and must
+# be flagged. `developer-branch` must not match either: the dash anchors the
+# boundary so `develop` cannot match as a prefix of an unrelated branch name.
+ignores_integration_branch() {
+  printf '%s\n' "$1" | grep -qE '^develop-'
+}
+
 if ! python3 -c 'import yaml' 2>/dev/null; then
   echo "FAIL: pyyaml_available - PyYAML is required to parse workflow triggers"
   fail=$((fail + 1))
@@ -156,7 +169,7 @@ for wf in "$WF_DIR"/*.yml; do
     case "$(basename "$wf")" in
       update-tracker-on-merge.yml) : ;;
       *)
-        if printf '%s\n' "$ignores" | grep -qE '^develop(-|$)'; then
+        if ignores_integration_branch "$ignores"; then
           checked=$((checked + 1))
           missing="${missing:+$missing }$(basename "$wf"):${trigger}-ignore"
           continue
@@ -286,6 +299,35 @@ jobs:
 FIXTURE
 run_test "branches_ignore_unrelated_exclusion_parsed" "gh-pages" \
   "$(branches_for_trigger "$FIXTURE_DIR/branches-ignore-unrelated.yml" pull_request-ignore)"
+
+# `branches-ignore: [develop]` (no dash) excludes only the literal `develop`
+# branch — not `develop-<slug>` — so the workflow still runs on integration
+# branches. Flagging it would be a false positive: #1525 is about
+# `develop-<slug>` coverage, not `develop` itself.
+cat > "$FIXTURE_DIR/branches-ignore-bare-develop.yml" <<'FIXTURE'
+name: fixture
+on:
+  pull_request:
+    branches-ignore:
+      - develop
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+FIXTURE
+run_test "branches_ignore_bare_develop_is_not_flagged" "no" \
+  "$(ignores_integration_branch "$(branches_for_trigger "$FIXTURE_DIR/branches-ignore-bare-develop.yml" pull_request-ignore)" && echo yes || echo no)"
+# The actual guard predicate, not just the parser, must flag a develop-**
+# exclusion and must not flag an unrelated one or a bare-`develop` one.
+run_test "guard_predicate_flags_develop_slug_exclusion" "yes" \
+  "$(ignores_integration_branch "$(branches_for_trigger "$FIXTURE_DIR/branches-ignore-excludes-integration.yml" pull_request-ignore)" && echo yes || echo no)"
+run_test "guard_predicate_ignores_unrelated_exclusion" "no" \
+  "$(ignores_integration_branch "$(branches_for_trigger "$FIXTURE_DIR/branches-ignore-unrelated.yml" pull_request-ignore)" && echo yes || echo no)"
+# A different branch that merely starts with the same letters must not match:
+# the dash anchors the boundary.
+run_test "guard_predicate_does_not_match_developer_branch" "no" \
+  "$(ignores_integration_branch "developer-branch" && echo yes || echo no)"
 
 run_test "pull_request_branches_are_trigger_scoped" "$(printf 'develop\nmain')" \
   "$(branches_for_trigger "$FIXTURE_DIR/pr-vs-pr-target.yml" pull_request)"


### PR DESCRIPTION
Closes #1525.

> **Merge authority:** this PR touches `.github/workflows/`, which the risk classifier scores **high**. Per the operator's standing instruction, it is prepared and left at `ready-for-human-review` for explicit merge authorization — it is not eligible for delegated merge.

## Problem

`e2e-regression.yml`, `markdown-lint.yml`, and `shellcheck.yml` gate on `branches: [develop, main]`. Protocol 05b defines integration branches (`develop-<slug>`), and an epic's sub-item PRs target them — so none of those workflows run on sub-item PRs, and the epic's whole implementation reaches the graduation PR untested. The issue measured it downstream: 4 checks on a sub-item PR vs 13 on the graduation PR, which then surfaced four real defects in already-merged, already-reviewed code (including a build broken on the integration branch for a full epic).

`workflow-tests.yml` already carries `develop-**` (added by #1537); the other three did not.

## Fix

- `develop-**` added to the three workflows, with a comment naming the failure it prevents.
- **`test-workflow-branch-filters.sh`** (new): parses each workflow's `pull_request` branch list and fails when a `develop`-gated workflow omits `develop-**`, or when any workflow hardcodes a specific slug. The second rule is the issue's second-order trap — `zeki-cl/zeki-platform` had a long-graduated `develop-best-practices-compliance` listed in seven workflows while the current integration branch was absent, so the filter *read* as coverage.
- Protocol 05b gains a "CI coverage for integration branches" section, since downstream repos add their own workflows and copy the shipped pattern.

## Deliberately out of scope

`update-tracker-on-merge.yml` also gates on `develop` alone, and the guard test excludes it with that reasoning recorded in code: it closes issues and writes tracker status on merge, so extending it to integration branches is a tracker-lifecycle decision (should a sub-item close before its epic graduates?), not the CI-coverage gap this issue reports. Worth a separate decision if you want it.

## Verification

- `test-workflow-branch-filters.sh`: 3/0. **Planted-violation proof**: with the three workflow files reverted and the test kept, `develop_gated_workflows_cover_integration_branches` fails and names all three; passes with the fix.
- guard lint, snippet lint (committed diff), shellcheck `--severity=warning`, markdownlint, CHANGELOG heuristic + duplicate-header: clean.
- The change is filter-only — no job, step, or permission was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI**
  * Pull request checks for end-to-end testing, Markdown linting, and ShellCheck now run for `develop-**` integration branches, alongside `develop` and `main`.
  * Added automated validation to ensure supported branch patterns are consistently covered and configured correctly.

* **Documentation**
  * Updated development workflow guidance and the unreleased changelog with the new branch coverage requirements.
  * Clarified expected workflow behavior for pull requests targeting protocol integration branches and documented validation expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->