### PR TITLE
fix(pr-review-loop): stop while Codex review is pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Stop local reviewer loop while Codex is pending** (#1603):
+  Codex GitHub review timeouts after a current-head trigger now surface
+  `RESULT=waiting_on_reviewer` with trigger/head telemetry instead of
+  escalating as reviewer unavailable or posting duplicate triggers.
 - **Reviewer settle ignores empty review containers** (#1596):
   `pr-review-loop.sh` now requires a substantive review body before
   `POST_CLEAN_REQUIRE_REVIEW` can settle, and binds that evidence to the

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -2052,6 +2052,7 @@ Interpret the result as follows:
 | `needs_fixes` and `cycle < max_cycles`  | Summary comment posted or updated automatically by the script. Increment `cycle`, dispatch the matching fixer agent, wait for a push, then run Step 7 again                                                                                                                                                                                                                                |
 | `needs_fixes` and `cycle >= max_cycles` | Summary comment posted or updated automatically by the script. Escalate to human                                                                                                                                                                                                                                                                                                          |
 | `needs_rerun` (exit code 3)             | (Reserved — not currently emitted.) Treat as `escalate` if encountered unexpectedly.                                                                                                                                                                                                                                                                                                      |
+| `waiting_on_reviewer` (exit code 4)     | Summary comment posted automatically by the script. Stop this local runner as waiting on the named reviewer; do not dispatch fixes, post duplicate triggers, apply readiness labels, enter CI readiness gates, or merge. Re-run Step 7 after the reviewer posts current-head terminal evidence or the human explicitly asks to poll again.                                                                                                                 |
 | `escalate`                              | Summary comment posted automatically by the script. Escalate to human                                                                                                                                                                                                                                                                                                                      |
 
 ### PR-Agent "Possible Issue" advisory labels
@@ -2638,8 +2639,9 @@ echo "READINESS_CI_TOTAL=$CI_TOTAL"
 echo "READINESS_CI_CONCLUSION=success"
 
 # Check 0.5: latest automated reviewer-loop summary must be clean or skipped.
-# A non-clean terminal result such as RESULT=escalate, needs_fixes, timeout, or
-# pending_timeout must never advance to ready-for-human-review, even if CI is green.
+# A non-clean terminal result such as RESULT=escalate, needs_fixes,
+# waiting_on_reviewer, timeout, or pending_timeout must never advance to
+# ready-for-human-review, even if CI is green.
 if ! LOOP_SUMMARY_BODY=$(gh pr view "$PR_NUMBER" --json comments --jq '
   [.comments[]
    | select(.body | test("Automated Reviewer Loop Summary|Reviewer Loop Summary|No blocking PR feedback"))]

--- a/scripts/development-workflow/codex-github-reviewer.sh
+++ b/scripts/development-workflow/codex-github-reviewer.sh
@@ -29,9 +29,10 @@
 # Exit codes:
 #   0 — APPROVED   (bot responded with no blocking findings)
 #   1 — NEEDS_REVISION (bot responded with blocking findings)
-#   2 — TIMED_OUT  (no bot response within max-wait; treat as unavailable under
-#                   configured internal_reviewers_unavailable_policy)
+#   2 — TIMED_OUT  (API/auth/setup failures while waiting; treat as unavailable
+#                   under configured internal_reviewers_unavailable_policy)
 #   3 — UNAVAILABLE (bot responded with review-capacity/quota exhaustion)
+#   4 — WAITING_ON_REVIEWER (current-head trigger exists, no bot review yet)
 #
 # Verdict parsing (three-path, blocking markers checked first per safe-fail):
 #   1. Blocking markers present → NEEDS_REVISION (exit 1)
@@ -2472,7 +2473,11 @@ echo "INFO: no bot response during async grace period"
 # ── Timeout ───────────────────────────────────────────────────────────────────
 
 TOTAL_ATTEMPTS=$((MAX_RETRIGGERS + 1))
-echo "VERDICT: TIMED_OUT — no response from '$BOT_LOGIN' after ${TOTAL_ELAPSED}s (budget ${MAX_WAIT}s) across up to ${TOTAL_ATTEMPTS} attempt(s)"
-echo "INFO: remediation — verify the Codex GitHub App is installed on $OWNER/$REPO."
-echo "INFO: You can manually trigger the review by posting: $TRIGGER_PHRASE"
-exit 2
+echo "VERDICT: WAITING_ON_REVIEWER — current-head Codex review is still pending after ${TOTAL_ELAPSED}s (budget ${MAX_WAIT}s) across up to ${TOTAL_ATTEMPTS} attempt(s)"
+echo "REASON=codex-github-review-pending"
+echo "PENDING_REVIEWER=codex-github"
+echo "PENDING_REVIEW_HEAD_SHA=$CURRENT_SHA_FULL"
+echo "PENDING_REVIEW_TRIGGER_COMMENT_ID=$TRIGGER_COMMENT_ID"
+echo "PENDING_REVIEW_TRIGGER_TIME=$TRIGGER_TIME"
+echo "INFO: no duplicate trigger needed; the existing current-head trigger is still pending."
+exit 4

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -8695,7 +8695,22 @@ for index in "${!platforms[@]}"; do
       fi
       aggregate_result="clean"
       ;;
-    needs_fixes|waiting_on_reviewer|escalate)
+    waiting_on_reviewer)
+      aggregate_result="$platform_result"
+      aggregate_reason="$(kv_value_default REASON "$platform_output" "")"
+      aggregate_output="$platform_output"
+      aggregate_status=$platform_status
+      if [ "$compare_mode" -eq 0 ]; then
+        break
+      fi
+      if [ -z "$compare_first_blocking_result" ]; then
+        compare_first_blocking_result="$platform_result"
+        compare_first_blocking_reason="$aggregate_reason"
+        compare_first_blocking_output="$platform_output"
+        compare_first_blocking_status=$platform_status
+      fi
+      ;;
+    needs_fixes|escalate)
       if [ "$phase_after_clean_enabled" -eq 1 ] \
           && [ "$phase_after_clean_started" -eq 1 ] \
           && is_phase_after_clean_platform "$platform_name"; then

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -478,7 +478,7 @@ Large-diff poll-window extension:
   key=value output includes CHANGED_FILES_COUNT so callers can inspect the value.
 
 Outputs stable key=value lines including:
