### PR TITLE
fix(review): default local-ai-reviewer to bundled Codex preset

### DIFF
--- a/.ai-dev-workflow.yaml
+++ b/.ai-dev-workflow.yaml
@@ -121,9 +121,13 @@ review:
   #
   # Local AI reviewer platform options (local-only CLI reviewer; enabled first
   # in on_draft.github by default before PR-Agent and ready-phase reviewers):
-  #   LOCAL_AI_REVIEWER_COMMAND        — command run under sh -c with
-  #                                      CONTEXT_BUNDLE_PATH and PR metadata env
-  #   LOCAL_AI_REVIEWER_TIMEOUT        — default local command timeout
+  #   LOCAL_AI_REVIEWER_COMMAND        — optional override; when unset,
+  #                                      local-ai-reviewer.sh defaults to
+  #                                      scripts/development-workflow/local-codex-review-command.sh
+  #   LOCAL_AI_REVIEWER_DISABLE_DEFAULT=1 — do not apply the bundled Codex preset
+  #   LOCAL_CODEX_REVIEWER_BIN         — Codex binary for the bundled preset (default: codex)
+  #   LOCAL_CODEX_REVIEWER_MODEL       — optional model for the bundled preset
+  #   LOCAL_AI_REVIEWER_TIMEOUT        — default local command timeout (default: 300)
   #   LOCAL_AI_REVIEWER_GRAPH_STRATEGY — none|auto|code-review-graph|graphify
   #   LOCAL_AI_REVIEWER_DISABLED=1     — intentionally skip with
   #                                      REASON=disabled_by_config

