### PR TITLE
chore(review): promote local AI reviewer default

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -64,6 +64,7 @@ review:
     # coderabbit-cli, local-ai-reviewer, pr-agent, codex-github,
     # claude-code-action, haystack, copilot, bugbot.
     github:
+      - local-ai-reviewer
       - pr-agent
 
   on_ready:
@@ -118,15 +119,15 @@ review:
   # "coderabbit" GitHub App platform):
   #   rate_limit_policy: warn      # warn|strict; default warn
   #
-  # Local AI reviewer platform options (local-only CLI reviewer; place
-  # "local-ai-reviewer" in on_draft.github to opt in before ready-phase
-  # reviewers):
+  # Local AI reviewer platform options (local-only CLI reviewer; enabled first
+  # in on_draft.github by default before PR-Agent and ready-phase reviewers):
   #   LOCAL_AI_REVIEWER_COMMAND        — command run under sh -c with
   #                                      CONTEXT_BUNDLE_PATH and PR metadata env
   #   LOCAL_AI_REVIEWER_TIMEOUT        — default local command timeout
   #   LOCAL_AI_REVIEWER_GRAPH_STRATEGY — none|auto|code-review-graph|graphify
   #   LOCAL_AI_REVIEWER_DISABLED=1     — intentionally skip with
   #                                      REASON=disabled_by_config
+  #                                      (or override on_draft.github locally)
   #
   # Configurable codex-github options (set via env vars or script flags to pr-review-loop.sh / codex-github-reviewer.sh):
   #   Setup/verification guide: docs/workflow/development-workflow/integrations/codex-github.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1613,6 +1613,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Local AI reviewer default promotion** (#1617): runs
