### PR TITLE
feat(review): add local Codex reviewer preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Local Codex reviewer preset and dogfood evidence** (#1609): adds a short
+  `local-codex-reviewer.sh` wrapper for the `local-ai-reviewer` platform,
+  enriches the local reviewer context bundle with compact diff metadata, and
+  can persist a JSON evidence artifact for comparing local-review outcomes
+  against ready-phase reviewers.
 - **Repo-native local AI reviewer platform** (#1604): adds an opt-in
   `local-ai-reviewer` Step 7 platform with a local companion script,
   conservative result parsing, current-head binding, optional graph-context

--- a/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
+++ b/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
@@ -37,6 +37,25 @@ Set the local command in the runner environment:
 export LOCAL_AI_REVIEWER_COMMAND='my-review-command "$CONTEXT_BUNDLE_PATH"'
 ```
 
+For Codex, use the bundled preset wrapper instead of hand-writing the full
+`codex exec` command:
+
+<!-- workflow-shell-contract: bash-zsh -->
+```bash
+./scripts/development-workflow/local-codex-reviewer.sh \
+  <pr-number> <owner> <repo> \
+  --repo-root "$PWD" \
+  --timeout 900 \
+  --evidence-file /tmp/local-ai-reviewer-evidence.json
+```
+
+The wrapper sets `LOCAL_AI_REVIEWER_COMMAND` to
+`scripts/development-workflow/local-codex-review-command.sh`, which runs
+`codex exec --sandbox read-only` and writes only the model JSON output back to
+the companion script. Override `LOCAL_CODEX_REVIEWER_BIN`,
+`LOCAL_CODEX_REVIEWER_MODEL`, or `LOCAL_CODEX_REVIEWER_PROMPT` when a local
+machine needs a different Codex binary, model, or prompt.
+
 The command runs under `sh -c` with these environment variables:
 
 - `CONTEXT_BUNDLE_PATH`
@@ -47,8 +66,26 @@ The command runs under `sh -c` with these environment variables:
 - `HEAD_BRANCH`
 - `REVIEWED_HEAD`
 
+The context bundle JSON uses `schema_version:
+local_ai_reviewer_context.v1` and includes:
+
+- PR metadata and `reviewed_head`
+- `changed_files`
+- compact `diff_name_status` and `diff_stat` fields when the base ref is
+  available in the checkout
+- `review_contract`
+- `graph_context`
+
 Use `LOCAL_AI_REVIEWER_DISABLED=1` to intentionally skip the local platform
 with `RESULT=skipped` and `REASON=disabled_by_config`.
+
+Set `LOCAL_AI_REVIEWER_EVIDENCE_FILE=/path/to/file.json` or pass
+`--evidence-file` to `local-codex-reviewer.sh` to persist a local evidence
+artifact. The artifact uses `schema_version: local_ai_reviewer_evidence.v1`
+and records the reviewed head, graph context, result, reason, counts, changed
+files, and compact diff summary. Keep this artifact alongside ready-phase
+reviewer-loop evidence when measuring whether Bugbot or another ready-phase
+reviewer found net-new blockers.
 
 ---
 

--- a/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
+++ b/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
@@ -71,6 +71,8 @@ local_ai_reviewer_context.v1` and includes:
 
 - PR metadata and `reviewed_head`
 - `changed_files`
+- bounded `pr_body` text, so validation notes and planted-violation proof in
+  the PR description are visible to the local model
 - compact `diff_name_status` and `diff_stat` fields when the base ref is
   available in the checkout
 - `review_contract`

--- a/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
+++ b/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
@@ -85,7 +85,9 @@ artifact. The artifact uses `schema_version: local_ai_reviewer_evidence.v1`
 and records the reviewed head, graph context, result, reason, counts, changed
 files, and compact diff summary. Keep this artifact alongside ready-phase
 reviewer-loop evidence when measuring whether Bugbot or another ready-phase
-reviewer found net-new blockers.
+reviewer found net-new blockers. Relative evidence paths are resolved from the
+operator's original working directory before `--repo-root` changes the checkout
+directory.
 
 ---
 

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -26,6 +26,7 @@ Environment:
                                     PR_NUMBER, OWNER, REPO, BASE_BRANCH,
                                     HEAD_BRANCH, and REVIEWED_HEAD in env.
   LOCAL_AI_REVIEWER_DISABLED=1      Emit RESULT=skipped / disabled_by_config.
+  LOCAL_AI_REVIEWER_EVIDENCE_FILE   Optional path for a JSON evidence artifact.
   LOCAL_AI_REVIEWER_GRAPH_STRATEGY  none|auto|code-review-graph|graphify.
 EOF
 }
@@ -183,6 +184,8 @@ BASE_BRANCH=""
 HEAD_BRANCH=""
 HEAD_SHA=""
 changed_files_json="[]"
+diff_name_status=""
+diff_stat=""
 diff_fetch_failed=0
 if command -v gh >/dev/null 2>&1; then
   pr_json=""
@@ -241,6 +244,15 @@ if [ -n "$REPO_ROOT" ]; then
   cd "$REPO_ROOT"
 fi
 
+if git rev-parse --verify "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+  if diff_name_status_full="$(git diff --name-status --find-renames --find-copies "origin/$BASE_BRANCH...HEAD" 2>/dev/null)"; then
+    diff_name_status="${diff_name_status_full:0:12000}"
+  fi
+  if diff_stat_full="$(git diff --stat --find-renames --find-copies "origin/$BASE_BRANCH...HEAD" 2>/dev/null)"; then
+    diff_stat="${diff_stat_full:0:12000}"
+  fi
+fi
+
 if [ ! -f REVIEW.md ]; then
   echo "ERROR: REVIEW.md is required for local review" >&2
   print_result escalate 0 0 0 review_contract_missing review_contract_missing
@@ -289,8 +301,11 @@ jq -n \
   --arg head_branch "$HEAD_BRANCH" \
   --arg reviewed_head "$HEAD_SHA" \
   --arg graph_context "$graph_context" \
+  --arg diff_name_status "$diff_name_status" \
+  --arg diff_stat "$diff_stat" \
   --argjson changed_files "$changed_files_json" \
   '{
+    schema_version: "local_ai_reviewer_context.v1",
     pr_number: ($pr_number | tonumber),
     owner: $owner,
     repo: $repo,
@@ -298,6 +313,8 @@ jq -n \
     head_branch: $head_branch,
     reviewed_head: $reviewed_head,
     changed_files: $changed_files,
+    diff_name_status: $diff_name_status,
+    diff_stat: $diff_stat,
     review_contract: "REVIEW.md",
     graph_context: $graph_context
   }' >"$context_file"