--- a/changelog.d/1640.changed.local-ai-reviewer-codex-default.md
+++ b/changelog.d/1640.changed.local-ai-reviewer-codex-default.md
@@ -1,0 +1,3 @@
+- **Local AI reviewer Codex default** (#1640): when `LOCAL_AI_REVIEWER_COMMAND`
+  is unset, `local-ai-reviewer.sh` now defaults to the bundled Codex preset so
+  Step 7 loops run local review instead of escalating with `missing_command`.

--- a/docs/testing/workflow/1604-repo-native-automated-pr-reviewer.smoke-test.md
+++ b/docs/testing/workflow/1604-repo-native-automated-pr-reviewer.smoke-test.md
@@ -60,7 +60,7 @@ bash scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-di
 
 **Maps to**: Failure-state classification
 
-1. Unset `LOCAL_AI_REVIEWER_COMMAND`.
+1. Unset `LOCAL_AI_REVIEWER_COMMAND` and set `LOCAL_AI_REVIEWER_DISABLE_DEFAULT=1`.
 2. Run the companion script or reviewer loop.
 3. Confirm output includes `RESULT=escalate` and `REASON=missing_command`.
 

--- a/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
+++ b/docs/workflow/development-workflow/integrations/local-ai-reviewer.md
@@ -27,17 +27,30 @@ review:
       - bugbot
 ```
 
-Set the local command in the runner environment:
+Set the local command in the runner environment when you need a custom command.
+When `LOCAL_AI_REVIEWER_COMMAND` is unset, `local-ai-reviewer.sh` defaults to
+the bundled Codex preset at
+`scripts/development-workflow/local-codex-review-command.sh` (requires the
+`codex` CLI on `PATH` and a working Codex login). Set
+`LOCAL_AI_REVIEWER_DISABLE_DEFAULT=1` to restore the old missing-command
+behavior for tests or minimal environments.
 
 <!-- workflow-shell-contract: bash-zsh -->
 ```bash
+# Optional overrides (the bundled preset is used when LOCAL_AI_REVIEWER_COMMAND is unset):
+export LOCAL_CODEX_REVIEWER_BIN='codex'
+export LOCAL_CODEX_REVIEWER_MODEL='gpt-5.4'   # optional; codex uses its own default when omitted
+export LOCAL_AI_REVIEWER_TIMEOUT='900'
+
+# Custom command instead of the bundled Codex preset:
 export LOCAL_AI_REVIEWER_COMMAND='my-review-command "$CONTEXT_BUNDLE_PATH"'
 ```
 
-A missing local command is a setup failure and emits `RESULT=escalate` with
-`REASON=missing_command`. To intentionally skip the default local reviewer for
-one run or one checkout, set `LOCAL_AI_REVIEWER_DISABLED=1` or override
-`review.on_draft.github` in `.ai-dev-workflow.local.yaml`.
+A missing local command **after** default resolution is a setup failure and
+emits `RESULT=escalate` with `REASON=missing_command`. To intentionally skip
+the default local reviewer for one run or one checkout, set
+`LOCAL_AI_REVIEWER_DISABLED=1` or override `review.on_draft.github` in
+`.ai-dev-workflow.local.yaml`.
 
 For Codex, use the bundled preset wrapper instead of hand-writing the full
 `codex exec` command:

--- a/docs/workflow/development-workflow/integrations/pr-review-platform.md
+++ b/docs/workflow/development-workflow/integrations/pr-review-platform.md
@@ -81,10 +81,13 @@ schema_version: 2
 review:
   on_draft:
     github:
-      # local-ai-reviewer: local-only CLI reviewer. Requires
-      # LOCAL_AI_REVIEWER_COMMAND in the runner environment. Missing command,
-      # credentials, model access, timeout, or malformed output escalates.
-      # Set LOCAL_AI_REVIEWER_DISABLED=1 or override this list locally to skip.
+      # local-ai-reviewer: local-only CLI reviewer. When
+      # LOCAL_AI_REVIEWER_COMMAND is unset, local-ai-reviewer.sh defaults to
+      # scripts/development-workflow/local-codex-review-command.sh (Codex CLI).
+      # Missing codex binary, credentials, model access, timeout, or malformed
+      # output escalates. Set LOCAL_AI_REVIEWER_DISABLE_DEFAULT=1 to require an
+      # explicit LOCAL_AI_REVIEWER_COMMAND. Set LOCAL_AI_REVIEWER_DISABLED=1
+      # or override this list locally to skip.
       - local-ai-reviewer
       - pr-agent
     # claude-code-action: own-key, own-CI reviewer with no per-hour vendor cap.

--- a/scripts/development-workflow/local-ai-reviewer.sh
+++ b/scripts/development-workflow/local-ai-reviewer.sh
@@ -21,14 +21,36 @@ Options:
                        match the pull request head SHA before review runs.
 
 Environment:
-  LOCAL_AI_REVIEWER_COMMAND         Required unless LOCAL_AI_REVIEWER_DISABLED=1.
+  LOCAL_AI_REVIEWER_COMMAND         Optional. When unset, defaults to the bundled
+                                    Codex preset at local-codex-review-command.sh
+                                    unless LOCAL_AI_REVIEWER_DISABLE_DEFAULT=1.
                                     The command receives CONTEXT_BUNDLE_PATH,
                                     PR_NUMBER, OWNER, REPO, BASE_BRANCH,
                                     HEAD_BRANCH, and REVIEWED_HEAD in env.
+  LOCAL_AI_REVIEWER_DISABLE_DEFAULT=1
+                                    Do not apply the bundled Codex preset default.
   LOCAL_AI_REVIEWER_DISABLED=1      Emit RESULT=skipped / disabled_by_config.
   LOCAL_AI_REVIEWER_EVIDENCE_FILE   Optional path for a JSON evidence artifact.
   LOCAL_AI_REVIEWER_GRAPH_STRATEGY  none|auto|code-review-graph|graphify.
+  LOCAL_CODEX_REVIEWER_BIN          Codex binary for the bundled preset (default: codex).
+  LOCAL_CODEX_REVIEWER_MODEL        Optional model for the bundled preset.
 EOF
+}
+
+resolve_local_ai_reviewer_command() {
+  if [ -n "${LOCAL_AI_REVIEWER_COMMAND:-}" ]; then
+    return 0
+  fi
+  if [ "${LOCAL_AI_REVIEWER_DISABLE_DEFAULT:-0}" = "1" ]; then
+    return 0
+  fi
+
+  local default_command="$SCRIPT_DIR/local-codex-review-command.sh"
+  if [ -f "$default_command" ]; then
+    LOCAL_AI_REVIEWER_COMMAND="$default_command"
+    export LOCAL_AI_REVIEWER_COMMAND
+    echo "INFO: LOCAL_AI_REVIEWER_COMMAND defaulted to bundled Codex preset: $default_command" >&2
+  fi
 }
 
 print_result() {
@@ -190,6 +212,8 @@ if [ "${LOCAL_AI_REVIEWER_DISABLED:-0}" = "1" ]; then
   print_result skipped 0 0 0 disabled_by_config disabled_by_config
   exit 3
 fi
+
+resolve_local_ai_reviewer_command
 
 if [ -z "${LOCAL_AI_REVIEWER_COMMAND:-}" ]; then
   echo "ERROR: LOCAL_AI_REVIEWER_COMMAND is not configured" >&2

--- a/scripts/development-workflow/tests/test-local-ai-reviewer.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer.sh
@@ -109,6 +109,7 @@ reset_mocks() {
   unset MOCK_LOCAL_REVIEWER_GRANDCHILD_PIDFILE
   unset LOCAL_AI_REVIEWER_COMMAND LOCAL_AI_REVIEWER_DISABLED LOCAL_AI_REVIEWER_TIMEOUT
   unset LOCAL_AI_REVIEWER_EVIDENCE_FILE LOCAL_AI_REVIEWER_GRAPH_STRATEGY
+  unset LOCAL_AI_REVIEWER_DISABLE_DEFAULT
 }
 
 set_mock_stdout() {
@@ -155,10 +156,31 @@ run_test "disabled_reason" "REASON=disabled_by_config" "$(line_for REASON)"
 run_test "disabled_exit" "3" "$(exit_code)"
 
 reset_mocks
+LOCAL_AI_REVIEWER_DISABLE_DEFAULT=1
+export LOCAL_AI_REVIEWER_DISABLE_DEFAULT
 run_reviewer "$MOCK_BIN:$PATH"
 run_test "missing_command_result" "RESULT=escalate" "$(line_for RESULT)"
 run_test "missing_command_reason" "REASON=missing_command" "$(line_for REASON)"
 run_test "missing_command_exit" "2" "$(exit_code)"
+
+reset_mocks
+cat > "$MOCK_BIN/codex" <<'MOCK_CODEX'
+#!/usr/bin/env bash
+output_file=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "-o" ]; then
+    output_file="$arg"
+  fi
+  previous="$arg"
+done
+[ -n "$output_file" ] || exit 2
+printf '{"result":"clean","reviewed_head":"%s","findings":[]}\n' "${REVIEWED_HEAD:?}" > "$output_file"
+MOCK_CODEX
+chmod +x "$MOCK_BIN/codex"
+run_reviewer "$MOCK_BIN:$PATH"
+run_test "default_command_result" "RESULT=clean" "$(line_for RESULT)"
+run_test "default_command_info" "yes" "$(grep -q 'LOCAL_AI_REVIEWER_COMMAND defaulted to bundled Codex preset' "$STDERR_FILE" && echo yes || echo no)"
 
 reset_mocks
 LOCAL_AI_REVIEWER_COMMAND=local-reviewer-mock


### PR DESCRIPTION
## Summary

- Default `LOCAL_AI_REVIEWER_COMMAND` to `scripts/development-workflow/local-codex-review-command.sh` when unset, so Step 7 reviewer loops run the bundled Codex preset instead of escalating with `missing_command`.
- Add `LOCAL_AI_REVIEWER_DISABLE_DEFAULT=1` escape hatch for tests and minimal environments.
- Update integration docs, `.ai-dev-workflow.yaml` comments, smoke runbook, and unit tests.

## Test plan

- [x] `bash scripts/development-workflow/tests/test-local-ai-reviewer.sh`
- [x] `bash scripts/development-workflow/tests/test-local-codex-review-command.sh`
- [ ] Reviewer loop on this PR (Codex local reviewer + PR-Agent + Bugbot)

Closes #1640

Made with [Cursor](https://cursor.com)