### PR TITLE
fix(workflow): handle cleanup from PR worktrees

### DIFF
--- a/changelog.d/1626.fixed.post-merge-worktree-cleanup.md
+++ b/changelog.d/1626.fixed.post-merge-worktree-cleanup.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Made post-merge cleanup re-enter the existing base-branch worktree when invoked from a merged PR worktree, avoiding `git checkout develop` failures when `develop` is already checked out elsewhere.

--- a/scripts/development-workflow/post-merge-cleanup.sh
+++ b/scripts/development-workflow/post-merge-cleanup.sh
@@ -434,6 +434,49 @@ else
 fi
 echo ""
 
+reenter_base_worktree_if_needed() {
+  local current_root base_worktree script_path
+  local reenter_args=()
+
+  # Git refuses to check out a branch that is already checked out in another
+  # linked worktree. When cleanup is invoked from a merged PR worktree, continue
+  # from the existing base-branch worktree instead of failing on checkout.
+  current_root="$(CDPATH='' cd -- "$CLEANUP_REPO_ROOT" && pwd -P)" || return 1
+  base_worktree="$(git -C "$CLEANUP_REPO_ROOT" worktree list --porcelain | awk -v branch="branch refs/heads/$DEVELOP_BRANCH" '
+    /^worktree / { wt = substr($0, 10) }
+    $0 == branch  { print wt; exit }
+  ' || true)"
+
+  [ -n "$base_worktree" ] || return 0
+  base_worktree="$(CDPATH='' cd -- "$base_worktree" && pwd -P)" || return 1
+  [ "$base_worktree" != "$current_root" ] || return 0
+
+  if [ "${POST_MERGE_CLEANUP_REENTERED:-}" = "1" ]; then
+    echo "ERROR: base branch '$DEVELOP_BRANCH' is checked out at '$base_worktree', but cleanup already re-entered once from '$current_root'." >&2
+    return 1
+  fi
+
+  script_path="$base_worktree/scripts/development-workflow/post-merge-cleanup.sh"
+  if [ ! -f "$script_path" ]; then
+    echo "ERROR: base branch '$DEVELOP_BRANCH' is checked out at '$base_worktree', but cleanup helper is missing there: $script_path" >&2
+    return 1
+  fi
+
+  echo "Base branch '$DEVELOP_BRANCH' is already checked out at '$base_worktree'. Re-entering cleanup from that worktree..."
+  if [ -n "$target_repo" ]; then
+    reenter_args+=(--repo "$target_repo")
+  fi
+  reenter_args+=(--repo-root "$base_worktree" --base "$DEVELOP_BRANCH")
+  if [ -n "$merged_pr_number" ]; then
+    reenter_args+=(--pr "$merged_pr_number")
+  fi
+  reenter_args+=("$TO_DELETE")
+
+  exec env POST_MERGE_CLEANUP_REENTERED=1 "$script_path" "${reenter_args[@]}"
+}
+
+reenter_base_worktree_if_needed
+
 echo "Fetching origin..."
 # --prune: remove stale remote-tracking refs (e.g. origin/<merged-branch>)
 git fetch origin --prune

--- a/scripts/development-workflow/tests/test-post-merge-cleanup.sh
+++ b/scripts/development-workflow/tests/test-post-merge-cleanup.sh
@@ -233,6 +233,49 @@ run_contains "merged_implementation_remote_deleted" "REMOTE_DELETE_RESULT=delete
 run_contains "merged_implementation_records_pr" "REMOTE_DELETE_PR_NUMBER=77" "$merged_output"
 run_test "merged_implementation_remote_ref_absent" "" "$("$REAL_GIT" -C "$merged_repo" ls-remote --heads origin "$merged_branch")"
 