@@ -444,35 +461,91 @@ blocking_count="${blocking_count:-0}"
 suggestion_count="${suggestion_count:-0}"
 reason="${reason:-}"
 
+write_evidence_file() {
+  local final_result="$1"
+  local final_reason="$2"
+  local final_comment_count="$3"
+  local final_blocking_count="$4"
+  local final_suggestion_count="$5"
+
+  [ -n "${LOCAL_AI_REVIEWER_EVIDENCE_FILE:-}" ] || return 0
+  jq -n \
+    --arg schema_version "local_ai_reviewer_evidence.v1" \
+    --arg result "$final_result" \
+    --arg reason "$final_reason" \
+    --arg pr_number "$PR_NUMBER" \
+    --arg owner "$OWNER" \
+    --arg repo "$REPO" \
+    --arg base_branch "$BASE_BRANCH" \
+    --arg head_branch "$HEAD_BRANCH" \
+    --arg reviewed_head "$HEAD_SHA" \
+    --arg graph_context "$graph_context" \
+    --arg diff_name_status "$diff_name_status" \
+    --arg diff_stat "$diff_stat" \
+    --argjson changed_files "$changed_files_json" \
+    --argjson comment_count "$final_comment_count" \
+    --argjson blocking_count "$final_blocking_count" \
+    --argjson suggestion_count "$final_suggestion_count" \
+    '{
+      schema_version: $schema_version,
+      result: $result,
+      reason: $reason,
+      pr_number: ($pr_number | tonumber),
+      owner: $owner,
+      repo: $repo,
+      base_branch: $base_branch,
+      head_branch: $head_branch,
+      reviewed_head: $reviewed_head,
+      graph_context: $graph_context,
+      counts: {
+        comments: $comment_count,
+        blocking: $blocking_count,
+        suggestions: $suggestion_count
+      },
+      context_summary: {
+        changed_files: $changed_files,
+        diff_name_status: $diff_name_status,
+        diff_stat: $diff_stat
+      }
+    }' >"$LOCAL_AI_REVIEWER_EVIDENCE_FILE"
+}
+
 case "$result" in
   clean)
     if [ "$command_exit" -ne 0 ]; then
