### PR TITLE
fix(review-loop): require substantive settle reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Reviewer settle ignores empty review containers** (#1596):
+  `pr-review-loop.sh` now requires a substantive review body before
+  `POST_CLEAN_REQUIRE_REVIEW` can settle, and binds that evidence to the
+  current head when GitHub reports a review `commit_id`, so reply-container
+  review objects cannot make an unreviewed head look clean.
 - **Quoted closing keywords are ignored during post-merge cleanup** (#1585):
   `post-merge-cleanup.sh` now excludes inline code spans and blockquote lines
   before scanning PR bodies for closing keywords, preventing quoted examples

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -7660,12 +7660,13 @@ _settle_config_for_platform() {
 # the current code and must not satisfy POST_CLEAN_REQUIRE_REVIEW.
 _review_body_is_substantive() {
   local body="${1:-}"
-  local normalized
+  local normalized normalized_key
   normalized="$(printf '%s' "$body" | tr '\r\n\t' '   ' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
   [ -n "$normalized" ] || return 1
+  normalized_key="$(printf '%s' "$normalized" | tr '[:upper:]' '[:lower:]' | sed 's/[[:space:][:punct:]]*$//')"
 
-  case "$(printf '%s' "$normalized" | tr '[:upper:]' '[:lower:]')" in
-    "thanks"|"thanks."|"thank you"|"thank you."|"acknowledged"|"acknowledged."|"got it"|"got it."|"the change is correct"|"the change is correct.")
+  case "$normalized_key" in
+    "thanks"|"thank you"|"acknowledged"|"got it"|"the change is correct")
       return 1
       ;;
   esac

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -7702,7 +7702,7 @@ _bot_review_submitted_since() {
             | ((($bots | index($l)) != null) or (($bots | index($raw)) != null))
           )
         | select((.submitted_at // "") > $since)
-        | select(($head == "") or ((.commit_id // "") == "") or (.commit_id == $head))
+        | select(($head == "") or ((.commit_id // "") == $head))
         | (.body // "")
       ' 2>/dev/null)" || reviews_status=$?
   if [ "$reviews_status" -ne 0 ]; then

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -7653,7 +7653,27 @@ _settle_config_for_platform() {
   printf '%s %s %s %s' "$window" "$quiet" "$poll" "$require_review"
 }
 
-# _bot_review_submitted_since <repo> <pr> <since-iso> <bot-login>...
+# _review_body_is_substantive <body>
+#
+# The GitHub reviews endpoint includes zero-body "review" containers when a bot
+# replies inside existing review threads. Those containers are not a review of
+# the current code and must not satisfy POST_CLEAN_REQUIRE_REVIEW.
+_review_body_is_substantive() {
+  local body="${1:-}"
+  local normalized
+  normalized="$(printf '%s' "$body" | tr '\r\n\t' '   ' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  [ -n "$normalized" ] || return 1
+
+  case "$(printf '%s' "$normalized" | tr '[:upper:]' '[:lower:]')" in
+    "thanks"|"thanks."|"thank you"|"thank you."|"acknowledged"|"acknowledged."|"got it"|"got it."|"the change is correct"|"the change is correct.")
+      return 1
+      ;;
+  esac
+
+  return 0
+}
+
+# _bot_review_submitted_since <repo> <pr> <since-iso> [head-sha] <bot-login>...
 #
 # Echoes 1 when any listed bot has SUBMITTED a formal review at or after
 # <since-iso>, 0 when none has, and -1 when the query failed. This is the
@@ -7663,20 +7683,45 @@ _settle_config_for_platform() {
 _bot_review_submitted_since() {
   local repo="$1" pr="$2" since="$3"
   shift 3
-  local logins_json n
+  local head_sha=""
+  if [ "$#" -gt 0 ]; then
+    case "$1" in
+      [0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]*)
+        head_sha="$1"
+        shift
+        ;;
+    esac
+  fi
+  local logins_json reviews matched=0 reviews_status=0
   logins_json="$(printf '%s\n' "$@" | jq -R . | jq -sc .)"
-  n="$(gh api "repos/$repo/pulls/$pr/reviews" --paginate 2>/dev/null \
-    | jq -s --argjson bots "$logins_json" --arg since "$since" '
-        [ .[][]? | select(
+  reviews="$(gh api "repos/$repo/pulls/$pr/reviews" --paginate 2>/dev/null \
+    | jq -sr --argjson bots "$logins_json" --arg since "$since" --arg head "$head_sha" '
+        .[][]? | select(
             ((.user.login // "")) as $raw
             | ($raw | rtrimstr("[bot]")) as $l
             | ((($bots | index($l)) != null) or (($bots | index($raw)) != null))
-          ) | select((.submitted_at // "") > $since)
-        ] | length' 2>/dev/null)" || n=""
-  case "$n" in
-    ''|*[!0-9]*) printf '%s' "-1"; return 0 ;;
-  esac
-  [ "$n" -gt 0 ] && printf '1' || printf '0'
+          )
+        | select((.submitted_at // "") > $since)
+        | select(($head == "") or ((.commit_id // "") == "") or (.commit_id == $head))
+        | (.body // "")
+      ' 2>/dev/null)" || reviews_status=$?
+  if [ "$reviews_status" -ne 0 ]; then
+    printf '%s' "-1"
+    return 0
+  fi
+  if [ -z "$reviews" ]; then
+    printf '0'
+    return 0
+  fi
+
+  while IFS= read -r body; do
+    if _review_body_is_substantive "$body"; then
+      matched=1
+      break
+    fi
+  done <<< "$reviews"
+
+  [ "$matched" -eq 1 ] && printf '1' || printf '0'
 }
 
 # _bot_activity_since <repo> <pr> <since-iso> <bot-login>...
@@ -9095,7 +9140,7 @@ if [ "$aggregate_result" = "clean" ] \
     elif [ "$settle_require_review" -eq 1 ] && [ "$settle_review_seen" -eq 0 ]; then
       # Silence before the review lands is the platform thinking, not finishing.
       # Do not let it accumulate toward the quiet period.
-      settle_review_probe="$(_bot_review_submitted_since "$settle_repo" "$pr_number" "$settle_head_iso" "${unresolved_bot_logins[@]}")"
+      settle_review_probe="$(_bot_review_submitted_since "$settle_repo" "$pr_number" "$settle_head_iso" "$settle_head_sha" "${unresolved_bot_logins[@]}")"
       if [ "$settle_review_probe" = "1" ]; then
         settle_review_seen=1
         echo "INFO: post-clean settle — submitted review detected at ${settle_elapsed}s; quiet period starts now" >&2

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -7703,7 +7703,7 @@ _bot_review_submitted_since() {
             | ((($bots | index($l)) != null) or (($bots | index($raw)) != null))
           )
         | select((.submitted_at // "") > $since)
-        | select(($head == "") or ((.commit_id // "") == $head))
+        | select(($head == "") or ((.commit_id // $head) == $head))
         | (.body // "")
       ' 2>/dev/null)" || reviews_status=$?
   if [ "$reviews_status" -ne 0 ]; then

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -15075,6 +15075,12 @@ run_test "review_probe_detects_submitted_review" "1" \
 run_test "review_probe_detects_submitted_review_for_head" "1" \
   "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" deadbeefdeadbeefdeadbeefdeadbeefdeadbeef coderabbitai)"
 
+# GitHub may omit commit_id. Missing commit metadata is still acceptable, but
+# an explicit different commit must not satisfy the current-head settle.
+_1556_mkreviews '[{"user":{"login":"coderabbitai[bot]"},"submitted_at":"2026-08-22T00:30:32Z","state":"COMMENTED","commit_id":null,"body":"Actionable comments posted: 3"}]'
+run_test "review_probe_detects_submitted_review_for_head_without_commit_id" "1" \
+  "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" deadbeefdeadbeefdeadbeefdeadbeefdeadbeef coderabbitai)"
+
 # Empty-body review containers are produced when the bot replies inside
 # existing review threads. They are not a review of the current code.
 _1556_mkreviews '[{"user":{"login":"coderabbitai[bot]"},"submitted_at":"2026-08-22T00:30:32Z","state":"COMMENTED","commit_id":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef","body":""}]'

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -15043,6 +15043,8 @@ run_test "settle_no_eval_in_lookup" "0" \
 
 run_test "review_probe_defined" "yes" \
   "$(type -t _bot_review_submitted_since >/dev/null 2>&1 && echo yes || echo no)"
+run_test "review_substantive_helper_defined" "yes" \
+  "$(type -t _review_body_is_substantive >/dev/null 2>&1 && echo yes || echo no)"
 
 _1556_rbin="$(mktemp -d)"
 _1556_mkreviews() {
@@ -15065,17 +15067,35 @@ run_test "review_probe_no_review_is_zero" "0" \
   "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" coderabbitai)"
 
 # The PR #1573 review, submitted 13 minutes after HEAD.
-_1556_mkreviews '[{"user":{"login":"coderabbitai[bot]"},"submitted_at":"2026-08-22T00:30:32Z","state":"COMMENTED"}]'
+_1556_mkreviews '[{"user":{"login":"coderabbitai[bot]"},"submitted_at":"2026-08-22T00:30:32Z","state":"COMMENTED","body":"Actionable comments posted: 3"}]'
 run_test "review_probe_detects_submitted_review" "1" \
   "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" coderabbitai)"
+run_test "review_probe_detects_submitted_review_for_head" "1" \
+  "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" deadbeefdeadbeefdeadbeefdeadbeefdeadbeef coderabbitai)"
+
+# Empty-body review containers are produced when the bot replies inside
+# existing review threads. They are not a review of the current code.
+_1556_mkreviews '[{"user":{"login":"coderabbitai[bot]"},"submitted_at":"2026-08-22T00:30:32Z","state":"COMMENTED","commit_id":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef","body":""}]'
+run_test "review_probe_empty_body_container_is_zero" "0" \
+  "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" deadbeefdeadbeefdeadbeefdeadbeefdeadbeef coderabbitai)"
+
+# A substantive review plus later empty containers still satisfies the settle.
+_1556_mkreviews '[{"user":{"login":"coderabbitai[bot]"},"submitted_at":"2026-08-22T00:30:32Z","state":"COMMENTED","commit_id":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef","body":"Actionable comments posted: 3"},{"user":{"login":"coderabbitai[bot]"},"submitted_at":"2026-08-22T00:33:22Z","state":"COMMENTED","commit_id":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef","body":""}]'
+run_test "review_probe_substantive_plus_container_is_one" "1" \
+  "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" deadbeefdeadbeefdeadbeefdeadbeefdeadbeef coderabbitai)"
+
+# Empty containers on a different head must not satisfy this head.
+_1556_mkreviews '[{"user":{"login":"coderabbitai[bot]"},"submitted_at":"2026-08-22T00:30:32Z","state":"COMMENTED","commit_id":"feedfacefeedfacefeedfacefeedfacefeedface","body":""}]'
+run_test "review_probe_other_head_container_is_zero" "0" \
+  "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" deadbeefdeadbeefdeadbeefdeadbeefdeadbeef coderabbitai)"
 
 # A review from a PREVIOUS head must not satisfy this head.
-_1556_mkreviews '[{"user":{"login":"coderabbitai[bot]"},"submitted_at":"2026-08-22T00:10:00Z","state":"COMMENTED"}]'
+_1556_mkreviews '[{"user":{"login":"coderabbitai[bot]"},"submitted_at":"2026-08-22T00:10:00Z","state":"COMMENTED","body":"Actionable comments posted: 3"}]'
 run_test "review_probe_ignores_stale_review" "0" \
   "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" coderabbitai)"
 
 # Another bot's review must not satisfy this bot.
-_1556_mkreviews '[{"user":{"login":"other-bot[bot]"},"submitted_at":"2026-08-22T00:30:32Z","state":"COMMENTED"}]'
+_1556_mkreviews '[{"user":{"login":"other-bot[bot]"},"submitted_at":"2026-08-22T00:30:32Z","state":"COMMENTED","body":"Actionable comments posted: 3"}]'
 run_test "review_probe_ignores_other_bot" "0" \
   "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" coderabbitai)"
 

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -15067,7 +15067,7 @@ run_test "review_probe_no_review_is_zero" "0" \
   "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" coderabbitai)"
 
 # The PR #1573 review, submitted 13 minutes after HEAD.
-_1556_mkreviews '[{"user":{"login":"coderabbitai[bot]"},"submitted_at":"2026-08-22T00:30:32Z","state":"COMMENTED","body":"Actionable comments posted: 3"}]'
+_1556_mkreviews '[{"user":{"login":"coderabbitai[bot]"},"submitted_at":"2026-08-22T00:30:32Z","state":"COMMENTED","commit_id":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef","body":"Actionable comments posted: 3"}]'
 run_test "review_probe_detects_submitted_review" "1" \
   "$(PATH="$_1556_rbin:$PATH" _bot_review_submitted_since owner/repo 42 "2026-08-22T00:17:29Z" coderabbitai)"
 run_test "review_probe_detects_submitted_review_for_head" "1" \

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -15045,6 +15045,8 @@ run_test "review_probe_defined" "yes" \
   "$(type -t _bot_review_submitted_since >/dev/null 2>&1 && echo yes || echo no)"
 run_test "review_substantive_helper_defined" "yes" \
   "$(type -t _review_body_is_substantive >/dev/null 2>&1 && echo yes || echo no)"
+run_test "review_substantive_helper_rejects_ack_punctuation" "no" \
+  "$(_review_body_is_substantive "Thanks!" && echo yes || echo no)"
 
 _1556_rbin="$(mktemp -d)"
 _1556_mkreviews() {


### PR DESCRIPTION
## Summary
- require post-clean submitted-review probes to ignore empty reply-container review objects
- bind review evidence to the current head when GitHub exposes review commit_id
- add focused regression coverage for empty containers, substantive reviews, mixed evidence, and other-head containers

## Pre-Submission Self-Review
- Scope check: diff is limited to pr-review-loop settle review detection, its focused shell harness tests, and CHANGELOG.
- Issue coverage: addresses #1596 AC-1 through AC-4 by centralizing substantive-body classification, preserving POST_CLEAN_NO_SUBMITTED_REVIEW behavior when only containers exist, and adding regression fixtures based on GitHub review-object body shape.
- Risk: medium workflow-tooling change; no schema, external configuration, or unrelated reviewer platforms changed.

## Validation
- bash -n scripts/development-workflow/pr-review-loop.sh
- bash -n scripts/development-workflow/tests/test-pr-review-loop.sh
- bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 19 (52 passed, 0 failed)
- shellcheck --severity=warning scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-pr-review-loop.sh
- python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop
- bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md
- git diff --check

Closes #1596

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the review loop declares a head “reviewed” for settle, which can lengthen waits or alter automation timing if bots only emit empty review containers.
> 
> **Overview**
> Fixes **post-clean settle** so `POST_CLEAN_REQUIRE_REVIEW` no longer treats GitHub’s empty “reply-container” review objects as a completed bot review on the current head.
> 
> `_bot_review_submitted_since` now takes an optional **head SHA**, ignores reviews whose `commit_id` points at another commit (while still accepting missing `commit_id`), and only returns success when at least one matching submitted review has a **substantive body** via new `_review_body_is_substantive` (non-empty text, excluding short acknowledgments like “Thanks!”). The settle loop passes **`$settle_head_sha`** into that probe. Regression tests cover empty containers, head binding, mixed evidence, and stale/other-head cases; **CHANGELOG** documents the fix for #1596.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db8d15b9df54f0578bebb88ac69cf61b56a2a89a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->