### PR TITLE
Feat: add repo-native local AI reviewer

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -61,8 +61,8 @@ review:
     # Ordered list of GitHub/App/CLI reviewers that can safely evaluate draft
     # PRs. These run before the PR is converted to ready.
     # Supported today by pr-review-loop.sh: greptile, devin, coderabbit,
-    # coderabbit-cli, pr-agent, codex-github, claude-code-action, haystack,
-    # copilot, bugbot.
+    # coderabbit-cli, local-ai-reviewer, pr-agent, codex-github,
+    # claude-code-action, haystack, copilot, bugbot.
     github:
       - pr-agent
 
@@ -117,6 +117,16 @@ review:
   # in on_draft.github or on_ready.github to opt in; independent from the
   # "coderabbit" GitHub App platform):
   #   rate_limit_policy: warn      # warn|strict; default warn
+  #
+  # Local AI reviewer platform options (local-only CLI reviewer; place
+  # "local-ai-reviewer" in on_draft.github to opt in before ready-phase
+  # reviewers):
+  #   LOCAL_AI_REVIEWER_COMMAND        — command run under sh -c with
+  #                                      CONTEXT_BUNDLE_PATH and PR metadata env
+  #   LOCAL_AI_REVIEWER_TIMEOUT        — default local command timeout
+  #   LOCAL_AI_REVIEWER_GRAPH_STRATEGY — none|auto|code-review-graph|graphify
+  #   LOCAL_AI_REVIEWER_DISABLED=1     — intentionally skip with
+  #                                      REASON=disabled_by_config
   #
   # Configurable codex-github options (set via env vars or script flags to pr-review-loop.sh / codex-github-reviewer.sh):
   #   Setup/verification guide: docs/workflow/development-workflow/integrations/codex-github.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Repo-native local AI reviewer platform** (#1604): adds an opt-in