+      write_evidence_file escalate malformed_output "$comment_count" "$blocking_count" "$suggestion_count"
       print_result escalate "$comment_count" "$blocking_count" "$suggestion_count" malformed_output malformed_output
       exit 2
     fi
+    write_evidence_file clean "" "$comment_count" 0 "$suggestion_count"
     print_result clean "$comment_count" 0 "$suggestion_count"
     exit 0
     ;;
   needs_fixes)
     [ "$blocking_count" -eq 0 ] && blocking_count=1
     [ "$comment_count" -eq 0 ] && comment_count=1
+    write_evidence_file needs_fixes local_ai_review_findings "$comment_count" "$blocking_count" "$suggestion_count"
     print_result needs_fixes "$comment_count" "$blocking_count" "$suggestion_count" local_ai_review_findings
     printf '%s\n' "$parse_result" | awk '/^BLOCKING_[0-9]+_(PATH|LINE|BODY)=/ { print }'
     exit 1
     ;;
   needs_rerun)
+    write_evidence_file needs_rerun "${reason:-needs_rerun}" "$comment_count" "$blocking_count" "$suggestion_count"
     print_result needs_rerun "$comment_count" "$blocking_count" "$suggestion_count" "${reason:-needs_rerun}"
     exit 1
     ;;
   skipped)
+    write_evidence_file skipped "${reason:-disabled_by_config}" "$comment_count" "$blocking_count" "$suggestion_count"
     print_result skipped "$comment_count" "$blocking_count" "$suggestion_count" "${reason:-disabled_by_config}" "${reason:-disabled_by_config}"
     exit 3
     ;;
   escalate)
+    write_evidence_file escalate "${reason:-malformed_output}" "$comment_count" "$blocking_count" "$suggestion_count"
     print_result escalate "$comment_count" "$blocking_count" "$suggestion_count" "${reason:-malformed_output}" "${reason:-malformed_output}"
     exit 2
     ;;
   *)
+    write_evidence_file escalate malformed_output 0 0 0
     print_result escalate 0 0 0 malformed_output malformed_output
     exit 2
     ;;

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -351,11 +351,11 @@ setup_probe_output="$command_stderr"
 if ! printf '%s\n' "$command_stdout" | jq -e . >/dev/null 2>&1; then
   setup_probe_output="$combined_output"
 fi
-if printf '%s\n' "$setup_probe_output" | grep -Eiq 'missing[[:space:]_-]+model|model[[:space:]_-]+access|model.*unavailable'; then
+if grep -Eiq 'missing[[:space:]_-]+model|model[[:space:]_-]+access|model.*unavailable' <<< "$setup_probe_output"; then
   print_result escalate 0 0 0 missing_model_access missing_model_access
   exit 2
 fi
-if printf '%s\n' "$setup_probe_output" | grep -Eiq 'missing[[:space:]_-]+credentials|credentials[[:space:]_-]+missing|unauthori[sz]ed|forbidden|(^|[^[:alnum:]_])(401|403)([^[:alnum:]_]|$)'; then
+if grep -Eiq 'missing[[:space:]_-]+credentials|credentials[[:space:]_-]+missing|unauthori[sz]ed|forbidden|(^|[^[:alnum:]_])(401|403)([^[:alnum:]_]|$)' <<< "$setup_probe_output"; then
   print_result escalate 0 0 0 missing_credentials missing_credentials
   exit 2
 fi

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -347,15 +347,18 @@ fi
 
 combined_output="${command_stdout}
 ${command_stderr}"
-setup_probe_output="$command_stderr"
+setup_probe_output=""
+if [ "$command_exit" -ne 0 ]; then
+  setup_probe_output="$command_stderr"
+fi
 if ! printf '%s\n' "$command_stdout" | jq -e . >/dev/null 2>&1; then
   setup_probe_output="$combined_output"
 fi
-if grep -Eiq 'missing[[:space:]_-]+model|model[[:space:]_-]+access|model.*unavailable' <<< "$setup_probe_output"; then
+if [ -n "$setup_probe_output" ] && grep -Eiq 'missing[[:space:]_-]+model|model[[:space:]_-]+access|model.*unavailable' <<< "$setup_probe_output"; then
   print_result escalate 0 0 0 missing_model_access missing_model_access
   exit 2
 fi
