### PR TITLE
fix(review-loop): preserve CodeRabbit quota attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `POST_CLEAN_REQUIRE_REVIEW` can settle, and binds that evidence to the
   current head when GitHub reports a review `commit_id`, so reply-container
   review objects cannot make an unreviewed head look clean.
+- **CodeRabbit retry attempts respect live quota windows** (#1597):
+  `pr-review-loop.sh` no longer spends a trigger while a current CodeRabbit
+  rate-limit comment remains live, reports `CODERABBIT_TRIGGER_ATTEMPTS` and
+  `CODERABBIT_REVIEWS_RECEIVED` in CodeRabbit results, and treats quota
+  refusals as waiting state rather than retry-budget consumption.
 - **Quoted closing keywords are ignored during post-merge cleanup** (#1585):
   `post-merge-cleanup.sh` now excludes inline code spans and blockquote lines
   before scanning PR bodies for closing keywords, preventing quoted examples

--- a/docs/workflow/development-workflow/integrations/coderabbit.md
+++ b/docs/workflow/development-workflow/integrations/coderabbit.md
@@ -105,6 +105,13 @@ disabled in the template default so the App does not review every PR or consume
 review quota unless the repository explicitly opts in with both configuration
 changes above.
 
+When several PRs are queued, trigger CodeRabbit one PR at a time. CodeRabbit's
+included allowance is based on trigger attempts, and parallel `@coderabbitai`
+requests can spend the same hourly quota without producing additional reviews.
+The reviewer loop reports `CODERABBIT_TRIGGER_ATTEMPTS` and
+`CODERABBIT_REVIEWS_RECEIVED` so the attempt-to-review ratio is visible in the
+run summary.
+
 ---
 
 ## Step 7a — Internal Reviewer (Draft PRs)

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -5167,6 +5167,7 @@ run_coderabbit_review() {
   # staleness so a reply the loop has already waited on cannot answer a newer
   # trigger (#1579, AC-1). Empty until this run posts its first trigger.
   local coderabbit_last_trigger_iso=""
+  local coderabbit_last_quota_refusal_trigger_iso=""
   # Defaults are sized against CodeRabbit's *hourly* quota reset: 4 retries x 900 s
   # covers 60 minutes of waiting, so a loop that hits the cap early in an hour can
   # still succeed once the vendor window rolls over. The previous 2 x 180 s (~6 min)
@@ -5391,6 +5392,13 @@ run_coderabbit_review() {
         rate_limit_comment_body="$(printf '%s' "$rate_limit_comment_json" | jq -r '.body // ""' 2>/dev/null)" || rate_limit_comment_body=""
         rate_limit_comment_created="$(printf '%s' "$rate_limit_comment_json" | jq -r '.effective_at // .created_at // ""' 2>/dev/null)" || rate_limit_comment_created=""
         if coderabbit_rate_limit_is_live "$rate_limit_comment_json" "$coderabbit_last_trigger_iso"; then
+          if [ -n "$coderabbit_last_trigger_iso" ] && [ "$coderabbit_last_quota_refusal_trigger_iso" != "$coderabbit_last_trigger_iso" ]; then
+            coderabbit_last_quota_refusal_trigger_iso="$coderabbit_last_trigger_iso"
+            if [ "$coderabbit_rate_limit_retries" -gt 0 ]; then
+              coderabbit_rate_limit_retries=$((coderabbit_rate_limit_retries - 1))
+            fi
+            echo "INFO: CodeRabbit quota refusal observed for last trigger — not counting it toward CODERABBIT_RATE_LIMIT_MAX_RETRIES" >&2
+          fi
           rate_limit_comment_count=1
         else
           echo "INFO: newest CodeRabbit rate-limit comment (${rate_limit_comment_created:-unknown time}) is past the window it announced — treating it as spent rather than waiting on it again (#1579)" >&2

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -5129,6 +5129,7 @@ run_coderabbit_review() {
     phase0_resume_since_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
     if gh pr comment "$pr_number" --body "@coderabbitai resume" >/dev/null 2>&1; then
       coderabbit_phase0_retrigger=1
+      coderabbit_rate_limit_hold_seen=0
       coderabbit_trigger_attempts=$((coderabbit_trigger_attempts + 1))
       since_iso="$phase0_resume_since_iso"
       echo "INFO: @coderabbitai resume posted; since_iso reset to $since_iso" >&2
@@ -5276,6 +5277,7 @@ run_coderabbit_review() {
         echo "INFO: CodeRabbit reviews are paused — posting @coderabbitai resume to trigger a fresh review" >&2
         if gh pr comment "$pr_number" --body "@coderabbitai resume" >/dev/null 2>&1; then
           coderabbit_retrigger_attempted=1
+          coderabbit_rate_limit_hold_seen=0
           coderabbit_trigger_attempts=$((coderabbit_trigger_attempts + 1))
           # Reset the elapsed timer to give the retrigger time to complete.
           elapsed=0
@@ -5301,6 +5303,7 @@ run_coderabbit_review() {
     # both mechanisms.
     if [ "$coderabbit_any_activity" -eq 0 ] \
         && [ "$coderabbit_retrigger_attempted" -eq 0 ] \
+        && [ "$coderabbit_rate_limit_hold_seen" -eq 0 ] \
         && [ "$coderabbit_no_trigger_retriggers" -lt "$coderabbit_rate_limit_max_retries" ] \
         && [ "$elapsed" -ge "$coderabbit_no_trigger_timeout" ]; then
       # Confirm neither a "paused" comment nor a *live* rate limit is present —
@@ -5347,6 +5350,7 @@ run_coderabbit_review() {
         coderabbit_no_trigger_retriggers=$((coderabbit_no_trigger_retriggers + 1))
         echo "INFO: CodeRabbit has not auto-triggered after ${elapsed}s (silent non-trigger, attempt ${coderabbit_no_trigger_retriggers}/${coderabbit_rate_limit_max_retries}) — posting @coderabbitai review" >&2
         if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
+          coderabbit_rate_limit_hold_seen=0
           coderabbit_trigger_attempts=$((coderabbit_trigger_attempts + 1))
           coderabbit_last_trigger_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           echo "INFO: @coderabbitai review trigger posted" >&2
@@ -5407,6 +5411,7 @@ run_coderabbit_review() {
             coderabbit_rate_limit_hold_seen=0
             echo "INFO: CodeRabbit rate-limit window elapsed after a held wait — posting @coderabbitai review" >&2
             if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
+              coderabbit_rate_limit_hold_seen=0
               coderabbit_rate_limit_retries=$((coderabbit_rate_limit_retries + 1))
               coderabbit_trigger_attempts=$((coderabbit_trigger_attempts + 1))
               coderabbit_last_trigger_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
@@ -5513,6 +5518,7 @@ run_coderabbit_review() {
           # acknowledgements (PR #1589: four resumes, zero reviews). A pause and a
           # rate limit need different verbs, and this branch is the rate-limit one.
           if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
+            coderabbit_rate_limit_hold_seen=0
             coderabbit_rate_limit_retries=$((coderabbit_rate_limit_retries + 1))
             coderabbit_trigger_attempts=$((coderabbit_trigger_attempts + 1))
             coderabbit_last_trigger_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -4988,6 +4988,7 @@ run_coderabbit_review() {
   local index=1
   local blocking_json=""
   local stale_file=""
+  local coderabbit_trigger_attempts=0
 
   trap 'rm -f "${existing_blocking_file:-}" "${blocking_lines_file:-}" "${stale_file:-}"' RETURN
 
@@ -5004,6 +5005,8 @@ run_coderabbit_review() {
     print_kv BRANCH "$branch_name"
     print_kv REVIEW_COMMENT_ID ""
     print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+    print_kv CODERABBIT_TRIGGER_ATTEMPTS "$coderabbit_trigger_attempts"
+    print_kv CODERABBIT_REVIEWS_RECEIVED 0
     return 2
   fi
   since_iso="$(gh api "repos/$repo/commits/$head_sha" --jq '.commit.committer.date // empty')"
@@ -5072,6 +5075,8 @@ run_coderabbit_review() {
     print_kv COMMENT_COUNT "$((existing_blocking_count + existing_suggestion_count))"
     print_kv BLOCKING_COUNT "$existing_blocking_count"
     print_kv SUGGESTION_COUNT "$existing_suggestion_count"
+    print_kv CODERABBIT_TRIGGER_ATTEMPTS "$coderabbit_trigger_attempts"
+    print_kv CODERABBIT_REVIEWS_RECEIVED 0
     while IFS= read -r blocking_json; do
       [ -z "${blocking_json:-}" ] && continue
       print_kv "BLOCKING_${index}_PATH" "$(printf '%s\n' "$blocking_json" | jq -r '.path')"
@@ -5124,6 +5129,7 @@ run_coderabbit_review() {
     phase0_resume_since_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
     if gh pr comment "$pr_number" --body "@coderabbitai resume" >/dev/null 2>&1; then
       coderabbit_phase0_retrigger=1
+      coderabbit_trigger_attempts=$((coderabbit_trigger_attempts + 1))
       since_iso="$phase0_resume_since_iso"
       echo "INFO: @coderabbitai resume posted; since_iso reset to $since_iso" >&2
     else
@@ -5142,6 +5148,8 @@ run_coderabbit_review() {
       print_kv COMMENT_COUNT 0
       print_kv BLOCKING_COUNT 0
       print_kv SUGGESTION_COUNT 0
+      print_kv CODERABBIT_TRIGGER_ATTEMPTS "$coderabbit_trigger_attempts"
+      print_kv CODERABBIT_REVIEWS_RECEIVED 0
       return 2
     fi
   fi
@@ -5266,6 +5274,7 @@ run_coderabbit_review() {
         echo "INFO: CodeRabbit reviews are paused — posting @coderabbitai resume to trigger a fresh review" >&2
         if gh pr comment "$pr_number" --body "@coderabbitai resume" >/dev/null 2>&1; then
           coderabbit_retrigger_attempted=1
+          coderabbit_trigger_attempts=$((coderabbit_trigger_attempts + 1))
           # Reset the elapsed timer to give the retrigger time to complete.
           elapsed=0
         else
@@ -5336,6 +5345,7 @@ run_coderabbit_review() {
         coderabbit_no_trigger_retriggers=$((coderabbit_no_trigger_retriggers + 1))
         echo "INFO: CodeRabbit has not auto-triggered after ${elapsed}s (silent non-trigger, attempt ${coderabbit_no_trigger_retriggers}/${coderabbit_rate_limit_max_retries}) — posting @coderabbitai review" >&2
         if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
+          coderabbit_trigger_attempts=$((coderabbit_trigger_attempts + 1))
           coderabbit_last_trigger_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           echo "INFO: @coderabbitai review trigger posted" >&2
         else
@@ -5387,8 +5397,7 @@ run_coderabbit_review() {
         fi
       fi
       if [ "${rate_limit_comment_count:-0}" -gt 0 ]; then
-        coderabbit_rate_limit_retries=$((coderabbit_rate_limit_retries + 1))
-        echo "INFO: CodeRabbit rate limit detected (retry $coderabbit_rate_limit_retries/$coderabbit_rate_limit_max_retries) — checking for SUCCESS commit status before waiting" >&2
+        echo "INFO: CodeRabbit rate limit detected (retry attempts spent $coderabbit_rate_limit_retries/$coderabbit_rate_limit_max_retries) — checking for SUCCESS commit status before waiting" >&2
         # --- Early SUCCESS check before retry wait ---
         # Check whether CodeRabbit already posted a genuine SUCCESS commit status for
         # the current HEAD SHA (state == "success" AND description is not a rate-limit
@@ -5425,6 +5434,8 @@ run_coderabbit_review() {
             print_kv COMMENT_COUNT 0
             print_kv BLOCKING_COUNT 0
             print_kv SUGGESTION_COUNT 0
+            print_kv CODERABBIT_TRIGGER_ATTEMPTS "$coderabbit_trigger_attempts"
+            print_kv CODERABBIT_REVIEWS_RECEIVED "$coderabbit_review_count"
             return 0
           fi
           if [ "$cr_early_gate_rc" -eq 1 ] || [ "$cr_early_gate_rc" -eq 2 ]; then
@@ -5444,23 +5455,48 @@ run_coderabbit_review() {
           echo "INFO: no SUCCESS commit status found — waiting ${coderabbit_this_wait}s before re-triggering" >&2
         fi
         _interruptible_sleep "$coderabbit_this_wait"
-        # Do NOT reset since_iso — keep the original HEAD-commit timestamp so any review
-        # posted by CodeRabbit during or after the wait is still within the detection window.
-        elapsed=0
-        # Re-trigger with "review", not "resume". "resume" only lifts a paused
-        # state; against a rate limit CodeRabbit answers "Reviews resumed" and
-        # reviews nothing, so the loop spends its whole budget on
-        # acknowledgements (PR #1589: four resumes, zero reviews). A pause and a
-        # rate limit need different verbs, and this branch is the rate-limit one.
-        if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
-          coderabbit_last_trigger_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-          echo "INFO: posted @coderabbitai review after rate-limit wait" >&2
-        else
-          echo "WARN: failed to post @coderabbitai review after rate-limit wait" >&2
+        local coderabbit_post_wait_rate_limit_json="" coderabbit_post_wait_lookup_status=0
+        local coderabbit_skip_rate_limit_retrigger=0
+        coderabbit_post_wait_rate_limit_json="$(coderabbit_newest_rate_limit_comment "$repo" "$pr_number" "$bot_login" "$since_iso")" || coderabbit_post_wait_lookup_status=$?
+        if [ "$coderabbit_post_wait_lookup_status" -ne 0 ]; then
+          echo "WARN: could not re-check CodeRabbit rate-limit state after waiting for PR #$pr_number — holding retrigger rather than spending a review attempt on unread quota state" >&2
+          _interruptible_sleep "$poll_interval"
+          elapsed=$((elapsed + coderabbit_this_wait + poll_interval))
+          if [ "$elapsed" -lt "$max_wait" ]; then
+            continue
+          fi
+          coderabbit_skip_rate_limit_retrigger=1
         fi
-        _interruptible_sleep "$poll_interval"
-        elapsed=$((elapsed + poll_interval))
-        continue
+        if coderabbit_rate_limit_is_live "$coderabbit_post_wait_rate_limit_json" "$coderabbit_last_trigger_iso"; then
+          echo "INFO: CodeRabbit rate limit is still live after waiting — not posting a trigger while quota refusal remains outstanding" >&2
+          _interruptible_sleep "$poll_interval"
+          elapsed=$((elapsed + coderabbit_this_wait + poll_interval))
+          if [ "$elapsed" -lt "$max_wait" ]; then
+            continue
+          fi
+          coderabbit_skip_rate_limit_retrigger=1
+        fi
+        if [ "$coderabbit_skip_rate_limit_retrigger" -eq 0 ]; then
+          # Do NOT reset since_iso — keep the original HEAD-commit timestamp so any review
+          # posted by CodeRabbit during or after the wait is still within the detection window.
+          elapsed=0
+          # Re-trigger with "review", not "resume". "resume" only lifts a paused
+          # state; against a rate limit CodeRabbit answers "Reviews resumed" and
+          # reviews nothing, so the loop spends its whole budget on
+          # acknowledgements (PR #1589: four resumes, zero reviews). A pause and a
+          # rate limit need different verbs, and this branch is the rate-limit one.
+          if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
+            coderabbit_rate_limit_retries=$((coderabbit_rate_limit_retries + 1))
+            coderabbit_trigger_attempts=$((coderabbit_trigger_attempts + 1))
+            coderabbit_last_trigger_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+            echo "INFO: posted @coderabbitai review after rate-limit wait" >&2
+          else
+            echo "WARN: failed to post @coderabbitai review after rate-limit wait" >&2
+          fi
+          _interruptible_sleep "$poll_interval"
+          elapsed=$((elapsed + poll_interval))
+          continue
+        fi
       fi
     fi
 
@@ -5502,6 +5538,8 @@ run_coderabbit_review() {
             print_kv COMMENT_COUNT 0
             print_kv BLOCKING_COUNT 0
             print_kv SUGGESTION_COUNT 0
+            print_kv CODERABBIT_TRIGGER_ATTEMPTS "$coderabbit_trigger_attempts"
+            print_kv CODERABBIT_REVIEWS_RECEIVED "$coderabbit_review_count"
             return 0
           fi
           if [ "$cr_success_gate_rc" -eq 1 ] || [ "$cr_success_gate_rc" -eq 2 ]; then
@@ -5564,6 +5602,8 @@ run_coderabbit_review() {
           print_kv COMMENT_COUNT "$stale_count"
           print_kv BLOCKING_COUNT "$stale_blocking_count"
           print_kv SUGGESTION_COUNT "$((stale_count - stale_blocking_count))"
+          print_kv CODERABBIT_TRIGGER_ATTEMPTS "$coderabbit_trigger_attempts"
+          print_kv CODERABBIT_REVIEWS_RECEIVED "$coderabbit_review_count"
           while IFS= read -r blocking_json; do
             [ -z "${blocking_json:-}" ] && continue
             print_kv "BLOCKING_${index}_PATH" "$(printf '%s\n' "$blocking_json" | jq -r '.path')"
@@ -5668,6 +5708,8 @@ run_coderabbit_review() {
           print_kv COMMENT_COUNT 0
           print_kv BLOCKING_COUNT 0
           print_kv SUGGESTION_COUNT 0
+          print_kv CODERABBIT_TRIGGER_ATTEMPTS "$coderabbit_trigger_attempts"
+          print_kv CODERABBIT_REVIEWS_RECEIVED "$coderabbit_review_count"
           return 2
         fi
         if [ "${timeout_incomplete_count:-0}" -gt 0 ] || [ "$coderabbit_phase0_retrigger" -eq 1 ]; then
@@ -5682,6 +5724,8 @@ run_coderabbit_review() {
           print_kv COMMENT_COUNT 0
           print_kv BLOCKING_COUNT 0
           print_kv SUGGESTION_COUNT 0
+          print_kv CODERABBIT_TRIGGER_ATTEMPTS "$coderabbit_trigger_attempts"
+          print_kv CODERABBIT_REVIEWS_RECEIVED "$coderabbit_review_count"
           return 2
         fi
 
@@ -5695,6 +5739,8 @@ run_coderabbit_review() {
         print_kv COMMENT_COUNT 0
         print_kv BLOCKING_COUNT 0
         print_kv SUGGESTION_COUNT 0
+        print_kv CODERABBIT_TRIGGER_ATTEMPTS "$coderabbit_trigger_attempts"
+        print_kv CODERABBIT_REVIEWS_RECEIVED "$coderabbit_review_count"
         return 0
       fi
       print_kv RESULT escalate
@@ -5704,6 +5750,8 @@ run_coderabbit_review() {
       print_kv BRANCH "$branch_name"
       print_kv REVIEW_COMMENT_ID ""
       print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv CODERABBIT_TRIGGER_ATTEMPTS "$coderabbit_trigger_attempts"
+      print_kv CODERABBIT_REVIEWS_RECEIVED "$coderabbit_review_count"
       return 2
     fi
 
@@ -5778,6 +5826,8 @@ run_coderabbit_review() {
     print_kv COMMENT_COUNT "$comment_count"
     print_kv BLOCKING_COUNT "$blocking_count"
     print_kv SUGGESTION_COUNT "$suggestion_count"
+    print_kv CODERABBIT_TRIGGER_ATTEMPTS "$coderabbit_trigger_attempts"
+    print_kv CODERABBIT_REVIEWS_RECEIVED "$coderabbit_review_count"
     while IFS= read -r blocking_json; do
       [ -z "${blocking_json:-}" ] && continue
       print_kv "BLOCKING_${index}_PATH" "$(printf '%s\n' "$blocking_json" | jq -r '.path')"
@@ -5804,6 +5854,8 @@ run_coderabbit_review() {
   print_kv COMMENT_COUNT "$comment_count"
   print_kv BLOCKING_COUNT 0
   print_kv SUGGESTION_COUNT "$suggestion_count"
+  print_kv CODERABBIT_TRIGGER_ATTEMPTS "$coderabbit_trigger_attempts"
+  print_kv CODERABBIT_REVIEWS_RECEIVED "$coderabbit_review_count"
   return 0
 }
 

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -5168,6 +5168,7 @@ run_coderabbit_review() {
   # trigger (#1579, AC-1). Empty until this run posts its first trigger.
   local coderabbit_last_trigger_iso=""
   local coderabbit_last_quota_refusal_trigger_iso=""
+  local coderabbit_rate_limit_hold_seen=0
   # Defaults are sized against CodeRabbit's *hourly* quota reset: 4 retries x 900 s
   # covers 60 minutes of waiting, so a loop that hits the cap early in an hour can
   # still succeed once the vendor window rolls over. The previous 2 x 180 s (~6 min)
@@ -5402,6 +5403,22 @@ run_coderabbit_review() {
           rate_limit_comment_count=1
         else
           echo "INFO: newest CodeRabbit rate-limit comment (${rate_limit_comment_created:-unknown time}) is past the window it announced — treating it as spent rather than waiting on it again (#1579)" >&2
+          if [ "$coderabbit_rate_limit_hold_seen" -eq 1 ] && [ "$coderabbit_rate_limit_retries" -lt "$coderabbit_rate_limit_max_retries" ]; then
+            coderabbit_rate_limit_hold_seen=0
+            echo "INFO: CodeRabbit rate-limit window elapsed after a held wait — posting @coderabbitai review" >&2
+            if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
+              coderabbit_rate_limit_retries=$((coderabbit_rate_limit_retries + 1))
+              coderabbit_trigger_attempts=$((coderabbit_trigger_attempts + 1))
+              coderabbit_last_trigger_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+              echo "INFO: posted @coderabbitai review after rate-limit window elapsed" >&2
+            else
+              echo "WARN: failed to post @coderabbitai review after rate-limit window elapsed" >&2
+            fi
+            elapsed=0
+            _interruptible_sleep "$poll_interval"
+            elapsed=$((elapsed + poll_interval))
+            continue
+          fi
         fi
       fi
       if [ "${rate_limit_comment_count:-0}" -gt 0 ]; then
@@ -5471,6 +5488,7 @@ run_coderabbit_review() {
           _interruptible_sleep "$poll_interval"
           elapsed=$((elapsed + coderabbit_this_wait + poll_interval))
           if [ "$elapsed" -lt "$max_wait" ]; then
+            coderabbit_rate_limit_hold_seen=1
             continue
           fi
           coderabbit_skip_rate_limit_retrigger=1
@@ -5480,6 +5498,7 @@ run_coderabbit_review() {
           _interruptible_sleep "$poll_interval"
           elapsed=$((elapsed + coderabbit_this_wait + poll_interval))
           if [ "$elapsed" -lt "$max_wait" ]; then
+            coderabbit_rate_limit_hold_seen=1
             continue
           fi
           coderabbit_skip_rate_limit_retrigger=1

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -5129,7 +5129,6 @@ run_coderabbit_review() {
     phase0_resume_since_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
     if gh pr comment "$pr_number" --body "@coderabbitai resume" >/dev/null 2>&1; then
       coderabbit_phase0_retrigger=1
-      coderabbit_rate_limit_hold_seen=0
       coderabbit_trigger_attempts=$((coderabbit_trigger_attempts + 1))
       since_iso="$phase0_resume_since_iso"
       echo "INFO: @coderabbitai resume posted; since_iso reset to $since_iso" >&2
@@ -5277,7 +5276,6 @@ run_coderabbit_review() {
         echo "INFO: CodeRabbit reviews are paused — posting @coderabbitai resume to trigger a fresh review" >&2
         if gh pr comment "$pr_number" --body "@coderabbitai resume" >/dev/null 2>&1; then
           coderabbit_retrigger_attempted=1
-          coderabbit_rate_limit_hold_seen=0
           coderabbit_trigger_attempts=$((coderabbit_trigger_attempts + 1))
           # Reset the elapsed timer to give the retrigger time to complete.
           elapsed=0
@@ -5408,7 +5406,6 @@ run_coderabbit_review() {
         else
           echo "INFO: newest CodeRabbit rate-limit comment (${rate_limit_comment_created:-unknown time}) is past the window it announced — treating it as spent rather than waiting on it again (#1579)" >&2
           if [ "$coderabbit_rate_limit_hold_seen" -eq 1 ] && [ "$coderabbit_rate_limit_retries" -lt "$coderabbit_rate_limit_max_retries" ]; then
-            coderabbit_rate_limit_hold_seen=0
             echo "INFO: CodeRabbit rate-limit window elapsed after a held wait — posting @coderabbitai review" >&2
             if gh pr comment "$pr_number" --body "@coderabbitai review" >/dev/null 2>&1; then
               coderabbit_rate_limit_hold_seen=0

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -15480,6 +15480,8 @@ run_test "1597_rate_limit_branch_holds_live_window" "yes" \
   "$([ "$(printf '%s' "$_1579_rl_branch" | grep -c 'not posting a trigger while quota refusal remains outstanding' || true)" -ge 1 ] && echo yes || echo no)"
 run_test "1597_rate_limit_refusal_refunds_retry_budget" "yes" \
   "$([ "$(grep_count_or_zero 'not counting it toward CODERABBIT_RATE_LIMIT_MAX_RETRIES' "$_1579_loop_src")" -ge 1 ] && echo yes || echo no)"
+run_test "1597_held_rate_limit_posts_when_spent" "yes" \
+  "$([ "$(grep_count_or_zero 'rate-limit window elapsed after a held wait' "$_1579_loop_src")" -ge 1 ] && echo yes || echo no)"
 run_test "1579_rate_limit_branch_does_not_post_resume" "0" \
   "$(printf '%s' "$_1579_rl_branch" | grep -c -- '--body "@coderabbitai resume"' || true)"
 # The extraction must actually have found the branch; an empty window would

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -15482,6 +15482,10 @@ run_test "1597_rate_limit_refusal_refunds_retry_budget" "yes" \
   "$([ "$(grep_count_or_zero 'not counting it toward CODERABBIT_RATE_LIMIT_MAX_RETRIES' "$_1579_loop_src")" -ge 1 ] && echo yes || echo no)"
 run_test "1597_held_rate_limit_posts_when_spent" "yes" \
   "$([ "$(grep_count_or_zero 'rate-limit window elapsed after a held wait' "$_1579_loop_src")" -ge 1 ] && echo yes || echo no)"
+run_test "1597_held_rate_limit_blocks_silent_preemption" "yes" \
+  "$([ "$(grep_count_or_zero 'coderabbit_rate_limit_hold_seen\" -eq 0' "$_1579_loop_src")" -ge 1 ] && echo yes || echo no)"
+run_test "1597_trigger_posts_clear_held_rate_limit" "yes" \
+  "$([ "$(grep_count_or_zero 'coderabbit_rate_limit_hold_seen=0' "$_1579_loop_src")" -ge 3 ] && echo yes || echo no)"
 run_test "1579_rate_limit_branch_does_not_post_resume" "0" \
   "$(printf '%s' "$_1579_rl_branch" | grep -c -- '--body "@coderabbitai resume"' || true)"
 # The extraction must actually have found the branch; an empty window would

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -15478,6 +15478,8 @@ run_test "1597_rate_limit_branch_rechecks_after_wait" "yes" \
   "$([ "$(printf '%s' "$_1579_rl_branch" | grep -c 'coderabbit_post_wait_rate_limit_json' || true)" -ge 1 ] && echo yes || echo no)"
 run_test "1597_rate_limit_branch_holds_live_window" "yes" \
   "$([ "$(printf '%s' "$_1579_rl_branch" | grep -c 'not posting a trigger while quota refusal remains outstanding' || true)" -ge 1 ] && echo yes || echo no)"
+run_test "1597_rate_limit_refusal_refunds_retry_budget" "yes" \
+  "$([ "$(grep_count_or_zero 'not counting it toward CODERABBIT_RATE_LIMIT_MAX_RETRIES' "$_1579_loop_src")" -ge 1 ] && echo yes || echo no)"
 run_test "1579_rate_limit_branch_does_not_post_resume" "0" \
   "$(printf '%s' "$_1579_rl_branch" | grep -c -- '--body "@coderabbitai resume"' || true)"
 # The extraction must actually have found the branch; an empty window would

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -15468,15 +15468,16 @@ run_test "1579_is_live_expired_window" "not-live" \
 # of a live limit, and reading it as one would re-create the #1579 stall.
 run_test "1579_is_live_malformed_json_not_live" "not-live" "$(_1579_live 'not json at all')"
 
-# --- AC-2: the post-rate-limit re-trigger asks for a review ----------------
+# --- AC-2 / AC-4: the post-rate-limit branch re-checks before posting -------
 # "resume" only lifts a paused state; against a rate limit CodeRabbit answers
-# "Reviews resumed" and reviews nothing (PR #1589: four resumes, zero reviews).
-# This reads the rate-limit branch itself, so the guarantee cannot be lost to a
-# later edit that reverts the verb.
+# "Reviews resumed" and reviews nothing. The branch may post `review` only after
+# re-reading the rate-limit state; while that state is live, it must hold.
 _1579_loop_src="$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
-_1579_rl_branch="$(awk '/no SUCCESS commit status found/,/_interruptible_sleep "\$poll_interval"/' "$_1579_loop_src")"
-run_test "1579_rate_limit_branch_posts_review" "1" \
-  "$(printf '%s' "$_1579_rl_branch" | grep -c -- '--body "@coderabbitai review"' || true)"
+_1579_rl_branch="$(awk '/no SUCCESS commit status found/,/CodeRabbit did.not review this HEAD/' "$_1579_loop_src")"
+run_test "1597_rate_limit_branch_rechecks_after_wait" "yes" \
+  "$([ "$(printf '%s' "$_1579_rl_branch" | grep -c 'coderabbit_post_wait_rate_limit_json' || true)" -ge 1 ] && echo yes || echo no)"
+run_test "1597_rate_limit_branch_holds_live_window" "yes" \
+  "$([ "$(printf '%s' "$_1579_rl_branch" | grep -c 'not posting a trigger while quota refusal remains outstanding' || true)" -ge 1 ] && echo yes || echo no)"
 run_test "1579_rate_limit_branch_does_not_post_resume" "0" \
   "$(printf '%s' "$_1579_rl_branch" | grep -c -- '--body "@coderabbitai resume"' || true)"
 # The extraction must actually have found the branch; an empty window would
@@ -15703,15 +15704,13 @@ rm -rf "$_1579_e2e_mock_dir"
 rm -f "$_1579_e2e_stderr"
 unset _1579_E2E_CALL_LOG _1579_E2E_STALE_CREATED _1579_e2e_mock_dir _1579_e2e_call_log _1579_e2e_stderr
 
-# --- AC-3(b) / AC-2: end-to-end — a LIVE rate limit re-triggers with "review",
-# not "resume". PR #1589 measured four "@coderabbitai resume" posts answered
-# with four "Reviews resumed" acknowledgements and zero reviews, because
-# "resume" only lifts CodeRabbit's auto-pause and does nothing against a rate
-# limit. Runs the real rate-limit wait/retrigger branch end to end so the
-# posted verb is proven from actual execution, not only from the static
-# source-text check above.
+# --- AC-3(b) / AC-2 / AC-4: end-to-end — a LIVE rate limit is a refusal, not
+# a review-attempt retry. Waiting is free; posting while the live quota refusal
+# is still outstanding spends the same allowance the loop is waiting on.
 _1579_e2e_mock_dir2="$(mktemp -d)"
 _1579_e2e_call_log2="$_1579_e2e_mock_dir2/calls.log"
+_1579_e2e_stdout2="$_1579_e2e_mock_dir2/stdout.log"
+_1579_e2e_stderr2="$_1579_e2e_mock_dir2/stderr.log"
 export _1579_E2E_CALL_LOG2="$_1579_e2e_call_log2"
 export _1579_E2E_LIVE_CREATED
 _1579_E2E_LIVE_CREATED="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
@@ -15738,18 +15737,24 @@ chmod +x "$_1579_e2e_mock_dir2/gh"
 PATH="$_1579_e2e_mock_dir2:$PATH" \
   CODERABBIT_NO_TRIGGER_TIMEOUT=999 CODERABBIT_RATE_LIMIT_MAX_RETRIES=1 CODERABBIT_RATE_LIMIT_WAIT=1 \
   CODERABBIT_RATE_LIMIT_MIN_WAIT=1 \
-  run_coderabbit_review "42" "fix/42-test" "1" "3" >/dev/null 2>&1 || true
+  run_coderabbit_review "42" "fix/42-test" "1" "3" >"$_1579_e2e_stdout2" 2>"$_1579_e2e_stderr2" || true
 
 # The mock logs "$*", which joins argv with spaces and drops the quoting the
-# real gh invocation used — matching the convention the #1531 mock already
-# established (pr comment 42 --body @coderabbitai review, no literal quotes).
-run_test "1579_live_rate_limit_reretrigger_posts_review" "yes" \
-  "$([ "$(grep_count_or_zero 'pr comment 42 --body @coderabbitai review' "$_1579_e2e_call_log2")" -ge 1 ] && echo yes || echo no)"
-run_test "1579_live_rate_limit_reretrigger_never_posts_resume" "0" \
+# real gh invocation used. A live rate-limit refusal must not produce either
+# trigger verb while it remains live after the wait.
+run_test "1597_live_rate_limit_does_not_post_review" "0" \
+  "$(grep_count_or_zero 'pr comment 42 --body @coderabbitai review' "$_1579_e2e_call_log2")"
+run_test "1597_live_rate_limit_does_not_post_resume" "0" \
   "$(grep_count_or_zero 'pr comment 42 --body @coderabbitai resume' "$_1579_e2e_call_log2")"
+run_test "1597_live_rate_limit_reports_zero_attempts" "CODERABBIT_TRIGGER_ATTEMPTS=0" \
+  "$(grep '^CODERABBIT_TRIGGER_ATTEMPTS=' "$_1579_e2e_stdout2" | tail -n 1)"
+run_test "1597_live_rate_limit_reports_zero_reviews" "CODERABBIT_REVIEWS_RECEIVED=0" \
+  "$(grep '^CODERABBIT_REVIEWS_RECEIVED=' "$_1579_e2e_stdout2" | tail -n 1)"
+run_test "1597_live_rate_limit_logs_hold_after_wait" "yes" \
+  "$([ "$(grep_count_or_zero 'not posting a trigger while quota refusal remains outstanding' "$_1579_e2e_stderr2")" -ge 1 ] && echo yes || echo no)"
 
 rm -rf "$_1579_e2e_mock_dir2"
-unset _1579_E2E_CALL_LOG2 _1579_E2E_LIVE_CREATED _1579_e2e_mock_dir2 _1579_e2e_call_log2
+unset _1579_E2E_CALL_LOG2 _1579_E2E_LIVE_CREATED _1579_e2e_mock_dir2 _1579_e2e_call_log2 _1579_e2e_stdout2 _1579_e2e_stderr2
 
 unset -f _1579_ago _1579_ago_s _1579_state _1579_live
 unset _1579_window _1579_nowindow _1579_real_parser _1579_loop_src _1579_rl_branch

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -15484,8 +15484,8 @@ run_test "1597_held_rate_limit_posts_when_spent" "yes" \
   "$([ "$(grep_count_or_zero 'rate-limit window elapsed after a held wait' "$_1579_loop_src")" -ge 1 ] && echo yes || echo no)"
 run_test "1597_held_rate_limit_blocks_silent_preemption" "yes" \
   "$([ "$(grep_count_or_zero 'coderabbit_rate_limit_hold_seen\" -eq 0' "$_1579_loop_src")" -ge 1 ] && echo yes || echo no)"
-run_test "1597_trigger_posts_clear_held_rate_limit" "yes" \
-  "$([ "$(grep_count_or_zero 'coderabbit_rate_limit_hold_seen=0' "$_1579_loop_src")" -ge 3 ] && echo yes || echo no)"
+run_test "1597_review_trigger_posts_clear_held_rate_limit" "3" \
+  "$(grep_count_or_zero '^[[:space:]]*coderabbit_rate_limit_hold_seen=0' "$_1579_loop_src")"
 run_test "1579_rate_limit_branch_does_not_post_resume" "0" \
   "$(printf '%s' "$_1579_rl_branch" | grep -c -- '--body "@coderabbitai resume"' || true)"
 # The extraction must actually have found the branch; an empty window would


### PR DESCRIPTION
## Summary

- hold CodeRabbit re-triggers while a current rate-limit comment remains live after the wait
- report `CODERABBIT_TRIGGER_ATTEMPTS` and `CODERABBIT_REVIEWS_RECEIVED` from CodeRabbit results
- document one-at-a-time CodeRabbit triggering for queued PRs

## Validation

- `bash -n scripts/development-workflow/pr-review-loop.sh`
- `bash -n scripts/development-workflow/tests/test-pr-review-loop.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 14` (96 passed, 0 failed)
- `shellcheck --severity=warning scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `npx markdownlint-cli2 "CHANGELOG.md" "docs/workflow/development-workflow/integrations/coderabbit.md"`
- `git diff --check`

Closes #1597

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes unattended PR review-loop timing and when GitHub comments are posted, which can affect whether reviews complete or escalate; scope is limited to CodeRabbit integration paths with added test coverage.
> 
> **Overview**
> **CodeRabbit handling in `pr-review-loop.sh` now treats live rate-limit comments as quota refusals instead of burning retry budget with immediate `@coderabbitai review` posts.**
> 
> After the configured wait, the loop re-reads rate-limit state and **holds** (no trigger) while the vendor window is still live; silent non-trigger retriggers are also suppressed during that hold. Quota refusals tied to the last trigger can **refund** a `CODERABBIT_RATE_LIMIT_MAX_RETRIES` count, and a spent window after a held wait can still post `review`. Every CodeRabbit result path now emits **`CODERABBIT_TRIGGER_ATTEMPTS`** and **`CODERABBIT_REVIEWS_RECEIVED`** for run summaries.
> 
> **Docs/changelog** add guidance to trigger CodeRabbit one PR at a time and explain the attempt-to-review metrics. **Tests** replace the old “always post review after wait” assertion with checks for re-check, hold, refund, and e2e behavior when a live limit persists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7232b391a1ffc4ff4a02cd845dbdedcc05f1d0a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->