### PR TITLE
fix(cleanup): ignore quoted closing keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-repository releases.
 
 ### Fixed
+
+- **Quoted closing keywords are ignored during post-merge cleanup** (#1585):
+  `post-merge-cleanup.sh` now excludes inline code spans and blockquote lines
+  before scanning PR bodies for closing keywords, preventing quoted examples
+  such as `` `Closes #123` `` from closing unrelated issues while preserving
+  ordinary live `Closes #N` references.
 - **Codex GitHub reviewer avoids duplicate trigger cycles** (#1601):
   `codex-github-reviewer.sh` now checks for existing current-head Codex review
   evidence before posting `@codex review`, reusing submitted reviews,

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -556,7 +556,7 @@ for line in lines:
             continue
         if re.match(r"^\s*>", line):
             continue
-        out.append(strip_inline_code_spans(line))
+        out.append(line)
     else:
         if (match and match.group(1)[0] == fence_char
                 and len(match.group(1)) >= fence_len
@@ -564,7 +564,7 @@ for line in lines:
             fence_char = None
             fence_len = 0
         continue
-sys.stdout.write("\n".join(out))
+sys.stdout.write(strip_inline_code_spans("\n".join(out)))
 '
 }
 

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -542,6 +542,21 @@ def strip_inline_code_spans(line):
         i = closing + len(ticks)
     return "".join(out)
 
+def strip_inline_code_spans_by_paragraph(lines):
+    out_lines = []
+    paragraph = []
+    for line in lines:
+        if line.strip() == "":
+            if paragraph:
+                out_lines.extend(strip_inline_code_spans("\n".join(paragraph)).split("\n"))
+                paragraph = []
+            out_lines.append(line)
+        else:
+            paragraph.append(line)
+    if paragraph:
+        out_lines.extend(strip_inline_code_spans("\n".join(paragraph)).split("\n"))
+    return "\n".join(out_lines)
+
 lines = sys.stdin.read().split("\n")
 out = []
 fence_char = None
@@ -564,7 +579,7 @@ for line in lines:
             fence_char = None
             fence_len = 0
         continue
-sys.stdout.write(strip_inline_code_spans("\n".join(out)))
+sys.stdout.write(strip_inline_code_spans_by_paragraph(out))
 '
 }
 

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -502,24 +502,46 @@ fi
 # --- Update tracker status and close associated GitHub issue (if any) ---
 
 # strip_fenced_pr_body_blocks
-# Removes fenced code blocks from stdin before it is scanned for closing
-# keywords, so an example like "Closes #999" inside a code sample in the PR
-# body is not treated as a live closing reference. Handles both backtick
-# (```) and tilde (~~~) fence styles, and treats an unclosed opening fence as
-# extending to end of input (rather than leaving the rest of the body
-# unfiltered). Matches GitHub-Flavored Markdown's fence-matching rule: a
-# closing fence must use the same character as the opening fence, be at
-# least as long, and have nothing but trailing whitespace after the fence
-# marker — a shorter, differently-charactered, or content-suffixed line
-# (e.g. a nested example fence, or "``` end of block") is treated as still
-# being inside the fence rather than closing it. A fence delimiter may be
-# indented up to 3 spaces per GFM; 4+ spaces of leading whitespace makes it
-# indented code instead, so the raw line (not a fully whitespace-stripped
-# line) is matched to preserve that boundary — otherwise a 4-space-indented
-# "```" could be mistaken for a real fence and hide a live closing reference.
+# Removes quoted/example PR body text from stdin before it is scanned for
+# closing keywords, so an example like "Closes #999" inside a code sample,
+# inline code span, or blockquote is not treated as a live closing reference.
+# Handles both backtick (```) and tilde (~~~) fence styles, and treats an
+# unclosed opening fence as extending to end of input (rather than leaving the
+# rest of the body unfiltered). Matches GitHub-Flavored Markdown's
+# fence-matching rule: a closing fence must use the same character as the
+# opening fence, be at least as long, and have nothing but trailing whitespace
+# after the fence marker — a shorter, differently-charactered, or
+# content-suffixed line (e.g. a nested example fence, or "``` end of block") is
+# treated as still being inside the fence rather than closing it. A fence
+# delimiter may be indented up to 3 spaces per GFM; 4+ spaces of leading
+# whitespace makes it indented code instead, so the raw line (not a fully
+# whitespace-stripped line) is matched to preserve that boundary — otherwise a
+# 4-space-indented "```" could be mistaken for a real fence and hide a live
+# closing reference.
 strip_fenced_pr_body_blocks() {
   python3 -c '
 import re, sys
+
+def strip_inline_code_spans(line):
+    out = []
+    i = 0
+    while i < len(line):
+        if line[i] != "`":
+            out.append(line[i])
+            i += 1
+            continue
+        j = i
+        while j < len(line) and line[j] == "`":
+            j += 1
+        ticks = line[i:j]
+        closing = line.find(ticks, j)
+        if closing == -1:
+            out.append(line[i])
+            i += 1
+            continue
+        i = closing + len(ticks)
+    return "".join(out)
+
 lines = sys.stdin.read().split("\n")
 out = []
 fence_char = None
@@ -532,7 +554,9 @@ for line in lines:
             fence_char = match.group(1)[0]
             fence_len = len(match.group(1))
             continue
-        out.append(line)
+        if re.match(r"^\s*>", line):
+            continue
+        out.append(strip_inline_code_spans(line))
     else:
         if (match and match.group(1)[0] == fence_char
                 and len(match.group(1)) >= fence_len

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -699,6 +699,42 @@ run_test \
     fi
   )"
 
+# Multi-line inline code spans must stay excluded until their closing delimiter.
+multiline_inline_branch="fix/retro-527-doc-gaps"
+multiline_inline_repo="$(make_repo multiline-inline "$multiline_inline_branch" yes)"
+multiline_inline_pr_body='Cleans up doc gaps.
+
+This quoted inline example starts here: `Closes #992
+and keeps quoting Closes #991`
+
+Closes #612'
+multiline_inline_output="$(
+  GH_MERGED_HEAD="$multiline_inline_branch" \
+  GH_MERGED_PR=660 \
+  GH_PR_BODY="$multiline_inline_pr_body" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$multiline_inline_repo" --base develop --pr 660 "$multiline_inline_branch"
+)"
+run_contains \
+  "multiline_inline_code_example_closes_real_issue" \
+  "Closing issue #612..." \
+  "$multiline_inline_output"
+run_test \
+  "multiline_inline_code_example_does_not_close_quoted_issues" \
+  "no" \
+  "$(
+    if grep -Fq "Closing issue #992" <<<"$multiline_inline_output" \
+      || grep -Fq "Processing issue #992" <<<"$multiline_inline_output" \
+      || grep -Fq "Closing issue #991" <<<"$multiline_inline_output" \
+      || grep -Fq "Processing issue #991" <<<"$multiline_inline_output"; then
+      printf 'yes'
+    else
+      printf 'no'
+    fi
+  )"
+
 # Blockquoted closing-keyword examples must not be treated as live references.
 blockquote_branch="fix/retro-526-doc-gaps"
 blockquote_repo="$(make_repo blockquote "$blockquote_branch" yes)"

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -667,6 +667,70 @@ run_test \
     fi
   )"
 
