### PR TITLE
docs(#1655): coverage follows what is present, not what the plan declares

### DIFF
--- a/docs/specs/developments/20260831062000_1655-strict-plan-review-mode/1_1655-strict-plan-review-mode_specs.md
+++ b/docs/specs/developments/20260831062000_1655-strict-plan-review-mode/1_1655-strict-plan-review-mode_specs.md
@@ -98,7 +98,7 @@ What that gate cannot see is a step **inside** the plan document that nothing in
 ### Use Case 3: A plan is reviewed with part of the checklist
 
 **Actor**: The local reviewer.
-**Preconditions**: The change is at the plan stage and no approved spec is available to the reviewer — because the item is a Refactor whose brief is the tracker issue, because the plan declares an approved spec that is not there, or because the plan declares no source at all.
+**Preconditions**: The change is at the plan stage and no approved spec is present in the plan's development directory — because the item is a Refactor whose brief is the tracker issue, or because the spec the plan needs is not there.
 
 **Steps**:
 
@@ -112,9 +112,9 @@ What that gate cannot see is a step **inside** the plan document that nothing in
 
 - **A count without its denominator is not a rate**, and this is the case that forces the point. Two plans each reporting one finding are not comparable if one was asked seven questions and the other four. #1657 computes incidence per check, and a check that was never applied belongs in neither the numerator nor the denominator.
 - Partial coverage is **not** a failure state. Nothing is retried, nothing is gated, and the review's verdict is what it would be with all seven applied. It is an ordinary outcome for an ordinary kind of item, and the only thing required of it is that it be visible.
-- **Partial coverage has exactly one cause — no approved spec is available to the reviewer — and that cause arises in three ways.** A Refactor plan declaring a tracker brief is the ordinary one, and nobody is at fault for it. A plan declaring an approved spec that is not present, and a plan declaring no source at all, are the other two, and both are defects in the plan.
-- **All three produce the same applied set**, because the three source-dependent checks have nothing to compare against in any of them. What tells them apart is `source_declaration`: it fires on the two defects and stays silent on the Refactor.
-- Coverage therefore records *what was asked*, and check 1 records *whether the plan was at fault for the gap*. Reading a partial applied set as an accusation, or the absence of a `source_declaration` finding as full coverage, gets both backwards.
+- **Partial coverage has exactly one cause**: no approved spec is present in the plan's development directory. Nothing about the plan's own text enters this; the three source-dependent checks have nothing to compare against, and that is the whole of it.
+- **Coverage and fault are different axes, and this specification keeps them apart.** The applied set records *what was asked*. `source_declaration` records *whether the plan named its source correctly*. A Refactor plan with a partial set and no finding is in good order; a plan with a full set and a `source_declaration` finding is not. Reading a partial applied set as an accusation gets the two crossed.
+- **A plan that declares nothing is still checked against a spec that is there.** The source-dependent checks compare a plan to a document, and the document's presence is what decides whether they can. Withholding an available spec to penalise a missing declaration would review the plan less thoroughly *because* it has a defect — and that defect is already reported, by check 1.
 
 ---
 
@@ -181,7 +181,7 @@ What that gate cannot see is a step **inside** the plan document that nothing in
 - The checks are applied to the **full text of each changed plan document at the reviewed head**, and to the full text of its source when that source is in the repository — not to the pull request's diff. A plan amended in a later pull request has most of its content outside that diff, and checks run over hunks would report absences that are artifacts of where the diff happens to end.
 - Every review reports the strict-plan **state**. The **count**, the set of **checks that produced findings**, and the set of **checks that were applied** accompany it only when the state is `applied` — the count including when it is zero — and are empty otherwise.
 - The set of applied checks is reported whenever the state is `applied`, including when it is all seven. A reader must never have to infer coverage from the spec's text and the round's date.
-- **Partial coverage has exactly one cause**: no approved spec is available to the reviewer. That cause arises in three ways — the item is a Refactor whose brief is the tracker issue, the plan declares an approved spec that is absent, or the plan declares no source at all — and the applied set is identical in all three. Only the last two produce a `source_declaration` finding. There is no separate field recording the cause, because a second place to state one fact is a second place for two statements to disagree; the applied set and check 1's finding are the record.
+- **Partial coverage has exactly one cause**: no approved spec is present in the plan's development directory. It is decided by what is present and never by what the plan declares — the two are independent, and a round can have full coverage and a `source_declaration` finding at once, or partial coverage and none. There is no separate field recording the cause, because a second place to state one fact is a second place for two statements to disagree; the applied set and check 1's finding are the record.
 - The state of each strict checklist is reported **independently**. A review at the spec stage reports the plan checklist as `not_applicable` and the spec checklist as `applied`, and the reverse holds at the plan stage. #1650's contract is unchanged by this item.
 - At most one strict checklist reaches the `applied` state on any review, because a change has one stage.
 - Incidence is measured **per pull request**, never by summing rounds: a check fired on a plan if any of its rounds reported that check, and was applied to that plan if any of its rounds applied it.
@@ -254,17 +254,22 @@ Each of `not_applicable` and `unavailable` carries a **reason**, and each reason
 
 The complete gate, from a review starting to strict findings existing or not. Rows are evaluated in order and the first match decides.
 
-The order asks three questions about the change before either question about the machinery: **what is this change** (rows 1–3), **can the checks run** (rows 4–5), **what did they find** (rows 6–10). An unresolved stage cannot be compared against `plan`; a pull request with no plan document has nothing for a checklist to be applied to; and checks never attempted cannot complete. No row evaluates an input that an earlier answer made unreachable.
+The order asks three questions about the change before either question about the machinery: **what is this change** (rows 1–3), **can the checks run** (rows 4–5), **what did they find** (rows 6–9). An unresolved stage cannot be compared against `plan`; a pull request with no plan document has nothing for a checklist to be applied to; and checks never attempted cannot complete. No row evaluates an input that an earlier answer made unreachable.
 
-**Plan's source** is the sixth input and takes three values, which partition every reachable case:
+**Plan's source** is the sixth input and takes two values, which partition every reachable case:
 
 | Value | Meaning |
 | --- | --- |
-| `spec readable` | The plan declares an approved spec and it is present in the development directory |
-| `no spec readable` | The plan declares an approved spec that is not present, **or** declares no source at all |
-| `tracker brief` | The plan declares that the item is a Refactor whose brief is the tracker issue |
+| `spec present` | An approved spec is present in the plan's development directory |
+| `no spec present` | None is |
 
-**`no spec readable` covers two distinct plan defects, and they share a row** because they share every output: the same applied set, a count above zero, and `source_declaration` in the fired set. Check 1's finding is what names which defect it was — a plan pointing at a spec that is not there, or a plan pointing at nothing. Splitting them into two matrix rows would produce rows differing in no column, which is padding rather than enumeration.
+**The input is what is present, not what the plan declares**, and the distinction is this feature's sharpest line. Whether a plan *named* its source is check 1's question and is answered in a finding; whether a source *exists to compare against* decides what can be checked at all. They are independent, and collapsing them costs something real in both directions:
+
+- A plan that declares nothing while its spec sits beside it is checked against that spec — all seven apply — **and** produces a `source_declaration` finding. Withholding an available source to punish a missing declaration would review the plan less thoroughly as a penalty for a defect the checklist already reports.
+- A plan that declares a spec which is absent gets the four, because there is nothing to compare against, **and** produces a `source_declaration` finding for naming a source that is not there.
+- A Refactor plan correctly declaring its tracker brief gets the four and produces **no** finding.
+
+An earlier revision of this specification made the input three-valued and keyed it on the declaration. That was a `trigger_semantics` defect of the kind check 5 exists to catch: it stated a gate's input as something the gate cannot observe. It was found while planning the implementation, and it is corrected here rather than worked around there — a plan cannot amend its own spec.
 
 | # | Stage resolves | Stage | Plan doc changed | Checklist available | Checks complete | Plan's source | Findings | State | Reason | Applied checks | Count | Checks that fired |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -273,17 +278,14 @@ The order asks three questions about the change before either question about the
 | 3 | Yes | plan | **No** | — | not attempted | — | — | `not_applicable` | `no_plan_document_changed` | **empty** | **empty** | **empty** |
 | 4 | Yes | plan | Yes | **No** | not attempted | — | — | `unavailable` | `checklist_unreadable` | **empty** | **empty** | **empty** |
 | 5 | Yes | plan | Yes | Yes | **No** | — | — | `unavailable` | `strict_pass_failed` | **empty** | **empty** | **empty** |
-| 6 | Yes | plan | Yes | Yes | Yes | `spec readable` | none | `applied` | none | all seven | `0` | empty list |
-| 7 | Yes | plan | Yes | Yes | Yes | `spec readable` | one or more | `applied` | none | all seven | *n* | the checks that fired |
-| 8 | Yes | plan | Yes | Yes | Yes | `no spec readable` | one or more | `applied` | none | the four needing no source | *n* | the checks that fired, always including `source_declaration` |
-| 9 | Yes | plan | Yes | Yes | Yes | `tracker brief` | none | `applied` | none | the four needing no source | `0` | empty list |
-| 10 | Yes | plan | Yes | Yes | Yes | `tracker brief` | one or more | `applied` | none | the four needing no source | *n* | the checks that fired |
+| 6 | Yes | plan | Yes | Yes | Yes | `spec present` | none | `applied` | none | all seven | `0` | empty list |
+| 7 | Yes | plan | Yes | Yes | Yes | `spec present` | one or more | `applied` | none | all seven | *n* | the checks that fired |
+| 8 | Yes | plan | Yes | Yes | Yes | `no spec present` | none | `applied` | none | the four needing no source | `0` | empty list |
+| 9 | Yes | plan | Yes | Yes | Yes | `no spec present` | one or more | `applied` | none | the four needing no source | *n* | the checks that fired |
 
-**Rows 8 through 10 are not degraded rows 6 and 7.** The plan's source does not gate anything; it partitions the applied set. That is why it is evaluated after completion rather than before: it changes what the checks cover, never whether they run.
+**Rows 8 and 9 are not degraded rows 6 and 7.** The plan's source does not gate anything; it partitions the applied set. That is why it is evaluated after completion rather than before: it changes what the checks cover, never whether they run.
 
-**There is no row pairing `no spec readable` with no findings, and the omission is not an oversight.** A plan that names a spec which is not there, or names nothing at all, produces a `source_declaration` finding by definition of check 1, so that combination is unreachable. That is why rows 8 through 10 are three rather than four: `tracker brief` takes both the find and find-nothing branches, and `no spec readable` takes only one.
-
-**Rows 8, 9 and 10 have the same applied set and differ in what fired.** All three mean the source-dependent checks had nothing to compare against. Only row 8 necessarily carries a defect in *how the plan declares its source*; row 10's findings come from the other applied checks and say nothing about the declaration, which is valid there. `source_declaration` in the fired set is the whole of what separates the two.
+**Every one of the four `applied` rows can carry a `source_declaration` finding, and none is required to.** Rows 6 and 7 differ from 8 and 9 in *coverage*, not in fault: a plan whose spec is present may still have named nothing, and a plan whose spec is absent may be a Refactor that named its brief correctly. Reading a partial applied set as an accusation — or full coverage as proof the plan declared properly — gets the two axes crossed. The fired set is where fault is recorded; the applied set is where coverage is.
 
 **The count is empty, not zero, in rows 1 through 5.** `0` means *the applied checks ran and found nothing*, and it is the only thing distinguishing a clean plan from one the checks never examined. Writing `0` for the other rows would put those rounds into the denominator of any later rate as if they had been checked.
 
@@ -297,12 +299,12 @@ The matrix decides the state; this table says what follows from it, so no surfac
 | --- | --- | --- | --- | --- |
 | `unavailable` (rows 1, 4, 5) | none — the review proceeds and its verdict is unchanged | the state and its reason; no count, no check sets | nothing added | the state and its reason; count and both sets empty |
 | `not_applicable` (rows 2, 3) | none | the state and its reason; no count, no check sets | nothing added | the state and its reason; count and both sets empty |
-| `applied`, count `0` (rows 6, 9) | none | the state, count `0`, and the applied set; fired set empty | nothing added | the state, count `0`, the applied set, and an empty fired set |
-| `applied`, count *n* (rows 7, 8, 10) | none that gates — the findings are reported and the verdict is decided without them | the state, the count, the applied set, and the checks that fired | each finding, labelled with its check and its document, grouped apart from blocking findings | the state, the count, the applied set, and the checks that fired |
+| `applied`, count `0` (rows 6, 8) | none | the state, count `0`, and the applied set; fired set empty | nothing added | the state, count `0`, the applied set, and an empty fired set |
+| `applied`, count *n* (rows 7, 9) | none that gates — the findings are reported and the verdict is decided without them | the state, the count, the applied set, and the checks that fired | each finding, labelled with its check and its document, grouped apart from blocking findings | the state, the count, the applied set, and the checks that fired |
 
-**"Next action" is empty in every row, and that is the feature.** No state gates, escalates, retries or demands acknowledgement. The only row group with any follow-up is 7, 8 and 10, whose follow-up is to *report* — which is why the column exists rather than being omitted: a reader checking whether some state blocks should find the answer here rather than infer it from silence.
+**"Next action" is empty in every row, and that is the feature.** No state gates, escalates, retries or demands acknowledgement. The only row group with any follow-up is 7 and 9, whose follow-up is to *report* — which is why the column exists rather than being omitted: a reader checking whether some state blocks should find the answer here rather than infer it from silence.
 
-The comment surface is touched in exactly one row group. A reader seeing no strict findings on a pull request cannot tell rows 1 through 6 and row 9 apart from the comments alone, which is why the state is on the reviewer output and in the history for every review.
+The comment surface is touched in exactly one row group. A reader seeing no strict findings on a pull request cannot tell rows 1 through 6 and row 8 apart from the comments alone, which is why the state is on the reviewer output and in the history for every review.
 
 ---
 
@@ -345,9 +347,9 @@ The comment surface is touched in exactly one row group. A reader seeing no stri
 - [ ] **AC-16d.** A budget exhausted before or during the checks is `unavailable` with reason `strict_pass_failed`, and is not distinguished from any other failed attempt: the review is complete, its outcome is unaffected, and *the checks produced no result* is the whole of what a reader needs.
 - [ ] **AC-17.** The state appears in the reviewer's output and in the reviewer-loop history for **every** review, at any stage. The count, the applied set and the fired set accompany it only in the `applied` state; in `not_applicable` and `unavailable` all three are **empty**, and the count is never `0`.
 - [ ] **AC-18.** In the `applied` state the **set of checks applied** is reported, including when it is all seven, in the reviewer's output and in the reviewer-loop history.
-- [ ] **AC-19.** At the plan stage with the checks applied and the plan declaring a tracker brief rather than an approved spec, the applied set is exactly those that need no source — `source_declaration`, `phase_ordering`, `dependency_state` and `reversal_risk` — and the state is `applied`, not `unavailable`.
-- [ ] **AC-19b.** At the plan stage with the checks applied and no approved spec readable — the plan declaring one that is not present, or declaring no source at all — the applied set is the same as in AC-19 **and** the fired set contains `source_declaration`. The count is never `0` in either case.
-- [ ] **AC-19c.** The applied set is identical for all three ways a source can be unavailable; a reader tells the Refactor case from the two defects by whether `source_declaration` is in the fired set, and tells the two defects apart by reading that finding.
+- [ ] **AC-19.** At the plan stage with the checks applied and **no approved spec present** in the plan's development directory, the applied set is exactly those that need no source — `source_declaration`, `phase_ordering`, `dependency_state` and `reversal_risk` — and the state is `applied`, not `unavailable`. This holds whatever the plan declares.
+- [ ] **AC-19b.** The applied set is decided by the spec's **presence** alone. A plan that declares no source, or declares one that is not there, and whose development directory nonetheless contains an approved spec, has **all seven** applied — and still produces a `source_declaration` finding.
+- [ ] **AC-19c.** Coverage and `source_declaration` vary independently. All four combinations are producible: full coverage with the finding, full coverage without it, partial coverage with it, and partial coverage without it. No combination is reported as an error of the reporting itself.
 - [ ] **AC-19a.** The set of checks that fired is a subset of the set of checks applied, on every round in the `applied` state.
 - [ ] **AC-20.** Ignoring a strict finding has no effect on any later review: no **workflow label** on the pull request, no gate, no escalation, and the same finding may be reported again on a later round without penalty. The finding's own check identifier, required by AC-2, is unaffected — it identifies the finding and marks nothing about the pull request.
 - [ ] **AC-21.** A reader can determine, from the reviewer-loop history alone, **which** checks produced findings on a round and **which** were applied — not only how many findings there were.

--- a/docs/specs/developments/20260831062000_1655-strict-plan-review-mode/1_1655-strict-plan-review-mode_specs.md
+++ b/docs/specs/developments/20260831062000_1655-strict-plan-review-mode/1_1655-strict-plan-review-mode_specs.md
@@ -55,7 +55,7 @@ What that gate cannot see is a step **inside** the plan document that nothing in
 **Steps**:
 
 1. The loop starts a local review.
-2. The reviewer is given the ordinary review contract, and — new here — the strict plan checklist, the full text of every implementation-plan document the pull request changes, and the plan's declared source of truth when that source is in the repository.
+2. The reviewer is given the ordinary review contract, and — new here — the strict plan checklist, the full text of every implementation-plan document the pull request changes, and the approved spec whenever one is present in that plan's development directory — independently of what the plan declares.
 3. It applies each applicable check to each of those plan documents.
 4. It reports what it finds: ordinary findings as it does today, and strict-check findings **labelled as such**, each naming the check it came from and the plan document it applies to.
 5. The review's overall verdict is decided **without** the strict findings.
@@ -103,7 +103,7 @@ What that gate cannot see is a step **inside** the plan document that nothing in
 **Steps**:
 
 1. The reviewer applies each check that needs no source document: `source_declaration`, `phase_ordering`, `dependency_state` and `reversal_risk`.
-2. It does not apply the checks that compare the plan against its source — `unspecified_step`, `spec_traceability` and `ac_test_coverage` — because the source text is not in the repository, whichever of the three reasons put it out of reach.
+2. It does not apply the checks that compare the plan against its source — `unspecified_step`, `spec_traceability` and `ac_test_coverage` — because no approved spec is present in the development directory, and there is nothing for them to compare against.
 3. It reports the state, the findings, and **the set of checks it applied**.
 
 **Postconditions**: The review is complete and unaffected. A reader can tell that three checks did not run on this pull request, and which three.


### PR DESCRIPTION
## What

A spec amendment for #1655, found while planning its implementation (PR #1680) and sent through the spec stage because **a plan pull request cannot edit its own spec**. Same route as #1677 and #1678 took for #1650.

## The defect

The decision matrix's sixth input, *Plan's source*, was three-valued and keyed on **what the plan declares**:

| Value (before) | Meaning |
| --- | --- |
| `spec readable` | the plan declares an approved spec and it is present |
| `no spec readable` | the plan declares one that is not present, **or** declares no source at all |
| `tracker brief` | the plan declares a Refactor brief in the tracker |

**The gate cannot observe that input.** Whether a plan "declares" a source is prose, and reading it is `source_declaration`'s job — check 1, which this same specification defines. The implementation can see one thing: whether an approved spec exists in the plan's development directory.

The contradiction it produced is concrete. A plan that declares nothing while its spec sits beside it is `no spec readable` under the old text, so AC-19b gave it the four source-independent checks — while the spec it would have been compared against was right there, readable, unused. The specification asked the reviewer to check the plan **less thoroughly as a penalty** for a defect the checklist already reports.

This is a `trigger_semantics` defect of exactly the shape check 5 exists to catch: a gate whose stated input is not one its inputs can supply.

## The fix

*Plan's source* becomes two-valued and is decided by **presence**:

| Value (after) | Meaning |
| --- | --- |
| `spec present` | an approved spec is present in the plan's development directory |
| `no spec present` | none is |

**Coverage and fault become independent axes**, which is the substance of the amendment rather than a side effect:

- the **applied set** records what could be asked — it follows what is present;
- **`source_declaration`** records whether the plan named its source correctly — it follows what is declared.

All four combinations are producible and none is an error of the reporting: full coverage with the finding (a plan that declared nothing, spec present anyway), full coverage without it, partial coverage with it (a plan naming a spec that is not there), partial coverage without it (a Refactor correctly declaring its brief). AC-19c now says so in as many words.

## What changed

- **Matrix: 10 rows → 9.** The three-valued column becomes two-valued, and rows 8/9/10 become 8/9. The old note explaining why there was no *`no spec readable` + no findings* row is **removed** — under presence semantics that row is reachable and is row 8, because a Refactor plan with no spec present and no findings is in perfectly good order.
- **AC-19** now says the partial set holds "whatever the plan declares".
- **AC-19b** is inverted: it used to require the partial set when the plan declared nothing; it now requires **all seven** when a spec is present, and the `source_declaration` finding alongside.
- **AC-19c** is rewritten from "the applied set is identical for all three ways" to the independence claim and its four combinations.
- Use Case 3, the partial-coverage business rule, and the outcome table's row references follow.

Check 1's own definition (line 213) is unchanged: it still asks whether the plan names its source, and whether a named spec is present. That was always the right question — the mistake was letting the gate try to answer it.

## Why not fix it in the plan

The plan's reviewer proposed parsing the plan's `**Spec**:` header in shell to recover the declaration before deciding what to supply. That answers a checklist question with a regex, gets it wrong on the first plan that words the line differently, and makes a coverage decision on the result. The specification was wrong, not the implementation, and the specification is where it is repaired.

Nine acceptance criteria, one use case, one business rule and one matrix touched. **37 acceptance criteria, 9 decision rows, 7 checks, 6 use cases, 9 out-of-scope entries** after the change — counts verified by extraction.

## Document Quality Gate

- Brief coverage: Checked - the amendment adds no objective; #1655's eight objectives still map as the traceability table records, and objective 8 (coverage in the summary) is the one this sharpens.
- Internal consistency: Checked - `spec present` / `no spec present` replace all three old values; no occurrence of `spec readable`, `no spec readable` or `tracker brief` as an input value remains, and every row reference in the outcome table was renumbered.
- Behavioral guarantees: Checked - the independence of coverage and fault is AC-19c, and the presence-not-declaration rule is AC-19 and AC-19b, rather than prose.
- Complex workflow decision-gate matrix: Checked - 9 rows over six ordered inputs, evaluation order stated, and the row that the previous revision declared unreachable is now present and explained.
- Reviewer-risk categories: Checked - the removed unreachability note was re-examined rather than deleted, since a claim of unreachability that stops being true is worse than one that was never made.