-  RESULT=clean|needs_fixes|needs_rerun|escalate|skipped
+  RESULT=clean|needs_fixes|needs_rerun|waiting_on_reviewer|escalate|skipped
   PLATFORM_<n>_NAME / PLATFORM_<n>_RESULT
   REASON=lock_contention (when exit code is 75)
   CHANGED_FILES_COUNT=<n> (PR's changed-files count, or -1 when the fetch failed)
@@ -1191,6 +1191,22 @@ run_codex_github_review() {
       print_kv BLOCKING_COUNT 0
       print_kv SUGGESTION_COUNT 0
       return 2
+      ;;
+    4)
+      print_kv RESULT waiting_on_reviewer
+      print_kv REASON "$(kv_value_default REASON "$script_output" codex-github-review-pending)"
+      print_kv PLATFORM "$platform"
+      print_kv PR_NUMBER "$pr_number"
+      print_kv BRANCH "$branch_name"
+      print_kv FIX_AGENT "$(reviewer_for_branch "$branch_name")"
+      print_kv COMMENT_COUNT 0
+      print_kv BLOCKING_COUNT 0
+      print_kv SUGGESTION_COUNT 0
+      print_kv PENDING_REVIEWER "$(kv_value_default PENDING_REVIEWER "$script_output" "$platform")"
+      print_kv PENDING_REVIEW_HEAD_SHA "$(kv_value_default PENDING_REVIEW_HEAD_SHA "$script_output" "")"
+      print_kv PENDING_REVIEW_TRIGGER_COMMENT_ID "$(kv_value_default PENDING_REVIEW_TRIGGER_COMMENT_ID "$script_output" "")"
+      print_kv PENDING_REVIEW_TRIGGER_TIME "$(kv_value_default PENDING_REVIEW_TRIGGER_TIME "$script_output" "")"
+      return 4
       ;;
     *)
       local codex_reason
