### PR TITLE
fix(review): kill the local-reviewer process group on timeout

### DIFF
--- a/changelog.d/1626.fixed.post-merge-worktree-cleanup.md
+++ b/changelog.d/1626.fixed.post-merge-worktree-cleanup.md
@@ -1,3 +1,1 @@
-### Fixed
-
 - Made post-merge cleanup re-enter the existing base-branch worktree when invoked from a merged PR worktree, avoiding `git checkout develop` failures when `develop` is already checked out elsewhere.

--- a/changelog.d/1635.fixed.reviewer-timeout-process-group.md
+++ b/changelog.d/1635.fixed.reviewer-timeout-process-group.md
@@ -1,0 +1,3 @@
+- **Local AI reviewer timeout kills the process group** (#1635): the macOS
+  fallback starts the command as a process-group leader and terminates the
+  group, so descendant model processes do not keep running after timeout.

--- a/changelog.d/1635.fixed.reviewer-timeout-process-group.md
+++ b/changelog.d/1635.fixed.reviewer-timeout-process-group.md
@@ -1,5 +1,3 @@
-### Fixed
-
 - **Local AI reviewer timeout kills the process group** (#1635): the macOS
   fallback starts the command as a process-group leader and terminates the
   group, so descendant model processes do not keep running after timeout.

--- a/changelog.d/1635.fixed.reviewer-timeout-process-group.md
+++ b/changelog.d/1635.fixed.reviewer-timeout-process-group.md
@@ -1,3 +1,5 @@
+### Fixed
+
 - **Local AI reviewer timeout kills the process group** (#1635): the macOS
   fallback starts the command as a process-group leader and terminates the
   group, so descendant model processes do not keep running after timeout.

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -96,16 +96,25 @@ run_with_timeout() {
     return $?
   fi
 
-  "$@" >"$stdout_file" 2>"$stderr_file" &
-  local child_pid=$!
+  # macOS and other hosts without GNU timeout: start a new process group so
+  # descendant reviewer processes die with the leader (Codex P2 / #1635).
+  local child_pid
+  if command -v setsid >/dev/null 2>&1; then
+    setsid "$@" >"$stdout_file" 2>"$stderr_file" &
+    child_pid=$!
+  else
+    perl -e 'setpgrp; exec @ARGV' -- "$@" >"$stdout_file" 2>"$stderr_file" &
+    child_pid=$!
+  fi
   local elapsed=0
   while kill -0 "$child_pid" 2>/dev/null && [ "$elapsed" -lt "$timeout_seconds" ]; do
     sleep 1
     elapsed=$((elapsed + 1))
   done
   if [ "$elapsed" -ge "$timeout_seconds" ]; then
-    kill "$child_pid" 2>/dev/null || true
+    kill -TERM -- "-$child_pid" 2>/dev/null || kill -TERM "$child_pid" 2>/dev/null || true
     wait "$child_pid" 2>/dev/null || true
+    kill -KILL -- "-$child_pid" 2>/dev/null || true
     return 124
   fi
   wait "$child_pid"

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -10,6 +10,7 @@ REVIEWER="$REPO_ROOT/scripts/development-workflow/local-ai-reviewer.sh"
 
 MOCK_BIN="$(mktemp -d)"
 NO_GRAPH_BIN="$(mktemp -d)"
+FALLBACK_BIN="$(mktemp -d)"
 OUTPUT_FILE="$(mktemp)"
 STDERR_FILE="$(mktemp)"
 EXIT_FILE="$(mktemp)"
@@ -19,15 +20,17 @@ VALID_REPO_ROOT="$(mktemp -d)"
 
 cleanup() {
   local status=$?
-  rm -rf "$MOCK_BIN" "$NO_GRAPH_BIN" "$VALID_REPO_ROOT"
+  rm -rf "$MOCK_BIN" "$NO_GRAPH_BIN" "$FALLBACK_BIN" "$VALID_REPO_ROOT"
   rm -f "$OUTPUT_FILE" "$STDERR_FILE" "$EXIT_FILE" "$EVIDENCE_FILE" "$RELATIVE_EVIDENCE_FILE"
   exit "$status"
 }
 trap cleanup EXIT
 
-for _cmd in awk bash cat dirname git grep jq mktemp rm sh sleep tr; do
+for _cmd in awk bash cat dirname git grep jq mktemp perl rm sh sleep tr; do
   _cmd_path="$(command -v "$_cmd")"
+  [ -n "$_cmd_path" ] || continue
   ln -sf "$_cmd_path" "$NO_GRAPH_BIN/$_cmd"
+  ln -sf "$_cmd_path" "$FALLBACK_BIN/$_cmd"
 done
 unset _cmd _cmd_path
 
@@ -78,6 +81,11 @@ MOCK_GH
 install_local_reviewer_mock() {
   cat > "$MOCK_BIN/local-reviewer-mock" <<'MOCK_REVIEWER'
 #!/usr/bin/env bash
+if [ -n "${MOCK_LOCAL_REVIEWER_GRANDCHILD_PIDFILE:-}" ]; then
+  sleep 30 &
+  printf '%s\n' "$!" > "$MOCK_LOCAL_REVIEWER_GRANDCHILD_PIDFILE"
+  wait
+fi
 if [ -n "${MOCK_LOCAL_REVIEWER_SLEEP:-}" ]; then
   sleep "$MOCK_LOCAL_REVIEWER_SLEEP"
 fi
@@ -98,6 +106,7 @@ reset_mocks() {
   install_local_reviewer_mock
   unset MOCK_PR_HEAD_SHA MOCK_PR_DIFF_EXIT MOCK_LOCAL_REVIEWER_STDOUT MOCK_LOCAL_REVIEWER_STDERR
   unset MOCK_LOCAL_REVIEWER_EXIT MOCK_LOCAL_REVIEWER_SLEEP
+  unset MOCK_LOCAL_REVIEWER_GRANDCHILD_PIDFILE
   unset LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_DISABLED LOCAL_AI_REVIEWER_TIMEOUT
   unset LOCAL_AI_REVIEWER_EVIDENCE_FILE LOCAL_AI_REVIEWER_GRAPH_STRATEGY
 }
@@ -288,6 +297,27 @@ export LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_TIMEOUT MOCK_LOCAL_REVIEWER_S
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "timeout_result" "RESULT=escalate" "$(line_for RESULT)"
 run_test "timeout_reason" "REASON=timeout" "$(line_for REASON)"
+
+reset_mocks
+LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock
+LOCAL_AI_REVIEWER_TIMEOUT=1
+MOCK_LOCAL_REVIEWER_GRANDCHILD_PIDFILE="$(mktemp)"
+export LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_TIMEOUT MOCK_LOCAL_REVIEWER_GRANDCHILD_PIDFILE
+run_reviewer "$MOCK_BIN:$FALLBACK_BIN"
+run_test "fallback_timeout_result" "RESULT=escalate" "$(line_for RESULT)"
+run_test "fallback_timeout_reason" "REASON=timeout" "$(line_for REASON)"
+_grandchild_pid=""
+if [ -s "$MOCK_LOCAL_REVIEWER_GRANDCHILD_PIDFILE" ]; then
+  _grandchild_pid="$(cat "$MOCK_LOCAL_REVIEWER_GRANDCHILD_PIDFILE")"
+fi
+_grandchild_alive=0
+if [ -n "$_grandchild_pid" ] && kill -0 "$_grandchild_pid" 2>/dev/null; then
+  _grandchild_alive=1
+  kill -KILL "$_grandchild_pid" 2>/dev/null || true
+fi
+run_test "fallback_timeout_kills_grandchild" "0" "$_grandchild_alive"
+rm -f "$MOCK_LOCAL_REVIEWER_GRANDCHILD_PIDFILE"
+unset MOCK_LOCAL_REVIEWER_GRANDCHILD_PIDFILE _grandchild_pid _grandchild_alive
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock


### PR DESCRIPTION
## Summary
- `run_with_timeout` fallback (hosts without GNU `timeout`) now starts the command as a process-group leader (`setsid` or `setpgrp`) and terminates the group.
- Adds a regression test that a grandchild `sleep` does not survive the fallback timeout.

Closes #1635

## Test plan
- [x] `bash scripts/development-workflow/tests/test-local-ai-reviewer.sh` (45 passed)
- [ ] On macOS without GNU `timeout`, confirm a hung reviewer wrapper does not leave model processes running


Made with [Cursor](https://cursor.com)