### PR TITLE
docs(plan): run expensive reviewers only after local clean evidence

### DIFF
--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -20,9 +20,11 @@ never review threads, never baseline CI, and it has no notion of a stale local
 clean result. This plan adds a dedicated pre-dispatch gate for `codex-github`
 that requires four current-head conditions — local reviewer clean and current,
 PR-Agent clean, zero unresolved review threads, and green non-reviewer baseline
-checks — evaluated immediately before the platform is dispatched, fail-closed
-when any input is missing or stale, with one explicit documented override for
-manual escalation.
+checks — evaluated immediately before the platform is dispatched, fail-closed when any input is
+missing or stale, with one explicit documented override for manual escalation.
+A gate that holds the reviewer back **defers** rather than skipping: it sets the
+loop's aggregate to `needs_fixes` so readiness is withheld and Step 7 re-runs,
+which is what makes the deferral guaranteed rather than merely hoped for.
 
 **Estimated complexity**: L
 
@@ -107,22 +109,63 @@ Not applicable — this repository ships workflow tooling, not a service.
 - [ ] Add `is_expensive_reviewer_platform <platform>` using the existing
       `array_contains_value` helper, mirroring `is_phase_after_clean_platform`.
 - [ ] Add `expensive_reviewer_gate <pr_number> <platform> <head_sha>` returning
-      `0` to dispatch and `1` to hold back, and printing one
-      `EXPENSIVE_GATE_*` key=value block. It evaluates four conditions against
+      `0` to dispatch and `1` to defer, and printing one `EXPENSIVE_GATE_*`
+      key=value block. It evaluates the conditions below against
       `loop_head_sha` (the pre-dispatch snapshot #1648 makes authoritative) and
       **stops at the first unmet one**, so the reported reason names a single
-      cause:
+      cause.
 
       | # | Condition | Unmet reason |
       | --- | --- | --- |
-      | 1 | `LOCAL_AI_CONFIGURED` is `1` and `LOCAL_AI_HEAD_CURRENT` is `1` | `local_evidence_stale` when `LOCAL_AI_HEAD_CURRENT` is `0`; `local_evidence_missing` when it is empty or `LOCAL_AI_CONFIGURED` is unset; `local_reviewer_not_configured` when `LOCAL_AI_CONFIGURED` is `0` |
-      | 2 | Every non-expensive platform already run in this invocation returned `clean` or `skipped` | `peer_reviewer_not_clean` |
-      | 3 | Zero unresolved, non-outdated review threads at `loop_head_sha` | `unresolved_threads` |
-      | 4 | Every non-reviewer check on `loop_head_sha` is `SUCCESS`, `SKIPPED`, or `NEUTRAL` | `baseline_checks_not_green` when one failed; `baseline_checks_pending` when one is still running |
+      | 0 | `LOCAL_AI_CONFIGURED` is `0` | *not a defer* — dispatch with `EXPENSIVE_GATE_DISPATCH_REASON=no_local_prefilter` (see below) |
+      | 1 | `LOCAL_AI_CONFIGURED` is `1` and `LOCAL_AI_HEAD_CURRENT` is `1` | `local_evidence_stale` when `LOCAL_AI_HEAD_CURRENT` is `0`; `local_evidence_missing` when it is empty or `LOCAL_AI_CONFIGURED` is unset |
+      | 2 | **Every** non-expensive platform in the resolved platform list has already run in this invocation **and** returned `clean` or `skipped` | `peer_reviewer_not_run` when one has not run yet; `peer_reviewer_not_clean` when one ran and did not return clean or skipped |
+      | 3 | Zero unresolved, non-outdated review threads | `unresolved_threads` |
+      | 4 | Every non-reviewer check is `SUCCESS`, `SKIPPED`, or `NEUTRAL` | `baseline_checks_not_green` when one failed; `baseline_checks_pending` when one is still running |
 
+- [ ] **Condition 2 must not depend on platform ordering.** Checking only the
+      platforms encountered so far would let a configuration that lists
+      `codex-github` before `pr-agent` dispatch the expensive reviewer while the
+      cheap one has not run at all — the exact inversion this item exists to
+      prevent. The gate therefore compares against the **full resolved platform
+      list** (`platforms[@]` minus the expensive ones), not against the
+      per-invocation results collected up to this index, and defers with
+      `peer_reviewer_not_run` when any of them has no recorded result yet. That
+      makes the gate correct under any ordering and removes the need for a
+      separate ordering rule elsewhere.
+- [ ] **Bind conditions 3 and 4 to the same head as the reviewer evidence.**
+      Both queries must return the live head alongside their payload, and the
+      gate must compare it to `loop_head_sha`. If they differ, the PR moved
+      while the loop ran: the thread and check evidence describes a newer commit
+      than the reviewer verdicts, and combining them would authorize dispatch on
+      inconsistent evidence. Defer with `evidence_head_moved`. This mirrors the
+      head-move guard the loop already applies to its own clean verdict, and
+      reuses the same `loop_head_sha` snapshot rather than introducing a second
+      notion of "current".
+- [ ] **A defer is not a clean skip.** Recording a deferred expensive reviewer
+      as `skipped` while leaving the aggregate result unchanged would let
+      Protocol 92's readiness conditions accept the run — `Result: clean` or
+      `Result: skipped` both satisfy them — so a PR could reach
+      `ready-for-human-review` having never run the reviewer, and nothing would
+      guarantee the "next invocation" this gate relies on. Instead, when the
+      gate defers, the loop sets its aggregate to `needs_fixes` with
+      `REASON=expensive_gate_deferred`. That is the loop's existing mechanism
+      for "not finished yet": Protocol 91 re-runs Step 7 on a non-clean result,
+      the readiness label is withheld, and the deferral is therefore guaranteed
+      to be retried rather than merely hoped for. The dual cycle caps already
+      bound how many retries happen, so this adds no unbounded loop.
+- [ ] **A repository with no local reviewer dispatches rather than defers.**
+      When `LOCAL_AI_CONFIGURED` is `0` the platform is not in the resolved
+      list, there is no cheap pre-filter to wait for, and deferring would hold
+      the expensive reviewer forever in every downstream consumer that does not
+      configure `local-ai-reviewer`. The gate dispatches, recording
+      `EXPENSIVE_GATE_RESULT=dispatched` with
+      `EXPENSIVE_GATE_DISPATCH_REASON=no_local_prefilter` so the reduced
+      gating is visible rather than silent. Conditions 2 to 4 still apply — a
+      missing local reviewer relaxes condition 1 only.
 - [ ] **Fail closed on every unknown.** If any input cannot be read, the gate
-      holds the platform back with one of exactly three reasons — there is no
-      generic unknown state:
+      defers with one of exactly three reasons — there is no generic unknown
+      state:
 
       | Unreadable input | Reason |
       | --- | --- |
@@ -130,11 +173,9 @@ Not applicable — this repository ships workflow tooling, not a service.
       | The review-threads query failed | `evidence_unavailable_review_threads` |
       | The check-rollup query failed | `evidence_unavailable_checks` |
 
-      Holding back is cheap — the expensive reviewer runs on the next
-      invocation — while dispatching on unknown evidence is the waste this item
-      exists to remove. The gate never fails the loop: it returns `1`, and the
-      loop records the platform as skipped rather than as a blocking verdict, so
-      the aggregate result is unchanged.
+      Deferring is cheap — the expensive reviewer runs on the retry the
+      `needs_fixes` aggregate forces — while dispatching on unknown evidence is
+      the waste this item exists to remove.
 - [ ] Call the gate from the per-platform block, immediately before
       `run_platform_review`, only when `is_expensive_reviewer_platform` matches.
       It composes with the existing phase mechanism rather than replacing it: a
@@ -146,21 +187,26 @@ Not applicable — this repository ships workflow tooling, not a service.
       evaluates and still emits its full `EXPENSIVE_GATE_*` block, then reports
       `EXPENSIVE_GATE_RESULT=forced` with the reason it would otherwise have
       given, and dispatches. The override never hides why the gate would have
-      held back — a forced run that later wastes reviewer cycles must be
-      traceable to the condition that was overridden.
+      deferred — a forced run that later wastes reviewer cycles must be
+      traceable to the condition that was overridden. A forced run does not set
+      the `needs_fixes` aggregate: the human took the decision explicitly.
 - [ ] Emit gate telemetry on the loop's stdout contract, per expensive platform:
       `EXPENSIVE_GATE_PLATFORM`, `EXPENSIVE_GATE_RESULT`
-      (`dispatched` | `held` | `forced`), `EXPENSIVE_GATE_REASON` (empty when
-      `dispatched`), and `EXPENSIVE_GATE_HEAD` (the `loop_head_sha` the gate
-      evaluated). All values stay inside the `[A-Za-z0-9:_-]` token charset the
+      (`dispatched` | `deferred` | `forced`), `EXPENSIVE_GATE_REASON` (the
+      unmet-condition reason; empty on an unconditional dispatch),
+      `EXPENSIVE_GATE_DISPATCH_REASON` (`no_local_prefilter`, or empty), and
+      `EXPENSIVE_GATE_HEAD` (the `loop_head_sha` the gate evaluated). All values stay inside the `[A-Za-z0-9:_-]` token charset the
       Protocol 91 carry-forward snippet admits.
 - [ ] Record the gate outcome in the reviewer-loop summary comment as an
       `**Expensive reviewer gate:**` line, and in the `reviewer_loop_history.v1`
       entry as an `expensive_gate` object (`platform`, `result`, `reason`,
-      `head`). Both are additive; readers dereference with defaults, so the
-      schema stays `v1`, consistent with #1648's treatment of `reviewed_heads`.
-- [ ] Document the gate, its four conditions, its fail-closed rule, and the
-      override variable in the `--help` usage block.
+      `head`, `dispatch_reason`). Both are additive; readers dereference with
+      defaults, so the schema stays `v1`, consistent with #1648's treatment of
+      `reviewed_heads`.
+- [ ] Document the gate in the `--help` usage block: its conditions and their
+      evaluation order, its fail-closed rule, the `deferred` aggregate
+      behavior, the `no_local_prefilter` dispatch path, and the override
+      variable.
 
 ### Frontend / UI
 
@@ -177,12 +223,16 @@ Not applicable — no user interface in this repository.
 ### Documentation
 
 - [ ] `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
-      — document the gate: the four conditions, the fail-closed rule, the
-      `held` outcome being a skip rather than a blocking verdict, and the
-      override variable with the expectation that its use is justified in the PR.
+      — document the gate: the conditions and their evaluation order, the
+      order-independence of condition 2, the head binding of conditions 3 and 4,
+      the fail-closed rule, the fact that a `deferred` outcome sets the
+      aggregate to `needs_fixes` (so readiness is withheld and Step 7 re-runs)
+      rather than passing as a clean skip, the `no_local_prefilter` dispatch
+      path, and the override variable with the expectation that its use is
+      justified in the PR.
 - [ ] `docs/workflow/development-workflow/integrations/codex-github.md` — add a
       section describing the gate so a reader configuring the reviewer learns
-      when it will actually run, when it will be held back, and how to override.
+      when it will actually run, when it will be deferred, and how to override.
       The file exists (confirmed in the Verification Log); no new file is
       created.
 
@@ -197,53 +247,65 @@ Not applicable — no user interface in this repository.
 1. `is_expensive_reviewer_platform` matches `codex-github` and rejects
    `local-ai-reviewer`, `pr-agent`, and `bugbot` — the gate must not
    accidentally hold back a cheap reviewer.
-2. All four conditions met → `EXPENSIVE_GATE_RESULT=dispatched`,
+2. All conditions met → `EXPENSIVE_GATE_RESULT=dispatched`,
    `EXPENSIVE_GATE_REASON` empty, and `run_platform_review` is called.
-3. `LOCAL_AI_HEAD_CURRENT=0` → `held` / `local_evidence_stale`, and
-   `run_platform_review` is **not** called — the core of brief scope bullet 1.
-4. `LOCAL_AI_CONFIGURED` unset → `held` / `local_evidence_missing`. This is the
-   fail-closed case for brief scope bullet 2 and pairs with #1648's rule that an
+3. `LOCAL_AI_HEAD_CURRENT=0` → `deferred` / `local_evidence_stale`,
+   `run_platform_review` is **not** called, and the loop's aggregate becomes
+   `needs_fixes` / `expensive_gate_deferred` — the core of brief scope bullet 1,
+   and the proof that a defer withholds readiness instead of passing as a skip.
+4. `LOCAL_AI_CONFIGURED` unset → `deferred` / `local_evidence_missing`. The
+   fail-closed case for brief scope bullet 2, pairing with #1648's rule that an
    absent key is telemetry loss rather than non-applicability.
-5. `LOCAL_AI_CONFIGURED=0` → `held` / `local_reviewer_not_configured`. Distinct
-   from scenario 4: the loop is correctly configured, there is simply no local
-   evidence to gate on, and dispatching an expensive reviewer with no cheap
-   pre-filter is exactly what this item prevents.
-6. A peer reviewer returned `needs_fixes` earlier in the same invocation →
-   `held` / `peer_reviewer_not_clean`.
-7. One unresolved non-outdated review thread → `held` / `unresolved_threads`;
-   the same thread marked outdated → `dispatched`.
-8. A failing baseline check → `held` / `baseline_checks_not_green`; a pending
-   one → `held` / `baseline_checks_pending`; a reviewer-owned check that is
-   pending → `dispatched`, because a reviewer's own check must not gate the
-   reviewer.
-9. Each unreadable input in turn → `held` with its specific reason —
-   `evidence_unavailable_head` for an empty `loop_head_sha`,
-   `evidence_unavailable_review_threads` for a failed threads query,
-   `evidence_unavailable_checks` for a failed check rollup — and the loop's
-   aggregate result is unchanged in all three. The gate skips; it does not
-   escalate.
-10. `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS=1` with condition 1 unmet →
+5. `LOCAL_AI_CONFIGURED=0` → `dispatched` with
+   `EXPENSIVE_GATE_DISPATCH_REASON=no_local_prefilter`, and conditions 2 to 4
+   still evaluated. Distinct from scenario 4: the loop is correctly configured
+   and there is simply no local reviewer to wait for, so deferring would hold
+   the expensive reviewer forever in every consumer that does not configure one.
+6. Condition 2 is order-independent: with `codex-github` listed **before**
+   `pr-agent` in the resolved platform list, the gate → `deferred` /
+   `peer_reviewer_not_run`; with `pr-agent` already run and `clean`, →
+   `dispatched`. The first case is the regression test for a configuration that
+   would otherwise dispatch the expensive reviewer before the cheap one ran.
+7. A peer reviewer that ran and returned `needs_fixes` → `deferred` /
+   `peer_reviewer_not_clean` — distinct from scenario 6's `peer_reviewer_not_run`.
+8. One unresolved non-outdated review thread → `deferred` /
+   `unresolved_threads`; the same thread marked outdated → `dispatched`.
+9. A failing baseline check → `deferred` / `baseline_checks_not_green`; a
+   pending one → `deferred` / `baseline_checks_pending`; a reviewer-owned check
+   that is pending → `dispatched`, because a reviewer's own check must not gate
+   the reviewer.
+10. The threads or checks query returns a live head different from
+    `loop_head_sha` → `deferred` / `evidence_head_moved`. Without this, evidence
+    from a newer commit could authorize dispatch against reviewer verdicts taken
+    on an older one.
+11. Each unreadable input in turn → `deferred` with its specific reason —
+    `evidence_unavailable_head` for an empty `loop_head_sha`,
+    `evidence_unavailable_review_threads` for a failed threads query,
+    `evidence_unavailable_checks` for a failed check rollup.
+12. `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS=1` with condition 1 unmet →
     `EXPENSIVE_GATE_RESULT=forced`, `EXPENSIVE_GATE_REASON=local_evidence_stale`
-    preserved, and `run_platform_review` **is** called — the override path of
-    brief scope bullet 3, proving the reason survives the override.
-11. Composition with the phase mechanism: a platform that is both a phase
+    preserved, `run_platform_review` **is** called, and the aggregate is **not**
+    set to `needs_fixes` — the override path of brief scope bullet 3, proving
+    both that the reason survives and that an explicit human decision is not
+    re-blocked.
+13. Composition with the phase mechanism: a platform that is both a phase
     platform and an expensive reviewer runs `ensure_pr_ready_for_ready_phase`
-    first and the gate second; when the gate holds, the PR has still been
-    converted to ready and the loop does not treat the hold as a phase failure.
-12. Composition with `--pre-after-clean-only`: an expensive reviewer that is
+    first and the gate second; when the gate defers, the PR has still been
+    converted to ready and the defer is not reported as a phase failure.
+14. Composition with `--pre-after-clean-only`: an expensive reviewer that is
     also a phase platform is filtered out before the gate is consulted, and the
-    gate emits no telemetry for it — no phantom `held` record for a platform
+    gate emits no telemetry for it — no phantom `deferred` record for a platform
     that was never in scope.
-13. A ledger entry written without `expensive_gate` still parses through
+15. A ledger entry written without `expensive_gate` still parses through
     `reviewer_loop_history_payload_from_existing` — `v1` backward compatibility,
     same contract as #1648's added fields.
 
 **Files**:
 
-- `scripts/development-workflow/tests/test-pr-review-loop.sh` — scenarios 1–9
-  and 13, as new cases in the existing `HARNESS_MODE=1` harness.
+- `scripts/development-workflow/tests/test-pr-review-loop.sh` — scenarios 1–11
+  and 15, as new cases in the existing `HARNESS_MODE=1` harness.
 - `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` — a new
-  suite for scenarios 10–12, the composition and override cases, which need
+  suite for scenarios 12–14, the override and composition cases, which need
   their own mock scaffolding for the phase and filter paths. It must declare:
 
   ```text
@@ -277,9 +339,11 @@ concrete file and line:
 | P1 | Stale local evidence: `LOCAL_AI_HEAD_CURRENT=0` with all other conditions met | the gate fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | the gate holds and `run_platform_review` is not called; setting it to `1` dispatches |
 | P2 | Missing local evidence: `LOCAL_AI_CONFIGURED` unset | same fixture | the gate holds with `local_evidence_missing`; exporting `LOCAL_AI_CONFIGURED=1` dispatches — the proof that an unknown is refused rather than assumed clean |
 | P3 | Unreadable evidence: make the review-threads query fail | same fixture | the gate holds with `evidence_unavailable_review_threads` and the loop's aggregate result is unchanged; restoring the query dispatches |
-| P4 | Gate bypass regression: remove the `is_expensive_reviewer_platform` guard so the gate is never consulted | a scratch copy of the per-platform block | scenario 3 fails because the platform is dispatched with stale evidence; restoring the guard passes — the proof that the gate is actually wired into the dispatch path and not merely defined |
+| P4 | Gate-not-wired regression: **delete the `expensive_reviewer_gate` call** from the per-platform block, leaving the function defined but unreachable | a scratch copy of the per-platform block in `scripts/development-workflow/pr-review-loop.sh` | scenario 3 fails, because `codex-github` is dispatched with stale local evidence and no `EXPENSIVE_GATE_*` telemetry is emitted; restoring the call passes. Deleting the call is the correct mutation: removing the `is_expensive_reviewer_platform` guard instead would consult the gate for *every* platform, which is a different defect and would not leave the gate unreachable |
+| P5 | Ordering regression: reorder the resolved platform list so `codex-github` precedes `pr-agent`, with condition 2 narrowed to platforms already encountered | the condition-2 fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | scenario 6 fails because the gate dispatches before `pr-agent` ran; restoring the full-list comparison defers with `peer_reviewer_not_run` |
+| P6 | Readiness regression: make a defer leave the aggregate result unchanged instead of setting `needs_fixes` | a scratch copy of the gate call site | scenario 3's aggregate assertion fails, and a run in which `codex-github` never executed would satisfy Protocol 92's readiness conditions; restoring the `needs_fixes` aggregate passes |
 
-Record all four in the implementation PR under a `Planted-Violation Proofs`
+Record all six in the implementation PR under a `Planted-Violation Proofs`
 heading, each with the command, the file and line of the planted violation, and
 both outcomes.
 
@@ -305,10 +369,10 @@ by the same sequential block that already writes `platform_result_tokens`.
 
 | Entity | Values / Scenario | File |
 | --- | --- | --- |
-| Gate condition fixture | A table-driven set of the four conditions with each one independently unmet, driving scenarios 2–8 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
-| Unreadable-input mocks | Mock `gh` commands that exit non-zero for the threads query and for the check rollup, driving scenario 9 and proof P3 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
-| Composition fixture | A platform list where `codex-github` is both a phase platform and an expensive reviewer, driving scenarios 11 and 12 | inline in `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` |
-| Legacy ledger payload | A `reviewer_loop_history.v1` entry with no `expensive_gate` object, driving scenario 13 | inline heredoc in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Gate condition fixture | A table-driven set of the conditions with each one independently unmet, plus a reordered platform list for the order-independence case, driving scenarios 2–10 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Unreadable-input mocks | Mock `gh` commands that exit non-zero for the threads query and for the check rollup, driving scenario 11 and proof P3 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Composition fixture | A platform list where `codex-github` is both a phase platform and an expensive reviewer, driving scenarios 13 and 14 | inline in `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` |
+| Legacy ledger payload | A `reviewer_loop_history.v1` entry with no `expensive_gate` object, driving scenario 15 | inline heredoc in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 
 No repository fixture files are added; both suites build their fixtures inline
 with mock `gh` commands and require no network access.
@@ -318,11 +382,13 @@ with mock `gh` commands and require no network access.
 ## Documentation Updates
 
 - [ ] `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
-      — document the gate, its four conditions, the fail-closed rule, the `held`
-      outcome being a skip rather than a blocking verdict, and the override
-      variable.
+      — document the gate: its conditions and evaluation order, the
+      order-independence of condition 2, the head binding of conditions 3 and 4,
+      the fail-closed rule, the `deferred` outcome setting the aggregate to
+      `needs_fixes` so readiness is withheld and Step 7 re-runs, the
+      `no_local_prefilter` dispatch path, and the override variable.
 - [ ] `docs/workflow/development-workflow/integrations/codex-github.md` — add a
-      section describing the gate, its four conditions, and the override, so the
+      section describing the gate, its conditions, and the override, so the
       gate is discoverable from the reviewer's own integration page rather than
       only from the loop protocol.
 - [ ] `REVIEW.md` — no change. The gate decides when a reviewer runs, not what
@@ -335,12 +401,14 @@ with mock `gh` commands and require no network access.
 
 | Risk | Likelihood | Impact | Mitigation |
 | --- | --- | --- | --- |
-| The gate silently stops `codex-github` from ever running | Med | High — the expensive reviewer's findings are the reason this epic exists; losing them entirely is worse than running it too often | Every hold emits `EXPENSIVE_GATE_RESULT=held` with a single named reason in both the summary comment and the ledger, so a permanent hold is visible rather than silent; scenario 2 pins the dispatch path and P4 proves the gate is wired in rather than defined-but-unreachable |
-| The gate is defined but never consulted, leaving behavior unchanged | Med | High — the item would appear complete while changing nothing | The call site is in the per-platform block immediately before `run_platform_review`, and proof P4 removes the guard and requires scenario 3 to fail — a gate that is not wired in cannot pass its own proof |
-| Fail-closed on unreadable evidence turns a transient API blip into a permanent hold | Med | Med | A hold is per-invocation, not sticky: the next loop invocation re-evaluates, and the existing dual cycle caps bound how many invocations happen. The gate adds no retry path of its own, so it cannot loop |
-| The gate contradicts the existing phase mechanism | Med | High — two gates disagreeing on whether a platform runs is worse than either alone | Composition is specified explicitly (phase gate first, then this gate; `--pre-after-clean-only` filters before both) and pinned by scenarios 11 and 12, including the no-phantom-telemetry case |
+| The gate silently stops `codex-github` from ever running | Med | High — the expensive reviewer's findings are the reason this epic exists; losing them entirely is worse than running it too often | A defer is never terminal: it sets the aggregate to `needs_fixes` / `expensive_gate_deferred`, so readiness is withheld and Protocol 91 re-runs Step 7 rather than accepting a run in which the reviewer never executed. Every defer emits `EXPENSIVE_GATE_RESULT=deferred` with one named reason in both the summary comment and the ledger, and a repository with no local reviewer dispatches with `no_local_prefilter` instead of deferring, so no downstream consumer can be held forever. Scenario 3 pins the withheld readiness and scenario 5 the no-local-reviewer path |
+| The gate is defined but never consulted, leaving behavior unchanged | Med | High — the item would appear complete while changing nothing | The call site is in the per-platform block immediately before `run_platform_review`, and proof P4 deletes that call outright and requires scenario 3 to fail — a gate that is not wired in cannot pass its own proof |
+| Fail-closed on unreadable evidence turns a transient API blip into a permanent defer | Med | Med | A defer is per-invocation, not sticky: the `needs_fixes` aggregate makes Protocol 91 re-run Step 7, which re-evaluates from scratch, and the existing dual cycle caps bound how many invocations happen. The gate adds no retry path of its own, so it cannot loop |
+| The gate contradicts the existing phase mechanism | Med | High — two gates disagreeing on whether a platform runs is worse than either alone | Composition is specified explicitly (phase gate first, then this gate; `--pre-after-clean-only` filters before both) and pinned by scenarios 13 and 14, including the no-phantom-telemetry case |
 | Implementation starts before #1648 lands and wires the gate to keys that do not exist | Med | High — the gate would read unset variables and hold everything, or be written against a guessed contract | Recorded as a Conflict in the Cross-Cutting check and as Implementation Order step 0, which is a hard stop that verifies #1648 is merged into the approved base before any edit |
-| A reviewer's own check gates that reviewer | Low | Med — `codex-github` would wait on a check it is responsible for producing | Condition 4 evaluates non-reviewer checks only, reusing the reviewer/baseline classification `pr-ci-loop.sh` already emits rather than a new one; scenario 8's third case pins it |
+| A reviewer's own check gates that reviewer | Low | Med — `codex-github` would wait on a check it is responsible for producing | Condition 4 evaluates non-reviewer checks only, reusing the reviewer/baseline classification `pr-ci-loop.sh` already emits rather than a new one; scenario 9's third case pins it |
+| Platform ordering decides whether the gate is effective | Med | High — a config listing `codex-github` first would dispatch it before the cheap reviewers ran, silently defeating the item | Condition 2 compares against the full resolved platform list rather than the platforms encountered so far, and defers with `peer_reviewer_not_run` for any that has not run; scenario 6 pins the reordered configuration |
+| Thread and CI evidence describes a newer commit than the reviewer verdicts | Med | High — dispatch would be authorized on an inconsistent mix of two heads | Conditions 3 and 4 require the live head returned with their queries to equal `loop_head_sha`, and defer with `evidence_head_moved` otherwise; scenario 10 pins it |
 
 ---
 
@@ -354,40 +422,46 @@ is_expensive_reviewer_platform() {
   array_contains_value "$1" "${EXPENSIVE_REVIEWER_PLATFORMS[@]}"
 }
 
-# Returns 0 to dispatch, 1 to hold back. Never fails the loop.
-# Stops at the first unmet condition so the reason names one cause.
+# Returns 0 to dispatch, 1 to defer. Stops at the first unmet condition so the
+# reason names one cause. A defer is not a clean skip: the caller sets the
+# aggregate to needs_fixes / expensive_gate_deferred so readiness is withheld
+# and Protocol 91 re-runs Step 7.
 expensive_reviewer_gate() {
   local pr_number="$1"
   local platform="$2"
   local head_sha="$3"
   local reason=""
+  local dispatch_reason=""
 
   if [ -z "$head_sha" ]; then
     reason="evidence_unavailable_head"
   elif [ -z "${LOCAL_AI_CONFIGURED:-}" ]; then
     reason="local_evidence_missing"
   elif [ "$LOCAL_AI_CONFIGURED" = "0" ]; then
-    reason="local_reviewer_not_configured"
+    # No cheap pre-filter exists in this repository. Dispatch rather than defer
+    # forever, but record the reduced gating.
+    dispatch_reason="no_local_prefilter"
   elif [ "${LOCAL_AI_HEAD_CURRENT:-}" = "0" ]; then
     reason="local_evidence_stale"
   elif [ -z "${LOCAL_AI_HEAD_CURRENT:-}" ]; then
     reason="local_evidence_missing"
   fi
-  # ... conditions 2-4 follow the same shape, each appending its own reason ...
+  # Conditions 2-4 follow, each appending its own reason and each comparing the
+  # live head returned by its query against "$head_sha" before trusting it.
 
   print_kv EXPENSIVE_GATE_PLATFORM "$platform"
   print_kv EXPENSIVE_GATE_HEAD "$head_sha"
+  print_kv EXPENSIVE_GATE_REASON "$reason"
+  print_kv EXPENSIVE_GATE_DISPATCH_REASON "$dispatch_reason"
   if [ -n "$reason" ]; then
-    print_kv EXPENSIVE_GATE_REASON "$reason"
     if [ "${PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS:-0}" = "1" ]; then
       print_kv EXPENSIVE_GATE_RESULT forced
       return 0
     fi
-    print_kv EXPENSIVE_GATE_RESULT held
+    print_kv EXPENSIVE_GATE_RESULT deferred
     return 1
   fi
   print_kv EXPENSIVE_GATE_RESULT dispatched
-  print_kv EXPENSIVE_GATE_REASON ""
   return 0
 }
 ```
@@ -395,7 +469,7 @@ expensive_reviewer_gate() {
 Summary-comment line, illustrative:
 
 ```markdown
-**Expensive reviewer gate:** codex-github — held (local_evidence_stale) at head `6780c658eebc8879d61e56842445749c1195b13f`
+**Expensive reviewer gate:** codex-github — deferred (local_evidence_stale) at head `6780c658eebc8879d61e56842445749c1195b13f`. The reviewer was not run; this loop result is `needs_fixes` so readiness is withheld and Step 7 will re-run.
 ```
 
 ---
@@ -414,21 +488,28 @@ Summary-comment line, illustrative:
 1. Add `EXPENSIVE_REVIEWER_PLATFORMS` and `is_expensive_reviewer_platform` near
    the existing `is_phase_after_clean_platform` helper. **Verify**: source with
    `HARNESS_MODE=1` and confirm scenario 1's matches and non-matches.
-2. Add `expensive_reviewer_gate` with conditions 1–4 in the documented order and
-   the fail-closed branch for every unreadable input. **Verify**: drive the
+2. Add `expensive_reviewer_gate` with the conditions in the documented order,
+   the `no_local_prefilter` dispatch branch, the full-platform-list comparison
+   for condition 2, the live-head comparison for conditions 3 and 4, and the
+   fail-closed branch for every unreadable input. **Verify**: drive the
    condition fixture and confirm each unmet condition yields its single named
-   reason.
+   reason, and that the reordered-platform case defers with
+   `peer_reviewer_not_run`.
 3. Wire the gate into the per-platform block immediately before
-   `run_platform_review`, guarded by `is_expensive_reviewer_platform`.
-   **Verify**: scenario 3 shows `run_platform_review` is not called on a hold.
-4. Add the override branch and confirm the reason survives it. **Verify**:
-   scenario 10.
-5. Emit the four `EXPENSIVE_GATE_*` keys and document them in `--help`.
-   **Verify**: run `pr-review-loop.sh --help` and confirm the gate, its four
-   conditions, the fail-closed rule, and the override variable are described.
+   `run_platform_review`, guarded by `is_expensive_reviewer_platform`, and make
+   a `deferred` result set the aggregate to `needs_fixes` with
+   `REASON=expensive_gate_deferred`. **Verify**: scenario 3 shows
+   `run_platform_review` is not called and the aggregate is `needs_fixes`.
+4. Add the override branch, confirm the reason survives it, and confirm a
+   `forced` result does **not** set the `needs_fixes` aggregate. **Verify**:
+   scenario 12.
+5. Emit the five `EXPENSIVE_GATE_*` keys and document them in `--help`.
+   **Verify**: run `pr-review-loop.sh --help` and confirm the gate, its
+   conditions, the fail-closed rule, the `deferred` aggregate behavior, the
+   `no_local_prefilter` path, and the override variable are described.
 6. Add the summary-comment line and the `expensive_gate` ledger object.
    **Verify**: build an entry in the harness and confirm the object shape, and
-   that a legacy entry without it still parses (scenario 13).
+   that a legacy entry without it still parses (scenario 15).
 7. Update
    `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
    and
@@ -440,7 +521,7 @@ Summary-comment line, illustrative:
    **Verify**: both suites exit 0, and
    `scripts/development-workflow/select-test-suites.sh` selects the new suite
    for a change touching only `pr-review-loop.sh`.
-9. Produce the four planted-violation proofs (P1–P4) and record them in the PR
+9. Produce the six planted-violation proofs (P1–P6) and record them in the PR
    under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
    at a concrete file and line — failing with the violation planted, passing
    once removed.

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -596,6 +596,9 @@ reads them against each other and fails on any divergence.
     kept failing is still reported. With one fewer recorded deferral it defers
     normally. This is the scenario the existing dual caps cannot cover, because
     they bucket `needs_fixes` uniquely by head and result.
+14. The deferral counter is head-scoped: deferrals recorded against a different
+    `expensive_gate.head` do not count toward the cap for the current head, so a
+    new push starts the budget over.
 14b. `expensive_gate_resolve_max_deferrals` returns `3` for unset and empty;
     the configured value for `1` and `999999`; and `3` with a `WARN` on stderr
     for `0`, `-1`, `1000000`, `abc`, `2.5`, and a value with surrounding
@@ -604,9 +607,6 @@ reads them against each other and fails on any divergence.
     `integer expression expected` and evaluate false, defeating the cap, while
     `0` or a negative value trips it before the first deferral and escalates
     every gated PR.
-14. The deferral counter is head-scoped: deferrals recorded against a different
-    `expensive_gate.head` do not count toward the cap for the current head, so a
-    new push starts the budget over.
 15. `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS=1` with condition 1 unmet →
     `EXPENSIVE_GATE_RESULT=forced`, `EXPENSIVE_GATE_REASON=local_evidence_stale`
     preserved, `run_platform_review` **is** called, and the aggregate is **not**
@@ -624,7 +624,6 @@ reads them against each other and fails on any divergence.
 18. A ledger entry written without `expensive_gate` still parses through
     `reviewer_loop_history_payload_from_existing` — `v1` backward compatibility,
     same contract as #1648's added fields.
-
 19. The deferral budget is genuinely unreadable — the history marker is present
     but its JSON block is unparseable, its schema does not match, or its
     persisted `history_status` is not `available` →
@@ -633,6 +632,24 @@ reads them against each other and fails on any divergence.
     `EXPENSIVE_GATE_DEFERRALS=-1`, and the loop escalates. Without this the
     bounded-deferral guarantee would hold only when the ledger happens to be
     readable, which is not a guarantee.
+19b. The ledger is **absent** — no summary comment yet, or a body with no
+    history marker — → `EXPENSIVE_GATE_DEFERRALS=0` and the gate defers or
+    dispatches normally. This is every PR's first reviewer-loop run; escalating
+    here would bypass the bounded deferrals on every PR without prior history
+    and the bound would never be exercised.
+
+**Files**:
+20. The relocation is behavior-preserving: `pr-ci-loop.sh` produces identical
+    `REVIEWER_CHECK_COUNT`, `REVIEWER_CHECKS` and `REVIEWER_CHECKS_JSON` before
+    and after `configured_reviewer_check_names_json` moves to
+    `workflow-lib.sh`, and `expensive_gate_baseline_checks_status` classifies
+    the same check names as reviewer-owned.
+21. A draft-phase defer does not start the ready phase: with `codex-github` on
+    draft deferring and `bugbot` on ready, the loop breaks out immediately —
+    `ensure_pr_ready_for_ready_phase` is not called, `gh pr ready` is not run,
+    the PR stays draft, and no `EXPENSIVE_GATE_*` or phase telemetry is emitted
+    for `bugbot`. Without the short-circuit the gate would produce a visible,
+    hard-to-undo side effect while refusing to proceed.
 22. In-loop derivation matches the printed contract: with #1648's actual
     producer populating `platform_reviewed_heads` — not with the variables
     pre-seeded — `expensive_gate_local_ai_configured` and
@@ -641,28 +658,15 @@ reads them against each other and fails on any divergence.
     current head, a stale head, an unreported head, and a run where
     `local-ai-reviewer` is not configured. This is the composition test with the
     dependency rather than a mock of it.
-21. A draft-phase defer does not start the ready phase: with `codex-github` on
-    draft deferring and `bugbot` on ready, the loop breaks out immediately —
-    `ensure_pr_ready_for_ready_phase` is not called, `gh pr ready` is not run,
-    the PR stays draft, and no `EXPENSIVE_GATE_*` or phase telemetry is emitted
-    for `bugbot`. Without the short-circuit the gate would produce a visible,
-    hard-to-undo side effect while refusing to proceed.
-20. The relocation is behavior-preserving: `pr-ci-loop.sh` produces identical
-    `REVIEWER_CHECK_COUNT`, `REVIEWER_CHECKS` and `REVIEWER_CHECKS_JSON` before
-    and after `configured_reviewer_check_names_json` moves to
-    `workflow-lib.sh`, and `expensive_gate_baseline_checks_status` classifies
-    the same check names as reviewer-owned.
-19b. The ledger is **absent** — no summary comment yet, or a body with no
-    history marker — → `EXPENSIVE_GATE_DEFERRALS=0` and the gate defers or
-    dispatches normally. This is every PR's first reviewer-loop run; escalating
-    here would bypass the bounded deferrals on every PR without prior history
-    and the bound would never be exercised.
 
-**Files**:
+Every scenario is assigned to exactly one suite. The list below enumerates them
+individually rather than by range, because the sub-lettered scenarios added
+during review (6b, 14b, 19b) are the ones a range silently drops — and each of
+them covers a fail-closed edge, which is precisely what must not go untested.
 
-- `scripts/development-workflow/tests/test-pr-review-loop.sh` — scenarios 1–14
-  (including 6b), 18 and 19, as new cases in the existing `HARNESS_MODE=1`
-  harness.
+- `scripts/development-workflow/tests/test-pr-review-loop.sh` — scenarios 1, 2,
+  3, 4, 5, 6, 6b, 7, 8, 9, 10, 11, 12, 13, 14, 14b, 18, 19 and 19b, as new
+  cases in the existing `HARNESS_MODE=1` harness.
 - `scripts/development-workflow/tests/test-pr-ci-loop.sh` — scenario 20, which
   asserts that `pr-ci-loop.sh` still produces the same `REVIEWER_CHECK_COUNT`,
   `REVIEWER_CHECKS` and `REVIEWER_CHECKS_JSON` after
@@ -671,8 +675,9 @@ reads them against each other and fails on any divergence.
   add `# covers: scripts/development-workflow/workflow-lib.sh` so a later edit
   to the relocated function also selects it.
 - `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` — a new
-  suite for scenarios 15–17, 21 and 22, the override and composition cases, which need
-  their own mock scaffolding for the phase and filter paths. It must declare:
+  suite for scenarios 15, 16, 17, 21 and 22 — the override and composition
+  cases, which need their own mock scaffolding for the phase and filter paths.
+  It must declare:
 
   ```text
   # covers: scripts/development-workflow/pr-review-loop.sh

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -650,8 +650,8 @@ concrete file and line:
 
 | # | Violation to plant | Where | Check that must fail, then pass |
 | --- | --- | --- | --- |
-| P1 | Stale local evidence: `LOCAL_AI_HEAD_CURRENT=0` with all other conditions met | the gate fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | the gate defers, `run_platform_review` is not called, and the aggregate is `needs_fixes` / `expensive_gate_deferred`; setting it to `1` dispatches |
-| P2 | Missing local evidence: `LOCAL_AI_CONFIGURED` unset | same fixture | the gate defers with `local_evidence_missing`; exporting `LOCAL_AI_CONFIGURED=1` dispatches — the proof that an unknown is refused rather than assumed clean |
+| P1 | Stale local evidence: populate `platform_reviewed_heads` so the `local-ai-reviewer` entry records a 40-character OID that is **not** `loop_head_sha`, with all other conditions met | the gate fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | the gate defers with `local_evidence_stale`, `run_platform_review` is not called, and the aggregate is `needs_fixes` / `expensive_gate_deferred`; setting that entry to `loop_head_sha` dispatches |
+| P2 | Missing local evidence: leave the `local-ai-reviewer` entry of `platform_reviewed_heads` absent while `local-ai-reviewer` **is** in the resolved platform list | same fixture | the gate defers with `local_evidence_missing`; adding the entry with the current head dispatches — the proof that an unknown is refused rather than assumed clean |
 | P3 | Unreadable evidence: make the review-threads query fail | same fixture | the gate defers with `evidence_unavailable_review_threads` **and** the aggregate becomes `needs_fixes` / `expensive_gate_deferred`, so readiness is withheld; restoring the query dispatches and leaves the aggregate clean |
 | P4 | Gate-not-wired regression: **delete the `expensive_reviewer_gate` call** from the per-platform block, leaving the function defined but unreachable | a scratch copy of the per-platform block in `scripts/development-workflow/pr-review-loop.sh` | scenario 3 fails, because `codex-github` is dispatched with stale local evidence and no `EXPENSIVE_GATE_*` telemetry is emitted; restoring the call passes. Deleting the call is the correct mutation: removing the `is_expensive_reviewer_platform` guard instead would consult the gate for *every* platform, which is a different defect and would not leave the gate unreachable |
 | P5 | Ordering regression: **delete the `reorder_expensive_reviewers_last` call**, leaving a platform list that declares `codex-github` before `pr-agent` | a scratch copy of the platform-resolution block | scenario 6 fails and scenario 7's suppressed-reorder case shows the gate deferring on every invocation with `peer_reviewer_not_run` — a deferral that can never resolve; restoring the call passes |
@@ -671,6 +671,12 @@ concrete file and line:
 Record all seventeen in the implementation PR under a `Planted-Violation Proofs`
 heading, each with the command, the file and line of the planted violation, and
 both outcomes.
+
+Every proof that touches the local evidence manipulates the **in-loop state** —
+the resolved platform list and `platform_reviewed_heads` — and never exports
+`LOCAL_AI_CONFIGURED` or `LOCAL_AI_HEAD_CURRENT`. Those names are stdout keys
+the gate is required to ignore, so a proof that set them would validate an
+interface the implementation must not have, and would contradict P17.
 
 ### Parser-risk addendum
 

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -206,19 +206,23 @@ Not applicable — this repository ships workflow tooling, not a service.
       failing, so a stuck gate reaches a human instead of cycling silently. The
       counter resets naturally when the head moves, because it is scoped to
       `loop_head_sha`.
-- [ ] **The deferral counter is itself fail-closed.** If the ledger cannot be
-      read or does not parse — the same `unavailable` state
-      `reviewer_loop_history_entries_count` already reports as `-1` — the
-      counter cannot prove the sequence is bounded, so the gate must not defer
-      again on an unproven budget. It escalates immediately with
-      `EXPENSIVE_GATE_RESULT=deferral_cap` and
-      `REASON=expensive_gate_deferral_budget_unreadable`, carrying the
-      condition that triggered the gate, and emits
-      `EXPENSIVE_GATE_DEFERRALS=-1` so the unreadable state is distinguishable
-      from a count of zero. Escalating on an unreadable budget is the
-      conservative choice: a human sees the gate immediately, whereas deferring
-      on an unknown budget is precisely the unbounded loop this counter exists
-      to prevent.
+- [ ] **The deferral counter is fail-closed only on a genuinely unreadable
+      ledger — an absent one is the normal first run.** The counter mirrors the
+      three states `reviewer_loop_history_entries_count` already distinguishes,
+      and must not collapse them:
+
+      | Ledger state | Counter | Gate behavior |
+      | --- | --- | --- |
+      | No summary comment, or a body with no history marker at all | `0` | normal — this is every PR's first reviewer-loop run, and escalating here would bypass the bounded deferrals on every PR without prior history |
+      | Marker present and parseable | the occurrence count for this head | normal |
+      | Marker present but no parseable JSON block, schema mismatch, or a persisted `history_status` other than `available` | `-1` | escalate with `EXPENSIVE_GATE_RESULT=deferral_cap` and `EXPENSIVE_GATE_ESCALATION=expensive_gate_deferral_budget_unreadable` |
+
+      Escalating on a genuinely unreadable budget is the conservative choice: a
+      human sees the gate immediately, whereas deferring on an unknown budget is
+      precisely the unbounded loop this counter exists to prevent. Treating an
+      *absent* ledger the same way would invert that, escalating the common case
+      and never exercising the bound. `EXPENSIVE_GATE_DEFERRALS=-1` keeps the
+      unreadable state distinguishable from a count of zero.
 - [ ] **A repository with no local reviewer defers, it does not dispatch.**
       When `LOCAL_AI_CONFIGURED` is `0` there is no current-head local clean
       evidence, and the brief requires `codex-github` to run *only after* that
@@ -430,12 +434,19 @@ reads them against each other and fails on any divergence.
     `reviewer_loop_history_payload_from_existing` — `v1` backward compatibility,
     same contract as #1648's added fields.
 
-19. The deferral budget is unreadable (the ledger is absent, unparseable, or
-    reports the `unavailable` state) → `EXPENSIVE_GATE_RESULT=deferral_cap`,
+19. The deferral budget is genuinely unreadable — the history marker is present
+    but its JSON block is unparseable, its schema does not match, or its
+    persisted `history_status` is not `available` →
+    `EXPENSIVE_GATE_RESULT=deferral_cap`,
     `REASON=expensive_gate_deferral_budget_unreadable`,
     `EXPENSIVE_GATE_DEFERRALS=-1`, and the loop escalates. Without this the
     bounded-deferral guarantee would hold only when the ledger happens to be
     readable, which is not a guarantee.
+19b. The ledger is **absent** — no summary comment yet, or a body with no
+    history marker — → `EXPENSIVE_GATE_DEFERRALS=0` and the gate defers or
+    dispatches normally. This is every PR's first reviewer-loop run; escalating
+    here would bypass the bounded deferrals on every PR without prior history
+    and the bound would never be exercised.
 
 **Files**:
 
@@ -483,9 +494,10 @@ concrete file and line:
 | P10 | Peer-evidence regression: accept any `skipped` peer instead of consulting `reviewer_failed_label_required_for_result` | a scratch copy of condition 2 | scenario 8's `unavailable`, `timeout` and `unauthorized` rows fail, because the gate dispatches with a peer that never produced a verdict; restoring the helper call passes |
 | P6 | Readiness regression: make a defer leave the aggregate result unchanged instead of setting `needs_fixes` | a scratch copy of the gate call site | scenario 3's aggregate assertion fails, and a run in which `codex-github` never executed would satisfy Protocol 92's readiness conditions; restoring the `needs_fixes` aggregate passes |
 | P7 | Unbounded-deferral regression: replace the head-scoped deferral counter with the existing `reviewer_loop_history_entries_count` caps | a scratch copy of the cap check | scenario 13 fails, because repeated `needs_fixes` results on one unchanged head collapse under that function's `unique` bucketing by `head_sha` + `result` and neither cap ever trips; restoring the dedicated counter escalates with `expensive_gate_deferral_cap` |
-| P8 | Unreadable-budget regression: make the ledger read fail, and change the counter to treat the failure as a count of zero | the deferral-budget fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | scenario 19 fails, because the gate defers on an unproven budget instead of escalating; restoring the fail-closed branch escalates with `expensive_gate_deferral_budget_unreadable` |
+| P8 | Unreadable-budget regression: seed a malformed ledger and change the counter to treat it as a count of zero | the deferral-budget fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | scenario 19 fails, because the gate defers on an unproven budget instead of escalating; restoring the fail-closed branch escalates with `expensive_gate_deferral_budget_unreadable` |
+| P11 | Absent-ledger regression: change the counter to return `-1` for an absent ledger as well as a malformed one | same fixture | scenario 19b fails, because a PR with no prior reviewer-loop history escalates on its first run and the bound is never exercised; restoring the three-state mapping passes |
 
-Record all ten in the implementation PR under a `Planted-Violation Proofs`
+Record all eleven in the implementation PR under a `Planted-Violation Proofs`
 heading, each with the command, the file and line of the planted violation, and
 both outcomes.
 
@@ -515,7 +527,7 @@ by the same sequential block that already writes `platform_result_tokens`.
 | Platform-order fixture | A resolved list declaring `codex-github` first, an already-correct list, and a two-bucket list with `codex-github` on draft and `bugbot` on ready — driving scenarios 6, 6b and 7 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Peer-evidence fixture | One peer per row of scenario 8's table, covering `clean`, the three accepted skip reasons, the three rejected skip reasons, `needs_fixes` and `escalate` | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Unreadable-input mocks | Mock `gh` commands that exit non-zero for the threads query and for the check rollup, driving scenario 12 and proof P3 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
-| Deferral-budget fixtures | Ledger payloads carrying `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` `expensive_gate.result=deferred` entries at the current head, one fewer, the same count at a different head, and an unparseable payload — driving scenarios 13, 14 and 19 and proofs P7 and P8 | inline heredocs in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Deferral-budget fixtures | Ledger payloads carrying `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` `expensive_gate.result=deferred` entries at the current head, one fewer, the same count at a different head, and an unparseable payload — driving scenarios 13, 14, 19 and 19b and proofs P7, P8 and P11 — including an absent ledger, a malformed one, and a well-formed one | inline heredocs in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Composition fixture | A platform list where `codex-github` is both a phase platform and an expensive reviewer, driving scenarios 16 and 17 | inline in `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` |
 | Legacy ledger payload | A `reviewer_loop_history.v1` entry with no `expensive_gate` object, driving scenario 18 | inline heredoc in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 
@@ -670,10 +682,12 @@ Summary-comment line, illustrative:
    reviewer still precedes every ready-phase platform.
 3. Add `expensive_gate_deferral_count`, reading occurrences of
    `expensive_gate.result == "deferred"` scoped to `expensive_gate.head` from
-   the ledger, and returning `-1` when the ledger is absent, unparseable, or
-   reports the `unavailable` state. **Verify**: scenarios 13, 14 and 19 — the
-   count reflects only the current head, and an unreadable ledger yields `-1`
-   rather than `0`.
+   the ledger, returning `0` for an absent ledger or a body with no history
+   marker, and `-1` only for a marker whose JSON is unparseable, whose schema
+   does not match, or whose persisted `history_status` is not `available` —
+   mirroring `reviewer_loop_history_entries_count`'s own three states.
+   **Verify**: scenarios 13, 14, 19 and 19b — the count reflects only the
+   current head, an absent ledger yields `0`, and a malformed one yields `-1`.
 4. Add `expensive_reviewer_gate` with the conditions in the documented order,
    the full-platform-list comparison for condition 2 delegating acceptance to
    `reviewer_failed_label_required_for_result`, the live-head comparison
@@ -716,7 +730,7 @@ Summary-comment line, illustrative:
     **Verify**: both suites exit 0, and
     `scripts/development-workflow/select-test-suites.sh` selects the new suite
     for a change touching only `pr-review-loop.sh`.
-11. Produce the ten planted-violation proofs (P1–P10) and record them in the PR
+11. Produce the eleven planted-violation proofs (P1–P11) and record them in the PR
     under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
     at a concrete file and line — failing with the violation planted, passing
     once removed.

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -862,17 +862,30 @@ Summary-comment line, illustrative:
    **Documentation Updates**. **Verify**: both files describe the same four
    conditions, the same fail-closed rule, and the same override variable name.
 10. Add the unit cases to `test-pr-review-loop.sh` and create
-    `test-expensive-reviewer-gate.sh` with both `# covers:` lines.
-    **Verify**: both suites exit 0, and
+    `test-expensive-reviewer-gate.sh` with both `# covers:` lines, and add the
+    `workflow-lib.sh` `# covers:` line to `test-pr-ci-loop.sh`.
+    **Verify**: all **three** suites exit 0 —
+    `test-pr-review-loop.sh`, `test-expensive-reviewer-gate.sh` and
+    `test-pr-ci-loop.sh`, the last of which carries scenario 20 and is the only
+    check that the classification relocation preserved behavior — and
     `scripts/development-workflow/select-test-suites.sh` selects the new suite
-    for a change touching only `pr-review-loop.sh`.
+    for a change touching only `pr-review-loop.sh` and selects
+    `test-pr-ci-loop.sh` for a change touching only `workflow-lib.sh`.
 11. Produce the fifteen planted-violation proofs (P1–P15) and record them in the PR
     under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
     at a concrete file and line — failing with the violation planted, passing
     once removed.
-12. Run `shellcheck` on the changed script and `markdownlint-cli2` on the
-    changed protocol document, this plan, and the runbook. **Verify**: both
-    tools exit 0.
+12. Run `shellcheck` on **all three** changed shell files —
+    `scripts/development-workflow/pr-review-loop.sh`,
+    `scripts/development-workflow/pr-ci-loop.sh` (the relocation removes a
+    function from it) and `scripts/development-workflow/workflow-lib.sh` (it
+    gains that function) — and `markdownlint-cli2` on **both** changed
+    documentation targets,
+    `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
+    and `docs/workflow/development-workflow/integrations/codex-github.md`, plus
+    this plan and the runbook. **Verify**: both tools exit 0 on every file
+    named here; the enumeration is explicit so a changed file cannot be omitted
+    by reading "the changed script" narrowly.
 13. Add a changelog fragment
     `changelog.d/1649.changed.expensive-reviewers-after-local-clean.md`
     containing exactly:

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -786,7 +786,7 @@ by the same sequential block that already writes `platform_result_tokens`.
 
 | Entity | Values / Scenario | File |
 | --- | --- | --- |
-| Gate condition fixture | A table-driven set of the conditions with each one independently unmet, plus the eight-row unexpected-value table for condition 1, driving scenarios 2–5 and 9–11 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Gate condition fixture | A table-driven set of the conditions with each one independently unmet, plus the six-row unexpected-value table for condition 1, driving scenarios 2–5 and 9–11 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Platform-order fixture | A resolved list declaring `codex-github` first, an already-correct list, and a two-bucket list with `codex-github` on draft and `bugbot` on ready — driving scenarios 6, 6b and 7 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Peer-evidence fixture | One peer per row of scenario 8's table: `clean`, the four accepted skip reasons, the three rejected skip reasons, an unknown skip reason, an empty skip reason, `needs_fixes` and `escalate` | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Unreadable-input mocks | Mock `gh` commands that exit non-zero for the threads query and for the check rollup, plus a rollup that returns an empty array and one containing only reviewer-owned checks — driving scenarios 10 and 12 and proofs P3 and P16 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -117,22 +117,29 @@ Not applicable — this repository ships workflow tooling, not a service.
 
       | # | Condition | Unmet reason |
       | --- | --- | --- |
-      | 0 | `LOCAL_AI_CONFIGURED` is `0` | *not a defer* — dispatch with `EXPENSIVE_GATE_DISPATCH_REASON=no_local_prefilter` (see below) |
-      | 1 | `LOCAL_AI_CONFIGURED` is `1` and `LOCAL_AI_HEAD_CURRENT` is `1` | `local_evidence_stale` when `LOCAL_AI_HEAD_CURRENT` is `0`; `local_evidence_missing` when it is empty or `LOCAL_AI_CONFIGURED` is unset |
+      | 1 | `LOCAL_AI_CONFIGURED` is `1` and `LOCAL_AI_HEAD_CURRENT` is `1` | `local_evidence_stale` when `LOCAL_AI_HEAD_CURRENT` is `0`; `local_evidence_missing` when it is empty or `LOCAL_AI_CONFIGURED` is unset; `local_reviewer_not_configured` when `LOCAL_AI_CONFIGURED` is `0` |
       | 2 | **Every** non-expensive platform in the resolved platform list has already run in this invocation **and** returned `clean` or `skipped` | `peer_reviewer_not_run` when one has not run yet; `peer_reviewer_not_clean` when one ran and did not return clean or skipped |
       | 3 | Zero unresolved, non-outdated review threads | `unresolved_threads` |
       | 4 | Every non-reviewer check is `SUCCESS`, `SKIPPED`, or `NEUTRAL` | `baseline_checks_not_green` when one failed; `baseline_checks_pending` when one is still running |
 
-- [ ] **Condition 2 must not depend on platform ordering.** Checking only the
-      platforms encountered so far would let a configuration that lists
-      `codex-github` before `pr-agent` dispatch the expensive reviewer while the
-      cheap one has not run at all — the exact inversion this item exists to
-      prevent. The gate therefore compares against the **full resolved platform
-      list** (`platforms[@]` minus the expensive ones), not against the
-      per-invocation results collected up to this index, and defers with
-      `peer_reviewer_not_run` when any of them has no recorded result yet. That
-      makes the gate correct under any ordering and removes the need for a
-      separate ordering rule elsewhere.
+- [ ] **Reorder expensive reviewers to the end of the platform list.** Add
+      `reorder_expensive_reviewers_last`, called once after the platform list is
+      resolved and before the iteration begins: it partitions `platforms` into
+      non-expensive followed by expensive, preserving relative order within each
+      partition. Detection alone is not enough — a configuration listing
+      `codex-github` before `pr-agent` would otherwise defer at the same point on
+      every invocation, because the loop would never reach `pr-agent` before the
+      gate, and the deferral would never resolve. Reordering makes the gate's
+      precondition reachable rather than merely checked. Emit
+      `EXPENSIVE_REVIEWERS_REORDERED=1` and the reordered `PLATFORM_LIST` when
+      the partition changed the order, so the behavior is visible rather than a
+      silent rewrite of the caller's configuration.
+- [ ] **Condition 2 compares against the full resolved list**
+      (`platforms[@]` minus the expensive ones), not the results collected up to
+      this index. After reordering, every non-expensive platform has run by the
+      time the gate is consulted, so `peer_reviewer_not_run` is a defensive
+      assertion rather than an expected outcome: if it ever fires, the reorder
+      did not happen and the gate says so instead of silently dispatching.
 - [ ] **Bind conditions 3 and 4 to the same head as the reviewer evidence.**
       Both queries must return the live head alongside their payload, and the
       gate must compare it to `loop_head_sha`. If they differ, the PR moved
@@ -152,17 +159,34 @@ Not applicable — this repository ships workflow tooling, not a service.
       `REASON=expensive_gate_deferred`. That is the loop's existing mechanism
       for "not finished yet": Protocol 91 re-runs Step 7 on a non-clean result,
       the readiness label is withheld, and the deferral is therefore guaranteed
-      to be retried rather than merely hoped for. The dual cycle caps already
-      bound how many retries happen, so this adds no unbounded loop.
-- [ ] **A repository with no local reviewer dispatches rather than defers.**
-      When `LOCAL_AI_CONFIGURED` is `0` the platform is not in the resolved
-      list, there is no cheap pre-filter to wait for, and deferring would hold
-      the expensive reviewer forever in every downstream consumer that does not
-      configure `local-ai-reviewer`. The gate dispatches, recording
-      `EXPENSIVE_GATE_RESULT=dispatched` with
-      `EXPENSIVE_GATE_DISPATCH_REASON=no_local_prefilter` so the reduced
-      gating is visible rather than silent. Conditions 2 to 4 still apply — a
-      missing local reviewer relaxes condition 1 only.
+      to be retried rather than merely hoped for.
+- [ ] **Bound the deferrals with their own counter — the existing caps do not
+      cover them.** `reviewer_loop_history_entries_count` buckets qualifying
+      entries as `unique` over `head_sha + "|" + result`, so repeated
+      `needs_fixes` results on one unchanged head collapse to a single count on
+      both the per-run and lifetime axes. Deferrals are exactly that shape: the
+      head does not move while the gate waits, so an unbounded number of
+      deferral cycles would advance neither cap. Add a dedicated counter that
+      reads the ledger for entries whose `expensive_gate.result` is `deferred`
+      **and** whose `expensive_gate.head` equals the current `loop_head_sha`,
+      counted as occurrences rather than uniques, bounded by
+      `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` (default `3`). On reaching the
+      cap the loop stops deferring and escalates with `RESULT=escalate` and
+      `REASON=expensive_gate_deferral_cap`, naming the condition that kept
+      failing, so a stuck gate reaches a human instead of cycling silently. The
+      counter resets naturally when the head moves, because it is scoped to
+      `loop_head_sha`.
+- [ ] **A repository with no local reviewer defers, it does not dispatch.**
+      When `LOCAL_AI_CONFIGURED` is `0` there is no current-head local clean
+      evidence, and the brief requires `codex-github` to run *only after* that
+      evidence exists and to fail closed when it is missing — it permits an
+      explicit manual override, not an implicit automatic one. The gate
+      therefore defers with `local_reviewer_not_configured`. The consequence for
+      a consumer that deliberately does not configure `local-ai-reviewer` is
+      handled by the deferral cap below, which escalates to a human after a
+      bounded number of deferrals rather than blocking forever, and by
+      `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS` for a one-off run. Both are
+      explicit; neither silently relaxes the gate.
 - [ ] **Fail closed on every unknown.** If any input cannot be read, the gate
       defers with one of exactly three reasons — there is no generic unknown
       state:
@@ -192,21 +216,25 @@ Not applicable — this repository ships workflow tooling, not a service.
       the `needs_fixes` aggregate: the human took the decision explicitly.
 - [ ] Emit gate telemetry on the loop's stdout contract, per expensive platform:
       `EXPENSIVE_GATE_PLATFORM`, `EXPENSIVE_GATE_RESULT`
-      (`dispatched` | `deferred` | `forced`), `EXPENSIVE_GATE_REASON` (the
-      unmet-condition reason; empty on an unconditional dispatch),
-      `EXPENSIVE_GATE_DISPATCH_REASON` (`no_local_prefilter`, or empty), and
-      `EXPENSIVE_GATE_HEAD` (the `loop_head_sha` the gate evaluated). All values stay inside the `[A-Za-z0-9:_-]` token charset the
+      (`dispatched` | `deferred` | `forced` | `deferral_cap`),
+      `EXPENSIVE_GATE_REASON` (the unmet-condition reason; empty when
+      `dispatched`), `EXPENSIVE_GATE_HEAD` (the `loop_head_sha` the gate
+      evaluated), and `EXPENSIVE_GATE_DEFERRALS` (how many deferrals the ledger
+      already records for this head, so the distance to the cap is visible
+      before it trips). `EXPENSIVE_REVIEWERS_REORDERED` is emitted once per run,
+      not per platform. All values stay inside the `[A-Za-z0-9:_-]` token charset the
       Protocol 91 carry-forward snippet admits.
 - [ ] Record the gate outcome in the reviewer-loop summary comment as an
       `**Expensive reviewer gate:**` line, and in the `reviewer_loop_history.v1`
       entry as an `expensive_gate` object (`platform`, `result`, `reason`,
-      `head`, `dispatch_reason`). Both are additive; readers dereference with
+      `head`). Both are additive; readers dereference with
       defaults, so the schema stays `v1`, consistent with #1648's treatment of
       `reviewed_heads`.
 - [ ] Document the gate in the `--help` usage block: its conditions and their
       evaluation order, its fail-closed rule, the `deferred` aggregate
-      behavior, the `no_local_prefilter` dispatch path, and the override
-      variable.
+      behavior, the bounded deferral counter and its escalation, the
+      reordering of expensive reviewers to the end of the platform list, and
+      the override variable.
 
 ### Frontend / UI
 
@@ -227,8 +255,9 @@ Not applicable — no user interface in this repository.
       order-independence of condition 2, the head binding of conditions 3 and 4,
       the fail-closed rule, the fact that a `deferred` outcome sets the
       aggregate to `needs_fixes` (so readiness is withheld and Step 7 re-runs)
-      rather than passing as a clean skip, the `no_local_prefilter` dispatch
-      path, and the override variable with the expectation that its use is
+      rather than passing as a clean skip, the bounded deferral counter and its
+      `expensive_gate_deferral_cap` escalation, the reordering of expensive
+      reviewers to the end of the platform list, and the override variable with the expectation that its use is
       justified in the PR.
 - [ ] `docs/workflow/development-workflow/integrations/codex-github.md` — add a
       section describing the gate so a reader configuring the reviewer learns
@@ -256,56 +285,73 @@ Not applicable — no user interface in this repository.
 4. `LOCAL_AI_CONFIGURED` unset → `deferred` / `local_evidence_missing`. The
    fail-closed case for brief scope bullet 2, pairing with #1648's rule that an
    absent key is telemetry loss rather than non-applicability.
-5. `LOCAL_AI_CONFIGURED=0` → `dispatched` with
-   `EXPENSIVE_GATE_DISPATCH_REASON=no_local_prefilter`, and conditions 2 to 4
-   still evaluated. Distinct from scenario 4: the loop is correctly configured
-   and there is simply no local reviewer to wait for, so deferring would hold
-   the expensive reviewer forever in every consumer that does not configure one.
-6. Condition 2 is order-independent: with `codex-github` listed **before**
-   `pr-agent` in the resolved platform list, the gate → `deferred` /
-   `peer_reviewer_not_run`; with `pr-agent` already run and `clean`, →
-   `dispatched`. The first case is the regression test for a configuration that
-   would otherwise dispatch the expensive reviewer before the cheap one ran.
-7. A peer reviewer that ran and returned `needs_fixes` → `deferred` /
-   `peer_reviewer_not_clean` — distinct from scenario 6's `peer_reviewer_not_run`.
-8. One unresolved non-outdated review thread → `deferred` /
+5. `LOCAL_AI_CONFIGURED=0` → `deferred` / `local_reviewer_not_configured`.
+   Distinct from scenario 4 (`missing` means the telemetry never arrived; this
+   means the platform is genuinely not configured), and deliberately still a
+   defer: the brief requires the expensive reviewer to run only after
+   current-head local clean evidence and to fail closed when it is absent. The
+   consumer that never configures a local reviewer is released by the deferral
+   cap in scenario 16 or by the override in scenario 12, both explicit.
+6. `reorder_expensive_reviewers_last` moves `codex-github` to the end of a
+   platform list that declared it first, preserves the relative order of the
+   remaining platforms, emits `EXPENSIVE_REVIEWERS_REORDERED=1`, and leaves an
+   already-correct list untouched with the flag unset. This is what makes the
+   gate's precondition reachable: without it the loop would defer at the same
+   point on every invocation and the deferral would never resolve.
+7. Condition 2 after reordering: with every non-expensive platform run and
+   `clean`, → `dispatched`. With the reorder suppressed so a peer has not run,
+   → `deferred` / `peer_reviewer_not_run` — the defensive assertion firing
+   rather than the gate silently dispatching.
+8. A peer reviewer that ran and returned `needs_fixes` → `deferred` /
+   `peer_reviewer_not_clean` — distinct from scenario 7's `peer_reviewer_not_run`.
+9. One unresolved non-outdated review thread → `deferred` /
    `unresolved_threads`; the same thread marked outdated → `dispatched`.
-9. A failing baseline check → `deferred` / `baseline_checks_not_green`; a
-   pending one → `deferred` / `baseline_checks_pending`; a reviewer-owned check
-   that is pending → `dispatched`, because a reviewer's own check must not gate
-   the reviewer.
-10. The threads or checks query returns a live head different from
+10. A failing baseline check → `deferred` / `baseline_checks_not_green`; a
+    pending one → `deferred` / `baseline_checks_pending`; a reviewer-owned check
+    that is pending → `dispatched`, because a reviewer's own check must not gate
+    the reviewer.
+11. The threads or checks query returns a live head different from
     `loop_head_sha` → `deferred` / `evidence_head_moved`. Without this, evidence
     from a newer commit could authorize dispatch against reviewer verdicts taken
     on an older one.
-11. Each unreadable input in turn → `deferred` with its specific reason —
+12. Each unreadable input in turn → `deferred` with its specific reason —
     `evidence_unavailable_head` for an empty `loop_head_sha`,
     `evidence_unavailable_review_threads` for a failed threads query,
     `evidence_unavailable_checks` for a failed check rollup.
-12. `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS=1` with condition 1 unmet →
+13. The deferral cap: with the ledger already recording
+    `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` deferrals for the current
+    `loop_head_sha`, the next run → `EXPENSIVE_GATE_RESULT=deferral_cap`,
+    `RESULT=escalate`, `REASON=expensive_gate_deferral_cap`, and the reason that
+    kept failing is still reported. With one fewer recorded deferral it defers
+    normally. This is the scenario the existing dual caps cannot cover, because
+    they bucket `needs_fixes` uniquely by head and result.
+14. The deferral counter is head-scoped: deferrals recorded against a different
+    `expensive_gate.head` do not count toward the cap for the current head, so a
+    new push starts the budget over.
+15. `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS=1` with condition 1 unmet →
     `EXPENSIVE_GATE_RESULT=forced`, `EXPENSIVE_GATE_REASON=local_evidence_stale`
     preserved, `run_platform_review` **is** called, and the aggregate is **not**
     set to `needs_fixes` — the override path of brief scope bullet 3, proving
     both that the reason survives and that an explicit human decision is not
     re-blocked.
-13. Composition with the phase mechanism: a platform that is both a phase
+16. Composition with the phase mechanism: a platform that is both a phase
     platform and an expensive reviewer runs `ensure_pr_ready_for_ready_phase`
     first and the gate second; when the gate defers, the PR has still been
     converted to ready and the defer is not reported as a phase failure.
-14. Composition with `--pre-after-clean-only`: an expensive reviewer that is
+17. Composition with `--pre-after-clean-only`: an expensive reviewer that is
     also a phase platform is filtered out before the gate is consulted, and the
     gate emits no telemetry for it — no phantom `deferred` record for a platform
     that was never in scope.
-15. A ledger entry written without `expensive_gate` still parses through
+18. A ledger entry written without `expensive_gate` still parses through
     `reviewer_loop_history_payload_from_existing` — `v1` backward compatibility,
     same contract as #1648's added fields.
 
 **Files**:
 
-- `scripts/development-workflow/tests/test-pr-review-loop.sh` — scenarios 1–11
-  and 15, as new cases in the existing `HARNESS_MODE=1` harness.
+- `scripts/development-workflow/tests/test-pr-review-loop.sh` — scenarios 1–14
+  and 18, as new cases in the existing `HARNESS_MODE=1` harness.
 - `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` — a new
-  suite for scenarios 12–14, the override and composition cases, which need
+  suite for scenarios 15–17, the override and composition cases, which need
   their own mock scaffolding for the phase and filter paths. It must declare:
 
   ```text
@@ -336,14 +382,15 @@ concrete file and line:
 
 | # | Violation to plant | Where | Check that must fail, then pass |
 | --- | --- | --- | --- |
-| P1 | Stale local evidence: `LOCAL_AI_HEAD_CURRENT=0` with all other conditions met | the gate fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | the gate holds and `run_platform_review` is not called; setting it to `1` dispatches |
-| P2 | Missing local evidence: `LOCAL_AI_CONFIGURED` unset | same fixture | the gate holds with `local_evidence_missing`; exporting `LOCAL_AI_CONFIGURED=1` dispatches — the proof that an unknown is refused rather than assumed clean |
-| P3 | Unreadable evidence: make the review-threads query fail | same fixture | the gate holds with `evidence_unavailable_review_threads` and the loop's aggregate result is unchanged; restoring the query dispatches |
+| P1 | Stale local evidence: `LOCAL_AI_HEAD_CURRENT=0` with all other conditions met | the gate fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | the gate defers, `run_platform_review` is not called, and the aggregate is `needs_fixes` / `expensive_gate_deferred`; setting it to `1` dispatches |
+| P2 | Missing local evidence: `LOCAL_AI_CONFIGURED` unset | same fixture | the gate defers with `local_evidence_missing`; exporting `LOCAL_AI_CONFIGURED=1` dispatches — the proof that an unknown is refused rather than assumed clean |
+| P3 | Unreadable evidence: make the review-threads query fail | same fixture | the gate defers with `evidence_unavailable_review_threads` **and** the aggregate becomes `needs_fixes` / `expensive_gate_deferred`, so readiness is withheld; restoring the query dispatches and leaves the aggregate clean |
 | P4 | Gate-not-wired regression: **delete the `expensive_reviewer_gate` call** from the per-platform block, leaving the function defined but unreachable | a scratch copy of the per-platform block in `scripts/development-workflow/pr-review-loop.sh` | scenario 3 fails, because `codex-github` is dispatched with stale local evidence and no `EXPENSIVE_GATE_*` telemetry is emitted; restoring the call passes. Deleting the call is the correct mutation: removing the `is_expensive_reviewer_platform` guard instead would consult the gate for *every* platform, which is a different defect and would not leave the gate unreachable |
-| P5 | Ordering regression: reorder the resolved platform list so `codex-github` precedes `pr-agent`, with condition 2 narrowed to platforms already encountered | the condition-2 fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | scenario 6 fails because the gate dispatches before `pr-agent` ran; restoring the full-list comparison defers with `peer_reviewer_not_run` |
+| P5 | Ordering regression: **delete the `reorder_expensive_reviewers_last` call**, leaving a platform list that declares `codex-github` before `pr-agent` | a scratch copy of the platform-resolution block | scenario 6 fails and scenario 7's suppressed-reorder case shows the gate deferring on every invocation with `peer_reviewer_not_run` — a deferral that can never resolve; restoring the call passes |
 | P6 | Readiness regression: make a defer leave the aggregate result unchanged instead of setting `needs_fixes` | a scratch copy of the gate call site | scenario 3's aggregate assertion fails, and a run in which `codex-github` never executed would satisfy Protocol 92's readiness conditions; restoring the `needs_fixes` aggregate passes |
+| P7 | Unbounded-deferral regression: replace the head-scoped deferral counter with the existing `reviewer_loop_history_entries_count` caps | a scratch copy of the cap check | scenario 13 fails, because repeated `needs_fixes` results on one unchanged head collapse under that function's `unique` bucketing by `head_sha` + `result` and neither cap ever trips; restoring the dedicated counter escalates with `expensive_gate_deferral_cap` |
 
-Record all six in the implementation PR under a `Planted-Violation Proofs`
+Record all seven in the implementation PR under a `Planted-Violation Proofs`
 heading, each with the command, the file and line of the planted violation, and
 both outcomes.
 
@@ -386,7 +433,8 @@ with mock `gh` commands and require no network access.
       order-independence of condition 2, the head binding of conditions 3 and 4,
       the fail-closed rule, the `deferred` outcome setting the aggregate to
       `needs_fixes` so readiness is withheld and Step 7 re-runs, the
-      `no_local_prefilter` dispatch path, and the override variable.
+      bounded deferral counter and its escalation, the reordering of expensive
+      reviewers to the end of the platform list, and the override variable.
 - [ ] `docs/workflow/development-workflow/integrations/codex-github.md` — add a
       section describing the gate, its conditions, and the override, so the
       gate is discoverable from the reviewer's own integration page rather than
@@ -401,13 +449,15 @@ with mock `gh` commands and require no network access.
 
 | Risk | Likelihood | Impact | Mitigation |
 | --- | --- | --- | --- |
-| The gate silently stops `codex-github` from ever running | Med | High — the expensive reviewer's findings are the reason this epic exists; losing them entirely is worse than running it too often | A defer is never terminal: it sets the aggregate to `needs_fixes` / `expensive_gate_deferred`, so readiness is withheld and Protocol 91 re-runs Step 7 rather than accepting a run in which the reviewer never executed. Every defer emits `EXPENSIVE_GATE_RESULT=deferred` with one named reason in both the summary comment and the ledger, and a repository with no local reviewer dispatches with `no_local_prefilter` instead of deferring, so no downstream consumer can be held forever. Scenario 3 pins the withheld readiness and scenario 5 the no-local-reviewer path |
+| The gate silently stops `codex-github` from ever running | Med | High — the expensive reviewer's findings are the reason this epic exists; losing them entirely is worse than running it too often | A defer is never terminal and never unbounded: it sets the aggregate to `needs_fixes` / `expensive_gate_deferred` so readiness is withheld and Step 7 re-runs, and a head-scoped counter escalates with `expensive_gate_deferral_cap` after `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` deferrals so a stuck gate reaches a human. Every defer names one reason in both the summary comment and the ledger, and `EXPENSIVE_GATE_DEFERRALS` shows the distance to the cap before it trips. Scenarios 3, 13 and 14 pin the three halves |
+| A deferral loop is invisible to the existing cycle caps | Med | High — the gate could cycle indefinitely on one unchanged head with neither cap advancing | `reviewer_loop_history_entries_count` buckets qualifying entries `unique` over `head_sha + "\|" + result`, so repeated `needs_fixes` on one head counts once; the plan therefore adds its own occurrence-counted, head-scoped deferral counter rather than relying on those caps, and proof P7 plants the reliance to demonstrate that it does not bound anything |
+| A consumer that never configures a local reviewer is blocked forever | Med | High — downstream template consumers would stall | The brief requires fail-closed on missing local evidence, so the gate defers rather than inventing an implicit dispatch. The release valves are explicit: the deferral cap escalates to a human after a bounded number of tries, and `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS` covers a one-off run. Scenario 5 pins the defer and scenario 13 the escalation |
 | The gate is defined but never consulted, leaving behavior unchanged | Med | High — the item would appear complete while changing nothing | The call site is in the per-platform block immediately before `run_platform_review`, and proof P4 deletes that call outright and requires scenario 3 to fail — a gate that is not wired in cannot pass its own proof |
 | Fail-closed on unreadable evidence turns a transient API blip into a permanent defer | Med | Med | A defer is per-invocation, not sticky: the `needs_fixes` aggregate makes Protocol 91 re-run Step 7, which re-evaluates from scratch, and the existing dual cycle caps bound how many invocations happen. The gate adds no retry path of its own, so it cannot loop |
 | The gate contradicts the existing phase mechanism | Med | High — two gates disagreeing on whether a platform runs is worse than either alone | Composition is specified explicitly (phase gate first, then this gate; `--pre-after-clean-only` filters before both) and pinned by scenarios 13 and 14, including the no-phantom-telemetry case |
 | Implementation starts before #1648 lands and wires the gate to keys that do not exist | Med | High — the gate would read unset variables and hold everything, or be written against a guessed contract | Recorded as a Conflict in the Cross-Cutting check and as Implementation Order step 0, which is a hard stop that verifies #1648 is merged into the approved base before any edit |
 | A reviewer's own check gates that reviewer | Low | Med — `codex-github` would wait on a check it is responsible for producing | Condition 4 evaluates non-reviewer checks only, reusing the reviewer/baseline classification `pr-ci-loop.sh` already emits rather than a new one; scenario 9's third case pins it |
-| Platform ordering decides whether the gate is effective | Med | High — a config listing `codex-github` first would dispatch it before the cheap reviewers ran, silently defeating the item | Condition 2 compares against the full resolved platform list rather than the platforms encountered so far, and defers with `peer_reviewer_not_run` for any that has not run; scenario 6 pins the reordered configuration |
+| Platform ordering decides whether the gate is effective | Med | High — a config listing `codex-github` first would either dispatch it before the cheap reviewers ran, or defer at the same point forever | Detection is not enough, so the loop reorders: `reorder_expensive_reviewers_last` moves expensive platforms to the end before iteration, making the gate's precondition reachable; condition 2 still compares against the full resolved list, so `peer_reviewer_not_run` fires as a defensive assertion if the reorder did not happen. Scenarios 6 and 7 and proof P5 pin both halves |
 | Thread and CI evidence describes a newer commit than the reviewer verdicts | Med | High — dispatch would be authorized on an inconsistent mix of two heads | Conditions 3 and 4 require the live head returned with their queries to equal `loop_head_sha`, and defer with `evidence_head_moved` otherwise; scenario 10 pins it |
 
 ---
@@ -431,16 +481,16 @@ expensive_reviewer_gate() {
   local platform="$2"
   local head_sha="$3"
   local reason=""
-  local dispatch_reason=""
+  local deferrals
 
   if [ -z "$head_sha" ]; then
     reason="evidence_unavailable_head"
   elif [ -z "${LOCAL_AI_CONFIGURED:-}" ]; then
     reason="local_evidence_missing"
   elif [ "$LOCAL_AI_CONFIGURED" = "0" ]; then
-    # No cheap pre-filter exists in this repository. Dispatch rather than defer
-    # forever, but record the reduced gating.
-    dispatch_reason="no_local_prefilter"
+    # No current-head local evidence exists. The brief requires fail-closed
+    # here; the deferral cap and the explicit override are the release valves.
+    reason="local_reviewer_not_configured"
   elif [ "${LOCAL_AI_HEAD_CURRENT:-}" = "0" ]; then
     reason="local_evidence_stale"
   elif [ -z "${LOCAL_AI_HEAD_CURRENT:-}" ]; then
@@ -449,14 +499,24 @@ expensive_reviewer_gate() {
   # Conditions 2-4 follow, each appending its own reason and each comparing the
   # live head returned by its query against "$head_sha" before trusting it.
 
+  # Occurrences, not uniques, and scoped to this head — the existing cycle
+  # caps bucket needs_fixes uniquely by head+result and so cannot bound a
+  # deferral loop on an unchanged head.
+  deferrals="$(expensive_gate_deferral_count "$head_sha")"
+
   print_kv EXPENSIVE_GATE_PLATFORM "$platform"
   print_kv EXPENSIVE_GATE_HEAD "$head_sha"
   print_kv EXPENSIVE_GATE_REASON "$reason"
-  print_kv EXPENSIVE_GATE_DISPATCH_REASON "$dispatch_reason"
+  print_kv EXPENSIVE_GATE_DEFERRALS "$deferrals"
   if [ -n "$reason" ]; then
     if [ "${PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS:-0}" = "1" ]; then
       print_kv EXPENSIVE_GATE_RESULT forced
       return 0
+    fi
+    if [ "$deferrals" -ge "${PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS:-3}" ]; then
+      # Stop cycling; escalate so a human sees which condition kept failing.
+      print_kv EXPENSIVE_GATE_RESULT deferral_cap
+      return 1
     fi
     print_kv EXPENSIVE_GATE_RESULT deferred
     return 1
@@ -488,53 +548,67 @@ Summary-comment line, illustrative:
 1. Add `EXPENSIVE_REVIEWER_PLATFORMS` and `is_expensive_reviewer_platform` near
    the existing `is_phase_after_clean_platform` helper. **Verify**: source with
    `HARNESS_MODE=1` and confirm scenario 1's matches and non-matches.
-2. Add `expensive_reviewer_gate` with the conditions in the documented order,
-   the `no_local_prefilter` dispatch branch, the full-platform-list comparison
-   for condition 2, the live-head comparison for conditions 3 and 4, and the
-   fail-closed branch for every unreadable input. **Verify**: drive the
-   condition fixture and confirm each unmet condition yields its single named
-   reason, and that the reordered-platform case defers with
-   `peer_reviewer_not_run`.
-3. Wire the gate into the per-platform block immediately before
-   `run_platform_review`, guarded by `is_expensive_reviewer_platform`, and make
-   a `deferred` result set the aggregate to `needs_fixes` with
-   `REASON=expensive_gate_deferred`. **Verify**: scenario 3 shows
-   `run_platform_review` is not called and the aggregate is `needs_fixes`.
-4. Add the override branch, confirm the reason survives it, and confirm a
+2. Add `reorder_expensive_reviewers_last`, called once after the platform list
+   is resolved and before iteration, and emit `EXPENSIVE_REVIEWERS_REORDERED`
+   when it changed the order. **Verify**: scenario 6 — a list declaring
+   `codex-github` first ends with it last, relative order is otherwise
+   preserved, and an already-correct list is untouched with the flag unset.
+3. Add `expensive_gate_deferral_count`, reading occurrences of
+   `expensive_gate.result == "deferred"` scoped to `expensive_gate.head` from
+   the ledger. **Verify**: scenarios 13 and 14 — the count reflects only the
+   current head.
+4. Add `expensive_reviewer_gate` with the conditions in the documented order,
+   the full-platform-list comparison for condition 2, the live-head comparison
+   for conditions 3 and 4, the fail-closed branch for every unreadable input,
+   and the deferral-cap branch. **Verify**: drive the condition fixture and
+   confirm each unmet condition yields its single named reason, and that the
+   cap escalates rather than deferring a fourth time.
+5. Wire the gate into the per-platform block immediately before
+   `run_platform_review`, guarded by `is_expensive_reviewer_platform`. A
+   `deferred` result sets the aggregate to `needs_fixes` with
+   `REASON=expensive_gate_deferred`; a `deferral_cap` result sets it to
+   `escalate` with `REASON=expensive_gate_deferral_cap`. **Verify**: scenario 3
+   shows `run_platform_review` is not called and the aggregate is `needs_fixes`;
+   scenario 13 shows the escalation.
+6. Add the override branch, confirm the reason survives it, and confirm a
    `forced` result does **not** set the `needs_fixes` aggregate. **Verify**:
-   scenario 12.
-5. Emit the five `EXPENSIVE_GATE_*` keys and document them in `--help`.
+   scenario 15.
+7. Emit the `EXPENSIVE_GATE_*` keys and `EXPENSIVE_REVIEWERS_REORDERED`, and
+   document them in `--help`.
    **Verify**: run `pr-review-loop.sh --help` and confirm the gate, its
    conditions, the fail-closed rule, the `deferred` aggregate behavior, the
-   `no_local_prefilter` path, and the override variable are described.
-6. Add the summary-comment line and the `expensive_gate` ledger object.
-   **Verify**: build an entry in the harness and confirm the object shape, and
-   that a legacy entry without it still parses (scenario 15).
-7. Update
+   reordering, `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS`, and the override
+   variable are described.
+8. Add the summary-comment line and the `expensive_gate` ledger object
+   (`platform`, `result`, `reason`, `head`). **Verify**: build an entry in the
+   harness and confirm the object shape, that `expensive_gate_deferral_count`
+   reads it back, and that a legacy entry without it still parses
+   (scenario 18).
+9. Update
    `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
    and
    `docs/workflow/development-workflow/integrations/codex-github.md` per
    **Documentation Updates**. **Verify**: both files describe the same four
    conditions, the same fail-closed rule, and the same override variable name.
-8. Add the unit cases to `test-pr-review-loop.sh` and create
-   `test-expensive-reviewer-gate.sh` with both `# covers:` lines.
-   **Verify**: both suites exit 0, and
-   `scripts/development-workflow/select-test-suites.sh` selects the new suite
-   for a change touching only `pr-review-loop.sh`.
-9. Produce the six planted-violation proofs (P1–P6) and record them in the PR
-   under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
-   at a concrete file and line — failing with the violation planted, passing
-   once removed.
-10. Run `shellcheck` on the changed script and `markdownlint-cli2` on the
+10. Add the unit cases to `test-pr-review-loop.sh` and create
+    `test-expensive-reviewer-gate.sh` with both `# covers:` lines.
+    **Verify**: both suites exit 0, and
+    `scripts/development-workflow/select-test-suites.sh` selects the new suite
+    for a change touching only `pr-review-loop.sh`.
+11. Produce the seven planted-violation proofs (P1–P7) and record them in the PR
+    under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
+    at a concrete file and line — failing with the violation planted, passing
+    once removed.
+12. Run `shellcheck` on the changed script and `markdownlint-cli2` on the
     changed protocol document, this plan, and the runbook. **Verify**: both
     tools exit 0.
-11. Add a changelog fragment
+13. Add a changelog fragment
     `changelog.d/1649.changed.expensive-reviewers-after-local-clean.md`
     containing exactly:
 
     ```markdown
-    - **Gate expensive reviewers on current-head local evidence** (#1649): `codex-github` now runs only after the local reviewer, peer reviewers, review threads, and baseline checks are clean on the current head, and holds back fail-closed when that evidence is missing or stale.
+    - **Gate expensive reviewers on current-head local evidence** (#1649): `codex-github` now runs only after the local reviewer, peer reviewers, review threads, and baseline checks are clean on the current head, and defers fail-closed when that evidence is missing or stale.
     ```
 
-12. Update project docs per **Documentation Updates** above (step 7 covers
+14. Update project docs per **Documentation Updates** above (step 9 covers
     them; no other project doc is affected).

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -61,7 +61,8 @@ implementation is ordered.
 | Baseline vs reviewer checks | `grep -n "REVIEWER_CHECKS\|REVIEWER_CHECK_COUNT" scripts/development-workflow/pr-ci-loop.sh` | `pr-ci-loop.sh` already separates reviewer-owned checks from baseline checks and emits `REVIEWER_CHECKS` / `REVIEWER_CHECKS_JSON`, so the gate can reuse that classification rather than inventing one |
 | `codex-github` integration doc exists | `ls docs/workflow/development-workflow/integrations/` | `codex-github.md` is present alongside `local-ai-reviewer.md`, `pr-agent.md`, and `bugbot.md`, so the gate's documentation target already exists and no new file is created |
 | Reviewer-loop protocol target | `grep -c "" docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` | 1142 lines; this is the protocol that documents loop behavior, and is the right home for the gate's normative description |
-| Cycle caps | `grep -n "MAX_CYCLES\|MAX_TOTAL_CYCLES" scripts/development-workflow/pr-review-loop.sh` | Dual caps (`max_cycles` per run, `max_total_cycles` per PR lifetime) already bound retries; the gate must not add a retry path outside them |
+| Cycle caps exist | `grep -n "MAX_CYCLES\|MAX_TOTAL_CYCLES" scripts/development-workflow/pr-review-loop.sh` | Dual caps are present: `max_cycles` per run and `max_total_cycles` per PR lifetime |
+| Cycle caps cannot bound deferrals | `sed -n '7371,7390p' scripts/development-workflow/pr-review-loop.sh` | `reviewer_loop_history_entries_count` reduces qualifying entries with `unique` over `(.head_sha) + "\|" + (.result)` before counting, on both the lifetime and per-run axes. Repeated `needs_fixes` results on one unchanged head — the exact shape of a deferral loop — therefore collapse to a single count and advance neither cap. This is why the gate needs its own occurrence-counted, head-scoped deferral counter rather than reusing these |
 
 ---
 
@@ -176,6 +177,19 @@ Not applicable — this repository ships workflow tooling, not a service.
       failing, so a stuck gate reaches a human instead of cycling silently. The
       counter resets naturally when the head moves, because it is scoped to
       `loop_head_sha`.
+- [ ] **The deferral counter is itself fail-closed.** If the ledger cannot be
+      read or does not parse — the same `unavailable` state
+      `reviewer_loop_history_entries_count` already reports as `-1` — the
+      counter cannot prove the sequence is bounded, so the gate must not defer
+      again on an unproven budget. It escalates immediately with
+      `EXPENSIVE_GATE_RESULT=deferral_cap` and
+      `REASON=expensive_gate_deferral_budget_unreadable`, carrying the
+      condition that triggered the gate, and emits
+      `EXPENSIVE_GATE_DEFERRALS=-1` so the unreadable state is distinguishable
+      from a count of zero. Escalating on an unreadable budget is the
+      conservative choice: a human sees the gate immediately, whereas deferring
+      on an unknown budget is precisely the unbounded loop this counter exists
+      to prevent.
 - [ ] **A repository with no local reviewer defers, it does not dispatch.**
       When `LOCAL_AI_CONFIGURED` is `0` there is no current-head local clean
       evidence, and the brief requires `codex-github` to run *only after* that
@@ -291,7 +305,7 @@ Not applicable — no user interface in this repository.
    defer: the brief requires the expensive reviewer to run only after
    current-head local clean evidence and to fail closed when it is absent. The
    consumer that never configures a local reviewer is released by the deferral
-   cap in scenario 16 or by the override in scenario 12, both explicit.
+   cap in scenario 13 or by the override in scenario 15, both explicit.
 6. `reorder_expensive_reviewers_last` moves `codex-github` to the end of a
    platform list that declared it first, preserves the relative order of the
    remaining platforms, emits `EXPENSIVE_REVIEWERS_REORDERED=1`, and leaves an
@@ -346,10 +360,17 @@ Not applicable — no user interface in this repository.
     `reviewer_loop_history_payload_from_existing` — `v1` backward compatibility,
     same contract as #1648's added fields.
 
+19. The deferral budget is unreadable (the ledger is absent, unparseable, or
+    reports the `unavailable` state) → `EXPENSIVE_GATE_RESULT=deferral_cap`,
+    `REASON=expensive_gate_deferral_budget_unreadable`,
+    `EXPENSIVE_GATE_DEFERRALS=-1`, and the loop escalates. Without this the
+    bounded-deferral guarantee would hold only when the ledger happens to be
+    readable, which is not a guarantee.
+
 **Files**:
 
-- `scripts/development-workflow/tests/test-pr-review-loop.sh` — scenarios 1–14
-  and 18, as new cases in the existing `HARNESS_MODE=1` harness.
+- `scripts/development-workflow/tests/test-pr-review-loop.sh` — scenarios 1–14,
+  18 and 19, as new cases in the existing `HARNESS_MODE=1` harness.
 - `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` — a new
   suite for scenarios 15–17, the override and composition cases, which need
   their own mock scaffolding for the phase and filter paths. It must declare:
@@ -389,8 +410,9 @@ concrete file and line:
 | P5 | Ordering regression: **delete the `reorder_expensive_reviewers_last` call**, leaving a platform list that declares `codex-github` before `pr-agent` | a scratch copy of the platform-resolution block | scenario 6 fails and scenario 7's suppressed-reorder case shows the gate deferring on every invocation with `peer_reviewer_not_run` — a deferral that can never resolve; restoring the call passes |
 | P6 | Readiness regression: make a defer leave the aggregate result unchanged instead of setting `needs_fixes` | a scratch copy of the gate call site | scenario 3's aggregate assertion fails, and a run in which `codex-github` never executed would satisfy Protocol 92's readiness conditions; restoring the `needs_fixes` aggregate passes |
 | P7 | Unbounded-deferral regression: replace the head-scoped deferral counter with the existing `reviewer_loop_history_entries_count` caps | a scratch copy of the cap check | scenario 13 fails, because repeated `needs_fixes` results on one unchanged head collapse under that function's `unique` bucketing by `head_sha` + `result` and neither cap ever trips; restoring the dedicated counter escalates with `expensive_gate_deferral_cap` |
+| P8 | Unreadable-budget regression: make the ledger read fail, and change the counter to treat the failure as a count of zero | the deferral-budget fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | scenario 19 fails, because the gate defers on an unproven budget instead of escalating; restoring the fail-closed branch escalates with `expensive_gate_deferral_budget_unreadable` |
 
-Record all seven in the implementation PR under a `Planted-Violation Proofs`
+Record all eight in the implementation PR under a `Planted-Violation Proofs`
 heading, each with the command, the file and line of the planted violation, and
 both outcomes.
 
@@ -416,10 +438,12 @@ by the same sequential block that already writes `platform_result_tokens`.
 
 | Entity | Values / Scenario | File |
 | --- | --- | --- |
-| Gate condition fixture | A table-driven set of the conditions with each one independently unmet, plus a reordered platform list for the order-independence case, driving scenarios 2–10 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
-| Unreadable-input mocks | Mock `gh` commands that exit non-zero for the threads query and for the check rollup, driving scenario 11 and proof P3 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
-| Composition fixture | A platform list where `codex-github` is both a phase platform and an expensive reviewer, driving scenarios 13 and 14 | inline in `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` |
-| Legacy ledger payload | A `reviewer_loop_history.v1` entry with no `expensive_gate` object, driving scenario 15 | inline heredoc in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Gate condition fixture | A table-driven set of the conditions with each one independently unmet, driving scenarios 2–5 and 8–11 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Platform-order fixture | A resolved list declaring `codex-github` first, and an already-correct list, driving scenarios 6 and 7 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Unreadable-input mocks | Mock `gh` commands that exit non-zero for the threads query and for the check rollup, driving scenario 12 and proof P3 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Deferral-budget fixtures | Ledger payloads carrying `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` `expensive_gate.result=deferred` entries at the current head, one fewer, the same count at a different head, and an unparseable payload — driving scenarios 13, 14 and 19 and proof P7 | inline heredocs in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Composition fixture | A platform list where `codex-github` is both a phase platform and an expensive reviewer, driving scenarios 16 and 17 | inline in `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` |
+| Legacy ledger payload | A `reviewer_loop_history.v1` entry with no `expensive_gate` object, driving scenario 18 | inline heredoc in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 
 No repository fixture files are added; both suites build their fixtures inline
 with mock `gh` commands and require no network access.
@@ -453,7 +477,7 @@ with mock `gh` commands and require no network access.
 | A deferral loop is invisible to the existing cycle caps | Med | High — the gate could cycle indefinitely on one unchanged head with neither cap advancing | `reviewer_loop_history_entries_count` buckets qualifying entries `unique` over `head_sha + "\|" + result`, so repeated `needs_fixes` on one head counts once; the plan therefore adds its own occurrence-counted, head-scoped deferral counter rather than relying on those caps, and proof P7 plants the reliance to demonstrate that it does not bound anything |
 | A consumer that never configures a local reviewer is blocked forever | Med | High — downstream template consumers would stall | The brief requires fail-closed on missing local evidence, so the gate defers rather than inventing an implicit dispatch. The release valves are explicit: the deferral cap escalates to a human after a bounded number of tries, and `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS` covers a one-off run. Scenario 5 pins the defer and scenario 13 the escalation |
 | The gate is defined but never consulted, leaving behavior unchanged | Med | High — the item would appear complete while changing nothing | The call site is in the per-platform block immediately before `run_platform_review`, and proof P4 deletes that call outright and requires scenario 3 to fail — a gate that is not wired in cannot pass its own proof |
-| Fail-closed on unreadable evidence turns a transient API blip into a permanent defer | Med | Med | A defer is per-invocation, not sticky: the `needs_fixes` aggregate makes Protocol 91 re-run Step 7, which re-evaluates from scratch, and the existing dual cycle caps bound how many invocations happen. The gate adds no retry path of its own, so it cannot loop |
+| Fail-closed on unreadable evidence turns a transient API blip into a permanent defer | Med | Med | A defer is per-invocation, not sticky: the `needs_fixes` aggregate makes Protocol 91 re-run Step 7, which re-evaluates from scratch. The bound is the gate's own head-scoped deferral counter, not the existing dual cycle caps — those cannot see a deferral loop, as the Verification Log records — and an unreadable budget escalates rather than deferring again. The gate adds no retry path of its own, so it cannot loop |
 | The gate contradicts the existing phase mechanism | Med | High — two gates disagreeing on whether a platform runs is worse than either alone | Composition is specified explicitly (phase gate first, then this gate; `--pre-after-clean-only` filters before both) and pinned by scenarios 13 and 14, including the no-phantom-telemetry case |
 | Implementation starts before #1648 lands and wires the gate to keys that do not exist | Med | High — the gate would read unset variables and hold everything, or be written against a guessed contract | Recorded as a Conflict in the Cross-Cutting check and as Implementation Order step 0, which is a hard stop that verifies #1648 is merged into the approved base before any edit |
 | A reviewer's own check gates that reviewer | Low | Med — `codex-github` would wait on a check it is responsible for producing | Condition 4 evaluates non-reviewer checks only, reusing the reviewer/baseline classification `pr-ci-loop.sh` already emits rather than a new one; scenario 9's third case pins it |
@@ -555,8 +579,10 @@ Summary-comment line, illustrative:
    preserved, and an already-correct list is untouched with the flag unset.
 3. Add `expensive_gate_deferral_count`, reading occurrences of
    `expensive_gate.result == "deferred"` scoped to `expensive_gate.head` from
-   the ledger. **Verify**: scenarios 13 and 14 — the count reflects only the
-   current head.
+   the ledger, and returning `-1` when the ledger is absent, unparseable, or
+   reports the `unavailable` state. **Verify**: scenarios 13, 14 and 19 — the
+   count reflects only the current head, and an unreadable ledger yields `-1`
+   rather than `0`.
 4. Add `expensive_reviewer_gate` with the conditions in the documented order,
    the full-platform-list comparison for condition 2, the live-head comparison
    for conditions 3 and 4, the fail-closed branch for every unreadable input,
@@ -567,9 +593,10 @@ Summary-comment line, illustrative:
    `run_platform_review`, guarded by `is_expensive_reviewer_platform`. A
    `deferred` result sets the aggregate to `needs_fixes` with
    `REASON=expensive_gate_deferred`; a `deferral_cap` result sets it to
-   `escalate` with `REASON=expensive_gate_deferral_cap`. **Verify**: scenario 3
-   shows `run_platform_review` is not called and the aggregate is `needs_fixes`;
-   scenario 13 shows the escalation.
+   `escalate` with `REASON=expensive_gate_deferral_cap`, or
+   `REASON=expensive_gate_deferral_budget_unreadable` when the counter returned
+   `-1`. **Verify**: scenario 3 shows `run_platform_review` is not called and
+   the aggregate is `needs_fixes`; scenarios 13 and 19 show both escalations.
 6. Add the override branch, confirm the reason survives it, and confirm a
    `forced` result does **not** set the `needs_fixes` aggregate. **Verify**:
    scenario 15.
@@ -595,7 +622,7 @@ Summary-comment line, illustrative:
     **Verify**: both suites exit 0, and
     `scripts/development-workflow/select-test-suites.sh` selects the new suite
     for a change touching only `pr-review-loop.sh`.
-11. Produce the seven planted-violation proofs (P1–P7) and record them in the PR
+11. Produce the eight planted-violation proofs (P1–P8) and record them in the PR
     under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
     at a concrete file and line — failing with the violation planted, passing
     once removed.

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -20,11 +20,13 @@ never review threads, never baseline CI, and it has no notion of a stale local
 clean result. This plan adds a dedicated pre-dispatch gate for `codex-github`
 that requires four current-head conditions — the local reviewer clean and
 current; every reviewer that **precedes** it having produced acceptable evidence
-(a `clean` result, or a `skipped` one whose reason is not a reviewer failure —
-deliberately **not** every `skipped`); zero unresolved non-outdated review
-threads; and green non-reviewer baseline checks — evaluated immediately before
-the platform is dispatched, fail-closed when any input is missing or stale, with
-one explicit documented override for manual escalation.
+(a `clean` result, or a `skipped` one whose reason is a member of a fixed
+allow-list of deliberate policy skips — deliberately **not** every `skipped`,
+and deliberately not "any reason that is not a known failure", which would
+accept unknown and future reasons); zero unresolved non-outdated review threads;
+and a non-empty set of non-reviewer baseline checks, all green — evaluated
+immediately before the platform is dispatched, fail-closed when any input is
+missing or stale, with one explicit documented override for manual escalation.
 A gate that holds the reviewer back **defers** rather than skipping: it sets the
 loop's aggregate to `needs_fixes` so readiness is withheld and Step 7 re-runs,
 which is what makes the deferral guaranteed rather than merely hoped for.

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -851,6 +851,13 @@ with mock `gh` commands and require no network access.
 
 ## Code Samples
 
+The snippet below uses Bash arrays (`EXPENSIVE_REVIEWER_PLATFORMS`,
+`EXPENSIVE_GATE_ACCEPTED_SKIP_REASONS`) and `local` declarations, matching
+`pr-review-loop.sh`'s own `#!/usr/bin/env bash` shebang. It is not portable to
+POSIX `sh`, so its contract is `bash` rather than `bash-zsh`.
+
+<!-- workflow-shell-contract: bash -->
+
 ```bash
 # Illustrative — adapt during implementation.
 EXPENSIVE_REVIEWER_PLATFORMS=(codex-github)

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -119,7 +119,7 @@ Not applicable — this repository ships workflow tooling, not a service.
       | # | Condition | Unmet reason |
       | --- | --- | --- |
       | 1 | `LOCAL_AI_CONFIGURED` is exactly `1` **and** `LOCAL_AI_HEAD_CURRENT` is exactly `1` | `local_reviewer_not_configured` when `LOCAL_AI_CONFIGURED` is `0`; `local_evidence_stale` when `LOCAL_AI_HEAD_CURRENT` is `0`; `local_evidence_missing` when either is empty, unset, or any value other than `0` or `1` |
-      | 2 | **Every** non-expensive platform in the resolved platform list has already run in this invocation **and** produced acceptable peer evidence (see below) | `peer_reviewer_not_run` when one has not run yet; `peer_reviewer_not_clean` when one ran without producing acceptable evidence |
+      | 2 | Every platform in this reviewer's **peer set** (defined below) has already run in this invocation **and** produced acceptable peer evidence | `peer_reviewer_not_run` when one has not run yet; `peer_reviewer_not_clean` when one ran without producing acceptable evidence |
       | 3 | Zero unresolved, non-outdated review threads | `unresolved_threads` |
       | 4 | Every non-reviewer check is `SUCCESS`, `SKIPPED`, or `NEUTRAL` | `baseline_checks_not_green` when one failed; `baseline_checks_pending` when one is still running |
 
@@ -164,12 +164,30 @@ Not applicable — this repository ships workflow tooling, not a service.
       peer defers. Reusing the existing helper means a future change to what
       counts as a reviewer failure updates this gate automatically instead of
       drifting from it.
-- [ ] **Condition 2 compares against the full resolved list**
-      (`platforms[@]` minus the expensive ones), not the results collected up to
-      this index. After reordering, every non-expensive platform has run by the
-      time the gate is consulted, so `peer_reviewer_not_run` is a defensive
-      assertion rather than an expected outcome: if it ever fires, the reorder
-      did not happen and the gate says so instead of silently dispatching.
+- [ ] **Define the peer set as the platforms that precede this reviewer under
+      the reordered list.** It cannot be the whole resolved list: the reorder
+      preserves phase buckets, so a draft-phase `codex-github` necessarily runs
+      before a ready-phase `bugbot`, and requiring every non-expensive platform
+      to have run would make that documented configuration defer with
+      `peer_reviewer_not_run` on every invocation until the cap — deadlocking
+      exactly the configuration scenario 6b exists to support. The peer set is
+      therefore:
+
+      - every non-expensive platform in the **same** phase bucket as this
+        expensive reviewer, plus
+      - **every** platform in any earlier bucket (a ready-phase expensive
+        reviewer waits on the whole draft bucket, expensive members included,
+        because those have already run by then).
+
+      A draft-phase `codex-github` therefore waits on the non-expensive draft
+      platforms only, and does not wait on `bugbot`. This set is well-defined
+      only *because* of the reorder: after it, "precedes this reviewer" and
+      "should have produced evidence before this reviewer" are the same set.
+      The set is computed from the reordered list and this reviewer's index in
+      it, not from the results collected so far, so `peer_reviewer_not_run`
+      remains a defensive assertion rather than an expected outcome: if it
+      fires, the reorder did not happen and the gate says so instead of silently
+      dispatching.
 - [ ] **Bind conditions 3 and 4 to the same head as the reviewer evidence.**
       Both queries must return the live head alongside their payload, and the
       gate must compare it to `loop_head_sha`. If they differ, the PR moved
@@ -322,7 +340,8 @@ reads them against each other and fails on any divergence.
 
 - [ ] `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
       — document the gate: the conditions and their evaluation order, the
-      order-independence of condition 2, the head binding of conditions 3 and 4,
+      order-independence of condition 2 and how its peer set is scoped by phase
+      bucket, the head binding of conditions 3 and 4,
       the fail-closed rule, the fact that a `deferred` outcome sets the
       aggregate to `needs_fixes` (so readiness is withheld and Step 7 re-runs)
       rather than passing as a clean skip, the reordering of expensive reviewers
@@ -396,10 +415,18 @@ reads them against each other and fails on any divergence.
     `bugbot`. A global partition would place it after `bugbot` and therefore
     after the ready-phase transition, inverting the configuration contract that
     draft reviewers run before `gh pr ready`.
-7. Condition 2 after reordering: with every non-expensive platform run and
-   `clean`, → `dispatched`. With the reorder suppressed so a peer has not run,
-   → `deferred` / `peer_reviewer_not_run` — the defensive assertion firing
-   rather than the gate silently dispatching. Scenario 8 covers what happens
+7. The peer set is scoped by phase, not the whole list:
+
+   | Configuration | Peer set for `codex-github` | Outcome with all peers clean |
+   | --- | --- | --- |
+   | `codex-github` and `pr-agent` both draft; `bugbot` ready | `pr-agent` only — **not** `bugbot` | `dispatched` |
+   | `codex-github` ready; `pr-agent` and `local-ai-reviewer` draft | the whole draft bucket | `dispatched` |
+   | Reorder suppressed so a same-bucket peer has not run | that peer | `deferred` / `peer_reviewer_not_run` |
+
+   The first row is the one a whole-list peer set fails: a draft-phase
+   `codex-github` necessarily runs before a ready-phase `bugbot`, so requiring
+   `bugbot` would defer on every invocation until the cap, deadlocking the
+   configuration scenario 6b exists to support. Scenario 8 covers what happens
    once a peer *has* run.
 8. Peer evidence acceptance, one case per class — distinct from scenario 7's
    `peer_reviewer_not_run`, which is about a peer that has not run at all:
@@ -518,13 +545,14 @@ concrete file and line:
 | P5 | Ordering regression: **delete the `reorder_expensive_reviewers_last` call**, leaving a platform list that declares `codex-github` before `pr-agent` | a scratch copy of the platform-resolution block | scenario 6 fails and scenario 7's suppressed-reorder case shows the gate deferring on every invocation with `peer_reviewer_not_run` — a deferral that can never resolve; restoring the call passes |
 | P9 | Phase-bucket regression: replace the per-bucket partition with a single global one | a scratch copy of `reorder_expensive_reviewers_last` | scenario 6b fails, because a draft-configured `codex-github` is placed after the ready-phase `bugbot` and therefore runs only after `gh pr ready`; restoring the per-bucket partition passes |
 | P10 | Peer-evidence regression: accept any `skipped` peer instead of consulting `reviewer_failed_label_required_for_result` | a scratch copy of condition 2 | scenario 8's `unavailable`, `timeout` and `unauthorized` rows fail, because the gate dispatches with a peer that never produced a verdict; restoring the helper call passes |
+| P13 | Peer-set regression: widen the peer set from the preceding platforms back to every non-expensive platform in the resolved list | a scratch copy of the peer-set computation | scenario 7's first row fails, because a draft-phase `codex-github` waits on a ready-phase `bugbot` that cannot have run yet and defers until the cap; restoring the phase-scoped set passes |
 | P6 | Readiness regression: make a defer leave the aggregate result unchanged instead of setting `needs_fixes` | a scratch copy of the gate call site | scenario 3's aggregate assertion fails, and a run in which `codex-github` never executed would satisfy Protocol 92's readiness conditions; restoring the `needs_fixes` aggregate passes |
 | P7 | Unbounded-deferral regression: replace the head-scoped deferral counter with the existing `reviewer_loop_history_entries_count` caps | a scratch copy of the cap check | scenario 13 fails, because repeated `needs_fixes` results on one unchanged head collapse under that function's `unique` bucketing by `head_sha` + `result` and neither cap ever trips; restoring the dedicated counter escalates with `expensive_gate_deferral_cap` |
 | P8 | Unreadable-budget regression: seed a malformed ledger and change the counter to treat it as a count of zero | the deferral-budget fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | scenario 19 fails, because the gate defers on an unproven budget instead of escalating; restoring the fail-closed branch escalates with `expensive_gate_deferral_budget_unreadable` |
 | P11 | Absent-ledger regression: change the counter to return `-1` for an absent ledger as well as a malformed one | same fixture | scenario 19b fails, because a PR with no prior reviewer-loop history escalates on its first run and the bound is never exercised; restoring the three-state mapping passes |
 | P12 | Deny-list regression: rewrite condition 1 to reject only `0` and empty rather than requiring exactly `1` | a scratch copy of condition 1 | scenario 4's `2` and `true` rows fail, because the gate dispatches with an unrecognized evidence value; restoring the exact-match allow-list passes |
 
-Record all twelve in the implementation PR under a `Planted-Violation Proofs`
+Record all thirteen in the implementation PR under a `Planted-Violation Proofs`
 heading, each with the command, the file and line of the planted violation, and
 both outcomes.
 
@@ -567,7 +595,8 @@ with mock `gh` commands and require no network access.
 
 - [ ] `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
       — document the gate: its conditions and evaluation order, the
-      order-independence of condition 2, the head binding of conditions 3 and 4,
+      order-independence of condition 2 and how its peer set is scoped by phase
+      bucket, the head binding of conditions 3 and 4,
       the fail-closed rule, the `deferred` outcome setting the aggregate to
       `needs_fixes` so readiness is withheld and Step 7 re-runs, the bounded
       deferral counter with both of its escalation values and the
@@ -598,7 +627,8 @@ with mock `gh` commands and require no network access.
 | The gate contradicts the existing phase mechanism | Med | High — two gates disagreeing on whether a platform runs is worse than either alone | Composition is specified explicitly (phase gate first, then this gate; `--pre-after-clean-only` filters before both) and pinned by scenarios 16 and 17, including the no-phantom-telemetry case |
 | Implementation starts before #1648 lands and wires the gate to keys that do not exist | Med | High — the gate would read unset variables and hold everything, or be written against a guessed contract | Recorded as a Conflict in the Cross-Cutting check and as Implementation Order step 0, which is a hard stop that verifies #1648 is merged into the approved base before any edit |
 | A reviewer's own check gates that reviewer | Low | Med — `codex-github` would wait on a check it is responsible for producing | Condition 4 evaluates non-reviewer checks only, reusing the reviewer/baseline classification `pr-ci-loop.sh` already emits rather than a new one; scenario 10's third case pins it |
-| Platform ordering decides whether the gate is effective | Med | High — a config listing `codex-github` first would either dispatch it before the cheap reviewers ran, or defer at the same point forever | Detection is not enough, so the loop reorders: `reorder_expensive_reviewers_last` moves expensive platforms to the end before iteration, making the gate's precondition reachable; condition 2 still compares against the full resolved list, so `peer_reviewer_not_run` fires as a defensive assertion if the reorder did not happen. Scenarios 6 and 7 and proof P5 pin both halves |
+| Platform ordering decides whether the gate is effective | Med | High — a config listing `codex-github` first would either dispatch it before the cheap reviewers ran, or defer at the same point forever | Detection is not enough, so the loop reorders: `reorder_expensive_reviewers_last` moves expensive platforms to the end of their own bucket before iteration, making the gate's precondition reachable; condition 2's peer set is computed from the reordered list, so `peer_reviewer_not_run` fires as a defensive assertion if the reorder did not happen. Scenarios 6 and 7 and proof P5 pin both halves |
+| The peer set and the phase-bucket reorder contradict each other | Med | High — a draft-phase expensive reviewer would wait on a ready-phase peer that cannot have run yet, deadlocking until the cap | The peer set is the platforms that *precede* this reviewer under the reordered list — its own bucket's non-expensive platforms plus every earlier bucket — rather than the whole resolved list; scenario 7's table and proof P13 pin it, including the draft-plus-ready configuration |
 | The reorder silently moves a reviewer across the draft/ready boundary | Med | High — a draft-configured expensive reviewer would run only after `gh pr ready`, inverting the configuration contract | The partition is per phase bucket, assigned with the existing `is_phase_after_clean_platform` predicate, and the buckets are concatenated in their original order; scenario 6b and proof P9 pin it |
 | An unrecognized evidence value falls through condition 1 | Med | High — a `2` or a stray `true` would authorize the expensive reviewer with no valid local-clean evidence, the exact opposite of fail-closed | Condition 1 is an exact-match allow-list requiring the literal `1` on both keys, not a deny-list on `0` and empty; anything else reports `local_evidence_missing`. Scenario 4's eight-row table and proof P12 pin it |
 | A peer that never produced a verdict is accepted as evidence | Med | High — `codex-github` would dispatch with no cheap pre-filter having actually run, which is the state the item exists to prevent | Acceptance delegates to `reviewer_failed_label_required_for_result`, which already classifies `unavailable`, `timeout`, `thread-check-failed`, `pending_timeout`, `forbidden` and `unauthorized` skips as reviewer failures, so only `clean` and deliberate policy skips count; scenario 8's table and proof P10 pin it, and reusing the helper keeps the two definitions from drifting |
@@ -719,7 +749,8 @@ Summary-comment line, illustrative:
    **Verify**: scenarios 13, 14, 19 and 19b — the count reflects only the
    current head, an absent ledger yields `0`, and a malformed one yields `-1`.
 4. Add `expensive_reviewer_gate` with the conditions in the documented order,
-   the full-platform-list comparison for condition 2 delegating acceptance to
+   condition 2 computing the peer set from the reordered list and this
+   reviewer's index in it and delegating acceptance to
    `reviewer_failed_label_required_for_result`, the live-head comparison
    for conditions 3 and 4, the fail-closed branch for every unreadable input,
    and the deferral-cap branch. **Verify**: drive the condition fixture and
@@ -760,7 +791,7 @@ Summary-comment line, illustrative:
     **Verify**: both suites exit 0, and
     `scripts/development-workflow/select-test-suites.sh` selects the new suite
     for a change touching only `pr-review-loop.sh`.
-11. Produce the twelve planted-violation proofs (P1–P12) and record them in the PR
+11. Produce the thirteen planted-violation proofs (P1–P13) and record them in the PR
     under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
     at a concrete file and line — failing with the violation planted, passing
     once removed.

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -228,16 +228,21 @@ Not applicable — this repository ships workflow tooling, not a service.
       deferred — a forced run that later wastes reviewer cycles must be
       traceable to the condition that was overridden. A forced run does not set
       the `needs_fixes` aggregate: the human took the decision explicitly.
-- [ ] Emit gate telemetry on the loop's stdout contract, per expensive platform:
-      `EXPENSIVE_GATE_PLATFORM`, `EXPENSIVE_GATE_RESULT`
-      (`dispatched` | `deferred` | `forced` | `deferral_cap`),
-      `EXPENSIVE_GATE_REASON` (the unmet-condition reason; empty when
-      `dispatched`), `EXPENSIVE_GATE_HEAD` (the `loop_head_sha` the gate
-      evaluated), and `EXPENSIVE_GATE_DEFERRALS` (how many deferrals the ledger
-      already records for this head, so the distance to the cap is visible
-      before it trips). `EXPENSIVE_REVIEWERS_REORDERED` is emitted once per run,
-      not per platform. All values stay inside the `[A-Za-z0-9:_-]` token charset the
-      Protocol 91 carry-forward snippet admits.
+- [ ] Emit gate telemetry on the loop's stdout contract, per expensive
+      platform:
+
+      | Key | Values | Emitted |
+      | --- | --- | --- |
+      | `EXPENSIVE_GATE_PLATFORM` | the platform name | always |
+      | `EXPENSIVE_GATE_RESULT` | `dispatched` \| `deferred` \| `forced` \| `deferral_cap` | always |
+      | `EXPENSIVE_GATE_REASON` | the unmet-condition reason; empty when `dispatched` | always |
+      | `EXPENSIVE_GATE_HEAD` | the `loop_head_sha` the gate evaluated | always |
+      | `EXPENSIVE_GATE_DEFERRALS` | deferrals the ledger records for this head, so the distance to the cap is visible before it trips; `-1` when the ledger could not be read, matching the existing `reviewer_loop_history_entries_count` convention | always |
+      | `EXPENSIVE_GATE_ESCALATION` | `expensive_gate_deferral_cap` \| `expensive_gate_deferral_budget_unreadable` | **only** when `EXPENSIVE_GATE_RESULT` is `deferral_cap`; absent otherwise, so its presence is itself the escalation signal and the two causes never have to be re-derived from the count |
+
+      `EXPENSIVE_REVIEWERS_REORDERED` is emitted once per run, not per platform.
+      All values stay inside the `[A-Za-z0-9:_-]` token charset the Protocol 91
+      carry-forward snippet admits.
 - [ ] Record the gate outcome in the reviewer-loop summary comment as an
       `**Expensive reviewer gate:**` line, and in the `reviewer_loop_history.v1`
       entry as an `expensive_gate` object (`platform`, `result`, `reason`,
@@ -246,7 +251,10 @@ Not applicable — this repository ships workflow tooling, not a service.
       `reviewed_heads`.
 - [ ] Document the gate in the `--help` usage block: its conditions and their
       evaluation order, its fail-closed rule, the `deferred` aggregate
-      behavior, the bounded deferral counter and its escalation, the
+      behavior, the bounded deferral counter with both of its escalation values
+      (`expensive_gate_deferral_cap` and
+      `expensive_gate_deferral_budget_unreadable`) and the fact that
+      `EXPENSIVE_GATE_ESCALATION` appears only on a `deferral_cap` result, the
       reordering of expensive reviewers to the end of the platform list, and
       the override variable.
 
@@ -456,9 +464,11 @@ with mock `gh` commands and require no network access.
       — document the gate: its conditions and evaluation order, the
       order-independence of condition 2, the head binding of conditions 3 and 4,
       the fail-closed rule, the `deferred` outcome setting the aggregate to
-      `needs_fixes` so readiness is withheld and Step 7 re-runs, the
-      bounded deferral counter and its escalation, the reordering of expensive
-      reviewers to the end of the platform list, and the override variable.
+      `needs_fixes` so readiness is withheld and Step 7 re-runs, the bounded
+      deferral counter with both of its escalation values and the
+      `deferral_cap`-only emission of `EXPENSIVE_GATE_ESCALATION`, the
+      reordering of expensive reviewers to the end of the platform list, and the
+      override variable.
 - [ ] `docs/workflow/development-workflow/integrations/codex-github.md` — add a
       section describing the gate, its conditions, and the override, so the
       gate is discoverable from the reviewer's own integration page rather than
@@ -608,12 +618,14 @@ Summary-comment line, illustrative:
 6. Add the override branch, confirm the reason survives it, and confirm a
    `forced` result does **not** set the `needs_fixes` aggregate. **Verify**:
    scenario 15.
-7. Emit the `EXPENSIVE_GATE_*` keys and `EXPENSIVE_REVIEWERS_REORDERED`, and
-   document them in `--help`.
+7. Emit the `EXPENSIVE_GATE_*` keys — including `EXPENSIVE_GATE_ESCALATION`,
+   which is emitted only on a `deferral_cap` result — and
+   `EXPENSIVE_REVIEWERS_REORDERED`, and document them in `--help`.
    **Verify**: run `pr-review-loop.sh --help` and confirm the gate, its
    conditions, the fail-closed rule, the `deferred` aggregate behavior, the
-   reordering, `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS`, and the override
-   variable are described.
+   reordering, `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS`,
+   `EXPENSIVE_GATE_ESCALATION` with both of its values and its
+   `deferral_cap`-only emission, and the override variable are described.
 8. Add the summary-comment line and the `expensive_gate` ledger object
    (`platform`, `result`, `reason`, `head`). **Verify**: build an entry in the
    harness and confirm the object shape, that `expensive_gate_deferral_count`

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -544,9 +544,15 @@ reads them against each other and fails on any divergence.
     draft reviewers run before `gh pr ready`.
 7. The peer set is scoped by phase, not the whole list:
 
+   Every row also configures `local-ai-reviewer` on draft with a current-head
+   `platform_reviewed_heads` entry, so condition 1 is satisfied and the row
+   isolates condition 2. Without that, a row expecting `dispatched` would be
+   internally impossible — condition 1 is evaluated first and would defer with
+   `local_reviewer_not_configured`.
+
    | Configuration | Peer set for `codex-github` | Outcome with all peers clean |
    | --- | --- | --- |
-   | `codex-github` and `pr-agent` both draft; `bugbot` ready | `pr-agent` only — **not** `bugbot` | `dispatched` |
+   | `codex-github`, `pr-agent` and `local-ai-reviewer` all draft; `bugbot` ready | `pr-agent` and `local-ai-reviewer` — **not** `bugbot` | `dispatched` |
    | `codex-github` ready; `pr-agent` and `local-ai-reviewer` draft | the whole draft bucket | `dispatched` |
    | Reorder suppressed so a same-bucket peer has not run | that peer | `deferred` / `peer_reviewer_not_run` |
 

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -311,8 +311,12 @@ Not applicable — this repository ships workflow tooling, not a service.
       `reviewer_loop_resolve_max_cycles` deliberately: two bounds resolvers in
       one script that disagree about what a bad value means is its own defect.
       Resolve once per run, not per gate call, and emit the effective value as
-      `EXPENSIVE_GATE_MAX_DEFERRALS` so the bound in force is visible alongside
-      `EXPENSIVE_GATE_DEFERRALS`.
+      `EXPENSIVE_GATE_MAX_DEFERRALS` on every gate call so the bound in force is
+      visible alongside `EXPENSIVE_GATE_DEFERRALS`. Resolve into a run-scoped
+      `expensive_gate_max_deferrals` variable before the platform iteration and
+      read that variable in the gate; resolving inside the gate would re-emit
+      the `WARN` once per expensive platform and re-parse a value that cannot
+      change within a run.
 - [ ] **The deferral counter is fail-closed only on a genuinely unreadable
       ledger — an absent one is the normal first run.** The counter mirrors the
       three states `reviewer_loop_history_entries_count` already distinguishes,
@@ -833,6 +837,10 @@ with mock `gh` commands and require no network access.
 ```bash
 # Illustrative — adapt during implementation.
 EXPENSIVE_REVIEWER_PLATFORMS=(codex-github)
+EXPENSIVE_GATE_ACCEPTED_SKIP_REASONS=(not_configured explicit-skip release_pr unsupported-platform)
+
+# Resolved ONCE per run, before the platform iteration — not inside the gate.
+expensive_gate_max_deferrals="$(expensive_gate_resolve_max_deferrals)"
 
 is_expensive_reviewer_platform() {
   array_contains_value "$1" "${EXPENSIVE_REVIEWER_PLATFORMS[@]}"
@@ -884,6 +892,8 @@ expensive_reviewer_gate() {
   print_kv EXPENSIVE_GATE_HEAD "$head_sha"
   print_kv EXPENSIVE_GATE_REASON "$reason"
   print_kv EXPENSIVE_GATE_DEFERRALS "$deferrals"
+  # Resolved once per run into expensive_gate_max_deferrals, not per call.
+  print_kv EXPENSIVE_GATE_MAX_DEFERRALS "$expensive_gate_max_deferrals"
   if [ -n "$reason" ]; then
     if [ "${PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS:-0}" = "1" ]; then
       print_kv EXPENSIVE_GATE_RESULT forced
@@ -896,7 +906,7 @@ expensive_reviewer_gate() {
       print_kv EXPENSIVE_GATE_ESCALATION expensive_gate_deferral_budget_unreadable
       return 1
     fi
-    if [ "$deferrals" -ge "$(expensive_gate_resolve_max_deferrals)" ]; then
+    if [ "$deferrals" -ge "$expensive_gate_max_deferrals" ]; then
       # Stop cycling; escalate so a human sees which condition kept failing.
       print_kv EXPENSIVE_GATE_RESULT deferral_cap
       print_kv EXPENSIVE_GATE_ESCALATION expensive_gate_deferral_cap

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -309,6 +309,16 @@ Not applicable — this repository ships workflow tooling, not a service.
       Deferring is cheap — the expensive reviewer runs on the retry the
       `needs_fixes` aggregate forces — while dispatching on unknown evidence is
       the waste this item exists to remove.
+- [ ] **A defer must short-circuit the iteration, not merely set the
+      aggregate.** Setting `needs_fixes` without breaking out would leave the
+      per-platform loop running, so a later ready-phase platform would still
+      reach `ensure_pr_ready_for_ready_phase` and call `gh pr ready` — converting
+      the PR out of draft even though a draft-phase expensive reviewer never
+      ran. That is a visible, hard-to-undo side effect produced by a gate whose
+      whole purpose was to *not* proceed. A `deferred` or `deferral_cap` outcome
+      therefore breaks out of the platform iteration immediately, exactly as the
+      existing non-clean short-circuit does, before any later platform is
+      considered. `forced` and `dispatched` continue normally.
 - [ ] Call the gate from the per-platform block, immediately before
       `run_platform_review`, only when `is_expensive_reviewer_platform` matches.
       It composes with the existing phase mechanism rather than replacing it: a
@@ -529,6 +539,12 @@ reads them against each other and fails on any divergence.
     `EXPENSIVE_GATE_DEFERRALS=-1`, and the loop escalates. Without this the
     bounded-deferral guarantee would hold only when the ledger happens to be
     readable, which is not a guarantee.
+21. A draft-phase defer does not start the ready phase: with `codex-github` on
+    draft deferring and `bugbot` on ready, the loop breaks out immediately —
+    `ensure_pr_ready_for_ready_phase` is not called, `gh pr ready` is not run,
+    the PR stays draft, and no `EXPENSIVE_GATE_*` or phase telemetry is emitted
+    for `bugbot`. Without the short-circuit the gate would produce a visible,
+    hard-to-undo side effect while refusing to proceed.
 20. The relocation is behavior-preserving: `pr-ci-loop.sh` produces identical
     `REVIEWER_CHECK_COUNT`, `REVIEWER_CHECKS` and `REVIEWER_CHECKS_JSON` before
     and after `configured_reviewer_check_names_json` moves to
@@ -553,7 +569,7 @@ reads them against each other and fails on any divergence.
   add `# covers: scripts/development-workflow/workflow-lib.sh` so a later edit
   to the relocated function also selects it.
 - `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` — a new
-  suite for scenarios 15–17, the override and composition cases, which need
+  suite for scenarios 15–17 and 21, the override and composition cases, which need
   their own mock scaffolding for the phase and filter paths. It must declare:
 
   ```text
@@ -591,6 +607,7 @@ concrete file and line:
 | P5 | Ordering regression: **delete the `reorder_expensive_reviewers_last` call**, leaving a platform list that declares `codex-github` before `pr-agent` | a scratch copy of the platform-resolution block | scenario 6 fails and scenario 7's suppressed-reorder case shows the gate deferring on every invocation with `peer_reviewer_not_run` — a deferral that can never resolve; restoring the call passes |
 | P9 | Phase-bucket regression: replace the per-bucket partition with a single global one | a scratch copy of `reorder_expensive_reviewers_last` | scenario 6b fails, because a draft-configured `codex-github` is placed after the ready-phase `bugbot` and therefore runs only after `gh pr ready`; restoring the per-bucket partition passes |
 | P10 | Peer-evidence regression: accept any `skipped` peer instead of consulting `reviewer_failed_label_required_for_result` | a scratch copy of condition 2 | scenario 8's `unavailable`, `timeout` and `unauthorized` rows fail, because the gate dispatches with a peer that never produced a verdict; restoring the helper call passes |
+| P15 | No-short-circuit regression: make a `deferred` result set the aggregate without breaking out of the platform iteration | a scratch copy of the gate call site | scenario 21 fails, because the loop continues to the ready-phase platform and calls `gh pr ready` on a PR whose draft-phase expensive reviewer never ran; restoring the break passes |
 | P14 | Reviewer-check-classification regression: make `expensive_gate_baseline_checks_status` treat every check as a baseline check | a scratch copy of the helper | scenario 10's reviewer-owned-pending row fails, because `codex-github` waits on a check it is responsible for producing; restoring the `configured_reviewer_check_names_json` exclusion passes |
 | P13 | Peer-set regression: widen the peer set from the preceding platforms back to every non-expensive platform in the resolved list | a scratch copy of the peer-set computation | scenario 7's first row fails, because a draft-phase `codex-github` waits on a ready-phase `bugbot` that cannot have run yet and defers until the cap; restoring the phase-scoped set passes |
 | P6 | Readiness regression: make a defer leave the aggregate result unchanged instead of setting `needs_fixes` | a scratch copy of the gate call site | scenario 3's aggregate assertion fails, and a run in which `codex-github` never executed would satisfy Protocol 92's readiness conditions; restoring the `needs_fixes` aggregate passes |
@@ -599,7 +616,7 @@ concrete file and line:
 | P11 | Absent-ledger regression: change the counter to return `-1` for an absent ledger as well as a malformed one | same fixture | scenario 19b fails, because a PR with no prior reviewer-loop history escalates on its first run and the bound is never exercised; restoring the three-state mapping passes |
 | P12 | Deny-list regression: rewrite condition 1 to reject only `0` and empty rather than requiring exactly `1` | a scratch copy of condition 1 | scenario 4's `2` and `true` rows fail, because the gate dispatches with an unrecognized evidence value; restoring the exact-match allow-list passes |
 
-Record all fourteen in the implementation PR under a `Planted-Violation Proofs`
+Record all fifteen in the implementation PR under a `Planted-Violation Proofs`
 heading, each with the command, the file and line of the planted violation, and
 both outcomes.
 
@@ -671,6 +688,7 @@ with mock `gh` commands and require no network access.
 | A consumer that never configures a local reviewer is blocked forever | Med | High — downstream template consumers would stall | The brief requires fail-closed on missing local evidence, so the gate defers rather than inventing an implicit dispatch. The release valves are explicit: the deferral cap escalates to a human after a bounded number of tries, and `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS` covers a one-off run. Scenario 5 pins the defer and scenario 13 the escalation |
 | The gate is defined but never consulted, leaving behavior unchanged | Med | High — the item would appear complete while changing nothing | The call site is in the per-platform block immediately before `run_platform_review`, and proof P4 deletes that call outright and requires scenario 3 to fail — a gate that is not wired in cannot pass its own proof |
 | Fail-closed on unreadable evidence turns a transient API blip into a permanent defer | Med | Med | A defer is per-invocation, not sticky: the `needs_fixes` aggregate makes Protocol 91 re-run Step 7, which re-evaluates from scratch. The bound is the gate's own head-scoped deferral counter, not the existing dual cycle caps — those cannot see a deferral loop, as the Verification Log records — and an unreadable budget escalates rather than deferring again. The gate adds no retry path of its own, so it cannot loop |
+| A defer still triggers the ready-phase transition | Med | High — `gh pr ready` would convert the PR out of draft even though the draft-phase expensive reviewer never ran, a visible side effect from a gate that refused to proceed | A `deferred` or `deferral_cap` outcome breaks out of the platform iteration immediately, exactly as the existing non-clean short-circuit does, so no later platform is considered; scenario 21 and proof P15 pin it |
 | The gate contradicts the existing phase mechanism | Med | High — two gates disagreeing on whether a platform runs is worse than either alone | Composition is specified explicitly (phase gate first, then this gate; `--pre-after-clean-only` filters before both) and pinned by scenarios 16 and 17, including the no-phantom-telemetry case |
 | Implementation starts before #1648 lands and wires the gate to keys that do not exist | Med | High — the gate would read unset variables and hold everything, or be written against a guessed contract | Recorded as a Conflict in the Cross-Cutting check and as Implementation Order step 0, which is a hard stop that verifies #1648 is merged into the approved base before any edit |
 | A reviewer's own check gates that reviewer | Low | Med — `codex-github` would wait on a check it is responsible for producing | Condition 4 evaluates non-reviewer checks only, excluding the names returned by `configured_reviewer_check_names_json`, which moves from `pr-ci-loop.sh` to `workflow-lib.sh` so both callers share one definition rather than two drifting copies; scenario 10's third case and proof P14 pin it |
@@ -816,8 +834,11 @@ Summary-comment line, illustrative:
    `REASON=expensive_gate_deferred`; a `deferral_cap` result sets it to
    `escalate` with `REASON=expensive_gate_deferral_cap`, or
    `REASON=expensive_gate_deferral_budget_unreadable` when the counter returned
-   `-1`. **Verify**: scenario 3 shows `run_platform_review` is not called and
-   the aggregate is `needs_fixes`; scenarios 13 and 19 show both escalations.
+   `-1`. Both **break out of the platform iteration** so no later platform is
+   considered. **Verify**: scenario 3 shows `run_platform_review` is not called
+   and the aggregate is `needs_fixes`; scenarios 13 and 19 show both
+   escalations; scenario 21 shows `gh pr ready` is not called after a
+   draft-phase defer.
 6. Add the override branch, confirm the reason survives it, and confirm a
    `forced` result does **not** set the `needs_fixes` aggregate. **Verify**:
    scenario 15.
@@ -845,7 +866,7 @@ Summary-comment line, illustrative:
     **Verify**: both suites exit 0, and
     `scripts/development-workflow/select-test-suites.sh` selects the new suite
     for a change touching only `pr-review-loop.sh`.
-11. Produce the fourteen planted-violation proofs (P1–P14) and record them in the PR
+11. Produce the fifteen planted-violation proofs (P1–P15) and record them in the PR
     under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
     at a concrete file and line — failing with the violation planted, passing
     once removed.

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -118,7 +118,7 @@ Not applicable — this repository ships workflow tooling, not a service.
 
       | # | Condition | Unmet reason |
       | --- | --- | --- |
-      | 1 | `LOCAL_AI_CONFIGURED` is `1` and `LOCAL_AI_HEAD_CURRENT` is `1` | `local_evidence_stale` when `LOCAL_AI_HEAD_CURRENT` is `0`; `local_evidence_missing` when it is empty or `LOCAL_AI_CONFIGURED` is unset; `local_reviewer_not_configured` when `LOCAL_AI_CONFIGURED` is `0` |
+      | 1 | `LOCAL_AI_CONFIGURED` is exactly `1` **and** `LOCAL_AI_HEAD_CURRENT` is exactly `1` | `local_reviewer_not_configured` when `LOCAL_AI_CONFIGURED` is `0`; `local_evidence_stale` when `LOCAL_AI_HEAD_CURRENT` is `0`; `local_evidence_missing` when either is empty, unset, or any value other than `0` or `1` |
       | 2 | **Every** non-expensive platform in the resolved platform list has already run in this invocation **and** produced acceptable peer evidence (see below) | `peer_reviewer_not_run` when one has not run yet; `peer_reviewer_not_clean` when one ran without producing acceptable evidence |
       | 3 | Zero unresolved, non-outdated review threads | `unresolved_threads` |
       | 4 | Every non-reviewer check is `SUCCESS`, `SKIPPED`, or `NEUTRAL` | `baseline_checks_not_green` when one failed; `baseline_checks_pending` when one is still running |
@@ -234,6 +234,17 @@ Not applicable — this repository ships workflow tooling, not a service.
       bounded number of deferrals rather than blocking forever, and by
       `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS` for a one-off run. Both are
       explicit; neither silently relaxes the gate.
+- [ ] **Condition 1 is an allow-list, not a deny-list.** Both keys are matched
+      against their exact expected value: the condition passes only when
+      `LOCAL_AI_CONFIGURED` is the literal `1` and `LOCAL_AI_HEAD_CURRENT` is
+      the literal `1`. Testing only for `0` and empty would let any unexpected
+      value — a `2` from a future contract change, a stray `true`, a value with
+      trailing whitespace — fall through and authorize the expensive reviewer
+      with no valid local-clean evidence, which is the opposite of fail-closed.
+      Any value that is neither `0` nor `1` is reported as
+      `local_evidence_missing`: it carries no more information than an absent
+      key, and treating it as its own reason would imply the gate understood it.
+      The same exact-match discipline applies to every token the gate reads.
 - [ ] **Fail closed on every unknown.** If any input cannot be read, the gate
       defers with one of exactly three reasons — there is no generic unknown
       state:
@@ -348,9 +359,24 @@ reads them against each other and fails on any divergence.
    `run_platform_review` is **not** called, and the loop's aggregate becomes
    `needs_fixes` / `expensive_gate_deferred` — the core of brief scope bullet 1,
    and the proof that a defer withholds readiness instead of passing as a skip.
-4. `LOCAL_AI_CONFIGURED` unset → `deferred` / `local_evidence_missing`. The
-   fail-closed case for brief scope bullet 2, pairing with #1648's rule that an
-   absent key is telemetry loss rather than non-applicability.
+4. Unexpected and absent values are equally refused, one case per row — the
+   allow-list check for brief scope bullet 2, pairing with #1648's rule that an
+   absent key is telemetry loss rather than non-applicability:
+
+   | `LOCAL_AI_CONFIGURED` | `LOCAL_AI_HEAD_CURRENT` | Required result |
+   | --- | --- | --- |
+   | unset | `1` | `deferred` / `local_evidence_missing` |
+   | empty | `1` | `deferred` / `local_evidence_missing` |
+   | `2` | `1` | `deferred` / `local_evidence_missing` |
+   | `true` | `1` | `deferred` / `local_evidence_missing` |
+   | `1` | unset | `deferred` / `local_evidence_missing` |
+   | `1` | empty | `deferred` / `local_evidence_missing` |
+   | `1` | `2` | `deferred` / `local_evidence_missing` |
+   | `1` | `yes` | `deferred` / `local_evidence_missing` |
+
+   The `2` and `true` rows are the ones a deny-list implementation fails: they
+   are neither `0` nor empty, so testing only for those would let them through
+   and dispatch the expensive reviewer with no valid evidence.
 5. `LOCAL_AI_CONFIGURED=0` → `deferred` / `local_reviewer_not_configured`.
    Distinct from scenario 4 (`missing` means the telemetry never arrived; this
    means the platform is genuinely not configured), and deliberately still a
@@ -496,8 +522,9 @@ concrete file and line:
 | P7 | Unbounded-deferral regression: replace the head-scoped deferral counter with the existing `reviewer_loop_history_entries_count` caps | a scratch copy of the cap check | scenario 13 fails, because repeated `needs_fixes` results on one unchanged head collapse under that function's `unique` bucketing by `head_sha` + `result` and neither cap ever trips; restoring the dedicated counter escalates with `expensive_gate_deferral_cap` |
 | P8 | Unreadable-budget regression: seed a malformed ledger and change the counter to treat it as a count of zero | the deferral-budget fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | scenario 19 fails, because the gate defers on an unproven budget instead of escalating; restoring the fail-closed branch escalates with `expensive_gate_deferral_budget_unreadable` |
 | P11 | Absent-ledger regression: change the counter to return `-1` for an absent ledger as well as a malformed one | same fixture | scenario 19b fails, because a PR with no prior reviewer-loop history escalates on its first run and the bound is never exercised; restoring the three-state mapping passes |
+| P12 | Deny-list regression: rewrite condition 1 to reject only `0` and empty rather than requiring exactly `1` | a scratch copy of condition 1 | scenario 4's `2` and `true` rows fail, because the gate dispatches with an unrecognized evidence value; restoring the exact-match allow-list passes |
 
-Record all eleven in the implementation PR under a `Planted-Violation Proofs`
+Record all twelve in the implementation PR under a `Planted-Violation Proofs`
 heading, each with the command, the file and line of the planted violation, and
 both outcomes.
 
@@ -523,7 +550,7 @@ by the same sequential block that already writes `platform_result_tokens`.
 
 | Entity | Values / Scenario | File |
 | --- | --- | --- |
-| Gate condition fixture | A table-driven set of the conditions with each one independently unmet, driving scenarios 2–5 and 9–11 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Gate condition fixture | A table-driven set of the conditions with each one independently unmet, plus the eight-row unexpected-value table for condition 1, driving scenarios 2–5 and 9–11 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Platform-order fixture | A resolved list declaring `codex-github` first, an already-correct list, and a two-bucket list with `codex-github` on draft and `bugbot` on ready — driving scenarios 6, 6b and 7 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Peer-evidence fixture | One peer per row of scenario 8's table, covering `clean`, the three accepted skip reasons, the three rejected skip reasons, `needs_fixes` and `escalate` | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Unreadable-input mocks | Mock `gh` commands that exit non-zero for the threads query and for the check rollup, driving scenario 12 and proof P3 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
@@ -573,6 +600,7 @@ with mock `gh` commands and require no network access.
 | A reviewer's own check gates that reviewer | Low | Med — `codex-github` would wait on a check it is responsible for producing | Condition 4 evaluates non-reviewer checks only, reusing the reviewer/baseline classification `pr-ci-loop.sh` already emits rather than a new one; scenario 10's third case pins it |
 | Platform ordering decides whether the gate is effective | Med | High — a config listing `codex-github` first would either dispatch it before the cheap reviewers ran, or defer at the same point forever | Detection is not enough, so the loop reorders: `reorder_expensive_reviewers_last` moves expensive platforms to the end before iteration, making the gate's precondition reachable; condition 2 still compares against the full resolved list, so `peer_reviewer_not_run` fires as a defensive assertion if the reorder did not happen. Scenarios 6 and 7 and proof P5 pin both halves |
 | The reorder silently moves a reviewer across the draft/ready boundary | Med | High — a draft-configured expensive reviewer would run only after `gh pr ready`, inverting the configuration contract | The partition is per phase bucket, assigned with the existing `is_phase_after_clean_platform` predicate, and the buckets are concatenated in their original order; scenario 6b and proof P9 pin it |
+| An unrecognized evidence value falls through condition 1 | Med | High — a `2` or a stray `true` would authorize the expensive reviewer with no valid local-clean evidence, the exact opposite of fail-closed | Condition 1 is an exact-match allow-list requiring the literal `1` on both keys, not a deny-list on `0` and empty; anything else reports `local_evidence_missing`. Scenario 4's eight-row table and proof P12 pin it |
 | A peer that never produced a verdict is accepted as evidence | Med | High — `codex-github` would dispatch with no cheap pre-filter having actually run, which is the state the item exists to prevent | Acceptance delegates to `reviewer_failed_label_required_for_result`, which already classifies `unavailable`, `timeout`, `thread-check-failed`, `pending_timeout`, `forbidden` and `unauthorized` skips as reviewer failures, so only `clean` and deliberate policy skips count; scenario 8's table and proof P10 pin it, and reusing the helper keeps the two definitions from drifting |
 | Thread and CI evidence describes a newer commit than the reviewer verdicts | Med | High — dispatch would be authorized on an inconsistent mix of two heads | Conditions 3 and 4 require the live head returned with their queries to equal `loop_head_sha`, and defer with `evidence_head_moved` otherwise; scenario 11 pins it |
 
@@ -601,15 +629,17 @@ expensive_reviewer_gate() {
 
   if [ -z "$head_sha" ]; then
     reason="evidence_unavailable_head"
-  elif [ -z "${LOCAL_AI_CONFIGURED:-}" ]; then
-    reason="local_evidence_missing"
-  elif [ "$LOCAL_AI_CONFIGURED" = "0" ]; then
+  elif [ "${LOCAL_AI_CONFIGURED:-}" = "0" ]; then
     # No current-head local evidence exists. The brief requires fail-closed
     # here; the deferral cap and the explicit override are the release valves.
     reason="local_reviewer_not_configured"
+  elif [ "${LOCAL_AI_CONFIGURED:-}" != "1" ]; then
+    # Allow-list, not deny-list: anything that is not exactly 0 or 1 is as
+    # uninformative as an absent key, so it must not fall through.
+    reason="local_evidence_missing"
   elif [ "${LOCAL_AI_HEAD_CURRENT:-}" = "0" ]; then
     reason="local_evidence_stale"
-  elif [ -z "${LOCAL_AI_HEAD_CURRENT:-}" ]; then
+  elif [ "${LOCAL_AI_HEAD_CURRENT:-}" != "1" ]; then
     reason="local_evidence_missing"
   fi
   # Conditions 2-4 follow, each appending its own reason and each comparing the
@@ -730,7 +760,7 @@ Summary-comment line, illustrative:
     **Verify**: both suites exit 0, and
     `scripts/development-workflow/select-test-suites.sh` selects the new suite
     for a change touching only `pr-review-loop.sh`.
-11. Produce the eleven planted-violation proofs (P1–P11) and record them in the PR
+11. Produce the twelve planted-violation proofs (P1–P12) and record them in the PR
     under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
     at a concrete file and line — failing with the violation planted, passing
     once removed.

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -441,7 +441,7 @@ by the same sequential block that already writes `platform_result_tokens`.
 | Gate condition fixture | A table-driven set of the conditions with each one independently unmet, driving scenarios 2–5 and 8–11 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Platform-order fixture | A resolved list declaring `codex-github` first, and an already-correct list, driving scenarios 6 and 7 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Unreadable-input mocks | Mock `gh` commands that exit non-zero for the threads query and for the check rollup, driving scenario 12 and proof P3 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
-| Deferral-budget fixtures | Ledger payloads carrying `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` `expensive_gate.result=deferred` entries at the current head, one fewer, the same count at a different head, and an unparseable payload — driving scenarios 13, 14 and 19 and proof P7 | inline heredocs in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Deferral-budget fixtures | Ledger payloads carrying `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` `expensive_gate.result=deferred` entries at the current head, one fewer, the same count at a different head, and an unparseable payload — driving scenarios 13, 14 and 19 and proofs P7 and P8 | inline heredocs in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Composition fixture | A platform list where `codex-github` is both a phase platform and an expensive reviewer, driving scenarios 16 and 17 | inline in `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` |
 | Legacy ledger payload | A `reviewer_loop_history.v1` entry with no `expensive_gate` object, driving scenario 18 | inline heredoc in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 
@@ -478,11 +478,11 @@ with mock `gh` commands and require no network access.
 | A consumer that never configures a local reviewer is blocked forever | Med | High — downstream template consumers would stall | The brief requires fail-closed on missing local evidence, so the gate defers rather than inventing an implicit dispatch. The release valves are explicit: the deferral cap escalates to a human after a bounded number of tries, and `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS` covers a one-off run. Scenario 5 pins the defer and scenario 13 the escalation |
 | The gate is defined but never consulted, leaving behavior unchanged | Med | High — the item would appear complete while changing nothing | The call site is in the per-platform block immediately before `run_platform_review`, and proof P4 deletes that call outright and requires scenario 3 to fail — a gate that is not wired in cannot pass its own proof |
 | Fail-closed on unreadable evidence turns a transient API blip into a permanent defer | Med | Med | A defer is per-invocation, not sticky: the `needs_fixes` aggregate makes Protocol 91 re-run Step 7, which re-evaluates from scratch. The bound is the gate's own head-scoped deferral counter, not the existing dual cycle caps — those cannot see a deferral loop, as the Verification Log records — and an unreadable budget escalates rather than deferring again. The gate adds no retry path of its own, so it cannot loop |
-| The gate contradicts the existing phase mechanism | Med | High — two gates disagreeing on whether a platform runs is worse than either alone | Composition is specified explicitly (phase gate first, then this gate; `--pre-after-clean-only` filters before both) and pinned by scenarios 13 and 14, including the no-phantom-telemetry case |
+| The gate contradicts the existing phase mechanism | Med | High — two gates disagreeing on whether a platform runs is worse than either alone | Composition is specified explicitly (phase gate first, then this gate; `--pre-after-clean-only` filters before both) and pinned by scenarios 16 and 17, including the no-phantom-telemetry case |
 | Implementation starts before #1648 lands and wires the gate to keys that do not exist | Med | High — the gate would read unset variables and hold everything, or be written against a guessed contract | Recorded as a Conflict in the Cross-Cutting check and as Implementation Order step 0, which is a hard stop that verifies #1648 is merged into the approved base before any edit |
-| A reviewer's own check gates that reviewer | Low | Med — `codex-github` would wait on a check it is responsible for producing | Condition 4 evaluates non-reviewer checks only, reusing the reviewer/baseline classification `pr-ci-loop.sh` already emits rather than a new one; scenario 9's third case pins it |
+| A reviewer's own check gates that reviewer | Low | Med — `codex-github` would wait on a check it is responsible for producing | Condition 4 evaluates non-reviewer checks only, reusing the reviewer/baseline classification `pr-ci-loop.sh` already emits rather than a new one; scenario 10's third case pins it |
 | Platform ordering decides whether the gate is effective | Med | High — a config listing `codex-github` first would either dispatch it before the cheap reviewers ran, or defer at the same point forever | Detection is not enough, so the loop reorders: `reorder_expensive_reviewers_last` moves expensive platforms to the end before iteration, making the gate's precondition reachable; condition 2 still compares against the full resolved list, so `peer_reviewer_not_run` fires as a defensive assertion if the reorder did not happen. Scenarios 6 and 7 and proof P5 pin both halves |
-| Thread and CI evidence describes a newer commit than the reviewer verdicts | Med | High — dispatch would be authorized on an inconsistent mix of two heads | Conditions 3 and 4 require the live head returned with their queries to equal `loop_head_sha`, and defer with `evidence_head_moved` otherwise; scenario 10 pins it |
+| Thread and CI evidence describes a newer commit than the reviewer verdicts | Med | High — dispatch would be authorized on an inconsistent mix of two heads | Conditions 3 and 4 require the live head returned with their queries to equal `loop_head_sha`, and defer with `evidence_head_moved` otherwise; scenario 11 pins it |
 
 ---
 
@@ -537,9 +537,17 @@ expensive_reviewer_gate() {
       print_kv EXPENSIVE_GATE_RESULT forced
       return 0
     fi
+    if [ "$deferrals" -eq -1 ]; then
+      # The budget is unreadable, so the sequence cannot be proven bounded.
+      # Escalate rather than defer on an unknown budget.
+      print_kv EXPENSIVE_GATE_RESULT deferral_cap
+      print_kv EXPENSIVE_GATE_ESCALATION expensive_gate_deferral_budget_unreadable
+      return 1
+    fi
     if [ "$deferrals" -ge "${PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS:-3}" ]; then
       # Stop cycling; escalate so a human sees which condition kept failing.
       print_kv EXPENSIVE_GATE_RESULT deferral_cap
+      print_kv EXPENSIVE_GATE_ESCALATION expensive_gate_deferral_cap
       return 1
     fi
     print_kv EXPENSIVE_GATE_RESULT deferred

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -1,0 +1,459 @@
+# Run Expensive Reviewers Only After Local Clean Evidence — Implementation Plan
+
+**Spec**: None — Refactor item. Source brief:
+[issue #1649](https://github.com/lhpaul/ai-dev-framework-template/issues/1649)
+(epic [#1647](https://github.com/lhpaul/ai-dev-framework-template/issues/1647))
+**Smoke test runbook**:
+[1649-expensive-reviewers-after-local-clean.smoke-test.md](../../../testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: The reviewer loop already has a phase mechanism —
+`phase_after_clean_platforms` (alias `ready_phase_platforms`) — that holds a
+platform back until the loop reaches it, and the loop breaks out before that
+point when an earlier platform returns non-clean. What the phase gate does *not*
+check is whether the accumulated evidence is (a) about the current head and
+(b) complete: it evaluates only earlier reviewer verdicts from this same run,
+never review threads, never baseline CI, and it has no notion of a stale local
+clean result. This plan adds a dedicated pre-dispatch gate for `codex-github`
+that requires four current-head conditions — local reviewer clean and current,
+PR-Agent clean, zero unresolved review threads, and green non-reviewer baseline
+checks — evaluated immediately before the platform is dispatched, fail-closed
+when any input is missing or stale, with one explicit documented override for
+manual escalation.
+
+**Estimated complexity**: L
+
+**Rationale**: The gate itself is a bounded addition, but it sits on the loop's
+hottest control path, must compose with three existing mechanisms that already
+decide whether a platform runs (`phase_after_clean`, `--pre-after-clean-only`,
+and the cycle caps), and it consumes evidence that sibling item #1648
+introduces. Getting the composition wrong either makes the gate inert or
+silently stops `codex-github` from ever running, and both failures are invisible
+in a green check rollup.
+
+**Dependencies**: **#1648 must be merged to
+`develop-internal-reviewer-effectiveness` before this item's implementation
+PR opens.** This plan consumes `LOCAL_AI_CONFIGURED` and
+`LOCAL_AI_HEAD_CURRENT`, which #1648 introduces, and the fail-closed semantics
+this gate applies to a missing `LOCAL_AI_CONFIGURED` are the ones #1648 defines.
+The plan PRs are independent and may be reviewed in parallel; only the
+implementation is ordered.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short HEAD` | `7998d43d` (base `develop-internal-reviewer-effectiveness`) |
+| Phase mechanism exists | `grep -n "phase_after_clean_platforms\|append_ready_phase_platforms" scripts/development-workflow/pr-review-loop.sh` | `append_ready_phase_platforms` delegates to `append_phase_after_clean_platforms`; `is_phase_after_clean_platform` decides membership; the ready-phase list is emitted as `READY_PHASE_PLATFORM_LIST` |
+| Phase gate contents | `sed -n '8576,8616p' scripts/development-workflow/pr-review-loop.sh` | Before the first phase platform runs, the loop calls `ensure_pr_ready_for_ready_phase` and nothing else; that function only reads `isDraft` and runs `gh pr ready` |
+| Gate checks no evidence | `sed -n '6211,6256p' scripts/development-workflow/pr-review-loop.sh` | `ensure_pr_ready_for_ready_phase` inspects draft state and the rate limit only — no head SHA, no review threads, no CI, no reviewer verdicts |
+| Non-clean short-circuit is per-run | Observed on PR #1660: a cycle where `local-ai-reviewer` returned `needs_fixes` emitted `READY_PHASE_SKIP_REASON=needs_fixes` and `PHASE_AFTER_CLEAN_STARTED=0`; a later clean cycle emitted `PHASE_AFTER_CLEAN_STARTED=1` | The existing hold-back works, but it is decided entirely by verdicts collected within the same invocation |
+| `codex-github` dispatch path | `grep -n "codex-github" scripts/development-workflow/pr-review-loop.sh` | Dispatched via `run_codex_github_review` at the `codex-github)` case of `run_platform_review`; `codex_github_defaults_should_apply` already tests membership with `array_contains_value` |
+| `codex-github` is not configured here | `sed -n '/^review:/,/^ *guardrails:/p' .ai-dev-workflow.yaml` | This repository's `on_draft.github` is `local-ai-reviewer, pr-agent` and `on_ready.github` is `bugbot`; `codex-github` appears in neither, so the gate must be inert-by-absence here and exercised through harness fixtures |
+| Evidence keys come from #1648 | `gh pr view 1660 --json state --jq .state` and the plan on that PR | `LOCAL_AI_CONFIGURED` / `LOCAL_AI_HEAD_CURRENT` are defined by #1648, whose plan PR #1660 is `ready-for-human-review` and not yet merged |
+| Baseline vs reviewer checks | `grep -n "REVIEWER_CHECKS\|REVIEWER_CHECK_COUNT" scripts/development-workflow/pr-ci-loop.sh` | `pr-ci-loop.sh` already separates reviewer-owned checks from baseline checks and emits `REVIEWER_CHECKS` / `REVIEWER_CHECKS_JSON`, so the gate can reuse that classification rather than inventing one |
+| `codex-github` integration doc exists | `ls docs/workflow/development-workflow/integrations/` | `codex-github.md` is present alongside `local-ai-reviewer.md`, `pr-agent.md`, and `bugbot.md`, so the gate's documentation target already exists and no new file is created |
+| Reviewer-loop protocol target | `grep -c "" docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` | 1142 lines; this is the protocol that documents loop behavior, and is the right home for the gate's normative description |
+| Cycle caps | `grep -n "MAX_CYCLES\|MAX_TOTAL_CYCLES" scripts/development-workflow/pr-review-loop.sh` | Dual caps (`max_cycles` per run, `max_total_cycles` per PR lifetime) already bound retries; the gate must not add a retry path outside them |
+
+---
+
+## Cross-Cutting Operational Assumption Check
+
+### Applicable
+
+| Assumption surface | Recorded value | Authoritative source | Verified at | Bounded cross-check scope | Result |
+| --- | --- | --- | --- | --- | --- |
+| Approved base branch for this item | `develop-internal-reviewer-effectiveness` | `integration-branch:internal-reviewer-effectiveness` label on #1649; Protocol 91 § Integration-branch base override | 2026-08-27, repo SHA `7998d43d` | Epic #1647 items #1648–#1657; the only other open PR on this base is #1660 (#1648's plan) | `Verified` |
+| Source of the current-head local evidence | `LOCAL_AI_CONFIGURED` / `LOCAL_AI_HEAD_CURRENT` from #1648 | #1648's implementation plan on PR #1660 | 2026-08-27, repo SHA `7998d43d` | #1648 and #1649 only | `Conflict` — see below |
+
+**Conflict record.** The evidence keys this gate consumes do not exist on the
+base branch yet: #1648's plan PR #1660 is `ready-for-human-review` and unmerged,
+so no implementation has landed. Affected plan statements: every reference to
+`LOCAL_AI_CONFIGURED` and `LOCAL_AI_HEAD_CURRENT`, and the fail-closed rule for
+a missing local evidence key.
+
+**Resolution status**: `Resolved` by sequencing, not by weakening the plan. This
+is a plan-stage artifact; the ordering requirement is recorded in
+**Dependencies** and enforced in **Implementation Order** step 0, which stops
+before any code change if #1648 is not merged into
+`develop-internal-reviewer-effectiveness`. Decision owner: LH — if #1648 is
+rejected or materially changed in human review, this plan must be revised before
+implementation rather than adapted during it.
+
+---
+
+## Layer-by-Layer Changes
+
+### Backend / API
+
+Not applicable — this repository ships workflow tooling, not a service.
+
+### Shared Packages / Libraries
+
+`scripts/development-workflow/pr-review-loop.sh` (shell contract: `bash`):
+
+- [ ] Add `EXPENSIVE_REVIEWER_PLATFORMS`, a constant list whose only member is
+      `codex-github`. The gate keys off this list rather than hard-coding the
+      platform name at the call site, so a later item can add a second expensive
+      reviewer without touching the gate logic. It is intentionally not
+      configurable from `.ai-dev-workflow.yaml`: which reviewers are expensive is
+      a property of the reviewer, not of the repository.
+- [ ] Add `is_expensive_reviewer_platform <platform>` using the existing
+      `array_contains_value` helper, mirroring `is_phase_after_clean_platform`.
+- [ ] Add `expensive_reviewer_gate <pr_number> <platform> <head_sha>` returning
+      `0` to dispatch and `1` to hold back, and printing one
+      `EXPENSIVE_GATE_*` key=value block. It evaluates four conditions against
+      `loop_head_sha` (the pre-dispatch snapshot #1648 makes authoritative) and
+      **stops at the first unmet one**, so the reported reason names a single
+      cause:
+
+      | # | Condition | Unmet reason |
+      | --- | --- | --- |
+      | 1 | `LOCAL_AI_CONFIGURED` is `1` and `LOCAL_AI_HEAD_CURRENT` is `1` | `local_evidence_stale` when `LOCAL_AI_HEAD_CURRENT` is `0`; `local_evidence_missing` when it is empty or `LOCAL_AI_CONFIGURED` is unset; `local_reviewer_not_configured` when `LOCAL_AI_CONFIGURED` is `0` |
+      | 2 | Every non-expensive platform already run in this invocation returned `clean` or `skipped` | `peer_reviewer_not_clean` |
+      | 3 | Zero unresolved, non-outdated review threads at `loop_head_sha` | `unresolved_threads` |
+      | 4 | Every non-reviewer check on `loop_head_sha` is `SUCCESS`, `SKIPPED`, or `NEUTRAL` | `baseline_checks_not_green` when one failed; `baseline_checks_pending` when one is still running |
+
+- [ ] **Fail closed on every unknown.** If any input cannot be read, the gate
+      holds the platform back with one of exactly three reasons — there is no
+      generic unknown state:
+
+      | Unreadable input | Reason |
+      | --- | --- |
+      | `loop_head_sha` is empty (the pre-dispatch head read failed) | `evidence_unavailable_head` |
+      | The review-threads query failed | `evidence_unavailable_review_threads` |
+      | The check-rollup query failed | `evidence_unavailable_checks` |
+
+      Holding back is cheap — the expensive reviewer runs on the next
+      invocation — while dispatching on unknown evidence is the waste this item
+      exists to remove. The gate never fails the loop: it returns `1`, and the
+      loop records the platform as skipped rather than as a blocking verdict, so
+      the aggregate result is unchanged.
+- [ ] Call the gate from the per-platform block, immediately before
+      `run_platform_review`, only when `is_expensive_reviewer_platform` matches.
+      It composes with the existing phase mechanism rather than replacing it: a
+      platform that is both a phase platform and an expensive reviewer must pass
+      `ensure_pr_ready_for_ready_phase` **and** this gate, in that order, and
+      `--pre-after-clean-only` still excludes phase platforms before either runs.
+- [ ] **Explicit override**: `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS=1`
+      bypasses the gate for manual escalation. When set, the gate still
+      evaluates and still emits its full `EXPENSIVE_GATE_*` block, then reports
+      `EXPENSIVE_GATE_RESULT=forced` with the reason it would otherwise have
+      given, and dispatches. The override never hides why the gate would have
+      held back — a forced run that later wastes reviewer cycles must be
+      traceable to the condition that was overridden.
+- [ ] Emit gate telemetry on the loop's stdout contract, per expensive platform:
+      `EXPENSIVE_GATE_PLATFORM`, `EXPENSIVE_GATE_RESULT`
+      (`dispatched` | `held` | `forced`), `EXPENSIVE_GATE_REASON` (empty when
+      `dispatched`), and `EXPENSIVE_GATE_HEAD` (the `loop_head_sha` the gate
+      evaluated). All values stay inside the `[A-Za-z0-9:_-]` token charset the
+      Protocol 91 carry-forward snippet admits.
+- [ ] Record the gate outcome in the reviewer-loop summary comment as an
+      `**Expensive reviewer gate:**` line, and in the `reviewer_loop_history.v1`
+      entry as an `expensive_gate` object (`platform`, `result`, `reason`,
+      `head`). Both are additive; readers dereference with defaults, so the
+      schema stays `v1`, consistent with #1648's treatment of `reviewed_heads`.
+- [ ] Document the gate, its four conditions, its fail-closed rule, and the
+      override variable in the `--help` usage block.
+
+### Frontend / UI
+
+Not applicable — no user interface in this repository.
+
+### Infrastructure / Configuration
+
+- [ ] No `.ai-dev-workflow.yaml` schema change. `codex-github` is already a
+      valid value in `review.on_draft.github` / `review.on_ready.github`; the
+      gate applies wherever it is configured. In this repository it is
+      configured nowhere, so the gate is inert here by absence — which is why
+      every scenario below is a harness fixture rather than a live run.
+
+### Documentation
+
+- [ ] `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
+      — document the gate: the four conditions, the fail-closed rule, the
+      `held` outcome being a skip rather than a blocking verdict, and the
+      override variable with the expectation that its use is justified in the PR.
+- [ ] `docs/workflow/development-workflow/integrations/codex-github.md` — add a
+      section describing the gate so a reader configuring the reviewer learns
+      when it will actually run, when it will be held back, and how to override.
+      The file exists (confirmed in the Verification Log); no new file is
+      created.
+
+---
+
+## Testing Strategy
+
+**Test types**: Unit (shell harness), plus the smoke test runbook.
+
+**Key scenarios to test**:
+
+1. `is_expensive_reviewer_platform` matches `codex-github` and rejects
+   `local-ai-reviewer`, `pr-agent`, and `bugbot` — the gate must not
+   accidentally hold back a cheap reviewer.
+2. All four conditions met → `EXPENSIVE_GATE_RESULT=dispatched`,
+   `EXPENSIVE_GATE_REASON` empty, and `run_platform_review` is called.
+3. `LOCAL_AI_HEAD_CURRENT=0` → `held` / `local_evidence_stale`, and
+   `run_platform_review` is **not** called — the core of brief scope bullet 1.
+4. `LOCAL_AI_CONFIGURED` unset → `held` / `local_evidence_missing`. This is the
+   fail-closed case for brief scope bullet 2 and pairs with #1648's rule that an
+   absent key is telemetry loss rather than non-applicability.
+5. `LOCAL_AI_CONFIGURED=0` → `held` / `local_reviewer_not_configured`. Distinct
+   from scenario 4: the loop is correctly configured, there is simply no local
+   evidence to gate on, and dispatching an expensive reviewer with no cheap
+   pre-filter is exactly what this item prevents.
+6. A peer reviewer returned `needs_fixes` earlier in the same invocation →
+   `held` / `peer_reviewer_not_clean`.
+7. One unresolved non-outdated review thread → `held` / `unresolved_threads`;
+   the same thread marked outdated → `dispatched`.
+8. A failing baseline check → `held` / `baseline_checks_not_green`; a pending
+   one → `held` / `baseline_checks_pending`; a reviewer-owned check that is
+   pending → `dispatched`, because a reviewer's own check must not gate the
+   reviewer.
+9. Each unreadable input in turn → `held` with its specific reason —
+   `evidence_unavailable_head` for an empty `loop_head_sha`,
+   `evidence_unavailable_review_threads` for a failed threads query,
+   `evidence_unavailable_checks` for a failed check rollup — and the loop's
+   aggregate result is unchanged in all three. The gate skips; it does not
+   escalate.
+10. `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS=1` with condition 1 unmet →
+    `EXPENSIVE_GATE_RESULT=forced`, `EXPENSIVE_GATE_REASON=local_evidence_stale`
+    preserved, and `run_platform_review` **is** called — the override path of
+    brief scope bullet 3, proving the reason survives the override.
+11. Composition with the phase mechanism: a platform that is both a phase
+    platform and an expensive reviewer runs `ensure_pr_ready_for_ready_phase`
+    first and the gate second; when the gate holds, the PR has still been
+    converted to ready and the loop does not treat the hold as a phase failure.
+12. Composition with `--pre-after-clean-only`: an expensive reviewer that is
+    also a phase platform is filtered out before the gate is consulted, and the
+    gate emits no telemetry for it — no phantom `held` record for a platform
+    that was never in scope.
+13. A ledger entry written without `expensive_gate` still parses through
+    `reviewer_loop_history_payload_from_existing` — `v1` backward compatibility,
+    same contract as #1648's added fields.
+
+**Files**:
+
+- `scripts/development-workflow/tests/test-pr-review-loop.sh` — scenarios 1–9
+  and 13, as new cases in the existing `HARNESS_MODE=1` harness.
+- `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` — a new
+  suite for scenarios 10–12, the composition and override cases, which need
+  their own mock scaffolding for the phase and filter paths. It must declare:
+
+  ```text
+  # covers: scripts/development-workflow/pr-review-loop.sh
+  # covers: docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md
+  ```
+
+  Both lines are required. In `select-test-suites.sh` the naming-convention
+  fallback runs only when a suite declares nothing (`declared=0`), and the
+  convention would map `test-expensive-reviewer-gate.sh` to a
+  `scripts/development-workflow/expensive-reviewer-gate.sh` that does not exist,
+  so this suite must declare its coverage explicitly or it would only ever run
+  when the test file itself changes.
+
+**Smoke test runbook**:
+`docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md`
+
+**Regression suite**: The repository's regression surface is the
+`workflow-tests.yml` harness selection; the two suites above are the regression
+coverage for this change.
+
+### Planted-violation proofs (mandatory before `ready-for-human-review`)
+
+This plan adds a new automated gate, so `REVIEW.md` § Planted-violation proof
+and `docs/best-practices/3-testing.md` § Planted-Violation Proofs apply, and the
+pure-refactor exemption does not. Two demonstrated runs per proof, each citing a
+concrete file and line:
+
+| # | Violation to plant | Where | Check that must fail, then pass |
+| --- | --- | --- | --- |
+| P1 | Stale local evidence: `LOCAL_AI_HEAD_CURRENT=0` with all other conditions met | the gate fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | the gate holds and `run_platform_review` is not called; setting it to `1` dispatches |
+| P2 | Missing local evidence: `LOCAL_AI_CONFIGURED` unset | same fixture | the gate holds with `local_evidence_missing`; exporting `LOCAL_AI_CONFIGURED=1` dispatches — the proof that an unknown is refused rather than assumed clean |
+| P3 | Unreadable evidence: make the review-threads query fail | same fixture | the gate holds with `evidence_unavailable_review_threads` and the loop's aggregate result is unchanged; restoring the query dispatches |
+| P4 | Gate bypass regression: remove the `is_expensive_reviewer_platform` guard so the gate is never consulted | a scratch copy of the per-platform block | scenario 3 fails because the platform is dispatched with stale evidence; restoring the guard passes — the proof that the gate is actually wired into the dispatch path and not merely defined |
+
+Record all four in the implementation PR under a `Planted-Violation Proofs`
+heading, each with the command, the file and line of the planted violation, and
+both outcomes.
+
+### Parser-risk addendum
+
+Not applicable. The gate compares tokens the loop already produces
+(`LOCAL_AI_*` values, platform names, check conclusions) and performs no
+text scanning, regex extraction, or structured-text parsing of its own. Review
+threads and check conclusions are read through `gh --jq`, which is existing
+parsing this plan does not modify.
+
+### Concurrent-event-source addendum
+
+Not applicable. The gate is evaluated synchronously inside the loop's existing
+sequential per-platform iteration, holds no state between invocations, and
+introduces no listeners, timers, or async callbacks. The one shared mutable
+input is the per-invocation record of peer reviewer verdicts, which is written
+by the same sequential block that already writes `platform_result_tokens`.
+
+---
+
+## Seed Data
+
+| Entity | Values / Scenario | File |
+| --- | --- | --- |
+| Gate condition fixture | A table-driven set of the four conditions with each one independently unmet, driving scenarios 2–8 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Unreadable-input mocks | Mock `gh` commands that exit non-zero for the threads query and for the check rollup, driving scenario 9 and proof P3 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Composition fixture | A platform list where `codex-github` is both a phase platform and an expensive reviewer, driving scenarios 11 and 12 | inline in `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` |
+| Legacy ledger payload | A `reviewer_loop_history.v1` entry with no `expensive_gate` object, driving scenario 13 | inline heredoc in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+
+No repository fixture files are added; both suites build their fixtures inline
+with mock `gh` commands and require no network access.
+
+---
+
+## Documentation Updates
+
+- [ ] `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
+      — document the gate, its four conditions, the fail-closed rule, the `held`
+      outcome being a skip rather than a blocking verdict, and the override
+      variable.
+- [ ] `docs/workflow/development-workflow/integrations/codex-github.md` — add a
+      section describing the gate, its four conditions, and the override, so the
+      gate is discoverable from the reviewer's own integration page rather than
+      only from the loop protocol.
+- [ ] `REVIEW.md` — no change. The gate decides when a reviewer runs, not what
+      the review contract requires.
+- [ ] `AGENTS.md` — no change. It does not enumerate reviewer-loop gates.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| The gate silently stops `codex-github` from ever running | Med | High — the expensive reviewer's findings are the reason this epic exists; losing them entirely is worse than running it too often | Every hold emits `EXPENSIVE_GATE_RESULT=held` with a single named reason in both the summary comment and the ledger, so a permanent hold is visible rather than silent; scenario 2 pins the dispatch path and P4 proves the gate is wired in rather than defined-but-unreachable |
+| The gate is defined but never consulted, leaving behavior unchanged | Med | High — the item would appear complete while changing nothing | The call site is in the per-platform block immediately before `run_platform_review`, and proof P4 removes the guard and requires scenario 3 to fail — a gate that is not wired in cannot pass its own proof |
+| Fail-closed on unreadable evidence turns a transient API blip into a permanent hold | Med | Med | A hold is per-invocation, not sticky: the next loop invocation re-evaluates, and the existing dual cycle caps bound how many invocations happen. The gate adds no retry path of its own, so it cannot loop |
+| The gate contradicts the existing phase mechanism | Med | High — two gates disagreeing on whether a platform runs is worse than either alone | Composition is specified explicitly (phase gate first, then this gate; `--pre-after-clean-only` filters before both) and pinned by scenarios 11 and 12, including the no-phantom-telemetry case |
+| Implementation starts before #1648 lands and wires the gate to keys that do not exist | Med | High — the gate would read unset variables and hold everything, or be written against a guessed contract | Recorded as a Conflict in the Cross-Cutting check and as Implementation Order step 0, which is a hard stop that verifies #1648 is merged into the approved base before any edit |
+| A reviewer's own check gates that reviewer | Low | Med — `codex-github` would wait on a check it is responsible for producing | Condition 4 evaluates non-reviewer checks only, reusing the reviewer/baseline classification `pr-ci-loop.sh` already emits rather than a new one; scenario 8's third case pins it |
+
+---
+
+## Code Samples
+
+```bash
+# Illustrative — adapt during implementation.
+EXPENSIVE_REVIEWER_PLATFORMS=(codex-github)
+
+is_expensive_reviewer_platform() {
+  array_contains_value "$1" "${EXPENSIVE_REVIEWER_PLATFORMS[@]}"
+}
+
+# Returns 0 to dispatch, 1 to hold back. Never fails the loop.
+# Stops at the first unmet condition so the reason names one cause.
+expensive_reviewer_gate() {
+  local pr_number="$1"
+  local platform="$2"
+  local head_sha="$3"
+  local reason=""
+
+  if [ -z "$head_sha" ]; then
+    reason="evidence_unavailable_head"
+  elif [ -z "${LOCAL_AI_CONFIGURED:-}" ]; then
+    reason="local_evidence_missing"
+  elif [ "$LOCAL_AI_CONFIGURED" = "0" ]; then
+    reason="local_reviewer_not_configured"
+  elif [ "${LOCAL_AI_HEAD_CURRENT:-}" = "0" ]; then
+    reason="local_evidence_stale"
+  elif [ -z "${LOCAL_AI_HEAD_CURRENT:-}" ]; then
+    reason="local_evidence_missing"
+  fi
+  # ... conditions 2-4 follow the same shape, each appending its own reason ...
+
+  print_kv EXPENSIVE_GATE_PLATFORM "$platform"
+  print_kv EXPENSIVE_GATE_HEAD "$head_sha"
+  if [ -n "$reason" ]; then
+    print_kv EXPENSIVE_GATE_REASON "$reason"
+    if [ "${PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS:-0}" = "1" ]; then
+      print_kv EXPENSIVE_GATE_RESULT forced
+      return 0
+    fi
+    print_kv EXPENSIVE_GATE_RESULT held
+    return 1
+  fi
+  print_kv EXPENSIVE_GATE_RESULT dispatched
+  print_kv EXPENSIVE_GATE_REASON ""
+  return 0
+}
+```
+
+Summary-comment line, illustrative:
+
+```markdown
+**Expensive reviewer gate:** codex-github — held (local_evidence_stale) at head `6780c658eebc8879d61e56842445749c1195b13f`
+```
+
+---
+
+## Implementation Order
+
+0. **Hard stop — dependency check.** Confirm #1648 is merged into
+   `develop-internal-reviewer-effectiveness` and that
+   `LOCAL_AI_CONFIGURED` / `LOCAL_AI_HEAD_CURRENT` exist in
+   `pr-review-loop.sh` on the base branch. **Verify**:
+   `gh pr view 1660 --json state,baseRefName` returns `MERGED` with the
+   integration branch as base, and `grep -n 'LOCAL_AI_CONFIGURED'
+   scripts/development-workflow/pr-review-loop.sh` on the rebased branch
+   returns a hit. If either fails, stop and report — do not implement against a
+   guessed contract.
+1. Add `EXPENSIVE_REVIEWER_PLATFORMS` and `is_expensive_reviewer_platform` near
+   the existing `is_phase_after_clean_platform` helper. **Verify**: source with
+   `HARNESS_MODE=1` and confirm scenario 1's matches and non-matches.
+2. Add `expensive_reviewer_gate` with conditions 1–4 in the documented order and
+   the fail-closed branch for every unreadable input. **Verify**: drive the
+   condition fixture and confirm each unmet condition yields its single named
+   reason.
+3. Wire the gate into the per-platform block immediately before
+   `run_platform_review`, guarded by `is_expensive_reviewer_platform`.
+   **Verify**: scenario 3 shows `run_platform_review` is not called on a hold.
+4. Add the override branch and confirm the reason survives it. **Verify**:
+   scenario 10.
+5. Emit the four `EXPENSIVE_GATE_*` keys and document them in `--help`.
+   **Verify**: run `pr-review-loop.sh --help` and confirm the gate, its four
+   conditions, the fail-closed rule, and the override variable are described.
+6. Add the summary-comment line and the `expensive_gate` ledger object.
+   **Verify**: build an entry in the harness and confirm the object shape, and
+   that a legacy entry without it still parses (scenario 13).
+7. Update
+   `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
+   and
+   `docs/workflow/development-workflow/integrations/codex-github.md` per
+   **Documentation Updates**. **Verify**: both files describe the same four
+   conditions, the same fail-closed rule, and the same override variable name.
+8. Add the unit cases to `test-pr-review-loop.sh` and create
+   `test-expensive-reviewer-gate.sh` with both `# covers:` lines.
+   **Verify**: both suites exit 0, and
+   `scripts/development-workflow/select-test-suites.sh` selects the new suite
+   for a change touching only `pr-review-loop.sh`.
+9. Produce the four planted-violation proofs (P1–P4) and record them in the PR
+   under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
+   at a concrete file and line — failing with the violation planted, passing
+   once removed.
+10. Run `shellcheck` on the changed script and `markdownlint-cli2` on the
+    changed protocol document, this plan, and the runbook. **Verify**: both
+    tools exit 0.
+11. Add a changelog fragment
+    `changelog.d/1649.changed.expensive-reviewers-after-local-clean.md`
+    containing exactly:
+
+    ```markdown
+    - **Gate expensive reviewers on current-head local evidence** (#1649): `codex-github` now runs only after the local reviewer, peer reviewers, review threads, and baseline checks are clean on the current head, and holds back fail-closed when that evidence is missing or stale.
+    ```
+
+12. Update project docs per **Documentation Updates** above (step 7 covers
+    them; no other project doc is affected).

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -122,7 +122,7 @@ Not applicable — this repository ships workflow tooling, not a service.
 
       | # | Condition | Unmet reason |
       | --- | --- | --- |
-      | 1 | `LOCAL_AI_CONFIGURED` is exactly `1` **and** `LOCAL_AI_HEAD_CURRENT` is exactly `1` | `local_reviewer_not_configured` when `LOCAL_AI_CONFIGURED` is `0`; `local_evidence_stale` when `LOCAL_AI_HEAD_CURRENT` is `0`; `local_evidence_missing` when either is empty, unset, or any value other than `0` or `1` |
+      | 1 | `expensive_gate_local_ai_configured` returns exactly `1` **and** `expensive_gate_local_ai_head_current` returns exactly `1` | `local_reviewer_not_configured` when the first returns `0`; `local_evidence_stale` when the second returns `0`; `local_evidence_missing` when either returns an empty string or any value other than `0` or `1` |
       | 2 | Every platform in this reviewer's **peer set** (defined below) has already run in this invocation **and** produced acceptable peer evidence | `peer_reviewer_not_run` when one has not run yet; `peer_reviewer_not_clean` when one ran without producing acceptable evidence |
       | 3 | Zero unresolved, non-outdated review threads | `unresolved_threads` |
       | 4 | The non-reviewer check set on `loop_head_sha` is **non-empty** and every member is `SUCCESS`, `SKIPPED`, or `NEUTRAL` | `baseline_checks_not_green` when one failed; `baseline_checks_pending` when one is still running; `baseline_checks_unobserved` when the set is empty |
@@ -329,8 +329,8 @@ Not applicable — this repository ships workflow tooling, not a service.
       and never exercising the bound. `EXPENSIVE_GATE_DEFERRALS=-1` keeps the
       unreadable state distinguishable from a count of zero.
 - [ ] **A repository with no local reviewer defers, it does not dispatch.**
-      When `LOCAL_AI_CONFIGURED` is `0` there is no current-head local clean
-      evidence, and the brief requires `codex-github` to run *only after* that
+      When `expensive_gate_local_ai_configured` returns `0` there is no
+      current-head local clean evidence, and the brief requires `codex-github` to run *only after* that
       evidence exists and to fail closed when it is missing — it permits an
       explicit manual override, not an implicit automatic one. The gate
       therefore defers with `local_reviewer_not_configured`. The consequence for
@@ -359,15 +359,16 @@ Not applicable — this repository ships workflow tooling, not a service.
       variables, the run prints them, and they cannot disagree.
 - [ ] **Condition 1 is an allow-list, not a deny-list.** Both keys are matched
       against their exact expected value: the condition passes only when
-      `LOCAL_AI_CONFIGURED` is the literal `1` and `LOCAL_AI_HEAD_CURRENT` is
-      the literal `1`. Testing only for `0` and empty would let any unexpected
+      `expensive_gate_local_ai_configured` returns the literal `1` and
+      `expensive_gate_local_ai_head_current` returns the literal `1`. Testing only for `0` and empty would let any unexpected
       value — a `2` from a future contract change, a stray `true`, a value with
       trailing whitespace — fall through and authorize the expensive reviewer
       with no valid local-clean evidence, which is the opposite of fail-closed.
       Any value that is neither `0` nor `1` is reported as
-      `local_evidence_missing`: it carries no more information than an absent
-      key, and treating it as its own reason would imply the gate understood it.
-      The same exact-match discipline applies to every token the gate reads.
+      `local_evidence_missing`: it carries no more information than absent
+      evidence, and treating it as its own reason would imply the gate
+      understood it. The same exact-match discipline applies to every token the
+      gate reads.
 - [ ] **Fail closed on every unknown.** If any input cannot be read, the gate
       defers with one of exactly three reasons — there is no generic unknown
       state:
@@ -491,29 +492,32 @@ reads them against each other and fails on any divergence.
    accidentally hold back a cheap reviewer.
 2. All conditions met → `EXPENSIVE_GATE_RESULT=dispatched`,
    `EXPENSIVE_GATE_REASON` empty, and `run_platform_review` is called.
-3. `LOCAL_AI_HEAD_CURRENT=0` → `deferred` / `local_evidence_stale`,
+3. The `local-ai-reviewer` entry of `platform_reviewed_heads` records a head
+   that is not `loop_head_sha`, so the derivation yields `0` → `deferred` /
+   `local_evidence_stale`,
    `run_platform_review` is **not** called, and the loop's aggregate becomes
    `needs_fixes` / `expensive_gate_deferred` — the core of brief scope bullet 1,
    and the proof that a defer withholds readiness instead of passing as a skip.
-4. Unexpected and absent values are equally refused, one case per row — the
-   allow-list check for brief scope bullet 2, pairing with #1648's rule that an
-   absent key is telemetry loss rather than non-applicability:
+4. Unexpected and absent derived values are equally refused, one case per row —
+   the allow-list check for brief scope bullet 2, pairing with #1648's rule that
+   absent evidence is telemetry loss rather than non-applicability. Each row
+   stubs the return of `expensive_gate_local_ai_configured` and
+   `expensive_gate_local_ai_head_current`; nothing is exported:
 
-   | `LOCAL_AI_CONFIGURED` | `LOCAL_AI_HEAD_CURRENT` | Required result |
+   | `configured` | `head_current` | Required result |
    | --- | --- | --- |
-   | unset | `1` | `deferred` / `local_evidence_missing` |
    | empty | `1` | `deferred` / `local_evidence_missing` |
    | `2` | `1` | `deferred` / `local_evidence_missing` |
    | `true` | `1` | `deferred` / `local_evidence_missing` |
-   | `1` | unset | `deferred` / `local_evidence_missing` |
    | `1` | empty | `deferred` / `local_evidence_missing` |
    | `1` | `2` | `deferred` / `local_evidence_missing` |
    | `1` | `yes` | `deferred` / `local_evidence_missing` |
 
-   The `2` and `true` rows are the ones a deny-list implementation fails: they
-   are neither `0` nor empty, so testing only for those would let them through
-   and dispatch the expensive reviewer with no valid evidence.
-5. `LOCAL_AI_CONFIGURED=0` → `deferred` / `local_reviewer_not_configured`.
+   The `2`, `true` and `yes` rows are the ones a deny-list implementation fails:
+   they are neither `0` nor empty, so testing only for those would let them
+   through and dispatch the expensive reviewer with no valid evidence.
+5. `local-ai-reviewer` is absent from the resolved platform list, so the
+   derivation yields `0` → `deferred` / `local_reviewer_not_configured`.
    Distinct from scenario 4 (`missing` means the telemetry never arrived; this
    means the platform is genuinely not configured), and deliberately still a
    defer: the brief requires the expensive reviewer to run only after

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -486,7 +486,8 @@ reads them against each other and fails on any divergence.
    | `needs_fixes` | `deferred` / `peer_reviewer_not_clean` |
    | `escalate` | `deferred` / `peer_reviewer_not_clean` |
 
-   The three accepted-skip rows and the three rejected-skip rows must be
+   The two accepted-skip rows (`not_configured`, `explicit-skip`) and the three
+   rejected-skip rows (`unavailable`, `timeout`, `unauthorized`) must be
    asserted against `reviewer_failed_label_required_for_result` rather than a
    duplicated list, so a future change to that helper moves this gate with it.
 9. One unresolved non-outdated review thread → `deferred` /

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -588,15 +588,26 @@ reads them against each other and fails on any divergence.
    asserted, in that order.
 9. One unresolved non-outdated review thread → `deferred` /
    `unresolved_threads`; the same thread marked outdated → `dispatched`.
-10. Baseline-check states, one case each: a failing check → `deferred` /
-    `baseline_checks_not_green`; a pending one → `deferred` /
-    `baseline_checks_pending`; a reviewer-owned check that is pending →
-    `dispatched`, because a reviewer's own check must not gate the reviewer; an
-    **empty** non-reviewer set → `deferred` / `baseline_checks_unobserved`, and
-    a set containing only reviewer-owned checks → the same, since filtering
-    leaves it empty. The two empty cases are the vacuous-green guard: "every
-    member is green" is trivially true of an empty set, so an unguarded
-    implementation would dispatch with no baseline evidence.
+10. Baseline-check states, one case each. Every row that expects `dispatched`
+    must include **at least one green non-reviewer check**, or filtering leaves
+    the set empty and the row hits the empty-set rule instead of the behavior it
+    is meant to test:
+
+    | Rollup contents | Required result |
+    | --- | --- |
+    | A failing non-reviewer check, plus a green one | `deferred` / `baseline_checks_not_green` |
+    | A pending non-reviewer check, plus a green one | `deferred` / `baseline_checks_pending` |
+    | A **pending reviewer-owned** check **plus a green non-reviewer check** | `dispatched` — the reviewer's own check was correctly excluded |
+    | An empty rollup | `deferred` / `baseline_checks_unobserved` |
+    | Only reviewer-owned checks | `deferred` / `baseline_checks_unobserved` |
+
+    The third row is the reviewer-exclusion test and the fifth is the
+    vacuous-green guard; they are only distinguishable because the third
+    carries a green non-reviewer check. Without it both rows would return
+    `baseline_checks_unobserved` and neither the row nor proof P14 could tell a
+    correct exclusion from a vacuous-green miss. The last two rows are the guard
+    itself: "every member is green" is trivially true of an empty set, so an
+    unguarded implementation would dispatch with no baseline evidence.
 11. The threads or checks query returns a live head different from
     `loop_head_sha` → `deferred` / `evidence_head_moved`. Without this, evidence
     from a newer commit could authorize dispatch against reviewer verdicts taken

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -272,20 +272,31 @@ Not applicable — no user interface in this repository.
 
 ### Documentation
 
+Both documents below must state the **same** contract, and both must include
+the full two-value `EXPENSIVE_GATE_ESCALATION` behavior — smoke test Step 10
+reads them against each other and fails on any divergence.
+
 - [ ] `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
       — document the gate: the conditions and their evaluation order, the
       order-independence of condition 2, the head binding of conditions 3 and 4,
       the fail-closed rule, the fact that a `deferred` outcome sets the
       aggregate to `needs_fixes` (so readiness is withheld and Step 7 re-runs)
-      rather than passing as a clean skip, the bounded deferral counter and its
-      `expensive_gate_deferral_cap` escalation, the reordering of expensive
-      reviewers to the end of the platform list, and the override variable with the expectation that its use is
-      justified in the PR.
+      rather than passing as a clean skip, the reordering of expensive reviewers
+      to the end of the platform list, the override variable with the
+      expectation that its use is justified in the PR, and the bounded deferral
+      counter with **both** escalation causes —
+      `expensive_gate_deferral_cap` when the budget is exhausted and
+      `expensive_gate_deferral_budget_unreadable` when it cannot be read —
+      naming `EXPENSIVE_GATE_ESCALATION` as the key that carries them and
+      stating that it is emitted only on a `deferral_cap` result.
 - [ ] `docs/workflow/development-workflow/integrations/codex-github.md` — add a
       section describing the gate so a reader configuring the reviewer learns
       when it will actually run, when it will be deferred, and how to override.
-      The file exists (confirmed in the Verification Log); no new file is
-      created.
+      It must carry the same `EXPENSIVE_GATE_ESCALATION` contract as Protocol 93
+      — both values, and the `deferral_cap`-only emission — because a reader who
+      only ever opens the integration page must be able to tell an exhausted
+      budget from an unreadable one without consulting the protocol. The file
+      exists (confirmed in the Verification Log); no new file is created.
 
 ---
 
@@ -470,9 +481,11 @@ with mock `gh` commands and require no network access.
       reordering of expensive reviewers to the end of the platform list, and the
       override variable.
 - [ ] `docs/workflow/development-workflow/integrations/codex-github.md` — add a
-      section describing the gate, its conditions, and the override, so the
-      gate is discoverable from the reviewer's own integration page rather than
-      only from the loop protocol.
+      section describing the gate, its conditions, the override, and the same
+      two-value `EXPENSIVE_GATE_ESCALATION` contract (`expensive_gate_deferral_cap`,
+      `expensive_gate_deferral_budget_unreadable`, emitted only on a
+      `deferral_cap` result), so the gate is fully discoverable from the
+      reviewer's own integration page rather than only from the loop protocol.
 - [ ] `REVIEW.md` — no change. The gate decides when a reviewer runs, not what
       the review contract requires.
 - [ ] `AGENTS.md` — no change. It does not enumerate reviewer-loop gates.

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -350,8 +350,8 @@ Not applicable — this repository ships workflow tooling, not a service.
       (`expensive_gate_deferral_cap` and
       `expensive_gate_deferral_budget_unreadable`) and the fact that
       `EXPENSIVE_GATE_ESCALATION` appears only on a `deferral_cap` result, the
-      reordering of expensive reviewers to the end of the platform list, and
-      the override variable.
+      reordering of expensive reviewers last **within their own phase bucket**
+      (never across the draft/ready boundary), and the override variable.
 
 ### Frontend / UI
 
@@ -378,7 +378,8 @@ reads them against each other and fails on any divergence.
       the fail-closed rule, the fact that a `deferred` outcome sets the
       aggregate to `needs_fixes` (so readiness is withheld and Step 7 re-runs)
       rather than passing as a clean skip, the reordering of expensive reviewers
-      to the end of the platform list, the override variable with the
+      last **within their own phase bucket** — never across the draft/ready
+      boundary — the override variable with the
       expectation that its use is justified in the PR, and the bounded deferral
       counter with **both** escalation causes —
       `expensive_gate_deferral_cap` when the budget is exhausted and
@@ -647,8 +648,8 @@ with mock `gh` commands and require no network access.
       `needs_fixes` so readiness is withheld and Step 7 re-runs, the bounded
       deferral counter with both of its escalation values and the
       `deferral_cap`-only emission of `EXPENSIVE_GATE_ESCALATION`, the
-      reordering of expensive reviewers to the end of the platform list, and the
-      override variable.
+      reordering of expensive reviewers last **within their own phase bucket**
+      (never across the draft/ready boundary), and the override variable.
 - [ ] `docs/workflow/development-workflow/integrations/codex-github.md` — add a
       section describing the gate, its conditions, the override, and the same
       two-value `EXPENSIVE_GATE_ESCALATION` contract (`expensive_gate_deferral_cap`,

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -198,23 +198,38 @@ Not applicable — this repository ships workflow tooling, not a service.
          non-blocking snapshot, and would conflate "CI is not green yet" with
          "the gate says wait". The gate takes a snapshot; the CI loop remains
          Step 8's job.
-- [ ] **Define acceptable peer evidence — not every `skipped` counts.**
-      Accepting any `skipped` peer would let `codex-github` dispatch when a
-      configured peer was unavailable, timed out, or was rejected for
-      credentials, which is precisely the "no cheap pre-filter actually ran"
-      state this item exists to prevent, and it contradicts the summary's claim
-      that peers are clean. The rule reuses the classification the loop already
-      owns rather than inventing a second one: a peer's evidence is acceptable
-      when its result is `clean`, or when its result is `skipped` **and**
-      `reviewer_failed_label_required_for_result` returns false for that
-      `(result, reason)` pair. That function already treats
-      `unavailable`, `timeout`, `thread-check-failed`, `pending_timeout`,
-      `forbidden` and `unauthorized` skips as reviewer failures, so those defer;
-      deliberate policy skips such as `not_configured`, `explicit-skip` and
-      `release_pr` are accepted. Any `needs_fixes`, `needs_rerun` or `escalate`
-      peer defers. Reusing the existing helper means a future change to what
-      counts as a reviewer failure updates this gate automatically instead of
-      drifting from it.
+- [ ] **Define acceptable peer evidence with a positive allow-list.** Accepting
+      any `skipped` peer would let `codex-github` dispatch when a configured
+      peer was unavailable, timed out, or was rejected for credentials — the
+      "no cheap pre-filter actually ran" state this item exists to prevent. But
+      deciding acceptance by asking whether
+      `reviewer_failed_label_required_for_result` returns false is the same
+      deny-list mistake in another place: that helper enumerates a *known* set
+      of failure reasons and returns false for anything it does not recognise,
+      including the empty string and any reason a future reviewer integration
+      introduces. A new skip reason would silently become acceptable evidence.
+      Acceptance is therefore an explicit allow-list:
+
+      ```text
+      EXPENSIVE_GATE_ACCEPTED_SKIP_REASONS=(not_configured explicit-skip release_pr unsupported-platform)
+      ```
+
+      A peer's evidence is acceptable when its result is `clean`, or when its
+      result is `skipped` **and** its reason is a member of that list **and**
+      `reviewer_failed_label_required_for_result` returns false for the pair.
+      The membership test is what makes it fail-closed; the helper call is a
+      second gate so a reason cannot be accepted here while the loop elsewhere
+      treats it as a reviewer failure. Every other result — `needs_fixes`,
+      `needs_rerun`, `escalate`, and every unlisted, unknown or empty skip
+      reason — defers with `peer_reviewer_not_clean`.
+
+      Each member is on the list for a stated reason: `not_configured` and
+      `unsupported-platform` mean the reviewer was never going to run in this
+      repository; `explicit-skip` is an operator's deliberate choice;
+      `release_pr` is the release-guard path, where review already happened on
+      the feature PRs. Adding a member is a deliberate act with a rationale, not
+      a side effect of a reviewer integration landing elsewhere.
+
 - [ ] **Define the peer set as the platforms that precede this reviewer under
       the reordered list.** It cannot be the whole resolved list: the reorder
       preserves phase buckets, so a draft-phase `codex-github` necessarily runs
@@ -544,10 +559,17 @@ reads them against each other and fails on any divergence.
    | `needs_fixes` | `deferred` / `peer_reviewer_not_clean` |
    | `escalate` | `deferred` / `peer_reviewer_not_clean` |
 
-   The two accepted-skip rows (`not_configured`, `explicit-skip`) and the three
-   rejected-skip rows (`unavailable`, `timeout`, `unauthorized`) must be
-   asserted against `reviewer_failed_label_required_for_result` rather than a
-   duplicated list, so a future change to that helper moves this gate with it.
+   | `skipped` / `release_pr` | contributes to `dispatched` |
+   | `skipped` / `unsupported-platform` | contributes to `dispatched` |
+   | `skipped` / `some_future_reason` (unknown) | `deferred` / `peer_reviewer_not_clean` |
+   | `skipped` / `""` (empty reason) | `deferred` / `peer_reviewer_not_clean` |
+
+   The four accepted rows are the members of
+   `EXPENSIVE_GATE_ACCEPTED_SKIP_REASONS`; the unknown and empty rows are the
+   fail-closed cases that a helper-only rule would have accepted, since
+   `reviewer_failed_label_required_for_result` returns false for any reason it
+   does not recognise. Both the membership test and the helper call must be
+   asserted, in that order.
 9. One unresolved non-outdated review thread → `deferred` /
    `unresolved_threads`; the same thread marked outdated → `dispatched`.
 10. Baseline-check states, one case each: a failing check → `deferred` /
@@ -686,7 +708,8 @@ concrete file and line:
 | P4 | Gate-not-wired regression: **delete the `expensive_reviewer_gate` call** from the per-platform block, leaving the function defined but unreachable | a scratch copy of the per-platform block in `scripts/development-workflow/pr-review-loop.sh` | scenario 3 fails, because `codex-github` is dispatched with stale local evidence and no `EXPENSIVE_GATE_*` telemetry is emitted; restoring the call passes. Deleting the call is the correct mutation: removing the `is_expensive_reviewer_platform` guard instead would consult the gate for *every* platform, which is a different defect and would not leave the gate unreachable |
 | P5 | Ordering regression: **delete the `reorder_expensive_reviewers_last` call**, leaving a platform list that declares `codex-github` before `pr-agent` | a scratch copy of the platform-resolution block | scenario 6 fails and scenario 7's suppressed-reorder case shows the gate deferring on every invocation with `peer_reviewer_not_run` — a deferral that can never resolve; restoring the call passes |
 | P9 | Phase-bucket regression: replace the per-bucket partition with a single global one | a scratch copy of `reorder_expensive_reviewers_last` | scenario 6b fails, because a draft-configured `codex-github` is placed after the ready-phase `bugbot` and therefore runs only after `gh pr ready`; restoring the per-bucket partition passes |
-| P10 | Peer-evidence regression: accept any `skipped` peer instead of consulting `reviewer_failed_label_required_for_result` | a scratch copy of condition 2 | scenario 8's `unavailable`, `timeout` and `unauthorized` rows fail, because the gate dispatches with a peer that never produced a verdict; restoring the helper call passes |
+| P10 | Peer-evidence regression: accept any `skipped` peer instead of applying the allow-list | a scratch copy of condition 2 | scenario 8's `unavailable`, `timeout` and `unauthorized` rows fail, because the gate dispatches with a peer that never produced a verdict; restoring the allow-list passes |
+| P19 | Deny-list regression: decide acceptance solely by `reviewer_failed_label_required_for_result` returning false, dropping the `EXPENSIVE_GATE_ACCEPTED_SKIP_REASONS` membership test | same scratch copy | scenario 8's unknown-reason and empty-reason rows fail, because that helper returns false for any reason it does not recognise and a future reviewer's new skip reason would silently become acceptable evidence; restoring the membership test passes |
 | P18 | Unvalidated-bound regression: pass `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS=abc` and then `=0` with the validation removed | the deferral-budget fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | with `abc` the comparison errors and the cap never trips, so scenario 13's escalation fails; with `0` every gated PR escalates before its first deferral, so scenario 3's defer fails. Restoring `expensive_gate_resolve_max_deferrals` makes both pass with the documented fallback |
 | P17 | Environment-read regression: change the gate to read `LOCAL_AI_CONFIGURED` and `LOCAL_AI_HEAD_CURRENT` as environment variables instead of calling the two derivation helpers | a scratch copy of condition 1 | scenario 22 fails and every condition-1 case defers with `local_evidence_missing`, because those names are stdout keys printed at end of run and are unset during the platform iteration; restoring the helpers passes |
 | P16 | Vacuous-green regression: make `expensive_gate_baseline_checks_status` return `green` for an empty non-reviewer check set | a scratch copy of the helper | scenario 10's two empty cases fail, because the gate dispatches with no baseline evidence on a head whose CI has not registered; restoring the `empty` state defers with `baseline_checks_unobserved` |
@@ -699,7 +722,7 @@ concrete file and line:
 | P11 | Absent-ledger regression: change the counter to return `-1` for an absent ledger as well as a malformed one | same fixture | scenario 19b fails, because a PR with no prior reviewer-loop history escalates on its first run and the bound is never exercised; restoring the three-state mapping passes |
 | P12 | Deny-list regression: rewrite condition 1 to reject only `0` and empty rather than requiring exactly `1` | a scratch copy of condition 1 | scenario 4's `2` and `true` rows fail, because the gate dispatches with an unrecognized evidence value; restoring the exact-match allow-list passes |
 
-Record all eighteen in the implementation PR under a `Planted-Violation Proofs`
+Record all nineteen in the implementation PR under a `Planted-Violation Proofs`
 heading, each with the command, the file and line of the planted violation, and
 both outcomes.
 
@@ -733,7 +756,7 @@ by the same sequential block that already writes `platform_result_tokens`.
 | --- | --- | --- |
 | Gate condition fixture | A table-driven set of the conditions with each one independently unmet, plus the eight-row unexpected-value table for condition 1, driving scenarios 2–5 and 9–11 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Platform-order fixture | A resolved list declaring `codex-github` first, an already-correct list, and a two-bucket list with `codex-github` on draft and `bugbot` on ready — driving scenarios 6, 6b and 7 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
-| Peer-evidence fixture | One peer per row of scenario 8's table, covering `clean`, the three accepted skip reasons, the three rejected skip reasons, `needs_fixes` and `escalate` | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Peer-evidence fixture | One peer per row of scenario 8's table: `clean`, the four accepted skip reasons, the three rejected skip reasons, an unknown skip reason, an empty skip reason, `needs_fixes` and `escalate` | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Unreadable-input mocks | Mock `gh` commands that exit non-zero for the threads query and for the check rollup, plus a rollup that returns an empty array and one containing only reviewer-owned checks — driving scenarios 10 and 12 and proofs P3 and P16 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Deferral-budget fixtures | Ledger payloads carrying `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` `expensive_gate.result=deferred` entries at the current head, one fewer, the same count at a different head, and an unparseable payload — driving scenarios 13, 14, 19 and 19b and proofs P7, P8 and P11 — including an absent ledger, a malformed one, and a well-formed one | inline heredocs in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Composition fixture | A platform list where `codex-github` is both a phase platform and an expensive reviewer, driving scenarios 16 and 17 | inline in `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` |
@@ -789,7 +812,7 @@ with mock `gh` commands and require no network access.
 | The reorder silently moves a reviewer across the draft/ready boundary | Med | High — a draft-configured expensive reviewer would run only after `gh pr ready`, inverting the configuration contract | The partition is per phase bucket, assigned with the existing `is_phase_after_clean_platform` predicate, and the buckets are concatenated in their original order; scenario 6b and proof P9 pin it |
 | The gate reads the local evidence from the environment and always defers | Med | High — #1648's `LOCAL_AI_*` are stdout keys printed at end of run, so an environment read is unset during the loop and the gate would refuse on every invocation | Both values are derived at gate time from the in-loop state #1648 already maintains — platform-list membership and `reviewer_loop_head_evidence_classify` over `platform_reviewed_heads` — with the stdout keys as the serialization of that same state rather than a second source. Scenario 22 composes with #1648's real producer instead of pre-seeding, and proof P17 plants the environment read |
 | An unrecognized evidence value falls through condition 1 | Med | High — a `2` or a stray `true` would authorize the expensive reviewer with no valid local-clean evidence, the exact opposite of fail-closed | Condition 1 is an exact-match allow-list requiring the literal `1` on both keys, not a deny-list on `0` and empty; anything else reports `local_evidence_missing`. Scenario 4's eight-row table and proof P12 pin it |
-| A peer that never produced a verdict is accepted as evidence | Med | High — `codex-github` would dispatch with no cheap pre-filter having actually run, which is the state the item exists to prevent | Acceptance delegates to `reviewer_failed_label_required_for_result`, which already classifies `unavailable`, `timeout`, `thread-check-failed`, `pending_timeout`, `forbidden` and `unauthorized` skips as reviewer failures, so only `clean` and deliberate policy skips count; scenario 8's table and proof P10 pin it, and reusing the helper keeps the two definitions from drifting |
+| A peer that never produced a verdict is accepted as evidence | Med | High — `codex-github` would dispatch with no cheap pre-filter having actually run, which is the state the item exists to prevent | Acceptance is a positive allow-list, `EXPENSIVE_GATE_ACCEPTED_SKIP_REASONS`, plus a confirming `reviewer_failed_label_required_for_result` call. A helper-only rule would be a deny-list: that helper returns false for any reason it does not recognise, so an unknown, empty, or newly-introduced skip reason would silently become acceptable. Scenario 8's table and proofs P10 and P19 pin both halves |
 | Thread and CI evidence describes a newer commit than the reviewer verdicts | Med | High — dispatch would be authorized on an inconsistent mix of two heads | Conditions 3 and 4 require the live head returned with their queries to equal `loop_head_sha`, and defer with `evidence_head_moved` otherwise; scenario 11 pins it |
 
 ---
@@ -934,7 +957,8 @@ Summary-comment line, illustrative:
    from the gate.
 4. Add `expensive_reviewer_gate` with the conditions in the documented order,
    condition 2 computing the peer set from the reordered list and this
-   reviewer's index in it and delegating acceptance to
+   reviewer's index in it and deciding acceptance by
+   `EXPENSIVE_GATE_ACCEPTED_SKIP_REASONS` membership confirmed by
    `reviewer_failed_label_required_for_result`, the live-head comparison
    for conditions 3 and 4, the fail-closed branch for every unreadable input,
    and the deferral-cap branch. **Verify**: drive the condition fixture and
@@ -983,7 +1007,7 @@ Summary-comment line, illustrative:
     `scripts/development-workflow/select-test-suites.sh` selects the new suite
     for a change touching only `pr-review-loop.sh` and selects
     `test-pr-ci-loop.sh` for a change touching only `workflow-lib.sh`.
-11. Produce the eighteen planted-violation proofs (P1–P18) and record them in the PR
+11. Produce the nineteen planted-violation proofs (P1–P19) and record them in the PR
     under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
     at a concrete file and line — failing with the violation planted, passing
     once removed.

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -303,6 +303,24 @@ Not applicable — this repository ships workflow tooling, not a service.
       bounded number of deferrals rather than blocking forever, and by
       `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS` for a one-off run. Both are
       explicit; neither silently relaxes the gate.
+- [ ] **Read the local evidence from in-loop state, not from the environment.**
+      #1648 defines `LOCAL_AI_CONFIGURED` and `LOCAL_AI_HEAD_CURRENT` as
+      *top-level stdout keys*, printed once for the run. They are not shell
+      variables set before the platform iteration, so a gate that reads
+      `${LOCAL_AI_CONFIGURED:-}` mid-loop would always see them unset and defer
+      on every invocation — the gate would be inert in the worst way, always
+      refusing. Both values must be derived at gate time from the same in-loop
+      state #1648 already maintains:
+
+      | Gate input | In-loop source |
+      | --- | --- |
+      | `local_ai_configured` | whether `local-ai-reviewer` appears in the resolved `platforms[@]` list — the same membership test `is_expensive_reviewer_platform` uses, applied to the local reviewer |
+      | `local_ai_head_current` | `reviewer_loop_head_evidence_classify` (from #1648) applied to the `local-ai-reviewer` entry of `platform_reviewed_heads` against `loop_head_sha`; `current` maps to `1`, `not-current` to `0`, and a missing entry to the empty string |
+
+      The stdout keys stay exactly as #1648 defines them — they are the
+      *serialization* of this same in-loop state at the end of the run, not a
+      second source of truth. One producer, two consumers: the gate reads the
+      variables, the run prints them, and they cannot disagree.
 - [ ] **Condition 1 is an allow-list, not a deny-list.** Both keys are matched
       against their exact expected value: the condition passes only when
       `LOCAL_AI_CONFIGURED` is the literal `1` and `LOCAL_AI_HEAD_CURRENT` is
@@ -563,6 +581,14 @@ reads them against each other and fails on any divergence.
     `EXPENSIVE_GATE_DEFERRALS=-1`, and the loop escalates. Without this the
     bounded-deferral guarantee would hold only when the ledger happens to be
     readable, which is not a guarantee.
+22. In-loop derivation matches the printed contract: with #1648's actual
+    producer populating `platform_reviewed_heads` — not with the variables
+    pre-seeded — `expensive_gate_local_ai_configured` and
+    `expensive_gate_local_ai_head_current` return exactly the values the run
+    later prints as `LOCAL_AI_CONFIGURED` and `LOCAL_AI_HEAD_CURRENT`, for a
+    current head, a stale head, an unreported head, and a run where
+    `local-ai-reviewer` is not configured. This is the composition test with the
+    dependency rather than a mock of it.
 21. A draft-phase defer does not start the ready phase: with `codex-github` on
     draft deferring and `bugbot` on ready, the loop breaks out immediately —
     `ensure_pr_ready_for_ready_phase` is not called, `gh pr ready` is not run,
@@ -593,7 +619,7 @@ reads them against each other and fails on any divergence.
   add `# covers: scripts/development-workflow/workflow-lib.sh` so a later edit
   to the relocated function also selects it.
 - `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` — a new
-  suite for scenarios 15–17 and 21, the override and composition cases, which need
+  suite for scenarios 15–17, 21 and 22, the override and composition cases, which need
   their own mock scaffolding for the phase and filter paths. It must declare:
 
   ```text
@@ -631,6 +657,7 @@ concrete file and line:
 | P5 | Ordering regression: **delete the `reorder_expensive_reviewers_last` call**, leaving a platform list that declares `codex-github` before `pr-agent` | a scratch copy of the platform-resolution block | scenario 6 fails and scenario 7's suppressed-reorder case shows the gate deferring on every invocation with `peer_reviewer_not_run` — a deferral that can never resolve; restoring the call passes |
 | P9 | Phase-bucket regression: replace the per-bucket partition with a single global one | a scratch copy of `reorder_expensive_reviewers_last` | scenario 6b fails, because a draft-configured `codex-github` is placed after the ready-phase `bugbot` and therefore runs only after `gh pr ready`; restoring the per-bucket partition passes |
 | P10 | Peer-evidence regression: accept any `skipped` peer instead of consulting `reviewer_failed_label_required_for_result` | a scratch copy of condition 2 | scenario 8's `unavailable`, `timeout` and `unauthorized` rows fail, because the gate dispatches with a peer that never produced a verdict; restoring the helper call passes |
+| P17 | Environment-read regression: change the gate to read `LOCAL_AI_CONFIGURED` and `LOCAL_AI_HEAD_CURRENT` as environment variables instead of calling the two derivation helpers | a scratch copy of condition 1 | scenario 22 fails and every condition-1 case defers with `local_evidence_missing`, because those names are stdout keys printed at end of run and are unset during the platform iteration; restoring the helpers passes |
 | P16 | Vacuous-green regression: make `expensive_gate_baseline_checks_status` return `green` for an empty non-reviewer check set | a scratch copy of the helper | scenario 10's two empty cases fail, because the gate dispatches with no baseline evidence on a head whose CI has not registered; restoring the `empty` state defers with `baseline_checks_unobserved` |
 | P15 | No-short-circuit regression: make a `deferred` result set the aggregate without breaking out of the platform iteration | a scratch copy of the gate call site | scenario 21 fails, because the loop continues to the ready-phase platform and calls `gh pr ready` on a PR whose draft-phase expensive reviewer never ran; restoring the break passes |
 | P14 | Reviewer-check-classification regression: make `expensive_gate_baseline_checks_status` treat every check as a baseline check | a scratch copy of the helper | scenario 10's reviewer-owned-pending row fails, because `codex-github` waits on a check it is responsible for producing; restoring the `configured_reviewer_check_names_json` exclusion passes |
@@ -641,7 +668,7 @@ concrete file and line:
 | P11 | Absent-ledger regression: change the counter to return `-1` for an absent ledger as well as a malformed one | same fixture | scenario 19b fails, because a PR with no prior reviewer-loop history escalates on its first run and the bound is never exercised; restoring the three-state mapping passes |
 | P12 | Deny-list regression: rewrite condition 1 to reject only `0` and empty rather than requiring exactly `1` | a scratch copy of condition 1 | scenario 4's `2` and `true` rows fail, because the gate dispatches with an unrecognized evidence value; restoring the exact-match allow-list passes |
 
-Record all sixteen in the implementation PR under a `Planted-Violation Proofs`
+Record all seventeen in the implementation PR under a `Planted-Violation Proofs`
 heading, each with the command, the file and line of the planted violation, and
 both outcomes.
 
@@ -722,6 +749,7 @@ with mock `gh` commands and require no network access.
 | Platform ordering decides whether the gate is effective | Med | High — a config listing `codex-github` first would either dispatch it before the cheap reviewers ran, or defer at the same point forever | Detection is not enough, so the loop reorders: `reorder_expensive_reviewers_last` moves expensive platforms to the end of their own bucket before iteration, making the gate's precondition reachable; condition 2's peer set is computed from the reordered list, so `peer_reviewer_not_run` fires as a defensive assertion if the reorder did not happen. Scenarios 6 and 7 and proof P5 pin both halves |
 | The peer set and the phase-bucket reorder contradict each other | Med | High — a draft-phase expensive reviewer would wait on a ready-phase peer that cannot have run yet, deadlocking until the cap | The peer set is the platforms that *precede* this reviewer under the reordered list — its own bucket's non-expensive platforms plus every earlier bucket — rather than the whole resolved list; scenario 7's table and proof P13 pin it, including the draft-plus-ready configuration |
 | The reorder silently moves a reviewer across the draft/ready boundary | Med | High — a draft-configured expensive reviewer would run only after `gh pr ready`, inverting the configuration contract | The partition is per phase bucket, assigned with the existing `is_phase_after_clean_platform` predicate, and the buckets are concatenated in their original order; scenario 6b and proof P9 pin it |
+| The gate reads the local evidence from the environment and always defers | Med | High — #1648's `LOCAL_AI_*` are stdout keys printed at end of run, so an environment read is unset during the loop and the gate would refuse on every invocation | Both values are derived at gate time from the in-loop state #1648 already maintains — platform-list membership and `reviewer_loop_head_evidence_classify` over `platform_reviewed_heads` — with the stdout keys as the serialization of that same state rather than a second source. Scenario 22 composes with #1648's real producer instead of pre-seeding, and proof P17 plants the environment read |
 | An unrecognized evidence value falls through condition 1 | Med | High — a `2` or a stray `true` would authorize the expensive reviewer with no valid local-clean evidence, the exact opposite of fail-closed | Condition 1 is an exact-match allow-list requiring the literal `1` on both keys, not a deny-list on `0` and empty; anything else reports `local_evidence_missing`. Scenario 4's eight-row table and proof P12 pin it |
 | A peer that never produced a verdict is accepted as evidence | Med | High — `codex-github` would dispatch with no cheap pre-filter having actually run, which is the state the item exists to prevent | Acceptance delegates to `reviewer_failed_label_required_for_result`, which already classifies `unavailable`, `timeout`, `thread-check-failed`, `pending_timeout`, `forbidden` and `unauthorized` skips as reviewer failures, so only `clean` and deliberate policy skips count; scenario 8's table and proof P10 pin it, and reusing the helper keeps the two definitions from drifting |
 | Thread and CI evidence describes a newer commit than the reviewer verdicts | Med | High — dispatch would be authorized on an inconsistent mix of two heads | Conditions 3 and 4 require the live head returned with their queries to equal `loop_head_sha`, and defer with `evidence_head_moved` otherwise; scenario 11 pins it |
@@ -748,20 +776,28 @@ expensive_reviewer_gate() {
   local head_sha="$3"
   local reason=""
   local deferrals
+  local configured
+  local head_current
+
+  # Derived from in-loop state, NOT from the environment: #1648's LOCAL_AI_*
+  # keys are stdout serializations printed once at end of run, so reading them
+  # here would always see them unset and the gate would defer forever.
+  configured="$(expensive_gate_local_ai_configured)"
+  head_current="$(expensive_gate_local_ai_head_current "$head_sha")"
 
   if [ -z "$head_sha" ]; then
     reason="evidence_unavailable_head"
-  elif [ "${LOCAL_AI_CONFIGURED:-}" = "0" ]; then
+  elif [ "$configured" = "0" ]; then
     # No current-head local evidence exists. The brief requires fail-closed
     # here; the deferral cap and the explicit override are the release valves.
     reason="local_reviewer_not_configured"
-  elif [ "${LOCAL_AI_CONFIGURED:-}" != "1" ]; then
+  elif [ "$configured" != "1" ]; then
     # Allow-list, not deny-list: anything that is not exactly 0 or 1 is as
-    # uninformative as an absent key, so it must not fall through.
+    # uninformative as an absent value, so it must not fall through.
     reason="local_evidence_missing"
-  elif [ "${LOCAL_AI_HEAD_CURRENT:-}" = "0" ]; then
+  elif [ "$head_current" = "0" ]; then
     reason="local_evidence_stale"
-  elif [ "${LOCAL_AI_HEAD_CURRENT:-}" != "1" ]; then
+  elif [ "$head_current" != "1" ]; then
     reason="local_evidence_missing"
   fi
   # Conditions 2-4 follow, each appending its own reason and each comparing the
@@ -840,6 +876,14 @@ Summary-comment line, illustrative:
    mirroring `reviewer_loop_history_entries_count`'s own three states.
    **Verify**: scenarios 13, 14, 19 and 19b — the count reflects only the
    current head, an absent ledger yields `0`, and a malformed one yields `-1`.
+3a. Add `expensive_gate_local_ai_configured` (membership of
+   `local-ai-reviewer` in the resolved `platforms[@]`) and
+   `expensive_gate_local_ai_head_current <head_sha>` (which applies #1648's
+   `reviewer_loop_head_evidence_classify` to the `local-ai-reviewer` entry of
+   `platform_reviewed_heads`). **Verify**: scenario 22 — with #1648's real
+   producer populating `platform_reviewed_heads`, both helpers return the same
+   values the run later prints as `LOCAL_AI_CONFIGURED` and
+   `LOCAL_AI_HEAD_CURRENT`. Do not read those names as environment variables.
 3b. Move `configured_reviewer_check_names_json` verbatim from `pr-ci-loop.sh`
    to `workflow-lib.sh`, delete the local definition, and add
    `expensive_gate_baseline_checks_status`. **Verify**: scenario 20 — the CI
@@ -897,7 +941,7 @@ Summary-comment line, illustrative:
     `scripts/development-workflow/select-test-suites.sh` selects the new suite
     for a change touching only `pr-review-loop.sh` and selects
     `test-pr-ci-loop.sh` for a change touching only `workflow-lib.sh`.
-11. Produce the sixteen planted-violation proofs (P1–P16) and record them in the PR
+11. Produce the seventeen planted-violation proofs (P1–P17) and record them in the PR
     under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
     at a concrete file and line — failing with the violation planted, passing
     once removed.

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -18,10 +18,13 @@ check is whether the accumulated evidence is (a) about the current head and
 (b) complete: it evaluates only earlier reviewer verdicts from this same run,
 never review threads, never baseline CI, and it has no notion of a stale local
 clean result. This plan adds a dedicated pre-dispatch gate for `codex-github`
-that requires four current-head conditions — local reviewer clean and current,
-PR-Agent clean, zero unresolved review threads, and green non-reviewer baseline
-checks — evaluated immediately before the platform is dispatched, fail-closed when any input is
-missing or stale, with one explicit documented override for manual escalation.
+that requires four current-head conditions — the local reviewer clean and
+current; every reviewer that **precedes** it having produced acceptable evidence
+(a `clean` result, or a `skipped` one whose reason is not a reviewer failure —
+deliberately **not** every `skipped`); zero unresolved non-outdated review
+threads; and green non-reviewer baseline checks — evaluated immediately before
+the platform is dispatched, fail-closed when any input is missing or stale, with
+one explicit documented override for manual escalation.
 A gate that holds the reviewer back **defers** rather than skipping: it sets the
 loop's aggregate to `needs_fixes` so readiness is withheld and Step 7 re-runs,
 which is what makes the deferral guaranteed rather than merely hoped for.
@@ -58,7 +61,8 @@ implementation is ordered.
 | `codex-github` dispatch path | `grep -n "codex-github" scripts/development-workflow/pr-review-loop.sh` | Dispatched via `run_codex_github_review` at the `codex-github)` case of `run_platform_review`; `codex_github_defaults_should_apply` already tests membership with `array_contains_value` |
 | `codex-github` is not configured here | `sed -n '/^review:/,/^ *guardrails:/p' .ai-dev-workflow.yaml` | This repository's `on_draft.github` is `local-ai-reviewer, pr-agent` and `on_ready.github` is `bugbot`; `codex-github` appears in neither, so the gate must be inert-by-absence here and exercised through harness fixtures |
 | Evidence keys come from #1648 | `gh pr view 1660 --json state --jq .state` and the plan on that PR | `LOCAL_AI_CONFIGURED` / `LOCAL_AI_HEAD_CURRENT` are defined by #1648, whose plan PR #1660 is `ready-for-human-review` and not yet merged |
-| Baseline vs reviewer checks | `grep -n "REVIEWER_CHECKS\|REVIEWER_CHECK_COUNT" scripts/development-workflow/pr-ci-loop.sh` | `pr-ci-loop.sh` already separates reviewer-owned checks from baseline checks and emits `REVIEWER_CHECKS` / `REVIEWER_CHECKS_JSON`, so the gate can reuse that classification rather than inventing one |
+| Baseline vs reviewer checks | `sed -n '112,147p' scripts/development-workflow/pr-ci-loop.sh` | The classification lives in one function, `configured_reviewer_check_names_json`, which maps configured review platforms to their GitHub check names (`haystack` → `Haystack / Review`, `bugbot` → `Cursor Bugbot`). Everything downstream — `REVIEWER_CHECK_COUNT`, `REVIEWER_CHECKS`, `REVIEWER_CHECKS_JSON` — is `jq` over that one list, so relocating the function is enough to share it |
+| Both scripts already share a library | `grep -n "source .*workflow-lib" scripts/development-workflow/pr-ci-loop.sh scripts/development-workflow/pr-review-loop.sh` | Both source `workflow-lib.sh` at line 7 and line 10 respectively, so the function can move there with no new dependency and no change to either script's load order |
 | `codex-github` integration doc exists | `ls docs/workflow/development-workflow/integrations/` | `codex-github.md` is present alongside `local-ai-reviewer.md`, `pr-agent.md`, and `bugbot.md`, so the gate's documentation target already exists and no new file is created |
 | Reviewer-loop protocol target | `grep -c "" docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` | 1142 lines; this is the protocol that documents loop behavior, and is the right home for the gate's normative description |
 | Cycle caps exist | `grep -n "MAX_CYCLES\|MAX_TOTAL_CYCLES" scripts/development-workflow/pr-review-loop.sh` | Dual caps are present: `max_cycles` per run and `max_total_cycles` per PR lifetime |
@@ -121,7 +125,7 @@ Not applicable — this repository ships workflow tooling, not a service.
       | 1 | `LOCAL_AI_CONFIGURED` is exactly `1` **and** `LOCAL_AI_HEAD_CURRENT` is exactly `1` | `local_reviewer_not_configured` when `LOCAL_AI_CONFIGURED` is `0`; `local_evidence_stale` when `LOCAL_AI_HEAD_CURRENT` is `0`; `local_evidence_missing` when either is empty, unset, or any value other than `0` or `1` |
       | 2 | Every platform in this reviewer's **peer set** (defined below) has already run in this invocation **and** produced acceptable peer evidence | `peer_reviewer_not_run` when one has not run yet; `peer_reviewer_not_clean` when one ran without producing acceptable evidence |
       | 3 | Zero unresolved, non-outdated review threads | `unresolved_threads` |
-      | 4 | Every non-reviewer check is `SUCCESS`, `SKIPPED`, or `NEUTRAL` | `baseline_checks_not_green` when one failed; `baseline_checks_pending` when one is still running |
+      | 4 | Every non-reviewer check on `loop_head_sha` is `SUCCESS`, `SKIPPED`, or `NEUTRAL` | `baseline_checks_not_green` when one failed; `baseline_checks_pending` when one is still running |
 
 - [ ] **Reorder expensive reviewers last *within their own phase bucket*.** Add
       `reorder_expensive_reviewers_last`, called once after the platform list is
@@ -147,6 +151,35 @@ Not applicable — this repository ships workflow tooling, not a service.
 - [ ] Emit `EXPENSIVE_REVIEWERS_REORDERED=1` and the reordered `PLATFORM_LIST`
       when the partition changed the order, so the behavior is visible rather
       than a silent rewrite of the caller's configuration.
+- [ ] **Share the reviewer/baseline check classification by relocating one
+      function — do not call `pr-ci-loop.sh`.** Condition 4 needs to know which
+      checks are reviewer-owned so a reviewer's own check cannot gate that
+      reviewer. That classification exists today as
+      `configured_reviewer_check_names_json` in
+      `scripts/development-workflow/pr-ci-loop.sh` (lines 112–147); everything
+      downstream of it — `REVIEWER_CHECK_COUNT`, `REVIEWER_CHECKS`,
+      `REVIEWER_CHECKS_JSON` — is `jq` over the list it returns. The concrete
+      change:
+      1. Move `configured_reviewer_check_names_json` **verbatim** from
+         `pr-ci-loop.sh` into `scripts/development-workflow/workflow-lib.sh`,
+         and delete the local definition. Both scripts already source
+         `workflow-lib.sh` (`pr-ci-loop.sh` line 7, `pr-review-loop.sh`
+         line 10), so no new dependency and no load-order change is introduced.
+         This is a pure relocation of already-proven logic with no behavior
+         change; state that exemption rationale in the PR per
+         `docs/best-practices/3-testing.md`.
+      2. Add `expensive_gate_baseline_checks_status <pr_number> <head_sha>` in
+         `pr-review-loop.sh`. It fetches the check rollup **once** via
+         `gh pr view --json statusCheckRollup,headRefOid`, excludes any check
+         whose name appears in `configured_reviewer_check_names_json`, and
+         prints one of `green`, `failed`, `pending`, or `unavailable` plus the
+         live head it observed.
+      3. **Do not invoke `pr-ci-loop.sh` from the gate.** That script is a
+         polling loop with its own waits and its own exit semantics; calling it
+         here would block the reviewer loop inside a gate that must be a
+         non-blocking snapshot, and would conflate "CI is not green yet" with
+         "the gate says wait". The gate takes a snapshot; the CI loop remains
+         Step 8's job.
 - [ ] **Define acceptable peer evidence — not every `skipped` counts.**
       Accepting any `skipped` peer would let `codex-github` dispatch when a
       configured peer was unavailable, timed out, or was rejected for
@@ -495,6 +528,11 @@ reads them against each other and fails on any divergence.
     `EXPENSIVE_GATE_DEFERRALS=-1`, and the loop escalates. Without this the
     bounded-deferral guarantee would hold only when the ledger happens to be
     readable, which is not a guarantee.
+20. The relocation is behavior-preserving: `pr-ci-loop.sh` produces identical
+    `REVIEWER_CHECK_COUNT`, `REVIEWER_CHECKS` and `REVIEWER_CHECKS_JSON` before
+    and after `configured_reviewer_check_names_json` moves to
+    `workflow-lib.sh`, and `expensive_gate_baseline_checks_status` classifies
+    the same check names as reviewer-owned.
 19b. The ledger is **absent** — no summary comment yet, or a body with no
     history marker — → `EXPENSIVE_GATE_DEFERRALS=0` and the gate defers or
     dispatches normally. This is every PR's first reviewer-loop run; escalating
@@ -506,6 +544,13 @@ reads them against each other and fails on any divergence.
 - `scripts/development-workflow/tests/test-pr-review-loop.sh` — scenarios 1–14
   (including 6b), 18 and 19, as new cases in the existing `HARNESS_MODE=1`
   harness.
+- `scripts/development-workflow/tests/test-pr-ci-loop.sh` — scenario 20, which
+  asserts that `pr-ci-loop.sh` still produces the same `REVIEWER_CHECK_COUNT`,
+  `REVIEWER_CHECKS` and `REVIEWER_CHECKS_JSON` after
+  `configured_reviewer_check_names_json` moves to `workflow-lib.sh`. Its
+  existing `# covers:` mapping already selects it for a `pr-ci-loop.sh` change;
+  add `# covers: scripts/development-workflow/workflow-lib.sh` so a later edit
+  to the relocated function also selects it.
 - `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` — a new
   suite for scenarios 15–17, the override and composition cases, which need
   their own mock scaffolding for the phase and filter paths. It must declare:
@@ -545,6 +590,7 @@ concrete file and line:
 | P5 | Ordering regression: **delete the `reorder_expensive_reviewers_last` call**, leaving a platform list that declares `codex-github` before `pr-agent` | a scratch copy of the platform-resolution block | scenario 6 fails and scenario 7's suppressed-reorder case shows the gate deferring on every invocation with `peer_reviewer_not_run` — a deferral that can never resolve; restoring the call passes |
 | P9 | Phase-bucket regression: replace the per-bucket partition with a single global one | a scratch copy of `reorder_expensive_reviewers_last` | scenario 6b fails, because a draft-configured `codex-github` is placed after the ready-phase `bugbot` and therefore runs only after `gh pr ready`; restoring the per-bucket partition passes |
 | P10 | Peer-evidence regression: accept any `skipped` peer instead of consulting `reviewer_failed_label_required_for_result` | a scratch copy of condition 2 | scenario 8's `unavailable`, `timeout` and `unauthorized` rows fail, because the gate dispatches with a peer that never produced a verdict; restoring the helper call passes |
+| P14 | Reviewer-check-classification regression: make `expensive_gate_baseline_checks_status` treat every check as a baseline check | a scratch copy of the helper | scenario 10's reviewer-owned-pending row fails, because `codex-github` waits on a check it is responsible for producing; restoring the `configured_reviewer_check_names_json` exclusion passes |
 | P13 | Peer-set regression: widen the peer set from the preceding platforms back to every non-expensive platform in the resolved list | a scratch copy of the peer-set computation | scenario 7's first row fails, because a draft-phase `codex-github` waits on a ready-phase `bugbot` that cannot have run yet and defers until the cap; restoring the phase-scoped set passes |
 | P6 | Readiness regression: make a defer leave the aggregate result unchanged instead of setting `needs_fixes` | a scratch copy of the gate call site | scenario 3's aggregate assertion fails, and a run in which `codex-github` never executed would satisfy Protocol 92's readiness conditions; restoring the `needs_fixes` aggregate passes |
 | P7 | Unbounded-deferral regression: replace the head-scoped deferral counter with the existing `reviewer_loop_history_entries_count` caps | a scratch copy of the cap check | scenario 13 fails, because repeated `needs_fixes` results on one unchanged head collapse under that function's `unique` bucketing by `head_sha` + `result` and neither cap ever trips; restoring the dedicated counter escalates with `expensive_gate_deferral_cap` |
@@ -552,7 +598,7 @@ concrete file and line:
 | P11 | Absent-ledger regression: change the counter to return `-1` for an absent ledger as well as a malformed one | same fixture | scenario 19b fails, because a PR with no prior reviewer-loop history escalates on its first run and the bound is never exercised; restoring the three-state mapping passes |
 | P12 | Deny-list regression: rewrite condition 1 to reject only `0` and empty rather than requiring exactly `1` | a scratch copy of condition 1 | scenario 4's `2` and `true` rows fail, because the gate dispatches with an unrecognized evidence value; restoring the exact-match allow-list passes |
 
-Record all thirteen in the implementation PR under a `Planted-Violation Proofs`
+Record all fourteen in the implementation PR under a `Planted-Violation Proofs`
 heading, each with the command, the file and line of the planted violation, and
 both outcomes.
 
@@ -626,7 +672,8 @@ with mock `gh` commands and require no network access.
 | Fail-closed on unreadable evidence turns a transient API blip into a permanent defer | Med | Med | A defer is per-invocation, not sticky: the `needs_fixes` aggregate makes Protocol 91 re-run Step 7, which re-evaluates from scratch. The bound is the gate's own head-scoped deferral counter, not the existing dual cycle caps — those cannot see a deferral loop, as the Verification Log records — and an unreadable budget escalates rather than deferring again. The gate adds no retry path of its own, so it cannot loop |
 | The gate contradicts the existing phase mechanism | Med | High — two gates disagreeing on whether a platform runs is worse than either alone | Composition is specified explicitly (phase gate first, then this gate; `--pre-after-clean-only` filters before both) and pinned by scenarios 16 and 17, including the no-phantom-telemetry case |
 | Implementation starts before #1648 lands and wires the gate to keys that do not exist | Med | High — the gate would read unset variables and hold everything, or be written against a guessed contract | Recorded as a Conflict in the Cross-Cutting check and as Implementation Order step 0, which is a hard stop that verifies #1648 is merged into the approved base before any edit |
-| A reviewer's own check gates that reviewer | Low | Med — `codex-github` would wait on a check it is responsible for producing | Condition 4 evaluates non-reviewer checks only, reusing the reviewer/baseline classification `pr-ci-loop.sh` already emits rather than a new one; scenario 10's third case pins it |
+| A reviewer's own check gates that reviewer | Low | Med — `codex-github` would wait on a check it is responsible for producing | Condition 4 evaluates non-reviewer checks only, excluding the names returned by `configured_reviewer_check_names_json`, which moves from `pr-ci-loop.sh` to `workflow-lib.sh` so both callers share one definition rather than two drifting copies; scenario 10's third case and proof P14 pin it |
+| The shared classification is duplicated or the gate blocks on the CI loop | Med | Med — a duplicated copy drifts, and calling `pr-ci-loop.sh` would make a snapshot gate poll | The plan names the exact function, the exact destination file, the fact that both scripts already source it, and an explicit prohibition on invoking `pr-ci-loop.sh` from the gate; scenario 20 asserts the relocation is behavior-preserving |
 | Platform ordering decides whether the gate is effective | Med | High — a config listing `codex-github` first would either dispatch it before the cheap reviewers ran, or defer at the same point forever | Detection is not enough, so the loop reorders: `reorder_expensive_reviewers_last` moves expensive platforms to the end of their own bucket before iteration, making the gate's precondition reachable; condition 2's peer set is computed from the reordered list, so `peer_reviewer_not_run` fires as a defensive assertion if the reorder did not happen. Scenarios 6 and 7 and proof P5 pin both halves |
 | The peer set and the phase-bucket reorder contradict each other | Med | High — a draft-phase expensive reviewer would wait on a ready-phase peer that cannot have run yet, deadlocking until the cap | The peer set is the platforms that *precede* this reviewer under the reordered list — its own bucket's non-expensive platforms plus every earlier bucket — rather than the whole resolved list; scenario 7's table and proof P13 pin it, including the draft-plus-ready configuration |
 | The reorder silently moves a reviewer across the draft/ready boundary | Med | High — a draft-configured expensive reviewer would run only after `gh pr ready`, inverting the configuration contract | The partition is per phase bucket, assigned with the existing `is_phase_after_clean_platform` predicate, and the buckets are concatenated in their original order; scenario 6b and proof P9 pin it |
@@ -748,6 +795,12 @@ Summary-comment line, illustrative:
    mirroring `reviewer_loop_history_entries_count`'s own three states.
    **Verify**: scenarios 13, 14, 19 and 19b — the count reflects only the
    current head, an absent ledger yields `0`, and a malformed one yields `-1`.
+3b. Move `configured_reviewer_check_names_json` verbatim from `pr-ci-loop.sh`
+   to `workflow-lib.sh`, delete the local definition, and add
+   `expensive_gate_baseline_checks_status`. **Verify**: scenario 20 — the CI
+   loop's three reviewer-check outputs are unchanged, and the new helper
+   classifies the same names as reviewer-owned. Do not call `pr-ci-loop.sh`
+   from the gate.
 4. Add `expensive_reviewer_gate` with the conditions in the documented order,
    condition 2 computing the peer set from the reordered list and this
    reviewer's index in it and delegating acceptance to
@@ -791,7 +844,7 @@ Summary-comment line, illustrative:
     **Verify**: both suites exit 0, and
     `scripts/development-workflow/select-test-suites.sh` selects the new suite
     for a change touching only `pr-review-loop.sh`.
-11. Produce the thirteen planted-violation proofs (P1–P13) and record them in the PR
+11. Produce the fourteen planted-violation proofs (P1–P14) and record them in the PR
     under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
     at a concrete file and line — failing with the violation planted, passing
     once removed.
@@ -803,7 +856,7 @@ Summary-comment line, illustrative:
     containing exactly:
 
     ```markdown
-    - **Gate expensive reviewers on current-head local evidence** (#1649): `codex-github` now runs only after the local reviewer, peer reviewers, review threads, and baseline checks are clean on the current head, and defers fail-closed when that evidence is missing or stale.
+    - **Gate expensive reviewers on current-head local evidence** (#1649): `codex-github` now runs only after the local reviewer is clean on the current head, every reviewer that precedes it has produced acceptable evidence, review threads are resolved, and non-reviewer checks are green — and defers fail-closed, with a bounded retry budget, when that evidence is missing or stale.
     ```
 
 14. Update project docs per **Documentation Updates** above (step 9 covers

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -275,6 +275,27 @@ Not applicable — this repository ships workflow tooling, not a service.
       failing, so a stuck gate reaches a human instead of cycling silently. The
       counter resets naturally when the head moves, because it is scoped to
       `loop_head_sha`.
+- [ ] **Validate `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` before using it.**
+      An unvalidated value is passed straight into `[ "$deferrals" -ge "$max" ]`,
+      where a non-integer raises `integer expression expected` and the
+      comparison silently evaluates false — defeating the cap entirely — and
+      where `0` or a negative number would trip the cap before the first
+      deferral, escalating every gated PR immediately. Resolve it with
+      `expensive_gate_resolve_max_deferrals`, following the convention
+      `reviewer_loop_resolve_max_cycles` already establishes in this script:
+
+      | Configured value | Effective value |
+      | --- | --- |
+      | Unset or empty | `3` (the default) |
+      | A positive integer within `1`–`999999` | that value |
+      | `0`, a negative number, a non-integer, or a value above `999999` | `3`, with a `WARN` on stderr naming the rejected value |
+
+      The upper bound and the `WARN`-and-fall-back behavior are copied from
+      `reviewer_loop_resolve_max_cycles` deliberately: two bounds resolvers in
+      one script that disagree about what a bad value means is its own defect.
+      Resolve once per run, not per gate call, and emit the effective value as
+      `EXPENSIVE_GATE_MAX_DEFERRALS` so the bound in force is visible alongside
+      `EXPENSIVE_GATE_DEFERRALS`.
 - [ ] **The deferral counter is fail-closed only on a genuinely unreadable
       ledger — an absent one is the normal first run.** The counter mirrors the
       three states `reviewer_loop_history_entries_count` already distinguishes,
@@ -379,6 +400,7 @@ Not applicable — this repository ships workflow tooling, not a service.
       | `EXPENSIVE_GATE_REASON` | the unmet-condition reason; empty when `dispatched` | always |
       | `EXPENSIVE_GATE_HEAD` | the `loop_head_sha` the gate evaluated | always |
       | `EXPENSIVE_GATE_DEFERRALS` | deferrals the ledger records for this head, so the distance to the cap is visible before it trips; `-1` when the ledger could not be read, matching the existing `reviewer_loop_history_entries_count` convention | always |
+      | `EXPENSIVE_GATE_MAX_DEFERRALS` | the effective bound after validation, so a rejected or defaulted configuration is visible next to the count it bounds | always |
       | `EXPENSIVE_GATE_ESCALATION` | `expensive_gate_deferral_cap` \| `expensive_gate_deferral_budget_unreadable` | **only** when `EXPENSIVE_GATE_RESULT` is `deferral_cap`; absent otherwise, so its presence is itself the escalation signal and the two causes never have to be re-derived from the count |
 
       `EXPENSIVE_REVIEWERS_REORDERED` is emitted once per run, not per platform.
@@ -552,6 +574,14 @@ reads them against each other and fails on any divergence.
     kept failing is still reported. With one fewer recorded deferral it defers
     normally. This is the scenario the existing dual caps cannot cover, because
     they bucket `needs_fixes` uniquely by head and result.
+14b. `expensive_gate_resolve_max_deferrals` returns `3` for unset and empty;
+    the configured value for `1` and `999999`; and `3` with a `WARN` on stderr
+    for `0`, `-1`, `1000000`, `abc`, `2.5`, and a value with surrounding
+    whitespace. `EXPENSIVE_GATE_MAX_DEFERRALS` reports the effective value in
+    every case. Without validation a non-integer makes `[ -ge ]` raise
+    `integer expression expected` and evaluate false, defeating the cap, while
+    `0` or a negative value trips it before the first deferral and escalates
+    every gated PR.
 14. The deferral counter is head-scoped: deferrals recorded against a different
     `expensive_gate.head` do not count toward the cap for the current head, so a
     new push starts the budget over.
@@ -657,6 +687,7 @@ concrete file and line:
 | P5 | Ordering regression: **delete the `reorder_expensive_reviewers_last` call**, leaving a platform list that declares `codex-github` before `pr-agent` | a scratch copy of the platform-resolution block | scenario 6 fails and scenario 7's suppressed-reorder case shows the gate deferring on every invocation with `peer_reviewer_not_run` — a deferral that can never resolve; restoring the call passes |
 | P9 | Phase-bucket regression: replace the per-bucket partition with a single global one | a scratch copy of `reorder_expensive_reviewers_last` | scenario 6b fails, because a draft-configured `codex-github` is placed after the ready-phase `bugbot` and therefore runs only after `gh pr ready`; restoring the per-bucket partition passes |
 | P10 | Peer-evidence regression: accept any `skipped` peer instead of consulting `reviewer_failed_label_required_for_result` | a scratch copy of condition 2 | scenario 8's `unavailable`, `timeout` and `unauthorized` rows fail, because the gate dispatches with a peer that never produced a verdict; restoring the helper call passes |
+| P18 | Unvalidated-bound regression: pass `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS=abc` and then `=0` with the validation removed | the deferral-budget fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | with `abc` the comparison errors and the cap never trips, so scenario 13's escalation fails; with `0` every gated PR escalates before its first deferral, so scenario 3's defer fails. Restoring `expensive_gate_resolve_max_deferrals` makes both pass with the documented fallback |
 | P17 | Environment-read regression: change the gate to read `LOCAL_AI_CONFIGURED` and `LOCAL_AI_HEAD_CURRENT` as environment variables instead of calling the two derivation helpers | a scratch copy of condition 1 | scenario 22 fails and every condition-1 case defers with `local_evidence_missing`, because those names are stdout keys printed at end of run and are unset during the platform iteration; restoring the helpers passes |
 | P16 | Vacuous-green regression: make `expensive_gate_baseline_checks_status` return `green` for an empty non-reviewer check set | a scratch copy of the helper | scenario 10's two empty cases fail, because the gate dispatches with no baseline evidence on a head whose CI has not registered; restoring the `empty` state defers with `baseline_checks_unobserved` |
 | P15 | No-short-circuit regression: make a `deferred` result set the aggregate without breaking out of the platform iteration | a scratch copy of the gate call site | scenario 21 fails, because the loop continues to the ready-phase platform and calls `gh pr ready` on a PR whose draft-phase expensive reviewer never ran; restoring the break passes |
@@ -668,7 +699,7 @@ concrete file and line:
 | P11 | Absent-ledger regression: change the counter to return `-1` for an absent ledger as well as a malformed one | same fixture | scenario 19b fails, because a PR with no prior reviewer-loop history escalates on its first run and the bound is never exercised; restoring the three-state mapping passes |
 | P12 | Deny-list regression: rewrite condition 1 to reject only `0` and empty rather than requiring exactly `1` | a scratch copy of condition 1 | scenario 4's `2` and `true` rows fail, because the gate dispatches with an unrecognized evidence value; restoring the exact-match allow-list passes |
 
-Record all seventeen in the implementation PR under a `Planted-Violation Proofs`
+Record all eighteen in the implementation PR under a `Planted-Violation Proofs`
 heading, each with the command, the file and line of the planted violation, and
 both outcomes.
 
@@ -741,6 +772,7 @@ with mock `gh` commands and require no network access.
 
 | Risk | Likelihood | Impact | Mitigation |
 | --- | --- | --- | --- |
+| A misconfigured deferral bound defeats or inverts the cap | Med | High — a non-integer makes the comparison error and evaluate false so the cap never trips, while `0` escalates every gated PR before its first deferral | `expensive_gate_resolve_max_deferrals` validates to a positive integer in `1`–`999999`, `WARN`s and falls back to `3` otherwise, and mirrors `reviewer_loop_resolve_max_cycles` so the script has one convention rather than two; the effective value is emitted as `EXPENSIVE_GATE_MAX_DEFERRALS`. Scenario 14b and proof P18 pin both failure directions |
 | The gate silently stops `codex-github` from ever running | Med | High — the expensive reviewer's findings are the reason this epic exists; losing them entirely is worse than running it too often | A defer is never terminal and never unbounded: it sets the aggregate to `needs_fixes` / `expensive_gate_deferred` so readiness is withheld and Step 7 re-runs, and a head-scoped counter escalates with `expensive_gate_deferral_cap` after `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` deferrals so a stuck gate reaches a human. Every defer names one reason in both the summary comment and the ledger, and `EXPENSIVE_GATE_DEFERRALS` shows the distance to the cap before it trips. Scenarios 3, 13 and 14 pin the three halves |
 | A deferral loop is invisible to the existing cycle caps | Med | High — the gate could cycle indefinitely on one unchanged head with neither cap advancing | `reviewer_loop_history_entries_count` buckets qualifying entries `unique` over `head_sha + "\|" + result`, so repeated `needs_fixes` on one head counts once; the plan therefore adds its own occurrence-counted, head-scoped deferral counter rather than relying on those caps, and proof P7 plants the reliance to demonstrate that it does not bound anything |
 | A consumer that never configures a local reviewer is blocked forever | Med | High — downstream template consumers would stall | The brief requires fail-closed on missing local evidence, so the gate defers rather than inventing an implicit dispatch. The release valves are explicit: the deferral cap escalates to a human after a bounded number of tries, and `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS` covers a one-off run. Scenario 5 pins the defer and scenario 13 the escalation |
@@ -830,7 +862,7 @@ expensive_reviewer_gate() {
       print_kv EXPENSIVE_GATE_ESCALATION expensive_gate_deferral_budget_unreadable
       return 1
     fi
-    if [ "$deferrals" -ge "${PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS:-3}" ]; then
+    if [ "$deferrals" -ge "$(expensive_gate_resolve_max_deferrals)" ]; then
       # Stop cycling; escalate so a human sees which condition kept failing.
       print_kv EXPENSIVE_GATE_RESULT deferral_cap
       print_kv EXPENSIVE_GATE_ESCALATION expensive_gate_deferral_cap
@@ -882,6 +914,10 @@ Summary-comment line, illustrative:
    mirroring `reviewer_loop_history_entries_count`'s own three states.
    **Verify**: scenarios 13, 14, 19 and 19b — the count reflects only the
    current head, an absent ledger yields `0`, and a malformed one yields `-1`.
+3.0 Add `expensive_gate_resolve_max_deferrals`, mirroring
+   `reviewer_loop_resolve_max_cycles`: default `3`, accept `1`–`999999`,
+   `WARN` and fall back on anything else, resolved once per run. **Verify**:
+   scenario 14b covers unset, empty, both bounds, and five rejected forms.
 3a. Add `expensive_gate_local_ai_configured` (membership of
    `local-ai-reviewer` in the resolved `platforms[@]`) and
    `expensive_gate_local_ai_head_current <head_sha>` (which applies #1648's
@@ -947,7 +983,7 @@ Summary-comment line, illustrative:
     `scripts/development-workflow/select-test-suites.sh` selects the new suite
     for a change touching only `pr-review-loop.sh` and selects
     `test-pr-ci-loop.sh` for a change touching only `workflow-lib.sh`.
-11. Produce the seventeen planted-violation proofs (P1–P17) and record them in the PR
+11. Produce the eighteen planted-violation proofs (P1–P18) and record them in the PR
     under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
     at a concrete file and line — failing with the violation planted, passing
     once removed.

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -125,7 +125,7 @@ Not applicable — this repository ships workflow tooling, not a service.
       | 1 | `LOCAL_AI_CONFIGURED` is exactly `1` **and** `LOCAL_AI_HEAD_CURRENT` is exactly `1` | `local_reviewer_not_configured` when `LOCAL_AI_CONFIGURED` is `0`; `local_evidence_stale` when `LOCAL_AI_HEAD_CURRENT` is `0`; `local_evidence_missing` when either is empty, unset, or any value other than `0` or `1` |
       | 2 | Every platform in this reviewer's **peer set** (defined below) has already run in this invocation **and** produced acceptable peer evidence | `peer_reviewer_not_run` when one has not run yet; `peer_reviewer_not_clean` when one ran without producing acceptable evidence |
       | 3 | Zero unresolved, non-outdated review threads | `unresolved_threads` |
-      | 4 | Every non-reviewer check on `loop_head_sha` is `SUCCESS`, `SKIPPED`, or `NEUTRAL` | `baseline_checks_not_green` when one failed; `baseline_checks_pending` when one is still running |
+      | 4 | The non-reviewer check set on `loop_head_sha` is **non-empty** and every member is `SUCCESS`, `SKIPPED`, or `NEUTRAL` | `baseline_checks_not_green` when one failed; `baseline_checks_pending` when one is still running; `baseline_checks_unobserved` when the set is empty |
 
 - [ ] **Reorder expensive reviewers last *within their own phase bucket*.** Add
       `reorder_expensive_reviewers_last`, called once after the platform list is
@@ -172,8 +172,26 @@ Not applicable — this repository ships workflow tooling, not a service.
          `pr-review-loop.sh`. It fetches the check rollup **once** via
          `gh pr view --json statusCheckRollup,headRefOid`, excludes any check
          whose name appears in `configured_reviewer_check_names_json`, and
-         prints one of `green`, `failed`, `pending`, or `unavailable` plus the
-         live head it observed.
+         prints one of `green`, `failed`, `pending`, `empty`, or `unavailable`
+         plus the live head it observed.
+      2b. **An empty check set is not green.** "Every member is green" is
+         vacuously true of an empty set, so a snapshot taken before CI jobs
+         register on the new head would dispatch the expensive reviewer with no
+         baseline evidence at all — the fail-closed contract inverted by a
+         quantifier. `expensive_gate_baseline_checks_status` therefore returns
+         a distinct `empty` state, and the gate defers with
+         `baseline_checks_unobserved`.
+
+         The gate deliberately does **not** try to distinguish "this repository
+         legitimately runs no baseline checks" from "the checks have not
+         registered yet": a single rollup snapshot cannot tell them apart, and
+         guessing would reintroduce the vacuous-green hole. Both defer. A
+         repository with genuinely no baseline CI reaches a human through the
+         deferral cap after `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` rounds,
+         with `baseline_checks_unobserved` naming the cause — which is the right
+         outcome, because "run an expensive reviewer with no CI at all" is a
+         decision worth a human, not a default. `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS`
+         covers the one-off case.
       3. **Do not invoke `pr-ci-loop.sh` from the gate.** That script is a
          polling loop with its own waits and its own exit semantics; calling it
          here would block the reviewer loop inside a gate that must be a
@@ -492,10 +510,15 @@ reads them against each other and fails on any divergence.
    duplicated list, so a future change to that helper moves this gate with it.
 9. One unresolved non-outdated review thread → `deferred` /
    `unresolved_threads`; the same thread marked outdated → `dispatched`.
-10. A failing baseline check → `deferred` / `baseline_checks_not_green`; a
-    pending one → `deferred` / `baseline_checks_pending`; a reviewer-owned check
-    that is pending → `dispatched`, because a reviewer's own check must not gate
-    the reviewer.
+10. Baseline-check states, one case each: a failing check → `deferred` /
+    `baseline_checks_not_green`; a pending one → `deferred` /
+    `baseline_checks_pending`; a reviewer-owned check that is pending →
+    `dispatched`, because a reviewer's own check must not gate the reviewer; an
+    **empty** non-reviewer set → `deferred` / `baseline_checks_unobserved`, and
+    a set containing only reviewer-owned checks → the same, since filtering
+    leaves it empty. The two empty cases are the vacuous-green guard: "every
+    member is green" is trivially true of an empty set, so an unguarded
+    implementation would dispatch with no baseline evidence.
 11. The threads or checks query returns a live head different from
     `loop_head_sha` → `deferred` / `evidence_head_moved`. Without this, evidence
     from a newer commit could authorize dispatch against reviewer verdicts taken
@@ -608,6 +631,7 @@ concrete file and line:
 | P5 | Ordering regression: **delete the `reorder_expensive_reviewers_last` call**, leaving a platform list that declares `codex-github` before `pr-agent` | a scratch copy of the platform-resolution block | scenario 6 fails and scenario 7's suppressed-reorder case shows the gate deferring on every invocation with `peer_reviewer_not_run` — a deferral that can never resolve; restoring the call passes |
 | P9 | Phase-bucket regression: replace the per-bucket partition with a single global one | a scratch copy of `reorder_expensive_reviewers_last` | scenario 6b fails, because a draft-configured `codex-github` is placed after the ready-phase `bugbot` and therefore runs only after `gh pr ready`; restoring the per-bucket partition passes |
 | P10 | Peer-evidence regression: accept any `skipped` peer instead of consulting `reviewer_failed_label_required_for_result` | a scratch copy of condition 2 | scenario 8's `unavailable`, `timeout` and `unauthorized` rows fail, because the gate dispatches with a peer that never produced a verdict; restoring the helper call passes |
+| P16 | Vacuous-green regression: make `expensive_gate_baseline_checks_status` return `green` for an empty non-reviewer check set | a scratch copy of the helper | scenario 10's two empty cases fail, because the gate dispatches with no baseline evidence on a head whose CI has not registered; restoring the `empty` state defers with `baseline_checks_unobserved` |
 | P15 | No-short-circuit regression: make a `deferred` result set the aggregate without breaking out of the platform iteration | a scratch copy of the gate call site | scenario 21 fails, because the loop continues to the ready-phase platform and calls `gh pr ready` on a PR whose draft-phase expensive reviewer never ran; restoring the break passes |
 | P14 | Reviewer-check-classification regression: make `expensive_gate_baseline_checks_status` treat every check as a baseline check | a scratch copy of the helper | scenario 10's reviewer-owned-pending row fails, because `codex-github` waits on a check it is responsible for producing; restoring the `configured_reviewer_check_names_json` exclusion passes |
 | P13 | Peer-set regression: widen the peer set from the preceding platforms back to every non-expensive platform in the resolved list | a scratch copy of the peer-set computation | scenario 7's first row fails, because a draft-phase `codex-github` waits on a ready-phase `bugbot` that cannot have run yet and defers until the cap; restoring the phase-scoped set passes |
@@ -617,7 +641,7 @@ concrete file and line:
 | P11 | Absent-ledger regression: change the counter to return `-1` for an absent ledger as well as a malformed one | same fixture | scenario 19b fails, because a PR with no prior reviewer-loop history escalates on its first run and the bound is never exercised; restoring the three-state mapping passes |
 | P12 | Deny-list regression: rewrite condition 1 to reject only `0` and empty rather than requiring exactly `1` | a scratch copy of condition 1 | scenario 4's `2` and `true` rows fail, because the gate dispatches with an unrecognized evidence value; restoring the exact-match allow-list passes |
 
-Record all fifteen in the implementation PR under a `Planted-Violation Proofs`
+Record all sixteen in the implementation PR under a `Planted-Violation Proofs`
 heading, each with the command, the file and line of the planted violation, and
 both outcomes.
 
@@ -646,7 +670,7 @@ by the same sequential block that already writes `platform_result_tokens`.
 | Gate condition fixture | A table-driven set of the conditions with each one independently unmet, plus the eight-row unexpected-value table for condition 1, driving scenarios 2–5 and 9–11 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Platform-order fixture | A resolved list declaring `codex-github` first, an already-correct list, and a two-bucket list with `codex-github` on draft and `bugbot` on ready — driving scenarios 6, 6b and 7 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Peer-evidence fixture | One peer per row of scenario 8's table, covering `clean`, the three accepted skip reasons, the three rejected skip reasons, `needs_fixes` and `escalate` | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
-| Unreadable-input mocks | Mock `gh` commands that exit non-zero for the threads query and for the check rollup, driving scenario 12 and proof P3 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Unreadable-input mocks | Mock `gh` commands that exit non-zero for the threads query and for the check rollup, plus a rollup that returns an empty array and one containing only reviewer-owned checks — driving scenarios 10 and 12 and proofs P3 and P16 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Deferral-budget fixtures | Ledger payloads carrying `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` `expensive_gate.result=deferred` entries at the current head, one fewer, the same count at a different head, and an unparseable payload — driving scenarios 13, 14, 19 and 19b and proofs P7, P8 and P11 — including an absent ledger, a malformed one, and a well-formed one | inline heredocs in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Composition fixture | A platform list where `codex-github` is both a phase platform and an expensive reviewer, driving scenarios 16 and 17 | inline in `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` |
 | Legacy ledger payload | A `reviewer_loop_history.v1` entry with no `expensive_gate` object, driving scenario 18 | inline heredoc in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
@@ -692,6 +716,7 @@ with mock `gh` commands and require no network access.
 | A defer still triggers the ready-phase transition | Med | High — `gh pr ready` would convert the PR out of draft even though the draft-phase expensive reviewer never ran, a visible side effect from a gate that refused to proceed | A `deferred` or `deferral_cap` outcome breaks out of the platform iteration immediately, exactly as the existing non-clean short-circuit does, so no later platform is considered; scenario 21 and proof P15 pin it |
 | The gate contradicts the existing phase mechanism | Med | High — two gates disagreeing on whether a platform runs is worse than either alone | Composition is specified explicitly (phase gate first, then this gate; `--pre-after-clean-only` filters before both) and pinned by scenarios 16 and 17, including the no-phantom-telemetry case |
 | Implementation starts before #1648 lands and wires the gate to keys that do not exist | Med | High — the gate would read unset variables and hold everything, or be written against a guessed contract | Recorded as a Conflict in the Cross-Cutting check and as Implementation Order step 0, which is a hard stop that verifies #1648 is merged into the approved base before any edit |
+| An empty check set reads as green | Med | High — a snapshot taken before CI registers on the new head would dispatch with no baseline evidence, inverting the fail-closed contract by a quantifier | Condition 4 requires the non-reviewer set to be **non-empty** as well as all-green; an empty set defers with `baseline_checks_unobserved`. The gate does not guess whether the repository has no CI or the checks have not registered — both defer, and the deferral cap sends the genuinely-no-CI case to a human, which is the right owner for "run an expensive reviewer with no CI". Scenario 10's two empty cases and proof P16 pin it |
 | A reviewer's own check gates that reviewer | Low | Med — `codex-github` would wait on a check it is responsible for producing | Condition 4 evaluates non-reviewer checks only, excluding the names returned by `configured_reviewer_check_names_json`, which moves from `pr-ci-loop.sh` to `workflow-lib.sh` so both callers share one definition rather than two drifting copies; scenario 10's third case and proof P14 pin it |
 | The shared classification is duplicated or the gate blocks on the CI loop | Med | Med — a duplicated copy drifts, and calling `pr-ci-loop.sh` would make a snapshot gate poll | The plan names the exact function, the exact destination file, the fact that both scripts already source it, and an explicit prohibition on invoking `pr-ci-loop.sh` from the gate; scenario 20 asserts the relocation is behavior-preserving |
 | Platform ordering decides whether the gate is effective | Med | High — a config listing `codex-github` first would either dispatch it before the cheap reviewers ran, or defer at the same point forever | Detection is not enough, so the loop reorders: `reorder_expensive_reviewers_last` moves expensive platforms to the end of their own bucket before iteration, making the gate's precondition reachable; condition 2's peer set is computed from the reordered list, so `peer_reviewer_not_run` fires as a defensive assertion if the reorder did not happen. Scenarios 6 and 7 and proof P5 pin both halves |
@@ -872,7 +897,7 @@ Summary-comment line, illustrative:
     `scripts/development-workflow/select-test-suites.sh` selects the new suite
     for a change touching only `pr-review-loop.sh` and selects
     `test-pr-ci-loop.sh` for a change touching only `workflow-lib.sh`.
-11. Produce the fifteen planted-violation proofs (P1–P15) and record them in the PR
+11. Produce the sixteen planted-violation proofs (P1–P16) and record them in the PR
     under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
     at a concrete file and line — failing with the violation planted, passing
     once removed.

--- a/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
+++ b/docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md
@@ -119,22 +119,51 @@ Not applicable — this repository ships workflow tooling, not a service.
       | # | Condition | Unmet reason |
       | --- | --- | --- |
       | 1 | `LOCAL_AI_CONFIGURED` is `1` and `LOCAL_AI_HEAD_CURRENT` is `1` | `local_evidence_stale` when `LOCAL_AI_HEAD_CURRENT` is `0`; `local_evidence_missing` when it is empty or `LOCAL_AI_CONFIGURED` is unset; `local_reviewer_not_configured` when `LOCAL_AI_CONFIGURED` is `0` |
-      | 2 | **Every** non-expensive platform in the resolved platform list has already run in this invocation **and** returned `clean` or `skipped` | `peer_reviewer_not_run` when one has not run yet; `peer_reviewer_not_clean` when one ran and did not return clean or skipped |
+      | 2 | **Every** non-expensive platform in the resolved platform list has already run in this invocation **and** produced acceptable peer evidence (see below) | `peer_reviewer_not_run` when one has not run yet; `peer_reviewer_not_clean` when one ran without producing acceptable evidence |
       | 3 | Zero unresolved, non-outdated review threads | `unresolved_threads` |
       | 4 | Every non-reviewer check is `SUCCESS`, `SKIPPED`, or `NEUTRAL` | `baseline_checks_not_green` when one failed; `baseline_checks_pending` when one is still running |
 
-- [ ] **Reorder expensive reviewers to the end of the platform list.** Add
+- [ ] **Reorder expensive reviewers last *within their own phase bucket*.** Add
       `reorder_expensive_reviewers_last`, called once after the platform list is
-      resolved and before the iteration begins: it partitions `platforms` into
-      non-expensive followed by expensive, preserving relative order within each
-      partition. Detection alone is not enough — a configuration listing
-      `codex-github` before `pr-agent` would otherwise defer at the same point on
-      every invocation, because the loop would never reach `pr-agent` before the
-      gate, and the deferral would never resolve. Reordering makes the gate's
-      precondition reachable rather than merely checked. Emit
-      `EXPENSIVE_REVIEWERS_REORDERED=1` and the reordered `PLATFORM_LIST` when
-      the partition changed the order, so the behavior is visible rather than a
-      silent rewrite of the caller's configuration.
+      resolved and before the iteration begins. Detection alone is not enough —
+      a configuration listing `codex-github` before `pr-agent` would otherwise
+      defer at the same point on every invocation, because the loop would never
+      reach `pr-agent` before the gate, and the deferral would never resolve.
+      Reordering makes the gate's precondition reachable rather than merely
+      checked.
+- [ ] **The reorder must not cross the draft/ready boundary.** A single global
+      partition would move every expensive reviewer behind every non-expensive
+      one, including behind the ready-phase platforms: `codex-github` configured
+      in `review.on_draft.github` alongside `bugbot` in `review.on_ready.github`
+      would end up running only after `bugbot` triggered the ready-phase
+      transition, silently inverting the configuration contract that draft
+      reviewers run before `gh pr ready`. The function therefore partitions
+      **within each bucket independently** — the non-phase platforms among
+      themselves, the `phase_after_clean_platforms` among themselves — using
+      the existing `is_phase_after_clean_platform` predicate to assign buckets,
+      and concatenates the buckets in their original order. Relative order is
+      preserved within each partition. An expensive reviewer therefore runs last
+      among its own phase peers and never changes phase.
+- [ ] Emit `EXPENSIVE_REVIEWERS_REORDERED=1` and the reordered `PLATFORM_LIST`
+      when the partition changed the order, so the behavior is visible rather
+      than a silent rewrite of the caller's configuration.
+- [ ] **Define acceptable peer evidence — not every `skipped` counts.**
+      Accepting any `skipped` peer would let `codex-github` dispatch when a
+      configured peer was unavailable, timed out, or was rejected for
+      credentials, which is precisely the "no cheap pre-filter actually ran"
+      state this item exists to prevent, and it contradicts the summary's claim
+      that peers are clean. The rule reuses the classification the loop already
+      owns rather than inventing a second one: a peer's evidence is acceptable
+      when its result is `clean`, or when its result is `skipped` **and**
+      `reviewer_failed_label_required_for_result` returns false for that
+      `(result, reason)` pair. That function already treats
+      `unavailable`, `timeout`, `thread-check-failed`, `pending_timeout`,
+      `forbidden` and `unauthorized` skips as reviewer failures, so those defer;
+      deliberate policy skips such as `not_configured`, `explicit-skip` and
+      `release_pr` are accepted. Any `needs_fixes`, `needs_rerun` or `escalate`
+      peer defers. Reusing the existing helper means a future change to what
+      counts as a reviewer failure updates this gate automatically instead of
+      drifting from it.
 - [ ] **Condition 2 compares against the full resolved list**
       (`platforms[@]` minus the expensive ones), not the results collected up to
       this index. After reordering, every non-expensive platform has run by the
@@ -331,12 +360,34 @@ reads them against each other and fails on any divergence.
    already-correct list untouched with the flag unset. This is what makes the
    gate's precondition reachable: without it the loop would defer at the same
    point on every invocation and the deferral would never resolve.
+6b. The reorder respects phase buckets: with `codex-github` in
+    `review.on_draft.github` and `bugbot` in `review.on_ready.github`,
+    `codex-github` ends last **among the draft platforms** and still precedes
+    `bugbot`. A global partition would place it after `bugbot` and therefore
+    after the ready-phase transition, inverting the configuration contract that
+    draft reviewers run before `gh pr ready`.
 7. Condition 2 after reordering: with every non-expensive platform run and
    `clean`, → `dispatched`. With the reorder suppressed so a peer has not run,
    → `deferred` / `peer_reviewer_not_run` — the defensive assertion firing
-   rather than the gate silently dispatching.
-8. A peer reviewer that ran and returned `needs_fixes` → `deferred` /
-   `peer_reviewer_not_clean` — distinct from scenario 7's `peer_reviewer_not_run`.
+   rather than the gate silently dispatching. Scenario 8 covers what happens
+   once a peer *has* run.
+8. Peer evidence acceptance, one case per class — distinct from scenario 7's
+   `peer_reviewer_not_run`, which is about a peer that has not run at all:
+
+   | Peer result and reason | Gate outcome |
+   | --- | --- |
+   | `clean` | contributes to `dispatched` |
+   | `skipped` / `not_configured` | contributes to `dispatched` |
+   | `skipped` / `explicit-skip` | contributes to `dispatched` |
+   | `skipped` / `unavailable` | `deferred` / `peer_reviewer_not_clean` |
+   | `skipped` / `timeout` | `deferred` / `peer_reviewer_not_clean` |
+   | `skipped` / `unauthorized` | `deferred` / `peer_reviewer_not_clean` |
+   | `needs_fixes` | `deferred` / `peer_reviewer_not_clean` |
+   | `escalate` | `deferred` / `peer_reviewer_not_clean` |
+
+   The three accepted-skip rows and the three rejected-skip rows must be
+   asserted against `reviewer_failed_label_required_for_result` rather than a
+   duplicated list, so a future change to that helper moves this gate with it.
 9. One unresolved non-outdated review thread → `deferred` /
    `unresolved_threads`; the same thread marked outdated → `dispatched`.
 10. A failing baseline check → `deferred` / `baseline_checks_not_green`; a
@@ -388,8 +439,9 @@ reads them against each other and fails on any divergence.
 
 **Files**:
 
-- `scripts/development-workflow/tests/test-pr-review-loop.sh` — scenarios 1–14,
-  18 and 19, as new cases in the existing `HARNESS_MODE=1` harness.
+- `scripts/development-workflow/tests/test-pr-review-loop.sh` — scenarios 1–14
+  (including 6b), 18 and 19, as new cases in the existing `HARNESS_MODE=1`
+  harness.
 - `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` — a new
   suite for scenarios 15–17, the override and composition cases, which need
   their own mock scaffolding for the phase and filter paths. It must declare:
@@ -427,11 +479,13 @@ concrete file and line:
 | P3 | Unreadable evidence: make the review-threads query fail | same fixture | the gate defers with `evidence_unavailable_review_threads` **and** the aggregate becomes `needs_fixes` / `expensive_gate_deferred`, so readiness is withheld; restoring the query dispatches and leaves the aggregate clean |
 | P4 | Gate-not-wired regression: **delete the `expensive_reviewer_gate` call** from the per-platform block, leaving the function defined but unreachable | a scratch copy of the per-platform block in `scripts/development-workflow/pr-review-loop.sh` | scenario 3 fails, because `codex-github` is dispatched with stale local evidence and no `EXPENSIVE_GATE_*` telemetry is emitted; restoring the call passes. Deleting the call is the correct mutation: removing the `is_expensive_reviewer_platform` guard instead would consult the gate for *every* platform, which is a different defect and would not leave the gate unreachable |
 | P5 | Ordering regression: **delete the `reorder_expensive_reviewers_last` call**, leaving a platform list that declares `codex-github` before `pr-agent` | a scratch copy of the platform-resolution block | scenario 6 fails and scenario 7's suppressed-reorder case shows the gate deferring on every invocation with `peer_reviewer_not_run` — a deferral that can never resolve; restoring the call passes |
+| P9 | Phase-bucket regression: replace the per-bucket partition with a single global one | a scratch copy of `reorder_expensive_reviewers_last` | scenario 6b fails, because a draft-configured `codex-github` is placed after the ready-phase `bugbot` and therefore runs only after `gh pr ready`; restoring the per-bucket partition passes |
+| P10 | Peer-evidence regression: accept any `skipped` peer instead of consulting `reviewer_failed_label_required_for_result` | a scratch copy of condition 2 | scenario 8's `unavailable`, `timeout` and `unauthorized` rows fail, because the gate dispatches with a peer that never produced a verdict; restoring the helper call passes |
 | P6 | Readiness regression: make a defer leave the aggregate result unchanged instead of setting `needs_fixes` | a scratch copy of the gate call site | scenario 3's aggregate assertion fails, and a run in which `codex-github` never executed would satisfy Protocol 92's readiness conditions; restoring the `needs_fixes` aggregate passes |
 | P7 | Unbounded-deferral regression: replace the head-scoped deferral counter with the existing `reviewer_loop_history_entries_count` caps | a scratch copy of the cap check | scenario 13 fails, because repeated `needs_fixes` results on one unchanged head collapse under that function's `unique` bucketing by `head_sha` + `result` and neither cap ever trips; restoring the dedicated counter escalates with `expensive_gate_deferral_cap` |
 | P8 | Unreadable-budget regression: make the ledger read fail, and change the counter to treat the failure as a count of zero | the deferral-budget fixture in `scripts/development-workflow/tests/test-pr-review-loop.sh` | scenario 19 fails, because the gate defers on an unproven budget instead of escalating; restoring the fail-closed branch escalates with `expensive_gate_deferral_budget_unreadable` |
 
-Record all eight in the implementation PR under a `Planted-Violation Proofs`
+Record all ten in the implementation PR under a `Planted-Violation Proofs`
 heading, each with the command, the file and line of the planted violation, and
 both outcomes.
 
@@ -457,8 +511,9 @@ by the same sequential block that already writes `platform_result_tokens`.
 
 | Entity | Values / Scenario | File |
 | --- | --- | --- |
-| Gate condition fixture | A table-driven set of the conditions with each one independently unmet, driving scenarios 2–5 and 8–11 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
-| Platform-order fixture | A resolved list declaring `codex-github` first, and an already-correct list, driving scenarios 6 and 7 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Gate condition fixture | A table-driven set of the conditions with each one independently unmet, driving scenarios 2–5 and 9–11 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Platform-order fixture | A resolved list declaring `codex-github` first, an already-correct list, and a two-bucket list with `codex-github` on draft and `bugbot` on ready — driving scenarios 6, 6b and 7 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Peer-evidence fixture | One peer per row of scenario 8's table, covering `clean`, the three accepted skip reasons, the three rejected skip reasons, `needs_fixes` and `escalate` | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Unreadable-input mocks | Mock `gh` commands that exit non-zero for the threads query and for the check rollup, driving scenario 12 and proof P3 | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Deferral-budget fixtures | Ledger payloads carrying `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` `expensive_gate.result=deferred` entries at the current head, one fewer, the same count at a different head, and an unparseable payload — driving scenarios 13, 14 and 19 and proofs P7 and P8 | inline heredocs in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Composition fixture | A platform list where `codex-github` is both a phase platform and an expensive reviewer, driving scenarios 16 and 17 | inline in `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` |
@@ -505,6 +560,8 @@ with mock `gh` commands and require no network access.
 | Implementation starts before #1648 lands and wires the gate to keys that do not exist | Med | High — the gate would read unset variables and hold everything, or be written against a guessed contract | Recorded as a Conflict in the Cross-Cutting check and as Implementation Order step 0, which is a hard stop that verifies #1648 is merged into the approved base before any edit |
 | A reviewer's own check gates that reviewer | Low | Med — `codex-github` would wait on a check it is responsible for producing | Condition 4 evaluates non-reviewer checks only, reusing the reviewer/baseline classification `pr-ci-loop.sh` already emits rather than a new one; scenario 10's third case pins it |
 | Platform ordering decides whether the gate is effective | Med | High — a config listing `codex-github` first would either dispatch it before the cheap reviewers ran, or defer at the same point forever | Detection is not enough, so the loop reorders: `reorder_expensive_reviewers_last` moves expensive platforms to the end before iteration, making the gate's precondition reachable; condition 2 still compares against the full resolved list, so `peer_reviewer_not_run` fires as a defensive assertion if the reorder did not happen. Scenarios 6 and 7 and proof P5 pin both halves |
+| The reorder silently moves a reviewer across the draft/ready boundary | Med | High — a draft-configured expensive reviewer would run only after `gh pr ready`, inverting the configuration contract | The partition is per phase bucket, assigned with the existing `is_phase_after_clean_platform` predicate, and the buckets are concatenated in their original order; scenario 6b and proof P9 pin it |
+| A peer that never produced a verdict is accepted as evidence | Med | High — `codex-github` would dispatch with no cheap pre-filter having actually run, which is the state the item exists to prevent | Acceptance delegates to `reviewer_failed_label_required_for_result`, which already classifies `unavailable`, `timeout`, `thread-check-failed`, `pending_timeout`, `forbidden` and `unauthorized` skips as reviewer failures, so only `clean` and deliberate policy skips count; scenario 8's table and proof P10 pin it, and reusing the helper keeps the two definitions from drifting |
 | Thread and CI evidence describes a newer commit than the reviewer verdicts | Med | High — dispatch would be authorized on an inconsistent mix of two heads | Conditions 3 and 4 require the live head returned with their queries to equal `loop_head_sha`, and defer with `evidence_head_moved` otherwise; scenario 11 pins it |
 
 ---
@@ -604,10 +661,13 @@ Summary-comment line, illustrative:
    the existing `is_phase_after_clean_platform` helper. **Verify**: source with
    `HARNESS_MODE=1` and confirm scenario 1's matches and non-matches.
 2. Add `reorder_expensive_reviewers_last`, called once after the platform list
-   is resolved and before iteration, and emit `EXPENSIVE_REVIEWERS_REORDERED`
-   when it changed the order. **Verify**: scenario 6 — a list declaring
-   `codex-github` first ends with it last, relative order is otherwise
-   preserved, and an already-correct list is untouched with the flag unset.
+   is resolved and before iteration, partitioning **within each phase bucket**
+   using `is_phase_after_clean_platform`, and emit
+   `EXPENSIVE_REVIEWERS_REORDERED` when it changed the order. **Verify**:
+   scenario 6 — a list declaring `codex-github` first ends with it last,
+   relative order is otherwise preserved, and an already-correct list is
+   untouched with the flag unset; scenario 6b — a draft-configured expensive
+   reviewer still precedes every ready-phase platform.
 3. Add `expensive_gate_deferral_count`, reading occurrences of
    `expensive_gate.result == "deferred"` scoped to `expensive_gate.head` from
    the ledger, and returning `-1` when the ledger is absent, unparseable, or
@@ -615,7 +675,8 @@ Summary-comment line, illustrative:
    count reflects only the current head, and an unreadable ledger yields `-1`
    rather than `0`.
 4. Add `expensive_reviewer_gate` with the conditions in the documented order,
-   the full-platform-list comparison for condition 2, the live-head comparison
+   the full-platform-list comparison for condition 2 delegating acceptance to
+   `reviewer_failed_label_required_for_result`, the live-head comparison
    for conditions 3 and 4, the fail-closed branch for every unreadable input,
    and the deferral-cap branch. **Verify**: drive the condition fixture and
    confirm each unmet condition yields its single named reason, and that the
@@ -655,7 +716,7 @@ Summary-comment line, illustrative:
     **Verify**: both suites exit 0, and
     `scripts/development-workflow/select-test-suites.sh` selects the new suite
     for a change touching only `pr-review-loop.sh`.
-11. Produce the eight planted-violation proofs (P1–P8) and record them in the PR
+11. Produce the ten planted-violation proofs (P1–P10) and record them in the PR
     under a `Planted-Violation Proofs` heading. **Verify**: each shows two runs
     at a concrete file and line — failing with the violation planted, passing
     once removed.

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -143,12 +143,13 @@ of the weight:
   `reviewer_failed_label_required_for_result` returns false would be a deny-list:
   that helper returns false for any reason it does not recognise, so a future
   reviewer's new skip reason would silently become acceptable evidence. The
-  membership test decides; the helper call confirms. Accepting every skip would let
-  `codex-github` dispatch when a configured peer was unavailable, timed out, or
-  was refused for credentials — no cheap pre-filter actually ran, which is the
-  state the item exists to prevent. Acceptance must be decided by calling
-  `reviewer_failed_label_required_for_result`, not by a duplicated list, so a
-  future change to that helper carries this gate with it.
+  membership test decides; the helper call confirms. Accepting every skip would
+  let `codex-github` dispatch when a configured peer was unavailable, timed out,
+  or was refused for credentials — no cheap pre-filter actually ran, which is
+  the state the item exists to prevent. The helper is kept as a second gate so a
+  reason cannot be accepted here while the loop elsewhere treats it as a
+  reviewer failure, but it must never be the sole decider: it returns false for
+  any reason it does not recognise, which is what P19 plants.
 - The **reviewer-owned pending check** row must dispatch: a reviewer's own check
   must never gate that reviewer, or `codex-github` would wait on a check it is
   responsible for producing.

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -483,9 +483,11 @@ must surface no contradiction.
 ## Rollback
 
 Revert the implementation PR. The change is additive — one gate function, one
-call site, one reorder step, one deferral counter, six `EXPENSIVE_GATE_*` keys
-plus `EXPENSIVE_REVIEWERS_REORDERED`, one summary line, and one optional ledger
-object —
+call site, one reorder step, one deferral counter, one bound resolver, seven
+`EXPENSIVE_GATE_*` keys (`PLATFORM`, `RESULT`, `REASON`, `HEAD`, `DEFERRALS`,
+`MAX_DEFERRALS`, `ESCALATION`) plus `EXPENSIVE_REVIEWERS_REORDERED`, one summary
+line, one optional ledger object, and one function relocated to
+`workflow-lib.sh` —
 and reverting restores the previous behavior, in which an expensive reviewer
 runs as soon as the phase mechanism reaches it. Ledger entries already written
 with `expensive_gate` remain parseable by the reverted reader, which dereferences

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -36,7 +36,8 @@
 | Reviewer-loop protocol | `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` |
 | Reviewer integration doc | `docs/workflow/development-workflow/integrations/codex-github.md` |
 | Override variable | `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS` |
-| Deferral bound | `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` (default `3`) |
+| Deferral bound | `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` (default `3`, valid `1`-`999999`) |
+| Bound resolver | `expensive_gate_resolve_max_deferrals`, mirroring `reviewer_loop_resolve_max_cycles` |
 
 ---
 
@@ -293,6 +294,27 @@ This bound cannot be delegated to the existing dual cycle caps:
 `head_sha` + `result`, so repeated `needs_fixes` on one unchanged head — exactly
 the shape of a deferral loop — counts once and advances neither cap.
 
+### Step 4c: The deferral bound is validated
+
+**Maps to**: the "misconfigured deferral bound" risk.
+
+1. Call `expensive_gate_resolve_max_deferrals` with
+   `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` unset, empty, `1`, `999999`, `0`,
+   `-1`, `1000000`, `abc`, `2.5`, and a value with surrounding whitespace.
+2. Read `EXPENSIVE_GATE_MAX_DEFERRALS` in a gate run for each.
+
+**Expected result**: `3` for unset and empty; the configured value for `1` and
+`999999`; `3` with a `WARN` on stderr naming the rejected value for the rest.
+`EXPENSIVE_GATE_MAX_DEFERRALS` reports the effective value every time.
+
+Both failure directions matter. An unvalidated non-integer reaches
+`[ "$deferrals" -ge "$max" ]`, which raises `integer expression expected` and
+evaluates false — the cap never trips and the deferral loop is unbounded again.
+An unvalidated `0` or negative trips the cap before the first deferral, so every
+gated PR escalates immediately. The resolver mirrors
+`reviewer_loop_resolve_max_cycles` on purpose: two bounds resolvers in one
+script that disagree about what a bad value means would be its own defect.
+
 ### Step 5: The override dispatches without hiding the reason
 
 **Maps to**: brief scope bullet 3.
@@ -396,10 +418,10 @@ so it would run only when the test file itself changed.
 **Maps to**: `REVIEW.md` § Planted-violation proof.
 
 1. Read the implementation PR description's `Planted-Violation Proofs` heading.
-2. Confirm P1–P17 from the plan each record the command, the file and line of
+2. Confirm P1–P18 from the plan each record the command, the file and line of
    the planted violation, and both outcomes.
 
-**Expected result**: seventeen proofs, each showing the check failing with the
+**Expected result**: eighteen proofs, each showing the check failing with the
 violation present and passing once removed. Four carry the most weight: P4
 deletes the `expensive_reviewer_gate` call so the function is defined but
 unreachable, and requires Step 3's stale-evidence row to fail — that is what
@@ -419,7 +441,8 @@ fail. P14 makes the baseline-check helper treat every check as a baseline check
 and requires Step 3's reviewer-owned-pending row to fail. P15 removes the
 short-circuit on a defer and requires Step 6b to fail. P16 makes an empty
 check set read as green and requires Step 3's two empty-set rows to fail. P17
-reads the local evidence from the environment and requires Step 3e to fail.
+reads the local evidence from the environment and requires Step 3e to fail. P18
+removes the bound validation and requires Step 4c to fail in both directions.
 
 ### Step 10: Documentation states one contract
 

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -190,7 +190,9 @@ aggregate.
 3. Re-seed the entries against a *different* `expensive_gate.head` and run again.
 4. Read `EXPENSIVE_GATE_DEFERRALS` in each run.
 
-5. Make the ledger read fail, or seed an unparseable payload, and run again.
+5. Seed a ledger whose history marker is present but whose JSON block is
+   unparseable, and run again.
+6. Remove the summary comment entirely — an absent ledger — and run again.
 
 **Expected result**: step 1 gives `EXPENSIVE_GATE_RESULT=deferral_cap` with
 `EXPENSIVE_GATE_ESCALATION=expensive_gate_deferral_cap` and the loop aggregate
@@ -204,6 +206,15 @@ Step 5 also escalates, with `EXPENSIVE_GATE_RESULT=deferral_cap`,
 `EXPENSIVE_GATE_DEFERRALS=-1` — an unreadable budget cannot prove the sequence
 is bounded, so deferring again would reopen the unbounded loop the counter
 exists to close, and `-1` keeps that state distinguishable from a count of zero.
+
+Step 6 must **not** escalate: `EXPENSIVE_GATE_DEFERRALS=0` and the gate defers
+or dispatches normally. An absent ledger is every PR's first reviewer-loop run,
+not a failure; escalating there would bypass the bounded deferrals on every PR
+without prior history and the bound would never be exercised. The counter must
+mirror the three states `reviewer_loop_history_entries_count` already
+distinguishes — absent, readable, unreadable — rather than collapsing the first
+into the third.
+
 `EXPENSIVE_GATE_DEFERRALS` shows the distance to the cap in every other run.
 
 This bound cannot be delegated to the existing dual cycle caps:
@@ -279,10 +290,10 @@ so it would run only when the test file itself changed.
 **Maps to**: `REVIEW.md` § Planted-violation proof.
 
 1. Read the implementation PR description's `Planted-Violation Proofs` heading.
-2. Confirm P1–P10 from the plan each record the command, the file and line of
+2. Confirm P1–P11 from the plan each record the command, the file and line of
    the planted violation, and both outcomes.
 
-**Expected result**: ten proofs, each showing the check failing with the
+**Expected result**: eleven proofs, each showing the check failing with the
 violation present and passing once removed. Four carry the most weight: P4
 deletes the `expensive_reviewer_gate` call so the function is defined but
 unreachable, and requires Step 3's stale-evidence row to fail — that is what
@@ -294,7 +305,8 @@ Step 4b to fail, demonstrating that those caps do not bound a deferral loop, and
 P8 makes an unreadable ledger count as zero and requires Step 4b's fifth run to
 fail. P9 replaces the per-bucket partition with a global one and requires
 Step 3c's two-bucket run to fail. P10 accepts any `skipped` peer and requires
-Step 3's three rejected-skip rows to fail.
+Step 3's three rejected-skip rows to fail. P11 makes an absent ledger return
+`-1` and requires Step 4b's sixth run to fail.
 
 ### Step 10: Documentation states one contract
 

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -104,6 +104,8 @@ Drive the fixture with exactly one condition unmet at a time and read
 | A non-reviewer check failed | `deferred` / `baseline_checks_not_green` |
 | A non-reviewer check still running | `deferred` / `baseline_checks_pending` |
 | A reviewer-owned check still running | `dispatched` |
+| The check rollup is empty | `deferred` / `baseline_checks_unobserved` |
+| The rollup contains only reviewer-owned checks | `deferred` / `baseline_checks_unobserved` |
 | The threads or checks query returns a live head different from `loop_head_sha` | `deferred` / `evidence_head_moved` |
 
 **Expected result**: each row returns exactly its stated result, and
@@ -138,6 +140,13 @@ of the weight:
 - The **reviewer-owned pending check** row must dispatch: a reviewer's own check
   must never gate that reviewer, or `codex-github` would wait on a check it is
   responsible for producing.
+- The two **empty-set** rows are the vacuous-green guard. "Every member is
+  green" is trivially true of an empty set, so an unguarded implementation would
+  dispatch on a head whose CI has not registered yet. The gate does not try to
+  tell "this repository has no baseline CI" from "the checks have not appeared
+  yet" — one snapshot cannot — so both defer, and the deferral cap sends the
+  genuinely-no-CI repository to a human, which is the right owner for the
+  decision to run an expensive reviewer with no CI at all.
 
 ### Step 3c: Expensive reviewers are reordered to the end
 
@@ -363,10 +372,10 @@ so it would run only when the test file itself changed.
 **Maps to**: `REVIEW.md` § Planted-violation proof.
 
 1. Read the implementation PR description's `Planted-Violation Proofs` heading.
-2. Confirm P1–P15 from the plan each record the command, the file and line of
+2. Confirm P1–P16 from the plan each record the command, the file and line of
    the planted violation, and both outcomes.
 
-**Expected result**: fifteen proofs, each showing the check failing with the
+**Expected result**: sixteen proofs, each showing the check failing with the
 violation present and passing once removed. Four carry the most weight: P4
 deletes the `expensive_reviewer_gate` call so the function is defined but
 unreachable, and requires Step 3's stale-evidence row to fail — that is what
@@ -384,7 +393,8 @@ deny-list and requires Step 3's unexpected-value rows to fail. P13 widens the
 peer set back to the whole resolved list and requires Step 3d's first run to
 fail. P14 makes the baseline-check helper treat every check as a baseline check
 and requires Step 3's reviewer-owned-pending row to fail. P15 removes the
-short-circuit on a defer and requires Step 6b to fail.
+short-circuit on a defer and requires Step 6b to fail. P16 makes an empty
+check set read as green and requires Step 3's two empty-set rows to fail.
 
 ### Step 10: Documentation states one contract
 

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -35,6 +35,7 @@
 | Reviewer-loop protocol | `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` |
 | Reviewer integration doc | `docs/workflow/development-workflow/integrations/codex-github.md` |
 | Override variable | `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS` |
+| Deferral bound | `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` (default `3`) |
 
 ---
 
@@ -68,25 +69,23 @@ the item's intent.
    non-outdated threads, and all non-reviewer checks green.
 
 **Expected result**: `EXPENSIVE_GATE_RESULT=dispatched`, an empty
-`EXPENSIVE_GATE_REASON` and `EXPENSIVE_GATE_DISPATCH_REASON`,
-`EXPENSIVE_GATE_HEAD` equal to the run's `loop_head_sha`, and
-`run_platform_review` called once for `codex-github`.
+`EXPENSIVE_GATE_REASON`, `EXPENSIVE_GATE_HEAD` equal to the run's
+`loop_head_sha`, and `run_platform_review` called once for `codex-github`.
 
 ### Step 3: Each unmet condition defers with one named reason
 
 **Maps to**: brief scope bullets 1 and 2.
 
 Drive the fixture with exactly one condition unmet at a time and read
-`EXPENSIVE_GATE_RESULT`, `EXPENSIVE_GATE_REASON`, and
-`EXPENSIVE_GATE_DISPATCH_REASON`:
+`EXPENSIVE_GATE_RESULT` and `EXPENSIVE_GATE_REASON`:
 
 | Fixture state | Required result |
 | --- | --- |
 | `LOCAL_AI_HEAD_CURRENT=0` | `deferred` / `local_evidence_stale` |
 | `LOCAL_AI_CONFIGURED` unset | `deferred` / `local_evidence_missing` |
 | `LOCAL_AI_CONFIGURED=1`, `LOCAL_AI_HEAD_CURRENT` empty | `deferred` / `local_evidence_missing` |
-| `LOCAL_AI_CONFIGURED=0` | `dispatched`, `EXPENSIVE_GATE_DISPATCH_REASON=no_local_prefilter` |
-| `codex-github` listed **before** `pr-agent`, which has not run yet | `deferred` / `peer_reviewer_not_run` |
+| `LOCAL_AI_CONFIGURED=0` | `deferred` / `local_reviewer_not_configured` |
+| Reorder suppressed, so `pr-agent` has not run yet | `deferred` / `peer_reviewer_not_run` |
 | A peer reviewer ran and returned `needs_fixes` | `deferred` / `peer_reviewer_not_clean` |
 | One unresolved, non-outdated review thread | `deferred` / `unresolved_threads` |
 | The same thread marked outdated | `dispatched` |
@@ -99,15 +98,36 @@ Drive the fixture with exactly one condition unmet at a time and read
 `run_platform_review` is not called on any `deferred` row. Three rows carry most
 of the weight:
 
-- The **reordered platform** row is what proves condition 2 is order-independent.
-  Comparing only against platforms already encountered would dispatch the
-  expensive reviewer before the cheap one ever ran, which inverts the item.
-- The **`LOCAL_AI_CONFIGURED=0`** row must dispatch, not defer. There is no
-  cheap pre-filter to wait for, and deferring would hold the reviewer forever in
-  every downstream consumer that does not configure `local-ai-reviewer`.
+- The **`LOCAL_AI_CONFIGURED=0`** row must defer, not dispatch. The brief
+  requires the expensive reviewer to run only after current-head local clean
+  evidence and to fail closed when it is absent, and it permits an explicit
+  manual override rather than an implicit automatic one. A consumer that never
+  configures a local reviewer is released by the deferral cap in Step 4b or the
+  override in Step 5, both explicit.
+- The **suppressed-reorder** row must fire `peer_reviewer_not_run`. That reason
+  is a defensive assertion: after `reorder_expensive_reviewers_last` runs, every
+  non-expensive platform has already executed, so seeing it in a normal run
+  means the reorder did not happen.
 - The **reviewer-owned pending check** row must dispatch: a reviewer's own check
   must never gate that reviewer, or `codex-github` would wait on a check it is
   responsible for producing.
+
+### Step 3c: Expensive reviewers are reordered to the end
+
+**Maps to**: the "platform ordering decides whether the gate is effective" risk.
+
+1. Resolve a platform list that declares `codex-github` before `pr-agent` and
+   `local-ai-reviewer`.
+2. Run `reorder_expensive_reviewers_last` and read the resulting `PLATFORM_LIST`
+   and `EXPENSIVE_REVIEWERS_REORDERED`.
+3. Repeat with a list that is already in the correct order.
+
+**Expected result**: `codex-github` ends last, the relative order of the
+remaining platforms is unchanged, and `EXPENSIVE_REVIEWERS_REORDERED=1` is
+emitted. The already-correct list is untouched and the flag is unset. Detection
+without reordering is not sufficient: the loop would never reach the cheap
+reviewers before the gate, so it would defer at the same point on every
+invocation and the deferral could never resolve.
 
 ### Step 3b: A defer withholds readiness
 
@@ -138,6 +158,28 @@ the aggregate `needs_fixes` / `expensive_gate_deferred` in all three. An
 unreadable input must not dispatch the expensive reviewer, and must not be
 recorded as a clean skip either — it is a retry, forced by the non-clean
 aggregate.
+
+### Step 4b: Deferrals are bounded, and the bound is this item's own
+
+**Maps to**: the "deferral loop is invisible to the existing cycle caps" risk.
+
+1. Seed the ledger with `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` entries whose
+   `expensive_gate.result` is `deferred` and whose `expensive_gate.head` equals
+   the current `loop_head_sha`. Run the gate.
+2. Remove one seeded entry and run again.
+3. Re-seed the entries against a *different* `expensive_gate.head` and run again.
+4. Read `EXPENSIVE_GATE_DEFERRALS` in each run.
+
+**Expected result**: step 1 gives `EXPENSIVE_GATE_RESULT=deferral_cap` with the
+loop aggregate `escalate` / `expensive_gate_deferral_cap`, still naming the
+condition that kept failing. Step 2 defers normally. Step 3 defers normally,
+because the counter is head-scoped and a new push starts the budget over.
+`EXPENSIVE_GATE_DEFERRALS` shows the distance to the cap in every run.
+
+This bound cannot be delegated to the existing dual cycle caps:
+`reviewer_loop_history_entries_count` buckets qualifying entries `unique` over
+`head_sha` + `result`, so repeated `needs_fixes` on one unchanged head — exactly
+the shape of a deferral loop — counts once and advances neither cap.
 
 ### Step 5: The override dispatches without hiding the reason
 
@@ -207,16 +249,18 @@ so it would run only when the test file itself changed.
 **Maps to**: `REVIEW.md` § Planted-violation proof.
 
 1. Read the implementation PR description's `Planted-Violation Proofs` heading.
-2. Confirm P1–P6 from the plan each record the command, the file and line of the
+2. Confirm P1–P7 from the plan each record the command, the file and line of the
    planted violation, and both outcomes.
 
-**Expected result**: six proofs, each showing the check failing with the
-violation present and passing once removed. Three carry the most weight: P4
+**Expected result**: seven proofs, each showing the check failing with the
+violation present and passing once removed. Four carry the most weight: P4
 deletes the `expensive_reviewer_gate` call so the function is defined but
 unreachable, and requires Step 3's stale-evidence row to fail — that is what
-proves the gate is wired into the dispatch path. P5 narrows condition 2 to
-platforms already encountered and requires the reordered-platform row to fail.
-P6 makes a defer leave the aggregate unchanged and requires Step 3b to fail.
+proves the gate is wired into the dispatch path. P5 deletes the
+`reorder_expensive_reviewers_last` call and requires Step 3c to fail. P6 makes a
+defer leave the aggregate unchanged and requires Step 3b to fail. P7 replaces
+the dedicated deferral counter with the existing cycle caps and requires
+Step 4b to fail, demonstrating that those caps do not bound a deferral loop.
 
 ### Step 10: Documentation states one contract
 
@@ -226,11 +270,13 @@ P6 makes a defer leave the aggregate unchanged and requires Step 3b to fail.
    `docs/workflow/development-workflow/integrations/codex-github.md`.
 
 **Expected result**: both name the same conditions in the same order, the same
-fail-closed rule, the same `dispatched` / `deferred` / `forced` outcomes, the
-same statement that a defer sets the aggregate to `needs_fixes` rather than
-passing as a clean skip, the same `no_local_prefilter` dispatch path, and the
-same override variable. Reading them against the Step 3 and Step 3b tables must
-surface no contradiction.
+fail-closed rule, the same `dispatched` / `deferred` / `forced` /
+`deferral_cap` outcomes, the same statement that a defer sets the aggregate to
+`needs_fixes` rather than passing as a clean skip, the same reordering of
+expensive reviewers to the end of the platform list, the same
+`PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` bound and its escalation, and the same
+override variable. Reading them against the Step 3, 3b, 3c and 4b expectations
+must surface no contradiction.
 
 ### Step 11: Static checks
 
@@ -245,7 +291,8 @@ surface no contradiction.
 ## Rollback
 
 Revert the implementation PR. The change is additive — one gate function, one
-call site, five stdout keys, one summary line, and one optional ledger object —
+call site, one reorder step, five stdout keys, one summary line, and one
+optional ledger object —
 and reverting restores the previous behavior, in which an expensive reviewer
 runs as soon as the phase mechanism reaches it. Ledger entries already written
 with `expensive_gate` remain parseable by the reverted reader, which dereferences

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -59,7 +59,7 @@
 matched would be held back by a gate that assumes an expensive one, inverting
 the item's intent.
 
-### Step 2: The gate dispatches when all four conditions are met
+### Step 2: The gate dispatches when all conditions are met
 
 **Maps to**: brief scope bullet 1.
 
@@ -68,35 +68,62 @@ the item's intent.
    non-outdated threads, and all non-reviewer checks green.
 
 **Expected result**: `EXPENSIVE_GATE_RESULT=dispatched`, an empty
-`EXPENSIVE_GATE_REASON`, `EXPENSIVE_GATE_HEAD` equal to the run's
-`loop_head_sha`, and `run_platform_review` called once for `codex-github`.
+`EXPENSIVE_GATE_REASON` and `EXPENSIVE_GATE_DISPATCH_REASON`,
+`EXPENSIVE_GATE_HEAD` equal to the run's `loop_head_sha`, and
+`run_platform_review` called once for `codex-github`.
 
-### Step 3: Each unmet condition holds the platform back with one named reason
+### Step 3: Each unmet condition defers with one named reason
 
 **Maps to**: brief scope bullets 1 and 2.
 
 Drive the fixture with exactly one condition unmet at a time and read
-`EXPENSIVE_GATE_RESULT` and `EXPENSIVE_GATE_REASON`:
+`EXPENSIVE_GATE_RESULT`, `EXPENSIVE_GATE_REASON`, and
+`EXPENSIVE_GATE_DISPATCH_REASON`:
 
 | Fixture state | Required result |
 | --- | --- |
-| `LOCAL_AI_HEAD_CURRENT=0` | `held` / `local_evidence_stale` |
-| `LOCAL_AI_CONFIGURED` unset | `held` / `local_evidence_missing` |
-| `LOCAL_AI_CONFIGURED=1`, `LOCAL_AI_HEAD_CURRENT` empty | `held` / `local_evidence_missing` |
-| `LOCAL_AI_CONFIGURED=0` | `held` / `local_reviewer_not_configured` |
-| A peer reviewer returned `needs_fixes` earlier in the invocation | `held` / `peer_reviewer_not_clean` |
-| One unresolved, non-outdated review thread | `held` / `unresolved_threads` |
+| `LOCAL_AI_HEAD_CURRENT=0` | `deferred` / `local_evidence_stale` |
+| `LOCAL_AI_CONFIGURED` unset | `deferred` / `local_evidence_missing` |
+| `LOCAL_AI_CONFIGURED=1`, `LOCAL_AI_HEAD_CURRENT` empty | `deferred` / `local_evidence_missing` |
+| `LOCAL_AI_CONFIGURED=0` | `dispatched`, `EXPENSIVE_GATE_DISPATCH_REASON=no_local_prefilter` |
+| `codex-github` listed **before** `pr-agent`, which has not run yet | `deferred` / `peer_reviewer_not_run` |
+| A peer reviewer ran and returned `needs_fixes` | `deferred` / `peer_reviewer_not_clean` |
+| One unresolved, non-outdated review thread | `deferred` / `unresolved_threads` |
 | The same thread marked outdated | `dispatched` |
-| A non-reviewer check failed | `held` / `baseline_checks_not_green` |
-| A non-reviewer check still running | `held` / `baseline_checks_pending` |
+| A non-reviewer check failed | `deferred` / `baseline_checks_not_green` |
+| A non-reviewer check still running | `deferred` / `baseline_checks_pending` |
 | A reviewer-owned check still running | `dispatched` |
+| The threads or checks query returns a live head different from `loop_head_sha` | `deferred` / `evidence_head_moved` |
 
 **Expected result**: each row returns exactly its stated result, and
-`run_platform_review` is not called on any `held` row. The last row matters
-most: a reviewer's own check must never gate that reviewer, or `codex-github`
-would wait on a check it is responsible for producing.
+`run_platform_review` is not called on any `deferred` row. Three rows carry most
+of the weight:
 
-### Step 4: Unreadable evidence holds, and does not escalate
+- The **reordered platform** row is what proves condition 2 is order-independent.
+  Comparing only against platforms already encountered would dispatch the
+  expensive reviewer before the cheap one ever ran, which inverts the item.
+- The **`LOCAL_AI_CONFIGURED=0`** row must dispatch, not defer. There is no
+  cheap pre-filter to wait for, and deferring would hold the reviewer forever in
+  every downstream consumer that does not configure `local-ai-reviewer`.
+- The **reviewer-owned pending check** row must dispatch: a reviewer's own check
+  must never gate that reviewer, or `codex-github` would wait on a check it is
+  responsible for producing.
+
+### Step 3b: A defer withholds readiness
+
+**Maps to**: the "silently stops `codex-github` from ever running" risk.
+
+1. Run the loop with the gate deferring for any reason from Step 3.
+2. Read the loop's aggregate `RESULT` and `REASON`.
+3. Apply the Protocol 92 readiness conditions to that result.
+
+**Expected result**: the aggregate is `needs_fixes` with
+`REASON=expensive_gate_deferred`, so `ready-for-human-review` is withheld and
+Protocol 91 re-runs Step 7. A defer that left the aggregate `clean` or `skipped`
+would satisfy Protocol 92 and let the PR reach human review having never run the
+expensive reviewer, with nothing guaranteeing the retry the gate depends on.
+
+### Step 4: Unreadable evidence defers, and does not escalate
 
 **Maps to**: brief scope bullet 2 (fail-closed).
 
@@ -105,11 +132,12 @@ would wait on a check it is responsible for producing.
 3. Set `loop_head_sha` to the empty string; run the gate.
 4. In each case, read the loop's aggregate `RESULT`.
 
-**Expected result**: `held` with `evidence_unavailable_review_threads`,
+**Expected result**: `deferred` with `evidence_unavailable_review_threads`,
 `evidence_unavailable_checks`, and `evidence_unavailable_head` respectively, and
-the loop's aggregate result unchanged in all three. A hold is a skip, not a
-blocking verdict — an unreadable input must not fail the PR, and it must not
-dispatch either.
+the aggregate `needs_fixes` / `expensive_gate_deferred` in all three. An
+unreadable input must not dispatch the expensive reviewer, and must not be
+recorded as a clean skip either — it is a retry, forced by the non-clean
+aggregate.
 
 ### Step 5: The override dispatches without hiding the reason
 
@@ -119,10 +147,11 @@ dispatch either.
 2. Run the gate with `LOCAL_AI_HEAD_CURRENT=0`.
 
 **Expected result**: `EXPENSIVE_GATE_RESULT=forced`,
-`EXPENSIVE_GATE_REASON=local_evidence_stale` still present, and
-`run_platform_review` called. The reason surviving the override is the point: a
-forced run that later wastes reviewer cycles must be traceable to the condition
-that was overridden.
+`EXPENSIVE_GATE_REASON=local_evidence_stale` still present,
+`run_platform_review` called, and the aggregate **not** set to `needs_fixes` —
+the human took the decision explicitly, so the run is not re-blocked. The reason
+surviving the override is the point: a forced run that later wastes reviewer
+cycles must be traceable to the condition that was overridden.
 
 ### Step 6: Composition with the existing phase mechanism
 
@@ -135,26 +164,28 @@ that was overridden.
 4. Re-run with `--pre-after-clean-only`.
 
 **Expected result**: `ensure_pr_ready_for_ready_phase` runs first and the gate
-second. When the gate holds, the PR has still been converted to ready and the
-hold is not reported as a phase failure. Under `--pre-after-clean-only` the
+second. When the gate defers, the PR has still been converted to ready and the
+defer is not reported as a phase failure. Under `--pre-after-clean-only` the
 platform is filtered out before the gate is consulted and **no**
-`EXPENSIVE_GATE_*` telemetry is emitted for it — a phantom `held` record for a
-platform that was never in scope would misreport why the reviewer did not run.
+`EXPENSIVE_GATE_*` telemetry is emitted for it — a phantom `deferred` record for
+a platform that was never in scope would misreport why the reviewer did not
+run.
 
 ### Step 7: Gate outcome is visible in both durable surfaces
 
 **Maps to**: the "silently stops `codex-github` from ever running" risk.
 
-1. Read the reviewer-loop summary comment produced by a `held` run.
+1. Read the reviewer-loop summary comment produced by a `deferred` run.
 2. Read the `reviewer_loop_history.v1` entry from the same run.
 3. Parse a legacy entry that has no `expensive_gate` object.
 
 **Expected result**: the summary carries one
 `**Expensive reviewer gate:**` line naming the platform, result, reason, and
-head; the ledger entry carries an `expensive_gate` object with the same four
-values; and the legacy entry still parses through
+head, and stating that the reviewer was not run and readiness is withheld; the
+ledger entry carries an `expensive_gate` object with the same values; and the
+legacy entry still parses through
 `reviewer_loop_history_payload_from_existing`, confirming the `v1` schema stayed
-backward compatible. A permanent hold must be readable from the PR without
+backward compatible. A repeated defer must be readable from the PR without
 re-running anything.
 
 ### Step 8: The new suite is selected by the right change sets
@@ -176,14 +207,16 @@ so it would run only when the test file itself changed.
 **Maps to**: `REVIEW.md` § Planted-violation proof.
 
 1. Read the implementation PR description's `Planted-Violation Proofs` heading.
-2. Confirm P1–P4 from the plan each record the command, the file and line of the
+2. Confirm P1–P6 from the plan each record the command, the file and line of the
    planted violation, and both outcomes.
 
-**Expected result**: four proofs, each showing the check failing with the
-violation present and passing once removed. P4 matters most — it removes the
-`is_expensive_reviewer_platform` guard and requires Step 3's stale-evidence row
-to fail, which is what proves the gate is wired into the dispatch path rather
-than merely defined.
+**Expected result**: six proofs, each showing the check failing with the
+violation present and passing once removed. Three carry the most weight: P4
+deletes the `expensive_reviewer_gate` call so the function is defined but
+unreachable, and requires Step 3's stale-evidence row to fail — that is what
+proves the gate is wired into the dispatch path. P5 narrows condition 2 to
+platforms already encountered and requires the reordered-platform row to fail.
+P6 makes a defer leave the aggregate unchanged and requires Step 3b to fail.
 
 ### Step 10: Documentation states one contract
 
@@ -192,10 +225,12 @@ than merely defined.
 2. Read the gate section of
    `docs/workflow/development-workflow/integrations/codex-github.md`.
 
-**Expected result**: both name the same four conditions in the same order, the
-same fail-closed rule, the same `held` / `dispatched` / `forced` outcomes, and
-the same override variable. Reading them against Step 3's table must surface no
-contradiction.
+**Expected result**: both name the same conditions in the same order, the same
+fail-closed rule, the same `dispatched` / `deferred` / `forced` outcomes, the
+same statement that a defer sets the aggregate to `needs_fixes` rather than
+passing as a clean skip, the same `no_local_prefilter` dispatch path, and the
+same override variable. Reading them against the Step 3 and Step 3b tables must
+surface no contradiction.
 
 ### Step 11: Static checks
 
@@ -210,7 +245,7 @@ contradiction.
 ## Rollback
 
 Revert the implementation PR. The change is additive — one gate function, one
-call site, four stdout keys, one summary line, and one optional ledger object —
+call site, five stdout keys, one summary line, and one optional ledger object —
 and reverting restores the previous behavior, in which an expensive reviewer
 runs as soon as the phase mechanism reaches it. Ledger entries already written
 with `expensive_gate` remain parseable by the reverted reader, which dereferences

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -70,7 +70,9 @@ the item's intent.
 
 **Expected result**: `EXPENSIVE_GATE_RESULT=dispatched`, an empty
 `EXPENSIVE_GATE_REASON`, `EXPENSIVE_GATE_HEAD` equal to the run's
-`loop_head_sha`, and `run_platform_review` called once for `codex-github`.
+`loop_head_sha`, **no** `EXPENSIVE_GATE_ESCALATION` key at all — it appears only
+on a `deferral_cap` result — and `run_platform_review` called once for
+`codex-github`.
 
 ### Step 3: Each unmet condition defers with one named reason
 

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -290,6 +290,24 @@ platform is filtered out before the gate is consulted and **no**
 a platform that was never in scope would misreport why the reviewer did not
 run.
 
+### Step 6b: A defer does not start the ready phase
+
+**Maps to**: the "defer still triggers the ready-phase transition" risk.
+
+1. Configure `codex-github` on draft and `bugbot` on ready.
+2. Make the gate defer for any reason from Step 3, and run the loop.
+3. Read the PR's draft state, the phase telemetry, and whether
+   `ensure_pr_ready_for_ready_phase` was called.
+
+**Expected result**: the loop breaks out at the defer.
+`ensure_pr_ready_for_ready_phase` is not called, `gh pr ready` is not run, the
+PR stays draft, and no `EXPENSIVE_GATE_*` or phase telemetry is emitted for
+`bugbot`. Setting the `needs_fixes` aggregate without breaking out would leave
+the iteration running, and the later ready-phase platform would convert the PR
+out of draft even though the draft-phase expensive reviewer never ran — a
+visible, hard-to-undo side effect produced by a gate whose purpose was to not
+proceed.
+
 ### Step 7: Gate outcome is visible in both durable surfaces
 
 **Maps to**: the "silently stops `codex-github` from ever running" risk.
@@ -343,10 +361,10 @@ so it would run only when the test file itself changed.
 **Maps to**: `REVIEW.md` § Planted-violation proof.
 
 1. Read the implementation PR description's `Planted-Violation Proofs` heading.
-2. Confirm P1–P14 from the plan each record the command, the file and line of
+2. Confirm P1–P15 from the plan each record the command, the file and line of
    the planted violation, and both outcomes.
 
-**Expected result**: fourteen proofs, each showing the check failing with the
+**Expected result**: fifteen proofs, each showing the check failing with the
 violation present and passing once removed. Four carry the most weight: P4
 deletes the `expensive_reviewer_gate` call so the function is defined but
 unreachable, and requires Step 3's stale-evidence row to fail — that is what
@@ -363,7 +381,8 @@ Step 3's three rejected-skip rows to fail. P11 makes an absent ledger return
 deny-list and requires Step 3's unexpected-value rows to fail. P13 widens the
 peer set back to the whole resolved list and requires Step 3d's first run to
 fail. P14 makes the baseline-check helper treat every check as a baseline check
-and requires Step 3's reviewer-owned-pending row to fail.
+and requires Step 3's reviewer-owned-pending row to fail. P15 removes the
+short-circuit on a defer and requires Step 6b to fail.
 
 ### Step 10: Documentation states one contract
 

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -84,8 +84,8 @@ Drive the fixture with exactly one condition unmet at a time and read
 | Fixture state | Required result |
 | --- | --- |
 | `LOCAL_AI_HEAD_CURRENT=0` | `deferred` / `local_evidence_stale` |
-| `LOCAL_AI_CONFIGURED` unset | `deferred` / `local_evidence_missing` |
-| `LOCAL_AI_CONFIGURED=1`, `LOCAL_AI_HEAD_CURRENT` empty | `deferred` / `local_evidence_missing` |
+| `LOCAL_AI_CONFIGURED` unset, empty, `2`, or `true` | `deferred` / `local_evidence_missing` |
+| `LOCAL_AI_CONFIGURED=1`, `LOCAL_AI_HEAD_CURRENT` unset, empty, `2`, or `yes` | `deferred` / `local_evidence_missing` |
 | `LOCAL_AI_CONFIGURED=0` | `deferred` / `local_reviewer_not_configured` |
 | Reorder suppressed, so `pr-agent` has not run yet | `deferred` / `peer_reviewer_not_run` |
 | A peer ran and returned `needs_fixes` or `escalate` | `deferred` / `peer_reviewer_not_clean` |
@@ -102,6 +102,11 @@ Drive the fixture with exactly one condition unmet at a time and read
 `run_platform_review` is not called on any `deferred` row. Three rows carry most
 of the weight:
 
+- The **unexpected-value** rows are the ones a deny-list implementation fails.
+  Condition 1 must be an exact-match allow-list requiring the literal `1` on
+  both keys; testing only for `0` and empty would let a `2` or a stray `true`
+  fall through and dispatch the expensive reviewer with no valid evidence, which
+  is the opposite of fail-closed.
 - The **`LOCAL_AI_CONFIGURED=0`** row must defer, not dispatch. The brief
   requires the expensive reviewer to run only after current-head local clean
   evidence and to fail closed when it is absent, and it permits an explicit
@@ -290,10 +295,10 @@ so it would run only when the test file itself changed.
 **Maps to**: `REVIEW.md` § Planted-violation proof.
 
 1. Read the implementation PR description's `Planted-Violation Proofs` heading.
-2. Confirm P1–P11 from the plan each record the command, the file and line of
+2. Confirm P1–P12 from the plan each record the command, the file and line of
    the planted violation, and both outcomes.
 
-**Expected result**: eleven proofs, each showing the check failing with the
+**Expected result**: twelve proofs, each showing the check failing with the
 violation present and passing once removed. Four carry the most weight: P4
 deletes the `expensive_reviewer_gate` call so the function is defined but
 unreachable, and requires Step 3's stale-evidence row to fail — that is what
@@ -306,7 +311,8 @@ P8 makes an unreadable ledger count as zero and requires Step 4b's fifth run to
 fail. P9 replaces the per-bucket partition with a global one and requires
 Step 3c's two-bucket run to fail. P10 accepts any `skipped` peer and requires
 Step 3's three rejected-skip rows to fail. P11 makes an absent ledger return
-`-1` and requires Step 4b's sixth run to fail.
+`-1` and requires Step 4b's sixth run to fail. P12 rewrites condition 1 as a
+deny-list and requires Step 3's unexpected-value rows to fail.
 
 ### Step 10: Documentation states one contract
 

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -376,7 +376,8 @@ and requires Step 3's reviewer-owned-pending row to fail.
 fail-closed rule, the same `dispatched` / `deferred` / `forced` /
 `deferral_cap` outcomes, the same statement that a defer sets the aggregate to
 `needs_fixes` rather than passing as a clean skip, the same reordering of
-expensive reviewers to the end of the platform list, the same
+expensive reviewers last within their own phase bucket, never across the
+draft/ready boundary, the same
 `PR_REVIEW_LOOP_MAX_EXPENSIVE_DEFERRALS` bound and its escalation, and the same
 override variable. Reading them against the Step 3, 3b, 3c and 4b expectations
 must surface no contradiction.

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -305,8 +305,9 @@ must surface no contradiction.
 ## Rollback
 
 Revert the implementation PR. The change is additive — one gate function, one
-call site, one reorder step, five stdout keys, one summary line, and one
-optional ledger object —
+call site, one reorder step, one deferral counter, six `EXPENSIVE_GATE_*` keys
+plus `EXPENSIVE_REVIEWERS_REORDERED`, one summary line, and one optional ledger
+object —
 and reverting restores the previous behavior, in which an expensive reviewer
 runs as soon as the phase mechanism reaches it. Ledger entries already written
 with `expensive_gate` remain parseable by the reverted reader, which dereferences

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -66,8 +66,9 @@ the item's intent.
 
 The four conditions are: the local reviewer clean and current; every reviewer
 that **precedes** this one having produced acceptable evidence — a `clean`
-result, or a `skipped` one whose reason is not a reviewer failure, deliberately
-**not** every `skipped`; zero unresolved non-outdated review threads; and green
+result, or a `skipped` one whose reason is a member of
+`EXPENSIVE_GATE_ACCEPTED_SKIP_REASONS`, deliberately **not** every `skipped` and
+deliberately not "any reason that is not a known failure"; zero unresolved non-outdated review threads; and green
 non-reviewer baseline checks. Steps 3 and 3d pin the second condition's two
 halves.
 

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -108,9 +108,9 @@ Drive the fixture with exactly one condition unmet at a time and read
 | A peer ran and returned `skipped` with an unknown or empty reason | `deferred` / `peer_reviewer_not_clean` |
 | One unresolved, non-outdated review thread | `deferred` / `unresolved_threads` |
 | The same thread marked outdated | `dispatched` |
-| A non-reviewer check failed | `deferred` / `baseline_checks_not_green` |
-| A non-reviewer check still running | `deferred` / `baseline_checks_pending` |
-| A reviewer-owned check still running | `dispatched` |
+| A non-reviewer check failed, plus a green one | `deferred` / `baseline_checks_not_green` |
+| A non-reviewer check still running, plus a green one | `deferred` / `baseline_checks_pending` |
+| A reviewer-owned check still running, **plus a green non-reviewer check** | `dispatched` |
 | The check rollup is empty | `deferred` / `baseline_checks_unobserved` |
 | The rollup contains only reviewer-owned checks | `deferred` / `baseline_checks_unobserved` |
 | The threads or checks query returns a live head different from `loop_head_sha` | `deferred` / `evidence_head_moved` |
@@ -157,7 +157,10 @@ of the weight:
   any reason it does not recognise, which is what P19 plants.
 - The **reviewer-owned pending check** row must dispatch: a reviewer's own check
   must never gate that reviewer, or `codex-github` would wait on a check it is
-  responsible for producing.
+  responsible for producing. Its fixture must carry a green non-reviewer check
+  as well — otherwise filtering empties the set and the row returns
+  `baseline_checks_unobserved`, becoming indistinguishable from the last row and
+  unable to tell a correct exclusion from a vacuous-green miss.
 - The two **empty-set** rows are the vacuous-green guard. "Every member is
   green" is trivially true of an empty set, so an unguarded implementation would
   dispatch on a head whose CI has not registered yet. The gate does not try to

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -87,7 +87,7 @@ Drive the fixture with exactly one condition unmet at a time and read
 | `LOCAL_AI_CONFIGURED` unset, empty, `2`, or `true` | `deferred` / `local_evidence_missing` |
 | `LOCAL_AI_CONFIGURED=1`, `LOCAL_AI_HEAD_CURRENT` unset, empty, `2`, or `yes` | `deferred` / `local_evidence_missing` |
 | `LOCAL_AI_CONFIGURED=0` | `deferred` / `local_reviewer_not_configured` |
-| Reorder suppressed, so `pr-agent` has not run yet | `deferred` / `peer_reviewer_not_run` |
+| Reorder suppressed, so a same-bucket peer has not run yet | `deferred` / `peer_reviewer_not_run` |
 | A peer ran and returned `needs_fixes` or `escalate` | `deferred` / `peer_reviewer_not_clean` |
 | A peer ran and returned `skipped` / `unavailable`, `timeout`, or `unauthorized` | `deferred` / `peer_reviewer_not_clean` |
 | A peer ran and returned `skipped` / `not_configured` or `explicit-skip` | contributes to `dispatched` |
@@ -115,8 +115,10 @@ of the weight:
   override in Step 5, both explicit.
 - The **suppressed-reorder** row must fire `peer_reviewer_not_run`. That reason
   is a defensive assertion: after `reorder_expensive_reviewers_last` runs, every
-  non-expensive platform has already executed, so seeing it in a normal run
-  means the reorder did not happen.
+  platform in the reviewer's peer set has already executed, so seeing it in a
+  normal run means the reorder did not happen. Note the peer set is scoped by
+  phase — Step 3d covers it — so a draft-phase `codex-github` must **not** wait
+  on a ready-phase `bugbot`.
 - The two **`skipped`** rows must split. Accepting every skip would let
   `codex-github` dispatch when a configured peer was unavailable, timed out, or
   was refused for credentials — no cheap pre-filter actually ran, which is the
@@ -167,6 +169,27 @@ order.
 Protocol 91 re-runs Step 7. A defer that left the aggregate `clean` or `skipped`
 would satisfy Protocol 92 and let the PR reach human review having never run the
 expensive reviewer, with nothing guaranteeing the retry the gate depends on.
+
+### Step 3d: The peer set is scoped by phase, not the whole list
+
+**Maps to**: the "peer set and phase-bucket reorder contradict each other" risk.
+
+1. Configure `codex-github` and `pr-agent` on draft and `bugbot` on ready. Run
+   the loop with `pr-agent` clean and `bugbot` not yet run.
+2. Configure `codex-github` on ready with `pr-agent` and `local-ai-reviewer` on
+   draft, all draft platforms clean. Run the loop.
+3. Suppress the reorder so a same-bucket peer has not run. Run the loop.
+
+**Expected result**: run 1 **dispatches** — `codex-github`'s peer set is
+`pr-agent` only, not `bugbot`, because a draft-phase reviewer necessarily runs
+before a ready-phase one. Run 2 dispatches, with the whole draft bucket in the
+peer set. Run 3 defers with `peer_reviewer_not_run`.
+
+Run 1 is the one a whole-list peer set fails: it would wait on a `bugbot` that
+cannot have run yet and defer on every invocation until the cap, deadlocking the
+exact configuration Step 3c exists to support. The peer set is well-defined only
+because of the reorder — after it, "precedes this reviewer" and "should have
+produced evidence before this reviewer" are the same set.
 
 ### Step 4: Unreadable evidence defers, and does not escalate
 
@@ -295,10 +318,10 @@ so it would run only when the test file itself changed.
 **Maps to**: `REVIEW.md` § Planted-violation proof.
 
 1. Read the implementation PR description's `Planted-Violation Proofs` heading.
-2. Confirm P1–P12 from the plan each record the command, the file and line of
+2. Confirm P1–P13 from the plan each record the command, the file and line of
    the planted violation, and both outcomes.
 
-**Expected result**: twelve proofs, each showing the check failing with the
+**Expected result**: thirteen proofs, each showing the check failing with the
 violation present and passing once removed. Four carry the most weight: P4
 deletes the `expensive_reviewer_gate` call so the function is defined but
 unreachable, and requires Step 3's stale-evidence row to fail — that is what
@@ -312,7 +335,9 @@ fail. P9 replaces the per-bucket partition with a global one and requires
 Step 3c's two-bucket run to fail. P10 accepts any `skipped` peer and requires
 Step 3's three rejected-skip rows to fail. P11 makes an absent ledger return
 `-1` and requires Step 4b's sixth run to fail. P12 rewrites condition 1 as a
-deny-list and requires Step 3's unexpected-value rows to fail.
+deny-list and requires Step 3's unexpected-value rows to fail. P13 widens the
+peer set back to the whole resolved list and requires Step 3d's first run to
+fail.
 
 ### Step 10: Documentation states one contract
 

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -68,15 +68,19 @@ The four conditions are: the local reviewer clean and current; every reviewer
 that **precedes** this one having produced acceptable evidence — a `clean`
 result, or a `skipped` one whose reason is a member of
 `EXPENSIVE_GATE_ACCEPTED_SKIP_REASONS`, deliberately **not** every `skipped` and
-deliberately not "any reason that is not a known failure"; zero unresolved non-outdated review threads; and green
-non-reviewer baseline checks. Steps 3 and 3d pin the second condition's two
-halves.
+deliberately not "any reason that is not a known failure"; zero unresolved
+non-outdated review threads; and a non-empty set of non-reviewer baseline
+checks, all green. Steps 3 and 3d pin the second condition's two halves, and
+every fixture in this runbook drives condition 1 through the in-loop state
+rather than the stdout keys — see Step 3e.
 
 **Maps to**: brief scope bullet 1.
 
-1. Drive the condition fixture with `LOCAL_AI_CONFIGURED=1`,
-   `LOCAL_AI_HEAD_CURRENT=1`, every peer reviewer `clean`, zero unresolved
-   non-outdated threads, and all non-reviewer checks green.
+1. Drive the condition fixture through the **in-loop state**, never by
+   exporting the stdout keys: put `local-ai-reviewer` in the resolved platform
+   list, set its `platform_reviewed_heads` entry to `loop_head_sha`, mark every
+   preceding peer `clean`, leave zero unresolved non-outdated threads, and make
+   the non-reviewer check set non-empty and all green.
 
 **Expected result**: `EXPENSIVE_GATE_RESULT=dispatched`, an empty
 `EXPENSIVE_GATE_REASON`, `EXPENSIVE_GATE_HEAD` equal to the run's
@@ -328,7 +332,11 @@ script that disagree about what a bad value means would be its own defect.
 **Maps to**: brief scope bullet 3.
 
 1. Set `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS=1`.
-2. Run the gate with `LOCAL_AI_HEAD_CURRENT=0`.
+2. Run the gate with the `local-ai-reviewer` entry of `platform_reviewed_heads`
+   recording a head that is not `loop_head_sha`, so the derivation yields `0`
+   and condition 1 is unmet. As everywhere else, drive this through the in-loop
+   state rather than by exporting `LOCAL_AI_HEAD_CURRENT` — Step 3e requires the
+   gate to ignore that name.
 
 **Expected result**: `EXPENSIVE_GATE_RESULT=forced`,
 `EXPENSIVE_GATE_REASON=local_evidence_stale` still present,

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -211,14 +211,21 @@ expensive reviewer, with nothing guaranteeing the retry the gate depends on.
 
 **Maps to**: the "peer set and phase-bucket reorder contradict each other" risk.
 
-1. Configure `codex-github` and `pr-agent` on draft and `bugbot` on ready. Run
-   the loop with `pr-agent` clean and `bugbot` not yet run.
+Every run below also configures `local-ai-reviewer` on draft with a current-head
+`platform_reviewed_heads` entry, so condition 1 is satisfied and each run
+isolates condition 2. Condition 1 is evaluated first, so a run expecting
+dispatch without it would defer with `local_reviewer_not_configured` regardless
+of the peer set.
+
+1. Configure `codex-github`, `pr-agent` and `local-ai-reviewer` on draft and
+   `bugbot` on ready. Run the loop with both draft peers clean and `bugbot` not
+   yet run.
 2. Configure `codex-github` on ready with `pr-agent` and `local-ai-reviewer` on
    draft, all draft platforms clean. Run the loop.
 3. Suppress the reorder so a same-bucket peer has not run. Run the loop.
 
-**Expected result**: run 1 **dispatches** — `codex-github`'s peer set is
-`pr-agent` only, not `bugbot`, because a draft-phase reviewer necessarily runs
+**Expected result**: run 1 **dispatches** — `codex-github`'s peer set is the two
+draft platforms, not `bugbot`, because a draft-phase reviewer necessarily runs
 before a ready-phase one. Run 2 dispatches, with the whole draft bucket in the
 peer set. Run 3 defers with `peer_reviewer_not_run`.
 

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -88,7 +88,9 @@ Drive the fixture with exactly one condition unmet at a time and read
 | `LOCAL_AI_CONFIGURED=1`, `LOCAL_AI_HEAD_CURRENT` empty | `deferred` / `local_evidence_missing` |
 | `LOCAL_AI_CONFIGURED=0` | `deferred` / `local_reviewer_not_configured` |
 | Reorder suppressed, so `pr-agent` has not run yet | `deferred` / `peer_reviewer_not_run` |
-| A peer reviewer ran and returned `needs_fixes` | `deferred` / `peer_reviewer_not_clean` |
+| A peer ran and returned `needs_fixes` or `escalate` | `deferred` / `peer_reviewer_not_clean` |
+| A peer ran and returned `skipped` / `unavailable`, `timeout`, or `unauthorized` | `deferred` / `peer_reviewer_not_clean` |
+| A peer ran and returned `skipped` / `not_configured` or `explicit-skip` | contributes to `dispatched` |
 | One unresolved, non-outdated review thread | `deferred` / `unresolved_threads` |
 | The same thread marked outdated | `dispatched` |
 | A non-reviewer check failed | `deferred` / `baseline_checks_not_green` |
@@ -110,6 +112,12 @@ of the weight:
   is a defensive assertion: after `reorder_expensive_reviewers_last` runs, every
   non-expensive platform has already executed, so seeing it in a normal run
   means the reorder did not happen.
+- The two **`skipped`** rows must split. Accepting every skip would let
+  `codex-github` dispatch when a configured peer was unavailable, timed out, or
+  was refused for credentials — no cheap pre-filter actually ran, which is the
+  state the item exists to prevent. Acceptance must be decided by calling
+  `reviewer_failed_label_required_for_result`, not by a duplicated list, so a
+  future change to that helper carries this gate with it.
 - The **reviewer-owned pending check** row must dispatch: a reviewer's own check
   must never gate that reviewer, or `codex-github` would wait on a check it is
   responsible for producing.
@@ -124,12 +132,22 @@ of the weight:
    and `EXPENSIVE_REVIEWERS_REORDERED`.
 3. Repeat with a list that is already in the correct order.
 
+4. Resolve a two-bucket list with `codex-github` in `review.on_draft.github`
+   and `bugbot` in `review.on_ready.github`, and run the reorder.
+
 **Expected result**: `codex-github` ends last, the relative order of the
 remaining platforms is unchanged, and `EXPENSIVE_REVIEWERS_REORDERED=1` is
 emitted. The already-correct list is untouched and the flag is unset. Detection
 without reordering is not sufficient: the loop would never reach the cheap
 reviewers before the gate, so it would defer at the same point on every
 invocation and the deferral could never resolve.
+
+In the two-bucket run, `codex-github` must end last **among the draft
+platforms** and still precede `bugbot`. A single global partition would place it
+after `bugbot` and therefore after the ready-phase transition, silently
+inverting the configuration contract that `review.on_draft.github` reviewers run
+before `gh pr ready`. Confirm the buckets themselves are still in their original
+order.
 
 ### Step 3b: A defer withholds readiness
 
@@ -261,10 +279,10 @@ so it would run only when the test file itself changed.
 **Maps to**: `REVIEW.md` § Planted-violation proof.
 
 1. Read the implementation PR description's `Planted-Violation Proofs` heading.
-2. Confirm P1–P8 from the plan each record the command, the file and line of the
-   planted violation, and both outcomes.
+2. Confirm P1–P10 from the plan each record the command, the file and line of
+   the planted violation, and both outcomes.
 
-**Expected result**: eight proofs, each showing the check failing with the
+**Expected result**: ten proofs, each showing the check failing with the
 violation present and passing once removed. Four carry the most weight: P4
 deletes the `expensive_reviewer_gate` call so the function is defined but
 unreachable, and requires Step 3's stale-evidence row to fail — that is what
@@ -274,7 +292,9 @@ defer leave the aggregate unchanged and requires Step 3b to fail. P7 replaces
 the dedicated deferral counter with the existing cycle caps and requires
 Step 4b to fail, demonstrating that those caps do not bound a deferral loop, and
 P8 makes an unreadable ledger count as zero and requires Step 4b's fifth run to
-fail.
+fail. P9 replaces the per-bucket partition with a global one and requires
+Step 3c's two-bucket run to fail. P10 accepts any `skipped` peer and requires
+Step 3's three rejected-skip rows to fail.
 
 ### Step 10: Documentation states one contract
 

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -170,11 +170,18 @@ aggregate.
 3. Re-seed the entries against a *different* `expensive_gate.head` and run again.
 4. Read `EXPENSIVE_GATE_DEFERRALS` in each run.
 
+5. Make the ledger read fail, or seed an unparseable payload, and run again.
+
 **Expected result**: step 1 gives `EXPENSIVE_GATE_RESULT=deferral_cap` with the
 loop aggregate `escalate` / `expensive_gate_deferral_cap`, still naming the
 condition that kept failing. Step 2 defers normally. Step 3 defers normally,
 because the counter is head-scoped and a new push starts the budget over.
-`EXPENSIVE_GATE_DEFERRALS` shows the distance to the cap in every run.
+Step 5 also escalates, with
+`REASON=expensive_gate_deferral_budget_unreadable` and
+`EXPENSIVE_GATE_DEFERRALS=-1` — an unreadable budget cannot prove the sequence
+is bounded, so deferring again would reopen the unbounded loop the counter
+exists to close, and `-1` keeps that state distinguishable from a count of zero.
+`EXPENSIVE_GATE_DEFERRALS` shows the distance to the cap in every other run.
 
 This bound cannot be delegated to the existing dual cycle caps:
 `reviewer_loop_history_entries_count` buckets qualifying entries `unique` over
@@ -249,10 +256,10 @@ so it would run only when the test file itself changed.
 **Maps to**: `REVIEW.md` § Planted-violation proof.
 
 1. Read the implementation PR description's `Planted-Violation Proofs` heading.
-2. Confirm P1–P7 from the plan each record the command, the file and line of the
+2. Confirm P1–P8 from the plan each record the command, the file and line of the
    planted violation, and both outcomes.
 
-**Expected result**: seven proofs, each showing the check failing with the
+**Expected result**: eight proofs, each showing the check failing with the
 violation present and passing once removed. Four carry the most weight: P4
 deletes the `expensive_reviewer_gate` call so the function is defined but
 unreachable, and requires Step 3's stale-evidence row to fail — that is what
@@ -260,7 +267,9 @@ proves the gate is wired into the dispatch path. P5 deletes the
 `reorder_expensive_reviewers_last` call and requires Step 3c to fail. P6 makes a
 defer leave the aggregate unchanged and requires Step 3b to fail. P7 replaces
 the dedicated deferral counter with the existing cycle caps and requires
-Step 4b to fail, demonstrating that those caps do not bound a deferral loop.
+Step 4b to fail, demonstrating that those caps do not bound a deferral loop, and
+P8 makes an unreadable ledger count as zero and requires Step 4b's fifth run to
+fail.
 
 ### Step 10: Documentation states one contract
 

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -210,6 +210,25 @@ exact configuration Step 3c exists to support. The peer set is well-defined only
 because of the reorder — after it, "precedes this reviewer" and "should have
 produced evidence before this reviewer" are the same set.
 
+### Step 3e: The local evidence is derived in-loop, not read from the environment
+
+**Maps to**: the "gate reads the local evidence from the environment" risk.
+
+1. With #1648's actual producer populating `platform_reviewed_heads` — **not**
+   with `LOCAL_AI_CONFIGURED` / `LOCAL_AI_HEAD_CURRENT` pre-seeded as
+   variables — run the gate for a current head, a stale head, an unreported
+   head, and a run where `local-ai-reviewer` is not configured.
+2. Compare the gate's inputs with the values the run later prints as
+   `LOCAL_AI_CONFIGURED` and `LOCAL_AI_HEAD_CURRENT`.
+3. Grep the gate implementation for reads of those two names as variables.
+
+**Expected result**: the derived values match the printed ones in all four
+runs, and the gate reads neither name from the environment. #1648 defines them
+as top-level stdout keys printed once at end of run, so an environment read
+would be unset during the platform iteration and the gate would defer on every
+invocation — inert in the worst way, always refusing. The stdout keys are the
+serialization of the same in-loop state, not a second source of truth.
+
 ### Step 4: Unreadable evidence defers, and does not escalate
 
 **Maps to**: brief scope bullet 2 (fail-closed).
@@ -372,10 +391,10 @@ so it would run only when the test file itself changed.
 **Maps to**: `REVIEW.md` § Planted-violation proof.
 
 1. Read the implementation PR description's `Planted-Violation Proofs` heading.
-2. Confirm P1–P16 from the plan each record the command, the file and line of
+2. Confirm P1–P17 from the plan each record the command, the file and line of
    the planted violation, and both outcomes.
 
-**Expected result**: sixteen proofs, each showing the check failing with the
+**Expected result**: seventeen proofs, each showing the check failing with the
 violation present and passing once removed. Four carry the most weight: P4
 deletes the `expensive_reviewer_gate` call so the function is defined but
 unreachable, and requires Step 3's stale-evidence row to fail — that is what
@@ -394,7 +413,8 @@ peer set back to the whole resolved list and requires Step 3d's first run to
 fail. P14 makes the baseline-check helper treat every check as a baseline check
 and requires Step 3's reviewer-owned-pending row to fail. P15 removes the
 short-circuit on a defer and requires Step 6b to fail. P16 makes an empty
-check set read as green and requires Step 3's two empty-set rows to fail.
+check set read as green and requires Step 3's two empty-set rows to fail. P17
+reads the local evidence from the environment and requires Step 3e to fail.
 
 ### Step 10: Documentation states one contract
 

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -99,7 +99,8 @@ Drive the fixture with exactly one condition unmet at a time and read
 | Reorder suppressed, so a same-bucket peer has not run yet | `deferred` / `peer_reviewer_not_run` |
 | A peer ran and returned `needs_fixes` or `escalate` | `deferred` / `peer_reviewer_not_clean` |
 | A peer ran and returned `skipped` / `unavailable`, `timeout`, or `unauthorized` | `deferred` / `peer_reviewer_not_clean` |
-| A peer ran and returned `skipped` / `not_configured` or `explicit-skip` | contributes to `dispatched` |
+| A peer ran and returned `skipped` with a reason in `EXPENSIVE_GATE_ACCEPTED_SKIP_REASONS` (`not_configured`, `explicit-skip`, `release_pr`, `unsupported-platform`) | contributes to `dispatched` |
+| A peer ran and returned `skipped` with an unknown or empty reason | `deferred` / `peer_reviewer_not_clean` |
 | One unresolved, non-outdated review thread | `deferred` / `unresolved_threads` |
 | The same thread marked outdated | `dispatched` |
 | A non-reviewer check failed | `deferred` / `baseline_checks_not_green` |
@@ -135,9 +136,14 @@ of the weight:
   normal run means the reorder did not happen. Note the peer set is scoped by
   phase — Step 3d covers it — so a draft-phase `codex-github` must **not** wait
   on a ready-phase `bugbot`.
-- The **`skipped`** rows must split — two accepted (`not_configured`,
-  `explicit-skip`) and three rejected (`unavailable`, `timeout`,
-  `unauthorized`). Accepting every skip would let
+- The **`skipped`** rows must split by a positive allow-list: four accepted
+  (`not_configured`, `explicit-skip`, `release_pr`, `unsupported-platform`) and
+  everything else rejected, including `unavailable`, `timeout`, `unauthorized`,
+  an unknown reason, and an empty one. Deciding this by asking whether
+  `reviewer_failed_label_required_for_result` returns false would be a deny-list:
+  that helper returns false for any reason it does not recognise, so a future
+  reviewer's new skip reason would silently become acceptable evidence. The
+  membership test decides; the helper call confirms. Accepting every skip would let
   `codex-github` dispatch when a configured peer was unavailable, timed out, or
   was refused for credentials — no cheap pre-filter actually ran, which is the
   state the item exists to prevent. Acceptance must be decided by calling
@@ -418,10 +424,10 @@ so it would run only when the test file itself changed.
 **Maps to**: `REVIEW.md` § Planted-violation proof.
 
 1. Read the implementation PR description's `Planted-Violation Proofs` heading.
-2. Confirm P1–P18 from the plan each record the command, the file and line of
+2. Confirm P1–P19 from the plan each record the command, the file and line of
    the planted violation, and both outcomes.
 
-**Expected result**: eighteen proofs, each showing the check failing with the
+**Expected result**: nineteen proofs, each showing the check failing with the
 violation present and passing once removed. Four carry the most weight: P4
 deletes the `expensive_reviewer_gate` call so the function is defined but
 unreachable, and requires Step 3's stale-evidence row to fail — that is what
@@ -443,6 +449,8 @@ short-circuit on a defer and requires Step 6b to fail. P16 makes an empty
 check set read as green and requires Step 3's two empty-set rows to fail. P17
 reads the local evidence from the environment and requires Step 3e to fail. P18
 removes the bound validation and requires Step 4c to fail in both directions.
+P19 drops the allow-list membership test and requires Step 3's unknown-reason
+and empty-reason rows to fail.
 
 ### Step 10: Documentation states one contract
 

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -1,0 +1,218 @@
+# Smoke Test Runbook: Expensive Reviewers After Local Clean Evidence
+
+**Feature**: Expensive-reviewer gate for the automated reviewer loop
+**Spec**: None — Refactor item. Source brief:
+[issue #1649](https://github.com/lhpaul/ai-dev-framework-template/issues/1649)
+**Implementation plan**:
+[2_1649-expensive-reviewers-after-local-clean_implementation-plan.md](../../specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md)
+**Created in**: Plan Ready stage
+**Updated in**: In Development stage
+
+---
+
+## Prerequisites
+
+- [ ] You are reviewing the implementation PR for #1649.
+- [ ] The PR targets `develop-internal-reviewer-effectiveness`.
+- [ ] #1648 is merged into that branch, so `LOCAL_AI_CONFIGURED` and
+      `LOCAL_AI_HEAD_CURRENT` exist in `pr-review-loop.sh`.
+- [ ] `bash`, `jq`, and `git` are available. No network access and no live
+      GitHub mutation are required — `codex-github` is configured in no bucket
+      of this repository's `.ai-dev-workflow.yaml`, so every step runs against
+      harness fixtures with mocked `gh` commands.
+
+---
+
+## Test Data
+
+| Item | Value |
+| --- | --- |
+| Reviewer loop | `scripts/development-workflow/pr-review-loop.sh` |
+| CI loop (reviewer/baseline check classification) | `scripts/development-workflow/pr-ci-loop.sh` |
+| Suite selector | `scripts/development-workflow/select-test-suites.sh` |
+| Loop harness suite | `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Gate suite (new) | `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` |
+| Reviewer-loop protocol | `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md` |
+| Reviewer integration doc | `docs/workflow/development-workflow/integrations/codex-github.md` |
+| Override variable | `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS` |
+
+---
+
+## Smoke Test Steps
+
+### Step 1: Only expensive reviewers are gated
+
+**Maps to**: the "must not hold back a cheap reviewer" risk.
+
+1. Source the loop in harness mode:
+
+   <!-- workflow-shell-contract: bash -->
+
+   ```bash
+   HARNESS_MODE=1 source scripts/development-workflow/pr-review-loop.sh
+   ```
+
+2. Call `is_expensive_reviewer_platform` with `codex-github`,
+   `local-ai-reviewer`, `pr-agent`, and `bugbot`.
+
+**Expected result**: success only for `codex-github`. A cheap reviewer that
+matched would be held back by a gate that assumes an expensive one, inverting
+the item's intent.
+
+### Step 2: The gate dispatches when all four conditions are met
+
+**Maps to**: brief scope bullet 1.
+
+1. Drive the condition fixture with `LOCAL_AI_CONFIGURED=1`,
+   `LOCAL_AI_HEAD_CURRENT=1`, every peer reviewer `clean`, zero unresolved
+   non-outdated threads, and all non-reviewer checks green.
+
+**Expected result**: `EXPENSIVE_GATE_RESULT=dispatched`, an empty
+`EXPENSIVE_GATE_REASON`, `EXPENSIVE_GATE_HEAD` equal to the run's
+`loop_head_sha`, and `run_platform_review` called once for `codex-github`.
+
+### Step 3: Each unmet condition holds the platform back with one named reason
+
+**Maps to**: brief scope bullets 1 and 2.
+
+Drive the fixture with exactly one condition unmet at a time and read
+`EXPENSIVE_GATE_RESULT` and `EXPENSIVE_GATE_REASON`:
+
+| Fixture state | Required result |
+| --- | --- |
+| `LOCAL_AI_HEAD_CURRENT=0` | `held` / `local_evidence_stale` |
+| `LOCAL_AI_CONFIGURED` unset | `held` / `local_evidence_missing` |
+| `LOCAL_AI_CONFIGURED=1`, `LOCAL_AI_HEAD_CURRENT` empty | `held` / `local_evidence_missing` |
+| `LOCAL_AI_CONFIGURED=0` | `held` / `local_reviewer_not_configured` |
+| A peer reviewer returned `needs_fixes` earlier in the invocation | `held` / `peer_reviewer_not_clean` |
+| One unresolved, non-outdated review thread | `held` / `unresolved_threads` |
+| The same thread marked outdated | `dispatched` |
+| A non-reviewer check failed | `held` / `baseline_checks_not_green` |
+| A non-reviewer check still running | `held` / `baseline_checks_pending` |
+| A reviewer-owned check still running | `dispatched` |
+
+**Expected result**: each row returns exactly its stated result, and
+`run_platform_review` is not called on any `held` row. The last row matters
+most: a reviewer's own check must never gate that reviewer, or `codex-github`
+would wait on a check it is responsible for producing.
+
+### Step 4: Unreadable evidence holds, and does not escalate
+
+**Maps to**: brief scope bullet 2 (fail-closed).
+
+1. Make the review-threads query fail; run the gate.
+2. Make the check-rollup query fail; run the gate.
+3. Set `loop_head_sha` to the empty string; run the gate.
+4. In each case, read the loop's aggregate `RESULT`.
+
+**Expected result**: `held` with `evidence_unavailable_review_threads`,
+`evidence_unavailable_checks`, and `evidence_unavailable_head` respectively, and
+the loop's aggregate result unchanged in all three. A hold is a skip, not a
+blocking verdict — an unreadable input must not fail the PR, and it must not
+dispatch either.
+
+### Step 5: The override dispatches without hiding the reason
+
+**Maps to**: brief scope bullet 3.
+
+1. Set `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS=1`.
+2. Run the gate with `LOCAL_AI_HEAD_CURRENT=0`.
+
+**Expected result**: `EXPENSIVE_GATE_RESULT=forced`,
+`EXPENSIVE_GATE_REASON=local_evidence_stale` still present, and
+`run_platform_review` called. The reason surviving the override is the point: a
+forced run that later wastes reviewer cycles must be traceable to the condition
+that was overridden.
+
+### Step 6: Composition with the existing phase mechanism
+
+**Maps to**: the "two gates disagreeing" risk.
+
+1. Configure `codex-github` as both a phase platform and an expensive reviewer.
+2. Run the loop and observe the order of operations.
+3. Re-run with the gate holding, and inspect the PR's draft state and the loop's
+   phase telemetry.
+4. Re-run with `--pre-after-clean-only`.
+
+**Expected result**: `ensure_pr_ready_for_ready_phase` runs first and the gate
+second. When the gate holds, the PR has still been converted to ready and the
+hold is not reported as a phase failure. Under `--pre-after-clean-only` the
+platform is filtered out before the gate is consulted and **no**
+`EXPENSIVE_GATE_*` telemetry is emitted for it — a phantom `held` record for a
+platform that was never in scope would misreport why the reviewer did not run.
+
+### Step 7: Gate outcome is visible in both durable surfaces
+
+**Maps to**: the "silently stops `codex-github` from ever running" risk.
+
+1. Read the reviewer-loop summary comment produced by a `held` run.
+2. Read the `reviewer_loop_history.v1` entry from the same run.
+3. Parse a legacy entry that has no `expensive_gate` object.
+
+**Expected result**: the summary carries one
+`**Expensive reviewer gate:**` line naming the platform, result, reason, and
+head; the ledger entry carries an `expensive_gate` object with the same four
+values; and the legacy entry still parses through
+`reviewer_loop_history_payload_from_existing`, confirming the `v1` schema stayed
+backward compatible. A permanent hold must be readable from the PR without
+re-running anything.
+
+### Step 8: The new suite is selected by the right change sets
+
+**Maps to**: the `# covers:` declaration requirement in the plan.
+
+1. Confirm `test-expensive-reviewer-gate.sh` declares both `# covers:` lines.
+2. Run `scripts/development-workflow/select-test-suites.sh` against a change set
+   touching only `scripts/development-workflow/pr-review-loop.sh`.
+3. Run it again against a change set touching only the reviewer-loop protocol.
+
+**Expected result**: the suite is selected in both runs. Without an explicit
+declaration the naming convention would map this suite to a
+`scripts/development-workflow/expensive-reviewer-gate.sh` that does not exist,
+so it would run only when the test file itself changed.
+
+### Step 9: Planted-violation proofs are present and two-directional
+
+**Maps to**: `REVIEW.md` § Planted-violation proof.
+
+1. Read the implementation PR description's `Planted-Violation Proofs` heading.
+2. Confirm P1–P4 from the plan each record the command, the file and line of the
+   planted violation, and both outcomes.
+
+**Expected result**: four proofs, each showing the check failing with the
+violation present and passing once removed. P4 matters most — it removes the
+`is_expensive_reviewer_platform` guard and requires Step 3's stale-evidence row
+to fail, which is what proves the gate is wired into the dispatch path rather
+than merely defined.
+
+### Step 10: Documentation states one contract
+
+1. Read the gate section of
+   `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`.
+2. Read the gate section of
+   `docs/workflow/development-workflow/integrations/codex-github.md`.
+
+**Expected result**: both name the same four conditions in the same order, the
+same fail-closed rule, the same `held` / `dispatched` / `forced` outcomes, and
+the same override variable. Reading them against Step 3's table must surface no
+contradiction.
+
+### Step 11: Static checks
+
+1. Run `shellcheck` on `scripts/development-workflow/pr-review-loop.sh`.
+2. Run `markdownlint-cli2` on the two changed documentation files, this runbook,
+   and the implementation plan.
+
+**Expected result**: both tools exit 0.
+
+---
+
+## Rollback
+
+Revert the implementation PR. The change is additive — one gate function, one
+call site, four stdout keys, one summary line, and one optional ledger object —
+and reverting restores the previous behavior, in which an expensive reviewer
+runs as soon as the phase mechanism reaches it. Ledger entries already written
+with `expensive_gate` remain parseable by the reverted reader, which dereferences
+unknown fields with defaults. No configuration migration is involved: the gate
+reads no `.ai-dev-workflow.yaml` key that this item adds.

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -127,7 +127,9 @@ of the weight:
   normal run means the reorder did not happen. Note the peer set is scoped by
   phase — Step 3d covers it — so a draft-phase `codex-github` must **not** wait
   on a ready-phase `bugbot`.
-- The two **`skipped`** rows must split. Accepting every skip would let
+- The **`skipped`** rows must split — two accepted (`not_configured`,
+  `explicit-skip`) and three rejected (`unavailable`, `timeout`,
+  `unauthorized`). Accepting every skip would let
   `codex-github` dispatch when a configured peer was unavailable, timed out, or
   was refused for credentials — no cheap pre-filter actually ran, which is the
   state the item exists to prevent. Acceptance must be decided by calling

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -172,11 +172,14 @@ aggregate.
 
 5. Make the ledger read fail, or seed an unparseable payload, and run again.
 
-**Expected result**: step 1 gives `EXPENSIVE_GATE_RESULT=deferral_cap` with the
-loop aggregate `escalate` / `expensive_gate_deferral_cap`, still naming the
-condition that kept failing. Step 2 defers normally. Step 3 defers normally,
+**Expected result**: step 1 gives `EXPENSIVE_GATE_RESULT=deferral_cap` with
+`EXPENSIVE_GATE_ESCALATION=expensive_gate_deferral_cap` and the loop aggregate
+`escalate` / `expensive_gate_deferral_cap`, still naming the condition that kept
+failing. `EXPENSIVE_GATE_ESCALATION` is what distinguishes the two escalation
+causes without re-deriving them from the count. Step 2 defers normally. Step 3 defers normally,
 because the counter is head-scoped and a new push starts the budget over.
-Step 5 also escalates, with
+Step 5 also escalates, with `EXPENSIVE_GATE_RESULT=deferral_cap`,
+`EXPENSIVE_GATE_ESCALATION=expensive_gate_deferral_budget_unreadable`,
 `REASON=expensive_gate_deferral_budget_unreadable` and
 `EXPENSIVE_GATE_DEFERRALS=-1` — an unreadable budget cannot prove the sequence
 is bounded, so deferring again would reopen the unbounded loop the counter

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -28,7 +28,8 @@
 | Item | Value |
 | --- | --- |
 | Reviewer loop | `scripts/development-workflow/pr-review-loop.sh` |
-| CI loop (reviewer/baseline check classification) | `scripts/development-workflow/pr-ci-loop.sh` |
+| Reviewer/baseline check classification | `configured_reviewer_check_names_json`, relocated to `scripts/development-workflow/workflow-lib.sh` |
+| CI loop (its consumer; **not** called by the gate) | `scripts/development-workflow/pr-ci-loop.sh` |
 | Suite selector | `scripts/development-workflow/select-test-suites.sh` |
 | Loop harness suite | `scripts/development-workflow/tests/test-pr-review-loop.sh` |
 | Gate suite (new) | `scripts/development-workflow/tests/test-expensive-reviewer-gate.sh` |
@@ -61,6 +62,13 @@ matched would be held back by a gate that assumes an expensive one, inverting
 the item's intent.
 
 ### Step 2: The gate dispatches when all conditions are met
+
+The four conditions are: the local reviewer clean and current; every reviewer
+that **precedes** this one having produced acceptable evidence — a `clean`
+result, or a `skipped` one whose reason is not a reviewer failure, deliberately
+**not** every `skipped`; zero unresolved non-outdated review threads; and green
+non-reviewer baseline checks. Steps 3 and 3d pin the second condition's two
+halves.
 
 **Maps to**: brief scope bullet 1.
 
@@ -299,6 +307,23 @@ legacy entry still parses through
 backward compatible. A repeated defer must be readable from the PR without
 re-running anything.
 
+### Step 7e: The shared classification moved without changing behavior
+
+**Maps to**: the "shared classification is duplicated or the gate blocks on the
+CI loop" risk.
+
+1. Confirm `configured_reviewer_check_names_json` is defined in
+   `workflow-lib.sh` and no longer in `pr-ci-loop.sh`.
+2. Run `scripts/development-workflow/tests/test-pr-ci-loop.sh`.
+3. Grep the gate's implementation for any invocation of `pr-ci-loop.sh`.
+
+**Expected result**: one definition, in the library both scripts already source;
+`pr-ci-loop.sh` still emits identical `REVIEWER_CHECK_COUNT`, `REVIEWER_CHECKS`
+and `REVIEWER_CHECKS_JSON`; and the gate calls `pr-ci-loop.sh` nowhere. The gate
+takes a single non-blocking snapshot of the check rollup — invoking the polling
+CI loop would block the reviewer loop inside a gate and conflate "CI is not
+green yet" with "the gate says wait".
+
 ### Step 8: The new suite is selected by the right change sets
 
 **Maps to**: the `# covers:` declaration requirement in the plan.
@@ -318,10 +343,10 @@ so it would run only when the test file itself changed.
 **Maps to**: `REVIEW.md` § Planted-violation proof.
 
 1. Read the implementation PR description's `Planted-Violation Proofs` heading.
-2. Confirm P1–P13 from the plan each record the command, the file and line of
+2. Confirm P1–P14 from the plan each record the command, the file and line of
    the planted violation, and both outcomes.
 
-**Expected result**: thirteen proofs, each showing the check failing with the
+**Expected result**: fourteen proofs, each showing the check failing with the
 violation present and passing once removed. Four carry the most weight: P4
 deletes the `expensive_reviewer_gate` call so the function is defined but
 unreachable, and requires Step 3's stale-evidence row to fail — that is what
@@ -337,7 +362,8 @@ Step 3's three rejected-skip rows to fail. P11 makes an absent ledger return
 `-1` and requires Step 4b's sixth run to fail. P12 rewrites condition 1 as a
 deny-list and requires Step 3's unexpected-value rows to fail. P13 widens the
 peer set back to the whole resolved list and requires Step 3d's first run to
-fail.
+fail. P14 makes the baseline-check helper treat every check as a baseline check
+and requires Step 3's reviewer-owned-pending row to fail.
 
 ### Step 10: Documentation states one contract
 
@@ -357,7 +383,8 @@ must surface no contradiction.
 
 ### Step 11: Static checks
 
-1. Run `shellcheck` on `scripts/development-workflow/pr-review-loop.sh`.
+1. Run `shellcheck` on `scripts/development-workflow/pr-review-loop.sh`,
+   `pr-ci-loop.sh`, and `workflow-lib.sh` — the relocation touches all three.
 2. Run `markdownlint-cli2` on the two changed documentation files, this runbook,
    and the implementation plan.
 

--- a/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
+++ b/docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md
@@ -91,10 +91,10 @@ Drive the fixture with exactly one condition unmet at a time and read
 
 | Fixture state | Required result |
 | --- | --- |
-| `LOCAL_AI_HEAD_CURRENT=0` | `deferred` / `local_evidence_stale` |
-| `LOCAL_AI_CONFIGURED` unset, empty, `2`, or `true` | `deferred` / `local_evidence_missing` |
-| `LOCAL_AI_CONFIGURED=1`, `LOCAL_AI_HEAD_CURRENT` unset, empty, `2`, or `yes` | `deferred` / `local_evidence_missing` |
-| `LOCAL_AI_CONFIGURED=0` | `deferred` / `local_reviewer_not_configured` |
+| `local-ai-reviewer` entry of `platform_reviewed_heads` records a head that is not `loop_head_sha` | `deferred` / `local_evidence_stale` |
+| That entry is absent while `local-ai-reviewer` is in the resolved list | `deferred` / `local_evidence_missing` |
+| The derivation helper returns any value other than `0` or `1` | `deferred` / `local_evidence_missing` |
+| `local-ai-reviewer` is not in the resolved platform list | `deferred` / `local_reviewer_not_configured` |
 | Reorder suppressed, so a same-bucket peer has not run yet | `deferred` / `peer_reviewer_not_run` |
 | A peer ran and returned `needs_fixes` or `escalate` | `deferred` / `peer_reviewer_not_clean` |
 | A peer ran and returned `skipped` / `unavailable`, `timeout`, or `unauthorized` | `deferred` / `peer_reviewer_not_clean` |
@@ -112,11 +112,16 @@ Drive the fixture with exactly one condition unmet at a time and read
 `run_platform_review` is not called on any `deferred` row. Three rows carry most
 of the weight:
 
-- The **unexpected-value** rows are the ones a deny-list implementation fails.
-  Condition 1 must be an exact-match allow-list requiring the literal `1` on
-  both keys; testing only for `0` and empty would let a `2` or a stray `true`
-  fall through and dispatch the expensive reviewer with no valid evidence, which
-  is the opposite of fail-closed.
+- Every row here is driven through the **in-loop state** — the resolved platform
+  list and `platform_reviewed_heads` — never by exporting
+  `LOCAL_AI_CONFIGURED` or `LOCAL_AI_HEAD_CURRENT`. Those are stdout keys the
+  gate must ignore (Step 3e), so a fixture that set them would be testing an
+  interface the implementation is required not to have.
+- The **unexpected-value** row is the one a deny-list implementation fails.
+  Condition 1 must be an exact-match allow-list requiring the literal `1` from
+  each derivation helper; testing only for `0` and empty would let any other
+  value fall through and dispatch with no valid evidence, the opposite of
+  fail-closed.
 - The **`LOCAL_AI_CONFIGURED=0`** row must defer, not dispatch. The brief
   requires the expensive reviewer to run only after current-head local clean
   evidence and to fail closed when it is absent, and it permits an explicit


### PR DESCRIPTION
## Summary

Refactor item for epic #1647. The reviewer loop already holds a platform back until the loop reaches it (`phase_after_clean_platforms`, alias `ready_phase_platforms`), and it already breaks out before that point when an earlier platform returns non-clean. What the phase gate does *not* check is whether the accumulated evidence is about the current head and complete: `ensure_pr_ready_for_ready_phase` inspects draft state and the rate limit only — no head SHA, no review threads, no CI, no reviewer verdicts.

This plan adds a dedicated pre-dispatch gate for `codex-github` requiring four current-head conditions — local reviewer clean and current, every reviewer that precedes it having produced acceptable evidence (a `clean` result, or a `skipped` one whose reason is on a fixed allow-list of deliberate policy skips), zero unresolved non-outdated review threads, and a non-empty set of non-reviewer baseline checks all green — evaluated immediately before dispatch, fail-closed on every unreadable input, with one documented override for manual escalation that preserves the reason it overrode.

Two mechanisms make the gate correct rather than merely present. Expensive reviewers are **reordered last within their own phase bucket**, so the gate's precondition is reachable instead of deadlocking, without moving a draft-configured reviewer past the ready-phase transition. A `deferred` or `deferral_cap` outcome also breaks out of the platform iteration, so a defer cannot trigger the ready-phase transition on its way to not proceeding. And a hold **defers** rather than skipping: it sets the loop aggregate to `needs_fixes` so readiness is withheld and Step 7 re-runs, bounded by the gate's own head-scoped deferral counter because the existing cycle caps cannot see a deferral loop.

**Estimated complexity**: L

**Dependencies**: **#1648 must be merged to `develop-internal-reviewer-effectiveness` before this item's implementation PR opens.** This plan consumes `LOCAL_AI_CONFIGURED` and `LOCAL_AI_HEAD_CURRENT`, which #1648 introduces, and inherits its rule that an absent key is telemetry loss rather than non-applicability. The plan PRs are independent and may be reviewed in parallel; only the implementation is ordered. This is recorded as a `Conflict` → `Resolved by sequencing` in the plan's Cross-Cutting Operational Assumption Check, and enforced by Implementation Order step 0, a hard stop.

**Key risks**: the gate could silently stop `codex-github` from ever running (worse than running it too often, since its findings are why this epic exists); it could be defined but never wired into the dispatch path; the reorder could move a reviewer across the draft/ready boundary; a peer that never produced a verdict could be accepted as evidence; and a deferral loop could run unbounded because the existing cycle caps deduplicate by head and result. Each has a named mitigation and a pinned scenario, and eleven planted-violation proofs plant each failure mode directly.

**Note on scope**: `codex-github` is configured in neither `review.on_draft.github` nor `review.on_ready.github` in this repository, so the gate is inert here by absence. Every scenario is therefore a harness fixture with mocked `gh` commands — no live run can exercise it, which is stated in the runbook prerequisites rather than left for a reviewer to discover.

## Artifacts

- Plan: `docs/specs/developments/20260827233000_1649-expensive-reviewers-after-local-clean/2_1649-expensive-reviewers-after-local-clean_implementation-plan.md`
- Smoke test runbook: `docs/testing/workflow/1649-expensive-reviewers-after-local-clean.smoke-test.md`

## Document Quality Gate

- Spec/brief coverage: Checked - all three brief scope bullets map to implementation steps, test scenarios, and smoke test steps. Bullet 1 (gate behind current-head local clean evidence) → conditions 1-4, the phase-bucket reorder, and scenarios 2, 3, 6, 6b, 7, 8. Bullet 2 (fail-closed when evidence is missing or stale) → the three `evidence_unavailable_*` reasons, the deferral bound and its two escalation causes, and scenarios 4, 5, 12, 13, 19, 19b. Bullet 3 (preserve explicit override paths) → `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS` and scenario 15.
- Implementation-order consistency: Checked - the constant, the four function names, the six `EXPENSIVE_GATE_*` keys plus `EXPENSIVE_REVIEWERS_REORDERED`, the eight condition reasons, the three `evidence_unavailable_*` reasons, the two escalation values, the ledger object, both env vars, and the two documentation paths agree across Summary, Layer-by-Layer, Testing Strategy, Seed Data, Documentation Updates, Risks, Code Samples and Implementation Order, and against the runbook's Step 3, 3b, 3c, 4b and 10 expectations.
- Verification support: Checked - every claim about current behavior cites a Verification Log command with its result at repo SHA `7998d43d`: the phase mechanism and its call site; that `ensure_pr_ready_for_ready_phase` checks only draft state and the rate limit; that the non-clean short-circuit is per-invocation (observed on PR #1660's own loop telemetry); that `codex-github` is configured in no bucket here; that `pr-ci-loop.sh` already separates reviewer-owned from baseline checks; that `integrations/codex-github.md` exists; that the dual cycle caps exist; and — with the `sed` range as evidence — that `reviewer_loop_history_entries_count` reduces with `unique` over `head_sha` + `result`, which is why the deferral bound cannot be delegated to them.
- Behavioral guarantees: Checked - "fail-closed" names three specific `evidence_unavailable_*` reasons with no generic unknown state; "a defer is not a skip" names the `needs_fixes` aggregate as the mechanism that withholds readiness and forces the retry, pinned by scenario 3 and proof P6; "bounded" names the head-scoped occurrence counter rather than the existing caps, pinned by scenario 13 and proof P7; "an absent ledger is the first run" names the three-state mapping mirroring `reviewer_loop_history_entries_count`, pinned by scenario 19b and proof P11; `v1` ledger compatibility names the additive-optional-object rule, pinned by scenario 18.
- Complex workflow decision-gate matrix: Checked - this plan adds a workflow decision gate. **Inputs**: `LOCAL_AI_CONFIGURED`, `LOCAL_AI_HEAD_CURRENT`, the results and reasons of every platform in this reviewer's **peer set** — the platforms that precede it under the reordered list, meaning the non-expensive platforms in its own phase bucket plus every platform in any earlier bucket, **not** every non-expensive platform in the resolved list, which would deadlock a draft-configured expensive reviewer behind a ready-phase peer — unresolved non-outdated review threads at `loop_head_sha`, non-reviewer check conclusions at `loop_head_sha`, the live head returned with each of those two queries, the head-scoped deferral count, and `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS`. **Outcomes**: `dispatched`; `deferred` with exactly one of eight condition reasons or three `evidence_unavailable_*` reasons; `deferral_cap` with `EXPENSIVE_GATE_ESCALATION` of `expensive_gate_deferral_cap` or `expensive_gate_deferral_budget_unreadable`; and `forced`. **Required next actions**: `dispatched` → run the platform; `deferred` → skip the platform, set the aggregate to `needs_fixes` / `expensive_gate_deferred` so readiness is withheld and Step 7 re-runs; `deferral_cap` → set the aggregate to `escalate` so a human sees which condition kept failing; `forced` → run the platform with the overridden reason recorded and the aggregate untouched. **Mirror surfaces**: Protocol 93, `integrations/codex-github.md`, the `--help` block, the summary comment line, and the ledger's `expensive_gate` object — the plan requires both documents to carry the identical two-value escalation contract, and smoke test Step 10 reads them against each other. **Examples**: the illustrative gate function and the summary-comment line are part of the changed surface and are asserted by Steps 2-4b and Step 7.
- Parser/API/concurrency checklist: Not applicable with rationale recorded in the plan. Parser-risk: the gate compares tokens the loop already produces and does no text scanning or regex extraction of its own. Concurrency: evaluated synchronously inside the existing sequential per-platform iteration, no state between invocations, no listeners or timers. API-surface: the six `EXPENSIVE_GATE_*` keys, `EXPENSIVE_REVIEWERS_REORDERED`, the ledger object, and both environment variables are enumerated in a table giving each key its allowed values and when it is emitted, and are required in `--help`.
- CHANGELOG literal format: Checked - Implementation Order step 13 gives the fragment path `changelog.d/1649.changed.expensive-reviewers-after-local-clean.md` and the literal body in the project's `**Bold Title** (#N):` bullet format.
- Not-applicable rationale: Checked - the Backend, Frontend, and Infrastructure layers, the parser-risk and concurrency addenda, and the `REVIEW.md` / `AGENTS.md` documentation entries each carry a short rationale.

Closes #1649

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only PR; workflow risk applies to the later implementation on `pr-review-loop.sh`, which this plan explicitly sequences behind #1648.
> 
> **Overview**
> Adds **planning-only** artifacts for #1649: a full implementation plan and a workflow smoke-test runbook. No shell, test, or protocol changes land in this PR—the work specifies what a follow-up implementation PR must do after **#1648** merges.
> 
> The plan defines a pre-dispatch **expensive-reviewer gate** for `codex-github` (four fail-closed conditions, phase-bucket reordering, `needs_fixes` deferrals with a dedicated head-scoped deferral cap, `PR_REVIEW_LOOP_FORCE_EXPENSIVE_REVIEWERS`, telemetry, ledger/summary surfaces, and relocation of `configured_reviewer_check_names_json` into `workflow-lib.sh`). It also locks **verification**: harness scenarios, a new `test-expensive-reviewer-gate.sh`, nineteen planted-violation proofs, and aligned updates to Protocol 93 and `codex-github.md` (called out in the plan, not edited here).
> 
> The runbook mirrors those expectations for manual review of the future implementation PR (fixtures/mocked `gh`, since this repo does not configure `codex-github`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cce7243ff6336cfcd1856a733423d0611293347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->