### PR TITLE
fix(release): gate auto-add on ancestry, not on having a merged PR (#1512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **Release stamping no longer treats "has a merged PR" as "shipped"**
+  (#1512): `detect_omitted_merged_items()` auto-added any Merged board item
+  with a merged PR closed inside the release window — but a PR merged into an
+  in-flight `develop-<slug>` integration branch satisfies all of that while
+  none of its code is in the tag. Downstream this stamped 16 issues onto a
+  release whose changelog named two, across at least five releases. Auto-add
+  is now gated on `git merge-base --is-ancestor <merge-commit> <tag>`;
+  candidates that fail it (or whose merge commit, tag, or git state cannot be
+  read) are reported and left out of the stamped scope, surfacing as
+  `TRACKER_INCOMPLETE`. Protocol 05 §9.1 says `--from-changelog` is not
+  unconditionally safe while integration branches exist.
 - **Codex reviewer unavailability is classified and recoverable** (#1522,
   #1526): the Codex GitHub App's "create a Codex account and connect to
   github" refusal — which it returns per triggering identity, so an org-wide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is now gated on `git merge-base --is-ancestor <merge-commit> <tag>`;
   candidates that fail it (or whose merge commit, tag, or git state cannot be
   read) are reported and left out of the stamped scope, surfacing as
-  `TRACKER_INCOMPLETE`. Protocol 05 §9.1 says `--from-changelog` is not
-  unconditionally safe while integration branches exist.
+  `TRACKER_INCOMPLETE`. The operational guidance lives in
+  [Protocol 05 §9.1](docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md).
 - **Codex reviewer unavailability is classified and recoverable** (#1522,
   #1526): the Codex GitHub App's "create a Codex account and connect to
   github" refusal — which it returns per triggering identity, so an org-wide

--- a/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
+++ b/docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md
@@ -451,6 +451,17 @@ shipped in that release section. Prefer the helper's `--from-changelog` parser,
 or pass the same explicit scope with `--issue` / `--issues`. Do not infer release
 scope from the whole project board.
 
+`--from-changelog` is not unconditionally safe on its own while integration
+branches exist (#1512). The helper also runs `detect_omitted_merged_items()`,
+which used to auto-add any Merged item that had a merged PR — and a PR merged
+into an in-flight `develop-<slug>` is merged, closed, and inside the release
+window while none of its code is in the tag. Downstream this stamped 16 issues
+onto a release whose changelog named two. Auto-add is now gated on the merge
+commit being an ancestor of the release tag; anything else is reported
+**report-only** and surfaces as `TRACKER_INCOMPLETE`. Read that report rather
+than assuming the changelog-derived scope was the only thing stamped, and pass
+`--issue` / `--issues` for anything the report names that genuinely shipped.
+
 ### 9.2 Preferred command (single entry point)
 
 Use the helper script:

--- a/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
+++ b/scripts/development-workflow/prepare-release-post-merge-cleanup.sh
@@ -515,12 +515,30 @@ PY
 #   - GITHUB_PROJECT_NUMBER is not configured
 #   - the current or previous release tag cannot be resolved
 #   - the GitHub Projects item-list API call fails
+# pr_merge_is_in_release <merge_sha> <version>
+# 0 when <merge_sha> is an ancestor of the release tag — i.e. the code actually
+# shipped in it. "Has a merged PR" is not that test: a PR merged into an
+# in-flight develop-<slug> integration branch is merged, closed, and inside the
+# release window, yet none of its code is in the tag. Downstream this stamped
+# 16 issues onto a release whose changelog named two (#1512).
+#
+# An unknown SHA, an unfetched tag, or any git failure returns non-zero, so the
+# caller degrades to report-only rather than auto-adding on a guess.
+pr_merge_is_in_release() {
+  local merge_sha="$1" version="$2"
+  [ -n "$merge_sha" ] && [ -n "$version" ] || return 1
+  git rev-parse --verify --quiet "${merge_sha}^{commit}" >/dev/null 2>&1 || return 1
+  git rev-parse --verify --quiet "refs/tags/${version}^{commit}" >/dev/null 2>&1 || return 1
+  git merge-base --is-ancestor "$merge_sha" "refs/tags/${version}" 2>/dev/null
+}
+
 detect_omitted_merged_items() {
   local version="$1"
   local provider project_number owner repo_owner repo_name repo_slug
   local current_tag_date prev_tag_name prev_tag_date project_items merged_items
   local known_scope_arg issue_num issue_closed_at in_window referencing_pr
-  local entry iss detail total_omitted epic_nums
+  local referencing_pr_merge_sha referencing_pr_base
+  local entry iss detail total_omitted epic_nums _ns_rest
   local omitted_epics omitted_shipped
   omitted_epics=""
   omitted_shipped=""
@@ -845,7 +863,7 @@ PY
     # The query is inlined as a single-line variable to avoid <<'PY' heredoc
     # quoting issues in bash 3.2 when the query spans multiple lines.
     # shellcheck disable=SC2016 # GraphQL variables are not Bash variables.
-    local _gql_tl_query='query($owner:String!,$repo:String!,$num:Int!,$after:String){repository(owner:$owner,name:$repo){issue(number:$num){timelineItems(first:100,after:$after,itemTypes:[CROSS_REFERENCED_EVENT,CLOSED_EVENT]){nodes{__typename ...on CrossReferencedEvent{source{__typename ...on PullRequest{number merged}}}...on ClosedEvent{closer{__typename ...on PullRequest{number merged}}}}pageInfo{hasNextPage endCursor}}}}}'
+    local _gql_tl_query='query($owner:String!,$repo:String!,$num:Int!,$after:String){repository(owner:$owner,name:$repo){issue(number:$num){timelineItems(first:100,after:$after,itemTypes:[CROSS_REFERENCED_EVENT,CLOSED_EVENT]){nodes{__typename ...on CrossReferencedEvent{source{__typename ...on PullRequest{number merged baseRefName mergeCommit{oid}}}}...on ClosedEvent{closer{__typename ...on PullRequest{number merged baseRefName mergeCommit{oid}}}}}pageInfo{hasNextPage endCursor}}}}}'
     local gql_pr_cursor="" gql_pr_has_next="true" gql_pr_page=0 gql_pr_max=20
     referencing_pr=""
     while [ "$gql_pr_has_next" = "true" ] && [ "$gql_pr_page" -lt "$gql_pr_max" ] && [ -z "$referencing_pr" ]; do
@@ -881,18 +899,24 @@ tl       = issue.get("timelineItems") or {}
 nodes    = tl.get("nodes") or []
 pi       = tl.get("pageInfo") or {}
 found_pr = None
+found_merge_sha = ""
+found_base = ""
+
+def _take(pr):
+    mc = pr.get("mergeCommit") or {}
+    return pr.get("number"), (mc.get("oid") or ""), (pr.get("baseRefName") or "")
 
 for n in nodes:
     t = n.get("__typename") or ""
     if t == "CrossReferencedEvent":
         src = n.get("source") or {}
         if src.get("__typename") == "PullRequest" and src.get("merged"):
-            found_pr = src.get("number")
+            found_pr, found_merge_sha, found_base = _take(src)
             break
     elif t == "ClosedEvent":
         closer = n.get("closer") or {}
         if closer.get("__typename") == "PullRequest" and closer.get("merged"):
-            found_pr = closer.get("number")
+            found_pr, found_merge_sha, found_base = _take(closer)
             break
 
 has_next   = "true"  if pi.get("hasNextPage") else "false"
@@ -901,6 +925,8 @@ end_cursor = pi.get("endCursor") or ""
 print(str(found_pr) if found_pr is not None else "")
 print(has_next)
 print(end_cursor)
+print(found_merge_sha)
+print(found_base)
 PY
       )" || true
       rm -f "$gql_pr_tmp"
@@ -908,12 +934,20 @@ PY
         break
       fi
       referencing_pr="$(printf '%s\n' "$gql_pr_parse_out" | sed -n '1p')"
+      referencing_pr_merge_sha="$(printf '%s\n' "$gql_pr_parse_out" | sed -n '4p')"
+      referencing_pr_base="$(printf '%s\n' "$gql_pr_parse_out" | sed -n '5p')"
       gql_pr_has_next="$(printf '%s\n' "$gql_pr_parse_out" | sed -n '2p')"
       gql_pr_cursor="$(printf '%s\n' "$gql_pr_parse_out" | sed -n '3p')"
     done
 
-    if [ -n "$referencing_pr" ]; then
+    if [ -n "$referencing_pr" ] && pr_merge_is_in_release "$referencing_pr_merge_sha" "$version"; then
       omitted_shipped="${omitted_shipped}${issue_num}:pr_${referencing_pr}
+"
+    elif [ -n "$referencing_pr" ]; then
+      # Merged, closed, inside the window — but the merge commit is not an
+      # ancestor of the tag, so this code did not ship in this release.
+      # Report it; never auto-add it (#1512).
+      omitted_epics="${omitted_epics}${issue_num}:not_shipped_pr_${referencing_pr}_into_${referencing_pr_base:-unknown}
 "
     else
       omitted_epics="${omitted_epics}${issue_num}:no_merged_pr
@@ -957,6 +991,10 @@ PY
       detail="${entry#*:}"
       case "$detail" in
         no_merged_pr)       echo "    #${iss} (likely parent epic — no merged PR referencing this issue in release window)" ;;
+        not_shipped_pr_*)
+          _ns_rest="${detail#not_shipped_pr_}"
+          echo "    #${iss} [merged PR #${_ns_rest%%_into_*} into ${_ns_rest#*_into_} is not an ancestor of ${version}: merged, but not shipped in this release - report-only]"
+          ;;
         unknown_close_date) echo "    #${iss} (could not determine close date — manual review required)" ;;
         *)                  echo "    #${iss} (${detail})" ;;
       esac

--- a/scripts/development-workflow/tests/test-prepare-release-tracker-cleanup.sh
+++ b/scripts/development-workflow/tests/test-prepare-release-tracker-cleanup.sh
@@ -214,6 +214,20 @@ run_test() {
   fi
 }
 
+run_not_contains() {
+  local name="$1"
+  local unexpected="$2"
+  local actual="$3"
+  if grep -Fq -- "$unexpected" <<< "$actual"; then
+    echo "FAIL: $name - expected output NOT to contain '${unexpected}'"
+    printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  else
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  fi
+}
+
 run_contains() {
   local name="$1"
   local expected="$2"
@@ -995,7 +1009,7 @@ case "$*" in
     printf '{"data":{"node":{"items":{"nodes":[{"type":"ISSUE","content":{"__typename":"Issue","number":101},"status":{"name":"Merged"}},{"type":"ISSUE","content":{"__typename":"Issue","number":200},"status":{"name":"Merged"}},{"type":"ISSUE","content":{"__typename":"Issue","number":201},"status":{"name":"Merged"}},{"type":"ISSUE","content":{"__typename":"Issue","number":99},"status":{"name":"Released"}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}\n' ;;
   # detect_omitted_merged_items: issue timeline for #200 — merged PR #500 references it
   *"num=200"*"timelineItems"*|*"num = 200"*"timelineItems"*)
-    printf '{"data":{"repository":{"issue":{"timelineItems":{"nodes":[{"__typename":"CrossReferencedEvent","source":{"__typename":"PullRequest","number":500,"merged":true}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}\n' ;;
+    printf '{"data":{"repository":{"issue":{"timelineItems":{"nodes":[{"__typename":"CrossReferencedEvent","source":{"__typename":"PullRequest","number":500,"merged":true,"baseRefName":"develop","mergeCommit":{"oid":"aaaa111shipped"}}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}\n' ;;
   # detect_omitted_merged_items: issue timeline for #201 — no merged PR
   *"num=201"*"timelineItems"*|*"num = 201"*"timelineItems"*)
     printf '{"data":{"repository":{"issue":{"timelineItems":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}\n' ;;