@@ -6268,7 +6284,7 @@ run_project_advisory_checks() {
 # the argument-parsing and main-loop sections below.
 
 # normalize_platform_verdict: map a raw platform result token to one of the five
-# canonical compare-mode verdict values: clean, blocking, advisory, timed out, unavailable.
+# canonical compare-mode verdict values: clean, blocking, advisory, waiting, timed out, unavailable.
 # $1 = platform_result token (e.g. clean, needs_fixes, skipped, escalate, needs_rerun)
 # $2 = full platform output (key=value block; used to inspect REASON for timeout detection)
 normalize_platform_verdict() {
@@ -6286,6 +6302,7 @@ normalize_platform_verdict() {
     advisory)    printf 'advisory' ;;
     skipped)     printf 'unavailable' ;;
     needs_rerun) printf 'blocking' ;;
+    waiting_on_reviewer) printf 'waiting' ;;
     escalate)
       # Distinguish timeout from service-unavailable via REASON.
       case "$reason" in
@@ -8678,7 +8695,7 @@ for index in "${!platforms[@]}"; do
       fi
       aggregate_result="clean"
       ;;
-    needs_fixes|escalate)
+    needs_fixes|waiting_on_reviewer|escalate)
       if [ "$phase_after_clean_enabled" -eq 1 ] \
           && [ "$phase_after_clean_started" -eq 1 ] \
           && is_phase_after_clean_platform "$platform_name"; then
@@ -8795,6 +8812,9 @@ _post_review_summary() {
       ;;
     escalate)
       result_line="escalated (${reason:-unknown})"
+      ;;
+    waiting_on_reviewer)
+      result_line="waiting_on_reviewer (${reason:-codex-github-review-pending}) — current-head review trigger posted; reviewer has not returned terminal evidence yet"
       ;;
     skipped)
       result_line="skipped — no GitHub reviewers configured in review.on_draft.github or review.on_ready.github"
@@ -9657,6 +9677,9 @@ case "$aggregate_result" in
     # already persisted above so retrospective retry metrics do not lose
     # the fix-pushed run.
     exit 3
