### PR TITLE
docs(#1656): plan — second local pass before ready-phase reviewers

### DIFF
--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -211,9 +211,16 @@ Not applicable — this repository ships workflow tooling, not a service.
 - [ ] **Run the pass, immediately before the ready-phase gate.** At
       `pr-review-loop.sh:8580`, before `ensure_pr_ready_for_ready_phase`:
 
-      1. If `reviewer_loop_local_pass_required` returns `not_required`, do
-         nothing and proceed exactly as today.
-      2. Otherwise dispatch the local reviewer once and process its output
+      1. If `reviewer_loop_local_pass_required` returns `not_required` **or**
+         `no_local_reviewer`, do nothing and proceed exactly as today. Both are
+         the table's non-owing rows, and they exempt for different reasons: the
+         first has current evidence, the second has no reviewer to produce any.
+         Listing only `not_required` here would have `no_local_reviewer` fall
+         through to a dispatch of a reviewer that does not exist — which is the
+         contradiction the table exists to prevent, reintroduced by an "and
+         otherwise" that predates the fifth value.
+      2. Otherwise — `head_changed`, `prior_findings` or `no_evidence` —
+         dispatch the local reviewer once and process its output
          through the **same code the platform loop uses**. That needs a small
          extraction first: `run_platform_review` only dispatches — the parsing,
          the aggregation, the `print_kv` forwarding, the

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -158,14 +158,40 @@ Not applicable — this repository ships workflow tooling, not a service.
       reported, and a reader wanting to know *why* a pass ran cannot recover it
       from `1`.
 
+      **The payload it reads must include the current round.** #1651's selector
+      is a pure query over one payload, and its caller composes the round's
+      in-memory `platform_results` and `reviewed_heads[]` into `entries[]` as a
+      synthetic entry before selecting. This condition inherits that
+      requirement, and it is not optional here: by the time the guard runs, the
+      local reviewer has usually already reported **in this cycle**, and its
+      verdict lives only in memory — the ledger entry carrying it is written at
+      the end of the cycle. Reading the persisted payload alone would make every
+      ordinary run owe a pass it does not need, which is scenario 4's case and
+      the opposite of the item's purpose. The composition is the same helper
+      #1651's call site uses; this is a second caller of it, not a second copy.
+
 - [ ] **Run the pass, immediately before the ready-phase gate.** At
       `pr-review-loop.sh:8580`, before `ensure_pr_ready_for_ready_phase`:
 
       1. If `reviewer_loop_local_pass_required` returns `not_required`, do
          nothing and proceed exactly as today.
-      2. Otherwise dispatch `run_local_ai_reviewer_review` once, through the
-         same `run_platform_review` path every platform uses, so its output is
-         parsed, recorded and forwarded identically.
+      2. Otherwise dispatch the local reviewer once and process its output
+         through the **same code the platform loop uses**. That needs a small
+         extraction first: `run_platform_review` only dispatches — the parsing,
+         the aggregation, the `print_kv` forwarding, the
+         `platform_result_records` accumulation and the reviewed-head collection
+         all live inline in the platform loop, *after* its call. A guard-side
+         call to `run_platform_review` alone would produce output nobody parsed
+         and a pass that appears in no ledger entry.
+
+         So the plan extracts that inline block into
+         `reviewer_loop_process_platform_output <platform_name> <platform_index> <output> <status>`,
+         called from both the platform loop and the guard. The extraction is
+         **behaviour-preserving by requirement, not by intention**: scenario 5a
+         runs a pull request that needs no pass and asserts the loop's entire
+         `key=value` output is byte-identical to the same run before this
+         change. An extraction that quietly reorders or drops a key would pass
+         every other scenario in this plan.
       3. If that pass is **clean**, proceed to the gate.
       4. If it is anything else, end the cycle with that result — the same
          `needs_fixes` / `escalate` path a first-pass finding takes — and do
@@ -296,8 +322,18 @@ Order step 0.
 4. With `not_required`, the gate is reached with **no** extra dispatch: the
    platform sequence is byte-for-byte what it is today.
 5. With any other value, the local reviewer is dispatched exactly once before
-   the gate, through `run_platform_review`, and its output is parsed and
-   forwarded like any platform's.
+   the gate, and its output is processed by
+   `reviewer_loop_process_platform_output` — the same function the platform loop
+   calls — so the pass is parsed, aggregated, forwarded and recorded in the
+   ledger entry like any platform's.
+5a. The extraction is behaviour-preserving: for a pull request that needs **no**
+   pass, the loop's entire `key=value` output is byte-identical to the same run
+   before this change. This is the scenario that fails if the extraction drops
+   or reorders a key, and every other scenario here would pass with that defect.
+5b. The condition sees the **current round**: a cycle in which the local
+   reviewer already reported clean, whose ledger entry is not yet written,
+   returns `not_required`. Reading the persisted payload alone returns
+   `head_changed` or `no_evidence` and makes every ordinary run owe a pass.
 6. A **clean** second pass proceeds to the gate and the pull request is
    converted to ready.
 7. A **needs_fixes** second pass ends the cycle with `needs_fixes`, does **not**
@@ -375,6 +411,8 @@ Order step 0.
 | Silence is read as satisfaction | **High** — `not_required` is the natural default for "nothing to compare" | **High** — a pull request the local reviewer never examined passes the gate, which is the exact fail-open this epic exists to close | `no_evidence` owes a pass. Scenario 2 and proof **P2** |
 | The pass increments a cycle cap | Med | Med — every run needing a pass gets a shorter budget, and `max_cycles_exceeded` starts meaning two different things | The pass is a dispatch inside an already-counted cycle. Scenarios 9 and 10; proof **P3** increments |
 | A failed pass converts the pull request anyway | Med | Med — the pull request is left ready with no reviewer dispatched, a state the loop never intended | The cycle ends before the gate. Scenario 7 asserts all three consequences; proof **P4** converts first |
+| The extraction changes the ordinary path | Med — it touches the busiest block in the script | **High** — every run's output shifts, and the cause is a refactor nobody was reviewing for behaviour | Byte-identical output required for a run needing no pass, in its own commit so the diff is readable. Scenario 5a and proof **P8** |
+| The condition ignores the current round | **High** — the persisted payload is the obvious input | Med — every ordinary run dispatches the local reviewer twice, and the guard becomes a tax on the path it was meant to leave alone | The round's in-memory results are composed in first, using #1651's helper. Scenarios 4 and 5b, proof **P7** |
 | The guard runs when there is no gate to protect | Med | Low — doubles the local reviewer's cost on every draft-only run | No-op when `phase_after_clean_enabled` is 0. Scenario 13 and proof **P5** |
 | This item and #1649 are implemented as one refusal | Med | **High** — the loop can never advance past a local finding, because the evidence that would clear the refusal is the dispatch the refusal prevents | The order is stated in **Interaction with #1649** and enforced by Implementation Order step 0 |
 
@@ -420,17 +458,20 @@ reviewer_loop_local_pass_required() {
 ## Planted-Violation Proofs
 
 `REVIEW.md` → Core Rules → Verification Discipline requires two demonstrated
-runs per proof, each citing a concrete file and line. The six proofs fall into
-two groups:
+runs per proof, each citing a concrete file and line. The eight proofs fall into
+three groups:
 
 | Group | Count | Proofs | What the plant reproduces |
 | --- | --- | --- | --- |
 | Fail-open | **3** | P2, P4, P6 | the gate reached, or the pull request converted, without the evidence |
-| Loop and cost | **3** | P1, P3, P5 | a guard that repeats, shortens the run, or runs where there is nothing to guard |
+| Loop and cost | **3** | P1, P3, P5 |
+| Integration | **2** | P7, P8 | a guard wired in beside the pipeline rather than into it | a guard that repeats, shortens the run, or runs where there is nothing to guard |
 
 | # | Violation to plant | Where | Check that must fail, then pass |
 | --- | --- | --- | --- |
 | P1 | Key the flag on a per-cycle boolean instead of the head | a scratch copy of the guard | scenario 8 fails: two cycles with no new commit dispatch the local reviewer twice, and a pull request whose reviewer never goes clean burns its whole budget on repeated local reviews. The plant looks equivalent — one pass per cycle reads as "at most once" — and only counting dispatches across cycles separates them; restoring the head key passes |
+| P7 | Read the persisted payload without composing the current round | a scratch copy of the condition | scenario 5b fails: a cycle whose local reviewer has already reported clean owes a pass anyway, so every ordinary run dispatches the reviewer twice — the guard becomes a tax on the path it was meant to leave alone. Scenario 4's no-dispatch case fails with it, which is the visible symptom; restoring the composition passes both |
+| P8 | Call `run_platform_review` from the guard without processing its output | a scratch copy of the dispatch block | scenario 5's ledger assertion fails: the pass runs, its verdict decides the gate, and it appears in no ledger entry and no `key=value` output — so the telemetry says the gate opened with no evidence of what opened it. The gate behaviour is still correct, which is what makes this the plant a hurried extraction invites; restoring the shared processor passes |
 | P6 | Make the flag suppress the dispatch without refusing the gate | same scratch copy | scenario 8a fails: the cycle after a failed pass reaches the gate with no current clean evidence, because the condition still owes a pass and nothing runs — a fail-open created by the anti-loop mechanism itself. Scenario 8's dispatch count still passes, which is what makes this the plant a two-way guard invites; restoring the refusal passes both |
 | P2 | Return `not_required` when the history names no local verdict | same scratch copy | scenario 2 fails: a pull request the local reviewer never examined reaches the gate and its ready-phase reviewers run, which is the fail-open this item exists to close. Every other scenario passes, because they all supply a verdict; restoring `no_evidence` passes |
 | P3 | Increment `CYCLE_COUNT` when the pass runs | a scratch copy of the dispatch block | scenarios 9 and 10 fail: a run needing a pass reports a different count than an identical run that does not, and `max_cycles_exceeded` arrives earlier — so the guard silently shortens every run it helps; restoring the no-op passes |
@@ -453,10 +494,15 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
 1. Add `reviewer_loop_local_pass_required`, calling #1651's selector with both
    of its arguments. **Verify**: scenarios 1, 2 and 3 — all four values,
    `no_evidence` for silence, and both head-mismatch shapes.
+1a. Extract the platform loop's inline post-dispatch block into
+   `reviewer_loop_process_platform_output`, changing nothing else. **Verify**:
+   scenario 5a — byte-identical `key=value` output for a run that needs no pass.
+   Do this as its own commit, so the extraction's diff can be read on its own.
 2. Add the three-way guard — dispatch, refuse, or proceed — with the flag
    holding the head a pass **failed** on, before
-   `ensure_pr_ready_for_ready_phase`. **Verify**: scenarios 4, 5, 6, 7, 8, 8a
-   and 8b — the dispatch count across cycles, all three consequences of a failed
+   `ensure_pr_ready_for_ready_phase`, and compose the current round into the
+   payload before evaluating the condition. **Verify**: scenarios 4, 5, 5b, 6,
+   7, 8, 8a and 8b — the dispatch count across cycles, all three consequences of a failed
    pass, the refusal on the next cycle at the same head, and the `not_required`
    path after a clean pass.
 3. Confirm the caps are untouched. **Verify**: scenarios 9 and 10.
@@ -466,7 +512,7 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    **Verify**: scenarios 11 and 12.
 6. Update Protocol 93, the `--help` block, and add
    `changelog.d/1656.changed.second-local-pass.md`. **Verify**: runbook Step 8.
-7. Produce the six planted-violation proofs (P1-P6) and record them in the PR
+7. Produce the eight planted-violation proofs (P1-P8) and record them in the PR
    with the command, file, line and both outcomes for each.
 
 ---

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -262,7 +262,7 @@ Not applicable — this repository ships workflow tooling, not a service.
       | --- | --- | --- |
       | `not_required` | — | proceed to the gate; no dispatch |
       | owes a pass | no | **dispatch once**; clean → proceed, otherwise end the cycle and record the head |
-      | owes a pass | yes | **refuse**: end the cycle with `needs_fixes`, reason `local_pass_failed_for_head`, no dispatch and no conversion |
+      | owes a pass | yes | **refuse**: end the cycle with `needs_fixes`, reason `failed_for_head`, no dispatch and no conversion |
 
       **The third row is the one a two-way guard gets wrong**, and it is not a
       corner case — it is the next cycle after any failed pass. A flag that only
@@ -440,7 +440,7 @@ Order step 0.
    hypothetical — the loop is re-invoked after every blocking result, which is
    what a failed pass produces.
 8a. After a **failed** pass, the next cycle at the same head **refuses**: the
-   cycle ends with `needs_fixes` and reason `local_pass_failed_for_head`, no
+   cycle ends with `needs_fixes` and reason `failed_for_head`, no
    local reviewer is dispatched, and the pull request is not converted. A guard
    that only suppressed the dispatch would let this cycle reach the gate with no
    current clean evidence — the fail-open the anti-loop flag would otherwise

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -137,8 +137,7 @@ Not applicable — this repository ships workflow tooling, not a service.
 
 - [ ] **Decide whether a second pass is owed.** Add
       `reviewer_loop_local_pass_required <history_payload> <loop_head_sha> <configured_platforms>`,
-      printing one of four values — three that owe a pass and one that does
-      not:
+      printing one of five values — three that owe a pass and two that do not:
 
       | Local reviewer's most recent verdict | Value | Owes a pass |
       | --- | --- | --- |
@@ -525,8 +524,8 @@ three groups:
 | Group | Count | Proofs | What the plant reproduces |
 | --- | --- | --- | --- |
 | Fail-open | **4** | P2, P4, P6, P10 | the gate reached, or the pull request converted, without the evidence |
-| Loop and cost | **3** | P1, P3, P5 |
-| Integration | **3** | P7, P8, P9 | a guard wired in beside the pipeline rather than into it | a guard that repeats, shortens the run, or runs where there is nothing to guard |
+| Loop and cost | **3** | P1, P3, P5 | a guard that repeats, shortens the run, or runs where there is nothing to guard |
+| Integration | **3** | P7, P8, P9 | a guard wired in beside the pipeline rather than into it |
 
 | # | Violation to plant | Where | Check that must fail, then pass |
 | --- | --- | --- | --- |

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -41,12 +41,30 @@ escalation contract — so the guard has to be provably incapable of running
 twice for the same head, and its interaction with both caps has to be decided
 rather than inherited.
 
-**Dependencies**: **#1648 must be implemented and merged before this item's
-implementation PR opens.** The condition reads the local reviewer's reviewed
-head per reviewer, which is #1648's `reviewed_heads[]`. #1649's plan is merged
-and its implementation is not; the two touch adjacent code but not the same
-lines, and this plan records the boundary in **Interaction with #1649** rather
-than sequencing them.
+**Dependencies**: **#1648 and #1651 must both be implemented and merged before
+this item's implementation PR opens, in that order.** The condition needs the
+local reviewer's most recent verdict *and* the commit it describes, and neither
+exists on the base branch today:
+
+- **#1648** adds `reviewed_heads[]`, the per-reviewer commit.
+- **#1651** adds `platform_results` and
+  `reviewer_loop_local_latest_verdict <history_payload> <configured_platforms>`
+  — the selector this item's condition calls, with that two-argument signature.
+  #1651 itself depends on #1648, so the chain is **#1648 → #1651 → #1656**.
+
+An earlier revision of this plan named only #1648 and called the selector with
+one argument. That was wrong twice: the helper belongs to #1651, and its
+signature takes the configured-platform list, without which `not_configured`
+cannot be distinguished from `not_yet_run` — a distinction this item's
+`no_evidence` row depends on.
+
+Defining a second selector here instead was considered and rejected: two
+readers of the same ledger field is how the two drift, and #1651's already
+handles the four absence cases this condition must classify.
+
+#1649's plan is merged and its implementation is not; the two touch adjacent
+code but not the same lines, and this plan records the boundary in
+**Interaction with #1649** rather than sequencing them.
 
 ---
 
@@ -76,15 +94,20 @@ would make the count zero afterwards.
 | --- | --- | --- | --- | --- | --- |
 | Approved base branch for this item | `develop-internal-reviewer-effectiveness` | `integration-branch:internal-reviewer-effectiveness` label on #1656 | 2026-08-28, repo SHA `d55d3e7f` | Epic #1647 items | `Verified` |
 | Per-reviewer head evidence exists | Introduced by #1648 | #1648's merged plan | 2026-08-28, repo SHA `d55d3e7f` | #1648 and #1656 | `Conflict` — see below |
+| The verdict selector exists, with two arguments | `reviewer_loop_local_latest_verdict <payload> <configured_platforms>`, introduced by #1651 | #1651's merged plan | 2026-08-28, repo SHA `d55d3e7f` | #1651 and #1656 | `Conflict` — see below |
 | The ready-phase gate's insertion point | `pr-review-loop.sh:8580-8616` | The file | 2026-08-28, repo SHA `d55d3e7f` | `pr-review-loop.sh`, #1649 | `Conflict` — see below |
 
-**Conflict record.** Two. First, the condition needs each reviewer's reviewed
+**Conflict record.** Three. First, the condition needs each reviewer's reviewed
 head, which does not exist on the base branch: #1648's plan is merged, its
-implementation is not. Second, #1649 adds its own gate in the same region.
-Affected plan statements: the guard's condition and its insertion point.
+implementation is not. Second, it calls #1651's verdict selector, which is in
+the same state — and whose two-argument signature is what separates
+`not_configured` from `not_yet_run`. Third, #1649 adds its own gate in the same
+region. Affected plan statements: the guard's condition and its insertion
+point.
 
-**Resolution status**: `Resolved`. The first by sequencing — **Implementation
-Order step 0**, a hard stop on #1648. The second by scope, recorded in
+**Resolution status**: `Resolved`. The first two by sequencing —
+**Implementation Order step 0**, a hard stop on the chain #1648 → #1651 →
+#1656. The second by scope, recorded in
 **Interaction with #1649**: that item decides *whether to dispatch* an expensive
 reviewer given the evidence; this one decides *whether to produce* the evidence
 first. Decision owner: LH — if #1649 is implemented as a single combined gate,
@@ -113,7 +136,7 @@ Not applicable — this repository ships workflow tooling, not a service.
 ### Shared Packages / Libraries
 
 - [ ] **Decide whether a second pass is owed.** Add
-      `reviewer_loop_local_pass_required <history_payload> <loop_head_sha>`,
+      `reviewer_loop_local_pass_required <history_payload> <loop_head_sha> <configured_platforms>`,
       printing one of four values — three that owe a pass and one that does
       not:
 
@@ -222,8 +245,10 @@ Not applicable — this repository ships workflow tooling, not a service.
 
 ### Infrastructure / Configuration
 
-- [ ] Document both keys and the four reasons in the `--help` block and in
-      Protocol 93.
+- [ ] Document both keys and **all five** reasons — the four conditions plus
+      `failed_for_head` — in the `--help` block and in Protocol 93. Four would
+      omit the refusal, which is the only reason that reports a *blocked* gate
+      rather than a satisfied or a repaired one.
 
 ---
 
@@ -363,9 +388,13 @@ Order step 0.
 # Four values, not a boolean: the reason is reported, and `1` cannot be read
 # backwards into a cause.
 reviewer_loop_local_pass_required() {
-  local payload="${1:-}" head="${2:-}" verdict outcome verdict_head
+  local payload="${1:-}" head="${2:-}" configured="${3:-}"
+  local verdict outcome verdict_head
 
-  verdict="$(reviewer_loop_local_latest_verdict "$payload")"
+  # #1651's selector, with its two-argument signature: the configured-platform
+  # list is what separates `not_configured` from `not_yet_run`, and this
+  # condition's `no_evidence` row needs both.
+  verdict="$(reviewer_loop_local_latest_verdict "$payload" "$configured")"
   outcome="$(printf '%s' "$verdict" | jq -r '.outcome // "unknown"')"
   verdict_head="$(printf '%s' "$verdict" | jq -r '.head_sha // ""')"
 
@@ -416,11 +445,14 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
 
 ## Implementation Order
 
-0. **Hard stop**: confirm #1648 is implemented and merged, and read #1649's
-   implementation — merged or in flight — to confirm it is a *check* and not a
-   combined gate. If it is combined, stop and revise this plan.
-1. Add `reviewer_loop_local_pass_required`. **Verify**: scenarios 1, 2 and 3 —
-   all four values, `no_evidence` for silence, and both head-mismatch shapes.
+0. **Hard stop**: confirm **#1648 and #1651** are both implemented and merged,
+   and that `reviewer_loop_local_latest_verdict` exists with the two-argument
+   signature #1651's plan specifies. Then read #1649's implementation — merged
+   or in flight — to confirm it is a *check* and not a combined gate. If either
+   check fails, stop and revise this plan.
+1. Add `reviewer_loop_local_pass_required`, calling #1651's selector with both
+   of its arguments. **Verify**: scenarios 1, 2 and 3 — all four values,
+   `no_evidence` for silence, and both head-mismatch shapes.
 2. Add the three-way guard — dispatch, refuse, or proceed — with the flag
    holding the head a pass **failed** on, before
    `ensure_pr_ready_for_ready_phase`. **Verify**: scenarios 4, 5, 6, 7, 8, 8a

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -1,0 +1,415 @@
+# Second Local Pass Before Ready-Phase Reviewers — Implementation Plan
+
+**Spec**: None — Refactor item. Source brief:
+[issue #1656](https://github.com/lhpaul/ai-dev-framework-template/issues/1656)
+(epic [#1647](https://github.com/lhpaul/ai-dev-framework-template/issues/1647))
+**Smoke test runbook**:
+[1656-second-local-pass.smoke-test.md](../../../testing/workflow/1656-second-local-pass.smoke-test.md)
+
+---
+
+## Summary
+
+**Approach**: Before the first ready-phase reviewer runs, the loop calls
+`ensure_pr_ready_for_ready_phase` — which converts the pull request to ready and
+nothing else. It does not ask whether the local reviewer has reported clean on
+the commit about to be reviewed. Within an ordinary run the local reviewer
+usually has, because platforms are dispatched in order every cycle; the gap is
+in the cases where it has not, and those are the ordinary operating cases of
+this repository: an invocation whose `--platform` list omits the local reviewer,
+a `--draft-github-only` run followed by a separate ready-phase run, and a head
+that moved after the local reviewer last spoke.
+
+This plan adds one guard immediately before that gate: if the local reviewer's
+most recent verdict is not **clean on `loop_head_sha`**, dispatch it once more
+and require that pass to be clean before any ready-phase reviewer is activated.
+
+**The design is a re-dispatch, not a refusal.** #1649 gates `codex-github`
+behind current-head local clean evidence and stops when the evidence is
+missing. This item is the other half: when the evidence is missing **because a
+fix landed**, the loop can produce it rather than escalate, and only escalates
+when the second pass itself is not clean. The two are complementary and the
+plan states where each applies, because implementing both as refusals would
+make the loop unable to advance after any local finding.
+
+**Estimated complexity**: M
+
+**Rationale**: The insertion point is one place and the condition is three
+comparisons. What makes it more than small is that it adds a reviewer dispatch
+**inside** an existing loop that already has two cycle caps and a documented
+escalation contract — so the guard has to be provably incapable of running
+twice for the same head, and its interaction with both caps has to be decided
+rather than inherited.
+
+**Dependencies**: **#1648 must be implemented and merged before this item's
+implementation PR opens.** The condition reads the local reviewer's reviewed
+head per reviewer, which is #1648's `reviewed_heads[]`. #1649's plan is merged
+and its implementation is not; the two touch adjacent code but not the same
+lines, and this plan records the boundary in **Interaction with #1649** rather
+than sequencing them.
+
+---
+
+## Verification Log
+
+| Check | Command / query | Result |
+| --- | --- | --- |
+| Repo revision | `git rev-parse --short origin/develop-internal-reviewer-effectiveness` | `d55d3e7f` |
+| The ready-phase gate does not consult the local reviewer | `sed -n '8580,8616p' scripts/development-workflow/pr-review-loop.sh` | The gate is `ensure_pr_ready_for_ready_phase "$pr_number"`, whose only job is converting the PR to ready; on success it sets `phase_after_clean_started=1` and dispatch proceeds. Nothing between the two reads any reviewer's result |
+| A blocking result ends the cycle | `sed -n '8736,8750p' scripts/development-workflow/pr-review-loop.sh` | On `needs_fixes` or `escalate` the loop `break`s out of the platform iteration in normal mode, so within a run a later cycle re-dispatches from the top — which is why the gap is not "every run" but the cases enumerated in the Summary |
+| The pre-dispatch head snapshot exists | `sed -n '8515,8519p' scripts/development-workflow/pr-review-loop.sh` | `loop_head_sha` is captured from `gh pr view --json headRefOid` before any reviewer runs, and is the value #1648 classifies against. The guard compares to it and takes no new snapshot |
+| Two caps already bound the run | `sed -n '7174,7195p' scripts/development-workflow/pr-review-loop.sh` | A per-run cap (`CYCLE_COUNT` / `MAX_CYCLES`, default 10) and a lifetime cap (`TOTAL_CYCLE_COUNT` / `MAX_TOTAL_CYCLES`) from the #1502 dual-cap work. The guard is bounded by them and adds no third counter |
+| The platform list is filtered before the loop | `sed -n '674,704p' scripts/development-workflow/pr-review-loop.sh` | `filter_phase_after_clean_platforms` removes configured ready-phase platforms absent from this invocation. An invocation can therefore contain ready-phase platforms and **no** local reviewer, which is the first of the Summary's three cases |
+
+**What this log does not establish.** It does not show how often a ready-phase
+reviewer has run on a head the local reviewer never saw. The loop does not
+record that today; recording it is #1651's work, and this item's guard is what
+would make the count zero afterwards.
+
+---
+
+## Cross-Cutting Operational Assumption Check
+
+### Applicable
+
+| Assumption surface | Recorded value | Authoritative source | Verified at | Bounded cross-check scope | Result |
+| --- | --- | --- | --- | --- | --- |
+| Approved base branch for this item | `develop-internal-reviewer-effectiveness` | `integration-branch:internal-reviewer-effectiveness` label on #1656 | 2026-08-28, repo SHA `d55d3e7f` | Epic #1647 items | `Verified` |
+| Per-reviewer head evidence exists | Introduced by #1648 | #1648's merged plan | 2026-08-28, repo SHA `d55d3e7f` | #1648 and #1656 | `Conflict` — see below |
+| The ready-phase gate's insertion point | `pr-review-loop.sh:8580-8616` | The file | 2026-08-28, repo SHA `d55d3e7f` | `pr-review-loop.sh`, #1649 | `Conflict` — see below |
+
+**Conflict record.** Two. First, the condition needs each reviewer's reviewed
+head, which does not exist on the base branch: #1648's plan is merged, its
+implementation is not. Second, #1649 adds its own gate in the same region.
+Affected plan statements: the guard's condition and its insertion point.
+
+**Resolution status**: `Resolved`. The first by sequencing — **Implementation
+Order step 0**, a hard stop on #1648. The second by scope, recorded in
+**Interaction with #1649**: that item decides *whether to dispatch* an expensive
+reviewer given the evidence; this one decides *whether to produce* the evidence
+first. Decision owner: LH — if #1649 is implemented as a single combined gate,
+this plan must be revised rather than layered on top.
+
+### Not applicable
+
+**Overall result for this check**: `Applicable` — the three rows above must be
+re-verified at implementation start.
+
+**Surfaces with no assumption**: no database, no runtime service, no
+user-facing surface, no scheduled job, no external API, no deployment target.
+
+---
+
+## Layer-by-Layer Changes
+
+### Database / Data Layer
+
+Not applicable.
+
+### Backend / API
+
+Not applicable — this repository ships workflow tooling, not a service.
+
+### Shared Packages / Libraries
+
+- [ ] **Decide whether a second pass is owed.** Add
+      `reviewer_loop_local_pass_required <history_payload> <loop_head_sha>`,
+      printing one of four values — three that owe a pass and one that does
+      not:
+
+      | Local reviewer's most recent verdict | Value | Owes a pass |
+      | --- | --- | --- |
+      | clean, on `loop_head_sha` | `not_required` | no |
+      | clean, on any other commit | `head_changed` | yes |
+      | not clean — findings, skipped, unavailable | `prior_findings` | yes |
+      | no verdict in this pull request's history | `no_evidence` | yes |
+
+      **Absence owes a pass.** The fourth row is the one a permissive reading
+      gets wrong: a pull request whose history says nothing about the local
+      reviewer has not been locally reviewed, and treating silence as
+      satisfaction is the same fail-open this epic exists to close. It is also
+      the ordinary state of an invocation whose `--platform` list omits the
+      local reviewer.
+
+      The four values are distinct rather than a boolean because they are
+      reported, and a reader wanting to know *why* a pass ran cannot recover it
+      from `1`.
+
+- [ ] **Run the pass, immediately before the ready-phase gate.** At
+      `pr-review-loop.sh:8580`, before `ensure_pr_ready_for_ready_phase`:
+
+      1. If `reviewer_loop_local_pass_required` returns `not_required`, do
+         nothing and proceed exactly as today.
+      2. Otherwise dispatch `run_local_ai_reviewer_review` once, through the
+         same `run_platform_review` path every platform uses, so its output is
+         parsed, recorded and forwarded identically.
+      3. If that pass is **clean**, proceed to the gate.
+      4. If it is anything else, end the cycle with that result — the same
+         `needs_fixes` / `escalate` path a first-pass finding takes — and do
+         **not** convert the pull request to ready.
+
+      Step 4 is what makes the guard worth having: a ready-phase reviewer is not
+      merely delayed, and the pull request is not converted, so the expensive
+      reviewers are not woken at all.
+
+- [ ] **Make repetition impossible, by construction rather than by counting.**
+      A flag, `local_second_pass_done_for_head`, holding the head the pass ran
+      against. The guard runs only when that value differs from
+      `loop_head_sha`, so:
+
+      - it cannot run twice for one head, in one cycle or across cycles;
+      - it *can* run again when the head genuinely moved, which is the case the
+        brief asks for;
+      - it needs no counter of its own, so it cannot drift from the caps.
+
+      **Keying on the head rather than on a per-cycle boolean is the whole
+      anti-loop argument.** A boolean reset each cycle would allow one pass per
+      cycle forever; a head-keyed flag allows one pass per *commit*, and commits
+      only appear when someone pushes. The loop cannot manufacture the condition
+      that lets it run again.
+
+- [ ] **Leave both cycle caps alone.** The pass does not increment
+      `CYCLE_COUNT` or `TOTAL_CYCLE_COUNT`: it is a dispatch within a cycle, as
+      every other platform dispatch is, and the cycle it belongs to is already
+      counted. Incrementing would make the caps mean two different things —
+      cycles for platforms, cycles-plus-passes for this one — and would shorten
+      every run that needed a pass.
+
+      What the caps still bound is the **run**: a pull request whose local
+      reviewer never goes clean produces one pass per cycle until
+      `MAX_CYCLES` escalates the run with `max_cycles_exceeded`, exactly as it
+      does today for a reviewer that never goes clean. Scenario 8 pins that.
+
+- [ ] **Report it.** Two `print_kv` lines:
+
+      ```text
+      LOCAL_SECOND_PASS=0|1
+      LOCAL_SECOND_PASS_REASON=not_required|head_changed|prior_findings|no_evidence
+      ```
+
+      `LOCAL_SECOND_PASS_REASON` is emitted **even when the pass did not run**,
+      carrying `not_required`. A key that appears only on the interesting path
+      makes its absence ambiguous — an old script, a skipped guard and a
+      satisfied condition all look alike — and this is telemetry #1657 will
+      read.
+
+      The same two values are added to the ledger entry, so a later report can
+      count passes per pull request without re-reading stdout.
+
+### Frontend / UI
+
+- [ ] One line in the reviewer-loop summary when the pass ran, naming the
+      reason and the result: `second local pass: head_changed → clean`.
+
+### Infrastructure / Configuration
+
+- [ ] Document both keys and the four reasons in the `--help` block and in
+      Protocol 93.
+
+---
+
+## Interaction with #1649
+
+The two items touch the same region and answer different questions. Stated as a
+table so an implementer holding both plans can see the seam:
+
+| | #1649 | This item |
+| --- | --- | --- |
+| Question | may an **expensive** reviewer be dispatched on this evidence? | should the loop **produce** the missing evidence first? |
+| Applies to | `codex-github` specifically | the ready-phase gate, whatever platforms follow it |
+| When evidence is missing | refuse, fail-closed | dispatch the local reviewer once, then decide |
+| Result if that fails | escalate | end the cycle with the pass's own result |
+
+**They compose in one order and not the other.** This item's pass runs first, at
+the gate; #1649's check then sees evidence that is either current-clean or
+absent-because-the-pass-failed, and in the second case the cycle has already
+ended. Implemented the other way round — #1649 refusing before this item can
+produce the evidence — the loop could never advance past a local finding,
+because the thing that would clear the refusal is the dispatch the refusal
+prevents.
+
+If #1649 is implemented as a single combined gate rather than a check, this plan
+must be revised rather than layered on it. That is a hard stop in Implementation
+Order step 0.
+
+---
+
+## Testing Strategy
+
+**Test types**: Unit (shell harness), plus the smoke test runbook.
+
+**Key scenarios to test**:
+
+1. `reviewer_loop_local_pass_required` returns each of its four values, one case
+   per row of its table.
+2. `no_evidence` is returned for a history with entries that never name the
+   local reviewer — not `not_required`. Silence is not satisfaction, and this is
+   the value an invocation without the local reviewer produces.
+3. `head_changed` is returned when the local reviewer's clean verdict names a
+   commit that is an **ancestor** of `loop_head_sha` — the ordinary
+   fix-was-pushed case — and also when it names an unrelated commit. Both owe a
+   pass; neither is `not_required`.
+4. With `not_required`, the gate is reached with **no** extra dispatch: the
+   platform sequence is byte-for-byte what it is today.
+5. With any other value, the local reviewer is dispatched exactly once before
+   the gate, through `run_platform_review`, and its output is parsed and
+   forwarded like any platform's.
+6. A **clean** second pass proceeds to the gate and the pull request is
+   converted to ready.
+7. A **needs_fixes** second pass ends the cycle with `needs_fixes`, does **not**
+   convert the pull request, and dispatches no ready-phase platform. Asserted on
+   all three, because converting-but-not-dispatching would leave the pull
+   request in a state the loop did not intend.
+8. The guard runs **at most once per head**: two cycles with no new commit
+   dispatch it once; a cycle after a new commit dispatches it again. Asserted by
+   counting dispatches, not by reading the flag.
+9. Neither `CYCLE_COUNT` nor `TOTAL_CYCLE_COUNT` changes because a pass ran: two
+   runs over identical input, one needing a pass and one not, report the same
+   counts.
+10. A pull request whose local reviewer never goes clean escalates with
+    `max_cycles_exceeded` at the same cycle count as today — the guard adds
+    passes, not cycles, so the run is not shortened.
+11. `LOCAL_SECOND_PASS_REASON` is emitted on **every** run, including
+    `not_required`, and `LOCAL_SECOND_PASS` is `0` there.
+12. Both values reach the ledger entry and the loop summary, and the summary
+    line names the reason and the result.
+13. The guard is a no-op when no ready-phase platform is configured: with
+    `phase_after_clean_enabled` at 0, nothing is dispatched whatever the
+    condition says. The pass exists to protect the gate; with no gate there is
+    nothing to protect, and dispatching anyway would double the local reviewer's
+    cost on every draft-only run.
+
+**Files**:
+
+- `scripts/development-workflow/tests/test-pr-review-loop.sh` — all thirteen, in
+  the existing `HARNESS_MODE=1` harness.
+
+**Smoke test runbook**:
+`docs/testing/workflow/1656-second-local-pass.smoke-test.md`
+
+**Regression suite**: the harness named above.
+
+---
+
+## Seed Data
+
+| Fixture | Contents | Location |
+| --- | --- | --- |
+| Verdict histories | Four `reviewer_loop_history.v1` payloads, one per row of the condition table: local clean on `loop_head_sha`; local clean on an ancestor; local `needs_fixes`; and entries that never name the local reviewer | inline in `scripts/development-workflow/tests/test-pr-review-loop.sh` |
+| Unrelated-commit history | A local clean verdict on a commit with no ancestry relationship to `loop_head_sha`, for scenario 3's second half | inline in the same file |
+| Two-cycle fixture | A run of two cycles with no new commit, and one where a commit lands between them, for scenario 8's dispatch count | inline in the same file |
+| Draft-only fixture | An invocation with no ready-phase platform configured, for scenario 13 | inline in the same file |
+
+---
+
+## Documentation Updates
+
+- `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
+  — the guard, its four reasons, and the two keys.
+- The `--help` block of `pr-review-loop.sh`.
+- `changelog.d/1656.changed.second-local-pass.md` — `changed` rather than
+  `added`: the ready-phase gate already existed and this alters when it fires.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| The guard loops — a pass that keeps triggering itself | Med | **High** — a run that never terminates, or one that burns its cycle budget on repeated local reviews | The flag is keyed on the **head**, so a second pass requires a new commit, which the loop cannot manufacture. Scenario 8 counts dispatches across cycles; proof **P1** replaces the key with a per-cycle boolean |
+| Silence is read as satisfaction | **High** — `not_required` is the natural default for "nothing to compare" | **High** — a pull request the local reviewer never examined passes the gate, which is the exact fail-open this epic exists to close | `no_evidence` owes a pass. Scenario 2 and proof **P2** |
+| The pass increments a cycle cap | Med | Med — every run needing a pass gets a shorter budget, and `max_cycles_exceeded` starts meaning two different things | The pass is a dispatch inside an already-counted cycle. Scenarios 9 and 10; proof **P3** increments |
+| A failed pass converts the pull request anyway | Med | Med — the pull request is left ready with no reviewer dispatched, a state the loop never intended | The cycle ends before the gate. Scenario 7 asserts all three consequences; proof **P4** converts first |
+| The guard runs when there is no gate to protect | Med | Low — doubles the local reviewer's cost on every draft-only run | No-op when `phase_after_clean_enabled` is 0. Scenario 13 and proof **P5** |
+| This item and #1649 are implemented as one refusal | Med | **High** — the loop can never advance past a local finding, because the evidence that would clear the refusal is the dispatch the refusal prevents | The order is stated in **Interaction with #1649** and enforced by Implementation Order step 0 |
+
+---
+
+## Code Samples
+
+<!-- workflow-shell-contract: bash -->
+
+```bash
+# Four values, not a boolean: the reason is reported, and `1` cannot be read
+# backwards into a cause.
+reviewer_loop_local_pass_required() {
+  local payload="${1:-}" head="${2:-}" verdict outcome verdict_head
+
+  verdict="$(reviewer_loop_local_latest_verdict "$payload")"
+  outcome="$(printf '%s' "$verdict" | jq -r '.outcome // "unknown"')"
+  verdict_head="$(printf '%s' "$verdict" | jq -r '.head_sha // ""')"
+
+  # Absence owes a pass. A history that says nothing about the local reviewer
+  # has not been locally reviewed, and `not_required` here would let an
+  # invocation that omits the reviewer walk straight through the gate.
+  case "$outcome" in
+    not_yet_run|not_configured|unknown) printf 'no_evidence\n'; return 0 ;;
+    clean) ;;
+    *) printf 'prior_findings\n'; return 0 ;;
+  esac
+
+  if [ -n "$head" ] && [ "$verdict_head" = "$head" ]; then
+    printf 'not_required\n'
+  else
+    printf 'head_changed\n'
+  fi
+}
+```
+
+---
+
+## Planted-Violation Proofs
+
+`REVIEW.md` → Core Rules → Verification Discipline requires two demonstrated
+runs per proof, each citing a concrete file and line. The five proofs fall into
+two groups:
+
+| Group | Count | Proofs | What the plant reproduces |
+| --- | --- | --- | --- |
+| Fail-open | **2** | P2, P4 | the gate reached, or the pull request converted, without the evidence |
+| Loop and cost | **3** | P1, P3, P5 | a guard that repeats, shortens the run, or runs where there is nothing to guard |
+
+| # | Violation to plant | Where | Check that must fail, then pass |
+| --- | --- | --- | --- |
+| P1 | Key the flag on a per-cycle boolean instead of the head | a scratch copy of the guard | scenario 8 fails: two cycles with no new commit dispatch the local reviewer twice, and a pull request whose reviewer never goes clean burns its whole budget on repeated local reviews. The plant looks equivalent — one pass per cycle reads as "at most once" — and only counting dispatches across cycles separates them; restoring the head key passes |
+| P2 | Return `not_required` when the history names no local verdict | same scratch copy | scenario 2 fails: a pull request the local reviewer never examined reaches the gate and its ready-phase reviewers run, which is the fail-open this item exists to close. Every other scenario passes, because they all supply a verdict; restoring `no_evidence` passes |
+| P3 | Increment `CYCLE_COUNT` when the pass runs | a scratch copy of the dispatch block | scenarios 9 and 10 fail: a run needing a pass reports a different count than an identical run that does not, and `max_cycles_exceeded` arrives earlier — so the guard silently shortens every run it helps; restoring the no-op passes |
+| P4 | Call `ensure_pr_ready_for_ready_phase` before checking the pass's result | same scratch copy | scenario 7 fails on its conversion assertion: a failed pass leaves the pull request converted to ready with no reviewer dispatched — a state the loop never intended and a human has to undo. The `needs_fixes` result is still reported, so a test asserting only the result passes; restoring the order passes |
+| P5 | Run the guard even when no ready-phase platform is configured | same scratch copy | scenario 13 fails: every draft-only run dispatches the local reviewer twice, doubling the cost of the cheapest gate for no benefit — the pass exists to protect a gate that is not there; restoring the no-op passes |
+
+Two proofs plant the fail-open direction, and P2 is the one to read twice: it is
+the natural default, it passes every scenario that supplies a verdict, and the
+pull requests it lets through are exactly the ones nobody reviewed locally.
+
+---
+
+## Implementation Order
+
+0. **Hard stop**: confirm #1648 is implemented and merged, and read #1649's
+   implementation — merged or in flight — to confirm it is a *check* and not a
+   combined gate. If it is combined, stop and revise this plan.
+1. Add `reviewer_loop_local_pass_required`. **Verify**: scenarios 1, 2 and 3 —
+   all four values, `no_evidence` for silence, and both head-mismatch shapes.
+2. Add the head-keyed flag and the dispatch, before
+   `ensure_pr_ready_for_ready_phase`. **Verify**: scenarios 4, 5, 6, 7 and 8 —
+   including the dispatch count across cycles and all three consequences of a
+   failed pass.
+3. Confirm the caps are untouched. **Verify**: scenarios 9 and 10.
+4. Add the no-op when no ready-phase platform is configured. **Verify**:
+   scenario 13.
+5. Add both `print_kv` lines, the ledger fields and the summary line.
+   **Verify**: scenarios 11 and 12.
+6. Update Protocol 93, the `--help` block, and add
+   `changelog.d/1656.changed.second-local-pass.md`. **Verify**: runbook Step 8.
+7. Produce the five planted-violation proofs (P1-P5) and record them in the PR
+   with the command, file, line and both outcomes for each.
+
+---
+
+## Rollback
+
+Revert the implementation PR. It removes one condition function, one dispatch
+block, one flag, two `print_kv` lines, two ledger fields, one summary line and
+the documentation updates. The ready-phase gate returns to converting the pull
+request without consulting the local reviewer, which is today's behavior;
+nothing else reads the removed keys.

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -77,6 +77,7 @@ code but not the same lines, and this plan records the boundary in
 | A blocking result ends the cycle | `sed -n '8736,8750p' scripts/development-workflow/pr-review-loop.sh` | On `needs_fixes` or `escalate` the loop `break`s out of the platform iteration in normal mode, so within a run a later cycle re-dispatches from the top — which is why the gap is not "every run" but the cases enumerated in the Summary |
 | The pre-dispatch head snapshot exists | `sed -n '8515,8519p' scripts/development-workflow/pr-review-loop.sh` | `loop_head_sha` is captured from `gh pr view --json headRefOid` before any reviewer runs, and is the value #1648 classifies against. The guard classifies against it and never re-reads the head for classification; the one extra read it does take is an equality test before the gate, described in Layer-by-Layer |
 | Two caps already bound the run | `sed -n '7174,7195p' scripts/development-workflow/pr-review-loop.sh` | A per-run cap (`CYCLE_COUNT` / `MAX_CYCLES`, default 10) and a lifetime cap (`TOTAL_CYCLE_COUNT` / `MAX_TOTAL_CYCLES`) from the #1502 dual-cap work. The guard adds no third counter |
+| `head_moved_during_run` carries two contracts | `sed -n '/^reviewer_loop_history_entries_count()/,/^}/p' scripts/development-workflow/pr-review-loop.sh`, plus Protocol 91's handling | Entries carrying that reason are excluded from the qualifying set — the round is not counted as a cycle — and Protocol 91 treats it as nothing-to-fix rather than dispatching a fixer. Both apply to a mid-pass head move, which is why the refusal reuses the token instead of minting one |
 | …but neither bounds a repeated identical entry | `sed -n '/^reviewer_loop_history_entries_count()/,/^}/p' scripts/development-workflow/pr-review-loop.sh` | The lifetime count is `unique` over `head_sha \| result`, so repeated `needs_fixes` entries at one head count **once**, and `CYCLE_COUNT` resets each invocation. A refusal reported as `needs_fixes` would therefore repeat indefinitely — which is why the refusal is `escalate` |
 | The platform list is filtered before the loop | `sed -n '674,704p' scripts/development-workflow/pr-review-loop.sh` | `filter_phase_after_clean_platforms` removes configured ready-phase platforms absent from this invocation. An invocation can therefore contain ready-phase platforms and **no** local reviewer, which is the first of the Summary's three cases |
 | The configuration is not read when `--platform` is given | `sed -n '8330,8342p' scripts/development-workflow/pr-review-loop.sh` | `workflow_config_review_platforms` is consulted only when the platform list is otherwise empty. So the invocation's `platforms` array cannot answer *is this reviewer configured for the repository* — the guard resolves that separately |
@@ -240,11 +241,26 @@ Not applicable — this repository ships workflow tooling, not a service.
          every other scenario in this plan.
       3. If that pass is **clean**, re-read the pull request's head once and
          compare it to `loop_head_sha`. If they match, proceed to the gate. If
-         they differ, end the cycle with `needs_fixes` and reason
-         `head_moved_during_pass` — the pass reviewed a commit that is no longer
-         the head, so opening the gate would dispatch expensive reviewers
-         against code the local reviewer has not seen, which is the guarantee
-         this whole item exists to provide.
+         they differ, end the cycle with `needs_fixes` and the loop's
+         **existing** reason `head_moved_during_run` — the pass reviewed a
+         commit that is no longer the head, so opening the gate would dispatch
+         expensive reviewers against code the local reviewer has not seen, which
+         is the guarantee this whole item exists to provide.
+
+         **Reusing that token rather than minting one is load-bearing.**
+         `head_moved_during_run` already has two contracts attached to it:
+         `reviewer_loop_history_entries_count` excludes entries carrying it from
+         the qualifying set, so the round is not counted as a cycle, and
+         Protocol 91 treats it as nothing-to-fix rather than dispatching a fixer.
+         Both are exactly right here — the head moved, there is nothing for a
+         fixer to do, and the round should not spend a cycle. A new token would
+         inherit neither: it would fall through to a fixer dispatch with nothing
+         to fix, and consume a cycle for a round that did no review work.
+
+         The finer detail — that the move happened during the *pass* rather than
+         anywhere in the run — is carried by this item's own key as
+         `LOCAL_SECOND_PASS_REASON=head_moved_during_pass`. Telemetry gets the
+         distinction; the loop's contract keeps its established vocabulary.
 
          **This is the one place the plan takes a second head snapshot, and the
          exception is narrow by construction.** #1648's rule is that every
@@ -460,8 +476,15 @@ Order step 0.
    pass; neither is `not_required`.
 3a. A head that moves **during** the pass refuses: with the pull request's head
    changing between the dispatch and its return, a clean pass does **not** open
-   the gate; the cycle ends with `needs_fixes` and reason
-   `head_moved_during_pass`, and no ready-phase platform is dispatched. Without
+   the gate; the cycle ends with `needs_fixes` and the loop's existing reason
+   `head_moved_during_run`, and no ready-phase platform is dispatched.
+3b. That round is **not counted and not sent to a fixer**: the ledger entry
+   carrying `head_moved_during_run` is excluded from the qualifying set by
+   `reviewer_loop_history_entries_count`, and Protocol 91 treats the reason as
+   nothing-to-fix. A newly minted token would inherit neither behaviour —
+   consuming a cycle and dispatching a fixer with nothing to fix — which is why
+   the loop's `REASON` reuses the established value while
+   `LOCAL_SECOND_PASS_REASON` keeps the finer `head_moved_during_pass`. Without
    this, a clean verdict for the old commit opens the gate for reviewers that
    then read code the local reviewer never saw — the failure the item exists to
    prevent, arriving through the item's own success path.
@@ -579,6 +602,7 @@ Order step 0.
 | A failed pass converts the pull request anyway | Med | Med — the pull request is left ready with no reviewer dispatched, a state the loop never intended | The cycle ends before the gate. Scenario 7 asserts all three consequences; proof **P4** converts first |
 | The extraction changes the ordinary path | Med — it touches the busiest block in the script | **High** — every run's output shifts, and the cause is a refactor nobody was reviewing for behaviour | Byte-identical output required for a run needing no pass, in its own commit so the diff is readable. Scenario 5a and proof **P8** |
 | The head moves while the pass is running | Med — the pass takes as long as a review | **High** — a clean verdict for the old commit opens the gate, and expensive reviewers read code the local reviewer never saw: the item's guarantee broken on its own success path | One head re-read immediately before the gate, used only for an equality test and only to refuse. Scenario 3a and proof **P13** |
+| The refusal mints a new reason token | **High** — a precise new name is the natural choice | Med — the round is counted as a cycle and a fixer is dispatched with nothing to fix, because two existing contracts key on `head_moved_during_run` | The loop's `REASON` reuses the established token; the finer detail lives in `LOCAL_SECOND_PASS_REASON`. Scenario 3b and proof **P14** |
 | The condition receives the invocation's platform list | **High** — `platforms` is in scope and looks right | **High** — an explicit `--platform` run omitting a configured reviewer reports `no_local_reviewer` and proceeds, which is the item's motivating case turned into a fail-open | The repository's configured list is resolved independently of `--platform`, by its own helper. Scenario 2b and proof **P11** |
 | The condition ignores the current round | **High** — the persisted payload is the obvious input | Med — every ordinary run dispatches the local reviewer twice, and the guard becomes a tax on the path it was meant to leave alone | The round's in-memory results are composed in first, using #1651's helper. Scenarios 4 and 5b, proof **P7** |
 | The guard runs when there is no gate to protect | Med | Low — doubles the local reviewer's cost on every draft-only run | No-op when `phase_after_clean_enabled` is 0. Scenario 13 and proof **P5** |
@@ -631,13 +655,13 @@ reviewer_loop_local_pass_required() {
 ## Planted-Violation Proofs
 
 `REVIEW.md` → Core Rules → Verification Discipline requires two demonstrated
-runs per proof, each citing a concrete file and line. The thirteen proofs fall into
+runs per proof, each citing a concrete file and line. The fourteen proofs fall into
 three groups:
 
 | Group | Count | Proofs | What the plant reproduces |
 | --- | --- | --- | --- |
 | Fail-open | **6** | P2, P4, P6, P10, P11, P13 | the gate reached, or the pull request converted, without the evidence |
-| Loop and cost | **4** | P1, P3, P5, P12 | a guard that repeats, shortens the run, or runs where there is nothing to guard |
+| Loop and cost | **5** | P1, P3, P5, P12, P14 | a guard that repeats, shortens the run, or runs where there is nothing to guard |
 | Integration | **3** | P7, P8, P9 | a guard wired in beside the pipeline rather than into it |
 
 | # | Violation to plant | Where | Check that must fail, then pass |
@@ -647,6 +671,7 @@ three groups:
 | P9 | Hold the failed head in a shell variable instead of the ledger | a scratch copy of the guard | scenario 8c fails: the invocation after a failed pass starts with an empty variable, sees the same non-clean verdict, and dispatches again — one dispatch per invocation forever on a pull request whose reviewer never goes clean. Scenario 8's within-run count still passes, because a variable survives a run; only crossing an invocation separates them; restoring the ledger field passes |
 | P8 | Call `run_platform_review` from the guard without processing its output | a scratch copy of the dispatch block | scenario 5's ledger assertion fails: the pass runs, its verdict decides the gate, and it appears in no ledger entry and no `key=value` output — so the telemetry says the gate opened with no evidence of what opened it. The gate behaviour is still correct, which is what makes this the plant a hurried extraction invites; restoring the shared processor passes |
 | P6 | Make the flag suppress the dispatch without refusing the gate | same scratch copy | scenario 8a fails: the cycle after a failed pass reaches the gate with no current clean evidence, because the condition still owes a pass and nothing runs — a fail-open created by the anti-loop mechanism itself. Scenario 8's dispatch count still passes, which is what makes this the plant a two-way guard invites; restoring the refusal passes both |
+| P14 | Report the mid-pass move with a new `head_moved_during_run`-style token of its own | a scratch copy of the refusal | scenario 3b fails: the round is counted as a cycle and Protocol 91 dispatches a fixer for a head move, which has nothing to fix. Scenario 3a passes, because the gate still closes — the plant only breaks the two contracts attached to the established token, neither of which is visible from the refusal itself; restoring `head_moved_during_run` passes both |
 | P13 | Open the gate on a clean pass without re-reading the head | a scratch copy of the guard | scenario 3a fails: the head moves during the pass, the clean verdict for the old commit opens the gate, and ready-phase reviewers read code the local reviewer never saw — the exact guarantee this item exists to provide, broken on its own success path. Every scenario with a stable head passes, which is all of the others, and the loop's end-of-run head-move check cannot help because it fires after the dispatch; restoring the re-read passes |
 | P12 | Refuse with `needs_fixes` instead of `escalate` | same scratch copy | scenario 10a fails: the lifetime cap counts `unique` `head_sha\|result` pairs and `CYCLE_COUNT` resets each invocation, so an unchanged head refuses forever with neither cap advancing — the boundedness the plan claims would be asserted and untrue. Scenario 8a's single-refusal assertion still passes, which is why 10a runs a **second** invocation; restoring `escalate` passes both |
 | P2 | Return `not_required` when the history names no local verdict | same scratch copy | scenario 2 fails: a pull request the local reviewer never examined reaches the gate and its ready-phase reviewers run, which is the fail-open this item exists to close. Every other scenario passes, because they all supply a verdict; restoring `no_evidence` passes |
@@ -686,7 +711,7 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    recording in the ledger the head a pass **failed** on, before
    `ensure_pr_ready_for_ready_phase`, and compose the current round into the
    payload before evaluating the condition. **Verify**: scenarios 4, 5, 5b, 6,
-   3a, 7, 8, 8a, 8b and 8c — the dispatch count across cycles, all three consequences of a failed
+   3a, 3b, 7, 8, 8a, 8b and 8c — the dispatch count across cycles, all three consequences of a failed
    pass, the refusal on the next cycle at the same head, and the `not_required`
    path after a clean pass.
 3. Confirm the caps are untouched and that the refusal terminates without one.
@@ -699,7 +724,7 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    `changelog.d/1656.changed.second-local-pass.md`. **Verify**: runbook **Step
    10**, which reads both surfaces and the fragment against each other — Step 8
    is the no-gate/no-guard case.
-7. Produce the thirteen planted-violation proofs (P1-P13) and record them in the PR
+7. Produce the fourteen planted-violation proofs (P1-P14) and record them in the PR
    with the command, file, line and both outcomes for each.
 
 ---

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -275,9 +275,39 @@ Not applicable — this repository ships workflow tooling, not a service.
          check, which fires *after* the dispatch it would need to prevent.
          Detecting the race requires looking at the moment before the gate
          opens, which is here.
-      4. If it is anything else, end the cycle with that result — the same
-         `needs_fixes` / `escalate` path a first-pass finding takes — and do
-         **not** convert the pull request to ready.
+      4. If it is anything other than **clean**, do **not** convert the pull
+         request to ready. The pass's result decides how the cycle ends, and
+         "anything else" is not specific enough — the shared processor
+         normalises some results toward the aggregate in ways that would open
+         the gate. The mapping is total over what the local reviewer can
+         return:
+
+         | Pass result | Cycle ends as | Why |
+         | --- | --- | --- |
+         | `clean` | proceeds to the gate | the evidence exists |
+         | `needs_fixes` | `needs_fixes` | a finding; the fixer path, as a first-pass finding takes |
+         | `escalate` | `escalate` | the reviewer could not complete |
+         | `skipped` — any reason, including `unavailable` and `not_configured` | **`escalate`**, reason `local_pass_unavailable` | see below |
+         | `needs_rerun` | `escalate`, reason `local_pass_unavailable` | a rerun the guard cannot itself perform without reopening the loop it closed |
+         | anything else, or unparseable | `escalate`, reason `local_pass_unavailable` | an unrecognised result is not evidence |
+
+         **The `skipped` row is the one that inverts.** The shared processor
+         treats a skipped platform as not blocking — correct for an ordinary
+         platform, and wrong here: the guard dispatched this pass *because* the
+         gate needs evidence, and a skipped pass produced none. Letting it fall
+         through to the aggregate would open the gate on the strength of a
+         review that did not happen, which is the fail-open this item exists to
+         close, arriving through the machinery the guard borrows.
+
+         So the guard reads the pass's own result **before** the shared
+         processor's aggregate contribution and overrides it: every non-clean
+         result closes the gate. The processor still parses, records and
+         forwards the pass exactly as it does any platform — only the gate
+         decision is the guard's.
+
+         `escalate` rather than `needs_fixes` for the last three rows: none of
+         them describes something a fixer can fix, and each would otherwise
+         invite an automated retry of a dispatch that produced no verdict.
 
       Step 4 is what makes the guard worth having: a ready-phase reviewer is not
       merely delayed, and the pull request is not converted, so the expensive
@@ -365,7 +395,7 @@ Not applicable — this repository ships workflow tooling, not a service.
 
       ```text
       LOCAL_SECOND_PASS=0|1
-      LOCAL_SECOND_PASS_REASON=not_required|head_changed|prior_findings|no_evidence|no_local_reviewer|failed_for_head|head_moved_during_pass
+      LOCAL_SECOND_PASS_REASON=not_required|head_changed|prior_findings|no_evidence|no_local_reviewer|failed_for_head|head_moved_during_pass|local_pass_unavailable
       ```
 
       `failed_for_head` is the refusal row — the pass did not run **and** the
@@ -392,8 +422,8 @@ Not applicable — this repository ships workflow tooling, not a service.
 
 ### Infrastructure / Configuration
 
-- [ ] Document both keys and **all seven** reasons — the five conditions plus
-      `head_moved_during_pass` and
+- [ ] Document both keys and **all eight** reasons — the five conditions plus
+      `head_moved_during_pass`, `local_pass_unavailable` and
       `failed_for_head` — in the `--help` block and in Protocol 93. The two
       easiest to omit are the ones that report neither a satisfied nor a
       repaired gate: `failed_for_head`, a **blocked** one, and
@@ -507,7 +537,17 @@ Order step 0.
 6. A **clean** second pass proceeds to the gate and the pull request is
    converted to ready.
 7. A **needs_fixes** second pass ends the cycle with `needs_fixes`, does **not**
-   convert the pull request, and dispatches no ready-phase platform. Asserted on
+   convert the pull request, and dispatches no ready-phase platform.
+7a. Every **non-clean** pass result closes the gate, one case per row of the
+   mapping: `needs_fixes`, `escalate`, `skipped` with reason `unavailable`,
+   `skipped` with reason `not_configured`, `skipped` with any other reason,
+   `needs_rerun`, and an unparseable result. None converts the pull request and
+   none dispatches a ready-phase platform.
+7b. The `skipped` rows specifically: the shared processor treats a skipped
+   platform as not blocking, so without the guard's override a skipped pass
+   would open the gate on a review that did not happen. Asserted through the
+   real processor rather than a stub, because the inversion lives in what the
+   processor does with the result, not in what the guard reads. Asserted on
    all three, because converting-but-not-dispatching would leave the pull
    request in a state the loop did not intend.
 8. The guard dispatches **at most once per head**: two cycles with no new
@@ -580,8 +620,9 @@ Order step 0.
 ## Documentation Updates
 
 - `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
-  — the guard, all **seven** reasons including `no_local_reviewer`,
-  `failed_for_head` and `head_moved_during_pass`, the two keys,
+  — the guard, all **eight** reasons including `no_local_reviewer`,
+  `failed_for_head`, `head_moved_during_pass` and `local_pass_unavailable`, the
+  two keys,
   and the `local_second_pass_failed_head` ledger field.
 - The `--help` block of `pr-review-loop.sh`.
 - `changelog.d/1656.changed.second-local-pass.md` — `changed` rather than
@@ -601,6 +642,7 @@ Order step 0.
 | The pass increments a cycle cap | Med | Med — every run needing a pass gets a shorter budget, and `max_cycles_exceeded` starts meaning two different things | The pass is a dispatch inside an already-counted cycle. Scenarios 9 and 10; proof **P3** increments |
 | A failed pass converts the pull request anyway | Med | Med — the pull request is left ready with no reviewer dispatched, a state the loop never intended | The cycle ends before the gate. Scenario 7 asserts all three consequences; proof **P4** converts first |
 | The extraction changes the ordinary path | Med — it touches the busiest block in the script | **High** — every run's output shifts, and the cause is a refactor nobody was reviewing for behaviour | Byte-identical output required for a run needing no pass, in its own commit so the diff is readable. Scenario 5a and proof **P8** |
+| A skipped or unparseable pass opens the gate | **High** — the shared processor treats skipped as not blocking, which is right for a platform and wrong for this pass | **High** — the gate opens on a review that did not happen, through the machinery the guard borrows | Every non-clean result closes the gate, by an override the guard applies before the aggregate. Scenarios 7a and 7b, proof **P15** |
 | The head moves while the pass is running | Med — the pass takes as long as a review | **High** — a clean verdict for the old commit opens the gate, and expensive reviewers read code the local reviewer never saw: the item's guarantee broken on its own success path | One head re-read immediately before the gate, used only for an equality test and only to refuse. Scenario 3a and proof **P13** |
 | The refusal mints a new reason token | **High** — a precise new name is the natural choice | Med — the round is counted as a cycle and a fixer is dispatched with nothing to fix, because two existing contracts key on `head_moved_during_run` | The loop's `REASON` reuses the established token; the finer detail lives in `LOCAL_SECOND_PASS_REASON`. Scenario 3b and proof **P14** |
 | The condition receives the invocation's platform list | **High** — `platforms` is in scope and looks right | **High** — an explicit `--platform` run omitting a configured reviewer reports `no_local_reviewer` and proceeds, which is the item's motivating case turned into a fail-open | The repository's configured list is resolved independently of `--platform`, by its own helper. Scenario 2b and proof **P11** |
@@ -655,12 +697,12 @@ reviewer_loop_local_pass_required() {
 ## Planted-Violation Proofs
 
 `REVIEW.md` → Core Rules → Verification Discipline requires two demonstrated
-runs per proof, each citing a concrete file and line. The fourteen proofs fall into
+runs per proof, each citing a concrete file and line. The fifteen proofs fall into
 three groups:
 
 | Group | Count | Proofs | What the plant reproduces |
 | --- | --- | --- | --- |
-| Fail-open | **6** | P2, P4, P6, P10, P11, P13 | the gate reached, or the pull request converted, without the evidence |
+| Fail-open | **7** | P2, P4, P6, P10, P11, P13, P15 | the gate reached, or the pull request converted, without the evidence |
 | Loop and cost | **5** | P1, P3, P5, P12, P14 | a guard that repeats, shortens the run, or runs where there is nothing to guard |
 | Integration | **3** | P7, P8, P9 | a guard wired in beside the pipeline rather than into it |
 
@@ -671,6 +713,7 @@ three groups:
 | P9 | Hold the failed head in a shell variable instead of the ledger | a scratch copy of the guard | scenario 8c fails: the invocation after a failed pass starts with an empty variable, sees the same non-clean verdict, and dispatches again — one dispatch per invocation forever on a pull request whose reviewer never goes clean. Scenario 8's within-run count still passes, because a variable survives a run; only crossing an invocation separates them; restoring the ledger field passes |
 | P8 | Call `run_platform_review` from the guard without processing its output | a scratch copy of the dispatch block | scenario 5's ledger assertion fails: the pass runs, its verdict decides the gate, and it appears in no ledger entry and no `key=value` output — so the telemetry says the gate opened with no evidence of what opened it. The gate behaviour is still correct, which is what makes this the plant a hurried extraction invites; restoring the shared processor passes |
 | P6 | Make the flag suppress the dispatch without refusing the gate | same scratch copy | scenario 8a fails: the cycle after a failed pass reaches the gate with no current clean evidence, because the condition still owes a pass and nothing runs — a fail-open created by the anti-loop mechanism itself. Scenario 8's dispatch count still passes, which is what makes this the plant a two-way guard invites; restoring the refusal passes both |
+| P15 | Let the pass's result reach the aggregate without overriding the gate decision | a scratch copy of the guard | scenario 7b fails: a `skipped` pass — which the shared processor treats as not blocking — opens the ready-phase gate on a review that did not happen, the fail-open this item exists to close, arriving through the machinery the guard borrows. Scenario 7's `needs_fixes` case still passes, because that result blocks on its own; restoring the override passes both |
 | P14 | Report the mid-pass move with a new `head_moved_during_run`-style token of its own | a scratch copy of the refusal | scenario 3b fails: the round is counted as a cycle and Protocol 91 dispatches a fixer for a head move, which has nothing to fix. Scenario 3a passes, because the gate still closes — the plant only breaks the two contracts attached to the established token, neither of which is visible from the refusal itself; restoring `head_moved_during_run` passes both |
 | P13 | Open the gate on a clean pass without re-reading the head | a scratch copy of the guard | scenario 3a fails: the head moves during the pass, the clean verdict for the old commit opens the gate, and ready-phase reviewers read code the local reviewer never saw — the exact guarantee this item exists to provide, broken on its own success path. Every scenario with a stable head passes, which is all of the others, and the loop's end-of-run head-move check cannot help because it fires after the dispatch; restoring the re-read passes |
 | P12 | Refuse with `needs_fixes` instead of `escalate` | same scratch copy | scenario 10a fails: the lifetime cap counts `unique` `head_sha\|result` pairs and `CYCLE_COUNT` resets each invocation, so an unchanged head refuses forever with neither cap advancing — the boundedness the plan claims would be asserted and untrue. Scenario 8a's single-refusal assertion still passes, which is why 10a runs a **second** invocation; restoring `escalate` passes both |
@@ -681,7 +724,7 @@ three groups:
 | P4 | Call `ensure_pr_ready_for_ready_phase` before checking the pass's result | same scratch copy | scenario 7 fails on its conversion assertion: a failed pass leaves the pull request converted to ready with no reviewer dispatched — a state the loop never intended and a human has to undo. The `needs_fixes` result is still reported, so a test asserting only the result passes; restoring the order passes |
 | P5 | Run the guard even when no ready-phase platform is configured | same scratch copy | scenario 13 fails: every draft-only run dispatches the local reviewer twice, doubling the cost of the cheapest gate for no benefit — the pass exists to protect a gate that is not there; restoring the no-op passes |
 
-Six proofs plant the fail-open direction, and P2 is the one to read twice: it is
+Seven proofs plant the fail-open direction, and P2 is the one to read twice: it is
 the natural default, it passes every scenario that supplies a verdict, and the
 pull requests it lets through are exactly the ones nobody reviewed locally.
 
@@ -711,7 +754,7 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    recording in the ledger the head a pass **failed** on, before
    `ensure_pr_ready_for_ready_phase`, and compose the current round into the
    payload before evaluating the condition. **Verify**: scenarios 4, 5, 5b, 6,
-   3a, 3b, 7, 8, 8a, 8b and 8c — the dispatch count across cycles, all three consequences of a failed
+   3a, 3b, 7, 7a, 7b, 8, 8a, 8b and 8c — the dispatch count across cycles, all three consequences of a failed
    pass, the refusal on the next cycle at the same head, and the `not_required`
    path after a clean pass.
 3. Confirm the caps are untouched and that the refusal terminates without one.
@@ -724,7 +767,7 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    `changelog.d/1656.changed.second-local-pass.md`. **Verify**: runbook **Step
    10**, which reads both surfaces and the fragment against each other — Step 8
    is the no-gate/no-guard case.
-7. Produce the fourteen planted-violation proofs (P1-P14) and record them in the PR
+7. Produce the fifteen planted-violation proofs (P1-P15) and record them in the PR
    with the command, file, line and both outcomes for each.
 
 ---

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -78,6 +78,7 @@ code but not the same lines, and this plan records the boundary in
 | The pre-dispatch head snapshot exists | `sed -n '8515,8519p' scripts/development-workflow/pr-review-loop.sh` | `loop_head_sha` is captured from `gh pr view --json headRefOid` before any reviewer runs, and is the value #1648 classifies against. The guard compares to it and takes no new snapshot |
 | Two caps already bound the run | `sed -n '7174,7195p' scripts/development-workflow/pr-review-loop.sh` | A per-run cap (`CYCLE_COUNT` / `MAX_CYCLES`, default 10) and a lifetime cap (`TOTAL_CYCLE_COUNT` / `MAX_TOTAL_CYCLES`) from the #1502 dual-cap work. The guard is bounded by them and adds no third counter |
 | The platform list is filtered before the loop | `sed -n '674,704p' scripts/development-workflow/pr-review-loop.sh` | `filter_phase_after_clean_platforms` removes configured ready-phase platforms absent from this invocation. An invocation can therefore contain ready-phase platforms and **no** local reviewer, which is the first of the Summary's three cases |
+| The configuration is not read when `--platform` is given | `sed -n '8330,8342p' scripts/development-workflow/pr-review-loop.sh` | `workflow_config_review_platforms` is consulted only when the platform list is otherwise empty. So the invocation's `platforms` array cannot answer *is this reviewer configured for the repository* — the guard resolves that separately |
 
 **What this log does not establish.** It does not show how often a ready-phase
 reviewer has run on a head the local reviewer never saw. The loop does not
@@ -172,6 +173,24 @@ Not applicable — this repository ships workflow tooling, not a service.
 
       Conflating the two rows is what an implementer would otherwise have to
       invent behavior for: a dispatch of a reviewer that does not exist.
+
+      **The list the condition receives must be the repository's, not the
+      invocation's**, and this is the part most easily got wrong. The loop's
+      `platforms` array is invocation-filtered, and `pr-review-loop.sh` skips
+      `workflow_config_review_platforms` entirely when explicit `--platform`
+      arguments are supplied — so passing `platforms` would report
+      `not_configured` for a reviewer that **is** configured and merely omitted
+      from this run. That is the motivating case of this whole item, and it
+      would proceed without a pass: a fail-open produced by the very argument
+      added to prevent one.
+
+      So the guard resolves its own input. Add
+      `reviewer_loop_repo_configured_platforms`, which reads
+      `workflow_config_review_platforms` from the configuration file
+      **unconditionally**, independent of `--platform`, and caches the result
+      for the run. The condition receives that value and never the `platforms`
+      array. Scenario 2b pins it with an explicit `--platform` invocation that
+      omits a configured local reviewer.
 
       The five values are distinct rather than a boolean because they are
       reported, and a reader wanting to know *why* a pass ran cannot recover it
@@ -355,6 +374,12 @@ Order step 0.
    local reviewer **while the reviewer is configured** — not `not_required`.
    Silence is not satisfaction, and this is the value an invocation whose
    `--platform` list omits a configured reviewer produces.
+2b. An explicit `--platform` invocation that **omits** a configured local
+   reviewer returns `no_evidence` and owes a pass — not `no_local_reviewer`.
+   The condition reads the repository's configured list, resolved
+   independently, and never the invocation-filtered `platforms` array, which is
+   empty of the reviewer in exactly this case. This is the item's motivating
+   scenario, and passing the wrong list turns it into a fail-open.
 2a. `no_local_reviewer` is returned when the reviewer is **not configured for
    the repository**, and the guard **proceeds** without dispatching. Asserted as
    a distinct value from both `no_evidence` and `not_required`: the first would
@@ -468,6 +493,7 @@ Order step 0.
 | The pass increments a cycle cap | Med | Med — every run needing a pass gets a shorter budget, and `max_cycles_exceeded` starts meaning two different things | The pass is a dispatch inside an already-counted cycle. Scenarios 9 and 10; proof **P3** increments |
 | A failed pass converts the pull request anyway | Med | Med — the pull request is left ready with no reviewer dispatched, a state the loop never intended | The cycle ends before the gate. Scenario 7 asserts all three consequences; proof **P4** converts first |
 | The extraction changes the ordinary path | Med — it touches the busiest block in the script | **High** — every run's output shifts, and the cause is a refactor nobody was reviewing for behaviour | Byte-identical output required for a run needing no pass, in its own commit so the diff is readable. Scenario 5a and proof **P8** |
+| The condition receives the invocation's platform list | **High** — `platforms` is in scope and looks right | **High** — an explicit `--platform` run omitting a configured reviewer reports `no_local_reviewer` and proceeds, which is the item's motivating case turned into a fail-open | The repository's configured list is resolved independently of `--platform`, by its own helper. Scenario 2b and proof **P11** |
 | The condition ignores the current round | **High** — the persisted payload is the obvious input | Med — every ordinary run dispatches the local reviewer twice, and the guard becomes a tax on the path it was meant to leave alone | The round's in-memory results are composed in first, using #1651's helper. Scenarios 4 and 5b, proof **P7** |
 | The guard runs when there is no gate to protect | Med | Low — doubles the local reviewer's cost on every draft-only run | No-op when `phase_after_clean_enabled` is 0. Scenario 13 and proof **P5** |
 | This item and #1649 are implemented as one refusal | Med | **High** — the loop can never advance past a local finding, because the evidence that would clear the refusal is the dispatch the refusal prevents | The order is stated in **Interaction with #1649** and enforced by Implementation Order step 0 |
@@ -518,12 +544,12 @@ reviewer_loop_local_pass_required() {
 ## Planted-Violation Proofs
 
 `REVIEW.md` → Core Rules → Verification Discipline requires two demonstrated
-runs per proof, each citing a concrete file and line. The ten proofs fall into
+runs per proof, each citing a concrete file and line. The eleven proofs fall into
 three groups:
 
 | Group | Count | Proofs | What the plant reproduces |
 | --- | --- | --- | --- |
-| Fail-open | **4** | P2, P4, P6, P10 | the gate reached, or the pull request converted, without the evidence |
+| Fail-open | **5** | P2, P4, P6, P10, P11 | the gate reached, or the pull request converted, without the evidence |
 | Loop and cost | **3** | P1, P3, P5 | a guard that repeats, shortens the run, or runs where there is nothing to guard |
 | Integration | **3** | P7, P8, P9 | a guard wired in beside the pipeline rather than into it |
 
@@ -535,12 +561,13 @@ three groups:
 | P8 | Call `run_platform_review` from the guard without processing its output | a scratch copy of the dispatch block | scenario 5's ledger assertion fails: the pass runs, its verdict decides the gate, and it appears in no ledger entry and no `key=value` output — so the telemetry says the gate opened with no evidence of what opened it. The gate behaviour is still correct, which is what makes this the plant a hurried extraction invites; restoring the shared processor passes |
 | P6 | Make the flag suppress the dispatch without refusing the gate | same scratch copy | scenario 8a fails: the cycle after a failed pass reaches the gate with no current clean evidence, because the condition still owes a pass and nothing runs — a fail-open created by the anti-loop mechanism itself. Scenario 8's dispatch count still passes, which is what makes this the plant a two-way guard invites; restoring the refusal passes both |
 | P2 | Return `not_required` when the history names no local verdict | same scratch copy | scenario 2 fails: a pull request the local reviewer never examined reaches the gate and its ready-phase reviewers run, which is the fail-open this item exists to close. Every other scenario passes, because they all supply a verdict; restoring `no_evidence` passes |
+| P11 | Pass the invocation's `platforms` array to the condition instead of the repository's configured list | a scratch copy of the guard's call site | scenario 2b fails: an explicit `--platform` run that omits a configured local reviewer reports `no_local_reviewer` and proceeds without a pass — the item's motivating case, turned into a fail-open by the argument added to prevent one. Every scenario that runs without `--platform` passes, because there the two lists coincide; restoring the independent resolution passes |
 | P10 | Fold `not_configured` into `no_evidence` | same scratch copy | scenario 2a fails: a repository with no local reviewer configured owes a pass that cannot be dispatched, so either the guard blocks its ready-phase gate forever or an implementer invents a fallback the plan never specified. Scenario 2 passes, because a configured-but-silent reviewer is a different input; restoring the fifth value passes both |
 | P3 | Increment `CYCLE_COUNT` when the pass runs | a scratch copy of the dispatch block | scenarios 9 and 10 fail: a run needing a pass reports a different count than an identical run that does not, and `max_cycles_exceeded` arrives earlier — so the guard silently shortens every run it helps; restoring the no-op passes |
 | P4 | Call `ensure_pr_ready_for_ready_phase` before checking the pass's result | same scratch copy | scenario 7 fails on its conversion assertion: a failed pass leaves the pull request converted to ready with no reviewer dispatched — a state the loop never intended and a human has to undo. The `needs_fixes` result is still reported, so a test asserting only the result passes; restoring the order passes |
 | P5 | Run the guard even when no ready-phase platform is configured | same scratch copy | scenario 13 fails: every draft-only run dispatches the local reviewer twice, doubling the cost of the cheapest gate for no benefit — the pass exists to protect a gate that is not there; restoring the no-op passes |
 
-Four proofs plant the fail-open direction, and P2 is the one to read twice: it is
+Five proofs plant the fail-open direction, and P2 is the one to read twice: it is
 the natural default, it passes every scenario that supplies a verdict, and the
 pull requests it lets through are exactly the ones nobody reviewed locally.
 
@@ -553,8 +580,10 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    signature #1651's plan specifies. Then read #1649's implementation — merged
    or in flight — to confirm it is a *check* and not a combined gate. If either
    check fails, stop and revise this plan.
-1. Add `reviewer_loop_local_pass_required`, calling #1651's selector with both
-   of its arguments. **Verify**: scenarios 1, 2, 2a and 3 — all five values,
+1. Add `reviewer_loop_repo_configured_platforms`, reading the configuration
+   unconditionally, and `reviewer_loop_local_pass_required`, calling #1651's
+   selector with both of its arguments and never with the `platforms` array.
+   **Verify**: scenarios 1, 2, 2a, 2b and 3 — all five values,
    `no_evidence` for a silent but configured reviewer, `no_local_reviewer` for
    an unconfigured one, and both head-mismatch shapes.
 1a. Extract the platform loop's inline post-dispatch block into
@@ -577,7 +606,7 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    `changelog.d/1656.changed.second-local-pass.md`. **Verify**: runbook **Step
    10**, which reads both surfaces and the fragment against each other — Step 8
    is the no-gate/no-guard case.
-7. Produce the ten planted-violation proofs (P1-P10) and record them in the PR
+7. Produce the eleven planted-violation proofs (P1-P11) and record them in the PR
    with the command, file, line and both outcomes for each.
 
 ---

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -312,12 +312,18 @@ Not applicable — this repository ships workflow tooling, not a service.
       cycles for platforms, cycles-plus-passes for this one — and would shorten
       every run that needed a pass.
 
-      What the caps still bound is the **run**: a pull request whose local
-      reviewer never goes clean produces **one dispatch for the first head**,
-      then a refusal on every later cycle at that head, until `MAX_CYCLES`
-      escalates the run with `max_cycles_exceeded` — the same escalation and the
-      same cycle count as today, with fewer dispatches than a per-cycle guard
-      would make. Scenarios 8 and 8a pin both halves.
+      What the caps still bound is the **moving-head** case: a pull request
+      whose local reviewer never goes clean while its head keeps changing gets
+      one dispatch per head, and reaches `max_cycles_exceeded` at the same cycle
+      count as today — the guard adds dispatches, not cycles.
+
+      **The unchanged-head case is not bounded by a cap at all, and must not
+      be.** There the guard refuses with `escalate` at the first repeat, which
+      terminates the run by itself. Relying on `MAX_CYCLES` there would not work
+      — the lifetime count is `unique` over `head_sha | result`, so repeated
+      identical entries never advance it — and would be the wrong shape anyway:
+      nothing changes between those cycles, so waiting ten of them to say so
+      helps nobody. Scenarios 8, 8a and 10a pin the three halves.
 
 - [ ] **Report it.** Two `print_kv` lines:
 

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -152,21 +152,32 @@ Not applicable — this repository ships workflow tooling, not a service.
       merely delayed, and the pull request is not converted, so the expensive
       reviewers are not woken at all.
 
-- [ ] **Make repetition impossible, by construction rather than by counting.**
-      A flag, `local_second_pass_done_for_head`, holding the head the pass ran
-      against. The guard runs only when that value differs from
-      `loop_head_sha`, so:
+- [ ] **Make repetition impossible without opening a hole.** A flag,
+      `local_second_pass_failed_for_head`, holding the head a pass ran against
+      **and failed on**. It produces a three-way guard, not a two-way one:
 
-      - it cannot run twice for one head, in one cycle or across cycles;
-      - it *can* run again when the head genuinely moved, which is the case the
-        brief asks for;
-      - it needs no counter of its own, so it cannot drift from the caps.
+      | Condition | Flag matches `loop_head_sha` | Action |
+      | --- | --- | --- |
+      | `not_required` | — | proceed to the gate; no dispatch |
+      | owes a pass | no | **dispatch once**; clean → proceed, otherwise end the cycle and set the flag |
+      | owes a pass | yes | **refuse**: end the cycle with `needs_fixes`, reason `local_pass_failed_for_head`, no dispatch and no conversion |
 
-      **Keying on the head rather than on a per-cycle boolean is the whole
-      anti-loop argument.** A boolean reset each cycle would allow one pass per
-      cycle forever; a head-keyed flag allows one pass per *commit*, and commits
-      only appear when someone pushes. The loop cannot manufacture the condition
-      that lets it run again.
+      **The third row is the one a two-way guard gets wrong**, and it is not a
+      corner case — it is the next cycle after any failed pass. A flag that only
+      suppresses the dispatch leaves the condition still owing a pass, nothing
+      running, and the gate reached with no current clean evidence: a fail-open
+      created by the anti-loop mechanism itself. Refusing instead is
+      deterministic, costs no dispatch, and keeps the guarantee the item exists
+      for.
+
+      A **clean** pass sets no flag and needs none: the verdict it produced is
+      clean on `loop_head_sha`, so the condition itself returns `not_required`
+      on every later cycle. The flag exists only for the failed case.
+
+      Keying on the head rather than on a per-cycle boolean is still the
+      anti-loop argument: at most one *dispatch* per commit, and commits only
+      appear when someone pushes. The loop cannot manufacture the condition that
+      lets it dispatch again.
 
 - [ ] **Leave both cycle caps alone.** The pass does not increment
       `CYCLE_COUNT` or `TOTAL_CYCLE_COUNT`: it is a dispatch within a cycle, as
@@ -176,16 +187,24 @@ Not applicable — this repository ships workflow tooling, not a service.
       every run that needed a pass.
 
       What the caps still bound is the **run**: a pull request whose local
-      reviewer never goes clean produces one pass per cycle until
-      `MAX_CYCLES` escalates the run with `max_cycles_exceeded`, exactly as it
-      does today for a reviewer that never goes clean. Scenario 8 pins that.
+      reviewer never goes clean produces **one dispatch for the first head**,
+      then a refusal on every later cycle at that head, until `MAX_CYCLES`
+      escalates the run with `max_cycles_exceeded` — the same escalation and the
+      same cycle count as today, with fewer dispatches than a per-cycle guard
+      would make. Scenarios 8 and 8a pin both halves.
 
 - [ ] **Report it.** Two `print_kv` lines:
 
       ```text
       LOCAL_SECOND_PASS=0|1
-      LOCAL_SECOND_PASS_REASON=not_required|head_changed|prior_findings|no_evidence
+      LOCAL_SECOND_PASS_REASON=not_required|head_changed|prior_findings|no_evidence|failed_for_head
       ```
+
+      `failed_for_head` is the refusal row — the pass did not run **and** the
+      gate was refused — and it is distinct from `not_required`, where the pass
+      did not run because none was owed. Collapsing the two would make the
+      telemetry unable to tell a satisfied gate from a blocked one, which is the
+      distinction #1657 needs most.
 
       `LOCAL_SECOND_PASS_REASON` is emitted **even when the pass did not run**,
       carrying `not_required`. A key that appears only on the interesting path
@@ -260,15 +279,25 @@ Order step 0.
    convert the pull request, and dispatches no ready-phase platform. Asserted on
    all three, because converting-but-not-dispatching would leave the pull
    request in a state the loop did not intend.
-8. The guard runs **at most once per head**: two cycles with no new commit
-   dispatch it once; a cycle after a new commit dispatches it again. Asserted by
-   counting dispatches, not by reading the flag.
+8. The guard dispatches **at most once per head**: two cycles with no new
+   commit dispatch it once; a cycle after a new commit dispatches it again.
+   Asserted by counting dispatches, not by reading the flag.
+8a. After a **failed** pass, the next cycle at the same head **refuses**: the
+   cycle ends with `needs_fixes` and reason `local_pass_failed_for_head`, no
+   local reviewer is dispatched, and the pull request is not converted. A guard
+   that only suppressed the dispatch would let this cycle reach the gate with no
+   current clean evidence — the fail-open the anti-loop flag would otherwise
+   create.
+8b. After a **clean** pass, later cycles take the `not_required` path with no
+   dispatch and no refusal, because the verdict the pass produced is clean on
+   `loop_head_sha`. The flag is never set for a clean pass and none is needed.
 9. Neither `CYCLE_COUNT` nor `TOTAL_CYCLE_COUNT` changes because a pass ran: two
    runs over identical input, one needing a pass and one not, report the same
    counts.
 10. A pull request whose local reviewer never goes clean escalates with
-    `max_cycles_exceeded` at the same cycle count as today — the guard adds
-    passes, not cycles, so the run is not shortened.
+    `max_cycles_exceeded` at the same cycle count as today, having dispatched
+    the pass **once** and refused on every later cycle at that head — the guard
+    adds no cycles, and after the first head it adds no dispatches either.
 11. `LOCAL_SECOND_PASS_REASON` is emitted on **every** run, including
     `not_required`, and `LOCAL_SECOND_PASS` is `0` there.
 12. Both values reach the ledger entry and the loop summary, and the summary
@@ -316,7 +345,8 @@ Order step 0.
 
 | Risk | Likelihood | Impact | Mitigation |
 | --- | --- | --- | --- |
-| The guard loops — a pass that keeps triggering itself | Med | **High** — a run that never terminates, or one that burns its cycle budget on repeated local reviews | The flag is keyed on the **head**, so a second pass requires a new commit, which the loop cannot manufacture. Scenario 8 counts dispatches across cycles; proof **P1** replaces the key with a per-cycle boolean |
+| The guard loops — a pass that keeps triggering itself | Med | **High** — a run that never terminates, or one that burns its cycle budget on repeated local reviews | The flag is keyed on the **head**, so a second dispatch requires a new commit, which the loop cannot manufacture. Scenario 8 counts dispatches across cycles; proof **P1** replaces the key with a per-cycle boolean |
+| The anti-loop flag creates a fail-open | **High** — a two-way guard is the obvious shape | **High** — the cycle after a failed pass reaches the gate with no current clean evidence, and the mechanism meant to bound the guard is what lets it through | Three-way guard: dispatch, refuse, or proceed. Scenario 8a and proof **P6** |
 | Silence is read as satisfaction | **High** — `not_required` is the natural default for "nothing to compare" | **High** — a pull request the local reviewer never examined passes the gate, which is the exact fail-open this epic exists to close | `no_evidence` owes a pass. Scenario 2 and proof **P2** |
 | The pass increments a cycle cap | Med | Med — every run needing a pass gets a shorter budget, and `max_cycles_exceeded` starts meaning two different things | The pass is a dispatch inside an already-counted cycle. Scenarios 9 and 10; proof **P3** increments |
 | A failed pass converts the pull request anyway | Med | Med — the pull request is left ready with no reviewer dispatched, a state the loop never intended | The cycle ends before the gate. Scenario 7 asserts all three consequences; proof **P4** converts first |
@@ -361,23 +391,24 @@ reviewer_loop_local_pass_required() {
 ## Planted-Violation Proofs
 
 `REVIEW.md` → Core Rules → Verification Discipline requires two demonstrated
-runs per proof, each citing a concrete file and line. The five proofs fall into
+runs per proof, each citing a concrete file and line. The six proofs fall into
 two groups:
 
 | Group | Count | Proofs | What the plant reproduces |
 | --- | --- | --- | --- |
-| Fail-open | **2** | P2, P4 | the gate reached, or the pull request converted, without the evidence |
+| Fail-open | **3** | P2, P4, P6 | the gate reached, or the pull request converted, without the evidence |
 | Loop and cost | **3** | P1, P3, P5 | a guard that repeats, shortens the run, or runs where there is nothing to guard |
 
 | # | Violation to plant | Where | Check that must fail, then pass |
 | --- | --- | --- | --- |
 | P1 | Key the flag on a per-cycle boolean instead of the head | a scratch copy of the guard | scenario 8 fails: two cycles with no new commit dispatch the local reviewer twice, and a pull request whose reviewer never goes clean burns its whole budget on repeated local reviews. The plant looks equivalent — one pass per cycle reads as "at most once" — and only counting dispatches across cycles separates them; restoring the head key passes |
+| P6 | Make the flag suppress the dispatch without refusing the gate | same scratch copy | scenario 8a fails: the cycle after a failed pass reaches the gate with no current clean evidence, because the condition still owes a pass and nothing runs — a fail-open created by the anti-loop mechanism itself. Scenario 8's dispatch count still passes, which is what makes this the plant a two-way guard invites; restoring the refusal passes both |
 | P2 | Return `not_required` when the history names no local verdict | same scratch copy | scenario 2 fails: a pull request the local reviewer never examined reaches the gate and its ready-phase reviewers run, which is the fail-open this item exists to close. Every other scenario passes, because they all supply a verdict; restoring `no_evidence` passes |
 | P3 | Increment `CYCLE_COUNT` when the pass runs | a scratch copy of the dispatch block | scenarios 9 and 10 fail: a run needing a pass reports a different count than an identical run that does not, and `max_cycles_exceeded` arrives earlier — so the guard silently shortens every run it helps; restoring the no-op passes |
 | P4 | Call `ensure_pr_ready_for_ready_phase` before checking the pass's result | same scratch copy | scenario 7 fails on its conversion assertion: a failed pass leaves the pull request converted to ready with no reviewer dispatched — a state the loop never intended and a human has to undo. The `needs_fixes` result is still reported, so a test asserting only the result passes; restoring the order passes |
 | P5 | Run the guard even when no ready-phase platform is configured | same scratch copy | scenario 13 fails: every draft-only run dispatches the local reviewer twice, doubling the cost of the cheapest gate for no benefit — the pass exists to protect a gate that is not there; restoring the no-op passes |
 
-Two proofs plant the fail-open direction, and P2 is the one to read twice: it is
+Three proofs plant the fail-open direction, and P2 is the one to read twice: it is
 the natural default, it passes every scenario that supplies a verdict, and the
 pull requests it lets through are exactly the ones nobody reviewed locally.
 
@@ -390,10 +421,12 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    combined gate. If it is combined, stop and revise this plan.
 1. Add `reviewer_loop_local_pass_required`. **Verify**: scenarios 1, 2 and 3 —
    all four values, `no_evidence` for silence, and both head-mismatch shapes.
-2. Add the head-keyed flag and the dispatch, before
-   `ensure_pr_ready_for_ready_phase`. **Verify**: scenarios 4, 5, 6, 7 and 8 —
-   including the dispatch count across cycles and all three consequences of a
-   failed pass.
+2. Add the three-way guard — dispatch, refuse, or proceed — with the flag
+   holding the head a pass **failed** on, before
+   `ensure_pr_ready_for_ready_phase`. **Verify**: scenarios 4, 5, 6, 7, 8, 8a
+   and 8b — the dispatch count across cycles, all three consequences of a failed
+   pass, the refusal on the next cycle at the same head, and the `not_required`
+   path after a clean pass.
 3. Confirm the caps are untouched. **Verify**: scenarios 9 and 10.
 4. Add the no-op when no ready-phase platform is configured. **Verify**:
    scenario 13.
@@ -401,7 +434,7 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    **Verify**: scenarios 11 and 12.
 6. Update Protocol 93, the `--help` block, and add
    `changelog.d/1656.changed.second-local-pass.md`. **Verify**: runbook Step 8.
-7. Produce the five planted-violation proofs (P1-P5) and record them in the PR
+7. Produce the six planted-violation proofs (P1-P6) and record them in the PR
    with the command, file, line and both outcomes for each.
 
 ---

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -75,7 +75,7 @@ code but not the same lines, and this plan records the boundary in
 | Repo revision | `git rev-parse --short origin/develop-internal-reviewer-effectiveness` | `d55d3e7f` |
 | The ready-phase gate does not consult the local reviewer | `sed -n '8580,8616p' scripts/development-workflow/pr-review-loop.sh` | The gate is `ensure_pr_ready_for_ready_phase "$pr_number"`, whose only job is converting the PR to ready; on success it sets `phase_after_clean_started=1` and dispatch proceeds. Nothing between the two reads any reviewer's result |
 | A blocking result ends the cycle | `sed -n '8736,8750p' scripts/development-workflow/pr-review-loop.sh` | On `needs_fixes` or `escalate` the loop `break`s out of the platform iteration in normal mode, so within a run a later cycle re-dispatches from the top — which is why the gap is not "every run" but the cases enumerated in the Summary |
-| The pre-dispatch head snapshot exists | `sed -n '8515,8519p' scripts/development-workflow/pr-review-loop.sh` | `loop_head_sha` is captured from `gh pr view --json headRefOid` before any reviewer runs, and is the value #1648 classifies against. The guard compares to it and takes no new snapshot |
+| The pre-dispatch head snapshot exists | `sed -n '8515,8519p' scripts/development-workflow/pr-review-loop.sh` | `loop_head_sha` is captured from `gh pr view --json headRefOid` before any reviewer runs, and is the value #1648 classifies against. The guard classifies against it and never re-reads the head for classification; the one extra read it does take is an equality test before the gate, described in Layer-by-Layer |
 | Two caps already bound the run | `sed -n '7174,7195p' scripts/development-workflow/pr-review-loop.sh` | A per-run cap (`CYCLE_COUNT` / `MAX_CYCLES`, default 10) and a lifetime cap (`TOTAL_CYCLE_COUNT` / `MAX_TOTAL_CYCLES`) from the #1502 dual-cap work. The guard adds no third counter |
 | …but neither bounds a repeated identical entry | `sed -n '/^reviewer_loop_history_entries_count()/,/^}/p' scripts/development-workflow/pr-review-loop.sh` | The lifetime count is `unique` over `head_sha \| result`, so repeated `needs_fixes` entries at one head count **once**, and `CYCLE_COUNT` resets each invocation. A refusal reported as `needs_fixes` would therefore repeat indefinitely — which is why the refusal is `escalate` |
 | The platform list is filtered before the loop | `sed -n '674,704p' scripts/development-workflow/pr-review-loop.sh` | `filter_phase_after_clean_platforms` removes configured ready-phase platforms absent from this invocation. An invocation can therefore contain ready-phase platforms and **no** local reviewer, which is the first of the Summary's three cases |
@@ -238,7 +238,27 @@ Not applicable — this repository ships workflow tooling, not a service.
          `key=value` output is byte-identical to the same run before this
          change. An extraction that quietly reorders or drops a key would pass
          every other scenario in this plan.
-      3. If that pass is **clean**, proceed to the gate.
+      3. If that pass is **clean**, re-read the pull request's head once and
+         compare it to `loop_head_sha`. If they match, proceed to the gate. If
+         they differ, end the cycle with `needs_fixes` and reason
+         `head_moved_during_pass` — the pass reviewed a commit that is no longer
+         the head, so opening the gate would dispatch expensive reviewers
+         against code the local reviewer has not seen, which is the guarantee
+         this whole item exists to provide.
+
+         **This is the one place the plan takes a second head snapshot, and the
+         exception is narrow by construction.** #1648's rule is that every
+         *classification* happens against `loop_head_sha` and no renderer
+         re-reads the live head, so that per-reviewer and aggregate evidence
+         cannot disagree. That rule is untouched here: this read classifies
+         nothing. Its only use is the equality test, and its only outcome is a
+         refusal — the evidence recorded for the pass remains attributed to
+         `loop_head_sha`, exactly as #1648 requires.
+
+         It also cannot be replaced by the loop's existing end-of-run head-move
+         check, which fires *after* the dispatch it would need to prevent.
+         Detecting the race requires looking at the moment before the gate
+         opens, which is here.
       4. If it is anything else, end the cycle with that result — the same
          `needs_fixes` / `escalate` path a first-pass finding takes — and do
          **not** convert the pull request to ready.
@@ -329,7 +349,7 @@ Not applicable — this repository ships workflow tooling, not a service.
 
       ```text
       LOCAL_SECOND_PASS=0|1
-      LOCAL_SECOND_PASS_REASON=not_required|head_changed|prior_findings|no_evidence|no_local_reviewer|failed_for_head
+      LOCAL_SECOND_PASS_REASON=not_required|head_changed|prior_findings|no_evidence|no_local_reviewer|failed_for_head|head_moved_during_pass
       ```
 
       `failed_for_head` is the refusal row — the pass did not run **and** the
@@ -356,7 +376,8 @@ Not applicable — this repository ships workflow tooling, not a service.
 
 ### Infrastructure / Configuration
 
-- [ ] Document both keys and **all six** reasons — the five conditions plus
+- [ ] Document both keys and **all seven** reasons — the five conditions plus
+      `head_moved_during_pass` and
       `failed_for_head` — in the `--help` block and in Protocol 93. The two
       easiest to omit are the ones that report neither a satisfied nor a
       repaired gate: `failed_for_head`, a **blocked** one, and
@@ -437,6 +458,13 @@ Order step 0.
    commit that is an **ancestor** of `loop_head_sha` — the ordinary
    fix-was-pushed case — and also when it names an unrelated commit. Both owe a
    pass; neither is `not_required`.
+3a. A head that moves **during** the pass refuses: with the pull request's head
+   changing between the dispatch and its return, a clean pass does **not** open
+   the gate; the cycle ends with `needs_fixes` and reason
+   `head_moved_during_pass`, and no ready-phase platform is dispatched. Without
+   this, a clean verdict for the old commit opens the gate for reviewers that
+   then read code the local reviewer never saw — the failure the item exists to
+   prevent, arriving through the item's own success path.
 4. With `not_required`, the gate is reached with **no** extra dispatch: the
    platform sequence is byte-for-byte what it is today.
 5. With any other value, the local reviewer is dispatched exactly once before
@@ -529,8 +557,8 @@ Order step 0.
 ## Documentation Updates
 
 - `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
-  — the guard, all **six** reasons including `no_local_reviewer` and
-  `failed_for_head`, the two keys,
+  — the guard, all **seven** reasons including `no_local_reviewer`,
+  `failed_for_head` and `head_moved_during_pass`, the two keys,
   and the `local_second_pass_failed_head` ledger field.
 - The `--help` block of `pr-review-loop.sh`.
 - `changelog.d/1656.changed.second-local-pass.md` — `changed` rather than
@@ -550,6 +578,7 @@ Order step 0.
 | The pass increments a cycle cap | Med | Med — every run needing a pass gets a shorter budget, and `max_cycles_exceeded` starts meaning two different things | The pass is a dispatch inside an already-counted cycle. Scenarios 9 and 10; proof **P3** increments |
 | A failed pass converts the pull request anyway | Med | Med — the pull request is left ready with no reviewer dispatched, a state the loop never intended | The cycle ends before the gate. Scenario 7 asserts all three consequences; proof **P4** converts first |
 | The extraction changes the ordinary path | Med — it touches the busiest block in the script | **High** — every run's output shifts, and the cause is a refactor nobody was reviewing for behaviour | Byte-identical output required for a run needing no pass, in its own commit so the diff is readable. Scenario 5a and proof **P8** |
+| The head moves while the pass is running | Med — the pass takes as long as a review | **High** — a clean verdict for the old commit opens the gate, and expensive reviewers read code the local reviewer never saw: the item's guarantee broken on its own success path | One head re-read immediately before the gate, used only for an equality test and only to refuse. Scenario 3a and proof **P13** |
 | The condition receives the invocation's platform list | **High** — `platforms` is in scope and looks right | **High** — an explicit `--platform` run omitting a configured reviewer reports `no_local_reviewer` and proceeds, which is the item's motivating case turned into a fail-open | The repository's configured list is resolved independently of `--platform`, by its own helper. Scenario 2b and proof **P11** |
 | The condition ignores the current round | **High** — the persisted payload is the obvious input | Med — every ordinary run dispatches the local reviewer twice, and the guard becomes a tax on the path it was meant to leave alone | The round's in-memory results are composed in first, using #1651's helper. Scenarios 4 and 5b, proof **P7** |
 | The guard runs when there is no gate to protect | Med | Low — doubles the local reviewer's cost on every draft-only run | No-op when `phase_after_clean_enabled` is 0. Scenario 13 and proof **P5** |
@@ -602,12 +631,12 @@ reviewer_loop_local_pass_required() {
 ## Planted-Violation Proofs
 
 `REVIEW.md` → Core Rules → Verification Discipline requires two demonstrated
-runs per proof, each citing a concrete file and line. The twelve proofs fall into
+runs per proof, each citing a concrete file and line. The thirteen proofs fall into
 three groups:
 
 | Group | Count | Proofs | What the plant reproduces |
 | --- | --- | --- | --- |
-| Fail-open | **5** | P2, P4, P6, P10, P11 | the gate reached, or the pull request converted, without the evidence |
+| Fail-open | **6** | P2, P4, P6, P10, P11, P13 | the gate reached, or the pull request converted, without the evidence |
 | Loop and cost | **4** | P1, P3, P5, P12 | a guard that repeats, shortens the run, or runs where there is nothing to guard |
 | Integration | **3** | P7, P8, P9 | a guard wired in beside the pipeline rather than into it |
 
@@ -618,6 +647,7 @@ three groups:
 | P9 | Hold the failed head in a shell variable instead of the ledger | a scratch copy of the guard | scenario 8c fails: the invocation after a failed pass starts with an empty variable, sees the same non-clean verdict, and dispatches again — one dispatch per invocation forever on a pull request whose reviewer never goes clean. Scenario 8's within-run count still passes, because a variable survives a run; only crossing an invocation separates them; restoring the ledger field passes |
 | P8 | Call `run_platform_review` from the guard without processing its output | a scratch copy of the dispatch block | scenario 5's ledger assertion fails: the pass runs, its verdict decides the gate, and it appears in no ledger entry and no `key=value` output — so the telemetry says the gate opened with no evidence of what opened it. The gate behaviour is still correct, which is what makes this the plant a hurried extraction invites; restoring the shared processor passes |
 | P6 | Make the flag suppress the dispatch without refusing the gate | same scratch copy | scenario 8a fails: the cycle after a failed pass reaches the gate with no current clean evidence, because the condition still owes a pass and nothing runs — a fail-open created by the anti-loop mechanism itself. Scenario 8's dispatch count still passes, which is what makes this the plant a two-way guard invites; restoring the refusal passes both |
+| P13 | Open the gate on a clean pass without re-reading the head | a scratch copy of the guard | scenario 3a fails: the head moves during the pass, the clean verdict for the old commit opens the gate, and ready-phase reviewers read code the local reviewer never saw — the exact guarantee this item exists to provide, broken on its own success path. Every scenario with a stable head passes, which is all of the others, and the loop's end-of-run head-move check cannot help because it fires after the dispatch; restoring the re-read passes |
 | P12 | Refuse with `needs_fixes` instead of `escalate` | same scratch copy | scenario 10a fails: the lifetime cap counts `unique` `head_sha\|result` pairs and `CYCLE_COUNT` resets each invocation, so an unchanged head refuses forever with neither cap advancing — the boundedness the plan claims would be asserted and untrue. Scenario 8a's single-refusal assertion still passes, which is why 10a runs a **second** invocation; restoring `escalate` passes both |
 | P2 | Return `not_required` when the history names no local verdict | same scratch copy | scenario 2 fails: a pull request the local reviewer never examined reaches the gate and its ready-phase reviewers run, which is the fail-open this item exists to close. Every other scenario passes, because they all supply a verdict; restoring `no_evidence` passes |
 | P11 | Pass the invocation's `platforms` array to the condition instead of the repository's configured list | a scratch copy of the guard's call site | scenario 2b fails: an explicit `--platform` run that omits a configured local reviewer reports `no_local_reviewer` and proceeds without a pass — the item's motivating case, turned into a fail-open by the argument added to prevent one. Every scenario that runs without `--platform` passes, because there the two lists coincide; restoring the independent resolution passes |
@@ -626,7 +656,7 @@ three groups:
 | P4 | Call `ensure_pr_ready_for_ready_phase` before checking the pass's result | same scratch copy | scenario 7 fails on its conversion assertion: a failed pass leaves the pull request converted to ready with no reviewer dispatched — a state the loop never intended and a human has to undo. The `needs_fixes` result is still reported, so a test asserting only the result passes; restoring the order passes |
 | P5 | Run the guard even when no ready-phase platform is configured | same scratch copy | scenario 13 fails: every draft-only run dispatches the local reviewer twice, doubling the cost of the cheapest gate for no benefit — the pass exists to protect a gate that is not there; restoring the no-op passes |
 
-Five proofs plant the fail-open direction, and P2 is the one to read twice: it is
+Six proofs plant the fail-open direction, and P2 is the one to read twice: it is
 the natural default, it passes every scenario that supplies a verdict, and the
 pull requests it lets through are exactly the ones nobody reviewed locally.
 
@@ -656,7 +686,7 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    recording in the ledger the head a pass **failed** on, before
    `ensure_pr_ready_for_ready_phase`, and compose the current round into the
    payload before evaluating the condition. **Verify**: scenarios 4, 5, 5b, 6,
-   7, 8, 8a, 8b and 8c — the dispatch count across cycles, all three consequences of a failed
+   3a, 7, 8, 8a, 8b and 8c — the dispatch count across cycles, all three consequences of a failed
    pass, the refusal on the next cycle at the same head, and the `not_required`
    path after a clean pass.
 3. Confirm the caps are untouched and that the refusal terminates without one.
@@ -669,7 +699,7 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    `changelog.d/1656.changed.second-local-pass.md`. **Verify**: runbook **Step
    10**, which reads both surfaces and the fragment against each other — Step 8
    is the no-gate/no-guard case.
-7. Produce the twelve planted-violation proofs (P1-P12) and record them in the PR
+7. Produce the thirteen planted-violation proofs (P1-P13) and record them in the PR
    with the command, file, line and both outcomes for each.
 
 ---

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -76,7 +76,8 @@ code but not the same lines, and this plan records the boundary in
 | The ready-phase gate does not consult the local reviewer | `sed -n '8580,8616p' scripts/development-workflow/pr-review-loop.sh` | The gate is `ensure_pr_ready_for_ready_phase "$pr_number"`, whose only job is converting the PR to ready; on success it sets `phase_after_clean_started=1` and dispatch proceeds. Nothing between the two reads any reviewer's result |
 | A blocking result ends the cycle | `sed -n '8736,8750p' scripts/development-workflow/pr-review-loop.sh` | On `needs_fixes` or `escalate` the loop `break`s out of the platform iteration in normal mode, so within a run a later cycle re-dispatches from the top — which is why the gap is not "every run" but the cases enumerated in the Summary |
 | The pre-dispatch head snapshot exists | `sed -n '8515,8519p' scripts/development-workflow/pr-review-loop.sh` | `loop_head_sha` is captured from `gh pr view --json headRefOid` before any reviewer runs, and is the value #1648 classifies against. The guard compares to it and takes no new snapshot |
-| Two caps already bound the run | `sed -n '7174,7195p' scripts/development-workflow/pr-review-loop.sh` | A per-run cap (`CYCLE_COUNT` / `MAX_CYCLES`, default 10) and a lifetime cap (`TOTAL_CYCLE_COUNT` / `MAX_TOTAL_CYCLES`) from the #1502 dual-cap work. The guard is bounded by them and adds no third counter |
+| Two caps already bound the run | `sed -n '7174,7195p' scripts/development-workflow/pr-review-loop.sh` | A per-run cap (`CYCLE_COUNT` / `MAX_CYCLES`, default 10) and a lifetime cap (`TOTAL_CYCLE_COUNT` / `MAX_TOTAL_CYCLES`) from the #1502 dual-cap work. The guard adds no third counter |
+| …but neither bounds a repeated identical entry | `sed -n '/^reviewer_loop_history_entries_count()/,/^}/p' scripts/development-workflow/pr-review-loop.sh` | The lifetime count is `unique` over `head_sha \| result`, so repeated `needs_fixes` entries at one head count **once**, and `CYCLE_COUNT` resets each invocation. A refusal reported as `needs_fixes` would therefore repeat indefinitely — which is why the refusal is `escalate` |
 | The platform list is filtered before the loop | `sed -n '674,704p' scripts/development-workflow/pr-review-loop.sh` | `filter_phase_after_clean_platforms` removes configured ready-phase platforms absent from this invocation. An invocation can therefore contain ready-phase platforms and **no** local reviewer, which is the first of the Summary's three cases |
 | The configuration is not read when `--platform` is given | `sed -n '8330,8342p' scripts/development-workflow/pr-review-loop.sh` | `workflow_config_review_platforms` is consulted only when the platform list is otherwise empty. So the invocation's `platforms` array cannot answer *is this reviewer configured for the repository* — the guard resolves that separately |
 
@@ -269,7 +270,7 @@ Not applicable — this repository ships workflow tooling, not a service.
       | --- | --- | --- |
       | `not_required` | — | proceed to the gate; no dispatch |
       | owes a pass | no | **dispatch once**; clean → proceed, otherwise end the cycle and record the head |
-      | owes a pass | yes | **refuse**: end the cycle with `needs_fixes`, reason `failed_for_head`, no dispatch and no conversion |
+      | owes a pass | yes | **refuse**: end the run with **`escalate`**, reason `failed_for_head`, no dispatch and no conversion |
 
       **The third row is the one a two-way guard gets wrong**, and it is not a
       corner case — it is the next cycle after any failed pass. A flag that only
@@ -278,6 +279,20 @@ Not applicable — this repository ships workflow tooling, not a service.
       created by the anti-loop mechanism itself. Refusing instead is
       deterministic, costs no dispatch, and keeps the guarantee the item exists
       for.
+
+      **It refuses with `escalate`, not `needs_fixes`, and that is what makes
+      the refusal bounded.** The lifetime cap counts `unique` entries keyed on
+      `head_sha|result` (`reviewer_loop_history_entries_count`), so repeated
+      `needs_fixes` entries at one head count **once** — and `CYCLE_COUNT`
+      resets every invocation. A refusal that reported `needs_fixes` could
+      therefore repeat across invocations forever without either cap advancing:
+      the boundedness would be asserted and untrue.
+
+      `escalate` is terminal for the run and routes to a human, which is also
+      the honest signal. Nothing has changed since the last failure — same head,
+      same verdict, no dispatch — so a result that invites another automated
+      attempt invites one the loop already knows is futile. Scenario 10a pins
+      that the refusal does not depend on a cap to terminate.
 
       A **clean** pass records nothing and needs to record nothing: the verdict
       it produced is clean on `loop_head_sha`, so the condition itself returns
@@ -442,13 +457,13 @@ Order step 0.
    commit dispatch it once; a cycle after a new commit dispatches it again.
    Asserted by counting dispatches, not by reading the field.
 8c. The guarantee survives **re-invocation**: after a failed pass ends a run, a
-   **new** invocation of the loop at the same head refuses rather than
-   dispatching again. This is the case an in-memory flag loses, and it is not
+   **new** invocation of the loop at the same head refuses with `escalate`
+   rather than dispatching again. This is the case an in-memory flag loses, and it is not
    hypothetical — the loop is re-invoked after every blocking result, which is
    what a failed pass produces.
 8a. After a **failed** pass, the next cycle at the same head **refuses**: the
-   cycle ends with `needs_fixes` and reason `failed_for_head`, no
-   local reviewer is dispatched, and the pull request is not converted. A guard
+   run ends with `escalate` and reason `failed_for_head`, no local reviewer is
+   dispatched, and the pull request is not converted. A guard
    that only suppressed the dispatch would let this cycle reach the gate with no
    current clean evidence — the fail-open the anti-loop flag would otherwise
    create.
@@ -458,10 +473,15 @@ Order step 0.
 9. Neither `CYCLE_COUNT` nor `TOTAL_CYCLE_COUNT` changes because a pass ran: two
    runs over identical input, one needing a pass and one not, report the same
    counts.
-10. A pull request whose local reviewer never goes clean escalates with
-    `max_cycles_exceeded` at the same cycle count as today, having dispatched
-    the pass **once** and refused on every later cycle at that head — the guard
-    adds no cycles, and after the first head it adds no dispatches either.
+10. A pull request whose local reviewer never goes clean reaches
+    `max_cycles_exceeded` at the same cycle count as today when the head keeps
+    moving — the guard adds no cycles, and one dispatch per head.
+10a. When the head does **not** move, the refusal terminates without relying on
+    a cap: the second invocation at that head escalates with `failed_for_head`.
+    Asserted directly, because the lifetime cap counts `unique`
+    `head_sha|result` pairs and would never advance on repeated identical
+    entries — a refusal reported as `needs_fixes` would repeat forever with both
+    caps standing still.
 11. `LOCAL_SECOND_PASS_REASON` is emitted on **every** run, including
     `not_required`, and `LOCAL_SECOND_PASS` is `0` there.
 12. Both values reach the ledger entry and the loop summary, and the summary
@@ -517,6 +537,7 @@ Order step 0.
 | Risk | Likelihood | Impact | Mitigation |
 | --- | --- | --- | --- |
 | The guard loops — a pass that keeps triggering itself | Med | **High** — a run that never terminates, or one that burns its cycle budget on repeated local reviews | Keyed on the **head**, so a second dispatch requires a new commit, which the loop cannot manufacture. Scenario 8 counts dispatches across cycles; proof **P1** replaces the key with a per-cycle boolean |
+| The refusal repeats forever because no cap counts it | **High** — `needs_fixes` is the natural result for a blocked gate | **High** — the boundedness the plan claims is asserted and untrue, and the run never terminates on an unchanged head | The refusal is `escalate`, terminal for the run. Scenario 10a runs a second invocation; proof **P12** reports `needs_fixes` |
 | The anti-loop state is lost between invocations | **High** — the loop is re-invoked after every blocking result, which is what a failed pass produces | **High** — one dispatch per invocation forever, the same loop arrived at from outside the run | The failed head lives in the ledger, the loop's existing cross-invocation memory. Scenario 8c and proof **P9** |
 | The anti-loop flag creates a fail-open | **High** — a two-way guard is the obvious shape | **High** — the cycle after a failed pass reaches the gate with no current clean evidence, and the mechanism meant to bound the guard is what lets it through | Three-way guard: dispatch, refuse, or proceed. Scenario 8a and proof **P6** |
 | Silence is read as satisfaction | **High** — `not_required` is the natural default for "nothing to compare" | **High** — a pull request the local reviewer never examined passes the gate, which is the exact fail-open this epic exists to close | `no_evidence` owes a pass. Scenario 2 and proof **P2** |
@@ -575,13 +596,13 @@ reviewer_loop_local_pass_required() {
 ## Planted-Violation Proofs
 
 `REVIEW.md` → Core Rules → Verification Discipline requires two demonstrated
-runs per proof, each citing a concrete file and line. The eleven proofs fall into
+runs per proof, each citing a concrete file and line. The twelve proofs fall into
 three groups:
 
 | Group | Count | Proofs | What the plant reproduces |
 | --- | --- | --- | --- |
 | Fail-open | **5** | P2, P4, P6, P10, P11 | the gate reached, or the pull request converted, without the evidence |
-| Loop and cost | **3** | P1, P3, P5 | a guard that repeats, shortens the run, or runs where there is nothing to guard |
+| Loop and cost | **4** | P1, P3, P5, P12 | a guard that repeats, shortens the run, or runs where there is nothing to guard |
 | Integration | **3** | P7, P8, P9 | a guard wired in beside the pipeline rather than into it |
 
 | # | Violation to plant | Where | Check that must fail, then pass |
@@ -591,6 +612,7 @@ three groups:
 | P9 | Hold the failed head in a shell variable instead of the ledger | a scratch copy of the guard | scenario 8c fails: the invocation after a failed pass starts with an empty variable, sees the same non-clean verdict, and dispatches again — one dispatch per invocation forever on a pull request whose reviewer never goes clean. Scenario 8's within-run count still passes, because a variable survives a run; only crossing an invocation separates them; restoring the ledger field passes |
 | P8 | Call `run_platform_review` from the guard without processing its output | a scratch copy of the dispatch block | scenario 5's ledger assertion fails: the pass runs, its verdict decides the gate, and it appears in no ledger entry and no `key=value` output — so the telemetry says the gate opened with no evidence of what opened it. The gate behaviour is still correct, which is what makes this the plant a hurried extraction invites; restoring the shared processor passes |
 | P6 | Make the flag suppress the dispatch without refusing the gate | same scratch copy | scenario 8a fails: the cycle after a failed pass reaches the gate with no current clean evidence, because the condition still owes a pass and nothing runs — a fail-open created by the anti-loop mechanism itself. Scenario 8's dispatch count still passes, which is what makes this the plant a two-way guard invites; restoring the refusal passes both |
+| P12 | Refuse with `needs_fixes` instead of `escalate` | same scratch copy | scenario 10a fails: the lifetime cap counts `unique` `head_sha\|result` pairs and `CYCLE_COUNT` resets each invocation, so an unchanged head refuses forever with neither cap advancing — the boundedness the plan claims would be asserted and untrue. Scenario 8a's single-refusal assertion still passes, which is why 10a runs a **second** invocation; restoring `escalate` passes both |
 | P2 | Return `not_required` when the history names no local verdict | same scratch copy | scenario 2 fails: a pull request the local reviewer never examined reaches the gate and its ready-phase reviewers run, which is the fail-open this item exists to close. Every other scenario passes, because they all supply a verdict; restoring `no_evidence` passes |
 | P11 | Pass the invocation's `platforms` array to the condition instead of the repository's configured list | a scratch copy of the guard's call site | scenario 2b fails: an explicit `--platform` run that omits a configured local reviewer reports `no_local_reviewer` and proceeds without a pass — the item's motivating case, turned into a fail-open by the argument added to prevent one. Every scenario that runs without `--platform` passes, because there the two lists coincide; restoring the independent resolution passes |
 | P10 | Fold `not_configured` into `no_evidence` | same scratch copy | scenario 2a fails: a repository with no local reviewer configured owes a pass that cannot be dispatched, so either the guard blocks its ready-phase gate forever or an implementer invents a fallback the plan never specified. Scenario 2 passes, because a configured-but-silent reviewer is a different input; restoring the fifth value passes both |
@@ -631,7 +653,8 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    7, 8, 8a, 8b and 8c — the dispatch count across cycles, all three consequences of a failed
    pass, the refusal on the next cycle at the same head, and the `not_required`
    path after a clean pass.
-3. Confirm the caps are untouched. **Verify**: scenarios 9 and 10.
+3. Confirm the caps are untouched and that the refusal terminates without one.
+   **Verify**: scenarios 9, 10 and 10a.
 4. Add the no-op when no ready-phase platform is configured. **Verify**:
    scenario 13.
 5. Add both `print_kv` lines, the ledger fields and the summary line.
@@ -640,7 +663,7 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    `changelog.d/1656.changed.second-local-pass.md`. **Verify**: runbook **Step
    10**, which reads both surfaces and the fragment against each other — Step 8
    is the no-gate/no-guard case.
-7. Produce the eleven planted-violation proofs (P1-P11) and record them in the PR
+7. Produce the twelve planted-violation proofs (P1-P12) and record them in the PR
    with the command, file, line and both outcomes for each.
 
 ---

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -145,16 +145,36 @@ Not applicable — this repository ships workflow tooling, not a service.
       | clean, on `loop_head_sha` | `not_required` | no |
       | clean, on any other commit | `head_changed` | yes |
       | not clean — findings, skipped, unavailable | `prior_findings` | yes |
-      | no verdict in this pull request's history | `no_evidence` | yes |
+      | no verdict, and the reviewer **is** configured | `no_evidence` | yes |
+      | the reviewer is **not configured** for this repository | `no_local_reviewer` | no — see below |
 
-      **Absence owes a pass.** The fourth row is the one a permissive reading
-      gets wrong: a pull request whose history says nothing about the local
-      reviewer has not been locally reviewed, and treating silence as
-      satisfaction is the same fail-open this epic exists to close. It is also
-      the ordinary state of an invocation whose `--platform` list omits the
-      local reviewer.
+      **Absence owes a pass — but only where a pass is possible.** The fourth
+      row is the one a permissive reading gets wrong: a pull request whose
+      history says nothing about a *configured* local reviewer has not been
+      locally reviewed, and treating silence as satisfaction is the same
+      fail-open this epic exists to close. It is the ordinary state of an
+      invocation whose `--platform` list omits the reviewer, and the reviewer is
+      there to be dispatched.
 
-      The four values are distinct rather than a boolean because they are
+      **The fifth row is a different fact and must not be folded into it.**
+      #1651's selector returns `not_configured` when the repository has no local
+      reviewer configured at all — not omitted from this invocation, but absent
+      from `review.on_draft.runner`. There is nothing to dispatch, so a pass is
+      not merely unowed, it is impossible.
+
+      That row **proceeds**, and the choice is deliberate. Refusing would block
+      the ready-phase gate on every pull request in every repository that has
+      not adopted a local reviewer — which this template must keep working for,
+      and which no amount of retrying could clear. Proceeding is not a silent
+      pass either: `LOCAL_SECOND_PASS_REASON` carries `no_local_reviewer`, so a
+      reader can tell *the gate was satisfied* from *there was nothing to
+      satisfy it with*, and #1657 can exclude those repositories from any
+      effectiveness rate rather than counting them as clean.
+
+      Conflating the two rows is what an implementer would otherwise have to
+      invent behavior for: a dispatch of a reviewer that does not exist.
+
+      The five values are distinct rather than a boolean because they are
       reported, and a reader wanting to know *why* a pass ran cannot recover it
       from `1`.
 
@@ -263,7 +283,7 @@ Not applicable — this repository ships workflow tooling, not a service.
 
       ```text
       LOCAL_SECOND_PASS=0|1
-      LOCAL_SECOND_PASS_REASON=not_required|head_changed|prior_findings|no_evidence|failed_for_head
+      LOCAL_SECOND_PASS_REASON=not_required|head_changed|prior_findings|no_evidence|no_local_reviewer|failed_for_head
       ```
 
       `failed_for_head` is the refusal row — the pass did not run **and** the
@@ -290,10 +310,11 @@ Not applicable — this repository ships workflow tooling, not a service.
 
 ### Infrastructure / Configuration
 
-- [ ] Document both keys and **all five** reasons — the four conditions plus
-      `failed_for_head` — in the `--help` block and in Protocol 93. Four would
-      omit the refusal, which is the only reason that reports a *blocked* gate
-      rather than a satisfied or a repaired one.
+- [ ] Document both keys and **all six** reasons — the five conditions plus
+      `failed_for_head` — in the `--help` block and in Protocol 93. The two
+      easiest to omit are the ones that report neither a satisfied nor a
+      repaired gate: `failed_for_head`, a **blocked** one, and
+      `no_local_reviewer`, one with nothing to satisfy it.
 
 ---
 
@@ -329,11 +350,19 @@ Order step 0.
 
 **Key scenarios to test**:
 
-1. `reviewer_loop_local_pass_required` returns each of its four values, one case
+1. `reviewer_loop_local_pass_required` returns each of its five values, one case
    per row of its table.
 2. `no_evidence` is returned for a history with entries that never name the
-   local reviewer — not `not_required`. Silence is not satisfaction, and this is
-   the value an invocation without the local reviewer produces.
+   local reviewer **while the reviewer is configured** — not `not_required`.
+   Silence is not satisfaction, and this is the value an invocation whose
+   `--platform` list omits a configured reviewer produces.
+2a. `no_local_reviewer` is returned when the reviewer is **not configured for
+   the repository**, and the guard **proceeds** without dispatching. Asserted as
+   a distinct value from both `no_evidence` and `not_required`: the first would
+   dispatch a reviewer that does not exist, the second would report a satisfied
+   gate where there was nothing to satisfy it with. The two inputs differ only
+   in the configured-platform list passed to #1651's selector, which is why that
+   argument is not optional.
 3. `head_changed` is returned when the local reviewer's clean verdict names a
    commit that is an **ancestor** of `loop_head_sha` — the ordinary
    fix-was-pushed case — and also when it names an unrelated commit. Both owe a
@@ -420,7 +449,8 @@ Order step 0.
 ## Documentation Updates
 
 - `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
-  — the guard, all **five** reasons including `failed_for_head`, the two keys,
+  — the guard, all **six** reasons including `no_local_reviewer` and
+  `failed_for_head`, the two keys,
   and the `local_second_pass_failed_head` ledger field.
 - The `--help` block of `pr-review-loop.sh`.
 - `changelog.d/1656.changed.second-local-pass.md` — `changed` rather than
@@ -467,7 +497,11 @@ reviewer_loop_local_pass_required() {
   # has not been locally reviewed, and `not_required` here would let an
   # invocation that omits the reviewer walk straight through the gate.
   case "$outcome" in
-    not_yet_run|not_configured|unknown) printf 'no_evidence\n'; return 0 ;;
+    # Not configured is not the same as configured-and-silent: there is nothing
+    # to dispatch, so the guard proceeds and says so rather than owing a pass it
+    # could never discharge.
+    not_configured) printf 'no_local_reviewer\n'; return 0 ;;
+    not_yet_run|unknown) printf 'no_evidence\n'; return 0 ;;
     clean) ;;
     *) printf 'prior_findings\n'; return 0 ;;
   esac
@@ -485,12 +519,12 @@ reviewer_loop_local_pass_required() {
 ## Planted-Violation Proofs
 
 `REVIEW.md` → Core Rules → Verification Discipline requires two demonstrated
-runs per proof, each citing a concrete file and line. The nine proofs fall into
+runs per proof, each citing a concrete file and line. The ten proofs fall into
 three groups:
 
 | Group | Count | Proofs | What the plant reproduces |
 | --- | --- | --- | --- |
-| Fail-open | **3** | P2, P4, P6 | the gate reached, or the pull request converted, without the evidence |
+| Fail-open | **4** | P2, P4, P6, P10 | the gate reached, or the pull request converted, without the evidence |
 | Loop and cost | **3** | P1, P3, P5 |
 | Integration | **3** | P7, P8, P9 | a guard wired in beside the pipeline rather than into it | a guard that repeats, shortens the run, or runs where there is nothing to guard |
 
@@ -502,11 +536,12 @@ three groups:
 | P8 | Call `run_platform_review` from the guard without processing its output | a scratch copy of the dispatch block | scenario 5's ledger assertion fails: the pass runs, its verdict decides the gate, and it appears in no ledger entry and no `key=value` output — so the telemetry says the gate opened with no evidence of what opened it. The gate behaviour is still correct, which is what makes this the plant a hurried extraction invites; restoring the shared processor passes |
 | P6 | Make the flag suppress the dispatch without refusing the gate | same scratch copy | scenario 8a fails: the cycle after a failed pass reaches the gate with no current clean evidence, because the condition still owes a pass and nothing runs — a fail-open created by the anti-loop mechanism itself. Scenario 8's dispatch count still passes, which is what makes this the plant a two-way guard invites; restoring the refusal passes both |
 | P2 | Return `not_required` when the history names no local verdict | same scratch copy | scenario 2 fails: a pull request the local reviewer never examined reaches the gate and its ready-phase reviewers run, which is the fail-open this item exists to close. Every other scenario passes, because they all supply a verdict; restoring `no_evidence` passes |
+| P10 | Fold `not_configured` into `no_evidence` | same scratch copy | scenario 2a fails: a repository with no local reviewer configured owes a pass that cannot be dispatched, so either the guard blocks its ready-phase gate forever or an implementer invents a fallback the plan never specified. Scenario 2 passes, because a configured-but-silent reviewer is a different input; restoring the fifth value passes both |
 | P3 | Increment `CYCLE_COUNT` when the pass runs | a scratch copy of the dispatch block | scenarios 9 and 10 fail: a run needing a pass reports a different count than an identical run that does not, and `max_cycles_exceeded` arrives earlier — so the guard silently shortens every run it helps; restoring the no-op passes |
 | P4 | Call `ensure_pr_ready_for_ready_phase` before checking the pass's result | same scratch copy | scenario 7 fails on its conversion assertion: a failed pass leaves the pull request converted to ready with no reviewer dispatched — a state the loop never intended and a human has to undo. The `needs_fixes` result is still reported, so a test asserting only the result passes; restoring the order passes |
 | P5 | Run the guard even when no ready-phase platform is configured | same scratch copy | scenario 13 fails: every draft-only run dispatches the local reviewer twice, doubling the cost of the cheapest gate for no benefit — the pass exists to protect a gate that is not there; restoring the no-op passes |
 
-Three proofs plant the fail-open direction, and P2 is the one to read twice: it is
+Four proofs plant the fail-open direction, and P2 is the one to read twice: it is
 the natural default, it passes every scenario that supplies a verdict, and the
 pull requests it lets through are exactly the ones nobody reviewed locally.
 
@@ -520,8 +555,9 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    or in flight — to confirm it is a *check* and not a combined gate. If either
    check fails, stop and revise this plan.
 1. Add `reviewer_loop_local_pass_required`, calling #1651's selector with both
-   of its arguments. **Verify**: scenarios 1, 2 and 3 — all four values,
-   `no_evidence` for silence, and both head-mismatch shapes.
+   of its arguments. **Verify**: scenarios 1, 2, 2a and 3 — all five values,
+   `no_evidence` for a silent but configured reviewer, `no_local_reviewer` for
+   an unconfigured one, and both head-mismatch shapes.
 1a. Extract the platform loop's inline post-dispatch block into
    `reviewer_loop_process_platform_output`, changing nothing else. **Verify**:
    scenario 5a — byte-identical `key=value` output for a run that needs no pass.
@@ -542,7 +578,7 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    `changelog.d/1656.changed.second-local-pass.md`. **Verify**: runbook **Step
    10**, which reads both surfaces and the fragment against each other — Step 8
    is the no-gate/no-guard case.
-7. Produce the nine planted-violation proofs (P1-P9) and record them in the PR
+7. Produce the ten planted-violation proofs (P1-P10) and record them in the PR
    with the command, file, line and both outcomes for each.
 
 ---

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -356,6 +356,24 @@ produce the evidence — the loop could never advance past a local finding,
 because the thing that would clear the refusal is the dispatch the refusal
 prevents.
 
+**One consequence of the repository-configured list reaches #1649 and must be
+recorded there rather than assumed.** #1649's plan derives
+`local_ai_configured` from the invocation-filtered `platforms[]`. On the
+motivating case — an explicit `--platform` run that omits a configured local
+reviewer — this item's guard now dispatches that reviewer and produces
+current-head clean evidence, and #1649 would still report
+`local_reviewer_not_configured` and refuse `codex-github`. The evidence exists;
+the check cannot see that it was allowed to.
+
+The fix belongs to whichever item lands second, and this plan states which:
+**#1649 must derive `local_ai_configured` from the repository's configured list**
+— `reviewer_loop_repo_configured_platforms`, the helper this item adds — rather
+than from `platforms[]`. If #1649 is implemented first, this is a one-line
+follow-up in its file; if this item is implemented first, the helper is already
+there. Implementation Order step 0 requires reading #1649's implementation and
+confirming which case applies, and scenario 12a asserts the composed behaviour
+end to end.
+
 If #1649 is implemented as a single combined gate rather than a check, this plan
 must be revised rather than layered on it. That is a hard stop in Implementation
 Order step 0.
@@ -441,6 +459,11 @@ Order step 0.
     `not_required`, and `LOCAL_SECOND_PASS` is `0` there.
 12. Both values reach the ledger entry and the loop summary, and the summary
     line names the reason and the result.
+12a. Composed with #1649 on the motivating case: an explicit `--platform` run
+    that omits a configured local reviewer dispatches the pass, produces
+    current-head clean evidence, and `codex-github` is **not** refused. Asserted
+    end to end rather than on each item's own unit, because the failure is
+    exactly that two correct units disagree about what "configured" means.
 13. The guard is a no-op when no ready-phase platform is configured: with
     `phase_after_clean_enabled` at 0, nothing is dispatched whatever the
     condition says. The pass exists to protect the gate; with no gate there is
@@ -496,6 +519,7 @@ Order step 0.
 | The condition receives the invocation's platform list | **High** — `platforms` is in scope and looks right | **High** — an explicit `--platform` run omitting a configured reviewer reports `no_local_reviewer` and proceeds, which is the item's motivating case turned into a fail-open | The repository's configured list is resolved independently of `--platform`, by its own helper. Scenario 2b and proof **P11** |
 | The condition ignores the current round | **High** — the persisted payload is the obvious input | Med — every ordinary run dispatches the local reviewer twice, and the guard becomes a tax on the path it was meant to leave alone | The round's in-memory results are composed in first, using #1651's helper. Scenarios 4 and 5b, proof **P7** |
 | The guard runs when there is no gate to protect | Med | Low — doubles the local reviewer's cost on every draft-only run | No-op when `phase_after_clean_enabled` is 0. Scenario 13 and proof **P5** |
+| #1649 keeps deriving `local_ai_configured` from `platforms[]` | **High** — that is what its merged plan says | **High** — the guard produces the evidence and #1649 refuses anyway, so the motivating case still cannot reach `codex-github` | Both read `reviewer_loop_repo_configured_platforms`; step 0 requires confirming or changing it. Scenario 12a asserts the composition end to end |
 | This item and #1649 are implemented as one refusal | Med | **High** — the loop can never advance past a local finding, because the evidence that would clear the refusal is the dispatch the refusal prevents | The order is stated in **Interaction with #1649** and enforced by Implementation Order step 0 |
 
 ---
@@ -505,7 +529,7 @@ Order step 0.
 <!-- workflow-shell-contract: bash -->
 
 ```bash
-# Four values, not a boolean: the reason is reported, and `1` cannot be read
+# Five values, not a boolean: the reason is reported, and `1` cannot be read
 # backwards into a cause.
 reviewer_loop_local_pass_required() {
   local payload="${1:-}" head="${2:-}" configured="${3:-}"
@@ -578,8 +602,11 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
 0. **Hard stop**: confirm **#1648 and #1651** are both implemented and merged,
    and that `reviewer_loop_local_latest_verdict` exists with the two-argument
    signature #1651's plan specifies. Then read #1649's implementation — merged
-   or in flight — to confirm it is a *check* and not a combined gate. If either
-   check fails, stop and revise this plan.
+   or in flight — to confirm it is a *check* and not a combined gate, **and**
+   that its `local_ai_configured` derives from the repository's configured list
+   rather than from `platforms[]`. If it derives from `platforms[]`, change it
+   to use `reviewer_loop_repo_configured_platforms` as part of this item. If it
+   is a combined gate, stop and revise this plan.
 1. Add `reviewer_loop_repo_configured_platforms`, reading the configuration
    unconditionally, and `reviewer_loop_local_pass_required`, calling #1651's
    selector with both of its arguments and never with the `platforms` array.

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -539,7 +539,9 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
 5. Add both `print_kv` lines, the ledger fields and the summary line.
    **Verify**: scenarios 11 and 12.
 6. Update Protocol 93, the `--help` block, and add
-   `changelog.d/1656.changed.second-local-pass.md`. **Verify**: runbook Step 8.
+   `changelog.d/1656.changed.second-local-pass.md`. **Verify**: runbook **Step
+   10**, which reads both surfaces and the fragment against each other — Step 8
+   is the no-gate/no-guard case.
 7. Produce the nine planted-violation proofs (P1-P9) and record them in the PR
    with the command, file, line and both outcomes for each.
 

--- a/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
+++ b/docs/specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md
@@ -201,14 +201,29 @@ Not applicable — this repository ships workflow tooling, not a service.
       merely delayed, and the pull request is not converted, so the expensive
       reviewers are not woken at all.
 
-- [ ] **Make repetition impossible without opening a hole.** A flag,
-      `local_second_pass_failed_for_head`, holding the head a pass ran against
-      **and failed on**. It produces a three-way guard, not a two-way one:
+- [ ] **Make repetition impossible without opening a hole, across invocations
+      as well as within one.** A **ledger field**,
+      `local_second_pass_failed_head`, holding the head a pass ran against and
+      failed on — written into the entry, not held in a variable.
 
-      | Condition | Flag matches `loop_head_sha` | Action |
+      An in-memory flag would not survive the run. The loop is re-invoked after
+      every blocking result, which is exactly what a failed pass produces: the
+      next invocation starts with an empty flag, sees the same non-clean
+      verdict, and dispatches again. The guarantee would then be "at most once
+      per head **per invocation**", which on a pull request whose local reviewer
+      never goes clean is one dispatch per invocation forever — the loop this
+      item is supposed to prevent, arrived at from outside the run instead of
+      inside it.
+
+      The guard therefore reads the most recent ledger entry carrying the field
+      and compares it to `loop_head_sha`. The ledger is already the loop's
+      cross-invocation memory; this is one more field in it, not a new
+      mechanism. It produces a three-way guard, not a two-way one:
+
+      | Condition | Recorded failed head matches `loop_head_sha` | Action |
       | --- | --- | --- |
       | `not_required` | — | proceed to the gate; no dispatch |
-      | owes a pass | no | **dispatch once**; clean → proceed, otherwise end the cycle and set the flag |
+      | owes a pass | no | **dispatch once**; clean → proceed, otherwise end the cycle and record the head |
       | owes a pass | yes | **refuse**: end the cycle with `needs_fixes`, reason `local_pass_failed_for_head`, no dispatch and no conversion |
 
       **The third row is the one a two-way guard gets wrong**, and it is not a
@@ -219,14 +234,16 @@ Not applicable — this repository ships workflow tooling, not a service.
       deterministic, costs no dispatch, and keeps the guarantee the item exists
       for.
 
-      A **clean** pass sets no flag and needs none: the verdict it produced is
-      clean on `loop_head_sha`, so the condition itself returns `not_required`
-      on every later cycle. The flag exists only for the failed case.
+      A **clean** pass records nothing and needs to record nothing: the verdict
+      it produced is clean on `loop_head_sha`, so the condition itself returns
+      `not_required` on every later cycle and in every later invocation. The
+      field exists only for the failed case.
 
       Keying on the head rather than on a per-cycle boolean is still the
-      anti-loop argument: at most one *dispatch* per commit, and commits only
-      appear when someone pushes. The loop cannot manufacture the condition that
-      lets it dispatch again.
+      anti-loop argument, and persisting it is what makes the argument hold
+      where it matters: at most one *dispatch* per commit, across the whole pull
+      request rather than per run, and commits only appear when someone pushes.
+      The loop cannot manufacture the condition that lets it dispatch again.
 
 - [ ] **Leave both cycle caps alone.** The pass does not increment
       `CYCLE_COUNT` or `TOTAL_CYCLE_COUNT`: it is a dispatch within a cycle, as
@@ -261,8 +278,10 @@ Not applicable — this repository ships workflow tooling, not a service.
       satisfied condition all look alike — and this is telemetry #1657 will
       read.
 
-      The same two values are added to the ledger entry, so a later report can
-      count passes per pull request without re-reading stdout.
+      The same two values are added to the ledger entry, together with
+      `local_second_pass_failed_head` — which is not merely telemetry but the
+      guard's own cross-invocation memory, and is why it lives in the ledger
+      rather than in a variable.
 
 ### Frontend / UI
 
@@ -327,8 +346,9 @@ Order step 0.
    calls — so the pass is parsed, aggregated, forwarded and recorded in the
    ledger entry like any platform's.
 5a. The extraction is behaviour-preserving: for a pull request that needs **no**
-   pass, the loop's entire `key=value` output is byte-identical to the same run
-   before this change. This is the scenario that fails if the extraction drops
+   pass, every `key=value` line that existed before this change is byte-identical
+   to the same run before it — the comparison excludes `LOCAL_SECOND_PASS` and
+   `LOCAL_SECOND_PASS_REASON`, which this item adds on every run by design. This is the scenario that fails if the extraction drops
    or reorders a key, and every other scenario here would pass with that defect.
 5b. The condition sees the **current round**: a cycle in which the local
    reviewer already reported clean, whose ledger entry is not yet written,
@@ -342,7 +362,12 @@ Order step 0.
    request in a state the loop did not intend.
 8. The guard dispatches **at most once per head**: two cycles with no new
    commit dispatch it once; a cycle after a new commit dispatches it again.
-   Asserted by counting dispatches, not by reading the flag.
+   Asserted by counting dispatches, not by reading the field.
+8c. The guarantee survives **re-invocation**: after a failed pass ends a run, a
+   **new** invocation of the loop at the same head refuses rather than
+   dispatching again. This is the case an in-memory flag loses, and it is not
+   hypothetical — the loop is re-invoked after every blocking result, which is
+   what a failed pass produces.
 8a. After a **failed** pass, the next cycle at the same head **refuses**: the
    cycle ends with `needs_fixes` and reason `local_pass_failed_for_head`, no
    local reviewer is dispatched, and the pull request is not converted. A guard
@@ -395,7 +420,8 @@ Order step 0.
 ## Documentation Updates
 
 - `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`
-  — the guard, its four reasons, and the two keys.
+  — the guard, all **five** reasons including `failed_for_head`, the two keys,
+  and the `local_second_pass_failed_head` ledger field.
 - The `--help` block of `pr-review-loop.sh`.
 - `changelog.d/1656.changed.second-local-pass.md` — `changed` rather than
   `added`: the ready-phase gate already existed and this alters when it fires.
@@ -406,7 +432,8 @@ Order step 0.
 
 | Risk | Likelihood | Impact | Mitigation |
 | --- | --- | --- | --- |
-| The guard loops — a pass that keeps triggering itself | Med | **High** — a run that never terminates, or one that burns its cycle budget on repeated local reviews | The flag is keyed on the **head**, so a second dispatch requires a new commit, which the loop cannot manufacture. Scenario 8 counts dispatches across cycles; proof **P1** replaces the key with a per-cycle boolean |
+| The guard loops — a pass that keeps triggering itself | Med | **High** — a run that never terminates, or one that burns its cycle budget on repeated local reviews | Keyed on the **head**, so a second dispatch requires a new commit, which the loop cannot manufacture. Scenario 8 counts dispatches across cycles; proof **P1** replaces the key with a per-cycle boolean |
+| The anti-loop state is lost between invocations | **High** — the loop is re-invoked after every blocking result, which is what a failed pass produces | **High** — one dispatch per invocation forever, the same loop arrived at from outside the run | The failed head lives in the ledger, the loop's existing cross-invocation memory. Scenario 8c and proof **P9** |
 | The anti-loop flag creates a fail-open | **High** — a two-way guard is the obvious shape | **High** — the cycle after a failed pass reaches the gate with no current clean evidence, and the mechanism meant to bound the guard is what lets it through | Three-way guard: dispatch, refuse, or proceed. Scenario 8a and proof **P6** |
 | Silence is read as satisfaction | **High** — `not_required` is the natural default for "nothing to compare" | **High** — a pull request the local reviewer never examined passes the gate, which is the exact fail-open this epic exists to close | `no_evidence` owes a pass. Scenario 2 and proof **P2** |
 | The pass increments a cycle cap | Med | Med — every run needing a pass gets a shorter budget, and `max_cycles_exceeded` starts meaning two different things | The pass is a dispatch inside an already-counted cycle. Scenarios 9 and 10; proof **P3** increments |
@@ -458,19 +485,20 @@ reviewer_loop_local_pass_required() {
 ## Planted-Violation Proofs
 
 `REVIEW.md` → Core Rules → Verification Discipline requires two demonstrated
-runs per proof, each citing a concrete file and line. The eight proofs fall into
+runs per proof, each citing a concrete file and line. The nine proofs fall into
 three groups:
 
 | Group | Count | Proofs | What the plant reproduces |
 | --- | --- | --- | --- |
 | Fail-open | **3** | P2, P4, P6 | the gate reached, or the pull request converted, without the evidence |
 | Loop and cost | **3** | P1, P3, P5 |
-| Integration | **2** | P7, P8 | a guard wired in beside the pipeline rather than into it | a guard that repeats, shortens the run, or runs where there is nothing to guard |
+| Integration | **3** | P7, P8, P9 | a guard wired in beside the pipeline rather than into it | a guard that repeats, shortens the run, or runs where there is nothing to guard |
 
 | # | Violation to plant | Where | Check that must fail, then pass |
 | --- | --- | --- | --- |
 | P1 | Key the flag on a per-cycle boolean instead of the head | a scratch copy of the guard | scenario 8 fails: two cycles with no new commit dispatch the local reviewer twice, and a pull request whose reviewer never goes clean burns its whole budget on repeated local reviews. The plant looks equivalent — one pass per cycle reads as "at most once" — and only counting dispatches across cycles separates them; restoring the head key passes |
 | P7 | Read the persisted payload without composing the current round | a scratch copy of the condition | scenario 5b fails: a cycle whose local reviewer has already reported clean owes a pass anyway, so every ordinary run dispatches the reviewer twice — the guard becomes a tax on the path it was meant to leave alone. Scenario 4's no-dispatch case fails with it, which is the visible symptom; restoring the composition passes both |
+| P9 | Hold the failed head in a shell variable instead of the ledger | a scratch copy of the guard | scenario 8c fails: the invocation after a failed pass starts with an empty variable, sees the same non-clean verdict, and dispatches again — one dispatch per invocation forever on a pull request whose reviewer never goes clean. Scenario 8's within-run count still passes, because a variable survives a run; only crossing an invocation separates them; restoring the ledger field passes |
 | P8 | Call `run_platform_review` from the guard without processing its output | a scratch copy of the dispatch block | scenario 5's ledger assertion fails: the pass runs, its verdict decides the gate, and it appears in no ledger entry and no `key=value` output — so the telemetry says the gate opened with no evidence of what opened it. The gate behaviour is still correct, which is what makes this the plant a hurried extraction invites; restoring the shared processor passes |
 | P6 | Make the flag suppress the dispatch without refusing the gate | same scratch copy | scenario 8a fails: the cycle after a failed pass reaches the gate with no current clean evidence, because the condition still owes a pass and nothing runs — a fail-open created by the anti-loop mechanism itself. Scenario 8's dispatch count still passes, which is what makes this the plant a two-way guard invites; restoring the refusal passes both |
 | P2 | Return `not_required` when the history names no local verdict | same scratch copy | scenario 2 fails: a pull request the local reviewer never examined reaches the gate and its ready-phase reviewers run, which is the fail-open this item exists to close. Every other scenario passes, because they all supply a verdict; restoring `no_evidence` passes |
@@ -499,10 +527,10 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    scenario 5a — byte-identical `key=value` output for a run that needs no pass.
    Do this as its own commit, so the extraction's diff can be read on its own.
 2. Add the three-way guard — dispatch, refuse, or proceed — with the flag
-   holding the head a pass **failed** on, before
+   recording in the ledger the head a pass **failed** on, before
    `ensure_pr_ready_for_ready_phase`, and compose the current round into the
    payload before evaluating the condition. **Verify**: scenarios 4, 5, 5b, 6,
-   7, 8, 8a and 8b — the dispatch count across cycles, all three consequences of a failed
+   7, 8, 8a, 8b and 8c — the dispatch count across cycles, all three consequences of a failed
    pass, the refusal on the next cycle at the same head, and the `not_required`
    path after a clean pass.
 3. Confirm the caps are untouched. **Verify**: scenarios 9 and 10.
@@ -512,7 +540,7 @@ pull requests it lets through are exactly the ones nobody reviewed locally.
    **Verify**: scenarios 11 and 12.
 6. Update Protocol 93, the `--help` block, and add
    `changelog.d/1656.changed.second-local-pass.md`. **Verify**: runbook Step 8.
-7. Produce the eight planted-violation proofs (P1-P8) and record them in the PR
+7. Produce the nine planted-violation proofs (P1-P9) and record them in the PR
    with the command, file, line and both outcomes for each.
 
 ---

--- a/docs/testing/workflow/1656-second-local-pass.smoke-test.md
+++ b/docs/testing/workflow/1656-second-local-pass.smoke-test.md
@@ -136,9 +136,22 @@ Proof P8.
    pass is running**.
 2. Let the pass return clean.
 
+3. Read the ledger entry for that round and the loop's cycle count.
+
 **Expected result**: the gate does **not** open. The cycle ends with
-`needs_fixes` and reason `head_moved_during_pass`, and no ready-phase platform
-is dispatched.
+`needs_fixes` and the loop's **existing** reason `head_moved_during_run`; no
+ready-phase platform is dispatched; the round is **not counted** as a cycle and
+no fixer is dispatched for it. `LOCAL_SECOND_PASS_REASON` carries the finer
+`head_moved_during_pass`.
+
+Reusing the established token is deliberate. `head_moved_during_run` already
+carries two contracts — `reviewer_loop_history_entries_count` excludes entries
+holding it from the qualifying set, and Protocol 91 treats it as nothing-to-fix
+— and both are exactly right for a mid-pass move: the head moved, there is
+nothing for a fixer to do, and the round did no review work. A newly minted
+token inherits neither, so it would consume a cycle and send a fixer after
+nothing. The distinction that matters for telemetry lives in this item's own
+key. Proof P14.
 
 Without the re-read, a clean verdict for the *old* commit opens the gate and
 expensive reviewers read code the local reviewer never saw — the guarantee this
@@ -324,11 +337,11 @@ ready-phase gate already existed and this alters when it fires.
 ## Step 12: Planted-violation proofs
 
 1. Read the implementation PR's `Planted-Violation Proofs` heading.
-2. Confirm P1 through P13 each record the command, the file and line of the
+2. Confirm P1 through P14 each record the command, the file and line of the
    planted violation, and both outcomes.
 
-**Expected result**: thirteen proofs in three groups — **six** fail-open,
-**four** loop and cost, **three** integration, per the plan's proof-group
+**Expected result**: fourteen proofs in three groups — **six** fail-open,
+**five** loop and cost, **three** integration, per the plan's proof-group
 table.
 
 P2 is the one to read twice: returning `not_required` for a history with no

--- a/docs/testing/workflow/1656-second-local-pass.smoke-test.md
+++ b/docs/testing/workflow/1656-second-local-pass.smoke-test.md
@@ -232,6 +232,28 @@ Proof P5.
 entries; and a summary line naming the reason and the result — `second local
 pass: head_changed → clean`.
 
+## Step 9a: Composed with #1649 on the motivating case
+
+**Maps to**: the cross-item contract.
+
+1. Run an explicit `--platform` invocation that omits a local reviewer the
+   repository configures, on a pull request whose local verdict is stale.
+2. Let the guard dispatch the pass and produce a current-head clean result.
+3. Observe whether `codex-github` is dispatched or refused.
+
+**Expected result**: the pass runs, the evidence is current-head clean, and
+`codex-github` is **not** refused.
+
+This is the one case where two correct units disagree. #1649's check derives
+`local_ai_configured` from the invocation-filtered `platforms[]`, which on this
+run does not contain the local reviewer — so it would report
+`local_reviewer_not_configured` and refuse, while the evidence it wants is
+sitting in the ledger. Both must read the repository's configured list, through
+the same helper this item adds.
+
+Assert it end to end rather than on either item's unit tests: each is correct in
+isolation, and the failure is only visible where they meet.
+
 ## Step 10: Documentation agrees
 
 **Maps to**: the documentation-drift risk.

--- a/docs/testing/workflow/1656-second-local-pass.smoke-test.md
+++ b/docs/testing/workflow/1656-second-local-pass.smoke-test.md
@@ -10,7 +10,7 @@ inside an `if` or with `|| true`.
 
 ---
 
-## Step 1: The condition's four values
+## Step 1: The condition's five values
 
 **Maps to**: brief scope bullets 1 and 2.
 

--- a/docs/testing/workflow/1656-second-local-pass.smoke-test.md
+++ b/docs/testing/workflow/1656-second-local-pass.smoke-test.md
@@ -128,6 +128,32 @@ the shared processor still decides the gate correctly and records nothing — th
 telemetry would then say the gate opened with no evidence of what opened it.
 Proof P8.
 
+## Step 4a: A head that moves during the pass closes the gate
+
+**Maps to**: the current-head guarantee.
+
+1. Run the loop so the guard dispatches a pass, and push a commit **while the
+   pass is running**.
+2. Let the pass return clean.
+
+**Expected result**: the gate does **not** open. The cycle ends with
+`needs_fixes` and reason `head_moved_during_pass`, and no ready-phase platform
+is dispatched.
+
+Without the re-read, a clean verdict for the *old* commit opens the gate and
+expensive reviewers read code the local reviewer never saw — the guarantee this
+item exists to provide, broken on its own success path. Every scenario with a
+stable head passes without it, which is all of the others.
+
+The loop's existing end-of-run head-move check cannot substitute: it fires
+*after* the dispatch it would need to prevent. Detecting the race requires
+looking at the moment before the gate opens.
+
+The re-read is the plan's only second head snapshot, and it classifies nothing —
+its sole use is the equality test, and its sole outcome a refusal. The pass's
+recorded evidence stays attributed to `loop_head_sha`, as #1648 requires.
+Proof P13.
+
 ## Step 5: A failed second pass closes it, and changes nothing else
 
 **Maps to**: the brief's outcome, the failure half.
@@ -273,8 +299,9 @@ isolation, and the failure is only visible where they meet.
 2. Run `scripts/development-workflow/pr-review-loop.sh --help`.
 3. Read `changelog.d/1656.changed.second-local-pass.md`.
 
-**Expected result**: both surfaces describe the same **six** reasons — the five
-conditions plus `failed_for_head` — and the same two keys, and neither describes the pass as consuming a cycle or as running
+**Expected result**: both surfaces describe the same **seven** reasons — the
+five conditions plus `failed_for_head` and `head_moved_during_pass` — and the
+same two keys, and neither describes the pass as consuming a cycle or as running
 without a ready-phase platform. The fragment is `changed`, not `added` — the
 ready-phase gate already existed and this alters when it fires.
 
@@ -297,10 +324,10 @@ ready-phase gate already existed and this alters when it fires.
 ## Step 12: Planted-violation proofs
 
 1. Read the implementation PR's `Planted-Violation Proofs` heading.
-2. Confirm P1 through P12 each record the command, the file and line of the
+2. Confirm P1 through P13 each record the command, the file and line of the
    planted violation, and both outcomes.
 
-**Expected result**: twelve proofs in three groups — **five** fail-open,
+**Expected result**: thirteen proofs in three groups — **six** fail-open,
 **four** loop and cost, **three** integration, per the plan's proof-group
 table.
 

--- a/docs/testing/workflow/1656-second-local-pass.smoke-test.md
+++ b/docs/testing/workflow/1656-second-local-pass.smoke-test.md
@@ -159,8 +159,8 @@ P4.
 4. After a **clean** pass, run another cycle at the same head.
 
 **Expected result**: case 1 dispatches the guard's pass **once**; case 2
-dispatches it twice. Cases 3 and 3a both **refuse** — the cycle ends with `needs_fixes`,
-reason `failed_for_head`, no dispatch, no conversion. Case 4 takes
+dispatches it twice. Cases 3 and 3a both **refuse with `escalate`** — the run
+ends with reason `failed_for_head`, no dispatch, no conversion. Case 4 takes
 the `not_required` path: no dispatch, no refusal.
 
 Case 3a is the hole an in-memory flag leaves, and it is the ordinary case rather
@@ -194,12 +194,22 @@ loop cannot manufacture a commit. Proof P1.
 
 1. Run two identical inputs, one needing a pass and one not, and compare
    `CYCLE_COUNT` and `TOTAL_CYCLE_COUNT`.
-2. Run a pull request whose local reviewer never goes clean to
-   `max_cycles_exceeded` and note the cycle count at escalation.
+2. Run a pull request whose local reviewer never goes clean, **with the head
+   moving each time**, to `max_cycles_exceeded`, and note the cycle count.
+3. With the head **unchanged**, run a second invocation after a failed pass.
 
 **Expected result**: case 1's counts are equal. Case 2 escalates at the same
-count as before this change, having dispatched the pass **once** and refused on
-every later cycle at that head.
+count as before this change. Case 3 escalates immediately with
+`failed_for_head`.
+
+Case 3 is why the refusal is `escalate` and not `needs_fixes`. The lifetime cap
+counts `unique` `head_sha|result` pairs, so repeated identical `needs_fixes`
+entries at one head count **once**, and `CYCLE_COUNT` resets every invocation —
+a refusal reported as `needs_fixes` would repeat forever with **both caps
+standing still**, and the boundedness this item claims would be asserted and
+untrue. `escalate` is terminal for the run, and it is the honest signal: nothing
+changed since the last failure, so another automated attempt is one the loop
+already knows is futile. Proof P12.
 
 The pass is a dispatch inside a cycle that is already counted. Incrementing a
 cap would make `max_cycles_exceeded` mean two different things — cycles for
@@ -287,11 +297,11 @@ ready-phase gate already existed and this alters when it fires.
 ## Step 12: Planted-violation proofs
 
 1. Read the implementation PR's `Planted-Violation Proofs` heading.
-2. Confirm P1 through P11 each record the command, the file and line of the
+2. Confirm P1 through P12 each record the command, the file and line of the
    planted violation, and both outcomes.
 
-**Expected result**: eleven proofs in three groups — **five** fail-open,
-**three** loop and cost, **three** integration, per the plan's proof-group
+**Expected result**: twelve proofs in three groups — **five** fail-open,
+**four** loop and cost, **three** integration, per the plan's proof-group
 table.
 
 P2 is the one to read twice: returning `not_required` for a history with no

--- a/docs/testing/workflow/1656-second-local-pass.smoke-test.md
+++ b/docs/testing/workflow/1656-second-local-pass.smoke-test.md
@@ -19,10 +19,26 @@ inside an `if` or with `|| true`.
 2. Call it with a local clean verdict on an **ancestor** of `loop_head_sha`.
 3. Call it with a local clean verdict on an **unrelated** commit.
 4. Call it with a local **needs_fixes** verdict.
-5. Call it with entries that **never name** the local reviewer.
+5. Call it with entries that **never name** the local reviewer, and a
+   configured-platform list that **contains** it.
+6. Call it with the same history and a configured-platform list that **does
+   not** contain it.
 
 **Expected result**: `not_required`, `head_changed`, `head_changed`,
-`prior_findings`, `no_evidence`.
+`prior_findings`, `no_evidence`, `no_local_reviewer`.
+
+Cases 5 and 6 differ **only** in the configured-platform list, and they must not
+collapse. Case 5 is a configured reviewer that has not spoken — dispatchable, so
+a pass is owed. Case 6 is a repository with no local reviewer at all: there is
+nothing to dispatch, so the guard **proceeds** and reports
+`no_local_reviewer` rather than owing a pass it could never discharge.
+
+Proceeding there is deliberate. Refusing would block the ready-phase gate on
+every pull request in every repository that has not adopted a local reviewer,
+which no amount of retrying could clear. It is not a silent pass either: the
+reason distinguishes *the gate was satisfied* from *there was nothing to satisfy
+it with*, which is what lets #1657 exclude those repositories from a rate rather
+than count them as clean. Proof P10.
 
 Case 5 is the one a permissive reading gets wrong. A history that says nothing
 about the local reviewer has not been locally reviewed, and `not_required` there
@@ -213,7 +229,7 @@ pass: head_changed → clean`.
 2. Run `scripts/development-workflow/pr-review-loop.sh --help`.
 3. Read `changelog.d/1656.changed.second-local-pass.md`.
 
-**Expected result**: both surfaces describe the same **five** reasons — the four
+**Expected result**: both surfaces describe the same **six** reasons — the five
 conditions plus `failed_for_head` — and the same two keys, and neither describes the pass as consuming a cycle or as running
 without a ready-phase platform. The fragment is `changed`, not `added` — the
 ready-phase gate already existed and this alters when it fires.
@@ -237,12 +253,11 @@ ready-phase gate already existed and this alters when it fires.
 ## Step 12: Planted-violation proofs
 
 1. Read the implementation PR's `Planted-Violation Proofs` heading.
-2. Confirm P1 through P9 each record the command, the file and line of the
+2. Confirm P1 through P10 each record the command, the file and line of the
    planted violation, and both outcomes.
 
-**Expected result**: nine proofs in three groups — **three** fail-open,
-**three** loop and cost, **three** integration, per the plan's proof-group
-table.
+**Expected result**: ten proofs in three groups — **four** fail-open, **three**
+loop and cost, **three** integration, per the plan's proof-group table.
 
 P2 is the one to read twice: returning `not_required` for a history with no
 local verdict is the natural default, it passes every scenario that supplies a

--- a/docs/testing/workflow/1656-second-local-pass.smoke-test.md
+++ b/docs/testing/workflow/1656-second-local-pass.smoke-test.md
@@ -60,11 +60,12 @@ look alike — and this is telemetry #1657 will read.
    `loop_head_sha`.
 2. Compare the platform dispatch sequence to the same run before this change.
 
-3. Compare the loop's entire `key=value` output to the same run before this
-   change.
+3. Compare the loop's `key=value` output to the same run before this change,
+   **excluding** `LOCAL_SECOND_PASS` and `LOCAL_SECOND_PASS_REASON`, which this
+   item adds on every run by design.
 
-**Expected result**: the dispatch sequence and the whole `key=value` output are
-byte-for-byte identical. The guard adds nothing to the path it does not need to
+**Expected result**: the dispatch sequence is identical, and every `key=value`
+line that existed before this change is byte-for-byte identical. The guard adds nothing to the path it does not need to
 protect.
 
 Two different things are being checked. The **dispatch** comparison depends on
@@ -125,12 +126,22 @@ P4.
 2. Run a cycle, land a commit, run another cycle, and count again.
 
 3. After a **failed** pass, run another cycle at the same head.
+3a. After a **failed** pass ends the run, start a **new invocation** of the loop
+   at the same head.
 4. After a **clean** pass, run another cycle at the same head.
 
 **Expected result**: case 1 dispatches the guard's pass **once**; case 2
-dispatches it twice. Case 3 **refuses** — the cycle ends with `needs_fixes`,
+dispatches it twice. Cases 3 and 3a both **refuse** — the cycle ends with `needs_fixes`,
 reason `local_pass_failed_for_head`, no dispatch, no conversion. Case 4 takes
 the `not_required` path: no dispatch, no refusal.
+
+Case 3a is the hole an in-memory flag leaves, and it is the ordinary case rather
+than an edge: the loop is re-invoked after every blocking result, which is what
+a failed pass produces. A variable starts empty in the new invocation, the
+verdict is still non-clean, and the guard dispatches again — one dispatch per
+invocation forever. The failed head therefore lives in the **ledger**, the
+loop's existing cross-invocation memory. Case 3 passes with a variable, so only
+crossing an invocation separates the two. Proof P9.
 
 Case 3 is the hole a two-way guard leaves. Suppressing the dispatch without
 refusing means the condition still owes a pass, nothing runs, and the gate is
@@ -226,11 +237,11 @@ ready-phase gate already existed and this alters when it fires.
 ## Step 12: Planted-violation proofs
 
 1. Read the implementation PR's `Planted-Violation Proofs` heading.
-2. Confirm P1 through P8 each record the command, the file and line of the
+2. Confirm P1 through P9 each record the command, the file and line of the
    planted violation, and both outcomes.
 
-**Expected result**: eight proofs in three groups — **three** fail-open,
-**three** loop and cost, **two** integration, per the plan's proof-group
+**Expected result**: nine proofs in three groups — **three** fail-open,
+**three** loop and cost, **three** integration, per the plan's proof-group
 table.
 
 P2 is the one to read twice: returning `not_required` for a history with no

--- a/docs/testing/workflow/1656-second-local-pass.smoke-test.md
+++ b/docs/testing/workflow/1656-second-local-pass.smoke-test.md
@@ -44,6 +44,10 @@ ready-phase reviewers are about to read.
 **Expected result**: the key is present and reads `not_required`; and
 `LOCAL_SECOND_PASS` is `0`.
 
+`not_required` and `failed_for_head` are both "the pass did not run" and must
+not be collapsed: one is a satisfied gate, the other a blocked one, and that is
+the distinction #1657 needs most.
+
 Emitting the reason only on the interesting path would make its absence
 ambiguous — an old script, a skipped guard and a satisfied condition would all
 look alike — and this is telemetry #1657 will read.
@@ -97,8 +101,24 @@ P4.
    dispatches.
 2. Run a cycle, land a commit, run another cycle, and count again.
 
+3. After a **failed** pass, run another cycle at the same head.
+4. After a **clean** pass, run another cycle at the same head.
+
 **Expected result**: case 1 dispatches the guard's pass **once**; case 2
-dispatches it twice.
+dispatches it twice. Case 3 **refuses** — the cycle ends with `needs_fixes`,
+reason `local_pass_failed_for_head`, no dispatch, no conversion. Case 4 takes
+the `not_required` path: no dispatch, no refusal.
+
+Case 3 is the hole a two-way guard leaves. Suppressing the dispatch without
+refusing means the condition still owes a pass, nothing runs, and the gate is
+reached with no current clean evidence — a fail-open created by the anti-loop
+mechanism itself, on the very next cycle after any failed pass. Case 1's
+dispatch count passes either way, which is what makes it worth its own case.
+Proof P6.
+
+Case 4 needs no flag: the verdict a clean pass produced is clean on
+`loop_head_sha`, so the condition returns `not_required` on its own. The flag
+exists only for the failed case.
 
 Count dispatches, not the flag. A per-cycle boolean reads as "at most once" and
 is not: it allows one pass per cycle forever, and on a pull request whose local
@@ -116,7 +136,8 @@ loop cannot manufacture a commit. Proof P1.
    `max_cycles_exceeded` and note the cycle count at escalation.
 
 **Expected result**: case 1's counts are equal. Case 2 escalates at the same
-count as before this change.
+count as before this change, having dispatched the pass **once** and refused on
+every later cycle at that head.
 
 The pass is a dispatch inside a cycle that is already counted. Incrementing a
 cap would make `max_cycles_exceeded` mean two different things — cycles for
@@ -158,8 +179,8 @@ pass: head_changed → clean`.
 2. Run `scripts/development-workflow/pr-review-loop.sh --help`.
 3. Read `changelog.d/1656.changed.second-local-pass.md`.
 
-**Expected result**: both surfaces describe the same four reasons and the same
-two keys, and neither describes the pass as consuming a cycle or as running
+**Expected result**: both surfaces describe the same **five** reasons — the four
+conditions plus `failed_for_head` — and the same two keys, and neither describes the pass as consuming a cycle or as running
 without a ready-phase platform. The fragment is `changed`, not `added` — the
 ready-phase gate already existed and this alters when it fires.
 
@@ -182,10 +203,10 @@ ready-phase gate already existed and this alters when it fires.
 ## Step 12: Planted-violation proofs
 
 1. Read the implementation PR's `Planted-Violation Proofs` heading.
-2. Confirm P1 through P5 each record the command, the file and line of the
+2. Confirm P1 through P6 each record the command, the file and line of the
    planted violation, and both outcomes.
 
-**Expected result**: five proofs in two groups — **two** fail-open, **three**
+**Expected result**: six proofs in two groups — **three** fail-open, **three**
 loop and cost, per the plan's proof-group table.
 
 P2 is the one to read twice: returning `not_required` for a history with no

--- a/docs/testing/workflow/1656-second-local-pass.smoke-test.md
+++ b/docs/testing/workflow/1656-second-local-pass.smoke-test.md
@@ -160,7 +160,7 @@ P4.
 
 **Expected result**: case 1 dispatches the guard's pass **once**; case 2
 dispatches it twice. Cases 3 and 3a both **refuse** — the cycle ends with `needs_fixes`,
-reason `local_pass_failed_for_head`, no dispatch, no conversion. Case 4 takes
+reason `failed_for_head`, no dispatch, no conversion. Case 4 takes
 the `not_required` path: no dispatch, no refusal.
 
 Case 3a is the hole an in-memory flag leaves, and it is the ordinary case rather

--- a/docs/testing/workflow/1656-second-local-pass.smoke-test.md
+++ b/docs/testing/workflow/1656-second-local-pass.smoke-test.md
@@ -1,0 +1,201 @@
+# Smoke Test: Second Local Pass Before Ready-Phase Reviewers (#1656)
+
+**Item**: [#1656](https://github.com/lhpaul/ai-dev-framework-template/issues/1656)
+**Plan**: [2_1656-second-local-pass_implementation-plan.md](../../specs/developments/20260828230000_1656-second-local-pass/2_1656-second-local-pass_implementation-plan.md)
+
+Steps 1 and 2 source the loop with `HARNESS_MODE=1` and call the condition
+directly; the rest exercise the assembled behavior. Sourcing enables
+`set -euo pipefail`; call anything that returns non-zero as a normal answer
+inside an `if` or with `|| true`.
+
+---
+
+## Step 1: The condition's four values
+
+**Maps to**: brief scope bullets 1 and 2.
+
+1. Call `reviewer_loop_local_pass_required` with a history whose local verdict is
+   **clean on `loop_head_sha`**.
+2. Call it with a local clean verdict on an **ancestor** of `loop_head_sha`.
+3. Call it with a local clean verdict on an **unrelated** commit.
+4. Call it with a local **needs_fixes** verdict.
+5. Call it with entries that **never name** the local reviewer.
+
+**Expected result**: `not_required`, `head_changed`, `head_changed`,
+`prior_findings`, `no_evidence`.
+
+Case 5 is the one a permissive reading gets wrong. A history that says nothing
+about the local reviewer has not been locally reviewed, and `not_required` there
+would let an invocation whose `--platform` list omits the reviewer walk straight
+through the gate — the fail-open this epic exists to close. It is also not a
+rare state: `filter_phase_after_clean_platforms` lets an invocation carry
+ready-phase platforms and no local reviewer at all. Proof P2.
+
+Cases 2 and 3 both owe a pass. An ancestor is the ordinary fix-was-pushed case;
+an unrelated commit is a force-push. Neither is evidence about the commit the
+ready-phase reviewers are about to read.
+
+## Step 2: Four values, not a boolean
+
+**Maps to**: the reporting contract.
+
+1. Read `LOCAL_SECOND_PASS_REASON` on a run where the pass did not run.
+
+**Expected result**: the key is present and reads `not_required`; and
+`LOCAL_SECOND_PASS` is `0`.
+
+Emitting the reason only on the interesting path would make its absence
+ambiguous — an old script, a skipped guard and a satisfied condition would all
+look alike — and this is telemetry #1657 will read.
+
+## Step 3: No extra dispatch when the evidence is current
+
+**Maps to**: brief scope bullet 3, the cost half.
+
+1. Run the loop on a pull request whose local reviewer is clean on
+   `loop_head_sha`.
+2. Compare the platform dispatch sequence to the same run before this change.
+
+**Expected result**: byte-for-byte identical. The guard adds nothing to the path
+it does not need to protect.
+
+## Step 4: A clean second pass opens the gate
+
+**Maps to**: the brief's outcome.
+
+1. Run the loop on a pull request whose local reviewer reported findings, then
+   push a fix so `loop_head_sha` moves.
+2. Let the loop reach the ready-phase gate.
+
+**Expected result**: the local reviewer is dispatched **once** before
+`ensure_pr_ready_for_ready_phase`, through `run_platform_review` like any
+platform; it reports clean; the pull request is converted; ready-phase reviewers
+run. `LOCAL_SECOND_PASS=1`, `LOCAL_SECOND_PASS_REASON=head_changed`.
+
+## Step 5: A failed second pass closes it, and changes nothing else
+
+**Maps to**: the brief's outcome, the failure half.
+
+1. Same as Step 4, but the second pass reports `needs_fixes`.
+
+**Expected result**: three things, all asserted:
+
+- the cycle ends with `needs_fixes`;
+- the pull request is **not** converted to ready;
+- **no** ready-phase platform is dispatched.
+
+Asserting only the result would pass an implementation that converts the pull
+request first and then reports the failure — leaving it ready, with no reviewer
+dispatched, in a state the loop never intended and a human has to undo. Proof
+P4.
+
+## Step 6: At most once per head, and again when the head moves
+
+**Maps to**: brief scope bullet 3, the loop half.
+
+1. Run two cycles with **no** new commit between them and count local-reviewer
+   dispatches.
+2. Run a cycle, land a commit, run another cycle, and count again.
+
+**Expected result**: case 1 dispatches the guard's pass **once**; case 2
+dispatches it twice.
+
+Count dispatches, not the flag. A per-cycle boolean reads as "at most once" and
+is not: it allows one pass per cycle forever, and on a pull request whose local
+reviewer never goes clean it burns the entire cycle budget on repeated local
+reviews. Keying the flag on the head allows one pass per **commit**, and the
+loop cannot manufacture a commit. Proof P1.
+
+## Step 7: The caps mean what they meant
+
+**Maps to**: brief scope bullet 3, the cap half.
+
+1. Run two identical inputs, one needing a pass and one not, and compare
+   `CYCLE_COUNT` and `TOTAL_CYCLE_COUNT`.
+2. Run a pull request whose local reviewer never goes clean to
+   `max_cycles_exceeded` and note the cycle count at escalation.
+
+**Expected result**: case 1's counts are equal. Case 2 escalates at the same
+count as before this change.
+
+The pass is a dispatch inside a cycle that is already counted. Incrementing a
+cap would make `max_cycles_exceeded` mean two different things — cycles for
+platforms, cycles-plus-passes here — and would silently shorten every run the
+guard helps. Proof P3.
+
+## Step 8: No gate, no guard
+
+**Maps to**: the cost of protecting nothing.
+
+1. Run with no ready-phase platform configured — `phase_after_clean_enabled` at
+   0 — and a condition that would otherwise owe a pass.
+
+**Expected result**: no extra dispatch; the run is what it is today.
+
+The pass exists to protect the ready-phase gate. With no gate, dispatching
+anyway doubles the local reviewer's cost on every draft-only run for no benefit.
+Proof P5.
+
+## Step 9: The two keys, the ledger and the summary
+
+**Maps to**: the reporting contract.
+
+1. Read the loop's `key=value` stdout on a run where the pass ran and on one
+   where it did not.
+2. Read the reviewer-loop history entry for both.
+3. Read the summary comment on the run where it ran.
+
+**Expected result**: both keys present in both runs; both values in both ledger
+entries; and a summary line naming the reason and the result — `second local
+pass: head_changed → clean`.
+
+## Step 10: Documentation agrees
+
+**Maps to**: the documentation-drift risk.
+
+1. Read the guard's description in
+   `docs/workflow/development-workflow/protocols/93-automated-reviewer-loop-protocol.md`.
+2. Run `scripts/development-workflow/pr-review-loop.sh --help`.
+3. Read `changelog.d/1656.changed.second-local-pass.md`.
+
+**Expected result**: both surfaces describe the same four reasons and the same
+two keys, and neither describes the pass as consuming a cycle or as running
+without a ready-phase platform. The fragment is `changed`, not `added` — the
+ready-phase gate already existed and this alters when it fires.
+
+## Step 11: Static checks
+
+1. Run `shellcheck` on `scripts/development-workflow/pr-review-loop.sh`.
+2. Run
+
+   <!-- workflow-shell-contract: bash -->
+
+   ```bash
+   python3 scripts/lint/workflow-shell-guard-lint.py \
+     --base-ref origin/develop-internal-reviewer-effectiveness
+   ```
+
+3. Run `markdownlint-cli2` on the changed documentation.
+
+**Expected result**: all three exit 0.
+
+## Step 12: Planted-violation proofs
+
+1. Read the implementation PR's `Planted-Violation Proofs` heading.
+2. Confirm P1 through P5 each record the command, the file and line of the
+   planted violation, and both outcomes.
+
+**Expected result**: five proofs in two groups — **two** fail-open, **three**
+loop and cost, per the plan's proof-group table.
+
+P2 is the one to read twice: returning `not_required` for a history with no
+local verdict is the natural default, it passes every scenario that supplies a
+verdict, and the pull requests it lets through are exactly the ones nobody
+reviewed locally.
+
+---
+
+## Rollback verification
+
+Revert the implementation PR and re-run Steps 3 and 4. No extra dispatch may
+occur in either, and neither key may appear in the loop's output.

--- a/docs/testing/workflow/1656-second-local-pass.smoke-test.md
+++ b/docs/testing/workflow/1656-second-local-pass.smoke-test.md
@@ -63,7 +63,7 @@ Cases 2 and 3 both owe a pass. An ancestor is the ordinary fix-was-pushed case;
 an unrelated commit is a force-push. Neither is evidence about the commit the
 ready-phase reviewers are about to read.
 
-## Step 2: Four values, not a boolean
+## Step 2: Six reasons, not a boolean
 
 **Maps to**: the reporting contract.
 

--- a/docs/testing/workflow/1656-second-local-pass.smoke-test.md
+++ b/docs/testing/workflow/1656-second-local-pass.smoke-test.md
@@ -172,12 +172,25 @@ Proof P13.
 **Maps to**: the brief's outcome, the failure half.
 
 1. Same as Step 4, but the second pass reports `needs_fixes`.
+2. Repeat once per remaining non-clean result: `escalate`; `skipped` with
+   reason `unavailable`; `skipped` with reason `not_configured`; `skipped` with
+   any other reason; `needs_rerun`; and an unparseable result. Run these through
+   the **real** shared processor, not a stub.
 
-**Expected result**: three things, all asserted:
+**Expected result**: for **every** case, three things, all asserted:
 
 - the cycle ends with `needs_fixes`;
 - the pull request is **not** converted to ready;
 - **no** ready-phase platform is dispatched.
+
+The `skipped` rows are the ones that invert. The shared processor treats a
+skipped platform as **not blocking** — correct for an ordinary platform, and
+wrong for this pass: the guard dispatched it *because* the gate needs evidence,
+and a skipped pass produced none. Without the guard's override, a skipped pass
+opens the ready-phase gate on a review that did not happen — the fail-open this
+item exists to close, arriving through the machinery the guard borrows. Run them
+through the real processor, because the inversion lives in what the processor
+does with the result rather than in what the guard reads. Proof P15.
 
 Asserting only the result would pass an implementation that converts the pull
 request first and then reports the failure — leaving it ready, with no reviewer
@@ -312,9 +325,9 @@ isolation, and the failure is only visible where they meet.
 2. Run `scripts/development-workflow/pr-review-loop.sh --help`.
 3. Read `changelog.d/1656.changed.second-local-pass.md`.
 
-**Expected result**: both surfaces describe the same **seven** reasons — the
-five conditions plus `failed_for_head` and `head_moved_during_pass` — and the
-same two keys, and neither describes the pass as consuming a cycle or as running
+**Expected result**: both surfaces describe the same **eight** reasons — the
+five conditions plus `failed_for_head`, `head_moved_during_pass` and
+`local_pass_unavailable` — and the same two keys, and neither describes the pass as consuming a cycle or as running
 without a ready-phase platform. The fragment is `changed`, not `added` — the
 ready-phase gate already existed and this alters when it fires.
 
@@ -337,10 +350,10 @@ ready-phase gate already existed and this alters when it fires.
 ## Step 12: Planted-violation proofs
 
 1. Read the implementation PR's `Planted-Violation Proofs` heading.
-2. Confirm P1 through P14 each record the command, the file and line of the
+2. Confirm P1 through P15 each record the command, the file and line of the
    planted violation, and both outcomes.
 
-**Expected result**: fourteen proofs in three groups — **six** fail-open,
+**Expected result**: fifteen proofs in three groups — **seven** fail-open,
 **five** loop and cost, **three** integration, per the plan's proof-group
 table.
 

--- a/docs/testing/workflow/1656-second-local-pass.smoke-test.md
+++ b/docs/testing/workflow/1656-second-local-pass.smoke-test.md
@@ -23,9 +23,21 @@ inside an `if` or with `|| true`.
    configured-platform list that **contains** it.
 6. Call it with the same history and a configured-platform list that **does
    not** contain it.
+7. Run the loop with an explicit `--platform` list that **omits** a local
+   reviewer the repository *does* configure, and read the condition's value.
 
 **Expected result**: `not_required`, `head_changed`, `head_changed`,
-`prior_findings`, `no_evidence`, `no_local_reviewer`.
+`prior_findings`, `no_evidence`, `no_local_reviewer`; and case 7 returns
+`no_evidence`, owing a pass.
+
+Case 7 is where the list comes from, and it is the item's motivating scenario.
+`pr-review-loop.sh` skips `workflow_config_review_platforms` entirely when
+explicit `--platform` arguments are supplied, and the `platforms` array is
+invocation-filtered — so handing that array to the condition would report
+`no_local_reviewer` for a reviewer that **is** configured and merely omitted,
+and the run would proceed without a pass. A fail-open produced by the argument
+added to prevent one. The guard resolves the repository's configured list
+independently of `--platform`. Proof P11.
 
 Cases 5 and 6 differ **only** in the configured-platform list, and they must not
 collapse. Case 5 is a configured reviewer that has not spoken — dispatchable, so
@@ -253,11 +265,12 @@ ready-phase gate already existed and this alters when it fires.
 ## Step 12: Planted-violation proofs
 
 1. Read the implementation PR's `Planted-Violation Proofs` heading.
-2. Confirm P1 through P10 each record the command, the file and line of the
+2. Confirm P1 through P11 each record the command, the file and line of the
    planted violation, and both outcomes.
 
-**Expected result**: ten proofs in three groups — **four** fail-open, **three**
-loop and cost, **three** integration, per the plan's proof-group table.
+**Expected result**: eleven proofs in three groups — **five** fail-open,
+**three** loop and cost, **three** integration, per the plan's proof-group
+table.
 
 P2 is the one to read twice: returning `not_required` for a history with no
 local verdict is the natural default, it passes every scenario that supplies a

--- a/docs/testing/workflow/1656-second-local-pass.smoke-test.md
+++ b/docs/testing/workflow/1656-second-local-pass.smoke-test.md
@@ -60,8 +60,25 @@ look alike — and this is telemetry #1657 will read.
    `loop_head_sha`.
 2. Compare the platform dispatch sequence to the same run before this change.
 
-**Expected result**: byte-for-byte identical. The guard adds nothing to the path
-it does not need to protect.
+3. Compare the loop's entire `key=value` output to the same run before this
+   change.
+
+**Expected result**: the dispatch sequence and the whole `key=value` output are
+byte-for-byte identical. The guard adds nothing to the path it does not need to
+protect.
+
+Two different things are being checked. The **dispatch** comparison depends on
+the condition seeing the current round: by the time the guard runs, the local
+reviewer has usually already reported in this cycle, and its verdict lives only
+in memory — the ledger entry carrying it is written at the end of the cycle.
+Reading the persisted payload alone makes every ordinary run owe a pass it does
+not need. Proof P7.
+
+The **output** comparison is about the extraction. The parsing, aggregation,
+forwarding and ledger accumulation live inline in the platform loop after
+`run_platform_review`, so the guard cannot reuse them without extracting them
+into a shared function first. That extraction touches the busiest block in the
+script, and this is the only check that it changed nothing. Proof P8.
 
 ## Step 4: A clean second pass opens the gate
 
@@ -72,9 +89,15 @@ it does not need to protect.
 2. Let the loop reach the ready-phase gate.
 
 **Expected result**: the local reviewer is dispatched **once** before
-`ensure_pr_ready_for_ready_phase`, through `run_platform_review` like any
-platform; it reports clean; the pull request is converted; ready-phase reviewers
-run. `LOCAL_SECOND_PASS=1`, `LOCAL_SECOND_PASS_REASON=head_changed`.
+`ensure_pr_ready_for_ready_phase`; it reports clean; the pull request is
+converted; ready-phase reviewers run. `LOCAL_SECOND_PASS=1`,
+`LOCAL_SECOND_PASS_REASON=head_changed`.
+
+Assert the pass appears in the **ledger entry** and the `key=value` output, not
+only that the gate opened. A guard that calls `run_platform_review` and skips
+the shared processor still decides the gate correctly and records nothing — the
+telemetry would then say the gate opened with no evidence of what opened it.
+Proof P8.
 
 ## Step 5: A failed second pass closes it, and changes nothing else
 
@@ -203,11 +226,12 @@ ready-phase gate already existed and this alters when it fires.
 ## Step 12: Planted-violation proofs
 
 1. Read the implementation PR's `Planted-Violation Proofs` heading.
-2. Confirm P1 through P6 each record the command, the file and line of the
+2. Confirm P1 through P8 each record the command, the file and line of the
    planted violation, and both outcomes.
 
-**Expected result**: six proofs in two groups — **three** fail-open, **three**
-loop and cost, per the plan's proof-group table.
+**Expected result**: eight proofs in three groups — **three** fail-open,
+**three** loop and cost, **two** integration, per the plan's proof-group
+table.
 
 P2 is the one to read twice: returning `not_required` for a history with no
 local verdict is the natural default, it passes every scenario that supplies a


### PR DESCRIPTION
## What

Implementation plan and smoke-test runbook for **#1656 — Run a second local pass after reviewer fixes** (epic #1647). Refactor item: plan only, no spec.

## The gap

Before the first ready-phase reviewer runs, the loop calls `ensure_pr_ready_for_ready_phase` — which converts the pull request to ready and nothing else. It never asks whether the local reviewer has reported clean on the commit about to be reviewed.

Within an ordinary run it usually has, because platforms are dispatched in order every cycle. The gap is the cases where it has not, and those are ordinary operating cases here: an invocation whose `--platform` list omits the local reviewer (which `filter_phase_after_clean_platforms` permits), a `--draft-github-only` run followed by a separate ready-phase run, and a head that moved after the local reviewer last spoke.

## The design

One guard immediately before that gate. If the local reviewer's most recent verdict is not clean on `loop_head_sha`, dispatch it once more; a clean pass opens the gate, anything else ends the cycle and the pull request is **not** converted.

**A re-dispatch, not a refusal** — and that distinction is the seam with #1649, which the plan states as a table. #1649 decides *whether to dispatch* an expensive reviewer given the evidence; this decides *whether to produce* the evidence first. They compose in one order only: implemented as two refusals, the loop could never advance past a local finding, because the thing that would clear the refusal is the dispatch the refusal prevents.

## Two decisions worth your eye

1. **Silence owes a pass.** A history that never names the local reviewer returns `no_evidence`, not `not_required`. Treating silence as satisfaction is the same fail-open this epic exists to close, and it is exactly what an invocation without the local reviewer produces. Proof P2 plants the permissive default — it passes every scenario that supplies a verdict.
2. **The anti-loop guarantee is a head-keyed flag, not a counter.** One pass per *commit*, and the loop cannot manufacture a commit. A per-cycle boolean reads as "at most once" and allows one pass per cycle forever, burning the whole budget on a pull request whose reviewer never goes clean. Proof P1, and scenario 6 counts dispatches across cycles rather than reading the flag.

Neither cycle cap is incremented: the pass is a dispatch inside an already-counted cycle, and incrementing would make `max_cycles_exceeded` mean two different things while silently shortening every run the guard helps.

## Scope and evidence

28 scenarios, 15 planted-violation proofs (seven fail-open, five loop-and-cost, three integration), 14 runbook steps. Counts verified by extraction. Every line-number reference read at `d55d3e7f`.

**Dependency**: #1648 must be implemented and merged first — the condition reads its per-reviewer `reviewed_heads[]`. Implementation Order step 0 also requires reading #1649's implementation to confirm it is a check and not a combined gate.

## Document Quality Gate

- Spec/brief coverage: Checked - all three brief scope bullets map to implementation steps and scenarios; the cycle-cap bullet has two scenarios and a proof.
- Implementation-order consistency: Checked - the condition's four values, the two keys and the flag's key agree across Layer-by-Layer, Testing Strategy, Seed Data and Implementation Order.
- Verification support: Checked - every claim about existing behavior cites a Verification Log command with line numbers, read at `d55d3e7f`, including the break-on-blocking behavior that bounds how often the gap is reachable.
- Behavioral guarantees: Checked - at-most-once-per-head, caps-unchanged and no-gate-no-guard each name the mechanism that enforces them.
- Complex workflow decision-gate matrix: Checked - the condition is a four-row table over the local reviewer's most recent verdict, with the absence row stated as the fail-closed one.
- Parser/API/concurrency checklist: Checked - no parser surface; the concurrency-adjacent signal is the head moving mid-run, which is what the head-keyed flag addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; workflow behavior is unchanged until a follow-up implementation PR lands.
> 
> **Overview**
> Adds **documentation only** for issue #1656 (epic #1647): no changes to `pr-review-loop.sh` or tests in this PR.
> 
> **New artifacts:** an implementation plan under `docs/specs/developments/20260828230000_1656-second-local-pass/` and a linked smoke-test runbook at `docs/testing/workflow/1656-second-local-pass.smoke-test.md`.
> 
> The plan specifies a future guard **before** `ensure_pr_ready_for_ready_phase`: when local clean evidence is missing or stale on `loop_head_sha`, **re-dispatch** the local reviewer once (contrast with #1649’s fail-closed refusal for expensive reviewers). It defines `reviewer_loop_local_pass_required` (five outcomes), `reviewer_loop_repo_configured_platforms` (repo config vs invocation `--platform`), extraction of `reviewer_loop_process_platform_output`, ledger field `local_second_pass_failed_head`, telemetry keys `LOCAL_SECOND_PASS` / `LOCAL_SECOND_PASS_REASON`, and composition order with #1649.
> 
> **Dependencies and verification:** hard sequencing **#1648 → #1651 → #1656**; verification log cites current `pr-review-loop.sh` line ranges at `d55d3e7f`. The runbook maps ~12 steps to scenarios, static checks, and **15 planted-violation proofs** for the eventual implementation PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 940bd850ca59e87849cf17488d937c882ab50d1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->