@@ -1038,6 +1052,9 @@ case "$*" in
   "ls-remote --exit-code --heads origin release/v1.17.0") exit 2 ;;
   "show-ref --quiet refs/heads/release/v1.17.0") exit 1 ;;
   "remote get-url origin") printf 'https://github.com/test-owner/test-repo.git\n' ;;
+  # #1512: a merge commit that is NOT an ancestor of the release tag — the
+  # shape of a PR merged into an in-flight develop-<slug> integration branch.
+  "merge-base --is-ancestor bbbb222unshipped"*) exit 1 ;;
   *) exit 0 ;;
 esac
 MOCK_GIT_DETECT
@@ -1062,6 +1079,26 @@ run_contains "detect_shipped_item_auto_added" "RELEASE_STAMPED issue=200" "$outp
 
 # AC-4: Parent epic #201 triggers TRACKER_INCOMPLETE.
 run_contains "detect_parent_epic_incomplete" "TRACKER_INCOMPLETE=1 REASON=omitted_parent_epics" "$output"
+
+# #1512: an item whose merged PR is NOT an ancestor of the release tag is
+# reported but never auto-added. "Has a merged PR" is not "shipped": a PR
+# merged into an in-flight develop-<slug> integration branch is merged,
+# closed, and inside the release window, yet none of its code is in the tag.
+DETECT_UNSHIPPED_BIN="$(mktemp -d)"
+cp "$DETECT_BIN/gh" "$DETECT_UNSHIPPED_BIN/gh"
+cp "$DETECT_BIN/git" "$DETECT_UNSHIPPED_BIN/git"
+# Same fixture, but #200's merged PR carries the non-ancestor merge commit.
+sed -i.bak 's/aaaa111shipped/bbbb222unshipped/' "$DETECT_UNSHIPPED_BIN/gh"
+rm -f "$DETECT_UNSHIPPED_BIN/gh.bak"
+chmod +x "$DETECT_UNSHIPPED_BIN/gh" "$DETECT_UNSHIPPED_BIN/git"
+repo_unshipped="$(fixture_github_projects_repo detect-unshipped)"
+unshipped_result="$(run_cleanup_with_bin "$DETECT_UNSHIPPED_BIN" "$repo_unshipped" v1.17.0 --from-changelog --best-effort)"
+unshipped_output="$(printf '%s\n' "$unshipped_result" | sed '1d')"
+run_contains "unshipped_item_is_reported" "#200 [merged PR #500 into develop is not an ancestor of v1.17.0" "$unshipped_output"
+run_not_contains "unshipped_item_not_auto_added" "RELEASE_STAMPED issue=200" "$unshipped_output"
+run_not_contains "unshipped_item_not_in_shipped_section" "Regular shipped items" "$unshipped_output"
+run_contains "unshipped_item_marks_incomplete" "TRACKER_INCOMPLETE=1 REASON=omitted_parent_epics" "$unshipped_output"
+rm -rf "$DETECT_UNSHIPPED_BIN"
 run_contains "detect_parent_epic_issues_list" "ISSUES=201" "$output"
 
 echo ""