+  `local-ai-reviewer` Step 7 platform with a local companion script,
+  conservative result parsing, current-head binding, optional graph-context
+  status, finding comparison fixtures, and integration docs so repositories can
+  run a local review pass before ready-phase reviewers such as Bugbot.
 - **Change-scoped CI test selection with a coverage-gap report** (#1537): adds
   `scripts/development-workflow/select-test-suites.sh`, which resolves the
   suites a change set requires from the repository itself — a `test-<name>.sh`

--- a/docs/testing/workflow/1604-repo-native-automated-pr-reviewer.smoke-test.md
+++ b/docs/testing/workflow/1604-repo-native-automated-pr-reviewer.smoke-test.md
@@ -3,7 +3,7 @@
 **Feature**: Add an opt-in local-only Step 7 review platform
 **Spec**: [1_1604-repo-native-automated-pr-reviewer_specs.md](../../specs/developments/20260825164644_1604-repo-native-automated-pr-reviewer/1_1604-repo-native-automated-pr-reviewer_specs.md)
 **Created in**: Plan Ready stage
-**Updated in**: Plan Ready stage
+**Updated in**: In Development stage
 
 ---
 
@@ -29,6 +29,7 @@ Before running this smoke test:
 | Draft-phase platform | `local-ai-reviewer` |
 | Current ready-phase platform | `bugbot` |
 | Mock command | A local script that emits clean, blocking, malformed, timeout, and advisory fixtures |
+| Focused automated tests | `test-local-ai-reviewer.sh`, `test-local-ai-reviewer-findings.py`, `test-local-ai-reviewer-pr-review-loop-dispatch.sh` |
 
 ---
 
@@ -49,6 +50,12 @@ Before running this smoke test:
 
 **Expected result**: The reviewer loop accepts the new platform without invoking Bugbot or another platform.
 
+**Automated fixture**:
+
+```bash
+bash scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh
+```
+
 ### Step 2: Confirm missing command escalates
 
 **Maps to**: Failure-state classification
@@ -58,6 +65,9 @@ Before running this smoke test:
 3. Confirm output includes `RESULT=escalate` and `REASON=missing_command`.
 
 **Expected result**: Missing local reviewer setup is unavailable evidence, not clean review evidence.
+
+**Automated fixture**: `missing_command_result` in
+`scripts/development-workflow/tests/test-local-ai-reviewer.sh`.
 
 ### Step 3: Confirm clean and advisory-only mapping
 
@@ -71,6 +81,10 @@ Before running this smoke test:
 
 **Expected result**: Advisory-only feedback never emits raw `RESULT=advisory`.
 
+**Automated fixtures**: `clean_result`, `advisory_result`,
+`clear_in_scope_suggestion_result`, and `important_result` in
+`scripts/development-workflow/tests/test-local-ai-reviewer.sh`.
+
 ### Step 4: Confirm blocking mapping
 
 **Maps to**: Result Wire Contract
@@ -81,6 +95,9 @@ Before running this smoke test:
 
 **Expected result**: Blocking local findings stop the loop for fixes.
 
+**Automated fixture**: `clear_in_scope_suggestion_blocking` in
+`scripts/development-workflow/tests/test-local-ai-reviewer.sh`.
+
 ### Step 5: Confirm head mismatch escalates
 
 **Maps to**: Current-head binding
@@ -90,6 +107,9 @@ Before running this smoke test:
 3. Confirm output includes `RESULT=escalate` and `REASON=head_mismatch`.
 
 **Expected result**: The local reviewer never reports clean evidence for a stale or wrong head.
+
+**Automated fixture**: `head_mismatch_result` in
+`scripts/development-workflow/tests/test-local-ai-reviewer.sh`.
 
 ### Step 6: Confirm malformed and timeout behavior
 
@@ -102,6 +122,9 @@ Before running this smoke test:
 
 **Expected result**: Unsafe output and timeout fail closed.
 
+**Automated fixtures**: `malformed_result` and `timeout_result` in
+`scripts/development-workflow/tests/test-local-ai-reviewer.sh`.
+
 ### Step 7: Confirm optional graph context behavior
 
 **Maps to**: Graph Context Adoption Criteria
@@ -113,6 +136,9 @@ Before running this smoke test:
    extra context, noise, and runtime.
 
 **Expected result**: Missing optional graph tooling does not block local review.
+
+**Automated fixture**: `graph_skipped_result` in
+`scripts/development-workflow/tests/test-local-ai-reviewer.sh`.
 
 ### Step 8: Confirm ready-phase Bugbot remains separate
 
@@ -134,6 +160,12 @@ Before running this smoke test:
 4. Confirm one local finding cannot consume multiple ready-phase findings.
 
 **Expected result**: The matcher is conservative and does not hide ready-phase findings.
+
+**Automated fixture**:
+
+```bash
+python3 scripts/development-workflow/tests/test-local-ai-reviewer-findings.py
+```
 
 ### Last Step: Validate & Shut Down
 

--- a/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
+++ b/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
@@ -32,6 +32,7 @@ missing local command is a setup failure and emits `RESULT=escalate`.
 
 Set the local command in the runner environment:
 
+<!-- workflow-shell-contract: bash-zsh -->
 ```bash
 export LOCAL_AI_REVIEWER_COMMAND='my-review-command "$CONTEXT_BUNDLE_PATH"'
 ```
@@ -123,6 +124,7 @@ Graph context is optional. The default strategy is no graph context.
 
 Set:
 
+<!-- workflow-shell-contract: bash-zsh -->
 ```bash
 export LOCAL_AI_REVIEWER_GRAPH_STRATEGY=auto
 ```

--- a/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
+++ b/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
@@ -1,0 +1,164 @@
+# Integration: Local AI Reviewer
+
+`local-ai-reviewer` is an optional Step 7 review platform for running a
+repository-local review command before ready-phase reviewers such as Bugbot.
+It is implemented by `scripts/development-workflow/local-ai-reviewer.sh` and
+is consumed by `scripts/development-workflow/pr-review-loop.sh`.
+
+The platform is local-only. It does not post GitHub inline comments in this
+MVP, and a local clean result does not replace human review, CI, unresolved
+thread checks, or the configured ready-phase reviewer.
+
+---
+
+## Configuration
+
+Enable it explicitly in `.ai-dev-workflow.yaml` or in
+`.ai-dev-workflow.local.yaml`:
+
+```yaml
+review:
+  on_draft:
+    github:
+      - local-ai-reviewer
+      - pr-agent
+  on_ready:
+    github:
+      - bugbot
+```
+
+The shared template does not enable `local-ai-reviewer` by default because a
+missing local command is a setup failure and emits `RESULT=escalate`.
+
+Set the local command in the runner environment:
+
+```bash
+export LOCAL_AI_REVIEWER_COMMAND='my-review-command "$CONTEXT_BUNDLE_PATH"'
+```
+
+The command runs under `sh -c` with these environment variables:
+
+- `CONTEXT_BUNDLE_PATH`
+- `PR_NUMBER`
+- `OWNER`
+- `REPO`
+- `BASE_BRANCH`
+- `HEAD_BRANCH`
+- `REVIEWED_HEAD`
+
+Use `LOCAL_AI_REVIEWER_DISABLED=1` to intentionally skip the local platform
+with `RESULT=skipped` and `REASON=disabled_by_config`.
+
+---
+
+## Command Output
+
+The local command must emit JSON on stdout. It may either emit an explicit
+terminal result:
+
+```json
+{
+  "result": "clean",
+  "reviewed_head": "abc123",
+  "findings": []
+}
+```
+
+or emit findings and let the companion script infer the terminal result:
+
+```json
+{
+  "findings": [
+    {
+      "severity": "important",
+      "path": "scripts/example.sh",
+      "line": 42,
+      "message": "Missing test coverage for this branch."
+    }
+  ]
+}
+```
+
+Accepted raw result values are:
+
+- `clean`
+- `needs_fixes`
+- `needs_rerun`
+- `skipped`
+- `escalate`
+
+Do not emit display labels such as `needs-fixes`.
+
+Clear in-scope suggestions, important findings, and blocking findings map to
+`RESULT=needs_fixes`. Scope-expanding or decision-bound advisory findings may
+remain clean when they are marked with fields such as `advisory: true`,
+`scope_expanding: true`, `decision_bound: true`, or a matching scope/disposition
+string.
+
+---
+
+## Failure Semantics
+
+The local reviewer fails closed:
+
+| Condition | Result |
+| --- | --- |
+| Missing `LOCAL_AI_REVIEWER_COMMAND` | `RESULT=escalate`, `REASON=missing_command` |
+| Missing model access | `RESULT=escalate`, `REASON=missing_model_access` |
+| Missing credentials or auth failure | `RESULT=escalate`, `REASON=missing_credentials` |
+| Checkout head mismatch | `RESULT=escalate`, `REASON=head_mismatch` |
+| Missing `REVIEW.md` | `RESULT=escalate`, `REASON=review_contract_missing` |
+| Timeout | `RESULT=escalate`, `REASON=timeout` |
+| Malformed output | `RESULT=escalate`, `REASON=malformed_output` |
+| Explicit disabled config | `RESULT=skipped`, `REASON=disabled_by_config` |
+
+A skipped or escalated local result is availability evidence, not clean review
+evidence.
+
+---
+
+## Graph Context
+
+Graph context is optional. The default strategy is no graph context.
+
+Set:
+
+```bash
+export LOCAL_AI_REVIEWER_GRAPH_STRATEGY=auto
+```
+
+Accepted values:
+
+- `none`
+- `auto`
+- `code-review-graph`
+- `graphify`
+
+When a requested optional graph tool is absent, the platform still runs with
+the no-graph context and emits `GRAPH_CONTEXT=skipped`. Missing optional graph
+tooling does not turn the platform result into clean or escalation.
+
+Before making graph context required, evaluate no-graph,
+`code-review-graph`, and `graphify` against the representative inputs named in
+the #1604 plan and record the adoption result as Deferred, Optional, or
+Required.
+
+---
+
+## Evidence
+
+`local-ai-reviewer` does not own a GitHub bot login. `bot_login_for_platform`
+returns empty, and the Automated Reviewer Loop Summary is the durable evidence.
+
+The companion script emits:
+
+- `REVIEWED_HEAD`
+- `GRAPH_CONTEXT`
+- `COMMENT_COUNT`
+- `BLOCKING_COUNT`
+- `SUGGESTION_COUNT`
+- `REASON` when the result is not plain clean
+
+Use `scripts/development-workflow/local-ai-reviewer-findings.py` to normalize
+and compare local findings against ready-phase reviewer findings when measuring
+whether the ready-phase reviewer found net-new blockers.

--- a/docs/workflow/development-workflow/integrations/pr-review-platform.md
+++ b/docs/workflow/development-workflow/integrations/pr-review-platform.md
@@ -9,6 +9,7 @@ Platform-specific setup lives in each platform's own integration doc. See:
 - [`integrations/codex-github.md`](codex-github.md)
 - [`integrations/coderabbit.md`](coderabbit.md) for both `coderabbit` and
   `coderabbit-cli`
+- [`integrations/local-ai-reviewer.md`](local-ai-reviewer.md)
 - [`integrations/greptile.md`](greptile.md)
 - [`integrations/devin.md`](devin.md)
 - [`integrations/haystack-triage.md`](haystack-triage.md)
@@ -80,6 +81,10 @@ schema_version: 2
 review:
   on_draft:
     github:
+      # local-ai-reviewer: local-only CLI reviewer. Requires
+      # LOCAL_AI_REVIEWER_COMMAND in the runner environment. Missing command,
+      # credentials, model access, timeout, or malformed output escalates.
+      # - local-ai-reviewer
       - pr-agent
     # claude-code-action: own-key, own-CI reviewer with no per-hour vendor cap.
     # Requires ANTHROPIC_API_KEY secret and .github/workflows/claude-code-review.yml.
@@ -87,7 +92,7 @@ review:
     # - claude-code-action
   on_ready:
     github:
-      - codex-github
+      - bugbot
     # CodeRabbit remains supported as an opt-in reviewer, but is intentionally
     # not a default ready-phase gate because vendor rate limits/spending caps
     # can block otherwise-clean PRs.

--- a/scripts/development-workflow/local-ai-reviewer-findings.py
+++ b/scripts/development-workflow/local-ai-reviewer-findings.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Normalize and compare local reviewer findings.
+
+The helper is intentionally conservative: ambiguous ready-phase matches are
+reported as net-new instead of being collapsed away.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+def norm(value: Any) -> str:
+    text = "" if value is None else str(value).lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text).strip("-")
+    return text or "unclassified"
+
+
+def title_norm(value: Any) -> str:
+    text = "" if value is None else str(value).lower()
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def line_range(item: dict[str, Any]) -> tuple[int | None, int | None]:
+    start = item.get("start_line", item.get("line"))
+    end = item.get("end_line", start)
+    try:
+        start_i = int(start) if start not in (None, "") else None
+        end_i = int(end) if end not in (None, "") else start_i
+    except (TypeError, ValueError):
+        return None, None
+    return start_i, end_i
+
+
+def ranges_overlap(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    left_start, left_end = line_range(left)
+    right_start, right_end = line_range(right)
+    if left_start is None or right_start is None:
+        return False
+    assert left_end is not None
+    assert right_end is not None
+    return left_start <= right_end and right_start <= left_end
+
+
+def normalize_item(item: dict[str, Any], index: int) -> dict[str, Any]:
+    title = item.get("title") or item.get("summary") or item.get("message") or item.get("body") or ""
+    return {
+        "id": str(item.get("id") or f"finding-{index}"),
+        "head": str(item.get("head") or item.get("head_sha") or item.get("reviewed_head") or ""),
+        "severity": norm(item.get("severity") or item.get("level")),
+        "path": str(item.get("path") or item.get("file") or ""),
+        "start_line": line_range(item)[0],
+        "end_line": line_range(item)[1],
+        "affected_scope": norm(item.get("affected_scope") or item.get("scope") or item.get("path") or "repo"),
+        "title": str(title),
+        "title_key": title_norm(title),
+        "category_key": norm(item.get("category_key") or item.get("category")),
+        "requirement_key": norm(item.get("requirement_key") or item.get("requirement")),
+        "failure_mode_key": norm(item.get("failure_mode_key") or item.get("failure_mode")),
+        "summary": str(item.get("summary") or item.get("message") or item.get("body") or title),
+    }
+
+
+def load_findings(path: str) -> list[dict[str, Any]]:
+    raw = json.loads(Path(path).read_text())
+    if isinstance(raw, dict):
+        raw_items = raw.get("findings", [])
+    else:
+        raw_items = raw
+    if not isinstance(raw_items, list):
+        raise ValueError(f"{path} does not contain a findings array")
+    return [normalize_item(item, idx + 1) for idx, item in enumerate(raw_items) if isinstance(item, dict)]
+
+
+def dedupe(items: list[dict[str, Any]], include_title: bool) -> list[dict[str, Any]]:
+    seen: set[tuple[str, ...]] = set()
+    result: list[dict[str, Any]] = []
+    for item in items:
+        key = (
+            item["head"],
+            item["affected_scope"],
+            item["category_key"],
+            item["requirement_key"],
+            item["failure_mode_key"],
+        )
+        if include_title:
+            key = (*key, item["title_key"])
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(item)
+    return result
+
+
+def same_class(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    return (
+        left["category_key"] == right["category_key"]
+        and left["requirement_key"] == right["requirement_key"]
+        and left["failure_mode_key"] == right["failure_mode_key"]
+    )
+
+
+def matches(local: dict[str, Any], ready: dict[str, Any]) -> bool:
+    if local["head"] and ready["head"] and local["head"] != ready["head"]:
+        return False
+    if "unclassified" in {local["category_key"], local["requirement_key"], local["failure_mode_key"],
+                          ready["category_key"], ready["requirement_key"], ready["failure_mode_key"]}:
+        return local["affected_scope"] == ready["affected_scope"] and local["title_key"] == ready["title_key"]
+    if local["affected_scope"] == ready["affected_scope"] and same_class(local, ready):
+        return True
+    if local["path"] and local["path"] == ready["path"] and ranges_overlap(local, ready):
+        return local["requirement_key"] == ready["requirement_key"]
+    return False
+
+
+def compare(local_items: list[dict[str, Any]], ready_items: list[dict[str, Any]]) -> dict[str, Any]:
+    local_deduped = dedupe(local_items, include_title=False)
+    ready_deduped = dedupe(ready_items, include_title=True)
+    consumed: set[str] = set()
+    net_new: list[dict[str, Any]] = []
+    matched: list[dict[str, str]] = []
+
+    for ready in ready_deduped:
+        candidates = [item for item in local_deduped if item["id"] not in consumed and matches(item, ready)]
+        if len(candidates) == 1:
+            consumed.add(candidates[0]["id"])
+            matched.append({"ready_id": ready["id"], "local_id": candidates[0]["id"]})
+        else:
+            copy = dict(ready)
+            if len(candidates) > 1:
+                copy["ambiguous_candidate_ids"] = [item["id"] for item in candidates]
+            net_new.append(copy)
+
+    return {
+        "local_count": len(local_deduped),
+        "ready_count": len(ready_deduped),
+        "matched_count": len(matched),
+        "net_new_count": len(net_new),
+        "matched": matched,
+        "net_new": net_new,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--local", required=True)
+    parser.add_argument("--ready", required=True)
+    args = parser.parse_args()
+    print(json.dumps(compare(load_findings(args.local), load_findings(args.ready)), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/development-workflow/local-ai-reviewer-findings.py
+++ b/scripts/development-workflow/local-ai-reviewer-findings.py
@@ -106,7 +106,7 @@ def same_class(left: dict[str, Any], right: dict[str, Any]) -> bool:
 
 
 def matches(local: dict[str, Any], ready: dict[str, Any]) -> bool:
-    if local["head"] and ready["head"] and local["head"] != ready["head"]:
+    if local["head"] != ready["head"]:
         return False
     if "unclassified" in {local["category_key"], local["requirement_key"], local["failure_mode_key"],
                           ready["category_key"], ready["requirement_key"], ready["failure_mode_key"]}:

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -183,6 +183,7 @@ BASE_BRANCH=""
 HEAD_BRANCH=""
 HEAD_SHA=""
 changed_files_json="[]"
+diff_fetch_failed=0
 if command -v gh >/dev/null 2>&1; then
   pr_json=""
   if pr_json="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json baseRefName,headRefName,headRefOid 2>/dev/null)"; then
@@ -192,6 +193,7 @@ if command -v gh >/dev/null 2>&1; then
   fi
   if ! diff_output="$(gh pr diff "$PR_NUMBER" --repo "$OWNER/$REPO" --name-only 2>/dev/null)"; then
     diff_output=""
+    diff_fetch_failed=1
   fi
   if [ -n "$diff_output" ]; then
     changed_files_json="$(printf '%s\n' "$diff_output" | jq -R -s -c 'split("\n") | map(select(length > 0))')"
@@ -205,6 +207,11 @@ fi
 if [ -z "$HEAD_SHA" ]; then
   echo "ERROR: could not resolve pull request head SHA for #$PR_NUMBER" >&2
   print_result escalate 0 0 0 head_sha_unavailable head_sha_unavailable
+  exit 2
+fi
+if [ "$diff_fetch_failed" -ne 0 ]; then
+  echo "ERROR: could not fetch pull request diff for #$PR_NUMBER" >&2
+  print_result escalate 0 0 0 diff_unavailable diff_unavailable
   exit 2
 fi
 
@@ -323,11 +330,15 @@ fi
 
 combined_output="${command_stdout}
 ${command_stderr}"
-if printf '%s\n' "$combined_output" | grep -Eiq 'missing[[:space:]_-]+model|model[[:space:]_-]+access|model.*unavailable'; then
+setup_probe_output="$command_stderr"
+if ! printf '%s\n' "$command_stdout" | jq -e . >/dev/null 2>&1; then
+  setup_probe_output="$combined_output"
+fi
+if printf '%s\n' "$setup_probe_output" | grep -Eiq 'missing[[:space:]_-]+model|model[[:space:]_-]+access|model.*unavailable'; then
   print_result escalate 0 0 0 missing_model_access missing_model_access
   exit 2
 fi
-if printf '%s\n' "$combined_output" | grep -Eiq 'missing[[:space:]_-]+credentials|credentials[[:space:]_-]+missing|unauthori[sz]ed|forbidden|(^|[^[:alnum:]_])(401|403)([^[:alnum:]_]|$)'; then
+if printf '%s\n' "$setup_probe_output" | grep -Eiq 'missing[[:space:]_-]+credentials|credentials[[:space:]_-]+missing|unauthori[sz]ed|forbidden|(^|[^[:alnum:]_])(401|403)([^[:alnum:]_]|$)'; then
   print_result escalate 0 0 0 missing_credentials missing_credentials
   exit 2
 fi
@@ -382,15 +393,27 @@ parse_result="$(
         | ($findings | map(select(blocking)) | length) as $blocking
         | ($findings | map(select((blocking | not) and advisory)) | length) as $advisory
         | ($findings | map(select((blocking | not) and (advisory | not))) | length) as $unknown
+        | ($findings | map(select(blocking or ((blocking | not) and (advisory | not))))) as $blocking_findings
+        | ($blocking_findings
+            | to_entries
+            | map(
+                [
+                  "BLOCKING_\(.key + 1)_PATH=\(.value | path_value)",
+                  "BLOCKING_\(.key + 1)_LINE=\(.value | line_value)",
+                  "BLOCKING_\(.key + 1)_BODY=\(.value | text_value | gsub("\n"; "\\n"))"
+                ]
+              )
+            | flatten
+            | join("\n")) as $blocking_lines
         | if $unknown > 0 then
-            "PARSE_STATUS=ok\nRESULT=needs_fixes\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking + $unknown)\nSUGGESTION_COUNT=\($advisory)"
+            "PARSE_STATUS=ok\nRESULT=needs_fixes\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking + $unknown)\nSUGGESTION_COUNT=\($advisory)\n\($blocking_lines)"
           elif $result == "clean" and $blocking > 0 then
-            "PARSE_STATUS=ok\nRESULT=needs_fixes\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking)\nSUGGESTION_COUNT=\($advisory)"
+            "PARSE_STATUS=ok\nRESULT=needs_fixes\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking)\nSUGGESTION_COUNT=\($advisory)\n\($blocking_lines)"
           elif $result == "" then
             (if $blocking > 0 then "needs_fixes" else "clean" end) as $inferred
-            | "PARSE_STATUS=ok\nRESULT=\($inferred)\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking)\nSUGGESTION_COUNT=\($advisory)"
+            | "PARSE_STATUS=ok\nRESULT=\($inferred)\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking)\nSUGGESTION_COUNT=\($advisory)\n\(if $blocking > 0 then $blocking_lines else "" end)"
           else
-            "PARSE_STATUS=ok\nRESULT=\($result)\nREASON=\($root.reason // "")\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking)\nSUGGESTION_COUNT=\($advisory)"
+            "PARSE_STATUS=ok\nRESULT=\($result)\nREASON=\($root.reason // "")\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking)\nSUGGESTION_COUNT=\($advisory)\n\(if $result == "needs_fixes" then $blocking_lines else "" end)"
           end
       end
   ' 2>/dev/null
@@ -434,6 +457,7 @@ case "$result" in
     [ "$blocking_count" -eq 0 ] && blocking_count=1
     [ "$comment_count" -eq 0 ] && comment_count=1
     print_result needs_fixes "$comment_count" "$blocking_count" "$suggestion_count" local_ai_review_findings
+    printf '%s\n' "$parse_result" | awk '/^BLOCKING_[0-9]+_(PATH|LINE|BODY)=/ { print }'
     exit 1
     ;;
   needs_rerun)

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -1,0 +1,451 @@
+#!/usr/bin/env bash
+# local-ai-reviewer.sh - local-only reviewer for Step 7.
+#
+# Builds a bounded PR review context, invokes LOCAL_AI_REVIEWER_COMMAND, and
+# emits the companion-script key=value contract consumed by pr-review-loop.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/development-workflow/workflow-lib.sh
+source "$SCRIPT_DIR/workflow-lib.sh"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: local-ai-reviewer.sh <pr_number> <owner> <repo> [--timeout <seconds>] [--repo-root <path>]
+
+Options:
+  --timeout <seconds>  Maximum seconds to wait for LOCAL_AI_REVIEWER_COMMAND.
+                       Defaults to LOCAL_AI_REVIEWER_TIMEOUT or 300.
+  --repo-root <path>   Repository checkout to review. When supplied, HEAD must
+                       match the pull request head SHA before review runs.
+
+Environment:
+  LOCAL_AI_REVIEWER_COMMAND         Required unless LOCAL_AI_REVIEWER_DISABLED=1.
+                                    The command receives CONTEXT_BUNDLE_PATH,
+                                    PR_NUMBER, OWNER, REPO, BASE_BRANCH,
+                                    HEAD_BRANCH, and REVIEWED_HEAD in env.
+  LOCAL_AI_REVIEWER_DISABLED=1      Emit RESULT=skipped / disabled_by_config.
+  LOCAL_AI_REVIEWER_GRAPH_STRATEGY  none|auto|code-review-graph|graphify.
+EOF
+}
+
+print_result() {
+  local result="$1"
+  local comment_count="$2"
+  local blocking_count="$3"
+  local suggestion_count="$4"
+  local reason="${5:-}"
+  local display_result="${6:-}"
+
+  print_kv RESULT "$result"
+  print_kv COMMENT_COUNT "$comment_count"
+  print_kv BLOCKING_COUNT "$blocking_count"
+  print_kv SUGGESTION_COUNT "$suggestion_count"
+  [ -n "$reason" ] && print_kv REASON "$reason"
+  [ -n "$display_result" ] && print_kv DISPLAY_RESULT "$display_result"
+  return 0
+}
+
+valid_slug_component() {
+  case "$1" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+normalize_github_remote_slug() {
+  local raw="$1"
+  local slug="$raw"
+
+  slug="${slug#git@github.com:}"
+  slug="${slug#ssh://git@github.com/}"
+  slug="${slug#https://github.com/}"
+  slug="${slug#http://github.com/}"
+  slug="${slug#https://*@github.com/}"
+  slug="${slug#http://*@github.com/}"
+  slug="${slug%.git}"
+  printf '%s\n' "$slug"
+}
+
+redact_github_remote_slug() {
+  local raw="$1"
+  local slug
+  case "$raw" in
+    http://*@github.com/*|https://*@github.com/*)
+      printf '<redacted-remote>\n'
+      return 0
+      ;;
+  esac
+  slug="$(normalize_github_remote_slug "$raw")"
+  case "$slug" in
+    http://*|https://*|*@*) printf '<redacted-remote>\n' ;;
+    *) printf '%s\n' "$slug" ;;
+  esac
+}
+
+run_with_timeout() {
+  local timeout_seconds="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+  shift 3
+
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$timeout_seconds" "$@" >"$stdout_file" 2>"$stderr_file"
+    return $?
+  fi
+
+  "$@" >"$stdout_file" 2>"$stderr_file" &
+  local child_pid=$!
+  local elapsed=0
+  while kill -0 "$child_pid" 2>/dev/null && [ "$elapsed" -lt "$timeout_seconds" ]; do
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  if [ "$elapsed" -ge "$timeout_seconds" ]; then
+    kill "$child_pid" 2>/dev/null || true
+    wait "$child_pid" 2>/dev/null || true
+    return 124
+  fi
+  wait "$child_pid"
+}
+
+if [ "$#" -lt 3 ]; then
+  usage
+  exit 2
+fi
+
+PR_NUMBER="$1"
+OWNER="$2"
+REPO="$3"
+shift 3
+
+case "$PR_NUMBER" in
+  ''|0|*[!0-9]*)
+    echo "ERROR: PR number '$PR_NUMBER' is not a valid positive integer" >&2
+    exit 2
+    ;;
+esac
+if ! valid_slug_component "$OWNER"; then
+  echo "ERROR: owner '$OWNER' contains invalid characters" >&2
+  exit 2
+fi
+if ! valid_slug_component "$REPO"; then
+  echo "ERROR: repo '$REPO' contains invalid characters" >&2
+  exit 2
+fi
+
+TIMEOUT="${LOCAL_AI_REVIEWER_TIMEOUT:-300}"
+REPO_ROOT=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --timeout)
+      [ "$#" -ge 2 ] && [ -n "${2:-}" ] || { echo "ERROR: --timeout requires a value" >&2; exit 2; }
+      TIMEOUT="$2"
+      shift 2
+      ;;
+    --repo-root)
+      [ "$#" -ge 2 ] && [ -n "${2:-}" ] || { echo "ERROR: --repo-root requires a value" >&2; exit 2; }
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown option '$1'" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+case "$TIMEOUT" in
+  ''|0|*[!0-9]*)
+    echo "ERROR: --timeout value '$TIMEOUT' is not a positive integer" >&2
+    exit 2
+    ;;
+esac
+
+if [ "${LOCAL_AI_REVIEWER_DISABLED:-0}" = "1" ]; then
+  print_result skipped 0 0 0 disabled_by_config disabled_by_config
+  exit 3
+fi
+
+if [ -z "${LOCAL_AI_REVIEWER_COMMAND:-}" ]; then
+  echo "ERROR: LOCAL_AI_REVIEWER_COMMAND is not configured" >&2
+  print_result escalate 0 0 0 missing_command missing_command
+  exit 2
+fi
+
+BASE_BRANCH=""
+HEAD_BRANCH=""
+HEAD_SHA=""
+changed_files_json="[]"
+if command -v gh >/dev/null 2>&1; then
+  pr_json=""
+  if pr_json="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json baseRefName,headRefName,headRefOid 2>/dev/null)"; then
+    BASE_BRANCH="$(printf '%s\n' "$pr_json" | jq -r '.baseRefName // empty' 2>/dev/null || true)"
+    HEAD_BRANCH="$(printf '%s\n' "$pr_json" | jq -r '.headRefName // empty' 2>/dev/null || true)"
+    HEAD_SHA="$(printf '%s\n' "$pr_json" | jq -r '.headRefOid // empty' 2>/dev/null || true)"
+  fi
+  diff_output="$(gh pr diff "$PR_NUMBER" --repo "$OWNER/$REPO" --name-only 2>/dev/null || true)"
+  if [ -n "$diff_output" ]; then
+    changed_files_json="$(printf '%s\n' "$diff_output" | jq -R -s -c 'split("\n") | map(select(length > 0))')"
+  fi
+fi
+if [ -z "$BASE_BRANCH" ]; then
+  echo "ERROR: could not resolve pull request base branch for #$PR_NUMBER" >&2
+  print_result escalate 0 0 0 base_branch_unavailable base_branch_unavailable
+  exit 2
+fi
+if [ -z "$HEAD_SHA" ]; then
+  echo "ERROR: could not resolve pull request head SHA for #$PR_NUMBER" >&2
+  print_result escalate 0 0 0 head_sha_unavailable head_sha_unavailable
+  exit 2
+fi
+
+if [ -n "$REPO_ROOT" ]; then
+  if [ ! -d "$REPO_ROOT/.git" ] && ! git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "ERROR: --repo-root is not a Git checkout: $REPO_ROOT" >&2
+    print_result escalate 0 0 0 invalid_repo_root invalid_repo_root
+    exit 2
+  fi
+  if ! repo_root_origin="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null)"; then
+    repo_root_origin=""
+  fi
+  repo_root_slug="$(normalize_github_remote_slug "$repo_root_origin")"
+  if [ "$repo_root_slug" != "$OWNER/$REPO" ]; then
+    echo "ERROR: --repo-root origin does not match expected repository ($(redact_github_remote_slug "$repo_root_origin") != $OWNER/$REPO)" >&2
+    print_result escalate 0 0 0 repo_root_mismatch repo_root_mismatch
+    exit 2
+  fi
+  if ! CURRENT_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)"; then
+    CURRENT_SHA=""
+  fi
+  if [ "$CURRENT_SHA" != "$HEAD_SHA" ]; then
+    echo "ERROR: checkout HEAD does not match PR head ($CURRENT_SHA != $HEAD_SHA)" >&2
+    print_result escalate 0 0 0 head_mismatch head_mismatch
+    exit 2
+  fi
+  cd "$REPO_ROOT"
+fi
+
+if [ ! -f REVIEW.md ]; then
+  echo "ERROR: REVIEW.md is required for local review" >&2
+  print_result escalate 0 0 0 review_contract_missing review_contract_missing
+  exit 2
+fi
+
+graph_strategy="${LOCAL_AI_REVIEWER_GRAPH_STRATEGY:-none}"
+graph_context="none"
+case "$graph_strategy" in
+  none|'') graph_context="none" ;;
+  auto)
+    if command -v code-review-graph >/dev/null 2>&1; then
+      graph_context="code-review-graph"
+    elif command -v graphify >/dev/null 2>&1; then
+      graph_context="graphify"
+    else
+      graph_context="skipped"
+    fi
+    ;;
+  code-review-graph)
+    command -v code-review-graph >/dev/null 2>&1 && graph_context="code-review-graph" || graph_context="skipped"
+    ;;
+  graphify)
+    command -v graphify >/dev/null 2>&1 && graph_context="graphify" || graph_context="skipped"
+    ;;
+  *)
+    echo "ERROR: invalid LOCAL_AI_REVIEWER_GRAPH_STRATEGY '$graph_strategy'" >&2
+    print_result escalate 0 0 0 malformed_output malformed_output
+    exit 2
+    ;;
+esac
+
+context_file="$(mktemp)"
+stdout_file="$(mktemp)"
+stderr_file="$(mktemp)"
+cleanup() {
+  rm -f "${context_file:-}" "${stdout_file:-}" "${stderr_file:-}"
+}
+trap cleanup EXIT
+
+jq -n \
+  --arg pr_number "$PR_NUMBER" \
+  --arg owner "$OWNER" \
+  --arg repo "$REPO" \
+  --arg base_branch "$BASE_BRANCH" \
+  --arg head_branch "$HEAD_BRANCH" \
+  --arg reviewed_head "$HEAD_SHA" \
+  --arg graph_context "$graph_context" \
+  --argjson changed_files "$changed_files_json" \
+  '{
+    pr_number: ($pr_number | tonumber),
+    owner: $owner,
+    repo: $repo,
+    base_branch: $base_branch,
+    head_branch: $head_branch,
+    reviewed_head: $reviewed_head,
+    changed_files: $changed_files,
+    review_contract: "REVIEW.md",
+    graph_context: $graph_context
+  }' >"$context_file"
+
+print_kv BASE_BRANCH "$BASE_BRANCH"
+[ -n "$HEAD_BRANCH" ] && print_kv HEAD_BRANCH "$HEAD_BRANCH"
+print_kv REVIEWED_HEAD "$HEAD_SHA"
+print_kv GRAPH_CONTEXT "$graph_context"
+
+set +e
+CONTEXT_BUNDLE_PATH="$context_file" \
+PR_NUMBER="$PR_NUMBER" \
+OWNER="$OWNER" \
+REPO="$REPO" \
+BASE_BRANCH="$BASE_BRANCH" \
+HEAD_BRANCH="$HEAD_BRANCH" \
+REVIEWED_HEAD="$HEAD_SHA" \
+  run_with_timeout "$TIMEOUT" "$stdout_file" "$stderr_file" sh -c "$LOCAL_AI_REVIEWER_COMMAND"
+command_exit=$?
+set -e
+
+command_stdout="$(cat "$stdout_file" 2>/dev/null || true)"
+command_stderr="$(cat "$stderr_file" 2>/dev/null || true)"
+
+if [ "$command_exit" -eq 124 ]; then
+  echo "WARN: local AI reviewer timed out after ${TIMEOUT}s" >&2
+  print_result escalate 0 0 0 timeout timeout
+  exit 2
+fi
+
+combined_output="${command_stdout}
+${command_stderr}"
+if printf '%s\n' "$combined_output" | grep -Eiq 'missing[[:space:]_-]+model|model[[:space:]_-]+access|model.*unavailable'; then
+  print_result escalate 0 0 0 missing_model_access missing_model_access
+  exit 2
+fi
+if printf '%s\n' "$combined_output" | grep -Eiq 'missing[[:space:]_-]+credentials|credentials[[:space:]_-]+missing|unauthori[sz]ed|forbidden|(^|[^[:alnum:]_])(401|403)([^[:alnum:]_]|$)'; then
+  print_result escalate 0 0 0 missing_credentials missing_credentials
+  exit 2
+fi
+if [ -z "$(printf '%s' "$command_stdout" | tr -d '[:space:]')" ]; then
+  echo "WARN: local AI reviewer produced no machine output" >&2
+  print_result escalate 0 0 0 malformed_output malformed_output
+  exit 2
+fi
+
+parse_result="$(
+  printf '%s\n' "$command_stdout" | jq -r --arg expected_head "$HEAD_SHA" '
+    def findings:
+      if (.findings? | type) == "array" then .findings
+      elif (.comments? | type) == "array" then .comments
+      elif (.issues? | type) == "array" then .issues
+      else [] end;
+    def text_value:
+      [.body?, .message?, .description?, .title?, .summary?, .comment?, .text?]
+      | map(select(type == "string" and length > 0)) | .[0] // "";
+    def path_value:
+      [.path?, .file?, .filename?, .filepath?, .location.path?]
+      | map(select(type == "string" and length > 0)) | .[0] // "";
+    def line_value:
+      [.line?, .startLine?, .start_line?, .location.line?]
+      | map(select((type == "number") or (type == "string" and length > 0))) | .[0] // "";
+    def severity_text:
+      [.severity?, .level?, .priority?, .type?, .classification?, .kind?, .result?]
+      | map(select(type == "string")) | join(" ") | ascii_downcase;
+    def scope_text:
+      [.scope?, .disposition?, .policy?, .category?]
+      | map(select(type == "string")) | join(" ") | ascii_downcase;
+    def explicit_advisory:
+      ((.advisory? == true) or (.decision_bound? == true) or (.scope_expanding? == true))
+      or (scope_text | test("advisory|scope.expanding|decision.bound|optional|polish"));
+    def blocking:
+      (severity_text | test("critical|blocker|blocking|important|error|bug|security|vulnerability|high|major|must.fix|needs.fixes|changes.requested"))
+      or (.clear_in_scope? == true)
+      or (scope_text | test("clear.in.scope|in.scope|must.fix|needs.fixes"));
+    def advisory:
+      explicit_advisory or (severity_text | test("minor|low|nit|nitpick|trivial|info|informational|advisory|optional"));
+    . as $root
+    | ($root.result // "") as $raw_result
+    | ($raw_result | tostring | ascii_downcase | gsub("-"; "_")) as $result
+    | ($root.reviewed_head // $root.head_sha // $root.head // $expected_head) as $reviewed
+    | if $reviewed != $expected_head then
+        "PARSE_STATUS=head_mismatch"
+      elif ($result != "" and (["clean","needs_fixes","needs_rerun","skipped","escalate"] | index($result) | not)) then
+        "PARSE_STATUS=malformed"
+      else
+        (findings) as $findings
+        | ($findings | length) as $comments
+        | ($findings | map(select(blocking)) | length) as $blocking
+        | ($findings | map(select((blocking | not) and advisory)) | length) as $advisory
+        | ($findings | map(select((blocking | not) and (advisory | not))) | length) as $unknown
+        | if $unknown > 0 then
+            "PARSE_STATUS=ok\nRESULT=needs_fixes\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking + $unknown)\nSUGGESTION_COUNT=\($advisory)"
+          elif $result == "" then
+            (if $blocking > 0 then "needs_fixes" else "clean" end) as $inferred
+            | "PARSE_STATUS=ok\nRESULT=\($inferred)\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking)\nSUGGESTION_COUNT=\($advisory)"
+          else
+            "PARSE_STATUS=ok\nRESULT=\($result)\nREASON=\($root.reason // "")\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking)\nSUGGESTION_COUNT=\($advisory)"
+          end
+      end
+  ' 2>/dev/null
+)" || parse_result=""
+
+parse_status="$(printf '%s\n' "$parse_result" | awk -F= '$1 == "PARSE_STATUS" { print $2; exit }')"
+case "$parse_status" in
+  ok) ;;
+  head_mismatch)
+    print_result escalate 0 0 0 head_mismatch head_mismatch
+    exit 2
+    ;;
+  *)
+    echo "WARN: local AI reviewer output was malformed" >&2
+    print_result escalate 0 0 0 malformed_output malformed_output
+    exit 2
+    ;;
+esac
+
+result="$(printf '%s\n' "$parse_result" | awk -F= '$1 == "RESULT" { print $2; exit }')"
+reason="$(printf '%s\n' "$parse_result" | awk -F= '$1 == "REASON" { print $2; exit }')"
+comment_count="$(printf '%s\n' "$parse_result" | awk -F= '$1 == "COMMENT_COUNT" { print $2; exit }')"
+blocking_count="$(printf '%s\n' "$parse_result" | awk -F= '$1 == "BLOCKING_COUNT" { print $2; exit }')"
+suggestion_count="$(printf '%s\n' "$parse_result" | awk -F= '$1 == "SUGGESTION_COUNT" { print $2; exit }')"
+
+comment_count="${comment_count:-0}"
+blocking_count="${blocking_count:-0}"
+suggestion_count="${suggestion_count:-0}"
+reason="${reason:-}"
+
+case "$result" in
+  clean)
+    if [ "$command_exit" -ne 0 ]; then
+      print_result escalate "$comment_count" "$blocking_count" "$suggestion_count" malformed_output malformed_output
+      exit 2
+    fi
+    print_result clean "$comment_count" 0 "$suggestion_count"
+    exit 0
+    ;;
+  needs_fixes)
+    [ "$blocking_count" -eq 0 ] && blocking_count=1
+    [ "$comment_count" -eq 0 ] && comment_count=1
+    print_result needs_fixes "$comment_count" "$blocking_count" "$suggestion_count" local_ai_review_findings
+    exit 1
+    ;;
+  needs_rerun)
+    print_result needs_rerun "$comment_count" "$blocking_count" "$suggestion_count" "${reason:-needs_rerun}"
+    exit 1
+    ;;
+  skipped)
+    print_result skipped "$comment_count" "$blocking_count" "$suggestion_count" "${reason:-disabled_by_config}" "${reason:-disabled_by_config}"
+    exit 3
+    ;;
+  escalate)
+    print_result escalate "$comment_count" "$blocking_count" "$suggestion_count" "${reason:-malformed_output}" "${reason:-malformed_output}"
+    exit 2
+    ;;
+  *)
+    print_result escalate 0 0 0 malformed_output malformed_output
+    exit 2
+    ;;
+esac

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -190,7 +190,9 @@ if command -v gh >/dev/null 2>&1; then
     HEAD_BRANCH="$(printf '%s\n' "$pr_json" | jq -r '.headRefName // empty' 2>/dev/null || true)"
     HEAD_SHA="$(printf '%s\n' "$pr_json" | jq -r '.headRefOid // empty' 2>/dev/null || true)"
   fi
