### PR TITLE
fix(review): make Bugbot the default reviewer

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -70,7 +70,7 @@ review:
     # Ordered list of GitHub/App/CLI reviewers that run only after draft gates
     # are clean and the PR has been converted with `gh pr ready`.
     github:
-      - codex-github
+      - bugbot
 
   # Optional: TWO independent reviewer-loop cycle caps enforced by
   # pr-review-loop.sh (issue #1502; dual-cap decision recorded on PR #1507's
@@ -108,6 +108,7 @@ review:
   # max_cycles: 10
   # max_total_cycles: 25
   #
+  # Bugbot is the default ready-phase GitHub reviewer for this repository.
   # CodeRabbit remains supported as an opt-in reviewer (`coderabbit` for the
   # GitHub App, `coderabbit-cli` for the local CLI), but it is not a default
   # gate because vendor rate limits/spending caps can block otherwise-clean PRs.

--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -124,10 +124,12 @@ review:
   #                                  (default: "chatgpt-codex-connector[bot]"; verify from GitHub App settings)
   #   CODEX_GITHUB_POLL_INTERVAL   — default polling interval for codex-github via pr-review-loop.sh (default: 60)
   #   CODEX_GITHUB_MAX_WAIT        — default maximum wait for codex-github via pr-review-loop.sh (default: 1800)
+  #   CODEX_GITHUB_PRE_TRIGGER_WAIT — wait for existing current-head Codex evidence before posting a trigger; 0 disables (default: 60)
   #
   # Additional options available as script flags to codex-github-reviewer.sh (passed via pr-review-loop.sh):
   #   --poll-interval <seconds>    — polling interval while waiting for bot response
   #   --max-wait      <seconds>    — maximum total wait time for bot response
+  #   --pre-trigger-wait <seconds> — wait for existing current-head evidence before posting a trigger; 0 disables
   #
   # Copilot platform options:
   #   Prerequisites: an active GitHub Copilot seat or the Copilot for Pull Requests feature

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,12 +3,10 @@
 # This file controls CodeRabbit's behavior for this repository.
 # Docs: https://docs.coderabbit.ai/reference/configuration
 #
-# This repository has OPTED IN to CodeRabbit GitHub App review (issue #1531).
-# CodeRabbit runs as the ready-phase reviewer via review.on_ready.github in
-# .ai-dev-workflow.yaml (or .ai-dev-workflow.local.yaml). The two files must stay
-# consistent: listing "coderabbit" in a lifecycle bucket that auto_review below
-# does not cover makes CodeRabbit post a "Review skipped" banner instead of a
-# review, which pr-review-loop.sh escalates as REASON=review_skipped_banner.
+# This repository keeps CodeRabbit available for explicit, manual review only.
+# The official ready-phase reviewer is configured in .ai-dev-workflow.yaml.
+# Keep auto_review disabled unless "coderabbit" is also restored to a workflow
+# lifecycle bucket; otherwise CodeRabbit may spend quota on every pushed PR.
 #
 # This file is NOT in sync-manifest.yaml, so it is repository-local and does not
 # change the CodeRabbit defaults inherited by projects created from this template.
@@ -19,10 +17,9 @@ reviews:
       enabled: true
       timeout_ms: 600000
   auto_review:
-    enabled: true
-    # drafts stays false on purpose: CodeRabbit is configured as the *ready-phase*
-    # reviewer only (review.on_ready.github), and pr-agent covers the draft phase.
-    # Reviewing drafts would spend hourly quota on revisions that are still moving.
+    enabled: false
+    # drafts stays false because this repository does not use CodeRabbit as an
+    # automatic draft or ready-phase reviewer by default.
     drafts: false
     # Raised from 1. CodeRabbit pauses auto review after this many reviewed commits
     # arrive without human interaction; at 1, every reviewer-loop fix commit tripped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Codex GitHub reviewer avoids duplicate trigger cycles** (#1601):
   `codex-github-reviewer.sh` now checks for existing current-head Codex review
   evidence before posting `@codex review`, reusing submitted reviews,
