### PR TITLE
fix(pr-review-loop): size CodeRabbit waits from its stated window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hour — so the parser tolerates the gap between them rather than matching one.
   Absent or reworded vendor text falls back to the previous constant, and the
   wait is clamped by `CODERABBIT_RATE_LIMIT_WAIT_MAX` (default 3600 s) so a
-  malformed window cannot park an unattended run.
+  malformed window cannot park an unattended run. The same leading-zero-safe
+  arithmetic that protects the vendor-parsed number now also applies to the
+  `CODERABBIT_RATE_LIMIT_WAIT_BUFFER`, `CODERABBIT_RATE_LIMIT_WAIT_MAX`, and
+  `CODERABBIT_TRIGGER_ANCHOR_SKEW` operator overrides — a zero-padded value
+  like `008` previously reached `$((...))` unstripped and aborted the whole
+  script under `set -e` ("008: value too great for base") instead of
+  degrading like every other malformed override.
 - **Codex reviewer unavailability is classified and recoverable** (#1522,
   #1526): the Codex GitHub App's "create a Codex account and connect to
   github" refusal — which it returns per triggering identity, so an org-wide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,8 +88,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wait is clamped by `CODERABBIT_RATE_LIMIT_WAIT_MAX` (default 3600 s) so a
   malformed window cannot park an unattended run. The same leading-zero-safe
   arithmetic that protects the vendor-parsed number now also applies to the
-  `CODERABBIT_RATE_LIMIT_WAIT_BUFFER`, `CODERABBIT_RATE_LIMIT_WAIT_MAX`, and
-  `CODERABBIT_TRIGGER_ANCHOR_SKEW` operator overrides — a zero-padded value
+  `CODERABBIT_RATE_LIMIT_WAIT_BUFFER`, `CODERABBIT_RATE_LIMIT_WAIT_MAX`,
+  `CODERABBIT_TRIGGER_ANCHOR_SKEW`, `CODERABBIT_RATE_LIMIT_STALE_AFTER`
+  (default 3600 s — how long a comment stating no window stays believable) and
+  `CODERABBIT_RATE_LIMIT_MIN_WAIT` (default 30 s — the floor applied once the
+  comment's age is subtracted from its stated window) operator overrides — a zero-padded value
   like `008` previously reached `$((...))` unstripped and aborted the whole
   script under `set -e` ("008: value too great for base") instead of
   degrading like every other malformed override.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **CodeRabbit rate-limit waits are read from the vendor, not guessed** (#1579):
+  the loop decided "CodeRabbit is rate limited" from the mere presence of a
+  rate-limit comment newer than the HEAD commit, so one stale reply suppressed
+  every later trigger on that HEAD — measured on PR #1575, a comment from 16:06
+  still read as live 21 hours later with no CodeRabbit activity in between. It
+  also sized every retry from a fixed constant: against the 1-review-per-hour
+  allowance measured on 2026-08-24, a 4 x 900 s budget spends all four retries
+  inside a window that grants at most one review, then escalates
+  `rate_limit_max_retries` at roughly the moment the review becomes available
+  (PR #1589: four retries, four "Reviews resumed" acknowledgements, zero
+  reviews). CodeRabbit states its own window — "Next included review available
+  in N minutes" — so the loop now parses that sentence to size the wait, treats
+  a comment past its announced window as spent rather than live, and re-triggers
+  with `@coderabbitai review` instead of `@coderabbitai resume`, which only
+  lifts a paused state and reviews nothing against a rate limit. A reply older
+  than this run's own most recent trigger no longer answers that trigger, with
+  a clock-skew tolerance because the anchor is stamped locally while the
+  comment timestamp comes from GitHub. CodeRabbit states the window in at least
+  two wordings — "Next included review available in 27 minutes" and "Your next
+  included review will be available in 7 minutes", both observed within one
+  hour — so the parser tolerates the gap between them rather than matching one.
+  Absent or reworded vendor text falls back to the previous constant, and the
+  wait is clamped by `CODERABBIT_RATE_LIMIT_WAIT_MAX` (default 3600 s) so a
+  malformed window cannot park an unattended run.
 - **Codex reviewer unavailability is classified and recoverable** (#1522,
   #1526): the Codex GitHub App's "create a Codex account and connect to
   github" refusal — which it returns per triggering identity, so an org-wide

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4656,10 +4656,28 @@ coderabbit_rate_limit_comment_is_current() {
 # previously each ran their own count query, which is how a spent rate-limit
 # comment could suppress the retrigger in one place while the other waited on
 # it (#1579).
+# Exit status is the caller's signal, and the three cases are NOT equivalent:
+#   0 with output  - a rate-limit comment was found (printed as compact JSON)
+#   0 with nothing - the lookup succeeded and there is no rate-limit comment
+#   2              - the lookup could not be performed
+#
+# The previous form piped straight into jq without `pipefail` and ended in
+# `|| printf ''`, so a failed `gh api` (network, auth, secondary rate limit)
+# was indistinguishable from "no rate-limit comment". Both call sites then
+# concluded CodeRabbit was not rate limited and posted a fresh
+# `@coderabbitai review`, spending a review from an allowance measured at 1
+# per hour — on evidence that was never actually read, and with nothing in the
+# log to say so.
 coderabbit_newest_rate_limit_comment() {
   local repo="$1" pr_number="$2" bot_login="$3" since_iso="$4"
-  gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-    | jq -cs --arg bot "$bot_login" --arg since "$since_iso" '
+  local raw="" status=0
+  raw="$(gh api "repos/$repo/issues/$pr_number/comments" --paginate 2>/dev/null)" || status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "WARN: coderabbit_newest_rate_limit_comment: could not read comments for PR #$pr_number (gh exited $status) — reporting a lookup failure, not an absence of rate limiting" >&2
+    return 2
+  fi
+  local selected="" jq_status=0
+  selected="$(printf '%s' "$raw" | jq -cs --arg bot "$bot_login" --arg since "$since_iso" '
         [.[].[] | select(
             .user.login == $bot and
             .created_at > $since and
@@ -4667,7 +4685,12 @@ coderabbit_newest_rate_limit_comment() {
         )]
         | sort_by(.created_at)
         | (last // empty)
-      ' 2>/dev/null || printf ''
+      ' 2>/dev/null)" || jq_status=$?
+  if [ "$jq_status" -ne 0 ]; then
+    echo "WARN: coderabbit_newest_rate_limit_comment: could not parse comments for PR #$pr_number (jq exited $jq_status) — reporting a lookup failure" >&2
+    return 2
+  fi
+  printf '%s' "$selected"
 }
 
 # ---------------------------------------------------------------------------
@@ -5048,9 +5071,16 @@ run_coderabbit_review() {
       if [ "${silent_paused_count:-0}" -gt 0 ]; then
         silent_blocked=1
       else
-        local silent_rate_limit_json
-        silent_rate_limit_json="$(coderabbit_newest_rate_limit_comment "$repo" "$pr_number" "$bot_login" "$since_iso")" || silent_rate_limit_json=""
-        if [ -n "$silent_rate_limit_json" ]; then
+        local silent_rate_limit_json="" silent_lookup_status=0
+        silent_rate_limit_json="$(coderabbit_newest_rate_limit_comment "$repo" "$pr_number" "$bot_login" "$since_iso")" || silent_lookup_status=$?
+        if [ "$silent_lookup_status" -ne 0 ]; then
+          # The lookup failed, so whether CodeRabbit is rate limited is unknown.
+          # Hold the retrigger rather than spend a review on a guess: the
+          # allowance was measured at 1 per hour, so a wasted trigger costs the
+          # PR an hour, while holding costs one poll interval.
+          echo "WARN: could not determine CodeRabbit rate-limit state for PR #$pr_number — holding the silent non-trigger retrigger rather than spending a review on an unread signal" >&2
+          silent_blocked=1
+        elif [ -n "$silent_rate_limit_json" ]; then
           if coderabbit_rate_limit_is_live "$silent_rate_limit_json" "$coderabbit_last_trigger_iso"; then
             silent_blocked=1
           else
@@ -5087,8 +5117,12 @@ run_coderabbit_review() {
       # included review available in N minutes") and its created_at says when
       # that window started — the two inputs needed to size the wait and to
       # tell a live limit from a spent one (#1579).
-      local rate_limit_comment_json rate_limit_comment_body="" rate_limit_comment_created=""
-      rate_limit_comment_json="$(coderabbit_newest_rate_limit_comment "$repo" "$pr_number" "$bot_login" "$since_iso")" || rate_limit_comment_json=""
+      local rate_limit_comment_json="" rate_limit_comment_body="" rate_limit_comment_created=""
+      local rate_limit_lookup_status=0
+      rate_limit_comment_json="$(coderabbit_newest_rate_limit_comment "$repo" "$pr_number" "$bot_login" "$since_iso")" || rate_limit_lookup_status=$?
+      if [ "$rate_limit_lookup_status" -ne 0 ]; then
+        rate_limit_comment_json=""
+      fi
 
       local rate_limit_comment_count=0
       if [ -n "$rate_limit_comment_json" ]; then

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4445,12 +4445,25 @@ coderabbit_rate_limit_wait_seconds() {
   case "$max_seconds" in
     '' | *[!0-9]*) max_seconds=3600 ;;
   esac
-  if [ "$max_seconds" -le 0 ]; then
-    max_seconds=3600
-  fi
   case "$fallback" in
     '' | *[!0-9]*) fallback="$CODERABBIT_RATE_LIMIT_WAIT_DEFAULT" ;;
   esac
+  # Strip leading zeros from every digit-only override before it can reach an
+  # arithmetic context: a digit-only string like "008" passes the checks above
+  # unchanged, but $((...)) below reads a leading-zero literal as octal, and
+  # "008" is not a valid octal literal (8 is not an octal digit) — an operator
+  # override of CODERABBIT_RATE_LIMIT_WAIT_BUFFER=008 aborts the whole script
+  # under `set -e` without this. Same idiom used below for the vendor-parsed
+  # value, applied here to the three operator-supplied numbers instead.
+  buffer="${buffer#"${buffer%%[!0]*}"}"
+  [ -z "$buffer" ] && buffer=0
+  max_seconds="${max_seconds#"${max_seconds%%[!0]*}"}"
+  [ -z "$max_seconds" ] && max_seconds=0
+  fallback="${fallback#"${fallback%%[!0]*}"}"
+  [ -z "$fallback" ] && fallback=0
+  if [ "$max_seconds" -le 0 ]; then
+    max_seconds=3600
+  fi
   if [ "$fallback" -le 0 ]; then
     fallback="$CODERABBIT_RATE_LIMIT_WAIT_DEFAULT"
   fi
@@ -4603,6 +4616,13 @@ coderabbit_rate_limit_comment_is_current() {
           case "$anchor_skew" in
             '' | *[!0-9]*) anchor_skew=60 ;;
           esac
+          # Strip leading zeros before the arithmetic below: a digit-only
+          # string like "008" passes the check above unchanged, but bash reads
+          # it as an invalid octal literal in `$((...))` and aborts the whole
+          # script under `set -e` (same class of bug guarded against for the
+          # vendor-parsed value in coderabbit_rate_limit_wait_seconds).
+          anchor_skew="${anchor_skew#"${anchor_skew%%[!0]*}"}"
+          [ -z "$anchor_skew" ] && anchor_skew=0
           if [ "$created_epoch" -lt "$((trigger_epoch - anchor_skew))" ]; then
             return 1
           fi

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4404,6 +4404,275 @@ coderabbit_resolve_no_trigger_timeout() {
   printf '%s\n' "$override"
 }
 
+# ---------------------------------------------------------------------------
+# coderabbit_rate_limit_wait_seconds
+#
+# CodeRabbit states how long the caller must wait inside its rate-limit
+# comment, e.g.
+#
+#     **Next included review available in 27 minutes.**
+#
+# Sizing the retry wait from that sentence rather than from a fixed constant is
+# what lets a retry land when the vendor can actually answer. See issue #1579:
+# measured on 2026-08-24 the org allowance was 1 review per hour, against which
+# a fixed 4 x 900 s budget spends every retry inside a window that grants at
+# most one review, then escalates at roughly the moment the review becomes
+# available (PR #1589: four retries, four "Reviews resumed" acknowledgements,
+# zero reviews, then RESULT=escalate REASON=rate_limit_max_retries).
+#
+# Args:
+#   $1 - body of the newest CodeRabbit rate-limit comment (may be empty)
+#   $2 - fallback wait in seconds, used when the sentence is absent or
+#        unparseable. Vendor wording changes, so absence is never fatal.
+#
+# Prints the wait in seconds on stdout, always a positive integer.
+#
+# CODERABBIT_RATE_LIMIT_WAIT_BUFFER (default 30) is added to the stated window
+# so the retry lands just after the vendor boundary rather than exactly on it.
+# CODERABBIT_RATE_LIMIT_WAIT_MAX (default 3600) clamps the result so that a
+# malformed or hostile "available in 100000 minutes" cannot park an unattended
+# run for a day. Both are validated here: a non-numeric or non-positive
+# override degrades to the documented default instead of yielding a zero wait
+# (a zero wait would busy-spin the retry against the vendor).
+coderabbit_rate_limit_wait_seconds() {
+  local body="${1:-}" fallback="${2:-}"
+  local buffer="${CODERABBIT_RATE_LIMIT_WAIT_BUFFER:-30}"
+  local max_seconds="${CODERABBIT_RATE_LIMIT_WAIT_MAX:-3600}"
+
+  case "$buffer" in
+    '' | *[!0-9]*) buffer=30 ;;
+  esac
+  case "$max_seconds" in
+    '' | *[!0-9]*) max_seconds=3600 ;;
+  esac
+  if [ "$max_seconds" -le 0 ]; then
+    max_seconds=3600
+  fi
+  case "$fallback" in
+    '' | *[!0-9]*) fallback="$CODERABBIT_RATE_LIMIT_WAIT_DEFAULT" ;;
+  esac
+  if [ "$fallback" -le 0 ]; then
+    fallback="$CODERABBIT_RATE_LIMIT_WAIT_DEFAULT"
+  fi
+
+  # Lowercase, then treat every run of non-alphanumeric bytes between the
+  # fixed words as a separator. That absorbs markdown emphasis, line wraps and
+  # the non-breaking spaces CodeRabbit sometimes emits, none of which the
+  # vendor guarantees to keep stable, without having to enumerate them.
+  local flat
+  flat="$(printf '%s' "$body" | tr '[:upper:]' '[:lower:]' | tr '\n' ' ')"
+
+  local parsed=""
+  # CodeRabbit uses at least two wordings for the same fact, both observed on
+  # 2026-08-24 within one hour:
+  #
+  #   "**Next included review available in 27 minutes.**"          (PR #1590)
+  #   "Your next included review will be available in 7 minutes."  (PR #1588)
+  #
+  # So the gap between "included" and "available" cannot be assumed to be just
+  # " review ". Allow a bounded run of non-digits there — bounded, not `*`, so
+  # the match cannot reach across unrelated prose to a number elsewhere in the
+  # comment. Requiring the word "included" keeps this off any other "available
+  # in N minutes" sentence the vendor might add.
+  if [[ "$flat" =~ included[^0-9]{0,40}available[^a-z0-9]*in[^a-z0-9]*([0-9]+)[^a-z0-9]*(second|minute|hour) ]]; then
+    local value="${BASH_REMATCH[1]}" unit="${BASH_REMATCH[2]}"
+    # Strip leading zeros before any arithmetic: bash reads "08" as an invalid
+    # octal literal and aborts the whole script under `set -e`.
+    value="${value#"${value%%[!0]*}"}"
+    if [ -z "$value" ]; then
+      value=0
+    fi
+    # More than six digits is not a real vendor window. Refuse to multiply it
+    # rather than letting the product wrap a signed 64-bit integer negative.
+    if [ "${#value}" -le 6 ]; then
+      local multiplier=1
+      case "$unit" in
+        second) multiplier=1 ;;
+        minute) multiplier=60 ;;
+        hour) multiplier=3600 ;;
+      esac
+      parsed=$((value * multiplier + buffer))
+    fi
+  fi
+
+  if [ -n "$parsed" ]; then
+    if [ "$parsed" -gt "$max_seconds" ]; then
+      parsed="$max_seconds"
+    fi
+    if [ "$parsed" -le 0 ]; then
+      parsed=30
+    fi
+    printf '%s\n' "$parsed"
+    return 0
+  fi
+
+  printf '%s\n' "$fallback"
+}
+
+# ---------------------------------------------------------------------------
+# _iso8601_to_epoch
+#
+# Convert an ISO-8601 UTC timestamp ("2026-08-24T03:12:02Z", the form every
+# GitHub REST timestamp uses) to seconds since the epoch. BSD date (macOS,
+# where this is developed) needs `-j -f`; GNU date (Linux, where CI runs)
+# needs `-d` and rejects `-j`. Try BSD first, fall back to GNU, and return
+# non-zero rather than printing garbage if neither parses the input.
+_iso8601_to_epoch() {
+  local iso="${1:-}"
+  [ -n "$iso" ] || return 1
+  date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null && return 0
+  date -u -d "$iso" +%s 2>/dev/null && return 0
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# coderabbit_rate_limit_comment_is_current
+#
+# Decide whether a CodeRabbit rate-limit comment still describes a live limit.
+#
+# This is the core of issue #1579. Detection previously asked only "does a
+# rate-limit comment exist after the HEAD commit time", so a single stale reply
+# suppressed every later trigger on that HEAD forever. Measured on PR #1575: a
+# rate-limit comment at 16:06 was still being treated as live 21 hours later,
+# with no CodeRabbit activity of any kind in between, and the loop waited out
+# its whole retry budget without ever posting a fresh review request.
+#
+# A rate-limit comment announces its own expiry ("Next included review
+# available in N minutes"), so the honest test is whether that window has
+# passed — not how the comment's timestamp compares to the HEAD commit.
+#
+# Args:
+#   $1 - comment body
+#   $2 - comment created_at (ISO-8601 UTC)
+#
+# Returns 0 when the announced window has not yet elapsed (the limit is live
+# and the caller should wait), 1 when it has (the comment is spent and must not
+# suppress a fresh trigger).
+#
+# When the body states no window, CODERABBIT_RATE_LIMIT_STALE_AFTER (default
+# 3600s, one vendor quota hour) bounds how long the comment stays believable.
+# When the timestamp cannot be parsed at all the comment is reported as
+# current: that preserves the previous behaviour exactly, so a date-parsing
+# failure degrades to today's conservative wait rather than to spending a
+# review attempt the caller may not have.
+coderabbit_rate_limit_comment_is_current() {
+  local body="${1:-}" created_at="${2:-}" last_trigger_iso="${3:-}"
+  local stale_after="${CODERABBIT_RATE_LIMIT_STALE_AFTER:-3600}"
+
+  case "$stale_after" in
+    '' | *[!0-9]*) stale_after=3600 ;;
+  esac
+  if [ "$stale_after" -le 0 ]; then
+    stale_after=3600
+  fi
+
+  local created_epoch now_epoch
+  created_epoch="$(_iso8601_to_epoch "$created_at")" || return 0
+  now_epoch="$(date -u +%s 2>/dev/null)" || return 0
+  case "$created_epoch" in
+    '' | *[!0-9]*) return 0 ;;
+  esac
+  case "$now_epoch" in
+    '' | *[!0-9]*) return 0 ;;
+  esac
+
+  # A comment stamped in the future (clock skew) is not stale.
+  if [ "$created_epoch" -ge "$now_epoch" ]; then
+    return 0
+  fi
+
+  # A reply older than this run's most recent trigger describes a limit the
+  # loop has already waited on. It must not stand in for an answer to the
+  # trigger just posted, or the loop reports "rate limited" without ever
+  # letting CodeRabbit respond (issue #1579, AC-1). Only applied when the
+  # caller has actually posted a trigger this run: on a fresh run the anchor
+  # is empty and the announced-window rule below decides alone, which is what
+  # keeps a genuinely live limit from being ignored at startup.
+  if [ -n "$last_trigger_iso" ]; then
+    local trigger_epoch
+    if trigger_epoch="$(_iso8601_to_epoch "$last_trigger_iso")"; then
+      case "$trigger_epoch" in
+        '' | *[!0-9]*) : ;;
+        *)
+          # Tolerance, because the two sides come from different clocks: the
+          # anchor is stamped locally with `date`, the comment timestamp comes
+          # from GitHub. Without slack, a few seconds of skew would discard
+          # CodeRabbit's genuine answer to the trigger just posted, and the
+          # loop would re-trigger and spend quota it may not have.
+          local anchor_skew="${CODERABBIT_TRIGGER_ANCHOR_SKEW:-60}"
+          case "$anchor_skew" in
+            '' | *[!0-9]*) anchor_skew=60 ;;
+          esac
+          if [ "$created_epoch" -lt "$((trigger_epoch - anchor_skew))" ]; then
+            return 1
+          fi
+          ;;
+      esac
+    fi
+  fi
+
+  # Reuse the same parser the wait uses, so the window that governs staleness
+  # and the window the loop actually sleeps for can never drift apart.
+  local window
+  window="$(coderabbit_rate_limit_wait_seconds "$body" "$stale_after")"
+  case "$window" in
+    '' | *[!0-9]*) window="$stale_after" ;;
+  esac
+
+  if [ "$((now_epoch - created_epoch))" -lt "$window" ]; then
+    return 0
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# coderabbit_newest_rate_limit_comment
+#
+# Print the newest CodeRabbit rate-limit comment for this HEAD window as a
+# compact JSON object, or print nothing when there is none.
+#
+# Shared by the rate-limit retry block and the silent-non-trigger guard so both
+# decide "is CodeRabbit rate limited right now" from the same evidence. They
+# previously each ran their own count query, which is how a spent rate-limit
+# comment could suppress the retrigger in one place while the other waited on
+# it (#1579).
+coderabbit_newest_rate_limit_comment() {
+  local repo="$1" pr_number="$2" bot_login="$3" since_iso="$4"
+  gh api "repos/$repo/issues/$pr_number/comments" --paginate \
+    | jq -cs --arg bot "$bot_login" --arg since "$since_iso" '
+        [.[].[] | select(
+            .user.login == $bot and
+            .created_at > $since and
+            ((.body // "") | test("rate.?limit"; "i"))
+        )]
+        | sort_by(.created_at)
+        | (last // empty)
+      ' 2>/dev/null || printf ''
+}
+
+# ---------------------------------------------------------------------------
+# coderabbit_rate_limit_is_live
+#
+# Given the JSON object from coderabbit_newest_rate_limit_comment, return 0
+# when CodeRabbit is rate limited right now and 1 when it is not (no comment,
+# or a comment whose announced window has already elapsed).
+coderabbit_rate_limit_is_live() {
+  local comment_json="${1:-}" last_trigger_iso="${2:-}"
+  [ -n "$comment_json" ] || return 1
+  # Reject anything that is not a JSON object before reading fields. Without
+  # this, a malformed blob yields two empty strings, and an empty timestamp is
+  # deliberately treated as "still current" by
+  # coderabbit_rate_limit_comment_is_current — so garbage would read as a live
+  # rate limit and stall the loop for the full retry budget. An unparseable
+  # blob is no evidence of a limit at all, which is a different question from
+  # a real comment whose timestamp could not be read.
+  printf '%s' "$comment_json" | jq -e 'type == "object"' >/dev/null 2>&1 || return 1
+  local body created
+  body="$(printf '%s' "$comment_json" | jq -r '.body // ""' 2>/dev/null)" || body=""
+  created="$(printf '%s' "$comment_json" | jq -r '.created_at // ""' 2>/dev/null)" || created=""
+  coderabbit_rate_limit_comment_is_current "$body" "$created" "$last_trigger_iso"
+}
+
 run_coderabbit_review() {
   local pr_number="$1"
   local branch_name="$2"
@@ -4599,6 +4868,10 @@ run_coderabbit_review() {
   # Initialize retrigger flag from Phase 0 so Phase 2 does not double-post a resume.
   local coderabbit_retrigger_attempted=$coderabbit_phase0_retrigger
   local coderabbit_rate_limit_retries=0
+  # When this run last asked CodeRabbit for a review. Anchors rate-limit
+  # staleness so a reply the loop has already waited on cannot answer a newer
+  # trigger (#1579, AC-1). Empty until this run posts its first trigger.
+  local coderabbit_last_trigger_iso=""
   # Defaults are sized against CodeRabbit's *hourly* quota reset: 4 retries x 900 s
   # covers 60 minutes of waiting, so a loop that hits the cap early in an hour can
   # still succeed once the vendor window rolls over. The previous 2 x 180 s (~6 min)
@@ -4732,26 +5005,44 @@ run_coderabbit_review() {
         && [ "$coderabbit_retrigger_attempted" -eq 0 ] \
         && [ "$coderabbit_no_trigger_retriggers" -lt "$coderabbit_rate_limit_max_retries" ] \
         && [ "$elapsed" -ge "$coderabbit_no_trigger_timeout" ]; then
-      # Confirm neither the "paused" nor the "rate limit" comment is present —
+      # Confirm neither a "paused" comment nor a *live* rate limit is present —
       # those are handled by their own dedicated blocks above/below.
-      local silent_no_paused_count
-      silent_no_paused_count="$(
+      #
+      # The rate-limit half is deliberately not a presence check. A rate-limit
+      # comment whose announced window has already elapsed is spent, and must
+      # not suppress this retrigger: a spent comment doing exactly that is what
+      # left PR #1575 with no CodeRabbit activity for 21 hours while the loop
+      # declined to post a trigger (#1579).
+      local silent_paused_count
+      silent_paused_count="$(
         gh api "repos/$repo/issues/$pr_number/comments" --paginate \
           | jq -s --arg bot "$bot_login" --arg since "$since_iso" '
               [.[].[] | select(
                   .user.login == $bot and
                   .created_at > $since and
-                  (
-                    ((.body // "") | test("Reviews paused|review paused"; "i")) or
-                    ((.body // "") | test("rate.?limit"; "i"))
-                  )
+                  ((.body // "") | test("Reviews paused|review paused"; "i"))
               )] | length
             '
       )"
-      if [ "${silent_no_paused_count:-0}" -eq 0 ]; then
+      local silent_blocked=0
+      if [ "${silent_paused_count:-0}" -gt 0 ]; then
+        silent_blocked=1
+      else
+        local silent_rate_limit_json
+        silent_rate_limit_json="$(coderabbit_newest_rate_limit_comment "$repo" "$pr_number" "$bot_login" "$since_iso")" || silent_rate_limit_json=""
+        if [ -n "$silent_rate_limit_json" ]; then
+          if coderabbit_rate_limit_is_live "$silent_rate_limit_json" "$coderabbit_last_trigger_iso"; then
+            silent_blocked=1
+          else
+            echo "INFO: a spent CodeRabbit rate-limit comment is present but its window has elapsed — not letting it suppress the silent non-trigger retrigger (#1579)" >&2
+          fi
+        fi
+      fi
+      if [ "$silent_blocked" -eq 0 ]; then
         coderabbit_no_trigger_retriggers=$((coderabbit_no_trigger_retriggers + 1))
         echo "INFO: CodeRabbit has not auto-triggered after ${elapsed}s (silent non-trigger, attempt ${coderabbit_no_trigger_retriggers}/${coderabbit_rate_limit_max_retries}) — posting @coderabbitai review" >&2
         if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
+          coderabbit_last_trigger_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           echo "INFO: @coderabbitai review trigger posted" >&2
         else
           echo "WARN: failed to post @coderabbitai review trigger for silent non-trigger" >&2
@@ -4771,17 +5062,26 @@ run_coderabbit_review() {
     # When retries are exhausted, the timeout block below escalates instead of returning
     # a false-clean no_review result (see the incomplete-review guard before no_review exit).
     if [ "$coderabbit_any_activity" -eq 0 ] && [ "$coderabbit_rate_limit_retries" -lt "$coderabbit_rate_limit_max_retries" ]; then
-      local rate_limit_comment_count
-      rate_limit_comment_count="$(
-        gh api "repos/$repo/issues/$pr_number/comments" --paginate \
-          | jq -s --arg bot "$bot_login" --arg since "$since_iso" '
-              [.[].[] | select(
-                  .user.login == $bot and
-                  .created_at > $since and
-                  ((.body // "") | test("rate.?limit"; "i"))
-              )] | length
-            '
-      )"
+      # Select the NEWEST matching rate-limit comment as a whole object, not a
+      # count. Its body carries the vendor's own remaining window ("Next
+      # included review available in N minutes") and its created_at says when
+      # that window started — the two inputs needed to size the wait and to
+      # tell a live limit from a spent one (#1579).
+      local rate_limit_comment_json rate_limit_comment_body="" rate_limit_comment_created=""
+      rate_limit_comment_json="$(coderabbit_newest_rate_limit_comment "$repo" "$pr_number" "$bot_login" "$since_iso")" || rate_limit_comment_json=""
+
+      local rate_limit_comment_count=0
+      if [ -n "$rate_limit_comment_json" ]; then
+        # `-r` on the body is deliberate: it is consumed as text by the regex
+        # parser, and a JSON-quoted string would not match.
+        rate_limit_comment_body="$(printf '%s' "$rate_limit_comment_json" | jq -r '.body // ""' 2>/dev/null)" || rate_limit_comment_body=""
+        rate_limit_comment_created="$(printf '%s' "$rate_limit_comment_json" | jq -r '.created_at // ""' 2>/dev/null)" || rate_limit_comment_created=""
+        if coderabbit_rate_limit_is_live "$rate_limit_comment_json" "$coderabbit_last_trigger_iso"; then
+          rate_limit_comment_count=1
+        else
+          echo "INFO: newest CodeRabbit rate-limit comment (${rate_limit_comment_created:-unknown time}) is past the window it announced — treating it as spent rather than waiting on it again (#1579)" >&2
+        fi
+      fi
       if [ "${rate_limit_comment_count:-0}" -gt 0 ]; then
         coderabbit_rate_limit_retries=$((coderabbit_rate_limit_retries + 1))
         echo "INFO: CodeRabbit rate limit detected (retry $coderabbit_rate_limit_retries/$coderabbit_rate_limit_max_retries) — checking for SUCCESS commit status before waiting" >&2
@@ -4827,15 +5127,32 @@ run_coderabbit_review() {
             return "$cr_early_gate_rc"
           fi
         fi
-        echo "INFO: no SUCCESS commit status found — waiting ${coderabbit_rate_limit_wait}s before re-triggering" >&2
-        _interruptible_sleep "$coderabbit_rate_limit_wait"
+        # Size this wait from the vendor's own stated window when it gives one,
+        # falling back to the configured constant otherwise. A fixed constant
+        # cannot track an allowance the vendor changes (measured at 1 review
+        # per hour on 2026-08-24), so it either retries far too early — burning
+        # the retry budget without a review — or far too late.
+        local coderabbit_this_wait
+        coderabbit_this_wait="$(coderabbit_rate_limit_wait_seconds "$rate_limit_comment_body" "$coderabbit_rate_limit_wait")"
+        if [ "$coderabbit_this_wait" != "$coderabbit_rate_limit_wait" ]; then
+          echo "INFO: no SUCCESS commit status found — CodeRabbit states its next review window; waiting ${coderabbit_this_wait}s (configured fallback ${coderabbit_rate_limit_wait}s) before re-triggering" >&2
+        else
+          echo "INFO: no SUCCESS commit status found — waiting ${coderabbit_this_wait}s before re-triggering" >&2
+        fi
+        _interruptible_sleep "$coderabbit_this_wait"
         # Do NOT reset since_iso — keep the original HEAD-commit timestamp so any review
         # posted by CodeRabbit during or after the wait is still within the detection window.
         elapsed=0
-        if gh pr comment "$pr_number" --body "@coderabbitai resume" >/dev/null 2>&1; then
-          echo "INFO: posted @coderabbitai resume after rate-limit wait" >&2
+        # Re-trigger with "review", not "resume". "resume" only lifts a paused
+        # state; against a rate limit CodeRabbit answers "Reviews resumed" and
+        # reviews nothing, so the loop spends its whole budget on
+        # acknowledgements (PR #1589: four resumes, zero reviews). A pause and a
+        # rate limit need different verbs, and this branch is the rate-limit one.
+        if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
+          coderabbit_last_trigger_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          echo "INFO: posted @coderabbitai review after rate-limit wait" >&2
         else
-          echo "WARN: failed to post @coderabbitai resume after rate-limit wait" >&2
+          echo "WARN: failed to post @coderabbitai review after rate-limit wait" >&2
         fi
         _interruptible_sleep "$poll_interval"
         elapsed=$((elapsed + poll_interval))

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4646,6 +4646,61 @@ coderabbit_rate_limit_comment_is_current() {
 }
 
 # ---------------------------------------------------------------------------
+# coderabbit_rate_limit_remaining_seconds
+#
+# How long is left of the window a rate-limit comment announced, given when
+# that comment was posted.
+#
+# coderabbit_rate_limit_wait_seconds returns the FULL announced window, which
+# is only the right thing to sleep at the instant the comment appears. A loop
+# that starts (or re-enters this branch) part-way through the window would
+# otherwise sleep the whole thing again: a 27-minute window on a comment
+# already 26 minutes old would wait a further 27m30s instead of ~90s, pushing
+# the retry a full extra quota cycle past the moment a review became
+# available. Against a one-review-per-hour allowance that is the difference
+# between finishing a PR this hour and finishing it next hour.
+#
+# Args: $1 body, $2 created_at (ISO-8601 UTC), $3 fallback seconds
+# Prints a positive integer. Falls back to the full window whenever the age
+# cannot be computed, which is the pre-existing behaviour.
+coderabbit_rate_limit_remaining_seconds() {
+  local body="${1:-}" created_at="${2:-}" fallback="${3:-}"
+  local full
+  full="$(coderabbit_rate_limit_wait_seconds "$body" "$fallback")"
+
+  # A floor, so a window that has just expired still leaves a beat for the
+  # vendor to settle rather than re-triggering instantly in a tight loop.
+  local floor="${CODERABBIT_RATE_LIMIT_MIN_WAIT:-30}"
+  case "$floor" in
+    '' | *[!0-9]*) floor=30 ;;
+  esac
+  floor="${floor#"${floor%%[!0]*}"}"
+  [ -z "$floor" ] && floor=0
+
+  local created_epoch now_epoch
+  created_epoch="$(_iso8601_to_epoch "$created_at")" || { printf '%s\n' "$full"; return 0; }
+  now_epoch="$(date -u +%s 2>/dev/null)" || { printf '%s\n' "$full"; return 0; }
+  case "$created_epoch" in '' | *[!0-9]*) printf '%s\n' "$full"; return 0 ;; esac
+  case "$now_epoch" in '' | *[!0-9]*) printf '%s\n' "$full"; return 0 ;; esac
+  # Clock skew: a comment stamped in the future has no elapsed age.
+  if [ "$created_epoch" -ge "$now_epoch" ]; then
+    printf '%s\n' "$full"
+    return 0
+  fi
+
+  local age remaining
+  age=$((now_epoch - created_epoch))
+  remaining=$((full - age))
+  if [ "$remaining" -lt "$floor" ]; then
+    remaining="$floor"
+  fi
+  if [ "$remaining" -le 0 ]; then
+    remaining=30
+  fi
+  printf '%s\n' "$remaining"
+}
+
+# ---------------------------------------------------------------------------
 # coderabbit_newest_rate_limit_comment
 #
 # Print the newest CodeRabbit rate-limit comment for this HEAD window as a
@@ -4694,10 +4749,21 @@ coderabbit_newest_rate_limit_comment() {
   selected="$(printf '%s' "$raw" | jq -cs --arg bot "$bot_login" --arg since "$since_iso" '
         [.[].[] | select(
             .user.login == $bot and
-            .created_at > $since and
-            ((.body // "") | test("rate.?limit"; "i"))
+            # CodeRabbit revises its walkthrough comment IN PLACE rather than
+            # posting a new one, so a rate-limit banner can arrive on a comment
+            # created before this HEAD (#1556 documents the same behaviour for
+            # the activity probe). Select on the later of the two timestamps.
+            (.created_at > $since or (.updated_at // .created_at) > $since) and
+            # Three banner shapes have been observed and no single marker
+            # covers them all: the standalone comment matches only the HTML
+            # marker "rate limited by coderabbit.ai" while its visible text
+            # reads "Review limit reached", and the command refusal carries no
+            # marker at all and matches only the visible "Review rate limited."
+            # Matching one of them means a live limit reads as absent, which
+            # spends a review from a one-per-hour allowance.
+            ((.body // "") | test("rate.?limit|review limit reached|next included review"; "i"))
         )]
-        | sort_by(.created_at)
+        | sort_by((.updated_at // .created_at))
         | (last // empty)
       ' 2>/dev/null)" || jq_status=$?
   if [ "$jq_status" -ne 0 ]; then
@@ -5201,7 +5267,7 @@ run_coderabbit_review() {
         # per hour on 2026-08-24), so it either retries far too early — burning
         # the retry budget without a review — or far too late.
         local coderabbit_this_wait
-        coderabbit_this_wait="$(coderabbit_rate_limit_wait_seconds "$rate_limit_comment_body" "$coderabbit_rate_limit_wait")"
+        coderabbit_this_wait="$(coderabbit_rate_limit_remaining_seconds "$rate_limit_comment_body" "$rate_limit_comment_created" "$coderabbit_rate_limit_wait")"
         if [ "$coderabbit_this_wait" != "$coderabbit_rate_limit_wait" ]; then
           echo "INFO: no SUCCESS commit status found — CodeRabbit states its next review window; waiting ${coderabbit_this_wait}s (configured fallback ${coderabbit_rate_limit_wait}s) before re-triggering" >&2
         else

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -5218,6 +5218,12 @@ run_coderabbit_review() {
       local rate_limit_lookup_status=0
       rate_limit_comment_json="$(coderabbit_newest_rate_limit_comment "$repo" "$pr_number" "$bot_login" "$since_iso")" || rate_limit_lookup_status=$?
       if [ "$rate_limit_lookup_status" -ne 0 ]; then
+        # Say so. Clearing the value silently is how a lookup that never
+        # happened becomes "there is no rate limit" — the exact conflation the
+        # status-2 contract was introduced to remove. The retry branch below
+        # is skipped either way, but a silent skip leaves nothing in the log to
+        # explain why the loop went on to spend a review.
+        echo "WARN: could not read the rate-limit comment for PR #$pr_number (lookup exit $rate_limit_lookup_status) — proceeding without rate-limit evidence for this pass, NOT concluding that no limit exists" >&2
         rate_limit_comment_json=""
       fi
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4575,6 +4575,14 @@ coderabbit_rate_limit_comment_is_current() {
   case "$stale_after" in
     '' | *[!0-9]*) stale_after=3600 ;;
   esac
+  # Strip leading zeros before any arithmetic context: a digit-only string like
+  # "008" passes the check above, but bash reads it as an invalid octal literal
+  # and aborts the script under `set -e`. Same guard as the other overrides —
+  # this was the one that still lacked it.
+  stale_after="${stale_after#"${stale_after%%[!0]*}"}"
+  if [ -z "$stale_after" ]; then
+    stale_after=3600
+  fi
   if [ "$stale_after" -le 0 ]; then
     stale_after=3600
   fi
@@ -4765,6 +4773,13 @@ coderabbit_newest_rate_limit_comment() {
         )]
         | sort_by((.updated_at // .created_at))
         | (last // empty)
+        # The filter accepts on, and sorts by, the LATER of created_at and
+        # updated_at, because CodeRabbit revises a comment in place. Emitting
+        # that value as `effective_at` keeps consumers from re-deriving it and
+        # disagreeing: reading `.created_at` for a comment selected on its
+        # updated_at would age it from the wrong instant, and the age is what
+        # the staleness and remaining-window arithmetic depend on.
+        | . + { effective_at: (.updated_at // .created_at) }
       ' 2>/dev/null)" || jq_status=$?
   if [ "$jq_status" -ne 0 ]; then
     echo "WARN: coderabbit_newest_rate_limit_comment: could not parse comments for PR #$pr_number (jq exited $jq_status) — reporting a lookup failure" >&2
@@ -4792,7 +4807,9 @@ coderabbit_rate_limit_is_live() {
   printf '%s' "$comment_json" | jq -e 'type == "object"' >/dev/null 2>&1 || return 1
   local body created
   body="$(printf '%s' "$comment_json" | jq -r '.body // ""' 2>/dev/null)" || body=""
-  created="$(printf '%s' "$comment_json" | jq -r '.created_at // ""' 2>/dev/null)" || created=""
+  # effective_at is what the selector matched and sorted on; fall back to
+  # created_at only for an object that did not come from that selector.
+  created="$(printf '%s' "$comment_json" | jq -r '.effective_at // .created_at // ""' 2>/dev/null)" || created=""
   coderabbit_rate_limit_comment_is_current "$body" "$created" "$last_trigger_iso"
 }
 
@@ -5209,7 +5226,7 @@ run_coderabbit_review() {
         # `-r` on the body is deliberate: it is consumed as text by the regex
         # parser, and a JSON-quoted string would not match.
         rate_limit_comment_body="$(printf '%s' "$rate_limit_comment_json" | jq -r '.body // ""' 2>/dev/null)" || rate_limit_comment_body=""
-        rate_limit_comment_created="$(printf '%s' "$rate_limit_comment_json" | jq -r '.created_at // ""' 2>/dev/null)" || rate_limit_comment_created=""
+        rate_limit_comment_created="$(printf '%s' "$rate_limit_comment_json" | jq -r '.effective_at // .created_at // ""' 2>/dev/null)" || rate_limit_comment_created=""
         if coderabbit_rate_limit_is_live "$rate_limit_comment_json" "$coderabbit_last_trigger_iso"; then
           rate_limit_comment_count=1
         else

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4669,6 +4669,20 @@ coderabbit_rate_limit_comment_is_current() {
 # per hour — on evidence that was never actually read, and with nothing in the
 # log to say so.
 coderabbit_newest_rate_limit_comment() {
+  # Validate before reading positional parameters. A missing argument would
+  # otherwise build a malformed endpoint or an empty `--arg`, and `gh` would
+  # fail in a way that now reports "lookup failure" — technically correct but
+  # indistinguishable from a real API outage, which is the very confusion this
+  # function was just changed to remove. Fail with the same status 2 contract,
+  # but say plainly that the caller, not the API, is at fault.
+  if [ "$#" -ne 4 ]; then
+    echo "ERROR: coderabbit_newest_rate_limit_comment requires 4 arguments (repo pr_number bot_login since_iso), got $#" >&2
+    return 2
+  fi
+  if [ -z "${1:-}" ] || [ -z "${2:-}" ] || [ -z "${3:-}" ] || [ -z "${4:-}" ]; then
+    echo "ERROR: coderabbit_newest_rate_limit_comment requires non-empty repo, pr_number, bot_login and since_iso (got repo='${1:-}' pr_number='${2:-}' bot_login='${3:-}' since_iso='${4:-}')" >&2
+    return 2
+  fi
   local repo="$1" pr_number="$2" bot_login="$3" since_iso="$4"
   local raw="" status=0
   raw="$(gh api "repos/$repo/issues/$pr_number/comments" --paginate 2>/dev/null)" || status=$?

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14693,6 +14693,155 @@ unset _1574_gate _1574_gate_bad _1574_clean _1574_skipped _1574_bad_status _1574
 unset _1574_loop _1574_p91 _1574_p92 _1574_cw _1574_cq _1574_help _reason _field
 
 # ---------------------------------------------------------------------------
+# Area 14: CodeRabbit rate-limit window is read from the vendor, not guessed
+# (issue #1579)
+#
+# Two defects, one root cause: the loop decided "CodeRabbit is rate limited"
+# from the mere presence of a rate-limit comment after the HEAD commit, and
+# sized its wait from a fixed constant. Measured 2026-08-24, the org allowance
+# was 1 review/hour while the loop retried 4 x 900 s, so it spent its whole
+# budget inside a window that could grant at most one review; and on PR #1575 a
+# 21-hour-old rate-limit comment still read as live, suppressing every trigger.
+#
+# CodeRabbit states its own window ("Next included review available in N
+# minutes"). These tests pin both the parse and the staleness decision it
+# enables.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Area 14: CodeRabbit rate-limit window parsing (issue #1579) ==="
+
+_1579_ago() {
+  local mins="$1"
+  date -u -v-"${mins}"M +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+    || date -u -d "${mins} minutes ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null
+}
+_1579_state() {
+  if coderabbit_rate_limit_comment_is_current "$1" "$2"; then
+    printf 'current\n'
+  else
+    printf 'stale\n'
+  fi
+}
+# The exact sentence CodeRabbit posted on PR #1590 at 2026-08-24T03:12:02Z.
+_1579_window='**Next included review available in 27 minutes.**'
+_1579_nowindow='> [!WARNING]
+> ## Review limit reached'
+
+# --- wait sizing -----------------------------------------------------------
+# 27 minutes + the 30 s boundary buffer. The fixed default (900) is what this
+# replaces: it would have retried 12 minutes before the vendor could answer.
+run_test "1579_wait_parses_stated_minutes" "1650" "$(coderabbit_rate_limit_wait_seconds "$_1579_window" 900)"
+run_test "1579_wait_singular_minute" "90" "$(coderabbit_rate_limit_wait_seconds 'Next included review available in 1 minute.' 900)"
+# CodeRabbit's second wording, observed on PR #1588 at 2026-08-24T03:42:56Z
+# within the same hour as the first. The extra "will be" is exactly what a
+# regex anchored on "review available" cannot span — it silently fell back to
+# the 900 s constant instead of the 7 minutes the vendor stated.
+run_test "1579_wait_parses_will_be_wording" "450" "$(coderabbit_rate_limit_wait_seconds 'Your next included review will be available in 7 minutes.' 900)"
+# The word "included" is what keeps this off unrelated "available in N" prose.
+run_test "1579_wait_ignores_unrelated_available_in" "900" "$(coderabbit_rate_limit_wait_seconds 'The maintainer is available in 5 minutes.' 900)"
+run_test "1579_wait_seconds_unit" "75" "$(coderabbit_rate_limit_wait_seconds 'next included review available in 45 seconds' 900)"
+# Clamped: an unattended run must never park for hours on a vendor string.
+run_test "1579_wait_hours_clamped_to_max" "3600" "$(coderabbit_rate_limit_wait_seconds 'Next included review available in 2 hours' 900)"
+run_test "1579_wait_absent_phrase_uses_fallback" "900" "$(coderabbit_rate_limit_wait_seconds "$_1579_nowindow" 900)"
+run_test "1579_wait_empty_body_uses_fallback" "900" "$(coderabbit_rate_limit_wait_seconds '' 900)"
+# Wording drift must degrade to the fallback, never to zero or to an error.
+run_test "1579_wait_non_numeric_uses_fallback" "900" "$(coderabbit_rate_limit_wait_seconds 'Next included review available in twelve minutes' 900)"
+# "05" must not be read as an octal literal (that aborts the script under set -e).
+run_test "1579_wait_leading_zero_not_octal" "330" "$(coderabbit_rate_limit_wait_seconds 'Next included review available in 05 minutes' 900)"
+# Seven digits would overflow the multiplication; refuse rather than wrap.
+run_test "1579_wait_absurd_value_refused" "900" "$(coderabbit_rate_limit_wait_seconds 'Next included review available in 1000000 minutes' 900)"
+run_test "1579_wait_never_zero_for_zero_window" "30" "$(coderabbit_rate_limit_wait_seconds 'Next included review available in 0 minutes' 900)"
+run_test "1579_wait_respects_max_override" "100" "$(CODERABBIT_RATE_LIMIT_WAIT_MAX=100 coderabbit_rate_limit_wait_seconds "$_1579_window" 900)"
+run_test "1579_wait_respects_buffer_override" "1620" "$(CODERABBIT_RATE_LIMIT_WAIT_BUFFER=0 coderabbit_rate_limit_wait_seconds "$_1579_window" 900)"
+# A junk override degrades to the documented default, never to a zero wait
+# (a zero wait would busy-spin the retry against the vendor).
+run_test "1579_wait_junk_buffer_uses_default" "1650" "$(CODERABBIT_RATE_LIMIT_WAIT_BUFFER=abc coderabbit_rate_limit_wait_seconds "$_1579_window" 900)"
+run_test "1579_wait_junk_fallback_arg_uses_default" "900" "$(coderabbit_rate_limit_wait_seconds "$_1579_nowindow" notanumber)"
+
+# --- staleness -------------------------------------------------------------
+run_test "1579_live_within_stated_window" "current" "$(_1579_state "$_1579_window" "$(_1579_ago 5)")"
+run_test "1579_live_just_inside_stated_window" "current" "$(_1579_state "$_1579_window" "$(_1579_ago 26)")"
+run_test "1579_spent_past_stated_window" "stale" "$(_1579_state "$_1579_window" "$(_1579_ago 60)")"
+# Without a stated window, CODERABBIT_RATE_LIMIT_STALE_AFTER (one vendor hour)
+# bounds how long the comment stays believable.
+run_test "1579_unstated_window_recent_is_live" "current" "$(_1579_state "$_1579_nowindow" "$(_1579_ago 30)")"
+run_test "1579_unstated_window_old_is_spent" "stale" "$(_1579_state "$_1579_nowindow" "$(_1579_ago 90)")"
+# The PR #1575 case that motivated the issue: 21 hours later, still "live".
+run_test "1579_pr1575_21h_old_comment_is_spent" "stale" "$(_1579_state "$_1579_nowindow" "$(_1579_ago 1260)")"
+# Unknown or skewed timestamps degrade to the previous conservative behaviour
+# (wait) rather than to spending a review attempt the caller may not have.
+run_test "1579_unparseable_timestamp_stays_live" "current" "$(_1579_state "$_1579_window" "not-a-date")"
+run_test "1579_empty_timestamp_stays_live" "current" "$(_1579_state "$_1579_window" "")"
+run_test "1579_future_timestamp_stays_live" "current" "$(_1579_state "$_1579_window" "2099-01-01T00:00:00Z")"
+
+# --- AC-1: a reply older than this run's own trigger is not an answer ------
+# Without this, the loop reads its own pre-trigger evidence as the response to
+# the trigger it just posted and reports "rate limited" without ever giving
+# CodeRabbit a chance to answer.
+run_test "1579_reply_before_this_runs_trigger_is_not_current" "stale" \
+  "$(coderabbit_rate_limit_comment_is_current "$_1579_window" "$(_1579_ago 5)" "$(_1579_ago 2)" && printf 'current\n' || printf 'stale\n')"
+run_test "1579_reply_after_this_runs_trigger_is_current" "current" \
+  "$(coderabbit_rate_limit_comment_is_current "$_1579_window" "$(_1579_ago 2)" "$(_1579_ago 5)" && printf 'current\n' || printf 'stale\n')"
+# On a fresh run there is no trigger yet. The anchor must not then discard a
+# genuinely live limit — the window rule has to decide alone.
+run_test "1579_empty_anchor_falls_back_to_window_rule" "current" \
+  "$(coderabbit_rate_limit_comment_is_current "$_1579_window" "$(_1579_ago 5)" "" && printf 'current\n' || printf 'stale\n')"
+# Clock skew: the anchor is stamped locally, the timestamp comes from GitHub.
+# A reply a few seconds "before" the trigger is still the answer to it.
+run_test "1579_anchor_tolerates_small_clock_skew" "current" \
+  "$(CODERABBIT_TRIGGER_ANCHOR_SKEW=60 coderabbit_rate_limit_comment_is_current "$_1579_window" "2026-08-24T03:41:00Z" "2026-08-24T03:41:30Z" && printf 'current\n' || printf 'stale\n')"
+# ...but a reply from well before the trigger is not.
+run_test "1579_anchor_rejects_large_gap" "stale" \
+  "$(CODERABBIT_TRIGGER_ANCHOR_SKEW=60 coderabbit_rate_limit_comment_is_current "$_1579_window" "2026-08-24T03:30:00Z" "2026-08-24T03:41:30Z" && printf 'current\n' || printf 'stale\n')"
+# An unparseable anchor must not silently discard the comment either.
+run_test "1579_junk_anchor_falls_back_to_window_rule" "current" \
+  "$(coderabbit_rate_limit_comment_is_current "$_1579_window" "$(_1579_ago 5)" "not-a-date" && printf 'current\n' || printf 'stale\n')"
+
+# --- the JSON wrapper both call sites share --------------------------------
+_1579_live() {
+  if coderabbit_rate_limit_is_live "$1"; then printf 'live\n'; else printf 'not-live\n'; fi
+}
+run_test "1579_is_live_empty_json_not_live" "not-live" "$(_1579_live '')"
+run_test "1579_is_live_recent_window" "live" \
+  "$(_1579_live "$(jq -cn --arg b "$_1579_window" --arg c "$(_1579_ago 5)" '{body:$b, created_at:$c}')")"
+run_test "1579_is_live_expired_window" "not-live" \
+  "$(_1579_live "$(jq -cn --arg b "$_1579_window" --arg c "$(_1579_ago 60)" '{body:$b, created_at:$c}')")"
+# Malformed JSON must not read as live — an unparseable object is no evidence
+# of a live limit, and reading it as one would re-create the #1579 stall.
+run_test "1579_is_live_malformed_json_not_live" "not-live" "$(_1579_live 'not json at all')"
+
+# --- AC-2: the post-rate-limit re-trigger asks for a review ----------------
+# "resume" only lifts a paused state; against a rate limit CodeRabbit answers
+# "Reviews resumed" and reviews nothing (PR #1589: four resumes, zero reviews).
+# This reads the rate-limit branch itself, so the guarantee cannot be lost to a
+# later edit that reverts the verb.
+_1579_loop_src="$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
+_1579_rl_branch="$(awk '/no SUCCESS commit status found/,/_interruptible_sleep "\$poll_interval"/' "$_1579_loop_src")"
+run_test "1579_rate_limit_branch_posts_review" "1" \
+  "$(printf '%s' "$_1579_rl_branch" | grep -c -- '--body "@coderabbitai review"' || true)"
+run_test "1579_rate_limit_branch_does_not_post_resume" "0" \
+  "$(printf '%s' "$_1579_rl_branch" | grep -c -- '--body "@coderabbitai resume"' || true)"
+# The extraction must actually have found the branch; an empty window would
+# make both counts trivially pass.
+run_test "1579_rate_limit_branch_extraction_nonempty" "yes" \
+  "$([ -n "$_1579_rl_branch" ] && printf 'yes\n' || printf 'no\n')"
+
+# --- mutation check --------------------------------------------------------
+# The staleness verdicts above must actually depend on the parsed window. Shadow
+# the parser with one that always reports a huge window: the 21-hour-old comment
+# must then flip to "current". If it does not, the assertions above are passing
+# for some reason other than the logic they claim to test.
+_1579_real_parser="$(declare -f coderabbit_rate_limit_wait_seconds)"
+coderabbit_rate_limit_wait_seconds() { printf '999999\n'; }
+run_test "1579_mutation_huge_window_flips_verdict" "current" "$(_1579_state "$_1579_nowindow" "$(_1579_ago 1260)")"
+eval "$_1579_real_parser"
+# Restored parser must give the real answer again.
+run_test "1579_mutation_restored_parser_is_stale" "stale" "$(_1579_state "$_1579_nowindow" "$(_1579_ago 1260)")"
+
+unset -f _1579_ago _1579_state _1579_live
+unset _1579_window _1579_nowindow _1579_real_parser _1579_loop_src _1579_rl_branch
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14972,8 +14972,19 @@ run_test "1579_remaining_unparseable_created_at" "1650" \
   "$(coderabbit_rate_limit_remaining_seconds "$_1579_window" "not-a-date" 900)"
 run_test "1579_remaining_future_created_at" "1650" \
   "$(coderabbit_rate_limit_remaining_seconds "$_1579_window" "2099-01-01T00:00:00Z" 900)"
-run_test "1579_remaining_no_stated_window_uses_fallback" "900" \
-  "$(coderabbit_rate_limit_remaining_seconds "Review rate limited." "$(_1579_ago_s 0)" 900)"
+# Clock-derived like the others above: the fallback is 900 minus the comment's
+# age, and a fresh comment's age is 0 or 1 depending on where the two `date`
+# reads land. Compared within a tolerance rather than pinned exactly.
+_1579_fallback_near() {
+  local got delta
+  got="$(coderabbit_rate_limit_remaining_seconds "Review rate limited." "$(_1579_ago_s 0)" 900)"
+  case "$got" in
+    '' | *[!0-9]*) printf 'non-numeric:%s\n' "$got"; return 0 ;;
+  esac
+  delta=$(( got > 900 ? got - 900 : 900 - got ))
+  if [ "$delta" -le 3 ]; then printf 'within\n'; else printf 'got %s want ~900\n' "$got"; fi
+}
+run_test "1579_remaining_no_stated_window_uses_fallback" "within" "$(_1579_fallback_near)"
 
 # --- the selector must match every observed banner shape -------------------
 # Three shapes have been seen and no single marker covers them all. Matching
@@ -14994,7 +15005,7 @@ run_test "1579_selector_matches_visible_text_without_marker" "yes" \
 **Next included review available in 27 minutes.**')"
 run_test "1579_selector_ignores_ordinary_comment" "no" \
   "$(_1579_sel 'Thanks, looks good to me.')"
-unset -f _1579_remaining_near _1579_tolerance_rejects _1579_sel
+unset -f _1579_remaining_near _1579_tolerance_rejects _1579_fallback_near _1579_sel
 
 # --- mutation check --------------------------------------------------------
 # The staleness verdicts above must actually depend on the parsed window. Shadow

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14715,6 +14715,11 @@ _1579_ago() {
   date -u -v-"${mins}"M +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
     || date -u -d "${mins} minutes ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null
 }
+_1579_ago_s() {
+  local secs="$1"
+  date -u -v-"${secs}"S +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+    || date -u -d "${secs} seconds ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null
+}
 _1579_state() {
   if coderabbit_rate_limit_comment_is_current "$1" "$2"; then
     printf 'current\n'
@@ -14757,6 +14762,19 @@ run_test "1579_wait_respects_buffer_override" "1620" "$(CODERABBIT_RATE_LIMIT_WA
 # (a zero wait would busy-spin the retry against the vendor).
 run_test "1579_wait_junk_buffer_uses_default" "1650" "$(CODERABBIT_RATE_LIMIT_WAIT_BUFFER=abc coderabbit_rate_limit_wait_seconds "$_1579_window" 900)"
 run_test "1579_wait_junk_fallback_arg_uses_default" "900" "$(coderabbit_rate_limit_wait_seconds "$_1579_nowindow" notanumber)"
+# PLANTED VIOLATION: a digit-only override with a leading zero and an 8 or 9
+# ("008") passes the `*[!0-9]*` check unchanged and is not "junk" by that
+# check's definition, but bash reads a leading-zero literal as octal inside
+# $((...)) and "008" is not a valid octal literal (8 is not an octal digit) —
+# this must not reach that arithmetic unstripped, or it aborts the whole
+# script under `set -e` instead of degrading like every other override above.
+# Reverting the leading-zero strip on buffer/max_seconds (pr-review-loop.sh,
+# coderabbit_rate_limit_wait_seconds) reproduces the crash: manually confirmed
+# during review (PR #1592) with `CODERABBIT_RATE_LIMIT_WAIT_BUFFER=008
+# coderabbit_rate_limit_wait_seconds` — the process exits nonzero with "008:
+# value too great for base" instead of returning a wait.
+run_test "1579_wait_buffer_leading_zero_with_8_not_octal" "1628" "$(CODERABBIT_RATE_LIMIT_WAIT_BUFFER=008 coderabbit_rate_limit_wait_seconds "$_1579_window" 900)"
+run_test "1579_wait_max_leading_zero_with_8_not_octal" "8" "$(CODERABBIT_RATE_LIMIT_WAIT_MAX=008 coderabbit_rate_limit_wait_seconds "$_1579_window" 900)"
 
 # --- staleness -------------------------------------------------------------
 run_test "1579_live_within_stated_window" "current" "$(_1579_state "$_1579_window" "$(_1579_ago 5)")"
@@ -14787,15 +14805,31 @@ run_test "1579_reply_after_this_runs_trigger_is_current" "current" \
 run_test "1579_empty_anchor_falls_back_to_window_rule" "current" \
   "$(coderabbit_rate_limit_comment_is_current "$_1579_window" "$(_1579_ago 5)" "" && printf 'current\n' || printf 'stale\n')"
 # Clock skew: the anchor is stamped locally, the timestamp comes from GitHub.
-# A reply a few seconds "before" the trigger is still the answer to it.
+# A reply a few seconds "before" the trigger is still the answer to it. Timestamps
+# are computed relative to real "now" (like _1579_ago above), not hardcoded to a
+# fixed calendar moment: a hardcoded pair only satisfies the window check in
+# coderabbit_rate_limit_comment_is_current while the wall clock is still close to
+# whenever the test was written, and silently starts failing once real time moves
+# past that window — this was caught live during review (PR #1592).
 run_test "1579_anchor_tolerates_small_clock_skew" "current" \
-  "$(CODERABBIT_TRIGGER_ANCHOR_SKEW=60 coderabbit_rate_limit_comment_is_current "$_1579_window" "2026-08-24T03:41:00Z" "2026-08-24T03:41:30Z" && printf 'current\n' || printf 'stale\n')"
+  "$(CODERABBIT_TRIGGER_ANCHOR_SKEW=60 coderabbit_rate_limit_comment_is_current "$_1579_window" "$(_1579_ago_s 300)" "$(_1579_ago_s 270)" && printf 'current\n' || printf 'stale\n')"
 # ...but a reply from well before the trigger is not.
 run_test "1579_anchor_rejects_large_gap" "stale" \
-  "$(CODERABBIT_TRIGGER_ANCHOR_SKEW=60 coderabbit_rate_limit_comment_is_current "$_1579_window" "2026-08-24T03:30:00Z" "2026-08-24T03:41:30Z" && printf 'current\n' || printf 'stale\n')"
+  "$(CODERABBIT_TRIGGER_ANCHOR_SKEW=60 coderabbit_rate_limit_comment_is_current "$_1579_window" "$(_1579_ago_s 990)" "$(_1579_ago_s 270)" && printf 'current\n' || printf 'stale\n')"
 # An unparseable anchor must not silently discard the comment either.
 run_test "1579_junk_anchor_falls_back_to_window_rule" "current" \
   "$(coderabbit_rate_limit_comment_is_current "$_1579_window" "$(_1579_ago 5)" "not-a-date" && printf 'current\n' || printf 'stale\n')"
+# PLANTED VIOLATION: same octal-literal class as the wait-sizing overrides
+# above, on the one operator override in this function that reaches $((...))
+# arithmetic. CODERABBIT_TRIGGER_ANCHOR_SKEW=008 passes the digit-only check
+# unchanged; "008" is not a valid octal literal, so the anchor-skew arithmetic
+# aborts the whole script under `set -e` without the leading-zero strip.
+# Manually confirmed during review (PR #1592): reverting the strip on
+# anchor_skew reproduces "008: value too great for base" from a comment 5 s
+# before the trigger with an 8 s configured skew (created a few seconds
+# outside a 0-padded skew window, which used to be within a 60 s skew).
+run_test "1579_anchor_skew_leading_zero_with_8_not_octal" "current" \
+  "$(CODERABBIT_TRIGGER_ANCHOR_SKEW=008 coderabbit_rate_limit_comment_is_current "$_1579_window" "$(_1579_ago_s 5)" "$(_1579_ago_s 1)" && printf 'current\n' || printf 'stale\n')"
 
 # --- the JSON wrapper both call sites share --------------------------------
 _1579_live() {
@@ -14838,7 +14872,102 @@ eval "$_1579_real_parser"
 # Restored parser must give the real answer again.
 run_test "1579_mutation_restored_parser_is_stale" "stale" "$(_1579_state "$_1579_nowindow" "$(_1579_ago 1260)")"
 
-unset -f _1579_ago _1579_state _1579_live
+# --- AC-3(a): end-to-end — a stale rate-limit reply must not suppress the
+# silent non-trigger retrigger. This is the PR #1575 defect itself: a
+# rate-limit comment whose window elapsed 21 hours earlier still read as "CodeRabbit
+# is rate limited" and silenced the loop's own proactive "@coderabbitai review"
+# nudge. Runs the real run_coderabbit_review poll loop against a scripted `gh`,
+# not just the extracted decision functions above, so the wiring between
+# coderabbit_rate_limit_is_live and the silent-non-trigger guard is proven, not
+# just each side in isolation.
+_1579_e2e_mock_dir="$(mktemp -d)"
+_1579_e2e_call_log="$_1579_e2e_mock_dir/calls.log"
+export _1579_E2E_CALL_LOG="$_1579_e2e_call_log"
+export _1579_E2E_STALE_CREATED
+_1579_E2E_STALE_CREATED="$(date -u -v-2H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '2 hours ago' +"%Y-%m-%dT%H:%M:%SZ")"
+cat > "$_1579_e2e_mock_dir/gh" <<'CR_GH_1579A'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$_1579_E2E_CALL_LOG"
+case "$*" in
+  "auth status") exit 0 ;;
+  *"repo view"*"nameWithOwner"*) printf 'owner/repo\n'; exit 0 ;;
+  *"pulls/42 --jq .head.sha"*) printf 'sha1579a\n'; exit 0 ;;
+  *"commits/sha1579a --jq .commit.committer.date"*) printf '2000-01-01T00:00:00Z\n'; exit 0 ;;
+  *"pr comment 42"*) exit 0 ;;
+  *"issues/42/comments"*)
+    printf '[{"user":{"login":"coderabbitai[bot]"},"created_at":"%s","updated_at":"%s","body":"Review rate limited."}]\n' \
+      "$_1579_E2E_STALE_CREATED" "$_1579_E2E_STALE_CREATED"
+    exit 0 ;;
+  *"api graphql"*)
+    printf '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}\n'; exit 0 ;;
+  *) printf '[]\n'; exit 0 ;;
+esac
+CR_GH_1579A
+chmod +x "$_1579_e2e_mock_dir/gh"
+
+PATH="$_1579_e2e_mock_dir:$PATH" \
+  CODERABBIT_NO_TRIGGER_TIMEOUT=1 CODERABBIT_RATE_LIMIT_MAX_RETRIES=1 \
+  run_coderabbit_review "42" "fix/42-test" "1" "3" >/dev/null 2>&1 || true
+
+run_test "1579_stale_reply_does_not_block_silent_retrigger" "yes" \
+  "$([ "$(grep_count_or_zero '@coderabbitai review' "$_1579_e2e_call_log")" -ge 1 ] && echo yes || echo no)"
+# The mock's default case is permissive ("[]" for anything unenumerated), so a
+# renamed endpoint could silently return empty and still look clean. Assert the
+# comments endpoint that carries the rate-limit reply was actually queried.
+run_test "1579_stale_reply_queried_issue_comments" "yes" \
+  "$([ "$(grep_count_or_zero 'issues/42/comments' "$_1579_e2e_call_log")" -ge 1 ] && echo yes || echo no)"
+
+rm -rf "$_1579_e2e_mock_dir"
+unset _1579_E2E_CALL_LOG _1579_E2E_STALE_CREATED _1579_e2e_mock_dir _1579_e2e_call_log
+
+# --- AC-3(b) / AC-2: end-to-end — a LIVE rate limit re-triggers with "review",
+# not "resume". PR #1589 measured four "@coderabbitai resume" posts answered
+# with four "Reviews resumed" acknowledgements and zero reviews, because
+# "resume" only lifts CodeRabbit's auto-pause and does nothing against a rate
+# limit. Runs the real rate-limit wait/retrigger branch end to end so the
+# posted verb is proven from actual execution, not only from the static
+# source-text check above.
+_1579_e2e_mock_dir2="$(mktemp -d)"
+_1579_e2e_call_log2="$_1579_e2e_mock_dir2/calls.log"
+export _1579_E2E_CALL_LOG2="$_1579_e2e_call_log2"
+export _1579_E2E_LIVE_CREATED
+_1579_E2E_LIVE_CREATED="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+cat > "$_1579_e2e_mock_dir2/gh" <<'CR_GH_1579B'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$_1579_E2E_CALL_LOG2"
+case "$*" in
+  "auth status") exit 0 ;;
+  *"repo view"*"nameWithOwner"*) printf 'owner/repo\n'; exit 0 ;;
+  *"pulls/42 --jq .head.sha"*) printf 'sha1579b\n'; exit 0 ;;
+  *"commits/sha1579b --jq .commit.committer.date"*) printf '2000-01-01T00:00:00Z\n'; exit 0 ;;
+  *"pr comment 42"*) exit 0 ;;
+  *"issues/42/comments"*)
+    printf '[{"user":{"login":"coderabbitai[bot]"},"created_at":"%s","updated_at":"%s","body":"Review rate limited."}]\n' \
+      "$_1579_E2E_LIVE_CREATED" "$_1579_E2E_LIVE_CREATED"
+    exit 0 ;;
+  *"api graphql"*)
+    printf '{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}\n'; exit 0 ;;
+  *) printf '[]\n'; exit 0 ;;
+esac
+CR_GH_1579B
+chmod +x "$_1579_e2e_mock_dir2/gh"
+
+PATH="$_1579_e2e_mock_dir2:$PATH" \
+  CODERABBIT_NO_TRIGGER_TIMEOUT=999 CODERABBIT_RATE_LIMIT_MAX_RETRIES=1 CODERABBIT_RATE_LIMIT_WAIT=1 \
+  run_coderabbit_review "42" "fix/42-test" "1" "3" >/dev/null 2>&1 || true
+
+# The mock logs "$*", which joins argv with spaces and drops the quoting the
+# real gh invocation used — matching the convention the #1531 mock already
+# established (pr comment 42 --body @coderabbitai review, no literal quotes).
+run_test "1579_live_rate_limit_reretrigger_posts_review" "yes" \
+  "$([ "$(grep_count_or_zero 'pr comment 42 --body @coderabbitai review' "$_1579_e2e_call_log2")" -ge 1 ] && echo yes || echo no)"
+run_test "1579_live_rate_limit_reretrigger_never_posts_resume" "0" \
+  "$(grep_count_or_zero 'pr comment 42 --body @coderabbitai resume' "$_1579_e2e_call_log2")"
+
+rm -rf "$_1579_e2e_mock_dir2"
+unset _1579_E2E_CALL_LOG2 _1579_E2E_LIVE_CREATED _1579_e2e_mock_dir2 _1579_e2e_call_log2
+
+unset -f _1579_ago _1579_ago_s _1579_state _1579_live
 unset _1579_window _1579_nowindow _1579_real_parser _1579_loop_src _1579_rl_branch
 
 # ---------------------------------------------------------------------------

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14894,8 +14894,22 @@ run_test "1579_lookup_none_has_no_output" "no" "$(_1579_probe_has_output empty)"
 # A failed API call must be its own signal, not "no rate limit".
 run_test "1579_lookup_gh_failure_status" "2" "$(_1579_probe fail)"
 run_test "1579_lookup_unparseable_status" "2" "$(_1579_probe garbage)"
+# Caller error is reported as a caller error, not as an API outage. Without
+# this, a missing argument builds a malformed endpoint, gh fails, and the
+# result is indistinguishable from a real lookup failure.
+_1579_argcheck() {
+  local st=0
+  PATH="$_1579_gh_dir:$PATH" STUB_MODE=empty coderabbit_newest_rate_limit_comment "$@" >/dev/null 2>&1 || st=$?
+  printf '%s\n' "$st"
+}
+run_test "1579_lookup_no_args_status" "2" "$(_1579_argcheck)"
+run_test "1579_lookup_too_few_args_status" "2" "$(_1579_argcheck a b c)"
+run_test "1579_lookup_too_many_args_status" "2" "$(_1579_argcheck a b c d e)"
+run_test "1579_lookup_blank_repo_status" "2" "$(_1579_argcheck '' 1 bot 2026-01-01T00:00:00Z)"
+run_test "1579_lookup_blank_since_status" "2" "$(_1579_argcheck owner/repo 1 bot '')"
+run_test "1579_lookup_four_valid_args_status" "0" "$(_1579_argcheck owner/repo 1 bot 2026-01-01T00:00:00Z)"
 rm -rf "$_1579_gh_dir"
-unset -f _1579_probe _1579_probe_has_output
+unset -f _1579_probe _1579_probe_has_output _1579_argcheck
 unset _1579_gh_dir
 
 # --- mutation check --------------------------------------------------------

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14501,8 +14501,12 @@ unset _1556_rbin
 _1556_loop="$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
 # The activity probe inside run_coderabbit_review must accept updated_at too;
 # that was the specific created_at-only filter reported on PR #1532.
-run_test "coderabbit_activity_probe_accepts_updated_at" "1" \
-  "$(grep_count_or_zero '(.created_at > $since or (.updated_at // .created_at) > $since)' "$_1556_loop")"
+# Asserted as "present", not "appears exactly once": the rate-limit comment
+# selector adopted the same created_at-or-updated_at filter for the same
+# reason (CodeRabbit edits a comment in place rather than posting a new one),
+# so a fixed count here would fail on a correct change elsewhere in the file.
+run_test "coderabbit_activity_probe_accepts_updated_at" "yes" \
+  "$([ "$(grep_count_or_zero '(.created_at > $since or (.updated_at // .created_at) > $since)' "$_1556_loop")" -ge 1 ] && echo yes || echo no)"
 # The verdict must no longer be a single fixed sleep.
 run_test "post_clean_no_longer_single_wait" "0" \
   "$(grep_count_or_zero '_interruptible_sleep "$post_clean_wait"' "$_1556_loop")"
@@ -14911,6 +14915,49 @@ run_test "1579_lookup_four_valid_args_status" "0" "$(_1579_argcheck owner/repo 1
 rm -rf "$_1579_gh_dir"
 unset -f _1579_probe _1579_probe_has_output _1579_argcheck
 unset _1579_gh_dir
+
+# --- remaining window, not the whole window again --------------------------
+# coderabbit_rate_limit_wait_seconds returns the FULL announced window, which
+# is only correct at the instant the comment appears. Sleeping it again
+# part-way through pushes the retry a full extra quota cycle past the moment a
+# review becomes available.
+_1579_remaining() {
+  coderabbit_rate_limit_remaining_seconds "$_1579_window" "$(_1579_ago_s "$1")" 900
+}
+run_test "1579_remaining_fresh_comment_is_full_window" "1650" "$(_1579_remaining 0)"
+# 27 min window, 26 min elapsed -> ~90s left, not another 1650s.
+run_test "1579_remaining_mid_window_subtracts_age" "90" "$(_1579_remaining 1560)"
+run_test "1579_remaining_half_window" "870" "$(_1579_remaining 780)"
+# Past the window, a floor keeps the retry from spinning instantly.
+run_test "1579_remaining_expired_window_uses_floor" "30" "$(_1579_remaining 3600)"
+# Age that cannot be computed degrades to the previous behaviour, not to zero.
+run_test "1579_remaining_unparseable_created_at" "1650" \
+  "$(coderabbit_rate_limit_remaining_seconds "$_1579_window" "not-a-date" 900)"
+run_test "1579_remaining_future_created_at" "1650" \
+  "$(coderabbit_rate_limit_remaining_seconds "$_1579_window" "2099-01-01T00:00:00Z" 900)"
+run_test "1579_remaining_no_stated_window_uses_fallback" "900" \
+  "$(coderabbit_rate_limit_remaining_seconds "Review rate limited." "$(_1579_ago_s 0)" 900)"
+
+# --- the selector must match every observed banner shape -------------------
+# Three shapes have been seen and no single marker covers them all. Matching
+# only one means a live limit reads as absent, and the loop spends a review
+# from a one-per-hour allowance.
+_1579_sel() {
+  # -R is required: the argument is raw text, not JSON. Without it jq fails to
+  # parse and the test silently compares against an empty string.
+  printf '%s' "$1" | jq -Rsr 'if test("rate.?limit|review limit reached|next included review"; "i") then "yes" else "no" end' 2>/dev/null
+}
+run_test "1579_selector_matches_html_marker_shape" "yes" \
+  "$(_1579_sel '<!-- rate limited by coderabbit.ai --> Review limit reached')"
+run_test "1579_selector_matches_command_refusal_shape" "yes" \
+  "$(_1579_sel 'Review rate limited. Your next included review will be available in 7 minutes.')"
+# The visible-text-only shape: no HTML marker, no literal "rate limit".
+run_test "1579_selector_matches_visible_text_without_marker" "yes" \
+  "$(_1579_sel '## Review limit reached
+**Next included review available in 27 minutes.**')"
+run_test "1579_selector_ignores_ordinary_comment" "no" \
+  "$(_1579_sel 'Thanks, looks good to me.')"
+unset -f _1579_remaining _1579_sel
 
 # --- mutation check --------------------------------------------------------
 # The staleness verdicts above must actually depend on the parsed window. Shadow

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -13958,7 +13958,7 @@ chmod +x "$_cr_mock_dir_1531b/gh"
 
 actual_output="$(
   PATH="$_cr_mock_dir_1531b:$PATH" CR_CALL_LOG="$_cr_call_log_1531b" \
-    CODERABBIT_NO_TRIGGER_TIMEOUT=1 CODERABBIT_RATE_LIMIT_WAIT=1 \
+    CODERABBIT_NO_TRIGGER_TIMEOUT=1 CODERABBIT_RATE_LIMIT_WAIT=1 CODERABBIT_RATE_LIMIT_MIN_WAIT=1 \
     CODERABBIT_RATE_LIMIT_MAX_RETRIES=1 \
     run_coderabbit_review "42" "fix/42-test" "1" "3" 2>/dev/null || true
 )"
@@ -14065,7 +14065,7 @@ chmod +x "$_cr_mock_dir_1531d/gh"
 
 actual_output="$(
   PATH="$_cr_mock_dir_1531d:$PATH" CR_CALL_LOG="$_cr_call_log_1531d" \
-    CODERABBIT_NO_TRIGGER_TIMEOUT=1 CODERABBIT_RATE_LIMIT_WAIT=1 \
+    CODERABBIT_NO_TRIGGER_TIMEOUT=1 CODERABBIT_RATE_LIMIT_WAIT=1 CODERABBIT_RATE_LIMIT_MIN_WAIT=1 \
     CODERABBIT_RATE_LIMIT_MAX_RETRIES=1 \
     run_coderabbit_review "42" "fix/42-test" "1" "3" 2>/dev/null || true
 )"
@@ -14105,7 +14105,7 @@ chmod +x "$_cr_mock_dir_1531e/gh"
 
 actual_output="$(
   PATH="$_cr_mock_dir_1531e:$PATH" CR_CALL_LOG="$_cr_call_log_1531e" \
-    CODERABBIT_NO_TRIGGER_TIMEOUT=1 CODERABBIT_RATE_LIMIT_WAIT=1 \
+    CODERABBIT_NO_TRIGGER_TIMEOUT=1 CODERABBIT_RATE_LIMIT_WAIT=1 CODERABBIT_RATE_LIMIT_MIN_WAIT=1 \
     CODERABBIT_RATE_LIMIT_MAX_RETRIES=1 \
     run_coderabbit_review "42" "fix/42-test" "1" "3" 2>/dev/null || true
 )"
@@ -14945,8 +14945,22 @@ run_test "1579_remaining_mid_window_subtracts_age" "within" "$(_1579_remaining_n
 run_test "1579_remaining_half_window" "within" "$(_1579_remaining_near 780 870)"
 # The tolerance must not be wide enough to hide the bug this pins: sleeping the
 # full window when only ~90s remains is a 1560s error, far outside it.
-run_test "1579_remaining_tolerance_still_catches_full_window" "got 90 want ~1650" \
-  "$(_1579_remaining_near 1560 1650)"
+# Assert only that the mismatch branch fired, not the exact computed value:
+# that value is clock-derived (89, 90 or 91), so pinning it reintroduces the
+# flakiness this whole block exists to remove.
+_1579_tolerance_rejects() {
+  # Did the near-comparison report a mismatch? Only that, deliberately: the
+  # computed value is clock-derived (89, 90 or 91), so asserting it exactly
+  # would reintroduce the flakiness this block exists to remove.
+  local out
+  out="$(_1579_remaining_near "$1" "$2")"
+  case "$out" in
+    within) printf 'accepted\n' ;;
+    *) printf 'rejected\n' ;;
+  esac
+}
+run_test "1579_remaining_tolerance_still_catches_full_window" "rejected" \
+  "$(_1579_tolerance_rejects 1560 1650)"
 # Past the window, a floor keeps the retry from spinning instantly. This one is
 # an exact comparison safely: the floor is a constant, not clock-derived.
 run_test "1579_remaining_expired_window_uses_floor" "30" \
@@ -14978,7 +14992,7 @@ run_test "1579_selector_matches_visible_text_without_marker" "yes" \
 **Next included review available in 27 minutes.**')"
 run_test "1579_selector_ignores_ordinary_comment" "no" \
   "$(_1579_sel 'Thanks, looks good to me.')"
-unset -f _1579_remaining_near _1579_sel
+unset -f _1579_remaining_near _1579_tolerance_rejects _1579_sel
 
 # --- mutation check --------------------------------------------------------
 # The staleness verdicts above must actually depend on the parsed window. Shadow

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -15057,13 +15057,24 @@ chmod +x "$_1579_e2e_mock_dir/gh"
 # skipped. If the staleness logic ever regresses, an unbounded invocation would
 # sleep the default wait and the suite would *stall* rather than fail — a
 # regression that hangs is harder to diagnose than one that goes red.
+# stderr is captured, not discarded: both the silent-non-trigger path and the
+# rate-limit retry post the identical `@coderabbitai review` body, so the call
+# log alone cannot say which one fired. The two paths log distinct lines, and
+# that is what distinguishes them.
+_1579_e2e_stderr="$(mktemp)"
 PATH="$_1579_e2e_mock_dir:$PATH" \
   CODERABBIT_NO_TRIGGER_TIMEOUT=1 CODERABBIT_RATE_LIMIT_MAX_RETRIES=1 \
   CODERABBIT_RATE_LIMIT_WAIT=1 CODERABBIT_RATE_LIMIT_MIN_WAIT=1 \
-  run_coderabbit_review "42" "fix/42-test" "1" "3" >/dev/null 2>&1 || true
+  run_coderabbit_review "42" "fix/42-test" "1" "3" >/dev/null 2>"$_1579_e2e_stderr" || true
 
 run_test "1579_stale_reply_does_not_block_silent_retrigger" "yes" \
   "$([ "$(grep_count_or_zero '@coderabbitai review' "$_1579_e2e_call_log")" -ge 1 ] && echo yes || echo no)"
+# It must be the SILENT NON-TRIGGER path: a spent rate-limit comment should not
+# route the loop through the rate-limit retry at all.
+run_test "1579_stale_reply_took_the_silent_non_trigger_path" "yes" \
+  "$([ "$(grep_count_or_zero 'silent non-trigger' "$_1579_e2e_stderr")" -ge 1 ] && echo yes || echo no)"
+run_test "1579_stale_reply_did_not_take_the_rate_limit_path" "yes" \
+  "$([ "$(grep_count_or_zero 'after rate-limit wait' "$_1579_e2e_stderr")" -eq 0 ] && echo yes || echo no)"
 # The mock's default case is permissive ("[]" for anything unenumerated), so a
 # renamed endpoint could silently return empty and still look clean. Assert the
 # comments endpoint that carries the rate-limit reply was actually queried.
@@ -15071,7 +15082,8 @@ run_test "1579_stale_reply_queried_issue_comments" "yes" \
   "$([ "$(grep_count_or_zero 'issues/42/comments' "$_1579_e2e_call_log")" -ge 1 ] && echo yes || echo no)"
 
 rm -rf "$_1579_e2e_mock_dir"
-unset _1579_E2E_CALL_LOG _1579_E2E_STALE_CREATED _1579_e2e_mock_dir _1579_e2e_call_log
+rm -f "$_1579_e2e_stderr"
+unset _1579_E2E_CALL_LOG _1579_E2E_STALE_CREATED _1579_e2e_mock_dir _1579_e2e_call_log _1579_e2e_stderr
 
 # --- AC-3(b) / AC-2: end-to-end — a LIVE rate limit re-triggers with "review",
 # not "resume". PR #1589 measured four "@coderabbitai resume" posts answered

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -13882,6 +13882,7 @@ chmod +x "$_cr_mock_dir_1531/gh"
 actual_output="$(
   PATH="$_cr_mock_dir_1531:$PATH" CR_CALL_LOG="$_cr_call_log_1531" \
     CODERABBIT_NO_TRIGGER_TIMEOUT=1 \
+    CODERABBIT_RATE_LIMIT_WAIT=1 CODERABBIT_RATE_LIMIT_MIN_WAIT=1 \
     run_coderabbit_review "42" "fix/42-test" "1" "3" 2>/dev/null || true
 )"
 
@@ -14015,6 +14016,7 @@ chmod +x "$_cr_mock_dir_1531c/gh"
 actual_output="$(
   PATH="$_cr_mock_dir_1531c:$PATH" CR_CALL_LOG="$_cr_call_log_1531c" \
     CODERABBIT_NO_TRIGGER_TIMEOUT=1 \
+    CODERABBIT_RATE_LIMIT_WAIT=1 CODERABBIT_RATE_LIMIT_MIN_WAIT=1 \
     run_coderabbit_review "42" "fix/42-test" "1" "3" 2>/dev/null || true
 )"
 
@@ -15039,8 +15041,14 @@ esac
 CR_GH_1579A
 chmod +x "$_1579_e2e_mock_dir/gh"
 
+# The wait is bounded even though this path should never take it: the fixture's
+# comment is two hours old and therefore spent, so the rate-limit branch is
+# skipped. If the staleness logic ever regresses, an unbounded invocation would
+# sleep the default wait and the suite would *stall* rather than fail — a
+# regression that hangs is harder to diagnose than one that goes red.
 PATH="$_1579_e2e_mock_dir:$PATH" \
   CODERABBIT_NO_TRIGGER_TIMEOUT=1 CODERABBIT_RATE_LIMIT_MAX_RETRIES=1 \
+  CODERABBIT_RATE_LIMIT_WAIT=1 CODERABBIT_RATE_LIMIT_MIN_WAIT=1 \
   run_coderabbit_review "42" "fix/42-test" "1" "3" >/dev/null 2>&1 || true
 
 run_test "1579_stale_reply_does_not_block_silent_retrigger" "yes" \

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -15088,6 +15088,7 @@ chmod +x "$_1579_e2e_mock_dir2/gh"
 
 PATH="$_1579_e2e_mock_dir2:$PATH" \
   CODERABBIT_NO_TRIGGER_TIMEOUT=999 CODERABBIT_RATE_LIMIT_MAX_RETRIES=1 CODERABBIT_RATE_LIMIT_WAIT=1 \
+  CODERABBIT_RATE_LIMIT_MIN_WAIT=1 \
   run_coderabbit_review "42" "fix/42-test" "1" "3" >/dev/null 2>&1 || true
 
 # The mock logs "$*", which joins argv with spaces and drops the quoting the

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14921,15 +14921,36 @@ unset _1579_gh_dir
 # is only correct at the instant the comment appears. Sleeping it again
 # part-way through pushes the retry a full extra quota cycle past the moment a
 # review becomes available.
-_1579_remaining() {
-  coderabbit_rate_limit_remaining_seconds "$_1579_window" "$(_1579_ago_s "$1")" 900
+# The timestamp is built by one `date` call and the age computed by another, so
+# a second boundary between them shifts the result by one. Assert the value is
+# within a tolerance of the expectation rather than exactly equal — an exact
+# comparison here is a flaky test, not a strict one.
+_1579_remaining_near() {
+  local age_s="$1" want="$2" tol="${3:-3}"
+  local got delta
+  got="$(coderabbit_rate_limit_remaining_seconds "$_1579_window" "$(_1579_ago_s "$age_s")" 900)"
+  case "$got" in
+    '' | *[!0-9]*) printf 'non-numeric:%s\n' "$got"; return 0 ;;
+  esac
+  delta=$(( got > want ? got - want : want - got ))
+  if [ "$delta" -le "$tol" ]; then
+    printf 'within\n'
+  else
+    printf 'got %s want ~%s\n' "$got" "$want"
+  fi
 }
-run_test "1579_remaining_fresh_comment_is_full_window" "1650" "$(_1579_remaining 0)"
+run_test "1579_remaining_fresh_comment_is_full_window" "within" "$(_1579_remaining_near 0 1650)"
 # 27 min window, 26 min elapsed -> ~90s left, not another 1650s.
-run_test "1579_remaining_mid_window_subtracts_age" "90" "$(_1579_remaining 1560)"
-run_test "1579_remaining_half_window" "870" "$(_1579_remaining 780)"
-# Past the window, a floor keeps the retry from spinning instantly.
-run_test "1579_remaining_expired_window_uses_floor" "30" "$(_1579_remaining 3600)"
+run_test "1579_remaining_mid_window_subtracts_age" "within" "$(_1579_remaining_near 1560 90)"
+run_test "1579_remaining_half_window" "within" "$(_1579_remaining_near 780 870)"
+# The tolerance must not be wide enough to hide the bug this pins: sleeping the
+# full window when only ~90s remains is a 1560s error, far outside it.
+run_test "1579_remaining_tolerance_still_catches_full_window" "got 90 want ~1650" \
+  "$(_1579_remaining_near 1560 1650)"
+# Past the window, a floor keeps the retry from spinning instantly. This one is
+# an exact comparison safely: the floor is a constant, not clock-derived.
+run_test "1579_remaining_expired_window_uses_floor" "30" \
+  "$(coderabbit_rate_limit_remaining_seconds "$_1579_window" "$(_1579_ago_s 3600)" 900)"
 # Age that cannot be computed degrades to the previous behaviour, not to zero.
 run_test "1579_remaining_unparseable_created_at" "1650" \
   "$(coderabbit_rate_limit_remaining_seconds "$_1579_window" "not-a-date" 900)"
@@ -14957,7 +14978,7 @@ run_test "1579_selector_matches_visible_text_without_marker" "yes" \
 **Next included review available in 27 minutes.**')"
 run_test "1579_selector_ignores_ordinary_comment" "no" \
   "$(_1579_sel 'Thanks, looks good to me.')"
-unset -f _1579_remaining _1579_sel
+unset -f _1579_remaining_near _1579_sel
 
 # --- mutation check --------------------------------------------------------
 # The staleness verdicts above must actually depend on the parsed window. Shadow

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -14860,6 +14860,44 @@ run_test "1579_rate_limit_branch_does_not_post_resume" "0" \
 run_test "1579_rate_limit_branch_extraction_nonempty" "yes" \
   "$([ -n "$_1579_rl_branch" ] && printf 'yes\n' || printf 'no\n')"
 
+# --- a failed lookup is not an absence of rate limiting ---------------------
+# coderabbit_newest_rate_limit_comment previously piped gh straight into jq and
+# ended in `|| printf ''`, so a failed API call and "no rate-limit comment"
+# were the same answer. Both call sites then posted a fresh review trigger,
+# spending from an allowance measured at 1 per hour on evidence never read.
+_1579_gh_dir="$(mktemp -d)"
+cat > "$_1579_gh_dir/gh" <<'_1579_GH_EOF'
+#!/bin/bash
+case "${STUB_MODE:-ok}" in
+  fail)    echo "gh: API error" >&2; exit 1 ;;
+  garbage) printf 'not json at all\n' ;;
+  empty)   printf '[]\n' ;;
+  *)       printf '[{"user":{"login":"coderabbitai[bot]"},"created_at":"2026-08-24T03:12:02Z","body":"rate limited by coderabbit.ai. Next included review available in 27 minutes."}]\n' ;;
+esac
+_1579_GH_EOF
+chmod +x "$_1579_gh_dir/gh"
+_1579_probe() {
+  local out st=0
+  out="$(PATH="$_1579_gh_dir:$PATH" STUB_MODE="$1" coderabbit_newest_rate_limit_comment owner/repo 1 "coderabbitai[bot]" 2026-08-24T00:00:00Z 2>/dev/null)" || st=$?
+  printf '%s\n' "$st"
+}
+_1579_probe_has_output() {
+  local out
+  out="$(PATH="$_1579_gh_dir:$PATH" STUB_MODE="$1" coderabbit_newest_rate_limit_comment owner/repo 1 "coderabbitai[bot]" 2026-08-24T00:00:00Z 2>/dev/null)" || true
+  if [ -n "$out" ]; then printf 'yes\n'; else printf 'no\n'; fi
+}
+run_test "1579_lookup_found_status" "0" "$(_1579_probe ok)"
+run_test "1579_lookup_found_has_output" "yes" "$(_1579_probe_has_output ok)"
+# Success with nothing to report is status 0 and empty — distinct from failure.
+run_test "1579_lookup_none_status" "0" "$(_1579_probe empty)"
+run_test "1579_lookup_none_has_no_output" "no" "$(_1579_probe_has_output empty)"
+# A failed API call must be its own signal, not "no rate limit".
+run_test "1579_lookup_gh_failure_status" "2" "$(_1579_probe fail)"
+run_test "1579_lookup_unparseable_status" "2" "$(_1579_probe garbage)"
+rm -rf "$_1579_gh_dir"
+unset -f _1579_probe _1579_probe_has_output
+unset _1579_gh_dir
+
 # --- mutation check --------------------------------------------------------
 # The staleness verdicts above must actually depend on the parsed window. Shadow
 # the parser with one that always reports a huge window: the 21-hour-old comment


### PR DESCRIPTION
Closes #1579.

## Problem

Two defects with one root cause: the loop treated "CodeRabbit is rate limited" as a yes/no question about whether a rate-limit comment *exists*, and sized its wait from a constant.

**Stale comments never expire.** Detection counted bot comments matching `rate.?limit` created after the HEAD commit. One such comment therefore made every later invocation on that HEAD report `rate limit detected` immediately, without posting a fresh trigger. Measured on PR #1575: a rate-limit comment at 16:06 still read as live 21 hours later, with no CodeRabbit activity of any kind in between.

**The retry budget cannot fit the vendor's window.** CodeRabbit's comment on PR #1590 at `2026-08-24T03:12:02Z` states the allowance outright:

```
Next included review available in 27 minutes.
Your 103 included PR review attempts over the past 7 days set your current
allowance at 1 review per hour.
```

Against 1 review/hour, the `4 x 900 s` default spends every retry inside a window that grants at most one review, then escalates at roughly the moment the review becomes available. Measured on PR #1589:

```
01:46:52  CodeRabbit reply to the loop's review command
02:03:51  "Reviews resumed"   (retry 1)
02:20:56  "Reviews resumed"   (retry 2)
02:37:59  "Reviews resumed"   (retry 3)
02:55:02  "Reviews resumed"   (retry 4)
03:15:25  RESULT=escalate REASON=rate_limit_max_retries -> `reviewer-failed`
```

Four retries, four acknowledgements, zero reviews. `resume` only lifts a *paused* state; against a rate limit CodeRabbit answers "Reviews resumed" and reviews nothing.

## Change

CodeRabbit announces its own expiry, so the loop now reads it instead of guessing.

- `coderabbit_rate_limit_wait_seconds` parses `Next included review available in N minutes` (also hours/seconds) and sizes the wait from it, plus a 30 s boundary buffer.
- `coderabbit_rate_limit_comment_is_current` treats a comment past its announced window as **spent**, so it no longer suppresses a fresh trigger. Where no window is stated, `CODERABBIT_RATE_LIMIT_STALE_AFTER` (default 3600 s, one vendor quota hour) bounds how long it stays believable.
- `coderabbit_newest_rate_limit_comment` / `coderabbit_rate_limit_is_live` are shared by the rate-limit retry block and the silent-non-trigger guard, so both judge "is CodeRabbit rate limited right now" from the same evidence. They previously ran separate count queries, which is how a spent comment could suppress the retrigger in one place while the other waited on it.
- The post-wait re-trigger is now `@coderabbitai review` rather than `@coderabbitai resume`.
- A reply older than this run's own most recent trigger no longer counts as an answer to it (AC-1), with a 60 s clock-skew tolerance — the anchor is stamped locally with `date` while the comment timestamp comes from GitHub, and without slack a few seconds of skew would discard a genuine reply and spend quota re-triggering.

### The vendor has more than one wording

Measured within a single hour on 2026-08-24, CodeRabbit stated the same fact two ways:

```
PR #1590 03:12  "**Next included review available in 27 minutes.**"
PR #1588 03:42  "Your next included review will be available in 7 minutes."
```

My first regex anchored on `review available in N` and matched only the first — it fell back silently to the 900 s constant on the second, which is the failure this PR exists to remove. The pattern now allows a bounded run of non-digits between "included" and "available". Bounded rather than open-ended, so it cannot reach past unrelated prose to a number elsewhere in the comment; and it still requires "included", so an unrelated "available in 5 minutes" sentence does not match.

The two bodies also differ structurally: the first carries the HTML marker `rate limited by coderabbit.ai` and its *visible* text says only "Review limit reached"; the second has no marker at all and matches on the visible "Review rate limited." Detection covers both, but it is worth knowing that neither signal alone is sufficient.

## Degradation is deliberate in both directions

- Absent or reworded vendor text falls back to the existing constant — vendor wording changes, so a failed parse must never be fatal.
- The wait is clamped by `CODERABBIT_RATE_LIMIT_WAIT_MAX` (default 3600 s) so a malformed `available in 1000000 minutes` cannot park an unattended run; values over six digits are refused outright rather than wrapping the multiplication.
- Leading zeros are stripped before arithmetic: bash reads `08` as an invalid octal literal and aborts under `set -e`.
- An **unparseable timestamp on a real comment** stays "current", preserving today's conservative wait. An **unparseable JSON blob** reads as not-live, because that is no evidence of a limit at all. These are different questions and the tests pin both.

## Verification

- `test-pr-review-loop.sh`: **1091 passed, 0 failed**, against a `origin/develop` baseline of **1051 passed, 0 failed** — 40 new assertions in a new Area 14, no regressions. Includes a mutation check — shadowing the parser with one that reports a huge window must flip the 21-hour-old comment from `stale` to `current`; if it does not, the staleness assertions are passing for some reason other than the logic they claim to test.
- Parsed the **real** rate-limit comment body fetched from PR #1590, not only synthetic strings: yields 1650 s where the old constant gave 900 s.
- Exercised `coderabbit_newest_rate_limit_comment` against a `gh` stub that hard-errors on any unexpected endpoint, so a URL mismatch cannot masquerade as "no comments". That stub caught a bad fixture of mine: the visible text of the comment says "Review limit reached", and detection actually matches the HTML marker `rate limited by coderabbit.ai`. The test now uses the genuine body.
- Verified `_iso8601_to_epoch` on **both** date implementations: BSD `-j -f` locally, and a stubbed GNU `date` that rejects `-j`, which is what CI runners use.
- The baseline comparison earned its keep: it caught that my first edit used `mv`, which replaced `pr-review-loop.sh` and **dropped its executable bit** (`100755 -> 100644`). Four unrelated `unlock_*` tests failed with exit 126 and would have been easy to wave off as environmental. Mode restored and re-verified in the staged diff.
- `shellcheck --severity=warning`, guard/snippet lints, `markdownlint-cli2`, CHANGELOG heuristic and duplicate-header checks: clean.

## Not in scope

Renaming the terminal label for an exhausted quota from `reviewer-failed` to something like `reviewer-unavailable` — a quota exhaustion is not a review verdict, and the current label is indistinguishable from a PR a reviewer actually rejected. That touches label application across several protocols, so it is left for a separate item and noted on #1579.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated review handling during rate limits.
  * Wait times now follow provider availability windows with safe bounds and fallback behavior.
  * Expired or stale rate-limit messages are ignored, allowing reviews to be retriggered correctly.
  * Retries now use the correct review request and response context.
  * Malformed data, lookup failures, clock differences, and invalid numeric settings are handled safely.

* **Documentation**
  * Added changelog coverage for rate-limit handling improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->