-  diff_output="$(gh pr diff "$PR_NUMBER" --repo "$OWNER/$REPO" --name-only 2>/dev/null || true)"
+  if ! diff_output="$(gh pr diff "$PR_NUMBER" --repo "$OWNER/$REPO" --name-only 2>/dev/null)"; then
+    diff_output=""
+  fi
   if [ -n "$diff_output" ]; then
     changed_files_json="$(printf '%s\n' "$diff_output" | jq -R -s -c 'split("\n") | map(select(length > 0))')"
   fi

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -384,6 +384,8 @@ parse_result="$(
         | ($findings | map(select((blocking | not) and (advisory | not))) | length) as $unknown
         | if $unknown > 0 then
             "PARSE_STATUS=ok\nRESULT=needs_fixes\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking + $unknown)\nSUGGESTION_COUNT=\($advisory)"
+          elif $result == "clean" and $blocking > 0 then
+            "PARSE_STATUS=ok\nRESULT=needs_fixes\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking)\nSUGGESTION_COUNT=\($advisory)"
           elif $result == "" then
             (if $blocking > 0 then "needs_fixes" else "clean" end) as $inferred
             | "PARSE_STATUS=ok\nRESULT=\($inferred)\nCOMMENT_COUNT=\($comments)\nBLOCKING_COUNT=\($blocking)\nSUGGESTION_COUNT=\($advisory)"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -2756,9 +2756,16 @@ run_coderabbit_cli_review() {
       return 0
       ;;
     1)