+# Inline-code examples quoted in prose must not be treated as live references.
+inline_code_branch="fix/retro-525-doc-gaps"
+inline_code_repo="$(make_repo inline-code "$inline_code_branch" yes)"
+inline_code_pr_body='Cleans up doc gaps.
+
+The old parser matched `Closes #995` in prose.
+
+Closes #610'
+inline_code_output="$(
+  GH_MERGED_HEAD="$inline_code_branch" \
+  GH_MERGED_PR=658 \
+  GH_PR_BODY="$inline_code_pr_body" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$inline_code_repo" --base develop --pr 658 "$inline_code_branch"
+)"
+run_contains \
+  "inline_code_example_closes_real_issue" \
+  "Closing issue #610..." \
+  "$inline_code_output"
+run_test \
+  "inline_code_example_does_not_close_quoted_issue" \
+  "no" \
+  "$(
+    if grep -Fq "Closing issue #995" <<<"$inline_code_output" || grep -Fq "Processing issue #995" <<<"$inline_code_output"; then
+      printf 'yes'
+    else
+      printf 'no'
+    fi
+  )"
+
+# Blockquoted closing-keyword examples must not be treated as live references.
+blockquote_branch="fix/retro-526-doc-gaps"
+blockquote_repo="$(make_repo blockquote "$blockquote_branch" yes)"
+blockquote_pr_body='Cleans up doc gaps.
+
+> Reviewer said: Closes #993
+
+Closes #611'
+blockquote_output="$(
+  GH_MERGED_HEAD="$blockquote_branch" \
+  GH_MERGED_PR=659 \
+  GH_PR_BODY="$blockquote_pr_body" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$blockquote_repo" --base develop --pr 659 "$blockquote_branch"
+)"
+run_contains \
+  "blockquote_example_closes_real_issue" \
+  "Closing issue #611..." \
+  "$blockquote_output"
+run_test \
+  "blockquote_example_does_not_close_quoted_issue" \
+  "no" \
+  "$(
+    if grep -Fq "Closing issue #993" <<<"$blockquote_output" || grep -Fq "Processing issue #993" <<<"$blockquote_output"; then
+      printf 'yes'
+    else
+      printf 'no'
+    fi
+  )"
+
 # Tilde-fenced (~~~) code blocks must be excluded the same way as
 # backtick-fenced blocks.
 tilde_fenced_branch="fix/retro-520-doc-gaps"

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -735,6 +735,27 @@ run_test \
     fi
   )"
 
