### PR TITLE
fix(ci): compare against the last prior head that ran workflows

### DIFF
--- a/changelog.d/1626.fixed.post-merge-worktree-cleanup.md
+++ b/changelog.d/1626.fixed.post-merge-worktree-cleanup.md
@@ -1,3 +1,1 @@
-### Fixed
-
 - Made post-merge cleanup re-enter the existing base-branch worktree when invoked from a merged PR worktree, avoiding `git checkout develop` failures when `develop` is already checked out elsewhere.

--- a/changelog.d/1634.fixed.ci-loop-prior-head-evidence.md
+++ b/changelog.d/1634.fixed.ci-loop-prior-head-evidence.md
@@ -1,0 +1,3 @@
+- **CI-loop prior-head uses the last SHA that actually ran workflows** (#1634):
+  walk earlier PR commits instead of `.[-2]`, so a multi-commit push cannot
+  treat an empty penultimate run set as “no expectation” and fail-open green.

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -298,20 +298,32 @@ workflow_run_names_for_sha() {
 }
 
 # previous_head_check_names <repo> <pr_number> <current_head_sha>
-# Prints the previous head's workflow-run names. Exit 0 with no output means
-# "no previous head" (single-commit PR, or the same SHA); exit 1 means the
-# lookup failed and the expectation is unknown.
+# Prints workflow-run names from the latest earlier PR commit that actually
+# has workflow-run evidence. A push of two or more commits makes `.[-2]` only
+# the penultimate SHA, which often never triggered pull_request workflows;
+# comparing against that empty set would fail-open as RESULT=green.
+# Exit 0 with no output means "no earlier head with runs" (single-commit PR,
+# or none of the earlier SHAs ran workflows). Exit 1 means a lookup failed
+# and the expectation is unknown.
 previous_head_check_names() {
-  local repo="$1" pr_number="$2" current_sha="$3" prev_sha=""
-  # --slurp: with --paginate alone, `.[-2]` is evaluated per page, so a PR
-  # with more than one page of commits emits one SHA per page.
-  prev_sha="$(
+  local repo="$1" pr_number="$2" current_sha="$3" shas="" sha="" names=""
+  # GitHub returns oldest-first. Reverse so we try newest earlier SHA first.
+  # --slurp: with --paginate alone, jq runs per page and cannot reverse the
+  # full commit list.
+  shas="$(
     gh api "repos/$repo/pulls/$pr_number/commits?per_page=100" --paginate --slurp 2>/dev/null \
-      | jq -r '[.[][].sha] | .[-2] // empty'
+      | jq -r '[.[][].sha] | reverse | .[]'
   )" || return 1
-  [ -n "$prev_sha" ] || return 0
-  [ "$prev_sha" != "$current_sha" ] || return 0
-  workflow_run_names_for_sha "$repo" "$prev_sha"
+  while IFS= read -r sha; do
+    [ -n "$sha" ] || continue
+    [ "$sha" != "$current_sha" ] || continue
+    names="$(workflow_run_names_for_sha "$repo" "$sha")" || return 1
+    if [ -n "$names" ]; then
+      printf '%s\n' "$names"
+      return 0
+    fi
+  done <<< "$shas"
+  return 0
 }
 
 while :; do