-      [ "$blocking_count" -eq 0 ] && blocking_count=1
-      [ "$comment_count" -eq 0 ] && comment_count=1
-      print_kv RESULT needs_fixes
+      local local_ai_script_result
+      local_ai_script_result="$(kv_value_default RESULT "$script_output" needs_fixes)"
+      if [ "$local_ai_script_result" != "needs_rerun" ]; then
+        [ "$blocking_count" -eq 0 ] && blocking_count=1
+        [ "$comment_count" -eq 0 ] && comment_count=1
+      fi
+      case "$local_ai_script_result" in
+        needs_rerun) print_kv RESULT needs_rerun ;;
+        *) print_kv RESULT needs_fixes ;;
+      esac
       print_kv PLATFORM "$platform"
       print_kv PR_NUMBER "$pr_number"
       print_kv BRANCH "$branch_name"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -2756,13 +2756,13 @@ run_coderabbit_cli_review() {
       return 0
       ;;
     1)
-      local local_ai_script_result
-      local_ai_script_result="$(kv_value_default RESULT "$script_output" needs_fixes)"
-      if [ "$local_ai_script_result" != "needs_rerun" ]; then
+      local coderabbit_cli_script_result
+      coderabbit_cli_script_result="$(kv_value_default RESULT "$script_output" needs_fixes)"
+      if [ "$coderabbit_cli_script_result" != "needs_rerun" ]; then
         [ "$blocking_count" -eq 0 ] && blocking_count=1
         [ "$comment_count" -eq 0 ] && comment_count=1
       fi
