### PR TITLE
fix(workflow): require current-head clean summary for regression label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Prevent stale reviewer summaries from restoring regression label** (#1621):
+  `pr-review-loop.sh` now restores `ready-for-regression` only from clean or
+  skipped reviewer-loop summary evidence for the current PR head.
 - **Trigger regression after reviewer clean** (#1615): Moved the normal
   regression dispatch path behind current-head reviewer-loop clean evidence so
   implementation PRs no longer run regression from open/reopen/ready events.

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -6565,22 +6565,15 @@ METRICS_HEADER
 #   - Runs only for feature/*, fix/*, refactor/*, hotfix/* branches.
 #   - Checks current label state via `gh pr view --json labels`.
 #     On gh failure the check is skipped (fail-open; WARN emitted to stderr).
-#   - When the label is absent, gates the restore on prior-loop evidence:
-#     checks whether an "Automated Reviewer Loop Summary" comment already exists
-#     on the PR via `gh api repos/.../issues/.../comments --paginate`.
-#       • summary comment PRESENT + label missing  → RESTORE.
-#         Within the reviewer-loop operating model, ready-for-regression is
-#         owned by the loop and should be present whenever the loop runs after
-#         the first summary comment. A label drop after the summary comment exists
-#         means the PR policy workflow removed a stale label after a new push
-#         (the #805 scenario), so restoring here is correct.
-#       • summary comment ABSENT + label missing   → do NOT restore.
-#         This is the normal initial state (loop has never run), and the only
-#         window in which a human intentional removal is unambiguous. A deliberate
-#         removal AFTER the loop has run while still re-invoking the loop is
-#         treated as out-of-model (the loop will re-apply on the next invocation).
-#     The summary-comment gate prevents overriding an intentional removal that
-#     occurs before the loop has ever applied the label.
+#   - When the label is absent, gates the restore on current-head clean-loop
+#     evidence from the newest "Automated Reviewer Loop Summary" comment:
+#       • latest summary result clean/skipped + head_sha matches current PR head
+#         → RESTORE.
+#       • no summary, stale-head summary, non-clean summary, or unreadable
+#         summary history → do NOT restore.
+#     This keeps the helper aligned with the PR policy workflow: a historical
+#     clean summary must not resurrect ready-for-regression after later pushes
+#     introduce reviewer findings.
 #   - If the comment-presence query fails (gh/API error): fail-open — the restore
 #     IS attempted and a WARN is emitted. This mirrors the higher-frequency
 #     real-world failure (#805) being more harmful than a spurious re-apply.
@@ -6607,10 +6600,9 @@ restore_regression_label_if_missing() {
         return 0
       fi
       if [ "${_rfr_has_label:-}" = "false" ]; then
-        # Gate the restore on prior-loop evidence: only restore when an
-        # "Automated Reviewer Loop Summary" comment already exists on the PR.
-        # This prevents overriding a human intentional label removal that occurs
-        # before the loop has ever applied the label.
+        # Gate the restore on current-head clean-loop evidence. A historical
+        # clean summary on an older head must not resurrect a stale label after
+        # a push that introduced reviewer findings.
         local _rfr_repo=""
         # repo_slug failure is handled explicitly below: an empty slug falls
         # into the else branch (fail-open WARN + restore). Do not use || true
@@ -6619,28 +6611,57 @@ restore_regression_label_if_missing() {
         if ! _rfr_repo="$(repo_slug 2>/dev/null)"; then
           _rfr_repo=""
         fi
-        local _rfr_loop_comment=0
+        local _rfr_current_head_sha=""
+        if ! _rfr_current_head_sha="$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid // ""' 2>/dev/null)" \
+            || [ -z "${_rfr_current_head_sha:-}" ]; then
+          echo "WARN: could not resolve current head for ready-for-regression restore on PR #${pr_number}; skipping restore." >&2
+          return 0
+        fi
+        local _rfr_latest_summary_record=""
+        local _rfr_latest_summary_body=""
+        local _rfr_latest_summary_json=""
+        local _rfr_latest_summary_result=""
+        local _rfr_latest_summary_head=""
+        local _rfr_restore_allowed=0
         local _rfr_comments_raw=""
         if [ -n "${_rfr_repo:-}" ] && _rfr_comments_raw="$(gh api \
             "repos/${_rfr_repo}/issues/${pr_number}/comments" \
             --paginate 2>/dev/null)"; then
-          _rfr_loop_comment="$(printf '%s\n' "$_rfr_comments_raw" \
-            | jq -rs 'add // [] | [.[] | select(
-                (.body // "" | contains("### Automated Reviewer Loop Summary"))
-              )] | length' 2>/dev/null)" || _rfr_loop_comment=0
+          _rfr_latest_summary_record="$(printf '%s\n' "$_rfr_comments_raw" \
+            | reviewer_loop_history_select_latest_summary_record 2>/dev/null)" || _rfr_latest_summary_record=""
+          if [ -n "${_rfr_latest_summary_record:-}" ]; then
+            _rfr_latest_summary_body="$(printf '%s\n' "$_rfr_latest_summary_record" \
+              | jq -r '.body // ""' 2>/dev/null)" || _rfr_latest_summary_body=""
+          fi
+          if [ -n "${_rfr_latest_summary_body:-}" ]; then
+            _rfr_latest_summary_json="$(printf '%s\n' "$_rfr_latest_summary_body" \
+              | reviewer_loop_history_extract_latest_json 2>/dev/null)" || _rfr_latest_summary_json=""
+          fi
+          if [ -n "${_rfr_latest_summary_json:-}" ]; then
+            _rfr_latest_summary_result="$(printf '%s\n' "$_rfr_latest_summary_json" \
+              | jq -r '(.entries // []) | last | .result // ""' 2>/dev/null)" || _rfr_latest_summary_result=""
+            _rfr_latest_summary_head="$(printf '%s\n' "$_rfr_latest_summary_json" \
+              | jq -r '(.entries // []) | last | .head_sha // ""' 2>/dev/null)" || _rfr_latest_summary_head=""
+          fi
+          if { [ "${_rfr_latest_summary_result:-}" = "clean" ] \
+              || [ "${_rfr_latest_summary_result:-}" = "skipped" ]; } \
+              && [ -n "${_rfr_latest_summary_head:-}" ] \
+              && [ "${_rfr_latest_summary_head:-}" = "${_rfr_current_head_sha:-}" ]; then
+            _rfr_restore_allowed=1
+          fi
         else
           echo "WARN: gh api failed for summary-comment gate on PR ${pr_number}; failing open — restoring label." >&2
-          _rfr_loop_comment=1
+          _rfr_restore_allowed=1
         fi
-        if [ "${_rfr_loop_comment:-0}" -gt 0 ]; then
-          echo "INFO: ready-for-regression label missing on PR #${pr_number} (${branch_name}); reviewer loop summary comment found — restoring before loop runs." >&2
+        if [ "${_rfr_restore_allowed:-0}" -eq 1 ]; then
+          echo "INFO: ready-for-regression label missing on PR #${pr_number} (${branch_name}); current-head clean reviewer-loop summary found — restoring before loop runs." >&2
           # Do NOT redirect stderr here: surface gh errors so failures are observable
           # rather than silently swallowed. The || branch handles the non-zero exit.
           if ! gh pr edit "$pr_number" --add-label "ready-for-regression"; then
             echo "WARN: failed to restore ready-for-regression label on PR #${pr_number}; proceeding without it" >&2
           fi
         else
-          echo "INFO: ready-for-regression label missing on PR #${pr_number} (${branch_name}); no reviewer loop summary comment found — skipping restore (label not yet applied by loop)." >&2
+          echo "INFO: ready-for-regression label missing on PR #${pr_number} (${branch_name}); no current-head clean reviewer-loop summary found — skipping restore." >&2
         fi
       fi
       ;;

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -6623,6 +6623,7 @@ restore_regression_label_if_missing() {
         local _rfr_latest_summary_result=""
         local _rfr_latest_summary_head=""
         local _rfr_restore_allowed=0
+        local _rfr_restore_reason="current-head clean reviewer-loop summary found"
         local _rfr_comments_raw=""
         if [ -n "${_rfr_repo:-}" ] && _rfr_comments_raw="$(gh api \
             "repos/${_rfr_repo}/issues/${pr_number}/comments" \
@@ -6652,9 +6653,10 @@ restore_regression_label_if_missing() {
         else
           echo "WARN: gh api failed for summary-comment gate on PR ${pr_number}; failing open — restoring label." >&2
           _rfr_restore_allowed=1
+          _rfr_restore_reason="summary-comment lookup failed; fail-open restore"
         fi
         if [ "${_rfr_restore_allowed:-0}" -eq 1 ]; then
-          echo "INFO: ready-for-regression label missing on PR #${pr_number} (${branch_name}); current-head clean reviewer-loop summary found — restoring before loop runs." >&2
+          echo "INFO: ready-for-regression label missing on PR #${pr_number} (${branch_name}); ${_rfr_restore_reason} — restoring before loop runs." >&2
           # Do NOT redirect stderr here: surface gh errors so failures are observable
           # rather than silently swallowed. The || branch handles the non-zero exit.
           if ! gh pr edit "$pr_number" --add-label "ready-for-regression"; then

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3108,36 +3108,61 @@ unset _entry_write_payload
 #   MOCK_GH_COMMENTS_EXIT — controls whether the comments API call exits with
 #                           an error independently of MOCK_GH_EXIT
 #
-# Summary-comment gate (issue #805 Haystack finding):
-#   label missing + summary PRESENT → restore IS called
-#   label missing + summary ABSENT  → restore NOT called
-#   comments API fails              → fail-open: restore IS called + WARN emitted
+# Summary-comment gate:
+#   label missing + latest summary clean/skipped for current head → restore IS called
+#   label missing + latest summary absent/stale/non-clean         → restore NOT called
+#   comments API fails                                            → fail-open: restore IS called + WARN emitted
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== Area 11: regression-label auto-restore (Option C, issue #805) ==="
 
 # Reset mock vars from earlier areas.
 unset MOCK_GH_POST_EXIT MOCK_GH_POST_OUTPUT MOCK_GH_CALL_LOG MOCK_GH_EXIT
-unset MOCK_GH_COMMENTS_OUTPUT MOCK_GH_COMMENTS_EXIT
+unset MOCK_GH_COMMENTS_OUTPUT MOCK_GH_COMMENTS_EXIT MOCK_GH_HEAD_SHA
 
-# JSON payload used by tests that require a summary comment to be "present".
-_SUMMARY_COMMENT_JSON='[{"id":1,"body":"### Automated Reviewer Loop Summary\nAll platforms clean."}]'
+_SUMMARY_CURRENT_HEAD_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+_SUMMARY_OLD_HEAD_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
-# Test 11.1: label absent + summary comment PRESENT on an implementation branch
-# → gh pr edit IS called (the #805 scenario: loop ran before, label was dropped
-# by a push, restore is correct).
+_summary_comment_json_for_11() {
+  local _head_sha="$1"
+  local _result="$2"
+  local _created_at="${3:-2026-08-26T12:00:00Z}"
+  local _payload
+  local _body
+
+  _payload="$(jq -n \
+    --arg headSha "$_head_sha" \
+    --arg result "$_result" \
+    '{
+      schema: "reviewer_loop_history.v1",
+      history_status: "available",
+      entries: [{iteration: 1, head_sha: $headSha, result: $result}]
+    }')"
+  _body="$(printf '### Automated Reviewer Loop Summary\n\n*Posted automatically by `pr-review-loop.sh`.*\n\n<!-- reviewer-loop-history:v1 -->\n```json\n%s\n```\n' "$_payload")"
+  jq -n --arg body "$_body" --arg createdAt "$_created_at" \
+    '[{id: 1, created_at: $createdAt, body: $body}]'
+}
+
+# JSON payload used by tests that require a current-head clean summary.
+_SUMMARY_COMMENT_JSON="$(_summary_comment_json_for_11 "$_SUMMARY_CURRENT_HEAD_SHA" "clean")"
+_SUMMARY_STALE_COMMENT_JSON="$(_summary_comment_json_for_11 "$_SUMMARY_OLD_HEAD_SHA" "clean")"
+_SUMMARY_NEEDS_FIXES_COMMENT_JSON="$(_summary_comment_json_for_11 "$_SUMMARY_CURRENT_HEAD_SHA" "needs_fixes")"
+
+# Test 11.1: label absent + latest summary clean for the current PR head on an
+# implementation branch → gh pr edit IS called.
 if ! _call_log_11="$(mktemp)"; then
   echo "ERROR: failed to allocate regression-label test temp file" >&2
   exit 1
 fi
 export MOCK_GH_OUTPUT="false"
+export MOCK_GH_HEAD_SHA="$_SUMMARY_CURRENT_HEAD_SHA"
 export MOCK_GH_COMMENTS_OUTPUT="$_SUMMARY_COMMENT_JSON"
 export MOCK_GH_CALL_LOG="$_call_log_11"
 restore_regression_label_if_missing "42" "fix/42-my-fix" 2>/dev/null
 _edit_calls="$(grep -c -- '--add-label' "$_call_log_11" 2>/dev/null)" || _edit_calls="0"
-run_test "restore_label_absent_summary_present_calls_gh_edit" "1" "$_edit_calls"
+run_test "restore_label_absent_current_head_clean_summary_calls_gh_edit" "1" "$_edit_calls"
 rm -f "$_call_log_11"
-unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_OUTPUT
+unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_OUTPUT MOCK_GH_HEAD_SHA
 
 # Test 11.2: label already present on an implementation branch → NO gh pr edit.
 # MOCK_GH_OUTPUT is "true" (label present); summary-comment gate is not reached.
@@ -3193,13 +3218,14 @@ if ! _call_log_11="$(mktemp)"; then
   exit 1
 fi
 export MOCK_GH_OUTPUT="false"
+export MOCK_GH_HEAD_SHA="$_SUMMARY_CURRENT_HEAD_SHA"
 export MOCK_GH_COMMENTS_OUTPUT="$_SUMMARY_COMMENT_JSON"
 export MOCK_GH_CALL_LOG="$_call_log_11"
 restore_regression_label_if_missing "99" "hotfix/99-critical" 2>/dev/null
 _edit_calls="$(grep -c -- '--add-label' "$_call_log_11" 2>/dev/null)" || _edit_calls="0"
 run_test "restore_label_hotfix_branch_calls_gh_edit" "1" "$_edit_calls"
 rm -f "$_call_log_11"
-unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_OUTPUT
+unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_OUTPUT MOCK_GH_HEAD_SHA
 
 # Test 11.6: restore function is defined before the HARNESS_MODE return point
 # (source-level ordering check — ensures the function remains testable after
@@ -3224,20 +3250,49 @@ unset _restore_fn_line _harness_return_line _fn_ordering_ok
 # a human intentional removal is unambiguous. The restore must be suppressed.
 _call_log_11="$(mktemp)"
 export MOCK_GH_OUTPUT="false"
+export MOCK_GH_HEAD_SHA="$_SUMMARY_CURRENT_HEAD_SHA"
 export MOCK_GH_COMMENTS_OUTPUT="[]"
 export MOCK_GH_CALL_LOG="$_call_log_11"
 restore_regression_label_if_missing "42" "fix/42-no-summary" 2>/dev/null
 _edit_calls="$(grep -c -- '--add-label' "$_call_log_11" 2>/dev/null)" || _edit_calls="0"
 run_test "restore_label_absent_summary_absent_no_gh_edit" "0" "$_edit_calls"
 rm -f "$_call_log_11"
-unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_OUTPUT
+unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_OUTPUT MOCK_GH_HEAD_SHA
 
-# Test 11.8: label absent + comments API failure → fail-open: gh pr edit IS called
+# Test 11.8: label absent + stale clean summary from an older head → gh pr edit
+# is NOT called. This is the regression where ready-for-regression could be
+# resurrected before reviewer findings were clean for the new push.
+_call_log_11="$(mktemp)"
+export MOCK_GH_OUTPUT="false"
+export MOCK_GH_HEAD_SHA="$_SUMMARY_CURRENT_HEAD_SHA"
+export MOCK_GH_COMMENTS_OUTPUT="$_SUMMARY_STALE_COMMENT_JSON"
+export MOCK_GH_CALL_LOG="$_call_log_11"
+restore_regression_label_if_missing "42" "fix/42-stale-summary" 2>/dev/null
+_edit_calls="$(grep -c -- '--add-label' "$_call_log_11" 2>/dev/null)" || _edit_calls="0"
+run_test "restore_label_stale_clean_summary_no_gh_edit" "0" "$_edit_calls"
+rm -f "$_call_log_11"
+unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_OUTPUT MOCK_GH_HEAD_SHA
+
+# Test 11.9: label absent + latest current-head summary is not clean/skipped
+# → gh pr edit is NOT called.
+_call_log_11="$(mktemp)"
+export MOCK_GH_OUTPUT="false"
+export MOCK_GH_HEAD_SHA="$_SUMMARY_CURRENT_HEAD_SHA"
+export MOCK_GH_COMMENTS_OUTPUT="$_SUMMARY_NEEDS_FIXES_COMMENT_JSON"
+export MOCK_GH_CALL_LOG="$_call_log_11"
+restore_regression_label_if_missing "42" "fix/42-needs-fixes" 2>/dev/null
+_edit_calls="$(grep -c -- '--add-label' "$_call_log_11" 2>/dev/null)" || _edit_calls="0"
+run_test "restore_label_current_head_needs_fixes_summary_no_gh_edit" "0" "$_edit_calls"
+rm -f "$_call_log_11"
+unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_OUTPUT MOCK_GH_HEAD_SHA
+
+# Test 11.10: label absent + comments API failure → fail-open: gh pr edit IS called
 # and a WARN is emitted. Rationale: the #805 regression (label silently dropped
 # after loop ran) is the higher-frequency real-world failure; when we cannot
 # determine whether the loop ran, restoring is the safer choice.
 _call_log_11="$(mktemp)"
 export MOCK_GH_OUTPUT="false"
+export MOCK_GH_HEAD_SHA="$_SUMMARY_CURRENT_HEAD_SHA"
 export MOCK_GH_COMMENTS_EXIT=1
 export MOCK_GH_CALL_LOG="$_call_log_11"
 _warn_output="$(restore_regression_label_if_missing "42" "fix/42-comments-fail" 2>&1)"
@@ -3251,12 +3306,13 @@ else
 fi
 run_test "restore_label_comments_api_fail_warn_emitted" "yes" "$_warn_emitted"
 rm -f "$_call_log_11"
-unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_EXIT _warn_output
+unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_EXIT MOCK_GH_HEAD_SHA _warn_output
 
 # Reset mock state.
 export MOCK_GH_OUTPUT='[]'
-unset MOCK_GH_EXIT MOCK_GH_COMMENTS_OUTPUT MOCK_GH_COMMENTS_EXIT
-unset _SUMMARY_COMMENT_JSON
+unset MOCK_GH_EXIT MOCK_GH_COMMENTS_OUTPUT MOCK_GH_COMMENTS_EXIT MOCK_GH_HEAD_SHA
+unset _SUMMARY_COMMENT_JSON _SUMMARY_STALE_COMMENT_JSON _SUMMARY_NEEDS_FIXES_COMMENT_JSON
+unset _SUMMARY_CURRENT_HEAD_SHA _SUMMARY_OLD_HEAD_SHA
 
 # ---------------------------------------------------------------------------
 # Area 12: reviewer-failed label sync (issue #804)

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -3305,8 +3305,15 @@ else
   _warn_emitted="no"
 fi
 run_test "restore_label_comments_api_fail_warn_emitted" "yes" "$_warn_emitted"
+if printf '%s\n' "$_warn_output" | grep -q "summary-comment lookup failed; fail-open restore" \
+    && ! printf '%s\n' "$_warn_output" | grep -q "current-head clean reviewer-loop summary found"; then
+  _failopen_reason_ok="yes"
+else
+  _failopen_reason_ok="no"
+fi
+run_test "restore_label_comments_api_fail_logs_failopen_reason" "yes" "$_failopen_reason_ok"
 rm -f "$_call_log_11"
-unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_EXIT MOCK_GH_HEAD_SHA _warn_output
+unset MOCK_GH_CALL_LOG MOCK_GH_COMMENTS_EXIT MOCK_GH_HEAD_SHA _warn_output _failopen_reason_ok
 
 # Reset mock state.
 export MOCK_GH_OUTPUT='[]'


### PR DESCRIPTION
## Summary

- Gates `pr-review-loop.sh` ready-for-regression restore on the latest reviewer-loop summary being clean or skipped for the current PR head.
- Keeps stale-head, non-clean, missing, or unreadable summary evidence from restoring the regression label.
- Adds Area 11 regressions for current-head clean restore, stale clean summaries, and needs-fixes summaries.

Closes #1621

## Decision-Gate Matrix

| Label state | Latest reviewer-loop summary | Current head match | Comment API | Outcome |
|---|---|---|---|---|
| `ready-for-regression` present | Any | Any | Not queried | No-op |
| Missing | `clean` or `skipped` | Yes | Available | Restore label |
| Missing | `clean` or `skipped` | No | Available | Do not restore |
| Missing | `needs_fixes`, `needs_rerun`, waiting, escalation, missing, or unreadable history | Any | Available | Do not restore |
| Missing | Any | Current head unavailable | Any | Do not restore; warn |
| Missing | Unknown | Current head resolved | Unavailable | Restore label; warn using the existing fail-open API-failure policy |

Mirror surfaces: this aligns the `pr-review-loop.sh` startup restore path with the current `.github/workflows/pr-policy.yml` rule introduced by #1615: regression readiness requires reviewer-loop clean evidence bound to the current PR head. Examples are covered by Area 11 tests for current-head clean restore, stale clean summaries, missing summaries, and current-head `needs_fixes` summaries.

## Planted-Violation Proof

The planted violation is the old behavior: a stale clean summary from an older head restores `ready-for-regression`.

- Check location: `scripts/development-workflow/tests/test-pr-review-loop.sh:3262` verifies `restore_label_stale_clean_summary_no_gh_edit` expects zero `gh pr edit --add-label` calls when the summary head differs from the current PR head.
- Failing proof against the old helper: in a temporary worktree at `origin/develop`, I applied only this PR's updated test harness and ran `bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 11`; it exited `1` with `FAIL: restore_label_stale_clean_summary_no_gh_edit — expected '0', got '1'` and `Tests: 10 passed, 3 failed`.
- Passing proof with the fix: on this branch, `bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 11` exits `0` with `restore_label_stale_clean_summary_no_gh_edit` passing and `Tests: 13 passed, 0 failed`.

## Verification

- `bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 11` — 13 passed, 0 failed
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop`
- `npx markdownlint-cli2 CHANGELOG.md`
- `bash -n scripts/development-workflow/pr-review-loop.sh scripts/development-workflow/tests/test-pr-review-loop.sh`
- `git diff --check origin/develop...HEAD`
- `scripts/development-workflow/run-nested-artifact-guard.sh --mode pre-pr --issue 1621 --expected-branch fix/1621-regression-label-current-head-restore --approved-base develop --repo-root /Users/lhpaul/Git/ai-dev-framework-template` — RESULT=clean

## Pre-Submission Self-Review Pass

- Reviewed `git diff origin/develop...HEAD`; changes are scoped to the stale regression-label restore path, its focused harness coverage, and the changelog entry.
- Confirmed the helper now requires current-head clean/skipped reviewer-loop history before restore, matching the PR policy behavior introduced by #1615.
- Confirmed stale-head and needs-fixes summaries do not call `gh pr edit --add-label ready-for-regression`.
- Recovery note: the issue was created after the initial branch was started, so the pre-create numeric guard could not be run. I preserved the original branch and created/pushed the compliant issue-prefixed branch before opening this PR; pre-PR guard is clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR workflow label automation that gates regression runs; mis-parsing summary JSON or head comparison could block or spuriously restore regression readiness.
> 
> **Overview**
> **Tightens when `pr-review-loop.sh` re-applies `ready-for-regression` before the reviewer loop runs.** Instead of restoring whenever any “Automated Reviewer Loop Summary” comment exists, restore now requires the **newest** summary’s embedded history to show **`clean` or `skipped`** and a **`head_sha` matching the current PR head**.
> 
> **Stale clean summaries, `needs_fixes` (and similar) results, missing/unreadable history, or an unresolved current head skip restore**; comment API failures still **fail-open** with a WARN. Area 11 tests and **CHANGELOG** document the #1621 behavior and add coverage for stale-head and non-clean summaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c362280d0e9c56f100b39381e7526291657b205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->