+    ;;
+  waiting_on_reviewer)
+    exit 4
     ;;
   escalate)
     exit 2

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -6283,7 +6283,7 @@ run_project_advisory_checks() {
 # the test harness can load them via HARNESS_MODE=1 sourcing without executing
 # the argument-parsing and main-loop sections below.
 
-# normalize_platform_verdict: map a raw platform result token to one of the five
+# normalize_platform_verdict: map a raw platform result token to one of the six
 # canonical compare-mode verdict values: clean, blocking, advisory, waiting, timed out, unavailable.
 # $1 = platform_result token (e.g. clean, needs_fixes, skipped, escalate, needs_rerun)
 # $2 = full platform output (key=value block; used to inspect REASON for timeout detection)

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -960,6 +960,9 @@ run_test "verdict_skipped" "unavailable" "$actual"
 actual="$(normalize_platform_verdict "needs_rerun" "")"
 run_test "verdict_needs_rerun" "blocking" "$actual"
 
+actual="$(normalize_platform_verdict "waiting_on_reviewer" "REASON=codex-github-review-pending")"
+run_test "verdict_waiting_on_reviewer" "waiting" "$actual"
+
 actual="$(normalize_platform_verdict "escalate" "REASON=timeout")"
 run_test "verdict_escalate_timeout" "timed out" "$actual"
 
@@ -2923,6 +2926,7 @@ run_test "persist_failure_escalates_on_needs_fixes" "yes"   "$(reviewer_loop_per
 run_test "persist_failure_escalates_on_needs_rerun" "yes"   "$(reviewer_loop_persist_failure_should_escalate 1 needs_rerun && echo yes || echo no)"
 run_test "persist_failure_does_not_escalate_on_clean" "no"   "$(reviewer_loop_persist_failure_should_escalate 1 clean && echo yes || echo no)"
 run_test "persist_failure_does_not_escalate_on_already_escalate" "no"   "$(reviewer_loop_persist_failure_should_escalate 1 escalate && echo yes || echo no)"
+run_test "persist_failure_does_not_escalate_on_waiting_on_reviewer" "no"   "$(reviewer_loop_persist_failure_should_escalate 1 waiting_on_reviewer && echo yes || echo no)"
 run_test "persist_failure_does_not_fire_when_persist_succeeded" "no"   "$(reviewer_loop_persist_failure_should_escalate 0 needs_fixes && echo yes || echo no)"
 
 # --- reviewer_loop_history_build_entry writes run_id from the
@@ -3282,6 +3286,7 @@ run_test "reviewer_failed_skipped_file_limit" "no" "$(_reviewer_failed_required 
 run_test "reviewer_failed_clean_no" "no" "$(_reviewer_failed_required clean timeout)"
 run_test "reviewer_failed_needs_fixes_no" "no" "$(_reviewer_failed_required needs_fixes '')"
 run_test "reviewer_failed_needs_rerun_no" "no" "$(_reviewer_failed_required needs_rerun '')"
+run_test "reviewer_failed_waiting_on_reviewer_no" "no" "$(_reviewer_failed_required waiting_on_reviewer codex-github-review-pending)"
 
 _rf_accumulated=0
 if reviewer_failed_label_required_for_result clean ""; then
@@ -3856,6 +3861,44 @@ run_test "codex_trigger_idempotency_paginated_selects_newest" "222" \
 run_test "codex_trigger_idempotency_paginated_single_object" "1" \
   "$(printf '%s\n' "$_codex_paginated_selected_trigger" | wc -l | tr -d ' ')"
 unset _codex_trigger_comments _codex_selected_trigger _codex_paginated_trigger_comments _codex_paginated_selected_trigger
+
+_codex_pending_idempotent_dir="$(mktemp -d)"
+cat > "$_codex_pending_idempotent_dir/gh" <<'CODEX_PENDING_IDEMPOTENT_GH'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*) exit 0 ;;
+  *"pr view"*headRefOid*) printf 'abc123pending0000000000000000000000000000\n'; exit 0 ;;
+  *"--method POST"*)
+    printf 'ERROR=duplicate-trigger-post\n' >&2
+    exit 64 ;;
+  *"issues/comments/"*"/reactions"*) printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/comments"*) printf '[]\n'; exit 0 ;;
+  *"pulls/"*"/reviews"*) printf '[]\n'; exit 0 ;;
+  *"issues/"*"/comments"*)
+    printf '[{"id":901,"created_at":"2026-01-01T00:00:00Z","user":{"login":"alice"},"body":"@codex review (review triggered by workflow runner, commit: abc123pending0000000000000000000000000000)"}]\n'
+    exit 0 ;;
+  *) printf 'ERROR=unexpected-gh-invocation\n' >&2; printf 'ARGS=%q\n' "$*" >&2; exit 64 ;;
+esac
+CODEX_PENDING_IDEMPOTENT_GH
+chmod +x "$_codex_pending_idempotent_dir/gh"
+_codex_pending_idempotent_exit=0
+PATH="$_codex_pending_idempotent_dir:$PATH" \
+  "$REPO_ROOT/scripts/development-workflow/codex-github-reviewer.sh" \
+  42 owner repo --poll-interval 1 --max-wait 1 --pre-trigger-wait 0 --max-retriggers 0 \
+  >"$_codex_pending_idempotent_dir/output.txt" 2>&1 || _codex_pending_idempotent_exit=$?
+_codex_pending_idempotent_output="$(cat "$_codex_pending_idempotent_dir/output.txt")"
+run_test "codex_pending_existing_trigger_exit_waiting" "4" "$_codex_pending_idempotent_exit"
+run_test "codex_pending_existing_trigger_verdict" \
+  "VERDICT: WAITING_ON_REVIEWER — current-head Codex review is still pending after 1s (budget 1s) across up to 1 attempt(s)" \
+  "$(printf '%s\n' "$_codex_pending_idempotent_output" | grep "^VERDICT:")"
+run_test "codex_pending_existing_trigger_no_duplicate_post" "0" \
+  "$(grep_count_or_zero 'duplicate-trigger-post' "$_codex_pending_idempotent_dir/output.txt")"
+run_test "codex_pending_existing_trigger_reason" "REASON=codex-github-review-pending" \
+  "$(printf '%s\n' "$_codex_pending_idempotent_output" | grep "^REASON=")"
+run_test "codex_pending_existing_trigger_id" "PENDING_REVIEW_TRIGGER_COMMENT_ID=901" \
+  "$(printf '%s\n' "$_codex_pending_idempotent_output" | grep "^PENDING_REVIEW_TRIGGER_COMMENT_ID=")"
+rm -rf "$_codex_pending_idempotent_dir"
+unset _codex_pending_idempotent_dir _codex_pending_idempotent_exit _codex_pending_idempotent_output
 
 # --- #1522: the account-not-connected refusal is unavailability, not a finding
 _codex_notconn_dir="$(mktemp -d)"
