### PR TITLE
refactor(#1648): reviewer loop current-head evidence

### DIFF
--- a/changelog.d/1648.changed.reviewer-loop-current-head-evidence.md
+++ b/changelog.d/1648.changed.reviewer-loop-current-head-evidence.md
@@ -1,0 +1,1 @@
+- **Reviewer-loop current-head evidence** (#1648): the reviewer-loop summary and history now record which commit each reviewer actually reviewed, and a stale local-ai-reviewer clean result no longer satisfies `ready-for-human-review`.

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -1395,6 +1395,7 @@ After the selected item reaches a terminal condition, provide a concise summary:
 - Final state: ready for human review / waiting on human decision / blocked / escalated
 - Path taken: plan written -> reviewed -> PR opened -> automated review clean -> CI green
 - Next human action: merge PR / answer architecture question / unblock dependency
+- Local reviewer head evidence: LOCAL_AI_CONFIGURED=[0|1], LOCAL_AI_REVIEWED_HEAD=[sha|empty], LOCAL_AI_HEAD_CURRENT=[1|0|empty]
 
 ## Ground-Truth Completion Verification
 
@@ -2043,7 +2044,7 @@ set -euo pipefail
 # Drop settle telemetry from any earlier invocation first. A loop that exits
 # before emitting POST_CLEAN_* (outer timeout, interruption, API failure)
 # must leave Check 0.6 with nothing — not with the previous HEAD's verdict.
-for settle_var in $(env | grep -o '^POST_CLEAN_[A-Z_]*' || true); do
+for settle_var in $(env | grep -oE '^(POST_CLEAN|LOCAL_AI)_[A-Z_]*' || true); do
   unset "$settle_var"
 done
 loop_out="$(mktemp)"
@@ -2054,7 +2055,7 @@ if [ "$loop_status" -ne 0 ]; then
   echo "Reviewer loop exited ${loop_status}: act on its RESULT=/REASON= lines (needs_fixes, escalate, ...). Do not enter Step 8a on this run."
 else
   settle_kv="$(mktemp)"
-  grep -E '^POST_CLEAN_[A-Z_]+=[A-Za-z0-9:_-]*$' "$loop_out" > "$settle_kv" || true
+  grep -E '^(POST_CLEAN|LOCAL_AI)_[A-Z_]+=[A-Za-z0-9:_-]*$' "$loop_out" > "$settle_kv" || true
   while IFS='=' read -r key value; do
     export "$key=$value"
   done < "$settle_kv"
@@ -2419,7 +2420,7 @@ Interpret the result as follows:
 | 9         | Residual gate missing, blocked, or escalated for broad-scope work                                | Keep out of readiness; fix residuals, add `needs-fixes`, or escalate |
 | 10        | Documentation-stage alignment checker infrastructure failure                                     | Retry checker or resolve GitHub/diff read failure |
 | 11        | Complex workflow decision-gate matrix evidence missing or contradictory when applicable          | Keep out of readiness; add `needs-fixes`, complete matrix evidence, and re-run review |
-| 12        | Reviewer-loop clean verdict not settled (Check 0.6): `POST_CLEAN_*` fields absent, recheck suppressed, platform never submitted a review, settle window exhausted while the platform was active, or `POST_CLEAN_HEAD_SHA` differs from the live PR head | Do not label ready; re-run Step 7, export its `POST_CLEAN_*` fields, and re-enter Step 8a; a second consecutive `POST_CLEAN_SETTLE_TIMEOUT=1` escalates (`settle_never_quiet`) |
+| 12        | Reviewer-loop clean verdict not settled (Check 0.6 / 0.6b): `POST_CLEAN_*` or `LOCAL_AI_*` fields absent, recheck suppressed, platform never submitted a review, settle window exhausted while the platform was active, `POST_CLEAN_HEAD_SHA` differs from the live PR head, or `LOCAL_AI_HEAD_CURRENT` is not exactly `1` when `LOCAL_AI_CONFIGURED=1` | Do not label ready; re-run Step 7, export its `POST_CLEAN_*` and `LOCAL_AI_*` fields, and re-enter Step 8a; a second consecutive `POST_CLEAN_SETTLE_TIMEOUT=1` escalates (`settle_never_quiet`) |
 
 When adding a new gate to this checklist, allocate the next unused exit code and update this table. Exit codes must not collide.
 
@@ -2754,6 +2755,21 @@ else
   exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
 fi
 
+# Check 0.6b: local-ai-reviewer current-head evidence (issue #1648).
+if [ -z "${LOCAL_AI_CONFIGURED:-}" ]; then
+  echo "ERROR: Reviewer-loop telemetry was not carried forward (LOCAL_AI_CONFIGURED is not set)."
+  echo "Re-run Step 7 and export its POST_CLEAN_* and LOCAL_AI_* fields before re-entering Step 8a."
+  exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
+elif [ "$LOCAL_AI_CONFIGURED" = "0" ]; then
+  echo "✅ Local-reviewer head check not applicable: local-ai-reviewer is not configured."
+elif [ "${LOCAL_AI_HEAD_CURRENT:-__unset__}" != "1" ]; then
+  echo "ERROR: local-ai-reviewer head evidence is not current (LOCAL_AI_HEAD_CURRENT=${LOCAL_AI_HEAD_CURRENT:-<empty>})."
+  echo "Re-run Step 7 on the live HEAD and export its POST_CLEAN_* and LOCAL_AI_* fields before applying ready-for-human-review."
+  exit 12  # Exit code 12 = "reviewer-loop verdict not settled"
+else
+  echo "✅ Local-reviewer head check: LOCAL_AI_HEAD_CURRENT=1 for head ${LOCAL_AI_REVIEWED_HEAD:-<unknown>}."
+fi
+
 # Check 1: PR is non-draft
 DRAFT=$(gh pr view "$PR_NUMBER" --json isDraft --jq '.isDraft')
 if [ "$DRAFT" = "true" ]; then
@@ -3086,7 +3102,7 @@ a wait of its own (issue #1574).
   - If `ready-for-regression not verified` on implementation PR (exit 3 from pre-Check-4 gate): Step 7b was not completed. Apply the label via Step 7b, run Step 8 (CI loop), and re-enter Step 8a from the beginning. This gate is a hard block — `ready-for-human-review` cannot be applied until `ready-for-regression` is verified present.
   - If `unresolved review threads found` (exit 4 from GraphQL pre-Check-4 gate): The GraphQL query returned unresolved bot-authored review threads. Address the findings, push fixes, and re-enter Step 8a from the beginning. This gate is a hard block — `ready-for-human-review` cannot be applied until the GraphQL query confirms all threads are resolved. **Do not rely on self-tracked thread state** — the GraphQL query is the authoritative check.
   - If `late-arriving review threads detected` (exit 6 from Step 8a.1 re-check): Unresolved review threads were discovered after the pre-Check-4 gate — a platform posted after the loop's verdict. Remove `ready-for-human-review`, add `needs-fixes`, and return to Step 7a.
-  - If `reviewer-loop verdict not settled` (exit 12 from Check 0.6): the latest Step 7 output is not in this environment, the loop's recheck was suppressed (`SKIP_POST_CLEAN_RECHECK`, `--compare`), the platform never submitted a review for this HEAD (`POST_CLEAN_NO_SUBMITTED_REVIEW=1`), the settle window ran out while the platform was still active (`POST_CLEAN_SETTLE_TIMEOUT=1`), or the verdict describes a head the PR has moved past (`POST_CLEAN_HEAD_SHA` differs from the live head). Do not apply `ready-for-human-review`. Re-run Step 7 for the current HEAD, export its `POST_CLEAN_*` fields, and re-enter Step 8a from the beginning. If a second consecutive run reports `POST_CLEAN_SETTLE_TIMEOUT=1`, escalate to the human with reason `settle_never_quiet` rather than re-running again.
+  - If `reviewer-loop verdict not settled` (exit 12 from Check 0.6 / 0.6b): the latest Step 7 output is not in this environment, the loop's recheck was suppressed (`SKIP_POST_CLEAN_RECHECK`, `--compare`), the platform never submitted a review for this HEAD (`POST_CLEAN_NO_SUBMITTED_REVIEW=1`), the settle window ran out while the platform was still active (`POST_CLEAN_SETTLE_TIMEOUT=1`), the verdict describes a head the PR has moved past (`POST_CLEAN_HEAD_SHA` differs from the live head), `LOCAL_AI_CONFIGURED` was not carried forward, or `LOCAL_AI_HEAD_CURRENT` is not exactly `1` when `local-ai-reviewer` is configured. Do not apply `ready-for-human-review`. Re-run Step 7 for the current HEAD, export its `POST_CLEAN_*` and `LOCAL_AI_*` fields, and re-enter Step 8a from the beginning. If a second consecutive run reports `POST_CLEAN_SETTLE_TIMEOUT=1`, escalate to the human with reason `settle_never_quiet` rather than re-running again.
   - If `reviewer-loop summary missing or non-clean` (exit 7 from Check 0.5): The latest automated reviewer-loop summary comment is absent or its `Result:` line is not `clean`/`skipped`. Do not apply `ready-for-human-review`. For `RESULT=escalate`, `pending_timeout`, `timeout`, `needs_fixes`, or any other non-clean terminal result, escalate or re-enter Step 7 according to the reviewer-loop result.
   - If `documentation-stage alignment mismatch` (exit 8 from Check 3.6):
     the PR is on `spec/*` or `implementation-plan/*` but includes files outside

--- a/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
+++ b/docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
@@ -2756,7 +2756,9 @@ else
 fi
 
 # Check 0.6b: local-ai-reviewer current-head evidence (issue #1648).
-if [ -z "${LOCAL_AI_CONFIGURED:-}" ]; then
+if [ "${REVIEWER_LOOP_SKIPPED_NO_PLATFORMS:-false}" = "true" ]; then
+  echo "✅ Local-reviewer head check not applicable: Step 7 was skipped (no review platforms)."
+elif [ -z "${LOCAL_AI_CONFIGURED:-}" ]; then
   echo "ERROR: Reviewer-loop telemetry was not carried forward (LOCAL_AI_CONFIGURED is not set)."
   echo "Re-run Step 7 and export its POST_CLEAN_* and LOCAL_AI_* fields before re-entering Step 8a."
   exit 12  # Exit code 12 = "reviewer-loop verdict not settled"

--- a/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -91,12 +91,14 @@ Apply this label when **all** of the following are true:
 - [ ] **When Step 7 returned `clean` and `local-ai-reviewer` is in the resolved
       platform list**, the reviewer loop reported `LOCAL_AI_HEAD_CURRENT=1`.
       Applicability is read from `LOCAL_AI_CONFIGURED`: `0` means the platform
-      is not configured and this condition does not apply; an unset
-      `LOCAL_AI_CONFIGURED` means the loop's telemetry never reached the
-      checklist and is itself blocking. Both `LOCAL_AI_HEAD_CURRENT=0` and an
-      empty `LOCAL_AI_HEAD_CURRENT` when `LOCAL_AI_CONFIGURED=1` block the
-      label — missing evidence is not a pass. Re-run Step 7 on the live head
-      before applying `ready-for-human-review`.
+      is not configured and this condition does not apply; when Step 7 was
+      skipped because no review platforms are configured
+      (`REVIEWER_LOOP_SKIPPED_NO_PLATFORMS=true`), this condition does not
+      apply either; an unset `LOCAL_AI_CONFIGURED` in any other case means the
+      loop's telemetry never reached the checklist and is itself blocking. Both
+      `LOCAL_AI_HEAD_CURRENT=0` and an empty `LOCAL_AI_HEAD_CURRENT` when
+      `LOCAL_AI_CONFIGURED=1` block the label — missing evidence is not a pass.
+      Re-run Step 7 on the live head before applying `ready-for-human-review`.
 - [ ] Every configured automated PR reviewer has no blocking PR feedback (or is skipped)
 - [ ] All feedback from a previous human review cycle has been addressed
 - [ ] For `spec/*` and `implementation-plan/*` PRs,

--- a/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
+++ b/docs/workflow/development-workflow/protocols/92-pr-readiness-signal-protocol.md
@@ -88,6 +88,15 @@ Apply this label when **all** of the following are true:
       only the adjacency re-query, timed by `POST_CLEAN_SETTLED_AT`. The loop's
       `--help` lists the per-platform defaults; the protocols do not repeat
       them.
+- [ ] **When Step 7 returned `clean` and `local-ai-reviewer` is in the resolved
+      platform list**, the reviewer loop reported `LOCAL_AI_HEAD_CURRENT=1`.
+      Applicability is read from `LOCAL_AI_CONFIGURED`: `0` means the platform
+      is not configured and this condition does not apply; an unset
+      `LOCAL_AI_CONFIGURED` means the loop's telemetry never reached the
+      checklist and is itself blocking. Both `LOCAL_AI_HEAD_CURRENT=0` and an
+      empty `LOCAL_AI_HEAD_CURRENT` when `LOCAL_AI_CONFIGURED=1` block the
+      label — missing evidence is not a pass. Re-run Step 7 on the live head
+      before applying `ready-for-human-review`.
 - [ ] Every configured automated PR reviewer has no blocking PR feedback (or is skipped)
 - [ ] All feedback from a previous human review cycle has been addressed
 - [ ] For `spec/*` and `implementation-plan/*` PRs,

--- a/scripts/development-workflow/item-completion-self-check.sh
+++ b/scripts/development-workflow/item-completion-self-check.sh
@@ -376,6 +376,45 @@ fetch_latest_review_summary() {
   printf '%s\n' "$latest"
 }
 
+extract_reviewer_loop_history_json() {
+  awk '
+    index($0, "<!-- reviewer-loop-history:v1 -->") > 0 {
+      seen_marker = 1
+      in_json = 0
+      block = ""
+      next
+    }
+    seen_marker && $0 ~ /^```json[[:space:]]*$/ {
+      in_json = 1
+      block = ""
+      next
+    }
+    in_json && $0 ~ /^```[[:space:]]*$/ {
+      latest = block
+      in_json = 0
+      seen_marker = 0
+      next
+    }
+    in_json {
+      block = block $0 "\n"
+    }
+    END {
+      printf "%s", latest
+    }
+  '
+}
+
+local_ai_reviewer_configured() {
+  local config_file
+  local platform
+
+  config_file="$(workflow_effective_config_file)"
+  while IFS= read -r platform; do
+    [ "$platform" = "local-ai-reviewer" ] && return 0
+  done < <(configured_review_platforms "$config_file")
+  return 1
+}
+
 fetch_unreplied_rest_review_comments_count() {
   local repo="$1"
   local number="$2"
@@ -715,6 +754,40 @@ if [ -n "$pr_number" ]; then
         else
           add_row "pull_request.review_summary" "unavailable_optional" "$latest_review_summary" "review summary not required for this terminal claim"
         fi
+      fi
+
+      if ! is_true "$require_review_summary"; then
+        add_row "pull_request.local_reviewer_head" "unavailable_optional" "not claimed" "--require-review-summary not set"
+      elif ! local_ai_reviewer_configured; then
+        add_row "pull_request.local_reviewer_head" "unavailable_optional" "local-ai-reviewer not configured" "resolved platform list"
+      elif latest_review_summary="$(fetch_latest_review_summary "$pr_repo" "$pr_number" 2>&1)"; then
+        if [ -n "$latest_review_summary" ]; then
+          ledger_json="$(printf '%s\n' "$latest_review_summary" | extract_reviewer_loop_history_json)"
+          if [ -z "$ledger_json" ] \
+              || ! ledger_payload="$(printf '%s\n' "$ledger_json" | jq -c '.' 2>&1)"; then
+            add_row "pull_request.local_reviewer_head" "unavailable_required" "ledger unreadable" "reviewer_loop_history.v1 in summary comment"
+          elif ! printf '%s\n' "$ledger_payload" | jq -e '.entries[-1].reviewed_heads? | type == "array"' >/dev/null 2>&1; then
+            add_row "pull_request.local_reviewer_head" "unavailable_required" "pre-field ledger entry" "reviewed_heads missing from newest entry"
+          elif ledger_local_head="$(printf '%s\n' "$ledger_payload" | jq -r '.entries[-1].reviewed_heads[]? | select(.platform == "local-ai-reviewer") | .reviewed_head // ""' | head -n 1)"; then
+            if [ -z "$ledger_local_head" ]; then
+              add_row "pull_request.local_reviewer_head" "unavailable_required" "local-ai-reviewer head not recorded" "newest reviewed_heads entry"
+            elif [ -z "${pr_head_oid:-}" ]; then
+              add_row "pull_request.local_reviewer_head" "unavailable_required" "live headRefOid unavailable" "gh pr view headRefOid"
+            elif [ "$ledger_local_head" = "$pr_head_oid" ]; then
+              add_row "pull_request.local_reviewer_head" "verified" "ledger head matches live headRefOid" "reviewer_loop_history.v1 reviewed_heads"
+            else
+              add_row "pull_request.local_reviewer_head" "discrepancy" "ledger head ${ledger_local_head} != live ${pr_head_oid}" "reviewer_loop_history.v1 reviewed_heads"
+            fi
+          else
+            add_row "pull_request.local_reviewer_head" "unavailable_required" "ledger parse failed" "reviewer_loop_history.v1 reviewed_heads"
+          fi
+        elif is_true "$require_review_summary"; then
+          add_row "pull_request.local_reviewer_head" "unavailable_required" "missing reviewer-loop summary" "gh api repos/$pr_repo/issues/$pr_number/comments --paginate"
+        else
+          add_row "pull_request.local_reviewer_head" "unavailable_optional" "not claimed" "review summary not required for this terminal claim"
+        fi
+      else
+        add_row "pull_request.local_reviewer_head" "unavailable_required" "$latest_review_summary" "gh api repos/$pr_repo/issues/$pr_number/comments --paginate"
       fi
 
       if is_true "$require_review_threads"; then

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -6975,7 +6975,7 @@ reviewer_loop_emit_local_ai_head_evidence_keys() {
     fi
   done
 
-  if [ "$local_ai_configured" -eq 1 ]; then
+  if [ "$local_ai_configured" -eq 1 ] && declare -p platform_reviewed_heads >/dev/null 2>&1; then
     for entry in "${platform_reviewed_heads[@]}"; do
       platform_name="${entry%%:*}"
       reviewed_head="${entry#*:}"
@@ -7051,7 +7051,11 @@ reviewer_loop_history_build_entry() {
   head_sha="$(reviewer_loop_history_current_head_sha)"
   recorded_at="$(reviewer_loop_history_recorded_at)"
   local reviewed_heads_json
-  reviewed_heads_json="$(reviewer_loop_head_evidence_json "${loop_head_sha:-}" "${platform_reviewed_heads[@]}")"
+  if declare -p platform_reviewed_heads >/dev/null 2>&1; then
+    reviewed_heads_json="$(reviewer_loop_head_evidence_json "${loop_head_sha:-}" "${platform_reviewed_heads[@]}")"
+  else
+    reviewed_heads_json="$(reviewer_loop_head_evidence_json "${loop_head_sha:-}")"
+  fi
 
   # run_id (#1502 dual-cap follow-up): read from the current_run_id global,
   # following the same convention already used in this function for

--- a/scripts/development-workflow/pr-review-loop.sh
+++ b/scripts/development-workflow/pr-review-loop.sh
@@ -517,6 +517,12 @@ Outputs stable key=value lines including:
   POST_CLEAN_HEAD_SHA=<sha> (the PR head this run reviewed, read BEFORE any reviewer was dispatched and
     emitted on every clean path; Protocol 91 Check 0.6 refuses the verdict when the live head differs —
     a push after Step 7 voids it — issue #1574)
+  LOCAL_AI_CONFIGURED=0|1 (1 when local-ai-reviewer is in the resolved platform list — the applicability
+    signal; an absent key means telemetry never reached the consumer and is fail-closed)
+  LOCAL_AI_REVIEWED_HEAD=<sha> (the reviewed head reported by local-ai-reviewer; empty when not
+    configured or when the reviewer reported no head)
+  LOCAL_AI_HEAD_CURRENT=1|0| (1 when local-ai-reviewer classification is current; 0 when not-current;
+    empty when not-reported or when local-ai-reviewer is not configured — missing evidence is not a pass)
   RESULT=needs_fixes REASON=head_moved_during_run (the PR head changed while the reviewers ran, so
     the clean verdict describes a commit the PR has left; nothing to fix — re-run the loop for the
     current HEAD)
@@ -6840,6 +6846,158 @@ reviewer_loop_small_findings_prior_consecutive_count() {
   ' 2>/dev/null || printf '0\n'
 }
 
+reviewer_loop_head_evidence_full_sha() {
+  local value="$1"
+
+  case "$value" in
+    ''|*[!0-9a-fA-F]*) return 1 ;;
+  esac
+  [ "${#value}" -eq 40 ]
+}
+
+reviewer_loop_head_evidence_classify() {
+  local reviewed="$1"
+  local current="$2"
+
+  if [ -z "$reviewed" ]; then
+    printf 'not-reported\n'
+    return 0
+  fi
+  if ! reviewer_loop_head_evidence_full_sha "$reviewed"; then
+    printf 'not-current|unverifiable_reviewed_head\n'
+    return 0
+  fi
+  if ! reviewer_loop_head_evidence_full_sha "$current"; then
+    printf 'not-current|unverifiable_current_head\n'
+    return 0
+  fi
+
+  reviewed="$(printf '%s' "$reviewed" | tr 'A-F' 'a-f')"
+  current="$(printf '%s' "$current" | tr 'A-F' 'a-f')"
+
+  if [ "$reviewed" = "$current" ]; then
+    printf 'current\n'
+  else
+    printf 'not-current|head_mismatch\n'
+  fi
+}
+
+reviewer_loop_head_evidence_render() {
+  local current_head="$1"
+  shift
+  local entry platform_name reviewed_head classification state reason line
+
+  printf '**Head evidence:** current PR head `%s`\n' "$current_head"
+  [ "$#" -gt 0 ] || return 0
+
+  for entry in "$@"; do
+    platform_name="${entry%%:*}"
+    reviewed_head="${entry#*:}"
+    classification="$(reviewer_loop_head_evidence_classify "$reviewed_head" "$current_head")"
+    state="${classification%%|*}"
+    reason="${classification#*|}"
+    if [ "$reason" = "$state" ]; then
+      reason=""
+    fi
+    case "$state" in
+      current)
+        if [ -n "$reviewed_head" ]; then
+          line="- ${platform_name}: reviewed \`${reviewed_head}\` — current"
+        else
+          line="- ${platform_name}: not-reported"
+        fi
+        ;;
+      not-reported)
+        line="- ${platform_name}: not-reported"
+        ;;
+      not-current)
+        if [ -n "$reviewed_head" ]; then
+          line="- ${platform_name}: reviewed \`${reviewed_head}\` — not-current (${reason})"
+        else
+          line="- ${platform_name}: not-reported"
+        fi
+        ;;
+      *)
+        line="- ${platform_name}: ${state}"
+        ;;
+    esac
+    printf '%s\n' "$line"
+  done
+}
+
+reviewer_loop_head_evidence_json() {
+  local current_head="$1"
+  shift
+  local entry platform_name reviewed_head classification state reason
+  local -a jq_parts=()
+  local idx=0
+
+  for entry in "$@"; do
+    platform_name="${entry%%:*}"
+    reviewed_head="${entry#*:}"
+    classification="$(reviewer_loop_head_evidence_classify "$reviewed_head" "$current_head")"
+    state="${classification%%|*}"
+    reason="${classification#*|}"
+    if [ "$reason" = "$state" ]; then
+      reason=""
+    fi
+    jq_parts+=("--arg" "p${idx}" "$platform_name" "--arg" "rh${idx}" "$reviewed_head" "--arg" "st${idx}" "$state" "--arg" "rs${idx}" "$reason")
+    idx=$((idx + 1))
+  done
+
+  if [ "$idx" -eq 0 ]; then
+    printf '[]'
+    return 0
+  fi
+
+  local jq_prog='['
+  local i=0
+  while [ "$i" -lt "$idx" ]; do
+    [ "$i" -gt 0 ] && jq_prog+=','
+    jq_prog+="{platform: \$p${i}, reviewed_head: \$rh${i}, state: \$st${i}, reason: \$rs${i}}"
+    i=$((i + 1))
+  done
+  jq_prog+=']'
+
+  jq -n "${jq_parts[@]}" "$jq_prog"
+}
+
+reviewer_loop_emit_local_ai_head_evidence_keys() {
+  local local_ai_configured=0
+  local local_ai_reviewed_head=""
+  local local_ai_head_current=""
+  local entry platform_name reviewed_head classification state
+
+  for platform_name in "${platforms[@]}"; do
+    if [ "$platform_name" = "local-ai-reviewer" ]; then
+      local_ai_configured=1
+      break
+    fi
+  done
+
+  if [ "$local_ai_configured" -eq 1 ]; then
+    for entry in "${platform_reviewed_heads[@]}"; do
+      platform_name="${entry%%:*}"
+      reviewed_head="${entry#*:}"
+      if [ "$platform_name" = "local-ai-reviewer" ]; then
+        local_ai_reviewed_head="$reviewed_head"
+        classification="$(reviewer_loop_head_evidence_classify "$reviewed_head" "$loop_head_sha")"
+        state="${classification%%|*}"
+        case "$state" in
+          current) local_ai_head_current=1 ;;
+          not-current) local_ai_head_current=0 ;;
+          not-reported) local_ai_head_current="" ;;
+        esac
+        break
+      fi
+    done
+  fi
+
+  print_kv LOCAL_AI_CONFIGURED "$local_ai_configured"
+  print_kv LOCAL_AI_REVIEWED_HEAD "$local_ai_reviewed_head"
+  print_kv LOCAL_AI_HEAD_CURRENT "$local_ai_head_current"
+}
+
 reviewer_loop_history_current_head_sha() {
   local head_sha=""
   [ -n "${pr_number:-}" ] || return 0
@@ -6892,6 +7050,8 @@ reviewer_loop_history_build_entry() {
   platforms_json="$(reviewer_loop_history_platforms_json "$platform_list")" || platforms_json='[]'
   head_sha="$(reviewer_loop_history_current_head_sha)"
   recorded_at="$(reviewer_loop_history_recorded_at)"
+  local reviewed_heads_json
+  reviewed_heads_json="$(reviewer_loop_head_evidence_json "${loop_head_sha:-}" "${platform_reviewed_heads[@]}")"
 
   # run_id (#1502 dual-cap follow-up): read from the current_run_id global,
   # following the same convention already used in this function for
@@ -6923,10 +7083,14 @@ reviewer_loop_history_build_entry() {
     --argjson smallFindingsRounds "${small_findings_rounds:-0}" \
     --argjson smallFindingsRequiredRounds "${small_findings_required_rounds:-0}" \
     --arg smallFindingsPaths "${small_findings_paths:-}" \
+    --arg classificationHead "${loop_head_sha:-}" \
+    --argjson reviewedHeads "$reviewed_heads_json" \
     '{
       iteration: $iteration,
       recorded_at: $recordedAt,
       head_sha: $headSha,
+      classification_head: $classificationHead,
+      reviewed_heads: $reviewedHeads,
       run_id: $runId,
       result: $result,
       reason: $reason,
@@ -8522,6 +8686,8 @@ fi
 # Per-platform result tokens for the PR summary comment.
 # Each entry is "platform_name:display_token" (e.g. "haystack:unavailable").
 declare -a platform_result_tokens=()
+# Per-platform reviewed heads for head-evidence surfaces (issue #1648).
+declare -a platform_reviewed_heads=()
 # Per-platform review-policy status notes for the PR summary comment. Haystack
 # emits these from `pr-status`; other platforms normally leave this empty.
 declare -a platform_policy_status_notes=()
@@ -8671,6 +8837,9 @@ for index in "${!platforms[@]}"; do
     esac
   fi
   platform_result_tokens+=("${platform_name}:${_prt_disp}")
+  _reviewed_head="$(kv_value_default REVIEWED_HEAD "$platform_output" "")"
+  platform_reviewed_heads+=("${platform_name}:${_reviewed_head}")
+  unset _reviewed_head
 
   _policy_status_available="$(kv_value_default POLICY_STATUS_AVAILABLE "$platform_output" 0)"
   if [ "$_policy_status_available" = "1" ]; then
@@ -8970,6 +9139,14 @@ Protocol 91 Step 7b requires this label on all \`${branch_name%%/*}/*\` PRs afte
     fi
   fi
 
+  local head_evidence_section=""
+  if declare -p platform_reviewed_heads >/dev/null 2>&1 \
+      && { [ "${#platform_reviewed_heads[@]}" -gt 0 ] || [ -n "${loop_head_sha:-}" ]; }; then
+    head_evidence_section="
+
+$(reviewer_loop_head_evidence_render "${loop_head_sha:-}" "${platform_reviewed_heads[@]}")"
+  fi
+
   local phase_section=""
   if [ "$phase_enabled" -eq 1 ]; then
     local _phase_value_line
@@ -9017,7 +9194,7 @@ Protocol 91 Step 7b requires this label on all \`${branch_name%%/*}/*\` PRs afte
 **Result:** ${result_line}
 **Platforms:** ${platform_list:-none}${policy_status_section}
 **Findings:** ${blocking} blocking, ${suggestions} suggestions
-${small_findings_section}${phase_section}${compare_section}${advisory_section}${advisory_checks_section}${regression_label_section}
+${small_findings_section}${head_evidence_section}${phase_section}${compare_section}${advisory_section}${advisory_checks_section}${regression_label_section}
 
 *Posted automatically by \`pr-review-loop.sh\`.*
 EOF
@@ -9146,6 +9323,7 @@ if [ -z "$last_platform" ]; then
   print_kv UNRESOLVED_THREAD_COUNT 0
   _post_review_summary "skipped" "not_configured" "none" "0" "0" "" "" "0" "" "0" "0" "" "0"
   sync_reviewer_failed_label "$pr_number" 0
+  reviewer_loop_emit_local_ai_head_evidence_keys
   exit 0
 fi
 
@@ -9691,6 +9869,8 @@ if [ -n "$aggregate_output" ]; then
   review_comment_id="$(kv_value REVIEW_COMMENT_ID "$aggregate_output")"
   [ -n "$review_comment_id" ] && print_kv REVIEW_COMMENT_ID "$review_comment_id"
 fi
+
+reviewer_loop_emit_local_ai_head_evidence_keys
 
 # _post_review_summary has already run above (using the pre-correction
 # aggregate_result as its own "result"/"reason" arguments intentionally —

--- a/scripts/development-workflow/tests/test-item-completion-self-check.sh
+++ b/scripts/development-workflow/tests/test-item-completion-self-check.sh
@@ -336,7 +336,9 @@ body() {
 
 bind_local_head_fixture() {
   local repo="$1"
-  export MOCK_GH_HEAD_OID="$(git -C "$repo" rev-parse HEAD)"
+  local head_oid
+  head_oid="$(git -C "$repo" rev-parse HEAD)"
+  export MOCK_GH_HEAD_OID="$head_oid"
   export MOCK_GH_PR_MODE="local_head_dynamic"
   export MOCK_GH_SUMMARY_MODE="local_head_dynamic"
 }

--- a/scripts/development-workflow/tests/test-item-completion-self-check.sh
+++ b/scripts/development-workflow/tests/test-item-completion-self-check.sh
@@ -90,6 +90,26 @@ JSON
 {"number":17,"baseRefName":"develop","headRefName":"feature/1202-self-check","headRefOid":"0000000000000000000000000000000000000000","isDraft":false,"labels":[{"name":"ready-for-human-review"}],"files":[{"path":"docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"comments":[{"body":"Automated Reviewer Loop Summary\n\nResult: clean"}]}
 JSON
       ;;
+    local_head_live)
+      cat <<'JSON'
+{"number":17,"baseRefName":"develop","headRefName":"feature/1202-self-check","headRefOid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","isDraft":false,"labels":[{"name":"ready-for-human-review"}],"files":[{"path":"docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md"}],"statusCheckRollup":[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS"}],"comments":[{"body":"Automated Reviewer Loop Summary\n\nResult: clean"}]}
+JSON
+      ;;
+    local_head_dynamic)
+      jq -n \
+        --arg headOid "${MOCK_GH_HEAD_OID:?MOCK_GH_HEAD_OID must be set for local_head_dynamic}" \
+        '{
+          number: 17,
+          baseRefName: "develop",
+          headRefName: "feature/1202-self-check",
+          headRefOid: $headOid,
+          isDraft: false,
+          labels: [{name: "ready-for-human-review"}],
+          files: [{path: "docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md"}],
+          statusCheckRollup: [{name: "ci", status: "COMPLETED", conclusion: "SUCCESS"}],
+          comments: [{body: "Automated Reviewer Loop Summary\n\nResult: clean"}]
+        }'
+      ;;
     invalid_json)
       printf '{not json]\n'
       ;;
@@ -126,9 +146,52 @@ JSON
 JSON
       ;;
     bold_clean_summary)
+      _history_json="$(jq -nc --arg headOid "${MOCK_GH_HEAD_OID:?MOCK_GH_HEAD_OID must be set for bold_clean_summary}" \
+        '{schema:"reviewer_loop_history.v1",entries:[{iteration:1,reviewed_heads:[{platform:"local-ai-reviewer",reviewed_head:$headOid,state:"current",reason:""}]}]}')"
+      _body_text="### Automated Reviewer Loop Summary
+
+**Result:** clean — no blocking feedback
+
+<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+${_history_json}
+\`\`\`"
+      jq -n --arg body "$_body_text" \
+        '{body:$body, created_at:"2026-01-01T00:00:00Z", updated_at:"2026-01-01T00:00:00Z"}'
+      ;;
+    local_head_verified)
       cat <<'JSON'
-{"body":"### Automated Reviewer Loop Summary\n\n**Result:** clean — no blocking feedback","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}
+{"body":"Automated Reviewer Loop Summary\n\nResult: clean\n\n<!-- reviewer-loop-history:v1 -->\n```json\n{\"schema\":\"reviewer_loop_history.v1\",\"entries\":[{\"iteration\":1,\"reviewed_heads\":[{\"platform\":\"local-ai-reviewer\",\"reviewed_head\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"state\":\"current\",\"reason\":\"\"}]}]}\n```","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}
 JSON
+      ;;
+    local_head_stale)
+      cat <<'JSON'
+{"body":"Automated Reviewer Loop Summary\n\nResult: clean\n\n<!-- reviewer-loop-history:v1 -->\n```json\n{\"schema\":\"reviewer_loop_history.v1\",\"entries\":[{\"iteration\":1,\"reviewed_heads\":[{\"platform\":\"local-ai-reviewer\",\"reviewed_head\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"state\":\"not-current\",\"reason\":\"head_mismatch\"}]}]}\n```","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}
+JSON
+      ;;
+    local_head_pre_field)
+      cat <<'JSON'
+{"body":"Automated Reviewer Loop Summary\n\nResult: clean\n\n<!-- reviewer-loop-history:v1 -->\n```json\n{\"schema\":\"reviewer_loop_history.v1\",\"entries\":[{\"iteration\":1,\"head_sha\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"result\":\"clean\"}]}\n```","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}
+JSON
+      ;;
+    local_head_unreadable)
+      cat <<'JSON'
+{"body":"Automated Reviewer Loop Summary\n\nResult: clean\n\n<!-- reviewer-loop-history:v1 -->\n```json\n{not-json","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}
+JSON
+      ;;
+    local_head_dynamic)
+      _history_json="$(jq -nc --arg headOid "${MOCK_GH_HEAD_OID:?MOCK_GH_HEAD_OID must be set for local_head_dynamic}" \
+        '{schema:"reviewer_loop_history.v1",entries:[{iteration:1,reviewed_heads:[{platform:"local-ai-reviewer",reviewed_head:$headOid,state:"current",reason:""}]}]}')"
+      _body_text="Automated Reviewer Loop Summary
+
+Result: clean
+
+<!-- reviewer-loop-history:v1 -->
+\`\`\`json
+${_history_json}
+\`\`\`"
+      jq -n --arg body "$_body_text" \
+        '{body:$body, created_at:"2026-01-01T00:00:00Z", updated_at:"2026-01-01T00:00:00Z"}'
       ;;
     *)
       cat <<'JSON'
@@ -271,6 +334,13 @@ body() {
   tail -n +2 <<< "$1"
 }
 
+bind_local_head_fixture() {
+  local repo="$1"
+  export MOCK_GH_HEAD_OID="$(git -C "$repo" rev-parse HEAD)"
+  export MOCK_GH_PR_MODE="local_head_dynamic"
+  export MOCK_GH_SUMMARY_MODE="local_head_dynamic"
+}
+
 make_repo() {
   local name="$1"
   local repo="$TMP_ROOT/$name/repo"
@@ -290,6 +360,7 @@ echo ""
 echo "=== item completion self-check ==="
 
 repo="$(make_repo happy)"
+bind_local_head_fixture "$repo"
 gh_log="$TMP_ROOT/target-repo-gh.log"
 export WORKFLOW_SELF_CHECK_TRACKER_STATUS="Development in Review"
 export WORKFLOW_TARGET_GITHUB_REPO="example/product-repo"
@@ -306,7 +377,7 @@ out="$(self_check_output \
   --forbid-label needs-fixes \
   --require-review-summary true \
   --expected-tracker-status "Development in Review")"
-unset WORKFLOW_TARGET_GITHUB_REPO MOCK_GH_LOG
+unset WORKFLOW_TARGET_GITHUB_REPO MOCK_GH_LOG MOCK_GH_HEAD_OID MOCK_GH_PR_MODE MOCK_GH_SUMMARY_MODE
 run_test "happy_exit_zero" "0" "$(status_code "$out")"
 run_contains "happy_heading" "## Ground-Truth Completion Verification" "$(body "$out")"
 run_contains "happy_result" "- Result: verified" "$(body "$out")"
@@ -688,6 +759,7 @@ run_test "stale_non_clean_summary_exit_one" "1" "$(status_code "$out")"
 run_contains "stale_non_clean_summary_discrepancy" "| pull_request.review_summary | discrepancy | summary present but not clean/skipped |" "$(body "$out")"
 
 repo="$(make_repo bold-clean-summary)"
+bind_local_head_fixture "$repo"
 export MOCK_GH_SUMMARY_MODE=bold_clean_summary
 export WORKFLOW_SELF_CHECK_TRACKER_STATUS="Development in Review"
 out="$(self_check_output \
@@ -718,6 +790,127 @@ out="$(self_check_output \
 unset MOCK_GH_SUMMARY_MODE
 run_test "optional_summary_fetch_failed_exit_zero" "0" "$(status_code "$out")"
 run_contains "optional_summary_fetch_failed_optional" "| pull_request.review_summary | unavailable_optional |" "$(body "$out")"
+
+local_ai_config="$TMP_ROOT/local-ai-workflow.yaml"
+cat > "$local_ai_config" <<'YAML'
+review:
+  on_draft:
+    github:
+      - local-ai-reviewer
+  on_ready:
+    github: []
+YAML
+
+no_bugbot_config="$TMP_ROOT/no-bugbot-workflow.yaml"
+cat > "$no_bugbot_config" <<'YAML'
+review:
+  on_draft:
+    github:
+      - pr-agent
+  on_ready:
+    github: []
+YAML
+
+repo="$(make_repo local-head-verified)"
+bind_local_head_fixture "$repo"
+export AI_DEV_WORKFLOW_CONFIG_FILE="$local_ai_config"
+export WORKFLOW_SELF_CHECK_TRACKER_STATUS="Development in Review"
+out="$(self_check_output \
+  --repo-root "$repo" \
+  --issue 1648 \
+  --branch feature/1202-self-check \
+  --stage implementation \
+  --worktree-path "$repo" \
+  --pr 17 \
+  --expected-base develop \
+  --require-review-summary true \
+  --require-ci-green false)"
+run_test "local_head_verified_exit_zero" "0" "$(status_code "$out")"
+run_contains "local_head_verified_row" "| pull_request.local_reviewer_head | verified |" "$(body "$out")"
+
+repo="$(make_repo local-head-stale)"
+export MOCK_GH_PR_MODE=local_head_live
+export MOCK_GH_SUMMARY_MODE=local_head_stale
+export AI_DEV_WORKFLOW_CONFIG_FILE="$local_ai_config"
+out="$(self_check_output \
+  --repo-root "$repo" \
+  --issue 1648 \
+  --branch feature/1202-self-check \
+  --stage implementation \
+  --worktree-path "$repo" \
+  --pr 17 \
+  --expected-base develop \
+  --require-review-summary true \
+  --require-ci-green false)"
+run_test "local_head_stale_exit_one" "1" "$(status_code "$out")"
+run_contains "local_head_stale_discrepancy" "| pull_request.local_reviewer_head | discrepancy |" "$(body "$out")"
+
+repo="$(make_repo local-head-pre-field)"
+export MOCK_GH_PR_MODE=local_head_live
+export MOCK_GH_SUMMARY_MODE=local_head_pre_field
+export AI_DEV_WORKFLOW_CONFIG_FILE="$local_ai_config"
+out="$(self_check_output \
+  --repo-root "$repo" \
+  --issue 1648 \
+  --branch feature/1202-self-check \
+  --stage implementation \
+  --worktree-path "$repo" \
+  --pr 17 \
+  --expected-base develop \
+  --require-review-summary true \
+  --require-ci-green false)"
+run_test "local_head_pre_field_exit_one" "1" "$(status_code "$out")"
+run_contains "local_head_pre_field_unavailable" "| pull_request.local_reviewer_head | unavailable_required | pre-field ledger entry |" "$(body "$out")"
+
+repo="$(make_repo local-head-unreadable)"
+export MOCK_GH_PR_MODE=local_head_live
+export MOCK_GH_SUMMARY_MODE=local_head_unreadable
+export AI_DEV_WORKFLOW_CONFIG_FILE="$local_ai_config"
+out="$(self_check_output \
+  --repo-root "$repo" \
+  --issue 1648 \
+  --branch feature/1202-self-check \
+  --stage implementation \
+  --worktree-path "$repo" \
+  --pr 17 \
+  --expected-base develop \
+  --require-review-summary true \
+  --require-ci-green false)"
+run_test "local_head_unreadable_exit_one" "1" "$(status_code "$out")"
+run_contains "local_head_unreadable_unavailable" "| pull_request.local_reviewer_head | unavailable_required | ledger unreadable |" "$(body "$out")"
+
+repo="$(make_repo local-head-not-configured)"
+export MOCK_GH_PR_MODE=local_head_live
+export MOCK_GH_SUMMARY_MODE=local_head_verified
+export AI_DEV_WORKFLOW_CONFIG_FILE="$no_bugbot_config"
+out="$(self_check_output \
+  --repo-root "$repo" \
+  --issue 1648 \
+  --branch feature/1202-self-check \
+  --stage implementation \
+  --worktree-path "$repo" \
+  --pr 17 \
+  --expected-base develop \
+  --require-review-summary true \
+  --require-ci-green false)"
+run_contains "local_head_not_configured_optional" "| pull_request.local_reviewer_head | unavailable_optional | local-ai-reviewer not configured |" "$(body "$out")"
+
+repo="$(make_repo local-head-not-required)"
+export MOCK_GH_PR_MODE=local_head_live
+export MOCK_GH_SUMMARY_MODE=local_head_stale
+export AI_DEV_WORKFLOW_CONFIG_FILE="$local_ai_config"
+out="$(self_check_output \
+  --repo-root "$repo" \
+  --issue 1648 \
+  --branch feature/1202-self-check \
+  --stage implementation \
+  --worktree-path "$repo" \
+  --pr 17 \
+  --expected-base develop \
+  --require-review-summary false \
+  --require-ci-green false)"
+run_contains "local_head_not_required_optional" "| pull_request.local_reviewer_head | unavailable_optional | not claimed |" "$(body "$out")"
+unset MOCK_GH_PR_MODE MOCK_GH_SUMMARY_MODE AI_DEV_WORKFLOW_CONFIG_FILE
 
 repo="$(make_repo unconfigured-reviewer-check-failure)"
 no_bugbot_config="$TMP_ROOT/no-bugbot-workflow.yaml"
@@ -761,6 +954,7 @@ run_test "non_clean_summary_optional_exit_zero" "0" "$(status_code "$out")"
 run_contains "non_clean_summary_observed" "| pull_request.review_summary | verified | non_clean_summary_observed |" "$(body "$out")"
 
 repo="$(make_repo addressed-thread)"
+bind_local_head_fixture "$repo"
 export MOCK_GH_THREAD_MODE=addressed
 export AI_DEV_WORKFLOW_CONFIG_FILE="$bugbot_configured_config"
 export WORKFLOW_SELF_CHECK_TRACKER_STATUS="Development in Review"
@@ -773,11 +967,12 @@ out="$(self_check_output \
   --pr 17 \
   --expected-base develop \
   --require-review-threads true)"
-unset MOCK_GH_THREAD_MODE AI_DEV_WORKFLOW_CONFIG_FILE
+unset MOCK_GH_THREAD_MODE AI_DEV_WORKFLOW_CONFIG_FILE MOCK_GH_HEAD_OID MOCK_GH_PR_MODE MOCK_GH_SUMMARY_MODE
 run_test "addressed_thread_exit_zero" "0" "$(status_code "$out")"
 run_contains "addressed_thread_verified" "| pull_request.review_threads | verified | unresolved=0 |" "$(body "$out")"
 
 repo="$(make_repo human-thread)"
+bind_local_head_fixture "$repo"
 export MOCK_GH_THREAD_MODE=human
 export BUGBOT_BOT_LOGIN=cursor
 export WORKFLOW_SELF_CHECK_TRACKER_STATUS="Development in Review"
@@ -790,7 +985,7 @@ out="$(self_check_output \
   --pr 17 \
   --expected-base develop \
   --require-review-threads true)"
-unset MOCK_GH_THREAD_MODE BUGBOT_BOT_LOGIN
+unset MOCK_GH_THREAD_MODE BUGBOT_BOT_LOGIN MOCK_GH_HEAD_OID MOCK_GH_PR_MODE MOCK_GH_SUMMARY_MODE
 run_test "human_thread_exit_zero" "0" "$(status_code "$out")"
 run_contains "human_thread_ignored" "| pull_request.review_threads | verified | unresolved=0 |" "$(body "$out")"
 

--- a/scripts/development-workflow/tests/test-item-completion-self-check.sh
+++ b/scripts/development-workflow/tests/test-item-completion-self-check.sh
@@ -773,7 +773,7 @@ out="$(self_check_output \
   --pr 17 \
   --expected-base develop \
   --require-review-summary true)"
-unset MOCK_GH_SUMMARY_MODE
+unset MOCK_GH_SUMMARY_MODE MOCK_GH_PR_MODE MOCK_GH_HEAD_OID
 run_test "bold_clean_summary_exit_zero" "0" "$(status_code "$out")"
 run_contains "bold_clean_summary_verified" "| pull_request.review_summary | verified | clean_or_skipped |" "$(body "$out")"
 

--- a/scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh
+++ b/scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh
@@ -72,6 +72,44 @@ run_test "local_ai_reviewer_preserves_needs_rerun_mapping" "present" "$actual"
 
 unset -f run_local_ai_reviewer_review
 
+# Issue #1648: LOCAL_AI_* stdout contract for dispatch surfaces
+_1648_ancestor_sha='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+_1648_live_sha='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+platforms=(local-ai-reviewer)
+platform_reviewed_heads=("local-ai-reviewer:$_1648_ancestor_sha")
+loop_head_sha="$_1648_live_sha"
+_1648_dispatch_out="$(mktemp)"
+reviewer_loop_emit_local_ai_head_evidence_keys > "$_1648_dispatch_out"
+run_test "1648_dispatch_stale_local_head_current" "LOCAL_AI_HEAD_CURRENT=0" \
+  "$(grep '^LOCAL_AI_HEAD_CURRENT=' "$_1648_dispatch_out")"
+run_test "1648_dispatch_stale_local_reviewed_head" "LOCAL_AI_REVIEWED_HEAD=$_1648_ancestor_sha" \
+  "$(grep '^LOCAL_AI_REVIEWED_HEAD=' "$_1648_dispatch_out")"
+
+platforms=(pr-agent)
+platform_reviewed_heads=()
+loop_head_sha="$_1648_live_sha"
+reviewer_loop_emit_local_ai_head_evidence_keys > "$_1648_dispatch_out"
+run_test "1648_dispatch_not_configured" "LOCAL_AI_CONFIGURED=0" \
+  "$(grep '^LOCAL_AI_CONFIGURED=' "$_1648_dispatch_out")"
+
+platforms=(local-ai-reviewer)
+platform_reviewed_heads=("local-ai-reviewer:")
+loop_head_sha="$_1648_live_sha"
+reviewer_loop_emit_local_ai_head_evidence_keys > "$_1648_dispatch_out"
+run_test "1648_dispatch_missing_reviewed_head" "LOCAL_AI_HEAD_CURRENT=" \
+  "$(grep '^LOCAL_AI_HEAD_CURRENT=' "$_1648_dispatch_out")"
+run_test "1648_dispatch_configured_no_head" "LOCAL_AI_CONFIGURED=1" \
+  "$(grep '^LOCAL_AI_CONFIGURED=' "$_1648_dispatch_out")"
+
+platforms=(local-ai-reviewer)
+platform_reviewed_heads=("local-ai-reviewer:$_1648_live_sha")
+loop_head_sha="$_1648_live_sha"
+reviewer_loop_emit_local_ai_head_evidence_keys > "$_1648_dispatch_out"
+run_test "1648_dispatch_current_head" "LOCAL_AI_HEAD_CURRENT=1" \
+  "$(grep '^LOCAL_AI_HEAD_CURRENT=' "$_1648_dispatch_out")"
+rm -f "$_1648_dispatch_out"
+unset _1648_ancestor_sha _1648_live_sha _1648_dispatch_out platforms platform_reviewed_heads loop_head_sha
+
 if [ "$FAIL_COUNT" -ne 0 ]; then
   echo "FAIL: $FAIL_COUNT test(s) failed"
   exit 1

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -16075,6 +16075,51 @@ _1648_legacy_payload='{"schema":"reviewer_loop_history.v1","entries":[{"iteratio
 run_test "1648_legacy_payload_parses" "1" \
   "$(printf '%s\n' "$_1648_legacy_payload" | jq -e '.entries[0].reviewed_heads // [] | length >= 0' >/dev/null && echo 1 || echo 0)"
 
+# Check 0.6b gate (Protocol 91 lines 2758-2771) — planted-violation proof P2/P3
+check_066b_local_ai_head() {
+  if [ -z "${LOCAL_AI_CONFIGURED:-}" ]; then
+    return 12
+  elif [ "$LOCAL_AI_CONFIGURED" = "0" ]; then
+    return 0
+  elif [ "${LOCAL_AI_HEAD_CURRENT:-__unset__}" != "1" ]; then
+    return 12
+  else
+    return 0
+  fi
+}
+
+unset LOCAL_AI_CONFIGURED LOCAL_AI_HEAD_CURRENT LOCAL_AI_REVIEWED_HEAD 2>/dev/null || true
+_1648_check_rc=0
+check_066b_local_ai_head || _1648_check_rc=$?
+run_test "1648_check_066b_unset_configured" "12" "$_1648_check_rc"
+
+export LOCAL_AI_CONFIGURED=1
+export LOCAL_AI_HEAD_CURRENT=
+_1648_check_rc=0
+check_066b_local_ai_head || _1648_check_rc=$?
+run_test "1648_check_066b_missing_head_current" "12" "$_1648_check_rc"
+
+export LOCAL_AI_HEAD_CURRENT=0
+_1648_check_rc=0
+check_066b_local_ai_head || _1648_check_rc=$?
+run_test "1648_check_066b_not_current" "12" "$_1648_check_rc"
+
+export LOCAL_AI_HEAD_CURRENT=1
+export LOCAL_AI_REVIEWED_HEAD="$_sha_a"
+_1648_check_rc=0
+check_066b_local_ai_head || _1648_check_rc=$?
+run_test "1648_check_066b_current_pass" "0" "$_1648_check_rc"
+
+export LOCAL_AI_CONFIGURED=0
+unset LOCAL_AI_HEAD_CURRENT LOCAL_AI_REVIEWED_HEAD 2>/dev/null || true
+_1648_check_rc=0
+check_066b_local_ai_head || _1648_check_rc=$?
+run_test "1648_check_066b_not_configured_pass" "0" "$_1648_check_rc"
+
+unset LOCAL_AI_CONFIGURED LOCAL_AI_HEAD_CURRENT LOCAL_AI_REVIEWED_HEAD 2>/dev/null || true
+unset -f check_066b_local_ai_head 2>/dev/null || true
+unset _1648_check_rc
+
 _1648_carry_capture=$'POST_CLEAN_HEAD_SHA=abc\nLOCAL_AI_CONFIGURED=1\nLOCAL_AI_REVIEWED_HEAD=def0123456789012345678901234567890abcd\nLOCAL_AI_HEAD_CURRENT=1\n'
 _1648_carry_out="$(mktemp)"
 printf '%s\n' "$_1648_carry_capture" > "$_1648_carry_out"
@@ -16094,45 +16139,6 @@ done
 run_test "1648_carry_forward_clears" "empty" \
   "$([ -z "${LOCAL_AI_CONFIGURED:-}" ] && [ -z "${LOCAL_AI_HEAD_CURRENT:-}" ] && printf empty || printf present)"
 rm -f "$_1648_carry_out" "$settle_kv"
-
-# Check 0.6b gate (Protocol 91 lines 2758-2771) — planted-violation proof P2/P3
-check_066b_local_ai_head() {
-  if [ -z "${LOCAL_AI_CONFIGURED:-}" ]; then
-    return 12
-  elif [ "$LOCAL_AI_CONFIGURED" = "0" ]; then
-    return 0
-  elif [ "${LOCAL_AI_HEAD_CURRENT:-__unset__}" != "1" ]; then
-    return 12
-  else
-    return 0
-  fi
-}
-
-unset LOCAL_AI_CONFIGURED LOCAL_AI_HEAD_CURRENT LOCAL_AI_REVIEWED_HEAD
-check_066b_local_ai_head; _1648_check_rc=$?
-run_test "1648_check_066b_unset_configured" "12" "$_1648_check_rc"
-
-export LOCAL_AI_CONFIGURED=1
-export LOCAL_AI_HEAD_CURRENT=
-check_066b_local_ai_head; _1648_check_rc=$?
-run_test "1648_check_066b_missing_head_current" "12" "$_1648_check_rc"
-
-export LOCAL_AI_HEAD_CURRENT=0
-check_066b_local_ai_head; _1648_check_rc=$?
-run_test "1648_check_066b_not_current" "12" "$_1648_check_rc"
-
-export LOCAL_AI_HEAD_CURRENT=1
-export LOCAL_AI_REVIEWED_HEAD="$_sha_a"
-check_066b_local_ai_head; _1648_check_rc=$?
-run_test "1648_check_066b_current_pass" "0" "$_1648_check_rc"
-
-export LOCAL_AI_CONFIGURED=0
-unset LOCAL_AI_HEAD_CURRENT LOCAL_AI_REVIEWED_HEAD
-check_066b_local_ai_head; _1648_check_rc=$?
-run_test "1648_check_066b_not_configured_pass" "0" "$_1648_check_rc"
-
-unset LOCAL_AI_CONFIGURED LOCAL_AI_HEAD_CURRENT LOCAL_AI_REVIEWED_HEAD
-unset -f check_066b_local_ai_head _1648_check_rc
 
 unset _sha_a _sha_b _sha_a_upper _sha_abbrev _sha_39 _sha_41 _sha_non_hex _unknown_head
 unset _1648_render _1648_json _1648_legacy_payload _1648_carry_capture

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -16095,6 +16095,45 @@ run_test "1648_carry_forward_clears" "empty" \
   "$([ -z "${LOCAL_AI_CONFIGURED:-}" ] && [ -z "${LOCAL_AI_HEAD_CURRENT:-}" ] && printf empty || printf present)"
 rm -f "$_1648_carry_out" "$settle_kv"
 
+# Check 0.6b gate (Protocol 91 lines 2758-2771) — planted-violation proof P2/P3
+check_066b_local_ai_head() {
+  if [ -z "${LOCAL_AI_CONFIGURED:-}" ]; then
+    return 12
+  elif [ "$LOCAL_AI_CONFIGURED" = "0" ]; then
+    return 0
+  elif [ "${LOCAL_AI_HEAD_CURRENT:-__unset__}" != "1" ]; then
+    return 12
+  else
+    return 0
+  fi
+}
+
+unset LOCAL_AI_CONFIGURED LOCAL_AI_HEAD_CURRENT LOCAL_AI_REVIEWED_HEAD
+check_066b_local_ai_head; _1648_check_rc=$?
+run_test "1648_check_066b_unset_configured" "12" "$_1648_check_rc"
+
+export LOCAL_AI_CONFIGURED=1
+export LOCAL_AI_HEAD_CURRENT=
+check_066b_local_ai_head; _1648_check_rc=$?
+run_test "1648_check_066b_missing_head_current" "12" "$_1648_check_rc"
+
+export LOCAL_AI_HEAD_CURRENT=0
+check_066b_local_ai_head; _1648_check_rc=$?
+run_test "1648_check_066b_not_current" "12" "$_1648_check_rc"
+
+export LOCAL_AI_HEAD_CURRENT=1
+export LOCAL_AI_REVIEWED_HEAD="$_sha_a"
+check_066b_local_ai_head; _1648_check_rc=$?
+run_test "1648_check_066b_current_pass" "0" "$_1648_check_rc"
+
+export LOCAL_AI_CONFIGURED=0
+unset LOCAL_AI_HEAD_CURRENT LOCAL_AI_REVIEWED_HEAD
+check_066b_local_ai_head; _1648_check_rc=$?
+run_test "1648_check_066b_not_configured_pass" "0" "$_1648_check_rc"
+
+unset LOCAL_AI_CONFIGURED LOCAL_AI_HEAD_CURRENT LOCAL_AI_REVIEWED_HEAD
+unset -f check_066b_local_ai_head _1648_check_rc
+
 unset _sha_a _sha_b _sha_a_upper _sha_abbrev _sha_39 _sha_41 _sha_non_hex _unknown_head
 unset _1648_render _1648_json _1648_legacy_payload _1648_carry_capture
 

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -15553,6 +15553,7 @@ run_test "gate_no_thread_platforms_other_head_refused" "12" "$(_1574_run_gate PO
 run_test "gate_suppressed_recheck_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=0 POST_CLEAN_RECHECK_SKIP_REASON=skip_env)"
 run_test "gate_recheck_without_reason_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=0)"
 run_test "gate_settled_passes" "0" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 POST_CLEAN_SETTLED_AT=2026-08-22T13:49:18Z POST_CLEAN_HEAD_SHA="$_1574_head")"
+run_test "gate_skipped_no_platforms_unset_local_ai_passes" "0" "$(_1574_run_gate REVIEWER_LOOP_SKIPPED_NO_PLATFORMS=true LOCAL_AI_CONFIGURED=)"
 run_test "gate_local_ai_unset_refused" "12" "$(_1574_run_gate LOCAL_AI_CONFIGURED= POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 POST_CLEAN_SETTLED_AT=2026-08-22T13:49:18Z POST_CLEAN_HEAD_SHA="$_1574_head")"
 run_test "gate_local_ai_not_current_refused" "12" "$(_1574_run_gate LOCAL_AI_CONFIGURED=1 LOCAL_AI_HEAD_CURRENT=0 LOCAL_AI_REVIEWED_HEAD="$_1574_head" POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 POST_CLEAN_SETTLED_AT=2026-08-22T13:49:18Z POST_CLEAN_HEAD_SHA="$_1574_head")"
 run_test "gate_local_ai_current_passes" "0" "$(_1574_run_gate LOCAL_AI_CONFIGURED=1 LOCAL_AI_HEAD_CURRENT=1 LOCAL_AI_REVIEWED_HEAD="$_1574_head" POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 POST_CLEAN_SETTLED_AT=2026-08-22T13:49:18Z POST_CLEAN_HEAD_SHA="$_1574_head")"
@@ -16082,7 +16083,9 @@ run_test "1648_legacy_payload_parses" "1" \
 
 # Check 0.6b gate (Protocol 91 lines 2758-2771) — planted-violation proof P2/P3
 check_066b_local_ai_head() {
-  if [ -z "${LOCAL_AI_CONFIGURED:-}" ]; then
+  if [ "${REVIEWER_LOOP_SKIPPED_NO_PLATFORMS:-false}" = "true" ]; then
+    return 0
+  elif [ -z "${LOCAL_AI_CONFIGURED:-}" ]; then
     return 12
   elif [ "$LOCAL_AI_CONFIGURED" = "0" ]; then
     return 0
@@ -16093,10 +16096,17 @@ check_066b_local_ai_head() {
   fi
 }
 
-unset LOCAL_AI_CONFIGURED LOCAL_AI_HEAD_CURRENT LOCAL_AI_REVIEWED_HEAD 2>/dev/null || true
+unset LOCAL_AI_CONFIGURED LOCAL_AI_HEAD_CURRENT LOCAL_AI_REVIEWED_HEAD REVIEWER_LOOP_SKIPPED_NO_PLATFORMS 2>/dev/null || true
 _1648_check_rc=0
 check_066b_local_ai_head || _1648_check_rc=$?
 run_test "1648_check_066b_unset_configured" "12" "$_1648_check_rc"
+
+export REVIEWER_LOOP_SKIPPED_NO_PLATFORMS=true
+unset LOCAL_AI_CONFIGURED
+_1648_check_rc=0
+check_066b_local_ai_head || _1648_check_rc=$?
+run_test "1648_check_066b_skipped_no_platforms_pass" "0" "$_1648_check_rc"
+unset REVIEWER_LOOP_SKIPPED_NO_PLATFORMS
 
 export LOCAL_AI_CONFIGURED=1
 export LOCAL_AI_HEAD_CURRENT=

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # test-pr-review-loop.sh — Self-contained test harness for pr-review-loop.sh.
+# covers: scripts/development-workflow/pr-review-loop.sh
+# covers: docs/workflow/development-workflow/protocols/91-orchestrate-work-protocol.md
 #
 # Exercises five highest-risk logic areas:
 #   1. normalize_platform_verdict (verdict normalization / mapping)
@@ -388,6 +390,19 @@ run_test() {
     PASS_COUNT=$(( PASS_COUNT + 1 ))
   else
     echo "FAIL: $name — expected '${expected}', got '${actual}'"
+    FAIL_COUNT=$(( FAIL_COUNT + 1 ))
+  fi
+}
+
+run_contains() {
+  local name="$1"
+  local needle="$2"
+  local haystack="$3"
+  if printf '%s\n' "$haystack" | grep -Fq -- "$needle"; then
+    echo "PASS: $name"
+    PASS_COUNT=$(( PASS_COUNT + 1 ))
+  else
+    echo "FAIL: $name — expected substring '${needle}'"
     FAIL_COUNT=$(( FAIL_COUNT + 1 ))
   fi
 }
@@ -16004,6 +16019,84 @@ unset _1579_E2E_CALL_LOG2 _1579_E2E_LIVE_CREATED _1579_e2e_mock_dir2 _1579_e2e_c
 
 unset -f _1579_ago _1579_ago_s _1579_state _1579_live
 unset _1579_window _1579_nowindow _1579_real_parser _1579_loop_src _1579_rl_branch
+
+# ---------------------------------------------------------------------------
+echo "=== Area 1648: reviewer-loop current-head evidence ==="
+
+HARNESS_MODE=1 source "$REPO_ROOT/scripts/development-workflow/pr-review-loop.sh"
+
+_sha_a='82d2f3a844a6c0c417f5c55e8a01eebdf343de45'
+_sha_b='29c0e9d2541a85c0e335052de42599f485d51a67'
+_sha_a_upper='82D2F3A844A6C0C417F5C55E8A01EEBDF343DE45'
+_sha_abbrev='82d2f3a'
+_sha_39='82d2f3a844a6c0c417f5c55e8a01eebdf343de4'
+_sha_41="${_sha_a}0"
+_sha_non_hex='82d2f3a844a6c0c417f5c55e8a01eebdf343de4g'
+_unknown_head='unknown-1756330000-4821-19342'
+
+run_test "1648_classify_same_sha_current" "current" \
+  "$(reviewer_loop_head_evidence_classify "$_sha_a" "$_sha_a")"
+run_test "1648_classify_case_insensitive_current" "current" \
+  "$(reviewer_loop_head_evidence_classify "$_sha_a_upper" "$_sha_a")"
+run_test "1648_classify_mismatch" "not-current|head_mismatch" \
+  "$(reviewer_loop_head_evidence_classify "$_sha_a" "$_sha_b")"
+run_test "1648_classify_abbreviation" "not-current|unverifiable_reviewed_head" \
+  "$(reviewer_loop_head_evidence_classify "$_sha_abbrev" "$_sha_a")"
+run_test "1648_classify_39_char" "not-current|unverifiable_reviewed_head" \
+  "$(reviewer_loop_head_evidence_classify "$_sha_39" "$_sha_a")"
+run_test "1648_classify_41_char" "not-current|unverifiable_reviewed_head" \
+  "$(reviewer_loop_head_evidence_classify "$_sha_41" "$_sha_a")"
+run_test "1648_classify_non_hex" "not-current|unverifiable_reviewed_head" \
+  "$(reviewer_loop_head_evidence_classify "$_sha_non_hex" "$_sha_a")"
+run_test "1648_classify_empty_reviewed" "not-reported" \
+  "$(reviewer_loop_head_evidence_classify "" "$_sha_a")"
+run_test "1648_classify_empty_current" "not-current|unverifiable_current_head" \
+  "$(reviewer_loop_head_evidence_classify "$_sha_a" "")"
+run_test "1648_classify_unknown_placeholder" "not-current|unverifiable_current_head" \
+  "$(reviewer_loop_head_evidence_classify "$_sha_a" "$_unknown_head")"
+
+run_test "1648_full_sha_accepts_40" "0" "$(reviewer_loop_head_evidence_full_sha "$_sha_a"; printf '%s' $?)"
+run_test "1648_full_sha_rejects_39" "1" "$(reviewer_loop_head_evidence_full_sha "$_sha_39"; printf '%s' $?)"
+run_test "1648_full_sha_rejects_41" "1" "$(reviewer_loop_head_evidence_full_sha "$_sha_41"; printf '%s' $?)"
+run_test "1648_full_sha_rejects_abbrev" "1" "$(reviewer_loop_head_evidence_full_sha "$_sha_abbrev"; printf '%s' $?)"
+run_test "1648_full_sha_rejects_non_hex" "1" "$(reviewer_loop_head_evidence_full_sha "$_sha_non_hex"; printf '%s' $?)"
+run_test "1648_full_sha_rejects_empty" "1" "$(reviewer_loop_head_evidence_full_sha ""; printf '%s' $?)"
+
+_1648_render="$(reviewer_loop_head_evidence_render "$_sha_a" "local-ai-reviewer:$_sha_a" "pr-agent:$_sha_b")"
+run_contains "1648_render_has_head_evidence_block" "**Head evidence:**" "$_1648_render"
+run_contains "1648_render_current_row" "local-ai-reviewer: reviewed \`${_sha_a}\` — current" "$_1648_render"
+run_contains "1648_render_mismatch_row" "pr-agent: reviewed \`${_sha_b}\` — not-current (head_mismatch)" "$_1648_render"
+
+_1648_json="$(reviewer_loop_head_evidence_json "$_sha_a" "local-ai-reviewer:$_sha_a")"
+run_test "1648_json_state_current" "current" \
+  "$(printf '%s\n' "$_1648_json" | jq -r '.[0].state')"
+
+_1648_legacy_payload='{"schema":"reviewer_loop_history.v1","entries":[{"iteration":1,"head_sha":"abc","result":"clean"}]}'
+run_test "1648_legacy_payload_parses" "1" \
+  "$(printf '%s\n' "$_1648_legacy_payload" | jq -e '.entries[0].reviewed_heads // [] | length >= 0' >/dev/null && echo 1 || echo 0)"
+
+_1648_carry_capture=$'POST_CLEAN_HEAD_SHA=abc\nLOCAL_AI_CONFIGURED=1\nLOCAL_AI_REVIEWED_HEAD=def0123456789012345678901234567890abcd\nLOCAL_AI_HEAD_CURRENT=1\n'
+_1648_carry_out="$(mktemp)"
+printf '%s\n' "$_1648_carry_capture" > "$_1648_carry_out"
+for settle_var in $(env | grep -oE '^(POST_CLEAN|LOCAL_AI)_[A-Z_]*' || true); do
+  unset "$settle_var"
+done
+settle_kv="$(mktemp)"
+grep -E '^(POST_CLEAN|LOCAL_AI)_[A-Z_]+=[A-Za-z0-9:_-]*$' "$_1648_carry_out" > "$settle_kv" || true
+while IFS='=' read -r key value; do
+  export "$key=$value"
+done < "$settle_kv"
+run_test "1648_carry_forward_configured" "1" "${LOCAL_AI_CONFIGURED:-}"
+run_test "1648_carry_forward_head_current" "1" "${LOCAL_AI_HEAD_CURRENT:-}"
+for settle_var in $(env | grep -oE '^(POST_CLEAN|LOCAL_AI)_[A-Z_]*' || true); do
+  unset "$settle_var"
+done
+run_test "1648_carry_forward_clears" "empty" \
+  "$([ -z "${LOCAL_AI_CONFIGURED:-}" ] && [ -z "${LOCAL_AI_HEAD_CURRENT:-}" ] && printf empty || printf present)"
+rm -f "$_1648_carry_out" "$settle_kv"
+
+unset _sha_a _sha_b _sha_a_upper _sha_abbrev _sha_39 _sha_41 _sha_non_hex _unknown_head
+unset _1648_render _1648_json _1648_legacy_payload _1648_carry_capture
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/development-workflow/tests/test-pr-review-loop.sh
+++ b/scripts/development-workflow/tests/test-pr-review-loop.sh
@@ -15497,7 +15497,7 @@ run_test "p91_checklist_refuses_no_submitted_review" "yes" \
 # the Step 7 block clears POST_CLEAN_* before the loop runs and exports nothing
 # when the loop exits non-zero.
 run_test "p91_step7_clears_stale_settle_vars" "yes" \
-  "$(grep -q "grep -o '^POST_CLEAN_\[A-Z_\]\*'" "$_1574_p91" && echo yes || echo no)"
+  "$(grep -q "grep -oE '^(POST_CLEAN|LOCAL_AI)_\[A-Z_\]\*'" "$_1574_p91" && echo yes || echo no)"
 run_test "p91_step7_exports_only_on_zero_exit" "yes" \
   "$(grep -q 'Do not enter Step 8a on this run' "$_1574_p91" && echo yes || echo no)"
 # Protocol 91 carries no wait at all any more: the only sleep in 8a.1 was the
@@ -15538,7 +15538,9 @@ _1574_head="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 _1574_run_gate() {
   # $@ = VAR=value assignments; prints the exit status
   local status=0
-  env -i PATH="$PATH" MOCK_SUMMARY="$_1574_clean" MOCK_HEAD="$_1574_head" "$@" bash "$_1574_gate" >/dev/null 2>&1 || status=$?
+  env -i PATH="$PATH" MOCK_SUMMARY="$_1574_clean" MOCK_HEAD="$_1574_head" \
+    LOCAL_AI_CONFIGURED=0 \
+    "$@" bash "$_1574_gate" >/dev/null 2>&1 || status=$?
   printf '%s' "$status"
 }
 run_test "gate_skipped_flag_passes" "0" "$(_1574_run_gate REVIEWER_LOOP_SKIPPED_NO_PLATFORMS=true)"
@@ -15551,6 +15553,9 @@ run_test "gate_no_thread_platforms_other_head_refused" "12" "$(_1574_run_gate PO
 run_test "gate_suppressed_recheck_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=0 POST_CLEAN_RECHECK_SKIP_REASON=skip_env)"
 run_test "gate_recheck_without_reason_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=0)"
 run_test "gate_settled_passes" "0" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 POST_CLEAN_SETTLED_AT=2026-08-22T13:49:18Z POST_CLEAN_HEAD_SHA="$_1574_head")"
+run_test "gate_local_ai_unset_refused" "12" "$(_1574_run_gate LOCAL_AI_CONFIGURED= POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 POST_CLEAN_SETTLED_AT=2026-08-22T13:49:18Z POST_CLEAN_HEAD_SHA="$_1574_head")"
+run_test "gate_local_ai_not_current_refused" "12" "$(_1574_run_gate LOCAL_AI_CONFIGURED=1 LOCAL_AI_HEAD_CURRENT=0 LOCAL_AI_REVIEWED_HEAD="$_1574_head" POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 POST_CLEAN_SETTLED_AT=2026-08-22T13:49:18Z POST_CLEAN_HEAD_SHA="$_1574_head")"
+run_test "gate_local_ai_current_passes" "0" "$(_1574_run_gate LOCAL_AI_CONFIGURED=1 LOCAL_AI_HEAD_CURRENT=1 LOCAL_AI_REVIEWED_HEAD="$_1574_head" POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1 POST_CLEAN_SETTLED_AT=2026-08-22T13:49:18Z POST_CLEAN_HEAD_SHA="$_1574_head")"
 # A settled verdict is bound to one head: telemetry without a head, or for a
 # head the PR has moved past, is refused.
 run_test "gate_settled_without_head_binding_refused" "12" "$(_1574_run_gate POST_CLEAN_RECHECK=1 POST_CLEAN_SETTLED=1)"


### PR DESCRIPTION
## Summary

- Thread `REVIEWED_HEAD` through reviewer-loop summary comments, `reviewer_loop_history.v1` ledger entries, and `LOCAL_AI_*` stdout keys.
- Fail closed when the last local-ai-reviewer clean result is for a stale PR head (`LOCAL_AI_HEAD_CURRENT` must be exactly `1` when configured).
- Add `pull_request.local_reviewer_head` to the ground-truth completion self-check.

## Planted-Violation Proofs

### P1 — stale local clean ledger head (self-check)

- **Planted at:** `scripts/development-workflow/tests/test-item-completion-self-check.sh` — `local_head_stale` mock ledger uses `aaaaaaaa…` while live `headRefOid` is `bbbbbbbb…`.
- **Command:** `bash scripts/development-workflow/tests/test-item-completion-self-check.sh` (case `local_head_stale_*`)
- **With violation:** exit `1`; row `pull_request.local_reviewer_head | discrepancy`.
- **After fix (matching OIDs / verified fixture):** exit `0`; row `pull_request.local_reviewer_head | verified`.

### P2 — missing head evidence (`LOCAL_AI_HEAD_CURRENT` empty)

- **Planted at:** `scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh` — configured reviewer with empty reviewed head emits `LOCAL_AI_HEAD_CURRENT=`.
- **Command:** `bash scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh` (`1648_dispatch_missing_reviewed_head`)
- **With violation:** `LOCAL_AI_CONFIGURED=1` and empty `LOCAL_AI_HEAD_CURRENT` (blocking state).
- **After fix (current head reported):** `LOCAL_AI_HEAD_CURRENT=1`.

### P3 — telemetry loss (`LOCAL_AI_CONFIGURED` unset)

- **Planted at:** carry-forward snippet test clears env without re-export (`1648_carry_forward_clears`).
- **Command:** `bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 1648`
- **With violation:** unset `LOCAL_AI_CONFIGURED` after clear → Check 0.6b would refuse (documented in Protocol 91).
- **After export:** `1648_carry_forward_configured` passes with `LOCAL_AI_CONFIGURED=1`.

### P4 — carry-forward grep regression

- **Planted at:** Protocol 91 snippet uses `grep -oE` (not `grep -o`); test `1648_carry_forward_clears` verifies unset loop clears keys.
- **Command:** `bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 1648`
- **With `-o` only:** alternation would not match `LOCAL_AI_*` keys (regression described in plan).
- **With `-oE`:** keys export and clear correctly.

### P5 — suite selection regression

- **Planted at:** remove `# covers: scripts/development-workflow/pr-review-loop.sh` from `test-pr-review-loop.sh`.
- **Command:** `bash scripts/development-workflow/select-test-suites.sh` on a diff touching only `pr-review-loop.sh`.
- **With violation:** suite not selected (`declared=1` disables naming fallback).
- **With line present:** suite selected (both `# covers:` lines required).

## Test plan

- [x] `bash scripts/development-workflow/tests/test-pr-review-loop.sh --area 1648`
- [x] `bash scripts/development-workflow/tests/test-local-ai-reviewer-pr-review-loop-dispatch.sh`
- [x] `bash scripts/development-workflow/tests/test-item-completion-self-check.sh`
- [x] `shellcheck` on changed shell scripts

Closes #1648
Epic: #1647

Made with [Cursor](https://cursor.com)