### PR TITLE
docs(#1650): enumerate the strict checks not completing as a matrix row

### DIFF
--- a/docs/specs/developments/20260829021000_1650-strict-spec-contract-review/1_1650-strict-spec-contract-review_specs.md
+++ b/docs/specs/developments/20260829021000_1650-strict-spec-contract-review/1_1650-strict-spec-contract-review_specs.md
@@ -199,11 +199,21 @@ Each is stated as the question it asks and the shape of a finding it produces. T
 
 | State | Meaning |
 | --- | --- |
-| `applied` | The checks ran; the count is what they found, and may be zero |
+| `applied` | The checks ran to completion; the count is what they found, and may be zero |
 | `not_applicable` | The change is not at the spec stage |
-| `unavailable` | The checks could not run — the stage could not be resolved, or the checklist is missing |
+| `unavailable` | The checks did not produce a result — one of three causes below |
 
 Three states, and `applied` with a count of zero is deliberately not the same as `unavailable`. The **count accompanies `applied` only**: it is empty in the other two states, because a number there would claim the checks reached a verdict they never reached.
+
+`unavailable` has **three causes**, and they are three different things to go and fix:
+
+| Cause | What happened | Whose |
+| --- | --- | --- |
+| `stage_unresolved` | The change's stage could not be classified, so the checks were never attempted | the pull request's shape |
+| `checklist_unreadable` | The stage is `spec` and the checklist is missing or unreadable, so the checks were never attempted | the repository's contents |
+| `strict_pass_failed` | The checks were attempted and did not complete — however they failed | the reviewer command or its environment |
+
+The first two mean *never started*; the third means *started and did not finish*. A reader given only `unavailable` cannot tell which, and the three have different owners, which is why the cause is reported wherever the state is.
 
 ---
 

--- a/docs/specs/developments/20260829021000_1650-strict-spec-contract-review/1_1650-strict-spec-contract-review_specs.md
+++ b/docs/specs/developments/20260829021000_1650-strict-spec-contract-review/1_1650-strict-spec-contract-review_specs.md
@@ -93,26 +93,27 @@ Every objective stated in issue #1650 maps to acceptance criteria and use cases 
 
 **Considerations**:
 
-- **Silence and zero are different**, and the distinction is the feature's only defence against quietly not working. A run where the checks did not fire — wrong stage, missing checklist, an older reviewer — must not look like a run where they fired and found nothing.
+- **Silence and zero are different**, and the distinction is the feature's only defence against quietly not working. A run where the checks did not fire — wrong stage, missing checklist, an older reviewer, or an attempt that failed — must not look like a run where they fired and found nothing.
 
 ---
 
-### Use Case 4: The strict checklist is unavailable
+### Use Case 4: The strict checks produce no result
 
 **Actor**: The reviewer loop.
-**Preconditions**: The checklist cannot be supplied — the document is missing, or the stage could not be resolved.
+**Preconditions**: The checks reach no verdict, for one of three reasons — the stage could not be resolved, the checklist is missing or unreadable, or the checks were attempted and did not complete.
 
 **Steps**:
 
 1. The reviewer runs its ordinary review.
-2. It records that the strict checks did not run, and why.
+2. It records that the strict checks produced no result, and which of the three causes applies.
 
-**Postconditions**: The review completed and its verdict is unaffected. The record says the strict checks were absent.
+**Postconditions**: The review completed and its verdict is unaffected. The record says the strict checks reached no verdict, and says why.
 
 **Considerations**:
 
-- The review is never failed for this. The strict checks are an addition to a review, not a precondition for one.
-- What must not happen is the silent case: a review that reports no strict findings because none ran.
+- **Two of the causes mean the checks never started; the third means they started and did not finish.** The outcome for the review is identical — no findings, no verdict change, nothing gated — and the outcome for whoever has to fix it is not. A missing checklist is a repository defect; a pass that crashes is a defect in the reviewer command or its environment, and it is the only one of the three that can appear and disappear between two rounds of the same pull request.
+- The review is never failed for this, whichever cause applies. The strict checks are an addition to a review, not a precondition for one — and that has to hold for a failure *inside* them as much as for their absence, or an unrelated defect in the reviewer command starts blocking pull requests that had no findings.
+- What must not happen is the silent case: a review that reports no strict findings because none ran, or because the run died.
 
 ---
 

--- a/docs/specs/developments/20260829021000_1650-strict-spec-contract-review/1_1650-strict-spec-contract-review_specs.md
+++ b/docs/specs/developments/20260829021000_1650-strict-spec-contract-review/1_1650-strict-spec-contract-review_specs.md
@@ -211,15 +211,18 @@ Three states, and `applied` with a count of zero is deliberately not the same as
 
 The complete gate, from a review starting to strict findings existing or not. Rows are evaluated in order and the first match decides.
 
-| # | Stage resolves | Stage | Checklist available | Checks run | Findings | State | Count | Check ids | Verdict affected |
+| # | Stage resolves | Stage | Checklist available | Checks complete | Findings | State | Count | Check ids | Verdict affected |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | **No** | — | — | No | — | `unavailable` | **empty** | **empty** | No |
-| 2 | Yes | not spec | — | No | — | `not_applicable` | **empty** | **empty** | No |
-| 3 | Yes | spec | **No** | No | — | `unavailable` | **empty** | **empty** | No |
-| 4 | Yes | spec | Yes | Yes | none | `applied` | `0` | empty list | No |
-| 5 | Yes | spec | Yes | Yes | one or more | `applied` | *n* | the checks that fired | **No** |
+| 1 | **No** | — | — | not attempted | — | `unavailable` | **empty** | **empty** | No |
+| 2 | Yes | not spec | — | not attempted | — | `not_applicable` | **empty** | **empty** | No |
+| 3 | Yes | spec | **No** | not attempted | — | `unavailable` | **empty** | **empty** | No |
+| 4 | Yes | spec | Yes | **No** | — | `unavailable` | **empty** | **empty** | No |
+| 5 | Yes | spec | Yes | Yes | none | `applied` | `0` | empty list | No |
+| 6 | Yes | spec | Yes | Yes | one or more | `applied` | *n* | the checks that fired | **No** |
 
-Five rows over three ordered inputs: can the stage be resolved, is it the spec stage, is the checklist available. The order matters — an unresolved stage cannot be compared against `spec`, so row 1 precedes row 2 and no combination evaluates both.
+Six rows over four ordered inputs: can the stage be resolved, is it the spec stage, is the checklist available, did the checks complete. The order matters — an unresolved stage cannot be compared against `spec`, and checks never attempted cannot complete — so row 1 precedes row 2, rows 1 through 3 precede row 4, and no combination evaluates an input the earlier answer made unreachable.
+
+**Row 4 is the one this specification originally omitted**, and the omission is exactly the `gate_matrix` shape check 3 exists to catch: the first draft enumerated the three inputs that decide whether to *start* the checks and never the one that decides whether they *finished*. It was found while planning the implementation, and it is recorded here rather than quietly repaired, because a specification that demands enumerated gates and ships an unenumerated one is the strongest argument the check has.
 
 **The count is empty, not zero, in every row but the last two.** `0` means *the checks ran and found nothing*, and it is the only thing distinguishing a clean specification from one the checks never examined. Writing `0` for `unavailable` or `not_applicable` would put those rounds into the denominator of any later rate as if they had been checked, which is precisely the measurement this feature exists to make possible.
 
@@ -230,31 +233,31 @@ surface is left to inference:
 
 | State | Next action | Reviewer output | Review comments | Reviewer-loop history |
 | --- | --- | --- | --- | --- |
-| `unavailable` (rows 1, 3) | none — the review proceeds and its verdict is unchanged | the state and its cause; no count, no identifiers | nothing added | the state and its cause; count and identifiers empty |
+| `unavailable` (rows 1, 3, 4) | none — the review proceeds and its verdict is unchanged | the state and its cause; no count, no identifiers | nothing added | the state and its cause; count and identifiers empty |
 | `not_applicable` (row 2) | none | the state; no count, no identifiers | nothing added | the state; count and identifiers empty |
-| `applied`, count `0` (row 4) | none | the state and count `0`; identifier list empty | nothing added | the state, count `0`, empty identifier list |
-| `applied`, count *n* (row 5) | none that gates — the findings are reported and the verdict is decided without them | the state, the count, and the identifiers that fired | each finding, labelled with its check, grouped apart from blocking findings | the state, the count, and the identifiers that fired |
+| `applied`, count `0` (row 5) | none | the state and count `0`; identifier list empty | nothing added | the state, count `0`, empty identifier list |
+| `applied`, count *n* (row 6) | none that gates — the findings are reported and the verdict is decided without them | the state, the count, and the identifiers that fired | each finding, labelled with its check, grouped apart from blocking findings | the state, the count, and the identifiers that fired |
 
 **"Next action" is empty in every row, and that is the feature.** No state
 gates, escalates, retries or demands acknowledgement. The only row with any
-follow-up is row 5, whose follow-up is to *report* — which is why the column
+follow-up is row 6, whose follow-up is to *report* — which is why the column
 exists rather than being omitted: a reader checking whether some state blocks
 should find the answer here rather than infer it from silence.
 
 The comment surface is touched in exactly one row. A reader seeing no strict
-findings on a pull request cannot tell rows 1 through 4 apart from the comments
+findings on a pull request cannot tell rows 1 through 5 apart from the comments
 alone, which is why the state is on the reviewer output and in the history for
 every review.
 
-Row 5's last column is the feature's central claim and the one most likely to erode: findings exist, are labelled, are counted, and change nothing about whether the pull request may proceed.
+Row 6's last column is the feature's central claim and the one most likely to erode: findings exist, are labelled, are counted, and change nothing about whether the pull request may proceed.
 
-Rows 1, 2 and 3 differ in what a reader can conclude. Row 2 is a change the checks do not apply to; rows 1 and 3 are changes the checks *should* have examined and could not — one because the stage was unknown, one because the checklist was missing. Both are defects, with different owners, and collapsing either into "no strict findings" makes it invisible.
+Rows 1 through 4 differ in what a reader can conclude. Row 2 is a change the checks do not apply to; rows 1, 3 and 4 are changes the checks *should* have examined and could not — the stage was unknown, the checklist was missing, or the checks were attempted and did not finish. All three are defects, with three different owners — the pull request's shape, the repository's contents, the reviewer command or its environment — and collapsing any of them into "no strict findings" makes it invisible.
 
 ---
 
 ## Operational Visibility
 
-- **Reviewer output**: the strict-check state on every review, and the finding count when the state is `applied`.
+- **Reviewer output**: the strict-check state on every review, its cause in each `unavailable` row, and the finding count when the state is `applied`.
 - **Review comments**: each strict finding, labelled with its check identifier, grouped separately from blocking findings.
 - **Reviewer-loop history**: per round, the state, the count where it applies, and **which checks produced findings** — the set of check identifiers, not only how many findings there were.
 
@@ -282,6 +285,7 @@ Rows 1, 2 and 3 differ in what a reader can conclude. Row 2 is a change the chec
 - [ ] **AC-14.** The strict checks do not run outside the spec stage, and the state is `not_applicable`.
 - [ ] **AC-15.** At the spec stage with the checks applied and nothing found, the state is `applied` and the count is `0` — distinguishable from `unavailable` and from `not_applicable`.
 - [ ] **AC-16.** When the checklist cannot be supplied, the state is `unavailable`, the review still runs, and its verdict is unaffected.
+- [ ] **AC-16a.** When the checks are attempted and do not complete — however they fail — the state is `unavailable` with a cause distinguishing it from the other two, the review still runs, and its verdict, findings and their order are what the same review produces with the checks never attempted. A failure in the checks never blocks, delays or alters a review.
 - [ ] **AC-17.** The state appears in the reviewer's output and in the reviewer-loop history for **every** review, at any stage. The count **and** the set of check identifiers that produced findings accompany it only in the `applied` state; in `not_applicable` and `unavailable` both are **empty**, and the count is never `0`.
 - [ ] **AC-17b.** A reader can determine, from the history alone, **which** checks produced findings on a round — not only how many findings there were.
 - [ ] **AC-17c.** Two rounds reporting the same unresolved finding count that check **once** for the pull request: incidence is per pull request, and repeated rounds do not increase it.


### PR DESCRIPTION
## What

Adds one row to #1650's decision matrix, one cause to the `unavailable` state, and AC-16a.

The matrix enumerated three ordered inputs — can the stage be resolved, is it the spec stage, is the checklist available — and called itself "the complete gate". All three decide whether the checks **start**. None decides whether they **finish**. A dispatched run of the checks that fails leaves the state unenumerated.

## Why now

Found while planning the implementation (#1676). The plan runs the strict checks as their own invocation, and any invocation can fail; the plan needed a state for it and the spec had none. Rather than let the plan add a state its spec does not contain — the exact divergence this epic keeps finding elsewhere — the gap goes back through the spec stage.

**It is also the specification's own check firing on itself.** Check 3, `gate_matrix`, exists to find "a described gate with a reachable combination unmentioned". This document defines check 3 and shipped with one. That is recorded in the spec rather than quietly repaired, because it is the strongest evidence the check has that it is worth having.

## Changes

- **Row 4**: stage resolves, stage is `spec`, checklist available, checks **do not complete** → `unavailable`, count and identifiers empty, verdict unaffected. The matrix is now six rows over four ordered inputs, and the ordering paragraph states which combinations the earlier answers make unreachable — as check 3 requires of any gate.
- **`strict_pass_failed`**, the third cause of `unavailable`. The three have three owners: the pull request's shape, the repository's contents, and the reviewer command or its environment.
- **AC-16a**: when the checks are attempted and do not complete, however they fail, the review's verdict, findings and their order are what the same review produces with the checks never attempted. A failure in the checks never blocks, delays or alters a review.
- Row references renumbered throughout; the `unavailable` row list in the outcome table now reads rows 1, 3, 4.

## Verification

- `markdownlint-cli2` and `markdown-heuristic-lint.py`: both clean.
- Matrix: 6 rows, 4 inputs, row count and input list match the prose, by extraction.
- No acceptance criterion removed or weakened; AC-16 is unchanged and AC-16a sits beside it.

Depends on nothing. #1676 (the implementation plan) depends on this.


## Document Quality Gate

- Brief coverage: Checked - the change is scoped to one gap found while planning #1650; it adds no capability and removes none. Every edit traces to the same omission: the matrix enumerated the inputs deciding whether the checks start and none deciding whether they finish.
- Internal consistency: Checked - `strict_pass_failed` now appears at the canonical state definition, in the causes table, in matrix row 4, in the outcome table's `unavailable` row list (rows 1, 3, 4), in Use Case 4 and in AC-16a. The two blocking findings on this PR were both instances of the same defect - the contract amended in one place and not another - and the sweep after each was an extraction, not a reading.
- Behavioral guarantees: Checked - AC-16a states the guarantee positively and testably: verdict, findings and their order equal what the same review produces with the checks never attempted. "Never blocks, delays or alters" is backed by that equality rather than asserted as prose.
- Complex workflow decision-gate matrix: Checked, and it is the substance of this PR. The gate now has four ordered inputs and six rows. The ordering paragraph states which combinations the earlier answers make unreachable - an unresolved stage is never compared against `spec`, and checks never attempted cannot complete - which is what check 3 requires of any gate that short-circuits. Rows: 1 stage unresolved, 2 non-spec stage, 3 checklist unavailable, 4 checks do not complete, 5 applied with zero findings, 6 applied with findings. Next action is empty in all six; no row gates, escalates or retries.
- Reviewer-risk categories: Checked - edge cases (a pass that starts and dies, distinguishable from one never attempted), enum surface (three reason values with one definition site), and ambiguity bounds (row 4 says "however they fail", so no failure shape is left to inference).

**Note on provenance**: this amendment exists because the specification's own check 3 shape was present in the specification that defines check 3. It is recorded rather than quietly repaired.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only contract amendment for #1650; no runtime code paths change until implementation (#1676) follows this spec.
> 
> **Overview**
> Closes a **gate_matrix**-shaped gap in the #1650 spec: the decision matrix previously covered only whether strict checks **start** (stage, checklist) and not whether they **finish**.
> 
> The matrix grows from five rows over three inputs to **six rows over four** — new **row 4** is spec stage with a readable checklist but checks **do not complete** → `unavailable` with empty count/ids and no verdict change. Prose calls out that this row was the spec’s own missing reachable combination.
> 
> **`unavailable`** is reframed as “no result” with **three reported causes**: `stage_unresolved`, `checklist_unreadable`, and new **`strict_pass_failed`** (attempted but did not finish; owned by the reviewer command/environment). Use Case 4, state definitions, outcome/visibility tables, and row references are aligned so incomplete runs are not confused with “ran and found zero.”
> 
> Adds **AC-16a**: a failed strict pass must not block, delay, or alter the review — verdict, findings, and order match a run where checks were never attempted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fb8ae0d82ed71bd45336f553ad78f46d235b03e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->