-if grep -Eiq 'missing[[:space:]_-]+credentials|credentials[[:space:]_-]+missing|unauthori[sz]ed|forbidden|(^|[^[:alnum:]_])(401|403)([^[:alnum:]_]|$)' <<< "$setup_probe_output"; then
+if [ -n "$setup_probe_output" ] && grep -Eiq 'missing[[:space:]_-]+credentials|credentials[[:space:]_-]+missing|unauthori[sz]ed|forbidden|(^|[^[:alnum:]_])(401|403)([^[:alnum:]_]|$)' <<< "$setup_probe_output"; then
   print_result escalate 0 0 0 missing_credentials missing_credentials
   exit 2
 fi

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -169,6 +169,14 @@ case "$TIMEOUT" in
     ;;
 esac
 
+if [ -n "${LOCAL_AI_REVIEWER_EVIDENCE_FILE:-}" ]; then
+  case "$LOCAL_AI_REVIEWER_EVIDENCE_FILE" in
+    /*) ;;
+    *) LOCAL_AI_REVIEWER_EVIDENCE_FILE="$PWD/$LOCAL_AI_REVIEWER_EVIDENCE_FILE" ;;
+  esac
+  export LOCAL_AI_REVIEWER_EVIDENCE_FILE
+fi
+
 if [ "${LOCAL_AI_REVIEWER_DISABLED:-0}" = "1" ]; then
   print_result skipped 0 0 0 disabled_by_config disabled_by_config
   exit 3
@@ -472,7 +480,7 @@ write_evidence_file() {
   local final_suggestion_count="$5"
 
   [ -n "${LOCAL_AI_REVIEWER_EVIDENCE_FILE:-}" ] || return 0
-  jq -n \
+  if ! jq -n \
     --arg schema_version "local_ai_reviewer_evidence.v1" \
     --arg result "$final_result" \
     --arg reason "$final_reason" \
@@ -510,7 +518,9 @@ write_evidence_file() {
         diff_name_status: $diff_name_status,
         diff_stat: $diff_stat
       }
-    }' >"$LOCAL_AI_REVIEWER_EVIDENCE_FILE"
+    }' >"$LOCAL_AI_REVIEWER_EVIDENCE_FILE"; then
+    echo "WARN: could not write local AI reviewer evidence file: $LOCAL_AI_REVIEWER_EVIDENCE_FILE" >&2
+  fi
 }
 
 case "$result" in

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -191,16 +191,18 @@ fi
 BASE_BRANCH=""
 HEAD_BRANCH=""
 HEAD_SHA=""
+PR_BODY=""
 changed_files_json="[]"
 diff_name_status=""
 diff_stat=""
 diff_fetch_failed=0
 if command -v gh >/dev/null 2>&1; then
   pr_json=""
-  if pr_json="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json baseRefName,headRefName,headRefOid 2>/dev/null)"; then
+  if pr_json="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json baseRefName,headRefName,headRefOid,body 2>/dev/null)"; then
     BASE_BRANCH="$(printf '%s\n' "$pr_json" | jq -r '.baseRefName // empty' 2>/dev/null || true)"
     HEAD_BRANCH="$(printf '%s\n' "$pr_json" | jq -r '.headRefName // empty' 2>/dev/null || true)"
     HEAD_SHA="$(printf '%s\n' "$pr_json" | jq -r '.headRefOid // empty' 2>/dev/null || true)"
+    PR_BODY="$(printf '%s\n' "$pr_json" | jq -r '.body // empty' 2>/dev/null || true)"
   fi
   if ! diff_output="$(gh pr diff "$PR_NUMBER" --repo "$OWNER/$REPO" --name-only 2>/dev/null)"; then
     diff_output=""
@@ -309,6 +311,7 @@ jq -n \
   --arg head_branch "$HEAD_BRANCH" \
   --arg reviewed_head "$HEAD_SHA" \
   --arg graph_context "$graph_context" \
+  --arg pr_body "$PR_BODY" \
   --arg diff_name_status "$diff_name_status" \
   --arg diff_stat "$diff_stat" \
   --argjson changed_files "$changed_files_json" \
@@ -321,6 +324,7 @@ jq -n \
     head_branch: $head_branch,
     reviewed_head: $reviewed_head,
     changed_files: $changed_files,
+    pr_body: ($pr_body[0:20000]),
     diff_name_status: $diff_name_status,
     diff_stat: $diff_stat,
     review_contract: "REVIEW.md",
@@ -491,6 +495,7 @@ write_evidence_file() {
     --arg head_branch "$HEAD_BRANCH" \
     --arg reviewed_head "$HEAD_SHA" \
     --arg graph_context "$graph_context" \
+    --arg pr_body "$PR_BODY" \
     --arg diff_name_status "$diff_name_status" \
     --arg diff_stat "$diff_stat" \
     --argjson changed_files "$changed_files_json" \
@@ -515,6 +520,7 @@ write_evidence_file() {
       },
       context_summary: {
         changed_files: $changed_files,
+        pr_body: ($pr_body[0:20000]),
         diff_name_status: $diff_name_status,
         diff_stat: $diff_stat
       }

--- a/scripts/development-workflow/local-codex-review-command.sh
+++ b/scripts/development-workflow/local-codex-review-command.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# local-codex-review-command.sh - LOCAL_AI_REVIEWER_COMMAND preset for Codex.
+
+set -euo pipefail
+
+codex_bin="${LOCAL_CODEX_REVIEWER_BIN:-codex}"
+output_file="$(mktemp)"
+cleanup() {
+  rm -f "${output_file:-}"
+}
+trap cleanup EXIT
+
+prompt="${LOCAL_CODEX_REVIEWER_PROMPT:-}"
+if [ -z "$prompt" ]; then
+  prompt="Review this PR change using REVIEW.md and the JSON context at ${CONTEXT_BUNDLE_PATH:?}. Inspect the changed files against origin/${BASE_BRANCH:-develop}...HEAD, using the context bundle diff metadata as a guide. Return only a compact JSON object with fields: result (clean or needs_fixes), reviewed_head, findings array. Each finding should include severity, path, line, message, and clear_in_scope. Use needs_fixes only for clear in-scope blocking issues; advisory or nit findings should not block."
+fi
+
+codex_args=(exec --sandbox read-only -C "$PWD" -o "$output_file")
+if [ -n "${LOCAL_CODEX_REVIEWER_MODEL:-}" ]; then
+  codex_args+=(-m "$LOCAL_CODEX_REVIEWER_MODEL")
+fi
+codex_args+=("$prompt")
+
+"$codex_bin" "${codex_args[@]}" >/dev/null
+cat "$output_file"

--- a/scripts/development-workflow/local-codex-reviewer.sh
+++ b/scripts/development-workflow/local-codex-reviewer.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# local-codex-reviewer.sh - short Codex preset wrapper for local-ai-reviewer.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: local-codex-reviewer.sh <pr_number> <owner> <repo> [local-ai-reviewer options] [--evidence-file <path>]
+
+Runs local-ai-reviewer.sh with LOCAL_AI_REVIEWER_COMMAND preset to the Codex
+read-only command in local-codex-review-command.sh.
+
+Environment:
+  LOCAL_CODEX_REVIEWER_BIN     Codex binary to execute. Defaults to codex.
+  LOCAL_CODEX_REVIEWER_MODEL   Optional model passed as `codex exec -m`.
+  LOCAL_CODEX_REVIEWER_PROMPT  Optional prompt override.
+EOF
+}
+
+args=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --evidence-file)
+      [ "$#" -ge 2 ] && [ -n "${2:-}" ] || { echo "ERROR: --evidence-file requires a value" >&2; exit 2; }
+      export LOCAL_AI_REVIEWER_EVIDENCE_FILE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+export LOCAL_AI_REVIEWER_COMMAND="$SCRIPT_DIR/local-codex-review-command.sh"
+exec "$SCRIPT_DIR/local-ai-reviewer.sh" "${args[@]}"

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -13,12 +13,13 @@ NO_GRAPH_BIN="$(mktemp -d)"
 OUTPUT_FILE="$(mktemp)"
 STDERR_FILE="$(mktemp)"
 EXIT_FILE="$(mktemp)"
+EVIDENCE_FILE="$(mktemp)"
 VALID_REPO_ROOT="$(mktemp -d)"
 
 cleanup() {
   local status=$?
   rm -rf "$MOCK_BIN" "$NO_GRAPH_BIN" "$VALID_REPO_ROOT"
-  rm -f "$OUTPUT_FILE" "$STDERR_FILE" "$EXIT_FILE"
+  rm -f "$OUTPUT_FILE" "$STDERR_FILE" "$EXIT_FILE" "$EVIDENCE_FILE"
   exit "$status"
 }
 trap cleanup EXIT
@@ -97,7 +98,7 @@ reset_mocks() {
   unset MOCK_PR_HEAD_SHA MOCK_PR_DIFF_EXIT MOCK_LOCAL_REVIEWER_STDOUT MOCK_LOCAL_REVIEWER_STDERR
   unset MOCK_LOCAL_REVIEWER_EXIT MOCK_LOCAL_REVIEWER_SLEEP
   unset LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_DISABLED LOCAL_AI_REVIEWER_TIMEOUT
-  unset LOCAL_AI_REVIEWER_GRAPH_STRATEGY
+  unset LOCAL_AI_REVIEWER_EVIDENCE_FILE LOCAL_AI_REVIEWER_GRAPH_STRATEGY
 }
 
 set_mock_stdout() {
@@ -157,6 +158,16 @@ run_reviewer "$MOCK_BIN:$PATH"
 run_test "clean_result" "RESULT=clean" "$(line_for RESULT)"
 run_test "clean_comments" "COMMENT_COUNT=0" "$(line_for COMMENT_COUNT)"
 run_test "clean_exit" "0" "$(exit_code)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+LOCAL_AI_REVIEWER_EVIDENCE_FILE="$EVIDENCE_FILE"
+set_mock_stdout '{"result":"clean","findings":[]}'
+export LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_EVIDENCE_FILE MOCK_LOCAL_REVIEWER_STDOUT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "evidence_schema" "local_ai_reviewer_evidence.v1" "$(jq -r '.schema_version' "$EVIDENCE_FILE")"
+run_test "evidence_result" "clean" "$(jq -r '.result' "$EVIDENCE_FILE")"
+run_test "evidence_changed_file" "scripts/example.sh" "$(jq -r '.context_summary.changed_files[0]' "$EVIDENCE_FILE")"
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -161,6 +161,14 @@ run_test "clean_exit" "0" "$(exit_code)"
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+MOCK_LOCAL_REVIEWER_STDERR='missing model access warning in non-authoritative stderr'
+set_mock_stdout '{"result":"clean","findings":[]}'
+export LOCAL_AI_REVIEWER_COMMAND MOCK_LOCAL_REVIEWER_STDERR MOCK_LOCAL_REVIEWER_STDOUT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "clean_json_ignores_nonfatal_stderr_probe" "RESULT=clean" "$(line_for RESULT)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
 LOCAL_AI_REVIEWER_EVIDENCE_FILE="$EVIDENCE_FILE"
 set_mock_stdout '{"result":"clean","findings":[]}'
 export LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_EVIDENCE_FILE MOCK_LOCAL_REVIEWER_STDOUT

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -14,12 +14,13 @@ OUTPUT_FILE="$(mktemp)"
 STDERR_FILE="$(mktemp)"
 EXIT_FILE="$(mktemp)"
 EVIDENCE_FILE="$(mktemp)"
+RELATIVE_EVIDENCE_FILE="local-ai-reviewer-relative-evidence.json"
 VALID_REPO_ROOT="$(mktemp -d)"
 
 cleanup() {
   local status=$?
   rm -rf "$MOCK_BIN" "$NO_GRAPH_BIN" "$VALID_REPO_ROOT"
-  rm -f "$OUTPUT_FILE" "$STDERR_FILE" "$EXIT_FILE" "$EVIDENCE_FILE"
+  rm -f "$OUTPUT_FILE" "$STDERR_FILE" "$EXIT_FILE" "$EVIDENCE_FILE" "$RELATIVE_EVIDENCE_FILE"
   exit "$status"
 }
 trap cleanup EXIT
@@ -176,6 +177,24 @@ run_reviewer "$MOCK_BIN:$PATH"
 run_test "evidence_schema" "local_ai_reviewer_evidence.v1" "$(jq -r '.schema_version' "$EVIDENCE_FILE")"
 run_test "evidence_result" "clean" "$(jq -r '.result' "$EVIDENCE_FILE")"
 run_test "evidence_changed_file" "scripts/example.sh" "$(jq -r '.context_summary.changed_files[0]' "$EVIDENCE_FILE")"
+
+reset_mocks
+rm -f "$RELATIVE_EVIDENCE_FILE" "$VALID_REPO_ROOT/$RELATIVE_EVIDENCE_FILE"
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+LOCAL_AI_REVIEWER_EVIDENCE_FILE="$RELATIVE_EVIDENCE_FILE"
+MOCK_PR_HEAD_SHA="$(git -C "$VALID_REPO_ROOT" rev-parse HEAD)"
+set_mock_stdout '{"result":"clean","findings":[]}'
+export LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_EVIDENCE_FILE MOCK_LOCAL_REVIEWER_STDOUT MOCK_PR_HEAD_SHA
+run_reviewer "$MOCK_BIN:$PATH" --repo-root "$VALID_REPO_ROOT"
+run_test "relative_evidence_path_uses_original_cwd" "yes" "$([ -f "$RELATIVE_EVIDENCE_FILE" ] && [ ! -f "$VALID_REPO_ROOT/$RELATIVE_EVIDENCE_FILE" ] && echo yes || echo no)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+LOCAL_AI_REVIEWER_EVIDENCE_FILE="$VALID_REPO_ROOT/missing-dir/evidence.json"
+set_mock_stdout '{"result":"clean","findings":[]}'
+export LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_EVIDENCE_FILE MOCK_LOCAL_REVIEWER_STDOUT
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "unwritable_evidence_path_preserves_result" "RESULT=clean" "$(line_for RESULT)"
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock

--- a/scripts/development-workflow/tests/test-local-codex-review-command.sh
+++ b/scripts/development-workflow/tests/test-local-codex-review-command.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Unit tests for local-codex-review-command.sh.
+# covers: scripts/development-workflow/local-codex-review-command.sh
+# covers: scripts/development-workflow/local-codex-reviewer.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)"
+COMMAND="$REPO_ROOT/scripts/development-workflow/local-codex-review-command.sh"
+WRAPPER="$REPO_ROOT/scripts/development-workflow/local-codex-reviewer.sh"
+
+MOCK_BIN="$(mktemp -d)"
+PROMPT_LOG="$(mktemp)"
+OUTPUT_FILE="$(mktemp)"
+STDERR_FILE="$(mktemp)"
+
+cleanup() {
+  local status=$?
+  rm -rf "$MOCK_BIN"
+  rm -f "$PROMPT_LOG" "$OUTPUT_FILE" "$STDERR_FILE"
+  exit "$status"
+}
+trap cleanup EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name - expected '$expected', got '$actual'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+cat > "$MOCK_BIN/codex" <<'MOCK_CODEX'
+#!/usr/bin/env bash
+output_file=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "-o" ]; then
+    output_file="$arg"
+  fi
+  previous="$arg"
+done
+[ -n "$output_file" ] || exit 2
+printf '%s\n' "${*: -1}" > "${PROMPT_LOG:?}"
+printf '{"result":"clean","reviewed_head":"%s","findings":[]}\n' "${REVIEWED_HEAD:?}" > "$output_file"
+MOCK_CODEX
+chmod +x "$MOCK_BIN/codex"
+
+CONTEXT_BUNDLE_PATH="/tmp/context.json"
+BASE_BRANCH="develop"
+REVIEWED_HEAD="abc123"
+export CONTEXT_BUNDLE_PATH BASE_BRANCH REVIEWED_HEAD PROMPT_LOG
+
+PATH="$MOCK_BIN:$PATH" "$COMMAND" >"$OUTPUT_FILE" 2>"$STDERR_FILE"
+
+run_test "codex_command_result" "clean" "$(jq -r '.result' "$OUTPUT_FILE")"
+run_test "codex_command_reviewed_head" "abc123" "$(jq -r '.reviewed_head' "$OUTPUT_FILE")"
+run_test "codex_prompt_mentions_context" "yes" "$(grep -q '/tmp/context.json' "$PROMPT_LOG" && echo yes || echo no)"
+run_test "codex_prompt_mentions_base_diff" "yes" "$(grep -q 'origin/develop...HEAD' "$PROMPT_LOG" && echo yes || echo no)"
+run_test "wrapper_help_mentions_evidence_file" "yes" "$("$WRAPPER" --help 2>&1 | grep -q -- '--evidence-file' && echo yes || echo no)"
+
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  echo "FAIL: $FAIL_COUNT test(s) failed"
+  exit 1
+fi
+
+echo "PASS: $PASS_COUNT test(s) passed"


### PR DESCRIPTION
## Summary

- Add `local-codex-reviewer.sh` and `local-codex-review-command.sh` so Codex local review can run from a short preset wrapper.
- Enrich `local-ai-reviewer.sh` context bundles with schema/versioned changed-file metadata, compact diff metadata, and bounded PR body text.
- Add optional `LOCAL_AI_REVIEWER_EVIDENCE_FILE` JSON output for dogfood comparison evidence.
- Harden evidence writes so optional evidence-file failures do not hide the reviewer result, and relative evidence paths resolve from the operator's original working directory.
- Document the wrapper and evidence artifact, and add focused shell coverage.

Closes #1609

## Pre-Submission Self-Review

- Scope check: limited to local reviewer ergonomics/evidence capture, integration docs, tests, and changelog.
- Existing safety rails preserved: repo/head binding, timeout handling, malformed-output handling, and key/value result output remain intact.
- Graph tooling remains optional and not required.
- Reviewer follow-up: local wrapper dogfood caught stderr-probe noise and PR-body context gaps; Bugbot caught evidence-write failure and relative-path drift. All four findings were fixed with regression coverage.

## Planted-Violation Proof

Targeted control: `scripts/development-workflow/tests/test-local-ai-reviewer.sh` now verifies that optional evidence-file write failures do not suppress the local reviewer `RESULT`.

- Planted failing run: in throwaway worktree `/tmp/ai-dev-framework-template-1609-proof`, I removed the `if ! jq ...; then WARN` guard from `scripts/development-workflow/local-ai-reviewer.sh` and ran `bash scripts/development-workflow/tests/test-local-ai-reviewer.sh`.
- Failing evidence: `FAIL: unwritable_evidence_path_preserves_result - expected 'RESULT=clean', got ''`; final count `FAIL: 1 test(s) failed`.
- Passing run after restoring the guard on this PR head: `bash scripts/development-workflow/tests/test-local-ai-reviewer.sh` -> 42 passed, 0 failed.
- Concrete regression location: `scripts/development-workflow/tests/test-local-ai-reviewer.sh` includes `unwritable_evidence_path_preserves_result` and `relative_evidence_path_uses_original_cwd`.

## Validation

- `bash scripts/development-workflow/tests/test-local-ai-reviewer.sh` -> 42 passed, 0 failed
- `bash scripts/development-workflow/tests/test-local-codex-review-command.sh` -> 5 passed, 0 failed
- `bash scripts/development-workflow/tests/test-local-ai-reviewer-findings.sh` -> 11 passed, 0 failed
- `bash scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh` -> 3 passed, 0 failed
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `shellcheck --severity=warning scripts/development-workflow/local-ai-reviewer.sh scripts/development-workflow/local-codex-review-command.sh scripts/development-workflow/local-codex-reviewer.sh scripts/development-workflow/tests/test-local-ai-reviewer.sh scripts/development-workflow/tests/test-local-codex-review-command.sh scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh`
- `printf '%s\n' scripts/development-workflow/local-codex-review-command.sh scripts/development-workflow/local-codex-reviewer.sh scripts/development-workflow/local-ai-reviewer.sh | bash scripts/development-workflow/select-test-suites.sh --changed-files -`
- `bash scripts/development-workflow/tests/test-select-test-suites.sh` -> 48 passed, 0 failed
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `npx markdownlint-cli2 "docs/specs/developments/**/*.md" "docs/testing/workflow/**/*.md" "docs/workflow/development-workflow/integrations/local-ai-reviewer.md" "CHANGELOG.md"`
- `find docs/specs/developments docs/testing/workflow -name "*.md" -print0 | xargs -0 python3 scripts/lint/markdown-heuristic-lint.py CHANGELOG.md docs/workflow/development-workflow/integrations/local-ai-reviewer.md`

## Dogfood Evidence

- `./scripts/development-workflow/local-codex-reviewer.sh 1610 lhpaul ai-dev-framework-template --repo-root /Users/lhpaul/Git/ai-dev-framework-template-1609-local-reviewer-hardening --timeout 900 --evidence-file /tmp/local-ai-reviewer-1610.json` on head `211ee020d9e217b9e9cdd3aa184a4bdb8655090b` -> clean, 0 blocking findings.
- Evidence artifact `/tmp/local-ai-reviewer-1610.json` recorded `schema_version: local_ai_reviewer_evidence.v1`, `result: clean`, `counts.blocking: 0`, changed files, `diff_name_status`, `diff_stat`, and PR body context.
- `./scripts/development-workflow/pr-review-loop.sh 1610 --branch feature/1609-local-ai-reviewer-dogfood-hardening --max-wait 600 --post-final-summary` -> clean.
- Ready phase: Bugbot clean, `UNRESOLVED_THREAD_COUNT=0`, post-clean quiet window settled, `READY_PHASE_NET_NEW_BLOCKER=0`.