@@ -4908,7 +4951,7 @@ PATH="$_codex_stale_root_review_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_stale_root_review_comment_mock_dir/output.txt" 2>&1 || _codex_stale_root_review_comment_exit=$?
 _codex_stale_root_review_comment_output="$(cat "$_codex_stale_root_review_comment_mock_dir/output.txt")"
-run_test "codex_stale_root_review_comment_exit_unavailable" "2" "$_codex_stale_root_review_comment_exit"
+run_test "codex_stale_root_review_comment_exit_waiting" "4" "$_codex_stale_root_review_comment_exit"
 if printf '%s\n' "$_codex_stale_root_review_comment_output" | grep -q "^VERDICT: APPROVED"; then
   _codex_stale_root_review_comment_approved="yes"
 else
@@ -8236,9 +8279,9 @@ PATH="$_codex_dismissed_review_excluded_root_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_dismissed_review_excluded_root_comment_mock_dir/output.txt" 2>&1 || _codex_dismissed_review_excluded_root_comment_exit=$?
 _codex_dismissed_review_excluded_root_comment_output="$(cat "$_codex_dismissed_review_excluded_root_comment_mock_dir/output.txt")"
-run_test "codex_dismissed_review_excluded_root_comment_exit_timed_out" "2" "$_codex_dismissed_review_excluded_root_comment_exit"
-run_test "codex_dismissed_review_excluded_root_comment_verdict_not_approved" "TIMED_OUT" \
-  "$(printf '%s\n' "$_codex_dismissed_review_excluded_root_comment_output" | grep -oE 'VERDICT: (TIMED_OUT|APPROVED)' | grep -oE 'TIMED_OUT|APPROVED')"
+run_test "codex_dismissed_review_excluded_root_comment_exit_waiting" "4" "$_codex_dismissed_review_excluded_root_comment_exit"
+run_test "codex_dismissed_review_excluded_root_comment_verdict_not_approved" "WAITING_ON_REVIEWER" \
+  "$(printf '%s\n' "$_codex_dismissed_review_excluded_root_comment_output" | grep -oE 'VERDICT: (WAITING_ON_REVIEWER|APPROVED)' | grep -oE 'WAITING_ON_REVIEWER|APPROVED')"
 rm -rf "$_codex_dismissed_review_excluded_root_comment_mock_dir"
 unset _codex_dismissed_review_excluded_root_comment_mock_dir _codex_dismissed_review_excluded_root_comment_output _codex_dismissed_review_excluded_root_comment_exit
 
@@ -9590,7 +9633,7 @@ PATH="$_codex_stale_review_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_stale_review_mock_dir/output.txt" 2>&1 || _codex_stale_review_exit=$?
 _codex_stale_review_output="$(cat "$_codex_stale_review_mock_dir/output.txt")"
-run_test "codex_stale_review_exit_unavailable" "2" "$_codex_stale_review_exit"
+run_test "codex_stale_review_exit_waiting" "4" "$_codex_stale_review_exit"
 if printf '%s\n' "$_codex_stale_review_output" | grep -q "^VERDICT: APPROVED"; then
   _codex_stale_review_approved="yes"
 else
