### PR TITLE
docs(plan): changelog fragments to end parallel-batch conflicts (#1554)

### DIFF
--- a/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
+++ b/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
@@ -57,7 +57,7 @@ the new code this plan adds.
 | `PR_HAS_CHANGELOG` semantics | Read `fetch_pr_meta` and `cmd_discover` in `scripts/development-workflow/batch-merge.sh` | It is a **merge-ordering** signal (non-CHANGELOG PRs merge first), not a readiness gate. The issue body's description of it as an assertion is inaccurate; this plan does not change its meaning |
 | Release scope parser | Read `append_issues_from_changelog` in `scripts/development-workflow/prepare-release-post-merge-cleanup.sh` | Extracts `#N` tokens from the published `## [X.Y.Z]` section. Requires no change **provided** assembled bullets keep the `(#N)` reference, which the fragment body convention mandates |
 | Hotfix tagging path | Read `.github/workflows/auto-tag-release.yml` | Reads only `CHANGELOG.md` version sections; the hotfix path writes those directly and is untouched by this plan |
-| Haystack rule identifier | `grep -n "changelog" .haystack/pr-rules.yml` and the comment block in `scripts/development-workflow/haystack-reviewer.sh` | The live rule id is `keep-single-unreleased-changelog-section`; the script's comment names `keep-changelog-unreleased-structure-canonical`, which does not exist in the rules file. Pre-existing drift, corrected as part of this change |
+| Haystack rule identifier | `grep -n "changelog" .haystack/pr-rules.yml` and the comment block in `scripts/development-workflow/haystack-reviewer.sh` | The live rule id is `keep-single-unreleased-changelog-section`; the script's comment names `keep-changelog-unreleased-structure-canonical`, which does not exist in the rules file. Pre-existing drift, observed but not yet corrected — the fix is scheduled for Implementation Order Step 10 and is out of scope for this plan-writing PR |
 | Documentation-stage allowlist | Read `path_allowed_for_stage` in `scripts/development-workflow/check-documentation-stage-alignment.sh` | `spec/*` and `implementation-plan/*` allow only their own stage artifacts, so a fragment on a documentation-stage branch is correctly reported as unexpected. No change needed |
 | CI suite selection | Read the `# covers:` convention in `scripts/development-workflow/select-test-suites.sh` | A suite named `test-changelog-fragments.sh` covers `changelog-fragments.sh` by naming convention with no workflow edit |
 | Sync manifest precedence | Read the precedence paragraph in `sync-manifest.yaml` | Only "project-specific exact path beats always-sync directory glob" is defined. The reverse is undefined, so this plan lists **only** `changelog.d/README.md` and leaves downstream fragment files unlisted (the manifest header already states unlisted files are never synced) |
@@ -174,14 +174,20 @@ illegal one.
 ### Decision 3 — Consumption semantics: how "assembled but not yet published" is represented
 
 The state is represented by **two artifacts that exist together only between
-assembly and publication**, both living on the release branch:
+assembly and publication**, both living on the release branch, **written in a
+fixed order so an interruption between them lands on a detected, named state
+rather than an ambiguous one**:
 
-1. The draft `## [X.Y.Z] - YYYY-MM-DD` section written into `CHANGELOG.md`.
-2. A release manifest at `changelog.d/manifests/v<X.Y.Z>.txt` naming exactly
-   the fragment files that fed the draft, one repository-relative path per
-   line, preceded by a single comment line recording the assembly timestamp,
-   the fragment count, and the count of bullets carried over from the shared
-   block.
+1. A release manifest at `changelog.d/manifests/v<X.Y.Z>.txt`, naming exactly
+   the fragment files that will feed the draft, one repository-relative path
+   per line, preceded by a single comment line recording the assembly
+   timestamp, the fragment count, and the count of bullets carried over from
+   the shared block. **Written first**, via a temp file plus atomic rename,
+   so its existence durably commits to one specific fragment set before
+   `CHANGELOG.md` is touched.
+2. The draft `## [X.Y.Z] - YYYY-MM-DD` section written into `CHANGELOG.md`,
+   built from exactly the fragment set already recorded in the manifest —
+   never a fresh directory scan. **Written second.**
 
 Fragment files themselves are **not touched by assembly**. This is the literal
 requirement from the spec ("Assembling a draft never destroys anything") and
@@ -189,31 +195,65 @@ from the tracker handoff, which records that the first spec draft left the
 interrupted case undefined and that any design where assembly destroys or moves
 fragments violates the corrected clause.
 
-- **The set is fixed at assembly.** After the manifest exists, it — not a fresh
-  directory scan — is the authority for what this release contains. A fragment
-  added afterwards (on `develop`, or cherry-picked onto the release branch as
-  part of a late fix) is absent from the manifest and is therefore not in this
-  release. It stays in `changelog.d/` and is picked up by the next assembly.
-- **Assembly is idempotent.** `assemble` refuses to write when `CHANGELOG.md`
-  already contains a `## [X.Y.Z]` heading for the target version, reporting
-  `ASSEMBLE_RESULT=already_assembled` and exiting 0 without modifying anything.
-  Running it twice in a row therefore leaves exactly the result of running it
-  once, including the releaser's edits. The heading check is the guarantee's
-  mechanism, and it holds even after the manifest has been removed.
+- **The set is fixed at assembly.** Once the manifest is written, it — not a
+  fresh directory scan — is the authority for what this release contains. A
+  fragment added afterwards (on `develop`, or cherry-picked onto the release
+  branch as part of a late fix) is absent from the manifest and is therefore
+  not in this release. It stays in `changelog.d/` and is picked up by the next
+  assembly.
+- **Assembly's four states are each named, and none is inferred.** `assemble`
+  checks the manifest for the target version and the `## [X.Y.Z]` heading
+  independently:
+  - Manifest present, heading present: `ASSEMBLE_RESULT=already_assembled`,
+    exit 0, no write. The normal resume path.
+  - Manifest present, heading absent: the run was interrupted between the two
+    writes. `assemble` completes the `CHANGELOG.md` write from the
+    already-frozen manifest (not a rescan), then reports
+    `ASSEMBLE_RESULT=assembled`, exit 0. Because the set was fixed before the
+    interruption, this is safe even if new fragments landed on `develop`
+    afterward — "the set is fixed at assembly" still holds.
+  - Manifest absent, heading present: the manifest was lost by something other
+    than `consume` (which moves it — see below — rather than deleting it),
+    since assembly never reaches the `CHANGELOG.md` write before the manifest
+    is committed. `assemble` reports
+    `ASSEMBLE_RESULT=assembled_unmanifested`, a non-zero exit, and names the
+    remediation: `assemble --reassemble`, which recomputes the manifest from
+    the current directory and, by the deterministic-ordering guarantee (Edge
+    case 28), reproduces byte-identical `CHANGELOG.md` content — safe to run
+    even though the version section already exists.
+  - Manifest absent, heading absent: nothing has happened yet; `assemble` runs
+    normally.
 - **Interrupted preparation resumes intact.** Both artifacts are ordinary
   committed files on the release branch, so resuming is `git checkout` of that
-  branch. Re-running `assemble` is safe (`already_assembled`). If the release
-  branch is discarded entirely, `develop` still holds every fragment, because
-  nothing was ever deleted there.
-- **Consumption happens at publication.** `consume` deletes exactly the files
-  named in the manifest, plus the manifest itself, as a commit on the release
-  branch. Those deletions reach `main` and `develop` only when the release PRs
-  merge — which is what "published" means. An abandoned release deletes
-  nothing anywhere that survives.
+  branch followed by re-running `assemble`, which always lands on one of the
+  four states above instead of guessing. If the release branch is discarded
+  entirely, `develop` still holds every fragment, because nothing was ever
+  deleted there.
+- **Consumption happens at publication, and its idempotence marker is a
+  positive fact, not an absence.** `consume` deletes exactly the fragment
+  files named in the manifest, then **moves** — never deletes — the manifest
+  itself to `changelog.d/manifests/consumed/v<X.Y.Z>.txt`, as a commit on the
+  release branch. This both strengthens the spec's Audit Trail principle (a
+  permanent record of what fed each published release) and removes the
+  ambiguity a delete would otherwise reintroduce:
+  - Manifest present in `changelog.d/manifests/`: normal `consumed` path.
+  - Manifest present in `changelog.d/manifests/consumed/`, absent from
+    `changelog.d/manifests/`: `CONSUME_RESULT=already_consumed`, exit 0 —
+    confirmed by the moved file's presence, not its absence.
+  - Manifest absent from **both** locations, version section present: no
+    longer conflated with `already_consumed`. Reports
+    `CONSUME_RESULT=inconsistent`, non-zero exit, and instructs the operator
+    to reconcile by hand — this is `assembled_unmanifested`'s sibling failure
+    mode surfacing at `consume` time instead of `assemble` time, and it must
+    fail loudly for the same reason.
+  Those deletions and the manifest move reach `main` and `develop` only when
+  the release PRs merge — which is what "published" means. An abandoned
+  release deletes nothing anywhere that survives.
 - **Re-assembly is possible but explicit.** `assemble --reassemble` recomputes
   the manifest from the current directory and replaces the existing version
   section. It prints the section it is about to replace before replacing it,
-  because that section may contain the releaser's editorial pass. It is the
+  because that section may contain the releaser's editorial pass. Besides the
+  `assembled_unmanifested` recovery path above (which reuses it), it is the
   only path that discards editorial edits, and it is never invoked by protocol
   05's normal flow.
 - **If a fragment is edited between assembly and consumption**, the draft in
@@ -249,11 +289,25 @@ migration step (Decision 7).
 ### Decision 5 — Readiness checks that must accept a fragment
 
 The authoritative check is the **CHANGELOG presence** row of Protocol 90 Step
-5.1's artifact table. It is the gate: a PR whose file list lacks `CHANGELOG.md`
-is redispatched rather than accepted as ready. Its pass condition becomes:
+5.1's artifact table. It is the gate: a PR whose file list lacks the required
+release-note artifact is redispatched rather than accepted as ready. The
+pass condition is now **branch-specific** rather than a single OR across every
+implementation branch type, and it matches only the strict top-level fragment
+grammar (Decision 1) — not `changelog.d/README.md`, not anything under
+`changelog.d/manifests/`, and not a malformed fragment name:
 
 ```text
-[.files[].path] | any(. == "CHANGELOG.md" or startswith("changelog.d/"))
+# feature/*, fix/*, refactor/*: a valid fragment, matching the top-level
+# grammar exactly (Decision 1's six kinds; no nested path)
+[.files[].path] | any(test(
+  "^changelog\\.d/[A-Za-z0-9][A-Za-z0-9_-]*\\.(added|changed|deprecated|removed|fixed|security)\\.[a-z0-9][a-z0-9-]*\\.md$"
+))
+
+# hotfix/*: unchanged — a versioned CHANGELOG.md section, never a fragment.
+# A fragment-only hotfix/* PR does not satisfy this gate, because the hotfix
+# path (Protocol 03 Path 4) still writes CHANGELOG.md directly (Decisions 4
+# and 5's Step 5.1 table row)
+[.files[].path] | any(. == "CHANGELOG.md")
 ```
 
 The complete set of surfaces that today assert or instruct "a release note was
@@ -261,7 +315,7 @@ recorded", each of which must accept a fragment:
 
 | Surface | What it asserts today | Change |
 | --- | --- | --- |
-| `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` Step 5.1 table | `CHANGELOG.md` in `files` for `feature/*`, `fix/*`, `refactor/*`, `hotfix/*` | Accept a `changelog.d/` path; keep `CHANGELOG.md` accepted for `hotfix/*` |
+| `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` Step 5.1 table | `CHANGELOG.md` in `files` for `feature/*`, `fix/*`, `refactor/*`, `hotfix/*` | Split into two branch-specific conditions: `feature/*`, `fix/*`, `refactor/*` require a strict-grammar `changelog.d/` fragment (not `CHANGELOG.md`, and not README/manifest/malformed paths under `changelog.d/`); `hotfix/*` still requires `CHANGELOG.md` exclusively — a fragment does not satisfy the hotfix gate |
 | `docs/workflow/development-workflow/protocols/03-implement-development-protocol.md` | Four per-path "Update CHANGELOG" steps and two PR-body "CHANGELOG entry preview" bullets | Paths 1–3 write a fragment; Path 4 (hotfix) unchanged; previews renamed to "release note preview" |
 | `REVIEW.md` (spec exemption, plan exemption, code-review checklist, reviewer-finding list) | Spec and plan branches must not touch `CHANGELOG.md`; code review flags a missing entry | Extend the exemptions to `changelog.d/`; restate the code-review item in terms of a release note |
 | `LLM_RULES.md` | "Do not skip CHANGELOG updates for feature/fix PRs" | Restate as "record a release note"; point at the fragment convention |
@@ -363,19 +417,28 @@ other workflow helpers, and every exit path prints its documented fields.
       Emits `PENDING_COUNT=<n>` and one `PENDING=<path>` per fragment.
       (Spec "Operational Visibility")
 - [ ] `assemble --version <X.Y.Z> [--date <YYYY-MM-DD>] [--reassemble]
-      [--allow-empty]` — freeze the set into
-      `changelog.d/manifests/v<X.Y.Z>.txt`, rename `## [Unreleased]` to the
-      version heading, merge fragment bullets per kind, and insert a fresh
-      empty `## [Unreleased]`. Emits `ASSEMBLE_RESULT`, `VERSION`,
+      [--allow-empty]` — acquire the per-release `mkdir` lock (Concurrent-
+      event-source addendum), write the manifest first (temp file, atomic
+      rename) into `changelog.d/manifests/v<X.Y.Z>.txt`, then rename
+      `## [Unreleased]` to the version heading, merge fragment bullets per
+      kind (from the manifest, not a rescan, when resuming), and insert a
+      fresh empty `## [Unreleased]`. Emits `ASSEMBLE_RESULT`, `VERSION`,
       `FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`, `MANIFEST_PATH`, and `ITEMS`.
-      (Spec AC-3, AC-5, AC-7, AC-10; Decisions 3 and 4)
-- [ ] `consume --version <X.Y.Z>` — delete the manifest-listed fragments and
-      the manifest. Emits `CONSUME_RESULT`, `REMOVED_COUNT`, `MANIFEST_PATH`.
-      (Spec AC-5, AC-7)
+      `ASSEMBLE_RESULT` includes `assembled_unmanifested` for the
+      manifest-absent, heading-present recovery state, and `locked` when the
+      lock is already held. (Spec AC-3, AC-5, AC-7, AC-10; Decisions 3 and 4)
+- [ ] `consume --version <X.Y.Z>` — acquire the same per-release lock, delete
+      the manifest-listed fragments, then move (not delete) the manifest to
+      `changelog.d/manifests/consumed/v<X.Y.Z>.txt`. Emits `CONSUME_RESULT`,
+      `REMOVED_COUNT`, `MANIFEST_PATH`. `CONSUME_RESULT` includes
+      `inconsistent` when neither manifest location holds the target version
+      but the version section is present, and `locked` when the lock is
+      already held. (Spec AC-5, AC-7; Decision 3)
 - [ ] Exit codes: `0` for `clean`, `assembled`, `already_assembled`,
-      `reassembled`, `consumed`, `already_consumed`; `1` for a validation or
-      assembly error; `3` for `no_notes` without `--allow-empty`; `64` for a
-      usage error, matching `check-documentation-stage-alignment.sh`.
+      `reassembled`, `consumed`, `already_consumed`; `1` for a validation,
+      assembly, `assembled_unmanifested`, `inconsistent`, or `locked` error;
+      `3` for `no_notes` without `--allow-empty`; `64` for a usage error,
+      matching `check-documentation-stage-alignment.sh`.
 - [ ] Reporting on assembly names each contributing item, and reports bullets
       carried over from the shared block as a single unattributed group, per
       the spec's Operational Visibility section.
@@ -388,6 +451,9 @@ New directory:
       scan by name.
 - [ ] `changelog.d/manifests/.gitkeep` — so the manifest directory exists on a
       fresh clone even though manifests exist only during a release.
+- [ ] `changelog.d/manifests/consumed/.gitkeep` — so the durable, post-publish
+      manifest archive (Decision 3) exists on a fresh clone even before any
+      release has been consumed.
 
 ### Infrastructure / Configuration
 
@@ -459,8 +525,10 @@ Protocols:
       polish guidance retargeted at the assembled draft, unchanged in
       substance), link-reference definitions (unchanged), consume the notes.
       Extend Step 7.2's release-artifact validation with the two checks that
-      prove consumption ran: `changelog.d/manifests/v<X.Y.Z>.txt` is absent and
-      `## [X.Y.Z] - YYYY-MM-DD` is present. (Spec AC-3, AC-4, AC-5, AC-8)
+      prove consumption ran: `changelog.d/manifests/consumed/v<X.Y.Z>.txt` is
+      present (not merely `changelog.d/manifests/v<X.Y.Z>.txt` absent — see
+      Decision 3) and `## [X.Y.Z] - YYYY-MM-DD` is present. (Spec AC-3, AC-4,
+      AC-5, AC-8)
 - [ ] `docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md`
       — extend Step 2.5 so the graduation PR is verified to carry the
       `changelog.d/` additions accumulated on `develop-<slug>`, alongside the
@@ -626,7 +694,7 @@ test in `scripts/development-workflow/tests/test-changelog-fragments.sh`.
 | 16 | Multiple top-level bullets in one fragment | Accepted; copied verbatim without renumbering |
 | 17 | Continuation lines indented by two spaces | Preserved verbatim; assembly never re-wraps |
 | 18 | CRLF line endings | Normalized to LF before insertion |
-| 19 | A body line beginning with `## [` | Copied verbatim and never interpreted; section boundaries are computed once from the pre-assembly `CHANGELOG.md`, and fragment bodies are opaque text thereafter. This is the overlapping-construct case |
+| 19 | A body line beginning with `## [` or `### ` | Rejected by `validate`, for the same reason as row 20: `check-changelog-duplicate-headers.sh` and `auto-tag-release.yml` re-parse `CHANGELOG.md` from scratch by matching `^## ` / `^### ` on raw lines, with no notion of "this line came from inside a fragment body." A verbatim-copied heading-shaped line would be interpreted as a real section or category boundary by every downstream consumer, even though the assembler's own single-pass boundary computation stays correct for that one run. Escaping (rather than rejecting) was considered and rejected: it would leave the releaser's rendered CHANGELOG.md containing an escaped artifact instead of the intended bullet, which is a worse outcome than asking the fragment's author to reword the line before assembly ever happens |
 | 20 | Trailing whitespace on a body line | Rejected by `validate`, so it fails on the item's PR rather than producing an MD009 failure on the assembled changelog |
 
 **Edge-case enumeration — changelog rewriting**
@@ -635,15 +703,18 @@ test in `scripts/development-workflow/tests/test-changelog-fragments.sh`.
 | --- | --- | --- |
 | 21 | No `## [Unreleased]` heading | Rejected; the heading is a precondition that `auto-tag-release.yml` also depends on |
 | 22 | Two `## [Unreleased]` headings | Rejected |
-| 23 | `## [X.Y.Z]` already present | `ASSEMBLE_RESULT=already_assembled`, exit 0, no write — the idempotence mechanism |
+| 23 | `## [X.Y.Z]` already present, manifest for that version also present in `changelog.d/manifests/` | `ASSEMBLE_RESULT=already_assembled`, exit 0, no write — the idempotence mechanism (Decision 3 requires both artifacts, not the heading alone) |
 | 24 | Populated shared block plus pending fragments | Both merged into one version section, each entry once, with no duplicate `### Category` heading |
 | 25 | Populated shared block, zero fragments | Rename only — the pre-fragment behaviour, preserved |
 | 26 | Empty shared block, zero fragments | `ASSEMBLE_RESULT=no_notes`, exit 3, unless `--allow-empty` |
 | 27 | A kind present in fragments but absent from the shared block | Heading created in canonical Keep a Changelog order |
 | 28 | Deterministic ordering | Bullets sorted by kind rank, then by the item field (numerically when it is all digits, lexicographically otherwise), then by full filename — so two runs on the same input produce identical bytes |
-| 29 | `consume` when the manifest is absent | `CONSUME_RESULT=manifest_missing`, non-zero, with the remediation named |
-| 30 | `consume` run twice | Second run reports `already_consumed`, exit 0 |
+| 29 | `consume` when the manifest is absent from both `changelog.d/manifests/` and `changelog.d/manifests/consumed/`, and the version section is also absent | `CONSUME_RESULT=manifest_missing`, non-zero, with the remediation named (run `assemble` first) |
+| 30 | `consume` run twice | First run reports `consumed`. Second run finds the manifest already moved to `changelog.d/manifests/consumed/` and reports `CONSUME_RESULT=already_consumed`, exit 0 |
 | 31 | `consume` when a manifest-listed file is already gone and the version section is absent | Rejected — the release state is inconsistent and must not be papered over |
+| 32 | `assemble` when the manifest for the target version is present but the `## [X.Y.Z]` heading is absent (interrupted between the two writes) | `assemble` completes the `CHANGELOG.md` write from the already-frozen manifest, never a rescan. `ASSEMBLE_RESULT=assembled`, exit 0 |
+| 33 | `assemble` when the `## [X.Y.Z]` heading is present but the manifest for that version is absent from both manifest locations | `ASSEMBLE_RESULT=assembled_unmanifested`, exit 1, naming `assemble --reassemble` as the remediation |
+| 34 | `consume` when neither manifest location holds the target version but the `## [X.Y.Z]` version section is present | `CONSUME_RESULT=inconsistent`, exit 1 — no longer conflated with `already_consumed`; the operator must reconcile by hand |
 
 **Suppression semantics**: not applicable. `changelog-fragments.sh` recognizes
 no inline suppression directives. Declining to write a release note is
@@ -652,15 +723,43 @@ expressed by not creating a fragment, exactly as declining to edit
 
 ### Concurrent-event-source addendum
 
-**Not applicable.** `changelog-fragments.sh` is a single-threaded command-line
-helper with no listeners, timers, sockets, or async queues, and no state shared
-across execution contexts. Each item below is recorded as not applicable for
-that reason: shared mutable state guards, re-entrancy and in-flight tracking,
-event deduplication, listener and resource cleanup, initialization races,
-teardown races, and error propagation across async boundaries. The concurrency
-this feature addresses is between independent git branches, and it is handled
-structurally — by disjoint file paths (Decision 1) — not by runtime
-synchronization.
+**Partially applicable, split by scope.** `changelog-fragments.sh` is a
+single-threaded command-line helper with no listeners, timers, sockets, or
+async queues, so every *in-process* async concern is not applicable: event
+deduplication, listener and resource cleanup, and error propagation across
+async boundaries. The concurrency between independent item PRs is likewise not
+applicable to runtime synchronization — it is handled structurally, by
+disjoint fragment file paths (Decision 1), before any of these commands run.
+
+**Concurrent *process* invocation on the same release branch is a real,
+narrower case**, and this plan does not leave it unguarded: `assemble` and
+`consume` both rewrite `CHANGELOG.md` and the manifest across several
+non-atomic file operations (Decision 3), so two invocations racing on the
+same release branch checkout could interleave and produce exactly the
+lost-note or inconsistent-state outcomes the spec's "no unreleased note may be
+silently left behind" rule forbids. This repository already has a precedent
+for this exact shape of problem: `prepare-release-post-merge-cleanup.sh`
+guards its own shared release-state mutation with an `mkdir`-based lock,
+scoped to the coordinating checkout's git-dir (not the tracked working tree),
+that fails clearly with a non-zero exit and a named remediation when already
+held, rather than allowing a second run to interleave.
+
+`assemble` and `consume` follow the same convention: before performing any
+write, each acquires an `mkdir`-created lock directory at
+`$(git rev-parse --git-dir)/changelog-fragments-locks/v<X.Y.Z>.lock`, scoped
+per target version (so `assemble` for `0.44.0` never blocks `consume` for
+`0.43.0`), and removes it on exit via a `trap`. If the `mkdir` fails because
+the lock is already held, the command exits non-zero immediately with
+`ASSEMBLE_RESULT=locked` / `CONSUME_RESULT=locked`, the lock directory path,
+and the instruction to retry once the other invocation completes — it never
+waits or retries silently. This is a bounded, single-checkout mitigation, the
+same known limitation `prepare-release-post-merge-cleanup.sh` documents for
+its own lock: it does not exclude a concurrent run from a different clone or
+worktree of the same release branch, and the plan does not claim otherwise.
+The test suite (Implementation Order Step 2) adds one interleaving case per
+command: start a run, hold its lock open, start a second run of the same
+command against the same version, and assert the second run reports `locked`
+and makes no write.
 
 ---
 
@@ -675,8 +774,10 @@ readiness check.
 
 | Gate inputs | Outcome | Required next action | Mirror surfaces |
 | --- | --- | --- | --- |
-| No `## [X.Y.Z]` heading; at least one pending fragment or a non-empty shared block | `assembled` | Continue to the editorial pass (Protocol 05 Step 3) | Protocol 05; `.claude/commands/prepare-release.md`; `.cursor/commands/prepare-release.md`; `.agents/skills/prepare-release/SKILL.md` |
-| `## [X.Y.Z]` heading already present | `already_assembled` | No write; continue. This is the resume path and the idempotence guarantee | Same |
+| No manifest for the target version; no `## [X.Y.Z]` heading; at least one pending fragment or a non-empty shared block | `assembled` | Continue to the editorial pass (Protocol 05 Step 3) | Protocol 05; `.claude/commands/prepare-release.md`; `.cursor/commands/prepare-release.md`; `.agents/skills/prepare-release/SKILL.md` |
+| Manifest for the target version present; `## [X.Y.Z]` heading also present | `already_assembled` | No write; continue. This is the resume path and the idempotence guarantee — both artifacts, not the heading alone (Decision 3) | Same |
+| Manifest for the target version present; `## [X.Y.Z]` heading absent | `assembled` | Interrupted between the two writes. Complete the `CHANGELOG.md` write from the already-frozen manifest, never a rescan; continue to the editorial pass | Same |
+| Manifest for the target version absent; `## [X.Y.Z]` heading present | `assembled_unmanifested` (exit 1) | Stop; run `assemble --reassemble` to deterministically regenerate the manifest, then continue | Protocol 05 Step 3 |
 | `--reassemble` passed and the heading is present | `reassembled` | Print the replaced section first; the releaser must redo any editorial pass | Same |
 | No pending fragment and an empty shared block | `no_notes` (exit 3) | Stop; either there is nothing to release or a fragment was lost. Pass `--allow-empty` only for a deliberate no-notes release | Same |
 | Any fragment fails the grammar or body checks | `invalid` (exit 1) | Fix the named fragment on `develop` and re-run; never assemble a partial set | Protocol 05; `.github/workflows/markdown-lint.yml` |
@@ -686,10 +787,11 @@ readiness check.
 
 | Gate inputs | Outcome | Required next action | Mirror surfaces |
 | --- | --- | --- | --- |
-| Manifest present, listed files present | `consumed` | Commit the deletions with the release commit | Protocol 05 Step 3 |
-| Manifest absent, version section present | `already_consumed` | Continue; the step already ran | Protocol 05 Steps 3 and 7.2 |
-| Manifest absent, version section absent | `manifest_missing` (non-zero) | Run `assemble` first | Protocol 05 Step 3 |
-| Manifest present, a listed file missing, version section absent | `error` (exit 1) | Stop and reconcile by hand; the release state is inconsistent | Protocol 05 Step 7.2 |
+| Manifest present in `changelog.d/manifests/`, listed files present | `consumed` | Commit the deletions and the manifest move (to `changelog.d/manifests/consumed/`) with the release commit | Protocol 05 Step 3 |
+| Manifest present in `changelog.d/manifests/consumed/`, absent from `changelog.d/manifests/` | `already_consumed` | Continue; confirmed by the moved file's presence, not by absence | Protocol 05 Steps 3 and 7.2 |
+| Manifest absent from both locations, version section absent | `manifest_missing` (non-zero) | Run `assemble` first | Protocol 05 Step 3 |
+| Manifest absent from both locations, version section present | `inconsistent` (exit 1) | Stop and reconcile by hand; no longer conflated with `already_consumed` | Protocol 05 Step 7.2 |
+| Manifest present in `changelog.d/manifests/`, a listed file missing, version section absent | `error` (exit 1) | Stop and reconcile by hand; the release state is inconsistent | Protocol 05 Step 7.2 |
 
 ### Gate C — release-note readiness (changed, not added)
 
@@ -801,16 +903,20 @@ changelog.d/1589.fixed.integration-branch-ci.md
 
 1. **Create the directory and its reference.** Add `changelog.d/README.md`
    documenting the grammar, the six kinds, and the body convention, and
-   `changelog.d/manifests/.gitkeep`. (Decisions 1, 2, 7)
+   `changelog.d/manifests/.gitkeep` and
+   `changelog.d/manifests/consumed/.gitkeep`. (Decisions 1, 2, 7)
 
-   *Verify*: `ls changelog.d` lists the README and the manifests directory, and
+   *Verify*: `ls changelog.d` lists the README and the manifests directory,
+   `ls changelog.d/manifests` lists the `consumed` subdirectory, and
    `node_modules/.bin/markdownlint-cli2 "changelog.d/README.md"` reports no
    violations.
 
 2. **Write the test suite first, red.** Create
    `scripts/development-workflow/tests/test-changelog-fragments.sh` with one
-   case per row of the three parser-risk tables, plus its `# covers:` header
-   lines. Every case fails at this point because the helper does not exist.
+   case per row of the three parser-risk tables, one interleaving case per
+   command for the per-release lock (Concurrent-event-source addendum), plus
+   its `# covers:` header lines. Every case fails at this point because the
+   helper does not exist.
 
    *Verify*: running the suite reports failures for every case and no case is
    silently skipped.
@@ -821,19 +927,25 @@ changelog.d/1589.fixed.integration-branch-ci.md
    *Verify*: the filename-grammar and fragment-body cases in the suite pass;
    the changelog-rewriting cases still fail.
 
-4. **Implement `assemble`.** Manifest write, heading rename, per-kind merge,
-   fresh empty `## [Unreleased]`, deterministic ordering, and the
-   already-assembled and no-notes outcomes.
+4. **Implement `assemble`.** The per-release `mkdir` lock (Concurrent-event-
+   source addendum), manifest-first write (temp file, atomic rename), heading
+   rename, per-kind merge, fresh empty `## [Unreleased]`, deterministic
+   ordering, and all four assembly states from Decision 3 (`assembled`,
+   `already_assembled`, the manifest-present/heading-absent resume, and
+   `assembled_unmanifested`), plus `no_notes`.
 
    *Verify*: the changelog-rewriting cases pass, and the suite's assembled
    fixtures are checked with `check-changelog-duplicate-headers.sh` and
    `markdown-heuristic-lint.py` inside the suite itself.
 
-5. **Implement `consume`.** Manifest-driven deletion, the already-consumed
-   outcome, and the inconsistent-state rejection.
+5. **Implement `consume`.** The per-release `mkdir` lock, manifest-driven
+   deletion, moving (not deleting) the manifest into
+   `changelog.d/manifests/consumed/`, the `already_consumed` outcome (detected
+   from the moved file's presence), and the `inconsistent` rejection when
+   neither manifest location holds the target version.
 
-   *Verify*: the whole suite passes. Run it twice in a row and confirm the
-   second run reports the same result as the first.
+   *Verify*: the whole suite passes. Run `consume` twice in a row and confirm
+   the first run reports `consumed` and the second reports `already_consumed`.
 
 6. **Wire the lint and CI surfaces.** Update
    `.github/workflows/markdown-lint.yml` (`paths:`, both independent

--- a/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
+++ b/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
@@ -122,6 +122,19 @@ Two notes from the **same** item (for example one `added` and one `fixed`) live
 on one branch, where the author sees both files; that is an ordinary
 same-branch edit, not a cross-branch merge.
 
+**Named exception — an explicitly approved split.** The guard's
+`--allow-split true` path (Protocol 03) exists precisely to let two branches
+carry the same tracker identifier at once, on explicit parent-run approval.
+In that documented case two split branches could each write a fragment for
+the same `<item>`, and if both authors independently choose the same
+`<kind>.<slug>` the paths collide — this is the one case where "impossible"
+is not literal. It surfaces as an ordinary same-path git conflict, which
+Decision 6 already classifies as non-trivial and routes to human resolution
+rather than auto-combining, so no note is silently lost or merged
+incorrectly; only the "cannot happen at all" framing is narrowed to "cannot
+happen outside an explicitly human-approved split, and is safely caught as a
+conflict if it does."
+
 Repositories with no issue tracker fall back to the branch slug as `<item>`.
 Uniqueness then rests on branch-name uniqueness, which git already enforces for
 concurrently existing branches.
@@ -379,16 +392,32 @@ New directory:
 ### Infrastructure / Configuration
 
 - [ ] `.github/workflows/markdown-lint.yml` — add `changelog.d/**` to the
-      `paths:` filter, add the directory to the file-collection step and the
-      `markdownlint-cli2` target list, and add a step running
-      `changelog-fragments.sh validate` so a malformed fragment fails on the
-      item's own PR rather than at release time. (Spec AC-9)
+      `paths:` filter. The file has **two independent file-discovery blocks**,
+      not one: the `find` in the "Collect target markdown files" step, and a
+      second, separately duplicated `find` inside the "Run heuristic lint
+      checks" step; the `markdownlint-cli2` step uses its own literal glob
+      list. Add `changelog.d/**` to all three (the two `find` commands and the
+      `markdownlint-cli2` glob list) so fragments get both lint passes, not
+      only `markdownlint-cli2`. Add a step running `changelog-fragments.sh
+      validate` so a malformed fragment fails on the item's own PR rather than
+      at release time. (Spec AC-9)
 - [ ] `sync-manifest.yaml` — one `always_sync` entry for
       `changelog.d/README.md`, `mode_scope: shared`, with a note recording that
       fragment files are intentionally unlisted. (Spec AC-12; Decision 7)
 - [ ] `.haystack/pr-rules.yml` — retarget the
       `keep-single-unreleased-changelog-section` rule message to hotfix and
       release edits.
+- [ ] `.haystack/review-policy.md` — add `changelog.d/**` to the "Review
+      release and changelog automation" section's path list (currently
+      `CHANGELOG.md`, `.github/workflows/auto-tag-release.yml`, severity
+      `critical`). That section's stated reason — "version parsing or
+      changelog structure mistakes can create incorrect release tags that are
+      hard to undo" — applies verbatim to `changelog-fragments.sh`'s
+      `assemble`/`consume` rewriting and to the `changelog.d/manifests/*.txt`
+      state files; without this the new automation and state files fall back
+      to the generic `scripts/development-workflow/**` = `high` policy row (or
+      no row at all for `changelog.d/manifests/`), one severity level below
+      what its own risk rationale calls for.
 - [ ] Verified as needing **no** change: `.github/workflows/auto-tag-release.yml`
       (reads published version sections only), `.markdownlint.jsonc` and
       `.markdownlint-cli2.jsonc` (rule set is file-agnostic),
@@ -807,13 +836,16 @@ changelog.d/1589.fixed.integration-branch-ci.md
    second run reports the same result as the first.
 
 6. **Wire the lint and CI surfaces.** Update
-   `.github/workflows/markdown-lint.yml` (`paths:`, the collection step, the
-   lint targets, and a `validate` step).
+   `.github/workflows/markdown-lint.yml` (`paths:`, both independent
+   file-discovery `find` blocks, the `markdownlint-cli2` glob list, and a
+   `validate` step).
 
    *Verify*: `bash scripts/development-workflow/select-test-suites.sh
    --changed-files <file listing the changed paths>` lists
-   `test-changelog-fragments.sh`, and running the repository's markdown lint
-   commands locally passes.
+   `test-changelog-fragments.sh`; running the repository's markdown lint
+   commands locally passes; and running `python3
+   scripts/lint/markdown-heuristic-lint.py` against a file under
+   `changelog.d/` confirms it is picked up (not just `markdownlint-cli2`).
 
 7. **Update the release path.** Protocol 05 Step 3 (assemble, editorial pass,
    link definitions, consume) and Step 7.2's artifact validation, then the three
@@ -843,11 +875,12 @@ changelog.d/1589.fixed.integration-branch-ci.md
    change was introduced.
 
 10. **Update the review contract and remaining documentation.** `REVIEW.md`,
-    `LLM_RULES.md`, `.haystack/pr-rules.yml`, the `haystack-reviewer.sh`
-    comment block (including the corrected rule id),
-    `haystack-triage.md`, `AGENTS.md`, `README.md`, both best-practices files,
-    both script READMEs, the spec and plan protocols, the plan template, and
-    `docs/testing/workflow/batch-merge.smoke-test.md`.
+    `LLM_RULES.md`, `.haystack/pr-rules.yml`, `.haystack/review-policy.md`
+    (add `changelog.d/**` to the release-and-changelog-automation path list),
+    the `haystack-reviewer.sh` comment block (including the corrected rule
+    id), `haystack-triage.md`, `AGENTS.md`, `README.md`, both best-practices
+    files, both script READMEs, the spec and plan protocols, the plan
+    template, and `docs/testing/workflow/batch-merge.smoke-test.md`.
 
     *Verify*: `bash scripts/development-workflow/tests/test-haystack-reviewer.sh`
     passes, and the rule id quoted in the script matches an id present in

--- a/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
+++ b/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
@@ -15,14 +15,18 @@ two different items always write different paths, and git does not conflict
 across different paths — the collision is removed by construction rather than
 resolved more cleverly. A new helper,
 `scripts/development-workflow/changelog-fragments.sh`, gathers the pending
-notes at release time into a draft `## [X.Y.Z]` section in `CHANGELOG.md`
-(`assemble`) and removes them in a separate, later step (`consume`), so an
-interrupted release loses neither notes nor the releaser's edits. Assembly also
-carries whatever is still sitting in the shared `## [Unreleased]` block into
-the same version section, which is what makes the transition release work
-without a migration and without a one-release-only code path. Every readiness
-check, protocol, agent surface, and lint that today asserts "this PR touched
-`CHANGELOG.md`" is updated to accept a fragment instead.
+notes at release time into a draft `## [X.Y.Z]` section in `CHANGELOG.md` and
+deletes the fragments it gathered, **in the same `assemble` invocation** —
+both as ordinary uncommitted edits on the release branch, riding along on
+Protocol 05's existing single release commit (Decision 3). An interrupted
+release loses neither notes nor the releaser's edits for the same reason an
+interrupted editorial pass already doesn't today: nothing is durable until
+that one commit runs. Assembly also carries whatever is still sitting in the
+shared `## [Unreleased]` block into the same version section, which is what
+makes the transition release work without a migration and without a
+one-release-only code path. Every readiness check, protocol, agent surface,
+and lint that today asserts "this PR touched `CHANGELOG.md`" is updated to
+accept a fragment instead.
 
 **Estimated complexity**: L
 
@@ -55,9 +59,9 @@ the new code this plan adds.
 | Category headers in the shared block | Headings between `## [Unreleased]` and the next `## [` heading | `### Added`, `### Fixed`, `### Changed` |
 | Readiness assertion on `CHANGELOG.md` | `grep -n "CHANGELOG presence" docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` | Step 5.1 artifact table, one row; pass condition is `[.files[].path] \| any(. == "CHANGELOG.md")` for `feature/*`, `fix/*`, `refactor/*`, `hotfix/*` |
 | `PR_HAS_CHANGELOG` semantics | Read `fetch_pr_meta` and `cmd_discover` in `scripts/development-workflow/batch-merge.sh` | It is a **merge-ordering** signal (non-CHANGELOG PRs merge first), not a readiness gate. The issue body's description of it as an assertion is inaccurate; this plan does not change its meaning |
-| Release scope parser | Read `append_issues_from_changelog` in `scripts/development-workflow/prepare-release-post-merge-cleanup.sh` | Extracts `#N` tokens from the published `## [X.Y.Z]` section. Requires no change **provided** assembled bullets keep the `(#N)` reference, which the fragment body convention mandates |
+| Release scope parser | Read `append_issues_from_changelog` in `scripts/development-workflow/prepare-release-post-merge-cleanup.sh` | Extracts `#N` tokens from the published `## [X.Y.Z]` section. Requires no change **provided** assembled bullets keep the `(#N)` reference, which the fragment body convention mandates except in the no-tracker fallback (Decision 1) — there, no `#N` exists to extract, so that bullet is correctly absent from the scope, exactly as it would be if hand-written without a reference today |
 | Hotfix tagging path | Read `.github/workflows/auto-tag-release.yml` | Reads only `CHANGELOG.md` version sections; the hotfix path writes those directly and is untouched by this plan |
-| Haystack rule identifier | `grep -n "changelog" .haystack/pr-rules.yml` and the comment block in `scripts/development-workflow/haystack-reviewer.sh` | The live rule id is `keep-single-unreleased-changelog-section`; the script's comment names `keep-changelog-unreleased-structure-canonical`, which does not exist in the rules file. Pre-existing drift, observed but not yet corrected — the fix is scheduled for Implementation Order Step 10 and is out of scope for this plan-writing PR |
+| Haystack rule identifier | `grep -n "changelog" .haystack/pr-rules.yml` and the comment block in `scripts/development-workflow/haystack-reviewer.sh` | The live rule id is `keep-single-unreleased-changelog-section`; the script's comment names `keep-changelog-unreleased-structure-canonical`, which does not exist in the rules file. Pre-existing drift, observed but not yet corrected — the fix is scheduled for Implementation Order Step 9 and is out of scope for this plan-writing PR |
 | Documentation-stage allowlist | Read `path_allowed_for_stage` in `scripts/development-workflow/check-documentation-stage-alignment.sh` | `spec/*` and `implementation-plan/*` allow only their own stage artifacts, so a fragment on a documentation-stage branch is correctly reported as unexpected. No change needed |
 | CI suite selection | Read the `# covers:` convention in `scripts/development-workflow/select-test-suites.sh` | A suite named `test-changelog-fragments.sh` covers `changelog-fragments.sh` by naming convention with no workflow edit |
 | Sync manifest precedence | Read the precedence paragraph in `sync-manifest.yaml` | Only "project-specific exact path beats always-sync directory glob" is defined. The reverse is undefined, so this plan lists **only** `changelog.d/README.md` and leaves downstream fragment files unlisted (the manifest header already states unlisted files are never synced) |
@@ -135,15 +139,28 @@ incorrectly; only the "cannot happen at all" framing is narrowed to "cannot
 happen outside an explicitly human-approved split, and is safely caught as a
 conflict if it does."
 
-Repositories with no issue tracker fall back to the branch slug as `<item>`.
-Uniqueness then rests on branch-name uniqueness, which git already enforces for
-concurrently existing branches.
+**Repositories with no issue tracker configured** (`issue_tracker.provider:
+none` or absent) fall back to a **sanitized branch identifier** as `<item>`:
+the branch name with its type prefix (`feature/`, `fix/`, `refactor/`)
+removed, and every remaining `/` or character outside `[A-Za-z0-9_-]`
+replaced with `-` — for example `fix/improve-caching` becomes
+`fix-improve-caching`. This is grammar-safe by construction (no `/` can
+survive into the filename) and repository-wide unique for the same reason a
+bare tracker identifier is: git already refuses two concurrently existing
+branches of the identical name, so at most one branch is authoring notes
+under a given sanitized identifier at a time — the same discriminator this
+repository's own `<item>` relies on, just computed over the whole slug
+instead of one field pulled out of it. In this mode the body's `(#N)`
+reference (Decision 2's worked examples) is **omitted entirely** — there is
+no issue number to reference, and `changelog.d/README.md` states this
+exception explicitly so an author does not invent a placeholder number that
+`validate` has no way to distinguish from a real one.
 
 **Corollary that must not be violated**: `changelog.d/` carries no index,
-ordering file, or aggregate manifest that every item edits. Any such file would
-be a shared path and would recreate exactly the conflict this item removes. The
-per-release manifest introduced by Decision 3 is written only by the releaser,
-on the release branch, and is never touched by item branches.
+ordering file, or aggregate manifest that every item edits, ever. Any such
+file would be a shared path and would recreate exactly the conflict this item
+removes. (Decision 3 confirms release preparation introduces no such file
+either — see "Why no manifest.")
 
 ### Decision 2 — Change-kind encoding
 
@@ -171,212 +188,170 @@ hyphen-separated grammar is ambiguous and, worse, silently mis-parses
 four-way split on `.` is unambiguous for every legal name and rejects every
 illegal one.
 
-### Decision 3 — Consumption semantics: how "assembled but not yet published" is represented
+### Decision 3 — Consumption semantics: fragments are deleted at assembly, not at a separate later step
 
-The state is represented by **two artifacts that exist together only between
-assembly and publication**, both living on the release branch, **written in a
-fixed order so an interruption between them lands on a detected, named state
-rather than an ambiguous one**:
+**Revised.** The first draft of this decision represented "assembled but not
+yet published" with a separate durable artifact (a per-release manifest) and
+a separate `consume` command, on the theory that assembly and publication
+were necessarily far apart in time and needed their own crash-recovery state
+machine. Three CodeRabbit rounds on that design (10 findings, then 4, then 12)
+each fixed the previous round's gaps by adding another artifact, command flag,
+or exit state — a manifest, then `changelog.d/manifests/consumed/`, then
+`--repair-manifest`, `history_truncated`, `not_assembled`, a per-release lock,
+an owner-record file — and each addition reopened a new interruption window
+of its own. That trend, not any single finding, is the signal that the
+design was wrong, not merely incomplete: **the recovery apparatus had become
+the dominant complexity in a plan whose actual job is putting each entry in
+its own file.**
 
-1. A release manifest at `changelog.d/manifests/v<X.Y.Z>.txt`, naming exactly
-   the fragment files that will feed the draft, one repository-relative path
-   per line, preceded by a single comment line recording the assembly
-   timestamp, the fragment count, and the count of bullets carried over from
-   the shared block. **Written first**, via a temp file plus atomic rename,
-   so its existence durably commits to one specific fragment set before
-   `CHANGELOG.md` is touched.
-2. The draft `## [X.Y.Z] - YYYY-MM-DD` section written into `CHANGELOG.md`,
-   built from exactly the fragment set already recorded in the manifest —
-   never a fresh directory scan. **Written second**, and with the same
-   atomicity guarantee as the manifest: the full new file content is written
-   to a temp file in the same directory, flushed and `fsync`'d, then renamed
-   over `CHANGELOG.md` in one `rename(2)` call. A process stop during this
-   step therefore never produces a truncated or partially-rewritten
-   `CHANGELOG.md` — on disk, the file is always either byte-for-byte the
-   pre-assembly content or byte-for-byte the fully assembled content, with no
-   third possibility. This is what makes the four states below exhaustive:
-   without it, a stop mid-rewrite would leave a *fifth*, undetectable state (a
-   corrupt file) that none of them names.
+**Corrected**: `assemble` writes the version section into `CHANGELOG.md`
+*and* deletes the fragment files that fed it, **in the same invocation**,
+both as ordinary uncommitted working-tree edits. There is no manifest, no
+`consume` command, no lock, and no separate "assembled but not consumed"
+state to represent, because there is no longer a gap between the two
+mutations for anything to sit in.
 
-Fragment files themselves are **not touched by assembly**. This is the literal
-requirement from the spec ("Assembling a draft never destroys anything") and
-from the tracker handoff, which records that the first spec draft left the
-interrupted case undefined and that any design where assembly destroys or moves
-fragments violates the corrected clause.
+**Why no manifest.** Read literally, Protocol 05 already has exactly **one**
+commit for this entire span. Its existing, unmodified Step 3 does the
+editorial polish, the heading rename, and the link-reference definitions —
+all in the working tree — and Step 5, immediately after Step 4's version
+bump, is the *only* "Commit" step in the whole protocol. Nothing today
+commits the assembled draft separately from the editorial pass; the working
+tree simply sits, uncommitted, for however long the polish takes, exactly as
+it always has. A manifest-based recovery model implicitly assumed assembly
+and consumption were separated by an unknown, possibly-long span that needed
+its own durability guarantee — but Protocol 05 was never designed that way,
+and the previous round's fix (adding two brand-new commits inside Step 3 so
+the manifest would have something to be "restored from") was solving a
+problem this plan itself introduced, not one the protocol had. Once assembly
+and deletion share a single working-tree edit that rides along on Protocol
+05's *existing, unmodified* Step 5 commit, there is nothing for a manifest to
+record that the commit's own diff doesn't already show.
 
-- **The set is fixed at assembly.** Once the manifest is written, it — not a
-  fresh directory scan — is the authority for what this release contains. A
-  fragment added afterwards (on `develop`, or cherry-picked onto the release
-  branch as part of a late fix) is absent from the manifest and is therefore
-  not in this release. It stays in `changelog.d/` and is picked up by the next
-  assembly.
-- **Assembly's four states are each named, and none is inferred.** `assemble`
-  checks the manifest for the target version and the `## [X.Y.Z]` heading
-  independently:
-  - Manifest present, heading present: `ASSEMBLE_RESULT=already_assembled`,
-    exit 0, no write. The normal resume path.
-  - Manifest present, heading absent: the run was interrupted between the two
-    writes — and, because the `CHANGELOG.md` write is itself atomic (point 2
-    above), `CHANGELOG.md` on disk is guaranteed to still be exactly its
-    pre-assembly content, never a partial rewrite. `assemble` performs the
-    `CHANGELOG.md` write (temp file, `fsync`, atomic rename) from the
-    already-frozen manifest, not a rescan, then reports
-    `ASSEMBLE_RESULT=assembled`, exit 0. Because the set was fixed before the
-    interruption, this is safe even if new fragments landed on `develop`
-    afterward — "the set is fixed at assembly" still holds.
-  - Manifest absent, heading present: the manifest was lost by something other
-    than `consume` (which moves it — see below — rather than deleting it),
-    since assembly never reaches the `CHANGELOG.md` write before the manifest
-    is committed. `assemble` reports `ASSEMBLE_RESULT=assembled_unmanifested`,
-    a non-zero exit. **The remediation is `assemble --repair-manifest`, never
-    a live directory rescan.** A rescan is explicitly wrong here: the spec
-    guarantees a note recorded after assembly belongs to the next release,
-    never retroactively to the one being prepared, and a fragment can
-    legitimately have landed in `changelog.d/` between the original assembly
-    and the manifest's loss (a late fix cherry-picked onto the release branch,
-    for instance). Recomputing "the current set" would silently pull that
-    fragment into an already-published-looking section. `--repair-manifest`
-    instead restores the manifest from the one source that reflects the set
-    **as it was at assembly time**: git history. It walks the current
-    branch's log for `changelog.d/manifests/v<X.Y.Z>.txt` and selects the
-    **most recent** commit that wrote that exact path — the path can
-    legitimately be written more than once (an earlier `--repair-manifest`, or
-    an explicit `--reassemble`, both write it again), and the most recent
-    write is always the one that reflects the currently-authoritative content,
-    never an earlier one. If such a commit exists, it restores that commit's
-    blob verbatim (`git show <commit>:<path>`), through the same temp-file,
-    `fsync`, atomic-rename discipline as every other write in this plan — a
-    stop mid-restore therefore lands on the still-absent manifest (safe to
-    retry), never a half-written one, which is what keeps this recovery path
-    from reopening the "fifth, undetectable corrupt state" the atomic-rename
-    discipline exists to rule out. On success it reports
-    `ASSEMBLE_RESULT=repaired`, exit 0. Before concluding no commit exists,
-    `--repair-manifest` checks `git rev-parse --is-shallow-repository`: a
-    shallow clone truncates the log before it reaches a commit that exists but
-    is outside the fetched depth, which is a clone-configuration problem, not
-    a data-loss one. In that case it reports a distinct
-    `ASSEMBLE_RESULT=history_truncated`, exit 1, naming `git fetch
-    --unshallow` as the remediation, rather than `manifest_unrecoverable`,
-    which would wrongly imply the data itself is gone. Only on a full clone,
-    with no commit ever having written that path (the manifest was lost before
-    it was committed), does `--repair-manifest` **refuse to guess**: it
-    reports `ASSEMBLE_RESULT=manifest_unrecoverable`, exit 1, and instructs
-    the operator to reconcile by hand — compare the `## [X.Y.Z]` section's
-    bullets against the fragment bodies still present in `changelog.d/` to
-    reconstruct the original set, or, only as a knowing last resort whose risk
-    the operator accepts explicitly, fall back to `assemble --reassemble` (see
-    below), which is never invoked automatically. `--reassemble` recomputes
-    and writes the manifest and rewrites `CHANGELOG.md` in the identical
-    manifest-first, atomic-rename order as a normal `assemble`, so a stop
-    mid-`--reassemble` also lands on one of the named states above rather than
-    a sixth, undocumented one.
-  - Manifest absent, heading absent: nothing has happened yet; `assemble` runs
-    normally.
-- **Interrupted preparation resumes intact — because Protocol 05 commits
-  twice inside Step 3, not only once at Step 5.** "Both artifacts are
-  ordinary committed files on the release branch" is true only if something
-  commits them, and Protocol 05's existing single "Commit" step (Step 5) runs
-  *after* Step 3's assemble, editorial pass, link-reference definitions, and
-  `consume` have all already happened. Left at that, the manifest and the
-  editorial pass would sit uncommitted for the entire span this design exists
-  to protect, and `--repair-manifest`'s git-history restore would find
-  nothing to restore for the whole of that span. The Layer-by-Layer Changes
-  entry restructuring Protocol 05 Step 3 therefore adds two commits inside it,
-  both before Step 5's version-bump commit: one immediately after `assemble` succeeds
-  (before the editorial pass touches anything), and one after the editorial
-  pass and link-reference definitions, immediately before `consume` runs.
-  With those in place, resuming on the *same* working tree needs no git
-  operation at all — the temp+rename writes already persisted to disk — and
-  resuming on a *different* clone, or after the original working tree is
-  lost, is `git checkout` of the release branch followed by re-running
-  `assemble`, which lands on one of the four states above because the
-  manifest and the editorial pass are both already committed. If the release
-  branch is discarded entirely, `develop` still holds every fragment, because
-  nothing was ever deleted there — but the releaser's editorial pass is not
-  on `develop`, and is genuinely lost in that specific scenario; only a
-  discarded *working tree*, not a discarded *branch*, is protected by the two
-  intermediate commits.
-- **Consumption requires a publishable section, not just a manifest.** Before
-  deleting anything, `consume` checks the manifest **and** the `## [X.Y.Z]`
-  heading — the same two facts `assemble` checks, in the same order of
-  concern. A manifest can exist while the heading does not: that is exactly
-  the "manifest present, heading absent" interrupted-assembly state above,
-  and it means assembly never finished writing the section. If `consume` ran
-  anyway, it would delete the source fragments and move the manifest with no
-  version section to show for them — the release's notes would be gone with
-  nothing published, which is precisely the "no unreleased note may be
-  silently left behind" failure the spec forbids. So: manifest present,
-  heading absent → `CONSUME_RESULT=not_assembled`, non-zero exit, deletes
-  nothing, and names the remediation: run `assemble` first (which completes
-  the interrupted write and lands on `already_assembled`, at which point
-  `consume` is safe).
-- **Consumption happens at publication, and its idempotence marker is a
-  positive fact, not an absence.** Once the section-exists precondition
-  passes, `consume` deletes the fragment files named in the manifest one at a
-  time, then **moves** — never deletes — the manifest itself to
-  `changelog.d/manifests/consumed/v<X.Y.Z>.txt` via a single `rename(2)` call
-  (both paths are on the same filesystem, under `changelog.d/`), so the move
-  itself cannot be interrupted into a state where the manifest is absent from
-  both locations — the "absent from both" state below can only result from
-  something outside these two commands, never from `consume`'s own crash
-  window. This both strengthens the spec's Audit Trail principle (a permanent
-  record of what fed each published release) and removes the ambiguity a
-  delete would otherwise reintroduce, as a commit on the release branch:
-  - Heading present, manifest present in `changelog.d/manifests/`, every
-    listed file present: normal `consumed` path.
-  - Heading present, manifest present in `changelog.d/manifests/`, **some or
-    all** listed files already absent: an interrupted consume — a prior run
-    stopped after deleting some fragments but before moving the manifest.
-    Per-file deletion is idempotent (skipping a file that is already gone is
-    not an error), so resuming simply finishes deleting whatever remains and
-    then performs the manifest move. This still reports
-    `CONSUME_RESULT=consumed`, exit 0 — from the operator's point of view, the
-    step that was interrupted just completes.
-  - Manifest present in `changelog.d/manifests/consumed/`, absent from
-    `changelog.d/manifests/`: `CONSUME_RESULT=already_consumed`, exit 0 —
-    confirmed by the moved file's presence, not its absence.
-  - Manifest absent from **both** locations, heading present: no longer
-    conflated with `already_consumed`. Reports `CONSUME_RESULT=inconsistent`,
-    non-zero exit, and instructs the operator to reconcile by hand — this is
-    `assembled_unmanifested`'s sibling failure mode surfacing at `consume`
-    time instead of `assemble` time (both manifest locations empty is not a
-    state either command's normal flow produces), and it must fail loudly for
-    the same reason.
-  Those deletions and the manifest move reach `main` and `develop` only when
-  the release PRs merge — which is what "published" means. An abandoned
-  release deletes nothing anywhere that survives.
-- **Re-assembly is possible but explicit, and is not a recovery mechanism.**
-  `assemble --reassemble` recomputes the manifest from the current directory
-  and replaces the existing version section. It prints the section it is
-  about to replace before replacing it, because that section may contain the
-  releaser's editorial pass. It is the only path that discards editorial
-  edits, it is never invoked by protocol 05's normal flow, and — unlike
-  `--repair-manifest` above — it is never invoked automatically by any
-  recovery path, because a live rescan can pull in a fragment that arrived
-  after the original assembly.
-- **If a fragment is edited between assembly and consumption**, the draft in
-  `CHANGELOG.md` wins: it is what the releaser reviewed. `consume` deletes the
-  file regardless of its content.
+**How the three spec rules hold, by construction, not by a state machine:**
+
+1. **Gathering is repeatable.** `assemble --version <X.Y.Z>` checks exactly
+   one fact: does `## [X.Y.Z] - YYYY-MM-DD` already exist in `CHANGELOG.md`?
+   If yes, `ASSEMBLE_RESULT=already_assembled`, exit 0, no write — the
+   idempotence guarantee, decidable from the working tree alone, no second
+   artifact to cross-check. (See "Residual interruption window" below for the
+   one narrow case this check alone does not fully close, and how it is
+   closed without a new artifact.)
+2. **Notes are consumed at publish, not at assembly.** `assemble` runs on
+   the release branch's local working tree. Its edits — the new
+   `CHANGELOG.md` section and the fragment deletions — are ordinary
+   uncommitted changes until Protocol 05's existing Step 5 commits them,
+   exactly like the editorial pass already is today. Nothing reaches
+   `develop` or `main` until the release PR **merges**. Abandon the release
+   (delete the branch, close the PR) and nothing was ever consumed, because
+   the commit that would have deleted the fragments never reached a branch
+   anyone reads from. "Published" is defined by the ordinary GitHub PR-merge
+   event, not by which local script ran.
+3. **A note recorded after assembly belongs to the next release.** In the
+   ordinary case, a fragment added to `develop` after the release branch was
+   cut is simply absent from that branch's tree — branches diverge, and the
+   next release (cut from a later `develop`) picks it up naturally. In the
+   rarer case of a fragment cherry-picked directly onto the *same* release
+   branch after `assemble` already ran: the idempotence check (fact 1) fires
+   before any directory scan, so a plain re-run of `assemble` reports
+   `already_assembled` and never looks at `changelog.d/` again — the late
+   fragment is untouched, stays in `changelog.d/`, and is picked up by the
+   next assembly. It is included only if the releaser deliberately runs
+   `assemble --reassemble` (below), which is a human editorial choice to
+   redo the section, not something any recovery path invokes automatically.
+
+**Assembly, concretely.** When the heading does not yet exist, `assemble`:
+validates every top-level fragment in `changelog.d/` (Decision 1's grammar);
+builds the new section (Decision 4: rename `## [Unreleased]`, merge fragment
+bullets by kind, carry over the existing shared-block bullets); writes
+`CHANGELOG.md` via a temp file, `fsync`, and one atomic `rename(2)` call (kept
+from the earlier design — it is one `mktemp`/`mv` pair, not a state machine,
+and it means a process kill mid-write leaves `CHANGELOG.md` exactly at its
+pre-assembly content, never truncated); then deletes each fragment file that
+fed the section. It reports `ASSEMBLE_RESULT=assembled`, `VERSION`,
+`FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`, and `ITEMS` — the same reporting the
+manifest previously existed partly to support, now emitted directly from the
+one live scan `assemble` already performed, with nothing persisted to disk
+for later inspection because nothing needs to be inspected later: the commit
+diff is that record (see "Audit trail" below).
+
+**Residual interruption window, and why it does not need a manifest.** A
+process kill *between* the `CHANGELOG.md` write succeeding and the fragment
+deletions finishing is still possible (deleting N small files is not one
+atomic operation). Left unaddressed, a re-run's idempotence check would see
+the heading and stop before finishing those deletions, permanently orphaning
+the undeleted fragment — which a *later* release's assembly would then
+gather again, publishing its bullet a second time. The fix does not need a
+manifest: on the `already_assembled` path, before returning, `assemble` scans
+`changelog.d/` for any fragment whose `(#<item>)` reference (Decision 2's
+body convention) appears **literally, as text**, inside the already-published
+`## [X.Y.Z]` section, and deletes it. This is a targeted, provably-safe
+cleanup, not a rescan-and-guess: a fragment is only ever removed by this path
+if its content is already visible in the published section, so a genuinely
+late fragment (whose `(#item)` is *not* in that section) is never touched by
+it — rule 3 above still holds. This closes the one gap with a few lines of
+logic inside the idempotence check, not a new command, file, exit code, or
+recovery flag.
+
+**Re-assembly is possible but explicit, and remains rare.**
+`assemble --reassemble` is unchanged in spirit from the original design: it
+prints the existing `## [X.Y.Z]` section (which may contain the releaser's
+edits) before deleting it, then runs the normal not-yet-assembled path fresh
+— a live rescan, deliberately, because this is an explicit human request to
+redo the section (for example, to pull in a fragment cherry-picked onto the
+branch after the first assembly), not an automatic recovery path. It is
+never invoked by Protocol 05's normal flow.
+
+**Audit trail.** The spec's Operational Visibility principle — "released"
+and "not yet released" visible from repository state rather than inferred —
+holds directly from `changelog.d/`'s contents (a fragment present there is
+not yet released) and from ordinary git history (`git show <commit>` on the
+commit that deleted a fragment shows exactly what its bullet became). This is
+a *stronger* audit trail than the manifest the earlier design added, because
+it reuses git's native history instead of a bespoke, separately-maintained
+file format.
+
+**Why no lock.** `assemble` is a single, synchronous, sub-second shell
+invocation run by one releaser (human or one delegated agent) in one working
+tree, and nothing it does is durable until that same releaser's own Step 5
+commit. A literal simultaneous double-invocation in the same checkout — the
+only scenario a lock would guard against — is an operator mistake (running
+the command twice in two terminals), not a scheduled or expected occurrence;
+its worst case is a locally confusing `CHANGELOG.md`, caught by the same
+`git status`/`git diff` review the releaser already performs before Step 5
+ever commits anything, exactly the same posture the *unmodified* Protocol 05
+editorial pass already has today (nobody locks that either). Building a
+per-release `mkdir` lock, an owner-record file, and staleness detection to
+guard a race whose blast radius is "notice it before you commit" was
+solving a problem `assemble`'s new, much narrower window does not actually
+have; Decision 3's earlier draft needed the lock only because it had opened
+a much wider, commit-spanning window in the first place.
+
+**If a fragment is edited between assembly and the release merging**, the
+draft in `CHANGELOG.md` wins: it is what the releaser reviewed. The fragment
+file is already deleted by that point, so there is nothing left to disagree
+with it.
 
 ### Decision 4 — The transition release
 
-Assembly performs, in one operation:
+Assembly performs, in one operation (Decision 3):
 
 1. Rename the existing `## [Unreleased]` heading to `## [X.Y.Z] - YYYY-MM-DD`,
    preserving every bullet already under it. This is exactly the rename the
    releaser performs by hand today.
-2. Merge the manifest's fragment bullets into that same section, per kind:
+2. Merge the pending fragments' bullets into that same section, per kind:
    append to an existing `### Category` heading when one is present, and create
    the heading in canonical Keep a Changelog order (Added, Changed, Deprecated,
    Removed, Fixed, Security) when it is not.
 3. Insert a fresh, empty `## [Unreleased]` heading above the new version
    section.
+4. Delete each fragment file whose bullet was just merged in step 2.
 
 Each entry appears exactly once because the carried-over bullets are **moved**
-with the heading rather than copied, and each fragment is emitted once from the
-manifest. Appending into an existing `### Category` rather than creating a
-second one is also what keeps `check-changelog-duplicate-headers.sh` passing on
-the assembled output.
+with the heading rather than copied, and each fragment is deleted in the same
+pass that emits its bullet. Appending into an existing `### Category` rather
+than creating a second one is also what keeps `check-changelog-duplicate-headers.sh`
+passing on the assembled output.
 
 The transition is therefore not a special mode and leaves no dead code: after
 it, `## [Unreleased]` is simply always empty, the rename produces an empty
@@ -515,43 +490,26 @@ other workflow helpers, and every exit path prints its documented fields.
       Emits `PENDING_COUNT=<n>` and one `PENDING=<path>` per fragment.
       (Spec "Operational Visibility")
 - [ ] `assemble --version <X.Y.Z> [--date <YYYY-MM-DD>] [--reassemble]
-      [--repair-manifest] [--allow-empty]` — acquire the per-release `mkdir`
-      lock (Concurrent-event-source addendum), write the manifest first (temp
-      file, `fsync`, atomic rename) into `changelog.d/manifests/v<X.Y.Z>.txt`,
-      then write `CHANGELOG.md` the same way (temp file, `fsync`, atomic
-      rename) — rename `## [Unreleased]` to the version heading, merge
-      fragment bullets per kind (from the manifest, not a rescan, when
-      resuming), and insert a fresh empty `## [Unreleased]`. Emits
-      `ASSEMBLE_RESULT`, `VERSION`, `FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`,
-      `MANIFEST_PATH`, and `ITEMS`. `ASSEMBLE_RESULT` includes
-      `assembled_unmanifested` for the manifest-absent, heading-present
-      recovery state; `repaired` when `--repair-manifest` restores the
-      manifest from the most recent commit that wrote it, via the same
-      atomic temp-file-and-rename write as every other write in this plan;
-      `history_truncated` when `--repair-manifest` is run against a shallow
-      clone whose fetched depth cannot rule out an existing-but-unreachable
-      commit; `manifest_unrecoverable` when `--repair-manifest` finds no
-      committed manifest to restore on a full clone; and `locked` when the
-      lock is already held. `--reassemble` follows the identical
-      manifest-first, atomic-rename write order as a normal assembly. (Spec
-      AC-3, AC-5, AC-7, AC-10; Decisions 3 and 4)
-- [ ] `consume --version <X.Y.Z>` — acquire the same per-release lock, require
-      the `## [X.Y.Z]` heading to exist (else refuse — see below), delete the
-      manifest-listed fragments one at a time (idempotent: a file already
-      absent is not an error), then move (not delete) the manifest to
-      `changelog.d/manifests/consumed/v<X.Y.Z>.txt`. Emits `CONSUME_RESULT`,
-      `REMOVED_COUNT`, `MANIFEST_PATH`. `CONSUME_RESULT` includes
-      `not_assembled` when the manifest exists but the heading does not (do
-      not delete anything in this case); `inconsistent` when neither manifest
-      location holds the target version but the heading is present; and
-      `locked` when the lock is already held. (Spec AC-5, AC-7; Decision 3)
+      [--allow-empty]` — the release-preparation command, and the **only**
+      write path this helper has (Decision 3). If `## [X.Y.Z] - YYYY-MM-DD`
+      already exists in `CHANGELOG.md` and `--reassemble` was not passed:
+      perform the residual-interruption sweep (delete any remaining fragment
+      whose `(#item)` reference already appears in that section), then report
+      `ASSEMBLE_RESULT=already_assembled`, exit 0, no `CHANGELOG.md` write.
+      Otherwise: validate every pending fragment, build the version section
+      (Decision 4), write `CHANGELOG.md` via temp file, `fsync`, and one
+      atomic `rename(2)`, then delete each fragment that fed the section.
+      Emits `ASSEMBLE_RESULT`, `VERSION`, `FRAGMENT_COUNT`,
+      `CARRIED_OVER_COUNT`, and `ITEMS`. `--reassemble` (only meaningful when
+      the heading already exists) prints the existing section, deletes it,
+      and re-runs the not-yet-assembled path fresh — a deliberate rescan, not
+      an automatic recovery path — reporting `ASSEMBLE_RESULT=reassembled`.
+      (Spec AC-3, AC-5, AC-6, AC-7, AC-10; Decisions 3 and 4)
 - [ ] Exit codes: `0` for `clean`, `assembled`, `already_assembled`,
-      `reassembled`, `repaired`, `consumed`, `already_consumed`; `1` for a
-      validation, assembly, `assembled_unmanifested`,
-      `manifest_unrecoverable`, `history_truncated`, `not_assembled`,
-      `inconsistent`, or `locked` error; `3` for `no_notes` without
-      `--allow-empty`; `64` for a usage
-      error, matching `check-documentation-stage-alignment.sh`.
+      `reassembled`; `1` for a validation or assembly error; `3` for
+      `no_notes` without `--allow-empty`; `64` for a usage error, matching
+      `check-documentation-stage-alignment.sh`. There is no `consume`
+      subcommand and no `CONSUME_RESULT` (Decision 3).
 - [ ] Reporting on assembly names each contributing item, and reports bullets
       carried over from the shared block as a single unattributed group, per
       the spec's Operational Visibility section.
@@ -560,13 +518,14 @@ New directory:
 
 - [ ] `changelog.d/README.md` — the filename grammar, the six kinds, the body
       convention (a complete markdown bullet including the `**Bold Title**
-      (#N):` prefix), and a worked example. It is excluded from the fragment
-      scan by name.
-- [ ] `changelog.d/manifests/.gitkeep` — so the manifest directory exists on a
-      fresh clone even though manifests exist only during a release.
-- [ ] `changelog.d/manifests/consumed/.gitkeep` — so the durable, post-publish
-      manifest archive (Decision 3) exists on a fresh clone even before any
-      release has been consumed.
+      (#N):` prefix, and the no-tracker exception that drops `(#N)`
+      entirely — Decision 1), and a worked example. It is excluded from the
+      fragment scan by name.
+
+`changelog.d/` has no other new directory to create: Decision 3 introduces no
+manifest, so there is nothing for a fresh downstream clone to be missing —
+`README.md` alone is both the only new file and the reason the directory
+exists on a fresh clone (git does not track empty directories).
 
 ### Infrastructure / Configuration
 
@@ -592,11 +551,10 @@ New directory:
       `critical`). That section's stated reason — "version parsing or
       changelog structure mistakes can create incorrect release tags that are
       hard to undo" — applies verbatim to `changelog-fragments.sh`'s
-      `assemble`/`consume` rewriting and to the `changelog.d/manifests/*.txt`
-      state files; without this the new automation and state files fall back
-      to the generic `scripts/development-workflow/**` = `high` policy row (or
-      no row at all for `changelog.d/manifests/`), one severity level below
-      what its own risk rationale calls for.
+      `assemble` rewriting `CHANGELOG.md`; without this the new automation
+      falls back to the generic `scripts/development-workflow/**` = `high`
+      policy row, one severity level below what its own risk rationale calls
+      for.
 - [ ] Verified as needing **no** change: `.github/workflows/auto-tag-release.yml`
       (reads published version sections only), `.markdownlint.jsonc` and
       `.markdownlint-cli2.jsonc` (rule set is file-agnostic),
@@ -634,20 +592,18 @@ Protocols:
       byte-for-byte unchanged. Rename both "CHANGELOG entry preview" PR-body
       bullets to "release note preview". (Spec AC-2, AC-11)
 - [ ] `docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md`
-      — restructure Step 3 into: assemble the draft; **commit** (the manifest
-      and the rewritten `CHANGELOG.md`); editorial pass (today's polish
+      — restructure Step 3 into: assemble the draft (now also deletes the
+      fragments it gathered — Decision 3); editorial pass (today's polish
       guidance retargeted at the assembled draft, unchanged in substance);
-      link-reference definitions (unchanged); **commit** (the editorial pass
-      and link-reference definitions); consume the notes. The two commits are
-      both new and both precede Step 5's existing version-bump commit — see
-      Decision 3's "Interrupted preparation resumes intact" bullet: without
-      them, neither artifact is a "committed file on the release branch" until
-      Step 5, and `--repair-manifest`'s git-history restore has no commit to
-      find for the entire span between assembly and Step 5. Extend Step 7.2's
-      release-artifact validation with the two checks that prove consumption
-      ran: `changelog.d/manifests/consumed/v<X.Y.Z>.txt` is present (not
-      merely `changelog.d/manifests/v<X.Y.Z>.txt` absent — see Decision 3) and
-      `## [X.Y.Z] - YYYY-MM-DD` is present. (Spec AC-3, AC-4, AC-5, AC-8)
+      link-reference definitions (unchanged). **No new commit is added
+      anywhere in Step 3.** Step 5 remains the protocol's only "Commit" step,
+      exactly as it is today, and now covers the assembled section, the
+      fragment deletions, the editorial pass, and the version bump together —
+      the same single commit Step 5 already produces, just with more of the
+      release branch's changes folded into it. Extend Step 7.2's
+      release-artifact validation with the one check that proves assembly
+      ran: `## [X.Y.Z] - YYYY-MM-DD` is present in the merged `CHANGELOG.md`.
+      (Spec AC-3, AC-4, AC-5, AC-6, AC-8)
 - [ ] `docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md`
       — extend Step 2.5 so the graduation PR is verified to carry the
       `changelog.d/` additions accumulated on `develop-<slug>`, alongside the
@@ -734,8 +690,8 @@ rehearsal), Smoke (runbook).
    edits — Spec AC-5.
 6. A fragment written after assembly is absent from that release and present
    for the next one — Spec AC-6.
-7. After consumption no manifest-listed fragment remains, and a repeat
-   assembly produces no duplicate section — Spec AC-7.
+7. After assembly, no fragment that fed the section remains in `changelog.d/`,
+   and a repeat assembly produces no duplicate section — Spec AC-7.
 8. After publication the changelog is ready for the next release and every
    version link resolves — Spec AC-8.
 9. The assembled section passes `markdownlint-cli2`,
@@ -767,10 +723,12 @@ rehearsal), Smoke (runbook).
 - **Extend** `scripts/development-workflow/tests/test-select-test-suites.sh`
   only if its expected-mapping fixtures enumerate suites; verify at
   implementation time.
-- **Run** `scripts/lint/check-changelog-duplicate-headers.sh` and
-  `scripts/lint/markdown-heuristic-lint.py` against every assembled fixture
-  produced by the new suite, so lint conformance of the output is asserted by
-  the suite itself rather than only observed in CI.
+- **Run** `node_modules/.bin/markdownlint-cli2`,
+  `scripts/lint/markdown-heuristic-lint.py`, and
+  `scripts/lint/check-changelog-duplicate-headers.sh` against every assembled
+  fixture produced by the new suite — all three checks AC-9 requires, not
+  only two of them — so lint conformance of the output is asserted by the
+  suite itself rather than only observed in CI.
 
 **Smoke test runbook**: `docs/testing/workflow/1554-changelog-fragments.smoke-test.md`
 
@@ -813,7 +771,7 @@ test in `scripts/development-workflow/tests/test-changelog-fragments.sh`.
 | 16 | Multiple top-level bullets in one fragment | Accepted; copied verbatim without renumbering |
 | 17 | Continuation lines indented by two spaces | Preserved verbatim; assembly never re-wraps |
 | 18 | CRLF line endings | Normalized to LF before insertion |
-| 19 | A body line beginning with `## [` or `### ` | Rejected by `validate`, for the same reason as row 20: `check-changelog-duplicate-headers.sh` and `auto-tag-release.yml` re-parse `CHANGELOG.md` from scratch by matching `^## ` / `^### ` on raw lines, with no notion of "this line came from inside a fragment body." A verbatim-copied heading-shaped line would be interpreted as a real section or category boundary by every downstream consumer, even though the assembler's own single-pass boundary computation stays correct for that one run. Escaping (rather than rejecting) was considered and rejected: it would leave the releaser's rendered CHANGELOG.md containing an escaped artifact instead of the intended bullet, which is a worse outcome than asking the fragment's author to reword the line before assembly ever happens |
+| 19 | A body line beginning with `## ` (any level-2 heading, not only `## [`) or `### ` | Rejected by `validate`, for the same reason as row 20: `check-changelog-duplicate-headers.sh` and `auto-tag-release.yml` re-parse `CHANGELOG.md` from scratch by matching `^## ` / `^### ` on raw lines, with no notion of "this line came from inside a fragment body." A verbatim-copied heading-shaped line — bracketed (`## [X]`) or not (`## Internal`) — would be interpreted as a real section or category boundary by every downstream consumer, even though the assembler's own single-pass boundary computation stays correct for that one run. Escaping (rather than rejecting) was considered and rejected: it would leave the releaser's rendered CHANGELOG.md containing an escaped artifact instead of the intended bullet, which is a worse outcome than asking the fragment's author to reword the line before assembly ever happens |
 | 20 | Trailing whitespace on a body line | Rejected by `validate`, so it fails on the item's PR rather than producing an MD009 failure on the assembled changelog |
 
 **Edge-case enumeration — changelog rewriting**
@@ -822,24 +780,17 @@ test in `scripts/development-workflow/tests/test-changelog-fragments.sh`.
 | --- | --- | --- |
 | 21 | No `## [Unreleased]` heading | Rejected; the heading is a precondition that `auto-tag-release.yml` also depends on |
 | 22 | Two `## [Unreleased]` headings | Rejected |
-| 23 | `## [X.Y.Z]` already present, manifest for that version also present in `changelog.d/manifests/` | `ASSEMBLE_RESULT=already_assembled`, exit 0, no write — the idempotence mechanism (Decision 3 requires both artifacts, not the heading alone) |
-| 24 | Populated shared block plus pending fragments | Both merged into one version section, each entry once, with no duplicate `### Category` heading |
-| 25 | Populated shared block, zero fragments | Rename only — the pre-fragment behaviour, preserved |
+| 23 | `## [X.Y.Z]` already present | `ASSEMBLE_RESULT=already_assembled`, exit 0, no `CHANGELOG.md` write — the idempotence mechanism (Decision 3). Before returning, the residual-interruption sweep (row 31) still runs |
+| 24 | Populated shared block plus pending fragments | Both merged into one version section, each entry once, with no duplicate `### Category` heading; every merged fragment is deleted in the same pass |
+| 25 | Populated shared block, zero fragments | Rename only — the pre-fragment behaviour, preserved. Nothing to delete |
 | 26 | Empty shared block, zero fragments | `ASSEMBLE_RESULT=no_notes`, exit 3, unless `--allow-empty` |
 | 27 | A kind present in fragments but absent from the shared block | Heading created in canonical Keep a Changelog order |
 | 28 | Deterministic ordering | Bullets sorted by kind rank, then by the item field (numerically when it is all digits, lexicographically otherwise), then by full filename — so two runs on the same input produce identical bytes |
-| 29 | `consume` when the manifest is absent from both `changelog.d/manifests/` and `changelog.d/manifests/consumed/`, and the version section is also absent | `CONSUME_RESULT=manifest_missing`, non-zero, with the remediation named (run `assemble` first) |
-| 30 | `consume` run twice | First run reports `consumed`. Second run finds the manifest already moved to `changelog.d/manifests/consumed/` and reports `CONSUME_RESULT=already_consumed`, exit 0 |
-| 31 | `consume` when the `## [X.Y.Z]` heading is absent, a manifest-listed file is already gone, and the manifest is not in either manifest location | Rejected — `CONSUME_RESULT=inconsistent`; the release state is corrupted and must not be papered over |
-| 32 | `assemble` when the manifest for the target version is present but the `## [X.Y.Z]` heading is absent (interrupted between the two writes) | `assemble` performs the `CHANGELOG.md` write (temp file, `fsync`, atomic rename) from the already-frozen manifest, never a rescan. `ASSEMBLE_RESULT=assembled`, exit 0 |
-| 33 | `assemble` when the `## [X.Y.Z]` heading is present but the manifest for that version is absent from both manifest locations | `ASSEMBLE_RESULT=assembled_unmanifested`, exit 1, naming `assemble --repair-manifest` (git-history restore) as the remediation — never a directory rescan |
-| 34 | `consume` when neither manifest location holds the target version but the `## [X.Y.Z]` version section is present | `CONSUME_RESULT=inconsistent`, exit 1 — no longer conflated with `already_consumed`; the operator must reconcile by hand |
-| 35 | `consume` when the manifest is present in `changelog.d/manifests/` but the `## [X.Y.Z]` heading is absent | `CONSUME_RESULT=not_assembled`, exit 1, deletes nothing — assembly never finished; remediation is to run `assemble` first |
-| 36 | `consume` when the heading is present, the manifest is present in `changelog.d/manifests/`, and some or all manifest-listed fragment files are already absent (a prior run stopped after deleting fragments but before moving the manifest) | Resume: finish deleting whatever remains (idempotent — an absent file is not an error), then move the manifest. `CONSUME_RESULT=consumed`, exit 0 |
-| 37 | `assemble --repair-manifest` when a commit on the current branch previously wrote `changelog.d/manifests/v<X.Y.Z>.txt` | Restore that commit's blob verbatim, via the same atomic temp-file-and-rename write as every other write in this plan. `ASSEMBLE_RESULT=repaired`, exit 0 — the restored set is exactly what was frozen at the original assembly, never a live rescan |
-| 38 | `assemble --repair-manifest` when the path was written by more than one commit (for example, an earlier `--repair-manifest` or `--reassemble`) | Restore the **most recent** commit's blob — the one that reflects the currently-authoritative content, not an earlier one. `ASSEMBLE_RESULT=repaired`, exit 0 |
-| 39 | `assemble --repair-manifest` on a shallow clone, where no commit in the fetched history wrote the manifest but one may exist outside the fetched depth | `ASSEMBLE_RESULT=history_truncated`, exit 1, naming `git fetch --unshallow` as the remediation — distinct from `manifest_unrecoverable`, which asserts no such commit exists at all |
-| 40 | `assemble --repair-manifest` on a full (non-shallow) clone when no commit on the current branch ever wrote the manifest for the target version | Refuse to guess. `ASSEMBLE_RESULT=manifest_unrecoverable`, exit 1, naming manual reconciliation (or an explicit, risk-accepted `--reassemble`) as the only remaining paths |
+| 29 | `assemble` run twice in a row, no interruption in between | First run: `assembled`, writes the section, deletes every fragment that fed it. Second run: `already_assembled`, exit 0, no write — `changelog.d/` already has nothing left for that version to delete |
+| 30 | `assemble` interrupted after the `CHANGELOG.md` rename succeeds but before every fed fragment is deleted | On the next run, the idempotence check (row 23) fires, then the residual-interruption sweep deletes any fragment still present whose `(#item)` reference already appears, as literal text, in the published `## [X.Y.Z]` section — closing the gap without a rescan of "what should this release contain" (only "what does this section already say") |
+| 31 | A fragment sitting in `changelog.d/` whose `(#item)` reference does **not** appear in the published `## [X.Y.Z]` section, encountered during the residual-interruption sweep | Left untouched — this is what keeps the sweep from ever behaving like a rescan: a fragment is deleted only when its content is already visible in the published section, never merely because the section exists |
+| 32 | `--reassemble` when the `## [X.Y.Z]` heading is present | Prints the existing section (it may hold the releaser's edits), deletes it, then re-runs the not-yet-assembled path fresh — a deliberate, human-invoked rescan. `ASSEMBLE_RESULT=reassembled`, exit 0 |
+| 33 | `--reassemble` when the `## [X.Y.Z]` heading is absent | Usage error, exit 64 — there is nothing to replace |
 
 **Suppression semantics**: not applicable. `changelog-fragments.sh` recognizes
 no inline suppression directives. Declining to write a release note is
@@ -848,108 +799,62 @@ expressed by not creating a fragment, exactly as declining to edit
 
 ### Concurrent-event-source addendum
 
-**Partially applicable, split by scope.** `changelog-fragments.sh` is a
-single-threaded command-line helper with no listeners, timers, sockets, or
-async queues, so every *in-process* async concern is not applicable: event
-deduplication, listener and resource cleanup, and error propagation across
-async boundaries. The concurrency between independent item PRs is likewise not
-applicable to runtime synchronization — it is handled structurally, by
-disjoint fragment file paths (Decision 1), before any of these commands run.
+**Not applicable**, and this is a corrected conclusion, not the original one.
+`changelog-fragments.sh` is a single-threaded command-line helper with no
+listeners, timers, sockets, or async queues, so every in-process async
+concern is not applicable, as before. The concurrency between independent
+item PRs is likewise not applicable to runtime synchronization — handled
+structurally, by disjoint fragment file paths (Decision 1).
 
-**Concurrent *process* invocation on the same release branch is a real,
-narrower case**, and this plan does not leave it unguarded: `assemble` and
-`consume` both rewrite `CHANGELOG.md` and the manifest across several
-non-atomic file operations (Decision 3), so two invocations racing on the
-same release branch checkout could interleave and produce exactly the
-lost-note or inconsistent-state outcomes the spec's "no unreleased note may be
-silently left behind" rule forbids. This repository already has a precedent
-for this exact shape of problem: `prepare-release-post-merge-cleanup.sh`
-guards its own shared release-state mutation with an `mkdir`-based lock,
-scoped to the coordinating checkout's git-dir (not the tracked working tree),
-that fails clearly with a non-zero exit and a named remediation when already
-held, rather than allowing a second run to interleave.
-
-`assemble` and `consume` follow the same convention: before performing any
-write, each acquires an `mkdir`-created lock directory at
-`$(git rev-parse --git-dir)/changelog-fragments-locks/v<X.Y.Z>.lock`, scoped
-per target version (so `assemble` for `0.44.0` never blocks `consume` for
-`0.43.0`), and removes it on exit via a `trap`. If the `mkdir` fails because
-the lock is already held, the command exits non-zero immediately with
-`ASSEMBLE_RESULT=locked` / `CONSUME_RESULT=locked`, the lock directory path,
-and the instruction to retry once the other invocation completes — it never
-waits or retries silently. This is a bounded, single-checkout mitigation, the
-same known limitation `prepare-release-post-merge-cleanup.sh` documents for
-its own lock: it does not exclude a concurrent run from a different clone or
-worktree of the same release branch, and the plan does not claim otherwise.
-
-**Staleness — a gap the precedent script leaves open, which this plan does
-not repeat.** `prepare-release-post-merge-cleanup.sh`'s lock has no built-in
-staleness recovery at all: if its owning process is killed, the lock directory
-is empty (`mkdir` with no marker file inside it) and stays held forever, with
-no documented way for an operator to tell "still running" apart from "leaked."
-Copying that as-is would mean this plan's own troubleshooting guidance — "wait
-for it to finish, or confirm it is stale and remove the lock directory" —
-gives the operator no actual mechanism to confirm staleness, which risks the
-operator guessing wrong and `rmdir`-ing a lock a still-running invocation
-holds, recreating the exact interleaving the lock exists to prevent. This plan
-closes that gap: at acquisition, `assemble`/`consume` write a single file
-inside the lock directory, `owner` (PID, hostname, and UTC start timestamp, one
-per line — no atomicity requirement on this file, since it exists only after
-the `mkdir` that already committed the lock). When `mkdir` fails, the reported
-remediation reads that file and instructs the operator to check
-`ps -p <pid>` (or the equivalent on the owner's host, if different from the
-current one) before removing the lock directory — remove it only when the
-recorded PID is confirmed not running on the recorded host. This is still a
-manual, human-in-the-loop judgment (there is no cross-host liveness protocol),
-so a wrong manual judgment remains possible; it is a strict improvement over
-"confirm it is stale" with no data to confirm it against, not a hard
-guarantee.
-
-The test suite (Implementation Order Step 2) adds one interleaving case per
-command: start a run, hold its lock open, start a second run of the same
-command against the same version, and assert the second run reports `locked`
-and makes no write; and one stale-lock case: create a lock directory with an
-`owner` file naming a PID that is not running, and assert the reported
-remediation names that file rather than only the lock directory path.
+A prior draft of this plan additionally built a per-release `mkdir` lock, an
+`owner` metadata file, and staleness-detection guidance for concurrent
+*process* invocation, reasoning by analogy to
+`prepare-release-post-merge-cleanup.sh`'s own lock. That reasoning no longer
+applies, because the thing it was protecting no longer exists: the earlier
+`assemble`/`consume` split left `CHANGELOG.md` and a manifest file mutated
+across two separate commands and (after the previous round's fix) two
+separate git commits, a multi-minute-to-multi-hour window in which a second
+invocation could plausibly land. Decision 3's simplification collapses that
+to one synchronous, sub-second `assemble` call, writing one file, that is not
+durable until the *releaser's own* Step 5 commit — the same commit that
+already exists, unmodified, in today's release process. A literal
+simultaneous double-invocation in the same checkout is now an operator
+mistake (two terminals, one command, at once), not a scheduled occurrence,
+and its worst case — a locally confusing `CHANGELOG.md` — is caught by the
+same `git status`/`git diff` review the releaser already performs before
+Step 5 commits anything, exactly the posture today's *unmodified* editorial
+pass already has. `prepare-release-post-merge-cleanup.sh`'s lock protects a
+different, genuinely longer-lived, cross-invocation window (component
+release cleanup coordinating across repositories); `assemble`'s window is not
+that shape, and copying the precedent regardless was solving a problem this
+design does not have.
 
 ---
 
 ## Complex Workflow Decision-Gate Matrix
 
-This plan adds a workflow decision gate: the release-time assemble/consume step
-in Protocol 05, whose behaviour depends on several inputs and produces several
-distinct next actions. It also changes an existing gate: the release-note
-readiness check.
+This plan adds a workflow decision gate: `assemble` in Protocol 05, whose
+behaviour depends on a small number of inputs and produces a small number of
+distinct next actions — Decision 3's simplification is directly visible here
+as the shrink from a two-command, manifest-driven gate pair to one gate with
+four rows. It also changes an existing gate: the release-note readiness
+check.
 
 ### Gate A — `changelog-fragments.sh assemble`
 
 | Gate inputs | Outcome | Required next action | Mirror surfaces |
 | --- | --- | --- | --- |
-| No manifest for the target version; no `## [X.Y.Z]` heading; at least one pending fragment or a non-empty shared block | `assembled` | Continue to the editorial pass (Protocol 05 Step 3) | Protocol 05; `.claude/commands/prepare-release.md`; `.cursor/commands/prepare-release.md`; `.agents/skills/prepare-release/SKILL.md` |
-| Manifest for the target version present; `## [X.Y.Z]` heading also present | `already_assembled` | No write; continue. This is the resume path and the idempotence guarantee — both artifacts, not the heading alone (Decision 3) | Same |
-| Manifest for the target version present; `## [X.Y.Z]` heading absent | `assembled` | Interrupted between the two writes. Perform the `CHANGELOG.md` write (temp file, `fsync`, atomic rename) from the already-frozen manifest, never a rescan; continue to the editorial pass | Same |
-| Manifest for the target version absent; `## [X.Y.Z]` heading present | `assembled_unmanifested` (exit 1) | Stop; run `assemble --repair-manifest` to restore the manifest from git history — never a directory rescan (a live rescan can pull in a fragment added since the original assembly) | Protocol 05 Step 3 |
-| `--repair-manifest` passed; a commit on the branch previously wrote the manifest for this version (the most recent such commit, if more than one) | `repaired` | The manifest is restored verbatim from that commit, via the same atomic temp-file-and-rename write as every other write in this plan; continue to `already_assembled` on the next run | Same |
-| `--repair-manifest` passed; the clone is shallow and cannot rule out a commit outside the fetched depth | `history_truncated` (exit 1) | Stop; run `git fetch --unshallow`, then retry `--repair-manifest` — this is a clone-configuration gap, not evidence the manifest is unrecoverable | Protocol 05 Step 7.2 |
-| `--repair-manifest` passed; the clone is not shallow and no commit on the branch ever wrote the manifest for this version | `manifest_unrecoverable` (exit 1) | Stop; reconcile by hand (compare the published section's bullets against fragments still in `changelog.d/`), or explicitly accept the risk of `--reassemble` | Protocol 05 Step 7.2 |
-| `--reassemble` passed and the heading is present | `reassembled` | Print the replaced section first; the releaser must redo any editorial pass. Not invoked automatically by any recovery path | Same |
+| No `## [X.Y.Z]` heading; at least one pending fragment or a non-empty shared block | `assembled` | Continue to the editorial pass (Protocol 05 Step 3) | Protocol 05; `.claude/commands/prepare-release.md`; `.cursor/commands/prepare-release.md`; `.agents/skills/prepare-release/SKILL.md` |
+| `## [X.Y.Z]` heading already present, `--reassemble` not passed | `already_assembled` | No `CHANGELOG.md` write (the residual-interruption sweep may still delete leftover fragments — edge cases 30–31); continue | Same |
+| `--reassemble` passed, heading present | `reassembled` | Print the replaced section first; the releaser must redo any editorial pass. Never invoked by Protocol 05's normal flow | Same |
 | No pending fragment and an empty shared block | `no_notes` (exit 3) | Stop; either there is nothing to release or a fragment was lost. Pass `--allow-empty` only for a deliberate no-notes release | Same |
 | Any fragment fails the grammar or body checks | `invalid` (exit 1) | Fix the named fragment on `develop` and re-run; never assemble a partial set | Protocol 05; `.github/workflows/markdown-lint.yml` |
 | `CHANGELOG.md` lacks exactly one `## [Unreleased]` heading | `error` (exit 1) | Repair the changelog before releasing | Protocol 05 Step 7.2 |
 
-### Gate B — `changelog-fragments.sh consume`
+There is no Gate B: Decision 3 removed `consume` as a distinct command, so
+there is no second gate for it to define.
 
-| Gate inputs | Outcome | Required next action | Mirror surfaces |
-| --- | --- | --- | --- |
-| Heading present; manifest present in `changelog.d/manifests/`, every listed file present | `consumed` | Commit the deletions and the manifest move (to `changelog.d/manifests/consumed/`) with the release commit | Protocol 05 Step 3 |
-| Manifest present in `changelog.d/manifests/`, `## [X.Y.Z]` heading absent | `not_assembled` (exit 1) | Stop; deletes nothing. Run `assemble` first — assembly never finished writing the section | Protocol 05 Step 3 |
-| Heading present; manifest present in `changelog.d/manifests/`; some or all listed files already absent | `consumed` | Interrupted consume, safe to resume: finish deleting whatever remains (idempotent), then move the manifest | Protocol 05 Step 3 |
-| Manifest present in `changelog.d/manifests/consumed/`, absent from `changelog.d/manifests/` | `already_consumed` | Continue; confirmed by the moved file's presence, not by absence | Protocol 05 Steps 3 and 7.2 |
-| Manifest absent from both locations, heading absent | `manifest_missing` (non-zero) | Run `assemble` first | Protocol 05 Step 3 |
-| Manifest absent from both locations, heading present | `inconsistent` (exit 1) | Stop and reconcile by hand; no longer conflated with `already_consumed` | Protocol 05 Step 7.2 |
-| Heading absent; manifest absent from both locations; a listed file (from the last-known manifest state) already gone | `inconsistent` (exit 1) | Stop and reconcile by hand; the release state is corrupted | Protocol 05 Step 7.2 |
-
-### Gate C — release-note readiness (changed, not added)
+### Gate B — release-note readiness (changed, not added)
 
 | Gate inputs | Outcome | Required next action | Mirror surfaces |
 | --- | --- | --- | --- |
@@ -975,7 +880,7 @@ the retired convention on a surface whose prose describes the new one.
 | Invalid fragments | One per rejected row of the parser-risk tables above | Same |
 | Changelog with a populated shared block | `## [Unreleased]` carrying `### Added` and `### Fixed` bullets, plus prior version sections and their link-reference definitions | Same — the transition-release fixture |
 | Changelog with an empty shared block | `## [Unreleased]` with no bullets | Same — the steady-state fixture |
-| This item's own release note | `changelog.d/1554.changed.per-item-release-notes.md` (content in Implementation Order Step 12) | Committed by the implementation PR |
+| This item's own release note | `changelog.d/1554.changed.per-item-release-notes.md` (content in Implementation Order Step 11) | Committed by the implementation PR |
 
 ---
 
@@ -1021,7 +926,7 @@ for execution, not performed during Plan Ready.
 | File-level overlap with open PR #1589 on `.github/workflows/markdown-lint.yml` and `05b-graduate-development-protocol.md` | Med | Low | The edits are in disjoint regions (branch filters and a new top section, versus `paths:`/targets and Step 2.5). If #1589 merges first, rebase; the conflict, if any, is a normal two-region docs conflict, not the combinatorial one this item removes |
 | A release-branch delete of a fragment races an edit of that same fragment on `develop` | Low | Low | Git reports a delete/modify conflict on one file owned by one item. Editing a note after its release is already a mistake; document the resolution (keep the deletion) in Protocol 94's `changelog.d/` clause |
 | `--reassemble` discards a releaser's editorial pass | Low | Med | The flag is never used by Protocol 05's normal flow, and the command prints the section it is about to replace before replacing it |
-| A recovery path (`--repair-manifest`, `assembled_unmanifested`/`not_assembled` handling) is implemented incorrectly, silently reintroducing the truncation or retroactive-inclusion bugs Decision 3 exists to prevent | Low | High | Edge cases 31–38 fixture every recovery combination (interrupted write, lost manifest with and without git history, interrupted consume, premature consume) as red tests before the corresponding code exists (Implementation Order Steps 2, 4, 5) |
+| A process is killed mid-`assemble`, after the `CHANGELOG.md` write but before every fed fragment is deleted, and the residual-interruption sweep (edge cases 30–31) is implemented incorrectly | Low | Med | Edge cases 29–31 fixture the interruption and the sweep as red tests before the code exists (Implementation Order Steps 2 and 4); the sweep's own correctness bar is narrow and checkable — delete only a fragment whose `(#item)` is already literal text in the published section |
 | Downstream projects that have not adopted fragments receive protocol updates describing a convention they do not use | Med | Low | Decision 6 keeps Protocol 94's auto-resolution and states the not-yet-adopted case explicitly; Decision 4's assembly works unchanged on a populated shared block, so adoption needs no migration |
 
 ---
@@ -1045,38 +950,26 @@ assembled section:
   `develop` ran zero checks on sub-item PRs targeting `develop-<slug>`.
 ```
 
-An example release manifest, `changelog.d/manifests/v0.43.0.txt`.
-**Illustrative**:
-
-```text
-# assembled 2026-09-01T09:14:22Z version=0.43.0 fragments=2 carried_over=56
-changelog.d/1554.changed.per-item-release-notes.md
-changelog.d/1589.fixed.integration-branch-ci.md
-```
+There is no manifest file to sample: Decision 3 does not introduce one.
 
 ---
 
 ## Implementation Order
 
 1. **Create the directory and its reference.** Add `changelog.d/README.md`
-   documenting the grammar, the six kinds, and the body convention, and
-   `changelog.d/manifests/.gitkeep` and
-   `changelog.d/manifests/consumed/.gitkeep`. (Decisions 1, 2, 7)
+   documenting the grammar, the six kinds, and the body convention (including
+   the no-tracker exception — Decision 1). No other file or directory is
+   needed: Decision 3 introduces no manifest. (Decisions 1, 2, 7)
 
-   *Verify*: `ls changelog.d` lists the README and the manifests directory,
-   `ls changelog.d/manifests` lists the `consumed` subdirectory, and
+   *Verify*: `ls changelog.d` lists the README, and
    `node_modules/.bin/markdownlint-cli2 "changelog.d/README.md"` reports no
    violations.
 
 2. **Write the test suite first, red.** Create
    `scripts/development-workflow/tests/test-changelog-fragments.sh` with one
-   case per row of the three parser-risk tables (including edge cases 31–38,
-   the recovery-state matrix), one interleaving case per command for the
-   per-release lock (Concurrent-event-source addendum), and a case that
-   verifies `CHANGELOG.md` is left byte-identical to its pre-assembly content
-   when the process is killed after the temp-file write but before the atomic
-   rename, plus its `# covers:` header lines. Every case fails at this point
-   because the helper does not exist.
+   case per row of the three parser-risk tables (including edge cases 29–33,
+   the interruption and re-assembly cases), plus its `# covers:` header
+   lines. Every case fails at this point because the helper does not exist.
 
    *Verify*: running the suite reports failures for every case and no case is
    silently skipped.
@@ -1087,41 +980,26 @@ changelog.d/1589.fixed.integration-branch-ci.md
    *Verify*: the filename-grammar and fragment-body cases in the suite pass;
    the changelog-rewriting cases still fail.
 
-4. **Implement `assemble`.** The per-release `mkdir` lock (Concurrent-event-
-   source addendum); manifest-first write (temp file, `fsync`, atomic
-   rename); then the `CHANGELOG.md` write with the same atomicity guarantee
-   (temp file, `fsync`, atomic rename) — heading rename, per-kind merge,
-   fresh empty `## [Unreleased]`, deterministic ordering; all four assembly
-   states from Decision 3 (`assembled`, `already_assembled`, the
-   manifest-present/heading-absent resume, and `assembled_unmanifested`);
-   `--repair-manifest` (git-history restore of the most recent writing
-   commit, itself written atomically; `repaired`, `history_truncated` on a
-   shallow clone, or `manifest_unrecoverable` on a full clone, never a
-   directory rescan); `--reassemble` (identical manifest-first, atomic-rename
-   write order as normal assembly); and `no_notes`.
+4. **Implement `assemble`.** The idempotence check (does `## [X.Y.Z]` already
+   exist); the residual-interruption sweep on that path (edge cases 30–31);
+   otherwise: validate pending fragments, build the section (heading rename,
+   per-kind merge, fresh empty `## [Unreleased]`, deterministic ordering),
+   write `CHANGELOG.md` via temp file, `fsync`, and one atomic `rename(2)`,
+   then delete every fragment that fed the section; `--reassemble` (edge
+   cases 32–33); and `no_notes`. There is no lock and no manifest to
+   implement (Decision 3).
 
    *Verify*: the changelog-rewriting cases pass, and the suite's assembled
-   fixtures are checked with `check-changelog-duplicate-headers.sh` and
-   `markdown-heuristic-lint.py` inside the suite itself. The kill-before-rename
-   case from Step 2 confirms `CHANGELOG.md` is untouched, not truncated.
+   fixtures are checked with `node_modules/.bin/markdownlint-cli2`,
+   `markdown-heuristic-lint.py`, and `check-changelog-duplicate-headers.sh`
+   inside the suite itself — all three AC-9 checks, not two. A case that
+   kills the process after the `CHANGELOG.md` write but before every fed
+   fragment is deleted, then re-runs `assemble`, confirms the sweep finishes
+   the deletions and `CHANGELOG.md` is unchanged by the second run. A case
+   with a genuinely unrelated fragment present during that same re-run
+   confirms the sweep does not touch it.
 
-5. **Implement `consume`.** The per-release `mkdir` lock; the `## [X.Y.Z]`
-   heading precondition (`not_assembled` when the manifest exists but the
-   heading does not — deletes nothing); manifest-driven, idempotent
-   per-file deletion (resuming an interrupted consume simply finishes
-   whatever remains); moving (not deleting) the manifest into
-   `changelog.d/manifests/consumed/`; the `already_consumed` outcome
-   (detected from the moved file's presence); and the `inconsistent`
-   rejection when neither manifest location holds the target version.
-
-   *Verify*: the whole suite passes. Run `consume` twice in a row and confirm
-   the first run reports `consumed` and the second reports `already_consumed`.
-   Run it against a fixture with the heading absent and confirm
-   `not_assembled` with zero fragment files deleted. Run it against a fixture
-   with some manifest-listed fragments pre-deleted and confirm it completes
-   and reports `consumed` rather than erroring.
-
-6. **Wire the lint and CI surfaces.** Update
+5. **Wire the lint and CI surfaces.** Update
    `.github/workflows/markdown-lint.yml` (`paths:`, both independent
    file-discovery `find` blocks, the `markdownlint-cli2` glob list, and a
    `validate` step).
@@ -1133,26 +1011,21 @@ changelog.d/1589.fixed.integration-branch-ci.md
    scripts/lint/markdown-heuristic-lint.py` against a file under
    `changelog.d/` confirms it is picked up (not just `markdownlint-cli2`).
 
-7. **Update the release path.** Protocol 05 Step 3 (assemble, editorial pass,
-   link definitions, consume) and Step 7.2's artifact validation, then the three
-   prepare-release command and skill surfaces. **Add two commits inside the
-   restructured Step 3, both before Step 5's existing version-bump commit**:
-   one immediately after `assemble` succeeds (before the editorial pass touches
-   anything) and one immediately after the editorial pass and link-reference
-   definitions, before `consume` runs. Without these, the manifest and the
-   editorial pass sit uncommitted for the whole span Decision 3's recovery
-   design protects, and `--repair-manifest`'s git-history restore has nothing
-   to restore from until Step 5 — see Decision 3's "Interrupted preparation
-   resumes intact" bullet, which this step implements.
+6. **Update the release path.** Protocol 05 Step 3 (assemble — now also
+   deletes the fragments it gathered — editorial pass, link definitions) and
+   Step 7.2's artifact validation, then the three prepare-release command and
+   skill surfaces. **No new commit is added anywhere in Protocol 05.** Step 5
+   remains the protocol's only "Commit" step, unchanged, and now covers the
+   assembled section, the fragment deletions, the editorial pass, and the
+   version bump together, in the one commit it already produces today.
 
    *Verify*: read Step 3 end to end and confirm a releaser can execute it
    without consulting this plan, that the editorial pass still appears
-   between assembly and consumption, and that the two new commit points are
-   both present and both precede Step 5. Confirm by inspection that a
-   `--repair-manifest` run immediately after the first of the two commits
-   (i.e. before the editorial pass) would find that commit in `git log`.
+   between assembly and the link-reference definitions, and that `git diff`
+   on Protocol 05 adds no new "Commit" step anywhere before the existing
+   Step 5.
 
-8. **Update the implementation path.** Protocol 03 Paths 1–3, leaving Path 4
+7. **Update the implementation path.** Protocol 03 Paths 1–3, leaving Path 4
    untouched; then `.claude/agents/developer.md`,
    `.cursor/agents/developer.md`, `.cursor/rules/workflow.mdc`, and
    `.cursor/commands/implement-development.md`.
@@ -1160,7 +1033,7 @@ changelog.d/1589.fixed.integration-branch-ci.md
    *Verify*: `git diff` on Protocol 03 shows no change within the hotfix path,
    and the four agent surfaces carry the same instruction as each other.
 
-9. **Update the orchestration and merge paths.** Protocol 90 Steps 3.6 and 5.1,
+8. **Update the orchestration and merge paths.** Protocol 90 Steps 3.6 and 5.1,
    Protocol 91's two parallel-batch paragraphs, Protocol 94 Step 4.3 per
    Decision 6, Protocol 05b Step 2.5, and the batch-merge command and skill
    surfaces. In `batch-merge.sh`, add the clarifying sentence to the
@@ -1171,19 +1044,19 @@ changelog.d/1589.fixed.integration-branch-ci.md
    and the other batch-merge suites pass unchanged, confirming no behavioural
    change was introduced.
 
-10. **Update the review contract and remaining documentation.** `REVIEW.md`,
-    `LLM_RULES.md`, `.haystack/pr-rules.yml`, `.haystack/review-policy.md`
-    (add `changelog.d/**` to the release-and-changelog-automation path list),
-    the `haystack-reviewer.sh` comment block (including the corrected rule
-    id), `haystack-triage.md`, `AGENTS.md`, `README.md`, both best-practices
-    files, both script READMEs, the spec and plan protocols, the plan
-    template, and `docs/testing/workflow/batch-merge.smoke-test.md`.
+9. **Update the review contract and remaining documentation.** `REVIEW.md`,
+   `LLM_RULES.md`, `.haystack/pr-rules.yml`, `.haystack/review-policy.md`
+   (add `changelog.d/**` to the release-and-changelog-automation path list),
+   the `haystack-reviewer.sh` comment block (including the corrected rule
+   id), `haystack-triage.md`, `AGENTS.md`, `README.md`, both best-practices
+   files, both script READMEs, the spec and plan protocols, the plan
+   template, and `docs/testing/workflow/batch-merge.smoke-test.md`.
 
-    *Verify*: `bash scripts/development-workflow/tests/test-haystack-reviewer.sh`
-    passes, and the rule id quoted in the script matches an id present in
-    `.haystack/pr-rules.yml`.
+   *Verify*: `bash scripts/development-workflow/tests/test-haystack-reviewer.sh`
+   passes, and the rule id quoted in the script matches an id present in
+   `.haystack/pr-rules.yml`.
 
-11. **Ship the convention downstream.** Add the `changelog.d/README.md` entry to
+10. **Ship the convention downstream.** Add the `changelog.d/README.md` entry to
     `sync-manifest.yaml` under `always_sync` with `mode_scope: shared` and a
     note recording that fragment files are intentionally unlisted.
 
@@ -1191,7 +1064,7 @@ changelog.d/1589.fixed.integration-branch-ci.md
     passes, and reading the manifest confirms no `project_specific` entry was
     added for `changelog.d/`.
 
-12. **Record this item's own release note the new way.** Create
+11. **Record this item's own release note the new way.** Create
     `changelog.d/1554.changed.per-item-release-notes.md` containing exactly:
 
     ```markdown
@@ -1199,8 +1072,9 @@ changelog.d/1589.fixed.integration-branch-ci.md
       each work item now records its release note in its own `changelog.d/` file,
       so two items worked in parallel no longer edit the same lines and cannot
       conflict. Release preparation gathers the pending notes into a draft
-      version section, which the releaser edits before publishing; the notes are
-      removed when the release merges.
+      version section and deletes the fragments in the same step; the releaser
+      edits the draft before publishing, and the deletions become permanent
+      only when the release merges.
     ```
 
     Do **not** add an entry to `CHANGELOG.md` — this PR is the change that ends
@@ -1211,10 +1085,10 @@ changelog.d/1589.fixed.integration-branch-ci.md
     reports `VALIDATE_RESULT=clean` with the new fragment counted, and
     `git diff --name-only origin/develop...HEAD` does not list `CHANGELOG.md`.
 
-13. **Run the residual verification** described in the next section and include
+12. **Run the residual verification** described in the next section and include
     its table in the PR description.
 
-14. **Execute the smoke test runbook** at
+13. **Execute the smoke test runbook** at
     `docs/testing/workflow/1554-changelog-fragments.smoke-test.md` and record
     the results.
 

--- a/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
+++ b/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
@@ -170,16 +170,30 @@ This is exactly the same allocation model as an issue tracker's own
 identifiers (Decision 1's primary case), just issued by the hosting platform
 instead of the tracker.
 
-**Consequence for authoring order**: in no-tracker mode, the fragment's
-final filename cannot be written before the PR exists, because the number
-it depends on does not exist yet. An author working before opening a PR
-uses any locally convenient temporary name and **renames** the file to the
-assigned PR number as part of opening the PR (or promptly afterward) — the
-rename is a single `git mv`, not a data migration, since the body content is
-unaffected. `changelog.d/README.md` states this explicitly, and `validate`
-does not special-case it: the readiness gate (Decision 5) that checks for a
-fragment on the PR's file list already runs *after* the PR exists, so by the
-time it matters the number is always known.
+**Consequence for authoring order — the PR opens before the fragment is
+named, not after.** In no-tracker mode, the fragment's final filename cannot
+be written before the PR exists, because the number it depends on does not
+exist yet. Protocol 03 Paths 1–3 normally write the release note as one of
+the last steps before opening the PR (Layer-by-Layer Changes); in no-tracker
+mode that order is reversed for this one step: **open the PR first — a
+draft is sufficient — note its number, then create the fragment directly as
+`<PR-number>.<kind>.<slug>.md` and run `validate` on it**, exactly like the
+tracker case, because by that point it is the tracker case in every way that
+matters to `validate` — the identifier already exists and is already known.
+This needs no change to `validate` itself and no second, body-only
+validation mode: there is no temporary name for `validate` to special-case,
+because there is no longer a step where the fragment is written before its
+final identifier is known. `changelog.d/README.md` and the no-tracker
+carve-out in Protocol 03 (Layer-by-Layer Changes) both state this ordering
+explicitly, so an author is never instructed to validate a name that is
+about to change.
+
+An author who genuinely wants to draft the note's body before any PR
+exists — a personal preference, not something this workflow requires — may
+do so in a scratch file outside `changelog.d/` (so it is not a candidate for
+`validate` or the readiness scan at all) and move the finished text into the
+correctly-named fragment once the PR is open. This is ordinary editing
+practice, not a second code path.
 
 In this mode the body's `(#N)` reference (Decision 2's worked examples) is
 **omitted entirely** — there is no issue number to reference (the PR number
@@ -263,12 +277,20 @@ record that the commit's own diff doesn't already show.
 **How the three spec rules hold, by construction, not by a state machine:**
 
 1. **Gathering is repeatable.** `assemble --version <X.Y.Z>` checks exactly
-   one fact: does `## [X.Y.Z] - YYYY-MM-DD` already exist in `CHANGELOG.md`?
-   If yes, `ASSEMBLE_RESULT=already_assembled`, exit 0, no write — the
-   idempotence guarantee, decidable from the working tree alone, no second
-   artifact to cross-check. (See "Residual interruption window" below for the
-   one narrow case this check alone does not fully close, and how it is
-   closed without a new artifact.)
+   one fact: does a `## [X.Y.Z]` section — matched on the **version label
+   alone**, never the trailing `- YYYY-MM-DD` — already exist in
+   `CHANGELOG.md`? If yes, `ASSEMBLE_RESULT=already_assembled`, exit 0, no
+   write — the idempotence guarantee, decidable from the working tree alone,
+   no second artifact to cross-check. The date is display data written once,
+   at assembly time, from `--date` (default: the day `assemble` runs); it is
+   never part of the identity `assemble` compares against on a later run. A
+   version is assembled once per release regardless of what calendar date
+   that assembly happens to fall on or be retried on — keying the check on
+   the dated string as well would make a same-day-vs-next-day retry
+   indistinguishable from "not yet assembled," which is exactly backwards.
+   (See "Interrupted assembly is a dirty working tree" below for the one
+   narrow case this check alone does not fully close, and why it needs no
+   new artifact, sweep, or identity scheme to close it.)
 2. **Notes are consumed at publish, not at assembly.** `assemble` runs on
    the release branch's local working tree. Its edits — the new
    `CHANGELOG.md` section and the fragment deletions — are ordinary
@@ -289,80 +311,118 @@ record that the commit's own diff doesn't already show.
    `already_assembled` and never looks at `changelog.d/` again — the late
    fragment is untouched, stays in `changelog.d/`, and is picked up by the
    next assembly. It is included in *this* release only if the releaser
-   deliberately discards the assembled state first (below, "There is no
-   `--reassemble` flag") and re-runs `assemble` fresh — a human editorial
-   choice, never something any part of `assemble` itself does automatically.
+   deliberately discards the assembled state first (below, "Recovering from
+   an interrupted or unwanted `assemble` run") and re-runs `assemble` fresh —
+   a human editorial choice, never something any part of `assemble` itself
+   does automatically.
 
-**Assembly, concretely.** When the heading does not yet exist, `assemble`:
-validates every top-level fragment in `changelog.d/` (Decision 1's grammar);
-builds the new section (Decision 4: rename `## [Unreleased]`, merge fragment
-bullets by kind, carry over the existing shared-block bullets); writes
-`CHANGELOG.md` via a temp file, `fsync`, and one atomic `rename(2)` call (kept
-from the earlier design — it is one `mktemp`/`mv` pair, not a state machine,
-and it means a process kill mid-write leaves `CHANGELOG.md` exactly at its
-pre-assembly content, never truncated); then deletes each fragment file that
-fed the section. It reports `ASSEMBLE_RESULT=assembled`, `VERSION`,
-`FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`, and `ITEMS` — the same reporting the
-manifest previously existed partly to support, now emitted directly from the
-one live scan `assemble` already performed, with nothing persisted to disk
-for later inspection because nothing needs to be inspected later: the commit
-diff is that record (see "Audit trail" below).
+**Assembly, concretely.** When no `## [X.Y.Z]` section (any date) exists yet,
+`assemble`: validates every top-level fragment in `changelog.d/` (Decision
+1's grammar); builds the new section (Decision 4: rename `## [Unreleased]`,
+merge fragment bullets by kind, carry over the existing shared-block
+bullets); writes `CHANGELOG.md` via a temp file, `fsync`, and one atomic
+`rename(2)` call (kept from the earlier design — it is one `mktemp`/`mv`
+pair, not a state machine, and it means a process kill mid-write leaves
+`CHANGELOG.md` exactly at its pre-assembly content, never truncated); then
+deletes each fragment file that fed the section. It reports
+`ASSEMBLE_RESULT=assembled`, `VERSION`, `FRAGMENT_COUNT`,
+`CARRIED_OVER_COUNT`, and `ITEMS` — the same reporting the manifest
+previously existed partly to support, now emitted directly from the one live
+scan `assemble` already performed, with nothing persisted to disk for later
+inspection because nothing needs to be inspected later: the commit diff is
+that record (see "Audit trail" below).
 
-**Residual interruption window, and why it does not need a manifest.** A
+**`--allow-empty`, defined.** When there is no pending fragment and the
+shared block is empty, the default is `ASSEMBLE_RESULT=no_notes`, exit 3,
+and no write (Gate A). `--allow-empty` overrides that stop for a release the
+team has decided to cut with no user-facing notes. It follows exactly the
+same "Assembly, concretely" path above with a zero-length fragment and
+carried-over set: it renames `## [Unreleased]` to the version heading (still
+performed — Decision 4's step 1 is unconditional), merges nothing (there is
+nothing to merge), inserts a fresh empty `## [Unreleased]` above it, and
+deletes nothing (there is nothing to delete — the whole reason this path
+exists is that no fragment fed it). The published section is therefore an
+empty version heading with no bullets under it, exactly as a human
+publishing a deliberately empty release would write by hand today.
+`ASSEMBLE_RESULT=assembled`, exit 0, with `FRAGMENT_COUNT=0` and
+`CARRIED_OVER_COUNT=0` — the same result and fields as any other successful
+assembly, not a distinct outcome, because from `CHANGELOG.md`'s point of
+view it is not distinct: the only difference is which counts came out as
+zero.
+
+**Interrupted assembly is a dirty working tree, not a state to identify.** A
 process kill *between* the `CHANGELOG.md` write succeeding and the fragment
 deletions finishing is still possible (deleting N small files is not one
-atomic operation). Left unaddressed, a re-run's idempotence check would see
-the heading and stop before finishing those deletions, permanently orphaning
-the undeleted fragment — which a *later* release's assembly would then
-gather again, publishing its bullet a second time.
+atomic operation). Two earlier fixes tried to name and recover that specific
+partial state — first by matching a fragment's tracker/PR-number reference
+against the published section, then, when that was shown to collide with a
+second pending fragment for the same item, by matching the fragment's exact
+body text instead. The body-matching fix has the identical flaw one level
+down: bullet text is not a durable identity either — the same normalized
+body can legitimately appear in more than one fragment (or already be part
+of the carried-over shared-block content), and the releaser's own editorial
+pass *edits the published text*, so "does this fragment's body still appear
+verbatim" can go from true to false through completely intended action, not
+just through interruption. Three attempts at naming this partial state
+follow the same trend Decision 3's manifest removal already diagnosed: each
+fix's own identity scheme was the thing wrong with it, not an oversight in
+applying it. **The fix is to stop trying to identify the partial state at
+all.**
 
-**The sweep matches on the fragment's own body, not on the item reference.**
-An earlier version of this fix matched by searching the published section for
-`(#<item>)` — the item's tracker or PR-number reference. That is not precise
-enough: this plan explicitly permits more than one fragment for the same
-item (two notes from the same item "live on one branch," Decision 1), and in
-no-tracker mode the body carries no `(#N)` at all, so there would be nothing
-to match against. Matching on the item reference cannot distinguish "this
-exact fragment's bullet was published" from "some fragment for this item was
-published" — a second, still-pending fragment for the same item would match
-and be wrongly deleted, exactly reproducing the loss the sweep exists to
-prevent, just relocated to a same-item case instead of the interruption case.
+Nothing `assemble` does is committed until Step 5, so an interrupted run
+never leaves anything durable to reconcile — it leaves an ordinary dirty
+working tree, the same kind Step 3's editorial pass already sits in for as
+long as the polish takes. The recovery for a dirty working tree is the
+ordinary one: discard the uncommitted changes and start over. There is
+nothing to *identify*, because the *entire* set of `assemble`'s uncommitted
+changes — however far it got — is exactly what must be discarded, and
+"however far it got" is never partially wrong for the fragments it did
+finish deleting, because it deletes only fragments it also just gathered
+into the write that preceded them.
 
-The corrected check matches on **the fragment's own body**: `assemble`
-normalizes each remaining fragment's body the same way `validate` already
-does (CRLF to LF, trailing whitespace trimmed) and checks whether that exact
-text — the complete bullet, including any continuation lines, as one
-contiguous block — appears verbatim inside the already-published
-`## [X.Y.Z]` section. Only then is the fragment deleted. This is precise by
-construction, in every mode: two fragments for the same item necessarily
-have different bodies (they are different bullets), so body matching tells
-them apart where item-number matching could not; and no-tracker fragments
-are matched the same way, since the check never depended on `(#N)` existing
-in the first place. A fragment is only ever removed by this path if its own
-content is already visible in the published section, so a genuinely late
-fragment — for a new item, a second fragment on the same item, or a
-no-tracker fragment — is never touched by it. Rule 3 still holds. This
-closes the gap with a body-text comparison inside the idempotence check, not
-a new command, file, exit code, or recovery flag.
+**Recovering from an interrupted or unwanted `assemble` run — one precise
+operation, not two.** Both "assemble was killed mid-run" and "the releaser
+wants to deliberately discard a completed assembly and redo it before the
+editorial pass" resolve to the same fix, because both are still entirely
+uncommitted:
 
-**There is no `--reassemble` flag.** An earlier draft included one, to let
-the releaser deliberately discard the published section and redo assembly
-from a live rescan — but a CodeRabbit round found it non-transactional (it
-deleted the existing section before validating and building the
-replacement, so a failure between those two steps left `CHANGELOG.md`
-without a section at all, and without one to restore from). Rather than add
-the machinery to make deletion-then-rebuild safe (build the replacement
-first, then swap it in — itself a second atomic-write path to design and
-test), this plan asks whether the flag is still pulling its weight now that
-there is no manifest for it to repair, and the answer is no: nothing is
-committed until the releaser's own Step 5, so "discard and redo" is already
-an ordinary git operation with no data at risk — `git checkout -- CHANGELOG.md
-changelog.d/` before any commit, or `git revert`/`git reset` after one,
-followed by a fresh `assemble` run, which naturally rescans because nothing
-still claims `already_assembled`. Removing the flag deletes the
-transactionality problem along with it, rather than solving it, and shrinks
-the interface `assemble` presents to exactly one command with no redo path
-to keep safe.
+- **Exact paths**: `git checkout -- CHANGELOG.md changelog.d/`. Nothing
+  else needs to be touched, and nothing else may safely be — no other path
+  is part of what `assemble` mutates.
+- **When it is safe — before this command, check one thing**: did `assemble`
+  print its `ASSEMBLE_RESULT=assembled` completion line (with
+  `FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`, and `ITEMS`) on this attempt? If
+  **no** — the process was killed, crashed, or is still running — discarding
+  is safe by construction: assembly never finished, so the editorial pass
+  (Protocol 05's next sub-step) cannot have started yet, and there is
+  nothing of the releaser's to lose. If **yes** — assembly completed, and
+  anything now present beyond the raw assembled output (however small) may
+  be the releaser's own edit — **do not run this command**; there is
+  nothing to recover from, and running it would discard real editorial
+  work. Resume normally instead: the working tree already holds exactly
+  what it should.
+- **What the operator sees**: after a safe discard, `git status --porcelain`
+  reports nothing for `CHANGELOG.md` or `changelog.d/` — the working tree is
+  back to its pre-assembly state, identical to before `assemble` was ever
+  run for this version. A fresh `assemble --version <X.Y.Z>` run then
+  behaves exactly like a first attempt, because it is one: the version
+  label is absent again, so the idempotence check (fact 1) does not
+  short-circuit it.
+- **This does not extend past Step 5.** Once Step 5's commit exists, there
+  is no single command this plan can specify safely in the abstract: that
+  commit also carries the version-manifest bump and whatever else Step 4
+  added, which Decision 3 has no visibility into, and a blanket
+  `git revert`/`git reset` risks undoing those alongside the assembly. A
+  releaser who wants to redo assembly after Step 5 has already committed
+  reconciles that specific commit by hand — `git commit --amend` if it is
+  the tip and unpushed, or a new follow-up commit otherwise — not through
+  guidance this plan states in general terms.
+
+This closes the interruption gap with an operator check the releaser already
+has the information to answer (did the command finish?) and one `git`
+invocation whose safety follows from Protocol 05's own step ordering, not
+from a new command, file, exit code, or identity scheme for `assemble` to
+maintain.
 
 **Audit trail.** The spec's Operational Visibility principle — "released"
 and "not yet released" visible from repository state rather than inferred —
@@ -474,7 +534,7 @@ recorded", each of which must accept a fragment:
 | Surface | What it asserts today | Change |
 | --- | --- | --- |
 | `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` Step 5.1 table | `CHANGELOG.md` in `files` for `feature/*`, `fix/*`, `refactor/*`, `hotfix/*` | Split into two branch-specific conditions: `feature/*`, `fix/*`, `refactor/*` require a strict-grammar `changelog.d/` fragment (not `CHANGELOG.md`, and not README/manifest/malformed paths under `changelog.d/`); `hotfix/*` still requires `CHANGELOG.md` exclusively — a fragment does not satisfy the hotfix gate |
-| `docs/workflow/development-workflow/protocols/03-implement-development-protocol.md` | Four per-path "Update CHANGELOG" steps and two PR-body "CHANGELOG entry preview" bullets | Paths 1–3 write a fragment; Path 4 (hotfix) unchanged; previews renamed to "release note preview" |
+| `docs/workflow/development-workflow/protocols/03-implement-development-protocol.md` | Four per-path "Update CHANGELOG" steps and two PR-body "CHANGELOG entry preview" bullets | Paths 1–3 write a fragment; Path 4 (hotfix) unchanged; previews renamed to "release note preview"; add a no-tracker carve-out noting the fragment step comes *after* opening the PR (a draft is sufficient), not before, so the filename's PR-number identifier (Decision 1) is already known when the fragment is created and `validate` runs |
 | `REVIEW.md` (spec exemption, plan exemption, code-review checklist, reviewer-finding list) | Spec and plan branches must not touch `CHANGELOG.md`; code review flags a missing entry | Extend the exemptions to `changelog.d/`; restate the code-review item in terms of a release note |
 | `LLM_RULES.md` | "Do not skip CHANGELOG updates for feature/fix PRs" | Restate as "record a release note"; point at the fragment convention |
 | `.haystack/pr-rules.yml` rule `keep-single-unreleased-changelog-section` | Agents must not create duplicate `[Unreleased]` headers | Keep the rule (it still guards hotfix and release edits); retarget its message to those contexts |
@@ -583,17 +643,22 @@ other workflow helpers, and every exit path prints its documented fields.
          `ASSEMBLE_RESULT=invalid`, exit 1, regardless of the heading or
          shared-block state — a malformed fragment is never assembled and
          never mistaken for "nothing pending."
-      2. Else, if `## [X.Y.Z] - YYYY-MM-DD` already exists in `CHANGELOG.md`:
-         perform the residual-interruption sweep (delete any remaining
-         fragment whose exact, normalized body already appears verbatim in
-         that section — see Decision 3's "Residual interruption window"),
-         then report `ASSEMBLE_RESULT=already_assembled`, exit 0, no
-         `CHANGELOG.md` write.
+      2. Else, if a `## [X.Y.Z]` section already exists in `CHANGELOG.md`
+         — matched on the version label alone, never the trailing
+         `- YYYY-MM-DD` (Decision 3, fact 1) — report
+         `ASSEMBLE_RESULT=already_assembled`, exit 0, no write, no scan of
+         `changelog.d/`. There is no sweep (Decision 3,
+         "Interrupted assembly is a dirty working tree"): an interrupted run
+         is recovered by discarding the uncommitted working tree and
+         re-running, never by identifying and cleaning up a partial state.
       3. Else, if there is no pending fragment and the shared block is
-         empty: `ASSEMBLE_RESULT=no_notes`, exit 3, unless `--allow-empty`.
+         empty: `ASSEMBLE_RESULT=no_notes`, exit 3, unless `--allow-empty`
+         (Decision 3, "`--allow-empty`, defined").
       4. Else: build the version section (Decision 4), write `CHANGELOG.md`
          via temp file, `fsync`, and one atomic `rename(2)`, then delete each
-         fragment that fed the section. `ASSEMBLE_RESULT=assembled`, exit 0.
+         fragment that fed the section. `ASSEMBLE_RESULT=assembled`, exit 0
+         (also the outcome for a `--allow-empty` run with nothing pending —
+         see Decision 3).
       Emits `ASSEMBLE_RESULT`, `VERSION`, `FRAGMENT_COUNT`,
       `CARRIED_OVER_COUNT`, and `ITEMS`. (Spec AC-3, AC-5, AC-6, AC-7, AC-10;
       Decisions 3 and 4)
@@ -611,8 +676,11 @@ New directory:
 - [ ] `changelog.d/README.md` — the filename grammar, the six kinds, the body
       convention (a complete markdown bullet including the `**Bold Title**
       (#N):` prefix, and the no-tracker exception that drops `(#N)`
-      entirely — Decision 1), and a worked example. It is excluded from the
-      fragment scan by name.
+      entirely — Decision 1), the no-tracker authoring order (open the PR
+      *before* naming the fragment, so `<item>` — the PR number — is already
+      known when `validate` runs; never write a fragment under a temporary
+      name and validate that instead), and a worked example. It is excluded
+      from the fragment scan by name.
 
 `changelog.d/` has no other new directory to create: Decision 3 introduces no
 manifest, so there is nothing for a fresh downstream clone to be missing —
@@ -873,16 +941,16 @@ test in `scripts/development-workflow/tests/test-changelog-fragments.sh`.
 | 21 | No `## [Unreleased]` heading | Rejected; the heading is a precondition that `auto-tag-release.yml` also depends on |
 | 22 | Two `## [Unreleased]` headings | Rejected |
 | 23 | Any fragment fails validation, regardless of whether `## [X.Y.Z]` already exists or the shared block is empty | `ASSEMBLE_RESULT=invalid`, exit 1 — validation is checked first (Gate A), so this is never overridden by `already_assembled` or `no_notes` |
-| 24 | `## [X.Y.Z]` already present, every fragment valid | `ASSEMBLE_RESULT=already_assembled`, exit 0, no `CHANGELOG.md` write — the idempotence mechanism (Decision 3). Before returning, the residual-interruption sweep (row 32) still runs |
+| 24 | `## [X.Y.Z]` already present, every fragment valid | `ASSEMBLE_RESULT=already_assembled`, exit 0, no `CHANGELOG.md` write, no scan of `changelog.d/` — the idempotence mechanism (Decision 3). There is no sweep |
 | 25 | Populated shared block plus pending fragments, every fragment valid | Both merged into one version section, each entry once, with no duplicate `### Category` heading; every merged fragment is deleted in the same pass |
 | 26 | Populated shared block, zero fragments | Rename only — the pre-fragment behaviour, preserved. Nothing to delete |
-| 27 | Empty shared block, zero fragments | `ASSEMBLE_RESULT=no_notes`, exit 3, unless `--allow-empty` |
-| 28 | A kind present in fragments but absent from the shared block | Heading created in canonical Keep a Changelog order |
-| 29 | Deterministic ordering | Bullets sorted by kind rank, then by the item field (numerically when it is all digits, lexicographically otherwise), then by full filename — so two runs on the same input produce identical bytes |
-| 30 | `assemble` run twice in a row, no interruption in between | First run: `assembled`, writes the section, deletes every fragment that fed it. Second run: `already_assembled`, exit 0, no write — `changelog.d/` already has nothing left for that version to delete |
-| 31 | `assemble` interrupted after the `CHANGELOG.md` rename succeeds but before every fed fragment is deleted | On the next run, the idempotence check (row 24) fires, then the residual-interruption sweep deletes any fragment still present whose exact, normalized body already appears verbatim in the published `## [X.Y.Z]` section — closing the gap without a rescan of "what should this release contain" (only "what does this section already say") |
-| 32 | A second fragment for the same item as one already published, still pending when the sweep runs | Left untouched — the sweep matches the fragment's own body, not its item reference, so a same-item fragment whose bullet is *not* in the section is correctly distinguished from the one that already fed it |
-| 33 | A fragment sitting in `changelog.d/` whose body does **not** appear in the published `## [X.Y.Z]` section, encountered during the sweep (including a no-tracker fragment, whose body carries no `(#N)` to match on in the first place) | Left untouched — this is what keeps the sweep from ever behaving like a rescan: a fragment is deleted only when its own content is already visible in the published section, never merely because the section exists or because another fragment for the same item is there |
+| 27 | Empty shared block, zero fragments, `--allow-empty` not passed | `ASSEMBLE_RESULT=no_notes`, exit 3 |
+| 28 | Empty shared block, zero fragments, `--allow-empty` passed | `ASSEMBLE_RESULT=assembled`, exit 0, `FRAGMENT_COUNT=0`, `CARRIED_OVER_COUNT=0` — the heading is still renamed and a fresh empty `## [Unreleased]` still inserted, per Decision 4 step 1; nothing is merged or deleted because nothing fed it |
+| 29 | A kind present in fragments but absent from the shared block | Heading created in canonical Keep a Changelog order |
+| 30 | Deterministic ordering | Bullets sorted by kind rank, then by the item field (numerically when it is all digits, lexicographically otherwise), then by full filename — so two runs on the same input produce identical bytes |
+| 31 | `assemble` run twice in a row, no interruption in between | First run: `assembled`, writes the section, deletes every fragment that fed it. Second run: `already_assembled`, exit 0, no write |
+| 32 | `assemble --version 0.44.0` run, then retried later with a different `--date` (e.g. the retry crosses midnight) | Still `already_assembled`, exit 0, no write — the idempotence check matches the version label `[0.44.0]` alone; the `- YYYY-MM-DD` suffix already written is display data from the *first* run and is never re-derived or re-compared |
+| 33 | `assemble` interrupted after the `CHANGELOG.md` rename succeeds but before every fed fragment is deleted | `## [X.Y.Z]` now exists with some fragments still present in `changelog.d/`. Nothing in `assemble` identifies or repairs this automatically — it is an ordinary dirty working tree. The documented recovery is `git checkout -- CHANGELOG.md changelog.d/`, safe here because `assemble` never printed its completion line, so no editorial edit could exist yet (Decision 3, "Recovering from an interrupted or unwanted `assemble` run"); then re-run `assemble`, which behaves as a first attempt |
 
 **Suppression semantics**: not applicable. `changelog-fragments.sh` recognizes
 no inline suppression directives. Declining to write a release note is
@@ -949,7 +1017,7 @@ the first is qualified by every earlier row not matching:
 | --- | --- | --- | --- | --- |
 | 1 | `CHANGELOG.md` lacks exactly one `## [Unreleased]` heading | `error` (exit 1) | Repair the changelog before releasing | Protocol 05 Step 7.2 |
 | 2 | Any fragment fails the grammar or body checks (checked before the heading or shared-block state is considered) | `invalid` (exit 1) | Fix the named fragment on `develop` and re-run; never assemble a partial set, and never report `already_assembled` or `no_notes` for an input that also has a malformed fragment | Protocol 05; `.github/workflows/markdown-lint.yml` |
-| 3 | Every fragment valid; `## [X.Y.Z]` heading already present | `already_assembled` | No `CHANGELOG.md` write (the residual-interruption sweep may still delete leftover fragments — edge cases 31–33); continue | Same |
+| 3 | Every fragment valid; `## [X.Y.Z]` section already present (version label only — the date is never compared) | `already_assembled` | No `CHANGELOG.md` write, no scan of `changelog.d/`; continue | Same |
 | 4 | Every fragment valid; heading absent; no pending fragment and an empty shared block | `no_notes` (exit 3) | Stop; either there is nothing to release or a fragment was lost. Pass `--allow-empty` only for a deliberate no-notes release | Same |
 | 5 | Every fragment valid; heading absent; at least one pending fragment or a non-empty shared block | `assembled` | Continue to the editorial pass (Protocol 05 Step 3) | Protocol 05; `.claude/commands/prepare-release.md`; `.cursor/commands/prepare-release.md`; `.agents/skills/prepare-release/SKILL.md` |
 
@@ -1022,12 +1090,12 @@ for execution, not performed during Plan Ready.
 
 | Risk | Likelihood | Impact | Mitigation |
 | --- | --- | --- | --- |
-| An entry is lost or duplicated at the transition release, which is the hardest failure to detect after the fact | Med | High | Design the transition first, not last (tracker handoff). Assembly **moves** the shared block by renaming its heading rather than copying bullets, so duplication requires a coding error rather than an oversight; edge cases 25, 26, and 28 are asserted by fixtures before any protocol text is written |
+| An entry is lost or duplicated at the transition release, which is the hardest failure to detect after the fact | Med | High | Design the transition first, not last (tracker handoff). Assembly **moves** the shared block by renaming its heading rather than copying bullets, so duplication requires a coding error rather than an oversight; edge cases 25, 26, and 29 are asserted by fixtures before any protocol text is written |
 | The sweep misses a surface, leaving one agent instructed to edit `[Unreleased]` and reintroducing the conflict for whatever it builds | Med | High | The residual verification strategy below requires the implementation PR to re-run the repository-wide scan and account for every hit, either as changed or with a written no-change rationale |
 | The risk classifier grades the implementation PR `high` because it touches `.github/workflows/`, blocking delegated merge under the `medium` ceiling | High | Low | Known and filed as #1565. Expect an explicit merge authorization request rather than treating it as a failure |
 | File-level overlap with open PR #1589 on `.github/workflows/markdown-lint.yml` and `05b-graduate-development-protocol.md` | Med | Low | The edits are in disjoint regions (branch filters and a new top section, versus `paths:`/targets and Step 2.5). If #1589 merges first, rebase; the conflict, if any, is a normal two-region docs conflict, not the combinatorial one this item removes |
 | A release-branch delete of a fragment races an edit of that same fragment on `develop` | Low | Low | Git reports a delete/modify conflict on one file owned by one item. Editing a note after its release is already a mistake; document the resolution (keep the deletion) in Protocol 94's `changelog.d/` clause |
-| The residual-interruption sweep (edge cases 31–33) matches a fragment it should not, either deleting an unpublished same-item fragment or leaving an orphan behind | Low | Med | Edge cases 30–33 fixture the interruption, the same-item case, and the no-match case as red tests before the code exists (Implementation Order Steps 2 and 4); the sweep's correctness bar is exact-body matching, not item-reference matching, precisely because item-reference matching was tried and found imprecise in review |
+| An operator misjudges whether `assemble` finished and runs the interruption-recovery discard (`git checkout -- CHANGELOG.md changelog.d/`) after real editorial edits already exist, losing them | Low | Low | The one signal to check — did `assemble` print its `ASSEMBLE_RESULT=assembled` completion line — is unambiguous and already visible in the operator's own terminal; nothing is committed at this point either way (Decision 3), so the worst case is redoing a few minutes of editorial work, discovered immediately, not a silent or unrecoverable loss. Three prior identity schemes for this same interruption (item reference, then exact body text) were each found imprecise in review; this is deliberately not a fourth — it asks the operator a question they can already answer instead of adding another thing for `assemble` to get right |
 | Downstream projects that have not adopted fragments receive protocol updates describing a convention they do not use | Med | Low | Decision 6 keeps Protocol 94's auto-resolution and states the not-yet-adopted case explicitly; Decision 4's assembly works unchanged on a populated shared block, so adoption needs no migration |
 
 ---
@@ -1068,8 +1136,9 @@ There is no manifest file to sample: Decision 3 does not introduce one.
 
 2. **Write the test suite first, red.** Create
    `scripts/development-workflow/tests/test-changelog-fragments.sh` with one
-   case per row of the three parser-risk tables (including edge cases 30–33,
-   the interruption and residual-sweep cases), plus its `# covers:` header
+   case per row of the three parser-risk tables (including edge cases 27–33:
+   `--allow-empty`, deterministic ordering, repeatability, the cross-date
+   retry, and the interrupted-run recovery), plus its `# covers:` header
    lines. Every case fails at this point because the helper does not exist.
 
    *Verify*: running the suite reports failures for every case and no case is
@@ -1082,31 +1151,28 @@ There is no manifest file to sample: Decision 3 does not introduce one.
    the changelog-rewriting cases still fail.
 
 4. **Implement `assemble`.** Precedence order (Gate A: invalid before
-   already_assembled/no_notes/assembled); the idempotence check (does
-   `## [X.Y.Z]` already exist); the residual-interruption sweep on that path,
-   matching each remaining fragment's exact normalized body against the
-   published section text, never its item reference (edge cases 31–33);
-   otherwise: validate pending fragments, build the section (heading rename,
-   per-kind merge, fresh empty `## [Unreleased]`, deterministic ordering),
-   write `CHANGELOG.md` via temp file, `fsync`, and one atomic `rename(2)`,
-   then delete every fragment that fed the section; and `no_notes`. There is
-   no lock, no manifest, and no `--reassemble` flag to implement (Decision 3).
+   already_assembled/no_notes/assembled); the idempotence check, matched on
+   the version label alone, never the trailing date (edge case 32);
+   `--allow-empty`'s defined outcome (edge case 28); otherwise: validate
+   pending fragments, build the section (heading rename, per-kind merge,
+   fresh empty `## [Unreleased]`, deterministic ordering), write
+   `CHANGELOG.md` via temp file, `fsync`, and one atomic `rename(2)`, then
+   delete every fragment that fed the section; and `no_notes`. There is no
+   lock, no manifest, no `--reassemble` flag, and no residual-interruption
+   sweep to implement (Decision 3) — an interrupted run is left exactly as
+   it is; recovery is documented, not automated.
 
    *Verify*: the changelog-rewriting cases pass, and the suite's assembled
    fixtures are checked with `node_modules/.bin/markdownlint-cli2`,
    `markdown-heuristic-lint.py`, and `check-changelog-duplicate-headers.sh`
    inside the suite itself — all three AC-9 checks, not two. A case that
-   kills the process after the `CHANGELOG.md` write but before every fed
-   fragment is deleted, then re-runs `assemble`, confirms the sweep finishes
-   the deletions and `CHANGELOG.md` is unchanged by the second run. A case
-   with a genuinely unrelated fragment present during that same re-run
-   confirms the sweep does not touch it. A case with a **second, still-pending
-   fragment for the same item** as the one just published (edge case 32)
-   confirms the sweep leaves it alone — proving the match is on body content,
-   not the item reference. A case with a no-tracker fragment (no `(#N)` in
-   its body) present during the same re-run confirms the sweep still
-   correctly leaves it untouched when it was never published, and still
-   correctly deletes it when it was.
+   asserts the idempotence check for a second run passing a **different**
+   `--date` than the first still reports `already_assembled` with
+   `CHANGELOG.md` unchanged (edge case 32). A case that kills the process
+   after the `CHANGELOG.md` write but before every fed fragment is deleted,
+   then runs `git checkout -- CHANGELOG.md changelog.d/` followed by a fresh
+   `assemble`, confirms the documented recovery (edge case 33) reproduces
+   the same result as an uninterrupted run, byte-for-byte.
 
 5. **Wire the lint and CI surfaces.** Update
    `.github/workflows/markdown-lint.yml` (`paths:`, both independent

--- a/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
+++ b/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
@@ -187,7 +187,16 @@ rather than an ambiguous one**:
    `CHANGELOG.md` is touched.
 2. The draft `## [X.Y.Z] - YYYY-MM-DD` section written into `CHANGELOG.md`,
    built from exactly the fragment set already recorded in the manifest —
-   never a fresh directory scan. **Written second.**
+   never a fresh directory scan. **Written second**, and with the same
+   atomicity guarantee as the manifest: the full new file content is written
+   to a temp file in the same directory, flushed and `fsync`'d, then renamed
+   over `CHANGELOG.md` in one `rename(2)` call. A process stop during this
+   step therefore never produces a truncated or partially-rewritten
+   `CHANGELOG.md` — on disk, the file is always either byte-for-byte the
+   pre-assembly content or byte-for-byte the fully assembled content, with no
+   third possibility. This is what makes the four states below exhaustive:
+   without it, a stop mid-rewrite would leave a *fifth*, undetectable state (a
+   corrupt file) that none of them names.
 
 Fragment files themselves are **not touched by assembly**. This is the literal
 requirement from the spec ("Assembling a draft never destroys anything") and
@@ -207,20 +216,40 @@ fragments violates the corrected clause.
   - Manifest present, heading present: `ASSEMBLE_RESULT=already_assembled`,
     exit 0, no write. The normal resume path.
   - Manifest present, heading absent: the run was interrupted between the two
-    writes. `assemble` completes the `CHANGELOG.md` write from the
-    already-frozen manifest (not a rescan), then reports
+    writes — and, because the `CHANGELOG.md` write is itself atomic (point 2
+    above), `CHANGELOG.md` on disk is guaranteed to still be exactly its
+    pre-assembly content, never a partial rewrite. `assemble` performs the
+    `CHANGELOG.md` write (temp file, `fsync`, atomic rename) from the
+    already-frozen manifest, not a rescan, then reports
     `ASSEMBLE_RESULT=assembled`, exit 0. Because the set was fixed before the
     interruption, this is safe even if new fragments landed on `develop`
     afterward — "the set is fixed at assembly" still holds.
   - Manifest absent, heading present: the manifest was lost by something other
     than `consume` (which moves it — see below — rather than deleting it),
     since assembly never reaches the `CHANGELOG.md` write before the manifest
-    is committed. `assemble` reports
-    `ASSEMBLE_RESULT=assembled_unmanifested`, a non-zero exit, and names the
-    remediation: `assemble --reassemble`, which recomputes the manifest from
-    the current directory and, by the deterministic-ordering guarantee (Edge
-    case 28), reproduces byte-identical `CHANGELOG.md` content — safe to run
-    even though the version section already exists.
+    is committed. `assemble` reports `ASSEMBLE_RESULT=assembled_unmanifested`,
+    a non-zero exit. **The remediation is `assemble --repair-manifest`, never
+    a live directory rescan.** A rescan is explicitly wrong here: the spec
+    guarantees a note recorded after assembly belongs to the next release,
+    never retroactively to the one being prepared, and a fragment can
+    legitimately have landed in `changelog.d/` between the original assembly
+    and the manifest's loss (a late fix cherry-picked onto the release branch,
+    for instance). Recomputing "the current set" would silently pull that
+    fragment into an already-published-looking section. `--repair-manifest`
+    instead restores the manifest from the one source that reflects the set
+    **as it was at assembly time**: git history. It walks the current
+    branch's log for `changelog.d/manifests/v<X.Y.Z>.txt` and, if a commit
+    wrote that exact path, restores that commit's blob verbatim (`git show
+    <commit>:<path>`) — not a rescan, a byte-for-byte restoration of what was
+    actually frozen. On success it reports `ASSEMBLE_RESULT=repaired`, exit 0.
+    If no commit ever wrote that path (the manifest was lost before the
+    releaser committed it), `--repair-manifest` **refuses to guess**: it
+    reports `ASSEMBLE_RESULT=manifest_unrecoverable`, exit 1, and instructs
+    the operator to reconcile by hand — compare the `## [X.Y.Z]` section's
+    bullets against the fragment bodies still present in `changelog.d/` to
+    reconstruct the original set, or, only as a knowing last resort whose risk
+    the operator accepts explicitly, fall back to `assemble --reassemble` (see
+    below), which is never invoked automatically.
   - Manifest absent, heading absent: nothing has happened yet; `assemble` runs
     normally.
 - **Interrupted preparation resumes intact.** Both artifacts are ordinary
@@ -229,33 +258,64 @@ fragments violates the corrected clause.
   four states above instead of guessing. If the release branch is discarded
   entirely, `develop` still holds every fragment, because nothing was ever
   deleted there.
+- **Consumption requires a publishable section, not just a manifest.** Before
+  deleting anything, `consume` checks the manifest **and** the `## [X.Y.Z]`
+  heading — the same two facts `assemble` checks, in the same order of
+  concern. A manifest can exist while the heading does not: that is exactly
+  the "manifest present, heading absent" interrupted-assembly state above,
+  and it means assembly never finished writing the section. If `consume` ran
+  anyway, it would delete the source fragments and move the manifest with no
+  version section to show for them — the release's notes would be gone with
+  nothing published, which is precisely the "no unreleased note may be
+  silently left behind" failure the spec forbids. So: manifest present,
+  heading absent → `CONSUME_RESULT=not_assembled`, non-zero exit, deletes
+  nothing, and names the remediation: run `assemble` first (which completes
+  the interrupted write and lands on `already_assembled`, at which point
+  `consume` is safe).
 - **Consumption happens at publication, and its idempotence marker is a
-  positive fact, not an absence.** `consume` deletes exactly the fragment
-  files named in the manifest, then **moves** — never deletes — the manifest
-  itself to `changelog.d/manifests/consumed/v<X.Y.Z>.txt`, as a commit on the
-  release branch. This both strengthens the spec's Audit Trail principle (a
-  permanent record of what fed each published release) and removes the
-  ambiguity a delete would otherwise reintroduce:
-  - Manifest present in `changelog.d/manifests/`: normal `consumed` path.
+  positive fact, not an absence.** Once the section-exists precondition
+  passes, `consume` deletes the fragment files named in the manifest one at a
+  time, then **moves** — never deletes — the manifest itself to
+  `changelog.d/manifests/consumed/v<X.Y.Z>.txt` via a single `rename(2)` call
+  (both paths are on the same filesystem, under `changelog.d/`), so the move
+  itself cannot be interrupted into a state where the manifest is absent from
+  both locations — the "absent from both" state below can only result from
+  something outside these two commands, never from `consume`'s own crash
+  window. This both strengthens the spec's Audit Trail principle (a permanent
+  record of what fed each published release) and removes the ambiguity a
+  delete would otherwise reintroduce, as a commit on the release branch:
+  - Heading present, manifest present in `changelog.d/manifests/`, every
+    listed file present: normal `consumed` path.
+  - Heading present, manifest present in `changelog.d/manifests/`, **some or
+    all** listed files already absent: an interrupted consume — a prior run
+    stopped after deleting some fragments but before moving the manifest.
+    Per-file deletion is idempotent (skipping a file that is already gone is
+    not an error), so resuming simply finishes deleting whatever remains and
+    then performs the manifest move. This still reports
+    `CONSUME_RESULT=consumed`, exit 0 — from the operator's point of view, the
+    step that was interrupted just completes.
   - Manifest present in `changelog.d/manifests/consumed/`, absent from
     `changelog.d/manifests/`: `CONSUME_RESULT=already_consumed`, exit 0 —
     confirmed by the moved file's presence, not its absence.
-  - Manifest absent from **both** locations, version section present: no
-    longer conflated with `already_consumed`. Reports
-    `CONSUME_RESULT=inconsistent`, non-zero exit, and instructs the operator
-    to reconcile by hand — this is `assembled_unmanifested`'s sibling failure
-    mode surfacing at `consume` time instead of `assemble` time, and it must
-    fail loudly for the same reason.
+  - Manifest absent from **both** locations, heading present: no longer
+    conflated with `already_consumed`. Reports `CONSUME_RESULT=inconsistent`,
+    non-zero exit, and instructs the operator to reconcile by hand — this is
+    `assembled_unmanifested`'s sibling failure mode surfacing at `consume`
+    time instead of `assemble` time (both manifest locations empty is not a
+    state either command's normal flow produces), and it must fail loudly for
+    the same reason.
   Those deletions and the manifest move reach `main` and `develop` only when
   the release PRs merge — which is what "published" means. An abandoned
   release deletes nothing anywhere that survives.
-- **Re-assembly is possible but explicit.** `assemble --reassemble` recomputes
-  the manifest from the current directory and replaces the existing version
-  section. It prints the section it is about to replace before replacing it,
-  because that section may contain the releaser's editorial pass. Besides the
-  `assembled_unmanifested` recovery path above (which reuses it), it is the
-  only path that discards editorial edits, and it is never invoked by protocol
-  05's normal flow.
+- **Re-assembly is possible but explicit, and is not a recovery mechanism.**
+  `assemble --reassemble` recomputes the manifest from the current directory
+  and replaces the existing version section. It prints the section it is
+  about to replace before replacing it, because that section may contain the
+  releaser's editorial pass. It is the only path that discards editorial
+  edits, it is never invoked by protocol 05's normal flow, and — unlike
+  `--repair-manifest` above — it is never invoked automatically by any
+  recovery path, because a live rescan can pull in a fragment that arrived
+  after the original assembly.
 - **If a fragment is edited between assembly and consumption**, the draft in
   `CHANGELOG.md` wins: it is what the releaser reviewed. `consume` deletes the
   file regardless of its content.
@@ -417,28 +477,37 @@ other workflow helpers, and every exit path prints its documented fields.
       Emits `PENDING_COUNT=<n>` and one `PENDING=<path>` per fragment.
       (Spec "Operational Visibility")
 - [ ] `assemble --version <X.Y.Z> [--date <YYYY-MM-DD>] [--reassemble]
-      [--allow-empty]` — acquire the per-release `mkdir` lock (Concurrent-
-      event-source addendum), write the manifest first (temp file, atomic
-      rename) into `changelog.d/manifests/v<X.Y.Z>.txt`, then rename
-      `## [Unreleased]` to the version heading, merge fragment bullets per
-      kind (from the manifest, not a rescan, when resuming), and insert a
-      fresh empty `## [Unreleased]`. Emits `ASSEMBLE_RESULT`, `VERSION`,
-      `FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`, `MANIFEST_PATH`, and `ITEMS`.
-      `ASSEMBLE_RESULT` includes `assembled_unmanifested` for the
-      manifest-absent, heading-present recovery state, and `locked` when the
-      lock is already held. (Spec AC-3, AC-5, AC-7, AC-10; Decisions 3 and 4)
-- [ ] `consume --version <X.Y.Z>` — acquire the same per-release lock, delete
-      the manifest-listed fragments, then move (not delete) the manifest to
+      [--repair-manifest] [--allow-empty]` — acquire the per-release `mkdir`
+      lock (Concurrent-event-source addendum), write the manifest first (temp
+      file, `fsync`, atomic rename) into `changelog.d/manifests/v<X.Y.Z>.txt`,
+      then write `CHANGELOG.md` the same way (temp file, `fsync`, atomic
+      rename) — rename `## [Unreleased]` to the version heading, merge
+      fragment bullets per kind (from the manifest, not a rescan, when
+      resuming), and insert a fresh empty `## [Unreleased]`. Emits
+      `ASSEMBLE_RESULT`, `VERSION`, `FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`,
+      `MANIFEST_PATH`, and `ITEMS`. `ASSEMBLE_RESULT` includes
+      `assembled_unmanifested` for the manifest-absent, heading-present
+      recovery state; `repaired` when `--repair-manifest` restores the
+      manifest from git history; `manifest_unrecoverable` when
+      `--repair-manifest` finds no committed manifest to restore; and
+      `locked` when the lock is already held. (Spec AC-3, AC-5, AC-7, AC-10;
+      Decisions 3 and 4)
+- [ ] `consume --version <X.Y.Z>` — acquire the same per-release lock, require
+      the `## [X.Y.Z]` heading to exist (else refuse — see below), delete the
+      manifest-listed fragments one at a time (idempotent: a file already
+      absent is not an error), then move (not delete) the manifest to
       `changelog.d/manifests/consumed/v<X.Y.Z>.txt`. Emits `CONSUME_RESULT`,
       `REMOVED_COUNT`, `MANIFEST_PATH`. `CONSUME_RESULT` includes
-      `inconsistent` when neither manifest location holds the target version
-      but the version section is present, and `locked` when the lock is
-      already held. (Spec AC-5, AC-7; Decision 3)
+      `not_assembled` when the manifest exists but the heading does not (do
+      not delete anything in this case); `inconsistent` when neither manifest
+      location holds the target version but the heading is present; and
+      `locked` when the lock is already held. (Spec AC-5, AC-7; Decision 3)
 - [ ] Exit codes: `0` for `clean`, `assembled`, `already_assembled`,
-      `reassembled`, `consumed`, `already_consumed`; `1` for a validation,
-      assembly, `assembled_unmanifested`, `inconsistent`, or `locked` error;
-      `3` for `no_notes` without `--allow-empty`; `64` for a usage error,
-      matching `check-documentation-stage-alignment.sh`.
+      `reassembled`, `repaired`, `consumed`, `already_consumed`; `1` for a
+      validation, assembly, `assembled_unmanifested`,
+      `manifest_unrecoverable`, `not_assembled`, `inconsistent`, or `locked`
+      error; `3` for `no_notes` without `--allow-empty`; `64` for a usage
+      error, matching `check-documentation-stage-alignment.sh`.
 - [ ] Reporting on assembly names each contributing item, and reports bullets
       carried over from the shared block as a single unattributed group, per
       the spec's Operational Visibility section.
@@ -711,10 +780,14 @@ test in `scripts/development-workflow/tests/test-changelog-fragments.sh`.
 | 28 | Deterministic ordering | Bullets sorted by kind rank, then by the item field (numerically when it is all digits, lexicographically otherwise), then by full filename — so two runs on the same input produce identical bytes |
 | 29 | `consume` when the manifest is absent from both `changelog.d/manifests/` and `changelog.d/manifests/consumed/`, and the version section is also absent | `CONSUME_RESULT=manifest_missing`, non-zero, with the remediation named (run `assemble` first) |
 | 30 | `consume` run twice | First run reports `consumed`. Second run finds the manifest already moved to `changelog.d/manifests/consumed/` and reports `CONSUME_RESULT=already_consumed`, exit 0 |
-| 31 | `consume` when a manifest-listed file is already gone and the version section is absent | Rejected — the release state is inconsistent and must not be papered over |
-| 32 | `assemble` when the manifest for the target version is present but the `## [X.Y.Z]` heading is absent (interrupted between the two writes) | `assemble` completes the `CHANGELOG.md` write from the already-frozen manifest, never a rescan. `ASSEMBLE_RESULT=assembled`, exit 0 |
-| 33 | `assemble` when the `## [X.Y.Z]` heading is present but the manifest for that version is absent from both manifest locations | `ASSEMBLE_RESULT=assembled_unmanifested`, exit 1, naming `assemble --reassemble` as the remediation |
+| 31 | `consume` when the `## [X.Y.Z]` heading is absent, a manifest-listed file is already gone, and the manifest is not in either manifest location | Rejected — `CONSUME_RESULT=inconsistent`; the release state is corrupted and must not be papered over |
+| 32 | `assemble` when the manifest for the target version is present but the `## [X.Y.Z]` heading is absent (interrupted between the two writes) | `assemble` performs the `CHANGELOG.md` write (temp file, `fsync`, atomic rename) from the already-frozen manifest, never a rescan. `ASSEMBLE_RESULT=assembled`, exit 0 |
+| 33 | `assemble` when the `## [X.Y.Z]` heading is present but the manifest for that version is absent from both manifest locations | `ASSEMBLE_RESULT=assembled_unmanifested`, exit 1, naming `assemble --repair-manifest` (git-history restore) as the remediation — never a directory rescan |
 | 34 | `consume` when neither manifest location holds the target version but the `## [X.Y.Z]` version section is present | `CONSUME_RESULT=inconsistent`, exit 1 — no longer conflated with `already_consumed`; the operator must reconcile by hand |
+| 35 | `consume` when the manifest is present in `changelog.d/manifests/` but the `## [X.Y.Z]` heading is absent | `CONSUME_RESULT=not_assembled`, exit 1, deletes nothing — assembly never finished; remediation is to run `assemble` first |
+| 36 | `consume` when the heading is present, the manifest is present in `changelog.d/manifests/`, and some or all manifest-listed fragment files are already absent (a prior run stopped after deleting fragments but before moving the manifest) | Resume: finish deleting whatever remains (idempotent — an absent file is not an error), then move the manifest. `CONSUME_RESULT=consumed`, exit 0 |
+| 37 | `assemble --repair-manifest` when a commit on the current branch previously wrote `changelog.d/manifests/v<X.Y.Z>.txt` | Restore that commit's blob verbatim. `ASSEMBLE_RESULT=repaired`, exit 0 — the restored set is exactly what was frozen at the original assembly, never a live rescan |
+| 38 | `assemble --repair-manifest` when no commit on the current branch ever wrote the manifest for the target version | Refuse to guess. `ASSEMBLE_RESULT=manifest_unrecoverable`, exit 1, naming manual reconciliation (or an explicit, risk-accepted `--reassemble`) as the only remaining paths |
 
 **Suppression semantics**: not applicable. `changelog-fragments.sh` recognizes
 no inline suppression directives. Declining to write a release note is
@@ -776,9 +849,11 @@ readiness check.
 | --- | --- | --- | --- |
 | No manifest for the target version; no `## [X.Y.Z]` heading; at least one pending fragment or a non-empty shared block | `assembled` | Continue to the editorial pass (Protocol 05 Step 3) | Protocol 05; `.claude/commands/prepare-release.md`; `.cursor/commands/prepare-release.md`; `.agents/skills/prepare-release/SKILL.md` |
 | Manifest for the target version present; `## [X.Y.Z]` heading also present | `already_assembled` | No write; continue. This is the resume path and the idempotence guarantee — both artifacts, not the heading alone (Decision 3) | Same |
-| Manifest for the target version present; `## [X.Y.Z]` heading absent | `assembled` | Interrupted between the two writes. Complete the `CHANGELOG.md` write from the already-frozen manifest, never a rescan; continue to the editorial pass | Same |
-| Manifest for the target version absent; `## [X.Y.Z]` heading present | `assembled_unmanifested` (exit 1) | Stop; run `assemble --reassemble` to deterministically regenerate the manifest, then continue | Protocol 05 Step 3 |
-| `--reassemble` passed and the heading is present | `reassembled` | Print the replaced section first; the releaser must redo any editorial pass | Same |
+| Manifest for the target version present; `## [X.Y.Z]` heading absent | `assembled` | Interrupted between the two writes. Perform the `CHANGELOG.md` write (temp file, `fsync`, atomic rename) from the already-frozen manifest, never a rescan; continue to the editorial pass | Same |
+| Manifest for the target version absent; `## [X.Y.Z]` heading present | `assembled_unmanifested` (exit 1) | Stop; run `assemble --repair-manifest` to restore the manifest from git history — never a directory rescan (a live rescan can pull in a fragment added since the original assembly) | Protocol 05 Step 3 |
+| `--repair-manifest` passed; a commit on the branch previously wrote the manifest for this version | `repaired` | The manifest is restored verbatim from that commit; continue to `already_assembled` on the next run | Same |
+| `--repair-manifest` passed; no commit on the branch ever wrote the manifest for this version | `manifest_unrecoverable` (exit 1) | Stop; reconcile by hand (compare the published section's bullets against fragments still in `changelog.d/`), or explicitly accept the risk of `--reassemble` | Protocol 05 Step 7.2 |
+| `--reassemble` passed and the heading is present | `reassembled` | Print the replaced section first; the releaser must redo any editorial pass. Not invoked automatically by any recovery path | Same |
 | No pending fragment and an empty shared block | `no_notes` (exit 3) | Stop; either there is nothing to release or a fragment was lost. Pass `--allow-empty` only for a deliberate no-notes release | Same |
 | Any fragment fails the grammar or body checks | `invalid` (exit 1) | Fix the named fragment on `develop` and re-run; never assemble a partial set | Protocol 05; `.github/workflows/markdown-lint.yml` |
 | `CHANGELOG.md` lacks exactly one `## [Unreleased]` heading | `error` (exit 1) | Repair the changelog before releasing | Protocol 05 Step 7.2 |
@@ -787,11 +862,13 @@ readiness check.
 
 | Gate inputs | Outcome | Required next action | Mirror surfaces |
 | --- | --- | --- | --- |
-| Manifest present in `changelog.d/manifests/`, listed files present | `consumed` | Commit the deletions and the manifest move (to `changelog.d/manifests/consumed/`) with the release commit | Protocol 05 Step 3 |
+| Heading present; manifest present in `changelog.d/manifests/`, every listed file present | `consumed` | Commit the deletions and the manifest move (to `changelog.d/manifests/consumed/`) with the release commit | Protocol 05 Step 3 |
+| Manifest present in `changelog.d/manifests/`, `## [X.Y.Z]` heading absent | `not_assembled` (exit 1) | Stop; deletes nothing. Run `assemble` first — assembly never finished writing the section | Protocol 05 Step 3 |
+| Heading present; manifest present in `changelog.d/manifests/`; some or all listed files already absent | `consumed` | Interrupted consume, safe to resume: finish deleting whatever remains (idempotent), then move the manifest | Protocol 05 Step 3 |
 | Manifest present in `changelog.d/manifests/consumed/`, absent from `changelog.d/manifests/` | `already_consumed` | Continue; confirmed by the moved file's presence, not by absence | Protocol 05 Steps 3 and 7.2 |
-| Manifest absent from both locations, version section absent | `manifest_missing` (non-zero) | Run `assemble` first | Protocol 05 Step 3 |
-| Manifest absent from both locations, version section present | `inconsistent` (exit 1) | Stop and reconcile by hand; no longer conflated with `already_consumed` | Protocol 05 Step 7.2 |
-| Manifest present in `changelog.d/manifests/`, a listed file missing, version section absent | `error` (exit 1) | Stop and reconcile by hand; the release state is inconsistent | Protocol 05 Step 7.2 |
+| Manifest absent from both locations, heading absent | `manifest_missing` (non-zero) | Run `assemble` first | Protocol 05 Step 3 |
+| Manifest absent from both locations, heading present | `inconsistent` (exit 1) | Stop and reconcile by hand; no longer conflated with `already_consumed` | Protocol 05 Step 7.2 |
+| Heading absent; manifest absent from both locations; a listed file (from the last-known manifest state) already gone | `inconsistent` (exit 1) | Stop and reconcile by hand; the release state is corrupted | Protocol 05 Step 7.2 |
 
 ### Gate C — release-note readiness (changed, not added)
 
@@ -865,6 +942,7 @@ for execution, not performed during Plan Ready.
 | File-level overlap with open PR #1589 on `.github/workflows/markdown-lint.yml` and `05b-graduate-development-protocol.md` | Med | Low | The edits are in disjoint regions (branch filters and a new top section, versus `paths:`/targets and Step 2.5). If #1589 merges first, rebase; the conflict, if any, is a normal two-region docs conflict, not the combinatorial one this item removes |
 | A release-branch delete of a fragment races an edit of that same fragment on `develop` | Low | Low | Git reports a delete/modify conflict on one file owned by one item. Editing a note after its release is already a mistake; document the resolution (keep the deletion) in Protocol 94's `changelog.d/` clause |
 | `--reassemble` discards a releaser's editorial pass | Low | Med | The flag is never used by Protocol 05's normal flow, and the command prints the section it is about to replace before replacing it |
+| A recovery path (`--repair-manifest`, `assembled_unmanifested`/`not_assembled` handling) is implemented incorrectly, silently reintroducing the truncation or retroactive-inclusion bugs Decision 3 exists to prevent | Low | High | Edge cases 31–38 fixture every recovery combination (interrupted write, lost manifest with and without git history, interrupted consume, premature consume) as red tests before the corresponding code exists (Implementation Order Steps 2, 4, 5) |
 | Downstream projects that have not adopted fragments receive protocol updates describing a convention they do not use | Med | Low | Decision 6 keeps Protocol 94's auto-resolution and states the not-yet-adopted case explicitly; Decision 4's assembly works unchanged on a populated shared block, so adoption needs no migration |
 
 ---
@@ -913,10 +991,13 @@ changelog.d/1589.fixed.integration-branch-ci.md
 
 2. **Write the test suite first, red.** Create
    `scripts/development-workflow/tests/test-changelog-fragments.sh` with one
-   case per row of the three parser-risk tables, one interleaving case per
-   command for the per-release lock (Concurrent-event-source addendum), plus
-   its `# covers:` header lines. Every case fails at this point because the
-   helper does not exist.
+   case per row of the three parser-risk tables (including edge cases 31–38,
+   the recovery-state matrix), one interleaving case per command for the
+   per-release lock (Concurrent-event-source addendum), and a case that
+   verifies `CHANGELOG.md` is left byte-identical to its pre-assembly content
+   when the process is killed after the temp-file write but before the atomic
+   rename, plus its `# covers:` header lines. Every case fails at this point
+   because the helper does not exist.
 
    *Verify*: running the suite reports failures for every case and no case is
    silently skipped.
@@ -928,24 +1009,35 @@ changelog.d/1589.fixed.integration-branch-ci.md
    the changelog-rewriting cases still fail.
 
 4. **Implement `assemble`.** The per-release `mkdir` lock (Concurrent-event-
-   source addendum), manifest-first write (temp file, atomic rename), heading
-   rename, per-kind merge, fresh empty `## [Unreleased]`, deterministic
-   ordering, and all four assembly states from Decision 3 (`assembled`,
-   `already_assembled`, the manifest-present/heading-absent resume, and
-   `assembled_unmanifested`), plus `no_notes`.
+   source addendum); manifest-first write (temp file, `fsync`, atomic
+   rename); then the `CHANGELOG.md` write with the same atomicity guarantee
+   (temp file, `fsync`, atomic rename) — heading rename, per-kind merge,
+   fresh empty `## [Unreleased]`, deterministic ordering; all four assembly
+   states from Decision 3 (`assembled`, `already_assembled`, the
+   manifest-present/heading-absent resume, and `assembled_unmanifested`);
+   `--repair-manifest` (git-history restore, `repaired` or
+   `manifest_unrecoverable`, never a directory rescan); and `no_notes`.
 
    *Verify*: the changelog-rewriting cases pass, and the suite's assembled
    fixtures are checked with `check-changelog-duplicate-headers.sh` and
-   `markdown-heuristic-lint.py` inside the suite itself.
+   `markdown-heuristic-lint.py` inside the suite itself. The kill-before-rename
+   case from Step 2 confirms `CHANGELOG.md` is untouched, not truncated.
 
-5. **Implement `consume`.** The per-release `mkdir` lock, manifest-driven
-   deletion, moving (not deleting) the manifest into
-   `changelog.d/manifests/consumed/`, the `already_consumed` outcome (detected
-   from the moved file's presence), and the `inconsistent` rejection when
-   neither manifest location holds the target version.
+5. **Implement `consume`.** The per-release `mkdir` lock; the `## [X.Y.Z]`
+   heading precondition (`not_assembled` when the manifest exists but the
+   heading does not — deletes nothing); manifest-driven, idempotent
+   per-file deletion (resuming an interrupted consume simply finishes
+   whatever remains); moving (not deleting) the manifest into
+   `changelog.d/manifests/consumed/`; the `already_consumed` outcome
+   (detected from the moved file's presence); and the `inconsistent`
+   rejection when neither manifest location holds the target version.
 
    *Verify*: the whole suite passes. Run `consume` twice in a row and confirm
    the first run reports `consumed` and the second reports `already_consumed`.
+   Run it against a fixture with the heading absent and confirm
+   `not_assembled` with zero fragment files deleted. Run it against a fixture
+   with some manifest-listed fragments pre-deleted and confirm it completes
+   and reports `consumed` rather than erroring.
 
 6. **Wire the lint and CI surfaces.** Update
    `.github/workflows/markdown-lint.yml` (`paths:`, both independent

--- a/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
+++ b/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
@@ -140,19 +140,51 @@ happen outside an explicitly human-approved split, and is safely caught as a
 conflict if it does."
 
 **Repositories with no issue tracker configured** (`issue_tracker.provider:
-none` or absent) fall back to a **sanitized branch identifier** as `<item>`:
-the branch name with its type prefix (`feature/`, `fix/`, `refactor/`)
-removed, and every remaining `/` or character outside `[A-Za-z0-9_-]`
-replaced with `-` — for example `fix/improve-caching` becomes
-`fix-improve-caching`. This is grammar-safe by construction (no `/` can
-survive into the filename) and repository-wide unique for the same reason a
-bare tracker identifier is: git already refuses two concurrently existing
-branches of the identical name, so at most one branch is authoring notes
-under a given sanitized identifier at a time — the same discriminator this
-repository's own `<item>` relies on, just computed over the whole slug
-instead of one field pulled out of it. In this mode the body's `(#N)`
-reference (Decision 2's worked examples) is **omitted entirely** — there is
-no issue number to reference, and `changelog.d/README.md` states this
+none` or absent) fall back to **the pull request number** as `<item>` — for
+example `changelog.d/1610.fixed.improve-caching.md` for PR #1610. This is a
+second, independent instance of the same principle Decision 1 already relies
+on for the tracker case: *the discriminator is an externally allocated
+unique identifier*, not something this plan derives by transforming a
+string it does not control.
+
+**A sanitized branch name was considered and rejected** — the first draft of
+this fallback used one, and a CodeRabbit round demonstrated it was not
+collision-resistant: `feature/a/b` and `feature/a-b` both normalize to the
+same string once `/` is folded into `-`, two different forks can use the
+identical branch name (each fork's branch namespace is independent, so git's
+own same-name-refusal — the property the sanitized-name design leaned on —
+does not apply across forks at all), and the transformation could produce a
+leading `-` or `_` that the filename grammar itself rejects. Every one of
+these is a structural consequence of deriving an identifier from a string
+whose only uniqueness guarantee is "no two *local* branches of the identical
+name coexist" — a guarantee that does not extend to cross-fork or
+lossy-normalization collisions. No further transformation of a branch name
+closes that gap; a different kind of identifier is needed, not a better
+sanitizer.
+
+**Why the PR number closes it completely**: GitHub assigns pull request
+numbers per repository, monotonically, regardless of which fork or branch
+name the PR's head is — two PRs from two different forks, or two branches
+that would sanitize to the same string, are still two different numbers.
+This is exactly the same allocation model as an issue tracker's own
+identifiers (Decision 1's primary case), just issued by the hosting platform
+instead of the tracker.
+
+**Consequence for authoring order**: in no-tracker mode, the fragment's
+final filename cannot be written before the PR exists, because the number
+it depends on does not exist yet. An author working before opening a PR
+uses any locally convenient temporary name and **renames** the file to the
+assigned PR number as part of opening the PR (or promptly afterward) — the
+rename is a single `git mv`, not a data migration, since the body content is
+unaffected. `changelog.d/README.md` states this explicitly, and `validate`
+does not special-case it: the readiness gate (Decision 5) that checks for a
+fragment on the PR's file list already runs *after* the PR exists, so by the
+time it matters the number is always known.
+
+In this mode the body's `(#N)` reference (Decision 2's worked examples) is
+**omitted entirely** — there is no issue number to reference (the PR number
+is used only as the filename's uniqueness discriminator, a distinct role
+from the body's issue citation), and `changelog.d/README.md` states this
 exception explicitly so an author does not invent a placeholder number that
 `validate` has no way to distinguish from a real one.
 
@@ -256,9 +288,10 @@ record that the commit's own diff doesn't already show.
    before any directory scan, so a plain re-run of `assemble` reports
    `already_assembled` and never looks at `changelog.d/` again — the late
    fragment is untouched, stays in `changelog.d/`, and is picked up by the
-   next assembly. It is included only if the releaser deliberately runs
-   `assemble --reassemble` (below), which is a human editorial choice to
-   redo the section, not something any recovery path invokes automatically.
+   next assembly. It is included in *this* release only if the releaser
+   deliberately discards the assembled state first (below, "There is no
+   `--reassemble` flag") and re-runs `assemble` fresh — a human editorial
+   choice, never something any part of `assemble` itself does automatically.
 
 **Assembly, concretely.** When the heading does not yet exist, `assemble`:
 validates every top-level fragment in `changelog.d/` (Decision 1's grammar);
@@ -281,26 +314,55 @@ deletions finishing is still possible (deleting N small files is not one
 atomic operation). Left unaddressed, a re-run's idempotence check would see
 the heading and stop before finishing those deletions, permanently orphaning
 the undeleted fragment — which a *later* release's assembly would then
-gather again, publishing its bullet a second time. The fix does not need a
-manifest: on the `already_assembled` path, before returning, `assemble` scans
-`changelog.d/` for any fragment whose `(#<item>)` reference (Decision 2's
-body convention) appears **literally, as text**, inside the already-published
-`## [X.Y.Z]` section, and deletes it. This is a targeted, provably-safe
-cleanup, not a rescan-and-guess: a fragment is only ever removed by this path
-if its content is already visible in the published section, so a genuinely
-late fragment (whose `(#item)` is *not* in that section) is never touched by
-it — rule 3 above still holds. This closes the one gap with a few lines of
-logic inside the idempotence check, not a new command, file, exit code, or
-recovery flag.
+gather again, publishing its bullet a second time.
 
-**Re-assembly is possible but explicit, and remains rare.**
-`assemble --reassemble` is unchanged in spirit from the original design: it
-prints the existing `## [X.Y.Z]` section (which may contain the releaser's
-edits) before deleting it, then runs the normal not-yet-assembled path fresh
-— a live rescan, deliberately, because this is an explicit human request to
-redo the section (for example, to pull in a fragment cherry-picked onto the
-branch after the first assembly), not an automatic recovery path. It is
-never invoked by Protocol 05's normal flow.
+**The sweep matches on the fragment's own body, not on the item reference.**
+An earlier version of this fix matched by searching the published section for
+`(#<item>)` — the item's tracker or PR-number reference. That is not precise
+enough: this plan explicitly permits more than one fragment for the same
+item (two notes from the same item "live on one branch," Decision 1), and in
+no-tracker mode the body carries no `(#N)` at all, so there would be nothing
+to match against. Matching on the item reference cannot distinguish "this
+exact fragment's bullet was published" from "some fragment for this item was
+published" — a second, still-pending fragment for the same item would match
+and be wrongly deleted, exactly reproducing the loss the sweep exists to
+prevent, just relocated to a same-item case instead of the interruption case.
+
+The corrected check matches on **the fragment's own body**: `assemble`
+normalizes each remaining fragment's body the same way `validate` already
+does (CRLF to LF, trailing whitespace trimmed) and checks whether that exact
+text — the complete bullet, including any continuation lines, as one
+contiguous block — appears verbatim inside the already-published
+`## [X.Y.Z]` section. Only then is the fragment deleted. This is precise by
+construction, in every mode: two fragments for the same item necessarily
+have different bodies (they are different bullets), so body matching tells
+them apart where item-number matching could not; and no-tracker fragments
+are matched the same way, since the check never depended on `(#N)` existing
+in the first place. A fragment is only ever removed by this path if its own
+content is already visible in the published section, so a genuinely late
+fragment — for a new item, a second fragment on the same item, or a
+no-tracker fragment — is never touched by it. Rule 3 still holds. This
+closes the gap with a body-text comparison inside the idempotence check, not
+a new command, file, exit code, or recovery flag.
+
+**There is no `--reassemble` flag.** An earlier draft included one, to let
+the releaser deliberately discard the published section and redo assembly
+from a live rescan — but a CodeRabbit round found it non-transactional (it
+deleted the existing section before validating and building the
+replacement, so a failure between those two steps left `CHANGELOG.md`
+without a section at all, and without one to restore from). Rather than add
+the machinery to make deletion-then-rebuild safe (build the replacement
+first, then swap it in — itself a second atomic-write path to design and
+test), this plan asks whether the flag is still pulling its weight now that
+there is no manifest for it to repair, and the answer is no: nothing is
+committed until the releaser's own Step 5, so "discard and redo" is already
+an ordinary git operation with no data at risk — `git checkout -- CHANGELOG.md
+changelog.d/` before any commit, or `git revert`/`git reset` after one,
+followed by a fresh `assemble` run, which naturally rescans because nothing
+still claims `already_assembled`. Removing the flag deletes the
+transactionality problem along with it, rather than solving it, and shrinks
+the interface `assemble` presents to exactly one command with no redo path
+to keep safe.
 
 **Audit trail.** The spec's Operational Visibility principle — "released"
 and "not yet released" visible from repository state rather than inferred —
@@ -311,21 +373,44 @@ a *stronger* audit trail than the manifest the earlier design added, because
 it reuses git's native history instead of a bespoke, separately-maintained
 file format.
 
-**Why no lock.** `assemble` is a single, synchronous, sub-second shell
-invocation run by one releaser (human or one delegated agent) in one working
-tree, and nothing it does is durable until that same releaser's own Step 5
-commit. A literal simultaneous double-invocation in the same checkout — the
-only scenario a lock would guard against — is an operator mistake (running
-the command twice in two terminals), not a scheduled or expected occurrence;
-its worst case is a locally confusing `CHANGELOG.md`, caught by the same
-`git status`/`git diff` review the releaser already performs before Step 5
-ever commits anything, exactly the same posture the *unmodified* Protocol 05
-editorial pass already has today (nobody locks that either). Building a
-per-release `mkdir` lock, an owner-record file, and staleness detection to
-guard a race whose blast radius is "notice it before you commit" was
-solving a problem `assemble`'s new, much narrower window does not actually
-have; Decision 3's earlier draft needed the lock only because it had opened
-a much wider, commit-spanning window in the first place.
+**Why no lock — declined a third time, on the same grounds, now with the
+specific failure mode named.** `assemble` is a single, synchronous,
+sub-second shell invocation run by one releaser (human or one delegated
+agent) in one working tree, and nothing it does is durable until that same
+releaser's own Step 5 commit. A literal simultaneous double-invocation in
+the same checkout — the only scenario a lock would guard against — is an
+operator mistake (running the command twice in two terminals), not a
+scheduled or expected occurrence, because Protocol 05 Step 3 does not
+support two people cutting the same version at once: it is one releaser,
+one release branch, run sequentially. This is not a new conclusion; it is
+the same one reached earlier in this review, when the prior review round's
+"serialize all mutations of `CHANGELOG.md`" and "define recovery for a
+missing or partial lock owner record" findings led to removing the lock
+Decision 3's earlier draft had built, and that removal was accepted. A
+concrete failure mode was raised again for the same scenario: two
+concurrent invocations could scan different pending sets, each write a
+different `CHANGELOG.md` snapshot (the later atomic rename wins), and each
+delete the fragments *it* gathered regardless of whether its own write
+survived — so the losing invocation's fragments can be deleted without
+their bullets surviving in the final file, and a later `git diff` cannot
+prove a missing bullet was never assembled. That mechanism is real *if* the
+precondition holds, but the precondition is exactly the scenario named
+above: two invocations of `assemble --version X` against the *same
+checkout* at overlapping instants. The protocol does not produce that
+precondition; only an operator running the command twice by hand does, and
+that operator has not yet committed anything when the interleaving would
+happen, so the same `git status`/`git diff` review before Step 5 that
+already catches a locally confusing `CHANGELOG.md` also catches this shape
+of it — nothing distinguishes "confusing" from "silently missing a bullet"
+from the releaser's point of view, since the reviewer would notice a
+smaller assembled section than the confirmed pending count either way.
+Building a per-release `mkdir` lock, an owner-record file, and staleness
+detection to guard a race whose precondition the protocol does not permit,
+and whose consequence is still caught before anything is committed, was
+solving a problem `assemble`'s narrow, uncommitted window does not actually
+create; Decision 3's earlier draft needed the lock only because it had
+opened a much wider, commit-spanning window in the first place, and that
+window is what was removed, not the underlying concern.
 
 **If a fragment is edited between assembly and the release merging**, the
 draft in `CHANGELOG.md` wins: it is what the releaser reviewed. The fragment
@@ -489,25 +574,32 @@ other workflow helpers, and every exit path prints its documented fields.
 - [ ] `list [--json]` — report the pending notes without changing anything.
       Emits `PENDING_COUNT=<n>` and one `PENDING=<path>` per fragment.
       (Spec "Operational Visibility")
-- [ ] `assemble --version <X.Y.Z> [--date <YYYY-MM-DD>] [--reassemble]
-      [--allow-empty]` — the release-preparation command, and the **only**
-      write path this helper has (Decision 3). If `## [X.Y.Z] - YYYY-MM-DD`
-      already exists in `CHANGELOG.md` and `--reassemble` was not passed:
-      perform the residual-interruption sweep (delete any remaining fragment
-      whose `(#item)` reference already appears in that section), then report
-      `ASSEMBLE_RESULT=already_assembled`, exit 0, no `CHANGELOG.md` write.
-      Otherwise: validate every pending fragment, build the version section
-      (Decision 4), write `CHANGELOG.md` via temp file, `fsync`, and one
-      atomic `rename(2)`, then delete each fragment that fed the section.
+- [ ] `assemble --version <X.Y.Z> [--date <YYYY-MM-DD>] [--allow-empty]` — the
+      release-preparation command, and the **only** write path this helper
+      has (Decision 3). There is no `--reassemble` flag (Decision 3). Checks
+      run in this fixed order, so the outcomes are mutually exclusive by
+      construction (Gate A):
+      1. Validate every pending fragment. Any grammar or body failure is
+         `ASSEMBLE_RESULT=invalid`, exit 1, regardless of the heading or
+         shared-block state — a malformed fragment is never assembled and
+         never mistaken for "nothing pending."
+      2. Else, if `## [X.Y.Z] - YYYY-MM-DD` already exists in `CHANGELOG.md`:
+         perform the residual-interruption sweep (delete any remaining
+         fragment whose exact, normalized body already appears verbatim in
+         that section — see Decision 3's "Residual interruption window"),
+         then report `ASSEMBLE_RESULT=already_assembled`, exit 0, no
+         `CHANGELOG.md` write.
+      3. Else, if there is no pending fragment and the shared block is
+         empty: `ASSEMBLE_RESULT=no_notes`, exit 3, unless `--allow-empty`.
+      4. Else: build the version section (Decision 4), write `CHANGELOG.md`
+         via temp file, `fsync`, and one atomic `rename(2)`, then delete each
+         fragment that fed the section. `ASSEMBLE_RESULT=assembled`, exit 0.
       Emits `ASSEMBLE_RESULT`, `VERSION`, `FRAGMENT_COUNT`,
-      `CARRIED_OVER_COUNT`, and `ITEMS`. `--reassemble` (only meaningful when
-      the heading already exists) prints the existing section, deletes it,
-      and re-runs the not-yet-assembled path fresh — a deliberate rescan, not
-      an automatic recovery path — reporting `ASSEMBLE_RESULT=reassembled`.
-      (Spec AC-3, AC-5, AC-6, AC-7, AC-10; Decisions 3 and 4)
-- [ ] Exit codes: `0` for `clean`, `assembled`, `already_assembled`,
-      `reassembled`; `1` for a validation or assembly error; `3` for
-      `no_notes` without `--allow-empty`; `64` for a usage error, matching
+      `CARRIED_OVER_COUNT`, and `ITEMS`. (Spec AC-3, AC-5, AC-6, AC-7, AC-10;
+      Decisions 3 and 4)
+- [ ] Exit codes: `0` for `clean`, `assembled`, or `already_assembled`; `1`
+      for a validation or assembly error; `3` for `no_notes` without
+      `--allow-empty`; `64` for a usage error, matching
       `check-documentation-stage-alignment.sh`. There is no `consume`
       subcommand and no `CONSUME_RESULT` (Decision 3).
 - [ ] Reporting on assembly names each contributing item, and reports bullets
@@ -780,17 +872,17 @@ test in `scripts/development-workflow/tests/test-changelog-fragments.sh`.
 | --- | --- | --- |
 | 21 | No `## [Unreleased]` heading | Rejected; the heading is a precondition that `auto-tag-release.yml` also depends on |
 | 22 | Two `## [Unreleased]` headings | Rejected |
-| 23 | `## [X.Y.Z]` already present | `ASSEMBLE_RESULT=already_assembled`, exit 0, no `CHANGELOG.md` write — the idempotence mechanism (Decision 3). Before returning, the residual-interruption sweep (row 31) still runs |
-| 24 | Populated shared block plus pending fragments | Both merged into one version section, each entry once, with no duplicate `### Category` heading; every merged fragment is deleted in the same pass |
-| 25 | Populated shared block, zero fragments | Rename only — the pre-fragment behaviour, preserved. Nothing to delete |
-| 26 | Empty shared block, zero fragments | `ASSEMBLE_RESULT=no_notes`, exit 3, unless `--allow-empty` |
-| 27 | A kind present in fragments but absent from the shared block | Heading created in canonical Keep a Changelog order |
-| 28 | Deterministic ordering | Bullets sorted by kind rank, then by the item field (numerically when it is all digits, lexicographically otherwise), then by full filename — so two runs on the same input produce identical bytes |
-| 29 | `assemble` run twice in a row, no interruption in between | First run: `assembled`, writes the section, deletes every fragment that fed it. Second run: `already_assembled`, exit 0, no write — `changelog.d/` already has nothing left for that version to delete |
-| 30 | `assemble` interrupted after the `CHANGELOG.md` rename succeeds but before every fed fragment is deleted | On the next run, the idempotence check (row 23) fires, then the residual-interruption sweep deletes any fragment still present whose `(#item)` reference already appears, as literal text, in the published `## [X.Y.Z]` section — closing the gap without a rescan of "what should this release contain" (only "what does this section already say") |
-| 31 | A fragment sitting in `changelog.d/` whose `(#item)` reference does **not** appear in the published `## [X.Y.Z]` section, encountered during the residual-interruption sweep | Left untouched — this is what keeps the sweep from ever behaving like a rescan: a fragment is deleted only when its content is already visible in the published section, never merely because the section exists |
-| 32 | `--reassemble` when the `## [X.Y.Z]` heading is present | Prints the existing section (it may hold the releaser's edits), deletes it, then re-runs the not-yet-assembled path fresh — a deliberate, human-invoked rescan. `ASSEMBLE_RESULT=reassembled`, exit 0 |
-| 33 | `--reassemble` when the `## [X.Y.Z]` heading is absent | Usage error, exit 64 — there is nothing to replace |
+| 23 | Any fragment fails validation, regardless of whether `## [X.Y.Z]` already exists or the shared block is empty | `ASSEMBLE_RESULT=invalid`, exit 1 — validation is checked first (Gate A), so this is never overridden by `already_assembled` or `no_notes` |
+| 24 | `## [X.Y.Z]` already present, every fragment valid | `ASSEMBLE_RESULT=already_assembled`, exit 0, no `CHANGELOG.md` write — the idempotence mechanism (Decision 3). Before returning, the residual-interruption sweep (row 32) still runs |
+| 25 | Populated shared block plus pending fragments, every fragment valid | Both merged into one version section, each entry once, with no duplicate `### Category` heading; every merged fragment is deleted in the same pass |
+| 26 | Populated shared block, zero fragments | Rename only — the pre-fragment behaviour, preserved. Nothing to delete |
+| 27 | Empty shared block, zero fragments | `ASSEMBLE_RESULT=no_notes`, exit 3, unless `--allow-empty` |
+| 28 | A kind present in fragments but absent from the shared block | Heading created in canonical Keep a Changelog order |
+| 29 | Deterministic ordering | Bullets sorted by kind rank, then by the item field (numerically when it is all digits, lexicographically otherwise), then by full filename — so two runs on the same input produce identical bytes |
+| 30 | `assemble` run twice in a row, no interruption in between | First run: `assembled`, writes the section, deletes every fragment that fed it. Second run: `already_assembled`, exit 0, no write — `changelog.d/` already has nothing left for that version to delete |
+| 31 | `assemble` interrupted after the `CHANGELOG.md` rename succeeds but before every fed fragment is deleted | On the next run, the idempotence check (row 24) fires, then the residual-interruption sweep deletes any fragment still present whose exact, normalized body already appears verbatim in the published `## [X.Y.Z]` section — closing the gap without a rescan of "what should this release contain" (only "what does this section already say") |
+| 32 | A second fragment for the same item as one already published, still pending when the sweep runs | Left untouched — the sweep matches the fragment's own body, not its item reference, so a same-item fragment whose bullet is *not* in the section is correctly distinguished from the one that already fed it |
+| 33 | A fragment sitting in `changelog.d/` whose body does **not** appear in the published `## [X.Y.Z]` section, encountered during the sweep (including a no-tracker fragment, whose body carries no `(#N)` to match on in the first place) | Left untouched — this is what keeps the sweep from ever behaving like a rescan: a fragment is deleted only when its own content is already visible in the published section, never merely because the section exists or because another fragment for the same item is there |
 
 **Suppression semantics**: not applicable. `changelog-fragments.sh` recognizes
 no inline suppression directives. Declining to write a release note is
@@ -837,19 +929,29 @@ This plan adds a workflow decision gate: `assemble` in Protocol 05, whose
 behaviour depends on a small number of inputs and produces a small number of
 distinct next actions — Decision 3's simplification is directly visible here
 as the shrink from a two-command, manifest-driven gate pair to one gate with
-four rows. It also changes an existing gate: the release-note readiness
+five rows, and there is no longer a `--reassemble` row: Decision 3 removed
+the flag. It also changes an existing gate: the release-note readiness
 check.
 
 ### Gate A — `changelog-fragments.sh assemble`
 
-| Gate inputs | Outcome | Required next action | Mirror surfaces |
-| --- | --- | --- | --- |
-| No `## [X.Y.Z]` heading; at least one pending fragment or a non-empty shared block | `assembled` | Continue to the editorial pass (Protocol 05 Step 3) | Protocol 05; `.claude/commands/prepare-release.md`; `.cursor/commands/prepare-release.md`; `.agents/skills/prepare-release/SKILL.md` |
-| `## [X.Y.Z]` heading already present, `--reassemble` not passed | `already_assembled` | No `CHANGELOG.md` write (the residual-interruption sweep may still delete leftover fragments — edge cases 30–31); continue | Same |
-| `--reassemble` passed, heading present | `reassembled` | Print the replaced section first; the releaser must redo any editorial pass. Never invoked by Protocol 05's normal flow | Same |
-| No pending fragment and an empty shared block | `no_notes` (exit 3) | Stop; either there is nothing to release or a fragment was lost. Pass `--allow-empty` only for a deliberate no-notes release | Same |
-| Any fragment fails the grammar or body checks | `invalid` (exit 1) | Fix the named fragment on `develop` and re-run; never assemble a partial set | Protocol 05; `.github/workflows/markdown-lint.yml` |
-| `CHANGELOG.md` lacks exactly one `## [Unreleased]` heading | `error` (exit 1) | Repair the changelog before releasing | Protocol 05 Step 7.2 |
+**Evaluated in this order**, so the rows below are mutually exclusive by
+construction — no input can match more than one row, because each row after
+the first is qualified by every earlier row not matching:
+
+1. `CHANGELOG.md` lacks exactly one `## [Unreleased]` heading.
+2. Any pending fragment fails the grammar or body checks.
+3. `## [X.Y.Z]` heading already present.
+4. No pending fragment and an empty shared block.
+5. Otherwise.
+
+| Order | Gate inputs | Outcome | Required next action | Mirror surfaces |
+| --- | --- | --- | --- | --- |
+| 1 | `CHANGELOG.md` lacks exactly one `## [Unreleased]` heading | `error` (exit 1) | Repair the changelog before releasing | Protocol 05 Step 7.2 |
+| 2 | Any fragment fails the grammar or body checks (checked before the heading or shared-block state is considered) | `invalid` (exit 1) | Fix the named fragment on `develop` and re-run; never assemble a partial set, and never report `already_assembled` or `no_notes` for an input that also has a malformed fragment | Protocol 05; `.github/workflows/markdown-lint.yml` |
+| 3 | Every fragment valid; `## [X.Y.Z]` heading already present | `already_assembled` | No `CHANGELOG.md` write (the residual-interruption sweep may still delete leftover fragments — edge cases 31–33); continue | Same |
+| 4 | Every fragment valid; heading absent; no pending fragment and an empty shared block | `no_notes` (exit 3) | Stop; either there is nothing to release or a fragment was lost. Pass `--allow-empty` only for a deliberate no-notes release | Same |
+| 5 | Every fragment valid; heading absent; at least one pending fragment or a non-empty shared block | `assembled` | Continue to the editorial pass (Protocol 05 Step 3) | Protocol 05; `.claude/commands/prepare-release.md`; `.cursor/commands/prepare-release.md`; `.agents/skills/prepare-release/SKILL.md` |
 
 There is no Gate B: Decision 3 removed `consume` as a distinct command, so
 there is no second gate for it to define.
@@ -920,13 +1022,12 @@ for execution, not performed during Plan Ready.
 
 | Risk | Likelihood | Impact | Mitigation |
 | --- | --- | --- | --- |
-| An entry is lost or duplicated at the transition release, which is the hardest failure to detect after the fact | Med | High | Design the transition first, not last (tracker handoff). Assembly **moves** the shared block by renaming its heading rather than copying bullets, so duplication requires a coding error rather than an oversight; edge cases 24, 25, and 27 are asserted by fixtures before any protocol text is written |
+| An entry is lost or duplicated at the transition release, which is the hardest failure to detect after the fact | Med | High | Design the transition first, not last (tracker handoff). Assembly **moves** the shared block by renaming its heading rather than copying bullets, so duplication requires a coding error rather than an oversight; edge cases 25, 26, and 28 are asserted by fixtures before any protocol text is written |
 | The sweep misses a surface, leaving one agent instructed to edit `[Unreleased]` and reintroducing the conflict for whatever it builds | Med | High | The residual verification strategy below requires the implementation PR to re-run the repository-wide scan and account for every hit, either as changed or with a written no-change rationale |
 | The risk classifier grades the implementation PR `high` because it touches `.github/workflows/`, blocking delegated merge under the `medium` ceiling | High | Low | Known and filed as #1565. Expect an explicit merge authorization request rather than treating it as a failure |
 | File-level overlap with open PR #1589 on `.github/workflows/markdown-lint.yml` and `05b-graduate-development-protocol.md` | Med | Low | The edits are in disjoint regions (branch filters and a new top section, versus `paths:`/targets and Step 2.5). If #1589 merges first, rebase; the conflict, if any, is a normal two-region docs conflict, not the combinatorial one this item removes |
 | A release-branch delete of a fragment races an edit of that same fragment on `develop` | Low | Low | Git reports a delete/modify conflict on one file owned by one item. Editing a note after its release is already a mistake; document the resolution (keep the deletion) in Protocol 94's `changelog.d/` clause |
-| `--reassemble` discards a releaser's editorial pass | Low | Med | The flag is never used by Protocol 05's normal flow, and the command prints the section it is about to replace before replacing it |
-| A process is killed mid-`assemble`, after the `CHANGELOG.md` write but before every fed fragment is deleted, and the residual-interruption sweep (edge cases 30–31) is implemented incorrectly | Low | Med | Edge cases 29–31 fixture the interruption and the sweep as red tests before the code exists (Implementation Order Steps 2 and 4); the sweep's own correctness bar is narrow and checkable — delete only a fragment whose `(#item)` is already literal text in the published section |
+| The residual-interruption sweep (edge cases 31–33) matches a fragment it should not, either deleting an unpublished same-item fragment or leaving an orphan behind | Low | Med | Edge cases 30–33 fixture the interruption, the same-item case, and the no-match case as red tests before the code exists (Implementation Order Steps 2 and 4); the sweep's correctness bar is exact-body matching, not item-reference matching, precisely because item-reference matching was tried and found imprecise in review |
 | Downstream projects that have not adopted fragments receive protocol updates describing a convention they do not use | Med | Low | Decision 6 keeps Protocol 94's auto-resolution and states the not-yet-adopted case explicitly; Decision 4's assembly works unchanged on a populated shared block, so adoption needs no migration |
 
 ---
@@ -967,8 +1068,8 @@ There is no manifest file to sample: Decision 3 does not introduce one.
 
 2. **Write the test suite first, red.** Create
    `scripts/development-workflow/tests/test-changelog-fragments.sh` with one
-   case per row of the three parser-risk tables (including edge cases 29–33,
-   the interruption and re-assembly cases), plus its `# covers:` header
+   case per row of the three parser-risk tables (including edge cases 30–33,
+   the interruption and residual-sweep cases), plus its `# covers:` header
    lines. Every case fails at this point because the helper does not exist.
 
    *Verify*: running the suite reports failures for every case and no case is
@@ -980,14 +1081,16 @@ There is no manifest file to sample: Decision 3 does not introduce one.
    *Verify*: the filename-grammar and fragment-body cases in the suite pass;
    the changelog-rewriting cases still fail.
 
-4. **Implement `assemble`.** The idempotence check (does `## [X.Y.Z]` already
-   exist); the residual-interruption sweep on that path (edge cases 30–31);
+4. **Implement `assemble`.** Precedence order (Gate A: invalid before
+   already_assembled/no_notes/assembled); the idempotence check (does
+   `## [X.Y.Z]` already exist); the residual-interruption sweep on that path,
+   matching each remaining fragment's exact normalized body against the
+   published section text, never its item reference (edge cases 31–33);
    otherwise: validate pending fragments, build the section (heading rename,
    per-kind merge, fresh empty `## [Unreleased]`, deterministic ordering),
    write `CHANGELOG.md` via temp file, `fsync`, and one atomic `rename(2)`,
-   then delete every fragment that fed the section; `--reassemble` (edge
-   cases 32–33); and `no_notes`. There is no lock and no manifest to
-   implement (Decision 3).
+   then delete every fragment that fed the section; and `no_notes`. There is
+   no lock, no manifest, and no `--reassemble` flag to implement (Decision 3).
 
    *Verify*: the changelog-rewriting cases pass, and the suite's assembled
    fixtures are checked with `node_modules/.bin/markdownlint-cli2`,
@@ -997,7 +1100,13 @@ There is no manifest file to sample: Decision 3 does not introduce one.
    fragment is deleted, then re-runs `assemble`, confirms the sweep finishes
    the deletions and `CHANGELOG.md` is unchanged by the second run. A case
    with a genuinely unrelated fragment present during that same re-run
-   confirms the sweep does not touch it.
+   confirms the sweep does not touch it. A case with a **second, still-pending
+   fragment for the same item** as the one just published (edge case 32)
+   confirms the sweep leaves it alone — proving the match is on body content,
+   not the item reference. A case with a no-tracker fragment (no `(#N)` in
+   its body) present during the same re-run confirms the sweep still
+   correctly leaves it untouched when it was never published, and still
+   correctly deletes it when it was.
 
 5. **Wire the lint and CI surfaces.** Update
    `.github/workflows/markdown-lint.yml` (`paths:`, both independent

--- a/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
+++ b/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
@@ -1,0 +1,914 @@
+# Changelog Fragments — Implementation Plan
+
+**Spec**: [1_1554-changelog-fragments_specs.md](1_1554-changelog-fragments_specs.md)
+**Smoke test runbook**: [1554-changelog-fragments.smoke-test.md](../../../testing/workflow/1554-changelog-fragments.smoke-test.md)
+**Work item**: #1554 (Type: Refactor, Priority: High)
+
+---
+
+## Summary
+
+**Approach**: Give every work item its own release-note file under a new
+`changelog.d/` directory, named `<item>.<kind>.<slug>.md`, whose body is the
+finished changelog bullet. Because the first field is the tracker identifier,
+two different items always write different paths, and git does not conflict
+across different paths — the collision is removed by construction rather than
+resolved more cleverly. A new helper,
+`scripts/development-workflow/changelog-fragments.sh`, gathers the pending
+notes at release time into a draft `## [X.Y.Z]` section in `CHANGELOG.md`
+(`assemble`) and removes them in a separate, later step (`consume`), so an
+interrupted release loses neither notes nor the releaser's edits. Assembly also
+carries whatever is still sitting in the shared `## [Unreleased]` block into
+the same version section, which is what makes the transition release work
+without a migration and without a one-release-only code path. Every readiness
+check, protocol, agent surface, and lint that today asserts "this PR touched
+`CHANGELOG.md`" is updated to accept a fragment instead.
+
+**Estimated complexity**: L
+
+<!-- S: < 1 day | M: 1-3 days | L: 3+ days -->
+
+**Rationale**: One new shell helper with a strict filename grammar and a
+CHANGELOG rewriter, one new test suite, and a wide but shallow sweep across
+protocol, agent, skill, lint, workflow, and manifest surfaces. The sweep is
+what makes this large: the changelog convention is stated in many places, and
+leaving any one of them saying "edit `[Unreleased]`" reintroduces the conflict
+for whichever agent reads that surface.
+
+**Dependencies**: None blocking. #1537 (change-scoped CI suite selection) is
+already merged at the plan-time revision, so the new suite
+`test-changelog-fragments.sh` is selected by CI automatically — the handoff
+comment's concern that most affected scripts are unrun in CI does not apply to
+the new code this plan adds.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `19c0f46e` (equals `origin/develop`) |
+| Files referencing the changelog | Repository-wide case-insensitive scan for `changelog`, excluding `.git`, `node_modules`, worktree directories, `docs/specs/`, `hooks/node_modules`, and `CHANGELOG.md` itself | 107 files; the ones this plan changes are enumerated in **Layer-by-Layer Changes**, and the ones deliberately left alone are enumerated in **Verified, no change needed** |
+| Cross-cutting agent/skill search | `grep -rl "02-generate-implementation-plan-protocol\|03-implement-development-protocol" .claude/agents/ .cursor/agents/ .codex/skills/ .agents/skills/` | `.claude/agents/developer.md`, `.claude/agents/tech-lead.md`, `.cursor/agents/developer.md`, `.cursor/agents/tech-lead.md`, `.codex/skills/workflow-implementer/SKILL.md`, `.codex/skills/workflow-plan-writer/SKILL.md` |
+| Codex skill mirroring | `ls -la .agents/skills/` | `.agents/skills/workflow-*`, `batch-merge`, and `post-merge-cleanup` are symlinks into `.codex/skills/`; `.agents/skills/prepare-release/` is a real directory and needs its own edit |
+| Bullets pending in the shared block | Count of top-level `- ` bullets between `## [Unreleased]` and the next `## [` heading in `CHANGELOG.md` | 56 |
+| Category headers in the shared block | Headings between `## [Unreleased]` and the next `## [` heading | `### Added`, `### Fixed`, `### Changed` |
+| Readiness assertion on `CHANGELOG.md` | `grep -n "CHANGELOG presence" docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` | Step 5.1 artifact table, one row; pass condition is `[.files[].path] \| any(. == "CHANGELOG.md")` for `feature/*`, `fix/*`, `refactor/*`, `hotfix/*` |
+| `PR_HAS_CHANGELOG` semantics | Read `fetch_pr_meta` and `cmd_discover` in `scripts/development-workflow/batch-merge.sh` | It is a **merge-ordering** signal (non-CHANGELOG PRs merge first), not a readiness gate. The issue body's description of it as an assertion is inaccurate; this plan does not change its meaning |
+| Release scope parser | Read `append_issues_from_changelog` in `scripts/development-workflow/prepare-release-post-merge-cleanup.sh` | Extracts `#N` tokens from the published `## [X.Y.Z]` section. Requires no change **provided** assembled bullets keep the `(#N)` reference, which the fragment body convention mandates |
+| Hotfix tagging path | Read `.github/workflows/auto-tag-release.yml` | Reads only `CHANGELOG.md` version sections; the hotfix path writes those directly and is untouched by this plan |
+| Haystack rule identifier | `grep -n "changelog" .haystack/pr-rules.yml` and the comment block in `scripts/development-workflow/haystack-reviewer.sh` | The live rule id is `keep-single-unreleased-changelog-section`; the script's comment names `keep-changelog-unreleased-structure-canonical`, which does not exist in the rules file. Pre-existing drift, corrected as part of this change |
+| Documentation-stage allowlist | Read `path_allowed_for_stage` in `scripts/development-workflow/check-documentation-stage-alignment.sh` | `spec/*` and `implementation-plan/*` allow only their own stage artifacts, so a fragment on a documentation-stage branch is correctly reported as unexpected. No change needed |
+| CI suite selection | Read the `# covers:` convention in `scripts/development-workflow/select-test-suites.sh` | A suite named `test-changelog-fragments.sh` covers `changelog-fragments.sh` by naming convention with no workflow edit |
+| Sync manifest precedence | Read the precedence paragraph in `sync-manifest.yaml` | Only "project-specific exact path beats always-sync directory glob" is defined. The reverse is undefined, so this plan lists **only** `changelog.d/README.md` and leaves downstream fragment files unlisted (the manifest header already states unlisted files are never synced) |
+| Same-surface open PRs | `gh pr list --state open` then `gh pr diff --name-only` for each | #1589 (`fix/1525-integration-branch-ci`) and #1592 (`fix/1579-coderabbit-rate-limit-window`). Both add `[Unreleased]` bullets; neither changes the changelog convention. #1589 also edits `.github/workflows/markdown-lint.yml` (branch filters) and `05b-graduate-development-protocol.md` (a new section at the top), in regions disjoint from this plan's edits |
+
+---
+
+## Cross-Cutting Operational Assumption Check
+
+### Applicable
+
+| Assumption surface | Recorded value | Authoritative source | Verified at | Bounded cross-check scope | Result |
+| --- | --- | --- | --- | --- | --- |
+| Repository mode and artifact owner | `single_repo` (no `mode` key present), so this repository owns both the plan and the implementation | `.ai-dev-workflow.yaml` | 2026-08-24, repo `19c0f46e` | Current invocation is item #1554 only; no open PR changes `.ai-dev-workflow.yaml` | `Verified` |
+| Approved artifact base branch | `develop` | Protocol 02 Step 5 plus the tracker handoff for #1554 | 2026-08-24, repo `19c0f46e` | `gh pr list --state open`: #1589 and #1592, both based on `develop` | `Verified` |
+| The shared `[Unreleased]` block is **not** migrated and is released from where it is, once | 56 bullets remain in `CHANGELOG.md` under `## [Unreleased]` | Spec "Out of Scope"; alignment decision recorded in PR #1555's description | 2026-08-24, repo `19c0f46e` | Open PRs #1589 and #1592 each add one more bullet to that block; both are additive and consistent with "released from where it is" | `Verified` — the transition design reads the block at assembly time rather than at plan time, so its exact size when the transition release is cut is irrelevant |
+| `template.is_template` is `true`, so the convention ships to downstream consumers | `true` | `.ai-dev-workflow.yaml` | 2026-08-24, repo `19c0f46e` | No open PR changes `sync-manifest.yaml` or `template.is_template` | `Verified` |
+
+Shared keywords are not treated as conflict evidence: #1589 and #1592 add
+changelog **entries**, which is the behaviour this plan changes, but neither
+changes the changelog **convention**, which is the operational surface. The
+file-level overlap with #1589 is recorded in **Risks & Mitigations** instead,
+where it belongs.
+
+---
+
+## Design Decisions
+
+Each decision below is referenced by index from the Layer-by-Layer changes and
+the Implementation Order. The indices are stable within this document.
+
+### Decision 1 — Fragment location and filename grammar
+
+**Chosen**: `changelog.d/<item>.<kind>.<slug>.md`, exactly three dot-separated
+fields before the `.md` extension, with dots forbidden inside every field.
+
+```text
+changelog.d/1554.changed.per-item-release-notes.md
+changelog.d/1589.fixed.integration-branch-ci.md
+changelog.d/ENG-42.added.export-button.md
+```
+
+- `<item>` is the bare tracker identifier for the work item, exactly as it
+  appears in the branch name (`1554`, `ENG-42`) and never with a `#`.
+- `<kind>` is one of `added`, `changed`, `deprecated`, `removed`, `fixed`,
+  `security` — lowercase.
+- `<slug>` is a short kebab-case description chosen by the author.
+
+**Why collisions are impossible, not merely unlikely**: the discriminator is an
+externally allocated unique identifier, not a date, a hash, or a free-text
+string. The tracker assigns each work item exactly one identifier, and
+`run-nested-artifact-guard.sh` already refuses a second in-flight artifact
+branch for the same issue, so at most one branch is authoring notes for a given
+`<item>` at a time. Two **different** items therefore differ in the first field
+and write different paths, and git produces a conflict only when both sides
+modify the same path. The name contains no date at all, which is the direct
+answer to the spec's "two items completed on the same day must never be able to
+claim the same file": the day is not part of the identity, so it cannot be
+shared.
+
+Two notes from the **same** item (for example one `added` and one `fixed`) live
+on one branch, where the author sees both files; that is an ordinary
+same-branch edit, not a cross-branch merge.
+
+Repositories with no issue tracker fall back to the branch slug as `<item>`.
+Uniqueness then rests on branch-name uniqueness, which git already enforces for
+concurrently existing branches.
+
+**Corollary that must not be violated**: `changelog.d/` carries no index,
+ordering file, or aggregate manifest that every item edits. Any such file would
+be a shared path and would recreate exactly the conflict this item removes. The
+per-release manifest introduced by Decision 3 is written only by the releaser,
+on the release branch, and is never touched by item branches.
+
+### Decision 2 — Change-kind encoding
+
+**Chosen**: encode the kind as the second filename field. **Rejected**: YAML
+front matter or a `Kind:` header line inside the file.
+
+- The readiness checks that must accept a fragment (Decision 5) all operate on
+  a PR's changed-file list — `gh pr view --json files`, `gh pr diff
+  --name-only`. A kind in the filename means readiness is decidable from the
+  file list alone, with zero file reads and zero additional API calls.
+- A filename field cannot drift from the file's content, because there is no
+  second copy of the kind to disagree with.
+- Front matter adds a second parser on a path that must not fail at release
+  time, and introduces malformed-YAML and missing-delimiter failure modes for
+  no gain — assembly must read the body anyway, but reading a body verbatim is
+  strictly simpler than parsing it.
+- A directory per kind (`changelog.d/fixed/1554-...`) was also rejected: it
+  adds six directories, complicates the scan, and encodes exactly the same
+  information as a filename field.
+
+**Dot as the separator, not hyphen**: hyphens appear inside both tracker
+identifiers (`ENG-42`) and slugs (`per-item-release-notes`), so a
+hyphen-separated grammar is ambiguous and, worse, silently mis-parses
+`1554.fixed.fixed-typo`-style names. Dots appear in neither field, so a strict
+four-way split on `.` is unambiguous for every legal name and rejects every
+illegal one.
+
+### Decision 3 — Consumption semantics: how "assembled but not yet published" is represented
+
+The state is represented by **two artifacts that exist together only between
+assembly and publication**, both living on the release branch:
+
+1. The draft `## [X.Y.Z] - YYYY-MM-DD` section written into `CHANGELOG.md`.
+2. A release manifest at `changelog.d/manifests/v<X.Y.Z>.txt` naming exactly
+   the fragment files that fed the draft, one repository-relative path per
+   line, preceded by a single comment line recording the assembly timestamp,
+   the fragment count, and the count of bullets carried over from the shared
+   block.
+
+Fragment files themselves are **not touched by assembly**. This is the literal
+requirement from the spec ("Assembling a draft never destroys anything") and
+from the tracker handoff, which records that the first spec draft left the
+interrupted case undefined and that any design where assembly destroys or moves
+fragments violates the corrected clause.
+
+- **The set is fixed at assembly.** After the manifest exists, it — not a fresh
+  directory scan — is the authority for what this release contains. A fragment
+  added afterwards (on `develop`, or cherry-picked onto the release branch as
+  part of a late fix) is absent from the manifest and is therefore not in this
+  release. It stays in `changelog.d/` and is picked up by the next assembly.
+- **Assembly is idempotent.** `assemble` refuses to write when `CHANGELOG.md`
+  already contains a `## [X.Y.Z]` heading for the target version, reporting
+  `ASSEMBLE_RESULT=already_assembled` and exiting 0 without modifying anything.
+  Running it twice in a row therefore leaves exactly the result of running it
+  once, including the releaser's edits. The heading check is the guarantee's
+  mechanism, and it holds even after the manifest has been removed.
+- **Interrupted preparation resumes intact.** Both artifacts are ordinary
+  committed files on the release branch, so resuming is `git checkout` of that
+  branch. Re-running `assemble` is safe (`already_assembled`). If the release
+  branch is discarded entirely, `develop` still holds every fragment, because
+  nothing was ever deleted there.
+- **Consumption happens at publication.** `consume` deletes exactly the files
+  named in the manifest, plus the manifest itself, as a commit on the release
+  branch. Those deletions reach `main` and `develop` only when the release PRs
+  merge — which is what "published" means. An abandoned release deletes
+  nothing anywhere that survives.
+- **Re-assembly is possible but explicit.** `assemble --reassemble` recomputes
+  the manifest from the current directory and replaces the existing version
+  section. It prints the section it is about to replace before replacing it,
+  because that section may contain the releaser's editorial pass. It is the
+  only path that discards editorial edits, and it is never invoked by protocol
+  05's normal flow.
+- **If a fragment is edited between assembly and consumption**, the draft in
+  `CHANGELOG.md` wins: it is what the releaser reviewed. `consume` deletes the
+  file regardless of its content.
+
+### Decision 4 — The transition release
+
+Assembly performs, in one operation:
+
+1. Rename the existing `## [Unreleased]` heading to `## [X.Y.Z] - YYYY-MM-DD`,
+   preserving every bullet already under it. This is exactly the rename the
+   releaser performs by hand today.
+2. Merge the manifest's fragment bullets into that same section, per kind:
+   append to an existing `### Category` heading when one is present, and create
+   the heading in canonical Keep a Changelog order (Added, Changed, Deprecated,
+   Removed, Fixed, Security) when it is not.
+3. Insert a fresh, empty `## [Unreleased]` heading above the new version
+   section.
+
+Each entry appears exactly once because the carried-over bullets are **moved**
+with the heading rather than copied, and each fragment is emitted once from the
+manifest. Appending into an existing `### Category` rather than creating a
+second one is also what keeps `check-changelog-duplicate-headers.sh` passing on
+the assembled output.
+
+The transition is therefore not a special mode and leaves no dead code: after
+it, `## [Unreleased]` is simply always empty, the rename produces an empty
+section, and fragments fill it. The same behaviour is what lets a downstream
+project that already has a populated shared block adopt fragments with no
+migration step (Decision 7).
+
+### Decision 5 — Readiness checks that must accept a fragment
+
+The authoritative check is the **CHANGELOG presence** row of Protocol 90 Step
+5.1's artifact table. It is the gate: a PR whose file list lacks `CHANGELOG.md`
+is redispatched rather than accepted as ready. Its pass condition becomes:
+
+```text
+[.files[].path] | any(. == "CHANGELOG.md" or startswith("changelog.d/"))
+```
+
+The complete set of surfaces that today assert or instruct "a release note was
+recorded", each of which must accept a fragment:
+
+| Surface | What it asserts today | Change |
+| --- | --- | --- |
+| `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md` Step 5.1 table | `CHANGELOG.md` in `files` for `feature/*`, `fix/*`, `refactor/*`, `hotfix/*` | Accept a `changelog.d/` path; keep `CHANGELOG.md` accepted for `hotfix/*` |
+| `docs/workflow/development-workflow/protocols/03-implement-development-protocol.md` | Four per-path "Update CHANGELOG" steps and two PR-body "CHANGELOG entry preview" bullets | Paths 1–3 write a fragment; Path 4 (hotfix) unchanged; previews renamed to "release note preview" |
+| `REVIEW.md` (spec exemption, plan exemption, code-review checklist, reviewer-finding list) | Spec and plan branches must not touch `CHANGELOG.md`; code review flags a missing entry | Extend the exemptions to `changelog.d/`; restate the code-review item in terms of a release note |
+| `LLM_RULES.md` | "Do not skip CHANGELOG updates for feature/fix PRs" | Restate as "record a release note"; point at the fragment convention |
+| `.haystack/pr-rules.yml` rule `keep-single-unreleased-changelog-section` | Agents must not create duplicate `[Unreleased]` headers | Keep the rule (it still guards hotfix and release edits); retarget its message to those contexts |
+| `scripts/development-workflow/haystack-reviewer.sh` comment block | Documents a `Rules violation` false positive, naming a rule id that does not exist in the rules file | Correct the rule id and rescope the guidance to hotfix/release edits |
+| `.claude/agents/developer.md`, `.cursor/agents/developer.md`, `.cursor/rules/workflow.mdc`, `.cursor/commands/implement-development.md` | "Always update CHANGELOG before opening the PR", plus duplicate-header avoidance | Replace with the fragment instruction; the duplicate-header guidance is no longer reachable for item PRs |
+| `AGENTS.md` (`CLAUDE.md` and `GEMINI.md` are symlinks to it) | "Feature and fix PRs add entries under `[Unreleased]`" | Restate; keep the hotfix exception verbatim |
+| `docs/best-practices/2-version-control.md` | "Every PR must update `CHANGELOG.md` under `[Unreleased]`" plus the parallel-batch note | Restate as the fragment convention and make this file the canonical format reference |
+| `scripts/development-workflow/batch-merge.sh` `PR_HAS_CHANGELOG` | Whether the diff touches `CHANGELOG.md`; drives merge **ordering** only | No semantic change — see Decision 6 |
+
+### Decision 6 — What happens to Protocol 94 Step 4.3
+
+**Chosen**: narrow and keep, rather than remove.
+
+Fragments make a `CHANGELOG.md` conflict between two in-flight item PRs
+impossible in this repository, but they do not make `CHANGELOG.md` conflicts
+impossible in general:
+
+- The hotfix path still writes versioned sections directly into `CHANGELOG.md`
+  (spec Use Case 3), so two hotfixes in flight, or a hotfix racing a release,
+  can still collide there.
+- Release and backport PRs edit `CHANGELOG.md` by design.
+- Downstream projects created from earlier template versions still use the
+  shared block. The spec's Out of Scope explicitly declines to ship a migration
+  tool for them, which means non-adopted consumers are an expected population,
+  and Protocol 94 is synced to them.
+
+Removal is therefore the higher-cost error: the failure mode is a downstream
+batch merge hitting a `CHANGELOG.md` conflict with no documented resolution,
+against a benefit of one dormant branch in a protocol. Concretely:
+
+- Step 4.3's `CHANGELOG.md` auto-resolution procedure stays, with its trigger
+  restated: expected for hotfix, release, backport, and not-yet-adopted
+  repositories, rather than "every PR in a wave".
+- A new `changelog.d/` clause is added: a conflict on a `changelog.d/` path is
+  **never** auto-resolved. Identical paths on both sides mean the same item
+  identifier was used twice, which is a real mistake, not a trivial collision.
+  Classify as non-trivial and escalate.
+- `PR_HAS_CHANGELOG` keeps its current meaning and name. It is emitted metadata
+  that tests and callers depend on, it accurately describes the diff, and
+  renaming an output contract field to make a documentation point would be a
+  gratuitous break. Its header comment gains one sentence clarifying that it is
+  an ordering signal, not a readiness gate.
+- The batch-merge hold-annotation text, which currently tells a runner that a
+  `CHANGELOG.md`-only conflict can be resolved at merge time, keeps that
+  sentence and gains the `changelog.d/` clause.
+
+### Decision 7 — Downstream template consumers
+
+The acceptance criterion is that a project created from this template records
+release notes the new way with no additional setup. Three things make that true:
+
+1. **The directory ships.** `changelog.d/README.md` is committed in the
+   template and documents the filename grammar and the six kinds. Its presence
+   is also what makes the directory exist in a fresh clone, since git does not
+   track empty directories.
+2. **The tooling ships.** `scripts/development-workflow/` and `scripts/lint/`
+   are already `always_sync` directory entries in `sync-manifest.yaml`, so
+   `changelog-fragments.sh` and its test arrive with no manifest edit. The
+   protocols and agent surfaces that instruct authors are likewise already
+   covered by the `docs/workflow/`, `.claude/`, `.cursor/`, and `.codex/`
+   entries.
+3. **The manifest gains exactly one entry**: `changelog.d/README.md` as
+   `always_sync`, `mode_scope: shared`. Downstream fragment files are
+   deliberately **not** listed in any category. The manifest header already
+   states that files absent from the manifest are not included in always-sync
+   batches, so a project's own notes are never overwritten, and the template's
+   own fragments are never pushed into a consumer.
+
+The reason for leaving fragments unlisted rather than adding a
+`project_specific` glob is recorded in the Verification Log: `sync-manifest.yaml`
+defines precedence only for "project-specific exact path beats always-sync
+directory glob". A `project_specific` glob for `changelog.d/` combined with an
+`always_sync` exact path for its README would depend on the reverse precedence,
+which is undefined. Relying on undefined manifest semantics for a
+data-preservation property is not acceptable; being absent from the manifest is
+unambiguous.
+
+Finally, a downstream project that already has a populated `[Unreleased]` block
+needs no migration: Decision 4's assembly carries that block into the version
+section on the project's next release, exactly as it does for this repository's
+transition release.
+
+---
+
+## Layer-by-Layer Changes
+
+### Shared Packages / Libraries
+
+New helper — `scripts/development-workflow/changelog-fragments.sh`. Shell
+contract: `bash` (it uses `set -euo pipefail`, arrays, and `local`, matching
+every sibling in that directory). It emits `KEY=VALUE` lines on stdout like the
+other workflow helpers, and every exit path prints its documented fields.
+
+- [ ] `validate [--dir <path>]` — parse and check every fragment. Emits
+      `VALIDATE_RESULT=clean|invalid`, `FRAGMENT_COUNT=<n>`, and one
+      `INVALID_FRAGMENT=<path>: <reason>` per failure. (Spec AC-2, AC-9)
+- [ ] `list [--json]` — report the pending notes without changing anything.
+      Emits `PENDING_COUNT=<n>` and one `PENDING=<path>` per fragment.
+      (Spec "Operational Visibility")
+- [ ] `assemble --version <X.Y.Z> [--date <YYYY-MM-DD>] [--reassemble]
+      [--allow-empty]` — freeze the set into
+      `changelog.d/manifests/v<X.Y.Z>.txt`, rename `## [Unreleased]` to the
+      version heading, merge fragment bullets per kind, and insert a fresh
+      empty `## [Unreleased]`. Emits `ASSEMBLE_RESULT`, `VERSION`,
+      `FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`, `MANIFEST_PATH`, and `ITEMS`.
+      (Spec AC-3, AC-5, AC-7, AC-10; Decisions 3 and 4)
+- [ ] `consume --version <X.Y.Z>` — delete the manifest-listed fragments and
+      the manifest. Emits `CONSUME_RESULT`, `REMOVED_COUNT`, `MANIFEST_PATH`.
+      (Spec AC-5, AC-7)
+- [ ] Exit codes: `0` for `clean`, `assembled`, `already_assembled`,
+      `reassembled`, `consumed`, `already_consumed`; `1` for a validation or
+      assembly error; `3` for `no_notes` without `--allow-empty`; `64` for a
+      usage error, matching `check-documentation-stage-alignment.sh`.
+- [ ] Reporting on assembly names each contributing item, and reports bullets
+      carried over from the shared block as a single unattributed group, per
+      the spec's Operational Visibility section.
+
+New directory:
+
+- [ ] `changelog.d/README.md` — the filename grammar, the six kinds, the body
+      convention (a complete markdown bullet including the `**Bold Title**
+      (#N):` prefix), and a worked example. It is excluded from the fragment
+      scan by name.
+- [ ] `changelog.d/manifests/.gitkeep` — so the manifest directory exists on a
+      fresh clone even though manifests exist only during a release.
+
+### Infrastructure / Configuration
+
+- [ ] `.github/workflows/markdown-lint.yml` — add `changelog.d/**` to the
+      `paths:` filter, add the directory to the file-collection step and the
+      `markdownlint-cli2` target list, and add a step running
+      `changelog-fragments.sh validate` so a malformed fragment fails on the
+      item's own PR rather than at release time. (Spec AC-9)
+- [ ] `sync-manifest.yaml` — one `always_sync` entry for
+      `changelog.d/README.md`, `mode_scope: shared`, with a note recording that
+      fragment files are intentionally unlisted. (Spec AC-12; Decision 7)
+- [ ] `.haystack/pr-rules.yml` — retarget the
+      `keep-single-unreleased-changelog-section` rule message to hotfix and
+      release edits.
+- [ ] Verified as needing **no** change: `.github/workflows/auto-tag-release.yml`
+      (reads published version sections only), `.markdownlint.jsonc` and
+      `.markdownlint-cli2.jsonc` (rule set is file-agnostic),
+      `.pr_agent.toml` (its changelog note remains accurate),
+      `scripts/development-workflow/check-documentation-stage-alignment.sh`
+      (fragments are correctly unexpected on documentation-stage branches),
+      `scripts/development-workflow/prepare-release-post-merge-cleanup.sh`
+      (its `--from-changelog` parser reads the assembled section and keeps
+      working because fragment bodies carry `(#N)`),
+      `scripts/development-workflow/component-release-target.sh` (ownership
+      resolution only), `.github/workflows/workflow-tests.yml` (selection is
+      computed, so the new suite needs no workflow edit).
+
+### Backend / API
+
+Not applicable — this repository ships workflow tooling and documentation; it
+has no application backend, database, or UI.
+
+### Documentation, protocols, and agent surfaces
+
+This plan **introduces or modifies a cross-cutting checklist**: the release-note
+requirement applies to every implementation across the workflow, and this change
+alters how every implementer, reviewer, and orchestrator satisfies it. The full
+enumeration below is the result of the live searches recorded in the
+Verification Log, not a copied list.
+
+Protocols:
+
+- [ ] `docs/workflow/development-workflow/protocols/03-implement-development-protocol.md`
+      — replace the "Update CHANGELOG" step in Path 1 (feature), Path 2
+      (refactor), and Path 3 (fix) with "Record the release note", writing a
+      fragment and running `changelog-fragments.sh validate`. Delete the
+      duplicate-`### Category` avoidance machinery from those three paths — it
+      is unreachable once no item edits a shared section. Leave Path 4 (hotfix)
+      byte-for-byte unchanged. Rename both "CHANGELOG entry preview" PR-body
+      bullets to "release note preview". (Spec AC-2, AC-11)
+- [ ] `docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md`
+      — restructure Step 3 into: assemble the draft, editorial pass (today's
+      polish guidance retargeted at the assembled draft, unchanged in
+      substance), link-reference definitions (unchanged), consume the notes.
+      Extend Step 7.2's release-artifact validation with the two checks that
+      prove consumption ran: `changelog.d/manifests/v<X.Y.Z>.txt` is absent and
+      `## [X.Y.Z] - YYYY-MM-DD` is present. (Spec AC-3, AC-4, AC-5, AC-8)
+- [ ] `docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md`
+      — extend Step 2.5 so the graduation PR is verified to carry the
+      `changelog.d/` additions accumulated on `develop-<slug>`, alongside the
+      existing `CHANGELOG.md` check. Note that #1589 is adding a new section
+      near the top of this file; the Step 2.5 edit is in a different region.
+- [ ] `docs/workflow/development-workflow/protocols/90-batch-orchestrate-work-protocol.md`
+      — update the Step 5.1 CHANGELOG-presence row per Decision 5; rewrite Step
+      3.6 from "conflicts are expected and auto-resolved" to "disjoint paths
+      make the conflict impossible", retaining a short note for repositories
+      that have not adopted fragments; update the Step 5.1 preamble sentence
+      about the `files` field. (Spec AC-1, AC-2)
+- [ ] `docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md`
+      — update the "CHANGELOG in parallel batches" paragraphs in both places
+      they appear.
+- [ ] `docs/workflow/development-workflow/protocols/94-batch-merge-protocol.md`
+      — apply Decision 6: restate the Step 4.3 `CHANGELOG.md` trigger, add the
+      `changelog.d/` never-auto-resolve clause, and update the merge-ordering
+      rationale text.
+- [ ] `docs/workflow/development-workflow/protocols/01-generate-spec-protocol.md`
+      and `02-generate-implementation-plan-protocol.md` — extend the "Do NOT
+      update CHANGELOG" steps to cover `changelog.d/`, and update Protocol 02's
+      "CHANGELOG literal format" guardrail to describe the fragment a plan
+      hands to the implementer.
+- [ ] `docs/workflow/development-workflow/templates/implementation-plan-template.md`
+      — update the final Implementation Order step.
+- [ ] `docs/workflow/development-workflow/README.md` — the implementation and
+      release narrative, and the hotfix section (which stays correct but should
+      name the contrast explicitly).
+- [ ] `docs/workflow/development-workflow/integrations/haystack-triage.md` — the
+      changelog false-positive guidance, rescoped and with the rule id
+      corrected.
+
+Review contract, agent, command, and skill surfaces:
+
+- [ ] `REVIEW.md` — spec exemption, plan exemption, code-review checklist item,
+      and the reviewer-finding list.
+- [ ] `.claude/agents/developer.md` and `.cursor/agents/developer.md`
+- [ ] `.claude/agents/tech-lead.md` and `.cursor/agents/tech-lead.md` — only if
+      the plan-stage CHANGELOG-literal guidance is quoted there; verify at
+      implementation time and record the result either way.
+- [ ] `.cursor/rules/workflow.mdc` and `.cursor/commands/implement-development.md`
+- [ ] `.claude/commands/prepare-release.md`, `.cursor/commands/prepare-release.md`,
+      `.agents/skills/prepare-release/SKILL.md` (a real directory, not a
+      symlink)
+- [ ] `.claude/commands/batch-merge.md`, `.cursor/commands/batch-merge.md`,
+      `.codex/skills/batch-merge/SKILL.md`, and
+      `.codex/skills/batch-merge/agents/openai.yaml`
+- [ ] `.claude/commands/graduate-development.md` and
+      `.cursor/commands/graduate-development.md`
+- [ ] `.codex/skills/workflow-implementer/SKILL.md` and
+      `.codex/skills/workflow-plan-writer/SKILL.md` — these delegate to the
+      protocols and contain no changelog text at the plan-time revision.
+      Re-check at implementation time; change only if that has changed.
+- [ ] `.codex/skills/workflow-sync-template/SKILL.md`,
+      `.claude/commands/sync-template.md`, `.claude/skills/sync-template.md`,
+      `.cursor/commands/sync-template.md` — their changelog references are
+      about the sync tool's own changelog handling; verify and record.
+- [ ] `AGENTS.md` — the "CHANGELOG & Versioning" section and the lint command
+      block. `CLAUDE.md` and `GEMINI.md` are symlinks and need no separate edit.
+- [ ] `LLM_RULES.md`, `README.md`, `docs/best-practices/1-general.md`,
+      `docs/best-practices/2-version-control.md`
+- [ ] `scripts/development-workflow/README.md` and `scripts/lint/README.md` —
+      document the new helper.
+- [ ] `docs/testing/workflow/batch-merge.smoke-test.md` — its CHANGELOG-conflict
+      scenarios describe behaviour that no longer occurs for item PRs.
+
+---
+
+## Testing Strategy
+
+**Test types**: Unit (shell suite), Integration (end-to-end merge and release
+rehearsal), Smoke (runbook).
+
+**Key scenarios to test**:
+
+1. Two branches each adding a fragment merge one after the other with no
+   conflict, and both notes survive — Spec AC-1.
+2. A PR carrying only a fragment satisfies the release-note readiness check
+   without touching `CHANGELOG.md` — Spec AC-2.
+3. Assembly gathers every pending note into a version section grouped by kind —
+   Spec AC-3.
+4. Edits made to the assembled draft survive to publication — Spec AC-4.
+5. Assembly followed by interruption and resumption loses neither notes nor
+   edits — Spec AC-5.
+6. A fragment written after assembly is absent from that release and present
+   for the next one — Spec AC-6.
+7. After consumption no manifest-listed fragment remains, and a repeat
+   assembly produces no duplicate section — Spec AC-7.
+8. After publication the changelog is ready for the next release and every
+   version link resolves — Spec AC-8.
+9. The assembled section passes `markdownlint-cli2`,
+   `markdown-heuristic-lint.py`, and `check-changelog-duplicate-headers.sh` —
+   Spec AC-9.
+10. A release cut with both a populated shared block and pending fragments
+    contains every entry exactly once — Spec AC-10.
+11. A hotfix writes its own versioned section and is untouched by assembly —
+    Spec AC-11.
+12. A fresh clone of the template can record a note with no setup — Spec AC-12.
+13. Published history above the new version section is byte-identical before
+    and after — Spec AC-13.
+
+**Suites to add or extend**:
+
+- **Add** `scripts/development-workflow/tests/test-changelog-fragments.sh`. It
+  covers `changelog-fragments.sh` by the naming convention, and declares
+  additional `# covers:` lines for `.github/workflows/markdown-lint.yml`,
+  `changelog.d/**`, and
+  `docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md`
+  so a change to any of them selects this suite in CI.
+- **Extend** `scripts/development-workflow/tests/test-prepare-release-tracker-cleanup.sh`
+  with a fixture whose version section was produced by assembly, proving
+  `--from-changelog` still extracts the issue scope from fragment-derived
+  bullets.
+- **Extend** `scripts/development-workflow/tests/test-batch-merge-changelog-race.sh`
+  with a case asserting that a `changelog.d/` conflict is classified
+  non-trivial rather than auto-resolved.
+- **Extend** `scripts/development-workflow/tests/test-select-test-suites.sh`
+  only if its expected-mapping fixtures enumerate suites; verify at
+  implementation time.
+- **Run** `scripts/lint/check-changelog-duplicate-headers.sh` and
+  `scripts/lint/markdown-heuristic-lint.py` against every assembled fixture
+  produced by the new suite, so lint conformance of the output is asserted by
+  the suite itself rather than only observed in CI.
+
+**Smoke test runbook**: `docs/testing/workflow/1554-changelog-fragments.smoke-test.md`
+
+**Regression suite**: the repository's automated regression surface is the
+shell suites under `scripts/development-workflow/tests/`, selected per change
+set by `select-test-suites.sh`. The new suite above is that regression
+coverage; no separate regression project applies.
+
+### Parser-risk addendum
+
+This plan is **parser-risk**: `changelog-fragments.sh` performs structured-text
+scanning of filenames against a strict grammar and rewrites `CHANGELOG.md` by
+locating section boundaries. Every case below maps to at least one automated
+test in `scripts/development-workflow/tests/test-changelog-fragments.sh`.
+
+**Edge-case enumeration — filename grammar**
+
+| # | Input | Required behaviour |
+| --- | --- | --- |
+| 1 | `1554.fixed.a.md` | Accepted; minimal legal name |
+| 2 | `1554.fixed.changelog-fragments-collide.md` | Accepted; hyphens in the slug |
+| 3 | `ENG-42.added.export-button.md` | Accepted; hyphen inside the tracker identifier |
+| 4 | `1554.fixed.fixed-fixed.md` | Accepted as kind `fixed`, slug `fixed-fixed` — the strict field split makes a kind-lookalike slug harmless |
+| 5 | `1554.improved.x.md` | Rejected; message names the six recognized kinds |
+| 6 | `1554.Fixed.x.md` | Rejected; kinds are lowercase |
+| 7 | `1554.fixed.md` | Rejected; too few fields |
+| 8 | `1554.fixed.a.b.md` | Rejected; dots are forbidden inside fields |
+| 9 | `.fixed.a.md` | Rejected; empty item field |
+| 10 | `README.md` | Ignored — never a fragment, never an error |
+| 11 | `.gitkeep`, `.DS_Store` | Ignored |
+| 12 | `1554.fixed.notes.txt` | Rejected loudly rather than skipped, so a note cannot be silently left behind |
+| 13 | `manifests/v1.0.0.txt` | Ignored by the fragment scan, which reads only the top level of `changelog.d/` |
+
+**Edge-case enumeration — fragment body**
+
+| # | Input | Required behaviour |
+| --- | --- | --- |
+| 14 | Empty or whitespace-only file | Rejected |
+| 15 | First non-blank line does not begin with `- ` | Rejected; a non-bullet body would corrupt the assembled list |
+| 16 | Multiple top-level bullets in one fragment | Accepted; copied verbatim without renumbering |
+| 17 | Continuation lines indented by two spaces | Preserved verbatim; assembly never re-wraps |
+| 18 | CRLF line endings | Normalized to LF before insertion |
+| 19 | A body line beginning with `## [` | Copied verbatim and never interpreted; section boundaries are computed once from the pre-assembly `CHANGELOG.md`, and fragment bodies are opaque text thereafter. This is the overlapping-construct case |
+| 20 | Trailing whitespace on a body line | Rejected by `validate`, so it fails on the item's PR rather than producing an MD009 failure on the assembled changelog |
+
+**Edge-case enumeration — changelog rewriting**
+
+| # | Input | Required behaviour |
+| --- | --- | --- |
+| 21 | No `## [Unreleased]` heading | Rejected; the heading is a precondition that `auto-tag-release.yml` also depends on |
+| 22 | Two `## [Unreleased]` headings | Rejected |
+| 23 | `## [X.Y.Z]` already present | `ASSEMBLE_RESULT=already_assembled`, exit 0, no write — the idempotence mechanism |
+| 24 | Populated shared block plus pending fragments | Both merged into one version section, each entry once, with no duplicate `### Category` heading |
+| 25 | Populated shared block, zero fragments | Rename only — the pre-fragment behaviour, preserved |
+| 26 | Empty shared block, zero fragments | `ASSEMBLE_RESULT=no_notes`, exit 3, unless `--allow-empty` |
+| 27 | A kind present in fragments but absent from the shared block | Heading created in canonical Keep a Changelog order |
+| 28 | Deterministic ordering | Bullets sorted by kind rank, then by the item field (numerically when it is all digits, lexicographically otherwise), then by full filename — so two runs on the same input produce identical bytes |
+| 29 | `consume` when the manifest is absent | `CONSUME_RESULT=manifest_missing`, non-zero, with the remediation named |
+| 30 | `consume` run twice | Second run reports `already_consumed`, exit 0 |
+| 31 | `consume` when a manifest-listed file is already gone and the version section is absent | Rejected — the release state is inconsistent and must not be papered over |
+
+**Suppression semantics**: not applicable. `changelog-fragments.sh` recognizes
+no inline suppression directives. Declining to write a release note is
+expressed by not creating a fragment, exactly as declining to edit
+`CHANGELOG.md` is expressed today, and it is not a directive the parser reads.
+
+### Concurrent-event-source addendum
+
+**Not applicable.** `changelog-fragments.sh` is a single-threaded command-line
+helper with no listeners, timers, sockets, or async queues, and no state shared
+across execution contexts. Each item below is recorded as not applicable for
+that reason: shared mutable state guards, re-entrancy and in-flight tracking,
+event deduplication, listener and resource cleanup, initialization races,
+teardown races, and error propagation across async boundaries. The concurrency
+this feature addresses is between independent git branches, and it is handled
+structurally — by disjoint file paths (Decision 1) — not by runtime
+synchronization.
+
+---
+
+## Complex Workflow Decision-Gate Matrix
+
+This plan adds a workflow decision gate: the release-time assemble/consume step
+in Protocol 05, whose behaviour depends on several inputs and produces several
+distinct next actions. It also changes an existing gate: the release-note
+readiness check.
+
+### Gate A — `changelog-fragments.sh assemble`
+
+| Gate inputs | Outcome | Required next action | Mirror surfaces |
+| --- | --- | --- | --- |
+| No `## [X.Y.Z]` heading; at least one pending fragment or a non-empty shared block | `assembled` | Continue to the editorial pass (Protocol 05 Step 3) | Protocol 05; `.claude/commands/prepare-release.md`; `.cursor/commands/prepare-release.md`; `.agents/skills/prepare-release/SKILL.md` |
+| `## [X.Y.Z]` heading already present | `already_assembled` | No write; continue. This is the resume path and the idempotence guarantee | Same |
+| `--reassemble` passed and the heading is present | `reassembled` | Print the replaced section first; the releaser must redo any editorial pass | Same |
+| No pending fragment and an empty shared block | `no_notes` (exit 3) | Stop; either there is nothing to release or a fragment was lost. Pass `--allow-empty` only for a deliberate no-notes release | Same |
+| Any fragment fails the grammar or body checks | `invalid` (exit 1) | Fix the named fragment on `develop` and re-run; never assemble a partial set | Protocol 05; `.github/workflows/markdown-lint.yml` |
+| `CHANGELOG.md` lacks exactly one `## [Unreleased]` heading | `error` (exit 1) | Repair the changelog before releasing | Protocol 05 Step 7.2 |
+
+### Gate B — `changelog-fragments.sh consume`
+
+| Gate inputs | Outcome | Required next action | Mirror surfaces |
+| --- | --- | --- | --- |
+| Manifest present, listed files present | `consumed` | Commit the deletions with the release commit | Protocol 05 Step 3 |
+| Manifest absent, version section present | `already_consumed` | Continue; the step already ran | Protocol 05 Steps 3 and 7.2 |
+| Manifest absent, version section absent | `manifest_missing` (non-zero) | Run `assemble` first | Protocol 05 Step 3 |
+| Manifest present, a listed file missing, version section absent | `error` (exit 1) | Stop and reconcile by hand; the release state is inconsistent | Protocol 05 Step 7.2 |
+
+### Gate C — release-note readiness (changed, not added)
+
+| Gate inputs | Outcome | Required next action | Mirror surfaces |
+| --- | --- | --- | --- |
+| `feature/*`, `fix/*`, `refactor/*` PR whose files include a `changelog.d/` path | Pass | Continue to the remaining Step 5.1 checks | Protocol 90 Step 5.1; `REVIEW.md`; `.claude/agents/developer.md`; `.cursor/agents/developer.md` |
+| `hotfix/*` PR whose files include `CHANGELOG.md` | Pass | Continue — the hotfix path is unchanged | Protocol 90 Step 5.1; Protocol 03 Path 4 |
+| Implementation PR with neither | Fail | Redispatch to record a release note; do not accept as ready | Protocol 90 Step 5.1 |
+| `spec/*` or `implementation-plan/*` PR | Not applicable | Exempt; a fragment on these branches is a finding, not a pass | `REVIEW.md`; `check-documentation-stage-alignment.sh` |
+| `backport/hotfix/*` PR | Not applicable | Exempt; the versioned entry already exists on `main` and flows through the merge | Protocol 90 Step 5.1 |
+
+**Examples**: the changed surfaces carry worked examples today (Protocol 03's
+per-path changelog snippets, Protocol 05's rename instructions, Protocol 94's
+auto-resolution report text). Each must be rewritten to the new convention in
+the same edit, and the implementation must not leave an example demonstrating
+the retired convention on a surface whose prose describes the new one.
+
+---
+
+## Seed Data
+
+| Entity | Values / Scenario | File |
+| --- | --- | --- |
+| Valid fragments spanning several kinds | `900.added.alpha.md`, `901.fixed.beta.md`, `902.changed.gamma.md` | Fixtures created by `scripts/development-workflow/tests/test-changelog-fragments.sh` in a temporary directory |
+| Invalid fragments | One per rejected row of the parser-risk tables above | Same |
+| Changelog with a populated shared block | `## [Unreleased]` carrying `### Added` and `### Fixed` bullets, plus prior version sections and their link-reference definitions | Same — the transition-release fixture |
+| Changelog with an empty shared block | `## [Unreleased]` with no bullets | Same — the steady-state fixture |
+| This item's own release note | `changelog.d/1554.changed.per-item-release-notes.md` (content in Implementation Order Step 12) | Committed by the implementation PR |
+
+---
+
+## Documentation Updates
+
+The developer must update the following after implementation. These are listed
+for execution, not performed during Plan Ready.
+
+- [ ] `AGENTS.md` — rewrite the "CHANGELOG & Versioning" section for the
+      fragment convention, keeping the hotfix exception; extend the markdown
+      lint command block to cover `changelog.d/`. `CLAUDE.md` and `GEMINI.md`
+      are symlinks to this file and must not be edited separately.
+- [ ] `README.md` — the repository-structure listing and the CHANGELOG-required
+      bullet.
+- [ ] `REVIEW.md` — spec exemption, plan exemption, code-review checklist item,
+      reviewer-finding list.
+- [ ] `LLM_RULES.md` — the agent commit rule.
+- [ ] `docs/best-practices/1-general.md` — the lint command block.
+- [ ] `docs/best-practices/2-version-control.md` — becomes the canonical
+      statement of the release-note convention.
+- [ ] `docs/workflow/development-workflow/README.md` — implementation and
+      release narrative, hotfix contrast.
+- [ ] `docs/workflow/development-workflow/integrations/haystack-triage.md` —
+      changelog false-positive guidance and rule id.
+- [ ] `scripts/development-workflow/README.md` and `scripts/lint/README.md` —
+      document `changelog-fragments.sh`.
+- [ ] `docs/testing/workflow/batch-merge.smoke-test.md` — its
+      CHANGELOG-conflict scenarios.
+- [ ] `changelog.d/README.md` — new; the authoritative filename and body
+      reference that ships to downstream projects.
+- [ ] `docs/project/` — no update required. This repository's project docs are
+      unfilled template placeholders and describe no changelog behaviour.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| An entry is lost or duplicated at the transition release, which is the hardest failure to detect after the fact | Med | High | Design the transition first, not last (tracker handoff). Assembly **moves** the shared block by renaming its heading rather than copying bullets, so duplication requires a coding error rather than an oversight; edge cases 24, 25, and 27 are asserted by fixtures before any protocol text is written |
+| The sweep misses a surface, leaving one agent instructed to edit `[Unreleased]` and reintroducing the conflict for whatever it builds | Med | High | The residual verification strategy below requires the implementation PR to re-run the repository-wide scan and account for every hit, either as changed or with a written no-change rationale |
+| The risk classifier grades the implementation PR `high` because it touches `.github/workflows/`, blocking delegated merge under the `medium` ceiling | High | Low | Known and filed as #1565. Expect an explicit merge authorization request rather than treating it as a failure |
+| File-level overlap with open PR #1589 on `.github/workflows/markdown-lint.yml` and `05b-graduate-development-protocol.md` | Med | Low | The edits are in disjoint regions (branch filters and a new top section, versus `paths:`/targets and Step 2.5). If #1589 merges first, rebase; the conflict, if any, is a normal two-region docs conflict, not the combinatorial one this item removes |
+| A release-branch delete of a fragment races an edit of that same fragment on `develop` | Low | Low | Git reports a delete/modify conflict on one file owned by one item. Editing a note after its release is already a mistake; document the resolution (keep the deletion) in Protocol 94's `changelog.d/` clause |
+| `--reassemble` discards a releaser's editorial pass | Low | Med | The flag is never used by Protocol 05's normal flow, and the command prints the section it is about to replace before replacing it |
+| Downstream projects that have not adopted fragments receive protocol updates describing a convention they do not use | Med | Low | Decision 6 keeps Protocol 94's auto-resolution and states the not-yet-adopted case explicitly; Decision 4's assembly works unchanged on a populated shared block, so adoption needs no migration |
+
+---
+
+## Code Samples
+
+The filename grammar, expressed as a regular expression. **Illustrative —
+adapt during implementation**; the authoritative behaviour is the edge-case
+tables above.
+
+```text
+^(?<item>[A-Za-z0-9][A-Za-z0-9_-]*)\.(?<kind>added|changed|deprecated|removed|fixed|security)\.(?<slug>[a-z0-9][a-z0-9-]*)\.md$
+```
+
+An example fragment file, `changelog.d/1589.fixed.integration-branch-ci.md`.
+**Illustrative** — the body is the finished bullet, copied verbatim into the
+assembled section:
+
+```markdown
+- **Integration-branch PRs now run CI** (#1525): workflows that gated only on
+  `develop` ran zero checks on sub-item PRs targeting `develop-<slug>`.
+```
+
+An example release manifest, `changelog.d/manifests/v0.43.0.txt`.
+**Illustrative**:
+
+```text
+# assembled 2026-09-01T09:14:22Z version=0.43.0 fragments=2 carried_over=56
+changelog.d/1554.changed.per-item-release-notes.md
+changelog.d/1589.fixed.integration-branch-ci.md
+```
+
+---
+
+## Implementation Order
+
+1. **Create the directory and its reference.** Add `changelog.d/README.md`
+   documenting the grammar, the six kinds, and the body convention, and
+   `changelog.d/manifests/.gitkeep`. (Decisions 1, 2, 7)
+
+   *Verify*: `ls changelog.d` lists the README and the manifests directory, and
+   `node_modules/.bin/markdownlint-cli2 "changelog.d/README.md"` reports no
+   violations.
+
+2. **Write the test suite first, red.** Create
+   `scripts/development-workflow/tests/test-changelog-fragments.sh` with one
+   case per row of the three parser-risk tables, plus its `# covers:` header
+   lines. Every case fails at this point because the helper does not exist.
+
+   *Verify*: running the suite reports failures for every case and no case is
+   silently skipped.
+
+3. **Implement `validate` and `list`.** Filename grammar, body checks, and the
+   reporting fields.
+
+   *Verify*: the filename-grammar and fragment-body cases in the suite pass;
+   the changelog-rewriting cases still fail.
+
+4. **Implement `assemble`.** Manifest write, heading rename, per-kind merge,
+   fresh empty `## [Unreleased]`, deterministic ordering, and the
+   already-assembled and no-notes outcomes.
+
+   *Verify*: the changelog-rewriting cases pass, and the suite's assembled
+   fixtures are checked with `check-changelog-duplicate-headers.sh` and
+   `markdown-heuristic-lint.py` inside the suite itself.
+
+5. **Implement `consume`.** Manifest-driven deletion, the already-consumed
+   outcome, and the inconsistent-state rejection.
+
+   *Verify*: the whole suite passes. Run it twice in a row and confirm the
+   second run reports the same result as the first.
+
+6. **Wire the lint and CI surfaces.** Update
+   `.github/workflows/markdown-lint.yml` (`paths:`, the collection step, the
+   lint targets, and a `validate` step).
+
+   *Verify*: `bash scripts/development-workflow/select-test-suites.sh
+   --changed-files <file listing the changed paths>` lists
+   `test-changelog-fragments.sh`, and running the repository's markdown lint
+   commands locally passes.
+
+7. **Update the release path.** Protocol 05 Step 3 (assemble, editorial pass,
+   link definitions, consume) and Step 7.2's artifact validation, then the three
+   prepare-release command and skill surfaces.
+
+   *Verify*: read Step 3 end to end and confirm a releaser can execute it
+   without consulting this plan, and that the editorial pass still appears
+   between assembly and consumption.
+
+8. **Update the implementation path.** Protocol 03 Paths 1–3, leaving Path 4
+   untouched; then `.claude/agents/developer.md`,
+   `.cursor/agents/developer.md`, `.cursor/rules/workflow.mdc`, and
+   `.cursor/commands/implement-development.md`.
+
+   *Verify*: `git diff` on Protocol 03 shows no change within the hotfix path,
+   and the four agent surfaces carry the same instruction as each other.
+
+9. **Update the orchestration and merge paths.** Protocol 90 Steps 3.6 and 5.1,
+   Protocol 91's two parallel-batch paragraphs, Protocol 94 Step 4.3 per
+   Decision 6, Protocol 05b Step 2.5, and the batch-merge command and skill
+   surfaces. In `batch-merge.sh`, add the clarifying sentence to the
+   `PR_HAS_CHANGELOG` header comment and the `changelog.d/` clause to the
+   hold-annotation text; change no logic.
+
+   *Verify*: `bash scripts/development-workflow/tests/test-batch-merge-changelog-race.sh`
+   and the other batch-merge suites pass unchanged, confirming no behavioural
+   change was introduced.
+
+10. **Update the review contract and remaining documentation.** `REVIEW.md`,
+    `LLM_RULES.md`, `.haystack/pr-rules.yml`, the `haystack-reviewer.sh`
+    comment block (including the corrected rule id),
+    `haystack-triage.md`, `AGENTS.md`, `README.md`, both best-practices files,
+    both script READMEs, the spec and plan protocols, the plan template, and
+    `docs/testing/workflow/batch-merge.smoke-test.md`.
+
+    *Verify*: `bash scripts/development-workflow/tests/test-haystack-reviewer.sh`
+    passes, and the rule id quoted in the script matches an id present in
+    `.haystack/pr-rules.yml`.
+
+11. **Ship the convention downstream.** Add the `changelog.d/README.md` entry to
+    `sync-manifest.yaml` under `always_sync` with `mode_scope: shared` and a
+    note recording that fragment files are intentionally unlisted.
+
+    *Verify*: `bash scripts/development-workflow/tests/test-sync-template-mode-scopes.sh`
+    passes, and reading the manifest confirms no `project_specific` entry was
+    added for `changelog.d/`.
+
+12. **Record this item's own release note the new way.** Create
+    `changelog.d/1554.changed.per-item-release-notes.md` containing exactly:
+
+    ```markdown
+    - **Per-item release notes replace the shared `[Unreleased]` block** (#1554):
+      each work item now records its release note in its own `changelog.d/` file,
+      so two items worked in parallel no longer edit the same lines and cannot
+      conflict. Release preparation gathers the pending notes into a draft
+      version section, which the releaser edits before publishing; the notes are
+      removed when the release merges.
+    ```
+
+    Do **not** add an entry to `CHANGELOG.md` — this PR is the change that ends
+    that practice, and doing both would produce the duplicate the transition
+    design exists to prevent.
+
+    *Verify*: `bash scripts/development-workflow/changelog-fragments.sh validate`
+    reports `VALIDATE_RESULT=clean` with the new fragment counted, and
+    `git diff --name-only origin/develop...HEAD` does not list `CHANGELOG.md`.
+
+13. **Run the residual verification** described in the next section and include
+    its table in the PR description.
+
+14. **Execute the smoke test runbook** at
+    `docs/testing/workflow/1554-changelog-fragments.smoke-test.md` and record
+    the results.
+
+---
+
+## Residual Verification Strategy
+
+This is a sweep with a pattern-completeness claim ("every surface that states
+the changelog convention is updated"), so the implementation must produce
+evidence rather than assert coverage.
+
+**Evidence source**: a re-run, at implementation time, of the repository-wide
+scan recorded in the Verification Log — a case-insensitive search for
+`changelog` across the repository, excluding `.git`, `node_modules`, worktree
+directories, `docs/specs/`, `hooks/node_modules`, and `CHANGELOG.md` itself.
+
+**Evidence form**: a table in the PR description with one row per file the scan
+returns, each classified as **changed**, **no change needed** with a one-line
+rationale, or **out of scope** with a rationale. Historical smoke-test runbooks
+for unrelated items and the published sections of `CHANGELOG.md` are expected to
+fall in the last two categories; every protocol, agent, command, skill, script,
+lint, workflow, and root-level document must fall in the first two.
+
+**Why a re-run rather than this plan's list**: `develop` moves during
+implementation, and a stale enumeration is exactly the failure this plan's own
+Verification Log exists to prevent. The scan is the authority; this plan's
+enumeration is the starting point.

--- a/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
+++ b/docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md
@@ -238,26 +238,64 @@ fragments violates the corrected clause.
     fragment into an already-published-looking section. `--repair-manifest`
     instead restores the manifest from the one source that reflects the set
     **as it was at assembly time**: git history. It walks the current
-    branch's log for `changelog.d/manifests/v<X.Y.Z>.txt` and, if a commit
-    wrote that exact path, restores that commit's blob verbatim (`git show
-    <commit>:<path>`) — not a rescan, a byte-for-byte restoration of what was
-    actually frozen. On success it reports `ASSEMBLE_RESULT=repaired`, exit 0.
-    If no commit ever wrote that path (the manifest was lost before the
-    releaser committed it), `--repair-manifest` **refuses to guess**: it
+    branch's log for `changelog.d/manifests/v<X.Y.Z>.txt` and selects the
+    **most recent** commit that wrote that exact path — the path can
+    legitimately be written more than once (an earlier `--repair-manifest`, or
+    an explicit `--reassemble`, both write it again), and the most recent
+    write is always the one that reflects the currently-authoritative content,
+    never an earlier one. If such a commit exists, it restores that commit's
+    blob verbatim (`git show <commit>:<path>`), through the same temp-file,
+    `fsync`, atomic-rename discipline as every other write in this plan — a
+    stop mid-restore therefore lands on the still-absent manifest (safe to
+    retry), never a half-written one, which is what keeps this recovery path
+    from reopening the "fifth, undetectable corrupt state" the atomic-rename
+    discipline exists to rule out. On success it reports
+    `ASSEMBLE_RESULT=repaired`, exit 0. Before concluding no commit exists,
+    `--repair-manifest` checks `git rev-parse --is-shallow-repository`: a
+    shallow clone truncates the log before it reaches a commit that exists but
+    is outside the fetched depth, which is a clone-configuration problem, not
+    a data-loss one. In that case it reports a distinct
+    `ASSEMBLE_RESULT=history_truncated`, exit 1, naming `git fetch
+    --unshallow` as the remediation, rather than `manifest_unrecoverable`,
+    which would wrongly imply the data itself is gone. Only on a full clone,
+    with no commit ever having written that path (the manifest was lost before
+    it was committed), does `--repair-manifest` **refuse to guess**: it
     reports `ASSEMBLE_RESULT=manifest_unrecoverable`, exit 1, and instructs
     the operator to reconcile by hand — compare the `## [X.Y.Z]` section's
     bullets against the fragment bodies still present in `changelog.d/` to
     reconstruct the original set, or, only as a knowing last resort whose risk
     the operator accepts explicitly, fall back to `assemble --reassemble` (see
-    below), which is never invoked automatically.
+    below), which is never invoked automatically. `--reassemble` recomputes
+    and writes the manifest and rewrites `CHANGELOG.md` in the identical
+    manifest-first, atomic-rename order as a normal `assemble`, so a stop
+    mid-`--reassemble` also lands on one of the named states above rather than
+    a sixth, undocumented one.
   - Manifest absent, heading absent: nothing has happened yet; `assemble` runs
     normally.
-- **Interrupted preparation resumes intact.** Both artifacts are ordinary
-  committed files on the release branch, so resuming is `git checkout` of that
-  branch followed by re-running `assemble`, which always lands on one of the
-  four states above instead of guessing. If the release branch is discarded
-  entirely, `develop` still holds every fragment, because nothing was ever
-  deleted there.
+- **Interrupted preparation resumes intact — because Protocol 05 commits
+  twice inside Step 3, not only once at Step 5.** "Both artifacts are
+  ordinary committed files on the release branch" is true only if something
+  commits them, and Protocol 05's existing single "Commit" step (Step 5) runs
+  *after* Step 3's assemble, editorial pass, link-reference definitions, and
+  `consume` have all already happened. Left at that, the manifest and the
+  editorial pass would sit uncommitted for the entire span this design exists
+  to protect, and `--repair-manifest`'s git-history restore would find
+  nothing to restore for the whole of that span. The Layer-by-Layer Changes
+  entry restructuring Protocol 05 Step 3 therefore adds two commits inside it,
+  both before Step 5's version-bump commit: one immediately after `assemble` succeeds
+  (before the editorial pass touches anything), and one after the editorial
+  pass and link-reference definitions, immediately before `consume` runs.
+  With those in place, resuming on the *same* working tree needs no git
+  operation at all — the temp+rename writes already persisted to disk — and
+  resuming on a *different* clone, or after the original working tree is
+  lost, is `git checkout` of the release branch followed by re-running
+  `assemble`, which lands on one of the four states above because the
+  manifest and the editorial pass are both already committed. If the release
+  branch is discarded entirely, `develop` still holds every fragment, because
+  nothing was ever deleted there — but the releaser's editorial pass is not
+  on `develop`, and is genuinely lost in that specific scenario; only a
+  discarded *working tree*, not a discarded *branch*, is protected by the two
+  intermediate commits.
 - **Consumption requires a publishable section, not just a manifest.** Before
   deleting anything, `consume` checks the manifest **and** the `## [X.Y.Z]`
   heading — the same two facts `assemble` checks, in the same order of
@@ -488,10 +526,15 @@ other workflow helpers, and every exit path prints its documented fields.
       `MANIFEST_PATH`, and `ITEMS`. `ASSEMBLE_RESULT` includes
       `assembled_unmanifested` for the manifest-absent, heading-present
       recovery state; `repaired` when `--repair-manifest` restores the
-      manifest from git history; `manifest_unrecoverable` when
-      `--repair-manifest` finds no committed manifest to restore; and
-      `locked` when the lock is already held. (Spec AC-3, AC-5, AC-7, AC-10;
-      Decisions 3 and 4)
+      manifest from the most recent commit that wrote it, via the same
+      atomic temp-file-and-rename write as every other write in this plan;
+      `history_truncated` when `--repair-manifest` is run against a shallow
+      clone whose fetched depth cannot rule out an existing-but-unreachable
+      commit; `manifest_unrecoverable` when `--repair-manifest` finds no
+      committed manifest to restore on a full clone; and `locked` when the
+      lock is already held. `--reassemble` follows the identical
+      manifest-first, atomic-rename write order as a normal assembly. (Spec
+      AC-3, AC-5, AC-7, AC-10; Decisions 3 and 4)
 - [ ] `consume --version <X.Y.Z>` — acquire the same per-release lock, require
       the `## [X.Y.Z]` heading to exist (else refuse — see below), delete the
       manifest-listed fragments one at a time (idempotent: a file already
@@ -505,8 +548,9 @@ other workflow helpers, and every exit path prints its documented fields.
 - [ ] Exit codes: `0` for `clean`, `assembled`, `already_assembled`,
       `reassembled`, `repaired`, `consumed`, `already_consumed`; `1` for a
       validation, assembly, `assembled_unmanifested`,
-      `manifest_unrecoverable`, `not_assembled`, `inconsistent`, or `locked`
-      error; `3` for `no_notes` without `--allow-empty`; `64` for a usage
+      `manifest_unrecoverable`, `history_truncated`, `not_assembled`,
+      `inconsistent`, or `locked` error; `3` for `no_notes` without
+      `--allow-empty`; `64` for a usage
       error, matching `check-documentation-stage-alignment.sh`.
 - [ ] Reporting on assembly names each contributing item, and reports bullets
       carried over from the shared block as a single unattributed group, per
@@ -590,14 +634,20 @@ Protocols:
       byte-for-byte unchanged. Rename both "CHANGELOG entry preview" PR-body
       bullets to "release note preview". (Spec AC-2, AC-11)
 - [ ] `docs/workflow/development-workflow/protocols/05-prepare-release-protocol.md`
-      — restructure Step 3 into: assemble the draft, editorial pass (today's
-      polish guidance retargeted at the assembled draft, unchanged in
-      substance), link-reference definitions (unchanged), consume the notes.
-      Extend Step 7.2's release-artifact validation with the two checks that
-      prove consumption ran: `changelog.d/manifests/consumed/v<X.Y.Z>.txt` is
-      present (not merely `changelog.d/manifests/v<X.Y.Z>.txt` absent — see
-      Decision 3) and `## [X.Y.Z] - YYYY-MM-DD` is present. (Spec AC-3, AC-4,
-      AC-5, AC-8)
+      — restructure Step 3 into: assemble the draft; **commit** (the manifest
+      and the rewritten `CHANGELOG.md`); editorial pass (today's polish
+      guidance retargeted at the assembled draft, unchanged in substance);
+      link-reference definitions (unchanged); **commit** (the editorial pass
+      and link-reference definitions); consume the notes. The two commits are
+      both new and both precede Step 5's existing version-bump commit — see
+      Decision 3's "Interrupted preparation resumes intact" bullet: without
+      them, neither artifact is a "committed file on the release branch" until
+      Step 5, and `--repair-manifest`'s git-history restore has no commit to
+      find for the entire span between assembly and Step 5. Extend Step 7.2's
+      release-artifact validation with the two checks that prove consumption
+      ran: `changelog.d/manifests/consumed/v<X.Y.Z>.txt` is present (not
+      merely `changelog.d/manifests/v<X.Y.Z>.txt` absent — see Decision 3) and
+      `## [X.Y.Z] - YYYY-MM-DD` is present. (Spec AC-3, AC-4, AC-5, AC-8)
 - [ ] `docs/workflow/development-workflow/protocols/05b-graduate-development-protocol.md`
       — extend Step 2.5 so the graduation PR is verified to carry the
       `changelog.d/` additions accumulated on `develop-<slug>`, alongside the
@@ -786,8 +836,10 @@ test in `scripts/development-workflow/tests/test-changelog-fragments.sh`.
 | 34 | `consume` when neither manifest location holds the target version but the `## [X.Y.Z]` version section is present | `CONSUME_RESULT=inconsistent`, exit 1 — no longer conflated with `already_consumed`; the operator must reconcile by hand |
 | 35 | `consume` when the manifest is present in `changelog.d/manifests/` but the `## [X.Y.Z]` heading is absent | `CONSUME_RESULT=not_assembled`, exit 1, deletes nothing — assembly never finished; remediation is to run `assemble` first |
 | 36 | `consume` when the heading is present, the manifest is present in `changelog.d/manifests/`, and some or all manifest-listed fragment files are already absent (a prior run stopped after deleting fragments but before moving the manifest) | Resume: finish deleting whatever remains (idempotent — an absent file is not an error), then move the manifest. `CONSUME_RESULT=consumed`, exit 0 |
-| 37 | `assemble --repair-manifest` when a commit on the current branch previously wrote `changelog.d/manifests/v<X.Y.Z>.txt` | Restore that commit's blob verbatim. `ASSEMBLE_RESULT=repaired`, exit 0 — the restored set is exactly what was frozen at the original assembly, never a live rescan |
-| 38 | `assemble --repair-manifest` when no commit on the current branch ever wrote the manifest for the target version | Refuse to guess. `ASSEMBLE_RESULT=manifest_unrecoverable`, exit 1, naming manual reconciliation (or an explicit, risk-accepted `--reassemble`) as the only remaining paths |
+| 37 | `assemble --repair-manifest` when a commit on the current branch previously wrote `changelog.d/manifests/v<X.Y.Z>.txt` | Restore that commit's blob verbatim, via the same atomic temp-file-and-rename write as every other write in this plan. `ASSEMBLE_RESULT=repaired`, exit 0 — the restored set is exactly what was frozen at the original assembly, never a live rescan |
+| 38 | `assemble --repair-manifest` when the path was written by more than one commit (for example, an earlier `--repair-manifest` or `--reassemble`) | Restore the **most recent** commit's blob — the one that reflects the currently-authoritative content, not an earlier one. `ASSEMBLE_RESULT=repaired`, exit 0 |
+| 39 | `assemble --repair-manifest` on a shallow clone, where no commit in the fetched history wrote the manifest but one may exist outside the fetched depth | `ASSEMBLE_RESULT=history_truncated`, exit 1, naming `git fetch --unshallow` as the remediation — distinct from `manifest_unrecoverable`, which asserts no such commit exists at all |
+| 40 | `assemble --repair-manifest` on a full (non-shallow) clone when no commit on the current branch ever wrote the manifest for the target version | Refuse to guess. `ASSEMBLE_RESULT=manifest_unrecoverable`, exit 1, naming manual reconciliation (or an explicit, risk-accepted `--reassemble`) as the only remaining paths |
 
 **Suppression semantics**: not applicable. `changelog-fragments.sh` recognizes
 no inline suppression directives. Declining to write a release note is
@@ -829,10 +881,36 @@ waits or retries silently. This is a bounded, single-checkout mitigation, the
 same known limitation `prepare-release-post-merge-cleanup.sh` documents for
 its own lock: it does not exclude a concurrent run from a different clone or
 worktree of the same release branch, and the plan does not claim otherwise.
+
+**Staleness — a gap the precedent script leaves open, which this plan does
+not repeat.** `prepare-release-post-merge-cleanup.sh`'s lock has no built-in
+staleness recovery at all: if its owning process is killed, the lock directory
+is empty (`mkdir` with no marker file inside it) and stays held forever, with
+no documented way for an operator to tell "still running" apart from "leaked."
+Copying that as-is would mean this plan's own troubleshooting guidance — "wait
+for it to finish, or confirm it is stale and remove the lock directory" —
+gives the operator no actual mechanism to confirm staleness, which risks the
+operator guessing wrong and `rmdir`-ing a lock a still-running invocation
+holds, recreating the exact interleaving the lock exists to prevent. This plan
+closes that gap: at acquisition, `assemble`/`consume` write a single file
+inside the lock directory, `owner` (PID, hostname, and UTC start timestamp, one
+per line — no atomicity requirement on this file, since it exists only after
+the `mkdir` that already committed the lock). When `mkdir` fails, the reported
+remediation reads that file and instructs the operator to check
+`ps -p <pid>` (or the equivalent on the owner's host, if different from the
+current one) before removing the lock directory — remove it only when the
+recorded PID is confirmed not running on the recorded host. This is still a
+manual, human-in-the-loop judgment (there is no cross-host liveness protocol),
+so a wrong manual judgment remains possible; it is a strict improvement over
+"confirm it is stale" with no data to confirm it against, not a hard
+guarantee.
+
 The test suite (Implementation Order Step 2) adds one interleaving case per
 command: start a run, hold its lock open, start a second run of the same
 command against the same version, and assert the second run reports `locked`
-and makes no write.
+and makes no write; and one stale-lock case: create a lock directory with an
+`owner` file naming a PID that is not running, and assert the reported
+remediation names that file rather than only the lock directory path.
 
 ---
 
@@ -851,8 +929,9 @@ readiness check.
 | Manifest for the target version present; `## [X.Y.Z]` heading also present | `already_assembled` | No write; continue. This is the resume path and the idempotence guarantee — both artifacts, not the heading alone (Decision 3) | Same |
 | Manifest for the target version present; `## [X.Y.Z]` heading absent | `assembled` | Interrupted between the two writes. Perform the `CHANGELOG.md` write (temp file, `fsync`, atomic rename) from the already-frozen manifest, never a rescan; continue to the editorial pass | Same |
 | Manifest for the target version absent; `## [X.Y.Z]` heading present | `assembled_unmanifested` (exit 1) | Stop; run `assemble --repair-manifest` to restore the manifest from git history — never a directory rescan (a live rescan can pull in a fragment added since the original assembly) | Protocol 05 Step 3 |
-| `--repair-manifest` passed; a commit on the branch previously wrote the manifest for this version | `repaired` | The manifest is restored verbatim from that commit; continue to `already_assembled` on the next run | Same |
-| `--repair-manifest` passed; no commit on the branch ever wrote the manifest for this version | `manifest_unrecoverable` (exit 1) | Stop; reconcile by hand (compare the published section's bullets against fragments still in `changelog.d/`), or explicitly accept the risk of `--reassemble` | Protocol 05 Step 7.2 |
+| `--repair-manifest` passed; a commit on the branch previously wrote the manifest for this version (the most recent such commit, if more than one) | `repaired` | The manifest is restored verbatim from that commit, via the same atomic temp-file-and-rename write as every other write in this plan; continue to `already_assembled` on the next run | Same |
+| `--repair-manifest` passed; the clone is shallow and cannot rule out a commit outside the fetched depth | `history_truncated` (exit 1) | Stop; run `git fetch --unshallow`, then retry `--repair-manifest` — this is a clone-configuration gap, not evidence the manifest is unrecoverable | Protocol 05 Step 7.2 |
+| `--repair-manifest` passed; the clone is not shallow and no commit on the branch ever wrote the manifest for this version | `manifest_unrecoverable` (exit 1) | Stop; reconcile by hand (compare the published section's bullets against fragments still in `changelog.d/`), or explicitly accept the risk of `--reassemble` | Protocol 05 Step 7.2 |
 | `--reassemble` passed and the heading is present | `reassembled` | Print the replaced section first; the releaser must redo any editorial pass. Not invoked automatically by any recovery path | Same |
 | No pending fragment and an empty shared block | `no_notes` (exit 3) | Stop; either there is nothing to release or a fragment was lost. Pass `--allow-empty` only for a deliberate no-notes release | Same |
 | Any fragment fails the grammar or body checks | `invalid` (exit 1) | Fix the named fragment on `develop` and re-run; never assemble a partial set | Protocol 05; `.github/workflows/markdown-lint.yml` |
@@ -1015,8 +1094,11 @@ changelog.d/1589.fixed.integration-branch-ci.md
    fresh empty `## [Unreleased]`, deterministic ordering; all four assembly
    states from Decision 3 (`assembled`, `already_assembled`, the
    manifest-present/heading-absent resume, and `assembled_unmanifested`);
-   `--repair-manifest` (git-history restore, `repaired` or
-   `manifest_unrecoverable`, never a directory rescan); and `no_notes`.
+   `--repair-manifest` (git-history restore of the most recent writing
+   commit, itself written atomically; `repaired`, `history_truncated` on a
+   shallow clone, or `manifest_unrecoverable` on a full clone, never a
+   directory rescan); `--reassemble` (identical manifest-first, atomic-rename
+   write order as normal assembly); and `no_notes`.
 
    *Verify*: the changelog-rewriting cases pass, and the suite's assembled
    fixtures are checked with `check-changelog-duplicate-headers.sh` and
@@ -1053,11 +1135,22 @@ changelog.d/1589.fixed.integration-branch-ci.md
 
 7. **Update the release path.** Protocol 05 Step 3 (assemble, editorial pass,
    link definitions, consume) and Step 7.2's artifact validation, then the three
-   prepare-release command and skill surfaces.
+   prepare-release command and skill surfaces. **Add two commits inside the
+   restructured Step 3, both before Step 5's existing version-bump commit**:
+   one immediately after `assemble` succeeds (before the editorial pass touches
+   anything) and one immediately after the editorial pass and link-reference
+   definitions, before `consume` runs. Without these, the manifest and the
+   editorial pass sit uncommitted for the whole span Decision 3's recovery
+   design protects, and `--repair-manifest`'s git-history restore has nothing
+   to restore from until Step 5 — see Decision 3's "Interrupted preparation
+   resumes intact" bullet, which this step implements.
 
    *Verify*: read Step 3 end to end and confirm a releaser can execute it
-   without consulting this plan, and that the editorial pass still appears
-   between assembly and consumption.
+   without consulting this plan, that the editorial pass still appears
+   between assembly and consumption, and that the two new commit points are
+   both present and both precede Step 5. Confirm by inspection that a
+   `--repair-manifest` run immediately after the first of the two commits
+   (i.e. before the editorial pass) would find that commit in `git log`.
 
 8. **Update the implementation path.** Protocol 03 Paths 1–3, leaving Path 4
    untouched; then `.claude/agents/developer.md`,

--- a/docs/testing/workflow/1554-changelog-fragments.smoke-test.md
+++ b/docs/testing/workflow/1554-changelog-fragments.smoke-test.md
@@ -29,11 +29,13 @@ repository root.
 | Item | Value |
 | --- | --- |
 | Fragment directory | `changelog.d/` |
-| Manifest directory (assembled, not yet published) | `changelog.d/manifests/` |
-| Manifest archive (published/consumed) | `changelog.d/manifests/consumed/` |
 | Helper | `scripts/development-workflow/changelog-fragments.sh` |
 | Rehearsal version | `9.9.9` (never released; used only for this runbook) |
 | Scratch item identifiers | `9001`, `9002`, `9003` |
+
+There is no manifest directory: `assemble` writes `CHANGELOG.md` and deletes
+the fragments it gathered in the same invocation, so there is no second
+artifact for this runbook to inspect.
 
 ---
 
@@ -74,12 +76,12 @@ than Step 0's, and the only changed path is the new fragment.
 
 1. From a scratch clone or worktree, create a local `base` branch from the
    branch under test: `git checkout -b base`.
-2. From `base`, create two branches: `git checkout -b item-a base` and
-   `git checkout -b item-b base`.
+2. From `base`, create `item-a` and switch to it: `git checkout -b item-a base`.
 3. On `item-a`, add `changelog.d/9002.added.smoke-beta.md`; commit.
-4. On `item-b`, add `changelog.d/9003.fixed.smoke-gamma.md`; commit.
-5. Check out `base` and merge `item-a` into it (`git merge item-a`).
-6. Merge `item-b` into `base` (`git merge item-b`).
+4. From `base`, create `item-b` and switch to it: `git checkout -b item-b base`.
+5. On `item-b`, add `changelog.d/9003.fixed.smoke-gamma.md`; commit.
+6. Check out `base` and merge `item-a` into it (`git merge item-a`).
+7. Merge `item-b` into `base` (`git merge item-b`).
 
 **Expected result**: neither merge reports a conflict, no manual resolution is
 performed, and after both merges `base` contains both fragment files with
@@ -100,28 +102,30 @@ scratch clone) once this step is done — they are not reused by later steps.
 each names the offending path and the reason — an unrecognized kind in the first
 case, a non-bullet body in the second.
 
-### Step 4: Assemble the draft
+### Step 4: Assemble the draft — and its fragments are gone in the same step
 
-**Maps to**: Acceptance Criteria 3 and 10
+**Maps to**: Acceptance Criteria 3, 7, and 10
 
 1. Create and check out a scratch branch **from the branch under test** (so it
    carries the `9001.fixed.smoke-alpha.md` fragment from Step 1 and any
    fragments the real implementation already added):
    `git checkout -b smoke-test/1554-release-rehearsal`. Steps 4 through 7 all
    run on this branch; the "Last Step" discards it.
-2. Run
+2. Record, by name, every fragment `list` currently reports as pending.
+3. Run
    `bash scripts/development-workflow/changelog-fragments.sh assemble --version 9.9.9`.
-3. Read the reported `FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`, and `ITEMS`.
-4. Open `CHANGELOG.md` and read the new `## [9.9.9]` section.
-5. Open `changelog.d/manifests/v9.9.9.txt`.
-6. Run `git status --short` on `changelog.d/`.
+4. Read the reported `FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`, and `ITEMS`.
+5. Open `CHANGELOG.md` and read the new `## [9.9.9]` section.
+6. Run `git status --short` on `changelog.d/`, and confirm against the list
+   from step 2.
 
 **Expected result**: `ASSEMBLE_RESULT=assembled`. The version section groups
 entries by kind and contains both every pending fragment's bullet and every
 bullet that was previously in `## [Unreleased]`, each appearing once. A fresh,
-empty `## [Unreleased]` heading sits above it. The manifest names exactly the
-fragments that contributed. **No fragment file has been deleted or modified** —
-this is the check that assembly destroys nothing.
+empty `## [Unreleased]` heading sits above it. **Every fragment recorded in
+step 2 is now gone from `changelog.d/`** — assembly deletes the fragments it
+gathers in the same operation that writes the section (Decision 3); this is
+the check that the two are inseparable, not that nothing was touched.
 
 ### Step 5: Assembly is repeatable
 
@@ -133,28 +137,27 @@ this is the check that assembly destroys nothing.
 
 **Expected result**: `ASSEMBLE_RESULT=already_assembled`, exit 0, and
 `CHANGELOG.md` is byte-identical to before the second run. No entry is
-duplicated.
+duplicated. There is nothing left in `changelog.d/` for this version to
+delete, so the second run's residual-interruption sweep (Step 4's design,
+Decision 3) is a no-op.
 
-### Step 6: The releaser's edits survive, and a late note waits for the next release
+### Step 6: The releaser's edits survive an interruption, and a late note waits for the next release
 
-**Maps to**: Acceptance Criteria 4, 5, and 6
+**Maps to**: Acceptance Criteria 4, 5, 6, and 8
 
 1. Edit the `## [9.9.9]` section by hand: merge two bullets and shorten a third,
    the way the release editorial pass does.
 2. Add the `[9.9.9]` link-reference definition at the bottom of `CHANGELOG.md`
-   and update the `[Unreleased]` definition, following Protocol 05 — this is
-   Protocol 05 Step 3's "link-reference definitions" sub-step, which happens
-   before `consume`, not after (Step 7 below only verifies it).
-3. Commit the assembled draft, the manifest, the editorial edit, and the
-   link-reference definitions on the scratch branch — this is what a real
-   release branch looks like at this point in Protocol 05 Step 3, and it is
-   what makes the next step a genuine resumption test rather than a
-   dirty-working-tree no-op. (The restructured Protocol 05 Step 3 actually
-   commits **twice** before `consume` — once right after `assemble`, once
-   here, after the editorial pass — so that `--repair-manifest` always has a
-   commit to restore from; this rehearsal folds both into the one commit
-   below, since the property being tested is "was anything committed before
-   the interruption," not the exact commit count.)
+   and update the `[Unreleased]` definition, following Protocol 05 Step 3's
+   link-reference sub-step.
+3. Commit `CHANGELOG.md` on the scratch branch — this is what a real release
+   branch looks like just before Protocol 05's Step 5 commit, and it is what
+   makes the next step a genuine resumption test rather than a
+   dirty-working-tree no-op. (In the real protocol this is the *only* commit
+   in the whole sequence — Step 5, unmodified. This rehearsal commits early
+   purely to simulate the interruption in step 4 below; a real release
+   preparation would still be sitting uncommitted at this point, exactly like
+   today's editorial pass, and that is fine — see Known Limitations.)
 4. Simulate an interruption: switch to another branch and back. `git status`
    is genuinely clean before this switch, because step 3 already committed
    everything on this branch and nothing has touched the working tree since.
@@ -165,40 +168,24 @@ duplicated.
    uncommitted and untracked — it represents a note added to the release
    branch, e.g. via a late cherry-pick, after assembly already ran).
 7. Run `assemble --version 9.9.9` a third time.
-8. Read `CHANGELOG.md` and `changelog.d/`.
+8. Run `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
+   to verify the `[9.9.9]` and `[Unreleased]` link-reference definitions added
+   in step 2 are both well-formed.
+9. Read `CHANGELOG.md` and `changelog.d/`.
 
 **Expected result**: step 5's post-interruption run reports `already_assembled`
 without rewriting anything, and the hand edits (including the link-reference
 definitions from step 2) are intact — verifiable because they are part of the
 committed history, not just the working tree, so nothing was lost by the
 interruption. Step 6's third run (item 7 above) also reports
-`already_assembled` (the manifest still matches the committed set); the late
-fragment from item 6 above is present in `changelog.d/` but absent from both
-the `## [9.9.9]` section and the manifest.
+`already_assembled`; the late fragment from item 6 above is present in
+`changelog.d/` but absent from both the `## [9.9.9]` section and — because it
+was never gathered — was never a candidate for deletion by the
+residual-interruption sweep either. The duplicate-header and link-reference
+checks (item 8) both pass (the one script performs both), so the changelog is
+ready to accumulate the next release's notes and its version links resolve.
 
-### Step 7: Publish consumes the notes
-
-**Maps to**: Acceptance Criteria 5, 7, and 8
-
-1. Run `bash scripts/development-workflow/changelog-fragments.sh consume --version 9.9.9`.
-2. List `changelog.d/`, `changelog.d/manifests/`, and
-   `changelog.d/manifests/consumed/`.
-3. Run `consume --version 9.9.9` a second time.
-4. Run `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
-   to verify the `[9.9.9]` and `[Unreleased]` link-reference definitions added
-   in Step 6 are both well-formed.
-
-**Expected result**: `CONSUME_RESULT=consumed` with a removed count matching the
-manifest. Every manifest-listed fragment is gone; `changelog.d/manifests/` no
-longer has a `v9.9.9.txt` entry, but `changelog.d/manifests/consumed/v9.9.9.txt`
-now exists (moved, not deleted — Decision 3's durable "already consumed"
-record). The late fragment from Step 6 remains. The second run reports
-`already_consumed` and exits 0, confirmed by the file's presence under
-`consumed/`. The duplicate-header and link-reference checks both pass (the one
-script performs both), so the changelog is ready to accumulate the next
-release's notes and its version links resolve.
-
-### Step 8: The published section passes the repository's document checks
+### Step 7: The published section passes the repository's document checks
 
 **Maps to**: Acceptance Criterion 9
 
@@ -222,7 +209,7 @@ release's notes and its version links resolve.
 
 **Expected result**: all three exit 0 with no violations reported.
 
-### Step 9: Published history is untouched
+### Step 8: Published history is untouched
 
 **Maps to**: Acceptance Criterion 13
 
@@ -234,21 +221,25 @@ heading, the new `## [9.9.9]` section, and the link-reference definitions. No
 line inside any previously published version section is added, removed, or
 altered.
 
-### Step 10: Hotfixes are unaffected
+### Step 9: Hotfixes are unaffected
 
 **Maps to**: Acceptance Criterion 11
 
-1. Follow Protocol 03 Path 4's changelog step on a scratch branch: write a new
-   versioned section directly below `## [Unreleased]`.
+1. Create and check out a separate, throwaway scratch branch — not
+   `smoke-test/1554-release-rehearsal` — and follow Protocol 03 Path 4's
+   changelog step on it: write a new versioned section directly below
+   `## [Unreleased]`.
 2. Run `bash scripts/development-workflow/changelog-fragments.sh list`.
 3. Read Protocol 03 Path 4 and confirm no step instructs the author to write a
    fragment.
+4. Discard this branch (`git checkout <branch under test> && git branch -D
+   <the throwaway branch>`); its changes are not needed by any later step.
 
 **Expected result**: the hotfix section is written directly into `CHANGELOG.md`,
 the pending-note list is unchanged by it, and the hotfix path's instructions are
 identical to the pre-change version.
 
-### Step 11: Readiness accepts a fragment
+### Step 10: Readiness accepts a fragment
 
 **Maps to**: Acceptance Criterion 2
 
@@ -266,7 +257,7 @@ identical to the pre-change version.
 **Expected result**: the query returns `true`, so the PR satisfies the
 release-note readiness check without having edited the shared changelog.
 
-### Step 12: A fresh consumer needs no setup
+### Step 11: A fresh consumer needs no setup
 
 **Maps to**: Acceptance Criterion 12
 
@@ -283,18 +274,35 @@ configuration, no directory creation, and no manifest edit.
 
 ### Last Step: Restore the working tree
 
-1. Check out the branch under test, then delete the scratch branch
+1. Commit or discard any remaining uncommitted change on the rehearsal branch
+   (Step 6 leaves the late fragment `changelog.d/9002.changed.smoke-late.md`
+   untracked): switch to `smoke-test/1554-release-rehearsal`, run
+   `git status --short`, and resolve anything it reports before the next
+   step, so the branch switch below cannot be refused or carry rehearsal
+   state forward. (Step 9 uses its own separate scratch branch for the
+   hotfix scenario and is unaffected by this step.)
+2. Check out the branch under test, then delete the scratch branch
    (`git branch -D smoke-test/1554-release-rehearsal`) — this removes the
    scratch branch's own committed history, including the rehearsal
-   `## [9.9.9]` section. Branch deletion does not remove untracked files, so
-   also run `git clean -fdx -- 'changelog.d/9001.*' 'changelog.d/9002.*'
-   'changelog.d/9003.*' 'changelog.d/manifests'` (or remove those paths by
-   hand) from the branch under test, to catch the Step 6 late fragment (added
-   uncommitted on the scratch branch, and therefore still present as an
-   untracked file after the branch switch) along with Steps 1 and 3's
-   fragments and the rehearsal manifest directory.
-2. Run `git status` and confirm the working tree matches the branch under test.
-3. Run `bash scripts/development-workflow/changelog-fragments.sh list` and
+   `## [9.9.9]` section.
+3. Branch deletion does not remove untracked files. From the branch under
+   test, remove exactly the rehearsal artifacts by name — never a directory
+   glob, which could delete files this runbook did not create:
+
+   ```bash
+   rm -f changelog.d/9001.fixed.smoke-alpha.md \
+         changelog.d/9001.improved.smoke-bad.md \
+         changelog.d/9001.fixed.smoke-bad.md \
+         changelog.d/9002.added.smoke-beta.md \
+         changelog.d/9002.changed.smoke-late.md \
+         changelog.d/9003.fixed.smoke-gamma.md
+   ```
+
+   Before running it, run `git status --short -- 'changelog.d/900*'` and
+   confirm every path it lists is one of the six above — if anything else
+   appears, stop and remove files by hand instead of running the command.
+4. Run `git status` and confirm the working tree matches the branch under test.
+5. Run `bash scripts/development-workflow/changelog-fragments.sh list` and
    confirm the pending count matches Step 0's recording.
 
 ---
@@ -308,18 +316,18 @@ each one without restating its full text, to avoid the two documents drifting
 apart.
 
 - [ ] AC-1 — no merge conflict, both notes survive (Step 2)
-- [ ] AC-2 — readiness passes on a fragment alone (Steps 1 and 11)
+- [ ] AC-2 — readiness passes on a fragment alone (Steps 1 and 10)
 - [ ] AC-3 — assembly gathers every pending note, grouped by kind (Step 4)
-- [ ] AC-4 — editorial edits survive to publication (Steps 6 and 7)
+- [ ] AC-4 — editorial edits survive to publication (Step 6)
 - [ ] AC-5 — interrupted-then-resumed preparation loses nothing (Step 6)
 - [ ] AC-6 — a post-assembly note waits for the next release (Step 6)
-- [ ] AC-7 — no duplicate entries after a repeat assembly (Steps 5 and 7)
-- [ ] AC-8 — changelog and version links are ready for the next release (Step 7)
-- [ ] AC-9 — the published section passes existing document checks (Steps 3 and 8)
+- [ ] AC-7 — no duplicate entries after a repeat assembly (Steps 4 and 5)
+- [ ] AC-8 — changelog and version links are ready for the next release (Step 6)
+- [ ] AC-9 — the published section passes existing document checks (Steps 3 and 7)
 - [ ] AC-10 — transition release merges shared-block and per-item notes once each (Step 4)
-- [ ] AC-11 — the hotfix path is unaffected (Step 10)
-- [ ] AC-12 — a fresh consumer needs no setup (Step 12)
-- [ ] AC-13 — published history is unchanged (Step 9)
+- [ ] AC-11 — the hotfix path is unaffected (Step 9)
+- [ ] AC-12 — a fresh consumer needs no setup (Step 11)
+- [ ] AC-13 — published history is unchanged (Step 8)
 
 ---
 
@@ -331,7 +339,7 @@ The following seed data must be present:
 | --- | --- | --- |
 | Scratch fragments `9001`, `9002`, `9003` | Valid notes across several kinds, plus two deliberately malformed ones | Created by hand in Steps 1, 2, 3, and 6 |
 | Populated shared block | The transition-release case | Present on `develop` until the first release after this change merges; recreate by hand in a scratch branch afterwards |
-| Rehearsal version `9.9.9` | Assembly and consumption without touching a real release | Passed with `--version` in Steps 4 through 7 |
+| Rehearsal version `9.9.9` | Assembly without touching a real release | Passed with `--version` in Steps 4 through 6 |
 
 ---
 
@@ -339,16 +347,10 @@ The following seed data must be present:
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
-| `VALIDATE_RESULT=invalid` naming a file you did not create | A stray non-markdown file or a leftover rehearsal fragment in `changelog.d/` | Remove it; only fragments, `README.md`, and the manifests directory belong there |
+| `VALIDATE_RESULT=invalid` naming a file you did not create | A stray non-markdown file or a leftover rehearsal fragment in `changelog.d/` | Remove it; only fragments and `README.md` belong at the top level of `changelog.d/` |
 | `ASSEMBLE_RESULT=already_assembled` when you expected a fresh draft | The version section already exists from an earlier run | Intended behaviour. Use `--reassemble` only if you accept losing the editorial pass on that section |
-| `ASSEMBLE_RESULT=no_notes` | Nothing is pending and the shared block is empty | Confirm the notes were not consumed by an earlier release before reaching for `--allow-empty` |
-| `CONSUME_RESULT=manifest_missing` | `consume` ran before `assemble`, or on the wrong branch | Run `assemble` first, and confirm you are on the release branch |
-| `ASSEMBLE_RESULT=assembled_unmanifested` | Assembly completed (the manifest is written before `CHANGELOG.md` — Decision 3), but the manifest was subsequently lost by something other than `consume` (a manual delete, a bad merge, a corrupted checkout) | Run `assemble --repair-manifest` — restores the manifest from git history. **Never** re-run `--reassemble` as the default fix: it rescans the live directory and can pull in a fragment added since the original assembly, violating "a note recorded after assembly waits for the next release" |
-| `ASSEMBLE_RESULT=manifest_unrecoverable` | `--repair-manifest` ran on a full (non-shallow) clone and found no commit on this branch that ever wrote the manifest for this version | Reconcile by hand: compare the `## [X.Y.Z]` section's bullets against fragment bodies still in `changelog.d/`. Only fall back to `--reassemble` if you have manually confirmed no fragment has landed since the original assembly |
-| `ASSEMBLE_RESULT=history_truncated` | `--repair-manifest` ran on a **shallow** clone (`git rev-parse --is-shallow-repository` is true), so it cannot rule out a commit that exists outside the fetched depth | Run `git fetch --unshallow`, then re-run `assemble --repair-manifest`. Do not treat this as `manifest_unrecoverable` — the data may still exist, only the clone is incomplete |
-| `CONSUME_RESULT=not_assembled` | `consume` was run before `assemble` finished writing the `## [X.Y.Z]` section — the manifest exists but the heading does not | Nothing was deleted. Run `assemble` first (it resumes safely from the frozen manifest), then `consume` |
-| `CONSUME_RESULT=inconsistent` | Neither `changelog.d/manifests/v<X.Y.Z>.txt` nor `changelog.d/manifests/consumed/v<X.Y.Z>.txt` exists, but the `## [X.Y.Z]` heading is present | Stop and reconcile by hand; do not assume this means already-published |
-| `ASSEMBLE_RESULT=locked` / `CONSUME_RESULT=locked` | Another `assemble`/`consume` invocation for the same version is already running, **or** a prior invocation was killed and left its lock directory behind | Read the `owner` file inside the reported lock directory (PID, hostname, start time). If that PID is running on that host, wait for it to finish. If it is not, the lock is stale — remove the lock directory only after confirming this; guessing wrong recreates the interleaving the lock exists to prevent |
+| `ASSEMBLE_RESULT=no_notes` | Nothing is pending and the shared block is empty | Confirm the notes were not already assembled by an earlier release before reaching for `--allow-empty` |
+| A fragment you expected `assemble` to gather is still present in `changelog.d/` after a run that reported `assembled` | It arrived after that run started (a late cherry-pick or a fresh scan started before the fragment landed) | Correct behaviour, not a bug — Decision 3 requires a note recorded after assembly to wait for the next release. Run `assemble --reassemble` only if you deliberately want to redo the section and include it now |
 | A `changelog.d/` path appears in a merge conflict | Two branches used the same item identifier | Treat as non-trivial per Protocol 94; find out which branch is misnamed rather than combining the files |
 | Duplicate `### Category` headings after assembly | A defect in the per-kind merge | Report against this feature; `check-changelog-duplicate-headers.sh` is the detector |
 
@@ -356,12 +358,28 @@ The following seed data must be present:
 
 ## Known Limitations
 
-- Steps 4 through 7 rehearse a release using version `9.9.9` rather than cutting
-  a real one. A genuine release additionally opens the production and backport
-  PRs, which this runbook does not exercise; Protocol 05's own steps cover that.
-- Step 12's downstream check inspects a fresh clone of this repository. Verifying
-  a real consumer project requires a sync-template run in that project, which is
-  outside this runbook's scope.
+- Steps 4 through 6 rehearse a release using version `9.9.9` rather than
+  cutting a real one. A genuine release additionally opens the production and
+  backport PRs, which this runbook does not exercise; Protocol 05's own steps
+  cover that.
+- Step 6 commits the assembled draft and the editorial pass on the scratch
+  branch before simulating the interruption, so the interruption-and-resume
+  behaviour this runbook exercises is "resume on a different clone or after
+  the local working tree is lost." A real release preparation more often sits
+  uncommitted through the whole of Protocol 05's existing Step 3 — exactly
+  like today's manual editorial pass already does — and resumes simply by
+  returning to the same working tree, with no git operation involved at all.
+  Both cases are covered by the design (Decision 3); this runbook exercises
+  the git-level one because it is the one that needs a "does it actually
+  work" check, not the trivial one.
+- The one narrow interruption window Decision 3 still names — a process
+  killed after the `CHANGELOG.md` write but before every fed fragment is
+  deleted — is exercised by the implementation's automated test suite
+  (edge cases 30–31), not by this runbook: reliably killing a process
+  mid-loop is not something a manual runbook can script.
+- Step 11's downstream check inspects a fresh clone of this repository.
+  Verifying a real consumer project requires a sync-template run in that
+  project, which is outside this runbook's scope.
 - The transition-release case (Step 4 with a populated shared block) can be
   exercised faithfully only once against real data. Afterwards it must be
   reproduced with a hand-built fixture, which is why the implementation's test

--- a/docs/testing/workflow/1554-changelog-fragments.smoke-test.md
+++ b/docs/testing/workflow/1554-changelog-fragments.smoke-test.md
@@ -110,22 +110,45 @@ case, a non-bullet body in the second.
    carries the `9001.fixed.smoke-alpha.md` fragment from Step 1 and any
    fragments the real implementation already added):
    `git checkout -b smoke-test/1554-release-rehearsal`. Steps 4 through 7 all
-   run on this branch; the "Last Step" discards it.
-2. Record, by name, every fragment `list` currently reports as pending.
-3. Run
+   run on this branch; the "Last Step" discards it. Capture the pre-assembly
+   commit for Step 8's independent verification:
+
+   ```bash
+   BASE_COMMIT="$(git rev-parse HEAD)"
+   ```
+
+2. **Confirm the transition scenario (AC-10) has something to carry over
+   before proceeding** — open `CHANGELOG.md` and count the bullets under
+   `## [Unreleased]`. This step exists to exercise carrying over the shared
+   block alongside per-item fragments; a `develop` where that block is
+   already empty (expected *after* this feature's own transition release
+   has merged) would let step 5 below pass without testing AC-10 at all. If
+   the count is zero, add one synthetic bullet by hand before continuing —
+   for example, under a `### Fixed` heading (create it if absent):
+   `- Smoke-test carry-over fixture bullet.` This is scratch-branch-only and
+   discarded with the rest of the rehearsal in the "Last Step"; it is never
+   committed to the branch under test.
+3. Record, by name, every fragment `list` currently reports as pending, and
+   record the shared-block bullet count from step 2 (including the fixture
+   bullet if you added one).
+4. Run
    `bash scripts/development-workflow/changelog-fragments.sh assemble --version 9.9.9`.
-4. Read the reported `FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`, and `ITEMS`.
-5. Open `CHANGELOG.md` and read the new `## [9.9.9]` section.
-6. Run `git status --short` on `changelog.d/`, and confirm against the list
-   from step 2.
+5. Read the reported `FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`, and `ITEMS`, and
+   confirm `CARRIED_OVER_COUNT` matches the count from step 3 — not zero.
+6. Open `CHANGELOG.md` and read the new `## [9.9.9]` section.
+7. Run `git status --short` on `changelog.d/`, and confirm against the list
+   from step 3.
 
 **Expected result**: `ASSEMBLE_RESULT=assembled`. The version section groups
 entries by kind and contains both every pending fragment's bullet and every
-bullet that was previously in `## [Unreleased]`, each appearing once. A fresh,
-empty `## [Unreleased]` heading sits above it. **Every fragment recorded in
-step 2 is now gone from `changelog.d/`** — assembly deletes the fragments it
-gathers in the same operation that writes the section (Decision 3); this is
-the check that the two are inseparable, not that nothing was touched.
+bullet that was previously in `## [Unreleased]` (including the fixture bullet
+from step 2 if one was needed), each appearing once. `CARRIED_OVER_COUNT` is
+never zero, so this step provably exercised the carry-over behavior rather
+than silently skipping it. A fresh, empty `## [Unreleased]` heading sits
+above the new section. **Every fragment recorded in step 3 is now gone from
+`changelog.d/`** — assembly deletes the fragments it gathers in the same
+operation that writes the section (Decision 3); this is the check that the
+two are inseparable, not that nothing was touched.
 
 ### Step 5: Assembly is repeatable
 
@@ -137,9 +160,9 @@ the check that the two are inseparable, not that nothing was touched.
 
 **Expected result**: `ASSEMBLE_RESULT=already_assembled`, exit 0, and
 `CHANGELOG.md` is byte-identical to before the second run. No entry is
-duplicated. There is nothing left in `changelog.d/` for this version to
-delete, so the second run's residual-interruption sweep (Step 4's design,
-Decision 3) is a no-op.
+duplicated, and `changelog.d/` is not scanned at all on this run — the
+idempotence check is decided purely from the `## [9.9.9]` heading already
+being present (Decision 3).
 
 ### Step 6: The releaser's edits survive an interruption, and a late note waits for the next release
 
@@ -185,9 +208,9 @@ definitions from step 2) are intact — verifiable because they are part of the
 committed history, not just the working tree, so nothing was lost by the
 interruption. Step 6's third run (item 7 above) also reports
 `already_assembled`; the late fragment from item 6 above is present in
-`changelog.d/` but absent from both the `## [9.9.9]` section and — because it
-was never gathered — was never a candidate for deletion by the
-residual-interruption sweep either. The duplicate-header and link-reference
+`changelog.d/` but absent from both the `## [9.9.9]` section — because
+`already_assembled` never scans `changelog.d/` at all (Decision 3), it was
+never a candidate for deletion in the first place. The duplicate-header and link-reference
 checks (item 8) both pass (the one script performs both), so the changelog is
 ready to accumulate the next release's notes and its version links resolve.
 
@@ -219,7 +242,12 @@ ready to accumulate the next release's notes and its version links resolve.
 
 **Maps to**: Acceptance Criterion 13
 
-1. Run `git diff` on `CHANGELOG.md` against the pre-assembly commit.
+1. Using the `BASE_COMMIT` captured in Step 4, run:
+
+   ```bash
+   git diff "$BASE_COMMIT" -- CHANGELOG.md
+   ```
+
 2. Read the diff hunks.
 
 **Expected result**: every change is confined to the new `## [Unreleased]`
@@ -239,9 +267,21 @@ altered.
 3. Read Protocol 03 Path 4 and confirm no step instructs the author to write a
    fragment.
 4. **Before switching away**, discard the uncommitted hotfix edit on this
-   branch — its content is not needed by any later step: run
-   `git checkout -- CHANGELOG.md`, then `git status --porcelain` and confirm
-   it prints nothing.
+   branch — its content is not needed by any later step. `git checkout --
+   CHANGELOG.md` discards *every* tracked change in that file, not only the
+   hotfix edit, so confirm the hotfix edit is the only tracked change before
+   running it:
+
+   ```bash
+   changed="$(git diff --name-only)"
+   [ "$changed" = "CHANGELOG.md" ] || {
+     printf 'Refusing to discard unexpected tracked changes:\n%s\n' "$changed" >&2
+     exit 1
+   }
+   git checkout -- CHANGELOG.md
+   ```
+
+   Then run `git status --porcelain` and confirm it prints nothing.
 5. Now switch and discard the branch itself:
    `git checkout <branch under test> && git branch -D <the throwaway branch>`.
 
@@ -275,7 +315,11 @@ release-note readiness check without having edited the shared changelog.
    that has synced the template.
 2. Confirm `changelog.d/README.md` and
    `scripts/development-workflow/changelog-fragments.sh` are present.
-3. Create a fragment following only the README's instructions and run `validate`.
+3. Create a fragment following only the README's instructions, then run:
+
+   ```bash
+   bash scripts/development-workflow/changelog-fragments.sh validate
+   ```
 4. Read `sync-manifest.yaml` and confirm `changelog.d/README.md` is listed under
    `always_sync` and that no entry claims the fragment files themselves.
 
@@ -363,9 +407,9 @@ The following seed data must be present:
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
 | `VALIDATE_RESULT=invalid` naming a file you did not create | A stray non-markdown file or a leftover rehearsal fragment in `changelog.d/` | Remove it; only fragments and `README.md` belong at the top level of `changelog.d/` |
-| `ASSEMBLE_RESULT=already_assembled` when you expected a fresh draft | The version section already exists from an earlier run | Intended behaviour. There is no `--reassemble` flag (Decision 3). To deliberately redo the section, discard the assembled state first — `git checkout -- CHANGELOG.md changelog.d/` if nothing is committed yet, or `git revert`/`git reset` if it is — accepting that this loses the editorial pass, then re-run `assemble` |
+| `ASSEMBLE_RESULT=already_assembled` when you expected a fresh draft | Either an earlier run completed (check for its `ASSEMBLE_RESULT=assembled` output — if you find it, this is not a bug: resume the editorial pass, do not discard anything), or a run was interrupted before finishing but still wrote the heading | There is no `--reassemble` flag (Decision 3). **Only if you confirmed no completed-assembly output exists and no editorial edits could have started**, discard with `git checkout -- CHANGELOG.md changelog.d/`, confirm `git status --porcelain` is empty, then re-run `assemble`. Once Step 5's real release commit exists, there is no safe blanket command — reconcile that commit by hand instead |
 | `ASSEMBLE_RESULT=no_notes` | Nothing is pending and the shared block is empty | Confirm the notes were not already assembled by an earlier release before reaching for `--allow-empty` |
-| A fragment you expected `assemble` to gather is still present in `changelog.d/` after a run that reported `assembled` | It arrived after that run started (a late cherry-pick or a fresh scan started before the fragment landed) | Correct behaviour, not a bug — Decision 3 requires a note recorded after assembly to wait for the next release. To deliberately include it now, discard the assembled state (see the `already_assembled` row above) and re-run `assemble` fresh |
+| A fragment you expected `assemble` to gather is still present in `changelog.d/` after a run that reported `assembled` | It arrived after that run started (a late cherry-pick or a fresh scan started before the fragment landed) | Correct behaviour, not a bug — Decision 3 requires a note recorded after assembly to wait for the next release. To deliberately include it now, apply the same discard-and-rerun guidance as the `already_assembled` row above, with the same safety check |
 | A `changelog.d/` path appears in a merge conflict | Two branches used the same item identifier | Treat as non-trivial per Protocol 94; find out which branch is misnamed rather than combining the files |
 | Duplicate `### Category` headings after assembly | A defect in the per-kind merge | Report against this feature; `check-changelog-duplicate-headers.sh` is the detector |
 

--- a/docs/testing/workflow/1554-changelog-fragments.smoke-test.md
+++ b/docs/testing/workflow/1554-changelog-fragments.smoke-test.md
@@ -29,7 +29,8 @@ repository root.
 | Item | Value |
 | --- | --- |
 | Fragment directory | `changelog.d/` |
-| Manifest directory | `changelog.d/manifests/` |
+| Manifest directory (assembled, not yet published) | `changelog.d/manifests/` |
+| Manifest archive (published/consumed) | `changelog.d/manifests/consumed/` |
 | Helper | `scripts/development-workflow/changelog-fragments.sh` |
 | Rehearsal version | `9.9.9` (never released; used only for this runbook) |
 | Scratch item identifiers | `9001`, `9002`, `9003` |
@@ -131,41 +132,68 @@ duplicated.
 
 1. Edit the `## [9.9.9]` section by hand: merge two bullets and shorten a third,
    the way the release editorial pass does.
-2. Add a new fragment `changelog.d/9002.changed.smoke-late.md`.
-3. Run `assemble --version 9.9.9` again.
-4. Simulate an interruption: switch to another branch and back.
-5. Read `CHANGELOG.md` and `changelog.d/`.
+2. Commit the assembled draft, the manifest, and the editorial edit on the
+   scratch branch — this is what a real release branch looks like at this
+   point in Protocol 05 Step 3, and it is what makes the next step a genuine
+   resumption test rather than a dirty-working-tree no-op.
+3. Add a new fragment `changelog.d/9002.changed.smoke-late.md` (left
+   uncommitted and untracked — it represents a note written on `develop`
+   after the release branch was cut).
+4. Run `assemble --version 9.9.9` again.
+5. Simulate an interruption: switch to another branch and back (`git status`
+   is clean before the switch, since Step 2 committed everything else, so the
+   switch cannot fail or carry dirty state).
+6. Read `CHANGELOG.md` and `changelog.d/`.
 
-**Expected result**: the hand edits are intact, the run reports
-`already_assembled` without rewriting anything, and the late fragment is present
-in `changelog.d/` but absent from both the `## [9.9.9]` section and the
-manifest. Nothing was lost by the interruption.
+**Expected result**: the hand edits are intact (verifiable because they are
+now part of the committed history, not just the working tree), the run
+reports `already_assembled` without rewriting anything, and the late fragment
+is present in `changelog.d/` but absent from both the `## [9.9.9]` section and
+the manifest. Nothing was lost by the interruption.
 
 ### Step 7: Publish consumes the notes
 
 **Maps to**: Acceptance Criteria 5, 7, and 8
 
 1. Run `bash scripts/development-workflow/changelog-fragments.sh consume --version 9.9.9`.
-2. List `changelog.d/` and `changelog.d/manifests/`.
+2. List `changelog.d/`, `changelog.d/manifests/`, and
+   `changelog.d/manifests/consumed/`.
 3. Run `consume --version 9.9.9` a second time.
 4. Add the `[9.9.9]` link-reference definition at the bottom of `CHANGELOG.md`
    and update the `[Unreleased]` definition, following Protocol 05.
 5. Run `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`.
 
 **Expected result**: `CONSUME_RESULT=consumed` with a removed count matching the
-manifest. Every manifest-listed fragment and the manifest itself are gone; the
-late fragment from Step 6 remains. The second run reports `already_consumed` and
-exits 0. The duplicate-header and link-reference checks both pass, so the
-changelog is ready to accumulate the next release's notes and its version links
-resolve.
+manifest. Every manifest-listed fragment is gone; `changelog.d/manifests/` no
+longer has a `v9.9.9.txt` entry, but `changelog.d/manifests/consumed/v9.9.9.txt`
+now exists (moved, not deleted — Decision 3's durable "already consumed"
+record). The late fragment from Step 6 remains. The second run reports
+`already_consumed` and exits 0, confirmed by the file's presence under
+`consumed/`. The duplicate-header and link-reference checks both pass (the one
+script performs both), so the changelog is ready to accumulate the next
+release's notes and its version links resolve.
 
 ### Step 8: The published section passes the repository's document checks
 
 **Maps to**: Acceptance Criterion 9
 
-1. Run the repository's `markdownlint-cli2` command over the changelog.
-2. Run `python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`.
-3. Run `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`.
+1. Run:
+
+   ```bash
+   npx markdownlint-cli2 "CHANGELOG.md"
+   ```
+
+2. Run:
+
+   ```bash
+   python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md
+   ```
+
+3. Run:
+
+   ```bash
+   bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md
+   ```
 
 **Expected result**: all three exit 0 with no violations reported.
 
@@ -199,9 +227,16 @@ identical to the pre-change version.
 
 **Maps to**: Acceptance Criterion 2
 
-1. Open Protocol 90's Step 5.1 artifact table and read the release-note row.
-2. Against a real implementation PR that carries a fragment and no
-   `CHANGELOG.md` change, run the row's documented query.
+1. Open Protocol 90's Step 5.1 artifact table and read the release-note row,
+   and the [implementation plan's Decision 5](../../specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md#decision-5--readiness-checks-that-must-accept-a-fragment)
+   for the exact pass condition.
+2. Against a real `feature/*`, `fix/*`, or `refactor/*` implementation PR that
+   carries a fragment and no `CHANGELOG.md` change, run:
+
+   ```bash
+   gh pr view <pr_number> --json files --jq \
+     '[.files[].path] | any(test("^changelog\\.d/[A-Za-z0-9][A-Za-z0-9_-]*\\.(added|changed|deprecated|removed|fixed|security)\\.[a-z0-9][a-z0-9-]*\\.md$"))'
+   ```
 
 **Expected result**: the query returns `true`, so the PR satisfies the
 release-note readiness check without having edited the shared changelog.
@@ -233,33 +268,25 @@ configuration, no directory creation, and no manifest edit.
 
 ## Assertions Checklist
 
-Each checkbox maps to an acceptance criterion from the spec.
+The canonical acceptance criteria live in the
+[spec's Acceptance Criteria section](../../specs/developments/20260821080421_1554-changelog-fragments/1_1554-changelog-fragments_specs.md#acceptance-criteria)
+(AC-1 through AC-13, in spec order); this checklist tracks execution against
+each one without restating its full text, to avoid the two documents drifting
+apart.
 
-- [ ] Two items completed at the same time merge one after the other with no
-      conflict, and both notes are present afterward (Step 2)
-- [ ] A pull request recording a note the new way passes the release-note
-      readiness check without editing the shared changelog (Steps 1 and 11)
-- [ ] Preparing a release gathers every unreleased note into a draft version
-      section grouped by kind, with none missing (Step 4)
-- [ ] The releaser can edit the assembled draft, and the published section
-      reflects those edits (Steps 6 and 7)
-- [ ] A release preparation interrupted after assembly resumes with no note lost
-      and the edits intact (Step 6)
-- [ ] A note recorded after assembly is absent from that release and available
-      for the next one (Step 6)
-- [ ] After the release no consumed note remains, and running assembly again
-      produces no duplicate entries (Steps 5 and 7)
-- [ ] After publishing, the changelog is ready for the next release and every
-      version link resolves (Step 7)
-- [ ] The published version section passes the repository's existing document
-      checks (Steps 3 and 8)
-- [ ] A release cut during the transition includes both the shared-block notes
-      and the per-item notes, each exactly once (Step 4)
-- [ ] An urgent production fix still writes its own versioned section and is
-      unaffected by gathering (Step 10)
-- [ ] A project created from this template records release notes the new way
-      without additional setup (Step 12)
-- [ ] The changelog's existing published history is unchanged (Step 9)
+- [ ] AC-1 — no merge conflict, both notes survive (Step 2)
+- [ ] AC-2 — readiness passes on a fragment alone (Steps 1 and 11)
+- [ ] AC-3 — assembly gathers every pending note, grouped by kind (Step 4)
+- [ ] AC-4 — editorial edits survive to publication (Steps 6 and 7)
+- [ ] AC-5 — interrupted-then-resumed preparation loses nothing (Step 6)
+- [ ] AC-6 — a post-assembly note waits for the next release (Step 6)
+- [ ] AC-7 — no duplicate entries after a repeat assembly (Steps 5 and 7)
+- [ ] AC-8 — changelog and version links are ready for the next release (Step 7)
+- [ ] AC-9 — the published section passes existing document checks (Steps 3 and 8)
+- [ ] AC-10 — transition release merges shared-block and per-item notes once each (Step 4)
+- [ ] AC-11 — the hotfix path is unaffected (Step 10)
+- [ ] AC-12 — a fresh consumer needs no setup (Step 12)
+- [ ] AC-13 — published history is unchanged (Step 9)
 
 ---
 
@@ -283,6 +310,9 @@ The following seed data must be present:
 | `ASSEMBLE_RESULT=already_assembled` when you expected a fresh draft | The version section already exists from an earlier run | Intended behaviour. Use `--reassemble` only if you accept losing the editorial pass on that section |
 | `ASSEMBLE_RESULT=no_notes` | Nothing is pending and the shared block is empty | Confirm the notes were not consumed by an earlier release before reaching for `--allow-empty` |
 | `CONSUME_RESULT=manifest_missing` | `consume` ran before `assemble`, or on the wrong branch | Run `assemble` first, and confirm you are on the release branch |
+| `ASSEMBLE_RESULT=assembled_unmanifested` | Assembly completed (the manifest is written before `CHANGELOG.md` — Decision 3), but the manifest was subsequently lost by something other than `consume` (a manual delete, a bad merge, a corrupted checkout) | Run `assemble --reassemble`; this is deterministic and safe here because nothing else has touched the fragments |
+| `CONSUME_RESULT=inconsistent` | Neither `changelog.d/manifests/v<X.Y.Z>.txt` nor `changelog.d/manifests/consumed/v<X.Y.Z>.txt` exists, but the version section is present | Stop and reconcile by hand; do not assume this means already-published |
+| `ASSEMBLE_RESULT=locked` / `CONSUME_RESULT=locked` | Another `assemble`/`consume` invocation for the same version is already running | Wait for it to finish, or confirm it is stale and remove the lock directory named in the error |
 | A `changelog.d/` path appears in a merge conflict | Two branches used the same item identifier | Treat as non-trivial per Protocol 94; find out which branch is misnamed rather than combining the files |
 | Duplicate `### Category` headings after assembly | A defect in the per-kind merge | Report against this feature; `check-changelog-duplicate-headers.sh` is the detector |
 

--- a/docs/testing/workflow/1554-changelog-fragments.smoke-test.md
+++ b/docs/testing/workflow/1554-changelog-fragments.smoke-test.md
@@ -1,0 +1,302 @@
+# Smoke Test Runbook: Changelog Fragments
+
+**Feature**: Per-item release notes assembled at release time
+**Spec**: [1_1554-changelog-fragments_specs.md](../../specs/developments/20260821080421_1554-changelog-fragments/1_1554-changelog-fragments_specs.md)
+**Implementation plan**: [2_1554-changelog-fragments_implementation-plan.md](../../specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+Before running this smoke test:
+
+- [ ] The implementation branch is checked out and `changelog.d/` exists
+- [ ] `bash`, `git`, `python3`, and `node_modules/` are available in the repository
+- [ ] A scratch clone or worktree is available for the merge exercise in Step 2,
+      so no shared branch is disturbed
+- [ ] No release is currently in preparation on the branch under test
+
+There is no running application, no database, and no login step: this feature is
+repository tooling, and every step below is executed from a shell at the
+repository root.
+
+---
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| Fragment directory | `changelog.d/` |
+| Manifest directory | `changelog.d/manifests/` |
+| Helper | `scripts/development-workflow/changelog-fragments.sh` |
+| Rehearsal version | `9.9.9` (never released; used only for this runbook) |
+| Scratch item identifiers | `9001`, `9002`, `9003` |
+
+---
+
+## Design assets
+
+None discovered for this item. The issue body carries no `## Design assets`
+section, the tracker item has no attachments, and the development folder has no
+`assets/` directory, so this runbook contains no visual fidelity step.
+
+---
+
+## Smoke Test Steps
+
+### Step 0: Establish a clean starting point
+
+1. From the repository root, run `git status` and confirm the working tree is clean.
+2. Run `bash scripts/development-workflow/changelog-fragments.sh list`.
+3. Record the reported `PENDING_COUNT` — later steps compare against it.
+
+**Expected result**: the command exits 0 and reports a pending count. `README.md`
+is not reported as a pending note.
+
+### Step 1: Record a release note without touching the changelog
+
+**Maps to**: Acceptance Criteria 1 and 2
+
+1. Create `changelog.d/9001.fixed.smoke-alpha.md` containing a single bullet in
+   the documented body format, including an issue reference.
+2. Run `bash scripts/development-workflow/changelog-fragments.sh validate`.
+3. Run `git status --short` and confirm `CHANGELOG.md` is unmodified.
+
+**Expected result**: `VALIDATE_RESULT=clean`, the fragment count is one higher
+than Step 0's, and the only changed path is the new fragment.
+
+### Step 2: Two items in parallel, no conflict
+
+**Maps to**: Acceptance Criterion 1
+
+1. From a scratch clone or worktree, create two branches from the same base.
+2. On the first, add `changelog.d/9002.added.smoke-beta.md`; commit.
+3. On the second, add `changelog.d/9003.fixed.smoke-gamma.md`; commit.
+4. Merge the first branch into the base.
+5. Merge the second branch into the base.
+
+**Expected result**: neither merge reports a conflict, no manual resolution is
+performed, and after both merges the base contains both fragment files with
+their original content.
+
+### Step 3: Malformed notes are rejected at the item's own PR
+
+**Maps to**: Acceptance Criterion 9
+
+1. Create `changelog.d/9001.improved.smoke-bad.md` with a valid bullet body.
+2. Run `bash scripts/development-workflow/changelog-fragments.sh validate`.
+3. Delete that file, then create `changelog.d/9001.fixed.smoke-bad.md` whose
+   first line is a plain sentence rather than a bullet.
+4. Run `validate` again, then delete the file.
+
+**Expected result**: both runs exit non-zero with `VALIDATE_RESULT=invalid`, and
+each names the offending path and the reason — an unrecognized kind in the first
+case, a non-bullet body in the second.
+
+### Step 4: Assemble the draft
+
+**Maps to**: Acceptance Criteria 3 and 10
+
+1. On a scratch branch, run
+   `bash scripts/development-workflow/changelog-fragments.sh assemble --version 9.9.9`.
+2. Read the reported `FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`, and `ITEMS`.
+3. Open `CHANGELOG.md` and read the new `## [9.9.9]` section.
+4. Open `changelog.d/manifests/v9.9.9.txt`.
+5. Run `git status --short` on `changelog.d/`.
+
+**Expected result**: `ASSEMBLE_RESULT=assembled`. The version section groups
+entries by kind and contains both every pending fragment's bullet and every
+bullet that was previously in `## [Unreleased]`, each appearing once. A fresh,
+empty `## [Unreleased]` heading sits above it. The manifest names exactly the
+fragments that contributed. **No fragment file has been deleted or modified** —
+this is the check that assembly destroys nothing.
+
+### Step 5: Assembly is repeatable
+
+**Maps to**: Acceptance Criterion 7
+
+1. Record the current contents of `CHANGELOG.md`.
+2. Run the same `assemble --version 9.9.9` command a second time.
+3. Compare `CHANGELOG.md` against the recording.
+
+**Expected result**: `ASSEMBLE_RESULT=already_assembled`, exit 0, and
+`CHANGELOG.md` is byte-identical to before the second run. No entry is
+duplicated.
+
+### Step 6: The releaser's edits survive, and a late note waits for the next release
+
+**Maps to**: Acceptance Criteria 4, 5, and 6
+
+1. Edit the `## [9.9.9]` section by hand: merge two bullets and shorten a third,
+   the way the release editorial pass does.
+2. Add a new fragment `changelog.d/9002.changed.smoke-late.md`.
+3. Run `assemble --version 9.9.9` again.
+4. Simulate an interruption: switch to another branch and back.
+5. Read `CHANGELOG.md` and `changelog.d/`.
+
+**Expected result**: the hand edits are intact, the run reports
+`already_assembled` without rewriting anything, and the late fragment is present
+in `changelog.d/` but absent from both the `## [9.9.9]` section and the
+manifest. Nothing was lost by the interruption.
+
+### Step 7: Publish consumes the notes
+
+**Maps to**: Acceptance Criteria 5, 7, and 8
+
+1. Run `bash scripts/development-workflow/changelog-fragments.sh consume --version 9.9.9`.
+2. List `changelog.d/` and `changelog.d/manifests/`.
+3. Run `consume --version 9.9.9` a second time.
+4. Add the `[9.9.9]` link-reference definition at the bottom of `CHANGELOG.md`
+   and update the `[Unreleased]` definition, following Protocol 05.
+5. Run `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`.
+
+**Expected result**: `CONSUME_RESULT=consumed` with a removed count matching the
+manifest. Every manifest-listed fragment and the manifest itself are gone; the
+late fragment from Step 6 remains. The second run reports `already_consumed` and
+exits 0. The duplicate-header and link-reference checks both pass, so the
+changelog is ready to accumulate the next release's notes and its version links
+resolve.
+
+### Step 8: The published section passes the repository's document checks
+
+**Maps to**: Acceptance Criterion 9
+
+1. Run the repository's `markdownlint-cli2` command over the changelog.
+2. Run `python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`.
+3. Run `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`.
+
+**Expected result**: all three exit 0 with no violations reported.
+
+### Step 9: Published history is untouched
+
+**Maps to**: Acceptance Criterion 13
+
+1. Run `git diff` on `CHANGELOG.md` against the pre-assembly commit.
+2. Read the diff hunks.
+
+**Expected result**: every change is confined to the new `## [Unreleased]`
+heading, the new `## [9.9.9]` section, and the link-reference definitions. No
+line inside any previously published version section is added, removed, or
+altered.
+
+### Step 10: Hotfixes are unaffected
+
+**Maps to**: Acceptance Criterion 11
+
+1. Follow Protocol 03 Path 4's changelog step on a scratch branch: write a new
+   versioned section directly below `## [Unreleased]`.
+2. Run `bash scripts/development-workflow/changelog-fragments.sh list`.
+3. Read Protocol 03 Path 4 and confirm no step instructs the author to write a
+   fragment.
+
+**Expected result**: the hotfix section is written directly into `CHANGELOG.md`,
+the pending-note list is unchanged by it, and the hotfix path's instructions are
+identical to the pre-change version.
+
+### Step 11: Readiness accepts a fragment
+
+**Maps to**: Acceptance Criterion 2
+
+1. Open Protocol 90's Step 5.1 artifact table and read the release-note row.
+2. Against a real implementation PR that carries a fragment and no
+   `CHANGELOG.md` change, run the row's documented query.
+
+**Expected result**: the query returns `true`, so the PR satisfies the
+release-note readiness check without having edited the shared changelog.
+
+### Step 12: A fresh consumer needs no setup
+
+**Maps to**: Acceptance Criterion 12
+
+1. Clone the repository into a fresh directory, or inspect a downstream project
+   that has synced the template.
+2. Confirm `changelog.d/README.md` and
+   `scripts/development-workflow/changelog-fragments.sh` are present.
+3. Create a fragment following only the README's instructions and run `validate`.
+4. Read `sync-manifest.yaml` and confirm `changelog.d/README.md` is listed under
+   `always_sync` and that no entry claims the fragment files themselves.
+
+**Expected result**: the fragment validates on the first attempt with no
+configuration, no directory creation, and no manifest edit.
+
+### Last Step: Restore the working tree
+
+1. Discard the scratch branch, the rehearsal `## [9.9.9]` section, and every
+   `9001`, `9002`, and `9003` fragment.
+2. Run `git status` and confirm the working tree matches the branch under test.
+3. Run `bash scripts/development-workflow/changelog-fragments.sh list` and
+   confirm the pending count matches Step 0's recording.
+
+---
+
+## Assertions Checklist
+
+Each checkbox maps to an acceptance criterion from the spec.
+
+- [ ] Two items completed at the same time merge one after the other with no
+      conflict, and both notes are present afterward (Step 2)
+- [ ] A pull request recording a note the new way passes the release-note
+      readiness check without editing the shared changelog (Steps 1 and 11)
+- [ ] Preparing a release gathers every unreleased note into a draft version
+      section grouped by kind, with none missing (Step 4)
+- [ ] The releaser can edit the assembled draft, and the published section
+      reflects those edits (Steps 6 and 7)
+- [ ] A release preparation interrupted after assembly resumes with no note lost
+      and the edits intact (Step 6)
+- [ ] A note recorded after assembly is absent from that release and available
+      for the next one (Step 6)
+- [ ] After the release no consumed note remains, and running assembly again
+      produces no duplicate entries (Steps 5 and 7)
+- [ ] After publishing, the changelog is ready for the next release and every
+      version link resolves (Step 7)
+- [ ] The published version section passes the repository's existing document
+      checks (Steps 3 and 8)
+- [ ] A release cut during the transition includes both the shared-block notes
+      and the per-item notes, each exactly once (Step 4)
+- [ ] An urgent production fix still writes its own versioned section and is
+      unaffected by gathering (Step 10)
+- [ ] A project created from this template records release notes the new way
+      without additional setup (Step 12)
+- [ ] The changelog's existing published history is unchanged (Step 9)
+
+---
+
+## Seed Data Reference
+
+The following seed data must be present:
+
+| Entity | Scenario | How to load |
+| --- | --- | --- |
+| Scratch fragments `9001`, `9002`, `9003` | Valid notes across several kinds, plus two deliberately malformed ones | Created by hand in Steps 1, 2, 3, and 6 |
+| Populated shared block | The transition-release case | Present on `develop` until the first release after this change merges; recreate by hand in a scratch branch afterwards |
+| Rehearsal version `9.9.9` | Assembly and consumption without touching a real release | Passed with `--version` in Steps 4 through 7 |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `VALIDATE_RESULT=invalid` naming a file you did not create | A stray non-markdown file or a leftover rehearsal fragment in `changelog.d/` | Remove it; only fragments, `README.md`, and the manifests directory belong there |
+| `ASSEMBLE_RESULT=already_assembled` when you expected a fresh draft | The version section already exists from an earlier run | Intended behaviour. Use `--reassemble` only if you accept losing the editorial pass on that section |
+| `ASSEMBLE_RESULT=no_notes` | Nothing is pending and the shared block is empty | Confirm the notes were not consumed by an earlier release before reaching for `--allow-empty` |
+| `CONSUME_RESULT=manifest_missing` | `consume` ran before `assemble`, or on the wrong branch | Run `assemble` first, and confirm you are on the release branch |
+| A `changelog.d/` path appears in a merge conflict | Two branches used the same item identifier | Treat as non-trivial per Protocol 94; find out which branch is misnamed rather than combining the files |
+| Duplicate `### Category` headings after assembly | A defect in the per-kind merge | Report against this feature; `check-changelog-duplicate-headers.sh` is the detector |
+
+---
+
+## Known Limitations
+
+- Steps 4 through 7 rehearse a release using version `9.9.9` rather than cutting
+  a real one. A genuine release additionally opens the production and backport
+  PRs, which this runbook does not exercise; Protocol 05's own steps cover that.
+- Step 12's downstream check inspects a fresh clone of this repository. Verifying
+  a real consumer project requires a sync-template run in that project, which is
+  outside this runbook's scope.
+- The transition-release case (Step 4 with a populated shared block) can be
+  exercised faithfully only once against real data. Afterwards it must be
+  reproduced with a hand-built fixture, which is why the implementation's test
+  suite asserts it rather than relying on this runbook.

--- a/docs/testing/workflow/1554-changelog-fragments.smoke-test.md
+++ b/docs/testing/workflow/1554-changelog-fragments.smoke-test.md
@@ -136,20 +136,26 @@ duplicated.
    scratch branch — this is what a real release branch looks like at this
    point in Protocol 05 Step 3, and it is what makes the next step a genuine
    resumption test rather than a dirty-working-tree no-op.
-3. Add a new fragment `changelog.d/9002.changed.smoke-late.md` (left
-   uncommitted and untracked — it represents a note written on `develop`
-   after the release branch was cut).
-4. Run `assemble --version 9.9.9` again.
-5. Simulate an interruption: switch to another branch and back (`git status`
-   is clean before the switch, since Step 2 committed everything else, so the
-   switch cannot fail or carry dirty state).
-6. Read `CHANGELOG.md` and `changelog.d/`.
+3. Simulate an interruption: switch to another branch and back. `git status`
+   is genuinely clean before this switch, because step 2 already committed
+   everything on this branch and nothing has touched the working tree since.
+4. Run `assemble --version 9.9.9` again — **after** the switch, so this
+   actually exercises resumption rather than repeating an assembly that ran
+   before any interruption was simulated.
+5. Add a new fragment `changelog.d/9002.changed.smoke-late.md` (left
+   uncommitted and untracked — it represents a note added to the release
+   branch, e.g. via a late cherry-pick, after assembly already ran).
+6. Run `assemble --version 9.9.9` a third time.
+7. Read `CHANGELOG.md` and `changelog.d/`.
 
-**Expected result**: the hand edits are intact (verifiable because they are
-now part of the committed history, not just the working tree), the run
-reports `already_assembled` without rewriting anything, and the late fragment
+**Expected result**: step 4's post-interruption run reports `already_assembled`
+without rewriting anything, and the hand edits are intact — verifiable because
+they are part of the committed history, not just the working tree, so nothing
+was lost by the interruption. Step 6's third run also reports
+`already_assembled` (the manifest still matches the committed set); the late
+fragment from step 5
 is present in `changelog.d/` but absent from both the `## [9.9.9]` section and
-the manifest. Nothing was lost by the interruption.
+the manifest.
 
 ### Step 7: Publish consumes the notes
 
@@ -310,8 +316,10 @@ The following seed data must be present:
 | `ASSEMBLE_RESULT=already_assembled` when you expected a fresh draft | The version section already exists from an earlier run | Intended behaviour. Use `--reassemble` only if you accept losing the editorial pass on that section |
 | `ASSEMBLE_RESULT=no_notes` | Nothing is pending and the shared block is empty | Confirm the notes were not consumed by an earlier release before reaching for `--allow-empty` |
 | `CONSUME_RESULT=manifest_missing` | `consume` ran before `assemble`, or on the wrong branch | Run `assemble` first, and confirm you are on the release branch |
-| `ASSEMBLE_RESULT=assembled_unmanifested` | Assembly completed (the manifest is written before `CHANGELOG.md` — Decision 3), but the manifest was subsequently lost by something other than `consume` (a manual delete, a bad merge, a corrupted checkout) | Run `assemble --reassemble`; this is deterministic and safe here because nothing else has touched the fragments |
-| `CONSUME_RESULT=inconsistent` | Neither `changelog.d/manifests/v<X.Y.Z>.txt` nor `changelog.d/manifests/consumed/v<X.Y.Z>.txt` exists, but the version section is present | Stop and reconcile by hand; do not assume this means already-published |
+| `ASSEMBLE_RESULT=assembled_unmanifested` | Assembly completed (the manifest is written before `CHANGELOG.md` — Decision 3), but the manifest was subsequently lost by something other than `consume` (a manual delete, a bad merge, a corrupted checkout) | Run `assemble --repair-manifest` — restores the manifest from git history. **Never** re-run `--reassemble` as the default fix: it rescans the live directory and can pull in a fragment added since the original assembly, violating "a note recorded after assembly waits for the next release" |
+| `ASSEMBLE_RESULT=manifest_unrecoverable` | `--repair-manifest` found no commit on this branch that ever wrote the manifest for this version | Reconcile by hand: compare the `## [X.Y.Z]` section's bullets against fragment bodies still in `changelog.d/`. Only fall back to `--reassemble` if you have manually confirmed no fragment has landed since the original assembly |
+| `CONSUME_RESULT=not_assembled` | `consume` was run before `assemble` finished writing the `## [X.Y.Z]` section — the manifest exists but the heading does not | Nothing was deleted. Run `assemble` first (it resumes safely from the frozen manifest), then `consume` |
+| `CONSUME_RESULT=inconsistent` | Neither `changelog.d/manifests/v<X.Y.Z>.txt` nor `changelog.d/manifests/consumed/v<X.Y.Z>.txt` exists, but the `## [X.Y.Z]` heading is present | Stop and reconcile by hand; do not assume this means already-published |
 | `ASSEMBLE_RESULT=locked` / `CONSUME_RESULT=locked` | Another `assemble`/`consume` invocation for the same version is already running | Wait for it to finish, or confirm it is stale and remove the lock directory named in the error |
 | A `changelog.d/` path appears in a merge conflict | Two branches used the same item identifier | Treat as non-trivial per Protocol 94; find out which branch is misnamed rather than combining the files |
 | Duplicate `### Category` headings after assembly | A defect in the per-kind merge | Report against this feature; `check-changelog-duplicate-headers.sh` is the detector |

--- a/docs/testing/workflow/1554-changelog-fragments.smoke-test.md
+++ b/docs/testing/workflow/1554-changelog-fragments.smoke-test.md
@@ -72,15 +72,19 @@ than Step 0's, and the only changed path is the new fragment.
 
 **Maps to**: Acceptance Criterion 1
 
-1. From a scratch clone or worktree, create two branches from the same base.
-2. On the first, add `changelog.d/9002.added.smoke-beta.md`; commit.
-3. On the second, add `changelog.d/9003.fixed.smoke-gamma.md`; commit.
-4. Merge the first branch into the base.
-5. Merge the second branch into the base.
+1. From a scratch clone or worktree, create a local `base` branch from the
+   branch under test: `git checkout -b base`.
+2. From `base`, create two branches: `git checkout -b item-a base` and
+   `git checkout -b item-b base`.
+3. On `item-a`, add `changelog.d/9002.added.smoke-beta.md`; commit.
+4. On `item-b`, add `changelog.d/9003.fixed.smoke-gamma.md`; commit.
+5. Check out `base` and merge `item-a` into it (`git merge item-a`).
+6. Merge `item-b` into `base` (`git merge item-b`).
 
 **Expected result**: neither merge reports a conflict, no manual resolution is
-performed, and after both merges the base contains both fragment files with
-their original content.
+performed, and after both merges `base` contains both fragment files with
+their original content. Discard `base`, `item-a`, and `item-b` (or the whole
+scratch clone) once this step is done — they are not reused by later steps.
 
 ### Step 3: Malformed notes are rejected at the item's own PR
 
@@ -100,12 +104,17 @@ case, a non-bullet body in the second.
 
 **Maps to**: Acceptance Criteria 3 and 10
 
-1. On a scratch branch, run
+1. Create and check out a scratch branch **from the branch under test** (so it
+   carries the `9001.fixed.smoke-alpha.md` fragment from Step 1 and any
+   fragments the real implementation already added):
+   `git checkout -b smoke-test/1554-release-rehearsal`. Steps 4 through 7 all
+   run on this branch; the "Last Step" discards it.
+2. Run
    `bash scripts/development-workflow/changelog-fragments.sh assemble --version 9.9.9`.
-2. Read the reported `FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`, and `ITEMS`.
-3. Open `CHANGELOG.md` and read the new `## [9.9.9]` section.
-4. Open `changelog.d/manifests/v9.9.9.txt`.
-5. Run `git status --short` on `changelog.d/`.
+3. Read the reported `FRAGMENT_COUNT`, `CARRIED_OVER_COUNT`, and `ITEMS`.
+4. Open `CHANGELOG.md` and read the new `## [9.9.9]` section.
+5. Open `changelog.d/manifests/v9.9.9.txt`.
+6. Run `git status --short` on `changelog.d/`.
 
 **Expected result**: `ASSEMBLE_RESULT=assembled`. The version section groups
 entries by kind and contains both every pending fragment's bullet and every
@@ -132,30 +141,40 @@ duplicated.
 
 1. Edit the `## [9.9.9]` section by hand: merge two bullets and shorten a third,
    the way the release editorial pass does.
-2. Commit the assembled draft, the manifest, and the editorial edit on the
-   scratch branch — this is what a real release branch looks like at this
-   point in Protocol 05 Step 3, and it is what makes the next step a genuine
-   resumption test rather than a dirty-working-tree no-op.
-3. Simulate an interruption: switch to another branch and back. `git status`
-   is genuinely clean before this switch, because step 2 already committed
+2. Add the `[9.9.9]` link-reference definition at the bottom of `CHANGELOG.md`
+   and update the `[Unreleased]` definition, following Protocol 05 — this is
+   Protocol 05 Step 3's "link-reference definitions" sub-step, which happens
+   before `consume`, not after (Step 7 below only verifies it).
+3. Commit the assembled draft, the manifest, the editorial edit, and the
+   link-reference definitions on the scratch branch — this is what a real
+   release branch looks like at this point in Protocol 05 Step 3, and it is
+   what makes the next step a genuine resumption test rather than a
+   dirty-working-tree no-op. (The restructured Protocol 05 Step 3 actually
+   commits **twice** before `consume` — once right after `assemble`, once
+   here, after the editorial pass — so that `--repair-manifest` always has a
+   commit to restore from; this rehearsal folds both into the one commit
+   below, since the property being tested is "was anything committed before
+   the interruption," not the exact commit count.)
+4. Simulate an interruption: switch to another branch and back. `git status`
+   is genuinely clean before this switch, because step 3 already committed
    everything on this branch and nothing has touched the working tree since.
-4. Run `assemble --version 9.9.9` again — **after** the switch, so this
+5. Run `assemble --version 9.9.9` again — **after** the switch, so this
    actually exercises resumption rather than repeating an assembly that ran
    before any interruption was simulated.
-5. Add a new fragment `changelog.d/9002.changed.smoke-late.md` (left
+6. Add a new fragment `changelog.d/9002.changed.smoke-late.md` (left
    uncommitted and untracked — it represents a note added to the release
    branch, e.g. via a late cherry-pick, after assembly already ran).
-6. Run `assemble --version 9.9.9` a third time.
-7. Read `CHANGELOG.md` and `changelog.d/`.
+7. Run `assemble --version 9.9.9` a third time.
+8. Read `CHANGELOG.md` and `changelog.d/`.
 
-**Expected result**: step 4's post-interruption run reports `already_assembled`
-without rewriting anything, and the hand edits are intact — verifiable because
-they are part of the committed history, not just the working tree, so nothing
-was lost by the interruption. Step 6's third run also reports
+**Expected result**: step 5's post-interruption run reports `already_assembled`
+without rewriting anything, and the hand edits (including the link-reference
+definitions from step 2) are intact — verifiable because they are part of the
+committed history, not just the working tree, so nothing was lost by the
+interruption. Step 6's third run (item 7 above) also reports
 `already_assembled` (the manifest still matches the committed set); the late
-fragment from step 5
-is present in `changelog.d/` but absent from both the `## [9.9.9]` section and
-the manifest.
+fragment from item 6 above is present in `changelog.d/` but absent from both
+the `## [9.9.9]` section and the manifest.
 
 ### Step 7: Publish consumes the notes
 
@@ -165,9 +184,9 @@ the manifest.
 2. List `changelog.d/`, `changelog.d/manifests/`, and
    `changelog.d/manifests/consumed/`.
 3. Run `consume --version 9.9.9` a second time.
-4. Add the `[9.9.9]` link-reference definition at the bottom of `CHANGELOG.md`
-   and update the `[Unreleased]` definition, following Protocol 05.
-5. Run `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`.
+4. Run `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
+   to verify the `[9.9.9]` and `[Unreleased]` link-reference definitions added
+   in Step 6 are both well-formed.
 
 **Expected result**: `CONSUME_RESULT=consumed` with a removed count matching the
 manifest. Every manifest-listed fragment is gone; `changelog.d/manifests/` no
@@ -264,8 +283,16 @@ configuration, no directory creation, and no manifest edit.
 
 ### Last Step: Restore the working tree
 
-1. Discard the scratch branch, the rehearsal `## [9.9.9]` section, and every
-   `9001`, `9002`, and `9003` fragment.
+1. Check out the branch under test, then delete the scratch branch
+   (`git branch -D smoke-test/1554-release-rehearsal`) — this removes the
+   scratch branch's own committed history, including the rehearsal
+   `## [9.9.9]` section. Branch deletion does not remove untracked files, so
+   also run `git clean -fdx -- 'changelog.d/9001.*' 'changelog.d/9002.*'
+   'changelog.d/9003.*' 'changelog.d/manifests'` (or remove those paths by
+   hand) from the branch under test, to catch the Step 6 late fragment (added
+   uncommitted on the scratch branch, and therefore still present as an
+   untracked file after the branch switch) along with Steps 1 and 3's
+   fragments and the rehearsal manifest directory.
 2. Run `git status` and confirm the working tree matches the branch under test.
 3. Run `bash scripts/development-workflow/changelog-fragments.sh list` and
    confirm the pending count matches Step 0's recording.
@@ -317,10 +344,11 @@ The following seed data must be present:
 | `ASSEMBLE_RESULT=no_notes` | Nothing is pending and the shared block is empty | Confirm the notes were not consumed by an earlier release before reaching for `--allow-empty` |
 | `CONSUME_RESULT=manifest_missing` | `consume` ran before `assemble`, or on the wrong branch | Run `assemble` first, and confirm you are on the release branch |
 | `ASSEMBLE_RESULT=assembled_unmanifested` | Assembly completed (the manifest is written before `CHANGELOG.md` — Decision 3), but the manifest was subsequently lost by something other than `consume` (a manual delete, a bad merge, a corrupted checkout) | Run `assemble --repair-manifest` — restores the manifest from git history. **Never** re-run `--reassemble` as the default fix: it rescans the live directory and can pull in a fragment added since the original assembly, violating "a note recorded after assembly waits for the next release" |
-| `ASSEMBLE_RESULT=manifest_unrecoverable` | `--repair-manifest` found no commit on this branch that ever wrote the manifest for this version | Reconcile by hand: compare the `## [X.Y.Z]` section's bullets against fragment bodies still in `changelog.d/`. Only fall back to `--reassemble` if you have manually confirmed no fragment has landed since the original assembly |
+| `ASSEMBLE_RESULT=manifest_unrecoverable` | `--repair-manifest` ran on a full (non-shallow) clone and found no commit on this branch that ever wrote the manifest for this version | Reconcile by hand: compare the `## [X.Y.Z]` section's bullets against fragment bodies still in `changelog.d/`. Only fall back to `--reassemble` if you have manually confirmed no fragment has landed since the original assembly |
+| `ASSEMBLE_RESULT=history_truncated` | `--repair-manifest` ran on a **shallow** clone (`git rev-parse --is-shallow-repository` is true), so it cannot rule out a commit that exists outside the fetched depth | Run `git fetch --unshallow`, then re-run `assemble --repair-manifest`. Do not treat this as `manifest_unrecoverable` — the data may still exist, only the clone is incomplete |
 | `CONSUME_RESULT=not_assembled` | `consume` was run before `assemble` finished writing the `## [X.Y.Z]` section — the manifest exists but the heading does not | Nothing was deleted. Run `assemble` first (it resumes safely from the frozen manifest), then `consume` |
 | `CONSUME_RESULT=inconsistent` | Neither `changelog.d/manifests/v<X.Y.Z>.txt` nor `changelog.d/manifests/consumed/v<X.Y.Z>.txt` exists, but the `## [X.Y.Z]` heading is present | Stop and reconcile by hand; do not assume this means already-published |
-| `ASSEMBLE_RESULT=locked` / `CONSUME_RESULT=locked` | Another `assemble`/`consume` invocation for the same version is already running | Wait for it to finish, or confirm it is stale and remove the lock directory named in the error |
+| `ASSEMBLE_RESULT=locked` / `CONSUME_RESULT=locked` | Another `assemble`/`consume` invocation for the same version is already running, **or** a prior invocation was killed and left its lock directory behind | Read the `owner` file inside the reported lock directory (PID, hostname, start time). If that PID is running on that host, wait for it to finish. If it is not, the lock is stale — remove the lock directory only after confirming this; guessing wrong recreates the interleaving the lock exists to prevent |
 | A `changelog.d/` path appears in a merge conflict | Two branches used the same item identifier | Treat as non-trivial per Protocol 94; find out which branch is misnamed rather than combining the files |
 | Duplicate `### Category` headings after assembly | A defect in the per-kind merge | Report against this feature; `check-changelog-duplicate-headers.sh` is the detector |
 

--- a/docs/testing/workflow/1554-changelog-fragments.smoke-test.md
+++ b/docs/testing/workflow/1554-changelog-fragments.smoke-test.md
@@ -150,17 +150,23 @@ Decision 3) is a no-op.
 2. Add the `[9.9.9]` link-reference definition at the bottom of `CHANGELOG.md`
    and update the `[Unreleased]` definition, following Protocol 05 Step 3's
    link-reference sub-step.
-3. Commit `CHANGELOG.md` on the scratch branch — this is what a real release
-   branch looks like just before Protocol 05's Step 5 commit, and it is what
-   makes the next step a genuine resumption test rather than a
-   dirty-working-tree no-op. (In the real protocol this is the *only* commit
-   in the whole sequence — Step 5, unmodified. This rehearsal commits early
-   purely to simulate the interruption in step 4 below; a real release
-   preparation would still be sitting uncommitted at this point, exactly like
-   today's editorial pass, and that is fine — see Known Limitations.)
-4. Simulate an interruption: switch to another branch and back. `git status`
-   is genuinely clean before this switch, because step 3 already committed
-   everything on this branch and nothing has touched the working tree since.
+3. Commit **everything** changed on the scratch branch so far — `CHANGELOG.md`
+   *and* the fragment deletions Step 4's `assemble` already made (they are
+   still sitting uncommitted; `git commit CHANGELOG.md` alone would leave
+   those deletions behind): run `git add -A` then
+   `git commit -m "rehearsal: assembled draft + editorial pass"`. This is
+   what a real release branch looks like just before Protocol 05's Step 5
+   commit, and it is what makes the next step a genuine resumption test
+   rather than a dirty-working-tree no-op. (In the real protocol this is the
+   *only* commit in the whole sequence — Step 5, unmodified. This rehearsal
+   commits early purely to simulate the interruption in step 4 below; a real
+   release preparation would still be sitting uncommitted at this point,
+   exactly like today's editorial pass, and that is fine — see Known
+   Limitations.)
+4. Simulate an interruption: run `git status --porcelain` and confirm it
+   prints nothing (step 3 committed everything on this branch; an empty
+   result is what makes the switch below guaranteed-clean, not merely
+   assumed clean), then switch to another branch and back.
 5. Run `assemble --version 9.9.9` again — **after** the switch, so this
    actually exercises resumption rather than repeating an assembly that ran
    before any interruption was simulated.
@@ -232,8 +238,12 @@ altered.
 2. Run `bash scripts/development-workflow/changelog-fragments.sh list`.
 3. Read Protocol 03 Path 4 and confirm no step instructs the author to write a
    fragment.
-4. Discard this branch (`git checkout <branch under test> && git branch -D
-   <the throwaway branch>`); its changes are not needed by any later step.
+4. **Before switching away**, discard the uncommitted hotfix edit on this
+   branch — its content is not needed by any later step: run
+   `git checkout -- CHANGELOG.md`, then `git status --porcelain` and confirm
+   it prints nothing.
+5. Now switch and discard the branch itself:
+   `git checkout <branch under test> && git branch -D <the throwaway branch>`.
 
 **Expected result**: the hotfix section is written directly into `CHANGELOG.md`,
 the pending-note list is unchanged by it, and the hotfix path's instructions are
@@ -298,9 +308,14 @@ configuration, no directory creation, and no manifest edit.
          changelog.d/9003.fixed.smoke-gamma.md
    ```
 
-   Before running it, run `git status --short -- 'changelog.d/900*'` and
-   confirm every path it lists is one of the six above — if anything else
-   appears, stop and remove files by hand instead of running the command.
+   Before running it, run
+   `git status --short --ignored -- 'changelog.d/900*'`. Plain
+   `git status --short` does not list ignored files, so an ignored file that
+   happens to share one of the six names above would pass a narrower check
+   and still be deleted by `rm -f`; `--ignored` closes that. Confirm every
+   path it lists is one of the six above — if anything else appears
+   (including an `!! ` ignored-file line), stop and remove files by hand
+   instead of running the command.
 4. Run `git status` and confirm the working tree matches the branch under test.
 5. Run `bash scripts/development-workflow/changelog-fragments.sh list` and
    confirm the pending count matches Step 0's recording.
@@ -348,9 +363,9 @@ The following seed data must be present:
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
 | `VALIDATE_RESULT=invalid` naming a file you did not create | A stray non-markdown file or a leftover rehearsal fragment in `changelog.d/` | Remove it; only fragments and `README.md` belong at the top level of `changelog.d/` |
-| `ASSEMBLE_RESULT=already_assembled` when you expected a fresh draft | The version section already exists from an earlier run | Intended behaviour. Use `--reassemble` only if you accept losing the editorial pass on that section |
+| `ASSEMBLE_RESULT=already_assembled` when you expected a fresh draft | The version section already exists from an earlier run | Intended behaviour. There is no `--reassemble` flag (Decision 3). To deliberately redo the section, discard the assembled state first — `git checkout -- CHANGELOG.md changelog.d/` if nothing is committed yet, or `git revert`/`git reset` if it is — accepting that this loses the editorial pass, then re-run `assemble` |
 | `ASSEMBLE_RESULT=no_notes` | Nothing is pending and the shared block is empty | Confirm the notes were not already assembled by an earlier release before reaching for `--allow-empty` |
-| A fragment you expected `assemble` to gather is still present in `changelog.d/` after a run that reported `assembled` | It arrived after that run started (a late cherry-pick or a fresh scan started before the fragment landed) | Correct behaviour, not a bug — Decision 3 requires a note recorded after assembly to wait for the next release. Run `assemble --reassemble` only if you deliberately want to redo the section and include it now |
+| A fragment you expected `assemble` to gather is still present in `changelog.d/` after a run that reported `assembled` | It arrived after that run started (a late cherry-pick or a fresh scan started before the fragment landed) | Correct behaviour, not a bug — Decision 3 requires a note recorded after assembly to wait for the next release. To deliberately include it now, discard the assembled state (see the `already_assembled` row above) and re-run `assemble` fresh |
 | A `changelog.d/` path appears in a merge conflict | Two branches used the same item identifier | Treat as non-trivial per Protocol 94; find out which branch is misnamed rather than combining the files |
 | Duplicate `### Category` headings after assembly | A defect in the per-kind merge | Report against this feature; `check-changelog-duplicate-headers.sh` is the detector |
 


### PR DESCRIPTION
Plan for #1554.

## Approach

Every work item gets its own release-note file under a new `changelog.d/`
directory, named `<item>.<kind>.<slug>.md`, whose body is the finished
changelog bullet. Because the first field is the tracker identifier, two
different items always write different paths, and git conflicts only on the
same path — the collision is removed by construction rather than resolved more
cleverly.

A new helper, `scripts/development-workflow/changelog-fragments.sh`, gathers
the pending notes at release time into a draft `## [X.Y.Z]` section
(`assemble`) and removes them in a separate, later step (`consume`). Assembly
also carries whatever is still in the shared `## [Unreleased]` block into the
same version section, which is what makes the transition release work with no
migration and no one-release-only code path.

**Complexity**: L. One new shell helper with a strict filename grammar and a
CHANGELOG rewriter, one new test suite, and a wide but shallow sweep across
protocol, agent, skill, lint, workflow, and manifest surfaces.

## Design decisions

| # | Question | Decision |
| --- | --- | --- |
| 1 | Fragment naming | `changelog.d/<item>.<kind>.<slug>.md`. Collisions are impossible because the discriminator is an externally allocated unique identifier, not a date or a hash — the name contains no date at all, and `run-nested-artifact-guard.sh` already prevents two in-flight branches per issue |
| 2 | Change-kind encoding | Filename field, not front matter. Readiness checks read changed-file lists, so a kind in the path is decidable with zero file reads; a filename field cannot drift from content. Dot separator, because hyphens appear in both `ENG-42` and slugs |
| 3 | Consumption | Assembly writes the draft plus a release manifest at `changelog.d/manifests/v<X.Y.Z>.txt` and **deletes nothing**. `consume` deletes the manifest-listed files as a later commit, so publication is when notes are consumed. Idempotence is enforced by refusing to write when the `## [X.Y.Z]` heading already exists |
| 4 | Transition release | Assembly renames `## [Unreleased]` (moving its bullets, not copying them) and merges fragment bullets into the same section per kind. Not a special mode; leaves no dead code, and gives downstream projects a migration-free adoption path |
| 5 | Readiness checks | Enumerated in full in the plan. The gate is Protocol 90 Step 5.1's CHANGELOG-presence row; nine other instructional surfaces also assert it |
| 6 | Protocol 94 §4.3 | **Narrow and keep**, not remove. Hotfix, release, and backport PRs still edit `CHANGELOG.md`, and non-adopted downstream projects are an expected population per the spec's Out of Scope. A new clause makes `changelog.d/` conflicts explicitly non-auto-resolvable |
| 7 | Downstream consumers | One `always_sync` manifest entry for `changelog.d/README.md`; fragment files deliberately unlisted, because the manifest defines precedence only in the opposite direction and unlisted files are never synced |

## Key risks

- An entry lost or duplicated at the transition release — mitigated by moving
  the shared block rather than copying it, and by asserting the case in
  fixtures before any protocol text is written.
- The sweep missing a surface — mitigated by a residual verification strategy
  requiring the implementation PR to re-run the repository-wide scan and
  account for every hit.
- The risk classifier will likely grade the implementation PR `high` because it
  touches `.github/workflows/` (#1565), so expect an explicit merge
  authorization request under the `medium` ceiling.

## Artifacts

- Plan: `docs/specs/developments/20260821080421_1554-changelog-fragments/2_1554-changelog-fragments_implementation-plan.md`
- Smoke runbook: `docs/testing/workflow/1554-changelog-fragments.smoke-test.md`

## Document Quality Gate

- Spec/brief coverage: Checked — all thirteen acceptance criteria map to
  Implementation Order steps, Testing Strategy scenarios, and numbered runbook
  steps; the runbook's assertions checklist has one row per criterion.
- Implementation-order consistency: Checked — script path, test path, manifest
  path, subcommand names, output field names, outcome strings, exit codes, and
  decision indices were compared across every occurrence in both documents by
  script; all agree.
- Verification support: Checked — every claim about existing behaviour cites a
  Verification Log row with the exact command or the source file read.
  `PR_HAS_CHANGELOG` is documented as a merge-ordering signal after reading
  `fetch_pr_meta` and `cmd_discover`, correcting the issue body's description
  of it as an assertion.
- Behavioral guarantees: Checked — idempotent assembly names the
  `## [X.Y.Z]` heading check as its mechanism, "the set is fixed at assembly"
  names the manifest, "nothing lost on interruption" names the
  never-delete-on-assembly rule, and deterministic ordering names its sort key.
- Complex workflow decision-gate matrix: Checked — included, covering the
  assemble gate, the consume gate, and the changed readiness gate, with inputs,
  outcomes, required next actions, and mirror surfaces per row.
- Parser/API/concurrency checklist: Checked — the plan is classified
  parser-risk (strict filename grammar plus CHANGELOG section rewriting) and
  carries a thirty-one-row edge-case enumeration across filenames, bodies, and
  changelog rewriting, each mapped to
  `scripts/development-workflow/tests/test-changelog-fragments.sh`.
  Suppression semantics: not applicable, with rationale.
  Concurrent-event-source: not applicable, with each of the seven checklist
  items recorded against a single stated rationale.
- Cross-cutting checklist enumeration: Checked — the live search prescribed by
  Protocol 02 was run and its results are in the Verification Log; the
  enumeration includes the developer and tech-lead agent surfaces for both
  Claude Code and Cursor, `REVIEW.md`, the Codex skills, and the observation
  that `.agents/skills/workflow-*` are symlinks into `.codex/skills/` while
  `.agents/skills/prepare-release/` is a real directory needing its own edit.
- CHANGELOG literal format: Checked — Implementation Order Step 12 gives the
  verbatim fragment body in the project's `**Bold Title** (#N):` format, and
  explicitly instructs the implementer **not** to add a `CHANGELOG.md` entry.
- Design-asset fidelity: Not applicable — no design assets exist for this item
  (no `## Design assets` section on the issue, no tracker attachments, no
  `assets/` directory in the development folder), so the runbook contains no
  fidelity step and invents no baseline.
- Not-applicable rationale: Checked — every skipped category above carries one.

## Pre-commit checks

- `markdownlint-cli2` on both files: 0 errors.
- `markdown-heuristic-lint.py` (GLOB001, COUNT001) on both files: clean.
- Relative links in both files verified to resolve on disk (the
  `relative-links` rule is disabled in this repository's markdownlint config,
  so this was checked by hand).
- `CHANGELOG.md` deliberately untouched: `implementation-plan/*` branches are
  exempt, and touching it would create the very conflict this item removes
  against #1589 and #1592, both currently in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an implementation plan for managing changelog entries as individual release fragments.
  * Documented fragment validation, deterministic release assembly, repeatable processing, transition releases, and error handling.
  * Added a smoke-test runbook covering end-to-end assembly, parallel changes, editorial updates, linting, hotfixes, and downstream consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->