-      case "$local_ai_script_result" in
+      case "$coderabbit_cli_script_result" in
         needs_rerun) print_kv RESULT needs_rerun ;;
         *) print_kv RESULT needs_fixes ;;
       esac
@@ -2883,9 +2883,16 @@ run_local_ai_reviewer_review() {
       return 0
       ;;
     1)
-      [ "$blocking_count" -eq 0 ] && blocking_count=1
-      [ "$comment_count" -eq 0 ] && comment_count=1
-      print_kv RESULT needs_fixes
+      local local_ai_script_result
+      local_ai_script_result="$(kv_value_default RESULT "$script_output" needs_fixes)"
+      if [ "$local_ai_script_result" != "needs_rerun" ]; then
+        [ "$blocking_count" -eq 0 ] && blocking_count=1
+        [ "$comment_count" -eq 0 ] && comment_count=1
+      fi
+      case "$local_ai_script_result" in
+        needs_rerun) print_kv RESULT needs_rerun ;;
+        *) print_kv RESULT needs_fixes ;;
+      esac
       print_kv PLATFORM "$platform"
       print_kv PR_NUMBER "$pr_number"
       print_kv BRANCH "$branch_name"
@@ -2894,6 +2901,11 @@ run_local_ai_reviewer_review() {
       print_kv COMMENT_COUNT "$comment_count"
       print_kv BLOCKING_COUNT "$blocking_count"
       print_kv SUGGESTION_COUNT "$suggestion_count"
+      for index in $(seq 1 "$blocking_count"); do
+        print_kv "BLOCKING_${index}_PATH" "$(kv_value_default "BLOCKING_${index}_PATH" "$script_output" "")"
+        print_kv "BLOCKING_${index}_LINE" "$(kv_value_default "BLOCKING_${index}_LINE" "$script_output" "")"
+        print_kv "BLOCKING_${index}_BODY" "$(kv_value_default "BLOCKING_${index}_BODY" "$script_output" "")"
+      done
       print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
       print_kv GRAPH_CONTEXT "$(kv_value_default GRAPH_CONTEXT "$script_output" "")"
       return 1

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -386,7 +386,7 @@ _interruptible_sleep() {
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--repo owner/repo|product-name] [--product-repo name] [--repo-root path] [--platform greptile] [--platform greptile,devin,pr-agent,coderabbit,coderabbit-cli,codex-github,claude-code-action,copilot,haystack,bugbot] [--ready-phase haystack] [--phase-after-clean haystack] [--draft-github-only] [--pre-after-clean-only] [--poll-interval seconds] [--max-wait seconds] [--pre-trigger-wait seconds] [--post-final-summary] [--compare]
+Usage: ./scripts/development-workflow/pr-review-loop.sh <pr-number> [--branch name] [--repo owner/repo|product-name] [--product-repo name] [--repo-root path] [--platform greptile] [--platform greptile,devin,pr-agent,coderabbit,coderabbit-cli,local-ai-reviewer,codex-github,claude-code-action,copilot,haystack,bugbot] [--ready-phase haystack] [--phase-after-clean haystack] [--draft-github-only] [--pre-after-clean-only] [--poll-interval seconds] [--max-wait seconds] [--pre-trigger-wait seconds] [--post-final-summary] [--compare]
        ./scripts/development-workflow/pr-review-loop.sh unlock <pr-number>
 
 Runs the automated PR review loop for one or more platforms in sequence. Before
@@ -2806,6 +2806,127 @@ run_coderabbit_cli_review() {
       print_kv COMMENT_COUNT "$comment_count"
       print_kv BLOCKING_COUNT "$blocking_count"
       print_kv SUGGESTION_COUNT "$suggestion_count"
+      return 0
+      ;;
+  esac
+}
+
+run_local_ai_reviewer_review() {
+  # Runs local-ai-reviewer.sh and maps its exit codes to the standard
+  # pr-review-loop key=value output contract.
+  local pr_number="$1"
+  local branch_name="$2"
+  local poll_interval="$3"
+  local max_wait="$4"
+  local platform="local-ai-reviewer"
+  local reviewer_script
+  local script_exit=0
+  local script_output=""
+  local blocking_count=0
+  local suggestion_count=0
+  local comment_count=0
+
+  : "$poll_interval"
+  require_gh
+  reviewer_script="$(workflow_repo_root)/scripts/development-workflow/local-ai-reviewer.sh"
+  review_repo_root="${repo_root:-$(workflow_repo_root)}"
+  cd "$review_repo_root"
+
+  local owner repo_name repo
+  repo="$(repo_slug)"
+  owner="$(printf '%s\n' "$repo" | cut -d/ -f1)"
+  repo_name="$(printf '%s\n' "$repo" | cut -d/ -f2)"
+
+  local local_ai_stderr_file
+  local local_ai_config_file="${AI_DEV_WORKFLOW_CONFIG_FILE:-${config_file:-}}"
+  local_ai_stderr_file="$(mktemp)"
+  trap 'rm -f "${local_ai_stderr_file:-}"' RETURN
+
+  set +e
+  if [ -n "$local_ai_config_file" ] && [ -f "$local_ai_config_file" ]; then
+    script_output="$(AI_DEV_WORKFLOW_CONFIG_FILE="$local_ai_config_file" "$reviewer_script" "$pr_number" "$owner" "$repo_name" --timeout "$max_wait" --repo-root "$review_repo_root" 2>"$local_ai_stderr_file")"
+  else
+    script_output="$("$reviewer_script" "$pr_number" "$owner" "$repo_name" --timeout "$max_wait" --repo-root "$review_repo_root" 2>"$local_ai_stderr_file")"
+  fi
+  script_exit=$?
+  set -e
+
+  if [ -s "$local_ai_stderr_file" ]; then
+    echo "INFO: local-ai-reviewer.sh stderr:" >&2
+    cat "$local_ai_stderr_file" >&2
+  fi
+  rm -f "$local_ai_stderr_file"
+
+  blocking_count="$(kv_value_default BLOCKING_COUNT "$script_output" 0)"
+  suggestion_count="$(kv_value_default SUGGESTION_COUNT "$script_output" 0)"
+  comment_count="$(kv_value_default COMMENT_COUNT "$script_output" 0)"
+
+  case "$script_exit" in
+    0)
+      print_kv RESULT clean
+      print_kv PLATFORM "$platform"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv BRANCH "$branch_name"
+      print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv COMMENT_COUNT "$comment_count"
+      print_kv BLOCKING_COUNT 0
+      print_kv SUGGESTION_COUNT "$suggestion_count"
+      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
+      print_kv GRAPH_CONTEXT "$(kv_value_default GRAPH_CONTEXT "$script_output" "")"
+      return 0
+      ;;
+    1)
+      [ "$blocking_count" -eq 0 ] && blocking_count=1
+      [ "$comment_count" -eq 0 ] && comment_count=1
+      print_kv RESULT needs_fixes
+      print_kv PLATFORM "$platform"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv BRANCH "$branch_name"
+      print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv REASON "$(kv_value_default REASON "$script_output" local_ai_review_findings)"
+      print_kv COMMENT_COUNT "$comment_count"
+      print_kv BLOCKING_COUNT "$blocking_count"
+      print_kv SUGGESTION_COUNT "$suggestion_count"
+      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
+      print_kv GRAPH_CONTEXT "$(kv_value_default GRAPH_CONTEXT "$script_output" "")"
+      return 1
+      ;;
+    2)
+      local local_ai_reason
+      local local_ai_display_result
+      local_ai_reason="$(kv_value_default REASON "$script_output" malformed_output)"
+      local_ai_display_result="$(kv_value_default DISPLAY_RESULT "$script_output" "")"
+      print_kv RESULT escalate
+      print_kv REASON "$local_ai_reason"
+      [ -n "$local_ai_display_result" ] && print_kv DISPLAY_RESULT "$local_ai_display_result"
+      print_kv PLATFORM "$platform"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv BRANCH "$branch_name"
+      print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv COMMENT_COUNT "$comment_count"
+      print_kv BLOCKING_COUNT "$blocking_count"
+      print_kv SUGGESTION_COUNT "$suggestion_count"
+      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
+      print_kv GRAPH_CONTEXT "$(kv_value_default GRAPH_CONTEXT "$script_output" "")"
+      return 2
+      ;;
+    *)
+      local local_ai_reason
+      local local_ai_display_result
+      local_ai_reason="$(kv_value_default REASON "$script_output" disabled_by_config)"
+      local_ai_display_result="$(kv_value_default DISPLAY_RESULT "$script_output" "")"
+      print_kv RESULT skipped
+      print_kv REASON "$local_ai_reason"
+      [ -n "$local_ai_display_result" ] && print_kv DISPLAY_RESULT "$local_ai_display_result"
+      print_kv PLATFORM "$platform"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv BRANCH "$branch_name"
+      print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv COMMENT_COUNT "$comment_count"
+      print_kv BLOCKING_COUNT "$blocking_count"
+      print_kv SUGGESTION_COUNT "$suggestion_count"
+      print_kv REVIEWED_HEAD "$(kv_value_default REVIEWED_HEAD "$script_output" "")"
+      print_kv GRAPH_CONTEXT "$(kv_value_default GRAPH_CONTEXT "$script_output" "")"
       return 0
       ;;
   esac