+# An unmatched backtick in an earlier paragraph must not swallow a later live
+# closing reference after a blank-line paragraph break.
+unmatched_inline_branch="fix/retro-528-doc-gaps"
+unmatched_inline_repo="$(make_repo unmatched-inline "$unmatched_inline_branch" yes)"
+unmatched_inline_pr_body='Cleans up doc gaps with an unmatched `example marker.
+
+Closes #613'
+unmatched_inline_output="$(
+  GH_MERGED_HEAD="$unmatched_inline_branch" \
+  GH_MERGED_PR=661 \
+  GH_PR_BODY="$unmatched_inline_pr_body" \
+  GH_ISSUE_STATE=OPEN \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" --repo-root "$unmatched_inline_repo" --base develop --pr 661 "$unmatched_inline_branch"
+)"
+run_contains \
+  "unmatched_inline_previous_paragraph_closes_real_issue" \
+  "Closing issue #613..." \
+  "$unmatched_inline_output"
+
 # Blockquoted closing-keyword examples must not be treated as live references.
 blockquote_branch="fix/retro-526-doc-gaps"
 blockquote_repo="$(make_repo blockquote "$blockquote_branch" yes)"


### PR DESCRIPTION
## Summary

- Strip quoted closing-keyword examples from PR bodies before post-merge cleanup decides which issues to close.
- Preserve ordinary live closing references, fenced-code behavior, and inline code that spans lines within a paragraph.
- Add regression coverage for inline-code, multiline-inline, unmatched-backtick, and blockquote examples.

Closes #1585

## Pre-Submission Self-Review

- Scope check: limited to post-merge cleanup closing-keyword parsing, focused cleanup tests, and changelog entry.
- Issue coverage: AC-1 inline code span ignored; AC-2 blockquote ignored; AC-3 inline, blockquote, and live `Closes #N` controls covered in `test-post-merge-cleanup.sh`.
- Reviewer follow-up: local reviewer caught multiline inline spans; Bugbot caught unmatched backticks crossing paragraph breaks. Both were fixed with regression tests.
- Stale markers: no TODO/FIXME placeholders added.
- Sibling/caller consistency: `fetch_pr_closing_issues` still returns sorted issue numbers and preserves fail-closed extraction errors.
- Workflow decision-gate matrix: not applicable; no workflow dispatch/security behavior or external API permissions changed.

## Validation

- `bash scripts/development-workflow/tests/test-post-merge-cleanup.sh` -> Passed: 65, Failed: 0
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `shellcheck --severity=warning scripts/development-workflow/post-merge-cleanup.sh scripts/development-workflow/tests/test-post-merge-cleanup.sh`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md`

## Dogfood Evidence

- `local-ai-reviewer.sh` on head `4a9d30257af2129e102952d1f81f98cf9f2a8738` -> clean, 0 blocking findings.
- `pr-review-loop.sh 1608 --branch fix/1585-closing-keywords-quoted-prose --max-wait 600 --post-final-summary` -> clean.
- Ready phase: Bugbot clean, 0 unresolved threads, post-clean quiet window settled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which GitHub issues get closed after merge; incorrect parsing could skip a real close or (less likely now) close the wrong issue, though scope is limited to cleanup parsing and is heavily tested.
> 
> **Overview**
> **Post-merge cleanup** no longer treats **example** `Closes #N` text in merged PR bodies as live closing keywords. `strip_fenced_pr_body_blocks` in `post-merge-cleanup.sh` now drops **blockquote lines** and removes **inline code spans** (including multi-line spans within a paragraph) before `fetch_pr_closing_issues` scans for keywords, on top of the existing fenced-code behavior.
> 
> Ordinary footer-style `Closes #N` references still close issues and update the tracker. **Regression tests** cover inline examples, multiline backticks, unmatched backticks in a prior paragraph, and blockquoted examples.
> 
> **CHANGELOG** documents the fix (#1585).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a9d30257af2129e102952d1f81f98cf9f2a8738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