@@ -9634,7 +9677,7 @@ PATH="$_codex_stale_inline_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_stale_inline_mock_dir/output.txt" 2>&1 || _codex_stale_inline_exit=$?
 _codex_stale_inline_output="$(cat "$_codex_stale_inline_mock_dir/output.txt")"
-run_test "codex_stale_inline_exit_unavailable" "2" "$_codex_stale_inline_exit"
+run_test "codex_stale_inline_exit_waiting" "4" "$_codex_stale_inline_exit"
 if printf '%s\n' "$_codex_stale_inline_output" | grep -q "^VERDICT: NEEDS_REVISION"; then
   _codex_stale_inline_needs_revision="yes"
 else
@@ -9943,7 +9986,7 @@ PATH="$_codex_final_ack_clean_comment_mock_dir:$PATH" \
   42 owner repo --poll-interval 1 --max-wait 1 --max-retriggers 0 \
   >"$_codex_final_ack_clean_comment_mock_dir/output.txt" 2>&1 || _codex_final_ack_clean_comment_exit=$?
 _codex_final_ack_clean_comment_output="$(cat "$_codex_final_ack_clean_comment_mock_dir/output.txt")"
-run_test "codex_final_ack_clean_comment_exit_unavailable" "2" "$_codex_final_ack_clean_comment_exit"
+run_test "codex_final_ack_clean_comment_exit_waiting" "4" "$_codex_final_ack_clean_comment_exit"
 if printf '%s\n' "$_codex_final_ack_clean_comment_output" | grep -q "^VERDICT: APPROVED"; then
   _codex_final_ack_clean_comment_approved="yes"
 else
@@ -12423,6 +12466,45 @@ run_test "codex_usage_limit_loop_suggestion_zero" "SUGGESTION_COUNT=0" \
 run_test "codex_usage_limit_loop_exit_code" "2" "$actual_exit"
 rm -rf "$_codex_usage_loop_tmp"
 unset _codex_usage_loop_tmp _codex_overrides actual_output actual_exit
+
+_codex_pending_loop_tmp="$(mktemp -d)"
+mkdir -p "$_codex_pending_loop_tmp/scripts/development-workflow"
+cat > "$_codex_pending_loop_tmp/scripts/development-workflow/codex-github-reviewer.sh" <<'CODEX_PENDING_LOOP_REVIEWER'
+#!/usr/bin/env bash
+printf 'VERDICT: WAITING_ON_REVIEWER — current-head Codex review is still pending\n'
+printf 'REASON=codex-github-review-pending\n'
+printf 'PENDING_REVIEWER=codex-github\n'
+printf 'PENDING_REVIEW_HEAD_SHA=abc123pending\n'
+printf 'PENDING_REVIEW_TRIGGER_COMMENT_ID=901\n'
+printf 'PENDING_REVIEW_TRIGGER_TIME=2026-01-01T00:00:00Z\n'
+exit 4
+CODEX_PENDING_LOOP_REVIEWER
+chmod +x "$_codex_pending_loop_tmp/scripts/development-workflow/codex-github-reviewer.sh"
+_codex_overrides='
+  cd_workflow_repo_root() { :; }
+  repo_slug() { printf "owner/repo\n"; }
+  require_gh() { :; }
+  workflow_repo_root() { printf "%s\n" "$_codex_pending_loop_tmp"; }
+  check_unresolved_threads() { printf "0\n"; return 0; }
+'
+actual_output=""
+actual_exit=0
+actual_output="$(
+  eval "$_codex_overrides"
+  _ec=0
+  run_codex_github_review "42" "fix/42-test" "1" "5" || _ec=$?
+  printf 'EXIT=%s\n' "$_ec"
+)"
+actual_exit="$(printf '%s\n' "$actual_output" | grep "^EXIT=" | cut -d= -f2)"
+run_test "codex_pending_loop_result" "RESULT=waiting_on_reviewer" \
+  "$(printf '%s\n' "$actual_output" | grep "^RESULT=")"
+run_test "codex_pending_loop_reason" "REASON=codex-github-review-pending" \
+  "$(printf '%s\n' "$actual_output" | grep "^REASON=")"
+run_test "codex_pending_loop_trigger_id" "PENDING_REVIEW_TRIGGER_COMMENT_ID=901" \
+  "$(printf '%s\n' "$actual_output" | grep "^PENDING_REVIEW_TRIGGER_COMMENT_ID=")"
+run_test "codex_pending_loop_exit_code" "4" "$actual_exit"
+rm -rf "$_codex_pending_loop_tmp"
+unset _codex_pending_loop_tmp _codex_overrides actual_output actual_exit
 
 _post_summary_source="$(awk '/^_post_review_summary\(\)/,/^}$/' \
   "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3288,6 +3288,19 @@ run_test "reviewer_failed_needs_fixes_no" "no" "$(_reviewer_failed_required need
 run_test "reviewer_failed_needs_rerun_no" "no" "$(_reviewer_failed_required needs_rerun '')"
 run_test "reviewer_failed_waiting_on_reviewer_no" "no" "$(_reviewer_failed_required waiting_on_reviewer codex-github-review-pending)"
 
