### PR TITLE
docs(spec): missed-finding telemetry

### DIFF
--- a/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
+++ b/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
@@ -150,7 +150,7 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 ### Use Case 5: The history itself cannot be read or written
 
 **Actor**: The reviewer loop.
-**Preconditions**: An external reviewer has reported blocking findings, and the reviewer-loop history surface on the pull request is unavailable — it cannot be read, it does not parse, or it cannot be appended to.
+**Preconditions**: A record was owed and could not be written. Specifically: an external reviewer other than the local one has reported **blocking** findings, the commit it reviewed **can** be established, and the reviewer-loop history surface on the pull request is unavailable — it cannot be read, it does not parse, or it cannot be appended to. If any of the first two conditions does not hold, no record was owed and this use case does not apply, whatever state the history is in.
 
 **Steps**:
 
@@ -174,6 +174,7 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 - This is deliberately distinct from Use Case 4. There, the history is healthy and simply does not say what the local reviewer concluded, so an `unknown` record is both possible and useful. Here nothing can be written at all, so `unknown` is not available as an outcome — a state that describes evidence cannot be recorded when the place it would be recorded is the thing that failed.
 - The loop must not append to, rebuild, or overwrite a history it could not read. A partial or reconstructed history would silently discard prior evidence, which is worse than a gap: a gap is visible, and a rewritten history looks authoritative.
 - The omission must be visible in the round's output rather than silent. Telemetry that can disappear without anyone noticing cannot be trusted later, which is the same reason the `unknown` state exists at all.
+- The report is owed **only when a record was owed**. A round carrying the local reviewer's own findings, or only advisory findings, or findings on a commit that cannot be established, terminates before history writability is ever considered — reporting a telemetry failure there would raise an alarm about a record nobody was going to write.
 
 ---
 
@@ -300,7 +301,8 @@ that failed.
 - [ ] **AC-5.** When the local reviewer's most recent verdict reported findings, the record is still written and its local evidence state is `not_clean`, and it does not count as missed.
 - [ ] **AC-6.** When the local reviewer was skipped, was unavailable, is configured but has not yet produced a verdict, or is not configured at all, the record is written with the corresponding state, the four are distinguishable from one another and from `not_clean`, **and none of the four counts as missed**.
 - [ ] **AC-7.** When the history is readable but does not establish the local reviewer's most recent verdict, the record is written with state `unknown` and does not count as missed.
-- [ ] **AC-7a.** When the reviewer-loop history cannot be read, parsed, or appended to, no missed-finding record is written, the existing history is left byte-for-byte unchanged, and the round's output states that telemetry could not be recorded and why.
+- [ ] **AC-7a.** When an external reviewer has reported blocking findings on an establishable commit **and** the reviewer-loop history cannot be read, parsed, or appended to, no missed-finding record is written, the existing history is left byte-for-byte unchanged, and the round's output states that telemetry could not be recorded and why.
+- [ ] **AC-7b.** When no record was owed in the first place — the findings came from the local reviewer, or were advisory only, or the reviewed commit could not be established — an unwritable history produces **no** telemetry-failure report, because nothing was owed.
 - [ ] **AC-8.** Advisory or suggestion-level external findings produce no missed-finding record.
 - [ ] **AC-9.** Findings reported by the local reviewer itself produce no missed-finding record.
 - [ ] **AC-10.** Two qualifying external rounds on the same pull request produce two records; neither replaces the other.

--- a/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
+++ b/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
@@ -10,6 +10,27 @@ The reviewer loop runs a cheap local reviewer before it runs slow external ones,
 
 This feature records exactly that. When an external reviewer reports blocking findings on a pull request where the local reviewer had previously reported clean, the loop writes a compact record of the miss into the pull request's reviewer-loop history — which reviewer found it, on which commit, how many findings and where, and what the local reviewer's verdict had been at the time. The record is deliberately conservative: it claims a miss only when the local reviewer demonstrably said clean, and says so plainly when the evidence is too weak to make the claim. Its purpose is measurement, and a measurement that inflates its own numbers is worthless.
 