-  SHA-pinned root comments, or current-head inline review comments when GitHub
-  already started Codex automatically. Stale evidence for older heads is
-  ignored, and `CODEX_GITHUB_PRE_TRIGGER_WAIT` / `--pre-trigger-wait` controls
-  the short pre-trigger wait window.
+  SHA-pinned root comments, or unresolved Codex review threads when GitHub
+  already started Codex automatically. Stale evidence for older heads and
+  resolved threads are ignored, and `CODEX_GITHUB_PRE_TRIGGER_WAIT` /
+  `--pre-trigger-wait` controls the short pre-trigger wait window from either
+  `codex-github-reviewer.sh` or `pr-review-loop.sh`.
 - **Regression label dispatch now creates a regression run** (#1600):
   `pr-policy.yml`
   no longer relies on a `labeled` event produced by the default GitHub Actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already started Codex automatically. Stale evidence for older heads and
   resolved threads are ignored, and `CODEX_GITHUB_PRE_TRIGGER_WAIT` /
   `--pre-trigger-wait` controls the short pre-trigger wait window from either
-  `codex-github-reviewer.sh` or `pr-review-loop.sh`.
+  `codex-github-reviewer.sh` or `pr-review-loop.sh`. The repository default
+  ready-phase reviewer is now Bugbot, and CodeRabbit auto-review is disabled so
+  it remains an explicit opt-in reviewer.
 - **Regression label dispatch now creates a regression run** (#1600):
   `pr-policy.yml`
   no longer relies on a `labeled` event produced by the default GitHub Actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+- **Codex GitHub reviewer avoids duplicate trigger cycles** (#1601):
+  `codex-github-reviewer.sh` now checks for existing current-head Codex review
+  evidence before posting `@codex review`, reusing submitted reviews,
+  SHA-pinned root comments, or current-head inline review comments when GitHub
+  already started Codex automatically. Stale evidence for older heads is
+  ignored, and `CODEX_GITHUB_PRE_TRIGGER_WAIT` / `--pre-trigger-wait` controls
+  the short pre-trigger wait window.
 - **Regression label dispatch now creates a regression run** (#1600):
   `pr-policy.yml`
   no longer relies on a `labeled` event produced by the default GitHub Actions

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -5,6 +5,17 @@ It is triggered by `scripts/development-workflow/codex-github-reviewer.sh`,
 which posts the configured Codex trigger phrase to the pull request and waits
 for Codex review evidence on the current head commit.
 
+Before posting a trigger, the script first checks for existing Codex evidence on
+the current PR head. This catches reviews that GitHub/Codex already started
+automatically when the PR was opened, marked ready, or updated, and avoids
+spending another full poll cycle on a duplicate trigger. The scan waits up to
+`CODEX_GITHUB_PRE_TRIGGER_WAIT` seconds, default `60`; set it to `0` to skip
+the pre-trigger check. Existing evidence is accepted only when it is tied to the
+current head: a submitted review whose `commit_id` matches the current
+`headRefOid`, a SHA-pinned root comment whose `Reviewed commit` marker matches
+that head, or current-head inline review comments. Stale review evidence for an
+older head is ignored and the normal trigger path still runs.
+
 The reviewer requires terminal evidence that can be tied to the current PR head:
 a submitted GitHub review whose `commit_id` matches the current `headRefOid`, or
 current-head inline review comments. Codex-authored root PR comments are terminal

--- a/docs/workflow/development-workflow/integrations/codex-github.md
+++ b/docs/workflow/development-workflow/integrations/codex-github.md
@@ -13,8 +13,9 @@ spending another full poll cycle on a duplicate trigger. The scan waits up to
 the pre-trigger check. Existing evidence is accepted only when it is tied to the
 current head: a submitted review whose `commit_id` matches the current
 `headRefOid`, a SHA-pinned root comment whose `Reviewed commit` marker matches
-that head, or current-head inline review comments. Stale review evidence for an
-older head is ignored and the normal trigger path still runs.
+that head, or unresolved non-outdated Codex review threads. Stale review
+evidence for an older head and resolved threads are ignored and the normal
+trigger path still runs.
 
 The reviewer requires terminal evidence that can be tied to the current PR head:
 a submitted GitHub review whose `commit_id` matches the current `headRefOid`, or

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -224,6 +224,7 @@ BOT_LOGIN_PLAIN="${BOT_LOGIN%\[bot\]}"
 echo "INFO: Bot login (plain, for PR-comment matching): $BOT_LOGIN_PLAIN"
 
 TRIGGER_COMMENT_ID=""
+FORCE_RETRIGGER_AFTER_CLEARED_FINDINGS=0
 
 codex_trigger_approval_reaction_count() {
   local comment_id="$1"
@@ -458,6 +459,11 @@ codex_response_is_environment_error() {
     return 1
   fi
   grep -qiE "to[[:space:]]+use[[:space:]]+codex[[:space:]]+here,[[:space:]]+create[[:space:]]+an[[:space:]]+environment[[:space:]]+for[[:space:]]+this[[:space:]]+repo" <<< "$response"
+}
+
+codex_response_is_inline_review_summary() {
+  local response="$1"
+  grep -q "Here are some automated review suggestions for this pull request." <<< "$response"
 }
 
 # codex_response_is_account_not_connected <response>
@@ -1512,14 +1518,17 @@ EOF
   fi
   [ -n "$EXISTING_BOT_RESPONSE_TIME" ] || return 1
 
-  echo "INFO: existing current-head Codex evidence detected; no trigger comment will be posted"
   codex_require_current_head
   response_display=$(printf '%s' "$EXISTING_BOT_RESPONSE" | jq -Rrs '.[0:10000]')  # workflow-shell-guard: allow SH003 - jq reads raw text for display truncation only.
 
-  if [ "$EXISTING_BOT_RESPONSE_SOURCE" = "review" ] && { [ "$EXISTING_BOT_RESPONSE_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$EXISTING_BOT_RESPONSE"; } && [ "$cleared_thread_count" -gt 0 ]; then
+  if [ "$EXISTING_BOT_RESPONSE_SOURCE" = "review" ] && [ "$cleared_thread_count" -gt 0 ] && \
+    { [ "$EXISTING_BOT_RESPONSE_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_inline_review_summary "$EXISTING_BOT_RESPONSE"; } && \
+    ! codex_response_is_blocking "$EXISTING_BOT_RESPONSE"; then
     echo "INFO: existing Codex blocking review has only cleared thread findings; posting a fresh trigger"
+    FORCE_RETRIGGER_AFTER_CLEARED_FINDINGS=1
     return 1
   fi
+  echo "INFO: existing current-head Codex evidence detected; no trigger comment will be posted"
   if [ "$EXISTING_BOT_RESPONSE_SOURCE" = "review" ] && { [ "$EXISTING_BOT_RESPONSE_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$EXISTING_BOT_RESPONSE"; }; then
     echo "VERDICT: NEEDS_REVISION"
     echo "---BEGIN BOT RESPONSE---"
@@ -1634,11 +1643,18 @@ if [ -n "$TRIGGER_COMMENT_INFO" ]; then
       fi
     else
       echo "WARNING: could not read bot replies to check whether the existing trigger was refused; keeping the existing trigger" >&2
-    fi
-  fi
-  if [ -n "$TRIGGER_TIME" ]; then
-    echo "INFO: trigger comment already posted for commit $CURRENT_SHA (at $TRIGGER_TIME) — skipping duplicate post"
-  fi
+	  fi
+	fi
+	if [ -n "$TRIGGER_TIME" ]; then
+	  if [ "$FORCE_RETRIGGER_AFTER_CLEARED_FINDINGS" -eq 1 ]; then
+	    echo "INFO: existing trigger for commit $CURRENT_SHA already produced only cleared Codex findings — posting a fresh trigger"
+	    TRIGGER_TIME=""
+	    TRIGGER_COMMENT_ID=""
+	  fi
+	fi
+	if [ -n "$TRIGGER_TIME" ]; then
+	  echo "INFO: trigger comment already posted for commit $CURRENT_SHA (at $TRIGGER_TIME) — skipping duplicate post"
+	fi
 fi
 
 # ── Post trigger comment (if no duplicate found) ──────────────────────────────

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -266,6 +266,7 @@ codex_inline_review_comment_count_since() {
 
 codex_review_thread_evidence_counts() {
   local thread_tmpfile thread_stderr cursor page max_pages count cleared_count page_count page_cleared_count has_next end_cursor
+  local -a gh_graphql_args
   thread_tmpfile=$(mktemp)
   thread_stderr=$(mktemp)
   cursor=""
@@ -281,11 +282,11 @@ codex_review_thread_evidence_counts() {
       return 3
     fi
     : > "$thread_stderr"
-    if ! gh api graphql \
-      -f owner="$OWNER" \
-      -f repo="$REPO" \
-      -F number="$PR_NUMBER" \
-      -f cursor="$cursor" \
+    gh_graphql_args=(api graphql -f owner="$OWNER" -f repo="$REPO" -F number="$PR_NUMBER")
+    if [ -n "$cursor" ]; then
+      gh_graphql_args+=(-f cursor="$cursor")
+    fi
+    if ! gh "${gh_graphql_args[@]}" \
       -f query='query($owner:String!, $repo:String!, $number:Int!, $cursor:String) {
         repository(owner:$owner, name:$repo) {
           pullRequest(number:$number) {

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -264,14 +264,14 @@ codex_inline_review_comment_count_since() {
 }
 
 codex_review_thread_evidence_counts() {
-  local thread_tmpfile thread_stderr cursor page max_pages count provisional_count page_count page_provisional_count has_next end_cursor
+  local thread_tmpfile thread_stderr cursor page max_pages count cleared_count page_count page_cleared_count has_next end_cursor
   thread_tmpfile=$(mktemp)
   thread_stderr=$(mktemp)
   cursor=""
   page=0
   max_pages=20
   count=0
-  provisional_count=0
+  cleared_count=0
   while :; do
     page=$((page + 1))
     if [ "$page" -gt "$max_pages" ]; then
@@ -324,16 +324,15 @@ codex_review_thread_evidence_counts() {
               | (.firstComment.nodes[0].author.login // "") as $first_author
               | (.lastComment.nodes[0].author.login // "") as $last_author
               | (.lastComment.nodes[0].createdAt // "") as $last_created
-              | select((.isResolved // false) == false)
               | select((.isOutdated // false) == false)
               | select($first_author == $bot or $first_author == $bot_plain)
               | {
-                  provisional: (($head_date != "") and ($last_author != $bot) and ($last_author != $bot_plain) and ($last_created > $head_date))
+                  cleared: ((.isResolved // false) or (($head_date != "") and ($last_author != $bot) and ($last_author != $bot_plain) and ($last_created > $head_date)))
                 }
             ] as $candidate_threads
-          | ($candidate_threads | map(select(.provisional | not)) | length) as $count
-          | ($candidate_threads | map(select(.provisional)) | length) as $provisional_count
-          | [$count, $provisional_count, $has_next, $end_cursor] | @tsv' \
+          | ($candidate_threads | map(select(.cleared | not)) | length) as $count
+          | ($candidate_threads | map(select(.cleared)) | length) as $cleared_count
+          | [$count, $cleared_count, $has_next, $end_cursor] | @tsv' \
       > "$thread_tmpfile"; then
       local thread_err
       thread_err=$(cat "$thread_stderr")
@@ -341,9 +340,9 @@ codex_review_thread_evidence_counts() {
       echo "ERROR: failed to fetch or parse existing Codex review threads: $thread_err" >&2
       return 3
     fi
-    IFS=$'\t' read -r page_count page_provisional_count has_next end_cursor < "$thread_tmpfile"
+    IFS=$'\t' read -r page_count page_cleared_count has_next end_cursor < "$thread_tmpfile"
     count=$((count + page_count))
-    provisional_count=$((provisional_count + page_provisional_count))
+    cleared_count=$((cleared_count + page_cleared_count))
     if [ "$has_next" != "true" ]; then
       break
     fi
@@ -354,7 +353,7 @@ codex_review_thread_evidence_counts() {
     fi
     cursor="$end_cursor"
   done
-  printf '%s\t%s\n' "$count" "$provisional_count"
+  printf '%s\t%s\n' "$count" "$cleared_count"
   rm -f "$thread_tmpfile" "$thread_stderr"
 }
 
@@ -1479,17 +1478,17 @@ codex_fetch_existing_current_head_evidence() {
 }
 
 codex_classify_existing_current_head_evidence() {
-  local thread_counts unresolved_thread_count provisionally_cleared_thread_count response_display fetch_status
+  local thread_counts unresolved_thread_count cleared_thread_count response_display fetch_status
   if ! thread_counts=$(codex_review_thread_evidence_counts); then
     echo "WARNING: failed to fetch existing Codex review threads before trigger" >&2
     echo "VERDICT: TIMED_OUT — could not fetch existing Codex thread state before trigger (treated as unavailable)"
     exit 2
   fi
-  IFS=$'\t' read -r unresolved_thread_count provisionally_cleared_thread_count <<EOF
+  IFS=$'\t' read -r unresolved_thread_count cleared_thread_count <<EOF
 $thread_counts
 EOF
   unresolved_thread_count="${unresolved_thread_count:-0}"
-  provisionally_cleared_thread_count="${provisionally_cleared_thread_count:-0}"
+  cleared_thread_count="${cleared_thread_count:-0}"
   if [ "$unresolved_thread_count" -gt 0 ]; then
     codex_require_current_head
     echo "INFO: existing current-head Codex evidence detected; no trigger comment will be posted"
@@ -1515,8 +1514,8 @@ EOF
   codex_require_current_head
   response_display=$(printf '%s' "$EXISTING_BOT_RESPONSE" | jq -Rrs '.[0:10000]')  # workflow-shell-guard: allow SH003 - jq reads raw text for display truncation only.
 
-  if [ "$EXISTING_BOT_RESPONSE_SOURCE" = "review" ] && [ "$EXISTING_BOT_RESPONSE_REVIEW_STATE" = "CHANGES_REQUESTED" ] && [ "$provisionally_cleared_thread_count" -gt 0 ]; then
-    echo "INFO: existing Codex CHANGES_REQUESTED review has only provisionally cleared thread findings; posting a fresh trigger"
+  if [ "$EXISTING_BOT_RESPONSE_SOURCE" = "review" ] && { [ "$EXISTING_BOT_RESPONSE_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$EXISTING_BOT_RESPONSE"; } && [ "$cleared_thread_count" -gt 0 ]; then
+    echo "INFO: existing Codex blocking review has only cleared thread findings; posting a fresh trigger"
     return 1
   fi
   if [ "$EXISTING_BOT_RESPONSE_SOURCE" = "review" ] && { [ "$EXISTING_BOT_RESPONSE_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$EXISTING_BOT_RESPONSE"; }; then

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -330,7 +330,7 @@ codex_review_thread_evidence_counts() {
 	              | select((.isOutdated // false) == false)
 	              | select($first_author == $bot or $first_author == $bot_plain)
 	              | {
-	                  cleared: ((.isResolved // false) or ($first_body | test("✅ Addressed")) or (($head_date != "") and ($last_author != $bot) and ($last_author != $bot_plain) and ($last_created > $head_date)))
+	                  cleared: ((.isResolved // false) or ($first_body | test("✅ Addressed")) or (($head_date != "") and ($last_author != "") and ($last_author != $bot) and ($last_author != $bot_plain) and ($last_created > $head_date)))
 	                }
             ] as $candidate_threads
           | ($candidate_threads | map(select(.cleared | not)) | length) as $count

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -264,45 +264,91 @@ codex_inline_review_comment_count_since() {
 }
 
 codex_unresolved_review_thread_count() {
-  local thread_tmpfile thread_stderr
+  local thread_tmpfile thread_stderr cursor page max_pages count page_count has_next end_cursor
   thread_tmpfile=$(mktemp)
   thread_stderr=$(mktemp)
-  if gh api graphql \
-    -f owner="$OWNER" \
-    -f repo="$REPO" \
-    -F number="$PR_NUMBER" \
-    -f query='query($owner:String!, $repo:String!, $number:Int!) {
-      repository(owner:$owner, name:$repo) {
-        pullRequest(number:$number) {
-          reviewThreads(first:100) {
-            nodes {
-              isResolved
-              isOutdated
-              comments(first:20) {
-                nodes {
-                  author { login }
+  cursor=""
+  page=0
+  max_pages=20
+  count=0
+  while :; do
+    page=$((page + 1))
+    if [ "$page" -gt "$max_pages" ]; then
+      rm -f "$thread_tmpfile" "$thread_stderr"
+      echo "ERROR: existing Codex review thread scan exceeded $max_pages pages" >&2
+      return 3
+    fi
+    : > "$thread_stderr"
+    if ! gh api graphql \
+      -f owner="$OWNER" \
+      -f repo="$REPO" \
+      -F number="$PR_NUMBER" \
+      -f cursor="$cursor" \
+      -f query='query($owner:String!, $repo:String!, $number:Int!, $cursor:String) {
+        repository(owner:$owner, name:$repo) {
+          pullRequest(number:$number) {
+            headRef {
+              target {
+                ... on Commit { committedDate }
+              }
+            }
+            reviewThreads(first:100, after:$cursor) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                isResolved
+                isOutdated
+                firstComment: comments(first:1) {
+                  nodes {
+                    author { login }
+                  }
+                }
+                lastComment: comments(last:1) {
+                  nodes {
+                    author { login }
+                    createdAt
+                  }
                 }
               }
             }
           }
         }
-      }
-    }' 2>"$thread_stderr" \
-    | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" \
-      '[.data.repository.pullRequest.reviewThreads.nodes[]?
-        | select((.isResolved // false) == false)
-        | select((.isOutdated // false) == false)
-        | select((.comments.nodes // []) | any((.author.login // "") == $bot or (.author.login // "") == $bot_plain))
-       ] | length' \
-    > "$thread_tmpfile"; then
-    cat "$thread_tmpfile"
-  else
-    local thread_err
-    thread_err=$(cat "$thread_stderr")
-    rm -f "$thread_tmpfile" "$thread_stderr"
-    echo "ERROR: failed to fetch or parse existing Codex review threads: $thread_err" >&2
-    return 3
-  fi
+      }' 2>"$thread_stderr" \
+      | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" '
+          .data.repository.pullRequest as $pr
+          | ($pr.headRef.target.committedDate // "") as $head_date
+          | ($pr.reviewThreads.pageInfo.hasNextPage // false) as $has_next
+          | ($pr.reviewThreads.pageInfo.endCursor // "") as $end_cursor
+          | ([
+              $pr.reviewThreads.nodes[]?
+              | (.firstComment.nodes[0].author.login // "") as $first_author
+              | (.lastComment.nodes[0].author.login // "") as $last_author
+              | (.lastComment.nodes[0].createdAt // "") as $last_created
+              | select((.isResolved // false) == false)
+              | select((.isOutdated // false) == false)
+              | select($first_author == $bot or $first_author == $bot_plain)
+              | select((($head_date != "") and ($last_author != $bot) and ($last_author != $bot_plain) and ($last_created > $head_date)) | not)
+            ] | length) as $count
+          | [$count, $has_next, $end_cursor] | @tsv' \
+      > "$thread_tmpfile"; then
+      local thread_err
+      thread_err=$(cat "$thread_stderr")
+      rm -f "$thread_tmpfile" "$thread_stderr"
+      echo "ERROR: failed to fetch or parse existing Codex review threads: $thread_err" >&2
+      return 3
+    fi
+    IFS=$'\t' read -r page_count has_next end_cursor < "$thread_tmpfile"
+    count=$((count + page_count))
+    if [ "$has_next" != "true" ]; then
+      break
+    fi
+    if [ -z "$end_cursor" ]; then
+      rm -f "$thread_tmpfile" "$thread_stderr"
+      echo "ERROR: existing Codex review thread scan had hasNextPage=true without endCursor" >&2
+      return 3
+    fi
+    cursor="$end_cursor"
+  done
+  printf '%s\n' "$count"
   rm -f "$thread_tmpfile" "$thread_stderr"
 }
 

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -1522,9 +1522,10 @@ EOF
   response_display=$(printf '%s' "$EXISTING_BOT_RESPONSE" | jq -Rrs '.[0:10000]')  # workflow-shell-guard: allow SH003 - jq reads raw text for display truncation only.
 
   if [ "$EXISTING_BOT_RESPONSE_SOURCE" = "review" ] && [ "$cleared_thread_count" -gt 0 ] && \
-    { [ "$EXISTING_BOT_RESPONSE_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_inline_review_summary "$EXISTING_BOT_RESPONSE"; } && \
+    [ "$EXISTING_BOT_RESPONSE_REVIEW_STATE" != "CHANGES_REQUESTED" ] && \
+    codex_response_is_inline_review_summary "$EXISTING_BOT_RESPONSE" && \
     ! codex_response_is_blocking "$EXISTING_BOT_RESPONSE"; then
-    echo "INFO: existing Codex blocking review has only cleared thread findings; posting a fresh trigger"
+    echo "INFO: existing Codex inline-review summary has only cleared thread findings; posting a fresh trigger"
     FORCE_RETRIGGER_AFTER_CLEARED_FINDINGS=1
     return 1
   fi

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -68,7 +68,8 @@
 #     here from the non-[bot] account (e.g. "chatgpt-codex-connector").
 #   - pulls/{PR}/reviews   — GitHub Review objects; matches both logins. Codex
 #     posts findings here from the [bot]-suffixed account. Only submitted
-#     reviews whose commit_id starts with the current head SHA are considered.
+#     reviews whose commit_id exactly matches the full current head SHA are
+#     considered.
 #     The review body safe-fails to NEEDS_REVISION, which causes
 #     pr-review-loop.sh to count unresolved inline threads.
 #
@@ -194,13 +195,14 @@ fi
 # Guard the assignment with 'if !' to prevent set -e from exiting with code 1
 # (NEEDS_REVISION) before the empty-check guard below can emit the VERDICT line.
 
-if ! CURRENT_SHA=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid --jq '.headRefOid' | head -c 100); then
+if ! CURRENT_SHA_FULL=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid --jq '.headRefOid' | head -c 100); then
   echo "ERROR: could not resolve PR #$PR_NUMBER HEAD SHA" >&2
   echo "VERDICT: TIMED_OUT — could not resolve PR HEAD SHA (treated as unavailable)"
   exit 2
 fi
-CURRENT_SHA=$(printf '%s' "$CURRENT_SHA" | cut -c1-12)
-if [ -z "$CURRENT_SHA" ]; then
+CURRENT_SHA_FULL=$(printf '%s' "$CURRENT_SHA_FULL" | tr -d '\n' | cut -c1-40)
+CURRENT_SHA=$(printf '%s' "$CURRENT_SHA_FULL" | cut -c1-12)
+if [ -z "$CURRENT_SHA_FULL" ]; then
   echo "ERROR: could not resolve PR #$PR_NUMBER HEAD SHA (empty result)" >&2
   echo "VERDICT: TIMED_OUT — could not resolve PR HEAD SHA (treated as unavailable)"
   exit 2
@@ -249,8 +251,8 @@ codex_inline_review_comment_count_since() {
   local review_comment_tmpfile
   review_comment_tmpfile=$(mktemp)
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments" --paginate \
-    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$trigger_time" --arg sha "$CURRENT_SHA" \
-      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .created_at >= $trigger_time and ((.commit_id // "") | startswith($sha)))] | length' \
+    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$trigger_time" --arg sha "$CURRENT_SHA_FULL" \
+      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .created_at >= $trigger_time and ((.commit_id // "") == $sha))] | length' \
     > "$review_comment_tmpfile"; then
     cat "$review_comment_tmpfile"
   else
@@ -1344,21 +1346,22 @@ codex_return_head_changed() {
 }
 
 codex_require_current_head() {
-  local latest_sha
-  if ! latest_sha=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid --jq '.headRefOid' | head -c 100); then
+  local latest_sha latest_sha_full
+  if ! latest_sha_full=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid --jq '.headRefOid' | head -c 100); then
     echo "ERROR: could not revalidate PR #$PR_NUMBER HEAD SHA" >&2
     echo "VERDICT: TIMED_OUT — could not revalidate PR HEAD SHA (treated as unavailable)"
     echo "REASON=codex-github-head-unavailable"
     exit 2
   fi
-  latest_sha=$(printf '%s' "$latest_sha" | cut -c1-12)
-  if [ -z "$latest_sha" ]; then
+  latest_sha_full=$(printf '%s' "$latest_sha_full" | tr -d '\n' | cut -c1-40)
+  latest_sha=$(printf '%s' "$latest_sha_full" | cut -c1-12)
+  if [ -z "$latest_sha_full" ]; then
     echo "ERROR: could not revalidate PR #$PR_NUMBER HEAD SHA (empty result)" >&2
     echo "VERDICT: TIMED_OUT — could not revalidate PR HEAD SHA (treated as unavailable)"
     echo "REASON=codex-github-head-unavailable"
     exit 2
   fi
-  if [ "$latest_sha" != "$CURRENT_SHA" ]; then
+  if [ "$latest_sha_full" != "$CURRENT_SHA_FULL" ]; then
     echo "INFO: PR head changed during Codex polling (started at $CURRENT_SHA, now $latest_sha)"
     codex_return_head_changed
   fi
@@ -1396,8 +1399,8 @@ codex_fetch_existing_current_head_evidence() {
   EXISTING_REVIEW_STATE=""
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>"$existing_reviews_stderr" \
-    | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg sha "$CURRENT_SHA" \
-        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and ((.commit_id // "") | startswith($sha)) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
+    | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg sha "$CURRENT_SHA_FULL" \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and ((.commit_id // "") == $sha) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
     > "$existing_reviews_tmpfile"; then
     codex_select_review_evidence "$existing_reviews_tmpfile"
     EXISTING_REVIEW_BODY="$SELECTED_REVIEW_BODY"
@@ -1701,8 +1704,8 @@ while true; do
   REVIEW_TMPFILE=$(mktemp)
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>"$REVIEW_STDERR" \
-    | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
+    | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA_FULL" \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") == $sha) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
     > "$REVIEW_TMPFILE" 2>"$REVIEW_STDERR"; then
     # Selects every review tied at the latest submitted_at timestamp (not
     # just one via sort_by | last) and picks the one requiring attention if
@@ -2021,8 +2024,8 @@ fi
 ASYNC_REVIEW_TMPFILE=$(mktemp)
 if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
   2>/dev/null \
-  | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
+  | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA_FULL" \
+      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") == $sha) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
   > "$ASYNC_REVIEW_TMPFILE" 2>/dev/null; then
   # Selects every review tied at the latest timestamp and picks the one
   # requiring attention, if any (see rationale above the main-loop
@@ -2131,8 +2134,8 @@ if [ -n "$ASYNC_BOT_RESPONSE_TIME" ]; then
     ASYNC_FINAL_REVIEW_TMPFILE=$(mktemp)
     if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
       2>/dev/null \
-      | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
+      | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA_FULL" \
+          '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") == $sha) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
       > "$ASYNC_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
       # Selects every review tied at the latest timestamp and picks the one
       # requiring attention, if any (see rationale above the main-loop
@@ -2287,8 +2290,8 @@ if [ "$ASYNC_APPROVAL_REACTION_COUNT" -gt 0 ]; then
   ASYNC_REACTION_FINAL_REVIEW_TMPFILE=$(mktemp)
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>/dev/null \
-    | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA" \
-        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") | startswith($sha)) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
+    | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg trigger_time "$TRIGGER_TIME" --arg sha "$CURRENT_SHA_FULL" \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and .submitted_at >= $trigger_time and ((.commit_id // "") == $sha) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
     > "$ASYNC_REACTION_FINAL_REVIEW_TMPFILE" 2>/dev/null; then
     # Selects every review tied at the latest timestamp and picks the one
     # requiring attention, if any (see rationale above the main-loop

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -19,6 +19,9 @@
 #   --poll-interval  <seconds>   Seconds between polling attempts. Default: 60
 #   --max-wait       <seconds>   Maximum total wait time for bot response across
 #                                all attempts. Default: 1800
+#   --pre-trigger-wait <seconds> Seconds to wait for existing current-head Codex
+#                                evidence before posting a trigger. Default: 60
+#                                Set to 0 to skip the pre-trigger check.
 #   --max-retriggers <count>     How many times to re-post the trigger after a timeout
 #                                before giving up. Default: 1 (so up to 2 attempts total).
 #                                Set to 0 to disable retriggering.
@@ -80,7 +83,7 @@ set -euo pipefail
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 if [ $# -lt 3 ]; then
-  echo "Usage: $0 <pr_number> <owner> <repo> [--trigger-phrase <phrase>] [--bot-login <login>] [--poll-interval <seconds>] [--max-wait <seconds>] [--max-retriggers <count>]" >&2
+  echo "Usage: $0 <pr_number> <owner> <repo> [--trigger-phrase <phrase>] [--bot-login <login>] [--poll-interval <seconds>] [--max-wait <seconds>] [--pre-trigger-wait <seconds>] [--max-retriggers <count>]" >&2
   exit 2
 fi
 
@@ -118,6 +121,7 @@ TRIGGER_PHRASE="${CODEX_GITHUB_TRIGGER_PHRASE:-@codex review}"
 BOT_LOGIN="${CODEX_GITHUB_BOT_LOGIN:-chatgpt-codex-connector[bot]}"
 POLL_INTERVAL=60
 MAX_WAIT=1800
+PRE_TRIGGER_WAIT="${CODEX_GITHUB_PRE_TRIGGER_WAIT:-60}"
 MAX_RETRIGGERS=1
 
 while [ $# -gt 0 ]; do
@@ -134,6 +138,9 @@ while [ $# -gt 0 ]; do
     --max-wait)
       if [ $# -lt 2 ]; then echo "ERROR: --max-wait requires a value" >&2; exit 2; fi
       MAX_WAIT="$2"; shift 2;;
+    --pre-trigger-wait)
+      if [ $# -lt 2 ]; then echo "ERROR: --pre-trigger-wait requires a value" >&2; exit 2; fi
+      PRE_TRIGGER_WAIT="$2"; shift 2;;
     --max-retriggers)
       if [ $# -lt 2 ]; then echo "ERROR: --max-retriggers requires a value" >&2; exit 2; fi
       MAX_RETRIGGERS="$2"; shift 2;;
@@ -156,6 +163,13 @@ esac
 case "$MAX_WAIT" in
   ''|0|*[!0-9]*)
     echo "ERROR: --max-wait value '$MAX_WAIT' is not a positive integer (must be >= 1)" >&2
+    exit 2
+    ;;
+esac
+# PRE_TRIGGER_WAIT may be 0 (skip the pre-trigger check) but must be non-negative.
+case "$PRE_TRIGGER_WAIT" in
+  ''|*[!0-9]*)
+    echo "ERROR: --pre-trigger-wait value '$PRE_TRIGGER_WAIT' is not a non-negative integer (must be >= 0)" >&2
     exit 2
     ;;
 esac
@@ -198,6 +212,7 @@ if [ "$POLL_INTERVAL" -gt "$MAX_WAIT" ]; then
   POLL_INTERVAL="$MAX_WAIT"
 fi
 echo "INFO: Poll interval: ${POLL_INTERVAL}s, Max wait (total): ${MAX_WAIT}s"
+echo "INFO: Pre-trigger wait: ${PRE_TRIGGER_WAIT}s"
 
 # Derive plain bot login (without [bot] suffix) for matching PR-comment
 # acknowledgements from the non-[bot] account (e.g. "chatgpt-codex-connector").
@@ -240,6 +255,22 @@ codex_inline_review_comment_count_since() {
   else
     rm -f "$review_comment_tmpfile"
     echo "ERROR: failed to fetch or parse Codex inline review comments" >&2
+    return 3
+  fi
+  rm -f "$review_comment_tmpfile"
+}
+
+codex_inline_review_comment_count_current_head() {
+  local review_comment_tmpfile
+  review_comment_tmpfile=$(mktemp)
+  if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments" --paginate \
+    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg sha "$CURRENT_SHA" \
+      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and ((.commit_id // "") | startswith($sha)))] | length' \
+    > "$review_comment_tmpfile"; then
+    cat "$review_comment_tmpfile"
+  else
+    rm -f "$review_comment_tmpfile"
+    echo "ERROR: failed to fetch or parse existing Codex inline review comments" >&2
     return 3
   fi
   rm -f "$review_comment_tmpfile"
@@ -1304,6 +1335,134 @@ codex_require_current_head() {
     codex_return_head_changed
   fi
 }
+
+codex_fetch_existing_current_head_evidence() {
+  local existing_comments_stderr existing_comments_tmpfile
+  existing_comments_stderr=$(mktemp)
+  existing_comments_tmpfile=$(mktemp)
+  COMMENT_TERMINAL_BODY=""
+  COMMENT_TERMINAL_TIME=""
+  COMMENT_LATEST_BODY=""
+  COMMENT_LATEST_TIME=""
+  COMMENT_LATEST_IS_TERMINAL=0
+  if gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" --paginate \
+    2>"$existing_comments_stderr" \
+    | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" \
+        '(add // []) | [.[] | select(.user.login == $bot or .user.login == $bot_plain)] | sort_by(.created_at, .id) | .[] | {created_at:(.created_at // ""), body:(.body // "")}' \
+    > "$existing_comments_tmpfile"; then
+    codex_scan_comment_evidence "$existing_comments_tmpfile"
+  else
+    local existing_comments_err
+    existing_comments_err=$(cat "$existing_comments_stderr")
+    rm -f "$existing_comments_stderr" "$existing_comments_tmpfile"
+    echo "WARNING: failed to fetch existing Codex root comments before trigger; continuing to trigger path: $existing_comments_err" >&2
+    return 1
+  fi
+  rm -f "$existing_comments_stderr" "$existing_comments_tmpfile"
+
+  local existing_reviews_stderr existing_reviews_tmpfile
+  existing_reviews_stderr=$(mktemp)
+  existing_reviews_tmpfile=$(mktemp)
+  if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+    2>"$existing_reviews_stderr" \
+    | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg sha "$CURRENT_SHA" \
+        '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and .submitted_at != null and ((.commit_id // "") | startswith($sha)) and ((.state // "") != "DISMISSED"))] | if length == 0 then empty else (map(.submitted_at) | max) as $latest | .[] | select(.submitted_at == $latest) | {created_at:(.submitted_at // ""), body:(.body // ""), state:(.state // "")} end' \
+    > "$existing_reviews_tmpfile"; then
+    codex_select_review_evidence "$existing_reviews_tmpfile"
+    EXISTING_REVIEW_BODY="$SELECTED_REVIEW_BODY"
+    EXISTING_REVIEW_TIME="$SELECTED_REVIEW_TIME"
+    EXISTING_REVIEW_STATE="$SELECTED_REVIEW_STATE"
+  else
+    local existing_reviews_err
+    existing_reviews_err=$(cat "$existing_reviews_stderr")
+    rm -f "$existing_reviews_stderr" "$existing_reviews_tmpfile"
+    echo "WARNING: failed to fetch existing Codex PR reviews before trigger; continuing to trigger path: $existing_reviews_err" >&2
+    return 1
+  fi
+  rm -f "$existing_reviews_stderr" "$existing_reviews_tmpfile"
+
+  codex_combine_terminal_evidence "existing current-head Codex evidence" \
+    "$COMMENT_TERMINAL_BODY" "$COMMENT_TERMINAL_TIME" \
+    "" "" \
+    "$EXISTING_REVIEW_BODY" "$EXISTING_REVIEW_TIME" 0 "$EXISTING_REVIEW_STATE"
+  EXISTING_BOT_RESPONSE="$COMBINED_BODY"
+  EXISTING_BOT_RESPONSE_SOURCE="$COMBINED_SOURCE"
+  EXISTING_BOT_RESPONSE_TIME="$COMBINED_TIME"
+  EXISTING_BOT_RESPONSE_REVIEW_STATE="$COMBINED_REVIEW_STATE"
+  return 0
+}
+
+codex_classify_existing_current_head_evidence() {
+  local inline_count response_display
+  if ! inline_count=$(codex_inline_review_comment_count_current_head); then
+    echo "WARNING: failed to fetch existing Codex inline comments before trigger; continuing to trigger path" >&2
+    return 1
+  fi
+  if [ "$inline_count" -gt 0 ]; then
+    codex_require_current_head
+    echo "INFO: existing current-head Codex evidence detected; no trigger comment will be posted"
+    echo "VERDICT: NEEDS_REVISION"
+    echo "INFO: detected $inline_count existing Codex inline review comment(s) on current head"
+    exit 1
+  fi
+
+  codex_fetch_existing_current_head_evidence || return 1
+  [ -n "$EXISTING_BOT_RESPONSE_TIME" ] || return 1
+
+  echo "INFO: existing current-head Codex evidence detected; no trigger comment will be posted"
+  codex_require_current_head
+  response_display=$(printf '%s' "$EXISTING_BOT_RESPONSE" | jq -Rrs '.[0:10000]')  # workflow-shell-guard: allow SH003 - jq reads raw text for display truncation only.
+
+  if [ "$EXISTING_BOT_RESPONSE_SOURCE" = "review" ] && { [ "$EXISTING_BOT_RESPONSE_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$EXISTING_BOT_RESPONSE"; }; then
+    echo "VERDICT: NEEDS_REVISION"
+    echo "---BEGIN BOT RESPONSE---"
+    echo "$response_display"
+    echo "---END BOT RESPONSE---"
+    exit 1
+  elif codex_response_is_usage_limit "$(codex_strip_quoted_spans "$EXISTING_BOT_RESPONSE")"; then
+    codex_return_usage_limit "$response_display"
+  elif codex_response_is_account_not_connected "$(codex_strip_quoted_spans "$EXISTING_BOT_RESPONSE")"; then
+    codex_return_account_not_connected "$response_display"
+  elif [ "$EXISTING_BOT_RESPONSE_SOURCE" = "review" ] && codex_response_is_approved "$EXISTING_BOT_RESPONSE"; then
+    echo "VERDICT: APPROVED"
+    echo "---BEGIN BOT RESPONSE---"
+    echo "$response_display"
+    echo "---END BOT RESPONSE---"
+    exit 0
+  else
+    echo "VERDICT: NEEDS_REVISION (unrecognized response format — safe-fail)"
+    echo "---BEGIN BOT RESPONSE---"
+    echo "$response_display"
+    echo "---END BOT RESPONSE---"
+    exit 1
+  fi
+}
+
+codex_wait_for_existing_current_head_evidence() {
+  local elapsed=0 sleep_for remaining
+  if [ "$PRE_TRIGGER_WAIT" -eq 0 ]; then
+    echo "INFO: pre-trigger existing-evidence check disabled"
+    return 0
+  fi
+  echo "INFO: checking for existing current-head Codex review evidence before posting trigger (max ${PRE_TRIGGER_WAIT}s)"
+  while :; do
+    codex_classify_existing_current_head_evidence || true
+    if [ "$elapsed" -ge "$PRE_TRIGGER_WAIT" ]; then
+      echo "INFO: no existing current-head Codex evidence found before trigger window elapsed"
+      return 0
+    fi
+    remaining=$((PRE_TRIGGER_WAIT - elapsed))
+    sleep_for="$POLL_INTERVAL"
+    if [ "$sleep_for" -gt "$remaining" ]; then
+      sleep_for="$remaining"
+    fi
+    echo "INFO: no existing current-head Codex evidence yet; waiting ${sleep_for}s before posting trigger"
+    sleep "$sleep_for"
+    elapsed=$((elapsed + sleep_for))
+  done
+}
+
+codex_wait_for_existing_current_head_evidence
 
 # ── Idempotency guard (BR-10) ─────────────────────────────────────────────────
 # Check whether a trigger comment for the current commit SHA already exists.

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -263,14 +263,15 @@ codex_inline_review_comment_count_since() {
   rm -f "$review_comment_tmpfile"
 }
 
-codex_unresolved_review_thread_count() {
-  local thread_tmpfile thread_stderr cursor page max_pages count page_count has_next end_cursor
+codex_review_thread_evidence_counts() {
+  local thread_tmpfile thread_stderr cursor page max_pages count provisional_count page_count page_provisional_count has_next end_cursor
   thread_tmpfile=$(mktemp)
   thread_stderr=$(mktemp)
   cursor=""
   page=0
   max_pages=20
   count=0
+  provisional_count=0
   while :; do
     page=$((page + 1))
     if [ "$page" -gt "$max_pages" ]; then
@@ -318,7 +319,7 @@ codex_unresolved_review_thread_count() {
           | ($pr.headRef.target.committedDate // "") as $head_date
           | ($pr.reviewThreads.pageInfo.hasNextPage // false) as $has_next
           | ($pr.reviewThreads.pageInfo.endCursor // "") as $end_cursor
-          | ([
+          | [
               $pr.reviewThreads.nodes[]?
               | (.firstComment.nodes[0].author.login // "") as $first_author
               | (.lastComment.nodes[0].author.login // "") as $last_author
@@ -326,9 +327,13 @@ codex_unresolved_review_thread_count() {
               | select((.isResolved // false) == false)
               | select((.isOutdated // false) == false)
               | select($first_author == $bot or $first_author == $bot_plain)
-              | select((($head_date != "") and ($last_author != $bot) and ($last_author != $bot_plain) and ($last_created > $head_date)) | not)
-            ] | length) as $count
-          | [$count, $has_next, $end_cursor] | @tsv' \
+              | {
+                  provisional: (($head_date != "") and ($last_author != $bot) and ($last_author != $bot_plain) and ($last_created > $head_date))
+                }
+            ] as $candidate_threads
+          | ($candidate_threads | map(select(.provisional | not)) | length) as $count
+          | ($candidate_threads | map(select(.provisional)) | length) as $provisional_count
+          | [$count, $provisional_count, $has_next, $end_cursor] | @tsv' \
       > "$thread_tmpfile"; then
       local thread_err
       thread_err=$(cat "$thread_stderr")
@@ -336,8 +341,9 @@ codex_unresolved_review_thread_count() {
       echo "ERROR: failed to fetch or parse existing Codex review threads: $thread_err" >&2
       return 3
     fi
-    IFS=$'\t' read -r page_count has_next end_cursor < "$thread_tmpfile"
+    IFS=$'\t' read -r page_count page_provisional_count has_next end_cursor < "$thread_tmpfile"
     count=$((count + page_count))
+    provisional_count=$((provisional_count + page_provisional_count))
     if [ "$has_next" != "true" ]; then
       break
     fi
@@ -348,7 +354,7 @@ codex_unresolved_review_thread_count() {
     fi
     cursor="$end_cursor"
   done
-  printf '%s\n' "$count"
+  printf '%s\t%s\n' "$count" "$provisional_count"
   rm -f "$thread_tmpfile" "$thread_stderr"
 }
 
@@ -1473,12 +1479,17 @@ codex_fetch_existing_current_head_evidence() {
 }
 
 codex_classify_existing_current_head_evidence() {
-  local unresolved_thread_count response_display fetch_status
-  if ! unresolved_thread_count=$(codex_unresolved_review_thread_count); then
+  local thread_counts unresolved_thread_count provisionally_cleared_thread_count response_display fetch_status
+  if ! thread_counts=$(codex_review_thread_evidence_counts); then
     echo "WARNING: failed to fetch existing Codex review threads before trigger" >&2
     echo "VERDICT: TIMED_OUT — could not fetch existing Codex thread state before trigger (treated as unavailable)"
     exit 2
   fi
+  IFS=$'\t' read -r unresolved_thread_count provisionally_cleared_thread_count <<EOF
+$thread_counts
+EOF
+  unresolved_thread_count="${unresolved_thread_count:-0}"
+  provisionally_cleared_thread_count="${provisionally_cleared_thread_count:-0}"
   if [ "$unresolved_thread_count" -gt 0 ]; then
     codex_require_current_head
     echo "INFO: existing current-head Codex evidence detected; no trigger comment will be posted"
@@ -1504,6 +1515,10 @@ codex_classify_existing_current_head_evidence() {
   codex_require_current_head
   response_display=$(printf '%s' "$EXISTING_BOT_RESPONSE" | jq -Rrs '.[0:10000]')  # workflow-shell-guard: allow SH003 - jq reads raw text for display truncation only.
 
+  if [ "$EXISTING_BOT_RESPONSE_SOURCE" = "review" ] && [ "$EXISTING_BOT_RESPONSE_REVIEW_STATE" = "CHANGES_REQUESTED" ] && [ "$provisionally_cleared_thread_count" -gt 0 ]; then
+    echo "INFO: existing Codex CHANGES_REQUESTED review has only provisionally cleared thread findings; posting a fresh trigger"
+    return 1
+  fi
   if [ "$EXISTING_BOT_RESPONSE_SOURCE" = "review" ] && { [ "$EXISTING_BOT_RESPONSE_REVIEW_STATE" = "CHANGES_REQUESTED" ] || codex_response_is_blocking "$EXISTING_BOT_RESPONSE"; }; then
     echo "VERDICT: NEEDS_REVISION"
     echo "---BEGIN BOT RESPONSE---"
@@ -1539,6 +1554,7 @@ codex_wait_for_existing_current_head_evidence() {
   while :; do
     codex_classify_existing_current_head_evidence || true
     if [ "$elapsed" -ge "$PRE_TRIGGER_WAIT" ]; then
+      codex_require_current_head
       echo "INFO: no existing current-head Codex evidence found before trigger window elapsed"
       return 0
     fi

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -261,20 +261,47 @@ codex_inline_review_comment_count_since() {
   rm -f "$review_comment_tmpfile"
 }
 
-codex_inline_review_comment_count_current_head() {
-  local review_comment_tmpfile
-  review_comment_tmpfile=$(mktemp)
-  if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments" --paginate \
-    | jq -sr --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg sha "$CURRENT_SHA" \
-      '(add // []) | [.[] | select((.user.login == $bot or .user.login == $bot_plain) and ((.commit_id // "") | startswith($sha)))] | length' \
-    > "$review_comment_tmpfile"; then
-    cat "$review_comment_tmpfile"
+codex_unresolved_review_thread_count() {
+  local thread_tmpfile thread_stderr
+  thread_tmpfile=$(mktemp)
+  thread_stderr=$(mktemp)
+  if gh api graphql \
+    -f owner="$OWNER" \
+    -f repo="$REPO" \
+    -F number="$PR_NUMBER" \
+    -f query='query($owner:String!, $repo:String!, $number:Int!) {
+      repository(owner:$owner, name:$repo) {
+        pullRequest(number:$number) {
+          reviewThreads(first:100) {
+            nodes {
+              isResolved
+              isOutdated
+              comments(first:20) {
+                nodes {
+                  author { login }
+                }
+              }
+            }
+          }
+        }
+      }
+    }' 2>"$thread_stderr" \
+    | jq -r --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" \
+      '[.data.repository.pullRequest.reviewThreads.nodes[]?
+        | select((.isResolved // false) == false)
+        | select((.isOutdated // false) == false)
+        | select((.comments.nodes // []) | any((.author.login // "") == $bot or (.author.login // "") == $bot_plain))
+       ] | length' \
+    > "$thread_tmpfile"; then
+    cat "$thread_tmpfile"
   else
-    rm -f "$review_comment_tmpfile"
-    echo "ERROR: failed to fetch or parse existing Codex inline review comments" >&2
+    local thread_err
+    thread_err=$(cat "$thread_stderr")
+    rm -f "$thread_tmpfile" "$thread_stderr"
+    echo "ERROR: failed to fetch or parse existing Codex review threads: $thread_err" >&2
     return 3
   fi
-  rm -f "$review_comment_tmpfile"
+  rm -f "$thread_tmpfile" "$thread_stderr"
 }
 
 # All classification helpers below match against the response via a
@@ -1397,16 +1424,16 @@ codex_fetch_existing_current_head_evidence() {
 }
 
 codex_classify_existing_current_head_evidence() {
-  local inline_count response_display
-  if ! inline_count=$(codex_inline_review_comment_count_current_head); then
-    echo "WARNING: failed to fetch existing Codex inline comments before trigger; continuing to trigger path" >&2
+  local unresolved_thread_count response_display
+  if ! unresolved_thread_count=$(codex_unresolved_review_thread_count); then
+    echo "WARNING: failed to fetch existing Codex review threads before trigger; continuing to trigger path" >&2
     return 1
   fi
-  if [ "$inline_count" -gt 0 ]; then
+  if [ "$unresolved_thread_count" -gt 0 ]; then
     codex_require_current_head
     echo "INFO: existing current-head Codex evidence detected; no trigger comment will be posted"
     echo "VERDICT: NEEDS_REVISION"
-    echo "INFO: detected $inline_count existing Codex inline review comment(s) on current head"
+    echo "INFO: detected $unresolved_thread_count existing unresolved Codex review thread(s)"
     exit 1
   fi
 

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -1383,8 +1383,8 @@ codex_fetch_existing_current_head_evidence() {
     local existing_comments_err
     existing_comments_err=$(cat "$existing_comments_stderr")
     rm -f "$existing_comments_stderr" "$existing_comments_tmpfile"
-    echo "WARNING: failed to fetch existing Codex root comments before trigger; continuing to trigger path: $existing_comments_err" >&2
-    return 1
+    echo "WARNING: failed to fetch existing Codex root comments before trigger: $existing_comments_err" >&2
+    return 2
   fi
   rm -f "$existing_comments_stderr" "$existing_comments_tmpfile"
 
@@ -1407,8 +1407,8 @@ codex_fetch_existing_current_head_evidence() {
     local existing_reviews_err
     existing_reviews_err=$(cat "$existing_reviews_stderr")
     rm -f "$existing_reviews_stderr" "$existing_reviews_tmpfile"
-    echo "WARNING: failed to fetch existing Codex PR reviews before trigger; continuing to trigger path: $existing_reviews_err" >&2
-    return 1
+    echo "WARNING: failed to fetch existing Codex PR reviews before trigger: $existing_reviews_err" >&2
+    return 2
   fi
   rm -f "$existing_reviews_stderr" "$existing_reviews_tmpfile"
 
@@ -1424,10 +1424,11 @@ codex_fetch_existing_current_head_evidence() {
 }
 
 codex_classify_existing_current_head_evidence() {
-  local unresolved_thread_count response_display
+  local unresolved_thread_count response_display fetch_status
   if ! unresolved_thread_count=$(codex_unresolved_review_thread_count); then
-    echo "WARNING: failed to fetch existing Codex review threads before trigger; continuing to trigger path" >&2
-    return 1
+    echo "WARNING: failed to fetch existing Codex review threads before trigger" >&2
+    echo "VERDICT: TIMED_OUT — could not fetch existing Codex thread state before trigger (treated as unavailable)"
+    exit 2
   fi
   if [ "$unresolved_thread_count" -gt 0 ]; then
     codex_require_current_head
@@ -1437,7 +1438,17 @@ codex_classify_existing_current_head_evidence() {
     exit 1
   fi
 
-  codex_fetch_existing_current_head_evidence || return 1
+  set +e
+  codex_fetch_existing_current_head_evidence
+  fetch_status=$?
+  set -e
+  if [ "$fetch_status" -eq 2 ]; then
+    echo "VERDICT: TIMED_OUT — could not fetch existing Codex evidence before trigger (treated as unavailable)"
+    exit 2
+  fi
+  if [ "$fetch_status" -ne 0 ]; then
+    return 1
+  fi
   [ -n "$EXISTING_BOT_RESPONSE_TIME" ] || return 1
 
   echo "INFO: existing current-head Codex evidence detected; no trigger comment will be posted"

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -173,6 +173,7 @@ case "$PRE_TRIGGER_WAIT" in
     exit 2
     ;;
 esac
+PRE_TRIGGER_WAIT=$((10#$PRE_TRIGGER_WAIT))
 # MAX_RETRIGGERS may be 0 (disable retriggering) but must be a non-negative integer.
 case "$MAX_RETRIGGERS" in
   ''|*[!0-9]*)

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -298,11 +298,12 @@ codex_review_thread_evidence_counts() {
               nodes {
                 isResolved
                 isOutdated
-                firstComment: comments(first:1) {
-                  nodes {
-                    author { login }
-                  }
-                }
+	                firstComment: comments(first:1) {
+	                  nodes {
+	                    author { login }
+	                    body
+	                  }
+	                }
                 lastComment: comments(last:1) {
                   nodes {
                     author { login }
@@ -321,14 +322,15 @@ codex_review_thread_evidence_counts() {
           | ($pr.reviewThreads.pageInfo.endCursor // "") as $end_cursor
           | [
               $pr.reviewThreads.nodes[]?
-              | (.firstComment.nodes[0].author.login // "") as $first_author
-              | (.lastComment.nodes[0].author.login // "") as $last_author
-              | (.lastComment.nodes[0].createdAt // "") as $last_created
-              | select((.isOutdated // false) == false)
-              | select($first_author == $bot or $first_author == $bot_plain)
-              | {
-                  cleared: ((.isResolved // false) or (($head_date != "") and ($last_author != $bot) and ($last_author != $bot_plain) and ($last_created > $head_date)))
-                }
+	              | (.firstComment.nodes[0].author.login // "") as $first_author
+	              | (.firstComment.nodes[0].body // "") as $first_body
+	              | (.lastComment.nodes[0].author.login // "") as $last_author
+	              | (.lastComment.nodes[0].createdAt // "") as $last_created
+	              | select((.isOutdated // false) == false)
+	              | select($first_author == $bot or $first_author == $bot_plain)
+	              | {
+	                  cleared: ((.isResolved // false) or ($first_body | test("✅ Addressed")) or (($head_date != "") and ($last_author != $bot) and ($last_author != $bot_plain) and ($last_created > $head_date)))
+	                }
             ] as $candidate_threads
           | ($candidate_threads | map(select(.cleared | not)) | length) as $count
           | ($candidate_threads | map(select(.cleared)) | length) as $cleared_count

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -1363,6 +1363,9 @@ codex_fetch_existing_current_head_evidence() {
   local existing_reviews_stderr existing_reviews_tmpfile
   existing_reviews_stderr=$(mktemp)
   existing_reviews_tmpfile=$(mktemp)
+  EXISTING_REVIEW_BODY=""
+  EXISTING_REVIEW_TIME=""
+  EXISTING_REVIEW_STATE=""
   if gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
     2>"$existing_reviews_stderr" \
     | jq -sc --arg bot "$BOT_LOGIN" --arg bot_plain "$BOT_LOGIN_PLAIN" --arg sha "$CURRENT_SHA" \

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -285,7 +285,7 @@ _skip_next=0
 for _arg in "$@"; do
   if [ "$_skip_next" -eq 1 ]; then _skip_next=0; continue; fi
   case "$_arg" in
-    --branch|--platform|--poll-interval|--max-wait|--repo|--product-repo|--repo-root) _skip_next=1 ;;
+    --branch|--platform|--poll-interval|--max-wait|--pre-trigger-wait|--repo|--product-repo|--repo-root) _skip_next=1 ;;
     [0-9]*) _PR_ARG="$_arg"; break ;;
   esac
 done
@@ -386,7 +386,7 @@ _interruptible_sleep() {
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--repo owner/repo|product-name] [--product-repo name] [--repo-root path] [--platform greptile] [--platform greptile,devin,pr-agent,coderabbit,coderabbit-cli,codex-github,claude-code-action,copilot,haystack,bugbot] [--ready-phase haystack] [--phase-after-clean haystack] [--draft-github-only] [--pre-after-clean-only] [--poll-interval seconds] [--max-wait seconds] [--post-final-summary] [--compare]
+Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--repo owner/repo|product-name] [--product-repo name] [--repo-root path] [--platform greptile] [--platform greptile,devin,pr-agent,coderabbit,coderabbit-cli,codex-github,claude-code-action,copilot,haystack,bugbot] [--ready-phase haystack] [--phase-after-clean haystack] [--draft-github-only] [--pre-after-clean-only] [--poll-interval seconds] [--max-wait seconds] [--pre-trigger-wait seconds] [--post-final-summary] [--compare]
        ./scripts/development-workflow/pr-review-loop.sh unlock <pr-number>
 
 Runs the automated PR review loop for one or more platforms in sequence. Before
@@ -1052,6 +1052,7 @@ run_codex_github_review() {
   local branch_name="$2"
   local poll_interval="$3"
   local max_wait="$4"
+  local pre_trigger_wait="${5:-${CODEX_GITHUB_PRE_TRIGGER_WAIT:-}}"
   local platform="codex-github"
   local bot_login="${CODEX_GITHUB_BOT_LOGIN:-chatgpt-codex-connector[bot]}"
   # REST API endpoints (e.g. /pulls/{n}/reviews, /issues/{n}/comments) return
@@ -1127,12 +1128,18 @@ run_codex_github_review() {
   if [ "$effective_poll_interval" -gt "$max_wait" ]; then
     effective_poll_interval="$max_wait"
   fi
+  local reviewer_args=(
+    "$pr_number" "$owner" "$repo_name"
+    --bot-login "$bot_login"
+    --poll-interval "$effective_poll_interval"
+    --max-wait "$max_wait"
+    --max-retriggers "$max_retriggers"
+  )
+  if [ -n "$pre_trigger_wait" ]; then
+    reviewer_args+=(--pre-trigger-wait "$pre_trigger_wait")
+  fi
   set +e
-  script_output="$("$reviewer_script" "$pr_number" "$owner" "$repo_name" \
-    --bot-login "$bot_login" \
-    --poll-interval "$effective_poll_interval" \
-    --max-wait "$max_wait" \
-    --max-retriggers "$max_retriggers" 2>&1)"
+  script_output="$("$reviewer_script" "${reviewer_args[@]}" 2>&1)"
   script_exit=$?
   set -e
 
@@ -5877,7 +5884,7 @@ run_platform_review() {
       run_pr_agent_review "$pr_number" "$branch_name" "$poll_interval" "$max_wait"
       ;;
     codex-github)
-      run_codex_github_review "$pr_number" "$branch_name" "$poll_interval" "$max_wait"
+      run_codex_github_review "$pr_number" "$branch_name" "$poll_interval" "$max_wait" "$codex_github_pre_trigger_wait"
       ;;
     claude-code-action)
       run_claude_code_action_review "$pr_number" "$branch_name" "$poll_interval" "$max_wait"
@@ -7590,6 +7597,7 @@ poll_interval=120
 poll_interval_explicit=0
 max_wait=1200
 max_wait_explicit=0
+codex_github_pre_trigger_wait=""
 post_final_summary=0
 compare_mode=0
 pre_after_clean_only=0
@@ -7662,6 +7670,11 @@ while [ "$#" -gt 0 ]; do
       require_option_value "$@"
       max_wait="$2"
       max_wait_explicit=1
+      shift 2
+      ;;
+    --pre-trigger-wait)
+      require_option_value "$@"
+      codex_github_pre_trigger_wait="$2"
       shift 2
       ;;
     --post-final-summary)

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4285,6 +4285,88 @@ run_test "codex_prefix_mismatch_review_no_fast_path" "yes" \
 rm -rf "$_codex_prefix_mismatch_mock_dir"
 unset _codex_prefix_mismatch_mock_dir _codex_prefix_mismatch_exit
 
+_codex_provisional_reply_mock_dir="$(mktemp -d)"
+cat > "$_codex_provisional_reply_mock_dir/gh" <<'CODEX_PROVISIONAL_REPLY_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n'; exit 0 ;;
+  *"api graphql"*)
+    printf '{"data":{"repository":{"pullRequest":{"headRef":{"target":{"committedDate":"2026-01-01T00:00:00Z"}},"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"isResolved":false,"isOutdated":false,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"}}]},"lastComment":{"nodes":[{"author":{"login":"lhpaul"},"createdAt":"2026-01-01T00:00:01Z"}]}}]}}}}}\n'
+    exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":107,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",state:"APPROVED",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `aaaaaaaaaaaa` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_PROVISIONAL_REPLY_GH
+chmod +x "$_codex_provisional_reply_mock_dir/gh"
+: > "$_codex_provisional_reply_mock_dir/posts.log"
+_codex_provisional_reply_exit=0
+MOCK_POST_LOG="$_codex_provisional_reply_mock_dir/posts.log" PATH="$_codex_provisional_reply_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 1 --max-retriggers 0 \
+  >"$_codex_provisional_reply_mock_dir/output.txt" 2>&1 || _codex_provisional_reply_exit=$?
+run_test "codex_provisional_reply_allows_existing_review" "0" "$_codex_provisional_reply_exit"
+run_test "codex_provisional_reply_skips_trigger" "0" \
+  "$(wc -l < "$_codex_provisional_reply_mock_dir/posts.log" | tr -d ' ')"
+rm -rf "$_codex_provisional_reply_mock_dir"
+unset _codex_provisional_reply_mock_dir _codex_provisional_reply_exit
+
+_codex_paginated_thread_mock_dir="$(mktemp -d)"
+cat > "$_codex_paginated_thread_mock_dir/gh" <<'CODEX_PAGINATED_THREAD_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n'; exit 0 ;;
+  *"api graphql"*cursor1*)
+    printf '{"data":{"repository":{"pullRequest":{"headRef":{"target":{"committedDate":"2026-01-01T00:00:00Z"}},"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"isResolved":false,"isOutdated":false,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"}}]},"lastComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"createdAt":"2026-01-01T00:00:01Z"}]}}]}}}}}\n'
+    exit 0 ;;
+  *"api graphql"*)
+    printf '{"data":{"repository":{"pullRequest":{"headRef":{"target":{"committedDate":"2026-01-01T00:00:00Z"}},"reviewThreads":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor1"},"nodes":[]}}}}}\n'
+    exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":108,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_PAGINATED_THREAD_GH
+chmod +x "$_codex_paginated_thread_mock_dir/gh"
+: > "$_codex_paginated_thread_mock_dir/posts.log"
+_codex_paginated_thread_output=""
+_codex_paginated_thread_exit=0
+MOCK_POST_LOG="$_codex_paginated_thread_mock_dir/posts.log" PATH="$_codex_paginated_thread_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 1 --max-retriggers 0 \
+  >"$_codex_paginated_thread_mock_dir/output.txt" 2>&1 || _codex_paginated_thread_exit=$?
+_codex_paginated_thread_output="$(cat "$_codex_paginated_thread_mock_dir/output.txt")"
+run_test "codex_paginated_thread_exit_needs_revision" "1" "$_codex_paginated_thread_exit"
+run_test "codex_paginated_thread_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_paginated_thread_output" | grep "^VERDICT:")"
+run_test "codex_paginated_thread_skips_trigger" "0" \
+  "$(wc -l < "$_codex_paginated_thread_mock_dir/posts.log" | tr -d ' ')"
+rm -rf "$_codex_paginated_thread_mock_dir"
+unset _codex_paginated_thread_mock_dir _codex_paginated_thread_output _codex_paginated_thread_exit
+
 _codex_reaction_mock_dir="$(mktemp -d)"
 cat > "$_codex_reaction_mock_dir/gh" <<'CODEX_REACTION_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3556,6 +3556,8 @@ unset -f _1509_reviewer_failed_required
 echo ""
 echo "=== Area 13: PR #801 reviewer-loop failure paths ==="
 
+export CODEX_GITHUB_PRE_TRIGGER_WAIT=0
+
 export MOCK_GH_OUTPUT='{
   "reviewThreads": {
   "pageInfo": {"hasNextPage": false, "endCursor": null},
@@ -4095,6 +4097,92 @@ run_test "codex_usage_limit_review_suggestion_count" "SUGGESTION_COUNT=0" \
   "$(printf '%s\n' "$_codex_usage_review_output" | grep "^SUGGESTION_COUNT=")"
 rm -rf "$_codex_usage_review_mock_dir"
 unset _codex_usage_review_mock_dir _codex_usage_review_output _codex_usage_review_exit
+
+_codex_existing_clean_mock_dir="$(mktemp -d)"
+cat > "$_codex_existing_clean_mock_dir/gh" <<'CODEX_EXISTING_CLEAN_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcef1234567890abcde\n'; exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":102,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"abcef1234567890abcde",state:"APPROVED",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `abcef1234567890abcde` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_EXISTING_CLEAN_GH
+chmod +x "$_codex_existing_clean_mock_dir/gh"
+: > "$_codex_existing_clean_mock_dir/posts.log"
+_codex_existing_clean_output=""
+_codex_existing_clean_exit=0
+MOCK_POST_LOG="$_codex_existing_clean_mock_dir/posts.log" PATH="$_codex_existing_clean_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 1 --max-retriggers 0 \
+  >"$_codex_existing_clean_mock_dir/output.txt" 2>&1 || _codex_existing_clean_exit=$?
+_codex_existing_clean_output="$(cat "$_codex_existing_clean_mock_dir/output.txt")"
+run_test "codex_existing_current_head_review_exit_clean" "0" "$_codex_existing_clean_exit"
+run_test "codex_existing_current_head_review_approved" "VERDICT: APPROVED" \
+  "$(printf '%s\n' "$_codex_existing_clean_output" | grep "^VERDICT:")"
+run_test "codex_existing_current_head_review_skips_trigger" "0" \
+  "$(wc -l < "$_codex_existing_clean_mock_dir/posts.log" | tr -d ' ')"
+run_test "codex_existing_current_head_review_logs_no_trigger" "yes" \
+  "$(if grep -Fq "existing current-head Codex evidence detected; no trigger comment will be posted" "$_codex_existing_clean_mock_dir/output.txt"; then printf yes; else printf no; fi)"
+rm -rf "$_codex_existing_clean_mock_dir"
+unset _codex_existing_clean_mock_dir _codex_existing_clean_output _codex_existing_clean_exit
+
+_codex_stale_existing_mock_dir="$(mktemp -d)"
+cat > "$_codex_stale_existing_mock_dir/gh" <<'CODEX_STALE_EXISTING_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcnewhead1234567890\n'; exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":104,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"abcoldhead1234567890",state:"APPROVED",user:{login:"chatgpt-codex-connector[bot]"},body:"Codex Review: Did not cover the current head."}]'
+    exit 0 ;;
+  *"issues/"*"/comments"*)
+    jq -nc '[{id:204,created_at:"2026-01-01T00:00:01Z",user:{login:"chatgpt-codex-connector[bot]"},body:"Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `abcoldhead1234567890`"}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_STALE_EXISTING_GH
+chmod +x "$_codex_stale_existing_mock_dir/gh"
+: > "$_codex_stale_existing_mock_dir/posts.log"
+_codex_stale_existing_exit=0
+MOCK_POST_LOG="$_codex_stale_existing_mock_dir/posts.log" PATH="$_codex_stale_existing_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 1 --max-retriggers 0 \
+  >"$_codex_stale_existing_mock_dir/output.txt" 2>&1 || _codex_stale_existing_exit=$?
+run_test "codex_stale_existing_evidence_posts_trigger" "1" \
+  "$(wc -l < "$_codex_stale_existing_mock_dir/posts.log" | tr -d ' ')"
+run_test "codex_stale_existing_evidence_no_fast_path" "yes" \
+  "$(if grep -Fq "no existing current-head Codex evidence found before trigger window elapsed" "$_codex_stale_existing_mock_dir/output.txt"; then printf yes; else printf no; fi)"
+rm -rf "$_codex_stale_existing_mock_dir"
+unset _codex_stale_existing_mock_dir _codex_stale_existing_exit
 
 _codex_reaction_mock_dir="$(mktemp -d)"
 cat > "$_codex_reaction_mock_dir/gh" <<'CODEX_REACTION_GH'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4241,6 +4241,50 @@ run_test "codex_stale_existing_evidence_no_fast_path" "yes" \
 rm -rf "$_codex_stale_existing_mock_dir"
 unset _codex_stale_existing_mock_dir _codex_stale_existing_exit
 
+_codex_prefix_mismatch_mock_dir="$(mktemp -d)"
+cat > "$_codex_prefix_mismatch_mock_dir/gh" <<'CODEX_PREFIX_MISMATCH_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcdefab1234567890abcdefab1234567890abcd\n'; exit 0 ;;
+  *"api graphql"*)
+    printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n'
+    exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":106,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"abcdefab1234567890abcdefab1234567890abce",state:"APPROVED",user:{login:"chatgpt-codex-connector[bot]"},body:("Codex Review: Didn'\''t find any major issues. Swish! **Reviewed commit:** `abcdefab1234` <details> <summary>ℹ️ About Codex in GitHub</summary> <br/> [Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you - Open a pull request for review - Mark a draft as ready - Comment \"@codex review\". If Codex has suggestions, it will comment; otherwise it will react with 👍. Codex can also answer questions or update the PR. Try commenting \"@codex address that feedback\". </details>")}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_PREFIX_MISMATCH_GH
+chmod +x "$_codex_prefix_mismatch_mock_dir/gh"
+: > "$_codex_prefix_mismatch_mock_dir/posts.log"
+_codex_prefix_mismatch_exit=0
+MOCK_POST_LOG="$_codex_prefix_mismatch_mock_dir/posts.log" PATH="$_codex_prefix_mismatch_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 1 --max-retriggers 0 \
+  >"$_codex_prefix_mismatch_mock_dir/output.txt" 2>&1 || _codex_prefix_mismatch_exit=$?
+run_test "codex_prefix_mismatch_review_posts_trigger" "1" \
+  "$(wc -l < "$_codex_prefix_mismatch_mock_dir/posts.log" | tr -d ' ')"
+run_test "codex_prefix_mismatch_review_no_fast_path" "yes" \
+  "$(if grep -Fq "no existing current-head Codex evidence found before trigger window elapsed" "$_codex_prefix_mismatch_mock_dir/output.txt"; then printf yes; else printf no; fi)"
+rm -rf "$_codex_prefix_mismatch_mock_dir"
+unset _codex_prefix_mismatch_mock_dir _codex_prefix_mismatch_exit
+
 _codex_reaction_mock_dir="$(mktemp -d)"
 cat > "$_codex_reaction_mock_dir/gh" <<'CODEX_REACTION_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4434,7 +4434,8 @@ case "$*" in
   *"pulls/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
   *"issues/"*"/comments"*)
-    printf '[]\n'; exit 0 ;;
+    jq -nc '[{id:212,created_at:"2026-01-01T00:00:00Z",user:{login:"lhpaul"},body:"@codex review (review triggered by workflow runner, commit: 999999999999)"}]'
+    exit 0 ;;
   *"pulls/"*"/reviews"*)
     jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"9999999999999999999999999999999999999999",state:"CHANGES_REQUESTED",user:{login:"chatgpt-codex-connector[bot]"},body:"Codex Review: stale finding self-marked addressed."}]'
     exit 0 ;;
@@ -4457,6 +4458,49 @@ run_test "codex_addressed_changes_requested_no_fast_path" "yes" \
   "$(if grep -Fq "only cleared thread findings; posting a fresh trigger" "$_codex_addressed_changes_requested_mock_dir/output.txt"; then printf yes; else printf no; fi)"
 rm -rf "$_codex_addressed_changes_requested_mock_dir"
 unset _codex_addressed_changes_requested_mock_dir _codex_addressed_changes_requested_exit
+
+_codex_cleared_thread_top_level_blocker_mock_dir="$(mktemp -d)"
+cat > "$_codex_cleared_thread_top_level_blocker_mock_dir/gh" <<'CODEX_CLEARED_THREAD_TOP_LEVEL_BLOCKER_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf '8888888888888888888888888888888888888888\n'; exit 0 ;;
+  *"api graphql"*)
+    printf '{"data":{"repository":{"pullRequest":{"headRef":{"target":{"committedDate":"2026-01-01T00:00:00Z"}},"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"isResolved":true,"isOutdated":false,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"body":"Resolved inline finding"}]},"lastComment":{"nodes":[{"author":{"login":"lhpaul"},"createdAt":"2026-01-01T00:00:01Z"}]}}]}}}}}\n'
+    exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":113,"created_at":"2026-01-01T00:00:10Z"}\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"8888888888888888888888888888888888888888",state:"COMMENTED",user:{login:"chatgpt-codex-connector[bot]"},body:"Blocking issues: top-level problem not represented by an inline thread."}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_CLEARED_THREAD_TOP_LEVEL_BLOCKER_GH
+chmod +x "$_codex_cleared_thread_top_level_blocker_mock_dir/gh"
+: > "$_codex_cleared_thread_top_level_blocker_mock_dir/posts.log"
+_codex_cleared_thread_top_level_blocker_exit=0
+MOCK_POST_LOG="$_codex_cleared_thread_top_level_blocker_mock_dir/posts.log" PATH="$_codex_cleared_thread_top_level_blocker_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 1 --max-retriggers 0 \
+  >"$_codex_cleared_thread_top_level_blocker_mock_dir/output.txt" 2>&1 || _codex_cleared_thread_top_level_blocker_exit=$?
+run_test "codex_cleared_thread_top_level_blocker_exit_needs_revision" "1" "$_codex_cleared_thread_top_level_blocker_exit"
+run_test "codex_cleared_thread_top_level_blocker_skips_trigger" "0" \
+  "$(wc -l < "$_codex_cleared_thread_top_level_blocker_mock_dir/posts.log" | tr -d ' ')"
+run_test "codex_cleared_thread_top_level_blocker_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(grep "^VERDICT:" "$_codex_cleared_thread_top_level_blocker_mock_dir/output.txt")"
+rm -rf "$_codex_cleared_thread_top_level_blocker_mock_dir"
+unset _codex_cleared_thread_top_level_blocker_mock_dir _codex_cleared_thread_top_level_blocker_exit
 
 _codex_pre_trigger_head_changed_mock_dir="$(mktemp -d)"
 cat > "$_codex_pre_trigger_head_changed_mock_dir/gh" <<'CODEX_PRE_TRIGGER_HEAD_CHANGED_GH'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4150,6 +4150,52 @@ run_test "codex_pre_trigger_wait_normalizes_leading_zero" "INFO: Pre-trigger wai
 rm -rf "$_codex_existing_clean_mock_dir"
 unset _codex_existing_clean_mock_dir _codex_existing_clean_output _codex_existing_clean_exit
 
+_codex_existing_fetch_failure_mock_dir="$(mktemp -d)"
+cat > "$_codex_existing_fetch_failure_mock_dir/gh" <<'CODEX_EXISTING_FETCH_FAILURE_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'abcfetchfail1234567890\n'; exit 0 ;;
+  *"api graphql"*)
+    printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n'
+    exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":105,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf 'api unavailable\n' >&2
+    exit 1 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_EXISTING_FETCH_FAILURE_GH
+chmod +x "$_codex_existing_fetch_failure_mock_dir/gh"
+: > "$_codex_existing_fetch_failure_mock_dir/posts.log"
+_codex_existing_fetch_failure_output=""
+_codex_existing_fetch_failure_exit=0
+MOCK_POST_LOG="$_codex_existing_fetch_failure_mock_dir/posts.log" PATH="$_codex_existing_fetch_failure_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 1 --max-retriggers 0 \
+  >"$_codex_existing_fetch_failure_mock_dir/output.txt" 2>&1 || _codex_existing_fetch_failure_exit=$?
+_codex_existing_fetch_failure_output="$(cat "$_codex_existing_fetch_failure_mock_dir/output.txt")"
+run_test "codex_existing_fetch_failure_exit_unavailable" "2" "$_codex_existing_fetch_failure_exit"
+run_test "codex_existing_fetch_failure_verdict" \
+  "VERDICT: TIMED_OUT — could not fetch existing Codex evidence before trigger (treated as unavailable)" \
+  "$(printf '%s\n' "$_codex_existing_fetch_failure_output" | grep "^VERDICT:")"
+run_test "codex_existing_fetch_failure_skips_trigger" "0" \
+  "$(wc -l < "$_codex_existing_fetch_failure_mock_dir/posts.log" | tr -d ' ')"
+rm -rf "$_codex_existing_fetch_failure_mock_dir"
+unset _codex_existing_fetch_failure_mock_dir _codex_existing_fetch_failure_output _codex_existing_fetch_failure_exit
+
 _codex_stale_existing_mock_dir="$(mktemp -d)"
 cat > "$_codex_stale_existing_mock_dir/gh" <<'CODEX_STALE_EXISTING_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4326,6 +4326,107 @@ run_test "codex_provisional_reply_skips_trigger" "0" \
 rm -rf "$_codex_provisional_reply_mock_dir"
 unset _codex_provisional_reply_mock_dir _codex_provisional_reply_exit
 
+_codex_provisional_changes_requested_mock_dir="$(mktemp -d)"
+cat > "$_codex_provisional_changes_requested_mock_dir/gh" <<'CODEX_PROVISIONAL_CHANGES_REQUESTED_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'cccccccccccccccccccccccccccccccccccccccc\n'; exit 0 ;;
+  *"api graphql"*)
+    printf '{"data":{"repository":{"pullRequest":{"headRef":{"target":{"committedDate":"2026-01-01T00:00:00Z"}},"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"isResolved":false,"isOutdated":false,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"}}]},"lastComment":{"nodes":[{"author":{"login":"lhpaul"},"createdAt":"2026-01-01T00:00:01Z"}]}}]}}}}}\n'
+    exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":109,"created_at":"2026-01-01T00:00:10Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"cccccccccccccccccccccccccccccccccccccccc",state:"CHANGES_REQUESTED",user:{login:"chatgpt-codex-connector[bot]"},body:"Codex Review: stale finding replied to after head commit."}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_PROVISIONAL_CHANGES_REQUESTED_GH
+chmod +x "$_codex_provisional_changes_requested_mock_dir/gh"
+: > "$_codex_provisional_changes_requested_mock_dir/posts.log"
+_codex_provisional_changes_requested_exit=0
+MOCK_POST_LOG="$_codex_provisional_changes_requested_mock_dir/posts.log" PATH="$_codex_provisional_changes_requested_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 1 --max-retriggers 0 \
+  >"$_codex_provisional_changes_requested_mock_dir/output.txt" 2>&1 || _codex_provisional_changes_requested_exit=$?
+run_test "codex_provisional_changes_requested_posts_trigger" "1" \
+  "$(wc -l < "$_codex_provisional_changes_requested_mock_dir/posts.log" | tr -d ' ')"
+run_test "codex_provisional_changes_requested_no_fast_path" "yes" \
+  "$(if grep -Fq "only provisionally cleared thread findings; posting a fresh trigger" "$_codex_provisional_changes_requested_mock_dir/output.txt"; then printf yes; else printf no; fi)"
+rm -rf "$_codex_provisional_changes_requested_mock_dir"
+unset _codex_provisional_changes_requested_mock_dir _codex_provisional_changes_requested_exit
+
+_codex_pre_trigger_head_changed_mock_dir="$(mktemp -d)"
+cat > "$_codex_pre_trigger_head_changed_mock_dir/gh" <<'CODEX_PRE_TRIGGER_HEAD_CHANGED_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+counter_file="$MOCK_PR_VIEW_COUNTER"
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    count=0
+    if [ -f "$counter_file" ]; then
+      count="$(cat "$counter_file")"
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$counter_file"
+    if [ "$count" -eq 1 ]; then
+      printf 'dddddddddddddddddddddddddddddddddddddddd\n'
+    else
+      printf 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\n'
+    fi
+    exit 0 ;;
+  *"api graphql"*)
+    printf '{"data":{"repository":{"pullRequest":{"headRef":{"target":{"committedDate":"2026-01-01T00:00:00Z"}},"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}\n'
+    exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":110,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    printf '[]\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_PRE_TRIGGER_HEAD_CHANGED_GH
+chmod +x "$_codex_pre_trigger_head_changed_mock_dir/gh"
+: > "$_codex_pre_trigger_head_changed_mock_dir/posts.log"
+: > "$_codex_pre_trigger_head_changed_mock_dir/pr-view-count"
+_codex_pre_trigger_head_changed_exit=0
+MOCK_POST_LOG="$_codex_pre_trigger_head_changed_mock_dir/posts.log" \
+  MOCK_PR_VIEW_COUNTER="$_codex_pre_trigger_head_changed_mock_dir/pr-view-count" \
+  PATH="$_codex_pre_trigger_head_changed_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 1 --max-retriggers 0 \
+  >"$_codex_pre_trigger_head_changed_mock_dir/output.txt" 2>&1 || _codex_pre_trigger_head_changed_exit=$?
+run_test "codex_pre_trigger_head_changed_exit_unavailable" "2" "$_codex_pre_trigger_head_changed_exit"
+run_test "codex_pre_trigger_head_changed_skips_trigger" "0" \
+  "$(wc -l < "$_codex_pre_trigger_head_changed_mock_dir/posts.log" | tr -d ' ')"
+run_test "codex_pre_trigger_head_changed_reason" "REASON=codex-github-head-changed" \
+  "$(grep "^REASON=" "$_codex_pre_trigger_head_changed_mock_dir/output.txt")"
+rm -rf "$_codex_pre_trigger_head_changed_mock_dir"
+unset _codex_pre_trigger_head_changed_mock_dir _codex_pre_trigger_head_changed_exit
+
 _codex_paginated_thread_mock_dir="$(mktemp -d)"
 cat > "$_codex_paginated_thread_mock_dir/gh" <<'CODEX_PAGINATED_THREAD_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4414,6 +4414,50 @@ run_test "codex_resolved_changes_requested_no_fast_path" "yes" \
 rm -rf "$_codex_resolved_changes_requested_mock_dir"
 unset _codex_resolved_changes_requested_mock_dir _codex_resolved_changes_requested_exit
 
+_codex_addressed_changes_requested_mock_dir="$(mktemp -d)"
+cat > "$_codex_addressed_changes_requested_mock_dir/gh" <<'CODEX_ADDRESSED_CHANGES_REQUESTED_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf '9999999999999999999999999999999999999999\n'; exit 0 ;;
+  *"api graphql"*)
+    printf '{"data":{"repository":{"pullRequest":{"headRef":{"target":{"committedDate":"2026-01-01T00:00:00Z"}},"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"isResolved":false,"isOutdated":false,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"body":"✅ Addressed in latest commit"}]},"lastComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"createdAt":"2026-01-01T00:00:01Z"}]}}]}}}}}\n'
+    exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":112,"created_at":"2026-01-01T00:00:10Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"9999999999999999999999999999999999999999",state:"CHANGES_REQUESTED",user:{login:"chatgpt-codex-connector[bot]"},body:"Codex Review: stale finding self-marked addressed."}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_ADDRESSED_CHANGES_REQUESTED_GH
+chmod +x "$_codex_addressed_changes_requested_mock_dir/gh"
+: > "$_codex_addressed_changes_requested_mock_dir/posts.log"
+_codex_addressed_changes_requested_exit=0
+MOCK_POST_LOG="$_codex_addressed_changes_requested_mock_dir/posts.log" PATH="$_codex_addressed_changes_requested_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 1 --max-retriggers 0 \
+  >"$_codex_addressed_changes_requested_mock_dir/output.txt" 2>&1 || _codex_addressed_changes_requested_exit=$?
+run_test "codex_addressed_changes_requested_posts_trigger" "1" \
+  "$(wc -l < "$_codex_addressed_changes_requested_mock_dir/posts.log" | tr -d ' ')"
+run_test "codex_addressed_changes_requested_no_fast_path" "yes" \
+  "$(if grep -Fq "only cleared thread findings; posting a fresh trigger" "$_codex_addressed_changes_requested_mock_dir/output.txt"; then printf yes; else printf no; fi)"
+rm -rf "$_codex_addressed_changes_requested_mock_dir"
+unset _codex_addressed_changes_requested_mock_dir _codex_addressed_changes_requested_exit
+
 _codex_pre_trigger_head_changed_mock_dir="$(mktemp -d)"
 cat > "$_codex_pre_trigger_head_changed_mock_dir/gh" <<'CODEX_PRE_TRIGGER_HEAD_CHANGED_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -932,6 +932,9 @@ else
 fi
 run_test "codex_github_defaults_ignore_telemetry_only_platform" "no" "$_codex_defaults_apply_telemetry"
 
+run_test "codex_github_pre_trigger_wait_forwarded" "yes" \
+  "$(if grep -q -- '--pre-trigger-wait "$pre_trigger_wait"' "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"; then printf yes; else printf no; fi)"
+
 platforms=()
 phase_after_clean_platforms=()
 unset CODEX_GITHUB_MAX_WAIT CODEX_GITHUB_POLL_INTERVAL _codex_timeout_output _codex_poll_output _codex_defaults_apply_active _codex_defaults_apply_telemetry
@@ -4107,6 +4110,9 @@ case "$*" in
     exit 0 ;;
   *"pr view"*headRefOid*)
     printf 'abcef1234567890abcde\n'; exit 0 ;;
+  *"api graphql"*)
+    printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":true,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"chatgpt-codex-connector"}}]}}]}}}}}\n'
+    exit 0 ;;
   *"--method POST"*)
     printf 'POST\n' >> "$log"
     printf '{"id":102,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
@@ -4153,6 +4159,9 @@ case "$*" in
     exit 0 ;;
   *"pr view"*headRefOid*)
     printf 'abcnewhead1234567890\n'; exit 0 ;;
+  *"api graphql"*)
+    printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n'
+    exit 0 ;;
   *"--method POST"*)
     printf 'POST\n' >> "$log"
     printf '{"id":104,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4348,7 +4348,7 @@ case "$*" in
   *"issues/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/reviews"*)
-    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"cccccccccccccccccccccccccccccccccccccccc",state:"CHANGES_REQUESTED",user:{login:"chatgpt-codex-connector[bot]"},body:"Codex Review: stale finding replied to after head commit."}]'
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"cccccccccccccccccccccccccccccccccccccccc",state:"COMMENTED",user:{login:"chatgpt-codex-connector[bot]"},body:"### 💡 Codex Review\n\nHere are some automated review suggestions for this pull request.\n\n**Reviewed commit:** `cccccccccccc`"}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
@@ -4366,7 +4366,7 @@ MOCK_POST_LOG="$_codex_provisional_changes_requested_mock_dir/posts.log" PATH="$
 run_test "codex_provisional_changes_requested_posts_trigger" "1" \
   "$(wc -l < "$_codex_provisional_changes_requested_mock_dir/posts.log" | tr -d ' ')"
 run_test "codex_provisional_changes_requested_no_fast_path" "yes" \
-  "$(if grep -Fq "only cleared thread findings; posting a fresh trigger" "$_codex_provisional_changes_requested_mock_dir/output.txt"; then printf yes; else printf no; fi)"
+  "$(if grep -Fq "inline-review summary has only cleared thread findings; posting a fresh trigger" "$_codex_provisional_changes_requested_mock_dir/output.txt"; then printf yes; else printf no; fi)"
 rm -rf "$_codex_provisional_changes_requested_mock_dir"
 unset _codex_provisional_changes_requested_mock_dir _codex_provisional_changes_requested_exit
 
@@ -4392,7 +4392,7 @@ case "$*" in
   *"issues/"*"/comments"*)
     printf '[]\n'; exit 0 ;;
   *"pulls/"*"/reviews"*)
-    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"ffffffffffffffffffffffffffffffffffffffff",state:"CHANGES_REQUESTED",user:{login:"chatgpt-codex-connector[bot]"},body:"Codex Review: stale finding resolved on the current head."}]'
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"ffffffffffffffffffffffffffffffffffffffff",state:"COMMENTED",user:{login:"chatgpt-codex-connector[bot]"},body:"### 💡 Codex Review\n\nHere are some automated review suggestions for this pull request.\n\n**Reviewed commit:** `ffffffffffff`"}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
@@ -4410,7 +4410,7 @@ MOCK_POST_LOG="$_codex_resolved_changes_requested_mock_dir/posts.log" PATH="$_co
 run_test "codex_resolved_changes_requested_posts_trigger" "1" \
   "$(wc -l < "$_codex_resolved_changes_requested_mock_dir/posts.log" | tr -d ' ')"
 run_test "codex_resolved_changes_requested_no_fast_path" "yes" \
-  "$(if grep -Fq "only cleared thread findings; posting a fresh trigger" "$_codex_resolved_changes_requested_mock_dir/output.txt"; then printf yes; else printf no; fi)"
+  "$(if grep -Fq "inline-review summary has only cleared thread findings; posting a fresh trigger" "$_codex_resolved_changes_requested_mock_dir/output.txt"; then printf yes; else printf no; fi)"
 rm -rf "$_codex_resolved_changes_requested_mock_dir"
 unset _codex_resolved_changes_requested_mock_dir _codex_resolved_changes_requested_exit
 
@@ -4437,7 +4437,7 @@ case "$*" in
     jq -nc '[{id:212,created_at:"2026-01-01T00:00:00Z",user:{login:"lhpaul"},body:"@codex review (review triggered by workflow runner, commit: 999999999999)"}]'
     exit 0 ;;
   *"pulls/"*"/reviews"*)
-    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"9999999999999999999999999999999999999999",state:"CHANGES_REQUESTED",user:{login:"chatgpt-codex-connector[bot]"},body:"Codex Review: stale finding self-marked addressed."}]'
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"9999999999999999999999999999999999999999",state:"COMMENTED",user:{login:"chatgpt-codex-connector[bot]"},body:"### 💡 Codex Review\n\nHere are some automated review suggestions for this pull request.\n\n**Reviewed commit:** `999999999999`"}]'
     exit 0 ;;
   *)
     printf 'ERROR=unexpected-gh-invocation\n' >&2
@@ -4455,7 +4455,7 @@ MOCK_POST_LOG="$_codex_addressed_changes_requested_mock_dir/posts.log" PATH="$_c
 run_test "codex_addressed_changes_requested_posts_trigger" "1" \
   "$(wc -l < "$_codex_addressed_changes_requested_mock_dir/posts.log" | tr -d ' ')"
 run_test "codex_addressed_changes_requested_no_fast_path" "yes" \
-  "$(if grep -Fq "only cleared thread findings; posting a fresh trigger" "$_codex_addressed_changes_requested_mock_dir/output.txt"; then printf yes; else printf no; fi)"
+  "$(if grep -Fq "inline-review summary has only cleared thread findings; posting a fresh trigger" "$_codex_addressed_changes_requested_mock_dir/output.txt"; then printf yes; else printf no; fi)"
 rm -rf "$_codex_addressed_changes_requested_mock_dir"
 unset _codex_addressed_changes_requested_mock_dir _codex_addressed_changes_requested_exit
 
@@ -4501,6 +4501,49 @@ run_test "codex_cleared_thread_top_level_blocker_verdict" "VERDICT: NEEDS_REVISI
   "$(grep "^VERDICT:" "$_codex_cleared_thread_top_level_blocker_mock_dir/output.txt")"
 rm -rf "$_codex_cleared_thread_top_level_blocker_mock_dir"
 unset _codex_cleared_thread_top_level_blocker_mock_dir _codex_cleared_thread_top_level_blocker_exit
+
+_codex_cleared_thread_changes_requested_state_mock_dir="$(mktemp -d)"
+cat > "$_codex_cleared_thread_changes_requested_state_mock_dir/gh" <<'CODEX_CLEARED_THREAD_CHANGES_REQUESTED_STATE_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf '7777777777777777777777777777777777777777\n'; exit 0 ;;
+  *"api graphql"*)
+    printf '{"data":{"repository":{"pullRequest":{"headRef":{"target":{"committedDate":"2026-01-01T00:00:00Z"}},"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"isResolved":true,"isOutdated":false,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"body":"Resolved inline finding"}]},"lastComment":{"nodes":[{"author":{"login":"lhpaul"},"createdAt":"2026-01-01T00:00:01Z"}]}}]}}}}}\n'
+    exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":114,"created_at":"2026-01-01T00:00:10Z"}\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"7777777777777777777777777777777777777777",state:"CHANGES_REQUESTED",user:{login:"chatgpt-codex-connector[bot]"},body:"### 💡 Codex Review\n\nHere are some automated review suggestions for this pull request.\n\n**Reviewed commit:** `777777777777`"}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_CLEARED_THREAD_CHANGES_REQUESTED_STATE_GH
+chmod +x "$_codex_cleared_thread_changes_requested_state_mock_dir/gh"
+: > "$_codex_cleared_thread_changes_requested_state_mock_dir/posts.log"
+_codex_cleared_thread_changes_requested_state_exit=0
+MOCK_POST_LOG="$_codex_cleared_thread_changes_requested_state_mock_dir/posts.log" PATH="$_codex_cleared_thread_changes_requested_state_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 1 --max-retriggers 0 \
+  >"$_codex_cleared_thread_changes_requested_state_mock_dir/output.txt" 2>&1 || _codex_cleared_thread_changes_requested_state_exit=$?
+run_test "codex_cleared_thread_changes_requested_state_exit_needs_revision" "1" "$_codex_cleared_thread_changes_requested_state_exit"
+run_test "codex_cleared_thread_changes_requested_state_skips_trigger" "0" \
+  "$(wc -l < "$_codex_cleared_thread_changes_requested_state_mock_dir/posts.log" | tr -d ' ')"
+run_test "codex_cleared_thread_changes_requested_state_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(grep "^VERDICT:" "$_codex_cleared_thread_changes_requested_state_mock_dir/output.txt")"
+rm -rf "$_codex_cleared_thread_changes_requested_state_mock_dir"
+unset _codex_cleared_thread_changes_requested_state_mock_dir _codex_cleared_thread_changes_requested_state_exit
 
 _codex_pre_trigger_head_changed_mock_dir="$(mktemp -d)"
 cat > "$_codex_pre_trigger_head_changed_mock_dir/gh" <<'CODEX_PRE_TRIGGER_HEAD_CHANGED_GH'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4366,9 +4366,53 @@ MOCK_POST_LOG="$_codex_provisional_changes_requested_mock_dir/posts.log" PATH="$
 run_test "codex_provisional_changes_requested_posts_trigger" "1" \
   "$(wc -l < "$_codex_provisional_changes_requested_mock_dir/posts.log" | tr -d ' ')"
 run_test "codex_provisional_changes_requested_no_fast_path" "yes" \
-  "$(if grep -Fq "only provisionally cleared thread findings; posting a fresh trigger" "$_codex_provisional_changes_requested_mock_dir/output.txt"; then printf yes; else printf no; fi)"
+  "$(if grep -Fq "only cleared thread findings; posting a fresh trigger" "$_codex_provisional_changes_requested_mock_dir/output.txt"; then printf yes; else printf no; fi)"
 rm -rf "$_codex_provisional_changes_requested_mock_dir"
 unset _codex_provisional_changes_requested_mock_dir _codex_provisional_changes_requested_exit
+
+_codex_resolved_changes_requested_mock_dir="$(mktemp -d)"
+cat > "$_codex_resolved_changes_requested_mock_dir/gh" <<'CODEX_RESOLVED_CHANGES_REQUESTED_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf 'ffffffffffffffffffffffffffffffffffffffff\n'; exit 0 ;;
+  *"api graphql"*)
+    printf '{"data":{"repository":{"pullRequest":{"headRef":{"target":{"committedDate":"2026-01-01T00:00:00Z"}},"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"isResolved":true,"isOutdated":false,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"}}]},"lastComment":{"nodes":[{"author":{"login":"lhpaul"},"createdAt":"2026-01-01T00:00:01Z"}]}}]}}}}}\n'
+    exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":111,"created_at":"2026-01-01T00:00:10Z"}\n'; exit 0 ;;
+  *"issues/comments/"*"/reactions"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*)
+    jq -nc '[{submitted_at:"2026-01-01T00:00:01Z",commit_id:"ffffffffffffffffffffffffffffffffffffffff",state:"CHANGES_REQUESTED",user:{login:"chatgpt-codex-connector[bot]"},body:"Codex Review: stale finding resolved on the current head."}]'
+    exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_RESOLVED_CHANGES_REQUESTED_GH
+chmod +x "$_codex_resolved_changes_requested_mock_dir/gh"
+: > "$_codex_resolved_changes_requested_mock_dir/posts.log"
+_codex_resolved_changes_requested_exit=0
+MOCK_POST_LOG="$_codex_resolved_changes_requested_mock_dir/posts.log" PATH="$_codex_resolved_changes_requested_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 1 --max-retriggers 0 \
+  >"$_codex_resolved_changes_requested_mock_dir/output.txt" 2>&1 || _codex_resolved_changes_requested_exit=$?
+run_test "codex_resolved_changes_requested_posts_trigger" "1" \
+  "$(wc -l < "$_codex_resolved_changes_requested_mock_dir/posts.log" | tr -d ' ')"
+run_test "codex_resolved_changes_requested_no_fast_path" "yes" \
+  "$(if grep -Fq "only cleared thread findings; posting a fresh trigger" "$_codex_resolved_changes_requested_mock_dir/output.txt"; then printf yes; else printf no; fi)"
+rm -rf "$_codex_resolved_changes_requested_mock_dir"
+unset _codex_resolved_changes_requested_mock_dir _codex_resolved_changes_requested_exit
 
 _codex_pre_trigger_head_changed_mock_dir="$(mktemp -d)"
 cat > "$_codex_pre_trigger_head_changed_mock_dir/gh" <<'CODEX_PRE_TRIGGER_HEAD_CHANGED_GH'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4326,6 +4326,44 @@ run_test "codex_provisional_reply_skips_trigger" "0" \
 rm -rf "$_codex_provisional_reply_mock_dir"
 unset _codex_provisional_reply_mock_dir _codex_provisional_reply_exit
 
+_codex_provisional_missing_author_mock_dir="$(mktemp -d)"
+cat > "$_codex_provisional_missing_author_mock_dir/gh" <<'CODEX_PROVISIONAL_MISSING_AUTHOR_GH'
+#!/usr/bin/env bash
+log="$MOCK_POST_LOG"
+case "$*" in
+  *"auth status"*)
+    exit 0 ;;
+  *"pr view"*headRefOid*)
+    printf '1212121212121212121212121212121212121212\n'; exit 0 ;;
+  *"api graphql"*)
+    printf '{"data":{"repository":{"pullRequest":{"headRef":{"target":{"committedDate":"2026-01-01T00:00:00Z"}},"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"isResolved":false,"isOutdated":false,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"body":"Blocking issue"}]},"lastComment":{"nodes":[{"author":null,"createdAt":"2026-01-01T00:00:01Z"}]}}]}}}}}\n'
+    exit 0 ;;
+  *"--method POST"*)
+    printf 'POST\n' >> "$log"
+    printf '{"id":115,"created_at":"2026-01-01T00:00:00Z"}\n'; exit 0 ;;
+  *)
+    printf 'ERROR=unexpected-gh-invocation\n' >&2
+    printf 'ARGS=%q\n' "$*" >&2
+    exit 64 ;;
+esac
+CODEX_PROVISIONAL_MISSING_AUTHOR_GH
+chmod +x "$_codex_provisional_missing_author_mock_dir/gh"
+: > "$_codex_provisional_missing_author_mock_dir/posts.log"
+_codex_provisional_missing_author_output=""
+_codex_provisional_missing_author_exit=0
+MOCK_POST_LOG="$_codex_provisional_missing_author_mock_dir/posts.log" PATH="$_codex_provisional_missing_author_mock_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 1 --max-retriggers 0 \
+  >"$_codex_provisional_missing_author_mock_dir/output.txt" 2>&1 || _codex_provisional_missing_author_exit=$?
+_codex_provisional_missing_author_output="$(cat "$_codex_provisional_missing_author_mock_dir/output.txt")"
+run_test "codex_provisional_missing_author_exit_needs_revision" "1" "$_codex_provisional_missing_author_exit"
+run_test "codex_provisional_missing_author_verdict" "VERDICT: NEEDS_REVISION" \
+  "$(printf '%s\n' "$_codex_provisional_missing_author_output" | grep "^VERDICT:")"
+run_test "codex_provisional_missing_author_skips_trigger" "0" \
+  "$(wc -l < "$_codex_provisional_missing_author_mock_dir/posts.log" | tr -d ' ')"
+rm -rf "$_codex_provisional_missing_author_mock_dir"
+unset _codex_provisional_missing_author_mock_dir _codex_provisional_missing_author_output _codex_provisional_missing_author_exit
+
 _codex_provisional_changes_requested_mock_dir="$(mktemp -d)"
 cat > "$_codex_provisional_changes_requested_mock_dir/gh" <<'CODEX_PROVISIONAL_CHANGES_REQUESTED_GH'
 #!/usr/bin/env bash

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4129,7 +4129,7 @@ _codex_existing_clean_output=""
 _codex_existing_clean_exit=0
 MOCK_POST_LOG="$_codex_existing_clean_mock_dir/posts.log" PATH="$_codex_existing_clean_mock_dir:$PATH" \
   "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
-  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 1 --max-retriggers 0 \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 08 --max-retriggers 0 \
   >"$_codex_existing_clean_mock_dir/output.txt" 2>&1 || _codex_existing_clean_exit=$?
 _codex_existing_clean_output="$(cat "$_codex_existing_clean_mock_dir/output.txt")"
 run_test "codex_existing_current_head_review_exit_clean" "0" "$_codex_existing_clean_exit"
@@ -4139,6 +4139,8 @@ run_test "codex_existing_current_head_review_skips_trigger" "0" \
   "$(wc -l < "$_codex_existing_clean_mock_dir/posts.log" | tr -d ' ')"
 run_test "codex_existing_current_head_review_logs_no_trigger" "yes" \
   "$(if grep -Fq "existing current-head Codex evidence detected; no trigger comment will be posted" "$_codex_existing_clean_mock_dir/output.txt"; then printf yes; else printf no; fi)"
+run_test "codex_pre_trigger_wait_normalizes_leading_zero" "INFO: Pre-trigger wait: 8s" \
+  "$(grep "^INFO: Pre-trigger wait:" "$_codex_existing_clean_mock_dir/output.txt")"
 rm -rf "$_codex_existing_clean_mock_dir"
 unset _codex_existing_clean_mock_dir _codex_existing_clean_output _codex_existing_clean_exit
 

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -4653,6 +4653,11 @@ case "$*" in
     printf '{"data":{"repository":{"pullRequest":{"headRef":{"target":{"committedDate":"2026-01-01T00:00:00Z"}},"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"isResolved":false,"isOutdated":false,"firstComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"}}]},"lastComment":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"createdAt":"2026-01-01T00:00:01Z"}]}}]}}}}}\n'
     exit 0 ;;
   *"api graphql"*)
+    case " $* " in
+      *" -f cursor="*)
+        printf 'ERROR=first-page-cursor-sent\n' >&2
+        exit 65 ;;
+    esac
     printf '{"data":{"repository":{"pullRequest":{"headRef":{"target":{"committedDate":"2026-01-01T00:00:00Z"}},"reviewThreads":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor1"},"nodes":[]}}}}}\n'
     exit 0 ;;
   *"--method POST"*)


### PR DESCRIPTION
## Summary
- add a pre-trigger current-head Codex evidence scan before posting `@codex review`
- accept only current-head submitted reviews, SHA-pinned root comments, or current-head inline review comments; stale evidence still falls through to the normal trigger path
- document `CODEX_GITHUB_PRE_TRIGGER_WAIT` / `--pre-trigger-wait` and add harness coverage

## Verification
- `bash -n scripts/development-workflow/codex-github-reviewer.sh`
- `bash -n scripts/development-workflow/tests/test-pr-review-loop.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 13` (372 passed, 0 failed)
- `npx markdownlint-cli2 docs/workflow/development-workflow/integrations/codex-github.md CHANGELOG.md`
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop`
- `git diff --check`

Closes #1601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable waiting before initiating a Codex review through environment and command-line options.
  - Detects valid current-commit review results and avoids duplicate review triggers.
  - Ignores outdated, resolved, dismissed, or mismatched review evidence.
  - Requires exact commit matching for review evidence.

- **Documentation**
  - Added configuration and behavior details to the workflow documentation and changelog.

- **Tests**
  - Added coverage for approvals, stale evidence, commit changes, pagination, failures, and wait-option handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR review gating defaults and Codex evidence matching (full SHA, thread pagination); mistakes could skip triggers or accept stale evidence, though behavior is heavily covered by new harness tests.
> 
> **Overview**
> **Codex GitHub reviewer** now waits up to **`CODEX_GITHUB_PRE_TRIGGER_WAIT`** (default 60s, **`--pre-trigger-wait`**, `0` disables) for **current-head** Codex evidence—submitted reviews with **exact** `commit_id`, SHA-pinned root comments, or unresolved inline threads—before posting `@codex review`. When valid evidence exists it classifies the verdict without a duplicate trigger; stale heads, prefix-only SHA matches, and “cleared thread only” inline summaries can still force a fresh trigger.
> 
> **`pr-review-loop.sh`** forwards **`--pre-trigger-wait`** / env into **`codex-github-reviewer.sh`**.
> 
> **Repo workflow defaults:** ready-phase GitHub reviewer moves from **`codex-github`** to **`bugbot`** in **`.ai-dev-workflow.yaml`**; **`.coderabbit.yaml`** turns **`auto_review`** off so CodeRabbit is manual/opt-in. Docs and **CHANGELOG** (#1601) updated; **Area 13** tests cover the new pre-trigger paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc889fab39acc38bb5dbaf0ece8e5d11ab8017d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->