@@ -5676,6 +5797,7 @@ bot_login_for_platform() {
   case "$1" in
     coderabbit)   printf 'coderabbitai\n' ;;
     coderabbit-cli) printf '\n' ;;
+    local-ai-reviewer) printf '\n' ;;
     devin)        printf 'devin-ai-integration\n' ;;
     greptile)     printf 'greptile-apps\n' ;;
     pr-agent)     printf '\n' ;;
@@ -5879,6 +6001,9 @@ run_platform_review() {
       ;;
     coderabbit-cli)
       run_coderabbit_cli_review "$pr_number" "$branch_name" "$poll_interval" "$max_wait"
+      ;;
+    local-ai-reviewer)
+      run_local_ai_reviewer_review "$pr_number" "$branch_name" "$poll_interval" "$max_wait"
       ;;
     pr-agent)
       run_pr_agent_review "$pr_number" "$branch_name" "$poll_interval" "$max_wait"

--- a/scripts/development-workflow/tests/test-local-ai-reviewer-findings.py
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer-findings.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Tests for local-ai-reviewer-findings.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HELPER_PATH = REPO_ROOT / "scripts" / "development-workflow" / "local-ai-reviewer-findings.py"
+spec = importlib.util.spec_from_file_location("local_ai_reviewer_findings", HELPER_PATH)
+assert spec and spec.loader
+helper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helper)
+
+PASS_COUNT = 0
+FAIL_COUNT = 0
+
+
+def check(name: str, expected, actual) -> None:
+    global PASS_COUNT, FAIL_COUNT
+    if expected == actual:
+        print(f"PASS: {name}")
+        PASS_COUNT += 1
+    else:
+        print(f"FAIL: {name} - expected {expected!r}, got {actual!r}")
+        FAIL_COUNT += 1
+
+
+def norm(items):
+    return [helper.normalize_item(item, index + 1) for index, item in enumerate(items)]
+
+
+same_local = norm([
+    {
+        "id": "l1",
+        "head": "abc",
+        "path": "scripts/a.sh",
+        "line": 10,
+        "affected_scope": "scripts/a.sh",
+        "category_key": "validation",
+        "requirement_key": "tests",
+        "failure_mode_key": "missing",
+        "title": "Add test",
+    }
+])
+
+same_ready = norm([
+    {
+        "id": "r1",
+        "head": "abc",
+        "path": "scripts/a.sh",
+        "line": 10,
+        "affected_scope": "scripts/a.sh",
+        "category_key": "validation",
+        "requirement_key": "tests",
+        "failure_mode_key": "missing",
+        "title": "Test is missing",
+    }
+])
+check("same_class_matches", 0, helper.compare(same_local, same_ready)["net_new_count"])
+
+different_key_ready = norm([
+    {
+        "id": "r2",
+        "head": "abc",
+        "path": "scripts/a.sh",
+        "line": 10,
+        "affected_scope": "scripts/a.sh",
+        "category_key": "validation",
+        "requirement_key": "review-contract",
+        "failure_mode_key": "missing",
+        "title": "Review contract missing",
+    }
+])
+check("same_path_different_key_net_new", 1, helper.compare(same_local, different_key_ready)["net_new_count"])
+
+ambiguous_local = norm([
+    {
+        "id": "l1",
+        "head": "abc",
+        "path": "scripts/a.sh",
+        "line": 10,
+        "affected_scope": "scripts/a.sh",
+        "category_key": "validation",
+        "requirement_key": "tests",
+        "failure_mode_key": "missing",
+        "title": "First",
+    },
+    {
+        "id": "l2",
+        "head": "abc",
+        "path": "scripts/a.sh",
+        "line": 10,
+        "affected_scope": "scripts/a.sh",
+        "category_key": "documentation",
+        "requirement_key": "tests",
+        "failure_mode_key": "missing",
+        "title": "Second",
+    },
+])
+ambiguous_ready = norm([
+    {
+        "id": "r1",
+        "head": "abc",
+        "path": "scripts/a.sh",
+        "line": 10,
+        "affected_scope": "scripts/a.sh",
+        "category_key": "review",
+        "requirement_key": "tests",
+        "failure_mode_key": "missing",
+        "title": "Missing test",
+    }
+])
+ambiguous = helper.compare(ambiguous_local, ambiguous_ready)
+check("ambiguous_counts_net_new", 1, ambiguous["net_new_count"])
+check("ambiguous_candidate_ids", ["l1", "l2"], ambiguous["net_new"][0]["ambiguous_candidate_ids"])
+
+two_ready = norm([
+    {
+        "id": "r1",
+        "head": "abc",
+        "affected_scope": "scripts/a.sh",
+        "category_key": "validation",
+        "requirement_key": "tests",
+        "failure_mode_key": "missing",
+        "title": "A",
+    },
+    {
+        "id": "r2",
+        "head": "abc",
+        "affected_scope": "scripts/a.sh",
+        "category_key": "validation",
+        "requirement_key": "tests",
+        "failure_mode_key": "missing",
+        "title": "B",
+    },
+])
+one_to_one = helper.compare(same_local, two_ready)
+check("one_local_not_consumed_twice", 1, one_to_one["matched_count"])
+check("second_ready_net_new", 1, one_to_one["net_new_count"])
+
+unclassified_local = norm([
+    {"id": "l1", "head": "abc", "affected_scope": "repo", "title": "Same words"},
+])
+unclassified_ready_same = norm([
+    {"id": "r1", "head": "abc", "affected_scope": "repo", "title": "Same words"},
+])
+unclassified_ready_diff = norm([
+    {"id": "r2", "head": "abc", "affected_scope": "repo", "title": "Different words"},
+])
+check("unclassified_exact_title_matches", 0, helper.compare(unclassified_local, unclassified_ready_same)["net_new_count"])
+check("unclassified_different_title_net_new", 1, helper.compare(unclassified_local, unclassified_ready_diff)["net_new_count"])
+
+with tempfile.TemporaryDirectory() as tmp:
+    local_path = Path(tmp) / "local.json"
+    ready_path = Path(tmp) / "ready.json"
+    local_path.write_text(json.dumps({"findings": [{"id": "l1", "head": "abc", "affected_scope": "repo", "title": "Same"}]}))
+    ready_path.write_text(json.dumps([{"id": "r1", "head": "abc", "affected_scope": "repo", "title": "Same"}]))
+    check("load_findings_dict", "l1", helper.load_findings(str(local_path))[0]["id"])
+    check("load_findings_list", "r1", helper.load_findings(str(ready_path))[0]["id"])
+
+if FAIL_COUNT:
+    raise SystemExit(f"FAIL: {FAIL_COUNT} test(s) failed")
+
+print(f"PASS: {PASS_COUNT} test(s) passed")

--- a/scripts/development-workflow/tests/test-local-ai-reviewer-findings.py
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer-findings.py
@@ -62,6 +62,20 @@ same_ready = norm([
 ])
 check("same_class_matches", 0, helper.compare(same_local, same_ready)["net_new_count"])
 