+
+---
+
+## Issue-Objective Traceability
+
+The objectives below are the discrete requirements stated in issue #1651. Every
+one maps to acceptance criteria and use cases here, or to an explicit entry
+under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
+
+| # | Objective (from #1651) | Where it is satisfied |
+| --- | --- | --- |
+| 1 | *Problem* — quantify whether the local reviewer reduces external rounds, by tracking what external reviewers found after a local clean result | Use Cases 1-4; the counting rule and the record-every-qualifying-round rule in Business Rules; the Decision Matrix rows 4-7; AC-1 through AC-7 |
+| 2 | *Outcome* — the reviewer-loop history records missed-by-local findings when an external reviewer reports blockers after a local clean result | Use Case 1; AC-1 through AC-3; Operational Visibility, reviewer-loop history |
+| 3 | *Scope* — capture the reviewer | AC-1; Use Case 1, Information shown |
+| 4 | *Scope* — capture the head commit | AC-1; the attribution rule in Business Rules; AC-11 for the case where it cannot be established |
+| 5 | *Scope* — capture the finding count | AC-1 |
+| 6 | *Scope* — capture the paths | AC-1; AC-14 bounds how many are shown |
+| 7 | *Scope* — capture whether the local reviewer was clean on the same head or an ancestor | AC-1 through AC-4; the four clean-ancestry states, which Business Rules forbid merging |
+| 8 | *Scope* — keep the record compact enough for PR comments | AC-13 through AC-15, with character and path bounds rather than an adjective; Use Case 4, Considerations |
+| 9 | *Scope* — support later effectiveness reporting | AC-16 (records readable in full without re-running a reviewer); the report itself is **deferred** to Out of Scope item 1 (#1657) |
+
 ---
 
 ## Use Cases
@@ -123,9 +144,10 @@ This feature records exactly that. When an external reviewer reports blocking fi
 
 ## Business Rules
 
-- A finding counts as **missed by the local reviewer** only when the local reviewer's most recent verdict for the pull request was explicitly clean. Every other state — findings reported, skipped, unavailable, never ran, unknown — does not count. The counting rule enumerates the states that *do* count rather than the states that do not, so a state introduced later is excluded until someone deliberately includes it.
+- A finding counts as **missed by the local reviewer** only when the local reviewer's most recent verdict was clean **and** covered the commit the external reviewer reviewed or one of its ancestors — states `clean_same_commit` and `clean_earlier_commit`. Every other state does not count. The counting rule enumerates the states that *do* count rather than the states that do not, so a state introduced later is excluded until someone deliberately includes it.
 - The local evidence state is recorded on every external round that reports blocking findings, whether or not it counts as a miss. A record that only appeared for confirmed misses would make the denominator unknowable, and a rate needs both halves.
-- A clean local verdict on the **same commit** the external reviewer reviewed, and a clean local verdict on an **earlier commit**, are recorded as distinct states and are never merged into one. An earlier-commit clean is weaker evidence: the external reviewer may be reporting on code the local reviewer never saw.
+- A clean local verdict is classified by its ancestry relationship to the commit the external reviewer reviewed — same, ancestor, descendant, or unrelated — and the four are recorded as distinct states that are never merged. Only same and ancestor count. A descendant clean means the local reviewer cleared newer code than the external reviewer looked at, and an unrelated clean means a force-push severed the relationship; neither is evidence that the local reviewer saw what was found.
+- A local reviewer that is **configured but has not yet produced a verdict** is recorded distinctly from one that is **not configured at all**. The first describes a pull request early in its life, the second a repository that will never produce local evidence, and summing them would make the two indistinguishable in the numbers.
 - Only **blocking** external findings qualify. Advisory or suggestion-level findings do not create a record, because the local reviewer is not expected to surface them and counting them would inflate the miss rate.
 - The **local** reviewer's own findings never create a missed-finding record. The record exists to compare an external reviewer against the local one; a reviewer cannot miss its own findings.
 - Records accumulate; they are never overwritten or de-duplicated. Two external rounds finding the same thing on the same commit are two records, because the loop genuinely ran twice.
@@ -136,21 +158,60 @@ This feature records exactly that. When an external reviewer reports blocking fi
 
 ## Statuses / Enum Values
 
-The **local evidence state** recorded on each external round that reports blocking findings:
+The **local evidence state** recorded on each external round that reports
+blocking findings. The list is closed: any situation not described by a row is
+recorded as `unknown`.
 
 | Code value | Display label | Description | Counts as missed |
 | --- | --- | --- | --- |
 | `clean_same_commit` | Clean, same commit | The local reviewer reported clean on the exact commit the external reviewer reviewed. | Yes |
-| `clean_earlier_commit` | Clean, earlier commit | The local reviewer reported clean on a commit earlier than the one the external reviewer reviewed. | Yes |
+| `clean_earlier_commit` | Clean, earlier commit | The local reviewer's most recent clean verdict was on an ancestor of the commit the external reviewer reviewed. | Yes |
+| `clean_later_commit` | Clean, later commit | The local reviewer's most recent clean verdict was on a descendant of the commit the external reviewer reviewed — it cleared newer code than the external reviewer looked at. | No |
+| `clean_unrelated_commit` | Clean, unrelated commit | The local reviewer's most recent clean verdict was on a commit with no ancestry relationship to the one the external reviewer reviewed, which a force-push can produce. | No |
 | `not_clean` | Reported findings | The local reviewer's most recent verdict reported findings of its own. | No |
-| `skipped` | Skipped | The local reviewer was configured but deliberately skipped this round. | No |
+| `skipped` | Skipped | The local reviewer was configured and deliberately skipped this round. | No |
 | `unavailable` | Unavailable | The local reviewer was configured but could not run — a timeout, an outage, or a credentials failure. | No |
-| `did_not_run` | Did not run | The local reviewer is not configured for this repository, so it never ran. | No |
+| `not_yet_run` | Not yet run | The local reviewer is configured and has not yet produced any verdict on this pull request. | No |
+| `not_configured` | Not configured | The local reviewer is not configured for this repository, so it will never run. | No |
 | `unknown` | Unknown | The local reviewer's verdict could not be established from the available history. | No |
 
-Exactly two of the seven states count as missed. Any state not in this table is treated as `unknown` and does not count.
+Exactly two of the ten states count as missed: `clean_same_commit` and
+`clean_earlier_commit`. Every other state, including `unknown` and any situation
+this table does not describe, does not count.
 
-**Valid transitions**: none. The state is decided once, when the record is written, and describes the evidence at that moment. It is never revised — a later local run does not rewrite an earlier record, because the record is a historical observation rather than a current status.
+`clean_later_commit` and `clean_unrelated_commit` are separated from
+`clean_earlier_commit` deliberately. A clean verdict on newer or unrelated code
+is not evidence that the local reviewer looked at what the external reviewer
+found, so counting it would attribute a miss to a reviewer that never saw the
+code. `not_yet_run` is separated from `not_configured` for the same reason the
+spec separates `unavailable` from `not_clean`: "has not run yet" and "will never
+run" describe different repositories and must not be summed.
+
+**Valid transitions**: none. The state is decided once, when the record is
+written, and describes the evidence at that moment. It is never revised — a
+later local run does not rewrite an earlier record, because the record is a
+historical observation rather than a current status.
+
+---
+
+## Decision Matrix
+
+The complete gate, from an external reviewer returning a result to a record
+existing or not. Rows are evaluated in order and the first match decides.
+
+| # | External result | Commit attributable | Local evidence state | Record written | Counts as missed | Next action |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | Reported by the local reviewer itself | — | — | No | No | Nothing; a reviewer cannot miss its own findings |
+| 2 | No blocking findings — clean, skipped, or advisory only | — | — | No | No | Nothing; only blocking external findings qualify |
+| 3 | Blocking findings | **No** | — | No | No | Report why the commit could not be established; write no unattributable record |
+| 4 | Blocking findings | Yes | `clean_same_commit` | Yes | **Yes** | Show in the summary; include in the effectiveness numbers |
+| 5 | Blocking findings | Yes | `clean_earlier_commit` | Yes | **Yes** | Show in the summary; include in the effectiveness numbers |
+| 6 | Blocking findings | Yes | Any other state in the Statuses table | Yes | No | Show in the summary; include in the denominator only |
+| 7 | Blocking findings | Yes | Not describable by any row of the Statuses table | Yes, as `unknown` | No | Show in the summary; include in the denominator only |
+
+Rows 4 through 7 are the reason a record is written on every qualifying external
+round rather than only on confirmed misses: rows 6 and 7 are the denominator,
+and a rate needs both halves.
 
 ---
 
@@ -164,18 +225,22 @@ Exactly two of the seven states count as missed. Any state not in this table is 
 
 ## Acceptance Criteria
 
-- [ ] When an external reviewer reports blocking findings on a commit for which the local reviewer's most recent verdict was clean on that same commit, the reviewer-loop history gains a record naming that reviewer, that commit, the number of blocking findings, the files they touch, and the local evidence state `clean_same_commit`.
-- [ ] When the local reviewer's most recent clean verdict was on an earlier commit than the one the external reviewer reviewed, the record's local evidence state is `clean_earlier_commit`, and it is distinguishable from `clean_same_commit` without inspecting commits by hand.
-- [ ] When the local reviewer's most recent verdict reported findings, the record is still written and its local evidence state is `not_clean`, and it does not count as missed.
-- [ ] When the local reviewer was skipped, was unavailable, or is not configured, the record is written with the corresponding state, and the three are distinguishable from one another and from `not_clean`.
-- [ ] When the local reviewer's verdict cannot be established from the history, the record is written with state `unknown` and does not count as missed.
-- [ ] Advisory or suggestion-level external findings produce no missed-finding record.
-- [ ] Findings reported by the local reviewer itself produce no missed-finding record.
-- [ ] Two qualifying external rounds on the same pull request produce two records; neither replaces the other.
-- [ ] When the commit an external reviewer reviewed cannot be established, no record is written and the loop reports the reason.
-- [ ] A pull request carrying missed-finding records reaches exactly the same review outcome, readiness label, and tracker status it would reach without them.
-- [ ] Each record adds no more than one line to the reviewer-loop summary, and a pull request carrying ten records still produces a summary a reader can read without expanding a collapsed section.
-- [ ] The records for a pull request can be read back in full by a later report without re-running any reviewer.
+- [ ] **AC-1.** When an external reviewer reports blocking findings on a commit for which the local reviewer's most recent verdict was clean on that same commit, the reviewer-loop history gains a record naming that reviewer, that commit, the number of blocking findings, the files they touch, and the local evidence state `clean_same_commit`.
+- [ ] **AC-2.** When the local reviewer's most recent clean verdict was on an ancestor of the commit the external reviewer reviewed, the record's local evidence state is `clean_earlier_commit`, and it is distinguishable from `clean_same_commit` without inspecting commits by hand.
+- [ ] **AC-3.** When the local reviewer's most recent clean verdict was on a descendant of the commit the external reviewer reviewed, the state is `clean_later_commit` and it does not count as missed.
+- [ ] **AC-4.** When the local reviewer's most recent clean verdict was on a commit with no ancestry relationship to the one the external reviewer reviewed, the state is `clean_unrelated_commit` and it does not count as missed.
+- [ ] **AC-5.** When the local reviewer's most recent verdict reported findings, the record is still written and its local evidence state is `not_clean`, and it does not count as missed.
+- [ ] **AC-6.** When the local reviewer was skipped, was unavailable, is configured but has not yet produced a verdict, or is not configured at all, the record is written with the corresponding state, and the four are distinguishable from one another and from `not_clean`.
+- [ ] **AC-7.** When the local reviewer's verdict cannot be established from the history, the record is written with state `unknown` and does not count as missed.
+- [ ] **AC-8.** Advisory or suggestion-level external findings produce no missed-finding record.
+- [ ] **AC-9.** Findings reported by the local reviewer itself produce no missed-finding record.
+- [ ] **AC-10.** Two qualifying external rounds on the same pull request produce two records; neither replaces the other.
+- [ ] **AC-11.** When the commit an external reviewer reviewed cannot be established, no record is written and the loop reports the reason.
+- [ ] **AC-12.** A pull request carrying missed-finding records reaches exactly the same review outcome, readiness label, and tracker status it would reach without them.
+- [ ] **AC-13.** Each record adds exactly one line to the reviewer-loop summary, and that line is at most 200 characters.
+- [ ] **AC-14.** A record's summary line names at most three file paths; when the findings touch more than three files, the line names three and states how many more there are.
+- [ ] **AC-15.** A pull request carrying twenty records adds at most twenty lines and 4,000 characters to the reviewer-loop summary, whatever the number of findings or the length of their paths.
+- [ ] **AC-16.** The records for a pull request can be read back in full by a later report without re-running any reviewer.
 
 ---
 

--- a/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
+++ b/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
@@ -21,14 +21,14 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 
 | # | Objective (from #1651) | Where it is satisfied |
 | --- | --- | --- |
-| 1 | *Problem* — quantify whether the local reviewer reduces external rounds, by tracking what external reviewers found after a local clean result | Use Cases 1-5; the counting rule and the record-every-qualifying-round rule in Business Rules; the Decision Matrix rows 4-7; AC-1 through AC-7 |
+| 1 | *Problem* — quantify whether the local reviewer reduces external rounds, by tracking what external reviewers found after a local clean result | Use Cases 1-6; the counting rule and the record-every-qualifying-round rule in Business Rules; the Decision Matrix rows 4-7; AC-1 through AC-7 |
 | 2 | *Outcome* — the reviewer-loop history records missed-by-local findings when an external reviewer reports blockers after a local clean result | Use Case 1; AC-1 through AC-3; Operational Visibility, reviewer-loop history |
 | 3 | *Scope* — capture the reviewer | AC-1; Use Case 1, Information shown |
 | 4 | *Scope* — capture the head commit | AC-1; the attribution rule in Business Rules; AC-11 for the case where it cannot be established |
 | 5 | *Scope* — capture the finding count | AC-1 |
 | 6 | *Scope* — capture the paths | AC-1; AC-14 bounds how many are shown |
 | 7 | *Scope* — capture whether the local reviewer was clean on the same head or an ancestor | AC-1 through AC-4 and AC-17; Use Case 3; the four clean-verdict states — same, ancestor, descendant, and unrelated — which Business Rules forbid merging |
-| 8 | *Scope* — keep the record compact enough for PR comments | AC-13, AC-14, AC-14a and AC-15, with character and path bounds rather than an adjective, and an explicit precedence rule between them; Use Case 5, Considerations |
+| 8 | *Scope* — keep the record compact enough for PR comments | AC-13, AC-14, AC-14a and AC-15, with character and path bounds rather than an adjective, and an explicit precedence rule between them; Use Case 6, Considerations |
 | 9 | *Scope* — support later effectiveness reporting | AC-16 (records readable in full without re-running a reviewer); the report itself is **deferred** to Out of Scope item 1 (#1657) |
 
 ---
@@ -124,12 +124,12 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 ### Use Case 4: The local evidence cannot be established
 
 **Actor**: The reviewer loop.
-**Preconditions**: An external reviewer has reported blocking findings, and the loop cannot determine what the local reviewer's most recent verdict was — the history is unreadable, or it predates the point where the loop began recording the evidence this feature reads.
+**Preconditions**: An external reviewer has reported blocking findings. The reviewer-loop history is readable and can be appended to, but it does not establish what the local reviewer's most recent verdict was — it predates the point where the loop began recording the evidence this feature reads, or the relevant entries are absent.
 
 **Steps**:
 
 1. The external reviewer returns a result carrying blocking findings.
-2. The loop attempts to establish the local reviewer's most recent verdict and fails.
+2. The loop reads the history successfully but finds nothing that establishes the local reviewer's most recent verdict.
 3. It writes a record whose local evidence state is `unknown`.
 
 **Postconditions**: The history records the external findings and records that the local evidence could not be established. The findings are **not** counted as missed.
@@ -143,10 +143,41 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 
 - Not counting is the conservative direction here, and it is deliberate. A miss recorded on absent evidence would overstate the local reviewer's failures, and the entire value of this record is that its numbers can be trusted.
 - `unknown` must be distinguishable from "the local reviewer ran and found nothing" and from "the record is missing". A reader who cannot tell those apart cannot use the data.
+- `unknown` describes **missing evidence inside a healthy history**. It is not the state for a history that could not be read or written at all — that case cannot produce a record of any kind, and is Use Case 5.
 
 ---
 
-### Use Case 5: A human or a later report reads the accumulated records
+### Use Case 5: The history itself cannot be read or written
+
+**Actor**: The reviewer loop.
+**Preconditions**: An external reviewer has reported blocking findings, and the reviewer-loop history surface on the pull request is unavailable — it cannot be read, it does not parse, or it cannot be appended to.
+
+**Steps**:
+
+1. The external reviewer returns a result carrying blocking findings.
+2. The loop attempts to read or append to the reviewer-loop history and fails.
+3. It writes **no** missed-finding record, and does not attempt to reconstruct or replace the history.
+4. It reports that telemetry could not be recorded for this round, and why.
+
+**Postconditions**: No record exists for this round. The existing history, whatever state it is in, is left exactly as it was. The review outcome is unchanged — the external findings are handled exactly as they are today.
+
+**Information shown**:
+
+- That missed-finding telemetry was not recorded for this round, and the reason.
+
+**Actions available**:
+
+- None from the loop. A human may repair the history surface; the loop does not.
+
+**Considerations**:
+
+- This is deliberately distinct from Use Case 4. There, the history is healthy and simply does not say what the local reviewer concluded, so an `unknown` record is both possible and useful. Here nothing can be written at all, so `unknown` is not available as an outcome — a state that describes evidence cannot be recorded when the place it would be recorded is the thing that failed.
+- The loop must not append to, rebuild, or overwrite a history it could not read. A partial or reconstructed history would silently discard prior evidence, which is worse than a gap: a gap is visible, and a rewritten history looks authoritative.
+- The omission must be visible in the round's output rather than silent. Telemetry that can disappear without anyone noticing cannot be trusted later, which is the same reason the `unknown` state exists at all.
+
+---
+
+### Use Case 6: A human or a later report reads the accumulated records
 
 **Actor**: A maintainer reading the pull request, or the reviewer-effectiveness report built on this data.
 **Preconditions**: The pull request has one or more missed-finding records in its reviewer-loop history.
@@ -200,7 +231,7 @@ recorded as `unknown`.
 | `unavailable` | Unavailable | The local reviewer was configured but could not run — a timeout, an outage, or a credentials failure. | No |
 | `not_yet_run` | Not yet run | The local reviewer is configured and has not yet produced any verdict on this pull request. | No |
 | `not_configured` | Not configured | The local reviewer is not configured for this repository, so it will never run. | No |
-| `unknown` | Unknown | The local reviewer's verdict could not be established from the available history. | No |
+| `unknown` | Unknown | The history is readable but does not establish the local reviewer's most recent verdict. | No |
 
 Exactly two of the ten states count as missed: `clean_same_commit` and
 `clean_earlier_commit`. Every other state, including `unknown` and any situation
@@ -228,6 +259,7 @@ existing or not. Rows are evaluated in order and the first match decides.
 
 | # | External result | Commit attributable | Local evidence state | Record written | Counts as missed | Next action |
 | --- | --- | --- | --- | --- | --- | --- |
+| 0 | Any — the history surface cannot be read, parsed, or appended to | — | — | No | No | Report that telemetry could not be recorded, and why; leave the existing history untouched |
 | 1 | Reported by the local reviewer itself | — | — | No | No | Nothing; a reviewer cannot miss its own findings |
 | 2 | No blocking findings — clean, skipped, or advisory only | — | — | No | No | Nothing; only blocking external findings qualify |
 | 3 | Blocking findings | **No** | — | No | No | Report why the commit could not be established; write no unattributable record |
@@ -239,6 +271,12 @@ existing or not. Rows are evaluated in order and the first match decides.
 Rows 4 through 7 are the reason a record is written on every qualifying external
 round rather than only on confirmed misses: rows 6 and 7 are the denominator,
 and a rate needs both halves.
+
+Row 0 is evaluated first and is the only row that can produce no record while an
+external reviewer reported blocking findings on an establishable commit. It is
+separated from row 7 deliberately: row 7 records `unknown` because the history
+is healthy and silent about the local verdict, whereas row 0 cannot record
+anything because the history is the thing that failed.
 
 ---
 
@@ -258,7 +296,8 @@ and a rate needs both halves.
 - [ ] **AC-4.** When the local reviewer's most recent clean verdict was on a commit with no ancestry relationship to the one the external reviewer reviewed, the state is `clean_unrelated_commit` and it does not count as missed.
 - [ ] **AC-5.** When the local reviewer's most recent verdict reported findings, the record is still written and its local evidence state is `not_clean`, and it does not count as missed.
 - [ ] **AC-6.** When the local reviewer was skipped, was unavailable, is configured but has not yet produced a verdict, or is not configured at all, the record is written with the corresponding state, the four are distinguishable from one another and from `not_clean`, **and none of the four counts as missed**.
-- [ ] **AC-7.** When the local reviewer's verdict cannot be established from the history, the record is written with state `unknown` and does not count as missed.
+- [ ] **AC-7.** When the history is readable but does not establish the local reviewer's most recent verdict, the record is written with state `unknown` and does not count as missed.
+- [ ] **AC-7a.** When the reviewer-loop history cannot be read, parsed, or appended to, no missed-finding record is written, the existing history is left byte-for-byte unchanged, and the round's output states that telemetry could not be recorded and why.
 - [ ] **AC-8.** Advisory or suggestion-level external findings produce no missed-finding record.
 - [ ] **AC-9.** Findings reported by the local reviewer itself produce no missed-finding record.
 - [ ] **AC-10.** Two qualifying external rounds on the same pull request produce two records; neither replaces the other.

--- a/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
+++ b/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
@@ -1,0 +1,187 @@
+# Missed-Finding Telemetry — Spec
+
+**Depends on**: 1648-reviewer-loop-current-head-evidence
+
+---
+
+## Overview
+
+The reviewer loop runs a cheap local reviewer before it runs slow external ones, on the premise that front-loading findings costs fewer review rounds. Nobody can currently say whether that premise holds. The loop records that each reviewer ran and what it concluded, but not the one thing that would settle the question: how often an external reviewer finds something blocking on a pull request the local reviewer had already called clean.
+
+This feature records exactly that. When an external reviewer reports blocking findings on a pull request where the local reviewer had previously reported clean, the loop writes a compact record of the miss into the pull request's reviewer-loop history — which reviewer found it, on which commit, how many findings and where, and what the local reviewer's verdict had been at the time. The record is deliberately conservative: it claims a miss only when the local reviewer demonstrably said clean, and says so plainly when the evidence is too weak to make the claim. Its purpose is measurement, and a measurement that inflates its own numbers is worthless.
+
+---
+
+## Use Cases
+
+### Use Case 1: An external reviewer finds something the local reviewer cleared
+
+**Actor**: The reviewer loop, running on behalf of the agent or maintainer advancing a pull request.
+**Preconditions**: The pull request has an existing reviewer-loop history. The local reviewer ran earlier in the pull request's life and reported clean. An external reviewer — any configured reviewer other than the local one — has now reported at least one blocking finding.
+
+**Steps**:
+
+1. The external reviewer returns a result carrying blocking findings.
+2. The loop looks back at the local reviewer's most recent verdict for this pull request.
+3. It establishes whether that verdict was clean, and whether it described the same commit the external reviewer just reviewed or an earlier one.
+4. It writes a missed-finding record into the pull request's reviewer-loop history.
+5. It shows the record in the reviewer-loop summary on the pull request.
+
+**Postconditions**: The pull request carries a durable, machine-readable record of the miss alongside the history the loop already keeps. Nothing about the review outcome changes — the findings are handled exactly as they are today, and the record neither blocks nor unblocks anything.
+
+**Information shown**:
+
+- Which external reviewer reported the findings.
+- The commit it reviewed.
+- How many blocking findings it reported, and which files they touched.
+- What the local reviewer's verdict had been, and whether it covered the same commit or an earlier one.
+
+**Actions available**:
+
+- None. The record is evidence, not a prompt. A human reading it may choose to act on the pattern it reveals, but the loop asks nothing of them.
+
+**Considerations**:
+
+- A pull request can accumulate several missed-finding records, one per external reviewer round that qualifies. They accumulate rather than overwrite, because the shape of the sequence is itself the signal.
+- The record must survive the pull request being re-reviewed, force-pushed, or converted between draft and ready, since the history it lives in already does.
+
+---
+
+### Use Case 2: An external reviewer finds something, but the local reviewer never cleared it
+
+**Actor**: The reviewer loop.
+**Preconditions**: An external reviewer has reported blocking findings, and the local reviewer's most recent verdict for this pull request was anything other than clean — it reported findings, was skipped, was unavailable, or never ran at all.
+
+**Steps**:
+
+1. The external reviewer returns a result carrying blocking findings.
+2. The loop looks back at the local reviewer's most recent verdict.
+3. It finds no clean verdict to have been missed against.
+4. It writes a record that names what the local evidence actually was, and does not count the findings as missed.
+
+**Postconditions**: The history records that an external reviewer found something and that no local clean verdict preceded it. The effectiveness numbers are unaffected.
+
+**Information shown**:
+
+- The same reviewer, commit, count and paths as Use Case 1.
+- The local evidence state, stated explicitly rather than left blank — the local reviewer reported findings, was skipped, was unavailable, or never ran.
+
+**Considerations**:
+
+- This is the common case early in a pull request's life, and it must not be mistaken for a miss. A reviewer that never claimed the code was clean cannot have missed anything.
+- The distinction matters most when the local reviewer was *unavailable*. An unavailable reviewer looks superficially like a reviewer that found nothing, and conflating the two would make an outage read as a quality failure.
+
+---
+
+### Use Case 3: The local evidence cannot be established
+
+**Actor**: The reviewer loop.
+**Preconditions**: An external reviewer has reported blocking findings, and the loop cannot determine what the local reviewer's most recent verdict was — the history is unreadable, or it predates the point where the loop began recording the evidence this feature reads.
+
+**Steps**:
+
+1. The external reviewer returns a result carrying blocking findings.
+2. The loop attempts to establish the local reviewer's most recent verdict and fails.
+3. It writes a record whose local evidence state is `unknown`.
+
+**Postconditions**: The history records the external findings and records that the local evidence could not be established. The findings are **not** counted as missed.
+
+**Information shown**:
+
+- The reviewer, commit, count and paths.
+- An explicit `unknown` local evidence state, distinguishable from every state in which the evidence *was* established.
+
+**Considerations**:
+
+- Not counting is the conservative direction here, and it is deliberate. A miss recorded on absent evidence would overstate the local reviewer's failures, and the entire value of this record is that its numbers can be trusted.
+- `unknown` must be distinguishable from "the local reviewer ran and found nothing" and from "the record is missing". A reader who cannot tell those apart cannot use the data.
+
+---
+
+### Use Case 4: A human or a later report reads the accumulated records
+
+**Actor**: A maintainer reading the pull request, or the reviewer-effectiveness report built on this data.
+**Preconditions**: The pull request has one or more missed-finding records in its reviewer-loop history.
+
+**Steps**:
+
+1. The reader opens the reviewer-loop summary on the pull request, or a later report reads the history directly.
+2. They see each qualifying external round, its local evidence state, and its finding count and paths.
+
+**Postconditions**: The reader can tell, for this pull request, how many times an external reviewer found something after the local reviewer said clean, and on which commits.
+
+**Information shown**:
+
+- One line per missed-finding record in the summary, compact enough to read without expanding anything.
+- The full structured record in the history, for a report to consume.
+
+**Considerations**:
+
+- The summary comment already carries the reviewer-loop history and is close to the length a human will read. The missed-finding lines must not push it past that, which is why the record is per-round rather than per-finding.
+
+---
+
+## Business Rules
+
+- A finding counts as **missed by the local reviewer** only when the local reviewer's most recent verdict for the pull request was explicitly clean. Every other state — findings reported, skipped, unavailable, never ran, unknown — does not count. The counting rule enumerates the states that *do* count rather than the states that do not, so a state introduced later is excluded until someone deliberately includes it.
+- The local evidence state is recorded on every external round that reports blocking findings, whether or not it counts as a miss. A record that only appeared for confirmed misses would make the denominator unknowable, and a rate needs both halves.
+- A clean local verdict on the **same commit** the external reviewer reviewed, and a clean local verdict on an **earlier commit**, are recorded as distinct states and are never merged into one. An earlier-commit clean is weaker evidence: the external reviewer may be reporting on code the local reviewer never saw.
+- Only **blocking** external findings qualify. Advisory or suggestion-level findings do not create a record, because the local reviewer is not expected to surface them and counting them would inflate the miss rate.
+- The **local** reviewer's own findings never create a missed-finding record. The record exists to compare an external reviewer against the local one; a reviewer cannot miss its own findings.
+- Records accumulate; they are never overwritten or de-duplicated. Two external rounds finding the same thing on the same commit are two records, because the loop genuinely ran twice.
+- No missed-finding record changes any review outcome, readiness label, tracker status, or merge decision. This feature only observes.
+- Every record is attributable to a specific commit. A record that cannot name the commit the external reviewer reviewed is not written, and the loop reports why rather than writing an unattributable record.
+
+---
+
+## Statuses / Enum Values
+
+The **local evidence state** recorded on each external round that reports blocking findings:
+
+| Code value | Display label | Description | Counts as missed |
+| --- | --- | --- | --- |
+| `clean_same_commit` | Clean, same commit | The local reviewer reported clean on the exact commit the external reviewer reviewed. | Yes |
+| `clean_earlier_commit` | Clean, earlier commit | The local reviewer reported clean on a commit earlier than the one the external reviewer reviewed. | Yes |
+| `not_clean` | Reported findings | The local reviewer's most recent verdict reported findings of its own. | No |
+| `skipped` | Skipped | The local reviewer was configured but deliberately skipped this round. | No |
+| `unavailable` | Unavailable | The local reviewer was configured but could not run — a timeout, an outage, or a credentials failure. | No |
+| `did_not_run` | Did not run | The local reviewer is not configured for this repository, so it never ran. | No |
+| `unknown` | Unknown | The local reviewer's verdict could not be established from the available history. | No |
+
+Exactly two of the seven states count as missed. Any state not in this table is treated as `unknown` and does not count.
+
+**Valid transitions**: none. The state is decided once, when the record is written, and describes the evidence at that moment. It is never revised — a later local run does not rewrite an earlier record, because the record is a historical observation rather than a current status.
+
+---
+
+## Operational Visibility
+
+- **Reviewer-loop summary**: each missed-finding record appears as one line in the pull request's reviewer-loop summary, naming the external reviewer, the commit, the finding count, and the local evidence state.
+- **Reviewer-loop history**: the full structured record is written into the history the loop already maintains on the pull request, in the same place and with the same lifecycle as the entries already there.
+- **Audit trail**: no separate audit surface is introduced. The pull request is the record, deliberately — telemetry stored somewhere a reviewer never looks does not get checked against reality.
+
+---
+
+## Acceptance Criteria
+
+- [ ] When an external reviewer reports blocking findings on a commit for which the local reviewer's most recent verdict was clean on that same commit, the reviewer-loop history gains a record naming that reviewer, that commit, the number of blocking findings, the files they touch, and the local evidence state `clean_same_commit`.
+- [ ] When the local reviewer's most recent clean verdict was on an earlier commit than the one the external reviewer reviewed, the record's local evidence state is `clean_earlier_commit`, and it is distinguishable from `clean_same_commit` without inspecting commits by hand.
+- [ ] When the local reviewer's most recent verdict reported findings, the record is still written and its local evidence state is `not_clean`, and it does not count as missed.
+- [ ] When the local reviewer was skipped, was unavailable, or is not configured, the record is written with the corresponding state, and the three are distinguishable from one another and from `not_clean`.
+- [ ] When the local reviewer's verdict cannot be established from the history, the record is written with state `unknown` and does not count as missed.
+- [ ] Advisory or suggestion-level external findings produce no missed-finding record.
+- [ ] Findings reported by the local reviewer itself produce no missed-finding record.
+- [ ] Two qualifying external rounds on the same pull request produce two records; neither replaces the other.
+- [ ] When the commit an external reviewer reviewed cannot be established, no record is written and the loop reports the reason.
+- [ ] A pull request carrying missed-finding records reaches exactly the same review outcome, readiness label, and tracker status it would reach without them.
+- [ ] Each record adds no more than one line to the reviewer-loop summary, and a pull request carrying ten records still produces a summary a reader can read without expanding a collapsed section.
+- [ ] The records for a pull request can be read back in full by a later report without re-running any reviewer.
+
+---
+
+## Out of Scope (MVP)
+
+- **Reporting or aggregating across pull requests.** This feature produces the per-pull-request record; turning it into an effectiveness report, per pull request or across a window, is item #1657. Deferral note: the brief's "support later effectiveness reporting" objective is met here by producing a readable, complete record, not by producing the report itself. No human confirmation requested — the split follows the epic's own decomposition.
+- **Attributing a miss to a cause.** The record says the local reviewer cleared a commit on which an external reviewer later found something. It does not say why — whether the finding was outside the local reviewer's checklist, beyond its context window, or a genuine oversight. Deferral note: cause attribution needs the doctrine work in #1654 to have landed first, and guessing at causes would pollute the measurement this item exists to make trustworthy. No human confirmation requested.
+- **Acting on the records.** Nothing in this feature changes a gate, a threshold, or a reviewer's configuration in response to what is recorded. Deferral note: measurement first, response second; a control loop built on unvalidated telemetry is worse than none. No human confirmation requested.
+- **Recording near-misses.** An external reviewer that reports advisory findings after a local clean verdict is not recorded. Deferral note: the brief scopes this to blockers, and advisory findings are not something the local reviewer is expected to surface. No human confirmation requested.

--- a/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
+++ b/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
@@ -203,7 +203,7 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 ## Business Rules
 
 - A finding counts as **missed by the local reviewer** only when the local reviewer's most recent verdict was clean **and** covered the commit the external reviewer reviewed or one of its ancestors — states `clean_same_commit` and `clean_earlier_commit`. Every other state does not count. The counting rule enumerates the states that *do* count rather than the states that do not, so a state introduced later is excluded until someone deliberately includes it.
-- The local evidence state is recorded on every external round that reports blocking findings **and whose reviewed commit can be established**, whether or not it counts as a miss. A record that only appeared for confirmed misses would make the denominator unknowable, and a rate needs both halves. The single exception is the unattributable-commit case below, which produces no record at all — a record that cannot name the commit it describes would corrupt the denominator rather than complete it.
+- The local evidence state is recorded on every external round that reports blocking findings **and whose reviewed commit can be established**, whether or not it counts as a miss. A record that only appeared for confirmed misses would make the denominator unknowable, and a rate needs both halves. Two cases are exceptions and produce no record at all. First, an unattributable commit: a record that cannot name the commit it describes would corrupt the denominator rather than complete it. Second, a history that cannot be read, parsed, or appended to: there is nowhere to write the record, and the loop must not reconstruct or overwrite the history to make room for one. Both are enumerated here and in the Decision Matrix, and there are no others.
 - A clean local verdict is classified by its ancestry relationship to the commit the external reviewer reviewed — same, ancestor, descendant, or unrelated — and the four are recorded as distinct states that are never merged. Only same and ancestor count. A descendant clean means the local reviewer cleared newer code than the external reviewer looked at, and an unrelated clean means a force-push severed the relationship; neither is evidence that the local reviewer saw what was found.
 - A local reviewer that is **configured but has not yet produced a verdict** is recorded distinctly from one that is **not configured at all**. The first describes a pull request early in its life, the second a repository that will never produce local evidence, and summing them would make the two indistinguishable in the numbers.
 - Only **blocking** external findings qualify. Advisory or suggestion-level findings do not create a record, because the local reviewer is not expected to surface them and counting them would inflate the miss rate.
@@ -257,26 +257,29 @@ historical observation rather than a current status.
 The complete gate, from an external reviewer returning a result to a record
 existing or not. Rows are evaluated in order and the first match decides.
 
-| # | External result | Commit attributable | Local evidence state | Record written | Counts as missed | Next action |
-| --- | --- | --- | --- | --- | --- | --- |
-| 0 | Any — the history surface cannot be read, parsed, or appended to | — | — | No | No | Report that telemetry could not be recorded, and why; leave the existing history untouched |
-| 1 | Reported by the local reviewer itself | — | — | No | No | Nothing; a reviewer cannot miss its own findings |
-| 2 | No blocking findings — clean, skipped, or advisory only | — | — | No | No | Nothing; only blocking external findings qualify |
-| 3 | Blocking findings | **No** | — | No | No | Report why the commit could not be established; write no unattributable record |
-| 4 | Blocking findings | Yes | `clean_same_commit` | Yes | **Yes** | Show in the summary; include in the effectiveness numbers |
-| 5 | Blocking findings | Yes | `clean_earlier_commit` | Yes | **Yes** | Show in the summary; include in the effectiveness numbers |
-| 6 | Blocking findings | Yes | Any other state in the Statuses table | Yes | No | Show in the summary; include in the denominator only |
-| 7 | Blocking findings | Yes | Not describable by any row of the Statuses table | Yes, as `unknown` | No | Show in the summary; include in the denominator only |
+| # | External result | Commit attributable | History writable | Local evidence state | Record written | Counts as missed | Next action |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Reported by the local reviewer itself | — | — | — | No | No | Nothing; a reviewer cannot miss its own findings |
+| 2 | No blocking findings — clean, skipped, or advisory only | — | — | — | No | No | Nothing; only blocking external findings qualify |
+| 3 | Blocking findings | **No** | — | — | No | No | Report why the commit could not be established; write no unattributable record |
+| 4 | Blocking findings | Yes | **No** | — | No | No | Report that telemetry could not be recorded, and why; leave the existing history untouched and attempt no reconstruction |
+| 5 | Blocking findings | Yes | Yes | `clean_same_commit` | Yes | **Yes** | Show in the summary; include in the effectiveness numbers |
+| 6 | Blocking findings | Yes | Yes | `clean_earlier_commit` | Yes | **Yes** | Show in the summary; include in the effectiveness numbers |
+| 7 | Blocking findings | Yes | Yes | Any other state in the Statuses table | Yes | No | Show in the summary; include in the denominator only |
+| 8 | Blocking findings | Yes | Yes | Not describable by any row of the Statuses table | Yes, as `unknown` | No | Show in the summary; include in the denominator only |
 
-Rows 4 through 7 are the reason a record is written on every qualifying external
-round rather than only on confirmed misses: rows 6 and 7 are the denominator,
+Rows 5 through 8 are the reason a record is written on every qualifying external
+round rather than only on confirmed misses: rows 7 and 8 are the denominator,
 and a rate needs both halves.
 
-Row 0 is evaluated first and is the only row that can produce no record while an
-external reviewer reported blocking findings on an establishable commit. It is
-separated from row 7 deliberately: row 7 records `unknown` because the history
-is healthy and silent about the local verdict, whereas row 0 cannot record
-anything because the history is the thing that failed.
+The ordering matters. History writability is checked at row 4 — **after**
+eligibility and commit attribution, not before. A round that was never going to
+produce a record, because the findings came from the local reviewer or were
+advisory, must not report a telemetry failure just because the history happens
+to be unwritable; nothing was owed. Row 4 is also distinct from row 8: row 8
+records `unknown` because the history is healthy and silent about the local
+verdict, whereas row 4 cannot record anything because the history is the thing
+that failed.
 
 ---
 

--- a/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
+++ b/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
@@ -38,7 +38,7 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 ### Use Case 1: An external reviewer finds something the local reviewer cleared
 
 **Actor**: The reviewer loop, running on behalf of the agent or maintainer advancing a pull request.
-**Preconditions**: The pull request has an existing reviewer-loop history. The local reviewer ran earlier in the pull request's life and reported clean. An external reviewer — any configured reviewer other than the local one — has now reported at least one blocking finding.
+**Preconditions**: The pull request has an existing reviewer-loop history. The local reviewer's **most recent** verdict on this pull request is clean. An external reviewer — any configured reviewer other than the local one — has now reported at least one blocking finding.
 
 **Steps**:
 
@@ -205,7 +205,8 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 
 - A finding counts as **missed by the local reviewer** only when the local reviewer's most recent verdict was clean **and** covered the commit the external reviewer reviewed or one of its ancestors — states `clean_same_commit` and `clean_earlier_commit`. Every other state does not count. The counting rule enumerates the states that *do* count rather than the states that do not, so a state introduced later is excluded until someone deliberately includes it.
 - The local evidence state is recorded on every external round that reports blocking findings **and whose reviewed commit can be established**, whether or not it counts as a miss. A record that only appeared for confirmed misses would make the denominator unknowable, and a rate needs both halves. Two cases are exceptions and produce no record at all. First, an unattributable commit: a record that cannot name the commit it describes would corrupt the denominator rather than complete it. Second, a history that cannot be read, parsed, or appended to: there is nowhere to write the record, and the loop must not reconstruct or overwrite the history to make room for one. Both are enumerated here and in the Decision Matrix, and there are no others.
-- A clean local verdict is classified by its ancestry relationship to the commit the external reviewer reviewed — same, ancestor, descendant, or unrelated — and the four are recorded as distinct states that are never merged. Only same and ancestor count. A descendant clean means the local reviewer cleared newer code than the external reviewer looked at, and an unrelated clean means a force-push severed the relationship; neither is evidence that the local reviewer saw what was found.
+- The state is always derived from the local reviewer's **most recent verdict**, never from its most recent *clean* verdict. Selection happens first, classification second.
+- When that most recent verdict is clean, it is classified by its commit's ancestry relationship to the commit the external reviewer reviewed — same, ancestor, descendant, or unrelated — and the four are recorded as distinct states that are never merged. Only same and ancestor count. A descendant clean means the local reviewer cleared newer code than the external reviewer looked at, and an unrelated clean means a force-push severed the relationship; neither is evidence that the local reviewer saw what was found.
 - A local reviewer that is **configured but has not yet produced a verdict** is recorded distinctly from one that is **not configured at all**. The first describes a pull request early in its life, the second a repository that will never produce local evidence, and summing them would make the two indistinguishable in the numbers.
 - Only **blocking** external findings qualify. Advisory or suggestion-level findings do not create a record, because the local reviewer is not expected to surface them and counting them would inflate the miss rate.
 - The **local** reviewer's own findings never create a missed-finding record. The record exists to compare an external reviewer against the local one; a reviewer cannot miss its own findings.
@@ -218,15 +219,27 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 ## Statuses / Enum Values
 
 The **local evidence state** recorded on each external round that reports
-blocking findings. The list is closed: any situation not described by a row is
-recorded as `unknown`.
+blocking findings.
+
+**One verdict is selected, then classified.** The state is derived from the
+local reviewer's **most recent verdict** on the pull request — not from its most
+recent *clean* verdict. If that most recent verdict is clean, its commit's
+ancestry relationship to the one the external reviewer reviewed selects among
+the four clean states. If it is anything else, that verdict's own outcome
+selects the state, and no earlier clean verdict is consulted. A local reviewer
+that cleared one commit and then reported findings on a later one is
+`not_clean`; reaching past that to the earlier clean verdict would count a round
+as missed on a verdict the reviewer itself had already superseded.
+
+The list is closed: any situation not described by a row is recorded as
+`unknown`.
 
 | Code value | Display label | Description | Counts as missed |
 | --- | --- | --- | --- |
 | `clean_same_commit` | Clean, same commit | The local reviewer reported clean on the exact commit the external reviewer reviewed. | Yes |
-| `clean_earlier_commit` | Clean, earlier commit | The local reviewer's most recent clean verdict was on an ancestor of the commit the external reviewer reviewed. | Yes |
-| `clean_later_commit` | Clean, later commit | The local reviewer's most recent clean verdict was on a descendant of the commit the external reviewer reviewed — it cleared newer code than the external reviewer looked at. | No |
-| `clean_unrelated_commit` | Clean, unrelated commit | The local reviewer's most recent clean verdict was on a commit with no ancestry relationship to the one the external reviewer reviewed, which a force-push can produce. | No |
+| `clean_earlier_commit` | Clean, earlier commit | The local reviewer's most recent verdict was clean, on an ancestor of the commit the external reviewer reviewed. | Yes |
+| `clean_later_commit` | Clean, later commit | The local reviewer's most recent verdict was clean, on a descendant of the commit the external reviewer reviewed — it cleared newer code than the external reviewer looked at. | No |
+| `clean_unrelated_commit` | Clean, unrelated commit | The local reviewer's most recent verdict was clean, on a commit with no ancestry relationship to the one the external reviewer reviewed, which a force-push can produce. | No |
 | `not_clean` | Reported findings | The local reviewer's most recent verdict reported findings of its own. | No |
 | `skipped` | Skipped | The local reviewer was configured and deliberately skipped this round. | No |
 | `unavailable` | Unavailable | The local reviewer was configured but could not run — a timeout, an outage, or a credentials failure. | No |
@@ -295,9 +308,10 @@ that failed.
 ## Acceptance Criteria
 
 - [ ] **AC-1.** When an external reviewer reports blocking findings on a commit for which the local reviewer's most recent verdict was clean on that same commit, the reviewer-loop history gains a record naming that reviewer, that commit, the number of blocking findings, the files they touch, and the local evidence state `clean_same_commit`, **and that record counts as missed**.
-- [ ] **AC-2.** When the local reviewer's most recent clean verdict was on an ancestor of the commit the external reviewer reviewed, the record's local evidence state is `clean_earlier_commit`, it is distinguishable from `clean_same_commit` without inspecting commits by hand, **and it counts as missed**.
-- [ ] **AC-3.** When the local reviewer's most recent clean verdict was on a descendant of the commit the external reviewer reviewed, the state is `clean_later_commit` and it does not count as missed.
-- [ ] **AC-4.** When the local reviewer's most recent clean verdict was on a commit with no ancestry relationship to the one the external reviewer reviewed, the state is `clean_unrelated_commit` and it does not count as missed.
+- [ ] **AC-2.** When the local reviewer's most recent verdict was clean and on an ancestor of the commit the external reviewer reviewed, the record's local evidence state is `clean_earlier_commit`, it is distinguishable from `clean_same_commit` without inspecting commits by hand, **and it counts as missed**.
+- [ ] **AC-3.** When the local reviewer's most recent verdict was clean and on a descendant of the commit the external reviewer reviewed, the state is `clean_later_commit` and it does not count as missed.
+- [ ] **AC-4.** When the local reviewer's most recent verdict was clean and on a commit with no ancestry relationship to the one the external reviewer reviewed, the state is `clean_unrelated_commit` and it does not count as missed.
+- [ ] **AC-4a.** When the local reviewer cleared one commit and then reported findings on a later commit, the state is `not_clean` and does not count as missed, even though an earlier clean verdict on an ancestor exists. The most recent verdict is the only one consulted.
 - [ ] **AC-5.** When the local reviewer's most recent verdict reported findings, the record is still written and its local evidence state is `not_clean`, and it does not count as missed.
 - [ ] **AC-6.** When the local reviewer was skipped, was unavailable, is configured but has not yet produced a verdict, or is not configured at all, the record is written with the corresponding state, the four are distinguishable from one another and from `not_clean`, **and none of the four counts as missed**.
 - [ ] **AC-7.** When the history is readable but does not establish the local reviewer's most recent verdict, the record is written with state `unknown` and does not count as missed.

--- a/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
+++ b/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
@@ -21,7 +21,7 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 
 | # | Objective (from #1651) | Where it is satisfied |
 | --- | --- | --- |
-| 1 | *Problem* — quantify whether the local reviewer reduces external rounds, by tracking what external reviewers found after a local clean result | Use Cases 1-6; the counting rule and the record-every-qualifying-round rule in Business Rules; the Decision Matrix rows 4-7; AC-1 through AC-7 |
+| 1 | *Problem* — quantify whether the local reviewer reduces external rounds, by tracking what external reviewers found after a local clean result | Use Cases 1-6; the counting rule and the record-every-qualifying-round rule in Business Rules; the Decision Matrix rows 5-8; AC-1 through AC-7 and AC-7a |
 | 2 | *Outcome* — the reviewer-loop history records missed-by-local findings when an external reviewer reports blockers after a local clean result | Use Case 1; AC-1 through AC-3; Operational Visibility, reviewer-loop history |
 | 3 | *Scope* — capture the reviewer | AC-1; Use Case 1, Information shown |
 | 4 | *Scope* — capture the head commit | AC-1; the attribution rule in Business Rules; AC-11 for the case where it cannot be established |

--- a/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
+++ b/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
@@ -21,14 +21,14 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 
 | # | Objective (from #1651) | Where it is satisfied |
 | --- | --- | --- |
-| 1 | *Problem* — quantify whether the local reviewer reduces external rounds, by tracking what external reviewers found after a local clean result | Use Cases 1-4; the counting rule and the record-every-qualifying-round rule in Business Rules; the Decision Matrix rows 4-7; AC-1 through AC-7 |
+| 1 | *Problem* — quantify whether the local reviewer reduces external rounds, by tracking what external reviewers found after a local clean result | Use Cases 1-5; the counting rule and the record-every-qualifying-round rule in Business Rules; the Decision Matrix rows 4-7; AC-1 through AC-7 |
 | 2 | *Outcome* — the reviewer-loop history records missed-by-local findings when an external reviewer reports blockers after a local clean result | Use Case 1; AC-1 through AC-3; Operational Visibility, reviewer-loop history |
 | 3 | *Scope* — capture the reviewer | AC-1; Use Case 1, Information shown |
 | 4 | *Scope* — capture the head commit | AC-1; the attribution rule in Business Rules; AC-11 for the case where it cannot be established |
 | 5 | *Scope* — capture the finding count | AC-1 |
 | 6 | *Scope* — capture the paths | AC-1; AC-14 bounds how many are shown |
-| 7 | *Scope* — capture whether the local reviewer was clean on the same head or an ancestor | AC-1 through AC-4; the four clean-ancestry states, which Business Rules forbid merging |
-| 8 | *Scope* — keep the record compact enough for PR comments | AC-13 through AC-15, with character and path bounds rather than an adjective; Use Case 4, Considerations |
+| 7 | *Scope* — capture whether the local reviewer was clean on the same head or an ancestor | AC-1 through AC-4 and AC-17; Use Case 3; the four clean-verdict states — same, ancestor, descendant, and unrelated — which Business Rules forbid merging |
+| 8 | *Scope* — keep the record compact enough for PR comments | AC-13, AC-14, AC-14a and AC-15, with character and path bounds rather than an adjective, and an explicit precedence rule between them; Use Case 5, Considerations |
 | 9 | *Scope* — support later effectiveness reporting | AC-16 (records readable in full without re-running a reviewer); the report itself is **deferred** to Out of Scope item 1 (#1657) |
 
 ---
@@ -94,7 +94,34 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 
 ---
 
-### Use Case 3: The local evidence cannot be established
+### Use Case 3: The local reviewer was clean, but not on the code that was reviewed
+
+**Actor**: The reviewer loop.
+**Preconditions**: An external reviewer has reported blocking findings, and the local reviewer's most recent verdict was clean — but on a commit that is a descendant of, or has no ancestry relationship to, the commit the external reviewer reviewed.
+
+**Steps**:
+
+1. The external reviewer returns a result carrying blocking findings.
+2. The loop looks back at the local reviewer's most recent verdict and finds it clean.
+3. It compares that verdict's commit with the one the external reviewer reviewed, and finds the local verdict describes newer code, or code on a different line of history.
+4. It writes a record naming the relationship, and does not count the findings as missed.
+
+**Postconditions**: The history records that an external reviewer found something and that the local clean verdict did not cover the reviewed code. The effectiveness numbers are unaffected.
+
+**Information shown**:
+
+- The same reviewer, commit, count and paths as Use Case 1.
+- The relationship between the two commits, stated as `clean_later_commit` or `clean_unrelated_commit` rather than collapsed into a generic "clean".
+
+**Considerations**:
+
+- The descendant case is ordinary: the local reviewer runs on each new push, so it routinely holds a clean verdict on newer code than a slower external reviewer is still reporting on. Counting it would attribute a miss to a reviewer that never saw the code in question.
+- The unrelated case arises after a force-push rewrites history. It is rarer, and it is separated rather than folded into the descendant case because the two say different things about what happened to the branch.
+- Both states are recorded rather than skipped, because they belong in the denominator. A pull request where the local reviewer is simply running ahead of the external one is not evidence of a miss, but it is evidence the loop ran.
+
+---
+
+### Use Case 4: The local evidence cannot be established
 
 **Actor**: The reviewer loop.
 **Preconditions**: An external reviewer has reported blocking findings, and the loop cannot determine what the local reviewer's most recent verdict was — the history is unreadable, or it predates the point where the loop began recording the evidence this feature reads.
@@ -119,7 +146,7 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 
 ---
 
-### Use Case 4: A human or a later report reads the accumulated records
+### Use Case 5: A human or a later report reads the accumulated records
 
 **Actor**: A maintainer reading the pull request, or the reviewer-effectiveness report built on this data.
 **Preconditions**: The pull request has one or more missed-finding records in its reviewer-loop history.
@@ -145,7 +172,7 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 ## Business Rules
 
 - A finding counts as **missed by the local reviewer** only when the local reviewer's most recent verdict was clean **and** covered the commit the external reviewer reviewed or one of its ancestors — states `clean_same_commit` and `clean_earlier_commit`. Every other state does not count. The counting rule enumerates the states that *do* count rather than the states that do not, so a state introduced later is excluded until someone deliberately includes it.
-- The local evidence state is recorded on every external round that reports blocking findings, whether or not it counts as a miss. A record that only appeared for confirmed misses would make the denominator unknowable, and a rate needs both halves.
+- The local evidence state is recorded on every external round that reports blocking findings **and whose reviewed commit can be established**, whether or not it counts as a miss. A record that only appeared for confirmed misses would make the denominator unknowable, and a rate needs both halves. The single exception is the unattributable-commit case below, which produces no record at all — a record that cannot name the commit it describes would corrupt the denominator rather than complete it.
 - A clean local verdict is classified by its ancestry relationship to the commit the external reviewer reviewed — same, ancestor, descendant, or unrelated — and the four are recorded as distinct states that are never merged. Only same and ancestor count. A descendant clean means the local reviewer cleared newer code than the external reviewer looked at, and an unrelated clean means a force-push severed the relationship; neither is evidence that the local reviewer saw what was found.
 - A local reviewer that is **configured but has not yet produced a verdict** is recorded distinctly from one that is **not configured at all**. The first describes a pull request early in its life, the second a repository that will never produce local evidence, and summing them would make the two indistinguishable in the numbers.
 - Only **blocking** external findings qualify. Advisory or suggestion-level findings do not create a record, because the local reviewer is not expected to surface them and counting them would inflate the miss rate.
@@ -225,12 +252,12 @@ and a rate needs both halves.
 
 ## Acceptance Criteria
 
-- [ ] **AC-1.** When an external reviewer reports blocking findings on a commit for which the local reviewer's most recent verdict was clean on that same commit, the reviewer-loop history gains a record naming that reviewer, that commit, the number of blocking findings, the files they touch, and the local evidence state `clean_same_commit`.
-- [ ] **AC-2.** When the local reviewer's most recent clean verdict was on an ancestor of the commit the external reviewer reviewed, the record's local evidence state is `clean_earlier_commit`, and it is distinguishable from `clean_same_commit` without inspecting commits by hand.
+- [ ] **AC-1.** When an external reviewer reports blocking findings on a commit for which the local reviewer's most recent verdict was clean on that same commit, the reviewer-loop history gains a record naming that reviewer, that commit, the number of blocking findings, the files they touch, and the local evidence state `clean_same_commit`, **and that record counts as missed**.
+- [ ] **AC-2.** When the local reviewer's most recent clean verdict was on an ancestor of the commit the external reviewer reviewed, the record's local evidence state is `clean_earlier_commit`, it is distinguishable from `clean_same_commit` without inspecting commits by hand, **and it counts as missed**.
 - [ ] **AC-3.** When the local reviewer's most recent clean verdict was on a descendant of the commit the external reviewer reviewed, the state is `clean_later_commit` and it does not count as missed.
 - [ ] **AC-4.** When the local reviewer's most recent clean verdict was on a commit with no ancestry relationship to the one the external reviewer reviewed, the state is `clean_unrelated_commit` and it does not count as missed.
 - [ ] **AC-5.** When the local reviewer's most recent verdict reported findings, the record is still written and its local evidence state is `not_clean`, and it does not count as missed.
-- [ ] **AC-6.** When the local reviewer was skipped, was unavailable, is configured but has not yet produced a verdict, or is not configured at all, the record is written with the corresponding state, and the four are distinguishable from one another and from `not_clean`.
+- [ ] **AC-6.** When the local reviewer was skipped, was unavailable, is configured but has not yet produced a verdict, or is not configured at all, the record is written with the corresponding state, the four are distinguishable from one another and from `not_clean`, **and none of the four counts as missed**.
 - [ ] **AC-7.** When the local reviewer's verdict cannot be established from the history, the record is written with state `unknown` and does not count as missed.
 - [ ] **AC-8.** Advisory or suggestion-level external findings produce no missed-finding record.
 - [ ] **AC-9.** Findings reported by the local reviewer itself produce no missed-finding record.
@@ -238,9 +265,11 @@ and a rate needs both halves.
 - [ ] **AC-11.** When the commit an external reviewer reviewed cannot be established, no record is written and the loop reports the reason.
 - [ ] **AC-12.** A pull request carrying missed-finding records reaches exactly the same review outcome, readiness label, and tracker status it would reach without them.
 - [ ] **AC-13.** Each record adds exactly one line to the reviewer-loop summary, and that line is at most 200 characters.
-- [ ] **AC-14.** A record's summary line names at most three file paths; when the findings touch more than three files, the line names three and states how many more there are.
+- [ ] **AC-14.** A record's summary line names **at most three** file paths and **always states the total number of files** the findings touch. When the findings touch more than the number of paths named, the line says how many more there are.
+- [ ] **AC-14a.** The 200-character bound in AC-13 takes precedence over the path count in AC-14. When naming three paths would exceed it, the line names as many as fit — down to none — and the total file count is still stated. A line that reaches the bound with zero paths named is a valid line, not a failure.
 - [ ] **AC-15.** A pull request carrying twenty records adds at most twenty lines and 4,000 characters to the reviewer-loop summary, whatever the number of findings or the length of their paths.
 - [ ] **AC-16.** The records for a pull request can be read back in full by a later report without re-running any reviewer.
+- [ ] **AC-17.** Exactly two of the ten local evidence states count as missed. A record in any of the other eight states, including `unknown`, is excluded from the missed count while remaining present in the history.
 
 ---
 

--- a/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
+++ b/docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md
@@ -8,7 +8,7 @@
 
 The reviewer loop runs a cheap local reviewer before it runs slow external ones, on the premise that front-loading findings costs fewer review rounds. Nobody can currently say whether that premise holds. The loop records that each reviewer ran and what it concluded, but not the one thing that would settle the question: how often an external reviewer finds something blocking on a pull request the local reviewer had already called clean.
 
-This feature records exactly that. When an external reviewer reports blocking findings on a pull request where the local reviewer had previously reported clean, the loop writes a compact record of the miss into the pull request's reviewer-loop history — which reviewer found it, on which commit, how many findings and where, and what the local reviewer's verdict had been at the time. The record is deliberately conservative: it claims a miss only when the local reviewer demonstrably said clean, and says so plainly when the evidence is too weak to make the claim. Its purpose is measurement, and a measurement that inflates its own numbers is worthless.
+This feature records exactly that. When an external reviewer reports blocking findings on a pull request where the local reviewer had previously reported clean, the loop writes a compact record of the miss into the pull request's reviewer-loop history — which reviewer found it, on which commit, how many findings and where, and what the local reviewer's verdict had been at the time. The record is deliberately conservative: it claims a miss only when the local reviewer demonstrably said clean, and says so plainly when the evidence is too weak to make the claim. Its purpose is measurement, and a measurement that inflates its own numbers is worthless — which is why a clean verdict on an *earlier* commit is recorded as a possible miss rather than a confirmed one.
 
 
 ---
@@ -27,7 +27,7 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 | 4 | *Scope* — capture the head commit | AC-1; the attribution rule in Business Rules; AC-11 for the case where it cannot be established |
 | 5 | *Scope* — capture the finding count | AC-1 |
 | 6 | *Scope* — capture the paths | AC-1; AC-14 bounds how many are shown |
-| 7 | *Scope* — capture whether the local reviewer was clean on the same head or an ancestor | AC-1 through AC-4 and AC-17; Use Case 3; the four clean-verdict states — same, ancestor, descendant, and unrelated — which Business Rules forbid merging |
+| 7 | *Scope* — capture whether the local reviewer was clean on the same head or an ancestor | AC-1 through AC-4, AC-17 and AC-17a — the distinction decides confirmed versus possible miss; Use Case 3; the four clean-verdict states — same, ancestor, descendant, and unrelated — which Business Rules forbid merging |
 | 8 | *Scope* — keep the record compact enough for PR comments | AC-13, AC-14, AC-14a and AC-15, with character and path bounds rather than an adjective, and an explicit precedence rule between them; Use Case 6, Considerations |
 | 9 | *Scope* — support later effectiveness reporting | AC-16 (records readable in full without re-running a reviewer); the report itself is **deferred** to Out of Scope item 1 (#1657) |
 
@@ -48,7 +48,7 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 4. It writes a missed-finding record into the pull request's reviewer-loop history.
 5. It shows the record in the reviewer-loop summary on the pull request.
 
-**Postconditions**: The pull request carries a durable, machine-readable record of the miss alongside the history the loop already keeps. Nothing about the review outcome changes — the findings are handled exactly as they are today, and the record neither blocks nor unblocks anything.
+**Postconditions**: The pull request carries a durable, machine-readable record of the miss alongside the history the loop already keeps. When the clean verdict covered the exact commit reviewed, the record is a confirmed miss; when it covered an ancestor, a possible miss, counted separately. Nothing about the review outcome changes — the findings are handled exactly as they are today, and the record neither blocks nor unblocks anything.
 
 **Information shown**:
 
@@ -203,7 +203,9 @@ under **Out of Scope (MVP)** with a deferral note. No objective is dropped.
 
 ## Business Rules
 
-- A finding counts as **missed by the local reviewer** only when the local reviewer's most recent verdict was clean **and** covered the commit the external reviewer reviewed or one of its ancestors — states `clean_same_commit` and `clean_earlier_commit`. Every other state does not count. The counting rule enumerates the states that *do* count rather than the states that do not, so a state introduced later is excluded until someone deliberately includes it.
+- A finding is a **confirmed miss** only when the local reviewer's most recent verdict was clean on the **exact commit** the external reviewer reviewed — state `clean_same_commit`. That is the only state in which the local reviewer demonstrably examined the code the finding is about.
+- A finding is a **possible miss** when that verdict was clean on an **ancestor** of the reviewed commit — state `clean_earlier_commit`. Possible misses are counted and reported separately and never folded into the confirmed count, because the flagged code may have arrived after the commit the local reviewer cleared.
+- Both rules enumerate the states that qualify rather than the states that do not, so a state introduced later qualifies for neither until someone deliberately includes it.
 - The local evidence state is recorded on every external round that reports blocking findings **and whose reviewed commit can be established**, whether or not it counts as a miss. A record that only appeared for confirmed misses would make the denominator unknowable, and a rate needs both halves. Two cases are exceptions and produce no record at all. First, an unattributable commit: a record that cannot name the commit it describes would corrupt the denominator rather than complete it. Second, a history that cannot be read, parsed, or appended to: there is nowhere to write the record, and the loop must not reconstruct or overwrite the history to make room for one. Both are enumerated here and in the Decision Matrix, and there are no others.
 - The state is always derived from the local reviewer's **most recent verdict**, never from its most recent *clean* verdict. Selection happens first, classification second.
 - When that most recent verdict is clean, it is classified by its commit's ancestry relationship to the commit the external reviewer reviewed — same, ancestor, descendant, or unrelated — and the four are recorded as distinct states that are never merged. Only same and ancestor count. A descendant clean means the local reviewer cleared newer code than the external reviewer looked at, and an unrelated clean means a force-push severed the relationship; neither is evidence that the local reviewer saw what was found.
@@ -236,8 +238,8 @@ The list is closed: any situation not described by a row is recorded as
 
 | Code value | Display label | Description | Counts as missed |
 | --- | --- | --- | --- |
-| `clean_same_commit` | Clean, same commit | The local reviewer reported clean on the exact commit the external reviewer reviewed. | Yes |
-| `clean_earlier_commit` | Clean, earlier commit | The local reviewer's most recent verdict was clean, on an ancestor of the commit the external reviewer reviewed. | Yes |
+| `clean_same_commit` | Clean, same commit | The local reviewer reported clean on the exact commit the external reviewer reviewed. | **Yes — confirmed miss** |
+| `clean_earlier_commit` | Clean, earlier commit | The local reviewer's most recent verdict was clean, on an ancestor of the commit the external reviewer reviewed. | No — **possible miss** |
 | `clean_later_commit` | Clean, later commit | The local reviewer's most recent verdict was clean, on a descendant of the commit the external reviewer reviewed — it cleared newer code than the external reviewer looked at. | No |
 | `clean_unrelated_commit` | Clean, unrelated commit | The local reviewer's most recent verdict was clean, on a commit with no ancestry relationship to the one the external reviewer reviewed, which a force-push can produce. | No |
 | `not_clean` | Reported findings | The local reviewer's most recent verdict reported findings of its own. | No |
@@ -247,9 +249,22 @@ The list is closed: any situation not described by a row is recorded as
 | `not_configured` | Not configured | The local reviewer is not configured for this repository, so it will never run. | No |
 | `unknown` | Unknown | The history is readable but does not establish the local reviewer's most recent verdict. | No |
 
-Exactly two of the ten states count as missed: `clean_same_commit` and
-`clean_earlier_commit`. Every other state, including `unknown` and any situation
-this table does not describe, does not count.
+**Exactly one of the ten states is a confirmed miss: `clean_same_commit`.**
+Only there did the local reviewer demonstrably look at the very code the
+external reviewer found something in.
+
+`clean_earlier_commit` is recorded as a **possible miss** and is reported
+separately. It is not counted as a confirmed miss, because a clean verdict on an
+ancestor does not establish that the local reviewer saw the defect: the code the
+external reviewer flagged may have arrived in a commit after the one the local
+reviewer cleared. Counting it would inflate the numerator on evidence that does
+not support the claim, which is the failure this spec exists to avoid. It is
+still recorded distinctly rather than discarded, because the brief asks for the
+same-head-or-ancestor distinction and a separate possible-miss count is a useful
+weaker signal for the effectiveness report.
+
+Every other state, including `unknown` and any situation this table does not
+describe, is neither a confirmed nor a possible miss.
 
 `clean_later_commit` and `clean_unrelated_commit` are separated from
 `clean_earlier_commit` deliberately. A clean verdict on newer or unrelated code
@@ -271,16 +286,16 @@ historical observation rather than a current status.
 The complete gate, from an external reviewer returning a result to a record
 existing or not. Rows are evaluated in order and the first match decides.
 
-| # | External result | Commit attributable | History writable | Local evidence state | Record written | Counts as missed | Next action |
+| # | External result | Commit attributable | History writable | Local evidence state | Record written | Miss classification | Next action |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Reported by the local reviewer itself | — | — | — | No | No | Nothing; a reviewer cannot miss its own findings |
-| 2 | No blocking findings — clean, skipped, or advisory only | — | — | — | No | No | Nothing; only blocking external findings qualify |
-| 3 | Blocking findings | **No** | — | — | No | No | Report why the commit could not be established; write no unattributable record |
-| 4 | Blocking findings | Yes | **No** | — | No | No | Report that telemetry could not be recorded, and why; leave the existing history untouched and attempt no reconstruction |
-| 5 | Blocking findings | Yes | Yes | `clean_same_commit` | Yes | **Yes** | Show in the summary; include in the effectiveness numbers |
-| 6 | Blocking findings | Yes | Yes | `clean_earlier_commit` | Yes | **Yes** | Show in the summary; include in the effectiveness numbers |
-| 7 | Blocking findings | Yes | Yes | Any other state in the Statuses table | Yes | No | Show in the summary; include in the denominator only |
-| 8 | Blocking findings | Yes | Yes | Not describable by any row of the Statuses table | Yes, as `unknown` | No | Show in the summary; include in the denominator only |
+| 1 | Reported by the local reviewer itself | — | — | — | No | Neither | Nothing; a reviewer cannot miss its own findings |
+| 2 | No blocking findings — clean, skipped, or advisory only | — | — | — | No | Neither | Nothing; only blocking external findings qualify |
+| 3 | Blocking findings | **No** | — | — | No | Neither | Report why the commit could not be established; write no unattributable record |
+| 4 | Blocking findings | Yes | **No** | — | No | Neither | Report that telemetry could not be recorded, and why; leave the existing history untouched and attempt no reconstruction |
+| 5 | Blocking findings | Yes | Yes | `clean_same_commit` | Yes | **Confirmed miss** | Show in the summary; include in the confirmed-miss count |
+| 6 | Blocking findings | Yes | Yes | `clean_earlier_commit` | Yes | **Possible miss** | Show in the summary; include in the possible-miss count, never in the confirmed count |
+| 7 | Blocking findings | Yes | Yes | Any other state in the Statuses table | Yes | Neither | Show in the summary; include in the denominator only |
+| 8 | Blocking findings | Yes | Yes | Not describable by any row of the Statuses table | Yes, as `unknown` | Neither | Show in the summary; include in the denominator only |
 
 Rows 5 through 8 are the reason a record is written on every qualifying external
 round rather than only on confirmed misses: rows 7 and 8 are the denominator,
@@ -307,14 +322,14 @@ that failed.
 
 ## Acceptance Criteria
 
-- [ ] **AC-1.** When an external reviewer reports blocking findings on a commit for which the local reviewer's most recent verdict was clean on that same commit, the reviewer-loop history gains a record naming that reviewer, that commit, the number of blocking findings, the files they touch, and the local evidence state `clean_same_commit`, **and that record counts as missed**.
-- [ ] **AC-2.** When the local reviewer's most recent verdict was clean and on an ancestor of the commit the external reviewer reviewed, the record's local evidence state is `clean_earlier_commit`, it is distinguishable from `clean_same_commit` without inspecting commits by hand, **and it counts as missed**.
-- [ ] **AC-3.** When the local reviewer's most recent verdict was clean and on a descendant of the commit the external reviewer reviewed, the state is `clean_later_commit` and it does not count as missed.
-- [ ] **AC-4.** When the local reviewer's most recent verdict was clean and on a commit with no ancestry relationship to the one the external reviewer reviewed, the state is `clean_unrelated_commit` and it does not count as missed.
-- [ ] **AC-4a.** When the local reviewer cleared one commit and then reported findings on a later commit, the state is `not_clean` and does not count as missed, even though an earlier clean verdict on an ancestor exists. The most recent verdict is the only one consulted.
-- [ ] **AC-5.** When the local reviewer's most recent verdict reported findings, the record is still written and its local evidence state is `not_clean`, and it does not count as missed.
-- [ ] **AC-6.** When the local reviewer was skipped, was unavailable, is configured but has not yet produced a verdict, or is not configured at all, the record is written with the corresponding state, the four are distinguishable from one another and from `not_clean`, **and none of the four counts as missed**.
-- [ ] **AC-7.** When the history is readable but does not establish the local reviewer's most recent verdict, the record is written with state `unknown` and does not count as missed.
+- [ ] **AC-1.** When an external reviewer reports blocking findings on a commit for which the local reviewer's most recent verdict was clean on that same commit, the reviewer-loop history gains a record naming that reviewer, that commit, the number of blocking findings, the files they touch, and the local evidence state `clean_same_commit`, **and that record is a confirmed miss**.
+- [ ] **AC-2.** When the local reviewer's most recent verdict was clean and on an ancestor of the commit the external reviewer reviewed, the record's local evidence state is `clean_earlier_commit`, it is distinguishable from `clean_same_commit` without inspecting commits by hand, **and it is a possible miss — counted separately and never included in the confirmed-miss count**.
+- [ ] **AC-3.** When the local reviewer's most recent verdict was clean and on a descendant of the commit the external reviewer reviewed, the state is `clean_later_commit` and it is neither a confirmed nor a possible miss.
+- [ ] **AC-4.** When the local reviewer's most recent verdict was clean and on a commit with no ancestry relationship to the one the external reviewer reviewed, the state is `clean_unrelated_commit` and it is neither a confirmed nor a possible miss.
+- [ ] **AC-4a.** When the local reviewer cleared one commit and then reported findings on a later commit, the state is `not_clean` and is neither a confirmed nor a possible miss, even though an earlier clean verdict on an ancestor exists. The most recent verdict is the only one consulted.
+- [ ] **AC-5.** When the local reviewer's most recent verdict reported findings, the record is still written and its local evidence state is `not_clean`, and it is neither a confirmed nor a possible miss.
+- [ ] **AC-6.** When the local reviewer was skipped, was unavailable, is configured but has not yet produced a verdict, or is not configured at all, the record is written with the corresponding state, the four are distinguishable from one another and from `not_clean`, **and none of the four is a confirmed or a possible miss**.
+- [ ] **AC-7.** When the history is readable but does not establish the local reviewer's most recent verdict, the record is written with state `unknown` and is neither a confirmed nor a possible miss.
 - [ ] **AC-7a.** When an external reviewer has reported blocking findings on an establishable commit **and** the reviewer-loop history cannot be read, parsed, or appended to, no missed-finding record is written, the existing history is left byte-for-byte unchanged, and the round's output states that telemetry could not be recorded and why.
 - [ ] **AC-7b.** When no record was owed in the first place — the findings came from the local reviewer, or were advisory only, or the reviewed commit could not be established — an unwritable history produces **no** telemetry-failure report, because nothing was owed.
 - [ ] **AC-8.** Advisory or suggestion-level external findings produce no missed-finding record.
@@ -327,7 +342,8 @@ that failed.
 - [ ] **AC-14a.** The 200-character bound in AC-13 takes precedence over the path count in AC-14. When naming three paths would exceed it, the line names as many as fit — down to none — and the total file count is still stated. A line that reaches the bound with zero paths named is a valid line, not a failure.
 - [ ] **AC-15.** A pull request carrying twenty records adds at most twenty lines and 4,000 characters to the reviewer-loop summary, whatever the number of findings or the length of their paths.
 - [ ] **AC-16.** The records for a pull request can be read back in full by a later report without re-running any reviewer.
-- [ ] **AC-17.** Exactly two of the ten local evidence states count as missed. A record in any of the other eight states, including `unknown`, is excluded from the missed count while remaining present in the history.
+- [ ] **AC-17.** Exactly one of the ten local evidence states is a confirmed miss (`clean_same_commit`) and exactly one is a possible miss (`clean_earlier_commit`). A record in any of the other eight states, including `unknown`, is neither, while remaining present in the history.
+- [ ] **AC-17a.** A report reading these records can produce the confirmed-miss count and the possible-miss count separately, and no operation folds the second into the first.
 
 ---
 


### PR DESCRIPTION
## Summary

Spec for #1651 — record, on the pull request itself, every time an external reviewer reports blocking findings on a commit the local reviewer had already called clean, so the premise this epic rests on can be measured rather than assumed.

Spec: [`docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md`](docs/specs/developments/20260828014500_1651-missed-findings-telemetry/1_1651-missed-findings-telemetry_specs.md)

## Central design decision

The record is **deliberately conservative about claiming a miss**, and the classification is two-tier:

- **Confirmed miss** — and only this — when the local reviewer's most recent verdict was clean on the **exact commit** the external reviewer reviewed. That is the only state in which the local reviewer demonstrably examined the code the finding is about.
- **Possible miss**, counted and reported separately, when that verdict was clean on an **ancestor**. A clean verdict on an ancestor does not establish that the local reviewer saw the defect — the flagged code may have arrived after the commit it cleared.

Both rules enumerate the states that qualify rather than the states that do not, so a state introduced later qualifies for neither until someone deliberately includes it. See the *Product decision* section below — this changes what the epic's headline number means and is cheap to reverse.

This matters more than it looks. The value of the telemetry is that its numbers can be trusted; a measurement that inflates its own failure count is worse than none, because it will be used to justify changes. Four distinctions carry that weight:

- **`unavailable` is not `not_clean`.** A local reviewer that timed out or lost credentials looks superficially like one that found nothing. Conflating them would make an outage read as a quality failure.
- **`clean_later_commit` and `clean_unrelated_commit` are not `clean_earlier_commit`.** A clean verdict on newer code, or on a branch a force-push rewrote, is not evidence the local reviewer saw what was found. Only same-commit and ancestor clean verdicts count.
- **`not_yet_run` is not `not_configured`.** "Has not run yet" and "will never run" describe different repositories and must not be summed.
- **`unknown` counts as neither.** When the history is readable but silent about the local verdict, the record says so and stays out of both numerators.
- **One verdict is selected, then classified.** The state derives from the local reviewer's *most recent* verdict, never its most recent *clean* verdict — otherwise a reviewer that cleared one commit and then reported findings on a later one would be counted as having missed something it had already superseded.

The record is written on **every** qualifying external round, not only on confirmed misses — a record that appeared only for misses would make the denominator unknowable, and a rate needs both halves.

## Dependency

**Depends on #1648** (`1648-reviewer-loop-current-head-evidence`). Classifying a clean local verdict by its ancestry relationship to the commit the external reviewer reviewed is exactly the per-reviewer head evidence #1648 introduces. Without it the four clean states collapse into one and the conservatism above is unavailable.

The spec PRs are independent and can be reviewed in either order; only the implementation is ordered. #1648's plan is #1660, currently `ready-for-human-review`.

## Product decision — flagged for review

`clean_earlier_commit` is recorded as a **possible miss**, not a confirmed one. The brief asks for the same-head-or-ancestor distinction to be *captured*; it does not say both must count the same way, and counting an ancestor clean toward the headline rate would inflate it on evidence that does not support the claim.

Two alternatives were considered and not taken. Discarding the ancestor case entirely was rejected because the brief asks for it and a weaker signal is still useful to #1657. Promoting an ancestor clean to confirmed *when the finding's paths were unchanged between the two commits* is the most accurate rule, and was deliberately left out: it requires per-finding path-diff evidence, which starts prescribing mechanism in a spec, and it can be added later — the possible-miss bucket is exactly where such records would be promoted from.

If the ancestor case was meant to count toward the headline rate, reversing this is one table cell, one Business Rule, `AC-2` and `AC-17`.

## Shape of the spec

- **Six use cases** — a miss, a non-miss because the local reviewer never cleared, a non-miss because it cleared different code, indeterminate local evidence, an unwritable history surface, and a reader consuming the accumulated records.
- **Ten local evidence states**, of which exactly one is a confirmed miss and exactly one a possible miss. Anything the table does not describe is `unknown`.
- **An eight-row Decision Matrix** covering the full gate: external finding eligibility, commit attributability, history writability, the state, whether a record is written, its miss classification, and the required next action. Row order is load-bearing — writability is evaluated *after* eligibility and attribution, so a round that was never going to produce a record does not raise a telemetry alarm.
- **Twenty-two numbered acceptance criteria** (`AC-1`…`AC-17`, plus `AC-4a`, `AC-7a`, `AC-7b`, `AC-14a`, `AC-17a`), so cross-references can be checked mechanically rather than by reading.

## Coverage Matrix

The spec carries this mapping in full as its **Issue-Objective Traceability** section; reproduced here for review convenience.

| #1651 objective | Disposition |
| --- | --- |
| Problem: cannot quantify whether the local reviewer reduces external rounds without tracking what external reviewers found after a local clean result | Covered. Use Cases 1-6; the confirmed-miss and possible-miss rules and the record-every-qualifying-round rule; Decision Matrix rows 5-8; AC-1 through AC-7, AC-4a and AC-7a. |
| Outcome: reviewer-loop history records missed-by-local findings when an external reviewer reports blockers after a local clean result | Covered. Use Case 1; AC-1 through AC-3; Operational Visibility. |
| Scope: capture reviewer | Covered. AC-1; Use Case 1 Information shown. |
| Scope: capture head SHA | Covered. AC-1; the attribution rule; AC-11 for the unestablishable case. |
| Scope: capture finding count | Covered. AC-1. |
| Scope: capture paths | Covered. AC-1; AC-14 bounds how many are shown. |
| Scope: capture whether local reviewer was clean on the same head or an ancestor | Covered. AC-1 through AC-4, AC-4a, AC-17 and AC-17a; Use Case 3; the four clean-verdict states, which the Business Rules forbid merging. The distinction is what separates a confirmed miss from a possible one. |
| Scope: keep the record compact enough for PR comments | Covered. AC-13, AC-14, AC-14a and AC-15 — character and path bounds with an explicit precedence rule, rather than an adjective. |
| Scope: support later effectiveness reporting | Covered as a complete, readable record — AC-16. The report itself is **deferred** to #1657, Out of Scope item 1. |

### Deferral notes

- **Reporting and aggregation** (Out of Scope 1) is #1657 in this epic. "Support later effectiveness reporting" is met by producing a complete record, not the report. No human confirmation requested — the split follows the epic's own decomposition.
- **Cause attribution** (Out of Scope 2) needs the doctrine work in #1654 first. Guessing at *why* a finding was missed would pollute the measurement this item exists to make trustworthy. No human confirmation requested.
- **Acting on the records** (Out of Scope 3): measurement first, response second. A control loop built on unvalidated telemetry is worse than none. No human confirmation requested.
- **Near-misses** (Out of Scope 4): advisory external findings after a local clean verdict are not recorded, since the brief scopes this to blockers. No human confirmation requested.

## Open questions

None. Four decisions the brief left implicit were resolved in the spec with their reasoning stated: only blocking external findings qualify; records are per external round rather than per finding; records accumulate rather than de-duplicate; and the local reviewer's own findings never create a record.

## Document Quality Gate

- Brief coverage: Checked - every objective in #1651's Problem, Outcome and Scope maps to numbered acceptance criteria or an Out-of-Scope entry with a deferral note, in the spec's own Issue-Objective Traceability table and in the Coverage Matrix above. No objective is silently dropped.
- Internal consistency: Checked - the **ten** state code values, their display labels and their miss classifications are identical in the Statuses table, the eight-row Decision Matrix, the Business Rules, the six use cases and the acceptance criteria. The claim "exactly one confirmed miss and exactly one possible miss" was verified against the table by counting rows, and is pinned by AC-17. Grepped for the superseded phrases "counts as missed" and "most recent clean verdict": neither remains anywhere in the spec.
- Naming and casing consistency: Checked - "local reviewer", "external reviewer", "missed-finding record", "local evidence state" and "reviewer-loop history" carry one spelling and one meaning throughout; state code values appear in one casing.
- Behavioral guarantees: Checked - each guarantee names the rule that makes it testable. "A possible miss is never folded into the confirmed count" → the two-tier rule plus AC-17a. "Never overwritten" → the accumulation rule plus AC-10. "Changes no outcome" → the observation-only rule plus AC-12. "Attributable to a commit" → the attribution rule plus AC-11. "Compact" → AC-13, AC-14, AC-14a and AC-15, with numbers and a precedence rule. "Never reconstructs a history it could not read" → Use Case 5 plus AC-7a.
- Complex workflow decision-gate matrix: Checked - the spec carries an eight-row Decision Matrix. **Inputs**: the external reviewer's identity and finding severity, whether the reviewed commit can be established, whether the history can be read and appended to, and the local reviewer's most recent verdict with its commit. **Outcomes**: no record (rows 1-4) or a record in one of ten states (rows 5-8), of which `clean_same_commit` is a confirmed miss, `clean_earlier_commit` a separately-counted possible miss, and the remaining eight neither. **Required next actions**: named per row, including the two distinct no-record reports — why a commit could not be established, and that telemetry could not be recorded. **Row order is part of the contract**: writability is evaluated after eligibility and attribution, so a round that owed no record raises no alarm; AC-7b pins the complement. **Mirror surfaces**: the summary line and the structured history record, required to carry the same reviewer, commit, count, paths and state. **Examples**: none are part of the changed surface at spec stage; the rendered summary line is an implementation-plan concern.
- Reviewer-risk categories: Checked. API surface — the record's fields are enumerated once and the ten states are closed. Concurrency — not applicable; records are appended by the sequential loop and never revised, and the state has no transitions. Single-snapshot semantics — this is the feature's central question, addressed by the four ancestry states, by the confirmed-versus-possible split, and by the select-then-classify rule that keys off the most recent verdict rather than the most recent clean one. Missing edge cases — unavailable, not-yet-run, not-configured, unreadable-history-content, unwritable-history-surface, and unestablishable-commit each have an acceptance criterion. Vague actors and triggers — the actor is the reviewer loop in Use Cases 1-5 and a human or later report in Use Case 6; the trigger is an external reviewer returning blocking findings. Untestable ACs — the compactness criteria carry numbers and a precedence rule; the no-effect criterion names the three surfaces it must not change. Hidden dependencies — #1648 is declared in the spec's `Depends on` line and explained above. Accidental implementation design — the spec names no file, function, field or storage format.
- Placeholder cleanup: Checked - the mandatory template-placeholder grep returns no output. `UX Rules` was deleted (no UI) and `Open Questions` was deleted (none remain), rather than left with placeholder content.
- Not-applicable rationale: Checked - `UX Rules`, `Open Questions`, and the concurrency reviewer-risk category each carry their reason above.

Closes #1651

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only spec addition with no runtime, auth, or data-path changes in this PR.
> 
> **Overview**
> Adds a **new product spec** for issue **#1651** — missed-finding telemetry in the reviewer loop — under `docs/specs/developments/20260828014500_1651-missed-findings-telemetry/`. There is **no application code** in this PR; it defines what a future implementation must do.
> 
> The spec requires **per-round records** on the pull request when an **external** reviewer reports **blocking** findings on an attributable commit: reviewer, head SHA, finding count, paths, and a **local evidence state**. Classification is intentionally conservative: only **`clean_same_commit`** is a **confirmed miss**; **`clean_earlier_commit`** is a **possible miss** reported separately; other states (e.g. `not_clean`, `unavailable`, `clean_later_commit`, `unknown`) stay in the denominator but do not count as misses. Records append on **every qualifying external round** (not only misses), must not change review outcomes, and include compact summary-line limits (AC-13–AC-15).
> 
> It also documents an **ordered decision matrix** (eligibility → commit attribution → history writability), **six use cases**, **22 acceptance criteria**, traceability to #1651 objectives, **dependency on #1648** for head/ancestry evidence, and **out-of-scope** items (aggregation #1657, cause attribution, automated actions, advisory near-misses).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fd3bc1d10d3bc09c584a85d6b96482a417d2993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->