--- a/scripts/development-workflow/pr-ci-loop.sh
+++ b/scripts/development-workflow/pr-ci-loop.sh
@@ -306,7 +306,7 @@ workflow_run_names_for_sha() {
 # or none of the earlier SHAs ran workflows). Exit 1 means a lookup failed
 # and the expectation is unknown.
 previous_head_check_names() {
-  local repo="$1" pr_number="$2" current_sha="$3" shas="" sha="" names=""
+  local repo="$1" pr_number="$2" current_sha="$3" shas="" sha="" workflow_names=""
   # GitHub returns oldest-first. Reverse so we try newest earlier SHA first.
   # --slurp: with --paginate alone, jq runs per page and cannot reverse the
   # full commit list.
@@ -317,9 +317,9 @@ previous_head_check_names() {
   while IFS= read -r sha; do
     [ -n "$sha" ] || continue
     [ "$sha" != "$current_sha" ] || continue
-    names="$(workflow_run_names_for_sha "$repo" "$sha")" || return 1
-    if [ -n "$names" ]; then
-      printf '%s\n' "$names"
+    workflow_names="$(workflow_run_names_for_sha "$repo" "$sha")" || return 1
+    if [ -n "$workflow_names" ]; then
+      printf '%s\n' "$workflow_names"
       return 0
     fi
   done <<< "$shas"

--- a/scripts/development-workflow/tests/test-pr-ci-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-ci-loop.sh
@@ -92,6 +92,11 @@ case "$*" in
     [ "${MOCK_RUNS_FAIL:-0}" = "1" ] && exit 1
     # Both sides of the evidence comparison hit this endpoint; distinguish
     # them by the head_sha in the query so a test can make them differ.
+    if [ -n "${MOCK_EMPTY_RUN_SHA:-}" ]; then
+      case "$*" in
+        *"head_sha=${MOCK_EMPTY_RUN_SHA}"*) emit '{"workflow_runs":[]}' ; exit 0 ;;
+      esac
+    fi
     case "$*" in
       *"head_sha=${MOCK_HEAD_SHA:-$head_default}"*) emit "${MOCK_CURRENT_RUNS:-$runs_default}" ;;
       *) emit "${MOCK_PREV_CHECKS:-$runs_default}" ;;
@@ -193,6 +198,15 @@ run_test "skip_flag_bypasses_lookup_failure" "RESULT=green" "$(grep '^RESULT=' <
 #     but no --slurp, `--jq` runs per page and emits one result per page.
 _out="$(run_ci MOCK_ROLLUP="$_success_rollup" MOCK_PREV_CHECKS="$_runs_two" MOCK_CURRENT_RUNS="$_runs_two" MOCK_PR_COMMITS="$_commits_two" MOCK_PAGINATED=1)"
 run_test "paginated_lookup_still_green" "RESULT=green" "$(grep '^RESULT=' <<<"$_out" || true)"
+
+# 4f. A multi-commit push: the penultimate SHA never ran pull_request
+#     workflows, but an earlier SHA did. Using `.[-2]` would treat the prior
+#     set as empty and fail-open green while the current head is missing a
+#     workflow. Walk back to the latest earlier SHA that has runs.
+_commits_three='[{"sha":"bbbb222000000000000"},{"sha":"cccc333000000000000"},{"sha":"aaaa111000000000000"}]'
+_out="$(run_ci MOCK_ROLLUP="$_subset_rollup" MOCK_PREV_CHECKS="$_runs_two" MOCK_CURRENT_RUNS="$_runs_one" MOCK_PR_COMMITS="$_commits_three" MOCK_EMPTY_RUN_SHA=cccc333000000000000)"
+run_test "penultimate_without_runs_still_uses_earlier_evidence" "RESULT=red" "$(grep '^RESULT=' <<<"$_out" || true)"
+run_test "penultimate_without_runs_names_missing_workflow" "MISSING_CHECKS=workflow test harnesses" "$(grep '^MISSING_CHECKS=' <<<"$_out" || true)"
 
 # 5. A genuinely failing check is still red (the gate did not displace it).
 _fail_rollup='{"statusCheckRollup":[{"__typename":"CheckRun","name":"ShellCheck","status":"COMPLETED","conclusion":"FAILURE"}]}'


### PR DESCRIPTION
## Summary
- `previous_head_check_names` now walks earlier PR commits from newest to oldest and uses the latest SHA that actually has workflow-run evidence.
- Stops a multi-commit push from treating the penultimate SHA's empty run set as “no expectation” and returning `RESULT=green` on a conflicting head.

Closes #1634

## Test plan
- [x] `bash scripts/development-workflow/tests/test-pr-ci-loop.sh` (21 passed)
- [ ] Confirm a 3-commit PR where only the oldest earlier SHA ran workflows still reports the missing current workflow as red


Made with [Cursor](https://cursor.com)