+worktree_branch="feature/noissue-worktree-cleanup"
+worktree_repo="$(make_repo worktree-cleanup "$worktree_branch" yes)"
+mkdir -p "$worktree_repo/scripts/development-workflow"
+cp "$REPO_ROOT/scripts/development-workflow/post-merge-cleanup.sh" "$worktree_repo/scripts/development-workflow/post-merge-cleanup.sh"
+cp "$REPO_ROOT/scripts/development-workflow/workflow-lib.sh" "$worktree_repo/scripts/development-workflow/workflow-lib.sh"
+cp "$REPO_ROOT/scripts/development-workflow/workflow-config-resolver.py" "$worktree_repo/scripts/development-workflow/workflow-config-resolver.py"
+chmod +x "$worktree_repo/scripts/development-workflow/post-merge-cleanup.sh"
+worktree_pr_path="$TMP_ROOT/worktree-cleanup-pr"
+"$REAL_GIT" -C "$worktree_repo" worktree add -q "$worktree_pr_path" "$worktree_branch"
+worktree_output="$(
+  GH_MERGED_HEAD="$worktree_branch" \
+  GH_MERGED_PR=85 \
+  WORKFLOW_TARGET_GITHUB_REPO=example/repo \
+  PATH="$stub_bin:$PATH" \
+  "$HELPER" \
+    --repo-root "$worktree_pr_path" \
+    --base develop \
+    --pr 85 \
+    "$worktree_branch"
+)"
+run_contains \
+  "worktree_cleanup_reenters_base_worktree" \
+  "Re-entering cleanup from that worktree" \
+  "$worktree_output"
+run_contains \
+  "worktree_cleanup_deletes_remote_branch" \
+  "REMOTE_DELETE_RESULT=deleted" \
+  "$worktree_output"
+run_test "worktree_cleanup_pr_worktree_removed" "no" "$(
+  if [ -d "$worktree_pr_path" ]; then
+    printf 'yes'
+  else
+    printf 'no'
+  fi
+)"
+run_test "worktree_cleanup_local_branch_removed" "no" "$(
+  if "$REAL_GIT" -C "$worktree_repo" show-ref --quiet "refs/heads/$worktree_branch"; then
+    printf 'yes'
+  else
+    printf 'no'
+  fi
+)"
+
 absent_branch="feature/noissue-already-absent"
 absent_repo="$(make_repo absent "$absent_branch" no)"
 absent_output="$(


### PR DESCRIPTION
## Summary

- Re-enter `post-merge-cleanup.sh` from the existing base-branch worktree when cleanup is invoked from a merged PR worktree.
- Preserve merged-PR validation and branch deletion semantics after re-entry.
- Add regression coverage for the exact worktree collision where `develop` is already checked out in the main worktree.

## Pre-Submission Self-Review Pass

- Reviewed `git diff origin/develop...HEAD` for scope: changes are limited to post-merge cleanup, its focused test, and the changelog fragment.
- Issue coverage: addresses #1626 by avoiding the `fatal: 'develop' is already used by worktree` failure during cleanup from PR worktrees.
- Complex workflow decision-gate matrix: applicable because this touches workflow cleanup. The change keeps the existing merged-PR guard before remote deletion, re-enters only once, requires the base worktree to contain the cleanup helper, and does not force-delete unverified branches.
- Operational assumptions: fast-track item with no implementation plan; no plan-time assumption re-verification required.

## Verification

- `bash scripts/development-workflow/tests/test-post-merge-cleanup.sh` — 69 passed, 0 failed.
- `python3 scripts/lint/workflow-shell-guard-lint.py --base-ref origin/develop`
- `python3 scripts/lint/workflow-shell-snippet-lint.py --base-ref origin/develop`
- `bash -n scripts/development-workflow/post-merge-cleanup.sh scripts/development-workflow/tests/test-post-merge-cleanup.sh`
- `git diff --check`

Closes #1626

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to development-workflow post-merge cleanup and its tests; no auth, data, or production runtime paths, with a single re-entry guard to limit recursion risk.
> 
> **Overview**
> Fixes post-merge cleanup failing with Git’s “branch already used by worktree” error when you run it from a merged PR’s linked worktree while **develop** (or the configured base) stays checked out in the main clone.
> 
> **`post-merge-cleanup.sh`** now calls **`reenter_base_worktree_if_needed`** right before fetch/checkout. If the base branch is active in a different worktree, it **`exec`**s the same helper from that path with **`--repo-root`**, **`--base`**, **`--pr`**, and the branch to delete preserved. A **`POST_MERGE_CLEANUP_REENTERED`** guard limits re-entry to once and errors if the helper script is missing on the base worktree.
> 
> Regression tests simulate a PR worktree invocation and assert re-entry messaging, remote branch deletion, PR worktree removal, and local branch cleanup. Changelog fragment documents the fix (#1626).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7021c1dc65e9fdd206abbda1bbc5fb00984d2b6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->