+missing_head_local = norm([
+    {
+        "id": "l1",
+        "path": "scripts/a.sh",
+        "line": 10,
+        "affected_scope": "scripts/a.sh",
+        "category_key": "validation",
+        "requirement_key": "tests",
+        "failure_mode_key": "missing",
+        "title": "Add test",
+    }
+])
+check("missing_local_head_does_not_match_ready_head", 1, helper.compare(missing_head_local, same_ready)["net_new_count"])
+
 different_key_ready = norm([
     {
         "id": "r2",

--- a/scripts/development-workflow/tests/test-local-ai-reviewer-findings.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer-findings.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Wrapper suite for local-ai-reviewer-findings.py.
+# covers: scripts/development-workflow/local-ai-reviewer-findings.py
+# covers: scripts/development-workflow/tests/test-local-ai-reviewer-findings.py
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+python3 "$SCRIPT_DIR/test-local-ai-reviewer-findings.py"

--- a/scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Dispatch tests for the local AI reviewer pr-review-loop platform.
+# covers: scripts/development-workflow/pr-review-loop.sh
+# covers: scripts/development-workflow/local-ai-reviewer.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '$expected', got '$actual'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+HARNESS_MODE=1 source "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
+
+actual="$(bot_login_for_platform local-ai-reviewer)"
+run_test "bot_login_for_platform_local_ai_reviewer_empty" "" "$actual"
+
+_local_ai_dispatch_called=0
+run_local_ai_reviewer_review() {
+  _local_ai_dispatch_called=1
+  print_kv RESULT skipped
+  print_kv REASON disabled_by_config
+  print_kv COMMENT_COUNT 0
+  print_kv BLOCKING_COUNT 0
+  print_kv SUGGESTION_COUNT 0
+}
+
+run_platform_review "local-ai-reviewer" "999" "feature/test" "30" "120" >/dev/null 2>&1 || true
+run_test "run_platform_review_routes_to_local_ai_reviewer" "1" "$_local_ai_dispatch_called"
+
+unset -f run_local_ai_reviewer_review
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  echo "FAIL: $FAIL_COUNT test(s) failed"
+  exit 1
+fi
+
+echo "PASS: $PASS_COUNT test(s) passed"

--- a/scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh
@@ -42,6 +42,13 @@ run_local_ai_reviewer_review() {
 run_platform_review "local-ai-reviewer" "999" "feature/test" "30" "120" >/dev/null 2>&1 || true
 run_test "run_platform_review_routes_to_local_ai_reviewer" "1" "$_local_ai_dispatch_called"
 
+if grep -q 'needs_rerun) print_kv RESULT needs_rerun' "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"; then
+  actual="present"
+else
+  actual="missing"
+fi
+run_test "local_ai_reviewer_preserves_needs_rerun_mapping" "present" "$actual"
+
 unset -f run_local_ai_reviewer_review
 
 if [ "$FAIL_COUNT" -ne 0 ]; then

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -97,6 +97,10 @@ reset_mocks() {
   unset LOCAL_AI_REVIEWER_GRAPH_STRATEGY
 }
 
+set_mock_stdout() {
+  MOCK_LOCAL_REVIEWER_STDOUT="$1"
+}
+
 init_repo_root_fixture() {
   git -C "$VALID_REPO_ROOT" init -q
   git -C "$VALID_REPO_ROOT" config user.email "test@example.com"
@@ -144,7 +148,7 @@ run_test "missing_command_exit" "2" "$(exit_code)"
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
-MOCK_LOCAL_REVIEWER_STDOUT='{"result":"clean","findings":[]}'
+set_mock_stdout '{"result":"clean","findings":[]}'
 export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "clean_result" "RESULT=clean" "$(line_for RESULT)"
@@ -153,7 +157,7 @@ run_test "clean_exit" "0" "$(exit_code)"
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
-MOCK_LOCAL_REVIEWER_STDOUT='{"findings":[{"severity":"low","advisory":true,"message":"optional wording"}]}'
+set_mock_stdout '{"findings":[{"severity":"low","advisory":true,"message":"optional wording"}]}'
 export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "advisory_result" "RESULT=clean" "$(line_for RESULT)"
@@ -161,7 +165,7 @@ run_test "advisory_suggestions" "SUGGESTION_COUNT=1" "$(line_for SUGGESTION_COUN
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
-MOCK_LOCAL_REVIEWER_STDOUT='{"findings":[{"severity":"suggestion","clear_in_scope":true,"message":"add missing test"}]}'
+set_mock_stdout '{"findings":[{"severity":"suggestion","clear_in_scope":true,"message":"add missing test"}]}'
 export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "clear_in_scope_suggestion_result" "RESULT=needs_fixes" "$(line_for RESULT)"
@@ -169,21 +173,21 @@ run_test "clear_in_scope_suggestion_blocking" "BLOCKING_COUNT=1" "$(line_for BLO
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
-MOCK_LOCAL_REVIEWER_STDOUT='{"findings":[{"severity":"important","message":"fix before ready"}]}'
+set_mock_stdout '{"findings":[{"severity":"important","message":"fix before ready"}]}'
 export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "important_result" "RESULT=needs_fixes" "$(line_for RESULT)"
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
-MOCK_LOCAL_REVIEWER_STDOUT='{"result":"clean","findings":[{"severity":"important","message":"fix before ready"}]}'
+set_mock_stdout '{"result":"clean","findings":[{"severity":"important","message":"fix before ready"}]}'
 export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "explicit_clean_with_important_result" "RESULT=needs_fixes" "$(line_for RESULT)"
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
-MOCK_LOCAL_REVIEWER_STDOUT='{"result":"needs_rerun","reason":"state_changed","findings":[]}'
+set_mock_stdout '{"result":"needs_rerun","reason":"state_changed","findings":[]}'
 export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "needs_rerun_result" "RESULT=needs_rerun" "$(line_for RESULT)"
@@ -192,7 +196,7 @@ run_test "needs_rerun_exit" "1" "$(exit_code)"
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
-MOCK_LOCAL_REVIEWER_STDOUT='not json'
+set_mock_stdout 'not json'
 export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "malformed_result" "RESULT=escalate" "$(line_for RESULT)"
@@ -228,7 +232,7 @@ run_test "timeout_reason" "REASON=timeout" "$(line_for REASON)"
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
 LOCAL_AI_REVIEWER_GRAPH_STRATEGY=auto
-MOCK_LOCAL_REVIEWER_STDOUT='{"result":"clean","findings":[]}'
+set_mock_stdout '{"result":"clean","findings":[]}'
 export LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_GRAPH_STRATEGY MOCK_LOCAL_REVIEWER_STDOUT
 run_reviewer "$MOCK_BIN:$NO_GRAPH_BIN"
 run_test "graph_skipped_result" "RESULT=clean" "$(line_for RESULT)"
@@ -236,7 +240,7 @@ run_test "graph_skipped_context" "GRAPH_CONTEXT=skipped" "$(line_for GRAPH_CONTE
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
-MOCK_LOCAL_REVIEWER_STDOUT='{"result":"clean","findings":[]}'
+set_mock_stdout '{"result":"clean","findings":[]}'
 MOCK_PR_HEAD_SHA="0000000000000000000000000000000000000000"
 export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT MOCK_PR_HEAD_SHA
 run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT"

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Unit tests for local-ai-reviewer.sh.
+# covers: scripts/development-workflow/local-ai-reviewer.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)"
+REVIEWER="$REPO_ROOT/scripts/development-workflow/local-ai-reviewer.sh"
+
+MOCK_BIN="$(mktemp -d)"
+NO_GRAPH_BIN="$(mktemp -d)"
+OUTPUT_FILE="$(mktemp)"
+STDERR_FILE="$(mktemp)"
+EXIT_FILE="$(mktemp)"
+VALID_REPO_ROOT="$(mktemp -d)"
+
+cleanup() {
+  local status=$?
+  rm -rf "$MOCK_BIN" "$NO_GRAPH_BIN" "$VALID_REPO_ROOT"
+  rm -f "$OUTPUT_FILE" "$STDERR_FILE" "$EXIT_FILE"
+  exit "$status"
+}
+trap cleanup EXIT
+
+for _cmd in awk bash cat dirname git grep jq mktemp rm sh sleep tr; do
+  _cmd_path="$(command -v "$_cmd")"
+  ln -sf "$_cmd_path" "$NO_GRAPH_BIN/$_cmd"
+done
+unset _cmd _cmd_path
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '$expected', got '$actual'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+install_gh_mock() {
+  cat > "$MOCK_BIN/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"pr view 123"*"--json baseRefName,headRefName,headRefOid"*)
+    if [ -n "${MOCK_PR_HEAD_SHA:-}" ]; then
+      mock_head_sha="$MOCK_PR_HEAD_SHA"
+    elif ! mock_head_sha="$(git rev-parse HEAD 2>/dev/null)"; then
+      mock_head_sha=""
+    fi
+    printf '{"baseRefName":"develop","headRefName":"feature/test","headRefOid":"%s"}\n' "$mock_head_sha"
+    exit 0
+    ;;
+  *"pr diff 123"*"--name-only"*)
+    printf 'scripts/example.sh\nREVIEW.md\n'
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+MOCK_GH
+  chmod +x "$MOCK_BIN/gh"
+}
+
+install_local_reviewer_mock() {
+  cat > "$MOCK_BIN/local-reviewer-mock" <<'MOCK_REVIEWER'
+#!/usr/bin/env bash
+if [ -n "${MOCK_LOCAL_REVIEWER_SLEEP:-}" ]; then
+  sleep "$MOCK_LOCAL_REVIEWER_SLEEP"
+fi
+if [ -n "${MOCK_LOCAL_REVIEWER_STDERR:-}" ]; then
+  printf '%s\n' "$MOCK_LOCAL_REVIEWER_STDERR" >&2
+fi
+if [ -n "${MOCK_LOCAL_REVIEWER_STDOUT:-}" ]; then
+  printf '%s\n' "$MOCK_LOCAL_REVIEWER_STDOUT"
+fi
+exit "${MOCK_LOCAL_REVIEWER_EXIT:-0}"
+MOCK_REVIEWER
+  chmod +x "$MOCK_BIN/local-reviewer-mock"
+}
+
+reset_mocks() {
+  rm -f "$MOCK_BIN/gh" "$MOCK_BIN/local-reviewer-mock"
+  install_gh_mock
+  install_local_reviewer_mock
+  unset MOCK_PR_HEAD_SHA MOCK_LOCAL_REVIEWER_STDOUT MOCK_LOCAL_REVIEWER_STDERR
+  unset MOCK_LOCAL_REVIEWER_EXIT MOCK_LOCAL_REVIEWER_SLEEP
+  unset LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_DISABLED LOCAL_AI_REVIEWER_TIMEOUT
+  unset LOCAL_AI_REVIEWER_GRAPH_STRATEGY
+}
+
+init_repo_root_fixture() {
+  git -C "$VALID_REPO_ROOT" init -q
+  git -C "$VALID_REPO_ROOT" config user.email "test@example.com"
+  git -C "$VALID_REPO_ROOT" config user.name "Test User"
+  printf '# Review\n' > "$VALID_REPO_ROOT/REVIEW.md"
+  git -C "$VALID_REPO_ROOT" add REVIEW.md
+  git -C "$VALID_REPO_ROOT" commit -q -m "fixture"
+  git -C "$VALID_REPO_ROOT" remote add origin "git@github.com:owner/repo.git"
+}
+
+run_reviewer() {
+  local path_value="$1"
+  shift
+  set +e
+  PATH="$path_value" "$REVIEWER" 123 owner repo "$@" >"$OUTPUT_FILE" 2>"$STDERR_FILE"
+  local status=$?
+  set -e
+  printf '%s\n' "$status" > "$EXIT_FILE"
+}
+
+line_for() {
+  local key="$1"
+  grep "^${key}=" "$OUTPUT_FILE" | head -n 1 || true
+}
+
+exit_code() {
+  cat "$EXIT_FILE"
+}
+
+init_repo_root_fixture
+
+reset_mocks
+LOCAL_AI_REVIEWER_DISABLED=1
+export LOCAL_AI_REVIEWER_DISABLED
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "disabled_result" "RESULT=skipped" "$(line_for RESULT)"
+run_test "disabled_reason" "REASON=disabled_by_config" "$(line_for REASON)"
+run_test "disabled_exit" "3" "$(exit_code)"
+
+reset_mocks
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "missing_command_result" "RESULT=escalate" "$(line_for RESULT)"
+run_test "missing_command_reason" "REASON=missing_command" "$(line_for REASON)"
+run_test "missing_command_exit" "2" "$(exit_code)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+MOCK_LOCAL_REVIEWER_STDOUT='{"result":"clean","findings":[]}'
+export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "clean_result" "RESULT=clean" "$(line_for RESULT)"
+run_test "clean_comments" "COMMENT_COUNT=0" "$(line_for COMMENT_COUNT)"
+run_test "clean_exit" "0" "$(exit_code)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+MOCK_LOCAL_REVIEWER_STDOUT='{"findings":[{"severity":"low","advisory":true,"message":"optional wording"}]}'
+export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "advisory_result" "RESULT=clean" "$(line_for RESULT)"
+run_test "advisory_suggestions" "SUGGESTION_COUNT=1" "$(line_for SUGGESTION_COUNT)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+MOCK_LOCAL_REVIEWER_STDOUT='{"findings":[{"severity":"suggestion","clear_in_scope":true,"message":"add missing test"}]}'
+export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "clear_in_scope_suggestion_result" "RESULT=needs_fixes" "$(line_for RESULT)"
+run_test "clear_in_scope_suggestion_blocking" "BLOCKING_COUNT=1" "$(line_for BLOCKING_COUNT)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+MOCK_LOCAL_REVIEWER_STDOUT='{"findings":[{"severity":"important","message":"fix before ready"}]}'
+export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "important_result" "RESULT=needs_fixes" "$(line_for RESULT)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+MOCK_LOCAL_REVIEWER_STDOUT='not json'
+export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "malformed_result" "RESULT=escalate" "$(line_for RESULT)"
+run_test "malformed_reason" "REASON=malformed_output" "$(line_for REASON)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+MOCK_LOCAL_REVIEWER_STDERR='missing model access'
+MOCK_LOCAL_REVIEWER_EXIT=1
+export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDERR MOCK_LOCAL_REVIEWER_EXIT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "missing_model_result" "RESULT=escalate" "$(line_for RESULT)"
+run_test "missing_model_reason" "REASON=missing_model_access" "$(line_for REASON)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+MOCK_LOCAL_REVIEWER_STDERR='missing credentials'
+MOCK_LOCAL_REVIEWER_EXIT=1
+export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDERR MOCK_LOCAL_REVIEWER_EXIT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "missing_credentials_result" "RESULT=escalate" "$(line_for RESULT)"
+run_test "missing_credentials_reason" "REASON=missing_credentials" "$(line_for REASON)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+LOCAL_AI_REVIEWER_TIMEOUT=1
+MOCK_LOCAL_REVIEWER_SLEEP=2
+export LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_TIMEOUT MOCK_LOCAL_REVIEWER_SLEEP
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "timeout_result" "RESULT=escalate" "$(line_for RESULT)"
+run_test "timeout_reason" "REASON=timeout" "$(line_for REASON)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+LOCAL_AI_REVIEWER_GRAPH_STRATEGY=auto
+MOCK_LOCAL_REVIEWER_STDOUT='{"result":"clean","findings":[]}'
+export LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_GRAPH_STRATEGY MOCK_LOCAL_REVIEWER_STDOUT
+run_reviewer "$MOCK_BIN:$NO_GRAPH_BIN"
+run_test "graph_skipped_result" "RESULT=clean" "$(line_for RESULT)"
+run_test "graph_skipped_context" "GRAPH_CONTEXT=skipped" "$(line_for GRAPH_CONTEXT)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+MOCK_LOCAL_REVIEWER_STDOUT='{"result":"clean","findings":[]}'
+MOCK_PR_HEAD_SHA="0000000000000000000000000000000000000000"
+export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT MOCK_PR_HEAD_SHA
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT"
+run_test "head_mismatch_result" "RESULT=escalate" "$(line_for RESULT)"
+run_test "head_mismatch_reason" "REASON=head_mismatch" "$(line_for REASON)"
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  echo "FAIL: $FAIL_COUNT test(s) failed"
+  exit 1
+fi
+
+echo "PASS: $PASS_COUNT test(s) passed"

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -59,6 +59,9 @@ case "$*" in
     exit 0
     ;;
   *"pr diff 123"*"--name-only"*)
+    if [ "${MOCK_PR_DIFF_EXIT:-0}" -ne 0 ]; then
+      exit "$MOCK_PR_DIFF_EXIT"
+    fi
     printf 'scripts/example.sh\nREVIEW.md\n'
     exit 0
     ;;
@@ -91,7 +94,7 @@ reset_mocks() {
   rm -f "$MOCK_BIN/gh" "$MOCK_BIN/local-reviewer-mock"
   install_gh_mock
   install_local_reviewer_mock
-  unset MOCK_PR_HEAD_SHA MOCK_LOCAL_REVIEWER_STDOUT MOCK_LOCAL_REVIEWER_STDERR
+  unset MOCK_PR_HEAD_SHA MOCK_PR_DIFF_EXIT MOCK_LOCAL_REVIEWER_STDOUT MOCK_LOCAL_REVIEWER_STDERR
   unset MOCK_LOCAL_REVIEWER_EXIT MOCK_LOCAL_REVIEWER_SLEEP
   unset LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_DISABLED LOCAL_AI_REVIEWER_TIMEOUT
   unset LOCAL_AI_REVIEWER_GRAPH_STRATEGY
@@ -187,6 +190,16 @@ run_test "explicit_clean_with_important_result" "RESULT=needs_fixes" "$(line_for
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+set_mock_stdout '{"findings":[{"severity":"important","path":"scripts/example.sh","line":42,"message":"unauthorized text in a real finding"}]}'
+export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "finding_text_does_not_trigger_auth_escalation_result" "RESULT=needs_fixes" "$(line_for RESULT)"
+run_test "blocking_detail_path" "BLOCKING_1_PATH=scripts/example.sh" "$(line_for BLOCKING_1_PATH)"
+run_test "blocking_detail_line" "BLOCKING_1_LINE=42" "$(line_for BLOCKING_1_LINE)"
+run_test "blocking_detail_body" "BLOCKING_1_BODY=unauthorized text in a real finding" "$(line_for BLOCKING_1_BODY)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
 set_mock_stdout '{"result":"needs_rerun","reason":"state_changed","findings":[]}'
 export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
 run_reviewer "$MOCK_BIN:$PATH"
@@ -219,6 +232,15 @@ export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDERR MOCK_LOCAL_REVIEWER_
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "missing_credentials_result" "RESULT=escalate" "$(line_for RESULT)"
 run_test "missing_credentials_reason" "REASON=missing_credentials" "$(line_for REASON)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+MOCK_PR_DIFF_EXIT=1
+set_mock_stdout '{"result":"clean","findings":[]}'
+export LOCAL_AI_REVIEWER_COMMAND MOCK_PR_DIFF_EXIT MOCK_LOCAL_REVIEWER_STDOUT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "diff_unavailable_result" "RESULT=escalate" "$(line_for RESULT)"
+run_test "diff_unavailable_reason" "REASON=diff_unavailable" "$(line_for REASON)"
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -176,6 +176,22 @@ run_test "important_result" "RESULT=needs_fixes" "$(line_for RESULT)"
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+MOCK_LOCAL_REVIEWER_STDOUT='{"result":"clean","findings":[{"severity":"important","message":"fix before ready"}]}'
+export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "explicit_clean_with_important_result" "RESULT=needs_fixes" "$(line_for RESULT)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+MOCK_LOCAL_REVIEWER_STDOUT='{"result":"needs_rerun","reason":"state_changed","findings":[]}'
+export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "needs_rerun_result" "RESULT=needs_rerun" "$(line_for RESULT)"
+run_test "needs_rerun_reason" "REASON=state_changed" "$(line_for REASON)"
+run_test "needs_rerun_exit" "1" "$(exit_code)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
 MOCK_LOCAL_REVIEWER_STDOUT='not json'
 export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDOUT
 run_reviewer "$MOCK_BIN:$PATH"


### PR DESCRIPTION
## Summary
- Adds an opt-in `local-ai-reviewer` Step 7 platform backed by `local-ai-reviewer.sh`.
- Adds conservative local result parsing, current-head binding, optional graph-context status, and finding comparison support.
- Wires the platform into `pr-review-loop.sh`, docs, smoke-test runbook, tests, and changelog while keeping Bugbot as this repo's ready-phase reviewer.

## Pre-Submission Self-Review Pass
- Diff reviewed against spec #1604 and approved plan #1606: local-only CLI reviewer, strict result contract, deterministic current-head/review-contract checks, optional graph fallback, no GitHub inline comments, ready-phase Bugbot preserved.
- Operational assumptions re-verified as still valid at implementation start: `develop` base, single-repo template, `review.on_ready.github: [bugbot]`, local reviewer as `review.on_draft.github`/`pr-review-loop.sh` platform, graph tooling optional.
- Complex decision-gate matrix coverage implemented for configured/missing/disabled command, head mismatch, malformed output, timeout, graph skipped, local findings, and ready-phase Bugbot measurement.
- Parser-risk coverage added for terminal result parsing and local/ready finding matching.
- Stale-marker scan over changed files found no TODO/FIXME/TBD/placeholder/debug markers.
- Stage alignment: implementation branch contains implementation files, tests, docs, config comments, smoke-test updates, and changelog entry only.

## Validation
- `bash scripts/development-workflow/tests/test-local-ai-reviewer.sh`
- `bash scripts/development-workflow/tests/test-local-ai-reviewer-findings.sh`
- `python3 scripts/development-workflow/tests/test-local-ai-reviewer-findings.py`
- `bash scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh`
- `bash scripts/development-workflow/tests/test-coderabbit-cli-pr-review-loop-dispatch.sh`
- `bash scripts/development-workflow/tests/test-placeholder-workflows-opt-in.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh` (1160 passed, 0 failed)
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md" "docs/workflow/development-workflow/integrations/**/*.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `bash scripts/development-workflow/select-test-suites.sh --changed-files /tmp/1604-changed-files.txt`
- `bash scripts/development-workflow/select-test-suites.sh --report-gaps` (existing uncovered scripts reduced back to 4; no unreachable suites)
- `bash scripts/development-workflow/run-nested-artifact-guard.sh --mode pre-pr --issue 1604 --expected-branch feature/1604-repo-native-automated-pr-reviewer --approved-base develop --expected-worktree /Users/lhpaul/Git/ai-dev-framework-template-1604-reviewer-impl --repo-root /Users/lhpaul/Git/ai-dev-framework-template-1604-reviewer-impl`

Closes #1604

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Step 7 review orchestration and result parsing; misconfiguration or parser bugs could block or misclassify PRs, though the platform is opt-in and fails closed on setup errors.
> 
> **Overview**
> Adds an **opt-in `local-ai-reviewer`** draft-phase Step 7 platform so repos can run a configured local command before ready-phase reviewers (e.g. Bugbot). **`local-ai-reviewer.sh`** builds a PR context bundle, runs `LOCAL_AI_REVIEWER_COMMAND` under timeout, binds results to the current PR head and `REVIEW.md`, maps JSON findings to the existing `pr-review-loop.sh` key=value contract (clean / needs_fixes / needs_rerun / escalate / skipped), and records optional graph context without blocking when tools are missing.
> 
> **`pr-review-loop.sh`** gains dispatch via `run_local_ai_reviewer_review`, empty bot login for this platform, and **`needs_rerun`** preservation aligned with the CodeRabbit CLI path. **`local-ai-reviewer-findings.py`** compares local vs ready-phase findings conservatively (ambiguous matches count as net-new).
> 
> Docs (integration guide, platform index, workflow YAML comments), changelog, smoke runbook with automated fixture pointers, and unit/dispatch tests cover the new behavior; Bugbot remains the documented ready-phase default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 371cf4b32e2e1b50fc458d0f1ca42f23e3af6285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->