### PR TITLE
docs(workflow): document backlog item type flag

### DIFF
--- a/changelog.d/1545.fixed.add-backlog-type-docs.md
+++ b/changelog.d/1545.fixed.add-backlog-type-docs.md
@@ -1,0 +1,3 @@
+- **Document backlog item Type creation** (#1545): updates the add-backlog-item
+  protocol to pass `--type` when creating GitHub Project-backed issues, so new
+  Backlog items get routeable project classification at creation time.

--- a/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
+++ b/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
@@ -22,7 +22,7 @@ Optional deterministic helper (destination resolution and GitHub issue creation)
 
 ```bash
 ./scripts/development-workflow/add-backlog-item.sh resolve
-./scripts/development-workflow/add-backlog-item.sh create --title "..." --body-file -
+./scripts/development-workflow/add-backlog-item.sh create --title "..." --body-file - --type Workflow
 ```
 
 ---
@@ -85,14 +85,32 @@ assets or a fidelity baseline.
 
 1. Create **one** item in the **confirmed** destination.
 2. For **GitHub Issues** (including when `issue_tracker.provider` is `github_projects`), prefer:
-   - `./scripts/development-workflow/add-backlog-item.sh create --title "..." --body-file - [--priority <value>] [--size <value>]` (requires `gh` authenticated), **or**
+   - `./scripts/development-workflow/add-backlog-item.sh create --title "..." --body-file - --type <Feature|Bug|Refactor|Workflow> [--priority <value>] [--size <value>]` (requires `gh` authenticated), **or**
    - Equivalent `gh issue create` with the same title/body, followed by manual project field updates.
 3. For **Linear**, use the Linear API/MCP per [`linear.md`](../integrations/linear.md). `add-backlog-item.sh create` now emits `TRACKER_ACTION_REQUIRED=create_item title=<title>` to stdout and exits 0 (not non-zero) when the configured provider is Linear. Multi-word titles are single-quoted (e.g., `title='My New Feature'`); strip the quotes before passing to the Linear MCP `createIssue` tool. Guidance referencing `linear.md` is also written to stderr for operator visibility.
 4. For **GitHub Projects** after the issue exists: if the team uses a project board, add/update the project item per `github-projects.md` (optional field updates such as Status = Backlog and Type = Feature/Bug/Refactor/Workflow) **only when** the human or repo docs supply enough context (project number, owner). If project context is missing, **ask** rather than guessing.
 5. When GitHub Projects is configured, use the project **Type** field for classification instead of repository labels. Set `Type = Workflow` for AI-development-framework/process/tooling work, `Type = Feature` for full-pipeline product work, `Type = Bug` for fast-track fixes, and `Type = Refactor` for plan-only refactors. Do not apply legacy classification labels such as `workflow`, `bug`, `enhancement`, or `type:*`; operational labels such as `integration-branch:<slug>` remain valid when the protocol requires them.
-6. When GitHub Projects is configured, set **Priority** and **Size** on the project item. Use the inference heuristics below to determine values without asking the human for every routine item.
+6. When GitHub Projects is configured, set **Type**, **Priority**, and **Size** on the project item. Use the inference heuristics below to determine values without asking the human for every routine item.
 
-### Priority and Size inference heuristics (GitHub Projects)
+### Type, Priority, and Size inference heuristics (GitHub Projects)
+
+**Type** — infer from the intended workflow path and pass it with `--type`.
+When GitHub Projects is configured, omitting Type makes the item harder for
+Protocol 90 to route because Backlog classification comes from the project
+field, not repository labels.
+
+| Signal | Type |
+| ------ | ---- |
+| Full Pipeline feature or product capability | `--type Feature` |
+| Fast Track bug fix, defect, or simple corrective change | `--type Bug` |
+| Plan-only restructuring or non-feature refactor | `--type Refactor` |
+| AI-development-framework/process/tooling item | `--type Workflow` |
+
+When two signals appear to conflict, prefer the project classification that
+best controls the workflow path. For example, a workflow-process bug that
+should move through the Fast Track path may use `--type Bug`; a framework
+process improvement that should be routed as workflow/tooling may use
+`--type Workflow`.
 
 **Priority** — infer from the request. When no explicit urgency/low signal
 applies (the routine case), **omit `--priority` entirely** and let the
@@ -135,10 +153,15 @@ Pass inferred values directly to the helper:
 ./scripts/development-workflow/add-backlog-item.sh create \
   --title "..." \
   --body-file - \
+  --type Workflow \
   --size S
 ```
 
 This example omits `--priority` for the routine case shown in the table above, so the helper script's adaptive default applies. Pass `--priority Urgent`, `--priority High`, or `--priority Low` explicitly only when the corresponding signal from the table applies.
+
+Always pass `--type` for GitHub Projects when the request has enough context to
+classify the item. If the type is genuinely unclear after reading the request,
+ask a targeted clarification instead of creating an untyped project item.
 
 When the scope is genuinely unclear after reading the request, omit `--size` (leave it unset) rather than guessing.
 

--- a/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
+++ b/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
@@ -20,6 +20,7 @@ Before creating anything, read:
 
 Optional deterministic helper (destination resolution and GitHub issue creation):
 
+<!-- workflow-shell-contract: bash-zsh -->
 ```bash
 ./scripts/development-workflow/add-backlog-item.sh resolve
 ./scripts/development-workflow/add-backlog-item.sh create --title "..." --body-file - --type Workflow
@@ -149,6 +150,7 @@ silent no-op:
 
 Pass inferred values directly to the helper:
 
+<!-- workflow-shell-contract: bash-zsh -->
 ```bash
 ./scripts/development-workflow/add-backlog-item.sh create \
   --title "..." \

--- a/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
+++ b/docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md
@@ -22,6 +22,8 @@ Optional deterministic helper (destination resolution and GitHub issue creation)
 
 <!-- workflow-shell-contract: bash-zsh -->
 ```bash
+set -euo pipefail
+
 ./scripts/development-workflow/add-backlog-item.sh resolve
 ./scripts/development-workflow/add-backlog-item.sh create --title "..." --body-file - --type Workflow
 ```
@@ -107,11 +109,11 @@ field, not repository labels.
 | Plan-only restructuring or non-feature refactor | `--type Refactor` |
 | AI-development-framework/process/tooling item | `--type Workflow` |
 
-When two signals appear to conflict, prefer the project classification that
-best controls the workflow path. For example, a workflow-process bug that
-should move through the Fast Track path may use `--type Bug`; a framework
-process improvement that should be routed as workflow/tooling may use
-`--type Workflow`.
+When two signals appear to conflict, prefer the classification that preserves
+the repository's routing source of truth. AI-development-framework,
+workflow-process, and tooling items use `--type Workflow` even when the item
+fixes a defect in that workflow surface. Use `--type Bug` for defects outside
+the framework/process/tooling classification.
 
 **Priority** — infer from the request. When no explicit urgency/low signal
 applies (the routine case), **omit `--priority` entirely** and let the


### PR DESCRIPTION
## Summary
- Adds `--type` to the preferred GitHub backlog item creation command in Protocol 00.
- Adds Type inference guidance next to Priority/Size guidance.
- Adds a changelog fragment for #1545.

Closes #1545

## Pre-Submission Self-Review
- Scope matches #1545: protocol-doc gap only; no helper behavior changed.
- Confirmed all issue-listed locations now mention or pass `--type`: optional helper, Step 3 create invocation, example snippet, and closing guidance.
- No workflow/security checklist applies beyond shell snippet lint because this edits protocol shell examples only.

## Validation
- `npx markdownlint-cli2 "docs/workflow/development-workflow/protocols/00-add-backlog-item-protocol.md" "changelog.d/1545.fixed.add-backlog-type-docs.md"`
- `bash scripts/development-workflow/changelog-fragments.sh validate`
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop`
- `git diff --check`
- `python3 - <<PY ...` explicit content check for optional helper, Step 3 invocation, example snippet, and closing guidance

## Planted Violation Proof
- The explicit content check fails when `--type Workflow` is removed from the example snippet or when the `--type <Feature|Bug|Refactor|Workflow>` placeholder is removed from the Step 3 invocation.
- Restored protocol text passes the same check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changelog only; no script or runtime behavior changes.
> 
> **Overview**
> Documents **`--type`** on `add-backlog-item.sh create` in Protocol 00 so GitHub Project-backed backlog items get **Type** at creation time, aligning docs with existing helper behavior (#1545).
> 
> Updates the optional helper snippet, Step 3 preferred invocation, and the full example to include `--type` (with `set -euo pipefail` and workflow-shell-contract markers on shell blocks). Step 6 and the inference section are renamed to cover **Type, Priority, and Size**, with a new signal table (`Feature` / `Bug` / `Refactor` / `Workflow`), conflict rules (workflow/tooling vs product bugs), and explicit guidance to always pass `--type` when classifiable—or ask rather than create untyped items. Adds a changelog fragment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1847daa24ba3a0fc85e78bf2d543d7427e2c7148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->