+  `local-ai-reviewer` before PR-Agent in the default draft reviewer path, while
+  keeping Bugbot as the ready-phase reviewer and documenting setup/opt-out
+  controls for local runner environments.
 - **Conservative Codex verdict classifier** (#1491): `codex-github-reviewer.sh` now requires the response —
   whitespace-normalized, with no truncation step of any kind — to be an exact match, from its first
   character to its last, against one of a small set of clean-response templates captured verbatim from real

--- a/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
+++ b/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
@@ -1,9 +1,10 @@
 # Integration: Local AI Reviewer
 
-`local-ai-reviewer` is an optional Step 7 review platform for running a
-repository-local review command before ready-phase reviewers such as Bugbot.
-It is implemented by `scripts/development-workflow/local-ai-reviewer.sh` and
-is consumed by `scripts/development-workflow/pr-review-loop.sh`.
+`local-ai-reviewer` is the default first Step 7 draft GitHub review platform in
+this template. It runs a repository-local review command before draft GitHub
+reviewers such as PR-Agent and before ready-phase reviewers such as Bugbot. It
+is implemented by `scripts/development-workflow/local-ai-reviewer.sh` and is
+consumed by `scripts/development-workflow/pr-review-loop.sh`.
 
 The platform is local-only. It does not post GitHub inline comments in this
 MVP, and a local clean result does not replace human review, CI, unresolved
@@ -13,8 +14,7 @@ thread checks, or the configured ready-phase reviewer.
 
 ## Configuration
 
-Enable it explicitly in `.ai-dev-workflow.yaml` or in
-`.ai-dev-workflow.local.yaml`:
+The shared template enables it before PR-Agent in `.ai-dev-workflow.yaml`:
 
 ```yaml
 review:
@@ -27,15 +27,17 @@ review:
       - bugbot
 ```
 
-The shared template does not enable `local-ai-reviewer` by default because a
-missing local command is a setup failure and emits `RESULT=escalate`.
-
 Set the local command in the runner environment:
 
 <!-- workflow-shell-contract: bash-zsh -->
 ```bash
 export LOCAL_AI_REVIEWER_COMMAND='my-review-command "$CONTEXT_BUNDLE_PATH"'
 ```
+
+A missing local command is a setup failure and emits `RESULT=escalate` with
+`REASON=missing_command`. To intentionally skip the default local reviewer for
+one run or one checkout, set `LOCAL_AI_REVIEWER_DISABLED=1` or override
+`review.on_draft.github` in `.ai-dev-workflow.local.yaml`.
 
 For Codex, use the bundled preset wrapper instead of hand-writing the full
 `codex exec` command:

--- a/docs/workflow/development-workflow/integrations/pr-review-platform.md
+++ b/docs/workflow/development-workflow/integrations/pr-review-platform.md
@@ -84,7 +84,8 @@ review:
       # local-ai-reviewer: local-only CLI reviewer. Requires
       # LOCAL_AI_REVIEWER_COMMAND in the runner environment. Missing command,
       # credentials, model access, timeout, or malformed output escalates.
-      # - local-ai-reviewer
+      # Set LOCAL_AI_REVIEWER_DISABLED=1 or override this list locally to skip.
+      - local-ai-reviewer
       - pr-agent
     # claude-code-action: own-key, own-CI reviewer with no per-hour vendor cap.
     # Requires ANTHROPIC_API_KEY secret and .github/workflows/claude-code-review.yml.

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -3144,6 +3144,8 @@ For the `reviewThreads` resolution check, `gh pr view --json` does not expose `r
 ```bash
 CODEX_BOT_LOGIN="${CODEX_GITHUB_BOT_LOGIN:-chatgpt-codex-connector[bot]}"
 CODEX_BOT_LOGIN="${CODEX_BOT_LOGIN%\[bot\]}"
+BUGBOT_BOT_LOGIN="${BUGBOT_BOT_LOGIN:-cursor[bot]}"
+BUGBOT_BOT_LOGIN="${BUGBOT_BOT_LOGIN%\[bot\]}"
 
 gh api graphql -f query='
   query($owner:String!, $repo:String!, $number:Int!) {
@@ -3155,14 +3157,21 @@ gh api graphql -f query='
       }
     }
   }' -f owner=<owner> -f repo=<repo> -F number=<pr_number> \
-  | jq --arg codex_bot "$CODEX_BOT_LOGIN" '.data.repository.pullRequest.reviewThreads.nodes[]
+  | jq --arg codex_bot "$CODEX_BOT_LOGIN" --arg bugbot_bot "$BUGBOT_BOT_LOGIN" '.data.repository.pullRequest.reviewThreads.nodes[]
         | select(.isResolved == false)
         | select((.isOutdated // false) == false)
-        | select(.comments.nodes[0].author.login as $a | ["coderabbitai","devin-ai-integration","greptile-apps",$codex_bot] | index($a) != null)
+        | select(.comments.nodes[0].author.login as $a | ["coderabbitai","devin-ai-integration","greptile-apps",$codex_bot,$bugbot_bot] | index($a) != null)
         | select((.comments.nodes[0].body // "") | test("✅ Addressed") | not)'
 ```
 
-The bot login list above is a superset covering all async review-bot platforms supported by `pr-review-loop.sh` (`coderabbit`, `devin`, `greptile`, `codex-github`). The current default GitHub reviewer config in `.ai-dev-workflow.yaml` uses `review.on_draft.github: [pr-agent]` and `review.on_ready.github: [codex-github]`. Update the list if your project uses different or additional review bots.
+The bot login list above is a superset covering async review-bot platforms
+supported by `pr-review-loop.sh` that may own GitHub review threads
+(`coderabbit`, `devin`, `greptile`, `codex-github`, `bugbot`). The current
+default GitHub reviewer config in `.ai-dev-workflow.yaml` uses
+`review.on_draft.github: [local-ai-reviewer, pr-agent]` and
+`review.on_ready.github: [bugbot]`; `local-ai-reviewer` and `pr-agent` do not
+own a GitHub review-thread bot login in this workflow. Update the list if your
+project uses different or additional review bots.
 
 The output must contain no unresolved, non-outdated threads from configured bot reviewers (e.g. `coderabbitai`, `devin-ai-integration`, `chatgpt-codex-connector`) before this step passes. A thread is considered non-blocking when `isResolved: true`, `isOutdated: true`, or the first comment body contains `✅ Addressed` (CodeRabbit appends this when a fix commit lands). Any unresolved, non-outdated bot-authored thread that does not meet those conditions — regardless of severity, including Nitpick and Trivial — blocks this check. For PRs with more than 100 threads, implement cursor-based pagination: add `pageInfo { hasNextPage endCursor }` to the `reviewThreads` field selection, capture `endCursor` from each response, and repeat the query with `reviewThreads(first: 100, after: $cursor)` until `hasNextPage` is false.
 

--- a/scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh
@@ -29,6 +29,12 @@ HARNESS_MODE=1 source "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh
 actual="$(bot_login_for_platform local-ai-reviewer)"
 run_test "bot_login_for_platform_local_ai_reviewer_empty" "" "$actual"
 
+shared_config_copy="$(mktemp)"
+cp "$REPO_ROOT/.ai-dev-workflow.yaml" "$shared_config_copy"
+actual="$(workflow_config_review_on_draft_github "$shared_config_copy" | paste -sd ',' -)"
+rm -f "$shared_config_copy"
+run_test "default_draft_github_reviewers_start_with_local_ai" "local-ai-reviewer,pr-agent" "$actual"
+
 _local_ai_dispatch_called=0
 run_local_ai_reviewer_review() {
   _local_ai_dispatch_called=1


### PR DESCRIPTION
## Summary
- Enables `local-ai-reviewer` before PR-Agent in the default draft reviewer path.
- Keeps Bugbot as the ready-phase reviewer.
- Updates integration/protocol docs, opt-out guidance, changelog, and a focused dispatch/config assertion.

Closes #1617

## Validation
- `bash scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh`
- `bash scripts/development-workflow/tests/test-workflow-config-resolver.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh`
- `bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 20`
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop`
- `bash scripts/lint/check-changelog-duplicate-headers.sh CHANGELOG.md`
- `npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md" "docs/workflow/development-workflow/integrations/local-ai-reviewer.md" "docs/workflow/development-workflow/integrations/pr-review-platform.md" "CHANGELOG.md"`
- `git diff --check`

## Planted Violation Proof
- Removed `      - local-ai-reviewer` from a temporary copy of `.ai-dev-workflow.yaml`.
- Parsed draft reviewers became `pr-agent`, not the required `local-ai-reviewer,pr-agent` (`PLANTED_RESULT=failed_as_expected`).
- Restored path is covered by `test-local-ai-reviewer-pr-review-loop-dispatch.sh`, which passes with `default_draft_github_reviewers_start_with_local_ai`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default draft review order means environments without `LOCAL_AI_REVIEWER_COMMAND` (and no opt-out) will hit local reviewer setup/escalation before PR-Agent unless they override config.
> 
> **Overview**
> **Promotes `local-ai-reviewer` to the first default draft-phase GitHub reviewer**, running before PR-Agent while **Bugbot stays the ready-phase reviewer**.
> 
> The shared `.ai-dev-workflow.yaml` now lists `local-ai-reviewer` ahead of `pr-agent` under `review.on_draft.github`, with inline comments describing default ordering and opt-out via `LOCAL_AI_REVIEWER_DISABLED=1` or a local `on_draft.github` override. Integration docs (`local-ai-reviewer.md`, `pr-review-platform.md`) and the changelog (#1617) are aligned with that default and spell out setup/skip behavior when `LOCAL_AI_REVIEWER_COMMAND` is missing.
> 
> Protocol **91** updates the mandatory `reviewThreads` jq filter to treat **Bugbot** (`cursor[bot]`) as a bot-owned thread source and refreshes the documented default reviewer lists. A dispatch test asserts parsed draft reviewers from the repo config are **`local-ai-reviewer,pr-agent`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36db3fd0d5939737ac145752125bc7ab0fdb5a9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->