--- a/scripts/development-workflow/tests/test-prepare-release-tracker-cleanup.sh
+++ b/scripts/development-workflow/tests/test-prepare-release-tracker-cleanup.sh
@@ -215,12 +215,26 @@ run_test() {
 }
 
 run_not_contains() {
+  if [ "$#" -ne 3 ]; then
+    echo "FAIL: run_not_contains called with $# argument(s), expected 3"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    return 0
+  fi
   local name="$1"
   local unexpected="$2"
   local actual="$3"
-  if grep -Fq -- "$unexpected" <<< "$actual"; then
+  # grep exits 0 on a match, 1 on no match, and >1 on an actual error (bad
+  # pattern, unreadable input). Folding >1 into the else branch reports PASS
+  # for an assertion that never ran — the same false pass that let a broken
+  # guard test through in #1523. Only status 1 is a confirmed non-match.
+  local grep_status=0
+  grep -Fq -- "$unexpected" <<< "$actual" || grep_status=$?
+  if [ "$grep_status" -eq 0 ]; then
     echo "FAIL: $name - expected output NOT to contain '${unexpected}'"
     printf 'Actual output:\n%s\n' "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  elif [ "$grep_status" -gt 1 ]; then
+    echo "FAIL: $name - grep exited ${grep_status}; the assertion could not be evaluated"
     FAIL_COUNT=$((FAIL_COUNT + 1))
   else
     echo "PASS: $name"


### PR DESCRIPTION
Closes #1512.

## Problem

`detect_omitted_merged_items()` auto-added any board item that was `Merged`, closed inside the release window, and referenced by a merged PR. None of that is a test for *shipped*: a PR merged into an in-flight `develop-<slug>` integration branch is merged, closed, and in the window while none of its code is an ancestor of the tag. Downstream this recurred across at least five releases — worst case `STAMPED=16` for a changelog section naming two issues.

## Fix

- The issue-timeline GraphQL query now returns `mergeCommit{oid}` and `baseRefName`.
- New `pr_merge_is_in_release()` runs `git merge-base --is-ancestor <merge-commit> refs/tags/<version>`. An unknown SHA, an unfetched tag, or any git failure returns non-zero, so the caller degrades to **report-only** rather than auto-adding on a guess.
- Failing candidates are reported with the base branch they merged into (`merged PR #500 into develop-foo is not an ancestor of v1.17.0 … report-only`) and count toward `TRACKER_INCOMPLETE`, so an operator can pass `--issue`/`--issues` for anything that genuinely shipped.
- Protocol 05 §9.1 now says `--from-changelog` is not unconditionally safe while integration branches exist, and to read the report rather than assume the changelog scope was all that was stamped (AC-5).

## Verification

- `test-prepare-release-tracker-cleanup.sh`: **77/0** (was 73). The existing shipped-item fixture now carries a merge commit and still auto-adds — proving the gate narrows rather than disables. New negative case (`unshipped_item_*`, 4 assertions) uses a merge commit the git mock refuses ancestry for: reported, **not** stamped, not listed under "Regular shipped items", and marks `TRACKER_INCOMPLETE`.
- Before the fixture carried `mergeCommit`, the three pre-existing auto-add assertions failed — the old contract is genuinely changed, and the tests say so rather than being loosened.
- guard lint, snippet lint (committed diff), shellcheck `--severity=warning`, markdownlint, CHANGELOG heuristic + duplicate-header: clean.

## Note on AC scope

AC-1 through AC-5 are covered. The issue's suggested cheap pre-filter (skip candidates whose PR `baseRefName` is neither the release base nor the default branch) is deliberately **not** used as a gate — ancestry is strictly more accurate and also catches reverts and post-tag merges. The base branch is captured and surfaced in the report instead, where it explains *why* something did not ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release tracking now includes only merged changes confirmed to be present in the release.
  * Unshipped or unreadable changes are excluded from automatic release stamping and clearly reported as incomplete.
* **Documentation**
  * Updated release preparation guidance to explain handling of merged but unshipped changes.
* **Tests**
  * Added coverage for release ancestry checks, incomplete cleanup reporting, and milestone exclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->