+_waiting_case_source="$(awk '
+  /case "\\$platform_result" in/ {capture=1}
+  capture {print}
+  /^  esac$/ && capture {exit}
+' "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh")"
+if printf '%s\n' "$_waiting_case_source" | grep -q 'needs_fixes|waiting_on_reviewer|escalate'; then
+  _waiting_folded_into_blocker="yes"
+else
+  _waiting_folded_into_blocker="no"
+fi
+run_test "waiting_on_reviewer_not_folded_into_blocker_arm" "no" "$_waiting_folded_into_blocker"
+unset _waiting_case_source _waiting_folded_into_blocker
+
 _rf_accumulated=0
 if reviewer_failed_label_required_for_result clean ""; then
   _rf_accumulated=1


### PR DESCRIPTION
## Summary

- Surface Codex final no-response states as `RESULT=waiting_on_reviewer` with current-head trigger telemetry instead of reviewer-unavailable escalation.
- Propagate the new result through `pr-review-loop.sh`, summary rendering, compare verdicts, and exit code 4.
- Document the Protocol 91 handling and add focused tests for pending triggers, duplicate-trigger avoidance, stale evidence, and wrapper propagation.

Closes #1603

## Validation

- `bash -n scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/codex-github-reviewer.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 1 --area 12 --area 13` (448 passed, 0 failed)
- `shellcheck --severity=warning scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/codex-github-reviewer.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `npx markdownlint-cli2 "CHANGELOG.md" "docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md"`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automated PR review orchestration and exit semantics for Codex; misclassification could block merges or spam triggers, but behavior is fail-closed (wait vs escalate) with broad test coverage.
> 
> **Overview**
> When **Codex GitHub review** exhausts its wait budget but a **current-head trigger is already posted** and no terminal bot evidence exists, the reviewer script now returns **`WAITING_ON_REVIEWER` (exit 4)** with trigger/head telemetry (`REASON=codex-github-review-pending`, `PENDING_REVIEW_*`) instead of **`TIMED_OUT` (exit 2)** and reviewer-unavailable escalation. Exit code 2 is narrowed to API/auth/setup failures while waiting.
> 
> **`pr-review-loop.sh`** propagates **`RESULT=waiting_on_reviewer`**, maps it to compare-mode **`waiting`**, posts an appropriate loop summary, and exits **4**. Pending state does **not** dispatch fixers, count as a required-reviewer failure, or escalate on ledger persist failure.
> 
> **Protocol 91** documents orchestrator behavior: stop the local runner, avoid duplicate triggers and readiness/merge steps, and re-run Step 7 when terminal evidence arrives. The readiness gate treats **`waiting_on_reviewer`** like other non-clean loop results.
> 
> Tests cover idempotent pending triggers, wrapper propagation, and scenarios that previously expected timeout/unavailable now expecting **waiting**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d75f4833e6d36b6653507d00f20e748c027c22b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->